### PR TITLE
fix(runtime): add remaining missing commentstrings

### DIFF
--- a/runtime/ftplugin/dot.lua
+++ b/runtime/ftplugin/dot.lua
@@ -1,0 +1,3 @@
+vim.bo.commentstring = '// %s'
+
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring<'

--- a/runtime/ftplugin/faust.lua
+++ b/runtime/ftplugin/faust.lua
@@ -1,0 +1,3 @@
+vim.bo.commentstring = '// %s'
+
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring<'

--- a/runtime/ftplugin/stata.lua
+++ b/runtime/ftplugin/stata.lua
@@ -1,0 +1,3 @@
+vim.bo.commentstring = '// %s'
+
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring<'

--- a/runtime/ftplugin/supercollider.lua
+++ b/runtime/ftplugin/supercollider.lua
@@ -1,0 +1,3 @@
+vim.bo.commentstring = '// %s'
+
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring<'

--- a/runtime/ftplugin/swift.lua
+++ b/runtime/ftplugin/swift.lua
@@ -1,0 +1,3 @@
+vim.bo.commentstring = '// %s'
+
+vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | setl commentstring<'


### PR DESCRIPTION
See https://github.com/neovim/neovim/pull/23039#issuecomment-1505645253, adds all the remaining commentstrings that have been missing since removing the default C-style value. Found #29259 after running into this issue while writing swift, but since it seems to be dead I've decided to just pick it up myself.

**filetypes added in this PR:** `swift`, `dot`, `faust`, `stata`, `supercollider`

----

`autohotkey`, `cpp`, `dart`, `kotlin`, `nix`, `solidity`, `sql` and `terraform` are set in their respective vimscript ftplugins

`cuda` inherits from `cpp`, no need to update
`typescriptreact` and `javascriptreact` inherit from `typescript` and `javascript`, no need to update

`arduino`, `cs` and `glsl` already got a new lua ftplugin since that comment was written