### PR TITLE
fix(win-msi): set installer scope to machine

### DIFF
--- a/cmake.packaging/CMakeLists.txt
+++ b/cmake.packaging/CMakeLists.txt
@@ -38,6 +38,7 @@ if(WIN32)
   # Create start menu and desktop shortcuts
   set(CPACK_WIX_PROGRAM_MENU_FOLDER "${CPACK_PACKAGE_NAME}")
   set(CPACK_PACKAGE_EXECUTABLES "nvim" "Neovim")
+  set(CPACK_WIX_INSTALL_SCOPE "perMachine")
 
   set(CPACK_WIX_UI_REF "WixUI_CustomInstallDir")
   list(APPEND CPACK_WIX_EXTRA_SOURCES ${CMAKE_CURRENT_LIST_DIR}/WixUI_CustomInstallDir.wxs)


### PR DESCRIPTION
Problem:
The windows installer did not have the AllUsers property which leads to the installer being misidentified as per user installer. Currently the installer already requires administrative privileges and installs into the system-wide ProgramFiles directory, but the start menu entry and uninstaller registration are created only for the current user. 

https://cmake.org/cmake/help/latest/cpack_gen/wix.html#variable:CPACK_WIX_INSTALL_SCOPE

Solution:
With setting CPACK_WIX_INSTALL_SCOPE to "perMachine" the generated msi installer includes the Property ALLUSERS=1.
Additionally the start menu entries and uninstaller registration will be created for all users.

resolves #29885

![fixed-installer](https://github.com/user-attachments/assets/75fad932-5185-4c7d-a7c6-b2f8d6157fe6)
