### PR TITLE
vim-patch:79a14c0: runtime(keymap): include Georgian keymap

### DIFF
--- a/runtime/keymap/georgian-qwerty.vim
+++ b/runtime/keymap/georgian-qwerty.vim
@@ -1,0 +1,51 @@
+" Vim keymap file for Georgian (Mkhedruli) layout
+" Maintainer: Mishiko Okropiridze <misho.okropiridze@gmail.com>
+" Last changed: 2024-06-14
+
+
+let b:keymap_name = "ge"
+
+loadkeymap
+a ა
+A ა
+b ბ
+c ც
+C ჩ
+d დ
+e ე
+E ე
+f ფ
+F ფ
+g გ
+G გ
+h ჰ
+H ჵ
+i ი
+I ი
+j ჯ
+J ჟ
+k კ
+l ლ
+m მ
+n ნ
+o ო
+p პ
+q ქ
+Q ქ
+r რ
+R ღ
+s ს
+S შ
+t ტ
+T თ
+u უ
+v ვ
+V ვ
+w წ
+W ჭ
+x ხ
+X ხ
+y ყ
+Y ყ
+z ზ
+Z ძ


### PR DESCRIPTION
closes: vim/vim#15002

https://github.com/vim/vim/commit/79a14c061bb7c5caafba09b9244f87be37693cf6

Co-authored-by: Misho <nnamper@gmail.com>
