### PR TITLE
fix(build): surpress spurious warnings from gcc in -E preprocessor mode

### DIFF
--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -563,7 +563,7 @@ foreach(sfile ${NVIM_SOURCES}
   if(MSVC)
     set(PREPROC_OUTPUT /P /Fi${gf_i} /nologo)
   else()
-    set(PREPROC_OUTPUT -E -o ${gf_i})
+    set(PREPROC_OUTPUT -w -E -o ${gf_i})
   endif()
 
   set(depends "${HEADER_GENERATOR}" "${sfile}" "${LUA_GEN_DEPS}")


### PR DESCRIPTION
Since #29315 we are also preprocessing header files in order to find functions which need prototype declarations. gcc emits a spurious "warning: #pragma once in main file" even when when you are just using `gcc -E` which causes a bit of noise in compiler output.

As a workaround, surpress all warnings for `gcc -E`, this should be pretty much harmless as we will still get preprocessor warnings when doing actual compilation `gcc -c` later.

reference: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=89808