### PR TITLE
perf(treesitter): cache the parser check in foldexpr

### DIFF
--- a/runtime/lua/vim/treesitter/_fold.lua
+++ b/runtime/lua/vim/treesitter/_fold.lua
@@ -103,6 +103,10 @@ local function edit_range(range, srow, erow_old, erow_new)
   range[2] = math.max(range[2], erow_new)
 end
 
+local get_parser = vim.func._memoize(tostring, function(bufnr)
+  return vim.F.npcall(ts.get_parser, bufnr)
+end)
+
 -- TODO(lewis6991): Setup a decor provider so injections folds can be parsed
 -- as the window is redrawn
 ---@param bufnr integer
@@ -114,7 +118,11 @@ local function compute_folds_levels(bufnr, info, srow, erow, parse_injections)
   srow = srow or 0
   erow = erow or api.nvim_buf_line_count(bufnr)
 
-  local parser = ts.get_parser(bufnr)
+  local parser = get_parser(bufnr)
+
+  if not parser then
+    return
+  end
 
   parser:parse(parse_injections and { srow, erow } or nil)
 
@@ -394,7 +402,7 @@ function M.foldexpr(lnum)
   lnum = lnum or vim.v.lnum
   local bufnr = api.nvim_get_current_buf()
 
-  local parser = vim.F.npcall(ts.get_parser, bufnr)
+  local parser = get_parser(bufnr)
   if not parser then
     return '0'
   end


### PR DESCRIPTION
**Problem:** When setting `vim.wo.foldexpr = 'v:lua.vim.treesitter.foldexpr()'` globally, opening large files can be quite slow. This is especially true in files without a tree-sitter parser, where a huge amount of time is spent rechecking whether a parser exists. 

**Solution:** Cache the call to get a parser.

These are the results I have achieved below, testing on [the big linux file™](https://raw.githubusercontent.com/torvalds/linux/master/drivers/gpu/drm/amd/include/asic_reg/dcn/dcn_3_2_0_sh_mask.h) (click at your own risk):

> Note that I renamed the file to have a `.txt` extension to test the parserless case.

### Before this change

<details>
<summary>No parser</summary>
<br>

```
--- Startup times for process: Primary/TUI ---

times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.003  000.003: --- NVIM STARTING ---
000.261  000.258: event init
000.372  000.111: early init
000.458  000.086: locale set
000.536  000.078: init first window
001.115  000.579: inits 1
001.130  000.015: window checked
001.180  000.050: parsing arguments
001.848  000.066  000.066: require('vim.shared')
001.974  000.047  000.047: require('vim.inspect')
002.035  000.046  000.046: require('vim._options')
002.037  000.183  000.089: require('vim._editor')
002.039  000.290  000.042: require('vim._init_packages')
002.041  000.570: init lua interpreter
003.246  001.205: --- NVIM STARTED ---

--- Startup times for process: Embedded ---

times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.003  000.003: --- NVIM STARTING ---
000.219  000.217: event init
000.300  000.080: early init
000.377  000.077: locale set
000.445  000.068: init first window
000.917  000.472: inits 1
000.935  000.018: window checked
000.978  000.043: parsing arguments
001.637  000.064  000.064: require('vim.shared')
001.777  000.056  000.056: require('vim.inspect')
001.861  000.062  000.062: require('vim._options')
001.862  000.218  000.100: require('vim._editor')
001.864  000.323  000.041: require('vim._init_packages')
001.865  000.565: init lua interpreter
002.013  000.147: expanding arguments
002.057  000.045: inits 2
002.576  000.518: init highlight
002.582  000.006: waiting for UI
002.903  000.321: done waiting for UI
002.909  000.006: clear screen
003.047  000.015  000.015: require('vim.keymap')
003.883  000.968  000.953: require('vim._defaults')
003.886  000.009: init default mappings & autocommands
1640.658  000.140  000.140: require('editorconfig')
1641.208  1555.730: opening buffers
1641.254  000.046: BufEnter autocommands
1641.258  000.004: editing files in windows
1642.083  000.520  000.520: require('alpha.themes.dashboard')
1642.331  000.217  000.217: require('alpha')
36308.263  34666.268: VimEnter autocommands
36308.396  000.133: UIEnter autocommands
36308.398  000.002: before starting main loop
36309.531  001.133: first screen update
36309.533  000.002: --- NVIM STARTED ---
```
</details>

<details>
<summary>Yes parser</summary>
<br>

```
--- Startup times for process: Primary/TUI ---

times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.005  000.005: --- NVIM STARTING ---
000.402  000.397: event init
000.565  000.163: early init
000.664  000.100: locale set
000.743  000.078: init first window
001.329  000.586: inits 1
001.346  000.017: window checked
001.401  000.056: parsing arguments
002.056  000.051  000.051: require('vim.shared')
002.170  000.048  000.048: require('vim.inspect')
002.231  000.046  000.046: require('vim._options')
002.233  000.173  000.080: require('vim._editor')
002.234  000.269  000.045: require('vim._init_packages')
002.236  000.566: init lua interpreter
003.524  001.287: --- NVIM STARTED ---

--- Startup times for process: Embedded ---

times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.003  000.003: --- NVIM STARTING ---
000.220  000.218: event init
000.302  000.082: early init
000.376  000.073: locale set
000.433  000.057: init first window
000.925  000.493: inits 1
000.944  000.019: window checked
000.989  000.045: parsing arguments
001.570  000.050  000.050: require('vim.shared')
001.690  000.052  000.052: require('vim.inspect')
001.757  000.052  000.052: require('vim._options')
001.759  000.184  000.079: require('vim._editor')
001.760  000.267  000.034: require('vim._init_packages')
001.762  000.506: init lua interpreter
001.847  000.085: expanding arguments
001.871  000.023: inits 2
002.175  000.304: init highlight
002.176  000.001: waiting for UI
002.343  000.167: done waiting for UI
002.347  000.004: clear screen
002.446  000.008  000.008: require('vim.keymap')
004.074  001.724  001.716: require('vim._defaults')
004.077  000.006: init default mappings & autocommands
2342.609  000.883  000.883: require('editorconfig')
3239.634  3138.673: opening buffers
3239.654  000.019: BufEnter autocommands
3239.657  000.004: editing files in windows
3240.416  000.457  000.457: require('alpha.themes.dashboard')
3240.541  000.110  000.110: require('alpha')
3241.170  000.946: VimEnter autocommands
3241.260  000.090: UIEnter autocommands
3241.262  000.002: before starting main loop
4864.438  000.085  000.085: require('dropbar.sources')
4864.496  000.047  000.047: require('dropbar.sources.path')
4864.525  000.027  000.027: require('dropbar.utils.source')
4864.579  000.052  000.052: require('dropbar.sources.lsp')
4864.613  000.033  000.033: require('dropbar.sources.treesitter')
4864.677  1623.171: first screen update
4864.678  000.001: --- NVIM STARTED ---
```
</details>

### After this change

<details>
<summary>No parser</summary>
<br>

```
--- Startup times for process: Primary/TUI ---

times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.001  000.001: --- NVIM STARTING ---
000.305  000.304: event init
000.538  000.232: early init
000.623  000.085: locale set
000.735  000.112: init first window
001.602  000.867: inits 1
001.612  000.011: window checked
001.691  000.079: parsing arguments
012.931  010.615  010.615: require('vim.shared')
013.714  000.104  000.104: require('vim.inspect')
014.312  000.562  000.562: require('vim._options')
014.315  001.377  000.711: require('vim._editor')
014.317  012.071  000.079: require('vim._init_packages')
014.321  000.560: init lua interpreter
015.785  001.463: --- NVIM STARTED ---

--- Startup times for process: Embedded ---

times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.001  000.001: --- NVIM STARTING ---
000.316  000.316: event init
000.451  000.135: early init
000.521  000.070: locale set
000.623  000.102: init first window
001.340  000.717: inits 1
001.359  000.018: window checked
001.417  000.058: parsing arguments
012.535  010.584  010.584: require('vim.shared')
013.300  000.081  000.081: require('vim.inspect')
013.874  000.516  000.516: require('vim._options')
013.877  001.334  000.736: require('vim._editor')
013.879  011.959  000.041: require('vim._init_packages')
013.883  000.507: init lua interpreter
014.067  000.184: expanding arguments
014.154  000.086: inits 2
014.751  000.597: init highlight
014.753  000.002: waiting for UI
015.091  000.338: done waiting for UI
015.125  000.034: clear screen
015.890  000.099  000.099: require('vim.keymap')
016.812  001.682  001.583: require('vim._defaults')
016.816  000.009: init default mappings & autocommands
926.201  000.340  000.340: require('editorconfig')
926.963  823.532: opening buffers
927.047  000.084: BufEnter autocommands
927.051  000.004: editing files in windows
928.157  000.749  000.749: require('alpha.themes.dashboard')
928.923  000.687  000.687: require('alpha')
1396.427  467.939: VimEnter autocommands
1396.590  000.163: UIEnter autocommands
1396.594  000.003: before starting main loop
1399.008  002.414: first screen update
1399.012  000.003: --- NVIM STARTED ---
```
</details>

<details>
<summary>Yes parser</summary>
<br>

```
--- Startup times for process: Primary/TUI ---

times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.001  000.001: --- NVIM STARTING ---
000.295  000.294: event init
000.491  000.196: early init
000.568  000.077: locale set
000.677  000.109: init first window
001.526  000.849: inits 1
001.536  000.011: window checked
001.613  000.077: parsing arguments
012.949  010.734  010.734: require('vim.shared')
013.666  000.061  000.061: require('vim.inspect')
014.176  000.483  000.483: require('vim._options')
014.179  001.222  000.679: require('vim._editor')
014.181  012.000  000.044: require('vim._init_packages')
014.185  000.572: init lua interpreter
015.562  001.377: --- NVIM STARTED ---

--- Startup times for process: Embedded ---

times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.001  000.001: --- NVIM STARTING ---
000.415  000.414: event init
000.631  000.216: early init
000.739  000.108: locale set
000.854  000.115: init first window
001.870  001.017: inits 1
001.889  000.019: window checked
001.965  000.076: parsing arguments
012.618  010.115  010.115: require('vim.shared')
013.347  000.064  000.064: require('vim.inspect')
013.912  000.537  000.537: require('vim._options')
013.916  001.291  000.690: require('vim._editor')
013.917  011.473  000.067: require('vim._init_packages')
013.920  000.482: init lua interpreter
014.074  000.154: expanding arguments
014.131  000.056: inits 2
014.640  000.509: init highlight
014.642  000.002: waiting for UI
014.977  000.335: done waiting for UI
015.010  000.033: clear screen
015.618  000.093  000.093: require('vim.keymap')
016.485  001.472  001.379: require('vim._defaults')
016.489  000.007: init default mappings & autocommands
2025.347  000.065  000.065: require('editorconfig')
2562.708  2452.155: opening buffers
2562.728  000.021: BufEnter autocommands
2562.734  000.005: editing files in windows
2563.559  000.547  000.547: require('alpha.themes.dashboard')
2563.675  000.101  000.101: require('alpha')
2564.262  000.880: VimEnter autocommands
2564.361  000.099: UIEnter autocommands
2564.364  000.003: before starting main loop
4165.767  000.125  000.125: require('dropbar.sources')
4165.848  000.066  000.066: require('dropbar.sources.path')
4165.887  000.035  000.035: require('dropbar.utils.source')
4165.996  000.108  000.108: require('dropbar.sources.lsp')
4166.050  000.052  000.052: require('dropbar.sources.treesitter')
4166.171  1601.421: first screen update
4166.172  000.001: --- NVIM STARTED ---
```
</details>

As you can see, on my machine there is about a 96% and 15% reduction in startup time for buffers without and with a parser, respectively. Note that these were not run with `--clean`, and this has a large impact on startup time as pointed out in https://github.com/neovim/neovim/pull/30164#issuecomment-2319596961.

**Caveats:** This caching means that, unlike before this change, buffers without a parser that *later* get a parser (e.g. the `ft` was changed (or maybe text was inserted into an empty buffer and then written as a certain `ft` that has a parser? but would the foldexpr even be set initially in this case...?)). But currently things like filetype changes are already cached when the previous file type had a parser, and even without this change the folds would need to be recomputed (or the buffer would have to be reopened) to get accurate folds when changing a file type. So the behavior is, in my opinion, mostly unchanged.