### PR TITLE
vim-patch:5e95c8f: runtime(java): Highlight javaConceptKind modifiers with StorageClass

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1683,6 +1683,12 @@ In order to highlight nested parens with different colors, define colors for
 or >
 	:hi javaParen ctermfg=blue guifg=#0000ff
 
+Certain modifiers are incompatible with each other, e.g. `abstract` and
+`final`: >
+	:syn list javaConceptKind
+and can be differently highlighted as a group than other modifiers with >
+	:hi link javaConceptKind NonText
+
 If you notice highlighting errors while scrolling backwards, which are fixed
 when redrawing with CTRL-L, try setting the "g:java_minlines" variable to
 a larger number: >

--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Aliaksei Budavei <0x000c70 AT gmail DOT com>
 " Former Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
-" Last Change:		2024 Sep 10
+" Last Change:		2024 Sep 11
 
 " Please check :help java.vim for comments on some of the options available.
 
@@ -663,7 +663,7 @@ hi def link javaStorageClass		StorageClass
 hi def link javaMethodDecl		javaStorageClass
 hi def link javaClassDecl		javaStorageClass
 hi def link javaScopeDecl		javaStorageClass
-hi def link javaConceptKind		NonText
+hi def link javaConceptKind		javaStorageClass
 
 hi def link javaBoolean			Boolean
 hi def link javaSpecial			Special


### PR DESCRIPTION
Stop assigning by default the NonText highlighting group for
javaConceptKind modifiers since its colour is hardly
distinguishable from a background colour for a range of
colour schemes.

fixes vim/vim#15237
related vim/vim#15238
closes: vim/vim#15664

https://github.com/vim/vim/commit/5e95c8f637ac8de625270fc2d371f4ebe304fac8

Co-authored-by: Aliaksei Budavei <0x000c70@gmail.com>
Co-authored-by: Dexter Gaon-Shatford <dexter@gaonshatford.ca>
