### PR TITLE
fix(cmake): Fix lua lpeg library search on MacOS

### DIFF
--- a/cmake/FindLpeg.cmake
+++ b/cmake/FindLpeg.cmake
@@ -1,3 +1,6 @@
+if(APPLE)
+  set(CMAKE_FIND_LIBRARY_PREFIXES ";lib")
+endif()
 find_library2(LPEG_LIBRARY NAMES lpeg_a lpeg liblpeg_a lpeg${CMAKE_SHARED_LIBRARY_SUFFIX} PATH_SUFFIXES lua/5.1)
 
 find_package_handle_standard_args(Lpeg DEFAULT_MSG LPEG_LIBRARY)


### PR DESCRIPTION
Problem:

CMake is unable to find the LUA lpeg library on a MacOS system.

Cause:

The lua-lpeg build process installs the library as `lpeg.so`. The CMake `find_library()` API defaults to adding `lib` to every name searched. This causes the 'find_library()' api to look for `liblpeg` and `libliblpeg`, but never just `lpeg`. Thus the CMake stage fails to complete.

Solution:

Set the `CMAKE_FIND_LIBRARY_PREFIXES` variable to `;lib` so it will not add a prefix when searching. Only change this setting on MacOS systems.