### PR TITLE
fix(health): check more "old" files

### DIFF
--- a/runtime/lua/vim/health/health.lua
+++ b/runtime/lua/vim/health/health.lua
@@ -11,10 +11,14 @@ local function check_runtime()
   health.start('Runtime')
   -- Files from an old installation.
   local bad_files = {
-    ['plugin/health.vim'] = false,
     ['autoload/health/nvim.vim'] = false,
     ['autoload/health/provider.vim'] = false,
     ['autoload/man.vim'] = false,
+    ['lua/provider/node/health.lua'] = false,
+    ['lua/provider/perl/health.lua'] = false,
+    ['lua/provider/python/health.lua'] = false,
+    ['lua/provider/ruby/health.lua'] = false,
+    ['plugin/health.vim'] = false,
     ['plugin/man.vim'] = false,
     ['queries/help/highlights.scm'] = false,
     ['queries/help/injections.scm'] = false,
@@ -39,7 +43,7 @@ local function check_runtime()
         'Found old files in $VIMRUNTIME (this can cause weird behavior):\n%s',
         bad_files_msg
       ),
-      { 'Delete the $VIMRUNTIME directory (or uninstall Nvim), then reinstall Nvim.' }
+      { 'Delete the $VIMRUNTIME directory, then reinstall Nvim.' }
     )
   end
 end


### PR DESCRIPTION

# Problem

    Node.js provider (optional) ~
    - ERROR Failed to run healthcheck for "provider.node" plugin. Exception:
      …/runtime/lua/provider/node/health.lua:9: attempt to call field 'provider_disabled' (a nil value)

    Perl provider (optional) ~
    - ERROR Failed to run healthcheck for "provider.perl" plugin. Exception:
      …/runtime/lua/provider/perl/health.lua:8: attempt to call field 'provider_disabled' (a nil value)

    Python 3 provider (optional) ~
    - ERROR Failed to run healthcheck for "provider.python" plugin. Exception:
      …/runtime/lua/provider/python/health.lua:226: attempt to call field 'provider_disabled' (a nil value)

    Ruby provider (optional) ~
    - ERROR Failed to run healthcheck for "provider.ruby" plugin. Exception:
      …/runtime/lua/provider/ruby/health.lua:9: attempt to call field 'provider_disabled' (a nil value)

# Solution
Add these files to the runtime sanity check.

This covers a change from https://github.com/neovim/neovim/pull/28839 which is not in 0.10 so doesn't need a backport.


fix #29302