### PR TITLE
fix(popupmenu): add column bounds check to `pum_select_mouse_pos`

### DIFF
--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -1365,8 +1365,8 @@ static void pum_select_mouse_pos(void)
 
   int idx = mouse_row - pum_row;
 
-  bool out_of_bounds = (idx < 0 || idx >= pum_height || mouse_col < pum_col -1
-                        || mouse_col > pum_col + pum_width -1);
+  bool out_of_bounds = (idx < 0 || idx >= pum_height || mouse_col < pum_col - 1
+                        || mouse_col > pum_col + pum_width - 1);
 
   if (out_of_bounds) {
     pum_selected = -1;

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -1365,7 +1365,10 @@ static void pum_select_mouse_pos(void)
 
   int idx = mouse_row - pum_row;
 
-  if (idx < 0 || idx >= pum_height) {
+  bool out_of_bounds = (idx < 0 || idx >= pum_height || mouse_col < pum_col -1
+                        || mouse_col > pum_col + pum_width -1);
+
+  if (out_of_bounds) {
     pum_selected = -1;
   } else if (*pum_array[idx].pum_text != NUL) {
     pum_selected = idx;


### PR DESCRIPTION
Problem:

Invalid popup menu selection is possible with mouse. For example items are selected as long as the mouse cursor is on the same row as the item, even if the cursor is not in the popup window.

Steps to reproduce:

Right click to create popup menue. Move cursor above an item. Move the cursor either to the left or to the right until it moves outside of the menu. The itme will stay selected even though the cursor is not above it anymore.

Solution:

Checks for the left and right column bounds of the popup menu were missing in `pum_select_mouse_pos`. Added checks for column bounds with the help of global variables: `mouse_col`, `pum_col` and `pum_width`.