### PR TITLE
feat(defaults): make `splitright` default option

### DIFF
--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7990,7 +7990,7 @@ return {
     },
     {
       abbreviation = 'spr',
-      defaults = { if_true = false },
+      defaults = { if_true = true },
       desc = [=[
         When on, splitting a window will put the new window right of the
         current one. |:vsplit|


### PR DESCRIPTION
`splitright=true` makes more sense as the current buffer stays in the
same place when splitting the window. Otherwise the entire buffer is
switched on split which is a bit disorienting.