### PR TITLE
fix: replace NVIM with Nvim in default titlestring

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6713,7 +6713,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 	When on, the title of the window will be set to the value of
 	'titlestring' (if it is not empty), or to:
-		filename [+=-] (path) - NVIM
+		filename [+=-] (path) - Nvim
 	Where:
 		filename	the name of the file being edited
 		-		indicates the file cannot be modified, 'ma' off
@@ -6721,7 +6721,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		=		indicates the file is read-only
 		=+		indicates the file is read-only and modified
 		(path)		is the path of the file being edited
-		- NVIM		the server name |v:servername| or "NVIM"
+		- Nvim		the server name |v:servername| or "Nvim"
 
 							*'titlelen'*
 'titlelen'		number	(default 85)

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -7255,7 +7255,7 @@ vim.go.tm = vim.go.timeoutlen
 
 --- When on, the title of the window will be set to the value of
 --- 'titlestring' (if it is not empty), or to:
---- 	filename [+=-] (path) - NVIM
+--- 	filename [+=-] (path) - Nvim
 --- Where:
 --- 	filename	the name of the file being edited
 --- 	-		indicates the file cannot be modified, 'ma' off
@@ -7263,7 +7263,7 @@ vim.go.tm = vim.go.timeoutlen
 --- 	=		indicates the file is read-only
 --- 	=+		indicates the file is read-only and modified
 --- 	(path)		is the path of the file being edited
---- 	- NVIM		the server name `v:servername` or "NVIM"
+--- 	- Nvim		the server name `v:servername` or "Nvim"
 ---
 --- @type boolean
 vim.o.title = false

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3338,7 +3338,7 @@ void maketitle(void)
 
 #define SPACE_FOR_FNAME (sizeof(buf) - 100)
 #define SPACE_FOR_DIR   (sizeof(buf) - 20)
-#define SPACE_FOR_ARGNR (sizeof(buf) - 10)  // At least room for " - NVIM".
+#define SPACE_FOR_ARGNR (sizeof(buf) - 10)  // At least room for " - Nvim".
       char *buf_p = buf;
       if (curbuf->b_fname == NULL) {
         const size_t size = xstrlcpy(buf_p, _("[No Name]"),
@@ -3412,7 +3412,7 @@ void maketitle(void)
 
       append_arg_number(curwin, buf_p, (int)(SPACE_FOR_ARGNR - (size_t)(buf_p - buf)));
 
-      xstrlcat(buf_p, " - NVIM", (sizeof(buf) - (size_t)(buf_p - buf)));
+      xstrlcat(buf_p, " - Nvim", (sizeof(buf) - (size_t)(buf_p - buf)));
 
       if (maxlen > 0) {
         // Make it shorter by removing a bit in the middle.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9047,7 +9047,7 @@ return {
       desc = [=[
         When on, the title of the window will be set to the value of
         'titlestring' (if it is not empty), or to:
-        	filename [+=-] (path) - NVIM
+        	filename [+=-] (path) - Nvim
         Where:
         	filename	the name of the file being edited
         	-		indicates the file cannot be modified, 'ma' off
@@ -9055,11 +9055,11 @@ return {
         	=		indicates the file is read-only
         	=+		indicates the file is read-only and modified
         	(path)		is the path of the file being edited
-        	- NVIM		the server name |v:servername| or "NVIM"
+        	- Nvim		the server name |v:servername| or "Nvim"
       ]=],
       full_name = 'title',
       scope = { 'global' },
-      short_desc = N_('Vim set the title of the window'),
+      short_desc = N_('set the title of the window'),
       type = 'boolean',
       varname = 'p_title',
     },

--- a/test/functional/ui/title_spec.lua
+++ b/test/functional/ui/title_spec.lua
@@ -22,7 +22,7 @@ describe('title', function()
   end)
 
   it('has correct default title with unnamed file', function()
-    local expected = '[No Name] - NVIM'
+    local expected = '[No Name] - Nvim'
     command('set title')
     screen:expect(function()
       eq(expected, screen.title)
@@ -30,7 +30,7 @@ describe('title', function()
   end)
 
   it('has correct default title with named file', function()
-    local expected = (is_os('win') and 'myfile (C:\\mydir) - NVIM' or 'myfile (/mydir) - NVIM')
+    local expected = (is_os('win') and 'myfile (C:\\mydir) - Nvim' or 'myfile (/mydir) - Nvim')
     command('set title')
     command(is_os('win') and 'file C:\\mydir\\myfile' or 'file /mydir/myfile')
     screen:expect(function()
@@ -41,7 +41,7 @@ describe('title', function()
   describe('is not changed by', function()
     local file1 = is_os('win') and 'C:\\mydir\\myfile1' or '/mydir/myfile1'
     local file2 = is_os('win') and 'C:\\mydir\\myfile2' or '/mydir/myfile2'
-    local expected = (is_os('win') and 'myfile1 (C:\\mydir) - NVIM' or 'myfile1 (/mydir) - NVIM')
+    local expected = (is_os('win') and 'myfile1 (C:\\mydir) - Nvim' or 'myfile1 (/mydir) - Nvim')
     local buf2
 
     before_each(function()


### PR DESCRIPTION
NVIM is improper branding.

@justinmk I'll let you decide if it should be `Nvim` or `nvim`.