### PR TITLE
test(rpc): retry flaky 'vim.rpcrequest and vim.rpcnotify' test

### DIFF
--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1319,7 +1319,9 @@ describe('lua stdlib', function()
     ]],
     }
     feed('<cr>')
-    eq({ 3, NIL }, api.nvim_get_var('yy'))
+    retry(10, nil, function()
+      eq({ 3, NIL }, api.nvim_get_var('yy'))
+    end)
 
     exec_lua([[timer:close()]])
   end)


### PR DESCRIPTION
Problem: 'vim.rpcrequest and vim.rpcnotify' is flaky on Windows.

Solution: retry it.
