### PR TITLE
vim-patch:9.1.0594: Unnecessary redraw when setting 'winfixbuf'

### DIFF
--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9889,7 +9889,6 @@ return {
       ]=],
       full_name = 'winfixbuf',
       pv_name = 'p_wfb',
-      redraw = { 'current_window' },
       scope = { 'window' },
       short_desc = N_('pin a window to a specific buffer'),
       type = 'boolean',

--- a/test/old/testdir/test_goto.vim
+++ b/test/old/testdir/test_goto.vim
@@ -321,14 +321,14 @@ func Test_set_options_keep_col()
   let pos = getcurpos()
   normal j
   set invhlsearch spell spelllang=en,cjk spelloptions=camel textwidth=80
-  set cursorline cursorcolumn cursorlineopt=line colorcolumn=+1
+  set cursorline cursorcolumn cursorlineopt=line colorcolumn=+1 winfixbuf
   set background=dark
   set background=light
   normal k
   call assert_equal(pos, getcurpos())
   bwipe!
   set hlsearch& spell& spelllang& spelloptions& textwidth&
-  set cursorline& cursorcolumn& cursorlineopt& colorcolumn&
+  set cursorline& cursorcolumn& cursorlineopt& colorcolumn& winfixbuf&
   set background&
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.0594: Unnecessary redraw when setting 'winfixbuf'

Problem:  Unnecessary redraw when setting 'winfixbuf'.
Solution: Remove P_RWIN flag. (zeertzjq)

closes: vim/vim#15283

https://github.com/vim/vim/commit/ac4ce9e15b7ee0fccfa72aecf98b696d880e53c3