### PR TITLE
vim-patch: update java syntax file and docs

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1660,6 +1660,16 @@ actually appear in Javadoc comments.  The variables to use are >
 	:let g:java_vb = 1
 Note that these three variables are maintained in the HTML syntax file.
 
+Numbers and strings can be recognized in non-Javadoc comments with >
+	:let g:java_comment_strings = 1
+
+Trailing whitespace characters or a run of space characters before a tab
+character can be marked as an error with >
+	:let g:java_space_errors = 1
+but either kind of an error can be suppressed by also defining one of >
+	:let g:java_no_trail_space_error = 1
+	:let g:java_no_tab_space_error = 1
+
 In order to highlight nested parens with different colors, define colors for
 `javaParen`, `javaParen1`, and `javaParen2`.  For example, >
 	:hi link javaParen Comment

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1559,23 +1559,23 @@ idlsyntax_showerror_soft	Use softer colours by default for errors
 
 JAVA						*java.vim* *ft-java-syntax*
 
-The java.vim syntax highlighting file offers several options:
+The java.vim syntax highlighting file offers several options.
 
-In Java 1.0.2 it was never possible to have braces inside parens, so this was
-flagged as an error.  Since Java 1.1 this is possible (with anonymous
-classes), and therefore is no longer marked as an error.  If you prefer the
-old way, put the following line into your vim startup file: >
-	:let java_mark_braces_in_parens_as_errors=1
+In Java 1.0.2, it was never possible to have braces inside parens, so this was
+flagged as an error.  Since Java 1.1, this is possible (with anonymous
+classes); and, therefore, is no longer marked as an error.  If you prefer the
+old way, put the following line into your Vim startup file: >
+	:let g:java_mark_braces_in_parens_as_errors = 1
 
-All identifiers in java.lang.* are always visible in all classes.  To
-highlight them use: >
-	:let java_highlight_java_lang_ids=1
+All (exported) public types declared in `java.lang` are always automatically
+imported and available as simple names.  To highlight them, use: >
+	:let g:java_highlight_java_lang_ids = 1
 
-You can also highlight identifiers of most standard Java packages if you
-download the javaid.vim script at https://www.fleiner.com/vim/download.html.
-If you prefer to only highlight identifiers of a certain package, say java.io
-use the following: >
-	:let java_highlight_java_io=1
+You can also highlight types of most standard Java packages if you download
+the javaid.vim script at https://www.fleiner.com/vim/download.html.  If you
+prefer to only highlight types of a certain package, say `java.io`, use the
+following: >
+	:let g:java_highlight_java_io = 1
 Check the javaid.vim file for a list of all the packages that are supported.
 
 Headers of indented function declarations can be highlighted (along with parts
@@ -1583,25 +1583,26 @@ of lambda expressions and method reference expressions), but it depends on how
 you write Java code.  Two formats are recognized:
 
 1) If you write function declarations that are consistently indented by either
-a tab, or a space . . . or eight space character(s), you may want to set >
-	:let java_highlight_functions="indent"
-	:let java_highlight_functions="indent1"
-	:let java_highlight_functions="indent2"
-	:let java_highlight_functions="indent3"
-	:let java_highlight_functions="indent4"
-	:let java_highlight_functions="indent5"
-	:let java_highlight_functions="indent6"
-	:let java_highlight_functions="indent7"
-	:let java_highlight_functions="indent8"
+a tab, or a space . . . or eight space character(s), you may want to set one
+of >
+	:let g:java_highlight_functions = "indent"
+	:let g:java_highlight_functions = "indent1"
+	:let g:java_highlight_functions = "indent2"
+	:let g:java_highlight_functions = "indent3"
+	:let g:java_highlight_functions = "indent4"
+	:let g:java_highlight_functions = "indent5"
+	:let g:java_highlight_functions = "indent6"
+	:let g:java_highlight_functions = "indent7"
+	:let g:java_highlight_functions = "indent8"
 Note that in terms of 'shiftwidth', this is the leftmost step of indentation.
 
 2) However, if you follow the Java guidelines about how functions and types
 are supposed to be named (with respect to upper- and lowercase) and there is
 any amount of indentation, you may want to set >
-	:let java_highlight_functions="style"
+	:let g:java_highlight_functions = "style"
 
-In addition, you can combine any value of "java_highlight_functions" with >
-	:let java_highlight_signature=1
+In addition, you can combine any value of "g:java_highlight_functions" with >
+	:let g:java_highlight_signature = 1
 to have the name of a function with its parameter list parens distinctly
 highlighted from its type parameters, return type, and formal parameters; and
 to have the parameter list parens of a lambda expression with its arrow
@@ -1614,54 +1615,61 @@ or compose new ones.
 Higher-order function types can be hard to parse by eye, so uniformly toning
 down some of their components may be of value.  Provided that such type names
 conform to the Java naming guidelines, you may arrange it with >
-	:let java_highlight_generics=1
+	:let g:java_highlight_generics = 1
 
-In Java 1.1 the functions System.out.println() and System.err.println() should
-only be used for debugging.  Therefore it is possible to highlight debugging
-statements differently.  To do this you must add the following definition in
-your startup file: >
-	:let java_highlight_debug=1
-The result will be that those statements are highlighted as 'Special'
-characters.  If you prefer to have them highlighted differently you must define
-new highlightings for the following groups.:
-    Debug, DebugSpecial, DebugString, DebugBoolean, DebugType
-which are used for the statement itself, special characters used in debug
-strings, strings, boolean constants and types (this, super) respectively.  I
-have opted to choose another background for those statements.
+In Java 1.1, the functions `System.out.println()` and `System.err.println()`
+should only be used for debugging.  Consider adding the following definition
+in your startup file: >
+	:let g:java_highlight_debug = 1
+to have the bulk of those statements colored as
+	`*Debug`	debugging statements,
+and to make some of their own items further grouped and linked:
+	`*Special`	as DebugSpecial,
+	`*String`	as DebugString,
+	`*Boolean`	as DebugBoolean,
+	`*Type`		as DebugType,
+which are used for special characters appearing in strings, strings proper,
+boolean literals, and special instance references (`super`, `this`, `null`),
+respectively.
 
 Javadoc is a program that takes special comments out of Java program files and
 creates HTML pages.  The standard configuration will highlight this HTML code
-similarly to HTML files (see |html.vim|).  You can even add Javascript
-and CSS inside this code (see below).  There are four differences however:
-  1. The title (all characters up to the first '.' which is followed by
-     some white space or up to the first '@') is colored differently (to change
-     the color change the group CommentTitle).
-  2. The text is colored as 'Comment'.
-  3. HTML comments are colored as 'Special'
-  4. The special Javadoc tags (@see, @param, ...) are highlighted as specials
-     and the argument (for @see, @param, @exception) as Function.
-To turn this feature off add the following line to your startup file: >
-	:let java_ignore_javadoc=1
+similarly to HTML files (see |html.vim|).  You can even add JavaScript and CSS
+inside this code (see below).  The HTML rendering diverges as follows:
+  1. The first sentence (all characters up to the first period `.`, which is
+     followed by a whitespace character or a line terminator, or up to the
+     first block tag, e.g. `@param`, `@return`) is colored as
+	*SpecialComment	special comments.
+  2. The text is colored as
+	`*Comment`	comments.
+  3. HTML comments are colored as
+	`*Special`	special symbols.
+  4. The standard Javadoc tags (`@code`, `@see`, etc.) are colored as
+	`*Special`	special symbols
+     and some of their arguments are colored as
+	`*Function`	function names.
+To turn this feature off, add the following line to your startup file: >
+	:let g:java_ignore_javadoc = 1
 
-If you use the special Javadoc comment highlighting described above you
-can also turn on special highlighting for Javascript, visual basic
-scripts and embedded CSS (stylesheets).  This makes only sense if you
-actually have Javadoc comments that include either Javascript or embedded
-CSS.  The options to use are >
-	:let java_javascript=1
-	:let java_css=1
-	:let java_vb=1
+If you use the special Javadoc comment highlighting described above, you can
+also turn on special highlighting for JavaScript, Visual Basic scripts, and
+embedded CSS (stylesheets).  This only makes sense if any of these languages
+actually appear in Javadoc comments.  The variables to use are >
+	:let g:java_javascript = 1
+	:let g:java_css = 1
+	:let g:java_vb = 1
+Note that these three variables are maintained in the HTML syntax file.
 
-In order to highlight nested parens with different colors define colors
-for javaParen, javaParen1 and javaParen2, for example with >
+In order to highlight nested parens with different colors, define colors for
+`javaParen`, `javaParen1`, and `javaParen2`.  For example, >
 	:hi link javaParen Comment
 or >
 	:hi javaParen ctermfg=blue guifg=#0000ff
 
 If you notice highlighting errors while scrolling backwards, which are fixed
-when redrawing with CTRL-L, try setting the "java_minlines" internal variable
-to a larger number: >
-	:let java_minlines = 50
+when redrawing with CTRL-L, try setting the "g:java_minlines" variable to
+a larger number: >
+	:let g:java_minlines = 50
 This will make the syntax synchronization start 50 lines before the first
 displayed line.  The default value is 10.  The disadvantage of using a larger
 number is that redrawing can become slow.

--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Aliaksei Budavei <0x000c70 AT gmail DOT com>
 " Former Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
-" Last Change:		2024 Jul 23
+" Last Change:		2024 Jul 30
 
 " Please check :help java.vim for comments on some of the options available.
 
@@ -309,6 +309,12 @@ hi def link javaCommentError javaError
 hi def link javaCommentStart javaComment
 
 if !exists("java_ignore_javadoc") && main_syntax != 'jsp'
+  " The overridable "html*" default links must be defined _before_ the
+  " inclusion of the same default links from "html.vim".
+  hi def link htmlComment	Special
+  hi def link htmlCommentPart	Special
+  hi def link htmlArg		Type
+  hi def link htmlString	String
   syntax case ignore
 
   " Include HTML syntax coloring for Javadoc comments.
@@ -601,10 +607,6 @@ hi def link javaCommentStar		javaComment
 hi def link javaType			Type
 hi def link javaExternal		Include
 
-hi def link htmlComment		Special
-hi def link htmlCommentPart		Special
-hi def link htmlArg			Type
-hi def link htmlString			String
 hi def link javaSpaceError		Error
 
 if s:module_info_cur_buf

--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -8,12 +8,12 @@
 " Please check :help java.vim for comments on some of the options available.
 
 " quit when a syntax file was already loaded
-if !exists("main_syntax")
+if !exists("g:main_syntax")
   if exists("b:current_syntax")
     finish
   endif
   " we define it here so that included files can test for it
-  let main_syntax='java'
+  let g:main_syntax = 'java'
 endif
 
 let s:cpo_save = &cpo
@@ -87,18 +87,18 @@ syn match   javaOperator	"\<var\>\%(\s*(\)\@!"
 " if necessary, on the line before that (h: \@<=), trying to match
 " neither a method reference nor a qualified method invocation.
 try
-  syn match   javaOperator	"\%(\%(::\|\.\)[[:space:]\n]*\)\@80<!\<yield\>"
+  syn match  javaOperator	"\%(\%(::\|\.\)[[:space:]\n]*\)\@80<!\<yield\>"
   let s:ff.Peek = s:ff.LeftConstant
 catch /\<E59:/
   call s:ReportOnce(v:exception)
-  syn match   javaOperator	"\%(\%(::\|\.\)[[:space:]\n]*\)\@<!\<yield\>"
+  syn match  javaOperator	"\%(\%(::\|\.\)[[:space:]\n]*\)\@<!\<yield\>"
   let s:ff.Peek = s:ff.RightConstant
 endtry
 
 syn keyword javaType		boolean char byte short int long float double
 syn keyword javaType		void
 syn keyword javaStatement	return
-syn keyword javaStorageClass	static synchronized transient volatile strictfp serializable
+syn keyword javaStorageClass	static synchronized transient volatile strictfp
 syn keyword javaExceptions	throw try catch finally
 syn keyword javaAssert		assert
 syn keyword javaMethodDecl	throws
@@ -113,7 +113,7 @@ syn match   javaAnnotation	"@\%(\K\k*\.\)*\K\k*\>"
 syn region  javaAnnotation	transparent matchgroup=javaAnnotationStart start=/@\%(\K\k*\.\)*\K\k*(/ end=/)/ skip=/\/\*.\{-}\*\/\|\/\/.*$/ contains=javaAnnotation,javaParenT,javaBlock,javaString,javaBoolean,javaNumber,javaTypedef,javaComment,javaLineComment
 syn match   javaClassDecl	"@interface\>"
 syn keyword javaBranch		break continue nextgroup=javaUserLabelRef skipwhite
-syn match   javaUserLabelRef	"\k\+" contained
+syn match   javaUserLabelRef	contained "\k\+"
 syn match   javaVarArg		"\.\.\."
 syn keyword javaScopeDecl	public protected private
 syn keyword javaConceptKind	abstract final
@@ -139,7 +139,7 @@ else
   let [s:ff.Engine, s:ff.UpperCase, s:ff.LowerCase] = repeat([s:ff.RightConstant], 3)
 endif
 
-if exists("java_highlight_signature")
+if exists("g:java_highlight_signature")
   let [s:ff.PeekTo, s:ff.PeekFrom, s:ff.GroupArgs] = repeat([s:ff.LeftConstant], 3)
 else
   let [s:ff.PeekTo, s:ff.PeekFrom, s:ff.GroupArgs] = repeat([s:ff.RightConstant], 3)
@@ -156,7 +156,7 @@ endif
 "
 " Note that false positives may elsewhere occur whenever an identifier
 " is butted against a less-than operator.  Cf. (X<Y) and (X < Y).
-if exists("java_highlight_generics")
+if exists("g:java_highlight_generics")
   syn keyword javaWildcardBound contained extends super
 
   " Parameterised types are delegated to javaGenerics (s:ctx.gsg) and
@@ -171,15 +171,15 @@ if exists("java_highlight_generics")
   endfor
 
   unlet s:ctx
-  hi def link javaWildcardBound Question
-  hi def link javaGenericsC1 javaFuncDef
-  hi def link javaGenericsC2 javaType
+  hi def link javaWildcardBound	Question
+  hi def link javaGenericsC1	javaFuncDef
+  hi def link javaGenericsC2	javaType
 endif
 
-if exists("java_highlight_java_lang_ids")
-  let java_highlight_all=1
+if exists("g:java_highlight_java_lang_ids")
+  let g:java_highlight_all = 1
 endif
-if exists("java_highlight_all")  || exists("java_highlight_java")  || exists("java_highlight_java_lang")
+if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("g:java_highlight_java_lang")
   " java.lang.*
   "
   " The keywords of javaR_JavaLang, javaC_JavaLang, javaE_JavaLang,
@@ -208,7 +208,7 @@ if exists("java_highlight_all")  || exists("java_highlight_java")  || exists("ja
   syn keyword javaC_JavaLang Boolean Character ClassLoader Compiler Double Float Integer Long Math Number Object Process Runtime SecurityManager String StringBuffer Thread ThreadGroup Byte Short Void Package RuntimePermission StrictMath StackTraceElement ProcessBuilder StringBuilder Module ModuleLayer StackWalker Record
   syn match   javaC_JavaLang "\<System\>"	" See javaDebug.
 
-  if !exists("java_highlight_generics")
+  if !exists("g:java_highlight_generics")
     " The non-interface parameterised names of java.lang members.
     exec 'syn match javaC_JavaLang "\%(\<Enum\.\)\@' . s:ff.Peek('5', '') . '<=\<EnumDesc\>"'
     syn keyword javaC_JavaLang Class InheritableThreadLocal ThreadLocal Enum ClassValue
@@ -229,10 +229,10 @@ if exists("java_highlight_all")  || exists("java_highlight_java")  || exists("ja
   hi def link javaC_Java javaC_
   hi def link javaE_Java javaE_
   hi def link javaX_Java javaX_
-  hi def link javaX_		     javaExceptions
-  hi def link javaR_		     javaExceptions
-  hi def link javaE_		     javaExceptions
-  hi def link javaC_		     javaConstant
+  hi def link javaX_ javaExceptions
+  hi def link javaR_ javaExceptions
+  hi def link javaE_ javaExceptions
+  hi def link javaC_ javaConstant
 
   syn keyword javaLangObject getClass notify notifyAll wait
 
@@ -251,12 +251,12 @@ if filereadable(expand("<sfile>:p:h") . "/javaid.vim")
   source <sfile>:p:h/javaid.vim
 endif
 
-if exists("java_space_errors")
-  if !exists("java_no_trail_space_error")
-    syn match	javaSpaceError	"\s\+$"
+if exists("g:java_space_errors")
+  if !exists("g:java_no_trail_space_error")
+    syn match javaSpaceError "\s\+$"
   endif
-  if !exists("java_no_tab_space_error")
-    syn match	javaSpaceError	" \+\t"me=e-1
+  if !exists("g:java_no_tab_space_error")
+    syn match javaSpaceError " \+\t"me=e-1
   endif
 endif
 
@@ -280,12 +280,12 @@ hi def link javaLabelNumber	javaNumber
 hi def link javaLabelCastType	javaType
 
 " Comments
-syn keyword javaTodo		 contained TODO FIXME XXX
+syn keyword javaTodo		contained TODO FIXME XXX
 
-if exists("java_comment_strings")
-  syn region  javaCommentString    contained start=+"+ end=+"+ end=+$+ end=+\*/+me=s-1,he=s-1 contains=javaSpecial,javaCommentStar,javaSpecialChar,@Spell
-  syn region  javaCommentString    contained start=+"""[ \t\x0c\r]*$+hs=e+1 end=+"""+he=s-1 contains=javaSpecial,javaCommentStar,javaSpecialChar,@Spell,javaSpecialError,javaTextBlockError
-  syn region  javaComment2String   contained start=+"+ end=+$\|"+ contains=javaSpecial,javaSpecialChar,@Spell
+if exists("g:java_comment_strings")
+  syn region  javaCommentString	contained start=+"+ end=+"+ end=+$+ end=+\*/+me=s-1,he=s-1 contains=javaSpecial,javaCommentStar,javaSpecialChar,@Spell
+  syn region  javaCommentString	contained start=+"""[ \t\x0c\r]*$+hs=e+1 end=+"""+he=s-1 contains=javaSpecial,javaCommentStar,javaSpecialChar,@Spell,javaSpecialError,javaTextBlockError
+  syn region  javaComment2String contained start=+"+ end=+$\|"+ contains=javaSpecial,javaSpecialChar,@Spell
   syn match   javaCommentCharacter contained "'\\[^']\{1,6\}'" contains=javaSpecialChar
   syn match   javaCommentCharacter contained "'\\''" contains=javaSpecialChar
   syn match   javaCommentCharacter contained "'[^\\]'"
@@ -293,9 +293,9 @@ if exists("java_comment_strings")
   syn cluster javaCommentSpecial2 add=javaComment2String,javaCommentCharacter,javaNumber,javaStrTempl
 endif
 
-syn region  javaComment		 matchgroup=javaCommentStart start="/\*" end="\*/" contains=@javaCommentSpecial,javaTodo,javaCommentError,javaSpaceError,@Spell fold
-syn match   javaCommentStar	 contained "^\s*\*[^/]"me=e-1
-syn match   javaCommentStar	 contained "^\s*\*$"
+syn region  javaComment		matchgroup=javaCommentStart start="/\*" end="\*/" contains=@javaCommentSpecial,javaTodo,javaCommentError,javaSpaceError,@Spell fold
+syn match   javaCommentStar	contained "^\s*\*[^/]"me=e-1
+syn match   javaCommentStar	contained "^\s*\*$"
 syn match   javaLineComment	"//.*" contains=@javaCommentSpecial2,javaTodo,javaCommentMarkupTag,javaSpaceError,@Spell
 syn match   javaCommentMarkupTag contained "@\%(end\|highlight\|link\|replace\|start\)\>" nextgroup=javaCommentMarkupTagAttr,javaSpaceError skipwhite
 syn match   javaCommentMarkupTagAttr contained "\<region\>" nextgroup=javaCommentMarkupTagAttr,javaSpaceError skipwhite
@@ -308,7 +308,7 @@ syn match   javaCommentError contained "/\*"me=e-1 display
 hi def link javaCommentError javaError
 hi def link javaCommentStart javaComment
 
-if !exists("java_ignore_javadoc") && main_syntax != 'jsp'
+if !exists("g:java_ignore_javadoc") && g:main_syntax != 'jsp'
   " The overridable "html*" default links must be defined _before_ the
   " inclusion of the same default links from "html.vim".
   hi def link htmlComment	Special
@@ -349,42 +349,42 @@ if !exists("java_ignore_javadoc") && main_syntax != 'jsp'
 endif
 
 " match the special comment /**/
-syn match   javaComment		 "/\*\*/"
+syn match   javaComment		"/\*\*/"
 
 " Strings and constants
-syn match   javaSpecialError	 contained "\\."
+syn match   javaSpecialError	contained "\\."
 syn match   javaSpecialCharError contained "[^']"
 " Escape Sequences (JLS-17, §3.10.7):
-syn match   javaSpecialChar	 contained "\\\%(u\x\x\x\x\|[0-3]\o\o\|\o\o\=\|[bstnfr"'\\]\)"
+syn match   javaSpecialChar	contained "\\\%(u\x\x\x\x\|[0-3]\o\o\|\o\o\=\|[bstnfr"'\\]\)"
 syn region  javaString		start=+"+ end=+"+ end=+$+ contains=javaSpecialChar,javaSpecialError,@Spell
 syn region  javaString		start=+"""[ \t\x0c\r]*$+hs=e+1 end=+"""+he=s-1 contains=javaSpecialChar,javaSpecialError,javaTextBlockError,@Spell
 syn match   javaTextBlockError	+"""\s*"""+
-syn region  javaStrTemplEmbExp	 contained matchgroup=javaStrTempl start="\\{" end="}" contains=TOP
+syn region  javaStrTemplEmbExp	contained matchgroup=javaStrTempl start="\\{" end="}" contains=TOP
 exec 'syn region javaStrTempl start=+\%(\.[[:space:]\n]*\)\@' . s:ff.Peek('80', '') . '<="+ end=+"+ contains=javaStrTemplEmbExp,javaSpecialChar,javaSpecialError,@Spell'
 exec 'syn region javaStrTempl start=+\%(\.[[:space:]\n]*\)\@' . s:ff.Peek('80', '') . '<="""[ \t\x0c\r]*$+hs=e+1 end=+"""+he=s-1 contains=javaStrTemplEmbExp,javaSpecialChar,javaSpecialError,javaTextBlockError,@Spell'
-syn match   javaCharacter	 "'[^']*'" contains=javaSpecialChar,javaSpecialCharError
-syn match   javaCharacter	 "'\\''" contains=javaSpecialChar
-syn match   javaCharacter	 "'[^\\]'"
+syn match   javaCharacter	"'[^']*'" contains=javaSpecialChar,javaSpecialCharError
+syn match   javaCharacter	"'\\''" contains=javaSpecialChar
+syn match   javaCharacter	"'[^\\]'"
 " Integer literals (JLS-17, §3.10.1):
-syn keyword javaNumber		 0 0l 0L
-syn match   javaNumber		 "\<\%(0\%([xX]\x\%(_*\x\)*\|_*\o\%(_*\o\)*\|[bB][01]\%(_*[01]\)*\)\|[1-9]\%(_*\d\)*\)[lL]\=\>"
+syn keyword javaNumber		0 0l 0L
+syn match   javaNumber		"\<\%(0\%([xX]\x\%(_*\x\)*\|_*\o\%(_*\o\)*\|[bB][01]\%(_*[01]\)*\)\|[1-9]\%(_*\d\)*\)[lL]\=\>"
 " Decimal floating-point literals (JLS-17, §3.10.2):
 " Against "\<\d\+\>\.":
-syn match   javaNumber		 "\<\d\%(_*\d\)*\."
-syn match   javaNumber		 "\%(\<\d\%(_*\d\)*\.\%(\d\%(_*\d\)*\)\=\|\.\d\%(_*\d\)*\)\%([eE][-+]\=\d\%(_*\d\)*\)\=[fFdD]\=\>"
-syn match   javaNumber		 "\<\d\%(_*\d\)*[eE][-+]\=\d\%(_*\d\)*[fFdD]\=\>"
-syn match   javaNumber		 "\<\d\%(_*\d\)*\%([eE][-+]\=\d\%(_*\d\)*\)\=[fFdD]\>"
+syn match   javaNumber		"\<\d\%(_*\d\)*\."
+syn match   javaNumber		"\%(\<\d\%(_*\d\)*\.\%(\d\%(_*\d\)*\)\=\|\.\d\%(_*\d\)*\)\%([eE][-+]\=\d\%(_*\d\)*\)\=[fFdD]\=\>"
+syn match   javaNumber		"\<\d\%(_*\d\)*[eE][-+]\=\d\%(_*\d\)*[fFdD]\=\>"
+syn match   javaNumber		"\<\d\%(_*\d\)*\%([eE][-+]\=\d\%(_*\d\)*\)\=[fFdD]\>"
 " Hexadecimal floating-point literals (JLS-17, §3.10.2):
-syn match   javaNumber		 "\<0[xX]\%(\x\%(_*\x\)*\.\=\|\%(\x\%(_*\x\)*\)\=\.\x\%(_*\x\)*\)[pP][-+]\=\d\%(_*\d\)*[fFdD]\=\>"
+syn match   javaNumber		"\<0[xX]\%(\x\%(_*\x\)*\.\=\|\%(\x\%(_*\x\)*\)\=\.\x\%(_*\x\)*\)[pP][-+]\=\d\%(_*\d\)*[fFdD]\=\>"
 
 " Unicode characters
 syn match   javaSpecial "\\u\x\x\x\x"
 
 " Method declarations (JLS-17, §8.4.3, §8.4.4, §9.4).
-if exists("java_highlight_functions")
+if exists("g:java_highlight_functions")
   syn cluster javaFuncParams contains=javaAnnotation,@javaClasses,javaGenerics,javaType,javaVarArg,javaComment,javaLineComment
 
-  if exists("java_highlight_signature")
+  if exists("g:java_highlight_signature")
     syn keyword javaParamModifier contained final
     syn cluster javaFuncParams add=javaParamModifier
     hi def link javaParamModifier javaConceptKind
@@ -393,8 +393,8 @@ if exists("java_highlight_functions")
     syn cluster javaFuncParams add=javaScopeDecl,javaConceptKind,javaStorageClass,javaExternal
   endif
 
-  if java_highlight_functions =~# '^indent[1-8]\=$'
-    let s:last = java_highlight_functions[-1 :]
+  if g:java_highlight_functions =~# '^indent[1-8]\=$'
+    let s:last = g:java_highlight_functions[-1 :]
     let s:indent = s:last != 't' ? repeat("\x20", s:last) : "\t"
     " Try to not match other type members, initialiser blocks, enum
     " constants (JLS-17, §8.9.1), and constructors (JLS-17, §8.1.7):
@@ -430,10 +430,10 @@ if exists("java_highlight_functions")
   endif
 endif
 
-if exists("java_highlight_debug")
+if exists("g:java_highlight_debug")
   " Strings and constants
   syn match   javaDebugSpecial		contained "\\\%(u\x\x\x\x\|[0-3]\o\o\|\o\o\=\|[bstnfr"'\\]\)"
-  syn region  javaDebugString		contained start=+"+  end=+"+  contains=javaDebugSpecial
+  syn region  javaDebugString		contained start=+"+ end=+"+ contains=javaDebugSpecial
   syn region  javaDebugString		contained start=+"""[ \t\x0c\r]*$+hs=e+1 end=+"""+he=s-1 contains=javaDebugSpecial,javaDebugTextBlockError
   " The highlight groups of java{StrTempl,Debug{,Paren,StrTempl}}\,
   " share one colour by default. Do not conflate unrelated parens.
@@ -453,7 +453,7 @@ if exists("java_highlight_debug")
   syn match   javaDebugNumber		contained "\<0[xX]\%(\x\%(_*\x\)*\.\=\|\%(\x\%(_*\x\)*\)\=\.\x\%(_*\x\)*\)[pP][-+]\=\d\%(_*\d\)*[fFdD]\=\>"
   syn keyword javaDebugBoolean		contained true false
   syn keyword javaDebugType		contained null this super
-  syn region javaDebugParen  start=+(+ end=+)+ contained contains=javaDebug.*,javaDebugParen
+  syn region  javaDebugParen		contained start=+(+ end=+)+ contains=javaDebug.*,javaDebugParen
 
   " To make this work, define the highlighting for these groups.
   syn match javaDebug "\<System\.\%(out\|err\)\.print\%(ln\)\=\s*("me=e-1 contains=javaDebug.* nextgroup=javaDebugParen
@@ -463,53 +463,53 @@ if exists("java_highlight_debug")
 " FIXME: What API do "trace*" belong to?
 " syn match javaDebug "\<trace[SL]\=\s*("me=e-1 contains=javaDebug.* nextgroup=javaDebugParen
 
-  hi def link javaDebug		 Debug
-  hi def link javaDebugString		 DebugString
-  hi def link javaDebugStrTempl		 Macro
-  hi def link javaDebugTextBlockError	 Error
-  hi def link javaDebugType		 DebugType
-  hi def link javaDebugBoolean		 DebugBoolean
-  hi def link javaDebugNumber		 Debug
-  hi def link javaDebugSpecial		 DebugSpecial
-  hi def link javaDebugSpecialCharacter DebugSpecial
-  hi def link javaDebugCharacter	 DebugString
-  hi def link javaDebugParen		 Debug
+  hi def link javaDebug			Debug
+  hi def link javaDebugString		DebugString
+  hi def link javaDebugStrTempl		Macro
+  hi def link javaDebugTextBlockError	Error
+  hi def link javaDebugType		DebugType
+  hi def link javaDebugBoolean		DebugBoolean
+  hi def link javaDebugNumber		Debug
+  hi def link javaDebugSpecial		DebugSpecial
+  hi def link javaDebugSpecialCharacter	DebugSpecial
+  hi def link javaDebugCharacter	DebugString
+  hi def link javaDebugParen		Debug
 
-  hi def link DebugString		 String
-  hi def link DebugSpecial		 Special
-  hi def link DebugBoolean		 Boolean
-  hi def link DebugType		 Type
+  hi def link DebugString		String
+  hi def link DebugSpecial		Special
+  hi def link DebugBoolean		Boolean
+  hi def link DebugType			Type
 endif
 
 " Try not to fold top-level-type bodies under assumption that there is
 " but one such body.
 exec 'syn region javaBlock transparent start="\%(^\|^\S[^:]\+\)\@' . s:ff.Peek('120', '') . '<!{" end="}" fold'
 
-if exists("java_mark_braces_in_parens_as_errors")
+if exists("g:java_mark_braces_in_parens_as_errors")
   syn match javaInParen contained "[{}]"
   hi def link javaInParen javaError
 endif
 
 " catch errors caused by wrong parenthesis
-syn region  javaParenT	transparent matchgroup=javaParen  start="(" end=")" contains=@javaTop,javaInParen,javaParenT1
-syn region  javaParenT1 transparent matchgroup=javaParen1 start="(" end=")" contains=@javaTop,javaInParen,javaParenT2 contained
-syn region  javaParenT2 transparent matchgroup=javaParen2 start="(" end=")" contains=@javaTop,javaInParen,javaParenT contained
-syn match   javaParenError	 ")"
+syn region  javaParenT	transparent matchgroup=javaParen start="(" end=")" contains=@javaTop,javaInParen,javaParenT1
+syn region  javaParenT1 contained transparent matchgroup=javaParen1 start="(" end=")" contains=@javaTop,javaInParen,javaParenT2
+syn region  javaParenT2 contained transparent matchgroup=javaParen2 start="(" end=")" contains=@javaTop,javaInParen,javaParenT
+syn match   javaParenError ")"
 " catch errors caused by wrong square parenthesis
-syn region  javaParenT	transparent matchgroup=javaParen  start="\[" end="\]" contains=@javaTop,javaParenT1
-syn region  javaParenT1 transparent matchgroup=javaParen1 start="\[" end="\]" contains=@javaTop,javaParenT2 contained
-syn region  javaParenT2 transparent matchgroup=javaParen2 start="\[" end="\]" contains=@javaTop,javaParenT  contained
-syn match   javaParenError	 "\]"
+syn region  javaParenT	transparent matchgroup=javaParen start="\[" end="\]" contains=@javaTop,javaParenT1
+syn region  javaParenT1 contained transparent matchgroup=javaParen1 start="\[" end="\]" contains=@javaTop,javaParenT2
+syn region  javaParenT2 contained transparent matchgroup=javaParen2 start="\[" end="\]" contains=@javaTop,javaParenT
+syn match   javaParenError "\]"
 
-hi def link javaParenError	javaError
+hi def link javaParenError javaError
 
-" Lambda expressions (JLS-17, §15.27) and method references (JLS-17,
-" §15.13).
-if exists("java_highlight_functions")
+" Lambda expressions (JLS-17, §15.27) and method reference expressions
+" (JLS-17, §15.13).
+if exists("g:java_highlight_functions")
   syn match javaMethodRef ":::\@!"
   hi def link javaMethodRef javaFuncDef
 
-  if exists("java_highlight_signature")
+  if exists("g:java_highlight_signature")
     let s:ff.LambdaDef = s:ff.LeftConstant
   else
     let s:ff.LambdaDef = s:ff.RightConstant
@@ -543,8 +543,8 @@ endif
 " Note that the syntax file "aidl.vim" relies on its availability.
 syn cluster javaTop contains=TOP,javaTopEnumDeclaration
 
-if !exists("java_minlines")
-  let java_minlines = 10
+if !exists("g:java_minlines")
+  let g:java_minlines = 10
 endif
 
 " Note that variations of a /*/ balanced comment, e.g., /*/*/, /*//*/,
@@ -553,7 +553,7 @@ endif
 " to make synchronisation start further towards file's beginning by
 " bumping up g:java_minlines or issuing ':syntax sync fromstart' or
 " preferring &foldmethod set to 'syntax'.
-exec "syn sync ccomment javaComment minlines=" . java_minlines
+exec "syn sync ccomment javaComment minlines=" . g:java_minlines
 
 " The default highlighting.
 hi def link javaLambdaDef		Function
@@ -574,8 +574,8 @@ hi def link javaClassDecl		javaStorageClass
 hi def link javaScopeDecl		javaStorageClass
 hi def link javaConceptKind		NonText
 
-hi def link javaBoolean		Boolean
-hi def link javaSpecial		Special
+hi def link javaBoolean			Boolean
+hi def link javaSpecial			Special
 hi def link javaSpecialError		Error
 hi def link javaSpecialCharError	Error
 hi def link javaString			String
@@ -587,17 +587,17 @@ hi def link javaError			Error
 hi def link javaTextBlockError		Error
 hi def link javaStatement		Statement
 hi def link javaOperator		Operator
-hi def link javaComment		Comment
+hi def link javaComment			Comment
 hi def link javaDocComment		Comment
 hi def link javaLineComment		Comment
 hi def link javaConstant		Constant
-hi def link javaTypedef		Typedef
+hi def link javaTypedef			Typedef
 hi def link javaTodo			Todo
 hi def link javaAnnotation		PreProc
 hi def link javaAnnotationStart		javaAnnotation
 
 hi def link javaCommentTitle		SpecialComment
-hi def link javaDocTags		Special
+hi def link javaDocTags			Special
 hi def link javaDocCodeTag		Special
 hi def link javaDocSnippetTag		Special
 hi def link javaDocParam		Function
@@ -617,8 +617,8 @@ endif
 
 let b:current_syntax = "java"
 
-if main_syntax == 'java'
-  unlet main_syntax
+if g:main_syntax == 'java'
+  unlet g:main_syntax
 endif
 
 let b:spell_options = "contained"


### PR DESCRIPTION
- **vim-patch:3749dff: runtime(java): Tidy up the documentation for "ft-java-syntax"**
- **vim-patch:9aabcef: runtime(java): Tidy up the syntax file**
- **vim-patch:77b87c3: runtime(java): Cluster optional group definitions and their group links**
- **vim-patch:30a8ad6: runtime(java): Document "g:java_space_errors" and "g:java_comment_strings"**
