### PR TITLE
feat(win32): embed executable icon

### DIFF
--- a/runtime/windows_icon.rc
+++ b/runtime/windows_icon.rc
@@ -1,0 +1,4 @@
+// NOTE: this resource file *must* be in the same folder as the icon.
+// Otherwise, absolute paths would need to be used.
+// see https://learn.microsoft.com/en-us/windows/win32/menurc/icon-resource
+NEOVIM_ICON ICON "neovim.ico"

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -708,6 +708,12 @@ target_sources(main_lib INTERFACE
   ${EXTERNAL_SOURCES}
   ${EXTERNAL_HEADERS})
 
+if(WIN32)
+  # add windows resource file pointing to the neovim icon
+  # this makes the icon appear for the neovim exe and associated filetypes
+  target_sources(nvim_bin PRIVATE ${NVIM_RUNTIME_DIR}/windows_icon.rc)
+endif()
+
 target_sources(nlua0 PUBLIC ${NLUA0_SOURCES})
 
 target_link_libraries(nvim_bin PRIVATE main_lib PUBLIC libuv)


### PR DESCRIPTION
Problem: on windows, the neovim executable (and thus the filetypes associated to open with neovim) has no embedded icon

Solution: create a windows resource file pointing to the icon, and add it to the nvim binary target

fixes #27466

before:
![image](https://github.com/neovim/neovim/assets/20356389/baa972c7-4216-401c-a721-d3dbc383445a)

after:
![image](https://github.com/neovim/neovim/assets/20356389/8dc4a495-9b95-4671-aaa9-10d31d214ab7)
