### PR TITLE
vim-patch:2606e77: runtime(doc): rename variable for pandoc markdown support

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2045,9 +2045,9 @@ PANDOC						*ft-pandoc-syntax*
 
 By default, markdown files will be detected as filetype "markdown".
 Alternatively, you may want them to be detected as filetype "pandoc" instead.
-To do so, set the following: >
+To do so, set the *g:filetype_md* var: >
 
-	:let g:markdown_md = 'pandoc'
+	:let g:filetype_md = 'pandoc'
 
 The pandoc syntax plugin uses |conceal| for pretty highlighting. Default is 1 >
 


### PR DESCRIPTION
fixes: vim/vim#15141

https://github.com/vim/vim/commit/2606e7718c49fc8221dfff21b36eff632ef668a0

Co-authored-by: Christian Brabandt <cb@256bit.org>
