### PR TITLE
feat: store the parsed command range as string

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1902,6 +1902,8 @@ nvim_parse_cmd({str}, {opts})                               *nvim_parse_cmd()*
           if command doesn't accept a range. Otherwise, has no elements if no
           range was specified, one element if only a single range item was
           specified, or two elements if both range items were specified.
+        • rangestr: (string) (optional) The parsed range extracted from the
+          command line.
         • count: (number) (optional) Command <count>. Omitted if command
           cannot take a count.
         • reg: (string) (optional) Command <register>. Omitted if command

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -25,6 +25,7 @@ error('Cannot require a meta file')
 --- @class vim.api.keyset.cmd
 --- @field cmd? string
 --- @field range? any[]
+--- @field rangestr? string
 --- @field count? integer
 --- @field reg? string
 --- @field bang? boolean

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -53,6 +53,7 @@
 ///                          Otherwise, has no elements if no range was specified, one element if
 ///                          only a single range item was specified, or two elements if both range
 ///                          items were specified.
+///         - rangestr: (string) (optional) The parsed range extracted from the command line.
 ///         - count: (number) (optional) Command [<count>].
 ///                           Omitted if command cannot take a count.
 ///         - reg: (string) (optional) Command [<register>].
@@ -162,6 +163,7 @@ Dict(cmd) nvim_parse_cmd(String str, Dict(empty) *opts, Arena *arena, Error *err
       ADD_C(range, INTEGER_OBJ(ea.line2));
     }
     PUT_KEY(result, cmd, range, range);
+    PUT_KEY(result, cmd, rangestr, cstr_as_string(ea.rangestr));
   }
 
   if (ea.argt & EX_COUNT) {

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -271,6 +271,7 @@ typedef struct {
   OptionalKeys is_set__cmd_;
   String cmd;
   Array range;
+  String rangestr;
   Integer count;
   String reg;
   Boolean bang;

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -144,6 +144,7 @@ struct exarg {
   char *cmd;                    ///< the name of the command (except for :make)
   char **cmdlinep;              ///< pointer to pointer of allocated cmdline
   char *cmdline_tofree;         ///< free later
+  char *rangestr;               ///< extracted range from cmdline
   cmdidx_T cmdidx;              ///< the index for the command
   uint32_t argt;                ///< flags for the command
   int skip;                     ///< don't execute the command, only parse it

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1499,8 +1499,9 @@ bool parse_cmdline(char *cmdline, exarg_T *eap, CmdParseInfo *cmdinfo, const cha
   }
   after_modifier = eap->cmd;
 
-  // Save location after command modifiers
+  // Save location after command modifiers, which is also the start of the range
   char *cmd = eap->cmd;
+  char *range_start = eap->cmd;
   // Skip ranges to find command name since we need the command to know what kind of range it uses
   eap->cmd = skip_range(eap->cmd, NULL);
   if (*eap->cmd == '*') {
@@ -1519,6 +1520,9 @@ bool parse_cmdline(char *cmdline, exarg_T *eap, CmdParseInfo *cmdinfo, const cha
     goto end;
   }
 
+  // Store the found range
+  // FIXME: this must be freed somewhere
+  eap->rangestr = xmemdupz(range_start, eap->cmd - range_start);
   // Skip colon and whitespace
   eap->cmd = skip_colon_white(eap->cmd, true);
   // Fail if command is a comment or if command doesn't exist
@@ -2795,6 +2799,9 @@ int parse_cmd_address(exarg_T *eap, const char **errormsg, bool silent)
   bool need_check_cursor = false;
   int ret = FAIL;
 
+  // Save the location of the start of the range
+  char *range_start = eap->cmd;
+
   // Repeat for all ',' or ';' separated addresses.
   while (true) {
     eap->line1 = eap->line2;
@@ -2919,6 +2926,10 @@ int parse_cmd_address(exarg_T *eap, const char **errormsg, bool silent)
     }
     eap->cmd++;
   }
+
+  // Store the found range as string
+  // FIXME: this must be freed somewhere
+  eap->rangestr = xmemdupz(range_start, eap->cmd - range_start);
 
   // One address given: set start and end lines.
   if (eap->addr_count == 1) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1522,7 +1522,7 @@ bool parse_cmdline(char *cmdline, exarg_T *eap, CmdParseInfo *cmdinfo, const cha
 
   // Store the found range
   // FIXME: this must be freed somewhere
-  eap->rangestr = xmemdupz(range_start, eap->cmd - range_start);
+  eap->rangestr = xmemdupz(range_start, (size_t)(eap->cmd - range_start));
   // Skip colon and whitespace
   eap->cmd = skip_colon_white(eap->cmd, true);
   // Fail if command is a comment or if command doesn't exist
@@ -2929,7 +2929,7 @@ int parse_cmd_address(exarg_T *eap, const char **errormsg, bool silent)
 
   // Store the found range as string
   // FIXME: this must be freed somewhere
-  eap->rangestr = xmemdupz(range_start, eap->cmd - range_start);
+  eap->rangestr = xmemdupz(range_start, (size_t)(eap->cmd - range_start));
 
   // One address given: set start and end lines.
   if (eap->addr_count == 1) {

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -2221,6 +2221,9 @@ int nlua_do_ucmd(ucmd_T *cmd, exarg_T *eap, bool preview)
   lua_pushinteger(lstate, eap->addr_count);
   lua_setfield(lstate, -2, "range");
 
+  lua_pushstring(lstate, eap->rangestr);
+  lua_setfield(lstate, -2, "rangestr");
+
   if (eap->addr_count > 0) {
     lua_pushinteger(lstate, eap->line2);
   } else {

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -249,6 +249,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 0,
+        rangestr = '',
         count = 2,
         reg = '',
       },
@@ -289,6 +290,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 0,
+        rangestr = '',
         count = 2,
         reg = '',
       },
@@ -329,6 +331,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 0,
+        rangestr = '',
         count = 2,
         reg = '',
       },
@@ -369,6 +372,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 1,
+        rangestr = '10',
         count = 10,
         reg = '',
       },
@@ -409,6 +413,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 1,
+        rangestr = '',
         count = 42,
         reg = '',
       },
@@ -449,6 +454,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 0,
+        rangestr = '',
         count = 2,
         reg = '',
       },
@@ -501,6 +507,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 0,
+        rangestr = '',
         count = 2,
         reg = '',
       },
@@ -508,6 +515,58 @@ describe('nvim_create_user_command', function()
       vim.api.nvim_command('CommandWithOneOrNoArg hello I\'m one argument')
       return result
     ]]
+    )
+
+    -- Test visual range
+    exec_lua [[
+      result = {}
+      vim.api.nvim_create_user_command('CommandWithRange', function(opts)
+        result = opts
+      end, {
+        range = true,
+      })
+    ]]
+    eq(
+      {
+        name = 'CommandWithRange',
+        args = '',
+        fargs = {},
+        bang = false,
+        line1 = 1,
+        line2 = 1,
+        mods = '',
+        smods = {
+          browse = false,
+          confirm = false,
+          emsg_silent = false,
+          hide = false,
+          horizontal = false,
+          keepalt = false,
+          keepjumps = false,
+          keepmarks = false,
+          keeppatterns = false,
+          lockmarks = false,
+          noautocmd = false,
+          noswapfile = false,
+          sandbox = false,
+          silent = false,
+          split = '',
+          tab = -1,
+          unsilent = false,
+          verbose = -1,
+          vertical = false,
+        },
+        range = 2,
+        rangestr = "'<,'>",
+        count = 1,
+        reg = '',
+      },
+      exec_lua [=[
+      vim.api.nvim_buf_set_mark(0, '<', 1, 0, {})
+      vim.api.nvim_buf_set_mark(0, '>', 1, 0, {})
+      vim.api.nvim_command("'<,'>CommandWithRange")
+      return result
+    ]=]
     )
 
     -- f-args is an empty table if no args were passed
@@ -542,6 +601,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 0,
+        rangestr = '',
         count = 2,
         reg = '',
       },
@@ -594,6 +654,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 0,
+        rangestr = '',
         count = 2,
         reg = '',
       },
@@ -634,6 +695,7 @@ describe('nvim_create_user_command', function()
           vertical = false,
         },
         range = 0,
+        rangestr = '',
         count = 2,
         reg = '+',
       },

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3954,6 +3954,7 @@ describe('API', function()
         args = { '/math.random/math.max/' },
         bang = false,
         range = { 4, 6 },
+        rangestr = '4,6',
         addr = 'line',
         magic = {
           file = false,
@@ -3988,12 +3989,56 @@ describe('API', function()
         },
       }, api.nvim_parse_cmd('4,6s/math.random/math.max/', {}))
     end)
+    it('works with visual ranges', function()
+      api.nvim_buf_set_mark(0, '<', 1, 0, {})
+      api.nvim_buf_set_mark(0, '>', 1, 0, {})
+      eq({
+        cmd = 'substitute',
+        args = { '/math.random/math.max/' },
+        bang = false,
+        range = { 1, 1 },
+        rangestr = "'<,'>",
+        addr = 'line',
+        magic = {
+          file = false,
+          bar = false,
+        },
+        nargs = '*',
+        nextcmd = '',
+        mods = {
+          browse = false,
+          confirm = false,
+          emsg_silent = false,
+          filter = {
+            pattern = '',
+            force = false,
+          },
+          hide = false,
+          horizontal = false,
+          keepalt = false,
+          keepjumps = false,
+          keepmarks = false,
+          keeppatterns = false,
+          lockmarks = false,
+          noautocmd = false,
+          noswapfile = false,
+          sandbox = false,
+          silent = false,
+          split = '',
+          tab = -1,
+          unsilent = false,
+          verbose = -1,
+          vertical = false,
+        },
+      }, api.nvim_parse_cmd("'<,'>s/math.random/math.max/", {}))
+    end)
     it('works with count', function()
       eq({
         cmd = 'buffer',
         args = {},
         bang = false,
         range = { 1 },
+        rangestr = '',
         count = 1,
         addr = 'buf',
         magic = {
@@ -4035,6 +4080,7 @@ describe('API', function()
         args = {},
         bang = false,
         range = {},
+        rangestr = '',
         reg = '+',
         addr = 'line',
         magic = {
@@ -4074,6 +4120,7 @@ describe('API', function()
         args = {},
         bang = false,
         range = {},
+        rangestr = '',
         reg = '',
         addr = 'line',
         magic = {
@@ -4115,6 +4162,7 @@ describe('API', function()
         args = {},
         bang = false,
         range = { 3, 7 },
+        rangestr = '1,3',
         count = 7,
         reg = '*',
         addr = 'line',
@@ -4157,6 +4205,7 @@ describe('API', function()
         args = {},
         bang = true,
         range = {},
+        rangestr = '',
         addr = 'line',
         magic = {
           file = true,
@@ -4198,6 +4247,7 @@ describe('API', function()
           args = { 'foo.txt' },
           bang = false,
           range = {},
+          rangestr = '',
           addr = '?',
           magic = {
             file = true,
@@ -4242,6 +4292,7 @@ describe('API', function()
           args = { 'foo.txt' },
           bang = false,
           range = {},
+          rangestr = '',
           addr = '?',
           magic = {
             file = true,
@@ -4288,6 +4339,7 @@ describe('API', function()
         args = { 'test', 'it' },
         bang = true,
         range = { 4, 6 },
+        rangestr = '4,6',
         addr = 'line',
         magic = {
           file = false,
@@ -4328,6 +4380,7 @@ describe('API', function()
         args = { 'a.txt' },
         bang = false,
         range = {},
+        rangestr = '',
         addr = 'arg',
         magic = {
           file = true,
@@ -4462,6 +4515,7 @@ describe('API', function()
         args = { 'x' },
         bang = true,
         range = { 3, 4 },
+        rangestr = '+2;/bar/',
         addr = 'line',
         magic = {
           file = false,


### PR DESCRIPTION
Problem: it's not possible to determine if a command is run over a visual range, rather than an ordinary range (line1, line2). Knowing we're handling a visual range can be important, since we can read the marks to know also the columns at which the range starts and ends.

Solution: store the parsed range as string in the `rangestr` key, so that the user can access it in the lua table that is passed to the command callback as argument.