### PR TITLE
fix(treesitter): do not modify highlight state for _on_spell_nav

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -377,11 +377,15 @@ function TSHighlighter._on_spell_nav(_, _, buf, srow, _, erow, _)
     return
   end
 
+  -- Do not affect potentially populated highlight state. Here we just want a temporary
+  -- empty state so the C code can detect whether the region should be spell checked.
+  local highlight_states = self._highlight_states
   self:prepare_highlight_states(srow, erow)
 
   for row = srow, erow do
     on_line_impl(self, buf, row, true)
   end
+  self._highlight_states = highlight_states
 end
 
 ---@private


### PR DESCRIPTION
Problem:  Treesitter highlighter clears the already populated highlight
          state when performing spell checking while drawing a
          smoothscrolled topline.
Solution: Save and restore the highlight state in the highlighter's
          _on_spell_nav callback.

Fix #29452