### PR TITLE
vim-patch:9.1.0789: tests: ':resize + 5' has invalid space after '+'

### DIFF
--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -539,7 +539,7 @@ func Test_equalalways_on_close()
   1wincmd w
   split
   4wincmd w
-  resize + 5
+  resize +5
   " left column has three windows, equalized heights.
   " right column has two windows, top one a bit higher
   let height_1 = winheight(1)


### PR DESCRIPTION
#### vim-patch:9.1.0789: tests: ':resize + 5' has invalid space after '+'

Problem:  tests: ':resize + 5' has invalid space after '+'
Solution: Correct the test (Milly)

closes: vim/vim#15884

https://github.com/vim/vim/commit/c0cba184f54e052cf8f04baca24bdee72a4b7de6

Co-authored-by: Milly <milly.ca@gmail.com>