### PR TITLE
fix(treesitter): correct condition in `__has_ancestor`

### DIFF
--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1151,7 +1151,7 @@ static int __has_ancestor(lua_State *L)
   int const pred_len = (int)lua_objlen(L, 2);
 
   TSNode node = ts_tree_root_node(descendant.tree);
-  while (node.id != descendant.id) {
+  while (node.id != descendant.id && !ts_node_is_null(node)) {
     char const *node_type = ts_node_type(node);
     size_t node_type_len = strlen(node_type);
 


### PR DESCRIPTION
Closes #30956

### Problem

A null node was being returned from `ts_node_child_with_descendant`, which was passed into `ts_node_type`, which causes a segfault.

### Solution

In the loop condition, also check if the node is not null. The guarantee in the upstream function is that if `node.id` is equal to `descendant.id` then the node itself is returned, and not null (the old behavior when `child_containing_descendant` was used **was** to return null).