### PR TITLE
vim-patch:62f7b55: runtime(netrw): save and restore register 0-9, a and unnamed

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -15,6 +15,7 @@
 "   2024 May 13 by Vim Project: prefer scp over pscp
 "   2024 Jun 04 by Vim Project: set bufhidden if buffer changed, nohidden is set and buffer shall be switched (#14915)
 "   2024 Jun 13 by Vim Project: glob() on Windows fails when a directory name contains [] (#14952)
+"   2024 Jun 23 by Vim Project: save ad restore registers when liststyle = WIDELIST (#15077)
 " Former Maintainer:	Charles E Campbell
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
 " Copyright:    Copyright (C) 2016 Charles E. Campbell {{{1
@@ -5526,13 +5527,12 @@ endfun
 " ---------------------------------------------------------------------
 " netrw#BrowseXVis: used by gx in visual mode to select a file for browsing {{{2
 fun! netrw#BrowseXVis()
-"  call Dfunc("netrw#BrowseXVis()")
-  let akeep = @a
+  let dict={}
+  let dict.a=[getreg('a'), getregtype('a')]
   norm! gv"ay
   let gxfile= @a
-  let @a    = akeep
+  call s:RestoreRegister(dict)
   call netrw#BrowseX(gxfile,netrw#CheckIfRemote(gxfile))
-"  call Dret("netrw#BrowseXVis")
 endfun
 
 " ---------------------------------------------------------------------
@@ -9679,7 +9679,13 @@ fun! s:NetrwWideListing()
    " fpl: filenames per line
    " fpc: filenames per column
    setl ma noro
-   let keepa= @a
+   let dict={}
+   " save the unnamed register and register 0-9 and a
+   let dict.a=[getreg('a'), getregtype('a')]
+   for i in range(0, 9)
+     let dict[i] = [getreg(i), getregtype(i)]
+   endfor
+   let dict.unnamed = [getreg(''), getregtype('')]
 "   call Decho("setl ma noro",'~'.expand("<slnum>"))
    let b:netrw_cpf= 0
    if line("$") >= w:netrw_bannercnt
@@ -9687,7 +9693,8 @@ fun! s:NetrwWideListing()
     exe 'sil NetrwKeepj '.w:netrw_bannercnt.',$g/^./if virtcol("$") > b:netrw_cpf|let b:netrw_cpf= virtcol("$")|endif'
     NetrwKeepj call histdel("/",-1)
    else
-    let @a= keepa
+    " restore stored registers
+    call s:RestoreRegister(dict)
 "    call Dret("NetrwWideListing")
     return
    endif
@@ -9729,7 +9736,7 @@ fun! s:NetrwWideListing()
    exe 'nno <buffer> <silent> b	:call search(''^.\\|\s\s\zs\S'',''bW'')'."\<cr>"
 "   call Decho("NetrwWideListing) setl noma nomod ro",'~'.expand("<slnum>"))
    exe "setl ".g:netrw_bufsettings
-    let @a= keepa
+   call s:RestoreRegister(dict)
 "   call Decho("ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
 "   call Dret("NetrwWideListing")
    return
@@ -9741,7 +9748,6 @@ fun! s:NetrwWideListing()
     sil! nunmap <buffer> b
    endif
   endif
-
 endfun
 
 " ---------------------------------------------------------------------
@@ -10062,7 +10068,8 @@ fun! s:SetupNetrwStatusLine(statline)
    endif
 
    " set up User9 highlighting as needed
-   let keepa= @a
+  let dict={}
+  let dict.a=[getreg('a'), getregtype('a')]
    redir @a
    try
     hi User9
@@ -10074,7 +10081,7 @@ fun! s:SetupNetrwStatusLine(statline)
     endif
    endtry
    redir END
-   let @a= keepa
+   call s:RestoreRegister(dict)
   endif
 
   " set up status line (may use User9 highlighting)
@@ -11882,6 +11889,16 @@ fun! s:RestoreCursorline()
   endif
 "  call Decho("(s:RestoreCursorline) COMBAK: cuc=".&l:cuc." cul=".&l:cul)
 "  call Dret("s:RestoreCursorline : restored cul=".&l:cursorline." cuc=".&l:cursorcolumn)
+endfun
+
+" s:RestoreRegister: restores all registers given in the dict {{{2
+fun! s:RestoreRegister(dict)
+  for [key, val] in items(a:dict)
+    if key == 'unnamed'
+      let key = ''
+    endif
+    call setreg(key, val[0], val[1])
+  endfor
 endfun
 
 " ---------------------------------------------------------------------


### PR DESCRIPTION
#### vim-patch:62f7b55: runtime(netrw): save and restore register 0-9, a and unnamed

https://github.com/vim/vim/commit/62f7b55c1a4564f8744af9446bc7af47fe16a245

Co-authored-by: Christian Brabandt <cb@256bit.org>