### PR TITLE
feat(commenting): Add 'inner comment' text object

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -97,6 +97,8 @@ DEFAULTS
   • |grr| in Normal mode maps to |vim.lsp.buf.references()|
   • |gra| in Normal and Visual mode maps to |vim.lsp.buf.code_action()|
   • CTRL-S in Insert mode maps to |vim.lsp.buf.signature_help()|
+  • |igc| is a text object for 'inner comment' (comment without comment
+    markers)
 
 • Snippet:
   • `<Tab>` in Insert and Select mode maps to `vim.snippet.jump({ direction = 1 })`

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -97,8 +97,8 @@ DEFAULTS
   • |grr| in Normal mode maps to |vim.lsp.buf.references()|
   • |gra| in Normal and Visual mode maps to |vim.lsp.buf.code_action()|
   • CTRL-S in Insert mode maps to |vim.lsp.buf.signature_help()|
-  • |igc| is a text object for 'inner comment' (comment without comment
-    markers)
+  • `igc` is a text object for 'inner comment' (comment without comment
+    markers) |o_igc-default|
 
 • Snippet:
   • `<Tab>` in Insert and Select mode maps to `vim.snippet.jump({ direction = 1 })`

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -611,4 +611,12 @@ gc			Text object for the largest contiguous block of
 			`gcgc` uncomments a comment block; `dgc` deletes it).
 			Works only in Operator-pending mode.
 
+							*o_igc* *o_igc-default*
+igc			Text object for the largest contiguous block of
+			non-blank commented lines around the cursor, but
+			without the comment markers (e.g. `cigc` removes
+			everything in the comment block but the markers,
+			and start insert). Works only in Operator-pending
+			mode.
+
  vim:noet:tw=78:ts=8:ft=help:norl:

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -136,7 +136,7 @@ of these in your config by simply removing the mapping, e.g. ":unmap Y".
 - @ |v_@-default|
 - # |v_#-default|
 - * |v_star-default|
-- gc |gc-default| |v_gc-default| |o_gc-default|
+- gc |gc-default| |v_gc-default| |o_gc-default| |o_igc-default|
 - gcc |gcc-default|
 - gr prefix |gr-default|
   - |grn|

--- a/runtime/lua/vim/_comment.lua
+++ b/runtime/lua/vim/_comment.lua
@@ -270,18 +270,7 @@ local function textobject(inner)
   end
 
   -- Select range from line:col to line:col for operator to act upon
-  vim.cmd(
-    'normal! '
-      .. lnum_from
-      .. 'G'
-      .. lcol_from
-      .. '|'
-      .. visual_cmd
-      .. lnum_to
-      .. 'G'
-      .. lcol_to
-      .. '|'
-  )
+  vim.cmd(('normal! %sG%s|%s%sG%s|'):format(lnum_from, lcol_from, visual_cmd, lnum_to, lcol_to))
 end
 
 return { operator = operator, textobject = textobject, toggle_lines = toggle_lines }

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -147,6 +147,11 @@ do
       require('vim._comment').textobject()
     end
     vim.keymap.set({ 'o' }, 'gc', textobject_rhs, { desc = 'Comment textobject' })
+
+    local inner_textobject_rhs = function()
+      require('vim._comment').textobject(true)
+    end
+    vim.keymap.set({ 'o' }, 'igc', inner_textobject_rhs, { desc = 'Inner comment textobject' })
   end
 
   --- Default maps for LSP functions.

--- a/test/functional/lua/comment_spec.lua
+++ b/test/functional/lua/comment_spec.lua
@@ -706,7 +706,7 @@ describe('commenting', function()
     end)
 
     it('leaves both comment markers in text', function()
-      set_commentstring("<!-- %s -->")
+      set_commentstring('<!-- %s -->')
       set_lines({ 'aa', '<!-- this is a comment -->', 'aa' })
       set_cursor(2, 0)
       feed('d', 'igc')

--- a/test/functional/lua/comment_spec.lua
+++ b/test/functional/lua/comment_spec.lua
@@ -649,7 +649,7 @@ describe('commenting', function()
     end)
   end)
 
-  describe('Inner textobject', function()
+  describe('inner textobject', function()
     it('works', function()
       set_lines({ 'aa', '# aa', '# aa', 'aa' })
       set_cursor(2, 0)


### PR DESCRIPTION
## Problem

No way to change a comment while keeping the markers. 

Currently changing a html comment:

```html
<!-- a |comment -->
```

Type: `cgc<!-- new comment -->`

```html
<!-- new comment -->|
```

I think changing an entire comment is done quite often by programmers.

## Solution

Add an 'inner comment' text object, which is in line with `it`, `i{`, `i[`, and other surrounding text objects.

The default keymap for this text object is `igc`.

With this change:
```html
<!-- a |comment -->
```

Type: `cigcnew comment`

```html
<!-- new comment| -->
```

Fixes #29318.