### PR TITLE
vim-patch:9.1.{0573,0574,0582}

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1927,6 +1927,16 @@ These two commands will keep on asking for lines, until you type a line
 containing only a ".".  Watch out for lines starting with a backslash, see
 |line-continuation|.
 
+Text typed after a "|" command separator is used first. So the following
+command in ex mode: >
+	:a|one
+	two
+	.
+	:visual
+<appends the following text, after the cursor line: >
+	one
+	two
+<
 NOTE: These commands cannot be used with |:global| or |:vglobal|.
 ":append" and ":insert" don't work properly in between ":if" and
 ":endif", ":for" and ":endfor", ":while" and ":endwhile".

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -342,6 +342,7 @@ gg			Goto line [count], default first line, on the first
 
 							*:[range]*
 :[range]		Set the cursor on the last line number in [range].
+			In Ex mode, print the lines in [range].
 			[range] can also be just one line number, e.g., ":1"
 			or ":'m".
 			In contrast with |G| this command does not modify the

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2784,7 +2784,11 @@ void ex_append(exarg_T *eap)
         indent = get_indent_lnum(lnum);
       }
     }
-    if (eap->ea_getline == NULL) {
+    if (*eap->arg == '|') {
+      // Get the text after the trailing bar.
+      theline = xstrdup(eap->arg + 1);
+      *eap->arg = NUL;
+    } else if (eap->ea_getline == NULL) {
       // No getline() function, use the lines that follow. This ends
       // when there is no more.
       if (eap->nextcmd == NULL || *eap->nextcmd == NUL) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2426,13 +2426,17 @@ char *ex_errmsg(const char *const msg, const char *const arg)
   return ex_error_buf;
 }
 
+/// The "+" string used in place of an empty command in Ex mode.
+/// This string is used in pointer comparison.
+static char exmode_plus[] = "+";
+
 /// Handle a range without a command.
 /// Returns an error message on failure.
 static char *ex_range_without_command(exarg_T *eap)
 {
   char *errormsg = NULL;
 
-  if (*eap->cmd == '|' || exmode_active) {
+  if (*eap->cmd == '|' || (exmode_active && eap->cmd != exmode_plus + 1)) {
     eap->cmdidx = CMD_print;
     eap->argt = EX_RANGE | EX_COUNT | EX_TRLBAR;
     if ((errormsg = invalid_range(eap)) == NULL) {
@@ -2491,7 +2495,7 @@ int parse_command_modifiers(exarg_T *eap, const char **errormsg, cmdmod_T *cmod,
     if (*eap->cmd == NUL && exmode_active
         && getline_equal(eap->ea_getline, eap->cookie, getexline)
         && curwin->w_cursor.lnum < curbuf->b_ml.ml_line_count) {
-      eap->cmd = "+";
+      eap->cmd = exmode_plus;
       if (!skip_only) {
         ex_pressedreturn = true;
       }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4108,7 +4108,12 @@ void separate_nextcmd(exarg_T *eap)
                 && !(eap->argt & EX_NOTRLCOM)
                 && (eap->cmdidx != CMD_at || p != eap->arg)
                 && (eap->cmdidx != CMD_redir
-                    || p != eap->arg + 1 || p[-1] != '@')) || *p == '|' || *p == '\n') {
+                    || p != eap->arg + 1 || p[-1] != '@'))
+               || (*p == '|'
+                   && eap->cmdidx != CMD_append
+                   && eap->cmdidx != CMD_change
+                   && eap->cmdidx != CMD_insert)
+               || *p == '\n') {
       // We remove the '\' before the '|', unless EX_CTRLV is used
       // AND 'b' is present in 'cpoptions'.
       if ((vim_strchr(p_cpo, CPO_BAR) == NULL

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2079,6 +2079,7 @@ static char *do_one_cmd(char **cmdlinep, int flags, cstack_T *cstack, LineGetter
     if (ea.skip) {  // skip this if inside :if
       goto doend;
     }
+    assert(errormsg == NULL);
     errormsg = ex_range_without_command(&ea);
     goto doend;
   }
@@ -2431,7 +2432,7 @@ static char *ex_range_without_command(exarg_T *eap)
 {
   char *errormsg = NULL;
 
-  if (*eap->cmd == '|' || (exmode_active && eap->line1 != eap->line2)) {
+  if (*eap->cmd == '|' || exmode_active) {
     eap->cmdidx = CMD_print;
     eap->argt = EX_RANGE | EX_COUNT | EX_TRLBAR;
     if ((errormsg = invalid_range(eap)) == NULL) {

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2729,7 +2729,7 @@ static int vgetorpeek(bool advance)
             timedout = true;
             continue;
           }
-          // In Ex-mode \n is compatible with original Vim behaviour.
+
           // For the command line only CTRL-C always breaks it.
           // For the cmdline window: Alternate between ESC and
           // CTRL-C: ESC for most situations and CTRL-C to close the

--- a/test/functional/legacy/ex_mode_spec.lua
+++ b/test/functional/legacy/ex_mode_spec.lua
@@ -48,7 +48,7 @@ describe('Ex mode', function()
     command('set noincsearch nohlsearch inccommand=')
     local screen = Screen.new(60, 6)
     screen:attach()
-    command([[call setline(1, ['foo foo', 'foo foo', 'foo foo'])]])
+    command([[call setline(1, repeat(['foo foo'], 4))]])
     command([[set number]])
     feed('gQ')
     screen:expect([[
@@ -110,12 +110,24 @@ describe('Ex mode', function()
       :^                                                           |
     ]])
 
+    -- The printed line should overwrite the colon
+    feed('<CR>')
+    screen:expect([[
+      {8:  2 }foo foo                                                 |
+          ^^^q                                                    |
+      {8:  2 }foo foo                                                 |
+      {8:  3 }foo foo                                                 |
+      {8:  4 }foo foo                                                 |
+      :^                                                           |
+    ]])
+
     feed(':vi<CR>')
     screen:expect([[
       {8:  1 }foo bar                                                 |
       {8:  2 }foo foo                                                 |
-      {8:  3 }^foo foo                                                 |
-      {1:~                                                           }|*2
+      {8:  3 }foo foo                                                 |
+      {8:  4 }^foo foo                                                 |
+      {1:~                                                           }|
                                                                   |
     ]])
   end)

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -32,8 +32,8 @@ if exists('s:did_load')
   endif
   if g:testname !~ 'test_mapping.vim$'
     " Make "Q" switch to Ex mode.
-    " This does not work for all tests.
-    nnoremap Q gQ
+    " This does not work for all tests as Nvim only supports Vim Ex mode.
+    nnoremap Q gQ<Cmd>call<SID>ExStart()<CR>
   endif
 endif
 
@@ -44,6 +44,21 @@ if exists('s:did_load')
   finish
 endif
 let s:did_load = 1
+
+func s:ExStart()
+  call feedkeys($"\<Cmd>call{expand('<SID>')}ExMayEnd()\<CR>")
+endfunc
+
+func s:ExMayEnd()
+  " When :normal runs out of characters in Vim, the behavior is different in
+  " normal Ex mode vs. Vim Ex mode.
+  " - In normal Ex mode, "\n" is used.
+  " - In Vim Ex mode, Ctrl-C is used.
+  " Nvim only supports Vim Ex mode, so emulate the normal Ex mode behavior.
+  if state('m') == '' && mode(1) == 'cv' && getcharstr(1) == "\<C-C>"
+    call feedkeys("\n")
+  endif
+endfunc
 
 " Clear Nvim default user commands, mappings and menus.
 comclear

--- a/test/old/testdir/test_ex_mode.vim
+++ b/test/old/testdir/test_ex_mode.vim
@@ -282,4 +282,15 @@ func Test_ex_mode_large_indent()
 endfunc
 
 
+" Testing implicit print command
+func Test_implicit_print()
+  new
+  call setline(1, ['one', 'two', 'three'])
+  call feedkeys('Q:let a=execute(":1,2")', 'xt')
+  call feedkeys('Q:let b=execute(":3")', 'xt')
+  call assert_equal('one two', a->split('\n')->join(' '))
+  call assert_equal('three', b->split('\n')->join(' '))
+  bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_ex_mode.vim
+++ b/test/old/testdir/test_ex_mode.vim
@@ -69,7 +69,7 @@ func Test_Ex_substitute()
   CheckRunVimInTerminal
   let buf = RunVimInTerminal('', {'rows': 6})
 
-  call term_sendkeys(buf, ":call setline(1, ['foo foo', 'foo foo', 'foo foo'])\<CR>")
+  call term_sendkeys(buf, ":call setline(1, repeat(['foo foo'], 4))\<CR>")
   call term_sendkeys(buf, ":set number\<CR>")
   call term_sendkeys(buf, "gQ")
   call WaitForAssert({-> assert_match(':', term_getline(buf, 6))}, 1000)
@@ -91,8 +91,14 @@ func Test_Ex_substitute()
 
   " Pressing enter in ex mode should print the current line
   call term_sendkeys(buf, "\<CR>")
-  call WaitForAssert({-> assert_match('  3 foo foo',
-        \ term_getline(buf, 5))}, 1000)
+  call WaitForAssert({-> assert_match('  3 foo foo', term_getline(buf, 5))}, 1000)
+  call WaitForAssert({-> assert_match(':', term_getline(buf, 6))}, 1000)
+
+  " The printed line should overwrite the colon
+  call term_sendkeys(buf, "\<CR>")
+  call WaitForAssert({-> assert_match('  3 foo foo', term_getline(buf, 4))}, 1000)
+  call WaitForAssert({-> assert_match('  4 foo foo', term_getline(buf, 5))}, 1000)
+  call WaitForAssert({-> assert_match(':', term_getline(buf, 6))}, 1000)
 
   call term_sendkeys(buf, ":vi\<CR>")
   call WaitForAssert({-> assert_match('foo bar', term_getline(buf, 1))}, 1000)

--- a/test/old/testdir/test_ex_mode.vim
+++ b/test/old/testdir/test_ex_mode.vim
@@ -293,4 +293,12 @@ func Test_implicit_print()
   bw!
 endfunc
 
+" Test inserting text after the trailing bar
+func Test_insert_after_trailing_bar()
+  new
+  call feedkeys("Qi|\nfoo\n.\na|bar\nbar\n.\nc|baz\n.", "xt")
+  call assert_equal(['', 'foo', 'bar', 'baz'], getline(1, '$'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0573: ex: no implicit print for single addresses

Problem:  ex: no implicit print for single addresses
Solution: explicitly print even during single addresses,
          as requested by POSIX (Mohamed Akram)

See the POSIX behaviour here:
https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ex.html#tag_20_40_13_03
Section 6b

closes: vim/vim#15230

https://github.com/vim/vim/commit/c25a7084e9ae1f78c28ddcbe1fa23374cfdf1e03

Co-authored-by: Mohamed Akram <mohd.akram@outlook.com>


#### vim-patch:9.1.0574: ex: wrong handling of commands after bar

Problem:  ex: wrong handling of commands after bar
Solution: for :append, :insert and :change use the text after the bar
          as input for those commands. This is what POSIX requests.
          (Mohamed Akram)

See the POSIX Spec:
https://pubs.opengroup.org/onlinepubs/9699919799/utilities/ex.html#tag_20_40_13_03
Section 12.c

closes: vim/vim#15229

https://github.com/vim/vim/commit/8c446da34998f6350911e07fbfd7932412c83185

Co-authored-by: Mohamed Akram <mohd.akram@outlook.com>


#### vim-patch:9.1.0582: Printed line doesn't overwrite colon when pressing Enter in Ex mode

Problem:  Printed line no longer overwrites colon when pressing Enter in
          Ex mode (after 9.1.0573).
Solution: Restore the behavior of pressing Enter in Ex mode.
          (zeertzjq)

closes: vim/vim#15258

https://github.com/vim/vim/commit/7d664bf0eb2cb25cb77933c8b7f11ca09929e7b8