### PR TITLE
vim-patch:9.1.0601: Wrong cursor position with 'breakindent' when wide char doesn't fit

### DIFF
--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -268,7 +268,7 @@ CharSize charsize_regular(CharsizeArg *csarg, char *const cur, colnr_T const vco
           head += (max_head_vcol - (vcol + head_prev + prev_rem)
                    + width2 - 1) / width2 * head_mid;
         } else if (max_head_vcol < 0) {
-          int off = virt_text_cursor_off(csarg, *cur == NUL);
+          int off = mb_added + virt_text_cursor_off(csarg, *cur == NUL);
           if (off >= prev_rem) {
             if (size > off) {
               head += (1 + (off - prev_rem) / width) * head_mid;

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -4027,11 +4027,23 @@ describe('decorations: inline virtual text', function()
       normal! $
     ]])
     api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { ('b'):rep(9) } }, virt_text_pos = 'inline' })
-    screen:expect{grid=[[
+    screen:expect([[
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbb{1:>}|
       口1234^5                                           |
                                                         |
-    ]]}
+    ]])
+    feed('g0')
+    screen:expect([[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbb{1:>}|
+      ^口12345                                           |
+                                                        |
+    ]])
+    command('set showbreak=+++')
+    screen:expect([[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbbbbbb{1:>}|
+      {1:+++}^口12345                                        |
+                                                        |
+    ]])
   end)
 end)
 

--- a/test/old/testdir/test_breakindent.vim
+++ b/test/old/testdir/test_breakindent.vim
@@ -1205,4 +1205,15 @@ func Test_breakindent_min_with_signcol()
   call s:close_windows()
 endfunc
 
+func Test_breakindent_with_double_width_wrap()
+  50vnew
+  setlocal tabstop=8 breakindent nolist
+  call setline(1, "\t" .. repeat('a', winwidth(0) - 9) .. '口口口')
+  normal! $g0
+  call assert_equal(2, winline())
+  call assert_equal(9, wincol())
+
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_listlbr_utf8.vim
+++ b/test/old/testdir/test_listlbr_utf8.vim
@@ -280,6 +280,9 @@ func Test_chinese_char_on_wrap_column()
   call s:compare_lines(expect, lines)
   call assert_equal(len(expect), winline())
   call assert_equal(strwidth(trim(expect[-1], ' ', 2)), wincol())
+  norm! g0
+  call assert_equal(len(expect), winline())
+  call assert_equal(1, wincol())
   call s:close_windows()
 endfunc
 
@@ -315,6 +318,9 @@ func Test_chinese_char_on_wrap_column_sbr()
   call s:compare_lines(expect, lines)
   call assert_equal(len(expect), winline())
   call assert_equal(strwidth(trim(expect[-1], ' ', 2)), wincol())
+  norm! g0
+  call assert_equal(len(expect), winline())
+  call assert_equal(4, wincol())
   call s:close_windows()
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.0601: Wrong cursor position with 'breakindent' when wide char doesn't fit

Problem:  Wrong cursor position with 'breakindent' when a double-width
          character doesn't fit in a screen line (mikoto2000)
Solution: Include the width of the 'breakindent' properly.
          (zeertzjq)

closes: vim/vim#15290

https://github.com/vim/vim/commit/b5d6b5caac752fe15856e37fd3abc5459292d4b8