### PR TITLE
refactor: convert str_byteindex to lua

### DIFF
--- a/src/nvim/lua/stdlib.c
+++ b/src/nvim/lua/stdlib.c
@@ -262,37 +262,6 @@ static int nlua_str_utf_end(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
   return 1;
 }
 
-/// convert UTF-32 or UTF-16 indices to byte index.
-///
-/// Expects up to three args: string, index and use_utf16.
-/// If use_utf16 is not supplied it defaults to false (use UTF-32)
-///
-/// Returns the byte index.
-int nlua_str_byteindex(lua_State *const lstate) FUNC_ATTR_NONNULL_ALL
-{
-  size_t s1_len;
-  const char *s1 = luaL_checklstring(lstate, 1, &s1_len);
-  intptr_t idx = luaL_checkinteger(lstate, 2);
-  if (idx < 0) {
-    lua_pushnil(lstate);
-    return 1;
-  }
-  bool use_utf16 = false;
-  if (lua_gettop(lstate) >= 3) {
-    use_utf16 = lua_toboolean(lstate, 3);
-  }
-
-  ssize_t byteidx = mb_utf_index_to_bytes(s1, s1_len, (size_t)idx, use_utf16);
-  if (byteidx == -1) {
-    lua_pushnil(lstate);
-    return 1;
-  }
-
-  lua_pushinteger(lstate, (lua_Integer)byteidx);
-
-  return 1;
-}
-
 int nlua_regex(lua_State *lstate)
 {
   Error err = ERROR_INIT;
@@ -700,9 +669,6 @@ void nlua_state_add_stdlib(lua_State *const lstate, bool is_thread)
     // str_utfindex
     lua_pushcfunction(lstate, &nlua_str_utfindex);
     lua_setfield(lstate, -2, "__str_utfindex");
-    // str_byteindex
-    lua_pushcfunction(lstate, &nlua_str_byteindex);
-    lua_setfield(lstate, -2, "__str_byteindex");
     // str_utf_pos
     lua_pushcfunction(lstate, &nlua_str_utf_pos);
     lua_setfield(lstate, -2, "str_utf_pos");

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1641,30 +1641,6 @@ void mb_utflen(const char *s, size_t len, size_t *codepoints, size_t *codeunits)
   *codeunits += count + extra;
 }
 
-ssize_t mb_utf_index_to_bytes(const char *s, size_t len, size_t index, bool use_utf16_units)
-  FUNC_ATTR_NONNULL_ALL
-{
-  size_t count = 0;
-  size_t clen;
-  if (index == 0) {
-    return 0;
-  }
-  for (size_t i = 0; i < len; i += clen) {
-    clen = (size_t)utf_ptr2len_len(s + i, (int)(len - i));
-    // NB: gets the byte value of invalid sequence bytes.
-    // we only care whether the char fits in the BMP or not
-    int c = (clen > 1) ? utf_ptr2char(s + i) : (uint8_t)s[i];
-    count++;
-    if (use_utf16_units && c > 0xFFFF) {
-      count++;
-    }
-    if (count >= index) {
-      return (ssize_t)(i + clen);
-    }
-  }
-  return -1;
-}
-
 /// Version of strnicmp() that handles multi-byte characters.
 /// Needed for Big5, Shift-JIS and UTF-8 encoding.  Other DBCS encodings can
 /// probably use strnicmp(), because there are no ASCII characters in the


### PR DESCRIPTION
Refactoring to lua of str_byteindex to allow opts to be passed. This will allow `vim.lsp._str_byteindex_enc` to be deprecated.

questions:

where should this function live, is _editor the right place?
where should the opts class be defined

deprectation suggested in #25272