### PR TITLE
vim-patch:a3bddb7,d6d4e13,262e25e,c509c00

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4997,9 +4997,9 @@ mkdir({name} [, {flags} [, {prot}]])                              *mkdir()* *E73
 		{flags} can contain these character flags:
 		 "p"	intermediate directories will be created as necessary
 		 "D"	{name} will be deleted at the end of the current
-			function, but not recursively |defer|
+			function, but not recursively |:defer|
 		 "R"	{name} will be deleted recursively at the end of the
-			current function |defer|
+			current function |:defer|
 
 		Note that when {name} has more than one part and "p" is used
 		some directories may already exist.  Only the first one that

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4994,17 +4994,14 @@ mkdir({name} [, {flags} [, {prot}]])                              *mkdir()* *E73
 		When {flags} is present it must be a string.  An empty string
 		has no effect.
 
-		If {flags} contains "p" then intermediate directories are
-		created as necessary.
+		{flags} can contain these character flags:
+		 "p"	intermediate directories will be created as necessary
+		 "D"	{name} will be deleted at the end of the current
+			function, but not recursively |defer|
+		 "R"	{name} will be deleted recursively at the end of the
+			current function |defer|
 
-		If {flags} contains "D" then {name} is deleted at the end of
-		the current function, as with: >vim
-			defer delete({name}, 'd')
-<
-		If {flags} contains "R" then {name} is deleted recursively at
-		the end of the current function, as with: >vim
-			defer delete({name}, 'rf')
-<		Note that when {name} has more than one part and "p" is used
+		Note that when {name} has more than one part and "p" is used
 		some directories may already exist.  Only the first one that
 		is created and what it contains is scheduled to be deleted.
 		E.g. when using: >vim

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -6007,17 +6007,14 @@ function vim.fn.min(expr) end
 --- When {flags} is present it must be a string.  An empty string
 --- has no effect.
 ---
---- If {flags} contains "p" then intermediate directories are
---- created as necessary.
+--- {flags} can contain these character flags:
+---  "p"  intermediate directories will be created as necessary
+---  "D"  {name} will be deleted at the end of the current
+---   function, but not recursively |defer|
+---  "R"  {name} will be deleted recursively at the end of the
+---   current function |defer|
 ---
---- If {flags} contains "D" then {name} is deleted at the end of
---- the current function, as with: >vim
----   defer delete({name}, 'd')
---- <
---- If {flags} contains "R" then {name} is deleted recursively at
---- the end of the current function, as with: >vim
----   defer delete({name}, 'rf')
---- <Note that when {name} has more than one part and "p" is used
+--- Note that when {name} has more than one part and "p" is used
 --- some directories may already exist.  Only the first one that
 --- is created and what it contains is scheduled to be deleted.
 --- E.g. when using: >vim

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -6010,9 +6010,9 @@ function vim.fn.min(expr) end
 --- {flags} can contain these character flags:
 ---  "p"  intermediate directories will be created as necessary
 ---  "D"  {name} will be deleted at the end of the current
----   function, but not recursively |defer|
+---   function, but not recursively |:defer|
 ---  "R"  {name} will be deleted recursively at the end of the
----   current function |defer|
+---   current function |:defer|
 ---
 --- Note that when {name} has more than one part and "p" is used
 --- some directories may already exist.  Only the first one that

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -60,9 +60,9 @@ syn case ignore
 syn keyword vimGroup contained	Comment Constant String Character Number Boolean Float Identifier Function Statement Conditional Repeat Label Operator Keyword Exception PreProc Include Define Macro PreCondit Type StorageClass Structure Typedef Special SpecialChar Tag Delimiter SpecialComment Debug Underlined Ignore Error Todo
 
 " Default highlighting groups {{{2
-syn keyword vimHLGroup contained ErrorMsg IncSearch ModeMsg NonText StatusLine StatusLineNC EndOfBuffer VertSplit DiffText PmenuSbar TabLineSel TabLineFill Cursor lCursor QuickFixLine CursorLineSign CursorLineFold CurSearch PmenuKind PmenuKindSel PmenuExtra PmenuExtraSel Normal Directory LineNr CursorLineNr MoreMsg Question Search SpellBad SpellCap SpellRare SpellLocal PmenuThumb Pmenu PmenuSel SpecialKey Title WarningMsg WildMenu Folded FoldColumn SignColumn Visual DiffAdd DiffChange DiffDelete TabLine CursorColumn CursorLine ColorColumn MatchParen CursorIM LineNrAbove LineNrBelow
+syn keyword vimHLGroup contained ErrorMsg IncSearch ModeMsg NonText StatusLine StatusLineNC EndOfBuffer VertSplit DiffText PmenuSbar TabLineSel TabLineFill Cursor lCursor QuickFixLine CursorLineSign CursorLineFold CurSearch PmenuKind PmenuKindSel PmenuMatch PmenuMatchSel PmenuExtra PmenuExtraSel Normal Directory LineNr CursorLineNr MoreMsg Question Search SpellBad SpellCap SpellRare SpellLocal PmenuThumb Pmenu PmenuSel SpecialKey Title WarningMsg WildMenu Folded FoldColumn SignColumn Visual DiffAdd DiffChange DiffDelete TabLine CursorColumn CursorLine ColorColumn MatchParen StatusLineTerm StatusLineTermNC CursorIM LineNrAbove LineNrBelow
 syn match vimHLGroup contained "\<Conceal\>"
-syn keyword vimOnlyHLGroup contained	Menu Scrollbar StatusLineTerm StatusLineTermNC ToolbarButton ToolbarLine Tooltip VisualNOS
+syn keyword vimOnlyHLGroup contained	Menu Scrollbar ToolbarButton ToolbarLine Tooltip VisualNOS
 syn keyword nvimHLGroup contained	FloatBorder FloatFooter FloatTitle MsgSeparator NormalFloat NormalNC Substitute TermCursor TermCursorNC VisualNC Whitespace WinBar WinBarNC WinSeparator
 "}}}2
 syn case match
@@ -165,7 +165,7 @@ syn match	vimNumber	'\%(^\|\A\)\zs#\x\{6}'		skipwhite nextgroup=vimGlobal,vimSub
 syn case match
 
 " All vimCommands are contained by vimIsCommand. {{{2
-syn cluster vimCmdList	contains=vimAbb,vimAddress,vimAutoCmd,vimAugroup,vimBehave,vimDef,@vimEcho,vimEnddef,vimEndfunction,vimExecute,vimIsCommand,vimExtCmd,vimFor,vimFunction,vimGlobal,vimHighlight,vimLet,vimMap,vimMark,vimNotFunc,vimNorm,vimSet,vimSyntax,vimUnlet,vimUnmap,vimUserCmd,vimMenu,vimMenutranslate
+syn cluster vimCmdList	contains=vimAbb,vimAddress,vimAutoCmd,vimAugroup,vimBehave,vimCatch,vimDef,@vimEcho,vimEnddef,vimEndfunction,vimExecute,vimIsCommand,vimExtCmd,vimFor,vimFunction,vimGlobal,vimHighlight,vimLet,vimMap,vimMark,vimNotFunc,vimNorm,vimSet,vimSyntax,vimThrow,vimUnlet,vimUnmap,vimUserCmd,vimMenu,vimMenutranslate
 syn match vimCmdSep	"[:|]\+"	skipwhite nextgroup=@vimCmdList,vimSubst1
 syn match vimIsCommand	"\<\%(\h\w*\|[23]mat\%[ch]\)\>"	contains=vimCommand
 syn match vimVar	      contained	"\<\h[a-zA-Z0-9#_]*\>"
@@ -195,6 +195,11 @@ endif
 syn match   vimBehave	"\<be\%[have]\>"	nextgroup=vimBehaveBang,vimBehaveModel,vimBehaveError skipwhite
 syn match   vimBehaveBang	contained	"\a\@1<=!" nextgroup=vimBehaveModel skipwhite
 syn keyword vimBehaveModel	contained	mswin	xterm
+
+" Exception Handling {{{2
+syn keyword	vimThrow	th[row]	skipwhite nextgroup=@vimExprList
+syn keyword	vimCatch	cat[ch]	skipwhite nextgroup=vimCatchPattern
+syn region	vimCatchPattern	contained	matchgroup=Delimiter start="\z([!#$%&'()*+,-./:;<=>?@[\]^_`{}~]\)" skip="\\\\\|\\\z1" end="\z1" contains=@vimSubstList oneline
 
 " Filetypes {{{2
 " =========
@@ -1067,6 +1072,7 @@ if !exists("skip_vim_syntax_inits")
  hi def link vimBehaveModel	vimBehave
  hi def link vimBehave	vimCommand
  hi def link vimBracket	Delimiter
+ hi def link vimCatch	vimCommand
  hi def link vimCmplxRepeat	SpecialChar
  hi def link vimCommand	Statement
  hi def link vimComment	Comment
@@ -1224,6 +1230,7 @@ if !exists("skip_vim_syntax_inits")
  hi def link vimSynReg	Type
  hi def link vimSyntax	vimCommand
  hi def link vimSynType	vimSpecial
+ hi def link vimThrow	vimCommand
  hi def link vimTodo	Todo
  hi def link vimType	Type
  hi def link vimUnlet	vimCommand

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -165,7 +165,7 @@ syn match	vimNumber	'\%(^\|\A\)\zs#\x\{6}'		skipwhite nextgroup=vimGlobal,vimSub
 syn case match
 
 " All vimCommands are contained by vimIsCommand. {{{2
-syn cluster vimCmdList	contains=vimAbb,vimAddress,vimAutoCmd,vimAugroup,vimBehave,vimCatch,vimDef,@vimEcho,vimEnddef,vimEndfunction,vimExecute,vimIsCommand,vimExtCmd,vimFor,vimFunction,vimGlobal,vimHighlight,vimLet,vimMap,vimMark,vimNotFunc,vimNorm,vimSet,vimSyntax,vimThrow,vimUnlet,vimUnmap,vimUserCmd,vimMenu,vimMenutranslate
+syn cluster vimCmdList	contains=vimAbb,vimAddress,vimAutoCmd,vimAugroup,vimBehave,vimCatch,vimDef,@vimEcho,vimEnddef,vimEndfunction,vimExecute,vimIsCommand,vimExtCmd,vimFor,vimFunction,vimGlobal,vimHighlight,vimLet,vimMap,vimMark,vimNotFunc,vimNorm,vimSet,vimSleep,vimSyntax,vimThrow,vimUnlet,vimUnmap,vimUserCmd,vimMenu,vimMenutranslate
 syn match vimCmdSep	"[:|]\+"	skipwhite nextgroup=@vimCmdList,vimSubst1
 syn match vimIsCommand	"\<\%(\h\w*\|[23]mat\%[ch]\)\>"	contains=vimCommand
 syn match vimVar	      contained	"\<\h[a-zA-Z0-9#_]*\>"
@@ -646,6 +646,12 @@ syn match vimNotFunc	"\<if\>\|\<el\%[seif]\>\|\<retu\%[rn]\>\|\<while\>"	skipwhi
 " ====
 syn match	vimNorm		"\<norm\%[al]!\=" skipwhite nextgroup=vimNormCmds
 syn match	vimNormCmds contained	".*$"
+
+" Sleep: {{{2
+" =====
+syn keyword	vimSleep		sl[eep]		skipwhite nextgroup=vimSleepBang,vimSleepArg
+syn match	vimSleepBang	contained	"\a\@1<=!"		skipwhite nextgroup=vimSleepArg
+syn match	vimSleepArg	contained	"\<\%(\d\+\)\=m\=\>"
 
 " Syntax: {{{2
 "=======
@@ -1190,6 +1196,9 @@ if !exists("skip_vim_syntax_inits")
  hi def link vimSetSep	Statement
  hi def link vimSetString	vimString
  hi def link vim9Vim9Script	vimCommand
+ hi def link vimSleep	vimCommand
+ hi def link vimSleepArg	Constant
+ hi def link vimSleepBang	vimBang
  hi def link vimSpecFile	Identifier
  hi def link vimSpecFileMod	vimSpecFile
  hi def link vimSpecial	Type

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -7267,9 +7267,9 @@ M.funcs = {
       {flags} can contain these character flags:
        "p"	intermediate directories will be created as necessary
        "D"	{name} will be deleted at the end of the current
-      	function, but not recursively |defer|
+      	function, but not recursively |:defer|
        "R"	{name} will be deleted recursively at the end of the
-      	current function |defer|
+      	current function |:defer|
 
       Note that when {name} has more than one part and "p" is used
       some directories may already exist.  Only the first one that

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -7264,17 +7264,14 @@ M.funcs = {
       When {flags} is present it must be a string.  An empty string
       has no effect.
 
-      If {flags} contains "p" then intermediate directories are
-      created as necessary.
+      {flags} can contain these character flags:
+       "p"	intermediate directories will be created as necessary
+       "D"	{name} will be deleted at the end of the current
+      	function, but not recursively |defer|
+       "R"	{name} will be deleted recursively at the end of the
+      	current function |defer|
 
-      If {flags} contains "D" then {name} is deleted at the end of
-      the current function, as with: >vim
-      	defer delete({name}, 'd')
-      <
-      If {flags} contains "R" then {name} is deleted recursively at
-      the end of the current function, as with: >vim
-      	defer delete({name}, 'rf')
-      <Note that when {name} has more than one part and "p" is used
+      Note that when {name} has more than one part and "p" is used
       some directories may already exist.  Only the first one that
       is created and what it contains is scheduled to be deleted.
       E.g. when using: >vim


### PR DESCRIPTION
#### vim-patch:a3bddb7: runtime(vim): Update base-syntax, match :catch and :throw args (vim/vim#14989)

Match :catch /{pattern}/ and :throw {expr1}.

https://github.com/vim/vim/commit/a3bddb759e77c52431a93a68674790dd02647cd1

Co-authored-by: dkearns <dougkearns@gmail.com>


#### vim-patch:d6d4e13: runtime(doc): rewrite mkdir() doc and simplify {flags} meaning

related: vim/vim#14991

https://github.com/vim/vim/commit/d6d4e1333659c0d2acee3133819498d014df47de

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:262e25e: runtime(vim): Update base-syntax, match :sleep arg

Match :sleep arg properly including a lone "m" with a leading count.

closes: vim/vim#15003

https://github.com/vim/vim/commit/262e25e5a10438770dc9e23e0d5ffcb116f05d0f

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:c509c00: runtime(doc): fix wrong helptag for :defer

https://github.com/vim/vim/commit/c509c009bbc07eff678a9239a5813398e180f019

Co-authored-by: Christian Brabandt <cb@256bit.org>