### PR TITLE
feat(comment): allow commentstring to be determined from node metadata

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -357,6 +357,10 @@ PLUGINS
   • spelling_language property is now supported.
 • 'inccommand' incremental preview can run on 'nomodifiable' buffers and
   restores their 'modifiable' state
+• Commenting
+  • 'commentstring' values can now be specified in a Treesitter capture's
+    `bo.commentstring` metadata field, providing finer grained support for
+    languages like `JSX`.
 
 STARTUP
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -531,6 +531,19 @@ attribute: >query
     ((super_important_node) @superimportant (#set! priority 105))
 <
 
+                                          *treesitter-highlight-commentstring*
+Treesitter highlighting supports finer-grained 'commentstring's, used by the
+built-in |commenting| plugin. When the cursor is within a node that sets the
+`bo.commentstring` metadata property (|treesitter-directive-set!|), that
+property defines the comment delimiter (where "innermost wins"). This is
+useful for languages like `JSX` that have different comment syntax depending
+on the code region, for example: >query
+
+    ((jsx_element) @_tag (#set! @_tag bo.commentstring "{/* %s */}"))
+<
+When multiple captures set this metadata over a region, only the innermost
+(most specific) one is applied to a given area.
+
 ==============================================================================
 TREESITTER LANGUAGE INJECTIONS                *treesitter-language-injections*
 <

--- a/runtime/lua/vim/_comment.lua
+++ b/runtime/lua/vim/_comment.lua
@@ -19,6 +19,18 @@ local function get_commentstring(ref_position)
   local row, col = ref_position[1] - 1, ref_position[2]
   local ref_range = { row, col, row, col + 1 }
 
+  -- Get 'commentstring' from tree-sitter captures' metadata.
+  -- Traverse backwards to prefer narrower captures.
+  local caps = vim.treesitter.get_captures_at_pos(0, row, col)
+  for i = #caps, 1, -1 do
+    local id, metadata = caps[i].id, caps[i].metadata
+    local md_cms = metadata['bo.commentstring'] or metadata[id] and metadata[id]['bo.commentstring']
+
+    if md_cms then
+      return md_cms
+    end
+  end
+
   -- - Get 'commentstring' from the deepest LanguageTree which both contains
   --   reference range and has valid 'commentstring' (meaning it has at least
   --   one associated 'filetype' with valid 'commentstring').

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -608,6 +608,7 @@ predicate_handlers['any-vim-match?'] = predicate_handlers['any-match?']
 ---@class vim.treesitter.query.TSMetadata
 ---@field range? Range
 ---@field conceal? string
+---@field bo.commentstring? string
 ---@field [integer]? vim.treesitter.query.TSMetadata
 ---@field [string]? integer|string
 


### PR DESCRIPTION
**Problem:** Some weird languages have different comment syntax depending on the location in the code, and we do not have a way to determine the correct `commentstring` for these special cases.

**Solution:** Allow queries to specify `commentstring` values in metadata, allowing users/`nvim-treesitter` to provide a better commenting experience without hugely increasing the scope of the code in core.

Fixes [#28830](https://github.com/neovim/neovim/issues/28830)