### PR TITLE
fix(scripts): update bundled dependencies in bump_deps

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -48,7 +48,7 @@ TREESITTER_VIMDOC_URL https://github.com/neovim/tree-sitter-vimdoc/archive/v3.0.
 TREESITTER_VIMDOC_SHA256 a639bf92bf57bfa1cdc90ca16af27bfaf26a9779064776dd4be34c1ef1453f6c
 TREESITTER_QUERY_URL https://github.com/tree-sitter-grammars/tree-sitter-query/archive/v0.4.0.tar.gz
 TREESITTER_QUERY_SHA256 d3a423ab66dc62b2969625e280116678a8a22582b5ff087795222108db2f6a6e
-TREESITTER_MARKDOWN_URL https://github.com/MDeiml/tree-sitter-markdown/archive/v0.2.3.tar.gz
+TREESITTER_MARKDOWN_URL https://github.com/tree-sitter-grammars/tree-sitter-markdown/archive/v0.2.3.tar.gz
 TREESITTER_MARKDOWN_SHA256 4909d6023643f1afc3ab219585d4035b7403f3a17849782ab803c5f73c8a31d5
 TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/v0.23.0.tar.gz
 TREESITTER_SHA256 6403b361b0014999e96f61b9c84d6950d42f0c7d6e806be79382e0232e48a11b

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -7,8 +7,8 @@ LUAJIT_SHA256 2b5514bd6a6573cb6111b43d013e952cbaf46762d14ebe26c872ddb80b5a84e0
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333
 
-UNIBILIUM_URL https://github.com/neovim/unibilium/archive/d72c3598e7ac5d1ebf86ee268b8b4ed95c0fa628.tar.gz
-UNIBILIUM_SHA256 9c4747c862ab5e3076dcf8fa8f0ea7a6b50f20ec5905618b9536655596797487
+UNIBILIUM_URL https://github.com/neovim/unibilium/archive/ab28a2ddb86a144194a798bcf1fef1ab4f981ab7.tar.gz
+UNIBILIUM_SHA256 7c0386fc48452632868e0dcb8e7ed140d67a3da79e39ceee54c1ba7a495ad625
 
 LUV_URL https://github.com/luvit/luv/releases/download/1.48.0-2/luv-1.48.0-2.tar.gz
 LUV_SHA256 2c3a1ddfebb4f6550293a40ee789f7122e97647eede51511f57203de48c03b7a

--- a/scripts/bump_deps.lua
+++ b/scripts/bump_deps.lua
@@ -81,6 +81,14 @@ local function get_dependency(dependency_name)
       repo = 'luvit/luv',
       symbol = 'LUV',
     },
+    ['unibilium'] = {
+      repo = 'neovim/unibilium',
+      symbol = 'UNIBILIUM',
+    },
+    ['utf8proc'] = {
+      repo = 'JuliaStrings/utf8proc',
+      symbol = 'UTF8PROC',
+    },
     ['tree-sitter'] = {
       repo = 'tree-sitter/tree-sitter',
       symbol = 'TREESITTER',
@@ -90,11 +98,11 @@ local function get_dependency(dependency_name)
       symbol = 'TREESITTER_C',
     },
     ['tree-sitter-lua'] = {
-      repo = 'MunifTanjim/tree-sitter-lua',
+      repo = 'tree-sitter-grammars/tree-sitter-lua',
       symbol = 'TREESITTER_LUA',
     },
     ['tree-sitter-vim'] = {
-      repo = 'neovim/tree-sitter-vim',
+      repo = 'tree-sitter-grammars/tree-sitter-vim',
       symbol = 'TREESITTER_VIM',
     },
     ['tree-sitter-vimdoc'] = {
@@ -102,8 +110,20 @@ local function get_dependency(dependency_name)
       symbol = 'TREESITTER_VIMDOC',
     },
     ['tree-sitter-query'] = {
-      repo = 'nvim-treesitter/tree-sitter-query',
+      repo = 'tree-sitter-grammars/tree-sitter-query',
       symbol = 'TREESITTER_QUERY',
+    },
+    ['tree-sitter-markdown'] = {
+      repo = 'tree-sitter-grammars/tree-sitter-markdown',
+      symbol = 'TREESITTER_MARKDOWN',
+    },
+    ['wasmtime'] = {
+      repo = 'bytecodealliance/wasmtime',
+      symbol = 'WASMTIME',
+    },
+    ['uncrustify'] = {
+      repo = 'uncrustify/uncrustify',
+      symbol = 'UNCRUSTIFY',
     },
   }
   local dependency = dependency_table[dependency_name]


### PR DESCRIPTION
Problem: Not all bundled dependencies are supported by `bump_deps.lua`.

Solution: Add missing dependencies; adapt to transferred repos.

Also update UNIBILIUM to HEAD to pull in https://github.com/neovim/unibilium/pull/24