### PR TITLE
vim-patch: update runtime files

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -24,6 +24,7 @@
 "   2024 Aug 22 by Vim Project: fix mf-selection highlight (#15551)
 "   2024 Aug 22 by Vim Project: adjust echo output of mx command (#15550)
 "   2024 Sep 15 by Vim Project: more strict confirmation dialog (#15680)
+"   2024 Sep 19 by Vim Project: mf-selection highlight uses wrong pattern (#15700)
 "   }}}
 " Former Maintainer:	Charles E Campbell
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
@@ -6827,7 +6828,7 @@ fun! s:NetrwMarkFile(islocal,fname)
 
   let ykeep   = @@
   let curbufnr= bufnr("%")
-  let leader= '\(^\|\s\)\zs'
+  let leader= '\%(^\|\s\)\zs'
   if a:fname =~ '\a$'
    let trailer = '\>[@=|\/\*]\=\ze\%(  \|\t\|$\)'
   else

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1704,10 +1704,11 @@ cycles for such a feature to become either integrated into the platform or
 withdrawn from this effort.  To cater for early adopters, there is optional
 support in Vim for syntax related preview features that are implemented.  You
 can request it by specifying a list of preview feature numbers as follows: >
-	:let g:java_syntax_previews = [430]
+	:let g:java_syntax_previews = [455]
 
 The supported JEP numbers are to be drawn from this table:
 	`430`: String Templates [JDK 21]
+	`455`: Primitive types in Patterns, instanceof, and switch
 
 Note that as soon as the particular preview feature will have been integrated
 into the Java platform, its entry will be removed from the table and related

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1704,11 +1704,12 @@ cycles for such a feature to become either integrated into the platform or
 withdrawn from this effort.  To cater for early adopters, there is optional
 support in Vim for syntax related preview features that are implemented.  You
 can request it by specifying a list of preview feature numbers as follows: >
-	:let g:java_syntax_previews = [455]
+	:let g:java_syntax_previews = [455, 476]
 
 The supported JEP numbers are to be drawn from this table:
 	`430`: String Templates [JDK 21]
 	`455`: Primitive types in Patterns, instanceof, and switch
+	`476`: Module Import Declarations
 
 Note that as soon as the particular preview feature will have been integrated
 into the Java platform, its entry will be removed from the table and related

--- a/runtime/ftplugin/gpg.vim
+++ b/runtime/ftplugin/gpg.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:             gpg(1) configuration file
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2023-10-07
+" Latest Revision:      2024-09-19 (simplify keywordprg #15696)
 
 if exists("b:did_ftplugin")
   finish
@@ -15,20 +15,12 @@ let b:undo_ftplugin = "setl com< cms< fo<"
 
 setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
-if has('unix') && executable('less')
-  if !has('gui_running')
-    command -buffer -nargs=1 GpgKeywordPrg
-          \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+--' . <q-args> . '\b'' --hilite-search" man ' . 'gpg' |
-          \ redraw!
-  elseif has('terminal')
-    command -buffer -nargs=1 GpgKeywordPrg
-          \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+--' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'gpg'
-  endif
-  if exists(':GpgKeywordPrg') == 2
-    setlocal iskeyword+=-
-    setlocal keywordprg=:GpgKeywordPrg
-    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer GpgKeywordPrg'
-  endif
+if has('unix') && executable('less') && exists(':terminal') == 2
+  command -buffer -nargs=1 GpgKeywordPrg
+        \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+--' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'gpg'
+  setlocal iskeyword+=-
+  setlocal keywordprg=:GpgKeywordPrg
+  let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer GpgKeywordPrg'
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/modconf.vim
+++ b/runtime/ftplugin/modconf.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
 " Language:             modules.conf(5) configuration file
+" Maintainer:           This runtime file is looking for a new maintainer.
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2024-09-19 (simplify keywordprg #15696)
+" Latest Revision:      2024-09-20 (remove erroneous endif)
 
 if exists("b:did_ftplugin")
   finish
@@ -22,7 +23,6 @@ if has('unix') && executable('less') && exists(':terminal') == 2
   setlocal iskeyword+=-
   setlocal keywordprg=:ModconfKeywordPrg
   let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer ModconfKeywordPrg'
-endif
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/modconf.vim
+++ b/runtime/ftplugin/modconf.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:             modules.conf(5) configuration file
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2023-10-07
+" Latest Revision:      2024-09-19 (simplify keywordprg #15696)
 
 if exists("b:did_ftplugin")
   finish
@@ -16,20 +16,13 @@ let b:undo_ftplugin = "setl com< cms< inc< fo<"
 setlocal comments=:# commentstring=#\ %s include=^\\s*include
 setlocal formatoptions-=t formatoptions+=croql
 
-if has('unix') && executable('less')
-  if !has('gui_running')
-    command -buffer -nargs=1 ModconfKeywordPrg
-          \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s{,8}' . <q-args> . '\b'' --hilite-search" man ' . 'modprobe.d' |
-          \ redraw!
-  elseif has('terminal')
-    command -buffer -nargs=1 ModconfKeywordPrg
-          \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'modprobe.d'
-  endif
-  if exists(':ModconfKeywordPrg') == 2
-    setlocal iskeyword+=-
-    setlocal keywordprg=:ModconfKeywordPrg
-    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer ModconfKeywordPrg'
-  endif
+if has('unix') && executable('less') && exists(':terminal') == 2
+  command -buffer -nargs=1 ModconfKeywordPrg
+        \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'modprobe.d'
+  setlocal iskeyword+=-
+  setlocal keywordprg=:ModconfKeywordPrg
+  let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer ModconfKeywordPrg'
+endif
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/muttrc.vim
+++ b/runtime/ftplugin/muttrc.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:             mutt RC File
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2023-10-07
+" Latest Revision:      2024-09-19 (simplify keywordprg #15696)
 
 if exists("b:did_ftplugin")
   finish
@@ -18,20 +18,12 @@ setlocal formatoptions-=t formatoptions+=croql
 
 let &l:include = '^\s*source\>'
 
-if has('unix') && executable('less')
-  if !has('gui_running')
-    command -buffer -nargs=1 MuttrcKeywordPrg
-          \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '\b'' --hilite-search" man ' . 'muttrc' |
-          \ redraw!
-  elseif has('terminal')
-    command -buffer -nargs=1 MuttrcKeywordPrg
-          \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'muttrc'
-  endif
-  if exists(':MuttrcKeywordPrg') == 2
-    setlocal iskeyword+=-
-    setlocal keywordprg=:MuttrcKeywordPrg
-    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer MuttrcKeywordPrg'
-  endif
+if has('unix') && executable('less') && exists(':terminal') == 2
+  command -buffer -nargs=1 MuttrcKeywordPrg
+        \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'muttrc'
+  setlocal iskeyword+=-
+  setlocal keywordprg=:MuttrcKeywordPrg
+  let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer MuttrcKeywordPrg'
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/ps1.vim
+++ b/runtime/ftplugin/ps1.vim
@@ -4,6 +4,7 @@
 " Last Change: 2021 Apr 02
 "              2024 Jan 14 by Vim Project (browsefilter)
 "              2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+"              2024 Sep 19 by Konfekt (simplify keywordprg #15696)
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin") | finish | endif
@@ -35,6 +36,10 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
 	endif
 endif
 
+" Undo the stuff we changed
+let b:undo_ftplugin = "setlocal tw< cms< fo< iskeyword<" .
+			\ " | unlet! b:browsefilter"
+
 " Look up keywords by Get-Help:
 " check for PowerShell Core in Windows, Linux or MacOS
 if executable('pwsh') | let s:pwsh_cmd = 'pwsh'
@@ -45,21 +50,14 @@ elseif executable('powershell.exe') | let s:pwsh_cmd = 'powershell.exe'
 endif
 
 if exists('s:pwsh_cmd')
-  if !has('gui_running') && executable('less') &&
-        \ !(exists('$ConEmuBuild') && &term =~? '^xterm')
-    " For exclusion of ConEmu, see https://github.com/Maximus5/ConEmu/issues/2048
-    command! -buffer -nargs=1 GetHelp silent exe '!' . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full "<args>" | ' . (has('unix') ? 'LESS= less' : 'less') | redraw!
-  elseif has('terminal')
+  if exists(':terminal') == 2
     command! -buffer -nargs=1 GetHelp silent exe 'term ' . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full "<args>"' . (executable('less') ? ' | less' : '')
   else
     command! -buffer -nargs=1 GetHelp echo system(s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full <args>')
   endif
+  setlocal keywordprg=:GetHelp
+  let b:undo_ftplugin ..= " | setl kp< | sil! delc -buffer GetHelp"
 endif
-setlocal keywordprg=:GetHelp
-
-" Undo the stuff we changed
-let b:undo_ftplugin = "setlocal tw< cms< fo< iskeyword< keywordprg<" .
-			\ " | unlet! b:browsefilter"
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/ftplugin/readline.vim
+++ b/runtime/ftplugin/readline.vim
@@ -2,7 +2,7 @@
 " Language:		readline(3) configuration file
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
-" Last Change:		2023 Aug 22
+" Last Change:		2024 Sep 19 (simplify keywordprg #15696)
 
 if exists("b:did_ftplugin")
   finish
@@ -34,20 +34,12 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 
-if has('unix') && executable('less')
-  if !has('gui_running')
-    command -buffer -nargs=1 ReadlineKeywordPrg
-          \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '\b'' --hilite-search" man ' . '3 readline' |
-          \ redraw!
-  elseif has('terminal')
-    command -buffer -nargs=1 ReadlineKeywordPrg
-          \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . '3 readline'
-  endif
-  if exists(':ReadlineKeywordPrg') == 2
-    setlocal iskeyword+=-
-    setlocal keywordprg=:ReadlineKeywordPrg
-    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer ReadlineKeywordPrg'
-  endif
+if has('unix') && executable('less') && exists(':terminal') == 2
+  command -buffer -nargs=1 ReadlineKeywordPrg
+        \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . '3 readline'
+  setlocal iskeyword+=-
+  setlocal keywordprg=:ReadlineKeywordPrg
+  let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer ReadlineKeywordPrg'
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -4,7 +4,7 @@
 " Previous Maintainer:	Dan Sharp
 " Contributor:		Enno Nagel <ennonagel+vim@gmail.com>
 "			Eisuke Kawashima
-" Last Change:		2024 May 06 by Vim Project (MANPAGER=)
+" Last Change:		2024 Sep 19 by Vim Project (compiler shellcheck)
 
 if exists("b:did_ftplugin")
   finish
@@ -54,6 +54,11 @@ if get(b:, "is_bash", 0)
   endif
   setlocal keywordprg=:ShKeywordPrg
   let b:undo_ftplugin ..= " | setl kp< | sil! delc -buffer ShKeywordPrg"
+
+  if !exists('current_compiler')
+    compiler shellcheck
+  endif
+  let b:undo_ftplugin .= ' | compiler make'
 endif
 
 let &cpo = s:save_cpo

--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -45,9 +45,7 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
 endif
 
 if get(b:, "is_bash", 0)
-  if !has("gui_running") && executable("less")
-    command! -buffer -nargs=1 ShKeywordPrg silent exe '!bash -c "{ help "<args>" 2>/dev/null || MANPAGER= man "<args>"; } | LESS= less"' | redraw!
-  elseif has("terminal")
+  if exists(':terminal') == 2
     command! -buffer -nargs=1 ShKeywordPrg silent exe ':term bash -c "help "<args>" 2>/dev/null || man "<args>""'
   else
     command! -buffer -nargs=1 ShKeywordPrg echo system('bash -c "help <args>" 2>/dev/null || MANPAGER= man "<args>"')

--- a/runtime/ftplugin/sshconfig.vim
+++ b/runtime/ftplugin/sshconfig.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
-" Language:         OpenSSH client configuration file
-" Previous Maintainer:       Nikolai Weibull <now@bitwi.se>
-" Latest Revision:  2023-10-07
+" Language:	OpenSSH client configuration file
+" Maintainer:	This runtime file is looking for a new maintainer.
+" Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
+" Latest Revision:	2024-09-19 (simplify keywordprg #15696)
 
 if exists("b:did_ftplugin")
   finish
@@ -14,20 +15,12 @@ set cpo&vim
 setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 let b:undo_ftplugin = 'setlocal com< cms< fo<'
 
-if has('unix') && executable('less')
-  if !has('gui_running')
-    command -buffer -nargs=1 SshconfigKeywordPrg
-          \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s+' . <q-args> . '$'' --hilite-search" man ' . 'ssh_config' |
-          \ redraw!
-  elseif has('terminal')
-    command -buffer -nargs=1 SshconfigKeywordPrg
-          \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '$', '\') . ''' --hilite-search" man ' . 'ssh_config'
-  endif
-  if exists(':SshconfigKeywordPrg') == 2
-    setlocal iskeyword+=-
-    setlocal keywordprg=:SshconfigKeywordPrg
-    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer SshconfigKeywordPrg'
-  endif
+if has('unix') && executable('less') && exists(':terminal') == 2
+  command -buffer -nargs=1 SshconfigKeywordPrg
+        \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '$', '\') . ''' --hilite-search" man ' . 'ssh_config'
+  setlocal iskeyword+=-
+  setlocal keywordprg=:SshconfigKeywordPrg
+  let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer SshconfigKeywordPrg'
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/sudoers.vim
+++ b/runtime/ftplugin/sudoers.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
-" Language:             sudoers(5) configuration files
-" Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2023-10-07
+" Language:	sudoers(5) configuration files
+" Maintainer:	This runtime file is looking for a new maintainer.
+" Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
+" Latest Revision:	2024-09-19 (simplify keywordprg #15696)
 
 if exists("b:did_ftplugin")
   finish
@@ -15,20 +16,12 @@ let b:undo_ftplugin = "setl com< cms< fo<"
 
 setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
-if has('unix') && executable('less')
-  if !has('gui_running')
-    command -buffer -nargs=1 SudoersKeywordPrg
-          \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''\b' . <q-args> . '\b'' --hilite-search" man ' . 'sudoers' |
-          \ redraw!
-  elseif has('terminal')
-    command -buffer -nargs=1 SudoersKeywordPrg
-          \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('\b' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'sudoers'
-  endif
-  if exists(':SudoersKeywordPrg') == 2
-    setlocal iskeyword+=-
-    setlocal keywordprg=:SudoersKeywordPrg
-    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer SudoersKeywordPrg'
-  endif
+if has('unix') && executable('less') && exists(':terminal') == 2
+  command -buffer -nargs=1 SudoersKeywordPrg
+        \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('\b' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'sudoers'
+  setlocal iskeyword+=-
+  setlocal keywordprg=:SudoersKeywordPrg
+  let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer SudoersKeywordPrg'
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/systemd.vim
+++ b/runtime/ftplugin/systemd.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:			systemd.unit(5)
 " Keyword Lookup Support:	Enno Nagel <enno.nagel+vim@gmail.com>
-" Latest Revision:      2023-10-07
+" Latest Revision:		2024-09-19 (simplify keywordprg #15696)
 
 if exists("b:did_ftplugin")
   finish
@@ -9,30 +9,22 @@ endif
 " Looks a lot like dosini files.
 runtime! ftplugin/dosini.vim
 
-if has('unix') && executable('less')
-  if !has('gui_running')
-    command -buffer -nargs=1 SystemdKeywordPrg silent exe '!' . KeywordLookup_systemd(<q-args>) | redraw!
-  elseif has('terminal')
-    command -buffer -nargs=1 SystemdKeywordPrg silent exe 'term ' . KeywordLookup_systemd(<q-args>)
-  endif
-  if exists(':SystemdKeywordPrg') == 2
-    if !exists('*KeywordLookup_systemd')
-      function KeywordLookup_systemd(keyword) abort
-        let matches = matchlist(getline(search('\v^\s*\[\s*.+\s*\]\s*$', 'nbWz')), '\v^\s*\[\s*(\k+).*\]\s*$')
-        if len(matches) > 1
-          let section = matches[1]
-          return 'LESS= MANPAGER="less --pattern=''(^|,)\s+' . a:keyword . '=$'' --hilite-search" man ' . 'systemd.' . section
-        else
-          return 'LESS= MANPAGER="less --pattern=''(^|,)\s+' . a:keyword . '=$'' --hilite-search" man ' . 'systemd'
-        endif
-      endfunction
-    endif
-    setlocal iskeyword+=-
-    setlocal keywordprg=:SystemdKeywordPrg
-    if !exists('b:undo_ftplugin') || empty(b:undo_ftplugin)
-      let b:undo_ftplugin = 'setlocal keywordprg< iskeyword<'
+if has('unix') && executable('less') && exists(':terminal') == 2
+  command -buffer -nargs=1 SystemdKeywordPrg silent exe 'term ' . KeywordLookup_systemd(<q-args>)
+  silent! function KeywordLookup_systemd(keyword) abort
+    let matches = matchlist(getline(search('\v^\s*\[\s*.+\s*\]\s*$', 'nbWz')), '\v^\s*\[\s*(\k+).*\]\s*$')
+    if len(matches) > 1
+      let section = matches[1]
+      return 'LESS= MANPAGER="less --pattern=''(^|,)\s+' . a:keyword . '=$'' --hilite-search" man ' . 'systemd.' . section
     else
-      let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer SystemdKeywordPrg'
+      return 'LESS= MANPAGER="less --pattern=''(^|,)\s+' . a:keyword . '=$'' --hilite-search" man ' . 'systemd'
     endif
+  endfunction
+  setlocal iskeyword+=-
+  setlocal keywordprg=:SystemdKeywordPrg
+  if !exists('b:undo_ftplugin') || empty(b:undo_ftplugin)
+    let b:undo_ftplugin = 'setlocal keywordprg< iskeyword<'
+  else
+    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer SystemdKeywordPrg'
   endif
 endif

--- a/runtime/ftplugin/udevrules.vim
+++ b/runtime/ftplugin/udevrules.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
-" Language:             udev(8) rules file
-" Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2023-10-07
+" Language:	udev(8) rules file
+" Maintainer:	This runtime file is looking for a new maintainer.
+" Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
+" Latest Revision:	2024-09-19 (simplify keywordprg #15696)
 
 if exists("b:did_ftplugin")
   finish
@@ -15,20 +16,12 @@ let b:undo_ftplugin = "setl com< cms< fo<"
 
 setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
-if has('unix') && executable('less')
-  if !has('gui_running')
-    command -buffer -nargs=1 UdevrulesKeywordPrg
-          \ silent exe '!' . 'LESS= MANPAGER="less --pattern=''^\s{,8}' . <q-args> . '\b'' --hilite-search" man ' . 'udev' |
-          \ redraw!
-  elseif has('terminal')
-    command -buffer -nargs=1 UdevrulesKeywordPrg
-          \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'udev'
-  endif
-  if exists(':UdevrulesKeywordPrg') == 2
-    setlocal iskeyword+=-
-    setlocal keywordprg=:UdevrulesKeywordPrg
-    let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer UdevrulesKeywordPrg'
-  endif
+if has('unix') && executable('less') && exists(':terminal') == 2
+  command -buffer -nargs=1 UdevrulesKeywordPrg
+        \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'udev'
+  setlocal iskeyword+=-
+  setlocal keywordprg=:UdevrulesKeywordPrg
+  let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer UdevrulesKeywordPrg'
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/zsh.vim
+++ b/runtime/ftplugin/zsh.vim
@@ -19,9 +19,7 @@ setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 let b:undo_ftplugin = "setl com< cms< fo< "
 
 if executable('zsh') && &shell !~# '/\%(nologin\|false\)$'
-  if !has('gui_running') && executable('less')
-    command! -buffer -nargs=1 ZshKeywordPrg silent exe '!MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null | LESS= less"' | redraw!
-  elseif has('terminal')
+  if exists(':terminal') == 2
     command! -buffer -nargs=1 ZshKeywordPrg silent exe ':term zsh -c "autoload -Uz run-help; run-help <args>"'
   else
     command! -buffer -nargs=1 ZshKeywordPrg echo system('MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null"')

--- a/runtime/ftplugin/zsh.vim
+++ b/runtime/ftplugin/zsh.vim
@@ -2,7 +2,7 @@
 " Language:             Zsh shell script
 " Maintainer:           Christian Brabandt <cb@256bit.org>
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2024 May 06 by Vim Project (MANPAGER=)
+" Latest Revision:      2024 Sep 19
 " License:              Vim (see :h license)
 " Repository:           https://github.com/chrisbra/vim-zsh
 
@@ -26,11 +26,13 @@ if executable('zsh') && &shell !~# '/\%(nologin\|false\)$'
   else
     command! -buffer -nargs=1 ZshKeywordPrg echo system('MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null"')
   endif
+  setlocal keywordprg=:ZshKeywordPrg
+  let b:undo_ftplugin .= '| setl keywordprg< | sil! delc -buffer ZshKeywordPrg'
+
   if !exists('current_compiler')
     compiler zsh
   endif
-  setlocal keywordprg=:ZshKeywordPrg
-  let b:undo_ftplugin .= 'keywordprg< | sil! delc -buffer ZshKeywordPrg'
+  let b:undo_ftplugin .= ' | compiler make'
 endif
 
 let b:match_words = '\<if\>:\<elif\>:\<else\>:\<fi\>'

--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Aliaksei Budavei <0x000c70 AT gmail DOT com>
 " Former Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
-" Last Change:		2024 Sep 11
+" Last Change:		2024 Sep 18
 
 " Please check :help java.vim for comments on some of the options available.
 
@@ -283,19 +283,27 @@ if exists("g:java_space_errors")
 endif
 
 exec 'syn match javaUserLabel "^\s*\<\K\k*\>\%(\<default\>\)\@' . s:ff.Peek('7', '') . '<!\s*::\@!"he=e-1'
-syn region  javaLabelRegion	transparent matchgroup=javaLabel start="\<case\>" matchgroup=NONE end=":\|->" contains=javaLabelCastType,javaLabelNumber,javaCharacter,javaString,javaConstant,@javaClasses,javaGenerics,javaLabelDefault,javaLabelVarType,javaLabelWhenClause
+
+if s:ff.IsRequestedPreviewFeature(455)
+  syn region  javaLabelRegion	transparent matchgroup=javaLabel start="\<case\>" matchgroup=NONE end=":\|->" contains=javaBoolean,javaNumber,javaCharacter,javaString,javaConstant,@javaClasses,javaGenerics,javaType,javaLabelDefault,javaLabelVarType,javaLabelWhenClause
+else
+  syn region  javaLabelRegion	transparent matchgroup=javaLabel start="\<case\>" matchgroup=NONE end=":\|->" contains=javaLabelCastType,javaLabelNumber,javaCharacter,javaString,javaConstant,@javaClasses,javaGenerics,javaLabelDefault,javaLabelVarType,javaLabelWhenClause
+  syn keyword javaLabelCastType	contained char byte short int
+  syn match   javaLabelNumber	contained "\<0\>[lL]\@!"
+  syn match   javaLabelNumber	contained "\<\%(0\%([xX]\x\%(_*\x\)*\|_*\o\%(_*\o\)*\|[bB][01]\%(_*[01]\)*\)\|[1-9]\%(_*\d\)*\)\>[lL]\@!"
+  hi def link javaLabelCastType	javaType
+  hi def link javaLabelNumber	javaNumber
+endif
+
 syn region  javaLabelRegion	transparent matchgroup=javaLabel start="\<default\>\%(\s*\%(:\|->\)\)\@=" matchgroup=NONE end=":\|->" oneline
 " Consider grouped _default_ _case_ labels, i.e.
 " case null, default ->
 " case null: default:
 syn keyword javaLabelDefault	contained default
 syn keyword javaLabelVarType	contained var
-syn keyword javaLabelCastType	contained char byte short int
 " Allow for the contingency of the enclosing region not being able to
 " _keep_ its _end_, e.g. case ':':.
 syn region  javaLabelWhenClause	contained transparent matchgroup=javaLabel start="\<when\>" matchgroup=NONE end=":"me=e-1 end="->"me=e-2 contains=TOP,javaExternal,javaLambdaDef
-syn match   javaLabelNumber	contained "\<0\>[lL]\@!"
-syn match   javaLabelNumber	contained "\<\%(0\%([xX]\x\%(_*\x\)*\|_*\o\%(_*\o\)*\|[bB][01]\%(_*[01]\)*\)\|[1-9]\%(_*\d\)*\)\>[lL]\@!"
 
 " Comments
 syn keyword javaTodo		contained TODO FIXME XXX
@@ -692,8 +700,6 @@ hi def link javaUserLabelRef		javaUserLabel
 hi def link javaLabel			Label
 hi def link javaLabelDefault		javaLabel
 hi def link javaLabelVarType		javaOperator
-hi def link javaLabelNumber		javaNumber
-hi def link javaLabelCastType		javaType
 
 hi def link javaComment			Comment
 hi def link javaCommentStar		javaComment

--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Aliaksei Budavei <0x000c70 AT gmail DOT com>
 " Former Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
-" Last Change:		2024 Sep 18
+" Last Change:		2024 Sep 19
 
 " Please check :help java.vim for comments on some of the options available.
 
@@ -91,6 +91,13 @@ syn keyword javaConstant	null
 syn keyword javaTypedef		this super
 syn keyword javaOperator	new instanceof
 syn match   javaOperator	"\<var\>\%(\s*(\)\@!"
+
+if s:ff.IsRequestedPreviewFeature(476)
+  " Module imports can be used in any source file.
+  syn match   javaExternal	"\<import\s\+module\>" contains=javaModuleImport
+  syn keyword javaModuleImport	contained module
+  hi def link javaModuleImport	Statement
+endif
 
 " Since the yield statement, which could take a parenthesised operand,
 " and _qualified_ yield methods get along within the switch block

--- a/runtime/syntax/lyrics.vim
+++ b/runtime/syntax/lyrics.vim
@@ -2,7 +2,7 @@
 " Language:     LyRiCs
 " Maintainer:   ObserverOfTime <chronobserver@disroot.org>
 " Filenames:    *.lrc
-" Last Change:  2022 Sep 18
+" Last Change:  2024 Sep 20
 
 if exists('b:current_syntax')
     finish
@@ -23,7 +23,7 @@ syn match lrcTagName contained nextgroup=lrcTagValue
 syn match lrcTagValue /:\zs.\+\ze\]/ contained
 
 " Lyrics
-syn match lrcLyricTime /^\s*\[\d\d:\d\d\.\d\d\]/
+syn match lrcLyricTime /^\s*\(\[\d\d:\d\d\.\d\d\]\)\+/
             \ contains=lrcNumber nextgroup=lrcLyricLine
 syn match lrcLyricLine /.*$/ contained contains=lrcWordTime,@Spell
 syn match lrcWordTime /<\d\d:\d\d\.\d\d>/ contained contains=lrcNumber,@NoSpell


### PR DESCRIPTION
- **vim-patch:c18a9d5: runtime(netrw): using inefficient highlight pattern for 'mf'**
- **vim-patch:41c7bba: runtime(zsh,sh): set and unset compiler in ftplugin**
- **vim-patch:2307945: runtime(java): Optionally recognise all primitive constants in _switch-case_ labels**
