### PR TITLE
vim-patch:9.1.0492: filetype: Vim-script files not detected by shebang line

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1783,6 +1783,7 @@ local patterns_hashbang = {
   ['^janet\\>'] = { 'janet', { vim_regex = true } },
   ['^dart\\>'] = { 'dart', { vim_regex = true } },
   ['^execlineb\\>'] = { 'execline', { vim_regex = true } },
+  ['^vim\\>'] = { 'vim', { vim_regex = true } },
 }
 
 ---@private

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -992,6 +992,7 @@ func s:GetScriptChecks() abort
       \          ['#!/path/regina']],
       \ 'janet':  [['#!/path/janet']],
       \ 'dart':   [['#!/path/dart']],
+      \ 'vim':   [['#!/path/vim']],
       \ }
 endfunc
 


### PR DESCRIPTION
Problem:  Vim-script files may not be recognised
Solution: Add shebang line detection (Doug Kearns)

closes: vim/vim#15012

https://github.com/vim/vim/commit/0d4d23dac0a5a77ccb0ebf1dcf646afe0c6886bf

Co-authored-by: Doug Kearns <dougkearns@gmail.com>
