### PR TITLE
refactor(declarations): also generate prototypes for functions in headers

### DIFF
--- a/src/clint.py
+++ b/src/clint.py
@@ -895,6 +895,7 @@ def CheckIncludes(filename, lines, error):
             if (not name.endswith('.h.generated.h') and
                     not name.endswith('/defs.h') and
                     not name.endswith('_defs.h') and
+                    not name.endswith('h.inline.generated.h') and
                     not name.endswith('_defs.generated.h') and
                     not name.endswith('_enum.generated.h')):
                 error(filename, i, 'build/include_defs', 5,

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -391,6 +391,7 @@ foreach(subdir
         event
         eval
         lua
+        lib
         viml
         viml/parser
        )
@@ -427,6 +428,21 @@ foreach(sfile ${NVIM_SOURCES})
 endforeach()
 
 list(REMOVE_ITEM NVIM_SOURCES ${to_remove})
+
+foreach(hfile ${NVIM_HEADERS})
+  get_filename_component(f ${hfile} NAME)
+  if(WIN32 AND ${f} MATCHES "^(unix_defs.h)$")
+    list(APPEND to_remove_h ${hfile})
+  endif()
+  if(WIN32 AND ${f} MATCHES "^(pty_process_unix.h)$")
+    list(APPEND to_remove_h ${hfile})
+  endif()
+  if(NOT WIN32 AND ${f} MATCHES "^(win_defs.h)$")
+    list(APPEND to_remove_h ${hfile})
+  endif()
+endforeach()
+
+list(REMOVE_ITEM NVIM_HEADERS ${to_remove_h})
 
 # xdiff, mpack, lua-cjson, termkey: inlined external project, we don't maintain it. #9306
 if(MSVC)
@@ -511,6 +527,7 @@ set(LUA_GEN_DEPS ${GENERATOR_PRELOAD} $<TARGET_FILE:nlua0>)
 # NVIM_GENERATED_FOR_SOURCES: generated headers to be included in sources
 # These lists must be mutually exclusive.
 foreach(sfile ${NVIM_SOURCES}
+              ${NVIM_HEADERS}
               ${GENERATED_API_DISPATCH}
               "${GENERATED_UI_EVENTS_CALL}"
               "${GENERATED_UI_EVENTS_REMOTE}"
@@ -523,13 +540,25 @@ foreach(sfile ${NVIM_SOURCES}
   endif()
   get_filename_component(f ${sfile} NAME)
   get_filename_component(r ${sfile} NAME_WE)
+  get_filename_component(ext ${sfile} EXT)
   if(NOT ${d} EQUAL ".")
     set(f "${d}/${f}")
     set(r "${d}/${r}")
   endif()
-  set(gf_c_h "${GENERATED_DIR}/${r}.c.generated.h")
-  set(gf_h_h "${GENERATED_INCLUDES_DIR}/${r}.h.generated.h")
-  set(gf_i "${GENERATED_DIR}/${r}.i")
+  set (gf_basename "")
+  if ("${ext}" STREQUAL ".c.h")
+    continue() # .c.h files are sussy baka, skip
+  elseif(${sfile} IN_LIST NVIM_HEADERS)
+    set(gf_basename "${r}.h.inline.generated.h")
+    set(gf_c_h "${GENERATED_INCLUDES_DIR}/${r}.h.inline.generated.h")
+    set(gf_h_h "SKIP")
+    set(gf_h_h_out "")
+  else()
+    set(gf_c_h "${GENERATED_DIR}/${r}.c.generated.h")
+    set(gf_h_h "${GENERATED_INCLUDES_DIR}/${r}.h.generated.h")
+    set(gf_h_h_out "${gf_h_h}")
+  endif()
+  set(gf_i "${GENERATED_DIR}/${f}.i")
 
   if(MSVC)
     set(PREPROC_OUTPUT /P /Fi${gf_i} /nologo)
@@ -543,14 +572,16 @@ foreach(sfile ${NVIM_SOURCES}
     list(APPEND depends update_version_stamp "${NVIM_VERSION_GIT_H}" "${NVIM_VERSION_DEF_H}")
   endif()
   add_custom_command(
-    OUTPUT "${gf_c_h}" "${gf_h_h}"
+    OUTPUT "${gf_c_h}" ${gf_h_h_out}
     COMMAND ${CMAKE_C_COMPILER} ${sfile} ${PREPROC_OUTPUT} ${gen_cflags}
-    COMMAND ${LUA_GEN} "${HEADER_GENERATOR}" "${sfile}" "${gf_c_h}" "${gf_h_h}" "${gf_i}"
+    COMMAND ${LUA_GEN} "${HEADER_GENERATOR}" "${sfile}" "${gf_c_h}" "${gf_h_h}" "${gf_i}" "${gf_basename}"
     DEPENDS ${depends})
   list(APPEND NVIM_GENERATED_FOR_SOURCES "${gf_c_h}")
-  list(APPEND NVIM_GENERATED_FOR_HEADERS "${gf_h_h}")
-  if(${d} MATCHES "^api$" AND NOT ${f} MATCHES "^api/helpers.c$")
-    list(APPEND API_HEADERS ${gf_h_h})
+  if (NOT ${sfile} IN_LIST NVIM_HEADERS)
+    list(APPEND NVIM_GENERATED_FOR_HEADERS "${gf_h_h}")
+    if(${d} MATCHES "^api$" AND NOT ${f} MATCHES "^api/helpers.c$")
+      list(APPEND API_HEADERS ${gf_h_h})
+    endif()
   endif()
 endforeach()
 

--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -5,7 +5,6 @@
 #include <string.h>
 
 #include "klib/kvec.h"
-#include "nvim/func_attr.h"
 #include "nvim/types_defs.h"
 
 #define ARRAY_DICT_INIT KV_INITIAL_VALUE
@@ -20,6 +19,7 @@
 # define ArrayOf(...) Array
 # define DictionaryOf(...) Dictionary
 # define Dict(name) KeyDict_##name
+# include "api/private/defs.h.inline.generated.h"
 #endif
 
 // Basic types
@@ -47,15 +47,13 @@ typedef enum {
 /// Internal call from Lua code
 #define LUA_INTERNAL_CALL (VIML_INTERNAL_CALL + 1)
 
-static inline bool is_internal_call(uint64_t channel_id)
-  REAL_FATTR_ALWAYS_INLINE REAL_FATTR_CONST;
-
 /// Check whether call is internal
 ///
 /// @param[in]  channel_id  Channel id.
 ///
 /// @return true if channel_id refers to internal channel.
 static inline bool is_internal_call(const uint64_t channel_id)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_CONST
 {
   return !!(channel_id & INTERNAL_CALL_MASK);
 }

--- a/src/nvim/ascii_defs.h
+++ b/src/nvim/ascii_defs.h
@@ -2,8 +2,11 @@
 
 #include <stdbool.h>
 
-#include "nvim/func_attr.h"
 #include "nvim/os/os_defs.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "ascii_defs.h.inline.generated.h"
+#endif
 
 // Definitions of various common control characters.
 
@@ -82,31 +85,24 @@
 # define PATHSEPSTR     "/"
 #endif
 
-static inline bool ascii_iswhite(int c)
-  REAL_FATTR_CONST
-  REAL_FATTR_ALWAYS_INLINE;
 /// Checks if `c` is a space or tab character.
 ///
 /// @see {ascii_isdigit}
 static inline bool ascii_iswhite(int c)
+  FUNC_ATTR_CONST FUNC_ATTR_ALWAYS_INLINE
 {
   return c == ' ' || c == '\t';
 }
 
-static inline bool ascii_iswhite_or_nul(int c)
-  REAL_FATTR_CONST
-  REAL_FATTR_ALWAYS_INLINE;
 /// Checks if `c` is a space or tab character or NUL.
 ///
 /// @see {ascii_isdigit}
 static inline bool ascii_iswhite_or_nul(int c)
+  FUNC_ATTR_CONST FUNC_ATTR_ALWAYS_INLINE
 {
   return ascii_iswhite(c) || c == NUL;
 }
 
-static inline bool ascii_isdigit(int c)
-  REAL_FATTR_CONST
-  REAL_FATTR_ALWAYS_INLINE;
 /// Check whether character is a decimal digit.
 ///
 /// Library isdigit() function is officially locale-dependent and, for
@@ -117,64 +113,55 @@ static inline bool ascii_isdigit(int c)
 /// what may be used for some optimizations (e.g. simple `return
 /// isdigit_table[c];`).
 static inline bool ascii_isdigit(int c)
+  FUNC_ATTR_CONST FUNC_ATTR_ALWAYS_INLINE
 {
   return c >= '0' && c <= '9';
 }
 
-static inline bool ascii_isxdigit(int c)
-  REAL_FATTR_CONST
-  REAL_FATTR_ALWAYS_INLINE;
 /// Checks if `c` is a hexadecimal digit, that is, one of 0-9, a-f, A-F.
 ///
 /// @see {ascii_isdigit}
 static inline bool ascii_isxdigit(int c)
+  FUNC_ATTR_CONST FUNC_ATTR_ALWAYS_INLINE
 {
   return (c >= '0' && c <= '9')
          || (c >= 'a' && c <= 'f')
          || (c >= 'A' && c <= 'F');
 }
 
-static inline bool ascii_isident(int c)
-  REAL_FATTR_CONST
-  REAL_FATTR_ALWAYS_INLINE;
 /// Checks if `c` is an “identifier” character
 ///
 /// That is, whether it is alphanumeric character or underscore.
 static inline bool ascii_isident(int c)
+  FUNC_ATTR_CONST FUNC_ATTR_ALWAYS_INLINE
 {
   return ASCII_ISALNUM(c) || c == '_';
 }
 
-static inline bool ascii_isbdigit(int c)
-  REAL_FATTR_CONST
-  REAL_FATTR_ALWAYS_INLINE;
 /// Checks if `c` is a binary digit, that is, 0-1.
 ///
 /// @see {ascii_isdigit}
 static inline bool ascii_isbdigit(int c)
+  FUNC_ATTR_CONST FUNC_ATTR_ALWAYS_INLINE
 {
   return (c == '0' || c == '1');
 }
 
-static inline bool ascii_isodigit(int c)
-  REAL_FATTR_CONST
-  REAL_FATTR_ALWAYS_INLINE;
 /// Checks if `c` is an octal digit, that is, 0-7.
 ///
 /// @see {ascii_isdigit}
 static inline bool ascii_isodigit(int c)
+  FUNC_ATTR_CONST FUNC_ATTR_ALWAYS_INLINE
 {
   return (c >= '0' && c <= '7');
 }
 
-static inline bool ascii_isspace(int c)
-  REAL_FATTR_CONST
-  REAL_FATTR_ALWAYS_INLINE;
 /// Checks if `c` is a white-space character, that is,
 /// one of \f, \n, \r, \t, \v.
 ///
 /// @see {ascii_isdigit}
 static inline bool ascii_isspace(int c)
+  FUNC_ATTR_CONST FUNC_ATTR_ALWAYS_INLINE
 {
   return (c >= 9 && c <= 13) || c == ' ';
 }

--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -5,7 +5,6 @@
 #include "nvim/buffer_defs.h"  // IWYU pragma: keep
 #include "nvim/eval/typval_defs.h"
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: keep
-#include "nvim/func_attr.h"
 #include "nvim/gettext_defs.h"  // IWYU pragma: keep
 #include "nvim/macros_defs.h"
 #include "nvim/marktree_defs.h"
@@ -76,11 +75,8 @@ EXTERN char *msg_qflist INIT( = N_("[Quickfix List]"));
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "buffer.h.generated.h"
+# include "buffer.h.inline.generated.h"
 #endif
-
-static inline varnumber_T buf_get_changedtick(const buf_T *buf)
-  REAL_FATTR_NONNULL_ALL REAL_FATTR_ALWAYS_INLINE REAL_FATTR_PURE
-  REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Get b:changedtick value
 ///
@@ -88,6 +84,8 @@ static inline varnumber_T buf_get_changedtick(const buf_T *buf)
 ///
 /// @param[in]  buf  Buffer to get b:changedtick from.
 static inline varnumber_T buf_get_changedtick(const buf_T *const buf)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_PURE
+  FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return buf->changedtick_di.di_tv.vval.v_number;
 }

--- a/src/nvim/channel.h
+++ b/src/nvim/channel.h
@@ -8,17 +8,11 @@
 #include "nvim/eval/typval_defs.h"
 #include "nvim/event/defs.h"
 #include "nvim/event/libuv_process.h"
-#include "nvim/func_attr.h"
 #include "nvim/macros_defs.h"
 #include "nvim/map_defs.h"
 #include "nvim/msgpack_rpc/channel_defs.h"
 #include "nvim/os/pty_process.h"
 #include "nvim/types_defs.h"
-
-static inline bool callback_reader_set(CallbackReader reader)
-{
-  return reader.cb.type != kCallbackNone || reader.self;
-}
 
 struct Channel {
   uint64_t id;
@@ -49,13 +43,19 @@ struct Channel {
   bool callback_scheduled;
 };
 
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "channel.h.generated.h"
+# include "channel.h.inline.generated.h"
+#endif
+
+static inline bool callback_reader_set(CallbackReader reader)
+{
+  return reader.cb.type != kCallbackNone || reader.self;
+}
+
 EXTERN PMap(uint64_t) channels INIT( = MAP_INIT);
 
 EXTERN Callback on_print INIT( = CALLBACK_INIT);
-
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "channel.h.generated.h"
-#endif
 
 /// @returns Channel with the id or NULL if not found
 static inline Channel *find_channel(uint64_t id)
@@ -64,9 +64,7 @@ static inline Channel *find_channel(uint64_t id)
 }
 
 static inline Stream *channel_instream(Channel *chan)
-  REAL_FATTR_NONNULL_ALL;
-
-static inline Stream *channel_instream(Channel *chan)
+  FUNC_ATTR_NONNULL_ALL
 {
   switch (chan->streamtype) {
   case kChannelStreamProc:
@@ -86,9 +84,7 @@ static inline Stream *channel_instream(Channel *chan)
 }
 
 static inline RStream *channel_outstream(Channel *chan)
-  REAL_FATTR_NONNULL_ALL;
-
-static inline RStream *channel_outstream(Channel *chan)
+  FUNC_ATTR_NONNULL_ALL
 {
   switch (chan->streamtype) {
   case kChannelStreamProc:

--- a/src/nvim/charset.h
+++ b/src/nvim/charset.h
@@ -3,7 +3,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "nvim/func_attr.h"
 #include "nvim/option_vars.h"
 #include "nvim/strings.h"  // IWYU pragma: keep
 
@@ -31,15 +30,13 @@ typedef enum {
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "charset.h.generated.h"
+# include "charset.h.inline.generated.h"
 #endif
-
-static inline bool vim_isbreak(int c)
-  REAL_FATTR_CONST
-  REAL_FATTR_ALWAYS_INLINE;
 
 /// Check if `c` is one of the characters in 'breakat'.
 /// Used very often if 'linebreak' is set
 static inline bool vim_isbreak(int c)
+  FUNC_ATTR_CONST FUNC_ATTR_ALWAYS_INLINE
 {
   return breakat_flags[(uint8_t)c];
 }

--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -7,7 +7,6 @@
 #include <string.h>
 
 #include "nvim/eval/typval_defs.h"  // IWYU pragma: keep
-#include "nvim/func_attr.h"
 #include "nvim/gettext_defs.h"
 #include "nvim/hashtab.h"
 #include "nvim/lib/queue_defs.h"
@@ -16,6 +15,10 @@
 #include "nvim/message.h"
 #include "nvim/types_defs.h"
 
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "eval/typval.h.inline.generated.h"
+#endif
+
 // In a hashtab item "hi_key" points to "di_key" in a dictitem.
 // This avoids adding a pointer to the hashtab item.
 
@@ -23,15 +26,13 @@
 #define TV_DICT_HI2DI(hi) \
   ((dictitem_T *)((hi)->hi_key - offsetof(dictitem_T, di_key)))
 
-static inline void tv_list_ref(list_T *l)
-  REAL_FATTR_ALWAYS_INLINE;
-
 /// Increase reference count for a given list
 ///
 /// Does nothing for NULL lists.
 ///
 /// @param[in,out]  l  List to modify.
 static inline void tv_list_ref(list_T *const l)
+  FUNC_ATTR_ALWAYS_INLINE
 {
   if (l == NULL) {
     return;
@@ -39,22 +40,17 @@ static inline void tv_list_ref(list_T *const l)
   l->lv_refcount++;
 }
 
-static inline void tv_list_set_ret(typval_T *tv, list_T *l)
-  REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ARG(1);
-
 /// Set a list as the return value.  Increments the reference count.
 ///
 /// @param[out]  tv  Object to receive the list
 /// @param[in,out]  l  List to pass to the object
 static inline void tv_list_set_ret(typval_T *const tv, list_T *const l)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_NONNULL_ARG(1)
 {
   tv->v_type = VAR_LIST;
   tv->vval.v_list = l;
   tv_list_ref(l);
 }
-
-static inline VarLockStatus tv_list_locked(const list_T *l)
-  REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Get list lock status
 ///
@@ -62,6 +58,7 @@ static inline VarLockStatus tv_list_locked(const list_T *l)
 ///
 /// @param[in]  l  List to check.
 static inline VarLockStatus tv_list_locked(const list_T *const l)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (l == NULL) {
     return VAR_FIXED;
@@ -84,9 +81,6 @@ static inline void tv_list_set_lock(list_T *const l, const VarLockStatus lock)
   l->lv_lock = lock;
 }
 
-static inline void tv_list_set_copyid(list_T *l, int copyid)
-  REAL_FATTR_NONNULL_ALL;
-
 /// Set list copyID
 ///
 /// Does not expect NULL list, be careful.
@@ -94,17 +88,16 @@ static inline void tv_list_set_copyid(list_T *l, int copyid)
 /// @param[out]  l  List to modify.
 /// @param[in]  copyid  New copyID.
 static inline void tv_list_set_copyid(list_T *const l, const int copyid)
+  FUNC_ATTR_NONNULL_ALL
 {
   l->lv_copyID = copyid;
 }
-
-static inline int tv_list_len(const list_T *l)
-  REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Get the number of items in a list
 ///
 /// @param[in]  l  List to check.
 static inline int tv_list_len(const list_T *const l)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (l == NULL) {
     return 0;
@@ -112,21 +105,16 @@ static inline int tv_list_len(const list_T *const l)
   return l->lv_len;
 }
 
-static inline int tv_list_copyid(const list_T *l)
-  REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT REAL_FATTR_NONNULL_ALL;
-
 /// Get list copyID
 ///
 /// Does not expect NULL list, be careful.
 ///
 /// @param[in]  l  List to check.
 static inline int tv_list_copyid(const list_T *const l)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
   return l->lv_copyID;
 }
-
-static inline list_T *tv_list_latest_copy(const list_T *l)
-  REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT REAL_FATTR_NONNULL_ALL;
 
 /// Get latest list copy
 ///
@@ -136,12 +124,10 @@ static inline list_T *tv_list_latest_copy(const list_T *l)
 ///
 /// @param[in]  l  List to check.
 static inline list_T *tv_list_latest_copy(const list_T *const l)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
   return l->lv_copylist;
 }
-
-static inline int tv_list_uidx(const list_T *l, int n)
-  REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Normalize index: that is, return either -1 or non-negative index
 ///
@@ -150,6 +136,7 @@ static inline int tv_list_uidx(const list_T *l, int n)
 ///
 /// @return -1 or list index in range [0, tv_list_len(l)).
 static inline int tv_list_uidx(const list_T *const l, int n)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   // Negative index is relative to the end.
   if (n < 0) {
@@ -163,9 +150,6 @@ static inline int tv_list_uidx(const list_T *const l, int n)
   return n;
 }
 
-static inline bool tv_list_has_watchers(const list_T *l)
-  REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
-
 /// Check whether list has watchers
 ///
 /// E.g. is referenced by a :for loop.
@@ -174,12 +158,10 @@ static inline bool tv_list_has_watchers(const list_T *l)
 ///
 /// @return true if there are watchers, false otherwise.
 static inline bool tv_list_has_watchers(const list_T *const l)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return l && l->lv_watch;
 }
-
-static inline listitem_T *tv_list_first(const list_T *l)
-  REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Get first list item
 ///
@@ -187,6 +169,7 @@ static inline listitem_T *tv_list_first(const list_T *l)
 ///
 /// @return List item or NULL in case of an empty list.
 static inline listitem_T *tv_list_first(const list_T *const l)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (l == NULL) {
     return NULL;
@@ -194,15 +177,13 @@ static inline listitem_T *tv_list_first(const list_T *const l)
   return l->lv_first;
 }
 
-static inline listitem_T *tv_list_last(const list_T *l)
-  REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
-
 /// Get last list item
 ///
 /// @param[in]  l  List to get item from.
 ///
 /// @return List item or NULL in case of an empty list.
 static inline listitem_T *tv_list_last(const list_T *const l)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (l == NULL) {
     return NULL;
@@ -210,14 +191,12 @@ static inline listitem_T *tv_list_last(const list_T *const l)
   return l->lv_last;
 }
 
-static inline void tv_dict_set_ret(typval_T *tv, dict_T *d)
-  REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ARG(1);
-
 /// Set a dictionary as the return value
 ///
 /// @param[out]  tv  Object to receive the dictionary
 /// @param[in,out]  d  Dictionary to pass to the object
 static inline void tv_dict_set_ret(typval_T *const tv, dict_T *const d)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_NONNULL_ARG(1)
 {
   tv->v_type = VAR_DICT;
   tv->vval.v_dict = d;
@@ -226,13 +205,11 @@ static inline void tv_dict_set_ret(typval_T *const tv, dict_T *const d)
   }
 }
 
-static inline long tv_dict_len(const dict_T *d)
-  REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
-
 /// Get the number of items in a Dictionary
 ///
 /// @param[in]  d  Dictionary to check.
 static inline long tv_dict_len(const dict_T *const d)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (d == NULL) {
     return 0;
@@ -240,21 +217,16 @@ static inline long tv_dict_len(const dict_T *const d)
   return (long)d->dv_hashtab.ht_used;
 }
 
-static inline bool tv_dict_is_watched(const dict_T *d)
-  REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
-
 /// Check if dictionary is watched
 ///
 /// @param[in]  d  Dictionary to check.
 ///
 /// @return true if there is at least one watcher.
 static inline bool tv_dict_is_watched(const dict_T *const d)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return d && !QUEUE_EMPTY(&d->watchers);
 }
-
-static inline void tv_blob_set_ret(typval_T *tv, blob_T *b)
-  REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ARG(1);
 
 /// Set a blob as the return value.
 ///
@@ -263,6 +235,7 @@ static inline void tv_blob_set_ret(typval_T *tv, blob_T *b)
 /// @param[out]  tv  Object to receive the blob.
 /// @param[in,out]  b  Blob to pass to the object.
 static inline void tv_blob_set_ret(typval_T *const tv, blob_T *const b)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_NONNULL_ARG(1)
 {
   tv->v_type = VAR_BLOB;
   tv->vval.v_blob = b;
@@ -271,22 +244,17 @@ static inline void tv_blob_set_ret(typval_T *const tv, blob_T *const b)
   }
 }
 
-static inline int tv_blob_len(const blob_T *b)
-  REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
-
 /// Get the length of the data in the blob, in bytes.
 ///
 /// @param[in]  b  Blob to check.
 static inline int tv_blob_len(const blob_T *const b)
+  FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (b == NULL) {
     return 0;
   }
   return b->bv_ga.ga_len;
 }
-
-static inline uint8_t tv_blob_get(const blob_T *b, int idx)
-  REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ALL REAL_FATTR_WARN_UNUSED_RESULT;
 
 /// Get the byte at index `idx` in the blob.
 ///
@@ -295,12 +263,10 @@ static inline uint8_t tv_blob_get(const blob_T *b, int idx)
 ///
 /// @return Byte value at the given index.
 static inline uint8_t tv_blob_get(const blob_T *const b, int idx)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return ((uint8_t *)b->bv_ga.ga_data)[idx];
 }
-
-static inline void tv_blob_set(blob_T *blob, int idx, uint8_t c)
-  REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ALL;
 
 /// Store the byte `c` at index `idx` in the blob.
 ///
@@ -308,6 +274,7 @@ static inline void tv_blob_set(blob_T *blob, int idx, uint8_t c)
 /// @param[in]  idx  Index in a blob. Must be valid.
 /// @param[in]  c  Value to store.
 static inline void tv_blob_set(blob_T *const blob, int idx, uint8_t c)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_NONNULL_ALL
 {
   ((uint8_t *)blob->bv_ga.ga_data)[idx] = c;
 }
@@ -417,9 +384,6 @@ extern bool tv_in_free_unref_items;
     } \
   })
 
-static inline bool tv_get_float_chk(const typval_T *tv, float_T *ret_f)
-  REAL_FATTR_NONNULL_ALL REAL_FATTR_WARN_UNUSED_RESULT;
-
 /// Get the float value
 ///
 /// Raises an error if object is not number or floating-point.
@@ -429,6 +393,7 @@ static inline bool tv_get_float_chk(const typval_T *tv, float_T *ret_f)
 ///
 /// @return true in case of success, false if tv is not a number or float.
 static inline bool tv_get_float_chk(const typval_T *const tv, float_T *const ret_f)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
 {
   if (tv->v_type == VAR_FLOAT) {
     *ret_f = tv->vval.v_float;
@@ -442,21 +407,16 @@ static inline bool tv_get_float_chk(const typval_T *const tv, float_T *const ret
   return false;
 }
 
-static inline DictWatcher *tv_dict_watcher_node_data(QUEUE *q)
-  REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ALL REAL_FATTR_NONNULL_RET
-    REAL_FATTR_NO_SANITIZE_ADDRESS REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
-
 /// Compute the `DictWatcher` address from a QUEUE node.
 ///
 /// This only exists for .asan-blacklist (ASAN doesn't handle QUEUE_DATA pointer
 /// arithmetic).
 static inline DictWatcher *tv_dict_watcher_node_data(QUEUE *q)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_NONNULL_ALL FUNC_ATTR_NONNULL_RET
+    FUNC_ATTR_NO_SANITIZE_ADDRESS FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return QUEUE_DATA(q, DictWatcher, node);
 }
-
-static inline bool tv_is_func(typval_T tv)
-  REAL_FATTR_WARN_UNUSED_RESULT REAL_FATTR_ALWAYS_INLINE REAL_FATTR_CONST;
 
 /// Check whether given typval_T contains a function
 ///
@@ -466,6 +426,7 @@ static inline bool tv_is_func(typval_T tv)
 ///
 /// @return True if it is a function or a partial, false otherwise.
 static inline bool tv_is_func(const typval_T tv)
+  FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_CONST
 {
   return tv.v_type == VAR_FUNC || tv.v_type == VAR_PARTIAL;
 }

--- a/src/nvim/eval/typval_encode.h
+++ b/src/nvim/eval/typval_encode.h
@@ -11,7 +11,10 @@
 
 #include "klib/kvec.h"
 #include "nvim/eval/typval_defs.h"
-#include "nvim/func_attr.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "eval/typval_encode.h.inline.generated.h"
+#endif
 
 /// Type of the stack entry
 typedef enum {
@@ -62,10 +65,6 @@ typedef struct {
 /// Stack used to convert Vimscript values to messagepack.
 typedef kvec_withinit_t(MPConvStackVal, 8) MPConvStack;
 
-static inline size_t tv_strlen(const typval_T *tv)
-  REAL_FATTR_ALWAYS_INLINE REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT
-  REAL_FATTR_NONNULL_ALL;
-
 /// Length of the string stored in typval_T
 ///
 /// @param[in]  tv  String for which to compute length for. Must be typval_T
@@ -74,6 +73,8 @@ static inline size_t tv_strlen(const typval_T *tv)
 /// @return Length of the string stored in typval_T, including 0 for NULL
 ///         string.
 static inline size_t tv_strlen(const typval_T *const tv)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
+  FUNC_ATTR_NONNULL_ALL
 {
   assert(tv->v_type == VAR_STRING);
   return (tv->vval.v_string == NULL ? 0 : strlen(tv->vval.v_string));

--- a/src/nvim/lib/queue_defs.h
+++ b/src/nvim/lib/queue_defs.h
@@ -21,12 +21,14 @@
 
 #include <stddef.h>
 
-#include "nvim/func_attr.h"
-
 typedef struct queue {
   struct queue *next;
   struct queue *prev;
 } QUEUE;
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "lib/queue_defs.h.inline.generated.h"
+#endif
 
 // Public macros.
 #define QUEUE_DATA(ptr, type, field) \
@@ -44,29 +46,23 @@ typedef struct queue {
   }
 
 // ffi.cdef is unable to swallow `bool` in place of `int` here.
-static inline int QUEUE_EMPTY(const QUEUE *q)
-  REAL_FATTR_ALWAYS_INLINE REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT;
-
 static inline int QUEUE_EMPTY(const QUEUE *const q)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   return q == q->next;
 }
 
 #define QUEUE_HEAD(q) (q)->next
 
-static inline void QUEUE_INIT(QUEUE *q)
-  REAL_FATTR_ALWAYS_INLINE;
-
 static inline void QUEUE_INIT(QUEUE *const q)
+  FUNC_ATTR_ALWAYS_INLINE
 {
   q->next = q;
   q->prev = q;
 }
 
-static inline void QUEUE_ADD(QUEUE *h, QUEUE *n)
-  REAL_FATTR_ALWAYS_INLINE;
-
 static inline void QUEUE_ADD(QUEUE *const h, QUEUE *const n)
+  FUNC_ATTR_ALWAYS_INLINE
 {
   h->prev->next = n->next;
   n->next->prev = h->prev;
@@ -74,10 +70,8 @@ static inline void QUEUE_ADD(QUEUE *const h, QUEUE *const n)
   h->prev->next = h;
 }
 
-static inline void QUEUE_INSERT_HEAD(QUEUE *h, QUEUE *q)
-  REAL_FATTR_ALWAYS_INLINE;
-
 static inline void QUEUE_INSERT_HEAD(QUEUE *const h, QUEUE *const q)
+  FUNC_ATTR_ALWAYS_INLINE
 {
   q->next = h->next;
   q->prev = h;
@@ -85,10 +79,8 @@ static inline void QUEUE_INSERT_HEAD(QUEUE *const h, QUEUE *const q)
   h->next = q;
 }
 
-static inline void QUEUE_INSERT_TAIL(QUEUE *h, QUEUE *q)
-  REAL_FATTR_ALWAYS_INLINE;
-
 static inline void QUEUE_INSERT_TAIL(QUEUE *const h, QUEUE *const q)
+  FUNC_ATTR_ALWAYS_INLINE
 {
   q->next = h;
   q->prev = h->prev;
@@ -96,10 +88,8 @@ static inline void QUEUE_INSERT_TAIL(QUEUE *const h, QUEUE *const q)
   h->prev = q;
 }
 
-static inline void QUEUE_REMOVE(QUEUE *q)
-  REAL_FATTR_ALWAYS_INLINE;
-
 static inline void QUEUE_REMOVE(QUEUE *const q)
+  FUNC_ATTR_ALWAYS_INLINE
 {
   q->prev->next = q->next;
   q->next->prev = q->prev;

--- a/src/nvim/mark.h
+++ b/src/nvim/mark.h
@@ -5,19 +5,18 @@
 #include "nvim/ascii_defs.h"
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: keep
 #include "nvim/extmark_defs.h"  // IWYU pragma: keep
-#include "nvim/func_attr.h"
 #include "nvim/macros_defs.h"
 #include "nvim/mark_defs.h"  // IWYU pragma: keep
 #include "nvim/os/time.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "mark.h.generated.h"
+# include "mark.h.inline.generated.h"
 #endif
 
-static inline int mark_global_index(char name)
-  REAL_FATTR_CONST;
 /// Convert mark name to the offset
 static inline int mark_global_index(const char name)
+  FUNC_ATTR_CONST
 {
   return (ASCII_ISUPPER(name)
           ? (name - 'A')
@@ -26,10 +25,9 @@ static inline int mark_global_index(const char name)
              : -1));
 }
 
-static inline int mark_local_index(char name)
-  REAL_FATTR_CONST;
 /// Convert local mark name to the offset
 static inline int mark_local_index(const char name)
+  FUNC_ATTR_CONST
 {
   return (ASCII_ISLOWER(name)
           ? (name - 'a')

--- a/src/nvim/mark_defs.h
+++ b/src/nvim/mark_defs.h
@@ -3,6 +3,10 @@
 #include "nvim/eval/typval_defs.h"
 #include "nvim/os/time_defs.h"
 
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "mark_defs.h.inline.generated.h"
+#endif
+
 // marks: positions in a file
 // (a normal mark is a lnum/col pair, the same as a file position)
 
@@ -84,11 +88,9 @@ typedef struct {
 
 #define INIT_XFMARK { INIT_FMARK, NULL }
 
-/// Set fmark using given value
-static inline bool lt(pos_T a, pos_T b)
-  REAL_FATTR_CONST REAL_FATTR_ALWAYS_INLINE;
 /// Return true if position a is before (less than) position b.
 static inline bool lt(pos_T a, pos_T b)
+  FUNC_ATTR_CONST FUNC_ATTR_ALWAYS_INLINE
 {
   if (a.lnum != b.lnum) {
     return a.lnum < b.lnum;
@@ -100,25 +102,19 @@ static inline bool lt(pos_T a, pos_T b)
 }
 
 static inline bool equalpos(pos_T a, pos_T b)
-  REAL_FATTR_CONST REAL_FATTR_ALWAYS_INLINE;
-/// Return true if position a and b are equal.
-static inline bool equalpos(pos_T a, pos_T b)
+  FUNC_ATTR_CONST FUNC_ATTR_ALWAYS_INLINE
 {
   return (a.lnum == b.lnum) && (a.col == b.col) && (a.coladd == b.coladd);
 }
 
 static inline bool ltoreq(pos_T a, pos_T b)
-  REAL_FATTR_CONST REAL_FATTR_ALWAYS_INLINE;
-/// Return true if position a is less than or equal to b.
-static inline bool ltoreq(pos_T a, pos_T b)
+  FUNC_ATTR_CONST FUNC_ATTR_ALWAYS_INLINE
 {
   return lt(a, b) || equalpos(a, b);
 }
 
 static inline void clearpos(pos_T *a)
-  REAL_FATTR_ALWAYS_INLINE;
-/// Clear the pos_T structure pointed to by a.
-static inline void clearpos(pos_T *a)
+  FUNC_ATTR_ALWAYS_INLINE
 {
   a->lnum = 0;
   a->col = 0;

--- a/src/nvim/mbyte.h
+++ b/src/nvim/mbyte.h
@@ -7,13 +7,13 @@
 
 #include "nvim/cmdexpand_defs.h"  // IWYU pragma: keep
 #include "nvim/eval/typval_defs.h"  // IWYU pragma: keep
-#include "nvim/func_attr.h"
 #include "nvim/macros_defs.h"
 #include "nvim/mbyte_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "mbyte.h.generated.h"
+# include "mbyte.h.inline.generated.h"
 #endif
 
 enum {
@@ -53,17 +53,13 @@ extern const uint8_t utf8len_tab[256];
   (p -= utf_head_off((char *)(s), (char *)(p) - 1) + 1)
 
 /// Check whether a given UTF-8 byte is a trailing byte (10xx.xxxx).
-static inline bool utf_is_trail_byte(uint8_t byte)
-  REAL_FATTR_CONST REAL_FATTR_ALWAYS_INLINE;
 
 static inline bool utf_is_trail_byte(uint8_t const byte)
+  FUNC_ATTR_CONST FUNC_ATTR_ALWAYS_INLINE
 {
   // uint8_t is for clang to use smaller cmp
   return (uint8_t)(byte & 0xC0U) == 0x80U;
 }
-
-static inline CharInfo utf_ptr2CharInfo(char const *p_in)
-  REAL_FATTR_NONNULL_ALL REAL_FATTR_PURE REAL_FATTR_WARN_UNUSED_RESULT REAL_FATTR_ALWAYS_INLINE;
 
 /// Convert a UTF-8 byte sequence to a Unicode code point.
 /// Handles ascii, multibyte sequiences and illegal sequences.
@@ -73,6 +69,7 @@ static inline CharInfo utf_ptr2CharInfo(char const *p_in)
 /// @return information abouth the character. When the sequence is illegal,
 /// "value" is negative, "len" is 1.
 static inline CharInfo utf_ptr2CharInfo(char const *const p_in)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_ALWAYS_INLINE
 {
   uint8_t const *const p = (uint8_t const *)p_in;
   uint8_t const first = *p;
@@ -88,14 +85,12 @@ static inline CharInfo utf_ptr2CharInfo(char const *const p_in)
   }
 }
 
-static inline StrCharInfo utfc_next(StrCharInfo cur)
-  REAL_FATTR_NONNULL_ALL REAL_FATTR_ALWAYS_INLINE REAL_FATTR_PURE;
-
 /// Return information about the next character.
 /// Composing and combining characters are considered a part of the current character.
 ///
 /// @param[in] cur  Information about the current character in the string.
 static inline StrCharInfo utfc_next(StrCharInfo cur)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_PURE
 {
   int32_t prev_code = cur.chr.value;
   uint8_t *next = (uint8_t *)(cur.ptr + cur.chr.len);
@@ -122,9 +117,7 @@ static inline StrCharInfo utfc_next(StrCharInfo cur)
 }
 
 static inline StrCharInfo utf_ptr2StrCharInfo(char *ptr)
-  REAL_FATTR_NONNULL_ALL REAL_FATTR_ALWAYS_INLINE REAL_FATTR_PURE;
-
-static inline StrCharInfo utf_ptr2StrCharInfo(char *ptr)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_PURE
 {
   return (StrCharInfo){ .ptr = ptr, .chr = utf_ptr2CharInfo(ptr) };
 }

--- a/src/nvim/ops.h
+++ b/src/nvim/ops.h
@@ -7,7 +7,6 @@
 #include "nvim/eval/typval_defs.h"
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: keep
 #include "nvim/extmark_defs.h"  // IWYU pragma: keep
-#include "nvim/func_attr.h"
 #include "nvim/macros_defs.h"
 #include "nvim/normal_defs.h"
 #include "nvim/option_defs.h"  // IWYU pragma: keep
@@ -121,8 +120,10 @@ typedef enum {
   YREG_PUT,
 } yreg_mode_t;
 
-static inline int op_reg_index(int regname)
-  REAL_FATTR_CONST;
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "ops.h.generated.h"
+# include "ops.h.inline.generated.h"
+#endif
 
 /// Convert register name into register index
 ///
@@ -130,6 +131,7 @@ static inline int op_reg_index(int regname)
 ///
 /// @return Index in y_regs array or -1 if register name was not recognized.
 static inline int op_reg_index(const int regname)
+  FUNC_ATTR_CONST
 {
   if (ascii_isdigit(regname)) {
     return regname - '0';
@@ -148,19 +150,13 @@ static inline int op_reg_index(const int regname)
   }
 }
 
-static inline bool is_literal_register(int regname)
-  REAL_FATTR_CONST;
-
 /// @see get_yank_register
 /// @return  true when register should be inserted literally
 /// (selection or clipboard)
 static inline bool is_literal_register(const int regname)
+  FUNC_ATTR_CONST
 {
   return regname == '*' || regname == '+';
 }
-
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ops.h.generated.h"
-#endif
 
 EXTERN LuaRef repeat_luaref INIT( = LUA_NOREF);  ///< LuaRef for "."

--- a/src/nvim/os/fileio_defs.h
+++ b/src/nvim/os/fileio_defs.h
@@ -3,8 +3,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "nvim/func_attr.h"
-
 /// Structure used to read from/write to file
 typedef struct {
   int fd;             ///< File descriptor. Can be -1 if no backing file (file_open_buffer)
@@ -17,8 +15,9 @@ typedef struct {
   uint64_t bytes_read;  ///< total bytes read so far
 } FileDescriptor;
 
-static inline bool file_eof(const FileDescriptor *fp)
-  REAL_FATTR_ALWAYS_INLINE REAL_FATTR_WARN_UNUSED_RESULT REAL_FATTR_NONNULL_ALL;
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "os/fileio_defs.h.inline.generated.h"
+#endif
 
 /// Check whether end of file was encountered
 ///
@@ -27,12 +26,10 @@ static inline bool file_eof(const FileDescriptor *fp)
 /// @return true if it was, false if it was not or read operation was never
 ///         performed.
 static inline bool file_eof(const FileDescriptor *const fp)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
   return fp->eof && fp->read_pos == fp->write_pos;
 }
-
-static inline int file_fd(const FileDescriptor *fp)
-  REAL_FATTR_ALWAYS_INLINE REAL_FATTR_WARN_UNUSED_RESULT REAL_FATTR_NONNULL_ALL;
 
 /// Return the file descriptor associated with the FileDescriptor structure
 ///
@@ -40,6 +37,7 @@ static inline int file_fd(const FileDescriptor *fp)
 ///
 /// @return File descriptor.
 static inline int file_fd(const FileDescriptor *const fp)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_NONNULL_ALL
 {
   return fp->fd;
 }

--- a/src/nvim/plines.h
+++ b/src/nvim/plines.h
@@ -3,7 +3,6 @@
 #include <stdbool.h>
 #include <stdint.h>
 
-#include "nvim/func_attr.h"
 #include "nvim/marktree_defs.h"
 #include "nvim/pos_defs.h"
 #include "nvim/types_defs.h"
@@ -39,11 +38,8 @@ typedef struct {
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "plines.h.generated.h"
+# include "plines.h.inline.generated.h"
 #endif
-
-static inline CharSize win_charsize(CSType cstype, int vcol, char *ptr, int32_t chr,
-                                    CharsizeArg *csarg)
-  REAL_FATTR_NONNULL_ALL REAL_FATTR_WARN_UNUSED_RESULT REAL_FATTR_ALWAYS_INLINE;
 
 /// Get the number of cells taken up on the screen by the given character at vcol.
 /// "csarg->cur_text_width_left" and "csarg->cur_text_width_right" are set
@@ -55,6 +51,7 @@ static inline CharSize win_charsize(CSType cstype, int vcol, char *ptr, int32_t 
 /// of 'showbreak'/'breakindent' before where cursor should be placed.
 static inline CharSize win_charsize(CSType cstype, int vcol, char *ptr, int32_t chr,
                                     CharsizeArg *csarg)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_ALWAYS_INLINE
 {
   if (cstype == kCharsizeFast) {
     return charsize_fast(csarg, vcol, chr);
@@ -63,9 +60,6 @@ static inline CharSize win_charsize(CSType cstype, int vcol, char *ptr, int32_t 
   }
 }
 
-static inline int linetabsize_str(char *s)
-  REAL_FATTR_NONNULL_ALL REAL_FATTR_WARN_UNUSED_RESULT REAL_FATTR_ALWAYS_INLINE;
-
 /// Return the number of cells the string "s" will take on the screen,
 /// taking into account the size of a tab.
 ///
@@ -73,12 +67,10 @@ static inline int linetabsize_str(char *s)
 ///
 /// @return Number of cells the string will take on the screen.
 static inline int linetabsize_str(char *s)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_ALWAYS_INLINE
 {
   return linetabsize_col(0, s);
 }
-
-static inline int win_linetabsize(win_T *wp, linenr_T lnum, char *line, colnr_T len)
-  REAL_FATTR_NONNULL_ALL REAL_FATTR_WARN_UNUSED_RESULT REAL_FATTR_ALWAYS_INLINE;
 
 /// Like linetabsize_str(), but for a given window instead of the current one.
 ///
@@ -88,6 +80,7 @@ static inline int win_linetabsize(win_T *wp, linenr_T lnum, char *line, colnr_T 
 ///
 /// @return Number of cells the string will take on the screen.
 static inline int win_linetabsize(win_T *wp, linenr_T lnum, char *line, colnr_T len)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT FUNC_ATTR_ALWAYS_INLINE
 {
   CharsizeArg csarg;
   CSType const cstype = init_charsize_arg(&csarg, wp, lnum, line);

--- a/src/nvim/strings.h
+++ b/src/nvim/strings.h
@@ -7,28 +7,8 @@
 #include "klib/kvec.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/eval/typval_defs.h"  // IWYU pragma: keep
-#include "nvim/func_attr.h"
 #include "nvim/os/os_defs.h"
 #include "nvim/types_defs.h"  // IWYU pragma: keep
-
-static inline char *strappend(char *dst, const char *src)
-  REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ALL
-    REAL_FATTR_NONNULL_RET REAL_FATTR_WARN_UNUSED_RESULT;
-
-/// Append string to string and return pointer to the next byte
-///
-/// Unlike strcat, this one does *not* add NUL byte and returns pointer to the
-/// past of the added string.
-///
-/// @param[out]  dst  String to append to.
-/// @param[in]  src  String to append.
-///
-/// @return pointer to the byte just past the appended byte.
-static inline char *strappend(char *const dst, const char *const src)
-{
-  const size_t src_len = strlen(src);
-  return (char *)memmove(dst, src, src_len) + src_len;
-}
 
 typedef kvec_t(char) StringBuilder;
 
@@ -46,7 +26,25 @@ typedef struct {
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "strings.h.generated.h"
+# include "strings.h.inline.generated.h"
 #endif
+
+/// Append string to string and return pointer to the next byte
+///
+/// Unlike strcat, this one does *not* add NUL byte and returns pointer to the
+/// past of the added string.
+///
+/// @param[out]  dst  String to append to.
+/// @param[in]  src  String to append.
+///
+/// @return pointer to the byte just past the appended byte.
+static inline char *strappend(char *const dst, const char *const src)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_NONNULL_ALL
+    FUNC_ATTR_NONNULL_RET FUNC_ATTR_WARN_UNUSED_RESULT
+{
+  const size_t src_len = strlen(src);
+  return (char *)memmove(dst, src, src_len) + src_len;
+}
 
 #ifdef HAVE_STRCASECMP
 # define STRICMP(d, s)      strcasecmp((char *)(d), (char *)(s))

--- a/src/nvim/viml/parser/parser.h
+++ b/src/nvim/viml/parser/parser.h
@@ -5,13 +5,13 @@
 #include <stddef.h>
 
 #include "klib/kvec.h"
-#include "nvim/func_attr.h"
 #include "nvim/mbyte_defs.h"
 #include "nvim/viml/parser/parser_defs.h"  // IWYU pragma: keep
 
-static inline void viml_parser_init(ParserState *ret_pstate, ParserLineGetter get_line,
-                                    void *cookie, ParserHighlight *colors)
-  REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ARG(1, 2);
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "viml/parser/parser.h.generated.h"
+# include "viml/parser/parser.h.inline.generated.h"
+#endif
 
 /// Initialize a new parser state instance
 ///
@@ -22,6 +22,7 @@ static inline void viml_parser_init(ParserState *ret_pstate, ParserLineGetter ge
 ///                     needed.
 static inline void viml_parser_init(ParserState *const ret_pstate, const ParserLineGetter get_line,
                                     void *const cookie, ParserHighlight *const colors)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_NONNULL_ARG(1, 2)
 {
   *ret_pstate = (ParserState) {
     .reader = {
@@ -37,9 +38,6 @@ static inline void viml_parser_init(ParserState *const ret_pstate, const ParserL
   kvi_init(ret_pstate->stack);
 }
 
-static inline void viml_parser_advance(ParserState *pstate, size_t len)
-  REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ALL;
-
 /// Advance position by a given number of bytes
 ///
 /// At maximum advances to the next line.
@@ -47,6 +45,7 @@ static inline void viml_parser_advance(ParserState *pstate, size_t len)
 /// @param  pstate  Parser state to advance.
 /// @param[in]  len  Number of bytes to advance.
 static inline void viml_parser_advance(ParserState *const pstate, const size_t len)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_NONNULL_ALL
 {
   assert(pstate->pos.line == kv_size(pstate->reader.lines) - 1);
   const ParserLine pline = kv_last(pstate->reader.lines);
@@ -58,10 +57,6 @@ static inline void viml_parser_advance(ParserState *const pstate, const size_t l
   }
 }
 
-static inline void viml_parser_highlight(ParserState *pstate, ParserPosition start, size_t len,
-                                         const char *group)
-  REAL_FATTR_ALWAYS_INLINE REAL_FATTR_NONNULL_ALL;
-
 /// Record highlighting of some region of text
 ///
 /// @param  pstate  Parser state to work with.
@@ -70,6 +65,7 @@ static inline void viml_parser_highlight(ParserState *pstate, ParserPosition sta
 /// @param[in]  group  Highlight group.
 static inline void viml_parser_highlight(ParserState *const pstate, const ParserPosition start,
                                          const size_t len, const char *const group)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_NONNULL_ALL
 {
   if (pstate->colors == NULL || len == 0) {
     return;
@@ -83,7 +79,3 @@ static inline void viml_parser_highlight(ParserState *const pstate, const Parser
     .group = group,
   }));
 }
-
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "viml/parser/parser.h.generated.h"
-#endif

--- a/test/unit/formatc.lua
+++ b/test/unit/formatc.lua
@@ -264,6 +264,7 @@ local function formatc(str)
         -- and ';' indicates we're at the end of a statement, so we put end
         -- it with a newline.
         token[1] = ';\n'
+        end_at_brace = false
       end
     elseif typ == 'whitespace' then
       -- replace all whitespace by one space


### PR DESCRIPTION
Before this change, "static inline" functions in headers needed to have their function attributes specified in a completely different and weird way. The prototype had to be duplicated, and REAL_FATTR_ had to be used instead of the public FUNC_ATTR_ names.

need a check that a "header.h.inline.generated.h" file is not forgotten when the first "static inline" function with attributes is added to a header (they would just be silently missing). (done)