### PR TITLE
feat(lsp)!: reimplement LSP document highlight with the new API style

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2137,6 +2137,55 @@ is_enabled({bufnr})                      *vim.lsp.document_color.is_enabled()*
 
 
 ==============================================================================
+Lua module: vim.lsp.document_highlight                *lsp-document_highlight*
+
+This module provides LSP support for highlighting patterns in a document,
+utility functions for interaction are also provided. Highlighting is disabled
+by default.
+
+
+enable({enable}, {filter})               *vim.lsp.document_highlight.enable()*
+    Enables or disables document highlights for the {filter}ed scope.
+
+    To "toggle", pass the inverse of `is_enabled()`: >lua
+        vim.lsp.document_highlight.enable(not vim.lsp.document_highlight.is_enabled())
+<
+
+    Note: Usage of |vim.lsp.document_highlight.enable()| requires the
+    following highlight groups to be defined or you won't be able to see the
+    actual highlights. |hl-LspReferenceText| |hl-LspReferenceRead|
+    |hl-LspReferenceWrite|
+
+    Parameters: ~
+      • {enable}  (`boolean?`)
+      • {filter}  (`table?`) A table with the following fields:
+                  • {bufnr}? (`integer`) Buffer number, or 0 for current
+                    buffer, or nil for all.
+                  • {client_id}? (`integer`) Client ID, or nil for all
+
+is_enabled({filter})                 *vim.lsp.document_highlight.is_enabled()*
+    Query whether document highlight is enabled in the {filter}ed scope
+
+    Parameters: ~
+      • {filter}  (`table?`) A table with the following fields:
+                  • {bufnr}? (`integer`) Buffer number, or 0 for current
+                    buffer, or nil for all.
+                  • {client_id}? (`integer`) Client ID, or nil for all
+
+jump({opts})                               *vim.lsp.document_highlight.jump()*
+    Jump to a document highlight.
+
+    Parameters: ~
+      • {opts}  (`table?`) A table with the following fields:
+                • {count} (`integer`, default: |v:count1|) The number of
+                  highlights to move by. A positive integer moves forward by
+                  {count} highlights, while a negative integer moves backward
+                  by {count} highlights.
+                • {winid}? (`integer`, default: `0`) Window ID, or 0 for the
+                  current window
+
+
+==============================================================================
 Lua module: vim.lsp.inlay_hint                                *lsp-inlay_hint*
 
 enable({enable}, {filter})                       *vim.lsp.inlay_hint.enable()*

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1329,9 +1329,6 @@ add_workspace_folder({workspace_folder})
     Parameters: ~
       • {workspace_folder}  (`string?`)
 
-clear_references()                            *vim.lsp.buf.clear_references()*
-    Removes document highlights from current buffer.
-
 code_action({opts})                                *vim.lsp.buf.code_action()*
     Selects a code action (LSP: "textDocument/codeAction" request) available
     at cursor position.
@@ -1377,20 +1374,6 @@ definition({opts})                                  *vim.lsp.buf.definition()*
 
     Parameters: ~
       • {opts}  (`vim.lsp.LocationOpts?`) See |vim.lsp.LocationOpts|.
-
-document_highlight()                        *vim.lsp.buf.document_highlight()*
-    Send request to the server to resolve document highlights for the current
-    text document position. This request can be triggered by a key mapping or
-    by events such as `CursorHold`, e.g.: >vim
-        autocmd CursorHold  <buffer> lua vim.lsp.buf.document_highlight()
-        autocmd CursorHoldI <buffer> lua vim.lsp.buf.document_highlight()
-        autocmd CursorMoved <buffer> lua vim.lsp.buf.clear_references()
-<
-
-    Note: Usage of |vim.lsp.buf.document_highlight()| requires the following
-    highlight groups to be defined or you won't be able to see the actual
-    highlights. |hl-LspReferenceText| |hl-LspReferenceRead|
-    |hl-LspReferenceWrite|
 
 document_symbol({opts})                        *vim.lsp.buf.document_symbol()*
     Lists all symbols in the current buffer in the |location-list|.
@@ -2580,24 +2563,6 @@ apply_workspace_edit({workspace_edit}, {position_encoding})
 
     See also: ~
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_applyEdit
-
-buf_clear_references({bufnr})            *vim.lsp.util.buf_clear_references()*
-    Removes document highlights from a buffer.
-
-    Parameters: ~
-      • {bufnr}  (`integer?`) Buffer id
-
-                                     *vim.lsp.util.buf_highlight_references()*
-buf_highlight_references({bufnr}, {references}, {position_encoding})
-    Shows a list of document highlights for a certain buffer.
-
-    Parameters: ~
-      • {bufnr}              (`integer`) Buffer id
-      • {references}         (`lsp.DocumentHighlight[]`) objects to highlight
-      • {position_encoding}  (`'utf-8'|'utf-16'|'utf-32'`)
-
-    See also: ~
-      • https://microsoft.github.io/language-server-protocol/specification/#textDocumentContentChangeEvent
 
                                              *vim.lsp.util.character_offset()*
 character_offset({buf}, {row}, {col}, {offset_encoding})

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3986,18 +3986,27 @@ comparisons and conversions between various types of positions.
     as format conversions.
 
     Fields: ~
-      • {row}     (`integer`) 0-based byte index.
-      • {col}     (`integer`) 0-based byte index.
-      • {buf}?    (`integer`) Optional buffer handle.
+      • {row}        (`integer`) 0-based byte index.
+      • {col}        (`integer`) 0-based byte index.
+      • {buf}?       (`integer`) Optional buffer handle.
 
-                  When specified, it indicates that this position belongs to a
-                  specific buffer. This field is required when performing
-                  position conversions.
-      • {to_lsp}  (`fun(pos: vim.Pos, position_encoding: lsp.PositionEncodingKind)`)
-                  See |Pos:to_lsp()|.
-      • {lsp}     (`fun(buf: integer, pos: lsp.Position, position_encoding: lsp.PositionEncodingKind)`)
-                  See |Pos:lsp()|.
+                     When specified, it indicates that this position belongs
+                     to a specific buffer. This field is required when
+                     performing position conversions.
+      • {to_lsp}     (`fun(pos: vim.Pos, position_encoding: lsp.PositionEncodingKind)`)
+                     See |Pos:to_lsp()|.
+      • {lsp}        (`fun(buf: integer, pos: lsp.Position, position_encoding: lsp.PositionEncodingKind)`)
+                     See |Pos:lsp()|.
+      • {to_cursor}  (`fun(pos: vim.Pos): [integer, integer]`) See
+                     |Pos:to_cursor()|.
+      • {cursor}     (`fun(pos: [integer, integer])`) See |Pos:cursor()|.
 
+
+Pos:cursor({pos})                                               *Pos:cursor()*
+    Creates a new |vim.Pos| from cursor position.
+
+    Parameters: ~
+      • {pos}  (`[integer, integer]`)
 
 Pos:lsp({buf}, {pos}, {position_encoding})                         *Pos:lsp()*
     Creates a new |vim.Pos| from `lsp.Position`.
@@ -4017,6 +4026,15 @@ Pos:lsp({buf}, {pos}, {position_encoding})                         *Pos:lsp()*
       • {buf}                (`integer`)
       • {pos}                (`lsp.Position`)
       • {position_encoding}  (`lsp.PositionEncodingKind`)
+
+Pos:to_cursor({pos})                                         *Pos:to_cursor()*
+    Converts |vim.Pos| to cursor position.
+
+    Parameters: ~
+      • {pos}  (`vim.Pos`) See |vim.Pos|.
+
+    Return: ~
+        (`[integer, integer]`)
 
 Pos:to_lsp({pos}, {position_encoding})                          *Pos:to_lsp()*
     Converts |vim.Pos| to `lsp.Position`.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -228,6 +228,9 @@ LSP
 • Support for related documents in pull diagnostics:
   https://microsoft.github.io/language-server-protocol/specifications/specification-current/#relatedFullDocumentDiagnosticReport
 • |vim.lsp.buf.signature_help()| supports "noActiveParameterSupport".
+• Re-implemented support for `textDocument/documentHighlight
+  |lsp-document_highlight|
+  https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_documentHighlight
 
 LUA
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -14,6 +14,7 @@ local lsp = vim._defer_require('vim.lsp', {
   completion = ..., --- @module 'vim.lsp.completion'
   diagnostic = ..., --- @module 'vim.lsp.diagnostic'
   document_color = ..., --- @module 'vim.lsp.document_color'
+  document_highlight = ..., --- @module 'vim.lsp.document_highlight'
   handlers = ..., --- @module 'vim.lsp.handlers'
   inlay_hint = ..., --- @module 'vim.lsp.inlay_hint'
   linked_editing_range = ..., --- @module 'vim.lsp.linked_editing_range'

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -1081,7 +1081,11 @@ end
 
 --- @deprecated
 function M.clear_references()
-  vim.deprecate('vim.lsp.buf.clear_references(false)', 'vim.lsp.document_highlight.enable()', '0.12')
+  vim.deprecate(
+    'vim.lsp.buf.clear_references(false)',
+    'vim.lsp.document_highlight.enable()',
+    '0.12'
+  )
 end
 
 ---@nodoc

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -1074,13 +1074,14 @@ end
 ---         |hl-LspReferenceText|
 ---         |hl-LspReferenceRead|
 ---         |hl-LspReferenceWrite|
+--- @deprecated
 function M.document_highlight()
-  lsp.buf_request(0, ms.textDocument_documentHighlight, client_positional_params())
+  vim.deprecate('vim.lsp.buf.document_highlight()', 'vim.lsp.document_highlight.enable()', '0.12')
 end
 
---- Removes document highlights from current buffer.
+--- @deprecated
 function M.clear_references()
-  util.buf_clear_references()
+  vim.deprecate('vim.lsp.buf.clear_references(false)', 'vim.lsp.document_highlight.enable()', '0.12')
 end
 
 ---@nodoc

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -1095,6 +1095,9 @@ function Client:on_attach(bufnr)
     if vim.tbl_get(self.server_capabilities, 'foldingRangeProvider') then
       lsp._folding_range._setup(bufnr)
     end
+    if vim.tbl_get(self.server_capabilities, 'documentHighlightProvider') then
+      lsp.document_highlight._start(bufnr, self.id)
+    end
   end)
 
   self.attached_buffers[bufnr] = true

--- a/runtime/lua/vim/lsp/document_highlight.lua
+++ b/runtime/lua/vim/lsp/document_highlight.lua
@@ -1,0 +1,434 @@
+---@brief This module provides LSP support for highlighting patterns in a document,
+--- utility functions for interaction are also provided.
+--- Highlighting is disabled by default.
+
+local bit = require('bit')
+local util = require('vim.lsp.util')
+local log = require('vim.lsp.log')
+local protocol = require('vim.lsp.protocol')
+local ms = require('vim.lsp.protocol').Methods
+local Range = require('vim.treesitter._range')
+local api = vim.api
+
+local Capability = require('vim.lsp._capability')
+
+local M = {}
+
+---@class (private) vim.lsp.document_highlight.Highlight
+---@field kind lsp.DocumentHighlightKind
+---@field range Range4
+
+---@class (private) vim.lsp.document_highlight.ClientState
+---@field namespace integer
+---@field highlights vim.lsp.document_highlight.Highlight[]
+---@field version integer
+
+---@class (private) vim.lsp.document_highlight.State : vim.lsp.Capability
+---@field active table<integer, vim.lsp.document_highlight.State?>
+---@field client_state table<integer, vim.lsp.document_highlight.ClientState?>
+---@field timer uv.uv_timer_t
+---@field version integer
+local State = { name = 'document_highlight', active = {} }
+State.__index = State
+setmetatable(State, Capability)
+
+--- Do a binary search of the highlights in the half-open range [lo, hi).
+---
+--- Return the index i in range such that
+--- highlights[j].range.end < (row, col) for all j < i, and
+--- highlights[j].range.end >= (row, col) for all j >= i,
+--- or return hi if no such index is found.
+---@param highlights vim.lsp.document_highlight.Highlight
+---@param row integer
+---@param col integer
+---@param lo integer
+---@param hi integer
+local function lower_bound(highlights, row, col, lo, hi)
+  while lo < hi do
+    local mid = bit.rshift(lo + hi, 1) -- Equivalent to floor((lo + hi) / 2).
+    if Range.cmp_pos.lt(highlights[mid].range[3], highlights[mid].range[4], row, col) then
+      lo = mid + 1
+    else
+      hi = mid
+    end
+  end
+  return lo
+end
+
+--- Do a binary search of the highlights in the half-open range [lo, hi).
+---
+--- Return the index i in range such that
+--- highlights[j].range.start <= (row, col) for all j < i, and
+--- highlights[j].range.start > (row, col) for all j >= i,
+--- or return hi if no such index is found.
+---@param highlights vim.lsp.document_highlight.Highlight
+---@param row integer
+---@param col integer
+---@param lo integer
+---@param hi integer
+local function upper_bound(highlights, row, col, lo, hi)
+  while lo < hi do
+    local mid = bit.rshift(lo + hi, 1) -- Equivalent to floor((lo + hi) / 2).
+    if Range.cmp_pos.lt(row, col, highlights[mid].range[1], highlights[mid].range[2]) then
+      hi = mid
+    else
+      lo = mid + 1
+    end
+  end
+  return lo
+end
+
+--- Return 0-based cursor position
+---
+---@param winid? integer
+local function cursor_pos(winid)
+  local line, col = unpack(api.nvim_win_get_cursor(winid or api.nvim_get_current_win()))
+  return line - 1, col
+end
+
+---@package
+---@param bufnr integer
+---@return vim.lsp.document_highlight.State
+function State:new(bufnr)
+  self = Capability.new(self, bufnr)
+  self.version = 0
+
+  api.nvim_buf_attach(bufnr, false, {
+    on_lines = function()
+      local state = State.active[bufnr]
+      if not state then
+        return true
+      end
+      if M.is_enabled({ bufnr = bufnr }) then
+        state:update()
+      end
+    end,
+  })
+  api.nvim_create_autocmd('CursorMoved', {
+    group = self.augroup,
+    buffer = bufnr,
+    callback = function()
+      if M.is_enabled({ bufnr = bufnr }) then
+        self:on_cursor_moved()
+      end
+    end,
+  })
+
+  return self
+end
+
+---@package
+---@param client_id integer
+function State:on_attach(client_id)
+  local state = self.client_state[client_id]
+  if not state then
+    self.client_state[client_id] = {
+      namespace = api.nvim_create_namespace('nvim.lsp.document_highlight:' .. client_id),
+      highlights = {},
+      version = 0,
+    }
+  end
+end
+
+---@package
+---@param client_id integer
+function State:on_detach(client_id)
+  local state = self.client_state[client_id]
+  if state then
+    self.client_state[client_id] = nil
+    api.nvim_buf_clear_namespace(self.bufnr, state.namespace, 0, -1)
+    api.nvim__redraw({ buf = self.bufnr, valid = true, flush = false })
+  end
+end
+
+---@package
+function State:on_cursor_moved()
+  local row, col = cursor_pos(api.nvim_get_current_win())
+  --- Clear and re-request document highlights
+  --- only when the cursor moves outside the current highlight range.
+  --- This avoids the illusion of lag and reduces unnecessary resource usage.
+  local update = false
+  for _, state in pairs(self.client_state) do
+    local highlights = state.highlights
+    local i = lower_bound(state.highlights, row, col, 1, #highlights)
+    local range = highlights[i] and highlights[i].range
+
+    if not range or not Range.contains(range, { row, col, row, col }) then
+      api.nvim_buf_clear_namespace(self.bufnr, state.namespace, 0, -1)
+      update = true
+    end
+  end
+  if update then
+    self:update()
+  end
+end
+
+---@package
+function State:reset()
+  self.version = 0
+  for _, state in pairs(self.client_state) do
+    api.nvim_buf_clear_namespace(self.bufnr, state.namespace, 0, -1)
+    state.highlights = {}
+    state.version = 0
+  end
+end
+
+---@package
+function State:update()
+  self.version = bit.band(self.version + 1, 0xffffffff)
+  self:reset_timer()
+  self.timer = vim.defer_fn(function()
+    self:request()
+    -- In most environments,
+    -- holding down a key triggers repeated input every 30–40ms,
+    -- so a debounce value of 50ms is sufficient.
+  end, 50)
+end
+
+---@private
+function State:reset_timer()
+  local timer = self.timer
+  if timer then
+    self.timer = nil
+    if not timer:is_closing() then
+      timer:stop()
+      timer:close()
+    end
+  end
+end
+
+---Store highlights for a specific buffer and client
+---@package
+---@param result? lsp.DocumentHighlight[]
+---@param ctx lsp.HandlerContext
+function State:handler(err, result, ctx)
+  if err then
+    log.error('document highlight', err)
+  end
+
+  local state = self.client_state[ctx.client_id]
+  if not state then
+    return
+  end
+
+  local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
+  ---@type vim.lsp.document_highlight.Highlight[]
+  local highlights = {}
+  for _, raw in ipairs(result or {}) do
+    highlights[#highlights + 1] = {
+      kind = raw.kind,
+      range = {
+        raw.range['start'].line,
+        util._get_line_byte_from_position(self.bufnr, raw.range['start'], client.offset_encoding),
+        raw.range['end'].line,
+        util._get_line_byte_from_position(self.bufnr, raw.range['end'], client.offset_encoding),
+      },
+    }
+  end
+  table.sort(highlights, function(a, b)
+    return Range.cmp_pos.lt(a.range[3], a.range[4], b.range[1], b.range[2])
+  end)
+
+  state.highlights = highlights
+  state.version = self.version
+
+  api.nvim__redraw({ buf = self.bufnr, valid = true })
+end
+
+---@package
+---@param client_id? integer
+function State:request(client_id)
+  local method = ms.textDocument_documentHighlight
+
+  for id in pairs(client_id and { client_id } or self.client_state) do
+    local client = assert(vim.lsp.get_client_by_id(id))
+    local params = util.make_position_params(0, client.offset_encoding)
+
+    util._cancel_requests({
+      bufnr = self.bufnr,
+      clients = { client },
+      method = method,
+      type = 'pending',
+    })
+
+    client:request(method, params, function(...)
+      self:handler(...)
+    end, self.bufnr)
+  end
+end
+
+---@param kind lsp.DocumentHighlightKind
+---@return string
+local function kind_hl(kind)
+  if kind == protocol.DocumentHighlightKind.Read then
+    return 'LspReferenceRead'
+  elseif kind == protocol.DocumentHighlightKind.Write then
+    return 'LspReferenceWrite'
+  else -- kind == 1 also the default
+    return 'LspReferenceText'
+  end
+end
+
+---@package
+---@param toprow integer
+---@param botrow integer
+function State:on_win(toprow, botrow)
+  for _, state in pairs(self.client_state) do
+    -- Buffer changes may invalidate the original highlight ranges,
+    -- never set outdated highlights as extmarks.
+    if state.version == self.version then
+      api.nvim_buf_clear_namespace(self.bufnr, state.namespace, 0, -1)
+
+      -- Only set extmarks for visible lines
+      local highlights = state.highlights
+      local first = lower_bound(highlights, toprow, 0, 1, #highlights + 1)
+      local last = upper_bound(highlights, botrow, math.huge, first, #highlights + 1) - 1
+
+      for i = first, last do
+        local row, col, end_row, end_col = Range.unpack4(highlights[i].range)
+
+        api.nvim_buf_set_extmark(self.bufnr, state.namespace, row, col, {
+          end_row = end_row,
+          end_col = end_col,
+          hl_group = kind_hl(highlights[i].kind),
+          -- Although we want to avoid
+          -- showing outdated document highlights when the cursor moves,
+          -- updating highlights after a document change
+          -- requires waiting for the server's response.
+          -- This delay can cause flickering, so we don't use ephemeral extmarks here.
+          ephemeral = false,
+        })
+      end
+    end
+  end
+end
+
+local namespace = api.nvim_create_namespace('nvim.lsp.document_highlight')
+api.nvim_set_decoration_provider(namespace, {
+  on_win = function(_, _, bufnr, toprow, botrow)
+    local state = State.active[bufnr]
+    if state then
+      state:on_win(toprow, botrow)
+    end
+  end,
+})
+
+function M._start(bufnr, client_id)
+  local state = State.active[bufnr]
+
+  if not state then
+    state = State:new(bufnr)
+  end
+
+  state:on_attach(client_id)
+  if M.is_enabled({ bufnr = bufnr }) then
+    state:update()
+  end
+end
+
+--- Enables or disables document highlights for the {filter}ed scope.
+---
+--- To "toggle", pass the inverse of `is_enabled()`:
+---
+--- ```lua
+--- vim.lsp.document_highlight.enable(not vim.lsp.document_highlight.is_enabled())
+--- ```
+---
+--- Note: Usage of |vim.lsp.document_highlight.enable()| requires
+--- the following highlight groups to be defined
+--- or you won't be able to see the actual highlights.
+---   |hl-LspReferenceText|
+---   |hl-LspReferenceRead|
+---   |hl-LspReferenceWrite|
+---@param enable? boolean
+---@param filter? vim.lsp.enable.Filter
+function M.enable(enable, filter)
+  util._enable('document_highlight', enable, filter)
+
+  for _, bufnr in ipairs(api.nvim_list_bufs()) do
+    local state = State.active[bufnr]
+    if state then
+      if M.is_enabled({ bufnr = bufnr }) then
+        state:request()
+      else
+        state:reset()
+      end
+    end
+  end
+end
+
+--- Query whether document highlight is enabled in the {filter}ed scope
+---@param filter? vim.lsp.enable.Filter
+function M.is_enabled(filter)
+  return util._is_enabled('document_highlight', filter)
+end
+
+---@class vim.lsp.document_highlight.jump.Opts
+---@inlinedoc
+---
+--- The number of highlights to move by.
+--- A positive integer moves forward by {count} highlights,
+--- while a negative integer moves backward by {count} highlights.
+---
+--- (default: |v:count1|)
+---@field count integer
+---
+--- Window ID, or 0 for the current window
+--- (default: `0`)
+---@field winid? integer
+
+--- Jump to a document highlight.
+---
+---@param opts? vim.lsp.document_highlight.jump.Opts
+function M.jump(opts)
+  vim.validate('opts', opts, 'table', true)
+  opts = opts or {}
+
+  vim.validate('count', opts.count, 'number', true)
+  vim.validate('count', opts.winid, 'number', true)
+  local count = opts.count or vim.v.count1
+  local winid = opts.winid or api.nvim_get_current_win()
+
+  local bufnr = api.nvim_win_get_buf(winid)
+  local state = State.active[bufnr]
+  if not state then
+    return
+  end
+
+  local cursor_row, cursor_col = cursor_pos(winid)
+  local row, col ---@type integer?, integer?
+  for _, client_state in pairs(state.client_state) do
+    local highlights = client_state.highlights
+    local i = lower_bound(highlights, cursor_row, cursor_col, 1, #highlights + 1) + count
+    i = math.min(math.max(1, i), #highlights)
+    local range = highlights[i] and highlights[i].range
+
+    -- For multiple clients support,
+    -- Select the (row, col) closest to (cursor_row, cursor_col).
+    if range then
+      if count < 0 and Range.cmp_pos.lt(range[1], range[2], cursor_row, cursor_col) then
+        if not (row and col) or Range.cmp_pos.lt(row, col, range[1], range[2]) then
+          row, col = range[1], range[2]
+        end
+      elseif count > 0 and Range.cmp_pos.lt(cursor_row, cursor_col, range[1], range[2]) then
+        if not (row and col) or Range.cmp_pos.lt(range[1], range[2], row, col) then
+          row, col = range[1], range[2]
+        end
+      end
+    end
+  end
+
+  vim._with({ win = winid }, function()
+    -- Save position in the window's jumplist
+    vim.cmd("normal! m'")
+    vim.api.nvim_win_set_cursor(winid, { (row or cursor_row) + 1, col or cursor_col })
+    -- Open folds under the cursor
+    vim.cmd('normal! zv')
+  end)
+end
+
+M.__DocumentHighlighter = State
+
+util._enable('document_highlight', false)
+
+return M

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -483,12 +483,6 @@ end
 --- @diagnostic disable-next-line:deprecated
 RCS[ms.textDocument_signatureHelp] = M.signature_help
 
---- @deprecated remove in 0.13
---- @see # https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentHighlight
-RCS[ms.textDocument_documentHighlight] = function(...)
-  vim.lsp.document_highlight.on_document_highlight(...)
-end
-
 --- Displays call hierarchy in the quickfix window.
 ---
 --- @param direction 'from'|'to' `"from"` for incoming calls and `"to"` for outgoing calls

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -485,16 +485,8 @@ RCS[ms.textDocument_signatureHelp] = M.signature_help
 
 --- @deprecated remove in 0.13
 --- @see # https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_documentHighlight
-RCS[ms.textDocument_documentHighlight] = function(_, result, ctx)
-  if not result then
-    return
-  end
-  local client_id = ctx.client_id
-  local client = vim.lsp.get_client_by_id(client_id)
-  if not client then
-    return
-  end
-  util.buf_highlight_references(ctx.bufnr, result, client.offset_encoding)
+RCS[ms.textDocument_documentHighlight] = function(...)
+  vim.lsp.document_highlight.on_document_highlight(...)
 end
 
 --- Displays call hierarchy in the quickfix window.

--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -34,6 +34,7 @@ local function check_active_features()
   local features = {
     require('vim.lsp.semantic_tokens').__STHighlighter,
     require('vim.lsp._folding_range').__FoldEvaluator,
+    require('vim.lsp.document_highlight').__DocumentHighlighter,
   }
   for _, feature in ipairs(features) do
     ---@type string[]

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -2366,7 +2366,7 @@ function M._is_enabled(feature, filter)
     and vim.F.if_nil(bufnr and vim.b[bufnr][var], vim.g[var])
 end
 
----@param feature 'semantic_tokens'
+---@param feature 'semantic_tokens' | 'document_highlight'
 ---@param enable? boolean
 ---@param filter? vim.lsp.enable.Filter
 function M._enable(feature, enable, filter)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1789,18 +1789,22 @@ do --[[ References ]]
 
   --- Removes document highlights from a buffer.
   ---
+  ---@deprecated
   ---@param bufnr integer? Buffer id
   function M.buf_clear_references(bufnr)
+    vim.deprecate('vim.lsp.util.buf_clear_references()', 'nil', '0.12')
     api.nvim_buf_clear_namespace(bufnr or 0, reference_ns, 0, -1)
   end
 
   --- Shows a list of document highlights for a certain buffer.
   ---
+  ---@deprecated
   ---@param bufnr integer Buffer id
   ---@param references lsp.DocumentHighlight[] objects to highlight
   ---@param position_encoding 'utf-8'|'utf-16'|'utf-32'
   ---@see https://microsoft.github.io/language-server-protocol/specification/#textDocumentContentChangeEvent
   function M.buf_highlight_references(bufnr, references, position_encoding)
+    vim.deprecate('vim.lsp.util.buf_highlight_references()', 'nil', '0.12')
     validate('bufnr', bufnr, 'number', true)
     validate('position_encoding', position_encoding, 'string', false)
     for _, reference in ipairs(references) do

--- a/runtime/lua/vim/pos.lua
+++ b/runtime/lua/vim/pos.lua
@@ -56,7 +56,7 @@ Pos.__index = Pos
 ---@package
 ---@param row integer
 ---@param col integer
----@param opts vim.Pos.Optional
+---@param opts? vim.Pos.Optional
 function Pos.new(row, col, opts)
   validate('row', row, 'number')
   validate('col', col, 'number')

--- a/runtime/lua/vim/pos.lua
+++ b/runtime/lua/vim/pos.lua
@@ -178,6 +178,19 @@ function Pos.lsp(buf, pos, position_encoding)
   return Pos.new(row, col, { buf = buf })
 end
 
+--- Converts |vim.Pos| to cursor position.
+---@param pos vim.Pos
+---@return [integer, integer]
+function Pos.to_cursor(pos)
+  return { pos.row + 1, pos.col }
+end
+
+--- Creates a new |vim.Pos| from cursor position.
+---@param pos [integer, integer]
+function Pos.cursor(pos)
+  return Pos.new(pos[1] - 1, pos[2])
+end
+
 -- Overload `Range.new` to allow calling this module as a function.
 setmetatable(Pos, {
   __call = function(_, ...)

--- a/src/gen/gen_vimdoc.lua
+++ b/src/gen/gen_vimdoc.lua
@@ -280,6 +280,7 @@ local config = {
       'completion.lua',
       'diagnostic.lua',
       'document_color.lua',
+      'document_highlight.lua',
       'folding_range.lua',
       'handlers.lua',
       'inlay_hint.lua',

--- a/test/functional/plugin/lsp/document_highlight_spec.lua
+++ b/test/functional/plugin/lsp/document_highlight_spec.lua
@@ -1,0 +1,185 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+local t_lsp = require('test.functional.plugin.lsp.testutil')
+local Screen = require('test.functional.ui.screen')
+
+local dedent = t.dedent
+
+local api = n.api
+local exec_lua = n.exec_lua
+local insert = n.insert
+local command = n.command
+
+local clear_notrace = t_lsp.clear_notrace
+local create_server_definition = t_lsp.create_server_definition
+
+describe('vim.lsp.document_highlight', function()
+  local text = dedent([[
+    global = _G
+
+    local variable = global
+
+    if variable == global then
+
+    end
+  ]])
+
+  local grid_without_highlights = dedent([[
+    ^global = _G                                          |
+                                                         |
+    local variable = global                              |
+                                                         |
+    if variable == global then                           |
+                                                         |
+    end                                                  |
+                                                         |
+    {2:~                                                    }|*5
+                                                         |
+  ]])
+
+  local grid_with_highlights = dedent([[
+    {1:^global} = _G                                          |
+                                                         |
+    local variable = {1:global}                              |
+                                                         |
+    if variable == {1:global} then                           |
+                                                         |
+    end                                                  |
+                                                         |
+    {2:~                                                    }|*5
+                                                         |
+  ]])
+
+  --- @type test.functional.ui.screen
+  local screen
+
+  --- @type integer
+  local client_id
+
+  before_each(function()
+    clear_notrace()
+    exec_lua(create_server_definition)
+
+    screen = Screen.new()
+    screen:set_default_attr_ids({
+      [1] = { foreground = Screen.colors.Grey0, background = Screen.colors.LightGrey },
+      [2] = { bold = true, foreground = Screen.colors.Blue1 },
+    })
+
+    client_id = exec_lua(function()
+      _G.server = _G._create_server({
+        capabilities = {
+          documentHighlightProvider = true,
+        },
+        handlers = {
+          ['textDocument/documentHighlight'] = function(_, _, callback)
+            callback(nil, {
+              {
+                kind = 3,
+                range = {
+                  ['end'] = {
+                    character = 6,
+                    line = 0,
+                  },
+                  start = {
+                    character = 0,
+                    line = 0,
+                  },
+                },
+              },
+              {
+                kind = 2,
+                range = {
+                  ['end'] = {
+                    character = 23,
+                    line = 2,
+                  },
+                  start = {
+                    character = 17,
+                    line = 2,
+                  },
+                },
+              },
+              {
+                kind = 2,
+                range = {
+                  ['end'] = {
+                    character = 21,
+                    line = 4,
+                  },
+                  start = {
+                    character = 15,
+                    line = 4,
+                  },
+                },
+              },
+            })
+          end,
+        },
+      })
+
+      return vim.lsp.start({ name = 'dummy', cmd = _G.server.cmd })
+    end)
+
+    insert(text)
+    command('1')
+    exec_lua(function()
+      vim.lsp.document_highlight.enable(true)
+    end)
+
+    screen:expect({ grid = grid_with_highlights })
+  end)
+
+  after_each(function()
+    api.nvim_exec_autocmds('VimLeavePre', { modeline = false })
+  end)
+
+  describe('enable()', function()
+    it('clears document highlights when sole client detaches', function()
+      exec_lua(function()
+        vim.lsp.stop_client(client_id)
+      end)
+
+      screen:expect({ grid = grid_without_highlights })
+    end)
+  end)
+
+  describe('jump()', function()
+    it('jumpts to the last highlight', function()
+      exec_lua(function()
+        vim.lsp.document_highlight.jump({ count = 999 })
+      end)
+      screen:expect([[
+        {1:global} = _G                                          |
+                                                             |
+        local variable = {1:global}                              |
+                                                             |
+        if variable == {1:^global} then                           |
+                                                             |
+        end                                                  |
+                                                             |
+        {2:~                                                    }|*5
+                                                             |
+      ]])
+    end)
+
+    it('jumpts to the first highlight', function()
+      exec_lua(function()
+        vim.lsp.document_highlight.jump({ count = 999 })
+        vim.lsp.document_highlight.jump({ count = -9 })
+      end)
+      screen:expect([[
+        {1:^global} = _G                                          |
+                                                             |
+        local variable = {1:global}                              |
+                                                             |
+        if variable == {1:global} then                           |
+                                                             |
+        end                                                  |
+                                                             |
+        {2:~                                                    }|*5
+                                                             |
+      ]])
+    end)
+  end)
+end)


### PR DESCRIPTION
## Problems
`vim.lsp.buf.document_highlight` was implemented quite a long time ago. Its API style differs from our latest APIs, such as `vim.lsp.inlay_hint`. I believe it's time to give it an overhaul.

## Solution
* Reimplement `textDocument/documentHighlight` as a standalone module, offering an API similar to `vim.lsp.document_highlight.enable()`.
* Additionally, `vim.lsp.document_highlight.jump()` for jumping between highlights.

[document_highlight.webm](https://github.com/user-attachments/assets/67755d5b-5084-4171-96e3-9fa2bc9dce5e)

