### PR TITLE
feat(ui): ctrl-z targets only the current UI

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -700,6 +700,9 @@ void api_set_error(Error *err, ErrorType errType, const char *format, ...)
   vsnprintf(err->msg, bufsize, format, args2);
   va_end(args2);
 
+  // Log API errors at INFO level. Aligns with emsg_multiline().
+  ILOG("API error: %s", err->msg);
+
   err->type = errType;
 }
 

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -225,6 +225,14 @@ void ui_attach(uint64_t channel_id, Integer width, Integer height, Boolean enabl
   nvim_ui_attach(channel_id, width, height, opts, err);
 }
 
+void ui_request_detach(uint64_t chan, String msg)
+{
+  RemoteUI *ui = pmap_get(uint64_t)(&connected_uis, chan);
+  if (ui) {
+    remote_ui_detach(ui, msg);
+  }
+}
+
 /// Tells the nvim server if focus was gained or lost by the GUI
 void nvim_ui_set_focus(uint64_t channel_id, Boolean gained, Error *error)
   FUNC_API_SINCE(11) FUNC_API_REMOTE_ONLY

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -46,6 +46,8 @@ void chdir(String path)
 // Stop event is not exported as such, represented by EOF in the msgpack stream.
 void stop(void)
   FUNC_API_NOEXPORT;
+void detach(String msg)
+  FUNC_API_SINCE(13);
 void ui_send(String content)
   FUNC_API_SINCE(14) FUNC_API_REMOTE_IMPL;
 

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -322,6 +322,7 @@ static void channel_destroy_early(Channel *chan)
     abort();
   }
   pmap_del(uint64_t)(&channels, chan->id, NULL);
+  // XXX: ??? this is used in `free_channel_event`, how can this work?!
   chan->id = 0;
 
   if ((--chan->refcount != 0)) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5971,9 +5971,19 @@ static void ex_tabs(exarg_T *eap)
 /// ":detach!" with bang (!) detaches all UIs _except_ the current UI.
 static void ex_detach(exarg_T *eap)
 {
+  String msg;
+  size_t n;
+  char **addrs = server_address_list(&n);
+  if (n > 0) {
+    msg.size = (size_t)snprintf(IObuff, IOSIZE, _("Detached from Nvim server: %s"), addrs[0]);
+    msg.data = IObuff;
+  } else {
+    msg = STATIC_CSTR_AS_STRING("Detached from Nvim server.");
+  }
+
   // come on pooky let's burn this mf down
   if (eap && eap->forceit) {
-    emsg("bang (!) not supported yet");
+    ui_call_detach(msg);
   } else {
     // 1. Send "error_exit" UI-event (notification only).
     // 2. Perform server-side UI detach.
@@ -5993,6 +6003,9 @@ static void ex_detach(exarg_T *eap)
     Error detach_err = ERROR_INIT;
     nvim__chan_set_detach(chan->id, true, &detach_err);
     api_clear_error(&detach_err);
+
+    // TODO(justinmk)
+    // ui_request_detach(chan->id, STATIC_CSTR_AS_STRING("Detached from Nvim server."));
 
     // Server-side UI detach. Doesn't close the channel.
     Error err2 = ERROR_INIT;

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -363,6 +363,7 @@ static void request_event(void **argv)
     goto free_ret;
   }
 
+  current_channel_id = channel->id;
   Object result = handler.fn(channel->id, e->args, &e->used_mem, &error);
   if (e->type == kMessageTypeRequest || ERROR_SET(&error)) {
     // Send the response.

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -14,13 +14,16 @@
 #include <string.h>
 #include <time.h>
 
+#include "nvim/api/private/defs.h"
 #include "nvim/api/private/helpers.h"
+#include "nvim/api/ui.h"
 #include "nvim/ascii_defs.h"
 #include "nvim/autocmd.h"
 #include "nvim/autocmd_defs.h"
 #include "nvim/buffer.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/change.h"
+#include "nvim/channel.h"
 #include "nvim/charset.h"
 #include "nvim/cmdhist.h"
 #include "nvim/cursor.h"
@@ -61,11 +64,13 @@
 #include "nvim/message.h"
 #include "nvim/mouse.h"
 #include "nvim/move.h"
+#include "nvim/msgpack_rpc/channel.h"
 #include "nvim/normal.h"
 #include "nvim/ops.h"
 #include "nvim/option.h"
 #include "nvim/option_vars.h"
 #include "nvim/os/input.h"
+#include "nvim/os/os.h"
 #include "nvim/os/time.h"
 #include "nvim/plines.h"
 #include "nvim/profile.h"
@@ -5160,14 +5165,22 @@ static void nv_window(cmdarg_T *cap)
   }
 }
 
-/// CTRL-Z: Suspend
+/// CTRL-Z: suspend UI, or detach if `count` is given.
 static void nv_suspend(cmdarg_T *cap)
 {
   clearop(cap->oap);
   if (VIsual_active) {
     end_visual_mode();                  // stop Visual mode
   }
-  do_cmdline_cmd("stop");
+
+  if (cap->count0 == 0) {
+    // Regular suspend.
+    // TODO(justinmk): target this to the current UI.
+    do_cmdline_cmd("suspend");
+    return;
+  }
+
+  do_cmdline_cmd("detach");
 }
 
 /// "gv": Reselect the previous Visual area.  If Visual already active,

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -18,6 +18,7 @@
 #include "nvim/event/defs.h"
 #include "nvim/event/loop.h"
 #include "nvim/event/multiqueue.h"
+#include "nvim/event/proc.h"
 #include "nvim/event/signal.h"
 #include "nvim/event/stream.h"
 #include "nvim/globals.h"
@@ -1691,6 +1692,37 @@ static void tui_suspend_cb(TUIData *tui)
   ui_client_attach(tui->width, tui->height, tui->term, tui->rgb);
 }
 #endif
+
+// static void detach_event(void **argv)
+//   FUNC_ATTR_NORETURN
+// {
+//   char *data = argv[0];
+//   ui_client_stop();
+//   if (data != NULL) {
+//     os_errmsg(data);
+//     os_errmsg("\n");
+//   }
+//   xfree(data);
+//   os_exit(0);
+// }
+
+void tui_detach(TUIData *tui, String msg)
+{
+  DLOG("UI 'detach' event");
+
+  // tui_stop(tui);
+  if (msg.data) {
+    // fprintf(stdout, "%s\n", msg.data);
+    fprintf(stderr, "%s\n", msg.data);
+  }
+
+  exit_on_closed_chan(0);
+  // multiqueue_put_event(resize_events, event_create(detach_event, 1, msg.data ? strdup(msg.data) : NULL));
+  // ui_client_detach();
+  // ui_client_stop();
+  // kill(0, SIGTERM);
+  // os_exit(0);
+}
 
 void tui_set_title(TUIData *tui, String title)
 {

--- a/test/client/session.lua
+++ b/test/client/session.lua
@@ -14,6 +14,7 @@ local RpcStream = require('test.client.rpc_stream')
 --- @field private _timer uv.uv_timer_t
 --- @field private _is_running boolean true during `Session:run()` scope.
 --- @field data table Arbitrary user data.
+--- @field closed boolean
 local Session = {}
 Session.__index = Session
 if package.loaded['jit'] then
@@ -244,6 +245,7 @@ function Session:_run(request_cb, notification_cb, timeout)
   self._prepare:stop()
   self._timer:stop()
   self._rpc_stream:read_stop()
+  -- self:close()
 end
 
 --- Nvim msgpack-RPC session.

--- a/test/functional/ui/embed_spec.lua
+++ b/test/functional/ui/embed_spec.lua
@@ -356,3 +356,40 @@ describe('--embed --listen UI', function()
     eq({ 'VimEnter', ('UIEnter:%d'):format(api_info[1]) }, var)
   end)
 end)
+
+describe('UI :detach', function()
+  after_each(function()
+    check_close()
+    -- os.remove(testlog)
+  end)
+
+  it('xxx1', function()
+    -- io_extra = pipe.read,
+    clear { args_rm = { '--headless' }, env = { NVIM_LOG_FILE = 'testlog' } }
+
+    -- attach immediately after startup, for early UI
+    -- rpc_async: Avoid hanging. #24888
+    -- local pipe = assert(uv.pipe())
+    -- local screen = Screen.new(40, 8, { stdin_fd = 3 }, false)
+    -- screen.rpc_async = true -- Avoid hanging. #24888
+    -- screen:attach()
+
+    -- n.expect_exit(1, n.command, 'detach')
+    -- eq('EOF was received from Nvim. Likely the Nvim process crashed.',
+    --   t.pcall_err(n.command, 'detach'))
+    local addr = n.eval('v:servername')
+    -- local s = n.get_session()
+
+    -- TODO(justinmk): using request(), because expect_exit() hangs for some reason.
+    -- local _, rv = s:request('nvim_command', 'detach')
+    n.expect_exit(n.command, 'detach')
+    -- XXX: :detach closes the stream, it didn't "crash", .
+    -- eq('EOF was received from Nvim. Likely the Nvim process crashed.', rv and rv[2] or '?')
+    -- ok(s.closed)
+
+    local s2 = n.connect(addr)
+    n.set_session(s2)
+    n.assert_alive()
+    n.expect_exit(1, n.command, 'qall!')
+  end)
+end)

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -312,6 +312,8 @@ function Screen:attach(session)
   if self._default_attr_ids == nil then
     self._default_attr_ids = Screen._global_default_attr_ids
   end
+
+  session:request('nvim_set_client_info', 'screen.lua', '1.0.0', 'ui', {}, {})
 end
 
 function Screen:detach()


### PR DESCRIPTION
## Problem

- ctrl-z suspends *all* clients (and raises `VimSuspend`)
- No way for users/scripts to identify the "current UI".

Current behavior on master:

- after ctrl-z...
    - you can still connect to the server with a new UI
    - you can `fg` (foreground) any of the suspended UIs
    - the client processes don't exit after ctrl-z, you need to terminate them manually.

## Solution

See below...


### Status:

- `:detach` or `[count]ctrl-z` detaches the current UI. #32385
    - Works for all UIs ([`error_exit` UI event is sent](https://github.com/neovim/neovim/pull/34411) as an optional hint to clients before the channel is closed).
- Builtin TUI calls `nvim_set_client_info` with info including PID (`client.attributes.pid`).

### TODO:

- [ ] `nvim --connect` (without args) attaches to most-recent server.
- [ ] `:quit` should confirm if multiple UIs are attached.
- [ ] `chanclose({detach:boolean})` parameter.
    - ~~Clients can set `detach=true` on a channel, to ensure the server does not "self-exit" if the client closes its end of the channel.~~
- [ ] Change "regular suspend" to target only the "current" UI, instead of all connected UIs.
- [ ] Scripts can ask "what's the current UI?" Set `v:ui` or add a field to `nvim_list_uis()`.
- [ ] Docs:
    - Update `:help ctrl-z`, `:suspend`, ...
    - How to map ctrl-z so that it copies `v:servername` to clipboard.
- [ ] The "tmux use-case": keep the server running after unexpected disconnect/SIGHUP.
    - 🚧 Needs to be opt-in.
    - If the foreground process/your terminal unexpectedly disconnects, the Nvim server stays running. SIGTERM/SIGHUP on the client exits *only* the client, not the server.
    - ~~Notes on daemonizing: https://github.com/neovim/neovim/issues/5035#issuecomment-379408935~~
- [x] Move the impl out of `input.c` and plumb it through as proper keymapping.
    - Works with any UI, not only the TUI.
    - ~~Currently it works by special-casing `ctrl-z` in the TUI input stream.~~
    - Ideally, *input sent from a UI should be mapped to a channel id.*
        - Currently, specific input is not mapped, there is only the concept of a "most-recent (current) UI".
- [x] Require `[count]<c-z>`. Regular `<c-z>` without `[count]` should have its old behavior.
    - ~~For `--remote-ui` clients, ctrl-z old behavior really doesn't seem useful.~~
- [x] Support the normal case where `nvim` spawns the server as a child.
    - [use detach=true](https://github.com/neovim/neovim/issues/23093#issuecomment-2337867984)?
- [x] `:connect [server]` (or `:attach`?) performs "hot swap" (attach current UI to a different server). https://github.com/neovim/neovim/issues/5035#issuecomment-2343537003
    - TBD: don't know how to make this work for the "stdio" case. (workaround: always start the server as a daemon instead of using stdio).
- ~~show a warning if `ctrl-z` / `:suspend` is used server-side when UIs are attached.~~

closes https://github.com/neovim/neovim/issues/23093
closes https://github.com/neovim/neovim/pull/23441