### PR TITLE
fix(treesitter): display fields for anonymous nodes in :InspectTree

### DIFF
--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -220,13 +220,12 @@ function TSTreeView:draw(bufnr)
 
     local text ---@type string
     if item.node:named() then
-      if item.field then
-        text = string.format('%s: (%s', item.field, item.node:type())
-      else
-        text = string.format('(%s', item.node:type())
-      end
+      text = string.format('(%s', item.node:type())
     else
       text = string.format('%q', item.node:type()):gsub('\n', 'n')
+    end
+    if item.field then
+      text = string.format('%s: %s', item.field, text)
     end
 
     local next = self:get(i + 1)

--- a/test/functional/treesitter/inspect_tree_spec.lua
+++ b/test/functional/treesitter/inspect_tree_spec.lua
@@ -37,7 +37,7 @@ describe('vim.treesitter.inspect_tree', function()
 
   it('can toggle to show anonymous nodes', function()
     insert([[
-      print()
+      print('hello')
       ]])
 
     exec_lua([[
@@ -48,11 +48,15 @@ describe('vim.treesitter.inspect_tree', function()
 
     expect_tree [[
       (chunk ; [0, 0] - [2, 0]
-        (function_call ; [0, 0] - [0, 7]
+        (function_call ; [0, 0] - [0, 14]
           name: (identifier) ; [0, 0] - [0, 5]
-          arguments: (arguments ; [0, 5] - [0, 7]
+          arguments: (arguments ; [0, 5] - [0, 14]
             "(" ; [0, 5] - [0, 6]
-            ")"))) ; [0, 6] - [0, 7]
+            (string ; [0, 6] - [0, 13]
+              start: "'" ; [0, 6] - [0, 7]
+              content: (string_content) ; [0, 7] - [0, 12]
+              end: "'") ; [0, 12] - [0, 13]
+            ")"))) ; [0, 13] - [0, 14]
       ]]
   end)
 


### PR DESCRIPTION
**Problem:** Anonymous nodes do not have their fields displayed in `:InspectTree`

**Solution:** Show them