### PR TITLE
vim-patch:9.1.0707: [security]: invalid cursor position may cause a crash

### DIFF
--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -516,7 +516,7 @@ static int virt_text_cursor_off(const CharsizeArg *csarg, bool on_NUL)
 void getvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor, colnr_T *end)
 {
   char *const line = ml_get_buf(wp->w_buffer, pos->lnum);  // start of the line
-  int const end_col = pos->col;
+  colnr_T const end_col = pos->col;
 
   CharsizeArg csarg;
   bool on_NUL = false;
@@ -558,6 +558,10 @@ void getvcol(win_T *wp, pos_T *pos, colnr_T *start, colnr_T *cursor, colnr_T *en
       ci = next;
       vcol += char_size.width;
     }
+  }
+
+  if (*ci.ptr == NUL && end_col < MAXCOL && end_col > ci.ptr - line) {
+    pos->col = (colnr_T)(ci.ptr - line);
   }
 
   int head = char_size.head;


### PR DESCRIPTION
#### vim-patch:9.1.0707: [security]: invalid cursor position may cause a crash

Problem:  [security]: invalid cursor position may cause a crash
          (after v9.1.0038)
Solution: Set cursor to the last character in a line, if it would
          otherwise point to beyond the line; no tests added, as it
          is unclear how to reproduce this.

Github Advisory:
https://github.com/vim/vim/security/advisories/GHSA-4ghr-c62x-cqfh

https://github.com/vim/vim/commit/396fd1ec2956307755392a1c61f55d5c1847f308

Co-authored-by: Christian Brabandt <cb@256bit.org>