### PR TITLE
vim-patch:9.1.0575: Wrong comments in alt_tabpage()

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3461,7 +3461,7 @@ static tabpage_T *alt_tabpage(void)
     return lastused_tabpage;
   }
 
-  // Use the previous tab page, if possible.
+  // Use the next tab page, if possible.
   bool forward = curtab->tp_next != NULL
                  && ((tcl_flags & TCL_LEFT) == 0 || curtab == first_tabpage);
 
@@ -3469,6 +3469,7 @@ static tabpage_T *alt_tabpage(void)
   if (forward) {
     tp = curtab->tp_next;
   } else {
+    // Use the previous tab page.
     for (tp = first_tabpage; tp->tp_next != curtab; tp = tp->tp_next) {}
   }
 


### PR DESCRIPTION
#### vim-patch:9.1.0575: Wrong comments in alt_tabpage()

Problem:  Wrong comments in alt_tabpage()
          (after v9.1.0572)
Solution: Correct the comments (zeertzjq).

closes: vim/vim#15235

https://github.com/vim/vim/commit/1a3dd7dc7847a3568fe96192a21e478f46c07929