### PR TITLE
vim-patch:9.1.0684: completion is inserted on Enter with "noselect"

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1244,7 +1244,9 @@ static int ins_compl_build_pum(void)
         if (comp->cp_score > max_fuzzy_score) {
           did_find_shown_match = true;
           max_fuzzy_score = comp->cp_score;
-          compl_shown_match = comp;
+          if (!compl_no_select) {
+            compl_shown_match = comp;
+          }
         }
 
         if (!shown_match_ok && comp == compl_shown_match && !compl_no_select) {

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2664,6 +2664,7 @@ func Test_complete_fuzzy_match()
   call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
   call assert_equal('hello help hero h', getline('.'))
 
+  " issue #15526
   set completeopt=fuzzy,menuone,menu,noselect
   call setline(1, ['Text', 'ToText', ''])
   call cursor(2, 1)

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2664,6 +2664,12 @@ func Test_complete_fuzzy_match()
   call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
   call assert_equal('hello help hero h', getline('.'))
 
+  set completeopt=fuzzy,menuone,menu,noselect
+  call setline(1, ['Text', 'ToText', ''])
+  call cursor(2, 1)
+  call feedkeys("STe\<C-X>\<C-N>x\<CR>\<Esc>0", 'tx!')
+  call assert_equal('Tex', getline('.'))
+
   " clean up
   set omnifunc=
   bw!


### PR DESCRIPTION
Problem:  completion is inserted on Enter with "noselect"
          (Carman Fu)
Solution: check noselect before update compl_shown_match
          (glepnir)

closes: vim/vim#15530

https://github.com/vim/vim/commit/753794bae8a9401903b82e5c5d1f35a106aa912a