### PR TITLE
vim-patch: zip plugin updates

### DIFF
--- a/runtime/autoload/zip.vim
+++ b/runtime/autoload/zip.vim
@@ -92,11 +92,11 @@ fun! zip#Browse(zipfile)
   endif
 
   let dict = s:SetSaneOpts()
+  defer s:RestoreOpts(dict)
 
   " sanity checks
   if !executable(g:zip_unzipcmd)
    call s:Mess('Error', "***error*** (zip#Browse) unzip not available on your system")
-   call s:RestoreOpts(dict)
    return
   endif
   if !filereadable(a:zipfile)
@@ -104,7 +104,6 @@ fun! zip#Browse(zipfile)
     " if it's an url, don't complain, let url-handlers such as vim do its thing
     call s:Mess('Error', "***error*** (zip#Browse) File not readable <".a:zipfile.">")
    endif
-   call s:RestoreOpts(dict)
    return
   endif
   if &ma != 1
@@ -140,7 +139,6 @@ fun! zip#Browse(zipfile)
    exe "keepj r ".fnameescape(a:zipfile)
    let &ei= eikeep
    keepj 1d
-   call s:RestoreOpts(dict)
    return
   endif
 
@@ -152,27 +150,24 @@ fun! zip#Browse(zipfile)
    noremap <silent> <buffer>	<leftmouse>	<leftmouse>:call <SID>ZipBrowseSelect()<cr>
   endif
 
-  call s:RestoreOpts(dict)
 endfun
 
 " ---------------------------------------------------------------------
 " ZipBrowseSelect: {{{2
 fun! s:ZipBrowseSelect()
   let dict = s:SetSaneOpts()
+  defer s:RestoreOpts(dict)
   let fname= getline(".")
   if !exists("b:zipfile")
-   call s:RestoreOpts(dict)
    return
   endif
 
   " sanity check
   if fname =~ '^"'
-   call s:RestoreOpts(dict)
    return
   endif
   if fname =~ '/$'
    call s:Mess('Error', "***error*** (zip#Browse) Please specify a file, not a directory")
-   call s:RestoreOpts(dict)
    return
   endif
 
@@ -188,13 +183,13 @@ fun! s:ZipBrowseSelect()
   exe "noswapfile e ".fnameescape("zipfile://".zipfile.'::'.fname)
   filetype detect
 
-  call s:RestoreOpts(dict)
 endfun
 
 " ---------------------------------------------------------------------
 " zip#Read: {{{2
 fun! zip#Read(fname,mode)
   let dict = s:SetSaneOpts()
+  defer s:RestoreOpts(dict)
 
   if has("unix")
    let zipfile = substitute(a:fname,'zipfile://\(.\{-}\)::[^\\].*$','\1','')
@@ -207,7 +202,6 @@ fun! zip#Read(fname,mode)
   " sanity check
   if !executable(substitute(g:zip_unzipcmd,'\s\+.*$','',''))
    call s:Mess('Error', "***error*** (zip#Read) sorry, your system doesn't appear to have the ".g:zip_unzipcmd." program")
-   call s:RestoreOpts(dict)
    return
   endif
 
@@ -227,23 +221,21 @@ fun! zip#Read(fname,mode)
   " cleanup
   set nomod
 
-  call s:RestoreOpts(dict)
 endfun
 
 " ---------------------------------------------------------------------
 " zip#Write: {{{2
 fun! zip#Write(fname)
   let dict = s:SetSaneOpts()
+  defer s:RestoreOpts(dict)
 
   " sanity checks
   if !executable(substitute(g:zip_zipcmd,'\s\+.*$','',''))
    call s:Mess('Error', "***error*** (zip#Write) sorry, your system doesn't appear to have the ".g:zip_zipcmd." program")
-   call s:RestoreOpts(dict)
    return
   endif
   if !exists("*mkdir")
    call s:Mess('Error', "***error*** (zip#Write) sorry, mkdir() doesn't work on your system")
-   call s:RestoreOpts(dict)
    return
   endif
 
@@ -256,7 +248,6 @@ fun! zip#Write(fname)
 
   " attempt to change to the indicated directory
   if s:ChgDir(tmpdir,s:ERROR,"(zip#Write) cannot cd to temporary directory")
-   call s:RestoreOpts(dict)
    return
   endif
 
@@ -321,7 +312,6 @@ fun! zip#Write(fname)
   call delete(tmpdir, "rf")
   setlocal nomod
 
-  call s:RestoreOpts(dict)
 endfun
 
 " ---------------------------------------------------------------------
@@ -329,16 +319,15 @@ endfun
 fun! zip#Extract()
 
   let dict = s:SetSaneOpts()
+  defer s:RestoreOpts(dict)
   let fname= getline(".")
 
   " sanity check
   if fname =~ '^"'
-   call s:RestoreOpts(dict)
    return
   endif
   if fname =~ '/$'
    call s:Mess('Error', "***error*** (zip#Extract) Please specify a file, not a directory")
-   call s:RestoreOpts(dict)
    return
   endif
 
@@ -351,9 +340,6 @@ fun! zip#Extract()
   else
    echomsg "***note*** successfully extracted ".fname
   endif
-
-  " restore option
-  call s:RestoreOpts(dict)
 
 endfun
 

--- a/runtime/autoload/zip.vim
+++ b/runtime/autoload/zip.vim
@@ -31,7 +31,7 @@ endif
 let g:loaded_zip= "v33"
 if v:version < 702
  echohl WarningMsg
- echo "***warning*** this version of zip needs vim 7.2 or later"
+ echomsg "***warning*** this version of zip needs vim 7.2 or later"
  echohl Normal
  finish
 endif
@@ -95,7 +95,7 @@ fun! zip#Browse(zipfile)
   endif
   if !executable(g:zip_unzipcmd)
    redraw!
-   echohl Error | echo "***error*** (zip#Browse) unzip not available on your system"
+   echohl Error | echomsg "***error*** (zip#Browse) unzip not available on your system"
    let &report= repkeep
    return
   endif
@@ -103,7 +103,7 @@ fun! zip#Browse(zipfile)
    if a:zipfile !~# '^\a\+://'
     " if it's an url, don't complain, let url-handlers such as vim do its thing
     redraw!
-    echohl Error | echo "***error*** (zip#Browse) File not readable<".a:zipfile.">" | echohl None
+    echohl Error | echomsg "***error*** (zip#Browse) File not readable<".a:zipfile.">" | echohl None
    endif
    let &report= repkeep
    return
@@ -135,7 +135,7 @@ fun! zip#Browse(zipfile)
   exe $"keepj sil r! {g:zip_unzipcmd} -Z1 -- {s:Escape(a:zipfile, 1)}"
   if v:shell_error != 0
    redraw!
-   echohl WarningMsg | echo "***warning*** (zip#Browse) ".fnameescape(a:zipfile)." is not a zip file" | echohl None
+   echohl WarningMsg | echomsg "***warning*** (zip#Browse) ".fnameescape(a:zipfile)." is not a zip file" | echohl None
    keepj sil! %d
    let eikeep= &ei
    set ei=BufReadCmd,FileReadCmd
@@ -173,7 +173,7 @@ fun! s:ZipBrowseSelect()
   endif
   if fname =~ '/$'
    redraw!
-   echohl Error | echo "***error*** (zip#Browse) Please specify a file, not a directory" | echohl None
+   echohl Error | echomsg "***error*** (zip#Browse) Please specify a file, not a directory" | echohl None
    let &report= repkeep
    return
   endif
@@ -210,7 +210,7 @@ fun! zip#Read(fname,mode)
   " sanity check
   if !executable(substitute(g:zip_unzipcmd,'\s\+.*$','',''))
    redraw!
-   echohl Error | echo "***error*** (zip#Read) sorry, your system doesn't appear to have the ".g:zip_unzipcmd." program" | echohl None
+   echohl Error | echomsg "***error*** (zip#Read) sorry, your system doesn't appear to have the ".g:zip_unzipcmd." program" | echohl None
    let &report= repkeep
    return
   endif
@@ -243,13 +243,13 @@ fun! zip#Write(fname)
   " sanity checks
   if !executable(substitute(g:zip_zipcmd,'\s\+.*$','',''))
    redraw!
-   echohl Error | echo "***error*** (zip#Write) sorry, your system doesn't appear to have the ".g:zip_zipcmd." program" | echohl None
+   echohl Error | echomsg "***error*** (zip#Write) sorry, your system doesn't appear to have the ".g:zip_zipcmd." program" | echohl None
    let &report= repkeep
    return
   endif
   if !exists("*mkdir")
    redraw!
-   echohl Error | echo "***error*** (zip#Write) sorry, mkdir() doesn't work on your system" | echohl None
+   echohl Error | echomsg "***error*** (zip#Write) sorry, mkdir() doesn't work on your system" | echohl None
    let &report= repkeep
    return
   endif
@@ -305,7 +305,7 @@ fun! zip#Write(fname)
   call system(g:zip_zipcmd." -u ".s:Escape(fnamemodify(zipfile,":p"),0)." ".s:Escape(fname,0))
   if v:shell_error != 0
    redraw!
-   echohl Error | echo "***error*** (zip#Write) sorry, unable to update ".zipfile." with ".fname | echohl None
+   echohl Error | echomsg "***error*** (zip#Write) sorry, unable to update ".zipfile." with ".fname | echohl None
 
   elseif s:zipfile_{winnr()} =~ '^\a\+://'
    " support writing zipfiles across a network
@@ -347,7 +347,7 @@ fun! zip#Extract()
   endif
   if fname =~ '/$'
    redraw!
-   echohl Error | echo "***error*** (zip#Extract) Please specify a file, not a directory" | echohl None
+   echohl Error | echomsg "***error*** (zip#Extract) Please specify a file, not a directory" | echohl None
    let &report= repkeep
    return
   endif
@@ -355,11 +355,11 @@ fun! zip#Extract()
   " extract the file mentioned under the cursor
   call system($"{g:zip_extractcmd} {shellescape(b:zipfile)} {shellescape(fname)}")
   if v:shell_error != 0
-   echohl Error | echo "***error*** ".g:zip_extractcmd." ".b:zipfile." ".fname.": failed!" | echohl NONE
+   echohl Error | echomsg "***error*** ".g:zip_extractcmd." ".b:zipfile." ".fname.": failed!" | echohl NONE
   elseif !filereadable(fname)
-   echohl Error | echo "***error*** attempted to extract ".fname." but it doesn't appear to be present!"
+   echohl Error | echomsg "***error*** attempted to extract ".fname." but it doesn't appear to be present!"
   else
-   echo "***note*** successfully extracted ".fname
+   echomsg "***note*** successfully extracted ".fname
   endif
 
   " restore option
@@ -394,11 +394,11 @@ fun! s:ChgDir(newdir,errlvl,errmsg)
   catch /^Vim\%((\a\+)\)\=:E344/
    redraw!
    if a:errlvl == s:NOTE
-    echo "***note*** ".a:errmsg
+    echomsg "***note*** ".a:errmsg
    elseif a:errlvl == s:WARNING
-    echohl WarningMsg | echo "***warning*** ".a:errmsg | echohl NONE
+    echohl WarningMsg | echomsg "***warning*** ".a:errmsg | echohl NONE
    elseif a:errlvl == s:ERROR
-    echohl Error | echo "***error*** ".a:errmsg | echohl NONE
+    echohl Error | echomsg "***error*** ".a:errmsg | echohl NONE
    endif
    return 1
   endtry

--- a/runtime/autoload/zip.vim
+++ b/runtime/autoload/zip.vim
@@ -87,12 +87,6 @@ fun! zip#Browse(zipfile)
   set report=10
 
   " sanity checks
-  if !exists("*fnameescape")
-   if &verbose > 1
-    echoerr "the zip plugin is not available (your vim doesn't support fnameescape())"
-   endif
-   return
-  endif
   if !executable(g:zip_unzipcmd)
    redraw!
    echohl Error | echomsg "***error*** (zip#Browse) unzip not available on your system"

--- a/runtime/autoload/zip.vim
+++ b/runtime/autoload/zip.vim
@@ -1,7 +1,7 @@
 " zip.vim: Handles browsing zipfiles
 " AUTOLOAD PORTION
 " Date:		Aug 05, 2024
-" Version:	33
+" Version:	34
 " Maintainer:	This runtime file is looking for a new maintainer.
 " Former Maintainer:	Charles E Campbell
 " Last Change:
@@ -28,7 +28,7 @@
 if &cp || exists("g:loaded_zip")
  finish
 endif
-let g:loaded_zip= "v33"
+let g:loaded_zip= "v34"
 if v:version < 702
  echohl WarningMsg
  echomsg "***warning*** this version of zip needs vim 7.2 or later"

--- a/test/old/testdir/test_zip_plugin.vim
+++ b/test/old/testdir/test_zip_plugin.vim
@@ -10,8 +10,6 @@ endif
 runtime plugin/zipPlugin.vim
 
 func Test_zip_basic()
-  let _sl = &shellslash
-  set noshellslash
 
   "## get our zip file
   if !filecopy("samples/test.zip", "X.zip")
@@ -133,7 +131,5 @@ func Test_zip_basic()
   call assert_match('File not readable', execute("e Xnot_exists.zip"))
 
   bw
-
-  let &shellslash = _sl
 
 endfunc


### PR DESCRIPTION
#### vim-patch:a63f66e: runtime(zip): clean up and remove comments

Problem:  zip plugin contains a lot of comments from the decho plugin
Solution: Clean up and remove un-used comments

https://github.com/vim/vim/commit/a63f66e953d811bb6d044e92fe338e533ad94ff5

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:120c0dd: runtime(zip): use :echomsg instead of :echo

Problem:  zip plugin uses :echo which does not store messages
Solution: use :echomsg instead of :echo so that messages are stored in
          the message history

https://github.com/vim/vim/commit/120c0dd815fa3b44df0fa477f7f3313e4a69c652

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:33836d3: runtime(zip): remove test for fnameescape

Problem:  zip plugin tests for fnameescape() function
Solution: Remove the check, fnameescape() has been available since
          7.1.299, it should nowadays always be available

https://github.com/vim/vim/commit/33836d38b82aa926a2a2b3f945a0139f373f7e56

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:19636be: runtime(zip): refactor save and restore of options

Problem:  zip plugin has no way to set/restore option values
Solution: Add the SetSaneOpts() and RestoreOpts() functions,
          so options that cause issues are set to sane values
          and restored back to their initial values later on.
          (this affects the 'shellslash' option on windows, which also
          changes how the shellescape() function works)

https://github.com/vim/vim/commit/19636be55e023cb726389107e9e7d62049b6fd58

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:a336d8f: runtime(zip): increment base version of zip plugin

Problem:  the zip plugin version is still v33
Solution: increment the version to v34

https://github.com/vim/vim/commit/a336d8f21e4cce877e23d47db238801a5a406992

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:8d52926: runtime(zip): add a generic Message function

Problem:  the zip plugin duplicates a lot of code for displaying
          warnings/errors
Solution: refactor common code into a generic Mess() function

https://github.com/vim/vim/commit/8d52926857ec7f08a9bee8f96470748cecf58002

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:afea6b9: runtime(zip): use defer to restore old settings

Problem:  RestoreOpts() plugin called too often
Solution: use :defer to have the RestoreOpts() function
          called when the function returns automatically

https://github.com/vim/vim/commit/afea6b946827e964271eb19579946a7f88d2f329

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.0663: tests: zip test still resets 'shellslash' option

Problem:  tests: zip test still resets 'shellslash' option
Solution: Remove resetting the 'shellslash' option, the zip
          plugin should now be able to handle this options

closes: vim/vim#15434

https://github.com/vim/vim/commit/91efcd115e700725b9ebded0f5d7bc0d3fa98d9d

Co-authored-by: Christian Brabandt <cb@256bit.org>