### PR TITLE
vim-patch: update runtime files

### DIFF
--- a/runtime/ftplugin/kdl.vim
+++ b/runtime/ftplugin/kdl.vim
@@ -1,0 +1,17 @@
+" Vim filetype plugin
+" Language:         KDL
+" Author:           Aram Drevekenin <aram@poor.dev>
+" Maintainer:       Yinzuo Jiang <jiangyinzuo@foxmail.com>
+" Last Change:      2024-06-10
+
+if exists("b:did_ftplugin")
+  finish
+endif
+
+let b:did_ftplugin = 1
+
+setlocal comments=://
+setlocal commentstring=//\ %s
+setlocal formatoptions-=t
+
+let b:undo_ftplugin = 'setlocal comments< commentstring< formatoptions<'

--- a/runtime/ftplugin/svelte.vim
+++ b/runtime/ftplugin/svelte.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin
+" Language:	svelte
+" Maintainer:	Igor Lacerda <igorlafarsi@gmail.com>
+" Last Change:	2024 Jun 09
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setl commentstring=<!--\ %s\ -->
+
+let b:undo_ftplugin = 'setl cms<'

--- a/runtime/indent/kdl.vim
+++ b/runtime/indent/kdl.vim
@@ -1,0 +1,26 @@
+" Vim indent file
+" Language:         KDL
+" Author:           Aram Drevekenin <aram@poor.dev>
+" Maintainer:       Yinzuo Jiang <jiangyinzuo@foxmail.com>
+" Last Change:      2024-06-10
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+    finish
+endif
+let b:did_indent = 1
+
+setlocal indentexpr=KdlIndent()
+let b:undo_indent = "setlocal indentexpr<"
+
+function! KdlIndent(...)
+  let line = getline(v:lnum)
+  let previousNum = prevnonblank(v:lnum - 1)
+  let previous = getline(previousNum)
+
+  if previous =~ "{" && previous !~ "}" && line !~ "}" && line !~ ":$"
+    return indent(previousNum) + &tabstop
+  else
+    return indent(previousNum)
+  endif
+endfunction

--- a/runtime/syntax/deb822sources.vim
+++ b/runtime/syntax/deb822sources.vim
@@ -40,7 +40,7 @@ syn match deb822sourcesUri            '\(https\?://\|ftp://\|[rs]sh://\|debtorre
 syn region deb822sourcesStrictField matchgroup=deb822sourcesEntryField start="^\%(Types\|URIs\|Suites\|Components\): *" end="$" contains=deb822sourcesType,deb822sourcesUri,deb822sourcesSupportedSuites,deb822sourcesUnsupportedSuites,deb822sourcesFreeComponent,deb822sourcesNonFreeComponent oneline
 syn region deb822sourcesField matchgroup=deb822sourcesOptionField start="^\%(Signed-By\|Check-Valid-Until\|Valid-Until-Min\|Valid-Until-Max\|Date-Max-Future\|InRelease-Path\): *" end="$" oneline
 syn region deb822sourcesField matchgroup=deb822sourcesMultiValueOptionField start="^\%(Architectures\|Languages\|Targets\)\%(-Add\|-Remove\)\?: *" end="$" oneline
-syn region deb822sourcesStrictField matchgroup=deb822sourcesBooleanOptionField start="^\%(PDiffs\|Allow-Insecure\|Allow-Weak\|Allow-Downgrade-To-Insecure\|Trusted\|Check-Date\): *" end="$" contains=deb822sourcesYesNo oneline
+syn region deb822sourcesStrictField matchgroup=deb822sourcesBooleanOptionField start="^\%(PDiffs\|Allow-Insecure\|Allow-Weak\|Allow-Downgrade-To-Insecure\|Trusted\|Check-Date\|Enabled\): *" end="$" contains=deb822sourcesYesNo oneline
 syn region deb822sourcesStrictField matchgroup=deb822sourcesForceBooleanOptionField start="^\%(By-Hash\): *" end="$" contains=deb822sourcesForce,deb822sourcesYesNo oneline
 
 hi def link deb822sourcesField                   Default

--- a/runtime/syntax/kdl.vim
+++ b/runtime/syntax/kdl.vim
@@ -1,0 +1,45 @@
+" Vim syntax file
+" Language: KDL
+" Maintainer: Aram Drevekenin <aram@poor.dev>
+" Maintainer: Yinzuo Jiang <jiangyinzuo@foxmail.com>
+" Latest Revision: 2024-06-10
+
+" quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+syn match kdlNode '\v(\w|-|\=)' display
+syn match kdlBool '\v(true|false)' display
+
+syn keyword kdlTodo contained TODO FIXME XXX NOTE
+syn match kdlComment "//.*$" contains=kdlTodo
+
+" Regular int like number with - + or nothing in front
+syn match kdlNumber '\d\+'
+syn match kdlNumber '[-+]\d\+'
+
+" Floating point number with decimal no E or e (+,-)
+syn match kdlNumber '\d\+\.\d*' contained display
+syn match kdlNumber '[-+]\d\+\.\d*' contained display
+ 
+" Floating point like number with E and no decimal point (+,-)
+syn match kdlNumber '[-+]\=\d[[:digit:]]*[eE][\-+]\=\d\+' contained display
+syn match kdlNumber '\d[[:digit:]]*[eE][\-+]\=\d\+' contained display
+ 
+" Floating point like number with E and decimal point (+,-)
+syn match kdlNumber '[-+]\=\d[[:digit:]]*\.\d*[eE][\-+]\=\d\+' contained display
+syn match kdlNumber '\d[[:digit:]]*\.\d*[eE][\-+]\=\d\+' contained display
+
+syn region kdlString start='"' end='"' skip='\\\\\|\\"' display
+ 
+syn region kdlChildren start="{" end="}" contains=kdlString,kdlNumber,kdlNode,kdlBool,kdlComment
+
+hi def link kdlTodo        Todo
+hi def link kdlComment     Comment
+hi def link kdlNode        Statement
+hi def link kdlBool        Boolean
+hi def link kdlString      String
+hi def link kdlNumber      Number
+
+let b:current_syntax = "kdl"


### PR DESCRIPTION
- **vim-patch:7e9a1a7: runtime(svelte): basic svelte ftplugin file**
- **vim-patch:b8076f9: runtime(deb822sources): add missing Enabled field in syntax script**
- **vim-patch:2d88210: runtime(kdl): include syntax, indent and ftplugin files**
