### PR TITLE
refactor: collapse statements in single assignments

### DIFF
--- a/src/nvim/arglist.c
+++ b/src/nvim/arglist.c
@@ -346,12 +346,7 @@ static void alist_add_list(int count, char **files, int after, bool will_edit)
   int old_argcount = ARGCOUNT;
   ga_grow(&ALIST(curwin)->al_ga, count);
   if (check_arglist_locked() != FAIL) {
-    if (after < 0) {
-      after = 0;
-    }
-    if (after > ARGCOUNT) {
-      after = ARGCOUNT;
-    }
+    after = MIN(MAX(after, 0), ARGCOUNT);
     if (after < ARGCOUNT) {
       memmove(&(ARGLIST[after + count]), &(ARGLIST[after]),
               (size_t)(ARGCOUNT - after) * sizeof(aentry_T));

--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -261,11 +261,8 @@ static int buf_write_convert(struct bw_info *ip, char **bufp, int *lenp)
           ip->bw_restlen += *lenp;
           break;
         }
-        if (n > 1) {
-          c = (unsigned)utf_ptr2char((char *)ip->bw_rest);
-        } else {
-          c = ip->bw_rest[0];
-        }
+        c = (n > 1) ? (unsigned)utf_ptr2char((char *)ip->bw_rest)
+                    : ip->bw_rest[0];
         if (n >= ip->bw_restlen) {
           n -= ip->bw_restlen;
           ip->bw_restlen = 0;
@@ -289,11 +286,8 @@ static int buf_write_convert(struct bw_info *ip, char **bufp, int *lenp)
                   (size_t)ip->bw_restlen);
           break;
         }
-        if (n > 1) {
-          c = (unsigned)utf_ptr2char(*bufp + wlen);
-        } else {
-          c = (uint8_t)(*bufp)[wlen];
-        }
+        c = n > 1 ? (unsigned)utf_ptr2char(*bufp + wlen)
+                  : (uint8_t)(*bufp)[wlen];
       }
 
       if (ucs2bytes(c, &p, flags) && !ip->bw_conv_error) {
@@ -876,9 +870,7 @@ static int buf_write_make_backup(char *fname, bool append, FileInfo *file_info_o
             // Change one character, just before the extension.
             //
             char *wp = *backupp + strlen(*backupp) - 1 - strlen(backup_ext);
-            if (wp < *backupp) {                // empty file name ???
-              wp = *backupp;
-            }
+            wp = MAX(wp, *backupp);  // empty file name ???
             *wp = 'z';
             while (*wp > 'a' && os_fileinfo(*backupp, &file_info_new)) {
               (*wp)--;
@@ -993,9 +985,7 @@ nobackup:
         // Change one character, just before the extension.
         if (!p_bk && os_path_exists(*backupp)) {
           p = *backupp + strlen(*backupp) - 1 - strlen(backup_ext);
-          if (p < *backupp) {           // empty file name ???
-            p = *backupp;
-          }
+          p = MAX(p, *backupp);  // empty file name ???
           *p = 'z';
           while (*p > 'a' && os_path_exists(*backupp)) {
             (*p)--;
@@ -1255,9 +1245,7 @@ int buf_write(buf_T *buf, char *fname, char *sfname, linenr_T start, linenr_T en
     status_redraw_all();            // redraw status lines later
   }
 
-  if (end > buf->b_ml.ml_line_count) {
-    end = buf->b_ml.ml_line_count;
-  }
+  end = MIN(end, buf->b_ml.ml_line_count);
   if (buf->b_ml.ml_flags & ML_EMPTY) {
     start = end + 1;
   }

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -523,19 +523,13 @@ void changed_lines_redraw_buf(buf_T *buf, linenr_T lnum, linenr_T lnume, linenr_
 {
   if (buf->b_mod_set) {
     // find the maximum area that must be redisplayed
-    if (lnum < buf->b_mod_top) {
-      buf->b_mod_top = lnum;
-    }
+    buf->b_mod_top = MIN(buf->b_mod_top, lnum);
     if (lnum < buf->b_mod_bot) {
       // adjust old bot position for xtra lines
       buf->b_mod_bot += xtra;
-      if (buf->b_mod_bot < lnum) {
-        buf->b_mod_bot = lnum;
-      }
+      buf->b_mod_bot = MAX(buf->b_mod_bot, lnum);
     }
-    if (lnume + xtra > buf->b_mod_bot) {
-      buf->b_mod_bot = lnume + xtra;
-    }
+    buf->b_mod_bot = MAX(buf->b_mod_bot, lnume + xtra);
     buf->b_mod_xlines += xtra;
   } else {
     // set the area that must be redisplayed
@@ -2262,9 +2256,7 @@ int get_last_leader_offset(char *line, char **flags)
         for (int off = (len2 > i ? i : len2); off > 0 && off + len1 > len2;) {
           off--;
           if (!strncmp(string + off, com_leader, (size_t)(len2 - off))) {
-            if (i - off < lower_check_bound) {
-              lower_check_bound = i - off;
-            }
+            lower_check_bound = MIN(lower_check_bound, i - off);
           }
         }
       }

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -670,10 +670,7 @@ static char *get_next_or_prev_match(int mode, expand_T *xp)
         ht -= 2;
       }
       findex -= ht;
-      if (findex < 0) {
-        // few entries left, select the first entry
-        findex = 0;
-      }
+      findex = MAX(findex, 0);  // few entries left, select the first entry
     }
   } else if (mode == WILD_PAGEDOWN) {
     if (findex == xp->xp_numfiles - 1) {
@@ -701,18 +698,10 @@ static char *get_next_or_prev_match(int mode, expand_T *xp)
 
   // When wrapping around, return the original string, set findex to -1.
   if (findex < 0) {
-    if (xp->xp_orig == NULL) {
-      findex = xp->xp_numfiles - 1;
-    } else {
-      findex = -1;
-    }
+    findex = xp->xp_orig == NULL ? xp->xp_numfiles - 1 : -1;
   }
   if (findex >= xp->xp_numfiles) {
-    if (xp->xp_orig == NULL) {
-      findex = 0;
-    } else {
-      findex = -1;
-    }
+    findex = xp->xp_orig == NULL ? 0 : -1;
   }
   if (compl_match_array) {
     compl_selected = findex;
@@ -1112,9 +1101,7 @@ int showmatches(expand_T *xp, bool wildmenu)
       } else {
         j = vim_strsize(SHOW_MATCH(i));
       }
-      if (j > maxlen) {
-        maxlen = j;
-      }
+      maxlen = MAX(maxlen, j);
     }
 
     if (xp->xp_context == EXPAND_TAGS_LISTFILES) {

--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -216,12 +216,7 @@ static int coladvance2(win_T *wp, pos_T *pos, bool addspaces, bool finetune, col
     }
   }
 
-  if (idx < 0) {
-    pos->col = 0;
-  } else {
-    pos->col = idx;
-  }
-
+  pos->col = MAX(idx, 0);
   pos->coladd = 0;
 
   if (finetune) {
@@ -310,15 +305,9 @@ linenr_T get_cursor_rel_lnum(win_T *wp, linenr_T lnum)
 /// This allows for the col to be on the NUL byte.
 void check_pos(buf_T *buf, pos_T *pos)
 {
-  if (pos->lnum > buf->b_ml.ml_line_count) {
-    pos->lnum = buf->b_ml.ml_line_count;
-  }
-
+  pos->lnum = MIN(pos->lnum, buf->b_ml.ml_line_count);
   if (pos->col > 0) {
-    colnr_T len = ml_get_buf_len(buf, pos->lnum);
-    if (pos->col > len) {
-      pos->col = len;
-    }
+    pos->col = MIN(pos->col, ml_get_buf_len(buf, pos->lnum));
   }
 }
 
@@ -385,9 +374,7 @@ void check_cursor_col(win_T *win)
         int cs, ce;
 
         getvcol(win, &win->w_cursor, &cs, NULL, &ce);
-        if (win->w_cursor.coladd > ce - cs) {
-          win->w_cursor.coladd = ce - cs;
-        }
+        win->w_cursor.coladd = MIN(win->w_cursor.coladd, ce - cs);
       }
     } else {
       // avoid weird number when there is a miscalculation or overflow

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -886,9 +886,7 @@ static int get_rightmost_vcol(win_T *wp, const int *color_cols)
   if (color_cols) {
     // determine rightmost colorcolumn to possibly draw
     for (int i = 0; color_cols[i] >= 0; i++) {
-      if (ret < color_cols[i]) {
-        ret = color_cols[i];
-      }
+      ret = MAX(ret, color_cols[i]);
     }
   }
 
@@ -2560,9 +2558,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
       // Highlight 'cursorcolumn' & 'colorcolumn' past end of the line.
 
       // check if line ends before left margin
-      if (wlv.vcol < start_col + wlv.col - win_col_off(wp)) {
-        wlv.vcol = start_col + wlv.col - win_col_off(wp);
-      }
+      wlv.vcol = MAX(wlv.vcol, start_col + wlv.col - win_col_off(wp));
       // Get rid of the boguscols now, we want to draw until the right
       // edge for 'cursorcolumn'.
       wlv.col -= wlv.boguscols;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -888,10 +888,7 @@ retry:
         // Use buffer >= 64K.  Add linerest to double the size if the
         // line gets very long, to avoid a lot of copying. But don't
         // read more than 1 Mbyte at a time, so we can be interrupted.
-        size = 0x10000 + linerest;
-        if (size > 0x100000) {
-          size = 0x100000;
-        }
+        size = MIN(0x10000 + linerest, 0x100000);
       }
 
       // Protect against the argument of lalloc() going negative.
@@ -2800,9 +2797,7 @@ int check_timestamps(int focus)
         bufref_T bufref;
         set_bufref(&bufref, buf);
         const int n = buf_check_timestamp(buf);
-        if (didit < n) {
-          didit = n;
-        }
+        didit = MAX(didit, n);
         if (n > 0 && !bufref_valid(&bufref)) {
           // Autocommands have removed the buffer, start at the first one again.
           buf = firstbuf;
@@ -3192,11 +3187,7 @@ void buf_reload(buf_T *buf, int orig_mode, bool reload_options)
 
   // Restore the topline and cursor position and check it (lines may
   // have been removed).
-  if (old_topline > curbuf->b_ml.ml_line_count) {
-    curwin->w_topline = curbuf->b_ml.ml_line_count;
-  } else {
-    curwin->w_topline = old_topline;
-  }
+  curwin->w_topline = MIN(old_topline, curbuf->b_ml.ml_line_count);
   curwin->w_cursor = old_cursor;
   check_cursor(curwin);
   update_topline(curwin);

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -248,9 +248,7 @@ bool hasFoldingWin(win_T *const win, const linenr_T lnum, linenr_T *const firstp
     return false;
   }
 
-  if (last > win->w_buffer->b_ml.ml_line_count) {
-    last = win->w_buffer->b_ml.ml_line_count;
-  }
+  last = MIN(last, win->w_buffer->b_ml.ml_line_count);
   if (lastp != NULL) {
     *lastp = last;
   }
@@ -618,15 +616,11 @@ void foldCreate(win_T *wp, pos_T start, pos_T end)
       ga_grow(&fold_ga, cont);
       // If the first fold starts before the new fold, let the new fold
       // start there.  Otherwise the existing fold would change.
-      if (start_rel.lnum > fp->fd_top) {
-        start_rel.lnum = fp->fd_top;
-      }
+      start_rel.lnum = MIN(start_rel.lnum, fp->fd_top);
 
       // When last contained fold isn't completely contained, adjust end
       // of new fold.
-      if (end_rel.lnum < fp[cont - 1].fd_top + fp[cont - 1].fd_len - 1) {
-        end_rel.lnum = fp[cont - 1].fd_top + fp[cont - 1].fd_len - 1;
-      }
+      end_rel.lnum = MAX(end_rel.lnum, fp[cont - 1].fd_top + fp[cont - 1].fd_len - 1);
       // Move contained folds to inside new fold
       memmove(fold_ga.ga_data, fp, sizeof(fold_T) * (size_t)cont);
       fold_ga.ga_len += cont;
@@ -722,12 +716,8 @@ void deleteFold(win_T *const wp, const linenr_T start, const linenr_T end, const
                         (int)(found_fp - (fold_T *)found_ga->ga_data),
                         recursive);
       } else {
-        if (first_lnum > found_fp->fd_top + found_off) {
-          first_lnum = found_fp->fd_top + found_off;
-        }
-        if (last_lnum < lnum) {
-          last_lnum = lnum;
-        }
+        first_lnum = MIN(first_lnum, found_fp->fd_top + found_off);
+        last_lnum = MAX(last_lnum, lnum);
         if (!did_one) {
           parseMarker(wp);
         }
@@ -788,14 +778,10 @@ void foldUpdate(win_T *wp, linenr_T top, linenr_T bot)
   }
 
   if (wp->w_folds.ga_len > 0) {
-    linenr_T maybe_small_start = top;
-    linenr_T maybe_small_end = bot;
-
     // Mark all folds from top to bot (or bot to top) as maybe-small.
-    if (top > bot) {
-      maybe_small_start = bot;
-      maybe_small_end = top;
-    }
+    linenr_T maybe_small_start = MIN(top, bot);
+    linenr_T maybe_small_end = MAX(top, bot);
+
     fold_T *fp;
     foldFind(&wp->w_folds, maybe_small_start, &fp);
     while (fp < (fold_T *)wp->w_folds.ga_data + wp->w_folds.ga_len
@@ -1225,11 +1211,7 @@ static linenr_T setManualFoldWin(win_T *wp, linenr_T lnum, bool opening, bool re
     // Change from level-dependent folding to manual.
     if (use_level || fp->fd_flags == FD_LEVEL) {
       use_level = true;
-      if (level >= wp->w_p_fdl) {
-        fp->fd_flags = FD_CLOSED;
-      } else {
-        fp->fd_flags = FD_OPEN;
-      }
+      fp->fd_flags = level >= wp->w_p_fdl ? FD_CLOSED : FD_OPEN;
       fp2 = (fold_T *)fp->fd_nested.ga_data;
       for (int j = 0; j < fp->fd_nested.ga_len; j++) {
         fp2[j].fd_flags = FD_LEVEL;
@@ -1378,15 +1360,11 @@ static void foldMarkAdjustRecurse(win_T *wp, garray_T *gap, linenr_T line1, line
     return;
   }
 
-  linenr_T top;
-
   // In Insert mode an inserted line at the top of a fold is considered part
   // of the fold, otherwise it isn't.
-  if ((State & MODE_INSERT) && amount == 1 && line2 == MAXLNUM) {
-    top = line1 + 1;
-  } else {
-    top = line1;
-  }
+  linenr_T top = ((State & MODE_INSERT) && amount == 1 && line2 == MAXLNUM)
+                 ? line1 + 1
+                 : line1;
 
   // Find the fold containing or just below "line1".
   fold_T *fp;
@@ -1480,9 +1458,7 @@ static int getDeepestNestingRecurse(garray_T *gap)
   fold_T *fp = (fold_T *)gap->ga_data;
   for (int i = 0; i < gap->ga_len; i++) {
     int level = getDeepestNestingRecurse(&fp[i].fd_nested) + 1;
-    if (level > maxlevel) {
-      maxlevel = level;
-    }
+    maxlevel = MAX(maxlevel, level);
   }
 
   return maxlevel;
@@ -1598,7 +1574,6 @@ static void foldCreateMarkers(win_T *wp, pos_T start, pos_T end)
 static void foldAddMarker(buf_T *buf, pos_T pos, const char *marker, size_t markerlen)
 {
   char *cms = buf->b_p_cms;
-  char *newline;
   char *p = strstr(buf->b_p_cms, "%s");
   bool line_is_comment = false;
   linenr_T lnum = pos.lnum;
@@ -1614,7 +1589,7 @@ static void foldAddMarker(buf_T *buf, pos_T pos, const char *marker, size_t mark
 
   // Check if the line ends with an unclosed comment
   skip_comment(line, false, false, &line_is_comment);
-  newline = xmalloc(line_len + markerlen + strlen(cms) + 1);
+  char *newline = xmalloc(line_len + markerlen + strlen(cms) + 1);
   STRCPY(newline, line);
   // Append the marker to the end of the line
   if (p == NULL || line_is_comment) {
@@ -1737,10 +1712,7 @@ char *get_foldtext(win_T *wp, linenr_T lnum, linenr_T lnume, foldinfo_T foldinfo
 
     // Set "v:folddashes" to a string of "level" dashes.
     // Set "v:foldlevel" to "level".
-    int level = foldinfo.fi_level;
-    if (level > (int)sizeof(dashes) - 1) {
-      level = (int)sizeof(dashes) - 1;
-    }
+    int level = MIN(foldinfo.fi_level, (int)sizeof(dashes) - 1);
     memset(dashes, '-', (size_t)level);
     dashes[level] = NUL;
     set_vim_var_string(VV_FOLDDASHES, dashes, -1);
@@ -1937,9 +1909,7 @@ static void foldUpdateIEMS(win_T *const wp, linenr_T top, linenr_T bot)
 
   // When deleting lines at the end of the buffer "top" can be past the end
   // of the buffer.
-  if (top > wp->w_buffer->b_ml.ml_line_count) {
-    top = wp->w_buffer->b_ml.ml_line_count;
-  }
+  top = MIN(top, wp->w_buffer->b_ml.ml_line_count);
 
   fline_T fline;
 
@@ -2047,9 +2017,7 @@ static void foldUpdateIEMS(win_T *const wp, linenr_T top, linenr_T bot)
     if (fpn != NULL && current_fdl == fline.lvl) {
       linenr_T fold_end_lnum = fold_start_lnum + fpn->fd_len;
 
-      if (fold_end_lnum > bot) {
-        bot = fold_end_lnum;
-      }
+      bot = MAX(bot, fold_end_lnum);
     }
   }
 
@@ -2127,9 +2095,7 @@ static void foldUpdateIEMS(win_T *const wp, linenr_T top, linenr_T bot)
     if (wp->w_redraw_top == 0 || wp->w_redraw_top > top) {
       wp->w_redraw_top = top;
     }
-    if (wp->w_redraw_bot < end) {
-      wp->w_redraw_bot = end;
-    }
+    wp->w_redraw_bot = MAX(wp->w_redraw_bot, end);
   }
 
   invalid_top = 0;
@@ -2205,10 +2171,7 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *const gap, const int level,
     // and after the first line of the fold, set the level to zero to
     // force the fold to end.  Do the same when had_end is set: Previous
     // line was marked as end of a fold.
-    lvl = flp->lvl;
-    if (lvl > MAX_LEVEL) {
-      lvl = MAX_LEVEL;
-    }
+    lvl = MIN(flp->lvl, MAX_LEVEL);
     if (flp->lnum > firstlnum
         && (level > lvl - flp->start || level >= flp->had_end)) {
       lvl = 0;
@@ -2263,12 +2226,7 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *const gap, const int level,
       while (!got_int) {
         // set concat to 1 if it's allowed to concatenate this fold
         // with a previous one that touches it.
-        int concat;
-        if (flp->start != 0 || flp->had_end <= MAX_LEVEL) {
-          concat = 0;
-        } else {
-          concat = 1;
-        }
+        int concat = (flp->start != 0 || flp->had_end <= MAX_LEVEL) ? 0 : 1;
 
         // Find an existing fold to re-use.  Preferably one that
         // includes startlnum, otherwise one that ends just before
@@ -2424,9 +2382,7 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *const gap, const int level,
     if (lvl > level && fp != NULL) {
       // There is a nested fold, handle it recursively.
       // At least do one line (can happen when finish is true).
-      if (bot < flp->lnum) {
-        bot = flp->lnum;
-      }
+      bot = MAX(bot, flp->lnum);
 
       // Line numbers in the nested fold are relative to the start of
       // this fold.
@@ -2556,9 +2512,7 @@ static linenr_T foldUpdateIEMSRecurse(garray_T *const gap, const int level,
 
   // Need to redraw the lines we inspected, which might be further down than
   // was asked for.
-  if (bot < flp->lnum - 1) {
-    bot = flp->lnum - 1;
-  }
+  bot = MAX(bot, flp->lnum - 1);
 
   return bot;
 }
@@ -2898,17 +2852,11 @@ static void foldlevelIndent(fline_T *flp)
   // depends on surrounding lines
   if (*s == NUL || vim_strchr(flp->wp->w_p_fdi, (uint8_t)(*s)) != NULL) {
     // first and last line can't be undefined, use level 0
-    if (lnum == 1 || lnum == buf->b_ml.ml_line_count) {
-      flp->lvl = 0;
-    } else {
-      flp->lvl = -1;
-    }
+    flp->lvl = (lnum == 1 || lnum == buf->b_ml.ml_line_count) ? 0 : -1;
   } else {
     flp->lvl = get_indent_buf(buf, lnum) / get_sw_value(buf);
   }
-  if (flp->lvl > flp->wp->w_p_fdn) {
-    flp->lvl = (int)MAX(0, flp->wp->w_p_fdn);
-  }
+  flp->lvl = MIN(flp->lvl, (int)MAX(0, flp->wp->w_p_fdn));
 }
 
 // foldlevelDiff() {{{2
@@ -2916,11 +2864,7 @@ static void foldlevelIndent(fline_T *flp)
 /// Doesn't use any caching.
 static void foldlevelDiff(fline_T *flp)
 {
-  if (diff_infold(flp->wp, flp->lnum + flp->off)) {
-    flp->lvl = 1;
-  } else {
-    flp->lvl = 0;
-  }
+  flp->lvl = (diff_infold(flp->wp, flp->lnum + flp->off)) ? 1 : 0;
 }
 
 // foldlevelExpr() {{{2
@@ -3067,11 +3011,7 @@ static void foldlevelMarker(fline_T *flp)
         if (n > 0) {
           flp->lvl = n;
           flp->lvl_next = n;
-          if (n <= start_lvl) {
-            flp->start = 1;
-          } else {
-            flp->start = n - start_lvl;
-          }
+          flp->start = MAX(n - start_lvl, 1);
         }
       } else {
         flp->lvl++;
@@ -3088,9 +3028,7 @@ static void foldlevelMarker(fline_T *flp)
           flp->lvl = n;
           flp->lvl_next = n - 1;
           // never start a fold with an end marker
-          if (flp->lvl_next > start_lvl) {
-            flp->lvl_next = start_lvl;
-          }
+          flp->lvl_next = MIN(flp->lvl_next, start_lvl);
         }
       } else {
         flp->lvl_next--;
@@ -3101,9 +3039,7 @@ static void foldlevelMarker(fline_T *flp)
   }
 
   // The level can't go negative, must be missing a start marker.
-  if (flp->lvl_next < 0) {
-    flp->lvl_next = 0;
-  }
+  flp->lvl_next = MAX(flp->lvl_next, 0);
 }
 
 // foldlevelSyntax() {{{2
@@ -3244,11 +3180,7 @@ static void foldclosed_both(typval_T *argvars, typval_T *rettv, bool end)
     linenr_T first;
     linenr_T last;
     if (hasFoldingWin(curwin, lnum, &first, &last, false, NULL)) {
-      if (end) {
-        rettv->vval.v_number = (varnumber_T)last;
-      } else {
-        rettv->vval.v_number = (varnumber_T)first;
-      }
+      rettv->vval.v_number = (varnumber_T)(end ? last : first);
       return;
     }
   }
@@ -3336,9 +3268,7 @@ void f_foldtextresult(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   entered = true;
   linenr_T lnum = tv_get_lnum(argvars);
   // Treat illegal types and illegal string values for {lnum} the same.
-  if (lnum < 0) {
-    lnum = 0;
-  }
+  lnum = MAX(lnum, 0);
 
   foldinfo_T info = fold_info(curwin, lnum);
   if (info.fi_lines > 0) {

--- a/src/nvim/garray.c
+++ b/src/nvim/garray.c
@@ -78,16 +78,12 @@ void ga_grow(garray_T *gap, int n)
   }
 
   // the garray grows by at least growsize
-  if (n < gap->ga_growsize) {
-    n = gap->ga_growsize;
-  }
+  n = MAX(n, gap->ga_growsize);
 
   // A linear growth is very inefficient when the array grows big.  This
   // is a compromise between allocating memory that won't be used and too
   // many copy operations. A factor of 1.5 seems reasonable.
-  if (n < gap->ga_len / 2) {
-    n = gap->ga_len / 2;
-  }
+  n = MAX(n, gap->ga_len / 2);
 
   int new_maxlen = gap->ga_len + n;
 

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -268,17 +268,12 @@ static void add_buff(buffheader_T *const buf, const char *const s, ptrdiff_t sle
   }
   buf->bh_index = 0;
 
-  size_t len;
   if (buf->bh_space >= (size_t)slen) {
-    len = strlen(buf->bh_curr->b_str);
+    size_t len = strlen(buf->bh_curr->b_str);
     xmemcpyz(buf->bh_curr->b_str + len, s, (size_t)slen);
     buf->bh_space -= (size_t)slen;
   } else {
-    if (slen < MINIMAL_SIZE) {
-      len = MINIMAL_SIZE;
-    } else {
-      len = (size_t)slen;
-    }
+    size_t len = MAX(MINIMAL_SIZE, (size_t)slen);
     buffblock_T *p = xmalloc(offsetof(buffblock_T, b_str) + len + 1);
     buf->bh_space = len - (size_t)slen;
     xmemcpyz(p->b_str, s, (size_t)slen);
@@ -2238,9 +2233,7 @@ static int handle_mapping(int *keylenp, const bool *timedout, int *mapdepth)
           }
         } else {
           // No match; may have to check for termcode at next character.
-          if (max_mlen < mlen) {
-            max_mlen = mlen;
-          }
+          max_mlen = MAX(max_mlen, mlen);
         }
       }
     }
@@ -2375,9 +2368,7 @@ static int handle_mapping(int *keylenp, const bool *timedout, int *mapdepth)
           if (State & MODE_CMDLINE) {
             // redraw the command below the error
             msg_didout = true;
-            if (msg_row < cmdline_row) {
-              msg_row = cmdline_row;
-            }
+            msg_row = MAX(msg_row, cmdline_row);
             redrawcmd();
           }
         } else if (State & (MODE_NORMAL | MODE_INSERT)) {
@@ -2734,11 +2725,7 @@ static int vgetorpeek(bool advance)
           // For the cmdline window: Alternate between ESC and
           // CTRL-C: ESC for most situations and CTRL-C to close the
           // cmdline window.
-          if ((State & MODE_CMDLINE) || (cmdwin_type > 0 && tc == ESC)) {
-            c = Ctrl_C;
-          } else {
-            c = ESC;
-          }
+          c = ((State & MODE_CMDLINE) || (cmdwin_type > 0 && tc == ESC)) ? Ctrl_C : ESC;
           tc = c;
 
           // set a flag to indicate this wasn't a normal char

--- a/src/nvim/hashtab.c
+++ b/src/nvim/hashtab.c
@@ -316,10 +316,7 @@ static void hash_may_resize(hashtab_T *ht, size_t minitems)
     }
   } else {
     // Use specified size.
-    if (minitems < ht->ht_used) {
-      // just in case...
-      minitems = ht->ht_used;
-    }
+    minitems = MAX(minitems, ht->ht_used);
     // array is up to 2/3 full
     minsize = minitems * 3 / 2;
   }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1384,11 +1384,7 @@ void msgmore(int n)
     return;
   }
 
-  if (n > 0) {
-    pn = n;
-  } else {
-    pn = -n;
-  }
+  pn = abs(n);
 
   if (pn > p_report) {
     if (n > 0) {
@@ -1426,9 +1422,7 @@ void msg_start(void)
 {
   bool did_return = false;
 
-  if (msg_row < cmdline_row) {
-    msg_row = cmdline_row;
-  }
+  msg_row = MAX(msg_row, cmdline_row);
 
   if (!msg_silent) {
     XFREE_CLEAR(keep_msg);              // don't display old message now
@@ -3382,9 +3376,7 @@ void msg_advance(int col)
     }
     return;
   }
-  if (col >= Columns) {         // not enough room
-    col = Columns - 1;
-  }
+  col = MIN(col, Columns - 1);  // not enough room
   while (msg_col < col) {
     msg_putchar(' ');
   }

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -1050,9 +1050,7 @@ void do_mousescroll(cmdarg_T *cap)
     // Horizontal scrolling
     int step = shift_or_ctrl ? curwin->w_width_inner : (int)p_mousescroll_hor;
     colnr_T leftcol = curwin->w_leftcol + (cap->arg == MSCR_RIGHT ? -step : +step);
-    if (leftcol < 0) {
-      leftcol = 0;
-    }
+    leftcol = MAX(leftcol, 0);
     do_mousescroll_horiz(leftcol);
   }
 }
@@ -1619,11 +1617,8 @@ bool mouse_comp_pos(win_T *win, int *rowp, int *colp, linenr_T *lnump)
   while (row > 0) {
     // Don't include filler lines in "count"
     if (win_may_fill(win)) {
-      if (lnum == win->w_topline) {
-        row -= win->w_topfill;
-      } else {
-        row -= win_get_fill(win, lnum);
-      }
+      row -= lnum == win->w_topline ? win->w_topfill
+                                    : win_get_fill(win, lnum);
       count = plines_win_nofill(win, lnum, false);
     } else {
       count = plines_win(win, lnum, false);
@@ -1664,9 +1659,7 @@ bool mouse_comp_pos(win_T *win, int *rowp, int *colp, linenr_T *lnump)
   if (!retval) {
     // Compute the column without wrapping.
     int off = win_col_off(win) - win_col_off2(win);
-    if (col < off) {
-      col = off;
-    }
+    col = MAX(col, off);
     col += row * (win->w_width_inner - off);
 
     // Add skip column for the topline.
@@ -1681,9 +1674,7 @@ bool mouse_comp_pos(win_T *win, int *rowp, int *colp, linenr_T *lnump)
 
   // skip line number and fold column in front of the line
   col -= win_col_off(win);
-  if (col <= 0) {
-    col = 0;
-  }
+  col = MAX(col, 0);
 
   *colp = col;
   *rowp = row;

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -894,9 +894,7 @@ void curs_columns(win_T *wp, int may_scroll)
           new_leftcol = wp->w_leftcol + diff;
         }
       }
-      if (new_leftcol < 0) {
-        new_leftcol = 0;
-      }
+      new_leftcol = MAX(new_leftcol, 0);
       if (new_leftcol != (int)wp->w_leftcol) {
         wp->w_leftcol = new_leftcol;
         win_check_anchored_floats(wp);
@@ -969,11 +967,8 @@ void curs_columns(win_T *wp, int may_scroll)
       if (n > plines - wp->w_height_inner + 1) {
         n = plines - wp->w_height_inner + 1;
       }
-      if (n > 0) {
-        wp->w_skipcol = width1 + (n - 1) * width2;
-      } else {
-        wp->w_skipcol = 0;
-      }
+      wp->w_skipcol = n > 0 ? width1 + (n - 1) * width2
+                            : 0;
     } else if (extra == 1) {
       // less than 'scrolloff' lines above, decrease skipcol
       assert(so <= INT_MAX);
@@ -990,9 +985,7 @@ void curs_columns(win_T *wp, int may_scroll)
       while (endcol > wp->w_virtcol) {
         endcol -= width2;
       }
-      if (endcol > wp->w_skipcol) {
-        wp->w_skipcol = endcol;
-      }
+      wp->w_skipcol = MAX(wp->w_skipcol, endcol);
     }
 
     // adjust w_wrow for the changed w_skipcol
@@ -1129,9 +1122,7 @@ void f_screenpos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     semsg(_(e_invalid_line_number_nr), pos.lnum);
     return;
   }
-  if (pos.col < 0) {
-    pos.col = 0;
-  }
+  pos.col = MAX(pos.col, 0);
   int row = 0;
   int scol = 0;
   int ccol = 0;
@@ -1423,9 +1414,7 @@ bool scrolldown(win_T *wp, linenr_T line_count, int byfold)
     foldAdjustCursor(wp);
     coladvance(wp, wp->w_curswant);
   }
-  if (wp->w_cursor.lnum < wp->w_topline) {
-    wp->w_cursor.lnum = wp->w_topline;
-  }
+  wp->w_cursor.lnum = MAX(wp->w_cursor.lnum, wp->w_topline);
 
   return moved;
 }
@@ -1506,12 +1495,8 @@ bool scrollup(win_T *wp, linenr_T line_count, bool byfold)
     wp->w_botline += line_count;            // approximate w_botline
   }
 
-  if (wp->w_topline > wp->w_buffer->b_ml.ml_line_count) {
-    wp->w_topline = wp->w_buffer->b_ml.ml_line_count;
-  }
-  if (wp->w_botline > wp->w_buffer->b_ml.ml_line_count + 1) {
-    wp->w_botline = wp->w_buffer->b_ml.ml_line_count + 1;
-  }
+  wp->w_topline = MIN(wp->w_topline, wp->w_buffer->b_ml.ml_line_count);
+  wp->w_botline = MIN(wp->w_botline, wp->w_buffer->b_ml.ml_line_count + 1);
 
   check_topfill(wp, false);
 
@@ -1623,9 +1608,7 @@ void check_topfill(win_T *wp, bool down)
         wp->w_topfill = 0;
       } else {
         wp->w_topfill = wp->w_height_inner - n;
-        if (wp->w_topfill < 0) {
-          wp->w_topfill = 0;
-        }
+        wp->w_topfill = MAX(wp->w_topfill, 0);
       }
     }
   }
@@ -1849,15 +1832,11 @@ void scroll_cursor_top(win_T *wp, int min_scroll, int always)
     if (new_topline < wp->w_topline || always) {
       wp->w_topline = new_topline;
     }
-    if (wp->w_topline > wp->w_cursor.lnum) {
-      wp->w_topline = wp->w_cursor.lnum;
-    }
+    wp->w_topline = MIN(wp->w_topline, wp->w_cursor.lnum);
     wp->w_topfill = win_get_fill(wp, wp->w_topline);
     if (wp->w_topfill > 0 && extra > off) {
       wp->w_topfill -= extra - off;
-      if (wp->w_topfill < 0) {
-        wp->w_topfill = 0;
-      }
+      wp->w_topfill = MAX(wp->w_topfill, 0);
     }
     check_topfill(wp, false);
     if (wp->w_topline != old_topline) {
@@ -2276,18 +2255,14 @@ void cursor_correct(win_T *wp)
   if (wp->w_topline == 1) {
     above_wanted = 0;
     int max_off = wp->w_height_inner / 2;
-    if (below_wanted > max_off) {
-      below_wanted = max_off;
-    }
+    below_wanted = MIN(below_wanted, max_off);
   }
   validate_botline(wp);
   if (wp->w_botline == wp->w_buffer->b_ml.ml_line_count + 1
       && mouse_dragging == 0) {
     below_wanted = 0;
     int max_off = (wp->w_height_inner - 1) / 2;
-    if (above_wanted > max_off) {
-      above_wanted = max_off;
-    }
+    above_wanted = MIN(above_wanted, max_off);
   }
 
   // If there are sufficient file-lines above and below the cursor, we can

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -947,11 +947,9 @@ int searchit(win_T *win, buf_T *buf, pos_T *pos, pos_T *end_pos, Direction dir, 
       // This message is also remembered in keep_msg for when the screen
       // is redrawn. The keep_msg is cleared whenever another message is
       // written.
-      if (dir == BACKWARD) {        // start second loop at the other end
-        lnum = buf->b_ml.ml_line_count;
-      } else {
-        lnum = 1;
-      }
+      lnum = dir == BACKWARD  // start second loop at the other end
+             ? buf->b_ml.ml_line_count
+             : 1;
       if (!shortmess(SHM_SEARCH)
           && shortmess(SHM_SEARCHCOUNT)
           && (options & SEARCH_MSG)) {
@@ -1053,7 +1051,6 @@ static int first_submatch(regmmatch_T *rp)
 int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, size_t patlen, int count,
               int options, searchit_arg_T *sia)
 {
-  pos_T pos;                    // position of the last match
   char *searchstr;
   size_t searchstrlen;
   int retval;                   // Return value
@@ -1078,7 +1075,8 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, size_t patlen
   // (there is no "if ()" around this because gcc wants them initialized)
   SearchOffset old_off = spats[0].off;
 
-  pos = curwin->w_cursor;       // start searching at the cursor position
+  pos_T pos = curwin->w_cursor;  // Position of the last match.
+                                 // Start searching at the cursor position.
 
   // Find out the direction of the search.
   if (dirc == 0) {
@@ -1088,11 +1086,7 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, size_t patlen
     set_vv_searchforward();
   }
   if (options & SEARCH_REV) {
-    if (dirc == '/') {
-      dirc = '?';
-    } else {
-      dirc = '/';
-    }
+    dirc = dirc == '/' ? '?' : '/';
   }
 
   // If the cursor is in a closed fold, don't find another match in the same
@@ -1564,11 +1558,9 @@ int searchc(cmdarg_T *cap, bool t_cmd)
     if (*lastc == NUL && lastc_bytelen <= 1) {
       return FAIL;
     }
-    if (dir) {        // repeat in opposite direction
-      dir = -lastcdir;
-    } else {
-      dir = lastcdir;
-    }
+    dir = dir  // repeat in opposite direction
+          ? -lastcdir
+          : lastcdir;
     t_cmd = last_t_cmd;
     c = *lastc;
     // For multi-byte re-use last lastc_bytes[] and lastc_bytelen.
@@ -1581,11 +1573,7 @@ int searchc(cmdarg_T *cap, bool t_cmd)
     }
   }
 
-  if (dir == BACKWARD) {
-    cap->oap->inclusive = false;
-  } else {
-    cap->oap->inclusive = true;
-  }
+  cap->oap->inclusive = dir != BACKWARD;
 
   char *p = get_cursor_line_ptr();
   int col = curwin->w_cursor.col;
@@ -2432,17 +2420,13 @@ int current_search(int count, bool forward)
     dec_cursor();
   }
 
-  pos_T end_pos;                // end position of the pattern match
-  pos_T orig_pos;               // position of the cursor at beginning
-  pos_T pos;                    // position after the pattern
-  int result;                   // result of various function calls
-
   // When searching forward and the cursor is at the start of the Visual
   // area, skip the first search backward, otherwise it doesn't move.
   const bool skip_first_backward = forward && VIsual_active
                                    && lt(curwin->w_cursor, VIsual);
 
-  orig_pos = pos = curwin->w_cursor;
+  pos_T pos = curwin->w_cursor;       // position after the pattern
+  pos_T orig_pos = curwin->w_cursor;  // position of the cursor at beginning
   if (VIsual_active) {
     // Searching further will extend the match.
     if (forward) {
@@ -2458,6 +2442,9 @@ int current_search(int count, bool forward)
   if (zero_width == -1) {
     return FAIL;  // pattern not found
   }
+
+  pos_T end_pos;  // end position of the pattern match
+  int result;     // result of various function calls
 
   // The trick is to first search backwards and then search forward again,
   // so that a match at the current cursor position will be correctly
@@ -3238,9 +3225,8 @@ static int fuzzy_match_item_compare(const void *const s1, const void *const s2)
 
   if (v1 == v2) {
     return idx1 == idx2 ? 0 : idx1 > idx2 ? 1 : -1;
-  } else {
-    return v1 > v2 ? -1 : 1;
   }
+  return v1 > v2 ? -1 : 1;
 }
 
 /// Fuzzy search the string "str" in a list of "items" and return the matching
@@ -3514,9 +3500,8 @@ static int fuzzy_match_func_compare(const void *const s1, const void *const s2)
   }
   if (v1 == v2) {
     return idx1 == idx2 ? 0 : idx1 > idx2 ? 1 : -1;
-  } else {
-    return v1 > v2 ? -1 : 1;
   }
+  return v1 > v2 ? -1 : 1;
 }
 
 /// Sort fuzzy matches of function names by score.
@@ -3704,13 +3689,8 @@ void find_pattern_in_path(char *ptr, Direction dir, size_t len, bool whole, bool
   int old_files = max_path_depth;
   int depth = depth_displayed = -1;
 
-  linenr_T lnum = start_lnum;
-  if (end_lnum > curbuf->b_ml.ml_line_count) {
-    end_lnum = curbuf->b_ml.ml_line_count;
-  }
-  if (lnum > end_lnum) {                // do at least one line
-    lnum = end_lnum;
-  }
+  end_lnum = MIN(end_lnum, curbuf->b_ml.ml_line_count);
+  linenr_T lnum = MIN(start_lnum, end_lnum);  // do at least one line
   char *line = get_line_and_copy(lnum, file_line);
 
   while (true) {
@@ -4159,9 +4139,7 @@ exit_matched:
       depth--;
       curr_fname = (depth == -1) ? curbuf->b_fname
                                  : files[depth].name;
-      if (depth < depth_displayed) {
-        depth_displayed = depth;
-      }
+      depth_displayed = MIN(depth_displayed, depth);
     }
     if (depth >= 0) {           // we could read the line
       files[depth].lnum++;

--- a/src/nvim/sha256.c
+++ b/src/nvim/sha256.c
@@ -223,18 +223,15 @@ static uint8_t sha256_padding[SHA256_BUFFER_SIZE] = {
 
 void sha256_finish(context_sha256_T *ctx, uint8_t digest[SHA256_SUM_SIZE])
 {
-  uint32_t last, padn;
-  uint32_t high, low;
+  uint32_t high = (ctx->total[0] >> 29) | (ctx->total[1] <<  3);
+  uint32_t low = (ctx->total[0] <<  3);
+
   uint8_t msglen[8];
-
-  high = (ctx->total[0] >> 29) | (ctx->total[1] <<  3);
-  low = (ctx->total[0] <<  3);
-
   PUT_UINT32(high, msglen, 0);
   PUT_UINT32(low,  msglen, 4);
 
-  last = ctx->total[0] & 0x3F;
-  padn = (last < 56) ? (56 - last) : (120 - last);
+  uint32_t last = ctx->total[0] & 0x3F;
+  uint32_t padn = (last < 56) ? (56 - last) : (120 - last);
 
   sha256_update(ctx, sha256_padding, padn);
   sha256_update(ctx, msglen,            8);
@@ -263,18 +260,18 @@ void sha256_finish(context_sha256_T *ctx, uint8_t digest[SHA256_SUM_SIZE])
 const char *sha256_bytes(const uint8_t *restrict buf,  size_t buf_len, const uint8_t *restrict salt,
                          size_t salt_len)
 {
-  uint8_t sha256sum[SHA256_SUM_SIZE];
   static char hexit[SHA256_BUFFER_SIZE + 1];  // buf size + NULL
-  context_sha256_T ctx;
 
   sha256_self_test();
 
+  context_sha256_T ctx;
   sha256_start(&ctx);
   sha256_update(&ctx, buf, buf_len);
 
   if (salt != NULL) {
     sha256_update(&ctx, salt, salt_len);
   }
+  uint8_t sha256sum[SHA256_SUM_SIZE];
   sha256_finish(&ctx, sha256sum);
 
   for (size_t j = 0; j < SHA256_SUM_SIZE; j++) {

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -276,7 +276,6 @@ static bool can_be_compound(trystate_T *sp, slang_T *slang, uint8_t *compflags, 
 static int score_wordcount_adj(slang_T *slang, int score, char *word, bool split)
 {
   int bonus;
-  int newscore;
 
   hashitem_T *hi = hash_find(&slang->sl_wordcount, word);
   if (HASHITEM_EMPTY(hi)) {
@@ -291,11 +290,8 @@ static int score_wordcount_adj(slang_T *slang, int score, char *word, bool split
   } else {
     bonus = SCORE_COMMON3;
   }
-  if (split) {
-    newscore = score - bonus / 2;
-  } else {
-    newscore = score - bonus;
-  }
+  int newscore = split ? score - bonus / 2
+                       : score - bonus;
   if (newscore < 0) {
     return 0;
   }
@@ -449,7 +445,6 @@ void spell_suggest(int count)
   suginfo_T sug;
   suggest_T *stp;
   bool mouse_used;
-  int limit;
   int selected = count;
   int badlen = 0;
   int msg_scroll_save = msg_scroll;
@@ -481,9 +476,7 @@ void spell_suggest(int count)
     badlen++;
     end_visual_mode();
     // make sure we don't include the NUL at the end of the line
-    if (badlen > get_cursor_line_len() - curwin->w_cursor.col) {
-      badlen = get_cursor_line_len() - curwin->w_cursor.col;
-    }
+    badlen = MIN(badlen, get_cursor_line_len() - curwin->w_cursor.col);
     // Find the start of the badly spelled word.
   } else if (spell_move_to(curwin, FORWARD, SMT_ALL, true, NULL) == 0
              || curwin->w_cursor.col > prev_cursor.col) {
@@ -519,11 +512,7 @@ void spell_suggest(int count)
 
   // Get the list of suggestions.  Limit to 'lines' - 2 or the number in
   // 'spellsuggest', whatever is smaller.
-  if (sps_limit > Rows - 2) {
-    limit = Rows - 2;
-  } else {
-    limit = sps_limit;
-  }
+  int limit = MIN(sps_limit, Rows - 2);
   spell_find_suggest(line + curwin->w_cursor.col, badlen, &sug, limit,
                      true, need_cap, true);
 
@@ -731,10 +720,7 @@ static void spell_find_suggest(char *badptr, int badlen, suginfo_T *su, int maxc
   }
   su->su_maxcount = maxcount;
   su->su_maxscore = SCORE_MAXINIT;
-
-  if (su->su_badlen >= MAXWLEN) {
-    su->su_badlen = MAXWLEN - 1;        // just in case
-  }
+  su->su_badlen = MIN(su->su_badlen, MAXWLEN - 1);  // just in case
   xmemcpyz(su->su_badword, su->su_badptr, (size_t)su->su_badlen);
   spell_casefold(curwin, su->su_badptr, su->su_badlen, su->su_fbadword,
                  MAXWLEN);
@@ -1145,7 +1131,6 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char *fword, bool soun
   idx_T *idxs, *fidxs, *pidxs;
   int c, c2, c3;
   int n = 0;
-  garray_T *gap;
   idx_T arridx;
   int fl = 0;
   int tl;
@@ -1736,11 +1721,8 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char *fword, bool soun
         // Done all bytes at this node, do next state.  When still at
         // already changed bytes skip the other tricks.
         PROF_STORE(sp->ts_state)
-        if (sp->ts_fidx >= sp->ts_fidxtry) {
-          sp->ts_state = STATE_DEL;
-        } else {
-          sp->ts_state = STATE_FINAL;
-        }
+        sp->ts_state = sp->ts_fidx >= sp->ts_fidxtry ? STATE_DEL
+                                                     : STATE_FINAL;
       } else {
         arridx += sp->ts_curi++;
         c = byts[arridx];
@@ -2254,11 +2236,8 @@ static void suggest_trie_walk(suginfo_T *su, langp_T *lp, char *fword, bool soun
       // valid.
       p = fword + sp->ts_fidx;
 
-      if (soundfold) {
-        gap = &slang->sl_repsal;
-      } else {
-        gap = &lp->lp_replang->sl_rep;
-      }
+      garray_T *gap = soundfold ? &slang->sl_repsal
+                                : &lp->lp_replang->sl_rep;
       while (sp->ts_curi < gap->ga_len) {
         fromto_T *ftp = (fromto_T *)gap->ga_data + sp->ts_curi++;
         if (*ftp->ft_from != *p) {
@@ -3126,11 +3105,9 @@ static void add_suggestion(suginfo_T *su, garray_T *gap, const char *goodword, i
     // the best suggestions.
     if (gap->ga_len > SUG_MAX_COUNT(su)) {
       if (maxsf) {
-        su->su_sfmaxscore = cleanup_suggestions(gap,
-                                                su->su_sfmaxscore, SUG_CLEAN_COUNT(su));
+        su->su_sfmaxscore = cleanup_suggestions(gap, su->su_sfmaxscore, SUG_CLEAN_COUNT(su));
       } else {
-        su->su_maxscore = cleanup_suggestions(gap,
-                                              su->su_maxscore, SUG_CLEAN_COUNT(su));
+        su->su_maxscore = cleanup_suggestions(gap, su->su_maxscore, SUG_CLEAN_COUNT(su));
       }
     }
   }
@@ -3276,8 +3253,6 @@ static int soundalike_score(char *goodstart, char *badstart)
 {
   char *goodsound = goodstart;
   char *badsound = badstart;
-  char *pl, *ps;
-  char *pl2, *ps2;
   int score = 0;
 
   // Adding/inserting "*" at the start (word starts with vowel) shouldn't be
@@ -3318,19 +3293,18 @@ static int soundalike_score(char *goodstart, char *badstart)
     return SCORE_MAXMAX;
   }
 
-  if (n > 0) {
-    pl = goodsound;         // goodsound is longest
-    ps = badsound;
-  } else {
-    pl = badsound;          // badsound is longest
-    ps = goodsound;
-  }
+  // n > 0 : goodsound is longest
+  // n <= 0 : badsound is longest
+  char *pl = n > 0 ? goodsound : badsound;
+  char *ps = n > 0 ? badsound : goodsound;
 
   // Skip over the identical part.
   while (*pl == *ps && *pl != NUL) {
     pl++;
     ps++;
   }
+
+  char *pl2, *ps2;
 
   switch (n) {
   case -2:
@@ -3552,19 +3526,13 @@ static int spell_edit_score(slang_T *slang, const char *badword, const char *goo
           int pgc = wgoodword[j - 2];
           if (bc == pgc && pbc == gc) {
             int t = SCORE_SWAP + CNT(i - 2, j - 2);
-            if (t < CNT(i, j)) {
-              CNT(i, j) = t;
-            }
+            CNT(i, j) = MIN(CNT(i, j), t);
           }
         }
         int t = SCORE_DEL + CNT(i - 1, j);
-        if (t < CNT(i, j)) {
-          CNT(i, j) = t;
-        }
+        CNT(i, j) = MIN(CNT(i, j), t);
         t = SCORE_INS + CNT(i, j - 1);
-        if (t < CNT(i, j)) {
-          CNT(i, j) = t;
-        }
+        CNT(i, j) = MIN(CNT(i, j), t);
       }
     }
   }

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -123,10 +123,7 @@ void win_redr_status(win_T *wp)
       // len += (int)strlen(p + len);  // dead assignment
     }
 
-    int this_ru_col = ru_col - (Columns - stl_width);
-    if (this_ru_col < (stl_width + 1) / 2) {
-      this_ru_col = (stl_width + 1) / 2;
-    }
+    int this_ru_col = MAX(ru_col - (Columns - stl_width), (stl_width + 1) / 2);
     if (this_ru_col <= 1) {
       p = "<";                // No room for file name!
       len = 1;
@@ -374,10 +371,7 @@ static void win_redr_custom(win_T *wp, bool draw_winbar, bool draw_ruler)
           stl = p_ruf;
         }
       }
-      col = ru_col - (Columns - maxwidth);
-      if (col < (maxwidth + 1) / 2) {
-        col = (maxwidth + 1) / 2;
-      }
+      col = MAX(ru_col - (Columns - maxwidth), (maxwidth + 1) / 2);
       maxwidth -= col;
       if (!in_status_line) {
         grid = &msg_grid_adj;
@@ -574,15 +568,9 @@ void win_redr_ruler(win_T *wp)
   if (wp->w_status_height == 0 && !is_stl_global) {  // can't use last char of screen
     o++;
   }
-  int this_ru_col = ru_col - (Columns - width);
-  if (this_ru_col < 0) {
-    this_ru_col = 0;
-  }
   // Never use more than half the window/screen width, leave the other half
   // for the filename.
-  if (this_ru_col < (width + 1) / 2) {
-    this_ru_col = (width + 1) / 2;
-  }
+  int this_ru_col = MAX(ru_col - (Columns - width), (width + 1) / 2);
   if (this_ru_col + o < width) {
     // Need at least 3 chars left for get_rel_pos() + NUL.
     while (this_ru_col + o < width && RULER_BUF_LEN > i + 4) {
@@ -726,7 +714,6 @@ void draw_tabline(void)
     win_redr_custom(NULL, false, false);
   } else {
     int tabcount = 0;
-    int tabwidth = 0;
     int col = 0;
     win_T *cwp;
     int wincount;
@@ -735,13 +722,7 @@ void draw_tabline(void)
       tabcount++;
     }
 
-    if (tabcount > 0) {
-      tabwidth = (Columns - 1 + tabcount / 2) / tabcount;
-    }
-
-    if (tabwidth < 6) {
-      tabwidth = 6;
-    }
+    int tabwidth = MAX(tabcount > 0 ? (Columns - 1 + tabcount / 2) / tabcount : 0, 6);
 
     int attr = attr_nosel;
     tabcount = 0;
@@ -810,9 +791,7 @@ void draw_tabline(void)
           len -= ptr2cells(p);
           MB_PTR_ADV(p);
         }
-        if (len > Columns - col - 1) {
-          len = Columns - col - 1;
-        }
+        len = MIN(len, Columns - col - 1);
 
         grid_line_puts(col, p, -1, attr);
         col += len;
@@ -1193,9 +1172,7 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, OptIndex op
 
           // If the item was partially or completely truncated, set its
           // start to the start of the group
-          if (stl_items[idx].start < t) {
-            stl_items[idx].start = t;
-          }
+          stl_items[idx].start = MAX(stl_items[idx].start, t);
         }
         // If the group is shorter than the minimum width, add padding characters.
       } else if (abs(stl_items[stl_groupitems[groupdepth]].minwid) > group_len) {

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1191,10 +1191,7 @@ static int term_sb_pop(int cols, VTermScreenCell *cells, void *data)
   memmove(term->sb_buffer, term->sb_buffer + 1,
           sizeof(term->sb_buffer[0]) * (term->sb_current));
 
-  size_t cols_to_copy = (size_t)cols;
-  if (cols_to_copy > sbrow->cols) {
-    cols_to_copy = sbrow->cols;
-  }
+  size_t cols_to_copy = MIN((size_t)cols, sbrow->cols);
 
   // copy to vterm state
   memcpy(cells, sbrow->cells, sizeof(cells[0]) * cols_to_copy);

--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -348,9 +348,7 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
       inc_cursor();
     }
     startcol -= curwin->w_cursor.col;
-    if (startcol < 0) {
-      startcol = 0;
-    }
+    startcol = MAX(startcol, 0);
 
     if (State & VREPLACE_FLAG) {
       // In MODE_VREPLACE state, we will backspace over the text to be
@@ -433,9 +431,7 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
       // may have added or removed indent.
       curwin->w_cursor.col += startcol;
       colnr_T len = get_cursor_line_len();
-      if (curwin->w_cursor.col > len) {
-        curwin->w_cursor.col = len;
-      }
+      curwin->w_cursor.col = MIN(curwin->w_cursor.col, len);
     }
 
     haveto_redraw = true;
@@ -758,14 +754,9 @@ int comp_textwidth(bool ff)
       textwidth -= 8;
     }
   }
-  if (textwidth < 0) {
-    textwidth = 0;
-  }
+  textwidth = MAX(textwidth, 0);
   if (ff && textwidth == 0) {
-    textwidth = curwin->w_width_inner - 1;
-    if (textwidth > 79) {
-      textwidth = 79;
-    }
+    textwidth = MIN(curwin->w_width_inner - 1, 79);
   }
   return textwidth;
 }
@@ -1105,11 +1096,7 @@ void format_lines(linenr_T line_count, bool avoid_fex)
         }
         first_par_line = false;
         // If the line is getting long, format it next time
-        if (get_cursor_line_len() > max_len) {
-          force_format = true;
-        } else {
-          force_format = false;
-        }
+        force_format = get_cursor_line_len() > max_len;
       }
     }
     line_breakcheck();

--- a/src/nvim/textobject.c
+++ b/src/nvim/textobject.c
@@ -1269,11 +1269,7 @@ int current_par(oparg_T *oap, int count, bool include, int type)
   // When visual area is more than one line: extend it.
   if (VIsual_active && start_lnum != VIsual.lnum) {
 extend:
-    if (start_lnum < VIsual.lnum) {
-      dir = BACKWARD;
-    } else {
-      dir = FORWARD;
-    }
+    dir = start_lnum < VIsual.lnum ? BACKWARD : FORWARD;
     for (int i = count; --i >= 0;) {
       if (start_lnum ==
           (dir == BACKWARD ? 1 : curbuf->b_ml.ml_line_count)) {

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1132,17 +1132,11 @@ static void serialize_pos(bufinfo_T *bi, pos_T pos)
 static void unserialize_pos(bufinfo_T *bi, pos_T *pos)
 {
   pos->lnum = undo_read_4c(bi);
-  if (pos->lnum < 0) {
-    pos->lnum = 0;
-  }
+  pos->lnum = MAX(pos->lnum, 0);
   pos->col = undo_read_4c(bi);
-  if (pos->col < 0) {
-    pos->col = 0;
-  }
+  pos->col = MAX(pos->col, 0);
   pos->coladd = undo_read_4c(bi);
-  if (pos->coladd < 0) {
-    pos->coladd = 0;
-  }
+  pos->coladd = MAX(pos->coladd, 0);
 }
 
 /// Serializes "info".
@@ -1209,14 +1203,12 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
   // Strip any sticky and executable bits.
   perm = perm & 0666;
 
-  int fd;
-
   // If the undo file already exists, verify that it actually is an undo
   // file, and delete it.
   if (os_path_exists(file_name)) {
     if (name == NULL || !forceit) {
       // Check we can read it and it's an undo file.
-      fd = os_open(file_name, O_RDONLY, 0);
+      int fd = os_open(file_name, O_RDONLY, 0);
       if (fd < 0) {
         if (name != NULL || p_verbose > 0) {
           if (name == NULL) {
@@ -1261,7 +1253,7 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
     goto theend;
   }
 
-  fd = os_open(file_name, O_CREAT|O_WRONLY|O_EXCL|O_NOFOLLOW, perm);
+  int fd = os_open(file_name, O_CREAT|O_WRONLY|O_EXCL|O_NOFOLLOW, perm);
   if (fd < 0) {
     semsg(_(e_not_open), file_name);
     goto theend;
@@ -2001,9 +1993,7 @@ void undo_time(int step, bool sec, bool file, bool absolute)
       target = curbuf->b_u_seq_cur + step;
     }
     if (step < 0) {
-      if (target < 0) {
-        target = 0;
-      }
+      target = MAX(target, 0);
       closest = -1;
     } else {
       if (dosec) {
@@ -2396,9 +2386,7 @@ static void u_undoredo(bool undo, bool do_buf_event)
     }
 
     // Set the '[ mark.
-    if (top + 1 < curbuf->b_op_start.lnum) {
-      curbuf->b_op_start.lnum = top + 1;
-    }
+    curbuf->b_op_start.lnum = MIN(curbuf->b_op_start.lnum, top + 1);
     // Set the '] mark.
     if (newsize == 0 && top + 1 > curbuf->b_op_end.lnum) {
       curbuf->b_op_end.lnum = top + 1;
@@ -2419,12 +2407,8 @@ static void u_undoredo(bool undo, bool do_buf_event)
   }
 
   // Ensure the '[ and '] marks are within bounds.
-  if (curbuf->b_op_start.lnum > curbuf->b_ml.ml_line_count) {
-    curbuf->b_op_start.lnum = curbuf->b_ml.ml_line_count;
-  }
-  if (curbuf->b_op_end.lnum > curbuf->b_ml.ml_line_count) {
-    curbuf->b_op_end.lnum = curbuf->b_ml.ml_line_count;
-  }
+  curbuf->b_op_start.lnum = MIN(curbuf->b_op_start.lnum, curbuf->b_ml.ml_line_count);
+  curbuf->b_op_end.lnum = MIN(curbuf->b_op_end.lnum, curbuf->b_ml.ml_line_count);
 
   // Adjust Extmarks
   if (undo) {

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -805,9 +805,7 @@ invalid_count:
         }
       }
 
-      if (*def < 0) {
-        *def = 0;
-      }
+      *def = MAX(*def, 0);
     } else if (STRNICMP(attr, "complete", attrlen) == 0) {
       if (val == NULL) {
         semsg(_(e_argument_required_for_str), "-complete");


### PR DESCRIPTION
Problem:

Variables are often assigned multiple places in common patterns.

Solution:

Replace these common patterns with different patterns that reduce the
number of assignments.

Use `MAX` and `MIN`:
```c
if (x < y) {
  x = y;
}

// -->

x = MAX(x, y);
```

```c
if (x > y) {
  x = y;
}

// -->

x = MIN(x, y);
```

Use ternary:
```c
int a;
if (cond) {
  a = b;
} else {
  a = c;
}

// -->

int a = cond ? b : c;

```
