### PR TITLE
fix(gen_help_html): first tag in h2 is broken

### DIFF
--- a/runtime/doc/nvim.txt
+++ b/runtime/doc/nvim.txt
@@ -4,7 +4,7 @@
                             NVIM REFERENCE MANUAL
 
 
-Nvim                                              *neovim* *nvim* *nvim-intro*
+Nvim                                              *nvim* *neovim* *nvim-intro*
 
 Nvim is based on Vim by Bram Moolenaar.
 


### PR DESCRIPTION

Problem:
In h2 headings, the first tag points to an invalid anchor. This used to
work but regressed a few months ago, possibly related to
ceea6898a8bdcb6c4cfe06b8dc4739c144e6b1f8.

Solution:
- Simplify the logic, don't try to be clever:
  - Always use to_heading_tag() for the h2 `id`.
- Also:
  - Render tags as `<span>`, because `<code>` is unnecessary and doesn't
    look great in headings.
  - In the main h1, use "foo.txt" as the anchor `name` (rarely used),
    prefer the next found tag for the `href`.
