### PR TITLE
fix(lsp): correct hover result handling

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -53,7 +53,7 @@ function M.hover(config)
       end
     end
 
-    if #results1 == 0 then
+    if vim.tbl_isempty(results1) then
       if config.silent ~= true then
         vim.notify('No information available')
       end


### PR DESCRIPTION
Problem: `vim.lsp.buf.hover()` displays `No information available` when client_id is not 1.

Solution: use vim.tbl_isempty(tbl) instead of #tbl==0
