### PR TITLE
vim-patch:9.1.0642: Check that mapping rhs starts with lhs fails if not simplified

### DIFF
--- a/src/nvim/mapping_defs.h
+++ b/src/nvim/mapping_defs.h
@@ -10,6 +10,9 @@ enum { MAXMAPLEN = 50, };  ///< Maximum length of key sequence to be mapped.
 typedef struct mapblock mapblock_T;
 struct mapblock {
   mapblock_T *m_next;       ///< next mapblock in list
+  mapblock_T *m_alt;        ///< pointer to mapblock of the same mapping
+                            ///< with an alternative form of m_keys, or NULL
+                            ///< if there is no such mapblock
   char *m_keys;             ///< mapped from, lhs
   char *m_str;              ///< mapped to, rhs
   char *m_orig_str;         ///< rhs as entered by the user


### PR DESCRIPTION
Fix #29896

#### vim-patch:9.1.0642: Check that mapping rhs starts with lhs fails if not simplified

Problem:  Check that mapping rhs starts with lhs doesn't work if lhs is
          not simplified.
Solution: Keep track of the mapblock containing the alternative lhs and
          also compare with it (zeertzjq).

closes: vim/vim#15384

https://github.com/vim/vim/commit/9d997addc7bd0fd132a809cf497ed816e61fcd25

Cherry-pick removal of save_m_str from patch 8.2.4059.