### PR TITLE
refactor: use S_LEN macro

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -824,11 +824,11 @@ void do_autocmd(exarg_T *eap, char *arg_in, int forceit)
         continue;
       }
 
-      invalid_flags |= arg_autocmd_flag_get(&once, &cmd, "++once", 6);
-      invalid_flags |= arg_autocmd_flag_get(&nested, &cmd, "++nested", 8);
+      invalid_flags |= arg_autocmd_flag_get(&once, &cmd, S_LEN("++once"));
+      invalid_flags |= arg_autocmd_flag_get(&nested, &cmd, S_LEN("++nested"));
 
       // Check the deprecated "nested" flag.
-      invalid_flags |= arg_autocmd_flag_get(&nested, &cmd, "nested", 6);
+      invalid_flags |= arg_autocmd_flag_get(&nested, &cmd, S_LEN("nested"));
     }
 
     if (invalid_flags) {
@@ -1245,7 +1245,7 @@ void ex_doautoall(exarg_T *eap)
 bool check_nomodeline(char **argp)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  if (strncmp(*argp, "<nomodeline>", 12) == 0) {
+  if (strncmp(*argp, S_LEN("<nomodeline>")) == 0) {
     *argp = skipwhite(*argp + 12);
     return false;
   }
@@ -2359,7 +2359,7 @@ theend:
 bool aupat_is_buflocal(const char *pat, int patlen)
   FUNC_ATTR_PURE
 {
-  return patlen >= 8 && strncmp(pat, "<buffer", 7) == 0 && (pat)[patlen - 1] == '>';
+  return patlen >= 8 && strncmp(pat, S_LEN("<buffer")) == 0 && (pat)[patlen - 1] == '>';
 }
 
 int aupat_get_buflocal_nr(const char *pat, int patlen)

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3850,8 +3850,8 @@ static int chk_modeline(linenr_T lnum, int flags)
   int prev = -1;
   for (s = ml_get(lnum); *s != NUL; s++) {
     if (prev == -1 || ascii_isspace(prev)) {
-      if ((prev != -1 && strncmp(s, "ex:", 3) == 0)
-          || strncmp(s, "vi:", 3) == 0) {
+      if ((prev != -1 && strncmp(s, S_LEN("ex:")) == 0)
+          || strncmp(s, S_LEN("vi:")) == 0) {
         break;
       }
       // Accept both "vim" and "Vim".
@@ -3867,7 +3867,7 @@ static int chk_modeline(linenr_T lnum, int flags)
 
         if (*e == ':'
             && (s[0] != 'V'
-                || strncmp(skipwhite(e + 1), "set", 3) == 0)
+                || strncmp(skipwhite(e + 1), S_LEN("set")) == 0)
             && (s[3] == ':'
                 || (VIM_VERSION_100 >= vers && isdigit((uint8_t)s[3]))
                 || (VIM_VERSION_100 < vers && s[3] == '<')
@@ -3916,8 +3916,8 @@ static int chk_modeline(linenr_T lnum, int flags)
     // "vi:set opt opt opt: foo" -- foo not interpreted
     // "vi:opt opt opt: foo" -- foo interpreted
     // Accept "se" for compatibility with Elvis.
-    if (strncmp(s, "set ", 4) == 0
-        || strncmp(s, "se ", 3) == 0) {
+    if (strncmp(s, S_LEN("set ")) == 0
+        || strncmp(s, S_LEN("se ")) == 0) {
       if (*e != ':') {                // no terminating ':'?
         break;
       }

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -641,7 +641,7 @@ static inline list_T *buffer_to_tv_list(const char *const buf, const size_t len)
   list_T *const l = tv_list_alloc(kListLenMayKnow);
   // Empty buffer should be represented by [''], encode_list_write() thinks
   // empty list is fine for the case.
-  tv_list_append_string(l, "", 0);
+  tv_list_append_string(l, S_LEN(""));
   if (len > 0) {
     encode_list_write(l, buf, len);
   }

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -2247,7 +2247,7 @@ static const char *set_one_cmd_context(expand_T *xp, const char *buff)
 
   // Does command allow "++argopt" argument?
   if (ea.argt & EX_ARGOPT) {
-    while (*arg != NUL && strncmp(arg, "++", 2) == 0) {
+    while (*arg != NUL && strncmp(arg, S_LEN("++")) == 0) {
       p = arg + 2;
       while (*p && !ascii_isspace(*p)) {
         MB_PTR_ADV(p);
@@ -2774,7 +2774,7 @@ static int ExpandFromContext(expand_T *xp, char *pat, char ***matches, int *numM
   // When expanding a function name starting with s:, match the <SNR>nr_
   // prefix.
   char *tofree = NULL;
-  if (xp->xp_context == EXPAND_USER_FUNC && strncmp(pat, "^s:", 3) == 0) {
+  if (xp->xp_context == EXPAND_USER_FUNC && strncmp(pat, S_LEN("^s:")) == 0) {
     const size_t len = strlen(pat) + 20;
 
     tofree = xmalloc(len);
@@ -3564,7 +3564,7 @@ void f_getcompletion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
   if (xpc.xp_context == EXPAND_USER_DEFINED) {
     // Must be "custom,funcname" pattern
-    if (strncmp(type, "custom,", 7) != 0) {
+    if (strncmp(type, S_LEN("custom,")) != 0) {
       semsg(_(e_invarg2), type);
       return;
     }
@@ -3574,7 +3574,7 @@ void f_getcompletion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
   if (xpc.xp_context == EXPAND_USER_LIST) {
     // Must be "customlist,funcname" pattern
-    if (strncmp(type, "customlist,", 11) != 0) {
+    if (strncmp(type, S_LEN("customlist,")) != 0) {
       semsg(_(e_invarg2), type);
       return;
     }

--- a/src/nvim/context.c
+++ b/src/nvim/context.c
@@ -261,7 +261,7 @@ static inline void ctx_save_funcs(Context *ctx, bool scriptonly)
 
   HASHTAB_ITER(func_tbl_get(), hi, {
     const char *const name = hi->hi_key;
-    bool islambda = (strncmp(name, "<lambda>", 8) == 0);
+    bool islambda = (strncmp(name, S_LEN("<lambda>")) == 0);
     bool isscript = ((uint8_t)name[0] == K_SPECIAL);
 
     if (!islambda && (!scriptonly || isscript)) {
@@ -299,7 +299,7 @@ static inline void ctx_restore_funcs(Context *ctx)
 static inline Array sbuf_to_array(msgpack_sbuffer sbuf, Arena *arena)
 {
   list_T *const list = tv_list_alloc(kListLenMayKnow);
-  tv_list_append_string(list, "", 0);
+  tv_list_append_string(list, S_LEN(""));
   if (sbuf.size > 0) {
     encode_list_write(list, sbuf.data, sbuf.size);
   }

--- a/src/nvim/debugger.c
+++ b/src/nvim/debugger.c
@@ -521,18 +521,18 @@ static int dbg_parsearg(char *arg, garray_T *gap)
   struct debuggy *bp = &DEBUGGY(gap, gap->ga_len);
 
   // Find "func" or "file".
-  if (strncmp(p, "func", 4) == 0) {
+  if (strncmp(p, S_LEN("func")) == 0) {
     bp->dbg_type = DBG_FUNC;
-  } else if (strncmp(p, "file", 4) == 0) {
+  } else if (strncmp(p, S_LEN("file")) == 0) {
     bp->dbg_type = DBG_FILE;
-  } else if (gap != &prof_ga && strncmp(p, "here", 4) == 0) {
+  } else if (gap != &prof_ga && strncmp(p, S_LEN("here")) == 0) {
     if (curbuf->b_ffname == NULL) {
       emsg(_(e_noname));
       return FAIL;
     }
     bp->dbg_type = DBG_FILE;
     here = true;
-  } else if (gap != &prof_ga && strncmp(p, "expr", 4) == 0) {
+  } else if (gap != &prof_ga && strncmp(p, S_LEN("expr")) == 0) {
     bp->dbg_type = DBG_EXPR;
   } else {
     semsg(_(e_invarg2), p);
@@ -559,7 +559,7 @@ static int dbg_parsearg(char *arg, garray_T *gap)
   }
 
   if (bp->dbg_type == DBG_FUNC) {
-    bp->dbg_name = xstrdup(strncmp(p, "g:", 2) == 0 ? p + 2 : p);
+    bp->dbg_name = xstrdup(strncmp(p, S_LEN("g:")) == 0 ? p + 2 : p);
   } else if (here) {
     bp->dbg_name = xstrdup(curbuf->b_ffname);
   } else if (bp->dbg_type == DBG_EXPR) {

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1020,7 +1020,7 @@ static int check_external_diff(diffio_T *diffio)
     if (fd == NULL) {
       io_error = true;
     } else {
-      if (fwrite("line1\n", 6, 1, fd) != 1) {
+      if (fwrite(S_LEN("line1\n"), 1, fd) != 1) {
         io_error = true;
       }
       fclose(fd);
@@ -1029,7 +1029,7 @@ static int check_external_diff(diffio_T *diffio)
       if (fd == NULL) {
         io_error = true;
       } else {
-        if (fwrite("line2\n", 6, 1, fd) != 1) {
+        if (fwrite(S_LEN("line2\n"), 1, fd) != 1) {
           io_error = true;
         }
         fclose(fd);
@@ -1050,8 +1050,8 @@ static int check_external_diff(diffio_T *diffio)
               break;
             }
 
-            if (strncmp(linebuf, "1c1", 3) == 0
-                || strncmp(linebuf, "@@ -1 +1 @@", 11) == 0) {
+            if (strncmp(linebuf, S_LEN("1c1")) == 0
+                || strncmp(linebuf, S_LEN("@@ -1 +1 @@")) == 0) {
               ok = kTrue;
             }
           }
@@ -1583,13 +1583,13 @@ static bool extract_hunk(FILE *fd, diffhunk_T *hunk, diffstyle_T *diffstyle)
       // @@ -1,3 +1,5 @@
       if (isdigit((uint8_t)(*line))) {
         *diffstyle = DIFF_ED;
-      } else if ((strncmp(line, "@@ ", 3) == 0)) {
+      } else if ((strncmp(line, S_LEN("@@ ")) == 0)) {
         *diffstyle = DIFF_UNIFIED;
-      } else if ((strncmp(line, "--- ", 4) == 0)
+      } else if ((strncmp(line, S_LEN("--- ")) == 0)
                  && (vim_fgets(line, LBUFLEN, fd) == 0)
-                 && (strncmp(line, "+++ ", 4) == 0)
+                 && (strncmp(line, S_LEN("+++ ")) == 0)
                  && (vim_fgets(line, LBUFLEN, fd) == 0)
-                 && (strncmp(line, "@@ ", 3) == 0)) {
+                 && (strncmp(line, S_LEN("@@ ")) == 0)) {
         *diffstyle = DIFF_UNIFIED;
       } else {
         // Format not recognized yet, skip over this line.  Cygwin diff
@@ -1607,7 +1607,7 @@ static bool extract_hunk(FILE *fd, diffhunk_T *hunk, diffstyle_T *diffstyle)
       }
     } else {
       assert(*diffstyle == DIFF_UNIFIED);
-      if (strncmp(line, "@@ ", 3) != 0) {
+      if (strncmp(line, S_LEN("@@ ")) != 0) {
         continue;   // not the start of a diff block
       }
       if (parse_diff_unified(line, hunk) == FAIL) {
@@ -2473,70 +2473,70 @@ int diffopt_changed(void)
   char *p = p_dip;
   while (*p != NUL) {
     // Note: Keep this in sync with p_dip_values
-    if (strncmp(p, "filler", 6) == 0) {
+    if (strncmp(p, S_LEN("filler")) == 0) {
       p += 6;
       diff_flags_new |= DIFF_FILLER;
-    } else if ((strncmp(p, "context:", 8) == 0) && ascii_isdigit(p[8])) {
+    } else if ((strncmp(p, S_LEN("context:")) == 0) && ascii_isdigit(p[8])) {
       p += 8;
       diff_context_new = getdigits_int(&p, false, diff_context_new);
-    } else if (strncmp(p, "iblank", 6) == 0) {
+    } else if (strncmp(p, S_LEN("iblank")) == 0) {
       p += 6;
       diff_flags_new |= DIFF_IBLANK;
-    } else if (strncmp(p, "icase", 5) == 0) {
+    } else if (strncmp(p, S_LEN("icase")) == 0) {
       p += 5;
       diff_flags_new |= DIFF_ICASE;
-    } else if (strncmp(p, "iwhiteall", 9) == 0) {
+    } else if (strncmp(p, S_LEN("iwhiteall")) == 0) {
       p += 9;
       diff_flags_new |= DIFF_IWHITEALL;
-    } else if (strncmp(p, "iwhiteeol", 9) == 0) {
+    } else if (strncmp(p, S_LEN("iwhiteeol")) == 0) {
       p += 9;
       diff_flags_new |= DIFF_IWHITEEOL;
-    } else if (strncmp(p, "iwhite", 6) == 0) {
+    } else if (strncmp(p, S_LEN("iwhite")) == 0) {
       p += 6;
       diff_flags_new |= DIFF_IWHITE;
-    } else if (strncmp(p, "horizontal", 10) == 0) {
+    } else if (strncmp(p, S_LEN("horizontal")) == 0) {
       p += 10;
       diff_flags_new |= DIFF_HORIZONTAL;
-    } else if (strncmp(p, "vertical", 8) == 0) {
+    } else if (strncmp(p, S_LEN("vertical")) == 0) {
       p += 8;
       diff_flags_new |= DIFF_VERTICAL;
-    } else if ((strncmp(p, "foldcolumn:", 11) == 0) && ascii_isdigit(p[11])) {
+    } else if ((strncmp(p, S_LEN("foldcolumn:")) == 0) && ascii_isdigit(p[11])) {
       p += 11;
       diff_foldcolumn_new = getdigits_int(&p, false, diff_foldcolumn_new);
-    } else if (strncmp(p, "hiddenoff", 9) == 0) {
+    } else if (strncmp(p, S_LEN("hiddenoff")) == 0) {
       p += 9;
       diff_flags_new |= DIFF_HIDDEN_OFF;
-    } else if (strncmp(p, "closeoff", 8) == 0) {
+    } else if (strncmp(p, S_LEN("closeoff")) == 0) {
       p += 8;
       diff_flags_new |= DIFF_CLOSE_OFF;
-    } else if (strncmp(p, "followwrap", 10) == 0) {
+    } else if (strncmp(p, S_LEN("followwrap")) == 0) {
       p += 10;
       diff_flags_new |= DIFF_FOLLOWWRAP;
-    } else if (strncmp(p, "indent-heuristic", 16) == 0) {
+    } else if (strncmp(p, S_LEN("indent-heuristic")) == 0) {
       p += 16;
       diff_indent_heuristic = XDF_INDENT_HEURISTIC;
-    } else if (strncmp(p, "internal", 8) == 0) {
+    } else if (strncmp(p, S_LEN("internal")) == 0) {
       p += 8;
       diff_flags_new |= DIFF_INTERNAL;
-    } else if (strncmp(p, "algorithm:", 10) == 0) {
+    } else if (strncmp(p, S_LEN("algorithm:")) == 0) {
       // Note: Keep this in sync with p_dip_algorithm_values.
       p += 10;
-      if (strncmp(p, "myers", 5) == 0) {
+      if (strncmp(p, S_LEN("myers")) == 0) {
         p += 5;
         diff_algorithm_new = 0;
-      } else if (strncmp(p, "minimal", 7) == 0) {
+      } else if (strncmp(p, S_LEN("minimal")) == 0) {
         p += 7;
         diff_algorithm_new = XDF_NEED_MINIMAL;
-      } else if (strncmp(p, "patience", 8) == 0) {
+      } else if (strncmp(p, S_LEN("patience")) == 0) {
         p += 8;
         diff_algorithm_new = XDF_PATIENCE_DIFF;
-      } else if (strncmp(p, "histogram", 9) == 0) {
+      } else if (strncmp(p, S_LEN("histogram")) == 0) {
         p += 9;
         diff_algorithm_new = XDF_HISTOGRAM_DIFF;
       } else {
         return FAIL;
       }
-    } else if ((strncmp(p, "linematch:", 10) == 0) && ascii_isdigit(p[10])) {
+    } else if ((strncmp(p, S_LEN("linematch:")) == 0) && ascii_isdigit(p[10])) {
       p += 10;
       linematch_lines_new = getdigits_int(&p, false, linematch_lines_new);
       diff_flags_new |= DIFF_LINEMATCH;

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3095,7 +3095,7 @@ bool in_cinkeys(int keytyped, int when, bool line_is_empty)
       if (try_match && keytyped == 'e' && curwin->w_cursor.col >= 4) {
         p = get_cursor_line_ptr();
         if (skipwhite(p) == p + curwin->w_cursor.col - 4
-            && strncmp(p + curwin->w_cursor.col - 4, "else", 4) == 0) {
+            && strncmp(p + curwin->w_cursor.col - 4, S_LEN("else")) == 0) {
           return true;
         }
       }

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1219,7 +1219,7 @@ int call_vim_function(const char *func, int argc, typval_T *argv, typval_T *rett
   int len = (int)strlen(func);
   partial_T *pt = NULL;
 
-  if (len >= 6 && !memcmp(func, "v:lua.", 6)) {
+  if (len >= 6 && !memcmp(func, S_LEN("v:lua."))) {
     func += 6;
     len = check_luafunc_name(func, false);
     if (len == 0) {
@@ -2161,7 +2161,7 @@ void del_menutrans_vars(void)
 {
   hash_lock(&globvarht);
   HASHTAB_ITER(&globvarht, hi, {
-    if (strncmp(hi->hi_key, "menutrans_", 10) == 0) {
+    if (strncmp(hi->hi_key, S_LEN("menutrans_")) == 0) {
       delete_var(&globvarht, hi);
     }
   });
@@ -3274,7 +3274,7 @@ static int eval7(char **arg, typval_T *rettv, evalarg_T *const evalarg, bool wan
         check_vars(s, (size_t)len);
         // If evaluate is false rettv->v_type was not set, but it's needed
         // in handle_subscript() to parse v:lua, so set it here.
-        if (rettv->v_type == VAR_UNKNOWN && !evaluate && strnequal(s, "v:lua.", 6)) {
+        if (rettv->v_type == VAR_UNKNOWN && !evaluate && strnequal(s, S_LEN("v:lua."))) {
           rettv->v_type = VAR_PARTIAL;
           rettv->vval.v_partial = vvlua_partial;
           rettv->vval.v_partial->pt_refcount++;
@@ -3483,7 +3483,7 @@ static int eval_method(char **const arg, typval_T *const rettv, evalarg_T *const
   int len;
   char *name = *arg;
   char *lua_funcname = NULL;
-  if (strnequal(name, "v:lua.", 6)) {
+  if (strnequal(name, S_LEN("v:lua."))) {
     lua_funcname = name + 6;
     *arg = (char *)skip_luafunc_name(lua_funcname);
     *arg = skipwhite(*arg);  // to detect trailing whitespace later
@@ -5618,7 +5618,7 @@ void common_function(typval_T *argvars, typval_T *rettv, bool is_funcref)
     int dict_idx = 0;
     int arg_idx = 0;
     list_T *list = NULL;
-    if (strncmp(s, "s:", 2) == 0 || strncmp(s, "<SID>", 5) == 0) {
+    if (strncmp(s, S_LEN("s:")) == 0 || strncmp(s, S_LEN("<SID>")) == 0) {
       // Expand s: and <SID> into <SNR>nr_, so that the function can
       // also be called from another script. Using trans_function_name()
       // would also work, but some plugins depend on the name being
@@ -6192,7 +6192,7 @@ bool callback_call(Callback *const callback, const int argcount_in, typval_T *co
   case kCallbackFuncref:
     name = callback->data.funcref;
     int len = (int)strlen(name);
-    if (len >= 6 && !memcmp(name, "v:lua.", 6)) {
+    if (len >= 6 && !memcmp(name, S_LEN("v:lua."))) {
       name += 6;
       len = check_luafunc_name(name, false);
       if (len == 0) {
@@ -6460,7 +6460,7 @@ bool write_list(FileDescriptor *const fp, const list_T *const list, const bool b
       }
     }
     if (!binary || TV_LIST_ITEM_NEXT(list, li) != NULL) {
-      const ptrdiff_t written = file_write(fp, "\n", 1);
+      const ptrdiff_t written = file_write(fp, S_LEN("\n"));
       if (written < 0) {
         error = (int)written;
         goto write_list_error;

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -5095,7 +5095,7 @@ static void get_matches_in_str(const char *str, regmatch_T *rmp, list_T *mlist, 
       // return a list with the submatches
       for (int i = 1; i < NSUBEXP; i++) {
         if (rmp->endp[i] == NULL) {
-          tv_list_append_string(sml, "", 0);
+          tv_list_append_string(sml, S_LEN(""));
         } else {
           tv_list_append_string(sml, rmp->startp[i], rmp->endp[i] - rmp->startp[i]);
         }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1360,11 +1360,11 @@ char *make_filter_cmd(char *cmd, char *itmp, char *otmp)
 {
   bool is_fish_shell =
 #if defined(UNIX)
-    strncmp(invocation_path_tail(p_sh, NULL), "fish", 4) == 0;
+    strncmp(invocation_path_tail(p_sh, NULL), S_LEN("fish")) == 0;
 #else
     false;
 #endif
-  bool is_pwsh = strncmp(invocation_path_tail(p_sh, NULL), "pwsh", 4) == 0
+  bool is_pwsh = strncmp(invocation_path_tail(p_sh, NULL), S_LEN("pwsh")) == 0
                  || strncmp(invocation_path_tail(p_sh, NULL), "powershell",
                             10) == 0;
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4195,7 +4195,7 @@ static int getargopt(exarg_T *eap)
   // Note: Keep this in sync with get_argopt_name.
 
   // ":edit ++[no]bin[ary] file"
-  if (strncmp(arg, "bin", 3) == 0 || strncmp(arg, "nobin", 5) == 0) {
+  if (strncmp(arg, S_LEN("bin")) == 0 || strncmp(arg, S_LEN("nobin")) == 0) {
     if (*arg == 'n') {
       arg += 2;
       eap->force_bin = FORCE_NOBIN;
@@ -4210,33 +4210,33 @@ static int getargopt(exarg_T *eap)
   }
 
   // ":read ++edit file"
-  if (strncmp(arg, "edit", 4) == 0) {
+  if (strncmp(arg, S_LEN("edit")) == 0) {
     eap->read_edit = true;
     eap->arg = skipwhite(arg + 4);
     return OK;
   }
 
   // ":write ++p foo/bar/file
-  if (strncmp(arg, "p", 1) == 0) {
+  if (strncmp(arg, S_LEN("p")) == 0) {
     eap->mkdir_p = true;
     eap->arg = skipwhite(arg + 1);
     return OK;
   }
 
-  if (strncmp(arg, "ff", 2) == 0) {
+  if (strncmp(arg, S_LEN("ff")) == 0) {
     arg += 2;
     pp = &eap->force_ff;
-  } else if (strncmp(arg, "fileformat", 10) == 0) {
+  } else if (strncmp(arg, S_LEN("fileformat")) == 0) {
     arg += 10;
     pp = &eap->force_ff;
-  } else if (strncmp(arg, "enc", 3) == 0) {
-    if (strncmp(arg, "encoding", 8) == 0) {
+  } else if (strncmp(arg, S_LEN("enc")) == 0) {
+    if (strncmp(arg, S_LEN("encoding")) == 0) {
       arg += 8;
     } else {
       arg += 3;
     }
     pp = &eap->force_enc;
-  } else if (strncmp(arg, "bad", 3) == 0) {
+  } else if (strncmp(arg, S_LEN("bad")) == 0) {
     arg += 3;
     pp = &bad_char_idx;
   }
@@ -4300,19 +4300,19 @@ int expand_argopt(char *pat, expand_T *xp, regmatch_T *rmp, char ***matches, int
 
     char *name_end = xp->xp_pattern - 1;
     if (name_end - xp->xp_line >= 2
-        && strncmp(name_end - 2, "ff", 2) == 0) {
+        && strncmp(name_end - 2, S_LEN("ff")) == 0) {
       cb = get_fileformat_name;
     } else if (name_end - xp->xp_line >= 10
-               && strncmp(name_end - 10, "fileformat", 10) == 0) {
+               && strncmp(name_end - 10, S_LEN("fileformat")) == 0) {
       cb = get_fileformat_name;
     } else if (name_end - xp->xp_line >= 3
-               && strncmp(name_end - 3, "enc", 3) == 0) {
+               && strncmp(name_end - 3, S_LEN("enc")) == 0) {
       cb = get_encoding_name;
     } else if (name_end - xp->xp_line >= 8
-               && strncmp(name_end - 8, "encoding", 8) == 0) {
+               && strncmp(name_end - 8, S_LEN("encoding")) == 0) {
       cb = get_encoding_name;
     } else if (name_end - xp->xp_line >= 3
-               && strncmp(name_end - 3, "bad", 3) == 0) {
+               && strncmp(name_end - 3, S_LEN("bad")) == 0) {
       cb = get_bad_name;
     }
 
@@ -7217,7 +7217,7 @@ char *expand_sfile(char *arg)
   char *result = xstrdup(arg);
 
   for (char *p = result; *p;) {
-    if (strncmp(p, "<sfile>", 7) != 0) {
+    if (strncmp(p, S_LEN("<sfile>")) != 0) {
       p++;
     } else {
       // replace "<sfile>" with the sourced file name, and do ":" stuff
@@ -7304,12 +7304,12 @@ static void ex_filetype(exarg_T *eap)
 
   // Accept "plugin" and "indent" in any order.
   while (true) {
-    if (strncmp(arg, "plugin", 6) == 0) {
+    if (strncmp(arg, S_LEN("plugin")) == 0) {
       plugin = true;
       arg = skipwhite(arg + 6);
       continue;
     }
-    if (strncmp(arg, "indent", 6) == 0) {
+    if (strncmp(arg, S_LEN("indent")) == 0) {
       indent = true;
       arg = skipwhite(arg + 6);
       continue;
@@ -7388,7 +7388,7 @@ static void ex_setfiletype(exarg_T *eap)
   }
 
   char *arg = eap->arg;
-  if (strncmp(arg, "FALLBACK ", 9) == 0) {
+  if (strncmp(arg, S_LEN("FALLBACK ")) == 0) {
     arg += 9;
   }
 

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -254,7 +254,7 @@ bool cause_errthrow(const char *mesg, bool multiline, bool severe, bool *ignore)
       if (plist == msg_list || severe) {
         // Skip the extra "Vim " prefix for message "E458".
         char *tmsg = elem->msg;
-        if (strncmp(tmsg, "Vim E", 5) == 0
+        if (strncmp(tmsg, S_LEN("Vim E")) == 0
             && ascii_isdigit(tmsg[5])
             && ascii_isdigit(tmsg[6])
             && ascii_isdigit(tmsg[7])
@@ -443,7 +443,7 @@ static int throw_exception(void *value, except_type_T type, char *cmdname)
   // would be treated differently from real interrupt or error exceptions
   // when no active try block is found, see do_cmdline().
   if (type == ET_USER) {
-    if (strncmp(value, "Vim", 3) == 0
+    if (strncmp(value, S_LEN("Vim")) == 0
         && (((char *)value)[3] == NUL || ((char *)value)[3] == ':'
             || ((char *)value)[3] == '(')) {
       emsg(_("E608: Cannot :throw exceptions with 'Vim' prefix"));

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2799,13 +2799,13 @@ int check_opt_wim(void)
     if (p[i] != NUL && p[i] != ',' && p[i] != ':') {
       return FAIL;
     }
-    if (i == 7 && strncmp(p, "longest", 7) == 0) {
+    if (i == 7 && strncmp(p, S_LEN("longest")) == 0) {
       new_wim_flags[idx] |= WIM_LONGEST;
-    } else if (i == 4 && strncmp(p, "full", 4) == 0) {
+    } else if (i == 4 && strncmp(p, S_LEN("full")) == 0) {
       new_wim_flags[idx] |= WIM_FULL;
-    } else if (i == 4 && strncmp(p, "list", 4) == 0) {
+    } else if (i == 4 && strncmp(p, S_LEN("list")) == 0) {
       new_wim_flags[idx] |= WIM_LIST;
-    } else if (i == 8 && strncmp(p, "lastused", 8) == 0) {
+    } else if (i == 8 && strncmp(p, S_LEN("lastused")) == 0) {
       new_wim_flags[idx] |= WIM_BUFLASTUSED;
     } else {
       return FAIL;

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -399,7 +399,7 @@ void *vim_findfile_init(char *path, char *filename, char *stopdirs, int level, i
         emsg(_(e_path_too_long_for_completion));
         break;
       }
-      if (strncmp(wc_part, "**", 2) == 0) {
+      if (strncmp(wc_part, S_LEN("**")) == 0) {
         ff_expand_buffer[len++] = *wc_part++;
         ff_expand_buffer[len++] = *wc_part++;
 
@@ -462,7 +462,7 @@ void *vim_findfile_init(char *path, char *filename, char *stopdirs, int level, i
       if (p > search_ctx->ffsc_fix_path) {
         // do not add '..' to the path and start upwards searching
         len = (int)(p - search_ctx->ffsc_fix_path) - 1;
-        if ((len >= 2 && strncmp(search_ctx->ffsc_fix_path, "..", 2) == 0)
+        if ((len >= 2 && strncmp(search_ctx->ffsc_fix_path, S_LEN("..")) == 0)
             && (len == 2 || search_ctx->ffsc_fix_path[2] == PATHSEP)) {
           xfree(buf);
           goto error_return;
@@ -678,7 +678,7 @@ char *vim_findfile(void *search_ctx_arg)
         rest_of_wildcards = stackp->ffs_wc_path;
         if (*rest_of_wildcards != NUL) {
           len = strlen(file_path);
-          if (strncmp(rest_of_wildcards, "**", 2) == 0) {
+          if (strncmp(rest_of_wildcards, S_LEN("**")) == 0) {
             // pointer to the restrict byte
             // The restrict byte is not a character!
             p = rest_of_wildcards + 2;
@@ -855,7 +855,7 @@ char *vim_findfile(void *search_ctx_arg)
 
       // if wildcards contains '**' we have to descent till we reach the
       // leaves of the directory tree.
-      if (strncmp(stackp->ffs_wc_path, "**", 2) == 0) {
+      if (strncmp(stackp->ffs_wc_path, S_LEN("**")) == 0) {
         for (int i = stackp->ffs_filearray_cur;
              i < stackp->ffs_filearray_size; i++) {
           if (path_fnamecmp(stackp->ffs_filearray[i],

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -1896,7 +1896,7 @@ theend:
 bool is_dev_fd_file(char *fname)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  return strncmp(fname, "/dev/fd/", 8) == 0
+  return strncmp(fname, S_LEN("/dev/fd/")) == 0
          && ascii_isdigit((uint8_t)fname[8])
          && *skipdigits(fname + 9) == NUL
          && (fname[9] != NUL

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -566,7 +566,7 @@ void AppendToRedobuffLit(const char *str, int len)
 
     // CTRL-V '0' must be inserted as CTRL-V 048.
     if (*s == NUL && c == '0') {
-      add_buff(&redobuff, "048", 3);
+      add_buff(&redobuff, S_LEN("048"));
     } else {
       add_char_buff(&redobuff, c);
     }
@@ -777,7 +777,7 @@ int start_redo(int count, bool old_redo)
 
   // copy the buffer name, if present
   if (c == '"') {
-    add_buff(&readbuf2, "\"", 1);
+    add_buff(&readbuf2, S_LEN("\""));
     c = read_redo(false, old_redo);
 
     // if a numbered buffer is used, increment the number

--- a/src/nvim/help.c
+++ b/src/nvim/help.c
@@ -655,7 +655,7 @@ void get_local_additions(void)
   // files.  This uses the very first line in the help file.
   char *const fname = path_tail(curbuf->b_fname);
   if (path_fnamecmp(fname, "help.txt") == 0
-      || (path_fnamencmp(fname, "help.", 5) == 0
+      || (path_fnamencmp(fname, S_LEN("help.")) == 0
           && ASCII_ISALPHA(fname[5])
           && ASCII_ISALPHA(fname[6])
           && TOLOWER_ASC(fname[7]) == 'x'
@@ -1015,7 +1015,7 @@ static void helptags_one(char *dir, const char *ext, const char *tagfname, bool 
     // Write the tags into the file.
     for (int i = 0; i < ga.ga_len; i++) {
       s = ((char **)ga.ga_data)[i];
-      if (strncmp(s, "help-tags\t", 10) == 0) {
+      if (strncmp(s, S_LEN("help-tags\t")) == 0) {
         // help-tags entry was added in formatted form
         fputs(s, fd_tags);
       } else {
@@ -1149,7 +1149,7 @@ void ex_helptags(exarg_T *eap)
   bool add_help_tags = false;
 
   // Check for ":helptags ++t {dir}".
-  if (strncmp(eap->arg, "++t", 3) == 0 && ascii_iswhite(eap->arg[3])) {
+  if (strncmp(eap->arg, S_LEN("++t")) == 0 && ascii_iswhite(eap->arg[3])) {
     add_help_tags = true;
     eap->arg = skipwhite(eap->arg + 3);
   }

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1057,7 +1057,7 @@ void do_highlight(const char *line, const bool forceit, const bool init)
     }
 
     int from_id = syn_check_group(from_start, (size_t)(from_end - from_start));
-    if (strncmp(to_start, "NONE", 4) == 0) {
+    if (strncmp(to_start, S_LEN("NONE")) == 0) {
       to_id = 0;
     } else {
       to_id = syn_check_group(to_start, (size_t)(to_end - to_start));

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -782,20 +782,20 @@ bool briopt_check(win_T *wp)
   char *p = wp->w_p_briopt;
   while (*p != NUL) {
     // Note: Keep this in sync with p_briopt_values
-    if (strncmp(p, "shift:", 6) == 0
+    if (strncmp(p, S_LEN("shift:")) == 0
         && ((p[6] == '-' && ascii_isdigit(p[7])) || ascii_isdigit(p[6]))) {
       p += 6;
       bri_shift = getdigits_int(&p, true, 0);
-    } else if (strncmp(p, "min:", 4) == 0 && ascii_isdigit(p[4])) {
+    } else if (strncmp(p, S_LEN("min:")) == 0 && ascii_isdigit(p[4])) {
       p += 4;
       bri_min = getdigits_int(&p, true, 0);
-    } else if (strncmp(p, "sbr", 3) == 0) {
+    } else if (strncmp(p, S_LEN("sbr")) == 0) {
       p += 3;
       bri_sbr = true;
-    } else if (strncmp(p, "list:", 5) == 0) {
+    } else if (strncmp(p, S_LEN("list:")) == 0) {
       p += 5;
       bri_list = (int)getdigits(&p, false, 0);
-    } else if (strncmp(p, "column:", 7) == 0) {
+    } else if (strncmp(p, S_LEN("column:")) == 0) {
       p += 7;
       bri_vcol = (int)getdigits(&p, false, 0);
     }

--- a/src/nvim/keycodes.c
+++ b/src/nvim/keycodes.c
@@ -904,7 +904,7 @@ char *replace_termcodes(const char *const from, const size_t from_len, char **co
     }
     // Check for special <> keycodes, like "<C-S-LeftMouse>"
     if (do_special && ((flags & REPTERM_DO_LT) || ((end - src) >= 3
-                                                   && strncmp(src, "<lt>", 4) != 0))) {
+                                                   && strncmp(src, S_LEN("<lt>")) != 0))) {
       // Change <SID>Func to K_SNR <script-nr> _Func.  This name is used
       // for script-local user functions.
       // (room: 5 * 6 = 30 bytes; needed: 3 + <nr> + 1 <= 14)

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -403,43 +403,43 @@ static int str_to_mapargs(const char *strargs, bool is_unmap, MapArguments *mapa
   // Accept <buffer>, <nowait>, <silent>, <expr>, <script>, and <unique> in
   // any order.
   while (true) {
-    if (strncmp(to_parse, "<buffer>", 8) == 0) {
+    if (strncmp(to_parse, S_LEN("<buffer>")) == 0) {
       to_parse = skipwhite(to_parse + 8);
       mapargs->buffer = true;
       continue;
     }
 
-    if (strncmp(to_parse, "<nowait>", 8) == 0) {
+    if (strncmp(to_parse, S_LEN("<nowait>")) == 0) {
       to_parse = skipwhite(to_parse + 8);
       mapargs->nowait = true;
       continue;
     }
 
-    if (strncmp(to_parse, "<silent>", 8) == 0) {
+    if (strncmp(to_parse, S_LEN("<silent>")) == 0) {
       to_parse = skipwhite(to_parse + 8);
       mapargs->silent = true;
       continue;
     }
 
     // Ignore obsolete "<special>" modifier.
-    if (strncmp(to_parse, "<special>", 9) == 0) {
+    if (strncmp(to_parse, S_LEN("<special>")) == 0) {
       to_parse = skipwhite(to_parse + 9);
       continue;
     }
 
-    if (strncmp(to_parse, "<script>", 8) == 0) {
+    if (strncmp(to_parse, S_LEN("<script>")) == 0) {
       to_parse = skipwhite(to_parse + 8);
       mapargs->script = true;
       continue;
     }
 
-    if (strncmp(to_parse, "<expr>", 6) == 0) {
+    if (strncmp(to_parse, S_LEN("<expr>")) == 0) {
       to_parse = skipwhite(to_parse + 6);
       mapargs->expr = true;
       continue;
     }
 
-    if (strncmp(to_parse, "<unique>", 8) == 0) {
+    if (strncmp(to_parse, S_LEN("<unique>")) == 0) {
       to_parse = skipwhite(to_parse + 8);
       mapargs->unique = true;
       continue;
@@ -1252,32 +1252,32 @@ char *set_context_in_map_cmd(expand_T *xp, char *cmd, char *arg, bool forceit, b
     xp->xp_context = EXPAND_MAPPINGS;
     expand_buffer = false;
     while (true) {
-      if (strncmp(arg, "<buffer>", 8) == 0) {
+      if (strncmp(arg, S_LEN("<buffer>")) == 0) {
         expand_buffer = true;
         arg = skipwhite(arg + 8);
         continue;
       }
-      if (strncmp(arg, "<unique>", 8) == 0) {
+      if (strncmp(arg, S_LEN("<unique>")) == 0) {
         arg = skipwhite(arg + 8);
         continue;
       }
-      if (strncmp(arg, "<nowait>", 8) == 0) {
+      if (strncmp(arg, S_LEN("<nowait>")) == 0) {
         arg = skipwhite(arg + 8);
         continue;
       }
-      if (strncmp(arg, "<silent>", 8) == 0) {
+      if (strncmp(arg, S_LEN("<silent>")) == 0) {
         arg = skipwhite(arg + 8);
         continue;
       }
-      if (strncmp(arg, "<special>", 9) == 0) {
+      if (strncmp(arg, S_LEN("<special>")) == 0) {
         arg = skipwhite(arg + 9);
         continue;
       }
-      if (strncmp(arg, "<script>", 8) == 0) {
+      if (strncmp(arg, S_LEN("<script>")) == 0) {
         arg = skipwhite(arg + 8);
         continue;
       }
-      if (strncmp(arg, "<expr>", 6) == 0) {
+      if (strncmp(arg, S_LEN("<expr>")) == 0) {
         arg = skipwhite(arg + 6);
         continue;
       }

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -2253,7 +2253,7 @@ char *enc_canonize(char *enc)
   if (enc_canon_search(p) >= 0) {
     // canonical name can be used unmodified
     if (p != r) {
-      memmove(r, p, (size_t)(p_e - p));
+      memmove(r, p, (size_t)(p_e - p) + 1);
     }
   } else if ((i = enc_alias_search(p)) >= 0) {
     // alias recognized, get canonical name

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -371,9 +371,9 @@ int enc_canon_props(const char *name)
   int i = enc_canon_search(name);
   if (i >= 0) {
     return enc_canon_table[i].prop;
-  } else if (strncmp(name, "2byte-", 6) == 0) {
+  } else if (strncmp(name, S_LEN("2byte-")) == 0) {
     return ENC_DBCS;
-  } else if (strncmp(name, "8bit-", 5) == 0 || strncmp(name, "iso-8859-", 9) == 0) {
+  } else if (strncmp(name, S_LEN("8bit-")) == 0 || strncmp(name, S_LEN("iso-8859-")) == 0) {
     return ENC_8BIT;
   }
   return 0;
@@ -393,10 +393,10 @@ int bomb_size(void)
     if (*curbuf->b_p_fenc == NUL
         || strcmp(curbuf->b_p_fenc, "utf-8") == 0) {
       n = 3;
-    } else if (strncmp(curbuf->b_p_fenc, "ucs-2", 5) == 0
-               || strncmp(curbuf->b_p_fenc, "utf-16", 6) == 0) {
+    } else if (strncmp(curbuf->b_p_fenc, S_LEN("ucs-2")) == 0
+               || strncmp(curbuf->b_p_fenc, S_LEN("utf-16")) == 0) {
       n = 2;
-    } else if (strncmp(curbuf->b_p_fenc, "ucs-4", 5) == 0) {
+    } else if (strncmp(curbuf->b_p_fenc, S_LEN("ucs-4")) == 0) {
       n = 4;
     }
   }
@@ -2188,10 +2188,10 @@ const char *mb_unescape(const char **const pp)
 /// Skip the Vim specific head of a 'encoding' name.
 char *enc_skip(char *p)
 {
-  if (strncmp(p, "2byte-", 6) == 0) {
+  if (strncmp(p, S_LEN("2byte-")) == 0) {
     return p + 6;
   }
-  if (strncmp(p, "8bit-", 5) == 0) {
+  if (strncmp(p, S_LEN("8bit-")) == 0) {
     return p + 5;
   }
   return p;
@@ -2222,37 +2222,38 @@ char *enc_canonize(char *enc)
     }
   }
   *p = NUL;
+  char *p_e = p;
 
   // Skip "2byte-" and "8bit-".
   p = enc_skip(r);
 
   // Change "microsoft-cp" to "cp".  Used in some spell files.
-  if (strncmp(p, "microsoft-cp", 12) == 0) {
-    STRMOVE(p, p + 10);
+  if (strncmp(p, S_LEN("microsoft-cp")) == 0) {
+    memmove(p, p + STRLEN_LITERAL("microsoft-"), (size_t)(p_e - (p + STRLEN_LITERAL("microsoft-"))) + 1);
   }
 
   // "iso8859" -> "iso-8859"
-  if (strncmp(p, "iso8859", 7) == 0) {
-    STRMOVE(p + 4, p + 3);
-    p[3] = '-';
+  if (strncmp(p, S_LEN("iso8859")) == 0) {
+    memmove(p + STRLEN_LITERAL("iso-"), p + STRLEN_LITERAL("iso"), (size_t)(p_e - (p + STRLEN_LITERAL("iso"))) + 1);
+    p[STRLEN_LITERAL("iso")] = '-';
   }
 
   // "iso-8859n" -> "iso-8859-n"
-  if (strncmp(p, "iso-8859", 8) == 0 && p[8] != '-') {
-    STRMOVE(p + 9, p + 8);
-    p[8] = '-';
+  if (strncmp(p, S_LEN("iso-8859")) == 0 && p[8] != '-') {
+    memmove(p + STRLEN_LITERAL("iso-8859-"), p + STRLEN_LITERAL("iso-8859"), (size_t)(p_e - (p + STRLEN_LITERAL("iso-8859"))) + 1);
+    p[STRLEN_LITERAL("iso-8859")] = '-';
   }
 
   // "latin-N" -> "latinN"
-  if (strncmp(p, "latin-", 6) == 0) {
-    STRMOVE(p + 5, p + 6);
+  if (strncmp(p, S_LEN("latin-")) == 0) {
+    memmove(p + STRLEN_LITERAL("latin"), p + STRLEN_LITERAL("latin-"), (size_t)(p_e - (p + STRLEN_LITERAL("latin-"))) + 1);
   }
 
   int i;
   if (enc_canon_search(p) >= 0) {
     // canonical name can be used unmodified
     if (p != r) {
-      STRMOVE(r, p);
+      memmove(r, p, (size_t)(p_e - p));
     }
   } else if ((i = enc_alias_search(p)) >= 0) {
     // alias recognized, get canonical name
@@ -2315,7 +2316,7 @@ char *enc_locale(void)
     if (p > s + 2 && !STRNICMP(p + 1, "EUC", 3)
         && !isalnum((uint8_t)p[4]) && p[4] != '-' && p[-3] == '_') {
       // Copy "XY.EUC" to "euc-XY" to buf[10].
-      memmove(buf, "euc-", 4);
+      memmove(buf, S_LEN("euc-"));
       buf[4] = (char)(ASCII_ISALNUM(p[-2]) ? TOLOWER_ASC(p[-2]) : 0);
       buf[5] = (char)(ASCII_ISALNUM(p[-1]) ? TOLOWER_ASC(p[-1]) : 0);
       buf[6] = NUL;

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -2229,24 +2229,28 @@ char *enc_canonize(char *enc)
 
   // Change "microsoft-cp" to "cp".  Used in some spell files.
   if (strncmp(p, S_LEN("microsoft-cp")) == 0) {
-    memmove(p, p + STRLEN_LITERAL("microsoft-"), (size_t)(p_e - (p + STRLEN_LITERAL("microsoft-"))) + 1);
+    memmove(p, p + STRLEN_LITERAL("microsoft-"),
+            (size_t)(p_e - (p + STRLEN_LITERAL("microsoft-"))) + 1);
   }
 
   // "iso8859" -> "iso-8859"
   if (strncmp(p, S_LEN("iso8859")) == 0) {
-    memmove(p + STRLEN_LITERAL("iso-"), p + STRLEN_LITERAL("iso"), (size_t)(p_e - (p + STRLEN_LITERAL("iso"))) + 1);
+    memmove(p + STRLEN_LITERAL("iso-"), p + STRLEN_LITERAL("iso"),
+            (size_t)(p_e - (p + STRLEN_LITERAL("iso"))) + 1);
     p[STRLEN_LITERAL("iso")] = '-';
   }
 
   // "iso-8859n" -> "iso-8859-n"
   if (strncmp(p, S_LEN("iso-8859")) == 0 && p[8] != '-') {
-    memmove(p + STRLEN_LITERAL("iso-8859-"), p + STRLEN_LITERAL("iso-8859"), (size_t)(p_e - (p + STRLEN_LITERAL("iso-8859"))) + 1);
+    memmove(p + STRLEN_LITERAL("iso-8859-"), p + STRLEN_LITERAL("iso-8859"),
+            (size_t)(p_e - (p + STRLEN_LITERAL("iso-8859"))) + 1);
     p[STRLEN_LITERAL("iso-8859")] = '-';
   }
 
   // "latin-N" -> "latinN"
   if (strncmp(p, S_LEN("latin-")) == 0) {
-    memmove(p + STRLEN_LITERAL("latin"), p + STRLEN_LITERAL("latin-"), (size_t)(p_e - (p + STRLEN_LITERAL("latin-"))) + 1);
+    memmove(p + STRLEN_LITERAL("latin"), p + STRLEN_LITERAL("latin-"),
+            (size_t)(p_e - (p + STRLEN_LITERAL("latin-"))) + 1);
   }
 
   int i;

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -864,7 +864,7 @@ void ml_recover(bool checkext)
     goto theend;
   }
   ZeroBlock *b0p = hp->bh_data;
-  if (strncmp(b0p->b0_version, "VIM 3.0", 7) == 0) {
+  if (strncmp(b0p->b0_version, S_LEN("VIM 3.0")) == 0) {
     msg_start();
     msg_outtrans(mfp->mf_fname, MSG_HIST);
     msg_puts_attr(_(" cannot be used with this version of Vim.\n"),
@@ -1538,7 +1538,7 @@ static time_t swapfile_info(char *fname)
   int fd = os_open(fname, O_RDONLY, 0);
   if (fd >= 0) {
     if (read_eintr(fd, &b0, sizeof(b0)) == sizeof(b0)) {
-      if (strncmp(b0.b0_version, "VIM 3.0", 7) == 0) {
+      if (strncmp(b0.b0_version, S_LEN("VIM 3.0")) == 0) {
         msg_puts(_("         [from Vim version 3.0]"));
       } else if (ml_check_b0_id(&b0) == FAIL) {
         msg_puts(_("         [does not look like a Vim swap file]"));

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -61,7 +61,7 @@ static const char e_nomenu[] = N_("E329: No menu \"%s\"");
 static bool menu_is_winbar(const char *const name)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
-  return (strncmp(name, "WinBar", 6) == 0);
+  return (strncmp(name, S_LEN("WinBar")) == 0);
 }
 
 static vimmenu_T **get_root_menu(const char *const name)
@@ -90,17 +90,17 @@ void ex_menu(exarg_T *eap)
   char *arg = eap->arg;
 
   while (true) {
-    if (strncmp(arg, "<script>", 8) == 0) {
+    if (strncmp(arg, S_LEN("<script>")) == 0) {
       noremap = REMAP_SCRIPT;
       arg = skipwhite(arg + 8);
       continue;
     }
-    if (strncmp(arg, "<silent>", 8) == 0) {
+    if (strncmp(arg, S_LEN("<silent>")) == 0) {
       silent = true;
       arg = skipwhite(arg + 8);
       continue;
     }
-    if (strncmp(arg, "<special>", 9) == 0) {
+    if (strncmp(arg, S_LEN("<special>")) == 0) {
       // Ignore obsolete "<special>" modifier.
       arg = skipwhite(arg + 9);
       continue;
@@ -110,7 +110,7 @@ void ex_menu(exarg_T *eap)
 
   // Locate an optional "icon=filename" argument
   // TODO(nvim): Currently this is only parsed. Should expose it to UIs.
-  if (strncmp(arg, "icon=", 5) == 0) {
+  if (strncmp(arg, S_LEN("icon=")) == 0) {
     arg += 5;
     while (*arg != NUL && *arg != ' ') {
       if (*arg == '\\') {
@@ -153,10 +153,10 @@ void ex_menu(exarg_T *eap)
   pri_tab[MENUDEPTH] = -1;              // mark end of the table
 
   // Check for "disable" or "enable" argument.
-  if (strncmp(arg, "enable", 6) == 0 && ascii_iswhite(arg[6])) {
+  if (strncmp(arg, S_LEN("enable")) == 0 && ascii_iswhite(arg[6])) {
     enable = kTrue;
     arg = skipwhite(arg + 6);
-  } else if (strncmp(arg, "disable", 7) == 0 && ascii_iswhite(arg[7])) {
+  } else if (strncmp(arg, S_LEN("disable")) == 0 && ascii_iswhite(arg[7])) {
     enable = kFalse;
     arg = skipwhite(arg + 7);
   }
@@ -889,10 +889,10 @@ char *set_context_in_menu_cmd(expand_T *xp, const char *cmd, char *arg, bool for
   }
 
   if (!ascii_iswhite(*p)) {
-    if (strncmp(arg, "enable", 6) == 0
+    if (strncmp(arg, S_LEN("enable")) == 0
         && (arg[6] == NUL || ascii_iswhite(arg[6]))) {
       p = arg + 6;
-    } else if (strncmp(arg, "disable", 7) == 0
+    } else if (strncmp(arg, S_LEN("disable")) == 0
                && (arg[7] == NUL || ascii_iswhite(arg[7]))) {
       p = arg + 7;
     } else {
@@ -1333,14 +1333,14 @@ bool menu_is_menubar(const char *const name)
 bool menu_is_popup(const char *const name)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
-  return strncmp(name, "PopUp", 5) == 0;
+  return strncmp(name, S_LEN("PopUp")) == 0;
 }
 
 // Return true if "name" is a toolbar menu name.
 bool menu_is_toolbar(const char *const name)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
-  return strncmp(name, "ToolBar", 7) == 0;
+  return strncmp(name, S_LEN("ToolBar")) == 0;
 }
 
 /// @return  true if the name is a menu separator identifier: Starts and ends
@@ -1701,7 +1701,7 @@ void ex_menutranslate(exarg_T *eap)
   }
 
   // ":menutrans clear": clear all translations.
-  if (strncmp(arg, "clear", 5) == 0 && ends_excmd(*skipwhite(arg + 5))) {
+  if (strncmp(arg, S_LEN("clear")) == 0 && ends_excmd(*skipwhite(arg + 5))) {
     GA_DEEP_CLEAR(&menutrans_ga, menutrans_T, FREE_MENUTRANS);
 
     // Delete all "menutrans_" global variables.

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -473,7 +473,7 @@ void trunc_string(const char *s, char *buf, int room_in, int buflen)
     }
   } else if (e + 3 < buflen) {
     // set the middle and copy the last part
-    memmove(buf + e, "...", 3);
+    memmove(buf + e, S_LEN("..."));
     len = (int)strlen(s + i) + 1;
     if (len >= buflen - e - 3) {
       len = buflen - e - 3 - 1;
@@ -3182,7 +3182,7 @@ static void redir_write(const char *const str, const ptrdiff_t maxlen)
     if (*s != '\n' && *s != '\r') {
       while (cur_col < msg_col) {
         if (capture_ga) {
-          ga_concat_len(capture_ga, " ", 1);
+          ga_concat_len(capture_ga, S_LEN(" "));
         }
         if (redir_reg) {
           write_reg_contents(redir_reg, " ", 1, true);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -347,7 +347,7 @@ void set_init_1(bool clean_arg)
   const size_t backupdir_len = strlen(backupdir);
   backupdir = xrealloc(backupdir, backupdir_len + 3);
   memmove(backupdir + 2, backupdir, backupdir_len + 1);
-  memmove(backupdir, ".,", 2);
+  memmove(backupdir, S_LEN(".,"));
   set_string_default(kOptBackupdir, backupdir, true);
   set_string_default(kOptViewdir, stdpaths_user_state_subpath("view", 2, true),
                      true);
@@ -1004,10 +1004,10 @@ static set_op_T get_op(const char *arg)
 
 static set_prefix_T get_option_prefix(char **argp)
 {
-  if (strncmp(*argp, "no", 2) == 0) {
+  if (strncmp(*argp, S_LEN("no")) == 0) {
     *argp += 2;
     return PREFIX_NO;
-  } else if (strncmp(*argp, "inv", 3) == 0) {
+  } else if (strncmp(*argp, S_LEN("inv")) == 0) {
     *argp += 3;
     return PREFIX_INV;
   }
@@ -1426,7 +1426,7 @@ int do_set(char *arg, int opt_flags)
     did_show = true;
   } else {
     while (*arg != NUL) {         // loop to process all options
-      if (strncmp(arg, "all", 3) == 0 && !ASCII_ISALPHA(arg[3])
+      if (strncmp(arg, S_LEN("all")) == 0 && !ASCII_ISALPHA(arg[3])
           && !(opt_flags & OPT_MODELINE)) {
         // ":set all"  show all options.
         // ":set all&" set all options to their default value.
@@ -2771,7 +2771,7 @@ static void do_spelllang_source(win_T *win)
   char *q = win->w_s->b_p_spl;
 
   // Skip the first name if it is "cjk".
-  if (strncmp(q, "cjk,", 4) == 0) {
+  if (strncmp(q, S_LEN("cjk,")) == 0) {
     q += 4;
   }
 
@@ -5450,11 +5450,11 @@ void set_context_in_set_cmd(expand_T *xp, char *arg, int opt_flags)
     }
     p--;
   }
-  if (strncmp(p, "no", 2) == 0) {
+  if (strncmp(p, S_LEN("no")) == 0) {
     xp->xp_context = EXPAND_BOOL_SETTINGS;
     xp->xp_prefix = XP_PREFIX_NO;
     p += 2;
-  } else if (strncmp(p, "inv", 3) == 0) {
+  } else if (strncmp(p, S_LEN("inv")) == 0) {
     xp->xp_context = EXPAND_BOOL_SETTINGS;
     xp->xp_prefix = XP_PREFIX_INV;
     p += 3;
@@ -5649,7 +5649,7 @@ void set_context_in_set_cmd(expand_T *xp, char *arg, int opt_flags)
   // manually handle it here to make sure we have the correct xp_context set.
   // for 'spellsuggest' start at "file:"
   if (options[opt_idx].var == &p_sps) {
-    if (strncmp(xp->xp_pattern, "file:", 5) == 0) {
+    if (strncmp(xp->xp_pattern, S_LEN("file:")) == 0) {
       xp->xp_pattern += 5;
       return;
     } else if (options[expand_option_idx].opt_expand_cb != NULL) {
@@ -6081,16 +6081,16 @@ int fill_culopt_flags(char *val, win_T *wp)
   }
   while (*p != NUL) {
     // Note: Keep this in sync with p_culopt_values.
-    if (strncmp(p, "line", 4) == 0) {
+    if (strncmp(p, S_LEN("line")) == 0) {
       p += 4;
       culopt_flags_new |= CULOPT_LINE;
-    } else if (strncmp(p, "both", 4) == 0) {
+    } else if (strncmp(p, S_LEN("both")) == 0) {
       p += 4;
       culopt_flags_new |= CULOPT_LINE | CULOPT_NBR;
-    } else if (strncmp(p, "number", 6) == 0) {
+    } else if (strncmp(p, S_LEN("number")) == 0) {
       p += 6;
       culopt_flags_new |= CULOPT_NBR;
-    } else if (strncmp(p, "screenline", 10) == 0) {
+    } else if (strncmp(p, S_LEN("screenline")) == 0) {
       p += 10;
       culopt_flags_new |= CULOPT_SCRLINE;
     }
@@ -6138,8 +6138,8 @@ int option_set_callback_func(char *optval, Callback *optcb)
 
   typval_T *tv;
   if (*optval == '{'
-      || (strncmp(optval, "function(", 9) == 0)
-      || (strncmp(optval, "funcref(", 8) == 0)) {
+      || (strncmp(optval, S_LEN("function(")) == 0)
+      || (strncmp(optval, S_LEN("funcref(")) == 0)) {
     // Lambda expression or a funcref
     tv = eval_expr(optval, NULL);
     if (tv == NULL) {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -288,15 +288,15 @@ int check_signcolumn(win_T *wp)
   }
 
   if (check_opt_strings(val, p_scl_values, false) == OK) {
-    if (!strncmp(val, "no", 2)) {  // no
+    if (!strncmp(val, S_LEN("no"))) {  // no
       wp->w_minscwidth = wp->w_maxscwidth = SCL_NO;
-    } else if (!strncmp(val, "nu", 2) && (wp->w_p_nu || wp->w_p_rnu)) {  // number
+    } else if (!strncmp(val, S_LEN("nu")) && (wp->w_p_nu || wp->w_p_rnu)) {  // number
       wp->w_minscwidth = wp->w_maxscwidth = SCL_NUM;
-    } else if (!strncmp(val, "yes:", 4)) {  // yes:<NUM>
+    } else if (!strncmp(val, S_LEN("yes:"))) {  // yes:<NUM>
       wp->w_minscwidth = wp->w_maxscwidth = val[4] - '0';
     } else if (*val == 'y') {  // yes
       wp->w_minscwidth = wp->w_maxscwidth = 1;
-    } else if (!strncmp(val, "auto:", 5)) {  // auto:<NUM>
+    } else if (!strncmp(val, S_LEN("auto:"))) {  // auto:<NUM>
       wp->w_minscwidth = 0;
       wp->w_maxscwidth = val[5] - '0';
     } else {  // auto
@@ -306,7 +306,7 @@ int check_signcolumn(win_T *wp)
     return OK;
   }
 
-  if (strncmp(val, "auto:", 5) != 0
+  if (strncmp(val, S_LEN("auto:")) != 0
       || strlen(val) != 8
       || !ascii_isdigit(val[5])
       || val[6] != '-'
@@ -1732,9 +1732,9 @@ const char *did_set_mousescroll(optset_T *args FUNC_ATTR_UNUSED)
 
     OptInt *direction;
 
-    if (memcmp(string, "ver:", 4) == 0) {
+    if (memcmp(string, S_LEN("ver:")) == 0) {
       direction = &vertical;
-    } else if (memcmp(string, "hor:", 4) == 0) {
+    } else if (memcmp(string, S_LEN("hor:")) == 0) {
       direction = &horizontal;
     } else {
       return e_invarg;

--- a/src/nvim/profile.c
+++ b/src/nvim/profile.c
@@ -294,7 +294,7 @@ void ex_profile(exarg_T *eap)
   int len = (int)(e - eap->arg);
   e = skipwhite(e);
 
-  if (len == 5 && strncmp(eap->arg, "start", 5) == 0 && *e != NUL) {
+  if (len == 5 && strncmp(eap->arg, S_LEN("start")) == 0 && *e != NUL) {
     xfree(profile_fname);
     profile_fname = expand_env_save_opt(e, true);
     do_profiling = PROF_YES;
@@ -369,12 +369,12 @@ void set_context_in_profile_cmd(expand_T *xp, const char *arg)
     return;
   }
 
-  if ((end_subcmd - arg == 5 && strncmp(arg, "start", 5) == 0)
-      || (end_subcmd - arg == 4 && strncmp(arg, "file", 4) == 0)) {
+  if ((end_subcmd - arg == 5 && strncmp(arg, S_LEN("start")) == 0)
+      || (end_subcmd - arg == 4 && strncmp(arg, S_LEN("file")) == 0)) {
     xp->xp_context = EXPAND_FILES;
     xp->xp_pattern = skipwhite(end_subcmd);
     return;
-  } else if (end_subcmd - arg == 4 && strncmp(arg, "func", 4) == 0) {
+  } else if (end_subcmd - arg == 4 && strncmp(arg, S_LEN("func")) == 0) {
     xp->xp_context = EXPAND_USER_FUNC;
     xp->xp_pattern = skipwhite(end_subcmd);
     return;

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -11517,7 +11517,7 @@ static void nfa_print_state2(FILE *debugf, nfa_state_T *state, garray_T *indent)
     uint8_t save[2];
 
     strncpy(save, &p[last], 2);  // NOLINT(runtime/printf)
-    memcpy(&p[last], "+-", 2);
+    memcpy(&p[last], S_LEN("+-"));
     fprintf(debugf, " %s", p);
     strncpy(&p[last], save, 2);  // NOLINT(runtime/printf)
   } else {
@@ -15932,7 +15932,7 @@ regprog_T *vim_regcomp(const char *expr_arg, int re_flags)
   regexp_engine = (int)p_re;
 
   // Check for prefix "\%#=", that sets the regexp engine
-  if (strncmp(expr, "\\%#=", 4) == 0) {
+  if (strncmp(expr, S_LEN("\\%#=")) == 0) {
     int newengine = expr[4] - '0';
 
     if (newengine == AUTOMATIC_ENGINE

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -1321,16 +1321,16 @@ expand:
     }
 
     if (flags & DIP_START) {
-      memcpy(tail - 15, "pack/*/start/*/", 15);  // NOLINT
+      memcpy(tail - 15, S_LEN("pack/*/start/*/"));  // NOLINT
       globpath(p_pp, tail - 15, gap, glob_flags, expand_dirs);
-      memcpy(tail - 8, "start/*/", 8);  // NOLINT
+      memcpy(tail - 8, S_LEN("start/*/"));  // NOLINT
       globpath(p_pp, tail - 8, gap, glob_flags, expand_dirs);
     }
 
     if (flags & DIP_OPT) {
-      memcpy(tail - 13, "pack/*/opt/*/", 13);  // NOLINT
+      memcpy(tail - 13, S_LEN("pack/*/opt/*/"));  // NOLINT
       globpath(p_pp, tail - 13, gap, glob_flags, expand_dirs);
-      memcpy(tail - 6, "opt/*/", 6);  // NOLINT
+      memcpy(tail - 6, S_LEN("opt/*/"));  // NOLINT
       globpath(p_pp, tail - 6, gap, glob_flags, expand_dirs);
     }
 
@@ -1877,7 +1877,7 @@ static bool concat_continued_line(garray_T *const ga, const int init_growsize, c
   const char *const line = skipwhite_len(p, len);
   len -= (size_t)(line - p);
   // Skip lines starting with '\" ', concat lines starting with '\'
-  if (len >= 3 && strncmp(line, "\"\\ ", 3) == 0) {
+  if (len >= 3 && strncmp(line, S_LEN("\"\\ ")) == 0) {
     return true;
   } else if (len == 0 || line[0] != '\\') {
     return false;

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -543,7 +543,7 @@ void last_pat_prog(regmmatch_T *regmatch)
     return;
   }
   emsg_off++;           // So it doesn't beep if bad expr
-  search_regcomp("", 0, NULL, 0, last_idx, SEARCH_KEEP, regmatch);
+  search_regcomp(S_LEN(""), NULL, 0, last_idx, SEARCH_KEEP, regmatch);
   emsg_off--;
 }
 
@@ -1821,9 +1821,9 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
         ptr = skipwhite(linep);
         if (*ptr == '#' && pos.col <= (colnr_T)(ptr - linep)) {
           ptr = skipwhite(ptr + 1);
-          if (strncmp(ptr, "if", 2) == 0
-              || strncmp(ptr, "endif", 5) == 0
-              || strncmp(ptr, "el", 2) == 0) {
+          if (strncmp(ptr, S_LEN("if")) == 0
+              || strncmp(ptr, S_LEN("endif")) == 0
+              || strncmp(ptr, S_LEN("el")) == 0) {
             hash_dir = 1;
           }
         } else if (linep[pos.col] == '/') {  // Are we on a comment?
@@ -1894,9 +1894,9 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
       }
       if (initc != '#') {
         ptr = skipwhite(skipwhite(linep) + 1);
-        if (strncmp(ptr, "if", 2) == 0 || strncmp(ptr, "el", 2) == 0) {
+        if (strncmp(ptr, S_LEN("if")) == 0 || strncmp(ptr, S_LEN("el")) == 0) {
           hash_dir = 1;
-        } else if (strncmp(ptr, "endif", 5) == 0) {
+        } else if (strncmp(ptr, S_LEN("endif")) == 0) {
           hash_dir = -1;
         } else {
           return NULL;
@@ -1921,29 +1921,29 @@ pos_T *findmatchlimit(oparg_T *oap, int initc, int flags, int64_t maxtravel)
         pos.col = (colnr_T)(ptr - linep);
         ptr = skipwhite(ptr + 1);
         if (hash_dir > 0) {
-          if (strncmp(ptr, "if", 2) == 0) {
+          if (strncmp(ptr, S_LEN("if")) == 0) {
             count++;
-          } else if (strncmp(ptr, "el", 2) == 0) {
+          } else if (strncmp(ptr, S_LEN("el")) == 0) {
             if (count == 0) {
               return &pos;
             }
-          } else if (strncmp(ptr, "endif", 5) == 0) {
+          } else if (strncmp(ptr, S_LEN("endif")) == 0) {
             if (count == 0) {
               return &pos;
             }
             count--;
           }
         } else {
-          if (strncmp(ptr, "if", 2) == 0) {
+          if (strncmp(ptr, S_LEN("if")) == 0) {
             if (count == 0) {
               return &pos;
             }
             count--;
-          } else if (initc == '#' && strncmp(ptr, "el", 2) == 0) {
+          } else if (initc == '#' && strncmp(ptr, S_LEN("el")) == 0) {
             if (count == 0) {
               return &pos;
             }
-          } else if (strncmp(ptr, "endif", 5) == 0) {
+          } else if (strncmp(ptr, S_LEN("endif")) == 0) {
             count++;
           }
         }
@@ -3891,7 +3891,7 @@ search_line:
           // is not considered to be a comment line.
           if (skip_comments) {
             if ((*line != '#'
-                 || strncmp(skipwhite(line + 1), "define", 6) != 0)
+                 || strncmp(skipwhite(line + 1), S_LEN("define")) != 0)
                 && get_leader_len(line, NULL, false, true)) {
               matched = false;
             }

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -610,17 +610,17 @@ static void sign_define_cmd(char *name, char *cmdline)
       break;
     }
     cmdline = skiptowhite_esc(arg);
-    if (strncmp(arg, "icon=", 5) == 0) {
+    if (strncmp(arg, S_LEN("icon=")) == 0) {
       icon = arg + 5;
-    } else if (strncmp(arg, "text=", 5) == 0) {
+    } else if (strncmp(arg, S_LEN("text=")) == 0) {
       text = arg + 5;
-    } else if (strncmp(arg, "linehl=", 7) == 0) {
+    } else if (strncmp(arg, S_LEN("linehl=")) == 0) {
       linehl = arg + 7;
-    } else if (strncmp(arg, "texthl=", 7) == 0) {
+    } else if (strncmp(arg, S_LEN("texthl=")) == 0) {
       texthl = arg + 7;
-    } else if (strncmp(arg, "culhl=", 6) == 0) {
+    } else if (strncmp(arg, S_LEN("culhl=")) == 0) {
       culhl = arg + 6;
-    } else if (strncmp(arg, "numhl=", 6) == 0) {
+    } else if (strncmp(arg, S_LEN("numhl=")) == 0) {
       numhl = arg + 6;
     } else {
       semsg(_(e_invarg2), arg);
@@ -728,19 +728,19 @@ static int parse_sign_cmd_args(int cmd, char *arg, char **name, int *id, char **
   }
 
   while (*arg != NUL) {
-    if (strncmp(arg, "line=", 5) == 0) {
+    if (strncmp(arg, S_LEN("line=")) == 0) {
       arg += 5;
       *lnum = atoi(arg);
       arg = skiptowhite(arg);
       lnum_arg = true;
-    } else if (strncmp(arg, "*", 1) == 0 && cmd == SIGNCMD_UNPLACE) {
+    } else if (strncmp(arg, S_LEN("*")) == 0 && cmd == SIGNCMD_UNPLACE) {
       if (*id != -1) {
         emsg(_(e_invarg));
         return FAIL;
       }
       *id = -2;
       arg = skiptowhite(arg + 1);
-    } else if (strncmp(arg, "name=", 5) == 0) {
+    } else if (strncmp(arg, S_LEN("name=")) == 0) {
       arg += 5;
       char *namep = arg;
       arg = skiptowhite(arg);
@@ -751,23 +751,23 @@ static int parse_sign_cmd_args(int cmd, char *arg, char **name, int *id, char **
         namep++;
       }
       *name = namep;
-    } else if (strncmp(arg, "group=", 6) == 0) {
+    } else if (strncmp(arg, S_LEN("group=")) == 0) {
       arg += 6;
       *group = arg;
       arg = skiptowhite(arg);
       if (*arg != NUL) {
         *arg++ = NUL;
       }
-    } else if (strncmp(arg, "priority=", 9) == 0) {
+    } else if (strncmp(arg, S_LEN("priority=")) == 0) {
       arg += 9;
       *prio = atoi(arg);
       arg = skiptowhite(arg);
-    } else if (strncmp(arg, "file=", 5) == 0) {
+    } else if (strncmp(arg, S_LEN("file=")) == 0) {
       arg += 5;
       filename = arg;
       *buf = buflist_findname_exp(arg);
       break;
-    } else if (strncmp(arg, "buffer=", 7) == 0) {
+    } else if (strncmp(arg, S_LEN("buffer=")) == 0) {
       arg += 7;
       filename = arg;
       *buf = buflist_findnr(getdigits_int(&arg, true, 0));
@@ -1145,23 +1145,23 @@ void set_context_in_sign_cmd(expand_T *xp, char *arg)
     xp->xp_pattern = p + 1;
     switch (cmd_idx) {
     case SIGNCMD_DEFINE:
-      if (strncmp(last, "texthl", 6) == 0
-          || strncmp(last, "linehl", 6) == 0
-          || strncmp(last, "culhl", 5) == 0
-          || strncmp(last, "numhl", 5) == 0) {
+      if (strncmp(last, S_LEN("texthl")) == 0
+          || strncmp(last, S_LEN("linehl")) == 0
+          || strncmp(last, S_LEN("culhl")) == 0
+          || strncmp(last, S_LEN("numhl")) == 0) {
         xp->xp_context = EXPAND_HIGHLIGHT;
-      } else if (strncmp(last, "icon", 4) == 0) {
+      } else if (strncmp(last, S_LEN("icon")) == 0) {
         xp->xp_context = EXPAND_FILES;
       } else {
         xp->xp_context = EXPAND_NOTHING;
       }
       break;
     case SIGNCMD_PLACE:
-      if (strncmp(last, "name", 4) == 0) {
+      if (strncmp(last, S_LEN("name")) == 0) {
         expand_what = EXP_SIGN_NAMES;
-      } else if (strncmp(last, "group", 5) == 0) {
+      } else if (strncmp(last, S_LEN("group")) == 0) {
         expand_what = EXP_SIGN_GROUPS;
-      } else if (strncmp(last, "file", 4) == 0) {
+      } else if (strncmp(last, S_LEN("file")) == 0) {
         xp->xp_context = EXPAND_BUFFERS;
       } else {
         xp->xp_context = EXPAND_NOTHING;
@@ -1169,9 +1169,9 @@ void set_context_in_sign_cmd(expand_T *xp, char *arg)
       break;
     case SIGNCMD_UNPLACE:
     case SIGNCMD_JUMP:
-      if (strncmp(last, "group", 5) == 0) {
+      if (strncmp(last, S_LEN("group")) == 0) {
         expand_what = EXP_SIGN_GROUPS;
-      } else if (strncmp(last, "file", 4) == 0) {
+      } else if (strncmp(last, S_LEN("file")) == 0) {
         xp->xp_context = EXPAND_BUFFERS;
       } else {
         xp->xp_context = EXPAND_NOTHING;

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -3615,7 +3615,7 @@ static int spell_read_wordfile(spellinfo_T *spin, char *fname)
 
     if (*line == '/') {
       line++;
-      if (strncmp(line, "encoding=", 9) == 0) {
+      if (strncmp(line, S_LEN("encoding=")) == 0) {
         if (spin->si_conv.vc_type != CONV_NONE) {
           smsg(0, _("Duplicate /encoding= line ignored in %s line %" PRIdLINENR ": %s"),
                fname, lnum, line - 1);
@@ -3637,7 +3637,7 @@ static int spell_read_wordfile(spellinfo_T *spin, char *fname)
         continue;
       }
 
-      if (strncmp(line, "regions=", 8) == 0) {
+      if (strncmp(line, S_LEN("regions=")) == 0) {
         if (spin->si_region_count > 1) {
           smsg(0, _("Duplicate /regions= line ignored in %s line %" PRIdLINENR ": %s"),
                fname, lnum, line);
@@ -4766,7 +4766,7 @@ void ex_mkspell(exarg_T *eap)
   char *arg = eap->arg;
   bool ascii = false;
 
-  if (strncmp(arg, "-ascii", 6) == 0) {
+  if (strncmp(arg, S_LEN("-ascii")) == 0) {
     ascii = true;
     arg = skipwhite(arg + 6);
   }

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -413,9 +413,9 @@ int spell_check_sps(void)
       f = SPS_FAST;
     } else if (strcmp(buf, "double") == 0) {
       f = SPS_DOUBLE;
-    } else if (strncmp(buf, "expr:", 5) != 0
-               && strncmp(buf, "file:", 5) != 0
-               && (strncmp(buf, "timeout:", 8) != 0
+    } else if (strncmp(buf, S_LEN("expr:")) != 0
+               && strncmp(buf, S_LEN("file:")) != 0
+               && (strncmp(buf, S_LEN("timeout:")) != 0
                    || (!ascii_isdigit(buf[8])
                        && !(buf[8] == '-' && ascii_isdigit(buf[9]))))) {
       f = -1;
@@ -543,7 +543,7 @@ void spell_suggest(int count)
     msg_row = Rows - 1;         // for when 'cmdheight' > 1
     lines_left = Rows;          // avoid more prompt
     char *fmt = _("Change \"%.*s\" to:");
-    if (cmdmsg_rl && strncmp(fmt, "Change", 6) == 0) {
+    if (cmdmsg_rl && strncmp(fmt, S_LEN("Change")) == 0) {
       // And now the rabbit from the high hat: Avoid showing the
       // untranslated message rightleft.
       fmt = ":ot \"%.*s\" egnahC";
@@ -792,7 +792,7 @@ static void spell_find_suggest(char *badptr, int badlen, suginfo_T *su, int maxc
   for (char *p = sps_copy; *p != NUL;) {
     copy_option_part(&p, buf, MAXPATHL, ",");
 
-    if (strncmp(buf, "expr:", 5) == 0) {
+    if (strncmp(buf, S_LEN("expr:")) == 0) {
       // Evaluate an expression.  Skip this when called recursively,
       // when using spellsuggest() in the expression.
       if (!expr_busy) {
@@ -800,10 +800,10 @@ static void spell_find_suggest(char *badptr, int badlen, suginfo_T *su, int maxc
         spell_suggest_expr(su, buf + 5);
         expr_busy = false;
       }
-    } else if (strncmp(buf, "file:", 5) == 0) {
+    } else if (strncmp(buf, S_LEN("file:")) == 0) {
       // Use list of suggestions in a file.
       spell_suggest_file(su, buf + 5);
-    } else if (strncmp(buf, "timeout:", 8) == 0) {
+    } else if (strncmp(buf, S_LEN("timeout:")) == 0) {
       // Limit the time searching for suggestions.
       spell_suggest_timeout = atoi(buf + 8);
     } else if (!did_intern) {

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -1487,7 +1487,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, OptIndex op
 
         new_fmt_p = (char *)memcpy(new_fmt_p, usefmt, parsed_usefmt) + parsed_usefmt;
         new_fmt_p = (char *)memcpy(new_fmt_p, str, str_length) + str_length;
-        new_fmt_p = (char *)memcpy(new_fmt_p, "%}", 2) + 2;
+        new_fmt_p = (char *)memcpy(new_fmt_p, S_LEN("%}")) + 2;
         new_fmt_p = (char *)memcpy(new_fmt_p, fmt_p, fmt_length) + fmt_length;
         *new_fmt_p = 0;
         new_fmt_p = NULL;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3186,7 +3186,7 @@ static void syn_cmd_onoff(exarg_T *eap, char *name)
   if (!eap->skip) {
     did_syntax_onoff = true;
     char buf[100];
-    xmemcpyz(buf, S_LEN("so "));
+    memcpy(buf, S_LEN("so ") + 1);
     vim_snprintf(buf + 3, sizeof(buf) - 3, SYNTAX_FNAME, name);
     do_cmdline_cmd(buf);
   }

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3186,7 +3186,7 @@ static void syn_cmd_onoff(exarg_T *eap, char *name)
   if (!eap->skip) {
     did_syntax_onoff = true;
     char buf[100];
-    memcpy(buf, "so ", 4);
+    memcpy(buf, S_LEN("so "));
     vim_snprintf(buf + 3, sizeof(buf) - 3, SYNTAX_FNAME, name);
     do_cmdline_cmd(buf);
   }
@@ -4296,7 +4296,7 @@ static void syn_cmd_region(exarg_T *eap, int syncing)
 
     if (item == ITEM_MATCHGROUP) {
       char *p = skiptowhite(rest);
-      if ((p - rest == 4 && strncmp(rest, "NONE", 4) == 0) || eap->skip) {
+      if ((p - rest == 4 && strncmp(rest, S_LEN("NONE")) == 0) || eap->skip) {
         matchgroup_id = 0;
       } else {
         matchgroup_id = syn_check_group(rest, (size_t)(p - rest));
@@ -4815,10 +4815,10 @@ static void syn_cmd_sync(exarg_T *eap, int syncing)
       } else if (!eap->skip) {
         curwin->w_s->b_syn_sync_id = (int16_t)syn_name2id("Comment");
       }
-    } else if (strncmp(key, "LINES", 5) == 0
-               || strncmp(key, "MINLINES", 8) == 0
-               || strncmp(key, "MAXLINES", 8) == 0
-               || strncmp(key, "LINEBREAKS", 10) == 0) {
+    } else if (strncmp(key, S_LEN("LINES")) == 0
+               || strncmp(key, S_LEN("MINLINES")) == 0
+               || strncmp(key, S_LEN("MAXLINES")) == 0
+               || strncmp(key, S_LEN("LINEBREAKS")) == 0) {
       if (key[4] == 'S') {
         arg_end = key + 6;
       } else if (key[0] == 'L') {

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3186,7 +3186,7 @@ static void syn_cmd_onoff(exarg_T *eap, char *name)
   if (!eap->skip) {
     did_syntax_onoff = true;
     char buf[100];
-    memcpy(buf, S_LEN("so "));
+    xmemcpyz(buf, S_LEN("so "));
     vim_snprintf(buf + 3, sizeof(buf) - 3, SYNTAX_FNAME, name);
     do_cmdline_cmd(buf);
   }

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -879,14 +879,14 @@ static void print_tag_list(bool new_tag, bool use_tagstack, int num_matches, cha
         }
 
         // skip "file:" without a value (static tag)
-        if (strncmp(p, "file:", 5) == 0 && ascii_isspace(p[5])) {
+        if (strncmp(p, S_LEN("file:")) == 0 && ascii_isspace(p[5])) {
           p += 5;
           continue;
         }
         // skip "kind:<kind>" and "<kind>"
         if (p == tagp.tagkind
             || (p + 5 == tagp.tagkind
-                && strncmp(p, "kind:", 5) == 0)) {
+                && strncmp(p, S_LEN("kind:")) == 0)) {
           p = tagp.tagkind_end;
           continue;
         }
@@ -1614,16 +1614,16 @@ static tags_read_status_T findtags_get_next_line(findtags_state_T *st, tagsearch
 static bool findtags_hdr_parse(findtags_state_T *st)
 {
   // Header lines in a tags file start with "!_TAG_"
-  if (strncmp(st->lbuf, "!_TAG_", 6) != 0) {
+  if (strncmp(st->lbuf, S_LEN("!_TAG_")) != 0) {
     // Non-header item before the header, e.g. "!" itself.
     return true;
   }
 
   // Process the header line.
-  if (strncmp(st->lbuf, "!_TAG_FILE_SORTED\t", 18) == 0) {
+  if (strncmp(st->lbuf, S_LEN("!_TAG_FILE_SORTED\t")) == 0) {
     st->tag_file_sorted = (uint8_t)st->lbuf[18];
   }
-  if (strncmp(st->lbuf, "!_TAG_FILE_ENCODING\t", 20) == 0) {
+  if (strncmp(st->lbuf, S_LEN("!_TAG_FILE_ENCODING\t")) == 0) {
     // Prepare to convert every line from the specified encoding to
     // 'encoding'.
     char *p;
@@ -1647,7 +1647,7 @@ static bool findtags_start_state_handler(findtags_state_T *st, bool *sortic,
 
   // The header ends when the line sorts below "!_TAG_".  When case is
   // folded lower case letters sort before "_".
-  if (strncmp(st->lbuf, "!_TAG_", 6) <= 0
+  if (strncmp(st->lbuf, S_LEN("!_TAG_")) <= 0
       || (st->lbuf[0] == '!' && ASCII_ISLOWER(st->lbuf[1]))) {
     return findtags_hdr_parse(st);
   }
@@ -2670,7 +2670,7 @@ static bool test_for_static(tagptrs_T *tagp)
   char *p = tagp->command;
   while ((p = vim_strchr(p, '\t')) != NULL) {
     p++;
-    if (strncmp(p, "file:", 5) == 0) {
+    if (strncmp(p, S_LEN("file:")) == 0) {
       return true;
     }
   }
@@ -2728,11 +2728,11 @@ static int parse_match(char *lbuf, tagptrs_T *tagp)
       // Accept ASCII alphabetic kind characters and any multi-byte
       // character.
       while (ASCII_ISALPHA(*p) || utfc_ptr2len(p) > 1) {
-        if (strncmp(p, "kind:", 5) == 0) {
+        if (strncmp(p, S_LEN("kind:")) == 0) {
           tagp->tagkind = p + 5;
-        } else if (strncmp(p, "user_data:", 10) == 0) {
+        } else if (strncmp(p, S_LEN("user_data:")) == 0) {
           tagp->user_data = p + 10;
-        } else if (strncmp(p, "line:", 5) == 0) {
+        } else if (strncmp(p, S_LEN("line:")) == 0) {
           tagp->tagline = atoi(p + 5);
         }
         if (tagp->tagkind != NULL && tagp->user_data != NULL) {
@@ -3174,7 +3174,7 @@ static int find_extra(char **pp)
     first_char = *str;
   }
 
-  if (str != NULL && strncmp(str, ";\"", 2) == 0) {
+  if (str != NULL && strncmp(str, ";\S_LEN("")) == 0) {
     *pp = str;
     return OK;
   }
@@ -3303,7 +3303,7 @@ int get_tags(list_T *list, char *pat, char *buf_fname)
     bool is_static = test_for_static(&tp);
 
     // Skip pseudo-tag lines.
-    if (strncmp(tp.tagname, "!_TAG_", 6) == 0) {
+    if (strncmp(tp.tagname, S_LEN("!_TAG_")) == 0) {
       xfree(matches[i]);
       continue;
     }
@@ -3328,10 +3328,10 @@ int get_tags(list_T *list, char *pat, char *buf_fname)
            *p != NUL && *p != '\n' && *p != '\r';
            MB_PTR_ADV(p)) {
         if (p == tp.tagkind
-            || (p + 5 == tp.tagkind && strncmp(p, "kind:", 5) == 0)) {
+            || (p + 5 == tp.tagkind && strncmp(p, S_LEN("kind:")) == 0)) {
           // skip "kind:<kind>" and "<kind>"
           p = tp.tagkind_end - 1;
-        } else if (strncmp(p, "file:", 5) == 0) {
+        } else if (strncmp(p, S_LEN("file:")) == 0) {
           // skip "file:" (static tag)
           p += 4;
         } else if (!ascii_iswhite(*p)) {

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -3174,7 +3174,7 @@ static int find_extra(char **pp)
     first_char = *str;
   }
 
-  if (str != NULL && strncmp(str, ";\S_LEN("")) == 0) {
+  if (str != NULL && strncmp(str, S_LEN(";\"")) == 0) {
     *pp = str;
     return OK;
   }

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -833,9 +833,9 @@ void terminal_paste(int count, char **y_array, size_t y_size)
       if (j) {
         // terminate the previous line
 #ifdef MSWIN
-        terminal_send(curbuf->terminal, "\r\n", 2);
+        terminal_send(curbuf->terminal, S_LEN("\r\n"));
 #else
-        terminal_send(curbuf->terminal, "\n", 1);
+        terminal_send(curbuf->terminal, S_LEN("\n"));
 #endif
       }
       size_t len = strlen(y_array[j]);

--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -1017,7 +1017,7 @@ void format_lines(linenr_T line_count, bool avoid_fex)
         // and this line has a line comment after some text, the
         // paragraph doesn't really end.
         if (next_leader_flags == NULL
-            || strncmp(next_leader_flags, "://", 3) != 0
+            || strncmp(next_leader_flags, S_LEN("://")) != 0
             || check_linecomment(get_cursor_line_ptr()) == MAXCOL) {
           is_end_par = true;
         }

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -422,10 +422,10 @@ char *get_user_cmd_complete(expand_T *xp, int idx)
 
 int cmdcomplete_str_to_type(const char *complete_str)
 {
-  if (strncmp(complete_str, "custom,", 7) == 0) {
+  if (strncmp(complete_str, S_LEN("custom,")) == 0) {
     return EXPAND_USER_DEFINED;
   }
-  if (strncmp(complete_str, "customlist,", 11) == 0) {
+  if (strncmp(complete_str, S_LEN("customlist,")) == 0) {
     return EXPAND_USER_LIST;
   }
 
@@ -1056,7 +1056,7 @@ void ex_delcommand(exarg_T *eap)
   const char *arg = eap->arg;
   bool buffer_only = false;
 
-  if (strncmp(arg, "-buffer", 7) == 0 && ascii_iswhite(arg[7])) {
+  if (strncmp(arg, S_LEN("-buffer")) == 0 && ascii_iswhite(arg[7])) {
     buffer_only = true;
     arg = skipwhite(arg + 7);
   }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -789,7 +789,7 @@ int win_fdccol_count(win_T *wp)
   const char *fdc = wp->w_p_fdc;
 
   // auto:<NUM>
-  if (strncmp(fdc, "auto", 4) == 0) {
+  if (strncmp(fdc, S_LEN("auto")) == 0) {
     const int fdccol = fdc[4] == ':' ? fdc[5] - '0' : 1;
     int needed_fdccols = getDeepestNesting(wp);
     return MIN(fdccol, needed_fdccols);


### PR DESCRIPTION
Use S_LEN(s) instead of writing s, n where n is a literal number for the length of s which may be error-prone. Also prefer memmove over strmove when the length of the source string is known to avoid a strlen.