### PR TITLE
vim-patch:88a6dd0: runtime(doc): fix typo

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1185,9 +1185,10 @@ items:
 			to the completion items
 	kind_hlgroup	an additional highlight group specifically for setting
 			the highlight attributes of the completion kind. When
-			this field is present, it will override the |hl-PmenuKind|
-			highlight group, allowing for the customization of
-			ctermfd and guifg properties for the completion kind
+			this field is present, it will override the
+			|hl-PmenuKind| highlight group, allowing for the
+			customization of ctermfg and guifg properties for the
+			completion kind
 
 All of these except "icase", "equal", "dup" and "empty" must be a string.  If
 an item does not meet these requirements then an error message is given and


### PR DESCRIPTION
#### vim-patch:88a6dd0: runtime(doc): fix typo

closes: vim/vim#15572

https://github.com/vim/vim/commit/88a6dd036a673b310c467bf43a872a4210e19e21

Co-authored-by: glepnir <glephunter@gmail.com>