### PR TITLE
vim-patch:8.2.3543: swapname has double slash when 'directory' ends in it

### DIFF
--- a/test/old/testdir/test_swap.vim
+++ b/test/old/testdir/test_swap.vim
@@ -409,7 +409,7 @@ func Test_swap_symlink()
 
   " Check that this also works when 'directory' ends with '//'
   edit Xtestlink
-  call assert_match('Xtestfile\.swp$', s:swapname())
+  call assert_match('Xswapdir[/\\]%.*testdir%Xtestfile\.swp$', s:swapname())
   bwipe!
 
   set dir&


### PR DESCRIPTION
#### vim-patch:8.2.3543: swapname has double slash when 'directory' ends in it

Problem:    Swapname has double slash when 'directory' ends in double slash.
            (Shane Smith)
Solution:   Remove the superfluous slash.

https://github.com/vim/vim/commit/8b0e62c93b6dad5ec5b2c7558d4f7b78c46216d2

The test got lost in #29758...

Co-authored-by: Bram Moolenaar <Bram@vim.org>