### PR TITLE
docs: fix path to check_colors.vim

### DIFF
--- a/runtime/colors/README.txt
+++ b/runtime/colors/README.txt
@@ -84,7 +84,7 @@ The default color settings can be found in the source file
 If you think you have a color scheme that is good enough to be used by others,
 please check the following items:
 
-- Source the $VIMRUNTIME/colors/tools/check_colors.vim script to check for
+- Source the $VIMRUNTIME/tools/check_colors.vim script to check for
   common mistakes.
 
 - Does it work in a color terminal as well as in the GUI? Is it consistent?


### PR DESCRIPTION
The file was moved in 567c0e6cd706fd814d081fae49bcc20a83dbc8b1 but docs weren't updated