### PR TITLE
vim-patch:f10db25: runtime(swayconfig): add flag for bindsym/bindcode to syntax script

### DIFF
--- a/runtime/compiler/cppcheck.vim
+++ b/runtime/compiler/cppcheck.vim
@@ -1,7 +1,7 @@
 " vim compiler file
 " Compiler:	cppcheck (C++ static checker)
 " Maintainer:   Vincent B. (twinside@free.fr)
-" Last Change:  2024 Oct 4 by @Konfekt
+" Last Change:  2024 oct 17 by @Konfekt
 
 if exists("cppcheck")
   finish
@@ -10,6 +10,8 @@ let current_compiler = "cppcheck"
 
 let s:cpo_save = &cpo
 set cpo-=C
+
+let s:slash = has('win32')? '\' : '/'
 
 if !exists('g:c_cppcheck_params')
   let g:c_cppcheck_params = '--verbose --force --inline-suppr'
@@ -20,11 +22,11 @@ endif
 
 let &l:makeprg = 'cppcheck --quiet'
       \ ..' --template="{file}:{line}:{column}: {severity}: [{id}] {message} {callstack}"'
-      \ ..' '..get(b:, 'c_cppcheck_params',
-      \            g:c_cppcheck_params..' '..(&filetype ==# 'cpp' ? ' --language=c++' : ''))
+      \ ..' '..get(b:, 'c_cppcheck_params', get(g:, 'c_cppcheck_params', (&filetype ==# 'cpp' ? ' --language=c++' : '')))
       \ ..' '..get(b:, 'c_cppcheck_includes', get(g:, 'c_cppcheck_includes',
       \	          (filereadable('compile_commands.json') ? '--project=compile_commands.json' :
-      \	          (empty(&path) ? '' : '-I')..join(map(filter(split(&path, ','), 'isdirectory(v:val)'),'shellescape(v:val)'), ' -I'))))
+      \           (!empty(glob('*'..s:slash..'compile_commands.json', 1, 1)) ? '--project='..glob('*'..s:slash..'compile_commands.json', 1, 1)[0] :
+      \	          (empty(&path) ? '' : '-I')..join(map(filter(split(&path, ','), 'isdirectory(v:val)'),'shellescape(v:val)'), ' -I')))))
 silent CompilerSet makeprg
 
 CompilerSet errorformat=

--- a/runtime/syntax/swayconfig.vim
+++ b/runtime/syntax/swayconfig.vim
@@ -3,7 +3,7 @@
 " Original Author: Josef Litos (JosefLitos/i3config.vim)
 " Maintainer: James Eapen <james.eapen@vai.org>
 " Version: 1.2.4
-" Last Change: 2024-05-24
+" Last Change: 2024 Oct 17
 
 " References:
 " http://i3wm.org/docs/userguide.html#configuring
@@ -29,7 +29,7 @@ syn keyword i3ConfigConditionProp app_id pid shell contained
 
 syn keyword i3ConfigWorkspaceDir prev_on_output next_on_output contained
 
-syn match i3ConfigBindArgument /--\(locked\|to-code\|no-repeat\|input-device=[^ '"]*\|no-warn\) / contained contains=i3ConfigShOper,@i3ConfigStrVar nextgroup=i3ConfigBindArgument,i3ConfigBindCombo
+syn match i3ConfigBindArgument /--\(locked\|to-code\|no-repeat\|input-device=[^ '"]*\|no-warn\|inhibited\) / contained contains=i3ConfigShOper,@i3ConfigStrVar nextgroup=i3ConfigBindArgument,i3ConfigBindCombo
 syn region i3ConfigBindArgument start=/--input-device=['"]/ end=/\s/ contained contains=@i3ConfigIdent,i3ConfigShOper,i3ConfigString nextgroup=i3ConfigBindArgument,i3ConfigBindCombo
 
 syn region i3ConfigBindCombo matchgroup=i3ConfigParen start=/{$/ end=/^\s*}$/ contained contains=i3ConfigBindArgument,i3ConfigBindCombo,i3ConfigComment fold keepend extend


### PR DESCRIPTION
Add the `--inhibited` flag for the bindsym/bindcode commands.

closes: vim/vim#15891

https://github.com/vim/vim/commit/f10db2536755736807908ffd8e423614939f7421

Co-authored-by: CismonX <admin@cismon.net>
