### PR TITLE
feat(treesitter): add node:ancestors()

### DIFF
--- a/runtime/lua/vim/treesitter/_meta.lua
+++ b/runtime/lua/vim/treesitter/_meta.lua
@@ -20,6 +20,7 @@ error('Cannot require a meta file')
 ---@field descendant_for_range fun(self: TSNode, start_row: integer, start_col: integer, end_row: integer, end_col: integer): TSNode?
 ---@field named_descendant_for_range fun(self: TSNode, start_row: integer, start_col: integer, end_row: integer, end_col: integer): TSNode?
 ---@field parent fun(self: TSNode): TSNode?
+---@field ancestors fun(self: TSNode): TSNode[]
 ---@field child_containing_descendant fun(self: TSNode, descendant: TSNode): TSNode?
 ---@field next_sibling fun(self: TSNode): TSNode?
 ---@field prev_sibling fun(self: TSNode): TSNode?


### PR DESCRIPTION
Not committed to this yet. Just putting here for safe keeping.

The motivation is to have a faster version of:

```lua
--- @param root TSNode
--- @param n TSNode
--- @return TSNode[]
local function node_ancestors(root, n)
  local ret = {} --- @type TSNode[]
  local p = root --- @type TSNode?
  while p do
    ret[#ret + 1] = p
    p = p:child_containing_descendant(n)
  end
  ret[#ret + 1] = n
  return ret
end
```

[The speedup is around 2x](https://github.com/tree-sitter/tree-sitter/discussions/3716)

For use in https://github.com/nvim-treesitter/nvim-treesitter-context