### PR TITLE
fix(doc): use "nvim" in swapfile message instead of "vim"

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1250,7 +1250,7 @@ theend:
 /// with the 'directory' option.
 ///
 /// Used to:
-/// - list the swapfiles for "vim -r"
+/// - list the swapfiles for "nvim -r"
 /// - count the number of swapfiles when recovering
 /// - list the swapfiles when recovering
 /// - list the swapfiles for swapfilelist()
@@ -3280,7 +3280,7 @@ static void attention_message(buf_T *buf, char *fname)
              " instances of the same\n    file when making changes."
              "  Quit, or continue with caution.\n"));
   msg_puts(_("(2) An edit session for this file crashed.\n"));
-  msg_puts(_("    If this is the case, use \":recover\" or \"vim -r "));
+  msg_puts(_("    If this is the case, use \":recover\" or \"nvim -r "));
   msg_outtrans(buf->b_fname, 0);
   msg_puts(_("\"\n    to recover the changes (see \":help recovery\").\n"));
   msg_puts(_("    If you did this already, delete the swap file \""));

--- a/src/nvim/po/af.po
+++ b/src/nvim/po/af.po
@@ -3608,8 +3608,8 @@ msgstr ""
 #~ "\n"
 #~ "(2) 'n Bewerkingsessie van hierdie lêer het ineengestort.\n"
 
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Indien wel, gebruik \":recover\" of \"vim -r"
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Indien wel, gebruik \":recover\" of \"nvim -r"
 
 msgid ""
 "\"\n"

--- a/src/nvim/po/ca.po
+++ b/src/nvim/po/ca.po
@@ -4015,8 +4015,8 @@ msgstr ""
 "(2) El Vim s'ha estrellat mentre s'editava aquest fitxer.\n"
 
 #: ../memline.c:3247
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    En aquest cas, useu \":recover\" o bé \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    En aquest cas, useu \":recover\" o bé \"nvim -r "
 
 #: ../memline.c:3249
 msgid ""

--- a/src/nvim/po/cs.cp1250.po
+++ b/src/nvim/po/cs.cp1250.po
@@ -4077,8 +4077,8 @@ msgstr ""
 "(2) Editace tohoto souboru byla pøerušena neèekaným ukonèením programu.\n"
 
 #: ../memline.c:3247
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Je-li tomu tak, pak použijte \":recover\" èi \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Je-li tomu tak, pak použijte \":recover\" èi \"nvim -r "
 
 #: ../memline.c:3249
 msgid ""

--- a/src/nvim/po/cs.po
+++ b/src/nvim/po/cs.po
@@ -4077,8 +4077,8 @@ msgstr ""
 "(2) Editace tohoto souboru byla pøeru¹ena neèekaným ukonèením programu.\n"
 
 #: ../memline.c:3247
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Je-li tomu tak, pak pou¾ijte \":recover\" èi \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Je-li tomu tak, pak pou¾ijte \":recover\" èi \"nvim -r "
 
 #: ../memline.c:3249
 msgid ""

--- a/src/nvim/po/da.po
+++ b/src/nvim/po/da.po
@@ -3663,8 +3663,8 @@ msgstr ""
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) En redigeringssession for filen holdt op med at virke.\n"
 
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Hvis det er tilfældet, så brug \":recover\" eller \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Hvis det er tilfældet, så brug \":recover\" eller \"nvim -r "
 
 msgid ""
 "\"\n"

--- a/src/nvim/po/de.po
+++ b/src/nvim/po/de.po
@@ -3436,9 +3436,9 @@ msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Eine Sitzung für diese Datei ist abgestürzt.\n"
 
 #: ../memline.c:3204
-msgid "    If this is the case, use \":recover\" or \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
 msgstr ""
-"    Wenn dies der Fall ist, so verwenden Sie \":recover\" oder \"vim -r "
+"    Wenn dies der Fall ist, so verwenden Sie \":recover\" oder \"nvim -r "
 
 #: ../memline.c:3206
 msgid ""

--- a/src/nvim/po/en_GB.po
+++ b/src/nvim/po/en_GB.po
@@ -3847,7 +3847,7 @@ msgid "(2) An edit session for this file crashed.\n"
 msgstr ""
 
 #: ../memline.c:3247
-msgid "    If this is the case, use \":recover\" or \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
 msgstr ""
 
 #: ../memline.c:3249

--- a/src/nvim/po/eo.po
+++ b/src/nvim/po/eo.po
@@ -3531,8 +3531,8 @@ msgstr ""
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Redakta seanco de tiu dosiero kolapsis.\n"
 
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Se veras, uzu \":recover\" aŭ \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Se veras, uzu \":recover\" aŭ \"nvim -r "
 
 msgid ""
 "\"\n"

--- a/src/nvim/po/es.po
+++ b/src/nvim/po/es.po
@@ -4078,8 +4078,8 @@ msgstr ""
 "(2) Falló una sesión de edición de este archivo.\n"
 
 #: ../memline.c:3247
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Si es así, use \":recover\" o \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Si es así, use \":recover\" o \"nvim -r "
 
 #: ../memline.c:3249
 msgid ""

--- a/src/nvim/po/fi.po
+++ b/src/nvim/po/fi.po
@@ -3660,8 +3660,8 @@ msgstr ""
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Tiedostonmuokkausistunto on kaatunut.\n"
 
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Jos näin on, käytä komentoa :recover tai vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Jos näin on, käytä komentoa :recover tai nvim -r "
 
 msgid ""
 "\"\n"

--- a/src/nvim/po/fr.po
+++ b/src/nvim/po/fr.po
@@ -3241,8 +3241,8 @@ msgstr ""
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Une session d'édition de ce fichier a planté.\n"
 
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Si c'est le cas, utilisez \":recover\" ou \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Si c'est le cas, utilisez \":recover\" ou \"nvim -r "
 
 msgid ""
 "\"\n"

--- a/src/nvim/po/ga.po
+++ b/src/nvim/po/ga.po
@@ -3696,8 +3696,8 @@ msgstr ""
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Thuairteáil seisiún eagarthóireachta.\n"
 
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Más amhlaidh, bain úsáid as \":recover\" nó \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Más amhlaidh, bain úsáid as \":recover\" nó \"nvim -r "
 
 msgid ""
 "\"\n"

--- a/src/nvim/po/it.po
+++ b/src/nvim/po/it.po
@@ -4037,8 +4037,8 @@ msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Una sessione di edit per questo file è finita male.\n"
 
 #: ../memline.c:3247
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Se è così, usa \":recover\" oppure \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Se è così, usa \":recover\" oppure \"nvim -r "
 
 #: ../memline.c:3249
 msgid ""

--- a/src/nvim/po/ja.euc-jp.po
+++ b/src/nvim/po/ja.euc-jp.po
@@ -3466,8 +3466,8 @@ msgstr ""
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) このファイルの編集セッションがクラッシュした.\n"
 
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    この場合には \":recover\" か \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    この場合には \":recover\" か \"nvim -r "
 
 msgid ""
 "\"\n"

--- a/src/nvim/po/ja.po
+++ b/src/nvim/po/ja.po
@@ -5092,8 +5092,8 @@ msgstr ""
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) このファイルの編集セッションがクラッシュした.\n"
 
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    この場合には \":recover\" か \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    この場合には \":recover\" か \"nvim -r "
 
 msgid ""
 "\"\n"

--- a/src/nvim/po/ko.UTF-8.po
+++ b/src/nvim/po/ko.UTF-8.po
@@ -3957,8 +3957,8 @@ msgstr ""
 "(2) 파일을 고치다가 죽었었습니다.\n"
 
 #: ../memline.c:3247
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    만약 그렇다면 \":recover\" 혹은 \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    만약 그렇다면 \":recover\" 혹은 \"nvim -r "
 
 #: ../memline.c:3249
 msgid ""

--- a/src/nvim/po/nb.po
+++ b/src/nvim/po/nb.po
@@ -3978,8 +3978,8 @@ msgstr ""
 "(2) En økt for denne filen kræsjet.\n"
 
 #: ../memline.c:3247
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Hvis det er tilfelle, bruk \":recover\" eller \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Hvis det er tilfelle, bruk \":recover\" eller \"nvim -r "
 
 #: ../memline.c:3249
 msgid ""

--- a/src/nvim/po/nl.po
+++ b/src/nvim/po/nl.po
@@ -3984,8 +3984,8 @@ msgstr ""
 "(2) Een sessie waarin dit bestand werd bewerkt is onverhoeds gestopt.\n"
 
 #: ../memline.c:3247
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Als dit het geval is, gebruikt dan \":recover\" of \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Als dit het geval is, gebruikt dan \":recover\" of \"nvim -r "
 
 #: ../memline.c:3249
 msgid ""

--- a/src/nvim/po/no.po
+++ b/src/nvim/po/no.po
@@ -3978,8 +3978,8 @@ msgstr ""
 "(2) En økt for denne filen kræsjet.\n"
 
 #: ../memline.c:3247
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Hvis det er tilfelle, bruk \":recover\" eller \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Hvis det er tilfelle, bruk \":recover\" eller \"nvim -r "
 
 #: ../memline.c:3249
 msgid ""

--- a/src/nvim/po/pl.UTF-8.po
+++ b/src/nvim/po/pl.UTF-8.po
@@ -3946,8 +3946,8 @@ msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Sesja edycji dla pliku załamała się.\n"
 
 #: ../memline.c:3247
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Jeśli tak, to użyj \":recover\" lub \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Jeśli tak, to użyj \":recover\" lub \"nvim -r "
 
 #: ../memline.c:3249
 msgid ""

--- a/src/nvim/po/pt_BR.po
+++ b/src/nvim/po/pt_BR.po
@@ -625,8 +625,8 @@ msgstr ""
 "(2) Ocorreu um travamento numa sessão de edição desse arquivo.\n"
 
 #: ../memline.c:3206
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Se esse for o caso, use \":recover\" ou \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Se esse for o caso, use \":recover\" ou \"nvim -r "
 
 #: ../memline.c:3208
 msgid ""

--- a/src/nvim/po/ru.po
+++ b/src/nvim/po/ru.po
@@ -3985,8 +3985,8 @@ msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Сеанс редактирования этого файла завершён аварийно.\n"
 
 #: ../memline.c:3247
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    В этом случае, используйте команду \":recover\" или \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    В этом случае, используйте команду \":recover\" или \"nvim -r "
 
 #: ../memline.c:3249
 msgid ""

--- a/src/nvim/po/sk.cp1250.po
+++ b/src/nvim/po/sk.cp1250.po
@@ -3975,8 +3975,8 @@ msgstr ""
 "(2) Úprava tohoto súboru bola prerušená neoèakávaným ukonèením programu.\n"
 
 #: ../memline.c:3247
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Ak je tomu tak, potom použite \":recover\" alebo \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Ak je tomu tak, potom použite \":recover\" alebo \"nvim -r "
 
 #: ../memline.c:3249
 msgid ""

--- a/src/nvim/po/sk.po
+++ b/src/nvim/po/sk.po
@@ -3975,8 +3975,8 @@ msgstr ""
 "(2) Úprava tohoto súboru bola preru¹ená neoèakávaným ukonèením programu.\n"
 
 #: ../memline.c:3247
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Ak je tomu tak, potom pou¾ite \":recover\" alebo \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Ak je tomu tak, potom pou¾ite \":recover\" alebo \"nvim -r "
 
 #: ../memline.c:3249
 msgid ""

--- a/src/nvim/po/sr.po
+++ b/src/nvim/po/sr.po
@@ -4048,8 +4048,8 @@ msgstr ""
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Сесија уређивања ове датотеке се срушила.\n"
 
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Ако је ово случај, користите \":recover\" или \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Ако је ово случај, користите \":recover\" или \"nvim -r "
 
 msgid ""
 "\"\n"

--- a/src/nvim/po/sv.po
+++ b/src/nvim/po/sv.po
@@ -6171,8 +6171,8 @@ msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) En redigeringssession för den här filen kraschade.\n"
 
 #: ../memline.c:3200
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Om så är fallet, använd \":recover\" eller \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Om så är fallet, använd \":recover\" eller \"nvim -r "
 
 #: ../memline.c:3202
 msgid ""

--- a/src/nvim/po/tr.po
+++ b/src/nvim/po/tr.po
@@ -3947,8 +3947,8 @@ msgstr ""
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Bu dosya düzenleme oturumu çöktü.\n"
 
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Durum buysa \":recover\" veya \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Durum buysa \":recover\" veya \"nvim -r "
 
 msgid ""
 "\"\n"

--- a/src/nvim/po/uk.po
+++ b/src/nvim/po/uk.po
@@ -5108,8 +5108,8 @@ msgstr ""
 msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) Сеанс редагування цього файлу зазнав краху.\n"
 
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    Якщо це справді трапилося, спробуйте «:recover» або «vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    Якщо це справді трапилося, спробуйте «:recover» або «nvim -r "
 
 msgid ""
 "\"\n"

--- a/src/nvim/po/vi.po
+++ b/src/nvim/po/vi.po
@@ -4009,9 +4009,9 @@ msgstr ""
 "(2) Lần soạn thảo trước của tập tin này gặp sự cố.\n"
 
 #: ../memline.c:3247
-msgid "    If this is the case, use \":recover\" or \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
 msgstr ""
-"    Trong trường hợp này, hãy sử dụng câu lệnh \":recover\" hoặc \"vim -r "
+"    Trong trường hợp này, hãy sử dụng câu lệnh \":recover\" hoặc \"nvim -r "
 
 #: ../memline.c:3249
 msgid ""

--- a/src/nvim/po/zh_CN.UTF-8.po
+++ b/src/nvim/po/zh_CN.UTF-8.po
@@ -4780,8 +4780,8 @@ msgid "(2) An edit session for this file crashed.\n"
 msgstr "(2) 上次编辑此文件时崩溃。\n"
 
 #: ../memline.c:3099
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    如果是这样，请用 \":recover\" 或 \"vim -r "
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    如果是这样，请用 \":recover\" 或 \"nvim -r "
 
 #: ../memline.c:3101
 msgid ""

--- a/src/nvim/po/zh_TW.UTF-8.po
+++ b/src/nvim/po/zh_TW.UTF-8.po
@@ -4017,8 +4017,8 @@ msgstr ""
 "(2) 前次編輯此檔時當機\n"
 
 #: ../memline.c:3247
-msgid "    If this is the case, use \":recover\" or \"vim -r "
-msgstr "    如果是這樣, 請用 \":recover\" 或 \"vim -r"
+msgid "    If this is the case, use \":recover\" or \"nvim -r "
+msgstr "    如果是這樣, 請用 \":recover\" 或 \"nvim -r"
 
 #: ../memline.c:3249
 msgid ""


### PR DESCRIPTION
Problem:
The message E325 displays “vim -r” to recover the file.

Solution:
Change the message to display “nvim -r” instead of “vim -r”.