### PR TITLE
vim-patch:9.1.{0729,0730}

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -170,23 +170,21 @@ static void margin_columns_win(win_T *wp, int *left_col, int *right_col)
   // cache previous calculations depending on w_virtcol
   static int saved_w_virtcol;
   static win_T *prev_wp;
+  static int prev_width1;
+  static int prev_width2;
   static int prev_left_col;
   static int prev_right_col;
-  static int prev_col_off;
 
   int cur_col_off = win_col_off(wp);
-  int width1;
-  int width2;
+  int width1 = wp->w_width_inner - cur_col_off;
+  int width2 = width1 + win_col_off2(wp);
 
   if (saved_w_virtcol == wp->w_virtcol && prev_wp == wp
-      && prev_col_off == cur_col_off) {
+      && prev_width1 == width1 && prev_width2 == width2) {
     *right_col = prev_right_col;
     *left_col = prev_left_col;
     return;
   }
-
-  width1 = wp->w_width_inner - cur_col_off;
-  width2 = width1 + win_col_off2(wp);
 
   *left_col = 0;
   *right_col = width1;
@@ -202,8 +200,9 @@ static void margin_columns_win(win_T *wp, int *left_col, int *right_col)
   prev_left_col = *left_col;
   prev_right_col = *right_col;
   prev_wp = wp;
+  prev_width1 = width1;
+  prev_width2 = width2;
   saved_w_virtcol = wp->w_virtcol;
-  prev_col_off = cur_col_off;
 }
 
 /// Put a single char from an UTF-8 buffer into a line buffer.

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -189,7 +189,7 @@ static void margin_columns_win(win_T *wp, int *left_col, int *right_col)
   *left_col = 0;
   *right_col = width1;
 
-  if (wp->w_virtcol >= (colnr_T)width1) {
+  if (wp->w_virtcol >= (colnr_T)width1 && width2 > 0) {
     *right_col = width1 + ((wp->w_virtcol - width1) / width2 + 1) * width2;
   }
   if (wp->w_virtcol >= (colnr_T)width1 && width2 > 0) {

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -1078,6 +1078,44 @@ describe('CursorLine and CursorLineNr highlights', function()
     ]])
   end)
 
+  -- oldtest: Test_cursorline_screenline_resize()
+  it("'cursorlineopt' screenline is updated on window resize", function()
+    local screen = Screen.new(75, 8)
+    screen:attach()
+    exec([[
+      50vnew
+      call setline(1, repeat('xyz ', 30))
+      setlocal number cursorline cursorlineopt=screenline
+      normal! $
+    ]])
+    screen:expect([[
+      {8:  1 }xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xy│                        |
+      {8:    }z xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz │{1:~                       }|
+      {8:    }{21:xyz xyz xyz xyz xyz xyz xyz^                   }│{1:~                       }|
+      {1:~                                                 }│{1:~                       }|*3
+      {3:[No Name] [+]                                      }{2:[No Name]               }|
+                                                                                 |
+    ]])
+    command('vertical resize -4')
+    screen:expect([[
+      {8:  1 }xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xy│                            |
+      {8:    }z xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz │{1:~                           }|
+      {8:    }{21:xyz xyz xyz xyz xyz xyz xyz xyz xyz^       }│{1:~                           }|
+      {1:~                                             }│{1:~                           }|*3
+      {3:[No Name] [+]                                  }{2:[No Name]                   }|
+                                                                                 |
+    ]])
+    command('set cpoptions+=n')
+    screen:expect([[
+      {8:  1 }xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xy│                            |
+      z xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz xyz │{1:~                           }|
+      {21:xyz xyz xyz xyz xyz xyz xyz xyz^               }│{1:~                           }|
+      {1:~                                             }│{1:~                           }|*3
+      {3:[No Name] [+]                                  }{2:[No Name]                   }|
+                                                                                 |
+    ]])
+  end)
+
   -- oldtest: Test_cursorline_after_yank()
   it('always updated. vim-patch:8.1.0849', function()
     local screen = Screen.new(50, 5)

--- a/test/old/testdir/test_cursorline.vim
+++ b/test/old/testdir/test_cursorline.vim
@@ -262,14 +262,34 @@ func Test_cursorline_callback()
 
       call timer_start(300, 'Func')
   END
-  call writefile(lines, 'Xcul_timer')
+  call writefile(lines, 'Xcul_timer', 'D')
 
   let buf = RunVimInTerminal('-S Xcul_timer', #{rows: 8})
   call TermWait(buf, 310)
   call VerifyScreenDump(buf, 'Test_cursorline_callback_1', {})
 
   call StopVimInTerminal(buf)
-  call delete('Xcul_timer')
+endfunc
+
+func Test_cursorline_screenline_resize()
+  CheckScreendump
+
+  let lines =<< trim END
+      50vnew
+      call setline(1, repeat('xyz ', 30))
+      setlocal number cursorline cursorlineopt=screenline
+      normal! $
+  END
+  call writefile(lines, 'Xcul_screenline_resize', 'D')
+
+  let buf = RunVimInTerminal('-S Xcul_screenline_resize', #{rows: 8})
+  call VerifyScreenDump(buf, 'Test_cursorline_screenline_resize_1', {})
+  call term_sendkeys(buf, ":vertical resize -4\<CR>")
+  call VerifyScreenDump(buf, 'Test_cursorline_screenline_resize_2', {})
+  call term_sendkeys(buf, ":set cpoptions+=n\<CR>")
+  call VerifyScreenDump(buf, 'Test_cursorline_screenline_resize_3', {})
+
+  call StopVimInTerminal(buf)
 endfunc
 
 func Test_cursorline_screenline_update()

--- a/test/old/testdir/test_cursorline.vim
+++ b/test/old/testdir/test_cursorline.vim
@@ -300,7 +300,7 @@ func Test_cursorline_screenline_update()
       set cursorline cursorlineopt=screenline
       inoremap <F2> <Cmd>call cursor(1, 1)<CR>
   END
-  call writefile(lines, 'Xcul_screenline')
+  call writefile(lines, 'Xcul_screenline', 'D')
 
   let buf = RunVimInTerminal('-S Xcul_screenline', #{rows: 8})
   call term_sendkeys(buf, "A")
@@ -310,7 +310,17 @@ func Test_cursorline_screenline_update()
   call term_sendkeys(buf, "\<Esc>")
 
   call StopVimInTerminal(buf)
-  call delete('Xcul_screenline')
+endfunc
+
+func Test_cursorline_screenline_zero_width()
+  CheckOption foldcolumn
+
+  set cursorline culopt=screenline winminwidth=1 foldcolumn=1
+  " This used to crash Vim
+  1vnew | redraw
+
+  bwipe!
+  set cursorline& culopt& winminwidth& foldcolumn&
 endfunc
 
 func Test_cursorline_cursorbind_horizontal_scroll()


### PR DESCRIPTION
#### vim-patch:9.1.0729: Wrong cursor-screenline when resizing window

Problem:  Wrong cursor-screenline when resizing window
Solution: Invalidate saved left_col and right_col when width1 or width2
          change.

closes: vim/vim#15679

https://github.com/vim/vim/commit/86dc4f8b432233a01d022c3e71df53db58229713


#### vim-patch:9.1.0730: Crash with cursor-screenline and narrow window

Problem:  Crash with cursor-screenline and narrow window
          (elig0n)
Solution: Don't set right_col when width2 is 0 (zeertzjq).

closes: vim/vim#15678

https://github.com/vim/vim/commit/59149f02692804267e7cc0665d0334f6ff4675be