### PR TITLE
vim-patch: update runtime files

### DIFF
--- a/runtime/compiler/javac.vim
+++ b/runtime/compiler/javac.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:	Java Development Kit Compiler
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
-" Last Change:	2024 Apr 03
+" Last Change:	2024 Jun 14
 
 if exists("current_compiler")
   finish
@@ -11,7 +11,12 @@ let current_compiler = "javac"
 let s:cpo_save = &cpo
 set cpo&vim
 
-CompilerSet makeprg=javac
+if exists("g:javac_makeprg_params")
+  execute $'CompilerSet makeprg=javac\ {escape(g:javac_makeprg_params, ' \|"')}'
+else
+  CompilerSet makeprg=javac
+endif
+
 CompilerSet errorformat=%E%f:%l:\ error:\ %m,
 		       \%W%f:%l:\ warning:\ %m,
 		       \%-Z%p^,

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1288,6 +1288,13 @@ g:compiler_gcc_ignore_unmatched_lines
 				commands run from make are generating false
 				positives.
 
+JAVAC							*compiler-javac*
+
+Commonly used compiler options can be added to 'makeprg' by setting the
+g:javac_makeprg_params variable.  For example: >
+	let g:javac_makeprg_params = "-Xlint:all -encoding utf-8"
+<
+
 PANDOC					*quickfix-pandoc* *compiler-pandoc*
 
 The Pandoc compiler plugin expects that an output file type extension is

--- a/runtime/syntax/html.vim
+++ b/runtime/syntax/html.vim
@@ -191,7 +191,7 @@ syn keyword htmlArg contained step title translate typemustmatch
 syn match   htmlArg contained "\<data-\h\%(\w\|[-.]\)*\%(\_s*=\)\@="
 
 " special characters
-syn match htmlSpecialChar "&#\=[0-9A-Za-z]\{1,8};"
+syn match htmlSpecialChar "&#\=[0-9A-Za-z]\{1,32};"
 
 " Comments (the real ones or the old netscape ones)
 if exists("html_wrong_comments")


### PR DESCRIPTION
This allows handling longer references such as
`&CounterClockwiseContourIntegral;`.

https://github.com/vim/vim/commit/917ff8a19d2746dd922b7292dc61fb92e18b7ce2

Co-authored-by: Mohamed Akram <mohd.akram@outlook.com>
