### PR TITLE
docs: expose typing for vim.* modules

### DIFF
--- a/runtime/lua/vim/F.lua
+++ b/runtime/lua/vim/F.lua
@@ -1,3 +1,4 @@
+---@class vim.F
 local F = {}
 
 --- Returns the first argument which is not nil.

--- a/runtime/lua/vim/_meta.lua
+++ b/runtime/lua/vim/_meta.lua
@@ -7,27 +7,48 @@ vim.uv = ...
 
 --- The following modules are loaded specially in _init_packages.lua
 
+---@type vim.F
 vim.F = require('vim.F')
+---@type vim._watch
 vim._watch = require('vim._watch')
+---@type vim.diagnostic
 vim.diagnostic = require('vim.diagnostic')
+---@type vim.filetype
 vim.filetype = require('vim.filetype')
+---@type vim.fs
 vim.fs = require('vim.fs')
+---@type vim.func
 vim.func = require('vim.func')
+---@type vim.glob
 vim.glob = require('vim.glob')
+---@type vim.health
 vim.health = require('vim.health')
+---@type vim.hl
 vim.hl = require('vim.hl')
+---@type IterMod
 vim.iter = require('vim.iter')
+---@type vim.keymap
 vim.keymap = require('vim.keymap')
+---@type vim.loader
 vim.loader = require('vim.loader')
+---@type vim.lsp
 vim.lsp = require('vim.lsp')
+---@type vim.re
 vim.re = require('vim.re')
+---@type vim.secure
 vim.secure = require('vim.secure')
+---@type vim.snippet
 vim.snippet = require('vim.snippet')
+---@type vim.text
 vim.text = require('vim.text')
+---@type vim.treesitter
 vim.treesitter = require('vim.treesitter')
+---@type vim.ui
 vim.ui = require('vim.ui')
+---@type vim.version
 vim.version = require('vim.version')
 
+---@type vim.uri
 local uri = require('vim.uri')
 
 vim.uri_from_fname = uri.uri_from_fname
@@ -35,4 +56,5 @@ vim.uri_from_bufnr = uri.uri_from_bufnr
 vim.uri_to_fname = uri.uri_to_fname
 vim.uri_to_bufnr = uri.uri_to_bufnr
 
+---@type vim.provider
 vim.provider = require('vim.provider')

--- a/runtime/lua/vim/_watch.lua
+++ b/runtime/lua/vim/_watch.lua
@@ -1,5 +1,6 @@
 local uv = vim.uv
 
+---@class vim._watch
 local M = {}
 
 --- @enum vim._watch.FileChangeType

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1,5 +1,6 @@
 local api, if_nil = vim.api, vim.F.if_nil
 
+---@class vim.diagnostic
 local M = {}
 
 --- [diagnostic-structure]()

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1,6 +1,7 @@
 local api = vim.api
 local fn = vim.fn
 
+---@class vim.filetype
 local M = {}
 
 --- @alias vim.filetype.mapfn fun(path:string,bufnr:integer, ...):string?, fun(b:integer)?

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -1,5 +1,6 @@
 local uv = vim.uv
 
+---@class vim.fs
 local M = {}
 
 -- Can't use `has('win32')` because the `nvim -ll` test runner doesn't support `vim.fn` yet.

--- a/runtime/lua/vim/func.lua
+++ b/runtime/lua/vim/func.lua
@@ -1,3 +1,4 @@
+---@class vim.func
 local M = {}
 
 -- TODO(lewis6991): Private for now until:

--- a/runtime/lua/vim/glob.lua
+++ b/runtime/lua/vim/glob.lua
@@ -2,6 +2,7 @@ local lpeg = vim.lpeg
 local P, S, V, R, B = lpeg.P, lpeg.S, lpeg.V, lpeg.R, lpeg.B
 local C, Cc, Ct, Cf, Cmt = lpeg.C, lpeg.Cc, lpeg.Ct, lpeg.Cf, lpeg.Cmt
 
+---@class vim.glob
 local M = {}
 
 local pathsep = P('/')

--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -86,6 +86,7 @@
 ---         return M
 ---</pre>
 
+---@class vim.health
 local M = {}
 
 local s_output = {} ---@type string[]

--- a/runtime/lua/vim/hl.lua
+++ b/runtime/lua/vim/hl.lua
@@ -1,5 +1,6 @@
 local api = vim.api
 
+---@class vim.hl
 local M = {}
 
 --- Table with default priorities used for highlighting:

--- a/runtime/lua/vim/keymap.lua
+++ b/runtime/lua/vim/keymap.lua
@@ -1,3 +1,4 @@
+---@class vim.keymap
 local keymap = {}
 
 --- Table of |:map-arguments|.

--- a/runtime/lua/vim/loader.lua
+++ b/runtime/lua/vim/loader.lua
@@ -5,6 +5,7 @@ local uri_encode = vim.uri_encode --- @type function
 --- @type (fun(modename: string): fun()|string)[]
 local loaders = package.loaders
 
+---@class vim.loader
 local M = {}
 
 ---@alias CacheHash {mtime: {nsec: integer, sec: integer}, size: integer, type?: string}

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1,7 +1,27 @@
 local api = vim.api
 local validate = vim.validate
 
-local lsp = vim._defer_require('vim.lsp', {
+---@class vim.lsp
+---@field _changetracking vim.lsp._changetracking
+---@field _dynamic lsp.DynamicCapabilities
+---@field _snippet_grammar vim.lsp._snippet_grammar
+---@field _tagfunc function
+---@field _watchfiles vim.lsp._watchfiles
+---@field buf vim.lsp.buf
+---@field client vim.lsp.Client
+---@field codelens vim.lsp.codelens
+---@field completion vim.lsp.completion
+---@field diagnostic vim.lsp.diagnostic
+---@field handlers vim.lsp.handlers
+---@field inlay_hint vim.lsp.inlay_hint
+---@field log vim.lsp.log
+---@field protocol vim.lsp.protocol
+---@field rpc vim.lsp.rpc
+---@field semantic_tokens vim.lsp.semantic_tokens
+---@field util vim.lsp.util
+local lsp
+
+lsp = vim._defer_require('vim.lsp', {
   _changetracking = ..., --- @module 'vim.lsp._changetracking'
   _dynamic = ..., --- @module 'vim.lsp._dynamic'
   _snippet_grammar = ..., --- @module 'vim.lsp._snippet_grammar'

--- a/runtime/lua/vim/lsp/_changetracking.lua
+++ b/runtime/lua/vim/lsp/_changetracking.lua
@@ -5,6 +5,7 @@ local util = require('vim.lsp.util')
 local api = vim.api
 local uv = vim.uv
 
+---@class vim.lsp._changetracking
 local M = {}
 
 --- LSP has 3 different sync modes:

--- a/runtime/lua/vim/lsp/_snippet_grammar.lua
+++ b/runtime/lua/vim/lsp/_snippet_grammar.lua
@@ -4,6 +4,7 @@ local lpeg = vim.lpeg
 local P, S, R, V = lpeg.P, lpeg.S, lpeg.R, lpeg.V
 local C, Cg, Ct = lpeg.C, lpeg.Cg, lpeg.Ct
 
+---@class vim.lsp._snippet_grammar
 local M = {}
 
 local alpha = R('az', 'AZ')

--- a/runtime/lua/vim/lsp/_watchfiles.lua
+++ b/runtime/lua/vim/lsp/_watchfiles.lua
@@ -5,6 +5,7 @@ local protocol = require('vim.lsp.protocol')
 local ms = protocol.Methods
 local lpeg = vim.lpeg
 
+---@class vim.lsp._watchfiles
 local M = {}
 
 if vim.fn.has('win32') == 1 or vim.fn.has('mac') == 1 then

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -5,6 +5,7 @@ local util = require('vim.lsp.util')
 local npcall = vim.F.npcall
 local ms = require('vim.lsp.protocol').Methods
 
+---@class vim.lsp.buf
 local M = {}
 
 --- @param params? table

--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -2,6 +2,7 @@ local util = require('vim.lsp.util')
 local log = require('vim.lsp.log')
 local ms = require('vim.lsp.protocol').Methods
 local api = vim.api
+---@class vim.lsp.codelens
 local M = {}
 
 --- bufnr → true|nil

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -1,3 +1,4 @@
+---@class vim.lsp.completion
 local M = {}
 
 local api = vim.api

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -3,6 +3,7 @@ local ms = protocol.Methods
 
 local api = vim.api
 
+---@class vim.lsp.diagnostic
 local M = {}
 
 local augroup = api.nvim_create_augroup('vim_lsp_diagnostic', {})

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -5,7 +5,8 @@ local util = require('vim.lsp.util')
 local api = vim.api
 local completion = require('vim.lsp.completion')
 
---- @type table<string,lsp.Handler>
+---@class vim.lsp.handlers
+---@field [string] lsp.Handler
 local M = {}
 
 -- FIXME: DOC: Expose in vimdocs

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -2,6 +2,7 @@ local util = require('vim.lsp.util')
 local log = require('vim.lsp.log')
 local ms = require('vim.lsp.protocol').Methods
 local api = vim.api
+---@class vim.lsp.inlay_hint
 local M = {}
 
 ---@class (private) vim.lsp.inlay_hint.globalstate Global state for inlay hints

--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -1,5 +1,6 @@
 -- Logger for language client plugin.
 
+---@class vim.lsp.log
 local log = {}
 
 local log_levels = vim.log.levels
@@ -169,7 +170,7 @@ end
 
 --- Checks whether the level is sufficient for logging.
 ---@param level integer log level
----@return bool : true if would log, false if not
+---@return boolean : true if would log, false if not
 function log.should_log(level)
   return level >= current_log_level
 end

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -623,6 +623,7 @@ end
 ---@enum vim.lsp.protocol.Methods
 ---@see https://microsoft.github.io/language-server-protocol/specification/#metaModel
 --- LSP method names.
+---@type table<string, string>
 protocol.Methods = {
   --- A request to resolve the incoming calls for a given `CallHierarchyItem`.
   --- @since 3.16.0

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -126,6 +126,7 @@ local function request_parser_loop()
   end
 end
 
+---@class vim.lsp.rpc
 local M = {}
 
 --- Mapping of error codes used by the client

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -544,6 +544,7 @@ function STHighlighter:reset_timer()
   end
 end
 
+---@class vim.lsp.semantic_tokens
 local M = {}
 
 --- Start the semantic token highlighting engine for the given buffer with the

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -4,6 +4,7 @@ local api = vim.api
 local list_extend = vim.list_extend
 local uv = vim.uv
 
+---@class vim.lsp.util
 local M = {}
 
 local default_border = {

--- a/runtime/lua/vim/provider.lua
+++ b/runtime/lua/vim/provider.lua
@@ -1,4 +1,10 @@
-local M = vim._defer_require('vim.provider', {
+---@class vim.provider
+---@field perl vim.provider.perl
+---@field python vim.provider.python
+---@field ruby vim.provider.ruby
+local M
+
+M = vim._defer_require('vim.provider', {
   perl = ..., --- @module 'vim.provider.perl'
   python = ..., --- @module 'vim.provider.python'
   ruby = ..., --- @module 'vim.provider.ruby'

--- a/runtime/lua/vim/provider/perl.lua
+++ b/runtime/lua/vim/provider/perl.lua
@@ -1,3 +1,4 @@
+---@class vim.provider.perl
 local M = {}
 local s_err ---@type string?
 local s_host ---@type string?

--- a/runtime/lua/vim/provider/python.lua
+++ b/runtime/lua/vim/provider/python.lua
@@ -1,3 +1,4 @@
+---@class vim.provider.python
 local M = {}
 local min_version = '3.7'
 local s_err ---@type string?

--- a/runtime/lua/vim/provider/ruby.lua
+++ b/runtime/lua/vim/provider/ruby.lua
@@ -1,3 +1,4 @@
+---@class vim.provider.ruby
 local M = {}
 local s_err ---@type string?
 local s_host ---@type string?

--- a/runtime/lua/vim/re.lua
+++ b/runtime/lua/vim/re.lua
@@ -259,6 +259,7 @@ end
 
 
 -- exported names
+---@class vim.re
 local re = {
   compile = compile,
   match = match,

--- a/runtime/lua/vim/secure.lua
+++ b/runtime/lua/vim/secure.lua
@@ -1,3 +1,4 @@
+---@class vim.secure
 local M = {}
 
 --- Reads trust database from $XDG_STATE_HOME/nvim/trust.

--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -306,6 +306,7 @@ function Session:set_group_gravity(index, right_gravity)
   end
 end
 
+---@class vim.snippet
 local M = { session = nil }
 
 --- Displays the choices for the given tabstop as completion items.

--- a/runtime/lua/vim/text.lua
+++ b/runtime/lua/vim/text.lua
@@ -1,5 +1,6 @@
 -- Text processing functions.
 
+---@class vim.text
 local M = {}
 
 --- Hex encode a string.

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -3,7 +3,18 @@ local api = vim.api
 ---@type table<integer,vim.treesitter.LanguageTree>
 local parsers = setmetatable({}, { __mode = 'v' })
 
-local M = vim._defer_require('vim.treesitter', {
+---@class vim.treesitter
+---@field _fold vim.treesitter._fold
+---@field _query_linter vim.treesitter._query_linter
+---@field _range vim.treesitter._range
+---@field dev vim.treesitter.dev
+---@field highlighter vim.treesitter.highlighter
+---@field language vim.treesitter.language
+---@field languagetree vim.treesitter.LanguageTree
+---@field query vim.treesitter.query
+local M
+
+M = vim._defer_require('vim.treesitter', {
   _fold = ..., --- @module 'vim.treesitter._fold'
   _query_linter = ..., --- @module 'vim.treesitter._query_linter'
   _range = ..., --- @module 'vim.treesitter._range'

--- a/runtime/lua/vim/treesitter/_fold.lua
+++ b/runtime/lua/vim/treesitter/_fold.lua
@@ -216,6 +216,7 @@ local function compute_folds_levels(bufnr, info, srow, erow, parse_injections)
   end
 end
 
+---@class vim.treesitter._fold
 local M = {}
 
 ---@type table<integer,TS.FoldInfo>

--- a/runtime/lua/vim/treesitter/_query_linter.lua
+++ b/runtime/lua/vim/treesitter/_query_linter.lua
@@ -2,6 +2,7 @@ local api = vim.api
 
 local namespace = api.nvim_create_namespace('vim.treesitter.query_linter')
 
+---@class vim.treesitter._query_linter
 local M = {}
 
 --- @class QueryLinterNormalizedOpts

--- a/runtime/lua/vim/treesitter/_range.lua
+++ b/runtime/lua/vim/treesitter/_range.lua
@@ -1,5 +1,6 @@
 local api = vim.api
 
+---@class vim.treesitter._range
 local M = {}
 
 ---@class Range2

--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -1,5 +1,6 @@
 local api = vim.api
 
+---@class vim.treesitter.dev
 local M = {}
 
 ---@class (private) vim.treesitter.dev.TSTreeView

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -1,5 +1,6 @@
 local api = vim.api
 
+---@class vim.treesitter.language
 local M = {}
 
 ---@type table<string,string>

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -2,6 +2,7 @@ local api = vim.api
 local language = require('vim.treesitter.language')
 local memoize = vim.func._memoize
 
+---@class vim.treesitter.query
 local M = {}
 
 ---@nodoc

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -1,3 +1,4 @@
+---@class vim.ui
 local M = {}
 
 --- Prompts the user to pick from a list of items, allowing arbitrary (potentially asynchronous)

--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -3,6 +3,7 @@
 -- https://tools.ietf.org/html/rfc2732
 -- https://tools.ietf.org/html/rfc2396
 
+---@class vim.uri
 local M = {}
 local sbyte = string.byte
 local schar = string.char

--- a/runtime/lua/vim/version.lua
+++ b/runtime/lua/vim/version.lua
@@ -52,6 +52,7 @@
 --- 1.2 - 2.3.0       is 1.2.0 - 2.3.0
 --- ```
 
+---@class vim.version
 local M = {}
 
 ---@nodoc

--- a/scripts/gen_lsp.lua
+++ b/scripts/gen_lsp.lua
@@ -64,6 +64,7 @@ local function gen_methods(protocol)
     '---@enum vim.lsp.protocol.Methods',
     '---@see https://microsoft.github.io/language-server-protocol/specification/#metaModel',
     '--- LSP method names.',
+    '---@type table<string, string>',
     'protocol.Methods = {',
   }
   local indent = (' '):rep(2)


### PR DESCRIPTION
**Problem:** No types are exposed for the vim.* modules (except for `vim.uv`)!! Some of these types are provided through `cmp-nvim-lua` but they are just stubs without true documentation information (and in my opinion these types should be provided by core itself anyway).

**Solution:** Create classes for the returned objects as needed and mark the modules as these class types in `_meta.lua`.

#### Before
![image](https://github.com/user-attachments/assets/1fc45c39-a7e3-42ca-9da3-d1993a76cdb2) (no autocompletion either)

#### After
![image](https://github.com/user-attachments/assets/321f7cec-a770-4fe8-bf94-37f9d61847b8) (also gets autocompleted)
