### PR TITLE
fix(vim.fs): dirname() returns "." on mingw/msys2

### DIFF
--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -2,7 +2,9 @@ local uv = vim.uv
 
 local M = {}
 
-local iswin = uv.os_uname().sysname == 'Windows_NT'
+-- Can't use `has('win32')` because the `nvim -ll` test runner doesn't support `vim.fn` yet.
+local sysname = uv.os_uname().sysname:lower()
+local iswin = not not (sysname:find('windows') or sysname:find('mingw'))
 local os_sep = iswin and '\\' or '/'
 
 --- Iterate over all the parents of the given path.

--- a/runtime/lua/vim/loader.lua
+++ b/runtime/lua/vim/loader.lua
@@ -208,8 +208,7 @@ end
 ---@return string|function
 ---@private
 function Loader.loader_lib(modname)
-  local sysname = uv.os_uname().sysname:lower() or ''
-  local is_win = sysname:find('win', 1, true) and not sysname:find('darwin', 1, true)
+  local is_win = vim.fn.has('win32') == 1
   local ret = M.find(modname, { patterns = is_win and { '.dll' } or { '.so' } })[1]
   if ret then
     -- Making function name in Lua 5.1 (see src/loadlib.c:mkfuncname) is

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -3,7 +3,7 @@ local log = require('vim.lsp.log')
 local protocol = require('vim.lsp.protocol')
 local validate, schedule, schedule_wrap = vim.validate, vim.schedule, vim.schedule_wrap
 
-local is_win = uv.os_uname().version:find('Windows')
+local is_win = vim.fn.has('win32') == 1
 
 --- Checks whether a given path exists and is a directory.
 ---@param filename string path to check

--- a/runtime/lua/vim/provider/health.lua
+++ b/runtime/lua/vim/provider/health.lua
@@ -1,5 +1,5 @@
 local health = vim.health
-local iswin = vim.uv.os_uname().sysname == 'Windows_NT'
+local iswin = vim.fn.has('win32') == 1
 
 local M = {}
 

--- a/test/testutil.lua
+++ b/test/testutil.lua
@@ -392,7 +392,7 @@ function M.check_logs()
   )
 end
 
-function M.sysname()
+local function sysname()
   return uv.os_uname().sysname:lower()
 end
 
@@ -403,11 +403,11 @@ function M.is_os(s)
     error('unknown platform: ' .. tostring(s))
   end
   return not not (
-    (s == 'win' and (M.sysname():find('windows') or M.sysname():find('mingw')))
-    or (s == 'mac' and M.sysname() == 'darwin')
-    or (s == 'freebsd' and M.sysname() == 'freebsd')
-    or (s == 'openbsd' and M.sysname() == 'openbsd')
-    or (s == 'bsd' and M.sysname():find('bsd'))
+    (s == 'win' and (sysname():find('windows') or sysname():find('mingw')))
+    or (s == 'mac' and sysname() == 'darwin')
+    or (s == 'freebsd' and sysname() == 'freebsd')
+    or (s == 'openbsd' and sysname() == 'openbsd')
+    or (s == 'bsd' and sysname():find('bsd'))
   )
 end
 


### PR DESCRIPTION
Problem:
`vim.fs.dirname([[C:\User\XXX\AppData\Local]])` returns "." on mingw/msys2.

Solution:
- Check for "mingw" when deciding `iswin`.
- Use `has("win32")` where possible, it works in "fast" contexts since  b02eeb6a7281df0561a021d7ae595c84be9a01be.

fix #30212