### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -11705,7 +11705,7 @@ wildmenumode()                                                  *wildmenumode()*
 		For example to make <c-j> work like <down> in wildmode, use: >vim
 		    cnoremap <expr> <C-j> wildmenumode() ? "\<Down>\<Tab>" : "\<c-j>"
 <
-		(Note, this needs the 'wildcharm' option set appropriately).
+		(Note: this needs the 'wildcharm' option set appropriately).
 
                 Return: ~
                   (`any`)

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6763,7 +6763,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	window.  This happens only when the 'title' option is on.
 
 	When this option contains printf-style '%' items, they will be
-	expanded according to the rules used for 'statusline'.
+	expanded according to the rules used for 'statusline'.  If it contains
+	an invalid '%' format, the value is used as-is and no error or warning
+	will be given when the value is set.
 	This option cannot be set in a modeline when 'modelineexpr' is off.
 
 	Example: >vim

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -967,21 +967,24 @@ For example, to profile the one_script.vim script file: >
 
 
 :prof[ile] start {fname}			*:prof* *:profile* *E750*
-		Start profiling, write the output in {fname} upon exit.
+		Start profiling, write the output in {fname} upon exit or when
+		a `:profile stop` or `:profile dump` command is invoked.
 		"~/" and environment variables in {fname} will be expanded.
 		If {fname} already exists it will be silently overwritten.
 		The variable |v:profiling| is set to one.
 
 :prof[ile] stop
-		Write the logfile and stop profiling.
+		Write the collected profiling information to the logfile and
+		stop profiling. You can use the `:profile start` command to
+		clear the profiling statistics and start profiling again.
 
 :prof[ile] pause
-		Don't profile until the following ":profile continue".  Can be
+		Don't profile until the following `:profile continue`.  Can be
 		used when doing something that should not be counted (e.g., an
 		external command).  Does not nest.
 
 :prof[ile] continue
-		Continue profiling after ":profile pause".
+		Continue profiling after `:profile pause`.
 
 :prof[ile] func {pattern}
 		Profile function that matches the pattern {pattern}.
@@ -999,16 +1002,24 @@ For example, to profile the one_script.vim script file: >
 		won't work.
 
 :prof[ile] dump
-		Don't wait until exiting Vim and write the current state of
-		profiling to the log immediately.
+		Write the current state of profiling to the logfile
+		immediately.  After running this command, Vim continues to
+		collect the profiling statistics.
 
 :profd[el] ...						*:profd* *:profdel*
 		Stop profiling for the arguments specified. See |:breakdel|
-		for the arguments.
-
+		for the arguments. Examples: >
+			profdel func MyFunc
+			profdel file MyScript.vim
+			profdel here
 
 You must always start with a ":profile start fname" command.  The resulting
-file is written when Vim exits.  Here is an example of the output, with line
+file is written when Vim exits.  For example, to profile one specific
+function: >
+	profile start /tmp/vimprofile
+	profile func MyFunc
+
+Here is an example of the output, with line
 numbers prepended for the explanation:
 
   1 FUNCTION  Test2() ~

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -979,9 +979,9 @@ For example, to profile the one_script.vim script file: >
 		clear the profiling statistics and start profiling again.
 
 :prof[ile] pause
-		Don't profile until the following `:profile continue`.  Can be
-		used when doing something that should not be counted (e.g., an
-		external command).  Does not nest.
+		Stop profiling until the next `:profile continue` command.
+		Can be used when doing something that should not be counted
+		(e.g., an external command).  Does not nest.
 
 :prof[ile] continue
 		Continue profiling after `:profile pause`.

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -7310,7 +7310,9 @@ vim.go.titleold = vim.o.titleold
 --- window.  This happens only when the 'title' option is on.
 ---
 --- When this option contains printf-style '%' items, they will be
---- expanded according to the rules used for 'statusline'.
+--- expanded according to the rules used for 'statusline'.  If it contains
+--- an invalid '%' format, the value is used as-is and no error or warning
+--- will be given when the value is set.
 --- This option cannot be set in a modeline when 'modelineexpr' is off.
 ---
 --- Example:

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -10629,7 +10629,7 @@ function vim.fn.wait(timeout, condition, interval) end
 --- For example to make <c-j> work like <down> in wildmode, use: >vim
 ---     cnoremap <expr> <C-j> wildmenumode() ? "\<Down>\<Tab>" : "\<c-j>"
 --- <
---- (Note, this needs the 'wildcharm' option set appropriately).
+--- (Note: this needs the 'wildcharm' option set appropriately).
 ---
 --- @return any
 function vim.fn.wildmenumode() end

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -53,6 +53,7 @@ else
   syn match helpIgnore		"." contained
 endif
 syn keyword helpNote		note Note NOTE note: Note: NOTE: Notes Notes:
+syn match helpNote		"\c(note\(:\|\>\)"ms=s+1
 syn keyword helpWarning		WARNING WARNING: Warning:
 syn keyword helpDeprecated	DEPRECATED DEPRECATED: Deprecated:
 syn match helpSpecial		"\<N\>"
@@ -65,6 +66,10 @@ syn match helpSpecial		"\[N]"
 syn match helpSpecial		"N  N"he=s+1
 syn match helpSpecial		"Nth"me=e-2
 syn match helpSpecial		"N-1"me=e-2
+" highlighting N for :resize in windows.txt
+syn match helpSpecial		"] -N\>"ms=s+3
+syn match helpSpecial		"+N\>"ms=s+1
+syn match helpSpecial		"\[+-]N\>"ms=s+4
 " highlighting N of cinoptions-values in indent.txt
 syn match helpSpecial		"^\t-\?\zsNs\?\s"me=s+1
 " highlighting N of cinoptions-values in indent.txt
@@ -140,7 +145,7 @@ syn match helpUnderlined	"\t[* ]Underlined\t\+[a-z].*"
 syn match helpError		"\t[* ]Error\t\+[a-z].*"
 syn match helpTodo		"\t[* ]Todo\t\+[a-z].*"
 
-syn match helpURL `\v<(((https?|ftp|gopher)://|(mailto|file|news):)[^' 	<>"]+|(www|web|w3)[a-z0-9_-]*\.[a-z0-9._-]+\.[^' 	<>"]+)[a-zA-Z0-9/]`
+syn match helpURL `\v<(((https?|ftp|gopher)://|(mailto|file|news):)[^'" \t<>{}]+|(www|web|w3)[a-z0-9_-]*\.[a-z0-9._-]+\.[^'" \t<>{}]+)[a-zA-Z0-9/]`
 
 syn match helpDiffAdded		"\t[* ]Added\t\+[a-z].*"
 syn match helpDiffChanged	"\t[* ]Changed\t\+[a-z].*"
@@ -150,16 +155,6 @@ syn match helpDiffRemoved	"\t[* ]Removed\t\+[a-z].*"
 let s:i = match(expand("%"), '\.\a\ax$')
 if s:i > 0
   exe "runtime syntax/help_" . strpart(expand("%"), s:i + 1, 2) . ".vim"
-endif
-
-" Italian
-if v:lang =~ '\<IT\>' || v:lang =~ '_IT\>' || v:lang =~? "italian"
-  syn keyword helpNote		nota Nota NOTA nota: Nota: NOTA: notare Notare NOTARE notare: Notare: NOTARE:
-  syn match helpSpecial		"Nma"me=e-2
-  syn match helpSpecial		"Nme"me=e-2
-  syn match helpSpecial		"Nmi"me=e-2
-  syn match helpSpecial		"Nmo"me=e-2
-  syn match helpSpecial		"\[interv.]"
 endif
 
 syn sync minlines=40

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Vim help file
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2024 Oct 08
+" Last Change:	2024 Oct 16
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
@@ -43,7 +43,8 @@ syn match helpOption		"'[a-z]\{2,\}'"
 syn match helpOption		"'t_..'"
 syn match helpNormal		"'ab'"
 syn match helpCommand		"`[^` \t]\+`"hs=s+1,he=e-1 contains=helpBacktick
-syn match helpCommand		"\(^\|[^a-z"[]\)\zs`[^`]\+`\ze\([^a-z\t."']\|$\)"hs=s+1,he=e-1 contains=helpBacktick
+" doesn't allow a . directly after an ending backtick. See :helpgrep `[^`,]\+ [^`,]\+`\.
+syn match helpCommand		"\(^\|[^a-z"[]\)\zs`[^`]\+`\ze\([^a-z\t."']\|[.?!]\?$\)"hs=s+1,he=e-1 contains=helpBacktick
 syn match helpHeader		"\s*\zs.\{-}\ze\s\=\~$" nextgroup=helpIgnore
 syn match helpGraphic		".* \ze`$" nextgroup=helpIgnore
 if has("conceal")

--- a/runtime/syntax/help_it.vim
+++ b/runtime/syntax/help_it.vim
@@ -1,0 +1,17 @@
+" Vim syntax file
+" Language:	Italian Vim program help files *.itx
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2024 Oct 16
+"
+" This script is sourced from syntax/help.vim.
+
+syn keyword helpNote		nota Nota NOTA nota: Nota: NOTA: notare Notare NOTARE notare: Notare: NOTARE:
+syn match helpNote		"\c(nota\(:\|\>\)"ms=s+1
+syn match helpSpecial		"Nma"me=e-2
+syn match helpSpecial		"Nme"me=e-2
+syn match helpSpecial		"Nmi"me=e-2
+syn match helpSpecial		"Nmo"me=e-2
+syn match helpSpecial		"\[interv.]"
+syn region helpNotVi		start="{non" start="{solo" start="{disponibile" end="}" contains=helpLeadBlank,helpHyperTextJump
+
+" vim: ts=8 sw=2

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -12768,7 +12768,7 @@ M.funcs = {
       For example to make <c-j> work like <down> in wildmode, use: >vim
           cnoremap <expr> <C-j> wildmenumode() ? "\<Down>\<Tab>" : "\<c-j>"
       <
-      (Note, this needs the 'wildcharm' option set appropriately).
+      (Note: this needs the 'wildcharm' option set appropriately).
     ]=],
     name = 'wildmenumode',
     params = {},

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9130,7 +9130,9 @@ return {
         window.  This happens only when the 'title' option is on.
 
         When this option contains printf-style '%' items, they will be
-        expanded according to the rules used for 'statusline'.
+        expanded according to the rules used for 'statusline'.  If it contains
+        an invalid '%' format, the value is used as-is and no error or warning
+        will be given when the value is set.
         This option cannot be set in a modeline when 'modelineexpr' is off.
 
         Example: >vim


### PR DESCRIPTION
#### vim-patch:partial:8.2.4712: only get profiling information after exiting

https://github.com/vim/vim/commit/18ee0f603ebd3c091f6d2ab88e652fda32821048

Doc updates only.
Cherry-pick profiling doc change from patch 8.2.2400.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:4bfb899: runtime(help): fix end of sentence highlight in code examples

https://github.com/vim/vim/commit/4bfb89996f227d5fbb4803f0d8dbd3105483b625

Co-authored-by: Christian Brabandt <cb@256bit.org>
Co-authored-by: Danilo Rezende <returndanilo@users.noreply.github.com>


#### vim-patch:6c2fc37: runtime(help): Update help syntax

This commit makaes the following changes to the vim help syntax:

- fix excessive URL detection in help, because `file:{filename}` in
  doc/options.txt is determined to be a URL.
- update highlighting N for :resize in help
- split Italian-specific syntax into separate help script
- highlight `Note` in parentheses in help
- update 'titlestring' behaviour in documentation for invalid '%' format

closes: vim/vim#15883

https://github.com/vim/vim/commit/6c2fc377bfbfb6f1a46b1061413cd21116b596ed

Co-authored-by: Milly <milly.ca@gmail.com>