### PR TITLE
fix(loader): follow the style of the error message for built-in loaders

### DIFF
--- a/runtime/lua/vim/loader.lua
+++ b/runtime/lua/vim/loader.lua
@@ -200,7 +200,7 @@ function Loader.loader(modname)
     return chunk or error(err)
   end
   Loader._hashes = nil
-  return '\ncache_loader: module ' .. modname .. ' not found'
+  return ("\n\tcache_loader: module '%s' not found"):format(modname)
 end
 
 --- The `package.loaders` loader for libs
@@ -222,7 +222,7 @@ function Loader.loader_lib(modname)
     local chunk, err = package.loadlib(ret.modpath, 'luaopen_' .. funcname:gsub('%.', '_'))
     return chunk or error(err)
   end
-  return '\ncache_loader_lib: module ' .. modname .. ' not found'
+  return ("\n\tcache_loader_lib: module '%s' not found"):format(modname)
 end
 
 --- `loadfile` using the cache

--- a/test/functional/lua/loader_spec.lua
+++ b/test/functional/lua/loader_spec.lua
@@ -90,16 +90,13 @@ describe('vim.loader', function()
   end)
 
   it('correct indent on error message (#29809)', function()
-    exec_lua [[
+    local errmsg = exec_lua [[
       vim.loader.enable()
-
-      local success, errmsg = pcall(require, 'non_existent_module')
-      assert(not success)
-
-      errmsg = errmsg:gsub("^module 'non_existent_module' not found:\n", '')
-      for line in vim.gsplit(errmsg, '\n') do
-        assert(line:find('^\t'), ('not indented: %q'):format(line))
-      end
+      local _, errmsg = pcall(require, 'non_existent_module')
+      return errmsg
     ]]
+    local errors = vim.split(errmsg, '\n')
+    eq("\tcache_loader: module 'non_existent_module' not found", errors[3])
+    eq("\tcache_loader_lib: module 'non_existent_module' not found", errors[4])
   end)
 end)

--- a/test/functional/lua/loader_spec.lua
+++ b/test/functional/lua/loader_spec.lua
@@ -88,4 +88,18 @@ describe('vim.loader', function()
     eq(1, exec_lua('return loadfile(...)()', tmp1))
     eq(2, exec_lua('return loadfile(...)()', tmp2))
   end)
+
+  it('correct indent on error message (#29809)', function()
+    exec_lua [[
+      vim.loader.enable()
+
+      local success, errmsg = pcall(require, 'non_existent_module')
+      assert(not success)
+
+      errmsg = errmsg:gsub("^module 'non_existent_module' not found:\n", '')
+      for line in vim.gsplit(errmsg, '\n') do
+        assert(line:find('^\t'), ('not indented: %q'):format(line))
+      end
+    ]]
+  end)
 end)


### PR DESCRIPTION
The error message should be started with `"\n\t"` and the module name should be surrounded by single quotes.

before

```
:lua require("foo")
E5108: Error executing lua [string ":lua"]:1: module 'foo' not found:
	no field package.preload['foo']
cache_loader: module foo not found
cache_loader_lib: module foo not found
	no file '.\foo.lua'
	...
```

after

```
:lua require("foo")
E5108: Error executing lua [string ":lua"]:1: module 'foo' not found:
	no field package.preload['foo']
	cache_loader: module 'foo' not found
	cache_loader_lib: module 'foo' not found
	no file '.\foo.lua'
	...
```