### PR TITLE
vim-patch:eb6d733: runtime(doc): fix more inconsistencies in assert function docs

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -169,8 +169,8 @@ assert_equal({expected}, {actual} [, {msg}])                    *assert_equal()*
 		added to |v:errors| and 1 is returned.  Otherwise zero is
 		returned. |assert-return|
 		The error is in the form "Expected {expected} but got
-		{actual}".  When {msg} is present it is prefixed to that, along
-		with the location of the assert when run from a script.
+		{actual}".  When {msg} is present it is prefixed to that,
+		along with the location of the assert when run from a script.
 
 		There is no automatic conversion, the String "4" is different
 		from the Number 4.  And the number 4 is different from the
@@ -211,16 +211,16 @@ assert_fails({cmd} [, {error} [, {msg} [, {lnum} [, {context}]]]])
 		When {error} is a string it must be found literally in the
 		first reported error. Most often this will be the error code,
 		including the colon, e.g. "E123:". >vim
-			assert_fails('bad cmd', 'E987:')
+			call assert_fails('bad cmd', 'E987:')
 <
 		When {error} is a |List| with one or two strings, these are
 		used as patterns.  The first pattern is matched against the
 		first reported error: >vim
-			assert_fails('cmd', ['E987:.*expected bool'])
+			call assert_fails('cmd', ['E987:.*expected bool'])
 <		The second pattern, if present, is matched against the last
 		reported error.  To only match the last error use an empty
 		string for the first error: >vim
-			assert_fails('cmd', ['', 'E987:'])
+			call assert_fails('cmd', ['', 'E987:'])
 <
 		If {msg} is empty then it is not used.  Do this to get the
 		default message when passing the {lnum} argument.
@@ -241,8 +241,8 @@ assert_false({actual} [, {msg}])                                *assert_false()*
 		When {actual} is not false an error message is added to
 		|v:errors|, like with |assert_equal()|.
 		The error is in the form "Expected False but got {actual}".
-		When {msg} is present it is prepended to that, along
-		with the location of the assert when run from a script.
+		When {msg} is present it is prefixed to that, along with the
+		location of the assert when run from a script.
 		Also see |assert-return|.
 
 		A value is false when it is zero. When {actual} is not a
@@ -272,7 +272,7 @@ assert_match({pattern}, {actual} [, {msg}])                     *assert_match()*
 		Use both to match the whole text.
 
 		Example: >vim
-			assert_match('^f.*o$', 'foobar')
+			call assert_match('^f.*o$', 'foobar')
 <		Will result in a string to be added to |v:errors|:
 			test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
 
@@ -301,8 +301,8 @@ assert_true({actual} [, {msg}])                                  *assert_true()*
 		Also see |assert-return|.
 		A value is |TRUE| when it is a non-zero number or |v:true|.
 		When {actual} is not a number or |v:true| the assert fails.
-		When {msg} is given it precedes the default message, along
-		with the location of the assert when run from a script.
+		When {msg} is given it is prefixed to the default message,
+		along with the location of the assert when run from a script.
 
 atan({expr})                                                            *atan()*
 		Return the principal value of the arc tangent of {expr}, in

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -203,8 +203,8 @@ function vim.fn.assert_beeps(cmd) end
 --- added to |v:errors| and 1 is returned.  Otherwise zero is
 --- returned. |assert-return|
 --- The error is in the form "Expected {expected} but got
---- {actual}".  When {msg} is present it is prefixed to that, along
---- with the location of the assert when run from a script.
+--- {actual}".  When {msg} is present it is prefixed to that,
+--- along with the location of the assert when run from a script.
 ---
 --- There is no automatic conversion, the String "4" is different
 --- from the Number 4.  And the number 4 is different from the
@@ -255,16 +255,16 @@ function vim.fn.assert_exception(error, msg) end
 --- When {error} is a string it must be found literally in the
 --- first reported error. Most often this will be the error code,
 --- including the colon, e.g. "E123:". >vim
----   assert_fails('bad cmd', 'E987:')
+---   call assert_fails('bad cmd', 'E987:')
 --- <
 --- When {error} is a |List| with one or two strings, these are
 --- used as patterns.  The first pattern is matched against the
 --- first reported error: >vim
----   assert_fails('cmd', ['E987:.*expected bool'])
+---   call assert_fails('cmd', ['E987:.*expected bool'])
 --- <The second pattern, if present, is matched against the last
 --- reported error.  To only match the last error use an empty
 --- string for the first error: >vim
----   assert_fails('cmd', ['', 'E987:'])
+---   call assert_fails('cmd', ['', 'E987:'])
 --- <
 --- If {msg} is empty then it is not used.  Do this to get the
 --- default message when passing the {lnum} argument.
@@ -292,8 +292,8 @@ function vim.fn.assert_fails(cmd, error, msg, lnum, context) end
 --- When {actual} is not false an error message is added to
 --- |v:errors|, like with |assert_equal()|.
 --- The error is in the form "Expected False but got {actual}".
---- When {msg} is present it is prepended to that, along
---- with the location of the assert when run from a script.
+--- When {msg} is present it is prefixed to that, along with the
+--- location of the assert when run from a script.
 --- Also see |assert-return|.
 ---
 --- A value is false when it is zero. When {actual} is not a
@@ -333,7 +333,7 @@ function vim.fn.assert_inrange(lower, upper, actual, msg) end
 --- Use both to match the whole text.
 ---
 --- Example: >vim
----   assert_match('^f.*o$', 'foobar')
+---   call assert_match('^f.*o$', 'foobar')
 --- <Will result in a string to be added to |v:errors|:
 ---   test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
 ---
@@ -383,8 +383,8 @@ function vim.fn.assert_report(msg) end
 --- Also see |assert-return|.
 --- A value is |TRUE| when it is a non-zero number or |v:true|.
 --- When {actual} is not a number or |v:true| the assert fails.
---- When {msg} is given it precedes the default message, along
---- with the location of the assert when run from a script.
+--- When {msg} is given it is prefixed to the default message,
+--- along with the location of the assert when run from a script.
 ---
 --- @param actual any
 --- @param msg? any

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -301,8 +301,8 @@ M.funcs = {
       added to |v:errors| and 1 is returned.  Otherwise zero is
       returned. |assert-return|
       The error is in the form "Expected {expected} but got
-      {actual}".  When {msg} is present it is prefixed to that, along
-      with the location of the assert when run from a script.
+      {actual}".  When {msg} is present it is prefixed to that,
+      along with the location of the assert when run from a script.
 
       There is no automatic conversion, the String "4" is different
       from the Number 4.  And the number 4 is different from the
@@ -367,16 +367,16 @@ M.funcs = {
       When {error} is a string it must be found literally in the
       first reported error. Most often this will be the error code,
       including the colon, e.g. "E123:". >vim
-      	assert_fails('bad cmd', 'E987:')
+      	call assert_fails('bad cmd', 'E987:')
       <
       When {error} is a |List| with one or two strings, these are
       used as patterns.  The first pattern is matched against the
       first reported error: >vim
-      	assert_fails('cmd', ['E987:.*expected bool'])
+      	call assert_fails('cmd', ['E987:.*expected bool'])
       <The second pattern, if present, is matched against the last
       reported error.  To only match the last error use an empty
       string for the first error: >vim
-      	assert_fails('cmd', ['', 'E987:'])
+      	call assert_fails('cmd', ['', 'E987:'])
       <
       If {msg} is empty then it is not used.  Do this to get the
       default message when passing the {lnum} argument.
@@ -412,8 +412,8 @@ M.funcs = {
       When {actual} is not false an error message is added to
       |v:errors|, like with |assert_equal()|.
       The error is in the form "Expected False but got {actual}".
-      When {msg} is present it is prepended to that, along
-      with the location of the assert when run from a script.
+      When {msg} is present it is prefixed to that, along with the
+      location of the assert when run from a script.
       Also see |assert-return|.
 
       A value is false when it is zero. When {actual} is not a
@@ -460,7 +460,7 @@ M.funcs = {
       Use both to match the whole text.
 
       Example: >vim
-      	assert_match('^f.*o$', 'foobar')
+      	call assert_match('^f.*o$', 'foobar')
       <Will result in a string to be added to |v:errors|:
       	test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
 
@@ -534,8 +534,8 @@ M.funcs = {
       Also see |assert-return|.
       A value is |TRUE| when it is a non-zero number or |v:true|.
       When {actual} is not a number or |v:true| the assert fails.
-      When {msg} is given it precedes the default message, along
-      with the location of the assert when run from a script.
+      When {msg} is given it is prefixed to the default message,
+      along with the location of the assert when run from a script.
 
     ]=],
     name = 'assert_true',


### PR DESCRIPTION
#### vim-patch:eb6d733: runtime(doc): fix more inconsistencies in assert function docs

related: https://github.com/vim/vim/pull/15280#issuecomment-2233771449

closes: vim/vim#15285

https://github.com/vim/vim/commit/eb6d733bef312a0634770e023e8a41f0347f1503