### PR TITLE
docs(filetype): use correct pattern in `add()` example

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2674,7 +2674,7 @@ vim.filetype.add({filetypes})                             *vim.filetype.add()*
             ['.*/etc/foo/.*%.conf'] = { 'dosini', { priority = 10 } },
             -- A pattern containing an environment variable
             ['${XDG_CONFIG_HOME}/foo/git'] = 'git',
-            ['README.(%a+)$'] = function(path, bufnr, ext)
+            ['.*README.(%a+)'] = function(path, bufnr, ext)
               if ext == 'md' then
                 return 'markdown'
               elseif ext == 'rst' then

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2431,7 +2431,7 @@ end
 ---     ['.*/etc/foo/.*%.conf'] = { 'dosini', { priority = 10 } },
 ---     -- A pattern containing an environment variable
 ---     ['${XDG_CONFIG_HOME}/foo/git'] = 'git',
----     ['README.(%a+)$'] = function(path, bufnr, ext)
+---     ['.*README.(%a+)'] = function(path, bufnr, ext)
 ---       if ext == 'md' then
 ---         return 'markdown'
 ---       elseif ext == 'rst' then


### PR DESCRIPTION
All user patterns are assumed to be implicitly anchored.