### PR TITLE
vim-patch: update runtime files (java, kdl)

### DIFF
--- a/runtime/indent/kdl.vim
+++ b/runtime/indent/kdl.vim
@@ -2,7 +2,7 @@
 " Language:         KDL
 " Author:           Aram Drevekenin <aram@poor.dev>
 " Maintainer:       Yinzuo Jiang <jiangyinzuo@foxmail.com>
-" Last Change:      2024-06-11
+" Last Change:      2024-06-16
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -14,13 +14,17 @@ setlocal indentexpr=KdlIndent()
 let b:undo_indent = "setlocal indentexpr<"
 
 function! KdlIndent(...)
-  let line = getline(v:lnum)
+  let line = substitute(getline(v:lnum), '//.*$', '', '')
   let previousNum = prevnonblank(v:lnum - 1)
-  let previous = getline(previousNum)
+  let previous = substitute(getline(previousNum), '//.*$', '', '')
 
-  if previous =~ "{" && previous !~ "}" && line !~ "}" && line !~ ":$"
-    return indent(previousNum) + shiftwidth()
-  else
-    return indent(previousNum)
+  let l:indent = indent(previousNum)
+  if previous =~ "{" && previous !~ "}"
+    let l:indent += shiftwidth()
   endif
+  if line =~ "}" && line !~ "{"
+    let l:indent -= shiftwidth()
+  endif
+  return l:indent
 endfunction
+" vim: sw=2 sts=2 et

--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Aliaksei Budavei <0x000c70 AT gmail DOT com>
 " Former Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
-" Last Change:		2024 Jun 10
+" Last Change:		2024 Jun 15
 
 " Please check :help java.vim for comments on some of the options available.
 
@@ -14,7 +14,6 @@ if !exists("main_syntax")
   endif
   " we define it here so that included files can test for it
   let main_syntax='java'
-  syn region javaFold start="{" end="}" transparent fold
 endif
 
 let s:cpo_save = &cpo
@@ -39,6 +38,18 @@ else
   function! s:ReportOnce(dummy)
   endfunction
 endif
+
+function! JavaSyntaxFoldTextExpr() abort
+  return getline(v:foldstart) !~ '/\*\+\s*$'
+    \ ? foldtext()
+    \ : printf('+-%s%3d lines: ',
+	  \ v:folddashes,
+	  \ (v:foldend - v:foldstart + 1)) .
+	\ getline(v:foldstart + 1)
+endfunction
+
+" E120 for "fdt=s:JavaSyntaxFoldTextExpr()" before v8.2.3900.
+setlocal foldtext=JavaSyntaxFoldTextExpr()
 
 " Admit the ASCII dollar sign to keyword characters (JLS-17, §3.8):
 try
@@ -99,7 +110,7 @@ syn match   javaClassDecl	"\<record\>\%(\s*(\)\@!"
 syn match   javaClassDecl	"^class\>"
 syn match   javaClassDecl	"[^.]\s*\<class\>"ms=s+1
 syn match   javaAnnotation	"@\%(\K\k*\.\)*\K\k*\>"
-syn region  javaAnnotation	transparent matchgroup=javaAnnotationStart start=/@\%(\K\k*\.\)*\K\k*(/ end=/)/ skip=/\/\*.\{-}\*\/\|\/\/.*$/ contains=javaAnnotation,javaParenT,javaBraces,javaString,javaBoolean,javaNumber,javaTypedef,javaComment,javaLineComment
+syn region  javaAnnotation	transparent matchgroup=javaAnnotationStart start=/@\%(\K\k*\.\)*\K\k*(/ end=/)/ skip=/\/\*.\{-}\*\/\|\/\/.*$/ contains=javaAnnotation,javaParenT,javaBlock,javaString,javaBoolean,javaNumber,javaTypedef,javaComment,javaLineComment
 syn match   javaClassDecl	"@interface\>"
 syn keyword javaBranch		break continue nextgroup=javaUserLabelRef skipwhite
 syn match   javaUserLabelRef	"\k\+" contained
@@ -238,7 +249,7 @@ if exists("java_comment_strings")
   syn cluster javaCommentSpecial2 add=javaComment2String,javaCommentCharacter,javaNumber,javaStrTempl
 endif
 
-syn region  javaComment		matchgroup=javaCommentStart start="/\*" end="\*/" contains=@javaCommentSpecial,javaTodo,javaCommentError,javaSpaceError,@Spell
+syn region  javaComment		 matchgroup=javaCommentStart start="/\*" end="\*/" contains=@javaCommentSpecial,javaTodo,javaCommentError,javaSpaceError,@Spell fold
 syn match   javaCommentStar	 contained "^\s*\*[^/]"me=e-1
 syn match   javaCommentStar	 contained "^\s*\*$"
 syn match   javaLineComment	"//.*" contains=@javaCommentSpecial2,javaTodo,javaCommentMarkupTag,javaSpaceError,@Spell
@@ -269,7 +280,7 @@ if !exists("java_ignore_javadoc") && main_syntax != 'jsp'
     call s:ReportOnce(v:exception)
   endtry
 
-  syn region javaDocComment	start="/\*\*" end="\*/" keepend contains=javaCommentTitle,@javaHtml,javaDocTags,javaDocSeeTag,javaDocCodeTag,javaDocSnippetTag,javaTodo,javaCommentError,javaSpaceError,@Spell
+  syn region javaDocComment	start="/\*\*" end="\*/" keepend contains=javaCommentTitle,@javaHtml,javaDocTags,javaDocSeeTag,javaDocCodeTag,javaDocSnippetTag,javaTodo,javaCommentError,javaSpaceError,@Spell fold
   exec 'syn region javaCommentTitle contained matchgroup=javaDocComment start="/\*\*" matchgroup=javaCommentTitle end="\.$" end="\.[ \t\r]\@=" end="\%(^\s*\**\s*\)\@' . s:ff.Peek('80', '') . '<=@"me=s-2,he=s-1 end="\*/"me=s-1,he=s-1 contains=@javaHtml,javaCommentStar,javaTodo,javaCommentError,javaSpaceError,@Spell,javaDocTags,javaDocSeeTag,javaDocCodeTag,javaDocSnippetTag'
   syn region javaCommentTitle	contained matchgroup=javaDocComment start="/\*\*\s*\r\=\n\=\s*\**\s*\%({@return\>\)\@=" matchgroup=javaCommentTitle end="}\%(\s*\.*\)*" contains=@javaHtml,javaCommentStar,javaTodo,javaCommentError,javaSpaceError,@Spell,javaDocTags,javaDocSeeTag,javaDocCodeTag,javaDocSnippetTag
   syn region javaDocTags	contained start="{@\%(li\%(teral\|nk\%(plain\)\=\)\|inherit[Dd]oc\|doc[rR]oot\|value\)\>" end="}"
@@ -348,8 +359,6 @@ if exists("java_highlight_functions")
     " Match: [@ɐ] [abstract] [<α, β>] Τʬ[<γ>][[][]] μʭʭ(/* ... */);
     exec 'syn region javaFuncDef start=/' . s:ff.Engine('\%#=2', '') . '^\s\+\%(\%(@\%(\K\k*\.\)*\K\k*\>\)\s\+\)*\%(p\%(ublic\|rotected\|rivate\)\s\+\)\=\%(\%(abstract\|default\)\s\+\|\%(\%(final\|\%(native\|strictfp\)\|s\%(tatic\|ynchronized\)\)\s\+\)*\)\=\%(<.*[[:space:]-]\@' . s:ff.Peek('1', '') . '<!>\s\+\)\=\%(void\|\%(b\%(oolean\|yte\)\|char\|short\|int\|long\|float\|double\|\%(\<\K\k*\>\.\)*\<' . s:ff.UpperCase('[$_[:upper:]]', '[^a-z0-9]') . '\k*\>\%(<[^(){}]*[[:space:]-]\@' . s:ff.Peek('1', '') . '<!>\)\=\)\%(\[\]\)*\)\s\+\<' . s:ff.LowerCase('[$_[:lower:]]', '[^A-Z0-9]') . '\k*\>\s*(/ end=/)/ skip=/\/\*.\{-}\*\/\|\/\/.*$/ contains=@javaFuncParams'
   endif
-
-  syn match javaBraces "[{}]"
 endif
 
 if exists("java_highlight_debug")
@@ -404,14 +413,18 @@ if exists("java_highlight_debug")
 endif
 
 if exists("java_mark_braces_in_parens_as_errors")
-  syn match javaInParen		 contained "[{}]"
-  hi def link javaInParen	javaError
+  syn match javaInParen contained "[{}]"
+  hi def link javaInParen javaError
 endif
 
+" Try not to fold top-level-type bodies under assumption that there is
+" but one such body.
+exec 'syn region javaBlock transparent start="\%(^\|^\S[^:]\+\)\@' . s:ff.Peek('120', '') . '<!{" end="}" fold'
+
 " catch errors caused by wrong parenthesis
-syn region  javaParenT	transparent matchgroup=javaParen  start="(" end=")" contains=@javaTop,javaParenT1
-syn region  javaParenT1 transparent matchgroup=javaParen1 start="(" end=")" contains=@javaTop,javaParenT2 contained
-syn region  javaParenT2 transparent matchgroup=javaParen2 start="(" end=")" contains=@javaTop,javaParenT  contained
+syn region  javaParenT	transparent matchgroup=javaParen  start="(" end=")" contains=@javaTop,javaInParen,javaParenT1
+syn region  javaParenT1 transparent matchgroup=javaParen1 start="(" end=")" contains=@javaTop,javaInParen,javaParenT2 contained
+syn region  javaParenT2 transparent matchgroup=javaParen2 start="(" end=")" contains=@javaTop,javaInParen,javaParenT contained
 syn match   javaParenError	 ")"
 " catch errors caused by wrong square parenthesis
 syn region  javaParenT	transparent matchgroup=javaParen  start="\[" end="\]" contains=@javaTop,javaParenT1
@@ -445,7 +458,7 @@ endif
 
 " The @javaTop cluster comprises non-contained Java syntax groups.
 " Note that the syntax file "aidl.vim" relies on its availability.
-syn cluster javaTop contains=TOP,javaDocComment,javaFold,javaParenError,javaParenT
+syn cluster javaTop contains=TOP,javaDocComment,javaBlock,javaParenError,javaParenT
 
 if !exists("java_minlines")
   let java_minlines = 10
@@ -463,7 +476,6 @@ exec "syn sync ccomment javaComment minlines=" . java_minlines
 hi def link javaLambdaDef		Function
 hi def link javaFuncDef		Function
 hi def link javaVarArg			Function
-hi def link javaBraces			Function
 hi def link javaBranch			Conditional
 hi def link javaUserLabelRef		javaUserLabel
 hi def link javaLabel			Label
@@ -533,4 +545,20 @@ let b:spell_options = "contained"
 let &cpo = s:cpo_save
 unlet s:module_info_cur_buf s:ff s:cpo_save
 
+" See ":help vim9-mix".
+if !has("vim9script")
+  finish
+endif
+
+def! s:JavaSyntaxFoldTextExpr(): string
+  return getline(v:foldstart) !~ '/\*\+\s*$'
+    ? foldtext()
+    : printf('+-%s%3d lines: ',
+	  v:folddashes,
+	  (v:foldend - v:foldstart + 1)) ..
+	getline(v:foldstart + 1)
+enddef
+
+setlocal foldtext=s:JavaSyntaxFoldTextExpr()
+delfunction! g:JavaSyntaxFoldTextExpr
 " vim: sw=2 ts=8 noet sta

--- a/runtime/syntax/kdl.vim
+++ b/runtime/syntax/kdl.vim
@@ -2,7 +2,7 @@
 " Language: KDL
 " Maintainer: Aram Drevekenin <aram@poor.dev>
 " Maintainer: Yinzuo Jiang <jiangyinzuo@foxmail.com>
-" Latest Revision: 2024-06-10
+" Latest Revision: 2024-06-16
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -13,7 +13,8 @@ syn match kdlNode '\v(\w|-|\=)' display
 syn match kdlBool '\v(true|false)' display
 
 syn keyword kdlTodo contained TODO FIXME XXX NOTE
-syn match kdlComment "//.*$" contains=kdlTodo
+syn region  kdlComment start="//"  end="$"   contains=kdlTodo,@Spell
+syn region  kdlComment start="/\*" end="\*/" contains=kdlTodo,@Spell
 
 " Regular int like number with - + or nothing in front
 syn match kdlNumber '\d\+'
@@ -22,17 +23,17 @@ syn match kdlNumber '[-+]\d\+'
 " Floating point number with decimal no E or e (+,-)
 syn match kdlNumber '\d\+\.\d*' contained display
 syn match kdlNumber '[-+]\d\+\.\d*' contained display
- 
+
 " Floating point like number with E and no decimal point (+,-)
 syn match kdlNumber '[-+]\=\d[[:digit:]]*[eE][\-+]\=\d\+' contained display
 syn match kdlNumber '\d[[:digit:]]*[eE][\-+]\=\d\+' contained display
- 
+
 " Floating point like number with E and decimal point (+,-)
 syn match kdlNumber '[-+]\=\d[[:digit:]]*\.\d*[eE][\-+]\=\d\+' contained display
 syn match kdlNumber '\d[[:digit:]]*\.\d*[eE][\-+]\=\d\+' contained display
 
 syn region kdlString start='"' end='"' skip='\\\\\|\\"' display
- 
+
 syn region kdlChildren start="{" end="}" contains=kdlString,kdlNumber,kdlNode,kdlBool,kdlComment
 
 hi def link kdlTodo        Todo
@@ -43,3 +44,5 @@ hi def link kdlString      String
 hi def link kdlNumber      Number
 
 let b:current_syntax = "kdl"
+
+" vim: sw=2 sts=2 et


### PR DESCRIPTION
- **vim-patch:371bab0: runtime(java): Fold multi-line comments with the syntax kind of &fdm (vim/vim#15016)**
- **vim-patch:79da22d: runtime(kdl): fix KdlIndent and kdlComment in indent script (vim/vim#15019)**
