### PR TITLE
build(macos): disable deduplication in link step

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -160,6 +160,9 @@ elseif(CMAKE_SYSTEM_NAME MATCHES "Darwin")
   # ENABLE_EXPORTS is set to true. See
   # https://github.com/neovim/neovim/issues/25295
   target_link_options(nvim_bin PRIVATE "-Wl,-export_dynamic")
+  # Apple Clang 16's new deduplication pass leads to lock-up on start
+  # TODO(clason): verify that problem remains after release or remove
+  target_link_options(nvim_bin PRIVATE "-Wl,-no_deduplicate")
 elseif(CMAKE_SYSTEM_NAME MATCHES "OpenBSD")
   target_link_libraries(main_lib INTERFACE pthread c++abi)
 elseif(CMAKE_SYSTEM_NAME STREQUAL "SunOS")


### PR DESCRIPTION
Problem: Apple Clang 16 comes with a new deduplication algorithm that is
enabled by default in release builds (https://developer.apple.com/documentation/xcode-release-notes/xcode-16-release-notes#New-Features-in-Xcode-16-Beta) which breaks the built
nvim binary (locks and spins at 100% CPU).

Solution: Disable deduplication on macOS. Tested on Clang 15 as well and
seems to make no difference to binary size anyway.
