### PR TITLE
fix(lsp): tagfunc fails in unusual buffer

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -296,6 +296,9 @@ local function get_lines(bufnr, rows)
   end
 
   local filename = api.nvim_buf_get_name(bufnr)
+  if vim.fn.isdirectory(filename) ~= 0 then
+    return {}
+  end
 
   -- get the data from the file
   local fd = uv.fs_open(filename, 'r', 438)


### PR DESCRIPTION
Problem:
tagfunc failed in a weird buffer (either a directory or some other non-file buffer, I don't remember):

    E987: Invalid return value from tagfunc
    E5108: Error executing lua …/runtime/lua/vim/lsp/util.lua:311: EISDIR: illegal operation on a directory
    stack traceback:

at this line:

    local data = assert(uv.fs_read(fd, stat.size, 0))

Solution:
Check for directory.