### PR TITLE
fix(highlight): update `PmenuSel` to work with colored completion items

### DIFF
--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -144,6 +144,7 @@ static const char e_missing_argument_str[]
 static const char *highlight_init_both[] = {
   "Cursor            guifg=bg      guibg=fg",
   "CursorLineNr      gui=bold      cterm=bold",
+  "PmenuSel          gui=reverse   cterm=reverse,underline blend=0",
   "RedrawDebugNormal gui=reverse   cterm=reverse",
   "TabLineSel        gui=bold      cterm=bold",
   "TermCursor        gui=reverse   cterm=reverse",
@@ -358,7 +359,6 @@ static const char *highlight_init_light[] = {
   "NonText              guifg=NvimLightGrey4",
   "NormalFloat                               guibg=NvimLightGrey1",
   "Pmenu                                     guibg=NvimLightGrey3            cterm=reverse",
-  "PmenuSel             guifg=NvimLightGrey3 guibg=NvimDarkGrey2             cterm=reverse,underline blend=0",
   "PmenuThumb                                guibg=NvimLightGrey4",
   "Question             guifg=NvimDarkCyan                                   ctermfg=6",
   "QuickFixLine         guifg=NvimDarkCyan                                   ctermfg=6",
@@ -443,7 +443,6 @@ static const char *highlight_init_dark[] = {
   "NonText              guifg=NvimDarkGrey4",
   "NormalFloat                                guibg=NvimDarkGrey1",
   "Pmenu                                      guibg=NvimDarkGrey3           cterm=reverse",
-  "PmenuSel             guifg=NvimDarkGrey3   guibg=NvimLightGrey2          cterm=reverse,underline blend=0",
   "PmenuThumb                                 guibg=NvimDarkGrey4",
   "Question             guifg=NvimLightCyan                                 ctermfg=14",
   "QuickFixLine         guifg=NvimLightCyan                                 ctermfg=14",


### PR DESCRIPTION
Problem: completion items can now have dedicated highlighting (through
  `hl_group` and `kind_hlgroup` fields). Both of the fields combine
  their highlight attributes with the underlying `PmenuXxx` group.

  As default color scheme `Pmenu` and `PmenuSel` are intentionally
  almost inverted versions of one another, the added highlighting will
  be unreadable in one of them if done only through foreground (which is
  the most convenient way for users and being able to do so is arguably
  the biggest benefit of actually combining added highlighting).

Solution: adjust `PmenuSel` to utilize `attr=reverse`. This works
  because `fg`/`bg` are first combined and only then reversed. This
  results in a colored background for items with `hl_group` and
  `kind_hlgroup` using text highlighting.

  This also results in the same background for regular selected item,
  while intentionally changing foreground from `Nvim{Light,Dark}Grey3`
  to (essentially) `Nvim{Light,Dark}Grey2`. This both provides better
  contrast ratio and does not need realigning of the whole block.

------

Before:

![pmenusel_cur_colored](https://github.com/user-attachments/assets/04867dc2-9cf2-449f-9cae-2dcc336ceedb)
![pmenusel_cur_regular](https://github.com/user-attachments/assets/9ad21458-5860-41aa-9930-eff351984b6c)

After:

![pmenusel_new_colored](https://github.com/user-attachments/assets/fecaecdd-2dae-4cee-8c31-191bb3c340d8)
![pmenusel_new_regular](https://github.com/user-attachments/assets/85d9e0ac-3918-446e-b01b-daa0ca0047f3)

Code used for screenshots:

```lua
local items = {
  { word = 'apple', kind = 'Fruit', hl_group = 'Special', kind_hlgroup = 'String' },
  { word = 'orange', kind = 'Fruit', hl_group = 'Special', kind_hlgroup = 'String' },
}

vim.keymap.set('i', '<M-m>', function() vim.fn.complete(1, items) end)
```