### PR TITLE
vim-patch:9.1.0797: testing of options can be further improved

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1417,7 +1417,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 						*'cmdheight'* *'ch'*
 'cmdheight' 'ch'	number	(default 1)
-			global or local to tab page |global-local|
+			global or local to tab page
 	Number of screen lines to use for the command-line.  Helps avoiding
 	|hit-enter| prompts.
 	The value of this option is stored with the tab page, so that each tab

--- a/scripts/gen_eval_files.lua
+++ b/scripts/gen_eval_files.lua
@@ -670,7 +670,7 @@ local function scope_to_doc(s)
     return m[s[1]]
   end
   assert(s[1] == 'global')
-  return 'global or ' .. m[s[2]] .. ' |global-local|'
+  return 'global or ' .. m[s[2]] .. (s[2] ~= 'tab' and ' |global-local|' or '')
 end
 
 -- @param o vim.option_meta

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -777,7 +777,11 @@ void getout(int exitval)
     }
   }
 
-  if (p_shada && *p_shada != NUL) {
+  if (
+#ifdef EXITFREE
+      !entered_free_all_mem &&
+#endif
+      p_shada && *p_shada != NUL) {
     // Write out the registers, history, marks etc, to the ShaDa file
     shada_write_file(NULL, false);
   }

--- a/test/old/testdir/Makefile
+++ b/test/old/testdir/Makefile
@@ -154,7 +154,7 @@ newtests: newtestssilent
 
 newtestssilent: $(NEW_TESTS_RES)
 
-GEN_OPT_DEPS = gen_opt_test.vim ../../../src/nvim/options.lua
+GEN_OPT_DEPS = gen_opt_test.vim ../../../src/nvim/options.lua ../../../runtime/doc/options.txt
 
 opt_test.vim: $(GEN_OPT_DEPS)
 	$(NVIM_PRG) -e -s -u NONE $(NO_INITS) -S $(GEN_OPT_DEPS)
@@ -164,7 +164,7 @@ opt_test.vim: $(GEN_OPT_DEPS)
 	fi
 
 # Explicit dependencies.
-test_options.res test_alot.res: opt_test.vim
+test_options_all.res: opt_test.vim
 
 %.res: %.vim .gdbinit
 	@echo "[OLDTEST] Running" $*

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -1,7 +1,10 @@
 " Test for options
 
+source shared.vim
 source check.vim
 source view_util.vim
+
+scriptencoding utf-8
 
 func Test_whichwrap()
   set whichwrap=b,s
@@ -1022,15 +1025,6 @@ func Test_set_all_one_column()
   call assert_equal(out_one[0], '--- Options ---')
   let options = out_one[1:]->mapnew({_, line -> line[2:]})
   call assert_equal(sort(copy(options)), options)
-endfunc
-
-func Test_set_values()
-  " opt_test.vim is generated from ../optiondefs.h using gen_opt_test.vim
-  if filereadable('opt_test.vim')
-    source opt_test.vim
-  else
-    throw 'Skipped: opt_test.vim does not exist'
-  endif
 endfunc
 
 func Test_renderoptions()

--- a/test/old/testdir/test_options_all.vim
+++ b/test/old/testdir/test_options_all.vim
@@ -1,0 +1,13 @@
+" Test for options
+
+" opt_test.vim is generated from src/optiondefs.h and runtime/doc/options.txt
+" using gen_opt_test.vim
+if filereadable('opt_test.vim')
+  source opt_test.vim
+else
+  func Test_set_values()
+    throw 'Skipped: opt_test.vim does not exist'
+  endfunc
+endif
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0797: testing of options can be further improved

Problem:  testing of options can be further improved
Solution: split the generated option test into test_options_all.vim,
          add more test cases, save and restore values, fix use-after-free

closes: vim/vim#15894

https://github.com/vim/vim/commit/6eca04e9f1d446dc509ba51e32da56fa413fe2f0

Co-authored-by: Milly <milly.ca@gmail.com>