### PR TITLE
vim-patch:baee844: runtime(doc): add `usr` tag to usr_toc.txt

### DIFF
--- a/runtime/doc/usr_toc.txt
+++ b/runtime/doc/usr_toc.txt
@@ -2,7 +2,7 @@
 
 		     VIM USER MANUAL - by Bram Moolenaar
 
-			      Table Of Contents			*user-manual*
+			      Table Of Contents		       *user-manual* *usr*
 
 ==============================================================================
 Overview


### PR DESCRIPTION
#### vim-patch:baee844: runtime(doc): add `usr` tag to usr_toc.txt

When typing `:h usr` it redirects to usr_01.txt, but I'd argue
usr_toc.txt is more useful as you can see an overview of all manuals.
When I usr `:h usr` I personally always intend to go to `usr_toc`.

closes: vim/vim#15779

https://github.com/vim/vim/commit/baee8448d1dc803d01ed61beff2a135827b1b8e3

Co-authored-by: dundargoc <gocdundar@gmail.com>