### PR TITLE
fix(paste): only record a paste when it's from RPC

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1234,7 +1234,8 @@ void nvim_set_current_tabpage(Tabpage tabpage, Error *err)
 /// @return
 ///     - true: Client may continue pasting.
 ///     - false: Client should cancel the paste.
-Boolean nvim_paste(String data, Boolean crlf, Integer phase, Arena *arena, Error *err)
+Boolean nvim_paste(uint64_t channel_id, String data, Boolean crlf, Integer phase, Arena *arena,
+                   Error *err)
   FUNC_API_SINCE(6)
   FUNC_API_TEXTLOCK_ALLOW_CMDWIN
 {
@@ -1259,13 +1260,13 @@ Boolean nvim_paste(String data, Boolean crlf, Integer phase, Arena *arena, Error
     cancelled = true;
   }
   if (!cancelled && (phase == -1 || phase == 1)) {
-    paste_store(kFalse, NULL_STRING, crlf);
+    paste_store(channel_id, kFalse, NULL_STRING, crlf);
   }
   if (!cancelled) {
-    paste_store(kNone, data, crlf);
+    paste_store(channel_id, kNone, data, crlf);
   }
   if (phase == 3 || phase == (cancelled ? 2 : -1)) {
-    paste_store(kTrue, NULL_STRING, crlf);
+    paste_store(channel_id, kTrue, NULL_STRING, crlf);
   }
 theend:
   ;

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1358,6 +1358,13 @@ describe('API', function()
         test_paste_repeat_visual_select(true)
       end)
     end)
+    it('in a mapping recorded in a macro', function()
+      command([[nnoremap <F2> <Cmd>call nvim_paste('foo', v:false, -1)<CR>]])
+      feed('qr<F2>$q')
+      expect('foo')
+      feed('@r') -- repeating a macro containing the mapping should only paste once
+      expect('foofoo')
+    end)
     local function test_paste_cancel_error(is_error)
       before_each(function()
         exec_lua(([[


### PR DESCRIPTION
Problem:  When using nvim_paste in a mapping during a macro recording,
          both the mapping and the paste are recorded, causing the paste
          to be performed twice when replaying the macro.
Solution: Only record a paste when it is from RPC.

Unfortunately this means there is no way for a script to make a recorded
paste. ~, unless scripts can override the call's channel ID: #28437.~ A way to enable that can be discussed later if there is need.
