### PR TITLE
feat(log): use "ui" as default name for TUI client

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -189,7 +189,8 @@ TREESITTER
 
 TUI
 
-• TODO
+• |log| messages written by the builtin UI client (TUI, |--remote-ui|) are
+  now prefixed with "ui" instead of "?".
 
 UI
 

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -53,7 +53,7 @@ bool server_init(const char *listen_addr)
 
   int rv = server_start(listen_addr);
 
-  // TODO(justinmk): this is for logging_spec. Can remove this after nvim_log #7062 is merged.
+  // TODO(justinmk): this is for log_spec. Can remove this after nvim_log #7062 is merged.
   if (os_env_exists("__NVIM_TEST_LOG")) {
     ELOG("test log message");
   }

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -100,7 +100,7 @@ static void reset_cursorhold_wait(int tb_change_cnt)
 ///
 /// Originally based on the Vim `mch_inchar` function.
 ///
-/// @param buf Buffer to store read input.
+/// @param buf Buffer to store consumed input.
 /// @param maxlen Maximum bytes to read into `buf`, or 0 to skip reading.
 /// @param ms Timeout in milliseconds. -1 for indefinite wait, 0 for no wait.
 /// @param tb_change_cnt Used to detect when typeahead changes.
@@ -493,7 +493,7 @@ static TriState inbuf_poll(int ms, MultiQueue *events)
     blocking = true;
     multiqueue_process_events(ch_before_blocking_events);
   }
-  DLOG("blocking... events=%d pending=%d", !!events, pending_events(events));
+  DLOG("blocking... events=%s", !!events ? "true" : "false");
   LOOP_PROCESS_EVENTS_UNTIL(&main_loop, NULL, ms, os_input_ready(events) || input_eof);
   blocking = false;
 

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -22,6 +22,7 @@
 #include "nvim/memory_defs.h"
 #include "nvim/msgpack_rpc/channel.h"
 #include "nvim/msgpack_rpc/channel_defs.h"
+#include "nvim/os/os.h"
 #include "nvim/os/os_defs.h"
 #include "nvim/tui/tui.h"
 #include "nvim/tui/tui_defs.h"
@@ -125,6 +126,11 @@ void ui_client_run(bool remote_ui)
   tui_start(&tui, &width, &height, &term, &rgb);
 
   ui_client_attach(width, height, term, rgb);
+
+  // TODO(justinmk): this is for log_spec. Can remove this after nvim_log #7062 is merged.
+  if (os_env_exists("__NVIM_TEST_LOG")) {
+    ELOG("test log message");
+  }
 
   // os_exit() will be invoked when the client channel detaches
   while (true) {

--- a/src/nvim/ui_client.h
+++ b/src/nvim/ui_client.h
@@ -14,7 +14,7 @@ EXTERN size_t grid_line_buf_size INIT( = 0);
 EXTERN schar_T *grid_line_buf_char INIT( = NULL);
 EXTERN sattr_T *grid_line_buf_attr INIT( = NULL);
 
-// ID of the ui client channel. If zero, the client is not running.
+// Client-side UI channel. Zero during early startup or if not a (--remote-ui) UI client.
 EXTERN uint64_t ui_client_channel_id INIT( = 0);
 
 // exit status from embedded nvim process


### PR DESCRIPTION
(Extracted from https://github.com/neovim/neovim/pull/30319 )

The default "session name" for the builtin TUI is "ui".

before:

    INF 2024-09-10T14:57:35.385 hello.sock os_exit:692: Nvim exit: 1
    INF 2024-09-10T14:57:35.388 ?.4543     os_exit:692: Nvim exit: 1

after:

    INF 2024-09-10T14:59:19.919 hello.sock os_exit:692: Nvim exit: 1
    INF 2024-09-10T14:59:19.922 ui.5684    os_exit:692: Nvim exit: 1