### PR TITLE
ci: don't add reviewers for backport PRs

### DIFF
--- a/.github/workflows/reviewers_add.yml
+++ b/.github/workflows/reviewers_add.yml
@@ -5,7 +5,7 @@ on:
   workflow_call:
 jobs:
   request-reviewer:
-    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && !endsWith(github.actor, '[bot]')
+    if: github.event.pull_request.state == 'open' && github.event.pull_request.draft == false && !startsWith(github.base_ref, 'release')
     runs-on: ubuntu-latest
     permissions:
       pull-requests: write


### PR DESCRIPTION
Trying to determine whether to add reviewers based on name turned out to
be more fragile than I imagined. Instead, simply disable reviewers for
all PRs when backporting, whether it's done manually or by the backport
action.
