### PR TITLE
fix(lsp): redundant spaces in lsp log

### DIFF
--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -19,7 +19,7 @@ local current_log_level = log_levels.WARN
 local log_date_format = '%F %H:%M:%S'
 
 local function format_func(arg)
-  return vim.inspect(arg, { newline = '' })
+  return vim.inspect(arg, { newline = ' ', indent = '' })
 end
 
 local function notify(msg, level)


### PR DESCRIPTION
Before
```
{  id = 4,  jsonrpc = "2.0",  method = "textDocument/inlayHint",  params = {    range = {      ["end"] = {        character = 0,        line = 177      },      start = {        character = 0,        line = 0      }    },    textDocument = {      uri = "..."    }  }}
```

After
```
{ id = 4, jsonrpc = "2.0", method = "textDocument/inlayHint", params = { range = { ["end"] = { character = 0, line = 177 }, start = { character = 0, line = 0 } }, textDocument = { uri = "..." } } }
```