### PR TITLE
vim-patch:9.1.{0802,0803,0804,0806,0812}: :setglobal fixes

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -255,7 +255,7 @@ int open_buffer(bool read_stdin, exarg_T *eap, int flags_arg)
     emsg(_("E83: Cannot allocate buffer, using other one..."));
     enter_buffer(curbuf);
     if (old_tw != curbuf->b_p_tw) {
-      check_colorcolumn(curwin);
+      check_colorcolumn(NULL, curwin);
     }
     return FAIL;
   }
@@ -1029,7 +1029,7 @@ void handle_swap_exists(bufref_T *old_curbuf)
       enter_buffer(buf);
 
       if (old_tw != curbuf->b_p_tw) {
-        check_colorcolumn(curwin);
+        check_colorcolumn(NULL, curwin);
       }
     }
     // If "old_curbuf" is NULL we are in big trouble here...
@@ -1669,7 +1669,7 @@ void set_curbuf(buf_T *buf, int action, bool update_jumplist)
     // enter some buffer.  Using the last one is hopefully OK.
     enter_buffer(valid ? buf : lastbuf);
     if (old_tw != curbuf->b_p_tw) {
-      check_colorcolumn(curwin);
+      check_colorcolumn(NULL, curwin);
     }
   }
 

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -769,9 +769,15 @@ int get_number_indent(linenr_T lnum)
   return (int)col;
 }
 
+/// Check "briopt" as 'breakindentopt' and update the members of "wp".
 /// This is called when 'breakindentopt' is changed and when a window is
 /// initialized
-bool briopt_check(win_T *wp)
+///
+/// @param briopt  when NULL: use "wp->w_p_briopt"
+/// @param wp      when NULL: only check "briopt"
+///
+/// @return  FAIL for failure, OK otherwise.
+bool briopt_check(char *briopt, win_T *wp)
 {
   int bri_shift = 0;
   int bri_min = 20;
@@ -779,7 +785,13 @@ bool briopt_check(win_T *wp)
   int bri_list = 0;
   int bri_vcol = 0;
 
-  char *p = wp->w_p_briopt;
+  char *p = empty_string_option;
+  if (briopt != NULL) {
+    p = briopt;
+  } else if (wp != NULL) {
+    p = wp->w_p_briopt;
+  }
+
   while (*p != NUL) {
     // Note: Keep this in sync with p_briopt_values
     if (strncmp(p, "shift:", 6) == 0
@@ -805,6 +817,10 @@ bool briopt_check(win_T *wp)
     if (*p == ',') {
       p++;
     }
+  }
+
+  if (wp == NULL) {
+    return OK;
   }
 
   wp->w_briopt_shift = bri_shift;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5112,7 +5112,7 @@ void didset_window_options(win_T *wp, bool valid_cursor)
     wp->w_skipcol = 0;
   }
   check_colorcolumn(NULL, wp);
-  briopt_check(wp);
+  briopt_check(NULL, wp);
   fill_culopt_flags(NULL, wp);
   set_chars_option(wp, wp->w_p_fcs, kFillchars, true, NULL, 0);
   set_chars_option(wp, wp->w_p_lcs, kListchars, true, NULL, 0);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2592,7 +2592,7 @@ static const char *did_set_swapfile(optset_T *args)
 static const char *did_set_textwidth(optset_T *args FUNC_ATTR_UNUSED)
 {
   FOR_ALL_TAB_WINDOWS(tp, wp) {
-    check_colorcolumn(wp);
+    check_colorcolumn(NULL, wp);
   }
 
   return NULL;
@@ -5111,7 +5111,7 @@ void didset_window_options(win_T *wp, bool valid_cursor)
   } else {
     wp->w_skipcol = 0;
   }
-  check_colorcolumn(wp);
+  check_colorcolumn(NULL, wp);
   briopt_check(wp);
   fill_culopt_flags(NULL, wp);
   set_chars_option(wp, wp->w_p_fcs, kFillchars, true, NULL, 0);

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -4459,7 +4459,7 @@ return {
     {
       abbreviation = 'isk',
       alloced = true,
-      cb = 'did_set_isopt',
+      cb = 'did_set_iskeyword',
       defaults = { if_true = '@,48-57,_,192-255' },
       deny_duplicates = true,
       desc = [=[

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1572,12 +1572,28 @@ int expand_set_inccommand(optexpand_T *args, int *numMatches, char ***matches)
                                matches);
 }
 
+/// The 'iskeyword' option is changed.
+const char *did_set_iskeyword(optset_T *args)
+{
+  char **varp = (char **)args->os_varp;
+
+  if (varp == &p_isk) {       // only check for global-value
+    if (check_isopt(*varp) == FAIL) {
+      return e_invarg;
+    }
+  } else {                    // fallthrough for local-value
+    return did_set_isopt(args);
+  }
+
+  return NULL;
+}
+
 /// The 'isident' or the 'iskeyword' or the 'isprint' or the 'isfname' option is
 /// changed.
 const char *did_set_isopt(optset_T *args)
 {
   buf_T *buf = (buf_T *)args->os_buf;
-  // 'isident', 'iskeyword', 'isprint or 'isfname' option: refill g_chartab[]
+  // 'isident', 'iskeyword', 'isprint' or 'isfname' option: refill g_chartab[]
   // If the new option is invalid, use old value.
   // 'lisp' option: refill g_chartab[] for '-' char
   if (buf_init_chartab(buf, true) == FAIL) {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -1448,8 +1448,7 @@ const char *did_set_foldmethod(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
   char **varp = (char **)args->os_varp;
-  if (check_opt_strings(*varp, p_fdm_values, false) != OK
-      || *win->w_p_fdm == NUL) {
+  if (check_opt_strings(*varp, p_fdm_values, false) != OK || **varp == NUL) {
     return e_invarg;
   }
   foldUpdateAll(win);

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -717,11 +717,14 @@ const char *did_set_breakat(optset_T *args FUNC_ATTR_UNUSED)
 const char *did_set_breakindentopt(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
-  if (briopt_check(win) == FAIL) {
+  char **varp = (char **)args->os_varp;
+
+  if (briopt_check(*varp, varp == &win->w_p_briopt ? win : NULL) == FAIL) {
     return e_invarg;
   }
+
   // list setting requires a redraw
-  if (win == curwin && win->w_briopt_list) {
+  if (varp == &win->w_p_briopt && win->w_briopt_list) {
     redraw_all_later(UPD_NOT_VALID);
   }
 

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -898,7 +898,8 @@ int expand_set_clipboard(optexpand_T *args, int *numMatches, char ***matches)
 const char *did_set_colorcolumn(optset_T *args)
 {
   win_T *win = (win_T *)args->os_win;
-  return check_colorcolumn(win);
+  char **varp = (char **)args->os_varp;
+  return check_colorcolumn(*varp, varp == &win->w_p_cc ? win : NULL);
 }
 
 /// The 'comments' option is changed.

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -7384,10 +7384,10 @@ const char *check_colorcolumn(char *cc, win_T *wp)
     return NULL;      // buffer was closed
   }
 
-  char *s;
+  char *s = empty_string_option;
   if (cc != NULL) {
     s = cc;
-  } else {
+  } else if (wp != NULL) {
     s = wp->w_p_cc;
   }
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -7371,18 +7371,37 @@ static int int_cmp(const void *pa, const void *pb)
   return a == b ? 0 : a < b ? -1 : 1;
 }
 
-/// Handle setting 'colorcolumn' or 'textwidth' in window "wp".
+/// Check "cc" as 'colorcolumn' and update the members of "wp".
+/// This is called when 'colorcolumn' or 'textwidth' is changed.
+///
+/// @param cc  when NULL: use "wp->w_p_cc"
+/// @param wp  when NULL: only parse "cc"
 ///
 /// @return error message, NULL if it's OK.
-const char *check_colorcolumn(win_T *wp)
+const char *check_colorcolumn(char *cc, win_T *wp)
 {
-  if (wp->w_buffer == NULL) {
+  if (wp != NULL && wp->w_buffer == NULL) {
     return NULL;      // buffer was closed
+  }
+
+  char *s;
+  if (cc != NULL) {
+    s = cc;
+  } else {
+    s = wp->w_p_cc;
+  }
+
+  OptInt tw;
+  if (wp != NULL) {
+    tw = wp->w_buffer->b_p_tw;
+  } else {
+    // buffer-local value not set, assume zero
+    tw = 0;
   }
 
   unsigned count = 0;
   int color_cols[256];
-  for (char *s = wp->w_p_cc; *s != NUL && count < 255;) {
+  while (*s != NUL && count < 255) {
     int col;
     if (*s == '-' || *s == '+') {
       // -N and +N: add to 'textwidth'
@@ -7392,16 +7411,12 @@ const char *check_colorcolumn(win_T *wp)
         return e_invarg;
       }
       col = col * getdigits_int(&s, true, 0);
-      if (wp->w_buffer->b_p_tw == 0) {
+      if (tw == 0) {
         goto skip;          // 'textwidth' not set, skip this item
       }
-      assert((col >= 0
-              && wp->w_buffer->b_p_tw <= INT_MAX - col
-              && wp->w_buffer->b_p_tw + col >= INT_MIN)
-             || (col < 0
-                 && wp->w_buffer->b_p_tw >= INT_MIN - col
-                 && wp->w_buffer->b_p_tw + col <= INT_MAX));
-      col += (int)wp->w_buffer->b_p_tw;
+      assert((col >= 0 && tw <= INT_MAX - col && tw + col >= INT_MIN)
+             || (col < 0 && tw >= INT_MIN - col && tw + col <= INT_MAX));
+      col += (int)tw;
       if (col < 0) {
         goto skip;
       }
@@ -7421,6 +7436,10 @@ skip:
     if (*++s == NUL) {
       return e_invarg;        // illegal trailing comma as in "set cc=80,"
     }
+  }
+
+  if (wp == NULL) {
+    return NULL;  // only parse "cc"
   }
 
   xfree(wp->w_p_cc_cols);

--- a/test/old/testdir/gen_opt_test.vim
+++ b/test/old/testdir/gen_opt_test.vim
@@ -46,7 +46,6 @@ let skip_setglobal_reasons = #{
       \ iminsert: 'The global value is always overwritten by the local value',
       \ imsearch: 'The global value is always overwritten by the local value',
       \ breakindentopt:	'TODO: fix missing error handling for setglobal',
-      \ colorcolumn:	'TODO: fix missing error handling for setglobal',
       \ conceallevel:	'TODO: fix missing error handling for setglobal',
       \ foldcolumn:	'TODO: fix missing error handling for setglobal',
       \ numberwidth:	'TODO: fix missing error handling for setglobal',

--- a/test/old/testdir/gen_opt_test.vim
+++ b/test/old/testdir/gen_opt_test.vim
@@ -49,7 +49,6 @@ let skip_setglobal_reasons = #{
       \ colorcolumn:	'TODO: fix missing error handling for setglobal',
       \ conceallevel:	'TODO: fix missing error handling for setglobal',
       \ foldcolumn:	'TODO: fix missing error handling for setglobal',
-      \ foldmethod:	'TODO: fix `setglobal fdm=` not given an error',
       \ iskeyword:	'TODO: fix missing error handling for setglobal',
       \ numberwidth:	'TODO: fix missing error handling for setglobal',
       \ scrolloff:	'TODO: fix missing error handling for setglobal',

--- a/test/old/testdir/gen_opt_test.vim
+++ b/test/old/testdir/gen_opt_test.vim
@@ -49,7 +49,6 @@ let skip_setglobal_reasons = #{
       \ colorcolumn:	'TODO: fix missing error handling for setglobal',
       \ conceallevel:	'TODO: fix missing error handling for setglobal',
       \ foldcolumn:	'TODO: fix missing error handling for setglobal',
-      \ iskeyword:	'TODO: fix missing error handling for setglobal',
       \ numberwidth:	'TODO: fix missing error handling for setglobal',
       \ scrolloff:	'TODO: fix missing error handling for setglobal',
       \ shiftwidth:	'TODO: fix missing error handling for setglobal',

--- a/test/old/testdir/gen_opt_test.vim
+++ b/test/old/testdir/gen_opt_test.vim
@@ -45,7 +45,6 @@ endwhile
 let skip_setglobal_reasons = #{
       \ iminsert: 'The global value is always overwritten by the local value',
       \ imsearch: 'The global value is always overwritten by the local value',
-      \ breakindentopt:	'TODO: fix missing error handling for setglobal',
       \ conceallevel:	'TODO: fix missing error handling for setglobal',
       \ foldcolumn:	'TODO: fix missing error handling for setglobal',
       \ numberwidth:	'TODO: fix missing error handling for setglobal',

--- a/test/old/testdir/gen_opt_test.vim
+++ b/test/old/testdir/gen_opt_test.vim
@@ -45,17 +45,7 @@ endwhile
 let skip_setglobal_reasons = #{
       \ iminsert: 'The global value is always overwritten by the local value',
       \ imsearch: 'The global value is always overwritten by the local value',
-      \ conceallevel:	'TODO: fix missing error handling for setglobal',
-      \ foldcolumn:	'TODO: fix missing error handling for setglobal',
-      \ numberwidth:	'TODO: fix missing error handling for setglobal',
-      \ scrolloff:	'TODO: fix missing error handling for setglobal',
-      \ shiftwidth:	'TODO: fix missing error handling for setglobal',
-      \ sidescrolloff:	'TODO: fix missing error handling for setglobal',
       \ signcolumn:	'TODO(nvim): fix missing error handling for setglobal',
-      \ tabstop:	'TODO: fix missing error handling for setglobal',
-      \ termwinkey:	'TODO: fix missing error handling for setglobal',
-      \ termwinsize:	'TODO: fix missing error handling for setglobal',
-      \ textwidth:	'TODO: fix missing error handling for setglobal',
       \ winhighlight:	'TODO(nvim): fix missing error handling for setglobal',
       \}
 


### PR DESCRIPTION
#### vim-patch:9.1.0802: tests: no error check when setting global 'fdm' to empty value

Problem:  tests: no error check when setting global 'fdm' to empty value
Solution: Also check global 'fdm' value for being empty (Milly).

closes: vim/vim#15916

https://github.com/vim/vim/commit/142cad1f88d1d3aa34b6050151e620b66185112e

Co-authored-by: Milly <milly.ca@gmail.com>


#### vim-patch:9.1.0803: tests: no error check when setting global 'isk'

Problem:  tests: no error check when setting global 'isk'
Solution: also parse and check global 'isk' value (Milly)

closes: vim/vim#15915

https://github.com/vim/vim/commit/5e7a6a4a106923e45c67dae6810e4c9753f88025

Co-authored-by: Milly <milly.ca@gmail.com>


#### vim-patch:9.1.0804: tests: no error check when setting global 'cc'

Problem:  tests: no error check when setting global 'cc'
Solution: also parse and check global 'cc' value (Milly)

closes: vim/vim#15914

https://github.com/vim/vim/commit/a441a3eaabbfc14b4772e07ecbecaaff3bd06a58

Co-authored-by: Milly <milly.ca@gmail.com>


#### vim-patch:9.1.0806: tests: no error check when setting global 'briopt'

Problem:  tests: no error check when setting global 'briopt'
Solution: also parse and check global 'briopt' value (Milly)

closes: vim/vim#15911

https://github.com/vim/vim/commit/b38700ac81d90a652e5c8495056dd78df5babdde

Co-authored-by: Milly <milly.ca@gmail.com>


#### vim-patch:9.1.0812: Coverity warns about dereferencing NULL ptr

Problem:  Coverity warns about dereferencing NULL ptr
          in check_colorcolumn()
Solution: verify that wp is not null before accessing it

related: vim/vim#15914

https://github.com/vim/vim/commit/d0809869d6445faecd323fb33dc271d8c74a94fb

Co-authored-by: Christian Brabandt <cb@256bit.org>