### PR TITLE
vim-patch:9.1.0499: MS-Windows: doesn't handle symlinks properly

### DIFF
--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -3475,6 +3475,29 @@ func Test_glob2()
   endif
 endfunc
 
+func Test_glob_symlinks()
+  call writefile([], 'Xglob1')
+
+  if has("win32")
+    silent !mklink XglobBad DoesNotExist
+    if v:shell_error
+      throw 'Skipped: cannot create symlinks'
+    endif
+    silent !mklink XglobOk Xglob1
+  else
+    silent !ln -s DoesNotExist XglobBad
+    silent !ln -s Xglob1 XglobOk
+  endif
+
+  " The broken symlink is excluded when alllinks is false.
+  call assert_equal(['Xglob1', 'XglobBad', 'XglobOk'], sort(glob('Xglob*', 0, 1, 1)))
+  call assert_equal(['Xglob1', 'XglobOk'], sort(glob('Xglob*', 0, 1, 0)))
+
+  call delete('Xglob1')
+  call delete('XglobBad')
+  call delete('XglobOk')
+endfunc
+
 " Test for browse()
 func Test_browse()
   CheckFeature browse


### PR DESCRIPTION
#### vim-patch:9.1.0499: MS-Windows: doesn't handle symlinks properly

Problem:  MS-Windows: doesn't handle symlinks properly
          (Timothy Madden)
Solution: Implement lstat() on MS-Windows
          (author)

lstat() differs from stat() in how it handles symbolic links, the former
doesn't resolve the symlink while the latter does so.

Implement a simple yet effective fallback using Win32 APIs.

closes: vim/vim#15014

https://github.com/vim/vim/commit/23c5ebeb95cb942df307946e3ced230a7c8312eb

Co-authored-by: LemonBoy <thatlemon@gmail.com>
Co-authored-by: K.Takata <kentkt@csc.jp>