### PR TITLE
fix(docs) wrong return value annotation for `nvim_buf_get_extmarks`

### DIFF
--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -378,7 +378,7 @@ function vim.api.nvim_buf_get_commands(buffer, opts) end
 ---             • details: Whether to include the details dict
 ---             • hl_name: Whether to include highlight group name instead of
 ---               id, true if omitted
---- @return vim.api.keyset.get_extmark_item
+--- @return vim.api.keyset.get_extmark_item_by_id
 function vim.api.nvim_buf_get_extmark_by_id(buffer, ns_id, id, opts) end
 
 --- Gets `extmarks` in "traversal order" from a `charwise` region defined by

--- a/runtime/lua/vim/_meta/api_keysets_extra.lua
+++ b/runtime/lua/vim/_meta/api_keysets_extra.lua
@@ -43,10 +43,16 @@ error('Cannot require a meta file')
 --- @field line_hl_group? string
 --- @field cursorline_hl_group? string
 
---- @class vim.api.keyset.get_extmark_item
+--- @class vim.api.keyset.get_extmark_item_by_id
 --- @field [1] integer row
 --- @field [2] integer col
 --- @field [3] vim.api.keyset.extmark_details?
+
+--- @class vim.api.keyset.get_extmark_item
+--- @field [1] integer extmark_id
+--- @field [2] integer row
+--- @field [3] integer col
+--- @field [4] vim.api.keyset.extmark_details?
 
 --- @class vim.api.keyset.get_mark
 --- @field [1] integer row

--- a/scripts/gen_eval_files.lua
+++ b/scripts/gen_eval_files.lua
@@ -20,7 +20,7 @@ local DEP_API_METADATA = 'build/funcs_metadata.mpack'
 
 local LUA_API_RETURN_OVERRIDES = {
   nvim_buf_get_command = 'table<string,vim.api.keyset.command_info>',
-  nvim_buf_get_extmark_by_id = 'vim.api.keyset.get_extmark_item',
+  nvim_buf_get_extmark_by_id = 'vim.api.keyset.get_extmark_item_by_id',
   nvim_buf_get_extmarks = 'vim.api.keyset.get_extmark_item[]',
   nvim_buf_get_keymap = 'vim.api.keyset.keymap[]',
   nvim_get_autocmds = 'vim.api.keyset.get_autocmds.ret[]',


### PR DESCRIPTION
Fixes #29828.

IIUC the annotations in `api_keysets_extra.lua` is not being used right now, but fixing it just in case.

Please feel free to correct me if anything is incorrect. Happy to discuss it further.