### PR TITLE
vim-patch:bd69b39: runtime(sudoers): improve recognized Runas_Spec and Tag_Spec items

### DIFF
--- a/runtime/syntax/sudoers.vim
+++ b/runtime/syntax/sudoers.vim
@@ -2,9 +2,10 @@
 " Language:             sudoers(5) configuration files
 " Maintainer:           Eisuke Kawashima ( e.kawaschima+vim AT gmail.com )
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2021 Mar 15
+" Latest Revision:      2024 Sep 02
 " Recent Changes:	Support for #include and #includedir.
 " 			Added many new options (Samuel D. Leslie)
+" 			Update allowed Tag_Spec Runas_Spec syntax items
 
 if exists("b:current_syntax")
   finish
@@ -22,7 +23,7 @@ syn match   sudoersUserSpec '^' nextgroup=@sudoersUserInSpec skipwhite
 
 syn match   sudoersSpecEquals         contained '=' nextgroup=@sudoersCmndSpecList skipwhite
 
-syn cluster sudoersCmndSpecList       contains=sudoersUserRunasBegin,sudoersPASSWD,@sudoersCmndInSpec
+syn cluster sudoersCmndSpecList       contains=sudoersUserRunasBegin,sudoersTagSpec,@sudoersCmndInSpec
 
 syn keyword sudoersTodo               contained TODO FIXME XXX NOTE
 
@@ -92,10 +93,11 @@ syn cluster sudoersUserList         contains=sudoersUserListComma,sudoersUserLis
 syn match   sudoersUserSpecComma    contained ',' nextgroup=@sudoersUserInSpec  skipwhite skipnl
 syn cluster sudoersUserSpec         contains=sudoersUserSpecComma,@sudoersHostInSpec
 
-syn match   sudoersUserRunasBegin   contained '(' nextgroup=@sudoersUserInRunas skipwhite skipnl
+syn match   sudoersUserRunasBegin   contained '(' nextgroup=@sudoersUserInRunas,sudoersUserRunasColon skipwhite skipnl
 syn match   sudoersUserRunasComma   contained ',' nextgroup=@sudoersUserInRunas skipwhite skipnl
-syn match   sudoersUserRunasEnd     contained ')' nextgroup=sudoersPASSWD,@sudoersCmndInSpec skipwhite skipnl
-syn cluster sudoersUserRunas        contains=sudoersUserRunasComma,@sudoersUserInRunas,sudoersUserRunasEnd
+syn match   sudoersUserRunasColon   contained ':' nextgroup=@sudoersUserInRunas skipwhite skipnl
+syn match   sudoersUserRunasEnd     contained ')' nextgroup=sudoersTagSpec,@sudoersCmndInSpec skipwhite skipnl
+syn cluster sudoersUserRunas        contains=sudoersUserRunasComma,sudoersUserRunasColon,@sudoersUserInRunas,sudoersUserRunasEnd
 
 
 syn match   sudoersHostAliasEquals  contained '=' nextgroup=@sudoersHostInList  skipwhite skipnl
@@ -291,7 +293,7 @@ syn region  sudoersStringValue  contained start=+"+ skip=+\\"+ end=+"+ nextgroup
 syn match   sudoersListValue    contained '[^[:space:],:=\\]*\%(\\[[:space:],:=\\][^[:space:],:=\\]*\)*' nextgroup=sudoersParameterListComma skipwhite skipnl
 syn region  sudoersListValue    contained start=+"+ skip=+\\"+ end=+"+ nextgroup=sudoersParameterListComma skipwhite skipnl
 
-syn match   sudoersPASSWD                   contained '\%(NO\)\=PASSWD:' nextgroup=@sudoersCmndInSpec skipwhite
+syn match   sudoersTagSpec      contained '\%(NO\)\=\%(EXEC\|FOLLOW\|LOG_\%(INPUT\|OUTPUT\)\|MAIL\|INTERCEPT\|PASSWD\|SETENV\):' nextgroup=sudoersTagSpec,@sudoersCmndInSpec skipwhite
 
 hi def link sudoersSpecEquals               Operator
 hi def link sudoersTodo                     Todo
@@ -345,6 +347,7 @@ hi def link sudoersUserListColon            Delimiter
 hi def link sudoersUserSpecComma            Delimiter
 hi def link sudoersUserRunasBegin           Delimiter
 hi def link sudoersUserRunasComma           Delimiter
+hi def link sudoersUserRunasColon           Delimiter
 hi def link sudoersUserRunasEnd             Delimiter
 hi def link sudoersHostAliasEquals          Operator
 hi def link sudoersHostListComma            Delimiter
@@ -381,7 +384,7 @@ hi def link sudoersListParameterEquals      Operator
 hi def link sudoersIntegerValue             Number
 hi def link sudoersStringValue              String
 hi def link sudoersListValue                String
-hi def link sudoersPASSWD                   Special
+hi def link sudoersTagSpec                  Special
 hi def link sudoersInclude                  Statement
 
 let b:current_syntax = "sudoers"


### PR DESCRIPTION
Recognize colon-delimited second part of Runas_Spec that specifies
permitted groups, e.g.:

    alan ALL = (root, bin : operator, system) ALL

This implementation is sloppy because it accepts any amount of colons
delimiting further Runas_Lists, but for now that's better than bailing
out completely as soon as a colon is encountered (esp. given that the
default sudoers uses these colons, breaking highlighting OOTB).

Also, while at it, make Vim recognize all Tag_Spec items, not just
{,NO}PASSWD

closes: vim/vim#15607

https://github.com/vim/vim/commit/bd69b39514f1fec45a5ac76cd36db5dec2faebe2

Co-authored-by: Christian Brabandt <cb@256bit.org>
