### PR TITLE
vim-patch:9.1.0516: need more tests for nested dicts and list comparison

### DIFF
--- a/test/old/testdir/test_listdict.vim
+++ b/test/old/testdir/test_listdict.vim
@@ -1447,4 +1447,53 @@ func Test_extendnew_leak()
   for i in range(100) | silent! call extendnew({}, {}, {}) | endfor
 endfunc
 
+" Test for comparing deeply nested List/Dict values
+func Test_deep_nested_listdict_compare()
+  let lines =<< trim END
+    func GetNestedList(sz)
+      let l = []
+      let x = l
+      for i in range(a:sz)
+        let y = [1]
+        call add(x, y)
+        let x = y
+      endfor
+      return l
+    endfunc
+
+    VAR l1 = GetNestedList(1000)
+    VAR l2 = GetNestedList(999)
+    call assert_false(l1 == l2)
+
+    #" after 1000 nested items, the lists are considered to be equal
+    VAR l3 = GetNestedList(1001)
+    VAR l4 = GetNestedList(1002)
+    call assert_true(l3 == l4)
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  let lines =<< trim END
+    func GetNestedDict(sz)
+      let d = {}
+      let x = d
+      for i in range(a:sz)
+        let y = {}
+        let x['a'] = y
+        let x = y
+      endfor
+      return d
+    endfunc
+
+    VAR d1 = GetNestedDict(1000)
+    VAR d2 = GetNestedDict(999)
+    call assert_false(d1 == d2)
+
+    #" after 1000 nested items, the Dicts are considered to be equal
+    VAR d3 = GetNestedDict(1001)
+    VAR d4 = GetNestedDict(1002)
+    call assert_true(d3 == d4)
+  END
+  call CheckLegacyAndVim9Success(lines)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION


Problem:  need more tests for nested dicts and list comparision Solution: Add tests for comparing deeply nested List/Dict values
          (Yegappan Lakshmanan)

closes: vim/vim#15081

https://github.com/vim/vim/commit/88bbdb04c2776ba69b8e5da58051fd94f8842b03