### PR TITLE
fix(lsp): don't send foreign diagnostics to servers in buf.code_action

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -852,13 +852,9 @@ function M.code_action(opts)
   if opts.diagnostics or opts.only then
     opts = { options = opts }
   end
-  local context = opts.context or {}
+  local context = opts.context and vim.deepcopy(opts.context) or {}
   if not context.triggerKind then
     context.triggerKind = vim.lsp.protocol.CodeActionTriggerKind.Invoked
-  end
-  if not context.diagnostics then
-    local bufnr = api.nvim_get_current_buf()
-    context.diagnostics = vim.lsp.diagnostic.get_line_diagnostics(bufnr)
   end
   local mode = api.nvim_get_mode().mode
   local bufnr = api.nvim_get_current_buf()
@@ -900,6 +896,18 @@ function M.code_action(opts)
         util.make_given_range_params(range.start, range['end'], bufnr, client.offset_encoding)
     else
       params = util.make_range_params(win, client.offset_encoding)
+    end
+    if not context.diagnostics then
+      local ns_push = vim.lsp.diagnostic.get_namespace(client.id, false)
+      local ns_pull = vim.lsp.diagnostic.get_namespace(client.id, true)
+      local diagnostics = {}
+      local lnum = api.nvim_win_get_cursor(0)[1] - 1
+      vim.list_extend(diagnostics, vim.diagnostic.get(bufnr, { namespace = ns_pull, lnum = lnum }))
+      vim.list_extend(diagnostics, vim.diagnostic.get(bufnr, { namespace = ns_push, lnum = lnum }))
+      ---@diagnostic disable-next-line: no-unknown
+      context.diagnostics = vim.tbl_map(function(d)
+        return d.user_data.lsp
+      end, diagnostics)
     end
     params.context = context
     client.request(ms.textDocument_codeAction, params, on_result, bufnr)

--- a/test/functional/plugin/lsp/diagnostic_spec.lua
+++ b/test/functional/plugin/lsp/diagnostic_spec.lua
@@ -98,33 +98,6 @@ describe('vim.lsp.diagnostic', function()
     clear()
   end)
 
-  describe('vim.lsp.diagnostic', function()
-    it('maintains LSP information when translating diagnostics', function()
-      local result = exec_lua [[
-        local diagnostics = {
-          make_error("Error 1", 1, 1, 1, 5),
-        }
-
-        diagnostics[1].code = 42
-        diagnostics[1].data = "Hello world"
-
-        vim.lsp.diagnostic.on_publish_diagnostics(nil, {
-          uri = fake_uri,
-          diagnostics = diagnostics,
-        }, {client_id=client_id})
-
-        return {
-          vim.diagnostic.get(diagnostic_bufnr, {lnum=1})[1],
-          vim.lsp.diagnostic.get_line_diagnostics(diagnostic_bufnr, 1)[1],
-        }
-      ]]
-      eq({ code = 42, data = 'Hello world' }, result[1].user_data.lsp)
-      eq(42, result[1].code)
-      eq(42, result[2].code)
-      eq('Hello world', result[2].data)
-    end)
-  end)
-
   describe('vim.lsp.diagnostic.on_publish_diagnostics', function()
     it('allows configuring the virtual text via vim.lsp.with', function()
       local expected_spacing = 10


### PR DESCRIPTION
`buf.code_action` always included diagnostics on a given line from all
clients. Servers should only receive diagnostics they published, and in
the exact same format they sent it.

Should fix https://github.com/neovim/neovim/issues/29500
