### PR TITLE
fix(treesitter): recognize aliased parsers in omnifunc, query parser

### DIFF
--- a/runtime/lua/vim/treesitter/_query_linter.lua
+++ b/runtime/lua/vim/treesitter/_query_linter.lua
@@ -40,7 +40,8 @@ end
 local function guess_query_lang(buf)
   local filename = api.nvim_buf_get_name(buf)
   if filename ~= '' then
-    return vim.F.npcall(vim.fn.fnamemodify, filename, ':p:h:t')
+    local resolved_filename = vim.F.npcall(vim.fn.fnamemodify, filename, ':p:h:t')
+    return resolved_filename and vim.treesitter.language.get_lang(resolved_filename) or nil
   end
 end
 


### PR DESCRIPTION
**Problem:** A query file for something like `html_tags` will not be given html node completion

**Solution:** Check for parser aliases before offering completions