### PR TITLE
fix(highlight): floating windows inherit NormalFloat from global-ns

### DIFF
--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -370,12 +370,15 @@ void update_window_hl(win_T *wp, bool invalid)
 
   // determine window specific background set in 'winhighlight'
   bool float_win = wp->w_floating && !wp->w_config.external;
-  if (float_win && hl_def[HLF_NFLOAT] != 0) {
+  if (float_win && hl_def[HLF_NFLOAT] != 0 && ns_id > 0) {
     wp->w_hl_attr_normal = hl_def[HLF_NFLOAT];
   } else if (hl_def[HLF_COUNT] > 0) {
     wp->w_hl_attr_normal = hl_def[HLF_COUNT];
+  } else if (float_win) {
+    wp->w_hl_attr_normal = HL_ATTR(HLF_NFLOAT) > 0
+                           ? HL_ATTR(HLF_NFLOAT) : highlight_attr[HLF_NFLOAT];
   } else {
-    wp->w_hl_attr_normal = float_win ? HL_ATTR(HLF_NFLOAT) : 0;
+    wp->w_hl_attr_normal = 0;
   }
 
   if (wp->w_floating) {

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -1344,6 +1344,53 @@ describe('float window', function()
                                                   |
         ]])
       end
+
+      --
+      -- floating windows inherit NormalFloat from global-ns.
+      --
+      command('fclose')
+      command('hi NormalFloat guibg=LightRed')
+      api.nvim_open_win(0, false, { relative = 'win', row = 3, col = 3, width = 12, height = 3, style = 'minimal' })
+      api.nvim_set_hl_ns(api.nvim_create_namespace('test1'))
+      if multigrid then
+        screen:expect({
+          grid = [[
+          ## grid 1
+            [2:----------------------------------------]|*6
+            [3:----------------------------------------]|
+          ## grid 2
+            {14:  1 }^x                                   |
+            {14:  2 }y                                   |
+            {14:  3 }                                    |
+            {0:~                                       }|*3
+          ## grid 3
+                                                    |
+          ## grid 5
+            {22:x           }|
+            {22:y           }|
+            {22:            }|
+          ]], float_pos={
+          [5] = {1002, "NW", 2, 3, 3, true, 50};
+        }, win_viewport={
+          [2] = {win = 1000, topline = 0, botline = 4, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
+          [5] = {win = 1002, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
+        }, win_viewport_margins={
+          [2] = { bottom = 0, left = 0, right = 0, top = 0, win = 1000 },
+          [5] = { bottom = 0, left = 0, right = 0, top = 0, win = 1002 }
+        }})
+      else
+        screen:expect({
+          grid = [[
+            {14:  1 }^x                                   |
+            {14:  2 }y                                   |
+            {14:  3 }                                    |
+            {0:~  }{22:x           }{0:                         }|
+            {0:~  }{22:y           }{0:                         }|
+            {0:~  }{22:            }{0:                         }|
+                                                    |
+          ]]
+        })
+      end
     end)
 
     it("can use 'minimal' style", function()


### PR DESCRIPTION
Problem:
floating windows did not correctly inherit the NormalFloat highlight group from the global namespace when it was not defined in the window-specific namespace. This led to floating windows losing their background highlight when switching between namespaces.

Solution:
Updated the window highlight logic in update_window_hl() to handle the fallback.

Fix #30262 