### PR TITLE
vim-patch:9.1.0472: Inconsistencies between functions for option flags

### DIFF
--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -1066,7 +1066,7 @@ int buf_write(buf_T *buf, char *fname, char *sfname, linenr_T start, linenr_T en
   bool whole = (start == 1 && end == buf->b_ml.ml_line_count);
   bool write_undo_file = false;
   context_sha256_T sha_ctx;
-  unsigned bkc = get_bkc_value(buf);
+  unsigned bkc = get_bkc_flags(buf);
 
   if (fname == NULL || *fname == NUL) {  // safety check
     return FAIL;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -6192,10 +6192,10 @@ bool can_bs(int what)
   return vim_strchr(p_bs, what) != NULL;
 }
 
-/// Get the local or global value of 'backupcopy'.
+/// Get the local or global value of 'backupcopy' flags.
 ///
 /// @param buf The buffer.
-unsigned get_bkc_value(buf_T *buf)
+unsigned get_bkc_flags(buf_T *buf)
 {
   return buf->b_bkc_flags ? buf->b_bkc_flags : bkc_flags;
 }
@@ -6211,7 +6211,7 @@ char *get_flp_value(buf_T *buf)
   return buf->b_p_flp;
 }
 
-/// Get the local or global value of the 'virtualedit' flags.
+/// Get the local or global value of 'virtualedit' flags.
 unsigned get_ve_flags(win_T *wp)
 {
   return (wp->w_ve_flags ? wp->w_ve_flags : ve_flags) & ~(VE_NONE | VE_NONEU);


### PR DESCRIPTION
#### vim-patch:9.1.0472: Inconsistencies between functions for option flags

Problem:  Inconsistencies between functions for option flags.
Solution: Consistently use "unsigned int" as return type and rename
          get_bkc_value() to get_bkc_flags() (zeertzjq).

closes: vim/vim#14925

https://github.com/vim/vim/commit/aa925eeb97bd294d4a5253a3194949a37cbc8365