### PR TITLE
vim-patch:26de90c: runtime(nohlsearch): include the the simple nohlsearch package

### DIFF
--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -141,13 +141,17 @@ CTRL-C			Interrupt current (search) command.
 			executing autocommands |autocmd-searchpat|.
 			Same thing for when invoking a user function.
 
+
 While typing the search pattern the current match will be shown if the
 'incsearch' option is on.  Remember that you still have to finish the search
 command with <CR> to actually position the cursor at the displayed match.  Or
 use <Esc> to abandon the search.
 
+							*nohlsearch-auto*
 All matches for the last used search pattern will be highlighted if you set
-the 'hlsearch' option.  This can be suspended with the |:nohlsearch| command.
+the 'hlsearch' option.  This can be suspended with the |:nohlsearch| command
+or auto suspended with nohlsearch plugin.  See |nohlsearch-install|.
+
 
 When 'shortmess' does not include the "S" flag, Vim will automatically show an
 index, on which the cursor is. This can look like this: >

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -234,6 +234,21 @@ an archive or as a repository.  For an archive you can follow these steps:
 	   Here "fancytext" is the name of the package, it can be anything
 	   else.
 
+
+Adding nohlsearch package				*nohlsearch-install*
+
+Load the plugin with this command: >
+	packadd nohlsearch
+<
+Automatically execute |:nohlsearch| after 'updatetime' or getting into |Insert| mode.
+Thus assuming default updatetime, hlsearch would be suspended/turned off after
+4 seconds of idle time.
+
+To disable the effect of the plugin after is has been loaded: >
+	au! nohlsearch
+<
+
+
 More information about packages can be found here: |packages|.
 
 ==============================================================================

--- a/runtime/pack/dist/opt/nohlsearch/plugin/nohlsearch.vim
+++ b/runtime/pack/dist/opt/nohlsearch/plugin/nohlsearch.vim
@@ -1,0 +1,14 @@
+" nohlsearch.vim: Auto turn off hlsearch
+" Last Change: 2024-06-18
+" Maintainer: Maxim Kim <habamax@gmail.com>
+"
+" turn off hlsearch after:
+" - doing nothing for 'updatetime'
+" - getting into insert mode
+augroup nohlsearch
+    au!
+    noremap <Plug>(nohlsearch) <cmd>nohlsearch<cr>
+    noremap! <expr> <Plug>(nohlsearch) execute('nohlsearch')[-1]
+    au CursorHold * call feedkeys("\<Plug>(nohlsearch)", 'm')
+    au InsertEnter * call feedkeys("\<Plug>(nohlsearch)", 'm')
+augroup END


### PR DESCRIPTION
fixes: vim/vim#15039
closes: vim/vim#15042

https://github.com/vim/vim/commit/26de90c6312cf16d7a4f2b6942befb4e1f14b960

Co-authored-by: Maxim Kim <habamax@gmail.com>
