### PR TITLE
feat(treesitter): handle quantified nodes for injection ranges

### DIFF
--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -488,7 +488,7 @@ int x = INT_MAX;
           parser = vim.treesitter.get_parser(0, "c", {
             injections = {
               c = (
-                '(preproc_def ((preproc_arg) @injection.content (#set! injection.language "c") (#offset! @injection.content 0 2 0 -1))) ' ..
+                '(preproc_def ((preproc_arg) @injection.content (#set! injection.language "c") (#offset! @injection.content 0 1 0 -1))) ' ..
                 '(preproc_function_def value: (preproc_arg) @injection.content (#set! injection.language "c"))'
               )
             }})
@@ -498,9 +498,9 @@ int x = INT_MAX;
         eq('table', exec_lua('return type(parser:children().c)'))
         eq({
           { 0, 0, 7, 0 }, -- root tree
-          { 3, 16, 3, 16 }, -- VALUE 123
-          { 4, 17, 4, 17 }, -- VALUE1 123
-          { 5, 17, 5, 17 }, -- VALUE2 123
+          { 3, 15, 3, 16 }, -- VALUE 123
+          { 4, 16, 4, 17 }, -- VALUE1 123
+          { 5, 16, 5, 17 }, -- VALUE2 123
           { 1, 26, 1, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
           { 2, 29, 2, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
         }, get_ranges())


### PR DESCRIPTION
Allows injection ranges to span quantified node captures. I had made this PR mostly for the sake of convenience but I have also noticed it's made injections more robust in certain ways:

- Empty injection ranges are ignored (see the modification in `parser_spec`; previously, the ranges were not counted before because they were empty, so I had to change the offset amount)
- Most use cases for `injection.combined` are now obsolete
  - The only cases where it would still be necessary (that I can think of) are when you really need a combined injection range and you cannot capture both nodes for that combination in just a single query.
- Combined injection ranges span the in-between area more accurately. See the below images:

Before:
![beforeinjection](https://github.com/neovim/neovim/assets/55766287/f9f8e90c-96a6-493c-8554-881646276326)

After:
![afterinjection](https://github.com/neovim/neovim/assets/55766287/6b618f6c-b844-491f-a31f-70b10bb1fbeb)

**Question:** Was the previous behavior intended? Perhaps there are cases where parsing the content in-between the combined range (rather than just combining the nodes themselves and parsing only those) leads to undesirable highlighting? I couldn't find an answer to that question from the documentation, but it is very specific. Perhaps a reviewer wiser than myself can answer it

---

I will add tests later, if this PR is deemed acceptable