### PR TITLE
fix(lsp): resolve blob to string error in semantic tokens callback

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -684,7 +684,7 @@ function Client:_request(method, params, handler, bufnr)
       params = params,
       version = version,
     }
-    handler(err, result, context)
+    pcall(handler, err, result, context)
   end, function(request_id)
     local request = self.requests[request_id]
     request.type = 'complete'


### PR DESCRIPTION
Hello everyone!

I put together this PR, which is my first contribution to Neovim, without being sure if I should have first created an issue or proposed the PR directly and described the issue here. Please excuse any possible mistakes or oversights on my part.

This PR fixes an issue that I've had for sometime, after successfully migrating from `nvim-cmp` to Neovim's builtin completion. More specifically, when I would trigger the omni completion via `CTRL_X CTRL_O` and try to select a `for ...` snippet, I would get this error message:

![unnamed](https://github.com/user-attachments/assets/3977648c-fd5d-4b5b-b6b9-163a6d5a589d)

After, investigating the stacktrace, I managed to fix the issue locally, by wraping the `handler(err, result, context)` call with a `pcall`, modifying this chunk from the `runtime/lua/vim/lsp/client.lua` file:
https://github.com/neovim/neovim/blob/deac7df80a1491ae65b68a1a1047902bcd775adc/runtime/lua/vim/lsp/client.lua#L679-L688

### Neovim version
```
NVIM v0.11.0-dev-deac7df
Build type: Debug
LuaJIT 2.1.1724512491
Run "nvim -V1 -v" for more info
```

### Steps to reproduce using "nvim -u minimal_config.lua"
> Make sure that `lua-language-server` is properly installed in your system and accessible in your `$PATH`.

For the purposes of easily reproducing the bug, I've created this simple `minimal_config.lua` file, after stumbling across #30122. 

First things first, create the `minimal_config.lua` file (preferably in your current working directory) and paste there the following:
```lua
local pattern = 'lua'
local cmd = {'lua-language-server'}

vim.api.nvim_create_autocmd('FileType', {
  pattern = pattern,
  callback = function()
    vim.lsp.start({
      name = 'testing-ls',
      cmd = cmd,
    })
  end
})
```
Finally, create a new file called `test.lua` (that's also in your current working directory) and paste there the following:
```lua
-- To trigger the bug, please follow these steps:
-- 1. Uncomment the `fo` line.
-- 2. Place your cursor at the end of the line.
-- 3. Go into insert mode by pressing `a`.
-- 4. Press CTRL-X CTRL-O to activate the completion.
--
-- IMPORTANT: As far as I'm aware this only works with `for ...` snippets,
-- so when testing make sure you select something relevant.

-- fo
```

Now, you should be able to reproduce the bug by running:
```
nvim --clean -u minimal_config.lua test.lua
```
And following the instructions on screen.

### Expected behavior
Neovim should be able to select any option that omnifunc serves inside the pmenu without throwing an exception when coming across a `for ...` snippet.

### Actual behavior
Uppon triggering omni-completion using `CTRL_X CTRL_O`, and selecting a `for ...` snippet, neovim throws this exception:
```
Error executing vim.schedule lua callback: ...local/share/nvim/runtime/lua/vim/lsp/semantic_tokens.lua:304: Vim:E976: Using a Blob as a String 
stack traceback:
[builtin#36]: at 0x5cfd722462d0
...local/share/nvim/runtime/lua/vim/lsp/semantic_tokens.lua:304: in function 'handler' /usr/local/share/nvim/runtime/lua/vim/lsp/client.lua:687: in function " vimLeditor.lua: in function <vimLeditor.lua:0> 
Press ENTER or type command to continue 
``` 

Please let me know if there are any adjustments or additional steps I should take. I'm happy to provide more information or make changes based on feedback. Thank you for your time!