### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/autoload/zip.vim
+++ b/runtime/autoload/zip.vim
@@ -1,6 +1,6 @@
 " zip.vim: Handles browsing zipfiles
 " AUTOLOAD PORTION
-" Date:		Jul 30, 2024
+" Date:		Aug 05, 2024
 " Version:	33
 " Maintainer:	This runtime file is looking for a new maintainer.
 " Former Maintainer:	Charles E Campbell
@@ -8,8 +8,9 @@
 " 2024 Jun 16 by Vim Project: handle whitespace on Windows properly (#14998)
 " 2024 Jul 23 by Vim Project: fix 'x' command
 " 2024 Jul 24 by Vim Project: use delete() function
-" 2024 Jul 20 by Vim Project: fix opening remote zipfile
+" 2024 Jul 30 by Vim Project: fix opening remote zipfile
 " 2024 Aug 04 by Vim Project: escape '[' in name of file to be extracted
+" 2024 Aug 05 by Vim Project: workaround for the FreeBSD's unzip
 " License:	Vim License  (see vim's :help license)
 " Copyright:	Copyright (C) 2005-2019 Charles E. Campbell {{{1
 "		Permission is hereby granted to use and distribute this code,
@@ -131,8 +132,7 @@ fun! zip#Browse(zipfile)
  \                '" Select a file with cursor and press ENTER'])
   keepj $
 
-"  call Decho("exe silent r! ".g:zip_unzipcmd." -l -- ".s:Escape(a:zipfile,1))
-  exe "keepj sil! r! ".g:zip_unzipcmd." -Z -1 -- ".s:Escape(a:zipfile,1)
+  exe $"keepj sil r! {g:zip_unzipcmd} -Z1 -- {s:Escape(a:zipfile, 1)}"
   if v:shell_error != 0
    redraw!
    echohl WarningMsg | echo "***warning*** (zip#Browse) ".fnameescape(a:zipfile)." is not a zip file" | echohl None
@@ -235,7 +235,7 @@ fun! zip#Read(fname,mode)
   " but allows zipfile://... entries in quickfix lists
   let temp = tempname()
   let fn   = expand('%:p')
-  exe "sil! !".g:zip_unzipcmd." -p -- ".s:Escape(zipfile,1)." ".s:Escape(fname,1).' > '.temp
+  exe "sil !".g:zip_unzipcmd." -p -- ".s:Escape(zipfile,1)." ".s:Escape(fname,1).' > '.temp
   sil exe 'keepalt file '.temp
   sil keepj e!
   sil exe 'keepalt file '.fnameescape(fn)

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -994,7 +994,7 @@ Another option is using 'makeencoding'.
 ==============================================================================
 5. Using :vimgrep and :grep				*grep* *lid*
 
-Vim has two ways to find matches for a pattern: Internal and external.  The
+Vim has two ways to find matches for a pattern: internal and external.  The
 advantage of the internal grep is that it works on all systems and uses the
 powerful Vim search patterns.  An external grep program can be used when the
 Vim grep does not do what you want.
@@ -1023,7 +1023,7 @@ commands can be combined to create a NewGrep command: >
         command! -nargs=+ NewGrep execute 'silent grep! <args>' | copen 42
 
 
-5.1 using Vim's internal grep
+5.1 Using Vim's internal grep
 
 					*:vim* *:vimgrep* *E682* *E683*
 :vim[grep][!] /{pattern}/[g][j][f] {file} ...


### PR DESCRIPTION
#### vim-patch:217d3c1: runtime(doc): capitalize correctly

* do not capitalize after a double colon when introducing a list
* Capitalize a header line

https://github.com/vim/vim/commit/217d3c17c6fa8d1223fa8dd39efd8c32897f9441

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:f0e9b72: runtime(zip): Fix for FreeBSD's unzip command

Problem:  Cannot browse zipfiles with the unzip program found
	  on FreeBSD.
Solution: Adjust command arguments.

Unzip found on FreeBSD complain about missing argument with the
zipinfo modifier '-Z -1'. Joining arguments seems to work
for both implementations.

Also change `:sil!` to `:sil` so that error messages are properly
reported (per review of Christian Brabandt).

related: vim/vim#15411

https://github.com/vim/vim/commit/f0e9b72c8fdd47b9b410a11edf7479953cb2aed9

Co-authored-by: Damien <141588647+xrandomname@users.noreply.github.com>