### PR TITLE
vim-patch:fd4e47e: runtime(doc): clarify the effect of 'startofline' option

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -60,10 +60,12 @@ When doubling the operator it operates on a line.  When using a count, before
 or after the first character, that many lines are operated upon.  Thus `3dd`
 deletes three lines. A count before and after the first character is
 multiplied, thus `2y3y` yanks six lines.
-
+						*operator-resulting-pos*
 After applying the operator the cursor is mostly left at the start of the text
 that was operated upon.  For example, "yfe" doesn't move the cursor, but "yFe"
 moves the cursor leftwards to the "e" where the yank started.
+The 'startofline' option applies only to the "d", "<<", "==" and ">>" linewise
+operations.
 
 						*linewise* *charwise* *characterwise*
 The operator either affects whole lines, or the characters between the start

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6016,7 +6016,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	non-blank of the line.  When off the cursor is kept in the same column
 	(if possible).  This applies to the commands:
 	- CTRL-D, CTRL-U, CTRL-B, CTRL-F, "G", "H", "M", "L", "gg"
-	- "d", "<<" and ">>" with a linewise operator
+	- "d", "<<", "==" and ">>" with a linewise operator
+	  (|operator-resulting-pos|)
 	- "%" with a count
 	- buffer changing commands (CTRL-^, :bnext, :bNext, etc.)
 	- Ex commands that only have a line number, e.g., ":25" or ":+".

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -6417,7 +6417,8 @@ vim.go.spr = vim.go.splitright
 --- non-blank of the line.  When off the cursor is kept in the same column
 --- (if possible).  This applies to the commands:
 --- - CTRL-D, CTRL-U, CTRL-B, CTRL-F, "G", "H", "M", "L", "gg"
---- - "d", "<<" and ">>" with a linewise operator
+--- - "d", "<<", "==" and ">>" with a linewise operator
+---   (`operator-resulting-pos`)
 --- - "%" with a count
 --- - buffer changing commands (CTRL-^, :bnext, :bNext, etc.)
 --- - Ex commands that only have a line number, e.g., ":25" or ":+".

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -8075,7 +8075,8 @@ return {
         non-blank of the line.  When off the cursor is kept in the same column
         (if possible).  This applies to the commands:
         - CTRL-D, CTRL-U, CTRL-B, CTRL-F, "G", "H", "M", "L", "gg"
-        - "d", "<<" and ">>" with a linewise operator
+        - "d", "<<", "==" and ">>" with a linewise operator
+          (|operator-resulting-pos|)
         - "%" with a count
         - buffer changing commands (CTRL-^, :bnext, :bNext, etc.)
         - Ex commands that only have a line number, e.g., ":25" or ":+".


### PR DESCRIPTION
#### vim-patch:fd4e47e: runtime(doc): clarify the effect of 'startofline' option

https://github.com/vim/vim/commit/fd4e47e06b77fa26cb38f057aba950449e1f47f6

Co-authored-by: Christian Brabandt <cb@256bit.org>