### PR TITLE
fix(lsp): :LspStop vim.keymap.del error

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -379,7 +379,7 @@ local function reset_defaults(bufnr)
   end
   api.nvim_buf_call(bufnr, function()
     local keymap = vim.fn.maparg('K', 'n', false, true)
-    if keymap and keymap.callback == vim.lsp.buf.hover then
+    if keymap and keymap.callback == vim.lsp.buf.hover and keymap.buffer == 1 then
       vim.keymap.del('n', 'K', { buffer = bufnr })
     end
   end)


### PR DESCRIPTION
Another try at #29051, implementing the fix described in the comments.

This checks that the mapping is buffer-local, because otherwise the deletion, which is buffer-local, will not find any mapping and give an error.