### PR TITLE
fix(lua): avoid recursive vim.on_key() callback

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1678,6 +1678,8 @@ vim.on_key({fn}, {ns_id})                                       *vim.on_key()*
 
     Note: ~
       • {fn} will be removed on error.
+      • {fn} won't be invoked recursively, i.e. if {fn} itself consumes input,
+        it won't be invoked for those keys.
       • {fn} will not be cleared by |nvim_buf_clear_namespace()|
 
     Parameters: ~

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -258,6 +258,9 @@ These existing features changed their behavior.
   more emoji characters than before, including those encoded with multiple
   emoji codepoints combined with ZWJ (zero width joiner) codepoints.
 
+• |vim.on_key()| callbacks won't be invoked recursively when a callback itself
+  consumes input.
+
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*
 

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -658,6 +658,8 @@ local on_key_cbs = {} --- @type table<integer,function>
 --- and cannot be toggled dynamically.
 ---
 ---@note {fn} will be removed on error.
+---@note {fn} won't be invoked recursively, i.e. if {fn} itself consumes input,
+---           it won't be invoked for those keys.
 ---@note {fn} will not be cleared by |nvim_buf_clear_namespace()|
 ---
 ---@param fn fun(key: string, typed: string)?

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -2065,6 +2065,13 @@ char *nlua_register_table_as_callable(const typval_T *const arg)
 
 void nlua_execute_on_key(int c, char *typed_buf)
 {
+  static bool recursive = false;
+
+  if (recursive) {
+    return;
+  }
+  recursive = true;
+
   char buf[MB_MAXBYTES * 3 + 4];
   size_t buf_len = special_to_buf(c, mod_mask, false, buf);
   vim_unescape_ks(typed_buf);
@@ -2103,6 +2110,8 @@ void nlua_execute_on_key(int c, char *typed_buf)
   // [ ]
   assert(top == lua_gettop(lstate));
 #endif
+
+  recursive = false;
 }
 
 // Sets the editor "script context" during Lua execution. Used by :verbose.


### PR DESCRIPTION
Fix #30752
