### PR TITLE
vim-patch:9.1.0713: Newline causes E749 in Ex mode

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2499,6 +2499,17 @@ int parse_command_modifiers(exarg_T *eap, const char **errormsg, cmdmod_T *cmod,
 
     // ignore comment and empty lines
     if (*eap->cmd == '"') {
+      // a comment ends at a NL
+      if (eap->nextcmd == NULL) {
+        eap->nextcmd = vim_strchr(eap->cmd, '\n');
+        if (eap->nextcmd != NULL) {
+          eap->nextcmd++;
+        }
+      }
+      return FAIL;
+    }
+    if (eap->nextcmd == NULL && *eap->cmd == '\n') {
+      eap->nextcmd = eap->cmd + 1;
       return FAIL;
     }
     if (*eap->cmd == NUL) {

--- a/test/old/testdir/test_ex_mode.vim
+++ b/test/old/testdir/test_ex_mode.vim
@@ -316,4 +316,20 @@ func Test_global_insert_newline()
   bwipe!
 endfunc
 
+" An empty command followed by a newline shouldn't cause E749 in Ex mode.
+func Test_ex_empty_command_newline()
+  let g:var = 0
+  call feedkeys("gQexecute \"\\nlet g:var = 1\"\r", 'xt')
+  call assert_equal(1, g:var)
+  call feedkeys("gQexecute \"  \\nlet g:var = 2\"\r", 'xt')
+  call assert_equal(2, g:var)
+  call feedkeys("gQexecute \"\\t \\nlet g:var = 3\"\r", 'xt')
+  call assert_equal(3, g:var)
+  call feedkeys("gQexecute \"\\\"?!\\nlet g:var = 4\"\r", 'xt')
+  call assert_equal(4, g:var)
+  call feedkeys("gQexecute \"  \\\"?!\\nlet g:var = 5\"\r", 'xt')
+  call assert_equal(5, g:var)
+  unlet g:var
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0713: Newline causes E749 in Ex mode

Problem:  Newline causes E749 in Ex mode (after 9.1.0573).
Solution: Don't execute empty command followed by a newline.

closes: vim/vim#15614

https://github.com/vim/vim/commit/2432b4a75321a1a9ac0f9b326c7e46d38bdb71bb

Cherry-pick code change from patch 8.2.3405.