### PR TITLE
feat(lsp): announce codeLens resolveSupport

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -427,6 +427,12 @@ function protocol.make_client_capabilities()
           properties = { 'edit' },
         },
       },
+      codeLens = {
+        dynamicRegistration = false,
+        resolveSupport = {
+          properties = { 'command' },
+        },
+      },
       formatting = {
         dynamicRegistration = true,
       },


### PR DESCRIPTION
The codelens implementation can resolve command and title via
`codeLens/resolve`.

The spec added client capabilities for that:

https://github.com/microsoft/language-server-protocol/pull/1979
