### PR TITLE
lsp: handle InsertTextMode in completion items

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -308,11 +308,22 @@ end
 local function adjust_start_col(lnum, line, items, encoding)
   local min_start_char = nil
   for _, item in pairs(items) do
-    if item.textEdit and item.textEdit.range.start.line == lnum then
-      if min_start_char and min_start_char ~= item.textEdit.range.start.character then
+    local start_line = 0
+    local start_char = 0
+
+    if item.textEdit and item.textEdit.newText then
+      start_line = item.textEdit.insert.start.line
+      start_char = item.textEdit.insert.start.chararacter
+    else
+      start_line = item.textEdit.range.start.line
+      start_char = item.textEdit.range.start.character
+    end
+
+    if item.textEdit and start_line == lnum then
+      if min_start_char and min_start_char ~= start_char then
         return nil
       end
-      min_start_char = item.textEdit.range.start.character
+      min_start_char = start_char
     end
   end
   if min_start_char then


### PR DESCRIPTION
Gopls may return a `InsertReplaceEdit` structure in a LSP completion item depending on settings.

Make completion.lua understand this could occur and extract the appropriate variables.

This fixes a crash in gopls completion:
```
Error executing vim.schedule lua callback: /usr/share/nvim/runtime/lua/vim/lsp/completion.lua:311: attempt to index field 'range' (a nil value)
stack traceback:
        /usr/share/nvim/runtime/lua/vim/lsp/completion.lua:311: in function 'adjust_start_col'
        /usr/share/nvim/runtime/lua/vim/lsp/completion.lua:362: in function '_convert_results'
        /usr/share/nvim/runtime/lua/vim/lsp/completion.lua:451: in function 'callback'
        /usr/share/nvim/runtime/lua/vim/lsp/completion.lua:390: in function 'handler'
        /usr/share/nvim/runtime/lua/vim/lsp/client.lua:687: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

Closes #30332