### PR TITLE
fix(lsp): revert text edit application order change

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -396,10 +396,7 @@ function M.apply_text_edits(text_edits, bufnr, offset_encoding)
     if a.range.start.character ~= b.range.start.character then
       return a.range.start.character > b.range.start.character
     end
-    if a._index ~= b._index then
-      return a._index < b._index
-    end
-    return false
+    return a._index > b._index
   end)
 
   -- save and restore local marks since they get deleted by nvim_buf_set_lines


### PR DESCRIPTION
Reverts https://github.com/neovim/neovim/pull/29212 and adds a few
additional test cases

After re-reading the spec several times:

> All text edits ranges refer to positions in the document they are
> computed on. They therefore move a document from state S1 to S2 without
> describing any intermediate state. Text edits ranges must never overlap,
> that means no part of the original document must be manipulated by more
> than one edit. However, it is possible that multiple edits have the same
> start position: multiple inserts, or any number of inserts followed by a
> single remove or replace edit. If multiple inserts have the same
> position, the order in the array defines the order in which the inserted
> strings appear in the resulting text.

I think the fix was actually wrong. The important part is here:

> If multiple inserts have the same position, the order in the array
> defines the order in which the inserted strings appear in the
> resulting text.

Emphasis on _appear in the resulting text_

Which means that in:

    local edits1 = {
      make_edit(0, 3, 0, 3, { 'World' }),
      make_edit(0, 3, 0, 3, { 'Hello' }),
    }

`World` must appear before `Hello` in the final text. That means the old
logic was correct, and the fix was wrong.


cc @alcolmenar 