### PR TITLE
vim-patch:6db3fc5: runtime(doc): reformat gnat example

### DIFF
--- a/runtime/doc/ft_ada.txt
+++ b/runtime/doc/ft_ada.txt
@@ -156,10 +156,9 @@ several versions available which differ in the licence terms used.
 
 The GNAT compiler plug-in will perform a compile on pressing <F7> and then
 immediately shows the result. You can set the project file to be used by
-setting:
- >
- > call g:gnat.Set_Project_File ('my_project.gpr')
-
+setting: >
+		call g:gnat.Set_Project_File ('my_project.gpr')
+<
 Setting a project file will also create a Vim session (|views-sessions|) so -
 like with the GPS - opened files, window positions etc. will be remembered
 separately for all projects.


### PR DESCRIPTION
#### vim-patch:6db3fc5: runtime(doc): reformat gnat example

closes: vim/vim#15758

https://github.com/vim/vim/commit/6db3fc5632c877062d759356c025fe06e9dc3630

Co-authored-by: hokorobi <hokorobi.hokorobi@gmail.com>