### PR TITLE
feat: add count param to fn.getchangelist()

### DIFF
--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -3373,7 +3373,7 @@ M.funcs = {
     signature = 'getcellwidths()',
   },
   getchangelist = {
-    args = { 0, 1 },
+    args = { 0, 2 },
     base = 1,
     desc = [=[
       Returns the |changelist| for the buffer {buf}. For the use
@@ -3393,9 +3393,9 @@ M.funcs = {
 
     ]=],
     name = 'getchangelist',
-    params = { { 'buf', 'integer|string' } },
+    params = { { 'buf', 'integer|string' }, {'count', 'integer'} },
     returns = 'table[]',
-    signature = 'getchangelist([{buf}])',
+    signature = 'getchangelist([{buf} [, {count}]])',
   },
   getchar = {
     args = { 0, 1 },


### PR DESCRIPTION
hi folks, i want to show inline extmarks for `g;` and `g,`, and i need to keep updating these extmarks while pressing `g;`/`g,`. but currently fn.getchangelist() returns the whole changelist, which could be expensive.

so this pr propuses to add a count parameter to it, which could be negative or positive that indicates the iterating direction relatived to changelistindex, and 0 for the current change only. the current change will always be included, i actually have no particular reason.

does it sound good? should i continue?