### PR TITLE
feat(lua): add vim.keymap.get

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2891,6 +2891,31 @@ vim.keymap.del({modes}, {lhs}, {opts})                      *vim.keymap.del()*
     See also: ~
       • |vim.keymap.set()|
 
+vim.keymap.get({modes}, {filter})                           *vim.keymap.get()*
+    Gets mappings in a format easily usable for vim.keymap.set Examples: >lua
+        -- Gets all normal mode mappings
+        vim.keymap.get('n')
+
+        -- Gets a mapping which maps to a certain rhs
+        vim.keymap.get('n', { rhs = "<Plug>(MyAmazingFunction)" })
+<
+
+    Parameters: ~
+      • {modes}   (`string|string[]`)
+      • {filter}  (`table?`) A table with the following fields:
+                  • {lhs}? (`string`) Lhs of mapping
+                  • {rhs}? (`string`) Patter to match against rhs of mapping
+                  • {buffer}? (`integer|boolean`) Get a mapping for a certain
+                    buffer
+
+    Return: ~
+        (`table[]`) A list of objects with the following fields:
+        • {lhs} (`string`) Lhs of mapping
+        • {rhs} (`string|function`) Rhs of mapping (can be callback)
+        • {mode} (`string`) Mode of the mapping
+        • {opts}? (`vim.keymap.get.Return.Opts`) Get a mapping for a certain
+          buffer
+
 vim.keymap.set({mode}, {lhs}, {rhs}, {opts})                *vim.keymap.set()*
     Defines a |mapping| of |keycodes| to a function or keycodes.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -330,7 +330,8 @@ LUA
 • |vim.fs.relpath()| gets relative path compared to base path.
 • |vim.fs.dir()| and |vim.fs.find()| now follow symbolic links by default,
   the behavior can be turn off using the new `follow` option.
-• |vim.text.indent()| indents/dedents text.
+- |vim.text.indent()| indents/dedents text.
+- Added |vim.keymap.get()| to get keymappings.
 
 OPTIONS
 


### PR DESCRIPTION
Fix https://github.com/neovim/neovim/issues/24333

Adds a function to get a keymapping. This is really useful for saving and restoring mappings.

Example case: Neorg adds mappings (insert and normal mode) for it's api functions for each buffer and wants to remove and restore them
Before:
```lua
-- Get mappings
local mappings = vim
  .iter({ vim.api.nvim_buf_get_keymap(0, 'n'), vim.api.nvim_buf_get_keymap(0, 'n') })
  :flatten()
  :filter(function(mapping)
    if string.match(mapping.rhs, '^<Plug>(Neorg') then
      return true
    else
      return false
    end
  end)

-- Restore
for _, mapping in ipairs(mappings) do
  vim.keymap.set({ 'n', 'i' }, mapping.lhs, mapping.rhs, { desc = mapping.desc, buffer = true })
end
```

After:
```lua
-- Get mappings
local mappings = vim.keymap.get({ 'n', 'i' }, { rhs = '^<Plug>(Neorg' })

-- Restore
for _, mapping in ipairs(mappings) do
  vim.keymap.set({ 'n', 'i' }, mapping.lhs, mapping.rhs, mapping.opts)
end
```