### PR TITLE
feat(treesitter): return supertypes in language.inspect()

### DIFF
--- a/cmake.deps/cmake/TreesitterCMakeLists.txt
+++ b/cmake.deps/cmake/TreesitterCMakeLists.txt
@@ -9,6 +9,7 @@ target_include_directories(tree-sitter
 
 install(FILES
   lib/include/tree_sitter/api.h
+  lib/src/parser.h
   DESTINATION include/tree_sitter)
 
 include(GNUInstallDirs)

--- a/cmake/FindTreesitter.cmake
+++ b/cmake/FindTreesitter.cmake
@@ -1,4 +1,5 @@
 find_path2(TREESITTER_INCLUDE_DIR tree_sitter/api.h)
+find_path2(TREESITTER_INCLUDE_DIR tree_sitter/parser.h)
 find_library2(TREESITTER_LIBRARY NAMES tree-sitter)
 find_package_handle_standard_args(Treesitter DEFAULT_MSG
   TREESITTER_LIBRARY TREESITTER_INCLUDE_DIR)

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -182,6 +182,7 @@ TREESITTER
 • |LanguageTree:node_for_range()| gets anonymous and named nodes for a range
 • |vim.treesitter.get_node()| now takes an option `include_anonymous`, default
   false, which allows it to return anonymous nodes as well as named nodes.
+• |vim.treesitter.language.inspect()| now shows node supertypes
 
 TUI
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -990,7 +990,8 @@ inspect({lang})                            *vim.treesitter.language.inspect()*
     Inspects the provided language.
 
     Inspecting provides some useful information on the language like node
-    names, ...
+    names, field names, and |vim.treesitter.language_version|. Each node name
+    has an associated boolean which is `false` if it is anonymous.
 
     Parameters: ~
       • {lang}  (`string`) Language

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -151,7 +151,9 @@ end
 
 --- Inspects the provided language.
 ---
---- Inspecting provides some useful information on the language like node names, ...
+--- Inspecting provides some useful information on the language like node
+--- names, field names, and |vim.treesitter.language_version|. Each node name
+--- has an associated boolean which is `false` if it is anonymous.
 ---
 ---@param lang string Language
 ---@return table

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -13,6 +13,7 @@
 #include <stdlib.h>
 #include <string.h>
 #include <tree_sitter/api.h>
+#include <tree_sitter/parser.h>
 #include <uv.h>
 
 #ifdef HAVE_WASMTIME
@@ -268,14 +269,14 @@ int tslua_inspect_lang(lua_State *L)
   lua_createtable(L, (int)(nsymbols - 1), 1);  // [retval, symbols]
   for (uint32_t i = 0; i < nsymbols; i++) {
     TSSymbolType t = ts_language_symbol_type(lang, (TSSymbol)i);
-    if (t == TSSymbolTypeAuxiliary) {
+    if (t == TSSymbolTypeAuxiliary && !lang->symbol_metadata[i].supertype) {
       // not used by the API
       continue;
     }
     lua_createtable(L, 2, 0);  // [retval, symbols, elem]
     lua_pushstring(L, ts_language_symbol_name(lang, (TSSymbol)i));
     lua_rawseti(L, -2, 1);
-    lua_pushboolean(L, t == TSSymbolTypeRegular);
+    lua_pushboolean(L, t != TSSymbolTypeAnonymous);
     lua_rawseti(L, -2, 2);  // [retval, symbols, elem]
     lua_rawseti(L, -2, (int)i);  // [retval, symbols]
   }

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -55,7 +55,7 @@ describe('treesitter language API', function()
 
   it('inspects language', function()
     local keys, fields, symbols = unpack(exec_lua(function()
-      local lang = vim.treesitter.language.inspect('c')
+      local lang = vim.treesitter.language.inspect('lua')
       local keys, symbols = {}, {}
       for k, v in pairs(lang) do
         if type(v) == 'boolean' then
@@ -80,20 +80,22 @@ describe('treesitter language API', function()
       eq('string', type(f))
       fset[f] = true
     end
-    eq(true, fset['directive'])
-    eq(true, fset['initializer'])
+    eq(true, fset['value'])
+    eq(true, fset['body'])
 
-    local has_named, has_anonymous
+    local has_named, has_anonymous, has_supertype
     for _, s in pairs(symbols) do
       eq('string', type(s[1]))
       eq('boolean', type(s[2]))
       if s[1] == 'for_statement' and s[2] == true then
         has_named = true
-      elseif s[1] == '|=' and s[2] == false then
+      elseif s[1] == '..' and s[2] == false then
         has_anonymous = true
+      elseif s[1] == 'statement' and s[2] == true then
+        has_supertype = true
       end
     end
-    eq({ true, true }, { has_named, has_anonymous })
+    eq({ true, true, true }, { has_named, has_anonymous, has_supertype })
   end)
 
   it(


### PR DESCRIPTION
- This commit requires pulling in Tree-sitter's `parser.h` file.
- Supertypes are just put in with the rest of the symbols in the same table field.