### PR TITLE
refactor(plines): correct double-width condition

### DIFF
--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -147,7 +147,7 @@ CharSize charsize_regular(CharsizeArg *csarg, char *const cur, colnr_T const vco
     size = kInvalidByteCells;
   } else {
     size = ptr2cells(cur);
-    is_doublewidth = size == 2 && cur_char > 0x80;
+    is_doublewidth = size == 2 && cur_char >= 0x80;
   }
 
   if (csarg->virt_row >= 0) {


### PR DESCRIPTION
To check for a non-ASCII character, the condition should be `>= 0x80`, not
`> 0x80`.  In this case it doesn't really matter as the 0x80 character is
unprintable and occupies 4 cells, but still make it consistent.
