### PR TITLE
vim-patch: :keepp does not retain last substitute string

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -348,7 +348,7 @@ terminals)
 
 :keepp[atterns] {command}			*:keepp* *:keeppatterns*
 		Execute {command}, without adding anything to the search
-		history or modifying the last substitute pattern.
+		history or modifying the last substitute string for |:&|.
 
 ==============================================================================
 2. Command-line completion				*cmdline-completion*

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -348,7 +348,7 @@ terminals)
 
 :keepp[atterns] {command}			*:keepp* *:keeppatterns*
 		Execute {command}, without adding anything to the search
-		history
+		history or modifying the last substitute pattern.
 
 ==============================================================================
 2. Command-line completion				*cmdline-completion*

--- a/test/old/testdir/test_substitute.vim
+++ b/test/old/testdir/test_substitute.vim
@@ -806,7 +806,7 @@ func Test_replace_keeppatterns()
   a
 foobar
 
-substitute foo asdf
+substitute foo asdf foo
 
 one two
 .
@@ -815,21 +815,26 @@ one two
   /^substitute
   s/foo/bar/
   call assert_equal('foo', @/)
-  call assert_equal('substitute bar asdf', getline('.'))
+  call assert_equal('substitute bar asdf foo', getline('.'))
 
   /^substitute
   keeppatterns s/asdf/xyz/
   call assert_equal('^substitute', @/)
-  call assert_equal('substitute bar xyz', getline('.'))
+  call assert_equal('substitute bar xyz foo', getline('.'))
+
+  /^substitute
+  &
+  call assert_equal('^substitute', @/)
+  call assert_equal('substitute bar xyz bar', getline('.'))
 
   exe "normal /bar /e\<CR>"
   call assert_equal(15, col('.'))
   normal -
   keeppatterns /xyz
   call assert_equal('bar ', @/)
-  call assert_equal('substitute bar xyz', getline('.'))
+  call assert_equal('substitute bar xyz bar', getline('.'))
   exe "normal 0dn"
-  call assert_equal('xyz', getline('.'))
+  call assert_equal('xyz bar', getline('.'))
 
   close!
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.0677: :keepp does not retain the substitute pattern

Problem:  :keeppatterns does not retain the substitute pattern
          for a :s command
Solution: preserve the last substitute pattern when used with the
          :keeppatterns command modifier (Gregory Anders)

closes: vim/vim#15497

https://github.com/vim/vim/commit/3b59be4ed8a145d3188934f1a5cd85432bd2433d

Co-authored-by: Gregory Anders <greg@gpanders.com>