### PR TITLE
vim-patch:9.1.0759: screenpos() may return invalid position

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5096,6 +5096,12 @@ void clear_winopt(winopt_T *wop)
 
 void didset_window_options(win_T *wp, bool valid_cursor)
 {
+  // Set w_leftcol or w_skipcol to zero.
+  if (wp->w_p_wrap) {
+    wp->w_leftcol = 0;
+  } else {
+    wp->w_skipcol = 0;
+  }
   check_colorcolumn(wp);
   briopt_check(wp);
   fill_culopt_flags(NULL, wp);

--- a/test/old/testdir/test_cursor_func.vim
+++ b/test/old/testdir/test_cursor_func.vim
@@ -279,6 +279,21 @@ func Test_screenpos_number()
   bwipe!
 endfunc
 
+func Test_screenpos_edit_newfile()
+  new
+  20vsp
+  setl nowrap
+  call setline(1, 'abcdefghijklmnopqrstuvwxyz')
+  call cursor(1, 10)
+  norm! 5zl
+  call assert_equal(#{col: 5, row: 1, endcol: 5, curscol: 5}, screenpos(win_getid(), 1, 10))
+  enew!
+  call assert_equal(1, &l:wrap)
+  call assert_equal(#{col: 1, row: 1, endcol: 1, curscol: 1}, screenpos(win_getid(), 1, 1))
+
+  bwipe!
+endfunc
+
 " Save the visual start character position
 func SaveVisualStartCharPos()
   call add(g:VisualStartPos, getcharpos('v'))


### PR DESCRIPTION
Fix #30639

#### vim-patch:9.1.0759: screenpos() may return invalid position

Problem:  screenpos() may return invalid position
          after switching buffers (Greg Hurrell)
Solution: reset w_leftcol if wrapping has been set
          after copying wrap option

closes: vim/vim#15803

https://github.com/vim/vim/commit/b065a10e245d020c11b521a2a5062300ca9891fc

Co-authored-by: Christian Brabandt <cb@256bit.org>