### PR TITLE
ci: adjust workflows to enable required checks

### DIFF
--- a/.github/workflows/build_dummy.yml
+++ b/.github/workflows/build_dummy.yml
@@ -1,0 +1,33 @@
+name: build_dummy
+on:
+  pull_request:
+    branches:
+      - 'master'
+      - 'release-[0-9]+.[0-9]+'
+    # This needs to be an exact complement of `paths` in the build.yml workflow.
+    # This is required to bypass required checks since a required job is always
+    # needed to run.
+    paths-ignore:
+      - '**.cmake'
+      - '**/CMakeLists.txt'
+      - '**/CMakePresets.json'
+      - 'cmake.*/**'
+      - '.github/**'
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  old-cmake:
+    name: Test oldest supported cmake
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - run: echo "success"
+
+  use-existing-src:
+    name: Test USE_EXISTING_SRC_DIR=ON builds with no network access
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "success"

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,13 +2,6 @@ name: docs
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
-    paths:
-      - 'src/nvim/api/*.[ch]'
-      - 'src/nvim/eval.lua'
-      - 'runtime/lua/**.lua'
-      - 'runtime/doc/**'
-      - 'scripts/gen_vimdoc.py'
-      - 'scripts/gen_help_html.lua'
 jobs:
   docs:
     runs-on: ubuntu-latest

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -8,8 +8,6 @@ on:
     branches:
       - 'master'
       - 'release-[0-9]+.[0-9]+'
-    paths-ignore:
-      - 'contrib/**'
   workflow_dispatch:
 
 concurrency:
@@ -95,18 +93,23 @@ jobs:
       - run: cmake --build build --target clang-analyzer
 
   posix:
-    name: ${{ matrix.build.runner }} ${{ matrix.build.flavor }} ${{ matrix.build.cc }} ${{ matrix.test }}
+    name: ${{ matrix.build.os }} ${{ matrix.build.flavor }} ${{ matrix.build.cc }} ${{ matrix.test }}
     strategy:
       fail-fast: false
       matrix:
+        # The `os` field is not needed to differentiate between the different
+        # matrix builds. It is needed to not change the required checks (which
+        # uses jobs names) each time we bump the runner version. It may be
+        # possible to remove if we e.g. start using `-latest` runner versions
+        # or if github introduces a wildcard for required checks in the future.
         build:
           [
-            { runner: ubuntu-22.04, flavor: asan, cc: clang, flags: -D ENABLE_ASAN_UBSAN=ON },
-            { runner: ubuntu-22.04, flavor: tsan, cc: clang, flags: -D ENABLE_TSAN=ON },
-            { runner: ubuntu-22.04, cc: gcc },
-            { runner: macos-12, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
-            { runner: macos-14, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
-            { runner: ubuntu-22.04, flavor: puc-lua, cc: gcc, deps_flags: -D USE_BUNDLED_LUAJIT=OFF -D USE_BUNDLED_LUA=ON, flags: -D PREFER_LUA=ON },
+            { runner: ubuntu-22.04, os: ubuntu, flavor: asan, cc: clang, flags: -D ENABLE_ASAN_UBSAN=ON },
+            { runner: ubuntu-22.04, os: ubuntu, flavor: tsan, cc: clang, flags: -D ENABLE_TSAN=ON },
+            { runner: ubuntu-22.04, os: ubuntu, cc: gcc },
+            { runner: macos-12, os: macos, flavor: 12, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
+            { runner: macos-14, os: macos, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
+            { runner: ubuntu-22.04, os: ubuntu, flavor: puc-lua, cc: gcc, deps_flags: -D USE_BUNDLED_LUAJIT=OFF -D USE_BUNDLED_LUA=ON, flags: -D PREFER_LUA=ON },
           ]
         test: [unittest, functionaltest, oldtest]
         exclude:


### PR DESCRIPTION
Auto-merging is a useful feature by github, but it requires required
checks which requires a few adjustments. The primary change is that
required checks can't use `paths` or `paths-ignore` as that risks not
running the job, and required checks must always be run.

A workaround for this is to introduce a dummy workflow which is used for
every path not used in the real workflow. That way the required job is
"always" run as far as github is concerned. The workaround is unweildly
so it's only useful to do it for costly workflows where the potential
benefits are big. If not it's better to simply remove any `paths` or
`paths-ignore` from a workflow instead.