### PR TITLE
fix(gen_help_html): handle delimiter, heading

### DIFF
--- a/runtime/doc/usr_21.txt
+++ b/runtime/doc/usr_21.txt
@@ -303,21 +303,21 @@ use, and save this in a session.  Then you can go back to this layout whenever
 you want.
    For example, this is a nice layout to use:
 >
-	+----------------------------------------+
-	|		   VIM - main help file  |
-	|					 |
-	|Move around:  Use the cursor keys, or "h|
-	|help.txt================================|
-	|explorer   |				 |
-	|dir	    |~				 |
-	|dir	    |~				 |
-	|file	    |~				 |
-	|file	    |~				 |
-	|file	    |~				 |
-	|file	    |~				 |
-	|~/=========|[No File]===================|
-	|					 |
-	+----------------------------------------+
+        +----------------------------------------+
+        |                  VIM - main help file  |
+        |                                        |
+        |Move around:  Use the cursor keys, or "h|
+        |help.txt================================|
+        |explorer   |                            |
+        |dir        |~                           |
+        |dir        |~                           |
+        |file       |~                           |
+        |file       |~                           |
+        |file       |~                           |
+        |file       |~                           |
+        |~/=========|[No File]===================|
+        |                                        |
+        +----------------------------------------+
 <
 This has a help window at the top, so that you can read this text.  The narrow
 vertical window on the left contains a file explorer.  This is a Vim plugin
@@ -448,9 +448,9 @@ trust the files you are editing: >
 
 	:set nomodeline
 
-Use this format for the modeline:
+Use this format for the modeline: >
 
-	any-text vim:set {option}={value} ... : any-text ~
+	any-text vim:set {option}={value} ... : any-text
 
 The "any-text" indicates that you can put any text before and after the part
 that Vim will use.  This allows making it look like a comment, like what was
@@ -462,9 +462,9 @@ using something like "gvim:" will not work.
 typing the ":set" command, except that you need to insert a backslash before a
 colon (otherwise it would be seen as the end of the modeline).
 
-Another example:
+Another example: >
 
-	// vim:set textwidth=72 dir=c\:\tmp:  use c:\tmp here ~
+	// vim:set textwidth=72 dir=c\:\tmp:  use c:\tmp here
 
 There is an extra backslash before the first colon, so that it's included in
 the ":set" command.  The text after the second colon is ignored, thus a remark


### PR DESCRIPTION
## Problem:
vimdoc grammar added new forms that are not handled in our HTML generator. https://github.com/neovim/tree-sitter-vimdoc/pull/134

## Solution:
Update `gen_help_html.lua`.

Fixes #29277