### PR TITLE
vim-patch:f21d28a: runtime(zathurarc): add double-click-follow to syntax script

### DIFF
--- a/runtime/syntax/zathurarc.vim
+++ b/runtime/syntax/zathurarc.vim
@@ -3,7 +3,7 @@
 " Maintainer:           Wu, Zhenyu <wuzhenyu@ustc.edu>
 " Documentation:        https://pwmt.org/projects/zathura/documentation/
 " Upstream:             https://github.com/Freed-Wu/zathurarc.vim
-" Latest Revision:      2024-04-02
+" Latest Revision:      2024-09-16
 
 if exists('b:current_syntax')
   finish
@@ -22,7 +22,7 @@ syntax region zathurarcString start=`'` skip=`\\'` end=`'`
 syntax keyword zathurarcMode normal fullscreen presentation index
 syntax keyword zathurarcBoolean true false
 syntax keyword zathurarcCommand include map set unmap
-syntax keyword zathurarcOption abort-clear-search adjust-open advance-pages-per-row completion-bg completion-fg completion-group-bg completion-group-fg completion-highlight-bg completion-highlight-fg continuous-hist-save database dbus-raise-window dbus-service default-bg default-fg exec-command filemonitor first-page-column font guioptions highlight-active-color highlight-color highlight-fg highlight-transparency incremental-search index-active-bg index-active-fg index-bg index-fg inputbar-bg inputbar-fg link-hadjust link-zoom n-completion-items notification-bg notification-error-bg notification-error-fg notification-fg notification-warning-bg notification-warning-fg page-cache-size page-padding page-right-to-left page-thumbnail-size pages-per-row recolor recolor-darkcolor recolor-keephue recolor-lightcolor recolor-reverse-video render-loading render-loading-bg render-loading-fg sandbox scroll-full-overlap scroll-hstep scroll-page-aware scroll-step scroll-wrap search-hadjust selection-clipboard selection-notification show-directories show-hidden show-recent statusbar-basename statusbar-bg statusbar-fg statusbar-h-padding statusbar-home-tilde statusbar-page-percent statusbar-v-padding synctex synctex-editor-command vertical-center window-height window-icon window-icon-document window-title-basename window-title-home-tilde window-title-page window-width zoom-center zoom-max zoom-min zoom-step
+syntax keyword zathurarcOption abort-clear-search adjust-open advance-pages-per-row completion-bg completion-fg completion-group-bg completion-group-fg completion-highlight-bg completion-highlight-fg continuous-hist-save database dbus-raise-window dbus-service default-bg default-fg double-click-follow exec-command filemonitor first-page-column font guioptions highlight-active-color highlight-color highlight-fg highlight-transparency incremental-search index-active-bg index-active-fg index-bg index-fg inputbar-bg inputbar-fg link-hadjust link-zoom n-completion-items notification-bg notification-error-bg notification-error-fg notification-fg notification-warning-bg notification-warning-fg page-cache-size page-padding page-right-to-left page-thumbnail-size pages-per-row recolor recolor-darkcolor recolor-keephue recolor-lightcolor recolor-reverse-video render-loading render-loading-bg render-loading-fg sandbox scroll-full-overlap scroll-hstep scroll-page-aware scroll-step scroll-wrap search-hadjust selection-clipboard selection-notification show-directories show-hidden show-recent statusbar-basename statusbar-bg statusbar-fg statusbar-h-padding statusbar-home-tilde statusbar-page-percent statusbar-v-padding synctex synctex-editor-command vertical-center window-height window-icon window-icon-document window-title-basename window-title-home-tilde window-title-page window-width zoom-center zoom-max zoom-min zoom-step
 
 highlight default link zathurarcComment Comment
 highlight default link zathurarcNumber Number


### PR DESCRIPTION
closes: vim/vim#15688

https://github.com/vim/vim/commit/f21d28a5c72987d42d540290e5a77500ab1a4d7c

Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>
