### PR TITLE
fix(quickfix): make shortmess+=O work with cmdheight=0

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -146,8 +146,7 @@ EXTERN hlf_T edit_submode_highl;                // highl. method for extra info
 EXTERN bool cmdmsg_rl INIT( = false);  // cmdline is drawn right to left
 EXTERN int msg_col;
 EXTERN int msg_row;
-EXTERN int msg_scrolled;        // Number of screen lines that windows have
-                                // scrolled because of printing messages.
+EXTERN int msg_scrolled;  ///< Number of screen lines that messages have scrolled.
 // when true don't set need_wait_return in msg_puts_attr()
 // when msg_scrolled is non-zero
 EXTERN bool msg_scrolled_ign INIT( = false);

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2915,8 +2915,7 @@ static void qf_jump_print_msg(qf_info_T *qi, int qf_index, qfline_T *qf_ptr, buf
 {
   garray_T *const gap = qfga_get();
 
-  // Update the screen before showing the message, unless the screen
-  // scrolled up.
+  // Update the screen before showing the message, unless messages scrolled.
   if (!msg_scrolled) {
     update_topline(curwin);
     if (must_redraw) {
@@ -2938,7 +2937,8 @@ static void qf_jump_print_msg(qf_info_T *qi, int qf_index, qfline_T *qf_ptr, buf
   linenr_T i = msg_scroll;
   if (curbuf == old_curbuf && curwin->w_cursor.lnum == old_lnum) {
     msg_scroll = true;
-  } else if (!msg_scrolled && shortmess(SHM_OVERALL)) {
+  } else if ((msg_scrolled == 0 || (p_ch == 0 && msg_scrolled == 1))
+             && shortmess(SHM_OVERALL)) {
     msg_scroll = false;
   }
   msg_ext_set_kind("quickfix");

--- a/test/functional/ex_cmds/quickfix_commands_spec.lua
+++ b/test/functional/ex_cmds/quickfix_commands_spec.lua
@@ -185,6 +185,9 @@ describe('quickfix', function()
   it('BufAdd does not cause E16 when reusing quickfix buffer #18135', function()
     local file = file_base .. '_reuse_qfbuf_BufAdd'
     write_file(file, ('\n'):rep(100) .. 'foo')
+    finally(function()
+      os.remove(file)
+    end)
     source([[
       set grepprg=internal
       autocmd BufAdd * call and(0, 0)
@@ -192,7 +195,24 @@ describe('quickfix', function()
     ]])
     command('grep foo ' .. file)
     command('grep foo ' .. file)
-    os.remove(file)
+  end)
+
+  it('jump message does not scroll with cmdheight=0 and shm+=O #29597', function()
+    local screen = Screen.new(40, 6)
+    screen:attach()
+    command('set cmdheight=0')
+    local file = file_base .. '_reuse_qfbuf_BufAdd'
+    write_file(file, 'foobar')
+    finally(function()
+      os.remove(file)
+    end)
+    command('vimgrep /foo/gj ' .. file)
+    feed(':cc<CR>')
+    screen:expect([[
+      ^foobar                                  |
+      {1:~                                       }|*4
+      (1 of 1): foobar                        |
+    ]])
   end)
 end)
 


### PR DESCRIPTION
Fix #29597
