### PR TITLE
test: allow exec_lua to handle functions

### DIFF
--- a/test/functional/lua/api_spec.lua
+++ b/test/functional/lua/api_spec.lua
@@ -145,10 +145,10 @@ describe('luaeval(vim.api.…)', function()
     eq(true, fn.luaeval('vim.api.nvim__id(vim.api.nvim__id)(true)'))
     eq(
       42,
-      exec_lua [[
-      local f = vim.api.nvim__id({42, vim.api.nvim__id})
-      return f[2](f[1])
-    ]]
+      exec_lua(function()
+        local f = vim.api.nvim__id({ 42, vim.api.nvim__id })
+        return f[2](f[1])
+      end)
     )
   end)
 

--- a/test/functional/lua/commands_spec.lua
+++ b/test/functional/lua/commands_spec.lua
@@ -178,13 +178,15 @@ describe(':lua', function()
     eq('hello', exec_capture(':lua = x()'))
     exec_lua('x = {a = 1, b = 2}')
     eq('{\n  a = 1,\n  b = 2\n}', exec_capture(':lua  =x'))
-    exec_lua([[function x(success)
-      if success then
-        return true, "Return value"
-      else
-        return false, nil, "Error message"
+    exec_lua(function()
+      function _G.x(success)
+        if success then
+          return true, 'Return value'
+        else
+          return false, nil, 'Error message'
+        end
       end
-    end]])
+    end)
     eq(
       dedent [[
       true

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -15,10 +15,10 @@ describe('vim.diagnostic', function()
   before_each(function()
     clear()
 
-    exec_lua [[
+    exec_lua(function()
       require('vim.diagnostic')
 
-      function make_diagnostic(msg, lnum, col, end_lnum, end_col, severity, source, code)
+      local function make_diagnostic(msg, lnum, col, end_lnum, end_col, severity, source, code)
         return {
           lnum = lnum,
           col = col,
@@ -31,54 +31,97 @@ describe('vim.diagnostic', function()
         }
       end
 
-      function make_error(msg, lnum, col, end_lnum, end_col, source, code)
-        return make_diagnostic(msg, lnum, col, end_lnum, end_col, vim.diagnostic.severity.ERROR, source, code)
+      function _G.make_error(msg, lnum, col, end_lnum, end_col, source, code)
+        return make_diagnostic(
+          msg,
+          lnum,
+          col,
+          end_lnum,
+          end_col,
+          vim.diagnostic.severity.ERROR,
+          source,
+          code
+        )
       end
 
-      function make_warning(msg, lnum, col, end_lnum, end_col, source, code)
-        return make_diagnostic(msg, lnum, col, end_lnum, end_col, vim.diagnostic.severity.WARN, source, code)
+      function _G.make_warning(msg, lnum, col, end_lnum, end_col, source, code)
+        return make_diagnostic(
+          msg,
+          lnum,
+          col,
+          end_lnum,
+          end_col,
+          vim.diagnostic.severity.WARN,
+          source,
+          code
+        )
       end
 
-      function make_info(msg, lnum, col, end_lnum, end_col, source, code)
-        return make_diagnostic(msg, lnum, col, end_lnum, end_col, vim.diagnostic.severity.INFO, source, code)
+      function _G.make_info(msg, lnum, col, end_lnum, end_col, source, code)
+        return make_diagnostic(
+          msg,
+          lnum,
+          col,
+          end_lnum,
+          end_col,
+          vim.diagnostic.severity.INFO,
+          source,
+          code
+        )
       end
 
-      function make_hint(msg, lnum, col, end_lnum, end_col, source, code)
-        return make_diagnostic(msg, lnum, col, end_lnum, end_col, vim.diagnostic.severity.HINT, source, code)
+      function _G.make_hint(msg, lnum, col, end_lnum, end_col, source, code)
+        return make_diagnostic(
+          msg,
+          lnum,
+          col,
+          end_lnum,
+          end_col,
+          vim.diagnostic.severity.HINT,
+          source,
+          code
+        )
       end
 
-      function count_diagnostics(bufnr, severity, namespace)
-        return #vim.diagnostic.get(bufnr, {severity = severity, namespace = namespace})
+      function _G.count_diagnostics(bufnr, severity, namespace)
+        return #vim.diagnostic.get(bufnr, { severity = severity, namespace = namespace })
       end
 
-      function count_extmarks(bufnr, namespace)
+      function _G.count_extmarks(bufnr, namespace)
         local ns = vim.diagnostic.get_namespace(namespace)
         local extmarks = 0
         if ns.user_data.virt_text_ns then
-          extmarks = extmarks + #vim.api.nvim_buf_get_extmarks(bufnr, ns.user_data.virt_text_ns, 0, -1, {})
+          extmarks = extmarks
+            + #vim.api.nvim_buf_get_extmarks(bufnr, ns.user_data.virt_text_ns, 0, -1, {})
         end
         if ns.user_data.underline_ns then
-          extmarks = extmarks + #vim.api.nvim_buf_get_extmarks(bufnr, ns.user_data.underline_ns, 0, -1, {})
+          extmarks = extmarks
+            + #vim.api.nvim_buf_get_extmarks(bufnr, ns.user_data.underline_ns, 0, -1, {})
         end
         return extmarks
       end
 
-      function get_virt_text_extmarks(ns)
-        local ns = vim.diagnostic.get_namespace(ns)
+      function _G.get_virt_text_extmarks(ns)
+        ns = vim.diagnostic.get_namespace(ns)
         local virt_text_ns = ns.user_data.virt_text_ns
-        return vim.api.nvim_buf_get_extmarks(diagnostic_bufnr, virt_text_ns, 0, -1, {details = true})
+        return vim.api.nvim_buf_get_extmarks(
+          _G.diagnostic_bufnr,
+          virt_text_ns,
+          0,
+          -1,
+          { details = true }
+        )
       end
-    ]]
+    end)
 
-    exec_lua([[
-      diagnostic_ns = vim.api.nvim_create_namespace("diagnostic_spec")
-      other_ns = vim.api.nvim_create_namespace("other_namespace")
-      diagnostic_bufnr = vim.api.nvim_create_buf(true, false)
-      local lines = {"1st line of text", "2nd line of text", "wow", "cool", "more", "lines"}
-      vim.fn.bufload(diagnostic_bufnr)
-      vim.api.nvim_buf_set_lines(diagnostic_bufnr, 0, 1, false, lines)
-      return diagnostic_bufnr
-    ]])
+    exec_lua(function()
+      _G.diagnostic_ns = vim.api.nvim_create_namespace('diagnostic_spec')
+      _G.other_ns = vim.api.nvim_create_namespace('other_namespace')
+      _G.diagnostic_bufnr = vim.api.nvim_create_buf(true, false)
+      local lines = { '1st line of text', '2nd line of text', 'wow', 'cool', 'more', 'lines' }
+      vim.fn.bufload(_G.diagnostic_bufnr)
+      vim.api.nvim_buf_set_lines(_G.diagnostic_bufnr, 0, 1, false, lines)
+    end)
   end)
 
   it('creates highlight groups', function()
@@ -115,27 +158,28 @@ describe('vim.diagnostic', function()
   end)
 
   it('retrieves diagnostics from all buffers and namespaces', function()
-    local result = exec_lua [[
+    local result = exec_lua(function()
       local other_bufnr = vim.api.nvim_create_buf(true, false)
-      local lines = vim.api.nvim_buf_get_lines(diagnostic_bufnr, 0, -1, true)
+      local lines = vim.api.nvim_buf_get_lines(_G.diagnostic_bufnr, 0, -1, true)
       vim.api.nvim_buf_set_lines(other_bufnr, 0, 1, false, lines)
 
-      vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-        make_error('Diagnostic #1', 1, 1, 1, 1),
-        make_error('Diagnostic #2', 2, 1, 2, 1),
+      vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+        _G.make_error('Diagnostic #1', 1, 1, 1, 1),
+        _G.make_error('Diagnostic #2', 2, 1, 2, 1),
       })
-      vim.diagnostic.set(other_ns, other_bufnr, {
-        make_error('Diagnostic #3', 3, 1, 3, 1),
+      vim.diagnostic.set(_G.other_ns, other_bufnr, {
+        _G.make_error('Diagnostic #3', 3, 1, 3, 1),
       })
       return vim.diagnostic.get()
-    ]]
+    end)
     eq(3, #result)
     eq(
       2,
-      exec_lua(
-        [[return #vim.tbl_filter(function(d) return d.bufnr == diagnostic_bufnr end, ...)]],
-        result
-      )
+      exec_lua(function(result0)
+        return #vim.tbl_filter(function(d)
+          return d.bufnr == _G.diagnostic_bufnr
+        end, result0)
+      end, result)
     )
     eq('Diagnostic #1', result[1].message)
   end)
@@ -143,155 +187,171 @@ describe('vim.diagnostic', function()
   it('removes diagnostics from the cache when a buffer is removed', function()
     eq(
       2,
-      exec_lua [[
-      vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-      local other_bufnr = vim.fn.bufadd('test | test')
-      local lines = vim.api.nvim_buf_get_lines(diagnostic_bufnr, 0, -1, true)
-      vim.api.nvim_buf_set_lines(other_bufnr, 0, 1, false, lines)
-      vim.cmd('bunload! ' .. other_bufnr)
+      exec_lua(function()
+        vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+        local other_bufnr = vim.fn.bufadd('test | test')
+        local lines = vim.api.nvim_buf_get_lines(_G.diagnostic_bufnr, 0, -1, true)
+        vim.api.nvim_buf_set_lines(other_bufnr, 0, 1, false, lines)
+        vim.cmd('bunload! ' .. other_bufnr)
 
-      vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-        make_error('Diagnostic #1', 1, 1, 1, 1),
-        make_error('Diagnostic #2', 2, 1, 2, 1),
-      })
-      vim.diagnostic.set(diagnostic_ns, other_bufnr, {
-        make_error('Diagnostic #3', 3, 1, 3, 1),
-      })
-      vim.api.nvim_set_current_buf(other_bufnr)
-      vim.opt_local.buflisted = true
-      vim.cmd('bwipeout!')
-      return #vim.diagnostic.get()
-    ]]
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Diagnostic #1', 1, 1, 1, 1),
+          _G.make_error('Diagnostic #2', 2, 1, 2, 1),
+        })
+        vim.diagnostic.set(_G.diagnostic_ns, other_bufnr, {
+          _G.make_error('Diagnostic #3', 3, 1, 3, 1),
+        })
+        vim.api.nvim_set_current_buf(other_bufnr)
+        vim.opt_local.buflisted = true
+        vim.cmd('bwipeout!')
+        return #vim.diagnostic.get()
+      end)
     )
     eq(
       2,
-      exec_lua [[
-      vim.api.nvim_set_current_buf(diagnostic_bufnr)
-      vim.opt_local.buflisted = false
-      return #vim.diagnostic.get()
-    ]]
+      exec_lua(function()
+        vim.api.nvim_set_current_buf(_G.diagnostic_bufnr)
+        vim.opt_local.buflisted = false
+        return #vim.diagnostic.get()
+      end)
     )
     eq(
       0,
-      exec_lua [[
-      vim.cmd('bwipeout!')
-      return #vim.diagnostic.get()
-    ]]
+      exec_lua(function()
+        vim.cmd('bwipeout!')
+        return #vim.diagnostic.get()
+      end)
     )
   end)
 
   it('removes diagnostic from stale cache on reset', function()
-    local diagnostics = exec_lua [[
-      vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-        make_error('Diagnostic #1', 1, 1, 1, 1),
-        make_error('Diagnostic #2', 2, 1, 2, 1),
+    local diagnostics = exec_lua(function()
+      vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+        _G.make_error('Diagnostic #1', 1, 1, 1, 1),
+        _G.make_error('Diagnostic #2', 2, 1, 2, 1),
       })
-      local other_bufnr = vim.fn.bufadd('test | test')
-      vim.cmd('noautocmd bwipeout! ' .. diagnostic_bufnr)
-      return vim.diagnostic.get(diagnostic_bufnr)
-    ]]
+      vim.fn.bufadd('test | test')
+      vim.cmd('noautocmd bwipeout! ' .. _G.diagnostic_bufnr)
+      return vim.diagnostic.get(_G.diagnostic_bufnr)
+    end)
     eq(2, #diagnostics)
-    diagnostics = exec_lua [[
+    diagnostics = exec_lua(function()
       vim.diagnostic.reset()
       return vim.diagnostic.get()
-    ]]
+    end)
     eq(0, #diagnostics)
   end)
 
   it('always returns a copy of diagnostic tables', function()
-    local result = exec_lua [[
-      vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-        make_error('Diagnostic #1', 1, 1, 1, 1),
+    local result = exec_lua(function()
+      vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+        _G.make_error('Diagnostic #1', 1, 1, 1, 1),
       })
       local diag = vim.diagnostic.get()
       diag[1].col = 10000
       return vim.diagnostic.get()[1].col == 10000
-    ]]
+    end)
     eq(false, result)
   end)
 
   it('resolves buffer number 0 to the current buffer', function()
     eq(
       2,
-      exec_lua [[
-      vim.api.nvim_set_current_buf(diagnostic_bufnr)
-      vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-        make_error('Diagnostic #1', 1, 1, 1, 1),
-        make_error('Diagnostic #2', 2, 1, 2, 1),
-      })
-      return #vim.diagnostic.get(0)
-    ]]
+      exec_lua(function()
+        vim.api.nvim_set_current_buf(_G.diagnostic_bufnr)
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Diagnostic #1', 1, 1, 1, 1),
+          _G.make_error('Diagnostic #2', 2, 1, 2, 1),
+        })
+        return #vim.diagnostic.get(0)
+      end)
     )
   end)
 
   it('saves and count a single error', function()
     eq(
       1,
-      exec_lua [[
-      vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-        make_error('Diagnostic #1', 1, 1, 1, 1),
-      })
-      return count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns)
-    ]]
+      exec_lua(function()
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Diagnostic #1', 1, 1, 1, 1),
+        })
+        return _G.count_diagnostics(
+          _G.diagnostic_bufnr,
+          vim.diagnostic.severity.ERROR,
+          _G.diagnostic_ns
+        )
+      end)
     )
   end)
 
   it('saves and count multiple errors', function()
     eq(
       2,
-      exec_lua [[
-      vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-        make_error('Diagnostic #1', 1, 1, 1, 1),
-        make_error('Diagnostic #2', 2, 1, 2, 1),
-      })
-      return count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns)
-    ]]
+      exec_lua(function()
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Diagnostic #1', 1, 1, 1, 1),
+          _G.make_error('Diagnostic #2', 2, 1, 2, 1),
+        })
+        return _G.count_diagnostics(
+          _G.diagnostic_bufnr,
+          vim.diagnostic.severity.ERROR,
+          _G.diagnostic_ns
+        )
+      end)
     )
   end)
 
   it('saves and count from multiple namespaces', function()
     eq(
       { 1, 1, 2 },
-      exec_lua [[
-      vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-        make_error('Diagnostic From Server 1', 1, 1, 1, 1),
-      })
-      vim.diagnostic.set(other_ns, diagnostic_bufnr, {
-        make_error('Diagnostic From Server 2', 1, 1, 1, 1),
-      })
-      return {
-        -- First namespace
-        count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns),
-        -- Second namespace
-        count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, other_ns),
-        -- All namespaces
-        count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR),
-      }
-    ]]
+      exec_lua(function()
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Diagnostic From Server 1', 1, 1, 1, 1),
+        })
+        vim.diagnostic.set(_G.other_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Diagnostic From Server 2', 1, 1, 1, 1),
+        })
+        return {
+          -- First namespace
+          _G.count_diagnostics(
+            _G.diagnostic_bufnr,
+            vim.diagnostic.severity.ERROR,
+            _G.diagnostic_ns
+          ),
+          -- Second namespace
+          _G.count_diagnostics(_G.diagnostic_bufnr, vim.diagnostic.severity.ERROR, _G.other_ns),
+          -- All namespaces
+          _G.count_diagnostics(_G.diagnostic_bufnr, vim.diagnostic.severity.ERROR),
+        }
+      end)
     )
   end)
 
   it('saves and count from multiple namespaces with respect to severity', function()
     eq(
       { 3, 0, 3 },
-      exec_lua [[
-      vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-        make_error('Diagnostic From Server 1:1', 1, 1, 1, 1),
-        make_error('Diagnostic From Server 1:2', 2, 2, 2, 2),
-        make_error('Diagnostic From Server 1:3', 2, 3, 3, 2),
-      })
-      vim.diagnostic.set(other_ns, diagnostic_bufnr, {
-        make_warning('Warning From Server 2', 3, 3, 3, 3),
-      })
-      return {
-        -- Namespace 1
-        count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns),
-        -- Namespace 2
-        count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, other_ns),
-        -- All namespaces
-        count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR),
-      }
-    ]]
+      exec_lua(function()
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Diagnostic From Server 1:1', 1, 1, 1, 1),
+          _G.make_error('Diagnostic From Server 1:2', 2, 2, 2, 2),
+          _G.make_error('Diagnostic From Server 1:3', 2, 3, 3, 2),
+        })
+        vim.diagnostic.set(_G.other_ns, _G.diagnostic_bufnr, {
+          _G.make_warning('Warning From Server 2', 3, 3, 3, 3),
+        })
+        return {
+          -- Namespace 1
+          _G.count_diagnostics(
+            _G.diagnostic_bufnr,
+            vim.diagnostic.severity.ERROR,
+            _G.diagnostic_ns
+          ),
+          -- Namespace 2
+          _G.count_diagnostics(_G.diagnostic_bufnr, vim.diagnostic.severity.ERROR, _G.other_ns),
+          -- All namespaces
+          _G.count_diagnostics(_G.diagnostic_bufnr, vim.diagnostic.severity.ERROR),
+        }
+      end)
     )
   end)
 
@@ -304,160 +364,190 @@ describe('vim.diagnostic', function()
     local all_highlights = { 1, 1, 2, 4, 2 }
     eq(
       all_highlights,
-      exec_lua [[
-      local ns_1_diags = {
-        make_error("Error 1", 1, 1, 1, 5),
-        make_warning("Warning on Server 1", 2, 1, 2, 3),
-      }
-      local ns_2_diags = {
-        make_warning("Warning 1", 2, 1, 2, 3),
-      }
+      exec_lua(function()
+        local ns_1_diags = {
+          _G.make_error('Error 1', 1, 1, 1, 5),
+          _G.make_warning('Warning on Server 1', 2, 1, 2, 3),
+        }
+        local ns_2_diags = {
+          _G.make_warning('Warning 1', 2, 1, 2, 3),
+        }
 
-      vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, ns_1_diags)
-      vim.diagnostic.set(other_ns, diagnostic_bufnr, ns_2_diags)
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, ns_1_diags)
+        vim.diagnostic.set(_G.other_ns, _G.diagnostic_bufnr, ns_2_diags)
 
-      return {
-        count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns),
-        count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.WARN, other_ns),
-        count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.WARN),
-        count_extmarks(diagnostic_bufnr, diagnostic_ns),
-        count_extmarks(diagnostic_bufnr, other_ns),
-      }
-    ]]
+        return {
+          _G.count_diagnostics(
+            _G.diagnostic_bufnr,
+            vim.diagnostic.severity.ERROR,
+            _G.diagnostic_ns
+          ),
+          _G.count_diagnostics(_G.diagnostic_bufnr, vim.diagnostic.severity.WARN, _G.other_ns),
+          _G.count_diagnostics(_G.diagnostic_bufnr, vim.diagnostic.severity.WARN),
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns),
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns),
+        }
+      end)
     )
 
     -- Clear diagnostics from namespace 1, and make sure we have the right amount of stuff for namespace 2
     eq(
       { 1, 1, 2, 0, 2 },
-      exec_lua [[
-      vim.diagnostic.enable(false, { bufnr = diagnostic_bufnr, ns_id = diagnostic_ns })
-      return {
-        count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns),
-        count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.WARN, other_ns),
-        count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.WARN),
-        count_extmarks(diagnostic_bufnr, diagnostic_ns),
-        count_extmarks(diagnostic_bufnr, other_ns),
-      }
-    ]]
+      exec_lua(function()
+        vim.diagnostic.enable(false, { bufnr = _G.diagnostic_bufnr, ns_id = _G.diagnostic_ns })
+        return {
+          _G.count_diagnostics(
+            _G.diagnostic_bufnr,
+            vim.diagnostic.severity.ERROR,
+            _G.diagnostic_ns
+          ),
+          _G.count_diagnostics(_G.diagnostic_bufnr, vim.diagnostic.severity.WARN, _G.other_ns),
+          _G.count_diagnostics(_G.diagnostic_bufnr, vim.diagnostic.severity.WARN),
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns),
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns),
+        }
+      end)
     )
 
     -- Show diagnostics from namespace 1 again
     eq(
       all_highlights,
-      exec_lua([[
-      vim.diagnostic.enable(true, { bufnr = diagnostic_bufnr, ns_id = diagnostic_ns })
-      return {
-        count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns),
-        count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.WARN, other_ns),
-        count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.WARN),
-        count_extmarks(diagnostic_bufnr, diagnostic_ns),
-        count_extmarks(diagnostic_bufnr, other_ns),
-      }
-    ]])
+      exec_lua(function()
+        vim.diagnostic.enable(true, { bufnr = _G.diagnostic_bufnr, ns_id = _G.diagnostic_ns })
+        return {
+          _G.count_diagnostics(
+            _G.diagnostic_bufnr,
+            vim.diagnostic.severity.ERROR,
+            _G.diagnostic_ns
+          ),
+          _G.count_diagnostics(_G.diagnostic_bufnr, vim.diagnostic.severity.WARN, _G.other_ns),
+          _G.count_diagnostics(_G.diagnostic_bufnr, vim.diagnostic.severity.WARN),
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns),
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns),
+        }
+      end)
     )
   end)
 
   it('does not display diagnostics when disabled', function()
     eq(
       { 0, 2 },
-      exec_lua [[
-      local ns_1_diags = {
-        make_error("Error 1", 1, 1, 1, 5),
-        make_warning("Warning on Server 1", 2, 1, 2, 3),
-      }
-      local ns_2_diags = {
-        make_warning("Warning 1", 2, 1, 2, 3),
-      }
+      exec_lua(function()
+        local ns_1_diags = {
+          _G.make_error('Error 1', 1, 1, 1, 5),
+          _G.make_warning('Warning on Server 1', 2, 1, 2, 3),
+        }
+        local ns_2_diags = {
+          _G.make_warning('Warning 1', 2, 1, 2, 3),
+        }
 
-      vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, ns_1_diags)
-      vim.diagnostic.set(other_ns, diagnostic_bufnr, ns_2_diags)
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, ns_1_diags)
+        vim.diagnostic.set(_G.other_ns, _G.diagnostic_bufnr, ns_2_diags)
 
-      vim.diagnostic.enable(false, { bufnr = diagnostic_bufnr, ns_id = diagnostic_ns })
+        vim.diagnostic.enable(false, { bufnr = _G.diagnostic_bufnr, ns_id = _G.diagnostic_ns })
 
-      return {
-        count_extmarks(diagnostic_bufnr, diagnostic_ns),
-        count_extmarks(diagnostic_bufnr, other_ns),
-      }
-    ]]
+        return {
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns),
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns),
+        }
+      end)
     )
 
     eq(
       { 4, 0 },
-      exec_lua [[
-      vim.diagnostic.enable(true, { bufnr = diagnostic_bufnr, ns_id = diagnostic_ns })
-      vim.diagnostic.enable(false, { bufnr = diagnostic_bufnr, ns_id = other_ns })
+      exec_lua(function()
+        vim.diagnostic.enable(true, { bufnr = _G.diagnostic_bufnr, ns_id = _G.diagnostic_ns })
+        vim.diagnostic.enable(false, { bufnr = _G.diagnostic_bufnr, ns_id = _G.other_ns })
 
-      return {
-        count_extmarks(diagnostic_bufnr, diagnostic_ns),
-        count_extmarks(diagnostic_bufnr, other_ns),
-      }
-    ]]
+        return {
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns),
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns),
+        }
+      end)
     )
   end)
 
   describe('show() and hide()', function()
     it('works', function()
-      local result = exec_lua [[
+      local result = exec_lua(function()
         local other_bufnr = vim.api.nvim_create_buf(true, false)
 
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
+        vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
 
         local result = {}
 
         vim.diagnostic.config({ underline = false, virtual_text = true })
 
         local ns_1_diags = {
-          make_error("Error 1", 1, 1, 1, 5),
-          make_warning("Warning on Server 1", 2, 1, 2, 5),
+          _G.make_error('Error 1', 1, 1, 1, 5),
+          _G.make_warning('Warning on Server 1', 2, 1, 2, 5),
         }
         local ns_2_diags = {
-          make_warning("Warning 1", 2, 1, 2, 5),
+          _G.make_warning('Warning 1', 2, 1, 2, 5),
         }
         local other_buffer_diags = {
-          make_info("This is interesting", 0, 0, 0, 0)
+          _G.make_info('This is interesting', 0, 0, 0, 0),
         }
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, ns_1_diags)
-        vim.diagnostic.set(other_ns, diagnostic_bufnr, ns_2_diags)
-        vim.diagnostic.set(diagnostic_ns, other_bufnr, other_buffer_diags)
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, ns_1_diags)
+        vim.diagnostic.set(_G.other_ns, _G.diagnostic_bufnr, ns_2_diags)
+        vim.diagnostic.set(_G.diagnostic_ns, other_bufnr, other_buffer_diags)
 
         -- All buffers and namespaces
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns) +
-                             count_extmarks(other_bufnr, diagnostic_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+            + _G.count_extmarks(other_bufnr, _G.diagnostic_ns)
+        )
 
         -- Hide one namespace
-        vim.diagnostic.hide(diagnostic_ns)
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns) +
-                             count_extmarks(other_bufnr, diagnostic_ns))
+        vim.diagnostic.hide(_G.diagnostic_ns)
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+            + _G.count_extmarks(other_bufnr, _G.diagnostic_ns)
+        )
 
         -- Show one namespace
-        vim.diagnostic.show(diagnostic_ns)
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns) +
-                             count_extmarks(other_bufnr, diagnostic_ns))
+        vim.diagnostic.show(_G.diagnostic_ns)
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+            + _G.count_extmarks(other_bufnr, _G.diagnostic_ns)
+        )
 
         -- Hide one buffer
         vim.diagnostic.hide(nil, other_bufnr)
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns) +
-                             count_extmarks(other_bufnr, diagnostic_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+            + _G.count_extmarks(other_bufnr, _G.diagnostic_ns)
+        )
 
         -- Hide everything
         vim.diagnostic.hide()
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns) +
-                             count_extmarks(other_bufnr, diagnostic_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+            + _G.count_extmarks(other_bufnr, _G.diagnostic_ns)
+        )
 
         -- Show one buffer
-        vim.diagnostic.show(nil, diagnostic_bufnr)
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns) +
-                             count_extmarks(other_bufnr, diagnostic_ns))
+        vim.diagnostic.show(nil, _G.diagnostic_bufnr)
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+            + _G.count_extmarks(other_bufnr, _G.diagnostic_ns)
+        )
 
         return result
-      ]]
+      end)
 
       eq(4, result[1])
       eq(1, result[2])
@@ -468,13 +558,17 @@ describe('vim.diagnostic', function()
     end)
 
     it("doesn't error after bwipeout on buffer", function()
-      exec_lua [[
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {{ lnum = 0, end_lnum = 0, col = 0, end_col = 0 }})
-        vim.cmd("bwipeout! " .. diagnostic_bufnr)
+      exec_lua(function()
+        vim.diagnostic.set(
+          _G.diagnostic_ns,
+          _G.diagnostic_bufnr,
+          { { lnum = 0, end_lnum = 0, col = 0, end_col = 0 } }
+        )
+        vim.cmd('bwipeout! ' .. _G.diagnostic_bufnr)
 
-        vim.diagnostic.show(diagnostic_ns)
-        vim.diagnostic.hide(diagnostic_ns)
-      ]]
+        vim.diagnostic.show(_G.diagnostic_ns)
+        vim.diagnostic.hide(_G.diagnostic_ns)
+      end)
     end)
   end)
 
@@ -505,52 +599,64 @@ describe('vim.diagnostic', function()
     end)
 
     it('without arguments', function()
-      local result = exec_lua [[
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
+      local result = exec_lua(function()
+        vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
 
         local result = {}
 
         vim.diagnostic.config({ underline = false, virtual_text = true })
 
         local ns_1_diags = {
-          make_error("Error 1", 1, 1, 1, 5),
-          make_warning("Warning on Server 1", 2, 1, 2, 5),
+          _G.make_error('Error 1', 1, 1, 1, 5),
+          _G.make_warning('Warning on Server 1', 2, 1, 2, 5),
         }
         local ns_2_diags = {
-          make_warning("Warning 1", 2, 1, 2, 5),
+          _G.make_warning('Warning 1', 2, 1, 2, 5),
         }
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, ns_1_diags)
-        vim.diagnostic.set(other_ns, diagnostic_bufnr, ns_2_diags)
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, ns_1_diags)
+        vim.diagnostic.set(_G.other_ns, _G.diagnostic_bufnr, ns_2_diags)
 
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+        )
 
         vim.diagnostic.enable(false)
 
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+        )
 
         -- Create a new buffer
         local other_bufnr = vim.api.nvim_create_buf(true, false)
         local other_buffer_diags = {
-          make_info("This is interesting", 0, 0, 0, 0)
+          _G.make_info('This is interesting', 0, 0, 0, 0),
         }
 
-        vim.diagnostic.set(diagnostic_ns, other_bufnr, other_buffer_diags)
+        vim.diagnostic.set(_G.diagnostic_ns, other_bufnr, other_buffer_diags)
 
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns) +
-                             count_extmarks(other_bufnr, diagnostic_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+            + _G.count_extmarks(other_bufnr, _G.diagnostic_ns)
+        )
 
         vim.diagnostic.enable()
 
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns) +
-                             count_extmarks(other_bufnr, diagnostic_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+            + _G.count_extmarks(other_bufnr, _G.diagnostic_ns)
+        )
 
         return result
-      ]]
+      end)
 
       eq(3, result[1])
       eq(0, result[2])
@@ -559,54 +665,66 @@ describe('vim.diagnostic', function()
     end)
 
     it('with buffer argument', function()
-      local result = exec_lua [[
+      local result = exec_lua(function()
         local other_bufnr = vim.api.nvim_create_buf(true, false)
 
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
+        vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
 
         local result = {}
 
         vim.diagnostic.config({ underline = false, virtual_text = true })
 
         local ns_1_diags = {
-          make_error("Error 1", 1, 1, 1, 5),
-          make_warning("Warning on Server 1", 2, 1, 2, 5),
+          _G.make_error('Error 1', 1, 1, 1, 5),
+          _G.make_warning('Warning on Server 1', 2, 1, 2, 5),
         }
         local ns_2_diags = {
-          make_warning("Warning 1", 2, 1, 2, 5),
+          _G.make_warning('Warning 1', 2, 1, 2, 5),
         }
         local other_buffer_diags = {
-          make_info("This is interesting", 0, 0, 0, 0)
+          _G.make_info('This is interesting', 0, 0, 0, 0),
         }
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, ns_1_diags)
-        vim.diagnostic.set(other_ns, diagnostic_bufnr, ns_2_diags)
-        vim.diagnostic.set(diagnostic_ns, other_bufnr, other_buffer_diags)
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, ns_1_diags)
+        vim.diagnostic.set(_G.other_ns, _G.diagnostic_bufnr, ns_2_diags)
+        vim.diagnostic.set(_G.diagnostic_ns, other_bufnr, other_buffer_diags)
 
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns) +
-                             count_extmarks(other_bufnr, diagnostic_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+            + _G.count_extmarks(other_bufnr, _G.diagnostic_ns)
+        )
 
-        vim.diagnostic.enable(false, { bufnr = diagnostic_bufnr })
+        vim.diagnostic.enable(false, { bufnr = _G.diagnostic_bufnr })
 
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns) +
-                             count_extmarks(other_bufnr, diagnostic_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+            + _G.count_extmarks(other_bufnr, _G.diagnostic_ns)
+        )
 
-        vim.diagnostic.enable(true, { bufnr = diagnostic_bufnr })
+        vim.diagnostic.enable(true, { bufnr = _G.diagnostic_bufnr })
 
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns) +
-                             count_extmarks(other_bufnr, diagnostic_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+            + _G.count_extmarks(other_bufnr, _G.diagnostic_ns)
+        )
 
         vim.diagnostic.enable(false, { bufnr = other_bufnr })
 
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns) +
-                             count_extmarks(other_bufnr, diagnostic_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+            + _G.count_extmarks(other_bufnr, _G.diagnostic_ns)
+        )
 
         return result
-      ]]
+      end)
 
       eq(4, result[1])
       eq(1, result[2])
@@ -615,44 +733,56 @@ describe('vim.diagnostic', function()
     end)
 
     it('with a namespace argument', function()
-      local result = exec_lua [[
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
+      local result = exec_lua(function()
+        vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
 
         local result = {}
 
         vim.diagnostic.config({ underline = false, virtual_text = true })
 
         local ns_1_diags = {
-          make_error("Error 1", 1, 1, 1, 5),
-          make_warning("Warning on Server 1", 2, 1, 2, 5),
+          _G.make_error('Error 1', 1, 1, 1, 5),
+          _G.make_warning('Warning on Server 1', 2, 1, 2, 5),
         }
         local ns_2_diags = {
-          make_warning("Warning 1", 2, 1, 2, 5),
+          _G.make_warning('Warning 1', 2, 1, 2, 5),
         }
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, ns_1_diags)
-        vim.diagnostic.set(other_ns, diagnostic_bufnr, ns_2_diags)
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, ns_1_diags)
+        vim.diagnostic.set(_G.other_ns, _G.diagnostic_bufnr, ns_2_diags)
 
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+        )
 
-        vim.diagnostic.enable(false, { ns_id = diagnostic_ns })
+        vim.diagnostic.enable(false, { ns_id = _G.diagnostic_ns })
 
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+        )
 
-        vim.diagnostic.enable(true, { ns_id = diagnostic_ns })
+        vim.diagnostic.enable(true, { ns_id = _G.diagnostic_ns })
 
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+        )
 
-        vim.diagnostic.enable(false, { ns_id = other_ns })
+        vim.diagnostic.enable(false, { ns_id = _G.other_ns })
 
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+        )
 
         return result
-      ]]
+      end)
 
       eq(3, result[1])
       eq(1, result[2])
@@ -662,82 +792,93 @@ describe('vim.diagnostic', function()
 
     --- @return table
     local function test_enable(legacy)
-      local result = exec_lua(
-        [[
-        local legacy = ...
+      local result = exec_lua(function(legacy0)
         local other_bufnr = vim.api.nvim_create_buf(true, false)
 
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
+        vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
 
         local result = {}
 
         vim.diagnostic.config({ underline = false, virtual_text = true })
 
         local ns_1_diags = {
-          make_error("Error 1", 1, 1, 1, 5),
-          make_warning("Warning on Server 1", 2, 1, 2, 5),
+          _G.make_error('Error 1', 1, 1, 1, 5),
+          _G.make_warning('Warning on Server 1', 2, 1, 2, 5),
         }
         local ns_2_diags = {
-          make_warning("Warning 1", 2, 1, 2, 5),
+          _G.make_warning('Warning 1', 2, 1, 2, 5),
         }
         local other_buffer_diags = {
-          make_info("This is interesting", 0, 0, 0, 0)
+          _G.make_info('This is interesting', 0, 0, 0, 0),
         }
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, ns_1_diags)
-        vim.diagnostic.set(other_ns, diagnostic_bufnr, ns_2_diags)
-        vim.diagnostic.set(diagnostic_ns, other_bufnr, other_buffer_diags)
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, ns_1_diags)
+        vim.diagnostic.set(_G.other_ns, _G.diagnostic_bufnr, ns_2_diags)
+        vim.diagnostic.set(_G.diagnostic_ns, other_bufnr, other_buffer_diags)
 
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns) +
-                             count_extmarks(other_bufnr, diagnostic_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+            + _G.count_extmarks(other_bufnr, _G.diagnostic_ns)
+        )
 
-        if legacy then
-          vim.diagnostic.disable(diagnostic_bufnr, diagnostic_ns)
+        if legacy0 then
+          vim.diagnostic.disable(_G.diagnostic_bufnr, _G.diagnostic_ns)
         else
-          vim.diagnostic.enable(false, { bufnr = diagnostic_bufnr, ns_id = diagnostic_ns })
+          vim.diagnostic.enable(false, { bufnr = _G.diagnostic_bufnr, ns_id = _G.diagnostic_ns })
         end
 
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns) +
-                             count_extmarks(other_bufnr, diagnostic_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+            + _G.count_extmarks(other_bufnr, _G.diagnostic_ns)
+        )
 
-        if legacy then
-          vim.diagnostic.disable(diagnostic_bufnr, other_ns)
+        if legacy0 then
+          vim.diagnostic.disable(_G.diagnostic_bufnr, _G.other_ns)
         else
-          vim.diagnostic.enable(false, { bufnr = diagnostic_bufnr, ns_id = other_ns })
+          vim.diagnostic.enable(false, { bufnr = _G.diagnostic_bufnr, ns_id = _G.other_ns })
         end
 
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns) +
-                             count_extmarks(other_bufnr, diagnostic_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+            + _G.count_extmarks(other_bufnr, _G.diagnostic_ns)
+        )
 
-        if legacy then
-          vim.diagnostic.enable(diagnostic_bufnr, diagnostic_ns)
+        if legacy0 then
+          vim.diagnostic.enable(_G.diagnostic_bufnr, _G.diagnostic_ns)
         else
-          vim.diagnostic.enable(true, { bufnr = diagnostic_bufnr, ns_id = diagnostic_ns })
+          vim.diagnostic.enable(true, { bufnr = _G.diagnostic_bufnr, ns_id = _G.diagnostic_ns })
         end
 
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns) +
-                             count_extmarks(other_bufnr, diagnostic_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+            + _G.count_extmarks(other_bufnr, _G.diagnostic_ns)
+        )
 
-        if legacy then
+        if legacy0 then
           -- Should have no effect
-          vim.diagnostic.disable(other_bufnr, other_ns)
+          vim.diagnostic.disable(other_bufnr, _G.other_ns)
         else
           -- Should have no effect
-          vim.diagnostic.enable(false, { bufnr = other_bufnr, ns_id = other_ns })
+          vim.diagnostic.enable(false, { bufnr = other_bufnr, ns_id = _G.other_ns })
         end
 
-        table.insert(result, count_extmarks(diagnostic_bufnr, diagnostic_ns) +
-                             count_extmarks(diagnostic_bufnr, other_ns) +
-                             count_extmarks(other_bufnr, diagnostic_ns))
+        table.insert(
+          result,
+          _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+            + _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns)
+            + _G.count_extmarks(other_bufnr, _G.diagnostic_ns)
+        )
 
         return result
-      ]],
-        legacy
-      )
+      end, legacy)
 
       return result
     end
@@ -772,74 +913,94 @@ describe('vim.diagnostic', function()
       local all_highlights = { 1, 1, 2, 4, 2 }
       eq(
         all_highlights,
-        exec_lua [[
-        local ns_1_diags = {
-          make_error("Error 1", 1, 1, 1, 5),
-          make_warning("Warning on Server 1", 2, 1, 2, 3),
-        }
-        local ns_2_diags = {
-          make_warning("Warning 1", 2, 1, 2, 3),
-        }
+        exec_lua(function()
+          local ns_1_diags = {
+            _G.make_error('Error 1', 1, 1, 1, 5),
+            _G.make_warning('Warning on Server 1', 2, 1, 2, 3),
+          }
+          local ns_2_diags = {
+            _G.make_warning('Warning 1', 2, 1, 2, 3),
+          }
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, ns_1_diags)
-        vim.diagnostic.set(other_ns, diagnostic_bufnr, ns_2_diags)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, ns_1_diags)
+          vim.diagnostic.set(_G.other_ns, _G.diagnostic_bufnr, ns_2_diags)
 
-        return {
-          count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns),
-          count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.WARN, other_ns),
-          count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.WARN),
-          count_extmarks(diagnostic_bufnr, diagnostic_ns),
-          count_extmarks(diagnostic_bufnr, other_ns),
-        }
-      ]]
+          return {
+            _G.count_diagnostics(
+              _G.diagnostic_bufnr,
+              vim.diagnostic.severity.ERROR,
+              _G.diagnostic_ns
+            ),
+            _G.count_diagnostics(_G.diagnostic_bufnr, vim.diagnostic.severity.WARN, _G.other_ns),
+            _G.count_diagnostics(_G.diagnostic_bufnr, vim.diagnostic.severity.WARN),
+            _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns),
+            _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns),
+          }
+        end)
       )
 
       -- Reset diagnostics from namespace 1
-      exec_lua([[ vim.diagnostic.reset(diagnostic_ns) ]])
+      exec_lua([[ vim.diagnostic.reset( _G.diagnostic_ns) ]])
 
       -- Make sure we have the right diagnostic count
       eq(
         { 0, 1, 1, 0, 2 },
-        exec_lua [[
-        local diagnostic_count = {}
-        vim.wait(100, function () diagnostic_count = {
-          count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns),
-          count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.WARN, other_ns),
-          count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.WARN),
-          count_extmarks(diagnostic_bufnr, diagnostic_ns),
-          count_extmarks(diagnostic_bufnr, other_ns),
-        } end )
-        return diagnostic_count
-      ]]
+        exec_lua(function()
+          local diagnostic_count = {}
+          vim.wait(100, function()
+            diagnostic_count = {
+              _G.count_diagnostics(
+                _G.diagnostic_bufnr,
+                vim.diagnostic.severity.ERROR,
+                _G.diagnostic_ns
+              ),
+              _G.count_diagnostics(_G.diagnostic_bufnr, vim.diagnostic.severity.WARN, _G.other_ns),
+              _G.count_diagnostics(_G.diagnostic_bufnr, vim.diagnostic.severity.WARN),
+              _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns),
+              _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns),
+            }
+          end)
+          return diagnostic_count
+        end)
       )
 
       -- Reset diagnostics from namespace 2
-      exec_lua([[ vim.diagnostic.reset(other_ns) ]])
+      exec_lua([[ vim.diagnostic.reset(_G.other_ns) ]])
 
       -- Make sure we have the right diagnostic count
       eq(
         { 0, 0, 0, 0, 0 },
-        exec_lua [[
-        local diagnostic_count = {}
-        vim.wait(100, function () diagnostic_count = {
-          count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns),
-          count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.WARN, other_ns),
-          count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.WARN),
-          count_extmarks(diagnostic_bufnr, diagnostic_ns),
-          count_extmarks(diagnostic_bufnr, other_ns),
-        } end )
-        return diagnostic_count
-      ]]
+        exec_lua(function()
+          local diagnostic_count = {}
+          vim.wait(100, function()
+            diagnostic_count = {
+              _G.count_diagnostics(
+                _G.diagnostic_bufnr,
+                vim.diagnostic.severity.ERROR,
+                _G.diagnostic_ns
+              ),
+              _G.count_diagnostics(_G.diagnostic_bufnr, vim.diagnostic.severity.WARN, _G.other_ns),
+              _G.count_diagnostics(_G.diagnostic_bufnr, vim.diagnostic.severity.WARN),
+              _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns),
+              _G.count_extmarks(_G.diagnostic_bufnr, _G.other_ns),
+            }
+          end)
+          return diagnostic_count
+        end)
       )
     end)
 
     it("doesn't error after bwipeout called on buffer", function()
-      exec_lua [[
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {{ lnum = 0, end_lnum = 0, col = 0, end_col = 0 }})
-        vim.cmd("bwipeout! " .. diagnostic_bufnr)
+      exec_lua(function()
+        vim.diagnostic.set(
+          _G.diagnostic_ns,
+          _G.diagnostic_bufnr,
+          { { lnum = 0, end_lnum = 0, col = 0, end_col = 0 } }
+        )
+        vim.cmd('bwipeout! ' .. _G.diagnostic_bufnr)
 
-        vim.diagnostic.reset(diagnostic_ns)
-      ]]
+        vim.diagnostic.reset(_G.diagnostic_ns)
+      end)
     end)
   end)
 
@@ -847,206 +1008,206 @@ describe('vim.diagnostic', function()
     it('can find the next pos with only one namespace', function()
       eq(
         { 1, 1 },
-        exec_lua [[
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error('Diagnostic #1', 1, 1, 1, 1),
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Diagnostic #1', 1, 1, 1, 1),
           })
-          vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
           local next = vim.diagnostic.get_next()
           return { next.lnum, next.col }
-        ]]
+        end)
       )
     end)
 
     it('can find next pos with two errors', function()
       eq(
         { 4, 4 },
-        exec_lua [[
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error('Diagnostic #1', 1, 1, 1, 1),
-            make_error('Diagnostic #2', 4, 4, 4, 4),
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Diagnostic #1', 1, 1, 1, 1),
+            _G.make_error('Diagnostic #2', 4, 4, 4, 4),
           })
-          vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-          vim.api.nvim_win_set_cursor(0, {3, 1})
-          local next = vim.diagnostic.get_next({ namespace = diagnostic_ns })
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.api.nvim_win_set_cursor(0, { 3, 1 })
+          local next = vim.diagnostic.get_next({ namespace = _G.diagnostic_ns })
           return { next.lnum, next.col }
-        ]]
+        end)
       )
     end)
 
     it('can cycle when position is past error', function()
       eq(
         { 1, 1 },
-        exec_lua [[
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error('Diagnostic #1', 1, 1, 1, 1),
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Diagnostic #1', 1, 1, 1, 1),
           })
-          vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-          vim.api.nvim_win_set_cursor(0, {3, 1})
-          local next = vim.diagnostic.get_next({ namespace = diagnostic_ns })
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.api.nvim_win_set_cursor(0, { 3, 1 })
+          local next = vim.diagnostic.get_next({ namespace = _G.diagnostic_ns })
           return { next.lnum, next.col }
-        ]]
+        end)
       )
     end)
 
     it('will not cycle when wrap is off', function()
       eq(
         vim.NIL,
-        exec_lua [[
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error('Diagnostic #1', 1, 1, 1, 1),
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Diagnostic #1', 1, 1, 1, 1),
           })
-          vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-          vim.api.nvim_win_set_cursor(0, {3, 1})
-          local next = vim.diagnostic.get_next({ namespace = diagnostic_ns, wrap = false })
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.api.nvim_win_set_cursor(0, { 3, 1 })
+          local next = vim.diagnostic.get_next({ namespace = _G.diagnostic_ns, wrap = false })
           return next
-        ]]
+        end)
       )
     end)
 
     it('can cycle even from the last line', function()
       eq(
         { 4, 4 },
-        exec_lua [[
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error('Diagnostic #2', 4, 4, 4, 4),
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Diagnostic #2', 4, 4, 4, 4),
           })
-          vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-          vim.api.nvim_win_set_cursor(0, {vim.api.nvim_buf_line_count(0), 1})
-          local prev = vim.diagnostic.get_prev({ namespace = diagnostic_ns })
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.api.nvim_win_set_cursor(0, { vim.api.nvim_buf_line_count(0), 1 })
+          local prev = vim.diagnostic.get_prev({ namespace = _G.diagnostic_ns })
           return { prev.lnum, prev.col }
-        ]]
+        end)
       )
     end)
 
     it('works with diagnostics past the end of the line #16349', function()
       eq(
         { 4, 0 },
-        exec_lua [[
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error('Diagnostic #1', 3, 9001, 3, 9001),
-            make_error('Diagnostic #2', 4, 0, 4, 0),
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Diagnostic #1', 3, 9001, 3, 9001),
+            _G.make_error('Diagnostic #2', 4, 0, 4, 0),
           })
-          vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-          vim.api.nvim_win_set_cursor(0, {1, 1})
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.api.nvim_win_set_cursor(0, { 1, 1 })
           vim.diagnostic.jump({ count = 1, float = false })
-          local next = vim.diagnostic.get_next({ namespace = diagnostic_ns })
+          local next = vim.diagnostic.get_next({ namespace = _G.diagnostic_ns })
           return { next.lnum, next.col }
-        ]]
+        end)
       )
     end)
 
     it('works with diagnostics before the start of the line', function()
       eq(
         { 4, 0 },
-        exec_lua [[
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-              make_error('Diagnostic #1', 3, 9001, 3, 9001),
-              make_error('Diagnostic #2', 4, -1, 4, -1),
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Diagnostic #1', 3, 9001, 3, 9001),
+            _G.make_error('Diagnostic #2', 4, -1, 4, -1),
           })
-          vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-          vim.api.nvim_win_set_cursor(0, {1, 1})
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.api.nvim_win_set_cursor(0, { 1, 1 })
           vim.diagnostic.jump({ count = 1, float = false })
-          local next = vim.diagnostic.get_next({ namespace = diagnostic_ns })
+          local next = vim.diagnostic.get_next({ namespace = _G.diagnostic_ns })
           return { next.lnum, next.col }
-        ]]
+        end)
       )
     end)
 
     it('jumps to diagnostic with highest severity', function()
-      exec_lua([[
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_info('Info', 1, 0, 1, 1),
-          make_error('Error', 2, 0, 2, 1),
-          make_warning('Warning', 3, 0, 3, 1),
-          make_error('Error', 4, 0, 4, 1),
+      exec_lua(function()
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_info('Info', 1, 0, 1, 1),
+          _G.make_error('Error', 2, 0, 2, 1),
+          _G.make_warning('Warning', 3, 0, 3, 1),
+          _G.make_error('Error', 4, 0, 4, 1),
         })
 
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.api.nvim_win_set_cursor(0, {1, 0})
-      ]])
+        vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      end)
 
       eq(
         { 3, 0 },
-        exec_lua([[
-        vim.diagnostic.jump({ count = 1, _highest = true })
-        return vim.api.nvim_win_get_cursor(0)
-      ]])
+        exec_lua(function()
+          vim.diagnostic.jump({ count = 1, _highest = true })
+          return vim.api.nvim_win_get_cursor(0)
+        end)
       )
 
       eq(
         { 5, 0 },
-        exec_lua([[
-        vim.diagnostic.jump({ count = 1, _highest = true })
-        return vim.api.nvim_win_get_cursor(0)
-      ]])
+        exec_lua(function()
+          vim.diagnostic.jump({ count = 1, _highest = true })
+          return vim.api.nvim_win_get_cursor(0)
+        end)
       )
 
-      exec_lua([[
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_info('Info', 1, 0, 1, 1),
-          make_hint('Hint', 2, 0, 2, 1),
-          make_warning('Warning', 3, 0, 3, 1),
-          make_hint('Hint', 4, 0, 4, 1),
-          make_warning('Warning', 5, 0, 5, 1),
+      exec_lua(function()
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_info('Info', 1, 0, 1, 1),
+          _G.make_hint('Hint', 2, 0, 2, 1),
+          _G.make_warning('Warning', 3, 0, 3, 1),
+          _G.make_hint('Hint', 4, 0, 4, 1),
+          _G.make_warning('Warning', 5, 0, 5, 1),
         })
 
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.api.nvim_win_set_cursor(0, {1, 0})
-      ]])
+        vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      end)
 
       eq(
         { 4, 0 },
-        exec_lua([[
-        vim.diagnostic.jump({ count = 1, _highest = true })
-        return vim.api.nvim_win_get_cursor(0)
-      ]])
+        exec_lua(function()
+          vim.diagnostic.jump({ count = 1, _highest = true })
+          return vim.api.nvim_win_get_cursor(0)
+        end)
       )
 
       eq(
         { 6, 0 },
-        exec_lua([[
-        vim.diagnostic.jump({ count = 1, _highest = true })
-        return vim.api.nvim_win_get_cursor(0)
-      ]])
+        exec_lua(function()
+          vim.diagnostic.jump({ count = 1, _highest = true })
+          return vim.api.nvim_win_get_cursor(0)
+        end)
       )
     end)
 
     it('jumps to next diagnostic if severity is non-nil', function()
-      exec_lua([[
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_info('Info', 1, 0, 1, 1),
-          make_error('Error', 2, 0, 2, 1),
-          make_warning('Warning', 3, 0, 3, 1),
-          make_error('Error', 4, 0, 4, 1),
+      exec_lua(function()
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_info('Info', 1, 0, 1, 1),
+          _G.make_error('Error', 2, 0, 2, 1),
+          _G.make_warning('Warning', 3, 0, 3, 1),
+          _G.make_error('Error', 4, 0, 4, 1),
         })
 
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.api.nvim_win_set_cursor(0, {1, 0})
-      ]])
+        vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
+      end)
 
       eq(
         { 2, 0 },
-        exec_lua([[
-        vim.diagnostic.jump({ count = 1 })
-        return vim.api.nvim_win_get_cursor(0)
-      ]])
+        exec_lua(function()
+          vim.diagnostic.jump({ count = 1 })
+          return vim.api.nvim_win_get_cursor(0)
+        end)
       )
 
       eq(
         { 3, 0 },
-        exec_lua([[
-        vim.diagnostic.jump({ count = 1 })
-        return vim.api.nvim_win_get_cursor(0)
-      ]])
+        exec_lua(function()
+          vim.diagnostic.jump({ count = 1 })
+          return vim.api.nvim_win_get_cursor(0)
+        end)
       )
 
       eq(
         { 4, 0 },
-        exec_lua([[
-        vim.diagnostic.jump({ count = 1 })
-        return vim.api.nvim_win_get_cursor(0)
-      ]])
+        exec_lua(function()
+          vim.diagnostic.jump({ count = 1 })
+          return vim.api.nvim_win_get_cursor(0)
+        end)
       )
     end)
   end)
@@ -1055,282 +1216,297 @@ describe('vim.diagnostic', function()
     it('can find the previous diagnostic with only one namespace', function()
       eq(
         { 1, 1 },
-        exec_lua [[
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error('Diagnostic #1', 1, 1, 1, 1),
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Diagnostic #1', 1, 1, 1, 1),
           })
-          vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-          vim.api.nvim_win_set_cursor(0, {3, 1})
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.api.nvim_win_set_cursor(0, { 3, 1 })
           local prev = vim.diagnostic.get_prev()
           return { prev.lnum, prev.col }
-        ]]
+        end)
       )
     end)
 
     it('can find the previous diagnostic with two errors', function()
       eq(
         { 1, 1 },
-        exec_lua [[
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error('Diagnostic #1', 1, 1, 1, 1),
-            make_error('Diagnostic #2', 4, 4, 4, 4),
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Diagnostic #1', 1, 1, 1, 1),
+            _G.make_error('Diagnostic #2', 4, 4, 4, 4),
           })
-          vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-          vim.api.nvim_win_set_cursor(0, {3, 1})
-          local prev = vim.diagnostic.get_prev({ namespace = diagnostic_ns })
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.api.nvim_win_set_cursor(0, { 3, 1 })
+          local prev = vim.diagnostic.get_prev({ namespace = _G.diagnostic_ns })
           return { prev.lnum, prev.col }
-        ]]
+        end)
       )
     end)
 
     it('can cycle when position is past error', function()
       eq(
         { 4, 4 },
-        exec_lua [[
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error('Diagnostic #2', 4, 4, 4, 4),
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Diagnostic #2', 4, 4, 4, 4),
           })
-          vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-          vim.api.nvim_win_set_cursor(0, {3, 1})
-          local prev = vim.diagnostic.get_prev({ namespace = diagnostic_ns })
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.api.nvim_win_set_cursor(0, { 3, 1 })
+          local prev = vim.diagnostic.get_prev({ namespace = _G.diagnostic_ns })
           return { prev.lnum, prev.col }
-        ]]
+        end)
       )
     end)
 
     it('respects wrap parameter', function()
       eq(
         vim.NIL,
-        exec_lua [[
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error('Diagnostic #2', 4, 4, 4, 4),
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Diagnostic #2', 4, 4, 4, 4),
           })
-          vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-          vim.api.nvim_win_set_cursor(0, {3, 1})
-          local prev = vim.diagnostic.get_prev({ namespace = diagnostic_ns, wrap = false })
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.api.nvim_win_set_cursor(0, { 3, 1 })
+          local prev = vim.diagnostic.get_prev({ namespace = _G.diagnostic_ns, wrap = false })
           return prev
-        ]]
+        end)
       )
     end)
 
     it('works on blank line #28397', function()
       eq(
         { 0, 2 },
-        exec_lua [[
-        local test_bufnr = vim.api.nvim_create_buf(true, false)
-        vim.api.nvim_buf_set_lines(test_bufnr, 0, -1, false, {
-          'first line',
-          '',
-          '',
-          'end line',
-        })
-        vim.diagnostic.set(diagnostic_ns, test_bufnr, {
-          make_info('Diagnostic #1', 0, 2, 0, 2),
-          make_info('Diagnostic #2', 2, 0, 2, 0),
-          make_info('Diagnostic #3', 2, 0, 2, 0),
-        })
-        vim.api.nvim_win_set_buf(0, test_bufnr)
-        vim.api.nvim_win_set_cursor(0, {3, 0})
-        return vim.diagnostic.get_prev_pos { namespace = diagnostic_ns}
-      ]]
+        exec_lua(function()
+          local test_bufnr = vim.api.nvim_create_buf(true, false)
+          vim.api.nvim_buf_set_lines(test_bufnr, 0, -1, false, {
+            'first line',
+            '',
+            '',
+            'end line',
+          })
+          vim.diagnostic.set(_G.diagnostic_ns, test_bufnr, {
+            _G.make_info('Diagnostic #1', 0, 2, 0, 2),
+            _G.make_info('Diagnostic #2', 2, 0, 2, 0),
+            _G.make_info('Diagnostic #3', 2, 0, 2, 0),
+          })
+          vim.api.nvim_win_set_buf(0, test_bufnr)
+          vim.api.nvim_win_set_cursor(0, { 3, 0 })
+          return vim.diagnostic.get_prev_pos { namespace = _G.diagnostic_ns }
+        end)
       )
     end)
   end)
 
   describe('jump()', function()
     before_each(function()
-      exec_lua([[
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error('Diagnostic #1', 0, 0, 0, 2),
-            make_error('Diagnostic #2', 1, 1, 1, 4),
-            make_warning('Diagnostic #3', 2, -1, 2, -1),
-            make_info('Diagnostic #4', 3, 0, 3, 3),
+      exec_lua(function()
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Diagnostic #1', 0, 0, 0, 2),
+          _G.make_error('Diagnostic #2', 1, 1, 1, 4),
+          _G.make_warning('Diagnostic #3', 2, -1, 2, -1),
+          _G.make_info('Diagnostic #4', 3, 0, 3, 3),
         })
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-      ]])
+        vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+      end)
     end)
 
     it('can move forward', function()
       eq(
         { 2, 1 },
-        exec_lua([[
-        vim.api.nvim_win_set_cursor(0, { 1, 0 })
-        vim.diagnostic.jump({ count = 1 })
-        return vim.api.nvim_win_get_cursor(0)
-      ]])
+        exec_lua(function()
+          vim.api.nvim_win_set_cursor(0, { 1, 0 })
+          vim.diagnostic.jump({ count = 1 })
+          return vim.api.nvim_win_get_cursor(0)
+        end)
       )
 
       eq(
         { 4, 0 },
-        exec_lua([[
-        vim.api.nvim_win_set_cursor(0, { 1, 0 })
-        vim.diagnostic.jump({ count = 3 })
-        return vim.api.nvim_win_get_cursor(0)
-      ]])
+        exec_lua(function()
+          vim.api.nvim_win_set_cursor(0, { 1, 0 })
+          vim.diagnostic.jump({ count = 3 })
+          return vim.api.nvim_win_get_cursor(0)
+        end)
       )
 
       eq(
         { 4, 0 },
-        exec_lua([[
-        vim.api.nvim_win_set_cursor(0, { 1, 0 })
-        vim.diagnostic.jump({ count = math.huge, wrap = false })
-        return vim.api.nvim_win_get_cursor(0)
-      ]])
+        exec_lua(function()
+          vim.api.nvim_win_set_cursor(0, { 1, 0 })
+          vim.diagnostic.jump({ count = math.huge, wrap = false })
+          return vim.api.nvim_win_get_cursor(0)
+        end)
       )
     end)
 
     it('can move backward', function()
       eq(
         { 3, 0 },
-        exec_lua([[
-        vim.api.nvim_win_set_cursor(0, { 4, 0 })
-        vim.diagnostic.jump({ count = -1 })
-        return vim.api.nvim_win_get_cursor(0)
-      ]])
+        exec_lua(function()
+          vim.api.nvim_win_set_cursor(0, { 4, 0 })
+          vim.diagnostic.jump({ count = -1 })
+          return vim.api.nvim_win_get_cursor(0)
+        end)
       )
 
       eq(
         { 1, 0 },
-        exec_lua([[
-        vim.api.nvim_win_set_cursor(0, { 4, 0 })
-        vim.diagnostic.jump({ count = -3 })
-        return vim.api.nvim_win_get_cursor(0)
-      ]])
+        exec_lua(function()
+          vim.api.nvim_win_set_cursor(0, { 4, 0 })
+          vim.diagnostic.jump({ count = -3 })
+          return vim.api.nvim_win_get_cursor(0)
+        end)
       )
 
       eq(
         { 1, 0 },
-        exec_lua([[
-        vim.api.nvim_win_set_cursor(0, { 4, 0 })
-        vim.diagnostic.jump({ count = -math.huge, wrap = false })
-        return vim.api.nvim_win_get_cursor(0)
-      ]])
+        exec_lua(function()
+          vim.api.nvim_win_set_cursor(0, { 4, 0 })
+          vim.diagnostic.jump({ count = -math.huge, wrap = false })
+          return vim.api.nvim_win_get_cursor(0)
+        end)
       )
     end)
 
     it('can filter by severity', function()
       eq(
         { 3, 0 },
-        exec_lua([[
-        vim.api.nvim_win_set_cursor(0, { 1, 0 })
-        vim.diagnostic.jump({ count = 1, severity = vim.diagnostic.severity.WARN })
-        return vim.api.nvim_win_get_cursor(0)
-      ]])
+        exec_lua(function()
+          vim.api.nvim_win_set_cursor(0, { 1, 0 })
+          vim.diagnostic.jump({ count = 1, severity = vim.diagnostic.severity.WARN })
+          return vim.api.nvim_win_get_cursor(0)
+        end)
       )
 
       eq(
         { 3, 0 },
-        exec_lua([[
-        vim.api.nvim_win_set_cursor(0, { 1, 0 })
-        vim.diagnostic.jump({ count = 9999, severity = vim.diagnostic.severity.WARN })
-        return vim.api.nvim_win_get_cursor(0)
-      ]])
+        exec_lua(function()
+          vim.api.nvim_win_set_cursor(0, { 1, 0 })
+          vim.diagnostic.jump({ count = 9999, severity = vim.diagnostic.severity.WARN })
+          return vim.api.nvim_win_get_cursor(0)
+        end)
       )
     end)
 
     it('can wrap', function()
       eq(
         { 1, 0 },
-        exec_lua([[
-        vim.api.nvim_win_set_cursor(0, { 4, 0 })
-        vim.diagnostic.jump({ count = 1, wrap = true })
-        return vim.api.nvim_win_get_cursor(0)
-      ]])
+        exec_lua(function()
+          vim.api.nvim_win_set_cursor(0, { 4, 0 })
+          vim.diagnostic.jump({ count = 1, wrap = true })
+          return vim.api.nvim_win_get_cursor(0)
+        end)
       )
 
       eq(
         { 4, 0 },
-        exec_lua([[
-        vim.api.nvim_win_set_cursor(0, { 1, 0 })
-        vim.diagnostic.jump({ count = -1, wrap = true })
-        return vim.api.nvim_win_get_cursor(0)
-      ]])
+        exec_lua(function()
+          vim.api.nvim_win_set_cursor(0, { 1, 0 })
+          vim.diagnostic.jump({ count = -1, wrap = true })
+          return vim.api.nvim_win_get_cursor(0)
+        end)
       )
     end)
   end)
 
   describe('get()', function()
     it('returns an empty table when no diagnostics are present', function()
-      eq({}, exec_lua [[return vim.diagnostic.get(diagnostic_bufnr, {namespace=diagnostic_ns})]])
+      eq(
+        {},
+        exec_lua [[return vim.diagnostic.get( _G.diagnostic_bufnr, {namespace=diagnostic_ns})]]
+      )
     end)
 
     it('returns all diagnostics when no severity is supplied', function()
       eq(
         2,
-        exec_lua [[
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error("Error 1", 1, 1, 1, 5),
-          make_warning("Warning on Server 1", 1, 1, 2, 3),
-        })
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Error 1', 1, 1, 1, 5),
+            _G.make_warning('Warning on Server 1', 1, 1, 2, 3),
+          })
 
-        return #vim.diagnostic.get(diagnostic_bufnr)
-      ]]
+          return #vim.diagnostic.get(_G.diagnostic_bufnr)
+        end)
       )
     end)
 
     it('returns only requested diagnostics when severity range is supplied', function()
       eq(
         { 2, 3, 2 },
-        exec_lua [[
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error("Error 1", 1, 1, 1, 5),
-          make_warning("Warning on Server 1", 1, 1, 2, 3),
-          make_info("Ignored information", 1, 1, 2, 3),
-          make_hint("Here's a hint", 1, 1, 2, 3),
-        })
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Error 1', 1, 1, 1, 5),
+            _G.make_warning('Warning on Server 1', 1, 1, 2, 3),
+            _G.make_info('Ignored information', 1, 1, 2, 3),
+            _G.make_hint("Here's a hint", 1, 1, 2, 3),
+          })
 
-        return {
-          #vim.diagnostic.get(diagnostic_bufnr, { severity = {min=vim.diagnostic.severity.WARN} }),
-          #vim.diagnostic.get(diagnostic_bufnr, { severity = {max=vim.diagnostic.severity.WARN} }),
-          #vim.diagnostic.get(diagnostic_bufnr, {
-            severity = {
-              min=vim.diagnostic.severity.INFO,
-              max=vim.diagnostic.severity.WARN,
-            }
-          }),
-        }
-      ]]
+          return {
+            #vim.diagnostic.get(
+              _G.diagnostic_bufnr,
+              { severity = { min = vim.diagnostic.severity.WARN } }
+            ),
+            #vim.diagnostic.get(
+              _G.diagnostic_bufnr,
+              { severity = { max = vim.diagnostic.severity.WARN } }
+            ),
+            #vim.diagnostic.get(_G.diagnostic_bufnr, {
+              severity = {
+                min = vim.diagnostic.severity.INFO,
+                max = vim.diagnostic.severity.WARN,
+              },
+            }),
+          }
+        end)
       )
     end)
 
     it('returns only requested diagnostics when severities are supplied', function()
       eq(
         { 1, 1, 2 },
-        exec_lua [[
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error("Error 1", 1, 1, 1, 5),
-          make_warning("Warning on Server 1", 1, 1, 2, 3),
-          make_info("Ignored information", 1, 1, 2, 3),
-          make_hint("Here's a hint", 1, 1, 2, 3),
-        })
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Error 1', 1, 1, 1, 5),
+            _G.make_warning('Warning on Server 1', 1, 1, 2, 3),
+            _G.make_info('Ignored information', 1, 1, 2, 3),
+            _G.make_hint("Here's a hint", 1, 1, 2, 3),
+          })
 
-        return {
-          #vim.diagnostic.get(diagnostic_bufnr, { severity = {vim.diagnostic.severity.WARN} }),
-          #vim.diagnostic.get(diagnostic_bufnr, { severity = {vim.diagnostic.severity.ERROR} }),
-          #vim.diagnostic.get(diagnostic_bufnr, {
-            severity = {
-              vim.diagnostic.severity.INFO,
-              vim.diagnostic.severity.WARN,
-            }
-          }),
-        }
-      ]]
+          return {
+            #vim.diagnostic.get(
+              _G.diagnostic_bufnr,
+              { severity = { vim.diagnostic.severity.WARN } }
+            ),
+            #vim.diagnostic.get(
+              _G.diagnostic_bufnr,
+              { severity = { vim.diagnostic.severity.ERROR } }
+            ),
+            #vim.diagnostic.get(_G.diagnostic_bufnr, {
+              severity = {
+                vim.diagnostic.severity.INFO,
+                vim.diagnostic.severity.WARN,
+              },
+            }),
+          }
+        end)
       )
     end)
 
     it('allows filtering by line', function()
       eq(
         2,
-        exec_lua [[
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error("Error 1", 1, 1, 1, 5),
-          make_warning("Warning on Server 1", 1, 1, 2, 3),
-          make_info("Ignored information", 1, 1, 2, 3),
-          make_error("Error On Other Line", 3, 1, 3, 5),
-        })
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Error 1', 1, 1, 1, 5),
+            _G.make_warning('Warning on Server 1', 1, 1, 2, 3),
+            _G.make_info('Ignored information', 1, 1, 2, 3),
+            _G.make_error('Error On Other Line', 3, 1, 3, 5),
+          })
 
-        return #vim.diagnostic.get(diagnostic_bufnr, {lnum = 2})
-      ]]
+          return #vim.diagnostic.get(_G.diagnostic_bufnr, { lnum = 2 })
+        end)
       )
     end)
   end)
@@ -1344,35 +1520,35 @@ describe('vim.diagnostic', function()
           [vim.diagnostic.severity.INFO] = 2,
           [vim.diagnostic.severity.HINT] = 1,
         }]],
-        exec_lua [[
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error("Error 1", 1, 1, 1, 2),
-            make_error("Error 2", 1, 3, 1, 4),
-            make_error("Error 3", 1, 5, 1, 6),
-            make_error("Error 4", 1, 7, 1, 8),
-            make_warning("Warning 1", 2, 1, 2, 2),
-            make_warning("Warning 2", 2, 3, 2, 4),
-            make_warning("Warning 3", 2, 5, 2, 6),
-            make_info("Info 1", 3, 1, 3, 2),
-            make_info("Info 2", 3, 3, 3, 4),
-            make_hint("Hint 1", 4, 1, 4, 2),
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Error 1', 1, 1, 1, 2),
+            _G.make_error('Error 2', 1, 3, 1, 4),
+            _G.make_error('Error 3', 1, 5, 1, 6),
+            _G.make_error('Error 4', 1, 7, 1, 8),
+            _G.make_warning('Warning 1', 2, 1, 2, 2),
+            _G.make_warning('Warning 2', 2, 3, 2, 4),
+            _G.make_warning('Warning 3', 2, 5, 2, 6),
+            _G.make_info('Info 1', 3, 1, 3, 2),
+            _G.make_info('Info 2', 3, 3, 3, 4),
+            _G.make_hint('Hint 1', 4, 1, 4, 2),
           })
-          return vim.diagnostic.count(diagnostic_bufnr)
-        ]]
+          return vim.diagnostic.count(_G.diagnostic_bufnr)
+        end)
       )
       eq(
         exec_lua [[return {
           [vim.diagnostic.severity.ERROR] = 2,
           [vim.diagnostic.severity.INFO] = 1,
         }]],
-        exec_lua [[
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error("Error 1", 1, 1, 1, 2),
-            make_error("Error 2", 1, 3, 1, 4),
-            make_info("Info 1", 3, 1, 3, 2),
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Error 1', 1, 1, 1, 2),
+            _G.make_error('Error 2', 1, 3, 1, 4),
+            _G.make_info('Info 1', 3, 1, 3, 2),
           })
-          return vim.diagnostic.count(diagnostic_bufnr)
-        ]]
+          return vim.diagnostic.count(_G.diagnostic_bufnr)
+        end)
       )
     end)
 
@@ -1383,25 +1559,31 @@ describe('vim.diagnostic', function()
           { [vim.diagnostic.severity.WARN] = 1,  [vim.diagnostic.severity.INFO] = 1, [vim.diagnostic.severity.HINT] = 1 },
           { [vim.diagnostic.severity.WARN] = 1,  [vim.diagnostic.severity.INFO] = 1 },
         }]],
-        exec_lua [[
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error("Error 1", 1, 1, 1, 5),
-            make_warning("Warning on Server 1", 1, 1, 2, 3),
-            make_info("Ignored information", 1, 1, 2, 3),
-            make_hint("Here's a hint", 1, 1, 2, 3),
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Error 1', 1, 1, 1, 5),
+            _G.make_warning('Warning on Server 1', 1, 1, 2, 3),
+            _G.make_info('Ignored information', 1, 1, 2, 3),
+            _G.make_hint("Here's a hint", 1, 1, 2, 3),
           })
 
           return {
-            vim.diagnostic.count(diagnostic_bufnr, { severity = {min=vim.diagnostic.severity.WARN} }),
-            vim.diagnostic.count(diagnostic_bufnr, { severity = {max=vim.diagnostic.severity.WARN} }),
-            vim.diagnostic.count(diagnostic_bufnr, {
+            vim.diagnostic.count(
+              _G.diagnostic_bufnr,
+              { severity = { min = vim.diagnostic.severity.WARN } }
+            ),
+            vim.diagnostic.count(
+              _G.diagnostic_bufnr,
+              { severity = { max = vim.diagnostic.severity.WARN } }
+            ),
+            vim.diagnostic.count(_G.diagnostic_bufnr, {
               severity = {
-                min=vim.diagnostic.severity.INFO,
-                max=vim.diagnostic.severity.WARN,
-              }
+                min = vim.diagnostic.severity.INFO,
+                max = vim.diagnostic.severity.WARN,
+              },
             }),
           }
-        ]]
+        end)
       )
     end)
 
@@ -1412,25 +1594,31 @@ describe('vim.diagnostic', function()
           { [vim.diagnostic.severity.ERROR] = 1 },
           { [vim.diagnostic.severity.WARN] = 1, [vim.diagnostic.severity.INFO] = 1 },
         }]],
-        exec_lua [[
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error("Error 1", 1, 1, 1, 5),
-            make_warning("Warning on Server 1", 1, 1, 2, 3),
-            make_info("Ignored information", 1, 1, 2, 3),
-            make_hint("Here's a hint", 1, 1, 2, 3),
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Error 1', 1, 1, 1, 5),
+            _G.make_warning('Warning on Server 1', 1, 1, 2, 3),
+            _G.make_info('Ignored information', 1, 1, 2, 3),
+            _G.make_hint("Here's a hint", 1, 1, 2, 3),
           })
 
           return {
-            vim.diagnostic.count(diagnostic_bufnr, { severity = {vim.diagnostic.severity.WARN} }),
-            vim.diagnostic.count(diagnostic_bufnr, { severity = {vim.diagnostic.severity.ERROR} }),
-            vim.diagnostic.count(diagnostic_bufnr, {
+            vim.diagnostic.count(
+              _G.diagnostic_bufnr,
+              { severity = { vim.diagnostic.severity.WARN } }
+            ),
+            vim.diagnostic.count(
+              _G.diagnostic_bufnr,
+              { severity = { vim.diagnostic.severity.ERROR } }
+            ),
+            vim.diagnostic.count(_G.diagnostic_bufnr, {
               severity = {
                 vim.diagnostic.severity.INFO,
                 vim.diagnostic.severity.WARN,
-              }
+              },
             }),
           }
-        ]]
+        end)
       )
     end)
 
@@ -1440,16 +1628,16 @@ describe('vim.diagnostic', function()
           [vim.diagnostic.severity.WARN] = 1,
           [vim.diagnostic.severity.INFO] = 1,
         }]],
-        exec_lua [[
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error("Error 1", 1, 1, 1, 5),
-            make_warning("Warning on Server 1", 1, 1, 2, 3),
-            make_info("Ignored information", 1, 1, 2, 3),
-            make_error("Error On Other Line", 3, 1, 3, 5),
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Error 1', 1, 1, 1, 5),
+            _G.make_warning('Warning on Server 1', 1, 1, 2, 3),
+            _G.make_info('Ignored information', 1, 1, 2, 3),
+            _G.make_error('Error On Other Line', 3, 1, 3, 5),
           })
 
-          return vim.diagnostic.count(diagnostic_bufnr, {lnum = 2})
-        ]]
+          return vim.diagnostic.count(_G.diagnostic_bufnr, { lnum = 2 })
+        end)
       )
     end)
   end)
@@ -1458,137 +1646,138 @@ describe('vim.diagnostic', function()
     it('works with global, namespace, and ephemeral options', function()
       eq(
         1,
-        exec_lua [[
-        vim.diagnostic.config({
-          virtual_text = false,
-        })
+        exec_lua(function()
+          vim.diagnostic.config({
+            virtual_text = false,
+          })
 
-        vim.diagnostic.config({
-          virtual_text = true,
-          underline = false,
-        }, diagnostic_ns)
+          vim.diagnostic.config({
+            virtual_text = true,
+            underline = false,
+          }, _G.diagnostic_ns)
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error('Some Error', 4, 4, 4, 4),
-        })
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Some Error', 4, 4, 4, 4),
+          })
 
-        return count_extmarks(diagnostic_bufnr, diagnostic_ns)
-      ]]
+          return _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+        end)
       )
 
       eq(
         1,
-        exec_lua [[
-        vim.diagnostic.config({
-          virtual_text = false,
-        })
+        exec_lua(function()
+          vim.diagnostic.config({
+            virtual_text = false,
+          })
 
-        vim.diagnostic.config({
-          virtual_text = false,
-          underline = false,
-        }, diagnostic_ns)
+          vim.diagnostic.config({
+            virtual_text = false,
+            underline = false,
+          }, _G.diagnostic_ns)
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error('Some Error', 4, 4, 4, 4),
-        }, {virtual_text = true})
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Some Error', 4, 4, 4, 4),
+          }, { virtual_text = true })
 
-        return count_extmarks(diagnostic_bufnr, diagnostic_ns)
-      ]]
+          return _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+        end)
       )
 
       eq(
         0,
-        exec_lua [[
-        vim.diagnostic.config({
-          virtual_text = false,
-        })
+        exec_lua(function()
+          vim.diagnostic.config({
+            virtual_text = false,
+          })
 
-        vim.diagnostic.config({
-          virtual_text = {severity=vim.diagnostic.severity.ERROR},
-          underline = false,
-        }, diagnostic_ns)
+          vim.diagnostic.config({
+            virtual_text = { severity = vim.diagnostic.severity.ERROR },
+            underline = false,
+          }, _G.diagnostic_ns)
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_warning('Some Warning', 4, 4, 4, 4),
-        }, {virtual_text = true})
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_warning('Some Warning', 4, 4, 4, 4),
+          }, { virtual_text = true })
 
-        return count_extmarks(diagnostic_bufnr, diagnostic_ns)
-      ]]
+          return _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+        end)
       )
 
       eq(
         1,
-        exec_lua [[
-        vim.diagnostic.config({
-          virtual_text = false,
-        })
+        exec_lua(function()
+          vim.diagnostic.config({
+            virtual_text = false,
+          })
 
-        vim.diagnostic.config({
-          virtual_text = {severity=vim.diagnostic.severity.ERROR},
-          underline = false,
-        }, diagnostic_ns)
+          vim.diagnostic.config({
+            virtual_text = { severity = vim.diagnostic.severity.ERROR },
+            underline = false,
+          }, _G.diagnostic_ns)
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_warning('Some Warning', 4, 4, 4, 4),
-        }, {
-          virtual_text = {} -- An empty table uses default values
-        })
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_warning('Some Warning', 4, 4, 4, 4),
+          }, {
+            virtual_text = {}, -- An empty table uses default values
+          })
 
-        return count_extmarks(diagnostic_bufnr, diagnostic_ns)
-      ]]
+          return _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+        end)
       )
     end)
 
     it('can use functions for config values', function()
-      exec_lua [[
+      exec_lua(function()
         vim.diagnostic.config({
-          virtual_text = function() return true end,
-        }, diagnostic_ns)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error('Delayed Diagnostic', 4, 4, 4, 4),
+          virtual_text = function()
+            return true
+          end,
+        }, _G.diagnostic_ns)
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Delayed Diagnostic', 4, 4, 4, 4),
         })
-      ]]
+      end)
 
       eq(
         1,
-        exec_lua [[return count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns)]]
+        exec_lua [[return _G.count_diagnostics( _G.diagnostic_bufnr, vim.diagnostic.severity.ERROR,  _G.diagnostic_ns)]]
       )
-      eq(2, exec_lua [[return count_extmarks(diagnostic_bufnr, diagnostic_ns)]])
+      eq(2, exec_lua [[return  _G.count_extmarks( _G.diagnostic_bufnr,  _G.diagnostic_ns)]])
 
       -- Now, don't enable virtual text.
       -- We should have one less extmark displayed.
-      exec_lua [[
+      exec_lua(function()
         vim.diagnostic.config({
-          virtual_text = function() return false end,
-        }, diagnostic_ns)
-      ]]
+          virtual_text = function()
+            return false
+          end,
+        }, _G.diagnostic_ns)
+      end)
 
       eq(
         1,
-        exec_lua [[return count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns)]]
+        exec_lua [[return _G.count_diagnostics( _G.diagnostic_bufnr, vim.diagnostic.severity.ERROR,  _G.diagnostic_ns)]]
       )
-      eq(1, exec_lua [[return count_extmarks(diagnostic_bufnr, diagnostic_ns)]])
+      eq(1, exec_lua [[return  _G.count_extmarks( _G.diagnostic_bufnr,  _G.diagnostic_ns)]])
     end)
 
     it('allows filtering by severity', function()
       local get_extmark_count_with_severity = function(min_severity)
-        return exec_lua(
-          [[
+        return exec_lua(function(min_severity0)
           vim.diagnostic.config({
             underline = false,
             virtual_text = {
-              severity = {min=...},
+              severity = { min = min_severity0 },
             },
           })
 
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_warning('Delayed Diagnostic', 4, 4, 4, 4),
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_warning('Delayed Diagnostic', 4, 4, 4, 4),
           })
 
-          return count_extmarks(diagnostic_bufnr, diagnostic_ns)
-        ]],
-          min_severity
-        )
+          return _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+        end, min_severity)
       end
 
       -- No messages with Error or higher
@@ -1600,152 +1789,158 @@ describe('vim.diagnostic', function()
     end)
 
     it('allows sorting by severity', function()
-      exec_lua [[
+      exec_lua(function()
         vim.diagnostic.config({
           underline = false,
           signs = true,
           virtual_text = true,
         })
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_warning('Warning', 4, 4, 4, 4),
-          make_error('Error', 4, 4, 4, 4),
-          make_info('Info', 4, 4, 4, 4),
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_warning('Warning', 4, 4, 4, 4),
+          _G.make_error('Error', 4, 4, 4, 4),
+          _G.make_info('Info', 4, 4, 4, 4),
         })
 
-        function get_virt_text_and_signs(severity_sort)
+        function _G.get_virt_text_and_signs(severity_sort)
           vim.diagnostic.config({
             severity_sort = severity_sort,
           })
 
-          local virt_text = get_virt_text_extmarks(diagnostic_ns)[1][4].virt_text
+          local virt_text = _G.get_virt_text_extmarks(_G.diagnostic_ns)[1][4].virt_text
 
           local virt_texts = {}
           for i = 2, #virt_text - 1 do
-            table.insert(virt_texts, (string.gsub(virt_text[i][2], "DiagnosticVirtualText", "")))
+            table.insert(virt_texts, (string.gsub(virt_text[i][2], 'DiagnosticVirtualText', '')))
           end
 
-          local ns = vim.diagnostic.get_namespace(diagnostic_ns)
+          local ns = vim.diagnostic.get_namespace(_G.diagnostic_ns)
           local sign_ns = ns.user_data.sign_ns
           local signs = {}
-          local all_signs = vim.api.nvim_buf_get_extmarks(diagnostic_bufnr, sign_ns, 0, -1, {type = 'sign', details = true})
+          local all_signs = vim.api.nvim_buf_get_extmarks(
+            _G.diagnostic_bufnr,
+            sign_ns,
+            0,
+            -1,
+            { type = 'sign', details = true }
+          )
           table.sort(all_signs, function(a, b)
             return a[1] > b[1]
           end)
 
           for _, v in ipairs(all_signs) do
-            local s = v[4].sign_hl_group:gsub('DiagnosticSign', "")
+            local s = v[4].sign_hl_group:gsub('DiagnosticSign', '')
             if not vim.tbl_contains(signs, s) then
               signs[#signs + 1] = s
             end
           end
 
-          return {virt_texts, signs}
+          return { virt_texts, signs }
         end
-      ]]
+      end)
 
-      local result = exec_lua [[return get_virt_text_and_signs(false)]]
+      local result = exec_lua [[return _G.get_virt_text_and_signs(false)]]
 
       -- Virt texts are defined lowest priority to highest, signs from
       -- highest to lowest
       eq({ 'Warn', 'Error', 'Info' }, result[1])
       eq({ 'Info', 'Error', 'Warn' }, result[2])
 
-      result = exec_lua [[return get_virt_text_and_signs(true)]]
+      result = exec_lua [[return _G.get_virt_text_and_signs(true)]]
       eq({ 'Info', 'Warn', 'Error' }, result[1])
       eq({ 'Error', 'Warn', 'Info' }, result[2])
 
-      result = exec_lua [[return get_virt_text_and_signs({ reverse = true })]]
+      result = exec_lua [[return _G.get_virt_text_and_signs({ reverse = true })]]
       eq({ 'Error', 'Warn', 'Info' }, result[1])
       eq({ 'Info', 'Warn', 'Error' }, result[2])
     end)
 
     it('can show diagnostic sources in virtual text', function()
-      local result = exec_lua [[
+      local result = exec_lua(function()
         local diagnostics = {
-          make_error('Some error', 0, 0, 0, 0, 'source x'),
+          _G.make_error('Some error', 0, 0, 0, 0, 'source x'),
         }
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics, {
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics, {
           underline = false,
           virtual_text = {
             prefix = '',
             source = 'always',
-          }
+          },
         })
 
-        local extmarks = get_virt_text_extmarks(diagnostic_ns)
+        local extmarks = _G.get_virt_text_extmarks(_G.diagnostic_ns)
         local virt_text = extmarks[1][4].virt_text[3][1]
         return virt_text
-      ]]
+      end)
       eq(' source x: Some error', result)
 
-      result = exec_lua [[
+      result = exec_lua(function()
         vim.diagnostic.config({
           underline = false,
           virtual_text = {
             prefix = '',
             source = 'if_many',
-          }
-        }, diagnostic_ns)
+          },
+        }, _G.diagnostic_ns)
 
-        local extmarks = get_virt_text_extmarks(diagnostic_ns)
+        local extmarks = _G.get_virt_text_extmarks(_G.diagnostic_ns)
         local virt_text = extmarks[1][4].virt_text[3][1]
         return virt_text
-      ]]
+      end)
       eq(' Some error', result)
 
-      result = exec_lua [[
+      result = exec_lua(function()
         local diagnostics = {
-          make_error('Some error', 0, 0, 0, 0, 'source x'),
-          make_error('Another error', 1, 1, 1, 1, 'source y'),
+          _G.make_error('Some error', 0, 0, 0, 0, 'source x'),
+          _G.make_error('Another error', 1, 1, 1, 1, 'source y'),
         }
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics, {
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics, {
           underline = false,
           virtual_text = {
             prefix = '',
             source = 'if_many',
-          }
+          },
         })
 
-        local extmarks = get_virt_text_extmarks(diagnostic_ns)
-        local virt_text = {extmarks[1][4].virt_text[3][1], extmarks[2][4].virt_text[3][1]}
+        local extmarks = _G.get_virt_text_extmarks(_G.diagnostic_ns)
+        local virt_text = { extmarks[1][4].virt_text[3][1], extmarks[2][4].virt_text[3][1] }
         return virt_text
-      ]]
+      end)
       eq(' source x: Some error', result[1])
       eq(' source y: Another error', result[2])
     end)
 
     it('supports a format function for diagnostic messages', function()
-      local result = exec_lua [[
+      local result = exec_lua(function()
         vim.diagnostic.config({
           underline = false,
           virtual_text = {
             prefix = '',
             format = function(diagnostic)
               if diagnostic.severity == vim.diagnostic.severity.ERROR then
-                return string.format("🔥 %s", diagnostic.message)
+                return string.format('🔥 %s', diagnostic.message)
               end
-              return string.format("👀 %s", diagnostic.message)
+              return string.format('👀 %s', diagnostic.message)
             end,
-          }
+          },
         })
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_warning('Warning', 0, 0, 0, 0),
-          make_error('Error', 1, 0, 1, 0),
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_warning('Warning', 0, 0, 0, 0),
+          _G.make_error('Error', 1, 0, 1, 0),
         })
 
-        local extmarks = get_virt_text_extmarks(diagnostic_ns)
-        return {extmarks[1][4].virt_text, extmarks[2][4].virt_text}
-      ]]
+        local extmarks = _G.get_virt_text_extmarks(_G.diagnostic_ns)
+        return { extmarks[1][4].virt_text, extmarks[2][4].virt_text }
+      end)
       eq(' 👀 Warning', result[1][3][1])
       eq(' 🔥 Error', result[2][3][1])
     end)
 
     it('includes source for formatted diagnostics', function()
-      local result = exec_lua [[
+      local result = exec_lua(function()
         vim.diagnostic.config({
           underline = false,
           virtual_text = {
@@ -1753,21 +1948,21 @@ describe('vim.diagnostic', function()
             source = 'always',
             format = function(diagnostic)
               if diagnostic.severity == vim.diagnostic.severity.ERROR then
-                return string.format("🔥 %s", diagnostic.message)
+                return string.format('🔥 %s', diagnostic.message)
               end
-              return string.format("👀 %s", diagnostic.message)
+              return string.format('👀 %s', diagnostic.message)
             end,
-          }
+          },
         })
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_warning('Warning', 0, 0, 0, 0, 'some_linter'),
-          make_error('Error', 1, 0, 1, 0, 'another_linter'),
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_warning('Warning', 0, 0, 0, 0, 'some_linter'),
+          _G.make_error('Error', 1, 0, 1, 0, 'another_linter'),
         })
 
-        local extmarks = get_virt_text_extmarks(diagnostic_ns)
-        return {extmarks[1][4].virt_text, extmarks[2][4].virt_text}
-      ]]
+        local extmarks = _G.get_virt_text_extmarks(_G.diagnostic_ns)
+        return { extmarks[1][4].virt_text, extmarks[2][4].virt_text }
+      end)
       eq(' some_linter: 👀 Warning', result[1][3][1])
       eq(' another_linter: 🔥 Error', result[2][3][1])
     end)
@@ -1775,90 +1970,94 @@ describe('vim.diagnostic', function()
     it('can add a prefix to virtual text', function()
       eq(
         'E Some error',
-        exec_lua [[
-        local diagnostics = {
-          make_error('Some error', 0, 0, 0, 0),
-        }
-
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics, {
-          underline = false,
-          virtual_text = {
-            prefix = 'E',
-            suffix = '',
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Some error', 0, 0, 0, 0),
           }
-        })
 
-        local extmarks = get_virt_text_extmarks(diagnostic_ns)
-        local prefix = extmarks[1][4].virt_text[2][1]
-        local message = extmarks[1][4].virt_text[3][1]
-        return prefix .. message
-      ]]
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics, {
+            underline = false,
+            virtual_text = {
+              prefix = 'E',
+              suffix = '',
+            },
+          })
+
+          local extmarks = _G.get_virt_text_extmarks(_G.diagnostic_ns)
+          local prefix = extmarks[1][4].virt_text[2][1]
+          local message = extmarks[1][4].virt_text[3][1]
+          return prefix .. message
+        end)
       )
 
       eq(
         '[(1/1) err-code] Some error',
-        exec_lua [[
-        local diagnostics = {
-          make_error('Some error', 0, 0, 0, 0, nil, 'err-code'),
-        }
-
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics, {
-          underline = false,
-          virtual_text = {
-            prefix = function(diag, i, total) return string.format('[(%d/%d) %s]', i, total, diag.code) end,
-            suffix = '',
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Some error', 0, 0, 0, 0, nil, 'err-code'),
           }
-        })
 
-        local extmarks = get_virt_text_extmarks(diagnostic_ns)
-        local prefix = extmarks[1][4].virt_text[2][1]
-        local message = extmarks[1][4].virt_text[3][1]
-        return prefix .. message
-      ]]
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics, {
+            underline = false,
+            virtual_text = {
+              prefix = function(diag, i, total)
+                return string.format('[(%d/%d) %s]', i, total, diag.code)
+              end,
+              suffix = '',
+            },
+          })
+
+          local extmarks = _G.get_virt_text_extmarks(_G.diagnostic_ns)
+          local prefix = extmarks[1][4].virt_text[2][1]
+          local message = extmarks[1][4].virt_text[3][1]
+          return prefix .. message
+        end)
       )
     end)
 
     it('can add a suffix to virtual text', function()
       eq(
         ' Some error ✘',
-        exec_lua [[
-        local diagnostics = {
-          make_error('Some error', 0, 0, 0, 0),
-        }
-
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics, {
-          underline = false,
-          virtual_text = {
-            prefix = '',
-            suffix = ' ✘',
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Some error', 0, 0, 0, 0),
           }
-        })
 
-        local extmarks = get_virt_text_extmarks(diagnostic_ns)
-        local virt_text = extmarks[1][4].virt_text[3][1]
-        return virt_text
-      ]]
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics, {
+            underline = false,
+            virtual_text = {
+              prefix = '',
+              suffix = ' ✘',
+            },
+          })
+
+          local extmarks = _G.get_virt_text_extmarks(_G.diagnostic_ns)
+          local virt_text = extmarks[1][4].virt_text[3][1]
+          return virt_text
+        end)
       )
 
       eq(
         ' Some error [err-code]',
-        exec_lua [[
-        local diagnostics = {
-          make_error('Some error', 0, 0, 0, 0, nil, 'err-code'),
-        }
-
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics, {
-          underline = false,
-          virtual_text = {
-            prefix = '',
-            suffix = function(diag) return string.format(' [%s]', diag.code) end,
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Some error', 0, 0, 0, 0, nil, 'err-code'),
           }
-        })
 
-        local extmarks = get_virt_text_extmarks(diagnostic_ns)
-        local virt_text = extmarks[1][4].virt_text[3][1]
-        return virt_text
-      ]]
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics, {
+            underline = false,
+            virtual_text = {
+              prefix = '',
+              suffix = function(diag)
+                return string.format(' [%s]', diag.code)
+              end,
+            },
+          })
+
+          local extmarks = _G.get_virt_text_extmarks(_G.diagnostic_ns)
+          local virt_text = extmarks[1][4].virt_text[3][1]
+          return virt_text
+        end)
       )
     end)
   end)
@@ -1872,80 +2071,80 @@ describe('vim.diagnostic', function()
     end)
 
     it('can perform updates after insert_leave', function()
-      exec_lua [[vim.api.nvim_set_current_buf(diagnostic_bufnr)]]
+      exec_lua [[vim.api.nvim_set_current_buf( _G.diagnostic_bufnr)]]
       api.nvim_input('o')
       eq({ mode = 'i', blocking = false }, api.nvim_get_mode())
 
       -- Save the diagnostics
-      exec_lua [[
+      exec_lua(function()
         vim.diagnostic.config({
           update_in_insert = false,
         })
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error('Delayed Diagnostic', 4, 4, 4, 4),
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Delayed Diagnostic', 4, 4, 4, 4),
         })
-      ]]
+      end)
 
       -- No diagnostics displayed yet.
       eq({ mode = 'i', blocking = false }, api.nvim_get_mode())
       eq(
         1,
-        exec_lua [[return count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns)]]
+        exec_lua [[return _G.count_diagnostics( _G.diagnostic_bufnr, vim.diagnostic.severity.ERROR,  _G.diagnostic_ns)]]
       )
-      eq(0, exec_lua [[return count_extmarks(diagnostic_bufnr, diagnostic_ns)]])
+      eq(0, exec_lua [[return  _G.count_extmarks( _G.diagnostic_bufnr,  _G.diagnostic_ns)]])
 
       api.nvim_input('<esc>')
       eq({ mode = 'n', blocking = false }, api.nvim_get_mode())
 
       eq(
         1,
-        exec_lua [[return count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns)]]
+        exec_lua [[return _G.count_diagnostics( _G.diagnostic_bufnr, vim.diagnostic.severity.ERROR,  _G.diagnostic_ns)]]
       )
-      eq(2, exec_lua [[return count_extmarks(diagnostic_bufnr, diagnostic_ns)]])
+      eq(2, exec_lua [[return  _G.count_extmarks( _G.diagnostic_bufnr,  _G.diagnostic_ns)]])
     end)
 
     it('does not perform updates when not needed', function()
-      exec_lua [[vim.api.nvim_set_current_buf(diagnostic_bufnr)]]
+      exec_lua [[vim.api.nvim_set_current_buf( _G.diagnostic_bufnr)]]
       api.nvim_input('o')
       eq({ mode = 'i', blocking = false }, api.nvim_get_mode())
 
       -- Save the diagnostics
-      exec_lua [[
+      exec_lua(function()
         vim.diagnostic.config({
           update_in_insert = false,
           virtual_text = true,
         })
 
-        DisplayCount = 0
+        _G.DisplayCount = 0
         local set_virtual_text = vim.diagnostic.handlers.virtual_text.show
         vim.diagnostic.handlers.virtual_text.show = function(...)
-          DisplayCount = DisplayCount + 1
+          _G.DisplayCount = _G.DisplayCount + 1
           return set_virtual_text(...)
         end
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error('Delayed Diagnostic', 4, 4, 4, 4),
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Delayed Diagnostic', 4, 4, 4, 4),
         })
-      ]]
+      end)
 
       -- No diagnostics displayed yet.
       eq({ mode = 'i', blocking = false }, api.nvim_get_mode())
       eq(
         1,
-        exec_lua [[return count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns)]]
+        exec_lua [[return _G.count_diagnostics( _G.diagnostic_bufnr, vim.diagnostic.severity.ERROR,  _G.diagnostic_ns)]]
       )
-      eq(0, exec_lua [[return count_extmarks(diagnostic_bufnr, diagnostic_ns)]])
-      eq(0, exec_lua [[return DisplayCount]])
+      eq(0, exec_lua [[return  _G.count_extmarks( _G.diagnostic_bufnr,  _G.diagnostic_ns)]])
+      eq(0, exec_lua [[return _G.DisplayCount]])
 
       api.nvim_input('<esc>')
       eq({ mode = 'n', blocking = false }, api.nvim_get_mode())
 
       eq(
         1,
-        exec_lua [[return count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns)]]
+        exec_lua [[return _G.count_diagnostics( _G.diagnostic_bufnr, vim.diagnostic.severity.ERROR,  _G.diagnostic_ns)]]
       )
-      eq(2, exec_lua [[return count_extmarks(diagnostic_bufnr, diagnostic_ns)]])
-      eq(1, exec_lua [[return DisplayCount]])
+      eq(2, exec_lua [[return  _G.count_extmarks( _G.diagnostic_bufnr,  _G.diagnostic_ns)]])
+      eq(1, exec_lua [[return _G.DisplayCount]])
 
       -- Go in and out of insert mode one more time.
       api.nvim_input('o')
@@ -1955,52 +2154,51 @@ describe('vim.diagnostic', function()
       eq({ mode = 'n', blocking = false }, api.nvim_get_mode())
 
       -- Should not have set the virtual text again.
-      eq(1, exec_lua [[return DisplayCount]])
+      eq(1, exec_lua [[return _G.DisplayCount]])
     end)
 
     it('never sets virtual text, in combination with insert leave', function()
-      exec_lua [[vim.api.nvim_set_current_buf(diagnostic_bufnr)]]
+      exec_lua [[vim.api.nvim_set_current_buf( _G.diagnostic_bufnr)]]
       api.nvim_input('o')
       eq({ mode = 'i', blocking = false }, api.nvim_get_mode())
 
       -- Save the diagnostics
-      exec_lua [[
+      exec_lua(function()
         vim.diagnostic.config({
           update_in_insert = false,
           virtual_text = false,
         })
 
-
-        DisplayCount = 0
+        _G.DisplayCount = 0
         local set_virtual_text = vim.diagnostic.handlers.virtual_text.show
         vim.diagnostic.handlers.virtual_text.show = function(...)
-          DisplayCount = DisplayCount + 1
+          _G.DisplayCount = _G.DisplayCount + 1
           return set_virtual_text(...)
         end
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error('Delayed Diagnostic', 4, 4, 4, 4),
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Delayed Diagnostic', 4, 4, 4, 4),
         })
-      ]]
+      end)
 
       -- No diagnostics displayed yet.
       eq({ mode = 'i', blocking = false }, api.nvim_get_mode())
       eq(
         1,
-        exec_lua [[return count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns)]]
+        exec_lua [[return _G.count_diagnostics( _G.diagnostic_bufnr, vim.diagnostic.severity.ERROR,  _G.diagnostic_ns)]]
       )
-      eq(0, exec_lua [[return count_extmarks(diagnostic_bufnr, diagnostic_ns)]])
-      eq(0, exec_lua [[return DisplayCount]])
+      eq(0, exec_lua [[return  _G.count_extmarks( _G.diagnostic_bufnr,  _G.diagnostic_ns)]])
+      eq(0, exec_lua [[return _G.DisplayCount]])
 
       api.nvim_input('<esc>')
       eq({ mode = 'n', blocking = false }, api.nvim_get_mode())
 
       eq(
         1,
-        exec_lua [[return count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns)]]
+        exec_lua [[return _G.count_diagnostics( _G.diagnostic_bufnr, vim.diagnostic.severity.ERROR,  _G.diagnostic_ns)]]
       )
-      eq(1, exec_lua [[return count_extmarks(diagnostic_bufnr, diagnostic_ns)]])
-      eq(0, exec_lua [[return DisplayCount]])
+      eq(1, exec_lua [[return  _G.count_extmarks( _G.diagnostic_bufnr,  _G.diagnostic_ns)]])
+      eq(0, exec_lua [[return _G.DisplayCount]])
 
       -- Go in and out of insert mode one more time.
       api.nvim_input('o')
@@ -2010,124 +2208,136 @@ describe('vim.diagnostic', function()
       eq({ mode = 'n', blocking = false }, api.nvim_get_mode())
 
       -- Should not have set the virtual text still.
-      eq(0, exec_lua [[return DisplayCount]])
+      eq(0, exec_lua [[return _G.DisplayCount]])
     end)
 
     it('can perform updates while in insert mode, if desired', function()
-      exec_lua [[vim.api.nvim_set_current_buf(diagnostic_bufnr)]]
+      exec_lua [[vim.api.nvim_set_current_buf( _G.diagnostic_bufnr)]]
       api.nvim_input('o')
       eq({ mode = 'i', blocking = false }, api.nvim_get_mode())
 
       -- Save the diagnostics
-      exec_lua [[
+      exec_lua(function()
         vim.diagnostic.config({
           update_in_insert = true,
         })
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error('Delayed Diagnostic', 4, 4, 4, 4),
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Delayed Diagnostic', 4, 4, 4, 4),
         })
-      ]]
+      end)
 
       -- Diagnostics are displayed, because the user wanted them that way!
       eq({ mode = 'i', blocking = false }, api.nvim_get_mode())
       eq(
         1,
-        exec_lua [[return count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns)]]
+        exec_lua [[return _G.count_diagnostics( _G.diagnostic_bufnr, vim.diagnostic.severity.ERROR,  _G.diagnostic_ns)]]
       )
-      eq(2, exec_lua [[return count_extmarks(diagnostic_bufnr, diagnostic_ns)]])
+      eq(2, exec_lua [[return  _G.count_extmarks( _G.diagnostic_bufnr,  _G.diagnostic_ns)]])
 
       api.nvim_input('<esc>')
       eq({ mode = 'n', blocking = false }, api.nvim_get_mode())
 
       eq(
         1,
-        exec_lua [[return count_diagnostics(diagnostic_bufnr, vim.diagnostic.severity.ERROR, diagnostic_ns)]]
+        exec_lua [[return _G.count_diagnostics( _G.diagnostic_bufnr, vim.diagnostic.severity.ERROR,  _G.diagnostic_ns)]]
       )
-      eq(2, exec_lua [[return count_extmarks(diagnostic_bufnr, diagnostic_ns)]])
+      eq(2, exec_lua [[return  _G.count_extmarks( _G.diagnostic_bufnr,  _G.diagnostic_ns)]])
     end)
 
     it('can set diagnostics without displaying them', function()
       eq(
         0,
-        exec_lua [[
-        vim.diagnostic.enable(false, { bufnr = diagnostic_bufnr, ns_id = diagnostic_ns })
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error('Diagnostic From Server 1:1', 1, 1, 1, 1),
-        })
-        return count_extmarks(diagnostic_bufnr, diagnostic_ns)
-      ]]
+        exec_lua(function()
+          vim.diagnostic.enable(false, { bufnr = _G.diagnostic_bufnr, ns_id = _G.diagnostic_ns })
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Diagnostic From Server 1:1', 1, 1, 1, 1),
+          })
+          return _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+        end)
       )
 
       eq(
         2,
-        exec_lua [[
-        vim.diagnostic.enable(true, { bufnr = diagnostic_bufnr, ns_id = diagnostic_ns })
-        return count_extmarks(diagnostic_bufnr, diagnostic_ns)
-      ]]
+        exec_lua(function()
+          vim.diagnostic.enable(true, { bufnr = _G.diagnostic_bufnr, ns_id = _G.diagnostic_ns })
+          return _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+        end)
       )
     end)
 
     it('can set display options', function()
       eq(
         0,
-        exec_lua [[
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error('Diagnostic From Server 1:1', 1, 1, 1, 1),
-        }, { virtual_text = false, underline = false })
-        return count_extmarks(diagnostic_bufnr, diagnostic_ns)
-      ]]
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Diagnostic From Server 1:1', 1, 1, 1, 1),
+          }, { virtual_text = false, underline = false })
+          return _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+        end)
       )
 
       eq(
         1,
-        exec_lua [[
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error('Diagnostic From Server 1:1', 1, 1, 1, 1),
-        }, { virtual_text = true, underline = false })
-        return count_extmarks(diagnostic_bufnr, diagnostic_ns)
-      ]]
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Diagnostic From Server 1:1', 1, 1, 1, 1),
+          }, { virtual_text = true, underline = false })
+          return _G.count_extmarks(_G.diagnostic_bufnr, _G.diagnostic_ns)
+        end)
       )
     end)
 
     it('sets and clears signs #26193 #26555', function()
       do
-        local result = exec_lua [[
+        local result = exec_lua(function()
           vim.diagnostic.config({
             signs = true,
           })
 
           local diagnostics = {
-            make_error('Error', 1, 1, 1, 2),
-            make_warning('Warning', 3, 3, 3, 3),
+            _G.make_error('Error', 1, 1, 1, 2),
+            _G.make_warning('Warning', 3, 3, 3, 3),
           }
 
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
 
-          local ns = vim.diagnostic.get_namespace(diagnostic_ns)
+          local ns = vim.diagnostic.get_namespace(_G.diagnostic_ns)
           local sign_ns = ns.user_data.sign_ns
 
-          local signs = vim.api.nvim_buf_get_extmarks(diagnostic_bufnr, sign_ns, 0, -1, {type ='sign', details = true})
+          local signs = vim.api.nvim_buf_get_extmarks(
+            _G.diagnostic_bufnr,
+            sign_ns,
+            0,
+            -1,
+            { type = 'sign', details = true }
+          )
           local result = {}
           for _, s in ipairs(signs) do
             result[#result + 1] = { lnum = s[2] + 1, name = s[4].sign_hl_group }
           end
           return result
-        ]]
+        end)
 
         eq({ 2, 'DiagnosticSignError' }, { result[1].lnum, result[1].name })
         eq({ 4, 'DiagnosticSignWarn' }, { result[2].lnum, result[2].name })
       end
 
       do
-        local result = exec_lua [[
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {})
+        local result = exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {})
 
-          local ns = vim.diagnostic.get_namespace(diagnostic_ns)
+          local ns = vim.diagnostic.get_namespace(_G.diagnostic_ns)
           local sign_ns = ns.user_data.sign_ns
 
-          return vim.api.nvim_buf_get_extmarks(diagnostic_bufnr, sign_ns, 0, -1, {type ='sign', details = true})
-        ]]
+          return vim.api.nvim_buf_get_extmarks(
+            _G.diagnostic_bufnr,
+            sign_ns,
+            0,
+            -1,
+            { type = 'sign', details = true }
+          )
+        end)
 
         eq({}, result)
       end
@@ -2142,22 +2352,28 @@ describe('vim.diagnostic', function()
       n.command('sign define DiagnosticSignInfo text= texthl= linehl=Underlined numhl=Underlined')
       n.command('sign define DiagnosticSignHint text= texthl= linehl=Underlined numhl=Underlined')
 
-      local result = exec_lua [[
+      local result = exec_lua(function()
         vim.diagnostic.config({
           signs = true,
         })
 
         local diagnostics = {
-          make_error('Error', 1, 1, 1, 2),
-          make_warning('Warning', 3, 3, 3, 3),
+          _G.make_error('Error', 1, 1, 1, 2),
+          _G.make_warning('Warning', 3, 3, 3, 3),
         }
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
 
-        local ns = vim.diagnostic.get_namespace(diagnostic_ns)
+        local ns = vim.diagnostic.get_namespace(_G.diagnostic_ns)
         local sign_ns = ns.user_data.sign_ns
 
-        local signs = vim.api.nvim_buf_get_extmarks(diagnostic_bufnr, sign_ns, 0, -1, {type ='sign', details = true})
+        local signs = vim.api.nvim_buf_get_extmarks(
+          _G.diagnostic_bufnr,
+          sign_ns,
+          0,
+          -1,
+          { type = 'sign', details = true }
+        )
         local result = {}
         for _, s in ipairs(signs) do
           result[#result + 1] = {
@@ -2169,7 +2385,7 @@ describe('vim.diagnostic', function()
           }
         end
         return result
-      ]]
+      end)
 
       eq({
         lnum = 2,
@@ -2193,65 +2409,67 @@ describe('vim.diagnostic', function()
     it('can display a header', function()
       eq(
         { 'Diagnostics:', '1. Syntax error' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float()
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          local float_bufnr, winnr = vim.diagnostic.open_float()
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       eq(
         { "We're no strangers to love...", '1. Syntax error' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float({header = "We're no strangers to love..."})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          local float_bufnr, winnr =
+            vim.diagnostic.open_float({ header = "We're no strangers to love..." })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       eq(
         { 'You know the rules', '1. Syntax error' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float({header = {'You know the rules', 'Search'}})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          local float_bufnr, winnr =
+            vim.diagnostic.open_float({ header = { 'You know the rules', 'Search' } })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
     end)
 
     it('can show diagnostics from the whole buffer', function()
       eq(
         { '1. Syntax error', '2. Some warning' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3),
-          make_warning("Some warning", 1, 1, 1, 3),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float({header = false, scope="buffer"})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3),
+            _G.make_warning('Some warning', 1, 1, 1, 3),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          local float_bufnr, winnr = vim.diagnostic.open_float({ header = false, scope = 'buffer' })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
     end)
 
@@ -2259,69 +2477,70 @@ describe('vim.diagnostic', function()
       -- Using cursor position
       eq(
         { '1. Some warning' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3),
-          make_warning("Some warning", 1, 1, 1, 3),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        vim.api.nvim_win_set_cursor(0, {2, 1})
-        local float_bufnr, winnr = vim.diagnostic.open_float({header=false})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3),
+            _G.make_warning('Some warning', 1, 1, 1, 3),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          vim.api.nvim_win_set_cursor(0, { 2, 1 })
+          local float_bufnr, winnr = vim.diagnostic.open_float({ header = false })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       -- With specified position
       eq(
         { '1. Some warning' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3),
-          make_warning("Some warning", 1, 1, 1, 3),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        vim.api.nvim_win_set_cursor(0, {1, 1})
-        local float_bufnr, winnr = vim.diagnostic.open_float({header=false, pos=1})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3),
+            _G.make_warning('Some warning', 1, 1, 1, 3),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          vim.api.nvim_win_set_cursor(0, { 1, 1 })
+          local float_bufnr, winnr = vim.diagnostic.open_float({ header = false, pos = 1 })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       -- End position is exclusive
       eq(
         vim.NIL,
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 1, 1, 2, 0),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        vim.api.nvim_win_set_cursor(0, {1, 1})
-        local _, winnr = vim.diagnostic.open_float(0, {header=false, pos={2,0}})
-        return winnr
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 1, 1, 2, 0),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          vim.api.nvim_win_set_cursor(0, { 1, 1 })
+          local _, winnr = vim.diagnostic.open_float(0, { header = false, pos = { 2, 0 } })
+          return winnr
+        end)
       )
 
       -- Works when width == 0
       eq(
         { '1. Syntax error' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 2, 0, 2, 0),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        vim.api.nvim_win_set_cursor(0, {1, 1})
-        local float_bufnr, winnr = vim.diagnostic.open_float(0, {header=false, pos={2,1}})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 2, 0, 2, 0),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          vim.api.nvim_win_set_cursor(0, { 1, 1 })
+          local float_bufnr, winnr =
+            vim.diagnostic.open_float(0, { header = false, pos = { 2, 1 } })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
     end)
 
@@ -2329,87 +2548,94 @@ describe('vim.diagnostic', function()
       -- Using cursor position
       eq(
         { 'Syntax error' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 1, 1, 1, 3),
-          make_warning("Some warning", 1, 3, 1, 4),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        vim.api.nvim_win_set_cursor(0, {2, 2})
-        local float_bufnr, winnr = vim.diagnostic.open_float({header=false, scope="cursor"})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 1, 1, 1, 3),
+            _G.make_warning('Some warning', 1, 3, 1, 4),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          vim.api.nvim_win_set_cursor(0, { 2, 2 })
+          local float_bufnr, winnr = vim.diagnostic.open_float({ header = false, scope = 'cursor' })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       -- With specified position
       eq(
         { 'Some warning' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 1, 1, 1, 3),
-          make_warning("Some warning", 1, 3, 1, 4),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        vim.api.nvim_win_set_cursor(0, {1, 1})
-        local float_bufnr, winnr = vim.diagnostic.open_float({header=false, scope="cursor", pos={1,3}})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 1, 1, 1, 3),
+            _G.make_warning('Some warning', 1, 3, 1, 4),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          vim.api.nvim_win_set_cursor(0, { 1, 1 })
+          local float_bufnr, winnr =
+            vim.diagnostic.open_float({ header = false, scope = 'cursor', pos = { 1, 3 } })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       -- With column position past the end of the line. #16062
       eq(
         { 'Syntax error' },
-        exec_lua [[
-        local first_line_len = #vim.api.nvim_buf_get_lines(diagnostic_bufnr, 0, 1, true)[1]
-        local diagnostics = {
-          make_error("Syntax error", 0, first_line_len + 1, 1, 0),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        vim.api.nvim_win_set_cursor(0, {1, 1})
-        local float_bufnr, winnr = vim.diagnostic.open_float({header=false, scope="cursor", pos={0,first_line_len}})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local first_line_len = #vim.api.nvim_buf_get_lines(_G.diagnostic_bufnr, 0, 1, true)[1]
+          local diagnostics = {
+            _G.make_error('Syntax error', 0, first_line_len + 1, 1, 0),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          vim.api.nvim_win_set_cursor(0, { 1, 1 })
+          local float_bufnr, winnr = vim.diagnostic.open_float({
+            header = false,
+            scope = 'cursor',
+            pos = { 0, first_line_len },
+          })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       -- End position is exclusive
       eq(
         vim.NIL,
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 1, 1, 1, 3),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        vim.api.nvim_win_set_cursor(0, {1, 1})
-        local _, winnr = vim.diagnostic.open_float(0, {header=false, scope="cursor", pos={1,3}})
-        return winnr
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 1, 1, 1, 3),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          vim.api.nvim_win_set_cursor(0, { 1, 1 })
+          local _, winnr =
+            vim.diagnostic.open_float(0, { header = false, scope = 'cursor', pos = { 1, 3 } })
+          return winnr
+        end)
       )
 
       -- Works when width == 0
       eq(
         { 'Syntax error' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 2, 0, 2, 0),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        vim.api.nvim_win_set_cursor(0, {1, 1})
-        local float_bufnr, winnr = vim.diagnostic.open_float({header=false, scope="cursor", pos={2,1}})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 2, 0, 2, 0),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          vim.api.nvim_win_set_cursor(0, { 1, 1 })
+          local float_bufnr, winnr =
+            vim.diagnostic.open_float({ header = false, scope = 'cursor', pos = { 2, 1 } })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
     end)
 
@@ -2421,17 +2647,17 @@ describe('vim.diagnostic', function()
         --    1. <msg>
         eq(
           2,
-          exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float(diagnostic_bufnr)
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return #lines
-      ]]
+          exec_lua(function()
+            local diagnostics = {
+              _G.make_error('Syntax error', 0, 1, 0, 3),
+            }
+            vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+            vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+            local float_bufnr, winnr = vim.diagnostic.open_float(_G.diagnostic_bufnr)
+            local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+            vim.api.nvim_win_close(winnr, true)
+            return #lines
+          end)
         )
       end
     )
@@ -2439,43 +2665,44 @@ describe('vim.diagnostic', function()
     it('only reports diagnostics from the current buffer when bufnr is omitted #15710', function()
       eq(
         2,
-        exec_lua [[
-        local other_bufnr = vim.api.nvim_create_buf(true, false)
-        local buf_1_diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3),
-        }
-        local buf_2_diagnostics = {
-          make_warning("Some warning", 0, 1, 0, 3),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, buf_1_diagnostics)
-        vim.diagnostic.set(other_ns, other_bufnr, buf_2_diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float()
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return #lines
-      ]]
+        exec_lua(function()
+          local other_bufnr = vim.api.nvim_create_buf(true, false)
+          local buf_1_diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3),
+          }
+          local buf_2_diagnostics = {
+            _G.make_warning('Some warning', 0, 1, 0, 3),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, buf_1_diagnostics)
+          vim.diagnostic.set(_G.other_ns, other_bufnr, buf_2_diagnostics)
+          local float_bufnr, winnr = vim.diagnostic.open_float()
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return #lines
+        end)
       )
     end)
 
     it('allows filtering by namespace', function()
       eq(
         2,
-        exec_lua [[
-        local ns_1_diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3),
-        }
-        local ns_2_diagnostics = {
-          make_warning("Some warning", 0, 1, 0, 3),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, ns_1_diagnostics)
-        vim.diagnostic.set(other_ns, diagnostic_bufnr, ns_2_diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float(diagnostic_bufnr, {namespace = diagnostic_ns})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return #lines
-      ]]
+        exec_lua(function()
+          local ns_1_diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3),
+          }
+          local ns_2_diagnostics = {
+            _G.make_warning('Some warning', 0, 1, 0, 3),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, ns_1_diagnostics)
+          vim.diagnostic.set(_G.other_ns, _G.diagnostic_bufnr, ns_2_diagnostics)
+          local float_bufnr, winnr =
+            vim.diagnostic.open_float(_G.diagnostic_bufnr, { namespace = _G.diagnostic_ns })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return #lines
+        end)
       )
     end)
 
@@ -2486,17 +2713,18 @@ describe('vim.diagnostic', function()
         --    1. <msg>
         eq(
           1,
-          exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float(diagnostic_bufnr, {header = false})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return #lines
-      ]]
+          exec_lua(function()
+            local diagnostics = {
+              _G.make_error('Syntax error', 0, 1, 0, 3),
+            }
+            vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+            vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+            local float_bufnr, winnr =
+              vim.diagnostic.open_float(_G.diagnostic_bufnr, { header = false })
+            local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+            vim.api.nvim_win_close(winnr, true)
+            return #lines
+          end)
         )
       end
     )
@@ -2504,138 +2732,141 @@ describe('vim.diagnostic', function()
     it('clamps diagnostic line numbers within the valid range', function()
       eq(
         1,
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 6, 0, 6, 0),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float(diagnostic_bufnr, {header = false, pos = 5})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return #lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 6, 0, 6, 0),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          local float_bufnr, winnr =
+            vim.diagnostic.open_float(_G.diagnostic_bufnr, { header = false, pos = 5 })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return #lines
+        end)
       )
     end)
 
     it('can show diagnostic source', function()
-      exec_lua [[vim.api.nvim_win_set_buf(0, diagnostic_bufnr)]]
+      exec_lua [[vim.api.nvim_win_set_buf(0,  _G.diagnostic_bufnr)]]
 
       eq(
         { '1. Syntax error' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3, "source x"),
-        }
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float(diagnostic_bufnr, {
-          header = false,
-          source = "if_many",
-        })
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3, 'source x'),
+          }
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          local float_bufnr, winnr = vim.diagnostic.open_float(_G.diagnostic_bufnr, {
+            header = false,
+            source = 'if_many',
+          })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       eq(
         { '1. source x: Syntax error' },
-        exec_lua [[
-        local float_bufnr, winnr = vim.diagnostic.open_float(diagnostic_bufnr, {
-          header = false,
-          source = "always",
-        })
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local float_bufnr, winnr = vim.diagnostic.open_float(_G.diagnostic_bufnr, {
+            header = false,
+            source = 'always',
+          })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       eq(
         { '1. source x: Syntax error', '2. source y: Another error' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3, "source x"),
-          make_error("Another error", 0, 1, 0, 3, "source y"),
-        }
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float(diagnostic_bufnr, {
-          header = false,
-          source = "if_many",
-        })
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3, 'source x'),
+            _G.make_error('Another error', 0, 1, 0, 3, 'source y'),
+          }
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          local float_bufnr, winnr = vim.diagnostic.open_float(_G.diagnostic_bufnr, {
+            header = false,
+            source = 'if_many',
+          })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
     end)
 
     it('respects severity_sort', function()
-      exec_lua [[vim.api.nvim_win_set_buf(0, diagnostic_bufnr)]]
+      exec_lua [[vim.api.nvim_win_set_buf(0,  _G.diagnostic_bufnr)]]
 
       eq(
         { '1. Syntax error', '2. Info', '3. Error', '4. Warning' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3),
-          make_info('Info', 0, 3, 0, 4),
-          make_error('Error', 0, 2, 0, 2),
-          make_warning('Warning', 0, 0, 0, 1),
-        }
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3),
+            _G.make_info('Info', 0, 3, 0, 4),
+            _G.make_error('Error', 0, 2, 0, 2),
+            _G.make_warning('Warning', 0, 0, 0, 1),
+          }
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
 
-        vim.diagnostic.config({severity_sort = false})
+          vim.diagnostic.config({ severity_sort = false })
 
-        local float_bufnr, winnr = vim.diagnostic.open_float(diagnostic_bufnr, { header = false })
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+          local float_bufnr, winnr =
+            vim.diagnostic.open_float(_G.diagnostic_bufnr, { header = false })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       eq(
         { '1. Syntax error', '2. Error', '3. Warning', '4. Info' },
-        exec_lua [[
-        vim.diagnostic.config({severity_sort = true})
-        local float_bufnr, winnr = vim.diagnostic.open_float(diagnostic_bufnr, { header = false })
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          vim.diagnostic.config({ severity_sort = true })
+          local float_bufnr, winnr =
+            vim.diagnostic.open_float(_G.diagnostic_bufnr, { header = false })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       eq(
         { '1. Info', '2. Warning', '3. Error', '4. Syntax error' },
-        exec_lua [[
-        vim.diagnostic.config({severity_sort = { reverse = true } })
-        local float_bufnr, winnr = vim.diagnostic.open_float(diagnostic_bufnr, { header = false })
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          vim.diagnostic.config({ severity_sort = { reverse = true } })
+          local float_bufnr, winnr =
+            vim.diagnostic.open_float(_G.diagnostic_bufnr, { header = false })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
     end)
 
     it('can filter by severity', function()
       local count_diagnostics_with_severity = function(min_severity, max_severity)
-        return exec_lua(
-          [[
-          local min_severity, max_severity = ...
+        return exec_lua(function(min_severity0, max_severity0)
           vim.diagnostic.config({
             float = {
-              severity = {min=min_severity, max=max_severity},
+              severity = { min = min_severity0, max = max_severity0 },
             },
           })
 
-          vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-            make_error("Syntax error", 0, 1, 0, 3),
-            make_info('Info', 0, 3, 0, 4),
-            make_error('Error', 0, 2, 0, 2),
-            make_warning('Warning', 0, 0, 0, 1),
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Syntax error', 0, 1, 0, 3),
+            _G.make_info('Info', 0, 3, 0, 4),
+            _G.make_error('Error', 0, 2, 0, 2),
+            _G.make_warning('Warning', 0, 0, 0, 1),
           })
 
-          local float_bufnr, winnr = vim.diagnostic.open_float(diagnostic_bufnr, { header = false })
+          local float_bufnr, winnr =
+            vim.diagnostic.open_float(_G.diagnostic_bufnr, { header = false })
           if not float_bufnr then
             return 0
           end
@@ -2643,10 +2874,7 @@ describe('vim.diagnostic', function()
           local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
           vim.api.nvim_win_close(winnr, true)
           return #lines
-        ]],
-          min_severity,
-          max_severity
-        )
+        end, min_severity, max_severity)
       end
 
       eq(2, count_diagnostics_with_severity('ERROR'))
@@ -2660,83 +2888,84 @@ describe('vim.diagnostic', function()
       -- Default is to add a number
       eq(
         { '1. Syntax error', '2. Some warning' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3),
-          make_warning("Some warning", 1, 1, 1, 3),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float({header = false, scope = "buffer"})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3),
+            _G.make_warning('Some warning', 1, 1, 1, 3),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          local float_bufnr, winnr = vim.diagnostic.open_float({ header = false, scope = 'buffer' })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       eq(
         { 'Syntax error', 'Some warning' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3),
-          make_warning("Some warning", 1, 1, 1, 3),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float({header = false, scope = "buffer", prefix = ""})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3),
+            _G.make_warning('Some warning', 1, 1, 1, 3),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          local float_bufnr, winnr =
+            vim.diagnostic.open_float({ header = false, scope = 'buffer', prefix = '' })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       eq(
         { '1. Syntax error', '2. Some warning' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3),
-          make_warning("Some warning", 0, 1, 0, 3),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float({
-          header = false,
-          prefix = function(_, i, total)
-            -- Only show a number if there is more than one diagnostic
-            if total > 1 then
-              return string.format("%d. ", i)
-            end
-            return ""
-          end,
-        })
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3),
+            _G.make_warning('Some warning', 0, 1, 0, 3),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          local float_bufnr, winnr = vim.diagnostic.open_float({
+            header = false,
+            prefix = function(_, i, total)
+              -- Only show a number if there is more than one diagnostic
+              if total > 1 then
+                return string.format('%d. ', i)
+              end
+              return ''
+            end,
+          })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       eq(
         { 'Syntax error' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float({
-          header = false,
-          prefix = function(_, i, total)
-            -- Only show a number if there is more than one diagnostic
-            if total > 1 then
-              return string.format("%d. ", i)
-            end
-            return ""
-          end,
-        })
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          local float_bufnr, winnr = vim.diagnostic.open_float({
+            header = false,
+            prefix = function(_, i, total)
+              -- Only show a number if there is more than one diagnostic
+              if total > 1 then
+                return string.format('%d. ', i)
+              end
+              return ''
+            end,
+          })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       eq(
@@ -2749,50 +2978,51 @@ describe('vim.diagnostic', function()
       -- Default is to render the diagnostic error code
       eq(
         { '1. Syntax error [code-x]', '2. Some warning [code-y]' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3, nil, "code-x"),
-          make_warning("Some warning", 1, 1, 1, 3, nil, "code-y"),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float({header = false, scope = "buffer"})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3, nil, 'code-x'),
+            _G.make_warning('Some warning', 1, 1, 1, 3, nil, 'code-y'),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          local float_bufnr, winnr = vim.diagnostic.open_float({ header = false, scope = 'buffer' })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       eq(
         { '1. Syntax error', '2. Some warning' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3, nil, "code-x"),
-          make_warning("Some warning", 1, 1, 1, 3, nil, "code-y"),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float({header = false, scope = "buffer", suffix = ""})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3, nil, 'code-x'),
+            _G.make_warning('Some warning', 1, 1, 1, 3, nil, 'code-y'),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          local float_bufnr, winnr =
+            vim.diagnostic.open_float({ header = false, scope = 'buffer', suffix = '' })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       -- Suffix is rendered on the last line of a multiline diagnostic
       eq(
         { '1. Syntax error', '   More context [code-x]' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error\nMore context", 0, 1, 0, 3, nil, "code-x"),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float({header = false, scope = "buffer"})
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error\nMore context', 0, 1, 0, 3, nil, 'code-x'),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          local float_bufnr, winnr = vim.diagnostic.open_float({ header = false, scope = 'buffer' })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       eq(
@@ -2804,132 +3034,134 @@ describe('vim.diagnostic', function()
     it('works with the old signature', function()
       eq(
         { '1. Syntax error' },
-        exec_lua [[
-        local diagnostics = {
-          make_error("Syntax error", 0, 1, 0, 3),
-        }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-        local float_bufnr, winnr = vim.diagnostic.open_float(0, { header = false })
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          local diagnostics = {
+            _G.make_error('Syntax error', 0, 1, 0, 3),
+          }
+          vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+          local float_bufnr, winnr = vim.diagnostic.open_float(0, { header = false })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
     end)
 
     it('works for multi-line diagnostics #21949', function()
       -- create diagnostic
-      exec_lua [[
+      exec_lua(function()
         local diagnostics = {
-          make_error("Error in two lines lnum is 1 and end_lnum is 2", 1, 1, 2, 3),
+          _G.make_error('Error in two lines lnum is 1 and end_lnum is 2', 1, 1, 2, 3),
         }
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, diagnostics)
-      ]]
+        vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, diagnostics)
+      end)
 
       -- open float failed non diagnostic lnum
       eq(
         vim.NIL,
-        exec_lua [[
-        vim.api.nvim_win_set_cursor(0, {1, 0})
-        local _, winnr = vim.diagnostic.open_float(0, { header = false })
-        return winnr
-      ]]
+        exec_lua(function()
+          vim.api.nvim_win_set_cursor(0, { 1, 0 })
+          local _, winnr = vim.diagnostic.open_float(0, { header = false })
+          return winnr
+        end)
       )
       eq(
         vim.NIL,
-        exec_lua [[
-        vim.api.nvim_win_set_cursor(0, {1, 0})
-        local _, winnr = vim.diagnostic.open_float(0, { header = false, scope = "cursor" })
-        return winnr
-      ]]
+        exec_lua(function()
+          vim.api.nvim_win_set_cursor(0, { 1, 0 })
+          local _, winnr = vim.diagnostic.open_float(0, { header = false, scope = 'cursor' })
+          return winnr
+        end)
       )
 
       -- can open a float window on lnum 1
       eq(
         { '1. Error in two lines lnum is 1 and end_lnum is 2' },
-        exec_lua [[
-        vim.api.nvim_win_set_cursor(0, {2, 0})
-        local float_bufnr, winnr = vim.diagnostic.open_float(0, { header = false })
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          vim.api.nvim_win_set_cursor(0, { 2, 0 })
+          local float_bufnr, winnr = vim.diagnostic.open_float(0, { header = false })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       -- can open a cursor-scoped float window on lnum 1
       eq(
         { 'Error in two lines lnum is 1 and end_lnum is 2' },
-        exec_lua [[
-        vim.api.nvim_win_set_cursor(0, {2, 1})
-        local float_bufnr, winnr = vim.diagnostic.open_float(0, { header = false, scope = "cursor" })
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          vim.api.nvim_win_set_cursor(0, { 2, 1 })
+          local float_bufnr, winnr =
+            vim.diagnostic.open_float(0, { header = false, scope = 'cursor' })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       -- can open a float window on end_lnum 2
       eq(
         { '1. Error in two lines lnum is 1 and end_lnum is 2' },
-        exec_lua [[
-        vim.api.nvim_win_set_cursor(0, {3, 0})
-        local float_bufnr, winnr = vim.diagnostic.open_float(0, { header = false })
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          vim.api.nvim_win_set_cursor(0, { 3, 0 })
+          local float_bufnr, winnr = vim.diagnostic.open_float(0, { header = false })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
 
       -- can open a cursor-scoped float window on end_lnum 2
       eq(
         { 'Error in two lines lnum is 1 and end_lnum is 2' },
-        exec_lua [[
-        vim.api.nvim_win_set_cursor(0, {3, 2})
-        local float_bufnr, winnr = vim.diagnostic.open_float(0, { header = false, scope = "cursor" })
-        local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
-        vim.api.nvim_win_close(winnr, true)
-        return lines
-      ]]
+        exec_lua(function()
+          vim.api.nvim_win_set_cursor(0, { 3, 2 })
+          local float_bufnr, winnr =
+            vim.diagnostic.open_float(0, { header = false, scope = 'cursor' })
+          local lines = vim.api.nvim_buf_get_lines(float_bufnr, 0, -1, false)
+          vim.api.nvim_win_close(winnr, true)
+          return lines
+        end)
       )
     end)
   end)
 
   describe('setloclist()', function()
     it('sets diagnostics in lnum order', function()
-      local loc_list = exec_lua [[
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
+      local loc_list = exec_lua(function()
+        vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error('Farther Diagnostic', 4, 4, 4, 4),
-          make_error('Lower Diagnostic', 1, 1, 1, 1),
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Farther Diagnostic', 4, 4, 4, 4),
+          _G.make_error('Lower Diagnostic', 1, 1, 1, 1),
         })
 
         vim.diagnostic.setloclist()
 
         return vim.fn.getloclist(0)
-      ]]
+      end)
 
       assert(loc_list[1].lnum < loc_list[2].lnum)
     end)
 
     it('sets diagnostics in lnum order, regardless of namespace', function()
-      local loc_list = exec_lua [[
-        vim.api.nvim_win_set_buf(0, diagnostic_bufnr)
+      local loc_list = exec_lua(function()
+        vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
 
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error('Lower Diagnostic', 1, 1, 1, 1),
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Lower Diagnostic', 1, 1, 1, 1),
         })
 
-        vim.diagnostic.set(other_ns, diagnostic_bufnr, {
-          make_warning('Farther Diagnostic', 4, 4, 4, 4),
+        vim.diagnostic.set(_G.other_ns, _G.diagnostic_bufnr, {
+          _G.make_warning('Farther Diagnostic', 4, 4, 4, 4),
         })
 
         vim.diagnostic.setloclist()
 
         return vim.fn.getloclist(0)
-      ]]
+      end)
 
       assert(loc_list[1].lnum < loc_list[2].lnum)
     end)
@@ -2948,22 +3180,23 @@ describe('vim.diagnostic', function()
       }
       eq(
         diagnostic,
-        exec_lua(
-          [[
-        return vim.diagnostic.match(..., "^(%w+): [^:]+:(%d+):(%d+):(.+)$", {"severity", "lnum", "col", "message"})
-      ]],
-          msg
-        )
+        exec_lua(function(msg0)
+          return vim.diagnostic.match(
+            msg0,
+            '^(%w+): [^:]+:(%d+):(%d+):(.+)$',
+            { 'severity', 'lnum', 'col', 'message' }
+          )
+        end, msg)
       )
     end)
 
     it('returns nil if the pattern fails to match', function()
       eq(
         NIL,
-        exec_lua [[
-        local msg = "The answer to life, the universe, and everything is"
-        return vim.diagnostic.match(msg, "This definitely will not match", {})
-      ]]
+        exec_lua(function()
+          local msg = 'The answer to life, the universe, and everything is'
+          return vim.diagnostic.match(msg, 'This definitely will not match', {})
+        end)
       )
     end)
 
@@ -2979,12 +3212,15 @@ describe('vim.diagnostic', function()
       }
       eq(
         diagnostic,
-        exec_lua(
-          [[
-        return vim.diagnostic.match(..., "^[^:]+:(%d+):(.+)$", {"lnum", "message"}, nil, {severity = vim.diagnostic.severity.INFO})
-      ]],
-          msg
-        )
+        exec_lua(function(msg0)
+          return vim.diagnostic.match(
+            msg0,
+            '^[^:]+:(%d+):(.+)$',
+            { 'lnum', 'message' },
+            nil,
+            { severity = vim.diagnostic.severity.INFO }
+          )
+        end, msg)
       )
     end)
 
@@ -3000,38 +3236,40 @@ describe('vim.diagnostic', function()
       }
       eq(
         diagnostic,
-        exec_lua(
-          [[
-        return vim.diagnostic.match(..., "^(%d+):(%w+):(.+)$", {"lnum", "severity", "message"}, {FATAL = vim.diagnostic.severity.ERROR})
-      ]],
-          msg
-        )
+        exec_lua(function(msg0)
+          return vim.diagnostic.match(
+            msg0,
+            '^(%d+):(%w+):(.+)$',
+            { 'lnum', 'severity', 'message' },
+            { FATAL = vim.diagnostic.severity.ERROR }
+          )
+        end, msg)
       )
     end)
   end)
 
   describe('toqflist() and fromqflist()', function()
     it('works', function()
-      local result = exec_lua [[
-      vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-        make_error('Error 1', 0, 1, 0, 1),
-        make_error('Error 2', 1, 1, 1, 1),
-        make_warning('Warning', 2, 2, 2, 2),
-      })
+      local result = exec_lua(function()
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Error 1', 0, 1, 0, 1),
+          _G.make_error('Error 2', 1, 1, 1, 1),
+          _G.make_warning('Warning', 2, 2, 2, 2),
+        })
 
-      local diagnostics = vim.diagnostic.get(diagnostic_bufnr)
-      vim.fn.setqflist(vim.diagnostic.toqflist(diagnostics))
-      local list = vim.fn.getqflist()
-      local new_diagnostics = vim.diagnostic.fromqflist(list)
+        local diagnostics = vim.diagnostic.get(_G.diagnostic_bufnr)
+        vim.fn.setqflist(vim.diagnostic.toqflist(diagnostics))
+        local list = vim.fn.getqflist()
+        local new_diagnostics = vim.diagnostic.fromqflist(list)
 
-      -- Remove namespace since it isn't present in the return value of
-      -- fromlist()
-      for _, v in ipairs(diagnostics) do
-        v.namespace = nil
-      end
+        -- Remove namespace since it isn't present in the return value of
+        -- fromlist()
+        for _, v in ipairs(diagnostics) do
+          v.namespace = nil
+        end
 
-      return {diagnostics, new_diagnostics}
-      ]]
+        return { diagnostics, new_diagnostics }
+      end)
       eq(result[1], result[2])
     end)
   end)
@@ -3051,179 +3289,181 @@ describe('vim.diagnostic', function()
     it('can add new handlers', function()
       eq(
         true,
-        exec_lua [[
-        local handler_called = false
-        vim.diagnostic.handlers.test = {
-          show = function(namespace, bufnr, diagnostics, opts)
-            assert(namespace == diagnostic_ns)
-            assert(bufnr == diagnostic_bufnr)
-            assert(#diagnostics == 1)
-            assert(opts.test.some_opt == 42)
-            handler_called = true
-          end,
-        }
+        exec_lua(function()
+          local handler_called = false
+          vim.diagnostic.handlers.test = {
+            show = function(namespace, bufnr, diagnostics, opts)
+              assert(namespace == _G.diagnostic_ns)
+              assert(bufnr == _G.diagnostic_bufnr)
+              assert(#diagnostics == 1)
+              assert(opts.test.some_opt == 42)
+              handler_called = true
+            end,
+          }
 
-        vim.diagnostic.config({test = {some_opt = 42}})
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_warning("Warning", 0, 0, 0, 0),
-        })
-        return handler_called
-      ]]
+          vim.diagnostic.config({ test = { some_opt = 42 } })
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_warning('Warning', 0, 0, 0, 0),
+          })
+          return handler_called
+        end)
       )
     end)
 
     it('can disable handlers by setting the corresponding option to false', function()
       eq(
         false,
-        exec_lua [[
-        local handler_called = false
-        vim.diagnostic.handlers.test = {
-          show = function(namespace, bufnr, diagnostics, opts)
-            handler_called = true
-          end,
-        }
+        exec_lua(function()
+          local handler_called = false
+          vim.diagnostic.handlers.test = {
+            show = function(_, _, _, _)
+              handler_called = true
+            end,
+          }
 
-        vim.diagnostic.config({test = false})
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_warning("Warning", 0, 0, 0, 0),
-        })
-        return handler_called
-      ]]
+          vim.diagnostic.config({ test = false })
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_warning('Warning', 0, 0, 0, 0),
+          })
+          return handler_called
+        end)
       )
     end)
 
     it("always calls a handler's hide function if defined", function()
       eq(
         { false, true },
-        exec_lua [[
-        local hide_called = false
-        local show_called = false
-        vim.diagnostic.handlers.test = {
-          show = function(namespace, bufnr, diagnostics, opts)
-            show_called = true
-          end,
-          hide = function(namespace, bufnr)
-            assert(namespace == diagnostic_ns)
-            assert(bufnr == diagnostic_bufnr)
-            hide_called = true
-          end,
-        }
+        exec_lua(function()
+          local hide_called = false
+          local show_called = false
+          vim.diagnostic.handlers.test = {
+            show = function(_, _, _, _)
+              show_called = true
+            end,
+            hide = function(namespace, bufnr)
+              assert(namespace == _G.diagnostic_ns)
+              assert(bufnr == _G.diagnostic_bufnr)
+              hide_called = true
+            end,
+          }
 
-        vim.diagnostic.config({test = false})
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_warning("Warning", 0, 0, 0, 0),
-        })
-        vim.diagnostic.hide(diagnostic_ns, diagnostic_bufnr)
-        return {show_called, hide_called}
-      ]]
+          vim.diagnostic.config({ test = false })
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_warning('Warning', 0, 0, 0, 0),
+          })
+          vim.diagnostic.hide(_G.diagnostic_ns, _G.diagnostic_bufnr)
+          return { show_called, hide_called }
+        end)
       )
     end)
 
     it('triggers the autocommand when diagnostics are set', function()
       eq(
         { true, true },
-        exec_lua [[
-        -- Set a different buffer as current to test that <abuf> is being set properly in
-        -- DiagnosticChanged callbacks
-        local tmp = vim.api.nvim_create_buf(false, true)
-        vim.api.nvim_set_current_buf(tmp)
+        exec_lua(function()
+          -- Set a different buffer as current to test that <abuf> is being set properly in
+          -- DiagnosticChanged callbacks
+          local tmp = vim.api.nvim_create_buf(false, true)
+          vim.api.nvim_set_current_buf(tmp)
 
-        local triggered = {}
-        vim.api.nvim_create_autocmd('DiagnosticChanged', {
-          callback = function(args)
-            triggered = {args.buf, #args.data.diagnostics}
-          end,
-        })
-        vim.api.nvim_buf_set_name(diagnostic_bufnr, "test | test")
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error('Diagnostic', 0, 0, 0, 0)
-        })
-        return {
-          triggered[1] == diagnostic_bufnr,
-          triggered[2] == 1,
-        }
-      ]]
+          local triggered = {}
+          vim.api.nvim_create_autocmd('DiagnosticChanged', {
+            callback = function(args)
+              triggered = { args.buf, #args.data.diagnostics }
+            end,
+          })
+          vim.api.nvim_buf_set_name(_G.diagnostic_bufnr, 'test | test')
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Diagnostic', 0, 0, 0, 0),
+          })
+          return {
+            triggered[1] == _G.diagnostic_bufnr,
+            triggered[2] == 1,
+          }
+        end)
       )
     end)
 
     it('triggers the autocommand when diagnostics are cleared', function()
       eq(
         true,
-        exec_lua [[
-        local tmp = vim.api.nvim_create_buf(false, true)
-        vim.api.nvim_set_current_buf(tmp)
-        vim.g.diagnostic_autocmd_triggered = 0
-        vim.cmd('autocmd DiagnosticChanged * let g:diagnostic_autocmd_triggered = +expand("<abuf>")')
-        vim.api.nvim_buf_set_name(diagnostic_bufnr, "test | test")
-        vim.diagnostic.reset(diagnostic_ns, diagnostic_bufnr)
-        return vim.g.diagnostic_autocmd_triggered == diagnostic_bufnr
-      ]]
+        exec_lua(function()
+          local tmp = vim.api.nvim_create_buf(false, true)
+          vim.api.nvim_set_current_buf(tmp)
+          vim.g.diagnostic_autocmd_triggered = 0
+          vim.cmd(
+            'autocmd DiagnosticChanged * let g:diagnostic_autocmd_triggered = +expand("<abuf>")'
+          )
+          vim.api.nvim_buf_set_name(_G.diagnostic_bufnr, 'test | test')
+          vim.diagnostic.reset(_G.diagnostic_ns, _G.diagnostic_bufnr)
+          return vim.g.diagnostic_autocmd_triggered == _G.diagnostic_bufnr
+        end)
       )
     end)
 
     it('is_enabled', function()
       eq(
         { false, false, false, false, false },
-        exec_lua [[
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error('Diagnostic #1', 1, 1, 1, 1),
-        })
-        vim.api.nvim_set_current_buf(diagnostic_bufnr)
-        vim.diagnostic.enable(false)
-        return {
-          vim.diagnostic.is_enabled(),
-          vim.diagnostic.is_enabled{ bufnr = 0 },
-          vim.diagnostic.is_enabled{ bufnr = diagnostic_bufnr },
-          vim.diagnostic.is_enabled{ bufnr = diagnostic_bufnr, ns_id = diagnostic_ns },
-          vim.diagnostic.is_enabled{ bufnr = 0, ns_id = diagnostic_ns },
-        }
-      ]]
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Diagnostic #1', 1, 1, 1, 1),
+          })
+          vim.api.nvim_set_current_buf(_G.diagnostic_bufnr)
+          vim.diagnostic.enable(false)
+          return {
+            vim.diagnostic.is_enabled(),
+            vim.diagnostic.is_enabled { bufnr = 0 },
+            vim.diagnostic.is_enabled { bufnr = _G.diagnostic_bufnr },
+            vim.diagnostic.is_enabled { bufnr = _G.diagnostic_bufnr, ns_id = _G.diagnostic_ns },
+            vim.diagnostic.is_enabled { bufnr = 0, ns_id = _G.diagnostic_ns },
+          }
+        end)
       )
 
       eq(
         { true, true, true, true, true },
-        exec_lua [[
-        vim.diagnostic.enable()
-        return {
-          vim.diagnostic.is_enabled(),
-          vim.diagnostic.is_enabled{ bufnr = 0 },
-          vim.diagnostic.is_enabled{ bufnr = diagnostic_bufnr },
-          vim.diagnostic.is_enabled{ bufnr = diagnostic_bufnr, ns_id = diagnostic_ns },
-          vim.diagnostic.is_enabled{ bufnr = 0, ns_id = diagnostic_ns },
-        }
-      ]]
+        exec_lua(function()
+          vim.diagnostic.enable()
+          return {
+            vim.diagnostic.is_enabled(),
+            vim.diagnostic.is_enabled { bufnr = 0 },
+            vim.diagnostic.is_enabled { bufnr = _G.diagnostic_bufnr },
+            vim.diagnostic.is_enabled { bufnr = _G.diagnostic_bufnr, ns_id = _G.diagnostic_ns },
+            vim.diagnostic.is_enabled { bufnr = 0, ns_id = _G.diagnostic_ns },
+          }
+        end)
       )
     end)
 
     it('is_disabled (deprecated)', function()
       eq(
         { true, true, true, true },
-        exec_lua [[
-        vim.diagnostic.set(diagnostic_ns, diagnostic_bufnr, {
-          make_error('Diagnostic #1', 1, 1, 1, 1),
-        })
-        vim.api.nvim_set_current_buf(diagnostic_bufnr)
-        vim.diagnostic.disable()
-        return {
-          vim.diagnostic.is_disabled(),
-          vim.diagnostic.is_disabled(diagnostic_bufnr),
-          vim.diagnostic.is_disabled(diagnostic_bufnr, diagnostic_ns),
-          vim.diagnostic.is_disabled(_, diagnostic_ns),
-        }
-      ]]
+        exec_lua(function()
+          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+            _G.make_error('Diagnostic #1', 1, 1, 1, 1),
+          })
+          vim.api.nvim_set_current_buf(_G.diagnostic_bufnr)
+          vim.diagnostic.disable()
+          return {
+            vim.diagnostic.is_disabled(),
+            vim.diagnostic.is_disabled(_G.diagnostic_bufnr),
+            vim.diagnostic.is_disabled(_G.diagnostic_bufnr, _G.diagnostic_ns),
+            vim.diagnostic.is_disabled(0, _G.diagnostic_ns),
+          }
+        end)
       )
 
       eq(
         { false, false, false, false },
-        exec_lua [[
-        vim.diagnostic.enable()
-        return {
-          vim.diagnostic.is_disabled(),
-          vim.diagnostic.is_disabled(diagnostic_bufnr),
-          vim.diagnostic.is_disabled(diagnostic_bufnr, diagnostic_ns),
-          vim.diagnostic.is_disabled(_, diagnostic_ns),
-        }
-      ]]
+        exec_lua(function()
+          vim.diagnostic.enable()
+          return {
+            vim.diagnostic.is_disabled(),
+            vim.diagnostic.is_disabled(_G.diagnostic_bufnr),
+            vim.diagnostic.is_disabled(_G.diagnostic_bufnr, _G.diagnostic_ns),
+            vim.diagnostic.is_disabled(0, _G.diagnostic_ns),
+          }
+        end)
       )
     end)
   end)

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -18,90 +18,82 @@ describe('vim.filetype', function()
   before_each(function()
     clear()
 
-    exec_lua [[
+    exec_lua(function()
       local bufnr = vim.api.nvim_create_buf(true, false)
       vim.api.nvim_set_current_buf(bufnr)
-    ]]
+    end)
   end)
 
   it('works with extensions', function()
     eq(
       'radicalscript',
-      exec_lua [[
-      vim.filetype.add({
-        extension = {
-          rs = 'radicalscript',
-        },
-      })
-      return vim.filetype.match({ filename = 'main.rs' })
-    ]]
+      exec_lua(function()
+        vim.filetype.add({
+          extension = {
+            rs = 'radicalscript',
+          },
+        })
+        return vim.filetype.match({ filename = 'main.rs' })
+      end)
     )
   end)
 
   it('prioritizes filenames over extensions', function()
     eq(
       'somethingelse',
-      exec_lua [[
-      vim.filetype.add({
-        extension = {
-          rs = 'radicalscript',
-        },
-        filename = {
-          ['main.rs'] = 'somethingelse',
-        },
-      })
-      return vim.filetype.match({ filename = 'main.rs' })
-    ]]
+      exec_lua(function()
+        vim.filetype.add({
+          extension = {
+            rs = 'radicalscript',
+          },
+          filename = {
+            ['main.rs'] = 'somethingelse',
+          },
+        })
+        return vim.filetype.match({ filename = 'main.rs' })
+      end)
     )
   end)
 
   it('works with filenames', function()
     eq(
       'nim',
-      exec_lua [[
-      vim.filetype.add({
-        filename = {
-          ['s_O_m_e_F_i_l_e'] = 'nim',
-        },
-      })
-      return vim.filetype.match({ filename = 's_O_m_e_F_i_l_e' })
-    ]]
+      exec_lua(function()
+        vim.filetype.add({
+          filename = {
+            ['s_O_m_e_F_i_l_e'] = 'nim',
+          },
+        })
+        return vim.filetype.match({ filename = 's_O_m_e_F_i_l_e' })
+      end)
     )
 
     eq(
       'dosini',
-      exec_lua(
-        [[
-      local root = ...
-      vim.filetype.add({
-        filename = {
-          ['config'] = 'toml',
-          [root .. '/.config/fun/config'] = 'dosini',
-        },
-      })
-      return vim.filetype.match({ filename = root .. '/.config/fun/config' })
-    ]],
-        root
-      )
+      exec_lua(function(root0)
+        vim.filetype.add({
+          filename = {
+            ['config'] = 'toml',
+            [root0 .. '/.config/fun/config'] = 'dosini',
+          },
+        })
+        return vim.filetype.match({ filename = root0 .. '/.config/fun/config' })
+      end, root)
     )
   end)
 
   it('works with patterns', function()
     eq(
       'markdown',
-      exec_lua(
-        [[
-      local root = ...
-      vim.env.HOME = '/a-funky+home%dir'
-      vim.filetype.add({
-        pattern = {
-          ['~/blog/.*%.txt'] = 'markdown',
-        }
-      })
-      return vim.filetype.match({ filename = '~/blog/why_neovim_is_awesome.txt' })
-    ]],
-        root
-      )
+      exec_lua(function()
+        vim.env.HOME = '/a-funky+home%dir'
+        vim.filetype.add({
+          pattern = {
+            ['~/blog/.*%.txt'] = 'markdown',
+          },
+        })
+        return vim.filetype.match({ filename = '~/blog/why_neovim_is_awesome.txt' })
+      end)
     )
   end)
 
@@ -110,43 +102,43 @@ describe('vim.filetype', function()
     command('file relevant_to_me')
     eq(
       'foss',
-      exec_lua [[
-      vim.filetype.add({
-        pattern = {
-          ["relevant_to_(%a+)"] = function(path, bufnr, capture)
-            if capture == "me" then
-              return "foss"
-            end
-          end,
-        }
-      })
-      return vim.filetype.match({ buf = 0 })
-    ]]
+      exec_lua(function()
+        vim.filetype.add({
+          pattern = {
+            ['relevant_to_(%a+)'] = function(_, _, capture)
+              if capture == 'me' then
+                return 'foss'
+              end
+            end,
+          },
+        })
+        return vim.filetype.match({ buf = 0 })
+      end)
     )
   end)
 
   it('works with contents #22180', function()
     eq(
       'sh',
-      exec_lua [[
-      -- Needs to be set so detect#sh doesn't fail
-      vim.g.ft_ignore_pat = '\\.\\(Z\\|gz\\|bz2\\|zip\\|tgz\\)$'
-      return vim.filetype.match({ contents = { '#!/usr/bin/env bash' } })
-    ]]
+      exec_lua(function()
+        -- Needs to be set so detect#sh doesn't fail
+        vim.g.ft_ignore_pat = '\\.\\(Z\\|gz\\|bz2\\|zip\\|tgz\\)$'
+        return vim.filetype.match({ contents = { '#!/usr/bin/env bash' } })
+      end)
     )
   end)
 
   it('considers extension mappings when matching from hashbang', function()
     eq(
       'fooscript',
-      exec_lua [[
-      vim.filetype.add({
-        extension = {
-          foo = 'fooscript',
-        }
-      })
-      return vim.filetype.match({ contents = { '#!/usr/bin/env foo' } })
-    ]]
+      exec_lua(function()
+        vim.filetype.add({
+          extension = {
+            foo = 'fooscript',
+          },
+        })
+        return vim.filetype.match({ contents = { '#!/usr/bin/env foo' } })
+      end)
     )
   end)
 

--- a/test/functional/lua/glob_spec.lua
+++ b/test/functional/lua/glob_spec.lua
@@ -9,14 +9,9 @@ describe('glob', function()
   after_each(n.clear)
 
   local match = function(...)
-    return exec_lua(
-      [[
-      local pattern = select(1, ...)
-      local str = select(2, ...)
-      return require("vim.glob").to_lpeg(pattern):match(str) ~= nil
-    ]],
-      ...
-    )
+    return exec_lua(function(pattern, str)
+      return require('vim.glob').to_lpeg(pattern):match(str) ~= nil
+    end, ...)
   end
 
   describe('glob matching', function()

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -835,9 +835,18 @@ function M.exec_capture(code)
   return M.api.nvim_exec2(code, { output = true }).output
 end
 
---- @param code string
+--- @param code string|function
 --- @return any
 function M.exec_lua(code, ...)
+  if type(code) == 'function' then
+    return M.api.nvim_exec_lua(
+      [[
+      local code = ...
+      return loadstring(code)(select(2, ...))
+    ]],
+      { string.dump(code), ... }
+    )
+  end
   return M.api.nvim_exec_lua(code, { ... })
 end
 

--- a/test/functional/treesitter/fold_spec.lua
+++ b/test/functional/treesitter/fold_spec.lua
@@ -48,13 +48,13 @@ void ui_refresh(void)
   end
 
   local function get_fold_levels()
-    return exec_lua([[
-    local res = {}
-    for i = 1, vim.api.nvim_buf_line_count(0) do
-      res[i] = vim.treesitter.foldexpr(i)
-    end
-    return res
-    ]])
+    return exec_lua(function()
+      local res = {}
+      for i = 1, vim.api.nvim_buf_line_count(0) do
+        res[i] = vim.treesitter.foldexpr(i)
+      end
+      return res
+    end)
   end
 
   it('can compute fold levels', function()
@@ -246,9 +246,13 @@ function f()
 end
 -- comment]])
 
-    exec_lua(
-      [[vim.treesitter.query.set('lua', 'folds', '[(function_declaration) (parameters) (arguments)] @fold')]]
-    )
+    exec_lua(function()
+      vim.treesitter.query.set(
+        'lua',
+        'folds',
+        '[(function_declaration) (parameters) (arguments)] @fold'
+      )
+    end)
     parse('lua')
 
     eq({
@@ -290,9 +294,13 @@ function f()
   )
 end]])
 
-    exec_lua(
-      [[vim.treesitter.query.set('lua', 'folds', '[(function_declaration) (function_definition) (parameters) (arguments)] @fold')]]
-    )
+    exec_lua(function()
+      vim.treesitter.query.set(
+        'lua',
+        'folds',
+        '[(function_declaration) (function_definition) (parameters) (arguments)] @fold'
+      )
+    end)
     parse('lua')
 
     -- If fold1.stop = fold2.start, then move fold1's stop up so that fold2.start gets proper level.
@@ -333,9 +341,13 @@ function f(a)
   end
 end]])
 
-    exec_lua(
-      [[vim.treesitter.query.set('lua', 'folds', '[(if_statement) (function_declaration) (parameters) (arguments) (table_constructor)] @fold')]]
-    )
+    exec_lua(function()
+      vim.treesitter.query.set(
+        'lua',
+        'folds',
+        '[(if_statement) (function_declaration) (parameters) (arguments) (table_constructor)] @fold'
+      )
+    end)
     parse('lua')
 
     eq({

--- a/test/functional/treesitter/inspect_tree_spec.lua
+++ b/test/functional/treesitter/inspect_tree_spec.lua
@@ -22,10 +22,10 @@ describe('vim.treesitter.inspect_tree', function()
       print()
       ]])
 
-    exec_lua([[
+    exec_lua(function()
       vim.treesitter.start(0, 'lua')
       vim.treesitter.inspect_tree()
-    ]])
+    end)
 
     expect_tree [[
       (chunk ; [0, 0] - [2, 0]
@@ -40,10 +40,10 @@ describe('vim.treesitter.inspect_tree', function()
       print('hello')
       ]])
 
-    exec_lua([[
+    exec_lua(function()
       vim.treesitter.start(0, 'lua')
       vim.treesitter.inspect_tree()
-    ]])
+    end)
     feed('a')
 
     expect_tree [[
@@ -67,11 +67,11 @@ describe('vim.treesitter.inspect_tree', function()
       ```
       ]])
 
-    exec_lua([[
+    exec_lua(function()
       vim.treesitter.start(0, 'markdown')
       vim.treesitter.get_parser():parse()
       vim.treesitter.inspect_tree()
-    ]])
+    end)
 
     expect_tree [[
       (document ; [0, 0] - [4, 0]
@@ -96,11 +96,11 @@ describe('vim.treesitter.inspect_tree', function()
       ```
       ]])
 
-    exec_lua([[
+    exec_lua(function()
       vim.treesitter.start(0, 'markdown')
       vim.treesitter.get_parser():parse()
       vim.treesitter.inspect_tree()
-    ]])
+    end)
     feed('I')
 
     expect_tree [[
@@ -125,28 +125,28 @@ describe('vim.treesitter.inspect_tree', function()
       ]])
 
     -- setup two windows for the source buffer
-    exec_lua([[
-      source_win = vim.api.nvim_get_current_win()
+    exec_lua(function()
+      _G.source_win = vim.api.nvim_get_current_win()
       vim.api.nvim_open_win(0, false, {
         win = 0,
-        split = 'left'
+        split = 'left',
       })
-    ]])
+    end)
 
     -- setup three windows for the tree buffer
-    exec_lua([[
+    exec_lua(function()
       vim.treesitter.start(0, 'lua')
       vim.treesitter.inspect_tree()
-      tree_win = vim.api.nvim_get_current_win()
-      tree_win_copy_1 = vim.api.nvim_open_win(0, false, {
+      _G.tree_win = vim.api.nvim_get_current_win()
+      _G.tree_win_copy_1 = vim.api.nvim_open_win(0, false, {
         win = 0,
-        split = 'left'
+        split = 'left',
       })
-      tree_win_copy_2 = vim.api.nvim_open_win(0, false, {
+      _G.tree_win_copy_2 = vim.api.nvim_open_win(0, false, {
         win = 0,
-        split = 'left'
+        split = 'left',
       })
-    ]])
+    end)
 
     -- close original source window
     exec_lua('vim.api.nvim_win_close(source_win, false)')

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -54,10 +54,10 @@ describe('treesitter language API', function()
   end)
 
   it('inspects language', function()
-    local keys, fields, symbols = unpack(exec_lua([[
+    local keys, fields, symbols = unpack(exec_lua(function()
       local lang = vim.treesitter.language.inspect('c')
       local keys, symbols = {}, {}
-      for k,_ in pairs(lang) do
+      for k, _ in pairs(lang) do
         keys[k] = true
       end
 
@@ -66,8 +66,8 @@ describe('treesitter language API', function()
       for _, v in pairs(lang.symbols) do
         table.insert(symbols, v)
       end
-      return {keys, lang.fields, symbols}
-    ]]))
+      return { keys, lang.fields, symbols }
+    end))
 
     eq({ fields = true, symbols = true, _abi_version = true }, keys)
 
@@ -113,12 +113,14 @@ describe('treesitter language API', function()
         int x = 3;
       }]])
 
-    exec_lua([[
-      langtree = vim.treesitter.get_parser(0, "c")
-      tree = langtree:tree_for_range({1, 3, 1, 3})
-    ]])
-
-    eq('<node translation_unit>', exec_lua('return tostring(tree:root())'))
+    eq(
+      '<node translation_unit>',
+      exec_lua(function()
+        local langtree = vim.treesitter.get_parser(0, 'c')
+        local tree = langtree:tree_for_range({ 1, 3, 1, 3 })
+        return tostring(tree:root())
+      end)
+    )
   end)
 
   it('retrieve the tree given a range when range is out of bounds relative to buffer', function()
@@ -127,12 +129,14 @@ describe('treesitter language API', function()
         int x = 3;
       }]])
 
-    exec_lua([[
-      langtree = vim.treesitter.get_parser(0, "c")
-      tree = langtree:tree_for_range({10, 10, 10, 10})
-    ]])
-
-    eq('<node translation_unit>', exec_lua('return tostring(tree:root())'))
+    eq(
+      '<node translation_unit>',
+      exec_lua(function()
+        local langtree = vim.treesitter.get_parser(0, 'c')
+        local tree = langtree:tree_for_range({ 10, 10, 10, 10 })
+        return tostring(tree:root())
+      end)
+    )
   end)
 
   it('retrieve the node given a range', function()
@@ -141,12 +145,14 @@ describe('treesitter language API', function()
         int x = 3;
       }]])
 
-    exec_lua([[
-      langtree = vim.treesitter.get_parser(0, "c")
-      node = langtree:named_node_for_range({1, 3, 1, 3})
-    ]])
-
-    eq('<node primitive_type>', exec_lua('return tostring(node)'))
+    eq(
+      '<node primitive_type>',
+      exec_lua(function()
+        local langtree = vim.treesitter.get_parser(0, 'c')
+        local node = langtree:named_node_for_range({ 1, 3, 1, 3 })
+        return tostring(node)
+      end)
+    )
   end)
 
   it('retrieve an anonymous node given a range', function()

--- a/test/functional/treesitter/node_spec.lua
+++ b/test/functional/treesitter/node_spec.lua
@@ -18,39 +18,39 @@ describe('treesitter node API', function()
 
   it('double free tree', function()
     insert('F')
-    exec_lua([[
+    exec_lua(function()
       vim.treesitter.start(0, 'lua')
       vim.treesitter.get_node():tree()
       vim.treesitter.get_node():tree()
       collectgarbage()
-    ]])
+    end)
     assert_alive()
   end)
 
   it('double free tree 2', function()
-    exec_lua([[
-      parser = vim.treesitter.get_parser(0, "c")
+    exec_lua(function()
+      local parser = vim.treesitter.get_parser(0, 'c')
       local x = parser:parse()[1]:root():tree()
-      vim.api.nvim_buf_set_text(0, 0,0, 0,0, {'y'})
+      vim.api.nvim_buf_set_text(0, 0, 0, 0, 0, { 'y' })
       parser:parse()
-      vim.api.nvim_buf_set_text(0, 0,0, 0,1, {'z'})
+      vim.api.nvim_buf_set_text(0, 0, 0, 0, 1, { 'z' })
       parser:parse()
       collectgarbage()
       x:root()
-    ]])
+    end)
     assert_alive()
   end)
 
   it('get_node() with lang given', function()
     -- this buffer doesn't have filetype set!
     insert('local foo = function() end')
-    exec_lua([[
-      node = vim.treesitter.get_node({
+    exec_lua(function()
+      _G.node = vim.treesitter.get_node({
         bufnr = 0,
-        pos = { 0, 6 },  -- on "foo"
+        pos = { 0, 6 }, -- on "foo"
         lang = 'lua',
       })
-    ]])
+    end)
     eq('foo', lua_eval('vim.treesitter.get_node_text(node, 0)'))
     eq('identifier', lua_eval('node:type()'))
   end)
@@ -79,16 +79,16 @@ describe('treesitter node API', function()
       }
     ]])
 
-    exec_lua([[
-      parser = vim.treesitter.get_parser(0, "c")
-      tree = parser:parse()[1]
-      root = tree:root()
-      lang = vim.treesitter.language.inspect('c')
+    exec_lua(function()
+      local parser = vim.treesitter.get_parser(0, 'c')
+      local tree = parser:parse()[1]
+      _G.root = tree:root()
+      vim.treesitter.language.inspect('c')
 
-      function node_text(node)
+      function _G.node_text(node)
         return vim.treesitter.get_node_text(node, 0)
       end
-    ]])
+    end)
 
     exec_lua 'node = root:descendant_for_range(0, 11, 0, 16)'
     eq('int x', lua_eval('node_text(node)'))
@@ -118,13 +118,13 @@ describe('treesitter node API', function()
         int x = 3;
       }]])
 
-    local len = exec_lua([[
-      tree = vim.treesitter.get_parser(0, "c"):parse()[1]
-      node = tree:root():child(0)
-      children = node:named_children()
+    local len = exec_lua(function()
+      local tree = vim.treesitter.get_parser(0, 'c'):parse()[1]
+      local node = tree:root():child(0)
+      _G.children = node:named_children()
 
-      return #children
-    ]])
+      return #_G.children
+    end)
 
     eq(3, len)
     eq('<node compound_statement>', lua_eval('tostring(children[3])'))
@@ -136,11 +136,11 @@ describe('treesitter node API', function()
         int x = 3;
       }]])
 
-    exec_lua([[
-      tree = vim.treesitter.get_parser(0, "c"):parse()[1]
-      root = tree:root()
-      node = root:child(0):child(2)
-    ]])
+    exec_lua(function()
+      local tree = vim.treesitter.get_parser(0, 'c'):parse()[1]
+      _G.root = tree:root()
+      _G.node = _G.root:child(0):child(2)
+    end)
 
     eq(lua_eval('tostring(root)'), lua_eval('tostring(node:root())'))
   end)
@@ -151,11 +151,11 @@ describe('treesitter node API', function()
         int x = 3;
       }]])
 
-    exec_lua([[
-      tree = vim.treesitter.get_parser(0, "c"):parse()[1]
-      root = tree:root()
-      child = root:child(0):child(0)
-    ]])
+    exec_lua(function()
+      local tree = vim.treesitter.get_parser(0, 'c'):parse()[1]
+      _G.root = tree:root()
+      _G.child = _G.root:child(0):child(0)
+    end)
 
     eq(28, lua_eval('root:byte_length()'))
     eq(3, lua_eval('child:byte_length()'))
@@ -167,15 +167,15 @@ describe('treesitter node API', function()
         int x = 3;
       }]])
 
-    exec_lua([[
-      tree = vim.treesitter.get_parser(0, "c"):parse()[1]
-      root = tree:root()
-      main = root:child(0)
-      body = main:child(2)
-      statement = body:child(1)
-      declarator = statement:child(1)
-      value = declarator:child(1)
-    ]])
+    exec_lua(function()
+      local tree = vim.treesitter.get_parser(0, 'c'):parse()[1]
+      _G.root = tree:root()
+      _G.main = _G.root:child(0)
+      _G.body = _G.main:child(2)
+      _G.statement = _G.body:child(1)
+      _G.declarator = _G.statement:child(1)
+      _G.value = _G.declarator:child(1)
+    end)
 
     eq(lua_eval('main:type()'), lua_eval('root:child_containing_descendant(value):type()'))
     eq(lua_eval('body:type()'), lua_eval('main:child_containing_descendant(value):type()'))

--- a/test/functional/treesitter/utils_spec.lua
+++ b/test/functional/treesitter/utils_spec.lua
@@ -17,26 +17,26 @@ describe('treesitter utils', function()
         int x = 3;
       }]])
 
-    exec_lua([[
-      parser = vim.treesitter.get_parser(0, "c")
-      tree = parser:parse()[1]
-      root = tree:root()
-      ancestor = root:child(0)
-      child = ancestor:child(0)
-    ]])
+    exec_lua(function()
+      local parser = vim.treesitter.get_parser(0, 'c')
+      local tree = parser:parse()[1]
+      local root = tree:root()
+      _G.ancestor = root:child(0)
+      _G.child = _G.ancestor:child(0)
+    end)
 
-    eq(true, exec_lua('return vim.treesitter.is_ancestor(ancestor, child)'))
-    eq(false, exec_lua('return vim.treesitter.is_ancestor(child, ancestor)'))
+    eq(true, exec_lua('return vim.treesitter.is_ancestor(_G.ancestor, _G.child)'))
+    eq(false, exec_lua('return vim.treesitter.is_ancestor(_G.child, _G.ancestor)'))
   end)
 
   it('can detect if a position is contained in a node', function()
-    exec_lua([[
-      node = {
+    exec_lua(function()
+      _G.node = {
         range = function()
           return 0, 4, 0, 8
         end,
       }
-    ]])
+    end)
 
     eq(false, exec_lua('return vim.treesitter.is_in_node_range(node, 0, 3)'))
     for i = 4, 7 do


### PR DESCRIPTION
Problem:

Tests have lots of exec_lua calls which input blocks of code
provided as unformatted strings.

Solution:

Teach exec_lua how to handle functions.
