### PR TITLE
vim-patch:6a4afb1,aaaa21b

### DIFF
--- a/runtime/doc/scroll.txt
+++ b/runtime/doc/scroll.txt
@@ -43,6 +43,8 @@ CTRL-D			Scroll window Downwards in the buffer.  The number of
 
 <S-Down>	or				*<S-Down>* *<kPageDown>*
 <PageDown>	or				*<PageDown>* *CTRL-F*
+<S-CR>	or				*<S-CR>* *CTRL-SHIFT-CR* *<S-NL>*
+<S-+>	or					*SHIFT-+* *<S-Plus>*
 CTRL-F			Scroll window [count] pages Forwards (downwards) in
 			the buffer.  See also 'startofline' option.
 			When there is only one window the 'window' option
@@ -80,6 +82,7 @@ CTRL-U			Scroll window Upwards in the buffer.  The number of
 
 <S-Up>		or					*<S-Up>* *<kPageUp>*
 <PageUp>	or					*<PageUp>* *CTRL-B*
+<S-->		or				*<S-Minus>* *SHIFT-MINUS*
 CTRL-B			Scroll window [count] pages Backwards (upwards) in the
 			buffer.  See also 'startofline' option.
 			When there is only one window the 'window' option

--- a/runtime/doc/scroll.txt
+++ b/runtime/doc/scroll.txt
@@ -43,7 +43,7 @@ CTRL-D			Scroll window Downwards in the buffer.  The number of
 
 <S-Down>	or				*<S-Down>* *<kPageDown>*
 <PageDown>	or				*<PageDown>* *CTRL-F*
-<S-CR>	or				*<S-CR>* *CTRL-SHIFT-CR* *<S-NL>*
+<S-CR>	or					*<S-CR>* *<S-NL>*
 <S-+>	or					*SHIFT-+* *<S-Plus>*
 CTRL-F			Scroll window [count] pages Forwards (downwards) in
 			the buffer.  See also 'startofline' option.


### PR DESCRIPTION
#### vim-patch:6a4afb1: runtime(doc): document further keys that scroll page up/down

https://github.com/vim/vim/commit/6a4afb1efca1bac5fbc0281804591cf0a52b2d81

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:aaaa21b: runtime(doc): Remove wrong help tag CTRL-SHIFT-CR

https://github.com/vim/vim/commit/aaaa21b58f8af2fe923368116f94832df3d273bc

Co-authored-by: Christian Brabandt <cb@256bit.org>