### PR TITLE
vim-patch:9.1.0774: "shellcmdline" doesn't work with getcompletion()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3362,6 +3362,7 @@ getcompletion({pat}, {type} [, {filtered}])                    *getcompletion()*
 		runtime		|:runtime| completion
 		scriptnames	sourced script names |:scriptnames|
 		shellcmd	Shell command
+		shellcmdline	Shell command line with filename arguments
 		sign		|:sign| suboptions
 		syntax		syntax file names |'syntax'|
 		syntime		|:syntime| suboptions

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3008,6 +3008,7 @@ function vim.fn.getcmdwintype() end
 --- runtime    |:runtime| completion
 --- scriptnames  sourced script names |:scriptnames|
 --- shellcmd  Shell command
+--- shellcmdline  Shell command line with filename arguments
 --- sign    |:sign| suboptions
 --- syntax    syntax file names |'syntax'|
 --- syntime    |:syntime| suboptions

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -1529,7 +1529,8 @@ static void set_context_for_wildcard_arg(exarg_T *eap, const char *arg, bool use
   xp->xp_context = EXPAND_FILES;
 
   // For a shell command more chars need to be escaped.
-  if (usefilter || eap->cmdidx == CMD_bang || eap->cmdidx == CMD_terminal
+  if (usefilter
+      || (eap != NULL && (eap->cmdidx == CMD_bang || eap->cmdidx == CMD_terminal))
       || *complp == EXPAND_SHELLCMDLINE) {
 #ifndef BACKSLASH_IN_FILENAME
     xp->xp_shell = true;
@@ -3602,6 +3603,11 @@ void f_getcompletion(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
   if (xpc.xp_context == EXPAND_RUNTIME) {
     set_context_in_runtime_cmd(&xpc, xpc.xp_pattern);
+    xpc.xp_pattern_len = strlen(xpc.xp_pattern);
+  }
+  if (xpc.xp_context == EXPAND_SHELLCMDLINE) {
+    int context = EXPAND_SHELLCMDLINE;
+    set_context_for_wildcard_arg(NULL, xpc.xp_pattern, false, &xpc, &context);
     xpc.xp_pattern_len = strlen(xpc.xp_pattern);
   }
 

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -3775,6 +3775,7 @@ M.funcs = {
       runtime		|:runtime| completion
       scriptnames	sourced script names |:scriptnames|
       shellcmd	Shell command
+      shellcmdline	Shell command line with filename arguments
       sign		|:sign| suboptions
       syntax		syntax file names |'syntax'|
       syntime		|:syntime| suboptions

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -1032,6 +1032,8 @@ func Test_cmdline_complete_shellcmdline()
 
   call feedkeys(":MyCmd whoam\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_match('^".*\<whoami\>', @:)
+  let l = getcompletion('whoam', 'shellcmdline')
+  call assert_match('\<whoami\>', join(l, ' '))
 
   delcommand MyCmd
 endfunc
@@ -3818,9 +3820,13 @@ func Test_cmdline_complete_shellcmdline_argument()
 
   call feedkeys(":MyCmd vim test_cmdline.\<Tab>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"MyCmd vim test_cmdline.vim', @:)
+  call assert_equal(['test_cmdline.vim'],
+        \ getcompletion('vim test_cmdline.', 'shellcmdline'))
 
   call feedkeys(":MyCmd vim nonexistentfile\<Tab>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"MyCmd vim nonexistentfile', @:)
+  call assert_equal([],
+        \ getcompletion('vim nonexistentfile', 'shellcmdline'))
 
   let compl1 = getcompletion('', 'file')[0]
   let compl2 = getcompletion('', 'file')[1]
@@ -3837,9 +3843,13 @@ func Test_cmdline_complete_shellcmdline_argument()
   set wildoptions&
   call feedkeys(":MyCmd vim test_cmdline.\<Tab>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"MyCmd vim test_cmdline.vim', @:)
+  call assert_equal(['test_cmdline.vim'],
+        \ getcompletion('vim test_cmdline.', 'shellcmdline'))
 
   call feedkeys(":MyCmd vim nonexistentfile\<Tab>\<C-B>\"\<CR>", 'xt')
   call assert_equal('"MyCmd vim nonexistentfile', @:)
+  call assert_equal([],
+        \ getcompletion('vim nonexistentfile', 'shellcmdline'))
 
   let compl1 = getcompletion('', 'file')[0]
   let compl2 = getcompletion('', 'file')[1]


### PR DESCRIPTION
#### vim-patch:9.1.0774: "shellcmdline" doesn't work with getcompletion()

Problem:  "shellcmdline" doesn't work with getcompletion().
Solution: Use set_context_for_wildcard_arg() (zeertzjq).

closes: vim/vim#15834

https://github.com/vim/vim/commit/85f36d61e09b12d6f1c60201129823371daa4a84