### PR TITLE
fix(tabline): restore behavior of click after last tabpage

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -810,6 +810,16 @@ void draw_tabline(void)
       }
     }
 
+    for (int scol = col; scol < Columns; scol++) {
+      // Use 0 as tabpage number here, so that double-click opens a tabpage
+      // after the last one, and single-click goes to the next tabpage.
+      tab_page_click_defs[scol] = (StlClickDefinition) {
+        .type = kStlClickTabSwitch,
+        .tabnr = 0,
+        .func = NULL,
+      };
+    }
+
     char c = use_sep_chars ? '_' : ' ';
     grid_line_fill(col, Columns, schar_from_ascii(c), attr_fill);
 
@@ -1246,24 +1256,17 @@ int build_stl_str_hl(win_T *wp, char *out, size_t outlen, char *fmt, OptIndex op
     // TABPAGE pairs are used to denote a region that when clicked will
     // either switch to or close a tab.
     //
-    // Ex: tabline=%0Ttab\ zero%X
-    //   This tabline has a TABPAGENR item with minwid `0`,
+    // Ex: tabline=%1Ttab\ one%X
+    //   This tabline has a TABPAGENR item with minwid `1`,
     //   which is then closed with a TABCLOSENR item.
-    //   Clicking on this region with mouse enabled will switch to tab 0.
+    //   Clicking on this region with mouse enabled will switch to tab 1.
     //   Setting the minwid to a different value will switch
     //   to that tab, if it exists
     //
     // Ex: tabline=%1Xtab\ one%X
     //   This tabline has a TABCLOSENR item with minwid `1`,
     //   which is then closed with a TABCLOSENR item.
-    //   Clicking on this region with mouse enabled will close tab 0.
-    //   This is determined by the following formula:
-    //      tab to close = (1 - minwid)
-    //   This is because for TABPAGENR we use `minwid` = `tab number`.
-    //   For TABCLOSENR we store the tab number as a negative value.
-    //   Because 0 is a valid TABPAGENR value, we have to
-    //   start our numbering at `-1`.
-    //   So, `-1` corresponds to us wanting to close tab `0`
+    //   Clicking on this region with mouse enabled will close tab 1.
     //
     // Note: These options are only valid when creating a tabline.
     if (*fmt_p == STL_TABPAGENR || *fmt_p == STL_TABCLOSENR) {

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -367,7 +367,7 @@ describe('ui/mouse/input', function()
       })
     end)
 
-    it('left click in default tabline (position 4) switches to tab', function()
+    it('left click in default tabline (tabpage label) switches to tab', function()
       feed_command('%delete')
       insert('this is foo')
       feed_command('silent file foo | tabnew | file bar')
@@ -385,9 +385,47 @@ describe('ui/mouse/input', function()
         {0:~                        }|*2
                                  |
       ]])
+      feed('<LeftMouse><6,0>')
+      screen:expect_unchanged()
+      feed('<LeftMouse><10,0>')
+      screen:expect([[
+        {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
+        this is ba^r{0:$}             |
+        {0:~                        }|*2
+                                 |
+      ]])
+      feed('<LeftMouse><12,0>')
+      screen:expect_unchanged()
     end)
 
-    it('left click in default tabline (position 24) closes tab', function()
+    it('left click in default tabline (blank space) switches tab', function()
+      feed_command('%delete')
+      insert('this is foo')
+      feed_command('silent file foo | tabnew | file bar')
+      insert('this is bar')
+      screen:expect([[
+        {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
+        this is ba^r{0:$}             |
+        {0:~                        }|*2
+                                 |
+      ]])
+      feed('<LeftMouse><20,0>')
+      screen:expect([[
+        {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
+        this is fo^o              |
+        {0:~                        }|*2
+                                 |
+      ]])
+      feed('<LeftMouse><22,0>')
+      screen:expect([[
+        {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
+        this is ba^r{0:$}             |
+        {0:~                        }|*2
+                                 |
+      ]])
+    end)
+
+    it('left click in default tabline (close label) closes tab', function()
       api.nvim_set_option_value('hidden', true, {})
       feed_command('%delete')
       insert('this is foo')
@@ -407,8 +445,7 @@ describe('ui/mouse/input', function()
       ]])
     end)
 
-    it('double click in default tabline (position 4) opens new tab', function()
-      api.nvim_set_option_value('hidden', true, {})
+    it('double click in default tabline opens new tab before', function()
       feed_command('%delete')
       insert('this is foo')
       feed_command('silent file foo | tabnew | file bar')
@@ -422,6 +459,34 @@ describe('ui/mouse/input', function()
       feed('<2-LeftMouse><4,0>')
       screen:expect([[
         {sel:  Name] }{tab: + foo  + bar }{fill:  }{tab:X}|
+        {0:^$}                        |
+        {0:~                        }|*2
+                                 |
+      ]])
+      command('tabclose')
+      screen:expect([[
+        {sel: + foo }{tab: + bar }{fill:          }{tab:X}|
+        this is fo^o              |
+        {0:~                        }|*2
+                                 |
+      ]])
+      feed('<2-LeftMouse><20,0>')
+      screen:expect([[
+        {tab: + foo  + bar }{sel:  Name] }{fill:  }{tab:X}|
+        {0:^$}                        |
+        {0:~                        }|*2
+                                 |
+      ]])
+      command('tabclose')
+      screen:expect([[
+        {tab: + foo }{sel: + bar }{fill:          }{tab:X}|
+        this is ba^r{0:$}             |
+        {0:~                        }|*2
+                                 |
+      ]])
+      feed('<2-LeftMouse><10,0>')
+      screen:expect([[
+        {tab: + foo }{sel:  Name] }{tab: + bar }{fill:  }{tab:X}|
         {0:^$}                        |
         {0:~                        }|*2
                                  |


### PR DESCRIPTION
Also correct the comments about tabpage labels in custom tabline.

Fix #30599
