### PR TITLE
fix(lsp): avoids an additional request.

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -403,6 +403,10 @@ local function trigger(bufnr, clients)
   reset_timer()
   Context:cancel_pending()
 
+  if tonumber(vim.fn.pumvisible()) == 1 and Context.isIncomplete then
+    return
+  end
+
   local win = api.nvim_get_current_win()
   local cursor_row, cursor_col = unpack(api.nvim_win_get_cursor(win)) --- @type integer, integer
   local line = api.nvim_get_current_line()


### PR DESCRIPTION
Problem: if result.item is empty there still invoke complete function.

Solution: when matches is empty no need invoke complete.