### PR TITLE
feat(terminal)!: make 'belloff' and 'visualbell' apply to terminal bell

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -63,6 +63,8 @@ EDITOR
 • Moving in the buffer list using |:bnext| and similar commands behaves as
   documented and skips help buffers if run from a non-help buffer, otherwise
   it moves to another help buffer.
+• Bells from a |terminal| buffer are now silent by default, unless 'belloff'
+  option doesn't contain "term" or "all".
 
 EVENTS
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1015,6 +1015,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	separated list of items. For each item that is present, the bell
 	will be silenced. This is most useful to specify specific events in
 	insert mode to be silenced.
+	You can also make it flash by using 'visualbell'.
 
 	item	    meaning when present	~
 	all	    All events.
@@ -1038,6 +1039,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	register    Unknown register after <C-R> in |Insert-mode|.
 	shell	    Bell from shell output |:!|.
 	spell	    Error happened on spell suggest.
+	term	    Bell from |:terminal| output.
 	wildmode    More matches in |cmdline-completion| available
 		    (depends on the 'wildmode' setting).
 

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -430,6 +430,7 @@ vim.go.bsk = vim.go.backupskip
 --- separated list of items. For each item that is present, the bell
 --- will be silenced. This is most useful to specify specific events in
 --- insert mode to be silenced.
+--- You can also make it flash by using 'visualbell'.
 ---
 --- item	    meaning when present	~
 --- all	    All events.
@@ -453,6 +454,7 @@ vim.go.bsk = vim.go.backupskip
 --- register    Unknown register after <C-R> in `Insert-mode`.
 --- shell	    Bell from shell output `:!`.
 --- spell	    Error happened on spell suggest.
+--- term	    Bell from `:terminal` output.
 --- wildmode    More matches in `cmdline-completion` available
 --- 	    (depends on the 'wildmode' setting).
 ---

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -403,7 +403,8 @@ EXTERN unsigned bo_flags;
 #define BO_REG    0x8000
 #define BO_SH     0x10000
 #define BO_SPELL  0x20000
-#define BO_WILD   0x40000
+#define BO_TERM   0x40000
+#define BO_WILD   0x80000
 
 EXTERN char *p_bsk;             ///< 'backupskip'
 EXTERN char *p_breakat;         ///< 'breakat'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -598,6 +598,7 @@ return {
         separated list of items. For each item that is present, the bell
         will be silenced. This is most useful to specify specific events in
         insert mode to be silenced.
+        You can also make it flash by using 'visualbell'.
 
         item	    meaning when present	~
         all	    All events.
@@ -621,6 +622,7 @@ return {
         register    Unknown register after <C-R> in |Insert-mode|.
         shell	    Bell from shell output |:!|.
         spell	    Error happened on spell suggest.
+        term	    Bell from |:terminal| output.
         wildmode    More matches in |cmdline-completion| available
         	    (depends on the 'wildmode' setting).
 

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -73,7 +73,8 @@ static char *(p_bg_values[]) = { "light", "dark", NULL };
 static char *(p_bkc_values[]) = { "yes", "auto", "no", "breaksymlink", "breakhardlink", NULL };
 static char *(p_bo_values[]) = { "all", "backspace", "cursor", "complete", "copy", "ctrlg", "error",
                                  "esc", "ex", "hangul", "insertmode", "lang", "mess", "showmatch",
-                                 "operator", "register", "shell", "spell", "wildmode", NULL };
+                                 "operator", "register", "shell", "spell", "term", "wildmode",
+                                 NULL };
 // Note: Keep this in sync with briopt_check()
 static char *(p_briopt_values[]) = { "shift:", "min:", "sbr", "list:", "column:", NULL };
 // Note: Keep this in sync with diffopt_changed()

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1178,9 +1178,10 @@ static int term_settermprop(VTermProp prop, VTermValue *val, void *data)
   return 1;
 }
 
+/// Called when the terminal wants to ring the system bell.
 static int term_bell(void *data)
 {
-  ui_call_bell();
+  vim_beep(BO_TERM);
   return 1;
 }
 

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -422,6 +422,44 @@ describe(':terminal buffer', function()
                                                         |*2
     ]])
   end)
+
+  it("handles bell respecting 'belloff' and 'visualbell'", function()
+    local screen = Screen.new(50, 7)
+    screen:attach()
+    local chan = api.nvim_open_term(0, {})
+
+    command('set belloff=')
+    api.nvim_chan_send(chan, '\a')
+    screen:expect(function()
+      eq({ true, false }, { screen.bell, screen.visual_bell })
+    end)
+    screen.bell = false
+
+    command('set visualbell')
+    api.nvim_chan_send(chan, '\a')
+    screen:expect(function()
+      eq({ false, true }, { screen.bell, screen.visual_bell })
+    end)
+    screen.visual_bell = false
+
+    command('set belloff=term')
+    api.nvim_chan_send(chan, '\a')
+    screen:expect({
+      condition = function()
+        eq({ false, false }, { screen.bell, screen.visual_bell })
+      end,
+      unchanged = true,
+    })
+
+    command('set belloff=all')
+    api.nvim_chan_send(chan, '\a')
+    screen:expect({
+      condition = function()
+        eq({ false, false }, { screen.bell, screen.visual_bell })
+      end,
+      unchanged = true,
+    })
+  end)
 end)
 
 describe('on_lines does not emit out-of-bounds line indexes when', function()


### PR DESCRIPTION
vim-patch:8.2.4744: a terminal window can't use the bell
vim-patch:8.2.4745: using wrong flag for using bell in the terminal

BREAKING CHANGE: Bells from :terminal are now silent by default, unless
'belloff' option doesn't contain "term" or "all".
