### PR TITLE
vim-patch:9.1.0783: 'spell' option setting has problems

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1705,7 +1705,7 @@ static void didset_options(void)
   spell_check_msm();
   spell_check_sps();
   compile_cap_prog(curwin->w_s);
-  did_set_spell_option(true);
+  did_set_spell_option();
   // set cedit_key
   did_set_cedit(NULL);
   // initialize the table for 'breakat'.

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -2118,7 +2118,7 @@ const char *did_set_spellfile(optset_T *args)
   if ((!valid_spellfile(*varp))) {
     return e_invarg;
   }
-  return did_set_spell_option(true);
+  return did_set_spell_option();
 }
 
 /// The 'spelllang' option is changed.
@@ -2131,7 +2131,7 @@ const char *did_set_spelllang(optset_T *args)
   if (!valid_spelllang(*varp)) {
     return e_invarg;
   }
-  return did_set_spell_option(false);
+  return did_set_spell_option();
 }
 
 /// The 'spelloptions' option is changed.

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -2091,7 +2091,7 @@ char *parse_spelllang(win_T *wp)
       int_wordlist_spl(spf_name);
     } else {
       // One entry in 'spellfile'.
-      copy_option_part(&spf, spf_name, MAXPATHL - 5, ",");
+      copy_option_part(&spf, spf_name, MAXPATHL - 4, ",");
       strcat(spf_name, ".spl");
       int c;
 
@@ -3664,29 +3664,25 @@ bool valid_spelllang(const char *val)
 bool valid_spellfile(const char *val)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
-  for (const char *s = val; *s != NUL; s++) {
-    if (!vim_is_fname_char((uint8_t)(*s))) {
+  char spf_name[MAXPATHL];
+  char *spf = (char *)val;
+  while (*spf != NUL) {
+    size_t l = copy_option_part(&spf, spf_name, MAXPATHL, ",");
+    if (l >= MAXPATHL - 4 || l < 4 || strcmp(spf_name + l - 4, ".add") != 0) {
       return false;
+    }
+    for (char *s = spf_name; *s != NUL; s++) {
+      if (!vim_is_fname_char((uint8_t)(*s))) {
+        return false;
+      }
     }
   }
   return true;
 }
 
-const char *did_set_spell_option(bool is_spellfile)
+const char *did_set_spell_option(void)
 {
   const char *errmsg = NULL;
-
-  if (is_spellfile) {
-    int l = (int)strlen(curwin->w_s->b_p_spf);
-    if (l > 0
-        && (l < 4 || strcmp(curwin->w_s->b_p_spf + l - 4, ".add") != 0)) {
-      errmsg = e_invarg;
-    }
-  }
-
-  if (errmsg != NULL) {
-    return errmsg;
-  }
 
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
     if (wp->w_buffer == curbuf && wp->w_p_spell) {

--- a/test/old/testdir/test_spellfile.vim
+++ b/test/old/testdir/test_spellfile.vim
@@ -1155,7 +1155,7 @@ endfunc
 " 'spellfile' accepts '@' on top of 'isfname'.
 func Test_spellfile_allow_at_character()
   call mkdir('Xtest/the foo@bar,dir', 'p')
-  let &spellfile = './Xtest/the foo@bar,dir/Xspellfile.add'
+  let &spellfile = './Xtest/the foo@bar\,dir/Xspellfile.add'
   let &spellfile = ''
   call delete('Xtest', 'rf')
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.0783: 'spell' option setting has problems

Problem:  'spell' option setting has problems
Solution: correctly check for comma for 'spellfile' option,
          remove unnecessary checks, refactor slightly (Milly)

closes: vim/vim#15873

https://github.com/vim/vim/commit/322ad0c953b7a3023cd2a65db61d05e180a5d682

Co-authored-by: Milly <milly.ca@gmail.com>