### PR TITLE
fix(treesitter): mark supertype nodes as named

### DIFF
--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -272,7 +272,7 @@ int tslua_inspect_lang(lua_State *L)
       continue;
     }
     const char *name = ts_language_symbol_name(lang, (TSSymbol)i);
-    bool named = t == TSSymbolTypeRegular;
+    bool named = t != TSSymbolTypeAnonymous;
     lua_pushboolean(L, named);  // [retval, symbols, is_named]
     if (!named) {
       char buf[256];

--- a/test/functional/treesitter/language_spec.lua
+++ b/test/functional/treesitter/language_spec.lua
@@ -73,7 +73,7 @@ describe('treesitter language API', function()
     eq(true, fset['directive'])
     eq(true, fset['initializer'])
 
-    local has_named, has_anonymous
+    local has_named, has_anonymous, has_supertype
     for symbol, named in pairs(symbols) do
       eq('string', type(symbol))
       eq('boolean', type(named))
@@ -81,11 +81,13 @@ describe('treesitter language API', function()
         has_named = true
       elseif symbol == '"|="' and named == false then
         has_anonymous = true
+      elseif symbol == 'statement' and named == true then
+        has_supertype = true
       end
     end
     eq(
-      { has_named = true, has_anonymous = true },
-      { has_named = has_named, has_anonymous = has_anonymous }
+      { has_named = true, has_anonymous = true, has_supertype = true },
+      { has_named = has_named, has_anonymous = has_anonymous, has_supertype = has_supertype }
     )
   end)
 


### PR DESCRIPTION
**Problem:** Tree-sitter 0.24.0 introduced a new symbol type to denote supertype nodes (`TSSymbolTypeSupertype`). Now, `language.inspect()` (and the query `omnifunc`) return supertype symbols, but with double quotes around them.

**Solution:** Mark a symbol as "named" based on it *not* being an anonymous node, rather than checking that it is a regular node (which a supertype also is not).