### PR TITLE
vim-patch:9.1.0655: filetype: goaccess config file not recognized

### DIFF
--- a/runtime/ftplugin/goaccess.vim
+++ b/runtime/ftplugin/goaccess.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin
+" Language: GoAccess configuration
+" Maintainer: Adam Monsen <haircut@gmail.com>
+" Last Change: 2024 Aug 1
+
+if exists('b:did_ftplugin')
+  finish
+endif
+
+let b:did_ftplugin = 1
+
+setl comments=:# commentstring=#\ %s
+
+let b:undo_ftplugin = 'setl com< cms<'

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1452,6 +1452,7 @@ local filename = {
   gnashpluginrc = 'gnash',
   gnashrc = 'gnash',
   ['.gnuplot_history'] = 'gnuplot',
+  ['goaccess.conf'] = 'goaccess',
   ['go.sum'] = 'gosum',
   ['go.work.sum'] = 'gosum',
   ['go.work'] = 'gowork',

--- a/runtime/syntax/goaccess.vim
+++ b/runtime/syntax/goaccess.vim
@@ -1,0 +1,34 @@
+" Vim syntax file
+" Language: GoAccess configuration
+" Maintainer: Adam Monsen <haircut@gmail.com>
+" Last Change: 2024 Aug 1
+" Remark: see https://goaccess.io/man#configuration
+"
+" The GoAccess configuration file syntax is line-separated settings. Settings
+" are space-separated key value pairs. Comments are any line starting with a
+" hash mark.
+" Example: https://github.com/allinurl/goaccess/blob/master/config/goaccess.conf
+"
+" This syntax definition supports todo/fixme highlighting in comments, and
+" special (Keyword) highlighting if a setting's value is 'true' or 'false'.
+"
+" TODO: a value is required, so use extreme highlighting (e.g. bright red
+" background) if a setting is missing a value.
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syn match goaccessSettingName '^[a-z-]\+' nextgroup=goaccessSettingValue
+syn match goaccessSettingValue '\s\+.\+$' contains=goaccessKeyword
+syn match goaccessComment "^#.*$" contains=goaccessTodo,@Spell
+syn keyword goaccessTodo TODO FIXME contained
+syn keyword goaccessKeyword true false contained
+
+hi def link goaccessSettingName Type
+hi def link goaccessSettingValue String
+hi def link goaccessComment Comment
+hi def link goaccessTodo Todo
+hi def link goaccessKeyword Keyword
+
+let b:current_syntax = "goaccess"

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -301,6 +301,7 @@ func s:GetFilenameChecks() abort
     \ 'gnash': ['gnashrc', '.gnashrc', 'gnashpluginrc', '.gnashpluginrc'],
     \ 'gnuplot': ['file.gpi', '.gnuplot', 'file.gnuplot', '.gnuplot_history'],
     \ 'go': ['file.go'],
+    \ 'goaccess': ['goaccess.conf'],
     \ 'gomod': ['go.mod'],
     \ 'gosum': ['go.sum', 'go.work.sum'],
     \ 'gowork': ['go.work'],


### PR DESCRIPTION
Problem:  filetype: goaccess config file not recognized
Solution: detect 'goaccess.conf' as goaccess filetype, also
          include a basic syntax and ftplugin (Adam Monsen)

Add syntax highlighting for GoAccess configuration file.

GoAccess is a real-time web log analyzer and interactive viewer that
runs in a terminal in *nix systems or through your browser.

GoAccess home page: https://goaccess.io

closes: vim/vim#15414

https://github.com/vim/vim/commit/0aa65b48fbe64e18a767b207802483026baecb5d

Co-authored-by: Adam Monsen <haircut@gmail.com>
