### PR TITLE
vim-patch:9.1.0003: Cannot build against Ruby 33 dynamically

### DIFF
--- a/test/old/testdir/test_ruby.vim
+++ b/test/old/testdir/test_ruby.vim
@@ -282,7 +282,7 @@ func Test_ruby_Vim_buffer_get()
   call assert_match('Xfoo1$', rubyeval('Vim::Buffer[1].name'))
   call assert_match('Xfoo2$', rubyeval('Vim::Buffer[2].name'))
   call assert_fails('ruby print Vim::Buffer[3].name',
-        \           "NoMethodError: undefined method `name' for nil:NilClass")
+        \           "NoMethodError: undefined method `name' for nil")
   %bwipe
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.0003: Cannot build against Ruby 33 dynamically

Problem:  Cannot build against Ruby 33 dynamically
Solution: Ruby 33 removed transient heap, so do not use
          rb_ary_transient anymore, NoMethodError format changed,
          so update test for expected error message
          (Isao Sato)

- ruby-3.3 removed transient heap for ruby/dyn

when +ruby/dyn with ruby-3.3 do command :ruby, E448 occur.
ruby-3.3 has no transient heap anymore, so disable rb_ary_transient etc.

$ LC_ALL=C VIMRUNTIME=runtime ./src/vim -u NONE -c 'ruby puts RUBY_VERSION'
"=> Error detected while processing command line:
"=> E448: Could not load library function rb_ary_detransient
"=> E266: Sorry, this command is disabled, the Ruby library could not be
    loaded.

- ruby-3.3 changed NoMethodError format:

$ rvm 3.2.2, 3.3.0-rc1 do ruby -e 'begin; nil.name; rescue => e; puts "%s : %s"%[RUBY_VERSION, e.message]; end '
=> 3.2.2 : undefined method `name' for nil:NilClass
=> 3.3.0 : undefined method `name' for nil

so loose pattern in Test_ruby_Vim_buffer_get()

closes: vim/vim#13741

https://github.com/vim/vim/commit/443657b32becb2318ae40e30a849bbe5cc1a153c

Co-authored-by: Isao Sato <svardew@gmail.com>