### PR TITLE
build: work around bug in make when PATH includes cmake as dir

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,7 +13,7 @@ else
   MKDIR := mkdir -p
   TOUCH := touch
   RM := rm -rf
-  CMAKE := $(shell (command -v cmake3 || echo cmake))
+  CMAKE := $(shell (command -v cmake3 || command -v cmake || echo cmake))
   CMAKE_GENERATOR ?= "$(shell (command -v ninja > /dev/null 2>&1 && echo "Ninja") || echo "Unix Makefiles")"
   define rmdir
     rm -rf $1


### PR DESCRIPTION
There appears to be a bug in `make` where if a rule asks `make` to
invoke a command called `foo`, and `foo` exists somewhere in `$PATH` as
a directory (not an executable file), `make` will attempt to `execve`
that directory instead of continuing to search in later parts of the
`$PATH` for `foo` as a true executable.

The cause can be traced back to a bug in Make 4.3 which stems from their
use of the findprog function in Gnulib. This was reported to the Make
maintainers here:

https://savannah.gnu.org/bugs/index.php?57962

and then forwarded to the Gnulib maintainers here:

https://github.com/coreutils/gnulib/commit/7b1de4a

Make 4.4 does not have this bug, and I can confirm that I'm able to run
make in the Neovim repo with no further modifications to my system than
upgrading the version of make I'm using to 4.4 or 4.4.1.

As the change is small enough, and it's unlikely that make version
around the world is going to be updated in a timely manner, it makes
sense to just add a workaround for this. Using `command -v` to resolve
the `cmake` command, similar to what is already being done with
`cmake3`, makes it work correctly in all cases. Continuing to include
`... || echo cmake` at the end means that if neither `cmake3` nor
`cmake` are installed, the user will still see a message about CMake
being missing.