### PR TITLE
Added callback argument type annotation for `nvim_create_user_command`

### DIFF
--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -922,7 +922,7 @@ function vim.api.nvim_create_augroup(name, opts) end
 --- ```
 ---
 ---
---- @param event any (string|array) Event(s) that will trigger the handler
+--- @param event string|string[] (string|array) Event(s) that will trigger the handler
 ---              (`callback` or `command`).
 --- @param opts vim.api.keyset.create_autocmd Options dict:
 ---             • group (string|integer) optional: autocommand group name or
@@ -994,7 +994,7 @@ function vim.api.nvim_create_namespace(name) end
 ---
 --- @param name string Name of the new user command. Must begin with an uppercase
 ---             letter.
---- @param command any Replacement command to execute when this user command is
+--- @param command string|fun(tbl: vim.api.keyset.user_command_arg) Replacement command to execute when this user command is
 ---                executed. When called from Lua, the command can also be a
 ---                Lua function. The function is called with a single table
 ---                argument that contains the following keys:

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -283,6 +283,20 @@ error('Cannot require a meta file')
 --- @field range? any
 --- @field register? boolean
 
+---@class vim.api.keyset.user_command_arg
+---@field name string # Command name
+---@field args? string The args passed to the command, if any (`<args>`)
+---@field fargs table The args split by unescaped whitespace (when more than one argument is allowed), if any (`<f-args>`)
+---@field nargs string Number of arguments (see `:command-nargs`)
+---@field bang boolean True if the command was executed with `!` modifier (`<bang>`)
+---@field line1? integer # The starting line of the command range (`<line1>`)
+---@field line2? integer # The final line of the command range (`<line2>`)
+---@field range? integer # The number of items in the command range (0, 1, or 2) (`<range>`)
+---@field count? number # Any count supplied (`<count>`)
+---@field reg? string # The optional register, if specified (`<reg>`)
+---@field mods? string # Command modifiers, if any (`<mods>`)
+---@field smods table # Command modifiers in a structured format. Has the same structure as the 'mods' key of `nvim_parse_cmd()`.
+
 --- @class vim.api.keyset.win_config
 --- @field row? number
 --- @field col? number


### PR DESCRIPTION
Added annotation for the argument passed to the function for `nvim_create_user_command`; integrated new type into `nvim_create_user_command` function annotation