### PR TITLE
test(api/buffer_updates_spec): prevent flakiness

### DIFF
--- a/test/functional/api/buffer_updates_spec.lua
+++ b/test/functional/api/buffer_updates_spec.lua
@@ -27,12 +27,10 @@ end
 
 local function sendkeys(keys)
   api.nvim_input(keys)
-  -- give nvim some time to process msgpack requests before possibly sending
+  -- Wait for Nvim to fully process pending input before possibly sending
   -- more key presses - otherwise they all pile up in the queue and get
   -- processed at once
-  local ntime = os.clock() + 0.1
-  repeat
-  until os.clock() > ntime
+  n.poke_eventloop()
 end
 
 local function open(activate, lines)


### PR DESCRIPTION
Use nvim_get_mode to wait for Nvim to finish processing input.
