### PR TITLE
fix(tui): reset active attr ID when OSC 8 sequence is terminated

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -888,6 +888,7 @@ static void cursor_goto(TUIData *tui, int row, int col)
   if (tui->url >= 0) {
     out(tui, S_LEN("\x1b]8;;\x1b\\"));
     tui->url = -1;
+    tui->print_attr_id = -1;
   }
 
   if (0 == row && 0 == col) {


### PR DESCRIPTION
When the cursor is moved we terminate any active OSC 8 sequences to prevent the sequence from inadvertently spanning regions it is not meant to span. However, if we do not also reset the TUI's active attr id (print_attr_id) then the TUI does not "know" that its current attribute set has changed. When cursor_goto is called to wrap a line, the TUI does not recompute the attributes so the OSC 8 sequence is not restarted again.

When we terminate an OSC 8 sequence before moving the cursor, also reset the active attr id so that the attributes are recomputed for URLs.

---

To verify this change, I made a modification to the TUI to also use a red background when an OSC 8 sequence is active.

**Before**:

<img width="367" alt="Untitled 3" src="https://github.com/user-attachments/assets/efe91ff1-e059-4deb-8b9f-cb6b03d179a4">

**After**:

<img width="368" alt="Untitled 4" src="https://github.com/user-attachments/assets/6367540d-7e90-42cb-84c8-60c3f338043d">
