### PR TITLE
vim-patch:df9f67e: runtime(html): update syntax script to sync by 250 minlines by default

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1436,6 +1436,10 @@ You can also disable this rendering by adding the following line to your
 vimrc file: >
 	:let html_no_rendering=1
 
+By default Vim synchronises the syntax to 250 lines before the first displayed
+line.  This can be configured using: >
+	:let html_minlines = 500
+<
 HTML comments are rather special (see an HTML reference document for the
 details), and the syntax coloring scheme will highlight all errors.
 However, if you prefer to use the wrong style (starts with <!-- and

--- a/runtime/syntax/html.vim
+++ b/runtime/syntax/html.vim
@@ -4,6 +4,7 @@
 " Previous Maintainers: Jorge Maldonado Ventura <jorgesumle@freakspot.net>
 "			Claudio Fleiner <claudio@fleiner.com>
 " Last Change:		2023 Nov 28
+" 2024 Jul 30 by Vim Project: increase syn-sync-minlines to 250
 
 " See :help html.vim for some comments and a description of the options
 
@@ -320,7 +321,7 @@ if main_syntax == "html"
   syn sync match htmlHighlight groupthere NONE "<[/a-zA-Z]"
   syn sync match htmlHighlight groupthere javaScript "<script"
   syn sync match htmlHighlightSkip "^.*['\"].*$"
-  syn sync minlines=10
+  exe "syn sync minlines=" . get(g:, 'html_minlines', 250)
 endif
 
 " Folding


### PR DESCRIPTION
closes: vim/vim#14071

https://github.com/vim/vim/commit/df9f67e10d214e0124f2141f59593529801307a4

Co-authored-by: Christian Brabandt <cb@256bit.org>
