### PR TITLE
vim-patch:9.1.0543: Behavior of CursorMovedC is strange

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -524,12 +524,9 @@ CursorMoved			After the cursor was moved in Normal or Visual
 				that is slow.
 							*CursorMovedC*
 CursorMovedC			After the cursor was moved in the command
-				line while the text in the command line hasn't
-				changed.  Be careful not to mess up the
-				command line, it may cause Vim to lock up.
-				<afile> is set to a single character,
-				indicating the type of command-line.
-				|cmdwin-char|
+				line.  Be careful not to mess up the command
+				line, it may cause Vim to lock up.
+				<afile> expands to the |cmdline-char|.
 							*CursorMovedI*
 CursorMovedI			After the cursor was moved in Insert mode.
 				Not triggered when the popup menu is visible.

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2188,6 +2188,7 @@ static int command_line_not_changed(CommandLineState *s)
     trigger_cmd_autocmd(get_cmdline_type(), EVENT_CURSORMOVEDC);
     s->prev_cmdpos = ccline.cmdpos;
   }
+
   // Incremental searches for "/" and "?":
   // Enter command_line_not_changed() when a character has been read but the
   // command line did not change. Then we only search and redraw if something
@@ -2662,9 +2663,14 @@ static void do_autocmd_cmdlinechanged(int firstc)
 
 static int command_line_changed(CommandLineState *s)
 {
-  s->prev_cmdpos = ccline.cmdpos;
   // Trigger CmdlineChanged autocommands.
   do_autocmd_cmdlinechanged(s->firstc > 0 ? s->firstc : '-');
+
+  // Trigger CursorMovedC autocommands.
+  if (ccline.cmdpos != s->prev_cmdpos) {
+    trigger_cmd_autocmd(get_cmdline_type(), EVENT_CURSORMOVEDC);
+    s->prev_cmdpos = ccline.cmdpos;
+  }
 
   const bool prev_cmdpreview = cmdpreview;
   if (s->firstc == ':'

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -2013,21 +2013,30 @@ func Test_Cmdline()
 
   au! CursorMovedC : let g:pos += [getcmdpos()]
   let g:pos = []
+  call feedkeys(":foo bar baz\<C-W>\<C-W>\<C-W>\<Esc>", 'xt')
+  call assert_equal([2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 9, 5, 1], g:pos)
+  let g:pos = []
+  call feedkeys(":hello\<C-B>\<Esc>", 'xt')
+  call assert_equal([2, 3, 4, 5, 6, 1], g:pos)
+  let g:pos = []
+  call feedkeys(":hello\<C-U>\<Esc>", 'xt')
+  call assert_equal([2, 3, 4, 5, 6, 1], g:pos)
+  let g:pos = []
   call feedkeys(":hello\<Left>\<C-R>=''\<CR>\<Left>\<Right>\<Esc>", 'xt')
-  call assert_equal([5, 4, 5], g:pos)
+  call assert_equal([2, 3, 4, 5, 6, 5, 4, 5], g:pos)
   let g:pos = []
   call feedkeys(":12345678\<C-R>=setcmdpos(3)??''\<CR>\<Esc>", 'xt')
-  call assert_equal([3], g:pos)
+  call assert_equal([2, 3, 4, 5, 6, 7, 8, 9, 3], g:pos)
   let g:pos = []
   call feedkeys(":12345678\<C-R>=setcmdpos(3)??''\<CR>\<Left>\<Esc>", 'xt')
-  call assert_equal([3, 2], g:pos)
+  call assert_equal([2, 3, 4, 5, 6, 7, 8, 9, 3, 2], g:pos)
   au! CursorMovedC
 
   " setcmdpos() is no-op inside an autocommand
   au! CursorMovedC : let g:pos += [getcmdpos()] | call setcmdpos(1)
   let g:pos = []
   call feedkeys(":hello\<Left>\<Left>\<Esc>", 'xt')
-  call assert_equal([5, 4], g:pos)
+  call assert_equal([2, 3, 4, 5, 6, 5, 4], g:pos)
   au! CursorMovedC
 
   unlet g:entered


### PR DESCRIPTION
#### vim-patch:9.1.0543: Behavior of CursorMovedC is strange

Problem:  Behavior of CursorMovedC is strange.
Solution: Also trigger when the cmdline has changed.
          (zeertzjq)

closes: vim/vim#15071

https://github.com/vim/vim/commit/8145620a958dbb5c82cf8f8a37556ee1ea501c6d