### PR TITLE
vim-patch:9.1.0809: filetype: petalinux config files not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2112,6 +2112,7 @@ local pattern = {
     ['/build/conf/.*%.conf$'] = 'bitbake',
     ['/meta%-.*/conf/.*%.conf$'] = 'bitbake',
     ['/meta/conf/.*%.conf$'] = 'bitbake',
+    ['/project%-spec/configs/.*%.conf$'] = 'bitbake',
     ['/%.cabal/config$'] = 'cabalconfig',
     ['/cabal/config$'] = 'cabalconfig',
     ['/%.aws/config$'] = 'confini',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -134,7 +134,7 @@ func s:GetFilenameChecks() abort
     \ 'bib': ['file.bib'],
     \ 'bicep': ['file.bicep', 'file.bicepparam'],
     \ 'bindzone': ['named.root', '/bind/db.file', '/named/db.file', 'any/bind/db.file', 'any/named/db.file', 'foobar.zone'],
-    \ 'bitbake': ['file.bb', 'file.bbappend', 'file.bbclass', 'build/conf/local.conf', 'meta/conf/layer.conf', 'build/conf/bbappend.conf', 'meta-layer/conf/distro/foo.conf'],
+    \ 'bitbake': ['file.bb', 'file.bbappend', 'file.bbclass', 'build/conf/local.conf', 'meta/conf/layer.conf', 'build/conf/bbappend.conf', 'meta-layer/conf/distro/foo.conf', 'project-spec/configs/zynqmp-generic-xczu7ev.conf'],
     \ 'blade': ['file.blade.php'],
     \ 'blank': ['file.bl'],
     \ 'blueprint': ['file.blp'],


### PR DESCRIPTION
Problem:  filetype: petalinux config files not recognized
Solution: detect 'project-spec/*.conf' files as bitbake filetype
          (Wu, Zhenyu)

References:
https://www.amd.com/en/products/software/adaptive-socs-and-fpgas/embedded-software/petalinux-sdk.html

closes: vim/vim#15926

https://github.com/vim/vim/commit/626b6ab48682b211c22ede5a6e63513c85f93e58

Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>
