### PR TITLE
vim-patch:57f7d75: runtime(logindefs): update syntax with new keywords

### DIFF
--- a/runtime/syntax/logindefs.vim
+++ b/runtime/syntax/logindefs.vim
@@ -1,7 +1,8 @@
-" Vim syntax file
+" Vim syntax file for login.defs(5)
 " Language:             login.defs(5) configuration file
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
 " Latest Revision:      2010-11-29
+" 2024 Jul 12 by Vim Project: Update keywords
 
 if exists("b:current_syntax")
   finish
@@ -35,6 +36,8 @@ syn keyword logindefsBooleanKeyword contained
                                     \ CREATE_HOME
                                     \ DEFAULT_HOME
                                     \ FAILLOG_ENAB
+                                    \ FORCE_SHADOW
+                                    \ GRANT_AUX_GROUP_SUBIDS
                                     \ LASTLOG_ENAB
                                     \ LOG_OK_LOGINS
                                     \ LOG_UNKFAIL_ENAB
@@ -54,15 +57,20 @@ syn keyword logindefsBoolean        contained yes no
 
 syn keyword logindefsEncryptKeyword contained
                                     \ ENCRYPT_METHOD
+                                    \ HMAC_CRYPTO_ALGO
                                     \ nextgroup=logindefsEncryptMethod skipwhite
 
 syn keyword logindefsEncryptMethod  contained
+                                    \ BCRYPT
                                     \ DES
                                     \ MD5
                                     \ SHA256
                                     \ SHA512
+                                    \ YESCRYPT
 
 syn keyword logindefsNumberKeyword  contained
+                                    \ BCRYPT_MAX_ROUNDS
+                                    \ BCRYPT_MIN_ROUNDS
                                     \ ERASECHAR
                                     \ FAIL_DELAY
                                     \ GID_MAX
@@ -79,6 +87,12 @@ syn keyword logindefsNumberKeyword  contained
                                     \ PASS_MIN_LEN
                                     \ SHA_CRYPT_MAX_ROUNDS
                                     \ SHA_CRYPT_MIN_ROUNDS
+                                    \ SUB_GID_COUNT
+                                    \ SUB_GID_MAX
+                                    \ SUB_GID_MIN
+                                    \ SUB_UID_COUNT
+                                    \ SUB_UID_MAX
+                                    \ SUB_UID_MIN
                                     \ SYS_GID_MAX
                                     \ SYS_GID_MIN
                                     \ SYS_UID_MAX
@@ -86,8 +100,14 @@ syn keyword logindefsNumberKeyword  contained
                                     \ UID_MAX
                                     \ UID_MIN
                                     \ ULIMIT
-                                    \ UMASK
+                                    \ YESCRYPT_COST_FACTOR
                                     \ nextgroup=@logindefsNumber skipwhite
+
+syn keyword logindefsNumberKeyword  contained
+                                    \ HOME_MODE
+                                    \ TTYPERM
+                                    \ UMASK
+                                    \ nextgroup=logindefsOctal,logindefsOctalError skipwhite
 
 syn cluster logindefsNumber         contains=
                                     \ logindefsDecimal,
@@ -114,6 +134,7 @@ syn keyword logindefsPathKeyword    contained
                                     \ MAIL_DIR
                                     \ MAIL_FILE
                                     \ NOLOGINS_FILE
+                                    \ NONEXISTENT
                                     \ SULOG_FILE
                                     \ TTYTYPE_FILE
                                     \ nextgroup=logindefsPath skipwhite
@@ -138,9 +159,9 @@ syn keyword logindefsStringKeyword  contained
                                     \ ENV_HZ
                                     \ ENV_TZ
                                     \ LOGIN_STRING
+                                    \ PREVENT_NO_AUTH
                                     \ SU_NAME
                                     \ TTYGROUP
-                                    \ TTYPERM
                                     \ USERDEL_CMD
                                     \ nextgroup=logindefsString skipwhite
 


### PR DESCRIPTION
* add keywords
* enforce octal format for permissions

closes: vim/vim#15222

https://github.com/vim/vim/commit/57f7d75591da0ec91068741eefbad295be8f78b4

Co-authored-by: Eisuke Kawashima <e-kwsm@users.noreply.github.com>
