### PR TITLE
fix(runtime): treat b:undo_ftplugin consistently in Lua ftplugins

### DIFF
--- a/runtime/ftplugin/arduino.lua
+++ b/runtime/ftplugin/arduino.lua
@@ -1,1 +1,3 @@
 vim.bo.commentstring = '// %s'
+
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring<'

--- a/runtime/ftplugin/c.lua
+++ b/runtime/ftplugin/c.lua
@@ -11,4 +11,4 @@ if vim.fn.isdirectory('/usr/include') == 1 then
   ]])
 end
 
-vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | setl path<'
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring< define< include< path<'

--- a/runtime/ftplugin/ch.lua
+++ b/runtime/ftplugin/ch.lua
@@ -1,1 +1,3 @@
 vim.bo.commentstring = '// %s'
+
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring<'

--- a/runtime/ftplugin/cs.lua
+++ b/runtime/ftplugin/cs.lua
@@ -1,3 +1,3 @@
 vim.bo.commentstring = '// %s'
 
-vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | setl commentstring<'
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring<'

--- a/runtime/ftplugin/d.lua
+++ b/runtime/ftplugin/d.lua
@@ -1,3 +1,3 @@
 vim.bo.commentstring = '// %s'
 
-vim.b.undo_ftplugin = 'setl commentstring<'
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring<'

--- a/runtime/ftplugin/glsl.lua
+++ b/runtime/ftplugin/glsl.lua
@@ -1,3 +1,3 @@
 vim.bo.commentstring = '// %s'
 
-vim.b.undo_ftplugin = 'setl commentstring<'
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring<'

--- a/runtime/ftplugin/help.lua
+++ b/runtime/ftplugin/help.lua
@@ -31,5 +31,5 @@ vim.keymap.set('n', 'gO', function()
   require('vim.vimhelp').show_toc()
 end, { buffer = 0, silent = true })
 
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n exe "nunmap <buffer> gO"'
 vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | call v:lua.vim.treesitter.stop()'
-vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | nunmap <buffer> gO'

--- a/runtime/ftplugin/indent.lua
+++ b/runtime/ftplugin/indent.lua
@@ -1,1 +1,3 @@
 vim.bo.commentstring = '// %s'
+
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring<'

--- a/runtime/ftplugin/lua.lua
+++ b/runtime/ftplugin/lua.lua
@@ -1,4 +1,4 @@
 -- use treesitter over syntax
 vim.treesitter.start()
 
-vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | call v:lua.vim.treesitter.stop()'
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n call v:lua.vim.treesitter.stop()'

--- a/runtime/ftplugin/objc.lua
+++ b/runtime/ftplugin/objc.lua
@@ -1,1 +1,3 @@
 vim.bo.commentstring = '// %s'
+
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring<'

--- a/runtime/ftplugin/query.lua
+++ b/runtime/ftplugin/query.lua
@@ -34,5 +34,5 @@ end
 -- it's a lisp!
 vim.cmd([[runtime! ftplugin/lisp.vim]])
 
-vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | setl omnifunc< iskeyword<'
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl omnifunc< iskeyword<'
 vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | call v:lua.vim.treesitter.stop()'

--- a/runtime/ftplugin/swift.lua
+++ b/runtime/ftplugin/swift.lua
@@ -1,3 +1,3 @@
 vim.bo.commentstring = '// %s'
 
-vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | setl commentstring<'
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring<'

--- a/runtime/ftplugin/xs.lua
+++ b/runtime/ftplugin/xs.lua
@@ -1,1 +1,3 @@
 vim.bo.commentstring = '// %s'
+
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring<'


### PR DESCRIPTION
- Don't assume b:undo_ftplugin is set when first modifying it.
- Don't assume b:undo_ftplugin already contains some resetting.
