### PR TITLE
vim-patch:9.1.0769: filetype: MLIR files are not recognized

### DIFF
--- a/runtime/ftplugin/mlir.vim
+++ b/runtime/ftplugin/mlir.vim
@@ -1,0 +1,10 @@
+" Vim filetype plugin file
+" Language:	MLIR
+
+if exists("b:did_ftplugin") | finish | endif
+let b:did_ftplugin = 1
+
+setl comments=:///,://
+setl commentstring=//\ %s
+
+let b:undo_ftplugin = "setl commentstring< comments<"

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -752,6 +752,7 @@ local extension = {
   mib = 'mib',
   mix = 'mix',
   mixal = 'mix',
+  mlir = 'mlir',
   mm = detect.mm,
   nb = 'mma',
   wl = 'mma',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -477,6 +477,7 @@ func s:GetFilenameChecks() abort
     \ 'mgp': ['file.mgp'],
     \ 'mib': ['file.mib', 'file.my'],
     \ 'mix': ['file.mix', 'file.mixal'],
+    \ 'mlir': ['file.mlir'],
     \ 'mma': ['file.nb', 'file.wl'],
     \ 'mmp': ['file.mmp'],
     \ 'modconf': ['/etc/modules.conf', '/etc/modules', '/etc/conf.modules', '/etc/modprobe.file', 'any/etc/conf.modules', 'any/etc/modprobe.file', 'any/etc/modules', 'any/etc/modules.conf'],


### PR DESCRIPTION
Problem:  filetype: MLIR files are not recognized
Solution: Detect '*.mlir' files as mlir filetype,
          include a mlir filetype plugin
          (Wu, Zhenyu)

closes: vim/vim#15826

https://github.com/vim/vim/commit/347d43bd33519ab537f77d1a8fa8ab8f9196bcb9

Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>
