### PR TITLE
build(deps): bump luajit to HEAD

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -1,8 +1,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.48.0.tar.gz
 LIBUV_SHA256 8c253adb0f800926a6cbd1c6576abae0bc8eb86a4f891049b72f9e5b7dc58f33
 
-LUAJIT_URL https://github.com/LuaJIT/LuaJIT/archive/ae4735f621d89d84758769b76432d2319dda9827.tar.gz
-LUAJIT_SHA256 4e444dd48dc4bf7196ca718f287a513f0e51f8608c03c1dccd25488871e5f823
+LUAJIT_URL https://github.com/LuaJIT/LuaJIT/archive/fb5e1c9f0d449a2b987c2c4b29f6cc811242b0a1.tar.gz
+LUAJIT_SHA256 75cd0e45a9cc493a555e34506a975b1d05b6b34e2a98a5a781631fcaaec2c9d1
 
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333


### PR DESCRIPTION
* Fix another potential file descriptor leak in luaL_loadfile*().
* MIPS32: Fix little-endian IR_RETF.
* Correctly close VM state after early OOM during open.
* Fix potential file descriptor leak in luaL_loadfile*().