### PR TITLE
fix(coverity): CID 509571 Uninitialized variables

### DIFF
--- a/src/nvim/os/pty_proc_unix.c
+++ b/src/nvim/os/pty_proc_unix.c
@@ -408,7 +408,7 @@ static void chld_handler(uv_signal_t *handle, int signum)
 
 PtyProc pty_proc_init(Loop *loop, void *data)
 {
-  PtyProc rv;
+  PtyProc rv = { 0 };
   rv.proc = proc_init(loop, kProcTypePty, data);
   rv.width = 80;
   rv.height = 24;


### PR DESCRIPTION
    /src/nvim/os/pty_proc_unix.c: 416 in pty_proc_init()
    410     {
    411       PtyProc rv;
    412       rv.proc = proc_init(loop, kProcTypePty, data);
    413       rv.width = 80;
    414       rv.height = 24;
    415       rv.tty_fd = -1;
    >>>     CID 509571:  Uninitialized variables  (UNINIT)
    >>>     Using uninitialized value "rv". Field "rv.winsize" is uninitialized.
    416       return rv;