### PR TITLE
refactor: remove special-case conversion for german sharp s

### DIFF
--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1352,8 +1352,7 @@ int mb_toupper(int a)
 
 bool mb_islower(int a)
 {
-  // German sharp s is lower case but has no upper case equivalent.
-  return (mb_toupper(a) != a) || a == 0xdf;
+  return mb_toupper(a) != a;
 }
 
 /// Return the lower-case equivalent of "a", which is a UCS-4 character.  Use


### PR DESCRIPTION
The comment "German sharp s is lower case but has no upper case
equivalent." is no longer true and is therefore not needed anymore.
