### PR TITLE
fix(float): missing error handle in win_alloc_aucmd_win

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4035,21 +4035,6 @@ void win_alloc_first(void)
   unuse_tabpage(first_tabpage);
 }
 
-// Init `aucmd_win[idx]`. This can only be done after the first window
-// is fully initialized, thus it can't be in win_alloc_first().
-void win_alloc_aucmd_win(int idx)
-{
-  Error err = ERROR_INIT;
-  WinConfig fconfig = WIN_CONFIG_INIT;
-  fconfig.width = Columns;
-  fconfig.height = 5;
-  fconfig.focusable = false;
-  fconfig.mouse = false;
-  aucmd_win[idx].auc_win = win_new_float(NULL, true, fconfig, &err);
-  aucmd_win[idx].auc_win->w_buffer->b_nwindows--;
-  RESET_BINDING(aucmd_win[idx].auc_win);
-}
-
 // Allocate the first window or the first window in a new tab page.
 // When "oldwin" is NULL create an empty buffer for it.
 // When "oldwin" is not NULL copy info from it to the new window.


### PR DESCRIPTION
Problem: missng error handling of win_new_float in win_alloc_aucmd_win. and this function only used in autocmd.c so move it to autocmd.c with static.

Solution: handler err after calling win_new_float.

PS:  Is this a design that no error handling is needed here?  we assuming that the creation will always succeed then..not sure returning directly is okay. maybe need some data clean up..