### PR TITLE
vim-patch:6e91853: runtime(gleam): add ftplugin for gleam files

### DIFF
--- a/runtime/ftplugin/gleam.vim
+++ b/runtime/ftplugin/gleam.vim
@@ -1,0 +1,16 @@
+" Vim filetype plugin file
+" Language:    Gleam
+" Maintainer:  Trilowy (https://github.com/trilowy)
+" Last Change: 2024 Oct 13
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=://,:///,:////
+setlocal commentstring=//\ %s
+
+let b:undo_ftplugin = "setlocal comments< commentstring<"
+
+" vim: sw=2 sts=2 et


### PR DESCRIPTION
fixes: vim/vim#15864
closes: vim/vim#15866

https://github.com/vim/vim/commit/6e918538b117c8c0b87a3d30300e8bbd073d652c

Co-authored-by: Trilowy <49493635+trilowy@users.noreply.github.com>
