### PR TITLE
fix(float): through an error when set current window to a hidden floating window

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -949,6 +949,12 @@ void nvim_set_current_win(Window window, Error *err)
     return;
   }
 
+  if (win->w_floating && win->w_config.hide) {
+    api_set_error(err, kErrorTypeException,
+                  "Failed to set the current window to a hidden floating window %d", window);
+    return;
+  }
+
   try_start();
   goto_tabpage_win(win_find_tabpage(win), win);
   if (!try_end(err) && win != curwin) {

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -9195,6 +9195,7 @@ describe('float window', function()
       eq(win3, api.nvim_get_current_win())
       eq(6, api.nvim_win_get_height(win3))
       eq(2, api.nvim_win_get_height(win))
+      eq(('Failed to set the current window to a hidden floating window %d'):format(win), pcall_err(api.nvim_set_current_win, win))
     end)
 
     it(':fclose command #9663', function()


### PR DESCRIPTION
Problem: cursor will jump into a hidden floating window when using `nvim_set_current_win` to switch.

Solution: through an error in nvim_set_current_win when window is a hidden floating window