### PR TITLE
fix(coverity/510436): shada_read_when_writing index out of bounds

### DIFF
--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -1889,7 +1889,7 @@ static inline ShaDaWriteResult shada_read_when_writing(FileDescriptor *const sd_
 
         // Global or numbered mark.
         PossiblyFreedShadaEntry *mark
-          = idx < 26 ? &wms->global_marks[idx] : &wms->numbered_marks[idx];
+          = idx < 26 ? &wms->global_marks[idx] : &wms->numbered_marks[idx - 26];
 
         if (mark->data.type == kSDItemMissing) {
           if (namedfm[idx].fmark.timestamp >= entry.timestamp) {


### PR DESCRIPTION
Problem:
Index for global and numbered marks out of bounds when indexing into numbered marks array (contains 10 elements but indexed by values 26 through 35.

Solution:
Offset index by number of global marks to correctly index numbered marks array.