### PR TITLE
vim-patch:8.2.4416: Vim9: using a script-local function requires using "s:"

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -384,15 +384,22 @@ the name, e.g. "<lambda>123".  Examples:
 	set opfunc=function('MyOpFunc')
 	set opfunc=funcref('MyOpFunc')
 	set opfunc={a\ ->\ MyOpFunc(a)}
-	" set using a funcref variable
+
+Set to a script-local function: >
+	set opfunc=s:MyLocalFunc
+	set opfunc=<SID>MyLocalFunc
+
+Set using a funcref variable: >
 	let Fn = function('MyTagFunc')
 	let &tagfunc = Fn
-	" set using a lambda expression
+
+Set using a lambda expression: >
 	let &tagfunc = {t -> MyTagFunc(t)}
-	" set using a variable with lambda expression
+
+Set using a variable with lambda expression: >
 	let L = {a, b, c -> MyTagFunc(a, b , c)}
 	let &tagfunc = L
-<
+
 
 Setting the filetype
 

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2084,7 +2084,7 @@ char *get_scriptlocal_funcname(char *funcname)
 
   if (strncmp(funcname, "s:", 2) != 0
       && strncmp(funcname, "<SID>", 5) != 0) {
-    // The function name is not a script-local function name
+    // The function name does not have a script-local prefix.
     return NULL;
   }
 

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -1691,6 +1691,23 @@ func Test_completefunc_callback()
   bw!
   delfunc s:CompleteFunc3
 
+  " In Vim9 script s: can be omitted
+  let lines =<< trim END
+      vim9script
+      var CompleteFunc4Args = []
+      def CompleteFunc4(findstart: bool, base: string): any
+        add(CompleteFunc4Args, [findstart, base])
+        return findstart ? 0 : []
+      enddef
+      set completefunc=CompleteFunc4
+      new
+      setline(1, 'script1')
+      feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')
+      assert_equal([[1, ''], [0, 'script1']], CompleteFunc4Args)
+      bw!
+  END
+  call CheckScriptSuccess(lines)
+
   " invalid return value
   let &completefunc = {a -> 'abc'}
   call feedkeys("A\<C-X>\<C-U>\<Esc>", 'x')


### PR DESCRIPTION
#### vim-patch:8.2.4416: Vim9: using a script-local function requires using "s:"

Problem:    Vim9: using a script-local function requires using "s:" when
            setting 'completefunc'.
Solution:   Do not require "s:" in Vim9 script.

https://github.com/vim/vim/commit/1fca5f3e86f08e696058fc7e86dfe41b415a78e6

vim-patch:8.2.4417: using NULL pointer

Problem:    Using NULL pointer.
Solution:   Set offset after checking for NULL pointer.

https://github.com/vim/vim/commit/e89bfd212b21c227f026e467f882c62cdd6e642d

Co-authored-by: Bram Moolenaar <Bram@vim.org>