### PR TITLE
feat(treesitter): include capture id in return value of `get_captures_at_pos()`

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -289,6 +289,7 @@ TREESITTER
   false, which allows it to return anonymous nodes as well as named nodes.
 • |treesitter-directive-trim!| can trim all whitespace (not just empty lines)
   from both sides of a node.
+• |vim.treesitter.get_captures_at_pos()| now returns the `id` of each capture
 
 TUI
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -902,8 +902,8 @@ get_captures_at_pos({bufnr}, {row}, {col})
     Returns a list of highlight captures at the given position
 
     Each capture is represented by a table containing the capture name as a
-    string as well as a table of metadata (`priority`, `conceal`, ...; empty
-    if none are defined).
+    string, the capture's language, a table of metadata (`priority`,
+    `conceal`, ...; empty if none are defined), and the id of the capture.
 
     Parameters: ~
       • {bufnr}  (`integer`) Buffer number (0 for current buffer)
@@ -911,7 +911,7 @@ get_captures_at_pos({bufnr}, {row}, {col})
       • {col}    (`integer`) Position column
 
     Return: ~
-        (`{capture: string, lang: string, metadata: vim.treesitter.query.TSMetadata}[]`)
+        (`{capture: string, lang: string, metadata: vim.treesitter.query.TSMetadata, id: integer}[]`)
 
 get_node({opts})                                   *vim.treesitter.get_node()*
     Returns the smallest named node at the given position

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -245,14 +245,15 @@ end
 
 --- Returns a list of highlight captures at the given position
 ---
---- Each capture is represented by a table containing the capture name as a string as
---- well as a table of metadata (`priority`, `conceal`, ...; empty if none are defined).
+--- Each capture is represented by a table containing the capture name as a string, the capture's
+--- language, a table of metadata (`priority`, `conceal`, ...; empty if none are defined), and the
+--- id of the capture.
 ---
 ---@param bufnr integer Buffer number (0 for current buffer)
 ---@param row integer Position row
 ---@param col integer Position column
 ---
----@return {capture: string, lang: string, metadata: vim.treesitter.query.TSMetadata}[]
+---@return {capture: string, lang: string, metadata: vim.treesitter.query.TSMetadata, id: integer}[]
 function M.get_captures_at_pos(bufnr, row, col)
   bufnr = vim._resolve_bufnr(bufnr)
   local buf_highlighter = M.highlighter.active[bufnr]
@@ -285,12 +286,15 @@ function M.get_captures_at_pos(bufnr, row, col)
 
     local iter = q:query():iter_captures(root, buf_highlighter.bufnr, row, row + 1)
 
-    for capture, node, metadata in iter do
+    for id, node, metadata in iter do
       if M.is_in_node_range(node, row, col) then
         ---@diagnostic disable-next-line: invisible
-        local c = q._query.captures[capture] -- name of the capture in the query
-        if c ~= nil then
-          table.insert(matches, { capture = c, metadata = metadata, lang = tree:lang() })
+        local capture = q._query.captures[id] -- name of the capture in the query
+        if capture ~= nil then
+          table.insert(
+            matches,
+            { capture = capture, metadata = metadata, lang = tree:lang(), id = id }
+          )
         end
       end
     end

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -12,6 +12,7 @@ local fn = n.fn
 local eq = t.eq
 
 local hl_query_c = [[
+  ; query
   (ERROR) @error
 
   "if" @keyword
@@ -639,8 +640,8 @@ describe('treesitter highlighting (C)', function()
     }
 
     eq({
-      { capture = 'constant', metadata = { priority = '101' }, lang = 'c' },
-      { capture = 'type', metadata = {}, lang = 'c' },
+      { capture = 'constant', metadata = { priority = '101' }, lang = 'c', id = 14 },
+      { capture = 'type', metadata = {}, lang = 'c', id = 3 },
     }, exec_lua [[ return vim.treesitter.get_captures_at_pos(0, 0, 2) ]])
   end)
 


### PR DESCRIPTION
**Problem:** Currently, it is difficult to get node(s)-level metadata for a capture returned by `get_captures_at_pos()`. This is because it is stored in `metadata[id]` and we do not have access to the value of `id`, so to get this value we have to iterate over the keys of `metadata`. See [this commit](https://github.com/neovim/neovim/commit/d63622930001b39b12f14112fc3abb55b760c447#diff-8bd4742121c2f359d0345f3c6c253a58220f1a28670cc4e1c957992232059a6cR16).

Things would be much simpler if we were given the `id` of the capture so we could use it to just index `metadata` directly.

**Solution:** Include `id` in the data returned by `get_captures_at_pos()`

**Examples:**

Under a normal query like:
```scm
((function_call) @_fn
  (#set! @_fn "test" 789))
```

The returned capture will look like this:
```lua
{                                                                                                                                              
  capture = "_fn",                                                                                                                             
  lang = "lua",                                                                                                                                
  metadata = {                                                                                                                                 
    [39] = {                                                                                                                                   
      test = "789"                                                                                                                             
    }                                                                                                                                          
  }                                                                                                                                            
}
```
only the metadata for this capture (of id 39) is returned, which is good; however, it's still annoying that we don't know the id for the capture, because it means we have to iterate over the keys of `metadata` and access the value that way.

```lua
for _, md in pairs(cap.metadata) do
  vim.print(md)
  break
end
```

Things are even worse if we have a query like the following:

```scm
((number) @_num @_numagain
  (#set! @_num "field1" 15)
  (#set! @_numagain "field2" 88))
```

Now the data returned by `get_captures_at_pos()` is:

```lua
{ {                                                                                                                                           
  capture = "_num",                                                                                                                            
  lang = "lua",                                                                                                                                
  metadata = <1>{                                                                                                                              
    [41] = {                                                                                                                                   
      field1 = "15"                                                                                                                            
    },                                                                                                                                         
    [42] = {                                                                                                                                   
      field2 = "88"                                                                                                                            
    }                                                                                                                                          
  }                                                                                                                                            
}, {                                                                                                                                           
  capture = "_numagain",                                                                                                                       
  lang = "lua",                                                                                                                                
  metadata = <table 1>                                                                                                                         
} }
```

In this case it would be impossible to, say, write a function to get all metadata information at a position (which would be useful for comment metadata & `_get_urls`) without counting duplicate metadata fields. We don't know the capture ids for `_numagain` or `_num` so we have to find them using a `for` loop, yet their metadata tables are identical so we can't properly extract the metadata for just that capture. Of course, this example is a bit convoluted, but we should be able to be robustly extract data in cases like this regardless, which would be possible only if we know the id for each specific capture, which we can then use to index into (potentially duplicate) metadata tables.