### PR TITLE
refactor(lsp): create `vim.g/b.inlay_hint_enabled`

### DIFF
--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -69,21 +69,10 @@ function M.on_inlayhint(err, result, ctx, _)
     return
   end
 
-  local lines = api.nvim_buf_get_lines(bufnr, 0, -1, false)
-  ---@param position lsp.Position
-  ---@return integer
-  local function pos_to_byte(position)
-    local col = position.character
-    if col > 0 then
-      local line = lines[position.line + 1] or ''
-      return util._str_byteindex_enc(line, col, client.offset_encoding)
-    end
-    return col
-  end
-
   for _, hint in ipairs(result) do
     local lnum = hint.position.line
-    hint.position.character = pos_to_byte(hint.position)
+    hint.position.character =
+      util._get_line_byte_from_position(bufnr, hint.position, client.offset_encoding)
     table.insert(new_lnum_hints[lnum], hint)
   end
 

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -4,23 +4,20 @@ local ms = require('vim.lsp.protocol').Methods
 local api = vim.api
 local M = {}
 
----@class (private) vim.lsp.inlay_hint.globalstate Global state for inlay hints
----@field enabled boolean Whether inlay hints are enabled for this scope
----@type vim.lsp.inlay_hint.globalstate
-local globalstate = {
-  enabled = false,
-}
+---@type boolean
+vim.g.inlay_hint_enabled = false
 
----@class (private) vim.lsp.inlay_hint.bufstate: vim.lsp.inlay_hint.globalstate Buffer local state for inlay hints
+---@class (private) vim.lsp.inlay_hint.bufstate Buffer local state for inlay hints
 ---@field version? integer
+---@field enabled boolean Whether inlay hints are enabled for this buffer
 ---@field client_hints? table<integer, table<integer, lsp.InlayHint[]>> client_id -> (lnum -> hints)
 ---@field applied table<integer, integer> Last version of hints applied to this line
 ---@type table<integer, vim.lsp.inlay_hint.bufstate>
 local bufstates = vim.defaulttable(function(_)
   return setmetatable({ applied = {} }, {
-    __index = globalstate,
+    __index = { enabled = vim.g.inlay_hint_enabled },
     __newindex = function(state, key, value)
-      if globalstate[key] == value then
+      if key == 'enabled' and value == vim.g.inlay_hint_enabled then
         rawset(state, key, nil)
       else
         rawset(state, key, value)
@@ -370,7 +367,7 @@ function M.is_enabled(filter)
 
   vim.validate('bufnr', bufnr, 'number', true)
   if bufnr == nil then
-    return globalstate.enabled
+    return vim.g.inlay_hint_enabled
   elseif bufnr == 0 then
     bufnr = api.nvim_get_current_buf()
   end
@@ -401,7 +398,7 @@ function M.enable(enable, filter)
   filter = filter or {}
 
   if filter.bufnr == nil then
-    globalstate.enabled = enable
+    vim.g.inlay_hint_enabled = true
     for _, bufnr in ipairs(api.nvim_list_bufs()) do
       if api.nvim_buf_is_loaded(bufnr) then
         if enable == false then


### PR DESCRIPTION
## Problem
In https://github.com/neovim/neovim/pull/28543#discussion_r1587440644, we discussed that we should make more use of vim variables like `vim.b` to store variables related to the lifecycle of buffers, but using it to store tables may have potential risks (https://github.com/neovim/neovim/issues/12544). However, there is no problem using `enable`(the variable presents whether the inlay hint is enabled) in `globalstate/bufstate`, as it is just a boolean value, and doing so has two advantages.
1. This provides a configuration method for global/local variables that aligns with the editor options style and does not disrupt our current `enable` strategy (related: https://github.com/neovim/neovim/issues/28603).
2. `enable` is a user-controlled state, while other variables managed by `bufstate` (such as `client_hints` and `version`) are controlled by LSP. They have different lifecycles, and separating them will better facilitate the next step of refactoring.
## Solution
Create two new variables `vim.g.inlay_hint_enabled` and `vim.b.inlay_hint_enabled`