### PR TITLE
vim-patch:9.1.0739: [security]: use-after-free in ex_getln.c

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3028,7 +3028,6 @@ void realloc_cmdbuff(int len)
   // there, thus copy up to the NUL and add a NUL.
   memmove(ccline.cmdbuff, p, (size_t)ccline.cmdlen);
   ccline.cmdbuff[ccline.cmdlen] = NUL;
-  xfree(p);
 
   if (ccline.xpc != NULL
       && ccline.xpc->xp_pattern != NULL
@@ -3042,6 +3041,8 @@ void realloc_cmdbuff(int len)
       ccline.xpc->xp_pattern = ccline.cmdbuff + i;
     }
   }
+
+  xfree(p);
 }
 
 enum { MAX_CB_ERRORS = 1, };


### PR DESCRIPTION
#### vim-patch:9.1.0739: [security]: use-after-free in ex_getln.c

Problem:  [security]: use-after-free in ex_getln.c
Solution: free pointer p a bit later (John Marriott)

closes: vim/vim#15712

https://github.com/vim/vim/commit/a6de28755ec3fcc86d1ed0b744f1b410a8e9702d

Co-authored-by: John Marriott <basilisk@internode.on.net>