### PR TITLE
build: fix CMake find_library search

### DIFF
--- a/cmake/Find.cmake
+++ b/cmake/Find.cmake
@@ -17,6 +17,7 @@ endfunction()
 # 2. Only search in .deps directory. Search all libraries
 # 3. Search everywhere, all libraries
 function(find_library2)
+  set(CMAKE_FIND_LIBRARY_PREFIXES "" "lib")
   find_library_nvim(STATIC ${ARGV})
   find_library_nvim(${ARGV})
   find_library(${ARGV})

--- a/cmake/FindIconv.cmake
+++ b/cmake/FindIconv.cmake
@@ -2,7 +2,7 @@
 # file can be removed once we decide to upgrade minimum cmake version.
 
 find_path2(ICONV_INCLUDE_DIR NAMES iconv.h)
-find_library2(ICONV_LIBRARY NAMES iconv libiconv)
+find_library2(ICONV_LIBRARY NAMES iconv)
 find_package_handle_standard_args(Iconv DEFAULT_MSG
   ICONV_INCLUDE_DIR)
 mark_as_advanced(ICONV_INCLUDE_DIR ICONV_LIBRARY)

--- a/cmake/FindLibuv.cmake
+++ b/cmake/FindLibuv.cmake
@@ -1,5 +1,5 @@
 find_path2(LIBUV_INCLUDE_DIR uv.h)
-find_library2(LIBUV_LIBRARY NAMES uv_a uv libuv)
+find_library2(LIBUV_LIBRARY NAMES uv_a uv)
 
 set(LIBUV_LIBRARIES ${LIBUV_LIBRARY})
 

--- a/cmake/FindLpeg.cmake
+++ b/cmake/FindLpeg.cmake
@@ -1,4 +1,4 @@
-find_library2(LPEG_LIBRARY NAMES lpeg_a lpeg liblpeg_a lpeg${CMAKE_SHARED_LIBRARY_SUFFIX} PATH_SUFFIXES lua/5.1)
+find_library2(LPEG_LIBRARY NAMES lpeg_a lpeg PATH_SUFFIXES lua/5.1)
 
 find_package_handle_standard_args(Lpeg DEFAULT_MSG LPEG_LIBRARY)
 mark_as_advanced(LPEG_LIBRARY)

--- a/cmake/FindLuv.cmake
+++ b/cmake/FindLuv.cmake
@@ -1,5 +1,5 @@
 find_path2(LUV_INCLUDE_DIR luv/luv.h PATH_SUFFIXES lua5.1)
-find_library2(LUV_LIBRARY NAMES luv_a luv libluv_a luv${CMAKE_SHARED_LIBRARY_SUFFIX} PATH_SUFFIXES lua/5.1)
+find_library2(LUV_LIBRARY NAMES luv_a luv PATH_SUFFIXES lua/5.1)
 
 find_package_handle_standard_args(Luv DEFAULT_MSG
   LUV_LIBRARY LUV_INCLUDE_DIR)


### PR DESCRIPTION
I faced a problem building Neovim from source on macOS. In particular the problem looks very similar/related to what has been reported in other issues/workarounds

- https://github.com/neovim/neovim/issues/25041
- https://github.com/neovim/neovim/issues/25027
- https://github.com/Homebrew/homebrew-core/pull/141673

After some digging I figured out that 

https://github.com/neovim/neovim/blob/20a7eebec086129e605041d32916f36df50890de/cmake/FindLpeg.cmake#L1

translates to:
- on linux `... NAMES lpeg_a lpeg liblpeg_a lpeg.so`
- on macos `... NAMES lpeg_a lpeg liblpeg_a lpeg.dylib`

## How it works

The CMake search mechanism turns out to look for either one of the given name "as is", or it "manipulates" the given name to create a regex with prefixes and suffixes.

Taking the second name given (i.e. `lpeg`) as example, CMake creates this regex

```
(lib)lpeg(\.tbd|\.dylib|\.so|\.a)
```

Turns out to either match with `lpeg` or 
- `liblpeg.tbd`
- `liblpeg.dylib`
- `liblpeg.so`
- `liblpeg.a`

None of this will match on Linux either...but in the given names we had also `lpeg.so`, obtained thanks to `lpeg${CMAKE_SHARED_LIBRARY_SUFFIX}`, so when it is its turn, it will find the match.

It is a bit of a workaround having it listed, because generally it is expected to find it with `lpeg`.

## Why does not work on macOS?

The problem is that on both platforms the `lpeg` library gets installed as `lpeg.so`, but `lpeg${CMAKE_SHARED_LIBRARY_SUFFIX}` ends up to be:
- on linux `lpeg.so`
- on macOS `lpeg.dylib`

Hence, for macOS the workaround of giving the exact name to look for does not work because of how the name is constructed.

## The fix

IMHO the fix is to make `find_library` work at its best. Since we are interested in looking for libraries that do not have the classic "lib" prefix, we instruct `find_library` to consider also this possibility, i.e. the library name to look for might also have an "empty" prefix and not just "lib".

In this way the regex ends up being (note the `|` before lib, indicating an empty option)

```
(|lib)lpeg(\.tbd|\.dylib|\.so|\.a)
```

that ends up looking for `lpeg` or:
- `lpeg.tbd`
- `lpeg.dylib`
- `lpeg.so`
- `lpeg.a`
- `liblpeg.tbd`
- `liblpeg.dylib`
- `liblpeg.so`
- `liblpeg.a`

Note: I took the chance to cleanup also other `find_library` calls to not explicitly have to deal with the prefix "lib".

It would be nice if someone having the issue with building with Homebrew could test it too.

Hope you find it useful and you are interested in having it merged.