### PR TITLE
vim-patch:9.1.{0618,0619}: cannot mark deprecated attributes in completion menu

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1177,6 +1177,12 @@ items:
 	user_data	custom data which is associated with the item and
 			available in |v:completed_item|; it can be any type;
 			defaults to an empty string
+	hl_group	allows specifying an additional highlight group to
+			apply extra attributes to completion items in the
+			popupmenu. Is combined with |hl-PmenuSel| and
+			|hl-Pmenu| highlighting attributes to apply cterm and
+			gui properties, such as strikethrough to the
+			completion items.
 
 All of these except "icase", "equal", "dup" and "empty" must be a string.  If
 an item does not meet these requirements then an error message is given and

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -356,6 +356,7 @@ static int cmdline_pum_create(CmdlineInfo *ccline, expand_T *xp, char **matches,
       .pum_info = NULL,
       .pum_extra = NULL,
       .pum_kind = NULL,
+      .pum_extrahlattr = -1,
     };
   }
 

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2568,9 +2568,9 @@ static int ins_compl_add_tv(typval_T *const tv, const Direction dir, bool fast)
     cptext[CPT_KIND] = tv_dict_get_string(tv->vval.v_dict, "kind", true);
     cptext[CPT_INFO] = tv_dict_get_string(tv->vval.v_dict, "info", true);
     tv_dict_get_tv(tv->vval.v_dict, "user_data", &user_data);
-    extra_hlname = tv_dict_get_string(tv->vval.v_dict, "hl_group", FALSE);
+    extra_hlname = tv_dict_get_string(tv->vval.v_dict, "hl_group", false);
     if (extra_hlname != NULL && *extra_hlname != NUL) {
-        extra_hlattr = syn_name2attr(extra_hlname);
+      extra_hlattr = syn_name2attr(extra_hlname);
     }
 
     if (tv_dict_get_number(tv->vval.v_dict, "icase")) {

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -39,6 +39,7 @@
 #include "nvim/globals.h"
 #include "nvim/highlight.h"
 #include "nvim/highlight_defs.h"
+#include "nvim/highlight_group.h"
 #include "nvim/indent.h"
 #include "nvim/indent_c.h"
 #include "nvim/insexpand.h"
@@ -170,6 +171,7 @@ struct compl_S {
   int cp_flags;                  ///< CP_ values
   int cp_number;                 ///< sequence number
   int cp_score;                  ///< fuzzy match score
+  int cp_extrahlattr;            ///< extra highlight group attr
 };
 
 /// state information used for getting the next set of insert completion
@@ -762,7 +764,7 @@ int ins_compl_add_infercase(char *str_arg, int len, bool icase, char *fname, Dir
     flags |= CP_ICASE;
   }
 
-  int res = ins_compl_add(str, len, fname, NULL, false, NULL, dir, flags, false);
+  int res = ins_compl_add(str, len, fname, NULL, false, NULL, dir, flags, false, -1);
   xfree(tofree);
   return res;
 }
@@ -802,7 +804,7 @@ static inline void free_cptext(char *const *const cptext)
 ///         returned in case of error.
 static int ins_compl_add(char *const str, int len, char *const fname, char *const *const cptext,
                          const bool cptext_allocated, typval_T *user_data, const Direction cdir,
-                         int flags_arg, const bool adup)
+                         int flags_arg, const bool adup, int extra_hlattr)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   compl_T *match;
@@ -868,6 +870,7 @@ static int ins_compl_add(char *const str, int len, char *const fname, char *cons
     match->cp_fname = NULL;
   }
   match->cp_flags = flags;
+  match->cp_extrahlattr = extra_hlattr;
 
   if (cptext != NULL) {
     int i;
@@ -1001,7 +1004,7 @@ static void ins_compl_add_matches(int num_matches, char **matches, int icase)
   for (int i = 0; i < num_matches && add_r != FAIL; i++) {
     if ((add_r = ins_compl_add(matches[i], -1, NULL, NULL, false, NULL, dir,
                                CP_FAST | (icase ? CP_ICASE : 0),
-                               false)) == OK) {
+                               false, -1)) == OK) {
       // If dir was BACKWARD then honor it just once.
       dir = FORWARD;
     }
@@ -1268,6 +1271,7 @@ static int ins_compl_build_pum(void)
       compl_match_array[i].pum_kind = comp->cp_text[CPT_KIND];
       compl_match_array[i].pum_info = comp->cp_text[CPT_INFO];
       compl_match_array[i].pum_score = comp->cp_score;
+      compl_match_array[i].pum_extrahlattr = comp->cp_extrahlattr;
       if (comp->cp_text[CPT_MENU] != NULL) {
         compl_match_array[i++].pum_extra = comp->cp_text[CPT_MENU];
       } else {
@@ -2553,6 +2557,8 @@ static int ins_compl_add_tv(typval_T *const tv, const Direction dir, bool fast)
   int flags = fast ? CP_FAST : 0;
   char *(cptext[CPT_COUNT]);
   typval_T user_data;
+  char *extra_hlname;
+  int extra_hlattr = -1;
 
   user_data.v_type = VAR_UNKNOWN;
   if (tv->v_type == VAR_DICT && tv->vval.v_dict != NULL) {
@@ -2562,6 +2568,10 @@ static int ins_compl_add_tv(typval_T *const tv, const Direction dir, bool fast)
     cptext[CPT_KIND] = tv_dict_get_string(tv->vval.v_dict, "kind", true);
     cptext[CPT_INFO] = tv_dict_get_string(tv->vval.v_dict, "info", true);
     tv_dict_get_tv(tv->vval.v_dict, "user_data", &user_data);
+    extra_hlname = tv_dict_get_string(tv->vval.v_dict, "hl_group", FALSE);
+    if (extra_hlname != NULL && *extra_hlname != NUL) {
+        extra_hlattr = syn_name2attr(extra_hlname);
+    }
 
     if (tv_dict_get_number(tv->vval.v_dict, "icase")) {
       flags |= CP_ICASE;
@@ -2582,7 +2592,7 @@ static int ins_compl_add_tv(typval_T *const tv, const Direction dir, bool fast)
     return FAIL;
   }
   int status = ins_compl_add((char *)word, -1, NULL, cptext, true,
-                             &user_data, dir, flags, dup);
+                             &user_data, dir, flags, dup, extra_hlattr);
   if (status != OK) {
     tv_clear(&user_data);
   }
@@ -2675,7 +2685,7 @@ static void set_completion(colnr_T startcol, list_T *list)
     flags |= CP_ICASE;
   }
   if (ins_compl_add(compl_orig_text, -1, NULL, NULL, false, NULL, 0,
-                    flags | CP_FAST, false) != OK) {
+                    flags | CP_FAST, false, -1) != OK) {
     return;
   }
 
@@ -3420,7 +3430,7 @@ static void get_next_bufname_token(void)
       char *tail = path_tail(b->b_sfname);
       if (strncmp(tail, compl_orig_text, strlen(compl_orig_text)) == 0) {
         ins_compl_add(tail, (int)strlen(tail), NULL, NULL, false, NULL, 0,
-                      p_ic ? CP_ICASE : 0, false);
+                      p_ic ? CP_ICASE : 0, false, -1);
       }
     }
   }
@@ -4458,7 +4468,7 @@ static int ins_compl_start(void)
     flags |= CP_ICASE;
   }
   if (ins_compl_add(compl_orig_text, -1, NULL, NULL, false, NULL, 0,
-                    flags, false) != OK) {
+                    flags, false, -1) != OK) {
     XFREE_CLEAR(compl_pattern);
     compl_patternlen = 0;
     XFREE_CLEAR(compl_orig_text);

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -506,7 +506,7 @@ static int *pum_compute_text_attrs(char *text, hlf_T hlf)
 
 /// Displays text on the popup menu with specific attributes.
 static void pum_grid_puts_with_attrs(int col, int cells, const char *text, int textlen,
-                                     const int *attrs)
+                                     const int *attrs, int extra_attr)
 {
   const int col_start = col;
   const char *ptr = text;
@@ -515,6 +515,9 @@ static void pum_grid_puts_with_attrs(int col, int cells, const char *text, int t
   while (*ptr != NUL && (textlen < 0 || ptr < text + textlen)) {
     int char_len = utfc_ptr2len(ptr);
     int attr = attrs[pum_rl ? (col_start + cells - col - 1) : (col - col_start)];
+    if (extra_attr > 0) {
+      attr = hl_combine_attr(extra_attr, attr);
+    }
     grid_line_puts(col, ptr, char_len, attr);
     col += utf_ptr2cells(ptr);
     ptr += char_len;
@@ -604,7 +607,6 @@ void pum_redraw(void)
     const hlf_T *const hlfs = (idx == pum_selected) ? hlfsSel : hlfsNorm;
     hlf_T hlf = hlfs[0];  // start with "word" highlight
     int attr = win_hl_attr(curwin, (int)hlf);
-
     grid_line_start(&pum_grid, row);
 
     // prepend a space if there is room
@@ -627,6 +629,9 @@ void pum_redraw(void)
     for (int round = 0; round < 3; round++) {
       hlf = hlfs[round];
       attr = win_hl_attr(curwin, (int)hlf);
+      if (pum_array[idx].pum_extrahlattr > 0) {
+        attr = hl_combine_attr(attr, pum_array[idx].pum_extrahlattr);
+      }
       int width = 0;
       char *s = NULL;
 
@@ -685,7 +690,7 @@ void pum_redraw(void)
               if (attrs == NULL) {
                 grid_line_puts(grid_col - cells + 1, rt, -1, attr);
               } else {
-                pum_grid_puts_with_attrs(grid_col - cells + 1, cells, rt, -1, attrs);
+                pum_grid_puts_with_attrs(grid_col - cells + 1, cells, rt, -1, attrs, pum_array[idx].pum_extrahlattr);
               }
 
               xfree(rt_start);
@@ -695,7 +700,7 @@ void pum_redraw(void)
               if (attrs == NULL) {
                 grid_line_puts(grid_col, st, -1, attr);
               } else {
-                pum_grid_puts_with_attrs(grid_col, vim_strsize(st), st, -1, attrs);
+                pum_grid_puts_with_attrs(grid_col, vim_strsize(st), st, -1, attrs, pum_array[idx].pum_extrahlattr);
               }
 
               xfree(st);

--- a/src/nvim/popupmenu.h
+++ b/src/nvim/popupmenu.h
@@ -10,12 +10,13 @@
 
 /// Used for popup menu items.
 typedef struct {
-  char *pum_text;   ///< main menu text
-  char *pum_kind;   ///< extra kind text (may be truncated)
-  char *pum_extra;  ///< extra menu text (may be truncated)
-  char *pum_info;   ///< extra info
-  int pum_score;    ///< fuzzy match score
-  int pum_idx;      ///< index of item before sorting by score
+  char *pum_text;       ///< main menu text
+  char *pum_kind;       ///< extra kind text (may be truncated)
+  char *pum_extra;      ///< extra menu text (may be truncated)
+  char *pum_info;       ///< extra info
+  int pum_score;        ///< fuzzy match score
+  int pum_idx;          ///< index of item before sorting by score
+  int pum_extrahlattr;  ///< extra highlight group attr for combine
 } pumitem_T;
 
 EXTERN ScreenGrid pum_grid INIT( = SCREEN_GRID_INIT);

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -4931,6 +4931,35 @@ describe('builtin popupmenu', function()
 
         feed('<C-E><Esc>')
       end)
+
+      -- oldtest: Test_pum_extrahl()
+      it('custom hl_group override', function()
+        exec([[
+          hi StrikeFake ctermfg=9
+          func CompleteFunc( findstart, base )
+            if a:findstart
+              return 0
+            endif
+            return {
+                  \ 'words': [
+                  \ { 'word': 'aword1', 'menu': 'extra text 1', 'kind': 'W', 'hl_group': 'StrikeFake' },
+                  \ { 'word': 'aword2', 'menu': 'extra text 2', 'kind': 'W', },
+                  \ { 'word': '你好', 'menu': 'extra text 3', 'kind': 'W', 'hl_group': 'StrikeFake' },
+                  \]}
+          endfunc
+          set completeopt=menu
+          set completefunc=CompleteFunc
+        ]])
+        feed('<ESC>iaw<C-X><C-U>')
+        screen:expect([[
+          aword1^                          |
+          {s:aword1 W extra text 1 }{1:          }|
+          {n:aword2 W extra text 2 }{1:          }|
+          {n:你好   W extra text 3 }{1:          }|
+          {1:~                               }|*15
+          {2:-- }{5:match 1 of 3}                 |
+        ]])
+      end)
     end
   end
 

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1516,9 +1516,9 @@ func Test_pum_extrahl()
       endif
       return {
             \ 'words': [
-            \ { 'word': 'aword1', 'menu': 'extra text 1', 'kind': 'W', 'extrahl': 'StrikeFake' },
+            \ { 'word': 'aword1', 'menu': 'extra text 1', 'kind': 'W', 'hl_group': 'StrikeFake' },
             \ { 'word': 'aword2', 'menu': 'extra text 2', 'kind': 'W', },
-            \ { 'word': '你好', 'menu': 'extra text 3', 'kind': 'W', 'extrahl': 'StrikeFake' },
+            \ { 'word': '你好', 'menu': 'extra text 3', 'kind': 'W', 'hl_group': 'StrikeFake' },
             \]}
     endfunc
     set completeopt=menu

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1506,4 +1506,33 @@ func Test_pum_highlights_match()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_pum_extrahl()
+  CheckScreendump
+  let lines =<< trim END
+    hi StrikeFake ctermfg=9
+    func CompleteFunc( findstart, base )
+      if a:findstart
+        return 0
+      endif
+      return {
+            \ 'words': [
+            \ { 'word': 'aword1', 'menu': 'extra text 1', 'kind': 'W', 'extrahl': 'StrikeFake' },
+            \ { 'word': 'aword2', 'menu': 'extra text 2', 'kind': 'W', },
+            \ { 'word': '你好', 'menu': 'extra text 3', 'kind': 'W', 'extrahl': 'StrikeFake' },
+            \]}
+    endfunc
+    set completeopt=menu
+    set completefunc=CompleteFunc
+  END
+  call writefile(lines, 'Xscript', 'D')
+  let buf = RunVimInTerminal('-S Xscript', {})
+  call TermWait(buf)
+  call term_sendkeys(buf, "iaw\<C-X>\<C-u>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_pum_highlights_12', {})
+  call term_sendkeys(buf, "\<C-E>\<Esc>u")
+  call TermWait(buf)
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
vim-patch:9.1.0618: cannot mark deprecated attributes in completion menu

Problem:  tests: test_popup fails
          (after v9.1.0618)
Solution: Correct test, move combining extra attributes to
          pum_compute_text_attrs() (glepnir)

closes: https://github.com/vim/vim/pull/15353
https://github.com/vim/vim/commit/8754efe437fcb17ad2c64192f8722e08d68e032e

vim-patch 9.1.0619: tests: test_popup fails

Problem:  tests: test_popup fails
          (after v9.1.0618)
Solution: Correct test, move combining extra attributes to
          pum_compute_text_attrs() (glepnir)

closes: https://github.com/vim/vim/pull/15353

https://github.com/vim/vim/commit/8754efe437fcb17ad2c64192f8722e08d68e032e

test: add case of hl_group field in complete function

Problem: missing test case of hl_gruop in lua.

Solution: add test case of hl_group in complete function