### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/ft_ada.txt
+++ b/runtime/doc/ft_ada.txt
@@ -48,14 +48,12 @@ ctermfg=White often shows well).
 There are several options you can select in this Ada mode. See |ft-ada-options|
 for a complete list.
 
-To enable them, assign a value to the option.  For example, to turn one on:
- >
-    > let g:ada_standard_types = 1
-
-To disable them use ":unlet".  Example:
->
-    > unlet g:ada_standard_types
-
+To enable them, assign a value to the option.  For example, to turn one on: >
+	let g:ada_standard_types = 1
+<
+To disable them use ":unlet".  Example: >
+	unlet g:ada_standard_types
+<
 You can just use ":" and type these into the command line to set these
 temporarily before loading an Ada file.  You can make these option settings
 permanent by adding the "let" command(s), without a colon, to your |init.vim|

--- a/runtime/doc/undo.txt
+++ b/runtime/doc/undo.txt
@@ -165,13 +165,13 @@ This is explained in the user manual: |usr_32.txt|.
 g-			Go to older text state.  With a count repeat that many
 			times.
 							*:ea* *:earlier*
-:earlier {count}	Go to older text state {count} times.
-:earlier {N}s		Go to older text state about {N} seconds before.
-:earlier {N}m		Go to older text state about {N} minutes before.
-:earlier {N}h		Go to older text state about {N} hours before.
-:earlier {N}d		Go to older text state about {N} days before.
+:ea[rlier] {count}	Go to older text state {count} times.
+:ea[rlier] {N}s		Go to older text state about {N} seconds before.
+:ea[rlier] {N}m		Go to older text state about {N} minutes before.
+:ea[rlier] {N}h		Go to older text state about {N} hours before.
+:ea[rlier] {N}d		Go to older text state about {N} days before.
 
-:earlier {N}f		Go to older text state {N} file writes before.
+:ea[rlier] {N}f		Go to older text state {N} file writes before.
 			When changes were made since the last write
 			":earlier 1f" will revert the text to the state when
 			it was written.  Otherwise it will go to the write
@@ -184,13 +184,13 @@ g-			Go to older text state.  With a count repeat that many
 g+			Go to newer text state.  With a count repeat that many
 			times.
 							*:lat* *:later*
-:later {count}		Go to newer text state {count} times.
-:later {N}s		Go to newer text state about {N} seconds later.
-:later {N}m		Go to newer text state about {N} minutes later.
-:later {N}h		Go to newer text state about {N} hours later.
-:later {N}d		Go to newer text state about {N} days later.
+:lat[er] {count}		Go to newer text state {count} times.
+:lat[er] {N}s		Go to newer text state about {N} seconds later.
+:lat[er] {N}m		Go to newer text state about {N} minutes later.
+:lat[er] {N}h		Go to newer text state about {N} hours later.
+:lat[er] {N}d		Go to newer text state about {N} days later.
 
-:later {N}f		Go to newer text state {N} file writes later.
+:lat[er] {N}f		Go to newer text state {N} file writes later.
 			When at the state of the last file write, ":later 1f"
 			will go to the newest text state.
 


### PR DESCRIPTION
#### vim-patch:998f018: runtime(doc): include short form for :earlier/:later

https://github.com/vim/vim/commit/998f018df37088455bd68ad79da3d16bc4ad9bbe

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:c3989f1: runtime(doc): reformat ada_standard_types section

closes: vim/vim#15759

https://github.com/vim/vim/commit/c3989f184d4dd1ee817c06bb3c04d5471382dd04

Co-authored-by: hokorobi <hokorobi.hokorobi@gmail.com>