### PR TITLE
refactor(tests): rename terminal/testutil.lua => testterm.lua

### DIFF
--- a/test/client/session.lua
+++ b/test/client/session.lua
@@ -114,6 +114,7 @@ function Session:request(method, ...)
   return true, result
 end
 
+--- Runs the event loop.
 function Session:run(request_cb, notification_cb, setup_cb, timeout)
   local function on_request(method, args, response)
     coroutine_exec(request_cb, method, args, function(status, result, flag)

--- a/test/functional/autocmd/focus_spec.lua
+++ b/test/functional/autocmd/focus_spec.lua
@@ -1,6 +1,6 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
-local tt = require('test.functional.terminal.testutil')
+local tt = require('test.functional.testterm')
 
 local clear = n.clear
 local feed_command = n.feed_command

--- a/test/functional/autocmd/termxx_spec.lua
+++ b/test/functional/autocmd/termxx_spec.lua
@@ -1,6 +1,6 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
-local tt = require('test.functional.terminal.testutil')
+local tt = require('test.functional.testterm')
 local uv = vim.uv
 
 local clear, command, testprg = n.clear, n.command, n.testprg
@@ -199,7 +199,7 @@ end)
 
 describe('autocmd TextChangedT', function()
   clear()
-  local screen = tt.screen_setup()
+  local screen = tt.setup_screen()
 
   it('works', function()
     command('autocmd TextChangedT * ++once let g:called = 1')

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -1,7 +1,7 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
-local tt = require('test.functional.terminal.testutil')
+local tt = require('test.functional.testterm')
 
 local clear = n.clear
 local eq = t.eq

--- a/test/functional/core/log_spec.lua
+++ b/test/functional/core/log_spec.lua
@@ -1,6 +1,6 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
-local tt = require('test.functional.terminal.testutil')
+local tt = require('test.functional.testterm')
 
 local assert_log = t.assert_log
 local clear = n.clear

--- a/test/functional/terminal/altscreen_spec.lua
+++ b/test/functional/terminal/altscreen_spec.lua
@@ -1,7 +1,7 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 
-local tt = require('test.functional.terminal.testutil')
+local tt = require('test.functional.testterm')
 local clear, eq, api = n.clear, t.eq, n.api
 local feed = n.feed
 local feed_data = tt.feed_data
@@ -17,7 +17,7 @@ describe(':terminal altscreen', function()
 
   before_each(function()
     clear()
-    screen = tt.screen_setup()
+    screen = tt.setup_screen()
     feed_data({
       'line1',
       'line2',

--- a/test/functional/terminal/api_spec.lua
+++ b/test/functional/terminal/api_spec.lua
@@ -1,7 +1,7 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 
-local tt = require('test.functional.terminal.testutil')
+local tt = require('test.functional.testterm')
 local ok = t.ok
 
 if t.skip(t.is_os('win')) then

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -1,7 +1,7 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
-local tt = require('test.functional.terminal.testutil')
+local tt = require('test.functional.testterm')
 
 local assert_alive = n.assert_alive
 local feed, clear = n.feed, n.clear
@@ -29,7 +29,7 @@ describe(':terminal buffer', function()
   before_each(function()
     clear()
     command('set modifiable swapfile undolevels=20')
-    screen = tt.screen_setup()
+    screen = tt.setup_screen()
   end)
 
   it('terminal-mode forces various options', function()
@@ -574,7 +574,7 @@ if is_os('win') then
       feed_command('set modifiable swapfile undolevels=20')
       poke_eventloop()
       local cmd = { 'cmd.exe', '/K', 'PROMPT=$g$s' }
-      screen = tt.screen_setup(nil, cmd)
+      screen = tt.setup_screen(nil, cmd)
     end)
 
     it('"put" operator sends data normally', function()

--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -1,7 +1,7 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
-local tt = require('test.functional.terminal.testutil')
+local tt = require('test.functional.testterm')
 
 local feed, clear = n.feed, n.clear
 local testprg, command = n.testprg, n.command
@@ -18,7 +18,7 @@ describe(':terminal cursor', function()
 
   before_each(function()
     clear()
-    screen = tt.screen_setup()
+    screen = tt.setup_screen()
   end)
 
   it('moves the screen cursor when focused', function()

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -1,7 +1,7 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
-local tt = require('test.functional.terminal.testutil')
+local tt = require('test.functional.testterm')
 
 local feed, clear = n.feed, n.clear
 local api = n.api

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -1,7 +1,7 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 
-local tt = require('test.functional.terminal.testutil')
+local tt = require('test.functional.testterm')
 local clear, eq, eval = n.clear, t.eq, n.eval
 local feed, api, command = n.feed, n.api, n.command
 local feed_data = tt.feed_data
@@ -14,7 +14,7 @@ describe(':terminal mouse', function()
   before_each(function()
     clear()
     api.nvim_set_option_value('statusline', '==========', {})
-    screen = tt.screen_setup()
+    screen = tt.setup_screen()
     command('highlight StatusLine NONE')
     command('highlight StatusLineNC NONE')
     command('highlight StatusLineTerm NONE')

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -1,7 +1,7 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
-local tt = require('test.functional.terminal.testutil')
+local tt = require('test.functional.testterm')
 
 local clear, eq = n.clear, t.eq
 local feed, testprg = n.feed, n.testprg
@@ -22,7 +22,7 @@ describe(':terminal scrollback', function()
 
   before_each(function()
     clear()
-    screen = tt.screen_setup(nil, nil, 30)
+    screen = tt.setup_screen(nil, nil, 30)
   end)
 
   describe('when the limit is exceeded', function()
@@ -399,9 +399,9 @@ describe("'scrollback' option", function()
   it('set to 0 behaves as 1', function()
     local screen
     if is_os('win') then
-      screen = tt.screen_setup(nil, { 'cmd.exe' }, 30)
+      screen = tt.setup_screen(nil, { 'cmd.exe' }, 30)
     else
-      screen = tt.screen_setup(nil, { 'sh' }, 30)
+      screen = tt.setup_screen(nil, { 'sh' }, 30)
     end
 
     api.nvim_set_option_value('scrollback', 0, {})
@@ -416,10 +416,10 @@ describe("'scrollback' option", function()
     local screen
     if is_os('win') then
       command([[let $PROMPT='$$']])
-      screen = tt.screen_setup(nil, { 'cmd.exe' }, 30)
+      screen = tt.setup_screen(nil, { 'cmd.exe' }, 30)
     else
       command('let $PS1 = "$"')
-      screen = tt.screen_setup(nil, { 'sh' }, 30)
+      screen = tt.setup_screen(nil, { 'sh' }, 30)
     end
 
     api.nvim_set_option_value('scrollback', 200, {})
@@ -480,8 +480,8 @@ describe("'scrollback' option", function()
   end)
 
   it('deletes extra lines immediately', function()
-    -- Scrollback is 10 on screen_setup
-    local screen = tt.screen_setup(nil, nil, 30)
+    -- Scrollback is 10 on setup_screen
+    local screen = tt.setup_screen(nil, nil, 30)
     local lines = {}
     for i = 1, 30 do
       table.insert(lines, 'line' .. tostring(i))

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -7,7 +7,7 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
-local tt = require('test.functional.terminal.testutil')
+local tt = require('test.functional.testterm')
 
 local eq = t.eq
 local feed_data = tt.feed_data
@@ -2111,7 +2111,7 @@ describe('TUI', function()
     finally(function()
       os.remove('testF')
     end)
-    local screen = tt.screen_setup(
+    local screen = tt.setup_screen(
       0,
       ('"%s" -u NONE -i NONE --cmd "set noswapfile noshowcmd noruler" --cmd "normal iabc" > /dev/null 2>&1 && cat testF && rm testF'):format(
         nvim_prog

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -1,7 +1,7 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 
-local tt = require('test.functional.terminal.testutil')
+local tt = require('test.functional.testterm')
 local feed_data = tt.feed_data
 local feed, clear = n.feed, n.clear
 local poke_eventloop = n.poke_eventloop
@@ -37,7 +37,7 @@ describe(':terminal window', function()
 
   before_each(function()
     clear()
-    screen = tt.screen_setup()
+    screen = tt.setup_screen()
   end)
 
   it('sets topline correctly #8556', function()
@@ -198,7 +198,7 @@ describe(':terminal with multigrid', function()
 
   before_each(function()
     clear()
-    screen = tt.screen_setup(0, nil, 50, nil, { ext_multigrid = true })
+    screen = tt.setup_screen(0, nil, 50, nil, { ext_multigrid = true })
   end)
 
   it('resizes to requested size', function()

--- a/test/functional/terminal/window_split_tab_spec.lua
+++ b/test/functional/terminal/window_split_tab_spec.lua
@@ -1,7 +1,7 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 
-local tt = require('test.functional.terminal.testutil')
+local tt = require('test.functional.testterm')
 local assert_alive = n.assert_alive
 local clear = n.clear
 local feed = n.feed
@@ -22,7 +22,7 @@ describe(':terminal', function()
     -- set the statusline to a constant value because of variables like pid
     -- and current directory and to improve visibility of splits
     api.nvim_set_option_value('statusline', '==========', {})
-    screen = tt.screen_setup(3)
+    screen = tt.setup_screen(3)
     command('highlight StatusLine NONE')
     command('highlight StatusLineNC NONE')
     command('highlight StatusLineTerm NONE')

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -250,6 +250,8 @@ function M.set_method_error(err)
   method_error = err
 end
 
+--- Runs the event loop of the given session.
+---
 --- @param lsession test.Session
 --- @param request_cb function?
 --- @param notification_cb function?
@@ -296,6 +298,7 @@ function M.run_session(lsession, request_cb, notification_cb, setup_cb, timeout)
   return lsession.eof_err
 end
 
+--- Runs the event loop of the current global session.
 function M.run(request_cb, notification_cb, setup_cb, timeout)
   assert(session)
   return M.run_session(session, request_cb, notification_cb, setup_cb, timeout)

--- a/test/functional/ui/hlstate_spec.lua
+++ b/test/functional/ui/hlstate_spec.lua
@@ -1,7 +1,7 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
-local tt = require('test.functional.terminal.testutil')
+local tt = require('test.functional.testterm')
 
 local clear, insert = n.clear, n.insert
 local command = n.command

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -1,7 +1,7 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
-local tt = require('test.functional.terminal.testutil')
+local tt = require('test.functional.testterm')
 
 local assert_alive = n.assert_alive
 local mkdir, write_file, rmdir = t.mkdir, t.write_file, n.rmdir


### PR DESCRIPTION
This module is generally used by any tests that need the full Nvim TUI instead of `screen.lua`. Thus it should live in `functional/` instead of in `functional/terminal/`.