### PR TITLE
docs(lsp): document alternative for vim.lsp.util.jump_to_location

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -44,7 +44,8 @@ TREESITTER
   return the descendant itself.
 
 LSP
-• *vim.lsp.util.jump_to_location*
+• *vim.lsp.util.jump_to_location*	Use |vim.lsp.util.show_document()| with
+  `{focus=true}` instead.
 • *vim.lsp.buf.execute_command*		Use |Client:exec_cmd()| instead.
 • *vim.lsp.buf.completion*		Use |vim.lsp.completion.trigger()| instead.
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -957,7 +957,7 @@ end
 
 --- Jumps to a location.
 ---
----@deprecated
+---@deprecated use `vim.lsp.util.show_document` with `{focus=true}` instead
 ---@param location lsp.Location|lsp.LocationLink
 ---@param offset_encoding 'utf-8'|'utf-16'|'utf-32'?
 ---@param reuse_win boolean? Jump to existing window if buffer is already open.


### PR DESCRIPTION
To make it easier for plugins to transition after #30877