### PR TITLE
vim-patch:8.2.0281: two placed signs in the same line are not combined

### DIFF
--- a/test/functional/legacy/signs_spec.lua
+++ b/test/functional/legacy/signs_spec.lua
@@ -31,6 +31,7 @@ describe('signs', function()
       call setline(1, [repeat('x', 75), 'mmmm', 'yyyy'])
       call cursor(2,1)
       sign define s1 texthl=Search text==>
+      sign define s2 linehl=Pmenu
       redraw
       sign place 10 line=2 name=s1
     ]])
@@ -54,8 +55,20 @@ describe('signs', function()
                                                                                  |
     ]])
 
+    -- Also place a line HL sign
+    command('sign place 11 line=2 name=s2')
+    screen:expect([[
+      {7:  }xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|
+      {7:  }xx                                                                       |
+      {10:-)}{4:^mmmm                                                                     }|
+      {7:  }yyyy                                                                     |
+      {1:~                                                                          }|
+                                                                                 |
+    ]])
+
     -- update cursor position calculation
     feed('lh')
+    command('sign unplace 11')
     command('sign unplace 10')
     screen:expect([[
       xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|

--- a/test/old/testdir/test_signs.vim
+++ b/test/old/testdir/test_signs.vim
@@ -1816,6 +1816,7 @@ func Test_sign_cursor_position()
 	call setline(1, [repeat('x', 75), 'mmmm', 'yyyy'])
 	call cursor(2,1)
    	sign define s1 texthl=Search text==>
+   	sign define s2 linehl=Pmenu
 	redraw
    	sign place 10 line=2 name=s1
   END
@@ -1827,11 +1828,15 @@ func Test_sign_cursor_position()
   call term_sendkeys(buf, ":sign define s1 text=-)\<CR>")
   call VerifyScreenDump(buf, 'Test_sign_cursor_2', {})
 
-  " update cursor position calculation
-  call term_sendkeys(buf, "lh")
-  call term_sendkeys(buf, ":sign unplace 10\<CR>")
+  " Also place a line HL sign
+  call term_sendkeys(buf, ":sign place 11 line=2 name=s2\<CR>")
   call VerifyScreenDump(buf, 'Test_sign_cursor_3', {})
 
+  " update cursor position calculation
+  call term_sendkeys(buf, "lh")
+  call term_sendkeys(buf, ":sign unplace 11\<CR>")
+  call term_sendkeys(buf, ":sign unplace 10\<CR>")
+  call VerifyScreenDump(buf, 'Test_sign_cursor_4', {})
 
   " clean up
   call StopVimInTerminal(buf)


### PR DESCRIPTION
#### vim-patch:8.2.0281: two placed signs in the same line are not combined

Problem:    Two placed signs in the same line are not combined.  E.g. in the
            terminal debugger a breakpoint and the PC cannot be both be
            displayed.
Solution:   Combine the sign column and line highlight attributes.

https://github.com/vim/vim/commit/a2f6e42ded067df8ee682c15aa246491a389b1a0

Nvim already does this in decor_redraw_signs().

Co-authored-by: Bram Moolenaar <Bram@vim.org>