### PR TITLE
feat(vim.lsp.completion): Add filter option

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1616,6 +1616,8 @@ Lua module: vim.lsp.completion                                *lsp-completion*
     Fields: ~
       • {autotrigger}?  (`boolean`) Whether to trigger completion
                         automatically. Default: false
+      • {filter}?       (`vim.lsp.completion.FilterFn`) Function used to
+                        filter completion items. Default: nil
 
 
                                                  *vim.lsp.completion.enable()*


### PR DESCRIPTION
Add `filter` option to the LSP completion `enable` function that allows filtering each completion item manually. 
This gives the flexibility to the user to do additional filtering on the completion items.
For example, to do a fuzzy filtering on a label this needs to be set up:

```lua
vim.lsp.completion.enable(true, client.id, bufnr, {
  autotrigger = true,
  filter = function(item, prefix)
    return next(vim.fn.matchfuzzy({ item.label }, prefix))
  end,
})
```

Closes https://github.com/neovim/neovim/issues/29287

