### PR TITLE
perf(treesitter): detach parser when it's no longer active

### DIFF
--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -41,17 +41,25 @@ function M._create_parser(bufnr, lang, opts)
   local self = LanguageTree.new(bufnr, lang, opts)
 
   local function bytes_cb(_, ...)
+    if parsers[bufnr] ~= self then
+      return true
+    end
     self:_on_bytes(...)
   end
 
   local function detach_cb(_, ...)
     if parsers[bufnr] == self then
       parsers[bufnr] = nil
+    else
+      return true
     end
     self:_on_detach(...)
   end
 
   local function reload_cb(_)
+    if parsers[bufnr] ~= self then
+      return true
+    end
     self:_on_reload()
   end
 


### PR DESCRIPTION
Problem:
When calling `vim.treesitter.get_parser()` with different languages on the same buffer, the active parser of the buffer is changed, but the old parser is still attached to the buffer even though it's not reachable any more. This can be observed as delay when typing text after executing the following script:
```lua
    for _ = 1, 100000 do
      vim.treesitter.get_parser(0, 'lua')
      vim.treesitter.get_parser(0, 'query')
    end
```
Solution:
When a parser is longer the active one in its buffer, detach from the buffer by returning `true` in `nvim_buf_attach` callbacks.

This is extracted from #29530.