### PR TITLE
fix(filetype): move fallback logic to `vim.filetype.match()`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2414,6 +2414,11 @@ vim.filetype.match({args})                              *vim.filetype.match()*
         (`function?`) A function that modifies buffer state when called (for
         example, to set some filetype specific buffer variables). The function
         accepts a buffer number as its only argument.
+        (`boolean?`) Return true if a match was found by falling back to a
+        generic configuration file (i.e., ".conf"). If true, the filetype
+        should be set with `:setf FALLBACK conf`, which enables a later
+        |:setf| command to override the filetype. See `:help setf` for more
+        information.
 
 
 ==============================================================================

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2415,7 +2415,7 @@ vim.filetype.match({args})                              *vim.filetype.match()*
         example, to set some filetype specific buffer variables). The function
         accepts a buffer number as its only argument.
         (`boolean?`) Return true if a match was found by falling back to a
-        generic configuration file (i.e., ".conf"). If true, the filetype
+        generic filetype (e.g. ".conf"). If true, the filetype
         should be set with `:setf FALLBACK conf`, which enables a later
         |:setf| command to override the filetype. See `:help setf` for more
         information.

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -3099,6 +3099,10 @@ end
 ---@return function|nil # A function that modifies buffer state when called (for example, to set some
 ---                     filetype specific buffer variables). The function accepts a buffer number as
 ---                     its only argument.
+---@return boolean|nil # Return true if a match was found by falling back to a generic configuration
+---                    file (i.e., ".conf"). If true, the filetype should be set with
+---                    `:setf FALLBACK conf`, which enables a later |:setf| command to override the
+---                    filetype. See `:help setf` for more information.
 function M.match(args)
   vim.validate('arg', args, 'table')
 
@@ -3191,9 +3195,17 @@ function M.match(args)
           return dispatch(extension[ext], name, bufnr)
         end
       )
-      if ok then
+      if ok and ft then
         return ft, on_detect
       end
+    end
+  end
+
+  -- Generic configuration file used as fallback
+  if name and bufnr then
+    local ft = detect.conf(name, bufnr)
+    if ft then
+      return ft, nil, true
     end
   end
 end

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -210,6 +210,25 @@ describe('vim.filetype', function()
     )
     rmdir('Xfiletype')
   end)
+
+  it('fallback to conf if any of the first five lines start with a #', function()
+    eq(
+      { 'conf', true },
+      exec_lua(function()
+        local bufnr = vim.api.nvim_create_buf(true, false)
+        local lines = {
+          '# foo',
+        }
+        vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+
+        -- Needs to be set so detect.conf() doesn't fail
+        vim.g.ft_ignore_pat = '\\.\\(Z\\|gz\\|bz2\\|zip\\|tgz\\)$'
+
+        local ft, _, fallback = vim.filetype.match({ buf = bufnr })
+        return { ft, fallback }
+      end)
+    )
+  end)
 end)
 
 describe('filetype.lua', function()


### PR DESCRIPTION
Problem:
Previously, the fallback logic to ".conf" was located outside of `vim.filetype.match()` and directly within the AutoCmd definition. As a result, `vim.filetype.match()` would return nil instead of ".conf" for fallback cases (https://github.com/neovim/neovim/issues/30100).

Solution:
Added a boolean return value to `vim.filetype.match()` that indicates whether the match was the result of fallback. If true, the filetype will be set using `setf FALLBACK <ft>` instead of `setf <ft>`.