### PR TITLE
fix(tohtml): apply sp color if present

### DIFF
--- a/runtime/lua/tohtml.lua
+++ b/runtime/lua/tohtml.lua
@@ -1003,6 +1003,7 @@ local function extend_style(out, state)
     --TODO(altermo) use local namespace (instead of global 0)
     local fg = vim.fn.synIDattr(hlid, 'fg#')
     local bg = vim.fn.synIDattr(hlid, 'bg#')
+    local sp = vim.fn.synIDattr(hlid, 'sp#')
     local decor_line = {}
     if vim.fn.synIDattr(hlid, 'underline') ~= '' then
       table.insert(decor_line, 'underline')
@@ -1020,6 +1021,8 @@ local function extend_style(out, state)
       ['font-weight'] = vim.fn.synIDattr(hlid, 'bold') ~= '' and 'bold' or nil,
       ['text-decoration-line'] = not vim.tbl_isempty(decor_line) and table.concat(decor_line, ' ')
         or nil,
+      -- TODO(ribru17): fallback to displayed text color if sp not set
+      ['text-decoration-color'] = sp ~= '' and cterm_to_hex(sp) or nil,
       --TODO(altermo) if strikethrough and undercurl then the strikethrough becomes wavy
       ['text-decoration-style'] = vim.fn.synIDattr(hlid, 'undercurl') ~= '' and 'wavy' or nil,
     }

--- a/test/functional/plugin/tohtml_spec.lua
+++ b/test/functional/plugin/tohtml_spec.lua
@@ -33,6 +33,10 @@ local function html_syntax_match()
       attr.underline = nil
       attr.undercurl = true
     end
+    attr.sp = style:match('text%-decoration%-color: #(%x+)')
+    if attr.sp then
+      attr.sp = tonumber(attr.sp, 16)
+    end
     attr.bg = style:match('background%-color: #(%x+)')
     if attr.bg then
       attr.bg = tonumber(attr.bg, 16)
@@ -49,7 +53,7 @@ local function html_syntax_match()
   local whitelist = {
     'fg',
     'bg',
-    --'sp',
+    'sp',
     --'blend',
     'bold',
     --'standout',
@@ -216,7 +220,7 @@ describe(':TOhtml', function()
 
   it('highlight attributes generated', function()
     --Make sure to uncomment the attribute in `html_syntax_match()`
-    exec('hi LINE gui=' .. table.concat({
+    exec('hi LINE guisp=#00ff00 gui=' .. table.concat({
       'bold',
       'underline',
       'italic',


### PR DESCRIPTION
**Problem:** Things like underlines are always given a default foreground highlight regardless of the value of `sp`.

**Solution:** Check for `sp` first, and apply that color to the text decoration color if it exists.

**Limitations:** If there is no value of `sp`, vim applies a text decoration color that matches the foreground of the text. This is still not implemented (and seems like a much more complex problem): in TOhtml, the underline will still be given a default foreground highlight.