### PR TITLE
vim-patch:9.1.{0518,0531}

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -111,6 +111,7 @@
 #include "nvim/os/os.h"
 #include "nvim/os/os_defs.h"
 #include "nvim/os/pty_process.h"
+#include "nvim/os/random.h"
 #include "nvim/os/shell.h"
 #include "nvim/os/stdpaths_defs.h"
 #include "nvim/os/time.h"
@@ -5883,42 +5884,22 @@ static void f_py3eval(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 static void init_srand(uint32_t *const x)
   FUNC_ATTR_NONNULL_ALL
 {
-#ifndef MSWIN
-  static int dev_urandom_state = NOTDONE;  // FAIL or OK once tried
+  struct {
+    union {
+      uint32_t number;
+      uint8_t bytes[sizeof(uint32_t)];
+    } contents;
+  } buf;
 
-  if (dev_urandom_state != FAIL) {
-    const int fd = os_open("/dev/urandom", O_RDONLY, 0);
-    struct {
-      union {
-        uint32_t number;
-        char bytes[sizeof(uint32_t)];
-      } contents;
-    } buf;
+  if (os_get_random(buf.contents.bytes, sizeof(buf.contents.bytes)) == OK) {
+    *x = buf.contents.number;
+    return;
+  }
 
-    // Attempt reading /dev/urandom.
-    if (fd == -1) {
-      dev_urandom_state = FAIL;
-    } else {
-      buf.contents.number = 0;
-      if (read(fd, buf.contents.bytes, sizeof(uint32_t)) != sizeof(uint32_t)) {
-        dev_urandom_state = FAIL;
-      } else {
-        dev_urandom_state = OK;
-        *x = buf.contents.number;
-      }
-      os_close(fd);
-    }
-  }
-  if (dev_urandom_state != OK) {
-    // Reading /dev/urandom doesn't work, fall back to os_hrtime() XOR with process ID
-#endif
-  // uncrustify:off
-    *x = (uint32_t)os_hrtime();
-    *x ^= (uint32_t)os_get_pid();
-#ifndef MSWIN
-  }
-#endif
-  // uncrustify:on
+  // The system's random number generator doesn't work,
+  // fall back to os_hrtime() XOR with process ID
+  *x = (uint32_t)os_hrtime();
+  *x ^= (uint32_t)os_get_pid();
 }
 
 static inline uint32_t splitmix32(uint32_t *const x)

--- a/src/nvim/os/random.c
+++ b/src/nvim/os/random.c
@@ -1,0 +1,65 @@
+#include <stddef.h>
+#include <stdint.h>
+
+#include "nvim/os/fs.h"
+#include "nvim/os/os_defs.h"
+#include "nvim/os/random.h"
+#include "nvim/vim_defs.h"
+
+#ifdef MSWIN
+/// Fill the buffer "buf" with "len" random bytes.
+/// Returns FAIL if the OS PRNG is not available or something went wrong.
+int os_get_random(uint8_t *buf, size_t len)
+{
+  static int initialized = NOTDONE;
+  static HINSTANCE hInstLib;
+  static BOOL(WINAPI *pProcessPrng)(PBYTE, SIZE_T);
+
+  if (initialized == NOTDONE) {
+    hInstLib = LoadLibrary("bcryptprimitives.dll");
+    if (hInstLib != NULL) {
+      pProcessPrng = (void *)GetProcAddress(hInstLib, "ProcessPrng");
+    }
+    if (hInstLib == NULL || pProcessPrng == NULL) {
+      FreeLibrary(hInstLib);
+      initialized = FAIL;
+    } else {
+      initialized = OK;
+    }
+  }
+
+  if (initialized == FAIL) {
+    return FAIL;
+  }
+
+  // According to the documentation this call cannot fail.
+  pProcessPrng(buf, len);
+
+  return OK;
+}
+#else
+/// Fill the buffer "buf" with "len" random bytes.
+/// Returns FAIL if the OS PRNG is not available or something went wrong.
+int os_get_random(uint8_t *buf, size_t len)
+{
+  static int dev_urandom_state = NOTDONE;  // FAIL or OK once tried
+
+  if (dev_urandom_state == FAIL) {
+    return FAIL;
+  }
+
+  const int fd = os_open("/dev/urandom", O_RDONLY, 0);
+
+  // Attempt reading /dev/urandom.
+  if (fd < 0) {
+    dev_urandom_state = FAIL;
+  } else if (read(fd, buf, len) == (ssize_t)len) {
+    dev_urandom_state = OK;
+  } else {
+    dev_urandom_state = FAIL;
+    os_close(fd);
+  }
+
+  return dev_urandom_state;
+}
+#endif

--- a/src/nvim/os/random.c
+++ b/src/nvim/os/random.c
@@ -55,6 +55,7 @@ int os_get_random(uint8_t *buf, size_t len)
     dev_urandom_state = FAIL;
   } else if (read(fd, buf, len) == (ssize_t)len) {
     dev_urandom_state = OK;
+    os_close(fd);
   } else {
     dev_urandom_state = FAIL;
     os_close(fd);

--- a/src/nvim/os/random.h
+++ b/src/nvim/os/random.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include <stddef.h>  // IWYU pragma: keep
+#include <stdint.h>  // IWYU pragma: keep
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "os/random.h.generated.h"
+#endif


### PR DESCRIPTION
#### vim-patch:9.1.0518: initialize the random buffer can be improved

Problem:  initialize the random buffer can be improved
Solution: refactor init_srand() function, move machine-specific parts to
          os_mswin and os_unix, implement a fallback for Windows 10 and
          later (LemonBoy)

closes: vim/vim#15125

https://github.com/vim/vim/commit/9987fe8ca05e5d367fc54eb94a5a583138d2e1f8

Co-authored-by: LemonBoy <thatlemon@gmail.com>


#### vim-patch:9.1.0531: resource leak in mch_get_random()

Problem:  resource leak in mch_get_random() (after v9.1.0518)
Solution: close file descriptor after reading successfully
          from /dev/urandom

https://github.com/vim/vim/commit/93a3d2b905f1012aa0eac8db36b31ce01c3571f3

Co-authored-by: Christian Brabandt <cb@256bit.org>