### PR TITLE
vim-patch:9.1.0785: cannot preserve error position when setting quickfix list

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -9039,6 +9039,8 @@ setqflist({list} [, {action} [, {what}]])                          *setqflist()*
 			clear the list: >vim
 				call setqflist([], 'r')
 <
+		'u'	Like 'r', but tries to preserve the current selection
+			in the quickfix list.
 		'f'	All the quickfix lists in the quickfix stack are
 			freed.
 

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -8229,6 +8229,8 @@ function vim.fn.setpos(expr, list) end
 ---   clear the list: >vim
 ---     call setqflist([], 'r')
 --- <
+--- 'u'  Like 'r', but tries to preserve the current selection
+---   in the quickfix list.
 --- 'f'  All the quickfix lists in the quickfix stack are
 ---   freed.
 ---

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -9896,6 +9896,8 @@ M.funcs = {
       	clear the list: >vim
       		call setqflist([], 'r')
       <
+      'u'	Like 'r', but tries to preserve the current selection
+      	in the quickfix list.
       'f'	All the quickfix lists in the quickfix stack are
       	freed.
 


### PR DESCRIPTION
Close #30724

#### vim-patch:9.1.0785: cannot preserve error position when setting quickfix list

Problem:  cannot preserve error position when setting quickfix lists
Solution: Add the 'u' action for setqflist()/setloclist() and try
          to keep the closes target position (Jeremy Fleischman)

closes: vim/vim#15841

https://github.com/vim/vim/commit/27fbf6e5e8bee5c6b61819a5e82a0b50b265f0b0

Co-authored-by: Jeremy Fleischman <jeremyfleischman@gmail.com>