### PR TITLE
vim-patch:9.1.0532: filetype: Cedar files not recognized

### DIFF
--- a/runtime/ftplugin/cedar.vim
+++ b/runtime/ftplugin/cedar.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin
+" Language:	Cedar
+" Maintainer:	Riley Bruins <ribru17@gmail.com>
+" Last Change:	2024 Jul 4
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setl comments=:// commentstring=//\ %s
+
+let b:undo_ftplugin = 'setl com< cms<'

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -261,6 +261,7 @@ local extension = {
   cdc = 'cdc',
   cdl = 'cdl',
   toc = detect_line1('\\contentsline', 'tex', 'cdrtoc'),
+  cedar = 'cedar',
   cfc = 'cf',
   cfm = 'cf',
   cfi = 'cf',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -143,6 +143,7 @@ func s:GetFilenameChecks() abort
     \ 'cdl': ['file.cdl'],
     \ 'cdrdaoconf': ['/etc/cdrdao.conf', '/etc/defaults/cdrdao', '/etc/default/cdrdao', '.cdrdao', 'any/etc/cdrdao.conf', 'any/etc/default/cdrdao', 'any/etc/defaults/cdrdao'],
     \ 'cdrtoc': ['file.toc'],
+    \ 'cedar': ['file.cedar'],
     \ 'cf': ['file.cfm', 'file.cfi', 'file.cfc'],
     \ 'cfengine': ['cfengine.conf'],
     \ 'cfg': ['file.hgrc', 'filehgrc', 'hgrc', 'some-hgrc'],


### PR DESCRIPTION
Problem:  filetype: Cedar files not recognized
Solution: Detect '*.cedar' files as cedar filetype
          (Riley Bruins)

References: https://github.com/cedar-policy

closes: vim/vim#15148

https://github.com/vim/vim/commit/15addb24dd3b2645f5c04d2742ab5eb53444a3a0

Co-authored-by: Riley Bruins <ribru17@hotmail.com>
