### PR TITLE
vim-patch:9.1.0477: block_editing errors out when using <enter>

### DIFF
--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -2709,4 +2709,13 @@ func Test_visual_block_cursor_delete()
   bwipe!
 endfunc
 
+func Test_visual_block_cursor_insert_enter()
+  new
+  call setline(1, ['asdf asdf', 'asdf asdf', 'asdf asdf', 'asdf asdf'])
+  call cursor(1, 5)
+  exe ":norm! \<c-v>3jcw\<cr>"
+  call assert_equal(['asdfw', 'asdf', 'asdfasdf', 'asdfasdf', 'asdfasdf'], getline(1, '$'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0477: block_editing errors out when using <enter>

Problem:  block_editing errors out when using <enter>
          (Ali Rizvi-Santiago, after v9.1.0274)
Solution: Change ins_len from size_t to int so that the test
          if ins_len is negative actually works properly

Add a test, so that this doesn't regress.

https://github.com/vim/vim/commit/1fb9eae5794c3f808468fbc2935c5144f9e0b5b1

Co-authored-by: Christian Brabandt <cb@256bit.org>