### PR TITLE
vim-patch:01a4fb1: runtime(java): Compose "g:java_highlight_signature" and "g:java_highlight_functions"

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1560,6 +1560,13 @@ However, if you follow the Java guidelines about how functions and classes are
 supposed to be named (with respect to upper- and lowercase) and there is any
 amount of indentation, you may want to set >
 	:let java_highlight_functions="style"
+In addition, you can combine any value of "java_highlight_functions" with >
+	:let java_highlight_signature=1
+to have the name of a function with its parameter list parens distinctly
+highlighted from its type parameters, return type, and formal parameters; and
+to have the parameter list parens of a lambda expression with its arrow
+distinctly highlighted from its formal parameters or identifiers.
+
 If neither setting does work for you, but you would still want headers of
 function declarations to be highlighted, modify the current syntax definitions
 or compose new ones.


### PR DESCRIPTION
With the variables defined, distinctly highlight parts of
a method declaration header: its name and parameter list
parens, from its type parameters, return type, and formal
parameters; and distinctly highlight parts of a lambda
expression: its parameter list parens and the arrow, from
its formal parameters and identifiers.

closes: vim/vim#15083

https://github.com/vim/vim/commit/01a4fb104dbee6a8b7ef20394a2a7c5b49cf49ca

Co-authored-by: Aliaksei Budavei <0x000c70@gmail.com>
