### PR TITLE
fix(paste): improve repeating of pasted text

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -907,6 +907,10 @@ static int insert_handle_key(InsertState *s)
   case K_IGNORE:      // Something mapped to nothing
     break;
 
+  case K_PASTE_START:
+    paste_repeat(1);
+    goto check_pum;
+
   case K_EVENT:       // some event
     state_handle_k_event();
     // If CTRL-G U was used apply it to the next typed key.

--- a/src/nvim/keycodes.h
+++ b/src/nvim/keycodes.h
@@ -380,6 +380,10 @@ enum key_extra {
 #define K_KENTER        TERMCAP2KEY('K', 'A')   // keypad Enter
 #define K_KPOINT        TERMCAP2KEY('K', 'B')   // keypad . or ,
 
+// Delimits pasted text (to repeat nvim_paste). Internal-only, not sent by UIs.
+#define K_PASTE_START   TERMCAP2KEY('P', 'S')   // paste start
+#define K_PASTE_END     TERMCAP2KEY('P', 'E')   // paste end
+
 #define K_K0            TERMCAP2KEY('K', 'C')   // keypad 0
 #define K_K1            TERMCAP2KEY('K', 'D')   // keypad 1
 #define K_K2            TERMCAP2KEY('K', 'E')   // keypad 2

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -351,6 +351,7 @@ static const struct nv_cmd {
   { K_F1,      nv_help,        NV_NCW,                 0 },
   { K_XF1,     nv_help,        NV_NCW,                 0 },
   { K_SELECT,  nv_select,      0,                      0 },
+  { K_PASTE_START, nv_paste,   NV_KEEPREG,             0 },
   { K_EVENT,   nv_event,       NV_KEEPREG,             0 },
   { K_COMMAND, nv_colon,       0,                      0 },
   { K_LUA, nv_colon,           0,                      0 },
@@ -6591,6 +6592,12 @@ static void nv_open(cmdarg_T *cap)
   } else {
     n_opencmd(cap);
   }
+}
+
+/// Handles K_PASTE_START, repeats pasted text.
+static void nv_paste(cmdarg_T *cap)
+{
+  paste_repeat(cap->count1);
 }
 
 /// Handle an arbitrary event in normal mode

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -748,6 +748,10 @@ static int terminal_execute(VimState *state, int key)
     }
     break;
 
+  case K_PASTE_START:
+    paste_repeat(1);
+    break;
+
   case K_EVENT:
     // We cannot let an event free the terminal yet. It is still needed.
     s->term->refcount++;

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -1106,7 +1106,7 @@ describe('TUI', function()
     screen:expect(expected_grid1)
     -- Dot-repeat/redo.
     feed_data('.')
-    screen:expect([[
+    local expected_grid2 = [[
       ESC:{6:^[} / CR:                                      |
       xline 1                                           |
       ESC:{6:^[} / CR:                                      |
@@ -1114,7 +1114,8 @@ describe('TUI', function()
       {5:[No Name] [+]                   5,1            Bot}|
                                                         |
       {3:-- TERMINAL --}                                    |
-    ]])
+    ]]
+    screen:expect(expected_grid2)
     -- Undo.
     feed_data('u')
     expect_child_buf_lines(expected_crlf)
@@ -1128,6 +1129,14 @@ describe('TUI', function()
     feed_data('\027[200~' .. table.concat(expected_lf, '\r\n') .. '\027[201~')
     screen:expect(expected_grid1)
     expect_child_buf_lines(expected_crlf)
+    -- Dot-repeat/redo.
+    feed_data('.')
+    screen:expect(expected_grid2)
+    -- Undo.
+    feed_data('u')
+    expect_child_buf_lines(expected_crlf)
+    feed_data('u')
+    expect_child_buf_lines({ '' })
   end)
 
   it('paste: cmdline-mode inserts 1 line', function()


### PR DESCRIPTION
- Fixes 'autoindent' being applied during redo.
- Makes redoing a large paste significantly faster.
- Stores pasted text in the register being recorded.

Fix #28561