### PR TITLE
feat(snippet): support multiple sessions

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -89,12 +89,7 @@ HIGHLIGHTS
 
 LSP
 
-• LSP capabilities:
-  • `textDocument/foo` …
-    https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_codeLens
-  • `textDocument/bar` …
-    https://microsoft.github.io/language-server-protocol/specification/#textDocument_colorPresentation
-• todo
+• Support for nested snippets.
 
 LUA
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -89,6 +89,11 @@ HIGHLIGHTS
 
 LSP
 
+• LSP capabilities:
+  • `textDocument/foo` …
+    https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_codeLens
+  • `textDocument/bar` …
+    https://microsoft.github.io/language-server-protocol/specification/#textDocument_colorPresentation
 • Support for nested snippets.
 
 LUA

--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -305,7 +305,7 @@ function Session:set_gravity()
   end
 end
 
-local M = { session = nil }
+local M = { _sessions = {} }
 
 --- Displays the choices for the given tabstop as completion items.
 ---
@@ -595,6 +595,7 @@ function M.expand(input)
     end_right_gravity = true,
   })
   M._session = Session.new(bufnr, snippet_extmark, tabstop_data)
+  table.insert(M._sessions, M._session)
 
   -- Jump to the first tabstop.
   M.jump(1)
@@ -678,10 +679,13 @@ function M.stop()
     return
   end
 
-  vim.api.nvim_clear_autocmds({ group = snippet_group, buf = M._session.bufnr })
-  vim.api.nvim_buf_clear_namespace(M._session.bufnr, snippet_ns, 0, -1)
+  if #M._sessions == 1 then
+    vim.api.nvim_clear_autocmds({ group = snippet_group, buffer = M._session.bufnr })
+    vim.api.nvim_buf_clear_namespace(M._session.bufnr, snippet_ns, 0, -1)
+  end
 
-  M._session = nil
+  table.remove(M._sessions)
+  M._session = #M._sessions > 0 and M._sessions[#M._sessions] or nil
 end
 
 return M

--- a/test/functional/lua/snippet_spec.lua
+++ b/test/functional/lua/snippet_spec.lua
@@ -403,4 +403,18 @@ describe('vim.snippet', function()
     feed('foo')
     eq({ '口口function(foo)' }, buf_lines(0))
   end)
+
+  it('supports multiple snippet sessions', function()
+    test_expand_success({ 'func $1($3) {', '  $2', '}' }, { 'func () {', '  ', '}' })
+
+    feed('foo<Tab>')
+
+    test_expand_success({ 'var x = $1 + $2' }, { 'func foo() {', '  var x =  + ', '}' })
+
+    feed('a<Tab>b')
+
+    feed('<Tab><Tab>a, b')
+
+    eq({ 'func foo(a, b) {', '  var x = a + b', '}' }, buf_lines(0))
+  end)
 end)


### PR DESCRIPTION
Part of https://github.com/neovim/neovim/issues/25696

Had kept this as a draft because the dynamic behavior of the snippet navigation keymaps was making this behavior not actually work. But now that [those are permanently set](https://github.com/neovim/neovim/pull/31887) the changes here are much simpler and the unit test passes now.

After a rebase this PR is basically the same as https://github.com/neovim/neovim/pull/38746, so credits to @notfirefox as well. 