### PR TITLE
vim-patch:9.1.0534: completion wrong with fuzzy when cycling back to original

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1240,6 +1240,10 @@ static int ins_compl_build_pum(void)
           did_find_shown_match = true;
           max_fuzzy_score = comp->cp_score;
           compl_shown_match = comp;
+        }
+
+        if (!shown_match_ok && comp == compl_shown_match && !compl_no_select) {
+          cur = i;
           shown_match_ok = true;
         }
 
@@ -1250,8 +1254,6 @@ static int ins_compl_build_pum(void)
         if (!compl_no_select
             && (max_fuzzy_score > 0
                 || (compl_leader == NULL || lead_len == 0))) {
-          shown_match_ok = true;
-          cur = 0;
           if (match_at_original_text(compl_shown_match)) {
             compl_shown_match = shown_compl;
           }
@@ -1299,6 +1301,7 @@ static int ins_compl_build_pum(void)
     // sort by the largest score of fuzzy match
     qsort(compl_match_array, (size_t)compl_match_arraysize, sizeof(pumitem_T),
           ins_compl_fuzzy_cmp);
+    shown_match_ok = true;
   }
 
   if (!shown_match_ok) {  // no displayed match at all
@@ -3651,7 +3654,9 @@ static compl_T *find_comp_when_fuzzy(void)
   if (compl_match_array == NULL
       || (is_forward && compl_selected_item == compl_match_arraysize - 1)
       || (is_backward && compl_selected_item == 0)) {
-    return compl_first_match;
+    return compl_first_match != compl_shown_match
+           ? compl_first_match
+           : (compl_first_match->cp_prev ? compl_first_match->cp_prev : NULL);
   }
 
   if (is_forward) {

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -4905,6 +4905,28 @@ describe('builtin popupmenu', function()
         feed('o<BS><C-R>=Comp()<CR>')
         screen:expect_unchanged(true)
 
+        feed('<Esc>')
+        command('set completeopt+=fuzzy,menu')
+        feed('S hello helio hero h<C-X><C-P>')
+        screen:expect([[
+           hello helio hero h^             |
+          {1:~                }{n: }{mn:h}{n:ello        }{1: }|
+          {1:~                }{n: }{mn:h}{n:elio        }{1: }|
+          {1:~                }{s: }{ms:h}{s:ero         }{1: }|
+          {1:~                               }|*15
+          {2:-- }{5:match 1 of 3}                 |
+        ]])
+
+        feed('<Esc>S hello helio hero h<C-X><C-P><C-P>')
+        screen:expect([[
+           hello helio hero h^             |
+          {1:~                }{n: }{mn:h}{n:ello        }{1: }|
+          {1:~                }{s: }{ms:h}{s:elio        }{1: }|
+          {1:~                }{n: }{mn:h}{n:ero         }{1: }|
+          {1:~                               }|*15
+          {2:-- }{5:match 2 of 3}                 |
+        ]])
+
         feed('<C-E><Esc>')
       end)
     end

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1489,6 +1489,17 @@ func Test_pum_highlights_match()
   call term_sendkeys(buf, "o\<BS>\<C-R>=Comp()\<CR>")
   call VerifyScreenDump(buf, 'Test_pum_highlights_09', {})
 
+  " issue #15095 wrong select
+  call term_sendkeys(buf, "\<ESC>:set completeopt=fuzzy,menu\<CR>")
+  call TermWait(buf)
+  call term_sendkeys(buf, "S hello helio hero h\<C-X>\<C-P>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_pum_highlights_10', {})
+
+  call term_sendkeys(buf, "\<ESC>S hello helio hero h\<C-X>\<C-P>\<C-P>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_pum_highlights_11', {})
+
   call term_sendkeys(buf, "\<C-E>\<Esc>")
   call TermWait(buf)
 


### PR DESCRIPTION
#### vim-patch:9.1.0534: completion wrong with fuzzy when cycling back to original

Problem:  completion wrong with fuzzy when cycling back to original
          (Quan Nguyen)
Solution: reset show_match_ok when cp_score is zero (glepnir)

closes: vim/vim#15105

https://github.com/vim/vim/commit/65407ce1d2963e7a758af8fecdcbd67b9a90bdb9

Co-authored-by: glepnir <glephunter@gmail.com>