### PR TITLE
vim-patch:9.1.0489: default completion may break with fuzzy

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3698,16 +3698,16 @@ static int find_next_completion_match(bool allow_get_expansion, int todo, bool a
 
   while (--todo >= 0) {
     if (compl_shows_dir_forward() && compl_shown_match->cp_next != NULL) {
-      compl_shown_match = !compl_fuzzy_match ? compl_shown_match->cp_next
-                                             : find_comp_when_fuzzy();
+      compl_shown_match = compl_fuzzy_match && compl_match_array != NULL
+                          ? find_comp_when_fuzzy() : compl_shown_match->cp_next;
       found_end = (compl_first_match != NULL
                    && (is_first_match(compl_shown_match->cp_next)
                        || is_first_match(compl_shown_match)));
     } else if (compl_shows_dir_backward()
                && compl_shown_match->cp_prev != NULL) {
       found_end = is_first_match(compl_shown_match);
-      compl_shown_match = !compl_fuzzy_match ? compl_shown_match->cp_prev
-                                             : find_comp_when_fuzzy();
+      compl_shown_match = compl_fuzzy_match && compl_match_array != NULL
+                          ? find_comp_when_fuzzy() : compl_shown_match->cp_prev;
       found_end |= is_first_match(compl_shown_match);
     } else {
       if (!allow_get_expansion) {

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2634,6 +2634,16 @@ func Test_complete_fuzzy_match()
   call feedkeys("S\<C-x>\<C-o>fb\<C-n>", 'tx')
   call assert_equal('fooBaz', g:word)
 
+  " avoid break default completion behavior
+  set completeopt=fuzzy,menu
+  call setline(1, ['hello help hero h'])
+  exe "norm! A\<C-X>\<C-N>"
+  call assert_equal('hello help hero hello', getline('.'))
+  set completeopt+=noinsert
+  call setline(1, ['hello help hero h'])
+  exe "norm! A\<C-X>\<C-N>"
+  call assert_equal('hello help hero h', getline('.'))
+
   " clean up
   set omnifunc=
   bw!


### PR DESCRIPTION
#### vim-patch:9.1.0489: default completion may break with fuzzy

Problem:  default completion may break with fuzzy
Solution: check that completion_match_array is not null
          (glepnir)

closes: vim/vim#15010

https://github.com/vim/vim/commit/aced8c2f4fd1cf3f8ac7cdb0dd54d19ef4390ef8

Co-authored-by: glepnir <glephunter@gmail.com>