### PR TITLE
vim-patch: fix prolog file detection

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1127,7 +1127,7 @@ function M.pl(_, bufnr)
   if
     line and line:find(':%-')
     or matchregex(line, [[\c\<prolog\>]])
-    or findany(line, { '^%s*%%+%s', '^%s*%%+$', '^%s*/%*' })
+    or findany(line, { '^:-', '^%%', '^/%*', '%.$' })
   then
     return 'prolog'
   else
@@ -1232,11 +1232,7 @@ function M.proto(_, bufnr)
   -- Recognize Prolog by specific text in the first non-empty line;
   -- require a blank after the '%' because Perl uses "%list" and "%translate"
   local line = nextnonblank(bufnr, 1)
-  if
-    line and line:find(':%-')
-    or matchregex(line, [[\c\<prolog\>]])
-    or findany(line, { '^%s*%%+%s', '^%s*%%+$', '^%s*/%*' })
-  then
+  if matchregex(line, [[\c\<prolog\>]]) or findany(line, { '^:%-', '^%%', '^/%*', '%.$' }) then
     return 'prolog'
   end
 end

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -2575,4 +2575,31 @@ func Test_uci_file()
   filetype off
 endfunc
 
+func Test_pro_file()
+  filetype on
+
+  "Prolog
+  call writefile([':-module(test/1,'], 'Xfile.pro', 'D')
+  split Xfile.pro
+  call assert_equal('prolog', &filetype)
+  bwipe!
+
+  call writefile(['% comment'], 'Xfile.pro', 'D')
+  split Xfile.pro
+  call assert_equal('prolog', &filetype)
+  bwipe!
+
+  call writefile(['/* multiline comment'], 'Xfile.pro', 'D')
+  split Xfile.pro
+  call assert_equal('prolog', &filetype)
+  bwipe!
+
+  call writefile(['rule(test, 1.7).'], 'Xfile.pro', 'D')
+  split Xfile.pro
+  call assert_equal('prolog', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
- **vim-patch:9.1.0558: filetype: prolog detection can be improved**
- **vim-patch:7347642: runtime(filetype): Fix Prolog file detection regex**

(I didn't want to convert vim regex twice so I skipped the bad regex and went straight for the corrected one in the first patch.)
