### PR TITLE
Better consistency with anonymous nodes

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -166,7 +166,7 @@ TERMINAL
 
 TREESITTER
 
-• TODO
+• |LanguageTree:node_for_range()| gets anonymous and named nodes for a range
 
 TUI
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -167,6 +167,8 @@ TERMINAL
 TREESITTER
 
 • |LanguageTree:node_for_range()| gets anonymous and named nodes for a range
+• |vim.treesitter.get_node()| now takes an option `include_anonymous`, default
+  false, which allows it to return anonymous nodes as well as named nodes.
 
 TUI
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1375,6 +1375,19 @@ LanguageTree:named_node_for_range({range}, {opts})
     Return: ~
         (`TSNode?`)
 
+                                               *LanguageTree:node_for_range()*
+LanguageTree:node_for_range({range}, {opts})
+    Gets the smallest node that contains {range}.
+
+    Parameters: ~
+      • {range}  (`Range4`) `{ start_line, start_col, end_line, end_col }`
+      • {opts}   (`table?`) A table with the following fields:
+                 • {ignore_injections}? (`boolean`, default: `true`) Ignore
+                   injected languages
+
+    Return: ~
+        (`TSNode?`)
+
 LanguageTree:parse({range})                             *LanguageTree:parse()*
     Recursively parse all regions in the language tree using
     |treesitter-parsers| for the corresponding languages and run injection

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -773,6 +773,8 @@ get_node({opts})                                   *vim.treesitter.get_node()*
                   filetype)
                 • {ignore_injections} (`boolean?`) Ignore injected languages
                   (default true)
+                • {include_anonymous} (`boolean?`) Include anonymous nodes
+                  (default false)
 
     Return: ~
         (`TSNode?`) Node at the given position

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -342,6 +342,9 @@ end
 ---
 --- Ignore injected languages (default true)
 --- @field ignore_injections boolean?
+---
+--- Include anonymous nodes (default false)
+--- @field include_anonymous boolean?
 
 --- Returns the smallest named node at the given position
 ---
@@ -388,6 +391,9 @@ function M.get_node(opts)
     return
   end
 
+  if opts.include_anonymous then
+    return root_lang_tree:node_for_range(ts_range, opts)
+  end
   return root_lang_tree:named_node_for_range(ts_range, opts)
 end
 

--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -183,6 +183,7 @@ local function set_inspector_cursor(treeview, lang, source_buf, inspect_buf, ins
     lang = lang,
     pos = pos,
     ignore_injections = false,
+    include_anonymous = treeview.opts.anon,
   })
   if not cursor_node then
     return

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -1133,6 +1133,18 @@ function LanguageTree:tree_for_range(range, opts)
   return nil
 end
 
+--- Gets the smallest node that contains {range}.
+---
+---@param range Range4 `{ start_line, start_col, end_line, end_col }`
+---@param opts? vim.treesitter.LanguageTree.tree_for_range.Opts
+---@return TSNode?
+function LanguageTree:node_for_range(range, opts)
+  local tree = self:tree_for_range(range, opts)
+  if tree then
+    return tree:root():descendant_for_range(unpack(range))
+  end
+end
+
 --- Gets the smallest named node that contains {range}.
 ---
 ---@param range Range4 `{ start_line, start_col, end_line, end_col }`

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -148,4 +148,15 @@ describe('treesitter language API', function()
 
     eq('<node primitive_type>', exec_lua('return tostring(node)'))
   end)
+
+  it('retrieve an anonymous node given a range', function()
+    insert([[vim.fn.input()]])
+
+    exec_lua([[
+      langtree = vim.treesitter.get_parser(0, "lua")
+      node = langtree:node_for_range({0, 3, 0, 3})
+    ]])
+
+    eq('.', exec_lua('return node:type()'))
+  end)
 end)

--- a/test/functional/treesitter/node_spec.lua
+++ b/test/functional/treesitter/node_spec.lua
@@ -55,6 +55,23 @@ describe('treesitter node API', function()
     eq('identifier', lua_eval('node:type()'))
   end)
 
+  it('get_node() with anonymous nodes included', function()
+    insert([[print('test')]])
+
+    exec_lua([[
+      parser = vim.treesitter.get_parser(0, 'lua')
+      tree = parser:parse()[1]
+      node = vim.treesitter.get_node({
+        bufnr = 0,
+        pos = { 0, 6 }, -- on the first apostrophe
+        include_anonymous = true,
+      })
+    ]])
+
+    eq("'", lua_eval('node:type()'))
+    eq(false, lua_eval('node:named()'))
+  end)
+
   it('can move between siblings', function()
     insert([[
       int main(int x, int y, int z) {


### PR DESCRIPTION
This PR has three different commits, each with relatively small changes (but ones that change the API). In order of when they appear:

### feat(treesitter): add node_for_range function

- This is identical to `named_node_for_range` except that it includes
anonymous nodes. This maintains consistency in the API because we
already have `descendant_for_range` and `named_descendant_for_range`.

### feat(treesitter): allow get_node to return anonymous nodes

- Adds a new field `include_anonymous` to the `get_node` options to allow
anonymous nodes to be returned.

### fix(treesitter): highlight anonymous nodes in inspect_tree

- **Problem:** With anonymous nodes toggled in the inspect tree, only
named nodes will be highlighted when moving the cursor in the source
code buffer.
\
**Solution:** Retrieve the anonymous node at the cursor (when toggled on
in the inspect tree) and highlight them when appropriate, for better
clarity/specificity.