### PR TITLE
":read :cmd" reads Ex command ":cmd" output

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -2051,14 +2051,20 @@ NOTE: These commands cannot be used with |:global| or |:vglobal|.
 
 							*:r!* *:read!*
 :[range]r[ead] [++opt] !{cmd}
-			Execute {cmd} and insert its standard output below
-			the cursor or the specified line.  A temporary file is
-			used to store the output of the command which is then
-			read into the buffer.  'shellredir' is used to save
-			the output of the command, which can be set to include
-			stderr or not.  {cmd} is executed like with ":!{cmd}",
-			any '!' is replaced with the previous command |:!|.
+			Execute shell {cmd} and insert its standard output
+			below the cursor or the specified line.  A temporary
+			file is used to store the output of the command which
+			is then	read into the buffer.  'shellredir' is used to
+			save the output of the command, which can be set to
+			include stderr or not.  {cmd} is executed like with
+			":!{cmd}", any '!' is replaced with the previous
+			command |:!|.
 			See |++opt| for the possible values of [++opt].
+
+							*:r:* *:read:*
+:[range]r[ead] :{cmd}
+			Execute Ex command {cmd} and insert its output below
+			the cursor or the specified line.
 
 These commands insert the contents of a file, or the output of a command,
 into the buffer.  They can be undone.  They cannot be repeated with the "."

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -182,6 +182,8 @@ EDITOR
    and |:vimgrep| commands.
 • For security, 'exrc' no longer shows an "(a)llow" choice. Instead you must
   "(v)iew" then run `:trust`.
+• |:read:| reads the output of an Ex command into the buffer. Example:>
+    :read :ls
 
 EVENTS
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -12,9 +12,11 @@
 #include <uv.h>
 
 #include "auto/config.h"
+#include "klib/kvec.h"
 #include "nvim/api/private/defs.h"
 #include "nvim/api/private/helpers.h"
 #include "nvim/api/ui.h"
+#include "nvim/api/vim.h"
 #include "nvim/api/vimscript.h"
 #include "nvim/arglist.h"
 #include "nvim/ascii_defs.h"
@@ -5954,12 +5956,43 @@ static void ex_syncbind(exarg_T *eap)
   }
 }
 
+/// Implements ":read :foo ...", i.e. reads the output of a ":foo ..." cmd.
+static void do_read_cmd(exarg_T *eap)
+{
+  Object cmd = CSTR_AS_OBJ(eap->arg + 1);
+  String cmd_var_name = cstr_as_string("_ex_cmd");
+  StringBuilder put_cmd = KV_INITIAL_VALUE;
+  Error error = ERROR_INIT;
+  nvim_set_var(cmd_var_name, cmd, &error);
+  if (error.type != kErrorTypeNone) {
+    emsg(error.msg);
+    return;
+  }
+
+  kv_printf(put_cmd, "%dput=execute(g:%s) | ", eap->line2, cmd_var_name.data);
+  kv_printf(put_cmd, "execute 'norm! )`.' | ");
+  kv_printf(put_cmd, "execute 'd _' | ");
+
+  do_cmdline(put_cmd.items, eap->ea_getline, eap->cookie, eap->flags);
+  kv_destroy(put_cmd);
+  nvim_del_var(cmd_var_name, &error);
+  if (error.type != kErrorTypeNone) {
+    emsg(error.msg);
+    return;
+  }
+}
+
 static void ex_read(exarg_T *eap)
 {
   int empty = (curbuf->b_ml.ml_flags & ML_EMPTY);
 
   if (eap->usefilter) {  // :r!cmd
     do_bang(1, eap, false, false, true);
+    return;
+  }
+
+  if (*eap->arg == ':') {
+    do_read_cmd(eap);
     return;
   }
 

--- a/test/functional/ex_cmds/read_spec.lua
+++ b/test/functional/ex_cmds/read_spec.lua
@@ -1,0 +1,56 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local eq, neq, clear, pcall_err = t.eq, t.neq, n.clear, t.pcall_err
+local fn = n.fn
+local setline, getline, setcharpos, execute = fn.setline, fn.getline, fn.setcharpos, fn.execute
+
+local original_text = { 'First', 'Last' }
+local read_text = { ' This is a line starts with a space', '  This one starts with two spaces.' }
+local inserted_middle = { original_text[1], read_text[1], read_text[2], original_text[2] }
+local inserted_start = { read_text[1], read_text[2], original_text[1], original_text[2] }
+
+local function test_read(cmd, expected)
+  setline(1, original_text)
+  setcharpos('.', { 0, 0, 0 })
+  execute(cmd)
+  for i, e in ipairs(expected) do
+    eq(e, getline(i))
+  end
+end
+
+local function set_up()
+  clear()
+  local make_lines = string.format('let lines="%s"', table.concat(read_text, '\\n'))
+  execute(make_lines)
+end
+
+local function clean_up()
+  execute('unlet lines')
+end
+
+describe(':read :cmd', function()
+  before_each(set_up)
+  after_each(clean_up)
+  it('inserts text from Ex command', function()
+    test_read('read :echo lines', inserted_middle)
+  end)
+  it('inserts text from cmd at specific position', function()
+    test_read('0read :echo lines', inserted_start)
+  end)
+  it('executes next command when using |', function()
+    execute("let guard = 'fail'")
+    test_read("read :echo lines | let guard='pass'", inserted_middle)
+    eq('pass', vim.trim(execute('echo guard')))
+  end)
+  it('command reads can be undone', function()
+    setline(1, original_text)
+    execute('read :echo lines')
+    neq(original_text, { getline(1), getline(2) })
+    execute('undo')
+    eq(original_text, { getline(1), getline(2) })
+  end)
+  it('failure modes', function()
+    eq('Vim:E492: Not an editor command: asdfasdf', pcall_err(execute, ':read :asdfasdf'))
+  end)
+end)


### PR DESCRIPTION
Based on issue #30376, I have made this change so that you can run commands when using the `read` command, and have their output added to the current buffer.

The current implementation uses vim script to basically do a `:put=execute('{cmd}')`, and I am happy to re-implement this in C if that would be better, but I would like to get some feedback on the tests and expected behaviour first. 

close #30376
close #31909