### PR TITLE
vim-patch:8.2.{3476,3477}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2959,7 +2959,17 @@ int setfname(buf_T *buf, char *ffname_arg, char *sfname_arg, bool message)
       obuf = buflist_findname_file_id(ffname, &file_id, file_id_valid);
     }
     if (obuf != NULL && obuf != buf) {
-      if (obuf->b_ml.ml_mfp != NULL) {          // it's loaded, fail
+      bool in_use = false;
+
+      // during startup a window may use a buffer that is not loaded yet
+      FOR_ALL_TAB_WINDOWS(tab, win) {
+        if (win->w_buffer == obuf) {
+          in_use = true;
+        }
+      }
+
+      // it's loaded or used in a window, fail
+      if (obuf->b_ml.ml_mfp != NULL || in_use) {
         if (message) {
           emsg(_("E95: Buffer with this name already exists"));
         }

--- a/test/old/testdir/test_startup.vim
+++ b/test/old/testdir/test_startup.vim
@@ -1276,4 +1276,34 @@ func Test_write_in_vimrc()
   call delete('Xvimrc')
 endfunc
 
+func Test_echo_true_in_cmd()
+  CheckNotGui
+
+  let lines =<< trim END
+      echo v:true
+      call writefile(['done'], 'Xresult')
+      quit
+  END
+  call writefile(lines, 'Xscript')
+  if RunVim([], [], '--cmd "source Xscript"')
+    call assert_equal(['done'], readfile('Xresult'))
+  endif
+  call delete('Xscript')
+  call delete('Xresult')
+endfunc
+
+func Test_rename_buffer_on_startup()
+  let lines =<< trim END
+      call writefile(['done'], 'Xresult')
+      qa!
+  END
+  call writefile(lines, 'Xscript')
+  if RunVim([], [], "--clean -e -s --cmd 'file x|new|file x' --cmd 'so Xscript'")
+    call assert_equal(['done'], readfile('Xresult'))
+  endif
+  call delete('Xscript')
+  call delete('Xresult')
+endfunc
+
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_startup.vim
+++ b/test/old/testdir/test_startup.vim
@@ -1293,6 +1293,8 @@ func Test_echo_true_in_cmd()
 endfunc
 
 func Test_rename_buffer_on_startup()
+  CheckUnix
+
   let lines =<< trim END
       call writefile(['done'], 'Xresult')
       qa!


### PR DESCRIPTION
#### vim-patch:8.2.3476: renaming a buffer on startup may cause using freed memory

Problem:    Renaming a buffer on startup may cause using freed memory.
Solution:   Check if the buffer is used in a window.

https://github.com/vim/vim/commit/d3710cf01ef6ab1b2f233866ff01dab76686f642

Cherry-pick Test_echo_true_in_cmd() from Vim.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.3477: startup test fails on MS-Windows

Problem:    Startup test fails on MS-Windows.
Solution:   Skip the test if not on Unix.

https://github.com/vim/vim/commit/6d197987745427801a2195836ef89e48537afbeb

Co-authored-by: Bram Moolenaar <Bram@vim.org>