### PR TITLE
vim-patch:9.1.0762: 'cedit', 'termwinkey' and 'wildchar' may not be parsed correctly

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7076,7 +7076,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Some keys will not work, such as CTRL-C, <CR> and Enter.
 	<Esc> can be used, but hitting it twice in a row will still exit
 	command-line as a failsafe measure.
-	Although 'wc' is a number option, you can set it to a special key: >vim
+	Although 'wc' is a number option, it can be specified as a number, a
+	single character, a |key-notation| (e.g. <Up>, <C-F>) or a letter
+	preceded with a caret (e.g. `^F` is CTRL-F): >vim
+		:set wc=27
+		:set wc=X
+		:set wc=^I
 		set wc=<Tab>
 <
 

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -7699,9 +7699,14 @@ vim.go.ww = vim.go.whichwrap
 --- Some keys will not work, such as CTRL-C, <CR> and Enter.
 --- <Esc> can be used, but hitting it twice in a row will still exit
 --- command-line as a failsafe measure.
---- Although 'wc' is a number option, you can set it to a special key:
+--- Although 'wc' is a number option, it can be specified as a number, a
+--- single character, a `key-notation` (e.g. <Up>, <C-F>) or a letter
+--- preceded with a caret (e.g. `^F` is CTRL-F):
 ---
 --- ```vim
+--- 	:set wc=27
+--- 	:set wc=X
+--- 	:set wc=^I
 --- 	set wc=<Tab>
 --- ```
 ---

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9620,7 +9620,12 @@ return {
         Some keys will not work, such as CTRL-C, <CR> and Enter.
         <Esc> can be used, but hitting it twice in a row will still exit
         command-line as a failsafe measure.
-        Although 'wc' is a number option, you can set it to a special key: >vim
+        Although 'wc' is a number option, it can be specified as a number, a
+        single character, a |key-notation| (e.g. <Up>, <C-F>) or a letter
+        preceded with a caret (e.g. `^F` is CTRL-F): >vim
+        	:set wc=27
+        	:set wc=X
+        	:set wc=^I
         	set wc=<Tab>
         <
       ]=],


### PR DESCRIPTION
#### vim-patch:9.1.0762: 'cedit', 'termwinkey' and 'wildchar' may not be parsed correctly

Problem:  'cedit', 'termwinkey' and 'wildchar' may not be parsed
          correctly
Solution: improve string_to_key() function in option.c
          (Milly)

- Problem: `^@` raises an error.
  Solution: Store as `<Nul>`.
- Problem: `<t_xx` does not raise an error.
  Solution: Raise an error if closing `>` is missing.
- Problem: Single `<` or `^` raises an error. It is inconvenient for users.
  Solution: They are stored as a single character.

closes: vim/vim#15811

https://github.com/vim/vim/commit/a9c6f90918d0012d1b8c8c5c1dccb77407f553fb

Co-authored-by: Milly <milly.ca@gmail.com>