### PR TITLE
vim-patch:partial:9.0.0418,9.1.0585

### DIFF
--- a/test/old/testdir/test_cpoptions.vim
+++ b/test/old/testdir/test_cpoptions.vim
@@ -19,7 +19,7 @@ func Test_cpo_a()
   set cpo+=a
   read XfileCpoA
   call assert_equal('XfileCpoA', @#)
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -39,7 +39,7 @@ func Test_cpo_A()
   set cpo+=A
   write XcpoAfile2
   call assert_equal('XcpoAfile2', @#)
-  close!
+  bw!
   call delete('XcpoAfile2')
   let &cpo = save_cpo
 endfunc
@@ -81,7 +81,7 @@ func Test_cpo_B()
   call assert_equal('abd ', getline(1))
   call feedkeys(":imap <buffer> x\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"imap <buffer> x\k', @:)
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -96,7 +96,7 @@ func Test_cpo_c()
   set cpo-=c
   exe "normal gg/abab\<CR>"
   call assert_equal(5, searchcount().total)
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -143,7 +143,7 @@ func Test_cpo_D()
   exe "norm! 1gg0f\<c-k>!!"
   call assert_equal(1, col('.'))
   set cpo-=D
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -183,7 +183,7 @@ func Test_cpo_E()
   call assert_beeps('exe "normal v\<C-A>"')
   call assert_beeps('exe "normal v\<C-X>"')
   set cpo-=E
-  close!
+  bw!
 endfunc
 
 " Test for the 'f' flag in 'cpo' (read in an empty buffer sets the file name)
@@ -213,7 +213,7 @@ func Test_cpo_F()
   set cpo+=F
   write XfileCpoF
   call assert_equal('XfileCpoF', @%)
-  close!
+  bw!
   call delete('XfileCpoF')
   let &cpo = save_cpo
 endfunc
@@ -230,7 +230,7 @@ func Test_cpo_g()
   " set cpo+=g
   " edit
   " call assert_equal(1, line('.'))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -247,7 +247,7 @@ func Test_cpo_H()
   " call setline(1, '    ')
   " normal! Ia
   " call assert_equal('   a ', getline(1))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -266,7 +266,7 @@ func Test_cpo_I()
   %d
   exe "normal i    one\<CR>\<Up>"
   call assert_equal('', getline(2))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -297,7 +297,7 @@ func Test_cpo_J()
     normal (
     call assert_equal(colnr, col('.'))
   endfor
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -319,7 +319,7 @@ func Test_cpo_l()
   set cpo+=l
   exe 'normal gg/[\t]' .. "\<CR>"
   call assert_equal([4, 10], [col('.'), virtcol('.')])
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -340,7 +340,7 @@ func Test_cpo_L()
   call setline(1, 'abcdefghijklmnopqr')
   exe "normal 0gR\<Tab>"
   call assert_equal("\<Tab>ijklmnopqr", getline(1))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -378,7 +378,7 @@ func Test_cpo_M()
   call cursor(2, 1)
   call assert_beeps('normal %')
 
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -394,7 +394,7 @@ func Test_cpo_n()
   set cpo+=n
   redraw!
   call assert_equal('aaaa', Screenline(2))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -411,7 +411,7 @@ func Test_cpo_o()
   exe "normal /one/+2\<CR>"
   normal n
   call assert_equal(5, line('.'))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -426,7 +426,7 @@ func Test_cpo_O()
   set cpo+=O
   write
   call assert_equal(['one'], readfile('XfileCpoO'))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -464,7 +464,7 @@ func Test_cpo_q()
   set cpo+=q
   normal gg4J
   call assert_equal(4, col('.'))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -485,7 +485,7 @@ func Test_cpo_r()
   let @/ = 'three'
   normal 2G.
   call assert_equal('abc three four', getline(2))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -505,7 +505,7 @@ func Test_cpo_R()
   3mark r
   %!sort
   call assert_equal(0, line("'r"))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -532,8 +532,8 @@ func Test_cpo_S()
   wincmd p
   call assert_equal(0, &autoindent)
   wincmd t
-  close!
-  close!
+  bw!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -552,7 +552,7 @@ func Test_cpo_u()
   exe "normal iabc\<C-G>udef\<C-G>ughi"
   normal uu
   call assert_equal('abcdefghi', getline(1))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -577,7 +577,7 @@ func Test_cpo_w()
   call assert_equal('hereZZZare   some words', getline('.'))
   norm! 1gg2elcWYYY
   call assert_equal('hereZZZare   someYYYwords', getline('.'))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -614,7 +614,7 @@ func Test_cpo_X()
   normal ggRy
   normal 4.
   call assert_equal('yyyyxxxaaaaa', getline(1))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -633,7 +633,7 @@ func Test_cpo_y()
   normal ggyy
   normal 2G.
   call assert_equal("two\n", @")
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -650,7 +650,7 @@ func Test_cpo_Z()
   setlocal readonly
   write!
   call assert_equal(1, &readonly)
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -704,7 +704,7 @@ func Test_cpo_percent()
   call assert_equal(15, col('.'))
   normal 22|%
   call assert_equal(27, col('.'))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -721,7 +721,7 @@ func Test_cpo_minus()
   call assert_beeps('normal 10k')
   call assert_equal(3, line('.'))
   call assert_fails(10, 'E16:')
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -737,7 +737,7 @@ func Test_cpo_plus()
   set cpo+=+
   write X2
   call assert_equal(0, &modified)
-  close!
+  bw!
   call delete('X1')
   call delete('X2')
   let &cpo = save_cpo
@@ -755,7 +755,7 @@ func Test_cpo_star()
   " set cpo+=*
   " *a
   " call assert_equal(1, x)
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -776,7 +776,7 @@ func Test_cpo_gt()
   normal gg"Rye
   normal "Rye
   call assert_equal("\none\none", @r)
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -809,7 +809,7 @@ func Test_cpo_semicolon()
   call assert_equal('bbb y', getline(4))
   call assert_equal('ccc', getline(5))
   call assert_equal('ddd yee y', getline(6))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -835,7 +835,7 @@ func Test_cpo_hash()
   " call assert_equal(['', 'one', 'two', 'three'], getline(1, '$'))
   " normal gg2Ozero
   " call assert_equal(['zero', '', 'one', 'two', 'three'], getline(1, '$'))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -867,7 +867,7 @@ func Test_cpo_backslash()
   " set cpo+=\
   " exe 'normal gg/[ \-]' .. "\<CR>n"
   " call assert_equal(2, col('.'))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -890,7 +890,7 @@ func Test_cpo_brace()
   " call assert_equal(2, line('.'))
   " normal G{
   " call assert_equal(2, line('.'))
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 
@@ -919,7 +919,7 @@ func Test_cpo_dot()
 
   call delete('Xfoo')
   set cpo&
-  close!
+  bw!
   let &cpo = save_cpo
 endfunc
 

--- a/test/old/testdir/test_cpoptions.vim
+++ b/test/old/testdir/test_cpoptions.vim
@@ -8,7 +8,7 @@ source view_util.vim
 " file name.
 func Test_cpo_a()
   let save_cpo = &cpo
-  call writefile(['one'], 'XfileCpoA')
+  call writefile(['one'], 'XfileCpoA', 'D')
   " Wipe out all the buffers, so that the alternate file is empty
   edit Xfoo | %bw
   set cpo-=a
@@ -20,7 +20,6 @@ func Test_cpo_a()
   read XfileCpoA
   call assert_equal('XfileCpoA', @#)
   close!
-  call delete('XfileCpoA')
   let &cpo = save_cpo
 endfunc
 
@@ -104,21 +103,20 @@ endfunc
 " Test for the 'C' flag in 'cpo' (line continuation)
 func Test_cpo_C()
   let save_cpo = &cpo
-  call writefile(['let l = [', '\ 1,', '\ 2]'], 'XfileCpoC')
+  call writefile(['let l = [', '\ 1,', '\ 2]'], 'XfileCpoC', 'D')
   set cpo-=C
   source XfileCpoC
   call assert_equal([1, 2], g:l)
   set cpo+=C
   call assert_fails('source XfileCpoC', ['E697:', 'E10:'])
-  call delete('XfileCpoC')
   let &cpo = save_cpo
 endfunc
 
 " Test for the 'd' flag in 'cpo' (tags relative to the current file)
 func Test_cpo_d()
   let save_cpo = &cpo
-  call mkdir('XdirCpoD')
-  call writefile(["one\tXfile1\t/^one$/"], 'tags')
+  call mkdir('XdirCpoD', 'R')
+  call writefile(["one\tXfile1\t/^one$/"], 'tags', 'D')
   call writefile(["two\tXfile2\t/^two$/"], 'XdirCpoD/tags')
   set tags=./tags
   set cpo-=d
@@ -126,9 +124,8 @@ func Test_cpo_d()
   call assert_equal('two', taglist('.*')[0].name)
   set cpo+=d
   call assert_equal('one', taglist('.*')[0].name)
+
   %bw!
-  call delete('tags')
-  call delete('XdirCpoD', 'rf')
   set tags&
   let &cpo = save_cpo
 endfunc
@@ -423,14 +420,13 @@ func Test_cpo_O()
   let save_cpo = &cpo
   new XfileCpoO
   call setline(1, 'one')
-  call writefile(['two'], 'XfileCpoO')
+  call writefile(['two'], 'XfileCpoO', 'D')
   set cpo-=O
   call assert_fails('write', 'E13:')
   set cpo+=O
   write
   call assert_equal(['one'], readfile('XfileCpoO'))
   close!
-  call delete('XfileCpoO')
   let &cpo = save_cpo
 endfunc
 
@@ -440,7 +436,7 @@ endfunc
 " name)
 func Test_cpo_P()
   let save_cpo = &cpo
-  call writefile([], 'XfileCpoP')
+  call writefile([], 'XfileCpoP', 'D')
   new
   call setline(1, 'one')
   set cpo+=F
@@ -452,7 +448,6 @@ func Test_cpo_P()
   call assert_equal('XfileCpoP', @%)
 
   bwipe!
-  call delete('XfileCpoP')
   let &cpo = save_cpo
 endfunc
 
@@ -645,7 +640,7 @@ endfunc
 " Test for the 'Z' flag in 'cpo' (write! resets 'readonly')
 func Test_cpo_Z()
   let save_cpo = &cpo
-  call writefile([], 'XfileCpoZ')
+  call writefile([], 'XfileCpoZ', 'D')
   new XfileCpoZ
   setlocal readonly
   set cpo-=Z
@@ -656,7 +651,6 @@ func Test_cpo_Z()
   write!
   call assert_equal(1, &readonly)
   close!
-  call delete('XfileCpoZ')
   let &cpo = save_cpo
 endfunc
 
@@ -735,7 +729,7 @@ endfunc
 " flag)
 func Test_cpo_plus()
   let save_cpo = &cpo
-  call writefile([], 'XfileCpoPlus')
+  call writefile([], 'XfileCpoPlus', 'D')
   new XfileCpoPlus
   call setline(1, 'foo')
   write X1
@@ -744,7 +738,6 @@ func Test_cpo_plus()
   write X2
   call assert_equal(0, &modified)
   close!
-  call delete('XfileCpoPlus')
   call delete('X1')
   call delete('X2')
   let &cpo = save_cpo
@@ -850,7 +843,7 @@ endfunc
 " loaded and ':preserve' is used.
 func Test_cpo_ampersand()
   throw 'Skipped: Nvim does not support cpoptions flag "&"'
-  call writefile(['one'], 'XfileCpoAmp')
+  call writefile(['one'], 'XfileCpoAmp', 'D')
   let after =<< trim [CODE]
     set cpo+=&
     preserve
@@ -860,7 +853,6 @@ func Test_cpo_ampersand()
     call assert_equal(1, filereadable('.XfileCpoAmp.swp'))
     call delete('.XfileCpoAmp.swp')
   endif
-  call delete('XfileCpoAmp')
 endfunc
 
 " Test for the '\' flag in 'cpo' (backslash in a [] range in a search pattern)


### PR DESCRIPTION
#### vim-patch:partial:9.0.0418: manually deleting temp test files

Problem:    Manually deleting temp test files.
Solution:   Use the 'D' flag of writefile() and mkdir().

https://github.com/vim/vim/commit/45bbaef0382c5468d9fac511775bd99ea7bf5b84

This only includes test_cpoptions.vim changes.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.1.0585: tests: test_cpoptions leaves swapfiles around

Problem:  tests: test_cpoptions leaves swapfiles around
Solution: Use :bw! instead of :close!

https://github.com/vim/vim/commit/bb5d27dc79187ff3bd51734946a4c8418989a218

Co-authored-by: Christian Brabandt <cb@256bit.org>