### PR TITLE
vim-patch:9.1.0778: filetype: lf config files are not recognized

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1750,6 +1750,20 @@ define the vim variable 'lace_case_insensitive' in your startup file: >
 	:let lace_case_insensitive=1
 
 
+LF (LFRC)		*lf.vim* *ft-lf-syntax* *g:lf_shell_syntax*
+						*b:lf_shell_syntax*
+
+For the lf file manager configuration files (lfrc) the shell commands
+syntax highlighting can be changed globally and per buffer by setting
+a different 'include' command search pattern using these variables:
+	let g:lf_shell_syntax = "syntax/dosbatch.vim"
+	let b:lf_shell_syntax = "syntax/zsh.vim"
+
+These variables are unset by default.
+
+The default 'include' command search pattern is 'syntax/sh.vim'.
+
+
 LEX						*lex.vim* *ft-lex-syntax*
 
 Lex uses brute-force synchronizing as the "^%%$" section delimiter

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1611,6 +1611,7 @@ local filename = {
   ['ldaprc'] = 'ldapconf',
   ['.ldaprc'] = 'ldapconf',
   ['ldap.conf'] = 'ldapconf',
+  ['lfrc'] = 'lf',
   ['lftp.conf'] = 'lftp',
   ['.lftprc'] = 'lftp',
   ['/.libao'] = 'libao',

--- a/runtime/syntax/lf.vim
+++ b/runtime/syntax/lf.vim
@@ -1,0 +1,236 @@
+" Vim syntax file
+" Language: lf file manager configuration file (lfrc)
+" Maintainer: Andis Sprinkis <andis@sprinkis.com>
+" Former Maintainer: Cameron Wright
+" Former URL: https://github.com/andis-sprinkis/lf-vim
+" Last Change: 13 October 2024
+"
+" The shell syntax highlighting is configurable. See $VIMRUNTIME/doc/syntax.txt
+" lf version: 32
+
+if exists("b:current_syntax")
+    finish
+endif
+
+let b:current_syntax = "lf"
+
+"{{{ Comment Matching
+syn match    lfComment        '#.*$'
+"}}}
+
+"{{{ String Matching
+syn match    lfString         "'.*'"
+syn match    lfString         '".*"' contains=lfVar,lfSpecial
+"}}}
+
+"{{{ Match lf Variables
+syn match    lfVar            '\$f\|\$fx\|\$fs\|\$id'
+"}}}
+
+"{{{ Keywords
+syn keyword  lfKeyword        set setlocal cmd map cmap skipwhite
+"}}}
+
+"{{{ Options Keywords
+syn keyword  lfOptions
+    \ quit
+    \ up
+    \ half-up
+    \ page-up
+    \ scroll-up
+    \ down
+    \ half-down
+    \ page-down
+    \ scroll-down
+    \ updir
+    \ open
+    \ jump-next
+    \ jump-prev
+    \ top
+    \ bottom
+    \ high
+    \ middle
+    \ low
+    \ toggle
+    \ invert
+    \ invert-below
+    \ unselect
+    \ glob-select
+    \ glob-unselect
+    \ calcdirsize
+    \ clearmaps
+    \ copy
+    \ cut
+    \ paste
+    \ clear
+    \ sync
+    \ draw
+    \ redraw
+    \ load
+    \ reload
+    \ echo
+    \ echomsg
+    \ echoerr
+    \ cd
+    \ select
+    \ delete
+    \ rename
+    \ source
+    \ push
+    \ read
+    \ shell
+    \ shell-pipe
+    \ shell-wait
+    \ shell-async
+    \ find
+    \ find-back
+    \ find-next
+    \ find-prev
+    \ search
+    \ search-back
+    \ search-next
+    \ search-prev
+    \ filter
+    \ setfilter
+    \ mark-save
+    \ mark-load
+    \ mark-remove
+    \ tag
+    \ tag-toggle
+    \ cmd-escape
+    \ cmd-complete
+    \ cmd-menu-complete
+    \ cmd-menu-complete-back
+    \ cmd-menu-accept
+    \ cmd-enter
+    \ cmd-interrupt
+    \ cmd-history-next
+    \ cmd-history-prev
+    \ cmd-left
+    \ cmd-right
+    \ cmd-home
+    \ cmd-end
+    \ cmd-delete
+    \ cmd-delete-back
+    \ cmd-delete-home
+    \ cmd-delete-end
+    \ cmd-delete-unix-word
+    \ cmd-yank
+    \ cmd-transpose
+    \ cmd-transpose-word
+    \ cmd-word
+    \ cmd-word-back
+    \ cmd-delete-word
+    \ cmd-delete-word-back
+    \ cmd-capitalize-word
+    \ cmd-uppercase-word
+    \ cmd-lowercase-word
+    \ anchorfind
+    \ autoquit
+    \ borderfmt
+    \ cleaner
+    \ copyfmt
+    \ cursoractivefmt
+    \ cursorparentfmt
+    \ cursorpreviewfmt
+    \ cutfmt
+    \ dircache
+    \ dircounts
+    \ dirfirst
+    \ dironly
+    \ dirpreviews
+    \ drawbox
+    \ dupfilefmt
+    \ errorfmt
+    \ filesep
+    \ findlen
+    \ globfilter
+    \ globsearch
+    \ hidden
+    \ hiddenfiles
+    \ hidecursorinactive
+    \ history
+    \ icons
+    \ ifs
+    \ ignorecase
+    \ ignoredia
+    \ incfilter
+    \ incsearch
+    \ info
+    \ infotimefmtnew
+    \ infotimefmtold
+    \ mouse
+    \ number
+    \ numberfmt
+    \ period
+    \ preserve
+    \ preview
+    \ previewer
+    \ promptfmt
+    \ ratios
+    \ relativenumber
+    \ reverse
+    \ roundbox
+    \ ruler
+    \ rulerfmt
+    \ scrolloff
+    \ selectfmt
+    \ selmode
+    \ shell
+    \ shellflag
+    \ shellopts
+    \ sixel
+    \ smartcase
+    \ smartdia
+    \ sortby
+    \ statfmt
+    \ tabstop
+    \ tagfmt
+    \ tempmarks
+    \ timefmt
+    \ truncatechar
+    \ truncatepct
+    \ waitmsg
+    \ wrapscan
+    \ wrapscroll
+    \ pre-cd
+    \ on-cd
+    \ on-select
+    \ on-redraw
+    \ on-quit
+"}}}
+
+"{{{ Special Matching
+syn match    lfSpecial        '<.*>\|\\.'
+"}}}
+
+"{{{ Shell Script Matching for cmd
+let s:shell_syntax = get(g:, 'lf_shell_syntax', "syntax/sh.vim")
+let s:shell_syntax = get(b:, 'lf_shell_syntax', s:shell_syntax)
+unlet b:current_syntax
+exe 'syn include @Shell '.s:shell_syntax
+let b:current_syntax = "lf"
+syn region   lfIgnore         start=".{{\n" end="^}}"
+    \ keepend contains=lfExternalShell,lfExternalPatch
+syn match    lfShell          '\$[a-zA-Z].*$
+    \\|:[a-zA-Z].*$
+    \\|%[a-zA-Z].*$
+    \\|![a-zA-Z].*$
+    \\|&[a-zA-Z].*$'
+    \ transparent contains=@Shell,lfExternalPatch
+syn match    lfExternalShell  "^.*$" transparent contained contains=@Shell
+syn match    lfExternalPatch  "^\s*cmd\ .*\ .{{$\|^}}$" contained
+"}}}
+
+"{{{ Link Highlighting
+hi def link  lfComment        Comment
+hi def link  lfVar            Type
+hi def link  lfSpecial        Special
+hi def link  lfString         String
+hi def link  lfKeyword        Statement
+hi def link  lfOptions        Constant
+hi def link  lfConstant       Constant
+hi def link  lfExternalShell  Normal
+hi def link  lfExternalPatch  Special
+hi def link  lfIgnore         Special
+"}}}

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -407,6 +407,7 @@ func s:GetFilenameChecks() abort
     \ 'ledger': ['file.ldg', 'file.ledger', 'file.journal'],
     \ 'less': ['file.less'],
     \ 'lex': ['file.lex', 'file.l', 'file.lxx', 'file.l++'],
+    \ 'lf': ['lfrc'],
     \ 'lftp': ['lftp.conf', '.lftprc', 'anylftp/rc', 'lftp/rc', 'some-lftp/rc'],
     \ 'lhaskell': ['file.lhs'],
     \ 'libao': ['/etc/libao.conf', '/.libao', 'any/.libao', 'any/etc/libao.conf'],


### PR DESCRIPTION
Problem:  filetype: lf config files are not recognized
Solution: detect lfrc files as lf filetype, include a syntax
          script for lf files (Andis Spriņķis).

References:
- https://github.com/gokcehan/lf

closes: vim/vim#15859

https://github.com/vim/vim/commit/0f146b7925178a5bdfdc8e07642976f0b76d9612

Co-authored-by: Andis Spriņķis <spr.andis@protonmail.com>
