### PR TITLE
Update vim.lua to interpret `ctermfg=3` consistently 

### DIFF
--- a/runtime/colors/vim.lua
+++ b/runtime/colors/vim.lua
@@ -245,7 +245,7 @@ if vim.o.background == 'light' then
   hi('Constant',         { fg = 'Magenta',                              ctermfg = 'DarkRed' })
   hi('Special',          { fg = '#6a5acd',                              ctermfg = 'DarkMagenta' })
   hi('Identifier',       { fg = 'DarkCyan',                             ctermfg = 'DarkCyan' })
-  hi('Statement',        { fg = 'Brown', bold = true,                   ctermfg = 'Brown' })
+  hi('Statement',        { fg = 'DarkYellow', bold = true,              ctermfg = 'DarkYellow', cterm = { bold = true } })
   hi('PreProc',          { fg = '#6a0dad',                              ctermfg = 'DarkMagenta' })
   hi('Type',             { fg = 'SeaGreen', bold = true,                ctermfg = 'DarkGreen' })
   hi('Underlined',       { fg = 'SlateBlue', underline = true,          ctermfg = 'DarkMagenta', cterm = { underline = true } })

--- a/runtime/colors/vim.lua
+++ b/runtime/colors/vim.lua
@@ -245,7 +245,7 @@ if vim.o.background == 'light' then
   hi('Constant',         { fg = 'Magenta',                              ctermfg = 'DarkRed' })
   hi('Special',          { fg = '#6a5acd',                              ctermfg = 'DarkMagenta' })
   hi('Identifier',       { fg = 'DarkCyan',                             ctermfg = 'DarkCyan' })
-  hi('Statement',        { fg = 'DarkYellow', bold = true,              ctermfg = 'DarkYellow', cterm = { bold = true } })
+  hi('Statement',        { fg = 'Brown', bold = true,                   ctermfg = 'DarkYellow', cterm = { bold = true } })
   hi('PreProc',          { fg = '#6a0dad',                              ctermfg = 'DarkMagenta' })
   hi('Type',             { fg = 'SeaGreen', bold = true,                ctermfg = 'DarkGreen' })
   hi('Underlined',       { fg = 'SlateBlue', underline = true,          ctermfg = 'DarkMagenta', cterm = { underline = true } })

--- a/runtime/colors/vim.lua
+++ b/runtime/colors/vim.lua
@@ -245,7 +245,7 @@ if vim.o.background == 'light' then
   hi('Constant',         { fg = 'Magenta',                              ctermfg = 'DarkRed' })
   hi('Special',          { fg = '#6a5acd',                              ctermfg = 'DarkMagenta' })
   hi('Identifier',       { fg = 'DarkCyan',                             ctermfg = 'DarkCyan' })
-  hi('Statement',        { fg = 'Brown', bold = true,                   ctermfg = 'DarkYellow', cterm = { bold = true } })
+  hi('Statement',        { fg = 'Brown', bold = true,                   ctermfg = 'DarkYellow' })
   hi('PreProc',          { fg = '#6a0dad',                              ctermfg = 'DarkMagenta' })
   hi('Type',             { fg = 'SeaGreen', bold = true,                ctermfg = 'DarkGreen' })
   hi('Underlined',       { fg = 'SlateBlue', underline = true,          ctermfg = 'DarkMagenta', cterm = { underline = true } })


### PR DESCRIPTION
Currently, colour no. 3 in the 8-colour scheme is interpreted as DarkYellow
https://github.com/neovim/neovim/blob/fb74fd2954ee4eeee566bb2fcfd480a4281f1e4a/runtime/syntax/dircolors.vim#L52

Thus, `hi Statement term=bold ctermfg=3` in Vim’s old default colorscheme for light background (ie peachpuff-legacy) is shown as bold DarkYellow in Vim/Neovim: https://github.com/mohvn/peachpuff-legacy/blob/eee3101fd33d58350274a16e60df7452080d2c56/colors/peachpuff.vim#L54

The same colour, however, is interpreted as Brown in vim.lua because `3	    Brown, DarkYellow`. As a result, although vim.lua is supposed to revert to the old Vim defaults, Statement actually sports a different colour under `:colo vim` (non-bold Brown) than with `:colo peachpuff-legacy` (bold DarkYellow) in a terminal context.

This PR fixes the inconsistency.