### PR TITLE
fix(terminal): interrupt/got_int hangs terminal

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -781,6 +781,11 @@ static int terminal_execute(VimState *state, int key)
     FALLTHROUGH;
 
   default:
+    if (key == Ctrl_C) {
+      // terminal_enter unconditionally sets `mapped_ctrl_c` to avoid `got_int`. 8eeda7169aa4
+      // But `got_int` may be set elsewhere, e.g. by interrupt(). So ensure that it is cleared.
+      got_int = false;
+    }
     if (key == Ctrl_BSL && !s->got_bsl) {
       s->got_bsl = true;
       break;

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -782,8 +782,9 @@ static int terminal_execute(VimState *state, int key)
 
   default:
     if (key == Ctrl_C) {
-      // terminal_enter unconditionally sets `mapped_ctrl_c` to avoid `got_int`. 8eeda7169aa4
-      // But `got_int` may be set elsewhere, e.g. by interrupt(). So ensure that it is cleared.
+      // terminal_enter() always sets `mapped_ctrl_c` to avoid `got_int`. 8eeda7169aa4
+      // But `got_int` may be set elsewhere, e.g. by interrupt() or an autocommand,
+      // so ensure that it is cleared.
       got_int = false;
     }
     if (key == Ctrl_BSL && !s->got_bsl) {

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -555,6 +555,22 @@ describe('terminal input', function()
   end)
 end)
 
+describe('terminal', function()
+  it('external interrupt (got_int) does not hang #20726', function()
+    clear()
+    command('au ModeChanged * let g:event = copy(v:event)')
+    command('au TermEnter * call timer_start(500, {-> interrupt()})')
+
+    command('term')
+    feed('i')
+    sleep(510)
+    eq({ old_mode = 'nt', new_mode = 't' }, eval('g:event'))
+    feed('<c-\\><c-n>')
+    eq({ old_mode = 't', new_mode = 'nt' }, eval('g:event'))
+    command('bd!')
+  end)
+end)
+
 if is_os('win') then
   describe(':terminal in Windows', function()
     local screen

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -312,6 +312,16 @@ describe(':terminal buffer', function()
       pcall_err(command, 'write test/functional/fixtures/tty-test.c')
     )
   end)
+
+  it('external interrupt (got_int) does not hang #20726', function()
+    eq({ mode = 't', blocking = false }, api.nvim_get_mode())
+    command('call timer_start(0, {-> interrupt()})')
+    feed('<Ignore>') -- Add input to separate two RPC requests
+    eq({ mode = 't', blocking = false }, api.nvim_get_mode())
+    feed([[<C-\><C-N>]])
+    eq({ mode = 'nt', blocking = false }, api.nvim_get_mode())
+    command('bd!')
+  end)
 end)
 
 describe(':terminal buffer', function()
@@ -552,22 +562,6 @@ describe('terminal input', function()
         {3:-- TERMINAL --}                                    |
       ]]):format(key))
     end
-  end)
-end)
-
-describe('terminal', function()
-  it('external interrupt (got_int) does not hang #20726', function()
-    clear()
-    command('au ModeChanged * let g:event = copy(v:event)')
-    command('au TermEnter * call timer_start(500, {-> interrupt()})')
-
-    command('term')
-    feed('i')
-    sleep(510)
-    eq({ old_mode = 'nt', new_mode = 't' }, eval('g:event'))
-    feed('<c-\\><c-n>')
-    eq({ old_mode = 't', new_mode = 'nt' }, eval('g:event'))
-    command('bd!')
   end)
 end)
 


### PR DESCRIPTION
`terminal_execute` should always clear `got_int` or `safe_vgetc` will keep returning `Ctrl_C` in an endless loop.

Minimal reproduction of the issue:
> will cause neovim to hang with 100% CPU prior to this patch
```vim
:autocmd TermEnter * call timer_start(500, {-> interrupt()})
:new | term
:startinsert
```

Closes #20726