### PR TITLE
fix(version): return nil with empty string

### DIFF
--- a/runtime/lua/vim/version.lua
+++ b/runtime/lua/vim/version.lua
@@ -174,6 +174,10 @@ function M._version(version, strict) -- Adapted from https://github.com/folke/la
     version = version:match('%d[^ ]*')
   end
 
+  if version == nil then
+    return nil
+  end
+
   local prerel = version:match('%-([^+]*)')
   local prerel_strict = version:match('%-([0-9A-Za-z-]*)')
   if

--- a/test/functional/lua/version_spec.lua
+++ b/test/functional/lua/version_spec.lua
@@ -112,6 +112,10 @@ describe('version', function()
       assert(vim.version.range('1.2.3-alpha'):has('1.2.3-alpha'))
       assert(not vim.version.range('1.2.3-alpha'):has('1.2.3-beta'))
     end)
+
+    it('returns nil with empty version', function()
+      eq(vim.version.parse(''), nil)
+    end)
   end)
 
   describe('cmp()', function()


### PR DESCRIPTION
Fixes #29842 