### PR TITLE
vim-patch:8.1.1413: error when the drive of the swap file was disconnected

### DIFF
--- a/src/nvim/memfile_defs.h
+++ b/src/nvim/memfile_defs.h
@@ -46,6 +46,8 @@ typedef struct {
   char *mf_fname;                    ///< name of the file
   char *mf_ffname;                   ///< idem, full path
   int mf_fd;                         ///< file descriptor
+  int mf_flags;                      ///< flags used when opening this memfile
+  bool mf_reopen;                    ///< mf_fd was closed, retry opening
   bhdr_T *mf_free_first;             ///< first block header in free list
 
   /// The used blocks are kept in mf_hash.


### PR DESCRIPTION
#### vim-patch:8.1.1413: error when the drive of the swap file was disconnected

Problem:    Error when the drive of the swap file was disconnected.
Solution:   Try closing and re-opening the swap file.

https://github.com/vim/vim/commit/b58a4b938c4bc7e0499700859bd7abba9acc5b11

Co-authored-by: Bram Moolenaar <Bram@vim.org>