### PR TITLE
fix: use utf8proc to detect emojis

### DIFF
--- a/src/nvim/generators/gen_unicode_tables.lua
+++ b/src/nvim/generators/gen_unicode_tables.lua
@@ -12,9 +12,9 @@
 --    2 then interval applies only to first, third, fifth, … character in range.
 --    Fourth value is number that should be added to the codepoint to yield
 --    folded codepoint.
--- 4. emoji_wide and emoji_all tables: sorted lists of non-overlapping closed
---    intervals of Emoji characters.  emoji_wide contains all the characters
---    which don't have ambiguous or double width, and emoji_all has all Emojis.
+-- 4. emoji_wide table: sorted list of non-overlapping closed
+--    intervals of Emoji characters. emoji_wide contains all the characters
+--    which don't have ambiguous or double width.
 if arg[1] == '--help' then
   print('Usage:')
   print('  gen_unicode_tables.lua unicode/ unicode_tables.generated.h')
@@ -269,12 +269,6 @@ local build_emoji_table = function(ut_fp, emojiprops, doublewidth, ambiwidth)
       end
     end
   end
-
-  ut_fp:write('static const struct interval emoji_all[] = {\n')
-  for _, p in ipairs(emoji) do
-    ut_fp:write(make_range(p[1], p[2]))
-  end
-  ut_fp:write('};\n')
 
   ut_fp:write('static const struct interval emoji_wide[] = {\n')
   for _, p in ipairs(emojiwidth) do

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1258,7 +1258,7 @@ int utf_class_tab(const int c, const uint64_t *const chartab)
   }
 
   // emoji
-  if (intable(emoji_all, ARRAY_SIZE(emoji_all), c)) {
+  if (utf8proc_get_property(c)->boundclass == UTF8PROC_BOUNDCLASS_EXTENDED_PICTOGRAPHIC) {
     return 3;
   }
 
@@ -1281,7 +1281,8 @@ int utf_class_tab(const int c, const uint64_t *const chartab)
 bool utf_ambiguous_width(int c)
 {
   return c >= 0x80 && (intable(ambiguous, ARRAY_SIZE(ambiguous), c)
-                       || intable(emoji_all, ARRAY_SIZE(emoji_all), c));
+                       || utf8proc_get_property(c)->boundclass ==
+                       UTF8PROC_BOUNDCLASS_EXTENDED_PICTOGRAPHIC);
 }
 
 // Generic conversion function for case operations.


### PR DESCRIPTION
More accurately, it will check if the codepoint has the
"Extended_Pictographic" property, which according to
https://www.unicode.org/reports/tr51/#Emoji_Properties_and_Data_Files is
described as:

"The Extended_Pictographic characters contain all the Emoji characters
except for some Emoji_Component characters." This should in most cases
align with what people refer to when they say "emoji".