### PR TITLE
vim-patch:8.2.{4724,5047}: make CurSearch behavior match Vim

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -47,6 +47,8 @@ EDITOR
 
 • The order in which signs are placed was changed. Higher priority signs will
   now appear left of lower priority signs.
+• |hl-CurSearch| now behaves the same as Vim and no longer updates on every
+  cursor movement.
 
 EVENTS
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4969,8 +4969,9 @@ ColorColumn	Used for the columns set with 'colorcolumn'.
 Conceal		Placeholder characters substituted for concealed
 		text (see 'conceallevel').
 							*hl-CurSearch*
-CurSearch	Used for highlighting a search pattern under the cursor
-		(see 'hlsearch').
+CurSearch	Current match for the last search pattern (see 'hlsearch').
+		Note: This is correct after a search, but may get outdated if
+		changes are made or the screen is redrawn.
 						*hl-Cursor* *hl-lCursor*
 Cursor		Character under the cursor.
 lCursor		Character under the cursor when |language-mapping|

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -539,8 +539,6 @@ Functions:
 Highlight groups:
 - |hl-ColorColumn|, |hl-CursorColumn| are lower priority than most other
   groups
-- |hl-CurSearch| highlights match under cursor instead of last match found
-  using |n| or |N|
 - |hl-CursorLine| is low-priority unless foreground color is set
 - |hl-VertSplit| superseded by |hl-WinSeparator|
 - Highlight groups names are allowed to contain `@` characters.

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -392,6 +392,10 @@ static void changed_common(buf_T *buf, linenr_T lnum, colnr_T col, linenr_T lnum
         }
       }
     }
+
+    if (wp == curwin && xtra != 0 && search_hl_has_cursor_lnum >= lnum) {
+      search_hl_has_cursor_lnum += xtra;
+    }
   }
 
   // Call update_screen() later, which checks out what needs to be redrawn,

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1593,6 +1593,18 @@ static void win_update(win_T *wp)
         }
       }
     }
+
+    if (search_hl_has_cursor_lnum > 0) {
+      // CurSearch was used last time, need to redraw the line with it to
+      // avoid having two matches highlighted with CurSearch.
+      if (mod_top == 0 || mod_top > search_hl_has_cursor_lnum) {
+        mod_top = search_hl_has_cursor_lnum;
+      }
+      if (mod_bot == 0 || mod_bot < search_hl_has_cursor_lnum + 1) {
+        mod_bot = search_hl_has_cursor_lnum + 1;
+      }
+    }
+
     if (mod_top != 0 && hasAnyFolding(wp)) {
       // A change in a line can cause lines above it to become folded or
       // unfolded.  Find the top most buffer line that may be affected.
@@ -1651,6 +1663,7 @@ static void win_update(win_T *wp)
 
   wp->w_redraw_top = 0;  // reset for next time
   wp->w_redraw_bot = 0;
+  search_hl_has_cursor_lnum = 0;
 
   // When only displaying the lines at the top, set top_end.  Used when
   // window has scrolled down for msg_scrolled.

--- a/src/nvim/drawscreen.h
+++ b/src/nvim/drawscreen.h
@@ -25,7 +25,11 @@ EXTERN bool updating_screen INIT( = false);
 /// must_redraw to be set.
 EXTERN bool redraw_not_allowed INIT( = false);
 
-EXTERN match_T screen_search_hl INIT( = { 0 });  ///< used for 'hlsearch' highlight matching
+/// used for 'hlsearch' highlight matching
+EXTERN match_T screen_search_hl INIT( = { 0 });
+
+/// last lnum where CurSearch was displayed
+EXTERN linenr_T search_hl_has_cursor_lnum INIT( = 0);
 
 #define W_ENDCOL(wp)   ((wp)->w_wincol + (wp)->w_width)
 #define W_ENDROW(wp)   ((wp)->w_winrow + (wp)->w_height)

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -706,6 +706,9 @@ int update_search_hl(win_T *wp, linenr_T lnum, colnr_T col, char **line, match_T
         // group.
         if (shl == search_hl && shl->has_cursor) {
           shl->attr_cur = win_hl_attr(wp, HLF_LC);
+          if (shl->attr_cur != shl->attr) {
+            search_hl_has_cursor_lnum = lnum;
+          }
         } else {
           shl->attr_cur = shl->attr;
         }

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -153,7 +153,6 @@ static void redraw_for_cursorline(win_T *wp)
 /// Redraw when w_virtcol changes and
 /// - 'cursorcolumn' is set, or
 /// - 'cursorlineopt' contains "screenline", or
-/// - "CurSearch" highlight is in use, or
 /// - 'concealcursor' is active, or
 /// - Visual mode is active.
 static void redraw_for_cursorcolumn(win_T *wp)
@@ -173,10 +172,8 @@ static void redraw_for_cursorcolumn(win_T *wp)
     return;
   }
 
-  if (wp->w_p_cuc
-      || (win_hl_attr(wp, HLF_LC) != win_hl_attr(wp, HLF_L) && using_hlsearch())) {
-    // When 'cursorcolumn' is set or "CurSearch" is in use
-    // need to redraw with UPD_SOME_VALID.
+  if (wp->w_p_cuc) {
+    // When 'cursorcolumn' is set need to redraw with UPD_SOME_VALID.
     redraw_later(wp, UPD_SOME_VALID);
   } else if (wp->w_p_cul && (wp->w_p_culopt_flags & CULOPT_SCRLINE)) {
     // When 'cursorlineopt' contains "screenline" need to redraw with UPD_VALID.

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3973,6 +3973,12 @@ static void nv_next(cmdarg_T *cap)
     normal_search(cap, 0, NULL, 0, SEARCH_MARK | cap->arg, NULL);
     cap->count1 -= 1;
   }
+
+  // Redraw the window to refresh the highlighted matches.
+  if (i > 0 && p_hls && !no_hlsearch
+      && win_hl_attr(curwin, HLF_LC) != win_hl_attr(curwin, HLF_L)) {
+    redraw_later(curwin, UPD_SOME_VALID);
+  }
 }
 
 /// Search for "pat" in direction "dir" ('/' or '?', 0 for repeat).
@@ -3984,6 +3990,7 @@ static void nv_next(cmdarg_T *cap)
 static int normal_search(cmdarg_T *cap, int dir, char *pat, size_t patlen, int opt, int *wrapped)
 {
   searchit_arg_T sia;
+  pos_T const prev_cursor = curwin->w_cursor;
 
   cap->oap->motion_type = kMTCharWise;
   cap->oap->inclusive = false;
@@ -4006,6 +4013,11 @@ static int normal_search(cmdarg_T *cap, int dir, char *pat, size_t patlen, int o
     if (cap->oap->op_type == OP_NOP && (fdo_flags & FDO_SEARCH) && KeyTyped) {
       foldOpenCursor();
     }
+  }
+  // Redraw the window to refresh the highlighted matches.
+  if (!equalpos(curwin->w_cursor, prev_cursor) && p_hls && !no_hlsearch
+      && win_hl_attr(curwin, HLF_LC) != win_hl_attr(curwin, HLF_L)) {
+    redraw_later(curwin, UPD_SOME_VALID);
   }
 
   // "/$" will put the cursor after the end of the line, may need to

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -4322,9 +4322,3 @@ bool search_was_last_used(void)
 {
   return last_idx == 0;
 }
-
-/// @return  true if 'hlsearch' highlight is currently in use.
-bool using_hlsearch(void)
-{
-  return spats[last_idx].pat != NULL && p_hls && !no_hlsearch;
-}

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -197,7 +197,8 @@ describe('search highlighting', function()
       }
     end)
 
-    it('works for multiline match', function()
+    -- oldtest: Test_hlsearch_cursearch()
+    it('works for multiline match, no duplicate highlight', function()
       command([[call setline(1, ['one', 'foo', 'bar', 'baz', 'foo the foo and foo', 'bar'])]])
       feed('gg/foo<CR>')
       screen:expect([[
@@ -280,6 +281,28 @@ describe('search highlighting', function()
         abcd{2:^efg }                                |
         {2:hij}kl                                   |
         /efg\nhij                               |
+      ]])
+
+      -- check clearing CurSearch when using it for another match
+      feed('G?^abcd<CR>Y')
+      screen:expect([[
+        ---                                     |
+        {1:abcd}efg                                 |
+        hijkl                                   |
+        ---                                     |
+        {2:^abcd}efg                                 |
+        hijkl                                   |
+        ?^abcd                                  |
+      ]])
+      feed('kkP')
+      screen:expect([[
+        ---                                     |
+        {1:abcd}efg                                 |
+        {2:^abcd}efg                                 |
+        hijkl                                   |
+        ---                                     |
+        {1:abcd}efg                                 |
+        ?^abcd                                  |
       ]])
     end)
   end)

--- a/test/old/testdir/test_search.vim
+++ b/test/old/testdir/test_search.vim
@@ -1094,6 +1094,11 @@ func Test_hlsearch_cursearch()
   call term_sendkeys(buf, "h\<C-L>")
   call VerifyScreenDump(buf, 'Test_hlsearch_cursearch_multiple_line_5', {})
 
+  " check clearing CurSearch when using it for another match
+  call term_sendkeys(buf, "G?^abcd\<CR>Y")
+  call term_sendkeys(buf, "kkP")
+  call VerifyScreenDump(buf, 'Test_hlsearch_cursearch_changed_1', {})
+
   call StopVimInTerminal(buf)
   call delete('Xhlsearch_cursearch')
 endfunc


### PR DESCRIPTION
Fix #23590

#### vim-patch:8.2.4724: current instance of last search pattern not easily spotted

Problem:    Current instance of last search pattern not easily spotted.
Solution:   Add CurSearch highlighting. (closes vim/vim#10133)

https://github.com/vim/vim/commit/a43993897aa372159f682df37562f159994dc85c

Some code is superseded by later patches that are already ported.

Co-authored-by: LemonBoy <thatlemon@gmail.com>


#### vim-patch:8.2.5047: CurSearch highlight is often wrong

Problem:    CurSearch highlight is often wrong.
Solution:   Remember the last highlighted position and redraw when needed.

https://github.com/vim/vim/commit/368137aa525982984beed73940af481ac53a62af

Co-authored-by: Bram Moolenaar <Bram@vim.org>