### PR TITLE
feat(vim.ui.open): try PowerShell before Explorer

### DIFF
--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -151,12 +151,15 @@ function M.open(path)
     end
   elseif vim.fn.executable('wslview') == 1 then
     cmd = { 'wslview', path }
+  elseif vim.fn.executable('powershell.exe') == 1 then
+    cmd = { 'powershell.exe', '-c', 'start', path }
   elseif vim.fn.executable('explorer.exe') == 1 then
     cmd = { 'explorer.exe', path }
   elseif vim.fn.executable('xdg-open') == 1 then
     cmd = { 'xdg-open', path }
   else
-    return nil, 'vim.ui.open: no handler found (tried: wslview, explorer.exe, xdg-open)'
+    return nil,
+      'vim.ui.open: no handler found (tried: wslview, powershell.exe, explorer.exe, xdg-open)'
   end
 
   return vim.system(cmd, { text = true, detach = true }), nil

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -153,7 +153,7 @@ describe('vim.ui', function()
         vim.fn.executable = function() return 0 end
       ]]
       eq(
-        'vim.ui.open: no handler found (tried: wslview, explorer.exe, xdg-open)',
+        'vim.ui.open: no handler found (tried: wslview, powershell.exe, explorer.exe, xdg-open)',
         exec_lua [[local _, err = vim.ui.open('foo') ; return err]]
       )
     end)


### PR DESCRIPTION
This comes from a similar motivation as #28424: explorer.exe does not work particularly well for opening arbitrary paths and URLs. However, in addition, due to an outstanding issue with WSL,[^1] explorer.exe always exits with a status of 1, resulting in an a superfluous error message being displayed.
PowerShell, on the other hand, does not suffer from this issue and preserves exit codes. Additionally, it handles URLs correctly that explorer.exe fails on.

[^1]: microsoft/WSL#6565