### PR TITLE
docs(diagnostic): diagnostic.Opts.Float extend open_floating_preview.Opts

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -568,6 +568,8 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
                              |vim.diagnostic.Opts.Jump|.
 
 *vim.diagnostic.Opts.Float*
+    Extends: |vim.lsp.util.open_floating_preview.Opts|
+
 
     Fields: ~
       • {bufnr}?          (`integer`, default: current buffer) Buffer number
@@ -576,7 +578,7 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
                           namespace(s).
       • {scope}?          (`'line'|'buffer'|'cursor'|'c'|'l'|'b'`, default:
                           `line`) Show diagnostics from the whole buffer
-                          (`buffer"`, the current cursor line (`line`), or the
+                          (`buffer`), the current cursor line (`line`), or the
                           current cursor position (`cursor`). Shorthand
                           versions are also accepted (`c` for `cursor`, `l`
                           for `line`, `b` for `buffer`).
@@ -625,8 +627,6 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
                           Same as {prefix}, but appends the text to the
                           diagnostic instead of prepending it. Overrides the
                           setting from |vim.diagnostic.config()|.
-      • {focus_id}?       (`string`)
-      • {border}?         (`string|string[]`) see |nvim_open_win()|.
 
 *vim.diagnostic.Opts.Jump*
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -119,7 +119,7 @@ end
 --- @field signs vim.diagnostic.Opts.Signs
 --- @field severity_sort {reverse?:boolean}
 
---- @class vim.diagnostic.Opts.Float
+--- @class vim.diagnostic.Opts.Float : vim.lsp.util.open_floating_preview.Opts
 ---
 --- Buffer number to show diagnostics from.
 --- (default: current buffer)
@@ -128,7 +128,7 @@ end
 --- Limit diagnostics to the given namespace(s).
 --- @field namespace? integer|integer[]
 ---
---- Show diagnostics from the whole buffer (`buffer"`, the current cursor line
+--- Show diagnostics from the whole buffer (`buffer`), the current cursor line
 --- (`line`), or the current cursor position (`cursor`). Shorthand versions
 --- are also accepted (`c` for `cursor`, `l` for `line`, `b` for `buffer`).
 --- (default: `line`)
@@ -183,10 +183,6 @@ end
 --- prepending it.
 --- Overrides the setting from |vim.diagnostic.config()|.
 --- @field suffix? string|table|(fun(diagnostic:vim.Diagnostic,i:integer,total:integer): string, string)
----
---- @field focus_id? string
----
---- @field border? string|string[] see |nvim_open_win()|.
 
 --- @class vim.diagnostic.Opts.Underline
 ---


### PR DESCRIPTION
Problem: the opts table also is param of util.open_floating_preview, vim.diagnostic.Opts.Float missing some fields of open_floating_preview.

Solution: diagnostic.Opts.Float extend util.open_floating_preview.Opts

Fix #29267