### PR TITLE
vim-patch:8.2.{1731,3264,4115},9.1.{partial:0411,0415,0419,partial:0445}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -3678,6 +3678,10 @@ static int eval_method(char **const arg, typval_T *const rettv, evalarg_T *const
   }
   xfree(tofree);
 
+  if (alias != NULL) {
+    xfree(alias);
+  }
+
   return ret;
 }
 
@@ -3815,7 +3819,7 @@ static int check_can_index(typval_T *rettv, bool evaluate, bool verbose)
 /// slice() function
 void f_slice(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  if (check_can_index(argvars, true, false) != OK) {
+  if (check_can_index(&argvars[0], true, false) != OK) {
     return;
   }
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -1519,7 +1519,14 @@ static char *get_lval_subscript(lval_T *lp, char *p, char *name, typval_T *rettv
         key = (char *)tv_get_string(&var1);  // is number or string
       }
       lp->ll_list = NULL;
+
+      // a NULL dict is equivalent with an empty dict
+      if (lp->ll_tv->vval.v_dict == NULL) {
+        lp->ll_tv->vval.v_dict = tv_dict_alloc();
+        lp->ll_tv->vval.v_dict->dv_refcount++;
+      }
       lp->ll_dict = lp->ll_tv->vval.v_dict;
+
       lp->ll_di = tv_dict_find(lp->ll_dict, key, len);
 
       // When assigning to a scope dictionary check that a function and

--- a/src/nvim/eval/executor.c
+++ b/src/nvim/eval/executor.c
@@ -21,6 +21,168 @@
 char *e_list_index_out_of_range_nr
   = N_("E684: List index out of range: %" PRId64);
 
+/// Handle "blob1 += blob2".
+/// Returns OK or FAIL.
+static int tv_op_blob(typval_T *tv1, const typval_T *tv2, const char *op)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (*op != '+' || tv2->v_type != VAR_BLOB) {
+    return FAIL;
+  }
+
+  // Blob += Blob
+  if (tv1->vval.v_blob == NULL || tv2->vval.v_blob == NULL) {
+    return OK;
+  }
+
+  blob_T *const b1 = tv1->vval.v_blob;
+  blob_T *const b2 = tv2->vval.v_blob;
+  const int len = tv_blob_len(b2);
+
+  for (int i = 0; i < len; i++) {
+    ga_append(&b1->bv_ga, tv_blob_get(b2, i));
+  }
+
+  return OK;
+}
+
+/// Handle "list1 += list2".
+/// Returns OK or FAIL.
+static int tv_op_list(typval_T *tv1, const typval_T *tv2, const char *op)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (*op != '+' || tv2->v_type != VAR_LIST) {
+    return FAIL;
+  }
+
+  // List += List
+  if (tv2->vval.v_list == NULL) {
+    return OK;
+  }
+
+  if (tv1->vval.v_list == NULL) {
+    tv1->vval.v_list = tv2->vval.v_list;
+    tv_list_ref(tv1->vval.v_list);
+  } else {
+    tv_list_extend(tv1->vval.v_list, tv2->vval.v_list, NULL);
+  }
+
+  return OK;
+}
+
+/// Handle number operations:
+///      nr += nr , nr -= nr , nr *=nr , nr /= nr , nr %= nr
+///
+/// Returns OK or FAIL.
+static int tv_op_number(typval_T *tv1, const typval_T *tv2, const char *op)
+  FUNC_ATTR_NONNULL_ALL
+{
+  varnumber_T n = tv_get_number(tv1);
+  if (tv2->v_type == VAR_FLOAT) {
+    float_T f = (float_T)n;
+    if (*op == '%') {
+      return FAIL;
+    }
+    switch (*op) {
+    case '+':
+      f += tv2->vval.v_float; break;
+    case '-':
+      f -= tv2->vval.v_float; break;
+    case '*':
+      f *= tv2->vval.v_float; break;
+    case '/':
+      f /= tv2->vval.v_float; break;
+    }
+    tv_clear(tv1);
+    tv1->v_type = VAR_FLOAT;
+    tv1->vval.v_float = f;
+  } else {
+    switch (*op) {
+    case '+':
+      n += tv_get_number(tv2); break;
+    case '-':
+      n -= tv_get_number(tv2); break;
+    case '*':
+      n *= tv_get_number(tv2); break;
+    case '/':
+      n = num_divide(n, tv_get_number(tv2)); break;
+    case '%':
+      n = num_modulus(n, tv_get_number(tv2)); break;
+    }
+    tv_clear(tv1);
+    tv1->v_type = VAR_NUMBER;
+    tv1->vval.v_number = n;
+  }
+
+  return OK;
+}
+
+/// Handle "str1 .= str2"
+/// Returns OK or FAIL.
+static int tv_op_string(typval_T *tv1, const typval_T *tv2, const char *op)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (tv2->v_type == VAR_FLOAT) {
+    return FAIL;
+  }
+
+  // str .= str
+  const char *tvs = tv_get_string(tv1);
+  char numbuf[NUMBUFLEN];
+  char *const s = concat_str(tvs, tv_get_string_buf(tv2, numbuf));
+  tv_clear(tv1);
+  tv1->v_type = VAR_STRING;
+  tv1->vval.v_string = s;
+
+  return OK;
+}
+
+/// Handle "tv1 += tv2", "tv1 -= tv2", "tv1 *= tv2", "tv1 /= tv2", "tv1 %= tv2"
+/// and "tv1 .= tv2"
+/// Returns OK or FAIL.
+static int tv_op_nr_or_string(typval_T *tv1, const typval_T *tv2, const char *op)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (tv2->v_type == VAR_LIST) {
+    return FAIL;
+  }
+
+  if (vim_strchr("+-*/%", (uint8_t)(*op)) != NULL) {
+    return tv_op_number(tv1, tv2, op);
+  }
+
+  return tv_op_string(tv1, tv2, op);
+}
+
+/// Handle "f1 += f2", "f1 -= f2", "f1 *= f2", "f1 /= f2".
+/// Returns OK or FAIL.
+static int tv_op_float(typval_T *tv1, const typval_T *tv2, const char *op)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (*op == '%' || *op == '.'
+      || (tv2->v_type != VAR_FLOAT
+          && tv2->v_type != VAR_NUMBER
+          && tv2->v_type != VAR_STRING)) {
+    return FAIL;
+  }
+
+  const float_T f = (tv2->v_type == VAR_FLOAT
+                     ? tv2->vval.v_float
+                     : (float_T)tv_get_number(tv2));
+  switch (*op) {
+  case '+':
+    tv1->vval.v_float += f; break;
+  case '-':
+    tv1->vval.v_float -= f; break;
+  case '*':
+    tv1->vval.v_float *= f; break;
+  case '/':
+    tv1->vval.v_float /= f; break;
+  }
+
+  return OK;
+}
+
 /// Handle tv1 += tv2, -=, *=, /=,  %=, .=
 ///
 /// @param[in,out]  tv1  First operand, modified typval.
@@ -29,131 +191,45 @@ char *e_list_index_out_of_range_nr
 ///
 /// @return OK or FAIL.
 int eexe_mod_op(typval_T *const tv1, const typval_T *const tv2, const char *const op)
-  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_NO_SANITIZE_UNDEFINED
+  FUNC_ATTR_NONNULL_ALL
 {
   // Can't do anything with a Funcref or Dict on the right.
   // v:true and friends only work with "..=".
-  if (tv2->v_type != VAR_FUNC && tv2->v_type != VAR_DICT
-      && ((tv2->v_type != VAR_BOOL && tv2->v_type != VAR_SPECIAL) || *op == '.')) {
-    switch (tv1->v_type) {
-    case VAR_DICT:
-    case VAR_FUNC:
-    case VAR_PARTIAL:
-    case VAR_BOOL:
-    case VAR_SPECIAL:
-      break;
-    case VAR_BLOB:
-      if (*op != '+' || tv2->v_type != VAR_BLOB) {
-        break;
-      }
-      // Blob += Blob
-      if (tv1->vval.v_blob != NULL && tv2->vval.v_blob != NULL) {
-        blob_T *const b1 = tv1->vval.v_blob;
-        blob_T *const b2 = tv2->vval.v_blob;
-        for (int i = 0; i < tv_blob_len(b2); i++) {
-          ga_append(&b1->bv_ga, tv_blob_get(b2, i));
-        }
-      }
-      return OK;
-    case VAR_LIST:
-      if (*op != '+' || tv2->v_type != VAR_LIST) {
-        break;
-      }
-      // List += List
-      if (tv2->vval.v_list != NULL) {
-        if (tv1->vval.v_list == NULL) {
-          tv1->vval.v_list = tv2->vval.v_list;
-          tv_list_ref(tv1->vval.v_list);
-        } else {
-          tv_list_extend(tv1->vval.v_list, tv2->vval.v_list, NULL);
-        }
-      }
-      return OK;
-    case VAR_NUMBER:
-    case VAR_STRING:
-      if (tv2->v_type == VAR_LIST) {
-        break;
-      }
-      if (vim_strchr("+-*/%", (uint8_t)(*op)) != NULL) {
-        // nr += nr  or  nr -= nr, nr *= nr, nr /= nr, nr %= nr
-        varnumber_T n = tv_get_number(tv1);
-        if (tv2->v_type == VAR_FLOAT) {
-          float_T f = (float_T)n;
-
-          if (*op == '%') {
-            break;
-          }
-          switch (*op) {
-          case '+':
-            f += tv2->vval.v_float; break;
-          case '-':
-            f -= tv2->vval.v_float; break;
-          case '*':
-            f *= tv2->vval.v_float; break;
-          case '/':
-            f /= tv2->vval.v_float; break;
-          }
-          tv_clear(tv1);
-          tv1->v_type = VAR_FLOAT;
-          tv1->vval.v_float = f;
-        } else {
-          switch (*op) {
-          case '+':
-            n += tv_get_number(tv2); break;
-          case '-':
-            n -= tv_get_number(tv2); break;
-          case '*':
-            n *= tv_get_number(tv2); break;
-          case '/':
-            n = num_divide(n, tv_get_number(tv2)); break;
-          case '%':
-            n = num_modulus(n, tv_get_number(tv2)); break;
-          }
-          tv_clear(tv1);
-          tv1->v_type = VAR_NUMBER;
-          tv1->vval.v_number = n;
-        }
-      } else {
-        // str .= str
-        if (tv2->v_type == VAR_FLOAT) {
-          break;
-        }
-        const char *tvs = tv_get_string(tv1);
-        char numbuf[NUMBUFLEN];
-        char *const s =
-          concat_str(tvs, tv_get_string_buf(tv2, numbuf));
-        tv_clear(tv1);
-        tv1->v_type = VAR_STRING;
-        tv1->vval.v_string = s;
-      }
-      return OK;
-    case VAR_FLOAT: {
-      if (*op == '%' || *op == '.'
-          || (tv2->v_type != VAR_FLOAT
-              && tv2->v_type != VAR_NUMBER
-              && tv2->v_type != VAR_STRING)) {
-        break;
-      }
-      const float_T f = (tv2->v_type == VAR_FLOAT
-                         ? tv2->vval.v_float
-                         : (float_T)tv_get_number(tv2));
-      switch (*op) {
-      case '+':
-        tv1->vval.v_float += f; break;
-      case '-':
-        tv1->vval.v_float -= f; break;
-      case '*':
-        tv1->vval.v_float *= f; break;
-      case '/':
-        tv1->vval.v_float /= f; break;
-      }
-      return OK;
-    }
-    case VAR_UNKNOWN:
-      abort();
-    }
+  if (tv2->v_type == VAR_FUNC || tv2->v_type == VAR_DICT
+      || ((tv2->v_type == VAR_BOOL || tv2->v_type == VAR_SPECIAL) && *op == '.')) {
+    semsg(_(e_letwrong), op);
+    return FAIL;
   }
 
-  semsg(_(e_letwrong), op);
-  return FAIL;
+  int retval = FAIL;
+
+  switch (tv1->v_type) {
+  case VAR_DICT:
+  case VAR_FUNC:
+  case VAR_PARTIAL:
+  case VAR_BOOL:
+  case VAR_SPECIAL:
+    break;
+  case VAR_BLOB:
+    retval = tv_op_blob(tv1, tv2, op);
+    break;
+  case VAR_LIST:
+    retval = tv_op_list(tv1, tv2, op);
+    break;
+  case VAR_NUMBER:
+  case VAR_STRING:
+    retval = tv_op_nr_or_string(tv1, tv2, op);
+    break;
+  case VAR_FLOAT:
+    retval = tv_op_float(tv1, tv2, op);
+    break;
+  case VAR_UNKNOWN:
+    abort();
+  }
+
+  if (retval != OK) {
+    semsg(_(e_letwrong), op);
+  }
+
+  return retval;
 }

--- a/src/nvim/eval/executor.c
+++ b/src/nvim/eval/executor.c
@@ -59,8 +59,13 @@ int eexe_mod_op(typval_T *const tv1, const typval_T *const tv2, const char *cons
         break;
       }
       // List += List
-      if (tv1->vval.v_list != NULL && tv2->vval.v_list != NULL) {
-        tv_list_extend(tv1->vval.v_list, tv2->vval.v_list, NULL);
+      if (tv2->vval.v_list != NULL) {
+        if (tv1->vval.v_list == NULL) {
+          tv1->vval.v_list = tv2->vval.v_list;
+          tv_list_ref(tv1->vval.v_list);
+        } else {
+          tv_list_extend(tv1->vval.v_list, tv2->vval.v_list, NULL);
+        }
       }
       return OK;
     case VAR_NUMBER:

--- a/src/nvim/eval/executor.c
+++ b/src/nvim/eval/executor.c
@@ -31,7 +31,13 @@ static int tv_op_blob(typval_T *tv1, const typval_T *tv2, const char *op)
   }
 
   // Blob += Blob
-  if (tv1->vval.v_blob == NULL || tv2->vval.v_blob == NULL) {
+  if (tv2->vval.v_blob == NULL) {
+    return OK;
+  }
+
+  if (tv1->vval.v_blob == NULL) {
+    tv1->vval.v_blob = tv2->vval.v_blob;
+    tv1->vval.v_blob->bv_refcount++;
     return OK;
   }
 

--- a/src/nvim/eval/executor.c
+++ b/src/nvim/eval/executor.c
@@ -31,9 +31,10 @@ char *e_list_index_out_of_range_nr
 int eexe_mod_op(typval_T *const tv1, const typval_T *const tv2, const char *const op)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_NO_SANITIZE_UNDEFINED
 {
-  // Can't do anything with a Funcref, a Dict or special value on the right.
+  // Can't do anything with a Funcref or Dict on the right.
+  // v:true and friends only work with "..=".
   if (tv2->v_type != VAR_FUNC && tv2->v_type != VAR_DICT
-      && tv2->v_type != VAR_BOOL && tv2->v_type != VAR_SPECIAL) {
+      && ((tv2->v_type != VAR_BOOL && tv2->v_type != VAR_SPECIAL) || *op == '.')) {
     switch (tv1->v_type) {
     case VAR_DICT:
     case VAR_FUNC:

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3880,12 +3880,17 @@ static varnumber_T indexof_blob(blob_T *b, varnumber_T startidx, typval_T *expr)
     }
   }
 
+  const int called_emsg_start = called_emsg;
   for (varnumber_T idx = startidx; idx < tv_blob_len(b); idx++) {
     set_vim_var_nr(VV_KEY, idx);
     set_vim_var_nr(VV_VAL, tv_blob_get(b, (int)idx));
 
     if (indexof_eval_expr(expr)) {
       return idx;
+    }
+
+    if (called_emsg != called_emsg_start) {
+      return -1;
     }
   }
 
@@ -3916,6 +3921,7 @@ static varnumber_T indexof_list(list_T *l, varnumber_T startidx, typval_T *expr)
     }
   }
 
+  const int called_emsg_start = called_emsg;
   for (; item != NULL; item = TV_LIST_ITEM_NEXT(l, item), idx++) {
     set_vim_var_nr(VV_KEY, idx);
     tv_copy(TV_LIST_ITEM_TV(item), get_vim_var_tv(VV_VAL));
@@ -3925,6 +3931,10 @@ static varnumber_T indexof_list(list_T *l, varnumber_T startidx, typval_T *expr)
 
     if (found) {
       return idx;
+    }
+
+    if (called_emsg != called_emsg_start) {
+      return -1;
     }
   }
 
@@ -3942,7 +3952,8 @@ static void f_indexof(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     return;
   }
 
-  if ((argvars[1].v_type == VAR_STRING && argvars[1].vval.v_string == NULL)
+  if ((argvars[1].v_type == VAR_STRING
+       && (argvars[1].vval.v_string == NULL || *argvars[1].vval.v_string == NUL))
       || (argvars[1].v_type == VAR_FUNC && argvars[1].vval.v_partial == NULL)) {
     return;
   }

--- a/test/functional/legacy/edit_spec.lua
+++ b/test/functional/legacy/edit_spec.lua
@@ -44,6 +44,12 @@ describe('edit', function()
       {1:~           }|*4
       =^           |
     ]])
+    feed([['r'<CR><Esc>]])
+    expect('r')
+    -- Test for inserting null and empty list
+    feed('a<C-R>=v:_null_list<CR><Esc>')
+    feed('a<C-R>=[]<CR><Esc>')
+    expect('r')
   end)
 
   -- oldtest: Test_edit_ctrl_r_failed()

--- a/test/old/testdir/test_autoload.vim
+++ b/test/old/testdir/test_autoload.vim
@@ -21,5 +21,4 @@ func Test_source_autoload()
   call assert_equal(1, g:loaded_sourced_vim)
 endfunc
 
-
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_blob.vim
+++ b/test/old/testdir/test_blob.vim
@@ -75,6 +75,13 @@ func Test_blob_assign()
       VAR l = [0z12]
       VAR m = deepcopy(l)
       LET m[0] = 0z34	#" E742 or E741 should not occur.
+
+      VAR blob1 = 0z10
+      LET blob1 += v:_null_blob
+      call assert_equal(0z10, blob1)
+      LET blob1 = v:_null_blob
+      LET blob1 += 0z20
+      call assert_equal(0z20, blob1)
   END
   call CheckLegacyAndVim9Success(lines)
 
@@ -330,6 +337,17 @@ func Test_blob_for_loop()
         LET i += 1
       endfor
       call assert_equal(5, i)
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  " Test for skipping the loop var assignment in a for loop
+  let lines =<< trim END
+    VAR blob = 0z998877
+    VAR c = 0
+    for _ in blob
+      LET c += 1
+    endfor
+    call assert_equal(3, c)
   END
   call CheckLegacyAndVim9Success(lines)
 endfunc
@@ -851,6 +869,7 @@ func Test_indexof()
   call assert_equal(-1, indexof(b, v:_null_string))
   " Nvim doesn't have null functions
   " call assert_equal(-1, indexof(b, test_null_function()))
+  call assert_equal(-1, indexof(b, ""))
 
   let b = 0z01020102
   call assert_equal(1, indexof(b, "v:val == 0x02", #{startidx: 0}))
@@ -862,6 +881,7 @@ func Test_indexof()
   " failure cases
   call assert_fails('let i = indexof(b, "val == 0xde")', 'E121:')
   call assert_fails('let i = indexof(b, {})', 'E1256:')
+  call assert_fails('let i = indexof(b, " ")', 'E15:')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -1973,6 +1973,11 @@ func Test_edit_insert_reg()
   let @r = 'sample'
   call feedkeys("a\<C-R>=SaveFirstLine()\<CR>", "xt")
   call assert_equal('"', g:Line)
+
+  " Test for inserting an null and an empty list
+  call feedkeys("a\<C-R>=test_null_list()\<CR>", "xt")
+  call feedkeys("a\<C-R>=[]\<CR>", "xt")
+  call assert_equal(['r'], getbufline('', 1, '$'))
   call test_override('ALL', 0)
   close!
 endfunc

--- a/test/old/testdir/test_fold.vim
+++ b/test/old/testdir/test_fold.vim
@@ -1497,6 +1497,35 @@ func Test_foldtext_in_modeline()
   delfunc ModelineFoldText
 endfunc
 
+" Test for setting 'foldexpr' from the modeline and executing the expression
+" in a sandbox
+func Test_foldexpr_in_modeline()
+  func ModelineFoldExpr()
+    call feedkeys('aFoo', 'xt')
+    return strlen(matchstr(getline(v:lnum),'^\s*'))
+  endfunc
+  let lines =<< trim END
+    aaa
+     bbb
+      ccc
+      ccc
+     bbb
+    aaa
+    " vim: foldenable foldmethod=expr foldexpr=ModelineFoldExpr()
+  END
+  call writefile(lines, 'Xmodelinefoldexpr', 'D')
+
+  set modeline modelineexpr
+  split Xmodelinefoldexpr
+
+  call assert_equal(2, foldlevel(3))
+  call assert_equal(lines, getbufline('', 1, '$'))
+
+  bw!
+  set modeline& modelineexpr&
+  delfunc ModelineFoldExpr
+endfunc
+
 " Make sure a fold containing a nested fold is split correctly when using
 " foldmethod=indent
 func Test_fold_split()

--- a/test/old/testdir/test_fold.vim
+++ b/test/old/testdir/test_fold.vim
@@ -1469,6 +1469,34 @@ func Test_foldtext_scriptlocal_func()
   delfunc s:FoldText
 endfunc
 
+" Test for setting 'foldtext' from the modeline and executing the expression
+" in a sandbox
+func Test_foldtext_in_modeline()
+  func ModelineFoldText()
+    call feedkeys('aFoo', 'xt')
+    return "folded text"
+  endfunc
+  let lines =<< trim END
+    func T()
+      let i = 1
+    endfunc
+    " vim: foldenable foldtext=ModelineFoldText()
+  END
+  call writefile(lines, 'Xmodelinefoldtext', 'D')
+
+  set modeline modelineexpr
+  split Xmodelinefoldtext
+
+  call cursor(1, 1)
+  normal! zf3j
+  call assert_equal('folded text', foldtextresult(1))
+  call assert_equal(lines, getbufline('', 1, '$'))
+
+  bw!
+  set modeline& modelineexpr&
+  delfunc ModelineFoldText
+endfunc
+
 " Make sure a fold containing a nested fold is split correctly when using
 " foldmethod=indent
 func Test_fold_split()

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -3731,6 +3731,8 @@ func Test_slice()
     call assert_equal('', 'ὰ̳β̳́γ̳̂δ̳̃ε̳̄ζ̳̅'->slice(1, -6))
   END
   call CheckLegacyAndVim9Success(lines)
+
+  call assert_equal(0, slice(v:true, 1))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_method.vim
+++ b/test/old/testdir/test_method.vim
@@ -134,6 +134,13 @@ func Test_method_syntax()
   call assert_fails('eval [1, 2, 3]-> sort()', 'E15:')
   call assert_fails('eval [1, 2, 3]->sort ()', 'E274:')
   call assert_fails('eval [1, 2, 3]-> sort ()', 'E15:')
+
+  " Test for using a method name containing a curly brace name
+  let s = 'len'
+  call assert_equal(4, "xxxx"->str{s}())
+
+  " Test for using a method in an interpolated string
+  call assert_equal('4', $'{"xxxx"->strlen()}')
 endfunc
 
 func Test_method_lambda()

--- a/test/old/testdir/test_partial.vim
+++ b/test/old/testdir/test_partial.vim
@@ -403,4 +403,18 @@ func Test_compare_partials()
   call assert_false(F1 is N1)
 endfunc
 
+func Test_partial_method()
+  func Foo(x, y, z)
+    return x + y + z
+  endfunc
+  let d = {"Fn": function('Foo', [10, 20])}
+  call assert_fails('echo 30->d.Fn()', 'E1265: Cannot use a partial here')
+  delfunc Foo
+endfunc
+
+func Test_non_callable_type_as_method()
+  let d = {"Fn": 10}
+  call assert_fails('echo 30->d.Fn()', 'E1085: Not a callable type: d.Fn')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_spellrare.vim
+++ b/test/old/testdir/test_spellrare.vim
@@ -11,15 +11,15 @@ func Test_spellrareword()
   " Create a small word list to test that spellbadword('...')
   " can return ['...', 'rare'].
   let lines =<< trim END
-     foo
-     foobar/?
-     foobara/?
-END
-   call writefile(lines, 'Xwords', 'D')
+    foo
+    foobar/?
+    foobara/?
+  END
+  call writefile(lines, 'Xwords', 'D')
 
-   mkspell! Xwords.spl Xwords
-   set spelllang=Xwords.spl
-   call assert_equal(['foobar', 'rare'], spellbadword('foo foobar'))
+  mkspell! Xwords.spl Xwords
+  set spelllang=Xwords.spl
+  call assert_equal(['foobar', 'rare'], spellbadword('foo foobar'))
 
   new
   call setline(1, ['foo', '', 'foo bar foo bar foobara foo foo foo foobar', '', 'End'])

--- a/test/old/testdir/test_substitute.vim
+++ b/test/old/testdir/test_substitute.vim
@@ -1507,4 +1507,18 @@ func Test_substitute_expr_recursive()
   exe bufnr .. "bw!"
 endfunc
 
+" Test for changing 'cpo' in a substitute expression
+func Test_substitute_expr_cpo()
+  func XSubExpr()
+    set cpo=
+    return 'x'
+  endfunc
+
+  let save_cpo = &cpo
+  call assert_equal('xxx', substitute('abc', '.', '\=XSubExpr()', 'g'))
+  call assert_equal(save_cpo, &cpo)
+
+  delfunc XSubExpr
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_vimscript.vim
+++ b/test/old/testdir/test_vimscript.vim
@@ -7450,12 +7450,13 @@ func Test_for_over_string()
   endfor
   call assert_equal('', res)
 
-  " Test for ignoring loop var assignment
-  let c = 0
-  for _ in 'abc'
-    let c += 1
+  " Test for using "_" as the loop variable
+  let i = 0
+  let s = 'abc'
+  for _ in s
+    call assert_equal(s[i], _)
+    let i += 1
   endfor
-  call assert_equal(3, c)
 endfunc
 
 " Test for deeply nested :source command  {{{1

--- a/test/old/testdir/test_vimscript.vim
+++ b/test/old/testdir/test_vimscript.vim
@@ -7449,6 +7449,13 @@ func Test_for_over_string()
     let res ..= c .. '-'
   endfor
   call assert_equal('', res)
+
+  " Test for ignoring loop var assignment
+  let c = 0
+  for _ in 'abc'
+    let c += 1
+  endfor
+  call assert_equal(3, c)
 endfunc
 
 " Test for deeply nested :source command  {{{1


### PR DESCRIPTION
#### vim-patch:8.2.1731: Vim9: cannot use += to append to empty NULL list

Problem:    Vim9: cannot use += to append to empty NULL list.
Solution:   Copy the list instead of extending it.

https://github.com/vim/vim/commit/81ed4960482f8baabdd7f95b4d5e39744be88ae7

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3264: Vim9: assign test fails

Problem:    Vim9: assign test fails.
Solution:   Add missing change.

https://github.com/vim/vim/commit/f24f51d03035379cf3e5b2dccf489a40bc4ca92a

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.4115: cannot use a method with a complex expression

Problem:    Cannot use a method with a complex expression.
Solution:   Evaluate the expression after "->" and use the result.

https://github.com/vim/vim/commit/c665dabdf4c49a0fbf1dc566253c75c2abe2effa

Cherry-pick a "verbose" check from patch 8.2.4123.

N/A patches for version.c:
vim-patch:8.2.4102: Vim9: import cannot be used after method
vim-patch:8.2.4110: Coverity warns for using NULL pointer

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:partial:9.1.0411: too long functions in eval.c

Problem:  too long functions in eval.c
Solution: refactor functions (Yegappan Lakshmanan)

closes: vim/vim#14755

https://github.com/vim/vim/commit/4ceb4dc825854032eed423ec1fc372317d3420bf

Skip the eval_expr_typval() changes.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.1.0415: Some functions are not tested

Problem:  Some functions are not tested
Solution: Add a few more tests, fix a few minor problems
          (Yegappan Lakshmanan)

closes: vim/vim#14789

https://github.com/vim/vim/commit/fe424d13ef6e5486923f23f15bb6951e3079412e

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.1.0419: eval.c not sufficiently tested

Problem:  eval.c not sufficiently tested
Solution: Add a few more additional tests for eval.c,
          (Yegappan Lakshmanan)

closes: vim/vim#14799

https://github.com/vim/vim/commit/4776e64e72de2976ff90b17d236e50e2b02c5540

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:partial:9.1.0445: Coverity warning after 9.1.0440

Problem:  Coverity warning after 9.1.0440
Solution: Fix Coverity warning, add a test and
          reduce the calls to clear_tv()
          (Yegappan Lakshmanan).

closes: vim/vim#14845

https://github.com/vim/vim/commit/dbac0da631c66869f41c3c573ad7a8cfef95964d

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>