### PR TITLE
fix(column): modifying a sign should update placed signs

### DIFF
--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -292,6 +292,9 @@ static void decor_free_inner(DecorVirtText *vt, uint32_t first_idx)
   while (idx != DECOR_ID_INVALID) {
     DecorSignHighlight *sh = &kv_A(decor_items, idx);
     if (sh->flags & kSHIsSign) {
+      if (sh->sign_name) {
+        sign_after_delete(sh->sign_name, idx);
+      }
       xfree(sh->sign_name);
     }
     sh->flags = 0;

--- a/src/nvim/sign_defs.h
+++ b/src/nvim/sign_defs.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "nvim/decoration_defs.h"
+#include "nvim/map_defs.h"
 #include "nvim/types_defs.h"
 
 /// Sign attributes. Used by the screen refresh routines.
@@ -19,6 +20,7 @@ typedef struct {
   int sn_cul_hl;   // highlight ID for text on current line when 'cursorline' is set
   int sn_num_hl;   // highlight ID for line number
   int sn_priority;  // default priority of this sign, -1 means SIGN_DEF_PRIO
+  Set(uint32_t) sn_sh_idxs;  ///< All sh_idx indexes of this sign
 } sign_T;
 
 typedef struct {

--- a/test/functional/legacy/signs_spec.lua
+++ b/test/functional/legacy/signs_spec.lua
@@ -1,13 +1,14 @@
 -- Tests for signs
 
 local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
 
-local clear, command, expect = n.clear, n.command, n.expect
+local clear, command, exec, expect, feed = n.clear, n.command, n.exec, n.expect, n.feed
 
 describe('signs', function()
-  setup(clear)
+  before_each(clear)
 
-  it('is working', function()
+  it('are working', function()
     command('sign define JumpSign text=x')
     command([[exe 'sign place 42 line=2 name=JumpSign buffer=' . bufnr('')]])
     -- Split the window to the bottom to verify :sign-jump will stay in the current
@@ -20,5 +21,48 @@ describe('signs', function()
     expect([[
 
       2]])
+  end)
+
+  -- oldtest: Test_sign_cursor_position()
+  it('are drawn correctly', function()
+    local screen = Screen.new(75, 6)
+    screen:attach()
+    exec([[
+      call setline(1, [repeat('x', 75), 'mmmm', 'yyyy'])
+      call cursor(2,1)
+      sign define s1 texthl=Search text==>
+      redraw
+      sign place 10 line=2 name=s1
+    ]])
+    screen:expect([[
+      {7:  }xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|
+      {7:  }xx                                                                       |
+      {10:=>}^mmmm                                                                     |
+      {7:  }yyyy                                                                     |
+      {1:~                                                                          }|
+                                                                                 |
+    ]])
+
+    -- Change the sign text
+    command('sign define s1 text=-)')
+    screen:expect([[
+      {7:  }xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|
+      {7:  }xx                                                                       |
+      {10:-)}^mmmm                                                                     |
+      {7:  }yyyy                                                                     |
+      {1:~                                                                          }|
+                                                                                 |
+    ]])
+
+    -- update cursor position calculation
+    feed('lh')
+    command('sign unplace 10')
+    screen:expect([[
+      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|
+      ^mmmm                                                                       |
+      yyyy                                                                       |
+      {1:~                                                                          }|*2
+                                                                                 |
+    ]])
   end)
 end)


### PR DESCRIPTION
Problem:  Modifying a sign no longer updates already placed signs.
Solution: Keep track of sh_idx indexes of a sign and update a sign's
          DecorSignHighlight entries when modifying it.
