### PR TITLE
runtime:ftplugin: make &keywordprg Nvim compatible

### DIFF
--- a/runtime/ftplugin/gpg.vim
+++ b/runtime/ftplugin/gpg.vim
@@ -20,7 +20,7 @@ if has('unix') && executable('less')
     command -buffer -nargs=1 GpgKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+--' . <q-args> . '\b'' --hilite-search" man ' . 'gpg' |
           \ redraw!
-  elseif executable(':terminal') == 2
+  elseif exists(':terminal') == 2
     command -buffer -nargs=1 GpgKeywordPrg
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+--' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'gpg'
   endif

--- a/runtime/ftplugin/gpg.vim
+++ b/runtime/ftplugin/gpg.vim
@@ -20,7 +20,7 @@ if has('unix') && executable('less')
     command -buffer -nargs=1 GpgKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+--' . <q-args> . '\b'' --hilite-search" man ' . 'gpg' |
           \ redraw!
-  elseif has('terminal') || has('nvim')
+  elseif executable(':terminal') == 2
     command -buffer -nargs=1 GpgKeywordPrg
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+--' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'gpg'
   endif

--- a/runtime/ftplugin/gpg.vim
+++ b/runtime/ftplugin/gpg.vim
@@ -16,11 +16,11 @@ let b:undo_ftplugin = "setl com< cms< fo<"
 setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
 if has('unix') && executable('less')
-  if !has('gui_running')
+  if !has('gui_running') && !has('nvim')
     command -buffer -nargs=1 GpgKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+--' . <q-args> . '\b'' --hilite-search" man ' . 'gpg' |
           \ redraw!
-  elseif has('terminal')
+  elseif has('terminal') || has('nvim')
     command -buffer -nargs=1 GpgKeywordPrg
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+--' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'gpg'
   endif

--- a/runtime/ftplugin/modconf.vim
+++ b/runtime/ftplugin/modconf.vim
@@ -21,7 +21,7 @@ if has('unix') && executable('less')
     command -buffer -nargs=1 ModconfKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s{,8}' . <q-args> . '\b'' --hilite-search" man ' . 'modprobe.d' |
           \ redraw!
-  elseif has('terminal') || has('nvim')
+  elseif executable(':terminal') == 2
     command -buffer -nargs=1 ModconfKeywordPrg
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'modprobe.d'
   endif

--- a/runtime/ftplugin/modconf.vim
+++ b/runtime/ftplugin/modconf.vim
@@ -17,11 +17,11 @@ setlocal comments=:# commentstring=#\ %s include=^\\s*include
 setlocal formatoptions-=t formatoptions+=croql
 
 if has('unix') && executable('less')
-  if !has('gui_running')
+  if !has('gui_running') && !has('nvim')
     command -buffer -nargs=1 ModconfKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s{,8}' . <q-args> . '\b'' --hilite-search" man ' . 'modprobe.d' |
           \ redraw!
-  elseif has('terminal')
+  elseif has('terminal') || has('nvim')
     command -buffer -nargs=1 ModconfKeywordPrg
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'modprobe.d'
   endif

--- a/runtime/ftplugin/modconf.vim
+++ b/runtime/ftplugin/modconf.vim
@@ -21,7 +21,7 @@ if has('unix') && executable('less')
     command -buffer -nargs=1 ModconfKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s{,8}' . <q-args> . '\b'' --hilite-search" man ' . 'modprobe.d' |
           \ redraw!
-  elseif executable(':terminal') == 2
+  elseif exists(':terminal') == 2
     command -buffer -nargs=1 ModconfKeywordPrg
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'modprobe.d'
   endif

--- a/runtime/ftplugin/muttrc.vim
+++ b/runtime/ftplugin/muttrc.vim
@@ -23,7 +23,7 @@ if has('unix') && executable('less')
     command -buffer -nargs=1 MuttrcKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '\b'' --hilite-search" man ' . 'muttrc' |
           \ redraw!
-  elseif executable(':terminal') == 2
+  elseif exists(':terminal') == 2
     command -buffer -nargs=1 MuttrcKeywordPrg
           \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'muttrc'
   endif

--- a/runtime/ftplugin/muttrc.vim
+++ b/runtime/ftplugin/muttrc.vim
@@ -23,7 +23,7 @@ if has('unix') && executable('less')
     command -buffer -nargs=1 MuttrcKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '\b'' --hilite-search" man ' . 'muttrc' |
           \ redraw!
-  elseif has('terminal') || has('nvim')
+  elseif executable(':terminal') == 2
     command -buffer -nargs=1 MuttrcKeywordPrg
           \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'muttrc'
   endif

--- a/runtime/ftplugin/muttrc.vim
+++ b/runtime/ftplugin/muttrc.vim
@@ -19,11 +19,11 @@ setlocal formatoptions-=t formatoptions+=croql
 let &l:include = '^\s*source\>'
 
 if has('unix') && executable('less')
-  if !has('gui_running')
+  if !has('gui_running') && !has('nvim')
     command -buffer -nargs=1 MuttrcKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '\b'' --hilite-search" man ' . 'muttrc' |
           \ redraw!
-  elseif has('terminal')
+  elseif has('terminal') || has('nvim')
     command -buffer -nargs=1 MuttrcKeywordPrg
           \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'muttrc'
   endif

--- a/runtime/ftplugin/ps1.vim
+++ b/runtime/ftplugin/ps1.vim
@@ -45,11 +45,11 @@ elseif executable('powershell.exe') | let s:pwsh_cmd = 'powershell.exe'
 endif
 
 if exists('s:pwsh_cmd')
-  if !has('gui_running') && executable('less') &&
+  if !has('gui_running') && !has("nvim") && executable('less') &&
         \ !(exists('$ConEmuBuild') && &term =~? '^xterm')
     " For exclusion of ConEmu, see https://github.com/Maximus5/ConEmu/issues/2048
     command! -buffer -nargs=1 GetHelp silent exe '!' . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full "<args>" | ' . (has('unix') ? 'LESS= less' : 'less') | redraw!
-  elseif has('terminal')
+  elseif has('terminal') || has('nvim')
     command! -buffer -nargs=1 GetHelp silent exe 'term ' . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full "<args>"' . (executable('less') ? ' | less' : '')
   else
     command! -buffer -nargs=1 GetHelp echo system(s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full <args>')

--- a/runtime/ftplugin/ps1.vim
+++ b/runtime/ftplugin/ps1.vim
@@ -49,7 +49,7 @@ if exists('s:pwsh_cmd')
         \ !(exists('$ConEmuBuild') && &term =~? '^xterm')
     " For exclusion of ConEmu, see https://github.com/Maximus5/ConEmu/issues/2048
     command! -buffer -nargs=1 GetHelp silent exe '!' . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full "<args>" | ' . (has('unix') ? 'LESS= less' : 'less') | redraw!
-  elseif has('terminal') || has('nvim')
+  elseif executable(':terminal') == 2
     command! -buffer -nargs=1 GetHelp silent exe 'term ' . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full "<args>"' . (executable('less') ? ' | less' : '')
   else
     command! -buffer -nargs=1 GetHelp echo system(s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full <args>')

--- a/runtime/ftplugin/ps1.vim
+++ b/runtime/ftplugin/ps1.vim
@@ -49,7 +49,7 @@ if exists('s:pwsh_cmd')
         \ !(exists('$ConEmuBuild') && &term =~? '^xterm')
     " For exclusion of ConEmu, see https://github.com/Maximus5/ConEmu/issues/2048
     command! -buffer -nargs=1 GetHelp silent exe '!' . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full "<args>" | ' . (has('unix') ? 'LESS= less' : 'less') | redraw!
-  elseif executable(':terminal') == 2
+  elseif exists(':terminal') == 2
     command! -buffer -nargs=1 GetHelp silent exe 'term ' . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full "<args>"' . (executable('less') ? ' | less' : '')
   else
     command! -buffer -nargs=1 GetHelp echo system(s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full <args>')

--- a/runtime/ftplugin/readline.vim
+++ b/runtime/ftplugin/readline.vim
@@ -39,7 +39,7 @@ if has('unix') && executable('less')
     command -buffer -nargs=1 ReadlineKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '\b'' --hilite-search" man ' . '3 readline' |
           \ redraw!
-  elseif executable(':terminal') == 2
+  elseif exists(':terminal') == 2
     command -buffer -nargs=1 ReadlineKeywordPrg
           \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . '3 readline'
   endif

--- a/runtime/ftplugin/readline.vim
+++ b/runtime/ftplugin/readline.vim
@@ -35,11 +35,11 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
 endif
 
 if has('unix') && executable('less')
-  if !has('gui_running')
+  if !has('gui_running') && !has('nvim')
     command -buffer -nargs=1 ReadlineKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '\b'' --hilite-search" man ' . '3 readline' |
           \ redraw!
-  elseif has('terminal')
+  elseif has('terminal') || has('nvim')
     command -buffer -nargs=1 ReadlineKeywordPrg
           \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . '3 readline'
   endif

--- a/runtime/ftplugin/readline.vim
+++ b/runtime/ftplugin/readline.vim
@@ -39,7 +39,7 @@ if has('unix') && executable('less')
     command -buffer -nargs=1 ReadlineKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '\b'' --hilite-search" man ' . '3 readline' |
           \ redraw!
-  elseif has('terminal') || has('nvim')
+  elseif executable(':terminal') == 2
     command -buffer -nargs=1 ReadlineKeywordPrg
           \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . '3 readline'
   endif

--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -45,9 +45,9 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
 endif
 
 if get(b:, "is_bash", 0)
-  if !has("gui_running") && executable("less")
+  if !has("gui_running") && !has("nvim") && executable("less")
     command! -buffer -nargs=1 ShKeywordPrg silent exe '!bash -c "{ help "<args>" 2>/dev/null || MANPAGER= man "<args>"; } | LESS= less"' | redraw!
-  elseif has("terminal")
+  elseif has("terminal") || has("nvim")
     command! -buffer -nargs=1 ShKeywordPrg silent exe ':term bash -c "help "<args>" 2>/dev/null || man "<args>""'
   else
     command! -buffer -nargs=1 ShKeywordPrg echo system('bash -c "help <args>" 2>/dev/null || MANPAGER= man "<args>"')

--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -47,7 +47,7 @@ endif
 if get(b:, "is_bash", 0)
   if !has("gui_running") && !has("nvim") && executable("less")
     command! -buffer -nargs=1 ShKeywordPrg silent exe '!bash -c "{ help "<args>" 2>/dev/null || MANPAGER= man "<args>"; } | LESS= less"' | redraw!
-  elseif executable(':terminal') == 2
+  elseif exists(':terminal') == 2
     command! -buffer -nargs=1 ShKeywordPrg silent exe ':term bash -c "help "<args>" 2>/dev/null || man "<args>""'
   else
     command! -buffer -nargs=1 ShKeywordPrg echo system('bash -c "help <args>" 2>/dev/null || MANPAGER= man "<args>"')

--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -47,7 +47,7 @@ endif
 if get(b:, "is_bash", 0)
   if !has("gui_running") && !has("nvim") && executable("less")
     command! -buffer -nargs=1 ShKeywordPrg silent exe '!bash -c "{ help "<args>" 2>/dev/null || MANPAGER= man "<args>"; } | LESS= less"' | redraw!
-  elseif has("terminal") || has("nvim")
+  elseif executable(':terminal') == 2
     command! -buffer -nargs=1 ShKeywordPrg silent exe ':term bash -c "help "<args>" 2>/dev/null || man "<args>""'
   else
     command! -buffer -nargs=1 ShKeywordPrg echo system('bash -c "help <args>" 2>/dev/null || MANPAGER= man "<args>"')

--- a/runtime/ftplugin/sshconfig.vim
+++ b/runtime/ftplugin/sshconfig.vim
@@ -19,7 +19,7 @@ if has('unix') && executable('less')
     command -buffer -nargs=1 SshconfigKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '$'' --hilite-search" man ' . 'ssh_config' |
           \ redraw!
-  elseif executable(':terminal') == 2
+  elseif exists(':terminal') == 2
     command -buffer -nargs=1 SshconfigKeywordPrg
           \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '$', '\') . ''' --hilite-search" man ' . 'ssh_config'
   endif

--- a/runtime/ftplugin/sshconfig.vim
+++ b/runtime/ftplugin/sshconfig.vim
@@ -15,11 +15,11 @@ setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 let b:undo_ftplugin = 'setlocal com< cms< fo<'
 
 if has('unix') && executable('less')
-  if !has('gui_running')
+  if !has('gui_running') && !has('nvim')
     command -buffer -nargs=1 SshconfigKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '$'' --hilite-search" man ' . 'ssh_config' |
           \ redraw!
-  elseif has('terminal')
+  elseif has('terminal') || has('nvim')
     command -buffer -nargs=1 SshconfigKeywordPrg
           \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '$', '\') . ''' --hilite-search" man ' . 'ssh_config'
   endif

--- a/runtime/ftplugin/sshconfig.vim
+++ b/runtime/ftplugin/sshconfig.vim
@@ -19,7 +19,7 @@ if has('unix') && executable('less')
     command -buffer -nargs=1 SshconfigKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '$'' --hilite-search" man ' . 'ssh_config' |
           \ redraw!
-  elseif has('terminal') || has('nvim')
+  elseif executable(':terminal') == 2
     command -buffer -nargs=1 SshconfigKeywordPrg
           \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '$', '\') . ''' --hilite-search" man ' . 'ssh_config'
   endif

--- a/runtime/ftplugin/sudoers.vim
+++ b/runtime/ftplugin/sudoers.vim
@@ -20,7 +20,7 @@ if has('unix') && executable('less')
     command -buffer -nargs=1 SudoersKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''\b' . <q-args> . '\b'' --hilite-search" man ' . 'sudoers' |
           \ redraw!
-  elseif has('terminal') || has('nvim')
+  elseif executable(':terminal') == 2
     command -buffer -nargs=1 SudoersKeywordPrg
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('\b' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'sudoers'
   endif

--- a/runtime/ftplugin/sudoers.vim
+++ b/runtime/ftplugin/sudoers.vim
@@ -20,7 +20,7 @@ if has('unix') && executable('less')
     command -buffer -nargs=1 SudoersKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''\b' . <q-args> . '\b'' --hilite-search" man ' . 'sudoers' |
           \ redraw!
-  elseif executable(':terminal') == 2
+  elseif exists(':terminal') == 2
     command -buffer -nargs=1 SudoersKeywordPrg
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('\b' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'sudoers'
   endif

--- a/runtime/ftplugin/sudoers.vim
+++ b/runtime/ftplugin/sudoers.vim
@@ -16,11 +16,11 @@ let b:undo_ftplugin = "setl com< cms< fo<"
 setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
 if has('unix') && executable('less')
-  if !has('gui_running')
+  if !has('gui_running') && !has('nvim')
     command -buffer -nargs=1 SudoersKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''\b' . <q-args> . '\b'' --hilite-search" man ' . 'sudoers' |
           \ redraw!
-  elseif has('terminal')
+  elseif has('terminal') || has('nvim')
     command -buffer -nargs=1 SudoersKeywordPrg
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('\b' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'sudoers'
   endif

--- a/runtime/ftplugin/systemd.vim
+++ b/runtime/ftplugin/systemd.vim
@@ -9,9 +9,9 @@ if !exists('b:did_ftplugin')
 endif
 
 if has('unix') && executable('less')
-  if !has('gui_running')
+  if !has('gui_running') && !has('nvim')
     command -buffer -nargs=1 SystemdKeywordPrg silent exe '!' . KeywordLookup_systemd(<q-args>) | redraw!
-  elseif has('terminal')
+  elseif has('terminal') || has('nvim')
     command -buffer -nargs=1 SystemdKeywordPrg silent exe 'term ' . KeywordLookup_systemd(<q-args>)
   endif
   if exists(':SystemdKeywordPrg') == 2

--- a/runtime/ftplugin/systemd.vim
+++ b/runtime/ftplugin/systemd.vim
@@ -11,7 +11,7 @@ endif
 if has('unix') && executable('less')
   if !has('gui_running') && !has('nvim')
     command -buffer -nargs=1 SystemdKeywordPrg silent exe '!' . KeywordLookup_systemd(<q-args>) | redraw!
-  elseif has('terminal') || has('nvim')
+  elseif executable(':terminal') == 2
     command -buffer -nargs=1 SystemdKeywordPrg silent exe 'term ' . KeywordLookup_systemd(<q-args>)
   endif
   if exists(':SystemdKeywordPrg') == 2

--- a/runtime/ftplugin/systemd.vim
+++ b/runtime/ftplugin/systemd.vim
@@ -11,7 +11,7 @@ endif
 if has('unix') && executable('less')
   if !has('gui_running') && !has('nvim')
     command -buffer -nargs=1 SystemdKeywordPrg silent exe '!' . KeywordLookup_systemd(<q-args>) | redraw!
-  elseif executable(':terminal') == 2
+  elseif exists(':terminal') == 2
     command -buffer -nargs=1 SystemdKeywordPrg silent exe 'term ' . KeywordLookup_systemd(<q-args>)
   endif
   if exists(':SystemdKeywordPrg') == 2

--- a/runtime/ftplugin/udevrules.vim
+++ b/runtime/ftplugin/udevrules.vim
@@ -20,7 +20,7 @@ if has('unix') && executable('less')
     command -buffer -nargs=1 UdevrulesKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s{,8}' . <q-args> . '\b'' --hilite-search" man ' . 'udev' |
           \ redraw!
-  elseif executable(':terminal') == 2
+  elseif exists(':terminal') == 2
     command -buffer -nargs=1 UdevrulesKeywordPrg
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'udev'
   endif

--- a/runtime/ftplugin/udevrules.vim
+++ b/runtime/ftplugin/udevrules.vim
@@ -16,11 +16,11 @@ let b:undo_ftplugin = "setl com< cms< fo<"
 setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
 if has('unix') && executable('less')
-  if !has('gui_running')
+  if !has('gui_running') && !has('nvim')
     command -buffer -nargs=1 UdevrulesKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s{,8}' . <q-args> . '\b'' --hilite-search" man ' . 'udev' |
           \ redraw!
-  elseif has('terminal')
+  elseif has('terminal') || has('nvim')
     command -buffer -nargs=1 UdevrulesKeywordPrg
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'udev'
   endif

--- a/runtime/ftplugin/udevrules.vim
+++ b/runtime/ftplugin/udevrules.vim
@@ -20,7 +20,7 @@ if has('unix') && executable('less')
     command -buffer -nargs=1 UdevrulesKeywordPrg
           \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s{,8}' . <q-args> . '\b'' --hilite-search" man ' . 'udev' |
           \ redraw!
-  elseif has('terminal') || has('nvim')
+  elseif executable(':terminal') == 2
     command -buffer -nargs=1 UdevrulesKeywordPrg
           \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'udev'
   endif

--- a/runtime/ftplugin/zsh.vim
+++ b/runtime/ftplugin/zsh.vim
@@ -21,7 +21,7 @@ let b:undo_ftplugin = "setl com< cms< fo< "
 if executable('zsh') && &shell !~# '/\%(nologin\|false\)$'
   if !has('gui_running') && !has("nvim") && executable('less')
     command! -buffer -nargs=1 ZshKeywordPrg silent exe '!MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null | LESS= less"' | redraw!
-  elseif executable(':terminal') == 2
+  elseif exists(':terminal') == 2
     command! -buffer -nargs=1 ZshKeywordPrg silent exe ':term zsh -c "autoload -Uz run-help; run-help <args>"'
   else
     command! -buffer -nargs=1 ZshKeywordPrg echo system('MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null"')

--- a/runtime/ftplugin/zsh.vim
+++ b/runtime/ftplugin/zsh.vim
@@ -19,9 +19,9 @@ setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 let b:undo_ftplugin = "setl com< cms< fo< "
 
 if executable('zsh') && &shell !~# '/\%(nologin\|false\)$'
-  if !has('gui_running') && executable('less')
+  if !has('gui_running') && !has("nvim") && executable('less')
     command! -buffer -nargs=1 ZshKeywordPrg silent exe '!MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null | LESS= less"' | redraw!
-  elseif has('terminal')
+  elseif has('terminal') || has('nvim')
     command! -buffer -nargs=1 ZshKeywordPrg silent exe ':term zsh -c "autoload -Uz run-help; run-help <args>"'
   else
     command! -buffer -nargs=1 ZshKeywordPrg echo system('MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null"')

--- a/runtime/ftplugin/zsh.vim
+++ b/runtime/ftplugin/zsh.vim
@@ -21,7 +21,7 @@ let b:undo_ftplugin = "setl com< cms< fo< "
 if executable('zsh') && &shell !~# '/\%(nologin\|false\)$'
   if !has('gui_running') && !has("nvim") && executable('less')
     command! -buffer -nargs=1 ZshKeywordPrg silent exe '!MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null | LESS= less"' | redraw!
-  elseif has('terminal') || has('nvim')
+  elseif executable(':terminal') == 2
     command! -buffer -nargs=1 ZshKeywordPrg silent exe ':term zsh -c "autoload -Uz run-help; run-help <args>"'
   else
     command! -buffer -nargs=1 ZshKeywordPrg echo system('MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null"')


### PR DESCRIPTION
Since `:!` does not work for terminal output and `:term` is implemented differently, some adaptions are [necessary](https://gist.github.com/Konfekt/8e484af2955a0c7bfe82114df683ce0f/).