### PR TITLE
revert: "Makefile: use pattern rules for build/.deps (#10366)"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,14 +155,4 @@ appimage:
 appimage-%:
 	bash scripts/genappimage.sh $*
 
-# Generic pattern rules, allowing for `make build/bin/nvim` etc.
-# Does not work with "Unix Makefiles".
-ifeq ($(CMAKE_GENERATOR),Ninja)
-build/%: phony_force
-	$(BUILD_TOOL) -C build $(patsubst build/%,%,$@)
-
-$(DEPS_BUILD_DIR)/%: phony_force
-	$(BUILD_TOOL) -C $(DEPS_BUILD_DIR) $(patsubst $(DEPS_BUILD_DIR)/%,%,$@)
-endif
-
 .PHONY: test clean distclean nvim libnvim cmake deps install appimage checkprefix benchmark $(FORMAT) $(LINT) $(TEST)


### PR DESCRIPTION
This reverts commit 7f6ff829aa2347eb940d8e70a825ea335d8f15ed.

The given reasoning and usecase is unsatisfactory. While it is true that
it allows to run `make build/bin/nvim`, it can easily be recreated with
`ninja -C build bin/nvim` which does the exact same thing. This minor
convenience is not worth adding the extra code given how rare this
usecase should be.
