### PR TITLE
fix: Use `vim_dialog_yesno` for the "file changed since reading" message

### DIFF
--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -355,9 +355,11 @@ static int check_mtime(buf_T *buf, FileInfo *file_info)
       && time_differs(file_info, buf->b_mtime_read, buf->b_mtime_read_ns)) {
     msg_scroll = true;  // Don't overwrite messages here.
     msg_silent = 0;     // Must give this prompt.
-    // Don't use emsg() here, don't want to flush the buffers.
-    msg(_("WARNING: The file has been changed since reading it!!!"), HL_ATTR(HLF_E));
-    if (ask_yesno(_("Do you really want to write to it"), true) == 'n') {
+    if (vim_dialog_yesno(VIM_WARNING,
+                         NULL,
+                         _(
+                          "WARNING: The file has been changed since reading it. Do you really want to write to it?"),
+                         2) == VIM_NO) {
       return FAIL;
     }
     msg_scroll = false;  // Always overwrite the file message now.

--- a/src/nvim/po/es.po
+++ b/src/nvim/po/es.po
@@ -2387,19 +2387,9 @@ msgstr "[no hay fin de línea]"
 msgid "[Incomplete last line]"
 msgstr "[Última línea incompleta]"
 
-# don't overwrite messages here
-# must give this prompt
-# don't use emsg() here, don't want to flush the buffers
-#. don't overwrite messages here
-#. must give this prompt
-#. don't use emsg() here, don't want to flush the buffers
-#: ../fileio.c:3865
-msgid "WARNING: The file has been changed since reading it!!!"
-msgstr "ADVERTENCIA: ¡¡¡El archivo ha cambiado desde que se leyó!!!"
-
-#: ../fileio.c:3867
-msgid "Do you really want to write to it"
-msgstr "¿Desea realmente escribir al archivo?"
+#: ../bufwrite.c:362
+msgid "WARNING: The file has been changed since reading it. Do you really want to write to it?"
+msgstr "ADVERTENCIA: El archivo ha cambiado desde que se leyó. ¿Desea realmente escribir en él?"
 
 #: ../fileio.c:4648
 #, c-format

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -295,10 +295,10 @@ describe('fileio', function()
     -- use async feed_command because nvim basically hangs on the prompt
     feed_command('w')
     screen:expect([[
-      {9:WARNING: The file has been changed since}|
-      {9: reading it!!!}                          |
-      {6:Do you really want to write to it (y/n)?}|
-      ^                                        |
+      {6:WARNING: The file has been changed since}|
+      {6: reading it. Do you really want to write}|
+      {6: to it?}                                 |
+      {6:(Y)es, [N]o: }^                           |
     ]])
 
     feed('n')

--- a/test/functional/ui/input_spec.lua
+++ b/test/functional/ui/input_spec.lua
@@ -344,11 +344,12 @@ describe('input non-printable chars', function()
     feed_command('w')
     screen:expect([[
       foobar                                                      |
-      {1:~                                                           }|*3
+      {1:~                                                           }|*2
       {3:                                                            }|
       "Xtest-overwrite"                                           |
-      {9:WARNING: The file has been changed since reading it!!!}      |
-      {6:Do you really want to write to it (y/n)?}^                    |
+      {6:WARNING: The file has been changed since reading it. Do you }|
+      {6:really want to write to it?}                                 |
+      {6:(Y)es, [N]o: }^                                               |
     ]])
 
     feed('u')
@@ -357,36 +358,23 @@ describe('input non-printable chars', function()
       {1:~                                                           }|*2
       {3:                                                            }|
       "Xtest-overwrite"                                           |
-      {9:WARNING: The file has been changed since reading it!!!}      |
-      {6:Do you really want to write to it (y/n)?}u                   |
-      {6:Do you really want to write to it (y/n)?}^                    |
+      {6:WARNING: The file has been changed since reading it. Do you }|
+      {6:really want to write to it?}                                 |
+      {6:(Y)es, [N]o: }^                                               |
     ]])
 
     feed('\005')
     screen:expect([[
       foobar                                                      |
-      {1:~                                                           }|
+      {1:~                                                           }|*2
       {3:                                                            }|
       "Xtest-overwrite"                                           |
-      {9:WARNING: The file has been changed since reading it!!!}      |
-      {6:Do you really want to write to it (y/n)?}u                   |
-      {6:Do you really want to write to it (y/n)?}                    |
-      {6:Do you really want to write to it (y/n)?}^                    |
+      {6:WARNING: The file has been changed since reading it. Do you }|
+      {6:really want to write to it?}                                 |
+      {6:(Y)es, [N]o: }^                                               |
     ]])
 
     feed('n')
-    screen:expect([[
-      foobar                                                      |
-      {3:                                                            }|
-      "Xtest-overwrite"                                           |
-      {9:WARNING: The file has been changed since reading it!!!}      |
-      {6:Do you really want to write to it (y/n)?}u                   |
-      {6:Do you really want to write to it (y/n)?}                    |
-      {6:Do you really want to write to it (y/n)?}n                   |
-      {6:Press ENTER or type command to continue}^                     |
-    ]])
-
-    feed('<cr>')
     screen:expect([[
       ^foobar                                                      |
       {1:~                                                           }|*6


### PR DESCRIPTION
In order to allow more flexibility in how UI plugins like [Noice handle this specific prompt](https://github.com/folke/noice.nvim/issues/720), switch from using `ask_yesno` to `vim_dialog_yesno`, which sends a `msg_send.confirm` event which can be handled by `vim.ui_attach`. This also brings it in line with other user prompts such as the swapfile dialog.

Before:
<img width="495" alt="image" src="https://github.com/neovim/neovim/assets/13615693/a397fc9c-6fe4-4543-994b-d95d8d384331">

After:
<img width="797" alt="image" src="https://github.com/neovim/neovim/assets/13615693/e184f1f8-50c8-4de2-9ad6-8af0c5a7f8d1">

With Noice:
<img width="845" alt="image" src="https://github.com/neovim/neovim/assets/13615693/124e9195-b245-44b9-b63a-7bac34a61e89">


Questions/feedback requested:
- I felt like combining the existing two messages together creates a better UX for this flow, but happy to leave it as is if that's preferred
- Even without combining the two strings onto one line, I probably would still need to update localization (at least to add the question mark that `ask_yesno` used to add). I'm happy to take a crack at that, but I'm having trouble testing it. Doing `VIMRUNTIME=runtime ./build/bin/nvim --clean` and then setting `:lang es_ES` doesn't seem to use Spanish strings :/
