### PR TITLE
vim-patch:9.1.0708: Recursive window update does not account for reset skipcol

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2453,10 +2453,12 @@ redr_statuscol:
       recursive = true;
       curwin->w_valid &= ~VALID_TOPLINE;
       update_topline(curwin);  // may invalidate w_botline again
+      // New redraw either due to updated topline or reset skipcol.
       if (must_redraw != 0) {
         // Don't update for changes in buffer again.
         int mod_set = curbuf->b_mod_set;
         curbuf->b_mod_set = false;
+        curs_columns(curwin, true);
         win_update(curwin);
         must_redraw = 0;
         curbuf->b_mod_set = mod_set;

--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -1204,16 +1204,15 @@ describe('smoothscroll', function()
       set smoothscroll scrolloff=3
       call setline(1, ['one', 'two long '->repeat(100), 'three', 'four', 'five', 'six'])
     ]])
-    --FIXME: incorrect screen due to reset_skipcol()/curs_columns() shenanigans
     feed(':norm j721|<CR>')
     screen:expect([[
-      two long two long two long two long two |
+      {1:<<<}two long two long two long two long t|
+      wo long two long two long two long two l|
+      ong two long two long two long two long |
+      ^two long two long two long two long two |
       long two long two long two long two long|
        two long two long two long two long two|
-      ^ long two long two long two long two lon|
-      g two long two long two long two long tw|
-      o long two long two long two long two lo|
-      ng two long two long two long two long t|
+       long two long two long two long two lon|
       :norm j721|                             |
     ]])
     feed('gj')
@@ -1272,15 +1271,14 @@ describe('smoothscroll', function()
       :norm j721|                             |
     ]])
     feed('gk')
-    --FIXME: incorrect screen due to reset_skipcol()/curs_columns() shenanigans
     screen:expect([[
+      {1:<<<}long two long two long two long two l|
+      ong two long two long two long two long |
       two long two long two long two long two |
       long two long two long two long two long|
        two long two long two long two long two|
        long two long two long two long two lon|
-      g two long two long two long two long tw|
-      o long two long two long two long two lo|
-      ^ng two long two long two long two long t|
+      ^g two long two long                     |
       :norm j721|                             |
     ]])
   end)

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -1165,7 +1165,6 @@ func Test_smooth_long_scrolloff()
   END
   call writefile(lines, 'XSmoothLongScrolloff', 'D')
   let buf = RunVimInTerminal('-u NONE -S XSmoothLongScrolloff', #{rows: 8, cols: 40})
-  "FIXME: empty screen due to reset_skipcol()/curs_columns() shenanigans
   call term_sendkeys(buf, ":norm j721|\<CR>")
   call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_1', {})
 
@@ -1185,7 +1184,6 @@ func Test_smooth_long_scrolloff()
   call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_6', {})
 
   call term_sendkeys(buf, "gk")
-  "FIXME: empty screen due to reset_skipcol()/curs_columns() shenanigans
   call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_7', {})
 
   call StopVimInTerminal(buf)


### PR DESCRIPTION
Problem:  Window is updated with potentially invalid skipcol in recursive
          window update path. I.e. cursor outside of visible range in
          large line that does not fit.
Solution: Make sure it is valid (Luuk van Baal).

https://github.com/vim/vim/commit/3d5065fc7553c8de3d0555c3085165bdd724663b