### PR TITLE
vim-patch:9.1.{0741,0742}: No way to get prompt for input()/confirm()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2361,18 +2361,18 @@ getcmdcompltype()                                            *getcmdcompltype()*
 		Only works when the command line is being edited, thus
 		requires use of |c_CTRL-\_e| or |c_CTRL-R_=|.
 		See |:command-completion| for the return string.
-		Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()| and
-		|setcmdline()|.
+		Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()|,
+		|getcmdprompt()| and |setcmdline()|.
 		Returns an empty string when completion is not defined.
 
 getcmdline()                                                      *getcmdline()*
-		Return the current command-line.  Only works when the command
-		line is being edited, thus requires use of |c_CTRL-\_e| or
-		|c_CTRL-R_=|.
+		Return the current command-line input.  Only works when the
+		command line is being edited, thus requires use of
+		|c_CTRL-\_e| or |c_CTRL-R_=|.
 		Example: >vim
 			cmap <F7> <C-\>eescape(getcmdline(), ' \')<CR>
-<		Also see |getcmdtype()|, |getcmdpos()|, |setcmdpos()| and
-		|setcmdline()|.
+<		Also see |getcmdtype()|, |getcmdpos()|, |setcmdpos()|,
+		|getcmdprompt()| and |setcmdline()|.
 		Returns an empty string when entering a password or using
 		|inputsecret()|.
 
@@ -2382,8 +2382,16 @@ getcmdpos()                                                        *getcmdpos()*
 		Only works when editing the command line, thus requires use of
 		|c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
 		Returns 0 otherwise.
-		Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()| and
-		|setcmdline()|.
+		Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()|,
+		|getcmdprompt()| and |setcmdline()|.
+
+getcmdprompt()                                                  *getcmdprompt()*
+		Return the current command-line prompt when using functions
+		like |input()| or |confirm()|.
+		Only works when the command line is being edited, thus
+		requires use of |c_CTRL-\_e| or |c_CTRL-R_=|.
+		Also see |getcmdtype()|, |getcmdline()|, |getcmdpos()|,
+		|setcmdpos()| and |setcmdline()|.
 
 getcmdscreenpos()                                            *getcmdscreenpos()*
 		Return the screen position of the cursor in the command line

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -908,7 +908,8 @@ Buffers, windows and the argument list:
 Command line:					*command-line-functions*
 	getcmdcompltype()	get the type of the current command line
 				completion
-	getcmdline()		get the current command line
+	getcmdline()		get the current command line input
+	getcmdprompt()		get the current command line prompt
 	getcmdpos()		get position of the cursor in the command line
 	getcmdscreenpos()	get screen position of the cursor in the
 				command line

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -2883,20 +2883,20 @@ function vim.fn.getcharstr(expr) end
 --- Only works when the command line is being edited, thus
 --- requires use of |c_CTRL-\_e| or |c_CTRL-R_=|.
 --- See |:command-completion| for the return string.
---- Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()| and
---- |setcmdline()|.
+--- Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()|,
+--- |getcmdprompt()| and |setcmdline()|.
 --- Returns an empty string when completion is not defined.
 ---
 --- @return string
 function vim.fn.getcmdcompltype() end
 
---- Return the current command-line.  Only works when the command
---- line is being edited, thus requires use of |c_CTRL-\_e| or
---- |c_CTRL-R_=|.
+--- Return the current command-line input.  Only works when the
+--- command line is being edited, thus requires use of
+--- |c_CTRL-\_e| or |c_CTRL-R_=|.
 --- Example: >vim
 ---   cmap <F7> <C-\>eescape(getcmdline(), ' \')<CR>
---- <Also see |getcmdtype()|, |getcmdpos()|, |setcmdpos()| and
---- |setcmdline()|.
+--- <Also see |getcmdtype()|, |getcmdpos()|, |setcmdpos()|,
+--- |getcmdprompt()| and |setcmdline()|.
 --- Returns an empty string when entering a password or using
 --- |inputsecret()|.
 ---
@@ -2908,11 +2908,21 @@ function vim.fn.getcmdline() end
 --- Only works when editing the command line, thus requires use of
 --- |c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
 --- Returns 0 otherwise.
---- Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()| and
---- |setcmdline()|.
+--- Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()|,
+--- |getcmdprompt()| and |setcmdline()|.
 ---
 --- @return integer
 function vim.fn.getcmdpos() end
+
+--- Return the current command-line prompt when using functions
+--- like |input()| or |confirm()|.
+--- Only works when the command line is being edited, thus
+--- requires use of |c_CTRL-\_e| or |c_CTRL-R_=|.
+--- Also see |getcmdtype()|, |getcmdline()|, |getcmdpos()|,
+--- |setcmdpos()| and |setcmdline()|.
+---
+--- @return string
+function vim.fn.getcmdprompt() end
 
 --- Return the screen position of the cursor in the command line
 --- as a byte count.  The first column is 1.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -3594,8 +3594,8 @@ M.funcs = {
       Only works when the command line is being edited, thus
       requires use of |c_CTRL-\_e| or |c_CTRL-R_=|.
       See |:command-completion| for the return string.
-      Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()| and
-      |setcmdline()|.
+      Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()|,
+      |getcmdprompt()| and |setcmdline()|.
       Returns an empty string when completion is not defined.
     ]=],
     name = 'getcmdcompltype',
@@ -3605,13 +3605,13 @@ M.funcs = {
   },
   getcmdline = {
     desc = [=[
-      Return the current command-line.  Only works when the command
-      line is being edited, thus requires use of |c_CTRL-\_e| or
-      |c_CTRL-R_=|.
+      Return the current command-line input.  Only works when the
+      command line is being edited, thus requires use of
+      |c_CTRL-\_e| or |c_CTRL-R_=|.
       Example: >vim
       	cmap <F7> <C-\>eescape(getcmdline(), ' \')<CR>
-      <Also see |getcmdtype()|, |getcmdpos()|, |setcmdpos()| and
-      |setcmdline()|.
+      <Also see |getcmdtype()|, |getcmdpos()|, |setcmdpos()|,
+      |getcmdprompt()| and |setcmdline()|.
       Returns an empty string when entering a password or using
       |inputsecret()|.
     ]=],
@@ -3627,13 +3627,27 @@ M.funcs = {
       Only works when editing the command line, thus requires use of
       |c_CTRL-\_e| or |c_CTRL-R_=| or an expression mapping.
       Returns 0 otherwise.
-      Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()| and
-      |setcmdline()|.
+      Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()|,
+      |getcmdprompt()| and |setcmdline()|.
     ]=],
     name = 'getcmdpos',
     params = {},
     returns = 'integer',
     signature = 'getcmdpos()',
+  },
+  getcmdprompt = {
+    desc = [=[
+      Return the current command-line prompt when using functions
+      like |input()| or |confirm()|.
+      Only works when the command line is being edited, thus
+      requires use of |c_CTRL-\_e| or |c_CTRL-R_=|.
+      Also see |getcmdtype()|, |getcmdline()|, |getcmdpos()|,
+      |setcmdpos()| and |setcmdline()|.
+    ]=],
+    name = 'getcmdprompt',
+    params = {},
+    returns = 'string',
+    signature = 'getcmdprompt()',
   },
   getcmdscreenpos = {
     desc = [=[

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -813,6 +813,8 @@ static void f_confirm(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   const char *message = tv_get_string_chk(&argvars[0]);
   if (message == NULL) {
     error = true;
+  } else {
+    set_prompt(message);
   }
   if (argvars[1].v_type != VAR_UNKNOWN) {
     buttons = tv_get_string_buf_chk(&argvars[1], buf);

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -813,8 +813,6 @@ static void f_confirm(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   const char *message = tv_get_string_chk(&argvars[0]);
   if (message == NULL) {
     error = true;
-  } else {
-    set_prompt(message);
   }
   if (argvars[1].v_type != VAR_UNKNOWN) {
     buttons = tv_get_string_buf_chk(&argvars[1], buf);

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4132,26 +4132,13 @@ void f_getcmdpos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   rettv->vval.v_number = p != NULL ? p->cmdpos + 1 : 0;
 }
 
-static char current_prompt[CMDBUFFSIZE + 1] = "";
-
-/// Get current command line prompt.
-static char *get_prompt(void)
-{
-  return current_prompt;
-}
-
-/// Set current command line prompt.
-void set_prompt(const char *str)
-{
-  xstrlcpy(current_prompt, str, sizeof(current_prompt));
-}
-
 /// "getcmdprompt()" function
 void f_getcmdprompt(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
   CmdlineInfo *p = get_ccline_ptr();
   rettv->v_type = VAR_STRING;
-  rettv->vval.v_string = p != NULL ? xstrdup(get_prompt()) : NULL;
+  rettv->vval.v_string = p != NULL && p->cmdprompt != NULL
+                         ? xstrdup(p->cmdprompt) : NULL;
 }
 
 /// "getcmdscreenpos()" function
@@ -4752,8 +4739,6 @@ void get_user_input(const typval_T *const argvars, typval_T *const rettv, const 
   const bool cmd_silent_save = cmd_silent;
 
   cmd_silent = false;  // Want to see the prompt.
-  set_prompt(prompt);
-
   // Only the part of the message after the last NL is considered as
   // prompt for the command line, unlsess cmdline is externalized
   const char *p = prompt;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4132,6 +4132,28 @@ void f_getcmdpos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   rettv->vval.v_number = p != NULL ? p->cmdpos + 1 : 0;
 }
 
+static char current_prompt[CMDBUFFSIZE + 1] = "";
+
+/// Get current command line prompt.
+static char *get_prompt(void)
+{
+  return current_prompt;
+}
+
+/// Set current command line prompt.
+void set_prompt(const char *str)
+{
+  xstrlcpy(current_prompt, str, sizeof(current_prompt));
+}
+
+/// "getcmdprompt()" function
+void f_getcmdprompt(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+{
+  CmdlineInfo *p = get_ccline_ptr();
+  rettv->v_type = VAR_STRING;
+  rettv->vval.v_string = p != NULL ? xstrdup(get_prompt()) : NULL;
+}
+
 /// "getcmdscreenpos()" function
 void f_getcmdscreenpos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
@@ -4730,6 +4752,8 @@ void get_user_input(const typval_T *const argvars, typval_T *const rettv, const 
   const bool cmd_silent_save = cmd_silent;
 
   cmd_silent = false;  // Want to see the prompt.
+  set_prompt(prompt);
+
   // Only the part of the message after the last NL is considered as
   // prompt for the command line, unlsess cmdline is externalized
   const char *p = prompt;

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -1534,7 +1534,7 @@ endfunc
 
 set cpo&
 
-func Test_getcmdtype()
+func Test_getcmdtype_getcmdprompt()
   call feedkeys(":MyCmd a\<C-R>=Check_cmdline(':')\<CR>\<Esc>", "xt")
 
   let cmdtype = ''
@@ -1558,6 +1558,20 @@ func Test_getcmdtype()
   cunmap <F6>
 
   call assert_equal('', getcmdline())
+
+  call assert_equal('', getcmdprompt())
+  augroup test_CmdlineEnter
+    autocmd!
+    autocmd CmdlineEnter * let g:cmdprompt=getcmdprompt()
+  augroup END
+  call feedkeys(":call input('Answer?')\<CR>a\<CR>\<ESC>", "xt")
+  call assert_equal('Answer?', g:cmdprompt)
+  call assert_equal('', getcmdprompt())
+
+  augroup test_CmdlineEnter
+    au!
+  augroup END
+  augroup! test_CmdlineEnter
 endfunc
 
 func Test_getcmdwintype()

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -1567,6 +1567,17 @@ func Test_getcmdtype_getcmdprompt()
   call feedkeys(":call input('Answer?')\<CR>a\<CR>\<ESC>", "xt")
   call assert_equal('Answer?', g:cmdprompt)
   call assert_equal('', getcmdprompt())
+  call feedkeys(":\<CR>\<ESC>", "xt")
+  call assert_equal('', g:cmdprompt)
+  call assert_equal('', getcmdprompt())
+
+  let str = "C" .. repeat("c", 1023) .. "xyz"
+  call feedkeys(":call input('" .. str .. "')\<CR>\<CR>\<ESC>", "xt")
+  call assert_equal(str, g:cmdprompt)
+
+  call feedkeys(':call input("Msg1\nMessage2\nAns?")' .. "\<CR>b\<CR>\<ESC>", "xt")
+  call assert_equal('Ans?', g:cmdprompt)
+  call assert_equal('', getcmdprompt())
 
   augroup test_CmdlineEnter
     au!


### PR DESCRIPTION
#### vim-patch:9.1.0741: No way to get prompt for input()/confirm()

Problem:  No way to get prompt for input()/confirm()
Solution: add getcmdprompt() function (Shougo Matsushita)
          (Shougo Matsushita)

closes: vim/vim#15667

https://github.com/vim/vim/commit/6908428560a0d6ae27bf7af6fcb6dc362e31926c

Co-authored-by: Shougo Matsushita <Shougo.Matsu@gmail.com>


#### vim-patch:9.1.0742: getcmdprompt() implementation can be improved

Problem:  getcmdprompt() implementation can be improved
Solution: Improve and simplify it (h-east)

closes: vim/vim#15743

https://github.com/vim/vim/commit/25876a6cdd439054d0b3f920ccca0a435481de15

Co-authored-by: h-east <h.east.727@gmail.com>