### PR TITLE
fix(scrollbind): properly take filler/virtual lines into account

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -183,7 +183,13 @@ CHANGED FEATURES                                                 *news-changed*
 
 These existing features changed their behavior.
 
-• N/A
+• 'scrollbind' now works properly with buffers that contain virutal lines.
+
+  Scrollbind works by aligning to a target top line of each window in a tab
+  page. Previously this was done by calculating the difference between the old
+  top line and the target top line, and scrolling by that amount. Now the
+  top lines are calculated using screen line numbers which take virtual lines
+  into account.
 
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -2143,7 +2143,11 @@ int diff_check_with_linestatus(win_T *wp, linenr_T lnum, int *linestatus)
     return 0;
   }
 
-  if (!dp->is_linematched && diff_linematch(dp)) {
+  // Don't run linematch when lnum is offscreen.
+  // Useful for scrollbind calculations which need to count all the filler lines
+  // above the screen.
+  if (lnum >= wp->w_topline && lnum < wp->w_botline
+      && !dp->is_linematched && diff_linematch(dp)) {
     run_linematch_algorithm(dp);
   }
 

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1156,7 +1156,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
     area_highlighting = true;
   }
   VirtLines virt_lines = KV_INITIAL_VALUE;
-  wlv.n_virt_lines = decor_virt_lines(wp, lnum, &virt_lines);
+  wlv.n_virt_lines = decor_virt_lines(wp, lnum - 1, lnum, &virt_lines, true);
   wlv.filler_lines += wlv.n_virt_lines;
   if (lnum == wp->w_topline) {
     wlv.filler_lines = wp->w_topfill;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2695,7 +2695,7 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
       *so_ptr = 999;    // force cursor to be vertically centered in the window
     }
     update_topline(curwin);
-    curwin->w_scbind_pos = curwin->w_topline;
+    curwin->w_scbind_pos = plines_m_win_fill(curwin, 1, curwin->w_topline);
     *so_ptr = n;
     redraw_curbuf_later(UPD_NOT_VALID);  // redraw this buffer later
   }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -88,6 +88,7 @@
 #include "nvim/os/os.h"
 #include "nvim/os/os_defs.h"
 #include "nvim/path.h"
+#include "nvim/plines.h"
 #include "nvim/popupmenu.h"
 #include "nvim/pos_defs.h"
 #include "nvim/regexp.h"
@@ -2474,7 +2475,7 @@ static const char *did_set_scrollbind(optset_T *args)
     return NULL;
   }
   do_check_scrollbind(false);
-  win->w_scbind_pos = win->w_topline;
+  win->w_scbind_pos = get_vtopline(win);
   return NULL;
 }
 

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -712,7 +712,7 @@ bool win_may_fill(win_T *wp)
 /// @return Number of filler lines above lnum
 int win_get_fill(win_T *wp, linenr_T lnum)
 {
-  int virt_lines = decor_virt_lines(wp, lnum, NULL);
+  int virt_lines = decor_virt_lines(wp, lnum - 1, lnum, NULL, true);
 
   // be quick when there are no filler lines
   if (diffopt_filler()) {
@@ -904,6 +904,25 @@ int plines_m_win(win_T *wp, linenr_T first, linenr_T last, int max)
     count += win_get_fill(wp, first);
   }
   return MIN(max, count);
+}
+
+/// Return number of window lines a physical line range will occupy.
+/// Only considers real and filler lines.
+///
+/// Mainly used for calculating scrolling offsets.
+int plines_m_win_fill(win_T *wp, linenr_T first, linenr_T last)
+{
+  int count = last - first + 1 + decor_virt_lines(wp, first - 1, last, NULL, false);
+
+  if (diffopt_filler()) {
+    for (int lnum = first; lnum <= last; lnum++) {
+      // Note: this also considers folds.
+      int n = diff_check(wp, lnum);
+      count += MAX(n, 0);
+    }
+  }
+
+  return MAX(count, 0);
 }
 
 /// Get the number of screen lines a range of text will take in window "wp".

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -835,9 +835,18 @@ function M.exec_capture(code)
   return M.api.nvim_exec2(code, { output = true }).output
 end
 
---- @param code string
+--- @param code string|function
 --- @return any
 function M.exec_lua(code, ...)
+  if type(code) == 'function' then
+    return M.api.nvim_exec_lua(
+      [[
+      local code = ...
+      return loadstring(code)(select(2, ...))
+    ]],
+      { string.dump(code), ... }
+    )
+  end
   return M.api.nvim_exec_lua(code, { ... })
 end
 

--- a/test/functional/ui/scrollbind_spec.lua
+++ b/test/functional/ui/scrollbind_spec.lua
@@ -1,0 +1,442 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+local clear = n.clear
+local Screen = require('test.functional.ui.screen')
+
+before_each(clear)
+
+describe('Scrollbind', function()
+  local screen --- @type test.functional.ui.screen
+
+  before_each(function()
+    screen = Screen.new(40, 12)
+    screen:attach()
+  end)
+
+  it('works with one buffer with virtual lines', function()
+    n.exec_lua(function()
+      local lines = {} --- @type string[]
+
+      for i = 1, 20 do
+        lines[i] = tostring(i * 2 - 1)
+      end
+
+      local ns = vim.api.nvim_create_namespace('test')
+
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+      vim.bo.buftype = 'nofile'
+
+      for i in ipairs(lines) do
+        vim.api.nvim_buf_set_extmark(0, ns, i - 1, 0, {
+          virt_lines = { { { tostring(2 * i) .. ' v' } } },
+        })
+      end
+
+      vim.wo.scrollbind = true
+      vim.cmd.vsplit()
+      vim.wo.scrollbind = true
+    end)
+
+    n.feed('<C-d>')
+
+    t.eq(5, n.api.nvim_get_option_value('scroll', {}))
+
+    screen:expect({
+      grid = [[
+        6 v                 │6 v                |
+        7                   │7                  |
+        8 v                 │8 v                |
+        9                   │9                  |
+        10 v                │10 v               |
+        ^11                  │11                 |
+        12 v                │12 v               |
+        13                  │13                 |
+        14 v                │14 v               |
+        15                  │15                 |
+        {3:[Scratch]            }{2:[Scratch]          }|
+                                                |
+      ]],
+    })
+
+    n.feed('<C-u>')
+
+    local line1_grid = [[
+      ^1                   │1                  |
+      2 v                 │2 v                |
+      3                   │3                  |
+      4 v                 │4 v                |
+      5                   │5                  |
+      6 v                 │6 v                |
+      7                   │7                  |
+      8 v                 │8 v                |
+      9                   │9                  |
+      10 v                │10 v               |
+      {3:[Scratch]            }{2:[Scratch]          }|
+                                              |
+    ]]
+
+    screen:expect({ grid = line1_grid })
+
+    n.api.nvim_set_option_value('scroll', 6, {})
+
+    n.feed('<C-d>')
+
+    screen:expect({
+      grid = [[
+        7                   │7                  |
+        8 v                 │8 v                |
+        9                   │9                  |
+        10 v                │10 v               |
+        11                  │11                 |
+        12 v                │12 v               |
+        ^13                  │13                 |
+        14 v                │14 v               |
+        15                  │15                 |
+        16 v                │16 v               |
+        {3:[Scratch]            }{2:[Scratch]          }|
+                                                |
+      ]],
+    })
+
+    n.feed('<C-u>')
+
+    screen:expect({ grid = line1_grid })
+  end)
+
+  it('works with two buffers with virtual lines on one side', function()
+    n.exec_lua(function()
+      local lines = {} --- @type string[]
+
+      for i = 1, 20 do
+        lines[i] = tostring(i)
+      end
+
+      local ns = vim.api.nvim_create_namespace('test')
+
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+      vim.bo.buftype = 'nofile'
+
+      vim.wo.scrollbind = true
+      vim.cmd.vnew()
+
+      lines = {} --- @type string[]
+
+      for i = 1, 20 do
+        lines[i] = tostring(i + (i > 3 and 4 or 0))
+      end
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+      vim.bo.buftype = 'nofile'
+
+      vim.api.nvim_buf_set_extmark(0, ns, 2, 0, {
+        virt_lines = {
+          { { '4 v' } },
+          { { '5 v' } },
+          { { '6 v' } },
+          { { '7 v' } },
+        },
+      })
+
+      vim.wo.scrollbind = true
+    end)
+
+    n.feed('<C-d>')
+
+    t.eq(5, n.api.nvim_get_option_value('scroll', {}))
+
+    screen:expect({
+      grid = [[
+        6 v                 │6                  |
+        7 v                 │7                  |
+        8                   │8                  |
+        9                   │9                  |
+        ^10                  │10                 |
+        11                  │11                 |
+        12                  │12                 |
+        13                  │13                 |
+        14                  │14                 |
+        15                  │15                 |
+        {3:[Scratch]            }{2:[Scratch]          }|
+                                                |
+      ]],
+    })
+
+    n.feed('<C-u>')
+
+    local line1_grid = [[
+      ^1                   │1                  |
+      2                   │2                  |
+      3                   │3                  |
+      4 v                 │4                  |
+      5 v                 │5                  |
+      6 v                 │6                  |
+      7 v                 │7                  |
+      8                   │8                  |
+      9                   │9                  |
+      10                  │10                 |
+      {3:[Scratch]            }{2:[Scratch]          }|
+                                              |
+    ]]
+
+    screen:expect({ grid = line1_grid })
+
+    n.api.nvim_set_option_value('scroll', 6, {})
+
+    n.feed('<C-d>')
+
+    screen:expect({
+      grid = [[
+        7 v                 │7                  |
+        8                   │8                  |
+        9                   │9                  |
+        10                  │10                 |
+        ^11                  │11                 |
+        12                  │12                 |
+        13                  │13                 |
+        14                  │14                 |
+        15                  │15                 |
+        16                  │16                 |
+        {3:[Scratch]            }{2:[Scratch]          }|
+                                                |
+      ]],
+    })
+
+    n.feed('<C-u>')
+
+    screen:expect({ grid = line1_grid })
+
+    -- Note: not the same as n.feed('4<C-e>')
+    n.feed('<C-e>')
+    n.feed('<C-e>')
+    n.feed('<C-e>')
+    n.feed('<C-e>')
+
+    screen:expect({
+      grid = [[
+        5 v                 │5                  |
+        6 v                 │6                  |
+        7 v                 │7                  |
+        ^8                   │8                  |
+        9                   │9                  |
+        10                  │10                 |
+        11                  │11                 |
+        12                  │12                 |
+        13                  │13                 |
+        14                  │14                 |
+        {3:[Scratch]            }{2:[Scratch]          }|
+                                                |
+      ]],
+    })
+
+    n.feed('<C-e>')
+
+    screen:expect({
+      grid = [[
+        6 v                 │6                  |
+        7 v                 │7                  |
+        ^8                   │8                  |
+        9                   │9                  |
+        10                  │10                 |
+        11                  │11                 |
+        12                  │12                 |
+        13                  │13                 |
+        14                  │14                 |
+        15                  │15                 |
+        {3:[Scratch]            }{2:[Scratch]          }|
+                                                |
+      ]],
+    })
+
+    n.feed('<C-y>')
+    n.feed('<C-y>')
+
+    screen:expect({
+      grid = [[
+        4 v                 │4                  |
+        5 v                 │5                  |
+        6 v                 │6                  |
+        7 v                 │7                  |
+        ^8                   │8                  |
+        9                   │9                  |
+        10                  │10                 |
+        11                  │11                 |
+        12                  │12                 |
+        13                  │13                 |
+        {3:[Scratch]            }{2:[Scratch]          }|
+                                                |
+      ]],
+    })
+  end)
+
+  it('works with buffers of different lengths', function()
+    n.exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { '1', '2', '3' })
+      vim.bo.buftype = 'nofile'
+
+      vim.wo.scrollbind = true
+      vim.cmd.vnew()
+
+      local lines = {} --- @type string[]
+
+      for i = 1, 50 do
+        lines[i] = tostring(i)
+      end
+
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+      vim.bo.buftype = 'nofile'
+      vim.wo.scrollbind = true
+    end)
+
+    n.feed('10<C-e>')
+
+    screen:expect({
+      grid = [[
+        ^11                  │3                  |
+        12                  │{1:~                  }|
+        13                  │{1:~                  }|
+        14                  │{1:~                  }|
+        15                  │{1:~                  }|
+        16                  │{1:~                  }|
+        17                  │{1:~                  }|
+        18                  │{1:~                  }|
+        19                  │{1:~                  }|
+        20                  │{1:~                  }|
+        {3:[Scratch]            }{2:[Scratch]          }|
+                                                |
+      ]],
+    })
+
+    n.feed('<C-y>')
+
+    screen:expect({
+      grid = [[
+        10                  │3                  |
+        ^11                  │{1:~                  }|
+        12                  │{1:~                  }|
+        13                  │{1:~                  }|
+        14                  │{1:~                  }|
+        15                  │{1:~                  }|
+        16                  │{1:~                  }|
+        17                  │{1:~                  }|
+        18                  │{1:~                  }|
+        19                  │{1:~                  }|
+        {3:[Scratch]            }{2:[Scratch]          }|
+                                                |
+      ]],
+    })
+  end)
+
+  it('works with buffers of different lengths and virtual lines', function()
+    n.exec_lua(function()
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { '1', '5', '6' })
+
+      local ns = vim.api.nvim_create_namespace('test')
+      vim.api.nvim_buf_set_extmark(0, ns, 0, 0, {
+        virt_lines = {
+          { { '2 v' } },
+          { { '3 v' } },
+          { { '4 v' } },
+        },
+      })
+
+      vim.bo.buftype = 'nofile'
+
+      vim.wo.scrollbind = true
+      vim.cmd.vnew()
+
+      local lines = {} --- @type string[]
+
+      for i = 1, 50 do
+        lines[i] = tostring(i)
+      end
+
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, lines)
+      vim.bo.buftype = 'nofile'
+      vim.wo.scrollbind = true
+    end)
+
+    n.feed('<C-e>')
+    n.feed('<C-e>')
+    screen:expect({
+      grid = [[
+        ^3                   │3 v                |
+        4                   │4 v                |
+        5                   │5                  |
+        6                   │6                  |
+        7                   │{1:~                  }|
+        8                   │{1:~                  }|
+        9                   │{1:~                  }|
+        10                  │{1:~                  }|
+        11                  │{1:~                  }|
+        12                  │{1:~                  }|
+        {3:[Scratch]            }{2:[Scratch]          }|
+                                                |
+      ]],
+    })
+
+    n.feed('8<C-e>')
+
+    screen:expect({
+      grid = [[
+        ^11                  │6                  |
+        12                  │{1:~                  }|
+        13                  │{1:~                  }|
+        14                  │{1:~                  }|
+        15                  │{1:~                  }|
+        16                  │{1:~                  }|
+        17                  │{1:~                  }|
+        18                  │{1:~                  }|
+        19                  │{1:~                  }|
+        20                  │{1:~                  }|
+        {3:[Scratch]            }{2:[Scratch]          }|
+                                                |
+      ]],
+    })
+
+    n.feed('<C-y>')
+    n.feed('<C-y>')
+    n.feed('<C-y>')
+    n.feed('<C-y>')
+    n.feed('<C-y>')
+
+    t.eq(n.exec_lua [[return vim.fn.line('w0', 1001)]], 6)
+    t.eq(n.exec_lua [[return vim.fn.line('w0', 1000)]], 3)
+
+    screen:expect({
+      grid = [[
+        6                   │6                  |
+        7                   │{1:~                  }|
+        8                   │{1:~                  }|
+        9                   │{1:~                  }|
+        10                  │{1:~                  }|
+        ^11                  │{1:~                  }|
+        12                  │{1:~                  }|
+        13                  │{1:~                  }|
+        14                  │{1:~                  }|
+        15                  │{1:~                  }|
+        {3:[Scratch]            }{2:[Scratch]          }|
+                                                |
+      ]],
+    })
+
+    n.feed('<C-y>')
+    n.feed('<C-y>')
+    n.feed('<C-y>')
+
+    screen:expect({
+      grid = [[
+        3                   │3 v                |
+        4                   │4 v                |
+        5                   │5                  |
+        6                   │6                  |
+        7                   │{1:~                  }|
+        8                   │{1:~                  }|
+        9                   │{1:~                  }|
+        10                  │{1:~                  }|
+        ^11                  │{1:~                  }|
+        12                  │{1:~                  }|
+        {3:[Scratch]            }{2:[Scratch]          }|
+                                                |
+      ]],
+    })
+  end)
+end)


### PR DESCRIPTION
Problem:

`'scrollbind'` does not work properly if the window being scrolled
automatically contains any filler/virtual lines (except for diff filler
lines).

This is because when the scrollbind check is done, the logic only
considers changes to topline which are represented as line numbers.

Solution:

Write the logic for determine the scroll amount to take into account
filler/virtual lines.

Fixes #29751