### PR TITLE
vim-patch:a420547: runtime(misc): Use consistent "Vim script" spelling

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1287,7 +1287,7 @@ separated by ';'.
 For example, to have only Vim files in the dialog, you could use the following
 command: >
 
-     let g:browsefilter = "Vim Scripts\t*.vim\nVim Startup Files\t*vimrc\n"
+     let g:browsefilter = "Vim scripts\t*.vim\nVim Startup Files\t*vimrc\n"
 
 You can override the filter setting on a per-buffer basis by setting the
 b:browsefilter variable.  You would most likely set b:browsefilter in a

--- a/runtime/menu.vim
+++ b/runtime/menu.vim
@@ -1130,7 +1130,7 @@ else
   endif
   tmenu ToolBar.LoadSesn	Choose a session to load
   tmenu ToolBar.SaveSesn	Save current session
-  tmenu ToolBar.RunScript	Choose a Vim Script to run
+  tmenu ToolBar.RunScript	Choose a Vim script to run
   tmenu ToolBar.Make		Make current project (:make)
   tmenu ToolBar.RunCtags	Build tags in current directory tree (!ctags -R .)
   tmenu ToolBar.TagJump		Jump to tag under cursor

--- a/runtime/syntax/modula2/opt/r10.vim
+++ b/runtime/syntax/modula2/opt/r10.vim
@@ -157,7 +157,7 @@ syn match modula2Base16Num "0[ux][0-9A-F]\+\('[0-9A-F]\+\)*"
 "| which greatly diminishes readability and thereby increases the opportunity
 "| for error during maintenance. Ideally, regular expressions should be split
 "| into small human readable pieces with interleaved comments that explain
-"| precisely what each piece is doing.  Vimscript imposes poor design. :-(
+"| precisely what each piece is doing.  Vim script imposes poor design. :-(
 
 syn match modula2Base10Num
   \ "\(\(0[bux]\@!\|[1-9]\)[0-9]*\('[0-9]\+\)*\)\(\.[0-9]\+\('[0-9]\+\)*\(e[+-]\?[0-9]\+\('[0-9]\+\)*\)\?\)\?"

--- a/test/old/testdir/script_util.vim
+++ b/test/old/testdir/script_util.vim
@@ -1,4 +1,4 @@
-" Functions shared by the tests for Vim Script
+" Functions shared by the tests for Vim script
 
 " Commands to track the execution path of a script
 com!		   XpathINIT  let g:Xpath = ''

--- a/test/old/testdir/test_expr.vim
+++ b/test/old/testdir/test_expr.vim
@@ -883,7 +883,7 @@ func Test_string_interp()
     #" String conversion.
     call assert_equal('hello from ' .. v:version, $"hello from {v:version}")
     call assert_equal('hello from ' .. v:version, $'hello from {v:version}')
-    #" Paper over a small difference between VimScript behaviour.
+    #" Paper over a small difference between Vim script behaviour.
     call assert_equal(string(v:true), $"{v:true}")
     call assert_equal('(1+1=2)', $"(1+1={1 + 1})")
     #" Hex-escaped opening brace: char2nr('{') == 0x7b


### PR DESCRIPTION
#### vim-patch:a420547: runtime(misc): Use consistent "Vim script" spelling

References: https://groups.google.com/g/vim_dev/c/3Z5yM8KER2w/m/wAqws0QSEAAJ

closes: vim/vim#15863

https://github.com/vim/vim/commit/a4205471adae39c80fb7f151a4f33051fcb80001

Co-authored-by: h-east <h.east.727@gmail.com>