### PR TITLE
refactor(options): make 'shellslash' and 'completeslash' no-op on POSIX

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2105,6 +2105,7 @@ void free_buf_options(buf_T *buf, bool free_p_ff)
   clear_string_option(&buf->b_p_lw);
   clear_string_option(&buf->b_p_bkc);
   clear_string_option(&buf->b_p_menc);
+  clear_string_option(&buf->b_p_csl);
 }
 
 /// Get alternate file "n".

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -536,9 +536,7 @@ struct file_buffer {
   char *b_p_cot;                ///< 'completeopt' local value
   unsigned b_cot_flags;         ///< flags for 'completeopt'
   char *b_p_cpt;                ///< 'complete'
-#ifdef BACKSLASH_IN_FILENAME
   char *b_p_csl;                ///< 'completeslash'
-#endif
   char *b_p_cfu;                ///< 'completefunc'
   Callback b_cfu_cb;            ///< 'completefunc' callback
   char *b_p_ofu;                ///< 'omnifunc'

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3151,7 +3151,6 @@ static void get_next_filename_completion(void)
 
   // May change home directory back to "~".
   tilde_replace(compl_pattern, num_matches, matches);
-#ifdef BACKSLASH_IN_FILENAME
   if (curbuf->b_p_csl[0] != NUL) {
     for (int i = 0; i < num_matches; i++) {
       char *ptr = matches[i];
@@ -3165,7 +3164,6 @@ static void get_next_filename_completion(void)
       }
     }
   }
-#endif
   ins_compl_add_matches(num_matches, matches, p_fic || p_wic);
 }
 

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -62,6 +62,9 @@ typedef struct {
   /// New value of the option.
   OptValData os_newval;
 
+  /// When set by the called function: Stop processing the option further.
+  bool os_doskip;
+
   /// Option value was checked to be safe, no need to set P_INSECURE
   /// Used for the 'keymap', 'filetype' and 'syntax' options.
   bool os_value_checked;

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -448,9 +448,7 @@ EXTERN unsigned cot_flags;      ///< flags from 'completeopt'
 #define COT_NOINSERT    0x020  // false: select & insert, true: noinsert
 #define COT_NOSELECT    0x040  // false: select & insert, true: noselect
 #define COT_FUZZY       0x080  // true: fuzzy match enabled
-#ifdef BACKSLASH_IN_FILENAME
 EXTERN char *p_csl;             ///< 'completeslash'
-#endif
 EXTERN OptInt p_pb;             ///< 'pumblend'
 EXTERN OptInt p_ph;             ///< 'pumheight'
 EXTERN OptInt p_pw;             ///< 'pumwidth'
@@ -661,9 +659,7 @@ EXTERN char *p_sxq;             ///< 'shellxquote'
 EXTERN char *p_sxe;             ///< 'shellxescape'
 EXTERN char *p_srr;             ///< 'shellredir'
 EXTERN int p_stmp;              ///< 'shelltemp'
-#ifdef BACKSLASH_IN_FILENAME
 EXTERN int p_ssl;               ///< 'shellslash'
-#endif
 EXTERN char *p_stl;             ///< 'statusline'
 EXTERN char *p_wbr;             ///< 'winbar'
 EXTERN int p_sr;                ///< 'shiftround'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1505,7 +1505,6 @@ return {
         For Insert mode completion the buffer-local value is used.  For
         command line completion the global value is used.
       ]=],
-      enable_if = 'BACKSLASH_IN_FILENAME',
       expand_cb = 'expand_set_completeslash',
       full_name = 'completeslash',
       scope = { 'buffer' },
@@ -7210,7 +7209,11 @@ return {
     {
       abbreviation = 'ssl',
       cb = 'did_set_shellslash',
-      defaults = { if_true = false },
+      defaults = {
+        condition = 'BACKSLASH_IN_FILENAME',
+        if_true = false,
+        if_false = true,
+      },
       desc = [=[
         		only for MS-Windows
         When set, a forward slash is used when expanding file names.  This is
@@ -7225,7 +7228,6 @@ return {
         	if exists('+shellslash')
         <	Also see 'completeslash'.
       ]=],
-      enable_if = 'BACKSLASH_IN_FILENAME',
       full_name = 'shellslash',
       scope = { 'global' },
       short_desc = N_('use forward slash for shell file names'),

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -127,9 +127,7 @@ static char *(p_fdm_values[]) = { "manual", "expr", "marker", "indent",
 static char *(p_fcl_values[]) = { "all", NULL };
 static char *(p_cot_values[]) = { "menu", "menuone", "longest", "preview", "popup",
                                   "noinsert", "noselect", "fuzzy", NULL };
-#ifdef BACKSLASH_IN_FILENAME
 static char *(p_csl_values[]) = { "slash", "backslash", NULL };
-#endif
 
 static char *(p_scl_values[]) = { "yes", "no", "auto", "auto:1", "auto:2", "auto:3", "auto:4",
                                   "auto:5", "auto:6", "auto:7", "auto:8", "auto:9", "yes:1",
@@ -1091,15 +1089,20 @@ int expand_set_completeopt(optexpand_T *args, int *numMatches, char ***matches)
                                matches);
 }
 
-#ifdef BACKSLASH_IN_FILENAME
 /// The 'completeslash' option is changed.
 const char *did_set_completeslash(optset_T *args)
 {
+#ifdef BACKSLASH_IN_FILENAME
   buf_T *buf = (buf_T *)args->os_buf;
   if (check_opt_strings(p_csl, p_csl_values, false) != OK
       || check_opt_strings(buf->b_p_csl, p_csl_values, false) != OK) {
     return e_invarg;
   }
+#else
+  // Setting 'completeslash' is no-op outside of Windows.
+  set_option_varp(kOptCompleteslash, args->os_varp, CSTR_AS_OPTVAL(empty_string_option), true);
+  args->os_doskip = true;
+#endif
   return NULL;
 }
 
@@ -1111,7 +1114,6 @@ int expand_set_completeslash(optexpand_T *args, int *numMatches, char ***matches
                                numMatches,
                                matches);
 }
-#endif
 
 /// The 'concealcursor' option is changed.
 const char *did_set_concealcursor(optset_T *args)


### PR DESCRIPTION
Problem: `'shellslash'` and `'completeslash'` are the only platform-specific options and require extra logic just to accomodate them.

Solution: Make `'shellslash'` and `'completeslash'` no-op on POSIX systems instead of disabling them altogether.
