### PR TITLE
fix(vim.text): handle very long strings

### DIFF
--- a/runtime/lua/vim/text.lua
+++ b/runtime/lua/vim/text.lua
@@ -7,10 +7,9 @@ local M = {}
 --- @param str string String to encode
 --- @return string : Hex encoded string
 function M.hexencode(str)
-  local bytes = { str:byte(1, #str) }
   local enc = {} ---@type string[]
-  for i = 1, #bytes do
-    enc[i] = string.format('%02X', bytes[i])
+  for i = 1, #str do
+    enc[i] = string.format('%02X', str:byte(i, i + 1))
   end
   return table.concat(enc)
 end

--- a/test/functional/lua/text_spec.lua
+++ b/test/functional/lua/text_spec.lua
@@ -20,5 +20,11 @@ describe('vim.text', function()
         eq(input, vim.text.hexdecode(output))
       end
     end)
+
+    it('works with very large strings', function()
+      local input, output = string.rep('😂', 2 ^ 16), string.rep('F09F9882', 2 ^ 16)
+      eq(output, vim.text.hexencode(input))
+      eq(input, vim.text.hexdecode(output))
+    end)
   end)
 end)


### PR DESCRIPTION
Lua's string.byte has a maximum (undocumented) allowable length, so vim.text.hencode fails on large strings with the error "string slice too long".

Instead of converting the string to an array of bytes up front, convert each character to a byte one at a time.

Fixes: https://github.com/neovim/neovim/issues/29981