### PR TITLE
fix(ui): prevent xdg-open subprocess from failing due to closed file descriptors

### DIFF
--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -140,6 +140,9 @@ function M.open(path)
   end
 
   local cmd --- @type string[]
+  local opts --- @type { [string]: boolean }
+
+  opts = { text = true, detach = true }
 
   if vim.fn.has('mac') == 1 then
     cmd = { 'open', path }
@@ -155,11 +158,13 @@ function M.open(path)
     cmd = { 'explorer.exe', path }
   elseif vim.fn.executable('xdg-open') == 1 then
     cmd = { 'xdg-open', path }
+    opts.stdout = false
+    opts.stderr = false
   else
     return nil, 'vim.ui.open: no handler found (tried: wslview, explorer.exe, xdg-open)'
   end
 
-  return vim.system(cmd, { text = true, detach = true }), nil
+  return vim.system(cmd, opts), nil
 end
 
 --- Gets the URL at cursor, if any.

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -140,7 +140,7 @@ function M.open(path)
   end
 
   local cmd --- @type string[]
-  local opts --- @type { [string]: boolean }
+  local opts --- @type vim.SystemOpts
 
   opts = { text = true, detach = true }
 


### PR DESCRIPTION
Problem: per https://github.com/neovim/neovim/issues/29932#issue-2440957530 when using `vim.ui.open` on linux systems, calls to `xdg-open` return before the subprocess it creates (launching xyz browser, etc.) is done using the file descriptors it's given. As the underlying `vim.system` closes the file descriptors once `xdg-open` returns, this causes the launched subprocess to crash if it attempts to write to stdout or stderr.

Solution: give `xdg-open` /dev/null as the file descriptor for stdout and stderr

Resolves #29932 