### PR TITLE
ci: add `needs:backport` label on backport PRs with conflict

### DIFF
--- a/.github/workflows/backport.yml
+++ b/.github/workflows/backport.yml
@@ -27,6 +27,18 @@ jobs:
           label_pattern: "^ci:backport ([^ ]+)$"
           github_token: ${{ steps.app-token.outputs.token }}
 
+      - name: Create failed backport label
+        if: ${{ steps.backport.outputs.was_successful == 'false' }}
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.addLabels({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              labels: ['needs:backport']
+            })
+
       - name: Enable automerge
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
This makes it easy to keep track of which backport PRs have failed and
need manual intervention to fix.
