### PR TITLE
vim-patch:9.1.0798: too many strlen() calls in cmdhist.c

### DIFF
--- a/src/nvim/cmdhist.h
+++ b/src/nvim/cmdhist.h
@@ -23,6 +23,7 @@ enum { HIST_COUNT = HIST_DEBUG + 1, };  ///< Number of history tables
 typedef struct {
   int hisnum;           ///< Entry identifier number.
   char *hisstr;         ///< Actual entry, separator char after the NUL.
+  size_t hisstrlen;     ///< Length of hisstr (excluding the NUL).
   Timestamp timestamp;  ///< Time when entry was added.
   AdditionalData *additional_data;  ///< Additional entries from ShaDa file.
 } histentry_T;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4434,11 +4434,11 @@ void ex_global(exarg_T *eap)
     delim = *cmd;               // get the delimiter
     cmd++;                      // skip delimiter if there is one
     pat = cmd;                  // remember start of pattern
-    patlen = strlen(pat);
     cmd = skip_regexp_ex(cmd, delim, magic_isset(), &eap->arg, NULL, NULL);
     if (cmd[0] == delim) {                  // end delimiter found
       *cmd++ = NUL;                         // replace it with a NUL
     }
+    patlen = strlen(pat);
   }
 
   char *used_pat;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1789,7 +1789,7 @@ static int command_line_browse_history(CommandLineState *s)
       plen = s->lookforlen;
     } else {
       p = get_histentry(s->histype)[s->hiscnt].hisstr;
-      plen = (int)strlen(p);
+      plen = (int)get_histentry(s->histype)[s->hiscnt].hisstrlen;
     }
 
     if (s->histype == HIST_SEARCH

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -658,7 +658,7 @@ static const void *shada_hist_iter(const void *const iter, const uint8_t history
           .histtype = history_type,
           .string = hist_he.hisstr,
           .sep = (char)(history_type == HIST_SEARCH
-                        ? hist_he.hisstr[strlen(hist_he.hisstr) + 1]
+                        ? hist_he.hisstr[hist_he.hisstrlen + 1]
                         : 0),
         }
       },
@@ -784,6 +784,7 @@ static inline void hms_to_he_array(const HistoryMergerState *const hms_p,
     hist->timestamp = cur_entry->data.timestamp;
     hist->hisnum = (int)(hist - hist_array) + 1;
     hist->hisstr = cur_entry->data.data.history_item.string;
+    hist->hisstrlen = strlen(cur_entry->data.data.history_item.string);
     hist->additional_data = cur_entry->data.additional_data;
     hist++;
   })


### PR DESCRIPTION
#### vim-patch:9.1.0798: too many strlen() calls in cmdhist.c

Problem:  too many strlen() calls in cmdhist.c
Solution: refactor code and remove strlen() calls
          (John Marriott)

closes: vim/vim#15888

https://github.com/vim/vim/commit/8df07d0ca310a55e1540f7d234b536abee49abd4

Co-authored-by: John Marriott <basilisk@internode.on.net>