### PR TITLE
vim-patch:f4bc59c: runtime(doc): add another tag for vim-shebang feature

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -140,7 +140,7 @@ gx			Opens the current filepath or URL (decided by
 :[range]# [count] [flags]
 			synonym for :number.
 
-							*:#!*
+							*:#!* *vim-shebang*
 :#!{anything}		Ignored, so that you can start a Vim script with: >
 				#!vim -S
 				echo "this is a Vim script"


### PR DESCRIPTION
#### vim-patch:f4bc59c: runtime(doc): add another tag for vim-shebang feature

related: vim/vim#15011

https://github.com/vim/vim/commit/f4bc59c4f67786e967db48e944c2cce2c0da8dc1

Co-authored-by: Christian Brabandt <cb@256bit.org>