### PR TITLE
vim-patch:9.1.0536: filetype: zone files are not recognized

### DIFF
--- a/runtime/ftplugin/bindzone.vim
+++ b/runtime/ftplugin/bindzone.vim
@@ -1,0 +1,16 @@
+" Vim filetype plugin file
+" Language:	bind zone file
+" Maintainer:	This runtime file is looking for a new maintainer.
+" Last Change:	2024 Jul 06
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin=1
+
+setlocal comments=b:;
+setlocal commentstring=;\ %s
+setlocal formatoptions-=t
+setlocal formatoptions+=crq
+
+let b:undo_ftplugin = "setlocal com< cms< fo<"

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -236,6 +236,7 @@ local extension = {
   db = detect.bindzone,
   bicep = 'bicep',
   bicepparam = 'bicep',
+  zone = 'bindzone',
   bb = 'bitbake',
   bbappend = 'bitbake',
   bbclass = 'bitbake',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -122,7 +122,7 @@ func s:GetFilenameChecks() abort
     \ 'beancount': ['file.beancount'],
     \ 'bib': ['file.bib'],
     \ 'bicep': ['file.bicep', 'file.bicepparam'],
-    \ 'bindzone': ['named.root', '/bind/db.file', '/named/db.file', 'any/bind/db.file', 'any/named/db.file'],
+    \ 'bindzone': ['named.root', '/bind/db.file', '/named/db.file', 'any/bind/db.file', 'any/named/db.file', 'foobar.zone'],
     \ 'bitbake': ['file.bb', 'file.bbappend', 'file.bbclass', 'build/conf/local.conf', 'meta/conf/layer.conf', 'build/conf/bbappend.conf', 'meta-layer/conf/distro/foo.conf'],
     \ 'blade': ['file.blade.php'],
     \ 'blank': ['file.bl'],


### PR DESCRIPTION
Problem:  filetype: zone files are not recognized
          (rpdprd)
Solution: Detect '*.zone' files as bindzone filetype

fixes: vim/vim#14222

https://github.com/vim/vim/commit/f095539b3900d76f5eeaaa0897c6abf970829b31

Co-authored-by: Christian Brabandt <cb@256bit.org>
