### PR TITLE
fix(lsp): enable `additionalPropertiesSupport`

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -562,7 +562,7 @@ function protocol.make_client_capabilities()
       workDoneProgress = true,
       showMessage = {
         messageActionItem = {
-          additionalPropertiesSupport = false,
+          additionalPropertiesSupport = true,
         },
       },
       showDocument = {


### PR DESCRIPTION
The handler of `window/showMessageRequest`
https://github.com/neovim/neovim/blob/500ab4cfbfd214847e3db5e049e7a708ba7d47b1/runtime/lua/vim/lsp/handlers.lua#L90-L90
Should directly return one of the items from the server, not only the `title`.

According to the code here:
https://github.com/neovim/neovim/blob/500ab4cfbfd214847e3db5e049e7a708ba7d47b1/runtime/lua/vim/lsp/rpc.lua#L419-L424
https://github.com/neovim/neovim/blob/500ab4cfbfd214847e3db5e049e7a708ba7d47b1/runtime/lua/vim/lsp/rpc.lua#L456-L456

The result should be directly returned to the server too.

So I think we already support this capability. See https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#window_showMessageRequest.