### PR TITLE
vim-patch:a7229c8: runtime(rmd,rrst): 'fex' option not properly restored

### DIFF
--- a/runtime/ftplugin/rmd.vim
+++ b/runtime/ftplugin/rmd.vim
@@ -3,7 +3,9 @@
 " Maintainer:		This runtime file is looking for a new maintainer.
 " Former Maintainer:	Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Former Repository:	https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:		2024 Feb 28 by Vim Project
+" Last Change:
+"  2024 Feb 28 by Vim Project
+"  2024 Sep 23 by Vim Project: properly restore fex option
 " Original work by Alex Zvoleff (adjusted from R help for rmd by Michel Kuhlmann)
 
 " Only do this when not yet done for this buffer
@@ -74,9 +76,9 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
 endif
 
 if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= " | setl cms< com< fo< flp< isk< | unlet! b:browsefilter"
+  let b:undo_ftplugin .= " | setl cms< com< fo< flp< isk< fex< | unlet! b:browsefilter"
 else
-  let b:undo_ftplugin = "setl cms< com< fo< flp< isk< | unlet! b:browsefilter"
+  let b:undo_ftplugin = "setl cms< com< fo< flp< isk< fex< | unlet! b:browsefilter"
 endif
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/rrst.vim
+++ b/runtime/ftplugin/rrst.vim
@@ -3,7 +3,9 @@
 " Maintainer:		This runtime file is looking for a new maintainer.
 " Former Maintainer:	Jakson Alves de Aquino <jalvesaq@gmail.com>
 " Former Repository:	https://github.com/jalvesaq/R-Vim-runtime
-" Last Change:		2024 Feb 28 by Vim Project
+" Last Change:
+"  2024 Feb 28 by Vim Project
+"  2024 Sep 23 by Vim Project: properly restore fex option
 " Original work by Alex Zvoleff
 
 " Only do this when not yet done for this buffer
@@ -48,9 +50,9 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
 endif
 
 if exists('b:undo_ftplugin')
-  let b:undo_ftplugin .= " | setl cms< com< fo< flp< isk< | unlet! b:browsefilter"
+  let b:undo_ftplugin .= " | setl cms< com< fo< flp< isk< fex< | unlet! b:browsefilter"
 else
-  let b:undo_ftplugin = "setl cms< com< fo< flp< isk< | unlet! b:browsefilter"
+  let b:undo_ftplugin = "setl cms< com< fo< flp< isk< fex< | unlet! b:browsefilter"
 endif
 
 let &cpo = s:cpo_save


### PR DESCRIPTION
Add 'fex' to b:undo_ftplugin variable

closes: vim/vim#15728

https://github.com/vim/vim/commit/a7229c8a99129608e9d651441cca6e6d3079ef56

Co-authored-by: John M Devin <john.m.devin@gmail.com>
