### PR TITLE
vim-patch:8.2.{0985,0986}: simplify() does not remove slashes from "///path"

### DIFF
--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1538,6 +1538,13 @@ void simplify_filename(char *filename)
     } while (vim_ispathsep(*p));
   }
   char *start = p;        // remember start after "c:/" or "/" or "///"
+#ifdef UNIX
+  // Posix says that "//path" is unchanged but "///path" is "/path".
+  if (start > filename + 2) {
+    STRMOVE(filename + 1, p);
+    start = p = filename + 1;
+  }
+#endif
 
   do {
     // At this point "p" is pointing to the char following a single "/"

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -383,6 +383,10 @@ func Test_simplify()
   call assert_equal('/',           simplify('/.'))
   call assert_equal('/',           simplify('/..'))
   call assert_equal('/...',        simplify('/...'))
+  call assert_equal('//path',      simplify('//path'))
+  call assert_equal('/path',       simplify('///path'))
+  call assert_equal('/path',       simplify('////path'))
+
   call assert_equal('./dir/file',  './dir/file'->simplify())
   call assert_equal('./dir/file',  simplify('.///dir//file'))
   call assert_equal('./dir/file',  simplify('./dir/./file'))
@@ -2069,6 +2073,7 @@ endfunc
 
 " Test for the inputdialog() function
 func Test_inputdialog()
+  set timeout timeoutlen=10
   if has('gui_running')
     call assert_fails('let v=inputdialog([], "xx")', 'E730:')
     call assert_fails('let v=inputdialog("Q", [])', 'E730:')
@@ -2078,6 +2083,7 @@ func Test_inputdialog()
     call feedkeys(":let v=inputdialog('Q:', 'xx', 'yy')\<CR>\<Esc>", 'xt')
     call assert_equal('yy', v)
   endif
+  set timeout& timeoutlen&
 endfunc
 
 " Test for inputlist()

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -384,8 +384,10 @@ func Test_simplify()
   call assert_equal('/',           simplify('/..'))
   call assert_equal('/...',        simplify('/...'))
   call assert_equal('//path',      simplify('//path'))
-  call assert_equal('/path',       simplify('///path'))
-  call assert_equal('/path',       simplify('////path'))
+  if has('unix')
+    call assert_equal('/path',       simplify('///path'))
+    call assert_equal('/path',       simplify('////path'))
+  endif
 
   call assert_equal('./dir/file',  './dir/file'->simplify())
   call assert_equal('./dir/file',  simplify('.///dir//file'))


### PR DESCRIPTION
Fix #30797

#### vim-patch:8.2.0985: simplify() does not remove slashes from "///path"

Problem:    Simplify() does not remove slashes from "///path".
Solution:   Reduce > 2 slashes to one.

https://github.com/vim/vim/commit/fdcbe3c3fedf48a43b22938c9331addb2f1182f1

Omit Test_readdirex() change: changed again in patch 9.0.0323.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.0986: MS-Windows: functions test fails

Problem:    MS-Windows: functions test fails.
Solution:   Only simplify ///path on Unix.

https://github.com/vim/vim/commit/c70222d12a2f8552273c0de48a3bf7138d649175

Co-authored-by: Bram Moolenaar <Bram@vim.org>