### PR TITLE
vim-patch: update runtime files

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -22,6 +22,7 @@
 "   2024 Aug 02 by Vim Project: honor g:netrw_alt{o,v} for :{S,H,V}explore (#15417)
 "   2024 Aug 15 by Vim Project: style changes, prevent E121 (#15501)
 "   2024 Aug 22 by Vim Project: fix mf-selection highlight (#15551)
+"   2024 Aug 22 by Vim Project: adjust echo output of mx command (#15550)
 "   }}}
 " Former Maintainer:	Charles E Campbell
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
@@ -7434,7 +7435,13 @@ fun! s:NetrwMarkFileExe(islocal,enbloc)
        NetrwKeepj call netrw#ErrorMsg(s:ERROR,"command<".xcmd."> failed, aborting",54)
        break
       else
-       echo ret
+       if ret !=# ''
+        echo "\n"
+        " skip trailing new line
+        echo ret[0:-2]
+       else
+        echo ret
+       endif
       endif
      endfor
 

--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -21,6 +21,7 @@
 "   2024 Jul 30 by Vim Project: handle mark-copy to same target directory (#12112)
 "   2024 Aug 02 by Vim Project: honor g:netrw_alt{o,v} for :{S,H,V}explore (#15417)
 "   2024 Aug 15 by Vim Project: style changes, prevent E121 (#15501)
+"   2024 Aug 22 by Vim Project: fix mf-selection highlight (#15551)
 "   }}}
 " Former Maintainer:	Charles E Campbell
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
@@ -6824,11 +6825,7 @@ fun! s:NetrwMarkFile(islocal,fname)
 
   let ykeep   = @@
   let curbufnr= bufnr("%")
-  if a:fname =~ '^\a'
-   let leader= '\<'
-  else
-   let leader= ''
-  endif
+  let leader= '\(^\|\s\)\zs'
   if a:fname =~ '\a$'
    let trailer = '\>[@=|\/\*]\=\ze\%(  \|\t\|$\)'
   else

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1663,6 +1663,14 @@ Note that these three variables are maintained in the HTML syntax file.
 Numbers and strings can be recognized in non-Javadoc comments with >
 	:let g:java_comment_strings = 1
 
+When 'foldmethod' is set to "syntax", blocks of code and multi-line comments
+will be folded.  No text is usually written in the first line of a multi-line
+comment, making folded contents of Javadoc comments less informative with the
+default 'foldtext' value; you may opt for showing the contents of a second
+line for any comments written in this way, and showing the contents of a first
+line otherwise, with >
+	:let g:java_foldtext_show_first_or_second_line = 1
+
 Trailing whitespace characters or a run of space characters before a tab
 character can be marked as an error with >
 	:let g:java_space_errors = 1

--- a/runtime/syntax/htmlangular.vim
+++ b/runtime/syntax/htmlangular.vim
@@ -1,0 +1,18 @@
+" Vim syntax file
+" Language: Angular HTML template
+" Maintainer: Dennis van den Berg <dennis@vdberg.dev>
+" Last Change: 2024 Aug 22
+
+" quit when a syntax file was already loaded
+if exists("b:current_syntax")
+  finish
+endif
+
+if !exists("main_syntax")
+  let main_syntax = 'html'
+endif
+
+runtime! syntax/html.vim
+unlet b:current_syntax
+
+let b:current_syntax = "htmlangular"


### PR DESCRIPTION
- **vim-patch:0e9fd77: runtime(htmlangular): add html syntax highlighting**
- **vim-patch:38cfa2b: runtime(netrw): Fix `mf`-selected entry highlighting**
- **vim-patch:c75dad0: runtime(netrw): Change line on `mx` if command output exists**
- **vim-patch:2750b83: runtime(java): Make the bundled &foldtext function optional**
