### PR TITLE
vim-patch:9.1.0672: marker folds may get corrupted on undo

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1336,6 +1336,9 @@ void deleteFoldRecurse(buf_T *bp, garray_T *gap)
 
 // foldMarkAdjust() {{{2
 /// Update line numbers of folds for inserted/deleted lines.
+///
+/// We are adjusting the folds in the range from line1 til line2,
+/// make sure that line2 does not get smaller than line1
 void foldMarkAdjust(win_T *wp, linenr_T line1, linenr_T line2, linenr_T amount,
                     linenr_T amount_after)
 {
@@ -1343,6 +1346,9 @@ void foldMarkAdjust(win_T *wp, linenr_T line1, linenr_T line2, linenr_T amount,
   // lines, set line2 so that only deleted lines have their folds removed.
   if (amount == MAXLNUM && line2 >= line1 && line2 - line1 >= -amount_after) {
     line2 = line1 - amount_after - 1;
+  }
+  if (line2 < line1) {
+    line2 = line1;
   }
   // If appending a line in Insert mode, it should be included in the fold
   // just above the line.

--- a/test/old/testdir/test_fold.vim
+++ b/test/old/testdir/test_fold.vim
@@ -1756,4 +1756,25 @@ func Test_cursor_down_fold_eob()
   bwipe!
 endfunc
 
+" issue: #15455
+func Test_cursor_fold_marker_undo()
+  new
+  call setline(1, ['{{{', '', 'This is a Line', '', 'This is a Line', '', '}}}'])
+  let &ul=&ul
+  setl foldmethod=marker
+  call cursor(2, 1)
+  norm! zo1vjdu
+  call assert_equal(1, foldlevel('.'))
+  bwipe!
+  new
+  call setline(1, ['', '{{{', '', 'This is a Line', '', 'This is a Line', '', '}}}'])
+  let &ul=&ul
+  setl foldmethod=marker
+  call cursor(3, 1)
+  norm! zo
+  norm! vjdu
+  call assert_equal(1, foldlevel('.'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0672: marker folds may get corrupted on undo

Problem:  marker folds may get corrupted on undo (Yousef Mohammed)
Solution: when adjusting folds, make sure that line1 is the lower limit
          and line2 is the upper line limit. In particular, line2 should
          not be able to get smaller than line1.

closes: vim/vim#15466

https://github.com/vim/vim/commit/8d02e5cf961b06da5bc490ac5972bcbc252c4793

Co-authored-by: Christian Brabandt <cb@256bit.org>