### PR TITLE
vim-patch:8e25d91: runtime(dist): verify that executable is in $PATH

### DIFF
--- a/runtime/autoload/dist/vim.vim
+++ b/runtime/autoload/dist/vim.vim
@@ -18,6 +18,10 @@ endif
 if !has('vim9script')
   function dist#vim#IsSafeExecutable(filetype, executable)
     let cwd = getcwd()
+    if empty(exepath(a:executable))
+      echomsg a:executable .. " not found in $PATH"
+      return v:false
+    endif
     return get(g:, a:filetype .. '_exec', get(g:, 'plugin_exec', 0)) &&
           \ (fnamemodify(exepath(a:executable), ':p:h') !=# cwd
           \ || (split($PATH, has('win32') ? ';' : ':')->index(cwd) != -1 &&


### PR DESCRIPTION
Otherwise, if the executable to be verified does not exist,
this would cause a false-positive in the 'IsSafeExecutable()' check,
because 'exepath(executable)' returns an empty string and
'fnamemodify('', ':p:h')' returns the current directory and as a result
the 'IsSafeExecutable()' returns false (for the wrong reason).

https://github.com/vim/vim/commit/8e25d91cb7bb4dc171cb4e95b1bb79a39400a13a

Co-authored-by: Christian Brabandt <cb@256bit.org>
