### PR TITLE
feat(treesitter): #trim! can trim all whitespace

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -280,6 +280,8 @@ TREESITTER
 • |LanguageTree:node_for_range()| gets anonymous and named nodes for a range
 • |vim.treesitter.get_node()| now takes an option `include_anonymous`, default
   false, which allows it to return anonymous nodes as well as named nodes.
+• |treesitter-directive-trim!| can trim all whitespace (not just empty lines)
+  from both sides of a node.
 
 TUI
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -245,15 +245,32 @@ The following directives are built in:
             (#gsub! @_node ".*%.(.*)" "%1")
 <
     `trim!`                                          *treesitter-directive-trim!*
-        Trim blank lines from the end of the node. This will set a new
-        `metadata[capture_id].range`.
+        Trims whitespace from the node. Sets a new
+        `metadata[capture_id].range`. Takes a capture ID and, optionally, four
+        integers to customize trimming behavior (`1` meaning trim, `0` meaning
+        don't trim). When only given a capture ID, trims blank lines (lines
+        that contain only whitespace, or are empty) from the end of the node
+        (for backwards compatibility). Can trim all whitespace from both sides
+        of the node if parameters are given.
 
+        Examples: >query
+            ; only trim blank lines from the end of the node
+            ; (equivalent to (#trim! @fold 0 0 1 0))
+            (#trim! @fold)
+
+            ; trim blank lines from both sides of the node
+            (#trim! @fold 1 0 1 0)
+
+            ; trim all whitespace around the node
+            (#trim! @fold 1 1 1 1)
+<
         Parameters: ~
             {capture_id}
+            {trim_start_linewise}
+            {trim_start_charwise}
+            {trim_end_linewise} (default `1` if only given {capture_id})
+            {trim_end_charwise}
 
-        Example: >query
-            (#trim! @fold)
-<
 Further directives can be added via |vim.treesitter.query.add_directive()|.
 Use |vim.treesitter.query.list_directives()| to list all available directives.
 

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -1,5 +1,6 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
+local ts_t = require('test.functional.treesitter.testutil')
 
 local clear = n.clear
 local dedent = t.dedent
@@ -8,6 +9,7 @@ local insert = n.insert
 local exec_lua = n.exec_lua
 local pcall_err = t.pcall_err
 local feed = n.feed
+local run_query = ts_t.run_query
 
 describe('treesitter parser API', function()
   before_each(function()
@@ -684,26 +686,13 @@ print()
         vim.treesitter.start(0, 'lua')
       end)
 
-      local function run_query()
-        return exec_lua(function(query_str)
-          local query = vim.treesitter.query.parse('lua', query_str)
-          local parser = vim.treesitter.get_parser()
-          local tree = parser:parse()[1]
-          local res = {}
-          for id, _, metadata in query:iter_captures(tree:root(), 0) do
-            table.insert(res, { query.captures[id], metadata[id].range })
-          end
-          return res
-        end, query_text)
-      end
-
       eq({
         { 'str', { 2, 12, 6, 10 } },
         { 'str', { 11, 10, 11, 10 } },
         { 'str', { 17, 10, 17, 10 } },
         { 'str', { 19, 10, 19, 10 } },
         { 'str', { 22, 15, 22, 25 } },
-      }, run_query())
+      }, run_query('lua', query_text))
     end)
 
     it('trims only empty lines by default (backwards compatible)', function()
@@ -726,23 +715,10 @@ print()
         vim.treesitter.start(0, 'markdown')
       end)
 
-      local function run_query()
-        return exec_lua(function(query_str)
-          local query = vim.treesitter.query.parse('markdown', query_str)
-          local parser = vim.treesitter.get_parser()
-          local tree = parser:parse()[1]
-          local res = {}
-          for id, _, metadata in query:iter_captures(tree:root(), 0) do
-            table.insert(res, { query.captures[id], metadata[id].range })
-          end
-          return res
-        end, query_text)
-      end
-
       eq({
         { 'fold', { 0, 0, 3, 0 } },
         { 'fold', { 4, 0, 7, 0 } },
-      }, run_query())
+      }, run_query('markdown', query_text))
     end)
   end)
 
@@ -761,32 +737,19 @@ print()
       vim.treesitter.start(0, 'c')
     end)
 
-    local function run_query()
-      return exec_lua(function()
-        local query = vim.treesitter.query.parse('c', query0)
-        local parser = vim.treesitter.get_parser()
-        local tree = parser:parse()[1]
-        local res = {}
-        for id, node in query:iter_captures(tree:root()) do
-          table.insert(res, { query.captures[id], node:range() })
-        end
-        return res
-      end)
-    end
-
     eq({
-      { 'function', 0, 0, 2, 1 },
-      { 'declaration', 1, 2, 1, 12 },
-    }, run_query())
+      { 'function', { 0, 0, 2, 1 } },
+      { 'declaration', { 1, 2, 1, 12 } },
+    }, run_query('c', query0))
 
     n.command 'normal ggO'
     insert('int a;')
 
     eq({
-      { 'declaration', 0, 0, 0, 6 },
-      { 'function', 1, 0, 3, 1 },
-      { 'declaration', 2, 2, 2, 12 },
-    }, run_query())
+      { 'declaration', { 0, 0, 0, 6 } },
+      { 'function', { 1, 0, 3, 1 } },
+      { 'declaration', { 2, 2, 2, 12 } },
+    }, run_query('c', query0))
   end)
 
   it('handles ranges when source is a multiline string (#20419)', function()

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -644,6 +644,108 @@ print()
     end)
   end)
 
+  describe('trim! directive', function()
+    it('can trim all whitespace', function()
+      -- luacheck: push ignore 611 613
+      insert([=[
+        print([[
+
+                  f
+           helllo
+        there
+        asdf
+        asdfassd   
+
+
+
+        ]])
+        print([[
+              
+              
+              
+        ]])
+
+        print([[]])
+
+        print([[
+        ]])
+
+        print([[     hello 😃    ]])
+      ]=])
+      -- luacheck: pop
+
+      local query_text = [[
+        ; query
+        ((string_content) @str
+          (#trim! @str 1 1 1 1))
+      ]]
+
+      exec_lua(function()
+        vim.treesitter.start(0, 'lua')
+      end)
+
+      local function run_query()
+        return exec_lua(function(query_str)
+          local query = vim.treesitter.query.parse('lua', query_str)
+          local parser = vim.treesitter.get_parser()
+          local tree = parser:parse()[1]
+          local res = {}
+          for id, _, metadata in query:iter_captures(tree:root(), 0) do
+            table.insert(res, { query.captures[id], metadata[id].range })
+          end
+          return res
+        end, query_text)
+      end
+
+      eq({
+        { 'str', { 2, 12, 6, 10 } },
+        { 'str', { 11, 10, 11, 10 } },
+        { 'str', { 17, 10, 17, 10 } },
+        { 'str', { 19, 10, 19, 10 } },
+        { 'str', { 22, 15, 22, 25 } },
+      }, run_query())
+    end)
+
+    it('trims only empty lines by default (backwards compatible)', function()
+      insert [[
+      ## Heading
+
+      With some text
+
+      ## And another
+
+      With some more]]
+
+      local query_text = [[
+        ; query
+        ((section) @fold
+          (#trim! @fold))
+      ]]
+
+      exec_lua(function()
+        vim.treesitter.start(0, 'markdown')
+      end)
+
+      local function run_query()
+        return exec_lua(function(query_str)
+          local query = vim.treesitter.query.parse('markdown', query_str)
+          local parser = vim.treesitter.get_parser()
+          local tree = parser:parse()[1]
+          local res = {}
+          for id, _, metadata in query:iter_captures(tree:root(), 0) do
+            table.insert(res, { query.captures[id], metadata[id].range })
+          end
+          return res
+        end, query_text)
+      end
+
+      eq({
+        { 'fold', { 0, 0, 3, 0 } },
+        { 'fold', { 4, 0, 7, 0 } },
+      }, run_query())
+    end)
+  end)
+
   it('tracks the root range properly (#22911)', function()
     insert([[
       int main() {

--- a/test/functional/treesitter/testutil.lua
+++ b/test/functional/treesitter/testutil.lua
@@ -1,0 +1,25 @@
+local n = require('test.functional.testnvim')()
+
+local exec_lua = n.exec_lua
+
+local M = {}
+
+---@param language string
+---@param query_string string
+function M.run_query(language, query_string)
+  return exec_lua(function(lang, query_str)
+    local query = vim.treesitter.query.parse(lang, query_str)
+    local parser = vim.treesitter.get_parser()
+    local tree = parser:parse()[1]
+    local res = {}
+    for id, node, metadata in query:iter_captures(tree:root(), 0) do
+      table.insert(
+        res,
+        { query.captures[id], metadata[id] and metadata[id].range or { node:range() } }
+      )
+    end
+    return res
+  end, language, query_string)
+end
+
+return M


### PR DESCRIPTION
This commit also implements more generic trimming, acting on all
whitespace (charwise) rather than just empty lines.

It will unblock
https://github.com/nvim-treesitter/nvim-treesitter/pull/3442 and allow
for properly concealing markdown bullet markers regardless of indent
width, e.g.