### PR TITLE
docs(treesitter): improve typing for `get_captures_at_pos()`

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -757,7 +757,7 @@ get_captures_at_pos({bufnr}, {row}, {col})
       • {col}    (`integer`) Position column
 
     Return: ~
-        (`{capture: string, lang: string, metadata: table}[]`)
+        (`{capture: string, lang: string, metadata: vim.treesitter.query.TSMetadata}[]`)
 
 get_node({opts})                                   *vim.treesitter.get_node()*
     Returns the smallest named node at the given position

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -276,7 +276,7 @@ end
 ---@param row integer Position row
 ---@param col integer Position column
 ---
----@return {capture: string, lang: string, metadata: table}[]
+---@return {capture: string, lang: string, metadata: vim.treesitter.query.TSMetadata}[]
 function M.get_captures_at_pos(bufnr, row, col)
   if bufnr == 0 then
     bufnr = api.nvim_get_current_buf()


### PR DESCRIPTION
**Problem:** The returned metadata for `get_captures_at_pos()` is just typed as a table, so there are no LSP niceties for it

**Solution:** Type it as `TSMetadata`!