### PR TITLE
fix(defaults): default @/Q broken when 'ignorecase' is set

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -85,13 +85,13 @@ do
   vim.keymap.set(
     'x',
     'Q',
-    "mode() == 'V' ? ':normal! @<C-R>=reg_recorded()<CR><CR>' : 'Q'",
+    "mode() ==# 'V' ? ':normal! @<C-R>=reg_recorded()<CR><CR>' : 'Q'",
     { silent = true, expr = true, desc = ':help v_Q-default' }
   )
   vim.keymap.set(
     'x',
     '@',
-    "mode() == 'V' ? ':normal! @'.getcharstr().'<CR>' : '@'",
+    "mode() ==# 'V' ? ':normal! @'.getcharstr().'<CR>' : '@'",
     { silent = true, expr = true, desc = ':help v_@-default' }
   )
 

--- a/test/functional/editor/macro_spec.lua
+++ b/test/functional/editor/macro_spec.lua
@@ -148,6 +148,23 @@ helloFOO]]
     eq({ 0, 1, 1, 0 }, fn.getpos('v'))
   end)
 
+  it('can be recorded and replayed in Visual mode when ignorecase', function()
+    command('set ignorecase')
+    insert('foo BAR BAR foo BAR foo BAR BAR BAR foo BAR BAR')
+    feed('0vqifofRq')
+    eq({ 0, 1, 7, 0 }, fn.getpos('.'))
+    eq({ 0, 1, 1, 0 }, fn.getpos('v'))
+    feed('Q')
+    eq({ 0, 1, 19, 0 }, fn.getpos('.'))
+    eq({ 0, 1, 1, 0 }, fn.getpos('v'))
+    feed('Q')
+    eq({ 0, 1, 27, 0 }, fn.getpos('.'))
+    eq({ 0, 1, 1, 0 }, fn.getpos('v'))
+    feed('@i')
+    eq({ 0, 1, 43, 0 }, fn.getpos('.'))
+    eq({ 0, 1, 1, 0 }, fn.getpos('v'))
+  end)
+
   it('can be replayed with @ in blockwise Visual mode', function()
     insert [[
 hello


### PR DESCRIPTION
**Problem:**
When 'ignorecase' is set, the default keymap Q and Q would exit visual
mode.

This issue was raised in #28287 and a fix was applied in #28289.

However, `==` operator is subject to user `ignorecase` setting.

**Solution:**
Switching to `==#` operator would guarantee case sensitive comparison
between visual mode and linewise visual mode.
