### PR TITLE
fix(diagnostic): make docs agree with code

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -401,7 +401,7 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
                        file or not. Similar to 'wrapscan'.
       • {severity}?    (`vim.diagnostic.SeverityFilter`) See
                        |diagnostic-severity|.
-      • {float}?       (`boolean|vim.diagnostic.Opts.Float`, default: `true`)
+      • {float}?       (`boolean|vim.diagnostic.Opts.Float`, default: `false`)
                        If `true`, call |vim.diagnostic.open_float()| after
                        moving. If a table, pass the table as the {opts}
                        parameter to |vim.diagnostic.open_float()|. Unless

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -972,9 +972,8 @@ local function goto_diagnostic(diagnostic, opts)
     vim.cmd('normal! zv')
   end)
 
-  local float = if_nil(opts.float, true)
-  if float then
-    local float_opts = type(float) == 'table' and float or {}
+  if opts.float then
+    local float_opts = type(opts.float) == 'table' and opts.float or {}
     vim.schedule(function()
       M.open_float(vim.tbl_extend('keep', float_opts, {
         bufnr = api.nvim_win_get_buf(winid),
@@ -1271,7 +1270,7 @@ end
 --- If a table, pass the table as the {opts} parameter to |vim.diagnostic.open_float()|.
 --- Unless overridden, the float will show diagnostics at the new cursor
 --- position (as if "cursor" were passed to the "scope" option).
---- (default: `true`)
+--- (default: `false`)
 --- @field float? boolean|vim.diagnostic.Opts.Float
 ---
 --- Window ID


### PR DESCRIPTION
Problem: the code and docs for vim.diagnostic.JumpOpts.float send mixed signals about what the default should be. When the option is first set, in the global_diagnostic_options table, the comment clearly says that the default is false. Later in the code, in goto_diagnostic, there's a line that sets the default to true if no default is present. Finally, the docs say that the default is true.

Solution: Change the docs to reflect the new default of false and fix the goto_diagnostic function.