### PR TITLE
ci: skip lintcommit workflow on release branches

### DIFF
--- a/.github/workflows/lintcommit.yml
+++ b/.github/workflows/lintcommit.yml
@@ -1,10 +1,9 @@
-name: "lintcommit"
+name: lintcommit
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
     branches:
       - 'master'
-      - 'release-[0-9]+.[0-9]+'
 jobs:
   lint-commits:
     runs-on: ubuntu-latest

--- a/.github/workflows/lintcommit_dummy.yml
+++ b/.github/workflows/lintcommit_dummy.yml
@@ -1,0 +1,16 @@
+# Dummy workflow of lintcommit.yml. lintcommit is a required check, but it's
+# only designed to work on master. Since required checks are always required to
+# run, we can essentially "skip" the lintcommit on release branches with this
+# dummy check that automatically passes.
+name: lintcommit_dummy
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, ready_for_review]
+    branches:
+      - 'release-[0-9]+.[0-9]+'
+jobs:
+  lint-commits:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.draft == false
+    steps:
+      - run: echo "success"


### PR DESCRIPTION
Since lintcommit is a required check, it will always need to be run.
However, the lintcommit script is not designed to work on PRs that
doesn't target master branch (and it's not clear whether it's even
desirable).

To circumvent this we create a "dummy" lintcommit check that is run on
release branches that always passes, thus fulfilling the condition of
the required check.
