### PR TITLE
fix(mouse): don't treat click on hsep as click on statusline

### DIFF
--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -250,11 +250,17 @@ static int get_fpos_of_mouse(pos_T *mpos)
   }
 
   // winpos and height may change in win_enter()!
-  if (winrow >= wp->w_height_inner) {  // In (or below) status line
+  if (winrow >= wp->w_height_inner + wp->w_status_height) {  // Below window
+    if (mouse_grid <= 1 && mouse_row < Rows - p_ch
+        && mouse_row >= Rows - p_ch - global_stl_height()) {  // In global status line
+      return IN_STATUS_LINE;
+    }
+    return IN_UNKNOWN;
+  } else if (winrow >= wp->w_height_inner) {  // In window status line
     return IN_STATUS_LINE;
   }
 
-  if (winrow < 0 && winrow + wp->w_winbar_height >= 0) {
+  if (winrow < 0 && winrow + wp->w_winbar_height >= 0) {  // In winbar
     return MOUSE_WINBAR;
   }
 

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -2002,5 +2002,24 @@ describe('ui/mouse/input', function()
     feed('<Down><CR>')
     eq({ 4, 20 }, api.nvim_win_get_cursor(0))
     eq('the moon', fn.getreg('"'))
+
+    -- Try clicking in the cmdline
+    api.nvim_input_mouse('right', 'press', '', 0, 23, 0)
+    api.nvim_input_mouse('right', 'release', '', 0, 23, 0)
+    feed('<Down><Down><Down><CR>')
+    eq('baz', api.nvim_get_var('menustr'))
+
+    -- Try clicking in horizontal separator with global statusline
+    command('set laststatus=3')
+    api.nvim_input_mouse('right', 'press', '', 0, 5, 0)
+    api.nvim_input_mouse('right', 'release', '', 0, 5, 0)
+    feed('<Down><CR>')
+    eq('foo', api.nvim_get_var('menustr'))
+
+    -- Try clicking in the cmdline with global statusline
+    api.nvim_input_mouse('right', 'press', '', 0, 23, 0)
+    api.nvim_input_mouse('right', 'release', '', 0, 23, 0)
+    feed('<Down><Down><CR>')
+    eq('bar', api.nvim_get_var('menustr'))
   end)
 end)

--- a/test/functional/ui/statuscolumn_spec.lua
+++ b/test/functional/ui/statuscolumn_spec.lua
@@ -652,9 +652,6 @@ describe('statuscolumn', function()
         -- Check that statusline click doesn't register as statuscolumn click
         api.nvim_input_mouse('right', 'press', '', 0, 12, 0)
         eq('', eval('g:testvar'))
-        -- Check that cmdline click doesn't register as statuscolumn click
-        api.nvim_input_mouse('right', 'press', '', 0, 13, 0)
-        eq('', eval('g:testvar'))
       end)
 
       it('clicks and highlights work with control characters', function()


### PR DESCRIPTION
This allows showing popup menu when right-clicking on hsep or cmdline.
