### PR TITLE
fix: handle edge case in `screenpos()`

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1080,7 +1080,9 @@ void textpos2screenpos(win_T *wp, pos_T *pos, int *rowp, int *scolp, int *ccolp,
         row += rowoff;
       }
 
-      col -= wp->w_leftcol;
+      if (col > (int)wp->w_leftcol) {
+        col -= wp->w_leftcol;
+      }
 
       if (col >= 0 && col < wp->w_width_inner && row >= 0 && row < wp->w_height_inner) {
         coloff = col - scol + (local ? 0 : wp->w_wincol + wp->w_wincol_off) + 1;


### PR DESCRIPTION
As described in the related issue, `screenpos()` can sometimes get confused and return all zeros, causing anything that relies on it (eg. the nvim-cmp completion menu) to draw in the top-left corner of the screen instead of in the right place.

This commit applies the Neovim fix, equivalent to the suggested fix for Vim, seen here:

- https://github.com/vim/vim/issues/15792#issuecomment-2392387779

`validate_cursor_col()` already has an `if` to handle this edge case:

- https://github.com/neovim/neovim/blob/b45c50f3140e7ece593f2126840900f5cc3d39ea/src/nvim/move.c#L758-L759

so it just needs to be copied into `textpos2screenpos()` as well.

Closes: https://github.com/neovim/neovim/issues/30639