### PR TITLE
ci: always add `target:release` label when backporting

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -26,14 +26,3 @@ jobs:
           pull_title: "${pull_title}"
           label_pattern: "^ci:backport ([^ ]+)$"
           github_token: ${{ steps.app-token.outputs.token }}
-
-      - if: ${{steps.backport.outputs.was_successful == 'true'}}
-        uses: actions/github-script@v7
-        with:
-          script: |
-            github.rest.issues.addLabels({
-              issue_number: ${{steps.backport.outputs.created_pull_numbers}},
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              labels: ['target:release']
-            })

--- a/.github/workflows/labeler_pr.yml
+++ b/.github/workflows/labeler_pr.yml
@@ -33,8 +33,25 @@ jobs:
     - name: "Extract if the PR is a breaking change and add it as label"
       run: gh pr edit "$PR_NUMBER" --add-label "$(echo "$PR_TITLE" | sed -E 's|[[:alpha:]]+(\(.*\))?!:.*|breaking-change|')" || true
 
-  request-reviewer:
+  target-release:
     needs: ["changed-files", "type-scope"]
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+    - if: startsWith(github.base_ref, 'release')
+      uses: actions/github-script@v7
+      with:
+        script: |
+          github.rest.issues.addLabels({
+            issue_number: context.issue.number,
+            owner: context.repo.owner,
+            repo: context.repo.repo,
+            labels: ['target:release']
+          })
+
+  request-reviewer:
+    needs: ["changed-files", "type-scope", "target-release"]
     permissions:
       pull-requests: write
     uses: ./.github/workflows/reviewers_add.yml


### PR DESCRIPTION
Previously the label was not added if the backport PR was created
manually. The new code is also easier to maintain as it's close to other
label-related code.
