### PR TITLE
refactor(lsp): tidy up error messaging of vim.notify

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -561,12 +561,10 @@ local function buf_attach(bufnr)
           client.notify(ms.textDocument_willSave, params)
         end
         if client.supports_method(ms.textDocument_willSaveWaitUntil) then
-          local result, err =
+          local result =
             client.request_sync(ms.textDocument_willSaveWaitUntil, params, 1000, ctx.buf)
           if result and result.result then
             util.apply_text_edits(result.result, ctx.buf, client.offset_encoding)
-          elseif err then
-            log.error(vim.inspect(err))
           end
         end
       end
@@ -634,7 +632,7 @@ function lsp.buf_attach_client(bufnr, client_id)
   validate('client_id', client_id, 'number')
   bufnr = resolve_bufnr(bufnr)
   if not api.nvim_buf_is_loaded(bufnr) then
-    log.warn(string.format('buf_attach_client called on unloaded buffer (id: %d): ', bufnr))
+    log.warn('lsp.buf_attach_client', string.format('called on unloaded buffer (id: %d): ', bufnr))
     return false
   end
 

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -676,19 +676,6 @@ function Client:_request(method, params, handler, bufnr)
       log.trace(self.name, 'handler', method, { err = err, result = result, ctx = context })
     end
 
-    -- Per LSP, don't show ContentModified error to the user.
-    if err and err.code ~= lsp.protocol.ErrorCodes.ContentModified then
-      -- (#25464) The haskell-language-server supports resolve only for a subset
-      -- of code actions. For many code actions trying to resolve the `edit`
-      -- property results in an error. The protocol specification is
-      -- unfortunately a bit vague about this, and what the
-      -- haskell-language-server does seems to be valid.
-      --
-      -- In these cases do not present the error to the user, but still log it.
-      local notify = method ~= ms.codeAction_resolve
-      self:error(err.code, err.message, notify)
-    end
-
     handler(err, result, context)
   end, function(request_id)
     local request = self.requests[request_id]

--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -1,5 +1,4 @@
 local util = require('vim.lsp.util')
-local log = require('vim.lsp.log')
 local ms = require('vim.lsp.protocol').Methods
 local api = vim.api
 local M = {}
@@ -264,7 +263,6 @@ end
 function M.on_codelens(err, result, ctx, _)
   if err then
     active_refreshes[assert(ctx.bufnr)] = nil
-    log.error('codelens', err)
     return
   end
 

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -549,7 +549,8 @@ local function on_complete_done()
     local command = completion_item.command
     if command then
       client:_exec_cmd(command, { bufnr = bufnr }, nil, function()
-        vim.lsp.log.warn(
+        lsp.log.warn(
+          'on_complete_done',
           string.format(
             'Language server `%s` does not support command `%s`. This command may require a client extension.',
             client.name,
@@ -568,15 +569,13 @@ local function on_complete_done()
     local changedtick = vim.b[bufnr].changedtick
 
     --- @param result lsp.CompletionItem
-    client.request(ms.completionItem_resolve, completion_item, function(err, result)
+    client.request(ms.completionItem_resolve, completion_item, function(_, result)
       if changedtick ~= vim.b[bufnr].changedtick then
         return
       end
 
       clear_word()
-      if err then
-        vim.notify_once(err.message, vim.log.levels.WARN)
-      elseif result and result.additionalTextEdits then
+      if result and result.additionalTextEdits then
         lsp.util.apply_text_edits(result.additionalTextEdits, bufnr, offset_encoding)
         if result.command then
           completion_item.command = result.command
@@ -731,7 +730,7 @@ end
 --- - findstart=0: column where the completion starts, or -2 or -3
 --- - findstart=1: list of matches (actually just calls |complete()|)
 function M._omnifunc(findstart, base)
-  vim.lsp.log.debug('omnifunc.findstart', { findstart = findstart, base = base })
+  lsp.log.debug('omnifunc', { findstart = findstart, base = base })
   assert(base) -- silence luals
   local bufnr = api.nvim_get_current_buf()
   local clients = lsp.get_clients({ bufnr = bufnr, method = ms.textDocument_completion })

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -112,10 +112,10 @@ local function diagnostic_lsp_to_vim(diagnostics, bufnr, client_id)
     local _end = diagnostic.range['end']
     local message = diagnostic.message
     if type(message) ~= 'string' then
-      vim.notify_once(
-        string.format('Unsupported Markup message from LSP client %d', client_id),
-        vim.lsp.log_levels.ERROR
-      )
+      if client then
+        --- @diagnostic disable-next-line:invisible
+        client:error(nil, 'Unsupported Markup message of type ' .. vim.inspect(message))
+      end
       message = diagnostic.message.value
     end
     --- @type vim.Diagnostic

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -10,10 +10,10 @@ local M = {}
 
 -- FIXME: DOC: Expose in vimdocs
 
---- Writes to error buffer.
----@param ... string Will be concatenated before being written
-local function err_message(...)
-  vim.notify(table.concat(vim.iter({ ... }):flatten():totable()), vim.log.levels.ERROR)
+--- @param client_id integer
+--- @param msg string
+local function err_message(client_id, msg)
+  vim.notify(string.format('LSP: client_id=%d: %s', client_id, msg), vim.log.levels.ERROR)
   api.nvim_command('redraw')
 end
 
@@ -28,7 +28,7 @@ end
 M[ms.dollar_progress] = function(_, params, ctx)
   local client = vim.lsp.get_client_by_id(ctx.client_id)
   if not client then
-    err_message('LSP[id=', tostring(ctx.client_id), '] client has shut down during progress update')
+    err_message(ctx.client_id, 'client has shut down during progress update')
     return vim.NIL
   end
   local kind = nil
@@ -64,7 +64,7 @@ end
 M[ms.window_workDoneProgress_create] = function(_, result, ctx)
   local client = vim.lsp.get_client_by_id(ctx.client_id)
   if not client then
-    err_message('LSP[id=', tostring(ctx.client_id), '] client has shut down during progress update')
+    err_message(ctx.client_id, 'client has shut down during progress update')
     return vim.NIL
   end
   client.progress:push(result)
@@ -133,7 +133,7 @@ M[ms.client_registerCapability] = function(_, result, ctx)
       .. 'Report upstream, this warning is harmless'
     local client_name = client and client.name or string.format('id=%d', client_id)
     local warning = string.format(warning_tpl, client_name, table.concat(unsupported, ', '))
-    log.warn(warning)
+    log.warn(client.name, ms.client_unregisterCapability, warning)
   end
   return vim.NIL
 end
@@ -187,11 +187,7 @@ M[ms.workspace_configuration] = function(_, result, ctx)
   local client_id = ctx.client_id
   local client = vim.lsp.get_client_by_id(client_id)
   if not client then
-    err_message(
-      'LSP[',
-      client_id,
-      '] client has shut down after sending a workspace/configuration request'
-    )
+    err_message(client_id, 'client has shut down after sending a workspace/configuration request')
     return
   end
   if not result.items then
@@ -220,7 +216,7 @@ M[ms.workspace_workspaceFolders] = function(_, _, ctx)
   local client_id = ctx.client_id
   local client = vim.lsp.get_client_by_id(client_id)
   if not client then
-    err_message('LSP[id=', client_id, '] client has shut down after sending the message')
+    err_message(client_id, 'client has shut down after sending the message')
     return
   end
   return client.workspace_folders or vim.NIL
@@ -547,18 +543,18 @@ M[ms.window_logMessage] = function(_, result, ctx, _)
   local message = result.message
   local client_id = ctx.client_id
   local client = vim.lsp.get_client_by_id(client_id)
-  local client_name = client and client.name or string.format('id=%d', client_id)
   if not client then
-    err_message('LSP[', client_name, '] client has shut down after sending ', message)
+    err_message(client_id, 'client has shut down after sending ' .. message)
+    return
   end
   if message_type == protocol.MessageType.Error then
-    log.error(message)
+    log.error(client.name, message)
   elseif message_type == protocol.MessageType.Warning then
-    log.warn(message)
+    log.warn(client.name, message)
   elseif message_type == protocol.MessageType.Info or message_type == protocol.MessageType.Log then
-    log.info(message)
+    log.info(client.name, message)
   else
-    log.debug(message)
+    log.debug(client.name, message)
   end
   return result
 end
@@ -572,10 +568,10 @@ M[ms.window_showMessage] = function(_, result, ctx, _)
   local client = vim.lsp.get_client_by_id(client_id)
   local client_name = client and client.name or string.format('id=%d', client_id)
   if not client then
-    err_message('LSP[', client_name, '] client has shut down after sending ', message)
+    err_message(client_id, 'client has shut down after sending ' .. message)
   end
   if message_type == protocol.MessageType.Error then
-    err_message('LSP[', client_name, '] ', message)
+    err_message(client_id, message)
   else
     --- @type string
     local message_type_name = protocol.MessageType[message_type]
@@ -609,9 +605,8 @@ M[ms.window_showDocument] = function(_, result, ctx, _)
 
   local client_id = ctx.client_id
   local client = vim.lsp.get_client_by_id(client_id)
-  local client_name = client and client.name or string.format('id=%d', client_id)
   if not client then
-    err_message('LSP[', client_name, '] client has shut down after sending ', ctx.method)
+    err_message(client_id, 'client has shut down after sending ' .. ctx.method)
     return vim.NIL
   end
 
@@ -628,41 +623,19 @@ M[ms.window_showDocument] = function(_, result, ctx, _)
 end
 
 ---@see https://microsoft.github.io/language-server-protocol/specification/#workspace_inlayHint_refresh
-M[ms.workspace_inlayHint_refresh] = function(err, result, ctx, config)
-  return vim.lsp.inlay_hint.on_refresh(err, result, ctx, config)
+M[ms.workspace_inlayHint_refresh] = function(...)
+  return vim.lsp.inlay_hint.on_refresh(...)
 end
 
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#semanticTokens_refreshRequest
-M[ms.workspace_semanticTokens_refresh] = function(err, result, ctx, _config)
-  return vim.lsp.semantic_tokens._refresh(err, result, ctx)
+M[ms.workspace_semanticTokens_refresh] = function(...)
+  return vim.lsp.semantic_tokens.on_refresh(...)
 end
 
--- Add boilerplate error validation and logging for all of these.
+-- Add boilerplate error handling for all of these.
 for k, fn in pairs(M) do
   M[k] = function(err, result, ctx, config)
-    if log.trace() then
-      log.trace('default_handler', ctx.method, {
-        err = err,
-        result = result,
-        ctx = vim.inspect(ctx),
-        config = config,
-      })
-    end
-
     if err then
-      -- LSP spec:
-      -- interface ResponseError:
-      --  code: integer;
-      --  message: string;
-      --  data?: string | number | boolean | array | object | null;
-
-      -- Per LSP, don't show ContentModified error to the user.
-      if err.code ~= protocol.ErrorCodes.ContentModified then
-        local client = vim.lsp.get_client_by_id(ctx.client_id)
-        local client_name = client and client.name or string.format('client_id=%d', ctx.client_id)
-
-        err_message(client_name .. ': ' .. tostring(err.code) .. ': ' .. err.message)
-      end
       return
     end
 

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -18,9 +18,8 @@ local function err_message(client_id, msg)
 end
 
 --- @see # https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_executeCommand
-M[ms.workspace_executeCommand] = function(_, _, _, _)
-  -- Error handling is done implicitly by wrapping all handlers; see end of this file
-end
+M[ms.workspace_executeCommand] = vim.lsp._handler_wrap(function(_, _, _, _)
+end)
 
 --- @see # https://microsoft.github.io/language-server-protocol/specifications/specification-current/#progress
 ---@param params lsp.ProgressParams
@@ -634,12 +633,13 @@ end
 
 -- Add boilerplate error handling for all of these.
 for k, fn in pairs(M) do
-  M[k] = function(err, result, ctx, config)
+  M[k] = function(err, ...)
     if err then
+      vim.lsp._handler_wrap()(err, ...)
       return
     end
 
-    return fn(err, result, ctx, config)
+    return fn(err, ...)
   end
 end
 

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -1,5 +1,4 @@
 local util = require('vim.lsp.util')
-local log = require('vim.lsp.log')
 local ms = require('vim.lsp.protocol').Methods
 local api = vim.api
 local M = {}
@@ -37,11 +36,7 @@ local augroup = api.nvim_create_augroup('vim_lsp_inlayhint', {})
 ---@param result lsp.InlayHint[]?
 ---@param ctx lsp.HandlerContext
 ---@private
-function M.on_inlayhint(err, result, ctx, _)
-  if err then
-    log.error('inlayhint', err)
-    return
-  end
+function M.on_inlayhint(_err, result, ctx, _)
   local bufnr = assert(ctx.bufnr)
   if
     util.buf_versions[bufnr] ~= ctx.version
@@ -95,10 +90,7 @@ end
 --- |lsp-handler| for the method `workspace/inlayHint/refresh`
 ---@param ctx lsp.HandlerContext
 ---@private
-function M.on_refresh(err, _, ctx, _)
-  if err then
-    return vim.NIL
-  end
+function M.on_refresh(_err, _, ctx, _)
   for _, bufnr in ipairs(vim.lsp.get_buffers_by_client_id(ctx.client_id)) do
     for _, winid in ipairs(api.nvim_list_wins()) do
       if api.nvim_win_get_buf(winid) == bufnr then

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -762,6 +762,7 @@ function M.highlight_token(token, bufnr, client_id, hl_group, opts)
   })
 end
 
+--- @private
 --- |lsp-handler| for the method `workspace/semanticTokens/refresh`
 ---
 --- Refresh requests are sent by the server to indicate a project-wide change
@@ -769,11 +770,7 @@ end
 --- invalidate the current results of all buffers and automatically kick off a
 --- new request for buffers that are displayed in a window. For those that aren't, a
 --- the BufWinEnter event should take care of it next time it's displayed.
-function M._refresh(err, _, ctx)
-  if err then
-    return vim.NIL
-  end
-
+function M.on_refresh(_, _, ctx)
   for _, bufnr in ipairs(vim.lsp.get_buffers_by_client_id(ctx.client_id)) do
     local highlighter = STHighlighter.active[bufnr]
     if highlighter and highlighter.client_state[ctx.client_id] then

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -5024,13 +5024,14 @@ describe('LSP', function()
         vim.notify = function(msg, _)
           _G.notify_msg = msg
         end
+        vim.notify_once = vim.notify
       end)
       local fail_msg = '[LSP] Format request failed, no matching language servers.'
       --- @param name string
       --- @param formatting boolean
       --- @param range_formatting boolean
       local function check_notify(name, formatting, range_formatting)
-        local timeout_msg = '[LSP][' .. name .. '] timeout'
+        local timeout_msg = 'LSP:' .. name .. ' (-1): timeout'
         exec_lua(function()
           local server = _G._create_server({
             capabilities = {


### PR DESCRIPTION
Problem:
  Error handling in LSP is inconsistent and partial.

Solution:
  Consolidate error messaging.
  - Errors are always logged.
  - The user is only notified once about an error.
  - Formatting is _more_ consistent.

---

- [ ] Provide a mechanism for plugins to suppress errors and provide fallbacks?