### PR TITLE
vim-patch:9.1.0767: A condition is always true in ex_getln.c

### DIFF
--- a/test/old/testdir/test_mapping.vim
+++ b/test/old/testdir/test_mapping.vim
@@ -88,7 +88,7 @@ func Test_abclear_buffer()
         \        .. "!  foo           foobar", execute('abbrev'))
 
   abclear
-   call assert_equal("\n\nNo abbreviation found", execute('abbrev'))
+  call assert_equal("\n\nNo abbreviation found", execute('abbrev'))
 
   %bwipe
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.0767: A condition is always true in ex_getln.c

Problem:  A cmdlen == 0 condition is always true as ccline.cmdlen == 0
          was already checked above (after v9.1.0766).
Solution: Remove the condition and the variable.
          (zeertzjq)

closes: vim/vim#15830

https://github.com/vim/vim/commit/c9aa6e4f2a040dc7f8411139d39d0463487100da