### PR TITLE
fix(runtime): update b:undo_ftplugin in Lua runtime files

### DIFF
--- a/runtime/ftplugin/c.lua
+++ b/runtime/ftplugin/c.lua
@@ -11,4 +11,4 @@ if vim.fn.isdirectory('/usr/include') == 1 then
   ]])
 end
 
-vim.b.undo_ftplugin = vim.b.undo_ftplugin .. '|setl path<'
+vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | setl path<'

--- a/runtime/ftplugin/cs.lua
+++ b/runtime/ftplugin/cs.lua
@@ -1,1 +1,3 @@
 vim.bo.commentstring = '// %s'
+
+vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | setl commentstring<'

--- a/runtime/ftplugin/d.lua
+++ b/runtime/ftplugin/d.lua
@@ -1,1 +1,3 @@
 vim.bo.commentstring = '// %s'
+
+vim.b.undo_ftplugin = 'setl commentstring<'

--- a/runtime/ftplugin/glsl.lua
+++ b/runtime/ftplugin/glsl.lua
@@ -1,1 +1,3 @@
 vim.bo.commentstring = '// %s'
+
+vim.b.undo_ftplugin = 'setl commentstring<'

--- a/runtime/ftplugin/help.lua
+++ b/runtime/ftplugin/help.lua
@@ -30,3 +30,5 @@ end
 vim.keymap.set('n', 'gO', function()
   require('vim.vimhelp').show_toc()
 end, { buffer = 0, silent = true })
+
+vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | nunmap <buffer> gO'

--- a/runtime/ftplugin/query.lua
+++ b/runtime/ftplugin/query.lua
@@ -33,3 +33,5 @@ end
 
 -- it's a lisp!
 vim.cmd([[ runtime! ftplugin/lisp.vim ]])
+
+vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | setl omnifunc< iskeyword<'


### PR DESCRIPTION
Related to #29506, but adding ` | lua vim.treesitter.stop()` to `b:undo_ftplugin` doesn't solve the problem.
