### PR TITLE
feat(lsp): support pull diagnostics on save via flag

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1033,6 +1033,11 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                   `150`) Debounce `didChange` notifications to
                                   the server by the given number in
                                   milliseconds. No debounce occurs if `nil`.
+                                • {pull_diagnostics_on_save} (`boolean`,
+                                  default: `false`) Request diagnostics from
+                                  the server on `didSave` events instead of
+                                  `didChange` events. Has no effect if the
+                                  server does not support pull diagnostics.
                                 • {exit_timeout} (`integer|false`, default:
                                   `false`) Milliseconds to wait for server to
                                   exit cleanly after sending the "shutdown"
@@ -1204,6 +1209,11 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                 `150`) Debounce `didChange` notifications to
                                 the server by the given number in
                                 milliseconds. No debounce occurs if `nil`.
+                              • {pull_diagnostics_on_save} (`boolean`,
+                                default: `false`) Request diagnostics from the
+                                server on `didSave` events instead of
+                                `didChange` events. Has no effect if the
+                                server does not support pull diagnostics.
                               • {exit_timeout} (`integer|false`, default:
                                 `false`) Milliseconds to wait for server to
                                 exit cleanly after sending the "shutdown"

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -130,6 +130,8 @@ LSP
 
 • Completion side effects (including snippet expansion, execution of commands
   and application of additional text edits) is now built-in.
+• |vim.lsp.Client| flag `pull_diagnostic_on_save` sends diagnostic requests on
+  save instead of change
 • |vim.lsp.util.locations_to_items()| sets `end_col` and `end_lnum` fields.
 • |vim.lsp.buf.format()| now supports passing a list of ranges
   via the `range` parameter (this requires support for the

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -23,6 +23,11 @@ local validate = vim.validate
 --- (default: `150`)
 --- @field debounce_text_changes integer
 ---
+--- Request diagnostics from the server on `didSave` events instead of `didChange` events.
+--- Has no effect if the server does not support pull diagnostics.
+--- (default: `false`)
+--- @field pull_diagnostics_on_save boolean
+---
 --- Milliseconds to wait for server to exit cleanly after sending the
 --- "shutdown" request before sending kill -15. If set to false, nvim exits
 --- immediately after sending the "shutdown" request to the server.


### PR DESCRIPTION
Problem:
Some lsp servers can be configured to refresh diagnostics on save to avoid performance issues. The introduction of pull diagnostics in 0.10 goes around those settings by requesting diagnostics with every change event. See #29792

Solution:
Add an optional lsp client flag to request diagnostics on save if the lsp server supports pull diagnostics. By default, the existing behavior is maintained and diagnostics are requested with every change event, if the server supports pull diagnostics.