### PR TITLE
build(deps): bump luajit to HEAD - 304da39cc

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -1,8 +1,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.48.0.tar.gz
 LIBUV_SHA256 8c253adb0f800926a6cbd1c6576abae0bc8eb86a4f891049b72f9e5b7dc58f33
 
-LUAJIT_URL https://github.com/LuaJIT/LuaJIT/archive/fb22d0f80f291827a4004e16bc589b54bcc4a3c7.tar.gz
-LUAJIT_SHA256 6ec85c9588aca09f30f2dc2a843e9710be96292e32d28fe8f606daf4a89aeb45
+LUAJIT_URL https://github.com/LuaJIT/LuaJIT/archive/304da39cc5ee43491f7b1f4e0c9c52d477ce0d98.tar.gz
+LUAJIT_SHA256 e43f8710dbab95b3456a81c584264d9012782ab88d7ba2779ccc7042247e2a2d
 
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333


### PR DESCRIPTION
* FFI: Add missing coercion when recording 64-bit bit.*().
* ARM64: Make tobit conversions match JIT backend behavior.
* ARM: Make hard-float tobit conversions match JIT backend behavior.

