### PR TITLE
docs: use nvim in error message

### DIFF
--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -199,7 +199,7 @@ void *xmallocz(size_t size)
 {
   size_t total_size = size + 1;
   if (total_size < size) {
-    preserve_exit(_("Vim: Data too large to fit into virtual memory space\n"));
+    preserve_exit(_("Nvim: Data too large to fit into virtual memory space\n"));
   }
 
   void *ret = xmalloc(total_size);

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -564,7 +564,7 @@ static void read_error_exit(void)
   if (silent_mode) {  // Normal way to exit for "nvim -es".
     getout(0);
   }
-  preserve_exit(_("Vim: Error reading input, exiting...\n"));
+  preserve_exit(_("Nvim: Error reading input, exiting...\n"));
 }
 
 static bool pending_events(MultiQueue *events)


### PR DESCRIPTION
Problem: some error msg still use vim as mentioned. 

Solution: use Nvim instead of.

