### PR TITLE
docs: improve luacats support

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2303,7 +2303,7 @@ Lua module: vim.lsp.rpc                                              *lsp-rpc*
 *vim.lsp.rpc.PublicClient*
 
     Fields: ~
-      • {request}     (`fun(method: string, params: table?, callback: fun(err: lsp.ResponseError?, result: any), notify_reply_callback: fun(integer)?):boolean,integer?`)
+      • {request}     (`fun(method: string, params: table?, callback: fun(err: lsp.ResponseError?, result: any), notify_reply_callback: fun(message_id: integer)?):boolean,integer?`)
                       see |vim.lsp.rpc.request()|
       • {notify}      (`fun(method: string, params: any):boolean`) see
                       |vim.lsp.rpc.notify()|

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -752,8 +752,8 @@ vim.diff({a}, {b}, {opts})                                        *vim.diff()*
                   the internal diff library.
 
     Return: ~
-        (`string|integer[]`) See {opts.result_type}. `nil` if {opts.on_hunk}
-        is given.
+        (`string|integer[][]?`) See {opts.result_type}. `nil` if
+        {opts.on_hunk} is given.
 
 
 ==============================================================================

--- a/runtime/lua/vim/_meta/builtin.lua
+++ b/runtime/lua/vim/_meta/builtin.lua
@@ -182,8 +182,8 @@ function vim.str_utf_end(str, index) end
 --- that sequence.
 --- @param str string
 --- @param index? integer
---- @return integer UTF-32 index
---- @return integer UTF-16 index
+--- @return integer # UTF-32 index
+--- @return integer # UTF-16 index
 function vim.str_utfindex(str, index) end
 
 --- The result is a String, which is the text {str} converted from

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -550,7 +550,7 @@ local function new_client(dispatchers, transport)
 end
 
 ---@class vim.lsp.rpc.PublicClient
----@field request fun(method: string, params: table?, callback: fun(err: lsp.ResponseError|nil, result: any), notify_reply_callback: fun(integer)|nil):boolean,integer? see |vim.lsp.rpc.request()|
+---@field request fun(method: string, params: table?, callback: fun(err: lsp.ResponseError|nil, result: any), notify_reply_callback: fun(message_id: integer)|nil):boolean,integer? see |vim.lsp.rpc.request()|
 ---@field notify fun(method: string, params: any):boolean see |vim.lsp.rpc.notify()|
 ---@field is_closing fun(): boolean
 ---@field terminate fun()

--- a/test/functional/script/luacats_grammar_spec.lua
+++ b/test/functional/script/luacats_grammar_spec.lua
@@ -166,4 +166,122 @@ describe('luacats grammar', function()
     name = 'type',
     type = '[number,string,"good"|"bad"]',
   })
+
+  test('@class vim.diagnostic.JumpOpts', {
+    kind = 'class',
+    name = 'vim.diagnostic.JumpOpts',
+  })
+
+  test('@class vim.diagnostic.JumpOpts : vim.diagnostic.GetOpts', {
+    kind = 'class',
+    name = 'vim.diagnostic.JumpOpts',
+    parent = 'vim.diagnostic.GetOpts',
+  })
+
+  test('@param opt? { cmd?: string[] } Options', {
+    kind = 'param',
+    name = 'opt?',
+    type = '{ cmd?: string[] }',
+    desc = 'Options',
+  })
+
+  ---@type [string, string?][]
+  local test_cases = {
+    { 'foo' },
+    { 'foo   ', 'foo' }, -- trims whitespace
+    { 'true' },
+    { 'vim.type' },
+    { 'vim-type' },
+    { 'vim_type' },
+    { 'foo.bar-baz_baz' },
+    { '`ABC`' },
+    { '42' },
+    { '-42' },
+    { '(foo)', 'foo' }, -- removes unnecessary parens
+    { 'true?' },
+    { '(true)?' },
+    { 'string[]' },
+    { 'string|number' },
+    { '(string)[]' },
+    { '(string|number)[]' },
+    { 'coalesce??', 'coalesce?' }, -- removes unnecessary ?
+    { 'number?|string' },
+    { "'foo'|'bar'|'baz'" },
+    { '"foo"|"bar"|"baz"' },
+    { '(number)?|string' }, --
+    { 'number[]|string' },
+    { 'string[]?' },
+    { 'foo?[]' },
+    { 'vim.type?|string?   ', 'vim.type?|string?' },
+    { 'number[][]' },
+    { 'number[][][]' },
+    { 'number[][]?' },
+    { 'string|integer[][]?' },
+
+    -- tuples
+    { '[string]' },
+    { '[1]' },
+    { '[string, number]' },
+    { '[string, number]?' },
+    { '[string, number][]' },
+    { '[string, number]|string' },
+    { '[string|number, number?]' },
+    { 'string|[string, number]' },
+    { '(true)?|[foo]' },
+    { '[fun(a: string):boolean]' },
+
+    -- dict
+    { '{[string]:string}' },
+    { '{ [ string ] : string }' },
+    { '{ [ string|any ] : string }' },
+    { '{[string]: string, [number]: boolean}' },
+
+    -- key-value table
+    { 'table<string,any>' },
+    { 'table' },
+    { 'string|table|boolean' },
+    { 'string|table|(boolean)' },
+
+    -- table literal
+    { '{foo: number}' },
+    { '{foo: string, bar: [number, boolean]?}' },
+    { 'boolean|{reverse?:boolean}' },
+    { '{ cmd?: string[] }' },
+
+    -- function
+    { 'fun(a: string, b:foo|bar): string' },
+    { 'fun(a?: string): string' },
+    { 'fun(a?: string): number?,string?' },
+    { '(fun(a: string, b:foo|bar): string)?' },
+    { 'fun(a: string, b:foo|bar): string, string' },
+    { 'fun(a: string, b:foo|bar)' },
+    { 'fun(_, foo, bar): string' },
+    { 'fun(...): number' },
+    { 'fun( ... ): number' },
+    { 'fun(...:number): number' },
+    { 'fun( ... : number): number' },
+
+    -- generics
+    { 'elem_or_list<string>' },
+    {
+      'elem_or_list<fun(client: vim.lsp.Client, initialize_result: lsp.InitializeResult)>',
+      nil,
+    },
+  }
+
+  for _, tc in ipairs(test_cases) do
+    local ty, exp_ty = tc[1], tc[2]
+    if exp_ty == nil then
+      exp_ty = ty
+    end
+
+    local var, desc = 'x', 'some desc'
+    local param = string.format('@param %s %s %s', var, ty, desc)
+    test(param, {
+      kind = 'param',
+      name = var,
+      type = exp_ty,
+      desc = desc,
+    })
+  end
 end)


### PR DESCRIPTION
Some composite/compound types even as basic as `(string|number)[]` are not currently supported by the luacats LPEG grammar used by gen_vimdoc. It would be parsed & rendered as just `string|number`.

Changeset adds better support for these types.

`make doc` was run. Only a few changes made to the docs itself.