### PR TITLE
vim-patch:9.1.0583: filetype: *.pdf_tex files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1076,6 +1076,7 @@ local extension = {
   nls = 'tex',
   thm = 'tex',
   eps_tex = 'tex',
+  pdf_tex = 'tex',
   pygtex = 'tex',
   pygstyle = 'tex',
   clo = 'tex',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -765,7 +765,7 @@ func s:GetFilenameChecks() abort
     \ 'teraterm': ['file.ttl'],
     \ 'terminfo': ['file.ti'],
     \ 'terraform-vars': ['file.tfvars'],
-    \ 'tex': ['file.latex', 'file.sty', 'file.dtx', 'file.ltx', 'file.bbl', 'any/.texlive/texmf-config/tex/latex/file/file.cfg', 'file.pgf', 'file.nlo', 'file.nls', 'file.thm', 'file.eps_tex', 'file.pygtex', 'file.pygstyle', 'file.clo', 'file.aux', 'file.brf', 'file.ind', 'file.lof', 'file.loe', 'file.nav', 'file.vrb', 'file.ins', 'file.tikz', 'file.bbx', 'file.cbx', 'file.beamer'],
+    \ 'tex': ['file.latex', 'file.sty', 'file.dtx', 'file.ltx', 'file.bbl', 'any/.texlive/texmf-config/tex/latex/file/file.cfg', 'file.pgf', 'file.nlo', 'file.nls', 'file.thm', 'file.eps_tex', 'file.pygtex', 'file.pygstyle', 'file.clo', 'file.aux', 'file.brf', 'file.ind', 'file.lof', 'file.loe', 'file.nav', 'file.vrb', 'file.ins', 'file.tikz', 'file.bbx', 'file.cbx', 'file.beamer', 'file.pdf_tex'],
     \ 'texinfo': ['file.texinfo', 'file.texi', 'file.txi'],
     \ 'texmf': ['texmf.cnf'],
     \ 'text': ['file.text', 'file.txt', 'README', 'LICENSE', 'COPYING', 'AUTHORS', '/usr/share/doc/bash-completion/AUTHORS', '/etc/apt/apt.conf.d/README', '/etc/Muttrc.d/README'],


### PR DESCRIPTION
Problem:  filetype: *.pdf_tex files are not recognized
Solution: Detect '*.pdf_tex' files as tex filetype
          (Jonas Dujava)

Those files are generated by inkscape, when exporting, see e.g.
https://inkscape.org/doc/inkscape-man.html

closes: vim/vim#15250

https://github.com/vim/vim/commit/28145e005d646cb0477aa26ef69d0f651a9f9d27

Co-authored-by: Jonas Dujava <jonas.dujava@gmail.com>
