### PR TITLE
docs(lsp): fix typo in root_dir explanation

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -867,9 +867,9 @@ start({config}, {opts})                                      *vim.lsp.start()*
       |vim.lsp.start_client()|.
     • `root_dir` path to the project root. By default this is used to decide
       if an existing client should be re-used. The example above uses
-      |vim.fs.root()| and |vim.fs.dirname()| to detect the root by traversing
-      the file system upwards starting from the current directory until either
-      a `pyproject.toml` or `setup.py` file is found.
+      |vim.fs.root()| to detect the root by traversing the file system upwards
+      starting from the current directory until either a `pyproject.toml` or
+      `setup.py` file is found.
     • `workspace_folders` list of `{ uri:string, name: string }` tables
       specifying the project root folders used by the language server. If
       `nil` the property is derived from `root_dir` for convenience.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -235,9 +235,9 @@ end
 --- - `name` arbitrary name for the LSP client. Should be unique per language server.
 --- - `cmd` command string[] or function, described at |vim.lsp.start_client()|.
 --- - `root_dir` path to the project root. By default this is used to decide if an existing client
----   should be re-used. The example above uses |vim.fs.root()| and |vim.fs.dirname()| to detect
----   the root by traversing the file system upwards starting from the current directory until
----   either a `pyproject.toml` or `setup.py` file is found.
+---   should be re-used. The example above uses |vim.fs.root()| to detect the root by traversing
+---   the file system upwards starting from the current directory until either a `pyproject.toml`
+---   or `setup.py` file is found.
 --- - `workspace_folders` list of `{ uri:string, name: string }` tables specifying the project root
 ---   folders used by the language server. If `nil` the property is derived from `root_dir` for
 ---   convenience.


### PR DESCRIPTION
This example used to have both `vim.fs.find()` and `vim.fs.dirname()`, but since https://github.com/neovim/neovim/pull/28477 it now only use `vim.fs.root()`, but the description still has the `vim.fs.dirname()` part left, which is no longer correct.