### PR TITLE
test(old): enable Test_address_line_overflow()

### DIFF
--- a/test/functional/legacy/excmd_spec.lua
+++ b/test/functional/legacy/excmd_spec.lua
@@ -5,44 +5,13 @@ local Screen = require('test.functional.ui.screen')
 local clear = n.clear
 local command = n.command
 local exec = n.exec
-local exec_lua = n.exec_lua
 local expect_exit = n.expect_exit
 local feed = n.feed
 local fn = n.fn
-local api = n.api
 local read_file = t.read_file
-local source = n.source
 local eq = t.eq
 local write_file = t.write_file
 local is_os = t.is_os
-
-local function sizeoflong()
-  if not exec_lua('return pcall(require, "ffi")') then
-    pending('missing LuaJIT FFI')
-  end
-  return exec_lua('return require("ffi").sizeof(require("ffi").typeof("long"))')
-end
-
-describe('Ex command', function()
-  before_each(clear)
-  after_each(function()
-    eq({}, api.nvim_get_vvar('errors'))
-  end)
-
-  it('checks for address line overflow', function()
-    if sizeoflong() < 8 then
-      pending('Skipped: only works with 64 bit long ints')
-    end
-
-    source [[
-      new
-      call setline(1, 'text')
-      call assert_fails('|.44444444444444444444444', 'E1247:')
-      call assert_fails('|.9223372036854775806', 'E1247:')
-      bwipe!
-    ]]
-  end)
-end)
 
 describe(':confirm command dialog', function()
   local screen

--- a/test/functional/legacy/put_spec.lua
+++ b/test/functional/legacy/put_spec.lua
@@ -1,52 +1,11 @@
-local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
 
 local clear = n.clear
-local exec_lua = n.exec_lua
-local api = n.api
 local source = n.source
-local eq = t.eq
-
-local function sizeoflong()
-  if not exec_lua('return pcall(require, "ffi")') then
-    pending('missing LuaJIT FFI')
-  end
-  return exec_lua('return require("ffi").sizeof(require("ffi").typeof("long"))')
-end
 
 describe('put', function()
   before_each(clear)
-  after_each(function()
-    eq({}, api.nvim_get_vvar('errors'))
-  end)
-
-  it('very large count 64-bit', function()
-    if sizeoflong() < 8 then
-      pending('Skipped: only works with 64 bit long ints')
-    end
-
-    source [[
-      new
-      let @" = repeat('x', 100)
-      call assert_fails('norm 999999999p', 'E1240:')
-      bwipe!
-    ]]
-  end)
-
-  it('very large count (visual block) 64-bit', function()
-    if sizeoflong() < 8 then
-      pending('Skipped: only works with 64 bit long ints')
-    end
-
-    source [[
-      new
-      call setline(1, repeat('x', 100))
-      exe "norm \<C-V>$y"
-      call assert_fails('norm 999999999p', 'E1240:')
-      bwipe!
-    ]]
-  end)
 
   -- oldtest: Test_put_other_window()
   it('above topline in buffer in two splits', function()

--- a/test/old/testdir/test_excmd.vim
+++ b/test/old/testdir/test_excmd.vim
@@ -718,9 +718,7 @@ func Test_not_break_expression_register()
 endfunc
 
 func Test_address_line_overflow()
-  throw 'Skipped: v:sizeoflong is N/A'  " use legacy/excmd_spec.lua instead
-
-  if v:sizeoflong < 8
+  if !has('nvim') && v:sizeoflong < 8
     throw 'Skipped: only works with 64 bit long ints'
   endif
   new

--- a/test/old/testdir/test_put.vim
+++ b/test/old/testdir/test_put.vim
@@ -168,9 +168,7 @@ func Test_very_large_count()
 endfunc
 
 func Test_very_large_count_64bit()
-  throw 'Skipped: v:sizeoflong is N/A'  " use legacy/put_spec.lua instead
-
-  if v:sizeoflong < 8
+  if !has('nvim') && v:sizeoflong < 8
     throw 'Skipped: only works with 64 bit long ints'
   endif
 
@@ -190,9 +188,7 @@ func Test_very_large_count_block()
 endfunc
 
 func Test_very_large_count_block_64bit()
-  throw 'Skipped: v:sizeoflong is N/A'  " use legacy/put_spec.lua instead
-
-  if v:sizeoflong < 8
+  if !has('nvim') && v:sizeoflong < 8
     throw 'Skipped: only works with 64 bit long ints'
   endif
 


### PR DESCRIPTION
Nvim doesn't use atol() in getdigits() and doesn't need to check for
size of long.
