### PR TITLE
fix(window): respect hide flag of float windows when switching

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -590,7 +590,7 @@ void ex_listdo(exarg_T *eap)
           break;
         }
         assert(wp);
-        execute = !wp->w_floating || wp->w_config.focusable;
+        execute = !wp->w_floating || (!wp->w_config.hide && wp->w_config.focusable);
         if (execute) {
           win_goto(wp);
           if (curwin != wp) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -359,13 +359,13 @@ newwindow:
             wp = lastwin;  // wrap around
           }
           while (wp != NULL && wp->w_floating
-                 && !wp->w_config.focusable) {
+                 && (wp->w_config.hide || !wp->w_config.focusable)) {
             wp = wp->w_prev;
           }
         } else {  // go to next window
           wp = curwin->w_next;
           while (wp != NULL && wp->w_floating
-                 && !wp->w_config.focusable) {
+                 && (wp->w_config.hide || !wp->w_config.focusable)) {
             wp = wp->w_next;
           }
           if (wp == NULL) {
@@ -2851,7 +2851,7 @@ int win_close(win_T *win, bool free_buf, bool force)
           break;
         }
         if (!wp->w_p_pvw && !bt_quickfix(wp->w_buffer)
-            && !(wp->w_floating && !wp->w_config.focusable)) {
+            && !(wp->w_floating && (wp->w_config.hide || !wp->w_config.focusable))) {
           curwin = wp;
           break;
         }

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -9068,6 +9068,7 @@ describe('float window', function()
     end)
 
     it('float window with hide option', function()
+      local cwin = api.nvim_get_current_win()
       local buf = api.nvim_create_buf(false,false)
       local win = api.nvim_open_win(buf, false, {relative='editor', width=10, height=2, row=2, col=5, hide = true})
       local expected_pos = {
@@ -9147,6 +9148,22 @@ describe('float window', function()
                                                   |
         ]])
       end
+      -- check window jump with hide
+      feed('<C-W><C-W>')
+      -- should keep on current window
+      eq(cwin, api.nvim_get_current_win())
+      api.nvim_win_set_config(win, {hide=false})
+      api.nvim_set_current_win(win)
+      local win3 = api.nvim_open_win(buf, true, {relative='editor', width=4, height=4, row=2, col=5, hide = false})
+      api.nvim_win_set_config(win, {hide=true})
+      feed('<C-W>w')
+      -- should goto the first window with prev
+      eq(cwin, api.nvim_get_current_win())
+      -- windo
+      command('windo set winheight=6')
+      eq(win3, api.nvim_get_current_win())
+      eq(6, api.nvim_win_get_height(win3))
+      eq(2, api.nvim_win_get_height(win))
     end)
 
     it(':fclose command #9663', function()


### PR DESCRIPTION
Problem: The hide option for floating windows was not respected in some window detection functions, causing them to improperly include hidden floating windows.

Solution: Added checks for the hide property in w_config to ensure hidden floating windows are properly ignored in relevant detection functions.

Fix #30503 