### PR TITLE
refactor: remove special handling for lowercase German sharp s

### DIFF
--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1326,9 +1326,6 @@ int utf_fold(int a)
 // invalid values or can't handle latin1 when the locale is C.
 // Speed is most important here.
 
-// Note: UnicodeData.txt does not define U+1E9E as being the corresponding upper
-// case letter for U+00DF (ß), however it is part of the toLower table
-
 /// Return the upper-case equivalent of "a", which is a UCS-4 character.  Use
 /// simple case folding.
 int mb_toupper(int a)

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -2148,18 +2148,6 @@ bool swapchar(int op_type, pos_T *pos)
     return false;
   }
 
-  // ~ is OP_NOP, g~ is OP_TILDE, gU is OP_UPPER
-  if ((op_type == OP_UPPER || op_type == OP_NOP || op_type == OP_TILDE) && c == 0xdf) {
-    pos_T sp = curwin->w_cursor;
-
-    // Special handling for lowercase German sharp s (ß): convert to uppercase (ẞ).
-    curwin->w_cursor = *pos;
-    del_char(false);
-    ins_char(0x1E9E);
-    curwin->w_cursor = sp;
-    return true;
-  }
-
   int nc = c;
   if (mb_islower(c)) {
     if (op_type == OP_ROT13) {


### PR DESCRIPTION
utf8proc already defines LATIN CAPITAL LETTER SHARP S (ẞ) to be the
uppercase variant of LATIN SMALL LETTER SHARP S (ß), so this special
workaround when using `gU` is no longer needed on the neovim side.