### PR TITLE
vim-patch:9abd02d: runtime(nu): include filetype plugin

### DIFF
--- a/runtime/ftplugin/nu.vim
+++ b/runtime/ftplugin/nu.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin
+" Language:	Nu
+" Maintainer:	Marc Jakobi <marc@jakobi.dev>
+" Last Change:	2024 Aug 31
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal commentstring=#\ %s
+
+let b:undo_ftplugin = 'setl com<'


### PR DESCRIPTION
This is used to set the commentstring option.

closes: vim/vim#15601

https://github.com/vim/vim/commit/9abd02d16ad08e61729fe08d909c87915239affb

Co-authored-by: Marc Jakobi <marc.jakobi@tiko.energy>
