### PR TITLE
ci: use default colorscheme

### DIFF
--- a/test/functional/autocmd/focus_spec.lua
+++ b/test/functional/autocmd/focus_spec.lua
@@ -22,7 +22,7 @@ describe('autoread TUI FocusGained/FocusLost', function()
       '-i',
       'NONE',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--cmd',
       'set noswapfile noshowcmd noruler notermguicolors',
     })

--- a/test/functional/terminal/api_spec.lua
+++ b/test/functional/terminal/api_spec.lua
@@ -21,7 +21,7 @@ describe('api', function()
       '-i',
       'NONE',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--cmd',
       n.nvim_set .. ' notermguicolors',
     })

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -491,7 +491,7 @@ describe('terminal input', function()
       '-i',
       'NONE',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--cmd',
       'set notermguicolors',
       '-c',

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -57,7 +57,7 @@ describe('TUI', function()
       '--cmd',
       nvim_set .. ' notermguicolors laststatus=2 background=dark',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
     })
     screen:expect([[
       {1: }                                                 |
@@ -2007,7 +2007,7 @@ describe('TUI', function()
       nvim_prog,
       '--clean',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--cmd',
       'set notermguicolors',
       '--cmd',
@@ -2136,7 +2136,7 @@ describe('TUI', function()
       '-i',
       'NONE',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--cmd',
       'set noruler notermguicolors',
       '--cmd',
@@ -2171,7 +2171,7 @@ describe('TUI', function()
       '--cmd',
       'set notermguicolors',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--cmd',
       'call setline(1, ["1st line" .. repeat(" ", 153), "2nd line"])',
     }, { cols = 80 })
@@ -2292,7 +2292,7 @@ describe('TUI UIEnter/UILeave', function()
       '-i',
       'NONE',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--cmd',
       'set noswapfile noshowcmd noruler notermguicolors',
       '--cmd',
@@ -2341,7 +2341,7 @@ describe('TUI FocusGained/FocusLost', function()
       '-i',
       'NONE',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--cmd',
       'set noswapfile noshowcmd noruler notermguicolors background=dark',
     })
@@ -2558,7 +2558,7 @@ describe("TUI 't_Co' (terminal colors)", function()
       '-i',
       'NONE',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--cmd',
       nvim_set .. ' notermguicolors',
     }, {
@@ -2901,7 +2901,7 @@ describe('TUI', function()
       '-i',
       'NONE',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--cmd',
       nvim_set .. ' notermguicolors',
       extra_args,
@@ -3120,7 +3120,7 @@ describe('TUI bg color', function()
       '-i',
       'NONE',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--cmd',
       'set noswapfile',
     })
@@ -3143,7 +3143,7 @@ describe('TUI bg color', function()
       '-i',
       'NONE',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--cmd',
       'set noswapfile',
     })
@@ -3172,7 +3172,7 @@ describe('TUI bg color', function()
       '-i',
       'NONE',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--cmd',
       'set noswapfile',
     })
@@ -3188,7 +3188,7 @@ describe('TUI bg color', function()
       '-i',
       'NONE',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--cmd',
       'set noswapfile',
       '-c',
@@ -3225,7 +3225,7 @@ describe('TUI as a client', function()
       '-i',
       'NONE',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--cmd',
       nvim_set .. ' notermguicolors laststatus=2 background=dark',
     })
@@ -3367,7 +3367,7 @@ describe('TUI as a client', function()
       '-i',
       'NONE',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--cmd',
       nvim_set .. ' notermguicolors laststatus=2 background=dark',
     })

--- a/test/functional/ui/embed_spec.lua
+++ b/test/functional/ui/embed_spec.lua
@@ -308,7 +308,7 @@ describe('--embed --listen UI', function()
       child_server,
       '--clean',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
     })
     retry(nil, nil, function()
       neq(nil, uv.fs_stat(child_server))

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -29,7 +29,7 @@ describe('shell command :!', function()
       '-i',
       'NONE',
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--cmd',
       n.nvim_set .. ' notermguicolors',
     })

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -21,7 +21,7 @@ describe('screen', function()
     '--cmd',
     'set shortmess+=I background=light noswapfile belloff= noshowcmd noruler',
     '--cmd',
-    'colorscheme vim',
+    'colorscheme default',
     '--embed',
   }
 
@@ -712,7 +712,7 @@ describe('Screen default colors', function()
       '--cmd',
       'set shortmess+=I noswapfile belloff= noshowcmd noruler' .. extra,
       '--cmd',
-      'colorscheme vim',
+      'colorscheme default',
       '--embed',
     }
     local screen_nvim = spawn(nvim_argv)

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -114,5 +114,4 @@ if !isdirectory($HOME)
   call mkdir($HOME)
 endif
 
-" Use Vim's default color scheme
-colorscheme vim
+colorscheme default


### PR DESCRIPTION
Use the default colorscheme instead of vim in tests.

Closes #28601