### PR TITLE
vim-patch:9.1.{0558,0602}

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1116,6 +1116,8 @@ function M.perl(path, bufnr)
   end
 end
 
+local prolog_patterns = { '^%s*:%-', '^%s*%%+%s', '^%s*%%+$', '^%s*/%*', '%.%s*$' }
+
 --- @type vim.filetype.mapfn
 function M.pl(_, bufnr)
   if vim.g.filetype_pl then
@@ -1124,11 +1126,7 @@ function M.pl(_, bufnr)
   -- Recognize Prolog by specific text in the first non-empty line;
   -- require a blank after the '%' because Perl uses "%list" and "%translate"
   local line = nextnonblank(bufnr, 1)
-  if
-    line and line:find(':%-')
-    or matchregex(line, [[\c\<prolog\>]])
-    or findany(line, { '^%s*%%+%s', '^%s*%%+$', '^%s*/%*' })
-  then
+  if line and matchregex(line, [[\c\<prolog\>]]) or findany(line, prolog_patterns) then
     return 'prolog'
   else
     return 'perl'
@@ -1232,11 +1230,7 @@ function M.proto(_, bufnr)
   -- Recognize Prolog by specific text in the first non-empty line;
   -- require a blank after the '%' because Perl uses "%list" and "%translate"
   local line = nextnonblank(bufnr, 1)
-  if
-    line and line:find(':%-')
-    or matchregex(line, [[\c\<prolog\>]])
-    or findany(line, { '^%s*%%+%s', '^%s*%%+$', '^%s*/%*' })
-  then
+  if line and matchregex(line, [[\c\<prolog\>]]) or findany(line, prolog_patterns) then
     return 'prolog'
   end
 end

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -2576,4 +2576,31 @@ func Test_uci_file()
   filetype off
 endfunc
 
+func Test_pro_file()
+  filetype on
+
+  "Prolog
+  call writefile([':-module(test/1,'], 'Xfile.pro', 'D')
+  split Xfile.pro
+  call assert_equal('prolog', &filetype)
+  bwipe!
+
+  call writefile(['% comment'], 'Xfile.pro', 'D')
+  split Xfile.pro
+  call assert_equal('prolog', &filetype)
+  bwipe!
+
+  call writefile(['/* multiline comment'], 'Xfile.pro', 'D')
+  split Xfile.pro
+  call assert_equal('prolog', &filetype)
+  bwipe!
+
+  call writefile(['rule(test, 1.7).'], 'Xfile.pro', 'D')
+  split Xfile.pro
+  call assert_equal('prolog', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -2600,6 +2600,44 @@ func Test_pro_file()
   call assert_equal('prolog', &filetype)
   bwipe!
 
+  " IDL
+  call writefile(['x = findgen(100)/10'], 'Xfile.pro', 'D')
+  split Xfile.pro
+  call assert_equal('idlang', &filetype)
+
+  filetype off
+endfunc
+
+
+func Test_pl_file()
+  filetype on
+
+  "Prolog
+  call writefile([':-module(test/1,'], 'Xfile.pl', 'D')
+  split Xfile.pl
+  call assert_equal('prolog', &filetype)
+  bwipe!
+
+  call writefile(['% comment'], 'Xfile.pl', 'D')
+  split Xfile.pl
+  call assert_equal('prolog', &filetype)
+  bwipe!
+
+  call writefile(['/* multiline comment'], 'Xfile.pl', 'D')
+  split Xfile.pl
+  call assert_equal('prolog', &filetype)
+  bwipe!
+
+  call writefile(['rule(test, 1.7).'], 'Xfile.pl', 'D')
+  split Xfile.pl
+  call assert_equal('prolog', &filetype)
+  bwipe!
+
+  " Perl
+  call writefile(['%data = (1, 2, 3);'], 'Xfile.pl', 'D')
+  split Xfile.pl
+  call assert_equal('perl', &filetype)
+
   filetype off
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.0558: filetype: prolog detection can be improved

Problem:  filetype: prolog detection can be improved
Solution: Improved the Prolog file detection regex and added tests for
          all cases. (igna_martinoli)

closes: vim/vim#15206

https://github.com/vim/vim/commit/50dc83cf9215aa787da54abbb0bd2ab4fb89e720

Only include the tests, as code changes are superseded by later patches.

Co-authored-by: igna_martinoli <ignamartinoli@protonmail.com>


#### vim-patch:9.1.0602: filetype: Prolog detection can be improved

Problem:  filetype: Prolog detection can be improved
Solution: update the prolog detection regex
          (igna_martinoli)

related: vim/vim#10835
related: vim/vim#15206
closes: vim/vim#15253

https://github.com/vim/vim/commit/37853b7de31ef34153fe76aa2b740d517ed0e5d4

N/A patch:

vim-patch:7347642: runtime(filetype): Fix Prolog file detection regex

Problem: filetype: .pro file detection for Prolog is broken
Solution: fixed the regex to only match on the tested
          cases (igna_martinoli)

closes: vim/vim#15206

https://github.com/vim/vim/commit/7347642633eb2de23a78c51a4388c9080440eec4

Co-authored-by: igna_martinoli <ignamartinoli@protonmail.com>
Co-authored-by: clason <c.clason@uni-graz.at>