### PR TITLE
vim-patch:9c4389a: runtime(doc): Fix small style issues

### DIFF
--- a/runtime/doc/mbyte.txt
+++ b/runtime/doc/mbyte.txt
@@ -686,7 +686,7 @@ You might want to select the font used for the menus.  Unfortunately this
 doesn't always work.  See the system specific remarks below, and 'langmenu'.
 
 
-USING UTF-8 IN X-Windows				*utf-8-in-xwindows*
+USING UTF-8 IN X-WINDOWS				*utf-8-in-xwindows*
 
 You need to specify a font to be used.  For double-wide characters another
 font is required, which is exactly twice as wide.  There are three ways to do

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1296,7 +1296,7 @@ passed to make, say :make html or :make pdf.
 Additional arguments can be passed to pandoc:
 
 - either by appending them to make, say `:make html --self-contained` .
-- or setting them in `b:pandoc_compiler_args` or `g:pandoc_compiler_args`
+- or setting them in `b:pandoc_compiler_args` or `g:pandoc_compiler_args`.
 
 PERL					*quickfix-perl* *compiler-perl*
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -466,14 +466,14 @@ ASTRO						*astro.vim* *ft-astro-syntax*
 Configuration
 
 The following variables control certain syntax highlighting features.
-You can add them to your .vimrc: >
+You can add them to your .vimrc.
+
+To enables TypeScript and TSX for ".astro" files (default "disable"): >
 	let g:astro_typescript = "enable"
 <
-Enables TypeScript and TSX for ".astro" files. Default Value: "disable" >
+To enables Stylus for ".astro" files (default "disable"): >
 	let g:astro_stylus = "enable"
 <
-Enables Stylus for ".astro" files. Default Value: "disable"
-
 NOTE: You need to install an external plugin to support stylus in astro files.
 
 
@@ -1437,7 +1437,7 @@ Note: Syntax folding might slow down syntax highlighting significantly,
 especially for large files.
 
 
-HTML/OS (by Aestiva)				*htmlos.vim* *ft-htmlos-syntax*
+HTML/OS (BY AESTIVA)				*htmlos.vim* *ft-htmlos-syntax*
 
 The coloring scheme for HTML/OS works as follows:
 


### PR DESCRIPTION
#### vim-patch:9c4389a: runtime(doc): Fix small style issues

closes: vim/vim#14942

https://github.com/vim/vim/commit/9c4389acc307943a2cd754ecbec3834810d152e4

Co-authored-by: h-east <h.east.727@gmail.com>