### PR TITLE
feat(lsp): deprecate vim.lsp.buf.completion

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -46,6 +46,7 @@ TREESITTER
 LSP
 • *vim.lsp.util.jump_to_location*
 • *vim.lsp.buf.execute_command*		Use |Client:exec_cmd()| instead.
+• *vim.lsp.buf.completion*		Use |vim.lsp.completion.trigger()| instead.
 
 ------------------------------------------------------------------------------
 DEPRECATED IN 0.10					*deprecated-0.10*

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1309,19 +1309,6 @@ code_action({opts})                                *vim.lsp.buf.code_action()*
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction
       • vim.lsp.protocol.CodeActionTriggerKind
 
-completion({context})                               *vim.lsp.buf.completion()*
-    Retrieves the completion items at the current cursor position. Can only be
-    called in Insert mode.
-
-    Parameters: ~
-      • {context}  (`table`) (context support not yet implemented) Additional
-                   information about the context in which a completion was
-                   triggered (how it was triggered, and by which trigger
-                   character, if applicable)
-
-    See also: ~
-      • vim.lsp.protocol.CompletionTriggerKind
-
 declaration({opts})                                *vim.lsp.buf.declaration()*
     Jumps to the declaration of the symbol under the cursor.
 

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -191,6 +191,7 @@ function M.signature_help()
   lsp.buf_request(0, ms.textDocument_signatureHelp, client_positional_params())
 end
 
+--- @deprecated
 --- Retrieves the completion items at the current cursor position. Can only be
 --- called in Insert mode.
 ---
@@ -200,6 +201,7 @@ end
 ---
 ---@see vim.lsp.protocol.CompletionTriggerKind
 function M.completion(context)
+  vim.depends('vim.lsp.buf.completion', 'vim.lsp.commpletion.trigger', '0.12')
   return lsp.buf_request(
     0,
     ms.textDocument_completion,

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -317,6 +317,7 @@ M[ms.textDocument_formatting] = function(_, result, ctx, _)
   util.apply_text_edits(result, ctx.bufnr, client.offset_encoding)
 end
 
+--- @deprecated
 --- @see # https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_completion
 M[ms.textDocument_completion] = function(_, result, _, _)
   if vim.tbl_isempty(result or {}) then


### PR DESCRIPTION
Followup to #30929

Use `vim.lsp.completion.trigger()` instead'
