### PR TITLE
refactor(lsp): deprecate get_client_by_id

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -783,18 +783,10 @@ get_buffers_by_client_id({client_id})
     Return: ~
         (`integer[]`) buffers list of buffer ids
 
-get_client_by_id({client_id})                     *vim.lsp.get_client_by_id()*
-    Gets a client by id, or nil if the id is invalid. The returned client may
-    not yet be fully initialized.
-
-    Parameters: ~
-      • {client_id}  (`integer`) client id
-
-    Return: ~
-        (`vim.lsp.Client?`) client rpc object
-
 get_clients({filter})                                  *vim.lsp.get_clients()*
     Get active clients.
+
+    The returned client(s) may not yet be fully initialized.
 
     Parameters: ~
       • {filter}  (`table?`) Key-value pairs used to filter the returned
@@ -909,9 +901,8 @@ start_client({config})                                *vim.lsp.start_client()*
                   |vim.lsp.ClientConfig|.
 
     Return (multiple): ~
-        (`integer?`) client_id |vim.lsp.get_client_by_id()| Note: client may
-        not be fully initialized. Use `on_init` to do any actions once the
-        client has been initialized.
+        (`integer?`) client_id Note: client may not be fully initialized. Use
+        `on_init` to do any actions once the client has been initialized.
         (`string?`) Error message, if any
 
 status()                                                    *vim.lsp.status()*

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -447,9 +447,8 @@ end
 
 --- Starts and initializes a client with the given configuration.
 --- @param config vim.lsp.ClientConfig Configuration for the server.
---- @return integer? client_id |vim.lsp.get_client_by_id()| Note: client may not be
----         fully initialized. Use `on_init` to do any actions once
----         the client has been initialized.
+--- @return integer? client_id Note: client may not be fully initialized. Use `on_init` to do any
+---         actions once the client has been initialized.
 --- @return string? # Error message, if any
 function lsp.start_client(config)
   local ok, res = pcall(require('vim.lsp.client').create, config)
@@ -639,7 +638,7 @@ function lsp.buf_attach_client(bufnr, client_id)
     return false
   end
 
-  local client = lsp.get_client_by_id(client_id)
+  local client = lsp.get_clients({ id = client_id })[1]
   if not client then
     return false
   end
@@ -695,6 +694,8 @@ function lsp.buf_is_attached(bufnr, client_id)
   return lsp.get_clients({ bufnr = bufnr, id = client_id, _uninitialized = true })[1] ~= nil
 end
 
+--- @deprecated
+--- Use `get_clients({ id = client_id })[1]`
 --- Gets a client by id, or nil if the id is invalid.
 --- The returned client may not yet be fully initialized.
 ---
@@ -766,6 +767,8 @@ end
 --- @field package _uninitialized? boolean
 
 --- Get active clients.
+---
+--- The returned client(s) may not yet be fully initialized.
 ---
 ---@param filter? vim.lsp.get_clients.Filter
 ---@return vim.lsp.Client[]: List of |vim.lsp.Client| objects

--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -46,7 +46,7 @@ local function execute_lens(lens, bufnr, client_id)
   local line = lens.range.start.line
   api.nvim_buf_clear_namespace(bufnr, namespaces[client_id], line, line + 1)
 
-  local client = vim.lsp.get_client_by_id(client_id)
+  local client = vim.lsp.get_clients({ id = client_id })[1]
   assert(client, 'Client is required to execute lens, client_id=' .. client_id)
   client:exec_cmd(lens.command, { bufnr = bufnr }, function(...)
     vim.lsp.handlers[ms.workspace_executeCommand](...)
@@ -225,7 +225,7 @@ local function resolve_lenses(lenses, bufnr, client_id, callback)
     end
   end
   local ns = namespaces[client_id]
-  local client = vim.lsp.get_client_by_id(client_id)
+  local client = vim.lsp.get_clients({ id = client_id })[1]
   for _, lens in pairs(lenses or {}) do
     if lens.command then
       countdown()

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -397,7 +397,7 @@ local function request(clients, bufnr, win, callback)
 
   return function()
     for client_id, request_id in pairs(request_ids) do
-      local client = lsp.get_client_by_id(client_id)
+      local client = vim.lsp.get_clients({ id = client_id })[1]
       if client then
         client.cancel_request(request_id)
       end
@@ -444,7 +444,7 @@ local function trigger(bufnr, clients)
       local result = response.result
       if result then
         Context.isIncomplete = Context.isIncomplete or result.isIncomplete
-        local client = lsp.get_client_by_id(client_id)
+        local client = vim.lsp.get_clients({ id = client_id })[1]
         local encoding = client and client.offset_encoding or 'utf-16'
         local client_matches
         client_matches, server_start_boundary = M._convert_results(
@@ -523,7 +523,7 @@ local function on_complete_done()
 
   Context:reset()
 
-  local client = lsp.get_client_by_id(client_id)
+  local client = vim.lsp.get_clients({ id = client_id })[1]
   if not client then
     return
   end
@@ -636,7 +636,7 @@ local function enable_completions(client_id, bufnr, opts)
   end
 
   if not buf_handle.clients[client_id] then
-    local client = lsp.get_client_by_id(client_id)
+    local client = vim.lsp.get_clients({ id = client_id })[1]
     assert(client, 'invalid client ID')
 
     -- Add the new client to the buffer's clients.

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -84,7 +84,7 @@ end
 ---@return vim.Diagnostic[]
 local function diagnostic_lsp_to_vim(diagnostics, bufnr, client_id)
   local buf_lines = get_buf_lines(bufnr)
-  local client = vim.lsp.get_client_by_id(client_id)
+  local client = vim.lsp.get_clients({ id = client_id })[1]
   local offset_encoding = client and client.offset_encoding or 'utf-16'
   --- @param diagnostic lsp.Diagnostic
   --- @return vim.Diagnostic
@@ -179,7 +179,7 @@ local _client_pull_namespaces = {}
 function M.get_namespace(client_id, is_pull)
   vim.validate('client_id', client_id, 'number')
 
-  local client = vim.lsp.get_client_by_id(client_id)
+  local client = vim.lsp.get_clients({ id = client_id })[1]
   if is_pull then
     local server_id =
       vim.tbl_get((client or {}).server_capabilities, 'diagnosticProvider', 'identifier')

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -26,7 +26,7 @@ end
 ---@param params lsp.ProgressParams
 ---@param ctx lsp.HandlerContext
 M[ms.dollar_progress] = function(_, params, ctx)
-  local client = vim.lsp.get_client_by_id(ctx.client_id)
+  local client = vim.lsp.get_clients({ id = ctx.client_id })[1]
   if not client then
     err_message('LSP[id=', tostring(ctx.client_id), '] client has shut down during progress update')
     return vim.NIL
@@ -62,7 +62,7 @@ end
 ---@param result lsp.WorkDoneProgressCreateParams
 ---@param ctx lsp.HandlerContext
 M[ms.window_workDoneProgress_create] = function(_, result, ctx)
-  local client = vim.lsp.get_client_by_id(ctx.client_id)
+  local client = vim.lsp.get_clients({ id = ctx.client_id })[1]
   if not client then
     err_message('LSP[id=', tostring(ctx.client_id), '] client has shut down during progress update')
     return vim.NIL
@@ -111,7 +111,7 @@ end
 --- @param result lsp.RegistrationParams
 M[ms.client_registerCapability] = function(_, result, ctx)
   local client_id = ctx.client_id
-  local client = assert(vim.lsp.get_client_by_id(client_id))
+  local client = assert(vim.lsp.get_clients({ id = client_id })[1])
 
   client.dynamic_capabilities:register(result.registrations)
   for bufnr, _ in pairs(client.attached_buffers) do
@@ -142,7 +142,7 @@ end
 --- @param result lsp.UnregistrationParams
 M[ms.client_unregisterCapability] = function(_, result, ctx)
   local client_id = ctx.client_id
-  local client = assert(vim.lsp.get_client_by_id(client_id))
+  local client = assert(vim.lsp.get_clients({ id = client_id })[1])
   client.dynamic_capabilities:unregister(result.unregisterations)
 
   for _, unreg in ipairs(result.unregisterations) do
@@ -161,7 +161,7 @@ M[ms.workspace_applyEdit] = function(_, workspace_edit, ctx)
   )
   -- TODO(ashkan) Do something more with label?
   local client_id = ctx.client_id
-  local client = assert(vim.lsp.get_client_by_id(client_id))
+  local client = assert(vim.lsp.get_clients({ id = client_id })[1])
   if workspace_edit.label then
     print('Workspace edit', workspace_edit.label)
   end
@@ -185,7 +185,7 @@ end
 --- @param result lsp.ConfigurationParams
 M[ms.workspace_configuration] = function(_, result, ctx)
   local client_id = ctx.client_id
-  local client = vim.lsp.get_client_by_id(client_id)
+  local client = vim.lsp.get_clients({ id = client_id })[1]
   if not client then
     err_message(
       'LSP[',
@@ -218,7 +218,7 @@ end
 --- @see # https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_workspaceFolders
 M[ms.workspace_workspaceFolders] = function(_, _, ctx)
   local client_id = ctx.client_id
-  local client = vim.lsp.get_client_by_id(client_id)
+  local client = vim.lsp.get_clients({ id = client_id })[1]
   if not client then
     err_message('LSP[id=', client_id, '] client has shut down after sending the message')
     return
@@ -295,7 +295,7 @@ M[ms.textDocument_rename] = function(_, result, ctx, _)
     vim.notify("Language server couldn't provide rename result", vim.log.levels.INFO)
     return
   end
-  local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
+  local client = assert(vim.lsp.get_clients({ id = ctx.client_id })[1])
   util.apply_workspace_edit(result, client.offset_encoding)
 end
 
@@ -304,7 +304,7 @@ M[ms.textDocument_rangeFormatting] = function(_, result, ctx, _)
   if not result then
     return
   end
-  local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
+  local client = assert(vim.lsp.get_clients({ id = ctx.client_id })[1])
   util.apply_text_edits(result, ctx.bufnr, client.offset_encoding)
 end
 
@@ -313,7 +313,7 @@ M[ms.textDocument_formatting] = function(_, result, ctx, _)
   if not result then
     return
   end
-  local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
+  local client = assert(vim.lsp.get_clients({ id = ctx.client_id })[1])
   util.apply_text_edits(result, ctx.bufnr, client.offset_encoding)
 end
 
@@ -424,7 +424,7 @@ function M.signature_help(_, result, ctx, config)
     end
     return
   end
-  local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
+  local client = assert(vim.lsp.get_clients({ id = ctx.client_id })[1])
   local triggers =
     vim.tbl_get(client.server_capabilities, 'signatureHelpProvider', 'triggerCharacters')
   local ft = vim.bo[ctx.bufnr].filetype
@@ -458,7 +458,7 @@ M[ms.textDocument_documentHighlight] = function(_, result, ctx, _)
     return
   end
   local client_id = ctx.client_id
-  local client = vim.lsp.get_client_by_id(client_id)
+  local client = vim.lsp.get_clients({ id = client_id })[1]
   if not client then
     return
   end
@@ -515,7 +515,7 @@ local function make_type_hierarchy_handler()
       end
       return string.format('%s %s', item.name, item.detail)
     end
-    local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
+    local client = assert(vim.lsp.get_clients({ id = ctx.client_id })[1])
     local items = {}
     for _, type_hierarchy_item in pairs(result) do
       local col = util._get_line_byte_from_position(
@@ -547,7 +547,7 @@ M[ms.window_logMessage] = function(_, result, ctx, _)
   local message_type = result.type
   local message = result.message
   local client_id = ctx.client_id
-  local client = vim.lsp.get_client_by_id(client_id)
+  local client = vim.lsp.get_clients({ id = client_id })[1]
   local client_name = client and client.name or string.format('id=%d', client_id)
   if not client then
     err_message('LSP[', client_name, '] client has shut down after sending ', message)
@@ -570,7 +570,7 @@ M[ms.window_showMessage] = function(_, result, ctx, _)
   local message_type = result.type
   local message = result.message
   local client_id = ctx.client_id
-  local client = vim.lsp.get_client_by_id(client_id)
+  local client = vim.lsp.get_clients({ id = client_id })[1]
   local client_name = client and client.name or string.format('id=%d', client_id)
   if not client then
     err_message('LSP[', client_name, '] client has shut down after sending ', message)
@@ -609,7 +609,7 @@ M[ms.window_showDocument] = function(_, result, ctx, _)
   end
 
   local client_id = ctx.client_id
-  local client = vim.lsp.get_client_by_id(client_id)
+  local client = vim.lsp.get_clients({ id = client_id })[1]
   local client_name = client and client.name or string.format('id=%d', client_id)
   if not client then
     err_message('LSP[', client_name, '] client has shut down after sending ', ctx.method)


### PR DESCRIPTION
This is WIP, wondering if there is any strong objections to this.

The `get({filter})` pattern is generally preferred and aliases to its special cases should be avoided.