### PR TITLE
fix(plines): don't count invalidated virt text in char size

### DIFF
--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -595,11 +595,7 @@ int decor_redraw_col(win_T *wp, int col, int win_col, bool hidden, DecorState *s
       break;
     }
 
-    if (!ns_in_win(mark.ns, wp)) {
-      goto next_mark;
-    }
-
-    if (mt_invalid(mark) || mt_end(mark) || !mt_decor_any(mark)) {
+    if (mt_invalid(mark) || mt_end(mark) || !mt_decor_any(mark) || !ns_in_win(mark.ns, wp)) {
       goto next_mark;
     }
 
@@ -743,8 +739,7 @@ void decor_redraw_signs(win_T *wp, buf_T *buf, int row, SignTextAttrs sattrs[], 
     if (mark.pos.row != row) {
       break;
     }
-    if (!mt_end(mark) && !mt_invalid(mark) && mt_decor_sign(mark)
-        && ns_in_win(mark.ns, wp)) {
+    if (!mt_invalid(mark) && !mt_end(mark) && mt_decor_sign(mark) && ns_in_win(mark.ns, wp)) {
       DecorSignHighlight *sh = decor_find_sign(mt_decor(mark));
       num_text += (sh->text[0] != NUL);
       kv_push(signs, ((SignItem){ sh, mark.id }));

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -158,8 +158,7 @@ CharSize charsize_regular(CharsizeArg *csarg, char *const cur, colnr_T const vco
       if (mark.pos.row != csarg->virt_row || mark.pos.col > col) {
         break;
       } else if (mark.pos.col == col) {
-        if (!mt_end(mark) && (mark.flags & MT_FLAG_DECOR_VIRT_TEXT_INLINE)
-            && ns_in_win(mark.ns, wp)) {
+        if (!mt_invalid(mark) && ns_in_win(mark.ns, wp)) {
           DecorInline decor = mt_decor(mark);
           DecorVirtText *vt = decor.ext ? decor.data.ext.vt : NULL;
           while (vt) {

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -4045,6 +4045,68 @@ describe('decorations: inline virtual text', function()
                                                         |
     ]])
   end)
+
+  it('cursor position is correct if end_row or end_col is specified', function()
+    screen:try_resize(50, 8)
+    api.nvim_buf_set_lines(0, 0, -1, false, { ('a'):rep(48), ('b'):rep(48), ('c'):rep(48), ('d'):rep(48) })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, {end_row = 2, virt_text_pos = 'inline', virt_text = {{'I1', 'NonText'}}})
+    api.nvim_buf_set_extmark(0, ns, 3, 0, {end_col = 2, virt_text_pos = 'inline', virt_text = {{'I2', 'NonText'}}})
+    feed('$')
+    screen:expect([[
+      {1:I1}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa^a|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  |
+      cccccccccccccccccccccccccccccccccccccccccccccccc  |
+      {1:I2}dddddddddddddddddddddddddddddddddddddddddddddddd|
+      {1:~                                                 }|*3
+                                                        |
+    ]])
+    feed('j')
+    screen:expect([[
+      {1:I1}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb^b  |
+      cccccccccccccccccccccccccccccccccccccccccccccccc  |
+      {1:I2}dddddddddddddddddddddddddddddddddddddddddddddddd|
+      {1:~                                                 }|*3
+                                                        |
+    ]])
+    feed('j')
+    screen:expect([[
+      {1:I1}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  |
+      ccccccccccccccccccccccccccccccccccccccccccccccc^c  |
+      {1:I2}dddddddddddddddddddddddddddddddddddddddddddddddd|
+      {1:~                                                 }|*3
+                                                        |
+    ]])
+    feed('j')
+    screen:expect([[
+      {1:I1}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  |
+      cccccccccccccccccccccccccccccccccccccccccccccccc  |
+      {1:I2}ddddddddddddddddddddddddddddddddddddddddddddddd^d|
+      {1:~                                                 }|*3
+                                                        |
+    ]])
+  end)
+
+  it('cursor position is correct with invalidated inline virt text', function()
+    screen:try_resize(50, 8)
+    api.nvim_buf_set_lines(0, 0, -1, false, { ('a'):rep(48), ('b'):rep(48) })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text_pos = 'inline', virt_text = {{'INLINE', 'NonText'}}, invalidate = true })
+    screen:expect([[
+      {1:INLINE}^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      aaaa                                              |
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb  |
+      {1:~                                                 }|*4
+                                                        |
+    ]])
+    feed('dd$')
+    screen:expect([[
+      bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb^b  |
+      {1:~                                                 }|*6
+                                                        |
+    ]])
+  end)
 end)
 
 describe('decorations: virtual lines', function()


### PR DESCRIPTION
Also:
- Remove mt_end() and MT_FLAG_DECOR_VIRT_TEXT_INLINE checks, as they are
  already checked by marktree_itr_check_filter().
- Move ns_in_win() to the last check in decor_redraw_col().
