### PR TITLE
test: tmpname(create:boolean)

### DIFF
--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -325,7 +325,7 @@ describe('tmpdir', function()
 
   before_each(function()
     -- Fake /tmp dir so that we can mess it up.
-    os_tmpdir = vim.uv.fs_mkdtemp(vim.fs.dirname(t.tmpname()) .. '/nvim_XXXXXXXXXX')
+    os_tmpdir = vim.uv.fs_mkdtemp(vim.fs.dirname(t.tmpname(false)) .. '/nvim_XXXXXXXXXX')
   end)
 
   after_each(function()

--- a/test/functional/lua/watch_spec.lua
+++ b/test/functional/lua/watch_spec.lua
@@ -12,7 +12,6 @@ local skip = t.skip
 -- events which can happen with some backends on some platforms
 local function touch(path)
   local tmp = t.tmpname()
-  io.open(tmp, 'w'):close()
   assert(vim.uv.fs_rename(tmp, path))
 end
 
@@ -42,7 +41,7 @@ describe('vim._watch', function()
         )
       end
 
-      local root_dir = vim.uv.fs_mkdtemp(vim.fs.dirname(t.tmpname()) .. '/nvim_XXXXXXXXXX')
+      local root_dir = vim.uv.fs_mkdtemp(vim.fs.dirname(t.tmpname(false)) .. '/nvim_XXXXXXXXXX')
 
       local expected_events = 0
 

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -8,7 +8,6 @@ local exec_lua = n.exec_lua
 local fn = n.fn
 local nvim_prog = n.nvim_prog
 local matches = t.matches
-local write_file = t.write_file
 local tmpname = t.tmpname
 local eq = t.eq
 local pesc = vim.pesc
@@ -226,7 +225,6 @@ describe(':Man', function()
     local actual_file = tmpname()
     -- actual_file must be an absolute path to an existent file for us to test against it
     matches('^/.+', actual_file)
-    write_file(actual_file, '')
     local args = { nvim_prog, '--headless', '+:Man ' .. actual_file, '+q' }
     matches(
       ('Error detected while processing command line:\r\n' .. 'man.lua: "no manual entry for %s"'):format(

--- a/test/functional/vimscript/server_spec.lua
+++ b/test/functional/vimscript/server_spec.lua
@@ -188,8 +188,7 @@ describe('startup --listen', function()
         return
       end
       matches(expected, output)
-      cmd = vim.list_extend({ unpack(n.nvim_argv) }, args)
-      matches(expected, fn.system(cmd))
+      matches(expected, fn.system(vim.list_extend({ unpack(n.nvim_argv) }, args)))
     end
 
     _test({ '--listen' }, 'nvim.*: Argument missing after: "%-%-listen"')

--- a/test/testutil.lua
+++ b/test/testutil.lua
@@ -402,7 +402,8 @@ end
 local tmpname_id = 0
 local tmpdir = tmpdir_get()
 
---- Generates a unique file path for use by tests, and writes the file unless `create=false`.
+--- Generates a unique filepath for use by tests, in a test-specific "…/Xtest_tmpdir/T42.7"
+--- directory (which is cleaned up by the test runner), and writes the file unless `create=false`.
 ---
 ---@param create? boolean (default true) Write the file.
 function M.tmpname(create)
@@ -418,6 +419,10 @@ function M.tmpname(create)
   end
 
   local fname = os.tmpname()
+  if create == false then
+    os.remove(fname)
+  end
+
   if M.is_os('win') and fname:sub(1, 2) == '\\s' then
     -- In Windows tmpname() returns a filename starting with
     -- special sequence \s, prepend $TEMP path


### PR DESCRIPTION
Problem:
137f98cf6428 added the `create` parameter to `tmpname()` but didn't fully implement it.

Solution:
- Update impl for the `os.tmpname()` codepath.
- Inspect all usages of `tmpname()`, update various tests.