### PR TITLE
vim-patch:9.0.{0228,0407,0414}

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -6256,13 +6256,12 @@ static bool regmatch(uint8_t *scan, const proftime_T *tm, int *timed_out)
 
         case RE_VCOL: {
           win_T *wp = rex.reg_win == NULL ? curwin : rex.reg_win;
-          linenr_T lnum = rex.reg_firstlnum + rex.lnum;
-          int vcol = 0;
-
-          if (lnum >= 0 && lnum <= wp->w_buffer->b_ml.ml_line_count) {
-            vcol = win_linetabsize(wp, lnum, (char *)rex.line,
-                                   (colnr_T)(rex.input - rex.line));
+          linenr_T lnum = REG_MULTI ? rex.reg_firstlnum + rex.lnum : 1;
+          if (REG_MULTI && (lnum <= 0 || lnum > wp->w_buffer->b_ml.ml_line_count)) {
+            lnum = 1;
           }
+          int vcol = win_linetabsize(wp, lnum, (char *)rex.line,
+                                     (colnr_T)(rex.input - rex.line));
           if (!re_num_cmp((uint32_t)vcol + 1, scan)) {
             status = RA_NOMATCH;
           }
@@ -15105,12 +15104,11 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
           result = col > t->state->val * ts;
         }
         if (!result) {
-          linenr_T lnum = rex.reg_firstlnum + rex.lnum;
-          int vcol = 0;
-
-          if (lnum >= 0 && lnum <= wp->w_buffer->b_ml.ml_line_count) {
-            vcol = win_linetabsize(wp, lnum, (char *)rex.line, col);
+          linenr_T lnum = REG_MULTI ? rex.reg_firstlnum + rex.lnum : 1;
+          if (REG_MULTI && (lnum <= 0 || lnum > wp->w_buffer->b_ml.ml_line_count)) {
+            lnum = 1;
           }
+          int vcol = win_linetabsize(wp, lnum, (char *)rex.line, col);
           assert(t->state->val >= 0);
           result = nfa_re_num_cmp((uintmax_t)t->state->val, op, (uintmax_t)vcol + 1);
         }

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -6254,15 +6254,21 @@ static bool regmatch(uint8_t *scan, const proftime_T *tm, int *timed_out)
           }
           break;
 
-        case RE_VCOL:
-          if (!re_num_cmp((unsigned)win_linetabsize(rex.reg_win == NULL ? curwin : rex.reg_win,
-                                                    rex.reg_firstlnum + rex.lnum,
-                                                    (char *)rex.line,
-                                                    (colnr_T)(rex.input - rex.line)) + 1,
-                          scan)) {
+        case RE_VCOL: {
+          win_T *wp = rex.reg_win == NULL ? curwin : rex.reg_win;
+          linenr_T lnum = rex.reg_firstlnum + rex.lnum;
+          int vcol = 0;
+
+          if (lnum > 0 && lnum <= wp->w_buffer->b_ml.ml_line_count) {
+            vcol = win_linetabsize(wp, lnum, (char *)rex.line,
+                                   (colnr_T)(rex.input - rex.line));
+          }
+          if (!re_num_cmp((uint32_t)vcol + 1, scan)) {
             status = RA_NOMATCH;
           }
           break;
+        }
+        break;
 
         case BOW:  // \<word; rex.input points to w
           if (c == NUL) {  // Can't match at end of line
@@ -15099,9 +15105,14 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
           result = col > t->state->val * ts;
         }
         if (!result) {
-          int lts = win_linetabsize(wp, rex.reg_firstlnum + rex.lnum, (char *)rex.line, col);
+          linenr_T lnum = rex.reg_firstlnum + rex.lnum;
+          int vcol = 0;
+
+          if (lnum > 0 && lnum <= wp->w_buffer->b_ml.ml_line_count) {
+            vcol = win_linetabsize(wp, lnum, (char *)rex.line, col);
+          }
           assert(t->state->val >= 0);
-          result = nfa_re_num_cmp((uintmax_t)t->state->val, op, (uintmax_t)lts + 1);
+          result = nfa_re_num_cmp((uintmax_t)t->state->val, op, (uintmax_t)vcol + 1);
         }
         if (result) {
           add_here = true;

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -6259,7 +6259,7 @@ static bool regmatch(uint8_t *scan, const proftime_T *tm, int *timed_out)
           linenr_T lnum = rex.reg_firstlnum + rex.lnum;
           int vcol = 0;
 
-          if (lnum > 0 && lnum <= wp->w_buffer->b_ml.ml_line_count) {
+          if (lnum >= 0 && lnum <= wp->w_buffer->b_ml.ml_line_count) {
             vcol = win_linetabsize(wp, lnum, (char *)rex.line,
                                    (colnr_T)(rex.input - rex.line));
           }
@@ -15108,7 +15108,7 @@ static int nfa_regmatch(nfa_regprog_T *prog, nfa_state_T *start, regsubs_T *subm
           linenr_T lnum = rex.reg_firstlnum + rex.lnum;
           int vcol = 0;
 
-          if (lnum > 0 && lnum <= wp->w_buffer->b_ml.ml_line_count) {
+          if (lnum >= 0 && lnum <= wp->w_buffer->b_ml.ml_line_count) {
             vcol = win_linetabsize(wp, lnum, (char *)rex.line, col);
           }
           assert(t->state->val >= 0);

--- a/test/old/testdir/test_regexp_latin.vim
+++ b/test/old/testdir/test_regexp_latin.vim
@@ -1135,4 +1135,16 @@ func Test_recursive_substitute_expr()
   delfunc Repl
 endfunc
 
+" def Test_compare_columns()
+"   # this was using a line below the last line
+"   enew
+"   setline(1, ['', ''])
+"   prop_type_add('name', {highlight: 'ErrorMsg'})
+"   prop_add(1, 1, {length: 1, type: 'name'})
+"   search('\%#=1\%>.l\n.*\%<2v', 'nW')
+"   search('\%#=2\%>.l\n.*\%<2v', 'nW')
+"   bwipe!
+"   prop_type_delete('name')
+" enddef
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_regexp_latin.vim
+++ b/test/old/testdir/test_regexp_latin.vim
@@ -1151,7 +1151,13 @@ endfunc
 " enddef
 
 func Test_compare_column_matchstr()
+  " do some search in text to set the line number, it should be ignored in
+  " matchstr().
   enew
+  call setline(1, ['one', 'two', 'three'])
+  :3 
+  :/ee
+  bwipe!
   set re=1
   call assert_equal('aaa', matchstr('aaaaaaaaaaaaaaaaaaaa', '.*\%<5v'))
   set re=2

--- a/test/old/testdir/test_regexp_latin.vim
+++ b/test/old/testdir/test_regexp_latin.vim
@@ -28,59 +28,45 @@ func s:equivalence_test()
 endfunc
 
 func Test_equivalence_re1()
-  throw 'skipped: Nvim does not support enc=latin1'
   set re=1
   call s:equivalence_test()
 endfunc
 
 func Test_equivalence_re2()
-  throw 'skipped: Nvim does not support enc=latin1'
   set re=2
   call s:equivalence_test()
 endfunc
 
-func Test_range_with_newline()
+func Test_recursive_substitute()
   new
-  call setline(1, "a")
-  call assert_equal(0, search("[ -*\\n- ]"))
-  call assert_equal(0, search("[ -*\\t-\\n]"))
+  s/^/\=execute("s#^##gn")
+  " check we are now not in the sandbox
+  call setwinvar(1, 'myvar', 1)
   bwipe!
 endfunc
 
-func Test_pattern_compile_speed()
-  CheckOption spellcapcheck
-  CheckFunction reltimefloat
-
-  let start = reltime()
-  " this used to be very slow, not it should be about a second
-  set spc=\\v(((((Nxxxxxxx&&xxxx){179})+)+)+){179}
-  call assert_inrange(0.01, 10.0, reltimefloat(reltime(start)))
-  set spc=
-endfunc
-
-func Test_get_equi_class()
+func Test_nested_backrefs()
+  " Check example in change.txt.
   new
-  " Incomplete equivalence class caused invalid memory access
-  s/^/[[=
-  call assert_equal(1, search(getline(1)))
-  s/.*/[[.
-  call assert_equal(1, search(getline(1)))
-endfunc
+  for re in range(0, 2)
+    exe 'set re=' . re
+    call setline(1, 'aa ab x')
+    1s/\(\(a[a-d] \)*\)\(x\)/-\1- -\2- -\3-/
+    call assert_equal('-aa ab - -ab - -x-', getline(1))
 
-func Test_rex_init()
-  set noincsearch
-  set re=1
-  new
-  setlocal iskeyword=a-z
-  call setline(1, ['abc', 'ABC'])
-  call assert_equal(1, search('[[:keyword:]]'))
-  new
-  setlocal iskeyword=A-Z
-  call setline(1, ['abc', 'ABC'])
-  call assert_equal(2, search('[[:keyword:]]'))
-  bwipe!
+    call assert_equal('-aa ab - -ab - -x-', substitute('aa ab x', '\(\(a[a-d] \)*\)\(x\)', '-\1- -\2- -\3-', ''))
+  endfor
   bwipe!
   set re=0
+endfunc
+
+func Test_eow_with_optional()
+  let expected = ['abc def', 'abc', 'def', '', '', '', '', '', '', '']
+  for re in range(0, 2)
+    exe 'set re=' . re
+    let actual = matchlist('abc def', '\(abc\>\)\?\s*\(def\)')
+    call assert_equal(expected, actual)
+  endfor
 endfunc
 
 func Test_backref()
@@ -142,6 +128,50 @@ func Test_out_of_memory()
   s/^/,n
   " This will be slow...
   call assert_fails('call search("\\v((n||<)+);")', 'E363:')
+endfunc
+
+func Test_get_equi_class()
+  new
+  " Incomplete equivalence class caused invalid memory access
+  s/^/[[=
+  call assert_equal(1, search(getline(1)))
+  s/.*/[[.
+  call assert_equal(1, search(getline(1)))
+endfunc
+
+func Test_rex_init()
+  set noincsearch
+  set re=1
+  new
+  setlocal iskeyword=a-z
+  call setline(1, ['abc', 'ABC'])
+  call assert_equal(1, search('[[:keyword:]]'))
+  new
+  setlocal iskeyword=A-Z
+  call setline(1, ['abc', 'ABC'])
+  call assert_equal(2, search('[[:keyword:]]'))
+  bwipe!
+  bwipe!
+  set re=0
+endfunc
+
+func Test_range_with_newline()
+  new
+  call setline(1, "a")
+  call assert_equal(0, search("[ -*\\n- ]"))
+  call assert_equal(0, search("[ -*\\t-\\n]"))
+  bwipe!
+endfunc
+
+func Test_pattern_compile_speed()
+  CheckOption spellcapcheck
+  CheckFunction reltimefloat
+
+  let start = reltime()
+  " this used to be very slow, not it should be about a second
+  set spc=\\v(((((Nxxxxxxx&&xxxx){179})+)+)+){179}
+  call assert_inrange(0.01, 10.0, reltimefloat(reltime(start)))
+  set spc=
 endfunc
 
 " Tests for regexp patterns without multi-byte support.

--- a/test/old/testdir/test_regexp_latin.vim
+++ b/test/old/testdir/test_regexp_latin.vim
@@ -30,11 +30,13 @@ endfunc
 func Test_equivalence_re1()
   set re=1
   call s:equivalence_test()
+  set re=0
 endfunc
 
 func Test_equivalence_re2()
   set re=2
   call s:equivalence_test()
+  set re=0
 endfunc
 
 func Test_recursive_substitute()
@@ -67,6 +69,7 @@ func Test_eow_with_optional()
     let actual = matchlist('abc def', '\(abc\>\)\?\s*\(def\)')
     call assert_equal(expected, actual)
   endfor
+  set re=0
 endfunc
 
 func Test_backref()
@@ -1146,5 +1149,15 @@ endfunc
 "   bwipe!
 "   prop_type_delete('name')
 " enddef
+
+func Test_compare_column_matchstr()
+  enew
+  set re=1
+  call assert_equal('aaa', matchstr('aaaaaaaaaaaaaaaaaaaa', '.*\%<5v'))
+  set re=2
+  call assert_equal('aaa', matchstr('aaaaaaaaaaaaaaaaaaaa', '.*\%<5v'))
+  set re=0
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_regexp_utf8.vim
+++ b/test/old/testdir/test_regexp_utf8.vim
@@ -188,38 +188,6 @@ func Test_classes_re2()
   set re=0
 endfunc
 
-func Test_recursive_substitute()
-  new
-  s/^/\=execute("s#^##gn")
-  " check we are now not in the sandbox
-  call setwinvar(1, 'myvar', 1)
-  bwipe!
-endfunc
-
-func Test_nested_backrefs()
-  " Check example in change.txt.
-  new
-  for re in range(0, 2)
-    exe 'set re=' . re
-    call setline(1, 'aa ab x')
-    1s/\(\(a[a-d] \)*\)\(x\)/-\1- -\2- -\3-/
-    call assert_equal('-aa ab - -ab - -x-', getline(1))
-
-    call assert_equal('-aa ab - -ab - -x-', substitute('aa ab x', '\(\(a[a-d] \)*\)\(x\)', '-\1- -\2- -\3-', ''))
-  endfor
-  bwipe!
-  set re=0
-endfunc
-
-func Test_eow_with_optional()
-  let expected = ['abc def', 'abc', 'def', '', '', '', '', '', '', '']
-  for re in range(0, 2)
-    exe 'set re=' . re
-    let actual = matchlist('abc def', '\(abc\>\)\?\s*\(def\)')
-    call assert_equal(expected, actual)
-  endfor
-endfunc
-
 func Test_reversed_range()
   for re in range(0, 2)
     exe 'set re=' . re


### PR DESCRIPTION
#### vim-patch:9.0.0228: crash when pattern looks below the last line

Problem:    Crash when pattern looks below the last line.
Solution:   Consider invalid lines to be empty.

https://github.com/vim/vim/commit/13ed494bb5edc5a02d0ed0feabddb68920f88570

Comment out the test as it uses Vim9 script and text properties.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0407: matchstr() does match column offset

Problem:    matchstr() does match column offset. (Yasuhiro Matsumoto)
Solution:   Accept line number zero.

https://github.com/vim/vim/commit/75a115e8d632e96b4f45dc5145ba261876a83dcf

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.0414: matchstr() still does not match column offset

Problem:    matchstr() still does not match column offset when done after a
            text search.
Solution:   Only use the line number for a multi-line search.  Fix the test.

https://github.com/vim/vim/commit/753aead960f163d0d3f8ce523ea523f2e0cec06d

Co-authored-by: Bram Moolenaar <Bram@vim.org>