### PR TITLE
refactor: rename "process" => "proc"

### DIFF
--- a/src/.valgrind.supp
+++ b/src/.valgrind.supp
@@ -10,7 +10,7 @@
   Memcheck:Leak
   fun:malloc
   fun:uv_spawn
-  fun:libuv_process_spawn
-  fun:process_spawn
+  fun:libuv_proc_spawn
+  fun:proc_spawn
   fun:job_start
 }

--- a/src/clint.py
+++ b/src/clint.py
@@ -848,7 +848,7 @@ def CheckIncludes(filename, lines, error):
             or filename.endswith('.in.h')
             or FileInfo(filename).RelativePath() in {
         'func_attr.h',
-        'os/pty_process.h',
+        'os/pty_proc.h',
     }):
         return
 
@@ -869,7 +869,7 @@ def CheckIncludes(filename, lines, error):
             "src/nvim/msgpack_rpc/unpacker.h",
             "src/nvim/option.h",
             "src/nvim/os/pty_conpty_win.h",
-            "src/nvim/os/pty_process_win.h",
+            "src/nvim/os/pty_proc_win.h",
                              ]
 
     skip_headers = [

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -417,10 +417,10 @@ list(SORT NVIM_HEADERS)
 
 foreach(sfile ${NVIM_SOURCES})
   get_filename_component(f ${sfile} NAME)
-  if(WIN32 AND ${f} MATCHES "^(pty_process_unix.c)$")
+  if(WIN32 AND ${f} MATCHES "^(pty_proc_unix.c)$")
     list(REMOVE_ITEM NVIM_SOURCES ${sfile})
   endif()
-  if(NOT WIN32 AND ${f} MATCHES "^(pty_process_win.c)$")
+  if(NOT WIN32 AND ${f} MATCHES "^(pty_proc_win.c)$")
     list(REMOVE_ITEM NVIM_SOURCES ${sfile})
   endif()
   if(NOT WIN32 AND ${f} MATCHES "^(pty_conpty_win.c)$")
@@ -436,7 +436,7 @@ foreach(hfile ${NVIM_HEADERS})
   if(WIN32 AND ${f} MATCHES "^(unix_defs.h)$")
     list(REMOVE_ITEM NVIM_HEADERS ${hfile})
   endif()
-  if(WIN32 AND ${f} MATCHES "^(pty_process_unix.h)$")
+  if(WIN32 AND ${f} MATCHES "^(pty_proc_unix.h)$")
     list(REMOVE_ITEM NVIM_HEADERS ${hfile})
   endif()
   if(NOT WIN32 AND ${f} MATCHES "^(win_defs.h)$")
@@ -832,12 +832,12 @@ find_program(CLANG_TIDY_PRG clang-tidy)
 set(EXCLUDE_CLANG_TIDY typval_encode.c.h ui_events.in.h)
 if(WIN32)
   list(APPEND EXCLUDE_CLANG_TIDY
-    os/pty_process_unix.h
+    os/pty_proc_unix.h
     os/unix_defs.h)
 else()
   list(APPEND EXCLUDE_CLANG_TIDY
     os/win_defs.h
-    os/pty_process_win.h
+    os/pty_proc_win.h
     os/pty_conpty_win.h
     os/os_win_console.h)
 endif()

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -70,7 +70,7 @@
 #include "nvim/optionstr.h"
 #include "nvim/os/input.h"
 #include "nvim/os/os_defs.h"
-#include "nvim/os/process.h"
+#include "nvim/os/proc.h"
 #include "nvim/popupmenu.h"
 #include "nvim/pos_defs.h"
 #include "nvim/runtime.h"

--- a/src/nvim/channel.h
+++ b/src/nvim/channel.h
@@ -7,11 +7,11 @@
 #include "nvim/channel_defs.h"  // IWYU pragma: keep
 #include "nvim/eval/typval_defs.h"
 #include "nvim/event/defs.h"
-#include "nvim/event/libuv_process.h"
+#include "nvim/event/libuv_proc.h"
 #include "nvim/macros_defs.h"
 #include "nvim/map_defs.h"
 #include "nvim/msgpack_rpc/channel_defs.h"
-#include "nvim/os/pty_process.h"
+#include "nvim/os/pty_proc.h"
 #include "nvim/types_defs.h"
 
 struct Channel {
@@ -21,9 +21,9 @@ struct Channel {
 
   ChannelStreamType streamtype;
   union {
-    Process proc;
-    LibuvProcess uv;
-    PtyProcess pty;
+    Proc proc;
+    LibuvProc uv;
+    PtyProc pty;
     RStream socket;
     StdioPair stdio;
     StderrState err;

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -32,7 +32,7 @@
 #include "nvim/eval/vars.h"
 #include "nvim/event/loop.h"
 #include "nvim/event/multiqueue.h"
-#include "nvim/event/process.h"
+#include "nvim/event/proc.h"
 #include "nvim/event/time.h"
 #include "nvim/ex_cmds.h"
 #include "nvim/ex_docmd.h"
@@ -8506,7 +8506,7 @@ Channel *find_job(uint64_t id, bool show_error)
 {
   Channel *data = find_channel(id);
   if (!data || data->streamtype != kChannelStreamProc
-      || process_is_stopped(&data->stream.proc)) {
+      || proc_is_stopped(&data->stream.proc)) {
     if (show_error) {
       if (data && data->streamtype != kChannelStreamProc) {
         emsg(_(e_invchanjob));

--- a/src/nvim/event/defs.h
+++ b/src/nvim/event/defs.h
@@ -142,30 +142,31 @@ struct socket_watcher {
 };
 
 typedef enum {
-  kProcessTypeUv,
-  kProcessTypePty,
-} ProcessType;
+  kProcTypeUv,
+  kProcTypePty,
+} ProcType;
 
-typedef struct process Process;
-typedef void (*process_exit_cb)(Process *proc, int status, void *data);
-typedef void (*internal_process_cb)(Process *proc);
+/// OS process
+typedef struct proc Proc;
+typedef void (*proc_exit_cb)(Proc *proc, int status, void *data);
+typedef void (*internal_proc_cb)(Proc *proc);
 
-struct process {
-  ProcessType type;
+struct proc {
+  ProcType type;
   Loop *loop;
   void *data;
   int pid, status, refcount;
   uint8_t exit_signal;  // Signal used when killing (on Windows).
-  uint64_t stopped_time;  // process_stop() timestamp
+  uint64_t stopped_time;  // proc_stop() timestamp
   const char *cwd;
   char **argv;
   const char *exepath;
   dict_T *env;
   Stream in;
   RStream out, err;
-  /// Exit handler. If set, user must call process_free().
-  process_exit_cb cb;
-  internal_process_cb internal_exit_cb, internal_close_cb;
+  /// Exit handler. If set, user must call proc_free().
+  proc_exit_cb cb;
+  internal_proc_cb internal_exit_cb, internal_close_cb;
   bool closed, detach, overlapped, fwd_err;
   MultiQueue *events;
 };

--- a/src/nvim/event/libuv_proc.c
+++ b/src/nvim/event/libuv_proc.c
@@ -5,9 +5,9 @@
 
 #include "nvim/eval/typval.h"
 #include "nvim/event/defs.h"
-#include "nvim/event/libuv_process.h"
+#include "nvim/event/libuv_proc.h"
 #include "nvim/event/loop.h"
-#include "nvim/event/process.h"
+#include "nvim/event/proc.h"
 #include "nvim/log.h"
 #include "nvim/os/os.h"
 #include "nvim/os/os_defs.h"
@@ -15,15 +15,15 @@
 #include "nvim/ui_client.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/libuv_process.c.generated.h"
+# include "event/libuv_proc.c.generated.h"
 #endif
 
 /// @returns zero on success, or negative error code
-int libuv_process_spawn(LibuvProcess *uvproc)
+int libuv_proc_spawn(LibuvProc *uvproc)
   FUNC_ATTR_NONNULL_ALL
 {
-  Process *proc = (Process *)uvproc;
-  uvproc->uvopts.file = process_get_exepath(proc);
+  Proc *proc = (Proc *)uvproc;
+  uvproc->uvopts.file = proc_get_exepath(proc);
   uvproc->uvopts.args = proc->argv;
   uvproc->uvopts.flags = UV_PROCESS_WINDOWS_HIDE;
 #ifdef MSWIN
@@ -101,7 +101,7 @@ int libuv_process_spawn(LibuvProcess *uvproc)
   return status;
 }
 
-void libuv_process_close(LibuvProcess *uvproc)
+void libuv_proc_close(LibuvProc *uvproc)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   uv_close((uv_handle_t *)&uvproc->uv, close_cb);
@@ -109,11 +109,11 @@ void libuv_process_close(LibuvProcess *uvproc)
 
 static void close_cb(uv_handle_t *handle)
 {
-  Process *proc = handle->data;
+  Proc *proc = handle->data;
   if (proc->internal_close_cb) {
     proc->internal_close_cb(proc);
   }
-  LibuvProcess *uvproc = (LibuvProcess *)proc;
+  LibuvProc *uvproc = (LibuvProc *)proc;
   if (uvproc->uvopts.env) {
     os_free_fullenv(uvproc->uvopts.env);
   }
@@ -121,7 +121,7 @@ static void close_cb(uv_handle_t *handle)
 
 static void exit_cb(uv_process_t *handle, int64_t status, int term_signal)
 {
-  Process *proc = handle->data;
+  Proc *proc = handle->data;
 #if defined(MSWIN)
   // Use stored/expected signal.
   term_signal = proc->exit_signal;
@@ -130,10 +130,10 @@ static void exit_cb(uv_process_t *handle, int64_t status, int term_signal)
   proc->internal_exit_cb(proc);
 }
 
-LibuvProcess libuv_process_init(Loop *loop, void *data)
+LibuvProc libuv_proc_init(Loop *loop, void *data)
 {
-  LibuvProcess rv = {
-    .process = process_init(loop, kProcessTypeUv, data)
+  LibuvProc rv = {
+    .proc = proc_init(loop, kProcTypeUv, data)
   };
   return rv;
 }

--- a/src/nvim/event/libuv_proc.h
+++ b/src/nvim/event/libuv_proc.h
@@ -5,12 +5,12 @@
 #include "nvim/event/defs.h"
 
 typedef struct {
-  Process process;
+  Proc proc;
   uv_process_t uv;
   uv_process_options_t uvopts;
   uv_stdio_container_t uvstdio[4];
-} LibuvProcess;
+} LibuvProc;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/libuv_process.h.generated.h"
+# include "event/libuv_proc.h.generated.h"
 #endif

--- a/src/nvim/event/proc.h
+++ b/src/nvim/event/proc.h
@@ -6,9 +6,9 @@
 #include "nvim/event/defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"
 
-static inline Process process_init(Loop *loop, ProcessType type, void *data)
+static inline Proc proc_init(Loop *loop, ProcType type, void *data)
 {
-  return (Process) {
+  return (Proc) {
     .type = type,
     .data = data,
     .loop = loop,
@@ -33,17 +33,17 @@ static inline Process process_init(Loop *loop, ProcessType type, void *data)
 }
 
 /// Get the path to the executable of the process.
-static inline const char *process_get_exepath(Process *proc)
+static inline const char *proc_get_exepath(Proc *proc)
 {
   return proc->exepath != NULL ? proc->exepath : proc->argv[0];
 }
 
-static inline bool process_is_stopped(Process *proc)
+static inline bool proc_is_stopped(Proc *proc)
 {
   bool exited = (proc->status >= 0);
   return exited || (proc->stopped_time != 0);
 }
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/process.h.generated.h"
+# include "event/proc.h.generated.h"
 #endif

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -43,7 +43,7 @@
 #include "nvim/eval/userfunc.h"
 #include "nvim/event/loop.h"
 #include "nvim/event/multiqueue.h"
-#include "nvim/event/process.h"
+#include "nvim/event/proc.h"
 #include "nvim/event/stream.h"
 #include "nvim/ex_cmds.h"
 #include "nvim/ex_docmd.h"
@@ -174,7 +174,7 @@ bool event_teardown(void)
   loop_poll_events(&main_loop, 0);  // Drain thread_events, fast_events.
   input_stop();
   channel_teardown();
-  process_teardown(&main_loop);
+  proc_teardown(&main_loop);
   timer_teardown();
   server_teardown();
   signal_teardown();
@@ -2207,7 +2207,7 @@ static void usage(void)
   printf(_("  --headless            Don't start a user interface\n"));
   printf(_("  --listen <address>    Serve RPC API from this address\n"));
   printf(_("  --remote[-subcommand] Execute commands remotely on a server\n"));
-  printf(_("  --server <address>    Specify RPC server to send commands to\n"));
+  printf(_("  --server <address>    Connect to this Nvim server\n"));
   printf(_("  --startuptime <file>  Write startup timing messages to <file>\n"));
   printf(_("\nSee \":help startup-options\" for all options.\n"));
 }

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -14,7 +14,7 @@
 #include "nvim/event/defs.h"
 #include "nvim/event/loop.h"
 #include "nvim/event/multiqueue.h"
-#include "nvim/event/process.h"
+#include "nvim/event/proc.h"
 #include "nvim/event/rstream.h"
 #include "nvim/event/wstream.h"
 #include "nvim/globals.h"

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -344,7 +344,7 @@ char *os_getenvname_at_index(size_t index)
 #endif
 }
 
-/// Get the process ID of the Neovim process.
+/// Get the process ID of the Nvim process.
 ///
 /// @return the process ID.
 int64_t os_get_pid(void)

--- a/src/nvim/os/proc.c
+++ b/src/nvim/os/proc.c
@@ -37,24 +37,24 @@
 
 #include "nvim/log.h"
 #include "nvim/memory.h"
-#include "nvim/os/process.h"
+#include "nvim/os/proc.h"
 
 #ifdef MSWIN
 # include "nvim/api/private/helpers.h"
 #endif
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/process.c.generated.h"
+# include "os/proc.c.generated.h"
 #endif
 
 #ifdef MSWIN
-static bool os_proc_tree_kill_rec(HANDLE process, int sig)
+static bool os_proc_tree_kill_rec(HANDLE proc, int sig)
 {
-  if (process == NULL) {
+  if (proc == NULL) {
     return false;
   }
   PROCESSENTRY32 pe;
-  DWORD pid = GetProcessId(process);
+  DWORD pid = GetProcessId(proc);
 
   if (pid != 0) {
     HANDLE h = CreateToolhelp32Snapshot(TH32CS_SNAPPROCESS, 0);
@@ -77,7 +77,7 @@ static bool os_proc_tree_kill_rec(HANDLE process, int sig)
   }
 
 theend:
-  return (bool)TerminateProcess(process, (unsigned)sig);
+  return (bool)TerminateProcess(proc, (unsigned)sig);
 }
 /// Kills process `pid` and its descendants recursively.
 bool os_proc_tree_kill(int pid, int sig)

--- a/src/nvim/os/proc.h
+++ b/src/nvim/os/proc.h
@@ -7,5 +7,5 @@
 #endif
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/process.h.generated.h"
+# include "os/proc.h.generated.h"
 #endif

--- a/src/nvim/os/pty_conpty_win.c
+++ b/src/nvim/os/pty_conpty_win.c
@@ -143,7 +143,7 @@ finished:
   return conpty_object;
 }
 
-bool os_conpty_spawn(conpty_t *conpty_object, HANDLE *process_handle, wchar_t *name,
+bool os_conpty_spawn(conpty_t *conpty_object, HANDLE *proc_handle, wchar_t *name,
                      wchar_t *cmd_line, wchar_t *cwd, wchar_t *env)
 {
   PROCESS_INFORMATION pi = { 0 };
@@ -159,7 +159,7 @@ bool os_conpty_spawn(conpty_t *conpty_object, HANDLE *process_handle, wchar_t *n
                       &pi)) {
     return false;
   }
-  *process_handle = pi.hProcess;
+  *proc_handle = pi.hProcess;
   return true;
 }
 

--- a/src/nvim/os/pty_proc.h
+++ b/src/nvim/os/pty_proc.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#ifdef MSWIN
+# include "nvim/os/pty_proc_win.h"
+#else
+# include "nvim/os/pty_proc_unix.h"
+#endif

--- a/src/nvim/os/pty_proc_unix.h
+++ b/src/nvim/os/pty_proc_unix.h
@@ -1,5 +1,5 @@
 #pragma once
-// IWYU pragma: private, include "nvim/os/pty_process.h"
+// IWYU pragma: private, include "nvim/os/pty_proc.h"
 
 #include <stdint.h>
 #include <sys/ioctl.h>
@@ -7,12 +7,12 @@
 #include "nvim/event/defs.h"
 
 typedef struct {
-  Process process;
+  Proc proc;
   uint16_t width, height;
   struct winsize winsize;
   int tty_fd;
-} PtyProcess;
+} PtyProc;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/pty_process_unix.h.generated.h"
+# include "os/pty_proc_unix.h.generated.h"
 #endif

--- a/src/nvim/os/pty_proc_win.h
+++ b/src/nvim/os/pty_proc_win.h
@@ -1,20 +1,20 @@
 #pragma once
-// IWYU pragma: private, include "nvim/os/pty_process.h"
+// IWYU pragma: private, include "nvim/os/pty_proc.h"
 
 #include <uv.h>
 
-#include "nvim/event/process.h"
+#include "nvim/event/proc.h"
 #include "nvim/lib/queue_defs.h"
 #include "nvim/os/pty_conpty_win.h"
 
 typedef struct pty_process {
-  Process process;
+  Proc proc;
   uint16_t width, height;
   conpty_t *conpty;
   HANDLE finish_wait;
-  HANDLE process_handle;
+  HANDLE proc_handle;
   uv_timer_t wait_eof_timer;
-} PtyProcess;
+} PtyProc;
 
 // Structure used by build_cmd_line()
 typedef struct arg_node {
@@ -23,5 +23,5 @@ typedef struct arg_node {
 } ArgNode;
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/pty_process_win.h.generated.h"
+# include "os/pty_proc_win.h.generated.h"
 #endif

--- a/src/nvim/os/pty_process.h
+++ b/src/nvim/os/pty_process.h
@@ -1,7 +1,0 @@
-#pragma once
-
-#ifdef MSWIN
-# include "nvim/os/pty_process_win.h"
-#else
-# include "nvim/os/pty_process_unix.h"
-#endif

--- a/src/nvim/profile.c
+++ b/src/nvim/profile.c
@@ -950,8 +950,8 @@ void time_msg(const char *mesg, const proftime_T *start)
 /// Initializes the `time_fd` stream for the --startuptime report.
 ///
 /// @param fname startuptime report file path
-/// @param process_name name of the current Nvim process to write in the report.
-void time_init(const char *fname, const char *process_name)
+/// @param proc_name name of the current Nvim process to write in the report.
+void time_init(const char *fname, const char *proc_name)
 {
   const size_t bufsize = 8192;  // Big enough for the entire --startuptime report.
   time_fd = fopen(fname, "a");
@@ -972,7 +972,7 @@ void time_init(const char *fname, const char *process_name)
     semsg("time_init: setvbuf failed: %d %s", r, uv_err_name(r));
     return;
   }
-  fprintf(time_fd, "--- Startup times for process: %s ---\n", process_name);
+  fprintf(time_fd, "--- Startup times for process: %s ---\n", proc_name);
 }
 
 /// Flushes the startuptimes to disk for the current process

--- a/test/README.md
+++ b/test/README.md
@@ -103,7 +103,7 @@ Debugging tests
     DBG 2022-06-15T18:37:45.227 T57.58016.0/c UI: stop
     INF 2022-06-15T18:37:45.227 T57.58016.0/c os_exit:595: Nvim exit: 0
     DBG 2022-06-15T18:37:45.229 T57.58016.0   read_cb:118: closing Stream (0x7fd5d700ea18): EOF (end of file)
-    INF 2022-06-15T18:37:45.229 T57.58016.0   on_process_exit:400: exited: pid=58017 status=0 stoptime=0
+    INF 2022-06-15T18:37:45.229 T57.58016.0   on_proc_exit:400: exited: pid=58017 status=0 stoptime=0
   ```
 - You can set `$GDB` to [run functional tests under gdbserver](https://github.com/neovim/neovim/pull/1527):
 


### PR DESCRIPTION
## Problem:
- "process" is often used as a verb (`multiqueue_process_events`), which is ambiguous for cases where it's used as a topic.
- We use "proc" in several places already.
- The documented naming convention for processes is "proc". `:help dev-name-common`
- Shorter is better, when it doesn't harm readability or discoverability.

## Solution:
Rename `process` => `proc`.