### PR TITLE
vim-patch:9.1.0690: cannot set special highlight kind in popupmenu

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1183,6 +1183,11 @@ items:
 			attributes in the popup menu to apply cterm and gui
 			properties (with higher priority) like strikethrough
 			to the completion items
+	kind_hlgroup	an additional highlight group specifically for setting
+			the highlight attributes of the completion kind. When
+			this field is present, it will override the |hl-PmenuKind|
+			highlight group, allowing for the customization of
+			ctermfd and guifg properties for the completion kind
 
 All of these except "icase", "equal", "dup" and "empty" must be a string.  If
 an item does not meet these requirements then an error message is given and

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -172,6 +172,7 @@ struct compl_S {
   int cp_number;                 ///< sequence number
   int cp_score;                  ///< fuzzy match score
   int cp_user_hlattr;            ///< highlight attribute to combine with
+  int cp_user_kind_hlattr;       ///< highlight attribute for kind
 };
 
 /// state information used for getting the next set of insert completion
@@ -764,7 +765,7 @@ int ins_compl_add_infercase(char *str_arg, int len, bool icase, char *fname, Dir
     flags |= CP_ICASE;
   }
 
-  int res = ins_compl_add(str, len, fname, NULL, false, NULL, dir, flags, false, -1);
+  int res = ins_compl_add(str, len, fname, NULL, false, NULL, dir, flags, false, -1, -1);
   xfree(tofree);
   return res;
 }
@@ -804,7 +805,7 @@ static inline void free_cptext(char *const *const cptext)
 ///         returned in case of error.
 static int ins_compl_add(char *const str, int len, char *const fname, char *const *const cptext,
                          const bool cptext_allocated, typval_T *user_data, const Direction cdir,
-                         int flags_arg, const bool adup, int user_hlattr)
+                         int flags_arg, const bool adup, int user_hlattr, int user_kind_hlattr)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   compl_T *match;
@@ -871,6 +872,7 @@ static int ins_compl_add(char *const str, int len, char *const fname, char *cons
   }
   match->cp_flags = flags;
   match->cp_user_hlattr = user_hlattr;
+  match->cp_user_kind_hlattr = user_kind_hlattr;
 
   if (cptext != NULL) {
     int i;
@@ -1004,7 +1006,7 @@ static void ins_compl_add_matches(int num_matches, char **matches, int icase)
   for (int i = 0; i < num_matches && add_r != FAIL; i++) {
     if ((add_r = ins_compl_add(matches[i], -1, NULL, NULL, false, NULL, dir,
                                CP_FAST | (icase ? CP_ICASE : 0),
-                               false, -1)) == OK) {
+                               false, -1, -1)) == OK) {
       // If dir was BACKWARD then honor it just once.
       dir = FORWARD;
     }
@@ -1272,6 +1274,7 @@ static int ins_compl_build_pum(void)
       compl_match_array[i].pum_info = comp->cp_text[CPT_INFO];
       compl_match_array[i].pum_score = comp->cp_score;
       compl_match_array[i].pum_user_hlattr = comp->cp_user_hlattr;
+      compl_match_array[i].pum_user_kind_hlattr = comp->cp_user_kind_hlattr;
       if (comp->cp_text[CPT_MENU] != NULL) {
         compl_match_array[i++].pum_extra = comp->cp_text[CPT_MENU];
       } else {
@@ -2539,6 +2542,14 @@ theend:
   }
 }
 
+static inline int get_user_highlight_attr(const char *hlname)
+{
+  if (hlname != NULL && *hlname != NUL) {
+    return syn_name2attr(hlname);
+  }
+  return -1;
+}
+
 /// Add a match to the list of matches from Vimscript object
 ///
 /// @param[in]  tv  Object to get matches from.
@@ -2557,7 +2568,9 @@ static int ins_compl_add_tv(typval_T *const tv, const Direction dir, bool fast)
   int flags = fast ? CP_FAST : 0;
   char *(cptext[CPT_COUNT]);
   char *user_hlname = NULL;
+  char *user_kind_hlname = NULL;
   int user_hlattr = -1;
+  int user_kind_hlattr = -1;
   typval_T user_data;
 
   user_data.v_type = VAR_UNKNOWN;
@@ -2567,10 +2580,13 @@ static int ins_compl_add_tv(typval_T *const tv, const Direction dir, bool fast)
     cptext[CPT_MENU] = tv_dict_get_string(tv->vval.v_dict, "menu", true);
     cptext[CPT_KIND] = tv_dict_get_string(tv->vval.v_dict, "kind", true);
     cptext[CPT_INFO] = tv_dict_get_string(tv->vval.v_dict, "info", true);
+
     user_hlname = tv_dict_get_string(tv->vval.v_dict, "hl_group", false);
-    if (user_hlname != NULL && *user_hlname != NUL) {
-      user_hlattr = syn_name2attr(user_hlname);
-    }
+    user_hlattr = get_user_highlight_attr(user_hlname);
+
+    user_kind_hlname = tv_dict_get_string(tv->vval.v_dict, "kind_hlgroup", false);
+    user_kind_hlattr = get_user_highlight_attr(user_kind_hlname);
+
     tv_dict_get_tv(tv->vval.v_dict, "user_data", &user_data);
 
     if (tv_dict_get_number(tv->vval.v_dict, "icase")) {
@@ -2592,7 +2608,7 @@ static int ins_compl_add_tv(typval_T *const tv, const Direction dir, bool fast)
     return FAIL;
   }
   int status = ins_compl_add((char *)word, -1, NULL, cptext, true,
-                             &user_data, dir, flags, dup, user_hlattr);
+                             &user_data, dir, flags, dup, user_hlattr, user_kind_hlattr);
   if (status != OK) {
     tv_clear(&user_data);
   }
@@ -2685,7 +2701,7 @@ static void set_completion(colnr_T startcol, list_T *list)
     flags |= CP_ICASE;
   }
   if (ins_compl_add(compl_orig_text, -1, NULL, NULL, false, NULL, 0,
-                    flags | CP_FAST, false, -1) != OK) {
+                    flags | CP_FAST, false, -1, -1) != OK) {
     return;
   }
 
@@ -3430,7 +3446,7 @@ static void get_next_bufname_token(void)
       char *tail = path_tail(b->b_sfname);
       if (strncmp(tail, compl_orig_text, strlen(compl_orig_text)) == 0) {
         ins_compl_add(tail, (int)strlen(tail), NULL, NULL, false, NULL, 0,
-                      p_ic ? CP_ICASE : 0, false, -1);
+                      p_ic ? CP_ICASE : 0, false, -1, -1);
       }
     }
   }
@@ -4468,7 +4484,7 @@ static int ins_compl_start(void)
     flags |= CP_ICASE;
   }
   if (ins_compl_add(compl_orig_text, -1, NULL, NULL, false, NULL, 0,
-                    flags, false, -1) != OK) {
+                    flags, false, -1, -1) != OK) {
     XFREE_CLEAR(compl_pattern);
     compl_patternlen = 0;
     XFREE_CLEAR(compl_orig_text);

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -634,6 +634,9 @@ void pum_redraw(void)
       if (pum_array[idx].pum_user_hlattr > 0) {
         attr = hl_combine_attr(attr, pum_array[idx].pum_user_hlattr);
       }
+      if (round == 1 && pum_array[idx].pum_user_kind_hlattr > 0) {
+        attr = hl_combine_attr(attr, pum_array[idx].pum_user_kind_hlattr);
+      }
       int width = 0;
       char *s = NULL;
 

--- a/src/nvim/popupmenu.h
+++ b/src/nvim/popupmenu.h
@@ -17,6 +17,7 @@ typedef struct {
   int pum_score;        ///< fuzzy match score
   int pum_idx;          ///< index of item before sorting by score
   int pum_user_hlattr;  ///< highlight attribute to combine with
+  int pum_user_kind_hlattr;  ///< highlight attribute for kind
 } pumitem_T;
 
 EXTERN ScreenGrid pum_grid INIT( = SCREEN_GRID_INIT);

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -5011,6 +5011,47 @@ describe('builtin popupmenu', function()
         ]])
         feed('<C-E><Esc>')
       end)
+
+      -- oldtest: Test_pum_user_kind_hlgroup()
+      it('custom kind_hlgroup override', function()
+        exec([[
+          func CompleteFunc( findstart, base )
+            if a:findstart
+              return 0
+            endif
+            return {
+                  \ 'words': [
+                  \ { 'word': 'aword1', 'menu': 'extra text 1', 'kind': 'variable', 'kind_hlgroup': 'KindVar', 'hl_group': 'StrikeFake' },
+                  \ { 'word': 'aword2', 'menu': 'extra text 2', 'kind': 'function', 'kind_hlgroup': 'KindFunc' },
+                  \ { 'word': '你好', 'menu': 'extra text 3', 'kind': 'class', 'kind_hlgroup': 'KindClass'  },
+                  \]}
+          endfunc
+          set completeopt=menu
+          set completefunc=CompleteFunc
+
+          hi StrikeFake guifg=DarkRed
+          hi KindVar guifg=DarkYellow
+          hi KindFunc guifg=DarkBlue
+          hi KindClass guifg=DarkGreen
+        ]])
+
+        local attr_ids = screen:get_default_attr_ids()
+        attr_ids.kvs = { foreground = Screen.colors.DarkYellow, background = Screen.colors.Grey }
+        attr_ids.kfn = { foreground = Screen.colors.DarkBlue, background = Screen.colors.Plum1 }
+        attr_ids.kcn = { foreground = Screen.colors.DarkGreen, background = Screen.colors.Plum1 }
+        screen:set_default_attr_ids(attr_ids)
+
+        feed('S<C-X><C-U>')
+        screen:expect([[
+          aword1^                          |
+          {ds:aword1 }{kvs:variable }{ds:extra text 1 }{1:   }|
+          {n:aword2 }{kfn:function }{n:extra text 2 }{1:   }|
+          {n:你好   }{kcn:class    }{n:extra text 3 }{1:   }|
+          {1:~                               }|*15
+          {2:-- }{5:match 1 of 3}                 |
+        ]])
+        feed('<C-E><Esc>')
+      end)
     end
   end
 

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1550,4 +1550,37 @@ func Test_pum_user_hl_group()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_pum_user_kind_hlgroup()
+  CheckScreendump
+  let lines =<< trim END
+    func CompleteFunc( findstart, base )
+      if a:findstart
+        return 0
+      endif
+      return {
+            \ 'words': [
+            \ { 'word': 'aword1', 'menu': 'extra text 1', 'kind': 'variable', 'kind_hlgroup': 'KindVar', 'hl_group': 'StrikeFake' },
+            \ { 'word': 'aword2', 'menu': 'extra text 2', 'kind': 'function', 'kind_hlgroup': 'KindFunc' },
+            \ { 'word': '你好', 'menu': 'extra text 3', 'kind': 'class', 'kind_hlgroup': 'KindClass'  },
+            \]}
+    endfunc
+    set completeopt=menu
+    set completefunc=CompleteFunc
+
+    hi StrikeFake ctermfg=9
+    hi KindVar ctermfg=yellow
+    hi KindFunc ctermfg=blue
+    hi KindClass ctermfg=green
+  END
+  call writefile(lines, 'Xscript', 'D')
+  let buf = RunVimInTerminal('-S Xscript', {})
+
+  call TermWait(buf)
+  call term_sendkeys(buf, "S\<C-X>\<C-U>")
+  call VerifyScreenDump(buf, 'Test_pum_highlights_16', {})
+  call term_sendkeys(buf, "\<C-E>\<Esc>")
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Close #30112

#### vim-patch:9.1.0690: cannot set special highlight kind in popupmenu

Problem:  cannot set special highlight kind in popupmenu
Solution: add kind_hlgroup item to complete function
          (glepnir)

closes: vim/vim#15561

https://github.com/vim/vim/commit/38f99a1f0d61e9bde3f4a3d0cbe2d06185c4a57f

Co-authored-by: glepnir <glephunter@gmail.com>