### PR TITLE
fix(lsp): do not reset buf version when detaching client

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -520,7 +520,6 @@ local function buf_detach_client(bufnr, client)
   end
 
   client.attached_buffers[bufnr] = nil
-  util.buf_versions[bufnr] = nil
 
   local namespace = lsp.diagnostic.get_namespace(client.id)
   vim.diagnostic.reset(namespace, bufnr)
@@ -605,6 +604,7 @@ local function buf_attach(bufnr)
         buf_detach_client(bufnr, client)
       end
       attached_buffers[bufnr] = nil
+      util.buf_versions[bufnr] = nil
     end,
 
     -- TODO if we know all of the potential clients ahead of time, then we


### PR DESCRIPTION
Detaching a client should not reset the buffer version because other attached clients could still be using it.