### PR TITLE
use "nvim -l" as test runner

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -68,7 +68,7 @@ endif()
 execute_process(
   # Note: because of "-ll" (low-level interpreter mode), some modules like
   # _editor.lua are not loaded.
-  COMMAND ${NVIM_PRG} -ll ${WORKING_DIR}/test/lua_runner.lua ${DEPS_INSTALL_DIR} busted -v -o test.busted.outputHandlers.nvim
+  COMMAND ${NVIM_PRG} -i NONE -u NONE -l ${WORKING_DIR}/test/lua_runner.lua ${DEPS_INSTALL_DIR} busted -v -o test.busted.outputHandlers.nvim
     --lazy --helper=${TEST_DIR}/${TEST_TYPE}/preload.lua
     --lpath=${BUILD_DIR}/?.lua
     --lpath=${WORKING_DIR}/runtime/lua/?.lua

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -62,27 +62,8 @@ end
 ---@param file T Path
 ---@return T Parent directory of {file}
 function M.dirname(file)
-  if file == nil then
-    return nil
-  end
   vim.validate('file', file, 'string')
-  if iswin then
-    file = file:gsub(os_sep, '/') --[[@as string]]
-    if file:match('^%w:/?$') then
-      return file
-    end
-  end
-  if not file:match('/') then
-    return '.'
-  elseif file == '/' or file:match('^/[^/]+$') then
-    return '/'
-  end
-  ---@type string
-  local dir = file:match('/$') and file:sub(1, #file - 1) or file:match('^(/?.+)/')
-  if iswin and dir:match('^%w:$') then
-    return dir .. '/'
-  end
-  return dir
+  return vim.fn.fnamemodify(file, ':h')
 end
 
 --- Return the basename of the given path
@@ -92,17 +73,8 @@ end
 ---@param file T Path
 ---@return T Basename of {file}
 function M.basename(file)
-  if file == nil then
-    return nil
-  end
   vim.validate('file', file, 'string')
-  if iswin then
-    file = file:gsub(os_sep, '/') --[[@as string]]
-    if file:match('^%w:/?$') then
-      return ''
-    end
-  end
-  return file:match('/$') and '' or (file:match('[^/]*$'))
+  return vim.fn.fnamemodify(file, ':t')
 end
 
 --- Concatenates partial paths (one absolute or relative path followed by zero or more relative


### PR DESCRIPTION
## Problem:
61e99217e684 replaced usages of `vim.fn`. This duplicates non-trivial logic and may have introduced bugs like 38e38d1b401e.

Later on, b02eeb6a7281 graduated `fnamemodify` to `fast`, so avoiding it in `vim.fs` is no longer necessary.

## Solution:
- Use `vim.fn` to deduplicate logic and increase quality.
- Use `nvim -l` instead of `nvim -ll` in the test runner.
    - This is a test balloon to see what CI does. 