### PR TITLE
build: remove -O2 from gen_cflags

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -477,7 +477,6 @@ endif()
 if(MSVC)
   list(APPEND gen_cflags -wd4003)
 endif()
-list(APPEND gen_cflags -O2)
 
 set(NVIM_VERSION_GIT_H ${PROJECT_BINARY_DIR}/cmake.config/auto/versiondef_git.h)
 add_custom_target(update_version_stamp


### PR DESCRIPTION
Problem:
zig cc implicitly defines NDEBUG with -O2. This breaks debug builds
which does not include -O2 or NDEBUG.

Solution:
Do not add -O2 when generating header files.
