### PR TITLE
feat(lsp): export diagnostic conversion functions

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1486,6 +1486,15 @@ workspace_symbol({query}, {opts})             *vim.lsp.buf.workspace_symbol()*
 ==============================================================================
 Lua module: vim.lsp.diagnostic                                *lsp-diagnostic*
 
+from({diagnostics})                                *vim.lsp.diagnostic.from()*
+    Converts the input `vim.Diagnostic`s to LSP diagnostics.
+
+    Parameters: ~
+      • {diagnostics}  (`vim.Diagnostic[]`)
+
+    Return: ~
+        (`lsp.Diagnostic[]`)
+
                                           *vim.lsp.diagnostic.get_namespace()*
 get_namespace({client_id}, {is_pull})
     Get the diagnostic namespace associated with an LSP client

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -68,6 +68,8 @@ LSP
 • Add convert field in |vim.lsp.completion.BufferOpts| of
   |vim.lsp.completion.enable()| an optional function used to customize the
   transformation of an Lsp CompletionItem to |complete-items|.
+• |vim.lsp.diagnostic.from()| can now be used to convert a given list of `vim`
+  diagnostics to their LSP representation.
 
 LUA
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -68,8 +68,8 @@ LSP
 • Add convert field in |vim.lsp.completion.BufferOpts| of
   |vim.lsp.completion.enable()| an optional function used to customize the
   transformation of an Lsp CompletionItem to |complete-items|.
-• |vim.lsp.diagnostic.from()| can now be used to convert a given list of `vim`
-  diagnostics to their LSP representation.
+• |vim.lsp.diagnostic.from()| can be used to convert a list of
+  |vim.Diagnostic| objects into their LSP diagnostic representation.
 
 LUA
 

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -153,9 +153,10 @@ local function tags_vim_to_lsp(diagnostic)
   return tags
 end
 
+--- Converts the input `vim.Diagnostic`s to LSP diagnostics.
 --- @param diagnostics vim.Diagnostic[]
 --- @return lsp.Diagnostic[]
-local function diagnostic_vim_to_lsp(diagnostics)
+function M.from(diagnostics)
   ---@param diagnostic vim.Diagnostic
   ---@return lsp.Diagnostic
   return vim.tbl_map(function(diagnostic)
@@ -385,7 +386,7 @@ function M.get_line_diagnostics(bufnr, line_nr, opts, client_id)
 
   diag_opts.lnum = line_nr or (api.nvim_win_get_cursor(0)[1] - 1)
 
-  return diagnostic_vim_to_lsp(vim.diagnostic.get(bufnr, diag_opts))
+  return M.from(vim.diagnostic.get(bufnr, diag_opts))
 end
 
 --- Clear diagnostics from pull based clients


### PR DESCRIPTION
Now that `vim.diagnostic.get` is the only way to obtain diagnostics, it's sometimes necessary to convert these to their LSP equivalent for use with other functions.

Example: When sending a code action request and including the diagnostics in the current line as context.