### PR TITLE
vim-patch:{8.2.3543,9.1.0615}

### DIFF
--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -822,9 +822,6 @@ static int buf_write_make_backup(char *fname, bool append, FileInfo *file_info_o
       size_t dir_len = copy_option_part(&dirp, IObuff, IOSIZE, ",");
       char *p = IObuff + dir_len;
       bool trailing_pathseps = after_pathsep(IObuff, p) && p[-1] == p[-2];
-      if (trailing_pathseps) {
-        IObuff[dir_len - 2] = NUL;
-      }
       if (*dirp == NUL && !os_isdir(IObuff)) {
         int ret;
         char *failed_dir;
@@ -964,9 +961,6 @@ nobackup:
       size_t dir_len = copy_option_part(&dirp, IObuff, IOSIZE, ",");
       char *p = IObuff + dir_len;
       bool trailing_pathseps = after_pathsep(IObuff, p) && p[-1] == p[-2];
-      if (trailing_pathseps) {
-        IObuff[dir_len - 2] = NUL;
-      }
       if (*dirp == NUL && !os_isdir(IObuff)) {
         int ret;
         char *failed_dir;

--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -821,7 +821,6 @@ static int buf_write_make_backup(char *fname, bool append, FileInfo *file_info_o
       // Isolate one directory name, using an entry in 'bdir'.
       size_t dir_len = copy_option_part(&dirp, IObuff, IOSIZE, ",");
       char *p = IObuff + dir_len;
-      bool trailing_pathseps = after_pathsep(IObuff, p) && p[-1] == p[-2];
       if (*dirp == NUL && !os_isdir(IObuff)) {
         int ret;
         char *failed_dir;
@@ -831,9 +830,9 @@ static int buf_write_make_backup(char *fname, bool append, FileInfo *file_info_o
           xfree(failed_dir);
         }
       }
-      if (trailing_pathseps) {
+      if (after_pathsep(IObuff, p) && p[-1] == p[-2]) {
         // Ends with '//', Use Full path
-        if ((p = make_percent_swname(IObuff, fname))
+        if ((p = make_percent_swname(IObuff, p, fname))
             != NULL) {
           *backupp = modname(p, backup_ext, no_prepend_dot);
           xfree(p);
@@ -960,7 +959,6 @@ nobackup:
       // Isolate one directory name and make the backup file name.
       size_t dir_len = copy_option_part(&dirp, IObuff, IOSIZE, ",");
       char *p = IObuff + dir_len;
-      bool trailing_pathseps = after_pathsep(IObuff, p) && p[-1] == p[-2];
       if (*dirp == NUL && !os_isdir(IObuff)) {
         int ret;
         char *failed_dir;
@@ -970,9 +968,9 @@ nobackup:
           xfree(failed_dir);
         }
       }
-      if (trailing_pathseps) {
+      if (after_pathsep(IObuff, p) && p[-1] == p[-2]) {
         // path ends with '//', use full path
-        if ((p = make_percent_swname(IObuff, fname))
+        if ((p = make_percent_swname(IObuff, p, fname))
             != NULL) {
           *backupp = modname(p, backup_ext, no_prepend_dot);
           xfree(p);

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1325,11 +1325,9 @@ int recover_names(char *fname, bool do_list, list_T *ret_list, int nr, char **fn
       } else {
         int len = (int)strlen(dir_name);
         p = dir_name + len;
-        if (after_pathsep(dir_name, p)
-            && len > 1
-            && p[-1] == p[-2]) {
+        if (after_pathsep(dir_name, p) && len > 1 && p[-1] == p[-2]) {
           // Ends with '//', Use Full path for swap name
-          tail = make_percent_swname(dir_name, fname_res);
+          tail = make_percent_swname(dir_name, p, fname_res);
         } else {
           tail = path_tail(fname_res);
           tail = concat_fnames(dir_name, tail, true);
@@ -1443,8 +1441,8 @@ int recover_names(char *fname, bool do_list, list_T *ret_list, int nr, char **fn
 /// signs, to "dir". An unnamed buffer is handled as "" (<currentdir>/"")
 /// The last character in "dir" must be an extra slash or backslash, it is
 /// removed.
-char *make_percent_swname(char *dir, const char *name)
-  FUNC_ATTR_NONNULL_ARG(1)
+char *make_percent_swname(char *dir, char *dir_end, const char *name)
+  FUNC_ATTR_NONNULL_ARG(1, 2)
 {
   char *d = NULL;
   char *f = fix_fname(name != NULL ? name : "");
@@ -1459,7 +1457,7 @@ char *make_percent_swname(char *dir, const char *name)
     }
   }
 
-  dir[strlen(dir) - 1] = NUL;  // remove one trailing slash
+  dir_end[-1] = NUL;  // remove one trailing slash
   d = concat_fnames(dir, s, true);
   xfree(s);
   xfree(f);
@@ -3197,11 +3195,10 @@ char *makeswapname(char *fname, char *ffname, buf_T *buf, char *dir_name)
   int len = (int)strlen(dir_name);
 
   char *s = dir_name + len;
-  if (after_pathsep(dir_name, s)
-      && len > 1
-      && s[-1] == s[-2]) {  // Ends with '//', Use Full path
+  if (after_pathsep(dir_name, s) && len > 1 && s[-1] == s[-2]) {
+    // Ends with '//', Use Full path
     char *r = NULL;
-    s = make_percent_swname(dir_name, fname_res);
+    s = make_percent_swname(dir_name, s, fname_res);
     if (s != NULL) {
       r = modname(s, ".swp", false);
       xfree(s);

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1440,7 +1440,10 @@ int recover_names(char *fname, bool do_list, list_T *ret_list, int nr, char **fn
 
 /// Append the full path to name with path separators made into percent
 /// signs, to dir. An unnamed buffer is handled as "" (<currentdir>/"")
-char *make_percent_swname(const char *dir, const char *name)
+/// signs, to "dir". An unnamed buffer is handled as "" (<currentdir>/"")
+/// The last character in "dir" must be an extra slash or backslash, it is
+/// removed.
+char *make_percent_swname(char *dir, const char *name)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   char *d = NULL;
@@ -1455,6 +1458,8 @@ char *make_percent_swname(const char *dir, const char *name)
       *d = '%';
     }
   }
+
+  dir[strlen(dir) - 1] = NUL;  // remove one trailing slash
   d = concat_fnames(dir, s, true);
   xfree(s);
   xfree(f);


### PR DESCRIPTION
Fix #14110

#### vim-patch:8.2.3543: swapname has double slash when 'directory' ends in it

Problem:    Swapname has double slash when 'directory' ends in double slash.
            (Shane Smith)
Solution:   Remove the superfluous slash.

https://github.com/vim/vim/commit/8b0e62c93b6dad5ec5b2c7558d4f7b78c46216d2

Co-authored-by: Bram Moolenaar <Bram@vim.org>