### PR TITLE
fix(filetype): improve `htmldjango` detection

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -676,7 +676,7 @@ end
 
 --- @type vim.filetype.mapfn
 function M.html(_, bufnr)
-  for _, line in ipairs(getlines(bufnr, 1, 10)) do
+  for _, line in ipairs(getlines(bufnr, 1, 40)) do
     if matchregex(line, [[\<DTD\s\+XHTML\s]]) then
       return 'xhtml'
     elseif matchregex(line, [[\c{%\s*\(autoescape\|block\|comment\|csrf_token\|cycle\|debug\|extends\|filter\|firstof\|for\|if\|ifchanged\|include\|load\|lorem\|now\|query_string\|regroup\|resetcycle\|spaceless\|templatetag\|url\|verbatim\|widthratio\|with\)\>\|{#\s\+]]) then

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -679,7 +679,7 @@ function M.html(_, bufnr)
   for _, line in ipairs(getlines(bufnr, 1, 10)) do
     if matchregex(line, [[\<DTD\s\+XHTML\s]]) then
       return 'xhtml'
-    elseif matchregex(line, [[\c{%\s*\(extends\|block\|load\)\>\|{#\s\+]]) then
+    elseif matchregex(line, [[\c{%\s*\(autoescape\|block\|comment\|csrf_token\|cycle\|debug\|extends\|filter\|firstof\|for\|if\|ifchanged\|include\|load\|lorem\|now\|query_string\|regroup\|resetcycle\|spaceless\|templatetag\|url\|verbatim\|widthratio\|with\)\>\|{#\s\+]]) then
       return 'htmldjango'
     end
   end


### PR DESCRIPTION
I found `htmldjango` filetype detection regex is only match small number of Django tags which results in high false negative. This PR adds the rest of the tags based on https://docs.djangoproject.com/en/5.0/ref/templates/builtins/#built-in-tag-reference.

In addition, the supplied lines for matching is too few and might result in high false negative too. Increasing it to 40 lines should reduce the false negative. (I picked 40 as I think it is close to the most common height of terminal in a 1080p screen).

Let me know if you have any suggestion :D