### PR TITLE
feat(defaults): map gO to document symbol

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -71,7 +71,7 @@ options are not restored when the LSP client is stopped or detached.
 - |K| is mapped to |vim.lsp.buf.hover()| unless |'keywordprg'| is customized or
   a custom keymap for `K` exists.
 
-                              *grr* *gra* *grn* *gri* *grs* *grS* *i_CTRL-S*
+                              *grr* *gra* *grn* *gri* *grs* *gO* *i_CTRL-S*
 Some keymaps are created unconditionally when Nvim starts:
 - "grn" is mapped in Normal mode to |vim.lsp.buf.rename()|
 - "gra" is mapped in Normal and Visual mode to |vim.lsp.buf.code_action()|

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -71,7 +71,7 @@ options are not restored when the LSP client is stopped or detached.
 - |K| is mapped to |vim.lsp.buf.hover()| unless |'keywordprg'| is customized or
   a custom keymap for `K` exists.
 
-                                   *grr* *gra* *grn* *gri* *i_CTRL-S*
+                                          *grr* *gra* *grn* *gri* *i_CTRL-S*
 Some keymaps are created unconditionally when Nvim starts:
 - "grn" is mapped in Normal mode to |vim.lsp.buf.rename()|
 - "gra" is mapped in Normal and Visual mode to |vim.lsp.buf.code_action()|

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -71,12 +71,14 @@ options are not restored when the LSP client is stopped or detached.
 - |K| is mapped to |vim.lsp.buf.hover()| unless |'keywordprg'| is customized or
   a custom keymap for `K` exists.
 
-                                          *grr* *gra* *grn* *gri* *i_CTRL-S*
+                              *grr* *gra* *grn* *gri* *grs* *grS* *i_CTRL-S*
 Some keymaps are created unconditionally when Nvim starts:
 - "grn" is mapped in Normal mode to |vim.lsp.buf.rename()|
 - "gra" is mapped in Normal and Visual mode to |vim.lsp.buf.code_action()|
 - "grr" is mapped in Normal mode to |vim.lsp.buf.references()|
 - "gri" is mapped in Normal mode to |vim.lsp.buf.implementation()|
+- "grs" is mapped in Normal mode to |vim.lsp.buf.workspace_symbol()|
+- "grS" is mapped in Normal mode to |vim.lsp.buf.document_symbol()|
 - CTRL-S is mapped in Insert mode to |vim.lsp.buf.signature_help()|
 
 If not wanted, these keymaps can be removed at any time using

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -77,8 +77,8 @@ Some keymaps are created unconditionally when Nvim starts:
 - "gra" is mapped in Normal and Visual mode to |vim.lsp.buf.code_action()|
 - "grr" is mapped in Normal mode to |vim.lsp.buf.references()|
 - "gri" is mapped in Normal mode to |vim.lsp.buf.implementation()|
-- "grs" is mapped in Normal mode to |vim.lsp.buf.workspace_symbol()|
-- "grS" is mapped in Normal mode to |vim.lsp.buf.document_symbol()|
+- "grS" is mapped in Normal mode to |vim.lsp.buf.workspace_symbol()|
+- "grs" is mapped in Normal mode to |vim.lsp.buf.document_symbol()|
 - CTRL-S is mapped in Insert mode to |vim.lsp.buf.signature_help()|
 
 If not wanted, these keymaps can be removed at any time using

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -77,7 +77,6 @@ Some keymaps are created unconditionally when Nvim starts:
 - "gra" is mapped in Normal and Visual mode to |vim.lsp.buf.code_action()|
 - "grr" is mapped in Normal mode to |vim.lsp.buf.references()|
 - "gri" is mapped in Normal mode to |vim.lsp.buf.implementation()|
-- "grs" is mapped in Normal mode to |vim.lsp.buf.workspace_symbol()|
 - "gO" is mapped in Normal mode to |vim.lsp.buf.document_symbol()|
 - CTRL-S is mapped in Insert mode to |vim.lsp.buf.signature_help()|
 

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -71,7 +71,7 @@ options are not restored when the LSP client is stopped or detached.
 - |K| is mapped to |vim.lsp.buf.hover()| unless |'keywordprg'| is customized or
   a custom keymap for `K` exists.
 
-                              *grr* *gra* *grn* *gri* *grs* *gO* *i_CTRL-S*
+                                 *grr* *gra* *grn* *gri* *gO* *i_CTRL-S*
 Some keymaps are created unconditionally when Nvim starts:
 - "grn" is mapped in Normal mode to |vim.lsp.buf.rename()|
 - "gra" is mapped in Normal and Visual mode to |vim.lsp.buf.code_action()|

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -71,7 +71,7 @@ options are not restored when the LSP client is stopped or detached.
 - |K| is mapped to |vim.lsp.buf.hover()| unless |'keywordprg'| is customized or
   a custom keymap for `K` exists.
 
-                                 *grr* *gra* *grn* *gri* *gO* *i_CTRL-S*
+                                   *grr* *gra* *grn* *gri* *i_CTRL-S*
 Some keymaps are created unconditionally when Nvim starts:
 - "grn" is mapped in Normal mode to |vim.lsp.buf.rename()|
 - "gra" is mapped in Normal and Visual mode to |vim.lsp.buf.code_action()|

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -77,8 +77,8 @@ Some keymaps are created unconditionally when Nvim starts:
 - "gra" is mapped in Normal and Visual mode to |vim.lsp.buf.code_action()|
 - "grr" is mapped in Normal mode to |vim.lsp.buf.references()|
 - "gri" is mapped in Normal mode to |vim.lsp.buf.implementation()|
-- "grS" is mapped in Normal mode to |vim.lsp.buf.workspace_symbol()|
-- "grs" is mapped in Normal mode to |vim.lsp.buf.document_symbol()|
+- "grs" is mapped in Normal mode to |vim.lsp.buf.workspace_symbol()|
+- "gO" is mapped in Normal mode to |vim.lsp.buf.document_symbol()|
 - CTRL-S is mapped in Insert mode to |vim.lsp.buf.signature_help()|
 
 If not wanted, these keymaps can be removed at any time using

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -140,8 +140,8 @@ DEFAULTS
   • |grn| in Normal mode maps to |vim.lsp.buf.rename()|
   • |grr| in Normal mode maps to |vim.lsp.buf.references()|
   • |gri| in Normal mode maps to |vim.lsp.buf.implementation()|
-  • |grs| in Normal mode maps to |vim.lsp.buf.workspace_symbol()|
-  • |grS| in Normal mode maps to |vim.lsp.buf.document_symbol()|
+  • |grS| in Normal mode maps to |vim.lsp.buf.workspace_symbol()|
+  • |grs| in Normal mode maps to |vim.lsp.buf.document_symbol()|
   • |gra| in Normal and Visual mode maps to |vim.lsp.buf.code_action()|
   • CTRL-S in Insert mode maps to |vim.lsp.buf.signature_help()|
   • Mouse |popup-menu| includes an "Open in web browser" item when you right-click

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -140,8 +140,8 @@ DEFAULTS
   • |grn| in Normal mode maps to |vim.lsp.buf.rename()|
   • |grr| in Normal mode maps to |vim.lsp.buf.references()|
   • |gri| in Normal mode maps to |vim.lsp.buf.implementation()|
-  • |grS| in Normal mode maps to |vim.lsp.buf.workspace_symbol()|
-  • |grs| in Normal mode maps to |vim.lsp.buf.document_symbol()|
+  • |grs| in Normal mode maps to |vim.lsp.buf.workspace_symbol()|
+  • |gO| in Normal mode maps to |vim.lsp.buf.document_symbol()|
   • |gra| in Normal and Visual mode maps to |vim.lsp.buf.code_action()|
   • CTRL-S in Insert mode maps to |vim.lsp.buf.signature_help()|
   • Mouse |popup-menu| includes an "Open in web browser" item when you right-click

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -140,6 +140,8 @@ DEFAULTS
   • |grn| in Normal mode maps to |vim.lsp.buf.rename()|
   • |grr| in Normal mode maps to |vim.lsp.buf.references()|
   • |gri| in Normal mode maps to |vim.lsp.buf.implementation()|
+  • |grs| in Normal mode maps to |vim.lsp.buf.workspace_symbol()|
+  • |grS| in Normal mode maps to |vim.lsp.buf.document_symbol()|
   • |gra| in Normal and Visual mode maps to |vim.lsp.buf.code_action()|
   • CTRL-S in Insert mode maps to |vim.lsp.buf.signature_help()|
   • Mouse |popup-menu| includes an "Open in web browser" item when you right-click

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -140,7 +140,6 @@ DEFAULTS
   • |grn| in Normal mode maps to |vim.lsp.buf.rename()|
   • |grr| in Normal mode maps to |vim.lsp.buf.references()|
   • |gri| in Normal mode maps to |vim.lsp.buf.implementation()|
-  • |grs| in Normal mode maps to |vim.lsp.buf.workspace_symbol()|
   • |gO| in Normal mode maps to |vim.lsp.buf.document_symbol()|
   • |gra| in Normal and Visual mode maps to |vim.lsp.buf.code_action()|
   • CTRL-S in Insert mode maps to |vim.lsp.buf.signature_help()|

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -152,7 +152,6 @@ of these in your config by simply removing the mapping, e.g. ":unmap Y".
   - |gra|
   - |gri|
   - |gO|
-  - |grs|
 - <C-S> |i_CTRL-S|
 - ]d |]d-default|
 - [d |[d-default|

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -151,6 +151,8 @@ of these in your config by simply removing the mapping, e.g. ":unmap Y".
   - |grr|
   - |gra|
   - |gri|
+  - |grs|
+  - |grS|
 - <C-S> |i_CTRL-S|
 - ]d |]d-default|
 - [d |[d-default|

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -151,8 +151,8 @@ of these in your config by simply removing the mapping, e.g. ":unmap Y".
   - |grr|
   - |gra|
   - |gri|
+  - |gO|
   - |grs|
-  - |grS|
 - <C-S> |i_CTRL-S|
 - ]d |]d-default|
 - [d |[d-default|

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -157,7 +157,7 @@ do
   --- client is attached. If no client is attached, or if a server does not support a capability, an
   --- error message is displayed rather than exhibiting different behavior.
   ---
-  --- See |grr|, |grn|, |gra|, |gri|, |i_CTRL-S|.
+  --- See |grr|, |grn|, |gra|, |gri|, |grs|, |grS|, |i_CTRL-S|.
   do
     vim.keymap.set('n', 'grn', function()
       vim.lsp.buf.rename()
@@ -174,6 +174,14 @@ do
     vim.keymap.set('n', 'gri', function()
       vim.lsp.buf.implementation()
     end, { desc = 'vim.lsp.buf.implementation()' })
+
+    vim.keymap.set('n', 'grs', function()
+      vim.lsp.buf.workspace_symbol()
+    end, { desc = 'vim.lsp.buf.workspace_symbol()' })
+
+    vim.keymap.set('n', 'grS', function()
+      vim.lsp.buf.document_symbol()
+    end, { desc = 'vim.lsp.buf.document_symbol()' })
 
     vim.keymap.set('i', '<C-S>', function()
       vim.lsp.buf.signature_help()

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -175,11 +175,11 @@ do
       vim.lsp.buf.implementation()
     end, { desc = 'vim.lsp.buf.implementation()' })
 
-    vim.keymap.set('n', 'grS', function()
+    vim.keymap.set('n', 'grs', function()
       vim.lsp.buf.workspace_symbol()
     end, { desc = 'vim.lsp.buf.workspace_symbol()' })
 
-    vim.keymap.set('n', 'grs', function()
+    vim.keymap.set('n', 'gO', function()
       vim.lsp.buf.document_symbol()
     end, { desc = 'vim.lsp.buf.document_symbol()' })
 

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -157,7 +157,7 @@ do
   --- client is attached. If no client is attached, or if a server does not support a capability, an
   --- error message is displayed rather than exhibiting different behavior.
   ---
-  --- See |grr|, |grn|, |gra|, |gri|, |grs|, |gO|, |i_CTRL-S|.
+  --- See |grr|, |grn|, |gra|, |gri|, |gO|, |i_CTRL-S|.
   do
     vim.keymap.set('n', 'grn', function()
       vim.lsp.buf.rename()
@@ -174,10 +174,6 @@ do
     vim.keymap.set('n', 'gri', function()
       vim.lsp.buf.implementation()
     end, { desc = 'vim.lsp.buf.implementation()' })
-
-    vim.keymap.set('n', 'grs', function()
-      vim.lsp.buf.workspace_symbol()
-    end, { desc = 'vim.lsp.buf.workspace_symbol()' })
 
     vim.keymap.set('n', 'gO', function()
       vim.lsp.buf.document_symbol()

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -157,7 +157,7 @@ do
   --- client is attached. If no client is attached, or if a server does not support a capability, an
   --- error message is displayed rather than exhibiting different behavior.
   ---
-  --- See |grr|, |grn|, |gra|, |gri|, |grs|, |grS|, |i_CTRL-S|.
+  --- See |grr|, |grn|, |gra|, |gri|, |grs|, |gO|, |i_CTRL-S|.
   do
     vim.keymap.set('n', 'grn', function()
       vim.lsp.buf.rename()

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -175,11 +175,11 @@ do
       vim.lsp.buf.implementation()
     end, { desc = 'vim.lsp.buf.implementation()' })
 
-    vim.keymap.set('n', 'grs', function()
+    vim.keymap.set('n', 'grS', function()
       vim.lsp.buf.workspace_symbol()
     end, { desc = 'vim.lsp.buf.workspace_symbol()' })
 
-    vim.keymap.set('n', 'grS', function()
+    vim.keymap.set('n', 'grs', function()
       vim.lsp.buf.document_symbol()
     end, { desc = 'vim.lsp.buf.document_symbol()' })
 


### PR DESCRIPTION
Adds 2 new LSP mappings under gr prefix.

gO: vim.lsp.buf.document_symbol()

mnemonic: "s" for "symbol"

gO was planned to show document symbols