### PR TITLE
vim-patch:ca47114: runtime(doc): improve the vim-shebang example

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -143,9 +143,15 @@ gx			Opens the current filepath or URL (decided by
 							*:#!* *vim-shebang*
 :#!{anything}		Ignored, so that you can start a Vim script with: >
 				#!vim -S
-				echo "this is a Vim script"
-				quit
+				let mylogbook='$HOME/logbook.md'
+				exe $':e {mylogbook}'
+				$
+				put ='## ' .. strftime('%d. %b %Y')
+				norm! o
 <
+			Make that script executable and run it to create a
+			new diary entry.
+
 							*:z* *E144*
 :[range]z[+-^.=][count]	Display several lines of text surrounding the line
 			specified with [range], or around the current line


### PR DESCRIPTION
#### vim-patch:ca47114: runtime(doc): improve the vim-shebang example

https://github.com/vim/vim/commit/ca471145321fa8089071330b7637ad3950ac4f11

Co-authored-by: Christian Brabandt <cb@256bit.org>