### PR TITLE
vim-patch:4407461: runtime(netrw): correctly test for windows in NetrwGlob()

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -5759,7 +5759,7 @@ fun! s:NetrwGlob(direntry,expr,pare)
    let w:netrw_liststyle= keep_liststyle
   else
    let path= s:ComposePath(fnameescape(a:direntry),a:expr) 
-    if has("win64")
+    if has("win32")
      " escape [ so it is not detected as wildcard character, see :h wildcard
      let path= substitute(path, '[', '[[]', 'g')
     endif


### PR DESCRIPTION
#### vim-patch:4407461: runtime(netrw): correctly test for windows in NetrwGlob()

use has("win32") instead of has("win64") otherwise it
won't work on x86 systems.

https://github.com/vim/vim/commit/440746158ce0fec2880ccacc03f39dbc954c5543

Co-authored-by: Christian Brabandt <cb@256bit.org>