### PR TITLE
vim-patch:9.1.0753: Wrong display when typing in diff mode with 'smoothscroll'

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1805,8 +1805,10 @@ static void win_update(win_T *wp)
           // Correct the first entry for filler lines at the top
           // when it won't get updated below.
           if (win_may_fill(wp) && bot_start > 0) {
-            wp->w_lines[0].wl_size = (uint16_t)(plines_win_nofill(wp, wp->w_topline, true)
-                                                + wp->w_topfill);
+            int n = plines_win_nofill(wp, wp->w_topline, false) + wp->w_topfill
+                    - adjust_plines_for_skipcol(wp);
+            n = MIN(n, wp->w_height_inner);
+            wp->w_lines[0].wl_size = (uint16_t)n;
           }
         }
       }

--- a/test/functional/legacy/scroll_opt_spec.lua
+++ b/test/functional/legacy/scroll_opt_spec.lua
@@ -375,6 +375,108 @@ describe('smoothscroll', function()
     screen:expect_unchanged()
   end)
 
+  -- oldtest: Test_smoothscroll_diff_change_line()
+  it('works in diff mode when changing line', function()
+    screen:try_resize(55, 20)
+    exec([[
+      set diffopt+=followwrap smoothscroll
+      call setline(1, repeat(' abc', &columns))
+      call setline(2, 'bar')
+      call setline(3, repeat(' abc', &columns))
+      vnew
+      call setline(1, repeat(' abc', &columns))
+      call setline(2, 'foo')
+      call setline(3, 'bar')
+      call setline(4, repeat(' abc', &columns))
+      windo exe "normal! 2gg5\<C-E>"
+      windo diffthis
+    ]])
+
+    screen:expect([[
+      {1:<<<}bc abc abc abc abc abc a│{1:<<<}bc abc abc abc abc abc a|
+      {7:  }bc abc abc abc abc abc ab│{7:  }bc abc abc abc abc abc ab|
+      {7:  }c abc abc abc abc abc abc│{7:  }c abc abc abc abc abc abc|
+      {7:  } abc abc abc abc abc     │{7:  } abc abc abc abc abc     |
+      {7:  }{22:foo                      }│{7:  }{23:-------------------------}|
+      {7:  }bar                      │{7:  }^bar                      |
+      {7:  } abc abc abc abc abc abc │{7:  } abc abc abc abc abc abc |
+      {7:  }abc abc abc abc abc abc a│{7:  }abc abc abc abc abc abc a|
+      {7:  }bc abc abc abc abc abc ab│{7:  }bc abc abc abc abc abc ab|
+      {7:  }c abc abc abc abc abc abc│{7:  }c abc abc abc abc abc abc|
+      {7:  } abc abc abc abc abc abc │{7:  } abc abc abc abc abc abc |
+      {7:  }abc abc abc abc abc abc a│{7:  }abc abc abc abc abc abc a|
+      {7:  }bc abc abc abc abc abc ab│{7:  }bc abc abc abc abc abc ab|
+      {7:  }c abc abc abc abc abc abc│{7:  }c abc abc abc abc abc abc|
+      {7:  } abc abc abc abc abc     │{7:  } abc abc abc abc abc     |
+      {1:~                          }│{1:~                          }|*3
+      {2:[No Name] [+]               }{3:[No Name] [+]              }|
+                                                             |
+    ]])
+    feed('Abar')
+    screen:expect([[
+      {1:<<<}bc abc abc abc abc abc a│{1:<<<}bc abc abc abc abc abc a|
+      {7:  }bc abc abc abc abc abc ab│{7:  }bc abc abc abc abc abc ab|
+      {7:  }c abc abc abc abc abc abc│{7:  }c abc abc abc abc abc abc|
+      {7:  } abc abc abc abc abc     │{7:  } abc abc abc abc abc     |
+      {7:  }{22:foo                      }│{7:  }{23:-------------------------}|
+      {7:  }bar                      │{7:  }barbar^                   |
+      {7:  } abc abc abc abc abc abc │{7:  } abc abc abc abc abc abc |
+      {7:  }abc abc abc abc abc abc a│{7:  }abc abc abc abc abc abc a|
+      {7:  }bc abc abc abc abc abc ab│{7:  }bc abc abc abc abc abc ab|
+      {7:  }c abc abc abc abc abc abc│{7:  }c abc abc abc abc abc abc|
+      {7:  } abc abc abc abc abc abc │{7:  } abc abc abc abc abc abc |
+      {7:  }abc abc abc abc abc abc a│{7:  }abc abc abc abc abc abc a|
+      {7:  }bc abc abc abc abc abc ab│{7:  }bc abc abc abc abc abc ab|
+      {7:  }c abc abc abc abc abc abc│{7:  }c abc abc abc abc abc abc|
+      {7:  } abc abc abc abc abc     │{7:  } abc abc abc abc abc     |
+      {1:~                          }│{1:~                          }|*3
+      {2:[No Name] [+]               }{3:[No Name] [+]              }|
+      {5:-- INSERT --}                                           |
+    ]])
+    feed('<Esc>')
+    screen:expect([[
+      {1:<<<}bc abc abc abc abc abc a│{1:<<<}bc abc abc abc abc abc a|
+      {7:  }bc abc abc abc abc abc ab│{7:  }bc abc abc abc abc abc ab|
+      {7:  }c abc abc abc abc abc abc│{7:  }c abc abc abc abc abc abc|
+      {7:  } abc abc abc abc abc     │{7:  } abc abc abc abc abc     |
+      {7:  }{27:foo}{4:                      }│{7:  }{27:barba^r}{4:                   }|
+      {7:  }{22:bar                      }│{7:  }{23:-------------------------}|
+      {7:  } abc abc abc abc abc abc │{7:  } abc abc abc abc abc abc |
+      {7:  }abc abc abc abc abc abc a│{7:  }abc abc abc abc abc abc a|
+      {7:  }bc abc abc abc abc abc ab│{7:  }bc abc abc abc abc abc ab|
+      {7:  }c abc abc abc abc abc abc│{7:  }c abc abc abc abc abc abc|
+      {7:  } abc abc abc abc abc abc │{7:  } abc abc abc abc abc abc |
+      {7:  }abc abc abc abc abc abc a│{7:  }abc abc abc abc abc abc a|
+      {7:  }bc abc abc abc abc abc ab│{7:  }bc abc abc abc abc abc ab|
+      {7:  }c abc abc abc abc abc abc│{7:  }c abc abc abc abc abc abc|
+      {7:  } abc abc abc abc abc     │{7:  } abc abc abc abc abc     |
+      {1:~                          }│{1:~                          }|*3
+      {2:[No Name] [+]               }{3:[No Name] [+]              }|
+                                                             |
+    ]])
+    feed('yyp')
+    screen:expect([[
+      {1:<<<}bc abc abc abc abc abc a│{1:<<<}bc abc abc abc abc abc a|
+      {7:  }bc abc abc abc abc abc ab│{7:  }bc abc abc abc abc abc ab|
+      {7:  }c abc abc abc abc abc abc│{7:  }c abc abc abc abc abc abc|
+      {7:  } abc abc abc abc abc     │{7:  } abc abc abc abc abc     |
+      {7:  }{27:foo}{4:                      }│{7:  }{27:barbar}{4:                   }|
+      {7:  }{4:bar                      }│{7:  }{4:^bar}{27:bar}{4:                   }|
+      {7:  } abc abc abc abc abc abc │{7:  } abc abc abc abc abc abc |
+      {7:  }abc abc abc abc abc abc a│{7:  }abc abc abc abc abc abc a|
+      {7:  }bc abc abc abc abc abc ab│{7:  }bc abc abc abc abc abc ab|
+      {7:  }c abc abc abc abc abc abc│{7:  }c abc abc abc abc abc abc|
+      {7:  } abc abc abc abc abc abc │{7:  } abc abc abc abc abc abc |
+      {7:  }abc abc abc abc abc abc a│{7:  }abc abc abc abc abc abc a|
+      {7:  }bc abc abc abc abc abc ab│{7:  }bc abc abc abc abc abc ab|
+      {7:  }c abc abc abc abc abc abc│{7:  }c abc abc abc abc abc abc|
+      {7:  } abc abc abc abc abc     │{7:  } abc abc abc abc abc     |
+      {1:~                          }│{1:~                          }|*3
+      {2:[No Name] [+]               }{3:[No Name] [+]              }|
+                                                             |
+    ]])
+  end)
+
   -- oldtest: Test_smoothscroll_wrap_scrolloff_zero()
   it("works with zero 'scrolloff'", function()
     screen:try_resize(40, 8)

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -302,6 +302,36 @@ func Test_smoothscroll_diff_mode()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_smoothscroll_diff_change_line()
+  CheckScreendump
+
+  let lines =<< trim END
+    set diffopt+=followwrap smoothscroll
+    call setline(1, repeat(' abc', &columns))
+    call setline(2, 'bar')
+    call setline(3, repeat(' abc', &columns))
+    vnew
+    call setline(1, repeat(' abc', &columns))
+    call setline(2, 'foo')
+    call setline(3, 'bar')
+    call setline(4, repeat(' abc', &columns))
+    windo exe "normal! 2gg5\<C-E>"
+    windo diffthis
+  END
+  call writefile(lines, 'XSmoothDiffChangeLine', 'D')
+  let buf = RunVimInTerminal('-S XSmoothDiffChangeLine', #{rows: 20, columns: 55})
+
+  call VerifyScreenDump(buf, 'Test_smooth_diff_change_line_1', {})
+  call term_sendkeys(buf, "Abar")
+  call VerifyScreenDump(buf, 'Test_smooth_diff_change_line_2', {})
+  call term_sendkeys(buf, "\<Esc>")
+  call VerifyScreenDump(buf, 'Test_smooth_diff_change_line_3', {})
+  call term_sendkeys(buf, "yyp")
+  call VerifyScreenDump(buf, 'Test_smooth_diff_change_line_4', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_smoothscroll_wrap_scrolloff_zero()
   CheckScreendump
 


### PR DESCRIPTION
Fix #30603

#### vim-patch:9.1.0753: Wrong display when typing in diff mode with 'smoothscroll'

Problem:  Wrong display when typing in diff mode with 'smoothscroll'.
Solution: Use adjust_plines_for_skipcol() (zeertzjq).

closes: vim/vim#15776

https://github.com/vim/vim/commit/47f8584a80006cd25e7dc6fa7fb1bfe2e768403c