### PR TITLE
vim-patch:9.0.{partial:0719,1257}

### DIFF
--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -48,8 +48,18 @@
 "	call add(v:errors, "this happened")
 
 
+" Without the +eval feature we can't run these tests, bail out.
+silent! while 0
+  qa!
+silent! endwhile
+
+" In the GUI we can always change the screen size.
+if has('gui_running')
+  set columns=80 lines=25
+endif
+
 " Check that the screen size is at least 24 x 80 characters.
-if &lines < 24 || &columns < 80 
+if &lines < 24 || &columns < 80
   let error = 'Screen size too small! Tests require at least 24 lines with 80 characters, got ' .. &lines .. ' lines with ' .. &columns .. ' characters'
   echoerr error
   split test.log

--- a/test/old/testdir/summarize.vim
+++ b/test/old/testdir/summarize.vim
@@ -33,7 +33,7 @@ if 1
     silent %s/^SKIPPED \zs.*/\=Count(submatch(0), 'skipped')/egn
     silent %s/^\(\d\+\)\s\+FAILED:/\=Count(submatch(1), 'failed')/egn
 
-    call extend(output, ["Skipped:"]) 
+    call extend(output, ["Skipped:"])
     call extend(output, skipped_output)
 
     call extend(output, [

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -273,8 +273,8 @@ func Test_win_tab_autocmd()
   augroup testing
     au WinNew * call add(g:record, 'WinNew')
     au WinClosed * call add(g:record, 'WinClosed')
-    au WinEnter * call add(g:record, 'WinEnter') 
-    au WinLeave * call add(g:record, 'WinLeave') 
+    au WinEnter * call add(g:record, 'WinEnter')
+    au WinLeave * call add(g:record, 'WinLeave')
     au TabNew * call add(g:record, 'TabNew')
     au TabClosed * call add(g:record, 'TabClosed')
     au TabEnter * call add(g:record, 'TabEnter')
@@ -3770,7 +3770,7 @@ endfunc
 
 func Test_autocmd_split_dummy()
   " Autocommand trying to split a window containing a dummy buffer.
-  auto BufReadPre * exe "sbuf " .. expand("<abuf>") 
+  auto BufReadPre * exe "sbuf " .. expand("<abuf>")
   " Avoid the "W11" prompt
   au FileChangedShell * let v:fcs_choice = 'reload'
   func Xautocmd_changelist()

--- a/test/old/testdir/test_blob.vim
+++ b/test/old/testdir/test_blob.vim
@@ -850,7 +850,7 @@ func Test_indexof()
   call assert_equal(-1, indexof(v:_null_blob, "v:val == 0xde"))
   call assert_equal(-1, indexof(b, v:_null_string))
   " Nvim doesn't have null functions
-  " call assert_equal(-1, indexof(b, test_null_function())) 
+  " call assert_equal(-1, indexof(b, test_null_function()))
 
   let b = 0z01020102
   call assert_equal(1, indexof(b, "v:val == 0x02", #{startidx: 0}))

--- a/test/old/testdir/test_blockedit.vim
+++ b/test/old/testdir/test_blockedit.vim
@@ -53,7 +53,7 @@ func Test_blockinsert_autoindent()
   let expected =<< trim END
       vim9script
       var d = {
-      	a: (): asdf => 0,
+	a: (): asdf => 0,
       b: (): asdf => 0,
       c: (): asdf => 0,
       }

--- a/test/old/testdir/test_codestyle.vim
+++ b/test/old/testdir/test_codestyle.vim
@@ -6,6 +6,45 @@ func s:ReportError(fname, lnum, msg)
   endif
 endfunc
 
+func Test_test_files()
+  for fname in glob('*.vim', 0, 1)
+    let g:ignoreSwapExists = 'e'
+    exe 'edit ' .. fname
+
+    " some files intentionally have misplaced white space
+    if fname =~ 'test_cindent.vim' || fname =~ 'test_join.vim'
+      continue
+    endif
+
+    " skip files that are known to have a space before a tab
+    if fname !~ 'test_comments.vim'
+          \ && fname !~ 'test_listchars.vim'
+          \ && fname !~ 'test_visual.vim'
+      call cursor(1, 1)
+      let skip = 'getline(".") =~ "codestyle: ignore"'
+      let lnum = search(fname =~ "test_regexp_latin" ? '[^á] \t' : ' \t', 'W', 0, 0, skip)
+      call s:ReportError('testdir/' .. fname, lnum, 'space before Tab')
+    endif
+
+    " skip files that are known to have trailing white space
+    if fname !~ 'test_cmdline.vim'
+          \ && fname !~ 'test_let.vim'
+          \ && fname !~ 'test_tagjump.vim'
+          \ && fname !~ 'test_vim9_cmd.vim'
+      call cursor(1, 1)
+      let lnum = search(
+            \ fname =~ 'test_vim9_assign.vim' ? '[^=]\s$'
+            \ : fname =~ 'test_vim9_class.vim' ? '[^)]\s$'
+            \ : fname =~ 'test_vim9_script.vim' ? '[^,:3]\s$'
+            \ : fname =~ 'test_visual.vim' ? '[^/]\s$'
+            \ : '[^\\]\s$')
+      call s:ReportError('testdir/' .. fname, lnum, 'trailing white space')
+    endif
+  endfor
+
+  bwipe!
+endfunc
+
 func Test_help_files()
   set nowrapscan
 

--- a/test/old/testdir/test_diffmode.vim
+++ b/test/old/testdir/test_diffmode.vim
@@ -1332,12 +1332,12 @@ endfunc
 func Test_diff_and_scroll()
   " this was causing an ml_get error
   set ls=2
-  for i in range(winheight(0) * 2) 
-    call setline(i, i < winheight(0) - 10 ? i : i + 10) 
+  for i in range(winheight(0) * 2)
+    call setline(i, i < winheight(0) - 10 ? i : i + 10)
   endfor
   vnew
-  for i in range(winheight(0)*2 + 10) 
-    call setline(i, i < winheight(0) - 10 ? 0 : i) 
+  for i in range(winheight(0)*2 + 10)
+    call setline(i, i < winheight(0) - 10 ? 0 : i)
   endfor
   diffthis
   wincmd p

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -2112,7 +2112,7 @@ func Test_edit_overlong_file_name()
   file %%%%%%%%%%%%%%%%%%%%%%%%%%
   file %%%%%%
   set readonly
-  set ls=2 
+  set ls=2
 
   redraw!
   set noreadonly ls&

--- a/test/old/testdir/test_expand_func.vim
+++ b/test/old/testdir/test_expand_func.vim
@@ -7,15 +7,15 @@ let s:slnum = str2nr(expand('<slnum>'))
 let s:sflnum = str2nr(expand('<sflnum>'))
 
 func s:expand_sfile()
-  return expand('<sfile>')  
+  return expand('<sfile>')
 endfunc
 
 func s:expand_slnum()
-  return str2nr(expand('<slnum>'))  
+  return str2nr(expand('<slnum>'))
 endfunc
 
 func s:expand_sflnum()
-  return str2nr(expand('<sflnum>'))  
+  return str2nr(expand('<sflnum>'))
 endfunc
 
 " This test depends on the location in the test file, put it first.

--- a/test/old/testdir/test_fold.vim
+++ b/test/old/testdir/test_fold.vim
@@ -499,7 +499,7 @@ func Test_move_folds_around_manual()
   %foldopen!
   13m7
   call Check_foldlevels([1, 2, 2, 2, 1, 2, 2, 1, 1, 1, 2, 2, 2, 1, 0])
-  
+
   bw!
 endfunc
 
@@ -748,7 +748,7 @@ func Test_fold_create_marker_in_C()
   let content =<< trim [CODE]
     /*
      * comment
-     * 
+     *
      *
      */
     int f(int* p) {

--- a/test/old/testdir/test_goto.vim
+++ b/test/old/testdir/test_goto.vim
@@ -17,7 +17,7 @@ endfunc
 func Test_gD()
   let lines =<< trim [CODE]
     int x;
-  
+
     int func(void)
     {
       return x;
@@ -30,7 +30,7 @@ endfunc
 func Test_gD_too()
   let lines =<< trim [CODE]
     Filename x;
-  
+
     int Filename
     int func() {
       Filename x;
@@ -44,7 +44,7 @@ func Test_gD_comment()
   let lines =<< trim [CODE]
     /* int x; */
     int x;
-  
+
     int func(void)
     {
       return x;
@@ -58,7 +58,7 @@ func Test_gD_inline_comment()
   let lines =<< trim [CODE]
     int y /* , x */;
     int x;
-  
+
     int func(void)
     {
       return x;
@@ -72,7 +72,7 @@ func Test_gD_string()
   let lines =<< trim [CODE]
     char *s[] = "x";
     int x = 1;
-  
+
     int func(void)
     {
       return x;
@@ -85,7 +85,7 @@ endfunc
 func Test_gD_string_same_line()
   let lines =<< trim [CODE]
     char *s[] = "x", int x = 1;
-  
+
     int func(void)
     {
       return x;
@@ -99,7 +99,7 @@ func Test_gD_char()
   let lines =<< trim [CODE]
     char c = 'x';
     int x = 1;
-  
+
     int func(void)
     {
       return x;
@@ -112,7 +112,7 @@ endfunc
 func Test_gd()
   let lines =<< trim [CODE]
     int x;
-  
+
     int func(int x)
     {
       return x;
@@ -146,7 +146,7 @@ func Test_gd_not_local()
     {
       return x;
     }
-  
+
     int func2(int x)
     {
       return x;
@@ -173,9 +173,9 @@ func Test_gd_missing_braces()
     def func1(a)
       a + 1
     end
-  
+
     a = 1
-  
+
     def func2()
       return a
     end
@@ -252,11 +252,11 @@ func Test_gd_inline_comment_body()
     int func(void)
     {
       int y /* , x */;
-  
+
       for (/* int x = 0 */; y < 2; y++);
-  
+
       int x = 0;
-  
+
       return x;
     }
   [CODE]
@@ -292,7 +292,7 @@ func Test_gd_string()
     {
       char *s = "x";
       int x = 1;
-  
+
       return x;
     }
   [CODE]
@@ -305,7 +305,7 @@ func Test_gd_string_only()
     int func(void)
     {
       char *s = "x";
-  
+
       return x;
     }
   [CODE]
@@ -347,7 +347,7 @@ func Test_gd_local_block()
         char *b = "NULL";
         return b;
       }
-  
+
       return 0;
     }
   [CODE]

--- a/test/old/testdir/test_increment.vim
+++ b/test/old/testdir/test_increment.vim
@@ -705,7 +705,7 @@ endfunc
 " Text:
 "   1 23
 "   4 56
-" 
+"
 " Expected:
 "   1) f2 Ctrl-V jl <ctrl-a>, repeat twice afterwards with .
 "   1 26

--- a/test/old/testdir/test_indent.vim
+++ b/test/old/testdir/test_indent.vim
@@ -176,7 +176,7 @@ func Test_modeline_indent_expr()
 endfunc
 
 func Test_indent_func_with_gq()
-  
+
   function GetTeXIndent()
     " Sample indent expression for TeX files
     let lnum = prevnonblank(v:lnum - 1)
@@ -187,7 +187,7 @@ func Test_indent_func_with_gq()
     let line = getline(lnum)
     let ind = indent(lnum)
     " Add a 'shiftwidth' after beginning of environments.
-    if line =~ '\\begin{center}' 
+    if line =~ '\\begin{center}'
       let ind = ind + shiftwidth()
     endif
     return ind
@@ -249,7 +249,7 @@ func Test_indent_func_with_gq()
 
   bwipe!
   delmark ab
-  delfunction GetTeXIndent 
+  delfunction GetTeXIndent
 endfu
 
 func Test_formatting_keeps_first_line_indent()

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2382,7 +2382,7 @@ endfunc
 
 func Test_ins_complete_end_of_line()
   " this was reading past the end of the line
-  new  
+  new
   norm 8oý 
   sil! norm o
 

--- a/test/old/testdir/test_map_functions.vim
+++ b/test/old/testdir/test_map_functions.vim
@@ -20,7 +20,7 @@ func Test_maparg()
   call assert_equal({'silent': 0, 'noremap': 0, 'script': 0, 'lhs': 'foo<C-V>',
         \ 'lhsraw': "foo\x80\xfc\x04V", 'lhsrawalt': "foo\x16",
         \ 'mode': ' ', 'nowait': 0, 'expr': 0, 'sid': sid, 'scriptversion': 1,
-        \ 'lnum': lnum + 1, 
+        \ 'lnum': lnum + 1,
 	\ 'rhs': 'is<F4>foo', 'buffer': 0, 'abbr': 0, 'mode_bits': 0x47},
 	\ maparg('foo<C-V>', '', 0, 1))
   call assert_equal({'silent': 1, 'noremap': 1, 'script': 1, 'lhs': 'bar',

--- a/test/old/testdir/test_method.vim
+++ b/test/old/testdir/test_method.vim
@@ -128,7 +128,7 @@ endfunc
 
 func Test_method_syntax()
   eval [1, 2, 3]  ->sort( )
-  eval [1, 2, 3]  
+  eval [1, 2, 3]
 	\ ->sort(
 	\ )
   call assert_fails('eval [1, 2, 3]-> sort()', 'E15:')

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -16,7 +16,7 @@ func ListMonths()
   if !empty(entered)
     let mth = filter(mth, 'v:val=~"^".entered')
   endif
-  call complete(1, mth) 
+  call complete(1, mth)
   return ''
 endfunc
 
@@ -74,7 +74,7 @@ func Test_popup_complete()
   call feedkeys("aJu\<f5>\<c-p>l\<c-y>", 'tx')
   call assert_equal(["Jul"], getline(1,2))
   %d
-  
+
   " any-non printable, non-white character: Add this character and
   " reduce number of matches
   call feedkeys("aJu\<f5>\<c-p>l\<c-n>\<c-y>", 'tx')
@@ -96,7 +96,7 @@ func Test_popup_complete()
   call feedkeys("aJ\<f5>".repeat("\<c-n>",3)."\<c-l>\<esc>", 'tx')
   call assert_equal(["J"], getline(1,2))
   %d
-  
+
   " <c-l> - Insert one character from the current match
   call feedkeys("aJ\<f5>".repeat("\<c-n>",4)."\<c-l>\<esc>", 'tx')
   call assert_equal(["January"], getline(1,2))
@@ -857,7 +857,7 @@ func Test_popup_position()
   call term_sendkeys(buf, "jI123456789_\<Esc>")
   call term_sendkeys(buf, "GA\<C-N>")
   call VerifyScreenDump(buf, 'Test_popup_position_04', {'rows': 10})
-  
+
   call term_sendkeys(buf, "\<Esc>u")
   call StopVimInTerminal(buf)
   call delete('Xtest')

--- a/test/old/testdir/test_quickfix.vim
+++ b/test/old/testdir/test_quickfix.vim
@@ -1020,52 +1020,50 @@ endfunc
 
 " More tests for 'errorformat'
 func Test_efm1()
-    if !has('unix')
-	" The 'errorformat' setting is different on non-Unix systems.
-	" This test works only on Unix-like systems.
-	return
-    endif
+  " The 'errorformat' setting is different on non-Unix systems.
+  " This test works only on Unix-like systems.
+  CheckUnix
 
-    let l =<< trim [DATA]
-      "Xtestfile", line 4.12: 1506-045 (S) Undeclared identifier fd_set.
-      ﻿"Xtestfile", line 6 col 19; this is an error
-      gcc -c -DHAVE_CONFIsing-prototypes -I/usr/X11R6/include  version.c
-      Xtestfile:9: parse error before `asd'
-      make: *** [src/vim/testdir/Makefile:100: test_quickfix] Error 1
-      in file "Xtestfile" linenr 10: there is an error
+  let l =<< trim [DATA]
+    "Xtestfile", line 4.12: 1506-045 (S) Undeclared identifier fd_set.
+    ﻿"Xtestfile", line 6 col 19; this is an error
+    gcc -c -DHAVE_CONFIsing-prototypes -I/usr/X11R6/include  version.c
+    Xtestfile:9: parse error before `asd'
+    make: *** [src/vim/testdir/Makefile:100: test_quickfix] Error 1
+    in file "Xtestfile" linenr 10: there is an error
 
-      2 returned
-      "Xtestfile", line 11 col 1; this is an error
-      "Xtestfile", line 12 col 2; this is another error
-      "Xtestfile", line 14:10; this is an error in column 10
-      =Xtestfile=, line 15:10; this is another error, but in vcol 10 this time
-      "Xtestfile", linenr 16: yet another problem
-      Error in "Xtestfile" at line 17:
-      x should be a dot
-      	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx    line 17
-                  ^
-      Error in "Xtestfile" at line 18:
-      x should be a dot
-      	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx    line 18
-      .............^
-      Error in "Xtestfile" at line 19:
-      x should be a dot
-      	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx    line 19
-      --------------^
-      Error in "Xtestfile" at line 20:
-      x should be a dot
-      	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx    line 20
-      	       ^
+    2 returned
+    "Xtestfile", line 11 col 1; this is an error
+    "Xtestfile", line 12 col 2; this is another error
+    "Xtestfile", line 14:10; this is an error in column 10
+    =Xtestfile=, line 15:10; this is another error, but in vcol 10 this time
+    "Xtestfile", linenr 16: yet another problem
+    Error in "Xtestfile" at line 17:
+    x should be a dot
+	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx    line 17
+                ^
+    Error in "Xtestfile" at line 18:
+    x should be a dot
+	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx    line 18
+    .............^
+    Error in "Xtestfile" at line 19:
+    x should be a dot
+	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx    line 19
+    --------------^
+    Error in "Xtestfile" at line 20:
+    x should be a dot
+	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx    line 20
+	       ^
 
-      Does anyone know what is the problem and how to correction it?
-      "Xtestfile", line 21 col 9: What is the title of the quickfix window?
-      "Xtestfile", line 22 col 9: What is the title of the quickfix window?
-    [DATA]
+    Does anyone know what is the problem and how to correction it?
+    "Xtestfile", line 21 col 9: What is the title of the quickfix window?
+    "Xtestfile", line 22 col 9: What is the title of the quickfix window?
+  [DATA]
 
-    call writefile(l, 'Xerrorfile1')
-    call writefile(l[:-2], 'Xerrorfile2')
+  call writefile(l, 'Xerrorfile1')
+  call writefile(l[:-2], 'Xerrorfile2')
 
-    let m =<< [DATA]
+  let m =<< [DATA]
 	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx    line  2
 	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx    line  3
 	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx    line  4
@@ -1088,55 +1086,55 @@ func Test_efm1()
 	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx    line 21
 	xxxxxxxxxxxxxxxxxxxxxxxxxxxxxx    line 22
 [DATA]
-    call writefile(m, 'Xtestfile')
+  call writefile(m, 'Xtestfile')
 
-    let save_efm = &efm
-    set efm+==%f=\\,\ line\ %l%*\\D%v%*[^\ ]\ %m
-    set efm^=%AError\ in\ \"%f\"\ at\ line\ %l:,%Z%p^,%C%m
+  let save_efm = &efm
+  set efm+==%f=\\,\ line\ %l%*\\D%v%*[^\ ]\ %m
+  set efm^=%AError\ in\ \"%f\"\ at\ line\ %l:,%Z%p^,%C%m
 
-    exe 'cf Xerrorfile2'
-    clast
-    copen
-    call assert_equal(':cf Xerrorfile2', w:quickfix_title)
-    wincmd p
+  exe 'cf Xerrorfile2'
+  clast
+  copen
+  call assert_equal(':cf Xerrorfile2', w:quickfix_title)
+  wincmd p
 
-    exe 'cf Xerrorfile1'
-    call assert_equal([4, 12], [line('.'), col('.')])
-    cn
-    call assert_equal([6, 19], [line('.'), col('.')])
-    cn
-    call assert_equal([9, 2], [line('.'), col('.')])
-    cn
-    call assert_equal([10, 2], [line('.'), col('.')])
-    cn
-    call assert_equal([11, 1], [line('.'), col('.')])
-    cn
-    call assert_equal([12, 2], [line('.'), col('.')])
-    cn
-    call assert_equal([14, 10], [line('.'), col('.')])
-    cn
-    call assert_equal([15, 3, 10], [line('.'), col('.'), virtcol('.')])
-    cn
-    call assert_equal([16, 2], [line('.'), col('.')])
-    cn
-    call assert_equal([17, 6], [line('.'), col('.')])
-    cn
-    call assert_equal([18, 7], [line('.'), col('.')])
-    cn
-    call assert_equal([19, 8], [line('.'), col('.')])
-    cn
-    call assert_equal([20, 9], [line('.'), col('.')])
-    clast
-    cprev
-    cprev
-    wincmd w
-    call assert_equal(':cf Xerrorfile1', w:quickfix_title)
-    wincmd p
+  exe 'cf Xerrorfile1'
+  call assert_equal([4, 12], [line('.'), col('.')])
+  cn
+  call assert_equal([6, 19], [line('.'), col('.')])
+  cn
+  call assert_equal([9, 2], [line('.'), col('.')])
+  cn
+  call assert_equal([10, 2], [line('.'), col('.')])
+  cn
+  call assert_equal([11, 1], [line('.'), col('.')])
+  cn
+  call assert_equal([12, 2], [line('.'), col('.')])
+  cn
+  call assert_equal([14, 10], [line('.'), col('.')])
+  cn
+  call assert_equal([15, 3, 10], [line('.'), col('.'), virtcol('.')])
+  cn
+  call assert_equal([16, 2], [line('.'), col('.')])
+  cn
+  call assert_equal([17, 6], [line('.'), col('.')])
+  cn
+  call assert_equal([18, 7], [line('.'), col('.')])
+  cn
+  call assert_equal([19, 8], [line('.'), col('.')])
+  cn
+  call assert_equal([20, 9], [line('.'), col('.')])
+  clast
+  cprev
+  cprev
+  wincmd w
+  call assert_equal(':cf Xerrorfile1', w:quickfix_title)
+  wincmd p
 
-    let &efm = save_efm
-    call delete('Xerrorfile1')
-    call delete('Xerrorfile2')
-    call delete('Xtestfile')
+  let &efm = save_efm
+  call delete('Xerrorfile1')
+  call delete('Xerrorfile2')
+  call delete('Xtestfile')
 endfunc
 
 " Test for quickfix directory stack support
@@ -1410,7 +1408,7 @@ func Test_efm2()
      failUnlessEqual
         raise self.failureException, \\
     W:AssertionError: 34 != 33
-  
+
     --------------------------------------------------------------
     Ran 27 tests in 0.063s
   [DATA]

--- a/test/old/testdir/test_regexp_latin.vim
+++ b/test/old/testdir/test_regexp_latin.vim
@@ -1164,7 +1164,7 @@ func Test_compare_column_matchstr()
   " matchstr().
   enew
   call setline(1, ['one', 'two', 'three'])
-  :3 
+  :3
   :/ee
   bwipe!
   set re=1

--- a/test/old/testdir/test_scriptnames.vim
+++ b/test/old/testdir/test_scriptnames.vim
@@ -1,7 +1,7 @@
 
 " Test for the :scriptnames command
 func Test_scriptnames()
-  call writefile(['let did_load_script = 123'], 'Xscripting')
+  call writefile(['let did_load_script = 123'], 'Xscripting', 'D')
   source Xscripting
   call assert_equal(123, g:did_load_script)
 
@@ -22,7 +22,6 @@ func Test_scriptnames()
   call assert_equal('Xscripting', expand('%:t'))
 
   bwipe
-  call delete('Xscripting')
 
   let msgs = execute('messages')
   scriptnames
@@ -47,7 +46,7 @@ func Test_getscriptinfo()
     " def Xscript_def_func2()
     " enddef
   END
-  call writefile(lines, 'X22script91')
+  call writefile(lines, 'X22script91', 'D')
   source X22script91
   let l = getscriptinfo()
   call assert_match('X22script91$', l[-1].name)
@@ -103,8 +102,6 @@ func Test_getscriptinfo()
 
   let max_sid = max(map(getscriptinfo(), { k, v -> v.sid }))
   call assert_equal([], getscriptinfo({'sid': max_sid + 1}))
-
-  call delete('X22script91')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -369,18 +369,18 @@ func Test_smoothscroll_wrap_long_line()
   call term_sendkeys(buf, ":set scrolloff=1\<CR>")
   call term_sendkeys(buf, "10|\<C-E>")
   call VerifyScreenDump(buf, 'Test_smooth_long_6', {})
-  
+
   " 'scrolloff' set to 1, scrolling down, cursor moves screen line up
   call term_sendkeys(buf, "\<C-E>")
   call term_sendkeys(buf, "gjgj")
   call term_sendkeys(buf, "\<C-Y>")
   call VerifyScreenDump(buf, 'Test_smooth_long_7', {})
-  
+
   " 'scrolloff' set to 2, scrolling up, cursor moves screen line down
   call term_sendkeys(buf, ":set scrolloff=2\<CR>")
   call term_sendkeys(buf, "10|\<C-E>")
   call VerifyScreenDump(buf, 'Test_smooth_long_8', {})
-  
+
   " 'scrolloff' set to 2, scrolling down, cursor moves screen line up
   call term_sendkeys(buf, "\<C-E>")
   call term_sendkeys(buf, "gj")
@@ -421,7 +421,7 @@ func Test_smoothscroll_wrap_long_line()
   call term_sendkeys(buf, "3Gzt")
   call term_sendkeys(buf, "\<C-E>j")
   call VerifyScreenDump(buf, 'Test_smooth_long_16', {})
-  
+
   call StopVimInTerminal(buf)
 endfunc
 
@@ -436,7 +436,7 @@ func Test_smoothscroll_one_long_line()
   call writefile(lines, 'XSmoothOneLong', 'D')
   let buf = RunVimInTerminal('-S XSmoothOneLong', #{rows: 6, cols: 40})
   call VerifyScreenDump(buf, 'Test_smooth_one_long_1', {})
-  
+
   call term_sendkeys(buf, "\<C-E>")
   call VerifyScreenDump(buf, 'Test_smooth_one_long_2', {})
 
@@ -458,7 +458,7 @@ func Test_smoothscroll_long_line_showbreak()
   call writefile(lines, 'XSmoothLongShowbreak', 'D')
   let buf = RunVimInTerminal('-S XSmoothLongShowbreak', #{rows: 6, cols: 40})
   call VerifyScreenDump(buf, 'Test_smooth_long_showbreak_1', {})
-  
+
   call term_sendkeys(buf, "\<C-E>")
   call VerifyScreenDump(buf, 'Test_smooth_long_showbreak_2', {})
 
@@ -648,7 +648,7 @@ func Test_smoothscroll_cursor_scrolloff()
   call NewWindow(10, 20)
   setl smoothscroll wrap
   setl scrolloff=3
-  
+
   " 120 chars are 6 screen lines
   call setline(1, "abcdefghijklmnopqrstABCDEFGHIJKLMNOPQRSTabcdefghijklmnopqrstABCDEFGHIJKLMNOPQRSTabcdefghijklmnopqrstABCDEFGHIJKLMNOPQRST")
   call setline(2, "below")

--- a/test/old/testdir/test_search.vim
+++ b/test/old/testdir/test_search.vim
@@ -674,7 +674,7 @@ func Test_search_cmdline8()
   endif
   " Prepare buffer text
   let lines = ['abb vim vim vi', 'vimvivim']
-  call writefile(lines, 'Xsearch.txt')
+  call writefile(lines, 'Xsearch.txt', 'D')
   let buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile', 'Xsearch.txt'], {'term_rows': 3})
 
   call WaitForAssert({-> assert_equal(lines, [term_getline(buf, 1), term_getline(buf, 2)])})
@@ -693,9 +693,8 @@ func Test_search_cmdline8()
   call assert_notequal(a1, a2)
   call assert_equal(a0, a2)
   call assert_equal(a1, a3)
-  " clean up
-  call delete('Xsearch.txt')
 
+  " clean up
   bwipe!
 endfunc
 
@@ -810,7 +809,7 @@ func Test_search_cmdline_incsearch_highlight_attr()
 
   " Prepare buffer text
   let lines = ['abb vim vim vi', 'vimvivim']
-  call writefile(lines, 'Xsearch.txt')
+  call writefile(lines, 'Xsearch.txt', 'D')
   let buf = term_start([GetVimProg(), '--clean', '-c', 'set noswapfile', 'Xsearch.txt'], {'term_rows': 3})
 
   call WaitForAssert({-> assert_equal(lines, [term_getline(buf, 1), term_getline(buf, 2)])})
@@ -879,9 +878,7 @@ func Test_search_cmdline_incsearch_highlight_attr()
   let attr_line2 = [a0,a0,a0,a0,a0,a0,a0,a0]
   call assert_equal(attr_line1, map(term_scrape(buf, 1)[:len(attr_line1)-1], 'v:val.attr'))
   call assert_equal(attr_line2, map(term_scrape(buf, 2)[:len(attr_line2)-1], 'v:val.attr'))
-  call delete('Xsearch.txt')
 
-  call delete('Xsearch.txt')
   bwipe!
 endfunc
 
@@ -908,7 +905,7 @@ func Test_incsearch_scrolling()
 	\ 'call setline(1, [dots, dots, dots, "", "target", dots, dots])',
 	\ 'normal gg',
 	\ 'redraw',
-	\ ], 'Xscript')
+	\ ], 'Xscript', 'D')
   let buf = RunVimInTerminal('-S Xscript', {'rows': 9, 'cols': 70})
   " Need to send one key at a time to force a redraw
   call term_sendkeys(buf, '/')
@@ -924,7 +921,6 @@ func Test_incsearch_scrolling()
 
   call term_sendkeys(buf, "\<Esc>")
   call StopVimInTerminal(buf)
-  call delete('Xscript')
 endfunc
 
 func Test_incsearch_search_dump()
@@ -937,7 +933,7 @@ func Test_incsearch_search_dump()
 	\ '  call setline(n, "foo " . n)',
 	\ 'endfor',
 	\ '3',
-	\ ], 'Xis_search_script')
+	\ ], 'Xis_search_script', 'D')
   let buf = RunVimInTerminal('-S Xis_search_script', {'rows': 9, 'cols': 70})
   " Give Vim a chance to redraw to get rid of the spaces in line 2 caused by
   " the 'ambiwidth' check.
@@ -954,7 +950,6 @@ func Test_incsearch_search_dump()
   call term_sendkeys(buf, "\<Esc>")
 
   call StopVimInTerminal(buf)
-  call delete('Xis_search_script')
 endfunc
 
 func Test_hlsearch_dump()
@@ -966,7 +961,7 @@ func Test_hlsearch_dump()
         \ 'call setline(1, ["xxx", "xxx", "xxx"])',
 	\ '/.*',
 	\ '2',
-	\ ], 'Xhlsearch_script')
+	\ ], 'Xhlsearch_script', 'D')
   let buf = RunVimInTerminal('-S Xhlsearch_script', {'rows': 6, 'cols': 50})
   call VerifyScreenDump(buf, 'Test_hlsearch_1', {})
 
@@ -974,7 +969,6 @@ func Test_hlsearch_dump()
   call VerifyScreenDump(buf, 'Test_hlsearch_2', {})
 
   call StopVimInTerminal(buf)
-  call delete('Xhlsearch_script')
 endfunc
 
 func Test_hlsearch_and_visual()
@@ -987,14 +981,13 @@ func Test_hlsearch_and_visual()
         \ 'hi Search cterm=bold',
 	\ '/yyy',
 	\ 'call cursor(1, 6)',
-	\ ], 'Xhlvisual_script')
+	\ ], 'Xhlvisual_script', 'D')
   let buf = RunVimInTerminal('-S Xhlvisual_script', {'rows': 6, 'cols': 40})
   call term_sendkeys(buf, "vjj")
   call VerifyScreenDump(buf, 'Test_hlsearch_visual_1', {})
   call term_sendkeys(buf, "\<Esc>")
 
   call StopVimInTerminal(buf)
-  call delete('Xhlvisual_script')
 endfunc
 
 func Test_hlsearch_block_visual_match()
@@ -1004,7 +997,7 @@ func Test_hlsearch_block_visual_match()
     set hlsearch
     call setline(1, ['aa', 'bbbb', 'cccccc'])
   END
-  call writefile(lines, 'Xhlsearch_block')
+  call writefile(lines, 'Xhlsearch_block', 'D')
   let buf = RunVimInTerminal('-S Xhlsearch_block', {'rows': 9, 'cols': 60})
 
   call term_sendkeys(buf, "G\<C-V>$kk\<Esc>")
@@ -1014,7 +1007,6 @@ func Test_hlsearch_block_visual_match()
   call VerifyScreenDump(buf, 'Test_hlsearch_block_visual_match', {})
 
   call StopVimInTerminal(buf)
-  call delete('Xhlsearch_block')
 endfunc
 
 func Test_incsearch_substitute()
@@ -1062,7 +1054,7 @@ func Test_hlsearch_cursearch()
     hi Search ctermbg=yellow
     hi CurSearch ctermbg=blue
   END
-  call writefile(lines, 'Xhlsearch_cursearch')
+  call writefile(lines, 'Xhlsearch_cursearch', 'D')
   let buf = RunVimInTerminal('-S Xhlsearch_cursearch', {'rows': 9, 'cols': 60})
 
   call term_sendkeys(buf, "gg/foo\<CR>")
@@ -1100,7 +1092,6 @@ func Test_hlsearch_cursearch()
   call VerifyScreenDump(buf, 'Test_hlsearch_cursearch_changed_1', {})
 
   call StopVimInTerminal(buf)
-  call delete('Xhlsearch_cursearch')
 endfunc
 
 " Similar to Test_incsearch_substitute() but with a screendump halfway.
@@ -1115,7 +1106,7 @@ func Test_incsearch_substitute_dump()
 	\ 'endfor',
 	\ 'call setline(11, "bar 11")',
 	\ '3',
-	\ ], 'Xis_subst_script')
+	\ ], 'Xis_subst_script', 'D')
   let buf = RunVimInTerminal('-S Xis_subst_script', {'rows': 9, 'cols': 70})
   " Give Vim a chance to redraw to get rid of the spaces in line 2 caused by
   " the 'ambiwidth' check.
@@ -1210,7 +1201,6 @@ func Test_incsearch_substitute_dump()
   call term_sendkeys(buf, "<Esc>")
 
   call StopVimInTerminal(buf)
-  call delete('Xis_subst_script')
 endfunc
 
 func Test_incsearch_highlighting()
@@ -1220,7 +1210,7 @@ func Test_incsearch_highlighting()
   call writefile([
 	\ 'set incsearch hlsearch',
 	\ 'call setline(1, "hello/there")',
-	\ ], 'Xis_subst_hl_script')
+	\ ], 'Xis_subst_hl_script', 'D')
   let buf = RunVimInTerminal('-S Xis_subst_hl_script', {'rows': 4, 'cols': 20})
   " Give Vim a chance to redraw to get rid of the spaces in line 2 caused by
   " the 'ambiwidth' check.
@@ -1233,7 +1223,6 @@ func Test_incsearch_highlighting()
   call term_sendkeys(buf, "<Esc>")
 
   call StopVimInTerminal(buf)
-  call delete('Xis_subst_hl_script')
 endfunc
 
 func Test_incsearch_with_change()
@@ -1245,7 +1234,7 @@ func Test_incsearch_with_change()
 	\ 'set incsearch hlsearch scrolloff=0',
 	\ 'call setline(1, ["one", "two ------ X", "three"])',
 	\ 'call timer_start(200, { _ -> setline(2, "x")})',
-	\ ], 'Xis_change_script')
+	\ ], 'Xis_change_script', 'D')
   let buf = RunVimInTerminal('-S Xis_change_script', {'rows': 9, 'cols': 70})
   " Give Vim a chance to redraw to get rid of the spaces in line 2 caused by
   " the 'ambiwidth' check.
@@ -1257,7 +1246,6 @@ func Test_incsearch_with_change()
   call term_sendkeys(buf, "\<Esc>")
 
   call StopVimInTerminal(buf)
-  call delete('Xis_change_script')
 endfunc
 
 " Similar to Test_incsearch_substitute_dump() for :sort
@@ -1268,7 +1256,7 @@ func Test_incsearch_sort_dump()
   call writefile([
 	\ 'set incsearch hlsearch scrolloff=0',
 	\ 'call setline(1, ["another one 2", "that one 3", "the one 1"])',
-	\ ], 'Xis_sort_script')
+	\ ], 'Xis_sort_script', 'D')
   let buf = RunVimInTerminal('-S Xis_sort_script', {'rows': 9, 'cols': 70})
   " Give Vim a chance to redraw to get rid of the spaces in line 2 caused by
   " the 'ambiwidth' check.
@@ -1283,7 +1271,6 @@ func Test_incsearch_sort_dump()
   call term_sendkeys(buf, "\<Esc>")
 
   call StopVimInTerminal(buf)
-  call delete('Xis_sort_script')
 endfunc
 
 " Similar to Test_incsearch_substitute_dump() for :vimgrep famiry
@@ -1294,7 +1281,7 @@ func Test_incsearch_vimgrep_dump()
   call writefile([
 	\ 'set incsearch hlsearch scrolloff=0',
 	\ 'call setline(1, ["another one 2", "that one 3", "the one 1"])',
-	\ ], 'Xis_vimgrep_script')
+	\ ], 'Xis_vimgrep_script', 'D')
   let buf = RunVimInTerminal('-S Xis_vimgrep_script', {'rows': 9, 'cols': 70})
   " Give Vim a chance to redraw to get rid of the spaces in line 2 caused by
   " the 'ambiwidth' check.
@@ -1322,7 +1309,6 @@ func Test_incsearch_vimgrep_dump()
   call term_sendkeys(buf, "\<Esc>")
 
   call StopVimInTerminal(buf)
-  call delete('Xis_vimgrep_script')
 endfunc
 
 func Test_keep_last_search_pattern()
@@ -1465,11 +1451,9 @@ endfunc
 func Test_no_last_substitute_pat()
   " Use viminfo to set the last search pattern to a string and make the last
   " substitute pattern the most recent used and make it empty (NULL).
-  call writefile(['~MSle0/bar', '~MSle0~&'], 'Xviminfo')
+  call writefile(['~MSle0/bar', '~MSle0~&'], 'Xviminfo', 'D')
   rviminfo! Xviminfo
   call assert_fails('normal n', 'E35:')
-
-  call delete('Xviminfo')
 endfunc
 
 func Test_search_Ctrl_L_combining()
@@ -1676,12 +1660,11 @@ func Test_search_with_no_last_pat()
     call writefile(v:errors, 'Xresult')
     qall!
   [SCRIPT]
-  call writefile(lines, 'Xscript')
+  call writefile(lines, 'Xscript', 'D')
 
   if RunVim([], [], '--clean -S Xscript')
     call assert_equal([], readfile('Xresult'))
   endif
-  call delete('Xscript')
   call delete('Xresult')
 endfunc
 
@@ -1699,11 +1682,10 @@ func Test_search_tilde_pat()
     call writefile(v:errors, 'Xresult')
     qall!
   [SCRIPT]
-  call writefile(lines, 'Xscript')
+  call writefile(lines, 'Xscript', 'D')
   if RunVim([], [], '--clean -S Xscript')
     call assert_equal([], readfile('Xresult'))
   endif
-  call delete('Xscript')
   call delete('Xresult')
 endfunc
 
@@ -1971,7 +1953,7 @@ func Test_incsearch_highlighting_newline()
     set incsearch nohls
     call setline(1, ['test', 'xxx'])
   [CODE]
-  call writefile(commands, 'Xincsearch_nl')
+  call writefile(commands, 'Xincsearch_nl', 'D')
   let buf = RunVimInTerminal('-S Xincsearch_nl', {'rows': 5, 'cols': 10})
   call term_sendkeys(buf, '/test')
   call VerifyScreenDump(buf, 'Test_incsearch_newline1', {})
@@ -1987,7 +1969,6 @@ func Test_incsearch_highlighting_newline()
   call StopVimInTerminal(buf)
 
   " clean up
-  call delete('Xincsearch_nl')
   call test_override("char_avail", 0)
   bw
 endfunc
@@ -2128,11 +2109,10 @@ func Test_search_with_invalid_range()
     5/
     c
   END
-  call writefile(lines, 'Xrangesearch')
+  call writefile(lines, 'Xrangesearch', 'D')
   source Xrangesearch
 
   bwipe!
-  call delete('Xrangesearch')
 endfunc
 
 

--- a/test/old/testdir/test_search_stat.vim
+++ b/test/old/testdir/test_search_stat.vim
@@ -308,7 +308,7 @@ func Test_searchcount_in_statusline()
     set hlsearch
     set laststatus=2 statusline+=%{TestSearchCount()}
   END
-  call writefile(lines, 'Xsearchstatusline')
+  call writefile(lines, 'Xsearchstatusline', 'D')
   let buf = RunVimInTerminal('-S Xsearchstatusline', #{rows: 10})
   call TermWait(buf)
   call term_sendkeys(buf, "/something")
@@ -316,7 +316,6 @@ func Test_searchcount_in_statusline()
 
   call term_sendkeys(buf, "\<Esc>")
   call StopVimInTerminal(buf)
-  call delete('Xsearchstatusline')
 endfunc
 
 func Test_search_stat_foldopen()
@@ -330,7 +329,7 @@ func Test_search_stat_foldopen()
     call cursor(1,1)
     norm n
   END
-  call writefile(lines, 'Xsearchstat1')
+  call writefile(lines, 'Xsearchstat1', 'D')
 
   let buf = RunVimInTerminal('-S Xsearchstat1', #{rows: 10})
   call VerifyScreenDump(buf, 'Test_searchstat_3', {})
@@ -342,7 +341,6 @@ func Test_search_stat_foldopen()
   call VerifyScreenDump(buf, 'Test_searchstat_3', {})
 
   call StopVimInTerminal(buf)
-  call delete('Xsearchstat1')
 endfunc
 
 func! Test_search_stat_screendump()
@@ -359,7 +357,7 @@ func! Test_search_stat_screendump()
     call cursor(1,1)
     norm n
   END
-  call writefile(lines, 'Xsearchstat')
+  call writefile(lines, 'Xsearchstat', 'D')
   let buf = RunVimInTerminal('-S Xsearchstat', #{rows: 10})
   call VerifyScreenDump(buf, 'Test_searchstat_1', {})
 
@@ -368,7 +366,6 @@ func! Test_search_stat_screendump()
   call VerifyScreenDump(buf, 'Test_searchstat_2', {})
 
   call StopVimInTerminal(buf)
-  call delete('Xsearchstat')
 endfunc
 
 func Test_search_stat_then_gd()
@@ -379,7 +376,7 @@ func Test_search_stat_then_gd()
     set shortmess-=S
     set hlsearch
   END
-  call writefile(lines, 'Xsearchstatgd')
+  call writefile(lines, 'Xsearchstatgd', 'D')
 
   let buf = RunVimInTerminal('-S Xsearchstatgd', #{rows: 10})
   call term_sendkeys(buf, "/dog\<CR>")
@@ -389,7 +386,6 @@ func Test_search_stat_then_gd()
   call VerifyScreenDump(buf, 'Test_searchstatgd_2', {})
 
   call StopVimInTerminal(buf)
-  call delete('Xsearchstatgd')
 endfunc
 
 func Test_search_stat_and_incsearch()

--- a/test/old/testdir/test_shell.vim
+++ b/test/old/testdir/test_shell.vim
@@ -188,7 +188,7 @@ func Test_shellxquote()
   let save_sxq = &shellxquote
   let save_sxe = &shellxescape
 
-  call writefile(['#!/bin/sh', 'echo "Cmd: [$*]" > Xlog'], 'Xtestshell')
+  call writefile(['#!/bin/sh', 'echo "Cmd: [$*]" > Xlog'], 'Xtestshell', 'D')
   call setfperm('Xtestshell', "r-x------")
   set shell=./Xtestshell
 
@@ -212,7 +212,6 @@ func Test_shellxquote()
   let &shell = save_shell
   let &shellxquote = save_sxq
   let &shellxescape = save_sxe
-  call delete('Xtestshell')
   call delete('Xlog')
 endfunc
 

--- a/test/old/testdir/test_signals.vim
+++ b/test/old/testdir/test_signals.vim
@@ -118,7 +118,7 @@ func Test_signal_TSTP()
     au VimSuspend * call writefile(["VimSuspend triggered"], "XautoOut1", "as")
     au VimResume * call writefile(["VimResume triggered"], "XautoOut2", "as")
   END
-  call writefile(lines, 'XsetupAucmd')
+  call writefile(lines, 'XsetupAucmd', 'D')
 
   let buf = RunVimInTerminal('-S XsetupAucmd Xsig_TERM', {'rows': 6})
   let pid_vim = term_getjob(buf)->job_info().process
@@ -148,7 +148,6 @@ func Test_signal_TSTP()
 
   %bwipe!
   call delete('.Xsig_TERM.swp')
-  call delete('XsetupAucmd')
   call delete('XautoOut1')
   call delete('XautoOut2')
 endfunc
@@ -177,7 +176,7 @@ func Test_deadly_signal_TERM()
     au VimLeave * call writefile(["VimLeave triggered"], "XautoOut", "as")
     au VimLeavePre * call writefile(["VimLeavePre triggered"], "XautoOut", "as")
   END
-  call writefile(lines, 'XsetupAucmd')
+  call writefile(lines, 'XsetupAucmd', 'D')
 
   let buf = RunVimInTerminal('-S XsetupAucmd Xsig_TERM', {'rows': 6})
   let pid_vim = term_getjob(buf)->job_info().process
@@ -201,7 +200,6 @@ func Test_deadly_signal_TERM()
 
   %bwipe!
   call delete('.Xsig_TERM.swp')
-  call delete('XsetupAucmd')
   call delete('XautoOut')
 endfunc
 

--- a/test/old/testdir/test_signals.vim
+++ b/test/old/testdir/test_signals.vim
@@ -134,7 +134,7 @@ func Test_signal_TSTP()
   sleep 100m
 
   " We resume after the suspend.  Sleep a bit for the signal to take effect,
-  " also when running under valgrind. 
+  " also when running under valgrind.
   exe 'silent !kill -s CONT ' .. pid_vim
   call WaitForAssert({-> assert_true(filereadable('XautoOut2'))})
   sleep 10m

--- a/test/old/testdir/test_signs.vim
+++ b/test/old/testdir/test_signs.vim
@@ -1808,10 +1808,10 @@ func Test_sign_cursor_position()
   let lines =<< trim END
 	call setline(1, [repeat('x', 75), 'mmmm', 'yyyy'])
 	call cursor(2,1)
-   	sign define s1 texthl=Search text==>
-   	sign define s2 linehl=Pmenu
+	sign define s1 texthl=Search text==>
+	sign define s2 linehl=Pmenu
 	redraw
-   	sign place 10 line=2 name=s1
+	sign place 10 line=2 name=s1
   END
   call writefile(lines, 'XtestSigncolumn', 'D')
   let buf = RunVimInTerminal('-S XtestSigncolumn', {'rows': 6})

--- a/test/old/testdir/test_signs.vim
+++ b/test/old/testdir/test_signs.vim
@@ -254,8 +254,8 @@ func Test_sign_completion()
                 \ 'SpellLocal SpellRare', @:)
   endfor
 
-  call writefile(repeat(["Sun is shining"], 30), "XsignOne")
-  call writefile(repeat(["Sky is blue"], 30), "XsignTwo")
+  call writefile(repeat(["Sun is shining"], 30), "XsignOne", 'D')
+  call writefile(repeat(["Sky is blue"], 30), "XsignTwo", 'D')
   call feedkeys(":sign define Sign icon=Xsig\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"sign define Sign icon=XsignOne XsignTwo', @:)
 
@@ -332,8 +332,6 @@ func Test_sign_completion()
   sign undefine Sign1
   sign undefine Sign2
   enew
-  call delete('XsignOne')
-  call delete('XsignTwo')
 endfunc
 
 func Test_sign_invalid_commands()
@@ -476,7 +474,7 @@ func Test_sign_funcs()
   call assert_fails('call sign_getdefined({})', 'E731:')
 
   " Tests for sign_place()
-  call writefile(repeat(["Sun is shining"], 30), "Xsign")
+  call writefile(repeat(["Sun is shining"], 30), "Xsign", 'D')
   edit Xsign
 
   call assert_equal(10, sign_place(10, '', 'sign1', 'Xsign',
@@ -582,7 +580,6 @@ func Test_sign_funcs()
 	      \ 'priority' : 10}]}],
 	      \ sign_getplaced('%', {'lnum' : 22}))
 
-  call delete("Xsign")
   call sign_unplace('*')
   call sign_undefine()
   enew | only
@@ -595,7 +592,7 @@ func Test_sign_group()
   call sign_unplace('*')
   call sign_undefine()
 
-  call writefile(repeat(["Sun is shining"], 30), "Xsign")
+  call writefile(repeat(["Sun is shining"], 30), "Xsign", 'D')
 
   let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Error'}
   call assert_equal(0, sign_define("sign1", attr))
@@ -836,7 +833,6 @@ func Test_sign_group()
   " Error cases
   call assert_fails("sign place 3 group= name=sign1 buffer=" . bnum, 'E474:')
 
-  call delete("Xsign")
   call sign_unplace('*')
   call sign_undefine()
   enew | only
@@ -879,8 +875,8 @@ func Test_sign_unplace()
   call sign_undefine()
 
   " Create two files and define signs
-  call writefile(repeat(["Sun is shining"], 30), "Xsign1")
-  call writefile(repeat(["It is beautiful"], 30), "Xsign2")
+  call writefile(repeat(["Sun is shining"], 30), "Xsign1", 'D')
+  call writefile(repeat(["It is beautiful"], 30), "Xsign2", 'D')
 
   let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Error'}
   call sign_define("sign1", attr)
@@ -1189,8 +1185,6 @@ func Test_sign_unplace()
   call sign_unplace('*')
   call sign_undefine()
   enew | only
-  call delete("Xsign1")
-  call delete("Xsign2")
 endfunc
 
 " Tests for auto-generating the sign identifier.
@@ -1202,7 +1196,7 @@ func Test_aaa_sign_id_autogen()
   let attr = {'text' : '=>', 'linehl' : 'Search', 'texthl' : 'Error'}
   call assert_equal(0, sign_define("sign1", attr))
 
-  call writefile(repeat(["Sun is shining"], 30), "Xsign")
+  call writefile(repeat(["Sun is shining"], 30), "Xsign", 'D')
   edit Xsign
 
   call assert_equal(1, sign_place(0, '', 'sign1', 'Xsign',
@@ -1224,7 +1218,6 @@ func Test_aaa_sign_id_autogen()
   call assert_equal(10,
 	      \ sign_getplaced('Xsign', {'id' : 1})[0].signs[0].lnum)
 
-  call delete("Xsign")
   call sign_unplace('*')
   call sign_undefine()
   enew | only
@@ -1820,7 +1813,7 @@ func Test_sign_cursor_position()
 	redraw
    	sign place 10 line=2 name=s1
   END
-  call writefile(lines, 'XtestSigncolumn')
+  call writefile(lines, 'XtestSigncolumn', 'D')
   let buf = RunVimInTerminal('-S XtestSigncolumn', {'rows': 6})
   call VerifyScreenDump(buf, 'Test_sign_cursor_1', {})
 
@@ -1840,7 +1833,6 @@ func Test_sign_cursor_position()
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete('XtestSigncolumn')
 endfunc
 
 " Return the 'len' characters in screen starting from (row,col)
@@ -1959,7 +1951,7 @@ endfunc
 
 " Test for managing multiple signs using the sign functions
 func Test_sign_funcs_multi()
-  call writefile(repeat(["Sun is shining"], 30), "Xsign")
+  call writefile(repeat(["Sun is shining"], 30), "Xsign", 'D')
   edit Xsign
   let bnum = bufnr('')
 
@@ -2072,7 +2064,6 @@ func Test_sign_funcs_multi()
   call sign_unplace('*')
   call sign_undefine()
   enew!
-  call delete("Xsign")
 endfunc
 
 func Test_sign_null_list()

--- a/test/old/testdir/test_sort.vim
+++ b/test/old/testdir/test_sort.vim
@@ -1525,11 +1525,10 @@ func Test_sort_with_no_last_search_pat()
     call writefile(v:errors, 'Xresult')
     qall!
   [SCRIPT]
-  call writefile(lines, 'Xscript')
+  call writefile(lines, 'Xscript', 'D')
   if RunVim([], [], '--clean -S Xscript')
     call assert_equal([], readfile('Xresult'))
   endif
-  call delete('Xscript')
   call delete('Xresult')
 endfunc
 

--- a/test/old/testdir/test_source.vim
+++ b/test/old/testdir/test_source.vim
@@ -53,12 +53,10 @@ endfunc
 " When deleting a file and immediately creating a new one the inode may be
 " recycled.  Vim should not recognize it as the same script.
 func Test_different_script()
-  call writefile(['let s:var = "asdf"'], 'XoneScript')
+  call writefile(['let s:var = "asdf"'], 'XoneScript', 'D')
   source XoneScript
-  call delete('XoneScript')
-  call writefile(['let g:var = s:var'], 'XtwoScript')
+  call writefile(['let g:var = s:var'], 'XtwoScript', 'D')
   call assert_fails('source XtwoScript', 'E121:')
-  call delete('XtwoScript')
 endfunc
 
 " When sourcing a vim script, shebang should be ignored.

--- a/test/old/testdir/test_source_utf8.vim
+++ b/test/old/testdir/test_source_utf8.vim
@@ -42,7 +42,7 @@ func Test_source_ctrl_v()
         \ "map __3 asd\<C-V>\<C-V>",
         \ "map __4 asd\<C-V>\<C-V>\<C-V>",
         \ "map __5 asd\<C-V>\<C-V>\<C-V>",
-        \ ], 'Xtestfile')
+        \ ], 'Xtestfile', 'D')
   source Xtestfile
   enew!
   exe "normal __1\<Esc>\<Esc>__2\<Esc>__3\<Esc>\<Esc>__4\<Esc>__5\<Esc>"
@@ -52,7 +52,6 @@ func Test_source_ctrl_v()
         \ getline(1, 2))
 
   enew!
-  call delete('Xtestfile')
   unmap __1
   unmap __2
   unmap __3

--- a/test/old/testdir/test_spell.vim
+++ b/test/old/testdir/test_spell.vim
@@ -812,8 +812,8 @@ func Test_zz_sal_and_addition()
   throw 'skipped: Nvim does not support enc=latin1'
   set enc=latin1
   set spellfile=
-  call writefile(g:test_data_dic1, "Xtest.dic")
-  call writefile(g:test_data_aff_sal, "Xtest.aff")
+  call writefile(g:test_data_dic1, "Xtest.dic", 'D')
+  call writefile(g:test_data_aff_sal, "Xtest.aff", 'D')
   mkspell! Xtest Xtest
   set spl=Xtest.latin1.spl spell
   call assert_equal('kbltykk', soundfold('goobledygoook'))
@@ -821,7 +821,7 @@ func Test_zz_sal_and_addition()
   call assert_equal('*fls kswts tl', soundfold('oeverloos gezwets edale'))
 
   "also use an addition file
-  call writefile(["/regions=usgbnz", "elequint/2", "elekwint/3"], "Xtest.latin1.add")
+  call writefile(["/regions=usgbnz", "elequint/2", "elekwint/3"], "Xtest.latin1.add", 'D')
   mkspell! Xtest.latin1.add.spl Xtest.latin1.add
 
   bwipe!
@@ -858,10 +858,9 @@ endfunc
 
 func Test_region_error()
   messages clear
-  call writefile(["/regions=usgbnz", "elequint/0"], "Xtest.latin1.add")
+  call writefile(["/regions=usgbnz", "elequint/0"], "Xtest.latin1.add", 'D')
   mkspell! Xtest.latin1.add.spl Xtest.latin1.add
   call assert_match('Invalid region nr in Xtest.latin1.add line 2: 0', execute('messages'))
-  call delete('Xtest.latin1.add')
   call delete('Xtest.latin1.add.spl')
 endfunc
 

--- a/test/old/testdir/test_spell_utf8.vim
+++ b/test/old/testdir/test_spell_utf8.vim
@@ -726,8 +726,8 @@ endfunc
 " Test with SAL instead of SOFO items; test automatic reloading
 func Test_spell_sal_and_addition()
   set spellfile=
-  call writefile(g:test_data_dic1, "Xtest.dic")
-  call writefile(g:test_data_aff_sal, "Xtest.aff")
+  call writefile(g:test_data_dic1, "Xtest.dic", 'D')
+  call writefile(g:test_data_aff_sal, "Xtest.aff", 'D')
   mkspell! Xtest Xtest
   set spl=Xtest.utf-8.spl spell
   call assert_equal('kbltykk', soundfold('goobledygoook'))
@@ -735,7 +735,7 @@ func Test_spell_sal_and_addition()
   call assert_equal('*fls kswts tl', soundfold('oeverloos gezwets edale'))
 
   "also use an addition file
-  call writefile(["/regions=usgbnz", "elequint/2", "elekwint/3"], "Xtest.utf-8.add")
+  call writefile(["/regions=usgbnz", "elequint/2", "elekwint/3"], "Xtest.utf-8.add", 'D')
   mkspell! Xtest.utf-8.add.spl Xtest.utf-8.add
 
   bwipe!

--- a/test/old/testdir/test_spellfile.vim
+++ b/test/old/testdir/test_spellfile.vim
@@ -212,7 +212,7 @@ endfunc
 " The spell file format is described in spellfile.c
 func Test_spellfile_format_error()
   let save_rtp = &rtp
-  call mkdir('Xtest/spell', 'p')
+  call mkdir('Xtest/spell', 'pR')
   let splfile = './Xtest/spell/Xtest.utf-8.spl'
 
   " empty spell file
@@ -384,13 +384,12 @@ func Test_spellfile_format_error()
   call Spellfile_Test(0zFF00000000000000000000000201010000, 'E759:')
 
   let &rtp = save_rtp
-  call delete('Xtest', 'rf')
 endfunc
 
 " Test for format errors in suggest file
 func Test_sugfile_format_error()
   let save_rtp = &rtp
-  call mkdir('Xtest/spell', 'p')
+  call mkdir('Xtest/spell', 'pR')
   let splfile = './Xtest/spell/Xtest.utf-8.spl'
   let sugfile = './Xtest/spell/Xtest.utf-8.sug'
 
@@ -473,7 +472,6 @@ func Test_sugfile_format_error()
   set nospell spelllang&
 
   let &rtp = save_rtp
-  call delete('Xtest', 'rf')
 endfunc
 
 " Test for using :mkspell to create a spell file from a list of words
@@ -486,7 +484,7 @@ func Test_wordlist_dic()
     /encoding=latin1
     example
   [END]
-  call writefile(lines, 'Xwordlist.dic')
+  call writefile(lines, 'Xwordlist.dic', 'D')
   let output = execute('mkspell Xwordlist.spl Xwordlist.dic')
   call assert_match('Duplicate /encoding= line ignored in Xwordlist.dic line 4: /encoding=latin1', output)
 
@@ -559,7 +557,6 @@ func Test_wordlist_dic()
   call assert_match('Compressed keep-case:', output)
 
   call delete('Xwordlist.spl')
-  call delete('Xwordlist.dic')
 endfunc
 
 " Test for the :mkspell command
@@ -600,8 +597,8 @@ func Test_aff_file_format_error()
   CheckNotMSWindows
 
   " No word count in .dic file
-  call writefile([], 'Xtest.dic')
-  call writefile([], 'Xtest.aff')
+  call writefile([], 'Xtest.dic', 'D')
+  call writefile([], 'Xtest.aff', 'D')
   call assert_fails('mkspell! Xtest.spl Xtest', 'E760:')
 
   " create a .dic file for the tests below
@@ -823,20 +820,14 @@ func Test_aff_file_format_error()
 
   " use multiple .aff files with different values for COMPOUNDWORDMAX and
   " MIDWORD (number and string)
-  call writefile(['1', 'world'], 'Xtest_US.dic')
-  call writefile(['1', 'world'], 'Xtest_CA.dic')
-  call writefile(["COMPOUNDWORDMAX 3", "MIDWORD '-"], 'Xtest_US.aff')
-  call writefile(["COMPOUNDWORDMAX 4", "MIDWORD '="], 'Xtest_CA.aff')
+  call writefile(['1', 'world'], 'Xtest_US.dic', 'D')
+  call writefile(['1', 'world'], 'Xtest_CA.dic', 'D')
+  call writefile(["COMPOUNDWORDMAX 3", "MIDWORD '-"], 'Xtest_US.aff', 'D')
+  call writefile(["COMPOUNDWORDMAX 4", "MIDWORD '="], 'Xtest_CA.aff', 'D')
   let output = execute('mkspell! Xtest.spl Xtest_US Xtest_CA')
   call assert_match('COMPOUNDWORDMAX value differs from what is used in another .aff file', output)
   call assert_match('MIDWORD value differs from what is used in another .aff file', output)
-  call delete('Xtest_US.dic')
-  call delete('Xtest_CA.dic')
-  call delete('Xtest_US.aff')
-  call delete('Xtest_CA.aff')
 
-  call delete('Xtest.dic')
-  call delete('Xtest.aff')
   call delete('Xtest.spl')
   call delete('Xtest.sug')
 endfunc
@@ -856,8 +847,8 @@ func Test_spell_add_word()
 endfunc
 
 func Test_spellfile_verbose()
-  call writefile(['1', 'one'], 'XtestVerbose.dic')
-  call writefile([], 'XtestVerbose.aff')
+  call writefile(['1', 'one'], 'XtestVerbose.dic', 'D')
+  call writefile([], 'XtestVerbose.aff', 'D')
   mkspell! XtestVerbose-utf8.spl XtestVerbose
   set spell
 
@@ -870,15 +861,13 @@ func Test_spellfile_verbose()
   call assert_notmatch('Reading spell file "XtestVerbose-utf8.spl"', a)
 
   set spell& spelllang&
-  call delete('XtestVerbose.dic')
-  call delete('XtestVerbose.aff')
   call delete('XtestVerbose-utf8.spl')
 endfunc
 
 " Test NOBREAK (see :help spell-NOBREAK)
 func Test_NOBREAK()
-  call writefile(['3', 'one', 'two', 'three' ], 'XtestNOBREAK.dic')
-  call writefile(['NOBREAK' ], 'XtestNOBREAK.aff')
+  call writefile(['3', 'one', 'two', 'three' ], 'XtestNOBREAK.dic', 'D')
+  call writefile(['NOBREAK' ], 'XtestNOBREAK.aff', 'D')
 
   mkspell! XtestNOBREAK-utf8.spl XtestNOBREAK
   set spell spelllang=XtestNOBREAK-utf8.spl
@@ -900,8 +889,6 @@ func Test_NOBREAK()
 
   bw!
   set spell& spelllang&
-  call delete('XtestNOBREAK.dic')
-  call delete('XtestNOBREAK.aff')
   call delete('XtestNOBREAK-utf8.spl')
 endfunc
 
@@ -911,11 +898,11 @@ func Test_spellfile_CHECKCOMPOUNDPATTERN()
         \         'one/c',
         \         'two/c',
         \         'three/c',
-        \         'four'], 'XtestCHECKCOMPOUNDPATTERN.dic')
+        \         'four'], 'XtestCHECKCOMPOUNDPATTERN.dic', 'D')
   " Forbid compound words where first word ends with 'wo' and second starts with 'on'.
   call writefile(['CHECKCOMPOUNDPATTERN 1',
         \         'CHECKCOMPOUNDPATTERN wo on',
-        \         'COMPOUNDFLAG c'], 'XtestCHECKCOMPOUNDPATTERN.aff')
+        \         'COMPOUNDFLAG c'], 'XtestCHECKCOMPOUNDPATTERN.aff', 'D')
 
   mkspell! XtestCHECKCOMPOUNDPATTERN-utf8.spl XtestCHECKCOMPOUNDPATTERN
   set spell spelllang=XtestCHECKCOMPOUNDPATTERN-utf8.spl
@@ -939,8 +926,6 @@ func Test_spellfile_CHECKCOMPOUNDPATTERN()
   endfor
 
   set spell& spelllang&
-  call delete('XtestCHECKCOMPOUNDPATTERN.dic')
-  call delete('XtestCHECKCOMPOUNDPATTERN.aff')
   call delete('XtestCHECKCOMPOUNDPATTERN-utf8.spl')
 endfunc
 
@@ -949,15 +934,15 @@ func Test_spellfile_NOCOMPOUNDSUGS()
   call writefile(['3',
         \         'one/c',
         \         'two/c',
-        \         'three/c'], 'XtestNOCOMPOUNDSUGS.dic')
+        \         'three/c'], 'XtestNOCOMPOUNDSUGS.dic', 'D')
 
   " pass 0 tests without NOCOMPOUNDSUGS, pass 1 tests with NOCOMPOUNDSUGS
   for pass in [0, 1]
     if pass == 0
-      call writefile(['COMPOUNDFLAG c'], 'XtestNOCOMPOUNDSUGS.aff')
+      call writefile(['COMPOUNDFLAG c'], 'XtestNOCOMPOUNDSUGS.aff', 'D')
     else
       call writefile(['NOCOMPOUNDSUGS',
-          \           'COMPOUNDFLAG c'], 'XtestNOCOMPOUNDSUGS.aff')
+          \           'COMPOUNDFLAG c'], 'XtestNOCOMPOUNDSUGS.aff', 'D')
     endif
 
     mkspell! XtestNOCOMPOUNDSUGS-utf8.spl XtestNOCOMPOUNDSUGS
@@ -985,8 +970,6 @@ func Test_spellfile_NOCOMPOUNDSUGS()
   endfor
 
   set spell& spelllang&
-  call delete('XtestNOCOMPOUNDSUGS.dic')
-  call delete('XtestNOCOMPOUNDSUGS.aff')
   call delete('XtestNOCOMPOUNDSUGS-utf8.spl')
 endfunc
 
@@ -999,8 +982,8 @@ func Test_spellfile_COMMON()
         \         'any',
         \         'tee',
         \         'the',
-        \         'ted'], 'XtestCOMMON.dic')
-  call writefile(['COMMON the and'], 'XtestCOMMON.aff')
+        \         'ted'], 'XtestCOMMON.dic', 'D')
+  call writefile(['COMMON the and'], 'XtestCOMMON.aff', 'D')
 
   mkspell! XtestCOMMON-utf8.spl XtestCOMMON
   set spell spelllang=XtestCOMMON-utf8.spl
@@ -1012,15 +995,13 @@ func Test_spellfile_COMMON()
   call assert_equal(['the', 'tee'], spellsuggest('dhe', 2))
 
   set spell& spelllang&
-  call delete('XtestCOMMON.dic')
-  call delete('XtestCOMMON.aff')
   call delete('XtestCOMMON-utf8.spl')
 endfunc
 
 " Test NOSUGGEST (see :help spell-COMMON)
 func Test_spellfile_NOSUGGEST()
-  call writefile(['2', 'foo/X', 'fog'], 'XtestNOSUGGEST.dic')
-  call writefile(['NOSUGGEST X'], 'XtestNOSUGGEST.aff')
+  call writefile(['2', 'foo/X', 'fog'], 'XtestNOSUGGEST.dic', 'D')
+  call writefile(['NOSUGGEST X'], 'XtestNOSUGGEST.aff', 'D')
 
   mkspell! XtestNOSUGGEST-utf8.spl XtestNOSUGGEST
   set spell spelllang=XtestNOSUGGEST-utf8.spl
@@ -1038,8 +1019,6 @@ func Test_spellfile_NOSUGGEST()
   call assert_equal(['fog'], spellsuggest('fogg', 1))
 
   set spell& spelllang&
-  call delete('XtestNOSUGGEST.dic')
-  call delete('XtestNOSUGGEST.aff')
   call delete('XtestNOSUGGEST-utf8.spl')
 endfunc
 
@@ -1048,7 +1027,7 @@ endfunc
 func Test_spellfile_CIRCUMFIX()
   " Example taken verbatim from https://github.com/hunspell/hunspell/tree/master/tests
   call writefile(['1',
-        \         'nagy/C	po:adj'], 'XtestCIRCUMFIX.dic')
+        \         'nagy/C	po:adj'], 'XtestCIRCUMFIX.dic', 'D')
   call writefile(['# circumfixes: ~ obligate prefix/suffix combinations',
         \         '# superlative in Hungarian: leg- (prefix) AND -bb (suffix)',
         \         '',
@@ -1063,7 +1042,7 @@ func Test_spellfile_CIRCUMFIX()
         \         'SFX C Y 3',
         \         'SFX C 0 obb . is:COMPARATIVE',
         \         'SFX C 0 obb/AX . is:SUPERLATIVE',
-        \         'SFX C 0 obb/BX . is:SUPERSUPERLATIVE'], 'XtestCIRCUMFIX.aff')
+        \         'SFX C 0 obb/BX . is:SUPERSUPERLATIVE'], 'XtestCIRCUMFIX.aff', 'D')
 
   mkspell! XtestCIRCUMFIX-utf8.spl XtestCIRCUMFIX
   set spell spelllang=XtestCIRCUMFIX-utf8.spl
@@ -1082,8 +1061,6 @@ func Test_spellfile_CIRCUMFIX()
   endfor
 
   set spell& spelllang&
-  call delete('XtestCIRCUMFIX.dic')
-  call delete('XtestCIRCUMFIX.aff')
   call delete('XtestCIRCUMFIX-utf8.spl')
 endfunc
 
@@ -1095,12 +1072,12 @@ func Test_spellfile_SFX_strip()
         \         'SFX A are hiamo [cg]are',
         \         'SFX A re mo iare',
         \         'SFX A re vamo are'],
-        \         'XtestSFX.aff')
+        \         'XtestSFX.aff', 'D')
   " Examples of Italian verbs:
   " - cantare = to sing
   " - cercare = to search
   " - odiare = to hate
-  call writefile(['3', 'cantare/A', 'cercare/A', 'odiare/A'], 'XtestSFX.dic')
+  call writefile(['3', 'cantare/A', 'cercare/A', 'odiare/A'], 'XtestSFX.dic', 'D')
 
   mkspell! XtestSFX-utf8.spl XtestSFX
   set spell spelllang=XtestSFX-utf8.spl
@@ -1124,8 +1101,6 @@ func Test_spellfile_SFX_strip()
   call assert_equal(['odiamo'],    spellsuggest('odiiamo', 1))
 
   set spell& spelllang&
-  call delete('XtestSFX.dic')
-  call delete('XtestSFX.aff')
   call delete('XtestSFX-utf8.spl')
 endfunc
 
@@ -1134,7 +1109,7 @@ endfunc
 func Test_init_spellfile()
   let save_rtp = &rtp
   let save_encoding = &encoding
-  call mkdir('Xrtp/spell', 'p')
+  call mkdir('Xrtp/spell', 'pR')
   call writefile(['vim'], 'Xrtp/spell/Xtest.dic')
   silent mkspell Xrtp/spell/Xtest.utf-8.spl Xrtp/spell/Xtest.dic
   set runtimepath=./Xrtp
@@ -1144,8 +1119,8 @@ func Test_init_spellfile()
   call assert_equal('./Xrtp/spell/Xtest.utf-8.add', &spellfile)
   call assert_equal(['abc'], readfile('Xrtp/spell/Xtest.utf-8.add'))
   call assert_true(filereadable('Xrtp/spell/Xtest.utf-8.spl'))
+
   set spell& spelllang& spellfile&
-  call delete('Xrtp', 'rf')
   let &encoding = save_encoding
   let &rtp = save_rtp
   %bw!
@@ -1171,12 +1146,10 @@ endfunc
 
 " this was using a NULL pointer
 func Test_mkspell_empty_dic()
-  call writefile(['1'], 'XtestEmpty.dic')
-  call writefile(['SOFOFROM abcd', 'SOFOTO ABCD', 'SAL CIA X'], 'XtestEmpty.aff')
+  call writefile(['1'], 'XtestEmpty.dic', 'D')
+  call writefile(['SOFOFROM abcd', 'SOFOTO ABCD', 'SAL CIA X'], 'XtestEmpty.aff', 'D')
   mkspell! XtestEmpty.spl XtestEmpty
 
-  call delete('XtestEmpty.dic')
-  call delete('XtestEmpty.aff')
   call delete('XtestEmpty.spl')
 endfunc
 

--- a/test/old/testdir/test_startup_utf8.vim
+++ b/test/old/testdir/test_startup_utf8.vim
@@ -6,7 +6,7 @@ source screendump.vim
 
 func Test_read_stdin_utf8()
   let linesin = ['テスト', '€ÀÈÌÒÙ']
-  call writefile(linesin, 'Xtestin')
+  call writefile(linesin, 'Xtestin', 'D')
   let before = [
 	\ 'set enc=utf-8',
 	\ 'set fencs=cp932,utf-8',
@@ -26,24 +26,22 @@ func Test_read_stdin_utf8()
   else
     call assert_equal('', 'RunVimPiped failed.')
   endif
+
   call delete('Xtestout')
-  call delete('Xtestin')
 endfunc
 
 func Test_read_fifo_utf8()
-  if !has('unix')
-    return
-  endif
+  CheckUnix
   " Using bash/zsh's process substitution.
   if executable('bash')
     set shell=bash
   elseif executable('zsh')
     set shell=zsh
   else
-    return
+    throw 'Skipped: bash or zsh is required'
   endif
   let linesin = ['テスト', '€ÀÈÌÒÙ']
-  call writefile(linesin, 'Xtestin')
+  call writefile(linesin, 'Xtestin', 'D')
   let before = [
 	\ 'set enc=utf-8',
 	\ 'set fencs=cp932,utf-8',
@@ -58,8 +56,8 @@ func Test_read_fifo_utf8()
   else
     call assert_equal('', 'RunVim failed.')
   endif
+
   call delete('Xtestout')
-  call delete('Xtestin')
 endfunc
 
 func Test_detect_ambiwidth()
@@ -71,12 +69,13 @@ func Test_detect_ambiwidth()
 	\ 'set ambiwidth=double',
 	\ 'call test_option_not_set("ambiwidth")',
 	\ 'redraw',
-	\ ], 'Xscript')
+	\ ], 'Xscript', 'D')
   let buf = RunVimInTerminal('-S Xscript', #{keep_t_u7: 1})
   call TermWait(buf)
   call term_sendkeys(buf, "S\<C-R>=&ambiwidth\<CR>\<Esc>")
   call WaitForAssert({-> assert_match('single', term_getline(buf, 1))})
 
   call StopVimInTerminal(buf)
-  call delete('Xscript')
 endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_stat.vim
+++ b/test/old/testdir/test_stat.vim
@@ -63,7 +63,7 @@ func Test_checktime()
   let fname = 'Xtest.tmp'
 
   let fl = ['Hello World!']
-  call writefile(fl, fname)
+  call writefile(fl, fname, 'D')
   set autoread
   exec 'e' fname
   call SleepForTimestamp()
@@ -72,8 +72,6 @@ func Test_checktime()
   call writefile(fl, fname)
   checktime
   call assert_equal(fl[0], getline(1))
-
-  call delete(fname)
 endfunc
 
 func Test_checktime_fast()
@@ -82,7 +80,7 @@ func Test_checktime_fast()
   let fname = 'Xtest.tmp'
 
   let fl = ['Hello World!']
-  call writefile(fl, fname)
+  call writefile(fl, fname, 'D')
   set autoread
   exec 'e' fname
   let fl = readfile(fname)
@@ -91,8 +89,6 @@ func Test_checktime_fast()
   call writefile(fl, fname)
   checktime
   call assert_equal(fl[0], getline(1))
-
-  call delete(fname)
 endfunc
 
 func Test_autoread_fast()
@@ -106,12 +102,10 @@ func Test_autoread_fast()
   call setline(1, 'foo')
   w!
   sleep 10m
-  call writefile(['bar'], 'Xautoread')
+  call writefile(['bar'], 'Xautoread', 'D')
   sleep 10m
   checktime
   call assert_equal('bar', trim(getline(1)))
-
-  call delete('Xautoread')
 endfunc
 
 func Test_autoread_file_deleted()

--- a/test/old/testdir/test_statusline.vim
+++ b/test/old/testdir/test_statusline.vim
@@ -417,7 +417,7 @@ func Test_statusline()
   " Test statusline works with 80+ items
   function! StatusLabel()
     redrawstatus
-    return '[label]'	
+    return '[label]'
   endfunc
   let statusline = '%{StatusLabel()}'
   for i in range(150)

--- a/test/old/testdir/test_statusline.vim
+++ b/test/old/testdir/test_statusline.vim
@@ -483,14 +483,13 @@ func Test_statusline_removed_group()
     set laststatus=2
     let &statusline = '%#StatColorHi2#%(✓%#StatColorHi2#%) Q≡'
   END
-  call writefile(lines, 'XTest_statusline')
+  call writefile(lines, 'XTest_statusline', 'D')
 
   let buf = RunVimInTerminal('-S XTest_statusline', {'rows': 10, 'cols': 50})
   call VerifyScreenDump(buf, 'Test_statusline_1', {})
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete('XTest_statusline')
 endfunc
 
 func Test_statusline_using_mode()
@@ -501,7 +500,7 @@ func Test_statusline_using_mode()
     split
     setlocal statusline=+%{mode()}+
   END
-  call writefile(lines, 'XTest_statusline')
+  call writefile(lines, 'XTest_statusline', 'D')
 
   let buf = RunVimInTerminal('-S XTest_statusline', {'rows': 7, 'cols': 50})
   call VerifyScreenDump(buf, 'Test_statusline_mode_1', {})
@@ -512,7 +511,6 @@ func Test_statusline_using_mode()
   " clean up
   call term_sendkeys(buf, "close\<CR>")
   call StopVimInTerminal(buf)
-  call delete('XTest_statusline')
 endfunc
 
 func Test_statusline_after_split_vsplit()
@@ -567,13 +565,12 @@ func Test_statusline_highlight_truncate()
     hi! link User2 ErrorMsg
     set statusline=%.5(%1*ABC%2*DEF%1*GHI%)
   END
-  call writefile(lines, 'XTest_statusline')
+  call writefile(lines, 'XTest_statusline', 'D')
 
   let buf = RunVimInTerminal('-S XTest_statusline', {'rows': 6})
   call VerifyScreenDump(buf, 'Test_statusline_hl', {})
 
   call StopVimInTerminal(buf)
-  call delete('XTest_statusline')
 endfunc
 
 func Test_statusline_showcmd()

--- a/test/old/testdir/test_substitute.vim
+++ b/test/old/testdir/test_substitute.vim
@@ -743,7 +743,7 @@ func Test_sub_highlight_zero_match()
 endfunc
 
 func Test_nocatch_sub_failure_handling()
-  " normal error results in all replacements 
+  " normal error results in all replacements
   func Foo()
     foobar
   endfunc

--- a/test/old/testdir/test_substitute.vim
+++ b/test/old/testdir/test_substitute.vim
@@ -892,7 +892,7 @@ func Test_sub_with_no_last_pat()
     call writefile(v:errors, 'Xresult')
     qall!
   [SCRIPT]
-  call writefile(lines, 'Xscript')
+  call writefile(lines, 'Xscript', 'D')
   if RunVim([], [], '--clean -S Xscript')
     call assert_equal([], readfile('Xresult'))
   endif
@@ -909,7 +909,6 @@ func Test_sub_with_no_last_pat()
   "   call assert_equal([], readfile('Xresult'))
   " endif
 
-  call delete('Xscript')
   call delete('Xresult')
 endfunc
 
@@ -1110,13 +1109,12 @@ func Test_sub_open_cmdline_win()
     redir END
     qall!
   [SCRIPT]
-  call writefile(lines, 'Xscript')
+  call writefile(lines, 'Xscript', 'D')
   if RunVim([], [], '-u NONE -S Xscript')
     call assert_match('E565: Not allowed to change text or change window',
           \ readfile('Xresult')->join('XX'))
   endif
 
-  call delete('Xscript')
   call delete('Xresult')
 endfunc
 

--- a/test/old/testdir/test_syntax.vim
+++ b/test/old/testdir/test_syntax.vim
@@ -644,15 +644,16 @@ func Test_syntax_c()
 	\ '   printf("Just an example piece of C code\n");',
 	\ '   return 0x0ff;',
 	\ '}',
+	\ "\t\t ",
 	\ '   static void',
 	\ 'myFunction(const double count, struct nothing, long there) {',
-	\ '  // 123: nothing to read here',
-	\ '  for (int i = 0; i < count; ++i) {',
-	\ '    break;',
-	\ '  }',
-	\ "  Note: asdf",
+	\ "\t// 123: nothing to endif here",
+	\ "\tfor (int i = 0; i < count; ++i) {",
+	\ "\t   break;",
+	\ "\t}",
+	\ "\tNote: asdf",
 	\ '}',
-	\ ], 'Xtest.c')
+	\ ], 'Xtest.c', 'D')
 
   " This makes the default for 'background' use "dark", check that the
   " response to t_RB corrects it to "light".
@@ -664,7 +665,6 @@ func Test_syntax_c()
   call StopVimInTerminal(buf)
 
   let $COLORFGBG = ''
-  call delete('Xtest.c')
 endfun
 
 " Test \z(...) along with \z1
@@ -698,10 +698,10 @@ func Test_syn_wrong_z_one()
 endfunc
 
 func Test_syntax_after_bufdo()
-  call writefile(['/* aaa comment */'], 'Xaaa.c')
-  call writefile(['/* bbb comment */'], 'Xbbb.c')
-  call writefile(['/* ccc comment */'], 'Xccc.c')
-  call writefile(['/* ddd comment */'], 'Xddd.c')
+  call writefile(['/* aaa comment */'], 'Xaaa.c', 'D')
+  call writefile(['/* bbb comment */'], 'Xbbb.c', 'D')
+  call writefile(['/* ccc comment */'], 'Xccc.c', 'D')
+  call writefile(['/* ddd comment */'], 'Xddd.c', 'D')
 
   let bnr = bufnr('%')
   new Xaaa.c
@@ -729,10 +729,6 @@ func Test_syntax_after_bufdo()
   bwipe! Xccc.c
   bwipe! Xddd.c
   syntax off
-  call delete('Xaaa.c')
-  call delete('Xbbb.c')
-  call delete('Xccc.c')
-  call delete('Xddd.c')
 endfunc
 
 func Test_syntax_foldlevel()

--- a/test/old/testdir/test_system.vim
+++ b/test/old/testdir/test_system.vim
@@ -53,7 +53,7 @@ func Test_system_exmode()
     let cmd = ' -es -c "source Xscript" +q; echo "result=$?"'
     " Need to put this in a script, "catch" isn't found after an unknown
     " function.
-    call writefile(['try', 'call doesnotexist()', 'catch', 'endtry'], 'Xscript')
+    call writefile(['try', 'call doesnotexist()', 'catch', 'endtry'], 'Xscript', 'D')
     let a = system(GetVimCommand() . cmd)
     call assert_match('result=0', a)
     call assert_equal(0, v:shell_error)
@@ -69,7 +69,6 @@ func Test_system_exmode()
   let cmd = ' -es -c "source Xscript" +q'
   let a = system(GetVimCommand() . cmd)
   call assert_notequal(0, v:shell_error)
-  call delete('Xscript')
 
   if has('unix') " echo $? only works on Unix
     let cmd = ' -es -c "call doesnotexist()" +q; echo $?'

--- a/test/old/testdir/test_tagfunc.vim
+++ b/test/old/testdir/test_tagfunc.vim
@@ -89,11 +89,11 @@ func Test_tagfunc()
     return v:null
   endfunc
   set tags= tfu=NullTagFunc
-  call assert_fails('tag nothing', 'E433')
+  call assert_fails('tag nothing', 'E433:')
   delf NullTagFunc
 
   bwipe!
-  set tags& tfu& cpt& 
+  set tags& tfu& cpt&
   call delete('Xfile1')
 endfunc
 

--- a/test/old/testdir/test_tagjump.vim
+++ b/test/old/testdir/test_tagjump.vim
@@ -777,7 +777,7 @@ func Test_tag_guess()
   let code =<< trim [CODE]
 
     int FUNC1  (int x) { }
-    int 
+    int
     func2   (int y) { }
     int * func3 () { }
 

--- a/test/old/testdir/test_timers.vim
+++ b/test/old/testdir/test_timers.vim
@@ -348,8 +348,15 @@ endfunc
 " Test that the garbage collector isn't triggered if a timer callback invokes
 " vgetc().
 func Test_nocatch_timer_garbage_collect()
-  " skipped: Nvim does not support test_garbagecollect_soon(), test_override()
-  return
+  " FIXME: why does this fail only on MacOS M1?
+  try
+    CheckNotMacM1
+    throw 'Skipped: Nvim does not support test_garbagecollect_soon(), test_override()'
+  catch /Skipped/
+    let g:skipped_reason = v:exception
+    return
+  endtry
+
   " 'uptimetime. must be bigger than the timer timeout
   set ut=200
   call test_garbagecollect_soon()

--- a/test/old/testdir/test_true_false.vim
+++ b/test/old/testdir/test_true_false.vim
@@ -49,11 +49,11 @@ func Test_if()
 endfunc
 
 function Try_arg_true_false(expr, false_val, true_val)
-  for v in ['v:false', '0', '"0"', '"foo"', '" "'] 
+  for v in ['v:false', '0', '"0"', '"foo"', '" "']
     let r = eval(substitute(a:expr, '%v%', v, ''))
     call assert_equal(a:false_val, r, 'result for ' . v . ' is not ' . string(a:false_val) . ' but ' . string(r))
   endfor
-  for v in ['v:true', '1', '"1"', '"1foo"'] 
+  for v in ['v:true', '1', '"1"', '"1foo"']
     let r = eval(substitute(a:expr, '%v%', v, ''))
     call assert_equal(a:true_val, r, 'result for ' . v . ' is not ' . string(a:true_val) . ' but ' . string(r))
   endfor
@@ -117,12 +117,11 @@ func Test_true_false_arg()
 endfunc
 
 function Try_arg_non_zero(expr, false_val, true_val)
-  CheckFeature float
-  for v in ['v:false', '0', '[1]', '{2:3}', '3.4'] 
+  for v in ['v:false', '0', '[1]', '{2:3}', '3.4']
     let r = eval(substitute(a:expr, '%v%', v, ''))
     call assert_equal(a:false_val, r, 'result for ' . v . ' is not ' . a:false_val . ' but ' . r)
   endfor
-  for v in ['v:true', '1', '" "', '"0"'] 
+  for v in ['v:true', '1', '" "', '"0"']
     let r = eval(substitute(a:expr, '%v%', v, ''))
     call assert_equal(a:true_val, r, 'result for ' . v . ' is not ' . a:true_val . ' but ' . r)
   endfor
@@ -138,14 +137,14 @@ func Test_non_zero_arg()
   call Try_arg_non_zero("shellescape('foo%', %v%)", "'foo%'", "'foo\\%'")
 
   " visualmode() needs to be called twice to check
-  for v in [v:false, 0, [1], {2:3}, 3.4] 
+  for v in [v:false, 0, [1], {2:3}, 3.4]
     normal vv
     let r = visualmode(v)
     call assert_equal('v', r, 'result for ' . string(v) . ' is not "v" but ' . r)
     let r = visualmode(v)
     call assert_equal('v', r, 'result for ' . string(v) . ' is not "v" but ' . r)
   endfor
-  for v in [v:true, 1, " ", "0"] 
+  for v in [v:true, 1, " ", "0"]
     normal vv
     let r = visualmode(v)
     call assert_equal('v', r, 'result for ' . v . ' is not "v" but ' . r)

--- a/test/old/testdir/test_utf8.vim
+++ b/test/old/testdir/test_utf8.vim
@@ -1,5 +1,5 @@
 " Tests for Unicode manipulations
- 
+
 source check.vim
 source view_util.vim
 source screendump.vim
@@ -112,7 +112,7 @@ func Test_list2str_str2list_latin1()
 
   let save_encoding = &encoding
   " set encoding=latin1
-  
+
   let lres = str2list(s, 1)
   let sres = list2str(l, 1)
   call assert_equal([65, 66, 67], str2list("ABC"))

--- a/test/old/testdir/test_virtualedit.vim
+++ b/test/old/testdir/test_virtualedit.vim
@@ -696,14 +696,14 @@ func Test_virtualedit_mouse()
   set virtualedit&
 endfunc
 
-" this was replacing the NUL at the end of the line 
+" this was replacing the NUL at the end of the line
 func Test_virtualedit_replace_after_tab()
   new
   s/\v/	0
   set ve=all
   let @" = ''
   sil! norm vPvr0
-  
+
   call assert_equal("\t0", getline(1))
   set ve&
   bwipe!

--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -1170,8 +1170,8 @@ endfunc
 func Test_visual_put_in_block_using_zp()
   new
   " paste using zP
-  call setline(1, ['/path;text', '/path;text', '/path;text', '', 
-    \ '/subdir', 
+  call setline(1, ['/path;text', '/path;text', '/path;text', '',
+    \ '/subdir',
     \ '/longsubdir',
     \ '/longlongsubdir'])
   exe "normal! 5G\<c-v>2j$y"
@@ -1179,8 +1179,8 @@ func Test_visual_put_in_block_using_zp()
   call assert_equal(['/path/subdir;text', '/path/longsubdir;text', '/path/longlongsubdir;text'], getline(1, 3))
   %d
   " paste using zP
-  call setline(1, ['/path;text', '/path;text', '/path;text', '', 
-    \ '/subdir', 
+  call setline(1, ['/path;text', '/path;text', '/path;text', '',
+    \ '/subdir',
     \ '/longsubdir',
     \ '/longlongsubdir'])
   exe "normal! 5G\<c-v>2j$y"
@@ -1193,7 +1193,7 @@ func Test_visual_put_in_block_using_zy_and_zp()
   new
 
   " Test 1) Paste using zp - after the cursor without trailing spaces
-  call setline(1, ['/path;text', '/path;text', '/path;text', '', 
+  call setline(1, ['/path;text', '/path;text', '/path;text', '',
     \ 'texttext  /subdir           columntext',
 		\ 'texttext  /longsubdir       columntext',
     \ 'texttext  /longlongsubdir   columntext'])
@@ -1203,7 +1203,7 @@ func Test_visual_put_in_block_using_zy_and_zp()
 
   " Test 2) Paste using zP - in front of the cursor without trailing spaces
   %d
-  call setline(1, ['/path;text', '/path;text', '/path;text', '', 
+  call setline(1, ['/path;text', '/path;text', '/path;text', '',
     \ 'texttext  /subdir           columntext',
 		\ 'texttext  /longsubdir       columntext',
     \ 'texttext  /longlongsubdir   columntext'])
@@ -1213,7 +1213,7 @@ func Test_visual_put_in_block_using_zy_and_zp()
 
   " Test 3) Paste using p - with trailing spaces
   %d
-  call setline(1, ['/path;text', '/path;text', '/path;text', '', 
+  call setline(1, ['/path;text', '/path;text', '/path;text', '',
     \ 'texttext  /subdir           columntext',
 		\ 'texttext  /longsubdir       columntext',
     \ 'texttext  /longlongsubdir   columntext'])
@@ -1223,7 +1223,7 @@ func Test_visual_put_in_block_using_zy_and_zp()
 
   " Test 4) Paste using P - with trailing spaces
   %d
-  call setline(1, ['/path;text', '/path;text', '/path;text', '', 
+  call setline(1, ['/path;text', '/path;text', '/path;text', '',
     \ 'texttext  /subdir           columntext',
 		\ 'texttext  /longsubdir       columntext',
     \ 'texttext  /longlongsubdir   columntext'])
@@ -1233,7 +1233,7 @@ func Test_visual_put_in_block_using_zy_and_zp()
 
   " Test 5) Yank with spaces inside the block
   %d
-  call setline(1, ['/path;text', '/path;text', '/path;text', '', 
+  call setline(1, ['/path;text', '/path;text', '/path;text', '',
     \ 'texttext  /sub    dir/           columntext',
     \ 'texttext  /lon    gsubdir/       columntext',
     \ 'texttext  /lon    glongsubdir/   columntext'])

--- a/test/old/testdir/test_winbuf_close.vim
+++ b/test/old/testdir/test_winbuf_close.vim
@@ -223,7 +223,7 @@ func Test_window_close_splitright_noequalalways()
   execute "normal \<c-w>b"
   let h = winheight(0)
   let w = win_getid()
-  new 
+  new
   q
   call assert_equal(h, winheight(0), "Window height does not match eight before opening and closing another window")
   call assert_equal(w, win_getid(), "Did not return to original window after opening and closing a window")


### PR DESCRIPTION
#### vim-patch:partial:9.0.0719: too many delete() calls in tests

Problem:    Too many delete() calls in tests.
Solution:   Use deferred delete where possible.

https://github.com/vim/vim/commit/56564964e6d0956c29687e8a10cb94fe42f5c097

This includes all changes expect changes in test_startup.vim.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1257: code style is not check in test scripts

Problem:    Code style is not check in test scripts.
Solution:   Add basic code style check for test files.

https://github.com/vim/vim/commit/94722c510745a0cfd494c51625a514b92dd2bfb2

Use Test_test_files() from latest Vim.

Co-authored-by: Bram Moolenaar <Bram@vim.org>