### PR TITLE
fix(runtime): add comment string for gleam lang

### DIFF
--- a/runtime/ftplugin/gleam.lua
+++ b/runtime/ftplugin/gleam.lua
@@ -1,0 +1,3 @@
+vim.bo.commentstring = '// %s'
+
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring<'


### PR DESCRIPTION
This adds `commentstring` for the gleam lang so that `gcc` and other comment key bindings work in gleam files.