### PR TITLE
vim-patch:9.1.0557: moving in the buffer list doesn't work as documented

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -49,6 +49,9 @@ EDITOR
   now appear left of lower priority signs.
 • |hl-CurSearch| now behaves the same as Vim and no longer updates on every
   cursor movement.
+• Moving in the buffer list using |:bnext| and similar commands behaves as
+  documented and skips help buffers if run from a non-help buffer, otherwise
+  it moves to another help buffer.
 
 VIM SCRIPT
 

--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -39,7 +39,7 @@ enum bln_values {
   BLN_NOCURWIN = 128,  ///< buffer is not associated with curwin
 };
 
-/// Values for action argument for do_buffer()
+/// Values for action argument for do_buffer_ext() and close_buffer()
 enum dobuf_action_values {
   DOBUF_GOTO   = 0,  ///< go to specified buffer
   DOBUF_SPLIT  = 1,  ///< split window and go to specified buffer
@@ -48,12 +48,19 @@ enum dobuf_action_values {
   DOBUF_WIPE   = 4,  ///< delete specified buffer(s) really
 };
 
-/// Values for start argument for do_buffer()
+/// Values for start argument for do_buffer_ext()
 enum dobuf_start_values {
   DOBUF_CURRENT = 0,  ///< "count" buffer from current buffer
   DOBUF_FIRST   = 1,  ///< "count" buffer from first buffer
   DOBUF_LAST    = 2,  ///< "count" buffer from last buffer
   DOBUF_MOD     = 3,  ///< "count" mod. buffer from current buffer
+};
+
+/// Values for flags argument of do_buffer_ext()
+enum dobuf_flags_value {
+  DOBUF_FORCEIT  = 1,  ///< :cmd!
+  DOBUF_SKIPHELP = 4,  ///< skip or keep help buffers depending on b_help of the
+                       ///< starting buffer
 };
 
 /// flags for buf_freeall()

--- a/test/old/testdir/test_buffer.vim
+++ b/test/old/testdir/test_buffer.vim
@@ -126,6 +126,52 @@ func Test_buflist_browse()
   %bwipe!
 endfunc
 
+" Test for :bnext and :bprev when called from help and non-help buffers.
+func Test_bnext_bprev_help()
+  %bwipe!
+
+  e XHelp1 | set bt=help
+  let b1 = bufnr()
+  e Xbuf1
+  let b2 = bufnr()
+
+  " There's only one buffer of each type.
+  b XHelp1
+  bnext | call assert_equal(b1, bufnr())
+  bprev | call assert_equal(b1, bufnr())
+  b Xbuf1
+  bnext | call assert_equal(b2, bufnr())
+  bprev | call assert_equal(b2, bufnr())
+
+  " Add one more buffer of each type.
+  e XHelp2 | set bt=help
+  let b3 = bufnr()
+  e Xbuf2
+  let b4 = bufnr()
+
+  " Help buffer jumps to help buffer.
+  b XHelp1
+  bnext | call assert_equal(b3, bufnr())
+  bnext | call assert_equal(b1, bufnr())
+  bprev | call assert_equal(b3, bufnr())
+  bprev | call assert_equal(b1, bufnr())
+
+  " Regular buffer jumps to regular buffer.
+  b Xbuf1
+  bnext | call assert_equal(b4, bufnr())
+  bnext | call assert_equal(b2, bufnr())
+  bprev | call assert_equal(b4, bufnr())
+  bprev | call assert_equal(b2, bufnr())
+
+  " :brewind and :blast are not affected by the buffer type.
+  b Xbuf2
+  brewind | call assert_equal(b1, bufnr())
+  b XHelp1
+  blast   | call assert_equal(b4, bufnr())
+
+  %bwipe!
+endfunc
+
 " Test for :bdelete
 func Test_bdelete_cmd()
   %bwipe!


### PR DESCRIPTION
#### vim-patch:9.1.0557: moving in the buffer list doesn't work as documented

Problem:  moving in the buffer list doesn't work as documented
          (SenileFelineS)
Solution: Skip non-help buffers, when run from normal buffers, else
          only move from help buffers to the next help buffer (LemonBoy)

As explained in the help section for :bnext and :bprev the commands
should jump from help buffers to help buffers (and from regular ones to
regular ones).

closes: vim/vim#15198

https://github.com/vim/vim/commit/893eeeb44583ca33276e263165b2a6e50fd297d0

Co-authored-by: LemonBoy <thatlemon@gmail.com>