### PR TITLE
feat(vim.ui.open): configurable opener

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2559,7 +2559,7 @@ vim.ui.input({opts}, {on_confirm})                            *vim.ui.input()*
                       typed (it might be an empty string if nothing was
                       entered), or `nil` if the user aborted the dialog.
 
-vim.ui.open({path})                                            *vim.ui.open()*
+vim.ui.open({path}, {opt})                                     *vim.ui.open()*
     Opens `path` with the system default handler (macOS `open`, Windows
     `explorer.exe`, Linux `xdg-open`, …), or returns (but does not show) an
     error message on failure.
@@ -2570,6 +2570,8 @@ vim.ui.open({path})                                            *vim.ui.open()*
         -- Asynchronous.
         vim.ui.open("https://neovim.io/")
         vim.ui.open("~/path/to/file")
+        -- Use the "osurl" command to handle the path or URL.
+        vim.ui.open("gh#neovim/neovim!29490", { cmd = { 'osurl' } })
         -- Synchronous (wait until the process exits).
         local cmd, err = vim.ui.open("$VIMRUNTIME")
         if cmd then
@@ -2579,6 +2581,8 @@ vim.ui.open({path})                                            *vim.ui.open()*
 
     Parameters: ~
       • {path}  (`string`) Path or URL to open
+      • {opt}   (`{ cmd?: string[] }?`) Options
+                • cmd string[]|nil Command used to open the path or URL.
 
     Return (multiple): ~
         (`vim.SystemObj?`) Command object, or nil if not found.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -194,7 +194,10 @@ TUI
 
 UI
 
-• TODO
+• |vim.ui.open()| (by default bound to |gx|) accepts an `opt.cmd` parameter
+  which controls the tool used to open the given path or URL. If you want to
+  globally set this, you can override vim.ui.open using the same approach
+  described at |vim.paste()|.
 
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -157,5 +157,28 @@ describe('vim.ui', function()
         exec_lua [[local _, err = vim.ui.open('foo') ; return err]]
       )
     end)
+
+    it('opt.cmd #29490', function()
+      t.matches(
+        'ENOENT: no such file or directory',
+        t.pcall_err(exec_lua, function()
+          vim.ui.open('foo', { cmd = { 'non-existent-tool' } })
+        end)
+      )
+
+      eq(
+        {
+          code = 0,
+          signal = 0,
+          stderr = '',
+          stdout = 'arg1=arg1;arg2=https://example.com;',
+        },
+        exec_lua(function(cmd_)
+          local cmd, err = vim.ui.open('https://example.com', { cmd = cmd_ })
+          assert(cmd and not err)
+          return cmd:wait()
+        end, { n.testprg('printargs-test'), 'arg1' })
+      )
+    end)
   end)
 end)


### PR DESCRIPTION
With the welcomed demise of `netrw`, we lost an opportunity to use an arbitrary command for opening URL-like strings with `gx`. This should suggest a way how to recover this functionality.

Of course, new name of the variable `vim.g.netrw_browsex_viewer` should be developed (I am not sure what are the standards for creating new options).

Another thing which is missing are tests. I tried to create one, but I got completely lost and frankly `neovim` is not my primary editor, so I don’t have a time to dive too deep into its innards.

Will eventually Fix: https://github.com/neovim/neovim/issues/29488