### PR TITLE
vim-patch:9.1.0814: mapset() may remove unrelated mapping

### DIFF
--- a/src/nvim/mapping.h
+++ b/src/nvim/mapping.h
@@ -19,9 +19,10 @@
 
 /// Used for the first argument of do_map()
 enum {
-  MAPTYPE_MAP     = 0,
-  MAPTYPE_UNMAP   = 1,
-  MAPTYPE_NOREMAP = 2,
+  MAPTYPE_MAP       = 0,
+  MAPTYPE_UNMAP     = 1,
+  MAPTYPE_NOREMAP   = 2,
+  MAPTYPE_UNMAP_LHS = 3,
 };
 
 /// Adjust chars in a language according to 'langmap' option.

--- a/test/old/testdir/test_map_functions.vim
+++ b/test/old/testdir/test_map_functions.vim
@@ -527,6 +527,25 @@ func Test_map_restore_negative_sid()
   call delete('Xresult')
 endfunc
 
+" Check that restoring a mapping doesn't remove a mapping whose {rhs} matches
+" the restored mapping's {lhs}.
+func Test_map_restore_with_rhs_match_lhs()
+  nnoremap <F2> <F3>
+  nnoremap <F3> <F4>
+  call assert_equal('<F3>', maparg('<F2>', 'n'))
+  call assert_equal('<F4>', maparg('<F3>', 'n'))
+  let d = maparg('<F3>', 'n', v:false, v:true)
+  nunmap <F3>
+  call assert_equal('<F3>', maparg('<F2>', 'n'))
+  call assert_equal('', maparg('<F3>', 'n'))
+  call mapset(d)
+  call assert_equal('<F3>', maparg('<F2>', 'n'))
+  call assert_equal('<F4>', maparg('<F3>', 'n'))
+
+  nunmap <F2>
+  nunmap <F3>
+endfunc
+
 func Test_maplist()
   new
   func s:ClearMappingsAbbreviations()


### PR DESCRIPTION
#### vim-patch:9.1.0814: mapset() may remove unrelated mapping

Problem:  mapset() may remove unrelated mapping whose {rhs} matches the
          restored mapping's {lhs}.
Solution: only match by {lhs} when unmapping for mapset() (zeertzjq).

closes: vim/vim#15935

https://github.com/vim/vim/commit/fdf135a0525746cc0ff85bed2fbbde320ddb6d0d
