### PR TITLE
refactor: remove CH_FOLD macro

### DIFF
--- a/src/nvim/charset.h
+++ b/src/nvim/charset.h
@@ -7,16 +7,6 @@
 #include "nvim/option_vars.h"
 #include "nvim/strings.h"  // IWYU pragma: keep
 
-/// Return the folded-case equivalent of the given character
-///
-/// @param[in]  c  Character to transform.
-///
-/// @return Folded variant.
-#define CH_FOLD(c) \
-  utf_fold((sizeof(c) == sizeof(char)) \
-           ? ((int)(uint8_t)(c)) \
-           : ((int)(c)))
-
 /// Flags for vim_str2nr()
 typedef enum {
   STR2NR_DEC = 0,

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -390,14 +390,14 @@ int path_fnamencmp(const char *const fname1, const char *const fname2, size_t le
     c2 = utf_ptr2char(p2);
     if ((c1 == NUL || c2 == NUL
          || (!((c1 == '/' || c1 == '\\') && (c2 == '\\' || c2 == '/'))))
-        && (p_fic ? (c1 != c2 && CH_FOLD(c1) != CH_FOLD(c2)) : c1 != c2)) {
+        && (p_fic ? (c1 != c2 && utf_fold(c1) != utf_fold(c2)) : c1 != c2)) {
       break;
     }
     len -= (size_t)utfc_ptr2len(p1);
     p1 += utfc_ptr2len(p1);
     p2 += utfc_ptr2len(p2);
   }
-  return p_fic ? CH_FOLD(c1) - CH_FOLD(c2) : c1 - c2;
+  return p_fic ? utf_fold(c1) - utf_fold(c2) : c1 - c2;
 #else
   if (p_fic) {
     return mb_strnicmp(fname1, fname2, len);


### PR DESCRIPTION
It should not be needed as utf_fold should already work on its own.
