### PR TITLE
build: work around bug in `make` when `PATH` includes `cmake` as dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -9,7 +9,7 @@ filter-true = $(strip $(filter-out 1 on ON true TRUE,$1))
 
 all: nvim
 
-CMAKE ?= $(shell (command -v cmake3 || echo cmake))
+CMAKE ?= $(shell (command -v cmake3 || command -v cmake || echo cmake))
 CMAKE_FLAGS := -DCMAKE_BUILD_TYPE=$(CMAKE_BUILD_TYPE)
 # Extra CMake flags which extend the default set
 CMAKE_EXTRA_FLAGS ?=


### PR DESCRIPTION
There appears to be a bug in `make` where if a rule asks `make` to
invoke a command called `foo`, and `foo` exists somewhere in `$PATH` as
a directory (not an executable file), `make` will attempt to `execve`
that directory instead of continuing to search in later parts of the
`$PATH` for `foo` as a true executable.

You can confirm this as follows:

    mkdir tmp
    cd tmp
    tmpdir="$(mktemp -d)"
    mkdir "$tmpdir/touch"
    export PATH="$tmpdir:$PATH"
    echo $'all:\n\ttouch foo.txt' > Makefile
    make

On my system, with `GNU Make 4.3` on Pop!\_OS 22.04, I'm greeted with
this output:

    touch foo.txt
    make: touch: Permission denied
    make: *** [Makefile:2: all] Error 127

A similar problem affected the user who opened #27490, but that issue
was closed because the problem was misdiagnosed (it was claimed that the
user was at fault for having their `$PATH` configured to include `.`).
In reality, this appears to be a bug in GNU Make--a Unix shell would not
mistake a directory (which technically have the execute permission set)
with a runnable file, while GNU Make does appear to do that.

It's easy enough to workaround this bug by using `command -v` to resolve
the `cmake` command, similar to what is already being done with
`cmake3`. Continuing to include `... || echo cmake` at the end means
that if neither `cmake3` nor `cmake` are installed, the user will still
see a message about CMake being missing.