### PR TITLE
vim-patch:9.1.0487: completed item not update on fuzzy completion

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1162,6 +1162,7 @@ static int ins_compl_build_pum(void)
   // Need to build the popup menu list.
   compl_match_arraysize = 0;
   compl_T *comp = compl_first_match;
+  compl_T *after_first_compl = NULL;
 
   // If it's user complete function and refresh_always,
   // do not use "compl_leader" as prefix filter.
@@ -1230,6 +1231,9 @@ static int ins_compl_build_pum(void)
         }
         cur = i;
       } else if (compl_fuzzy_match) {
+        if (i == 0) {
+          after_first_compl = comp;
+        }
         // Update the maximum fuzzy score and the shown match
         // if the current item's score is higher
         if (comp->cp_score > max_fuzzy_score) {
@@ -1248,6 +1252,9 @@ static int ins_compl_build_pum(void)
                 || (compl_leader == NULL || lead_len == 0))) {
           shown_match_ok = true;
           cur = 0;
+          if (match_at_original_text(compl_shown_match)) {
+            compl_shown_match = after_first_compl;
+          }
         }
       }
 

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2620,6 +2620,13 @@ func Test_complete_fuzzy_match()
   call feedkeys("S\<C-x>\<C-o>fb\<C-p>\<C-p>\<C-p>\<C-p>", 'tx')
   call assert_equal('fooBaz', g:word)
 
+  func Comp()
+    call complete(col('.'), ["fooBaz", "foobar", "foobala"])
+    return ''
+  endfunc
+  call feedkeys("i\<C-R>=Comp()\<CR>", 'tx')
+  call assert_equal('fooBaz', g:word)
+
   " respect noselect
   set completeopt+=noselect
   call feedkeys("S\<C-x>\<C-o>fb", 'tx')
@@ -2635,6 +2642,7 @@ func Test_complete_fuzzy_match()
   augroup! AAAAA_Group
   delfunc OnPumChange
   delfunc Omni_test
+  delfunc Comp
   unlet g:item
   unlet g:word
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.0487: completed item not update on fuzzy completion

Problem:  completed item not update on fuzzy completion
Solution: reset compl_shown_match when at original match position
          (glepnir)

closes: vim/vim#14955

https://github.com/vim/vim/commit/f94c9c482a6dd488f0136ac99499eb6e2ab3ccca

Co-authored-by: glepnir <glephunter@gmail.com>