### PR TITLE
fix(clipboard-osc52): use tmux passthrough sequence when running in tmux

### DIFF
--- a/runtime/lua/vim/ui/clipboard/osc52.lua
+++ b/runtime/lua/vim/ui/clipboard/osc52.lua
@@ -6,7 +6,11 @@ local M = {}
 --- @param contents string The Base64 encoded contents to write to the clipboard, or '?' to read
 ---                        from the clipboard
 local function osc52(clipboard, contents)
-  return string.format('\027]52;%s;%s\027\\', clipboard, contents)
+  local query = string.format('\027]52;%s;%s\027\\', clipboard, contents)
+  if os.getenv('TMUX') then
+    query = string.format('\027Ptmux;%s\027\\', query:gsub('\027', '\027\027'))
+  end
+  return query
 end
 
 function M.copy(reg)


### PR DESCRIPTION
Problem:

A nvim instance behind the tmux session cannot send osc52 sequence to the host terminal.

Solution:

Wraps the query in the tmux passthrough sequence when running inside tmux to ensure the query arrives at the "host" terminal.