### PR TITLE
docs(treesitter): some functions are only valid for registered parsers

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -970,7 +970,7 @@ add({lang}, {opts})                            *vim.treesitter.language.add()*
                   language to load
 
 get_filetypes({lang})                *vim.treesitter.language.get_filetypes()*
-    Get the filetypes associated with the parser named {lang}.
+    Get the filetypes associated with the registered parser named {lang}.
 
     Parameters: ~
       • {lang}  (`string`) Name of parser
@@ -979,6 +979,7 @@ get_filetypes({lang})                *vim.treesitter.language.get_filetypes()*
         (`string[]`) filetypes
 
 get_lang({filetype})                      *vim.treesitter.language.get_lang()*
+    Get the registered parser name associated with the provided filetype.
 
     Parameters: ~
       • {filetype}  (`string`)

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -7,7 +7,7 @@ local ft_to_lang = {
   help = 'vimdoc',
 }
 
---- Get the filetypes associated with the parser named {lang}.
+--- Get the filetypes associated with the registered parser named {lang}.
 --- @param lang string Name of parser
 --- @return string[] filetypes
 function M.get_filetypes(lang)
@@ -20,6 +20,7 @@ function M.get_filetypes(lang)
   return r
 end
 
+--- Get the registered parser name associated with the provided filetype.
 --- @param filetype string
 --- @return string|nil
 function M.get_lang(filetype)


### PR DESCRIPTION
We do not load parsers automatically, even if the user has a `parser/lang.so`, `get_lang` will return `nil` before it is loaded or registered.

Edit: I mean `get_lang` instead of `get_parser`.