### PR TITLE
vim-patch:9.1.0638: E1510 may happen when formatting a message for smsg()

### DIFF
--- a/test/old/testdir/test_spellfile.vim
+++ b/test/old/testdir/test_spellfile.vim
@@ -846,6 +846,22 @@ func Test_spell_add_word()
   %bw!
 endfunc
 
+func Test_spell_add_long_word()
+  set spell spellfile=./Xspellfile.add spelllang=en
+
+  let word = repeat('a', 9000)
+  let v:errmsg = ''
+  " Spell checking doesn't really work for such a long word,
+  " but this should not cause an E1510 error.
+  exe 'spellgood ' .. word
+  call assert_equal('', v:errmsg)
+  call assert_equal([word], readfile('./Xspellfile.add'))
+
+  set spell& spellfile= spelllang& encoding=utf-8
+  call delete('./Xspellfile.add')
+  call delete('./Xspellfile.add.spl')
+endfunc
+
 func Test_spellfile_verbose()
   call writefile(['1', 'one'], 'XtestVerbose.dic', 'D')
   call writefile([], 'XtestVerbose.aff', 'D')


### PR DESCRIPTION
Fix #29886

#### vim-patch:9.1.0638: E1510 may happen when formatting a message for smsg()

Problem:  E1510 may happen when formatting a message
          (after 9.1.0181).
Solution: Only give E1510 when using typval. (zeertzjq)

closes: vim/vim#15391

https://github.com/vim/vim/commit/0dff31576a340b74cec81517912923c38cb28450