### PR TITLE
vim-patch:d657d3d: runtime(doc): clarify the effect of the timeout for search()-functions

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6201,6 +6201,9 @@ search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]]) *search()*
 		The value must not be negative.  A zero value is like not
 		giving the argument.
 
+		Note: the timeout is only considered when searching, not
+		while evaluating the {skip} expression.
+
 		If the {skip} expression is given it is evaluated with the
 		cursor positioned on the start of a match.  If it evaluates to
 		non-zero this match is skipped.  This can be used, for

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -7421,6 +7421,9 @@ function vim.fn.screenstring(row, col) end
 --- The value must not be negative.  A zero value is like not
 --- giving the argument.
 ---
+--- Note: the timeout is only considered when searching, not
+--- while evaluating the {skip} expression.
+---
 --- If the {skip} expression is given it is evaluated with the
 --- cursor positioned on the start of a match.  If it evaluates to
 --- non-zero this match is skipped.  This can be used, for

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -8927,6 +8927,9 @@ M.funcs = {
       The value must not be negative.  A zero value is like not
       giving the argument.
 
+      Note: the timeout is only considered when searching, not
+      while evaluating the {skip} expression.
+
       If the {skip} expression is given it is evaluated with the
       cursor positioned on the start of a match.  If it evaluates to
       non-zero this match is skipped.  This can be used, for


### PR DESCRIPTION
#### vim-patch:d657d3d: runtime(doc): clarify the effect of the timeout for search()-functions

related: vim/vim#15657
related: vim/vim#15404

https://github.com/vim/vim/commit/d657d3d8fd635dbd78402358788dc58a96d04117

Co-authored-by: Christian Brabandt <cb@256bit.org>