### PR TITLE
ci: run workflows on release branches

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -12,12 +12,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+
+      - uses: actions/create-github-app-token@v1
+        id: app-token
+        with:
+          app-id: ${{ vars.BACKPORT_APP }}
+          private-key: ${{ secrets.BACKPORT_KEY }}
+
       - name: Create backport PR
         id: backport
         uses: korthout/backport-action@v3
         with:
           pull_title: "${pull_title}"
           label_pattern: "^ci:backport ([^ ]+)$"
+          github_token: ${{ steps.app-token.outputs.token }}
 
       - if: ${{steps.backport.outputs.was_successful == 'true'}}
         uses: actions/github-script@v7

--- a/.github/workflows/lintcommit.yml
+++ b/.github/workflows/lintcommit.yml
@@ -4,6 +4,7 @@ on:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - 'master'
+      - 'release-[0-9]+.[0-9]+'
 jobs:
   lint-commits:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Github doesn't allow workflows to be run from the `github-actions`
account, which is the default account. This caused the CI on backport
PRs to not be run. The way to circumvent this is to use a token that
essentially "pretends" to be another user, which in turn triggers the CI
as desired.

Also run lintcommit on release branches as that is now a required check,
meaning it must always be run.
