### PR TITLE
vim-patch: documentation updates

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -7063,6 +7063,7 @@ sign_define({list})
 		   icon		full path to the bitmap file for the sign.
 		   linehl	highlight group used for the whole line the
 				sign is placed in.
+		   priority	default priority value of the sign
 		   numhl	highlight group used for the line number where
 				the sign is placed.
 		   text		text that is displayed when there is no icon

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -196,10 +196,12 @@ tag		char	      note action in Normal mode	~
 |<Tab>|		<Tab>		1  go to N newer entry in jump list
 |CTRL-I|	CTRL-I		1  same as <Tab>
 |<NL>|		<NL>		1  same as "j"
+|<S-NL>|	<S-NL>		1  same as CTRL-F
 |CTRL-J|	CTRL-J		1  same as "j"
 		CTRL-K		   not used
 |CTRL-L|	CTRL-L		   redraw screen
 |<CR>|		<CR>		1  cursor to the first CHAR N lines lower
+|<S-CR>|	<S-CR>		1  same as CTRL-F
 |CTRL-M|	CTRL-M		1  same as <CR>
 |CTRL-N|	CTRL-N		1  same as "j"
 |CTRL-O|	CTRL-O		1  go to N older entry in jump list
@@ -272,9 +274,11 @@ tag		char	      note action in Normal mode	~
 |star|		*		1  search forward for the Nth occurrence of
 				   the ident under the cursor
 |+|		+		1  same as <CR>
+|<S-Plus>|	<S-+>		1  same as CTRL-F
 |,|		,		1  repeat latest f, t, F or T in opposite
 				   direction N times
 |-|		-		1  cursor to the first CHAR N lines higher
+|<S-Minus>|	<S-->		1  same as CTRL-B
 |.|		.		2  repeat last change with count replaced with
 				   N
 |/|		/{pattern}<CR>	1  search forward for the Nth occurrence of

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -752,6 +752,21 @@ will be classified as tcsh, UNLESS the "filetype_csh" variable exists.  If the
 "filetype_csh" variable exists, the filetype will be set to the value of the
 variable.
 
+CSV							*ft-csv-syntax*
+
+If you change the delimiter of the CSV file, the syntax highlighting will be
+now longer match the changed file content. You will need to unlet the
+following variable: >
+
+	:unlet b:csv_delimiter
+
+And afterwards save and reload the file: >
+
+	:w
+	:e
+
+Now the syntax engine should determine the newly changed csv delimiter.
+
 
 CYNLIB						*cynlib.vim* *ft-cynlib-syntax*
 

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -8427,6 +8427,7 @@ function vim.fn.sign_define(name, dict) end
 ---    icon    full path to the bitmap file for the sign.
 ---    linehl  highlight group used for the whole line the
 ---     sign is placed in.
+---    priority  default priority value of the sign
 ---    numhl  highlight group used for the line number where
 ---     the sign is placed.
 ---    text    text that is displayed when there is no icon

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -10057,6 +10057,7 @@ M.funcs = {
          icon		full path to the bitmap file for the sign.
          linehl	highlight group used for the whole line the
       		sign is placed in.
+         priority	default priority value of the sign
          numhl	highlight group used for the line number where
       		the sign is placed.
          text		text that is displayed when there is no icon


### PR DESCRIPTION
#### vim-patch:b9bbf1f: runtime(doc): clarify how to re-init csv syntax file

https://github.com/vim/vim/commit/b9bbf1f04439a6cdb6d376c94852721e4ebf8300

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:fbbabbc: runtime(doc): add page-scrolling keys to index.txt

Also add the newly documented keys from commit 6a4afb1efca1bac5fbc0281804591cf0a52b2d81
to index.txt which was forgotten.

related: vim/vim#15107

https://github.com/vim/vim/commit/fbbabbca3319ea1b358c08f250b4582421c40600

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.0540: Unused assignment in sign_define_cmd()

Problem:  Unused assignment in sign_define_cmd()
Solution: Remove the assignment.  Also document the "priority" flag of
          sign_define(). (zeertzjq)

closes: vim/vim#15169

https://github.com/vim/vim/commit/fc3f5dba52099d82ccc8bfe309d58a6fac01373d