### PR TITLE
build: add quotes around `CMAKE_GENERATOR` variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ else
   TOUCH := touch
   RM := rm -rf
   CMAKE := $(shell (command -v cmake3 || echo cmake))
-  CMAKE_GENERATOR ?= $(shell (command -v ninja > /dev/null 2>&1 && echo "Ninja") || echo "Unix Makefiles")
+  CMAKE_GENERATOR ?= "$(shell (command -v ninja > /dev/null 2>&1 && echo "Ninja") || echo "Unix Makefiles")"
   define rmdir
     rm -rf $1
   endef


### PR DESCRIPTION
This will fix the following error when using generators that have a
space in them, e.g. "Unix Makefiles":

"CMake Error: Could not create named generator Unix".

Closes https://github.com/neovim/neovim/issues/30218.
