### PR TITLE
vim-patch:8.2.{3716,4065},9.1.{0577,0579}

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3619,6 +3619,7 @@ static linenr_T get_address(exarg_T *eap, char **ptr, cmd_addr_T addr_type, bool
         n = getdigits_int32(&cmd, false, MAXLNUM);
         if (n == MAXLNUM) {
           *errormsg = _(e_line_number_out_of_range);
+          cmd = NULL;
           goto error;
         }
       }
@@ -3641,6 +3642,7 @@ static linenr_T get_address(exarg_T *eap, char **ptr, cmd_addr_T addr_type, bool
         } else {
           if (lnum >= 0 && n >= INT32_MAX - lnum) {
             *errormsg = _(e_line_number_out_of_range);
+            cmd = NULL;
             goto error;
           }
           lnum += n;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2079,29 +2079,7 @@ static char *do_one_cmd(char **cmdlinep, int flags, cstack_T *cstack, LineGetter
     if (ea.skip) {  // skip this if inside :if
       goto doend;
     }
-    if (*ea.cmd == '|' || (exmode_active && ea.line1 != ea.line2)) {
-      ea.cmdidx = CMD_print;
-      ea.argt = EX_RANGE | EX_COUNT | EX_TRLBAR;
-      if ((errormsg = invalid_range(&ea)) == NULL) {
-        correct_range(&ea);
-        ex_print(&ea);
-      }
-    } else if (ea.addr_count != 0) {
-      if (ea.line2 > curbuf->b_ml.ml_line_count) {
-        ea.line2 = curbuf->b_ml.ml_line_count;
-      }
-
-      if (ea.line2 < 0) {
-        errormsg = _(e_invrange);
-      } else {
-        if (ea.line2 == 0) {
-          curwin->w_cursor.lnum = 1;
-        } else {
-          curwin->w_cursor.lnum = ea.line2;
-        }
-        beginline(BL_SOL | BL_FIX);
-      }
-    }
+    errormsg = ex_range_without_command(&ea);
     goto doend;
   }
 
@@ -2445,6 +2423,38 @@ char *ex_errmsg(const char *const msg, const char *const arg)
 {
   vim_snprintf(ex_error_buf, MSG_BUF_LEN, _(msg), arg);
   return ex_error_buf;
+}
+
+/// Handle a range without a command.
+/// Returns an error message on failure.
+static char *ex_range_without_command(exarg_T *eap)
+{
+  char *errormsg = NULL;
+
+  if (*eap->cmd == '|' || (exmode_active && eap->line1 != eap->line2)) {
+    eap->cmdidx = CMD_print;
+    eap->argt = EX_RANGE | EX_COUNT | EX_TRLBAR;
+    if ((errormsg = invalid_range(eap)) == NULL) {
+      correct_range(eap);
+      ex_print(eap);
+    }
+  } else if (eap->addr_count != 0) {
+    if (eap->line2 > curbuf->b_ml.ml_line_count) {
+      eap->line2 = curbuf->b_ml.ml_line_count;
+    }
+
+    if (eap->line2 < 0) {
+      errormsg = _(e_invrange);
+    } else {
+      if (eap->line2 == 0) {
+        curwin->w_cursor.lnum = 1;
+      } else {
+        curwin->w_cursor.lnum = eap->line2;
+      }
+      beginline(BL_SOL | BL_FIX);
+    }
+  }
+  return errormsg;
 }
 
 /// Parse and skip over command modifiers:

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1411,7 +1411,11 @@ void set_cmd_count(exarg_T *eap, linenr_T count, bool validate)
     }
   } else {
     eap->line1 = eap->line2;
-    eap->line2 += count - 1;
+    if (eap->line2 >= INT32_MAX - (count - 1)) {
+      eap->line2 = INT32_MAX;
+    } else {
+      eap->line2 += count - 1;
+    }
     eap->addr_count++;
     // Be vi compatible: no error message for out of range.
     if (validate && eap->line2 > curbuf->b_ml.ml_line_count) {
@@ -1429,7 +1433,7 @@ static int parse_count(exarg_T *eap, const char **errormsg, bool validate)
   if ((eap->argt & EX_COUNT) && ascii_isdigit(*eap->arg)
       && (!(eap->argt & EX_BUFNAME) || *(p = skipdigits(eap->arg + 1)) == NUL
           || ascii_iswhite(*p))) {
-    linenr_T n = getdigits_int32(&eap->arg, false, -1);
+    linenr_T n = getdigits_int32(&eap->arg, false, INT32_MAX);
     eap->arg = skipwhite(eap->arg);
 
     if (eap->args != NULL) {

--- a/test/functional/ex_cmds/excmd_spec.lua
+++ b/test/functional/ex_cmds/excmd_spec.lua
@@ -29,13 +29,13 @@ describe('Ex cmds', function()
       ':tabnext 9999999999999999999999999999999999999999',
       'Vim(tabnext):E475: Invalid argument: 9999999999999999999999999999999999999999'
     )
-    check_excmd_err(
-      ':N 9999999999999999999999999999999999999999',
-      'Vim(Next):E939: Positive count required'
+    eq(
+      'Vim(Next):E163: There is only one file to edit',
+      pcall_err(command, ':N 9999999999999999999999999999999999999999')
     )
     check_excmd_err(
       ':bdelete 9999999999999999999999999999999999999999',
-      'Vim(bdelete):E939: Positive count required'
+      'Vim(bdelete):E516: No buffers were deleted'
     )
     eq(
       'Vim(menu):E329: No menu "9999999999999999999999999999999999999999"',

--- a/test/functional/legacy/excmd_spec.lua
+++ b/test/functional/legacy/excmd_spec.lua
@@ -5,44 +5,13 @@ local Screen = require('test.functional.ui.screen')
 local clear = n.clear
 local command = n.command
 local exec = n.exec
-local exec_lua = n.exec_lua
 local expect_exit = n.expect_exit
 local feed = n.feed
 local fn = n.fn
-local api = n.api
 local read_file = t.read_file
-local source = n.source
 local eq = t.eq
 local write_file = t.write_file
 local is_os = t.is_os
-
-local function sizeoflong()
-  if not exec_lua('return pcall(require, "ffi")') then
-    pending('missing LuaJIT FFI')
-  end
-  return exec_lua('return require("ffi").sizeof(require("ffi").typeof("long"))')
-end
-
-describe('Ex command', function()
-  before_each(clear)
-  after_each(function()
-    eq({}, api.nvim_get_vvar('errors'))
-  end)
-
-  it('checks for address line overflow', function()
-    if sizeoflong() < 8 then
-      pending('Skipped: only works with 64 bit long ints')
-    end
-
-    source [[
-      new
-      call setline(1, 'text')
-      call assert_fails('|.44444444444444444444444', 'E1247:')
-      call assert_fails('|.9223372036854775806', 'E1247:')
-      bwipe!
-    ]]
-  end)
-end)
 
 describe(':confirm command dialog', function()
   local screen

--- a/test/functional/legacy/put_spec.lua
+++ b/test/functional/legacy/put_spec.lua
@@ -1,52 +1,11 @@
-local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
 
 local clear = n.clear
-local exec_lua = n.exec_lua
-local api = n.api
 local source = n.source
-local eq = t.eq
-
-local function sizeoflong()
-  if not exec_lua('return pcall(require, "ffi")') then
-    pending('missing LuaJIT FFI')
-  end
-  return exec_lua('return require("ffi").sizeof(require("ffi").typeof("long"))')
-end
 
 describe('put', function()
   before_each(clear)
-  after_each(function()
-    eq({}, api.nvim_get_vvar('errors'))
-  end)
-
-  it('very large count 64-bit', function()
-    if sizeoflong() < 8 then
-      pending('Skipped: only works with 64 bit long ints')
-    end
-
-    source [[
-      new
-      let @" = repeat('x', 100)
-      call assert_fails('norm 999999999p', 'E1240:')
-      bwipe!
-    ]]
-  end)
-
-  it('very large count (visual block) 64-bit', function()
-    if sizeoflong() < 8 then
-      pending('Skipped: only works with 64 bit long ints')
-    end
-
-    source [[
-      new
-      call setline(1, repeat('x', 100))
-      exe "norm \<C-V>$y"
-      call assert_fails('norm 999999999p', 'E1240:')
-      bwipe!
-    ]]
-  end)
 
   -- oldtest: Test_put_other_window()
   it('above topline in buffer in two splits', function()

--- a/test/old/testdir/test_excmd.vim
+++ b/test/old/testdir/test_excmd.vim
@@ -725,6 +725,8 @@ func Test_address_line_overflow()
   call setline(1, range(100))
   call assert_fails('|.44444444444444444444444', 'E1247:')
   call assert_fails('|.9223372036854775806', 'E1247:')
+  call assert_fails('.44444444444444444444444d', 'E1247:')
+  call assert_equal(range(100)->map('string(v:val)'), getline(1, '$'))
 
   $
   yank 77777777777777777777

--- a/test/old/testdir/test_excmd.vim
+++ b/test/old/testdir/test_excmd.vim
@@ -722,9 +722,14 @@ func Test_address_line_overflow()
     throw 'Skipped: only works with 64 bit long ints'
   endif
   new
-  call setline(1, 'text')
+  call setline(1, range(100))
   call assert_fails('|.44444444444444444444444', 'E1247:')
   call assert_fails('|.9223372036854775806', 'E1247:')
+
+  $
+  yank 77777777777777777777
+  call assert_equal("99\n", @")
+
   bwipe!
 endfunc
 

--- a/test/old/testdir/test_excmd.vim
+++ b/test/old/testdir/test_excmd.vim
@@ -718,9 +718,7 @@ func Test_not_break_expression_register()
 endfunc
 
 func Test_address_line_overflow()
-  throw 'Skipped: v:sizeoflong is N/A'  " use legacy/excmd_spec.lua instead
-
-  if v:sizeoflong < 8
+  if !has('nvim') && v:sizeoflong < 8
     throw 'Skipped: only works with 64 bit long ints'
   endif
   new

--- a/test/old/testdir/test_put.vim
+++ b/test/old/testdir/test_put.vim
@@ -168,12 +168,6 @@ func Test_very_large_count()
 endfunc
 
 func Test_very_large_count_64bit()
-  throw 'Skipped: v:sizeoflong is N/A'  " use legacy/put_spec.lua instead
-
-  if v:sizeoflong < 8
-    throw 'Skipped: only works with 64 bit long ints'
-  endif
-
   new
   let @" = repeat('x', 100)
   call assert_fails('norm 999999999p', 'E1240:')
@@ -190,12 +184,6 @@ func Test_very_large_count_block()
 endfunc
 
 func Test_very_large_count_block_64bit()
-  throw 'Skipped: v:sizeoflong is N/A'  " use legacy/put_spec.lua instead
-
-  if v:sizeoflong < 8
-    throw 'Skipped: only works with 64 bit long ints'
-  endif
-
   new
   call setline(1, repeat('x', 100))
   exe "norm \<C-V>$y"


### PR DESCRIPTION
#### vim-patch:9.1.0577: Unnecessary checks for v:sizeoflong in test_put.vim

Problem:  Unnecessary checks for v:sizeoflong in test_put.vim.  They are
          no longer necessary as patch 8.2.3661 has changed the count to
          be within 32-bit integer limit.
Solution: Remove the checks (zeertzjq).

closes: vim/vim#15239

https://github.com/vim/vim/commit/69a28f6c0861523b1a9c565b3c882f439ae73ef4


#### vim-patch:8.2.4065: computation overflow with large cound for :yank

Problem:    Computation overflow with large cound for :yank.
Solution:   Avoid an overflow.

https://github.com/vim/vim/commit/3cf21b305104e91a28e4ce3a473672b2e88a9469

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.1.0579: Ex command is still executed after giving E1247

Problem:  Ex command is still executed after giving E1247.
Solution: Indicate the error properly and set cmd to NULL.
          (zeertzjq)

closes: vim/vim#15241

https://github.com/vim/vim/commit/d1b5ea984d41102d253ecdd9a76124cd4c58b97d


#### vim-patch:8.2.3716: Vim9: range without a command is not compiled

Problem:    Vim9: range without a command is not compiled.
Solution:   Add the ISN_EXECRANGE byte code.

https://github.com/vim/vim/commit/e4eed8c6db693a9183b776032570ce2f89dcffb6

Co-authored-by: Bram Moolenaar <Bram@vim.org>