### PR TITLE
vim-patch:9.1.0765: No test for patches 6.2.418 and 7.3.489

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -66,6 +66,8 @@ modes.
 			where the map command applies.  Disallow mapping of
 			{rhs}, to avoid nested and recursive mappings.  Often
 			used to redefine a command.
+			Note: Keys in {rhs} also won't trigger abbreviation,
+			with the exception of |i_CTRL-]| and |c_CTRL-]|.
 			Note: When <Plug> appears in the {rhs} this part is
 			always applied even if remapping is disallowed.
 

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -4070,7 +4070,7 @@ func Test_term_option()
   let &cpo = _cpo
 endfunc
 
-func Test_cd_bslsh_completion_windows()
+func Test_cd_bslash_completion_windows()
   CheckMSWindows
   let save_shellslash = &shellslash
   set noshellslash

--- a/test/old/testdir/test_mapping.vim
+++ b/test/old/testdir/test_mapping.vim
@@ -6,33 +6,62 @@ source screendump.vim
 source term_util.vim
 
 func Test_abbreviation()
+  new
   " abbreviation with 0x80 should work
   inoreab чкпр   vim
   call feedkeys("Goчкпр \<Esc>", "xt")
   call assert_equal('vim ', getline('$'))
   iunab чкпр
-  set nomodified
+  bwipe!
+endfunc
+
+func Test_abbreviation_with_noremap()
+  nnoremap <F2> :echo "cheese"
+  cabbr cheese xxx
+  call feedkeys(":echo \"cheese\"\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"echo "xxx"', @:)
+  call feedkeys("\<F2>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"echo "cheese"', @:)
+  nnoremap <F2> :echo "cheese<C-]>"
+  call feedkeys("\<F2>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"echo "xxx"', @:)
+  nunmap <F2>
+  cunabbr cheese
+
+  new
+  inoremap <buffer> ( <C-]>()
+  iabbr <buffer> fnu fun
+  call feedkeys("ifnu(", 'tx')
+  call assert_equal('fun()', getline(1))
+  bwipe!
 endfunc
 
 func Test_abclear()
-   abbrev foo foobar
-   iabbrev fooi foobari
-   cabbrev fooc foobarc
-   call assert_equal("\n\nc  fooc          foobarc\ni  fooi          foobari\n!  foo           foobar", execute('abbrev'))
+  abbrev foo foobar
+  iabbrev fooi foobari
+  cabbrev fooc foobarc
+  call assert_equal("\n\n"
+        \        .. "c  fooc          foobarc\n"
+        \        .. "i  fooi          foobari\n"
+        \        .. "!  foo           foobar", execute('abbrev'))
 
-   iabclear
-   call assert_equal("\n\nc  fooc          foobarc\nc  foo           foobar", execute('abbrev'))
-   abbrev foo foobar
-   iabbrev fooi foobari
+  iabclear
+  call assert_equal("\n\n"
+        \        .. "c  fooc          foobarc\n"
+        \        .. "c  foo           foobar", execute('abbrev'))
+  abbrev foo foobar
+  iabbrev fooi foobari
 
-   cabclear
-   call assert_equal("\n\ni  fooi          foobari\ni  foo           foobar", execute('abbrev'))
-   abbrev foo foobar
-   cabbrev fooc foobarc
+  cabclear
+  call assert_equal("\n\n"
+        \        .. "i  fooi          foobari\n"
+        \        .. "i  foo           foobar", execute('abbrev'))
+  abbrev foo foobar
+  cabbrev fooc foobarc
 
-   abclear
-   call assert_equal("\n\nNo abbreviation found", execute('abbrev'))
-   call assert_fails('%abclear', 'E481:')
+  abclear
+  call assert_equal("\n\nNo abbreviation found", execute('abbrev'))
+  call assert_fails('%abclear', 'E481:')
 endfunc
 
 func Test_abclear_buffer()
@@ -42,15 +71,21 @@ func Test_abclear_buffer()
   new X2
   abbrev <buffer> foo2 foobar2
 
-  call assert_equal("\n\n!  foo2         @foobar2\n!  foo           foobar", execute('abbrev'))
+  call assert_equal("\n\n"
+        \        .. "!  foo2         @foobar2\n"
+        \        .. "!  foo           foobar", execute('abbrev'))
 
   abclear <buffer>
-  call assert_equal("\n\n!  foo           foobar", execute('abbrev'))
+  call assert_equal("\n\n"
+        \        .. "!  foo           foobar", execute('abbrev'))
 
   b X1
-  call assert_equal("\n\n!  foo1         @foobar1\n!  foo           foobar", execute('abbrev'))
+  call assert_equal("\n\n"
+        \        .. "!  foo1         @foobar1\n"
+        \        .. "!  foo           foobar", execute('abbrev'))
   abclear <buffer>
-  call assert_equal("\n\n!  foo           foobar", execute('abbrev'))
+  call assert_equal("\n\n"
+        \        .. "!  foo           foobar", execute('abbrev'))
 
   abclear
    call assert_equal("\n\nNo abbreviation found", execute('abbrev'))

--- a/test/old/testdir/test_quickfix.vim
+++ b/test/old/testdir/test_quickfix.vim
@@ -6459,8 +6459,8 @@ func Test_cbuffer_range()
   call XbufferTests_range('l')
 endfunc
 
-" Test for displaying fname pass from setqflist when the name
-" are hard links to prevent seemly duplicate entries.
+" Test for displaying fname passed from setqflist() when the names include
+" hard links to prevent seemingly duplicate entries.
 func Xtest_hardlink_fname(cchar)
   call s:setup_commands(a:cchar)
   %bwipe


### PR DESCRIPTION
#### vim-patch:9.1.0765: No test for patches 6.2.418 and 7.3.489

Problem:  No test for patches 6.2.418 and 7.3.489
Solution: Add a test.  Fix some whitespace problems in test_mapping.vim.
          Document the behavior (zeertzjq).

closes: vim/vim#15815

https://github.com/vim/vim/commit/5df3cb2898d8b4ad42ac367a436afc79bffecfb4