### PR TITLE
vim-patch: update runtime files

### DIFF
--- a/runtime/autoload/zip.vim
+++ b/runtime/autoload/zip.vim
@@ -9,6 +9,7 @@
 " 2024 Jul 23 by Vim Project: fix 'x' command
 " 2024 Jul 24 by Vim Project: use delete() function
 " 2024 Jul 20 by Vim Project: fix opening remote zipfile
+" 2024 Aug 04 by Vim Project: escape '[' in name of file to be extracted
 " License:	Vim License  (see vim's :help license)
 " Copyright:	Copyright (C) 2005-2019 Charles E. Campbell {{{1
 "		Permission is hereby granted to use and distribute this code,
@@ -218,8 +219,8 @@ fun! zip#Read(fname,mode)
   else
    let zipfile = substitute(a:fname,'^.\{-}zipfile://\(.\{-}\)::[^\\].*$','\1','')
    let fname   = substitute(a:fname,'^.\{-}zipfile://.\{-}::\([^\\].*\)$','\1','')
-   let fname   = substitute(fname, '[', '[[]', 'g')
   endif
+  let fname    = substitute(fname, '[', '[[]', 'g')
   " sanity check
   if !executable(substitute(g:zip_unzipcmd,'\s\+.*$','',''))
    redraw!
@@ -230,7 +231,7 @@ fun! zip#Read(fname,mode)
   endif
 
   " the following code does much the same thing as
-  "   exe "keepj sil! r! ".g:zip_unzipcmd." -p -- ".s:Escape(zipfile,1)." ".s:Escape(fnameescape(fname),1)
+  "   exe "keepj sil! r! ".g:zip_unzipcmd." -p -- ".s:Escape(zipfile,1)." ".s:Escape(fname,1)
   " but allows zipfile://... entries in quickfix lists
   let temp = tempname()
   let fn   = expand('%:p')

--- a/runtime/indent/lua.vim
+++ b/runtime/indent/lua.vim
@@ -4,6 +4,7 @@
 " First Author:	Max Ischenko <mfi 'at' ukr.net>
 " Last Change:	2017 Jun 13
 "		2022 Sep 07: b:undo_indent added by Doug Kearns
+"		2024 Jul 27: by Vim project: match '(', ')' in function GetLuaIndentIntern()
 
 " Only load this indent file when no other was loaded.
 if exists("b:did_indent")
@@ -46,12 +47,12 @@ function! GetLuaIndentIntern()
   endif
 
   " Add a 'shiftwidth' after lines that start a block:
-  " 'function', 'if', 'for', 'while', 'repeat', 'else', 'elseif', '{'
+  " 'function', 'if', 'for', 'while', 'repeat', 'else', 'elseif', '{', '('
   let ind = indent(prevlnum)
   let prevline = getline(prevlnum)
   let midx = match(prevline, '^\s*\%(if\>\|for\>\|while\>\|repeat\>\|else\>\|elseif\>\|do\>\|then\>\)')
   if midx == -1
-    let midx = match(prevline, '{\s*\%(--\%([^[].*\)\?\)\?$')
+    let midx = match(prevline, '\%({\|(\)\s*\%(--\%([^[].*\)\?\)\?$')
     if midx == -1
       let midx = match(prevline, '\<function\>\s*\%(\k\|[.:]\)\{-}\s*(')
     endif
@@ -65,9 +66,9 @@ function! GetLuaIndentIntern()
     endif
   endif
 
-  " Subtract a 'shiftwidth' on end, else, elseif, until and '}'
+  " Subtract a 'shiftwidth' on end, else, elseif, until, '}' and ')'
   " This is the part that requires 'indentkeys'.
-  let midx = match(getline(v:lnum), '^\s*\%(end\>\|else\>\|elseif\>\|until\>\|}\)')
+  let midx = match(getline(v:lnum), '^\s*\%(end\>\|else\>\|elseif\>\|until\>\|}\|)\)')
   if midx != -1 && synIDattr(synID(v:lnum, midx + 1, 1), "name") != "luaComment"
     let ind = ind - shiftwidth()
   endif

--- a/runtime/indent/testdir/lua.in
+++ b/runtime/indent/testdir/lua.in
@@ -1,0 +1,19 @@
+-- vim: set ft=lua sw=2 noet:
+
+-- START_INDENT
+function foo(a, b, c, d)
+ return { a, b, c, d }
+end
+
+local a = foo(
+1,
+2,
+"longxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+4
+)
+
+local b = {
+1,
+ 2,
+}
+-- END_INDENT

--- a/runtime/indent/testdir/lua.ok
+++ b/runtime/indent/testdir/lua.ok
@@ -1,0 +1,19 @@
+-- vim: set ft=lua sw=2 noet:
+
+-- START_INDENT
+function foo(a, b, c, d)
+  return { a, b, c, d }
+end
+
+local a = foo(
+  1,
+  2,
+  "longxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx",
+  4
+)
+
+local b = {
+  1,
+  2,
+}
+-- END_INDENT


### PR DESCRIPTION
- **vim-patch:c5bdd66: runtime(zip): escape '[' on Unix as well**
- **vim-patch:c0f7505: runtime(lua): add/subtract a 'shiftwidth' after '('/')' in indentexpr**
