### PR TITLE
fixup(checkhealth): deprecated pypi url

### DIFF
--- a/runtime/doc/faq.txt
+++ b/runtime/doc/faq.txt
@@ -189,7 +189,7 @@ Other hints:
 
 - The python `neovim` module was renamed to `pynvim` (long ago).
 - If you're using pyenv or virtualenv for the `pynvim` module
-    https://pypi.python.org/pypi/pynvim/, you must set `g:python3_host_prog` to
+    https://pypi.org/project/pynvim/, you must set `g:python3_host_prog` to
     the virtualenv's interpreter path.
 - Read |provider-python|.
 - Be sure you have the latest version of the `pynvim` Python module: >bash

--- a/runtime/lua/vim/provider/health.lua
+++ b/runtime/lua/vim/provider/health.lua
@@ -449,7 +449,7 @@ end
 --- Get the latest Nvim Python client (pynvim) version from PyPI.
 local function latest_pypi_version()
   local pypi_version = 'unable to get pypi response'
-  local pypi_response = download('https://pypi.python.org/pypi/pynvim/json')
+  local pypi_response = download('https://pypi.org/pypi/pynvim/json')
   if pypi_response ~= '' then
     local pcall_ok, output = pcall(vim.fn.json_decode, pypi_response)
     if not pcall_ok then


### PR DESCRIPTION
Problem:  `pypi.python.org` is deprecated since 2016: [https://packaging.python.org/en/latest/guides/migrating-to-pypi-org/](https://packaging.python.org/en/latest/guides/migrating-to-pypi-org/)

Solution: use `pypi.org`