### PR TITLE
vim-patch:9.1.0746: tests: Test_halfpage_longline() fails on large terminals

### DIFF
--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4276,6 +4276,7 @@ endfunc
 " Test for Ctrl-D with long line
 func Test_halfpage_longline()
   10new
+  40vsplit
   call setline(1, ['long'->repeat(1000), 'short'])
   exe "norm! \<C-D>"
   call assert_equal(2, line('.'))


### PR DESCRIPTION
#### vim-patch:9.1.0746: tests: Test_halfpage_longline() fails on large terminals

Problem:  Test_halfpage_longline() fails on large terminals
          (lazypingu)
Solution: Use a window with known width (zeertzjq).

closes: vim/vim#15756

https://github.com/vim/vim/commit/fa117387eea97306e4c59043b607ccb1533f64ea