### PR TITLE
vim-patch:9.1.0794: tests: tests may fail on Windows environment

### DIFF
--- a/test/old/testdir/shared.vim
+++ b/test/old/testdir/shared.vim
@@ -64,7 +64,7 @@ func RunCommand(cmd)
     let job = job_start(a:cmd, {"stoponexit": "hup"})
     call job_setoptions(job, {"stoponexit": "kill"})
   elseif has('win32')
-    exe 'silent !start cmd /c start "test_channel" ' . a:cmd
+    exe 'silent !start cmd /D /c start "test_channel" ' . a:cmd
   else
     exe 'silent !' . a:cmd . '&'
   endif

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -88,9 +88,9 @@ if has('timers')
     " CursorHoldI event.
     let g:triggered = 0
     au CursorHoldI * let g:triggered += 1
-    set updatetime=500
-    call job_start(has('win32') ? 'cmd /c echo:' : 'echo',
-          \ {'exit_cb': {-> timer_start(1000, 'ExitInsertMode')}})
+    set updatetime=100
+    call job_start(has('win32') ? 'cmd /D /c echo:' : 'echo',
+          \ {'exit_cb': {-> timer_start(200, 'ExitInsertMode')}})
     call feedkeys('a', 'x!')
     call assert_equal(1, g:triggered)
     unlet g:triggered

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -3097,7 +3097,7 @@ func Test_range()
     call assert_fails('call term_start(range(3, 4))', 'E474:')
     let g:terminal_ansi_colors = range(16)
     if has('win32')
-      let cmd = "cmd /c dir"
+      let cmd = "cmd /D /c dir"
     else
       let cmd = "ls"
     endif

--- a/test/old/testdir/test_swap.vim
+++ b/test/old/testdir/test_swap.vim
@@ -420,7 +420,7 @@ func s:get_unused_pid(base)
   if has('job')
     " Execute 'echo' as a temporary job, and return its pid as an unused pid.
     if has('win32')
-      let cmd = 'cmd /c echo'
+      let cmd = 'cmd /D /c echo'
     else
       let cmd = 'echo'
     endif

--- a/test/old/testdir/test_windows_home.vim
+++ b/test/old/testdir/test_windows_home.vim
@@ -105,7 +105,7 @@ func Test_WindowsHome()
       RestoreEnv
       let $HOME = save_home
       let env = ''
-      let job = job_start('cmd /c set', {'out_cb': {ch,x->[env,execute('let env=x')]}})
+      let job = job_start('cmd /D /c set', {'out_cb': {ch,x->[env,execute('let env=x')]}})
       sleep 1
       let env = filter(split(env, "\n"), 'v:val=="HOME"')
       let home = len(env) == 0 ? "" : env[0]


### PR DESCRIPTION
#### vim-patch:9.1.0794: tests: tests may fail on Windows environment

Problem:  tests: tests may fail on Windows environment
Solution: use shellcmdflag=/D to skip executing autorun from
          the registry (Milly)

closes: vim/vim#15900

https://github.com/vim/vim/commit/4f5681dbdfaf25f3357cba3172906c076421c7b9

Cherry-pick Test_cursorhold_insert_with_timer_interrupt() change from
patch 8.2.1836.

Co-authored-by: Milly <milly.ca@gmail.com>