### PR TITLE
vim-patch:9.1.0725: filetype: swiftinterface files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1164,6 +1164,7 @@ local extension = {
   svelte = 'svelte',
   svg = 'svg',
   swift = 'swift',
+  swiftinterface = 'swift',
   swig = 'swig',
   swg = 'swig',
   sys = detect.sys,

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -710,7 +710,7 @@ func s:GetFilenameChecks() abort
     \ 'svg': ['file.svg'],
     \ 'svn': ['svn-commitfile.tmp', 'svn-commit-file.tmp', 'svn-commit.tmp'],
     \ 'swayconfig': ['/home/user/.sway/config', '/home/user/.config/sway/config', '/etc/sway/config', '/etc/xdg/sway/config'],
-    \ 'swift': ['file.swift'],
+    \ 'swift': ['file.swift', 'file.swiftinterface'],
     \ 'swiftgyb': ['file.swift.gyb'],
     \ 'swig': ['file.swg', 'file.swig'],
     \ 'sysctl': ['/etc/sysctl.conf', '/etc/sysctl.d/file.conf', 'any/etc/sysctl.conf', 'any/etc/sysctl.d/file.conf'],


### PR DESCRIPTION
#### vim-patch:9.1.0725: filetype: swiftinterface files are not recognized

Problem:  filetype: swiftinterface files are not recognized
Solution: Detect '*.swiftinterface' files as swift filetype
          (LosFarmosCTL)

closes: vim/vim#15658

https://github.com/vim/vim/commit/03cac4b70d819148f4b4404701b8f331a3af0fb6

Co-authored-by: LosFarmosCTL <80157503+LosFarmosCTL@users.noreply.github.com>