### PR TITLE
fix(runtime): add commentstring for swift

### DIFF
--- a/runtime/ftplugin/swift.lua
+++ b/runtime/ftplugin/swift.lua
@@ -1,0 +1,1 @@
+vim.bo.commentstring = '// %s'


### PR DESCRIPTION
# Problem
The builtin commenting was not able to comment in swift files

# Solution
Add ftplugin/swift.lua with swift commentstring

# Reference 
https://github.com/neovim/neovim/pull/23039#issuecomment-1505645253