### PR TITLE
feat(defaults): map gri to vim.lsp.buf.implementation()

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -71,11 +71,12 @@ options are not restored when the LSP client is stopped or detached.
 - |K| is mapped to |vim.lsp.buf.hover()| unless |'keywordprg'| is customized or
   a custom keymap for `K` exists.
 
-                                                *grr* *gra* *grn* *i_CTRL-S*
+                                          *grr* *gra* *grn* *gri* *i_CTRL-S*
 Some keymaps are created unconditionally when Nvim starts:
 - "grn" is mapped in Normal mode to |vim.lsp.buf.rename()|
 - "gra" is mapped in Normal and Visual mode to |vim.lsp.buf.code_action()|
 - "grr" is mapped in Normal mode to |vim.lsp.buf.references()|
+- "gri" is mapped in Normal mode to |vim.lsp.buf.implementation()|
 - CTRL-S is mapped in Insert mode to |vim.lsp.buf.signature_help()|
 
 If not wanted, these keymaps can be removed at any time using

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -136,6 +136,7 @@ DEFAULTS
 • Mappings:
   • |grn| in Normal mode maps to |vim.lsp.buf.rename()|
   • |grr| in Normal mode maps to |vim.lsp.buf.references()|
+  • |gri| in Normal mode maps to |vim.lsp.buf.implementation()|
   • |gra| in Normal and Visual mode maps to |vim.lsp.buf.code_action()|
   • CTRL-S in Insert mode maps to |vim.lsp.buf.signature_help()|
   • Mouse |popup-menu| includes an "Open in web browser" item when you right-click

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -150,6 +150,7 @@ of these in your config by simply removing the mapping, e.g. ":unmap Y".
   - |grn|
   - |grr|
   - |gra|
+  - |gri|
 - <C-S> |i_CTRL-S|
 - ]d |]d-default|
 - [d |[d-default|

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -157,7 +157,7 @@ do
   --- client is attached. If no client is attached, or if a server does not support a capability, an
   --- error message is displayed rather than exhibiting different behavior.
   ---
-  --- See |grr|, |grn|, |gra|, |i_CTRL-S|.
+  --- See |grr|, |grn|, |gra|, |gri|, |i_CTRL-S|.
   do
     vim.keymap.set('n', 'grn', function()
       vim.lsp.buf.rename()
@@ -170,6 +170,10 @@ do
     vim.keymap.set('n', 'grr', function()
       vim.lsp.buf.references()
     end, { desc = 'vim.lsp.buf.references()' })
+
+    vim.keymap.set('n', 'gri', function()
+      vim.lsp.buf.implementation()
+    end, { desc = 'vim.lsp.buf.implementation()' })
 
     vim.keymap.set('i', '<C-S>', function()
       vim.lsp.buf.signature_help()


### PR DESCRIPTION
Continuing the default LSP maps under the "gr" prefix. Mnemonic: "i" for "implementation".