### PR TITLE
build(vim-patch.sh): use 7 hex digits for runtime patch file name

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -156,7 +156,7 @@ assign_commit_details() {
     local munge_commit_line=true
   else
     # Interpret parameter as commit hash.
-    vim_version="${1:0:12}"
+    vim_version="${1:0:7}"
     vim_tag=
     vim_commit_ref="$vim_version"
     local munge_commit_line=false


### PR DESCRIPTION
7 digits are used in commit message, so also using this in patch file
name allows its proper deletion on PR creation.
