### PR TITLE
vim-patch:9.1.{0771,0772}

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1177,12 +1177,12 @@ items:
 	user_data	custom data which is associated with the item and
 			available in |v:completed_item|; it can be any type;
 			defaults to an empty string
-	hl_group	an additional highlight group whose attributes are
+	abbr_hlgroup	an additional highlight group whose attributes are
 			combined with |hl-PmenuSel| and |hl-Pmenu| or
 			|hl-PmenuMatchSel| and |hl-PmenuMatch| highlight
 			attributes in the popup menu to apply cterm and gui
 			properties (with higher priority) like strikethrough
-			to the completion items
+			to the completion items abbreviation
 	kind_hlgroup	an additional highlight group specifically for setting
 			the highlight attributes of the completion kind. When
 			this field is present, it will override the

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -272,7 +272,7 @@ function M._lsp_to_complete_items(result, prefix, client_id)
         icase = 1,
         dup = 1,
         empty = 1,
-        hl_group = hl_group,
+        abbr_hlgroup = hl_group,
         user_data = {
           nvim = {
             lsp = {

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -357,7 +357,8 @@ static int cmdline_pum_create(CmdlineInfo *ccline, expand_T *xp, char **matches,
       .pum_info = NULL,
       .pum_extra = NULL,
       .pum_kind = NULL,
-      .pum_user_hlattr = -1,
+      .pum_user_abbr_hlattr = -1,
+      .pum_user_kind_hlattr = -1,
     };
   }
 

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -164,7 +164,7 @@ struct compl_S {
   int cp_flags;                  ///< CP_ values
   int cp_number;                 ///< sequence number
   int cp_score;                  ///< fuzzy match score
-  int cp_user_hlattr;            ///< highlight attribute to combine with
+  int cp_user_abbr_hlattr;       ///< highlight attribute to combine with for abbr
   int cp_user_kind_hlattr;       ///< highlight attribute for kind
 };
 
@@ -798,7 +798,7 @@ static inline void free_cptext(char *const *const cptext)
 ///         returned in case of error.
 static int ins_compl_add(char *const str, int len, char *const fname, char *const *const cptext,
                          const bool cptext_allocated, typval_T *user_data, const Direction cdir,
-                         int flags_arg, const bool adup, int user_hlattr, int user_kind_hlattr)
+                         int flags_arg, const bool adup, int user_abbr_hlattr, int user_kind_hlattr)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   compl_T *match;
@@ -864,7 +864,7 @@ static int ins_compl_add(char *const str, int len, char *const fname, char *cons
     match->cp_fname = NULL;
   }
   match->cp_flags = flags;
-  match->cp_user_hlattr = user_hlattr;
+  match->cp_user_abbr_hlattr = user_abbr_hlattr;
   match->cp_user_kind_hlattr = user_kind_hlattr;
 
   if (cptext != NULL) {
@@ -1268,7 +1268,7 @@ static int ins_compl_build_pum(void)
       compl_match_array[i].pum_kind = comp->cp_text[CPT_KIND];
       compl_match_array[i].pum_info = comp->cp_text[CPT_INFO];
       compl_match_array[i].pum_score = comp->cp_score;
-      compl_match_array[i].pum_user_hlattr = comp->cp_user_hlattr;
+      compl_match_array[i].pum_user_abbr_hlattr = comp->cp_user_abbr_hlattr;
       compl_match_array[i].pum_user_kind_hlattr = comp->cp_user_kind_hlattr;
       if (comp->cp_text[CPT_MENU] != NULL) {
         compl_match_array[i++].pum_extra = comp->cp_text[CPT_MENU];
@@ -2567,9 +2567,9 @@ static int ins_compl_add_tv(typval_T *const tv, const Direction dir, bool fast)
   bool empty = false;
   int flags = fast ? CP_FAST : 0;
   char *(cptext[CPT_COUNT]);
-  char *user_hlname = NULL;
+  char *user_abbr_hlname = NULL;
+  int user_abbr_hlattr = -1;
   char *user_kind_hlname = NULL;
-  int user_hlattr = -1;
   int user_kind_hlattr = -1;
   typval_T user_data;
 
@@ -2581,8 +2581,8 @@ static int ins_compl_add_tv(typval_T *const tv, const Direction dir, bool fast)
     cptext[CPT_KIND] = tv_dict_get_string(tv->vval.v_dict, "kind", true);
     cptext[CPT_INFO] = tv_dict_get_string(tv->vval.v_dict, "info", true);
 
-    user_hlname = tv_dict_get_string(tv->vval.v_dict, "hl_group", false);
-    user_hlattr = get_user_highlight_attr(user_hlname);
+    user_abbr_hlname = tv_dict_get_string(tv->vval.v_dict, "abbr_hlgroup", false);
+    user_abbr_hlattr = get_user_highlight_attr(user_abbr_hlname);
 
     user_kind_hlname = tv_dict_get_string(tv->vval.v_dict, "kind_hlgroup", false);
     user_kind_hlattr = get_user_highlight_attr(user_kind_hlname);
@@ -2608,7 +2608,8 @@ static int ins_compl_add_tv(typval_T *const tv, const Direction dir, bool fast)
     return FAIL;
   }
   int status = ins_compl_add((char *)word, -1, NULL, cptext, true,
-                             &user_data, dir, flags, dup, user_hlattr, user_kind_hlattr);
+                             &user_data, dir, flags, dup,
+                             user_abbr_hlattr, user_kind_hlattr);
   if (status != OK) {
     tv_clear(&user_data);
   }

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -164,7 +164,7 @@ struct compl_S {
   int cp_flags;                  ///< CP_ values
   int cp_number;                 ///< sequence number
   int cp_score;                  ///< fuzzy match score
-  int cp_user_abbr_hlattr;       ///< highlight attribute to combine with for abbr
+  int cp_user_abbr_hlattr;       ///< highlight attribute for abbr
   int cp_user_kind_hlattr;       ///< highlight attribute for kind
 };
 

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -733,8 +733,7 @@ void pum_redraw(void)
             }
 
             if (attrs != NULL) {
-              xfree(attrs);
-              attrs = NULL;
+              XFREE_CLEAR(attrs);
             }
 
             if (*p != TAB) {
@@ -743,10 +742,10 @@ void pum_redraw(void)
 
             // Display two spaces for a Tab.
             if (pum_rl) {
-              grid_line_puts(grid_col - 1, "  ", 2, orig_attr);
+              grid_line_puts(grid_col - 1, "  ", 2, attr);
               grid_col -= 2;
             } else {
-              grid_line_puts(grid_col, "  ", 2, orig_attr);
+              grid_line_puts(grid_col, "  ", 2, attr);
               grid_col += 2;
             }
             totwidth += 2;
@@ -777,10 +776,12 @@ void pum_redraw(void)
       }
 
       if (pum_rl) {
-        grid_line_fill(col_off - basic_width - n + 1, grid_col + 1, schar_from_ascii(' '), attr);
+        grid_line_fill(col_off - basic_width - n + 1, grid_col + 1,
+                       schar_from_ascii(' '), orig_attr);
         grid_col = col_off - basic_width - n;
       } else {
-        grid_line_fill(grid_col, col_off + basic_width + n, schar_from_ascii(' '), orig_attr);
+        grid_line_fill(grid_col, col_off + basic_width + n,
+                       schar_from_ascii(' '), orig_attr);
         grid_col = col_off + basic_width + n;
       }
       totwidth = basic_width + n;

--- a/src/nvim/popupmenu.h
+++ b/src/nvim/popupmenu.h
@@ -16,7 +16,7 @@ typedef struct {
   char *pum_info;       ///< extra info
   int pum_score;        ///< fuzzy match score
   int pum_idx;          ///< index of item before sorting by score
-  int pum_user_hlattr;  ///< highlight attribute to combine with
+  int pum_user_abbr_hlattr;  ///< highlight attribute to combine with
   int pum_user_kind_hlattr;  ///< highlight attribute for kind
 } pumitem_T;
 

--- a/src/nvim/popupmenu.h
+++ b/src/nvim/popupmenu.h
@@ -16,7 +16,7 @@ typedef struct {
   char *pum_info;       ///< extra info
   int pum_score;        ///< fuzzy match score
   int pum_idx;          ///< index of item before sorting by score
-  int pum_user_abbr_hlattr;  ///< highlight attribute to combine with
+  int pum_user_abbr_hlattr;  ///< highlight attribute for abbr
   int pum_user_kind_hlattr;  ///< highlight attribute for kind
 } pumitem_T;
 

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -320,7 +320,7 @@ describe('vim.lsp.completion: item conversion', function()
       info = '',
       kind = 'Module',
       menu = '',
-      hl_group = '',
+      abbr_hlgroup = '',
       word = 'this_thread',
     }
     local result = complete('  std::this|', completion_list)
@@ -376,7 +376,7 @@ describe('vim.lsp.completion: item conversion', function()
       info = '',
       kind = 'Module',
       menu = '',
-      hl_group = '',
+      abbr_hlgroup = '',
       word = 'this_thread',
     }
     local result = complete('  std::this|is', completion_list)
@@ -570,7 +570,7 @@ describe('vim.lsp.completion: protocol', function()
           info = '',
           kind = 'Unknown',
           menu = '',
-          hl_group = '',
+          abbr_hlgroup = '',
           user_data = {
             nvim = {
               lsp = {
@@ -591,7 +591,7 @@ describe('vim.lsp.completion: protocol', function()
           info = '',
           kind = 'Unknown',
           menu = '',
-          hl_group = 'DiagnosticDeprecated',
+          abbr_hlgroup = 'DiagnosticDeprecated',
           user_data = {
             nvim = {
               lsp = {
@@ -613,7 +613,7 @@ describe('vim.lsp.completion: protocol', function()
           info = '',
           kind = 'Unknown',
           menu = '',
-          hl_group = 'DiagnosticDeprecated',
+          abbr_hlgroup = 'DiagnosticDeprecated',
           user_data = {
             nvim = {
               lsp = {

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -4963,8 +4963,8 @@ describe('builtin popupmenu', function()
         feed('<C-E><Esc>')
       end)
 
-      -- oldtest: Test_pum_user_hl_group()
-      it('custom hl_group override', function()
+      -- oldtest: Test_pum_user_abbr_hlgroup()
+      it('custom abbr_hlgroup override', function()
         exec([[
           func CompleteFunc( findstart, base )
             if a:findstart
@@ -4972,9 +4972,9 @@ describe('builtin popupmenu', function()
             endif
             return {
                   \ 'words': [
-                  \ { 'word': 'aword1', 'menu': 'extra text 1', 'kind': 'W', 'hl_group': 'StrikeFake' },
+                  \ { 'word': 'aword1', 'menu': 'extra text 1', 'kind': 'W', 'abbr_hlgroup': 'StrikeFake' },
                   \ { 'word': 'aword2', 'menu': 'extra text 2', 'kind': 'W', },
-                  \ { 'word': '你好', 'menu': 'extra text 3', 'kind': 'W', 'hl_group': 'StrikeFake' },
+                  \ { 'word': '你好', 'menu': 'extra text 3', 'kind': 'W', 'abbr_hlgroup': 'StrikeFake' },
                   \]}
           endfunc
           set completeopt=menu
@@ -4990,9 +4990,9 @@ describe('builtin popupmenu', function()
         feed('Saw<C-X><C-U>')
         screen:expect([[
           aword1^                          |
-          {ds:aword1 W extra text 1 }{1:          }|
+          {ds:aword1}{s: W extra text 1 }{1:          }|
           {n:aword2 W extra text 2 }{1:          }|
-          {dn:你好   W extra text 3 }{1:          }|
+          {dn:你好}{n:   W extra text 3 }{1:          }|
           {1:~                               }|*15
           {2:-- }{5:match 1 of 3}                 |
         ]])
@@ -5003,18 +5003,18 @@ describe('builtin popupmenu', function()
         feed('Saw<C-X><C-U>')
         screen:expect([[
           aword1^                          |
-          {uds:aw}{ds:ord1 W extra text 1 }{1:          }|
+          {uds:aw}{ds:ord1}{s: W extra text 1 }{1:          }|
           {umn:aw}{n:ord2 W extra text 2 }{1:          }|
-          {dn:你好   W extra text 3 }{1:          }|
+          {dn:你好}{n:   W extra text 3 }{1:          }|
           {1:~                               }|*15
           {2:-- }{5:match 1 of 3}                 |
         ]])
         feed('<C-N>')
         screen:expect([[
           aword2^                          |
-          {udn:aw}{dn:ord1 W extra text 1 }{1:          }|
+          {udn:aw}{dn:ord1}{n: W extra text 1 }{1:          }|
           {ums:aw}{s:ord2 W extra text 2 }{1:          }|
-          {dn:你好   W extra text 3 }{1:          }|
+          {dn:你好}{n:   W extra text 3 }{1:          }|
           {1:~                               }|*15
           {2:-- }{5:match 2 of 3}                 |
         ]])
@@ -5030,7 +5030,7 @@ describe('builtin popupmenu', function()
             endif
             return {
                   \ 'words': [
-                  \ { 'word': 'aword1', 'menu': 'extra text 1', 'kind': 'variable', 'kind_hlgroup': 'KindVar', 'hl_group': 'StrikeFake' },
+                  \ { 'word': 'aword1', 'menu': 'extra text 1', 'kind': 'variable', 'kind_hlgroup': 'KindVar', 'abbr_hlgroup': 'StrikeFake' },
                   \ { 'word': 'aword2', 'menu': 'extra text 2', 'kind': 'function', 'kind_hlgroup': 'KindFunc' },
                   \ { 'word': '你好', 'menu': 'extra text 3', 'kind': 'class', 'kind_hlgroup': 'KindClass'  },
                   \]}
@@ -5053,9 +5053,9 @@ describe('builtin popupmenu', function()
         feed('S<C-X><C-U>')
         screen:expect([[
           aword1^                          |
-          {ds:aword1 }{kvs:variable }{ds:extra text 1 }{1:   }|
-          {n:aword2 }{kfn:function }{n:extra text 2 }{1:   }|
-          {n:你好   }{kcn:class    }{n:extra text 3 }{1:   }|
+          {ds:aword1}{s: }{kvs:variable}{s: extra text 1 }{1:   }|
+          {n:aword2 }{kfn:function}{n: extra text 2 }{1:   }|
+          {n:你好   }{kcn:class}{n:    extra text 3 }{1:   }|
           {1:~                               }|*15
           {2:-- }{5:match 1 of 3}                 |
         ]])

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1506,7 +1506,7 @@ func Test_pum_highlights_match()
   call StopVimInTerminal(buf)
 endfunc
 
-func Test_pum_user_hl_group()
+func Test_pum_user_abbr_hlgroup()
   CheckScreendump
   let lines =<< trim END
     func CompleteFunc( findstart, base )
@@ -1515,9 +1515,9 @@ func Test_pum_user_hl_group()
       endif
       return {
             \ 'words': [
-            \ { 'word': 'aword1', 'menu': 'extra text 1', 'kind': 'W', 'hl_group': 'StrikeFake' },
+            \ { 'word': 'aword1', 'menu': 'extra text 1', 'kind': 'W', 'abbr_hlgroup': 'StrikeFake' },
             \ { 'word': 'aword2', 'menu': 'extra text 2', 'kind': 'W', },
-            \ { 'word': '你好', 'menu': 'extra text 3', 'kind': 'W', 'hl_group': 'StrikeFake' },
+            \ { 'word': '你好', 'menu': 'extra text 3', 'kind': 'W', 'abbr_hlgroup': 'StrikeFake' },
             \]}
     endfunc
     set completeopt=menu
@@ -1559,7 +1559,7 @@ func Test_pum_user_kind_hlgroup()
       endif
       return {
             \ 'words': [
-            \ { 'word': 'aword1', 'menu': 'extra text 1', 'kind': 'variable', 'kind_hlgroup': 'KindVar', 'hl_group': 'StrikeFake' },
+            \ { 'word': 'aword1', 'menu': 'extra text 1', 'kind': 'variable', 'kind_hlgroup': 'KindVar', 'abbr_hlgroup': 'StrikeFake' },
             \ { 'word': 'aword2', 'menu': 'extra text 2', 'kind': 'function', 'kind_hlgroup': 'KindFunc' },
             \ { 'word': '你好', 'menu': 'extra text 3', 'kind': 'class', 'kind_hlgroup': 'KindClass'  },
             \]}


### PR DESCRIPTION
#### vim-patch:9.1.0771: completion attribute hl_group is confusing

Problem:  Currently completion attribute hl_group is combined with
          all items, which is redundant and confusing with kind_hlgroup
Solution: Renamed to abbr_hlgroup and combine it only with the abbr item
          (glepnir).

closes: vim/vim#15818

https://github.com/vim/vim/commit/0fe17f8ffbd2588ecd2bf42dced556897bc64f89

Co-authored-by: glepnir <glephunter@gmail.com>


#### vim-patch:9.1.0772: some missing changes from v9.1.0771

Problem:  some missing changes from v9.1.0771
Solution: use correct highlighting attribute and adjust comments
          (glepnir)

closes: vim/vim#15836

https://github.com/vim/vim/commit/7baa014d0f73c3b2c6831471d047220633651238

Co-authored-by: glepnir <glephunter@gmail.com>