### PR TITLE
fix(lsp.buf): use correct offset_encoding for all requests

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -854,7 +854,7 @@ api.nvim_create_autocmd('VimLeavePre', {
 ---
 ---@param bufnr (integer) Buffer handle, or 0 for current.
 ---@param method (string) LSP method name
----@param params table|nil Parameters to send to the server
+---@param params? table|(fun(client: vim.lsp.Client, bufnr: integer): table?) Parameters to send to the server
 ---@param handler? lsp.Handler See |lsp-handler|
 ---       If nil, follows resolution strategy defined in |lsp-handler-configuration|
 ---@param on_unsupported? fun()
@@ -879,7 +879,8 @@ function lsp.buf_request(bufnr, method, params, handler, on_unsupported)
     if client.supports_method(method, { bufnr = bufnr }) then
       method_supported = true
 
-      local request_success, request_id = client.request(method, params, handler, bufnr)
+      local cparams = type(params) == 'function' and params(client, bufnr) or params --[[@as table?]]
+      local request_success, request_id = client.request(method, cparams, handler, bufnr)
       -- This could only fail if the client shut down in the time since we looked
       -- it up and we did the request, which should be rare.
       if request_success then

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -7,26 +7,6 @@ local ms = require('vim.lsp.protocol').Methods
 
 local M = {}
 
---- Sends an async request to all active clients attached to the current
---- buffer.
----
----@param method (string) LSP method name
----@param params (table|nil) Parameters to send to the server
----@param handler lsp.Handler? See |lsp-handler|. Follows |lsp-handler-resolution|
----
----@return table<integer, integer> client_request_ids Map of client-id:request-id pairs
----for all successful requests.
----@return function _cancel_all_requests Function which can be used to
----cancel all the requests. You could instead
----iterate all clients and call their `cancel_request()` methods.
----
----@see |vim.lsp.buf_request()|
-local function request(method, params, handler)
-  validate('method', method, 'string')
-  validate('handler', handler, 'function', true)
-  return lsp.buf_request(0, method, params, handler)
-end
-
 --- Displays hover information about the symbol under the cursor in a floating
 --- window. The window will be dismissed on cursor move.
 --- Calling the function twice will jump into the floating window
@@ -48,7 +28,7 @@ local function request_with_opts(name, params, opts)
       handler(err, result, ctx, vim.tbl_extend('force', config or {}, opts))
     end
   end
-  request(name, params, req_handler)
+  lsp.buf_request(0, name, params, req_handler)
 end
 
 ---@param method string
@@ -187,7 +167,7 @@ end
 --- floating window.
 function M.signature_help()
   local params = util.make_position_params()
-  request(ms.textDocument_signatureHelp, params)
+  lsp.buf_request(0, ms.textDocument_signatureHelp, params)
 end
 
 --- Retrieves the completion items at the current cursor position. Can only be
@@ -201,7 +181,7 @@ end
 function M.completion(context)
   local params = util.make_position_params()
   params.context = context
-  return request(ms.textDocument_completion, params)
+  return lsp.buf_request(0, ms.textDocument_completion, params)
 end
 
 ---@param bufnr integer
@@ -609,7 +589,7 @@ end
 local function call_hierarchy(method)
   local params = util.make_position_params()
   --- @param result lsp.CallHierarchyItem[]?
-  request(ms.textDocument_prepareCallHierarchy, params, function(err, result, ctx)
+  lsp.buf_request(0, ms.textDocument_prepareCallHierarchy, params, function(err, result, ctx)
     if err then
       vim.notify(err.message, vim.log.levels.WARN)
       return
@@ -794,7 +774,7 @@ end
 ---         |hl-LspReferenceWrite|
 function M.document_highlight()
   local params = util.make_position_params()
-  request(ms.textDocument_documentHighlight, params)
+  lsp.buf_request(0, ms.textDocument_documentHighlight, params)
 end
 
 --- Removes document highlights from current buffer.
@@ -1063,7 +1043,7 @@ function M.execute_command(command_params)
     arguments = command_params.arguments,
     workDoneToken = command_params.workDoneToken,
   }
-  request(ms.workspace_executeCommand, command_params)
+  lsp.buf_request(0, ms.workspace_executeCommand, command_params)
 end
 
 return M

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -12,6 +12,8 @@ end
 
 local sysname = vim.uv.os_uname().sysname
 
+--- @class vim.lsp.protocol.constants
+--- @nodoc
 local constants = {
   --- @enum lsp.DiagnosticSeverity
   DiagnosticSeverity = {
@@ -314,7 +316,9 @@ local constants = {
   },
 }
 
--- Protocol for the Microsoft Language Server Protocol (mslsp)
+--- Protocol for the Microsoft Language Server Protocol (mslsp)
+--- @class vim.lsp.protocol : vim.lsp.protocol.constants
+--- @nodoc
 local protocol = {}
 
 --- @diagnostic disable:no-unknown

--- a/scripts/gen_vimdoc.lua
+++ b/scripts/gen_vimdoc.lua
@@ -289,6 +289,9 @@ local config = {
     },
     fn_xform = function(fun)
       fun.name = fun.name:gsub('result%.', '')
+      if fun.module == 'vim.lsp.protocol' then
+        fun.classvar = nil
+      end
     end,
     section_fmt = function(name)
       if name:lower() == 'lsp' then


### PR DESCRIPTION
Problem:

`lsp.buf_request` send the same params to all servers and many
calls to this pass PositionalParams which depends on the clients
offset_encoding. This can result with incorrect params being sent
to a server.

Solution:

`lsp.buf_request` `params` argument can now be passed as a function
which takes the client as the first argument. This is used in
lsp/buf.lua to construct correct params for each client request.