### PR TITLE
vim-patch:5e53fca: runtime(jinja): Support jinja syntax as secondary filetype

### DIFF
--- a/runtime/syntax/jinja.vim
+++ b/runtime/syntax/jinja.vim
@@ -2,8 +2,9 @@
 " Language: Jinja
 " Maintainer: Gregory Anders
 " Upstream: https://gitlab.com/HiPhish/jinja.vim
+" Last Change: 2024 Oct 16
 
-if exists('b:current_syntax')
+if exists('b:current_syntax') && b:current_syntax =~? 'jinja'
     finish
 endif
 


### PR DESCRIPTION
fixes: #vim/vim#15880
closes: vim/vim#15885

https://github.com/vim/vim/commit/5e53fca76fd991d64d83429d74b573cc73116d66

Co-authored-by: Gregory Anders <greg@gpanders.com>
