### PR TITLE
fix(meta): mod operator lpeg meta

### DIFF
--- a/runtime/lua/vim/_meta/lpeg.lua
+++ b/runtime/lua/vim/_meta/lpeg.lua
@@ -32,7 +32,7 @@ vim.lpeg = {}
 --- @operator div(table): vim.lpeg.Capture
 --- @operator div(function): vim.lpeg.Capture
 --- @operator pow(number): vim.lpeg.Pattern
---- @operator mod(function): nil
+--- @operator mod(function): vim.lpeg.Capture
 local Pattern = {}
 
 --- @alias vim.lpeg.Capture vim.lpeg.Pattern


### PR DESCRIPTION
The mod operator does not produce any captures, but within the lua-ls type system it makes sense that it returns a Capture.

Upstream PR https://github.com/LuaCATS/lpeg/pull/10