### PR TITLE
vim-patch:9.1.0528: spell completion message still wrong in translations

### DIFF
--- a/src/nvim/po/af.po
+++ b/src/nvim/po/af.po
@@ -315,7 +315,7 @@ msgstr " Bevelreëlvoltooiing (^V^N^P)"
 #~ msgstr " Etiketvoltooiing (^]^N^P)"
 
 #, fuzzy
-#~ msgid " Spelling suggestion (s^N^P)"
+#~ msgid " Spelling suggestion (^S^N^P)"
 #~ msgstr " Hele-reël voltooiing (^L^N^P)"
 
 msgid " Keyword Local completion (^N^P)"

--- a/src/nvim/po/ca.po
+++ b/src/nvim/po/ca.po
@@ -393,8 +393,8 @@ msgid " Omni completion (^O^N^P)"
 msgstr " Omni-compleció (^O^N^P)"
 
 #: ../edit.c:96
-msgid " Spelling suggestion (s^N^P)"
-msgstr "Suggeriment ortogràfic (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr "Suggeriment ortogràfic (^S^N^P)"
 
 # buscar un nom, en lloc del verb «completar».  eac
 #: ../edit.c:97

--- a/src/nvim/po/cs.cp1250.po
+++ b/src/nvim/po/cs.cp1250.po
@@ -404,7 +404,7 @@ msgid " Omni completion (^O^N^P)"
 msgstr " Doplòování tagù (^I/^N/^P)"
 
 #: ../edit.c:96
-msgid " Spelling suggestion (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
 msgstr ""
 
 #: ../edit.c:97

--- a/src/nvim/po/cs.po
+++ b/src/nvim/po/cs.po
@@ -404,7 +404,7 @@ msgid " Omni completion (^O^N^P)"
 msgstr " Doplòování tagù (^I/^N/^P)"
 
 #: ../edit.c:96
-msgid " Spelling suggestion (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
 msgstr ""
 
 #: ../edit.c:97

--- a/src/nvim/po/da.po
+++ b/src/nvim/po/da.po
@@ -403,8 +403,8 @@ msgstr " Fuldførelse af brugerdefineret (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Fuldførelse af omni (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Staveforslag (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Staveforslag (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Fuldførelse af nøgleord local (^N^P)"

--- a/src/nvim/po/de.po
+++ b/src/nvim/po/de.po
@@ -397,8 +397,8 @@ msgid " Omni completion (^O^N^P)"
 msgstr " Omni-Ergänzung (^O^N^P)"
 
 #: ../edit.c:97
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Vorschlag der Rechtschreibprüfung (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Vorschlag der Rechtschreibprüfung (^S^N^P)"
 
 #: ../edit.c:98
 msgid " Keyword Local completion (^N^P)"

--- a/src/nvim/po/en_GB.po
+++ b/src/nvim/po/en_GB.po
@@ -386,7 +386,7 @@ msgid " Omni completion (^O^N^P)"
 msgstr ""
 
 #: ../edit.c:96
-msgid " Spelling suggestion (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
 msgstr ""
 
 #: ../edit.c:97

--- a/src/nvim/po/eo.po
+++ b/src/nvim/po/eo.po
@@ -410,8 +410,8 @@ msgstr " Kompletigo difinita de uzanto (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Kompletigo Omni (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Sugesto de literumo (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Sugesto de literumo (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Kompletigo loka de ŝlosilvorto (^N/^P)"

--- a/src/nvim/po/es.po
+++ b/src/nvim/po/es.po
@@ -387,8 +387,8 @@ msgid " Omni completion (^O^N^P)"
 msgstr " Completar con método Omni (^O^N^P)"
 
 #: ../edit.c:96
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Sugerencia de ortografía (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Sugerencia de ortografía (^S^N^P)"
 
 # Scroll has it's own msgs, in it's place there is the msg for local
 # * ctrl_x_mode = 0 (eg continue_status & CONT_LOCAL)  -- Acevedo

--- a/src/nvim/po/fi.po
+++ b/src/nvim/po/fi.po
@@ -526,8 +526,8 @@ msgstr " Käyttäjän määrittelemä täydennys (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Omnitäydennys (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Oikaisulukuehdotus (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Oikaisulukuehdotus (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Avainsanan paikallinen täydennys (^N^P)"

--- a/src/nvim/po/ga.po
+++ b/src/nvim/po/ga.po
@@ -389,8 +389,8 @@ msgstr " Comhlánú saincheaptha (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Comhlánú Omni (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Moladh litrithe (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Moladh litrithe (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Comhlánú logánta lorgfhocal (^N^P)"

--- a/src/nvim/po/it.po
+++ b/src/nvim/po/it.po
@@ -383,8 +383,8 @@ msgid " Omni completion (^O^N^P)"
 msgstr " Completamento globale (^O^N^P)"
 
 #: ../edit.c:96
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Suggerimento ortografico (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Suggerimento ortografico (^S^N^P)"
 
 #: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"

--- a/src/nvim/po/ja.euc-jp.po
+++ b/src/nvim/po/ja.euc-jp.po
@@ -409,8 +409,8 @@ msgstr " ユーザー定義補完 (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " オムニ補完 (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " 綴り修正候補 (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " 綴り修正候補 (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " 局所キーワード補完 (^N^P)"

--- a/src/nvim/po/ja.po
+++ b/src/nvim/po/ja.po
@@ -4247,8 +4247,8 @@ msgstr " ユーザー定義補完 (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " オムニ補完 (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " 綴り修正候補 (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " 綴り修正候補 (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " 局所キーワード補完 (^N^P)"

--- a/src/nvim/po/ko.UTF-8.po
+++ b/src/nvim/po/ko.UTF-8.po
@@ -381,8 +381,8 @@ msgid " Omni completion (^O^N^P)"
 msgstr " Omni 완성 (^O^N^P)"
 
 #: ../edit.c:96
-msgid " Spelling suggestion (s^N^P)"
-msgstr " 단어 제안 (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " 단어 제안 (^S^N^P)"
 
 #: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"

--- a/src/nvim/po/nb.po
+++ b/src/nvim/po/nb.po
@@ -401,8 +401,7 @@ msgid " Omni completion (^O^N^P)"
 msgstr " Omni-fullføring (^O^N^P)"
 
 #: ../edit.c:96
-#, fuzzy
-msgid " Spelling suggestion (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
 msgstr " Staveforslag (^S^N^P)"
 
 #: ../edit.c:97

--- a/src/nvim/po/nl.po
+++ b/src/nvim/po/nl.po
@@ -384,8 +384,8 @@ msgid " Omni completion (^O^N^P)"
 msgstr " omni-voltooiing (^O^N^P)"
 
 #: ../edit.c:96
-msgid " Spelling suggestion (s^N^P)"
-msgstr " spellingsuggestie (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " spellingsuggestie (^S^N^P)"
 
 #: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"

--- a/src/nvim/po/no.po
+++ b/src/nvim/po/no.po
@@ -401,8 +401,7 @@ msgid " Omni completion (^O^N^P)"
 msgstr " Omni-fullføring (^O^N^P)"
 
 #: ../edit.c:96
-#, fuzzy
-msgid " Spelling suggestion (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
 msgstr " Staveforslag (^S^N^P)"
 
 #: ../edit.c:97

--- a/src/nvim/po/pl.UTF-8.po
+++ b/src/nvim/po/pl.UTF-8.po
@@ -380,8 +380,8 @@ msgid " Omni completion (^O^N^P)"
 msgstr " Omni uzupełnianie (^O^N^P)"
 
 #: ../edit.c:96
-msgid " Spelling suggestion (s^N^P)"
-msgstr "Propozycja pisowni (^L^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr "Propozycja pisowni (^S^N^P)"
 
 #: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"

--- a/src/nvim/po/pt_BR.po
+++ b/src/nvim/po/pt_BR.po
@@ -5610,8 +5610,8 @@ msgid " Omni completion (^O^N^P)"
 msgstr " Completação inteligente (^O^N^P)"
 
 #: ../edit.c:97
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Sugestão de ortografia (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Sugestão de ortografia (^S^N^P)"
 
 #: ../edit.c:98
 msgid " Keyword Local completion (^N^P)"

--- a/src/nvim/po/ru.po
+++ b/src/nvim/po/ru.po
@@ -382,8 +382,8 @@ msgid " Omni completion (^O^N^P)"
 msgstr " Omni-дополнение (^O^N^P)"
 
 #: ../edit.c:96
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Предложение исправления правописания (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Предложение исправления правописания (^S^N^P)"
 
 #: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"

--- a/src/nvim/po/sk.cp1250.po
+++ b/src/nvim/po/sk.cp1250.po
@@ -383,8 +383,7 @@ msgid " Omni completion (^O^N^P)"
 msgstr " Doplòovanie tagov (^O^N^P)"
 
 #: ../edit.c:96
-#, fuzzy
-msgid " Spelling suggestion (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
 msgstr " Doplòovanie celých riadkov (^S^N^P)"
 
 #: ../edit.c:97

--- a/src/nvim/po/sk.po
+++ b/src/nvim/po/sk.po
@@ -383,8 +383,7 @@ msgid " Omni completion (^O^N^P)"
 msgstr " Doplòovanie tagov (^O^N^P)"
 
 #: ../edit.c:96
-#, fuzzy
-msgid " Spelling suggestion (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
 msgstr " Doplòovanie celých riadkov (^S^N^P)"
 
 #: ../edit.c:97

--- a/src/nvim/po/sr.po
+++ b/src/nvim/po/sr.po
@@ -643,8 +643,8 @@ msgstr " Кориснички дефинисано довршавање (^U^N^P)
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni довршавање (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Правописни предлог (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Правописни предлог (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Довршавање локалне кључне речи (^N^P)"
@@ -3002,8 +3002,8 @@ msgstr " Кориснички дефинисано довршавање (^U^N^P)
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni довршавање (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Правописни предлог (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Правописни предлог (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Довршавање локалне кључне речи (^N^P)"

--- a/src/nvim/po/sv.po
+++ b/src/nvim/po/sv.po
@@ -4335,8 +4335,8 @@ msgid " Omni completion (^O^N^P)"
 msgstr " Omnikomplettering (^O^N^P)"
 
 #: ../edit.c:97
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Stavningsförslag (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Stavningsförslag (^S^N^P)"
 
 #: ../edit.c:98
 msgid " Keyword Local completion (^N^P)"

--- a/src/nvim/po/tr.po
+++ b/src/nvim/po/tr.po
@@ -3109,8 +3109,8 @@ msgstr " Kullanıcı tanımlı tamamlamalar (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Omni tamamlaması (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Yazım önerisi (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Yazım önerisi (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Dahili anahtar sözcük tamamlaması (^N^P)"

--- a/src/nvim/po/uk.po
+++ b/src/nvim/po/uk.po
@@ -4254,8 +4254,8 @@ msgstr " Користувацьке доповнення (^U^N^P)"
 msgid " Omni completion (^O^N^P)"
 msgstr " Кмітливе доповнення (^O^N^P)"
 
-msgid " Spelling suggestion (s^N^P)"
-msgstr " Орфографічна підказка (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " Орфографічна підказка (^S^N^P)"
 
 msgid " Keyword Local completion (^N^P)"
 msgstr " Доповнення місцевих ключових слів (^N^P)"

--- a/src/nvim/po/vi.po
+++ b/src/nvim/po/vi.po
@@ -388,7 +388,7 @@ msgstr " Tự động kết thúc thẻ đánh dấu (^]^N^P)"
 
 #: ../edit.c:96
 #, fuzzy
-msgid " Spelling suggestion (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
 msgstr " Tự động kết thúc cho cả dòng (^L^N^P)"
 
 #: ../edit.c:97

--- a/src/nvim/po/zh_CN.UTF-8.po
+++ b/src/nvim/po/zh_CN.UTF-8.po
@@ -3716,8 +3716,8 @@ msgid " Omni completion (^O^N^P)"
 msgstr " 全能补全 (^O^N^P)"
 
 #: ../insexpand.c:113
-msgid " Spelling suggestion (s^N^P)"
-msgstr " 拼写建议 (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
+msgstr " 拼写建议 (^S^N^P)"
 
 #: ../insexpand.c:114
 msgid " Keyword Local completion (^N^P)"

--- a/src/nvim/po/zh_TW.UTF-8.po
+++ b/src/nvim/po/zh_TW.UTF-8.po
@@ -421,7 +421,7 @@ msgstr " 標籤自動完成 (^]^N^P)"
 
 #: ../edit.c:96
 #, fuzzy
-msgid " Spelling suggestion (s^N^P)"
+msgid " Spelling suggestion (^S^N^P)"
 msgstr " 整行自動完成 (^L^N^P)"
 
 #: ../edit.c:97


### PR DESCRIPTION
#### vim-patch:9.1.0528: spell completion message still wrong in translations

Problem:  spell completion message still wrong in translations
          (after 9.1.0512)
Solution: Update translation files with the new message
          (Kyle Kovacs)

closes: vim/vim#15113

https://github.com/vim/vim/commit/68f5ceddca2ec2d591b9180020c95bb86bf6d3d2

Co-authored-by: Kyle Kovacs <kkovacs@diconfiberoptics.com>