### PR TITLE
fix(lsp): apply LspInlayHint to inlay hint padding

### DIFF
--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -350,11 +350,11 @@ api.nvim_set_decoration_provider(namespace, {
             end
             local vt = {} --- @type [string, string?][]
             if hint.paddingLeft then
-              vt[#vt + 1] = { ' ' }
+              vt[#vt + 1] = { ' ', 'LspInlayHint' }
             end
             vt[#vt + 1] = { text, 'LspInlayHint' }
             if hint.paddingRight then
-              vt[#vt + 1] = { ' ' }
+              vt[#vt + 1] = { ' ', 'LspInlayHint' }
             end
             api.nvim_buf_set_extmark(bufnr, namespace, lnum, hint.position.character, {
               virt_text_pos = 'inline',

--- a/test/functional/plugin/lsp/inlay_hint_spec.lua
+++ b/test/functional/plugin/lsp/inlay_hint_spec.lua
@@ -48,7 +48,7 @@ local grid_with_inlay_hints = [[
   int main() {                                      |
       int x = 1;                                    |
       int y = 2;                                    |
-      return add({1:a:} x,{1:b:} y);                        |
+      return add({1:a: }x,{1:b: }y);                        |
   }                                                 |
   ^}                                                 |
                                                     |


### PR DESCRIPTION
Problem: The whitespace padding around inlay hints is not given a highlight group, making it confusing for colorschemes that apply a background color to inlay hints. The padding looks like a real space even though it is an inlay hint space.

Solution: Apply the content highlight to the padding characters.

Before:
![beforeinlay](https://github.com/neovim/neovim/assets/55766287/34dd1dc0-09c2-49c3-9a81-bdde07ba2f87)
After:
![afterinlay](https://github.com/neovim/neovim/assets/55766287/dde910db-1432-4dfc-be2d-6ecf3d26f59f)
