### PR TITLE
vim-patch:ce47d32: runtime(cpp): Change 'cms' for C++ to '// %s'

### DIFF
--- a/runtime/ftplugin/cpp.vim
+++ b/runtime/ftplugin/cpp.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:	C++
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2023 Aug 10
+" Last Change:	2024 Jun 06
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Only do this when not done yet for this buffer
@@ -12,6 +12,10 @@ endif
 " Behaves mostly just like C
 " XXX: "[.]" in the first pattern makes it a wildcard on Windows
 runtime! ftplugin/c[.]{vim,lua} ftplugin/c_*.{vim,lua} ftplugin/c/*.{vim,lua}
+
+" Change 'commentstring' to "C++ style"/"mono-line" comments
+setlocal commentstring=//\ %s
+let b:undo_ftplugin ..= ' | setl commentstring<'
 
 " C++ uses templates with <things>
 " Disabled, because it gives an error for typing an unmatched ">".


### PR DESCRIPTION
fixes: vim/vim#14911
closes: vim/vim#14926

https://github.com/vim/vim/commit/ce47d32b03bb7df0100b2625ef68fad1eb4646e3

Co-authored-by: Luc Hermitte <luc.hermitte@csgroup.eu>
