### PR TITLE
Fix unordered list line wrap

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -41,11 +41,13 @@ thus you cannot edit beyond that.
 The command-lines that you enter are remembered in a history table.  You can
 recall them with the up and down cursor keys.  There are actually five
 history tables:
+
 - one for ':' commands
 - one for search strings
 - one for expressions
 - one for input lines, typed for the |input()| function.
 - one for debug mode commands
+
 These are completely separate.  Each history can only be accessed when
 entering the same type of line.
 Use the 'history' option to set the number of lines that are remembered.


### PR DESCRIPTION
Problem: Paragraph below bulleted list was joined to last list item instead of dropping below as expected.

Solution: Added necessary newlines.