### PR TITLE
build: silence "po" noise

### DIFF
--- a/src/nvim/po/CMakeLists.txt
+++ b/src/nvim/po/CMakeLists.txt
@@ -53,13 +53,13 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
   list(SORT NVIM_RELATIVE_SOURCES)
   add_custom_command(
     OUTPUT ${NVIM_POT}
-    COMMAND $<TARGET_FILE:nvim_bin> -u NONE -i NONE -n --headless --cmd "set cpo+=+"
+    COMMAND $<TARGET_FILE:nvim_bin> -u NONE -i NONE -n -es --cmd "set cpo+=+"
       -S ${CMAKE_CURRENT_SOURCE_DIR}/tojavascript.vim ${NVIM_POT} ${PROJECT_SOURCE_DIR}/runtime/optwin.vim
     COMMAND ${XGETTEXT_PRG} -o ${NVIM_POT} --default-domain=nvim
       --add-comments --keyword=_ --keyword=N_ --keyword=NGETTEXT:1,2
       -D ${CMAKE_CURRENT_SOURCE_DIR} -D ${CMAKE_CURRENT_BINARY_DIR}
       ${NVIM_RELATIVE_SOURCES} optwin.js
-    COMMAND $<TARGET_FILE:nvim_bin> -u NONE -i NONE -n --headless --cmd "set cpo+=+"
+    COMMAND $<TARGET_FILE:nvim_bin> -u NONE -i NONE -n -es --cmd "set cpo+=+"
       -S ${CMAKE_CURRENT_SOURCE_DIR}/fixfilenames.vim ${NVIM_POT} ../../../runtime/optwin.vim
     VERBATIM
     DEPENDS ${NVIM_SOURCES} nvim_bin nvim_runtime_deps)

--- a/src/nvim/po/CMakeLists.txt
+++ b/src/nvim/po/CMakeLists.txt
@@ -53,14 +53,16 @@ if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
   list(SORT NVIM_RELATIVE_SOURCES)
   add_custom_command(
     OUTPUT ${NVIM_POT}
-    COMMAND $<TARGET_FILE:nvim_bin> -u NONE -i NONE -n -es --cmd "set cpo+=+"
-      -S ${CMAKE_CURRENT_SOURCE_DIR}/tojavascript.vim ${NVIM_POT} ${PROJECT_SOURCE_DIR}/runtime/optwin.vim
+    COMMAND $<TARGET_FILE:nvim_bin> -u NONE -i NONE -n --headless --cmd "set cpo+=+"
+      -c "silent source ${CMAKE_CURRENT_SOURCE_DIR}/tojavascript.vim"
+      ${NVIM_POT} ${PROJECT_SOURCE_DIR}/runtime/optwin.vim
     COMMAND ${XGETTEXT_PRG} -o ${NVIM_POT} --default-domain=nvim
       --add-comments --keyword=_ --keyword=N_ --keyword=NGETTEXT:1,2
       -D ${CMAKE_CURRENT_SOURCE_DIR} -D ${CMAKE_CURRENT_BINARY_DIR}
       ${NVIM_RELATIVE_SOURCES} optwin.js
-    COMMAND $<TARGET_FILE:nvim_bin> -u NONE -i NONE -n -es --cmd "set cpo+=+"
-      -S ${CMAKE_CURRENT_SOURCE_DIR}/fixfilenames.vim ${NVIM_POT} ../../../runtime/optwin.vim
+    COMMAND $<TARGET_FILE:nvim_bin> -u NONE -i NONE -n --headless --cmd "set cpo+=+"
+      -c "silent source ${CMAKE_CURRENT_SOURCE_DIR}/fixfilenames.vim"
+      ${NVIM_POT} ${PROJECT_SOURCE_DIR}/runtime/optwin.vim
     VERBATIM
     DEPENDS ${NVIM_SOURCES} nvim_bin nvim_runtime_deps)
 


### PR DESCRIPTION
## Problem:
Noise in stderr from src/nvim/po/CMakeLists.txt during build:

    48 substitutions on 48 lines
    "optwin.js" "optwin.js" 1299L, 57582B written
    385 substitutions on 385 lines
    "nvim.pot" "nvim.pot" 9318L, 180177B written

## Solution:
Run with `-c silent source` instead of `-S`.