### PR TITLE
refactor(decor): decor_virt_lines()

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1158,7 +1158,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
     area_highlighting = true;
   }
   VirtLines virt_lines = KV_INITIAL_VALUE;
-  wlv.n_virt_lines = decor_virt_lines(wp, lnum, &virt_lines, has_fold);
+  wlv.n_virt_lines = decor_virt_lines(wp, lnum, &virt_lines);
   wlv.filler_lines += wlv.n_virt_lines;
   if (lnum == wp->w_topline) {
     wlv.filler_lines = wp->w_topfill;

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -712,7 +712,7 @@ bool win_may_fill(win_T *wp)
 /// @return Number of filler lines above lnum
 int win_get_fill(win_T *wp, linenr_T lnum)
 {
-  int virt_lines = decor_virt_lines(wp, lnum, NULL, kNone);
+  int virt_lines = decor_virt_lines(wp, lnum, NULL);
 
   // be quick when there are no filler lines
   if (diffopt_filler()) {


### PR DESCRIPTION
refactor(decor): decor_virt_lines()

Reduce calls to hasFolding() and remove the has_fold argument.

For lines that don't have virtual lines this should be more efficient as
it should avoid any calls to hasFolding(), whereas before it was called
at least once for any buffer containing at least one virtual line.

This will be slightly less efficient for lines with multiple virtual
lines marks as hasFolding() is called once for each mark. This could be
optimized, but having multiple virtual lines marks on a single line is
very rare.