### PR TITLE
vim-patch:9.0.0003: functions are global while they could be local

### DIFF
--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -105,7 +105,7 @@ char *eval_one_expr_in_str(char *p, garray_T *gap, bool evaluate)
 /// string in allocated memory.  "{{" is reduced to "{" and "}}" to "}".
 /// Used for a heredoc assignment.
 /// Returns NULL for an error.
-char *eval_all_expr_in_str(char *str)
+static char *eval_all_expr_in_str(char *str)
 {
   garray_T ga;
   ga_init(&ga, 1, 80);

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -853,7 +853,7 @@ static int color_numbers_8[28] = { 0, 4, 2, 6,
 // color_names[].
 // "boldp" will be set to kTrue or kFalse for a foreground color when using 8
 // colors, otherwise it will be unchanged.
-int lookup_color(const int idx, const bool foreground, TriState *const boldp)
+static int lookup_color(const int idx, const bool foreground, TriState *const boldp)
 {
   int color = color_numbers_16[idx];
 

--- a/test/old/testdir/test_fold.vim
+++ b/test/old/testdir/test_fold.vim
@@ -1486,6 +1486,8 @@ func Test_fold_split()
   call assert_equal([0, 1, 1, 2, 2], range(1, 5)->map('foldlevel(v:val)'))
   call append(2, 'line 2.5')
   call assert_equal([0, 1, 0, 1, 2, 2], range(1, 6)->map('foldlevel(v:val)'))
+  3d
+  call assert_equal([0, 1, 1, 2, 2], range(1, 5)->map('foldlevel(v:val)'))
   bw!
 endfunc
 

--- a/test/old/testdir/test_quickfix.vim
+++ b/test/old/testdir/test_quickfix.vim
@@ -3210,8 +3210,11 @@ func Test_bufoverflow()
   cgetexpr ['Compiler: ' . repeat('a', 1015), 'File1:10:Hello World']
 
   set efm=%DEntering\ directory\ %f,%f:%l:%m
-  cgetexpr ['Entering directory ' . repeat('a', 1006),
-	      \ 'File1:10:Hello World']
+  let lines =<< trim eval END
+    Entering directory $"{repeat('a', 1006)}"
+    File1:10:Hello World
+  END
+  cgetexpr lines
   set efm&vim
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.0.0003: functions are global while they could be local

Problem:    Functions are global while they could be local.
Solution:   Add "static".  Add a few tests. (Yegappan Lakshmanan,
            closes vim/vim#10612)

https://github.com/vim/vim/commit/ee47eaceaa148e07b566ff420f9a3c2edde2fa34

Omit script_name_after_autoload(), untrans_function_name(): Vim9 script
only.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>