### PR TITLE
feat(startup): validate --listen address

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -53,12 +53,6 @@ EDITOR
   documented and skips help buffers if run from a non-help buffer, otherwise
   it moves to another help buffer.
 
-VIM SCRIPT
-
-• |v:msgpack_types| has the type "binary" removed. |msgpackparse()| no longer
-  treats BIN, STR and FIXSTR as separate types. Any of these is returned as a
-  string if possible, or a |blob| if the value contained embedded NUL:s.
-
 EVENTS
 
 • TODO
@@ -97,6 +91,12 @@ TREESITTER
 TUI
 
 • TODO
+
+VIMSCRIPT
+
+• |v:msgpack_types| has the type "binary" removed. |msgpackparse()| no longer
+  treats BIN, STR and FIXSTR as separate types. Any of these is returned as a
+  string if possible, or a |blob| if the value contained embedded NUL:s.
 
 ==============================================================================
 NEW FEATURES                                                    *news-features*
@@ -162,7 +162,8 @@ PLUGINS
 
 STARTUP
 
-• TODO
+• Nvim will fail if the |--listen| or |$NVIM_LISTEN_ADDRESS| address is
+  invalid, instead of silently skipping an invalid address.
 
 TERMINAL
 

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -93,15 +93,15 @@ void remote_ui_free_all_mem(void)
 }
 #endif
 
-/// Wait until ui has connected on stdio channel if only_stdio
-/// is true, otherwise any channel.
+/// Wait until UI has connected.
+///
+/// @param only_stdio UI is expected to connect on stdio.
 void remote_ui_wait_for_attach(bool only_stdio)
 {
   if (only_stdio) {
     Channel *channel = find_channel(CHAN_STDIO);
     if (!channel) {
-      // this function should only be called in --embed mode, stdio channel
-      // can be assumed.
+      // `only_stdio` implies --embed mode, thus stdio channel can be assumed.
       abort();
     }
 

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -332,12 +332,6 @@ int main(int argc, char **argv)
 #endif
   bool use_builtin_ui = (has_term && !headless_mode && !embedded_mode && !silent_mode);
 
-  // don't bind the server yet, if we are using builtin ui.
-  // This will be done when nvim server has been forked from the ui process
-  if (!use_builtin_ui) {
-    server_init(params.listen_addr);
-  }
-
   if (params.remote) {
     remote_request(&params, params.remote, params.server_addr, argc, argv,
                    use_builtin_ui);
@@ -355,11 +349,19 @@ int main(int argc, char **argv)
     ui_client_channel_id = rv;
   }
 
+  // NORETURN: Start builtin UI client.
   if (ui_client_channel_id) {
     time_finish();
     ui_client_run(remote_ui);  // NORETURN
   }
   assert(!ui_client_channel_id && !use_builtin_ui);
+  // Nvim server...
+
+  int listen_rv = server_init(params.listen_addr);
+  if (listen_rv != 0) {
+    mainerr("Failed to --listen", listen_rv < 0
+            ? os_strerror(listen_rv) : (listen_rv == 1 ? "empty address" : NULL));
+  }
 
   TIME_MSG("expanding arguments");
 

--- a/test/functional/ex_cmds/profile_spec.lua
+++ b/test/functional/ex_cmds/profile_spec.lua
@@ -6,16 +6,10 @@ require('os')
 local eval = n.eval
 local command = n.command
 local eq, neq = t.eq, t.neq
-local tempfile = t.tmpname()
+local tempfile = t.tmpname(false)
 local source = n.source
 local matches = t.matches
 local read_file = t.read_file
-
--- tmpname() also creates the file on POSIX systems. Remove it again.
--- We just need the name, ignoring any race conditions.
-if uv.fs_stat(tempfile).uid then
-  os.remove(tempfile)
-end
 
 local function assert_file_exists(filepath)
   neq(nil, uv.fs_stat(filepath).uid)
@@ -31,6 +25,7 @@ describe(':profile', function()
   after_each(function()
     n.expect_exit(command, 'qall!')
     if uv.fs_stat(tempfile).uid ~= nil then
+      -- Delete the tempfile. We just need the name, ignoring any race conditions.
       os.remove(tempfile)
     end
   end)

--- a/test/functional/lua/loader_spec.lua
+++ b/test/functional/lua/loader_spec.lua
@@ -74,8 +74,7 @@ describe('vim.loader', function()
       vim.loader.enable()
     ]]
 
-    local tmp = t.tmpname()
-    assert(os.remove(tmp))
+    local tmp = t.tmpname(false)
     assert(t.mkdir(tmp))
     assert(t.mkdir(tmp .. '/%'))
     local tmp1 = tmp .. '/%/x'

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -800,8 +800,7 @@ describe('LSP', function()
           eq(table.remove(expected_handlers), { err, result, ctx }, 'expected handler')
           if ctx.method == 'start' then
             local tmpfile_old = tmpname()
-            local tmpfile_new = tmpname()
-            os.remove(tmpfile_new)
+            local tmpfile_new = tmpname(false)
             exec_lua(function(oldname, newname)
               _G.BUFFER = vim.api.nvim_get_current_buf()
               vim.api.nvim_buf_set_name(_G.BUFFER, oldname)
@@ -2370,8 +2369,7 @@ describe('LSP', function()
     end)
 
     it('Supports file creation with CreateFile payload', function()
-      local tmpfile = tmpname()
-      os.remove(tmpfile) -- Should not exist, only interested in a tmpname
+      local tmpfile = tmpname(false)
       local uri = exec_lua('return vim.uri_from_fname(...)', tmpfile)
       local edit = {
         documentChanges = {
@@ -2388,9 +2386,7 @@ describe('LSP', function()
     it(
       'Supports file creation in folder that needs to be created with CreateFile payload',
       function()
-        local tmpfile = tmpname()
-        os.remove(tmpfile) -- Should not exist, only interested in a tmpname
-        tmpfile = tmpfile .. '/dummy/x/'
+        local tmpfile = tmpname(false) .. '/dummy/x/'
         local uri = exec_lua('return vim.uri_from_fname(...)', tmpfile)
         local edit = {
           documentChanges = {
@@ -2468,8 +2464,7 @@ describe('LSP', function()
     end)
 
     it('DeleteFile fails if file does not exist and ignoreIfNotExists is false', function()
-      local tmpfile = tmpname()
-      os.remove(tmpfile)
+      local tmpfile = tmpname(false)
       local uri = exec_lua('return vim.uri_from_fname(...)', tmpfile)
       local edit = {
         documentChanges = {
@@ -2493,8 +2488,7 @@ describe('LSP', function()
     it('Can rename an existing file', function()
       local old = tmpname()
       write_file(old, 'Test content')
-      local new = tmpname()
-      os.remove(new) -- only reserve the name, file must not exist for the test scenario
+      local new = tmpname(false)
       local lines = exec_lua(function(old0, new0)
         local old_bufnr = vim.fn.bufadd(old0)
         vim.fn.bufload(old_bufnr)
@@ -2514,10 +2508,8 @@ describe('LSP', function()
 
     it('Can rename a directory', function()
       -- only reserve the name, file must not exist for the test scenario
-      local old_dir = tmpname()
-      local new_dir = tmpname()
-      os.remove(old_dir)
-      os.remove(new_dir)
+      local old_dir = tmpname(false)
+      local new_dir = tmpname(false)
 
       n.mkdir_p(old_dir)
 
@@ -2542,10 +2534,8 @@ describe('LSP', function()
     end)
 
     it('Does not touch buffers that do not match path prefix', function()
-      local old = tmpname()
-      local new = tmpname()
-      os.remove(old)
-      os.remove(new)
+      local old = tmpname(false)
+      local new = tmpname(false)
       n.mkdir_p(old)
 
       eq(
@@ -2604,8 +2594,7 @@ describe('LSP', function()
     it('Maintains undo information for loaded buffer', function()
       local old = tmpname()
       write_file(old, 'line')
-      local new = tmpname()
-      os.remove(new)
+      local new = tmpname(false)
 
       local undo_kept = exec_lua(function(old0, new0)
         vim.opt.undofile = true
@@ -2629,8 +2618,7 @@ describe('LSP', function()
     it('Maintains undo information for unloaded buffer', function()
       local old = tmpname()
       write_file(old, 'line')
-      local new = tmpname()
-      os.remove(new)
+      local new = tmpname(false)
 
       local undo_kept = exec_lua(function(old0, new0)
         vim.opt.undofile = true
@@ -2651,8 +2639,7 @@ describe('LSP', function()
     it('Does not rename file when it conflicts with a buffer without file', function()
       local old = tmpname()
       write_file(old, 'Old File')
-      local new = tmpname()
-      os.remove(new)
+      local new = tmpname(false)
 
       local lines = exec_lua(function(old0, new0)
         local old_buf = vim.fn.bufadd(old0)
@@ -5023,13 +5010,7 @@ describe('LSP', function()
     end)
 
     it('can connect to lsp server via pipe or domain_socket', function()
-      local tmpfile --- @type string
-      if is_os('win') then
-        tmpfile = '\\\\.\\\\pipe\\pipe.test'
-      else
-        tmpfile = tmpname()
-        os.remove(tmpfile)
-      end
+      local tmpfile = is_os('win') and '\\\\.\\\\pipe\\pipe.test' or tmpname(false)
       local result = exec_lua(function(SOCK)
         local uv = vim.uv
         local server = assert(uv.new_pipe(false))
@@ -5135,9 +5116,7 @@ describe('LSP', function()
 
   describe('#dynamic vim.lsp._dynamic', function()
     it('supports dynamic registration', function()
-      ---@type string
-      local root_dir = tmpname()
-      os.remove(root_dir)
+      local root_dir = tmpname(false)
       mkdir(root_dir)
       local tmpfile = root_dir .. '/dynamic.foo'
       local file = io.open(tmpfile, 'w')
@@ -5264,8 +5243,7 @@ describe('LSP', function()
             )
           end
 
-          local root_dir = tmpname()
-          os.remove(root_dir)
+          local root_dir = tmpname(false)
           mkdir(root_dir)
 
           exec_lua(create_server_definition)

--- a/test/testutil.lua
+++ b/test/testutil.lua
@@ -402,14 +402,18 @@ end
 local tmpname_id = 0
 local tmpdir = tmpdir_get()
 
---- Creates a new temporary file for use by tests.
-function M.tmpname()
+--- Generates a unique file path for use by tests, and writes the file unless `create=false`.
+---
+---@param create? boolean (default true) Write the file.
+function M.tmpname(create)
   if tmpdir_is_local(tmpdir) then
     -- Cannot control os.tmpname() dir, so hack our own tmpname() impl.
     tmpname_id = tmpname_id + 1
     -- "…/Xtest_tmpdir/T42.7"
     local fname = ('%s/%s.%d'):format(tmpdir, (_G._nvim_test_id or 'nvim-test'), tmpname_id)
-    io.open(fname, 'w'):close()
+    if create ~= false then
+      io.open(fname, 'w'):close()
+    end
     return fname
   end
 


### PR DESCRIPTION
## Problem:
`nvim --listen` does not error on EADDRINUSE. #30123

## Solution:
Now that `$NVIM_LISTEN_ADDRESS` is deprecated and input *only* (instead of the old, ambiguous situation where it was both an input *and* an output), we can be fail fast instead of trying to "recover". This reverts the "recovery" behavior of 704ba4151e7f67999510ee0ac19fdabb595d530c, but that was basically a workaround for the fragility of `$NVIM_LISTEN_ADDRESS`. 

close #30123