### PR TITLE
ci: don't add reviewers for PRs created by a bot

### DIFF
--- a/.github/workflows/reviewers_add.yml
+++ b/.github/workflows/reviewers_add.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
 jobs:
   request-reviewer:
-    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && !endsWith(github.actor, '[bot]')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
This will ensure automatic backports created by the backport action does
not request reviewers (since the commit in question has already been
vetted and merged), but manual backports created by users does request
reviewers as these commits has not been vetted previously.