### PR TITLE
feat(tui): parse CSI subparams in termkey

### DIFF
--- a/src/termkey/termkey.h
+++ b/src/termkey/termkey.h
@@ -143,6 +143,11 @@ typedef struct {
   char utf8[7];
 } TermKeyKey;
 
+typedef struct {
+  const unsigned char *param;
+  size_t length;
+} TermKeyCsiParam;
+
 typedef struct TermKey TermKey;
 
 enum {
@@ -215,7 +220,9 @@ TermKeyResult termkey_interpret_position(TermKey *tk, const TermKeyKey *key, int
 
 TermKeyResult termkey_interpret_modereport(TermKey *tk, const TermKeyKey *key, int *initial, int *mode, int *value);
 
-TermKeyResult termkey_interpret_csi(TermKey *tk, const TermKeyKey *key, long args[], size_t *nargs, unsigned long *cmd);
+TermKeyResult termkey_interpret_csi(TermKey *tk, const TermKeyKey *key, TermKeyCsiParam params[], size_t *nparams, unsigned long *cmd);
+
+TermKeyResult termkey_interpret_csi_param(TermKeyCsiParam param, long *paramp, long subparams[], size_t *nsubparams);
 
 TermKeyResult termkey_interpret_string(TermKey *tk, const TermKeyKey *key, const char **strp);
 


### PR DESCRIPTION
libtermkey does not know how to parse CSI subparameters (parameters separated by ':', ASCII 0x3A) and currently just ignores them. However, many important CSI sequences sent by the terminal make use of subparameters, most notably key events when using the kitty keyboard protocol [1]. Enabling subparameters is a prerequisite for [expanding kitty keyboard protocol](https://github.com/neovim/neovim/issues/27509) support in Neovim.

Concretely, we do this by returning pointers into the internal termkey buffer for each CSI parameter rather than parsing them into integers directly. When a caller wants to actually use the parameter as an integer, they must call termkey_interpret_csi_param, which parses the full parameter string into an integer parameter and zero or more subparameters.

The pointers into the internal buffer will become invalidated when new input arrives from the terminal so it is important that the individual params are used and parsed right away. All of our code (and libtermkey's code) does this, so this is fine for now, but is something to keep in mind moving forward.

[1]: https://sw.kovidgoyal.net/kitty/keyboard-protocol/