### PR TITLE
fix(lua): don't include text after cursor in completion pattern

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -241,7 +241,7 @@ int nextwild(expand_T *xp, int type, int options, bool escape)
   if (xp->xp_numfiles == -1) {
     set_expand_context(xp);
     if (xp->xp_context == EXPAND_LUA) {
-      nlua_expand_pat(xp, xp->xp_pattern);
+      nlua_expand_pat(xp);
     }
     cmd_showtail = expand_showtail(xp);
   }
@@ -1059,7 +1059,7 @@ int showmatches(expand_T *xp, bool wildmenu)
   if (xp->xp_numfiles == -1) {
     set_expand_context(xp);
     if (xp->xp_context == EXPAND_LUA) {
-      nlua_expand_pat(xp, xp->xp_pattern);
+      nlua_expand_pat(xp);
     }
     int i = expand_cmdline(xp, ccline->cmdbuff, ccline->cmdpos,
                            &numMatches, &matches);
@@ -3610,7 +3610,8 @@ void f_getcompletion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
 theend:
   if (xpc.xp_context == EXPAND_LUA) {
-    nlua_expand_pat(&xpc, xpc.xp_pattern);
+    xpc.xp_col = (int)strlen(xpc.xp_line);
+    nlua_expand_pat(&xpc);
     xpc.xp_pattern_len = strlen(xpc.xp_pattern);
   }
   char *pat;

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -4146,7 +4146,7 @@ static int get_cmdline_compl_info(char *line, colnr_T curs_col)
   compl_patternlen = (size_t)curs_col;
   set_cmd_context(&compl_xp, compl_pattern, (int)compl_patternlen, curs_col, false);
   if (compl_xp.xp_context == EXPAND_LUA) {
-    nlua_expand_pat(&compl_xp, compl_xp.xp_pattern);
+    nlua_expand_pat(&compl_xp);
   }
   if (compl_xp.xp_context == EXPAND_UNSUCCESSFUL
       || compl_xp.xp_context == EXPAND_NOTHING) {

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -854,6 +854,16 @@ describe('completion', function()
       ]])
     end)
 
+    it('works when cursor is in the middle of cmdline #29586', function()
+      feed(':lua math.a(); 1<Left><Left><Left><Left><Left><Tab>')
+      screen:expect([[
+                                                                    |
+        {1:~                                                           }|*5
+        {100:abs}{3:  acos  asin  atan  atan2                                }|
+        :lua math.abs^(); 1                                          |
+      ]])
+    end)
+
     it('provides completion from `getcompletion()`', function()
       eq({ 'vim' }, fn.getcompletion('vi', 'lua'))
       eq({ 'api' }, fn.getcompletion('vim.ap', 'lua'))


### PR DESCRIPTION
Fix #29586
