### PR TITLE
docs(treesitter): fix list of included parsers

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -22,9 +22,11 @@ search for in the `parser` runtime directory.
 
 Nvim includes these parsers:
 
+- Bash
 - C
 - Lua
 - Markdown
+- Python
 - Vimscript
 - Vimdoc
 - Treesitter query files |ft-query-plugin|


### PR DESCRIPTION
Neovim v0.10 ships with 8 pre-built parsers (3 more than in neovim v0.9):
 - bash c lua markdown python query vim vimdoc

The list of parsers shipped with Neovim v0.10 can be found here: https://github.com/neovim/neovim/blob/release-0.10/cmake.deps/cmake/BuildTreesitterParsers.cmake#L31-L34