### PR TITLE
fix(ui): increase the priority of xdg-open

### DIFF
--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -152,14 +152,14 @@ function M.open(path)
     else
       return nil, 'vim.ui.open: rundll32 not found'
     end
-  elseif vim.fn.executable('wslview') == 1 then
-    cmd = { 'wslview', path }
-  elseif vim.fn.executable('explorer.exe') == 1 then
-    cmd = { 'explorer.exe', path }
   elseif vim.fn.executable('xdg-open') == 1 then
     cmd = { 'xdg-open', path }
     opts.stdout = false
     opts.stderr = false
+  elseif vim.fn.executable('wslview') == 1 then
+    cmd = { 'wslview', path }
+  elseif vim.fn.executable('explorer.exe') == 1 then
+    cmd = { 'explorer.exe', path }
   else
     return nil, 'vim.ui.open: no handler found (tried: wslview, explorer.exe, xdg-open)'
   end


### PR DESCRIPTION
This change will only affect the behavior under WSL. Unlike typical Linux distributions, xdg-open is usually not installed in WSL. However, if the user deliberately installs it, I think prioritizing using xdg-open would be more reasonable.