### PR TITLE
vim-patch:9.1.0526: Unwanted cursor movement with pagescroll at start of buffer

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2518,9 +2518,11 @@ int pagescroll(Direction dir, int count, bool half)
               ? MAX(1, (int)p_window - 2) : get_scroll_overlap(dir));
     nochange = scroll_with_sms(dir, count, &count);
 
-    // Place cursor at top or bottom of window.
-    validate_botline(curwin);
-    curwin->w_cursor.lnum = (dir == FORWARD ? curwin->w_topline : curwin->w_botline - 1);
+    if (!nochange) {
+      // Place cursor at top or bottom of window.
+      validate_botline(curwin);
+      curwin->w_cursor.lnum = (dir == FORWARD ? curwin->w_topline : curwin->w_botline - 1);
+    }
   }
 
   if (get_scrolloff_value(curwin) > 0) {

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4267,6 +4267,9 @@ func Test_page_cursor_topbot()
   call assert_equal(18, line('.'))
   exe "norm! \<C-B>\<C-F>"
   call assert_equal(9, line('.'))
+  " Not when already at the start of the buffer.
+  exe "norm! ggj\<C-B>"
+  call assert_equal(2, line('.'))
   bwipe!
 endfunc
 


### PR DESCRIPTION
Problem:  Cursor is moved to bottom of window trying to pagescroll when
          already at the start of the buffer (Asheq Imran, after v9.1.0357)
Solution: Don't move cursor when buffer content did not move.
          (Luuk van Baal)

https://github.com/vim/vim/commit/8ccb89016e4b4b7f87acd1da78486c077350ceef