### PR TITLE
refactor(lsp): use metatable for buf_versions

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -916,18 +916,16 @@ function Client:_text_document_did_open_handler(bufnr)
   if not api.nvim_buf_is_loaded(bufnr) then
     return
   end
-  local filetype = vim.bo[bufnr].filetype
 
-  local params = {
+  local filetype = vim.bo[bufnr].filetype
+  self.notify(ms.textDocument_didOpen, {
     textDocument = {
-      version = 0,
+      version = lsp.util.buf_versions[bufnr],
       uri = vim.uri_from_bufnr(bufnr),
       languageId = self.get_language_id(bufnr, filetype),
       text = lsp._buf_get_full_text(bufnr),
     },
-  }
-  self.notify(ms.textDocument_didOpen, params)
-  lsp.util.buf_versions[bufnr] = params.textDocument.version
+  })
 
   -- Next chance we get, we should re-do the diagnostics
   vim.schedule(function()

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -412,7 +412,7 @@ end
 function STHighlighter:on_win(topline, botline)
   for client_id, state in pairs(self.client_state) do
     local current_result = state.current_result
-    if current_result.version and current_result.version == util.buf_versions[self.bufnr] then
+    if current_result.version == util.buf_versions[self.bufnr] then
       if not current_result.namespace_cleared then
         api.nvim_buf_clear_namespace(self.bufnr, state.namespace, 0, -1)
         current_result.namespace_cleared = true

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -516,7 +516,6 @@ function M.apply_text_document_edit(text_document_edit, index, offset_encoding)
     and (
       text_document.version
       and text_document.version > 0
-      and M.buf_versions[bufnr]
       and M.buf_versions[bufnr] > text_document.version
     )
   then
@@ -2222,6 +2221,11 @@ end
 M._get_line_byte_from_position = get_line_byte_from_position
 
 ---@nodoc
-M.buf_versions = {} ---@type table<integer,integer>
+---@type table<integer,integer>
+M.buf_versions = setmetatable({}, {
+  __index = function(t, bufnr)
+    return rawget(t, bufnr) or 0
+  end,
+})
 
 return M

--- a/test/functional/plugin/lsp/semantic_tokens_spec.lua
+++ b/test/functional/plugin/lsp/semantic_tokens_spec.lua
@@ -111,14 +111,13 @@ describe('semantic token highlighting', function()
     end)
 
     it('buffer is highlighted when attached', function()
+      insert(text)
       exec_lua([[
         bufnr = vim.api.nvim_get_current_buf()
         vim.api.nvim_win_set_buf(0, bufnr)
         vim.bo[bufnr].filetype = 'some-filetype'
         client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
       ]])
-
-      insert(text)
 
       screen:expect {
         grid = [[
@@ -141,6 +140,7 @@ describe('semantic token highlighting', function()
     end)
 
     it('use LspTokenUpdate and highlight_token', function()
+      insert(text)
       exec_lua([[
         vim.api.nvim_create_autocmd("LspTokenUpdate", {
           callback = function(args)
@@ -156,8 +156,6 @@ describe('semantic token highlighting', function()
         vim.api.nvim_win_set_buf(0, bufnr)
         client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
       ]])
-
-      insert(text)
 
       screen:expect {
         grid = [[
@@ -180,13 +178,16 @@ describe('semantic token highlighting', function()
     end)
 
     it('buffer is unhighlighted when client is detached', function()
+      insert(text)
+
       exec_lua([[
         bufnr = vim.api.nvim_get_current_buf()
         vim.api.nvim_win_set_buf(0, bufnr)
         client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
+        vim.wait(1000, function()
+          return #server.messages > 1
+        end)
       ]])
-
-      insert(text)
 
       exec_lua([[
         vim.notify = function() end
@@ -331,13 +332,12 @@ describe('semantic token highlighting', function()
     end)
 
     it('buffer is re-highlighted when force refreshed', function()
+      insert(text)
       exec_lua([[
         bufnr = vim.api.nvim_get_current_buf()
         vim.api.nvim_win_set_buf(0, bufnr)
         client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
       ]])
-
-      insert(text)
 
       screen:expect {
         grid = [[
@@ -412,13 +412,14 @@ describe('semantic token highlighting', function()
     end)
 
     it('updates highlights with delta request on buffer change', function()
+      insert(text)
+
       exec_lua([[
         bufnr = vim.api.nvim_get_current_buf()
         vim.api.nvim_win_set_buf(0, bufnr)
         client_id = vim.lsp.start({ name = 'dummy', cmd = server.cmd })
       ]])
 
-      insert(text)
       screen:expect {
         grid = [[
         #include <iostream>                     |
@@ -597,6 +598,7 @@ describe('semantic token highlighting', function()
     end)
 
     it('does not send delta requests if not supported by server', function()
+      insert(text)
       exec_lua(
         [[
         local legend, response, edit_response = ...
@@ -625,7 +627,6 @@ describe('semantic token highlighting', function()
         edit_response
       )
 
-      insert(text)
       screen:expect {
         grid = [[
         #include <iostream>                     |
@@ -1449,6 +1450,7 @@ int main()
       },
     }) do
       it(test.it, function()
+        insert(test.text1)
         exec_lua(create_server_definition)
         exec_lua(
           [[
@@ -1484,8 +1486,6 @@ int main()
           test.response1,
           test.response2
         )
-
-        insert(test.text1)
 
         test.expected_screen1()
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -255,7 +255,7 @@ describe('LSP', function()
         return
       end
       local expected_handlers = {
-        { NIL, {}, { method = 'shutdown', bufnr = 1, client_id = 1 } },
+        { NIL, {}, { method = 'shutdown', bufnr = 1, client_id = 1, version = 0 } },
         { NIL, {}, { method = 'test', client_id = 1 } },
       }
       test_rpc_server {
@@ -948,7 +948,11 @@ describe('LSP', function()
     it('should forward ContentModified to callback', function()
       local expected_handlers = {
         { NIL, {}, { method = 'finish', client_id = 1 } },
-        { { code = -32801 }, NIL, { method = 'error_code_test', bufnr = 1, client_id = 1 } },
+        {
+          { code = -32801 },
+          NIL,
+          { method = 'error_code_test', bufnr = 1, client_id = 1, version = 0 },
+        },
       }
       local client --- @type vim.lsp.Client
       test_rpc_server {
@@ -978,7 +982,7 @@ describe('LSP', function()
     it('should track pending requests to the language server', function()
       local expected_handlers = {
         { NIL, {}, { method = 'finish', client_id = 1 } },
-        { NIL, {}, { method = 'slow_request', bufnr = 1, client_id = 1 } },
+        { NIL, {}, { method = 'slow_request', bufnr = 1, client_id = 1, version = 0 } },
       }
       local client --- @type vim.lsp.Client
       test_rpc_server {
@@ -1045,7 +1049,7 @@ describe('LSP', function()
     it('should clear pending and cancel requests on reply', function()
       local expected_handlers = {
         { NIL, {}, { method = 'finish', client_id = 1 } },
-        { NIL, {}, { method = 'slow_request', bufnr = 1, client_id = 1 } },
+        { NIL, {}, { method = 'slow_request', bufnr = 1, client_id = 1, version = 0 } },
       }
       local client --- @type vim.lsp.Client
       test_rpc_server {
@@ -1084,7 +1088,7 @@ describe('LSP', function()
     it('should trigger LspRequest autocmd when requests table changes', function()
       local expected_handlers = {
         { NIL, {}, { method = 'finish', client_id = 1 } },
-        { NIL, {}, { method = 'slow_request', bufnr = 1, client_id = 1 } },
+        { NIL, {}, { method = 'slow_request', bufnr = 1, client_id = 1, version = 0 } },
       }
       local client --- @type vim.lsp.Client
       test_rpc_server {
@@ -1364,6 +1368,7 @@ describe('LSP', function()
             },
             bufnr = 2,
             client_id = 1,
+            version = 0,
           },
         },
         { NIL, {}, { method = 'start', client_id = 1 } },


### PR DESCRIPTION
This reduces the number of nil checks around buf_versions usage