### PR TITLE
fix(tohtml): quote font-family names

### DIFF
--- a/test/functional/plugin/tohtml_spec.lua
+++ b/test/functional/plugin/tohtml_spec.lua
@@ -136,6 +136,53 @@ local function run_tohtml_and_assert(screen, func)
   screen:expect({ grid = expected.grid, attr_ids = expected.attr_ids })
 end
 
+---@param guifont boolean
+local function test_generates_html(guifont)
+  insert([[line]])
+  exec('set termguicolors')
+  local bg = fn.synIDattr(fn.hlID('Normal'), 'bg#', 'gui')
+  local fg = fn.synIDattr(fn.hlID('Normal'), 'fg#', 'gui')
+  if guifont then
+    exec_lua [[
+      vim.o.guifont="Font,Escape\\,comma, Ignore space after comma"
+      local outfile = vim.fn.tempname() .. '.html'
+      local html = require('tohtml').tohtml(0,{title="title"})
+      vim.fn.writefile(html, outfile)
+      vim.cmd.split(outfile)
+    ]]
+  else
+    exec_lua [[
+      local outfile = vim.fn.tempname() .. '.html'
+      local html = require('tohtml').tohtml(0,{title="title",font={ "dumyfont","anotherfont" }})
+      vim.fn.writefile(html, outfile)
+      vim.cmd.split(outfile)
+    ]]
+  end
+  local out_file = api.nvim_buf_get_name(api.nvim_get_current_buf())
+  eq({
+    '<!DOCTYPE html>',
+    '<html>',
+    '<head>',
+    '<meta charset="UTF-8">',
+    '<title>title</title>',
+    ('<meta name="colorscheme" content="%s"></meta>'):format(api.nvim_get_var('colors_name')),
+    '<style>',
+    ('* {font-family: %s,monospace}'):format(
+      guifont and '"Font","Escape,comma","Ignore space after comma"' or '"dumyfont","anotherfont"'
+    ),
+    ('body {background-color: %s; color: %s}'):format(bg, fg),
+    '</style>',
+    '</head>',
+    '<body style="display: flex">',
+    '<pre>',
+    'line',
+    '',
+    '</pre>',
+    '</body>',
+    '</html>',
+  }, fn.readfile(out_file))
+end
+
 describe(':TOhtml', function()
   --- @type test.functional.ui.screen
   local screen
@@ -146,38 +193,12 @@ describe(':TOhtml', function()
     exec('colorscheme default')
   end)
 
-  it('expected internal html generated', function()
-    insert([[line]])
-    exec('set termguicolors')
-    local bg = fn.synIDattr(fn.hlID('Normal'), 'bg#', 'gui')
-    local fg = fn.synIDattr(fn.hlID('Normal'), 'fg#', 'gui')
-    exec_lua [[
-    local outfile = vim.fn.tempname() .. '.html'
-    local html = require('tohtml').tohtml(0,{title="title",font="dumyfont"})
-    vim.fn.writefile(html, outfile)
-    vim.cmd.split(outfile)
-    ]]
-    local out_file = api.nvim_buf_get_name(api.nvim_get_current_buf())
-    eq({
-      '<!DOCTYPE html>',
-      '<html>',
-      '<head>',
-      '<meta charset="UTF-8">',
-      '<title>title</title>',
-      ('<meta name="colorscheme" content="%s"></meta>'):format(api.nvim_get_var('colors_name')),
-      '<style>',
-      '* {font-family: dumyfont,monospace}',
-      ('body {background-color: %s; color: %s}'):format(bg, fg),
-      '</style>',
-      '</head>',
-      '<body style="display: flex">',
-      '<pre>',
-      'line',
-      '',
-      '</pre>',
-      '</body>',
-      '</html>',
-    }, fn.readfile(out_file))
+  it('generates html', function()
+    test_generates_html(false)
+  end)
+
+  it("generates html, respects 'guifont'", function()
+    test_generates_html(true)
   end)
 
   it('expected internal html generated from range', function()


### PR DESCRIPTION
Problem:
The font is not applied when the font-family name contains spaces.

Solution:
Enclose the font-family name in quotation marks.