### PR TITLE
vim-patch:39eff4c: runtime(proto): Add indent script for protobuf filetype

### DIFF
--- a/runtime/indent/proto.vim
+++ b/runtime/indent/proto.vim
@@ -1,0 +1,19 @@
+" Vim indent file
+" Language:	Protobuf
+" Maintainer:	David Pedersen <limero@me.com>
+" Last Change:	2024 Aug 07
+
+" Only load this indent file when no other was loaded.
+if exists("b:did_indent")
+  finish
+endif
+let b:did_indent = 1
+
+" Protobuf is like indenting C
+setlocal cindent
+setlocal expandtab
+setlocal shiftwidth=2
+
+let b:undo_indent = "setlocal cindent< expandtab< shiftwidth<"
+
+" vim: sw=2 sts=2 et


### PR DESCRIPTION
closes: vim/vim#15446

https://github.com/vim/vim/commit/39eff4cdc055a0f0db0d32fcf7a74fe30ea54f25

Co-authored-by: David Pedersen <limero@me.com>
