### PR TITLE
fix(gen_vimdoc): correctly generate function fields

### DIFF
--- a/scripts/luacats_parser.lua
+++ b/scripts/luacats_parser.lua
@@ -253,9 +253,12 @@ end
 --- @return nvim.luacats.parser.field
 local function fun2field(fun)
   local parts = { 'fun(' }
+
+  local params = {} ---@type string[]
   for _, p in ipairs(fun.params or {}) do
-    parts[#parts + 1] = string.format('%s: %s', p.name, p.type)
+    params[#params + 1] = string.format('%s: %s', p.name, p.type)
   end
+  parts[#parts + 1] = table.concat(params, ', ')
   parts[#parts + 1] = ')'
   if fun.returns then
     parts[#parts + 1] = ': '


### PR DESCRIPTION
Fixes the problem described in this comment: https://github.com/neovim/neovim/pull/29327#discussion_r1649110562