### PR TITLE
refactor: use ERROR_SET() to check for error

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3181,7 +3181,7 @@ bool map_execute_lua(bool may_repeat)
   Error err = ERROR_INIT;
   Array args = ARRAY_DICT_INIT;
   nlua_call_ref(ref, NULL, args, kRetNilBool, NULL, &err);
-  if (err.type != kErrorTypeNone) {
+  if (ERROR_SET(&err)) {
     semsg_multiline("E5108: %s", err.msg);
     api_clear_error(&err);
   }

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -1651,7 +1651,7 @@ char *eval_map_expr(mapblock_T *mp, int c)
       p = string_to_cstr(ret.data.string);
     }
     api_free_object(ret);
-    if (err.type != kErrorTypeNone) {
+    if (ERROR_SET(&err)) {
       semsg_multiline("E5108: %s", err.msg);
       api_clear_error(&err);
     }


### PR DESCRIPTION
Replaces the only two places where kErrorTypeNone is checked explicitly.
