### PR TITLE
vim-patch:9.1.0717: Unnecessary nextcmd NULL checks in parse_command_modifiers()

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2500,15 +2500,13 @@ int parse_command_modifiers(exarg_T *eap, const char **errormsg, cmdmod_T *cmod,
     // ignore comment and empty lines
     if (*eap->cmd == '"') {
       // a comment ends at a NL
-      if (eap->nextcmd == NULL) {
-        eap->nextcmd = vim_strchr(eap->cmd, '\n');
-        if (eap->nextcmd != NULL) {
-          eap->nextcmd++;
-        }
+      eap->nextcmd = vim_strchr(eap->cmd, '\n');
+      if (eap->nextcmd != NULL) {
+        eap->nextcmd++;
       }
       return FAIL;
     }
-    if (eap->nextcmd == NULL && *eap->cmd == '\n') {
+    if (*eap->cmd == '\n') {
       eap->nextcmd = eap->cmd + 1;
       return FAIL;
     }


### PR DESCRIPTION
#### vim-patch:9.1.0717: Unnecessary nextcmd NULL checks in parse_command_modifiers()

Problem:  Unnecessary nextcmd NULL checks in parse_command_modifiers().
Solution: Remove them (zeertzjq)

Every place parse_command_modifiers() is called, nextcmd is NULL, and
after it's set to non-NULL the function returns very soon.
Even if one day nextcmd may be non-NULL, the NULL checks may still be
wrong as the correct behavior may be overriding nextcmd.

closes: vim/vim#15620

https://github.com/vim/vim/commit/f7b8609446f171a6a287f61564e39a8dac5ff47d