### PR TITLE
fix(diagnostic): fix backwards compatibility for goto_next and goto_prev

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -23,8 +23,8 @@ LUA
 - vim.region()		Use |getregionpos()| instead.
 
 DIAGNOSTICS
-- *vim.diagnostic.goto_next()*	Use |vim.diagnostic.jump()| with `{count = 1}` instead.
-- *vim.diagnostic.goto_prev()*	Use |vim.diagnostic.jump()| with `{count = -1}` instead.
+- *vim.diagnostic.goto_next()*	Use |vim.diagnostic.jump()| with `{count = 1, float=true}` instead.
+- *vim.diagnostic.goto_prev()*	Use |vim.diagnostic.jump()| with `{count = -1, float=true}` instead.
 - *vim.diagnostic.get_next_pos()*
 	Use the "lnum" and "col" fields from the return value of
 	|vim.diagnostic.get_next()| instead.

--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -23,8 +23,8 @@ LUA
 - vim.region()		Use |getregionpos()| instead.
 
 DIAGNOSTICS
-- *vim.diagnostic.goto_next()*	Use |vim.diagnostic.jump()| with `{count = 1, float=true}` instead.
-- *vim.diagnostic.goto_prev()*	Use |vim.diagnostic.jump()| with `{count = -1, float=true}` instead.
+- *vim.diagnostic.goto_next()*	Use |vim.diagnostic.jump()| with `{count=1, float=true}` instead.
+- *vim.diagnostic.goto_prev()*	Use |vim.diagnostic.jump()| with `{count=-1, float=true}` instead.
 - *vim.diagnostic.get_next_pos()*
 	Use the "lnum" and "col" fields from the return value of
 	|vim.diagnostic.get_next()| instead.

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1194,6 +1194,8 @@ end
 ---@deprecated
 function M.goto_prev(opts)
   vim.deprecate('vim.diagnostic.goto_prev()', 'vim.diagnostic.jump()', '0.13')
+  opts = opts or {}
+  opts.float = if_nil(opts.float, true)
   goto_diagnostic(M.get_prev(opts), opts)
 end
 
@@ -1339,6 +1341,8 @@ end
 ---@deprecated
 function M.goto_next(opts)
   vim.deprecate('vim.diagnostic.goto_next()', 'vim.diagnostic.jump()', '0.13')
+  opts = opts or {}
+  opts.float = if_nil(opts.float, true)
   goto_diagnostic(M.get_next(opts), opts)
 end
 


### PR DESCRIPTION

Summary:


8ba73f0e4cc6 deprecated `vim.diagnostic.goto_next` in favor of
`vim.diagnostic.jump`, and reimplements `goto_next` in terms of `jump`.  This
is fine.  However, when reimplementing `goto_next`, we forgot that the default
behavior of `goto_next` is to show a floating window with the error (the
`float` option).

This commit adds the `float` option to the `opts` table in `goto_next` and
`goto_prev`, and sets it to `true` by default.  This is the behavior that
`goto_next` and `goto_prev` had before the deprecation.  This commit also
updates the documentation to reflect this change.

Test Plan:

1. use neovim 0.10
2. run `:lua vim.diagnostic.goto_next()`
3. verify that the error is shown in a floating window
4. run `:lua vim.diagnostic.goto_next({float=false})`
5. verify that the error is not shown in a floating window
----
6. use previous commit to this commit
7. run `:lua vim.diagnostic.goto_next()`
8. verify that the error is NOT shown in a floating window
----
9. use this commit
10. run `:lua vim.diagnostic.goto_next()`
11. verify that the error is shown in a floating window

Fixes #29591
