### PR TITLE
vim-patch:9.1.0756: missing change from patch v9.1.0754

### DIFF
--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -764,7 +764,7 @@ void pum_redraw(void)
       // Stop when there is nothing more to display.
       if ((j == 2)
           || (next_isempty && (j == 1 || (j == 0 && pum_get_item(idx, order[j + 2]) == NULL)))
-          || (pum_base_width + n >= pum_width)) {
+          || (basic_width + n >= pum_width)) {
         break;
       }
 

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -5077,6 +5077,17 @@ describe('builtin popupmenu', function()
                   \ { 'word': '你好', 'kind': 'C', 'menu': '中文' },
                   \]}
           endfunc
+
+          func Omni_long(findstart, base)
+            if a:findstart
+              return col(".")
+            endif
+            return {
+                  \ 'words': [
+                  \ { 'word': 'loooong_foo', 'kind': 'S', 'menu': 'menu' },
+                  \ { 'word': 'loooong_bar', 'kind': 'T', 'menu': 'menu' },
+                  \]}
+          endfunc
           set omnifunc=Omni_test
         ]])
         -- T1
@@ -5162,6 +5173,20 @@ describe('builtin popupmenu', function()
           {1:~                             }|*10
           {2:-- }{5:match 1 of 3}               |
         ]])
+        feed('<C-E><ESC>')
+
+        -- Test_pum_completeitemalign_07
+        command('set cia=menu,kind,abbr columns=12 cmdheight=2 omnifunc=Omni_long')
+        feed('S<C-X><C-O>')
+        screen:expect([[
+          loooong_foo^ |
+          {s:menu S loooo}|
+          {n:menu T loooo}|
+          {1:~           }|*10
+                      |
+          {2:--}          |
+        ]])
+        feed('<C-E><ESC>')
       end)
     end
   end

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1597,6 +1597,17 @@ func Test_pum_completeitemalign()
             \ { 'word': '你好', 'kind': 'C', 'menu': '中文' },
             \]}
     endfunc
+
+    func Omni_long(findstart, base)
+      if a:findstart
+        return col(".")
+      endif
+      return {
+            \ 'words': [
+            \ { 'word': 'loooong_foo', 'kind': 'S', 'menu': 'menu' },
+            \ { 'word': 'loooong_bar', 'kind': 'T', 'menu': 'menu' },
+            \]}
+    endfunc
     set omnifunc=Omni_test
     command! -nargs=0 T1 set cia=abbr,kind,menu
     command! -nargs=0 T2 set cia=abbr,menu,kind
@@ -1638,8 +1649,11 @@ func Test_pum_completeitemalign()
   " T6
   call term_sendkeys(buf, ":T6\<CR>S\<C-X>\<C-O>")
   call VerifyScreenDump(buf, 'Test_pum_completeitemalign_06', {})
-  call term_sendkeys(buf, "\<C-E>\<Esc>:T7\<CR>")
+  call term_sendkeys(buf, "\<C-E>\<Esc>")
 
+  call term_sendkeys(buf, ":set columns=12 cmdheight=2 omnifunc=Omni_long\<CR>S\<C-X>\<C-O>")
+  call VerifyScreenDump(buf, 'Test_pum_completeitemalign_07', {})
+  call term_sendkeys(buf, "\<C-E>\<Esc>:T7\<CR>")
   call StopVimInTerminal(buf)
 endfunc
 


### PR DESCRIPTION
Problem:  missing change from patch v9.1.0754
Solution: use correct width for the actual item
          in pum_redraw() (glepnir)

closes: vim/vim#15786

https://github.com/vim/vim/commit/a6d9e3c4e07f73f6523699961d8b7b54bdb80cf6