### PR TITLE
feat(lsp)!: support filter and on_result opts for lsp.completion.get

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1637,6 +1637,14 @@ Lua module: vim.lsp.completion                                *lsp-completion*
       • {convert}?      (`fun(item: lsp.CompletionItem): table`) Transforms an
                         LSP CompletionItem to |complete-items|.
 
+*vim.lsp.completion.get.opts*
+
+    Fields: ~
+      • {convert}?    (`fun(item: lsp.CompletionItem): table`)
+      • {filter}?     (`fun(prefix: string, item: lsp.CompletionItem): boolean`)
+      • {on_result}?  (`fun(startcol: integer, matches: table[])`) defaults to
+                      vim.fn.complete
+
 
                                                  *vim.lsp.completion.enable()*
 enable({enable}, {client_id}, {bufnr}, {opts})
@@ -1650,8 +1658,12 @@ enable({enable}, {client_id}, {bufnr}, {opts})
       • {opts}       (`vim.lsp.completion.BufferOpts?`) See
                      |vim.lsp.completion.BufferOpts|.
 
-trigger()                                       *vim.lsp.completion.trigger()*
+get({opts})                                         *vim.lsp.completion.get()*
     Trigger LSP completion in the current buffer.
+
+    Parameters: ~
+      • {opts}  (`vim.lsp.completion.get.opts?`) See
+                |vim.lsp.completion.get.opts|.
 
 
 ==============================================================================

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -531,7 +531,7 @@ describe('vim.lsp.completion: protocol', function()
     exec_lua(function()
       local win = vim.api.nvim_get_current_win()
       vim.api.nvim_win_set_cursor(win, pos)
-      vim.lsp.completion.trigger()
+      vim.lsp.completion.get()
     end)
 
     retry(nil, nil, function()


### PR DESCRIPTION
Allows to implement custom completion lookups like the following, which
shows only snippets, and auto-expands if there is only a single match:

    ---@param item lsp.CompletionItem
    local function filter(_, item)
      local kind = vim.lsp.protocol.CompletionItemKind[item.kind] or ''
      return kind == 'Snippet'
    end

    local function on_result(startcol, matches)
      if #matches == 0 then
        return exit()
      else
        vim.fn.complete(startcol, matches)
        if #matches == 1 then
          api.nvim_feedkeys(
            api.nvim_replace_termcodes("<C-n>", true, false, true), 'n', true)
          api.nvim_feedkeys(
            api.nvim_replace_termcodes("<CR>", true, false, true), 'm', true)
        end
      end
    end
    vim.lsp.completion.get({ filter = filter, on_result = vim.schedule_wrap(on_result) })


---

I'm not sure about the rename

TODO:

- [ ] update remaining trigger references or revert rename
- [ ] maybe some additional tests?
