### PR TITLE
perf(filetype): skip contents check in `match()` if there is no contents

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2595,20 +2595,24 @@ function M.match(args)
         contents = M._getlines(bufnr)
       end
     end
-    -- If name is nil, catch any errors from the contents filetype detection function.
-    -- If the function tries to use the filename that is nil then it will fail,
-    -- but this enables checks which do not need a filename to still work.
-    local ok
-    ok, ft, on_detect = pcall(
-      require('vim.filetype.detect').match_contents,
-      contents,
-      name,
-      function(ext)
-        return dispatch(extension[ext], name, bufnr)
+
+    -- Match based solely on content only if there is any content (for performance)
+    if not (#contents == 1 and contents[1] == '') then
+      -- If name is nil, catch any errors from the contents filetype detection function.
+      -- If the function tries to use the filename that is nil then it will fail,
+      -- but this enables checks which do not need a filename to still work.
+      local ok
+      ok, ft, on_detect = pcall(
+        require('vim.filetype.detect').match_contents,
+        contents,
+        name,
+        function(ext)
+          return dispatch(extension[ext], name, bufnr)
+        end
+      )
+      if ok then
+        return ft, on_detect
       end
-    )
-    if ok then
-      return ft, on_detect
     end
   end
 end


### PR DESCRIPTION
Problem: `vim.filetype.match()` tries to match on contents even if there
  is no contents (empty buffer or `{''}` explicit contents).
  This results in extra avoidable execution duration for cases.
  It matters, for example, when trying to match filetype based solely
  on file name (which still needs `contents` or `buf` to properly match
  earlier in the code path).

Solution: skip matching based solely on contents if it is `{''}`. This
  works because:
    - Matching solely on content is done after any user-configured `vim.filetype.add()` hooks.
    - All default matching on content might depend on supplied path *only* if there is non-empty content (like in `require('vim.filetype.detect').match_from_hashbang()`).

------

In my manual profiling, the content based matching runs about 0.15 ms from about 0.9 ms. Skipping it means reducing duration by about 17%, which seems significant.

------

I am not sure if adding standalone early return `if ... then ... else` is better here, as it is itself inside `if`, so decided to be more explicit in wrapping actual execution part.