### PR TITLE
vim-patch:9.1.0699: "dvgo" is not always an inclusive motion

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -355,11 +355,11 @@ gg			Goto line [count], default first line, on the first
 			See also 'startofline' option.
 
 :[range]go[to] [count]					*:go* *:goto* *go*
-[count]go		Go to [count] byte in the buffer.  Default [count] is
-			one, start of the file.  When giving [range], the
-			last number in it used as the byte count.  End-of-line
-			characters are counted depending on the current
-			'fileformat' setting.
+[count]go		Go to [count] byte in the buffer.  |exclusive| motion.
+			Default [count] is one, start of the file.  When
+			giving [range], the last number in it used as the byte
+			count.  End-of-line characters are counted depending
+			on the current 'fileformat' setting.
 			Also see the |line2byte()| function, and the 'o'
 			option in 'statusline'.
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5631,6 +5631,7 @@ static void nv_g_cmd(cmdarg_T *cap)
 
   // "go": goto byte count from start of buffer
   case 'o':
+    oap->inclusive = false;
     goto_byte(cap->count0);
     break;
 

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4291,4 +4291,17 @@ func Test_scroll_longline_no_loop()
   exe "normal! \<C-E>"
   bwipe!
 endfunc
+
+" Test for go command
+func Test_normal_go()
+  new
+  call setline(1, ['one two three four'])
+  call cursor(1, 5)
+  norm! dvgo
+  call assert_equal('wo three four', getline(1))
+  norm! ...
+  call assert_equal('three four', getline(1))
+
+  bwipe!
+endfunc
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Fix #30170

#### vim-patch:9.1.0699: "dvgo" is not always an inclusive motion

Problem:  "dvgo" is not always an inclusive motion
          (Iain King-Speir)
Solution: initialize the inclusive flag to false

closes: vim/vim#15582

https://github.com/vim/vim/commit/f8702aeb8ff85554d909901ae45b50c3d532bf70

Co-authored-by: Christian Brabandt <cb@256bit.org>