### PR TITLE
vim-patch:1487947: runtime(netrw): glob() on windows fails with [] in directory name

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -14,6 +14,7 @@
 "   2024 May 10 by Vim Project: recursively delete directories by default
 "   2024 May 13 by Vim Project: prefer scp over pscp
 "   2024 Jun 04 by Vim Project: set bufhidden if buffer changed, nohidden is set and buffer shall be switched (#14915)
+"   2024 Jun 13 by Vim Project: glob() on Windows fails when a directory name contains [] (#14952)
 " Former Maintainer:	Charles E Campbell
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
 " Copyright:    Copyright (C) 2016 Charles E. Campbell {{{1
@@ -5756,16 +5757,20 @@ fun! s:NetrwGlob(direntry,expr,pare)
     let filelist= w:netrw_treedict[a:direntry]
    endif
    let w:netrw_liststyle= keep_liststyle
-  elseif v:version > 704 || (v:version == 704 && has("patch656"))
-   let filelist= glob(s:ComposePath(fnameescape(a:direntry),a:expr),0,1,1)
-   if a:pare
-    let filelist= map(filelist,'substitute(v:val, "^.*/", "", "")')
-   endif
   else
-   let filelist= glob(s:ComposePath(fnameescape(a:direntry),a:expr),0,1)
-   if a:pare
-    let filelist= map(filelist,'substitute(v:val, "^.*/", "", "")')
-   endif
+   let path= s:ComposePath(fnameescape(a:direntry),a:expr) 
+    if has("win64")
+     " escape [ so it is not detected as wildcard character, see :h wildcard
+     let path= substitute(path, '[', '[[]', 'g')
+    endif
+    if v:version > 704 || (v:version == 704 && has("patch656"))
+     let filelist= glob(path,0,1,1)
+    else
+     let filelist= glob(path,0,1)
+    endif
+    if a:pare
+     let filelist= map(filelist,'substitute(v:val, "^.*/", "", "")')
+    endif
   endif
 "  call Dret("s:NetrwGlob ".string(filelist))
   return filelist


### PR DESCRIPTION
#### vim-patch:1487947: runtime(netrw): glob() on windows fails with [] in directory name

closes: vim/vim#14991

https://github.com/vim/vim/commit/1487947fb625d44ed02382ea6b0d5bf72b12583a

Co-authored-by: Christian Brabandt <cb@256bit.org>