### PR TITLE
build(deps): bump wasmtime to v25.0.2

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -53,8 +53,8 @@ TREESITTER_MARKDOWN_SHA256 5dac48a6d971eb545aab665d59a18180d21963afc781bbf40f907
 TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/v0.24.1.tar.gz
 TREESITTER_SHA256 7adb5bb3b3c2c4f4fdc980a9a13df8fbf3526a82b5c37dd9cf2ed29de56a4683
 
-WASMTIME_URL https://github.com/bytecodealliance/wasmtime/archive/v25.0.1.tar.gz
-WASMTIME_SHA256 0e816ee247eda6c35fca20dfaeac50c2cbb0df60d305b722fa2be9eced5b95da
+WASMTIME_URL https://github.com/bytecodealliance/wasmtime/archive/v25.0.2.tar.gz
+WASMTIME_SHA256 6d1c17c756b83f29f629963228e5fa208ba9d6578421ba2cd07132b6a120accb
 
 UNCRUSTIFY_URL https://github.com/uncrustify/uncrustify/archive/uncrustify-0.79.0.tar.gz
 UNCRUSTIFY_SHA256 e7afaeabf636b7f0ce4e3e9747b95f7bd939613a8db49579755dddf44fedca5f

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -49,7 +49,7 @@ if(ENABLE_LIBINTL)
 endif()
 
 if(ENABLE_WASMTIME)
-  find_package(Wasmtime 25.0.1 EXACT REQUIRED)
+  find_package(Wasmtime 25.0.2 EXACT REQUIRED)
   target_link_libraries(main_lib INTERFACE wasmtime)
   target_compile_definitions(nvim_bin PRIVATE HAVE_WASMTIME)
 endif()


### PR DESCRIPTION
https://github.com/bytecodealliance/wasmtime/releases/tag/v25.0.2

(Security advisory fix)
