### PR TITLE
fix(health): fix fetching url with python in provider health

### DIFF
--- a/runtime/lua/vim/provider/health.lua
+++ b/runtime/lua/vim/provider/health.lua
@@ -409,12 +409,15 @@ local function download(url)
       return out
     end
   elseif vim.fn.executable('python') == 1 then
-    local script = "try:\n\
-          from urllib.request import urlopen\n\
-          except ImportError:\n\
-          from urllib2 import urlopen\n\
-          response = urlopen('" .. url .. "')\n\
-          print(response.read().decode('utf8'))\n"
+    local script = ([[
+try:
+    from urllib.request import urlopen
+except ImportError:
+    from urllib2 import urlopen
+
+response = urlopen('%s')
+print(response.read().decode('utf8'))
+]]):format(url)
     local out, rc = system({ 'python', '-c', script })
     if out == '' and rc ~= 0 then
       return 'python urllib.request error: ' .. rc


### PR DESCRIPTION
I've got an error in python provider checkhealth. Turned out it was not a provider error, but a wrong indentation for inline python code that is downloading URL content. It was introduced in 71225228fc2700a18c56c57f9dc14494cef83149.

Before:
![image](https://github.com/neovim/neovim/assets/1353637/1c536ae0-6ed7-49bf-99fd-02867c087366)
After:
![image](https://github.com/neovim/neovim/assets/1353637/520b2583-6cd9-4b9e-8d25-f79db6a45a65)
