### PR TITLE
fix(column): set signcolumn width after splitting window

### DIFF
--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -306,7 +306,7 @@ int check_signcolumn(win_T *wp)
       wp->w_minscwidth = 0;
       wp->w_maxscwidth = 1;
     }
-    return OK;
+    goto done;
   }
 
   if (strncmp(val, "auto:", 5) != 0
@@ -326,6 +326,11 @@ int check_signcolumn(win_T *wp)
 
   wp->w_minscwidth = min;
   wp->w_maxscwidth = max;
+
+done:
+  ;
+  int scwidth = wp->w_minscwidth <= 0 ? 0 : MIN(wp->w_maxscwidth, wp->w_scwidth);
+  wp->w_scwidth = MAX(wp->w_minscwidth, scwidth);
   return OK;
 }
 
@@ -2038,8 +2043,6 @@ const char *did_set_signcolumn(optset_T *args)
   if (check_signcolumn(win) != OK) {
     return e_invarg;
   }
-  int scwidth = win->w_minscwidth <= 0 ? 0 : MIN(win->w_maxscwidth, win->w_scwidth);
-  win->w_scwidth = MAX(win->w_minscwidth, scwidth);
   // When changing the 'signcolumn' to or from 'number', recompute the
   // width of the number column if 'number' or 'relativenumber' is set.
   if ((*oldval == 'n' && *(oldval + 1) == 'u') || win->w_minscwidth == SCL_NUM) {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -306,29 +306,24 @@ int check_signcolumn(win_T *wp)
       wp->w_minscwidth = 0;
       wp->w_maxscwidth = 1;
     }
-    goto done;
+  } else {
+    if (strncmp(val, "auto:", 5) != 0
+        || strlen(val) != 8
+        || !ascii_isdigit(val[5])
+        || val[6] != '-'
+        || !ascii_isdigit(val[7])) {
+      return FAIL;
+    }
+    // auto:<NUM>-<NUM>
+    int min = val[5] - '0';
+    int max = val[7] - '0';
+    if (min < 1 || max < 2 || min > 8 || min >= max) {
+      return FAIL;
+    }
+    wp->w_minscwidth = min;
+    wp->w_maxscwidth = max;
   }
 
-  if (strncmp(val, "auto:", 5) != 0
-      || strlen(val) != 8
-      || !ascii_isdigit(val[5])
-      || val[6] != '-'
-      || !ascii_isdigit(val[7])) {
-    return FAIL;
-  }
-
-  // auto:<NUM>-<NUM>
-  int min = val[5] - '0';
-  int max = val[7] - '0';
-  if (min < 1 || max < 2 || min > 8 || min >= max) {
-    return FAIL;
-  }
-
-  wp->w_minscwidth = min;
-  wp->w_maxscwidth = max;
-
-done:
-  ;
   int scwidth = wp->w_minscwidth <= 0 ? 0 : MIN(wp->w_maxscwidth, wp->w_scwidth);
   wp->w_scwidth = MAX(wp->w_minscwidth, scwidth);
   return OK;

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -4,6 +4,7 @@ local Screen = require('test.functional.ui.screen')
 
 local api, clear, eq = n.api, n.clear, t.eq
 local eval, exec, feed = n.eval, n.exec, n.feed
+local exec_lua = n.exec_lua
 
 describe('Signs', function()
   local screen
@@ -606,5 +607,16 @@ describe('Signs', function()
     -- Unplacing the sign does not crash by decrementing tracked signs below zero
     exec('sign unplace 1')
     screen:expect(s1)
+  end)
+
+  it('signcolumn width is set immediately after splitting window #30547', function()
+    local infos = exec_lua([[
+      vim.o.number = true
+      vim.o.signcolumn = 'yes'
+      vim.cmd.wincmd('v')
+      return vim.fn.getwininfo()
+    ]])
+    eq(6, infos[1].textoff)
+    eq(6, infos[2].textoff)
   end)
 end)


### PR DESCRIPTION
Fix #30547
