### PR TITLE
fix: assert failure in VimL expression parser

### DIFF
--- a/src/nvim/viml/parser/expressions.c
+++ b/src/nvim/viml/parser/expressions.c
@@ -1264,21 +1264,12 @@ static bool viml_pexpr_handle_bop(const ParserState *const pstate, ExprASTStack 
                                    || bop_node->type == kExprNodeSubscript)
                                   ? kEOpLvlSubscript
                                   : node_lvl(*bop_node));
-#ifndef NDEBUG
-  const ExprOpAssociativity bop_node_ass = (
-                                            (bop_node->type == kExprNodeCall
-                                             || bop_node->type == kExprNodeSubscript)
-                                            ? kEOpAssLeft
-                                            : node_ass(*bop_node));
-#endif
   do {
     ExprASTNode **new_top_node_p = kv_last(*ast_stack);
     ExprASTNode *new_top_node = *new_top_node_p;
     assert(new_top_node != NULL);
     const ExprOpLvl new_top_node_lvl = node_lvl(*new_top_node);
     const ExprOpAssociativity new_top_node_ass = node_ass(*new_top_node);
-    assert(bop_node_lvl != new_top_node_lvl
-           || bop_node_ass == new_top_node_ass);
     if (top_node_p != NULL
         && ((bop_node_lvl > new_top_node_lvl
              || (bop_node_lvl == new_top_node_lvl

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -2938,6 +2938,13 @@ describe('API', function()
         return ('%s(%s)%s'):format(typ, args, rest)
       end
     end
+
+    it('does not crash parsing invalid VimL expression #29648', function()
+      api.nvim_input(':<C-r>=')
+      api.nvim_input('1bork/')
+      assert_alive()
+    end)
+
     require('test.unit.viml.expressions.parser_tests')(it, _check_parsing, hl, fmtn)
   end)
 


### PR DESCRIPTION
Fix #7889
Fix #29648

Okay, I promise I'm not just coming in and tossing asserts out the window without care. On the contrary, I gently slid it down the window only after careful consideration.

The assertion fails when we end up with a kExprNodeOpMissing as one of the operands in multiplication or division (see issue steps to reproduce). The OpMissing node has an operator priority level of Multiplication (kEOpLvlMultiplication) but an associativity of None (kEOpAssNo). However, this case is actually checked for and handled in an if statement directly following the assert.  We could add more logic to the assert by checking that either `bop_node_ass` is `kEOpAssNo` or `new_top_node_ass` is `kEOpAssNo` but frankly I don't think we need to see any more `ass` logic.

Added  a test :)