### PR TITLE
fix(snippet): don't auto map tab and s-tab when already have define

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4368,7 +4368,10 @@ vim.snippet.active({filter})                            *vim.snippet.active()*
 vim.snippet.expand({input})                             *vim.snippet.expand()*
     Expands the given snippet text. Refer to
     https://microsoft.github.io/language-server-protocol/specification/#snippet_syntax
-    for the specification of valid input.
+    for the specification of valid input. If no key mappings for snippet jump
+    (tab/shift-tab) are detected, this function will automatically add
+    mappings for 'tab' and 'shift-tab' in both insert ('i') and select ('s')
+    modes. restore after leave snippet.
 
     Tabstops are highlighted with |hl-SnippetTabstop|.
 


### PR DESCRIPTION
Problem:
Currently, `vim.snippet.expand` automatically creates mappings for `tab` and `shift-tab`. This is done as part of our efforts to provide some default keybindings. However, silently overriding users' existing tab and shift-tab mappings is not a good approach, especially since this is not even documented. There are too many customization possibilities with mappings. The default behavior should inject mappings only when they don't already exist, rather than overwriting them. I have checked #30306 and previous discussions, but I still believe that overriding users' mappings can cause confusion.

Solution:
Add mapping checks to ensure that mappings are injected only if they do not already exist.