### PR TITLE
vim-patch:9.1.0720: Wrong breakindentopt=list:-1 with multibyte or TABs

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1129,9 +1129,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 		list:{n}    Adds an additional indent for lines that match a
 			    numbered or bulleted list (using the
 			    'formatlistpat' setting).
-		list:-1	    Uses the length of a match with 'formatlistpat'
-			    for indentation.
 			    (default: 0)
+		list:-1	    Uses the width of a match with 'formatlistpat' for
+			    indentation.
 		column:{n}  Indent at column {n}. Will overrule the other
 			    sub-options. Note: an additional indent may be
 			    added for the 'showbreak' setting.

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -558,9 +558,9 @@ vim.wo.bri = vim.wo.breakindent
 --- 	list:{n}    Adds an additional indent for lines that match a
 --- 		    numbered or bulleted list (using the
 --- 		    'formatlistpat' setting).
---- 	list:-1	    Uses the length of a match with 'formatlistpat'
---- 		    for indentation.
 --- 		    (default: 0)
+--- 	list:-1	    Uses the width of a match with 'formatlistpat' for
+--- 		    indentation.
 --- 	column:{n}  Indent at column {n}. Will overrule the other
 --- 		    sub-options. Note: an additional indent may be
 --- 		    added for the 'showbreak' setting.

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -891,7 +891,17 @@ int get_breakindent_win(win_T *wp, char *line)
           if (wp->w_briopt_list > 0) {
             prev_list += wp->w_briopt_list;
           } else {
-            prev_indent = (int)(*regmatch.endp - *regmatch.startp);
+            char *ptr = *regmatch.startp;
+            char *end_ptr = *regmatch.endp;
+            int indent = 0;
+            // Compute the width of the matched text.
+            // Use win_chartabsize() so that TAB size is correct,
+            // while wrapping is ignored.
+            while (ptr < end_ptr) {
+              indent += win_chartabsize(wp, ptr, indent);
+              MB_PTR_ADV(ptr);
+            }
+            prev_indent = indent;
           }
         }
         vim_regfree(regmatch.regprog);

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -761,9 +761,9 @@ return {
         	list:{n}    Adds an additional indent for lines that match a
         		    numbered or bulleted list (using the
         		    'formatlistpat' setting).
-        	list:-1	    Uses the length of a match with 'formatlistpat'
-        		    for indentation.
         		    (default: 0)
+        	list:-1	    Uses the width of a match with 'formatlistpat' for
+        		    indentation.
         	column:{n}  Indent at column {n}. Will overrule the other
         		    sub-options. Note: an additional indent may be
         		    added for the 'showbreak' setting.

--- a/test/old/testdir/test_breakindent.vim
+++ b/test/old/testdir/test_breakindent.vim
@@ -837,18 +837,73 @@ func Test_breakindent20_list()
 	\ ]
   let lines = s:screen_lines2(1, 9, 20)
   call s:compare_lines(expect, lines)
+
+  " check with TABs
+  call setline(1, ["\t1.\tCongress shall make no law",
+        \ "\t2.) Congress shall make no law",
+        \ "\t3.] Congress shall make no law"])
+  setl tabstop=4 list listchars=tab:<->
+  norm! 1gg
+  redraw!
+  let expect = [
+	\ "<-->1.<>Congress    ",
+	\ "        shall make  ",
+	\ "        no law      ",
+	\ "<-->2.) Congress    ",
+	\ "        shall make  ",
+	\ "        no law      ",
+	\ "<-->3.] Congress    ",
+	\ "        shall make  ",
+	\ "        no law      ",
+	\ ]
+  let lines = s:screen_lines2(1, 9, 20)
+  call s:compare_lines(expect, lines)
+
+  setl tabstop=2 nolist
+  redraw!
+  let expect = [
+	\ "  1.  Congress      ",
+	\ "      shall make no ",
+	\ "      law           ",
+	\ "  2.) Congress      ",
+	\ "      shall make no ",
+	\ "      law           ",
+	\ "  3.] Congress      ",
+	\ "      shall make no ",
+	\ "      law           ",
+	\ ]
+  let lines = s:screen_lines2(1, 9, 20)
+  call s:compare_lines(expect, lines)
+
+  setl tabstop& list listchars=space:_
+  redraw!
+  let expect = [
+	\ "^I1.^ICongress_     ",
+	\ "      shall_make_no_",
+	\ "      law           ",
+	\ "^I2.)_Congress_     ",
+	\ "      shall_make_no_",
+	\ "      law           ",
+	\ "^I3.]_Congress_     ",
+	\ "      shall_make_no_",
+	\ "      law           ",
+	\ ]
+  let lines = s:screen_lines2(1, 9, 20)
+  call s:compare_lines(expect, lines)
+
   " check formatlistpat indent with different list levels
-  let &l:flp = '^\s*\*\+\s\+'
+  let &l:flp = '^\s*\(\*\|•\)\+\s\+'
+  setl list&vim listchars&vim
   %delete _
   call setline(1, ['* Congress shall make no law',
-        \ '*** Congress shall make no law',
+        \ '••• Congress shall make no law',
         \ '**** Congress shall make no law'])
   norm! 1gg
   redraw!
   let expect = [
 	\ "* Congress shall    ",
 	\ "  make no law       ",
-	\ "*** Congress shall  ",
+	\ "••• Congress shall  ",
 	\ "    make no law     ",
 	\ "**** Congress shall ",
 	\ "     make no law    ",
@@ -864,7 +919,7 @@ func Test_breakindent20_list()
   let expect = [
 	\ "* Congress shall    ",
 	\ "> make no law       ",
-	\ "*** Congress shall  ",
+	\ "••• Congress shall  ",
 	\ ">   make no law     ",
 	\ "**** Congress shall ",
 	\ ">    make no law    ",
@@ -880,7 +935,7 @@ func Test_breakindent20_list()
   let expect = [
 	\ "* Congress shall    ",
 	\ ">   make no law     ",
-	\ "*** Congress shall  ",
+	\ "••• Congress shall  ",
 	\ ">     make no law   ",
 	\ "**** Congress shall ",
 	\ ">      make no law  ",


### PR DESCRIPTION
#### vim-patch:9.1.0720: Wrong breakindentopt=list:-1 with multibyte or TABs

Problem:  Wrong breakindentopt=list:-1 with multibyte chars or TABs in
          text matched by 'formatlistpat' (John M Devin)
Solution: Use the width of the match text (zeertzjq)

closes: vim/vim#15635

https://github.com/vim/vim/commit/61a6ac4d0066317131528f1b3ecc3b3a2599a75c