### PR TITLE
build(lpeg): lpeg.so is missed due to looking for lpeg.dylib on MacOS

### DIFF
--- a/cmake/FindLpeg.cmake
+++ b/cmake/FindLpeg.cmake
@@ -1,4 +1,13 @@
-find_library2(LPEG_LIBRARY NAMES lpeg_a lpeg liblpeg_a lpeg${CMAKE_SHARED_LIBRARY_SUFFIX} PATH_SUFFIXES lua/5.1)
+find_library2(LPEG_LIBRARY NAMES lpeg_a lpeg liblpeg_a lpeg.so lpeg${CMAKE_SHARED_LIBRARY_SUFFIX} PATH_SUFFIXES lua/5.1)
+if(CMAKE_SYSTEM_NAME STREQUAL "Darwin" AND LPEG_LIBRARY MATCHES ".so$")
+  execute_process(
+    COMMAND otool -hv "${LPEG_LIBRARY}"
+    OUTPUT_VARIABLE LPEG_HEADER
+    )
+  if(LPEG_HEADER MATCHES ".* BUNDLE .*")
+    message(FATAL_ERROR "lpeg library found at ${LPEG_LIBRARY} but built as a bundle rather than a dylib, please rebuild with `-dynamiclib` rather than `-bundle`")
+  endif()
+endif()
 
 find_package_handle_standard_args(Lpeg DEFAULT_MSG LPEG_LIBRARY)
 mark_as_advanced(LPEG_LIBRARY)


### PR DESCRIPTION
build(lpeg): lpeg.so is missed due to looking for lpeg.dylib

Problem: Currently Neovim only searches for lpeg.dylib, liblpeg.dylib, etc. on MacOS, but a normal installation of lpeg will produce lpeg.so instead.  There are explicit workarounds for this by modifying lpeg's package in Homebrew, and will shortly be another in spack.

Solution: also search for lpeg.so even if that's not the platform default, because Lua and luarocks use it anyway.