### PR TITLE
refactor(shada): use msgpack_sbuffer less

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -548,10 +548,6 @@ String buf_get_text(buf_T *buf, int64_t lnum, int64_t start_col, int64_t end_col
 
 void api_free_string(String value)
 {
-  if (!value.data) {
-    return;
-  }
-
   xfree(value.data);
 }
 

--- a/src/nvim/context.c
+++ b/src/nvim/context.c
@@ -66,21 +66,11 @@ Context *ctx_get(size_t index)
 void ctx_free(Context *ctx)
   FUNC_ATTR_NONNULL_ALL
 {
-  if (ctx->regs.data) {
-    msgpack_sbuffer_destroy(&ctx->regs);
-  }
-  if (ctx->jumps.data) {
-    msgpack_sbuffer_destroy(&ctx->jumps);
-  }
-  if (ctx->bufs.data) {
-    msgpack_sbuffer_destroy(&ctx->bufs);
-  }
-  if (ctx->gvars.data) {
-    msgpack_sbuffer_destroy(&ctx->gvars);
-  }
-  if (ctx->funcs.items) {
-    api_free_array(ctx->funcs);
-  }
+  api_free_string(ctx->regs);
+  api_free_string(ctx->jumps);
+  api_free_string(ctx->bufs);
+  api_free_string(ctx->gvars);
+  api_free_array(ctx->funcs);
 }
 
 /// Saves the editor state to a context.
@@ -98,19 +88,19 @@ void ctx_save(Context *ctx, const int flags)
   }
 
   if (flags & kCtxRegs) {
-    ctx_save_regs(ctx);
+    ctx->regs = shada_encode_regs();
   }
 
   if (flags & kCtxJumps) {
-    ctx_save_jumps(ctx);
+    ctx->jumps = shada_encode_jumps();
   }
 
   if (flags & kCtxBufs) {
-    ctx_save_bufs(ctx);
+    ctx->bufs = shada_encode_buflist();
   }
 
   if (flags & kCtxGVars) {
-    ctx_save_gvars(ctx);
+    ctx->gvars = shada_encode_gvars();
   }
 
   if (flags & kCtxFuncs) {
@@ -173,33 +163,13 @@ bool ctx_restore(Context *ctx, const int flags)
   return true;
 }
 
-/// Saves the global registers to a context.
-///
-/// @param  ctx    Save to this context.
-static inline void ctx_save_regs(Context *ctx)
-  FUNC_ATTR_NONNULL_ALL
-{
-  msgpack_sbuffer_init(&ctx->regs);
-  shada_encode_regs(&ctx->regs);
-}
-
 /// Restores the global registers from a context.
 ///
 /// @param  ctx   Restore from this context.
 static inline void ctx_restore_regs(Context *ctx)
   FUNC_ATTR_NONNULL_ALL
 {
-  shada_read_sbuf(&ctx->regs, kShaDaWantInfo | kShaDaForceit);
-}
-
-/// Saves the jumplist to a context.
-///
-/// @param  ctx  Save to this context.
-static inline void ctx_save_jumps(Context *ctx)
-  FUNC_ATTR_NONNULL_ALL
-{
-  msgpack_sbuffer_init(&ctx->jumps);
-  shada_encode_jumps(&ctx->jumps);
+  shada_read_string(ctx->regs, kShaDaWantInfo | kShaDaForceit);
 }
 
 /// Restores the jumplist from a context.
@@ -208,17 +178,7 @@ static inline void ctx_save_jumps(Context *ctx)
 static inline void ctx_restore_jumps(Context *ctx)
   FUNC_ATTR_NONNULL_ALL
 {
-  shada_read_sbuf(&ctx->jumps, kShaDaWantInfo | kShaDaForceit);
-}
-
-/// Saves the buffer list to a context.
-///
-/// @param  ctx  Save to this context.
-static inline void ctx_save_bufs(Context *ctx)
-  FUNC_ATTR_NONNULL_ALL
-{
-  msgpack_sbuffer_init(&ctx->bufs);
-  shada_encode_buflist(&ctx->bufs);
+  shada_read_string(ctx->jumps, kShaDaWantInfo | kShaDaForceit);
 }
 
 /// Restores the buffer list from a context.
@@ -227,17 +187,7 @@ static inline void ctx_save_bufs(Context *ctx)
 static inline void ctx_restore_bufs(Context *ctx)
   FUNC_ATTR_NONNULL_ALL
 {
-  shada_read_sbuf(&ctx->bufs, kShaDaWantInfo | kShaDaForceit);
-}
-
-/// Saves global variables to a context.
-///
-/// @param  ctx  Save to this context.
-static inline void ctx_save_gvars(Context *ctx)
-  FUNC_ATTR_NONNULL_ALL
-{
-  msgpack_sbuffer_init(&ctx->gvars);
-  shada_encode_gvars(&ctx->gvars);
+  shada_read_string(ctx->bufs, kShaDaWantInfo | kShaDaForceit);
 }
 
 /// Restores global variables from a context.
@@ -246,7 +196,7 @@ static inline void ctx_save_gvars(Context *ctx)
 static inline void ctx_restore_gvars(Context *ctx)
   FUNC_ATTR_NONNULL_ALL
 {
-  shada_read_sbuf(&ctx->gvars, kShaDaWantInfo | kShaDaForceit);
+  shada_read_string(ctx->gvars, kShaDaWantInfo | kShaDaForceit);
 }
 
 /// Saves functions to a context.
@@ -291,41 +241,16 @@ static inline void ctx_restore_funcs(Context *ctx)
   }
 }
 
-/// Convert msgpack_sbuffer to readfile()-style array.
-///
-/// @param[in]  sbuf  msgpack_sbuffer to convert.
-///
-/// @return readfile()-style array representation of "sbuf".
-static inline Array sbuf_to_array(msgpack_sbuffer sbuf, Arena *arena)
-{
-  list_T *const list = tv_list_alloc(kListLenMayKnow);
-  tv_list_append_string(list, "", 0);
-  if (sbuf.size > 0) {
-    encode_list_write(list, sbuf.data, sbuf.size);
-  }
-
-  typval_T list_tv = (typval_T) {
-    .v_lock = VAR_UNLOCKED,
-    .v_type = VAR_LIST,
-    .vval.v_list = list
-  };
-
-  Array array = vim_to_object(&list_tv, arena, false).data.array;
-  tv_clear(&list_tv);
-  return array;
-}
-
-/// Convert readfile()-style array to msgpack_sbuffer.
+/// Convert readfile()-style array to String
 ///
 /// @param[in]  array  readfile()-style array to convert.
 /// @param[out]  err   Error object.
 ///
-/// @return msgpack_sbuffer with conversion result.
-static inline msgpack_sbuffer array_to_sbuf(Array array, Error *err)
+/// @return String with conversion result.
+static inline String array_to_string(Array array, Error *err)
   FUNC_ATTR_NONNULL_ALL
 {
-  msgpack_sbuffer sbuf;
-  msgpack_sbuffer_init(&sbuf);
+  String sbuf = STRING_INIT;
 
   typval_T list_tv;
   object_to_vim(ARRAY_OBJ(array), &list_tv, err);
@@ -335,7 +260,6 @@ static inline msgpack_sbuffer array_to_sbuf(Array array, Error *err)
     api_set_error(err, kErrorTypeException, "%s",
                   "E474: Failed to convert list to msgpack string buffer");
   }
-  sbuf.alloc = sbuf.size;
 
   tv_clear(&list_tv);
   return sbuf;
@@ -353,10 +277,10 @@ Dictionary ctx_to_dict(Context *ctx, Arena *arena)
 
   Dictionary rv = arena_dict(arena, 5);
 
-  PUT_C(rv, "regs", ARRAY_OBJ(sbuf_to_array(ctx->regs, arena)));
-  PUT_C(rv, "jumps", ARRAY_OBJ(sbuf_to_array(ctx->jumps, arena)));
-  PUT_C(rv, "bufs", ARRAY_OBJ(sbuf_to_array(ctx->bufs, arena)));
-  PUT_C(rv, "gvars", ARRAY_OBJ(sbuf_to_array(ctx->gvars, arena)));
+  PUT_C(rv, "regs", ARRAY_OBJ(string_to_array(ctx->regs, false, arena)));
+  PUT_C(rv, "jumps", ARRAY_OBJ(string_to_array(ctx->jumps, false, arena)));
+  PUT_C(rv, "bufs", ARRAY_OBJ(string_to_array(ctx->bufs, false, arena)));
+  PUT_C(rv, "gvars", ARRAY_OBJ(string_to_array(ctx->gvars, false, arena)));
   PUT_C(rv, "funcs", ARRAY_OBJ(copy_array(ctx->funcs, arena)));
 
   return rv;
@@ -382,16 +306,16 @@ int ctx_from_dict(Dictionary dict, Context *ctx, Error *err)
     }
     if (strequal(item.key.data, "regs")) {
       types |= kCtxRegs;
-      ctx->regs = array_to_sbuf(item.value.data.array, err);
+      ctx->regs = array_to_string(item.value.data.array, err);
     } else if (strequal(item.key.data, "jumps")) {
       types |= kCtxJumps;
-      ctx->jumps = array_to_sbuf(item.value.data.array, err);
+      ctx->jumps = array_to_string(item.value.data.array, err);
     } else if (strequal(item.key.data, "bufs")) {
       types |= kCtxBufs;
-      ctx->bufs = array_to_sbuf(item.value.data.array, err);
+      ctx->bufs = array_to_string(item.value.data.array, err);
     } else if (strequal(item.key.data, "gvars")) {
       types |= kCtxGVars;
-      ctx->gvars = array_to_sbuf(item.value.data.array, err);
+      ctx->gvars = array_to_string(item.value.data.array, err);
     } else if (strequal(item.key.data, "funcs")) {
       types |= kCtxFuncs;
       ctx->funcs = copy_object(item.value, NULL).data.array;

--- a/src/nvim/context.h
+++ b/src/nvim/context.h
@@ -7,25 +7,19 @@
 #include "nvim/api/private/defs.h"
 
 typedef struct {
-  msgpack_sbuffer regs;     ///< Registers.
-  msgpack_sbuffer jumps;    ///< Jumplist.
-  msgpack_sbuffer bufs;     ///< Buffer list.
-  msgpack_sbuffer gvars;    ///< Global variables.
+  String regs;     ///< Registers.
+  String jumps;    ///< Jumplist.
+  String bufs;     ///< Buffer list.
+  String gvars;    ///< Global variables.
   Array funcs;              ///< Functions.
 } Context;
 typedef kvec_t(Context) ContextVec;
 
-#define MSGPACK_SBUFFER_INIT (msgpack_sbuffer) { \
-  .size = 0, \
-  .data = NULL, \
-  .alloc = 0, \
-}
-
 #define CONTEXT_INIT (Context) { \
-  .regs = MSGPACK_SBUFFER_INIT, \
-  .jumps = MSGPACK_SBUFFER_INIT, \
-  .bufs = MSGPACK_SBUFFER_INIT, \
-  .gvars = MSGPACK_SBUFFER_INIT, \
+  .regs = STRING_INIT, \
+  .jumps = STRING_INIT, \
+  .bufs = STRING_INIT, \
+  .gvars = STRING_INIT, \
   .funcs = ARRAY_DICT_INIT, \
 }
 

--- a/src/nvim/memory.h
+++ b/src/nvim/memory.h
@@ -45,8 +45,6 @@ EXTERN size_t arena_alloc_count INIT( = 0);
   ((v).capacity = (s), \
    (v).items = (void *)arena_alloc(a, sizeof((v).items[0]) * (v).capacity, true))
 
-#define ARENA_BLOCK_SIZE 4096
-
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "memory.h.generated.h"
 #endif

--- a/src/nvim/memory_defs.h
+++ b/src/nvim/memory_defs.h
@@ -11,5 +11,7 @@ typedef struct {
   size_t pos, size;
 } Arena;
 
+#define ARENA_BLOCK_SIZE 4096
+
 // inits an empty arena.
 #define ARENA_EMPTY { .cur_blk = NULL, .pos = 0, .size = 0 }

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -590,16 +590,16 @@ static void packer_buffer_init_channels(Channel **chans, size_t nchans, PackerBu
   packer->endptr = packer->startptr + ARENA_BLOCK_SIZE;
   packer->packer_flush = channel_flush_callback;
   packer->anydata = chans;
-  packer->anylen = nchans;
+  packer->anyint = (int64_t)nchans;
 }
 
 static void packer_buffer_finish_channels(PackerBuffer *packer)
 {
   size_t len = (size_t)(packer->ptr - packer->startptr);
   if (len > 0) {
-    WBuffer *buf = wstream_new_buffer(packer->startptr, len, packer->anylen, free_block);
+    WBuffer *buf = wstream_new_buffer(packer->startptr, len, (size_t)packer->anyint, free_block);
     Channel **chans = packer->anydata;
-    for (size_t i = 0; i < packer->anylen; i++) {
+    for (int64_t i = 0; i < packer->anyint; i++) {
       channel_write(chans[i], buf);
     }
   } else {
@@ -610,7 +610,7 @@ static void packer_buffer_finish_channels(PackerBuffer *packer)
 static void channel_flush_callback(PackerBuffer *packer)
 {
   packer_buffer_finish_channels(packer);
-  packer_buffer_init_channels(packer->anydata, packer->anylen, packer);
+  packer_buffer_init_channels(packer->anydata, (size_t)packer->anyint, packer);
 }
 
 void rpc_set_client_info(uint64_t id, Dictionary info)

--- a/src/nvim/msgpack_rpc/packer.h
+++ b/src/nvim/msgpack_rpc/packer.h
@@ -71,6 +71,11 @@ static inline void mpack_map(char **buf, uint32_t len)
   }
 }
 
+static inline size_t mpack_remaining(PackerBuffer *packer)
+{
+  return (size_t)(packer->endptr - packer->ptr);
+}
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "msgpack_rpc/packer.h.generated.h"
 #endif

--- a/src/nvim/msgpack_rpc/packer_defs.h
+++ b/src/nvim/msgpack_rpc/packer_defs.h
@@ -19,6 +19,6 @@ struct packer_buffer_t {
 
   // these are free to be used by packer_flush for any purpose, if want
   void *anydata;
-  size_t anylen;
+  int64_t anyint;
   PackerBufferFlush packer_flush;
 };

--- a/src/nvim/os/fileio.c
+++ b/src/nvim/os/fileio.c
@@ -320,9 +320,8 @@ ptrdiff_t file_write(FileDescriptor *const fp, const char *const buf, const size
   FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ARG(1)
 {
   assert(fp->wr);
-  ptrdiff_t space = (fp->buffer + ARENA_BLOCK_SIZE) - fp->write_pos;
   // includes the trivial case of size==0
-  if (size < (size_t)space) {
+  if (size < file_space(fp)) {
     memcpy(fp->write_pos, buf, size);
     fp->write_pos += size;
     return (ptrdiff_t)size;

--- a/src/nvim/os/fileio.h
+++ b/src/nvim/os/fileio.h
@@ -2,6 +2,7 @@
 
 #include <stddef.h>  // IWYU pragma: keep
 
+#include "nvim/memory_defs.h"
 #include "nvim/os/fileio_defs.h"  // IWYU pragma: keep
 
 /// file_open() flags
@@ -31,6 +32,11 @@ enum {
   /// Currently equal to (IOSIZE - 1), but they do not need to be connected.
   kRWBufferSize = 1024,
 };
+
+static inline size_t file_space(FileDescriptor *fp)
+{
+  return (size_t)((fp->buffer + ARENA_BLOCK_SIZE) - fp->write_pos);
+}
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/fileio.h.generated.h"

--- a/src/nvim/shada.h
+++ b/src/nvim/shada.h
@@ -2,6 +2,8 @@
 
 #include <msgpack.h>  // IWYU pragma: keep
 
+#include "nvim/api/private/defs.h"
+
 /// Flags for shada_read_file and children
 typedef enum {
   kShaDaWantInfo = 1,       ///< Load non-mark information


### PR DESCRIPTION
Work towards getting rid of libmsgpack depedency eventually.

msgpack_sbuffer is just a string buffer, we can use our own String type.