### PR TITLE
vim-patch:9.1.{0503, }: cannot use fuzzy keyword completion

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1536,6 +1536,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    difference how completion candidates are reduced from the
 		    list of alternatives, but not how the candidates are
 		    collected (using different completion types).
+	   fuzzycollect  Enable fuzzy collection for default keyword completion.
+	                This allows the collection of matches using fuzzy matching
+	                criteria, providing more comprehensive and flexible
+	                results. Works in combination with other fuzzy options.
 
 						*'completeslash'* *'csl'*
 'completeslash' 'csl'	string	(default "")

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1080,6 +1080,10 @@ vim.bo.cfu = vim.bo.completefunc
 --- 	    difference how completion candidates are reduced from the
 --- 	    list of alternatives, but not how the candidates are
 --- 	    collected (using different completion types).
+---    fuzzycollect  Enable fuzzy collection for default keyword completion.
+---                 This allows the collection of matches using fuzzy matching
+---                 criteria, providing more comprehensive and flexible
+---                 results. Works in combination with other fuzzy options.
 ---
 --- @type string
 vim.o.completeopt = "menu,preview"

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -437,12 +437,13 @@ EXTERN unsigned cot_flags;      ///< flags from 'completeopt'
 #define COT_ANY_MENU    0x003  // combination of menu flags
 #define COT_LONGEST     0x004  // false: insert full match,
                                // true: insert longest prefix
-#define COT_PREVIEW     0x008
-#define COT_POPUP       0x010
-#define COT_ANY_PREVIEW 0x018  // combination of preview flags
-#define COT_NOINSERT    0x020  // false: select & insert, true: noinsert
-#define COT_NOSELECT    0x040  // false: select & insert, true: noselect
-#define COT_FUZZY       0x080  // true: fuzzy match enabled
+#define COT_PREVIEW         0x008
+#define COT_POPUP           0x010
+#define COT_ANY_PREVIEW     0x018  // combination of preview flags
+#define COT_NOINSERT        0x020  // false: select & insert, true: noinsert
+#define COT_NOSELECT        0x040  // false: select & insert, true: noselect
+#define COT_FUZZY           0x080  // true: fuzzy match enabled
+#define COT_FUZZYCOLLECT    0x100  // true: fuzzycollect match enabled
 #ifdef BACKSLASH_IN_FILENAME
 EXTERN char *p_csl;             ///< 'completeslash'
 #endif

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1462,6 +1462,10 @@ return {
         	    difference how completion candidates are reduced from the
         	    list of alternatives, but not how the candidates are
         	    collected (using different completion types).
+           fuzzycollect  Enable fuzzy collection for default keyword completion.
+                        This allows the collection of matches using fuzzy matching
+                        criteria, providing more comprehensive and flexible
+                        results. Works in combination with other fuzzy options.
       ]=],
       expand_cb = 'expand_set_completeopt',
       full_name = 'completeopt',

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -123,7 +123,7 @@ static char *(p_fdm_values[]) = { "manual", "expr", "marker", "indent",
                                   "syntax",  "diff", NULL };
 static char *(p_fcl_values[]) = { "all", NULL };
 static char *(p_cot_values[]) = { "menu", "menuone", "longest", "preview", "popup",
-                                  "noinsert", "noselect", "fuzzy", NULL };
+                                  "noinsert", "noselect", "fuzzy", "fuzzycollect", NULL };
 #ifdef BACKSLASH_IN_FILENAME
 static char *(p_csl_values[]) = { "slash", "backslash", NULL };
 #endif

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2647,6 +2647,37 @@ func Test_complete_fuzzy_match()
   call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
   call assert_equal('hello help hero h', getline('.'))
 
+  set completeopt=fuzzycollect
+  call setline(1, ['xyz  yxz  x'])
+  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('xyz  yxz  xyz', getline('.'))
+  " can fuzzy get yxz when use Ctrl-N twice
+  call setline(1, ['xyz  yxz  x'])
+  call feedkeys("A\<C-X>\<C-N>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('xyz  yxz  yxz', getline('.'))
+
+  call setline(1, ['one two o'])
+  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('one two one', getline('.'))
+
+  call setline(1, ['你好 你'])
+  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('你好 你好', getline('.'))
+  call setline(1, ['你的 我的 的'])
+  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('你的 我的 你的', getline('.'))
+  " can fuzzy get multiple-byte word when use Ctrl-N twice
+  call setline(1, ['你的 我的 的'])
+  call feedkeys("A\<C-X>\<C-N>\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('你的 我的 我的', getline('.'))
+
+  "respect noinsert
+  set completeopt=fuzzycollect,menu,menuone,noinsert
+  call setline(1, ['one two o'])
+  call feedkeys("A\<C-X>\<C-N>", 'tx')
+  call assert_equal('one', g:word)
+  call assert_equal('one two o', getline('.'))
+
   " clean up
   set omnifunc=
   bw!


### PR DESCRIPTION
Problem:  cannot use fuzzy keyword completion
                 r(Maxim Kim)
Solution: add the fuzzycollect value for the 'completeopt'
          setting, to gather matches using fuzzy logic (glepnir)

fixes: https://github.com/vim/vim/issues/14912
closes: https://github.com/vim/vim/pull/14976

https://github.com/vim/vim/commit/43eef882ff42e673af1e753892801ba20c5d002a