### PR TITLE
vim-patch:8.2.3381: crash when using NULL list with sign functions

### DIFF
--- a/test/old/testdir/test_signs.vim
+++ b/test/old/testdir/test_signs.vim
@@ -2069,3 +2069,12 @@ func Test_sign_funcs_multi()
   enew!
   call delete("Xsign")
 endfunc
+
+func Test_sign_null_list()
+  eval v:_null_list->sign_define()
+  eval v:_null_list->sign_placelist()
+  eval v:_null_list->sign_undefine()
+  eval v:_null_list->sign_unplacelist()
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:8.2.3381: crash when using NULL list with sign functions

Problem:    Crash when using NULL list with sign functions.
Solution:   Handle a NULL list like an empty list. (issue vim/vim#8260)

https://github.com/vim/vim/commit/5c56da4de8398566ef96122db44ec93e6c2d483a

Nvim's TV_LIST_ITER_MOD() already checks for NULL.

Co-authored-by: Bram Moolenaar <Bram@vim.org>