### PR TITLE
fix(lsp): if item.score bigger than zero also add into matches

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -246,6 +246,7 @@ function M._lsp_to_complete_items(result, prefix, client_id)
     matches = function(item)
       local text = item.filterText or item.label
       return next(vim.fn.matchfuzzy({ text }, prefix)) ~= nil
+        or (vim.tbl_get(item, 'score') or 0) > 0
     end
   end
 


### PR DESCRIPTION
Problem: currently matches in _lsp_to_complete_item can not handle the prefix is dot.

Solution: matches also check the item.score


input dot after a pointer variable of strcut the clangd result as below. then currently matches can not handle it then the result is ignored.

```
    result = {
      isIncomplete = false,
      items = { {
          detail = "struct list_node *",
          filterText = "head",
          insertText = "->head",
          insertTextFormat = 1,
          kind = 5,
          label = " head",
          score = 0.50963842868805,
          sortText = "40fd8856head",
          textEdit = {
            newText = "->head",
            range = {
              ["end"] = {
                character = 9,
                line = 63
              },
              start = {
                character = 8,
                line = 63
              }
            }
          }
        } }
```