### PR TITLE
fix(build): remove USE_FNAME_CASE, redundant with CASE_INSENSITIVE_FILENAME

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -111,10 +111,8 @@ if(APPLE)
 endif()
 
 if(WIN32 OR APPLE)
-  # Ignore case when comparing filenames on Windows and Mac.
+  # Handle case-insensitive filenames for Windows and Mac.
   set(CASE_INSENSITIVE_FILENAME TRUE)
-  # Enable fixing case-insensitive filenames for Windows and Mac.
-  set(USE_FNAME_CASE TRUE)
 endif()
 
 if (MINGW)

--- a/cmake.config/config.h.in
+++ b/cmake.config/config.h.in
@@ -34,7 +34,6 @@
 #cmakedefine HAVE_WORKING_LIBINTL
 #cmakedefine UNIX
 #cmakedefine CASE_INSENSITIVE_FILENAME
-#cmakedefine USE_FNAME_CASE
 #cmakedefine HAVE_SYS_UIO_H
 #ifdef HAVE_SYS_UIO_H
 #cmakedefine HAVE_READV

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2985,7 +2985,7 @@ int setfname(buf_T *buf, char *ffname_arg, char *sfname_arg, bool message)
       close_buffer(NULL, obuf, DOBUF_WIPE, false, false);
     }
     sfname = xstrdup(sfname);
-#ifdef USE_FNAME_CASE
+#ifdef CASE_INSENSITIVE_FILENAME
     path_fix_case(sfname);            // set correct case for short file name
 #endif
     if (buf->b_sfname != buf->b_ffname) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2134,7 +2134,7 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
     if (sfname == NULL) {
       sfname = ffname;
     }
-#ifdef USE_FNAME_CASE
+#ifdef CASE_INSENSITIVE_FILENAME
     if (sfname != NULL) {
       path_fix_case(sfname);             // set correct case for sfname
     }

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1448,7 +1448,7 @@ scripterror:
         p = r;
       }
 
-#ifdef USE_FNAME_CASE
+#ifdef CASE_INSENSITIVE_FILENAME
       // Make the case of the file name match the actual file.
       path_fix_case(p);
 #endif

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1827,7 +1827,7 @@ char *fix_fname(const char *fname)
 
   fname = xstrdup(fname);
 
-# ifdef USE_FNAME_CASE
+# ifdef CASE_INSENSITIVE_FILENAME
   path_fix_case((char *)fname);  // set correct case for file name
 # endif
 

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -2035,7 +2035,7 @@ func Test_edit_browse()
     au!
   augroup END
 
-  " When the USE_FNAME_CASE is defined this used to cause a crash.
+  " When the CASE_INSENSITIVE_FILENAME is defined this used to cause a crash.
   browse enew
   bwipe!
 


### PR DESCRIPTION
It stands to reason, you need to "fix" case-insensitive filenames if-and-only-if you have case-insensitive filenames.