### PR TITLE
docs: vim.lsp.rpc.connect() TCP requires IP address

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2318,7 +2318,7 @@ connect({host_or_path}, {port})                        *vim.lsp.rpc.connect()*
     |vim.lsp.start_client()| or |vim.lsp.start()|.
 
     Parameters: ~
-      • {host_or_path}  (`string`) host (IP Address) to connect to or path to
+      • {host_or_path}  (`string`) host (IP address) to connect to or path to
                         a pipe/domain socket
       • {port}          (`integer?`) TCP port to connect to. If absent the
                         first argument must be a pipe

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2312,14 +2312,14 @@ connect({host_or_path}, {port})                        *vim.lsp.rpc.connect()*
     Create a LSP RPC client factory that connects to either:
     • a named pipe (windows)
     • a domain socket (unix)
-    • a host and port via TCP
+    • a host and port via TCP (Host must be IP Address)
 
     Return a function that can be passed to the `cmd` field for
     |vim.lsp.start_client()| or |vim.lsp.start()|.
 
     Parameters: ~
-      • {host_or_path}  (`string`) host to connect to or path to a pipe/domain
-                        socket
+      • {host_or_path}  (`string`) host (IP Address) to connect to or path to
+                        a pipe/domain socket
       • {port}          (`integer?`) TCP port to connect to. If absent the
                         first argument must be a pipe
 

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2312,7 +2312,7 @@ connect({host_or_path}, {port})                        *vim.lsp.rpc.connect()*
     Create a LSP RPC client factory that connects to either:
     • a named pipe (windows)
     • a domain socket (unix)
-    • a host and port via TCP (Host must be IP Address)
+    • a host and port via TCP (host must be IP address)
 
     Return a function that can be passed to the `cmd` field for
     |vim.lsp.start_client()| or |vim.lsp.start()|.

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -632,7 +632,7 @@ end
 --- Return a function that can be passed to the `cmd` field for
 --- |vim.lsp.start_client()| or |vim.lsp.start()|.
 ---
----@param host_or_path string host (IP Address) to connect to or path to a pipe/domain socket
+---@param host_or_path string host (IP address) to connect to or path to a pipe/domain socket
 ---@param port integer? TCP port to connect to. If absent the first argument must be a pipe
 ---@return fun(dispatchers: vim.lsp.rpc.Dispatchers): vim.lsp.rpc.PublicClient
 function M.connect(host_or_path, port)

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -627,7 +627,7 @@ end
 ---
 ---  - a named pipe (windows)
 ---  - a domain socket (unix)
----  - a host and port via TCP (Host must be IP Address)
+---  - a host and port via TCP (host must be IP address)
 ---
 --- Return a function that can be passed to the `cmd` field for
 --- |vim.lsp.start_client()| or |vim.lsp.start()|.

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -627,12 +627,12 @@ end
 ---
 ---  - a named pipe (windows)
 ---  - a domain socket (unix)
----  - a host and port via TCP
+---  - a host and port via TCP (Host must be IP Address)
 ---
 --- Return a function that can be passed to the `cmd` field for
 --- |vim.lsp.start_client()| or |vim.lsp.start()|.
 ---
----@param host_or_path string host to connect to or path to a pipe/domain socket
+---@param host_or_path string host (IP Address) to connect to or path to a pipe/domain socket
 ---@param port integer? TCP port to connect to. If absent the first argument must be a pipe
 ---@return fun(dispatchers: vim.lsp.rpc.Dispatchers): vim.lsp.rpc.PublicClient
 function M.connect(host_or_path, port)


### PR DESCRIPTION
Updated documentation and code comments to specify that the host must be currently be an IP address when connecting via TCP.

Document #29513 