### PR TITLE
vim-patch:8.2.4838: checking for absolute path is not trivial

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3859,6 +3859,21 @@ invert({expr})                                                        *invert()*
 			let bits = invert(bits)
 <
 
+isabsolutepath({path})                                        *isabsolutepath()*
+		The result is a Number, which is |TRUE| when {path} is an
+		absolute path.
+		On Unix, a path is considered absolute when it starts with '/'.
+		On MS-Windows, it is considered absolute when it starts with an
+		optional drive prefix and is followed by a '\' or '/'. UNC paths
+		are always absolute.
+		Example: >vim
+			echo isabsolutepath('/usr/share/')	" 1
+			echo isabsolutepath('./foobar')		" 0
+			echo isabsolutepath('C:\Windows')	" 1
+			echo isabsolutepath('foobar')		" 0
+			echo isabsolutepath('\\remote\file')	" 1
+<
+
 isdirectory({directory})                                         *isdirectory()*
 		The result is a Number, which is |TRUE| when a directory
 		with the name {directory} exists.  If {directory} doesn't

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -836,6 +836,7 @@ System functions and manipulation of files:
 	getfperm()		get the permissions of a file
 	setfperm()		set the permissions of a file
 	getftype()		get the kind of a file
+	isabsolutepath()	check if a path is absolute
 	isdirectory()		check if a directory exists
 	getfsize()		get the size of a file
 	getcwd()		get the current working directory

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -4646,6 +4646,24 @@ function vim.fn.interrupt() end
 --- @return any
 function vim.fn.invert(expr) end
 
+--- The result is a Number, which is |TRUE| when {path} is an
+--- absolute path.
+--- On Unix, a path is considered absolute when it starts with '/'.
+--- On MS-Windows, it is considered absolute when it starts with an
+--- optional drive prefix and is followed by a '\' or '/'. UNC paths
+--- are always absolute.
+--- Example: >vim
+---   echo isabsolutepath('/usr/share/')  " 1
+---   echo isabsolutepath('./foobar')    " 0
+---   echo isabsolutepath('C:\Windows')  " 1
+---   echo isabsolutepath('foobar')    " 0
+---   echo isabsolutepath('\\remote\file')  " 1
+--- <
+---
+--- @param path any
+--- @return 0|1
+function vim.fn.isabsolutepath(path) end
+
 --- The result is a Number, which is |TRUE| when a directory
 --- with the name {directory} exists.  If {directory} doesn't
 --- exist, or isn't a directory, the result is |FALSE|.  {directory}

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -5669,6 +5669,30 @@ M.funcs = {
     params = { { 'expr', 'any' } },
     signature = 'invert({expr})',
   },
+  isabsolutepath = {
+    args = 1,
+    base = 1,
+    desc = [=[
+      The result is a Number, which is |TRUE| when {path} is an
+      absolute path.
+      On Unix, a path is considered absolute when it starts with '/'.
+      On MS-Windows, it is considered absolute when it starts with an
+      optional drive prefix and is followed by a '\' or '/'. UNC paths
+      are always absolute.
+      Example: >vim
+      	echo isabsolutepath('/usr/share/')	" 1
+      	echo isabsolutepath('./foobar')		" 0
+      	echo isabsolutepath('C:\Windows')	" 1
+      	echo isabsolutepath('foobar')		" 0
+      	echo isabsolutepath('\\remote\file')	" 1
+      <
+    ]=],
+    fast = true,
+    name = 'isabsolutepath',
+    params = { { 'path', 'any' } },
+    returns = '0|1',
+    signature = 'isabsolutepath({path})',
+  },
   isdirectory = {
     args = 1,
     base = 1,

--- a/src/nvim/eval/fs.c
+++ b/src/nvim/eval/fs.c
@@ -667,6 +667,12 @@ void f_haslocaldir(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
 }
 
+/// "isabsolutepath()" function
+void f_isabsolutepath(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+{
+  rettv->vval.v_number = path_is_absolute(tv_get_string(&argvars[0]));
+}
+
 /// "isdirectory()" function
 void f_isdirectory(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -3559,6 +3559,24 @@ func Test_builtin_check()
   unlet bar
 endfunc
 
+" Test for isabsolutepath()
+func Test_isabsolutepath()
+  call assert_false(isabsolutepath(''))
+  call assert_false(isabsolutepath('.'))
+  call assert_false(isabsolutepath('../Foo'))
+  call assert_false(isabsolutepath('Foo/'))
+  if has('win32')
+    call assert_true(isabsolutepath('A:\'))
+    call assert_true(isabsolutepath('A:\Foo'))
+    call assert_true(isabsolutepath('A:/Foo'))
+    call assert_false(isabsolutepath('A:Foo'))
+    call assert_false(isabsolutepath('\Windows'))
+    call assert_true(isabsolutepath('\\Server2\Share\Test\Foo.txt'))
+  else
+    call assert_true(isabsolutepath('/'))
+    call assert_true(isabsolutepath('/usr/share/'))
+  endif
+endfunc
 
 " Test for virtcol()
 func Test_virtcol()


### PR DESCRIPTION
#### vim-patch:8.2.4838: checking for absolute path is not trivial

Problem:    Checking for absolute path is not trivial.
Solution:   Add isabsolutepath(). (closes vim/vim#10303)

https://github.com/vim/vim/commit/dca1d40cd0f2af0755519e7028378bd3c8fefd31

Co-authored-by: LemonBoy <thatlemon@gmail.com>