### PR TITLE
feat(diff): cancel linematch if ctrl-c is pressed while it's running

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -793,8 +793,8 @@ struct diffblock_S {
   diff_T *df_next;
   linenr_T df_lnum[DB_COUNT];           // line number in buffer
   linenr_T df_count[DB_COUNT];          // nr of inserted/changed lines
-  bool is_linematched;  // has the linematch algorithm ran on this diff hunk to divide it into
-                        // smaller diff hunks?
+  int is_linematched;  // has the linematch algorithm ran on this diff hunk to divide it into
+                       // smaller diff hunks? 0: not run yet / 1: success / -1: canceled
 
   bool has_changes;     ///< has cached list of inline changes
   garray_T df_changes;  ///< list of inline changes (diffline_change_T)

--- a/src/nvim/lua/xdiff.c
+++ b/src/nvim/lua/xdiff.c
@@ -73,7 +73,8 @@ static void get_linematch_results(lua_State *lstate, mmfile_t *ma, mmfile_t *mb,
   int diff_length[2] = { count_a, count_b };
 
   int *decisions = NULL;
-  size_t decisions_length = linematch_nbuffers(diff_begin, diff_length, 2, &decisions, iwhite);
+  bool linematchCanceled = false;
+  size_t decisions_length = linematch_nbuffers(diff_begin, diff_length, 2, &decisions, iwhite, &linematchCanceled);
 
   int lnuma = start_a;
   int lnumb = start_b;

--- a/test/functional/ui/linematch_spec.lua
+++ b/test/functional/ui/linematch_spec.lua
@@ -1017,6 +1017,39 @@ something
       end
     )
   end)
+
+  describe('very big diff with linematch:8000 can be canceled with ctrl-c', function()
+    before_each(function()
+      local f1 = [[
+a
+a
+a
+a
+a
+a
+      ]])
+      local f2 = [[
+ba
+ba
+ba
+
+ba
+ba
+ba
+      ]]
+      write_file(fname, f1, false)
+      write_file(fname_2, f2, false)
+      reread()
+    end)
+
+    it(
+      'cancel the linematch algorithm',
+      function()
+      feed(':set diffopt+=linematch:800<cr>')
+      -- feed('<C-c>') -- cancel from user
+      end
+    )
+  end)
 end)
 
 describe('regressions', function()


### PR DESCRIPTION
@lewis6991 
In the case of running a linematch algorithm with a really large diff hunk that takes forever, the algorithm will hang and the user must stop the neovim process. With this pull request, I added an ability for the running algorithm to respect the ctrl + c press, similar to when you have a word completion (ctrl-p / ctrl-n) huge word list coming from many open buffers or large files, it will hang until you press ctrl + c to cancel it.

I'm not sure if i handled the capture of the ctrl-c the best way, but it seems to work. so some input on that would be appreciated if anyone knows a better way