### PR TITLE
fix(runtime): add commentstring for glsl ftplugin

### DIFF
--- a/runtime/ftplugin/glsl.lua
+++ b/runtime/ftplugin/glsl.lua
@@ -1,0 +1,1 @@
+vim.bo.commentstring = '// %s'


### PR DESCRIPTION
# Problem 

The builtin commenting was not able to comment in `.glsl` shader files

# Solution

Add `ftplugin/glsl.lua` with glsl commentstring

# Reference Pull Request

https://github.com/neovim/neovim/pull/23039