### PR TITLE
vim-patch:9.1.0666: assert_equal() doesn't show multibyte string correctly

### DIFF
--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -130,7 +130,7 @@ static void ga_concat_shorten_esc(garray_T *gap, const char *str)
     return;
   }
 
-  for (const char *p = str; *p != NUL; p++) {
+  for (const char *p = str; *p != NUL;) {
     int same_len = 1;
     const char *s = p;
     const int c = mb_cptr2char_adv(&s);
@@ -146,9 +146,10 @@ static void ga_concat_shorten_esc(garray_T *gap, const char *str)
       vim_snprintf(buf, NUMBUFLEN, "%d", same_len);
       ga_concat(gap, buf);
       ga_concat(gap, " times]");
-      p = s - 1;
+      p = s;
     } else {
       ga_concat_esc(gap, p, clen);
+      p += clen;
     }
   }
 }

--- a/test/old/testdir/test_assert.vim
+++ b/test/old/testdir/test_assert.vim
@@ -48,8 +48,17 @@ func Test_assert_equal()
   call assert_match("Expected 'bar' but got 'foo'", v:errors[0])
   call remove(v:errors, 0)
 
+  let s = 'αβγ'
+  call assert_equal(1, assert_equal('δεζ', s))
+  call assert_match("Expected 'δεζ' but got 'αβγ'", v:errors[0])
+  call remove(v:errors, 0)
+
   call assert_equal('XxxxxxxxxxxxxxxxxxxxxxX', 'XyyyyyyyyyyyyyyyyyyyyyyyyyX')
   call assert_match("Expected 'X\\\\\\[x occurs 21 times]X' but got 'X\\\\\\[y occurs 25 times]X'", v:errors[0])
+  call remove(v:errors, 0)
+
+  call assert_equal('ΩωωωωωωωωωωωωωωωωωωωωωΩ', 'ΩψψψψψψψψψψψψψψψψψψψψψψψψψΩ')
+  call assert_match("Expected 'Ω\\\\\\[ω occurs 21 times]Ω' but got 'Ω\\\\\\[ψ occurs 25 times]Ω'", v:errors[0])
   call remove(v:errors, 0)
 
   " special characters are escaped


### PR DESCRIPTION
#### vim-patch:9.1.0666: assert_equal() doesn't show multibyte string correctly

Problem:  assert_equal() doesn't show multibyte string correctly
Solution: Properly advance over a multibyte char.
          (zeertzjq)

closes: vim/vim#15456

https://github.com/vim/vim/commit/9c4b2462bb498f44044616f7309d111d12170369