### PR TITLE
feat(ui): introduce cascading style inheritance for Pmenu* highlights

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -234,6 +234,10 @@ UI
   which controls the tool used to open the given path or URL. If you want to
   globally set this, you can override vim.ui.open using the same approach
   described at |vim.paste()|.
+• The |ins-completion-menu| now supports cascading highlight styles.
+  |hl-PmenuSel| and |hl-PmenuMatch| both inherit from |hl-Pmenu|, and
+  |hl-PmenuMatchSel| inherits highlights from both |hl-PmenuSel| and
+  |hl-PmenuMatch|.
 
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5202,7 +5202,7 @@ NormalNC	Normal text in non-current windows.
 							*hl-Pmenu*
 Pmenu		Popup menu: Normal item.
 							*hl-PmenuSel*
-PmenuSel	Popup menu: Selected item.
+PmenuSel	Popup menu: Selected item. Combined with |hl-Pmenu|.
 							*hl-PmenuKind*
 PmenuKind	Popup menu: Normal item "kind".
 							*hl-PmenuKindSel*
@@ -5216,9 +5216,11 @@ PmenuSbar	Popup menu: Scrollbar.
 							*hl-PmenuThumb*
 PmenuThumb	Popup menu: Thumb of the scrollbar.
 							*hl-PmenuMatch*
-PmenuMatch	Popup menu: Matched text in normal item.
+PmenuMatch	Popup menu: Matched text in normal item. Combined with
+		|hl-Pmenu|.
 							*hl-PmenuMatchSel*
-PmenuMatchSel	Popup menu: Matched text in selected item.
+PmenuMatchSel	Popup menu: Matched text in selected item. Combined with
+		|hl-PmenuMatch| and |hl-PmenuSel|.
 							*hl-Question*
 Question	|hit-enter| prompt and yes/no questions.
 							*hl-QuickFixLine*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -561,6 +561,9 @@ Highlight groups:
     the regexp `[a-zA-Z0-9_.@-]*` (see |group-name|).
 - |hl-StatusLineTerm| |hl-StatusLineTermNC| are implemented as 'winhighlight'
   window-local highlights which are set by the default |TermOpen| handler.
+- The |ins-completion-menu| has cascading highlight styles. |hl-PmenuSel| and
+  |hl-PmenuMatch| both inherit from |hl-Pmenu|, and |hl-PmenuMatchSel|
+  inherits highlights from both |hl-PmenuSel| and |hl-PmenuMatch|.
 
 Macro (|recording|) behavior:
 - Replay of a macro recorded during :lmap produces the same actions as when it

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -480,12 +480,18 @@ static int *pum_compute_text_attrs(char *text, hlf_T hlf, int user_hlattr)
       for (int i = 0; i < ga->ga_len; i++) {
         if (char_pos == ((uint32_t *)ga->ga_data)[i]) {
           new_attr = win_hl_attr(curwin, hlf == HLF_PSI ? HLF_PMSI : HLF_PMNI);
+          new_attr = hl_combine_attr(win_hl_attr(curwin, HLF_PMNI), new_attr);
+          new_attr = hl_combine_attr(win_hl_attr(curwin, (int)hlf), new_attr);
           break;
         }
       }
     } else if (matched_start && ptr < text + leader_len) {
       new_attr = win_hl_attr(curwin, hlf == HLF_PSI ? HLF_PMSI : HLF_PMNI);
+      new_attr = hl_combine_attr(win_hl_attr(curwin, HLF_PMNI), new_attr);
+      new_attr = hl_combine_attr(win_hl_attr(curwin, (int)hlf), new_attr);
     }
+
+    new_attr = hl_combine_attr(win_hl_attr(curwin, HLF_PNI), new_attr);
 
     if (user_hlattr > 0) {
       new_attr = hl_combine_attr(new_attr, user_hlattr);
@@ -629,6 +635,7 @@ void pum_redraw(void)
     const hlf_T *const hlfs = (idx == pum_selected) ? hlfsSel : hlfsNorm;
     hlf_T hlf = hlfs[0];  // start with "word" highlight
     int attr = win_hl_attr(curwin, (int)hlf);
+    attr = hl_combine_attr(win_hl_attr(curwin, HLF_PNI), attr);
 
     grid_line_start(&pum_grid, row);
 
@@ -663,6 +670,7 @@ void pum_redraw(void)
       if (item_type == CPT_KIND && user_kind_hlattr > 0) {
         attr = hl_combine_attr(attr, user_kind_hlattr);
       }
+      attr = hl_combine_attr(win_hl_attr(curwin, HLF_PNI), attr);
       int width = 0;
       char *s = NULL;
       p = pum_get_item(idx, item_type);

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -3636,6 +3636,59 @@ describe('builtin popupmenu', function()
           :sign un^                        |
         ]])
       end)
+
+      it(
+        'cascading highlights for matched text (PmenuMatch, PmenuMatchSel) in cmdline pum',
+        function()
+          screen:set_default_attr_ids({
+            [1] = { foreground = Screen.colors.Blue1, bold = true },
+            [2] = {
+              underline = true,
+              italic = true,
+              foreground = Screen.colors.White,
+              background = Screen.colors.Grey,
+            },
+            [3] = {
+              foreground = Screen.colors.Red,
+              background = Screen.colors.Grey,
+              strikethrough = true,
+              underline = true,
+              italic = true,
+            },
+            [4] = {
+              foreground = Screen.colors.Yellow,
+              background = Screen.colors.Pink,
+              bold = true,
+              underline = true,
+              italic = true,
+            },
+            [5] = {
+              foreground = Screen.colors.Black,
+              background = Screen.colors.White,
+              bold = true,
+              underline = true,
+              italic = true,
+              strikethrough = true,
+            },
+          })
+          exec([[
+            set wildoptions=pum,fuzzy
+            hi Pmenu          guifg=White guibg=Grey gui=underline,italic
+            hi PmenuSel       guifg=Red gui=strikethrough
+            hi PmenuMatch     guifg=Yellow guibg=Pink gui=bold
+            hi PmenuMatchSel  guifg=Black guibg=White
+          ]])
+
+          feed(':sign plc<Tab>')
+          screen:expect([[
+                                            |
+            {1:~                               }|*16
+            {1:~    }{3: }{5:pl}{3:a}{5:c}{3:e          }{1:           }|
+            {1:~    }{2: un}{4:pl}{2:a}{4:c}{2:e        }{1:           }|
+            :sign place^                     |
+          ]])
+        end
+      )
     end
 
     it("'pumheight'", function()


### PR DESCRIPTION
Basically this commit makes it so that, for items in the popup menu:

- `PmenuSel` and `PmenuMatch` inherit from `Pmenu`
- `PmenuMatchSel` inherits from both `PmenuSel` and `PmenuMatch`

Justification for the change is based on
[this comment](https://github.com/neovim/neovim/pull/29976#issuecomment-2267399153).