### PR TITLE
fix(lua): revert vim.tbl_deep_extend behavior change and document it.

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2230,6 +2230,12 @@ vim.tbl_count({t})                                           *vim.tbl_count()*
 vim.tbl_deep_extend({behavior}, {...})                 *vim.tbl_deep_extend()*
     Merges recursively two or more tables.
 
+    Only values that are empty tables or tables that are not |lua-list|s
+    (indexed by consecutive integers starting from 1) are merged recursively.
+    This is useful for merging nested tables like default and user
+    configurations where lists should be treated as literals (i.e., are
+    overwritten instead of merged).
+
     Parameters: ~
       • {behavior}  (`'error'|'keep'|'force'`) Decides what to do if a key is
                     found in more than one map:

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -214,9 +214,6 @@ These existing features changed their behavior.
   more emoji characters than before, including those encoded with multiple
   emoji codepoints combined with ZWJ (zero width joiner) codepoints.
 
-• |vim.tbl_deep_extend()| no longer ignores any values for which |vim.isarray()|
-  returns `true`.
-
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*
 

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1071,12 +1071,11 @@ describe('lua stdlib', function()
     ]])
     )
 
-    -- Fix github issue #23654
     ok(exec_lua([[
-      local a = { sub = { [1] = 'a' } }
-      local b = { sub = { b = 'a' } }
+      local a = { sub = { 'a', 'b' } }
+      local b = { sub = { 'b', 'c' } }
       local c = vim.tbl_deep_extend('force', a, b)
-      return vim.deep_equal(c, { sub = { [1] = 'a', b = 'a' } })
+      return vim.deep_equal(c, { sub = { 'b', 'c' } })
     ]]))
 
     matches('invalid "behavior": nil', pcall_err(exec_lua, [[return vim.tbl_deep_extend()]]))


### PR DESCRIPTION
# Problem: 

`vim.tbl_deep_extend` had an undocumented feature where arrays (integer-indexed tables) were not merged but compared literally (used for merging default and user config, where one list should
overwrite the other completely). Turns out this behavior was relied on in quite a number of plugins (even though it wasn't a robust solution even for that use case, since lists of tables (e.g., plugin specs) can be array-like as well).

# Solution: 

Revert the removal of this special feature. Check for list-like (contiguous integer indices starting from 1) instead, as this is closer to the intent. Document this behavior.

Follow-up should be to add a new (better) `vim.merge` API that covers all current use cases and deprecates these legacy functions. It should also offer more -- and more explicit -- control. (See, e.g., https://github.com/neovim/neovim/pull/15124#issuecomment-2336685680.)
