### PR TITLE
feat(treesitter)!: remove unnecessary side effects from  `language.add` and add return value

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -97,12 +97,12 @@ TREESITTER
   capture IDs to a list of nodes that need to be iterated over. For
   backwards compatibility, an option `all=false` (only return the last
   matching node) is provided that will be removed in a future release.
-
 • |vim.treesitter.language.get_filetypes()| always includes the {language}
   argument in addition to explicitly registered filetypes.
-
 • |vim.treesitter.language.get_lang()| falls back to the {filetype} argument
   if no languages are explicitly registered.
+• |vim.treesitter.language.add()| returns `true` if a parser was loaded
+  successfully and `nil,errmsg` otherwise instead of throwing an error.
 
 TUI
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -98,6 +98,12 @@ TREESITTER
   backwards compatibility, an option `all=false` (only return the last
   matching node) is provided that will be removed in a future release.
 
+• |vim.treesitter.language.get_filetypes()| always includes the {language}
+  argument in addition to explicitly registered filetypes.
+
+• |vim.treesitter.language.get_lang()| falls back to the {filetype} argument
+  if no languages are explicitly registered.
+
 TUI
 
 • TODO

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -969,14 +969,15 @@ add({lang}, {opts})                            *vim.treesitter.language.add()*
     Parameters: ~
       • {lang}  (`string`) Name of the parser (alphanumerical and `_` only)
       • {opts}  (`table?`) Options:
-                • {filetype}? (`string|string[]`, default: {lang}) Default
-                  filetype the parser should be associated with.
                 • {path}? (`string`) Optional path the parser is located at
                 • {symbol_name}? (`string`) Internal symbol name for the
                   language to load
 
 get_filetypes({lang})                *vim.treesitter.language.get_filetypes()*
-    Get the filetypes associated with the parser named {lang}.
+    Returns the filetypes for which a parser named {lang} is used.
+
+    The list includes {lang} itself plus all filetypes registered via
+    |vim.treesitter.language.register()|.
 
     Parameters: ~
       • {lang}  (`string`) Name of parser
@@ -985,6 +986,11 @@ get_filetypes({lang})                *vim.treesitter.language.get_filetypes()*
         (`string[]`) filetypes
 
 get_lang({filetype})                      *vim.treesitter.language.get_lang()*
+    Returns the language name to be used when loading a parser for {filetype}.
+
+    If no language has been explicitly registered via
+    |vim.treesitter.language.register()|, default to {filetype}. For composite
+    filetypes like `html.glimmer`, only the main filetype is returned.
 
     Parameters: ~
       • {filetype}  (`string`)

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -964,7 +964,12 @@ add({lang}, {opts})                            *vim.treesitter.language.add()*
     Load parser with name {lang}
 
     Parsers are searched in the `parser` runtime directory, or the provided
-    {path}
+    {path}. Can be used to check for available parsers before enabling
+    treesitter features, e.g., >lua
+          if vim.treesitter.language.add('markdown') then
+            vim.treesitter.start(bufnr, 'markdown')
+          end
+<
 
     Parameters: ~
       • {lang}  (`string`) Name of the parser (alphanumerical and `_` only)
@@ -972,6 +977,10 @@ add({lang}, {opts})                            *vim.treesitter.language.add()*
                 • {path}? (`string`) Optional path the parser is located at
                 • {symbol_name}? (`string`) Internal symbol name for the
                   language to load
+
+    Return (multiple): ~
+        (`boolean?`) True if parser is loaded
+        (`string?`) Error if parser cannot be loaded
 
 get_filetypes({lang})                *vim.treesitter.language.get_filetypes()*
     Returns the filetypes for which a parser named {lang} is used.

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -95,7 +95,7 @@ function M.get_parser(bufnr, lang, opts)
   end
 
   if not valid_lang(lang) then
-    lang = M.language.get_lang(vim.bo[bufnr].filetype) or vim.bo[bufnr].filetype
+    lang = M.language.get_lang(vim.bo[bufnr].filetype)
   end
 
   if not valid_lang(lang) then

--- a/runtime/lua/vim/treesitter/_query_linter.lua
+++ b/runtime/lua/vim/treesitter/_query_linter.lua
@@ -41,7 +41,7 @@ local function guess_query_lang(buf)
   local filename = api.nvim_buf_get_name(buf)
   if filename ~= '' then
     local resolved_filename = vim.F.npcall(vim.fn.fnamemodify, filename, ':p:h:t')
-    return resolved_filename and vim.treesitter.language.get_lang(resolved_filename) or nil
+    return resolved_filename and vim.treesitter.language.get_lang(resolved_filename)
   end
 end
 

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -108,7 +108,7 @@ LanguageTree.__index = LanguageTree
 ---@param opts vim.treesitter.LanguageTree.new.Opts?
 ---@return vim.treesitter.LanguageTree parser object
 function LanguageTree.new(source, lang, opts)
-  language.add(lang)
+  assert(language.add(lang))
   opts = opts or {}
 
   if source == 0 then
@@ -734,7 +734,7 @@ local function add_injection(t, tree_index, pattern, lang, combined, ranges)
   table.insert(t[tree_index][lang][pattern].regions, ranges)
 end
 
--- TODO(clason): replace by refactored `ts.has_parser` API (without registering)
+-- TODO(clason): replace by refactored `ts.has_parser` API (without side effects)
 --- The result of this function is cached to prevent nvim_get_runtime_file from being
 --- called too often
 --- @param lang string parser name

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -247,8 +247,7 @@ end)
 ---
 ---@see [vim.treesitter.query.get()]
 M.parse = memoize('concat-2', function(lang, query)
-  language.add(lang)
-
+  assert(language.add(lang))
   local ts_query = vim._ts_parse_query(lang, query)
   return Query.new(lang, ts_query)
 end)

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -31,16 +31,11 @@ describe('treesitter language API', function()
       )
     )
 
-    eq(false, exec_lua("return pcall(vim.treesitter.language.add, 'borklang')"))
+    eq(NIL, exec_lua("return vim.treesitter.language.add('borklang')"))
 
     eq(
       false,
       exec_lua("return pcall(vim.treesitter.language.add, 'borklang', { path = 'borkbork.so' })")
-    )
-
-    eq(
-      ".../language.lua:0: no parser for 'borklang' language, see :help treesitter-parsers",
-      pcall_err(exec_lua, "parser = vim.treesitter.language.inspect('borklang')")
     )
 
     matches(
@@ -49,11 +44,8 @@ describe('treesitter language API', function()
     )
   end)
 
-  it('shows error for invalid language name', function()
-    eq(
-      ".../language.lua:0: '/foo/' is not a valid language name",
-      pcall_err(exec_lua, 'vim.treesitter.language.add("/foo/")')
-    )
+  it('does not load parser for invalid language name', function()
+    eq(NIL, exec_lua('vim.treesitter.language.add("/foo/")'))
   end)
 
   it('inspects language', function()


### PR DESCRIPTION
# Problem

Language names are only registered for filetype<->language lookups when parsers are actually loaded; this means users cannot rely on `vim.treesitter.language.get_lang()` or `get_filetypes()` to return
the correct value when language and filetype coincide and always need to add explicit fallbacks.

# Solution

 Always return the language name as valid filetype in `get_filetypes()`, and default to the filetype in `get_lang()`. Document this behavior.

Supersedes #30353

---

# Problem

No clear way to check whether parsers are available for a given language.

# Solution

Make `language.add()` return `true` if a parser was successfully added and `nil` otherwise. Use explicit `assert` instead of relying on thrown errors.

Cf. #30382 

---

Do not squash.

---

Note to self: needs (trivial) adapting for in nvim-treesitter and telescope.