### PR TITLE
docs(lua): "vim.bo" is always equivalent to :setlocal

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1464,12 +1464,9 @@ Option:remove({value})                                      *vim.opt:remove()*
       • {value}  (`string`) Value to remove
 
 vim.bo[{bufnr}]                                                       *vim.bo*
-    Get or set buffer-scoped |options| for the buffer with number {bufnr}. If
-    {bufnr} is omitted then the current buffer is used. Invalid {bufnr} or key
-    is an error.
-
-    Note: this is equivalent to `:setlocal` for |global-local| options and
-    `:set` otherwise.
+    Get or set buffer-scoped |options| for the buffer with number {bufnr}.
+    Like `:setlocal`. If {bufnr} is omitted then the current buffer is used.
+    Invalid {bufnr} or key is an error.
 
     Example: >lua
         local bufnr = vim.api.nvim_get_current_buf()

--- a/runtime/lua/vim/_options.lua
+++ b/runtime/lua/vim/_options.lua
@@ -274,10 +274,8 @@ vim.go = setmetatable({}, {
 })
 
 --- Get or set buffer-scoped |options| for the buffer with number {bufnr}.
---- If {bufnr} is omitted then the current buffer is used.
+--- Like `:setlocal`. If {bufnr} is omitted then the current buffer is used.
 --- Invalid {bufnr} or key is an error.
----
---- Note: this is equivalent to `:setlocal` for |global-local| options and `:set` otherwise.
 ---
 --- Example:
 ---


### PR DESCRIPTION
vim.bo

    :lua vim.bo.textwidth = 80
    :setglobal textwidth?
      textwidth=0

:setlocal

    :setlocal textwidth=80
    :setglobal textwidth?
      textwidth=0

:set

    :set textwidth=80
    :setglobal textwidth?
      textwidth=80