### PR TITLE
vim-patch:9.1.0538: not possible to assign priority when defining a sign

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -7110,6 +7110,7 @@ sign_getdefined([{name}])                                    *sign_getdefined()*
 		   linehl	highlight group used for the whole line the
 				sign is placed in; not present if not set.
 		   name		name of the sign
+		   priority	default priority value of the sign
 		   numhl	highlight group used for the line number where
 				the sign is placed; not present if not set.
 		   text		text that is displayed when there is no icon
@@ -7282,7 +7283,8 @@ sign_placelist({list})                                        *sign_placelist()*
 		    priority	Priority of the sign. When multiple signs are
 				placed on a line, the sign with the highest
 				priority is used. If not specified, the
-				default value of 10 is used. See
+				default value of 10 is used, unless specified
+				otherwise by the sign definition. See
 				|sign-priority| for more information.
 
 		If {id} refers to an existing sign, then the existing sign is

--- a/runtime/doc/sign.txt
+++ b/runtime/doc/sign.txt
@@ -68,11 +68,12 @@ other plugins using signs.
 
 							*sign-priority*
 Each placed sign is assigned a priority value independently of the sign group.
-The default priority for a sign is 10. When multiple signs that each have an
-icon or text are placed on the same line, signs are ordered with decreasing
-priority from left to right, up until the maximum width set in 'signcolumn'.
-Lower priority signs that do not fit are hidden. Highest priority signs with
-highlight attributes are always shown.
+The default priority for a sign is 10, this value can be changed for different
+signs by specifying a different value at definition time. When multiple signs
+that each have an icon or text are placed on the same line, signs are ordered
+with decreasing priority from left to right, up until the maximum width set in
+'signcolumn'. Low priority signs that do not fit are hidden. Highest priority
+signs with highlight attributes are always shown.
 
 When the line on which the sign is placed is deleted, the sign is removed along
 with it.
@@ -112,6 +113,9 @@ See |sign_define()| for the equivalent Vim script function.
 		will cause redraw problems.
 			toolkit		supports ~
 			Win32		.bmp, .ico, .cur
+
+	priority={prio}
+		Default priority for the sign, see |sign-priority|.
 
 	linehl={group}
 		Highlighting group used for the whole line the sign is placed
@@ -183,11 +187,11 @@ See |sign_place()| for the equivalent Vim script function.
 
 		By default, the sign is placed in the global sign group.
 
-		By default, the sign is assigned a default priority of 10. To
-		assign a different priority value, use "priority={prio}" to
-		specify a value.  The priority is used to determine the sign
-		that is displayed when multiple signs are placed on the same
-		line.
+		By default, the sign is assigned a default priority of 10,
+		unless specified otherwise by the sign definition.  To assign a
+		different priority value, use "priority={prio}" to specify a
+		value.  The priority is used to determine the sign that is
+		displayed when multiple signs are placed on the same line.
 
 		Examples: >
 			:sign place 5 line=3 name=sign1 file=a.py

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -8477,6 +8477,7 @@ function vim.fn.sign_define(list) end
 ---    linehl  highlight group used for the whole line the
 ---     sign is placed in; not present if not set.
 ---    name    name of the sign
+---    priority  default priority value of the sign
 ---    numhl  highlight group used for the line number where
 ---     the sign is placed; not present if not set.
 ---    text    text that is displayed when there is no icon
@@ -8668,7 +8669,8 @@ function vim.fn.sign_place(id, group, name, buf, dict) end
 ---     priority  Priority of the sign. When multiple signs are
 ---     placed on a line, the sign with the highest
 ---     priority is used. If not specified, the
----     default value of 10 is used. See
+---     default value of 10 is used, unless specified
+---     otherwise by the sign definition. See
 ---     |sign-priority| for more information.
 ---
 --- If {id} refers to an existing sign, then the existing sign is

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -10112,6 +10112,7 @@ M.funcs = {
          linehl	highlight group used for the whole line the
       		sign is placed in; not present if not set.
          name		name of the sign
+         priority	default priority value of the sign
          numhl	highlight group used for the line number where
       		the sign is placed; not present if not set.
          text		text that is displayed when there is no icon
@@ -10322,7 +10323,8 @@ M.funcs = {
           priority	Priority of the sign. When multiple signs are
       		placed on a line, the sign with the highest
       		priority is used. If not specified, the
-      		default value of 10 is used. See
+      		default value of 10 is used, unless specified
+      		otherwise by the sign definition. See
       		|sign-priority| for more information.
 
       If {id} refers to an existing sign, then the existing sign is

--- a/src/nvim/sign_defs.h
+++ b/src/nvim/sign_defs.h
@@ -18,6 +18,7 @@ typedef struct {
   int sn_text_hl;  // highlight ID for text
   int sn_cul_hl;   // highlight ID for text on current line when 'cursorline' is set
   int sn_num_hl;   // highlight ID for line number
+  int sn_priority;  // default priority of this sign, -1 means SIGN_DEF_PRIO
 } sign_T;
 
 typedef struct {

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -2920,11 +2920,12 @@ describe('builtin popupmenu', function()
         feed('<C-U>sign define <Tab>')
         screen:expect([[
                                           |
-          {1:~                               }|*2
+          {1:~                               }|
           {1:~           }{s: culhl=         }{1:    }|
           {1:~           }{n: icon=          }{1:    }|
           {1:~           }{n: linehl=        }{1:    }|
           {1:~           }{n: numhl=         }{1:    }|
+          {1:~           }{n: priority=      }{1:    }|
           {1:~           }{n: text=          }{1:    }|
           {1:~           }{n: texthl=        }{1:    }|
           :sign define culhl=^             |
@@ -2933,11 +2934,12 @@ describe('builtin popupmenu', function()
         feed('<Space><Tab>')
         screen:expect([[
                                           |
-          {1:~                               }|*2
+          {1:~                               }|
           {1:~                  }{s: culhl=     }{1: }|
           {1:~                  }{n: icon=      }{1: }|
           {1:~                  }{n: linehl=    }{1: }|
           {1:~                  }{n: numhl=     }{1: }|
+          {1:~                  }{n: priority=  }{1: }|
           {1:~                  }{n: text=      }{1: }|
           {1:~                  }{n: texthl=    }{1: }|
           :sign define culhl= culhl=^      |

--- a/test/old/testdir/test_signs.vim
+++ b/test/old/testdir/test_signs.vim
@@ -246,7 +246,7 @@ func Test_sign_completion()
   call assert_equal('"sign define jump list place undefine unplace', @:)
 
   call feedkeys(":sign define Sign \<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"sign define Sign culhl= icon= linehl= numhl= text= texthl=', @:)
+  call assert_equal('"sign define Sign culhl= icon= linehl= numhl= priority= text= texthl=', @:)
 
   for hl in ['culhl', 'linehl', 'numhl', 'texthl']
     call feedkeys(":sign define Sign "..hl.."=Spell\<C-A>\<C-B>\"\<CR>", 'tx')
@@ -1240,9 +1240,28 @@ func Test_sign_priority()
   call sign_define("sign1", attr)
   call sign_define("sign2", attr)
   call sign_define("sign3", attr)
+  let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Search', 'priority': 60}
+  call sign_define("sign4", attr)
+
+  " Test for :sign list
+  let a = execute('sign list')
+  call assert_equal("\nsign sign1 text==> linehl=Search texthl=Search\n" .
+      \ "sign sign2 text==> linehl=Search texthl=Search\n" .
+      \ "sign sign3 text==> linehl=Search texthl=Search\n" .
+      \ "sign sign4 text==> priority=60 linehl=Search texthl=Search", a)
+
+  " Test for sign_getdefined()
+  let s = sign_getdefined()
+  call assert_equal([
+      \ {'name': 'sign1', 'texthl': 'Search', 'linehl': 'Search', 'text': '=>'},
+      \ {'name': 'sign2', 'texthl': 'Search', 'linehl': 'Search', 'text': '=>'},
+      \ {'name': 'sign3', 'texthl': 'Search', 'linehl': 'Search', 'text': '=>'},
+      \ {'name': 'sign4', 'priority': 60, 'texthl': 'Search', 'linehl': 'Search',
+      \ 'text': '=>'}],
+      \ s)
 
   " Place three signs with different priority in the same line
-  call writefile(repeat(["Sun is shining"], 30), "Xsign")
+  call writefile(repeat(["Sun is shining"], 30), "Xsign", 'D')
   edit Xsign
 
   call sign_place(1, 'g1', 'sign1', 'Xsign',
@@ -1578,15 +1597,33 @@ func Test_sign_priority()
 	      \ "    line=10  id=5  group=g1  name=sign1  priority=20\n", a)
 
   call sign_unplace('*')
+
+  " Test for sign with default priority.
+  call sign_place(1, 'g1', 'sign4', 'Xsign', {'lnum' : 3})
+  sign place 2 line=5 name=sign4 group=g1 file=Xsign
+
+  let s = sign_getplaced('Xsign', {'group' : '*'})
+  call assert_equal([
+	      \ {'id' : 1, 'name' : 'sign4', 'lnum' : 3, 'group' : 'g1',
+	      \ 'priority' : 60},
+	      \ {'id' : 2, 'name' : 'sign4', 'lnum' : 5, 'group' : 'g1',
+	      \ 'priority' : 60}],
+	      \ s[0].signs)
+
+  let a = execute('sign place group=g1')
+  call assert_equal("\n--- Signs ---\nSigns for Xsign:\n" .
+	      \ "    line=3  id=1  group=g1  name=sign4  priority=60\n" .
+	      \ "    line=5  id=2  group=g1  name=sign4  priority=60\n", a)
+
+  call sign_unplace('*')
   call sign_undefine()
   enew | only
-  call delete("Xsign")
 endfunc
 
 " Tests for memory allocation failures in sign functions
 func Test_sign_memfailures()
   CheckFunction test_alloc_fail
-  call writefile(repeat(["Sun is shining"], 30), "Xsign")
+  call writefile(repeat(["Sun is shining"], 30), "Xsign", 'D')
   edit Xsign
 
   call test_alloc_fail(GetAllocId('sign_getdefined'), 0, 0)
@@ -1623,7 +1660,6 @@ func Test_sign_memfailures()
   call sign_unplace('*')
   call sign_undefine()
   enew | only
-  call delete("Xsign")
 endfunc
 
 " Test for auto-adjusting the line number of a placed sign.


### PR DESCRIPTION
#### vim-patch:9.1.0538: not possible to assign priority when defining a sign

Problem:  not possible to assign priority when defining a sign
          (Mathias Fußenegger)
Solution: Add the priority argument for the :sign-define ex command and
          the sign_define() function (LemonBoy)

Use the specified value instead of the default one (SIGN_DEF_PRIO) when
no priority is explicitly specified in sign_place or :sign place.

closes: vim/vim#15124

https://github.com/vim/vim/commit/b975ddfdf96644b8df808415dee36f99abd48753

Co-authored-by: LemonBoy <thatlemon@gmail.com>