### PR TITLE
vim-patch:9.1.0761: :cd completion fails on Windows with backslash in path

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3618,6 +3618,7 @@ bool match_file_list(char *list, char *sfname, char *ffname)
 /// @param pat_end     first char after pattern or NULL
 /// @param allow_dirs  Result passed back out in here
 /// @param no_bslash   Don't use a backward slash as pathsep
+///                    (only makes a difference when BACKSLASH_IN_FILENAME in defined)
 ///
 /// @return            NULL on failure.
 char *file_pat_to_reg_pat(const char *pat, const char *pat_end, char *allow_dirs, int no_bslash)

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -959,7 +959,7 @@ static void uniquefy_paths(garray_T *gap, char *pattern, char *path_option)
   file_pattern[0] = '*';
   file_pattern[1] = NUL;
   strcat(file_pattern, pattern);
-  char *pat = file_pat_to_reg_pat(file_pattern, NULL, NULL, true);
+  char *pat = file_pat_to_reg_pat(file_pattern, NULL, NULL, false);
   xfree(file_pattern);
   if (pat == NULL) {
     return;

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -4070,4 +4070,15 @@ func Test_term_option()
   let &cpo = _cpo
 endfunc
 
+func Test_cd_bslsh_completion_windows()
+  CheckMSWindows
+  let save_shellslash = &shellslash
+  set noshellslash
+  call system('mkdir XXXa\_b')
+  defer delete('XXXa', 'rf')
+  call feedkeys(":cd XXXa\\_b\<C-A>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"cd XXXa\_b\', @:)
+  let &shellslash = save_shellslash
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0761: :cd completion fails on Windows with backslash in path

Problem:  :cd completion fails on Windows with backslash in path
Solution: switch no_bslash argument to FALSE in file_pat_to_reg_pat()

Note: only fixes the problem on Windows. For Unix, we still need to
escape backslashes since those are taken as regex atoms (and could be
invalid regex atoms).

closes: vim/vim#15808

https://github.com/vim/vim/commit/1a31c430bb175144d097ca607dbe10d7960f372a

Co-authored-by: Christian Brabandt <cb@256bit.org>