### PR TITLE
vim-patch:9.1.0683: mode() returns wrong value with <Cmd> mapping

### DIFF
--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -177,17 +177,8 @@ void get_mode(char *buf)
 {
   int i = 0;
 
-  if (VIsual_active) {
-    if (VIsual_select) {
-      buf[i++] = (char)(VIsual_mode + 's' - 'v');
-    } else {
-      buf[i++] = (char)VIsual_mode;
-      if (restart_VIsual_select) {
-        buf[i++] = 's';
-      }
-    }
-  } else if (State == MODE_HITRETURN || State == MODE_ASKMORE || State == MODE_SETWSIZE
-             || State == MODE_CONFIRM) {
+  if (State == MODE_HITRETURN || State == MODE_ASKMORE
+      || State == MODE_SETWSIZE || State == MODE_CONFIRM) {
     buf[i++] = 'r';
     if (State == MODE_ASKMORE) {
       buf[i++] = 'm';
@@ -222,6 +213,15 @@ void get_mode(char *buf)
     }
   } else if (State & MODE_TERMINAL) {
     buf[i++] = 't';
+  } else if (VIsual_active) {
+    if (VIsual_select) {
+      buf[i++] = (char)(VIsual_mode + 's' - 'v');
+    } else {
+      buf[i++] = (char)VIsual_mode;
+      if (restart_VIsual_select) {
+        buf[i++] = 's';
+      }
+    }
   } else {
     buf[i++] = 'n';
     if (finish_op) {
@@ -233,8 +233,7 @@ void get_mode(char *buf)
       if (restart_edit == 'I') {
         buf[i++] = 'T';
       }
-    } else if (restart_edit == 'I' || restart_edit == 'R'
-               || restart_edit == 'V') {
+    } else if (restart_edit == 'I' || restart_edit == 'R' || restart_edit == 'V') {
       buf[i++] = 'i';
       buf[i++] = (char)restart_edit;
     }

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -810,6 +810,10 @@ func Test_mode()
   call feedkeys("gQ\<Insert>\<F2>vi\<CR>", 'xt')
   call assert_equal("c-cvr", g:current_modes)
 
+  " Commandline mode in Visual mode should return "c-c", never "v-v".
+  call feedkeys("v\<Cmd>call input('')\<CR>\<F2>\<CR>\<Esc>", 'xt')
+  call assert_equal("c-c", g:current_modes)
+
   " Executing commands in Vim Ex mode should return "cv", never "cvr",
   " as Cmdline editing has already ended.
   call feedkeys("gQcall Save_mode()\<CR>vi\<CR>", 'xt')


### PR DESCRIPTION
#### vim-patch:9.1.0683: mode() returns wrong value with \<Cmd> mapping

Problem:  mode() returns wrong value with \<Cmd> mapping
Solution: Change decision priority of VIsual_active and move
          visual mode a bit further down (kuuote)

closes: vim/vim#15533

https://github.com/vim/vim/commit/0fd1cb1b1fc90b68cb37f71e65289eadac3588a6

Co-authored-by: kuuote <znmxodq1@gmail.com>