### PR TITLE
fix(diagnostic): correct `severity` type on `setqflist`, `setloclist`

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -831,7 +831,7 @@ setloclist({opts})                               *vim.diagnostic.setloclist()*
                   after setting.
                 • {title}? (`string`) Title of the location list. Defaults to
                   "Diagnostics".
-                • {severity}? (`vim.diagnostic.Severity`) See
+                • {severity}? (`vim.diagnostic.SeverityFilter`) See
                   |diagnostic-severity|.
 
 setqflist({opts})                                 *vim.diagnostic.setqflist()*
@@ -845,7 +845,7 @@ setqflist({opts})                                 *vim.diagnostic.setqflist()*
                   after setting.
                 • {title}? (`string`) Title of quickfix list. Defaults to
                   "Diagnostics".
-                • {severity}? (`vim.diagnostic.Severity`) See
+                • {severity}? (`vim.diagnostic.SeverityFilter`) See
                   |diagnostic-severity|.
 
                                                        *vim.diagnostic.show()*

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -2078,7 +2078,7 @@ end
 --- @field title? string
 ---
 --- See |diagnostic-severity|.
---- @field severity? vim.diagnostic.Severity
+--- @field severity? vim.diagnostic.SeverityFilter
 
 --- Add all diagnostics to the quickfix list.
 ---
@@ -2106,7 +2106,7 @@ end
 --- @field title? string
 ---
 --- See |diagnostic-severity|.
---- @field severity? vim.diagnostic.Severity
+--- @field severity? vim.diagnostic.SeverityFilter
 
 --- Add buffer diagnostics to the location list.
 ---


### PR DESCRIPTION
`vim.diagnostic.setqflist` and `vim.diagnostic.setloclist` each accept a `severity` option which can be a simple value or a table (`:h diagnostic-severity`). However, the LuaLS types are incorrect for these functions. Many of the other diagnostic functions use `DiagnosticFilter` (introduced in #27143) to capture all possible forms of the `severity` option; this change brings `DiagnosticFilter` to `setqflist` and `setloclist`.