### PR TITLE
fix(lsp): tune completion word extraction for decorated labels

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -145,8 +145,8 @@ local function get_completion_word(item)
       --    label: insert
       --
       -- Typing `i` would remove the candidate because newText starts with `t`.
-      local text = item.insertText or item.textEdit.newText
-      return #text < #item.label and text or item.label
+      local text = parse_snippet(item.insertText or item.textEdit.newText)
+      return #text < #item.label and vim.fn.matchstr(text, '\\k*') or item.label
     elseif item.insertText and item.insertText ~= '' then
       return parse_snippet(item.insertText)
     else

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -81,9 +81,20 @@ describe('vim.lsp.completion: item conversion', function()
       -- plain text
       {
         label = 'foocar',
-        sortText = 'k',
+        sortText = 'g',
         insertText = 'foodar(${1:var1})',
         insertTextFormat = 1,
+      },
+      {
+        label = '•INT16_C(c)',
+        insertText = 'INT16_C(${1:c})',
+        insertTextFormat = 2,
+        filterText = 'INT16_C',
+        sortText = 'h',
+        textEdit = {
+          newText = 'INT16_C(${1:c})',
+          range = range0,
+        },
       },
     }
     local expected = {
@@ -114,6 +125,10 @@ describe('vim.lsp.completion: item conversion', function()
       {
         abbr = 'foocar',
         word = 'foodar(${1:var1})', -- marked as PlainText, text is used as is
+      },
+      {
+        abbr = '•INT16_C(c)',
+        word = 'INT16_C',
       },
     }
     local result = complete('|', completion_list)


### PR DESCRIPTION
Problem:

For snippets lsp.completion prefers the label if it is shorter than the
insertText or textEdit to support postfix completion cases but clangd
adds decoration characters to labels. E.g.: `•INT16_C(c)`

Solution:

Use parse_snippet on insertText/textEdit before checking if it is
shorter than the label.

Fixes https://github.com/neovim/neovim/issues/29301
