### PR TITLE
fix(column): modifying a sign should update placed signs

### DIFF
--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -31,9 +31,6 @@
 # include "decoration.c.generated.h"
 #endif
 
-// TODO(bfredl): These should maybe be per-buffer, so that all resources
-// associated with a buffer can be freed when the buffer is unloaded.
-kvec_t(DecorSignHighlight) decor_items = KV_INITIAL_VALUE;
 uint32_t decor_freelist = UINT32_MAX;
 
 // Decorations might be requested to be deleted in a callback in the middle of redrawing.
@@ -292,7 +289,7 @@ static void decor_free_inner(DecorVirtText *vt, uint32_t first_idx)
   while (idx != DECOR_ID_INVALID) {
     DecorSignHighlight *sh = &kv_A(decor_items, idx);
     if (sh->flags & kSHIsSign) {
-      xfree(sh->sign_name);
+      XFREE_CLEAR(sh->sign_name);
     }
     sh->flags = 0;
     if (sh->url != NULL) {

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -77,6 +77,9 @@ typedef struct {
 } DecorState;
 
 EXTERN DecorState decor_state INIT( = { 0 });
+// TODO(bfredl): These should maybe be per-buffer, so that all resources
+// associated with a buffer can be freed when the buffer is unloaded.
+EXTERN kvec_t(DecorSignHighlight) decor_items INIT( = KV_INITIAL_VALUE);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "decoration.h.generated.h"

--- a/test/functional/legacy/signs_spec.lua
+++ b/test/functional/legacy/signs_spec.lua
@@ -1,13 +1,14 @@
 -- Tests for signs
 
 local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
 
-local clear, command, expect = n.clear, n.command, n.expect
+local clear, command, exec, expect, feed = n.clear, n.command, n.exec, n.expect, n.feed
 
 describe('signs', function()
-  setup(clear)
+  before_each(clear)
 
-  it('is working', function()
+  it('are working', function()
     command('sign define JumpSign text=x')
     command([[exe 'sign place 42 line=2 name=JumpSign buffer=' . bufnr('')]])
     -- Split the window to the bottom to verify :sign-jump will stay in the current
@@ -20,5 +21,48 @@ describe('signs', function()
     expect([[
 
       2]])
+  end)
+
+  -- oldtest: Test_sign_cursor_position()
+  it('are drawn correctly', function()
+    local screen = Screen.new(75, 6)
+    screen:attach()
+    exec([[
+      call setline(1, [repeat('x', 75), 'mmmm', 'yyyy'])
+      call cursor(2,1)
+      sign define s1 texthl=Search text==>
+      redraw
+      sign place 10 line=2 name=s1
+    ]])
+    screen:expect([[
+      {7:  }xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|
+      {7:  }xx                                                                       |
+      {10:=>}^mmmm                                                                     |
+      {7:  }yyyy                                                                     |
+      {1:~                                                                          }|
+                                                                                 |
+    ]])
+
+    -- Change the sign text
+    command('sign define s1 text=-)')
+    screen:expect([[
+      {7:  }xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|
+      {7:  }xx                                                                       |
+      {10:-)}^mmmm                                                                     |
+      {7:  }yyyy                                                                     |
+      {1:~                                                                          }|
+                                                                                 |
+    ]])
+
+    -- update cursor position calculation
+    feed('lh')
+    command('sign unplace 10')
+    screen:expect([[
+      xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|
+      ^mmmm                                                                       |
+      yyyy                                                                       |
+      {1:~                                                                          }|*2
+                                                                                 |
+    ]])
   end)
 end)


### PR DESCRIPTION
Problem:  Modifying a sign no longer updates already placed signs.
Solution: Loop over (newly-exposed) placed decorations when modifying a
          sign definition. Update placed decor if it belongs to the sign
          that is modified.