### PR TITLE
vim-patch:2e3b2a8: runtime(kdl): use shiftwidth() instead of &tabstop in indent script

### DIFF
--- a/runtime/indent/kdl.vim
+++ b/runtime/indent/kdl.vim
@@ -2,7 +2,7 @@
 " Language:         KDL
 " Author:           Aram Drevekenin <aram@poor.dev>
 " Maintainer:       Yinzuo Jiang <jiangyinzuo@foxmail.com>
-" Last Change:      2024-06-10
+" Last Change:      2024-06-11
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -19,7 +19,7 @@ function! KdlIndent(...)
   let previous = getline(previousNum)
 
   if previous =~ "{" && previous !~ "}" && line !~ "}" && line !~ ":$"
-    return indent(previousNum) + &tabstop
+    return indent(previousNum) + shiftwidth()
   else
     return indent(previousNum)
   endif


### PR DESCRIPTION
closes: vim/vim#14962

https://github.com/vim/vim/commit/2e3b2a8d8971850f15fb367ddb358a8565e15324

Co-authored-by: Yinzuo Jiang <jiangyinzuo@foxmail.com>
