### PR TITLE
feat(editor): handle new multibyte sequences in normal mode replacement

### DIFF
--- a/src/nvim/grid_defs.h
+++ b/src/nvim/grid_defs.h
@@ -7,10 +7,6 @@
 #include "nvim/pos_defs.h"
 #include "nvim/types_defs.h"
 
-// Includes final NUL. MAX_MCO is no longer used, but at least 4*(MAX_MCO+1)+1=29
-// ensures we can fit all composed chars which did fit before.
-#define MAX_SCHAR_SIZE 32
-
 enum {
   kZIndexDefaultGrid = 0,
   kZIndexFloatDefault = 50,

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -839,6 +839,13 @@ bool utf_composinglike(const char *p1, const char *p2, GraphemeState *state)
   return arabic_combine(first, second);
 }
 
+/// same as utf_composinglike but operating on UCS-4 values
+bool utf_iscomposing(int c1, int c2, GraphemeState *state)
+{
+  return (!utf8proc_grapheme_break_stateful(c1, c2, state)
+          || arabic_combine(c1, c2));
+}
+
 /// Get the screen char at the beginning of a string
 ///
 /// Caller is expected to check for things like unprintable chars etc
@@ -1852,8 +1859,7 @@ StrCharInfo utfc_next_impl(StrCharInfo cur)
   while (true) {
     uint8_t const next_len = utf8len_tab[*next];
     int32_t const next_code = utf_ptr2CharInfo_impl(next, (uintptr_t)next_len);
-    if (utf8proc_grapheme_break_stateful(prev_code, next_code, &state)
-        && !arabic_combine(prev_code, next_code)) {
+    if (!utf_iscomposing(prev_code, next_code, &state)) {
       return (StrCharInfo){
         .ptr = (char *)next,
         .chr = (CharInfo){ .value = next_code, .len = (next_code < 0 ? 1 : next_len) },

--- a/src/nvim/normal_defs.h
+++ b/src/nvim/normal_defs.h
@@ -3,6 +3,7 @@
 #include <stdbool.h>
 
 #include "nvim/pos_defs.h"
+#include "nvim/types_defs.h"
 
 /// Motion types, used for operators and for yank/delete registers.
 ///
@@ -47,8 +48,8 @@ typedef struct {
   int prechar;      ///< prefix character (optional, always 'g')
   int cmdchar;      ///< command character
   int nchar;        ///< next command character (optional)
-  int ncharC1;      ///< first composing character (optional)
-  int ncharC2;      ///< second composing character (optional)
+  char nchar_composing[MAX_SCHAR_SIZE];  ///< next char with composing chars (optional)
+  int nchar_len;    ///< len of nchar_composing (when zero, use nchar instead)
   int extra_char;   ///< yet another character (optional)
   int opcount;      ///< count before an operator
   int count0;       ///< count before command, default 0

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -113,7 +113,7 @@ static int last_idx = 0;        // index in spats[] for RE_LAST
 static uint8_t lastc[2] = { NUL, NUL };   // last character searched for
 static Direction lastcdir = FORWARD;      // last direction of character search
 static bool last_t_cmd = true;            // last search t_cmd
-static char lastc_bytes[MB_MAXBYTES + 1];
+static char lastc_bytes[MAX_SCHAR_SIZE + 1];
 static int lastc_bytelen = 1;             // >1 for multi-byte char
 
 // copy of spats[], for keeping the search patterns while executing autocmds
@@ -1550,14 +1550,11 @@ int searchc(cmdarg_T *cap, bool t_cmd)
       *lastc = (uint8_t)c;
       set_csearch_direction(dir);
       set_csearch_until(t_cmd);
-      lastc_bytelen = utf_char2bytes(c, lastc_bytes);
-      if (cap->ncharC1 != 0) {
-        lastc_bytelen += utf_char2bytes(cap->ncharC1,
-                                        lastc_bytes + lastc_bytelen);
-        if (cap->ncharC2 != 0) {
-          lastc_bytelen += utf_char2bytes(cap->ncharC2,
-                                          lastc_bytes + lastc_bytelen);
-        }
+      if (cap->nchar_len) {
+        lastc_bytelen = cap->nchar_len;
+        memcpy(lastc_bytes, cap->nchar_composing, (size_t)cap->nchar_len);
+      } else {
+        lastc_bytelen = utf_char2bytes(c, lastc_bytes);
       }
     }
   } else {            // repeat previous search

--- a/src/nvim/types_defs.h
+++ b/src/nvim/types_defs.h
@@ -12,6 +12,10 @@ typedef int32_t sattr_T;
 // must be at least as big as the biggest of schar_T, sattr_T, colnr_T
 typedef int32_t sscratch_T;
 
+// Includes final NUL. MAX_MCO is no longer used, but at least 4*(MAX_MCO+1)+1=29
+// ensures we can fit all composed chars which did fit before.
+#define MAX_SCHAR_SIZE 32
+
 // Opaque handle used by API clients to refer to various objects in vim
 typedef int handle_T;
 

--- a/test/functional/editor/mode_normal_spec.lua
+++ b/test/functional/editor/mode_normal_spec.lua
@@ -9,6 +9,7 @@ local feed = n.feed
 local fn = n.fn
 local command = n.command
 local eq = t.eq
+local api = n.api
 
 describe('Normal mode', function()
   before_each(clear)
@@ -40,5 +41,24 @@ describe('Normal mode', function()
       ]],
       attr_ids = {},
     })
+  end)
+
+  it('replacing with ZWJ emoji sequences', function()
+    local screen = Screen.new(30, 8)
+    screen:attach()
+    api.nvim_buf_set_lines(0, 0, -1, true, { 'abcdefg' })
+    feed('05r🧑‍🌾') -- ZWJ
+    screen:expect([[
+      🧑‍🌾🧑‍🌾🧑‍🌾🧑‍🌾^🧑‍🌾fg                  |
+      {1:~                             }|*6
+                                    |
+    ]])
+
+    feed('2r🏳️‍⚧️') -- ZWJ and variant selectors
+    screen:expect([[
+      🧑‍🌾🧑‍🌾🧑‍🌾🧑‍🌾🏳️‍⚧️^🏳️‍⚧️g                 |
+      {1:~                             }|*6
+                                    |
+    ]])
   end)
 end)


### PR DESCRIPTION
while the implementation is not tied to screen chars, it is a reasonable expectation to support the same size. If nvim is able to display a multibyte character, it will accept the same character as input, including in normal mode commands like `r{char}`