### PR TITLE
vim-patch:9.1.0504: inner-tag textobject confused about ">" in attributes

### DIFF
--- a/src/nvim/textobject.c
+++ b/src/nvim/textobject.c
@@ -1193,13 +1193,18 @@ again:
   pos_T end_pos = curwin->w_cursor;
 
   if (!do_include) {
-    // Exclude the start tag.
+    // Exclude the start tag,
+    // but skip over '>' if it appears in quotes
+    bool in_quotes = false;
     curwin->w_cursor = start_pos;
     while (inc_cursor() >= 0) {
-      if (*get_cursor_pos_ptr() == '>') {
+      p = get_cursor_pos_ptr();
+      if (*p == '>' && !in_quotes) {
         inc_cursor();
         start_pos = curwin->w_cursor;
         break;
+      } else if (*p == '"' || *p == '\'') {
+        in_quotes = !in_quotes;
       }
     }
     curwin->w_cursor = end_pos;

--- a/test/old/testdir/test_textobjects.vim
+++ b/test/old/testdir/test_textobjects.vim
@@ -203,6 +203,18 @@ func Test_string_html_objects()
     normal! 2k0vaty
     call assert_equal("<div><div\nattr=\"attr\"\n></div></div>", @", e)
 
+    " tag, that includes a > in some attribute
+    let t = "<div attr=\"attr >> foo >> bar \">Hello</div>"
+    $put =t
+    normal! fHyit
+    call assert_equal("Hello", @", e)
+
+    " tag, that includes a > in some attribute
+    let t = "<div attr='attr >> foo >> bar '>Hello 123</div>"
+    $put =t
+    normal! fHyit
+    call assert_equal("Hello 123", @", e)
+
     set quoteescape&
 
     " this was going beyond the end of the line


### PR DESCRIPTION
#### vim-patch:9.1.0504: inner-tag textobject confused about ">" in attributes

Problem:  inner-tag textobject confused about ">" in attributes
Solution: Skip over quoted '>' when determining the start position

closes: vim/vim#15049

https://github.com/vim/vim/commit/ca7f93e6f351b310c17cfc8f88acf21c839d6116

Co-authored-by: Christian Brabandt <cb@256bit.org>