### PR TITLE
vim-patch:1ce65e3: runtime(csv): include a simple csv filetype and syntax plugin

### DIFF
--- a/runtime/ftplugin/csv.vim
+++ b/runtime/ftplugin/csv.vim
@@ -8,7 +8,7 @@ if !exists("b:csv_delimiter")
 
     let s:max = 0
     for s:d in s:delimiters
-        let s:count = getline(1)->split(d)->len() + getline(2)->split(d)->len()
+        let s:count = getline(1)->split(s:d)->len() + getline(2)->split(s:d)->len()
         if s:count > s:max
             let s:max = s:count
             let b:csv_delimiter = s:d

--- a/runtime/ftplugin/csv.vim
+++ b/runtime/ftplugin/csv.vim
@@ -1,0 +1,22 @@
+" Maintainer: Maxim Kim <habamax@gmail.com>
+" Converted from vim9script
+" Last Update: 2024-06-18
+
+if !exists("b:csv_delimiter")
+    " detect delimiter
+    let s:delimiters = ",;\t|"
+
+    let s:max = 0
+    for d in s:delimiters
+        let s:count = getline(1)->split(d)->len() + getline(2)->split(d)->len()
+        if s:count > s:max
+            let s:max = s:count
+            let b:csv_delimiter = d
+        endif
+    endfor
+endif
+
+if exists("b:did_ftplugin")
+    finish
+endif
+let b:did_ftplugin = 1

--- a/runtime/ftplugin/csv.vim
+++ b/runtime/ftplugin/csv.vim
@@ -7,11 +7,11 @@ if !exists("b:csv_delimiter")
     let s:delimiters = ",;\t|"
 
     let s:max = 0
-    for d in s:delimiters
+    for s:d in s:delimiters
         let s:count = getline(1)->split(d)->len() + getline(2)->split(d)->len()
         if s:count > s:max
             let s:max = s:count
-            let b:csv_delimiter = d
+            let b:csv_delimiter = s:d
         endif
     endfor
 endif

--- a/runtime/syntax/csv.vim
+++ b/runtime/syntax/csv.vim
@@ -11,10 +11,10 @@ let s:delimiter = get(b:, "csv_delimiter", ",")
 " generate bunch of following syntaxes:
 " syntax match csvCol8 /.\{-}\(,\|$\)/ nextgroup=escCsvCol0,csvCol0
 " syntax region escCsvCol8 start=/ *"\([^"]*""\)*[^"]*/ end=/" *\(,\|$\)/ nextgroup=escCsvCol0,csvCol0
-for col in range(8, 0, -1)
-    let s:ncol = (col == 8 ? 0 : col + 1)
-    exe $'syntax match csvCol{col}' .. ' /.\{-}\(' .. s:delimiter .. '\|$\)/ nextgroup=escCsvCol' .. s:ncol .. ',csvCol' .. s:ncol
-    exe $'syntax region escCsvCol{col}' .. ' start=/ *"\([^"]*""\)*[^"]*/ end=/" *\(' .. s:delimiter .. '\|$\)/ nextgroup=escCsvCol' .. s:ncol .. ',csvCol' .. s:ncol
+for s:col in range(8, 0, -1)
+    let s:ncol = (s:col == 8 ? 0 : s:col + 1)
+    exe $'syntax match csvCol{s:col}' .. ' /.\{-}\(' .. s:delimiter .. '\|$\)/ nextgroup=escCsvCol' .. s:ncol .. ',csvCol' .. s:ncol
+    exe $'syntax region escCsvCol{s:col}' .. ' start=/ *"\([^"]*""\)*[^"]*/ end=/" *\(' .. s:delimiter .. '\|$\)/ nextgroup=escCsvCol' .. s:ncol .. ',csvCol' .. s:ncol
 endfor
 
 hi def link csvCol1 Statement

--- a/runtime/syntax/csv.vim
+++ b/runtime/syntax/csv.vim
@@ -1,0 +1,38 @@
+" Maintainer: Maxim Kim <habamax@gmail.com>
+" Converted from vim9script
+" Last Update: 2024-06-18
+
+if exists("b:current_syntax")
+    finish
+endif
+
+let s:delimiter = get(b:, "csv_delimiter", ",")
+
+" generate bunch of following syntaxes:
+" syntax match csvCol8 /.\{-}\(,\|$\)/ nextgroup=escCsvCol0,csvCol0
+" syntax region escCsvCol8 start=/ *"\([^"]*""\)*[^"]*/ end=/" *\(,\|$\)/ nextgroup=escCsvCol0,csvCol0
+for col in range(8, 0, -1)
+    let s:ncol = (col == 8 ? 0 : col + 1)
+    exe $'syntax match csvCol{col}' .. ' /.\{-}\(' .. s:delimiter .. '\|$\)/ nextgroup=escCsvCol' .. s:ncol .. ',csvCol' .. s:ncol
+    exe $'syntax region escCsvCol{col}' .. ' start=/ *"\([^"]*""\)*[^"]*/ end=/" *\(' .. s:delimiter .. '\|$\)/ nextgroup=escCsvCol' .. s:ncol .. ',csvCol' .. s:ncol
+endfor
+
+hi def link csvCol1 Statement
+hi def link csvCol2 Constant
+hi def link csvCol3 Type
+hi def link csvCol4 PreProc
+hi def link csvCol5 Identifier
+hi def link csvCol6 Special
+hi def link csvCol7 String
+hi def link csvCol8 Comment
+
+hi def link escCsvCol1 csvCol1
+hi def link escCsvCol2 csvCol2
+hi def link escCsvCol3 csvCol3
+hi def link escCsvCol4 csvCol4
+hi def link escCsvCol5 csvCol5
+hi def link escCsvCol6 csvCol6
+hi def link escCsvCol7 csvCol7
+hi def link escCsvCol8 csvCol8
+
+let b:current_syntax = "csv"


### PR DESCRIPTION
fixes: vim/vim#15038

https://github.com/vim/vim/commit/1ce65e35ac6555054db1276e30d9d63421e6b346

Co-authored-by: Maxim Kim <habamax@gmail.com>
