### PR TITLE
vim-patch:8.2.4275: cannot use an autoload function from a package under start

### DIFF
--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -2857,7 +2857,7 @@ bool script_autoload(const char *const name, const size_t name_len, const bool r
     // Try loading the package from $VIMRUNTIME/autoload/<name>.vim
     // Use "ret_sid" to avoid loading the same script again.
     int ret_sid;
-    if (do_in_runtimepath(scriptname, 0, source_callback, &ret_sid) == OK) {
+    if (do_in_runtimepath(scriptname, DIP_START, source_callback, &ret_sid) == OK) {
       ret = true;
     }
   }

--- a/test/old/testdir/test_packadd.vim
+++ b/test/old/testdir/test_packadd.vim
@@ -258,6 +258,19 @@ func Test_packloadall()
   call assert_equal(4321, g:plugin_bar_number)
 endfunc
 
+func Test_start_autoload()
+  " plugin foo with an autoload directory
+  let autodir = &packpath .. '/pack/mine/start/foo/autoload'
+  call mkdir(autodir, 'p')
+  let fname = autodir .. '/foobar.vim'
+  call writefile(['func foobar#test()',
+	\ '  return 1666',
+	\ 'endfunc'], fname)
+
+  call assert_equal(1666, foobar#test())
+  call delete(fname)
+endfunc
+
 func Test_helptags()
   let docdir1 = &packpath . '/pack/mine/start/foo/doc'
   let docdir2 = &packpath . '/pack/mine/start/bar/doc'


### PR DESCRIPTION
#### vim-patch:8.2.4275: cannot use an autoload function from a package under start

Problem:    Cannot use an autoload function from a package under start.
Solution:   Also look in the "start" package directory. (Bjorn Linse,
            closes vim/vim#7193)

https://github.com/vim/vim/commit/223a950a85448253780da4e821a5b23dcdfad28f

Nvim already does this in do_in_cached_path(), and this change has no
effect in Nvim as Nvim removes DIP_START after do_in_cached_path().

Accidentally failed to mark as ported:
vim-patch:8.2.1731: Vim9: cannot use += to append to empty NULL list

Co-authored-by: bfredl <bjorn.linse@gmail.com>