### PR TITLE
vim-patch:9.1.0644: Unnecessary STRLEN() when applying mapping

### DIFF
--- a/test/old/testdir/test_mapping.vim
+++ b/test/old/testdir/test_mapping.vim
@@ -1694,11 +1694,11 @@ func Test_map_rhs_starts_with_lhs()
       endif
 
       let @a = 'foo'
-      call feedkeys("S\<C-R>a", 'tx')
+      call assert_nobeep('call feedkeys("S\<C-R>a", "tx")')
       call assert_equal('foo', getline('.'))
 
       let @a = 'bar'
-      call feedkeys("S\<*C-R>a", 'tx')
+      call assert_nobeep('call feedkeys("S\<*C-R>a", "tx")')
       call assert_equal('bar', getline('.'))
     endfor
   endfor


### PR DESCRIPTION
#### vim-patch:9.1.0644: Unnecessary STRLEN() when applying mapping

Problem:  Unnecessary STRLEN() when applying mapping.
          (after v9.1.0642)
Solution: Use m_keylen and vim_strnsave().
          (zeertzjq)

closes: vim/vim#15394

https://github.com/vim/vim/commit/74011dc1fa7bca6c901937173a42e0edce68e080