### PR TITLE
vim-patch:9.1.0667: Some other options reset curswant unnecessarily when set

### DIFF
--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1321,7 +1321,6 @@ return {
       ]=],
       full_name = 'comments',
       list = 'onecomma',
-      redraw = { 'curswant' },
       scope = { 'buffer' },
       short_desc = N_('patterns that can start a comment line'),
       tags = { 'E524', 'E525' },
@@ -1339,7 +1338,6 @@ return {
         Used for |commenting| and to add markers for folding, see |fold-marker|.
       ]=],
       full_name = 'commentstring',
-      redraw = { 'curswant' },
       scope = { 'buffer' },
       short_desc = N_('template for comments; used for fold marker'),
       tags = { 'E537' },
@@ -1975,7 +1973,6 @@ return {
         <
       ]=],
       full_name = 'define',
-      redraw = { 'curswant' },
       scope = { 'global', 'buffer' },
       short_desc = N_('pattern to be used to find a macro definition'),
       type = 'string',

--- a/test/old/testdir/test_goto.vim
+++ b/test/old/testdir/test_goto.vim
@@ -322,6 +322,7 @@ func Test_set_options_keep_col()
   normal j
   set invhlsearch spell spelllang=en,cjk spelloptions=camel textwidth=80
   set cursorline cursorcolumn cursorlineopt=line colorcolumn=+1 winfixbuf
+  set comments=:# commentstring=#%s define=function
   set background=dark
   set background=light
   normal k
@@ -329,6 +330,7 @@ func Test_set_options_keep_col()
   bwipe!
   set hlsearch& spell& spelllang& spelloptions& textwidth&
   set cursorline& cursorcolumn& cursorlineopt& colorcolumn& winfixbuf&
+  set comments& commentstring& define&
   set background&
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.0667: Some other options reset curswant unnecessarily when set

Problem:  Some other options reset curswant unnecessarily when set.
          (Andrew Haust)
Solution: Don't reset curswant when setting 'comments', 'commentstring'
          or 'define' (zeertzjq)

closes: vim/vim#15467

https://github.com/vim/vim/commit/b026a293b1e9d7a30f7717e256fe5f7f1dfa20d7