### PR TITLE
docs(eval): wrong return type of getcharsearch

### DIFF
--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -2861,7 +2861,7 @@ function vim.fn.getcharpos(expr) end
 ---   nnoremap <expr> , getcharsearch().forward ? ',' : ';'
 --- <Also see |setcharsearch()|.
 ---
---- @return table[]
+--- @return table
 function vim.fn.getcharsearch() end
 
 --- Get a single character from the user or input stream as a

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -3564,7 +3564,7 @@ M.funcs = {
     ]=],
     name = 'getcharsearch',
     params = {},
-    returns = 'table[]',
+    returns = 'table',
     signature = 'getcharsearch()',
   },
   getcharstr = {


### PR DESCRIPTION
Problem: return type of getcharsearch in eval.lua is not correct.

Solution: change to table.

Fix #30174