### PR TITLE
fix(startup): server fails if $NVIM_APPNAME is relative dir

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -7641,7 +7641,7 @@ static void get_xdg_var_list(const XDGVarType xdg, typval_T *rettv)
     return;
   }
   const void *iter = NULL;
-  const char *appname = get_appname();
+  const char *appname = get_appname(false);
   do {
     size_t dir_len;
     const char *dir;

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -121,14 +121,15 @@ char *server_address_new(const char *name)
 {
   static uint32_t count = 0;
   char fmt[ADDRESS_MAX_SIZE];
-  const char *appname = get_appname();
 #ifdef MSWIN
+  (void)get_appname(true);
   int r = snprintf(fmt, sizeof(fmt), "\\\\.\\pipe\\%s.%" PRIu64 ".%" PRIu32,
-                   name ? name : appname, os_get_pid(), count++);
+                   name ? name : NameBuff, os_get_pid(), count++);
 #else
   char *dir = stdpaths_get_xdg_var(kXDGRuntimeDir);
+  (void)get_appname(true);
   int r = snprintf(fmt, sizeof(fmt), "%s/%s.%" PRIu64 ".%" PRIu32,
-                   dir, name ? name : appname, os_get_pid(), count++);
+                   dir, name ? name : NameBuff, os_get_pid(), count++);
   xfree(dir);
 #endif
   if ((size_t)r >= sizeof(fmt)) {

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -1559,7 +1559,7 @@ static inline char *add_env_sep_dirs(char *dest, const char *const val, const ch
     return dest;
   }
   const void *iter = NULL;
-  const char *appname = get_appname();
+  const char *appname = get_appname(false);
   const size_t appname_len = strlen(appname);
   do {
     size_t dir_len;
@@ -1626,7 +1626,7 @@ static inline char *add_dir(char *dest, const char *const dir, const size_t dir_
     if (!after_pathsep(dest - 1, dest)) {
       *dest++ = PATHSEP;
     }
-    const char *appname = get_appname();
+    const char *appname = get_appname(false);
     size_t appname_len = strlen(appname);
     assert(appname_len < (IOSIZE - sizeof("-data")));
     xmemcpyz(IObuff, appname, appname_len);
@@ -1697,7 +1697,7 @@ char *runtimepath_default(bool clean_arg)
   size_t config_len = 0;
   size_t vimruntime_len = 0;
   size_t libdir_len = 0;
-  const char *appname = get_appname();
+  const char *appname = get_appname(false);
   size_t appname_len = strlen(appname);
   if (data_home != NULL) {
     data_len = strlen(data_home);

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -321,11 +321,11 @@ end)
 describe('tmpdir', function()
   local tmproot_pat = [=[.*[/\\]nvim%.[^/\\]+]=]
   local testlog = 'Xtest_tmpdir_log'
-  local os_tmpdir
+  local os_tmpdir ---@type string
 
   before_each(function()
     -- Fake /tmp dir so that we can mess it up.
-    os_tmpdir = vim.uv.fs_mkdtemp(vim.fs.dirname(t.tmpname(false)) .. '/nvim_XXXXXXXXXX')
+    os_tmpdir = assert(vim.uv.fs_mkdtemp(vim.fs.dirname(t.tmpname(false)) .. '/nvim_XXXXXXXXXX'))
   end)
 
   after_each(function()
@@ -413,16 +413,5 @@ describe('tmpdir', function()
     eq('E5431: tempdir disappeared (2 times)', api.nvim_get_vvar('errmsg'))
     rm_tmpdir()
     eq('E5431: tempdir disappeared (3 times)', api.nvim_get_vvar('errmsg'))
-  end)
-
-  it('$NVIM_APPNAME relative path', function()
-    clear({
-      env = {
-        NVIM_APPNAME = 'a/b',
-        NVIM_LOG_FILE = testlog,
-        TMPDIR = os_tmpdir,
-      },
-    })
-    matches([=[.*[/\\]a%%b%.[^/\\]+]=], fn.tempname())
   end)
 end)

--- a/test/functional/core/server_spec.lua
+++ b/test/functional/core/server_spec.lua
@@ -154,7 +154,7 @@ describe('server', function()
     clear_serverlist()
 
     -- Address without slashes is a "name" which is appended to a generated path. #8519
-    matches([[.*[/\\]xtest1%.2%.3%.4[^/\\]*]], fn.serverstart('xtest1.2.3.4'))
+    matches([[[/\\]xtest1%.2%.3%.4[^/\\]*]], fn.serverstart('xtest1.2.3.4'))
     clear_serverlist()
 
     eq('Vim:Failed to start server: invalid argument', pcall_err(fn.serverstart, '127.0.0.1:65536')) -- invalid port
@@ -273,6 +273,6 @@ describe('startup --listen', function()
 
     -- Address without slashes is a "name" which is appended to a generated path. #8519
     clear({ args = { '--listen', 'test-name' } })
-    matches([[.*[/\\]test%-name[^/\\]*]], api.nvim_get_vvar('servername'))
+    matches([[[/\\]test%-name[^/\\]*]], api.nvim_get_vvar('servername'))
   end)
 end)

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -915,7 +915,7 @@ describe('stdpath()', function()
     assert_alive() -- Check for crash. #8393
   end)
 
-  it('supports $NVIM_APPNAME', function()
+  it('$NVIM_APPNAME', function()
     local appname = 'NVIM_APPNAME_TEST' .. ('_'):rep(106)
     clear({ env = { NVIM_APPNAME = appname, NVIM_LOG_FILE = testlog } })
     eq(appname, fn.fnamemodify(fn.stdpath('config'), ':t'))
@@ -955,6 +955,25 @@ describe('stdpath()', function()
     -- Valid appnames:
     test_appname('a/b', 0)
     test_appname('a/b\\c', 0)
+  end)
+
+  it('$NVIM_APPNAME relative path', function()
+    local tmpdir = t.tmpname(false)
+    t.mkdir(tmpdir)
+
+    clear({
+      args_rm = { '--listen' },
+      env = {
+        NVIM_APPNAME = 'relative/appname',
+        NVIM_LOG_FILE = testlog,
+        TMPDIR = tmpdir,
+      },
+    })
+
+    t.matches(vim.pesc(tmpdir), fn.tempname():gsub('\\', '/'))
+    t.assert_nolog('tempdir', testlog, 100)
+    t.assert_nolog('TMPDIR', testlog, 100)
+    t.matches([=[[/\\]relative%-appname.[^/\\]+]=], api.nvim_get_vvar('servername'))
   end)
 
   describe('returns a String', function()

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -14,8 +14,7 @@ local is_os = t.is_os
 local ok = t.ok
 local sleep = uv.sleep
 
---- This module uses functions from the context of the test session, i.e. in the context of the
---- nvim being tests.
+--- Functions executing in the current nvim session/process being tested.
 local M = {}
 
 local runtime_set = 'set runtimepath^=./build/lib/nvim/'

--- a/test/testutil.lua
+++ b/test/testutil.lua
@@ -16,7 +16,7 @@ local function shell_quote(str)
   return str
 end
 
---- This module uses functions from the context of the test runner.
+--- Functions executing in the context of the test runner (not the current nvim test session).
 --- @class test.testutil
 local M = {
   paths = Paths,


### PR DESCRIPTION
## Problem:
If `$NVIM_APPNAME` is a relative dir path, Nvim fails to start its primary/default server, and `v:servername` is empty. Root cause is d34c64e342dfba9248d1055e702d02620a1b31a8, but this wasn't noticed until 96128a5076b7 started reporting the error more loudly.

## Solution:
- `server_address_new`: replace slashes "/" in the appname before using  it as a servername.
- `vim_mktempdir`: always prefer the system-wide top-level "nvim.user/" directory. That isn't intended to be specific to NVIM_APPNAME; rather, each *subdirectory* ("nvim.user/xxx") is owned by each Nvim instance. Nvim "apps" can be identified by the server socket(s) stored in those per-Nvim subdirs.

fix #30256

## Reference

See https://github.com/neovim/neovim/pull/22128#discussion_r1749271437

> > usecase I had in mind was applications that do something very different from each other (e.g. mail clients embedding nvim, chat clients embedding nvim and so on). From that point of view, it made little sense to desire a way to connect to all neovims running on the same machine
> 
> I think we can still support that use-case even if all the nvim tempdirs are under one `/tmp/nvim.user/` root. The nvim servernames stored in each `/tmp/nvim.user/xxx/<appname>.n.m` use the appname. And eventually, for a given `$NVIM_APPNAME` we could keep a list of "peers" in the app-specific data dir.

