### PR TITLE
vim-patch:b4e648a: runtime(doc): fix typos in syntax.txt

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -468,10 +468,10 @@ Configuration
 The following variables control certain syntax highlighting features.
 You can add them to your .vimrc.
 
-To enables TypeScript and TSX for ".astro" files (default "disable"): >
+To enable TypeScript and TSX for ".astro" files (default "disable"): >
 	let g:astro_typescript = "enable"
 <
-To enables Stylus for ".astro" files (default "disable"): >
+To enable Stylus for ".astro" files (default "disable"): >
 	let g:astro_stylus = "enable"
 <
 NOTE: You need to install an external plugin to support stylus in astro files.


### PR DESCRIPTION
#### vim-patch:b4e648a: runtime(doc): fix typos in syntax.txt

https://github.com/vim/vim/commit/b4e648a0066940e0e8b513ff2e7347b5a3473694

Co-authored-by: Ken Takata <kentkt@csc.jp>