### PR TITLE
vim-patch:9.1.0776: test_strftime may fail because of missing TZ data

### DIFF
--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -272,17 +272,17 @@ func Test_strftime()
     let tz = $TZ
   endif
 
-  " Force EST and then UTC, save the current hour (24-hour clock) for each
-  let $TZ = 'EST' | let est = strftime('%H')
-  let $TZ = 'UTC' | let utc = strftime('%H')
+  " Force different time zones, save the current hour (24-hour clock) for each
+  let $TZ = 'GMT+1' | let one = strftime('%H')
+  let $TZ = 'GMT+2' | let two = strftime('%H')
 
   " Those hours should be two bytes long, and should not be the same; if they
   " are, a tzset(3) call may have failed somewhere
-  call assert_equal(strlen(est), 2)
-  call assert_equal(strlen(utc), 2)
+  call assert_equal(strlen(one), 2)
+  call assert_equal(strlen(two), 2)
   " TODO: this fails on MS-Windows
   if has('unix')
-    call assert_notequal(est, utc)
+    call assert_notequal(one, two)
   endif
 
   " If we cached a timezone value, put it back, otherwise clear it


### PR DESCRIPTION
#### vim-patch:9.1.0776: test_strftime may fail because of missing TZ data

Problem:  test_strftime may fail because of missing TZ data
Solution: Use GMT offsets to validate timezone differences (James McCoy)

Some systems only provide timezones that follow the geographical region
naming (e.g. America/New_York) by default and require an additional
install for other names (like EST).

The GMT+<offset> format must always be honored, so use that to generate
distinct data for the test.

closes: vim/vim#15848

https://github.com/vim/vim/commit/ea997edc7aaa5bc1d645b57b6700e0b30c07acbd

Co-authored-by: James McCoy <jamessan@jamessan.com>