### PR TITLE
docs(eval): use table in virtcol function

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -959,7 +959,7 @@ charcol({expr} [, {winid}])                                          *charcol()*
 <
 
                 Parameters: ~
-                  • {expr} (`string|integer[]`)
+                  • {expr} (`string|table`)
                   • {winid} (`integer?`)
 
                 Return: ~
@@ -1100,7 +1100,7 @@ col({expr} [, {winid}])                                                  *col()*
 <
 
                 Parameters: ~
-                  • {expr} (`string|integer[]`)
+                  • {expr} (`string|table`)
                   • {winid} (`integer?`)
 
                 Return: ~
@@ -11611,7 +11611,7 @@ virtcol({expr} [, {list} [, {winid}]])                               *virtcol()*
 <
 
                 Parameters: ~
-                  • {expr} (`string|integer[]`)
+                  • {expr} (`string|table`)
                   • {list} (`boolean?`)
                   • {winid} (`integer?`)
 

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -828,7 +828,7 @@ function vim.fn.charclass(string) end
 ---   echo col('.')    " returns 7
 --- <
 ---
---- @param expr string|integer[]
+--- @param expr string|table
 --- @param winid? integer
 --- @return integer
 function vim.fn.charcol(expr, winid) end
@@ -956,7 +956,7 @@ function vim.fn.clearmatches(win) end
 ---   imap <F2> <Cmd>echo col(".").."\n"<CR>
 --- <
 ---
---- @param expr string|integer[]
+--- @param expr string|table
 --- @param winid? integer
 --- @return integer
 function vim.fn.col(expr, winid) end
@@ -10546,7 +10546,7 @@ function vim.fn.values(dict) end
 ---     echo max(map(range(1, line('$')), "virtcol([v:val, '$'])"))
 --- <
 ---
---- @param expr string|integer[]
+--- @param expr string|table
 --- @param list? boolean
 --- @param winid? integer
 --- @return any

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -1137,7 +1137,7 @@ M.funcs = {
 
     ]=],
     name = 'charcol',
-    params = { { 'expr', 'string|integer[]' }, { 'winid', 'integer' } },
+    params = { { 'expr', 'string|table' }, { 'winid', 'integer' } },
     returns = 'integer',
     signature = 'charcol({expr} [, {winid}])',
   },
@@ -1296,7 +1296,7 @@ M.funcs = {
 
     ]=],
     name = 'col',
-    params = { { 'expr', 'string|integer[]' }, { 'winid', 'integer' } },
+    params = { { 'expr', 'string|table' }, { 'winid', 'integer' } },
     returns = 'integer',
     signature = 'col({expr} [, {winid}])',
   },
@@ -12683,7 +12683,7 @@ M.funcs = {
 
     ]=],
     name = 'virtcol',
-    params = { { 'expr', 'string|integer[]' }, { 'list', 'boolean' }, { 'winid', 'integer' } },
+    params = { { 'expr', 'string|table' }, { 'list', 'boolean' }, { 'winid', 'integer' } },
     signature = 'virtcol({expr} [, {list} [, {winid}]])',
   },
   virtcol2col = {


### PR DESCRIPTION
when is a list-like table first is line number second can be string like `$`