### PR TITLE
backport tohtml fixes

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4410,7 +4410,7 @@ vim.text.hexencode({str})                               *vim.text.hexencode()*
 Lua module: tohtml                                                *vim.tohtml*
 
 
-:TOhtml {file}                                                       *:TOhtml*
+:[range]TOhtml {file}                                                *:TOhtml*
 Converts the buffer shown in the current window to HTML, opens the generated
 HTML in a new split window, and saves its contents to {file}. If {file} is not
 given, a temporary file (created by |tempname()|) is used.
@@ -4432,6 +4432,8 @@ tohtml.tohtml({winid}, {opt})                         *tohtml.tohtml.tohtml()*
                  • {width}? (`integer`, default: 'textwidth' if non-zero or
                    window width otherwise) Width used for items which are
                    either right aligned or repeat a character infinitely.
+                 • {range}? (`integer[]`, default: entire buffer) Range of
+                   rows to use.
 
     Return: ~
         (`string[]`)

--- a/runtime/lua/tohtml.lua
+++ b/runtime/lua/tohtml.lua
@@ -481,8 +481,15 @@ end
 
 --- @param state vim.tohtml.state
 --- @param extmark {[1]:integer,[2]:integer,[3]:integer,[4]:vim.api.keyset.set_extmark|any}
-local function _styletable_extmarks_virt_text(state, extmark)
+--- @param namespaces table<integer,string>
+local function _styletable_extmarks_virt_text(state, extmark, namespaces)
   if not extmark[4].virt_text then
+    return
+  end
+  ---TODO(altermo) LSP semantic tokens (and some other extmarks) are only
+  ---generated in visible lines, and not in the whole buffer.
+  if (namespaces[extmark[4].ns_id] or ''):find('vim_lsp_inlayhint') then
+    vim.notify_once('Info(TOhtml): lsp inlay hints are not supported, HTML may be incorrect')
     return
   end
   local styletable = state.style
@@ -586,7 +593,7 @@ local function styletable_extmarks(state)
     _styletable_extmarks_conceal(state, v)
   end
   for _, v in ipairs(extmarks) do
-    _styletable_extmarks_virt_text(state, v)
+    _styletable_extmarks_virt_text(state, v, namespaces)
   end
   for _, v in ipairs(extmarks) do
     _styletable_extmarks_virt_lines(state, v)

--- a/runtime/lua/tohtml.lua
+++ b/runtime/lua/tohtml.lua
@@ -188,6 +188,8 @@ local background_color_cache = nil
 --- @type string?
 local foreground_color_cache = nil
 
+local len = vim.api.nvim_strwidth
+
 --- @see https://invisible-island.net/xterm/ctlseqs/ctlseqs.html#h3-Operating-System-Commands
 --- @param color "background"|"foreground"|integer
 --- @return string?
@@ -312,9 +314,12 @@ local function style_line_insert_virt_text(style_line, col, val)
 end
 
 --- @param state vim.tohtml.state
---- @param hl string|integer|nil
+--- @param hl string|integer|string[]|integer[]?
 --- @return nil|integer
 local function register_hl(state, hl)
+  if type(hl) == 'table' then
+    hl = hl[#hl]
+  end
   if type(hl) == 'nil' then
     return
   elseif type(hl) == 'string' then
@@ -537,7 +542,7 @@ local function _styletable_extmarks_virt_text(state, extmark, namespaces)
       else
         style_line_insert_virt_text(styletable[row + 1], col + 1, { i[1], hlid })
       end
-      virt_text_len = virt_text_len + #i[1]
+      virt_text_len = virt_text_len + len(i[1])
     end
     if extmark[4].virt_text_pos == 'overlay' then
       styletable_insert_range(state, row + 1, col + 1, row + 1, col + virt_text_len + 1, HIDE_ID)
@@ -782,7 +787,7 @@ local function styletable_statuscolumn(state)
       statuscolumn,
       { winid = state.winid, use_statuscol_lnum = row, highlights = true }
     )
-    local width = vim.api.nvim_strwidth(status.str)
+    local width = len(status.str)
     if width > minwidth then
       minwidth = width
     end
@@ -797,7 +802,7 @@ local function styletable_statuscolumn(state)
     for k, v in ipairs(hls) do
       local text = str:sub(v.start + 1, hls[k + 1] and hls[k + 1].start or nil)
       if k == #hls then
-        text = text .. (' '):rep(minwidth - vim.api.nvim_strwidth(str))
+        text = text .. (' '):rep(minwidth - len(str))
       end
       if text ~= '' then
         local hlid = register_hl(state, v.group)
@@ -817,7 +822,6 @@ local function styletable_listchars(state)
   local function utf8_sub(str, i, j)
     return vim.fn.strcharpart(str, i - 1, j and j - i + 1 or nil)
   end
-  local len = vim.api.nvim_strwidth
   --- @type table<string,string>
   local listchars = vim.opt_local.listchars:get()
   local ids = setmetatable({}, {

--- a/runtime/lua/tohtml.lua
+++ b/runtime/lua/tohtml.lua
@@ -1,6 +1,6 @@
 --- @brief
 ---<pre>help
----:TOhtml {file}                                                       *:TOhtml*
+---:[range]TOhtml {file}                                                *:TOhtml*
 ---Converts the buffer shown in the current window to HTML, opens the generated
 ---HTML in a new split window, and saves its contents to {file}. If {file} is not
 ---given, a temporary file (created by |tempname()|) is used.
@@ -40,7 +40,8 @@
 --- @field winid integer
 --- @field bufnr integer
 --- @field width integer
---- @field buflen integer
+--- @field start integer
+--- @field end_ integer
 
 --- @class (private) vim.tohtml.styletable
 --- @field [integer] vim.tohtml.line (integer: (1-index, exclusive))
@@ -395,7 +396,7 @@ end
 
 --- @param state vim.tohtml.state
 local function styletable_syntax(state)
-  for row = 1, state.buflen do
+  for row = state.start, state.end_ do
     local prev_id = 0
     local prev_col = nil
     for col = 1, #vim.fn.getline(row) + 1 do
@@ -415,7 +416,7 @@ end
 --- @param state vim.tohtml.state
 local function styletable_diff(state)
   local styletable = state.style
-  for row = 1, state.buflen do
+  for row = state.start, state.end_ do
     local style_line = styletable[row]
     local filler = vim.fn.diff_filler(row)
     if filler ~= 0 then
@@ -425,7 +426,7 @@ local function styletable_diff(state)
         { { fill:rep(state.width), register_hl(state, 'DiffDelete') } }
       )
     end
-    if row == state.buflen + 1 then
+    if row == state.end_ + 1 then
       break
     end
     local prev_id = 0
@@ -467,7 +468,9 @@ local function styletable_treesitter(state)
     if not query then
       return
     end
-    for capture, node, metadata in query:iter_captures(root, buf_highlighter.bufnr, 0, state.buflen) do
+    for capture, node, metadata in
+      query:iter_captures(root, buf_highlighter.bufnr, state.start - 1, state.end_)
+    do
       local srow, scol, erow, ecol = node:range()
       --- @diagnostic disable-next-line: invisible
       local c = q._query.captures[capture]
@@ -521,7 +524,7 @@ local function _styletable_extmarks_virt_text(state, extmark, namespaces)
   --- @type integer,integer
   local row, col = extmark[2], extmark[3]
   if
-    row < state.buflen
+    row < vim.api.nvim_buf_line_count(state.bufnr)
     and (
       extmark[4].virt_text_pos == 'inline'
       or extmark[4].virt_text_pos == 'eol'
@@ -630,7 +633,7 @@ end
 local function styletable_folds(state)
   local styletable = state.style
   local has_folded = false
-  for row = 1, state.buflen do
+  for row = state.start, state.end_ do
     if vim.fn.foldclosed(row) > 0 then
       has_folded = true
       styletable[row].hide = true
@@ -652,7 +655,7 @@ end
 local function styletable_conceal(state)
   local bufnr = state.bufnr
   vim.api.nvim_buf_call(bufnr, function()
-    for row = 1, state.buflen do
+    for row = state.start, state.end_ do
       --- @type table<integer,{[1]:integer,[2]:integer,[3]:string}>
       local conceals = {}
       local line_len_exclusive = #vim.fn.getline(row) + 1
@@ -770,7 +773,7 @@ local function styletable_statuscolumn(state)
       local max = tonumber(foldcolumn:match('^%w-:(%d)')) or 1
       local maxfold = 0
       vim.api.nvim_buf_call(state.bufnr, function()
-        for row = 1, vim.api.nvim_buf_line_count(state.bufnr) do
+        for row = state.start, state.end_ do
           local foldlevel = vim.fn.foldlevel(row)
           if foldlevel > maxfold then
             maxfold = foldlevel
@@ -785,7 +788,7 @@ local function styletable_statuscolumn(state)
 
   --- @type table<integer,any>
   local statuses = {}
-  for row = 1, state.buflen do
+  for row = state.start, state.end_ do
     local status = vim.api.nvim_eval_statusline(
       statuscolumn,
       { winid = state.winid, use_statuscol_lnum = row, highlights = true }
@@ -835,7 +838,7 @@ local function styletable_listchars(state)
   })
 
   if listchars.eol then
-    for row = 1, state.buflen do
+    for row = state.start, state.end_ do
       local style_line = state.style[row]
       style_line_insert_overlay_char(
         style_line,
@@ -1129,16 +1132,22 @@ end
 local function extend_pre(out, state)
   local styletable = state.style
   table.insert(out, '<pre>')
+  local out_start = #out
   local hide_count = 0
   --- @type integer[]
   local stack = {}
 
+  local before = ''
+  local after = ''
   local function loop(row)
+    local inside = row <= state.end_ and row >= state.start
     local style_line = styletable[row]
     if style_line.hide and (styletable[row - 1] or {}).hide then
       return
     end
-    _extend_virt_lines(out, state, row)
+    if inside then
+      _extend_virt_lines(out, state, row)
+    end
     --Possible improvement (altermo):
     --Instead of looping over all the buffer characters per line,
     --why not loop over all the style_line cells,
@@ -1148,7 +1157,9 @@ local function extend_pre(out, state)
     end
     local line = vim.api.nvim_buf_get_lines(state.bufnr, row - 1, row, false)[1] or ''
     local s = ''
-    s = s .. _pre_text_to_html(state, row)
+    if inside then
+      s = s .. _pre_text_to_html(state, row)
+    end
     local true_line_len = #line + 1
     for k in pairs(style_line) do
       if type(k) == 'number' and k > true_line_len then
@@ -1195,7 +1206,7 @@ local function extend_pre(out, state)
           end
         end
 
-        if cell[3] then
+        if cell[3] and inside then
           s = s .. _virt_text_to_html(state, cell)
         end
 
@@ -1206,7 +1217,7 @@ local function extend_pre(out, state)
         break
       end
 
-      if hide_count == 0 then
+      if hide_count == 0 and inside then
         s = s
           .. _char_to_html(
             state,
@@ -1215,12 +1226,20 @@ local function extend_pre(out, state)
           )
       end
     end
-    table.insert(out, s)
+    if row > state.end_ + 1 then
+      after = after .. s
+    elseif row < state.start then
+      before = s .. before
+    else
+      table.insert(out, s)
+    end
   end
 
-  for row = 1, state.buflen + 1 do
+  for row = 1, vim.api.nvim_buf_line_count(state.bufnr) + 1 do
     loop(row)
   end
+  out[out_start] = out[out_start] .. before
+  out[#out] = out[#out] .. after
   assert(#stack == 0, 'an open HTML tag was never closed')
   table.insert(out, '</pre>')
 end
@@ -1252,6 +1271,7 @@ local function global_state_to_state(winid, global_state)
   if not width or width < 1 then
     width = vim.api.nvim_win_get_width(winid)
   end
+  local range = opt.range or { 1, vim.api.nvim_buf_line_count(bufnr) }
   local state = setmetatable({
     winid = winid == 0 and vim.api.nvim_get_current_win() or winid,
     opt = vim.wo[winid],
@@ -1259,7 +1279,8 @@ local function global_state_to_state(winid, global_state)
     bufnr = bufnr,
     tabstop = (' '):rep(vim.bo[bufnr].tabstop),
     width = width,
-    buflen = vim.api.nvim_buf_line_count(bufnr),
+    start = range[1],
+    end_ = range[2],
   }, { __index = global_state })
   return state --[[@as vim.tohtml.state]]
 end
@@ -1318,35 +1339,22 @@ local function state_generate_style(state)
   end)
 end
 
---- @param winid integer[]|integer
+--- @param winid integer
 --- @param opt? vim.tohtml.opt
 --- @return string[]
 local function win_to_html(winid, opt)
-  if type(winid) == 'number' then
-    winid = { winid }
-  end
-  --- @cast winid integer[]
-  assert(#winid > 0, 'no window specified')
   opt = opt or {}
-  local title = table.concat(
-    vim.tbl_map(vim.api.nvim_buf_get_name, vim.tbl_map(vim.api.nvim_win_get_buf, winid)),
-    ','
-  )
+  local title = vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(winid))
+
   local global_state = opt_to_global_state(opt, title)
-  --- @type vim.tohtml.state[]
-  local states = {}
-  for _, i in ipairs(winid) do
-    local state = global_state_to_state(i, global_state)
-    state_generate_style(state)
-    table.insert(states, state)
-  end
+  local state = global_state_to_state(winid, global_state)
+  state_generate_style(state)
+
   local html = {}
   extend_html(html, function()
     extend_head(html, global_state)
     extend_body(html, function()
-      for _, state in ipairs(states) do
-        extend_pre(html, state)
-      end
+      extend_pre(html, state)
     end)
   end)
   return html
@@ -1373,6 +1381,10 @@ local M = {}
 --- infinitely.
 --- (default: 'textwidth' if non-zero or window width otherwise)
 --- @field width? integer
+---
+--- Range of rows to use.
+--- (default: entire buffer)
+--- @field range? integer[]
 
 --- Converts the buffer shown in the window {winid} to HTML and returns the output as a list of string.
 --- @param winid? integer Window to convert (defaults to current window)

--- a/runtime/lua/tohtml.lua
+++ b/runtime/lua/tohtml.lua
@@ -521,9 +521,12 @@ local function _styletable_extmarks_virt_text(state, extmark, namespaces)
   --- @type integer,integer
   local row, col = extmark[2], extmark[3]
   if
-    extmark[4].virt_text_pos == 'inline'
-    or extmark[4].virt_text_pos == 'eol'
-    or extmark[4].virt_text_pos == 'overlay'
+    row < state.buflen
+    and (
+      extmark[4].virt_text_pos == 'inline'
+      or extmark[4].virt_text_pos == 'eol'
+      or extmark[4].virt_text_pos == 'overlay'
+    )
   then
     if extmark[4].virt_text_pos == 'eol' then
       style_line_insert_virt_text(styletable[row + 1], #vim.fn.getline(row + 1) + 1, { ' ' })
@@ -1146,7 +1149,13 @@ local function extend_pre(out, state)
     local line = vim.api.nvim_buf_get_lines(state.bufnr, row - 1, row, false)[1] or ''
     local s = ''
     s = s .. _pre_text_to_html(state, row)
-    for col = 1, #line + 1 do
+    local true_line_len = #line + 1
+    for k in pairs(style_line) do
+      if type(k) == 'number' and k > true_line_len then
+        true_line_len = k
+      end
+    end
+    for col = 1, true_line_len do
       local cell = style_line[col]
       --- @type table?
       local char
@@ -1193,7 +1202,7 @@ local function extend_pre(out, state)
         char = cell[4][#cell[4]]
       end
 
-      if col == #line + 1 and not char then
+      if col == true_line_len and not char then
         break
       end
 

--- a/runtime/lua/tohtml.lua
+++ b/runtime/lua/tohtml.lua
@@ -521,7 +521,7 @@ local function _styletable_extmarks_virt_text(state, extmark)
     hl_mode = 'blend',
     hl_group = 'combine',
   }
-  for opt, val in ipairs(not_supported) do
+  for opt, val in pairs(not_supported) do
     if extmark[4][opt] == val then
       vim.notify_once(
         ('Info(TOhtml): extmark.%s="%s" is not supported, HTML may be incorrect'):format(opt, val)

--- a/runtime/lua/tohtml.lua
+++ b/runtime/lua/tohtml.lua
@@ -57,6 +57,26 @@
 --- @field [3] any[][] virt_text
 --- @field [4] any[][] overlay_text
 
+--- @type string[]
+local notifications = {}
+
+---@param msg string
+local function notify(msg)
+  if #notifications == 0 then
+    vim.schedule(function()
+      if #notifications > 1 then
+        vim.notify(
+          ('TOhtml: %s (+ %d more warnings)'):format(notifications[1], tostring(#notifications - 1))
+        )
+      elseif #notifications == 1 then
+        vim.notify('TOhtml: ' .. notifications[1])
+      end
+      notifications = {}
+    end)
+  end
+  table.insert(notifications, msg)
+end
+
 local HIDE_ID = -1
 -- stylua: ignore start
 local cterm_8_to_hex={
@@ -215,7 +235,7 @@ local function cterm_to_hex(colorstr)
   if hex then
     cterm_color_cache[color] = hex
   else
-    vim.notify_once("Info(TOhtml): Couldn't get terminal colors, using fallback")
+    notify("Couldn't get terminal colors, using fallback")
     local t_Co = tonumber(vim.api.nvim_eval('&t_Co'))
     if t_Co <= 8 then
       cterm_color_cache = cterm_8_to_hex
@@ -241,7 +261,7 @@ local function get_background_color()
   end
   local hex = try_query_terminal_color('background')
   if not hex or not hex:match('#%x%x%x%x%x%x') then
-    vim.notify_once("Info(TOhtml): Couldn't get terminal background colors, using fallback")
+    notify("Couldn't get terminal background colors, using fallback")
     hex = vim.o.background == 'light' and '#ffffff' or '#000000'
   end
   background_color_cache = hex
@@ -259,7 +279,7 @@ local function get_foreground_color()
   end
   local hex = try_query_terminal_color('foreground')
   if not hex or not hex:match('#%x%x%x%x%x%x') then
-    vim.notify_once("Info(TOhtml): Couldn't get terminal foreground colors, using fallback")
+    notify("Couldn't get terminal foreground colors, using fallback")
     hex = vim.o.background == 'light' and '#000000' or '#ffffff'
   end
   foreground_color_cache = hex
@@ -467,7 +487,7 @@ local function _styletable_extmarks_highlight(state, extmark, namespaces)
   ---TODO(altermo) LSP semantic tokens (and some other extmarks) are only
   ---generated in visible lines, and not in the whole buffer.
   if (namespaces[extmark[4].ns_id] or ''):find('vim_lsp_semantic_tokens') then
-    vim.notify_once('Info(TOhtml): lsp semantic tokens are not supported, HTML may be incorrect')
+    notify('lsp semantic tokens are not supported, HTML may be incorrect')
     return
   end
   local srow, scol, erow, ecol =
@@ -489,7 +509,7 @@ local function _styletable_extmarks_virt_text(state, extmark, namespaces)
   ---TODO(altermo) LSP semantic tokens (and some other extmarks) are only
   ---generated in visible lines, and not in the whole buffer.
   if (namespaces[extmark[4].ns_id] or ''):find('vim_lsp_inlayhint') then
-    vim.notify_once('Info(TOhtml): lsp inlay hints are not supported, HTML may be incorrect')
+    notify('lsp inlay hints are not supported, HTML may be incorrect')
     return
   end
   local styletable = state.style
@@ -530,9 +550,7 @@ local function _styletable_extmarks_virt_text(state, extmark, namespaces)
   }
   for opt, val in pairs(not_supported) do
     if extmark[4][opt] == val then
-      vim.notify_once(
-        ('Info(TOhtml): extmark.%s="%s" is not supported, HTML may be incorrect'):format(opt, val)
-      )
+      notify(('extmark.%s="%s" is not supported, HTML may be incorrect'):format(opt, val))
     end
   end
 end
@@ -618,9 +636,7 @@ local function styletable_folds(state)
     end
   end
   if has_folded and type(({ pcall(vim.api.nvim_eval, vim.o.foldtext) })[2]) == 'table' then
-    vim.notify_once(
-      'Info(TOhtml): foldtext returning a table is half supported, HTML may be incorrect'
-    )
+    notify('foldtext returning a table with highlights is not supported, HTML may be incorrect')
   end
 end
 

--- a/runtime/plugin/tohtml.lua
+++ b/runtime/plugin/tohtml.lua
@@ -5,8 +5,8 @@ vim.g.loaded_2html_plugin = true
 
 vim.api.nvim_create_user_command('TOhtml', function(args)
   local outfile = args.args ~= '' and args.args or vim.fn.tempname() .. '.html'
-  local html = require('tohtml').tohtml()
+  local html = require('tohtml').tohtml(0, { range = { args.line1, args.line2 } })
   vim.fn.writefile(html, outfile)
   vim.cmd.split(outfile)
   vim.bo.filetype = 'html'
-end, { bar = true, nargs = '?' })
+end, { bar = true, nargs = '?', range = '%' })

--- a/test/functional/plugin/tohtml_spec.lua
+++ b/test/functional/plugin/tohtml_spec.lua
@@ -176,6 +176,44 @@ describe(':TOhtml', function()
     }, fn.readfile(out_file))
   end)
 
+  it('expected internal html generated from range', function()
+    insert([[
+    line1
+    line2
+    line3
+    ]])
+    local ns = api.nvim_create_namespace ''
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_col = 1, end_row = 1, hl_group = 'Visual' })
+    exec('set termguicolors')
+    local bg = fn.synIDattr(fn.hlID('Normal'), 'bg#', 'gui')
+    local fg = fn.synIDattr(fn.hlID('Normal'), 'fg#', 'gui')
+    exec_lua [[
+    local html = vim.cmd'2,2TOhtml'
+    ]]
+    local out_file = api.nvim_buf_get_name(api.nvim_get_current_buf())
+    eq({
+      '<!DOCTYPE html>',
+      '<html>',
+      '<head>',
+      '<meta charset="UTF-8">',
+      '<title></title>',
+      ('<meta name="colorscheme" content="%s"></meta>'):format(api.nvim_get_var('colors_name')),
+      '<style>',
+      '* {font-family: monospace}',
+      ('body {background-color: %s; color: %s}'):format(bg, fg),
+      '.Visual {background-color: #9b9ea4}',
+      '</style>',
+      '</head>',
+      '<body style="display: flex">',
+      '<pre><span class="Visual">',
+      'l</span>ine2',
+      '',
+      '</pre>',
+      '</body>',
+      '</html>',
+    }, fn.readfile(out_file))
+  end)
+
   it('highlight attributes generated', function()
     --Make sure to uncomment the attribute in `html_syntax_match()`
     exec('hi LINE gui=' .. table.concat({

--- a/test/functional/plugin/tohtml_spec.lua
+++ b/test/functional/plugin/tohtml_spec.lua
@@ -287,7 +287,13 @@ describe(':TOhtml', function()
         0,
         { virt_text = { { 'foo' } }, virt_text_pos = 'overlay' }
       )
-      api.nvim_buf_set_extmark(0, ns, 2, 0, { virt_text = { { 'foo' } }, virt_text_pos = 'inline' })
+      api.nvim_buf_set_extmark(
+        0,
+        ns,
+        2,
+        0,
+        { virt_text = { { 'fo┊o', { 'Conceal', 'Comment' } } }, virt_text_pos = 'inline' }
+      )
       --api.nvim_buf_set_extmark(0,ns,3,0,{virt_text={{'foo'}},virt_text_pos='right_align'})
       run_tohtml_and_assert(screen)
     end)


### PR DESCRIPTION
- **fix(tohtml): replace ipairs with pairs**
- **fix(tohtml): ignore lsp inlay hints**
- **fix(tohtml): show how many warnings are hidden**
- **fix(tohtml): properly handle multiple hl groups #29012**
- **fix(tohtml): extmark text may be out of bounds**
- **fix(tohtml): support ranges again**
