### PR TITLE
build(deps): fix formatc target on MSVC

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -307,6 +307,7 @@ get_externalproject_options(uncrustify ${DEPS_IGNORE_SHA})
 ExternalProject_Add(uncrustify
   DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/uncrustify
   CMAKE_ARGS ${DEPS_CMAKE_ARGS}
+    -D CMAKE_RUNTIME_OUTPUT_DIRECTORY=${DEPS_BIN_DIR}
   EXCLUDE_FROM_ALL TRUE
   ${EXTERNALPROJECT_OPTIONS})
 


### PR DESCRIPTION
Set CMAKE_RUNTIME_OUTPUT_DIRECTORY for CMAKE_ARGS for the uncrustify ExternalProject to point to DEPS_BIN_DIR because the uncrustify cmake sources do not install to DESTDIR/bin under MSVC but to DESTDIR.