### PR TITLE
feat: let getmousepos accepts row, col params

### DIFF
--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4107,6 +4107,8 @@ M.funcs = {
     signature = 'getmatches([{win}])',
   },
   getmousepos = {
+    args = {0, 2},
+    base = 0,
     desc = [=[
       Returns a |Dictionary| with the last known position of the
       mouse.  This can be used in a mapping for a mouse click.  The
@@ -4139,8 +4141,8 @@ M.funcs = {
       |v:mouse_col| and |v:mouse_winid| also provide these values.
     ]=],
     name = 'getmousepos',
-    params = {},
-    signature = 'getmousepos()',
+    params = {{'row', 'integer'}, {'col', 'integer'}},
+    signature = 'getmousepos([{row} [, {col}]])',
     returns = 'vim.fn.getmousepos.ret',
   },
   getpid = {

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -1913,9 +1913,9 @@ static void mouse_check_grid(colnr_T *vcolp, int *flagsp)
 /// "getmousepos()" function
 void f_getmousepos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  int row = mouse_row;
-  int col = mouse_col;
-  int grid = mouse_grid;
+  int row = 0;
+  int col = 0;
+  int grid = 0;
   varnumber_T winid = 0;
   varnumber_T winrow = 0;
   varnumber_T wincol = 0;
@@ -1923,11 +1923,22 @@ void f_getmousepos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   varnumber_T column = 0;
   colnr_T coladd = 0;
 
+  if (argvars[0].v_type != VAR_UNKNOWN && argvars[1].v_type != VAR_UNKNOWN) {
+     // todo: overflow
+     row = (int)tv_get_number(&argvars[0]) - 1;
+     col = (int)tv_get_number(&argvars[1]) - 1;
+     grid = 0;
+  } else {
+    row = mouse_row;
+    col = mouse_col;
+    grid = mouse_grid;
+  }
+
   tv_dict_alloc_ret(rettv);
   dict_T *d = rettv->vval.v_dict;
 
-  tv_dict_add_nr(d, S_LEN("screenrow"), (varnumber_T)mouse_row + 1);
-  tv_dict_add_nr(d, S_LEN("screencol"), (varnumber_T)mouse_col + 1);
+  tv_dict_add_nr(d, S_LEN("screenrow"), (varnumber_T)row + 1);
+  tv_dict_add_nr(d, S_LEN("screencol"), (varnumber_T)col + 1);
 
   win_T *wp = mouse_find_win(&grid, &row, &col);
   if (wp != NULL) {


### PR DESCRIPTION
hi folks, i have the need to resolve a point(screenrow,screencol) to window id, col and row (which share the same meaning with col/line(), not winline/wincol()). and i found the getmousepos() offers almost identical functionality, except it accepts no screen (or mouse) row/col.
so this pr tries to add these two parameters.

the reason i do not use getwininfo to compute it by myself is that i found it's rather difficult to deal with a line contains `<tab>` and utf-8 characters.

currently it's just my very early attempt: the code is not mature enough, no tests. yet it does work in my plugin. 

what do you think?