### PR TITLE
vim-patch:9.1.0556: :bwipe doesn't remove file from jumplist of other tabpages

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -699,7 +699,7 @@ bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last, bool i
     if (buf->b_nwindows > 0) {
       return false;
     }
-    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+    FOR_ALL_TAB_WINDOWS(tp, wp) {
       mark_forget_file(wp, buf->b_fnum);
     }
     if (buf->b_sfname != buf->b_ffname) {

--- a/test/old/testdir/test_jumplist.vim
+++ b/test/old/testdir/test_jumplist.vim
@@ -19,7 +19,7 @@ func Test_getjumplist()
   for i in range(1, 100)
     call add(lines, "Line " . i)
   endfor
-  call writefile(lines, "Xtest")
+  call writefile(lines, "Xtest", 'D')
 
   " Jump around and create a jump list
   edit Xtest
@@ -61,11 +61,9 @@ func Test_getjumplist()
   clearjumps
   call test_garbagecollect_now()
   call assert_equal(4, l[1])
-
-  call delete("Xtest")
 endfunc
 
-func Test_jumplist_invalid()
+func Test_jumplist_wipe_buf()
   new
   clearjumps
   " Put some random text and fill the jump list.
@@ -78,6 +76,50 @@ func Test_jumplist_invalid()
   call assert_equal([[], 0], getjumplist())
   let jumps = execute(':jumps')
   call assert_equal('>', jumps[-1:])
+
+  " Put some random text and fill the jump list.
+  call setline(1, ['foo', 'bar', 'baz'])
+  setl bufhidden=hide
+
+  " References to wiped buffer are deleted with multiple tabpages.
+  let [w1, t1] = [win_getid(), tabpagenr()]
+  clearjumps
+  normal G
+  normal gg
+  enew
+
+  split XXJumpListBuffer
+  let [w2, t2] = [win_getid(), tabpagenr()]
+  clearjumps
+  normal G
+  normal gg
+  enew
+
+  tabnew XXJumpListBuffer
+  let [w3, t3] = [win_getid(), tabpagenr()]
+  clearjumps
+  normal G
+  normal gg
+  enew
+
+  split XXJumpListBuffer
+  let [w4, t4] = [win_getid(), tabpagenr()]
+  clearjumps
+  normal G
+  normal gg
+  enew
+
+  for [w, t] in [[w1, t1], [w2, t2], [w3, t3], [w4, t4]]
+    call assert_equal(2, len(getjumplist(w, t)[0]))
+  endfor
+
+  bwipe! XXJumpListBuffer
+
+  for [w, t] in [[w1, t1], [w2, t2], [w3, t3], [w4, t4]]
+    call assert_equal(0, len(getjumplist(w, t)[0]))
+  endfor
+
+  %bwipe!
 endfunc
 
 " Test for '' mark in an empty buffer

--- a/test/old/testdir/test_tagjump.vim
+++ b/test/old/testdir/test_tagjump.vim
@@ -1018,8 +1018,46 @@ func Test_tag_stack()
   call assert_equal(0, t.length)
   call assert_equal(1, t.curidx)
 
+  " References to wiped buffer are deleted with multiple tabpages.
+  let w1 = win_getid()
+  call settagstack(1, {'items' : []})
+  for i in range(10, 20) | edit Xtest | exe "tag var" .. i | endfor
+  enew
+
+  new
+  let w2 = win_getid()
+  call settagstack(1, {'items' : []})
+  for i in range(10, 20) | edit Xtest | exe "tag var" .. i | endfor
+  enew
+
+  tabnew
+  let w3 = win_getid()
+  call settagstack(1, {'items' : []})
+  for i in range(10, 20) | edit Xtest | exe "tag var" .. i | endfor
+  enew
+
+  new
+  let w4 = win_getid()
+  call settagstack(1, {'items' : []})
+  for i in range(10, 20) | edit Xtest | exe "tag var" .. i | endfor
+  enew
+
+  for w in [w1, w2, w3, w4]
+    let t = gettagstack(w)
+    call assert_equal(11, t.length)
+    call assert_equal(12, t.curidx)
+  endfor
+
+  bwipe! Xtest
+
+  for w in [w1, w2, w3, w4]
+    let t = gettagstack(w)
+    call assert_equal(0, t.length)
+    call assert_equal(1, t.curidx)
+  endfor
+
+  %bwipe!
   set tags&
-  %bwipe
 endfunc
 
 " Test for browsing multiple matching tags


### PR DESCRIPTION
#### vim-patch:9.1.0556: :bwipe doesn't remove file from jumplist of other tabpages

Problem:  :bwipe doesn't remove file from jumplist and tagstack of other
          tabpages. Time complexity of mark_forget_file() is O(n^2) when
          removing all entries (after v9.1.0554)
Solution: Use FOR_ALL_TAB_WINDOWS().  Start the loops over the arrays
          from the end instead of the start (zeertzjq)

closes: vim/vim#15199

https://github.com/vim/vim/commit/2e7d89b39883b0cfd3e615b02bd55186e00fb7ce