### PR TITLE
fix(diagnostic): add cursorlinehl in vim.diagnotic.opts.Signs

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -526,28 +526,32 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
 *vim.diagnostic.Opts.Signs*
 
     Fields: ~
-      • {severity}?  (`vim.diagnostic.SeverityFilter`) Only show virtual text
-                     for diagnostics matching the given severity
-                     |diagnostic-severity|
-      • {priority}?  (`integer`, default: `10`) Base priority to use for
-                     signs. When {severity_sort} is used, the priority of a
-                     sign is adjusted based on its severity. Otherwise, all
-                     signs use the same priority.
-      • {text}?      (`table<vim.diagnostic.Severity,string>`) A table mapping
-                     |diagnostic-severity| to the sign text to display in the
-                     sign column. The default is to use `"E"`, `"W"`, `"I"`,
-                     and `"H"` for errors, warnings, information, and hints,
-                     respectively. Example: >lua
-                         vim.diagnostic.config({
-                           signs = { text = { [vim.diagnostic.severity.ERROR] = 'E', ... } }
-                         })
+      • {severity}?     (`vim.diagnostic.SeverityFilter`) Only show virtual
+                        text for diagnostics matching the given severity
+                        |diagnostic-severity|
+      • {priority}?     (`integer`, default: `10`) Base priority to use for
+                        signs. When {severity_sort} is used, the priority of a
+                        sign is adjusted based on its severity. Otherwise, all
+                        signs use the same priority.
+      • {text}?         (`table<vim.diagnostic.Severity,string>`) A table
+                        mapping |diagnostic-severity| to the sign text to
+                        display in the sign column. The default is to use
+                        `"E"`, `"W"`, `"I"`, and `"H"` for errors, warnings,
+                        information, and hints, respectively. Example: >lua
+                            vim.diagnostic.config({
+                              signs = { text = { [vim.diagnostic.severity.ERROR] = 'E', ... } }
+                            })
 <
-      • {numhl}?     (`table<vim.diagnostic.Severity,string>`) A table mapping
-                     |diagnostic-severity| to the highlight group used for the
-                     line number where the sign is placed.
-      • {linehl}?    (`table<vim.diagnostic.Severity,string>`) A table mapping
-                     |diagnostic-severity| to the highlight group used for the
-                     whole line the sign is placed in.
+      • {numhl}?        (`table<vim.diagnostic.Severity,string>`) A table
+                        mapping |diagnostic-severity| to the highlight group
+                        used for the line number where the sign is placed.
+      • {linehl}?       (`table<vim.diagnostic.Severity,string>`) A table
+                        mapping |diagnostic-severity| to the highlight group
+                        used for the whole line the sign is placed in.
+      • {cursorlinehl}  (`table<vim.diagnostic.Severity,string>`) A table
+                        mapping |diagnostic-severity| to the highlight group
+                        used for the highlight the sign column text when
+                        cursor is on target line and 'cursorline' is enabled.
 
 *vim.diagnostic.Opts.Underline*
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -243,6 +243,10 @@ local M = {}
 --- A table mapping |diagnostic-severity| to the highlight group used for the
 --- whole line the sign is placed in.
 --- @field linehl? table<vim.diagnostic.Severity,string>
+---
+--- A table mapping |diagnostic-severity| to the highlight group used for the
+--- highlight the sign column text when cursor is on target line and 'cursorline' is enabled.
+--- @field cursorlinehl table<vim.diagnostic.Severity,string>
 
 --- @class vim.diagnostic.Opts.Jump
 ---
@@ -1447,6 +1451,7 @@ M.handlers.signs = {
 
     local numhl = opts.signs.numhl or {}
     local linehl = opts.signs.linehl or {}
+    local curlinehl = opts.signs.cursorlinehl or {}
 
     local line_count = api.nvim_buf_line_count(bufnr)
 
@@ -1457,6 +1462,7 @@ M.handlers.signs = {
           sign_hl_group = sign_highlight_map[diagnostic.severity],
           number_hl_group = numhl[diagnostic.severity],
           line_hl_group = linehl[diagnostic.severity],
+          cursorline_hl_group = vim.wo.cursorline and curlinehl[diagnostic.severity] or nil,
           priority = get_priority(diagnostic.severity),
         })
       end

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -2347,6 +2347,7 @@ describe('vim.diagnostic', function()
       -- Legacy signs for diagnostics were deprecated in 0.10 and will be removed in 0.12
       eq(0, n.fn.has('nvim-0.12'))
 
+      n.command('set cursorline')
       n.command('sign define DiagnosticSignError text= texthl= linehl=ErrorMsg numhl=ErrorMsg')
       n.command('sign define DiagnosticSignWarn text= texthl= linehl=WarningMsg numhl=WarningMsg')
       n.command('sign define DiagnosticSignInfo text= texthl= linehl=Underlined numhl=Underlined')
@@ -2354,7 +2355,7 @@ describe('vim.diagnostic', function()
 
       local result = exec_lua(function()
         vim.diagnostic.config({
-          signs = true,
+          signs = { cursorlinehl = { 'DiagnosticError', 'DiagnosticWarn' } },
         })
 
         local diagnostics = {
@@ -2382,6 +2383,7 @@ describe('vim.diagnostic', function()
             text = s[4].sign_text or '',
             numhl = s[4].number_hl_group,
             linehl = s[4].line_hl_group,
+            culhl = s[4].cursorline_hl_group,
           }
         end
         return result
@@ -2393,6 +2395,7 @@ describe('vim.diagnostic', function()
         text = '',
         numhl = 'ErrorMsg',
         linehl = 'ErrorMsg',
+        culhl = 'DiagnosticError',
       }, result[1])
 
       eq({
@@ -2401,6 +2404,7 @@ describe('vim.diagnostic', function()
         text = '',
         numhl = 'WarningMsg',
         linehl = 'WarningMsg',
+        culhl = 'DiagnosticWarn',
       }, result[2])
     end)
   end)


### PR DESCRIPTION
Problem: extmark also support cursorline_hl_group when cursorline is on.

Solution: support it on vim.diangostic.optss.Signs

Fix #30226 