### PR TITLE
fix(ui): avoid wrong message scroll up

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2187,7 +2187,7 @@ static void msg_puts_display(const char *str, int maxlen, int attr, int recurse)
       msg_row = Rows - 1;
 
       // When no more prompt and no more room, truncate here
-      if (msg_no_more && lines_left == 0) {
+      if ((!recurse && *s == '\r') || (msg_no_more && lines_left == 0)) {
         break;
       }
 


### PR DESCRIPTION
Problem: after refactor the message scoll up triggered early.

Solution: Skip scrolling when bottom of screen is reached and
          current characteris newline/carriage return.


Fix #30386