### PR TITLE
build(vim-patch.sh): don't ignore changes to version*.txt

### DIFF
--- a/runtime/doc/news-0.9.txt
+++ b/runtime/doc/news-0.9.txt
@@ -92,7 +92,7 @@ The following new APIs or features were added.
   showing a text representation of the nodes in a language tree for the current
   buffer.
 
-• |'statuscolumn'| option to customize the area to the side of a window,
+• 'statuscolumn' option to customize the area to the side of a window,
   normally containing the fold, sign and number columns. This new option follows
   the 'statusline' syntax and can be used to transform the line numbers, create
   mouse click callbacks for |signs|, introduce a custom margin or separator etc.
@@ -129,15 +129,17 @@ The following new APIs or features were added.
 • When using Nvim inside tmux 3.2 or later, the default clipboard provider
   will now copy to the system clipboard. |provider-clipboard|
 
-• |'showcmdloc'| option to display the 'showcmd' information in the
-  status line or tab line. A new %S statusline item is available to place
-  the 'showcmd' text in a custom 'statusline'. Useful for when |'cmdheight'|
-  is set to 0.
+• 'showcmdloc' option to display the 'showcmd' information in the status
+  line or tab line. A new %S statusline item is available to place the
+  'showcmd' text in a custom 'statusline'. Useful for when 'cmdheight' is set
+  to 0.
 
-• |'splitkeep'| option to control the scroll behavior of horizontal splits.
+• 'splitkeep' option to control the scroll behavior of horizontal splits.
 
-• |'diffopt'| now includes a `linematch` option to enable a second-stage diff
-  on individual hunks to provide much more accurate diffs. This option is also
+• 'wildoptions' flag "fuzzy" enables |fuzzy-matching| during |cmdline-completion|.
+
+• 'diffopt' now includes a `linematch` option to enable a second-stage diff on
+  individual hunks to provide much more accurate diffs. This option is also
   available to |vim.diff()|
 
   See https://github.com/neovim/neovim/pull/14537.
@@ -235,7 +237,7 @@ The following changes to existing APIs or features add new behavior.
   relative to the mouse. Note that the mouse doesn't update frequently without
   setting `vim.o.mousemoveevent = true`
 
-• |nvim_eval_statusline()| supports evaluating the |'statuscolumn'| through a
+• |nvim_eval_statusline()| supports evaluating the 'statuscolumn' through a
   new `opts` field: `use_statuscol_lnum`.
 
 • |nvim_buf_get_extmarks()| now accepts a -1 `ns_id` to request extmarks from

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -109,6 +109,7 @@ EDITOR
 • On Windows, filename arguments on the command-line prefixed with "~\" or
   "~/" are now expanded to the user's profile directory, not a relative path
   to a literal "~" directory.
+• |hl-PmenuMatch| and |hl-PmenuMatchSel| show matched text in completion popup.
 
 EVENTS
 
@@ -127,7 +128,7 @@ LUA
 
 OPTIONS
 
-• TODO
+• 'completeopt' flag "fuzzy" enables |fuzzy-matching| during |ins-completion|.
 
 PERFORMANCE
 

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -207,7 +207,7 @@ preprocess_patch() {
   2>/dev/null $nvim --cmd 'set dir=/tmp' +'g@^diff --git a/runtime/\<\%('"${na_rt}"'\)\>@exe "norm! d/\\v(^diff)|%$\r"' +w +q "$file"
 
   # Remove unwanted Vim doc files.
-  local na_doc='channel\.txt\|if_cscop\.txt\|netbeans\.txt\|os_\w\+\.txt\|print\.txt\|term\.txt\|todo\.txt\|version\d\.txt\|vim9\.txt\|sponsor\.txt\|intro\.txt\|tags'
+  local na_doc='channel\.txt\|if_cscop\.txt\|netbeans\.txt\|os_\w\+\.txt\|print\.txt\|term\.txt\|todo\.txt\|vim9\.txt\|tags'
   2>/dev/null $nvim --cmd 'set dir=/tmp' +'g@^diff --git a/runtime/doc/\<\%('"${na_doc}"'\)\>@exe "norm! d/\\v(^diff)|%$\r"' +w +q "$file"
 
   # Remove "Last change ..." changes in doc files.
@@ -291,6 +291,14 @@ preprocess_patch() {
 
   # Rename option.h to option_vars.h
   LC_ALL=C sed -Ee 's/( [ab]\/src\/nvim)\/option\.h/\1\/option_vars.h/g' \
+    "$file" > "$file".tmp && mv "$file".tmp "$file"
+
+  # Rename version*.txt to news.txt
+  LC_ALL=C sed -Ee 's/( [ab]\/runtime\/doc)\/version[0-9]+\.txt/\1\/news.txt/g' \
+    "$file" > "$file".tmp && mv "$file".tmp "$file"
+
+  # Rename sponsor.txt to intro.txt
+  LC_ALL=C sed -Ee 's/( [ab]\/runtime\/doc)\/sponsor\.txt/\1\/intro.txt/g' \
     "$file" > "$file".tmp && mv "$file".tmp "$file"
 
   # Rename terminal.txt to nvim_terminal_emulator.txt


### PR DESCRIPTION
Suggest adding them to news.txt instead. Close #29422

Also don't ignore changes to intro.txt and sponsor.txt, as they don't
change much these days, and it's necessary to consider whether to
include their changes in Nvim's intro.txt.
