### PR TITLE
feat(defaults): popupmenu "Open in browser", "Go to definition"

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -444,6 +444,10 @@ when the right mouse button is pressed, if 'mousemodel' is set to popup or
 popup_setpos.
 
 The default "PopUp" menu is: >vim
+    anoremenu PopUp.Go\ to\ definition      <Cmd>lua vim.lsp.buf.definition()<CR>
+    amenu     PopUp.Open\ in\ web\ browser  gx
+    anoremenu PopUp.Inspect                 <Cmd>Inspect<CR>
+    anoremenu PopUp.-1-                     <Nop>
     vnoremenu PopUp.Cut                     "+x
     vnoremenu PopUp.Copy                    "+y
     anoremenu PopUp.Paste                   "+gP
@@ -452,8 +456,7 @@ The default "PopUp" menu is: >vim
     nnoremenu PopUp.Select\ All             ggVG
     vnoremenu PopUp.Select\ All             gg0oG$
     inoremenu PopUp.Select\ All             <C-Home><C-O>VG
-    anoremenu PopUp.Inspect                 <Cmd>Inspect<CR>
-    anoremenu PopUp.-1-                     <Nop>
+    anoremenu PopUp.-2-                     <Nop>
     anoremenu PopUp.How-to\ disable\ mouse  <Cmd>help disable-mouse<CR>
 <
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -114,6 +114,10 @@ DEFAULTS
   • |grr| in Normal mode maps to |vim.lsp.buf.references()|
   • |gra| in Normal and Visual mode maps to |vim.lsp.buf.code_action()|
   • CTRL-S in Insert mode maps to |vim.lsp.buf.signature_help()|
+  • Mouse |popup-menu| includes an "Open in web browser" item when you right-click
+    on a URL.
+  • Mouse |popup-menu| includes a "Go to definition" item when LSP is active
+    in the buffer.
 
 • Snippet:
   • `<Tab>` in Insert and Select mode maps to `vim.snippet.jump({ direction = 1 })`

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -106,23 +106,28 @@ standard actions ("Cut", "Copy", "Paste", …). Mouse is NOT enabled in
 |command-mode| or the |more-prompt|, so you can temporarily disable it just by
 typing ":".
 
-If you don't like this you can disable the mouse in your |config| using any of
-the following:
+Or you can disable the popup-menu using any of the following:
 - Disable mouse completely by unsetting the 'mouse' option: >vim
   set mouse=
-- Pressing <RightMouse> extends selection instead of showing popup-menu: >vim
+- Change the 'mousemodel', so <RightMouse> extends selection instead of
+  showing the popup-menu: >vim
   set mousemodel=extend
-- Pressing <A-LeftMouse> releases mouse until the cursor moves:  >vim
+- Map <A-LeftMouse> so that it temporarily disables mouse until the cursor
+  moves:  >vim
   nnoremap <A-LeftMouse> <Cmd>
     \ set mouse=<Bar>
     \ echo 'mouse OFF until next cursor-move'<Bar>
     \ autocmd CursorMoved * ++once set mouse&<Bar>
     \ echo 'mouse ON'<CR>
 <
-To remove the "How-to disable mouse" menu item and the separator above it: >vim
+To remove the default popup-menu without disabling mouse: >vim
+  aunmenu PopUp
+  autocmd! nvim_popupmenu
+
+To remove only the "How-to disable mouse" menu item (and its separator): >vim
   aunmenu PopUp.How-to\ disable\ mouse
-  aunmenu PopUp.-1-
-<
+  aunmenu PopUp.-2-
+
 DEFAULT MAPPINGS
                                                         *default-mappings*
 Nvim creates the following default mappings at |startup|. You can disable any

--- a/test/functional/editor/defaults_spec.lua
+++ b/test/functional/editor/defaults_spec.lua
@@ -1,0 +1,100 @@
+--
+-- Tests for default autocmds, mappings, commands, and menus.
+--
+-- See options/defaults_spec.lua for default options and environment decisions.
+--
+
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
+
+describe('default', function()
+  describe('autocommands', function()
+    it('nvim_terminal.TermClose closes terminal with default shell on success', function()
+      n.clear()
+      n.api.nvim_set_option_value('shell', n.testprg('shell-test'), {})
+      n.command('set shellcmdflag=EXIT shellredir= shellpipe= shellquote= shellxquote=')
+
+      -- Should not block other events
+      n.command('let g:n=0')
+      n.command('au BufEnter * let g:n = g:n + 1')
+
+      n.command('terminal')
+      t.eq(1, n.eval('get(g:, "n", 0)'))
+
+      t.retry(nil, 1000, function()
+        t.neq('terminal', n.api.nvim_get_option_value('buftype', { buf = 0 }))
+        t.eq(2, n.eval('get(g:, "n", 0)'))
+      end)
+    end)
+  end)
+
+  describe('popupmenu', function()
+    it('can be disabled by user', function()
+      n.clear {
+        args = { '+autocmd! nvim_popupmenu', '+aunmenu PopUp' },
+      }
+      local screen = Screen.new(40, 8)
+      screen:attach()
+      n.insert([[
+        1 line 1
+        2 https://example.com
+        3 line 3
+        4 line 4]])
+
+      n.api.nvim_input_mouse('right', 'press', '', 0, 1, 4)
+      screen:expect({
+        grid = [[
+          1 line 1                                |
+          2 ht^tps://example.com                   |
+          3 line 3                                |
+          4 line 4                                |
+          {1:~                                       }|*3
+                                                  |
+        ]],
+      })
+    end)
+
+    it('right-click on URL shows "Open in web browser"', function()
+      n.clear()
+      local screen = Screen.new(40, 8)
+      screen:attach()
+      n.insert([[
+        1 line 1
+        2 https://example.com
+        3 line 3
+        4 line 4]])
+
+      n.api.nvim_input_mouse('right', 'press', '', 0, 3, 4)
+      screen:expect({
+        grid = [[
+          1 line 1                                |
+          2 https://example.com                   |
+          3 line 3                                |
+          4 li^ne 4                                |
+          {1:~  }{4: Inspect              }{1:               }|
+          {1:~  }{4:                      }{1:               }|
+          {1:~  }{4: Paste                }{1:               }|
+             {4: Select All           }               |
+        ]],
+      })
+
+      n.api.nvim_input_mouse('right', 'press', '', 0, 1, 4)
+      screen:expect({
+        grid = [[
+          1 line 1                                |
+          2 ht^tps://example.com                   |
+          3 l{4: Open in web browser  }               |
+          4 l{4: Inspect              }               |
+          {1:~  }{4:                      }{1:               }|
+          {1:~  }{4: Paste                }{1:               }|
+          {1:~  }{4: Select All           }{1:               }|
+             {4:                      }               |
+        ]],
+      })
+    end)
+  end)
+
+  -- describe('key mappings', function()
+  -- end)
+end)

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -1,3 +1,9 @@
+--
+-- Tests for default options and environment decisions.
+--
+-- See editor/defaults_spec.lua for default autocmds, mappings, commands, and menus.
+--
+
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
@@ -1252,26 +1258,6 @@ describe('stdpath()', function()
     it('on non-strings', function()
       eq('Vim(call):E731: Using a Dictionary as a String', exc_exec('call stdpath({"eris": 23})'))
       eq('Vim(call):E730: Using a List as a String', exc_exec('call stdpath([23])'))
-    end)
-  end)
-end)
-
-describe('autocommands', function()
-  it('closes terminal with default shell on success', function()
-    clear()
-    api.nvim_set_option_value('shell', n.testprg('shell-test'), {})
-    command('set shellcmdflag=EXIT shellredir= shellpipe= shellquote= shellxquote=')
-
-    -- Should not block other events
-    command('let g:n=0')
-    command('au BufEnter * let g:n = g:n + 1')
-
-    command('terminal')
-    eq(1, eval('get(g:, "n", 0)'))
-
-    t.retry(nil, 1000, function()
-      neq('terminal', api.nvim_get_option_value('buftype', { buf = 0 }))
-      eq(2, eval('get(g:, "n", 0)'))
     end)
   end)
 end)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -630,6 +630,8 @@ describe('TUI', function()
       set mouse=a mousemodel=popup
 
       aunmenu PopUp
+      " Delete the default MenuPopup event handler.
+      autocmd! nvim_popupmenu
       menu PopUp.foo :let g:menustr = 'foo'<CR>
       menu PopUp.bar :let g:menustr = 'bar'<CR>
       menu PopUp.baz :let g:menustr = 'baz'<CR>

--- a/test/functional/ui/multigrid_spec.lua
+++ b/test/functional/ui/multigrid_spec.lua
@@ -1095,6 +1095,7 @@ describe('ext_multigrid', function()
   end)
 
   it('supports mouse', function()
+    command('autocmd! nvim_popupmenu') -- Delete the default MenuPopup event handler.
     insert('some text\nto be clicked')
     screen:expect{grid=[[
     ## grid 1

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -851,6 +851,8 @@ describe('ui/ext_popupmenu', function()
       set mouse=a mousemodel=popup
 
       aunmenu PopUp
+      " Delete the default MenuPopup event handler.
+      autocmd! nvim_popupmenu
       menu PopUp.foo :let g:menustr = 'foo'<CR>
       menu PopUp.bar :let g:menustr = 'bar'<CR>
       menu PopUp.baz :let g:menustr = 'baz'<CR>
@@ -3805,6 +3807,8 @@ describe('builtin popupmenu', function()
         call setline(1, 'popup menu test')
         set mouse=a mousemodel=popup
 
+        " Delete the default MenuPopup event handler.
+        autocmd! nvim_popupmenu
         aunmenu PopUp
         menu PopUp.foo :let g:menustr = 'foo'<CR>
         menu PopUp.bar :let g:menustr = 'bar'<CR>
@@ -4489,6 +4493,9 @@ describe('builtin popupmenu', function()
       -- oldtest: Test_popup_command_dump()
       it(':popup command', function()
         exec([[
+          " Delete the default MenuPopup event handler.
+          autocmd! nvim_popupmenu
+
           func ChangeMenu()
             aunmenu PopUp.&Paste
             nnoremenu 1.40 PopUp.&Paste :echomsg "pasted"<CR>
@@ -4646,6 +4653,8 @@ describe('builtin popupmenu', function()
         screen:try_resize(50, 20)
         exec([[
           set mousemodel=popup_setpos
+          " Delete the default MenuPopup event handler.
+          autocmd! nvim_popupmenu
           aunmenu *
           source $VIMRUNTIME/menu.vim
           call setline(1, join(range(20)))

--- a/test/functional/vimscript/server_spec.lua
+++ b/test/functional/vimscript/server_spec.lua
@@ -18,12 +18,16 @@ local function clear_serverlist()
   end
 end
 
-describe('server', function()
-  after_each(function()
-    check_close()
-    os.remove(testlog)
-  end)
+after_each(function()
+  check_close()
+  os.remove(testlog)
+end)
 
+before_each(function()
+  os.remove(testlog)
+end)
+
+describe('server', function()
   it('serverstart() stores sockets in $XDG_RUNTIME_DIR', function()
     local dir = 'Xtest_xdg_run'
     mkdir(dir)
@@ -172,7 +176,6 @@ end)
 
 describe('startup --listen', function()
   it('validates', function()
-    os.remove(testlog)
     clear { env = { NVIM_LOG_FILE = testlog } }
 
     -- Tests args with and without "--headless".

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -66,6 +66,7 @@ mapclear
 mapclear!
 aunmenu *
 tlunmenu *
+autocmd! nvim_popupmenu
 
 " Undo the 'grepprg' and 'grepformat' setting in _defaults.lua.
 set grepprg& grepformat&


### PR DESCRIPTION
- Use the popup to expose more features such as LSP and gx.
- Move the copy/paste items lower in the menu, they are lower priority.



Todo:

- [x] fix existing tests
- [x] add tests?
- [x] document `nvim_menupopup` ?

![image](https://github.com/user-attachments/assets/ec488473-3d38-454f-9a05-8c00b2cd2312)

