### PR TITLE
vim-patch:d3b55d7: runtime(help): highlight CTRL-<Key> correctly

### DIFF
--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Vim help file
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2024 Oct 05
+" Last Change:	2024 Oct 08
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
@@ -92,6 +92,7 @@ syn match helpSpecial		"\[group]"
 syn match helpNormal		"\[\(readonly\|fifo\|socket\|converted\|crypted\)]"
 
 syn match helpSpecial		"CTRL-."
+syn match helpSpecial		"CTRL-<\a\+>"
 syn match helpSpecial		"CTRL-SHIFT-."
 syn match helpSpecial		"CTRL-Break"
 syn match helpSpecial		"CTRL-PageUp"


### PR DESCRIPTION
#### vim-patch:d3b55d7: runtime(help): highlight CTRL-\<Key> correctly

https://github.com/vim/vim/commit/d3b55d7f76e32e9b7f895fe43f37435ce7bf782e

Co-authored-by: Christian Brabandt <cb@256bit.org>