### PR TITLE
feat(treesitter): return supertypes in language.inspect()

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -985,7 +985,8 @@ inspect({lang})                            *vim.treesitter.language.inspect()*
     Inspects the provided language.
 
     Inspecting provides some useful information on the language like node
-    names, ...
+    names, field names, and |vim.treesitter.language_version|. Each node name
+    has an associated boolean which is `false` if it is anonymous.
 
     Parameters: ~
       • {lang}  (`string`) Language

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <tree_sitter/api.h>
+#include <tree_sitter/parser.h>
 #include <uv.h>
 
 #include "klib/kvec.h"
@@ -162,14 +163,14 @@ int tslua_inspect_lang(lua_State *L)
   lua_createtable(L, (int)(nsymbols - 1), 1);  // [retval, symbols]
   for (uint32_t i = 0; i < nsymbols; i++) {
     TSSymbolType t = ts_language_symbol_type(lang, (TSSymbol)i);
-    if (t == TSSymbolTypeAuxiliary) {
+    if (t == TSSymbolTypeAuxiliary && !lang->symbol_metadata[i].supertype) {
       // not used by the API
       continue;
     }
     lua_createtable(L, 2, 0);  // [retval, symbols, elem]
     lua_pushstring(L, ts_language_symbol_name(lang, (TSSymbol)i));
     lua_rawseti(L, -2, 1);
-    lua_pushboolean(L, t == TSSymbolTypeRegular);
+    lua_pushboolean(L, t != TSSymbolTypeAnonymous);
     lua_rawseti(L, -2, 2);  // [retval, symbols, elem]
     lua_rawseti(L, -2, (int)i);  // [retval, symbols]
   }

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -55,7 +55,7 @@ describe('treesitter language API', function()
 
   it('inspects language', function()
     local keys, fields, symbols = unpack(exec_lua(function()
-      local lang = vim.treesitter.language.inspect('c')
+      local lang = vim.treesitter.language.inspect('lua')
       local keys, symbols = {}, {}
       for k, _ in pairs(lang) do
         keys[k] = true
@@ -76,20 +76,22 @@ describe('treesitter language API', function()
       eq('string', type(f))
       fset[f] = true
     end
-    eq(true, fset['directive'])
-    eq(true, fset['initializer'])
+    eq(true, fset['value'])
+    eq(true, fset['body'])
 
-    local has_named, has_anonymous
+    local has_named, has_anonymous, has_supertype
     for _, s in pairs(symbols) do
       eq('string', type(s[1]))
       eq('boolean', type(s[2]))
       if s[1] == 'for_statement' and s[2] == true then
         has_named = true
-      elseif s[1] == '|=' and s[2] == false then
+      elseif s[1] == '..' and s[2] == false then
         has_anonymous = true
+      elseif s[1] == 'statement' and s[2] == true then
+        has_supertype = true
       end
     end
-    eq({ true, true }, { has_named, has_anonymous })
+    eq({ true, true, true }, { has_named, has_anonymous, has_supertype })
   end)
 
   it(


### PR DESCRIPTION
This makes sense imo since they can still be queried as `(supertype_name) @capture`.

This commit just puts them with the other symbols, in that same table.