### PR TITLE
vim-patch:5b07213: runtime(doc): re-format tag example lines, mention ctags --list-kinds

### DIFF
--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -565,12 +565,12 @@ ctags).
 {term}		;" The two characters semicolon and double quote.  This is
 		interpreted by Vi as the start of a comment, which makes the
 		following be ignored.  This is for backwards compatibility
-		with Vi, it ignores the following fields. Example:
+		with Vi, it ignores the following fields. Example: >
 			APP	file	/^static int APP;$/;"	v
-		When {tagaddress} is not a line number or search pattern, then
+<		When {tagaddress} is not a line number or search pattern, then
 		{term} must be `|;"`.  Here the bar ends the command (excluding
 		the bar) and `;"` is used to have Vi ignore the rest of the
-		line.  Example:
+		line.  Example: >
 			APP	file.c	call cursor(3, 4)|;"	v
 
 {field} ..	A list of optional fields.  Each field has the form:
@@ -588,7 +588,9 @@ ctags).
 
 		There is one field that doesn't have a ':'.  This is the kind
 		of the tag.  It is handled like it was preceded with "kind:".
-		See the documentation of ctags for the kinds it produces.
+		In the above example, this was "kind:v" (typically variable).
+		See the documentation of ctags for the kinds it produces, with
+		ctags you can use `ctags --list-kinds` .
 
 		The only other field currently recognized by Vim is "file:"
 		(with an empty value).  It is used for a static tag.
@@ -633,14 +635,14 @@ If the command is a normal search command (it starts and ends with "/" or
   The direction of the search is forward for "/", backward for "?".
   Note that 'wrapscan' does not matter, the whole file is always searched.
 - If the search fails, another try is done ignoring case.  If that fails too,
-  a search is done for:
+  a search is done for: >
 	"^tagname[ \t]*("
-  (the tag with '^' prepended and "[ \t]*(" appended).  When using function
+<  (the tag with '^' prepended and "[ \t]*(" appended).  When using function
   names, this will find the function name when it is in column 0.  This will
   help when the arguments to the function have changed since the tags file was
-  made.  If this search also fails another search is done with:
+  made.  If this search also fails another search is done with: >
 	"^[#a-zA-Z_].*\<tagname[ \t]*("
-  This means: A line starting with '#' or an identifier and containing the tag
+<  This means: A line starting with '#' or an identifier and containing the tag
   followed by white space and a '('.  This will find macro names and function
   names with a type prepended.
 


### PR DESCRIPTION
#### vim-patch:5b07213: runtime(doc): re-format tag example lines, mention ctags --list-kinds

https://github.com/vim/vim/commit/5b07213c0b365f2a7fcdd10c7e7cd00aae3560a5

Co-authored-by: Christian Brabandt <cb@256bit.org>