### PR TITLE
vim-patch:9.1.0704: inserting with a count is inefficient

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -464,7 +464,8 @@ static int insert_check(VimState *state)
       && !curwin->w_p_sms
       && !s->did_backspace
       && curwin->w_topline == s->old_topline
-      && curwin->w_topfill == s->old_topfill) {
+      && curwin->w_topfill == s->old_topfill
+      && s->count <= 1) {
     s->mincol = curwin->w_wcol;
     validate_cursor_col(curwin);
 
@@ -486,11 +487,15 @@ static int insert_check(VimState *state)
   }
 
   // May need to adjust w_topline to show the cursor.
-  update_topline(curwin);
+  if (s->count <= 1) {
+    update_topline(curwin);
+  }
 
   s->did_backspace = false;
 
-  validate_cursor(curwin);                  // may set must_redraw
+  if (s->count <= 1) {
+    validate_cursor(curwin);  // may set must_redraw
+  }
 
   // Redraw the display when no characters are waiting.
   // Also shows mode, ruler and positions cursor.
@@ -504,7 +509,9 @@ static int insert_check(VimState *state)
     do_check_cursorbind();
   }
 
-  update_curswant();
+  if (s->count <= 1) {
+    update_curswant();
+  }
   s->old_topline = curwin->w_topline;
   s->old_topfill = curwin->w_topfill;
 

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -987,7 +987,7 @@ describe('ui/mouse/input', function()
     command('set sidescroll=0')
     feed('<esc>:set nowrap<cr>')
 
-    feed('a <esc>20Ab<esc>')
+    feed('a <esc>17Ab<esc>3Ab<esc>')
     screen:expect([[
                                |*2
       bbbbbbbbbbbbbbb^b         |
@@ -1017,7 +1017,7 @@ describe('ui/mouse/input', function()
     command('set sidescroll=0')
     feed('<esc>:set nowrap<cr>')
 
-    feed('a <esc>20Ab<esc>')
+    feed('a <esc>17Ab<esc>3Ab<esc>')
     screen:expect([[
                                |*2
       bbbbbbbbbbbbbbb^b         |


### PR DESCRIPTION
#### vim-patch:9.1.0704: inserting with a count is inefficient

Problem:  inserting with a count is inefficient
Solution: Disable calculation of the cursor position and topline, if a
          count has been used (Ken Takata)

Optimize insertion when using :normal 10000ix.

This patch optimizes the insertion with a large count (e.g. `:normal
10000ix`).

It seems that calculation of the cursor position for a long line is slow
and it takes O(n^2). Disable the calculation if not needed.

Before:
```
$ time ./vim --clean -c 'normal 10000ix' -cq!
real    0m1.879s
user    0m1.328s
sys     0m0.139s

$ time ./vim --clean -c 'normal 20000ix' -cq!
real    0m5.574s
user    0m5.421s
sys     0m0.093s

$ time ./vim --clean -c 'normal 40000ix' -cq!
real    0m23.588s
user    0m23.187s
sys     0m0.140s
```

After:
```
$ time ./vim --clean -c 'normal 10000ix' -cq!
real    0m0.187s
user    0m0.046s
sys     0m0.093s

$ time ./vim --clean -c 'normal 20000ix' -cq!
real    0m0.217s
user    0m0.046s
sys     0m0.108s

$ time ./vim --clean -c 'normal 40000ix' -cq!
real    0m0.278s
user    0m0.093s
sys     0m0.140s

$ time ./vim --clean -c 'normal 80000ix' -cq!
real    0m0.494s
user    0m0.311s
sys     0m0.140s

$ time ./vim --clean -c 'normal 160000ix' -cq!
real    0m1.302s
user    0m1.140s
sys     0m0.094s
```

closes: vim/vim#15588

https://github.com/vim/vim/commit/09b80d23cfae24fa13ef4f52b0ec90625839a6ab

Co-authored-by: Ken Takata <kentkt@csc.jp>