### PR TITLE
fix(coverity/497375): f_strpart cast overflow

### DIFF
--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -2838,10 +2838,10 @@ void f_strpart(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
 
   if (argvars[2].v_type != VAR_UNKNOWN && argvars[3].v_type != VAR_UNKNOWN) {
-    int off;
+    int64_t off;
 
     // length in characters
-    for (off = (int)n; off < (int)slen && len > 0; len--) {
+    for (off = n; off < (int64_t)slen && len > 0; len--) {
       off += utfc_ptr2len(p + off);
     }
     len = off - n;


### PR DESCRIPTION
Problem:
Casting long to int introduces risk of overflow.

Solution:
Work with all longs rather than casting between int and long.