### PR TITLE
vim-patch: update :keeppatterns doc

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -348,7 +348,8 @@ terminals)
 
 :keepp[atterns] {command}			*:keepp* *:keeppatterns*
 		Execute {command}, without adding anything to the search
-		history or modifying the last substitute string for |:&|.
+		history and, in case of the the |:s| and |:&| command, without 
+		modifying the last substitute pattern and substitute string.
 
 ==============================================================================
 2. Command-line completion				*cmdline-completion*

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -348,7 +348,7 @@ terminals)
 
 :keepp[atterns] {command}			*:keepp* *:keeppatterns*
 		Execute {command}, without adding anything to the search
-		history and, in case of the the |:s| and |:&| command, without 
+		history and, in case of the the |:s| and |:&| command, without
 		modifying the last substitute pattern and substitute string.
 
 ==============================================================================

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -348,8 +348,8 @@ terminals)
 
 :keepp[atterns] {command}			*:keepp* *:keeppatterns*
 		Execute {command}, without adding anything to the search
-		history and, in case of the the |:s| and |:&| command, without
-		modifying the last substitute pattern and substitute string.
+		history and, in case of |:s| or |:&|, without modifying the
+		last substitute pattern or substitute string.
 
 ==============================================================================
 2. Command-line completion				*cmdline-completion*


### PR DESCRIPTION
#### vim-patch:175a87c: runtime(doc): more clarification for the :keeppatterns needed

https://github.com/vim/vim/commit/175a87c7f163e34876c6848f829970fec61fc9d7

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:3840d2f: runtime(doc): remove trailing whitespace in cmdline.txt

https://github.com/vim/vim/commit/3840d2feaf1454c934f71a97aae7a56a5ceccef9

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:e44e644: runtime(doc): fix grammar in :h :keeppatterns

- It's clear that :s and :& are Ex commands, so remove "command" along
  with the duplicate "the".
- Use "or" instead of "and" following "without".

closes: vim/vim#15527

https://github.com/vim/vim/commit/e44e64492cf0a99191826b05ea5ee80b3a5fb3f5