### PR TITLE
vim-patch:aeca717: runtime(nohlsearch): simplify mapping

### DIFF
--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -244,7 +244,7 @@ Automatically execute |:nohlsearch| after 'updatetime' or getting into |Insert| 
 Thus assuming default updatetime, hlsearch would be suspended/turned off after
 4 seconds of idle time.
 
-To disable the effect of the plugin after is has been loaded: >
+To disable the effect of the plugin after it has been loaded: >
 	au! nohlsearch
 <
 

--- a/runtime/pack/dist/opt/nohlsearch/plugin/nohlsearch.vim
+++ b/runtime/pack/dist/opt/nohlsearch/plugin/nohlsearch.vim
@@ -1,5 +1,5 @@
 " nohlsearch.vim: Auto turn off hlsearch
-" Last Change: 2024-06-18
+" Last Change: 2024-06-19
 " Maintainer: Maxim Kim <habamax@gmail.com>
 "
 " turn off hlsearch after:
@@ -8,7 +8,7 @@
 augroup nohlsearch
     au!
     noremap <Plug>(nohlsearch) <cmd>nohlsearch<cr>
-    noremap! <expr> <Plug>(nohlsearch) execute('nohlsearch')[-1]
+    noremap! <Plug>(nohlsearch) <cmd>nohlsearch<cr>
     au CursorHold * call feedkeys("\<Plug>(nohlsearch)", 'm')
     au InsertEnter * call feedkeys("\<Plug>(nohlsearch)", 'm')
 augroup END


### PR DESCRIPTION
Use <cmd> instead of <expr> with execute(...)[-1]

closes: vim/vim#15047

https://github.com/vim/vim/commit/aeca7176f3b7bdc2d698938062f6cad802fea783

Co-authored-by: Maxim Kim <habamax@gmail.com>
