### PR TITLE
vim-patch:9.1.0554: :bw leaves jumplist and tagstack data around

### DIFF
--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1175,11 +1175,12 @@ list of buffers. |unlisted-buffer|
 :bw[ipeout][!] N1 N2 ...
 		Like |:bdelete|, but really delete the buffer.  Everything
 		related to the buffer is lost.  All marks in this buffer
-		become invalid, option settings are lost, etc.  Don't use this
+		become invalid, option settings are lost, the jumplist and
+		tagstack data will be purged, etc.  Don't use this
 		unless you know what you are doing. Examples: >
-                    :.+,$bwipeout   " wipe out all buffers after the current
-                                    " one
-                    :%bwipeout      " wipe out all buffers
+		    :.+,$bwipeout   " wipe out all buffers after the current
+				    " one
+		    :%bwipeout	    " wipe out all buffers
 <
 :[N]bun[load][!]				*:bun* *:bunload* *E515*
 :bun[load][!] [N]

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -43,6 +43,7 @@
 #include "nvim/pos_defs.h"
 #include "nvim/quickfix.h"
 #include "nvim/strings.h"
+#include "nvim/tag.h"
 #include "nvim/textobject.h"
 #include "nvim/types_defs.h"
 #include "nvim/vim_defs.h"
@@ -163,6 +164,56 @@ int setmark_pos(int c, pos_T *pos, int fnum, fmarkv_T *view_pt)
     return OK;
   }
   return FAIL;
+}
+
+/// Remove every jump list entry referring to a given buffer.
+/// This function will also adjust the current jump list index.
+void mark_jumplist_forget_file(win_T *wp, int fnum)
+{
+  // Remove all jump list entries that match the deleted buffer.
+  for (int i = wp->w_jumplistlen - 1; i >= 0; i--) {
+    if (wp->w_jumplist[i].fmark.fnum == fnum) {
+      // Found an entry that we want to delete.
+      free_xfmark(wp->w_jumplist[i]);
+
+      // If the current jump list index is behind the entry we want to delete,
+      // move it back by one.
+      if (wp->w_jumplistidx > i) {
+        wp->w_jumplistidx--;
+      }
+
+      // Actually remove the entry from the jump list.
+      wp->w_jumplistlen--;
+      memmove(&wp->w_jumplist[i], &wp->w_jumplist[i + 1],
+              (size_t)(wp->w_jumplistlen - i) * sizeof(wp->w_jumplist[i]));
+    }
+  }
+}
+
+/// Delete every entry referring to file "fnum" from both the jumplist and the
+/// tag stack.
+void mark_forget_file(win_T *wp, int fnum)
+{
+  mark_jumplist_forget_file(wp, fnum);
+
+  // Remove all tag stack entries that match the deleted buffer.
+  for (int i = wp->w_tagstacklen - 1; i >= 0; i--) {
+    if (wp->w_tagstack[i].fmark.fnum == fnum) {
+      // Found an entry that we want to delete.
+      tagstack_clear_entry(&wp->w_tagstack[i]);
+
+      // If the current tag stack index is behind the entry we want to delete,
+      // move it back by one.
+      if (wp->w_tagstackidx > i) {
+        wp->w_tagstackidx--;
+      }
+
+      // Actually remove the entry from the tag stack.
+      wp->w_tagstacklen--;
+      memmove(&wp->w_tagstack[i], &wp->w_tagstack[i + 1],
+              (size_t)(wp->w_tagstacklen - i) * sizeof(wp->w_tagstack[i]));
+    }
+  }
 }
 
 // Set the previous context mark to the current position and add it to the

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -3184,7 +3184,7 @@ static int find_extra(char **pp)
 //
 // Free a single entry in a tag stack
 //
-static void tagstack_clear_entry(taggy_T *item)
+void tagstack_clear_entry(taggy_T *item)
 {
   XFREE_CLEAR(item->tagname);
   XFREE_CLEAR(item->user_data);

--- a/src/nvim/tag.h
+++ b/src/nvim/tag.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "nvim/buffer_defs.h"  // IWYU pragma: keep
 #include "nvim/eval/typval_defs.h"  // IWYU pragma: keep
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: keep
 #include "nvim/option_defs.h"  // IWYU pragma: keep

--- a/test/old/testdir/test_jumplist.vim
+++ b/test/old/testdir/test_jumplist.vim
@@ -68,26 +68,16 @@ endfunc
 func Test_jumplist_invalid()
   new
   clearjumps
-  " put some randome text
-  put ='a'
-  let prev = bufnr('%')
+  " Put some random text and fill the jump list.
+  call setline(1, ['foo', 'bar', 'baz'])
+  normal G
+  normal gg
   setl nomodified bufhidden=wipe
   e XXJumpListBuffer
-  let bnr = bufnr('%')
-  " 1) empty jumplist
-  let expected = [[
-   \ {'lnum': 2, 'bufnr': prev, 'col': 0, 'coladd': 0}], 1]
-  call assert_equal(expected, getjumplist())
+  " The jump list is empty as the buffer was wiped out.
+  call assert_equal([[], 0], getjumplist())
   let jumps = execute(':jumps')
   call assert_equal('>', jumps[-1:])
-  " now jump back
-  exe ":norm! \<c-o>"
-  let expected = [[
-    \ {'lnum': 2, 'bufnr': prev, 'col': 0, 'coladd': 0},
-    \ {'lnum': 1, 'bufnr': bnr,  'col': 0, 'coladd': 0}], 0]
-  call assert_equal(expected, getjumplist())
-  let jumps = execute(':jumps')
-  call assert_match('>  0     2    0 -invalid-', jumps)
 endfunc
 
 " Test for '' mark in an empty buffer

--- a/test/old/testdir/test_tagjump.vim
+++ b/test/old/testdir/test_tagjump.vim
@@ -1001,6 +1001,23 @@ func Test_tag_stack()
   call settagstack(1, {'items' : []})
   call assert_fails('pop', 'E73:')
 
+  " References to wiped buffer are deleted.
+  for i in range(10, 20)
+    edit Xtest
+    exe "tag var" .. i
+  endfor
+  edit Xtest
+
+  let t = gettagstack()
+  call assert_equal(11, t.length)
+  call assert_equal(12, t.curidx)
+
+  bwipe!
+
+  let t = gettagstack()
+  call assert_equal(0, t.length)
+  call assert_equal(1, t.curidx)
+
   set tags&
   %bwipe
 endfunc

--- a/test/old/testdir/test_winfixbuf.vim
+++ b/test/old/testdir/test_winfixbuf.vim
@@ -2934,6 +2934,7 @@ func Test_tfirst()
         \ "Xtags", 'D')
   call writefile(["one", "two", "three"], "Xfile", 'D')
   call writefile(["one"], "Xother", 'D')
+  tag one
   edit Xother
 
   set winfixbuf


### PR DESCRIPTION
#### vim-patch:9.1.0554: :bw leaves jumplist and tagstack data around

Problem:  :bw leaves jumplist and tagstack data around
          (Paul "Joey" Clark)
Solution: Wipe jumplist and tagstack references to the wiped buffer
          (LemonBoy)

As documented the :bwipeout command brutally deletes all the references
to the buffer, so let's make it delete all the entries in the jump list
and tag stack referring to the wiped-out buffer.

closes: vim/vim#15185

https://github.com/vim/vim/commit/4ff3a9b1e3ba45f9dbd0ea8c721f27d9315c4d93

Co-authored-by: LemonBoy <thatlemon@gmail.com>