### PR TITLE
vim-patch:9.1.0728: [security]: heap-use-after-free in garbage collection with location list user data

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -6875,7 +6875,8 @@ bool set_ref_in_quickfix(int copyID)
       // In a location list window and none of the other windows is
       // referring to this location list. Mark the location list
       // context as still in use.
-      if (mark_quickfix_ctx(win->w_llist_ref, copyID)) {
+      if (mark_quickfix_ctx(win->w_llist_ref, copyID)
+          || mark_quickfix_user_data(win->w_llist_ref, copyID)) {
         return true;
       }
     }

--- a/test/old/testdir/test_quickfix.vim
+++ b/test/old/testdir/test_quickfix.vim
@@ -4071,11 +4071,23 @@ func Test_ll_window_ctx()
   enew | only
 endfunc
 
+" Similar to the problem above, but for user data.
+func Test_ll_window_user_data()
+  call setloclist(0, [#{bufnr: bufnr(), user_data: {}}])
+  lopen
+  wincmd t
+  close
+  call test_garbagecollect_now()
+  call feedkeys("\<CR>", 'tx')
+  call test_garbagecollect_now()
+  %bwipe!
+endfunc
+
 " The following test used to crash vim
 func Test_lfile_crash()
   sp Xtest
   au QuickFixCmdPre * bw
-  call assert_fails('lfile', 'E40')
+  call assert_fails('lfile', 'E40:')
   au! QuickFixCmdPre
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.0728: [security]: heap-use-after-free in garbage collection with location list user data

Problem:  heap-use-after-free in garbage collection with location list
          user data.
Solution: Mark user data as in use when no other window is referencing
          the location list (zeertzjq)

fixes: neovim/neovim#30371
closes: vim/vim#15683

https://github.com/vim/vim/commit/be4bd189d23854ddf1d85ad291d8f7ad3f22b7a0