### PR TITLE
feat(func): allow manual cache invalidation for _memoize

### DIFF
--- a/runtime/lua/vim/func.lua
+++ b/runtime/lua/vim/func.lua
@@ -3,9 +3,6 @@ local M = {}
 -- TODO(lewis6991): Private for now until:
 -- - There are other places in the codebase that could benefit from this
 --   (e.g. LSP), but might require other changes to accommodate.
--- - Invalidation of the cache needs to be controllable. Using weak tables
---   is an acceptable invalidation policy, but it shouldn't be the only
---   one.
 -- - I don't think the story around `hash` is completely thought out. We
 --   may be able to have a good default hash by hashing each argument,
 --   so basically a better 'concat'.
@@ -16,6 +13,10 @@ local M = {}
 ---
 --- Internally uses a |lua-weaktable| to cache the results of {fn} meaning the
 --- cache will be invalidated whenever Lua does garbage collection.
+---
+--- The cache can also be manually invalidated by calling `:clear()` on the returned object.
+--- Calling this function with no arguments clears the entire cache; otherwise, the arguments will
+--- be interpreted as function inputs, and only the cache entry at their hash will be cleared.
 ---
 --- The memoized function returns shared references so be wary about
 --- mutating return values.
@@ -32,11 +33,12 @@ local M = {}
 ---     first n arguments passed to {fn}.
 ---
 --- @param fn F Function to memoize.
---- @param strong? boolean Do not use a weak table
+--- @param weak? boolean Use a weak table (default `true`)
 --- @return F # Memoized version of {fn}
 --- @nodoc
-function M._memoize(hash, fn, strong)
-  return require('vim.func._memoize')(hash, fn, strong)
+function M._memoize(hash, fn, weak)
+  -- this is wrapped in a function to lazily require the module
+  return require('vim.func._memoize')(hash, fn, weak)
 end
 
 return M

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -902,8 +902,8 @@ function Query:iter_captures(node, source, start, stop)
 
   local cursor = vim._create_ts_querycursor(node, self.query, start, stop, { match_limit = 256 })
 
-  local apply_directives = memoize(match_id_hash, self.apply_directives, true)
-  local match_preds = memoize(match_id_hash, self.match_preds, true)
+  local apply_directives = memoize(match_id_hash, self.apply_directives, false)
+  local match_preds = memoize(match_id_hash, self.match_preds, false)
 
   local function iter(end_line)
     local capture, captured_node, match = cursor:next_capture()

--- a/test/functional/func/memoize_spec.lua
+++ b/test/functional/func/memoize_spec.lua
@@ -1,0 +1,142 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+local clear = n.clear
+local exec_lua = n.exec_lua
+local eq = t.eq
+
+describe('vim.func._memoize', function()
+  before_each(clear)
+
+  it('caches function results based on their parameters', function()
+    exec_lua([[
+      _G.count = 0
+
+      local adder = vim.func._memoize('concat', function(arg1, arg2)
+        _G.count = _G.count + 1
+        return arg1 + arg2
+      end)
+
+      collectgarbage('stop')
+      adder(3, -4)
+      adder(3, -4)
+      adder(3, -4)
+      adder(3, -4)
+      adder(3, -4)
+      collectgarbage('restart')
+    ]])
+
+    eq(1, exec_lua([[return _G.count]]))
+  end)
+
+  it('caches function results using a weak table by default', function()
+    exec_lua([[
+      _G.count = 0
+
+      local adder = vim.func._memoize('concat-2', function(arg1, arg2)
+        _G.count = _G.count + 1
+        return arg1 + arg2
+      end)
+
+      adder(3, -4)
+      collectgarbage()
+      adder(3, -4)
+      collectgarbage()
+      adder(3, -4)
+    ]])
+
+    eq(3, exec_lua([[return _G.count]]))
+  end)
+
+  it('can cache using a strong table', function()
+    exec_lua([[
+      _G.count = 0
+
+      local adder = vim.func._memoize('concat-2', function(arg1, arg2)
+        _G.count = _G.count + 1
+        return arg1 + arg2
+      end, false)
+
+      adder(3, -4)
+      collectgarbage()
+      adder(3, -4)
+      collectgarbage()
+      adder(3, -4)
+    ]])
+
+    eq(1, exec_lua([[return _G.count]]))
+  end)
+
+  it('can clear a single cache entry', function()
+    exec_lua([[
+      _G.count = 0
+
+      local adder = vim.func._memoize(function(arg1, arg2)
+        return tostring(arg1) .. '%%' .. tostring(arg2)
+      end, function(arg1, arg2)
+        _G.count = _G.count + 1
+        return arg1 + arg2
+      end)
+
+      collectgarbage('stop')
+      adder(3, -4)
+      adder(3, -4)
+      adder(3, -4)
+      adder(3, -4)
+      adder(3, -4)
+      adder:clear(3, -4)
+      adder(3, -4)
+      collectgarbage('restart')
+    ]])
+
+    eq(2, exec_lua([[return _G.count]]))
+  end)
+
+  it('can clear the entire cache', function()
+    exec_lua([[
+      _G.count = 0
+
+      local adder = vim.func._memoize(function(arg1, arg2)
+        return tostring(arg1) .. '%%' .. tostring(arg2)
+      end, function(arg1, arg2)
+        _G.count = _G.count + 1
+        return arg1 + arg2
+      end)
+
+      collectgarbage('stop')
+      adder(1, 2)
+      adder(3, -4)
+      adder(1, 2)
+      adder(3, -4)
+      adder(1, 2)
+      adder(3, -4)
+      adder:clear()
+      adder(1, 2)
+      adder(3, -4)
+      collectgarbage('restart')
+    ]])
+
+    eq(4, exec_lua([[return _G.count]]))
+  end)
+
+  it('can cache functions that return nil', function()
+    exec_lua([[
+      _G.count = 0
+
+      local adder = vim.func._memoize('concat', function(arg1, arg2)
+        _G.count = _G.count + 1
+        return nil
+      end)
+
+      collectgarbage('stop')
+      adder(1, 2)
+      adder(1, 2)
+      adder(1, 2)
+      adder(1, 2)
+      adder:clear()
+      adder(1, 2)
+      collectgarbage('restart')
+    ]])
+
+    eq(2, exec_lua([[return _G.count]]))
+  end)
+end)


### PR DESCRIPTION
This commit also adds some tests for the existing memoization functionality.

---

### Justification

1. It would be nice to have some finer-grained control over the memoization cache invalidation. I have anecdotally observed that this would be very helpful when trying to tackle something like https://github.com/neovim/neovim/pull/27422#issuecomment-1937493022. (E.g., how can we manually invalidate the result of a function for a specific bufnr?)
2. Based on [this TODO comment](https://github.com/neovim/neovim/blob/60ea0467411d8452b0af75836aec377cbe781fbc/runtime/lua/vim/func.lua#L6C1-L8C10), it seems like this was already a feature that was desired in general

### Implementation

Now, instead of just returning a function which has it's result memoized, the memoization initializer (now a separate `_init` method) returns a table, which is still callable as a function to match the previous functionality, but also stores additional metadata (in its metatable, to avoid clashes with the actual cache content), like a function to invalidate the cache value at a certain index. This invalidation function is then used by a new method in the memoization module (`_invalidate`) to actually perform the cache invalidation 