### PR TITLE
vim-patch:9.1.0651: ex: trailing dot is optional for :g and :insert/:append

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2781,7 +2781,7 @@ void ex_append(exarg_T *eap)
     } else if (eap->ea_getline == NULL) {
       // No getline() function, use the lines that follow. This ends
       // when there is no more.
-      if (eap->nextcmd == NULL || *eap->nextcmd == NUL) {
+      if (eap->nextcmd == NULL) {
         break;
       }
       p = vim_strchr(eap->nextcmd, NL);
@@ -2791,6 +2791,8 @@ void ex_append(exarg_T *eap)
       theline = xmemdupz(eap->nextcmd, (size_t)(p - eap->nextcmd));
       if (*p != NUL) {
         p++;
+      } else {
+        p = NULL;
       }
       eap->nextcmd = p;
     } else {

--- a/test/functional/ex_cmds/append_spec.lua
+++ b/test/functional/ex_cmds/append_spec.lua
@@ -23,7 +23,7 @@ local cmdtest = function(cmd, prep, ret1)
     end
 
     it(cmd .. 's' .. prep .. ' the current line by default', function()
-      command(cmd .. '\nabc\ndef\n')
+      command(cmd .. '\nabc\ndef')
       eq(ret1, buffer_contents())
     end)
     -- Used to crash because this invokes history processing which uses

--- a/test/old/testdir/test_ex_mode.vim
+++ b/test/old/testdir/test_ex_mode.vim
@@ -307,4 +307,13 @@ func Test_insert_after_trailing_bar()
   bwipe!
 endfunc
 
+" Test global insert of a newline without terminating period
+func Test_global_insert_newline()
+  new
+  call setline(1, ['foo'])
+  call feedkeys("Qg/foo/i\\\n", "xt")
+  call assert_equal(['', 'foo'], getline(1, '$'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0651: ex: trailing dot is optional for :g and :insert/:append

Problem:  ex: trailing dot is optional for :g and :insert/:append
Solution: don't break out early, when the next command is empty.
          (Mohamed Akram)

The terminating period is optional for the last command in a global
command list.

closes: vim/vim#15407

https://github.com/vim/vim/commit/0214680a8ec5f7f656cb42e5db19243709202ed2

Co-authored-by: Mohamed Akram <mohd.akram@outlook.com>