### PR TITLE
vim-patch:fc533c9: runtime(mojo): include mojo ftplugin and indent script

### DIFF
--- a/runtime/ftplugin/mojo.vim
+++ b/runtime/ftplugin/mojo.vim
@@ -1,0 +1,41 @@
+" Vim filetype plugin
+" Language:	Mojo
+" Maintainer:	Riley Bruins <ribru17@gmail.com>
+" Last Change:	2024 Jul 07
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal include=^\\s*\\(from\\\|import\\)
+setlocal define=^\\s*\\(\\(async\\s\\+\\)\\?def\\\|class\\)
+
+" For imports with leading .., append / and replace additional .s with ../
+let b:grandparent_match = '^\(.\.\)\(\.*\)'
+let b:grandparent_sub = '\=submatch(1)."/".repeat("../",strlen(submatch(2)))'
+
+" For imports with a single leading ., replace it with ./
+let b:parent_match = '^\.\(\.\)\@!'
+let b:parent_sub = './'
+
+" Replace any . sandwiched between word characters with /
+let b:child_match = '\(\w\)\.\(\w\)'
+let b:child_sub = '\1/\2'
+
+setlocal includeexpr=substitute(substitute(substitute(
+      \v:fname,
+      \b:grandparent_match,b:grandparent_sub,''),
+      \b:parent_match,b:parent_sub,''),
+      \b:child_match,b:child_sub,'g')
+
+setlocal suffixesadd=.mojo
+setlocal comments=b:#,fb:-
+setlocal commentstring=#\ %s
+
+let b:undo_ftplugin = 'setlocal include<'
+      \ . '|setlocal define<'
+      \ . '|setlocal includeexpr<'
+      \ . '|setlocal suffixesadd<'
+      \ . '|setlocal comments<'
+      \ . '|setlocal commentstring<'

--- a/runtime/indent/mojo.vim
+++ b/runtime/indent/mojo.vim
@@ -1,0 +1,6 @@
+" Vim indent file
+" Language:	Mojo
+" Maintainer:	Riley Bruins <ribru17@gmail.com>
+" Last Change:	2024 Jul 07
+
+runtime! indent/python.vim


### PR DESCRIPTION
Taken from excerpts of the Python ftplugin and adapted,
indent script simply sources the python indent script.

closes: vim/vim#15171

https://github.com/vim/vim/commit/fc533c9f06aff579437f9f2348a21241a72c7967

Co-authored-by: Riley Bruins <ribru17@hotmail.com>
