### PR TITLE
fix(diff): use mmfile_t in linematch

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -713,8 +713,8 @@ vim.diff({a}, {b}, {opts})                                        *vim.diff()*
     Parameters: ~
       • {a}     (`string`) First string to compare
       • {b}     (`string`) Second string to compare
-      • {opts}  (`table`) Optional parameters:
-                • {on_hunk}
+      • {opts}  (`table?`) Optional parameters:
+                • {on_hunk}?
                   (`fun(start_a: integer, count_a: integer, start_b: integer, count_b: integer): integer`)
                   Invoked for each hunk in the diff. Return a negative number
                   to cancel the callback for any remaining hunks. Arguments:
@@ -722,33 +722,33 @@ vim.diff({a}, {b}, {opts})                                        *vim.diff()*
                   • `count_a` (`integer`): Hunk size in {a}.
                   • `start_b` (`integer`): Start line of hunk in {b}.
                   • `count_b` (`integer`): Hunk size in {b}.
-                • {result_type} (`'unified'|'indices'`, default: `'unified'`)
+                • {result_type}? (`'unified'|'indices'`, default: `'unified'`)
                   Form of the returned diff:
                   • `unified`: String in unified format.
                   • `indices`: Array of hunk locations. Note: This option is
                     ignored if `on_hunk` is used.
-                • {linematch} (`boolean|integer`) Run linematch on the
+                • {linematch}? (`boolean|integer`) Run linematch on the
                   resulting hunks from xdiff. When integer, only hunks upto
                   this size in lines are run through linematch. Requires
                   `result_type = indices`, ignored otherwise.
-                • {algorithm} (`'myers'|'minimal'|'patience'|'histogram'`,
+                • {algorithm}? (`'myers'|'minimal'|'patience'|'histogram'`,
                   default: `'myers'`) Diff algorithm to use. Values:
                   • `myers`: the default algorithm
                   • `minimal`: spend extra time to generate the smallest
                     possible diff
                   • `patience`: patience diff algorithm
                   • `histogram`: histogram diff algorithm
-                • {ctxlen} (`integer`) Context length
-                • {interhunkctxlen} (`integer`) Inter hunk context length
-                • {ignore_whitespace} (`boolean`) Ignore whitespace
-                • {ignore_whitespace_change} (`boolean`) Ignore whitespace
+                • {ctxlen}? (`integer`) Context length
+                • {interhunkctxlen}? (`integer`) Inter hunk context length
+                • {ignore_whitespace}? (`boolean`) Ignore whitespace
+                • {ignore_whitespace_change}? (`boolean`) Ignore whitespace
                   change
-                • {ignore_whitespace_change_at_eol} (`boolean`) Ignore
+                • {ignore_whitespace_change_at_eol}? (`boolean`) Ignore
                   whitespace change at end-of-line.
-                • {ignore_cr_at_eol} (`boolean`) Ignore carriage return at
+                • {ignore_cr_at_eol}? (`boolean`) Ignore carriage return at
                   end-of-line
-                • {ignore_blank_lines} (`boolean`) Ignore blank lines
-                • {indent_heuristic} (`boolean`) Use the indent heuristic for
+                • {ignore_blank_lines}? (`boolean`) Ignore blank lines
+                • {indent_heuristic}? (`boolean`) Use the indent heuristic for
                   the internal diff library.
 
     Return: ~

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -715,7 +715,7 @@ vim.diff({a}, {b}, {opts})                                        *vim.diff()*
       • {b}     (`string`) Second string to compare
       • {opts}  (`table?`) Optional parameters:
                 • {on_hunk}?
-                  (`fun(start_a: integer, count_a: integer, start_b: integer, count_b: integer): integer`)
+                  (`fun(start_a: integer, count_a: integer, start_b: integer, count_b: integer): integer?`)
                   Invoked for each hunk in the diff. Return a negative number
                   to cancel the callback for any remaining hunks. Arguments:
                   • `start_a` (`integer`): Start line of hunk in {a}.

--- a/runtime/lua/vim/_meta/diff.lua
+++ b/runtime/lua/vim/_meta/diff.lua
@@ -11,7 +11,7 @@
 ---   - `count_a` (`integer`): Hunk size in {a}.
 ---   - `start_b` (`integer`): Start line of hunk in {b}.
 ---   - `count_b` (`integer`): Hunk size in {b}.
---- @field on_hunk? fun(start_a: integer, count_a: integer, start_b: integer, count_b: integer): integer
+--- @field on_hunk? fun(start_a: integer, count_a: integer, start_b: integer, count_b: integer): integer?
 ---
 --- Form of the returned diff:
 ---   - `unified`: String in unified format.

--- a/runtime/lua/vim/_meta/diff.lua
+++ b/runtime/lua/vim/_meta/diff.lua
@@ -11,19 +11,19 @@
 ---   - `count_a` (`integer`): Hunk size in {a}.
 ---   - `start_b` (`integer`): Start line of hunk in {b}.
 ---   - `count_b` (`integer`): Hunk size in {b}.
---- @field on_hunk fun(start_a: integer, count_a: integer, start_b: integer, count_b: integer): integer
+--- @field on_hunk? fun(start_a: integer, count_a: integer, start_b: integer, count_b: integer): integer
 ---
 --- Form of the returned diff:
 ---   - `unified`: String in unified format.
 ---   - `indices`: Array of hunk locations.
 --- Note: This option is ignored if `on_hunk` is used.
 --- (default: `'unified'`)
---- @field result_type 'unified'|'indices'
+--- @field result_type? 'unified'|'indices'
 ---
 --- Run linematch on the resulting hunks from xdiff. When integer, only hunks
 --- upto this size in lines are run through linematch.
 --- Requires `result_type = indices`, ignored otherwise.
---- @field linematch boolean|integer
+--- @field linematch? boolean|integer
 ---
 --- Diff algorithm to use. Values:
 ---   - `myers`: the default algorithm
@@ -31,15 +31,15 @@
 ---   - `patience`: patience diff algorithm
 ---   - `histogram`: histogram diff algorithm
 --- (default: `'myers'`)
---- @field algorithm 'myers'|'minimal'|'patience'|'histogram'
---- @field ctxlen integer Context length
---- @field interhunkctxlen integer Inter hunk context length
---- @field ignore_whitespace boolean Ignore whitespace
---- @field ignore_whitespace_change boolean Ignore whitespace change
---- @field ignore_whitespace_change_at_eol boolean Ignore whitespace change at end-of-line.
---- @field ignore_cr_at_eol boolean Ignore carriage return at end-of-line
---- @field ignore_blank_lines boolean Ignore blank lines
---- @field indent_heuristic boolean Use the indent heuristic for the internal diff library.
+--- @field algorithm? 'myers'|'minimal'|'patience'|'histogram'
+--- @field ctxlen? integer Context length
+--- @field interhunkctxlen? integer Inter hunk context length
+--- @field ignore_whitespace? boolean Ignore whitespace
+--- @field ignore_whitespace_change? boolean Ignore whitespace change
+--- @field ignore_whitespace_change_at_eol? boolean Ignore whitespace change at end-of-line.
+--- @field ignore_cr_at_eol? boolean Ignore carriage return at end-of-line
+--- @field ignore_blank_lines? boolean Ignore blank lines
+--- @field indent_heuristic? boolean Use the indent heuristic for the internal diff library.
 
 -- luacheck: no unused args
 
@@ -65,7 +65,7 @@
 ---
 ---@param a string First string to compare
 ---@param b string Second string to compare
----@param opts vim.diff.Opts
+---@param opts? vim.diff.Opts
 ---@return string|integer[][]?
 ---     See {opts.result_type}. `nil` if {opts.on_hunk} is given.
 function vim.diff(a, b, opts) end

--- a/src/clint.py
+++ b/src/clint.py
@@ -881,6 +881,7 @@ def CheckIncludes(filename, lines, error):
             "nvim/func_attr.h",
             "termkey/termkey.h",
             "vterm/vterm.h",
+            "xdiff/xdiff.h",
             ]
 
     for i in check_includes_ignore:

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -2005,7 +2005,7 @@ static void run_linematch_algorithm(diff_T *dp)
 {
   // define buffers for diff algorithm
   mmfile_t diffbufs_mm[DB_COUNT];
-  const char *diffbufs[DB_COUNT];
+  const mmfile_t *diffbufs[DB_COUNT];
   int diff_length[DB_COUNT];
   size_t ndiffs = 0;
   for (int i = 0; i < DB_COUNT; i++) {
@@ -2015,9 +2015,7 @@ static void run_linematch_algorithm(diff_T *dp)
       diff_write_buffer(curtab->tp_diffbuf[i], &diffbufs_mm[ndiffs],
                         dp->df_lnum[i], dp->df_lnum[i] + dp->df_count[i] - 1);
 
-      // we want to get the char* to the diff buffer that was just written
-      // we add it to the array of char*, diffbufs
-      diffbufs[ndiffs] = diffbufs_mm[ndiffs].ptr;
+      diffbufs[ndiffs] = &diffbufs_mm[ndiffs];
 
       // keep track of the length of this diff block to pass it to the linematch
       // algorithm

--- a/src/nvim/linematch.h
+++ b/src/nvim/linematch.h
@@ -3,6 +3,7 @@
 #include <stddef.h>  // IWYU pragma: keep
 
 #include "nvim/pos_defs.h"  // IWYU pragma: keep
+#include "xdiff/xdiff.h"
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "linematch.h.generated.h"

--- a/src/nvim/lua/xdiff.c
+++ b/src/nvim/lua/xdiff.c
@@ -67,11 +67,11 @@ static void get_linematch_results(lua_State *lstate, mmfile_t *ma, mmfile_t *mb,
                                   int count_a, int start_b, int count_b, bool iwhite)
 {
   // get the pointer to char of the start of the diff to pass it to linematch algorithm
-  const char *diff_begin[2] = { ma->ptr, mb->ptr };
-  int diff_length[2] = { count_a, count_b };
+  mmfile_t ma0 = fastforward_buf_to_lnum(*ma, (linenr_T)start_a + 1);
+  mmfile_t mb0 = fastforward_buf_to_lnum(*mb, (linenr_T)start_b + 1);
 
-  fastforward_buf_to_lnum(&diff_begin[0], (linenr_T)start_a + 1);
-  fastforward_buf_to_lnum(&diff_begin[1], (linenr_T)start_b + 1);
+  const mmfile_t *diff_begin[2] = { &ma0, &mb0 };
+  int diff_length[2] = { count_a, count_b };
 
   int *decisions = NULL;
   size_t decisions_length = linematch_nbuffers(diff_begin, diff_length, 2, &decisions, iwhite);

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -496,6 +496,20 @@ char *vim_strchr(const char *const string, const int c)
   }
 }
 
+// Sized version of strchr that can handle embedded NULs.
+// Adjusts n to the new size.
+char *strnchr(const char *p, size_t *n, int c)
+{
+  while (*n > 0) {
+    if (*p == c) {
+      return (char *)p;
+    }
+    p++;
+    (*n)--;
+  }
+  return NULL;
+}
+
 // Sort an array of strings.
 
 static int sort_compare(const void *s1, const void *s2)

--- a/test/functional/lua/xdiff_spec.lua
+++ b/test/functional/lua/xdiff_spec.lua
@@ -174,4 +174,13 @@ describe('xdiff bindings', function()
       pcall_err(exec_lua, [[vim.diff('a', 'b', { on_hunk = true })]])
     )
   end)
+
+  it('can handle strings with embedded NUL characters (GitHub #30305)', function()
+    eq(
+      { { 0, 0, 1, 1 }, { 1, 0, 3, 2 } },
+      exec_lua(function()
+        return vim.diff('\n', '\0\n\n\nb', { linematch = true, result_type = 'indices' })
+      end)
+    )
+  end)
 end)

--- a/test/functional/lua/xdiff_spec.lua
+++ b/test/functional/lua/xdiff_spec.lua
@@ -12,15 +12,11 @@ describe('xdiff bindings', function()
   end)
 
   describe('can diff text', function()
-    before_each(function()
-      exec_lua [[
-        a1 = 'Hello\n'
-        b1 = 'Helli\n'
+    local a1 = 'Hello\n'
+    local b1 = 'Helli\n'
 
-        a2 = 'Hello\nbye\nfoo\n'
-        b2 = 'Helli\nbye\nbar\nbaz\n'
-      ]]
-    end)
+    local a2 = 'Hello\nbye\nfoo\n'
+    local b2 = 'Helli\nbye\nbar\nbaz\n'
 
     it('with no callback', function()
       eq(
@@ -30,7 +26,9 @@ describe('xdiff bindings', function()
           '+Helli',
           '',
         }, '\n'),
-        exec_lua('return vim.diff(a1, b1)')
+        exec_lua(function()
+          return vim.diff(a1, b1)
+        end)
       )
 
       eq(
@@ -44,63 +42,81 @@ describe('xdiff bindings', function()
           '+baz',
           '',
         }, '\n'),
-        exec_lua('return vim.diff(a2, b2)')
+        exec_lua(function()
+          return vim.diff(a2, b2)
+        end)
       )
     end)
 
     it('with callback', function()
-      exec_lua([[on_hunk = function(sa, ca, sb, cb)
-          exp[#exp+1] = {sa, ca, sb, cb}
-        end]])
-
       eq(
         { { 1, 1, 1, 1 } },
-        exec_lua [[
-          exp = {}
-          assert(vim.diff(a1, b1, {on_hunk = on_hunk}) == nil)
+        exec_lua(function()
+          local exp = {} --- @type table[]
+          assert(vim.diff(a1, b1, {
+            on_hunk = function(...)
+              exp[#exp + 1] = { ... }
+            end,
+          }) == nil)
           return exp
-        ]]
+        end)
       )
 
       eq(
         { { 1, 1, 1, 1 }, { 3, 1, 3, 2 } },
-        exec_lua [[
-          exp = {}
-          assert(vim.diff(a2, b2, {on_hunk = on_hunk}) == nil)
+        exec_lua(function()
+          local exp = {} --- @type table[]
+          assert(vim.diff(a2, b2, {
+            on_hunk = function(...)
+              exp[#exp + 1] = { ... }
+            end,
+          }) == nil)
           return exp
-        ]]
+        end)
       )
 
       -- gives higher precedence to on_hunk over result_type
       eq(
         { { 1, 1, 1, 1 }, { 3, 1, 3, 2 } },
-        exec_lua [[
-          exp = {}
-          assert(vim.diff(a2, b2, {on_hunk = on_hunk, result_type='indices'}) == nil)
+        exec_lua(function()
+          local exp = {} --- @type table[]
+          assert(vim.diff(a2, b2, {
+            on_hunk = function(...)
+              exp[#exp + 1] = { ... }
+            end,
+            result_type = 'indices',
+          }) == nil)
           return exp
-        ]]
+        end)
       )
     end)
 
     it('with error callback', function()
-      exec_lua [[
-        on_hunk = function(sa, ca, sb, cb)
-          error('ERROR1')
-        end
-      ]]
-
       eq(
-        [[error running function on_hunk: [string "<nvim>"]:0: ERROR1]],
-        pcall_err(exec_lua, [[vim.diff(a1, b1, {on_hunk = on_hunk})]])
+        [[.../xdiff_spec.lua:0: error running function on_hunk: .../xdiff_spec.lua:0: ERROR1]],
+        pcall_err(exec_lua, function()
+          vim.diff(a1, b1, {
+            on_hunk = function()
+              error('ERROR1')
+            end,
+          })
+        end)
       )
     end)
 
     it('with hunk_lines', function()
-      eq({ { 1, 1, 1, 1 } }, exec_lua([[return vim.diff(a1, b1, {result_type = 'indices'})]]))
+      eq(
+        { { 1, 1, 1, 1 } },
+        exec_lua(function()
+          return vim.diff(a1, b1, { result_type = 'indices' })
+        end)
+      )
 
       eq(
         { { 1, 1, 1, 1 }, { 3, 1, 3, 2 } },
-        exec_lua([[return vim.diff(a2, b2, {result_type = 'indices'})]])
+        exec_lua(function()
+          return vim.diff(a2, b2, { result_type = 'indices' })
+        end)
       )
     end)
 
@@ -143,16 +159,11 @@ describe('xdiff bindings', function()
           '+}',
           '',
         }, '\n'),
-        exec_lua(
-          [[
-          local args = {...}
-          return vim.diff(args[1], args[2], {
-            algorithm = 'patience'
+        exec_lua(function()
+          return vim.diff(a, b, {
+            algorithm = 'patience',
           })
-        ]],
-          a,
-          b
-        )
+        end)
       )
     end)
   end)


### PR DESCRIPTION
Problem:

Linematch used to use strchr to navigate a string, however strchr does
not supoprt embedded NULs.

Solution:

Use `mmfile_t` instead of `char*` in linematch and introduce `strnchr()`.

Fixes: #30505
