### PR TITLE
test: spawn_wait() starts a non-RPC Nvim process

### DIFF
--- a/MAINTAIN.md
+++ b/MAINTAIN.md
@@ -143,6 +143,8 @@ These dependencies are "vendored" (inlined), we must update the sources manually
 
 * `src/mpack/`: [libmpack](https://github.com/libmpack/libmpack)
     * send improvements upstream!
+* `src/mpack/lmpack.c`: [libmpack-lua](https://github.com/libmpack/libmpack-lua)
+    * send improvements upstream!
 * `src/xdiff/`: [xdiff](https://github.com/git/git/tree/master/xdiff)
 * `src/cjson/`: [lua-cjson](https://github.com/openresty/lua-cjson)
 * `src/klib/`: [Klib](https://github.com/attractivechaos/klib)

--- a/runtime/lua/coxpcall.lua
+++ b/runtime/lua/coxpcall.lua
@@ -1,5 +1,9 @@
 -------------------------------------------------------------------------------
+-- (Not needed for LuaJIT or Lua 5.2+)
+--
 -- Coroutine safe xpcall and pcall versions
+--
+-- https://keplerproject.github.io/coxpcall/
 --
 -- Encapsulates the protected calls with a coroutine based loop, so errors can
 -- be dealed without the usual Lua 5.x pcall/xpcall issues with coroutines

--- a/src/nvim/grid.c
+++ b/src/nvim/grid.c
@@ -383,7 +383,8 @@ void grid_line_start(ScreenGrid *grid, int row)
 
   assert((size_t)grid_line_maxcol <= linebuf_size);
 
-  if (rdb_flags & kOptRdbFlagInvalid) {
+  if (full_screen && (rdb_flags & kOptRdbFlagInvalid)) {
+    assert(linebuf_char);
     // Current batch must not depend on previous contents of linebuf_char.
     // Set invalid values which will cause assertion failures later if they are used.
     memset(linebuf_char, 0xFF, sizeof(schar_T) * linebuf_size);

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -634,6 +634,7 @@ int main(int argc, char **argv)
   if (params.luaf != NULL) {
     // Like "--cmd", "+", "-c" and "-S", don't truncate messages.
     msg_scroll = true;
+    DLOG("executing Lua -l script");
     bool lua_ok = nlua_exec_file(params.luaf);
     TIME_MSG("executing Lua -l script");
     if (msg_didout) {

--- a/test/client/session.lua
+++ b/test/client/session.lua
@@ -1,13 +1,21 @@
-local uv = vim.uv
-local MsgpackRpcStream = require('test.client.msgpack_rpc_stream')
+---
+--- Nvim msgpack-RPC protocol session. Manages requests/notifications/responses.
+---
 
+local uv = vim.uv
+local RpcStream = require('test.client.rpc_stream')
+
+--- Nvim msgpack-RPC protocol session. Manages requests/notifications/responses.
+---
 --- @class test.Session
---- @field private _pending_messages string[]
---- @field private _msgpack_rpc_stream test.MsgpackRpcStream
+--- @field private _pending_messages string[] Requests/notifications received from the remote end.
+--- @field private _rpc_stream test.RpcStream
 --- @field private _prepare uv.uv_prepare_t
 --- @field private _timer uv.uv_timer_t
---- @field private _is_running boolean
 --- @field exec_lua_setup boolean
+--- @field private _is_running boolean true during `Session:run()` scope.
+--- @field private _stdout_buffer string[] Stores stdout chunks
+--- @field public stdout string Full stdout after the process exits
 local Session = {}
 Session.__index = Session
 if package.loaded['jit'] then
@@ -51,9 +59,10 @@ local function coroutine_exec(func, ...)
   end))
 end
 
+--- Creates a new msgpack-RPC session.
 function Session.new(stream)
   return setmetatable({
-    _msgpack_rpc_stream = MsgpackRpcStream.new(stream),
+    _rpc_stream = RpcStream.new(stream),
     _pending_messages = {},
     _prepare = uv.new_prepare(),
     _timer = uv.new_timer(),
@@ -91,10 +100,13 @@ function Session:next_message(timeout)
   return table.remove(self._pending_messages, 1)
 end
 
+--- Sends a notification to the RPC endpoint.
 function Session:notify(method, ...)
-  self._msgpack_rpc_stream:write(method, { ... })
+  self._rpc_stream:write(method, { ... })
 end
 
+--- Sends a request to the RPC endpoint.
+---
 --- @param method string
 --- @param ... any
 --- @return boolean, table
@@ -114,8 +126,16 @@ function Session:request(method, ...)
   return true, result
 end
 
---- Runs the event loop.
+--- Processes incoming RPC requests/notifications until exhausted.
+---
+--- TODO(justinmk): luaclient2 avoids this via uvutil.cb_wait() + uvutil.add_idle_call()?
+---
+--- @param request_cb function Handles requests from the sever to the local end.
+--- @param notification_cb function Handles notifications from the sever to the local end.
+--- @param setup_cb function
+--- @param timeout number
 function Session:run(request_cb, notification_cb, setup_cb, timeout)
+  --- Handles an incoming request.
   local function on_request(method, args, response)
     coroutine_exec(request_cb, method, args, function(status, result, flag)
       if status then
@@ -126,6 +146,7 @@ function Session:run(request_cb, notification_cb, setup_cb, timeout)
     end)
   end
 
+  --- Handles an incoming notification.
   local function on_notification(method, args)
     coroutine_exec(notification_cb, method, args)
   end
@@ -160,39 +181,45 @@ function Session:close(signal)
   if not self._prepare:is_closing() then
     self._prepare:close()
   end
-  self._msgpack_rpc_stream:close(signal)
+  self._rpc_stream:close(signal)
   self.closed = true
 end
 
+--- Sends a request to the RPC endpoint, without blocking (schedules a coroutine).
 function Session:_yielding_request(method, args)
   return coroutine.yield(function(co)
-    self._msgpack_rpc_stream:write(method, args, function(err, result)
+    self._rpc_stream:write(method, args, function(err, result)
       resume(co, err, result)
     end)
   end)
 end
 
+--- Sends a request to the RPC endpoint, and blocks (polls event loop) until a response is received.
 function Session:_blocking_request(method, args)
   local err, result
 
+  -- Invoked when a request is received from the remote end.
   local function on_request(method_, args_, response)
     table.insert(self._pending_messages, { 'request', method_, args_, response })
   end
 
+  -- Invoked when a notification is received from the remote end.
   local function on_notification(method_, args_)
     table.insert(self._pending_messages, { 'notification', method_, args_ })
   end
 
-  self._msgpack_rpc_stream:write(method, args, function(e, r)
+  self._rpc_stream:write(method, args, function(e, r)
     err = e
     result = r
     uv.stop()
   end)
 
+  -- Poll for incoming requests/notifications received from the remote end.
   self:_run(on_request, on_notification)
   return (err or self.eof_err), result
 end
 
+--- Polls for incoming requests/notifications received from the remote end.
 function Session:_run(request_cb, notification_cb, timeout)
   if type(timeout) == 'number' then
     self._prepare:start(function()
@@ -202,14 +229,15 @@ function Session:_run(request_cb, notification_cb, timeout)
       self._prepare:stop()
     end)
   end
-  self._msgpack_rpc_stream:read_start(request_cb, notification_cb, function()
+  self._rpc_stream:read_start(request_cb, notification_cb, function()
     uv.stop()
     self.eof_err = { 1, 'EOF was received from Nvim. Likely the Nvim process crashed.' }
   end)
   uv.run()
   self._prepare:stop()
   self._timer:stop()
-  self._msgpack_rpc_stream:read_stop()
+  self._rpc_stream:read_stop()
 end
 
+--- Nvim msgpack-RPC session.
 return Session

--- a/test/client/uv_stream.lua
+++ b/test/client/uv_stream.lua
@@ -1,3 +1,8 @@
+---
+--- Basic stream types.
+--- See `rpc_stream.lua` for the msgpack layer.
+---
+
 local uv = vim.uv
 
 --- @class test.Stream
@@ -6,6 +11,8 @@ local uv = vim.uv
 --- @field read_stop fun(self)
 --- @field close fun(self, signal?: string)
 
+--- Stream over given pipes.
+---
 --- @class vim.StdioStream : test.Stream
 --- @field private _in uv.uv_pipe_t
 --- @field private _out uv.uv_pipe_t
@@ -45,6 +52,8 @@ function StdioStream:close()
   self._out:close()
 end
 
+--- Stream over a named pipe or TCP socket.
+---
 --- @class test.SocketStream : test.Stream
 --- @field package _stream_error? string
 --- @field package _socket uv.uv_pipe_t
@@ -109,26 +118,46 @@ function SocketStream:close()
   uv.close(self._socket)
 end
 
---- @class test.ChildProcessStream : test.Stream
+--- Stream over child process stdio.
+---
+--- @class test.ProcStream : test.Stream
 --- @field private _proc uv.uv_process_t
 --- @field private _pid integer
 --- @field private _child_stdin uv.uv_pipe_t
 --- @field private _child_stdout uv.uv_pipe_t
+--- @field private _child_stderr uv.uv_pipe_t
+--- @field stdout string
+--- @field stderr string
+--- @field stdout_eof boolean
+--- @field stderr_eof boolean
+--- @field private collect_output boolean
+--- Exit code
 --- @field status integer
 --- @field signal integer
-local ChildProcessStream = {}
-ChildProcessStream.__index = ChildProcessStream
+local ProcStream = {}
+ProcStream.__index = ProcStream
 
+--- Starts child process specified by `argv`.
+---
 --- @param argv string[]
 --- @param env string[]?
 --- @param io_extra uv.uv_pipe_t?
---- @return test.ChildProcessStream
-function ChildProcessStream.spawn(argv, env, io_extra)
+--- @return test.ProcStream
+function ProcStream.spawn(argv, env, io_extra)
   local self = setmetatable({
-    _child_stdin = uv.new_pipe(false),
-    _child_stdout = uv.new_pipe(false),
+    collect_output = false,
+    output = '',
+    stdout = '',
+    stderr = '',
+    stdout_error = nil, -- TODO: not used, remove
+    stderr_error = nil, -- TODO: not used, remove
+    stdout_eof = false,
+    stderr_eof = false,
+    _child_stdin = assert(uv.new_pipe(false)),
+    _child_stdout = assert(uv.new_pipe(false)),
+    _child_stderr = assert(uv.new_pipe(false)),
     _exiting = false,
-  }, ChildProcessStream)
+  }, ProcStream)
   local prog = argv[1]
   local args = {} --- @type string[]
   for i = 2, #argv do
@@ -136,13 +165,14 @@ function ChildProcessStream.spawn(argv, env, io_extra)
   end
   --- @diagnostic disable-next-line:missing-fields
   self._proc, self._pid = uv.spawn(prog, {
-    stdio = { self._child_stdin, self._child_stdout, 1, io_extra },
+    stdio = { self._child_stdin, self._child_stdout, self._child_stderr, io_extra },
     args = args,
     --- @diagnostic disable-next-line:assign-type-mismatch
     env = env,
   }, function(status, signal)
-    self.status = status
     self.signal = signal
+    -- "Abort" exit may not set status; force to nonzero in that case.
+    self.status = (0 ~= (status or 0) or 0 == (signal or 0)) and status or (128 + (signal or 0))
   end)
 
   if not self._proc then
@@ -153,24 +183,56 @@ function ChildProcessStream.spawn(argv, env, io_extra)
   return self
 end
 
-function ChildProcessStream:write(data)
+function ProcStream:write(data)
   self._child_stdin:write(data)
 end
 
-function ChildProcessStream:read_start(cb)
-  self._child_stdout:read_start(function(err, chunk)
-    if err then
-      error(err)
+function ProcStream:on_read(stream, cb, err, chunk)
+  if err then
+    -- stderr_error/stdout_error
+    self[stream .. '_error'] = err ---@type string
+    -- error(err)
+  elseif chunk then
+    -- 'stderr' or 'stdout'
+    if self.collect_output then
+      self[stream] = self[stream] .. chunk ---@type string
+      --- Collects both stdout + stderr.
+      self.output = self[stream] .. chunk ---@type string
     end
+  else
+    -- stderr_eof/stdout_eof
+    self[stream .. '_eof'] = true ---@type boolean
+  end
+
+  -- Handler provided by the caller.
+  if cb then
     cb(chunk)
+  end
+end
+
+--- Collects output until the process exits.
+function ProcStream:wait()
+  self.collect_output = true
+  while not (self.stdout_eof and self.stderr_eof and (self.status or self.signal)) do
+    uv.run('once')
+  end
+end
+
+function ProcStream:read_start(on_stdout, on_stderr)
+  self._child_stdout:read_start(function(err, chunk)
+    self:on_read('stdout', on_stdout, err, chunk)
+  end)
+  self._child_stderr:read_start(function(err, chunk)
+    self:on_read('stderr', on_stderr, err, chunk)
   end)
 end
 
-function ChildProcessStream:read_stop()
+function ProcStream:read_stop()
   self._child_stdout:read_stop()
+  self._child_stderr:read_stop()
 end
 
-function ChildProcessStream:close(signal)
+function ProcStream:close(signal)
   if self._closed then
     return
   end
@@ -178,6 +240,7 @@ function ChildProcessStream:close(signal)
   self:read_stop()
   self._child_stdin:close()
   self._child_stdout:close()
+  self._child_stderr:close()
   if type(signal) == 'string' then
     self._proc:kill('sig' .. signal)
   end
@@ -189,6 +252,6 @@ end
 
 return {
   StdioStream = StdioStream,
-  ChildProcessStream = ChildProcessStream,
+  ProcStream = ProcStream,
   SocketStream = SocketStream,
 }

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -154,8 +154,9 @@ describe('startup', function()
 
     it('failure modes', function()
       -- nvim -l <empty>
-      matches('nvim%.?e?x?e?: Argument missing after: "%-l"', fn.system({ nvim_prog, '-l' }))
-      eq(1, eval('v:shell_error'))
+      local proc = n.spawn_wait('-l')
+      matches('nvim%.?e?x?e?: Argument missing after: "%-l"', proc.stderr)
+      eq(1, proc.status)
     end)
 
     it('os.exit() sets Nvim exitcode', function()
@@ -182,12 +183,11 @@ describe('startup', function()
     end)
 
     it('Lua-error sets Nvim exitcode', function()
+      local proc = n.spawn_wait('-l', 'test/functional/fixtures/startup-fail.lua')
+      matches('E5113: .* my pearls!!', proc.output)
+      eq(1, proc.status)
+
       eq(0, eval('v:shell_error'))
-      matches(
-        'E5113: .* my pearls!!',
-        fn.system({ nvim_prog, '-l', 'test/functional/fixtures/startup-fail.lua' })
-      )
-      eq(1, eval('v:shell_error'))
       matches(
         'E5113: .* %[string "error%("whoa"%)"%]:1: whoa',
         fn.system({ nvim_prog, '-l', '-' }, 'error("whoa")')

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -333,9 +333,9 @@ end
 function M.expect_exit(fn_or_timeout, ...)
   local eof_err_msg = 'EOF was received from Nvim. Likely the Nvim process crashed.'
   if type(fn_or_timeout) == 'function' then
-    eq(eof_err_msg, t.pcall_err(fn_or_timeout, ...))
+    t.matches(eof_err_msg, t.pcall_err(fn_or_timeout, ...))
   else
-    eq(
+    t.matches(
       eof_err_msg,
       t.pcall_err(function(timeout, fn, ...)
         fn(...)


### PR DESCRIPTION
# Problem

Can't use `n.clear()` to test non-RPC Nvim. So tests end up creating ad-hoc wrappers around `system()` or `jobstart()`.

# Solution

- Introduce `n.spawn_wait()`
- TODO (followup PR): Rename `n.spawn()` and `n.spawn_wait()`.
  It's misleading that `n.spawn()` returns a RPC session...

<details>
<summary>old summary</summary>

Merge [garyburd](https://github.com/garyburd/)'s https://github.com/justinmk/lua-client2 into `test/client2` and use that instead of the old Lua client.

Advantages of client2:

- has direct test coverage
- smaller, simpler
- `add_idle_call` looks neat
- `Nvim.handlers` (for https://github.com/neovim/neovim/issues/27949 )

Disadvantages:

- not really needed anymore: can use Nvim Lua + builtin RPC now.
    - TODO: how do nvim lua plugins listen to custom (non-`nvim_xx`) RPC methods?
- doesn't use `coxpcall`

</details>