### PR TITLE
fix(lsp): list all workspace folders in healthcheck

### DIFF
--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -39,12 +39,27 @@ local function check_active_clients()
       elseif type(client.config.cmd) == 'function' then
         cmd = tostring(client.config.cmd)
       end
+      local dirs_info ---@type string
+      if client.workspace_folders and #client.workspace_folders > 1 then
+        dirs_info = string.format(
+          '  Workspace folders:\n    %s',
+          vim
+            .iter(client.workspace_folders)
+            ---@param folder lsp.WorkspaceFolder
+            :map(function(folder)
+              return folder.name
+            end)
+            :join('\n    ')
+        )
+      else
+        dirs_info = string.format(
+          '  Root directory: %s',
+          client.root_dir and vim.fn.fnamemodify(client.root_dir, ':~')
+        ) or nil
+      end
       report_info(table.concat({
         string.format('%s (id: %d)', client.name, client.id),
-        string.format(
-          '  Root directory: %s',
-          client.root_dir and vim.fn.fnamemodify(client.root_dir, ':~') or nil
-        ),
+        dirs_info,
         string.format('  Command: %s', cmd),
         string.format('  Settings: %s', vim.inspect(client.settings, { newline = '\n  ' })),
         string.format(


### PR DESCRIPTION
Closes #30648 

Note that when workspace folders is defined we can just print those, since they should include the `root_dir`.

Example of what it looks like:
![image](https://github.com/user-attachments/assets/32490d69-6571-43c0-9f9a-f89197a7fd22)
