### PR TITLE
vim-patch:9.1.0716: resetting setcellwidth() doesn't update the screen

### DIFF
--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -2926,7 +2926,7 @@ void f_setcellwidths(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     xfree(cw_table);
     cw_table = NULL;
     cw_table_size = 0;
-    return;
+    goto done;
   }
 
   // Note: use list_T instead of listitem_T so that TV_LIST_ITEM_NEXT can be used properly below.
@@ -3023,6 +3023,7 @@ void f_setcellwidths(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
 
   xfree(cw_table_save);
+done:
   changed_window_setting_all();
   redraw_all_later(UPD_NOT_VALID);
 }

--- a/test/old/testdir/test_utf8.vim
+++ b/test/old/testdir/test_utf8.vim
@@ -228,6 +228,9 @@ func Test_setcellwidths()
     call setcellwidths([[0x2103, 0x2103, 2]])
     redraw
     call assert_equal(19, wincol())
+    call setcellwidths([])
+    redraw
+    call assert_equal((aw == 'single') ? 10 : 19, wincol())
   endfor
   set ambiwidth& isprint&
 


### PR DESCRIPTION
#### vim-patch:9.1.0716: resetting setcellwidth() doesn't update the screen

Problem:  resetting setcellwidth() doesn't update the screen
Solution: Redraw after clearing the cellwidth table (Ken Takata)

closes: vim/vim#15628

https://github.com/vim/vim/commit/539e9b571ae2a80dfa8a42eb132ad9f65f0bbcbc

Co-authored-by: Ken Takata <kentkt@csc.jp>