### PR TITLE
vim-patch:9.1.0823: filetype: Zephyr overlay files not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -402,6 +402,7 @@ local extension = {
   dtso = 'dts',
   its = 'dts',
   keymap = 'dts',
+  overlay = 'dts',
   dylan = 'dylan',
   intr = 'dylanintr',
   lid = 'dylanlid',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -239,7 +239,7 @@ func s:GetFilenameChecks() abort
     \ 'dracula': ['file.drac', 'file.drc', 'file.lvs', 'file.lpe', 'drac.file'],
     \ 'dtd': ['file.dtd'],
     \ 'dtrace': ['/usr/lib/dtrace/io.d'],
-    \ 'dts': ['file.dts', 'file.dtsi', 'file.dtso', 'file.its', 'file.keymap'],
+    \ 'dts': ['file.dts', 'file.dtsi', 'file.dtso', 'file.its', 'file.keymap', 'file.overlay'],
     \ 'dune': ['jbuild', 'dune', 'dune-project', 'dune-workspace', 'dune-file'],
     \ 'dylan': ['file.dylan'],
     \ 'dylanintr': ['file.intr'],


### PR DESCRIPTION
Problem:  filetype: Zephyr overlay files not recognized
Solution: detect '*.overlay' files as dts filetype,
          include syntax tests for DTS files
          (Xudong Zheng)

Reference:
https://docs.zephyrproject.org/latest/build/dts/howtos.html

closes: vim/vim#15963

https://github.com/vim/vim/commit/a68bd6f089239a51ba90026b18109707e601b107

Co-authored-by: Xudong Zheng <7pkvm5aw@slicealias.com>
