### PR TITLE
vim-patch:9718ed7: runtime(filetype): update htmldjango detection

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -676,10 +676,15 @@ end
 
 --- @type vim.filetype.mapfn
 function M.html(_, bufnr)
-  for _, line in ipairs(getlines(bufnr, 1, 10)) do
+  for _, line in ipairs(getlines(bufnr, 1, 40)) do
     if matchregex(line, [[\<DTD\s\+XHTML\s]]) then
       return 'xhtml'
-    elseif matchregex(line, [[\c{%\s*\(extends\|block\|load\)\>\|{#\s\+]]) then
+    elseif
+      matchregex(
+        line,
+        [[\c{%\s*\(autoescape\|block\|comment\|csrf_token\|cycle\|debug\|extends\|filter\|firstof\|for\|if\|ifchanged\|include\|load\|lorem\|now\|query_string\|regroup\|resetcycle\|spaceless\|templatetag\|url\|verbatim\|widthratio\|with\)\>\|{#\s\+]]
+      )
+    then
       return 'htmldjango'
     end
   end


### PR DESCRIPTION
- update tags to detect djangohtml based on
  https://docs.djangoproject.com/en/5.0/ref/templates/builtins/#built-in-tag-reference

- increase the lines to inspect to 40 lines

  10 lines is too few and might result in high false negative.
  Increasing it to 40 lines should reduce the false negative.

closes: vim/vim#15037

https://github.com/vim/vim/commit/9718ed7ab989c0a0be88a0d749f24321eb0e6af1

Co-authored-by: Afiq Nazrie <afnazrie@gmail.com>
