### PR TITLE
vim-patch:8.1.1588: in :let-heredoc line continuation is recognized

### DIFF
--- a/test/old/testdir/test_let.vim
+++ b/test/old/testdir/test_let.vim
@@ -521,12 +521,12 @@ END
 END
   call assert_equal(['vim', '', 'end', '  END', 'END '], var3)
 
-  let var1 =<< trim END
-  Line1
-    Line2
-  	Line3
-   END
-  END
+	let var1 =<< trim END
+	Line1
+	  Line2
+		Line3
+	 END
+	END
   call assert_equal(['Line1', '  Line2', "\tLine3", ' END'], var1)
 
   let var1 =<< trim !!!
@@ -562,6 +562,14 @@ END
   endfunc
   END
   call assert_equal(['something', 'endfunc'], var1)
+
+  " not concatenate lines
+  let var1 =<< END
+some
+  \thing
+  \ else
+END
+  call assert_equal(['some', '  \thing', '  \ else'], var1)
 
   " ignore "python << xx"
   let var1 =<<END

--- a/test/old/testdir/test_startup.vim
+++ b/test/old/testdir/test_startup.vim
@@ -163,6 +163,7 @@ endfunc
 " horizontally or vertically.
 func Test_o_arg()
   let after =<< trim [CODE]
+    set cpo&vim
     call writefile([winnr("$"),
 		\ winheight(1), winheight(2), &lines,
 		\ winwidth(1), winwidth(2), &columns,


### PR DESCRIPTION
#### vim-patch:8.1.1588: in :let-heredoc line continuation is recognized

Problem:    In :let-heredoc line continuation is recognized.
Solution:   Do not consume line continuation. (Ozaki Kiichi, closes vim/vim#4580)

https://github.com/vim/vim/commit/e96a2498f9a2d3e93ac07431f6d4afd77f30afdf

Nvim already sets may_garbage_collect to false in nv_event(), so the
timer change isn't needed.
Other changes have already been ported.
Also fix incorrect port of test in patch 8.1.1356.

Co-authored-by: Bram Moolenaar <Bram@vim.org>