### PR TITLE
feat(lsp): drop fswatch, use inotifywait

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -30,7 +30,7 @@ if [[ $os == Linux ]]; then
   fi
 
   if [[ -n $TEST ]]; then
-    sudo apt-get install -y locales-all cpanminus attr libattr1-dev gdb fswatch
+    sudo apt-get install -y locales-all cpanminus attr libattr1-dev gdb inotify-tools
 
     # Use default CC to avoid compilation problems when installing Python modules
     CC=cc python3 -m pip -q install --user --upgrade pynvim

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -543,15 +543,18 @@ Example: File-change detection                                    *watch-file*
     vim.api.nvim_command(
       "command! -nargs=1 Watch call luaeval('watch_file(_A)', expand('<args>'))")
 <
-                                                         *fswatch-limitations*
-When on Linux and using fswatch, you may need to increase the maximum number
-of `inotify` watches and queued events as the default limit can be too low. To
-increase the limit, run: >sh
-    sysctl fs.inotify.max_user_watches=100000
-    sysctl fs.inotify.max_queued_events=100000
+                                                         *inotify-limitations*
+When on Linux you may need to increase the maximum number of `inotify` watches
+and queued events as the default limit can be too low. To increase the limit,
+run: >sh
+    sysctl fs.inotify.max_user_watches=494462
 <
-This will increase the limit to 100000 watches and queued events. These lines
+This will increase the limit to 494462 watches and queued events. These lines
 can be added to `/etc/sysctl.conf` to make the changes persistent.
+
+Note that each watch is a structure in the Kernel, thus available memory is
+also a bottleneck for using inotify. In fact, a watch can take up to 1KB of
+space. This means a million watches could result in 1GB of extra RAM usage.
 
 Example: TCP echo-server                                          *tcp-server*
     1. Save this code to a file.

--- a/runtime/lua/vim/lsp/_watchfiles.lua
+++ b/runtime/lua/vim/lsp/_watchfiles.lua
@@ -9,8 +9,8 @@ local M = {}
 
 if vim.fn.has('win32') == 1 or vim.fn.has('mac') == 1 then
   M._watchfunc = watch.watch
-elseif vim.fn.executable('fswatch') == 1 then
-  M._watchfunc = watch.fswatch
+elseif vim.fn.executable('inotifywait') == 1 then
+  M._watchfunc = watch.inotify
 else
   M._watchfunc = watch.watchdirs
 end

--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -90,8 +90,8 @@ local function check_watcher()
     watchfunc_name = 'libuv-watch'
   elseif watchfunc == vim._watch.watchdirs then
     watchfunc_name = 'libuv-watchdirs'
-  elseif watchfunc == vim._watch.fswatch then
-    watchfunc_name = 'fswatch'
+  elseif watchfunc == vim._watch.inotifywait then
+    watchfunc_name = 'inotifywait'
   else
     local nm = debug.getinfo(watchfunc, 'S').source
     watchfunc_name = string.format('Custom (%s)', nm)
@@ -99,7 +99,7 @@ local function check_watcher()
 
   report_info('File watch backend: ' .. watchfunc_name)
   if watchfunc_name == 'libuv-watchdirs' then
-    report_warn('libuv-watchdirs has known performance issues. Consider installing fswatch.')
+    report_warn('libuv-watchdirs has known performance issues. Consider installing inotify-tools.')
   end
 end
 

--- a/test/functional/lua/watch_spec.lua
+++ b/test/functional/lua/watch_spec.lua
@@ -23,10 +23,13 @@ describe('vim._watch', function()
 
   local function run(watchfunc)
     it('detects file changes (watchfunc=' .. watchfunc .. '())', function()
-      if watchfunc == 'fswatch' then
+      if watchfunc == 'inotify' then
         skip(is_os('win'), 'not supported on windows')
         skip(is_os('mac'), 'flaky test on mac')
-        skip(not is_ci() and n.fn.executable('fswatch') == 0, 'fswatch not installed and not on CI')
+        skip(
+          not is_ci() and n.fn.executable('inotifywait') == 0,
+          'inotify-tools not installed and not on CI'
+        )
       end
 
       if watchfunc == 'watch' then
@@ -123,5 +126,5 @@ describe('vim._watch', function()
 
   run('watch')
   run('watchdirs')
-  run('fswatch')
+  run('inotify')
 end)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -5048,12 +5048,12 @@ describe('LSP', function()
       it(
         string.format('sends notifications when files change (watchfunc=%s)', watchfunc),
         function()
-          if watchfunc == 'fswatch' then
+          if watchfunc == 'inotify' then
             skip(is_os('win'), 'not supported on windows')
             skip(is_os('mac'), 'flaky test on mac')
             skip(
-              not is_ci() and fn.executable('fswatch') == 0,
-              'fswatch not installed and not on CI'
+              not is_ci() and fn.executable('inotifywait') == 0,
+              'inotify-tools not installed and not on CI'
             )
           end
 
@@ -5185,7 +5185,7 @@ describe('LSP', function()
 
     test_filechanges('watch')
     test_filechanges('watchdirs')
-    test_filechanges('fswatch')
+    test_filechanges('inotify')
 
     it('correctly registers and unregisters', function()
       local root_dir = '/some_dir'


### PR DESCRIPTION
This patch replaces fswatch with inotifywait from inotify-tools:

https://github.com/inotify-tools/inotify-tools

fswatch takes ~1min to set up recursively for the Samba source code directory. inotifywait needs less than a second to do the same thing.

https://github.com/emcrisostomo/fswatch/issues/321

Also fswatch seems to be unmaintained in the meantime.