### PR TITLE
vim-patch:9.1.0758: it's possible to set an invalid key to 'wildcharm'

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1216,8 +1216,9 @@ static OptVal get_option_newval(OptIndex opt_idx, int opt_flags, set_prefix_T pr
     // Different ways to set a number option:
     // &            set to default value
     // <            set to global value
-    // <xx>         accept special key codes for 'wildchar'
-    // c            accept any non-digit for 'wildchar'
+    // <xx>         accept special key codes for 'wildchar' or 'wildcharm'
+    // ^x           accept ctrl key codes for 'wildchar' or 'wildcharm'
+    // c            accept any non-digit for 'wildchar' or 'wildcharm'
     // [-]0-9       set number
     // other        error
     arg++;
@@ -1239,7 +1240,7 @@ static OptVal get_option_newval(OptIndex opt_idx, int opt_flags, set_prefix_T pr
                    || (*arg != NUL && (!arg[1] || ascii_iswhite(arg[1]))
                        && !ascii_isdigit(*arg)))) {
       newval_num = string_to_key(arg);
-      if (newval_num == 0 && (OptInt *)varp != &p_wcm) {
+      if (newval_num == 0) {
         *errmsg = e_invarg;
         return newval;
       }


### PR DESCRIPTION
#### vim-patch:9.1.0758: it's possible to set an invalid key to 'wildcharm'

Problem:  it's possible to set an invalid key to 'wildcharm'
Solution: error out, if the 'wildcharm' value is an invalid key
          (Milly)

closes: vim/vim#15787

https://github.com/vim/vim/commit/40c6babc1789aceb241b23bab76eea16da37e33d

Co-authored-by: Milly <milly.ca@gmail.com>