### PR TITLE
vim-patch:9.1.0525: Right release selects immediately when pum is truncated.

### DIFF
--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -1265,8 +1265,9 @@ static void pum_position_at_mouse(int min_width)
     pum_anchor_grid = mouse_grid;
   }
 
-  if (max_row - mouse_row > pum_size) {
-    // Enough space below the mouse row.
+  if (max_row - mouse_row > pum_size || max_row - mouse_row > mouse_row - min_row) {
+    // Enough space below the mouse row,
+    // or there is more space below the mouse row than above.
     pum_above = false;
     pum_row = mouse_row + 1;
     if (pum_height > max_row - pum_row) {
@@ -1322,7 +1323,7 @@ static void pum_select_mouse_pos(void)
 
   int idx = mouse_row - pum_row;
 
-  if (idx < 0 || idx >= pum_size) {
+  if (idx < 0 || idx >= pum_height) {
     pum_selected = -1;
   } else if (*pum_array[idx].pum_text != NUL) {
     pum_selected = idx;

--- a/test/old/testdir/test_menu.vim
+++ b/test/old/testdir/test_menu.vim
@@ -482,13 +482,48 @@ func Test_popup_menu()
   unmenu PopUp
 endfunc
 
+func Test_popup_menu_truncated()
+  CheckNotGui
+
+  set mouse=a mousemodel=popup
+  aunmenu PopUp
+  for i in range(2 * &lines)
+    exe $'menu PopUp.{i} <Cmd>let g:res = {i}<CR>'
+  endfor
+
+  func LeftClickExpr(row, col)
+    call Ntest_setmouse(a:row, a:col)
+    return "\<LeftMouse>"
+  endfunc
+
+  " Clicking at the bottom should place popup menu above click position.
+  " <RightRelease> should not select an item immediately.
+  let g:res = -1
+  call Ntest_setmouse(&lines, 1)
+  nnoremap <expr><F2> LeftClickExpr(4, 1)
+  call feedkeys("\<RightMouse>\<RightRelease>\<F2>", 'tx')
+  call assert_equal(3, g:res)
+
+  " Clicking at the top should place popup menu below click position.
+  let g:res = -1
+  call Ntest_setmouse(1, 1)
+  nnoremap <expr><F2> LeftClickExpr(5, 1)
+  call feedkeys("\<RightMouse>\<RightRelease>\<F2>", 'tx')
+  call assert_equal(3, g:res)
+
+  nunmap <F2>
+  delfunc LeftClickExpr
+  unlet g:res
+  aunmenu PopUp
+  set mouse& mousemodel&
+endfunc
+
 " Test for MenuPopup autocommand
 func Test_autocmd_MenuPopup()
   CheckNotGui
 
-  set mouse=a
-  set mousemodel=popup
-  aunmenu *
+  set mouse=a mousemodel=popup
+  aunmenu PopUp
   autocmd MenuPopup * exe printf(
     \ 'anoremenu PopUp.Foo <Cmd>let g:res = ["%s", "%s"]<CR>',
     \ expand('<afile>'), expand('<amatch>'))


### PR DESCRIPTION
#### vim-patch:9.1.0525: Right release selects immediately when pum is truncated.

Problem:  Right release selects immediately when pum is truncated.
Solution: Use pum_height instead of pum_size when checking click row.
          Don't place it above mouse row when there is more space below.
          (zeertzjq)

closes: vim/vim#15102

https://github.com/vim/vim/commit/761a420c66402545acd8ee3ffa17c3a1fc3110e4