### PR TITLE
fix(filetype): fix :filetype detect error with -u NONE

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7330,7 +7330,7 @@ static void ex_filetype(exarg_T *eap)
     break;
   }
   if (strcmp(arg, "on") == 0 || strcmp(arg, "detect") == 0) {
-    if (*arg == 'o' || !filetype_detect) {
+    if (*arg == 'o' || filetype_detect != kTrue) {
       source_runtime(FILETYPE_FILE, DIP_ALL);
       filetype_detect = kTrue;
       if (plugin) {

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -112,6 +112,13 @@ describe('startup', function()
                                                                   |*2
     ]])
   end)
+
+  it(':filetype detect enables filetype detection with -u NONE', function()
+    clear()
+    eq('filetype detection:OFF  plugin:OFF  indent:OFF', exec_capture('filetype'))
+    command('filetype detect')
+    eq('filetype detection:ON  plugin:OFF  indent:OFF', exec_capture('filetype'))
+  end)
 end)
 
 describe('startup', function()


### PR DESCRIPTION
:filetype detect should enable filetype detection when it hasn't been
enabled before.
