### PR TITLE
fix(treesitter): escape things like `"` in omnifunc results

### DIFF
--- a/runtime/lua/vim/treesitter/_query_linter.lua
+++ b/runtime/lua/vim/treesitter/_query_linter.lua
@@ -241,7 +241,7 @@ function M.omnifunc(findstart, base)
     end
   end
   for _, s in pairs(parser_info.symbols) do
-    local text = s[2] and s[1] or '"' .. s[1]:gsub([[\]], [[\\]]) .. '"' ---@type string
+    local text = s[2] and s[1] or string.format('%q', s[1]):gsub('\n', 'n') ---@type string
     if text:find(base, 1, true) then
       table.insert(items, text)
     end


### PR DESCRIPTION
**Problem:** Anonymous double quote nodes are omnifunc'ed improperly

**Solution:** Escape them (and everything else that needs to be escaped) using a backslash

*See a discussion in https://github.com/neovim/neovim/pull/28613*