### PR TITLE
vim-patch:9.1.{0495,0496}

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5075,9 +5075,9 @@ PmenuSbar	Popup menu: Scrollbar.
 							*hl-PmenuThumb*
 PmenuThumb	Popup menu: Thumb of the scrollbar.
 							*hl-PmenuMatch*
-PmenuMatch	Popup menu: Matched text in normal item
+PmenuMatch	Popup menu: Matched text in normal item.
 							*hl-PmenuMatchSel*
-PmenuMatchSel	Popup menu: Matched text in selected item
+PmenuMatchSel	Popup menu: Matched text in selected item.
 							*hl-Question*
 Question	|hit-enter| prompt and yes/no questions.
 							*hl-QuickFixLine*

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -402,6 +402,20 @@ void cmdline_pum_cleanup(CmdlineInfo *cclp)
   wildmenu_cleanup(cclp);
 }
 
+/// Returns the current cmdline completion pattern.
+char *cmdline_compl_pattern(void)
+{
+  expand_T *xp = get_cmdline_info()->xpc;
+  return xp == NULL ? NULL : xp->xp_orig;
+}
+
+/// Returns true if fuzzy cmdline completion is active, false otherwise.
+bool cmdline_compl_is_fuzzy(void)
+{
+  expand_T *xp = get_cmdline_info()->xpc;
+  return xp != NULL && cmdline_fuzzy_completion_supported(xp);
+}
+
 /// Return the number of characters that should be skipped in the wildmenu
 /// These are backslashes used for escaping.  Do show backslashes in help tags.
 static int skip_wildmenu_char(expand_T *xp, char *s)

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1397,7 +1397,7 @@ bool compl_match_curr_select(int selected)
 /// Get current completion leader
 char *ins_compl_leader(void)
 {
-  return compl_leader;
+  return compl_leader != NULL ? compl_leader : compl_orig_text;
 }
 
 /// Add any identifiers that match the given pattern "pat" in the list of

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -17,6 +17,7 @@
 #include "nvim/buffer_updates.h"
 #include "nvim/change.h"
 #include "nvim/charset.h"
+#include "nvim/cmdexpand.h"
 #include "nvim/drawscreen.h"
 #include "nvim/edit.h"
 #include "nvim/errors.h"
@@ -441,17 +442,21 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
 /// Returns attributes for every cell, or NULL if all attributes are the same.
 static int *pum_compute_text_attrs(char *text, hlf_T hlf)
 {
-  char *leader = ins_compl_leader();
-
-  if (leader == NULL || *leader == NUL || (hlf != HLF_PSI && hlf != HLF_PNI)
+  if ((hlf != HLF_PSI && hlf != HLF_PNI)
       || (win_hl_attr(curwin, HLF_PMSI) == win_hl_attr(curwin, HLF_PSI)
           && win_hl_attr(curwin, HLF_PMNI) == win_hl_attr(curwin, HLF_PNI))) {
     return NULL;
   }
 
+  char *leader = State == MODE_CMDLINE ? cmdline_compl_pattern() : ins_compl_leader();
+  if (leader == NULL || *leader == NUL) {
+    return NULL;
+  }
+
   int *attrs = xmalloc(sizeof(int) * (size_t)vim_strsize(text));
+  bool in_fuzzy = State == MODE_CMDLINE ? cmdline_compl_is_fuzzy()
+                                        : (get_cot_flags() & COT_FUZZY) != 0;
   size_t leader_len = strlen(leader);
-  const bool in_fuzzy = (get_cot_flags() & COT_FUZZY) != 0;
 
   garray_T *ga = NULL;
   bool matched_start = false;

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -448,7 +448,8 @@ static int *pum_compute_text_attrs(char *text, hlf_T hlf)
     return NULL;
   }
 
-  char *leader = State == MODE_CMDLINE ? cmdline_compl_pattern() : ins_compl_leader();
+  char *leader = State == MODE_CMDLINE ? cmdline_compl_pattern()
+                                       : ins_compl_leader();
   if (leader == NULL || *leader == NUL) {
     return NULL;
   }
@@ -464,7 +465,7 @@ static int *pum_compute_text_attrs(char *text, hlf_T hlf)
   if (in_fuzzy) {
     ga = fuzzy_match_str_with_pos(text, leader);
   } else {
-    matched_start = strncmp(text, leader, leader_len) == 0;
+    matched_start = mb_strnicmp(text, leader, leader_len) == 0;
   }
 
   const char *ptr = text;

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -4739,6 +4739,20 @@ describe('builtin popupmenu', function()
                   \ { 'word': '你可好吗' },
                   \]}
           endfunc
+
+          func Comp()
+            let col = col('.')
+            if getline('.') == 'f'
+              let col -= 1
+            endif
+            call complete(col, [
+                  \ #{word: "foo", icase: 1},
+                  \ #{word: "Foobar", icase: 1},
+                  \ #{word: "fooBaz", icase: 1},
+                  \])
+            return ''
+          endfunc
+
           set omnifunc=Omni_test
           set completeopt=menu,noinsert,fuzzy
           hi PmenuMatchSel  guifg=Blue guibg=Grey
@@ -4878,6 +4892,20 @@ describe('builtin popupmenu', function()
         ]])
         feed('<C-E><Esc>')
         command('set norightleft')
+
+        feed('S<C-R>=Comp()<CR>f')
+        screen:expect([[
+          f^                               |
+          {ms:f}{s:oo            }{1:                 }|
+          {mn:F}{n:oobar         }{1:                 }|
+          {mn:f}{n:ooBaz         }{1:                 }|
+          {1:~                               }|*15
+          {2:-- INSERT --}                    |
+        ]])
+        feed('o<BS><C-R>=Comp()<CR>')
+        screen:expect_unchanged(true)
+
+        feed('<C-E><Esc>')
       end)
     end
   end

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -3550,6 +3550,66 @@ describe('builtin popupmenu', function()
                                         |
         ]])
       end)
+
+      -- oldtest: Test_wildmenu_pum_hl_match()
+      it('highlighting matched text in cmdline pum', function()
+        exec([[
+          set wildoptions=pum,fuzzy
+          hi PmenuMatchSel  guifg=Blue guibg=Grey
+          hi PmenuMatch     guifg=Blue guibg=Magenta
+        ]])
+
+        feed(':sign plc<Tab>')
+        screen:expect([[
+                                          |
+          {1:~                               }|*16
+          {1:~    }{s: }{ms:pl}{s:a}{ms:c}{s:e          }{1:           }|
+          {1:~    }{n: un}{mn:pl}{n:a}{mn:c}{n:e        }{1:           }|
+          :sign place^                     |
+        ]])
+        feed('<Tab>')
+        screen:expect([[
+                                          |
+          {1:~                               }|*16
+          {1:~    }{n: }{mn:pl}{n:a}{mn:c}{n:e          }{1:           }|
+          {1:~    }{s: un}{ms:pl}{s:a}{ms:c}{s:e        }{1:           }|
+          :sign unplace^                   |
+        ]])
+        feed('<Tab>')
+        screen:expect([[
+                                          |
+          {1:~                               }|*16
+          {1:~    }{n: }{mn:pl}{n:a}{mn:c}{n:e          }{1:           }|
+          {1:~    }{n: un}{mn:pl}{n:a}{mn:c}{n:e        }{1:           }|
+          :sign plc^                       |
+        ]])
+        feed('<Esc>')
+        command('set wildoptions-=fuzzy')
+        feed(':sign un<Tab>')
+        screen:expect([[
+                                          |
+          {1:~                               }|*16
+          {1:~    }{s: }{ms:un}{s:define       }{1:           }|
+          {1:~    }{n: }{mn:un}{n:place        }{1:           }|
+          :sign undefine^                  |
+        ]])
+        feed('<Tab>')
+        screen:expect([[
+                                          |
+          {1:~                               }|*16
+          {1:~    }{n: }{mn:un}{n:define       }{1:           }|
+          {1:~    }{s: }{ms:un}{s:place        }{1:           }|
+          :sign unplace^                   |
+        ]])
+        feed('<Tab>')
+        screen:expect([[
+                                          |
+          {1:~                               }|*16
+          {1:~    }{n: }{mn:un}{n:define       }{1:           }|
+          {1:~    }{n: }{mn:un}{n:place        }{1:           }|
+          :sign un^                        |
+        ]])
+      end)
     end
 
     it("'pumheight'", function()

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -2923,6 +2923,37 @@ func Test_wildmenu_pum_rightleft()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test highlighting matched text in cmdline completion popup menu.
+func Test_wildmenu_pum_hl_match()
+  CheckScreendump
+
+  let lines =<< trim END
+    set wildoptions=pum,fuzzy
+    hi PmenuMatchSel  ctermfg=6 ctermbg=7
+    hi PmenuMatch     ctermfg=4 ctermbg=225
+  END
+  call writefile(lines, 'Xwildmenu_pum_hl', 'D')
+  let buf = RunVimInTerminal('-S Xwildmenu_pum_hl', #{rows: 10, cols: 50})
+
+  call term_sendkeys(buf, ":sign plc\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_hl_match_1', {})
+  call term_sendkeys(buf, "\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_hl_match_2', {})
+  call term_sendkeys(buf, "\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_hl_match_3', {})
+  call term_sendkeys(buf, "\<Esc>:set wildoptions-=fuzzy\<CR>")
+  call TermWait(buf)
+  call term_sendkeys(buf, ":sign un\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_hl_match_4', {})
+  call term_sendkeys(buf, "\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_hl_match_5', {})
+  call term_sendkeys(buf, "\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_hl_match_6', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " Test for completion after a :substitute command followed by a pipe (|)
 " character
 func Test_cmdline_complete_substitute()

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1407,6 +1407,20 @@ func Test_pum_highlights_match()
             \ { 'word': '你可好吗' },
             \]}
     endfunc
+
+    func Comp()
+      let col = col('.')
+      if getline('.') == 'f'
+        let col -= 1
+      endif
+      call complete(col, [
+            \ #{word: "foo", icase: 1},
+            \ #{word: "Foobar", icase: 1},
+            \ #{word: "fooBaz", icase: 1},
+            \])
+      return ''
+    endfunc
+
     set omnifunc=Omni_test
     set completeopt=menu,noinsert,fuzzy
     hi PmenuMatchSel  ctermfg=6 ctermbg=7
@@ -1470,7 +1484,14 @@ func Test_pum_highlights_match()
     call term_sendkeys(buf, ":set norightleft\<CR>")
   endif
 
+  call term_sendkeys(buf, "S\<C-R>=Comp()\<CR>f")
+  call VerifyScreenDump(buf, 'Test_pum_highlights_09', {})
+  call term_sendkeys(buf, "o\<BS>\<C-R>=Comp()\<CR>")
+  call VerifyScreenDump(buf, 'Test_pum_highlights_09', {})
+
+  call term_sendkeys(buf, "\<C-E>\<Esc>")
   call TermWait(buf)
+
   call StopVimInTerminal(buf)
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.0495: Matched text isn't highlighted in cmdline pum

Problem:  Matched text isn't highlighted in cmdline pum.
Solution: Use cmdline completion pattern in cmdline mode.
          (zeertzjq)

closes: vim/vim#15029

https://github.com/vim/vim/commit/d8c9340fc67ca19f82ec3e77ec38296424e758cf


#### vim-patch:9.1.0496: matched text is highlighted case-sensitively

Problem:  matched text is highlighted case-sensitively
Solution: use MB_STRNICMP, update highlighting when the base changes
          (glepnir)

closes: vim/vim#15023

https://github.com/vim/vim/commit/f189138b39a11ed5cf3adea6610469b478841aba

Co-authored-by: glepnir <glephunter@gmail.com>