### PR TITLE
fix(highlight): fix the seg fault caused by the invalid linked hl ids

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -774,7 +774,8 @@ int object_to_hl_id(Object obj, const char *what, Error *err)
     String str = obj.data.string;
     return str.size ? syn_check_group(str.data, str.size) : 0;
   } else if (obj.type == kObjectTypeInteger) {
-    return MAX((int)obj.data.integer, 0);
+    int id = (int)obj.data.integer;
+    return (1 <= id && id <= highlight_num_groups()) ? id : 0;
   } else {
     api_set_error(err, kErrorTypeValidation, "Invalid highlight: %s", what);
     return 0;

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1648,6 +1648,7 @@ static bool hlgroup2dict(Dictionary *hl, NS ns_id, int hl_id, Arena *arena)
     PUT_C(*hl, "default", BOOLEAN_OBJ(true));
   }
   if (link > 0) {
+    assert(1 <= link && link <= highlight_ga.ga_len);
     PUT_C(*hl, "link", CSTR_AS_OBJ(hl_table[link - 1].sg_name));
   }
   Dictionary hl_cterm = arena_dict(arena, HLATTRS_DICT_SIZE);


### PR DESCRIPTION
Problem:
Accessing a hl group linking to an out-of-bounds (> `highlight_ga.ga_len`) hl id causes seg fault. Case can be reproduced by simply running `nvim --clean -u segv.lua` with `segv.lua` having:
```lua
vim.api.nvim_set_hl(0, 'SegV', { link = 9999 }) -- linked id needs to be large enough
vim.api.nvim_get_hl(0, { name = 'SegV' })
```

Solution:
Add the boundary check for the linked id. Ignores the linkage when id exceeds the boundary, like when id <= 0.
Additional boundary check assertion is added before accessing `hl_table` as the last guard. (Not sure if this one is necessary.)