### PR TITLE
Add `fast` option to `vim.filetype.match()`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2515,6 +2515,10 @@ vim.filetype.match({args})                              *vim.filetype.match()*
                 • {contents}? (`string[]`) An array of lines representing file
                   contents to use for matching. Can be used with {filename}.
                   Mutually exclusive with {buf}.
+                • {fast}? (`boolean`) Whether to skip time consuming detection
+                  steps, like pattern and content matching. Makes detection
+                  significantly faster at the cost of slightly fewer filetypes
+                  detected.
                 • {filename}? (`string`) Filename to use for matching. When
                   {buf} is given, defaults to the filename of the given buffer
                   number. The file need not actually exist in the filesystem.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2538,6 +2538,10 @@ vim.filetype.match({args})                              *vim.filetype.match()*
                 • {contents}? (`string[]`) An array of lines representing file
                   contents to use for matching. Can be used with {filename}.
                   Mutually exclusive with {buf}.
+                • {fast}? (`boolean`) Whether to skip time consuming detection
+                  steps, like pattern and content matching. Makes detection
+                  significantly faster at the cost of slightly fewer filetypes
+                  detected.
                 • {filename}? (`string`) Filename to use for matching. When
                   {buf} is given, defaults to the filename of the given buffer
                   number. The file need not actually exist in the filesystem.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -187,6 +187,7 @@ LUA
 
 • |vim.ui.img| can display images. Use `:checkhealth img` to confirm your
   terminal supports it.
+• |vim.filetype.match()| now takes `fast` option to perform fast detection.
 • |vim.net.request()| can specify custom headers by passing `opts.headers`.
 • |vim.net.request()| can now accept  `method` param overload for multiple HTTP methods.
 • |writefile()| treats Lua strings as "blob", so it can be used to write

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -370,6 +370,7 @@ LUA
 
 • |vim.ui.img| can display images. Use `:checkhealth vim.health` to confirm
   your terminal supports it.
+• |vim.filetype.match()| now takes `fast` option to perform fast detection.
 • |vim.net.request()| can specify custom headers by passing `opts.headers`.
 • |vim.net.request()| can now accept  `method` param overload for multiple HTTP methods.
 • |writefile()| treats Lua and RPC strings as |Blob|, so it can be used to

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -3172,6 +3172,11 @@ end
 --- matching. Can be used with {filename}. Mutually exclusive
 --- with {buf}.
 --- @field contents? string[]
+---
+--- Whether to skip time consuming detection steps, like
+--- pattern and content matching. Makes detection significantly
+--- faster at the cost of slightly fewer filetypes detected.
+--- @field fast? boolean
 
 --- Perform filetype detection.
 ---
@@ -3220,6 +3225,7 @@ function M.match(args)
   local bufnr = args.buf
   local name = args.filename
   local contents = args.contents
+  local not_fast = not args.fast
 
   if bufnr and not name then
     name = api.nvim_buf_get_name(bufnr)
@@ -3248,11 +3254,13 @@ function M.match(args)
     -- Next, check the file path against available patterns with non-negative priority
     -- Cache match results of all parent patterns to improve performance
     local parent_matches = {}
-    do
-      local ft, on_detect =
-        match_pattern_sorted(name, path, tail, pattern_sorted_pos, parent_matches, bufnr)
-      if ft then
-        return ft, on_detect
+    if not_fast then
+      do
+        local ft, on_detect =
+          match_pattern_sorted(name, path, tail, pattern_sorted_pos, parent_matches, bufnr)
+        if ft then
+          return ft, on_detect
+        end
       end
     end
 
@@ -3267,17 +3275,20 @@ function M.match(args)
       end
     end
 
-    do -- Next, check patterns with negative priority
-      local ft, on_detect =
-        match_pattern_sorted(name, path, tail, pattern_sorted_neg, parent_matches, bufnr)
-      if ft then
-        return ft, on_detect
+    -- Next, check patterns with negative priority
+    if not_fast then
+      do
+        local ft, on_detect =
+          match_pattern_sorted(name, path, tail, pattern_sorted_neg, parent_matches, bufnr)
+        if ft then
+          return ft, on_detect
+        end
       end
     end
   end
 
   -- Finally, check file contents
-  if contents or bufnr then
+  if not_fast and (contents or bufnr) then
     if contents == nil then
       assert(bufnr)
       if api.nvim_buf_line_count(bufnr) > 101 then
@@ -3309,7 +3320,7 @@ function M.match(args)
   end
 
   -- Generic configuration file used as fallback
-  if name and bufnr then
+  if not_fast and name and bufnr then
     local ft = detect.conf(name, bufnr)
     if ft then
       return ft, nil, true

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -3215,6 +3215,11 @@ end
 --- matching. Can be used with {filename}. Mutually exclusive
 --- with {buf}.
 --- @field contents? string[]
+---
+--- Whether to skip time consuming detection steps, like
+--- pattern and content matching. Makes detection significantly
+--- faster at the cost of slightly fewer filetypes detected.
+--- @field fast? boolean
 
 --- Perform filetype detection.
 ---
@@ -3263,6 +3268,7 @@ function M.match(args)
   local bufnr = args.buf
   local name = args.filename
   local contents = args.contents
+  local not_fast = not args.fast
 
   if bufnr and not name then
     name = api.nvim_buf_get_name(bufnr)
@@ -3295,11 +3301,13 @@ function M.match(args)
     -- Next, check the file path against available patterns with non-negative priority
     -- Cache match results of all parent patterns to improve performance
     local parent_matches = {}
-    do
-      local ft, on_detect =
-        match_pattern_sorted(name, path, tail, pattern_sorted_pos, parent_matches, bufnr)
-      if ft then
-        return ft, on_detect
+    if not_fast then
+      do
+        local ft, on_detect =
+          match_pattern_sorted(name, path, tail, pattern_sorted_pos, parent_matches, bufnr)
+        if ft then
+          return ft, on_detect
+        end
       end
     end
 
@@ -3314,17 +3322,20 @@ function M.match(args)
       end
     end
 
-    do -- Next, check patterns with negative priority
-      local ft, on_detect =
-        match_pattern_sorted(name, path, tail, pattern_sorted_neg, parent_matches, bufnr)
-      if ft then
-        return ft, on_detect
+    -- Next, check patterns with negative priority
+    if not_fast then
+      do
+        local ft, on_detect =
+          match_pattern_sorted(name, path, tail, pattern_sorted_neg, parent_matches, bufnr)
+        if ft then
+          return ft, on_detect
+        end
       end
     end
   end
 
   -- Finally, check file contents
-  if contents or bufnr then
+  if not_fast and (contents or bufnr) then
     if contents == nil then
       assert(bufnr)
       if api.nvim_buf_line_count(bufnr) > 101 then
@@ -3356,7 +3367,7 @@ function M.match(args)
   end
 
   -- Generic configuration file used as fallback
-  if name and bufnr then
+  if not_fast and name and bufnr then
     local ft = detect.conf(name, bufnr)
     if ft then
       return ft, nil, true

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -2199,7 +2199,7 @@ local patterns_text = {
   -- Mason
   ['^<[%%&].*>'] = 'mason',
   -- Vim scripts (must have '" vim' as the first line to trigger this)
-  ['^" *[vV]im$['] = 'vim',
+  ['^" *[vV]im$'] = 'vim',
   -- libcxx and libstdc++ standard library headers like ["iostream["] do not have
   -- an extension, recognize the Emacs file mode.
   ['%-%*%-.*[cC]%+%+.*%-%*%-'] = 'cpp',

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -2258,7 +2258,7 @@ local patterns_text = {
   -- Mason
   ['^<[%%&].*>'] = 'mason',
   -- Vim scripts (must have '" vim' as the first line to trigger this)
-  ['^" *[vV]im$['] = 'vim',
+  ['^" *[vV]im$'] = 'vim',
   -- libcxx and libstdc++ standard library headers like ["iostream["] do not have
   -- an extension, recognize the Emacs file mode.
   ['%-%*%-.*[cC]%+%+.*%-%*%-'] = 'cpp',

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -155,6 +155,44 @@ describe('vim.filetype', function()
     )
   end)
 
+  it('can be fast', function()
+    eq(
+      exec_lua(function()
+        return vim.filetype.match({ filename = 'init.lua', fast = true })
+      end),
+      'lua'
+    )
+    eq(
+      exec_lua(function()
+        return vim.filetype.match({ filename = 'Dockerfile', fast = true })
+      end),
+      'dockerfile'
+    )
+
+    -- Pattern and content matching should be skipped
+    eq(
+      exec_lua(function()
+        return {
+          no_fast = vim.filetype.match({ filename = '/etc/a2ps/top-secret.cfg' }),
+          yes_fast = vim.filetype.match({ filename = '/etc/a2ps/top-secret.cfg', fast = true }),
+        }
+      end),
+      { no_fast = 'a2ps', yes_fast = 'cfg' }
+    )
+
+    eq(
+      exec_lua(function()
+        local buf = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { '" vim' })
+        return {
+          no_fast = vim.filetype.match({ buf = buf }),
+          yes_fast = vim.filetype.match({ buf = buf, fast = true }),
+        }
+      end),
+      { no_fast = 'vim', yes_fast = nil }
+    )
+  end)
+
   it('considers extension mappings when matching from hashbang', function()
     eq(
       'fooscript',

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -180,6 +180,44 @@ describe('vim.filetype', function()
     )
   end)
 
+  it('can be fast', function()
+    eq(
+      exec_lua(function()
+        return vim.filetype.match({ filename = 'init.lua', fast = true })
+      end),
+      'lua'
+    )
+    eq(
+      exec_lua(function()
+        return vim.filetype.match({ filename = 'Dockerfile', fast = true })
+      end),
+      'dockerfile'
+    )
+
+    -- Pattern and content matching should be skipped
+    eq(
+      exec_lua(function()
+        return {
+          no_fast = vim.filetype.match({ filename = '/etc/a2ps/top-secret.cfg' }),
+          yes_fast = vim.filetype.match({ filename = '/etc/a2ps/top-secret.cfg', fast = true }),
+        }
+      end),
+      { no_fast = 'a2ps', yes_fast = 'cfg' }
+    )
+
+    eq(
+      exec_lua(function()
+        local buf = vim.api.nvim_create_buf(false, true)
+        vim.api.nvim_buf_set_lines(buf, 0, -1, false, { '" vim' })
+        return {
+          no_fast = vim.filetype.match({ buf = buf }),
+          yes_fast = vim.filetype.match({ buf = buf, fast = true }),
+        }
+      end),
+      { no_fast = 'vim', yes_fast = nil }
+    )
+  end)
+
   it('considers extension mappings when matching from hashbang', function()
     eq(
       'fooscript',


### PR DESCRIPTION
This PR introduces a rather concise implementation-wise `fast` option to `vim.filetype.match()`. If `true`, it makes detection skip pattern and content matching (two slowest steps, as they are not table lookups). As pattern matching covers (by default) rather niche set of cases, this should provide plenty of coverage for actually detected filetypes.

------

The `vim.filetype.match()` function can be used in contexts where performance is very critical. For example, computing filetype based solely on the file name to later get an icon/option/table value. Currently after some refactor to improve performance (#29596, #29632, #29660) the speed is already decent enough for `vim.filetype.match()` to be called synchronously about 1000 times without very noticeable delay (about 40 ms based on profiling in the latest from mentioned PRs).

Based on the profiling, the biggest bottleneck is the sheer amount of pattern matches needed to be done before reaching the target (fast) state: extension matching (via table lookup) or not matching at all. #29660 makes things better, but maybe not enough for some cases.

------

Here is the result of benchmarking:

Filename | fast=false | fast=true |
--------------|-----------|--------------|
init.lua | 0.030ms  | 0.0051ms |
no-match | 0.039ms | 0.0051ms |
/home/user/.config/hello/world/no-match | 0.063ms | 0.0048ms |

The improvement is from 6x to 10x times in speed at the cost of not matching handful of filetype patterns. Whether this trade is worth it is up to `vim.filetype.match()` users.