### PR TITLE
vim-patch:9.1.{0799,0805},19be0eb

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5472,7 +5472,8 @@ This will set the "w:current_syntax" variable to "foo".  The value of
 restoring "b:current_syntax", since the syntax files do set
 "b:current_syntax".  The value set by the syntax file is assigned to
 "w:current_syntax".
-Note: This resets the 'spell', 'spellcapcheck' and 'spellfile' options.
+Note: This resets the 'spell', 'spellcapcheck', 'spellfile' and 'spelloptions'
+options.
 
 Once a window has its own syntax, syntax commands executed from other windows
 on the same buffer (including :syntax clear) have no effect. Conversely,

--- a/test/old/testdir/gen_opt_test.vim
+++ b/test/old/testdir/gen_opt_test.vim
@@ -25,7 +25,7 @@ endwhile
 call extend(global_locals, #{
       \ scrolloff: -1,
       \ sidescrolloff: -1,
-      \ undolevels: -12345,
+      \ undolevels: -123456,
       \})
 
 " Get local-noglobal options.
@@ -63,7 +63,8 @@ let skip_setglobal_reasons = #{
       \ winhighlight:	'TODO(nvim): fix missing error handling for setglobal',
       \}
 
-" The terminal size is restored at the end.
+" Script header.
+" The test values contains multibyte characters.
 let script = [
       \ '" DO NOT EDIT: Generated with gen_opt_test.vim',
       \ '" Used by test_options_all.vim.',
@@ -453,8 +454,9 @@ for option in options
       endfor
       " Testing to clear the local value and switch back to the global value.
       if global_locals->has_key(fullname)
-	let swichback_val = global_locals[fullname]
-	call add(script, $'setlocal {opt}={swichback_val}')
+	let switchback_val = global_locals[fullname]
+	call add(script, $'setlocal {opt}={switchback_val}')
+	call add(script, $'call assert_equal(&g:{fullname}, &{fullname})')
       endif
     endfor
 
@@ -516,4 +518,4 @@ endif
 
 qa!
 
-" vim:sw=2:ts=8:noet:nolist:nosta:
+" vim:sw=2:ts=8:noet:nosta:

--- a/test/old/testdir/test_getvar.vim
+++ b/test/old/testdir/test_getvar.vim
@@ -22,6 +22,12 @@ func Test_var()
   call assert_equal('Chance', getwinvar(9, '', def_str))
   call assert_equal(0, getwinvar(1, '&nu'))
   call assert_equal(0, getwinvar(1, '&nu', 1))
+  call assert_match(v:t_dict, type(getwinvar(1, '&')))
+  call assert_match(v:t_dict, type(getwinvar(1, '&', def_str)))
+  call assert_equal('', getwinvar(9, '&'))
+  call assert_equal('Chance', getwinvar(9, '&', def_str))
+  call assert_equal('', getwinvar(1, '&nux'))
+  call assert_equal('Chance', getwinvar(1, '&nux', def_str))
   unlet def_str
 
   " test for gettabvar()
@@ -83,7 +89,12 @@ func Test_var()
 
   unlet def_dict
 
+  call assert_match(v:t_dict, type(gettabwinvar(2, 3, '&')))
+  call assert_match(v:t_dict, type(gettabwinvar(2, 3, '&', 1)))
   call assert_equal("", gettabwinvar(9, 2020, ''))
+  call assert_equal(1, gettabwinvar(9, 2020, '', 1))
+  call assert_equal('', gettabwinvar(9, 2020, '&'))
+  call assert_equal(1, gettabwinvar(9, 2020, '&', 1))
   call assert_equal('', gettabwinvar(2, 3, '&nux'))
   call assert_equal(1, gettabwinvar(2, 3, '&nux', 1))
   tabonly


### PR DESCRIPTION
#### vim-patch:9.1.0799: tests: gettwinvar()/gettabwinvar() tests are not comprehensive

Problem:  tests: gettwinvar()/gettabwinvar() tests are not comprehensive
Solution: Add more tests (Milly)

closes: vim/vim#15920

https://github.com/vim/vim/commit/ceec8640df0f75c6e7759fbb3d7a1064313321fb

Co-authored-by: Milly <milly.ca@gmail.com>


#### vim-patch:19be0eb: runtime(doc): :ownsyntax also resets 'spelloptions'

closes: vim/vim#15919

https://github.com/vim/vim/commit/19be0eb7f0c5877fef927a22457fdd7b3ec0ea9b


#### vim-patch:9.1.0805: tests: minor issues in gen_opt_test.vim

Problem:  tests: minor issues in gen_opt_test.vim
Solution: fix restore value for 'undolevels', fix comment, fix
          wrong cpo value, add equality test for global-local options on
          switchback (Milly).

closes: vim/vim#15913

https://github.com/vim/vim/commit/231480f9753fa3fb28e17b670550ce43172c0eba

Cherry-pick gen_opt_test.vim change from patch 9.1.0807.

Co-authored-by: Milly <milly.ca@gmail.com>