### PR TITLE
vim-patch:9.1.0692: Wrong patlen value in ex_substitute()

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3378,12 +3378,12 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
       which_pat = RE_LAST;                  // use last used regexp
       delimiter = (uint8_t)(*cmd++);                   // remember delimiter character
       pat = cmd;                            // remember start of search pat
-      patlen = strlen(pat);
       cmd = skip_regexp_ex(cmd, delimiter, magic_isset(), &eap->arg, NULL, NULL);
       if (cmd[0] == delimiter) {            // end delimiter found
         *cmd++ = NUL;                       // replace it with a NUL
         has_second_delim = true;
       }
+      patlen = strlen(pat);
     }
 
     // Small incompatibility: vi sees '\n' as end of the command, but in

--- a/test/old/testdir/test_search.vim
+++ b/test/old/testdir/test_search.vim
@@ -1668,6 +1668,37 @@ func Test_search_with_no_last_pat()
   call delete('Xresult')
 endfunc
 
+" Test for using the last substitute pattern without last search pattern.
+func Test_search_with_last_substitute_pat()
+  let lines =<< trim [SCRIPT]
+    new
+    set shortmess+=S
+    call setline(1, repeat(['foofoo'], 3))
+    %s/foo/bar/
+    call assert_equal(repeat(['barfoo'], 3), getline(1, '$'))
+
+    call cursor(1, 1)
+    call assert_equal("/foo", execute('call feedkeys("/\r", "tx")', '')->trim())
+    call assert_equal([0, 1, 4, 0], getpos('.'))
+
+    if has('rightleft')
+      set rightleft rightleftcmd=search
+      call cursor(1, 1)
+      call assert_equal("oof/", execute('call feedkeys("/\r", "tx")', '')->trim())
+      call assert_equal([0, 1, 4, 0], getpos('.'))
+    endif
+
+    call writefile(v:errors, 'Xresult')
+    qall!
+  [SCRIPT]
+  call writefile(lines, 'Xscript', 'D')
+
+  if RunVim([], [], '--clean -S Xscript')
+    call assert_equal([], readfile('Xresult'))
+  endif
+  call delete('Xresult')
+endfunc
+
 " Test for using tilde (~) atom in search. This should use the last used
 " substitute pattern
 func Test_search_tilde_pat()


### PR DESCRIPTION
#### vim-patch:9.1.0692: Wrong patlen value in ex_substitute()

Problem:  Wrong patlen value in ex_substitute() (after 9.1.0426).
Solution: Compute patlen after finding end separator.
          (zeertzjq)

Add a more explicit test.  The test already passes as the only case
where a overlarge patlen value matters was fixed by patch 9.1.0689.

closes: vim/vim#15565

https://github.com/vim/vim/commit/d1c8d2de4b9fa44b3d2b39b7ed8b92846c5502b7