### PR TITLE
refactor(textformat): remove replace_offset which is not needed?

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2801,28 +2801,11 @@ static bool echeck_abbr(int c)
 
 /// Push character that is replaced onto the replace stack.
 ///
-/// replace_offset is normally 0, in which case replace_push will add a new
-/// character at the end of the stack.  If replace_offset is not 0, that many
-/// characters will be left on the stack above the newly inserted character.
-///
 /// @param str character that is replaced (NUL is none)
 /// @param len length of character in bytes
 void replace_push(char *str, size_t len)
 {
-  // TODO(bfredl): replace_offset is suss af, if we don't need it, this
-  // function is just kv_concat() :p
-  if (kv_size(replace_stack) < (size_t)replace_offset) {  // nothing to do
-    return;
-  }
-
-  kv_ensure_space(replace_stack, len);
-
-  char *p = replace_stack.items + kv_size(replace_stack) - replace_offset;
-  if (replace_offset) {
-    memmove(p + len, p, (size_t)replace_offset);
-  }
-  memcpy(p, str, len);
-  kv_size(replace_stack) += len;
+  kv_concat_len(replace_stack, str, len);
 }
 
 /// push NUL as separator between entries in the stack

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -707,8 +707,6 @@ EXTERN bool g_tag_at_cursor INIT( = false);  // whether the tag command comes
                                              // from the command line (0) or was
                                              // invoked as a normal command (1)
 
-EXTERN int replace_offset INIT( = 0);        // offset for replace_push()
-
 EXTERN char *escape_chars INIT( = " \t\\\"|");  // need backslash in cmd line
 
 EXTERN bool keep_help_flag INIT( = false);  // doing :ta from help file

--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -99,7 +99,6 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
     int startcol;                       // Cursor column at entry
     int wantcol;                        // column at textwidth border
     int foundcol;                       // column for start of spaces
-    int end_foundcol = 0;               // column for start of word
     int orig_col = 0;
     char *saved_text = NULL;
     colnr_T col;
@@ -171,9 +170,6 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
         cc = gchar_cursor();
       }
       if (WHITECHAR(cc)) {
-        // remember position of blank just before text
-        colnr_T end_col = curwin->w_cursor.col;
-
         // find start of sequence of blanks
         int wcc = 0;  // counter for whitespace chars
         while (curwin->w_cursor.col > 0 && WHITECHAR(cc)) {
@@ -222,7 +218,6 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
 
         inc_cursor();
 
-        end_foundcol = end_col + 1;
         foundcol = curwin->w_cursor.col;
         if (curwin->w_cursor.col <= (colnr_T)wantcol) {
           break;
@@ -245,7 +240,6 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
           // If we have already checked this position, skip!
           if (curwin->w_cursor.col != skip_pos && allow_break) {
             foundcol = curwin->w_cursor.col;
-            end_foundcol = foundcol;
             if (curwin->w_cursor.col <= (colnr_T)wantcol) {
               break;
             }
@@ -279,7 +273,6 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
         // Must handle this to respect line break prohibition.
         if (allow_break) {
           foundcol = curwin->w_cursor.col;
-          end_foundcol = foundcol;
         }
         if (curwin->w_cursor.col <= (colnr_T)wantcol) {
           const bool ncc_allow_break = utf_allow_break_before(ncc);
@@ -292,7 +285,7 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
             if (curwin->w_cursor.col == startcol) {
               // We are inserting a non-breakable char, postpone
               // line break check to next insert.
-              end_foundcol = foundcol = 0;
+              foundcol = 0;
               break;
             }
 
@@ -310,7 +303,7 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
 
             if (allow_break) {
               // Break only when we are not at end of line.
-              end_foundcol = foundcol = ncc == NUL ? 0 : curwin->w_cursor.col;
+              foundcol = ncc == NUL ? 0 : curwin->w_cursor.col;
               break;
             }
             curwin->w_cursor.col = col;
@@ -336,8 +329,6 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
     // over the text instead.
     if (State & VREPLACE_FLAG) {
       orig_col = startcol;              // Will start backspacing from here
-    } else {
-      replace_offset = startcol - end_foundcol;
     }
 
     // adjust startcol for spaces that will be deleted and
@@ -387,7 +378,6 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
       no_leader = false;
     }
 
-    replace_offset = 0;
     if (first_line) {
       if (!(flags & INSCHAR_COM_LIST)) {
         // This section is for auto-wrap of numeric lists.  When not


### PR DESCRIPTION
This kind of calculation looks suspicious as incidies in `replace_stack` do not directly correspond to bytes anymore, as extra NUL chars are inserted between each separate replace action (typically a single user-editable char).

Likely this was logic that was needed _before_ `replace_stack` was made more robust with action separators.