### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1684,7 +1684,7 @@ The valid escape sequences are
 		nothing. Supported modifiers are |:aboveleft|, |:belowright|,
 		|:botright|, |:browse|, |:confirm|, |:hide|, |:horizontal|,
 		|:keepalt|, |:keepjumps|, |:keepmarks|, |:keeppatterns|,
-		|:leftabove|, |:lockmarks|, |:noautocmd|, |:noswapfile|
+		|:leftabove|, |:lockmarks|, |:noautocmd|, |:noswapfile|,
 		|:rightbelow|, |:sandbox|, |:silent|, |:tab|, |:topleft|,
 		|:unsilent|, |:verbose|, and |:vertical|.
 		Note that |:filter| is not supported.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -333,13 +333,14 @@ between string and number-based options.
 			options which are different from the default.
 
 For buffer-local and window-local options:
-	Command		 global value	    local value ~
-      :set option=value	     set		set
- :setlocal option=value	      -			set
-:setglobal option=value	     set		 -
-      :set option?	      -		       display
- :setlocal option?	      -		       display
-:setglobal option?	    display		 -
+	Command		 global value	  local value	       condition ~
+      :set option=value	     set	      set
+ :setlocal option=value	      -		      set
+:setglobal option=value	     set	       -
+      :set option?	      -		     display	 local value is set
+      :set option?	    display	       -	 local value is not set
+ :setlocal option?	      -		     display
+:setglobal option?	    display	       -
 
 
 Global options with a local value			*global-local*


### PR DESCRIPTION
#### vim-patch:d9af78b: runtime(docs): update `:set?` command behavior table

closes: vim/vim#15746

https://github.com/vim/vim/commit/d9af78b9450362847b344f8dc0f68d015b428d03

Co-authored-by: Milly <milly.ca@gmail.com>


#### vim-patch:2c41dad: runtime(doc): Fix typo in :help :command-modifiers

closes: vim/vim#15734

https://github.com/vim/vim/commit/2c41dad3873e71cdd4076907cf35e985d0d7a0d1

Co-authored-by: Doug Kearns <dougkearns@gmail.com>