### PR TITLE
vim-patch:9.1.0488: Wrong padding for pum "kind" with 'rightleft'

### DIFF
--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -713,7 +713,7 @@ void pum_redraw(void)
 
       if (pum_rl) {
         grid_line_fill(col_off - pum_base_width - n + 1, grid_col + 1, schar_from_ascii(' '), attr);
-        grid_col = col_off - pum_base_width - n + 1;
+        grid_col = col_off - pum_base_width - n;
       } else {
         grid_line_fill(grid_col, col_off + pum_base_width + n, schar_from_ascii(' '), attr);
         grid_col = col_off + pum_base_width + n;

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -4664,10 +4664,10 @@ describe('builtin popupmenu', function()
         feed('S<C-X><C-O>')
         screen:expect([[
                                          ^ |
-          {1:               }{s:  dnikoof     oof}|
-          {1:               }{n:  dnikoof  raboof}|
-          {1:               }{n:  dnikoof  zaBoof}|
-          {1:               }{n:  dnikoof alaboof}|
+          {1:               }{s: dnikoof      oof}|
+          {1:               }{n: dnikoof   raboof}|
+          {1:               }{n: dnikoof   zaBoof}|
+          {1:               }{n: dnikoof  alaboof}|
           {1:               }{n:             好你}|
           {1:               }{n:           吗好你}|
           {1:               }{n:         吗好不你}|
@@ -4678,10 +4678,10 @@ describe('builtin popupmenu', function()
         feed('fo')
         screen:expect([[
                                        ^ of|
-          {1:                }{s:  dnikoof    o}{ms:of}|
-          {1:                }{n:  dnikoof rabo}{mn:of}|
-          {1:                }{n:  dnikoof zaBo}{mn:of}|
-          {1:                }{n:  dnikoofalabo}{mn:of}|
+          {1:                }{s: dnikoof     o}{ms:of}|
+          {1:                }{n: dnikoof  rabo}{mn:of}|
+          {1:                }{n: dnikoof  zaBo}{mn:of}|
+          {1:                }{n: dnikoof alabo}{mn:of}|
           {1:                               ~}|*14
           {2:-- }{5:match 1 of 8}                 |
         ]])


### PR DESCRIPTION
#### vim-patch:9.1.0488: Wrong padding for pum "kind" with 'rightleft'

Problem:  Wrong padding for pum "kind" with 'rightleft'.
Solution: Fix off-by-one error (zeertzjq).

The screen_fill() above is end-exclusive, and
- With 'rightleft' it fills `pum_col - pum_base_width - n + 1` to `col`,
  so the next `col` should be `pum_col - pum_base_width - n`.
- With 'norightleft' it fills `col` to `pum_col - pum_base_width + n - 1`,
  so the next `col` should be `pum_col - pum_base_width + n`.

closes: vim/vim#15004

https://github.com/vim/vim/commit/a2324373eb1c3f1777bc40cb6dcd5e895a15fe10