### PR TITLE
fix(lsp): compare URI instead of workspace folder name

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -189,9 +189,10 @@ local function reuse_client_default(client, config)
   end
 
   if config.root_dir then
+    local root = vim.uri_from_fname(config.root_dir)
     for _, dir in ipairs(client.workspace_folders or {}) do
       -- note: do not need to check client.root_dir since that should be client.workspace_folders[1]
-      if config.root_dir == dir.name then
+      if root == dir.uri then
         return true
       end
     end


### PR DESCRIPTION
The workspace folder name is meant to be a human-readable name which is only used in the UI. Comparing the name against root_dir is thus not a valid comparison. Instead, we should compare the workspace folder's URI against the root dir URI.

Ref: https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#workspaceFolder

```
export interface WorkspaceFolder {
	/**
	 * The associated URI for this workspace folder.
	 */
	uri: URI;

	/**
	 * The name of the workspace folder. Used to refer to this
	 * workspace folder in the user interface.
	 */
	name: string;
}
```