### PR TITLE
fix(lua): use expandcmd() instead of expand() in vim.ui.open()

### DIFF
--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -136,7 +136,7 @@ function M.open(path)
   })
   local is_uri = path:match('%w+:')
   if not is_uri then
-    path = vim.fn.expand(path)
+    path = vim.fn.expandcmd(path)
   end
 
   local cmd --- @type string[]


### PR DESCRIPTION
Unlike expand(), expandcmd() doesn't expand wildcards.

Fix #29579
