### PR TITLE
fix(runtime): use CTRL-W_q to close window (#30743)

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -269,7 +269,7 @@ These existing features changed their behavior.
 • |vim.on_key()| callbacks won't be invoked recursively when a callback itself
   consumes input.
 
-• |q| in man pages now uses |CTRL-W_q| instead of |CTRL-W_c| to close the
+• "q" in man pages now uses |CTRL-W_q| instead of |CTRL-W_c| to close the
   current window, and it no longer throws |E444| when there is only one window
   on the screen. Global variable `vim.g.pager` is removed.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -269,6 +269,10 @@ These existing features changed their behavior.
 • |vim.on_key()| callbacks won't be invoked recursively when a callback itself
   consumes input.
 
+• |q| in man pages now uses |CTRL-W_q| instead of |CTRL-W_c| to close the
+  current window, and it no longer throws |E444| when there is only one window
+  on the screen. Global variable `vim.g.pager` is removed.
+
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*
 

--- a/runtime/ftplugin/man.vim
+++ b/runtime/ftplugin/man.vim
@@ -26,11 +26,7 @@ if !exists('g:no_plugin_maps') && !exists('g:no_man_maps')
   nnoremap <silent> <buffer> k             gk
   nnoremap <silent> <buffer> gO            :lua require'man'.show_toc()<CR>
   nnoremap <silent> <buffer> <2-LeftMouse> :Man<CR>
-  if get(g:, 'pager')
-    nnoremap <silent> <buffer> <nowait> q :lclose<CR><C-W>q
-  else
-    nnoremap <silent> <buffer> <nowait> q :lclose<CR><C-W>c
-  endif
+  nnoremap <silent> <buffer> <nowait> q :lclose<CR><C-W>q
 endif
 
 if get(g:, 'ft_man_folding_enable', 0)

--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -675,7 +675,6 @@ function M.init_pager()
     vim.cmd.file({ 'man://' .. fn.fnameescape(ref):lower(), mods = { silent = true } })
   end
 
-  vim.g.pager = true
   set_options()
 end
 


### PR DESCRIPTION
- NOTE: |CTRL-W_q| exits neovim when quitting the last edit window (not counting help or preview windows). |CTRL-W_c| counts help windows, so it only closes the man page if any help window is on the screen.

- Closes: #30743