### PR TITLE
vim-patch:9.1.0752: can set 'cedit' to an invalid value

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1276,9 +1276,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 	The key used in Command-line Mode to open the command-line window.
 	Only non-printable keys are allowed.
 	The key can be specified as a single character, but it is difficult to
-	type.  The preferred way is to use the <> notation.  Examples: >vim
-		exe "set cedit=\<C-Y>"
-		exe "set cedit=\<Esc>"
+	type.  The preferred way is to use |key-notation| (e.g. <Up>, <C-F>) or
+	a letter preceded with a caret (e.g. `^F` is CTRL-F).  Examples: >vim
+		set cedit=^Y
+		set cedit=<Esc>
 <	|Nvi| also has this option, but it only uses the first character.
 	See |cmdwin|.
 

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -731,11 +731,12 @@ vim.go.cd = vim.go.cdpath
 --- The key used in Command-line Mode to open the command-line window.
 --- Only non-printable keys are allowed.
 --- The key can be specified as a single character, but it is difficult to
---- type.  The preferred way is to use the <> notation.  Examples:
+--- type.  The preferred way is to use `key-notation` (e.g. <Up>, <C-F>) or
+--- a letter preceded with a caret (e.g. `^F` is CTRL-F).  Examples:
 ---
 --- ```vim
---- 	exe "set cedit=\\<C-Y>"
---- 	exe "set cedit=\\<Esc>"
+--- 	set cedit=^Y
+--- 	set cedit=<Esc>
 --- ```
 --- `Nvi` also has this option, but it only uses the first character.
 --- See `cmdwin`.

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4302,7 +4302,7 @@ const char *did_set_cedit(optset_T *args)
     cedit_key = -1;
   } else {
     int n = string_to_key(p_cedit);
-    if (vim_isprintc(n)) {
+    if (n == 0 || vim_isprintc(n)) {
       return e_invarg;
     }
     cedit_key = n;

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -996,9 +996,10 @@ return {
         The key used in Command-line Mode to open the command-line window.
         Only non-printable keys are allowed.
         The key can be specified as a single character, but it is difficult to
-        type.  The preferred way is to use the <> notation.  Examples: >vim
-        	exe "set cedit=\\<C-Y>"
-        	exe "set cedit=\\<Esc>"
+        type.  The preferred way is to use |key-notation| (e.g. <Up>, <C-F>) or
+        a letter preceded with a caret (e.g. `^F` is CTRL-F).  Examples: >vim
+        	set cedit=^Y
+        	set cedit=<Esc>
         <	|Nvi| also has this option, but it only uses the first character.
         See |cmdwin|.
       ]=],


### PR DESCRIPTION
#### vim-patch:9.1.0752: can set 'cedit' to an invalid value

Problem:  can set cedit to an invalid value
Solution: Check that the value is a valid key name
          (Milly)

closes: vim/vim#15778

https://github.com/vim/vim/commit/25732435c56d762abb260499680939bd8882c708

Co-authored-by: Milly <milly.ca@gmail.com>