### PR TITLE
revert: "fix(man): handle absolute paths as `:Man` targets (#20624)"

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -267,14 +267,6 @@ local function get_path(sect, name, silent)
     return
   end
 
-  -- `man -w /some/path` will return `/some/path` for any existent file, which
-  -- stops us from actually determining if a path has a corresponding man file.
-  -- Since `:Man /some/path/to/man/file` isn't supported anyway, we should just
-  -- error out here if we detect this is the case.
-  if sect == '' and #results == 1 and results[1] == name then
-    return
-  end
-
   -- find any that match the specified name
   ---@param v string
   local namematches = vim.tbl_filter(function(v)

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -8,12 +8,7 @@ local exec_lua = n.exec_lua
 local fn = n.fn
 local nvim_prog = n.nvim_prog
 local matches = t.matches
-local write_file = t.write_file
-local tmpname = t.tmpname
 local eq = t.eq
-local pesc = vim.pesc
-local skip = t.skip
-local is_ci = t.is_ci
 
 -- Collects all names passed to find_path() after attempting ":Man foo".
 local function get_search_history(name)
@@ -221,20 +216,21 @@ describe(':Man', function()
     matches('quit works!!', fn.system(args, { 'manpage contents' }))
   end)
 
-  it('reports non-existent man pages for absolute paths', function()
-    skip(is_ci('cirrus'))
-    local actual_file = tmpname()
-    -- actual_file must be an absolute path to an existent file for us to test against it
-    matches('^/.+', actual_file)
-    write_file(actual_file, '')
-    local args = { nvim_prog, '--headless', '+:Man ' .. actual_file, '+q' }
-    matches(
-      ('Error detected while processing command line:\r\n' .. 'man.lua: "no manual entry for %s"'):format(
-        pesc(actual_file)
-      ),
-      fn.system(args, { '' })
-    )
-    os.remove(actual_file)
+  it('supports passing a path to a man page', function()
+    local screen = Screen.new(60, 8)
+    screen:attach()
+    command('runtime plugin/man.lua')
+    command('hide Man src/man/nvim.1')
+    screen:expect([[
+      ^NVIM(1)            General Commands Manual          NVIM(1) |
+                                                                  |
+      NAME                                                        |
+             nvim — edit text                                     |
+                                                                  |
+      SYNOPSIS                                                    |
+             nvim [options] [file ...]                            |
+                                                                  |
+    ]])
   end)
 
   it('tries variants with spaces, underscores #22503', function()


### PR DESCRIPTION
This reverts commit 39911d76be560c998cc7dee51c5d94f811164f66.

Restores support for the :Man {path} mentioned in the help.
