### PR TITLE
fix(lsp): default to `label` for newText

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -176,7 +176,7 @@ local function apply_defaults(item, defaults)
   if defaults.editRange then
     local textEdit = item.textEdit or {}
     item.textEdit = textEdit
-    textEdit.newText = textEdit.newText or item.textEditText or item.insertText
+    textEdit.newText = textEdit.newText or item.textEditText or item.insertText or item.label
     if defaults.editRange.start then
       textEdit.range = textEdit.range or defaults.editRange
     elseif defaults.editRange.insert then

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -427,6 +427,33 @@ describe('vim.lsp.completion: item conversion', function()
       eq('the-insertText', text)
     end
   )
+
+  it(
+    'defaults to label as textEdit.newText if insertText or textEditText are not present',
+    function()
+      local completion_list = {
+        isIncomplete = false,
+        itemDefaults = {
+          editRange = {
+            start = { line = 1, character = 1 },
+            ['end'] = { line = 1, character = 4 },
+          },
+          insertTextFormat = 2,
+          data = 'foobar',
+        },
+        items = {
+          {
+            label = 'hello',
+            data = 'item-property-has-priority',
+          },
+        },
+      }
+      local result = complete('|', completion_list)
+      eq(1, #result.items)
+      local text = result.items[1].user_data.nvim.lsp.completion_item.textEdit.newText
+      eq('hello', text)
+    end
+  )
 end)
 
 describe('vim.lsp.completion: protocol', function()


### PR DESCRIPTION
Problem: 

If the server doesn't provide newText, item.textEditText or item.insertText, `newText` will be `nil`.
This will result in an error on line 157 trying to index a nil value.

Solution:

From what I could read from the spec: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#completionItem

the client should default back to using `label` if `textEditText` or `insertText` is not provided.