### PR TITLE
vim-patch:9.1.0764: [security]: use-after-free when closing a buffer

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -478,6 +478,11 @@ static bool can_unload_buffer(buf_T *buf)
   return can_unload;
 }
 
+bool buf_locked(buf_T *buf)
+{
+  return buf->b_locked || buf->b_locked_split;
+}
+
 /// Close the link to a buffer.
 ///
 /// @param win    If not NULL, set b_last_cursor.

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2261,6 +2261,16 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
     if (buf == NULL) {
       goto theend;
     }
+    // autocommands try to edit a file that is goind to be removed, abort
+    if (buf_locked(buf)) {
+      // window was split, but not editing the new buffer, reset b_nwindows again
+      if (oldwin == NULL
+          && curwin->w_buffer != NULL
+          && curwin->w_buffer->b_nwindows > 1) {
+        curwin->w_buffer->b_nwindows--;
+      }
+      goto theend;
+    }
     if (curwin->w_alt_fnum == buf->b_fnum && prev_alt_fnum != 0) {
       // reusing the buffer, keep the old alternate file
       curwin->w_alt_fnum = prev_alt_fnum;

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -15,6 +15,13 @@ func s:cleanup_buffers() abort
   endfor
 endfunc
 
+func CleanUpTestAuGroup()
+  augroup testing
+    au!
+  augroup END
+  augroup! testing
+endfunc
+
 func Test_vim_did_enter()
   call assert_false(v:vim_did_enter)
 
@@ -4150,6 +4157,25 @@ func Test_BufEnter_botline()
   bwipe! Xxx2
   au! BufEnter Xxx1
   set hidden&vim
+endfunc
+
+" This was using freed memory
+func Test_autocmd_BufWinLeave_with_vsp()
+  new
+  let fname = 'XXXBufWinLeaveUAF.txt'
+  let dummy = 'XXXDummy.txt'
+  call writefile([], fname)
+  call writefile([], dummy)
+  defer delete(fname)
+  defer delete(dummy)
+  exe "e " fname
+  vsp
+  augroup testing
+    exe "au BufWinLeave " .. fname .. " :e " dummy .. "| vsp " .. fname
+  augroup END
+  bw
+  call CleanUpTestAuGroup()
+  exe "bw! " .. dummy
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0764: [security]: use-after-free when closing a buffer

Problem:  [security]: use-after-free when closing a buffer
Solution: When splitting the window and editing a new buffer,
          check whether the newly to be edited buffer has been marked
          for deletion and abort in this case

Github Advisory:
https://github.com/vim/vim/security/advisories/GHSA-rj48-v4mq-j4vg

https://github.com/vim/vim/commit/51b62387be93c65fa56bbabe1c3c1ea5df187641

Co-authored-by: Christian Brabandt <cb@256bit.org>