### PR TITLE
feat(highlight): make `PmenuMatch` and `PmenuMatchSel` bold

### DIFF
--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -144,6 +144,8 @@ static const char e_missing_argument_str[]
 static const char *highlight_init_both[] = {
   "Cursor            guifg=bg      guibg=fg",
   "CursorLineNr      gui=bold      cterm=bold",
+  "PmenuMatch        gui=bold      cterm=bold",
+  "PmenuMatchSel     gui=bold      cterm=bold",
   "PmenuSel          gui=reverse   cterm=reverse,underline blend=0",
   "RedrawDebugNormal gui=reverse   cterm=reverse",
   "TabLineSel        gui=bold      cterm=bold",
@@ -170,8 +172,6 @@ static const char *highlight_init_both[] = {
   "default link PmenuExtraSel    PmenuSel",
   "default link PmenuKind        Pmenu",
   "default link PmenuKindSel     PmenuSel",
-  "default link PmenuMatch       Pmenu",
-  "default link PmenuMatchSel    PmenuSel",
   "default link PmenuSbar        Pmenu",
   "default link Substitute       Search",
   "default link StatusLineTerm   StatusLine",


### PR DESCRIPTION
Problem: both `PmenuMatch` and `PmenuMatchSel` can provide helpful
  information about characters which actually match query in completion
  candidates. This is not as useful with default regular match, but much
  more useful with 'completopt+=fuzzy'.

Solution: make both highlight groups bold. This will also affect
  (i.e. benefit) other color schemes which do not define groups
  separately.
  This is possible since the recently merged changes to `PmenuMatch` and
  `PmenuMatchSel` combine attributes with underlying "base" groups.
  See PR 29980.