### PR TITLE
Use ui_busy_start()/ui_busy_stop() when search

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1264,6 +1264,7 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, size_t patlen
       // do not fill the msgbuf buffer, if cmd_silent is set, leave it
       // empty for the search_stat feature.
       if (!cmd_silent) {
+        ui_busy_start();
         msgbuf[0] = (char)dirc;
         if (utf_iscomposing_first(utf_ptr2char(p))) {
           // Use a space to draw the composing char on.
@@ -1310,6 +1311,7 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, size_t patlen
 
         gotocmdline(false);
         ui_flush();
+        ui_busy_stop();
         msg_nowait = true;  // don't wait for this message
       }
 


### PR DESCRIPTION
Fix #25980

~~I have removed `gotocmdline()` when search.~~
~~It resolves #25980 problem, but the side effect may exist.~~

I use `ui_busy_start()`  and `ui_busy_stop()` instead.