### PR TITLE
docs(gen_help_html): fix heading wrapping

### DIFF
--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -1146,10 +1146,11 @@ local function gen_css(fname)
       font-size: smaller;
     }
     .help-heading {
-      overflow: hidden;
-      white-space: nowrap;
+      white-space: normal;
       display: flex;
+      flex-flow: row wrap;
       justify-content: space-between;
+      gap: 0 15px;
     }
     /* The (right-aligned) "tags" part of a section heading. */
     .help-heading-tags {
@@ -1184,8 +1185,7 @@ local function gen_css(fname)
     pre:last-child {
       margin-bottom: 0;
     }
-    pre:hover,
-    .help-heading:hover {
+    pre:hover {
       overflow: visible;
     }
     .generator-stats {


### PR DESCRIPTION
This simple change allows headings and help tags in the html docs to wrap nicely on small screens.

Before:
![image](https://github.com/user-attachments/assets/a448b2ee-40d6-42fa-ac89-7c56ca7e906c)


After:
![image](https://github.com/user-attachments/assets/2bf1945f-3e50-44b6-9225-ea9fed6f0e7f)
