### PR TITLE
vim-patch:9.1.{0503,0549}

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3651,8 +3651,8 @@ static compl_T *find_comp_when_fuzzy(void)
   const bool is_backward = compl_shows_dir_backward();
   compl_T *comp = NULL;
 
-  if (compl_match_array == NULL
-      || (is_forward && compl_selected_item == compl_match_arraysize - 1)
+  assert(compl_match_array != NULL);
+  if ((is_forward && compl_selected_item == compl_match_arraysize - 1)
       || (is_backward && compl_selected_item == 0)) {
     return compl_first_match != compl_shown_match
            ? compl_first_match


### PR DESCRIPTION
#### vim-patch:9.1.{0503,0549}

vim-patch:9.1.0503: cannot use fuzzy keyword completion

Problem:  cannot use fuzzy keyword completion
          (Maxim Kim)
Solution: add the "fuzzycollect" value for the 'completeopt'
          setting, to gather matches using fuzzy logic (glepnir)

closes: vim/vim#14976

https://github.com/vim/vim/commit/43eef882ff42e673af1e753892801ba20c5d002a

vim-patch:9.1.0549: fuzzycollect regex based completion not working as expected

Problem:  fuzzycollect regex based completion not working as expected
Solution: Revert Patch v9.1.0503 (glepnir)

closes: vim/vim#15192

https://github.com/vim/vim/commit/600a12d08e7aeb95a6b02382bfee310aef9801dd

Co-authored-by: glepnir <glephunter@gmail.com>