### PR TITLE
vim-patch:e6b01cf: runtime(dist): do not output a message if executable is not found

### DIFF
--- a/runtime/autoload/dist/vim.vim
+++ b/runtime/autoload/dist/vim.vim
@@ -19,7 +19,6 @@ if !has('vim9script')
   function dist#vim#IsSafeExecutable(filetype, executable)
     let cwd = getcwd()
     if empty(exepath(a:executable))
-      echomsg a:executable .. " not found in $PATH"
       return v:false
     endif
     return get(g:, a:filetype .. '_exec', get(g:, 'plugin_exec', 0)) &&


### PR DESCRIPTION
#### vim-patch:e6b01cf: runtime(dist): do not output a message if executable is not found

https://github.com/vim/vim/commit/e6b01cfe01a2722ec55a011ae04c4c404e88f924

Co-authored-by: Christian Brabandt <cb@256bit.org>