### PR TITLE
build(cmake): remove unnecessary policy code

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -1,5 +1,5 @@
 # This is not meant to be included by the top-level.
-cmake_minimum_required (VERSION 3.16)
+cmake_minimum_required(VERSION 3.16)
 project(NVIM_DEPS C)
 
 if(POLICY CMP0135)

--- a/cmake/Deps.cmake
+++ b/cmake/Deps.cmake
@@ -18,11 +18,6 @@ if(APPLE)
   list(APPEND DEPS_CMAKE_ARGS -D CMAKE_FIND_FRAMEWORK=${CMAKE_FIND_FRAMEWORK})
 endif()
 
-# Can be removed once minimum version is at least 3.15
-if(POLICY CMP0092)
-  list(APPEND DEPS_CMAKE_ARGS -D CMAKE_POLICY_DEFAULT_CMP0092=NEW)
-endif()
-
 find_program(CACHE_PRG NAMES ccache sccache)
 if(CACHE_PRG)
   set(CMAKE_C_COMPILER_LAUNCHER ${CMAKE_COMMAND} -E env CCACHE_SLOPPINESS=pch_defines,time_macros ${CACHE_PRG})


### PR DESCRIPTION
Policy CMP0092 is by default on for minimum cmake versions above 3.15.
