### PR TITLE
fix(coverity/497355): shada_read_when_writing out of bounds read

### DIFF
--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -1886,13 +1886,18 @@ static inline ShaDaWriteResult shada_read_when_writing(FileDescriptor *const sd_
           shada_free_shada_entry(&entry);
           break;
         }
-        if (wms->global_marks[idx].data.type == kSDItemMissing) {
+
+        // Global or numbered mark.
+        PossiblyFreedShadaEntry *mark
+          = idx < 26 ? &wms->global_marks[idx] : &wms->numbered_marks[idx];
+
+        if (mark->data.type == kSDItemMissing) {
           if (namedfm[idx].fmark.timestamp >= entry.timestamp) {
             shada_free_shada_entry(&entry);
             break;
           }
         }
-        COMPARE_WITH_ENTRY(&wms->global_marks[idx], entry);
+        COMPARE_WITH_ENTRY(mark, entry);
       }
       break;
     case kSDItemChange:


### PR DESCRIPTION
Problem:
There appears to be an intentional array out of bounds read when indexing global and numbered marks since they are adjacent in the struct that holds them.

Solution:
Explicitly index numeric marks array to avoid reading out of bounds from global marks array.