### PR TITLE
fix(lsp): when prefix is non word add all result into matches

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -237,7 +237,7 @@ function M._lsp_to_complete_items(result, prefix, client_id)
 
   ---@type fun(item: lsp.CompletionItem):boolean
   local matches
-  if prefix == '' then
+  if not prefix:find('%w') then
     matches = function(_)
       return true
     end


### PR DESCRIPTION
Problem: prefix can be a symbol like period, the fuzzy mathes can't handle it correctly.

Solution: when prefix is empty or a symbol add all lsp completion result into matches.