### PR TITLE
vim-patch:a7295ae: runtime(autohotkey): include initial filetype plugin

### DIFF
--- a/runtime/ftplugin/autohotkey.vim
+++ b/runtime/ftplugin/autohotkey.vim
@@ -1,0 +1,16 @@
+" Vim filetype plugin file
+" Language:     AutoHotkey
+" Maintainer:   Peter Aronoff <peteraronoff@fastmail.com>
+" Last Changed: 2024 Jul 25
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=:;
+setlocal commentstring=;\ %s
+
+let b:undo_ftplugin = "setlocal comments< commentstring<"
+
+" vim: nowrap sw=2 sts=2 ts=8 noet:


### PR DESCRIPTION
closes: vim/vim#15345

https://github.com/vim/vim/commit/a7295ae7f5b956758f1c9c9a29d10c48661b29bc

Co-authored-by: Peter Aronoff <peter@aronoff.org>
