### PR TITLE
vim-patch:27c5598: runtime(doc): Add hint how to load termdebug from vimrc

### DIFF
--- a/runtime/doc/nvim_terminal_emulator.txt
+++ b/runtime/doc/nvim_terminal_emulator.txt
@@ -213,6 +213,8 @@ Starting ~
 							*termdebug-starting*
 Load the plugin with this command: >vim
 	packadd termdebug
+When loading the plugin from the |vimrc| file, add the "!" attribute: >vim
+	packadd! termdebug
 <							*:Termdebug*
 To start debugging use `:Termdebug` or `:TermdebugCommand` followed by the
 command name, for example: >vim


### PR DESCRIPTION
#### vim-patch:27c5598: runtime(doc): Add hint how to load termdebug from vimrc

https://github.com/vim/vim/commit/27c55984def4c6ff7afc89958c90f6018c474b2c

Co-authored-by: Christian Brabandt <cb@256bit.org>