### PR TITLE
fix(decor): revise marktree metadata for invalid marks

### DIFF
--- a/src/nvim/marktree.c
+++ b/src/nvim/marktree.c
@@ -446,7 +446,7 @@ static MTNode *marktree_alloc_node(MarkTree *b, bool internal)
 // really meta_inc[kMTMetaCount]
 static void meta_describe_key_inc(uint32_t *meta_inc, MTKey *k)
 {
-  if (!mt_end(*k)) {
+  if (!mt_end(*k) && !mt_invalid(*k)) {
     meta_inc[kMTMetaInline] += (k->flags & MT_FLAG_DECOR_VIRT_TEXT_INLINE) ? 1 : 0;
     meta_inc[kMTMetaLines] += (k->flags & MT_FLAG_DECOR_VIRT_LINES) ? 1 : 0;
     meta_inc[kMTMetaSignHL] += (k->flags & MT_FLAG_DECOR_SIGNHL) ? 1 : 0;
@@ -774,14 +774,10 @@ uint64_t marktree_del_itr(MarkTree *b, MarkTreeIter *itr, bool rev)
   return other;
 }
 
-void marktree_revise_flags(MarkTree *b, MarkTreeIter *itr, uint16_t new_flags)
+void marktree_revise_meta(MarkTree *b, MarkTreeIter *itr, MTKey old_key)
 {
-  uint32_t meta_old[4];
-  meta_describe_key(meta_old, rawkey(itr));
-  rawkey(itr).flags &= (uint16_t) ~MT_FLAG_EXTERNAL_MASK;
-  rawkey(itr).flags |= new_flags;
-
-  uint32_t meta_new[4];
+  uint32_t meta_old[4], meta_new[4];
+  meta_describe_key(meta_old, old_key);
   meta_describe_key(meta_new, rawkey(itr));
 
   if (!memcmp(meta_old, meta_new, sizeof(meta_old))) {

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -5641,6 +5641,19 @@ l5
     ]])
     eq("Invalid 'sign_text'", pcall_err(api.nvim_buf_set_extmark, 0, ns, 5, 0, {sign_text='❤️x'}))
   end)
+
+  it('auto signcolumn hides with invalidated sign', function()
+    api.nvim_set_option_value('signcolumn', 'auto', {})
+    api.nvim_buf_set_extmark(0, ns, 0, 0, {sign_text='S1', invalidate=true})
+    feed('ia<cr>b<esc>dd')
+    screen:expect({
+      grid = [[
+        ^a                                                 |
+        {1:~                                                 }|*8
+                                                          |
+      ]]
+    })
+  end)
 end)
 
 describe('decorations: virt_text', function()


### PR DESCRIPTION
Problem:  Marktree meta count still includes invalidated marks, making
          guards that check the meta total ineffective.
Solution: Revise marktree metadata when in/revalidating a mark.

Fix #30197