### PR TITLE
fix(treesitter): suppress get_parser warnings via opts.error

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -818,6 +818,11 @@ get_parser({bufnr}, {lang}, {opts})              *vim.treesitter.get_parser()*
 
     If needed, this will create the parser.
 
+    If no parser can be created, an error is thrown. Set `opts.error = false`
+    to suppress this and return nil (and an error message) instead. WARNING:
+    This behavior will become default in Nvim 0.12 and the option will be
+    removed.
+
     Parameters: ~
       • {bufnr}  (`integer?`) Buffer the parser should be tied to (default:
                  current buffer)
@@ -825,8 +830,9 @@ get_parser({bufnr}, {lang}, {opts})              *vim.treesitter.get_parser()*
                  filetype)
       • {opts}   (`table?`) Options to pass to the created language tree
 
-    Return: ~
-        (`vim.treesitter.LanguageTree`) object to use for parsing
+    Return (multiple): ~
+        (`vim.treesitter.LanguageTree?`) object to use for parsing
+        (`string?`) error message, if applicable
 
 get_range({node}, {source}, {metadata})           *vim.treesitter.get_range()*
     Get the range of a |TSNode|. Can also supply {source} and {metadata} to

--- a/runtime/lua/vim/_comment.lua
+++ b/runtime/lua/vim/_comment.lua
@@ -9,7 +9,7 @@
 local function get_commentstring(ref_position)
   local buf_cs = vim.bo.commentstring
 
-  local ts_parser = vim.treesitter._get_parser()
+  local ts_parser = vim.treesitter.get_parser(0, '', { error = false })
   if not ts_parser then
     return buf_cs
   end

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -74,15 +74,21 @@ end
 
 --- Returns the parser for a specific buffer and attaches it to the buffer
 ---
---- If needed, this will create the parser. If no parser can be found or created, returns `nil`.
+--- If needed, this will create the parser.
+---
+--- If no parser can be created, an error is thrown. Set `opts.error = false` to suppress this and
+--- return nil (and an error message) instead. WARNING: This behavior will become default in Nvim
+--- 0.12 and the option will be removed.
 ---
 ---@param bufnr (integer|nil) Buffer the parser should be tied to (default: current buffer)
 ---@param lang (string|nil) Language of this parser (default: from buffer filetype)
 ---@param opts (table|nil) Options to pass to the created language tree
 ---
----@return vim.treesitter.LanguageTree? object to use for parsing, or `nil` if not found
-function M._get_parser(bufnr, lang, opts)
+---@return vim.treesitter.LanguageTree? object to use for parsing
+---@return string? error message, if applicable
+function M.get_parser(bufnr, lang, opts)
   opts = opts or {}
+  local should_error = opts.error == nil or opts.error
 
   if bufnr == nil or bufnr == 0 then
     bufnr = api.nvim_get_current_buf()
@@ -94,12 +100,22 @@ function M._get_parser(bufnr, lang, opts)
 
   if not valid_lang(lang) then
     if not parsers[bufnr] then
-      return nil
+      local err_msg =
+        string.format('Parser not found for buffer %s: language could not be determined', bufnr)
+      if should_error then
+        error(err_msg)
+      end
+      return nil, err_msg
     end
   elseif parsers[bufnr] == nil or parsers[bufnr]:lang() ~= lang then
     local parser = vim.F.npcall(M._create_parser, bufnr, lang, opts)
     if not parser then
-      return nil
+      local err_msg =
+        string.format('Parser could not be created for buffer %s and language "%s"', bufnr, lang)
+      if should_error then
+        error(err_msg)
+      end
+      return nil, err_msg
     end
     parsers[bufnr] = parser
   end
@@ -107,29 +123,6 @@ function M._get_parser(bufnr, lang, opts)
   parsers[bufnr]:register_cbs(opts.buf_attach_cbs)
 
   return parsers[bufnr]
-end
-
---- Returns the parser for a specific buffer and attaches it to the buffer
----
---- If needed, this will create the parser.
----
----@param bufnr (integer|nil) Buffer the parser should be tied to (default: current buffer)
----@param lang (string|nil) Language of this parser (default: from buffer filetype)
----@param opts (table|nil) Options to pass to the created language tree
----
----@return vim.treesitter.LanguageTree object to use for parsing
-function M.get_parser(bufnr, lang, opts)
-  -- TODO(ribru17): Remove _get_parser and move that logic back here once the breaking function
-  -- signature change is acceptable.
-  local parser = M._get_parser(bufnr, lang, opts)
-  if not parser then
-    vim.notify_once(
-      'WARNING: vim.treesitter.get_parser will return nil instead of raising an error in Neovim 0.12',
-      vim.log.levels.WARN
-    )
-    error('Parser not found.')
-  end
-  return parser
 end
 
 --- Returns a string parser
@@ -405,7 +398,7 @@ function M.get_node(opts)
 
   local ts_range = { row, col, row, col }
 
-  local root_lang_tree = M._get_parser(bufnr, opts.lang)
+  local root_lang_tree = M.get_parser(bufnr, opts.lang, { error = false })
   if not root_lang_tree then
     return
   end
@@ -438,11 +431,7 @@ end
 ---@param lang (string|nil) Language of the parser (default: from buffer filetype)
 function M.start(bufnr, lang)
   bufnr = bufnr or api.nvim_get_current_buf()
-  local parser = M._get_parser(bufnr, lang)
-  if not parser then
-    vim.notify('No parser for the given buffer.', vim.log.levels.WARN)
-    return
-  end
+  local parser = assert(M.get_parser(bufnr, lang, { error = false }))
   M.highlighter.new(parser)
 end
 

--- a/runtime/lua/vim/treesitter/_fold.lua
+++ b/runtime/lua/vim/treesitter/_fold.lua
@@ -114,7 +114,7 @@ local function compute_folds_levels(bufnr, info, srow, erow, parse_injections)
   srow = srow or 0
   erow = erow or api.nvim_buf_line_count(bufnr)
 
-  local parser = assert(ts._get_parser(bufnr))
+  local parser = assert(ts.get_parser(bufnr, nil, { error = false }))
 
   parser:parse(parse_injections and { srow, erow } or nil)
 
@@ -392,7 +392,7 @@ function M.foldexpr(lnum)
   lnum = lnum or vim.v.lnum
   local bufnr = api.nvim_get_current_buf()
 
-  local parser = ts._get_parser(bufnr)
+  local parser = ts.get_parser(bufnr, nil, { error = false })
   if not parser then
     return '0'
   end

--- a/runtime/lua/vim/treesitter/_query_linter.lua
+++ b/runtime/lua/vim/treesitter/_query_linter.lua
@@ -177,7 +177,7 @@ function M.lint(buf, opts)
       is_first_lang = i == 1,
     }
 
-    local parser = assert(vim.treesitter._get_parser(buf), 'query parser not found.')
+    local parser = assert(vim.treesitter.get_parser(buf, nil, { error = false }))
     parser:parse()
     parser:for_each_tree(function(tree, ltree)
       if ltree:lang() == 'query' then

--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -76,9 +76,14 @@ end
 ---
 ---@package
 function TSTreeView:new(bufnr, lang)
-  local parser = vim.treesitter._get_parser(bufnr or 0, lang)
+  local parser = vim.treesitter.get_parser(bufnr or 0, lang, { error = false })
   if not parser then
-    return nil, 'No parser available for the given buffer.'
+    return nil,
+      string.format(
+        'Failed to create TSTreeView for buffer %s: no parser for lang "%s"',
+        bufnr,
+        lang
+      )
   end
 
   -- For each child tree (injected language), find the root of the tree and locate the node within
@@ -538,7 +543,7 @@ local edit_ns = api.nvim_create_namespace('treesitter/dev-edit')
 local function update_editor_highlights(query_win, base_win, lang)
   local base_buf = api.nvim_win_get_buf(base_win)
   local query_buf = api.nvim_win_get_buf(query_win)
-  local parser = assert(vim.treesitter._get_parser(base_buf, lang))
+  local parser = assert(vim.treesitter.get_parser(base_buf, lang, { error = false }))
   api.nvim_buf_clear_namespace(base_buf, edit_ns, 0, -1)
   local query_content = table.concat(api.nvim_buf_get_lines(query_buf, 0, -1, false), '\n')
 
@@ -595,9 +600,10 @@ function M.edit_query(lang)
   end
   vim.cmd(cmd)
 
-  local parser = vim.treesitter._get_parser(buf, lang)
+  local parser = vim.treesitter.get_parser(buf, lang, { error = false })
   if not parser then
-    return nil, 'No parser available for the given buffer'
+    return nil,
+      string.format('Failed to show query editor for buffer %s: no parser for lang "%s"', buf, lang)
   end
   lang = parser:lang()
 

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -1028,7 +1028,11 @@ end
 ---
 --- @param lang? string language to open the query editor for. If omitted, inferred from the current buffer's filetype.
 function M.edit(lang)
-  vim.treesitter.dev.edit_query(lang)
+  -- TODO(ribru17): Make edit_query return true upon success so we can just assert here
+  local _, err_msg = vim.treesitter.dev.edit_query(lang)
+  if err_msg then
+    error(err_msg)
+  end
 end
 
 return M

--- a/runtime/lua/vim/vimhelp.lua
+++ b/runtime/lua/vim/vimhelp.lua
@@ -33,7 +33,7 @@ end
 --- Show a table of contents for the help buffer in a loclist
 function M.show_toc()
   local bufnr = vim.api.nvim_get_current_buf()
-  local parser = assert(vim.treesitter._get_parser(bufnr, 'vimdoc'), 'vimdoc parser not found.')
+  local parser = assert(vim.treesitter.get_parser(bufnr, 'vimdoc', { error = false }))
   local query = vim.treesitter.query.parse(
     parser:lang(),
     [[

--- a/scripts/gen_help_html.lua
+++ b/scripts/gen_help_html.lua
@@ -802,7 +802,7 @@ local function parse_buf(fname, text, parser_path)
   if parser_path then
     vim.treesitter.language.add('vimdoc', { path = parser_path })
   end
-  local lang_tree = assert(vim.treesitter._get_parser(buf), 'vimdoc parser not found.')
+  local lang_tree = assert(vim.treesitter.get_parser(buf, nil, { error = false }))
   return lang_tree, buf
 end
 

--- a/test/functional/lua/deprecated_spec.lua
+++ b/test/functional/lua/deprecated_spec.lua
@@ -1,0 +1,22 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local clear = n.clear
+local exec_lua = n.exec_lua
+local eq = t.eq
+
+describe('deprecated lua code', function()
+  before_each(clear)
+
+  describe('vim.treesitter.get_parser()', function()
+    it('returns nil for versions >= 0.12', function()
+      local result = exec_lua(function()
+        if vim.version.ge(vim.version(), '0.12') then
+          return vim.treesitter.get_parser(0, 'borklang')
+        end
+        return nil
+      end)
+      eq(nil, result)
+    end)
+  end)
+end)

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -16,11 +16,11 @@ describe('treesitter language API', function()
   -- error tests not requiring a parser library
   it('handles missing language', function()
     eq(
-      '.../treesitter.lua:0: Parser not found.',
+      '.../treesitter.lua:0: Parser could not be created for buffer 1 and language "borklang"',
       pcall_err(exec_lua, "parser = vim.treesitter.get_parser(0, 'borklang')")
     )
 
-    eq(NIL, exec_lua("return vim.treesitter._get_parser(0, 'borklang')"))
+    eq(NIL, exec_lua("return vim.treesitter.get_parser(0, 'borklang', { error = false })"))
 
     -- actual message depends on platform
     matches(
@@ -108,10 +108,10 @@ describe('treesitter language API', function()
       command('set filetype=borklang')
       -- Should throw an error when filetype changes to borklang
       eq(
-        '.../treesitter.lua:0: Parser not found.',
+        '.../treesitter.lua:0: Parser could not be created for buffer 1 and language "borklang"',
         pcall_err(exec_lua, "new_parser = vim.treesitter.get_parser(0, 'borklang')")
       )
-      eq(NIL, exec_lua("return vim.treesitter._get_parser(0, 'borklang')"))
+      eq(NIL, exec_lua("return vim.treesitter.get_parser(0, 'borklang', { error = false })"))
     end
   )
 

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -135,7 +135,7 @@ void ui_refresh(void)
     insert(test_text)
 
     eq(
-      '.../treesitter.lua:0: Parser not found.',
+      '.../treesitter.lua:0: Parser not found for buffer 1: language could not be determined',
       pcall_err(exec_lua, 'vim.treesitter.get_parser(0)')
     )
 


### PR DESCRIPTION
**Problem:** #30313 introduced a change to `vim.treesitter.get_parser` that would always show a deprecation warning message without giving plugins/users a way to suppress it by updating to the new functionality.

**Solution:** Introduce `opts.error` to allow plugins/users to explicitly say that they are moving away from the deprecated functionality, thus allowing them to remove the annoying warning. See https://github.com/neovim/neovim/pull/30313#issuecomment-2349327458