### PR TITLE
vim-patch: update runtime files

### DIFF
--- a/runtime/compiler/README.txt
+++ b/runtime/compiler/README.txt
@@ -4,6 +4,8 @@ They are used with the ":compiler" command.
 These scripts usually set options, for example 'errorformat'.
 See ":help write-compiler-plugin".
 
+To undo the effect of a compiler plugin, use the make compiler plugin.
+
 If you want to write your own compiler plugin, have a look at the other files
 for how to do it, the format is simple.
 

--- a/runtime/compiler/groff.vim
+++ b/runtime/compiler/groff.vim
@@ -1,0 +1,45 @@
+" Vim compiler file
+" Compiler:     Groff
+" Maintainer:   Konfekt
+" Last Change:	2024 Sep 8
+"
+" Expects output file extension, say `:make html` or `:make pdf`.
+" Supported devices as of Sept 2024 are: (x)html, pdf, ps, dvi, lj4, lbp ...
+" Adjust command-line flags, language, encoding by buffer-local/global variables
+" groff_compiler_args, groff_compiler_lang, and groff_compiler_encoding,
+" which default to '', &spelllang and 'utf8'.
+
+if exists("current_compiler")
+  finish
+endif
+
+let s:keepcpo = &cpo
+set cpo&vim
+
+let current_compiler = 'groff'
+
+silent! function s:groff_compiler_lang()
+  let lang = get(b:, 'groff_compiler_lang',
+      \ &spell ? matchstr(&spelllang, '^\a\a') : '')
+  if lang ==# 'en' | let lang = '' | endif
+  return empty(lang) ? '' : '-m'..lang
+endfunction
+
+" Requires output format (= device) to be set by user after :make.
+execute 'CompilerSet makeprg=groff'..escape(
+    \ ' '..s:groff_compiler_lang()..
+    \ ' -K'..get(b:, 'groff_compiler_encoding', get(g:, 'groff_compiler_encoding', 'utf8'))..
+    \ ' '..get(b:, 'groff_compiler_args', get(g:, 'groff_compiler_args', ''))..
+    \ ' -mom -T$* -- %:S > %:r:S.$*', ' ')
+" From Gavin Freeborn's https://github.com/Gavinok/vim-troff under Vim License
+" https://github.com/Gavinok/vim-troff/blob/91017b1423caa80aba541c997909a4f810edd275/compiler/troff.vim#L39
+CompilerSet errorformat=%o:<standard\ input>\ (%f):%l:%m,
+			\%o:\ <standard\ input>\ (%f):%l:%m,
+			\%o:%f:%l:%m,
+			\%o:\ %f:%l:%m,
+			\%f:%l:\ macro\ %trror:%m,
+			\%f:%l:%m,
+			\%W%tarning:\ file\ '%f'\\,\ around\ line\ %l:,%Z%m
+
+let &cpo = s:keepcpo
+unlet s:keepcpo

--- a/runtime/compiler/make.vim
+++ b/runtime/compiler/make.vim
@@ -1,0 +1,13 @@
+" Vim compiler plugin
+"
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2024 Sep 10
+" Original Author: Konfekt
+"
+" This compiler plugin is used to reset previously set compiler options.
+
+if exists("g:current_compiler") | unlet g:current_compiler | endif
+if exists("b:current_compiler") | unlet b:current_compiler | endif
+
+CompilerSet makeprg&
+CompilerSet errorformat&

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1318,8 +1318,7 @@ Additional arguments can be passed to pandoc:
 
 The `--from` argument is an educated guess using the buffer file type;
 it can be overridden by setting `b:pandoc_compiler_from`.
-Likewise the `--metadata lang` argument is set using `&spelllang`;
-it can be overridden by setting `b:pandoc_compiler_lang`.
+The `--metadata lang` argument is set using 'spelllang';
 If `--from=markdown` is assumed and no title set in a title header or
 YAML block, then the filename (without extension) is used as the title.
 

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1294,6 +1294,17 @@ Commonly used compiler options can be added to 'makeprg' by setting the
 g:javac_makeprg_params variable.  For example: >
 	let g:javac_makeprg_params = "-Xlint:all -encoding utf-8"
 <
+GROFF					*quickfix-groff* *compiler-groff*
+
+The GROFF compiler plugin uses the mom macro set (documented in the groff_mom
+manpage) as input and expects that the output file type extension is passed to
+make, say :make html or :make pdf.
+
+Additional arguments can be passed to groff by setting them in
+`b:groff_compiler_args` or `g:groff_compiler_args`. The `language` argument
+passed to groff is set using 'spelllang'; it can be overridden by setting
+`b:groff_compiler_lang`. The default enconding is `UTF-8` and can be changed
+by setting `b:groff_compiler_encoding` or `g:groff_compiler_encoding`.
 
 PANDOC					*quickfix-pandoc* *compiler-pandoc*
 

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1262,6 +1262,7 @@ not "b:current_compiler".  What the command actually does is the following:
 
 For writing a compiler plugin, see |write-compiler-plugin|.
 
+Use the |compiler-make| plugin to undo the effect of a compiler plugin.
 
 DOTNET							*compiler-dotnet*
 
@@ -1277,7 +1278,6 @@ Example: limit output to only display errors, and suppress the project name: >
 	let dotnet_show_project_file = v:false
 	compiler dotnet
 <
-
 GCC					*quickfix-gcc*	*compiler-gcc*
 
 There's one variable you can set for the GCC compiler:
@@ -1294,6 +1294,13 @@ Commonly used compiler options can be added to 'makeprg' by setting the
 g:javac_makeprg_params variable.  For example: >
 	let g:javac_makeprg_params = "-Xlint:all -encoding utf-8"
 <
+GNU MAKE						*compiler-make*
+
+Since the default make program is "make", the compiler plugin for make,
+:compiler make, will reset the 'makeprg' and 'errorformat' option to
+the default values and unlet any variables that may have been set by a
+previous compiler plugin.
+
 GROFF					*quickfix-groff* *compiler-groff*
 
 The GROFF compiler plugin uses the mom macro set (documented in the groff_mom

--- a/runtime/ftplugin/spec.vim
+++ b/runtime/ftplugin/spec.vim
@@ -2,8 +2,9 @@
 " Filename: spec.vim
 " Maintainer: Igor Gnatenko i.gnatenko.brain@gmail.com
 " Former Maintainer: Gustavo Niemeyer <niemeyer@conectiva.com> (until March 2014)
-" Last Change: Mon Jun 01 21:15 MSK 2015 Igor Gnatenko
-" Update by Zdenek Dohnal, 2022 May 17
+" Last Change: 2015 Jun 01
+"  Update by Zdenek Dohnal, 2022 May 17
+"  2024 Sep 10 by Vim Project: add epoch support for spec changelog, #15537
 
 if exists("b:did_ftplugin")
 	finish
@@ -66,9 +67,11 @@ if !exists("*s:SpecChangelog")
 		endif
 		let line = 0
 		let name = ""
+		let epoch = ""
 		let ver = ""
 		let rel = ""
 		let nameline = -1
+		let epochline = -1
 		let verline = -1
 		let relline = -1
 		let chgline = -1
@@ -77,6 +80,9 @@ if !exists("*s:SpecChangelog")
 			if name == "" && linestr =~? '^Name:'
 				let nameline = line
 				let name = substitute(strpart(linestr,5), '^[	 ]*\([^ 	]\+\)[		]*$','\1','')
+			elseif epoch == "" && linestr =~? '^Epoch:'
+				let epochline = line
+				let epoch = substitute(strpart(linestr,6), '^[     ]*\([^         ]\+\)[          ]*$','\1','')
 			elseif ver == "" && linestr =~? '^Version:'
 				let verline = line
 				let ver = substitute(strpart(linestr,8), '^[	 ]*\([^ 	]\+\)[		]*$','\1','')
@@ -93,6 +99,7 @@ if !exists("*s:SpecChangelog")
 		if nameline != -1 && verline != -1 && relline != -1
 			let include_release_info = exists("g:spec_chglog_release_info")
 			let name = s:ParseRpmVars(name, nameline)
+			let epoch = s:ParseRpmVars(epoch, epochline)
 			let ver = s:ParseRpmVars(ver, verline)
 			let rel = s:ParseRpmVars(rel, relline)
 		else
@@ -117,6 +124,9 @@ if !exists("*s:SpecChangelog")
 		if chgline != -1
 			let tmptime = v:lc_time
 			language time C
+			if strlen(epoch)
+				let ver = epoch.":".ver
+			endif
 			let parsed_format = "* ".strftime(format)." - ".ver."-".rel
 			execute "language time" tmptime
 			let release_info = "+ ".name."-".ver."-".rel

--- a/runtime/syntax/dosini.vim
+++ b/runtime/syntax/dosini.vim
@@ -1,12 +1,12 @@
 " Vim syntax file
 " Language:               Configuration File (ini file) for MSDOS/MS Windows
-" Version:                2.3
+" Version:                2.4
 " Original Author:        Sean M. McKee <mckee@misslink.net>
 " Previous Maintainer:    Nima Talebi <nima@it.net.au>
 " Current Maintainer:     Hong Xu <hong@topbug.net>
 " Homepage:               http://www.vim.org/scripts/script.php?script_id=3747
 " Repository:             https://github.com/xuhdev/syntax-dosini.vim
-" Last Change:            2023 Aug 20
+" Last Change:            2024 Sept 08
 
 
 " quit when a syntax file was already loaded
@@ -27,7 +27,7 @@ syn match  dosiniNumber   "=\zs\s*\d\+\s*$"
 syn match  dosiniNumber   "=\zs\s*\d*\.\d\+\s*$"
 syn match  dosiniNumber   "=\zs\s*\d\+e[+-]\=\d\+\s*$"
 syn region dosiniHeader   start="^\s*\[" end="\]"
-syn match  dosiniComment  "^[#;].*$"
+syn match  dosiniComment  "^[#;].*$" contains=@Spell
 syn region dosiniSection  start="\s*\[.*\]" end="\ze\s*\[.*\]" fold
       \ contains=dosiniLabel,dosiniValue,dosiniNumber,dosiniHeader,dosiniComment
 

--- a/runtime/syntax/idlang.vim
+++ b/runtime/syntax/idlang.vim
@@ -1,7 +1,8 @@
 " Interactive Data Language syntax file (IDL, too  [:-)]
 " Maintainer: Aleksandar Jelenak <ajelenak AT yahoo.com>
-" Last change: 2011 Apr 11
-" Created by: Hermann Rochholz <Hermann.Rochholz AT gmx.de>
+" Created By: Hermann Rochholz <Hermann.Rochholz AT gmx.de>
+" Last Change: 2011 Apr 11
+"  2024 Sep 10 by Vim Project: update syntax script, #15419
 
 " Remove any old syntax stuff hanging around
 " quit when a syntax file was already loaded
@@ -16,7 +17,7 @@ syn match idlangStatement "^\s*function\s"
 syn keyword idlangStatement return continue mod do break
 syn keyword idlangStatement compile_opt forward_function goto
 syn keyword idlangStatement begin common end of
-syn keyword idlangStatement inherits on_ioerror begin
+syn keyword idlangStatement inherits on_error on_ioerror begin
 
 syn keyword idlangConditional if else then for while case switch
 syn keyword idlangConditional endcase endelse endfor endswitch
@@ -82,7 +83,7 @@ syn keyword idlangRoutine CALL_EXTERNAL CALL_FUNCTION CALL_METHOD
 syn keyword idlangRoutine CALL_PROCEDURE CATCH CD CEIL CHEBYSHEV CHECK_MATH
 syn keyword idlangRoutine CHISQR_CVF CHISQR_PDF CHOLDC CHOLSOL CINDGEN
 syn keyword idlangRoutine CIR_3PNT CLOSE CLUST_WTS CLUSTER COLOR_CONVERT
-syn keyword idlangRoutine COLOR_QUAN COLORMAP_APPLICABLE COMFIT COMMON
+syn keyword idlangRoutine COLOR_QUAN COLORMAP_APPLICABLE COMFIT
 syn keyword idlangRoutine COMPLEX COMPLEXARR COMPLEXROUND
 syn keyword idlangRoutine COMPUTE_MESH_NORMALS COND CONGRID CONJ
 syn keyword idlangRoutine CONSTRAINED_MIN CONTOUR CONVERT_COORD CONVOL
@@ -98,7 +99,7 @@ syn keyword idlangRoutine CW_PALETTE_EDITOR_GET CW_PALETTE_EDITOR_SET
 syn keyword idlangRoutine CW_PDMENU CW_RGBSLIDER CW_TMPL CW_ZOOM DBLARR
 syn keyword idlangRoutine DCINDGEN DCOMPLEX DCOMPLEXARR DEFINE_KEY DEFROI
 syn keyword idlangRoutine DEFSYSV DELETE_SYMBOL DELLOG DELVAR DERIV DERIVSIG
-syn keyword idlangRoutine DETERM DEVICE DFPMIN DIALOG_MESSAGE
+syn keyword idlangRoutine DETERM DEVICE DFPMIN DIAG_MATRIX DIALOG_MESSAGE
 syn keyword idlangRoutine DIALOG_PICKFILE DIALOG_PRINTERSETUP
 syn keyword idlangRoutine DIALOG_PRINTJOB DIALOG_READ_IMAGE
 syn keyword idlangRoutine DIALOG_WRITE_IMAGE DIGITAL_FILTER DILATE DINDGEN
@@ -155,7 +156,7 @@ syn keyword idlangRoutine MPEG_PUT MPEG_SAVE MSG_CAT_CLOSE MSG_CAT_COMPILE
 syn keyword idlangRoutine MSG_CAT_OPEN MULTI N_ELEMENTS N_PARAMS N_TAGS
 syn keyword idlangRoutine NEWTON NORM OBJ_CLASS OBJ_DESTROY OBJ_ISA OBJ_NEW
 syn keyword idlangRoutine OBJ_VALID OBJARR ON_ERROR ON_IOERROR ONLINE_HELP
-syn keyword idlangRoutine OPEN OPENR OPENW OPLOT OPLOTERR P_CORRELATE
+syn keyword idlangRoutine OPEN OPENR OPENW OPENU OPLOT OPLOTERR P_CORRELATE
 syn keyword idlangRoutine PARTICLE_TRACE PCOMP PLOT PLOT_3DBOX PLOT_FIELD
 syn keyword idlangRoutine PLOTERR PLOTS PNT_LINE POINT_LUN POLAR_CONTOUR
 syn keyword idlangRoutine POLAR_SURFACE POLY POLY_2D POLY_AREA POLY_FIT

--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Aliaksei Budavei <0x000c70 AT gmail DOT com>
 " Former Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
-" Last Change:		2024 Aug 26
+" Last Change:		2024 Sep 10
 
 " Please check :help java.vim for comments on some of the options available.
 
@@ -157,13 +157,20 @@ endif
 " testing in a project without attendant confusion for IDEs, with the
 " ".java\=" extension used for a production version and an arbitrary
 " extension used for a testing version.
-if fnamemodify(bufname("%"), ":t") =~ '^module-info\%(\.class\>\)\@!'
+if fnamemodify(bufname("%"), ":t") =~ '^module-info\>\%(\.class\>\)\@!'
   syn keyword javaModuleStorageClass	module transitive
   syn keyword javaModuleStmt		open requires exports opens uses provides
   syn keyword javaModuleExternal	to with
   hi def link javaModuleStorageClass	StorageClass
   hi def link javaModuleStmt		Statement
   hi def link javaModuleExternal	Include
+
+  if !exists("g:java_ignore_javadoc") && g:main_syntax != 'jsp'
+    syn match javaDocProvidesTag	contained "@provides\_s\+\S\+" contains=javaDocParam
+    syn match javaDocUsesTag		contained "@uses\_s\+\S\+" contains=javaDocParam
+    hi def link javaDocProvidesTag	Special
+    hi def link javaDocUsesTag		Special
+  endif
 endif
 
 " Fancy parameterised types (JLS-17, §4.5).
@@ -335,29 +342,99 @@ if !exists("g:java_ignore_javadoc") && g:main_syntax != 'jsp'
     call s:ReportOnce(v:exception)
   endtry
 
-  syn region javaDocComment	start="/\*\*" end="\*/" keepend contains=javaCommentTitle,@javaHtml,javaDocTags,javaDocSeeTag,javaDocCodeTag,javaDocSnippetTag,javaTodo,javaCommentError,javaSpaceError,@Spell fold
-  exec 'syn region javaCommentTitle contained matchgroup=javaDocComment start="/\*\*" matchgroup=javaCommentTitle end="\.$" end="\.[ \t\r]\@=" end="\%(^\s*\**\s*\)\@' . s:ff.Peek('80', '') . '<=@"me=s-2,he=s-1 end="\*/"me=s-1,he=s-1 contains=@javaHtml,javaCommentStar,javaTodo,javaCommentError,javaSpaceError,@Spell,javaDocTags,javaDocSeeTag,javaDocCodeTag,javaDocSnippetTag'
-  syn region javaCommentTitle	contained matchgroup=javaDocComment start="/\*\*\s*\r\=\n\=\s*\**\s*\%({@return\>\)\@=" matchgroup=javaCommentTitle end="}\%(\s*\.*\)*" contains=@javaHtml,javaCommentStar,javaTodo,javaCommentError,javaSpaceError,@Spell,javaDocTags,javaDocSeeTag,javaDocCodeTag,javaDocSnippetTag
-  syn region javaDocTags	contained start="{@\%(li\%(teral\|nk\%(plain\)\=\)\|inherit[Dd]oc\|doc[rR]oot\|value\)\>" end="}"
-  syn match  javaDocTags	contained "@\%(param\|exception\|throws\|since\)\s\+\S\+" contains=javaDocParam
-  syn match  javaDocParam	contained "\s\S\+"
-  syn match  javaDocTags	contained "@\%(version\|author\|return\|deprecated\|serial\%(Field\|Data\)\=\)\>"
-  syn region javaDocSeeTag	contained matchgroup=javaDocTags start="@see\s\+" matchgroup=NONE end="\_."re=e-1 contains=javaDocSeeTagParam
-  syn match  javaDocSeeTagParam	contained @"\_[^"]\+"\|<a\s\+\_.\{-}</a>\|\%(\k\|\.\)*\%(#\k\+\%((\_[^)]*)\)\=\)\=@ contains=@javaHtml extend
+  syn region javaDocComment	start="/\*\*" end="\*/" keepend contains=javaCommentTitle,@javaHtml,@javaDocTags,javaTodo,javaCommentError,javaSpaceError,@Spell fold
+  exec 'syn region javaCommentTitle contained matchgroup=javaDocComment start="/\*\*" matchgroup=javaCommentTitle end="\.$" end="\.[ \t\r]\@=" end="\%(^\s*\**\s*\)\@' . s:ff.Peek('80', '') . '<=@"me=s-2,he=s-1 end="\*/"me=s-1,he=s-1 contains=@javaHtml,javaCommentStar,javaTodo,javaCommentError,javaSpaceError,@Spell,@javaDocTags'
+  syn region javaCommentTitle	contained matchgroup=javaDocComment start="/\*\*\s*\r\=\n\=\s*\**\s*\%({@return\>\)\@=" matchgroup=javaCommentTitle end="}\%(\s*\.*\)*" contains=@javaHtml,javaCommentStar,javaTodo,javaCommentError,javaSpaceError,@Spell,@javaDocTags,javaTitleSkipBlock
+  syn region javaCommentTitle	contained matchgroup=javaDocComment start="/\*\*\s*\r\=\n\=\s*\**\s*\%({@summary\>\)\@=" matchgroup=javaCommentTitle end="}" contains=@javaHtml,javaCommentStar,javaTodo,javaCommentError,javaSpaceError,@Spell,@javaDocTags,javaTitleSkipBlock
+  " The members of javaDocTags are sub-grouped according to the Java
+  " version of their introduction, and sub-group members in turn are
+  " arranged in alphabetical order, so that future newer members can
+  " be pre-sorted and appended without disturbing the current member
+  " placement.
+  " Since they only have significance in javaCommentTitle, neither
+  " javaDocSummaryTag nor javaDocReturnTitleTag are defined.
+  syn cluster javaDocTags	contains=javaDocAuthorTag,javaDocDeprecatedTag,javaDocExceptionTag,javaDocParamTag,javaDocReturnTag,javaDocSeeTag,javaDocVersionTag,javaDocSinceTag,javaDocLinkTag,javaDocSerialTag,javaDocSerialDataTag,javaDocSerialFieldTag,javaDocThrowsTag,javaDocDocRootTag,javaDocInheritDocTag,javaDocLinkplainTag,javaDocValueTag,javaDocCodeTag,javaDocLiteralTag,javaDocHiddenTag,javaDocIndexTag,javaDocProvidesTag,javaDocUsesTag,javaDocSystemPropertyTag,javaDocSnippetTag,javaDocSpecTag
+
+  " Anticipate non-standard inline tags in {@return} and {@summary}.
+  syn region javaTitleSkipBlock	contained transparent start="{\%(@\%(return\|summary\)\>\)\@!" end="}"
+  syn match  javaDocDocRootTag	contained "{@docRoot}"
+  syn match  javaDocInheritDocTag contained "{@inheritDoc}"
+  syn region javaIndexSkipBlock	contained transparent start="{\%(@index\>\)\@!" end="}" contains=javaIndexSkipBlock,javaDocIndexTag
+  syn region javaDocIndexTag	contained start="{@index\>" end="}" contains=javaDocIndexTag,javaIndexSkipBlock
+  syn region javaLinkSkipBlock	contained transparent start="{\%(@link\>\)\@!" end="}" contains=javaLinkSkipBlock,javaDocLinkTag
+  syn region javaDocLinkTag	contained start="{@link\>" end="}" contains=javaDocLinkTag,javaLinkSkipBlock
+  syn region javaLinkplainSkipBlock contained transparent start="{\%(@linkplain\>\)\@!" end="}" contains=javaLinkplainSkipBlock,javaDocLinkplainTag
+  syn region javaDocLinkplainTag contained start="{@linkplain\>" end="}" contains=javaDocLinkplainTag,javaLinkplainSkipBlock
+  syn region javaLiteralSkipBlock contained transparent start="{\%(@literal\>\)\@!" end="}" contains=javaLiteralSkipBlock,javaDocLiteralTag
+  syn region javaDocLiteralTag	contained start="{@literal\>" end="}" contains=javaDocLiteralTag,javaLiteralSkipBlock
+  syn region javaSystemPropertySkipBlock contained transparent start="{\%(@systemProperty\>\)\@!" end="}" contains=javaSystemPropertySkipBlock,javaDocSystemPropertyTag
+  syn region javaDocSystemPropertyTag contained start="{@systemProperty\>" end="}" contains=javaDocSystemPropertyTag,javaSystemPropertySkipBlock
+  syn region javaValueSkipBlock	contained transparent start="{\%(@value\>\)\@!" end="}" contains=javaValueSkipBlock,javaDocValueTag
+  syn region javaDocValueTag	contained start="{@value\>" end="}" contains=javaDocValueTag,javaValueSkipBlock
+
+  syn match  javaDocParam	contained "\s\zs\S\+"
+  syn match  javaDocExceptionTag contained "@exception\s\+\S\+" contains=javaDocParam
+  syn match  javaDocParamTag	contained "@param\s\+\S\+" contains=javaDocParam
+  syn match  javaDocSinceTag	contained "@since\s\+\S\+" contains=javaDocParam
+  syn match  javaDocThrowsTag	contained "@throws\s\+\S\+" contains=javaDocParam
+  syn match  javaDocSpecTag	contained "@spec\_s\+\S\+\ze\_s\+\S\+" contains=javaDocParam
+
+  syn match  javaDocAuthorTag	contained "@author\>"
+  syn match  javaDocDeprecatedTag contained "@deprecated\>"
+  syn match  javaDocHiddenTag	contained "@hidden\>"
+  syn match  javaDocReturnTag	contained "@return\>"
+  syn match  javaDocSerialTag	contained "@serial\>"
+  syn match  javaDocSerialDataTag contained "@serialData\>"
+  syn match  javaDocSerialFieldTag contained "@serialField\>"
+  syn match  javaDocVersionTag	contained "@version\>"
+
+  syn match  javaDocSeeTag	contained "@see\>" nextgroup=javaDocSeeTag1,javaDocSeeTag2,javaDocSeeTag3,javaDocSeeTagStar skipwhite skipempty
+  syn match  javaDocSeeTagStar	contained "^\s*\*\+\%(\s*{\=@\|/\|$\)\@!" nextgroup=javaDocSeeTag1,javaDocSeeTag2,javaDocSeeTag3 skipwhite skipempty
+  syn match  javaDocSeeTag1	contained @"\_[^"]\+"@
+  syn match  javaDocSeeTag2	contained @<a\s\+\_.\{-}</a>@ contains=@javaHtml extend
+  syn match  javaDocSeeTag3	contained @["< \t]\@!\%(\k\|[/.]\)*\%(##\=\k\+\%((\_[^)]*)\)\=\)\=@ nextgroup=javaDocSeeTag3Label skipwhite skipempty
+  syn match  javaDocSeeTag3Label contained @\k\%(\k\+\s*\)*$@
+
   syn region javaCodeSkipBlock	contained transparent start="{\%(@code\>\)\@!" end="}" contains=javaCodeSkipBlock,javaDocCodeTag
   syn region javaDocCodeTag	contained start="{@code\>" end="}" contains=javaDocCodeTag,javaCodeSkipBlock
+
   exec 'syn region javaDocSnippetTagAttr contained transparent matchgroup=javaHtmlArg start=/\<\%(class\|file\|id\|lang\|region\)\%(\s*=\)\@=/ matchgroup=javaHtmlString end=/:$/ end=/\%(=\s*\)\@' . s:ff.Peek('80', '') . '<=\%("[^"]\+"\|' . "\x27[^\x27]\\+\x27" . '\|\%([.\\/-]\|\k\)\+\)/ nextgroup=javaDocSnippetTagAttr skipwhite skipnl'
   syn region javaSnippetSkipBlock contained transparent start="{\%(@snippet\>\)\@!" end="}" contains=javaSnippetSkipBlock,javaDocSnippetTag,javaCommentMarkupTag
   syn region javaDocSnippetTag	contained start="{@snippet\>" end="}" contains=javaDocSnippetTag,javaSnippetSkipBlock,javaDocSnippetTagAttr,javaCommentMarkupTag
 
   syntax case match
   hi def link javaDocComment		Comment
+  hi def link javaDocSeeTagStar		javaDocComment
   hi def link javaCommentTitle		SpecialComment
-  hi def link javaDocTags		Special
-  hi def link javaDocCodeTag		Special
-  hi def link javaDocSnippetTag		Special
-  hi def link javaDocSeeTagParam	Function
   hi def link javaDocParam		Function
+
+  hi def link javaDocAuthorTag		Special
+  hi def link javaDocCodeTag		Special
+  hi def link javaDocDeprecatedTag	Special
+  hi def link javaDocDocRootTag		Special
+  hi def link javaDocExceptionTag	Special
+  hi def link javaDocHiddenTag		Special
+  hi def link javaDocIndexTag		Special
+  hi def link javaDocInheritDocTag	Special
+  hi def link javaDocLinkTag		Special
+  hi def link javaDocLinkplainTag	Special
+  hi def link javaDocLiteralTag		Special
+  hi def link javaDocParamTag		Special
+  hi def link javaDocReturnTag		Special
+  hi def link javaDocSeeTag		Special
+  hi def link javaDocSeeTag1		String
+  hi def link javaDocSeeTag2		Special
+  hi def link javaDocSeeTag3		Function
+  hi def link javaDocSerialTag		Special
+  hi def link javaDocSerialDataTag	Special
+  hi def link javaDocSerialFieldTag	Special
+  hi def link javaDocSinceTag		Special
+  hi def link javaDocSnippetTag		Special
+  hi def link javaDocSpecTag		Special
+  hi def link javaDocSystemPropertyTag	Special
+  hi def link javaDocThrowsTag		Special
+  hi def link javaDocValueTag		Special
+  hi def link javaDocVersionTag		Special
 endif
 
 " match the special comment /**/

--- a/runtime/syntax/spec.vim
+++ b/runtime/syntax/spec.vim
@@ -4,6 +4,7 @@
 " Maintainer:  Igor Gnatenko i.gnatenko.brain@gmail.com
 " Former Maintainer:  Donovan Rebbechi elflord@panix.com (until March 2014)
 " Last Change: 2020 May 25
+"  2024 Sep 10 by Vim Project: add file triggers support, #15569
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -111,7 +112,7 @@ syn region specDescriptionArea matchgroup=specSection start='^%description' end=
 syn region specPackageArea matchgroup=specSection start='^%package' end='^%'me=e-1 contains=specPackageOpts,specPreAmble,specComment
 
 "%% Scripts Section %%
-syn region specScriptArea matchgroup=specSection start='^%\(prep\|generate_buildrequires\|conf\|build\|install\|clean\|check\|pre\|postun\|preun\|post\|posttrans\)\>' skip='^%{\|^%\(define\|patch\d*\|configure\|GNUconfigure\|setup\|autosetup\|autopatch\|find_lang\|make_build\|makeinstall\|make_install\)\>' end='^%'me=e-1 contains=specSpecialVariables,specVariables,@specCommands,specVariables,shDo,shFor,shCaseEsac,specNoNumberHilite,specCommandOpts,shComment,shIf,specSpecialChar,specMacroIdentifier,specSectionMacroArea,specSectionMacroBracketArea,shOperator,shQuote1,shQuote2
+syn region specScriptArea matchgroup=specSection start='^%\(prep\|generate_buildrequires\|conf\|build\|install\|clean\|check\|pre\|postun\|preun\|post\|posttrans\|filetriggerin\|filetriggerun\|filetriggerpostun\|transfiletriggerin\|transfiletriggerun\|transfiletriggerpostun\)\>' skip='^%{\|^%\(define\|patch\d*\|configure\|GNUconfigure\|setup\|autosetup\|autopatch\|find_lang\|make_build\|makeinstall\|make_install\)\>' end='^%'me=e-1 contains=specSpecialVariables,specVariables,@specCommands,specVariables,shDo,shFor,shCaseEsac,specNoNumberHilite,specCommandOpts,shComment,shIf,specSpecialChar,specMacroIdentifier,specSectionMacroArea,specSectionMacroBracketArea,shOperator,shQuote1,shQuote2
 
 "%% Changelog Section %%
 syn region specChangelogArea matchgroup=specSection start='^%changelog' end='^%'me=e-1 contains=specEmail,specURL,specWeekday,specMonth,specNumber,specComment,specLicense


### PR DESCRIPTION
- **vim-patch:7cc0e91: runtime(groff): Add compiler plugin for groff**
- **vim-patch:d30ffdc: runtime(pandoc): Update compiler plugin to use actual 'spelllang'**
- **vim-patch:c0982f9: runtime(dosini): Update syntax script, spellcheck comments only**
- **vim-patch:a9ae38d: runtime(java): Recognise all available standard doclet tags**
- **vim-patch:077d1d2: runtime(make): add compiler/make.vim to reset compiler plugin settings**
- **vim-patch:2241f08: runtime(spec): add file triggers to syntax script**
- **vim-patch:e401576: runtime(spec): Recognize epoch when making spec changelog in ftplugin**
- **vim-patch:fc72a2f: runtime(idlang): update syntax script**
