### PR TITLE
fix(lsp): wrong startcol and avoid pum deleted

### DIFF
--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -218,6 +218,49 @@ describe('vim.lsp.completion: item conversion', function()
     eq(expected, result)
   end)
 
+  it('removes unnecessary symbols in label', function()
+    local items = {
+      {
+        detail = 'colnr_T',
+        filterText = 'w_virtcol',
+        insertText = '->w_virtcol',
+        insertTextFormat = 1,
+        kind = 5,
+        label = ' w_virtcol',
+        score = 0.59581798315048,
+        sortText = '40e77879w_virtcol',
+        textEdit = {
+          newText = '->w_virtcol',
+          range = {
+            ['end'] = {
+              character = 0,
+              line = 0,
+            },
+            start = {
+              character = 0,
+              line = 0,
+            },
+          },
+        },
+      },
+    }
+    local result = complete('|', items)
+    result = vim.tbl_map(function(x)
+      return {
+        abbr = x.abbr,
+        word = x.word,
+      }
+    end, result.items)
+
+    local expected = {
+      {
+        abbr = ' w_virtcol',
+        word = 'w_virtcol',
+      },
+    }
+    eq(expected, result)
+  end)
+
   it('prefers wordlike components for snippets', function()
     -- There are two goals here:
     --


### PR DESCRIPTION

Problem:
1. comletion prefix value sub index not correct. which cause
       input `wp.` completion in there after do and type w the completion
       window will be delete.
 2. wrong complete-word generate this will include symbol like `->` ,
       it will make compl_match_array build failed. because the leader
       is character it can not find in this complete-word(cp_str).

Solution:
1. use max value of server_bounary, word_boundary
2. use vimregex keyword remove unncessary symbols.


before

![now](https://github.com/user-attachments/assets/ed3d7522-8b0b-4d8c-a9a1-9ea153f2b8d9)

After

![after](https://github.com/user-attachments/assets/cf8565c1-ea41-4676-95ec-be6febbab1fc)


