### PR TITLE
feat(lsp): show server name in code actions

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -182,6 +182,8 @@ LSP
 • |vim.lsp.buf.format()| now supports passing a list of ranges
   via the `range` parameter (this requires support for the
   `textDocument/rangesFormatting` request).
+• |vim.lsp.buf.code_action()| actions show client name when there are multiple
+  clients.
 
 LUA
 

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -827,11 +827,19 @@ local function on_code_action_results(results, opts)
     return
   end
 
-  ---@param item {action: lsp.Command|lsp.CodeAction}
+  ---@param item {action: lsp.Command|lsp.CodeAction, ctx: lsp.HandlerContext}
   local function format_item(item)
-    local title = item.action.title:gsub('\r\n', '\\r\\n')
-    return title:gsub('\n', '\\n')
+    local clients = vim.lsp.get_clients({ bufnr = item.ctx.bufnr })
+    local title = item.action.title:gsub('\r\n', '\\r\\n'):gsub('\n', '\\n')
+
+    if #clients == 1 then
+      return title
+    end
+
+    local source = vim.lsp.get_client_by_id(item.ctx.client_id).name
+    return ('%s [%s]'):format(title, source)
   end
+
   local select_opts = {
     prompt = 'Code actions:',
     kind = 'codeaction',


### PR DESCRIPTION
Problem:

Outlined in #30710, currently users need to implement their own solution for showing the language server in the code actions list.

Solution:

This fixes #30710 by adding the language server name next to each
action.

Edit: Update to solution block message for clarity