### PR TITLE
vim-patch:9.1.0617: Cursor moves beyond first line of folded end of buffer

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2650,7 +2650,6 @@ void cursor_down_inner(win_T *wp, int n)
 
     // count each sequence of folded lines as one logical line
     while (n--) {
-      // Move to last line of fold, will fail if it's the end-of-file.
       if (hasFoldingWin(wp, lnum, NULL, &last, true, NULL)) {
         lnum = last + 1;
       } else {
@@ -2673,8 +2672,10 @@ void cursor_down_inner(win_T *wp, int n)
 /// @param upd_topline  When true: update topline
 int cursor_down(int n, bool upd_topline)
 {
-  // This fails if the cursor is already in the last line.
-  if (n > 0 && curwin->w_cursor.lnum >= curwin->w_buffer->b_ml.ml_line_count) {
+  linenr_T lnum = curwin->w_cursor.lnum;
+  // This fails if the cursor is already in the last (folded) line.
+  hasFoldingWin(curwin, lnum, NULL, &lnum, true, NULL);
+  if (n > 0 && lnum >= curwin->w_buffer->b_ml.ml_line_count) {
     return FAIL;
   }
   cursor_down_inner(curwin, n);

--- a/test/old/testdir/test_fold.vim
+++ b/test/old/testdir/test_fold.vim
@@ -1659,4 +1659,18 @@ func Test_foldexpr_end_fold()
   bwipe!
 endfunc
 
+" Test moving cursor down to or beyond start of folded end of buffer.
+func Test_cursor_down_fold_eob()
+  call setline(1, range(1, 4))
+  norm Gzf2kj
+  call assert_equal(2, line('.'))
+  norm zojzc
+  call assert_equal(3, line('.'))
+  norm j
+  call assert_equal(3, line('.'))
+  norm k2j
+  call assert_equal(4, line('.'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  Cursor moves beyond start of a folded range at the end of a buffer.
Solution: Move cursor to start of fold when going beyond end of buffer.
          Check that cursor moved to detect FAIL in outer cursor function.
          (Luuk van Baal)

https://github.com/vim/vim/commit/dc373d456b5919ed2b8f83e8642c115f646ca93d