### PR TITLE
docs(api): adjust `nvim_echo` comment to make `api.txt` more understandable

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -662,8 +662,8 @@ nvim_echo({chunks}, {history}, {opts})                           *nvim_echo()*
                    be omitted for no highlight.
       • {history}  if true, add to |message-history|.
       • {opts}     Optional parameters.
-                   • verbose: Message was printed as a result of 'verbose'
-                     option if Nvim was invoked with -V3log_file, the message
+                   • verbose: Message is printed as a result of 'verbose'
+                     option. If Nvim was invoked with -V3log_file, the message
                      will be redirected to the log_file and suppressed from
                      direct output.
 

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1110,8 +1110,8 @@ function vim.api.nvim_del_var(name) end
 --- can be omitted for no highlight.
 --- @param history boolean if true, add to `message-history`.
 --- @param opts vim.api.keyset.echo_opts Optional parameters.
---- - verbose: Message was printed as a result of 'verbose' option
----   if Nvim was invoked with -V3log_file, the message will be
+--- - verbose: Message is printed as a result of 'verbose' option.
+---   If Nvim was invoked with -V3log_file, the message will be
 ---   redirected to the log_file and suppressed from direct output.
 function vim.api.nvim_echo(chunks, history, opts) end
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -781,8 +781,8 @@ void nvim_set_vvar(String name, Object value, Error *err)
 ///                can be omitted for no highlight.
 /// @param history  if true, add to |message-history|.
 /// @param opts  Optional parameters.
-///          - verbose: Message was printed as a result of 'verbose' option
-///            if Nvim was invoked with -V3log_file, the message will be
+///          - verbose: Message is printed as a result of 'verbose' option.
+///            If Nvim was invoked with -V3log_file, the message will be
 ///            redirected to the log_file and suppressed from direct output.
 void nvim_echo(Array chunks, Boolean history, Dict(echo_opts) *opts, Error *err)
   FUNC_API_SINCE(7)


### PR DESCRIPTION
The comment gets confusing (at least to me) when translated to docs.
```
      • {opts}     Optional parameters.
                   • verbose: Message was printed as a result of 'verbose'
                     option if Nvim was invoked with -V3log_file, the message
```
But I may be misunderstanding...