### PR TITLE
vim-patch: Check NoDefaultCurrentDirectoryInExePath

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1256,8 +1256,10 @@ executable({expr})                                                *executable()*
 		This function checks if an executable with the name {expr}
 		exists.  {expr} must be the name of the program without any
 		arguments.
+
 		executable() uses the value of $PATH and/or the normal
-		searchpath for programs.		*PATHEXT*
+		searchpath for programs.
+							*PATHEXT*
 		On MS-Windows the ".exe", ".bat", etc. can optionally be
 		included.  Then the extensions in $PATHEXT are tried.  Thus if
 		"foo.exe" does not exist, "foo.exe.bat" can be found.  If
@@ -1267,8 +1269,13 @@ executable({expr})                                                *executable()*
 		then the name is also tried without adding an extension.
 		On MS-Windows it only checks if the file exists and is not a
 		directory, not if it's really executable.
-		On Windows an executable in the same directory as Vim is
-		always found (it is added to $PATH at |startup|).
+		On MS-Windows an executable in the same directory as the Vim
+		executable is always found (it's added to $PATH at |startup|).
+					*NoDefaultCurrentDirectoryInExePath*
+		On MS-Windows an executable in Vim's current working directory
+		is also normally found, but this can be disabled by setting
+		the $NoDefaultCurrentDirectoryInExePath environment variable.
+
 		The result is a Number:
 			1	exists
 			0	does not exist

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -1586,8 +1586,10 @@ function vim.fn.eventhandler() end
 --- This function checks if an executable with the name {expr}
 --- exists.  {expr} must be the name of the program without any
 --- arguments.
+---
 --- executable() uses the value of $PATH and/or the normal
---- searchpath for programs.    *PATHEXT*
+--- searchpath for programs.
+---           *PATHEXT*
 --- On MS-Windows the ".exe", ".bat", etc. can optionally be
 --- included.  Then the extensions in $PATHEXT are tried.  Thus if
 --- "foo.exe" does not exist, "foo.exe.bat" can be found.  If
@@ -1597,8 +1599,13 @@ function vim.fn.eventhandler() end
 --- then the name is also tried without adding an extension.
 --- On MS-Windows it only checks if the file exists and is not a
 --- directory, not if it's really executable.
---- On Windows an executable in the same directory as Vim is
---- always found (it is added to $PATH at |startup|).
+--- On MS-Windows an executable in the same directory as the Vim
+--- executable is always found (it's added to $PATH at |startup|).
+---       *NoDefaultCurrentDirectoryInExePath*
+--- On MS-Windows an executable in Vim's current working directory
+--- is also normally found, but this can be disabled by setting
+--- the $NoDefaultCurrentDirectoryInExePath environment variable.
+---
 --- The result is a Number:
 ---   1  exists
 ---   0  does not exist

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -2059,8 +2059,10 @@ M.funcs = {
       This function checks if an executable with the name {expr}
       exists.  {expr} must be the name of the program without any
       arguments.
+
       executable() uses the value of $PATH and/or the normal
-      searchpath for programs.		*PATHEXT*
+      searchpath for programs.
+      					*PATHEXT*
       On MS-Windows the ".exe", ".bat", etc. can optionally be
       included.  Then the extensions in $PATHEXT are tried.  Thus if
       "foo.exe" does not exist, "foo.exe.bat" can be found.  If
@@ -2070,8 +2072,13 @@ M.funcs = {
       then the name is also tried without adding an extension.
       On MS-Windows it only checks if the file exists and is not a
       directory, not if it's really executable.
-      On Windows an executable in the same directory as Vim is
-      always found (it is added to $PATH at |startup|).
+      On MS-Windows an executable in the same directory as the Vim
+      executable is always found (it's added to $PATH at |startup|).
+      			*NoDefaultCurrentDirectoryInExePath*
+      On MS-Windows an executable in Vim's current working directory
+      is also normally found, but this can be disabled by setting
+      the $NoDefaultCurrentDirectoryInExePath environment variable.
+
       The result is a Number:
       	1	exists
       	0	does not exist

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -17,7 +17,6 @@
 #endif
 
 #include "auto/config.h"
-#include "nvim/errors.h"
 #include "nvim/os/fs.h"
 #include "nvim/os/os_defs.h"
 
@@ -36,6 +35,7 @@
 
 #include "nvim/api/private/helpers.h"
 #include "nvim/ascii_defs.h"
+#include "nvim/errors.h"
 #include "nvim/gettext_defs.h"
 #include "nvim/globals.h"
 #include "nvim/log.h"
@@ -356,10 +356,16 @@ static bool is_executable_in_path(const char *name, char **abspath)
   }
 
 #ifdef MSWIN
-  // Prepend ".;" to $PATH.
-  size_t pathlen = strlen(path_env);
-  char *path = memcpy(xmallocz(pathlen + 2), "." ENV_SEPSTR, 2);
-  memcpy(path + 2, path_env, pathlen);
+  char *path = NULL;
+  if (!os_env_exists("NoDefaultCurrentDirectoryInExePath")) {
+    // Prepend ".;" to $PATH.
+    size_t pathlen = strlen(path_env);
+    path = xmallocz(pathlen + 2);
+    memcpy(path, "." ENV_SEPSTR, 2);
+    memcpy(path + 2, path_env, pathlen);
+  } else {
+    path = xstrdup(path_env);
+  }
 #else
   char *path = xstrdup(path_env);
 #endif

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -3578,6 +3578,24 @@ func Test_isabsolutepath()
   endif
 endfunc
 
+" Test for exepath()
+func Test_exepath()
+  if has('win32')
+    call assert_notequal(exepath('cmd'), '')
+
+    let oldNoDefaultCurrentDirectoryInExePath = $NoDefaultCurrentDirectoryInExePath
+    call writefile(['@echo off', 'echo Evil'], 'vim-test-evil.bat')
+    let $NoDefaultCurrentDirectoryInExePath = ''
+    call assert_notequal(exepath("vim-test-evil.bat"), '')
+    let $NoDefaultCurrentDirectoryInExePath = '1'
+    call assert_equal(exepath("vim-test-evil.bat"), '')
+    let $NoDefaultCurrentDirectoryInExePath = oldNoDefaultCurrentDirectoryInExePath
+    call delete('vim-test-evil.bat')
+  else
+    call assert_notequal(exepath('sh'), '')
+  endif
+endfunc
+
 " Test for virtcol()
 func Test_virtcol()
   new


### PR DESCRIPTION
#### vim-patch:8.2.4860: MS-Windows: always uses current directory for executables

Problem:    MS-Windows: always uses current directory for executables.
Solution:   Check the NoDefaultCurrentDirectoryInExePath environment variable.
            (Yasuhiro Matsumoto, closes vim/vim#10341)

https://github.com/vim/vim/commit/05cf63e9bdca1ac070df3e7d9c6dfc45e68ac916

Omit doc change: override in later doc update.

Co-authored-by: Yasuhiro Matsumoto <mattn.jp@gmail.com>


#### vim-patch:0cc5dce: runtime(doc): clarify directory of Vim's executable vs CWD

According to :h win32-PATH, "the same directory as Vim" means the same
directory as the Vim executable, not Vim's current directory.  In patch
8.2.4860 these two concepts were mixed up.

closes: vim/vim#15451

https://github.com/vim/vim/commit/0cc5dce5780d39fe621f6146d4fb862318918125