### PR TITLE
vim-patch:9.1.0749: filetype: http files not recognized

### DIFF
--- a/runtime/ftplugin/http.vim
+++ b/runtime/ftplugin/http.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin
+" Language:	HTTP
+" Maintainer:	Riley Bruins <ribru17@gmail.com>
+" Last Change:	2024 Sep 28
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setl comments=:# commentstring=#\ %s
+
+let b:undo_ftplugin = 'setl com< cms<'

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -578,6 +578,7 @@ local extension = {
   stm = detect.html,
   htt = 'httest',
   htb = 'httest',
+  http = 'http',
   hurl = 'hurl',
   hw = detect.hw,
   module = detect.hw,

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -340,6 +340,7 @@ func s:GetFilenameChecks() abort
     \ 'hostconf': ['/etc/host.conf', 'any/etc/host.conf'],
     \ 'hostsaccess': ['/etc/hosts.allow', '/etc/hosts.deny', 'any/etc/hosts.allow', 'any/etc/hosts.deny'],
     \ 'html': ['file.html', 'file.htm', 'file.cshtml', 'file.component.html'],
+    \ 'http': ['file.http'],
     \ 'htmlm4': ['file.html.m4'],
     \ 'httest': ['file.htt', 'file.htb'],
     \ 'hurl': ['file.hurl'],


### PR DESCRIPTION
Problem:  filetype: http files not recognized
Solution: detect '*.http' as http filetype, include
          http filetype plugin (Riley Bruins)

Based on the specification found
[here](https://github.com/JetBrains/http-request-in-editor-spec/blob/master/spec.md)

closes: vim/vim#15762

https://github.com/vim/vim/commit/de6c1d1182076b10212342fd2d441267fbe43a22

Co-authored-by: Riley Bruins <ribru17@hotmail.com>
