### PR TITLE
test: avoid noise in CI logs

### DIFF
--- a/test/testutil.lua
+++ b/test/testutil.lua
@@ -143,7 +143,7 @@ end
 ---
 ---@param pat (string) Lua pattern to match lines in the log file
 ---@param logfile? (string) Full path to log file (default=$NVIM_LOG_FILE)
----@param nrlines? (number) Search up to this many log lines
+---@param nrlines? (number) Search up to this many log lines (default 10)
 ---@param inverse? (boolean) Assert that the pattern does NOT match.
 function M.assert_log(pat, logfile, nrlines, inverse)
   logfile = logfile or os.getenv('NVIM_LOG_FILE') or '.nvimlog'


### PR DESCRIPTION
Problem:
Since 96128a5076b7 the test logs have noise from tests that *expect* failures:

    $NVIM_LOG_FILE: /tmp/cirrus-ci-build/build/.nvimlog
    (last 100 lines)
    ERR 2024-09-04T13:38:45.181 T949.28335.0/c terminfo_start:486: uv_pipe_open failed: no such device or address
    ERR 2024-09-04T13:38:45.181 T949.28335.0/c flush_buf:2527: uv_write failed: bad file descriptor
    ERR 2024-09-04T13:38:45.181 T949.28335.0/c flush_buf:2527: uv_write failed: bad file descriptor
    WRN 2024-09-04T13:43:43.294 ?.35904    server_start:173: Failed to start server: address already in use: /…/Xtest_tmpdir/…/T7159.35895.0
    WRN 2024-09-04T13:43:43.314 ?.35907    server_start:173: Failed to start server: illegal operation on a directory: /
    ERR 2024-09-04T13:43:43.332 ?.35909    socket_watcher_init:60: Host lookup failed: https://example.com

Solution:
Rewrite the test to use `vim.system()`. Set NVIM_LOG_FILE in the child process to a "throwaway" logfile.