### PR TITLE
docs: update msgpack specification reference to master

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -27,7 +27,7 @@ MessagePack-RPC protocol with these extra (out-of-spec) constraints:
 
 MessagePack-RPC specification:
   https://github.com/msgpack-rpc/msgpack-rpc/blob/master/spec.md
-  https://github.com/msgpack/msgpack/blob/0b8f5ac/spec.md
+  https://github.com/msgpack/msgpack/blob/master/spec.md
 
 Many clients use the API: user interfaces (GUIs), remote plugins, scripts like
 "nvr" (https://github.com/mhinz/neovim-remote).  Even Nvim itself can control


### PR DESCRIPTION
Updated the msgpack specification reference from commit 0b8f5ac to the latest master branch. This change resolves formatting issues in the previous reference and ensures consistency with the msgpack-rpc specification reference.