### PR TITLE
fix: bracketed paste not stored in macro recording

### DIFF
--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -268,8 +268,8 @@ do
     end
 
     local recording = vim.fn.reg_recording() -- Check if recording is currently happening
-    local function feed_paste_as_input(text, mode)
-      if mode == 'i' then
+    local function feed_paste_as_input(text, input_mode)
+      if input_mode == 'i' then
         vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(text, true, false, true), 'it', true)
       else
         vim.api.nvim_feedkeys(vim.api.nvim_replace_termcodes(text, true, false, true), 'nt', true)
@@ -277,7 +277,7 @@ do
       end
     end
 
-    local text = table.concat(lines, "\n")
+    local text = table.concat(lines, '\n')
 
     if mode:find('^i') or mode:find('^n?t') then -- Insert mode or Terminal buffer
       if recording ~= '' then


### PR DESCRIPTION
Problem: While macro recording the content from the bracketed paste do not reach the register

Solution: Use feed_keys to simulate typing of the pasted content while recording is going on

Fixes [neovim/neovim#28561](https://github.com/neovim/neovim/issues/28561) 