### PR TITLE
fix(mouse): early return when clicking in padded 'statuscolumn'

### DIFF
--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -688,6 +688,9 @@ popupexit:
     if (in_statuscol && wp->w_p_rl) {
       click_col = wp->w_width_inner - click_col - 1;
     }
+    if (in_statuscol && click_col >= (int)wp->w_statuscol_click_defs_size) {
+      return false;
+    }
 
     if (click_defs != NULL) {
       switch (click_defs[click_col].type) {

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -91,6 +91,10 @@ describe('statuscolumn', function()
       {8:2    }aaaaa                                           |
                                                            |
     ]])
+    -- Doesn't crash when clicking inside padded area without click_defs
+    command('set numberwidth=10')
+    api.nvim_input_mouse('left', 'press', '', 0, 0, 5)
+    assert_alive()
   end)
 
   it("works with 'number' and 'relativenumber'", function()


### PR DESCRIPTION
Problem:  Hit assert when clicking inside a padded 'statuscolumn' that
          is padded beyond the length of the allocated click_defs.
Solution: Still consider this a "in_statuscol" click, but return early
          when about to execute the click func.

Fix #29390