### PR TITLE
vim-patch:9.1.0650: Coverity warning in cstrncmp()

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1743,7 +1743,7 @@ static int cstrncmp(char *s1, char *s2, int *n)
     result = strncmp(s1, s2, (size_t)(*n));
   } else {
     char *p = s1;
-    size_t n2 = 0;
+    int n2 = 0;
     int n1 = *n;
     // count the number of characters for byte-length of s1
     while (n1 > 0 && *p != NUL) {
@@ -1757,11 +1757,11 @@ static int cstrncmp(char *s1, char *s2, int *n)
       MB_PTR_ADV(p);
     }
 
-    n2 = (size_t)(p - s2);
+    n2 = (int)(p - s2);
 
-    result = utf_strnicmp(s1, s2, (size_t)(*n), n2);
-    if (result == 0 && (int)n2 < *n) {
-      *n = (int)n2;
+    result = utf_strnicmp(s1, s2, (size_t)(*n), (size_t)n2);
+    if (result == 0 && n2 < *n) {
+      *n = n2;
     }
   }
 


### PR DESCRIPTION
#### vim-patch:9.1.0650: Coverity warning in cstrncmp()

Problem:  Coverity warning in cstrncmp()
          (after v9.1.0645)
Solution: Change the type of n2 to int.
          (zeertzjq)

________________________________________________________________________________________________________
*** CID 1615684:  Integer handling issues  (INTEGER_OVERFLOW)
/src/regexp.c: 1757 in cstrncmp()
1751                 n1 -= mb_ptr2len(s1);
1752                 MB_PTR_ADV(p);
1753                 n2++;
1754             }
1755             // count the number of bytes to advance the same number of chars for s2
1756             p = s2;
>>>     CID 1615684:  Integer handling issues  (INTEGER_OVERFLOW)
>>>     Expression "n2--", which is equal to 18446744073709551615, where "n2" is known to be equal to 0, underflows the type that receives it, an unsigned integer 64 bits wide.
1757             while (n2-- > 0 && *p != NUL)
1758                 MB_PTR_ADV(p);
1759
1760             n2 = p - s2;
1761
1762             result = MB_STRNICMP2(s1, s2, *n, n2);

closes: vim/vim#15409

https://github.com/vim/vim/commit/e8feaa354e685e527198093904492f67c52c2302