### PR TITLE
fix(runtime): add commentstring for editorconfig ftplugin

### DIFF
--- a/runtime/ftplugin/editorconfig.vim
+++ b/runtime/ftplugin/editorconfig.vim
@@ -1,0 +1,1 @@
+setlocal commentstring=#\ %s


### PR DESCRIPTION
Problem: No commentstring is set for `editorconfig` buffers

Solution: Add `ftplugin/editorconfig.vim` with `setlocal commentstring=#\ %s`