### PR TITLE
fix(watch): .git was not excluded

### DIFF
--- a/runtime/lua/vim/_watch.lua
+++ b/runtime/lua/vim/_watch.lua
@@ -277,7 +277,7 @@ function M.inotify(path, opts, callback)
     'modify',
     '--event',
     'move',
-    '@.git', -- ignore git directory
+    string.format('@%s/.git', path), -- ignore git directory
     path,
   }, {
     stderr = function(err, data)


### PR DESCRIPTION
`inotifywait` man page specifies:
The file must be specified with a relative or absolute path according to whether a relative or absolute path is given for watched directories.

So it would only work this way in case the path is relative (which at least for `gopls` it is not)