### PR TITLE
docs(tui): rename term.txt, nvim_terminal_emulator.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Features
 - [API access](https://github.com/neovim/neovim/wiki/Related-projects#api-clients)
   from any language including C/C++, C#, Clojure, D, Elixir, Go, Haskell, Java/Kotlin,
   JavaScript/Node.js, Julia, Lisp, Lua, Perl, Python, Racket, Ruby, Rust
-- Embedded, scriptable [terminal emulator](https://neovim.io/doc/user/nvim_terminal_emulator.html)
+- Embedded, scriptable [terminal emulator](https://neovim.io/doc/user/terminal.html)
 - Asynchronous [job control](https://github.com/neovim/neovim/pull/2247)
 - [Shared data (shada)](https://github.com/neovim/neovim/pull/2506) among multiple editor instances
 - [XDG base directories](https://github.com/neovim/neovim/pull/3470) support

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -1,4 +1,4 @@
-*terminal_emulator.txt*   Nvim
+*terminal.txt*   Nvim
 
 
 		 NVIM REFERENCE MANUAL    by Thiago de Arruda

--- a/runtime/doc/tui.txt
+++ b/runtime/doc/tui.txt
@@ -1,4 +1,4 @@
-*term.txt*      Nvim
+*tui.txt*      Nvim
 
 
                             NVIM REFERENCE MANUAL

--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -301,10 +301,6 @@ preprocess_patch() {
   LC_ALL=C sed -Ee 's/( [ab]\/runtime\/doc)\/sponsor\.txt/\1\/intro.txt/g' \
     "$file" > "$file".tmp && mv "$file".tmp "$file"
 
-  # Rename terminal.txt to nvim_terminal_emulator.txt
-  LC_ALL=C sed -Ee 's/( [ab]\/runtime\/doc)\/terminal\.txt/\1\/nvim_terminal_emulator.txt/g' \
-    "$file" > "$file".tmp && mv "$file".tmp "$file"
-
   # Rename test_urls.vim to check_urls.vim
   LC_ALL=C sed -Ee 's/( [ab])\/runtime\/doc\/test(_urls\.vim)/\1\/scripts\/check\2/g' \
     "$file" > "$file".tmp && mv "$file".tmp "$file"


### PR DESCRIPTION
## Problem:
It has long been a convention that references to the builtin terminal UI should mention "tui", not "term", in order to avoid ambiguity vs the builtin `:terminal` feature. The final step was to rename term.txt; let's take that step.

## Solution:
- rename term.txt => tui.txt
- rename nvim_terminal_emulator.txt => terminal.txt
