### PR TITLE
docs: generate params, returns in builtin.txt

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -25,6 +25,12 @@ abs({expr})                                                              *abs()*
 			echo abs(-4)
 <			4
 
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`number`)
+
 acos({expr})                                                            *acos()*
 		Return the arc cosine of {expr} measured in radians, as a
 		|Float| in the range of [0, pi].
@@ -38,6 +44,12 @@ acos({expr})                                                            *acos()*
 			echo acos(-0.5)
 <			2.094395
 
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`number`)
+
 add({object}, {expr})                                                    *add()*
 		Append the item {expr} to |List| or |Blob| {object}.  Returns
 		the resulting |List| or |Blob|.  Examples: >vim
@@ -49,6 +61,14 @@ add({object}, {expr})                                                    *add()*
 		Use |insert()| to add an item at another position.
 		Returns 1 if {object} is not a |List| or a |Blob|.
 
+                Parameters: ~
+                  • {object} (`any`)
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`any`) Resulting |List| or |Blob|, or 1 if {object} is not
+                  a |List| or a |Blob|.
+
 and({expr}, {expr})                                                      *and()*
 		Bitwise AND on the two arguments.  The arguments are converted
 		to a number.  A List, Dict or Float argument causes an error.
@@ -57,12 +77,22 @@ and({expr}, {expr})                                                      *and()*
 			let flag = and(bits, 0x80)
 <
 
+                Parameters: ~
+                  • {expr} (`any`)
+                  • {expr1} (`any`)
+
+                Return: ~
+                  (`integer`)
+
 api_info()                                                          *api_info()*
 		Returns Dictionary of |api-metadata|.
 
 		View it in a nice human-readable format: >vim
 		       lua vim.print(vim.fn.api_info())
 <
+
+                Return: ~
+                  (`table`)
 
 append({lnum}, {text})                                                *append()*
 		When {text} is a |List|: Append each item of the |List| as a
@@ -78,6 +108,13 @@ append({lnum}, {text})                                                *append()*
 			let failed = append(line('$'), "# THE END")
 			let failed = append(0, ["Chapter 1", "the beginning"])
 <
+
+                Parameters: ~
+                  • {lnum} (`integer`)
+                  • {text} (`any`)
+
+                Return: ~
+                  (`0|1`)
 
 appendbufline({buf}, {lnum}, {text})                           *appendbufline()*
 		Like |append()| but append the text in buffer {expr}.
@@ -100,6 +137,14 @@ appendbufline({buf}, {lnum}, {text})                           *appendbufline()*
 <		However, when {text} is an empty list then no error is given
 		for an invalid {lnum}, since {lnum} isn't actually used.
 
+                Parameters: ~
+                  • {buf} (`integer|string`)
+                  • {lnum} (`integer`)
+                  • {text} (`string`)
+
+                Return: ~
+                  (`0|1`)
+
 argc([{winid}])                                                         *argc()*
 		The result is the number of files in the argument list.  See
 		|arglist|.
@@ -110,9 +155,18 @@ argc([{winid}])                                                         *argc()*
 		list is used: either the window number or the window ID.
 		Returns -1 if the {winid} argument is invalid.
 
+                Parameters: ~
+                  • {winid} (`integer?`)
+
+                Return: ~
+                  (`integer`)
+
 argidx()                                                              *argidx()*
 		The result is the current index in the argument list.  0 is
 		the first file.  argc() - 1 is the last one.  See |arglist|.
+
+                Return: ~
+                  (`integer`)
 
 arglistid([{winnr} [, {tabnr}]])                                   *arglistid()*
 		Return the argument list ID.  This is a number which
@@ -125,6 +179,13 @@ arglistid([{winnr} [, {tabnr}]])                                   *arglistid()*
 		With {winnr} and {tabnr} use the window in the specified tab
 		page.
 		{winnr} can be the window number or the |window-ID|.
+
+                Parameters: ~
+                  • {winnr} (`integer?`)
+                  • {tabnr} (`integer?`)
+
+                Return: ~
+                  (`integer`)
 
 argv([{nr} [, {winid}]])                                                *argv()*
 		The result is the {nr}th file in the argument list.  See
@@ -145,6 +206,13 @@ argv([{nr} [, {winid}]])                                                *argv()*
 		the argument list.  Returns an empty List if the {winid}
 		argument is invalid.
 
+                Parameters: ~
+                  • {nr} (`integer?`)
+                  • {winid} (`integer?`)
+
+                Return: ~
+                  (`string|string[]`)
+
 asin({expr})                                                            *asin()*
 		Return the arc sine of {expr} measured in radians, as a |Float|
 		in the range of [-pi/2, pi/2].
@@ -158,11 +226,23 @@ asin({expr})                                                            *asin()*
 			echo asin(-0.5)
 <			-0.523599
 
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`number`)
+
 assert_beeps({cmd})                                             *assert_beeps()*
 		Run {cmd} and add an error message to |v:errors| if it does
 		NOT produce a beep or visual bell.
 		Also see |assert_fails()|, |assert_nobeep()| and
 		|assert-return|.
+
+                Parameters: ~
+                  • {cmd} (`string`)
+
+                Return: ~
+                  (`0|1`)
 
 assert_equal({expected}, {actual} [, {msg}])                    *assert_equal()*
 		When {expected} and {actual} are not equal an error message is
@@ -181,12 +261,27 @@ assert_equal({expected}, {actual} [, {msg}])                    *assert_equal()*
 <		Will add the following to |v:errors|:
 			test.vim line 12: baz: Expected 'foo' but got 'bar' ~
 
+                Parameters: ~
+                  • {expected} (`any`)
+                  • {actual} (`any`)
+                  • {msg} (`any?`)
+
+                Return: ~
+                  (`0|1`)
+
 assert_equalfile({fname-one}, {fname-two})                  *assert_equalfile()*
 		When the files {fname-one} and {fname-two} do not contain
 		exactly the same text an error message is added to |v:errors|.
 		Also see |assert-return|.
 		When {fname-one} or {fname-two} does not exist the error will
 		mention that.
+
+                Parameters: ~
+                  • {fname-one} (`string`)
+                  • {fname-two} (`string`)
+
+                Return: ~
+                  (`0|1`)
 
 assert_exception({error} [, {msg}])                         *assert_exception()*
 		When v:exception does not contain the string {error} an error
@@ -201,6 +296,13 @@ assert_exception({error} [, {msg}])                         *assert_exception()*
 			  call assert_exception('E492:')
 			endtry
 <
+
+                Parameters: ~
+                  • {error} (`any`)
+                  • {msg} (`any?`)
+
+                Return: ~
+                  (`0|1`)
 
                                                                 *assert_fails()*
 assert_fails({cmd} [, {error} [, {msg} [, {lnum} [, {context}]]]])
@@ -237,6 +339,16 @@ assert_fails({cmd} [, {error} [, {msg} [, {lnum} [, {context}]]]])
 		Note that beeping is not considered an error, and some failing
 		commands only beep.  Use |assert_beeps()| for those.
 
+                Parameters: ~
+                  • {cmd} (`string`)
+                  • {error} (`any?`)
+                  • {msg} (`any?`)
+                  • {lnum} (`integer?`)
+                  • {context} (`any?`)
+
+                Return: ~
+                  (`0|1`)
+
 assert_false({actual} [, {msg}])                                *assert_false()*
 		When {actual} is not false an error message is added to
 		|v:errors|, like with |assert_equal()|.
@@ -248,6 +360,13 @@ assert_false({actual} [, {msg}])                                *assert_false()*
 		A value is false when it is zero. When {actual} is not a
 		number the assert fails.
 
+                Parameters: ~
+                  • {actual} (`any`)
+                  • {msg} (`any?`)
+
+                Return: ~
+                  (`0|1`)
+
 assert_inrange({lower}, {upper}, {actual} [, {msg}])          *assert_inrange()*
 		This asserts number and |Float| values.  When {actual}  is lower
 		than {lower} or higher than {upper} an error message is added
@@ -255,6 +374,15 @@ assert_inrange({lower}, {upper}, {actual} [, {msg}])          *assert_inrange()*
 		The error is in the form "Expected range {lower} - {upper},
 		but got {actual}".  When {msg} is present it is prefixed to
 		that.
+
+                Parameters: ~
+                  • {lower} (`number`)
+                  • {upper} (`number`)
+                  • {actual} (`number`)
+                  • {msg} (`string?`)
+
+                Return: ~
+                  (`0|1`)
 
 assert_match({pattern}, {actual} [, {msg}])                     *assert_match()*
 		When {pattern} does not match {actual} an error message is
@@ -276,24 +404,60 @@ assert_match({pattern}, {actual} [, {msg}])                     *assert_match()*
 <		Will result in a string to be added to |v:errors|:
 			test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
 
+                Parameters: ~
+                  • {pattern} (`string`)
+                  • {actual} (`string`)
+                  • {msg} (`string?`)
+
+                Return: ~
+                  (`0|1`)
+
 assert_nobeep({cmd})                                           *assert_nobeep()*
 		Run {cmd} and add an error message to |v:errors| if it
 		produces a beep or visual bell.
 		Also see |assert_beeps()|.
+
+                Parameters: ~
+                  • {cmd} (`string`)
+
+                Return: ~
+                  (`0|1`)
 
 assert_notequal({expected}, {actual} [, {msg}])              *assert_notequal()*
 		The opposite of `assert_equal()`: add an error message to
 		|v:errors| when {expected} and {actual} are equal.
 		Also see |assert-return|.
 
+                Parameters: ~
+                  • {expected} (`any`)
+                  • {actual} (`any`)
+                  • {msg} (`any?`)
+
+                Return: ~
+                  (`0|1`)
+
 assert_notmatch({pattern}, {actual} [, {msg}])               *assert_notmatch()*
 		The opposite of `assert_match()`: add an error message to
 		|v:errors| when {pattern} matches {actual}.
 		Also see |assert-return|.
 
+                Parameters: ~
+                  • {pattern} (`string`)
+                  • {actual} (`string`)
+                  • {msg} (`string?`)
+
+                Return: ~
+                  (`0|1`)
+
 assert_report({msg})                                           *assert_report()*
 		Report a test failure directly, using String {msg}.
 		Always returns one.
+
+                Parameters: ~
+                  • {msg} (`string`)
+
+                Return: ~
+                  (`0|1`)
 
 assert_true({actual} [, {msg}])                                  *assert_true()*
 		When {actual} is not true an error message is added to
@@ -303,6 +467,13 @@ assert_true({actual} [, {msg}])                                  *assert_true()*
 		When {actual} is not a number or |v:true| the assert fails.
 		When {msg} is given it is prefixed to the default message,
 		along with the location of the assert when run from a script.
+
+                Parameters: ~
+                  • {actual} (`any`)
+                  • {msg} (`string?`)
+
+                Return: ~
+                  (`0|1`)
 
 atan({expr})                                                            *atan()*
 		Return the principal value of the arc tangent of {expr}, in
@@ -314,6 +485,12 @@ atan({expr})                                                            *atan()*
 <			1.560797 >vim
 			echo atan(-4.01)
 <			-1.326405
+
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`number`)
 
 atan2({expr1}, {expr2})                                                *atan2()*
 		Return the arc tangent of {expr1} / {expr2}, measured in
@@ -327,6 +504,13 @@ atan2({expr1}, {expr2})                                                *atan2()*
 			echo atan2(1, -1)
 <			2.356194
 
+                Parameters: ~
+                  • {expr1} (`number`)
+                  • {expr2} (`number`)
+
+                Return: ~
+                  (`number`)
+
 blob2list({blob})                                                  *blob2list()*
 		Return a List containing the number value of each byte in Blob
 		{blob}.  Examples: >vim
@@ -334,6 +518,12 @@ blob2list({blob})                                                  *blob2list()*
 			blob2list(0z)		" returns []
 <		Returns an empty List on error.  |list2blob()| does the
 		opposite.
+
+                Parameters: ~
+                  • {blob} (`any`)
+
+                Return: ~
+                  (`any[]`)
 
 browse({save}, {title}, {initdir}, {default})                         *browse()*
 		Put up a file requester.  This only works when "has("browse")"
@@ -346,6 +536,15 @@ browse({save}, {title}, {initdir}, {default})                         *browse()*
 		An empty string is returned when the "Cancel" button is hit,
 		something went wrong, or browsing is not possible.
 
+                Parameters: ~
+                  • {save} (`any`)
+                  • {title} (`string`)
+                  • {initdir} (`string`)
+                  • {default} (`string`)
+
+                Return: ~
+                  (`0|1`)
+
 browsedir({title}, {initdir})                                      *browsedir()*
 		Put up a directory requester.  This only works when
 		"has("browse")" returns |TRUE| (only in some GUI versions).
@@ -357,6 +556,13 @@ browsedir({title}, {initdir})                                      *browsedir()*
 		    {initdir}	directory to start browsing in
 		When the "Cancel" button is hit, something went wrong, or
 		browsing is not possible, an empty string is returned.
+
+                Parameters: ~
+                  • {title} (`string`)
+                  • {initdir} (`string`)
+
+                Return: ~
+                  (`0|1`)
 
 bufadd({name})                                                        *bufadd()*
 		Add a buffer to the buffer list with name {name} (must be a
@@ -371,6 +577,12 @@ bufadd({name})                                                        *bufadd()*
 			call bufload(bufnr)
 			call setbufline(bufnr, 1, ['some', 'text'])
 <		Returns 0 on error.
+
+                Parameters: ~
+                  • {name} (`string`)
+
+                Return: ~
+                  (`integer`)
 
 bufexists({buf})                                                   *bufexists()*
 		The result is a Number, which is |TRUE| if a buffer called
@@ -394,10 +606,22 @@ bufexists({buf})                                                   *bufexists()*
 		Use "bufexists(0)" to test for the existence of an alternate
 		file name.
 
+                Parameters: ~
+                  • {buf} (`any`)
+
+                Return: ~
+                  (`0|1`)
+
 buflisted({buf})                                                   *buflisted()*
 		The result is a Number, which is |TRUE| if a buffer called
 		{buf} exists and is listed (has the 'buflisted' option set).
 		The {buf} argument is used like with |bufexists()|.
+
+                Parameters: ~
+                  • {buf} (`any`)
+
+                Return: ~
+                  (`0|1`)
 
 bufload({buf})                                                       *bufload()*
 		Ensure the buffer {buf} is loaded.  When the buffer name
@@ -409,10 +633,19 @@ bufload({buf})                                                       *bufload()*
 		there will be no dialog, the buffer will be loaded anyway.
 		The {buf} argument is used like with |bufexists()|.
 
+                Parameters: ~
+                  • {buf} (`any`)
+
 bufloaded({buf})                                                   *bufloaded()*
 		The result is a Number, which is |TRUE| if a buffer called
 		{buf} exists and is loaded (shown in a window or hidden).
 		The {buf} argument is used like with |bufexists()|.
+
+                Parameters: ~
+                  • {buf} (`any`)
+
+                Return: ~
+                  (`0|1`)
 
 bufname([{buf}])                                                     *bufname()*
 		The result is the name of a buffer.  Mostly as it is displayed
@@ -445,6 +678,12 @@ bufname([{buf}])                                                     *bufname()*
 			echo bufname("file2")	" name of buffer where "file2" matches.
 <
 
+                Parameters: ~
+                  • {buf} (`integer|string?`)
+
+                Return: ~
+                  (`string`)
+
 bufnr([{buf} [, {create}]])                                            *bufnr()*
 		The result is the number of a buffer, as it is displayed by
 		the `:ls` command.  For the use of {buf}, see |bufname()|
@@ -459,6 +698,13 @@ bufnr([{buf} [, {create}]])                                            *bufnr()*
 		number necessarily exist, because ":bwipeout" may have removed
 		them.  Use bufexists() to test for the existence of a buffer.
 
+                Parameters: ~
+                  • {buf} (`integer|string?`)
+                  • {create} (`any?`)
+
+                Return: ~
+                  (`integer`)
+
 bufwinid({buf})                                                     *bufwinid()*
 		The result is a Number, which is the |window-ID| of the first
 		window associated with buffer {buf}.  For the use of {buf},
@@ -469,6 +715,12 @@ bufwinid({buf})                                                     *bufwinid()*
 <
 		Only deals with the current tab page.  See |win_findbuf()| for
 		finding more.
+
+                Parameters: ~
+                  • {buf} (`any`)
+
+                Return: ~
+                  (`integer`)
 
 bufwinnr({buf})                                                     *bufwinnr()*
 		Like |bufwinid()| but return the window number instead of the
@@ -481,6 +733,12 @@ bufwinnr({buf})                                                     *bufwinnr()*
 <		The number can be used with |CTRL-W_w| and ":wincmd w"
 		|:wincmd|.
 
+                Parameters: ~
+                  • {buf} (`any`)
+
+                Return: ~
+                  (`integer`)
+
 byte2line({byte})                                                  *byte2line()*
 		Return the line number that contains the character at byte
 		count {byte} in the current buffer.  This includes the
@@ -490,6 +748,12 @@ byte2line({byte})                                                  *byte2line()*
 		Also see |line2byte()|, |go| and |:goto|.
 
 		Returns -1 if the {byte} value is invalid.
+
+                Parameters: ~
+                  • {byte} (`any`)
+
+                Return: ~
+                  (`integer`)
 
 byteidx({expr}, {nr} [, {utf16}])                                    *byteidx()*
 		Return byte index of the {nr}th character in the String
@@ -527,6 +791,14 @@ byteidx({expr}, {nr} [, {utf16}])                                    *byteidx()*
 			echo byteidx('a😊😊', 3, 1)	" returns 5
 <
 
+                Parameters: ~
+                  • {expr} (`any`)
+                  • {nr} (`integer`)
+                  • {utf16} (`any?`)
+
+                Return: ~
+                  (`integer`)
+
 byteidxcomp({expr}, {nr} [, {utf16}])                            *byteidxcomp()*
 		Like byteidx(), except that a composing character is counted
 		as a separate character.  Example: >vim
@@ -538,6 +810,14 @@ byteidxcomp({expr}, {nr} [, {utf16}])                            *byteidxcomp()*
 		character is 3 bytes), the second echo results in 1 ('e' is
 		one byte).
 
+                Parameters: ~
+                  • {expr} (`any`)
+                  • {nr} (`integer`)
+                  • {utf16} (`any?`)
+
+                Return: ~
+                  (`integer`)
+
 call({func}, {arglist} [, {dict}])                                 *call()* *E699*
 		Call function {func} with the items in |List| {arglist} as
 		arguments.
@@ -546,6 +826,14 @@ call({func}, {arglist} [, {dict}])                                 *call()* *E69
 		Returns the return value of the called function.
 		{dict} is for functions with the "dict" attribute.  It will be
 		used to set the local variable "self". |Dictionary-function|
+
+                Parameters: ~
+                  • {func} (`any`)
+                  • {arglist} (`any`)
+                  • {dict} (`any?`)
+
+                Return: ~
+                  (`any`)
 
 ceil({expr})                                                            *ceil()*
 		Return the smallest integral value greater than or equal to
@@ -561,6 +849,12 @@ ceil({expr})                                                            *ceil()*
 
 		Returns 0.0 if {expr} is not a |Float| or a |Number|.
 
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`number`)
+
 chanclose({id} [, {stream}])                                       *chanclose()*
 		Close a channel or a specific stream associated with it.
 		For a job, {stream} can be one of "stdin", "stdout",
@@ -571,6 +865,13 @@ chanclose({id} [, {stream}])                                       *chanclose()*
 		For a socket, there is only one stream, and {stream} should be
 		omitted.
 
+                Parameters: ~
+                  • {id} (`integer`)
+                  • {stream} (`string?`)
+
+                Return: ~
+                  (`0|1`)
+
 changenr()                                                          *changenr()*
 		Return the number of the most recent change.  This is the same
 		number as what is displayed with |:undolist| and can be used
@@ -579,6 +880,9 @@ changenr()                                                          *changenr()*
 		redo it is the number of the redone change.  After undo it is
 		one less than the number of the undone change.
 		Returns 0 if the undo list is empty.
+
+                Return: ~
+                  (`integer`)
 
 chansend({id}, {data})                                              *chansend()*
 		Send data to channel {id}. For a job, it writes it to the
@@ -598,6 +902,13 @@ chansend({id}, {data})                                              *chansend()*
 		was created with `"rpc":v:true` then the channel expects RPC
 		messages, use |rpcnotify()| and |rpcrequest()| instead.
 
+                Parameters: ~
+                  • {id} (`number`)
+                  • {data} (`string|string[]`)
+
+                Return: ~
+                  (`0|1`)
+
 char2nr({string} [, {utf8}])                                         *char2nr()*
 		Return Number value of the first char in {string}.
 		Examples: >vim
@@ -613,6 +924,13 @@ char2nr({string} [, {utf8}])                                         *char2nr()*
 
 		Returns 0 if {string} is not a |String|.
 
+                Parameters: ~
+                  • {string} (`string`)
+                  • {utf8} (`any?`)
+
+                Return: ~
+                  (`0|1`)
+
 charclass({string})                                                *charclass()*
 		Return the character class of the first character in {string}.
 		The character class is one of:
@@ -624,6 +942,12 @@ charclass({string})                                                *charclass()*
 		The class is used in patterns and word motions.
 		Returns 0 if {string} is not a |String|.
 
+                Parameters: ~
+                  • {string} (`string`)
+
+                Return: ~
+                  (`0|1|2|3|'other'`)
+
 charcol({expr} [, {winid}])                                          *charcol()*
 		Same as |col()| but returns the character index of the column
 		position given with {expr} instead of the byte position.
@@ -632,6 +956,14 @@ charcol({expr} [, {winid}])                                          *charcol()*
 		With the cursor on '세' in line 5 with text "여보세요": >vim
 			echo charcol('.')	" returns 3
 			echo col('.')		" returns 7
+<
+
+                Parameters: ~
+                  • {expr} (`string|integer[]`)
+                  • {winid} (`integer?`)
+
+                Return: ~
+                  (`integer`)
 
 charidx({string}, {idx} [, {countcc} [, {utf16}]])                   *charidx()*
 		Return the character index of the byte at {idx} in {string}.
@@ -667,6 +999,15 @@ charidx({string}, {idx} [, {countcc} [, {utf16}]])                   *charidx()*
 			echo charidx('a😊😊', 4, 0, 1)	" returns 2
 <
 
+                Parameters: ~
+                  • {string} (`string`)
+                  • {idx} (`integer`)
+                  • {countcc} (`boolean?`)
+                  • {utf16} (`boolean?`)
+
+                Return: ~
+                  (`integer`)
+
 chdir({dir})                                                           *chdir()*
 		Change the current working directory to {dir}.  The scope of
 		the directory change depends on the directory of the current
@@ -688,6 +1029,13 @@ chdir({dir})                                                           *chdir()*
 			   " ... do some work
 			   call chdir(save_dir)
 			endif
+<
+
+                Parameters: ~
+                  • {dir} (`string`)
+
+                Return: ~
+                  (`string`)
 
 cindent({lnum})                                                      *cindent()*
 		Get the amount of indent for line {lnum} according the C
@@ -697,11 +1045,20 @@ cindent({lnum})                                                      *cindent()*
 		When {lnum} is invalid -1 is returned.
 		See |C-indenting|.
 
+                Parameters: ~
+                  • {lnum} (`integer`)
+
+                Return: ~
+                  (`integer`)
+
 clearmatches([{win}])                                           *clearmatches()*
 		Clears all matches previously defined for the current window
 		by |matchadd()| and the |:match| commands.
 		If {win} is specified, use the window with this number or
 		window ID instead of the current window.
+
+                Parameters: ~
+                  • {win} (`integer?`)
 
 col({expr} [, {winid}])                                                  *col()*
 		The result is a Number, which is the byte index of the column
@@ -740,6 +1097,14 @@ col({expr} [, {winid}])                                                  *col()*
 		line.  Also, when using a <Cmd> mapping the cursor isn't
 		moved, this can be used to obtain the column in Insert mode: >vim
 			imap <F2> <Cmd>echo col(".").."\n"<CR>
+<
+
+                Parameters: ~
+                  • {expr} (`string|integer[]`)
+                  • {winid} (`integer?`)
+
+                Return: ~
+                  (`integer`)
 
 complete({startcol}, {matches})                                *complete()* *E785*
 		Set the matches for Insert mode completion.
@@ -771,6 +1136,10 @@ complete({startcol}, {matches})                                *complete()* *E78
 <		This isn't very useful, but it shows how it works.  Note that
 		an empty string is returned to avoid a zero being inserted.
 
+                Parameters: ~
+                  • {startcol} (`integer`)
+                  • {matches} (`any[]`)
+
 complete_add({expr})                                            *complete_add()*
 		Add {expr} to the list of matches.  Only to be used by the
 		function specified with the 'completefunc' option.
@@ -780,6 +1149,12 @@ complete_add({expr})                                            *complete_add()*
 		See |complete-functions| for an explanation of {expr}.  It is
 		the same as one item in the list that 'omnifunc' would return.
 
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`0|1|2`)
+
 complete_check()                                              *complete_check()*
 		Check for a key typed while looking for completion matches.
 		This is to be used when looking for matches takes some time.
@@ -787,6 +1162,9 @@ complete_check()                                              *complete_check()*
 		zero otherwise.
 		Only to be used by the function specified with the
 		'completefunc' option.
+
+                Return: ~
+                  (`0|1`)
 
 complete_info([{what}])                                        *complete_info()*
 		Returns a |Dictionary| with information about Insert mode
@@ -847,6 +1225,13 @@ complete_info([{what}])                                        *complete_info()*
 			call complete_info(['mode'])
 			" Get only 'mode' and 'pum_visible'
 			call complete_info(['mode', 'pum_visible'])
+<
+
+                Parameters: ~
+                  • {what} (`any[]?`)
+
+                Return: ~
+                  (`table`)
 
 confirm({msg} [, {choices} [, {default} [, {type}]]])                *confirm()*
 		confirm() offers the user a dialog, from which a choice can be
@@ -900,6 +1285,15 @@ confirm({msg} [, {choices} [, {default} [, {type}]]])                *confirm()*
 		don't fit, a vertical layout is used anyway.  For some systems
 		the horizontal layout is always used.
 
+                Parameters: ~
+                  • {msg} (`string`)
+                  • {choices} (`string?`)
+                  • {default} (`integer?`)
+                  • {type} (`string?`)
+
+                Return: ~
+                  (`integer`)
+
 copy({expr})                                                            *copy()*
 		Make a copy of {expr}.  For Numbers and Strings this isn't
 		different from using {expr} directly.
@@ -909,6 +1303,12 @@ copy({expr})                                                            *copy()*
 		changing an item changes the contents of both |Lists|.
 		A |Dictionary| is copied in a similar way as a |List|.
 		Also see |deepcopy()|.
+
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`any`)
 
 cos({expr})                                                              *cos()*
 		Return the cosine of {expr}, measured in radians, as a |Float|.
@@ -920,6 +1320,12 @@ cos({expr})                                                              *cos()*
 			echo cos(-4.01)
 <			-0.646043
 
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`number`)
+
 cosh({expr})                                                            *cosh()*
 		Return the hyperbolic cosine of {expr} as a |Float| in the range
 		[1, inf].
@@ -930,6 +1336,12 @@ cosh({expr})                                                            *cosh()*
 <			1.127626 >vim
 			echo cosh(-0.5)
 <			-1.127626
+
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`number`)
 
 count({comp}, {expr} [, {ic} [, {start}]])                        *count()* *E706*
 		Return the number of times an item with value {expr} appears
@@ -944,14 +1356,32 @@ count({comp}, {expr} [, {ic} [, {start}]])                        *count()* *E70
 		occurrences of {expr} is returned. Zero is returned when
 		{expr} is an empty string.
 
+                Parameters: ~
+                  • {comp} (`string|table|any[]`)
+                  • {expr} (`any`)
+                  • {ic} (`boolean?`)
+                  • {start} (`integer?`)
+
+                Return: ~
+                  (`integer`)
+
 ctxget([{index}])                                                     *ctxget()*
 		Returns a |Dictionary| representing the |context| at {index}
 		from the top of the |context-stack| (see |context-dict|).
 		If {index} is not given, it is assumed to be 0 (i.e.: top).
 
+                Parameters: ~
+                  • {index} (`integer?`)
+
+                Return: ~
+                  (`table`)
+
 ctxpop()                                                              *ctxpop()*
 		Pops and restores the |context| at the top of the
 		|context-stack|.
+
+                Return: ~
+                  (`any`)
 
 ctxpush([{types}])                                                   *ctxpush()*
 		Pushes the current editor state (|context|) on the
@@ -960,14 +1390,30 @@ ctxpush([{types}])                                                   *ctxpush()*
 		which |context-types| to include in the pushed context.
 		Otherwise, all context types are included.
 
+                Parameters: ~
+                  • {types} (`string[]?`)
+
+                Return: ~
+                  (`any`)
+
 ctxset({context} [, {index}])                                         *ctxset()*
 		Sets the |context| at {index} from the top of the
 		|context-stack| to that represented by {context}.
 		{context} is a Dictionary with context data (|context-dict|).
 		If {index} is not given, it is assumed to be 0 (i.e.: top).
 
+                Parameters: ~
+                  • {context} (`table`)
+                  • {index} (`integer?`)
+
+                Return: ~
+                  (`any`)
+
 ctxsize()                                                            *ctxsize()*
 		Returns the size of the |context-stack|.
+
+                Return: ~
+                  (`any`)
 
 cursor({lnum}, {col} [, {off}])                                       *cursor()*
 cursor({list})
@@ -1002,6 +1448,12 @@ cursor({list})
 		position within a <Tab> or after the last character.
 		Returns 0 when the position could be set, -1 otherwise.
 
+                Parameters: ~
+                  • {list} (`integer[]`)
+
+                Return: ~
+                  (`any`)
+
 debugbreak({pid})                                                 *debugbreak()*
 		Specifically used to interrupt a program being debugged.  It
 		will cause process {pid} to get a SIGTRAP.  Behavior for other
@@ -1010,6 +1462,12 @@ debugbreak({pid})                                                 *debugbreak()*
 
 		Returns |TRUE| if successfully interrupted the program.
 		Otherwise returns |FALSE|.
+
+                Parameters: ~
+                  • {pid} (`integer`)
+
+                Return: ~
+                  (`any`)
 
 deepcopy({expr} [, {noref}])                                   *deepcopy()* *E698*
 		Make a copy of {expr}.  For Numbers and Strings this isn't
@@ -1031,6 +1489,13 @@ deepcopy({expr} [, {noref}])                                   *deepcopy()* *E69
 		{noref} set to 1 will fail.
 		Also see |copy()|.
 
+                Parameters: ~
+                  • {expr} (`any`)
+                  • {noref} (`boolean?`)
+
+                Return: ~
+                  (`any`)
+
 delete({fname} [, {flags}])                                           *delete()*
 		Without {flags} or with {flags} empty: Deletes the file by the
 		name {fname}.
@@ -1050,6 +1515,13 @@ delete({fname} [, {flags}])                                           *delete()*
 		operation was successful and -1/true when the deletion failed
 		or partly failed.
 
+                Parameters: ~
+                  • {fname} (`string`)
+                  • {flags} (`string?`)
+
+                Return: ~
+                  (`integer`)
+
 deletebufline({buf}, {first} [, {last}])                       *deletebufline()*
 		Delete lines {first} to {last} (inclusive) from buffer {buf}.
 		If {last} is omitted then delete line {first} only.
@@ -1063,6 +1535,14 @@ deletebufline({buf}, {first} [, {last}])                       *deletebufline()*
 		{first} and {last} are used like with |getline()|. Note that
 		when using |line()| this refers to the current buffer. Use "$"
 		to refer to the last line in buffer {buf}.
+
+                Parameters: ~
+                  • {buf} (`integer|string`)
+                  • {first} (`integer|string`)
+                  • {last} (`integer|string?`)
+
+                Return: ~
+                  (`any`)
 
 dictwatcheradd({dict}, {pattern}, {callback})                 *dictwatcheradd()*
 		Adds a watcher to a dictionary. A dictionary watcher is
@@ -1104,10 +1584,26 @@ dictwatcheradd({dict}, {pattern}, {callback})                 *dictwatcheradd()*
 		This function can be used by plugins to implement options with
 		validation and parsing logic.
 
+                Parameters: ~
+                  • {dict} (`table`)
+                  • {pattern} (`string`)
+                  • {callback} (`function`)
+
+                Return: ~
+                  (`any`)
+
 dictwatcherdel({dict}, {pattern}, {callback})                 *dictwatcherdel()*
 		Removes a watcher added  with |dictwatcheradd()|. All three
 		arguments must match the ones passed to |dictwatcheradd()| in
 		order for the watcher to be successfully deleted.
+
+                Parameters: ~
+                  • {dict} (`any`)
+                  • {pattern} (`string`)
+                  • {callback} (`function`)
+
+                Return: ~
+                  (`any`)
 
 did_filetype()                                                  *did_filetype()*
 		Returns |TRUE| when autocommands are being executed and the
@@ -1121,6 +1617,9 @@ did_filetype()                                                  *did_filetype()*
 		editing another buffer to set 'filetype' and load a syntax
 		file.
 
+                Return: ~
+                  (`any`)
+
 diff_filler({lnum})                                              *diff_filler()*
 		Returns the number of filler lines above line {lnum}.
 		These are the lines that were inserted at this point in
@@ -1129,6 +1628,12 @@ diff_filler({lnum})                                              *diff_filler()*
 		{lnum} is used like with |getline()|.  Thus "." is the current
 		line, "'m" mark m, etc.
 		Returns 0 if the current window is not in diff mode.
+
+                Parameters: ~
+                  • {lnum} (`integer`)
+
+                Return: ~
+                  (`any`)
 
 diff_hlID({lnum}, {col})                                           *diff_hlID()*
 		Returns the highlight ID for diff mode at line {lnum} column
@@ -1140,6 +1645,13 @@ diff_hlID({lnum}, {col})                                           *diff_hlID()*
 		line.
 		The highlight ID can be used with |synIDattr()| to obtain
 		syntax information about the highlighting.
+
+                Parameters: ~
+                  • {lnum} (`integer`)
+                  • {col} (`integer`)
+
+                Return: ~
+                  (`any`)
 
 digraph_get({chars})                                       *digraph_get()* *E1214*
 		Return the digraph of {chars}.  This should be a string with
@@ -1158,6 +1670,12 @@ digraph_get({chars})                                       *digraph_get()* *E121
 		echo digraph_get('aa')		" Returns 'あ'
 <
 
+                Parameters: ~
+                  • {chars} (`string`)
+
+                Return: ~
+                  (`any`)
+
 digraph_getlist([{listall}])                                 *digraph_getlist()*
 		Return a list of digraphs.  If the {listall} argument is given
 		and it is TRUE, return all digraphs, including the default
@@ -1172,6 +1690,12 @@ digraph_getlist([{listall}])                                 *digraph_getlist()*
 		" Get all the digraphs, including default digraphs
 		echo digraph_getlist(1)
 <
+
+                Parameters: ~
+                  • {listall} (`boolean?`)
+
+                Return: ~
+                  (`any`)
 
 digraph_set({chars}, {digraph})                                  *digraph_set()*
 		Add digraph {chars} to the list.  {chars} must be a string
@@ -1190,9 +1714,13 @@ digraph_set({chars}, {digraph})                                  *digraph_set()*
 		Example: >vim
 			call digraph_set('  ', 'あ')
 <
-		Can be used as a |method|: >vim
-			GetString()->digraph_set('あ')
-<
+
+                Parameters: ~
+                  • {chars} (`string`)
+                  • {digraph} (`string`)
+
+                Return: ~
+                  (`any`)
 
 digraph_setlist({digraphlist})                               *digraph_setlist()*
 		Similar to |digraph_set()| but this function can add multiple
@@ -1209,9 +1737,11 @@ digraph_setlist({digraphlist})                               *digraph_setlist()*
 <		Except that the function returns after the first error,
 		following digraphs will not be added.
 
-		Can be used as a |method|: >vim
-		    GetList()->digraph_setlist()
-<
+                Parameters: ~
+                  • {digraphlist} (`table<integer,string[]>`)
+
+                Return: ~
+                  (`any`)
 
 empty({expr})                                                          *empty()*
 		Return the Number 1 if {expr} is empty, zero otherwise.
@@ -1222,6 +1752,12 @@ empty({expr})                                                          *empty()*
 		- |v:false| and |v:null| are empty, |v:true| is not.
 		- A |Blob| is empty when its length is zero.
 
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`any`)
+
 environ()                                                            *environ()*
 		Return all of environment variables as dictionary. You can
 		check if an environment variable exists like this: >vim
@@ -1231,6 +1767,9 @@ environ()                                                            *environ()*
 			echo index(keys(environ()), 'HOME', 0, 1) != -1
 <
 
+                Return: ~
+                  (`any`)
+
 escape({string}, {chars})                                             *escape()*
 		Escape the characters in {chars} that occur in {string} with a
 		backslash.  Example: >vim
@@ -1239,6 +1778,13 @@ escape({string}, {chars})                                             *escape()*
 			c:\\program\ files\\vim
 <		Also see |shellescape()| and |fnameescape()|.
 
+                Parameters: ~
+                  • {string} (`string`)
+                  • {chars} (`string`)
+
+                Return: ~
+                  (`any`)
+
 eval({string})                                                          *eval()*
 		Evaluate {string} and return the result.  Especially useful to
 		turn the result of |string()| back into the original value.
@@ -1246,11 +1792,20 @@ eval({string})                                                          *eval()*
 		of them.  Also works for |Funcref|s that refer to existing
 		functions.
 
+                Parameters: ~
+                  • {string} (`string`)
+
+                Return: ~
+                  (`any`)
+
 eventhandler()                                                  *eventhandler()*
 		Returns 1 when inside an event handler.  That is that Vim got
 		interrupted while waiting for the user to type a character,
 		e.g., when dropping a file on Vim.  This means interactive
 		commands cannot be used.  Otherwise zero is returned.
+
+                Return: ~
+                  (`any`)
 
 executable({expr})                                                *executable()*
 		This function checks if an executable with the name {expr}
@@ -1281,6 +1836,12 @@ executable({expr})                                                *executable()*
 			0	does not exist
 		|exepath()| can be used to get the full path of an executable.
 
+                Parameters: ~
+                  • {expr} (`string`)
+
+                Return: ~
+                  (`0|1`)
+
 execute({command} [, {silent}])                                      *execute()*
 		Execute {command} and capture its output.
 		If {command} is a |String|, returns {command} output.
@@ -1309,11 +1870,24 @@ execute({command} [, {silent}])                                      *execute()*
 		To execute a command in another window than the current one
 		use `win_execute()`.
 
+                Parameters: ~
+                  • {command} (`string|string[]`)
+                  • {silent} (`''|'silent'|'silent!'?`)
+
+                Return: ~
+                  (`string`)
+
 exepath({expr})                                                      *exepath()*
 		Returns the full path of {expr} if it is an executable and
 		given as a (partial or full) path or is found in $PATH.
 		Returns empty string otherwise.
 		If {expr} starts with "./" the |current-directory| is used.
+
+                Parameters: ~
+                  • {expr} (`string`)
+
+                Return: ~
+                  (`string`)
 
 exists({expr})                                                        *exists()*
 		The result is a Number, which is |TRUE| if {expr} is
@@ -1404,6 +1978,12 @@ exists({expr})                                                        *exists()*
 <		This doesn't check for existence of the "bufcount" variable,
 		but gets the value of "bufcount", and checks if that exists.
 
+                Parameters: ~
+                  • {expr} (`string`)
+
+                Return: ~
+                  (`0|1`)
+
 exp({expr})                                                              *exp()*
 		Return the exponential of {expr} as a |Float| in the range
 		[0, inf].
@@ -1414,6 +1994,12 @@ exp({expr})                                                              *exp()*
 <			7.389056 >vim
 			echo exp(-1)
 <			0.367879
+
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`any`)
 
 expand({string} [, {nosuf} [, {list}]])                               *expand()*
 		Expand wildcards and the following special keywords in
@@ -1506,6 +2092,14 @@ expand({string} [, {nosuf} [, {list}]])                               *expand()*
 		See |glob()| for finding existing files.  See |system()| for
 		getting the raw output of an external command.
 
+                Parameters: ~
+                  • {string} (`string`)
+                  • {nosuf} (`boolean?`)
+                  • {list} (`nil|false?`)
+
+                Return: ~
+                  (`string`)
+
 expandcmd({string} [, {options}])                                  *expandcmd()*
 		Expand special items in String {string} like what is done for
 		an Ex command such as `:edit`.  This expands special keywords,
@@ -1529,6 +2123,13 @@ expandcmd({string} [, {options}])                                  *expandcmd()*
 <		 >vim
 			echo expandcmd('make %<.o', {'errmsg': v:true})
 <
+
+                Parameters: ~
+                  • {string} (`string`)
+                  • {options} (`table?`)
+
+                Return: ~
+                  (`any`)
 
 extend({expr1}, {expr2} [, {expr3}])                                  *extend()*
 		{expr1} and {expr2} must be both |Lists| or both
@@ -1566,10 +2167,26 @@ extend({expr1}, {expr2} [, {expr3}])                                  *extend()*
 		fails.
 		Returns {expr1}.  Returns 0 on error.
 
+                Parameters: ~
+                  • {expr1} (`table`)
+                  • {expr2} (`table`)
+                  • {expr3} (`table?`)
+
+                Return: ~
+                  (`any`)
+
 extendnew({expr1}, {expr2} [, {expr3}])                            *extendnew()*
 		Like |extend()| but instead of adding items to {expr1} a new
 		List or Dictionary is created and returned.  {expr1} remains
 		unchanged.
+
+                Parameters: ~
+                  • {expr1} (`table`)
+                  • {expr2} (`table`)
+                  • {expr3} (`table?`)
+
+                Return: ~
+                  (`any`)
 
 feedkeys({string} [, {mode}])                                       *feedkeys()*
 		Characters in {string} are queued for processing as if they
@@ -1617,6 +2234,13 @@ feedkeys({string} [, {mode}])                                       *feedkeys()*
 
 		Return value is always 0.
 
+                Parameters: ~
+                  • {string} (`string`)
+                  • {mode} (`string?`)
+
+                Return: ~
+                  (`any`)
+
 filecopy({from}, {to})                                              *filecopy()*
 		Copy the file pointed to by the name {from} to {to}. The
 		result is a Number, which is |TRUE| if the file was copied
@@ -1625,6 +2249,13 @@ filecopy({from}, {to})                                              *filecopy()*
 		Note that it does not handle directories (yet).
 
 		This function is not available in the |sandbox|.
+
+                Parameters: ~
+                  • {from} (`string`)
+                  • {to} (`string`)
+
+                Return: ~
+                  (`0|1`)
 
 filereadable({file})                                            *filereadable()*
 		The result is a Number, which is |TRUE| when a file with the
@@ -1643,11 +2274,23 @@ filereadable({file})                                            *filereadable()*
 			1
 <
 
+                Parameters: ~
+                  • {file} (`string`)
+
+                Return: ~
+                  (`0|1`)
+
 filewritable({file})                                            *filewritable()*
 		The result is a Number, which is 1 when a file with the
 		name {file} exists, and can be written.  If {file} doesn't
 		exist, or is not writable, the result is 0.  If {file} is a
 		directory, and we can write to it, the result is 2.
+
+                Parameters: ~
+                  • {file} (`string`)
+
+                Return: ~
+                  (`0|1`)
 
 filter({expr1}, {expr2})                                              *filter()*
 		{expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
@@ -1702,6 +2345,13 @@ filter({expr1}, {expr2})                                              *filter()*
 		When {expr2} is a Funcref errors inside a function are ignored,
 		unless it was defined with the "abort" flag.
 
+                Parameters: ~
+                  • {expr1} (`string|table`)
+                  • {expr2} (`string|function`)
+
+                Return: ~
+                  (`any`)
+
 finddir({name} [, {path} [, {count}]])                               *finddir()*
 		Find directory {name} in {path}.  Supports both downwards and
 		upwards recursive directory searches.  See |file-searching|
@@ -1720,6 +2370,14 @@ finddir({name} [, {path} [, {count}]])                               *finddir()*
 
 		This is quite similar to the ex-command `:find`.
 
+                Parameters: ~
+                  • {name} (`string`)
+                  • {path} (`string?`)
+                  • {count} (`integer?`)
+
+                Return: ~
+                  (`any`)
+
 findfile({name} [, {path} [, {count}]])                             *findfile()*
 		Just like |finddir()|, but find a file instead of a directory.
 		Uses 'suffixesadd'.
@@ -1727,6 +2385,14 @@ findfile({name} [, {path} [, {count}]])                             *findfile()*
 			echo findfile("tags.vim", ".;")
 <		Searches from the directory of the current file upwards until
 		it finds the file "tags.vim".
+
+                Parameters: ~
+                  • {name} (`string`)
+                  • {path} (`string?`)
+                  • {count} (`any?`)
+
+                Return: ~
+                  (`any`)
 
 flatten({list} [, {maxdepth}])                                       *flatten()*
 		Flatten {list} up to {maxdepth} levels.  Without {maxdepth}
@@ -1747,8 +2413,22 @@ flatten({list} [, {maxdepth}])                                       *flatten()*
 			echo flatten([1, [2, [3, 4]], 5], 1)
 <			[1, 2, [3, 4], 5]
 
+                Parameters: ~
+                  • {list} (`any[]`)
+                  • {maxdepth} (`integer?`)
+
+                Return: ~
+                  (`any[]|0`)
+
 flattennew({list} [, {maxdepth}])                                 *flattennew()*
 		Like |flatten()| but first make a copy of {list}.
+
+                Parameters: ~
+                  • {list} (`any[]`)
+                  • {maxdepth} (`integer?`)
+
+                Return: ~
+                  (`any[]|0`)
 
 float2nr({expr})                                                    *float2nr()*
 		Convert {expr} to a Number by omitting the part after the
@@ -1772,6 +2452,12 @@ float2nr({expr})                                                    *float2nr()*
 			echo float2nr(1.0e-100)
 <			0
 
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`any`)
+
 floor({expr})                                                          *floor()*
 		Return the largest integral value less than or equal to
 		{expr} as a |Float| (round down).
@@ -1784,6 +2470,12 @@ floor({expr})                                                          *floor()*
 <			-6.0  >vim
 			echo floor(4.0)
 <			4.0
+
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`any`)
 
 fmod({expr1}, {expr2})                                                  *fmod()*
 		Return the remainder of {expr1} / {expr2}, even if the
@@ -1800,6 +2492,13 @@ fmod({expr1}, {expr2})                                                  *fmod()*
 <			0.13 >vim
 			echo fmod(-12.33, 1.22)
 <			-0.13
+
+                Parameters: ~
+                  • {expr1} (`number`)
+                  • {expr2} (`number`)
+
+                Return: ~
+                  (`any`)
 
 fnameescape({string})                                            *fnameescape()*
 		Escape {string} for use as file name command argument.  All
@@ -1818,6 +2517,12 @@ fnameescape({string})                                            *fnameescape()*
 			edit \+some\ str\%nge\|name
 <
 
+                Parameters: ~
+                  • {string} (`string`)
+
+                Return: ~
+                  (`string`)
+
 fnamemodify({fname}, {mods})                                     *fnamemodify()*
 		Modify file name {fname} according to {mods}.  {mods} is a
 		string of characters like it is used for file names on the
@@ -1835,6 +2540,13 @@ fnamemodify({fname}, {mods})                                     *fnamemodify()*
 		Note: Environment variables don't work in {fname}, use
 		|expand()| first then.
 
+                Parameters: ~
+                  • {fname} (`string`)
+                  • {mods} (`string`)
+
+                Return: ~
+                  (`string`)
+
 foldclosed({lnum})                                                *foldclosed()*
 		The result is a Number.  If the line {lnum} is in a closed
 		fold, the result is the number of the first line in that fold.
@@ -1842,12 +2554,24 @@ foldclosed({lnum})                                                *foldclosed()*
 		{lnum} is used like with |getline()|.  Thus "." is the current
 		line, "'m" mark m, etc.
 
+                Parameters: ~
+                  • {lnum} (`integer`)
+
+                Return: ~
+                  (`integer`)
+
 foldclosedend({lnum})                                          *foldclosedend()*
 		The result is a Number.  If the line {lnum} is in a closed
 		fold, the result is the number of the last line in that fold.
 		If the line {lnum} is not in a closed fold, -1 is returned.
 		{lnum} is used like with |getline()|.  Thus "." is the current
 		line, "'m" mark m, etc.
+
+                Parameters: ~
+                  • {lnum} (`integer`)
+
+                Return: ~
+                  (`integer`)
 
 foldlevel({lnum})                                                  *foldlevel()*
 		The result is a Number, which is the foldlevel of line {lnum}
@@ -1860,6 +2584,12 @@ foldlevel({lnum})                                                  *foldlevel()*
 		previous line is usually available.
 		{lnum} is used like with |getline()|.  Thus "." is the current
 		line, "'m" mark m, etc.
+
+                Parameters: ~
+                  • {lnum} (`integer`)
+
+                Return: ~
+                  (`integer`)
 
 foldtext()                                                          *foldtext()*
 		Returns a String, to be displayed for a closed fold.  This is
@@ -1878,6 +2608,9 @@ foldtext()                                                          *foldtext()*
 		setting.
 		Returns an empty string when there is no fold.
 
+                Return: ~
+                  (`string`)
+
 foldtextresult({lnum})                                        *foldtextresult()*
 		Returns the text that is displayed for the closed fold at line
 		{lnum}.  Evaluates 'foldtext' in the appropriate context.
@@ -1886,6 +2619,12 @@ foldtextresult({lnum})                                        *foldtextresult()*
 		{lnum} is used like with |getline()|.  Thus "." is the current
 		line, "'m" mark m, etc.
 		Useful when exporting folded text, e.g., to HTML.
+
+                Parameters: ~
+                  • {lnum} (`integer`)
+
+                Return: ~
+                  (`string`)
 
 foreach({expr1}, {expr2})                                            *foreach()*
 		{expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
@@ -1922,6 +2661,13 @@ foreach({expr1}, {expr2})                                            *foreach()*
 		When {expr2} is a Funcref errors inside a function are ignored,
 		unless it was defined with the "abort" flag.
 
+                Parameters: ~
+                  • {expr1} (`string|table`)
+                  • {expr2} (`string|function`)
+
+                Return: ~
+                  (`any`)
+
 fullcommand({name})                                              *fullcommand()*
 		Get the full command name from a short abbreviated command
 		name; see |20.2| for details on command abbreviations.
@@ -1934,6 +2680,12 @@ fullcommand({name})                                              *fullcommand()*
 		For example `fullcommand('s')`, `fullcommand('sub')`,
 		`fullcommand(':%substitute')` all return "substitute".
 
+                Parameters: ~
+                  • {name} (`string`)
+
+                Return: ~
+                  (`string`)
+
 funcref({name} [, {arglist}] [, {dict}])                             *funcref()*
 		Just like |function()|, but the returned Funcref will lookup
 		the function by reference, not by name.  This matters when the
@@ -1945,6 +2697,14 @@ funcref({name} [, {arglist}] [, {dict}])                             *funcref()*
 		when only intending to use the function name, use |function()|
 		instead). {name} cannot be a builtin function.
 		Returns 0 on error.
+
+                Parameters: ~
+                  • {name} (`string`)
+                  • {arglist} (`any?`)
+                  • {dict} (`any?`)
+
+                Return: ~
+                  (`any`)
 
 function({name} [, {arglist}] [, {dict}])         *function()* *partial* *E700* *E923*
 		Return a |Funcref| variable that refers to function {name}.
@@ -2028,6 +2788,14 @@ function({name} [, {arglist}] [, {dict}])         *function()* *partial* *E700* 
 <
 		Returns 0 on error.
 
+                Parameters: ~
+                  • {name} (`string`)
+                  • {arglist} (`any?`)
+                  • {dict} (`any?`)
+
+                Return: ~
+                  (`any`)
+
 garbagecollect([{atexit}])                                    *garbagecollect()*
 		Cleanup unused |Lists| and |Dictionaries| that have circular
 		references.
@@ -2048,15 +2816,37 @@ garbagecollect([{atexit}])                                    *garbagecollect()*
 		it's safe to perform.  This is when waiting for the user to
 		type a character.
 
+                Parameters: ~
+                  • {atexit} (`boolean?`)
+
+                Return: ~
+                  (`any`)
+
 get({list}, {idx} [, {default}])                              *get()* *get()-list*
 		Get item {idx} from |List| {list}.  When this item is not
 		available return {default}.  Return zero when {default} is
 		omitted.
 
+                Parameters: ~
+                  • {list} (`any[]`)
+                  • {idx} (`integer`)
+                  • {default} (`any?`)
+
+                Return: ~
+                  (`any`)
+
 get({blob}, {idx} [, {default}])                                    *get()-blob*
 		Get byte {idx} from |Blob| {blob}.  When this byte is not
 		available return {default}.  Return -1 when {default} is
 		omitted.
+
+                Parameters: ~
+                  • {blob} (`string`)
+                  • {idx} (`integer`)
+                  • {default} (`any?`)
+
+                Return: ~
+                  (`any`)
 
 get({dict}, {key} [, {default}])                                    *get()-dict*
 		Get item with key {key} from |Dictionary| {dict}.  When this
@@ -2065,6 +2855,14 @@ get({dict}, {key} [, {default}])                                    *get()-dict*
 			let val = get(g:, 'var_name', 'default')
 <		This gets the value of g:var_name if it exists, and uses
 		"default" when it does not exist.
+
+                Parameters: ~
+                  • {dict} (`table<string,any>`)
+                  • {key} (`string`)
+                  • {default} (`any?`)
+
+                Return: ~
+                  (`any`)
 
 get({func}, {what})                                                 *get()-func*
 		Get item {what} from |Funcref| {func}.  Possible values for
@@ -2087,6 +2885,13 @@ get({func}, {what})                                                 *get()-func*
 				Funcref expects, it's not validated.
 
 		Returns zero on error.
+
+                Parameters: ~
+                  • {func} (`function`)
+                  • {what} (`string`)
+
+                Return: ~
+                  (`any`)
 
 getbufinfo([{buf}])                                               *getbufinfo()*
 getbufinfo([{dict}])
@@ -2157,6 +2962,12 @@ getbufinfo([{dict}])
 			getbufvar({bufnr}, '&option_name')
 <
 
+                Parameters: ~
+                  • {dict} (`vim.fn.getbufinfo.dict?`)
+
+                Return: ~
+                  (`vim.fn.getbufinfo.ret.item[]`)
+
 getbufline({buf}, {lnum} [, {end}])                               *getbufline()*
 		Return a |List| with the lines starting from {lnum} to {end}
 		(inclusive) in the buffer {buf}.  If {end} is omitted, a
@@ -2181,10 +2992,26 @@ getbufline({buf}, {lnum} [, {end}])                               *getbufline()*
 
 		Example: >vim
 			let lines = getbufline(bufnr("myfile"), 1, "$")
+<
+
+                Parameters: ~
+                  • {buf} (`integer|string`)
+                  • {lnum} (`integer`)
+                  • {end_} (`integer?`)
+
+                Return: ~
+                  (`any`)
 
 getbufoneline({buf}, {lnum})                                   *getbufoneline()*
 		Just like `getbufline()` but only get one line and return it
 		as a string.
+
+                Parameters: ~
+                  • {buf} (`integer|string`)
+                  • {lnum} (`integer`)
+
+                Return: ~
+                  (`string`)
 
 getbufvar({buf}, {varname} [, {def}])                              *getbufvar()*
 		The result is the value of option or local buffer variable
@@ -2207,11 +3034,22 @@ getbufvar({buf}, {varname} [, {def}])                              *getbufvar()*
 			let bufmodified = getbufvar(1, "&mod")
 			echo "todo myvar = " .. getbufvar("todo", "myvar")
 
+                Parameters: ~
+                  • {buf} (`integer|string`)
+                  • {varname} (`string`)
+                  • {def} (`any?`)
+
+                Return: ~
+                  (`any`)
+
 getcellwidths()                                                *getcellwidths()*
 		Returns a |List| of cell widths of character ranges overridden
 		by |setcellwidths()|.  The format is equal to the argument of
 		|setcellwidths()|.  If no character ranges have their cell
 		widths overridden, an empty List is returned.
+
+                Return: ~
+                  (`any`)
 
 getchangelist([{buf}])                                         *getchangelist()*
 		Returns the |changelist| for the buffer {buf}. For the use
@@ -2228,6 +3066,12 @@ getchangelist([{buf}])                                         *getchangelist()*
 		If buffer {buf} is the current buffer, then the current
 		position refers to the position in the list. For other
 		buffers, it is set to the length of the list.
+
+                Parameters: ~
+                  • {buf} (`integer|string?`)
+
+                Return: ~
+                  (`table[]`)
 
 getchar([{expr}])                                                    *getchar()*
 		Get a single character from the user or input stream.
@@ -2294,6 +3138,12 @@ getchar([{expr}])                                                    *getchar()*
 			endfunction
 <
 
+                Parameters: ~
+                  • {expr} (`0|1?`)
+
+                Return: ~
+                  (`integer`)
+
 getcharmod()                                                      *getcharmod()*
 		The result is a Number which is the state of the modifiers for
 		the last obtained character with getchar() or in another way.
@@ -2310,6 +3160,9 @@ getcharmod()                                                      *getcharmod()*
 		character itself are obtained.  Thus Shift-a results in "A"
 		without a modifier.  Returns 0 if no modifiers are used.
 
+                Return: ~
+                  (`integer`)
+
 getcharpos({expr})                                                *getcharpos()*
 		Get the position for String {expr}. Same as |getpos()| but the
 		column number in the returned List is a character index
@@ -2323,6 +3176,12 @@ getcharpos({expr})                                                *getcharpos()*
 			getcharpos('.')		returns [0, 5, 3, 0]
 			getpos('.')		returns [0, 5, 7, 0]
 <
+
+                Parameters: ~
+                  • {expr} (`string`)
+
+                Return: ~
+                  (`integer[]`)
 
 getcharsearch()                                                *getcharsearch()*
 		Return the current character search information as a {dict}
@@ -2344,6 +3203,9 @@ getcharsearch()                                                *getcharsearch()*
 			nnoremap <expr> , getcharsearch().forward ? ',' : ';'
 <		Also see |setcharsearch()|.
 
+                Return: ~
+                  (`table`)
+
 getcharstr([{expr}])                                              *getcharstr()*
 		Get a single character from the user or input stream as a
 		string.
@@ -2356,6 +3218,12 @@ getcharstr([{expr}])                                              *getcharstr()*
 		Otherwise this works like |getchar()|, except that a number
 		result is converted to a string.
 
+                Parameters: ~
+                  • {expr} (`0|1?`)
+
+                Return: ~
+                  (`string`)
+
 getcmdcompltype()                                            *getcmdcompltype()*
 		Return the type of the current command-line completion.
 		Only works when the command line is being edited, thus
@@ -2364,6 +3232,9 @@ getcmdcompltype()                                            *getcmdcompltype()*
 		Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()|,
 		|getcmdprompt()| and |setcmdline()|.
 		Returns an empty string when completion is not defined.
+
+                Return: ~
+                  (`string`)
 
 getcmdline()                                                      *getcmdline()*
 		Return the current command-line input.  Only works when the
@@ -2376,6 +3247,9 @@ getcmdline()                                                      *getcmdline()*
 		Returns an empty string when entering a password or using
 		|inputsecret()|.
 
+                Return: ~
+                  (`string`)
+
 getcmdpos()                                                        *getcmdpos()*
 		Return the position of the cursor in the command line as a
 		byte count.  The first column is 1.
@@ -2385,6 +3259,9 @@ getcmdpos()                                                        *getcmdpos()*
 		Also see |getcmdtype()|, |setcmdpos()|, |getcmdline()|,
 		|getcmdprompt()| and |setcmdline()|.
 
+                Return: ~
+                  (`integer`)
+
 getcmdprompt()                                                  *getcmdprompt()*
 		Return the current command-line prompt when using functions
 		like |input()| or |confirm()|.
@@ -2392,6 +3269,9 @@ getcmdprompt()                                                  *getcmdprompt()*
 		requires use of |c_CTRL-\_e| or |c_CTRL-R_=|.
 		Also see |getcmdtype()|, |getcmdline()|, |getcmdpos()|,
 		|setcmdpos()| and |setcmdline()|.
+
+                Return: ~
+                  (`string`)
 
 getcmdscreenpos()                                            *getcmdscreenpos()*
 		Return the screen position of the cursor in the command line
@@ -2402,6 +3282,9 @@ getcmdscreenpos()                                            *getcmdscreenpos()*
 		Returns 0 otherwise.
 		Also see |getcmdpos()|, |setcmdpos()|, |getcmdline()| and
 		|setcmdline()|.
+
+                Return: ~
+                  (`any`)
 
 getcmdtype()                                                      *getcmdtype()*
 		Return the current command-line type. Possible return values
@@ -2418,10 +3301,16 @@ getcmdtype()                                                      *getcmdtype()*
 		Returns an empty string otherwise.
 		Also see |getcmdpos()|, |setcmdpos()| and |getcmdline()|.
 
+                Return: ~
+                  (`':'|'>'|'/'|'?'|'@'|'-'|'='`)
+
 getcmdwintype()                                                *getcmdwintype()*
 		Return the current |command-line-window| type. Possible return
 		values are the same as |getcmdtype()|. Returns an empty string
 		when not in the command-line window.
+
+                Return: ~
+                  (`':'|'>'|'/'|'?'|'@'|'-'|'='`)
 
 getcompletion({pat}, {type} [, {filtered}])                    *getcompletion()*
 		Return a list of command-line completion matches. The String
@@ -2493,6 +3382,14 @@ getcompletion({pat}, {type} [, {filtered}])                    *getcompletion()*
 		If there are no matches, an empty list is returned.  An
 		invalid value for {type} produces an error.
 
+                Parameters: ~
+                  • {pat} (`string`)
+                  • {type} (`string`)
+                  • {filtered} (`boolean?`)
+
+                Return: ~
+                  (`string[]`)
+
 getcurpos([{winid}])                                               *getcurpos()*
 		Get the position of the cursor.  This is like getpos('.'), but
 		includes an extra "curswant" item in the list:
@@ -2518,6 +3415,12 @@ getcurpos([{winid}])                                               *getcurpos()*
 <		Note that this only works within the window.  See
 		|winrestview()| for restoring more state.
 
+                Parameters: ~
+                  • {winid} (`integer?`)
+
+                Return: ~
+                  (`any`)
+
 getcursorcharpos([{winid}])                                 *getcursorcharpos()*
 		Same as |getcurpos()| but the column number in the returned
 		List is a character index instead of a byte index.
@@ -2527,6 +3430,12 @@ getcursorcharpos([{winid}])                                 *getcursorcharpos()*
 			getcursorcharpos()	" returns [0, 3, 2, 0, 3]
 			getcurpos()		" returns [0, 3, 4, 0, 3]
 <
+
+                Parameters: ~
+                  • {winid} (`integer?`)
+
+                Return: ~
+                  (`any`)
 
 getcwd([{winnr} [, {tabnr}]])                                         *getcwd()*
 		With no arguments, returns the name of the effective
@@ -2544,6 +3453,13 @@ getcwd([{winnr} [, {tabnr}]])                                         *getcwd()*
 		directory is returned.
 		Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
 
+                Parameters: ~
+                  • {winnr} (`integer?`)
+                  • {tabnr} (`integer?`)
+
+                Return: ~
+                  (`string`)
+
 getenv({name})                                                        *getenv()*
 		Return the value of environment variable {name}.  The {name}
 		argument is a string, without a leading '$'.  Example: >vim
@@ -2552,6 +3468,12 @@ getenv({name})                                                        *getenv()*
 <		When the variable does not exist |v:null| is returned.  That
 		is different from a variable set to an empty string.
 		See also |expr-env|.
+
+                Parameters: ~
+                  • {name} (`string`)
+
+                Return: ~
+                  (`string`)
 
 getfontname([{name}])                                            *getfontname()*
 		Without an argument returns the name of the normal font being
@@ -2564,6 +3486,12 @@ getfontname([{name}])                                            *getfontname()*
 		Only works when the GUI is running, thus not in your vimrc or
 		gvimrc file.  Use the |GUIEnter| autocommand to use this
 		function just after the GUI has started.
+
+                Parameters: ~
+                  • {name} (`string?`)
+
+                Return: ~
+                  (`string`)
 
 getfperm({fname})                                                   *getfperm()*
 		The result is a String, which is the read, write, and execute
@@ -2582,6 +3510,12 @@ getfperm({fname})                                                   *getfperm()*
 
 		For setting permissions use |setfperm()|.
 
+                Parameters: ~
+                  • {fname} (`string`)
+
+                Return: ~
+                  (`string`)
+
 getfsize({fname})                                                   *getfsize()*
 		The result is a Number, which is the size in bytes of the
 		given file {fname}.
@@ -2590,12 +3524,24 @@ getfsize({fname})                                                   *getfsize()*
 		If the size of {fname} is too big to fit in a Number then -2
 		is returned.
 
+                Parameters: ~
+                  • {fname} (`string`)
+
+                Return: ~
+                  (`integer`)
+
 getftime({fname})                                                   *getftime()*
 		The result is a Number, which is the last modification time of
 		the given file {fname}.  The value is measured as seconds
 		since 1st Jan 1970, and may be passed to strftime().  See also
 		|localtime()| and |strftime()|.
 		If the file {fname} can't be found -1 is returned.
+
+                Parameters: ~
+                  • {fname} (`string`)
+
+                Return: ~
+                  (`integer`)
 
 getftype({fname})                                                   *getftype()*
 		The result is a String, which is a description of the kind of
@@ -2617,6 +3563,12 @@ getftype({fname})                                                   *getftype()*
 		systems that support it.  On some systems only "dir" and
 		"file" are returned.
 
+                Parameters: ~
+                  • {fname} (`string`)
+
+                Return: ~
+                  (`'file'|'dir'|'link'|'bdev'|'cdev'|'socket'|'fifo'|'other'`)
+
 getjumplist([{winnr} [, {tabnr}]])                               *getjumplist()*
 		Returns the |jumplist| for the specified window.
 
@@ -2636,6 +3588,13 @@ getjumplist([{winnr} [, {tabnr}]])                               *getjumplist()*
 			coladd		column offset for 'virtualedit'
 			filename	filename if available
 			lnum		line number
+
+                Parameters: ~
+                  • {winnr} (`integer?`)
+                  • {tabnr} (`integer?`)
+
+                Return: ~
+                  (`vim.fn.getjumplist.ret`)
 
 getline({lnum} [, {end}])                                            *getline()*
 		Without {end} the result is a String, which is line {lnum}
@@ -2661,6 +3620,13 @@ getline({lnum} [, {end}])                                            *getline()*
 
 <		To get lines from another buffer see |getbufline()| and
 		|getbufoneline()|
+
+                Parameters: ~
+                  • {lnum} (`integer|string`)
+                  • {end_} (`nil|false?`)
+
+                Return: ~
+                  (`string`)
 
 getloclist({nr} [, {what}])                                       *getloclist()*
 		Returns a |List| with all the entries in the location list for
@@ -2694,6 +3660,13 @@ getloclist({nr} [, {what}])                                       *getloclist()*
 			echo getloclist(5, {'filewinid': 0})
 <
 
+                Parameters: ~
+                  • {nr} (`integer`)
+                  • {what} (`table?`)
+
+                Return: ~
+                  (`any`)
+
 getmarklist([{buf}])                                             *getmarklist()*
 		Without the {buf} argument returns a |List| with information
 		about all the global marks. |mark|
@@ -2712,6 +3685,12 @@ getmarklist([{buf}])                                             *getmarklist()*
 
 		Refer to |getpos()| for getting information about a specific
 		mark.
+
+                Parameters: ~
+                  • {buf} (`integer??`)
+
+                Return: ~
+                  (`vim.fn.getmarklist.ret.item[]`)
 
 getmatches([{win}])                                               *getmatches()*
 		Returns a |List| with all matches previously defined for the
@@ -2745,6 +3724,12 @@ getmatches([{win}])                                               *getmatches()*
 			unlet m
 <
 
+                Parameters: ~
+                  • {win} (`integer?`)
+
+                Return: ~
+                  (`any`)
+
 getmousepos()                                                    *getmousepos()*
 		Returns a |Dictionary| with the last known position of the
 		mouse.  This can be used in a mapping for a mouse click.  The
@@ -2776,9 +3761,15 @@ getmousepos()                                                    *getmousepos()*
 		When using |getchar()| the Vim variables |v:mouse_lnum|,
 		|v:mouse_col| and |v:mouse_winid| also provide these values.
 
+                Return: ~
+                  (`vim.fn.getmousepos.ret`)
+
 getpid()                                                              *getpid()*
 		Return a Number which is the process ID of the Vim process.
 		This is a unique number, until Vim exits.
+
+                Return: ~
+                  (`integer`)
 
 getpos({expr})                                                        *getpos()*
 		Get the position for String {expr}.
@@ -2838,6 +3829,12 @@ getpos({expr})                                                        *getpos()*
 			call setpos("'a", save_a_mark)
 <
 		Also see |getcharpos()|, |getcurpos()| and |setpos()|.
+
+                Parameters: ~
+                  • {expr} (`string`)
+
+                Return: ~
+                  (`integer[]`)
 
 getqflist([{what}])                                                *getqflist()*
 		Returns a |List| with all the current quickfix errors.  Each
@@ -2943,6 +3940,12 @@ getqflist([{what}])                                                *getqflist()*
 			echo getqflist({'lines' : ["F1:10:L10"]})
 <
 
+                Parameters: ~
+                  • {what} (`table?`)
+
+                Return: ~
+                  (`any`)
+
 getreg([{regname} [, 1 [, {list}]]])                                  *getreg()*
 		The result is a String, which is the contents of register
 		{regname}.  Example: >vim
@@ -2965,6 +3968,13 @@ getreg([{regname} [, 1 [, {list}]]])                                  *getreg()*
 		When the register was not set an empty list is returned.
 
 		If {regname} is not specified, |v:register| is used.
+
+                Parameters: ~
+                  • {regname} (`string?`)
+                  • {list} (`nil|false?`)
+
+                Return: ~
+                  (`string`)
 
 getreginfo([{regname}])                                           *getreginfo()*
 		Returns detailed information about register {regname} as a
@@ -2989,6 +3999,12 @@ getreginfo([{regname}])                                           *getreginfo()*
 		or not set, an empty Dictionary will be returned.
 		If {regname} is not specified, |v:register| is used.
 		The returned Dictionary can be passed to |setreg()|.
+
+                Parameters: ~
+                  • {regname} (`string?`)
+
+                Return: ~
+                  (`table`)
 
 getregion({pos1}, {pos2} [, {opts}])                               *getregion()*
 		Returns the list of strings from {pos1} to {pos2} from a
@@ -3041,6 +4057,14 @@ getregion({pos1}, {pos2} [, {opts}])                               *getregion()*
 			\ getpos('v'), getpos('.'), #{ type: mode() })<CR>
 <
 
+                Parameters: ~
+                  • {pos1} (`table`)
+                  • {pos2} (`table`)
+                  • {opts} (`table?`)
+
+                Return: ~
+                  (`string[]`)
+
 getregionpos({pos1}, {pos2} [, {opts}])                         *getregionpos()*
 		Same as |getregion()|, but returns a list of positions
 		describing the buffer text segments bound by {pos1} and
@@ -3073,6 +4097,14 @@ getregionpos({pos1}, {pos2} [, {opts}])                         *getregionpos()*
 					value of 0 is used for both positions.
 					(default: |FALSE|)
 
+                Parameters: ~
+                  • {pos1} (`table`)
+                  • {pos2} (`table`)
+                  • {opts} (`table?`)
+
+                Return: ~
+                  (`integer[][][]`)
+
 getregtype([{regname}])                                           *getregtype()*
 		The result is a String, which is type of register {regname}.
 		The value will be one of:
@@ -3083,6 +4115,12 @@ getregtype([{regname}])                                           *getregtype()*
 		<CTRL-V> is one character with value 0x16.
 		The {regname} argument is a string.  If {regname} is not
 		specified, |v:register| is used.
+
+                Parameters: ~
+                  • {regname} (`string?`)
+
+                Return: ~
+                  (`string`)
 
 getscriptinfo([{opts}])                                        *getscriptinfo()*
 		Returns a |List| with information about all the sourced Vim
@@ -3121,6 +4159,12 @@ getscriptinfo([{opts}])                                        *getscriptinfo()*
 			echo getscriptinfo({'sid': 15})[0].variables
 <
 
+                Parameters: ~
+                  • {opts} (`table?`)
+
+                Return: ~
+                  (`vim.fn.getscriptinfo.ret[]`)
+
 gettabinfo([{tabnr}])                                             *gettabinfo()*
 		If {tabnr} is not specified, then information about all the
 		tab pages is returned as a |List|. Each List item is a
@@ -3134,6 +4178,12 @@ gettabinfo([{tabnr}])                                             *gettabinfo()*
 					tabpage-local variables
 			windows		List of |window-ID|s in the tab page.
 
+                Parameters: ~
+                  • {tabnr} (`integer?`)
+
+                Return: ~
+                  (`any`)
+
 gettabvar({tabnr}, {varname} [, {def}])                            *gettabvar()*
 		Get the value of a tab-local variable {varname} in tab page
 		{tabnr}. |t:var|
@@ -3143,6 +4193,14 @@ gettabvar({tabnr}, {varname} [, {def}])                            *gettabvar()*
 		Note that the name without "t:" must be used.
 		When the tab or variable doesn't exist {def} or an empty
 		string is returned, there is no error message.
+
+                Parameters: ~
+                  • {tabnr} (`integer`)
+                  • {varname} (`string`)
+                  • {def} (`any?`)
+
+                Return: ~
+                  (`any`)
 
 gettabwinvar({tabnr}, {winnr}, {varname} [, {def}])             *gettabwinvar()*
 		Get the value of window-local variable {varname} in window
@@ -3170,6 +4228,15 @@ gettabwinvar({tabnr}, {winnr}, {varname} [, {def}])             *gettabwinvar()*
 		To obtain all window-local variables use: >vim
 			gettabwinvar({tabnr}, {winnr}, '&')
 <
+
+                Parameters: ~
+                  • {tabnr} (`integer`)
+                  • {winnr} (`integer`)
+                  • {varname} (`string`)
+                  • {def} (`any?`)
+
+                Return: ~
+                  (`any`)
 
 gettagstack([{winnr}])                                           *gettagstack()*
 		The result is a Dict, which is the tag stack of window {winnr}.
@@ -3199,6 +4266,12 @@ gettagstack([{winnr}])                                           *gettagstack()*
 
 		See |tagstack| for more information about the tag stack.
 
+                Parameters: ~
+                  • {winnr} (`integer?`)
+
+                Return: ~
+                  (`any`)
+
 gettext({text})                                                      *gettext()*
 		Translate String {text} if possible.
 		This is mainly for use in the distributed Vim scripts.  When
@@ -3209,6 +4282,12 @@ gettext({text})                                                      *gettext()*
 		For {text} double quoted strings are preferred, because
 		xgettext does not understand escaping in single quoted
 		strings.
+
+                Parameters: ~
+                  • {text} (`string`)
+
+                Return: ~
+                  (`any`)
 
 getwininfo([{winid}])                                             *getwininfo()*
 		Returns information about windows as a |List| with Dictionaries.
@@ -3244,6 +4323,12 @@ getwininfo([{winid}])                                             *getwininfo()*
 			winrow		topmost screen line of the window;
 					"row" from |win_screenpos()|
 
+                Parameters: ~
+                  • {winid} (`integer?`)
+
+                Return: ~
+                  (`vim.fn.getwininfo.ret.item[]`)
+
 getwinpos([{timeout}])                                             *getwinpos()*
 		The result is a |List| with two numbers, the result of
 		|getwinposx()| and |getwinposy()| combined:
@@ -3265,11 +4350,20 @@ getwinpos([{timeout}])                                             *getwinpos()*
 			endwhile
 <
 
+                Parameters: ~
+                  • {timeout} (`integer?`)
+
+                Return: ~
+                  (`any`)
+
 getwinposx()                                                      *getwinposx()*
 		The result is a Number, which is the X coordinate in pixels of
 		the left hand side of the GUI Vim window.  The result will be
 		-1 if the information is not available.
 		The value can be used with `:winpos`.
+
+                Return: ~
+                  (`integer`)
 
 getwinposy()                                                      *getwinposy()*
 		The result is a Number, which is the Y coordinate in pixels of
@@ -3277,11 +4371,22 @@ getwinposy()                                                      *getwinposy()*
 		information is not available.
 		The value can be used with `:winpos`.
 
+                Return: ~
+                  (`integer`)
+
 getwinvar({winnr}, {varname} [, {def}])                            *getwinvar()*
 		Like |gettabwinvar()| for the current tabpage.
 		Examples: >vim
 			let list_is_on = getwinvar(2, '&list')
 			echo "myvar = " .. getwinvar(1, 'myvar')
+
+                Parameters: ~
+                  • {winnr} (`integer`)
+                  • {varname} (`string`)
+                  • {def} (`any?`)
+
+                Return: ~
+                  (`any`)
 
 glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])                      *glob()*
 		Expand the file wildcards in {expr}.  See |wildcards| for the
@@ -3319,6 +4424,15 @@ glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])                      *glob()*
 		See |expand()| for expanding special Vim variables.  See
 		|system()| for getting the raw output of an external command.
 
+                Parameters: ~
+                  • {expr} (`string`)
+                  • {nosuf} (`boolean?`)
+                  • {list} (`boolean?`)
+                  • {alllinks} (`boolean?`)
+
+                Return: ~
+                  (`any`)
+
 glob2regpat({string})                                            *glob2regpat()*
 		Convert a file pattern, as used by glob(), into a search
 		pattern.  The result can be used to match with a string that
@@ -3334,6 +4448,12 @@ glob2regpat({string})                                            *glob2regpat()*
 		empty string.
 		Note that the result depends on the system.  On MS-Windows
 		a backslash usually means a path separator.
+
+                Parameters: ~
+                  • {string} (`string`)
+
+                Return: ~
+                  (`any`)
 
 globpath({path}, {expr} [, {nosuf} [, {list} [, {allinks}]]])       *globpath()*
 		Perform glob() for String {expr} on all directories in {path}
@@ -3369,6 +4489,16 @@ globpath({path}, {expr} [, {nosuf} [, {list} [, {allinks}]]])       *globpath()*
 			echo globpath(&rtp, "**/README.txt")
 <		Upwards search and limiting the depth of "**" is not
 		supported, thus using 'path' will not always work properly.
+
+                Parameters: ~
+                  • {path} (`string`)
+                  • {expr} (`string`)
+                  • {nosuf} (`boolean?`)
+                  • {list} (`boolean?`)
+                  • {allinks} (`boolean?`)
+
+                Return: ~
+                  (`any`)
 
 has({feature})                                                           *has()*
 		Returns 1 if {feature} is supported, 0 otherwise.  The
@@ -3438,10 +4568,23 @@ has({feature})                                                           *has()*
 			endif
 <
 
+                Parameters: ~
+                  • {feature} (`string`)
+
+                Return: ~
+                  (`0|1`)
+
 has_key({dict}, {key})                                               *has_key()*
 		The result is a Number, which is TRUE if |Dictionary| {dict}
 		has an entry with key {key}.  FALSE otherwise. The {key}
 		argument is a string.
+
+                Parameters: ~
+                  • {dict} (`table`)
+                  • {key} (`string`)
+
+                Return: ~
+                  (`0|1`)
 
 haslocaldir([{winnr} [, {tabnr}]])                               *haslocaldir()*
 		The result is a Number, which is 1 when the window has set a
@@ -3459,6 +4602,13 @@ haslocaldir([{winnr} [, {tabnr}]])                               *haslocaldir()*
 		{winnr} can be the window number or the |window-ID|.
 		If {winnr} is -1 it is ignored, only the tab is resolved.
 		Throw error if the arguments are invalid. |E5000| |E5001| |E5002|
+
+                Parameters: ~
+                  • {winnr} (`integer?`)
+                  • {tabnr} (`integer?`)
+
+                Return: ~
+                  (`0|1`)
 
 hasmapto({what} [, {mode} [, {abbr}]])                              *hasmapto()*
 		The result is a Number, which is TRUE if there is a mapping
@@ -3491,6 +4641,14 @@ hasmapto({what} [, {mode} [, {abbr}]])                              *hasmapto()*
 <		This installs the mapping to "\ABCdoit" only if there isn't
 		already a mapping to "\ABCdoit".
 
+                Parameters: ~
+                  • {what} (`any`)
+                  • {mode} (`string?`)
+                  • {abbr} (`boolean?`)
+
+                Return: ~
+                  (`0|1`)
+
 histadd({history}, {item})                                           *histadd()*
 		Add the String {item} to the history {history} which can be
 		one of:					*hist-names*
@@ -3511,6 +4669,13 @@ histadd({history}, {item})                                           *histadd()*
 			call histadd("input", strftime("%Y %b %d"))
 			let date=input("Enter date: ")
 <		This function is not available in the |sandbox|.
+
+                Parameters: ~
+                  • {history} (`string`)
+                  • {item} (`any`)
+
+                Return: ~
+                  (`0|1`)
 
 histdel({history} [, {item}])                                        *histdel()*
 		Clear {history}, i.e. delete all its entries.  See |hist-names|
@@ -3545,6 +4710,13 @@ histdel({history} [, {item}])                                        *histdel()*
 			let @/ = histget("search", -1)
 <
 
+                Parameters: ~
+                  • {history} (`string`)
+                  • {item} (`any?`)
+
+                Return: ~
+                  (`0|1`)
+
 histget({history} [, {index}])                                       *histget()*
 		The result is a String, the entry with Number {index} from
 		{history}.  See |hist-names| for the possible values of
@@ -3561,6 +4733,13 @@ histget({history} [, {index}])                                       *histget()*
 			command -nargs=1 H execute histget("cmd", 0+<args>)
 <
 
+                Parameters: ~
+                  • {history} (`string`)
+                  • {index} (`integer|string?`)
+
+                Return: ~
+                  (`string`)
+
 histnr({history})                                                     *histnr()*
 		The result is the Number of the current entry in {history}.
 		See |hist-names| for the possible values of {history}.
@@ -3568,6 +4747,13 @@ histnr({history})                                                     *histnr()*
 
 		Example: >vim
 			let inp_index = histnr("expr")
+<
+
+                Parameters: ~
+                  • {history} (`string`)
+
+                Return: ~
+                  (`integer`)
 
 hlID({name})                                                            *hlID()*
 		The result is a Number, which is the ID of the highlight group
@@ -3579,6 +4765,12 @@ hlID({name})                                                            *hlID()*
 			echo synIDattr(synIDtrans(hlID("Comment")), "bg")
 <
 
+                Parameters: ~
+                  • {name} (`string`)
+
+                Return: ~
+                  (`integer`)
+
 hlexists({name})                                                    *hlexists()*
 		The result is a Number, which is TRUE if a highlight group
 		called {name} exists.  This is when the group has been
@@ -3586,10 +4778,19 @@ hlexists({name})                                                    *hlexists()*
 		been defined for it, it may also have been used for a syntax
 		item.
 
+                Parameters: ~
+                  • {name} (`string`)
+
+                Return: ~
+                  (`0|1`)
+
 hostname()                                                          *hostname()*
 		The result is a String, which is the name of the machine on
 		which Vim is currently running.  Machine names greater than
 		256 characters long are truncated.
+
+                Return: ~
+                  (`string`)
 
 iconv({string}, {from}, {to})                                          *iconv()*
 		The result is a String, which is the text {string} converted
@@ -3602,6 +4803,14 @@ iconv({string}, {from}, {to})                                          *iconv()*
 		Note that Vim uses UTF-8 for all Unicode encodings, conversion
 		from/to UCS-2 is automatically changed to use UTF-8.  You
 		cannot use UCS-2 in a string anyway, because of the NUL bytes.
+
+                Parameters: ~
+                  • {string} (`string`)
+                  • {from} (`string`)
+                  • {to} (`string`)
+
+                Return: ~
+                  (`any`)
 
 id({expr})                                                                *id()*
 		Returns a |String| which is a unique identifier of the
@@ -3620,12 +4829,24 @@ id({expr})                                                                *id()*
 		will not be equal to some other `id()`: new containers may
 		reuse identifiers of the garbage-collected ones.
 
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`any`)
+
 indent({lnum})                                                        *indent()*
 		The result is a Number, which is indent of line {lnum} in the
 		current buffer.  The indent is counted in spaces, the value
 		of 'tabstop' is relevant.  {lnum} is used just like in
 		|getline()|.
 		When {lnum} is invalid -1 is returned.
+
+                Parameters: ~
+                  • {lnum} (`integer|string`)
+
+                Return: ~
+                  (`integer`)
 
 index({object}, {expr} [, {start} [, {ic}]])                           *index()*
 		Find {expr} in {object} and return its index.  See
@@ -3653,6 +4874,16 @@ index({object}, {expr} [, {start} [, {ic}]])                           *index()*
 			if index(numbers, 123) >= 0
 			  " ...
 			endif
+<
+
+                Parameters: ~
+                  • {object} (`any`)
+                  • {expr} (`any`)
+                  • {start} (`integer?`)
+                  • {ic} (`boolean?`)
+
+                Return: ~
+                  (`any`)
 
 indexof({object}, {expr} [, {opts}])                                 *indexof()*
 		Returns the index of an item in {object} where {expr} is
@@ -3691,8 +4922,25 @@ indexof({object}, {expr} [, {opts}])                                 *indexof()*
 			echo indexof(l, "v:val.n == 20")
 			echo indexof(l, {i, v -> v.n == 30})
 			echo indexof(l, "v:val.n == 20", #{startidx: 1})
+<
+
+                Parameters: ~
+                  • {object} (`any`)
+                  • {expr} (`any`)
+                  • {opts} (`table?`)
+
+                Return: ~
+                  (`any`)
 
 input({prompt} [, {text} [, {completion}]])                            *input()*
+
+                Parameters: ~
+                  • {prompt} (`string`)
+                  • {text} (`string?`)
+                  • {completion} (`string?`)
+
+                Return: ~
+                  (`any`)
 
 input({opts})
 		The result is a String, which is whatever the user typed on
@@ -3803,6 +5051,13 @@ input({opts})
 			  let g:Foo = input("enter search pattern: ")
 			  call inputrestore()
 			endfunction
+<
+
+                Parameters: ~
+                  • {opts} (`table`)
+
+                Return: ~
+                  (`any`)
 
 inputlist({textlist})                                              *inputlist()*
 		{textlist} must be a |List| of strings.  This |List| is
@@ -3821,11 +5076,20 @@ inputlist({textlist})                                              *inputlist()*
 			let color = inputlist(['Select color:', '1. red',
 				\ '2. green', '3. blue'])
 
+                Parameters: ~
+                  • {textlist} (`string[]`)
+
+                Return: ~
+                  (`any`)
+
 inputrestore()                                                  *inputrestore()*
 		Restore typeahead that was saved with a previous |inputsave()|.
 		Should be called the same number of times inputsave() is
 		called.  Calling it more often is harmless though.
 		Returns TRUE when there is nothing to restore, FALSE otherwise.
+
+                Return: ~
+                  (`any`)
 
 inputsave()                                                        *inputsave()*
 		Preserve typeahead (also from mappings) and clear it, so that
@@ -3834,6 +5098,9 @@ inputsave()                                                        *inputsave()*
 		be used several times, in which case there must be just as
 		many inputrestore() calls.
 		Returns TRUE when out of memory, FALSE otherwise.
+
+                Return: ~
+                  (`any`)
 
 inputsecret({prompt} [, {text}])                                 *inputsecret()*
 		This function acts much like the |input()| function with but
@@ -3845,6 +5112,13 @@ inputsecret({prompt} [, {text}])                                 *inputsecret()*
 		The result is a String, which is whatever the user actually
 		typed on the command-line in response to the issued prompt.
 		NOTE: Command-line completion is not supported.
+
+                Parameters: ~
+                  • {prompt} (`string`)
+                  • {text} (`string?`)
+
+                Return: ~
+                  (`any`)
 
 insert({object}, {item} [, {idx}])                                    *insert()*
 		When {object} is a |List| or a |Blob| insert {item} at the start
@@ -3863,6 +5137,14 @@ insert({object}, {item} [, {idx}])                                    *insert()*
 		Note that when {item} is a |List| it is inserted as a single
 		item.  Use |extend()| to concatenate |Lists|.
 
+                Parameters: ~
+                  • {object} (`any`)
+                  • {item} (`any`)
+                  • {idx} (`integer?`)
+
+                Return: ~
+                  (`any`)
+
 interrupt()                                                        *interrupt()*
 		Interrupt script execution.  It works more or less like the
 		user typing CTRL-C, most commands won't execute and control
@@ -3877,11 +5159,20 @@ interrupt()                                                        *interrupt()*
 		au BufWritePre * call s:check_typoname(expand('<amatch>'))
 <
 
+                Return: ~
+                  (`any`)
+
 invert({expr})                                                        *invert()*
 		Bitwise invert.  The argument is converted to a number.  A
 		List, Dict or Float argument causes an error.  Example: >vim
 			let bits = invert(bits)
 <
+
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`any`)
 
 isabsolutepath({path})                                        *isabsolutepath()*
 		The result is a Number, which is |TRUE| when {path} is an
@@ -3898,11 +5189,23 @@ isabsolutepath({path})                                        *isabsolutepath()*
 			echo isabsolutepath('\\remote\file')	" 1
 <
 
+                Parameters: ~
+                  • {path} (`string`)
+
+                Return: ~
+                  (`0|1`)
+
 isdirectory({directory})                                         *isdirectory()*
 		The result is a Number, which is |TRUE| when a directory
 		with the name {directory} exists.  If {directory} doesn't
 		exist, or isn't a directory, the result is |FALSE|.  {directory}
 		is any expression, which is used as a String.
+
+                Parameters: ~
+                  • {directory} (`string`)
+
+                Return: ~
+                  (`0|1`)
 
 isinf({expr})                                                          *isinf()*
 		Return 1 if {expr} is a positive infinity, or -1 a negative
@@ -3911,6 +5214,12 @@ isinf({expr})                                                          *isinf()*
 <			1 >vim
 			echo isinf(-1.0 / 0.0)
 <			-1
+
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`1|0|-1`)
 
 islocked({expr})                                               *islocked()* *E786*
 		The result is a Number, which is |TRUE| when {expr} is the
@@ -3926,10 +5235,22 @@ islocked({expr})                                               *islocked()* *E78
 <		When {expr} is a variable that does not exist you get an error
 		message.  Use |exists()| to check for existence.
 
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`0|1`)
+
 isnan({expr})                                                          *isnan()*
 		Return |TRUE| if {expr} is a float with value NaN. >vim
 			echo isnan(0.0 / 0.0)
 <			1
+
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`0|1`)
 
 items({dict})                                                          *items()*
 		Return a |List| with all the key-value pairs of {dict}.  Each
@@ -3945,13 +5266,33 @@ items({dict})                                                          *items()*
 		cases, items() returns a List with the index and the value at
 		the index.
 
+                Parameters: ~
+                  • {dict} (`any`)
+
+                Return: ~
+                  (`any`)
+
 jobpid({job})                                                         *jobpid()*
 		Return the PID (process id) of |job-id| {job}.
+
+                Parameters: ~
+                  • {job} (`integer`)
+
+                Return: ~
+                  (`integer`)
 
 jobresize({job}, {width}, {height})                                *jobresize()*
 		Resize the pseudo terminal window of |job-id| {job} to {width}
 		columns and {height} rows.
 		Fails if the job was not started with `"pty":v:true`.
+
+                Parameters: ~
+                  • {job} (`integer`)
+                  • {width} (`integer`)
+                  • {height} (`integer`)
+
+                Return: ~
+                  (`any`)
 
 jobstart({cmd} [, {opts}])                                          *jobstart()*
 		Note: Prefer |vim.system()| in Lua (unless using the `pty` option).
@@ -4039,6 +5380,13 @@ jobstart({cmd} [, {opts}])                                          *jobstart()*
 		  - -1 if {cmd}[0] is not executable.
 		See also |job-control|, |channel|, |msgpack-rpc|.
 
+                Parameters: ~
+                  • {cmd} (`string|string[]`)
+                  • {opts} (`table?`)
+
+                Return: ~
+                  (`any`)
+
 jobstop({id})                                                        *jobstop()*
 		Stop |job-id| {id} by sending SIGTERM to the job process. If
 		the process does not terminate after a timeout then SIGKILL
@@ -4048,6 +5396,12 @@ jobstop({id})                                                        *jobstop()*
 
 		Returns 1 for valid job id, 0 for invalid id, including jobs have
 		exited or stopped.
+
+                Parameters: ~
+                  • {id} (`integer`)
+
+                Return: ~
+                  (`any`)
 
 jobwait({jobs} [, {timeout}])                                        *jobwait()*
 		Waits for jobs and their |on_exit| handlers to complete.
@@ -4070,6 +5424,13 @@ jobwait({jobs} [, {timeout}])                                        *jobwait()*
 			-2 if the job was interrupted (by |CTRL-C|)
 			-3 if the job-id is invalid
 
+                Parameters: ~
+                  • {jobs} (`integer[]`)
+                  • {timeout} (`integer?`)
+
+                Return: ~
+                  (`any`)
+
 join({list} [, {sep}])                                                  *join()*
 		Join the items in {list} together into one String.
 		When {sep} is specified it is put in between the items.  If
@@ -4080,6 +5441,13 @@ join({list} [, {sep}])                                                  *join()*
 <		String items are used as-is.  |Lists| and |Dictionaries| are
 		converted into a string like with |string()|.
 		The opposite function is |split()|.
+
+                Parameters: ~
+                  • {list} (`any[]`)
+                  • {sep} (`string?`)
+
+                Return: ~
+                  (`any`)
 
 json_decode({expr})                                              *json_decode()*
 		Convert {expr} from JSON object.  Accepts |readfile()|-style
@@ -4096,6 +5464,12 @@ json_decode({expr})                                              *json_decode()*
 		recommended and the only one required to be supported.
 		Non-UTF-8 characters are an error.
 
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`any`)
+
 json_encode({expr})                                              *json_encode()*
 		Convert {expr} into a JSON string.  Accepts
 		|msgpack-special-dict| as the input.  Will not convert
@@ -4108,9 +5482,21 @@ json_encode({expr})                                              *json_encode()*
 		or special escapes like "\t", other are dumped as-is.
 		|Blob|s are converted to arrays of the individual bytes.
 
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`any`)
+
 keys({dict})                                                            *keys()*
 		Return a |List| with all the keys of {dict}.  The |List| is in
 		arbitrary order.  Also see |items()| and |values()|.
+
+                Parameters: ~
+                  • {dict} (`table`)
+
+                Return: ~
+                  (`any`)
 
 keytrans({string})                                                  *keytrans()*
 		Turn the internal byte representation of keys into a form that
@@ -4118,6 +5504,12 @@ keytrans({string})                                                  *keytrans()*
 			let xx = "\<C-Home>"
 			echo keytrans(xx)
 <			<C-Home>
+
+                Parameters: ~
+                  • {string} (`string`)
+
+                Return: ~
+                  (`any`)
 
 len({expr})                                                         *len()* *E701*
 		The result is a Number, which is the length of the argument.
@@ -4129,6 +5521,12 @@ len({expr})                                                         *len()* *E70
 		When {expr} is a |Dictionary| the number of entries in the
 		|Dictionary| is returned.
 		Otherwise an error is given and returns zero.
+
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`any`)
 
 libcall({libname}, {funcname}, {argument})                 *libcall()* *E364* *E368*
 		Call function {funcname} in the run-time library {libname}
@@ -4172,6 +5570,14 @@ libcall({libname}, {funcname}, {argument})                 *libcall()* *E364* *E
 		Examples: >vim
 			echo libcall("libc.so", "getenv", "HOME")
 
+                Parameters: ~
+                  • {libname} (`string`)
+                  • {funcname} (`string`)
+                  • {argument} (`any`)
+
+                Return: ~
+                  (`any`)
+
 libcallnr({libname}, {funcname}, {argument})                       *libcallnr()*
 		Just like |libcall()|, but used for a function that returns an
 		int instead of a string.
@@ -4180,6 +5586,14 @@ libcallnr({libname}, {funcname}, {argument})                       *libcallnr()*
 			call libcallnr("libc.so", "printf", "Hello World!\n")
 			call libcallnr("libc.so", "sleep", 10)
 <
+
+                Parameters: ~
+                  • {libname} (`string`)
+                  • {funcname} (`string`)
+                  • {argument} (`any`)
+
+                Return: ~
+                  (`any`)
 
 line({expr} [, {winid}])                                                *line()*
 		See |getpos()| for accepted positions.
@@ -4201,6 +5615,13 @@ line({expr} [, {winid}])                                                *line()*
 		To jump to the last known position when opening a file see
 		|last-position-jump|.
 
+                Parameters: ~
+                  • {expr} (`string|integer[]`)
+                  • {winid} (`integer?`)
+
+                Return: ~
+                  (`integer`)
+
 line2byte({lnum})                                                  *line2byte()*
 		Return the byte count from the start of the buffer for line
 		{lnum}.  This includes the end-of-line character, depending on
@@ -4214,12 +5635,24 @@ line2byte({lnum})                                                  *line2byte()*
 		|getline()|.  When {lnum} is invalid -1 is returned.
 		Also see |byte2line()|, |go| and |:goto|.
 
+                Parameters: ~
+                  • {lnum} (`integer`)
+
+                Return: ~
+                  (`integer`)
+
 lispindent({lnum})                                                *lispindent()*
 		Get the amount of indent for line {lnum} according the lisp
 		indenting rules, as with 'lisp'.
 		The indent is counted in spaces, the value of 'tabstop' is
 		relevant.  {lnum} is used just like in |getline()|.
 		When {lnum} is invalid, -1 is returned.
+
+                Parameters: ~
+                  • {lnum} (`integer`)
+
+                Return: ~
+                  (`any`)
 
 list2blob({list})                                                  *list2blob()*
 		Return a Blob concatenating all the number values in {list}.
@@ -4230,6 +5663,12 @@ list2blob({list})                                                  *list2blob()*
 		negative or more than 255 error *E1239* is given.
 
 		|blob2list()| does the opposite.
+
+                Parameters: ~
+                  • {list} (`any[]`)
+
+                Return: ~
+                  (`any`)
 
 list2str({list} [, {utf8}])                                         *list2str()*
 		Convert each number in {list} to a character string can
@@ -4247,9 +5686,19 @@ list2str({list} [, {utf8}])                                         *list2str()*
 <
 		Returns an empty string on error.
 
+                Parameters: ~
+                  • {list} (`any[]`)
+                  • {utf8} (`boolean?`)
+
+                Return: ~
+                  (`any`)
+
 localtime()                                                        *localtime()*
 		Return the current time, measured as seconds since 1st Jan
 		1970.  See also |strftime()|, |strptime()| and |getftime()|.
+
+                Return: ~
+                  (`any`)
 
 log({expr})                                                              *log()*
 		Return the natural logarithm (base e) of {expr} as a |Float|.
@@ -4262,6 +5711,12 @@ log({expr})                                                              *log()*
 			echo log(exp(5))
 <			5.0
 
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`any`)
+
 log10({expr})                                                          *log10()*
 		Return the logarithm of Float {expr} to base 10 as a |Float|.
 		{expr} must evaluate to a |Float| or a |Number|.
@@ -4272,9 +5727,22 @@ log10({expr})                                                          *log10()*
 			echo log10(0.01)
 <			-2.0
 
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`any`)
+
 luaeval({expr} [, {expr}])                                           *luaeval()*
 		Evaluate Lua expression {expr} and return its result converted
 		to Vim data structures. See |lua-eval| for more details.
+
+                Parameters: ~
+                  • {expr} (`string`)
+                  • {expr1} (`any[]?`)
+
+                Return: ~
+                  (`any`)
 
 map({expr1}, {expr2})                                                    *map()*
 		{expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
@@ -4329,6 +5797,13 @@ map({expr1}, {expr2})                                                    *map()*
 		further items in {expr1} are processed.
 		When {expr2} is a Funcref errors inside a function are ignored,
 		unless it was defined with the "abort" flag.
+
+                Parameters: ~
+                  • {expr1} (`string|table|any[]`)
+                  • {expr2} (`string|function`)
+
+                Return: ~
+                  (`any`)
 
 maparg({name} [, {mode} [, {abbr} [, {dict}]]])                       *maparg()*
 		When {dict} is omitted or zero: Return the rhs of mapping
@@ -4402,6 +5877,16 @@ maparg({name} [, {mode} [, {abbr} [, {dict}]]])                       *maparg()*
 		This function can be used to map a key even when it's already
 		mapped, and have it do the original mapping too.  Sketch: >vim
 			exe 'nnoremap <Tab> ==' .. maparg('<Tab>', 'n')
+<
+
+                Parameters: ~
+                  • {name} (`string`)
+                  • {mode} (`string?`)
+                  • {abbr} (`boolean?`)
+                  • {dict} (`false?`)
+
+                Return: ~
+                  (`string`)
 
 mapcheck({name} [, {mode} [, {abbr}]])                              *mapcheck()*
 		Check if there is a mapping that matches with {name} in mode
@@ -4436,6 +5921,14 @@ mapcheck({name} [, {mode} [, {abbr}]])                              *mapcheck()*
 <		This avoids adding the "_vv" mapping when there already is a
 		mapping for "_v" or for "_vvv".
 
+                Parameters: ~
+                  • {name} (`string`)
+                  • {mode} (`string?`)
+                  • {abbr} (`boolean?`)
+
+                Return: ~
+                  (`any`)
+
 maplist([{abbr}])                                                    *maplist()*
 		Returns a |List| of all mappings.  Each List item is a |Dict|,
 		the same as what is returned by |maparg()|, see
@@ -4466,12 +5959,26 @@ maplist([{abbr}])                                                    *maplist()*
 			    \ {_, m -> m.lhs == 'xyzzy'})[0].mode_bits
 			ounmap xyzzy
 			echo printf("Operator-pending mode bit: 0x%x", op_bit)
+<
+
+                Parameters: ~
+                  • {abbr} (`0|1?`)
+
+                Return: ~
+                  (`table[]`)
 
 mapnew({expr1}, {expr2})                                              *mapnew()*
 		Like |map()| but instead of replacing items in {expr1} a new
 		List or Dictionary is created and returned.  {expr1} remains
 		unchanged.  Items can still be changed by {expr2}, if you
 		don't want that use |deepcopy()| first.
+
+                Parameters: ~
+                  • {expr1} (`any`)
+                  • {expr2} (`any`)
+
+                Return: ~
+                  (`any`)
 
 mapset({mode}, {abbr}, {dict})                                        *mapset()*
 mapset({dict})
@@ -4509,6 +6016,13 @@ mapset({dict})
 			for d in save_maps
 			    call mapset(d)
 			endfor
+<
+
+                Parameters: ~
+                  • {dict} (`boolean`)
+
+                Return: ~
+                  (`any`)
 
 match({expr}, {pat} [, {start} [, {count}]])                           *match()*
 		When {expr} is a |List| then this returns the index of the
@@ -4573,6 +6087,15 @@ match({expr}, {pat} [, {start} [, {count}]])                           *match()*
 		zero matches at the start instead of a number of matches
 		further down in the text.
 
+                Parameters: ~
+                  • {expr} (`string|any[]`)
+                  • {pat} (`string`)
+                  • {start} (`integer?`)
+                  • {count} (`integer?`)
+
+                Return: ~
+                  (`any`)
+
                                                 *matchadd()* *E798* *E799* *E801* *E957*
 matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])
 		Defines a pattern to be highlighted in the current window (a
@@ -4632,6 +6155,16 @@ matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])
 		available from |getmatches()|.  All matches can be deleted in
 		one operation by |clearmatches()|.
 
+                Parameters: ~
+                  • {group} (`integer|string`)
+                  • {pattern} (`string`)
+                  • {priority} (`integer?`)
+                  • {id} (`integer?`)
+                  • {dict} (`string?`)
+
+                Return: ~
+                  (`any`)
+
 matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])   *matchaddpos()*
 		Same as |matchadd()|, but requires a list of positions {pos}
 		instead of a pattern. This command is faster than |matchadd()|
@@ -4669,6 +6202,16 @@ matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])   *matchaddpos()*
 <		Matches added by |matchaddpos()| are returned by
 		|getmatches()|.
 
+                Parameters: ~
+                  • {group} (`integer|string`)
+                  • {pos} (`any[]`)
+                  • {priority} (`integer?`)
+                  • {id} (`integer?`)
+                  • {dict} (`string?`)
+
+                Return: ~
+                  (`any`)
+
 matcharg({nr})                                                      *matcharg()*
 		Selects the {nr} match item, as set with a |:match|,
 		|:2match| or |:3match| command.
@@ -4680,6 +6223,12 @@ matcharg({nr})                                                      *matcharg()*
 		This is useful to save and restore a |:match|.
 		Highlighting matches using the |:match| commands are limited
 		to three matches. |matchadd()| does not have this limitation.
+
+                Parameters: ~
+                  • {nr} (`integer`)
+
+                Return: ~
+                  (`any`)
 
 matchbufline({buf}, {pat}, {lnum}, {end}, [, {dict}])           *matchbufline()*
 		Returns the |List| of matches in lines from {lnum} to {end} in
@@ -4725,6 +6274,16 @@ matchbufline({buf}, {pat}, {lnum}, {end}, [, {dict}])           *matchbufline()*
 		is not found, then an empty string is returned for that
 		submatch.
 
+                Parameters: ~
+                  • {buf} (`string|integer`)
+                  • {pat} (`string`)
+                  • {lnum} (`string|integer`)
+                  • {end_} (`string|integer`)
+                  • {dict} (`table?`)
+
+                Return: ~
+                  (`any`)
+
 matchdelete({id} [, {win}])                            *matchdelete()* *E802* *E803*
 		Deletes a match with ID {id} previously defined by |matchadd()|
 		or one of the |:match| commands.  Returns 0 if successful,
@@ -4732,6 +6291,13 @@ matchdelete({id} [, {win}])                            *matchdelete()* *E802* *E
 		be deleted in one operation by |clearmatches()|.
 		If {win} is specified, use the window with this number or
 		window ID instead of the current window.
+
+                Parameters: ~
+                  • {id} (`integer`)
+                  • {win} (`integer?`)
+
+                Return: ~
+                  (`any`)
 
 matchend({expr}, {pat} [, {start} [, {count}]])                     *matchend()*
 		Same as |match()|, but return the index of first character
@@ -4751,6 +6317,15 @@ matchend({expr}, {pat} [, {start} [, {count}]])                     *matchend()*
 			echo matchend("testing", "ing", 5)
 <		result is "-1".
 		When {expr} is a |List| the result is equal to |match()|.
+
+                Parameters: ~
+                  • {expr} (`any`)
+                  • {pat} (`string`)
+                  • {start} (`integer?`)
+                  • {count} (`integer?`)
+
+                Return: ~
+                  (`any`)
 
 matchfuzzy({list}, {str} [, {dict}])                              *matchfuzzy()*
 		If {list} is a list of strings, then returns a |List| with all
@@ -4815,6 +6390,14 @@ matchfuzzy({list}, {str} [, {dict}])                              *matchfuzzy()*
 						\ {'matchseq': 1})
 <		results in `['two one']`.
 
+                Parameters: ~
+                  • {list} (`any[]`)
+                  • {str} (`string`)
+                  • {dict} (`string?`)
+
+                Return: ~
+                  (`any`)
+
 matchfuzzypos({list}, {str} [, {dict}])                        *matchfuzzypos()*
 		Same as |matchfuzzy()|, but returns the list of matched
 		strings, the list of character positions where characters
@@ -4837,6 +6420,14 @@ matchfuzzypos({list}, {str} [, {dict}])                        *matchfuzzypos()*
 				\ ->matchfuzzypos('ll', {'key' : 'text'})
 <		results in `[[{"id": 10, "text": "hello"}], [[2, 3]], [127]]`
 
+                Parameters: ~
+                  • {list} (`any[]`)
+                  • {str} (`string`)
+                  • {dict} (`string?`)
+
+                Return: ~
+                  (`any`)
+
 matchlist({expr}, {pat} [, {start} [, {count}]])                   *matchlist()*
 		Same as |match()|, but return a |List|.  The first item in the
 		list is the matched string, same as what matchstr() would
@@ -4848,6 +6439,15 @@ matchlist({expr}, {pat} [, {start} [, {count}]])                   *matchlist()*
 		When there is no match an empty list is returned.
 
 		You can pass in a List, but that is not very useful.
+
+                Parameters: ~
+                  • {expr} (`any`)
+                  • {pat} (`string`)
+                  • {start} (`integer?`)
+                  • {count} (`integer?`)
+
+                Return: ~
+                  (`any`)
 
 matchstr({expr}, {pat} [, {start} [, {count}]])                     *matchstr()*
 		Same as |match()|, but return the matched string.  Example: >vim
@@ -4861,6 +6461,15 @@ matchstr({expr}, {pat} [, {start} [, {count}]])                     *matchstr()*
 <		result is "".
 		When {expr} is a |List| then the matching item is returned.
 		The type isn't changed, it's not necessarily a String.
+
+                Parameters: ~
+                  • {expr} (`any`)
+                  • {pat} (`string`)
+                  • {start} (`integer?`)
+                  • {count} (`integer?`)
+
+                Return: ~
+                  (`any`)
 
 matchstrlist({list}, {pat} [, {dict}])                          *matchstrlist()*
 		Returns the |List| of matches in {list} where {pat} matches.
@@ -4895,6 +6504,14 @@ matchstrlist({list}, {pat} [, {dict}])                          *matchstrlist()*
 		is not found, then an empty string is returned for that
 		submatch.
 
+                Parameters: ~
+                  • {list} (`string[]`)
+                  • {pat} (`string`)
+                  • {dict} (`table?`)
+
+                Return: ~
+                  (`any`)
+
 matchstrpos({expr}, {pat} [, {start} [, {count}]])               *matchstrpos()*
 		Same as |matchstr()|, but return the matched string, the start
 		position and the end position of the match.  Example: >vim
@@ -4913,6 +6530,15 @@ matchstrpos({expr}, {pat} [, {start} [, {count}]])               *matchstrpos()*
 <		result is ["x", 1, 2, 3].
 		The type isn't changed, it's not necessarily a String.
 
+                Parameters: ~
+                  • {expr} (`any`)
+                  • {pat} (`string`)
+                  • {start} (`integer?`)
+                  • {count} (`integer?`)
+
+                Return: ~
+                  (`any`)
+
 max({expr})                                                              *max()*
 		Return the maximum value of all items in {expr}. Example: >vim
 			echo max([apples, pears, oranges])
@@ -4922,6 +6548,12 @@ max({expr})                                                              *max()*
 		If {expr} is neither a List nor a Dictionary, or one of the
 		items in {expr} cannot be used as a Number this results in
 		an error.  An empty |List| or |Dictionary| results in zero.
+
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`any`)
 
 menu_get({path} [, {modes}])                                        *menu_get()*
 		Returns a |List| of |Dictionaries| describing |menus| (defined
@@ -4968,6 +6600,13 @@ menu_get({path} [, {modes}])                                        *menu_get()*
 			  } ]
 			} ]
 <
+
+                Parameters: ~
+                  • {path} (`string`)
+                  • {modes} (`string?`)
+
+                Return: ~
+                  (`any`)
 
 menu_info({name} [, {mode}])                                       *menu_info()*
 		Return information about the specified menu {name} in
@@ -5040,6 +6679,13 @@ menu_info({name} [, {mode}])                                       *menu_info()*
 			endfor
 <
 
+                Parameters: ~
+                  • {name} (`string`)
+                  • {mode} (`string?`)
+
+                Return: ~
+                  (`any`)
+
 min({expr})                                                              *min()*
 		Return the minimum value of all items in {expr}. Example: >vim
 			echo min([apples, pears, oranges])
@@ -5049,6 +6695,12 @@ min({expr})                                                              *min()*
 		If {expr} is neither a List nor a Dictionary, or one of the
 		items in {expr} cannot be used as a Number this results in
 		an error.  An empty |List| or |Dictionary| results in zero.
+
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`any`)
 
 mkdir({name} [, {flags} [, {prot}]])                              *mkdir()* *E739*
 		Create directory {name}.
@@ -5089,6 +6741,14 @@ mkdir({name} [, {flags} [, {prot}]])                              *mkdir()* *E73
 		The function result is a Number, which is TRUE if the call was
 		successful or FALSE if the directory creation failed or partly
 		failed.
+
+                Parameters: ~
+                  • {name} (`string`)
+                  • {flags} (`string?`)
+                  • {prot} (`string?`)
+
+                Return: ~
+                  (`any`)
 
 mode([{expr}])                                                          *mode()*
 		Return a string that indicates the current mode.
@@ -5144,6 +6804,12 @@ mode([{expr}])                                                          *mode()*
 		the leading character(s).
 		Also see |visualmode()|.
 
+                Parameters: ~
+                  • {expr} (`any?`)
+
+                Return: ~
+                  (`any`)
+
 msgpackdump({list} [, {type}])                                   *msgpackdump()*
 		Convert a list of Vimscript objects to msgpack. Returned value is a
 		|readfile()|-style list. When {type} contains "B", a |Blob| is
@@ -5162,6 +6828,13 @@ msgpackdump({list} [, {type}])                                   *msgpackdump()*
 		3. Dictionary keys are always dumped as STR strings.
 		4. Other strings and |Blob|s are always dumped as BIN strings.
 		5. Points 3. and 4. do not apply to |msgpack-special-dict|s.
+
+                Parameters: ~
+                  • {list} (`any`)
+                  • {type} (`any?`)
+
+                Return: ~
+                  (`any`)
 
 msgpackparse({data})                                            *msgpackparse()*
 		Convert a |readfile()|-style list or a |Blob| to a list of
@@ -5231,6 +6904,12 @@ msgpackparse({data})                                            *msgpackparse()*
 			representing extension type. Second is
 			|readfile()|-style list of strings.
 
+                Parameters: ~
+                  • {data} (`any`)
+
+                Return: ~
+                  (`any`)
+
 nextnonblank({lnum})                                            *nextnonblank()*
 		Return the line number of the first line at or below {lnum}
 		that is not blank.  Example: >vim
@@ -5239,6 +6918,12 @@ nextnonblank({lnum})                                            *nextnonblank()*
 		below it, zero is returned.
 		{lnum} is used like with |getline()|.
 		See also |prevnonblank()|.
+
+                Parameters: ~
+                  • {lnum} (`integer`)
+
+                Return: ~
+                  (`any`)
 
 nr2char({expr} [, {utf8}])                                           *nr2char()*
 		Return a string with a single character, which has the number
@@ -5255,6 +6940,13 @@ nr2char({expr} [, {utf8}])                                           *nr2char()*
 		characters.  nr2char(0) is a real NUL and terminates the
 		string, thus results in an empty string.
 
+                Parameters: ~
+                  • {expr} (`integer`)
+                  • {utf8} (`boolean?`)
+
+                Return: ~
+                  (`any`)
+
 nvim_...({...})                                      *nvim_...()* *E5555* *eval-api*
 		Call nvim |api| functions. The type checking of arguments will
 		be stricter than for most other builtins. For instance,
@@ -5265,6 +6957,12 @@ nvim_...({...})                                      *nvim_...()* *E5555* *eval-
 		expecting an object (buffer, window or tabpage) can
 		also take the numerical value 0 to indicate the current
 		(focused) object.
+
+                Parameters: ~
+                  • {...} (`any`)
+
+                Return: ~
+                  (`any`)
 
 or({expr}, {expr})                                                        *or()*
 		Bitwise OR on the two arguments.  The arguments are converted
@@ -5277,6 +6975,13 @@ or({expr}, {expr})                                                        *or()*
 		character like many languages, is that Vi has always used "|"
 		to separate commands.  In many places it would not be clear if
 		"|" is an operator or a command separator.
+
+                Parameters: ~
+                  • {expr} (`number`)
+                  • {expr1} (`number`)
+
+                Return: ~
+                  (`any`)
 
 pathshorten({path} [, {len}])                                    *pathshorten()*
 		Shorten directory names in the path {path} and return the
@@ -5291,6 +6996,13 @@ pathshorten({path} [, {len}])                                    *pathshorten()*
 <			~/.co/nv/au/file2.vim ~
 		It doesn't matter if the path exists or not.
 		Returns an empty string on error.
+
+                Parameters: ~
+                  • {path} (`string`)
+                  • {len} (`integer?`)
+
+                Return: ~
+                  (`any`)
 
 perleval({expr})                                                    *perleval()*
 		Evaluate |perl| expression {expr} and return its result
@@ -5307,6 +7019,12 @@ perleval({expr})                                                    *perleval()*
 			echo perleval('[1 .. 4]')
 <			[1, 2, 3, 4]
 
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`any`)
+
 pow({x}, {y})                                                            *pow()*
 		Return the power of {x} to the exponent {y} as a |Float|.
 		{x} and {y} must evaluate to a |Float| or a |Number|.
@@ -5319,6 +7037,13 @@ pow({x}, {y})                                                            *pow()*
 			echo pow(32, 0.20)
 <			2.0
 
+                Parameters: ~
+                  • {x} (`number`)
+                  • {y} (`number`)
+
+                Return: ~
+                  (`any`)
+
 prevnonblank({lnum})                                            *prevnonblank()*
 		Return the line number of the first line at or above {lnum}
 		that is not blank.  Example: >vim
@@ -5327,6 +7052,12 @@ prevnonblank({lnum})                                            *prevnonblank()*
 		above it, zero is returned.
 		{lnum} is used like with |getline()|.
 		Also see |nextnonblank()|.
+
+                Parameters: ~
+                  • {lnum} (`integer`)
+
+                Return: ~
+                  (`any`)
 
 printf({fmt}, {expr1} ...)                                            *printf()*
 		Return a String with {fmt}, where "%" items are replaced by
@@ -5651,12 +7382,25 @@ printf({fmt}, {expr1} ...)                                            *printf()*
 		into this, copying the exact format string and parameters that
 		were used.
 
+                Parameters: ~
+                  • {fmt} (`string`)
+                  • {expr1} (`any?`)
+
+                Return: ~
+                  (`string`)
+
 prompt_getprompt({buf})                                     *prompt_getprompt()*
 		Returns the effective prompt text for buffer {buf}.  {buf} can
 		be a buffer name or number.  See |prompt-buffer|.
 
 		If the buffer doesn't exist or isn't a prompt buffer, an empty
 		string is returned.
+
+                Parameters: ~
+                  • {buf} (`integer|string`)
+
+                Return: ~
+                  (`any`)
 
 prompt_setcallback({buf}, {expr})                         *prompt_setcallback()*
 		Set prompt callback for buffer {buf} to {expr}.  When {expr}
@@ -5690,6 +7434,13 @@ prompt_setcallback({buf}, {expr})                         *prompt_setcallback()*
 		   endfunc
 		   call prompt_setcallback(bufnr(), function('s:TextEntered'))
 
+                Parameters: ~
+                  • {buf} (`integer|string`)
+                  • {expr} (`string|function`)
+
+                Return: ~
+                  (`any`)
+
 prompt_setinterrupt({buf}, {expr})                       *prompt_setinterrupt()*
 		Set a callback for buffer {buf} to {expr}.  When {expr} is an
 		empty string the callback is removed.  This has only effect if
@@ -5699,6 +7450,13 @@ prompt_setinterrupt({buf}, {expr})                       *prompt_setinterrupt()*
 		mode.  Without setting a callback Vim will exit Insert mode,
 		as in any buffer.
 
+                Parameters: ~
+                  • {buf} (`integer|string`)
+                  • {expr} (`string|function`)
+
+                Return: ~
+                  (`any`)
+
 prompt_setprompt({buf}, {text})                             *prompt_setprompt()*
 		Set prompt for buffer {buf} to {text}.  You most likely want
 		{text} to end in a space.
@@ -5706,6 +7464,13 @@ prompt_setprompt({buf}, {text})                             *prompt_setprompt()*
 		"prompt".  Example: >vim
 			call prompt_setprompt(bufnr(''), 'command: ')
 <
+
+                Parameters: ~
+                  • {buf} (`integer|string`)
+                  • {text} (`string`)
+
+                Return: ~
+                  (`any`)
 
 pum_getpos()                                                      *pum_getpos()*
 		If the popup menu (see |ins-completion-menu|) is not visible,
@@ -5720,11 +7485,17 @@ pum_getpos()                                                      *pum_getpos()*
 
 		The values are the same as in |v:event| during |CompleteChanged|.
 
+                Return: ~
+                  (`any`)
+
 pumvisible()                                                      *pumvisible()*
 		Returns non-zero when the popup menu is visible, zero
 		otherwise.  See |ins-completion-menu|.
 		This can be used to avoid some things that would remove the
 		popup menu.
+
+                Return: ~
+                  (`any`)
 
 py3eval({expr})                                                      *py3eval()*
 		Evaluate Python expression {expr} and return its result
@@ -5736,6 +7507,12 @@ py3eval({expr})                                                      *py3eval()*
 		Dictionaries are represented as Vim |Dictionary| type with
 		keys converted to strings.
 
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`any`)
+
 pyeval({expr})                                              *pyeval()* *E858* *E859*
 		Evaluate Python expression {expr} and return its result
 		converted to Vim data structures.
@@ -5745,11 +7522,23 @@ pyeval({expr})                                              *pyeval()* *E858* *E
 		Dictionaries are represented as Vim |Dictionary| type,
 		non-string keys result in error.
 
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`any`)
+
 pyxeval({expr})                                                      *pyxeval()*
 		Evaluate Python expression {expr} and return its result
 		converted to Vim data structures.
 		Uses Python 2 or 3, see |python_x| and 'pyxversion'.
 		See also: |pyeval()|, |py3eval()|
+
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`any`)
 
 rand([{expr}])                                                          *rand()*
 		Return a pseudo-random Number generated with an xoshiro128**
@@ -5766,6 +7555,12 @@ rand([{expr}])                                                          *rand()*
 			echo rand(seed)
 			echo rand(seed) % 16  " random number 0 - 15
 <
+
+                Parameters: ~
+                  • {expr} (`number?`)
+
+                Return: ~
+                  (`any`)
 
 range({expr} [, {max} [, {stride}]])                         *range()* *E726* *E727*
 		Returns a |List| with Numbers:
@@ -5785,6 +7580,14 @@ range({expr} [, {max} [, {stride}]])                         *range()* *E726* *E
 			echo range(0)		" []
 			echo range(2, 0)	" error!
 <
+
+                Parameters: ~
+                  • {expr} (`any`)
+                  • {max} (`integer?`)
+                  • {stride} (`integer?`)
+
+                Return: ~
+                  (`any`)
 
 readblob({fname} [, {offset} [, {size}]])                           *readblob()*
 		Read file {fname} in binary mode and return a |Blob|.
@@ -5809,6 +7612,14 @@ readblob({fname} [, {offset} [, {size}]])                           *readblob()*
 		When trying to read more bytes than are available the result
 		is truncated.
 		Also see |readfile()| and |writefile()|.
+
+                Parameters: ~
+                  • {fname} (`string`)
+                  • {offset} (`integer?`)
+                  • {size} (`integer?`)
+
+                Return: ~
+                  (`any`)
 
 readdir({directory} [, {expr}])                                      *readdir()*
 		Return a list with file and directory names in {directory}.
@@ -5839,6 +7650,13 @@ readdir({directory} [, {expr}])                                      *readdir()*
 		  echo s:tree(".")
 <
 		Returns an empty List on error.
+
+                Parameters: ~
+                  • {directory} (`string`)
+                  • {expr} (`integer?`)
+
+                Return: ~
+                  (`any`)
 
 readfile({fname} [, {type} [, {max}]])                              *readfile()*
 		Read file {fname} and return a |List|, each line of the file
@@ -5873,6 +7691,14 @@ readfile({fname} [, {type} [, {max}]])                              *readfile()*
 		the result is an empty list.
 		Also see |writefile()|.
 
+                Parameters: ~
+                  • {fname} (`string`)
+                  • {type} (`string?`)
+                  • {max} (`integer?`)
+
+                Return: ~
+                  (`any`)
+
 reduce({object}, {func} [, {initial}])                           *reduce()* *E998*
 		{func} is called for every item in {object}, which can be a
 		|String|, |List| or a |Blob|.  {func} is called with two
@@ -5891,19 +7717,36 @@ reduce({object}, {func} [, {initial}])                           *reduce()* *E99
 			echo reduce('xyz', { acc, val -> acc .. ',' .. val })
 <
 
+                Parameters: ~
+                  • {object} (`any`)
+                  • {func} (`function`)
+                  • {initial} (`any?`)
+
+                Return: ~
+                  (`any`)
+
 reg_executing()                                                *reg_executing()*
 		Returns the single letter name of the register being executed.
 		Returns an empty string when no register is being executed.
 		See |@|.
+
+                Return: ~
+                  (`any`)
 
 reg_recorded()                                                  *reg_recorded()*
 		Returns the single letter name of the last recorded register.
 		Returns an empty string when nothing was recorded yet.
 		See |q| and |Q|.
 
+                Return: ~
+                  (`any`)
+
 reg_recording()                                                *reg_recording()*
 		Returns the single letter name of the register being recorded.
 		Returns an empty string when not recording.  See |q|.
+
+                Return: ~
+                  (`any`)
 
 reltime()                                                            *reltime()*
 reltime({start})
@@ -5927,6 +7770,13 @@ reltime({start}, {end})
 
 		Note: |localtime()| returns the current (non-relative) time.
 
+                Parameters: ~
+                  • {start} (`any?`)
+                  • {end_} (`any?`)
+
+                Return: ~
+                  (`any`)
+
 reltimefloat({time})                                            *reltimefloat()*
 		Return a Float that represents the time value of {time}.
 		Unit of time is seconds.
@@ -5937,6 +7787,12 @@ reltimefloat({time})                                            *reltimefloat()*
 		See the note of reltimestr() about overhead.
 		Also see |profiling|.
 		If there is an error an empty string is returned
+
+                Parameters: ~
+                  • {time} (`any`)
+
+                Return: ~
+                  (`any`)
 
 reltimestr({time})                                                *reltimestr()*
 		Return a String that represents the time value of {time}.
@@ -5951,6 +7807,12 @@ reltimestr({time})                                                *reltimestr()*
 			echo split(reltimestr(reltime(start)))[0]
 <		Also see |profiling|.
 		If there is an error an empty string is returned
+
+                Parameters: ~
+                  • {time} (`any`)
+
+                Return: ~
+                  (`any`)
 
 remove({list}, {idx})                                                 *remove()*
 remove({list}, {idx}, {end})
@@ -5968,6 +7830,14 @@ remove({list}, {idx}, {end})
 <
 		Use |delete()| to remove a file.
 
+                Parameters: ~
+                  • {list} (`any[]`)
+                  • {idx} (`integer`)
+                  • {end_} (`integer?`)
+
+                Return: ~
+                  (`any`)
+
 remove({blob}, {idx})
 remove({blob}, {idx}, {end})
 		Without {end}: Remove the byte at {idx} from |Blob| {blob} and
@@ -5982,12 +7852,27 @@ remove({blob}, {idx}, {end})
 			call remove(mylist, 0, 9)
 <
 
+                Parameters: ~
+                  • {blob} (`any`)
+                  • {idx} (`integer`)
+                  • {end_} (`integer?`)
+
+                Return: ~
+                  (`any`)
+
 remove({dict}, {key})
 		Remove the entry from {dict} with key {key} and return it.
 		Example: >vim
 			echo "removed " .. remove(dict, "one")
 <		If there is no {key} in {dict} this is an error.
 		Returns zero on error.
+
+                Parameters: ~
+                  • {dict} (`any`)
+                  • {key} (`string`)
+
+                Return: ~
+                  (`any`)
 
 rename({from}, {to})                                                  *rename()*
 		Rename the file by the name {from} to the name {to}.  This
@@ -5996,6 +7881,13 @@ rename({from}, {to})                                                  *rename()*
 		successfully, and non-zero when the renaming failed.
 		NOTE: If {to} exists it is overwritten without warning.
 		This function is not available in the |sandbox|.
+
+                Parameters: ~
+                  • {from} (`string`)
+                  • {to} (`string`)
+
+                Return: ~
+                  (`any`)
 
 repeat({expr}, {count})                                               *repeat()*
 		Repeat {expr} {count} times and return the concatenated
@@ -6006,6 +7898,13 @@ repeat({expr}, {count})                                               *repeat()*
 		concatenated {count} times.  Example: >vim
 			let longlist = repeat(['a', 'b'], 3)
 <		Results in ['a', 'b', 'a', 'b', 'a', 'b'].
+
+                Parameters: ~
+                  • {expr} (`any`)
+                  • {count} (`integer`)
+
+                Return: ~
+                  (`any`)
 
 resolve({filename})                                             *resolve()* *E655*
 		On MS-Windows, when {filename} is a shortcut (a .lnk file),
@@ -6020,6 +7919,12 @@ resolve({filename})                                             *resolve()* *E65
 		current directory (provided the result is still a relative
 		path name) and also keeps a trailing path separator.
 
+                Parameters: ~
+                  • {filename} (`string`)
+
+                Return: ~
+                  (`any`)
+
 reverse({object})                                                    *reverse()*
 		Reverse the order of items in {object}.  {object} can be a
 		|List|, a |Blob| or a |String|.  For a List and a Blob the
@@ -6030,6 +7935,12 @@ reverse({object})                                                    *reverse()*
 		first: >vim
 			let revlist = reverse(copy(mylist))
 <
+
+                Parameters: ~
+                  • {object} (`any`)
+
+                Return: ~
+                  (`any`)
 
 round({expr})                                                          *round()*
 		Round off {expr} to the nearest integral value and return it
@@ -6045,12 +7956,26 @@ round({expr})                                                          *round()*
 			echo round(-4.5)
 <			-5.0
 
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`any`)
+
 rpcnotify({channel}, {event} [, {args}...])                        *rpcnotify()*
 		Sends {event} to {channel} via |RPC| and returns immediately.
 		If {channel} is 0, the event is broadcast to all channels.
 		Example: >vim
 			au VimLeave call rpcnotify(0, "leaving")
 <
+
+                Parameters: ~
+                  • {channel} (`integer`)
+                  • {event} (`string`)
+                  • {args} (`any?`)
+
+                Return: ~
+                  (`any`)
 
 rpcrequest({channel}, {method} [, {args}...])                     *rpcrequest()*
 		Sends a request to {channel} to invoke {method} via
@@ -6059,12 +7984,13 @@ rpcrequest({channel}, {method} [, {args}...])                     *rpcrequest()*
 			let result = rpcrequest(rpc_chan, "func", 1, 2, 3)
 <
 
-rpcstart({prog} [, {argv}])                                         *rpcstart()*
-		Deprecated. Replace  >vim
-			let id = rpcstart('prog', ['arg1', 'arg2'])
-<		with >vim
-			let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
-<
+                Parameters: ~
+                  • {channel} (`integer`)
+                  • {method} (`string`)
+                  • {args} (`any?`)
+
+                Return: ~
+                  (`any`)
 
 rubyeval({expr})                                                    *rubyeval()*
 		Evaluate Ruby expression {expr} and return its result
@@ -6076,11 +8002,24 @@ rubyeval({expr})                                                    *rubyeval()*
 		Other objects are represented as strings resulted from their
 		"Object#to_s" method.
 
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`any`)
+
 screenattr({row}, {col})                                          *screenattr()*
 		Like |screenchar()|, but return the attribute.  This is a rather
 		arbitrary number that can only be used to compare to the
 		attribute at other positions.
 		Returns -1 when row or col is out of range.
+
+                Parameters: ~
+                  • {row} (`integer`)
+                  • {col} (`integer`)
+
+                Return: ~
+                  (`any`)
 
 screenchar({row}, {col})                                          *screenchar()*
 		The result is a Number, which is the character at position
@@ -6092,12 +8031,26 @@ screenchar({row}, {col})                                          *screenchar()*
 		This is mainly to be used for testing.
 		Returns -1 when row or col is out of range.
 
+                Parameters: ~
+                  • {row} (`integer`)
+                  • {col} (`integer`)
+
+                Return: ~
+                  (`any`)
+
 screenchars({row}, {col})                                        *screenchars()*
 		The result is a |List| of Numbers.  The first number is the same
 		as what |screenchar()| returns.  Further numbers are
 		composing characters on top of the base character.
 		This is mainly to be used for testing.
 		Returns an empty List when row or col is out of range.
+
+                Parameters: ~
+                  • {row} (`integer`)
+                  • {col} (`integer`)
+
+                Return: ~
+                  (`any`)
 
 screencol()                                                        *screencol()*
 		The result is a Number, which is the current screen column of
@@ -6113,6 +8066,9 @@ screencol()                                                        *screencol()*
 			nnoremap <silent> GG :echom screencol()<CR>
 			noremap GG <Cmd>echom screencol()<CR>
 <
+
+                Return: ~
+                  (`any`)
 
 screenpos({winid}, {lnum}, {col})                                  *screenpos()*
 		The result is a Dict with the screen position of the text
@@ -6138,6 +8094,14 @@ screenpos({winid}, {lnum}, {col})                                  *screenpos()*
 		first character is returned, {col} is not used.
 		Returns an empty Dict if {winid} is invalid.
 
+                Parameters: ~
+                  • {winid} (`integer`)
+                  • {lnum} (`integer`)
+                  • {col} (`integer`)
+
+                Return: ~
+                  (`any`)
+
 screenrow()                                                        *screenrow()*
 		The result is a Number, which is the current screen row of the
 		cursor.  The top line has number one.
@@ -6146,6 +8110,9 @@ screenrow()                                                        *screenrow()*
 
 		Note: Same restrictions as with |screencol()|.
 
+                Return: ~
+                  (`any`)
+
 screenstring({row}, {col})                                      *screenstring()*
 		The result is a String that contains the base character and
 		any composing characters at position [row, col] on the screen.
@@ -6153,6 +8120,13 @@ screenstring({row}, {col})                                      *screenstring()*
 		characters.
 		This is mainly to be used for testing.
 		Returns an empty String when row or col is out of range.
+
+                Parameters: ~
+                  • {row} (`integer`)
+                  • {col} (`integer`)
+
+                Return: ~
+                  (`any`)
 
 search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]]) *search()*
 		Search for regexp pattern {pattern}.  The search starts at the
@@ -6258,6 +8232,16 @@ search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]]) *search()*
 		finds the "endif" and returns 3.  The same thing happens
 		without the 'e' flag if the cursor is on the "f" of "if".
 		The 'n' flag tells the function not to move the cursor.
+
+                Parameters: ~
+                  • {pattern} (`string`)
+                  • {flags} (`string?`)
+                  • {stopline} (`integer?`)
+                  • {timeout} (`integer?`)
+                  • {skip} (`string|function?`)
+
+                Return: ~
+                  (`any`)
 
 searchcount([{options}])                                         *searchcount()*
 		Get or update the last search count, like what is displayed
@@ -6380,6 +8364,12 @@ searchcount([{options}])                                         *searchcount()*
 						value. see |cursor()|, |getpos()|
 						(default: cursor's position)
 
+                Parameters: ~
+                  • {options} (`table?`)
+
+                Return: ~
+                  (`any`)
+
 searchdecl({name} [, {global} [, {thisblock}]])                   *searchdecl()*
 		Search for the declaration of {name}.
 
@@ -6398,6 +8388,14 @@ searchdecl({name} [, {global} [, {thisblock}]])                   *searchdecl()*
 			   echo getline('.')
 			endif
 <
+
+                Parameters: ~
+                  • {name} (`string`)
+                  • {global} (`boolean?`)
+                  • {thisblock} (`boolean?`)
+
+                Return: ~
+                  (`any`)
 
                                                                   *searchpair()*
 searchpair({start}, {middle}, {end} [, {flags} [, {skip} [, {stopline} [, {timeout}]]]])
@@ -6485,6 +8483,18 @@ searchpair({start}, {middle}, {end} [, {flags} [, {skip} [, {stopline} [, {timeo
 			     \ 'synIDattr(synID(line("."), col("."), 0), "name") =~? "string"')
 <
 
+                Parameters: ~
+                  • {start} (`string`)
+                  • {middle} (`string`)
+                  • {end_} (`string`)
+                  • {flags} (`string?`)
+                  • {skip} (`string|function?`)
+                  • {stopline} (`integer?`)
+                  • {timeout} (`integer?`)
+
+                Return: ~
+                  (`integer`)
+
                                                                *searchpairpos()*
 searchpairpos({start}, {middle}, {end} [, {flags} [, {skip} [, {stopline} [, {timeout}]]]])
 		Same as |searchpair()|, but returns a |List| with the line and
@@ -6496,6 +8506,18 @@ searchpairpos({start}, {middle}, {end} [, {flags} [, {skip} [, {stopline} [, {ti
 			let [lnum,col] = searchpairpos('{', '', '}', 'n')
 <
 		See |match-parens| for a bigger and more useful example.
+
+                Parameters: ~
+                  • {start} (`string`)
+                  • {middle} (`string`)
+                  • {end_} (`string`)
+                  • {flags} (`string?`)
+                  • {skip} (`string|function?`)
+                  • {stopline} (`integer?`)
+                  • {timeout} (`integer?`)
+
+                Return: ~
+                  (`[integer, integer]`)
 
                                                                    *searchpos()*
 searchpos({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
@@ -6513,12 +8535,25 @@ searchpos({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
 <		In this example "submatch" is 2 when a lowercase letter is
 		found |/\l|, 3 when an uppercase letter is found |/\u|.
 
+                Parameters: ~
+                  • {pattern} (`string`)
+                  • {flags} (`string?`)
+                  • {stopline} (`integer?`)
+                  • {timeout} (`integer?`)
+                  • {skip} (`string|function?`)
+
+                Return: ~
+                  (`any`)
+
 serverlist()                                                      *serverlist()*
 		Returns a list of server addresses, or empty if all servers
 		were stopped. |serverstart()| |serverstop()|
 		Example: >vim
 			echo serverlist()
 <
+
+                Return: ~
+                  (`any`)
 
 serverstart([{address}])                                         *serverstart()*
 		Opens a socket or named pipe at {address} and listens for
@@ -6554,11 +8589,23 @@ serverstart([{address}])                                         *serverstart()*
 			echo serverstart('::1:12345')
 <
 
+                Parameters: ~
+                  • {address} (`string?`)
+
+                Return: ~
+                  (`any`)
+
 serverstop({address})                                             *serverstop()*
 		Closes the pipe or socket at {address}.
 		Returns TRUE if {address} is valid, else FALSE.
 		If |v:servername| is stopped it is set to the next available
 		address in |serverlist()|.
+
+                Parameters: ~
+                  • {address} (`string`)
+
+                Return: ~
+                  (`any`)
 
 setbufline({buf}, {lnum}, {text})                                 *setbufline()*
 		Set line {lnum} to {text} in buffer {buf}.  This works like
@@ -6585,6 +8632,14 @@ setbufline({buf}, {lnum}, {text})                                 *setbufline()*
 		If {buf} is not a valid buffer or {lnum} is not valid, an
 		error message is given.
 
+                Parameters: ~
+                  • {buf} (`integer|string`)
+                  • {lnum} (`integer`)
+                  • {text} (`string|string[]`)
+
+                Return: ~
+                  (`any`)
+
 setbufvar({buf}, {varname}, {val})                                 *setbufvar()*
 		Set option or local variable {varname} in buffer {buf} to
 		{val}.
@@ -6598,6 +8653,14 @@ setbufvar({buf}, {varname}, {val})                                 *setbufvar()*
 			call setbufvar(1, "&mod", 1)
 			call setbufvar("todo", "myvar", "foobar")
 <		This function is not available in the |sandbox|.
+
+                Parameters: ~
+                  • {buf} (`integer|string`)
+                  • {varname} (`string`)
+                  • {val} (`any`)
+
+                Return: ~
+                  (`any`)
 
 setcellwidths({list})                                          *setcellwidths()*
 		Specify overrides for cell widths of character ranges.  This
@@ -6633,6 +8696,12 @@ setcellwidths({list})                                          *setcellwidths()*
 		match with what Vim knows about each emoji.  If it doesn't
 		look right you need to adjust the {list} argument.
 
+                Parameters: ~
+                  • {list} (`any[]`)
+
+                Return: ~
+                  (`any`)
+
 setcharpos({expr}, {list})                                        *setcharpos()*
 		Same as |setpos()| but uses the specified column number as the
 		character index instead of the byte index in the line.
@@ -6643,6 +8712,13 @@ setcharpos({expr}, {list})                                        *setcharpos()*
 <		positions the cursor on the fourth character '요'. >vim
 			call setpos('.', [0, 8, 4, 0])
 <		positions the cursor on the second character '보'.
+
+                Parameters: ~
+                  • {expr} (`string`)
+                  • {list} (`integer[]`)
+
+                Return: ~
+                  (`any`)
 
 setcharsearch({dict})                                          *setcharsearch()*
 		Set the current character search information to {dict},
@@ -6664,12 +8740,25 @@ setcharsearch({dict})                                          *setcharsearch()*
 			call setcharsearch(prevsearch)
 <		Also see |getcharsearch()|.
 
+                Parameters: ~
+                  • {dict} (`string`)
+
+                Return: ~
+                  (`any`)
+
 setcmdline({str} [, {pos}])                                       *setcmdline()*
 		Set the command line to {str} and set the cursor position to
 		{pos}.
 		If {pos} is omitted, the cursor is positioned after the text.
 		Returns 0 when successful, 1 when not editing the command
 		line.
+
+                Parameters: ~
+                  • {str} (`string`)
+                  • {pos} (`integer?`)
+
+                Return: ~
+                  (`any`)
 
 setcmdpos({pos})                                                   *setcmdpos()*
 		Set the cursor position in the command line to byte position
@@ -6686,6 +8775,12 @@ setcmdpos({pos})                                                   *setcmdpos()*
 		Returns 0 when successful, 1 when not editing the command
 		line.
 
+                Parameters: ~
+                  • {pos} (`integer`)
+
+                Return: ~
+                  (`any`)
+
 setcursorcharpos({lnum}, {col} [, {off}])                   *setcursorcharpos()*
 setcursorcharpos({list})
 		Same as |cursor()| but uses the specified column number as the
@@ -6698,12 +8793,25 @@ setcursorcharpos({list})
 			call cursor(4, 3)
 <		positions the cursor on the first character '여'.
 
+                Parameters: ~
+                  • {list} (`integer[]`)
+
+                Return: ~
+                  (`any`)
+
 setenv({name}, {val})                                                 *setenv()*
 		Set environment variable {name} to {val}.  Example: >vim
 			call setenv('HOME', '/home/myhome')
 
 <		When {val} is |v:null| the environment variable is deleted.
 		See also |expr-env|.
+
+                Parameters: ~
+                  • {name} (`string`)
+                  • {val} (`string`)
+
+                Return: ~
+                  (`any`)
 
 setfperm({fname}, {mode})                                     *setfperm()* *chmod*
 		Set the file permissions for {fname} to {mode}.
@@ -6721,6 +8829,13 @@ setfperm({fname}, {mode})                                     *setfperm()* *chmo
 		Returns non-zero for success, zero for failure.
 
 		To read permissions see |getfperm()|.
+
+                Parameters: ~
+                  • {fname} (`string`)
+                  • {mode} (`string`)
+
+                Return: ~
+                  (`any`)
 
 setline({lnum}, {text})                                              *setline()*
 		Set line {lnum} of the current buffer to {text}.  To insert
@@ -6750,6 +8865,13 @@ setline({lnum}, {text})                                              *setline()*
 
 <		Note: The '[ and '] marks are not set.
 
+                Parameters: ~
+                  • {lnum} (`integer`)
+                  • {text} (`any`)
+
+                Return: ~
+                  (`any`)
+
 setloclist({nr}, {list} [, {action} [, {what}]])                  *setloclist()*
 		Create or replace or add to the location list for window {nr}.
 		{nr} can be the window number or the |window-ID|.
@@ -6766,6 +8888,15 @@ setloclist({nr}, {list} [, {action} [, {what}]])                  *setloclist()*
 		only the items listed in {what} are set. Refer to |setqflist()|
 		for the list of supported keys in {what}.
 
+                Parameters: ~
+                  • {nr} (`integer`)
+                  • {list} (`any`)
+                  • {action} (`string?`)
+                  • {what} (`table?`)
+
+                Return: ~
+                  (`any`)
+
 setmatches({list} [, {win}])                                      *setmatches()*
 		Restores a list of matches saved by |getmatches()| for the
 		current window.  Returns 0 if successful, otherwise -1.  All
@@ -6773,6 +8904,13 @@ setmatches({list} [, {win}])                                      *setmatches()*
 		example for |getmatches()|.
 		If {win} is specified, use the window with this number or
 		window ID instead of the current window.
+
+                Parameters: ~
+                  • {list} (`any`)
+                  • {win} (`integer?`)
+
+                Return: ~
+                  (`any`)
 
 setpos({expr}, {list})                                                *setpos()*
 		Set the position for String {expr}.  Possible values:
@@ -6822,6 +8960,13 @@ setpos({expr}, {list})                                                *setpos()*
 		|k| motions will jump to previous columns!  Use |cursor()| to
 		also set the preferred column.  Also see the "curswant" key in
 		|winrestview()|.
+
+                Parameters: ~
+                  • {expr} (`string`)
+                  • {list} (`integer[]`)
+
+                Return: ~
+                  (`any`)
 
 setqflist({list} [, {action} [, {what}]])                          *setqflist()*
 		Create or replace or add to the quickfix list.
@@ -6937,6 +9082,14 @@ setqflist({list} [, {action} [, {what}]])                          *setqflist()*
 		independent of the 'errorformat' setting.  Use a command like
 		`:cc 1` to jump to the first position.
 
+                Parameters: ~
+                  • {list} (`any[]`)
+                  • {action} (`string?`)
+                  • {what} (`table?`)
+
+                Return: ~
+                  (`any`)
+
 setreg({regname}, {value} [, {options}])                              *setreg()*
 		Set the register {regname} to {value}.
 		If {regname} is "" or "@", the unnamed register '"' is used.
@@ -6993,6 +9146,14 @@ setreg({regname}, {value} [, {options}])                              *setreg()*
 		nothing: >vim
 			call setreg('a', '', 'al')
 
+                Parameters: ~
+                  • {regname} (`string`)
+                  • {value} (`any`)
+                  • {options} (`string?`)
+
+                Return: ~
+                  (`any`)
+
 settabvar({tabnr}, {varname}, {val})                               *settabvar()*
 		Set tab-local variable {varname} to {val} in tab page {tabnr}.
 		|t:var|
@@ -7000,6 +9161,14 @@ settabvar({tabnr}, {varname}, {val})                               *settabvar()*
 		Note that the variable name without "t:" must be used.
 		Tabs are numbered starting with one.
 		This function is not available in the |sandbox|.
+
+                Parameters: ~
+                  • {tabnr} (`integer`)
+                  • {varname} (`string`)
+                  • {val} (`any`)
+
+                Return: ~
+                  (`any`)
 
 settabwinvar({tabnr}, {winnr}, {varname}, {val})                *settabwinvar()*
 		Set option or local variable {varname} in window {winnr} to
@@ -7016,6 +9185,15 @@ settabwinvar({tabnr}, {winnr}, {varname}, {val})                *settabwinvar()*
 			call settabwinvar(1, 1, "&list", 0)
 			call settabwinvar(3, 2, "myvar", "foobar")
 <		This function is not available in the |sandbox|.
+
+                Parameters: ~
+                  • {tabnr} (`integer`)
+                  • {winnr} (`integer`)
+                  • {varname} (`string`)
+                  • {val} (`any`)
+
+                Return: ~
+                  (`any`)
 
 settagstack({nr}, {dict} [, {action}])                           *settagstack()*
 		Modify the tag stack of the window {nr} using {dict}.
@@ -7051,15 +9229,37 @@ settagstack({nr}, {dict} [, {action}])                           *settagstack()*
 			unlet stack
 <
 
+                Parameters: ~
+                  • {nr} (`integer`)
+                  • {dict} (`any`)
+                  • {action} (`string?`)
+
+                Return: ~
+                  (`any`)
+
 setwinvar({nr}, {varname}, {val})                                  *setwinvar()*
 		Like |settabwinvar()| for the current tab page.
 		Examples: >vim
 			call setwinvar(1, "&list", 0)
 			call setwinvar(2, "myvar", "foobar")
 
+                Parameters: ~
+                  • {nr} (`integer`)
+                  • {varname} (`string`)
+                  • {val} (`any`)
+
+                Return: ~
+                  (`any`)
+
 sha256({string})                                                      *sha256()*
 		Returns a String with 64 hex characters, which is the SHA256
 		checksum of {string}.
+
+                Parameters: ~
+                  • {string} (`string`)
+
+                Return: ~
+                  (`any`)
 
 shellescape({string} [, {special}])                              *shellescape()*
 		Escape {string} for use as a shell command argument.
@@ -7093,6 +9293,13 @@ shellescape({string} [, {special}])                              *shellescape()*
 		    call system("chmod +w -- " .. shellescape(expand("%")))
 <		See also |::S|.
 
+                Parameters: ~
+                  • {string} (`string`)
+                  • {special} (`boolean?`)
+
+                Return: ~
+                  (`any`)
+
 shiftwidth([{col}])                                               *shiftwidth()*
 		Returns the effective value of 'shiftwidth'. This is the
 		'shiftwidth' value unless it is zero, in which case it is the
@@ -7113,6 +9320,12 @@ shiftwidth([{col}])                                               *shiftwidth()*
 		for which to return the 'shiftwidth' value. This matters for the
 		'vartabstop' feature. If no {col} argument is given, column 1
 		will be assumed.
+
+                Parameters: ~
+                  • {col} (`integer?`)
+
+                Return: ~
+                  (`integer`)
 
 sign_define({name} [, {dict}])                                   *sign_define()*
 sign_define({list})
@@ -7162,6 +9375,12 @@ sign_define({list})
 				\ ])
 <
 
+                Parameters: ~
+                  • {list} (`vim.fn.sign_define.dict[]`)
+
+                Return: ~
+                  (`(0|-1)[]`)
+
 sign_getdefined([{name}])                                    *sign_getdefined()*
 		Get a list of defined signs and their attributes.
 		This is similar to the |:sign-list| command.
@@ -7198,6 +9417,12 @@ sign_getdefined([{name}])                                    *sign_getdefined()*
 			" Get the attribute of the sign named mySign
 			echo sign_getdefined("mySign")
 <
+
+                Parameters: ~
+                  • {name} (`string?`)
+
+                Return: ~
+                  (`vim.fn.sign_getdefined.ret.item[]`)
 
 sign_getplaced([{buf} [, {dict}]])                            *sign_getplaced()*
 		Return a list of signs placed in a buffer or all the buffers.
@@ -7260,6 +9485,13 @@ sign_getplaced([{buf} [, {dict}]])                            *sign_getplaced()*
 			echo sign_getplaced()
 <
 
+                Parameters: ~
+                  • {buf} (`integer|string?`)
+                  • {dict} (`vim.fn.sign_getplaced.dict?`)
+
+                Return: ~
+                  (`vim.fn.sign_getplaced.ret.item[]`)
+
 sign_jump({id}, {group}, {buf})                                    *sign_jump()*
 		Open the buffer {buf} or jump to the window that contains
 		{buf} and position the cursor at sign {id} in group {group}.
@@ -7275,6 +9507,14 @@ sign_jump({id}, {group}, {buf})                                    *sign_jump()*
 			" Jump to sign 10 in the current buffer
 			call sign_jump(10, '', '')
 <
+
+                Parameters: ~
+                  • {id} (`integer`)
+                  • {group} (`string`)
+                  • {buf} (`integer|string`)
+
+                Return: ~
+                  (`integer`)
 
 sign_place({id}, {group}, {name}, {buf} [, {dict}])               *sign_place()*
 		Place the sign defined as {name} at line {lnum} in file or
@@ -7324,6 +9564,16 @@ sign_place({id}, {group}, {name}, {buf} [, {dict}])               *sign_place()*
 			call sign_place(10, 'g3', 'sign4', 'json.c',
 					\ {'lnum' : 40, 'priority' : 90})
 <
+
+                Parameters: ~
+                  • {id} (`integer`)
+                  • {group} (`string`)
+                  • {name} (`string`)
+                  • {buf} (`integer|string`)
+                  • {dict} (`vim.fn.sign_place.dict?`)
+
+                Return: ~
+                  (`integer`)
 
 sign_placelist({list})                                        *sign_placelist()*
 		Place one or more signs.  This is similar to the
@@ -7385,6 +9635,12 @@ sign_placelist({list})                                        *sign_placelist()*
 				\ ])
 <
 
+                Parameters: ~
+                  • {list} (`vim.fn.sign_placelist.list.item[]`)
+
+                Return: ~
+                  (`integer[]`)
+
 sign_undefine([{name}])                                        *sign_undefine()*
 sign_undefine({list})
 		Deletes a previously defined sign {name}. This is similar to
@@ -7408,6 +9664,12 @@ sign_undefine({list})
 			" Delete all the signs
 			call sign_undefine()
 <
+
+                Parameters: ~
+                  • {list} (`string[]?`)
+
+                Return: ~
+                  (`integer[]`)
 
 sign_unplace({group} [, {dict}])                                *sign_unplace()*
 		Remove a previously placed sign in one or more buffers.  This
@@ -7451,6 +9713,13 @@ sign_unplace({group} [, {dict}])                                *sign_unplace()*
 			" Remove all the placed signs from all the buffers
 			call sign_unplace('*')
 
+                Parameters: ~
+                  • {group} (`string`)
+                  • {dict} (`vim.fn.sign_unplace.dict?`)
+
+                Return: ~
+                  (`0|-1`)
+
 sign_unplacelist({list})                                    *sign_unplacelist()*
 		Remove previously placed signs from one or more buffers.  This
 		is similar to the |sign_unplace()| function.
@@ -7480,6 +9749,12 @@ sign_unplacelist({list})                                    *sign_unplacelist()*
 				\ ])
 <
 
+                Parameters: ~
+                  • {list} (`vim.fn.sign_unplacelist.list.item`)
+
+                Return: ~
+                  (`(0|-1)[]`)
+
 simplify({filename})                                                *simplify()*
 		Simplify the file name as much as possible without changing
 		the meaning.  Shortcuts (on MS-Windows) or symbolic links (on
@@ -7497,6 +9772,12 @@ simplify({filename})                                                *simplify()*
 		directory.  In order to resolve all the involved symbolic
 		links before simplifying the path name, use |resolve()|.
 
+                Parameters: ~
+                  • {filename} (`string`)
+
+                Return: ~
+                  (`any`)
+
 sin({expr})                                                              *sin()*
 		Return the sine of {expr}, measured in radians, as a |Float|.
 		{expr} must evaluate to a |Float| or a |Number|.
@@ -7506,6 +9787,12 @@ sin({expr})                                                              *sin()*
 <			-0.506366 >vim
 			echo sin(-4.01)
 <			0.763301
+
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`any`)
 
 sinh({expr})                                                            *sinh()*
 		Return the hyperbolic sine of {expr} as a |Float| in the range
@@ -7518,6 +9805,12 @@ sinh({expr})                                                            *sinh()*
 			echo sinh(-0.9)
 <			-1.026517
 
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`any`)
+
 slice({expr}, {start} [, {end}])                                       *slice()*
 		Similar to using a |slice| "expr[start : end]", but "end" is
 		used exclusive.  And for a string the indexes are used as
@@ -7527,6 +9820,14 @@ slice({expr}, {start} [, {end}])                                       *slice()*
 		When {end} is omitted the slice continues to the last item.
 		When {end} is -1 the last item is omitted.
 		Returns an empty value if {start} or {end} are invalid.
+
+                Parameters: ~
+                  • {expr} (`any`)
+                  • {start} (`integer`)
+                  • {end_} (`integer?`)
+
+                Return: ~
+                  (`any`)
 
 sockconnect({mode}, {address} [, {opts}])                        *sockconnect()*
 		Connect a socket to an address. If {mode} is "pipe" then
@@ -7552,6 +9853,14 @@ sockconnect({mode}, {address} [, {opts}])                        *sockconnect()*
 		Returns:
 		  - The channel ID on success (greater than zero)
 		  - 0 on invalid arguments or connection failure.
+
+                Parameters: ~
+                  • {mode} (`string`)
+                  • {address} (`string`)
+                  • {opts} (`table?`)
+
+                Return: ~
+                  (`any`)
 
 sort({list} [, {how} [, {dict}]])                                  *sort()* *E702*
 		Sort the items in {list} in-place.  Returns {list}.
@@ -7626,6 +9935,14 @@ sort({list} [, {how} [, {dict}]])                                  *sort()* *E70
 			eval mylist->sort({i1, i2 -> i1 - i2})
 <
 
+                Parameters: ~
+                  • {list} (`any`)
+                  • {how} (`string|function?`)
+                  • {dict} (`any?`)
+
+                Return: ~
+                  (`any`)
+
 soundfold({word})                                                  *soundfold()*
 		Return the sound-folded equivalent of {word}.  Uses the first
 		language in 'spelllang' for the current window that supports
@@ -7633,6 +9950,12 @@ soundfold({word})                                                  *soundfold()*
 		possible the {word} is returned unmodified.
 		This can be used for making spelling suggestions.  Note that
 		the method can be quite slow.
+
+                Parameters: ~
+                  • {word} (`string`)
+
+                Return: ~
+                  (`any`)
 
 spellbadword([{sentence}])                                      *spellbadword()*
 		Without argument: The result is the badly spelled word under
@@ -7658,6 +9981,12 @@ spellbadword([{sentence}])                                      *spellbadword()*
 		The spelling information for the current window and the value
 		of 'spelllang' are used.
 
+                Parameters: ~
+                  • {sentence} (`string?`)
+
+                Return: ~
+                  (`any`)
+
 spellsuggest({word} [, {max} [, {capital}]])                    *spellsuggest()*
 		Return a |List| with spelling suggestions to replace {word}.
 		When {max} is given up to this number of suggestions are
@@ -7678,6 +10007,14 @@ spellsuggest({word} [, {max} [, {capital}]])                    *spellsuggest()*
 
 		The spelling information for the current window is used.  The
 		values of 'spelllang' and 'spellsuggest' are used.
+
+                Parameters: ~
+                  • {word} (`string`)
+                  • {max} (`integer?`)
+                  • {capital} (`boolean?`)
+
+                Return: ~
+                  (`any`)
 
 split({string} [, {pattern} [, {keepempty}]])                          *split()*
 		Make a |List| out of {string}.  When {pattern} is omitted or
@@ -7704,6 +10041,14 @@ split({string} [, {pattern} [, {keepempty}]])                          *split()*
 			let items = split(line, ':', 1)
 <		The opposite function is |join()|.
 
+                Parameters: ~
+                  • {string} (`string`)
+                  • {pattern} (`string?`)
+                  • {keepempty} (`boolean?`)
+
+                Return: ~
+                  (`any`)
+
 sqrt({expr})                                                            *sqrt()*
 		Return the non-negative square root of Float {expr} as a
 		|Float|.
@@ -7716,6 +10061,12 @@ sqrt({expr})                                                            *sqrt()*
 			echo sqrt(-4.01)
 <			str2float("nan")
 		NaN may be different, it depends on system libraries.
+
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`any`)
 
 srand([{expr}])                                                        *srand()*
 		Initialize seed used by |rand()|:
@@ -7731,6 +10082,12 @@ srand([{expr}])                                                        *srand()*
 			let seed = srand(userinput)
 			echo rand(seed)
 <
+
+                Parameters: ~
+                  • {expr} (`number?`)
+
+                Return: ~
+                  (`any`)
 
 state([{what}])                                                        *state()*
 		Return a string which contains characters indicating the
@@ -7762,6 +10119,12 @@ state([{what}])                                                        *state()*
 			recursiveness up to "ccc")
 		    s	screen has scrolled for messages
 
+                Parameters: ~
+                  • {what} (`string?`)
+
+                Return: ~
+                  (`any`)
+
 stdioopen({opts})                                                  *stdioopen()*
 		With |--headless| this opens stdin and stdout as a |channel|.
 		May be called only once. See |channel-stdio|. stderr is not
@@ -7782,6 +10145,12 @@ stdioopen({opts})                                                  *stdioopen()*
 		Returns:
 		  - |channel-id| on success (value is always 1)
 		  - 0 on invalid arguments
+
+                Parameters: ~
+                  • {opts} (`table`)
+
+                Return: ~
+                  (`any`)
 
 stdpath({what})                                                *stdpath()* *E6100*
 		Returns |standard-path| locations of various default files and
@@ -7805,6 +10174,13 @@ stdpath({what})                                                *stdpath()* *E610
 			echo stdpath("config")
 <
 
+                Parameters: ~
+                  • {what}
+                    (`'cache'|'config'|'config_dirs'|'data'|'data_dirs'|'log'|'run'|'state'`)
+
+                Return: ~
+                  (`string|string[]`)
+
 str2float({string} [, {quoted}])                                   *str2float()*
 		Convert String {string} to a Float.  This mostly works the
 		same as when using a floating point number in an expression,
@@ -7824,6 +10200,13 @@ str2float({string} [, {quoted}])                                   *str2float()*
 <
 		Returns 0.0 if the conversion fails.
 
+                Parameters: ~
+                  • {string} (`string`)
+                  • {quoted} (`boolean?`)
+
+                Return: ~
+                  (`any`)
+
 str2list({string} [, {utf8}])                                       *str2list()*
 		Return a list containing the number values which represent
 		each character in String {string}.  Examples: >vim
@@ -7835,6 +10218,13 @@ str2list({string} [, {utf8}])                                       *str2list()*
 		and exists only for backwards-compatibility.
 		With UTF-8 composing characters are handled properly: >vim
 			echo str2list("á")		" returns [97, 769]
+
+                Parameters: ~
+                  • {string} (`string`)
+                  • {utf8} (`boolean?`)
+
+                Return: ~
+                  (`any`)
 
 str2nr({string} [, {base}])                                           *str2nr()*
 		Convert string {string} to a number.
@@ -7855,6 +10245,13 @@ str2nr({string} [, {base}])                                           *str2nr()*
 
 		Returns 0 if {string} is empty or on error.
 
+                Parameters: ~
+                  • {string} (`string`)
+                  • {base} (`integer?`)
+
+                Return: ~
+                  (`any`)
+
 strcharlen({string})                                              *strcharlen()*
 		The result is a Number, which is the number of characters
 		in String {string}.  Composing characters are ignored.
@@ -7864,6 +10261,12 @@ strcharlen({string})                                              *strcharlen()*
 		Returns 0 if {string} is empty or on error.
 
 		Also see |strlen()|, |strdisplaywidth()| and |strwidth()|.
+
+                Parameters: ~
+                  • {string} (`string`)
+
+                Return: ~
+                  (`any`)
 
 strcharpart({src}, {start} [, {len} [, {skipcc}]])               *strcharpart()*
 		Like |strpart()| but using character index and length instead
@@ -7879,6 +10282,15 @@ strcharpart({src}, {start} [, {len} [, {skipcc}]])               *strcharpart()*
 <		results in 'a'.
 
 		Returns an empty string on error.
+
+                Parameters: ~
+                  • {src} (`string`)
+                  • {start} (`integer`)
+                  • {len} (`integer?`)
+                  • {skipcc} (`boolean?`)
+
+                Return: ~
+                  (`any`)
 
 strchars({string} [, {skipcc}])                                     *strchars()*
 		The result is a Number, which is the number of characters
@@ -7909,6 +10321,13 @@ strchars({string} [, {skipcc}])                                     *strchars()*
 		    endif
 <
 
+                Parameters: ~
+                  • {string} (`string`)
+                  • {skipcc} (`boolean?`)
+
+                Return: ~
+                  (`integer`)
+
 strdisplaywidth({string} [, {col}])                          *strdisplaywidth()*
 		The result is a Number, which is the number of display cells
 		String {string} occupies on the screen when it starts at {col}
@@ -7922,6 +10341,13 @@ strdisplaywidth({string} [, {col}])                          *strdisplaywidth()*
 		Ambiguous, this function's return value depends on 'ambiwidth'.
 		Returns zero on error.
 		Also see |strlen()|, |strwidth()| and |strchars()|.
+
+                Parameters: ~
+                  • {string} (`string`)
+                  • {col} (`integer?`)
+
+                Return: ~
+                  (`integer`)
 
 strftime({format} [, {time}])                                       *strftime()*
 		The result is a String, which is a formatted date and time, as
@@ -7940,6 +10366,13 @@ strftime({format} [, {time}])                                       *strftime()*
 		  echo strftime("%c", getftime("file.c"))
 						   " Show mod time of file.c.
 
+                Parameters: ~
+                  • {format} (`string`)
+                  • {time} (`number?`)
+
+                Return: ~
+                  (`string`)
+
 strgetchar({str}, {index})                                        *strgetchar()*
 		Get a Number corresponding to the character at {index} in
 		{str}.  This uses a zero-based character index, not a byte
@@ -7948,6 +10381,13 @@ strgetchar({str}, {index})                                        *strgetchar()*
 		String.
 		Returns -1 if {index} is invalid.
 		Also see |strcharpart()| and |strchars()|.
+
+                Parameters: ~
+                  • {str} (`string`)
+                  • {index} (`integer`)
+
+                Return: ~
+                  (`integer`)
 
 stridx({haystack}, {needle} [, {start}])                              *stridx()*
 		The result is a Number, which gives the byte index in
@@ -7967,6 +10407,14 @@ stridx({haystack}, {needle} [, {start}])                              *stridx()*
 <						*strstr()* *strchr()*
 		stridx() works similar to the C function strstr().  When used
 		with a single character it works similar to strchr().
+
+                Parameters: ~
+                  • {haystack} (`string`)
+                  • {needle} (`string`)
+                  • {start} (`integer?`)
+
+                Return: ~
+                  (`integer`)
 
 string({expr})                                                        *string()*
 		Return {expr} converted to a String.  If {expr} is a Number,
@@ -7992,6 +10440,12 @@ string({expr})                                                        *string()*
 		method.  Use |msgpackdump()| or |json_encode()| if you need to
 		share data with other applications.
 
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`string`)
+
 strlen({string})                                                      *strlen()*
 		The result is a Number, which is the length of the String
 		{string} in bytes.
@@ -8000,6 +10454,12 @@ strlen({string})                                                      *strlen()*
 		If you want to count the number of multibyte characters use
 		|strchars()|.
 		Also see |len()|, |strdisplaywidth()| and |strwidth()|.
+
+                Parameters: ~
+                  • {string} (`string`)
+
+                Return: ~
+                  (`integer`)
 
 strpart({src}, {start} [, {len} [, {chars}]])                        *strpart()*
 		The result is a String, which is part of {src}, starting from
@@ -8026,6 +10486,15 @@ strpart({src}, {start} [, {len} [, {chars}]])                        *strpart()*
 <
 		Returns an empty string on error.
 
+                Parameters: ~
+                  • {src} (`string`)
+                  • {start} (`integer`)
+                  • {len} (`integer?`)
+                  • {chars} (`0|1?`)
+
+                Return: ~
+                  (`string`)
+
 strptime({format}, {timestring})                                    *strptime()*
 		The result is a Number, which is a unix timestamp representing
 		the date and time in {timestring}, which is expected to match
@@ -8050,6 +10519,13 @@ strptime({format}, {timestring})                                    *strptime()*
 		  echo strftime("%c", strptime("%Y%m%d%H%M%S", "19970427115355") + 3600)
 <		  Sun Apr 27 12:53:55 1997
 
+                Parameters: ~
+                  • {format} (`string`)
+                  • {timestring} (`string`)
+
+                Return: ~
+                  (`integer`)
+
 strridx({haystack}, {needle} [, {start}])                            *strridx()*
 		The result is a Number, which gives the byte index in
 		{haystack} of the last occurrence of the String {needle}.
@@ -8068,6 +10544,14 @@ strridx({haystack}, {needle} [, {start}])                            *strridx()*
 		When used with a single character it works similar to the C
 		function strrchr().
 
+                Parameters: ~
+                  • {haystack} (`string`)
+                  • {needle} (`string`)
+                  • {start} (`integer?`)
+
+                Return: ~
+                  (`integer`)
+
 strtrans({string})                                                  *strtrans()*
 		The result is a String, which is {string} with all unprintable
 		characters translated into printable characters |'isprint'|.
@@ -8077,6 +10561,12 @@ strtrans({string})                                                  *strtrans()*
 		starting a new line.
 
 		Returns an empty string on error.
+
+                Parameters: ~
+                  • {string} (`string`)
+
+                Return: ~
+                  (`string`)
 
 strutf16len({string} [, {countcc}])                              *strutf16len()*
 		The result is a Number, which is the number of UTF-16 code
@@ -8098,6 +10588,13 @@ strutf16len({string} [, {countcc}])                              *strutf16len()*
 		    echo strutf16len('ą́', v:true)	" returns 3
 <
 
+                Parameters: ~
+                  • {string} (`string`)
+                  • {countcc} (`0|1?`)
+
+                Return: ~
+                  (`integer`)
+
 strwidth({string})                                                  *strwidth()*
 		The result is a Number, which is the number of display cells
 		String {string} occupies.  A Tab character is counted as one
@@ -8106,6 +10603,12 @@ strwidth({string})                                                  *strwidth()*
 		Ambiguous, this function's return value depends on 'ambiwidth'.
 		Returns zero on error.
 		Also see |strlen()|, |strdisplaywidth()| and |strchars()|.
+
+                Parameters: ~
+                  • {string} (`string`)
+
+                Return: ~
+                  (`integer`)
 
 submatch({nr} [, {list}])                                      *submatch()* *E935*
 		Only for an expression in a |:substitute| command or
@@ -8134,6 +10637,13 @@ submatch({nr} [, {list}])                                      *submatch()* *E93
 			echo substitute(text, '\d\+', '\=submatch(0) + 1', '')
 <		This finds the first number in the line and adds one to it.
 		A line break is included as a newline character.
+
+                Parameters: ~
+                  • {nr} (`integer`)
+                  • {list} (`nil?`)
+
+                Return: ~
+                  (`string`)
 
 substitute({string}, {pat}, {sub}, {flags})                       *substitute()*
 		The result is a String, which is a copy of {string}, in which
@@ -8178,6 +10688,15 @@ substitute({string}, {pat}, {sub}, {flags})                       *substitute()*
 
 <		Returns an empty string on error.
 
+                Parameters: ~
+                  • {string} (`string`)
+                  • {pat} (`string`)
+                  • {sub} (`string`)
+                  • {flags} (`string`)
+
+                Return: ~
+                  (`string`)
+
 swapfilelist()                                                  *swapfilelist()*
 		Returns a list of swap file names, like what "vim -r" shows.
 		See the |-r| command argument.  The 'directory' option is used
@@ -8188,6 +10707,9 @@ swapfilelist()                                                  *swapfilelist()*
 			let &directory = '.'
 			let swapfiles = swapfilelist()
 			let &directory = save_dir
+
+                Return: ~
+                  (`string[]`)
 
 swapinfo({fname})                                                   *swapinfo()*
 		The result is a dictionary, which holds information about the
@@ -8207,12 +10729,24 @@ swapinfo({fname})                                                   *swapinfo()*
 			Not a swap file: does not contain correct block ID
 			Magic number mismatch: Info in first block is invalid
 
+                Parameters: ~
+                  • {fname} (`string`)
+
+                Return: ~
+                  (`any`)
+
 swapname({buf})                                                     *swapname()*
 		The result is the swap file path of the buffer {buf}.
 		For the use of {buf}, see |bufname()| above.
 		If buffer {buf} is the current buffer, the result is equal to
 		|:swapname| (unless there is no swap file).
 		If buffer {buf} has no swap file, returns an empty string.
+
+                Parameters: ~
+                  • {buf} (`integer|string`)
+
+                Return: ~
+                  (`string`)
 
 synID({lnum}, {col}, {trans})                                          *synID()*
 		The result is a Number, which is the syntax ID at the position
@@ -8239,6 +10773,14 @@ synID({lnum}, {col}, {trans})                                          *synID()*
 		Example (echoes the name of the syntax item under the cursor): >vim
 			echo synIDattr(synID(line("."), col("."), 1), "name")
 <
+
+                Parameters: ~
+                  • {lnum} (`integer`)
+                  • {col} (`integer`)
+                  • {trans} (`0|1`)
+
+                Return: ~
+                  (`integer`)
 
 synIDattr({synID}, {what} [, {mode}])                              *synIDattr()*
 		The result is a String, which is the {what} attribute of
@@ -8286,6 +10828,14 @@ synIDattr({synID}, {what} [, {mode}])                              *synIDattr()*
 			echo synID(line("."), col("."), 1)->synIDtrans()->synIDattr("fg")
 <
 
+                Parameters: ~
+                  • {synID} (`integer`)
+                  • {what} (`string`)
+                  • {mode} (`string?`)
+
+                Return: ~
+                  (`string`)
+
 synIDtrans({synID})                                               *synIDtrans()*
 		The result is a Number, which is the translated syntax ID of
 		{synID}.  This is the syntax group ID of what is being used to
@@ -8293,6 +10843,12 @@ synIDtrans({synID})                                               *synIDtrans()*
 		":highlight link" are followed.
 
 		Returns zero on error.
+
+                Parameters: ~
+                  • {synID} (`integer`)
+
+                Return: ~
+                  (`integer`)
 
 synconcealed({lnum}, {col})                                     *synconcealed()*
 		The result is a |List| with currently three items:
@@ -8323,6 +10879,13 @@ synconcealed({lnum}, {col})                                     *synconcealed()*
 		since syntax and matching highlighting are two different
 		mechanisms |syntax-vs-match|.
 
+                Parameters: ~
+                  • {lnum} (`integer`)
+                  • {col} (`integer`)
+
+                Return: ~
+                  (`[integer, string, integer]`)
+
 synstack({lnum}, {col})                                             *synstack()*
 		Return a |List|, which is the stack of syntax items at the
 		position {lnum} and {col} in the current window.  {lnum} is
@@ -8341,6 +10904,13 @@ synstack({lnum}, {col})                                             *synstack()*
 		an empty list is returned.  The position just after the last
 		character in a line and the first column in an empty line are
 		valid positions.
+
+                Parameters: ~
+                  • {lnum} (`integer`)
+                  • {col} (`integer`)
+
+                Return: ~
+                  (`integer[]`)
 
 system({cmd} [, {input}])                                        *system()* *E677*
 		Note: Prefer |vim.system()| in Lua.
@@ -8391,6 +10961,13 @@ system({cmd} [, {input}])                                        *system()* *E67
 <		Unlike ":!cmd" there is no automatic check for changed files.
 		Use |:checktime| to force a check.
 
+                Parameters: ~
+                  • {cmd} (`string|string[]`)
+                  • {input} (`string|string[]|integer?`)
+
+                Return: ~
+                  (`string`)
+
 systemlist({cmd} [, {input} [, {keepempty}]])                     *systemlist()*
 		Same as |system()|, but returns a |List| with lines (parts of
 		output separated by NL) with NULs transformed into NLs. Output
@@ -8405,6 +10982,14 @@ systemlist({cmd} [, {input} [, {keepempty}]])                     *systemlist()*
 <
 		Returns an empty string on error.
 
+                Parameters: ~
+                  • {cmd} (`string|string[]`)
+                  • {input} (`string|string[]|integer?`)
+                  • {keepempty} (`integer?`)
+
+                Return: ~
+                  (`string[]`)
+
 tabpagebuflist([{arg}])                                       *tabpagebuflist()*
 		The result is a |List|, where each item is the number of the
 		buffer associated with each window in the current tab page.
@@ -8417,6 +11002,12 @@ tabpagebuflist([{arg}])                                       *tabpagebuflist()*
 			   call extend(buflist, tabpagebuflist(i + 1))
 			endfor
 <		Note that a buffer may appear in more than one window.
+
+                Parameters: ~
+                  • {arg} (`integer?`)
+
+                Return: ~
+                  (`any`)
 
 tabpagenr([{arg}])                                                 *tabpagenr()*
 		The result is a Number, which is the number of the current
@@ -8432,6 +11023,12 @@ tabpagenr([{arg}])                                                 *tabpagenr()*
 
 		Returns zero on error.
 
+                Parameters: ~
+                  • {arg} (`'$'|'#'?`)
+
+                Return: ~
+                  (`integer`)
+
 tabpagewinnr({tabarg} [, {arg}])                                *tabpagewinnr()*
 		Like |winnr()| but for tab page {tabarg}.
 		{tabarg} specifies the number of tab page to be used.
@@ -8445,9 +11042,19 @@ tabpagewinnr({tabarg} [, {arg}])                                *tabpagewinnr()*
 		    tabpagewinnr(4, '$')    " number of windows in tab page 4
 <		When {tabarg} is invalid zero is returned.
 
+                Parameters: ~
+                  • {tabarg} (`integer`)
+                  • {arg} (`'$'|'#'?`)
+
+                Return: ~
+                  (`integer`)
+
 tagfiles()                                                          *tagfiles()*
 		Returns a |List| with the file names used to search for tags
 		for the current buffer.  This is the 'tags' option expanded.
+
+                Return: ~
+                  (`string[]`)
 
 taglist({expr} [, {filename}])                                       *taglist()*
 		Returns a |List| of tags matching the regular expression {expr}.
@@ -8492,6 +11099,13 @@ taglist({expr} [, {filename}])                                       *taglist()*
 		located by Vim. Refer to |tags-file-format| for the format of
 		the tags file generated by the different ctags tools.
 
+                Parameters: ~
+                  • {expr} (`any`)
+                  • {filename} (`string?`)
+
+                Return: ~
+                  (`any`)
+
 tan({expr})                                                              *tan()*
 		Return the tangent of {expr}, measured in radians, as a |Float|
 		in the range [-inf, inf].
@@ -8502,6 +11116,12 @@ tan({expr})                                                              *tan()*
 <			0.648361 >vim
 			echo tan(-4.01)
 <			-1.181502
+
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`number`)
 
 tanh({expr})                                                            *tanh()*
 		Return the hyperbolic tangent of {expr} as a |Float| in the
@@ -8514,6 +11134,12 @@ tanh({expr})                                                            *tanh()*
 			echo tanh(-1)
 <			-0.761594
 
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`number`)
+
 tempname()                                                          *tempname()*
 		Generates a (non-existent) filename located in the Nvim root
 		|tempdir|. Scripts can use the filename as a temporary file.
@@ -8521,6 +11147,9 @@ tempname()                                                          *tempname()*
 			let tmpfile = tempname()
 			exe "redir > " .. tmpfile
 <
+
+                Return: ~
+                  (`string`)
 
 termopen({cmd} [, {opts}])                                          *termopen()*
 		Spawns {cmd} in a new pseudo-terminal session connected
@@ -8537,11 +11166,21 @@ termopen({cmd} [, {opts}])                                          *termopen()*
 		except $TERM is set to "xterm-256color". Full behavior is
 		described in |terminal|.
 
+                Parameters: ~
+                  • {cmd} (`string|string[]`)
+                  • {opts} (`table?`)
+
+                Return: ~
+                  (`any`)
+
 test_garbagecollect_now()                            *test_garbagecollect_now()*
 		Like |garbagecollect()|, but executed right away.  This must
 		only be called directly to avoid any structure to exist
 		internally, and |v:testing| must have been set before calling
 		any function.   *E1142*
+
+                Return: ~
+                  (`any`)
 
 timer_info([{id}])                                                *timer_info()*
 		Return a list with information about timers.
@@ -8558,6 +11197,12 @@ timer_info([{id}])                                                *timer_info()*
 				    -1 means forever
 		    "callback"	    the callback
 
+                Parameters: ~
+                  • {id} (`integer?`)
+
+                Return: ~
+                  (`any`)
+
 timer_pause({timer}, {paused})                                   *timer_pause()*
 		Pause or unpause a timer.  A paused timer does not invoke its
 		callback when its time expires.  Unpausing a timer may cause
@@ -8570,6 +11215,13 @@ timer_pause({timer}, {paused})                                   *timer_pause()*
 		If {paused} evaluates to a non-zero Number or a non-empty
 		String, then the timer is paused, otherwise it is unpaused.
 		See |non-zero-arg|.
+
+                Parameters: ~
+                  • {timer} (`integer`)
+                  • {paused} (`boolean`)
+
+                Return: ~
+                  (`any`)
 
 timer_start({time}, {callback} [, {options}])              *timer_start()* *timer*
 		Create a timer and return the timer ID.
@@ -8601,25 +11253,54 @@ timer_start({time}, {callback} [, {options}])              *timer_start()* *time
 				\ {'repeat': 3})
 <		This invokes MyHandler() three times at 500 msec intervals.
 
+                Parameters: ~
+                  • {time} (`number`)
+                  • {callback} (`string|function`)
+                  • {options} (`table?`)
+
+                Return: ~
+                  (`any`)
+
 timer_stop({timer})                                               *timer_stop()*
 		Stop a timer.  The timer callback will no longer be invoked.
 		{timer} is an ID returned by timer_start(), thus it must be a
 		Number.  If {timer} does not exist there is no error.
+
+                Parameters: ~
+                  • {timer} (`integer`)
+
+                Return: ~
+                  (`any`)
 
 timer_stopall()                                                *timer_stopall()*
 		Stop all timers.  The timer callbacks will no longer be
 		invoked.  Useful if some timers is misbehaving.  If there are
 		no timers there is no error.
 
+                Return: ~
+                  (`any`)
+
 tolower({expr})                                                      *tolower()*
 		The result is a copy of the String given, with all uppercase
 		characters turned into lowercase (just like applying |gu| to
 		the string).  Returns an empty string on error.
 
+                Parameters: ~
+                  • {expr} (`string`)
+
+                Return: ~
+                  (`string`)
+
 toupper({expr})                                                      *toupper()*
 		The result is a copy of the String given, with all lowercase
 		characters turned into uppercase (just like applying |gU| to
 		the string).  Returns an empty string on error.
+
+                Parameters: ~
+                  • {expr} (`string`)
+
+                Return: ~
+                  (`string`)
 
 tr({src}, {fromstr}, {tostr})                                             *tr()*
 		The result is a copy of the {src} string with all characters
@@ -8636,6 +11317,14 @@ tr({src}, {fromstr}, {tostr})                                             *tr()*
 <		returns "Hello THere" >vim
 			echo tr("<blob>", "<>", "{}")
 <		returns "{blob}"
+
+                Parameters: ~
+                  • {src} (`string`)
+                  • {fromstr} (`string`)
+                  • {tostr} (`string`)
+
+                Return: ~
+                  (`string`)
 
 trim({text} [, {mask} [, {dir}]])                                       *trim()*
 		Return {text} as a String where any character in {mask} is
@@ -8665,6 +11354,14 @@ trim({text} [, {mask} [, {dir}]])                                       *trim()*
 			echo trim("  vim  ", " ", 2)
 <		returns "  vim"
 
+                Parameters: ~
+                  • {text} (`string`)
+                  • {mask} (`string?`)
+                  • {dir} (`0|1|2?`)
+
+                Return: ~
+                  (`string`)
+
 trunc({expr})                                                          *trunc()*
 		Return the largest integral value with magnitude less than or
 		equal to {expr} as a |Float| (truncate towards zero).
@@ -8677,6 +11374,12 @@ trunc({expr})                                                          *trunc()*
 <			-5.0  >vim
 			echo trunc(4.0)
 <			4.0
+
+                Parameters: ~
+                  • {expr} (`number`)
+
+                Return: ~
+                  (`integer`)
 
 type({expr})                                                            *type()*
 		The result is a Number representing the type of {expr}.
@@ -8704,6 +11407,13 @@ type({expr})                                                            *type()*
 			if myvar is v:null | endif
 <		To check if the v:t_ variables exist use this: >vim
 			if exists('v:t_number') | endif
+<
+
+                Parameters: ~
+                  • {expr} (`any`)
+
+                Return: ~
+                  (`integer`)
 
 undofile({name})                                                    *undofile()*
 		Return the name of the undo file that would be used for a file
@@ -8715,6 +11425,12 @@ undofile({name})                                                    *undofile()*
 		If {name} is empty undofile() returns an empty string, since a
 		buffer without a file name will not write an undo file.
 		Useful in combination with |:wundo| and |:rundo|.
+
+                Parameters: ~
+                  • {name} (`string`)
+
+                Return: ~
+                  (`string`)
 
 undotree([{buf}])                                                   *undotree()*
 		Return the current state of the undo tree for the current
@@ -8760,6 +11476,12 @@ undotree([{buf}])                                                   *undotree()*
 				blocks.  Each item may again have an "alt"
 				item.
 
+                Parameters: ~
+                  • {buf} (`integer|string?`)
+
+                Return: ~
+                  (`vim.fn.undotree.ret`)
+
 uniq({list} [, {func} [, {dict}]])                                 *uniq()* *E882*
 		Remove second and succeeding copies of repeated adjacent
 		{list} items in-place.  Returns {list}.  If you want a list
@@ -8769,6 +11491,14 @@ uniq({list} [, {func} [, {dict}]])                                 *uniq()* *E88
 		each item.  For the use of {func} and {dict} see |sort()|.
 
 		Returns zero if {list} is not a |List|.
+
+                Parameters: ~
+                  • {list} (`any`)
+                  • {func} (`any?`)
+                  • {dict} (`any?`)
+
+                Return: ~
+                  (`any[]|0`)
 
 utf16idx({string}, {idx} [, {countcc} [, {charidx}]])               *utf16idx()*
 		Same as |charidx()| but returns the UTF-16 code unit index of
@@ -8798,10 +11528,25 @@ utf16idx({string}, {idx} [, {countcc} [, {charidx}]])               *utf16idx()*
 			echo utf16idx('a😊😊', 9)	" returns -1
 <
 
+                Parameters: ~
+                  • {string} (`string`)
+                  • {idx} (`integer`)
+                  • {countcc} (`boolean?`)
+                  • {charidx} (`boolean?`)
+
+                Return: ~
+                  (`integer`)
+
 values({dict})                                                        *values()*
 		Return a |List| with all the values of {dict}.  The |List| is
 		in arbitrary order.  Also see |items()| and |keys()|.
 		Returns zero if {dict} is not a |Dict|.
+
+                Parameters: ~
+                  • {dict} (`any`)
+
+                Return: ~
+                  (`any`)
 
 virtcol({expr} [, {list} [, {winid}]])                               *virtcol()*
 		The result is a Number, which is the screen column of the file
@@ -8849,6 +11594,15 @@ virtcol({expr} [, {list} [, {winid}]])                               *virtcol()*
 		A more advanced example that echoes the maximum length of
 		all lines: >vim
 		    echo max(map(range(1, line('$')), "virtcol([v:val, '$'])"))
+<
+
+                Parameters: ~
+                  • {expr} (`string|integer[]`)
+                  • {list} (`boolean?`)
+                  • {winid} (`integer?`)
+
+                Return: ~
+                  (`any`)
 
 virtcol2col({winid}, {lnum}, {col})                              *virtcol2col()*
 		The result is a Number, which is the byte index of the
@@ -8872,6 +11626,14 @@ virtcol2col({winid}, {lnum}, {col})                              *virtcol2col()*
 
 		See also |screenpos()|, |virtcol()| and |col()|.
 
+                Parameters: ~
+                  • {winid} (`integer`)
+                  • {lnum} (`integer`)
+                  • {col} (`integer`)
+
+                Return: ~
+                  (`any`)
+
 visualmode([{expr}])                                              *visualmode()*
 		The result is a String, which describes the last Visual mode
 		used in the current buffer.  Initially it returns an empty
@@ -8890,6 +11652,12 @@ visualmode([{expr}])                                              *visualmode()*
 		a non-empty String, then the Visual mode will be cleared and
 		the old value is returned.  See |non-zero-arg|.
 
+                Parameters: ~
+                  • {expr} (`boolean?`)
+
+                Return: ~
+                  (`any`)
+
 wait({timeout}, {condition} [, {interval}])                             *wait()*
 		Waits until {condition} evaluates to |TRUE|, where {condition}
 		is a |Funcref| or |string| containing an expression.
@@ -8906,6 +11674,14 @@ wait({timeout}, {condition} [, {interval}])                             *wait()*
 			-2 if the function was interrupted (by |CTRL-C|)
 			-3 if an error occurred
 
+                Parameters: ~
+                  • {timeout} (`integer`)
+                  • {condition} (`any`)
+                  • {interval} (`number?`)
+
+                Return: ~
+                  (`any`)
+
 wildmenumode()                                                  *wildmenumode()*
 		Returns |TRUE| when the wildmenu is active and |FALSE|
 		otherwise.  See 'wildmenu' and 'wildmode'.
@@ -8916,6 +11692,9 @@ wildmenumode()                                                  *wildmenumode()*
 		    cnoremap <expr> <C-j> wildmenumode() ? "\<Down>\<Tab>" : "\<c-j>"
 <
 		(Note, this needs the 'wildcharm' option set appropriately).
+
+                Return: ~
+                  (`any`)
 
 win_execute({id}, {command} [, {silent}])                        *win_execute()*
 		Like `execute()` but in the context of window {id}.
@@ -8931,9 +11710,23 @@ win_execute({id}, {command} [, {silent}])                        *win_execute()*
 		When window {id} does not exist then no error is given and
 		an empty string is returned.
 
+                Parameters: ~
+                  • {id} (`integer`)
+                  • {command} (`string`)
+                  • {silent} (`boolean?`)
+
+                Return: ~
+                  (`any`)
+
 win_findbuf({bufnr})                                             *win_findbuf()*
 		Returns a |List| with |window-ID|s for windows that contain
 		buffer {bufnr}.  When there is none the list is empty.
+
+                Parameters: ~
+                  • {bufnr} (`integer`)
+
+                Return: ~
+                  (`integer[]`)
 
 win_getid([{win} [, {tab}]])                                       *win_getid()*
 		Get the |window-ID| for the specified window.
@@ -8943,6 +11736,13 @@ win_getid([{win} [, {tab}]])                                       *win_getid()*
 		Without {tab} use the current tab, otherwise the tab with
 		number {tab}.  The first tab has number one.
 		Return zero if the window cannot be found.
+
+                Parameters: ~
+                  • {win} (`integer?`)
+                  • {tab} (`integer?`)
+
+                Return: ~
+                  (`integer`)
 
 win_gettype([{nr}])                                              *win_gettype()*
 		Return the type of the window:
@@ -8962,19 +11762,43 @@ win_gettype([{nr}])                                              *win_gettype()*
 
 		Also see the 'buftype' option.
 
+                Parameters: ~
+                  • {nr} (`integer?`)
+
+                Return: ~
+                  (`'autocmd'|'command'|''|'loclist'|'popup'|'preview'|'quickfix'|'unknown'`)
+
 win_gotoid({expr})                                                *win_gotoid()*
 		Go to window with ID {expr}.  This may also change the current
 		tabpage.
 		Return TRUE if successful, FALSE if the window cannot be found.
+
+                Parameters: ~
+                  • {expr} (`integer`)
+
+                Return: ~
+                  (`0|1`)
 
 win_id2tabwin({expr})                                          *win_id2tabwin()*
 		Return a list with the tab number and window number of window
 		with ID {expr}: [tabnr, winnr].
 		Return [0, 0] if the window cannot be found.
 
+                Parameters: ~
+                  • {expr} (`integer`)
+
+                Return: ~
+                  (`any`)
+
 win_id2win({expr})                                                *win_id2win()*
 		Return the window number of window with ID {expr}.
 		Return 0 if the window cannot be found in the current tabpage.
+
+                Parameters: ~
+                  • {expr} (`integer`)
+
+                Return: ~
+                  (`any`)
 
 win_move_separator({nr}, {offset})                        *win_move_separator()*
 		Move window {nr}'s vertical separator (i.e., the right border)
@@ -8991,6 +11815,13 @@ win_move_separator({nr}, {offset})                        *win_move_separator()*
 		window, since it has no separator on the right.
 		Only works for the current tab page. *E1308*
 
+                Parameters: ~
+                  • {nr} (`integer`)
+                  • {offset} (`integer`)
+
+                Return: ~
+                  (`any`)
+
 win_move_statusline({nr}, {offset})                      *win_move_statusline()*
 		Move window {nr}'s status line (i.e., the bottom border) by
 		{offset} rows, as if being dragged by the mouse. {nr} can be a
@@ -9003,6 +11834,13 @@ win_move_statusline({nr}, {offset})                      *win_move_statusline()*
 		be found and FALSE otherwise.
 		Only works for the current tab page.
 
+                Parameters: ~
+                  • {nr} (`integer`)
+                  • {offset} (`integer`)
+
+                Return: ~
+                  (`any`)
+
 win_screenpos({nr})                                            *win_screenpos()*
 		Return the screen position of window {nr} as a list with two
 		numbers: [row, col].  The first window always has position
@@ -9010,6 +11848,12 @@ win_screenpos({nr})                                            *win_screenpos()*
 		{nr} can be the window number or the |window-ID|.  Use zero
 		for the current window.
 		Returns [0, 0] if the window cannot be found.
+
+                Parameters: ~
+                  • {nr} (`integer`)
+
+                Return: ~
+                  (`any`)
 
 win_splitmove({nr}, {target} [, {options}])                    *win_splitmove()*
 		Temporarily switch to window {target}, then move window {nr}
@@ -9031,6 +11875,14 @@ win_splitmove({nr}, {target} [, {options}])                    *win_splitmove()*
 				present, the values of 'splitbelow' and
 				'splitright' are used.
 
+                Parameters: ~
+                  • {nr} (`integer`)
+                  • {target} (`integer`)
+                  • {options} (`table?`)
+
+                Return: ~
+                  (`any`)
+
 winbufnr({nr})                                                      *winbufnr()*
 		The result is a Number, which is the number of the buffer
 		associated with window {nr}.  {nr} can be the window number or
@@ -9042,16 +11894,28 @@ winbufnr({nr})                                                      *winbufnr()*
 		  echo "The file in the current window is " .. bufname(winbufnr(0))
 <
 
+                Parameters: ~
+                  • {nr} (`integer`)
+
+                Return: ~
+                  (`integer`)
+
 wincol()                                                              *wincol()*
 		The result is a Number, which is the virtual column of the
 		cursor in the window.  This is counting screen cells from the
 		left side of the window.  The leftmost column is one.
+
+                Return: ~
+                  (`integer`)
 
 windowsversion()                                              *windowsversion()*
 		The result is a String.  For MS-Windows it indicates the OS
 		version.  E.g, Windows 10 is "10.0", Windows 8 is "6.2",
 		Windows XP is "5.1".  For non-MS-Windows systems the result is
 		an empty string.
+
+                Return: ~
+                  (`string`)
 
 winheight({nr})                                                    *winheight()*
 		The result is a Number, which is the height of window {nr}.
@@ -9062,6 +11926,13 @@ winheight({nr})                                                    *winheight()*
 		This excludes any window toolbar line.
 		Examples: >vim
 		  echo "The current window has " .. winheight(0) .. " lines."
+<
+
+                Parameters: ~
+                  • {nr} (`integer`)
+
+                Return: ~
+                  (`integer`)
 
 winlayout([{tabnr}])                                               *winlayout()*
 		The result is a nested List containing the layout of windows
@@ -9100,12 +11971,21 @@ winlayout([{tabnr}])                                               *winlayout()*
 					    ['leaf', 1001]]], ['leaf', 1000]]]
 <
 
+                Parameters: ~
+                  • {tabnr} (`integer?`)
+
+                Return: ~
+                  (`any`)
+
 winline()                                                            *winline()*
 		The result is a Number, which is the screen line of the cursor
 		in the window.  This is counting screen lines from the top of
 		the window.  The first line is one.
 		If the cursor was moved the view on the file will be updated
 		first, this may cause a scroll.
+
+                Return: ~
+                  (`integer`)
 
 winnr([{arg}])                                                         *winnr()*
 		The result is a Number, which is the number of the current
@@ -9137,6 +12017,13 @@ winnr([{arg}])                                                         *winnr()*
 			let window_count = winnr('$')
 			let prev_window = winnr('#')
 			let wnum = winnr('3k')
+<
+
+                Parameters: ~
+                  • {arg} (`string|integer?`)
+
+                Return: ~
+                  (`any`)
 
 winrestcmd()                                                      *winrestcmd()*
 		Returns a sequence of |:resize| commands that should restore
@@ -9148,6 +12035,9 @@ winrestcmd()                                                      *winrestcmd()*
 			call MessWithWindowSizes()
 			exe cmd
 <
+
+                Return: ~
+                  (`any`)
 
 winrestview({dict})                                              *winrestview()*
 		Uses the |Dictionary| returned by |winsaveview()| to restore
@@ -9164,6 +12054,12 @@ winrestview({dict})                                              *winrestview()*
 
 		If you have changed the values the result is unpredictable.
 		If the window size changed the result won't be the same.
+
+                Parameters: ~
+                  • {dict} (`vim.fn.winrestview.dict`)
+
+                Return: ~
+                  (`any`)
 
 winsaveview()                                                    *winsaveview()*
 		Returns a |Dictionary| that contains information to restore
@@ -9192,6 +12088,9 @@ winsaveview()                                                    *winsaveview()*
 			skipcol		columns skipped
 		Note that no option values are saved.
 
+                Return: ~
+                  (`vim.fn.winsaveview.ret`)
+
 winwidth({nr})                                                      *winwidth()*
 		The result is a Number, which is the width of window {nr}.
 		{nr} can be the window number or the |window-ID|.
@@ -9205,6 +12104,12 @@ winwidth({nr})                                                      *winwidth()*
 		  endif
 <		For getting the terminal or screen size, see the 'columns'
 		option.
+
+                Parameters: ~
+                  • {nr} (`integer`)
+
+                Return: ~
+                  (`any`)
 
 wordcount()                                                        *wordcount()*
 		The result is a dictionary of byte/chars/word statistics for
@@ -9226,6 +12131,9 @@ wordcount()                                                        *wordcount()*
 					(only in Visual mode)
 			visual_words    Number of words visually selected
 					(only in Visual mode)
+
+                Return: ~
+                  (`any`)
 
 writefile({object}, {fname} [, {flags}])                           *writefile()*
 		When {object} is a |List| write it to file {fname}.  Each list
@@ -9272,6 +12180,15 @@ writefile({object}, {fname} [, {flags}])                           *writefile()*
 		To copy a file byte for byte: >vim
 			let fl = readfile("foo", "b")
 			call writefile(fl, "foocopy", "b")
+<
+
+                Parameters: ~
+                  • {object} (`any`)
+                  • {fname} (`string`)
+                  • {flags} (`string?`)
+
+                Return: ~
+                  (`any`)
 
 xor({expr}, {expr})                                                      *xor()*
 		Bitwise XOR on the two arguments.  The arguments are converted
@@ -9280,6 +12197,13 @@ xor({expr}, {expr})                                                      *xor()*
 		Example: >vim
 			let bits = xor(bits, 0x80)
 <
+
+                Parameters: ~
+                  • {expr} (`number`)
+                  • {expr1} (`number`)
+
+                Return: ~
+                  (`any`)
 
 ==============================================================================
 2. Matching a pattern in a String			*string-match*

--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -173,6 +173,7 @@ FUNCTIONS
 - *jobclose()*		Obsolete name for |chanclose()|
 - *jobsend()*		Obsolete name for |chansend()|
 - *last_buffer_nr()*	Obsolete name for bufnr("$").
+- *rpcstart()*		Use |jobstart()| with `{'rpc': v:true}` instead.
 - *rpcstop()*		Use |jobstop()| instead to stop any job, or
 			`chanclose(id, "rpc")` to close RPC communication
 			without stopping the job. Use chanclose(id) to close

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -47,7 +47,7 @@ function vim.fn.acos(expr) end
 ---
 --- @param object any
 --- @param expr any
---- @return any
+--- @return any # Resulting |List| or |Blob|, or 1 if {object} is not a |List| or a |Blob|.
 function vim.fn.add(object, expr) end
 
 --- Bitwise AND on the two arguments.  The arguments are converted
@@ -110,7 +110,7 @@ function vim.fn.append(lnum, text) end
 --- <However, when {text} is an empty list then no error is given
 --- for an invalid {lnum}, since {lnum} isn't actually used.
 ---
---- @param buf any
+--- @param buf integer|string
 --- @param lnum integer
 --- @param text string
 --- @return 0|1
@@ -195,7 +195,7 @@ function vim.fn.asin(expr) end
 --- Also see |assert_fails()|, |assert_nobeep()| and
 --- |assert-return|.
 ---
---- @param cmd any
+--- @param cmd string
 --- @return 0|1
 function vim.fn.assert_beeps(cmd) end
 
@@ -227,8 +227,10 @@ function vim.fn.assert_equal(expected, actual, msg) end
 --- When {fname-one} or {fname-two} does not exist the error will
 --- mention that.
 ---
+--- @param fname-one string
+--- @param fname-two string
 --- @return 0|1
-function vim.fn.assert_equalfile() end
+function vim.fn.assert_equalfile(fname-one, fname-two) end
 
 --- When v:exception does not contain the string {error} an error
 --- message is added to |v:errors|.  Also see |assert-return|.
@@ -281,7 +283,7 @@ function vim.fn.assert_exception(error, msg) end
 --- Note that beeping is not considered an error, and some failing
 --- commands only beep.  Use |assert_beeps()| for those.
 ---
---- @param cmd any
+--- @param cmd string
 --- @param error? any
 --- @param msg? any
 --- @param lnum? integer
@@ -311,10 +313,10 @@ function vim.fn.assert_false(actual, msg) end
 --- but got {actual}".  When {msg} is present it is prefixed to
 --- that.
 ---
---- @param lower any
---- @param upper any
---- @param actual any
---- @param msg? any
+--- @param lower number
+--- @param upper number
+--- @param actual number
+--- @param msg? string
 --- @return 0|1
 function vim.fn.assert_inrange(lower, upper, actual, msg) end
 
@@ -337,9 +339,9 @@ function vim.fn.assert_inrange(lower, upper, actual, msg) end
 --- <Will result in a string to be added to |v:errors|:
 ---   test.vim line 12: Pattern '^f.*o$' does not match 'foobar' ~
 ---
---- @param pattern any
---- @param actual any
---- @param msg? any
+--- @param pattern string
+--- @param actual string
+--- @param msg? string
 --- @return 0|1
 function vim.fn.assert_match(pattern, actual, msg) end
 
@@ -347,7 +349,7 @@ function vim.fn.assert_match(pattern, actual, msg) end
 --- produces a beep or visual bell.
 --- Also see |assert_beeps()|.
 ---
---- @param cmd any
+--- @param cmd string
 --- @return 0|1
 function vim.fn.assert_nobeep(cmd) end
 
@@ -365,16 +367,16 @@ function vim.fn.assert_notequal(expected, actual, msg) end
 --- |v:errors| when {pattern} matches {actual}.
 --- Also see |assert-return|.
 ---
---- @param pattern any
---- @param actual any
---- @param msg? any
+--- @param pattern string
+--- @param actual string
+--- @param msg? string
 --- @return 0|1
 function vim.fn.assert_notmatch(pattern, actual, msg) end
 
 --- Report a test failure directly, using String {msg}.
 --- Always returns one.
 ---
---- @param msg any
+--- @param msg string
 --- @return 0|1
 function vim.fn.assert_report(msg) end
 
@@ -387,7 +389,7 @@ function vim.fn.assert_report(msg) end
 --- along with the location of the assert when run from a script.
 ---
 --- @param actual any
---- @param msg? any
+--- @param msg? string
 --- @return 0|1
 function vim.fn.assert_true(actual, msg) end
 
@@ -401,7 +403,7 @@ function vim.fn.assert_true(actual, msg) end
 ---   echo atan(-4.01)
 --- <  -1.326405
 ---
---- @param expr any
+--- @param expr number
 --- @return number
 function vim.fn.atan(expr) end
 
@@ -416,8 +418,8 @@ function vim.fn.atan(expr) end
 ---   echo atan2(1, -1)
 --- <  2.356194
 ---
---- @param expr1 any
---- @param expr2 any
+--- @param expr1 number
+--- @param expr2 number
 --- @return number
 function vim.fn.atan2(expr1, expr2) end
 
@@ -443,9 +445,9 @@ function vim.fn.blob2list(blob) end
 --- something went wrong, or browsing is not possible.
 ---
 --- @param save any
---- @param title any
---- @param initdir any
---- @param default any
+--- @param title string
+--- @param initdir string
+--- @param default string
 --- @return 0|1
 function vim.fn.browse(save, title, initdir, default) end
 
@@ -460,8 +462,8 @@ function vim.fn.browse(save, title, initdir, default) end
 --- When the "Cancel" button is hit, something went wrong, or
 --- browsing is not possible, an empty string is returned.
 ---
---- @param title any
---- @param initdir any
+--- @param title string
+--- @param initdir string
 --- @return 0|1
 function vim.fn.browsedir(title, initdir) end
 
@@ -733,7 +735,7 @@ function vim.fn.call(func, arglist, dict) end
 ---
 --- Returns 0.0 if {expr} is not a |Float| or a |Number|.
 ---
---- @param expr any
+--- @param expr number
 --- @return number
 function vim.fn.ceil(expr) end
 
@@ -746,8 +748,8 @@ function vim.fn.ceil(expr) end
 --- For a socket, there is only one stream, and {stream} should be
 --- omitted.
 ---
---- @param id any
---- @param stream? any
+--- @param id integer
+--- @param stream? string
 --- @return 0|1
 function vim.fn.chanclose(id, stream) end
 
@@ -779,8 +781,8 @@ function vim.fn.changenr() end
 --- was created with `"rpc":v:true` then the channel expects RPC
 --- messages, use |rpcnotify()| and |rpcrequest()| instead.
 ---
---- @param id any
---- @param data any
+--- @param id number
+--- @param data string|string[]
 --- @return 0|1
 function vim.fn.chansend(id, data) end
 
@@ -824,8 +826,9 @@ function vim.fn.charclass(string) end
 --- With the cursor on '세' in line 5 with text "여보세요": >vim
 ---   echo charcol('.')  " returns 3
 ---   echo col('.')    " returns 7
+--- <
 ---
---- @param expr any
+--- @param expr string|integer[]
 --- @param winid? integer
 --- @return integer
 function vim.fn.charcol(expr, winid) end
@@ -865,8 +868,8 @@ function vim.fn.charcol(expr, winid) end
 ---
 --- @param string string
 --- @param idx integer
---- @param countcc? any
---- @param utf16? any
+--- @param countcc? boolean
+--- @param utf16? boolean
 --- @return integer
 function vim.fn.charidx(string, idx, countcc, utf16) end
 
@@ -890,6 +893,7 @@ function vim.fn.charidx(string, idx, countcc, utf16) end
 ---      " ... do some work
 ---      call chdir(save_dir)
 ---   endif
+--- <
 ---
 --- @param dir string
 --- @return string
@@ -911,7 +915,7 @@ function vim.fn.cindent(lnum) end
 --- If {win} is specified, use the window with this number or
 --- window ID instead of the current window.
 ---
---- @param win? any
+--- @param win? integer
 function vim.fn.clearmatches(win) end
 
 --- The result is a Number, which is the byte index of the column
@@ -950,8 +954,9 @@ function vim.fn.clearmatches(win) end
 --- line.  Also, when using a <Cmd> mapping the cursor isn't
 --- moved, this can be used to obtain the column in Insert mode: >vim
 ---   imap <F2> <Cmd>echo col(".").."\n"<CR>
+--- <
 ---
---- @param expr any
+--- @param expr string|integer[]
 --- @param winid? integer
 --- @return integer
 function vim.fn.col(expr, winid) end
@@ -985,8 +990,8 @@ function vim.fn.col(expr, winid) end
 --- <This isn't very useful, but it shows how it works.  Note that
 --- an empty string is returned to avoid a zero being inserted.
 ---
---- @param startcol any
---- @param matches any
+--- @param startcol integer
+--- @param matches any[]
 function vim.fn.complete(startcol, matches) end
 
 --- Add {expr} to the list of matches.  Only to be used by the
@@ -1069,8 +1074,9 @@ function vim.fn.complete_check() end
 ---   call complete_info(['mode'])
 ---   " Get only 'mode' and 'pum_visible'
 ---   call complete_info(['mode', 'pum_visible'])
+--- <
 ---
---- @param what? any
+--- @param what? any[]
 --- @return table
 function vim.fn.complete_info(what) end
 
@@ -1125,10 +1131,10 @@ function vim.fn.complete_info(what) end
 --- don't fit, a vertical layout is used anyway.  For some systems
 --- the horizontal layout is always used.
 ---
---- @param msg any
---- @param choices? any
---- @param default? any
---- @param type? any
+--- @param msg string
+--- @param choices? string
+--- @param default? integer
+--- @param type? string
 --- @return integer
 function vim.fn.confirm(msg, choices, default, type) end
 
@@ -1154,7 +1160,7 @@ function vim.fn.copy(expr) end
 ---   echo cos(-4.01)
 --- <  -0.646043
 ---
---- @param expr any
+--- @param expr number
 --- @return number
 function vim.fn.cos(expr) end
 
@@ -1168,7 +1174,7 @@ function vim.fn.cos(expr) end
 ---   echo cosh(-0.5)
 --- <  -1.127626
 ---
---- @param expr any
+--- @param expr number
 --- @return number
 function vim.fn.cosh(expr) end
 
@@ -1184,10 +1190,10 @@ function vim.fn.cosh(expr) end
 --- occurrences of {expr} is returned. Zero is returned when
 --- {expr} is an empty string.
 ---
---- @param comp any
+--- @param comp string|table|any[]
 --- @param expr any
---- @param ic? any
---- @param start? any
+--- @param ic? boolean
+--- @param start? integer
 --- @return integer
 function vim.fn.count(comp, expr, ic, start) end
 
@@ -1195,7 +1201,7 @@ function vim.fn.count(comp, expr, ic, start) end
 --- from the top of the |context-stack| (see |context-dict|).
 --- If {index} is not given, it is assumed to be 0 (i.e.: top).
 ---
---- @param index? any
+--- @param index? integer
 --- @return table
 function vim.fn.ctxget(index) end
 
@@ -1211,7 +1217,7 @@ function vim.fn.ctxpop() end
 --- which |context-types| to include in the pushed context.
 --- Otherwise, all context types are included.
 ---
---- @param types? any
+--- @param types? string[]
 --- @return any
 function vim.fn.ctxpush(types) end
 
@@ -1220,8 +1226,8 @@ function vim.fn.ctxpush(types) end
 --- {context} is a Dictionary with context data (|context-dict|).
 --- If {index} is not given, it is assumed to be 0 (i.e.: top).
 ---
---- @param context any
---- @param index? any
+--- @param context table
+--- @param index? integer
 --- @return any
 function vim.fn.ctxset(context, index) end
 
@@ -1232,7 +1238,7 @@ function vim.fn.ctxsize() end
 
 --- @param lnum integer
 --- @param col? integer
---- @param off? any
+--- @param off? integer
 --- @return any
 function vim.fn.cursor(lnum, col, off) end
 
@@ -1267,7 +1273,7 @@ function vim.fn.cursor(lnum, col, off) end
 --- position within a <Tab> or after the last character.
 --- Returns 0 when the position could be set, -1 otherwise.
 ---
---- @param list any
+--- @param list integer[]
 --- @return any
 function vim.fn.cursor(list) end
 
@@ -1279,7 +1285,7 @@ function vim.fn.cursor(list) end
 --- Returns |TRUE| if successfully interrupted the program.
 --- Otherwise returns |FALSE|.
 ---
---- @param pid any
+--- @param pid integer
 --- @return any
 function vim.fn.debugbreak(pid) end
 
@@ -1303,7 +1309,7 @@ function vim.fn.debugbreak(pid) end
 --- Also see |copy()|.
 ---
 --- @param expr any
---- @param noref? any
+--- @param noref? boolean
 --- @return any
 function vim.fn.deepcopy(expr, noref) end
 
@@ -1343,9 +1349,9 @@ function vim.fn.delete(fname, flags) end
 --- when using |line()| this refers to the current buffer. Use "$"
 --- to refer to the last line in buffer {buf}.
 ---
---- @param buf any
---- @param first any
---- @param last? any
+--- @param buf integer|string
+--- @param first integer|string
+--- @param last? integer|string
 --- @return any
 function vim.fn.deletebufline(buf, first, last) end
 
@@ -1388,9 +1394,9 @@ function vim.fn.deletebufline(buf, first, last) end
 --- This function can be used by plugins to implement options with
 --- validation and parsing logic.
 ---
---- @param dict any
---- @param pattern any
---- @param callback any
+--- @param dict table
+--- @param pattern string
+--- @param callback function
 --- @return any
 function vim.fn.dictwatcheradd(dict, pattern, callback) end
 
@@ -1399,8 +1405,8 @@ function vim.fn.dictwatcheradd(dict, pattern, callback) end
 --- order for the watcher to be successfully deleted.
 ---
 --- @param dict any
---- @param pattern any
---- @param callback any
+--- @param pattern string
+--- @param callback function
 --- @return any
 function vim.fn.dictwatcherdel(dict, pattern, callback) end
 
@@ -1461,7 +1467,7 @@ function vim.fn.diff_hlID(lnum, col) end
 --- echo digraph_get('aa')    " Returns 'あ'
 --- <
 ---
---- @param chars any
+--- @param chars string
 --- @return any
 function vim.fn.digraph_get(chars) end
 
@@ -1479,7 +1485,7 @@ function vim.fn.digraph_get(chars) end
 --- echo digraph_getlist(1)
 --- <
 ---
---- @param listall? any
+--- @param listall? boolean
 --- @return any
 function vim.fn.digraph_getlist(listall) end
 
@@ -1499,12 +1505,9 @@ function vim.fn.digraph_getlist(listall) end
 --- Example: >vim
 ---   call digraph_set('  ', 'あ')
 --- <
---- Can be used as a |method|: >vim
----   GetString()->digraph_set('あ')
---- <
 ---
---- @param chars any
---- @param digraph any
+--- @param chars string
+--- @param digraph string
 --- @return any
 function vim.fn.digraph_set(chars, digraph) end
 
@@ -1522,11 +1525,7 @@ function vim.fn.digraph_set(chars, digraph) end
 --- <Except that the function returns after the first error,
 --- following digraphs will not be added.
 ---
---- Can be used as a |method|: >vim
----     GetList()->digraph_setlist()
---- <
----
---- @param digraphlist any
+--- @param digraphlist table<integer,string[]>
 --- @return any
 function vim.fn.digraph_setlist(digraphlist) end
 
@@ -1561,7 +1560,7 @@ function vim.fn.environ() end
 --- <Also see |shellescape()| and |fnameescape()|.
 ---
 --- @param string string
---- @param chars any
+--- @param chars string
 --- @return any
 function vim.fn.escape(string, chars) end
 
@@ -1611,7 +1610,7 @@ function vim.fn.eventhandler() end
 ---   0  does not exist
 --- |exepath()| can be used to get the full path of an executable.
 ---
---- @param expr any
+--- @param expr string
 --- @return 0|1
 function vim.fn.executable(expr) end
 
@@ -1652,7 +1651,7 @@ function vim.fn.execute(command, silent) end
 --- Returns empty string otherwise.
 --- If {expr} starts with "./" the |current-directory| is used.
 ---
---- @param expr any
+--- @param expr string
 --- @return string
 function vim.fn.exepath(expr) end
 
@@ -1744,7 +1743,7 @@ function vim.fn.exepath(expr) end
 --- <This doesn't check for existence of the "bufcount" variable,
 --- but gets the value of "bufcount", and checks if that exists.
 ---
---- @param expr any
+--- @param expr string
 --- @return 0|1
 function vim.fn.exists(expr) end
 
@@ -1758,7 +1757,7 @@ function vim.fn.exists(expr) end
 ---   echo exp(-1)
 --- <  0.367879
 ---
---- @param expr any
+--- @param expr number
 --- @return any
 function vim.fn.exp(expr) end
 
@@ -1927,9 +1926,9 @@ function vim.fn.expandcmd(string, options) end
 --- fails.
 --- Returns {expr1}.  Returns 0 on error.
 ---
---- @param expr1 any
---- @param expr2 any
---- @param expr3? any
+--- @param expr1 table
+--- @param expr2 table
+--- @param expr3? table
 --- @return any
 function vim.fn.extend(expr1, expr2, expr3) end
 
@@ -1937,9 +1936,9 @@ function vim.fn.extend(expr1, expr2, expr3) end
 --- List or Dictionary is created and returned.  {expr1} remains
 --- unchanged.
 ---
---- @param expr1 any
---- @param expr2 any
---- @param expr3? any
+--- @param expr1 table
+--- @param expr2 table
+--- @param expr3? table
 --- @return any
 function vim.fn.extendnew(expr1, expr2, expr3) end
 
@@ -2094,8 +2093,8 @@ function vim.fn.filewritable(file) end
 --- When {expr2} is a Funcref errors inside a function are ignored,
 --- unless it was defined with the "abort" flag.
 ---
---- @param expr1 any
---- @param expr2 any
+--- @param expr1 string|table
+--- @param expr2 string|function
 --- @return any
 function vim.fn.filter(expr1, expr2) end
 
@@ -2118,7 +2117,7 @@ function vim.fn.filter(expr1, expr2) end
 ---
 --- @param name string
 --- @param path? string
---- @param count? any
+--- @param count? integer
 --- @return any
 function vim.fn.finddir(name, path, count) end
 
@@ -2153,15 +2152,15 @@ function vim.fn.findfile(name, path, count) end
 ---   echo flatten([1, [2, [3, 4]], 5], 1)
 --- <  [1, 2, [3, 4], 5]
 ---
---- @param list any
---- @param maxdepth? any
+--- @param list any[]
+--- @param maxdepth? integer
 --- @return any[]|0
 function vim.fn.flatten(list, maxdepth) end
 
 --- Like |flatten()| but first make a copy of {list}.
 ---
---- @param list any
---- @param maxdepth? any
+--- @param list any[]
+--- @param maxdepth? integer
 --- @return any[]|0
 function vim.fn.flattennew(list, maxdepth) end
 
@@ -2186,7 +2185,7 @@ function vim.fn.flattennew(list, maxdepth) end
 ---   echo float2nr(1.0e-100)
 --- <  0
 ---
---- @param expr any
+--- @param expr number
 --- @return any
 function vim.fn.float2nr(expr) end
 
@@ -2202,7 +2201,7 @@ function vim.fn.float2nr(expr) end
 ---   echo floor(4.0)
 --- <  4.0
 ---
---- @param expr any
+--- @param expr number
 --- @return any
 function vim.fn.floor(expr) end
 
@@ -2221,8 +2220,8 @@ function vim.fn.floor(expr) end
 ---   echo fmod(-12.33, 1.22)
 --- <  -0.13
 ---
---- @param expr1 any
---- @param expr2 any
+--- @param expr1 number
+--- @param expr2 number
 --- @return any
 function vim.fn.fmod(expr1, expr2) end
 
@@ -2367,8 +2366,8 @@ function vim.fn.foldtextresult(lnum) end
 --- When {expr2} is a Funcref errors inside a function are ignored,
 --- unless it was defined with the "abort" flag.
 ---
---- @param expr1 any
---- @param expr2 any
+--- @param expr1 string|table
+--- @param expr2 string|function
 --- @return any
 function vim.fn.foreach(expr1, expr2) end
 
@@ -2510,7 +2509,7 @@ vim.fn['function'] = function(name, arglist, dict) end
 --- it's safe to perform.  This is when waiting for the user to
 --- type a character.
 ---
---- @param atexit? any
+--- @param atexit? boolean
 --- @return any
 function vim.fn.garbagecollect(atexit) end
 
@@ -2671,8 +2670,9 @@ function vim.fn.getbufinfo(dict) end
 ---
 --- Example: >vim
 ---   let lines = getbufline(bufnr("myfile"), 1, "$")
+--- <
 ---
---- @param buf any
+--- @param buf integer|string
 --- @param lnum integer
 --- @param end_? integer
 --- @return any
@@ -2706,7 +2706,7 @@ function vim.fn.getbufoneline(buf, lnum) end
 ---   let bufmodified = getbufvar(1, "&mod")
 ---   echo "todo myvar = " .. getbufvar("todo", "myvar")
 ---
---- @param buf any
+--- @param buf integer|string
 --- @param varname string
 --- @param def? any
 --- @return any
@@ -2838,7 +2838,7 @@ function vim.fn.getcharmod() end
 ---   getpos('.')    returns [0, 5, 7, 0]
 --- <
 ---
---- @param expr any
+--- @param expr string
 --- @return integer[]
 function vim.fn.getcharpos(expr) end
 
@@ -3029,9 +3029,9 @@ function vim.fn.getcmdwintype() end
 --- If there are no matches, an empty list is returned.  An
 --- invalid value for {type} produces an error.
 ---
---- @param pat any
---- @param type any
---- @param filtered? any
+--- @param pat string
+--- @param type string
+--- @param filtered? boolean
 --- @return string[]
 function vim.fn.getcompletion(pat, type, filtered) end
 
@@ -3277,7 +3277,7 @@ function vim.fn.getline(lnum, end_) end
 --- <
 ---
 --- @param nr integer
---- @param what? any
+--- @param what? table
 --- @return any
 function vim.fn.getloclist(nr, what) end
 
@@ -3334,7 +3334,7 @@ function vim.fn.getmarklist(buf) end
 ---   unlet m
 --- <
 ---
---- @param win? any
+--- @param win? integer
 --- @return any
 function vim.fn.getmatches(win) end
 
@@ -3542,7 +3542,7 @@ function vim.fn.getpos(expr) end
 ---   echo getqflist({'lines' : ["F1:10:L10"]})
 --- <
 ---
---- @param what? any
+--- @param what? table
 --- @return any
 function vim.fn.getqflist(what) end
 
@@ -3857,7 +3857,7 @@ function vim.fn.gettagstack(winnr) end
 --- xgettext does not understand escaping in single quoted
 --- strings.
 ---
---- @param text any
+--- @param text string
 --- @return any
 function vim.fn.gettext(text) end
 
@@ -3984,10 +3984,10 @@ function vim.fn.getwinvar(winnr, varname, def) end
 --- See |expand()| for expanding special Vim variables.  See
 --- |system()| for getting the raw output of an external command.
 ---
---- @param expr any
+--- @param expr string
 --- @param nosuf? boolean
---- @param list? any
---- @param alllinks? any
+--- @param list? boolean
+--- @param alllinks? boolean
 --- @return any
 function vim.fn.glob(expr, nosuf, list, alllinks) end
 
@@ -4045,10 +4045,10 @@ function vim.fn.glob2regpat(string) end
 --- supported, thus using 'path' will not always work properly.
 ---
 --- @param path string
---- @param expr any
+--- @param expr string
 --- @param nosuf? boolean
---- @param list? any
---- @param allinks? any
+--- @param list? boolean
+--- @param allinks? boolean
 --- @return any
 function vim.fn.globpath(path, expr, nosuf, list, allinks) end
 
@@ -4119,7 +4119,7 @@ function vim.fn.globpath(path, expr, nosuf, list, allinks) end
 ---   endif
 --- <
 ---
---- @param feature any
+--- @param feature string
 --- @return 0|1
 function vim.fn.has(feature) end
 
@@ -4127,8 +4127,8 @@ function vim.fn.has(feature) end
 --- has an entry with key {key}.  FALSE otherwise. The {key}
 --- argument is a string.
 ---
---- @param dict any
---- @param key any
+--- @param dict table
+--- @param key string
 --- @return 0|1
 function vim.fn.has_key(dict, key) end
 
@@ -4185,7 +4185,7 @@ function vim.fn.haslocaldir(winnr, tabnr) end
 ---
 --- @param what any
 --- @param mode? string
---- @param abbr? any
+--- @param abbr? boolean
 --- @return 0|1
 function vim.fn.hasmapto(what, mode, abbr) end
 
@@ -4223,7 +4223,7 @@ function vim.fn.highlight_exists(name) end
 ---   let date=input("Enter date: ")
 --- <This function is not available in the |sandbox|.
 ---
---- @param history any
+--- @param history string
 --- @param item any
 --- @return 0|1
 function vim.fn.histadd(history, item) end
@@ -4260,7 +4260,7 @@ function vim.fn.histadd(history, item) end
 ---   let \@/ = histget("search", -1)
 --- <
 ---
---- @param history any
+--- @param history string
 --- @param item? any
 --- @return 0|1
 function vim.fn.histdel(history, item) end
@@ -4280,8 +4280,8 @@ function vim.fn.histdel(history, item) end
 ---   command -nargs=1 H execute histget("cmd", 0+<args>)
 --- <
 ---
---- @param history any
---- @param index? any
+--- @param history string
+--- @param index? integer|string
 --- @return string
 function vim.fn.histget(history, index) end
 
@@ -4291,8 +4291,9 @@ function vim.fn.histget(history, index) end
 ---
 --- Example: >vim
 ---   let inp_index = histnr("expr")
+--- <
 ---
---- @param history any
+--- @param history string
 --- @return integer
 function vim.fn.histnr(history) end
 
@@ -4338,8 +4339,8 @@ function vim.fn.hostname() end
 --- cannot use UCS-2 in a string anyway, because of the NUL bytes.
 ---
 --- @param string string
---- @param from any
---- @param to any
+--- @param from string
+--- @param to string
 --- @return any
 function vim.fn.iconv(string, from, to) end
 
@@ -4398,11 +4399,12 @@ function vim.fn.indent(lnum) end
 ---   if index(numbers, 123) >= 0
 ---     " ...
 ---   endif
+--- <
 ---
 --- @param object any
 --- @param expr any
---- @param start? any
---- @param ic? any
+--- @param start? integer
+--- @param ic? boolean
 --- @return any
 function vim.fn.index(object, expr, start, ic) end
 
@@ -4442,6 +4444,7 @@ function vim.fn.index(object, expr, start, ic) end
 ---   echo indexof(l, "v:val.n == 20")
 ---   echo indexof(l, {i, v -> v.n == 30})
 ---   echo indexof(l, "v:val.n == 20", #{startidx: 1})
+--- <
 ---
 --- @param object any
 --- @param expr any
@@ -4450,9 +4453,9 @@ function vim.fn.index(object, expr, start, ic) end
 function vim.fn.indexof(object, expr, opts) end
 
 ---
---- @param prompt any
---- @param text? any
---- @param completion? any
+--- @param prompt string
+--- @param text? string
+--- @param completion? string
 --- @return any
 function vim.fn.input(prompt, text, completion) end
 
@@ -4564,6 +4567,7 @@ function vim.fn.input(prompt, text, completion) end
 ---     let g:Foo = input("enter search pattern: ")
 ---     call inputrestore()
 ---   endfunction
+--- <
 ---
 --- @param opts table
 --- @return any
@@ -4592,7 +4596,7 @@ function vim.fn.inputdialog(...) end
 ---   let color = inputlist(['Select color:', '1. red',
 ---     \ '2. green', '3. blue'])
 ---
---- @param textlist any
+--- @param textlist string[]
 --- @return any
 function vim.fn.inputlist(textlist) end
 
@@ -4624,8 +4628,8 @@ function vim.fn.inputsave() end
 --- typed on the command-line in response to the issued prompt.
 --- NOTE: Command-line completion is not supported.
 ---
---- @param prompt any
---- @param text? any
+--- @param prompt string
+--- @param text? string
 --- @return any
 function vim.fn.inputsecret(prompt, text) end
 
@@ -4672,7 +4676,7 @@ function vim.fn.interrupt() end
 ---   let bits = invert(bits)
 --- <
 ---
---- @param expr any
+--- @param expr number
 --- @return any
 function vim.fn.invert(expr) end
 
@@ -4690,7 +4694,7 @@ function vim.fn.invert(expr) end
 ---   echo isabsolutepath('\\remote\file')  " 1
 --- <
 ---
---- @param path any
+--- @param path string
 --- @return 0|1
 function vim.fn.isabsolutepath(path) end
 
@@ -4699,7 +4703,7 @@ function vim.fn.isabsolutepath(path) end
 --- exist, or isn't a directory, the result is |FALSE|.  {directory}
 --- is any expression, which is used as a String.
 ---
---- @param directory any
+--- @param directory string
 --- @return 0|1
 function vim.fn.isdirectory(directory) end
 
@@ -4710,7 +4714,7 @@ function vim.fn.isdirectory(directory) end
 ---   echo isinf(-1.0 / 0.0)
 --- <  -1
 ---
---- @param expr any
+--- @param expr number
 --- @return 1|0|-1
 function vim.fn.isinf(expr) end
 
@@ -4735,7 +4739,7 @@ function vim.fn.islocked(expr) end
 ---   echo isnan(0.0 / 0.0)
 --- <  1
 ---
---- @param expr any
+--- @param expr number
 --- @return 0|1
 function vim.fn.isnan(expr) end
 
@@ -4765,7 +4769,7 @@ function vim.fn.jobclose(...) end
 
 --- Return the PID (process id) of |job-id| {job}.
 ---
---- @param job any
+--- @param job integer
 --- @return integer
 function vim.fn.jobpid(job) end
 
@@ -4773,7 +4777,7 @@ function vim.fn.jobpid(job) end
 --- columns and {height} rows.
 --- Fails if the job was not started with `"pty":v:true`.
 ---
---- @param job any
+--- @param job integer
 --- @param width integer
 --- @param height integer
 --- @return any
@@ -4871,7 +4875,7 @@ function vim.fn.jobsend(...) end
 ---   - -1 if {cmd}[0] is not executable.
 --- See also |job-control|, |channel|, |msgpack-rpc|.
 ---
---- @param cmd any
+--- @param cmd string|string[]
 --- @param opts? table
 --- @return any
 function vim.fn.jobstart(cmd, opts) end
@@ -4885,7 +4889,7 @@ function vim.fn.jobstart(cmd, opts) end
 --- Returns 1 for valid job id, 0 for invalid id, including jobs have
 --- exited or stopped.
 ---
---- @param id any
+--- @param id integer
 --- @return any
 function vim.fn.jobstop(id) end
 
@@ -4909,7 +4913,7 @@ function vim.fn.jobstop(id) end
 ---   -2 if the job was interrupted (by |CTRL-C|)
 ---   -3 if the job-id is invalid
 ---
---- @param jobs any
+--- @param jobs integer[]
 --- @param timeout? integer
 --- @return any
 function vim.fn.jobwait(jobs, timeout) end
@@ -4924,8 +4928,8 @@ function vim.fn.jobwait(jobs, timeout) end
 --- converted into a string like with |string()|.
 --- The opposite function is |split()|.
 ---
---- @param list any
---- @param sep? any
+--- @param list any[]
+--- @param sep? string
 --- @return any
 function vim.fn.join(list, sep) end
 
@@ -4965,7 +4969,7 @@ function vim.fn.json_encode(expr) end
 --- Return a |List| with all the keys of {dict}.  The |List| is in
 --- arbitrary order.  Also see |items()| and |values()|.
 ---
---- @param dict any
+--- @param dict table
 --- @return any
 function vim.fn.keys(dict) end
 
@@ -5079,7 +5083,7 @@ function vim.fn.libcallnr(libname, funcname, argument) end
 --- To jump to the last known position when opening a file see
 --- |last-position-jump|.
 ---
---- @param expr any
+--- @param expr string|integer[]
 --- @param winid? integer
 --- @return integer
 function vim.fn.line(expr, winid) end
@@ -5119,7 +5123,7 @@ function vim.fn.lispindent(lnum) end
 ---
 --- |blob2list()| does the opposite.
 ---
---- @param list any
+--- @param list any[]
 --- @return any
 function vim.fn.list2blob(list) end
 
@@ -5138,8 +5142,8 @@ function vim.fn.list2blob(list) end
 --- <
 --- Returns an empty string on error.
 ---
---- @param list any
---- @param utf8? any
+--- @param list any[]
+--- @param utf8? boolean
 --- @return any
 function vim.fn.list2str(list, utf8) end
 
@@ -5159,7 +5163,7 @@ function vim.fn.localtime() end
 ---   echo log(exp(5))
 --- <  5.0
 ---
---- @param expr any
+--- @param expr number
 --- @return any
 function vim.fn.log(expr) end
 
@@ -5172,7 +5176,7 @@ function vim.fn.log(expr) end
 ---   echo log10(0.01)
 --- <  -2.0
 ---
---- @param expr any
+--- @param expr number
 --- @return any
 function vim.fn.log10(expr) end
 
@@ -5229,8 +5233,8 @@ function vim.fn.log10(expr) end
 --- When {expr2} is a Funcref errors inside a function are ignored,
 --- unless it was defined with the "abort" flag.
 ---
---- @param expr1 any
---- @param expr2 any
+--- @param expr1 string|table|any[]
+--- @param expr2 string|function
 --- @return any
 function vim.fn.map(expr1, expr2) end
 
@@ -5305,6 +5309,7 @@ function vim.fn.map(expr1, expr2) end
 --- This function can be used to map a key even when it's already
 --- mapped, and have it do the original mapping too.  Sketch: >vim
 ---   exe 'nnoremap <Tab> ==' .. maparg('<Tab>', 'n')
+--- <
 ---
 --- @param name string
 --- @param mode? string
@@ -5354,7 +5359,7 @@ function vim.fn.maparg(name, mode, abbr, dict) end
 ---
 --- @param name string
 --- @param mode? string
---- @param abbr? any
+--- @param abbr? boolean
 --- @return any
 function vim.fn.mapcheck(name, mode, abbr) end
 
@@ -5387,6 +5392,7 @@ function vim.fn.mapcheck(name, mode, abbr) end
 ---       \ {_, m -> m.lhs == 'xyzzy'})[0].mode_bits
 ---   ounmap xyzzy
 ---   echo printf("Operator-pending mode bit: 0x%x", op_bit)
+--- <
 ---
 --- @param abbr? 0|1
 --- @return table[]
@@ -5403,8 +5409,8 @@ function vim.fn.maplist(abbr) end
 function vim.fn.mapnew(expr1, expr2) end
 
 --- @param mode string
---- @param abbr? any
---- @param dict? any
+--- @param abbr? boolean
+--- @param dict? boolean
 --- @return any
 function vim.fn.mapset(mode, abbr, dict) end
 
@@ -5442,8 +5448,9 @@ function vim.fn.mapset(mode, abbr, dict) end
 ---   for d in save_maps
 ---       call mapset(d)
 ---   endfor
+--- <
 ---
---- @param dict any
+--- @param dict boolean
 --- @return any
 function vim.fn.mapset(dict) end
 
@@ -5509,10 +5516,10 @@ function vim.fn.mapset(dict) end
 --- zero matches at the start instead of a number of matches
 --- further down in the text.
 ---
---- @param expr any
---- @param pat any
---- @param start? any
---- @param count? any
+--- @param expr string|any[]
+--- @param pat string
+--- @param start? integer
+--- @param count? integer
 --- @return any
 function vim.fn.match(expr, pat, start, count) end
 
@@ -5573,11 +5580,11 @@ function vim.fn.match(expr, pat, start, count) end
 --- available from |getmatches()|.  All matches can be deleted in
 --- one operation by |clearmatches()|.
 ---
---- @param group any
---- @param pattern any
---- @param priority? any
---- @param id? any
---- @param dict? any
+--- @param group integer|string
+--- @param pattern string
+--- @param priority? integer
+--- @param id? integer
+--- @param dict? string
 --- @return any
 function vim.fn.matchadd(group, pattern, priority, id, dict) end
 
@@ -5617,11 +5624,11 @@ function vim.fn.matchadd(group, pattern, priority, id, dict) end
 --- <Matches added by |matchaddpos()| are returned by
 --- |getmatches()|.
 ---
---- @param group any
---- @param pos any
---- @param priority? any
---- @param id? any
---- @param dict? any
+--- @param group integer|string
+--- @param pos any[]
+--- @param priority? integer
+--- @param id? integer
+--- @param dict? string
 --- @return any
 function vim.fn.matchaddpos(group, pos, priority, id, dict) end
 
@@ -5698,8 +5705,8 @@ function vim.fn.matchbufline(buf, pat, lnum, end_, dict) end
 --- If {win} is specified, use the window with this number or
 --- window ID instead of the current window.
 ---
---- @param id any
---- @param win? any
+--- @param id integer
+--- @param win? integer
 --- @return any
 function vim.fn.matchdelete(id, win) end
 
@@ -5722,9 +5729,9 @@ function vim.fn.matchdelete(id, win) end
 --- When {expr} is a |List| the result is equal to |match()|.
 ---
 --- @param expr any
---- @param pat any
---- @param start? any
---- @param count? any
+--- @param pat string
+--- @param start? integer
+--- @param count? integer
 --- @return any
 function vim.fn.matchend(expr, pat, start, count) end
 
@@ -5790,9 +5797,9 @@ function vim.fn.matchend(expr, pat, start, count) end
 ---         \ {'matchseq': 1})
 --- <results in `['two one']`.
 ---
---- @param list any
---- @param str any
---- @param dict? any
+--- @param list any[]
+--- @param str string
+--- @param dict? string
 --- @return any
 function vim.fn.matchfuzzy(list, str, dict) end
 
@@ -5817,9 +5824,9 @@ function vim.fn.matchfuzzy(list, str, dict) end
 ---     \ ->matchfuzzypos('ll', {'key' : 'text'})
 --- <results in `[[{"id": 10, "text": "hello"}], [[2, 3]], [127]]`
 ---
---- @param list any
---- @param str any
---- @param dict? any
+--- @param list any[]
+--- @param str string
+--- @param dict? string
 --- @return any
 function vim.fn.matchfuzzypos(list, str, dict) end
 
@@ -5835,9 +5842,9 @@ function vim.fn.matchfuzzypos(list, str, dict) end
 --- You can pass in a List, but that is not very useful.
 ---
 --- @param expr any
---- @param pat any
---- @param start? any
---- @param count? any
+--- @param pat string
+--- @param start? integer
+--- @param count? integer
 --- @return any
 function vim.fn.matchlist(expr, pat, start, count) end
 
@@ -5854,9 +5861,9 @@ function vim.fn.matchlist(expr, pat, start, count) end
 --- The type isn't changed, it's not necessarily a String.
 ---
 --- @param expr any
---- @param pat any
---- @param start? any
---- @param count? any
+--- @param pat string
+--- @param start? integer
+--- @param count? integer
 --- @return any
 function vim.fn.matchstr(expr, pat, start, count) end
 
@@ -5916,9 +5923,9 @@ function vim.fn.matchstrlist(list, pat, dict) end
 --- The type isn't changed, it's not necessarily a String.
 ---
 --- @param expr any
---- @param pat any
---- @param start? any
---- @param count? any
+--- @param pat string
+--- @param start? integer
+--- @param count? integer
 --- @return any
 function vim.fn.matchstrpos(expr, pat, start, count) end
 
@@ -5981,7 +5988,7 @@ function vim.fn.max(expr) end
 --- <
 ---
 --- @param path string
---- @param modes? any
+--- @param modes? string
 --- @return any
 function vim.fn.menu_get(path, modes) end
 
@@ -6114,7 +6121,7 @@ function vim.fn.min(expr) end
 ---
 --- @param name string
 --- @param flags? string
---- @param prot? any
+--- @param prot? string
 --- @return any
 function vim.fn.mkdir(name, flags, prot) end
 
@@ -6295,8 +6302,8 @@ function vim.fn.nextnonblank(lnum) end
 --- characters.  nr2char(0) is a real NUL and terminates the
 --- string, thus results in an empty string.
 ---
---- @param expr any
---- @param utf8? any
+--- @param expr integer
+--- @param utf8? boolean
 --- @return any
 function vim.fn.nr2char(expr, utf8) end
 
@@ -6311,8 +6318,8 @@ function vim.fn.nr2char(expr, utf8) end
 --- to separate commands.  In many places it would not be clear if
 --- "|" is an operator or a command separator.
 ---
---- @param expr any
---- @param expr1 any
+--- @param expr number
+--- @param expr1 number
 --- @return any
 vim.fn['or'] = function(expr, expr1) end
 
@@ -6330,7 +6337,7 @@ vim.fn['or'] = function(expr, expr1) end
 --- Returns an empty string on error.
 ---
 --- @param path string
---- @param len? any
+--- @param len? integer
 --- @return any
 function vim.fn.pathshorten(path, len) end
 
@@ -6363,8 +6370,8 @@ function vim.fn.perleval(expr) end
 ---   echo pow(32, 0.20)
 --- <  2.0
 ---
---- @param x any
---- @param y any
+--- @param x number
+--- @param y number
 --- @return any
 function vim.fn.pow(x, y) end
 
@@ -6702,7 +6709,7 @@ function vim.fn.prevnonblank(lnum) end
 --- into this, copying the exact format string and parameters that
 --- were used.
 ---
---- @param fmt any
+--- @param fmt string
 --- @param expr1? any
 --- @return string
 function vim.fn.printf(fmt, expr1) end
@@ -6850,7 +6857,7 @@ function vim.fn.pyxeval(expr) end
 ---   echo rand(seed) % 16  " random number 0 - 15
 --- <
 ---
---- @param expr? any
+--- @param expr? number
 --- @return any
 function vim.fn.rand(expr) end
 
@@ -6873,8 +6880,8 @@ function vim.fn.rand(expr) end
 --- <
 ---
 --- @param expr any
---- @param max? any
---- @param stride? any
+--- @param max? integer
+--- @param stride? integer
 --- @return any
 function vim.fn.range(expr, max, stride) end
 
@@ -6902,8 +6909,8 @@ function vim.fn.range(expr, max, stride) end
 --- Also see |readfile()| and |writefile()|.
 ---
 --- @param fname string
---- @param offset? any
---- @param size? any
+--- @param offset? integer
+--- @param size? integer
 --- @return any
 function vim.fn.readblob(fname, offset, size) end
 
@@ -6936,8 +6943,8 @@ function vim.fn.readblob(fname, offset, size) end
 --- <
 --- Returns an empty List on error.
 ---
---- @param directory any
---- @param expr? any
+--- @param directory string
+--- @param expr? integer
 --- @return any
 function vim.fn.readdir(directory, expr) end
 
@@ -6974,8 +6981,8 @@ function vim.fn.readdir(directory, expr) end
 --- Also see |writefile()|.
 ---
 --- @param fname string
---- @param type? any
---- @param max? any
+--- @param type? string
+--- @param max? integer
 --- @return any
 function vim.fn.readfile(fname, type, max) end
 
@@ -6997,7 +7004,7 @@ function vim.fn.readfile(fname, type, max) end
 --- <
 ---
 --- @param object any
---- @param func any
+--- @param func function
 --- @param initial? any
 --- @return any
 function vim.fn.reduce(object, func, initial) end
@@ -7103,9 +7110,9 @@ function vim.fn.remove(list, idx) end
 --- <
 --- Use |delete()| to remove a file.
 ---
---- @param list any
+--- @param list any[]
 --- @param idx integer
---- @param end_? any
+--- @param end_? integer
 --- @return any
 function vim.fn.remove(list, idx, end_) end
 
@@ -7128,7 +7135,7 @@ function vim.fn.remove(blob, idx) end
 ---
 --- @param blob any
 --- @param idx integer
---- @param end_? any
+--- @param end_? integer
 --- @return any
 function vim.fn.remove(blob, idx, end_) end
 
@@ -7139,7 +7146,7 @@ function vim.fn.remove(blob, idx, end_) end
 --- Returns zero on error.
 ---
 --- @param dict any
---- @param key any
+--- @param key string
 --- @return any
 function vim.fn.remove(dict, key) end
 
@@ -7150,8 +7157,8 @@ function vim.fn.remove(dict, key) end
 --- NOTE: If {to} exists it is overwritten without warning.
 --- This function is not available in the |sandbox|.
 ---
---- @param from any
---- @param to any
+--- @param from string
+--- @param to string
 --- @return any
 function vim.fn.rename(from, to) end
 
@@ -7165,7 +7172,7 @@ function vim.fn.rename(from, to) end
 --- <Results in ['a', 'b', 'a', 'b', 'a', 'b'].
 ---
 --- @param expr any
---- @param count any
+--- @param count integer
 --- @return any
 vim.fn['repeat'] = function(expr, count) end
 
@@ -7181,7 +7188,7 @@ vim.fn['repeat'] = function(expr, count) end
 --- current directory (provided the result is still a relative
 --- path name) and also keeps a trailing path separator.
 ---
---- @param filename any
+--- @param filename string
 --- @return any
 function vim.fn.resolve(filename) end
 
@@ -7212,7 +7219,7 @@ function vim.fn.reverse(object) end
 ---   echo round(-4.5)
 --- <  -5.0
 ---
---- @param expr any
+--- @param expr number
 --- @return any
 function vim.fn.round(expr) end
 
@@ -7222,8 +7229,8 @@ function vim.fn.round(expr) end
 ---   au VimLeave call rpcnotify(0, "leaving")
 --- <
 ---
---- @param channel any
---- @param event any
+--- @param channel integer
+--- @param event string
 --- @param args? any
 --- @return any
 function vim.fn.rpcnotify(channel, event, args) end
@@ -7234,19 +7241,20 @@ function vim.fn.rpcnotify(channel, event, args) end
 ---   let result = rpcrequest(rpc_chan, "func", 1, 2, 3)
 --- <
 ---
---- @param channel any
---- @param method any
+--- @param channel integer
+--- @param method string
 --- @param args? any
 --- @return any
 function vim.fn.rpcrequest(channel, method, args) end
 
+--- @deprecated
 --- Deprecated. Replace  >vim
 ---   let id = rpcstart('prog', ['arg1', 'arg2'])
 --- <with >vim
 ---   let id = jobstart(['prog', 'arg1', 'arg2'], {'rpc': v:true})
 --- <
 ---
---- @param prog any
+--- @param prog string
 --- @param argv? any
 --- @return any
 function vim.fn.rpcstart(prog, argv) end
@@ -7279,7 +7287,7 @@ function vim.fn.rubyeval(expr) end
 --- attribute at other positions.
 --- Returns -1 when row or col is out of range.
 ---
---- @param row any
+--- @param row integer
 --- @param col integer
 --- @return any
 function vim.fn.screenattr(row, col) end
@@ -7293,7 +7301,7 @@ function vim.fn.screenattr(row, col) end
 --- This is mainly to be used for testing.
 --- Returns -1 when row or col is out of range.
 ---
---- @param row any
+--- @param row integer
 --- @param col integer
 --- @return any
 function vim.fn.screenchar(row, col) end
@@ -7304,7 +7312,7 @@ function vim.fn.screenchar(row, col) end
 --- This is mainly to be used for testing.
 --- Returns an empty List when row or col is out of range.
 ---
---- @param row any
+--- @param row integer
 --- @param col integer
 --- @return any
 function vim.fn.screenchars(row, col) end
@@ -7372,7 +7380,7 @@ function vim.fn.screenrow() end
 --- This is mainly to be used for testing.
 --- Returns an empty String when row or col is out of range.
 ---
---- @param row any
+--- @param row integer
 --- @param col integer
 --- @return any
 function vim.fn.screenstring(row, col) end
@@ -7481,11 +7489,11 @@ function vim.fn.screenstring(row, col) end
 --- without the 'e' flag if the cursor is on the "f" of "if".
 --- The 'n' flag tells the function not to move the cursor.
 ---
---- @param pattern any
+--- @param pattern string
 --- @param flags? string
---- @param stopline? any
+--- @param stopline? integer
 --- @param timeout? integer
---- @param skip? any
+--- @param skip? string|function
 --- @return any
 function vim.fn.search(pattern, flags, stopline, timeout, skip) end
 
@@ -7632,8 +7640,8 @@ function vim.fn.searchcount(options) end
 --- <
 ---
 --- @param name string
---- @param global? any
---- @param thisblock? any
+--- @param global? boolean
+--- @param thisblock? boolean
 --- @return any
 function vim.fn.searchdecl(name, global, thisblock) end
 
@@ -7721,12 +7729,12 @@ function vim.fn.searchdecl(name, global, thisblock) end
 ---        \ 'synIDattr(synID(line("."), col("."), 0), "name") =~? "string"')
 --- <
 ---
---- @param start any
---- @param middle any
---- @param end_ any
+--- @param start string
+--- @param middle string
+--- @param end_ string
 --- @param flags? string
---- @param skip? any
---- @param stopline? any
+--- @param skip? string|function
+--- @param stopline? integer
 --- @param timeout? integer
 --- @return integer
 function vim.fn.searchpair(start, middle, end_, flags, skip, stopline, timeout) end
@@ -7741,12 +7749,12 @@ function vim.fn.searchpair(start, middle, end_, flags, skip, stopline, timeout) 
 --- <
 --- See |match-parens| for a bigger and more useful example.
 ---
---- @param start any
---- @param middle any
---- @param end_ any
+--- @param start string
+--- @param middle string
+--- @param end_ string
 --- @param flags? string
---- @param skip? any
---- @param stopline? any
+--- @param skip? string|function
+--- @param stopline? integer
 --- @param timeout? integer
 --- @return [integer, integer]
 function vim.fn.searchpairpos(start, middle, end_, flags, skip, stopline, timeout) end
@@ -7765,11 +7773,11 @@ function vim.fn.searchpairpos(start, middle, end_, flags, skip, stopline, timeou
 --- <In this example "submatch" is 2 when a lowercase letter is
 --- found |/\l|, 3 when an uppercase letter is found |/\u|.
 ---
---- @param pattern any
+--- @param pattern string
 --- @param flags? string
---- @param stopline? any
+--- @param stopline? integer
 --- @param timeout? integer
---- @param skip? any
+--- @param skip? string|function
 --- @return any
 function vim.fn.searchpos(pattern, flags, stopline, timeout, skip) end
 
@@ -7815,7 +7823,7 @@ function vim.fn.serverlist() end
 ---   echo serverstart('::1:12345')
 --- <
 ---
---- @param address? any
+--- @param address? string
 --- @return any
 function vim.fn.serverstart(address) end
 
@@ -7824,7 +7832,7 @@ function vim.fn.serverstart(address) end
 --- If |v:servername| is stopped it is set to the next available
 --- address in |serverlist()|.
 ---
---- @param address any
+--- @param address string
 --- @return any
 function vim.fn.serverstop(address) end
 
@@ -7852,9 +7860,9 @@ function vim.fn.serverstop(address) end
 --- If {buf} is not a valid buffer or {lnum} is not valid, an
 --- error message is given.
 ---
---- @param buf any
+--- @param buf integer|string
 --- @param lnum integer
---- @param text any
+--- @param text string|string[]
 --- @return any
 function vim.fn.setbufline(buf, lnum, text) end
 
@@ -7871,7 +7879,7 @@ function vim.fn.setbufline(buf, lnum, text) end
 ---   call setbufvar("todo", "myvar", "foobar")
 --- <This function is not available in the |sandbox|.
 ---
---- @param buf any
+--- @param buf integer|string
 --- @param varname string
 --- @param val any
 --- @return any
@@ -7910,7 +7918,7 @@ function vim.fn.setbufvar(buf, varname, val) end
 --- match with what Vim knows about each emoji.  If it doesn't
 --- look right you need to adjust the {list} argument.
 ---
---- @param list any
+--- @param list any[]
 --- @return any
 function vim.fn.setcellwidths(list) end
 
@@ -7924,8 +7932,8 @@ function vim.fn.setcellwidths(list) end
 ---   call setpos('.', [0, 8, 4, 0])
 --- <positions the cursor on the second character '보'.
 ---
---- @param expr any
---- @param list any
+--- @param expr string
+--- @param list integer[]
 --- @return any
 function vim.fn.setcharpos(expr, list) end
 
@@ -7948,7 +7956,7 @@ function vim.fn.setcharpos(expr, list) end
 ---   call setcharsearch(prevsearch)
 --- <Also see |getcharsearch()|.
 ---
---- @param dict any
+--- @param dict string
 --- @return any
 function vim.fn.setcharsearch(dict) end
 
@@ -7958,8 +7966,8 @@ function vim.fn.setcharsearch(dict) end
 --- Returns 0 when successful, 1 when not editing the command
 --- line.
 ---
---- @param str any
---- @param pos? any
+--- @param str string
+--- @param pos? integer
 --- @return any
 function vim.fn.setcmdline(str, pos) end
 
@@ -7977,13 +7985,13 @@ function vim.fn.setcmdline(str, pos) end
 --- Returns 0 when successful, 1 when not editing the command
 --- line.
 ---
---- @param pos any
+--- @param pos integer
 --- @return any
 function vim.fn.setcmdpos(pos) end
 
 --- @param lnum integer
 --- @param col? integer
---- @param off? any
+--- @param off? integer
 --- @return any
 function vim.fn.setcursorcharpos(lnum, col, off) end
 
@@ -7997,7 +8005,7 @@ function vim.fn.setcursorcharpos(lnum, col, off) end
 ---   call cursor(4, 3)
 --- <positions the cursor on the first character '여'.
 ---
---- @param list any
+--- @param list integer[]
 --- @return any
 function vim.fn.setcursorcharpos(list) end
 
@@ -8008,7 +8016,7 @@ function vim.fn.setcursorcharpos(list) end
 --- See also |expr-env|.
 ---
 --- @param name string
---- @param val any
+--- @param val string
 --- @return any
 function vim.fn.setenv(name, val) end
 
@@ -8082,8 +8090,8 @@ function vim.fn.setline(lnum, text) end
 ---
 --- @param nr integer
 --- @param list any
---- @param action? any
---- @param what? any
+--- @param action? string
+--- @param what? table
 --- @return any
 function vim.fn.setloclist(nr, list, action, what) end
 
@@ -8095,7 +8103,7 @@ function vim.fn.setloclist(nr, list, action, what) end
 --- window ID instead of the current window.
 ---
 --- @param list any
---- @param win? any
+--- @param win? integer
 --- @return any
 function vim.fn.setmatches(list, win) end
 
@@ -8147,8 +8155,8 @@ function vim.fn.setmatches(list, win) end
 --- also set the preferred column.  Also see the "curswant" key in
 --- |winrestview()|.
 ---
---- @param expr any
---- @param list any
+--- @param expr string
+--- @param list integer[]
 --- @return any
 function vim.fn.setpos(expr, list) end
 
@@ -8265,9 +8273,9 @@ function vim.fn.setpos(expr, list) end
 --- independent of the 'errorformat' setting.  Use a command like
 --- `:cc 1` to jump to the first position.
 ---
---- @param list any
---- @param action? any
---- @param what? any
+--- @param list any[]
+--- @param action? string
+--- @param what? table
 --- @return any
 function vim.fn.setqflist(list, action, what) end
 
@@ -8402,7 +8410,7 @@ function vim.fn.settabwinvar(tabnr, winnr, varname, val) end
 ---
 --- @param nr integer
 --- @param dict any
---- @param action? any
+--- @param action? string
 --- @return any
 function vim.fn.settagstack(nr, dict, action) end
 
@@ -8456,7 +8464,7 @@ function vim.fn.sha256(string) end
 --- <See also |::S|.
 ---
 --- @param string string
---- @param special? any
+--- @param special? boolean
 --- @return any
 function vim.fn.shellescape(string, special) end
 
@@ -8639,7 +8647,7 @@ function vim.fn.sign_getdefined(name) end
 ---   echo sign_getplaced()
 --- <
 ---
---- @param buf? any
+--- @param buf? integer|string
 --- @param dict? vim.fn.sign_getplaced.dict
 --- @return vim.fn.sign_getplaced.ret.item[]
 function vim.fn.sign_getplaced(buf, dict) end
@@ -8713,10 +8721,10 @@ function vim.fn.sign_jump(id, group, buf) end
 ---       \ {'lnum' : 40, 'priority' : 90})
 --- <
 ---
---- @param id any
---- @param group any
+--- @param id integer
+--- @param group string
 --- @param name string
---- @param buf any
+--- @param buf integer|string
 --- @param dict? vim.fn.sign_place.dict
 --- @return integer
 function vim.fn.sign_place(id, group, name, buf, dict) end
@@ -8908,7 +8916,7 @@ function vim.fn.sign_unplacelist(list) end
 --- directory.  In order to resolve all the involved symbolic
 --- links before simplifying the path name, use |resolve()|.
 ---
---- @param filename any
+--- @param filename string
 --- @return any
 function vim.fn.simplify(filename) end
 
@@ -8921,7 +8929,7 @@ function vim.fn.simplify(filename) end
 ---   echo sin(-4.01)
 --- <  0.763301
 ---
---- @param expr any
+--- @param expr number
 --- @return any
 function vim.fn.sin(expr) end
 
@@ -8935,7 +8943,7 @@ function vim.fn.sin(expr) end
 ---   echo sinh(-0.9)
 --- <  -1.026517
 ---
---- @param expr any
+--- @param expr number
 --- @return any
 function vim.fn.sinh(expr) end
 
@@ -8949,8 +8957,8 @@ function vim.fn.sinh(expr) end
 --- Returns an empty value if {start} or {end} are invalid.
 ---
 --- @param expr any
---- @param start any
---- @param end_? any
+--- @param start integer
+--- @param end_? integer
 --- @return any
 function vim.fn.slice(expr, start, end_) end
 
@@ -8979,7 +8987,7 @@ function vim.fn.slice(expr, start, end_) end
 ---   - 0 on invalid arguments or connection failure.
 ---
 --- @param mode string
---- @param address any
+--- @param address string
 --- @param opts? table
 --- @return any
 function vim.fn.sockconnect(mode, address, opts) end
@@ -9057,7 +9065,7 @@ function vim.fn.sockconnect(mode, address, opts) end
 --- <
 ---
 --- @param list any
---- @param how? any
+--- @param how? string|function
 --- @param dict? any
 --- @return any
 function vim.fn.sort(list, how, dict) end
@@ -9069,7 +9077,7 @@ function vim.fn.sort(list, how, dict) end
 --- This can be used for making spelling suggestions.  Note that
 --- the method can be quite slow.
 ---
---- @param word any
+--- @param word string
 --- @return any
 function vim.fn.soundfold(word) end
 
@@ -9096,7 +9104,7 @@ function vim.fn.soundfold(word) end
 --- The spelling information for the current window and the value
 --- of 'spelllang' are used.
 ---
---- @param sentence? any
+--- @param sentence? string
 --- @return any
 function vim.fn.spellbadword(sentence) end
 
@@ -9120,9 +9128,9 @@ function vim.fn.spellbadword(sentence) end
 --- The spelling information for the current window is used.  The
 --- values of 'spelllang' and 'spellsuggest' are used.
 ---
---- @param word any
---- @param max? any
---- @param capital? any
+--- @param word string
+--- @param max? integer
+--- @param capital? boolean
 --- @return any
 function vim.fn.spellsuggest(word, max, capital) end
 
@@ -9151,8 +9159,8 @@ function vim.fn.spellsuggest(word, max, capital) end
 --- <The opposite function is |join()|.
 ---
 --- @param string string
---- @param pattern? any
---- @param keepempty? any
+--- @param pattern? string
+--- @param keepempty? boolean
 --- @return any
 function vim.fn.split(string, pattern, keepempty) end
 
@@ -9168,7 +9176,7 @@ function vim.fn.split(string, pattern, keepempty) end
 --- <  str2float("nan")
 --- NaN may be different, it depends on system libraries.
 ---
---- @param expr any
+--- @param expr number
 --- @return any
 function vim.fn.sqrt(expr) end
 
@@ -9186,7 +9194,7 @@ function vim.fn.sqrt(expr) end
 ---   echo rand(seed)
 --- <
 ---
---- @param expr? any
+--- @param expr? number
 --- @return any
 function vim.fn.srand(expr) end
 
@@ -9291,7 +9299,7 @@ function vim.fn.stdpath(what) end
 --- Returns 0.0 if the conversion fails.
 ---
 --- @param string string
---- @param quoted? any
+--- @param quoted? boolean
 --- @return any
 function vim.fn.str2float(string, quoted) end
 
@@ -9307,7 +9315,7 @@ function vim.fn.str2float(string, quoted) end
 ---   echo str2list("á")    " returns [97, 769]
 ---
 --- @param string string
---- @param utf8? any
+--- @param utf8? boolean
 --- @return any
 function vim.fn.str2list(string, utf8) end
 
@@ -9330,7 +9338,7 @@ function vim.fn.str2list(string, utf8) end
 --- Returns 0 if {string} is empty or on error.
 ---
 --- @param string string
---- @param base? any
+--- @param base? integer
 --- @return any
 function vim.fn.str2nr(string, base) end
 
@@ -9361,10 +9369,10 @@ function vim.fn.strcharlen(string) end
 ---
 --- Returns an empty string on error.
 ---
---- @param src any
---- @param start any
---- @param len? any
---- @param skipcc? any
+--- @param src string
+--- @param start integer
+--- @param len? integer
+--- @param skipcc? boolean
 --- @return any
 function vim.fn.strcharpart(src, start, len, skipcc) end
 
@@ -9397,7 +9405,7 @@ function vim.fn.strcharpart(src, start, len, skipcc) end
 --- <
 ---
 --- @param string string
---- @param skipcc? any
+--- @param skipcc? boolean
 --- @return integer
 function vim.fn.strchars(string, skipcc) end
 
@@ -9435,8 +9443,8 @@ function vim.fn.strdisplaywidth(string, col) end
 ---   echo strftime("%c", getftime("file.c"))
 ---            " Show mod time of file.c.
 ---
---- @param format any
---- @param time? any
+--- @param format string
+--- @param time? number
 --- @return string
 function vim.fn.strftime(format, time) end
 
@@ -10010,7 +10018,7 @@ function vim.fn.systemlist(cmd, input, keepempty) end
 ---   endfor
 --- <Note that a buffer may appear in more than one window.
 ---
---- @param arg? any
+--- @param arg? integer
 --- @return any
 function vim.fn.tabpagebuflist(arg) end
 
@@ -10153,7 +10161,7 @@ function vim.fn.tempname() end
 --- except $TERM is set to "xterm-256color". Full behavior is
 --- described in |terminal|.
 ---
---- @param cmd any
+--- @param cmd string|string[]
 --- @param opts? table
 --- @return any
 function vim.fn.termopen(cmd, opts) end
@@ -10172,7 +10180,7 @@ function vim.fn.termopen(cmd, opts) end
 ---         -1 means forever
 ---     "callback"      the callback
 ---
---- @param id? any
+--- @param id? integer
 --- @return any
 function vim.fn.timer_info(id) end
 
@@ -10188,8 +10196,8 @@ function vim.fn.timer_info(id) end
 --- String, then the timer is paused, otherwise it is unpaused.
 --- See |non-zero-arg|.
 ---
---- @param timer any
---- @param paused any
+--- @param timer integer
+--- @param paused boolean
 --- @return any
 function vim.fn.timer_pause(timer, paused) end
 
@@ -10222,8 +10230,8 @@ function vim.fn.timer_pause(timer, paused) end
 ---     \ {'repeat': 3})
 --- <This invokes MyHandler() three times at 500 msec intervals.
 ---
---- @param time any
---- @param callback any
+--- @param time number
+--- @param callback string|function
 --- @param options? table
 --- @return any
 function vim.fn.timer_start(time, callback, options) end
@@ -10232,7 +10240,7 @@ function vim.fn.timer_start(time, callback, options) end
 --- {timer} is an ID returned by timer_start(), thus it must be a
 --- Number.  If {timer} does not exist there is no error.
 ---
---- @param timer any
+--- @param timer integer
 --- @return any
 function vim.fn.timer_stop(timer) end
 
@@ -10247,7 +10255,7 @@ function vim.fn.timer_stopall() end
 --- characters turned into lowercase (just like applying |gu| to
 --- the string).  Returns an empty string on error.
 ---
---- @param expr any
+--- @param expr string
 --- @return string
 function vim.fn.tolower(expr) end
 
@@ -10255,7 +10263,7 @@ function vim.fn.tolower(expr) end
 --- characters turned into uppercase (just like applying |gU| to
 --- the string).  Returns an empty string on error.
 ---
---- @param expr any
+--- @param expr string
 --- @return string
 function vim.fn.toupper(expr) end
 
@@ -10307,7 +10315,7 @@ function vim.fn.tr(src, fromstr, tostr) end
 ---   echo trim("  vim  ", " ", 2)
 --- <returns "  vim"
 ---
---- @param text any
+--- @param text string
 --- @param mask? string
 --- @param dir? 0|1|2
 --- @return string
@@ -10325,7 +10333,7 @@ function vim.fn.trim(text, mask, dir) end
 ---   echo trunc(4.0)
 --- <  4.0
 ---
---- @param expr any
+--- @param expr number
 --- @return integer
 function vim.fn.trunc(expr) end
 
@@ -10354,6 +10362,7 @@ function vim.fn.trunc(expr) end
 ---   if myvar is v:null | endif
 --- <To check if the v:t_ variables exist use this: >vim
 ---   if exists('v:t_number') | endif
+--- <
 ---
 --- @param expr any
 --- @return integer
@@ -10464,8 +10473,8 @@ function vim.fn.uniq(list, func, dict) end
 ---
 --- @param string string
 --- @param idx integer
---- @param countcc? any
---- @param charidx? any
+--- @param countcc? boolean
+--- @param charidx? boolean
 --- @return integer
 function vim.fn.utf16idx(string, idx, countcc, charidx) end
 
@@ -10522,9 +10531,10 @@ function vim.fn.values(dict) end
 --- A more advanced example that echoes the maximum length of
 --- all lines: >vim
 ---     echo max(map(range(1, line('$')), "virtcol([v:val, '$'])"))
+--- <
 ---
---- @param expr any
---- @param list? any
+--- @param expr string|integer[]
+--- @param list? boolean
 --- @param winid? integer
 --- @return any
 function vim.fn.virtcol(expr, list, winid) end
@@ -10573,7 +10583,7 @@ function vim.fn.virtcol2col(winid, lnum, col) end
 --- a non-empty String, then the Visual mode will be cleared and
 --- the old value is returned.  See |non-zero-arg|.
 ---
---- @param expr? any
+--- @param expr? boolean
 --- @return any
 function vim.fn.visualmode(expr) end
 
@@ -10594,7 +10604,7 @@ function vim.fn.visualmode(expr) end
 ---
 --- @param timeout integer
 --- @param condition any
---- @param interval? any
+--- @param interval? number
 --- @return any
 function vim.fn.wait(timeout, condition, interval) end
 
@@ -10624,8 +10634,8 @@ function vim.fn.wildmenumode() end
 --- When window {id} does not exist then no error is given and
 --- an empty string is returned.
 ---
---- @param id any
---- @param command any
+--- @param id integer
+--- @param command string
 --- @param silent? boolean
 --- @return any
 function vim.fn.win_execute(id, command, silent) end
@@ -10633,7 +10643,7 @@ function vim.fn.win_execute(id, command, silent) end
 --- Returns a |List| with |window-ID|s for windows that contain
 --- buffer {bufnr}.  When there is none the list is empty.
 ---
---- @param bufnr any
+--- @param bufnr integer
 --- @return integer[]
 function vim.fn.win_findbuf(bufnr) end
 
@@ -10645,8 +10655,8 @@ function vim.fn.win_findbuf(bufnr) end
 --- number {tab}.  The first tab has number one.
 --- Return zero if the window cannot be found.
 ---
---- @param win? any
---- @param tab? any
+--- @param win? integer
+--- @param tab? integer
 --- @return integer
 function vim.fn.win_getid(win, tab) end
 
@@ -10675,7 +10685,7 @@ function vim.fn.win_gettype(nr) end
 --- tabpage.
 --- Return TRUE if successful, FALSE if the window cannot be found.
 ---
---- @param expr any
+--- @param expr integer
 --- @return 0|1
 function vim.fn.win_gotoid(expr) end
 
@@ -10683,14 +10693,14 @@ function vim.fn.win_gotoid(expr) end
 --- with ID {expr}: [tabnr, winnr].
 --- Return [0, 0] if the window cannot be found.
 ---
---- @param expr any
+--- @param expr integer
 --- @return any
 function vim.fn.win_id2tabwin(expr) end
 
 --- Return the window number of window with ID {expr}.
 --- Return 0 if the window cannot be found in the current tabpage.
 ---
---- @param expr any
+--- @param expr integer
 --- @return any
 function vim.fn.win_id2win(expr) end
 
@@ -10709,7 +10719,7 @@ function vim.fn.win_id2win(expr) end
 --- Only works for the current tab page. *E1308*
 ---
 --- @param nr integer
---- @param offset any
+--- @param offset integer
 --- @return any
 function vim.fn.win_move_separator(nr, offset) end
 
@@ -10725,7 +10735,7 @@ function vim.fn.win_move_separator(nr, offset) end
 --- Only works for the current tab page.
 ---
 --- @param nr integer
---- @param offset any
+--- @param offset integer
 --- @return any
 function vim.fn.win_move_statusline(nr, offset) end
 
@@ -10760,7 +10770,7 @@ function vim.fn.win_screenpos(nr) end
 ---     'splitright' are used.
 ---
 --- @param nr integer
---- @param target any
+--- @param target integer
 --- @param options? table
 --- @return any
 function vim.fn.win_splitmove(nr, target, options) end
@@ -10802,6 +10812,7 @@ function vim.fn.windowsversion() end
 --- This excludes any window toolbar line.
 --- Examples: >vim
 ---   echo "The current window has " .. winheight(0) .. " lines."
+--- <
 ---
 --- @param nr integer
 --- @return integer
@@ -10885,8 +10896,9 @@ function vim.fn.winline() end
 ---   let window_count = winnr('$')
 ---   let prev_window = winnr('#')
 ---   let wnum = winnr('3k')
+--- <
 ---
---- @param arg? any
+--- @param arg? string|integer
 --- @return any
 function vim.fn.winnr(arg) end
 
@@ -11035,6 +11047,7 @@ function vim.fn.wordcount() end
 --- To copy a file byte for byte: >vim
 ---   let fl = readfile("foo", "b")
 ---   call writefile(fl, "foocopy", "b")
+--- <
 ---
 --- @param object any
 --- @param fname string
@@ -11049,7 +11062,7 @@ function vim.fn.writefile(object, fname, flags) end
 ---   let bits = xor(bits, 0x80)
 --- <
 ---
---- @param expr any
---- @param expr1 any
+--- @param expr number
+--- @param expr1 number
 --- @return any
 function vim.fn.xor(expr, expr1) end

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -99,6 +99,7 @@ M.funcs = {
     name = 'add',
     params = { { 'object', 'any' }, { 'expr', 'any' } },
     returns = 'any',
+    returns_desc = [=[Resulting |List| or |Blob|, or 1 if {object} is not a |List| or a |Blob|.]=],
     signature = 'add({object}, {expr})',
   },
   ['and'] = {
@@ -181,7 +182,7 @@ M.funcs = {
 
     ]=],
     name = 'appendbufline',
-    params = { { 'buf', 'any' }, { 'lnum', 'integer' }, { 'text', 'string' } },
+    params = { { 'buf', 'integer|string' }, { 'lnum', 'integer' }, { 'text', 'string' } },
     returns = '0|1',
     signature = 'appendbufline({buf}, {lnum}, {text})',
   },
@@ -291,7 +292,7 @@ M.funcs = {
 
     ]=],
     name = 'assert_beeps',
-    params = { { 'cmd', 'any' } },
+    params = { { 'cmd', 'string' } },
     returns = '0|1',
     signature = 'assert_beeps({cmd})',
   },
@@ -333,7 +334,7 @@ M.funcs = {
 
     ]=],
     name = 'assert_equalfile',
-    params = {},
+    params = { { 'fname-one', 'string' }, { 'fname-two', 'string' } },
     returns = '0|1',
     signature = 'assert_equalfile({fname-one}, {fname-two})',
   },
@@ -398,7 +399,7 @@ M.funcs = {
     ]=],
     name = 'assert_fails',
     params = {
-      { 'cmd', 'any' },
+      { 'cmd', 'string' },
       { 'error', 'any' },
       { 'msg', 'any' },
       { 'lnum', 'integer' },
@@ -439,7 +440,12 @@ M.funcs = {
       that.
     ]=],
     name = 'assert_inrange',
-    params = { { 'lower', 'any' }, { 'upper', 'any' }, { 'actual', 'any' }, { 'msg', 'any' } },
+    params = {
+      { 'lower', 'number' },
+      { 'upper', 'number' },
+      { 'actual', 'number' },
+      { 'msg', 'string' },
+    },
     returns = '0|1',
     signature = 'assert_inrange({lower}, {upper}, {actual} [, {msg}])',
   },
@@ -468,7 +474,7 @@ M.funcs = {
 
     ]=],
     name = 'assert_match',
-    params = { { 'pattern', 'any' }, { 'actual', 'any' }, { 'msg', 'any' } },
+    params = { { 'pattern', 'string' }, { 'actual', 'string' }, { 'msg', 'string' } },
     returns = '0|1',
     signature = 'assert_match({pattern}, {actual} [, {msg}])',
   },
@@ -482,7 +488,7 @@ M.funcs = {
 
     ]=],
     name = 'assert_nobeep',
-    params = { { 'cmd', 'any' } },
+    params = { { 'cmd', 'string' } },
     returns = '0|1',
     signature = 'assert_nobeep({cmd})',
   },
@@ -510,7 +516,7 @@ M.funcs = {
 
     ]=],
     name = 'assert_notmatch',
-    params = { { 'pattern', 'any' }, { 'actual', 'any' }, { 'msg', 'any' } },
+    params = { { 'pattern', 'string' }, { 'actual', 'string' }, { 'msg', 'string' } },
     returns = '0|1',
     signature = 'assert_notmatch({pattern}, {actual} [, {msg}])',
   },
@@ -523,7 +529,7 @@ M.funcs = {
 
     ]=],
     name = 'assert_report',
-    params = { { 'msg', 'any' } },
+    params = { { 'msg', 'string' } },
     returns = '0|1',
     signature = 'assert_report({msg})',
   },
@@ -541,7 +547,7 @@ M.funcs = {
 
     ]=],
     name = 'assert_true',
-    params = { { 'actual', 'any' }, { 'msg', 'any' } },
+    params = { { 'actual', 'any' }, { 'msg', 'string' } },
     returns = '0|1',
     signature = 'assert_true({actual} [, {msg}])',
   },
@@ -562,7 +568,7 @@ M.funcs = {
     ]=],
     float_func = 'atan',
     name = 'atan',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     returns = 'number',
     signature = 'atan({expr})',
   },
@@ -583,7 +589,7 @@ M.funcs = {
 
     ]=],
     name = 'atan2',
-    params = { { 'expr1', 'any' }, { 'expr2', 'any' } },
+    params = { { 'expr1', 'number' }, { 'expr2', 'number' } },
     returns = 'number',
     signature = 'atan2({expr1}, {expr2})',
   },
@@ -618,7 +624,12 @@ M.funcs = {
       something went wrong, or browsing is not possible.
     ]=],
     name = 'browse',
-    params = { { 'save', 'any' }, { 'title', 'any' }, { 'initdir', 'any' }, { 'default', 'any' } },
+    params = {
+      { 'save', 'any' },
+      { 'title', 'string' },
+      { 'initdir', 'string' },
+      { 'default', 'string' },
+    },
     returns = '0|1',
     signature = 'browse({save}, {title}, {initdir}, {default})',
   },
@@ -637,7 +648,7 @@ M.funcs = {
       browsing is not possible, an empty string is returned.
     ]=],
     name = 'browsedir',
-    params = { { 'title', 'any' }, { 'initdir', 'any' } },
+    params = { { 'title', 'string' }, { 'initdir', 'string' } },
     returns = '0|1',
     signature = 'browsedir({title}, {initdir})',
   },
@@ -1006,7 +1017,7 @@ M.funcs = {
     ]=],
     float_func = 'ceil',
     name = 'ceil',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     returns = 'number',
     signature = 'ceil({expr})',
   },
@@ -1023,7 +1034,7 @@ M.funcs = {
       omitted.
     ]=],
     name = 'chanclose',
-    params = { { 'id', 'any' }, { 'stream', 'any' } },
+    params = { { 'id', 'integer' }, { 'stream', 'string' } },
     returns = '0|1',
     signature = 'chanclose({id} [, {stream}])',
   },
@@ -1063,7 +1074,7 @@ M.funcs = {
       messages, use |rpcnotify()| and |rpcrequest()| instead.
     ]=],
     name = 'chansend',
-    params = { { 'id', 'any' }, { 'data', 'any' } },
+    params = { { 'id', 'number' }, { 'data', 'string|string[]' } },
     returns = '0|1',
     signature = 'chansend({id}, {data})',
   },
@@ -1122,10 +1133,11 @@ M.funcs = {
       With the cursor on '세' in line 5 with text "여보세요": >vim
       	echo charcol('.')	" returns 3
       	echo col('.')		" returns 7
+      <
 
     ]=],
     name = 'charcol',
-    params = { { 'expr', 'any' }, { 'winid', 'integer' } },
+    params = { { 'expr', 'string|integer[]' }, { 'winid', 'integer' } },
     returns = 'integer',
     signature = 'charcol({expr} [, {winid}])',
   },
@@ -1170,8 +1182,8 @@ M.funcs = {
     params = {
       { 'string', 'string' },
       { 'idx', 'integer' },
-      { 'countcc', 'any' },
-      { 'utf16', 'any' },
+      { 'countcc', 'boolean' },
+      { 'utf16', 'boolean' },
     },
     returns = 'integer',
     signature = 'charidx({string}, {idx} [, {countcc} [, {utf16}]])',
@@ -1200,6 +1212,7 @@ M.funcs = {
       	   " ... do some work
       	   call chdir(save_dir)
       	endif
+      <
 
     ]=],
     name = 'chdir',
@@ -1235,7 +1248,7 @@ M.funcs = {
 
     ]=],
     name = 'clearmatches',
-    params = { { 'win', 'any' } },
+    params = { { 'win', 'integer' } },
     returns = false,
     signature = 'clearmatches([{win}])',
   },
@@ -1279,10 +1292,11 @@ M.funcs = {
       line.  Also, when using a <Cmd> mapping the cursor isn't
       moved, this can be used to obtain the column in Insert mode: >vim
       	imap <F2> <Cmd>echo col(".").."\n"<CR>
+      <
 
     ]=],
     name = 'col',
-    params = { { 'expr', 'any' }, { 'winid', 'integer' } },
+    params = { { 'expr', 'string|integer[]' }, { 'winid', 'integer' } },
     returns = 'integer',
     signature = 'col({expr} [, {winid}])',
   },
@@ -1321,7 +1335,7 @@ M.funcs = {
 
     ]=],
     name = 'complete',
-    params = { { 'startcol', 'any' }, { 'matches', 'any' } },
+    params = { { 'startcol', 'integer' }, { 'matches', 'any[]' } },
     returns = false,
     signature = 'complete({startcol}, {matches})',
     tags = { 'E785' },
@@ -1420,10 +1434,11 @@ M.funcs = {
       	call complete_info(['mode'])
       	" Get only 'mode' and 'pum_visible'
       	call complete_info(['mode', 'pum_visible'])
+      <
 
     ]=],
     name = 'complete_info',
-    params = { { 'what', 'any' } },
+    params = { { 'what', 'any[]' } },
     returns = 'table',
     signature = 'complete_info([{what}])',
   },
@@ -1484,7 +1499,12 @@ M.funcs = {
 
     ]=],
     name = 'confirm',
-    params = { { 'msg', 'any' }, { 'choices', 'any' }, { 'default', 'any' }, { 'type', 'any' } },
+    params = {
+      { 'msg', 'string' },
+      { 'choices', 'string' },
+      { 'default', 'integer' },
+      { 'type', 'string' },
+    },
     returns = 'integer',
     signature = 'confirm({msg} [, {choices} [, {default} [, {type}]]])',
   },
@@ -1522,7 +1542,7 @@ M.funcs = {
     ]=],
     float_func = 'cos',
     name = 'cos',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     returns = 'number',
     signature = 'cos({expr})',
   },
@@ -1543,7 +1563,7 @@ M.funcs = {
     ]=],
     float_func = 'cosh',
     name = 'cosh',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     returns = 'number',
     signature = 'cosh({expr})',
   },
@@ -1566,7 +1586,12 @@ M.funcs = {
 
     ]=],
     name = 'count',
-    params = { { 'comp', 'any' }, { 'expr', 'any' }, { 'ic', 'any' }, { 'start', 'any' } },
+    params = {
+      { 'comp', 'string|table|any[]' },
+      { 'expr', 'any' },
+      { 'ic', 'boolean' },
+      { 'start', 'integer' },
+    },
     returns = 'integer',
     signature = 'count({comp}, {expr} [, {ic} [, {start}]])',
   },
@@ -1578,7 +1603,7 @@ M.funcs = {
       If {index} is not given, it is assumed to be 0 (i.e.: top).
     ]=],
     name = 'ctxget',
-    params = { { 'index', 'any' } },
+    params = { { 'index', 'integer' } },
     returns = 'table',
     signature = 'ctxget([{index}])',
   },
@@ -1601,7 +1626,7 @@ M.funcs = {
       Otherwise, all context types are included.
     ]=],
     name = 'ctxpush',
-    params = { { 'types', 'any' } },
+    params = { { 'types', 'string[]' } },
     signature = 'ctxpush([{types}])',
   },
   ctxset = {
@@ -1613,7 +1638,7 @@ M.funcs = {
       If {index} is not given, it is assumed to be 0 (i.e.: top).
     ]=],
     name = 'ctxset',
-    params = { { 'context', 'any' }, { 'index', 'any' } },
+    params = { { 'context', 'table' }, { 'index', 'integer' } },
     signature = 'ctxset({context} [, {index}])',
   },
   ctxsize = {
@@ -1628,7 +1653,7 @@ M.funcs = {
     args = { 1, 3 },
     base = 1,
     name = 'cursor',
-    params = { { 'lnum', 'integer' }, { 'col', 'integer' }, { 'off', 'any' } },
+    params = { { 'lnum', 'integer' }, { 'col', 'integer' }, { 'off', 'integer' } },
     signature = 'cursor({lnum}, {col} [, {off}])',
   },
   cursor__1 = {
@@ -1668,7 +1693,7 @@ M.funcs = {
 
     ]=],
     name = 'cursor',
-    params = { { 'list', 'any' } },
+    params = { { 'list', 'integer[]' } },
     signature = 'cursor({list})',
   },
   debugbreak = {
@@ -1685,7 +1710,7 @@ M.funcs = {
 
     ]=],
     name = 'debugbreak',
-    params = { { 'pid', 'any' } },
+    params = { { 'pid', 'integer' } },
     signature = 'debugbreak({pid})',
   },
   deepcopy = {
@@ -1714,7 +1739,7 @@ M.funcs = {
 
     ]=],
     name = 'deepcopy',
-    params = { { 'expr', 'any' }, { 'noref', 'any' } },
+    params = { { 'expr', 'any' }, { 'noref', 'boolean' } },
     signature = 'deepcopy({expr} [, {noref}])',
   },
   delete = {
@@ -1764,7 +1789,11 @@ M.funcs = {
 
     ]=],
     name = 'deletebufline',
-    params = { { 'buf', 'any' }, { 'first', 'any' }, { 'last', 'any' } },
+    params = {
+      { 'buf', 'integer|string' },
+      { 'first', 'integer|string' },
+      { 'last', 'integer|string' },
+    },
     signature = 'deletebufline({buf}, {first} [, {last}])',
   },
   dictwatcheradd = {
@@ -1810,7 +1839,7 @@ M.funcs = {
       validation and parsing logic.
     ]=],
     name = 'dictwatcheradd',
-    params = { { 'dict', 'any' }, { 'pattern', 'any' }, { 'callback', 'any' } },
+    params = { { 'dict', 'table' }, { 'pattern', 'string' }, { 'callback', 'function' } },
     signature = 'dictwatcheradd({dict}, {pattern}, {callback})',
   },
   dictwatcherdel = {
@@ -1821,7 +1850,7 @@ M.funcs = {
       order for the watcher to be successfully deleted.
     ]=],
     name = 'dictwatcherdel',
-    params = { { 'dict', 'any' }, { 'pattern', 'any' }, { 'callback', 'any' } },
+    params = { { 'dict', 'any' }, { 'pattern', 'string' }, { 'callback', 'function' } },
     signature = 'dictwatcherdel({dict}, {pattern}, {callback})',
   },
   did_filetype = {
@@ -1900,7 +1929,7 @@ M.funcs = {
       <
     ]=],
     name = 'digraph_get',
-    params = { { 'chars', 'any' } },
+    params = { { 'chars', 'string' } },
     signature = 'digraph_get({chars})',
   },
   digraph_getlist = {
@@ -1922,7 +1951,7 @@ M.funcs = {
       <
     ]=],
     name = 'digraph_getlist',
-    params = { { 'listall', 'any' } },
+    params = { { 'listall', 'boolean' } },
     signature = 'digraph_getlist([{listall}])',
   },
   digraph_set = {
@@ -1945,12 +1974,9 @@ M.funcs = {
       Example: >vim
       	call digraph_set('  ', 'あ')
       <
-      Can be used as a |method|: >vim
-      	GetString()->digraph_set('あ')
-      <
     ]=],
     name = 'digraph_set',
-    params = { { 'chars', 'any' }, { 'digraph', 'any' } },
+    params = { { 'chars', 'string' }, { 'digraph', 'string' } },
     signature = 'digraph_set({chars}, {digraph})',
   },
   digraph_setlist = {
@@ -1970,13 +1996,9 @@ M.funcs = {
           endfor
       <Except that the function returns after the first error,
       following digraphs will not be added.
-
-      Can be used as a |method|: >vim
-          GetList()->digraph_setlist()
-      <
     ]=],
     name = 'digraph_setlist',
-    params = { { 'digraphlist', 'any' } },
+    params = { { 'digraphlist', 'table<integer,string[]>' } },
     signature = 'digraph_setlist({digraphlist})',
   },
   empty = {
@@ -2025,7 +2047,7 @@ M.funcs = {
     ]=],
     fast = true,
     name = 'escape',
-    params = { { 'string', 'string' }, { 'chars', 'any' } },
+    params = { { 'string', 'string' }, { 'chars', 'string' } },
     signature = 'escape({string}, {chars})',
   },
   eval = {
@@ -2089,7 +2111,7 @@ M.funcs = {
     ]=],
     fast = true,
     name = 'executable',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'string' } },
     returns = '0|1',
     signature = 'executable({expr})',
   },
@@ -2144,7 +2166,7 @@ M.funcs = {
 
     ]=],
     name = 'exepath',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'string' } },
     signature = 'exepath({expr})',
     returns = 'string',
   },
@@ -2242,7 +2264,7 @@ M.funcs = {
 
     ]=],
     name = 'exists',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'string' } },
     returns = '0|1',
     signature = 'exists({expr})',
   },
@@ -2263,7 +2285,7 @@ M.funcs = {
     ]=],
     float_func = 'exp',
     name = 'exp',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     signature = 'exp({expr})',
   },
   expand = {
@@ -2449,7 +2471,7 @@ M.funcs = {
 
     ]=],
     name = 'extend',
-    params = { { 'expr1', 'any' }, { 'expr2', 'any' }, { 'expr3', 'any' } },
+    params = { { 'expr1', 'table' }, { 'expr2', 'table' }, { 'expr3', 'table' } },
     signature = 'extend({expr1}, {expr2} [, {expr3}])',
   },
   extendnew = {
@@ -2461,7 +2483,7 @@ M.funcs = {
       unchanged.
     ]=],
     name = 'extendnew',
-    params = { { 'expr1', 'any' }, { 'expr2', 'any' }, { 'expr3', 'any' } },
+    params = { { 'expr1', 'table' }, { 'expr2', 'table' }, { 'expr3', 'table' } },
     signature = 'extendnew({expr1}, {expr2} [, {expr3}])',
   },
   feedkeys = {
@@ -2648,7 +2670,7 @@ M.funcs = {
 
     ]=],
     name = 'filter',
-    params = { { 'expr1', 'any' }, { 'expr2', 'any' } },
+    params = { { 'expr1', 'string|table' }, { 'expr2', 'string|function' } },
     signature = 'filter({expr1}, {expr2})',
   },
   finddir = {
@@ -2674,7 +2696,7 @@ M.funcs = {
 
     ]=],
     name = 'finddir',
-    params = { { 'name', 'string' }, { 'path', 'string' }, { 'count', 'any' } },
+    params = { { 'name', 'string' }, { 'path', 'string' }, { 'count', 'integer' } },
     signature = 'finddir({name} [, {path} [, {count}]])',
   },
   findfile = {
@@ -2717,7 +2739,7 @@ M.funcs = {
 
     ]=],
     name = 'flatten',
-    params = { { 'list', 'any' }, { 'maxdepth', 'any' } },
+    params = { { 'list', 'any[]' }, { 'maxdepth', 'integer' } },
     returns = 'any[]|0',
     signature = 'flatten({list} [, {maxdepth}])',
   },
@@ -2728,7 +2750,7 @@ M.funcs = {
       Like |flatten()| but first make a copy of {list}.
     ]=],
     name = 'flattennew',
-    params = { { 'list', 'any' }, { 'maxdepth', 'any' } },
+    params = { { 'list', 'any[]' }, { 'maxdepth', 'integer' } },
     returns = 'any[]|0',
     signature = 'flattennew({list} [, {maxdepth}])',
   },
@@ -2759,7 +2781,7 @@ M.funcs = {
 
     ]=],
     name = 'float2nr',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     signature = 'float2nr({expr})',
   },
   floor = {
@@ -2781,7 +2803,7 @@ M.funcs = {
     ]=],
     float_func = 'floor',
     name = 'floor',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     signature = 'floor({expr})',
   },
   fmod = {
@@ -2805,7 +2827,7 @@ M.funcs = {
 
     ]=],
     name = 'fmod',
-    params = { { 'expr1', 'any' }, { 'expr2', 'any' } },
+    params = { { 'expr1', 'number' }, { 'expr2', 'number' } },
     signature = 'fmod({expr1}, {expr2})',
   },
   fnameescape = {
@@ -2994,7 +3016,7 @@ M.funcs = {
       unless it was defined with the "abort" flag.
     ]=],
     name = 'foreach',
-    params = { { 'expr1', 'any' }, { 'expr2', 'any' } },
+    params = { { 'expr1', 'string|table' }, { 'expr2', 'string|function' } },
     signature = 'foreach({expr1}, {expr2})',
   },
   foreground = {
@@ -3157,7 +3179,7 @@ M.funcs = {
       type a character.
     ]=],
     name = 'garbagecollect',
-    params = { { 'atexit', 'any' } },
+    params = { { 'atexit', 'boolean' } },
     signature = 'garbagecollect([{atexit}])',
   },
   get = {
@@ -3344,10 +3366,11 @@ M.funcs = {
 
       Example: >vim
       	let lines = getbufline(bufnr("myfile"), 1, "$")
+      <
 
     ]=],
     name = 'getbufline',
-    params = { { 'buf', 'any' }, { 'lnum', 'integer' }, { 'end', 'integer' } },
+    params = { { 'buf', 'integer|string' }, { 'lnum', 'integer' }, { 'end', 'integer' } },
     signature = 'getbufline({buf}, {lnum} [, {end}])',
   },
   getbufoneline = {
@@ -3388,7 +3411,7 @@ M.funcs = {
 
     ]=],
     name = 'getbufvar',
-    params = { { 'buf', 'any' }, { 'varname', 'string' }, { 'def', 'any' } },
+    params = { { 'buf', 'integer|string' }, { 'varname', 'string' }, { 'def', 'any' } },
     signature = 'getbufvar({buf}, {varname} [, {def}])',
   },
   getcellwidths = {
@@ -3539,7 +3562,7 @@ M.funcs = {
       <
     ]=],
     name = 'getcharpos',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'string' } },
     returns = 'integer[]',
     signature = 'getcharpos({expr})',
   },
@@ -3771,7 +3794,7 @@ M.funcs = {
 
     ]=],
     name = 'getcompletion',
-    params = { { 'pat', 'any' }, { 'type', 'any' }, { 'filtered', 'any' } },
+    params = { { 'pat', 'string' }, { 'type', 'string' }, { 'filtered', 'boolean' } },
     returns = 'string[]',
     signature = 'getcompletion({pat}, {type} [, {filtered}])',
   },
@@ -4082,7 +4105,7 @@ M.funcs = {
       <
     ]=],
     name = 'getloclist',
-    params = { { 'nr', 'integer' }, { 'what', 'any' } },
+    params = { { 'nr', 'integer' }, { 'what', 'table' } },
     signature = 'getloclist({nr} [, {what}])',
   },
   getmarklist = {
@@ -4148,7 +4171,7 @@ M.funcs = {
       <
     ]=],
     name = 'getmatches',
-    params = { { 'win', 'any' } },
+    params = { { 'win', 'integer' } },
     signature = 'getmatches([{win}])',
   },
   getmousepos = {
@@ -4374,7 +4397,7 @@ M.funcs = {
       <
     ]=],
     name = 'getqflist',
-    params = { { 'what', 'any' } },
+    params = { { 'what', 'table' } },
     signature = 'getqflist([{what}])',
   },
   getreg = {
@@ -4741,7 +4764,7 @@ M.funcs = {
       strings.
     ]=],
     name = 'gettext',
-    params = { { 'text', 'any' } },
+    params = { { 'text', 'string' } },
     signature = 'gettext({text})',
   },
   getwininfo = {
@@ -4894,7 +4917,12 @@ M.funcs = {
 
     ]=],
     name = 'glob',
-    params = { { 'expr', 'any' }, { 'nosuf', 'boolean' }, { 'list', 'any' }, { 'alllinks', 'any' } },
+    params = {
+      { 'expr', 'string' },
+      { 'nosuf', 'boolean' },
+      { 'list', 'boolean' },
+      { 'alllinks', 'boolean' },
+    },
     signature = 'glob({expr} [, {nosuf} [, {list} [, {alllinks}]]])',
   },
   glob2regpat = {
@@ -4963,10 +4991,10 @@ M.funcs = {
     name = 'globpath',
     params = {
       { 'path', 'string' },
-      { 'expr', 'any' },
+      { 'expr', 'string' },
       { 'nosuf', 'boolean' },
-      { 'list', 'any' },
-      { 'allinks', 'any' },
+      { 'list', 'boolean' },
+      { 'allinks', 'boolean' },
     },
     signature = 'globpath({path}, {expr} [, {nosuf} [, {list} [, {allinks}]]])',
   },
@@ -5042,7 +5070,7 @@ M.funcs = {
     ]=],
     fast = true,
     name = 'has',
-    params = { { 'feature', 'any' } },
+    params = { { 'feature', 'string' } },
     returns = '0|1',
     signature = 'has({feature})',
   },
@@ -5056,7 +5084,7 @@ M.funcs = {
 
     ]=],
     name = 'has_key',
-    params = { { 'dict', 'any' }, { 'key', 'any' } },
+    params = { { 'dict', 'table' }, { 'key', 'string' } },
     returns = '0|1',
     signature = 'has_key({dict}, {key})',
   },
@@ -5122,7 +5150,7 @@ M.funcs = {
 
     ]=],
     name = 'hasmapto',
-    params = { { 'what', 'any' }, { 'mode', 'string' }, { 'abbr', 'any' } },
+    params = { { 'what', 'any' }, { 'mode', 'string' }, { 'abbr', 'boolean' } },
     returns = '0|1',
     signature = 'hasmapto({what} [, {mode} [, {abbr}]])',
   },
@@ -5174,7 +5202,7 @@ M.funcs = {
 
     ]=],
     name = 'histadd',
-    params = { { 'history', 'any' }, { 'item', 'any' } },
+    params = { { 'history', 'string' }, { 'item', 'any' } },
     returns = '0|1',
     signature = 'histadd({history}, {item})',
   },
@@ -5215,7 +5243,7 @@ M.funcs = {
       <
     ]=],
     name = 'histdel',
-    params = { { 'history', 'any' }, { 'item', 'any' } },
+    params = { { 'history', 'string' }, { 'item', 'any' } },
     returns = '0|1',
     signature = 'histdel({history} [, {item}])',
   },
@@ -5239,7 +5267,7 @@ M.funcs = {
       <
     ]=],
     name = 'histget',
-    params = { { 'history', 'any' }, { 'index', 'any' } },
+    params = { { 'history', 'string' }, { 'index', 'integer|string' } },
     returns = 'string',
     signature = 'histget({history} [, {index}])',
   },
@@ -5253,10 +5281,11 @@ M.funcs = {
 
       Example: >vim
       	let inp_index = histnr("expr")
+      <
 
     ]=],
     name = 'histnr',
-    params = { { 'history', 'any' } },
+    params = { { 'history', 'string' } },
     returns = 'integer',
     signature = 'histnr({history})',
   },
@@ -5324,7 +5353,7 @@ M.funcs = {
     ]=],
     fast = true,
     name = 'iconv',
-    params = { { 'string', 'string' }, { 'from', 'any' }, { 'to', 'any' } },
+    params = { { 'string', 'string' }, { 'from', 'string' }, { 'to', 'string' } },
     signature = 'iconv({string}, {from}, {to})',
   },
   id = {
@@ -5395,10 +5424,11 @@ M.funcs = {
       	if index(numbers, 123) >= 0
       	  " ...
       	endif
+      <
 
     ]=],
     name = 'index',
-    params = { { 'object', 'any' }, { 'expr', 'any' }, { 'start', 'any' }, { 'ic', 'any' } },
+    params = { { 'object', 'any' }, { 'expr', 'any' }, { 'start', 'integer' }, { 'ic', 'boolean' } },
     signature = 'index({object}, {expr} [, {start} [, {ic}]])',
   },
   indexof = {
@@ -5441,6 +5471,7 @@ M.funcs = {
       	echo indexof(l, "v:val.n == 20")
       	echo indexof(l, {i, v -> v.n == 30})
       	echo indexof(l, "v:val.n == 20", #{startidx: 1})
+      <
 
     ]=],
     name = 'indexof',
@@ -5452,7 +5483,7 @@ M.funcs = {
     base = 1,
     desc = '',
     name = 'input',
-    params = { { 'prompt', 'any' }, { 'text', 'any' }, { 'completion', 'any' } },
+    params = { { 'prompt', 'string' }, { 'text', 'string' }, { 'completion', 'string' } },
     signature = 'input({prompt} [, {text} [, {completion}]])',
   },
   input__1 = {
@@ -5567,6 +5598,7 @@ M.funcs = {
       	  let g:Foo = input("enter search pattern: ")
       	  call inputrestore()
       	endfunction
+      <
 
     ]=],
     name = 'input',
@@ -5605,7 +5637,7 @@ M.funcs = {
 
     ]=],
     name = 'inputlist',
-    params = { { 'textlist', 'any' } },
+    params = { { 'textlist', 'string[]' } },
     signature = 'inputlist({textlist})',
   },
   inputrestore = {
@@ -5648,7 +5680,7 @@ M.funcs = {
 
     ]=],
     name = 'inputsecret',
-    params = { { 'prompt', 'any' }, { 'text', 'any' } },
+    params = { { 'prompt', 'string' }, { 'text', 'string' } },
     signature = 'inputsecret({prompt} [, {text}])',
   },
   insert = {
@@ -5706,7 +5738,7 @@ M.funcs = {
       <
     ]=],
     name = 'invert',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     signature = 'invert({expr})',
   },
   isabsolutepath = {
@@ -5729,7 +5761,7 @@ M.funcs = {
     ]=],
     fast = true,
     name = 'isabsolutepath',
-    params = { { 'path', 'any' } },
+    params = { { 'path', 'string' } },
     returns = '0|1',
     signature = 'isabsolutepath({path})',
   },
@@ -5745,7 +5777,7 @@ M.funcs = {
     ]=],
     fast = true,
     name = 'isdirectory',
-    params = { { 'directory', 'any' } },
+    params = { { 'directory', 'string' } },
     returns = '0|1',
     signature = 'isdirectory({directory})',
   },
@@ -5762,7 +5794,7 @@ M.funcs = {
 
     ]=],
     name = 'isinf',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     returns = '1|0|-1',
     signature = 'isinf({expr})',
   },
@@ -5800,7 +5832,7 @@ M.funcs = {
 
     ]=],
     name = 'isnan',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     returns = '0|1',
     signature = 'isnan({expr})',
   },
@@ -5841,7 +5873,7 @@ M.funcs = {
       Return the PID (process id) of |job-id| {job}.
     ]=],
     name = 'jobpid',
-    params = { { 'job', 'any' } },
+    params = { { 'job', 'integer' } },
     returns = 'integer',
     signature = 'jobpid({job})',
   },
@@ -5853,7 +5885,7 @@ M.funcs = {
       Fails if the job was not started with `"pty":v:true`.
     ]=],
     name = 'jobresize',
-    params = { { 'job', 'any' }, { 'width', 'integer' }, { 'height', 'integer' } },
+    params = { { 'job', 'integer' }, { 'width', 'integer' }, { 'height', 'integer' } },
     signature = 'jobresize({job}, {width}, {height})',
   },
   jobsend = {
@@ -5955,7 +5987,7 @@ M.funcs = {
       See also |job-control|, |channel|, |msgpack-rpc|.
     ]=],
     name = 'jobstart',
-    params = { { 'cmd', 'any' }, { 'opts', 'table' } },
+    params = { { 'cmd', 'string|string[]' }, { 'opts', 'table' } },
     signature = 'jobstart({cmd} [, {opts}])',
   },
   jobstop = {
@@ -5971,7 +6003,7 @@ M.funcs = {
       exited or stopped.
     ]=],
     name = 'jobstop',
-    params = { { 'id', 'any' } },
+    params = { { 'id', 'integer' } },
     signature = 'jobstop({id})',
   },
   jobwait = {
@@ -5998,7 +6030,7 @@ M.funcs = {
       	-3 if the job-id is invalid
     ]=],
     name = 'jobwait',
-    params = { { 'jobs', 'any' }, { 'timeout', 'integer' } },
+    params = { { 'jobs', 'integer[]' }, { 'timeout', 'integer' } },
     signature = 'jobwait({jobs} [, {timeout}])',
   },
   join = {
@@ -6017,7 +6049,7 @@ M.funcs = {
 
     ]=],
     name = 'join',
-    params = { { 'list', 'any' }, { 'sep', 'any' } },
+    params = { { 'list', 'any[]' }, { 'sep', 'string' } },
     signature = 'join({list} [, {sep}])',
   },
   json_decode = {
@@ -6072,7 +6104,7 @@ M.funcs = {
 
     ]=],
     name = 'keys',
-    params = { { 'dict', 'any' } },
+    params = { { 'dict', 'table' } },
     signature = 'keys({dict})',
   },
   keytrans = {
@@ -6210,7 +6242,7 @@ M.funcs = {
 
     ]=],
     name = 'line',
-    params = { { 'expr', 'any' }, { 'winid', 'integer' } },
+    params = { { 'expr', 'string|integer[]' }, { 'winid', 'integer' } },
     returns = 'integer',
     signature = 'line({expr} [, {winid}])',
   },
@@ -6266,7 +6298,7 @@ M.funcs = {
 
     ]=],
     name = 'list2blob',
-    params = { { 'list', 'any' } },
+    params = { { 'list', 'any[]' } },
     signature = 'list2blob({list})',
   },
   list2str = {
@@ -6290,7 +6322,7 @@ M.funcs = {
 
     ]=],
     name = 'list2str',
-    params = { { 'list', 'any' }, { 'utf8', 'any' } },
+    params = { { 'list', 'any[]' }, { 'utf8', 'boolean' } },
     signature = 'list2str({list} [, {utf8}])',
   },
   localtime = {
@@ -6319,7 +6351,7 @@ M.funcs = {
     ]=],
     float_func = 'log',
     name = 'log',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     signature = 'log({expr})',
   },
   log10 = {
@@ -6338,7 +6370,7 @@ M.funcs = {
     ]=],
     float_func = 'log10',
     name = 'log10',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     signature = 'log10({expr})',
   },
   luaeval = {
@@ -6351,7 +6383,7 @@ M.funcs = {
     ]=],
     lua = false,
     name = 'luaeval',
-    params = { { 'expr', 'any' }, { 'expr', 'any' } },
+    params = { { 'expr', 'string' }, { 'expr', 'any[]' } },
     signature = 'luaeval({expr} [, {expr}])',
   },
   map = {
@@ -6413,7 +6445,7 @@ M.funcs = {
 
     ]=],
     name = 'map',
-    params = { { 'expr1', 'any' }, { 'expr2', 'any' } },
+    params = { { 'expr1', 'string|table|any[]' }, { 'expr2', 'string|function' } },
     signature = 'map({expr1}, {expr2})',
   },
   maparg = {
@@ -6491,6 +6523,7 @@ M.funcs = {
       This function can be used to map a key even when it's already
       mapped, and have it do the original mapping too.  Sketch: >vim
       	exe 'nnoremap <Tab> ==' .. maparg('<Tab>', 'n')
+      <
 
     ]=],
     name = 'maparg',
@@ -6553,7 +6586,7 @@ M.funcs = {
 
     ]=],
     name = 'mapcheck',
-    params = { { 'name', 'string' }, { 'mode', 'string' }, { 'abbr', 'any' } },
+    params = { { 'name', 'string' }, { 'mode', 'string' }, { 'abbr', 'boolean' } },
     signature = 'mapcheck({name} [, {mode} [, {abbr}]])',
   },
   maplist = {
@@ -6588,6 +6621,7 @@ M.funcs = {
       	    \ {_, m -> m.lhs == 'xyzzy'})[0].mode_bits
       	ounmap xyzzy
       	echo printf("Operator-pending mode bit: 0x%x", op_bit)
+      <
     ]],
     name = 'maplist',
     params = { { 'abbr', '0|1' } },
@@ -6611,7 +6645,7 @@ M.funcs = {
     args = { 1, 3 },
     base = 1,
     name = 'mapset',
-    params = { { 'mode', 'string' }, { 'abbr', 'any' }, { 'dict', 'any' } },
+    params = { { 'mode', 'string' }, { 'abbr', 'boolean' }, { 'dict', 'boolean' } },
     signature = 'mapset({mode}, {abbr}, {dict})',
   },
   mapset__1 = {
@@ -6652,9 +6686,10 @@ M.funcs = {
       	for d in save_maps
       	    call mapset(d)
       	endfor
+      <
     ]=],
     name = 'mapset',
-    params = { { 'dict', 'any' } },
+    params = { { 'dict', 'boolean' } },
     signature = 'mapset({dict})',
   },
   match = {
@@ -6725,7 +6760,12 @@ M.funcs = {
 
     ]=],
     name = 'match',
-    params = { { 'expr', 'any' }, { 'pat', 'any' }, { 'start', 'any' }, { 'count', 'any' } },
+    params = {
+      { 'expr', 'string|any[]' },
+      { 'pat', 'string' },
+      { 'start', 'integer' },
+      { 'count', 'integer' },
+    },
     signature = 'match({expr}, {pat} [, {start} [, {count}]])',
   },
   matchadd = {
@@ -6792,11 +6832,11 @@ M.funcs = {
     ]=],
     name = 'matchadd',
     params = {
-      { 'group', 'any' },
-      { 'pattern', 'any' },
-      { 'priority', 'any' },
-      { 'id', 'any' },
-      { 'dict', 'any' },
+      { 'group', 'integer|string' },
+      { 'pattern', 'string' },
+      { 'priority', 'integer' },
+      { 'id', 'integer' },
+      { 'dict', 'string' },
     },
     signature = 'matchadd({group}, {pattern} [, {priority} [, {id} [, {dict}]]])',
     tags = { 'E798', 'E799', 'E801', 'E957' },
@@ -6844,11 +6884,11 @@ M.funcs = {
     ]=],
     name = 'matchaddpos',
     params = {
-      { 'group', 'any' },
-      { 'pos', 'any' },
-      { 'priority', 'any' },
-      { 'id', 'any' },
-      { 'dict', 'any' },
+      { 'group', 'integer|string' },
+      { 'pos', 'any[]' },
+      { 'priority', 'integer' },
+      { 'id', 'integer' },
+      { 'dict', 'string' },
     },
     signature = 'matchaddpos({group}, {pos} [, {priority} [, {id} [, {dict}]]])',
   },
@@ -6942,7 +6982,7 @@ M.funcs = {
 
     ]=],
     name = 'matchdelete',
-    params = { { 'id', 'any' }, { 'win', 'any' } },
+    params = { { 'id', 'integer' }, { 'win', 'integer' } },
     signature = 'matchdelete({id} [, {win}])',
     tags = { 'E802', 'E803' },
   },
@@ -6970,7 +7010,12 @@ M.funcs = {
 
     ]=],
     name = 'matchend',
-    params = { { 'expr', 'any' }, { 'pat', 'any' }, { 'start', 'any' }, { 'count', 'any' } },
+    params = {
+      { 'expr', 'any' },
+      { 'pat', 'string' },
+      { 'start', 'integer' },
+      { 'count', 'integer' },
+    },
     signature = 'matchend({expr}, {pat} [, {start} [, {count}]])',
   },
   matchfuzzy = {
@@ -7040,7 +7085,7 @@ M.funcs = {
       <results in `['two one']`.
     ]=],
     name = 'matchfuzzy',
-    params = { { 'list', 'any' }, { 'str', 'any' }, { 'dict', 'any' } },
+    params = { { 'list', 'any[]' }, { 'str', 'string' }, { 'dict', 'string' } },
     signature = 'matchfuzzy({list}, {str} [, {dict}])',
   },
   matchfuzzypos = {
@@ -7069,7 +7114,7 @@ M.funcs = {
       <results in `[[{"id": 10, "text": "hello"}], [[2, 3]], [127]]`
     ]=],
     name = 'matchfuzzypos',
-    params = { { 'list', 'any' }, { 'str', 'any' }, { 'dict', 'any' } },
+    params = { { 'list', 'any[]' }, { 'str', 'string' }, { 'dict', 'string' } },
     signature = 'matchfuzzypos({list}, {str} [, {dict}])',
   },
   matchlist = {
@@ -7089,7 +7134,12 @@ M.funcs = {
 
     ]=],
     name = 'matchlist',
-    params = { { 'expr', 'any' }, { 'pat', 'any' }, { 'start', 'any' }, { 'count', 'any' } },
+    params = {
+      { 'expr', 'any' },
+      { 'pat', 'string' },
+      { 'start', 'integer' },
+      { 'count', 'integer' },
+    },
     signature = 'matchlist({expr}, {pat} [, {start} [, {count}]])',
   },
   matchstr = {
@@ -7110,7 +7160,12 @@ M.funcs = {
 
     ]=],
     name = 'matchstr',
-    params = { { 'expr', 'any' }, { 'pat', 'any' }, { 'start', 'any' }, { 'count', 'any' } },
+    params = {
+      { 'expr', 'any' },
+      { 'pat', 'string' },
+      { 'start', 'integer' },
+      { 'count', 'integer' },
+    },
     signature = 'matchstr({expr}, {pat} [, {start} [, {count}]])',
   },
   matchstrlist = {
@@ -7176,7 +7231,12 @@ M.funcs = {
 
     ]=],
     name = 'matchstrpos',
-    params = { { 'expr', 'any' }, { 'pat', 'any' }, { 'start', 'any' }, { 'count', 'any' } },
+    params = {
+      { 'expr', 'any' },
+      { 'pat', 'string' },
+      { 'start', 'integer' },
+      { 'count', 'integer' },
+    },
     signature = 'matchstrpos({expr}, {pat} [, {start} [, {count}]])',
   },
   max = {
@@ -7246,7 +7306,7 @@ M.funcs = {
       <
     ]=],
     name = 'menu_get',
-    params = { { 'path', 'string' }, { 'modes', 'any' } },
+    params = { { 'path', 'string' }, { 'modes', 'string' } },
     signature = 'menu_get({path} [, {modes}])',
   },
   menu_info = {
@@ -7390,7 +7450,7 @@ M.funcs = {
 
     ]=],
     name = 'mkdir',
-    params = { { 'name', 'string' }, { 'flags', 'string' }, { 'prot', 'any' } },
+    params = { { 'name', 'string' }, { 'flags', 'string' }, { 'prot', 'string' } },
     signature = 'mkdir({name} [, {flags} [, {prot}]])',
     tags = { 'E739' },
   },
@@ -7592,7 +7652,7 @@ M.funcs = {
 
     ]=],
     name = 'nr2char',
-    params = { { 'expr', 'any' }, { 'utf8', 'any' } },
+    params = { { 'expr', 'integer' }, { 'utf8', 'boolean' } },
     signature = 'nr2char({expr} [, {utf8}])',
   },
   nvim_api__ = {
@@ -7631,7 +7691,7 @@ M.funcs = {
       "|" is an operator or a command separator.
     ]=],
     name = 'or',
-    params = { { 'expr', 'any' }, { 'expr', 'any' } },
+    params = { { 'expr', 'number' }, { 'expr', 'number' } },
     signature = 'or({expr}, {expr})',
   },
   pathshorten = {
@@ -7653,7 +7713,7 @@ M.funcs = {
 
     ]=],
     name = 'pathshorten',
-    params = { { 'path', 'string' }, { 'len', 'any' } },
+    params = { { 'path', 'string' }, { 'len', 'integer' } },
     signature = 'pathshorten({path} [, {len}])',
   },
   perleval = {
@@ -7696,7 +7756,7 @@ M.funcs = {
 
     ]=],
     name = 'pow',
-    params = { { 'x', 'any' }, { 'y', 'any' } },
+    params = { { 'x', 'number' }, { 'y', 'number' } },
     signature = 'pow({x}, {y})',
   },
   prevnonblank = {
@@ -8044,7 +8104,7 @@ M.funcs = {
 
     ]=],
     name = 'printf',
-    params = { { 'fmt', 'any' }, { 'expr1', 'any' } },
+    params = { { 'fmt', 'string' }, { 'expr1', 'any' } },
     signature = 'printf({fmt}, {expr1} ...)',
     returns = 'string',
   },
@@ -8236,7 +8296,7 @@ M.funcs = {
       <
     ]=],
     name = 'rand',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     signature = 'rand([{expr}])',
   },
   range = {
@@ -8262,7 +8322,7 @@ M.funcs = {
       <
     ]=],
     name = 'range',
-    params = { { 'expr', 'any' }, { 'max', 'any' }, { 'stride', 'any' } },
+    params = { { 'expr', 'any' }, { 'max', 'integer' }, { 'stride', 'integer' } },
     signature = 'range({expr} [, {max} [, {stride}]])',
     tags = { 'E726', 'E727' },
   },
@@ -8294,7 +8354,7 @@ M.funcs = {
       Also see |readfile()| and |writefile()|.
     ]=],
     name = 'readblob',
-    params = { { 'fname', 'string' }, { 'offset', 'any' }, { 'size', 'any' } },
+    params = { { 'fname', 'string' }, { 'offset', 'integer' }, { 'size', 'integer' } },
     signature = 'readblob({fname} [, {offset} [, {size}]])',
   },
   readdir = {
@@ -8332,7 +8392,7 @@ M.funcs = {
 
     ]=],
     name = 'readdir',
-    params = { { 'directory', 'any' }, { 'expr', 'any' } },
+    params = { { 'directory', 'string' }, { 'expr', 'integer' } },
     signature = 'readdir({directory} [, {expr}])',
   },
   readfile = {
@@ -8373,7 +8433,7 @@ M.funcs = {
 
     ]=],
     name = 'readfile',
-    params = { { 'fname', 'string' }, { 'type', 'any' }, { 'max', 'any' } },
+    params = { { 'fname', 'string' }, { 'type', 'string' }, { 'max', 'integer' } },
     signature = 'readfile({fname} [, {type} [, {max}]])',
   },
   reduce = {
@@ -8399,7 +8459,7 @@ M.funcs = {
       <
     ]=],
     name = 'reduce',
-    params = { { 'object', 'any' }, { 'func', 'any' }, { 'initial', 'any' } },
+    params = { { 'object', 'any' }, { 'func', 'function' }, { 'initial', 'any' } },
     signature = 'reduce({object}, {func} [, {initial}])',
   },
   reg_executing = {
@@ -8545,7 +8605,7 @@ M.funcs = {
 
     ]=],
     name = 'remove',
-    params = { { 'list', 'any' }, { 'idx', 'integer' }, { 'end', 'any' } },
+    params = { { 'list', 'any[]' }, { 'idx', 'integer' }, { 'end', 'integer' } },
     signature = 'remove({list}, {idx}, {end})',
   },
   remove__2 = {
@@ -8572,7 +8632,7 @@ M.funcs = {
       <
     ]=],
     name = 'remove',
-    params = { { 'blob', 'any' }, { 'idx', 'integer' }, { 'end', 'any' } },
+    params = { { 'blob', 'any' }, { 'idx', 'integer' }, { 'end', 'integer' } },
     signature = 'remove({blob}, {idx}, {end})',
   },
   remove__4 = {
@@ -8586,7 +8646,7 @@ M.funcs = {
       Returns zero on error.
     ]=],
     name = 'remove',
-    params = { { 'dict', 'any' }, { 'key', 'any' } },
+    params = { { 'dict', 'any' }, { 'key', 'string' } },
     signature = 'remove({dict}, {key})',
   },
   rename = {
@@ -8602,7 +8662,7 @@ M.funcs = {
 
     ]=],
     name = 'rename',
-    params = { { 'from', 'any' }, { 'to', 'any' } },
+    params = { { 'from', 'string' }, { 'to', 'string' } },
     signature = 'rename({from}, {to})',
   },
   ['repeat'] = {
@@ -8621,7 +8681,7 @@ M.funcs = {
     ]=],
     fast = true,
     name = 'repeat',
-    params = { { 'expr', 'any' }, { 'count', 'any' } },
+    params = { { 'expr', 'any' }, { 'count', 'integer' } },
     signature = 'repeat({expr}, {count})',
   },
   resolve = {
@@ -8644,7 +8704,7 @@ M.funcs = {
     ]=],
     fast = true,
     name = 'resolve',
-    params = { { 'filename', 'any' } },
+    params = { { 'filename', 'string' } },
     signature = 'resolve({filename})',
   },
   reverse = {
@@ -8685,7 +8745,7 @@ M.funcs = {
     ]=],
     float_func = 'round',
     name = 'round',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     signature = 'round({expr})',
   },
   rpcnotify = {
@@ -8698,7 +8758,7 @@ M.funcs = {
       <
     ]=],
     name = 'rpcnotify',
-    params = { { 'channel', 'any' }, { 'event', 'any' }, { 'args', 'any' } },
+    params = { { 'channel', 'integer' }, { 'event', 'string' }, { 'args', 'any' } },
     signature = 'rpcnotify({channel}, {event} [, {args}...])',
   },
   rpcrequest = {
@@ -8711,10 +8771,11 @@ M.funcs = {
       <
     ]=],
     name = 'rpcrequest',
-    params = { { 'channel', 'any' }, { 'method', 'any' }, { 'args', 'any' } },
+    params = { { 'channel', 'integer' }, { 'method', 'string' }, { 'args', 'any' } },
     signature = 'rpcrequest({channel}, {method} [, {args}...])',
   },
   rpcstart = {
+    deprecated = true,
     args = { 1, 2 },
     desc = [=[
       Deprecated. Replace  >vim
@@ -8724,7 +8785,7 @@ M.funcs = {
       <
     ]=],
     name = 'rpcstart',
-    params = { { 'prog', 'any' }, { 'argv', 'any' } },
+    params = { { 'prog', 'string' }, { 'argv', 'any' } },
     signature = 'rpcstart({prog} [, {argv}])',
   },
   rpcstop = {
@@ -8768,7 +8829,7 @@ M.funcs = {
 
     ]=],
     name = 'screenattr',
-    params = { { 'row', 'any' }, { 'col', 'integer' } },
+    params = { { 'row', 'integer' }, { 'col', 'integer' } },
     signature = 'screenattr({row}, {col})',
   },
   screenchar = {
@@ -8786,7 +8847,7 @@ M.funcs = {
 
     ]=],
     name = 'screenchar',
-    params = { { 'row', 'any' }, { 'col', 'integer' } },
+    params = { { 'row', 'integer' }, { 'col', 'integer' } },
     signature = 'screenchar({row}, {col})',
   },
   screenchars = {
@@ -8801,7 +8862,7 @@ M.funcs = {
 
     ]=],
     name = 'screenchars',
-    params = { { 'row', 'any' }, { 'col', 'integer' } },
+    params = { { 'row', 'integer' }, { 'col', 'integer' } },
     signature = 'screenchars({row}, {col})',
   },
   screencol = {
@@ -8882,7 +8943,7 @@ M.funcs = {
 
     ]=],
     name = 'screenstring',
-    params = { { 'row', 'any' }, { 'col', 'integer' } },
+    params = { { 'row', 'integer' }, { 'col', 'integer' } },
     signature = 'screenstring({row}, {col})',
   },
   search = {
@@ -8996,11 +9057,11 @@ M.funcs = {
     ]=],
     name = 'search',
     params = {
-      { 'pattern', 'any' },
+      { 'pattern', 'string' },
       { 'flags', 'string' },
-      { 'stopline', 'any' },
+      { 'stopline', 'integer' },
       { 'timeout', 'integer' },
-      { 'skip', 'any' },
+      { 'skip', 'string|function' },
     },
     signature = 'search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])',
   },
@@ -9156,7 +9217,7 @@ M.funcs = {
       <
     ]=],
     name = 'searchdecl',
-    params = { { 'name', 'string' }, { 'global', 'any' }, { 'thisblock', 'any' } },
+    params = { { 'name', 'string' }, { 'global', 'boolean' }, { 'thisblock', 'boolean' } },
     signature = 'searchdecl({name} [, {global} [, {thisblock}]])',
   },
   searchpair = {
@@ -9248,12 +9309,12 @@ M.funcs = {
     ]=],
     name = 'searchpair',
     params = {
-      { 'start', 'any' },
-      { 'middle', 'any' },
-      { 'end', 'any' },
+      { 'start', 'string' },
+      { 'middle', 'string' },
+      { 'end', 'string' },
       { 'flags', 'string' },
-      { 'skip', 'any' },
-      { 'stopline', 'any' },
+      { 'skip', 'string|function' },
+      { 'stopline', 'integer' },
       { 'timeout', 'integer' },
     },
     returns = 'integer',
@@ -9274,12 +9335,12 @@ M.funcs = {
     ]=],
     name = 'searchpairpos',
     params = {
-      { 'start', 'any' },
-      { 'middle', 'any' },
-      { 'end', 'any' },
+      { 'start', 'string' },
+      { 'middle', 'string' },
+      { 'end', 'string' },
       { 'flags', 'string' },
-      { 'skip', 'any' },
-      { 'stopline', 'any' },
+      { 'skip', 'string|function' },
+      { 'stopline', 'integer' },
       { 'timeout', 'integer' },
     },
     returns = '[integer, integer]',
@@ -9306,11 +9367,11 @@ M.funcs = {
     ]=],
     name = 'searchpos',
     params = {
-      { 'pattern', 'any' },
+      { 'pattern', 'string' },
       { 'flags', 'string' },
-      { 'stopline', 'any' },
+      { 'stopline', 'integer' },
       { 'timeout', 'integer' },
-      { 'skip', 'any' },
+      { 'skip', 'string|function' },
     },
     signature = 'searchpos({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])',
   },
@@ -9363,7 +9424,7 @@ M.funcs = {
       <
     ]=],
     name = 'serverstart',
-    params = { { 'address', 'any' } },
+    params = { { 'address', 'string' } },
     signature = 'serverstart([{address}])',
   },
   serverstop = {
@@ -9375,7 +9436,7 @@ M.funcs = {
       address in |serverlist()|.
     ]=],
     name = 'serverstop',
-    params = { { 'address', 'any' } },
+    params = { { 'address', 'string' } },
     signature = 'serverstop({address})',
   },
   setbufline = {
@@ -9408,7 +9469,7 @@ M.funcs = {
 
     ]=],
     name = 'setbufline',
-    params = { { 'buf', 'any' }, { 'lnum', 'integer' }, { 'text', 'any' } },
+    params = { { 'buf', 'integer|string' }, { 'lnum', 'integer' }, { 'text', 'string|string[]' } },
     signature = 'setbufline({buf}, {lnum}, {text})',
   },
   setbufvar = {
@@ -9430,7 +9491,7 @@ M.funcs = {
 
     ]=],
     name = 'setbufvar',
-    params = { { 'buf', 'any' }, { 'varname', 'string' }, { 'val', 'any' } },
+    params = { { 'buf', 'integer|string' }, { 'varname', 'string' }, { 'val', 'any' } },
     signature = 'setbufvar({buf}, {varname}, {val})',
   },
   setcellwidths = {
@@ -9471,7 +9532,7 @@ M.funcs = {
       look right you need to adjust the {list} argument.
     ]=],
     name = 'setcellwidths',
-    params = { { 'list', 'any' } },
+    params = { { 'list', 'any[]' } },
     signature = 'setcellwidths({list})',
   },
   setcharpos = {
@@ -9490,7 +9551,7 @@ M.funcs = {
 
     ]=],
     name = 'setcharpos',
-    params = { { 'expr', 'any' }, { 'list', 'any' } },
+    params = { { 'expr', 'string' }, { 'list', 'integer[]' } },
     signature = 'setcharpos({expr}, {list})',
   },
   setcharsearch = {
@@ -9518,7 +9579,7 @@ M.funcs = {
 
     ]=],
     name = 'setcharsearch',
-    params = { { 'dict', 'any' } },
+    params = { { 'dict', 'string' } },
     signature = 'setcharsearch({dict})',
   },
   setcmdline = {
@@ -9533,7 +9594,7 @@ M.funcs = {
 
     ]=],
     name = 'setcmdline',
-    params = { { 'str', 'any' }, { 'pos', 'any' } },
+    params = { { 'str', 'string' }, { 'pos', 'integer' } },
     signature = 'setcmdline({str} [, {pos}])',
   },
   setcmdpos = {
@@ -9556,14 +9617,14 @@ M.funcs = {
 
     ]=],
     name = 'setcmdpos',
-    params = { { 'pos', 'any' } },
+    params = { { 'pos', 'integer' } },
     signature = 'setcmdpos({pos})',
   },
   setcursorcharpos = {
     args = { 1, 3 },
     base = 1,
     name = 'setcursorcharpos',
-    params = { { 'lnum', 'integer' }, { 'col', 'integer' }, { 'off', 'any' } },
+    params = { { 'lnum', 'integer' }, { 'col', 'integer' }, { 'off', 'integer' } },
     signature = 'setcursorcharpos({lnum}, {col} [, {off}])',
   },
   setcursorcharpos__1 = {
@@ -9582,7 +9643,7 @@ M.funcs = {
 
     ]=],
     name = 'setcursorcharpos',
-    params = { { 'list', 'any' } },
+    params = { { 'list', 'integer[]' } },
     signature = 'setcursorcharpos({list})',
   },
   setenv = {
@@ -9597,7 +9658,7 @@ M.funcs = {
 
     ]=],
     name = 'setenv',
-    params = { { 'name', 'string' }, { 'val', 'any' } },
+    params = { { 'name', 'string' }, { 'val', 'string' } },
     signature = 'setenv({name}, {val})',
   },
   setfperm = {
@@ -9682,7 +9743,7 @@ M.funcs = {
 
     ]=],
     name = 'setloclist',
-    params = { { 'nr', 'integer' }, { 'list', 'any' }, { 'action', 'any' }, { 'what', 'any' } },
+    params = { { 'nr', 'integer' }, { 'list', 'any' }, { 'action', 'string' }, { 'what', 'table' } },
     signature = 'setloclist({nr}, {list} [, {action} [, {what}]])',
   },
   setmatches = {
@@ -9698,7 +9759,7 @@ M.funcs = {
 
     ]=],
     name = 'setmatches',
-    params = { { 'list', 'any' }, { 'win', 'any' } },
+    params = { { 'list', 'any' }, { 'win', 'integer' } },
     signature = 'setmatches({list} [, {win}])',
   },
   setpos = {
@@ -9755,7 +9816,7 @@ M.funcs = {
 
     ]=],
     name = 'setpos',
-    params = { { 'expr', 'any' }, { 'list', 'any' } },
+    params = { { 'expr', 'string' }, { 'list', 'integer[]' } },
     signature = 'setpos({expr}, {list})',
   },
   setqflist = {
@@ -9877,7 +9938,7 @@ M.funcs = {
 
     ]=],
     name = 'setqflist',
-    params = { { 'list', 'any' }, { 'action', 'any' }, { 'what', 'any' } },
+    params = { { 'list', 'any[]' }, { 'action', 'string' }, { 'what', 'table' } },
     signature = 'setqflist({list} [, {action} [, {what}]])',
   },
   setreg = {
@@ -10027,7 +10088,7 @@ M.funcs = {
       <
     ]=],
     name = 'settagstack',
-    params = { { 'nr', 'integer' }, { 'dict', 'any' }, { 'action', 'any' } },
+    params = { { 'nr', 'integer' }, { 'dict', 'any' }, { 'action', 'string' } },
     signature = 'settagstack({nr}, {dict} [, {action}])',
   },
   setwinvar = {
@@ -10093,7 +10154,7 @@ M.funcs = {
 
     ]=],
     name = 'shellescape',
-    params = { { 'string', 'string' }, { 'special', 'any' } },
+    params = { { 'string', 'string' }, { 'special', 'boolean' } },
     signature = 'shellescape({string} [, {special}])',
   },
   shiftwidth = {
@@ -10299,7 +10360,7 @@ M.funcs = {
       <
     ]=],
     name = 'sign_getplaced',
-    params = { { 'buf', 'any' }, { 'dict', 'vim.fn.sign_getplaced.dict' } },
+    params = { { 'buf', 'integer|string' }, { 'dict', 'vim.fn.sign_getplaced.dict' } },
     signature = 'sign_getplaced([{buf} [, {dict}]])',
     returns = 'vim.fn.sign_getplaced.ret.item[]',
   },
@@ -10381,10 +10442,10 @@ M.funcs = {
     ]=],
     name = 'sign_place',
     params = {
-      { 'id', 'any' },
-      { 'group', 'any' },
+      { 'id', 'integer' },
+      { 'group', 'string' },
       { 'name', 'string' },
-      { 'buf', 'any' },
+      { 'buf', 'integer|string' },
       { 'dict', 'vim.fn.sign_place.dict' },
     },
     signature = 'sign_place({id}, {group}, {name}, {buf} [, {dict}])',
@@ -10607,7 +10668,7 @@ M.funcs = {
 
     ]=],
     name = 'simplify',
-    params = { { 'filename', 'any' } },
+    params = { { 'filename', 'string' } },
     signature = 'simplify({filename})',
   },
   sin = {
@@ -10626,7 +10687,7 @@ M.funcs = {
     ]=],
     float_func = 'sin',
     name = 'sin',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     signature = 'sin({expr})',
   },
   sinh = {
@@ -10646,7 +10707,7 @@ M.funcs = {
     ]=],
     float_func = 'sinh',
     name = 'sinh',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     signature = 'sinh({expr})',
   },
   slice = {
@@ -10664,7 +10725,7 @@ M.funcs = {
 
     ]=],
     name = 'slice',
-    params = { { 'expr', 'any' }, { 'start', 'any' }, { 'end', 'any' } },
+    params = { { 'expr', 'any' }, { 'start', 'integer' }, { 'end', 'integer' } },
     signature = 'slice({expr}, {start} [, {end}])',
   },
   sockconnect = {
@@ -10695,7 +10756,7 @@ M.funcs = {
         - 0 on invalid arguments or connection failure.
     ]=],
     name = 'sockconnect',
-    params = { { 'mode', 'string' }, { 'address', 'any' }, { 'opts', 'table' } },
+    params = { { 'mode', 'string' }, { 'address', 'string' }, { 'opts', 'table' } },
     signature = 'sockconnect({mode}, {address} [, {opts}])',
   },
   sort = {
@@ -10776,7 +10837,7 @@ M.funcs = {
       <
     ]=],
     name = 'sort',
-    params = { { 'list', 'any' }, { 'how', 'any' }, { 'dict', 'any' } },
+    params = { { 'list', 'any' }, { 'how', 'string|function' }, { 'dict', 'any' } },
     signature = 'sort({list} [, {how} [, {dict}]])',
   },
   soundfold = {
@@ -10792,7 +10853,7 @@ M.funcs = {
 
     ]=],
     name = 'soundfold',
-    params = { { 'word', 'any' } },
+    params = { { 'word', 'string' } },
     signature = 'soundfold({word})',
   },
   spellbadword = {
@@ -10824,7 +10885,7 @@ M.funcs = {
 
     ]=],
     name = 'spellbadword',
-    params = { { 'sentence', 'any' } },
+    params = { { 'sentence', 'string' } },
     signature = 'spellbadword([{sentence}])',
   },
   spellsuggest = {
@@ -10853,7 +10914,7 @@ M.funcs = {
 
     ]=],
     name = 'spellsuggest',
-    params = { { 'word', 'any' }, { 'max', 'any' }, { 'capital', 'any' } },
+    params = { { 'word', 'string' }, { 'max', 'integer' }, { 'capital', 'boolean' } },
     signature = 'spellsuggest({word} [, {max} [, {capital}]])',
   },
   split = {
@@ -10886,7 +10947,7 @@ M.funcs = {
 
     ]=],
     name = 'split',
-    params = { { 'string', 'string' }, { 'pattern', 'any' }, { 'keepempty', 'any' } },
+    params = { { 'string', 'string' }, { 'pattern', 'string' }, { 'keepempty', 'boolean' } },
     signature = 'split({string} [, {pattern} [, {keepempty}]])',
   },
   sqrt = {
@@ -10908,7 +10969,7 @@ M.funcs = {
     ]=],
     float_func = 'sqrt',
     name = 'sqrt',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     signature = 'sqrt({expr})',
   },
   srand = {
@@ -10930,7 +10991,7 @@ M.funcs = {
       <
     ]=],
     name = 'srand',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     signature = 'srand([{expr}])',
   },
   stdioopen = {
@@ -11053,7 +11114,7 @@ M.funcs = {
 
     ]=],
     name = 'str2float',
-    params = { { 'string', 'string' }, { 'quoted', 'any' } },
+    params = { { 'string', 'string' }, { 'quoted', 'boolean' } },
     signature = 'str2float({string} [, {quoted}])',
   },
   str2list = {
@@ -11073,7 +11134,7 @@ M.funcs = {
 
     ]=],
     name = 'str2list',
-    params = { { 'string', 'string' }, { 'utf8', 'any' } },
+    params = { { 'string', 'string' }, { 'utf8', 'boolean' } },
     signature = 'str2list({string} [, {utf8}])',
   },
   str2nr = {
@@ -11100,7 +11161,7 @@ M.funcs = {
 
     ]=],
     name = 'str2nr',
-    params = { { 'string', 'string' }, { 'base', 'any' } },
+    params = { { 'string', 'string' }, { 'base', 'integer' } },
     signature = 'str2nr({string} [, {base}])',
   },
   strcharlen = {
@@ -11142,7 +11203,12 @@ M.funcs = {
     ]=],
     fast = true,
     name = 'strcharpart',
-    params = { { 'src', 'any' }, { 'start', 'any' }, { 'len', 'any' }, { 'skipcc', 'any' } },
+    params = {
+      { 'src', 'string' },
+      { 'start', 'integer' },
+      { 'len', 'integer' },
+      { 'skipcc', 'boolean' },
+    },
     signature = 'strcharpart({src}, {start} [, {len} [, {skipcc}]])',
   },
   strchars = {
@@ -11178,7 +11244,7 @@ M.funcs = {
       <
     ]=],
     name = 'strchars',
-    params = { { 'string', 'string' }, { 'skipcc', 'any' } },
+    params = { { 'string', 'string' }, { 'skipcc', 'boolean' } },
     returns = 'integer',
     signature = 'strchars({string} [, {skipcc}])',
   },
@@ -11227,7 +11293,7 @@ M.funcs = {
 
     ]=],
     name = 'strftime',
-    params = { { 'format', 'any' }, { 'time', 'any' } },
+    params = { { 'format', 'string' }, { 'time', 'number' } },
     returns = 'string',
     signature = 'strftime({format} [, {time}])',
   },
@@ -11936,7 +12002,7 @@ M.funcs = {
 
     ]=],
     name = 'tabpagebuflist',
-    params = { { 'arg', 'any' } },
+    params = { { 'arg', 'integer' } },
     signature = 'tabpagebuflist([{arg}])',
   },
   tabpagenr = {
@@ -12117,7 +12183,7 @@ M.funcs = {
       described in |terminal|.
     ]=],
     name = 'termopen',
-    params = { { 'cmd', 'any' }, { 'opts', 'table' } },
+    params = { { 'cmd', 'string|string[]' }, { 'opts', 'table' } },
     signature = 'termopen({cmd} [, {opts}])',
   },
   test_garbagecollect_now = {
@@ -12157,7 +12223,7 @@ M.funcs = {
 
     ]=],
     name = 'timer_info',
-    params = { { 'id', 'any' } },
+    params = { { 'id', 'integer' } },
     signature = 'timer_info([{id}])',
   },
   timer_pause = {
@@ -12178,7 +12244,7 @@ M.funcs = {
 
     ]=],
     name = 'timer_pause',
-    params = { { 'timer', 'any' }, { 'paused', 'any' } },
+    params = { { 'timer', 'integer' }, { 'paused', 'boolean' } },
     signature = 'timer_pause({timer}, {paused})',
   },
   timer_start = {
@@ -12217,7 +12283,7 @@ M.funcs = {
 
     ]=],
     name = 'timer_start',
-    params = { { 'time', 'any' }, { 'callback', 'any' }, { 'options', 'table' } },
+    params = { { 'time', 'number' }, { 'callback', 'string|function' }, { 'options', 'table' } },
     signature = 'timer_start({time}, {callback} [, {options}])',
   },
   timer_stop = {
@@ -12230,7 +12296,7 @@ M.funcs = {
 
     ]=],
     name = 'timer_stop',
-    params = { { 'timer', 'any' } },
+    params = { { 'timer', 'integer' } },
     signature = 'timer_stop({timer})',
   },
   timer_stopall = {
@@ -12255,7 +12321,7 @@ M.funcs = {
     ]=],
     fast = true,
     name = 'tolower',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'string' } },
     returns = 'string',
     signature = 'tolower({expr})',
   },
@@ -12270,7 +12336,7 @@ M.funcs = {
     ]=],
     fast = true,
     name = 'toupper',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'string' } },
     returns = 'string',
     signature = 'toupper({expr})',
   },
@@ -12332,7 +12398,7 @@ M.funcs = {
 
     ]=],
     name = 'trim',
-    params = { { 'text', 'any' }, { 'mask', 'string' }, { 'dir', '0|1|2' } },
+    params = { { 'text', 'string' }, { 'mask', 'string' }, { 'dir', '0|1|2' } },
     returns = 'string',
     signature = 'trim({text} [, {mask} [, {dir}]])',
   },
@@ -12355,7 +12421,7 @@ M.funcs = {
     ]=],
     float_func = 'trunc',
     name = 'trunc',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'number' } },
     returns = 'integer',
     signature = 'trunc({expr})',
   },
@@ -12388,6 +12454,7 @@ M.funcs = {
       	if myvar is v:null | endif
       <To check if the v:t_ variables exist use this: >vim
       	if exists('v:t_number') | endif
+      <
 
     ]=],
     fast = true,
@@ -12523,8 +12590,8 @@ M.funcs = {
     params = {
       { 'string', 'string' },
       { 'idx', 'integer' },
-      { 'countcc', 'any' },
-      { 'charidx', 'any' },
+      { 'countcc', 'boolean' },
+      { 'charidx', 'boolean' },
     },
     returns = 'integer',
     signature = 'utf16idx({string}, {idx} [, {countcc} [, {charidx}]])',
@@ -12591,10 +12658,11 @@ M.funcs = {
       A more advanced example that echoes the maximum length of
       all lines: >vim
           echo max(map(range(1, line('$')), "virtcol([v:val, '$'])"))
+      <
 
     ]=],
     name = 'virtcol',
-    params = { { 'expr', 'any' }, { 'list', 'any' }, { 'winid', 'integer' } },
+    params = { { 'expr', 'string|integer[]' }, { 'list', 'boolean' }, { 'winid', 'integer' } },
     signature = 'virtcol({expr} [, {list} [, {winid}]])',
   },
   virtcol2col = {
@@ -12648,7 +12716,7 @@ M.funcs = {
       the old value is returned.  See |non-zero-arg|.
     ]=],
     name = 'visualmode',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'boolean' } },
     signature = 'visualmode([{expr}])',
   },
   wait = {
@@ -12670,7 +12738,7 @@ M.funcs = {
       	-3 if an error occurred
     ]=],
     name = 'wait',
-    params = { { 'timeout', 'integer' }, { 'condition', 'any' }, { 'interval', 'any' } },
+    params = { { 'timeout', 'integer' }, { 'condition', 'any' }, { 'interval', 'number' } },
     signature = 'wait({timeout}, {condition} [, {interval}])',
   },
   wildmenumode = {
@@ -12708,7 +12776,7 @@ M.funcs = {
 
     ]=],
     name = 'win_execute',
-    params = { { 'id', 'any' }, { 'command', 'any' }, { 'silent', 'boolean' } },
+    params = { { 'id', 'integer' }, { 'command', 'string' }, { 'silent', 'boolean' } },
     signature = 'win_execute({id}, {command} [, {silent}])',
   },
   win_findbuf = {
@@ -12720,7 +12788,7 @@ M.funcs = {
 
     ]=],
     name = 'win_findbuf',
-    params = { { 'bufnr', 'any' } },
+    params = { { 'bufnr', 'integer' } },
     returns = 'integer[]',
     signature = 'win_findbuf({bufnr})',
   },
@@ -12738,7 +12806,7 @@ M.funcs = {
 
     ]=],
     name = 'win_getid',
-    params = { { 'win', 'any' }, { 'tab', 'any' } },
+    params = { { 'win', 'integer' }, { 'tab', 'integer' } },
     returns = 'integer',
     signature = 'win_getid([{win} [, {tab}]])',
   },
@@ -12779,7 +12847,7 @@ M.funcs = {
 
     ]=],
     name = 'win_gotoid',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'integer' } },
     returns = '0|1',
     signature = 'win_gotoid({expr})',
   },
@@ -12793,7 +12861,7 @@ M.funcs = {
 
     ]=],
     name = 'win_id2tabwin',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'integer' } },
     signature = 'win_id2tabwin({expr})',
   },
   win_id2win = {
@@ -12805,7 +12873,7 @@ M.funcs = {
 
     ]=],
     name = 'win_id2win',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'integer' } },
     signature = 'win_id2win({expr})',
   },
   win_move_separator = {
@@ -12828,7 +12896,7 @@ M.funcs = {
 
     ]=],
     name = 'win_move_separator',
-    params = { { 'nr', 'integer' }, { 'offset', 'any' } },
+    params = { { 'nr', 'integer' }, { 'offset', 'integer' } },
     signature = 'win_move_separator({nr}, {offset})',
   },
   win_move_statusline = {
@@ -12848,7 +12916,7 @@ M.funcs = {
 
     ]=],
     name = 'win_move_statusline',
-    params = { { 'nr', 'integer' }, { 'offset', 'any' } },
+    params = { { 'nr', 'integer' }, { 'offset', 'integer' } },
     signature = 'win_move_statusline({nr}, {offset})',
   },
   win_screenpos = {
@@ -12891,7 +12959,7 @@ M.funcs = {
 
     ]=],
     name = 'win_splitmove',
-    params = { { 'nr', 'integer' }, { 'target', 'any' }, { 'options', 'table' } },
+    params = { { 'nr', 'integer' }, { 'target', 'integer' }, { 'options', 'table' } },
     signature = 'win_splitmove({nr}, {target} [, {options}])',
   },
   winbufnr = {
@@ -12949,6 +13017,7 @@ M.funcs = {
       This excludes any window toolbar line.
       Examples: >vim
         echo "The current window has " .. winheight(0) .. " lines."
+      <
 
     ]=],
     name = 'winheight',
@@ -13046,10 +13115,10 @@ M.funcs = {
       	let window_count = winnr('$')
       	let prev_window = winnr('#')
       	let wnum = winnr('3k')
-
+      <
     ]=],
     name = 'winnr',
-    params = { { 'arg', 'any' } },
+    params = { { 'arg', 'string|integer' } },
     signature = 'winnr([{arg}])',
   },
   winrestcmd = {
@@ -13221,6 +13290,7 @@ M.funcs = {
       To copy a file byte for byte: >vim
       	let fl = readfile("foo", "b")
       	call writefile(fl, "foocopy", "b")
+      <
 
     ]=],
     name = 'writefile',
@@ -13239,7 +13309,7 @@ M.funcs = {
       <
     ]=],
     name = 'xor',
-    params = { { 'expr', 'any' }, { 'expr', 'any' } },
+    params = { { 'expr', 'number' }, { 'expr', 'number' } },
     signature = 'xor({expr}, {expr})',
   },
 }


### PR DESCRIPTION
Thanks to @lewis6991 's fantastic work on `gen_*.lua`, we can easily add structured info to builtin.txt, so let's do that.

Notes:
- ~~The parameter list intentionally does not surround each name with "{...}" because this just adds noise.~~
- Currently the types are Lua types. Can revisit this later, or maybe it's fine.

TODO(future):
- remove the "{...}" from param lists in api.txt, lua.txt
- use AI to generate the `returns_desc` for each "return" item, based on the `desc` field.
    - feeding eval.lua into chatgpt/cody hits the free tier limit, can someone do this? :)
    - also for params