### PR TITLE
vim-patch:4c45425: runtime(debcopyright): Add support for Files-Included in syntax script

### DIFF
--- a/runtime/syntax/debcopyright.vim
+++ b/runtime/syntax/debcopyright.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:    Debian copyright file
 " Maintainer:  Debian Vim Maintainers
-" Last Change: 2023 Jan 16
+" Last Change: 2024 Jul 28
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/debcopyright.vim
 
 " Standard syntax initialization
@@ -15,7 +15,7 @@ set cpo&vim
 syn case match
 
 syn match debcopyrightUrl       "\vhttps?://[[:alnum:]][-[:alnum:]]*[[:alnum:]]?(\.[[:alnum:]][-[:alnum:]]*[[:alnum:]]?)*\.[[:alpha:]][-[:alnum:]]*[[:alpha:]]?(:\d+)?(/[^[:space:]]*)?$"
-syn match debcopyrightKey       "^\%(Format\|Upstream-Name\|Upstream-Contact\|Disclaimer\|Source\|Comment\|Files\|Copyright\|License\|Files-Excluded\%(-[-a-zA-Z0-9]\+\)\=\): *"
+syn match debcopyrightKey       "^\%(Format\|Upstream-Name\|Upstream-Contact\|Disclaimer\|Source\|Comment\|Files\|Copyright\|License\|Files-\%(Excluded\|Included\)\%(-[-a-zA-Z0-9]\+\)\=\): *"
 syn match debcopyrightEmail     "[_=[:alnum:]\.+-]\+@[[:alnum:]\./\-]\+"
 syn match debcopyrightEmail     "<.\{-}>"
 syn match debcopyrightComment   "^#.*$" contains=@Spell


### PR DESCRIPTION
Full support (including for components) was finished with this commit:
https://salsa.debian.org/debian/devscripts/-/commit/ee90dad7712a7db1e9541b405e065a08d29d62f8

closes: vim/vim#15374

https://github.com/vim/vim/commit/4c45425c10a94382a435239e8f63c6b1ca55d4e4

Co-authored-by: josch <josch@debian.org>
