### PR TITLE
vim-patch:9.1.0465: missing filecopy() function

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1610,6 +1610,15 @@ feedkeys({string} [, {mode}])                                       *feedkeys()*
 
 		Return value is always 0.
 
+filecopy({from}, {to})                                              *filecopy()*
+		Copy the file pointed to by the name {from} to {to}. The
+		result is a Number, which is |TRUE| if the file was copied
+		successfully, and |FALSE| when it failed.
+		If a file with name {to} already exists, it will fail.
+		Note that it does not handle directories (yet).
+
+		This function is not available in the |sandbox|.
+
 filereadable({file})                                            *filereadable()*
 		The result is a Number, which is |TRUE| when a file with the
 		name {file} exists, and can be read.  If {file} doesn't exist,

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -855,6 +855,7 @@ System functions and manipulation of files:
 	readblob()		read a file into a Blob
 	readdir()		get a List of file names in a directory
 	writefile()		write a List of lines or Blob into a file
+	filecopy()		copy a file {from} to {to}
 
 Date and Time:				*date-functions* *time-functions*
 	getftime()		get last modification time of a file

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -1993,6 +1993,19 @@ function vim.fn.feedkeys(string, mode) end
 --- @return any
 function vim.fn.file_readable(file) end
 
+--- Copy the file pointed to by the name {from} to {to}. The
+--- result is a Number, which is |TRUE| if the file was copied
+--- successfully, and |FALSE| when it failed.
+--- If a file with name {to} already exists, it will fail.
+--- Note that it does not handle directories (yet).
+---
+--- This function is not available in the |sandbox|.
+---
+--- @param from string
+--- @param to string
+--- @return 0|1
+function vim.fn.filecopy(from, to) end
+
 --- The result is a Number, which is |TRUE| when a file with the
 --- name {file} exists, and can be read.  If {file} doesn't exist,
 --- or is a directory, the result is |FALSE|.  {file} is any

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -2521,6 +2521,23 @@ M.funcs = {
     params = { { 'file', 'string' } },
     signature = 'file_readable({file})',
   },
+  filecopy = {
+    args = 2,
+    base = 1,
+    desc = [[
+      Copy the file pointed to by the name {from} to {to}. The
+      result is a Number, which is |TRUE| if the file was copied
+      successfully, and |FALSE| when it failed.
+      If a file with name {to} already exists, it will fail.
+      Note that it does not handle directories (yet).
+
+      This function is not available in the |sandbox|.
+    ]],
+    name = 'filecopy',
+    params = { { 'from', 'string' }, { 'to', 'string' } },
+    returns = '0|1',
+    signature = 'filecopy({from}, {to})',
+  },
   filereadable = {
     args = 1,
     base = 1,

--- a/src/nvim/eval/fs.c
+++ b/src/nvim/eval/fs.c
@@ -154,6 +154,27 @@ void f_exepath(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   rettv->vval.v_string = path;
 }
 
+/// "filecopy()" function
+void f_filecopy(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+{
+  rettv->vval.v_number = false;
+
+  if (check_secure()
+      || tv_check_for_string_arg(argvars, 0) == FAIL
+      || tv_check_for_string_arg(argvars, 1) == FAIL) {
+    return;
+  }
+
+  const char *from = tv_get_string(&argvars[0]);
+
+  FileInfo from_info;
+  if (os_fileinfo_link(from, &from_info)
+      && (S_ISREG(from_info.stat.st_mode) || S_ISLNK(from_info.stat.st_mode))) {
+    rettv->vval.v_number
+      = vim_copyfile(tv_get_string(&argvars[0]), tv_get_string(&argvars[1])) == OK;
+  }
+}
+
 /// "filereadable()" function
 void f_filereadable(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {

--- a/test/old/testdir/test_filecopy.vim
+++ b/test/old/testdir/test_filecopy.vim
@@ -1,0 +1,72 @@
+" Test filecopy()
+
+source check.vim
+source shared.vim
+
+func Test_copy_file_to_file()
+  call writefile(['foo'], 'Xcopy1')
+
+  call assert_true(filecopy('Xcopy1', 'Xcopy2'))
+
+  call assert_equal(['foo'], readfile('Xcopy2'))
+
+  " When the destination file already exists, it should not be overwritten.
+  call writefile(['foo'], 'Xcopy1')
+  call writefile(['bar'], 'Xcopy2', 'D')
+  call assert_false(filecopy('Xcopy1', 'Xcopy2'))
+  call assert_equal(['bar'], readfile('Xcopy2'))
+
+  call delete('Xcopy2')
+  call delete('Xcopy1')
+endfunc
+
+func Test_copy_symbolic_link()
+  CheckUnix
+
+  call writefile(['text'], 'Xtestfile', 'D')
+  silent !ln -s -f Xtestfile Xtestlink
+
+  call assert_true(filecopy('Xtestlink', 'Xtestlink2'))
+  call assert_equal('link', getftype('Xtestlink2'))
+  call assert_equal(['text'], readfile('Xtestlink2'))
+
+  " When the destination file already exists, it should not be overwritten.
+  call assert_false(filecopy('Xtestlink', 'Xtestlink2'))
+
+  call delete('Xtestlink2')
+  call delete('Xtestlink')
+  call delete('Xtestfile')
+endfunc
+
+func Test_copy_dir_to_dir()
+  call mkdir('Xcopydir1')
+  call writefile(['foo'], 'Xcopydir1/Xfilecopy')
+  call mkdir('Xcopydir2')
+
+  " Directory copy is not supported
+  call assert_false(filecopy('Xcopydir1', 'Xcopydir2'))
+
+  call delete('Xcopydir2', 'rf')
+  call delete('Xcopydir1', 'rf')
+endfunc
+
+func Test_copy_fails()
+  CheckUnix
+
+  call writefile(['foo'], 'Xfilecopy', 'D')
+
+  " Can't copy into a non-existing directory.
+  call assert_false(filecopy('Xfilecopy', 'Xdoesnotexist/Xfilecopy'))
+
+  " Can't copy a non-existing file.
+  call assert_false(filecopy('Xdoesnotexist', 'Xfilecopy2'))
+  call assert_equal('', glob('Xfilecopy2'))
+
+  " Can't copy to en empty file name.
+  call assert_false(filecopy('Xfilecopy', ''))
+
+  call assert_fails('call filecopy("Xfilecopy", [])', 'E1174:')
+  call assert_fails('call filecopy(0z, "Xfilecopy")', 'E1174:')
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0465: missing filecopy() function

Problem:  missing filecopy() function
Solution: implement filecopy() Vim script function
          (Shougo Matsushita)

closes: vim/vim#12346

https://github.com/vim/vim/commit/60c8743ab6c90e402e6ed49d27455ef7e5698abe

Co-authored-by: Shougo Matsushita <Shougo.Matsu@gmail.com>