### PR TITLE
fix(lsp): handle empty call hierarchy items

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -447,11 +447,9 @@ function M.document_symbol(opts)
   request_with_opts(ms.textDocument_documentSymbol, params, opts)
 end
 
---- @param call_hierarchy_items lsp.CallHierarchyItem[]?
+--- @param call_hierarchy_items lsp.CallHierarchyItem[]
+--- @return lsp.CallHierarchyItem?
 local function pick_call_hierarchy_item(call_hierarchy_items)
-  if not call_hierarchy_items then
-    return
-  end
   if #call_hierarchy_items == 1 then
     return call_hierarchy_items[1]
   end
@@ -476,7 +474,7 @@ local function call_hierarchy(method)
       vim.notify(err.message, vim.log.levels.WARN)
       return
     end
-    if not result then
+    if not result or vim.tbl_isempty(result) then
       vim.notify('No item resolved', vim.log.levels.WARN)
       return
     end


### PR DESCRIPTION
Ensure that the function `pick_call_hierarchy_item` correctly handles the case where `call_hierarchy_items` is nil or an empty table. This prevents erroneous behavior when the function is called with an empty list.

### Steps to reproduce
Using steps from https://github.com/neovim/neovim/issues/30122
Replace step 1 with: Place the cursor on the call to foo_func() (63go)

### Expected result
To not get a input prompt with no valid selections

### Actual result
Get an input prompt with no valid selections
![image](https://github.com/user-attachments/assets/4322bd23-6c60-44f9-b564-e1104f10ecc0)
