### PR TITLE
vim-patch:9.1.0782: tests: using wrong neomuttlog file name

### DIFF
--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -524,7 +524,7 @@ func s:GetFilenameChecks() abort
     \ 'nanorc': ['/etc/nanorc', 'file.nanorc', 'any/etc/nanorc'],
     \ 'natural': ['file.NSA', 'file.NSC', 'file.NSG', 'file.NSL', 'file.NSM', 'file.NSN', 'file.NSP', 'file.NSS'],
     \ 'ncf': ['file.ncf'],
-    \ 'neomuttlog': ['foo.neomuttdebug'],
+    \ 'neomuttlog': ['/home/user/.neomuttdebug1'],
     \ 'neomuttrc': ['Neomuttrc', '.neomuttrc', '.neomuttrc-file', '/.neomutt/neomuttrc', '/.neomutt/neomuttrc-file', 'Neomuttrc', 'Neomuttrc-file', 'any/.neomutt/neomuttrc', 'any/.neomutt/neomuttrc-file', 'neomuttrc', 'neomuttrc-file'],
     \ 'netrc': ['.netrc'],
     \ 'nginx': ['file.nginx', 'nginxfile.conf', 'filenginx.conf', 'any/etc/nginx/file', 'any/usr/local/nginx/conf/file', 'any/nginx/file.conf'],


### PR DESCRIPTION
Problem:  tests: using wrong neomuttlog file name
Solution: use correct file name

related: vim/vim#15858

https://github.com/vim/vim/commit/0c59c3027199ce593f6612d7cd418f375933c7cb

Co-authored-by: Christian Brabandt <cb@256bit.org>
