### PR TITLE
vim-patch:011f222: runtime(thrift): add ftplugin, indent and syntax scripts

### DIFF
--- a/runtime/ftplugin/thrift.vim
+++ b/runtime/ftplugin/thrift.vim
@@ -1,0 +1,17 @@
+" Vim filetype plugin file
+" Language: Apache Thrift
+" Maintainer: Yinzuo Jiang <jiangyinzuo@foxmail.com>
+" Last Change: 2024/07/29
+
+if exists("b:did_ftplugin")
+  finish
+endif
+
+let b:did_ftplugin = 1
+
+" Thrift supports shell-style, C-style multi-line as well as single-line Java/C++ style comments.
+" Reference: https://diwakergupta.github.io/thrift-missing-guide/#_language_reference
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,:///,://,b:#
+setlocal commentstring=//\ %s
+
+let b:undo_ftplugin = 'setl comments< commentstring<'

--- a/runtime/indent/testdir/thrift.in
+++ b/runtime/indent/testdir/thrift.in
@@ -1,0 +1,38 @@
+// vim: set ft=thrift sw=4 et:
+
+# START_INDENT
+namespace cpp foo
+namespace java com.foo.thrift
+
+include "Status.thrift"
+
+// These are supporting structs for JniFrontend.java, which serves as the glue
+// between our C++ execution environment and the Java frontend.
+
+struct TSetSessionParams {
+ 1: required string user
+}
+
+struct TAuthenticateParams {
+    1: required string user
+ 2: required string passwd
+    3: optional string host
+4: optional string db_name
+    5: optional list<string> table_names;
+}
+
+/* {
+ * xxxx
+ * }
+ */
+// TColumnDesc
+struct TColumnDesc {
+    // {
+4: optional string tableName
+5: optional string columnDefault
+    // Let FE control the type, which makes it easier to modify and display complex types
+6: optional string columnTypeStr // deprecated
+7: optional string dataType
+    // }
+}
+# END_INDENT

--- a/runtime/indent/testdir/thrift.ok
+++ b/runtime/indent/testdir/thrift.ok
@@ -1,0 +1,38 @@
+// vim: set ft=thrift sw=4 et:
+
+# START_INDENT
+namespace cpp foo
+namespace java com.foo.thrift
+
+include "Status.thrift"
+
+// These are supporting structs for JniFrontend.java, which serves as the glue
+// between our C++ execution environment and the Java frontend.
+
+struct TSetSessionParams {
+    1: required string user
+}
+
+struct TAuthenticateParams {
+    1: required string user
+    2: required string passwd
+    3: optional string host
+    4: optional string db_name
+    5: optional list<string> table_names;
+}
+
+/* {
+ * xxxx
+ * }
+ */
+// TColumnDesc
+struct TColumnDesc {
+    // {
+    4: optional string tableName
+    5: optional string columnDefault
+    // Let FE control the type, which makes it easier to modify and display complex types
+    6: optional string columnTypeStr // deprecated
+    7: optional string dataType
+    // }
+}
+# END_INDENT

--- a/runtime/indent/thrift.vim
+++ b/runtime/indent/thrift.vim
@@ -1,0 +1,74 @@
+" Vim indent file
+" Language: Apache Thrift
+" Maintainer: Yinzuo Jiang <jiangyinzuo@foxmail.com>
+" Last Change: 2024/07/29
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+  finish
+endif
+let b:did_indent = 1
+
+setlocal cindent
+setlocal indentexpr=GetThriftIndent()
+
+let b:undo_indent = "set cindent< indentexpr<"
+
+" Only define the function once.
+if exists("*GetThriftIndent")
+  finish
+endif
+
+let s:keepcpo= &cpo
+set cpo&vim
+
+function! SkipThriftBlanksAndComments(startline)
+  let lnum = a:startline
+  while lnum > 1
+    let lnum = prevnonblank(lnum)
+    if getline(lnum) =~ '\*/\s*$'
+      while getline(lnum) !~ '/\*' && lnum > 1
+        let lnum = lnum - 1
+      endwhile
+      if getline(lnum) =~ '^\s*/\*'
+        let lnum = lnum - 1
+      else
+        break
+      endif
+    elseif getline(lnum) =~ '^\s*\(//\|#\)'
+      let lnum = lnum - 1
+    else
+      break
+    endif
+  endwhile
+  return lnum
+endfunction
+
+function GetThriftIndent()
+  " Thrift is just like C; use the built-in C indenting and then correct a few
+  " specific cases.
+  let theIndent = cindent(v:lnum)
+
+  " If we're in the middle of a comment then just trust cindent
+  if getline(v:lnum) =~ '^\s*\*'
+    return theIndent
+  endif
+
+  let line = substitute(getline(v:lnum), '\(//\|#\).*$', '', '')
+  let previousNum = SkipThriftBlanksAndComments(v:lnum - 1)
+  let previous = substitute(getline(previousNum), '\(//\|#\).*$', '', '')
+
+  let l:indent = indent(previousNum)
+  if previous =~ "{" && previous !~ "}"
+    let l:indent += shiftwidth()
+  endif
+  if line =~ "}" && line !~ "{"
+    let l:indent -= shiftwidth()
+  endif
+  return l:indent
+endfunction
+
+let &cpo = s:keepcpo
+unlet s:keepcpo
+
+" vim: sw=2 sts=2 et

--- a/runtime/syntax/thrift.vim
+++ b/runtime/syntax/thrift.vim
@@ -1,0 +1,74 @@
+" Vim syntax file
+" Language: Thrift
+" Original Author: Martin Smith <martin@facebook.com>
+" Maintainer: Yinzuo Jiang <jiangyinzuo@foxmail.com>
+" Last Change: 2024/07/29
+" https://github.com/apache/thrift/blob/master/contrib/thrift.vim
+"
+" Licensed to the Apache Software Foundation (ASF) under one
+" or more contributor license agreements. See the NOTICE file
+" distributed with this work for additional information
+" regarding copyright ownership. The ASF licenses this file
+" to you under the Apache License, Version 2.0 (the
+" "License"); you may not use this file except in compliance
+" with the License. You may obtain a copy of the License at
+"
+"   http://www.apache.org/licenses/LICENSE-2.0
+"
+" Unless required by applicable law or agreed to in writing,
+" software distributed under the License is distributed on an
+" "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+" KIND, either express or implied. See the License for the
+" specific language governing permissions and limitations
+" under the License.
+"
+
+if exists("b:current_syntax")
+  finish
+endif
+
+" Todo
+syn keyword thriftTodo TODO todo FIXME fixme XXX xxx contained
+
+" Comments
+syn match thriftComment "#.*" contains=thriftTodo
+syn region thriftComment start="/\*" end="\*/" contains=thriftTodo
+syn match thriftComment "//.\{-}\(?>\|$\)\@="
+
+" String
+syn region thriftStringDouble matchgroup=None start=+"+  end=+"+
+
+" Number
+syn match thriftNumber "-\=\<\d\+\>" contained
+
+" Keywords
+syn keyword thriftKeyword namespace
+syn keyword thriftKeyword xsd_all xsd_optional xsd_nillable xsd_attrs
+syn keyword thriftKeyword include cpp_include cpp_type const optional required
+syn keyword thriftBasicTypes void bool byte i8 i16 i32 i64 double string binary
+syn keyword thriftStructure map list set struct typedef exception enum throws union
+
+" Special
+syn match thriftSpecial "\d\+:"
+
+" Structure
+syn keyword thriftStructure service oneway extends
+"async"         { return tok_async;         }
+"exception"     { return tok_xception;      }
+"extends"       { return tok_extends;       }
+"throws"        { return tok_throws;        }
+"service"       { return tok_service;       }
+"enum"          { return tok_enum;          }
+"const"         { return tok_const;         }
+
+hi def link thriftComment Comment
+hi def link thriftKeyword Special
+hi def link thriftBasicTypes Type
+hi def link thriftStructure StorageClass
+hi def link thriftTodo Todo
+hi def link thriftString String
+hi def link thriftNumber Number
+hi def link thriftSpecial Special
+hi def link thriftStructure Structure
+
+let b:current_syntax = "thrift"


### PR DESCRIPTION
Problem: Apache Thrift files misses ftplugin, indent and syntax scripts

Solution:
- add ftplugin and indent scripts
- add thrift indent test
- port the syntax script from apache/thrift (Apache License 2)

Reference:
https://diwakergupta.github.io/thrift-missing-guide/#_language_reference

closes: vim/vim#15387

https://github.com/vim/vim/commit/011f2223e5df68f45a382f6a9dff6eaf5ecac346

Co-authored-by: Yinzuo Jiang <jiangyinzuo@foxmail.com>
