### PR TITLE
docs: remove mention of removed parsers

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -22,11 +22,9 @@ search for in the `parser` runtime directory.
 
 Nvim includes these parsers:
 
-- Bash
 - C
 - Lua
 - Markdown
-- Python
 - Vimscript
 - Vimdoc
 - Treesitter query files |ft-query-plugin|


### PR DESCRIPTION
Partial backport of https://github.com/neovim/neovim/pull/29719.