### PR TITLE
`vim.diagnostic.setqflist` improvements

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -303,6 +303,8 @@ UI
   |hl-PmenuSel| and |hl-PmenuMatch| both inherit from |hl-Pmenu|, and
   |hl-PmenuMatchSel| inherits highlights from both |hl-PmenuSel| and
   |hl-PmenuMatch|.
+• |vim.diagnostic.setqflist()| updates existing diagnostics quickfix list if one
+  exists.
 
 • |ui-messages| content chunks now also contain the highlight group ID.
 


### PR DESCRIPTION
I made 2 changes here:

1. We use the new `'u'` action to update the quickfix list so we don't lose our position in the quickfix list when updating it.
2. Rather than creating a new quickfix list each time, we update the exiting one if we've already created one.