### PR TITLE
fix(runtime): stop treesitter highlight in b:undo_ftplugin

### DIFF
--- a/runtime/ftplugin/help.lua
+++ b/runtime/ftplugin/help.lua
@@ -31,4 +31,5 @@ vim.keymap.set('n', 'gO', function()
   require('vim.vimhelp').show_toc()
 end, { buffer = 0, silent = true })
 
+vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | call v:lua.vim.treesitter.stop()'
 vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | nunmap <buffer> gO'

--- a/runtime/ftplugin/lua.lua
+++ b/runtime/ftplugin/lua.lua
@@ -1,2 +1,4 @@
 -- use treesitter over syntax
 vim.treesitter.start()
+
+vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | call v:lua.vim.treesitter.stop()'

--- a/runtime/ftplugin/query.lua
+++ b/runtime/ftplugin/query.lua
@@ -1,6 +1,6 @@
 -- Neovim filetype plugin file
 -- Language:	Treesitter query
--- Last Change:	2023 Aug 23
+-- Last Change:	2024 Jul 03
 
 if vim.b.did_ftplugin == 1 then
   return
@@ -32,6 +32,7 @@ if not vim.b.disable_query_linter and #query_lint_on > 0 then
 end
 
 -- it's a lisp!
-vim.cmd([[ runtime! ftplugin/lisp.vim ]])
+vim.cmd([[runtime! ftplugin/lisp.vim]])
 
 vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | setl omnifunc< iskeyword<'
+vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | call v:lua.vim.treesitter.stop()'

--- a/runtime/indent/query.lua
+++ b/runtime/indent/query.lua
@@ -1,6 +1,6 @@
 -- Neovim indent file
 -- Language:	Treesitter query
--- Last Change:	2022 Mar 29
+-- Last Change:	2024 Jul 03
 
 -- it's a lisp!
-vim.cmd([[ runtime! indent/lisp.vim ]])
+vim.cmd([[runtime! indent/lisp.vim]])

--- a/runtime/syntax/query.lua
+++ b/runtime/syntax/query.lua
@@ -1,6 +1,6 @@
 -- Neovim syntax file
 -- Language:	Treesitter query
--- Last Change:	2022 Apr 13
+-- Last Change:	2024 Jul 03
 
 -- it's a lisp!
-vim.cmd([[ runtime! syntax/lisp.vim ]])
+vim.cmd([[runtime! syntax/lisp.vim]])


### PR DESCRIPTION
It seems that nvim-treesitter stops treesitter highlight when changing
filetype, so it makes sense for builtin ftplugins to do this as well.

Use :call and v:lua here to allow separation with '|'.

This is extracted from #29530.
