### PR TITLE
fix(terminal): handle C0 characters in OSC terminator

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -271,10 +271,11 @@ static int parse_osc8(VTermStringFragment frag, int *attr)
 }
 
 static int on_osc(int command, VTermStringFragment frag, void *user)
+  FUNC_ATTR_NONNULL_ALL
 {
   Terminal *term = user;
 
-  if (frag.str == NULL) {
+  if (frag.str == NULL || frag.len == 0) {
     return 0;
   }
 

--- a/src/vterm/parser.c
+++ b/src/vterm/parser.c
@@ -1,5 +1,6 @@
 #include "vterm_internal.h"
 
+#include <assert.h>
 #include <stdio.h>
 #include <string.h>
 
@@ -190,8 +191,10 @@ size_t vterm_input_write(VTerm *vt, const char *bytes, size_t len)
           ((!IS_STRING_STATE() || c == 0x5c))) {
         c += 0x40;
         c1_allowed = true;
-        if(string_len)
+        if(string_len) {
+          assert(string_len > 0);
           string_len -= 1;
+        }
         vt->parser.in_esc = false;
       }
       else {
@@ -377,9 +380,12 @@ string_state:
 
   if(string_start) {
     size_t string_len = bytes + pos - string_start;
-    if(vt->parser.in_esc)
-      string_len -= 1;
-    string_fragment(vt, string_start, string_len, false);
+    if (string_len > 0) {
+      if(vt->parser.in_esc) {
+        string_len -= 1;
+      }
+      string_fragment(vt, string_start, string_len, false);
+    }
   }
 
   return len;

--- a/test/functional/terminal/parser_spec.lua
+++ b/test/functional/terminal/parser_spec.lua
@@ -1,0 +1,15 @@
+local n = require('test.functional.testnvim')()
+
+local clear = n.clear
+local api = n.api
+local assert_alive = n.assert_alive
+
+describe(':terminal', function()
+  before_each(clear)
+
+  it('handles invalid OSC terminators #30084', function()
+    local chan = api.nvim_open_term(0, {})
+    api.nvim_chan_send(chan, '\027]8;;https://example.com\027\\Example\027]8;;\027\n')
+    assert_alive()
+  end)
+end)


### PR DESCRIPTION
When a C0 character is present in an OSC terminator (i.e. after the ESC but before a \ (0x5c) or printable character), vterm executes the control character and resets the current string fragment. If the C0 character is the final byte in the sequence, the string fragment has a zero length. However, because the VT parser is still in the "escape" state, vterm attempts to subtract 1 from the string length (to account for the escape character). When the string fragment is empty, this causes an underflow in the unsigned size variable, resulting in a buffer overflow.

The fix is simple: explicitly check if the string length is non-zero before subtracting.

**NOTE:** This is the immediately obvious (and trivial) fix, but I think the fact that we are triggering this code path at all implies a bug in the parser itself. Debugging that is not only much more difficult, but any changes to the existing parser risk introducing regressions, for which we have no tests for at present. So this is a low-risk, if tepid, solution.

Fixes: https://github.com/neovim/neovim/issues/30084