### PR TITLE
refactor: use `vim._with` where possible

### DIFF
--- a/runtime/filetype.lua
+++ b/runtime/filetype.lua
@@ -21,7 +21,7 @@ vim.api.nvim_create_autocmd({ 'BufRead', 'BufNewFile', 'StdinReadPost' }, {
       -- Generic configuration file used as fallback
       ft = require('vim.filetype.detect').conf(args.file, args.buf)
       if ft then
-        vim.api.nvim_buf_call(args.buf, function()
+        vim._with({ buf = args.buf }, function()
           vim.api.nvim_cmd({ cmd = 'setf', args = { 'FALLBACK', ft } }, {})
         end)
       end
@@ -32,7 +32,7 @@ vim.api.nvim_create_autocmd({ 'BufRead', 'BufNewFile', 'StdinReadPost' }, {
         on_detect(args.buf)
       end
 
-      vim.api.nvim_buf_call(args.buf, function()
+      vim._with({ buf = args.buf }, function()
         vim.api.nvim_cmd({ cmd = 'setf', args = { ft } }, {})
       end)
     end

--- a/runtime/lua/tohtml.lua
+++ b/runtime/lua/tohtml.lua
@@ -646,7 +646,7 @@ end
 --- @param state vim.tohtml.state
 local function styletable_conceal(state)
   local bufnr = state.bufnr
-  vim.api.nvim_buf_call(bufnr, function()
+  vim._with({ buf = bufnr }, function()
     for row = 1, state.buflen do
       --- @type table<integer,[integer,integer,string]>
       local conceals = {}
@@ -764,7 +764,7 @@ local function styletable_statuscolumn(state)
     if foldcolumn:match('^auto') then
       local max = tonumber(foldcolumn:match('^%w-:(%d)')) or 1
       local maxfold = 0
-      vim.api.nvim_buf_call(state.bufnr, function()
+      vim._with({ buf = state.bufnr }, function()
         for row = 1, vim.api.nvim_buf_line_count(state.bufnr) do
           local foldlevel = vim.fn.foldlevel(row)
           if foldlevel > maxfold then
@@ -1291,7 +1291,7 @@ local styletable_funcs = {
 
 --- @param state vim.tohtml.state
 local function state_generate_style(state)
-  vim.api.nvim_win_call(state.winid, function()
+  vim._with({ win = state.winid }, function()
     for _, fn in ipairs(styletable_funcs) do
       --- @type string?
       local cond

--- a/runtime/lua/vim/_inspector.lua
+++ b/runtime/lua/vim/_inspector.lua
@@ -84,7 +84,7 @@ function vim.inspect_pos(bufnr, row, col, filter)
 
   -- syntax
   if filter.syntax and vim.api.nvim_buf_is_valid(bufnr) then
-    vim.api.nvim_buf_call(bufnr, function()
+    vim._with({ buf = bufnr }, function()
       for _, i1 in ipairs(vim.fn.synstack(row + 1, col + 1)) do
         results.syntax[#results.syntax + 1] =
           resolve_hl({ hl_group = vim.fn.synIDattr(i1, 'name') })

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -964,7 +964,7 @@ local function goto_diagnostic(diagnostic, opts)
 
   local winid = opts.winid or api.nvim_get_current_win()
 
-  api.nvim_win_call(winid, function()
+  vim._with({ win = winid }, function()
     -- Save position in the window's jumplist
     vim.cmd("normal! m'")
     api.nvim_win_set_cursor(winid, { diagnostic.lnum + 1, diagnostic.col })

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -450,7 +450,7 @@ local function modula2(bufnr)
 
   return 'modula2',
     function(b)
-      vim.api.nvim_buf_call(b, function()
+      vim._with({ buf = b }, function()
         fn['modula2#SetDialect'](dialect, extension)
       end)
     end

--- a/runtime/lua/vim/highlight.lua
+++ b/runtime/lua/vim/highlight.lua
@@ -71,7 +71,7 @@ function M.range(bufnr, ns, higroup, start, finish, opts)
     return
   end
 
-  vim.api.nvim_buf_call(bufnr, function()
+  vim._with({ buf = bufnr }, function()
     if pos1[3] ~= v_maxcol then
       local max_col1 = vim.fn.col({ pos1[2], '$' })
       pos1[3] = math.min(pos1[3], max_col1)

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -352,7 +352,7 @@ function lsp._set_defaults(client, bufnr)
   then
     vim.bo[bufnr].formatexpr = 'v:lua.vim.lsp.formatexpr()'
   end
-  api.nvim_buf_call(bufnr, function()
+  vim._with({ buf = bufnr }, function()
     if
       client.supports_method(ms.textDocument_hover)
       and is_empty_or_default(bufnr, 'keywordprg')
@@ -378,7 +378,7 @@ local function reset_defaults(bufnr)
   if vim.bo[bufnr].formatexpr == 'v:lua.vim.lsp.formatexpr()' then
     vim.bo[bufnr].formatexpr = nil
   end
-  api.nvim_buf_call(bufnr, function()
+  vim._with({ buf = bufnr }, function()
     local keymap = vim.fn.maparg('K', 'n', false, true)
     if keymap and keymap.callback == vim.lsp.buf.hover and keymap.buffer == 1 then
       vim.keymap.del('n', 'K', { buffer = bufnr })

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -640,7 +640,7 @@ function M.rename(old_fname, new_fname, opts)
     -- Rename with :saveas. This does two things:
     -- * Unset BF_WRITE_MASK, so that users don't get E13 when they do :write.
     -- * Send didClose and didOpen via textDocument/didSave handler.
-    api.nvim_buf_call(b, function()
+    vim._with({ buf = b }, function()
       vim.cmd('keepalt saveas! ' .. vim.fn.fnameescape(rename.to))
     end)
     -- Delete the new buffer with the old name created by :saveas. nvim_buf_delete and
@@ -1014,7 +1014,7 @@ function M.show_document(location, offset_encoding, opts)
     local row = range.start.line
     local col = get_line_byte_from_position(bufnr, range.start, offset_encoding)
     api.nvim_win_set_cursor(win, { row + 1, col })
-    api.nvim_win_call(win, function()
+    vim._with({ win = win }, function()
       -- Open folds under the cursor
       vim.cmd('normal! zv')
     end)
@@ -1334,7 +1334,7 @@ function M.stylize_markdown(bufnr, contents, opts)
   end
 
   -- needs to run in the buffer for the regions to work
-  api.nvim_buf_call(bufnr, function()
+  vim._with({ buf = bufnr }, function()
     -- we need to apply lsp_markdown regions speperately, since otherwise
     -- markdown regions can "bleed" through the other syntax regions
     -- and mess up the formatting

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -1218,6 +1218,8 @@ end
 ---   only moving context save and restore to lower level might resolve this.
 ---
 --- @param context vim.context.mods
+--- @param f function
+--- @return any
 function vim._with(context, f)
   vim.validate('context', context, 'table')
   vim.validate('f', f, 'function')

--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -257,7 +257,7 @@ end
 function Session:restore_keymaps()
   local function restore(keymap, lhs, mode)
     if keymap then
-      vim.api.nvim_buf_call(self.bufnr, function()
+      vim._with({ buf = self.bufnr }, function()
         vim.fn.mapset(keymap)
       end)
     else

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -143,7 +143,7 @@ function TSHighlighter.new(tree, opts)
     vim.cmd.runtime({ 'syntax/synload.vim', bang = true })
   end
 
-  api.nvim_buf_call(self.bufnr, function()
+  vim._with({ buf = self.bufnr }, function()
     vim.opt_local.spelloptions:append('noplainbuffer')
   end)
 

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -180,10 +180,9 @@ function M._get_url()
     end
   end
 
-  local old_isfname = vim.o.isfname
-  vim.cmd [[set isfname+=@-@]]
-  local url = vim.fn.expand('<cfile>')
-  vim.o.isfname = old_isfname
+  local url = vim._with({ go = { isfname = vim.o.isfname .. ',@-@' } }, function()
+    return vim.fn.expand('<cfile>')
+  end)
 
   return url
 end

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -85,7 +85,7 @@ describe('API/win', function()
           [[
            local cmdwin_buf = vim.api.nvim_get_current_buf()
            local new_win, new_buf = ...
-           vim.api.nvim_buf_call(new_buf, function()
+           vim._with({buf = new_buf}, function()
              vim.api.nvim_win_set_buf(new_win, cmdwin_buf)
            end)
          ]],
@@ -100,7 +100,7 @@ describe('API/win', function()
           [[
            local cmdwin_win = vim.api.nvim_get_current_win()
            local new_win, new_buf = ...
-           vim.api.nvim_win_call(new_win, function()
+           vim._with({win = new_win}, function()
              vim.api.nvim_win_set_buf(cmdwin_win, new_buf)
            end)
          ]],
@@ -638,7 +638,7 @@ describe('API/win', function()
       feed('q:')
       exec_lua(
         [[
-        vim.api.nvim_win_call(..., function()
+        vim._with({win = ...}, function()
           vim.api.nvim_win_close(0, true)
         end)
       ]],
@@ -657,7 +657,7 @@ describe('API/win', function()
       exec_lua(
         [[
         local otherwin, cmdwin = ...
-        vim.api.nvim_win_call(otherwin, function()
+        vim._with({win = otherwin}, function()
           vim.api.nvim_win_close(cmdwin, true)
         end)
       ]],
@@ -771,7 +771,7 @@ describe('API/win', function()
       })
       exec_lua(
         [[
-        vim.api.nvim_win_call(..., function()
+        vim._with({win = ...}, function()
           vim.api.nvim_win_hide(0)
         end)
       ]],
@@ -790,7 +790,7 @@ describe('API/win', function()
       exec_lua(
         [[
         local otherwin, cmdwin = ...
-        vim.api.nvim_win_call(otherwin, function()
+        vim._with({win = otherwin}, function()
           vim.api.nvim_win_hide(cmdwin)
         end)
       ]],
@@ -1178,7 +1178,7 @@ describe('API/win', function()
           exec_lua,
           [[
            local cmdwin_buf = vim.api.nvim_get_current_buf()
-           vim.api.nvim_buf_call(vim.api.nvim_create_buf(false, true), function()
+           vim._with({buf = vim.api.nvim_create_buf(false, true)}, function()
              vim.api.nvim_open_win(cmdwin_buf, false, {
                relative='editor', row=5, col=5, width=5, height=5,
              })

--- a/test/functional/autocmd/autocmd_spec.lua
+++ b/test/functional/autocmd/autocmd_spec.lua
@@ -350,11 +350,11 @@ describe('autocmd', function()
     }
 
     -- Create specific layout and ensure it's left unchanged.
-    -- Use nvim_buf_call on a hidden buffer so aucmd_win is used.
+    -- Use vim._with on a hidden buffer so aucmd_win is used.
     exec_lua [[
       vim.cmd "wincmd s | wincmd _"
       _G.buf = vim.api.nvim_create_buf(true, true)
-      vim.api.nvim_buf_call(_G.buf, function() vim.cmd "wincmd J" end)
+      vim._with({buf = _G.buf}, function() vim.cmd "wincmd J" end)
     ]]
     screen:expect [[
       ^                                                  |
@@ -367,14 +367,14 @@ describe('autocmd', function()
     -- This used to crash after making aucmd_win a normal window via the above.
     exec_lua [[
       vim.cmd "tabnew | tabclose # | wincmd s | wincmd _"
-      vim.api.nvim_buf_call(_G.buf, function() vim.cmd "wincmd K" end)
+      vim._with({buf = _G.buf}, function() vim.cmd "wincmd K" end)
     ]]
     assert_alive()
     screen:expect_unchanged()
 
     -- Also check with win_splitmove().
     exec_lua [[
-      vim.api.nvim_buf_call(_G.buf, function()
+      vim._with({buf = _G.buf}, function()
         vim.fn.win_splitmove(vim.fn.winnr(), vim.fn.win_getid(1))
       end)
     ]]
@@ -382,11 +382,11 @@ describe('autocmd', function()
 
     -- Also check with nvim_win_set_config().
     matches(
-      ': Failed to move window %d+ into split$',
+      '^Failed to move window %d+ into split$',
       pcall_err(
         exec_lua,
         [[
-          vim.api.nvim_buf_call(_G.buf, function()
+          vim._with({buf = _G.buf}, function()
             vim.api.nvim_win_set_config(0, {
               vertical = true,
               win = vim.fn.win_getid(1)
@@ -398,7 +398,7 @@ describe('autocmd', function()
     screen:expect_unchanged()
 
     -- Ensure splitting still works from inside the aucmd_win.
-    exec_lua [[vim.api.nvim_buf_call(_G.buf, function() vim.cmd "split" end)]]
+    exec_lua [[vim._with({buf = _G.buf}, function() vim.cmd "split" end)]]
     screen:expect [[
       ^                                                  |
       {1:~                                                 }|
@@ -418,7 +418,7 @@ describe('autocmd', function()
       'editor',
       exec_lua [[
         vim.cmd "only"
-        vim.api.nvim_buf_call(_G.buf, function()
+        vim._with({buf = _G.buf}, function()
           _G.config = vim.api.nvim_win_get_config(0)
         end)
         return _G.config.relative
@@ -463,7 +463,7 @@ describe('autocmd', function()
       pcall_err(
         exec_lua,
         [[
-          vim.api.nvim_buf_call(_G.buf, function()
+          vim._with({buf = _G.buf}, function()
             local win = vim.api.nvim_get_current_win()
             vim.api.nvim_win_close(win, true)
           end)
@@ -475,7 +475,7 @@ describe('autocmd', function()
       pcall_err(
         exec_lua,
         [[
-          vim.api.nvim_buf_call(_G.buf, function()
+          vim._with({buf = _G.buf}, function()
             local win = vim.api.nvim_get_current_win()
             vim.cmd('tabnext')
             vim.api.nvim_win_close(win, true)
@@ -488,7 +488,7 @@ describe('autocmd', function()
       pcall_err(
         exec_lua,
         [[
-          vim.api.nvim_buf_call(_G.buf, function()
+          vim._with({buf = _G.buf}, function()
             local win = vim.api.nvim_get_current_win()
             vim.api.nvim_win_hide(win)
           end)
@@ -500,7 +500,7 @@ describe('autocmd', function()
       pcall_err(
         exec_lua,
         [[
-          vim.api.nvim_buf_call(_G.buf, function()
+          vim._with({buf = _G.buf}, function()
             local win = vim.api.nvim_get_current_win()
             vim.cmd('tabnext')
             vim.api.nvim_win_hide(win)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -371,7 +371,7 @@ describe('LSP', function()
               true,
               exec_lua [[
               local keymap
-              vim.api.nvim_buf_call(BUFFER, function()
+              vim._with({buf = BUFFER}, function()
                 keymap = vim.fn.maparg("K", "n", false, true)
               end)
               return keymap.callback == vim.lsp.buf.hover
@@ -388,7 +388,7 @@ describe('LSP', function()
             '',
             exec_lua [[
             local keymap
-            vim.api.nvim_buf_call(BUFFER, function()
+            vim._with({buf = BUFFER}, function()
               keymap = vim.fn.maparg("K", "n", false, false)
             end)
             return keymap
@@ -782,7 +782,7 @@ describe('LSP', function()
               vim.api.nvim_buf_set_name(BUFFER, oldname)
               vim.api.nvim_buf_set_lines(BUFFER, 0, -1, true, {"help me"})
               lsp.buf_attach_client(BUFFER, TEST_RPC_CLIENT_ID)
-              vim.api.nvim_buf_call(BUFFER, function() vim.cmd('saveas ' .. newname) end)
+              vim._with({buf = BUFFER}, function() vim.cmd('saveas ' .. newname) end)
             ]=],
               tmpfile_old,
               tmpfile_new

--- a/test/functional/ui/title_spec.lua
+++ b/test/functional/ui/title_spec.lua
@@ -82,11 +82,11 @@ describe('title', function()
       end)
     end)
 
-    it('a Lua callback calling nvim_buf_call in a hidden buffer', function()
+    it('a Lua callback calling vim._with in a hidden buffer', function()
       exec_lua(string.format(
         [[
         vim.schedule(function()
-          vim.api.nvim_buf_call(%d, function() end)
+          vim._with({buf = %d}, function() end)
         end)
       ]],
         buf2

--- a/test/functional/vimscript/api_functions_spec.lua
+++ b/test/functional/vimscript/api_functions_spec.lua
@@ -115,7 +115,7 @@ describe('eval-API', function()
         exec_lua,
         [[
          local cmdwin_buf = vim.api.nvim_get_current_buf()
-         vim.api.nvim_buf_call(vim.api.nvim_create_buf(false, true), function()
+         vim._with({buf = vim.api.nvim_create_buf(false, true)}, function()
            vim.api.nvim_open_term(cmdwin_buf, {})
          end)
        ]]


### PR DESCRIPTION
This mostly means replacing `nvim_buf_call` and `nvim_win_call` with
`vim._with`.