### PR TITLE
vim-patch:9.1.0490: minor style problems with patch 9.1.0487

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1162,7 +1162,6 @@ static int ins_compl_build_pum(void)
   // Need to build the popup menu list.
   compl_match_arraysize = 0;
   compl_T *comp = compl_first_match;
-  compl_T *after_first_compl = NULL;
 
   // If it's user complete function and refresh_always,
   // do not use "compl_leader" as prefix filter.
@@ -1232,7 +1231,7 @@ static int ins_compl_build_pum(void)
         cur = i;
       } else if (compl_fuzzy_match) {
         if (i == 0) {
-          after_first_compl = comp;
+          shown_compl = comp;
         }
         // Update the maximum fuzzy score and the shown match
         // if the current item's score is higher
@@ -1253,7 +1252,7 @@ static int ins_compl_build_pum(void)
           shown_match_ok = true;
           cur = 0;
           if (match_at_original_text(compl_shown_match)) {
-            compl_shown_match = after_first_compl;
+            compl_shown_match = shown_compl;
           }
         }
       }


### PR DESCRIPTION
#### vim-patch:9.1.0490: minor style problems with patch 9.1.0487

Problem:  minor style problems with patch 9.1.0487
Solution: use shown_compl instead of after_first_compl variable
          (glepnir)

closes: vim/vim#15008

fix(completion): use exist shown_compl instead after_first_compl

https://github.com/vim/vim/commit/105f741fac1b3242909c3c69384f00e4dcd9356e

Co-authored-by: glepnir <glephunter@gmail.com>