### PR TITLE
build(deps): remove libtermkey dependency

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -241,7 +241,6 @@ jobs:
           sudo add-apt-repository ppa:neovim-ppa/stable
           sudo apt-get install -y \
             libluajit-5.1-dev \
-            libtermkey-dev \
             libunibilium-dev \
             libuv1-dev \
             lua-filesystem \


### PR DESCRIPTION
It's been vendored since https://github.com/neovim/neovim/pull/25870.