### PR TITLE
vim-patch: netrw fixes

### DIFF
--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -1465,7 +1465,6 @@ With either form of the command, netrw will first ask for confirmation
 that the removal is in fact what you want to do.  If netrw doesn't have
 permission to remove a file, it will issue an error message.
 
-                                                *netrw-gx* *Open* *Launch*
 CUSTOMIZING BROWSING WITH A SPECIAL HANDLER	*netrw-x* *netrw-handler* {{{2
 
 Certain files, such as html, gif, jpeg, (word/office) doc, etc, files, are
@@ -1475,7 +1474,7 @@ operating system).  Netrw allows one to invoke such special handlers by:
         * hitting gx with the cursor atop the file path or alternatively x
           in a netrw buffer; the former can be disabled by defining the
           |g:netrw_nogx| variable
-        * when in command line, typing :Open <path>
+        * when in command line, typing :Open <path>, see |:Open| below.
 
 One may also use visual mode (see |visual-start|) to select the text that the
 special handler will use.  Normally gx checks for a close-by URL or file name
@@ -1486,47 +1485,54 @@ select the text to be used by gx by making a visual selection (see
 |visual-block|) and then pressing gx.
 
 The selection function can be adapted for each filetype by adding a function
-Netrw_get_URL_<filetype>, where <filetype> is given by &filetype.
+`Netrw_get_URL_<filetype>`, where <filetype> is given by the 'filetype'.
 The function should return the URL or file name to be used by gx, and will
 fall back to the default behavior if it returns an empty string.
 For example, special handlers for links Markdown and HTML are
->
-" make gx work on concealed links regardless of exact cursor position
-function Netrw_get_URL_markdown()
-  " markdown URL such as [link text](http://ya.ru 'yandex search')
-  try
-    let save_view = winsaveview()
-    if searchpair('\[.\{-}\](', '', ')\zs', 'cbW', '', line('.')) > 0
-      return matchstr(getline('.')[col('.')-1:], '\[.\{-}\](\zs' .. g:netrw_regex_url .. '\ze\(\s\+.\{-}\)\?)')
-    endif
-  finally
-    call winrestview(save_view)
-    return ''
-  endtry
-endfunction
 
-function Netrw_get_URL_html()
-  " HTML URL such as <a href='http://www.python.org'>Python is here</a>
-  "                  <a href="http://www.python.org"/>
-  try
-    let save_view = winsaveview()
-    if searchpair('<a\s\+href=', '', '\%(</a>\|/>\)\zs', 'cbW', '', line('.')) > 0
-      return matchstr(getline('.')[col('.') - 1 : ],
-            \ 'href=["'.."'"..']\?\zs\S\{-}\ze["'.."'"..']\?/\?>')
-    endif
-  finally
-    call winrestview(save_view)
-    return ''
-  endtry
-endfunction
+" make gx work on concealed links regardless of exact cursor position: >
+
+  function Netrw_get_URL_markdown()
+    " markdown URL such as [link text](http://ya.ru 'yandex search')
+    try
+      let save_view = winsaveview()
+      if searchpair('\[.\{-}\](', '', ')\zs', 'cbW', '', line('.')) > 0
+        return matchstr(getline('.')[col('.')-1:],
+          \ '\[.\{-}\](\zs' .. g:netrw_regex_url .. '\ze\(\s\+.\{-}\)\?)')
+      endif
+    finally
+      call winrestview(save_view)
+      return ''
+    endtry
+  endfunction
+
+  function Netrw_get_URL_html()
+    " HTML URL such as <a href='http://www.python.org'>Python is here</a>
+    "                  <a href="http://www.python.org"/>
+    try
+      let save_view = winsaveview()
+      if searchpair('<a\s\+href=', '', '\%(</a>\|/>\)\zs', 'cbW', '', line('.')) > 0
+        return matchstr(getline('.')[col('.') - 1 : ],
+          \ 'href=["'.."'"..']\?\zs\S\{-}\ze["'.."'"..']\?/\?>')
+      endif
+    finally
+      call winrestview(save_view)
+      return ''
+    endtry
+  endfunction
 <
-
 Other than a file path, the text under the cursor may be a URL.  Netrw uses
 by default the following regular expression to determine if the text under the
 cursor is a URL:
 >
-	g:netrw_regex_url = '\%(\%(http\|ftp\|irc\)s\?\|file\)://\S\{-}'
+  :let g:netrw_regex_url = '\%(\%(http\|ftp\|irc\)s\?\|file\)://\S\{-}'
 <
+Associated setting variables:
+	|g:netrw_gx|	control how gx picks up the text under the cursor
+	|g:netrw_nogx|	prevent gx map while editing
+	|g:netrw_suppress_gx_mesg| controls gx's suppression of browser messages
+
+OPENING FILES AND LAUNCHING APPS                 *netrw-gx* *:Open* *:Launch* {{{2
 
 Netrw determines which special handler by the following method:
 
@@ -1540,24 +1546,25 @@ Netrw determines which special handler by the following method:
     * for Mac OS X			: open is used.
     * for Linux				: xdg-open is used.
 
-To open a file <filepath> by the appropriate handler, type
+To open a path (or URL) <path> by the appropriate handler, type >
 
-	:Open <filepath>
+    :Open <path>
+<
+No escaping, neither for the shell nor for Vim's command-line, is needed.
 
-No escaping, neither for the shell, nor for Vim's command-line is needed.
+To launch a specific application <app> <args>, often <args> being <path> >
 
-To launch a specific application <app> <args>, often <args> being <filepath>,
-
-	:Launch <app> <args>.
+    :Launch <app> <args>.
 
 Since <args> can be arbitrarily complex, in particular contain many file
 paths, the escaping is left to the user.
 
-Associated setting variables:
-	|g:netrw_gx|	control how gx picks up the text under the cursor
-	|g:netrw_nogx|	prevent gx map while editing
-	|g:netrw_suppress_gx_mesg| controls gx's suppression of browser messages
+If you disabled the netrw plugin by setting g:loaded_netrwPlugin (see
+|netrw-noload|), then you can use >
 
+    :call netrw#Launch('<app> <args>')
+    :call netrw#Open('<path>')
+<
 							*netrw-curdir*
 DELETING BOOKMARKS					*netrw-mB* {{{2
 

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -1465,42 +1465,93 @@ With either form of the command, netrw will first ask for confirmation
 that the removal is in fact what you want to do.  If netrw doesn't have
 permission to remove a file, it will issue an error message.
 
-						*netrw-gx*
+                                                *netrw-gx* *Open* *Launch*
 CUSTOMIZING BROWSING WITH A SPECIAL HANDLER	*netrw-x* *netrw-handler* {{{2
 
 Certain files, such as html, gif, jpeg, (word/office) doc, etc, files, are
 best seen with a special handler (ie. a tool provided with your computer's
-operating system).  Netrw allows one to invoke such special handlers by: >
+operating system).  Netrw allows one to invoke such special handlers by:
 
-	* when Exploring, hit the "x" key
-	* when editing, hit gx with the cursor atop the special filename
-<	  (latter not available if the |g:netrw_nogx| variable exists)
+        * hitting gx with the cursor atop the file path or alternatively x
+          in a netrw buffer; the former can be disabled by defining the
+          |g:netrw_nogx| variable
+        * when in command line, typing :Open <path>
 
-Netrw determines which special handler by the following method:
-
-  * if |g:netrw_browsex_viewer| exists, then it will be used to attempt to
-    view files.  Examples of useful settings (place into your <.vimrc>): >
-
-	:let g:netrw_browsex_viewer= "kfmclient exec"
-<   or >
-	:let g:netrw_browsex_viewer= "xdg-open"
-<
-    If the viewer you wish to use does not support handling of a remote URL
-    directory, set |g:netrw_browsex_support_remote| to 0.
-  * for Windows 32 or 64, the URL and FileProtocolHandler dlls are used.
-  * for Gnome (with gnome-open): gnome-open is used.
-  * for KDE (with kfmclient)   : kfmclient is used
-  * for Mac OS X               : open is used.
-
-The gx mapping extends to all buffers; apply "gx" while atop a word and netrw
-will apply a special handler to it (like "x" works when in a netrw buffer).
 One may also use visual mode (see |visual-start|) to select the text that the
-special handler will use.  Normally gx uses expand("<cfile>") to pick up the
-text under the cursor; one may change what |expand()| uses via the
+special handler will use.  Normally gx checks for a close-by URL or file name
+to pick up the text under the cursor; one may change what |expand()| uses via the
 |g:netrw_gx| variable (options include "<cword>", "<cWORD>").  Note that
 expand("<cfile>") depends on the |'isfname'| setting.  Alternatively, one may
 select the text to be used by gx by making a visual selection (see
 |visual-block|) and then pressing gx.
+
+The selection function can be adapted for each filetype by adding a function
+Netrw_get_URL_<filetype>, where <filetype> is given by &filetype.
+The function should return the URL or file name to be used by gx, and will
+fall back to the default behavior if it returns an empty string.
+For example, special handlers for links Markdown and HTML are
+>
+" make gx work on concealed links regardless of exact cursor position
+function Netrw_get_URL_markdown()
+  " markdown URL such as [link text](http://ya.ru 'yandex search')
+  try
+    let save_view = winsaveview()
+    if searchpair('\[.\{-}\](', '', ')\zs', 'cbW', '', line('.')) > 0
+      return matchstr(getline('.')[col('.')-1:], '\[.\{-}\](\zs' .. g:netrw_regex_url .. '\ze\(\s\+.\{-}\)\?)')
+    endif
+  finally
+    call winrestview(save_view)
+    return ''
+  endtry
+endfunction
+
+function Netrw_get_URL_html()
+  " HTML URL such as <a href='http://www.python.org'>Python is here</a>
+  "                  <a href="http://www.python.org"/>
+  try
+    let save_view = winsaveview()
+    if searchpair('<a\s\+href=', '', '\%(</a>\|/>\)\zs', 'cbW', '', line('.')) > 0
+      return matchstr(getline('.')[col('.') - 1 : ],
+            \ 'href=["'.."'"..']\?\zs\S\{-}\ze["'.."'"..']\?/\?>')
+    endif
+  finally
+    call winrestview(save_view)
+    return ''
+  endtry
+endfunction
+<
+
+Other than a file path, the text under the cursor may be a URL.  Netrw uses
+by default the following regular expression to determine if the text under the
+cursor is a URL:
+>
+	g:netrw_regex_url = '\%(\%(http\|ftp\|irc\)s\?\|file\)://\S\{-}'
+<
+
+Netrw determines which special handler by the following method:
+
+  * if |g:netrw_browsex_viewer| exists, then it will be used to attempt to
+    view files.  Examples of useful settings (place into your <.vimrc>):
+    If the viewer you wish to use does not support handling of a remote URL
+    directory, set |g:netrw_browsex_support_remote| to 0.
+  * otherwise:
+
+    * for Windows			: explorer.exe is used
+    * for Mac OS X			: open is used.
+    * for Linux				: xdg-open is used.
+
+To open a file <filepath> by the appropriate handler, type
+
+	:Open <filepath>
+
+No escaping, neither for the shell, nor for Vim's command-line is needed.
+
+To launch a specific application <app> <args>, often <args> being <filepath>,
+
+	:Launch <app> <args>.
+
+Since <args> can be arbitrarily complex, in particular contain many file
+paths, the escaping is left to the user.
 
 Associated setting variables:
 	|g:netrw_gx|	control how gx picks up the text under the cursor

--- a/runtime/plugin/netrwPlugin.vim
+++ b/runtime/plugin/netrwPlugin.vim
@@ -1,9 +1,10 @@
 " netrwPlugin.vim: Handles file transfer and remote directory listing across a network
 "            PLUGIN SECTION
 " Maintainer:	This runtime file is looking for a new maintainer.
-" Date:		Feb 09, 2021
+" Date:		Sep 09, 2021
 " Last Change:
 "   2024 May 08 by Vim Project: cleanup legacy Win9X checks
+"   2024 Oct 27 by Vim Project: cleanup gx mapping
 " Former Maintainer:   Charles E Campbell
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
 " Copyright:    Copyright (C) 1999-2021 Charles E. Campbell {{{1
@@ -31,6 +32,87 @@ set cpo&vim
 " ---------------------------------------------------------------------
 " Public Interface: {{{1
 
+" Commands Launch/URL {{{2
+" surpress output of command; use bang for GUI applications
+
+" set up redirection (avoids browser messages)
+" by default, g:netrw_suppress_gx_mesg is true
+if get(g:, ':netrw_suppress_gx_mesg', 1)
+  if &srr =~# "%s"
+    let s:redir = printf(&srr, has("win32") ? "nul" : "/dev/null")
+  else
+    let s:redir= &srr .. (has("win32") ? "nul" : "/dev/null")
+  endif
+else
+  let s:redir= ""
+endif
+
+if has('unix')
+  if has('win32unix')
+    " If cygstart provided, then assume Cygwin and use cygstart --hide; see man cygstart.
+    if executable('cygstart')
+      command -complete=shellcmd -nargs=1 -bang Launch
+          \ exe 'silent ! cygstart --hide' trim(<q-args>)  s:redir | redraw!
+    elseif !empty($MSYSTEM) && executable('start')
+      " MSYS2/Git Bash comes by default without cygstart; see
+      " https://www.msys2.org/wiki/How-does-MSYS2-differ-from-Cygwin
+      " Instead it provides /usr/bin/start script running `cmd.exe //c start`
+      " Adding "" //b` sets void title, hides cmd window and blocks path conversion
+      " of /b to \b\ " by MSYS2; see https://www.msys2.org/docs/filesystem-paths/
+      command -complete=shellcmd -nargs=1 -bang Launch
+            \ exe 'silent !start "" //b' trim(<q-args>)  s:redir | redraw!
+    else
+      " imitate /usr/bin/start script for other environments and hope for the best
+      command -complete=shellcmd -nargs=1 -bang Launch
+            \ exe 'silent !cmd //c start "" //b' trim(<q-args>)  s:redir | redraw!
+    endif
+  elseif exists('$WSL_DISTRO_NAME') " use cmd.exe to start GUI apps in WSL
+    command -complete=shellcmd -nargs=1 -bang Launch execute ':silent !'..
+          \ ((<q-args> =~? '\v<\f+\.(exe|com|bat|cmd)>') ?
+            \ 'cmd.exe /c start "" /b' trim(<q-args>) :
+            \ 'nohup ' trim(<q-args>) s:redir '&')
+          \ | redraw!
+  else
+    command -complete=shellcmd -nargs=1 -bang Launch
+        \ exe ':silent ! nohup' trim(<q-args>) s:redir '&' | redraw!
+  endif
+elseif has('win32')
+  command -complete=shellcmd -nargs=1 -bang Launch
+        \ exe 'silent !'.. (&shell =~? '\<cmd\.exe\>' ? '' : 'cmd.exe /c')
+        \ 'start /b ' trim(<q-args>) s:redir | redraw!
+endif
+if exists(':Launch') == 2
+  " Git Bash
+  if has('win32unix')
+      " start suffices
+      let s:cmd = ''
+  " Windows / WSL
+  elseif executable('explorer.exe')
+      let s:cmd = 'explorer.exe'
+  " Linux / BSD
+  elseif executable('xdg-open')
+      let s:cmd = 'xdg-open'
+  " MacOS
+  elseif executable('open')
+      let s:cmd = 'open'
+  else
+    s:cmd = ''
+  endif
+  function s:Open(cmd, file)
+    if empty(a:cmd) && !exists('g:netrw_browsex_viewer')
+      echoerr "No program to open this path found. See :help Open for more information."
+    else
+      Launch cmd shellescape(a:file, 1)
+    endif
+  endfunction
+  command -complete=file -nargs=1 Open call s:Open(s:cmd, <q-args>)
+endif
+
+if !exists('g:netrw_regex_url')
+  let g:netrw_regex_url = '\%(\%(http\|ftp\|irc\)s\?\|file\)://\S\{-}'
+endif
+
+" " }}}
 " Local Browsing Autocmds: {{{2
 augroup FileExplorer
  au!

--- a/runtime/plugin/netrwPlugin.vim
+++ b/runtime/plugin/netrwPlugin.vim
@@ -6,6 +6,7 @@
 "   2024 May 08 by Vim Project: cleanup legacy Win9X checks
 "   2024 Oct 27 by Vim Project: cleanup gx mapping
 "   2024 Oct 28 by Vim Project: further improvements
+"   2024 Oct 31 by Vim Project: use autoloaded functions
 " Former Maintainer:   Charles E Campbell
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
 " Copyright:    Copyright (C) 1999-2021 Charles E. Campbell {{{1
@@ -34,84 +35,8 @@ set cpo&vim
 " Public Interface: {{{1
 
 " Commands Launch/URL {{{2
-" surpress output of command; use bang for GUI applications
-
-func s:redir()
-  " set up redirection (avoids browser messages)
-  " by default if not set, g:netrw_suppress_gx_mesg is true
-  if get(g:, 'netrw_suppress_gx_mesg', 1)
-    if &srr =~# "%s"
-      return printf(&srr, has("win32") ? "nul" : "/dev/null")
-    else
-      return &srr .. (has("win32") ? "nul" : "/dev/null")
-    endif
-  endif
-  return ''
-endfunc
-
-if has('unix')
-  if has('win32unix')
-    " If cygstart provided, then assume Cygwin and use cygstart --hide; see man cygstart.
-    if executable('cygstart')
-      command -complete=shellcmd -nargs=1 -bang Launch
-          \ exe 'silent ! cygstart --hide' trim(<q-args>)  s:redir() | redraw!
-    elseif !empty($MSYSTEM) && executable('start')
-      " MSYS2/Git Bash comes by default without cygstart; see
-      " https://www.msys2.org/wiki/How-does-MSYS2-differ-from-Cygwin
-      " Instead it provides /usr/bin/start script running `cmd.exe //c start`
-      " Adding "" //b` sets void title, hides cmd window and blocks path conversion
-      " of /b to \b\ " by MSYS2; see https://www.msys2.org/docs/filesystem-paths/
-      command -complete=shellcmd -nargs=1 -bang Launch
-            \ exe 'silent !start "" //b' trim(<q-args>)  s:redir() | redraw!
-    else
-      " imitate /usr/bin/start script for other environments and hope for the best
-      command -complete=shellcmd -nargs=1 -bang Launch
-            \ exe 'silent !cmd //c start "" //b' trim(<q-args>)  s:redir() | redraw!
-    endif
-  elseif exists('$WSL_DISTRO_NAME') " use cmd.exe to start GUI apps in WSL
-    command -complete=shellcmd -nargs=1 -bang Launch execute ':silent !'..
-          \ ((<q-args> =~? '\v<\f+\.(exe|com|bat|cmd)>') ?
-            \ 'cmd.exe /c start "" /b' trim(<q-args>) :
-            \ 'nohup ' trim(<q-args>) s:redir() '&')
-          \ | redraw!
-  else
-    command -complete=shellcmd -nargs=1 -bang Launch
-        \ exe ':silent ! nohup' trim(<q-args>) s:redir() '&' | redraw!
-  endif
-elseif has('win32')
-  command -complete=shellcmd -nargs=1 -bang Launch
-        \ exe 'silent !'.. (&shell =~? '\<cmd\.exe\>' ? '' : 'cmd.exe /c')
-        \ 'start /b ' trim(<q-args>) s:redir() | redraw!
-endif
-if exists(':Launch') == 2
-  " Git Bash
-  if has('win32unix')
-      " start suffices
-      let s:cmd = ''
-  " Windows / WSL
-  elseif executable('explorer.exe')
-      let s:cmd = 'explorer.exe'
-  " Linux / BSD
-  elseif executable('xdg-open')
-      let s:cmd = 'xdg-open'
-  " MacOS
-  elseif executable('open')
-      let s:cmd = 'open'
-  endif
-  function s:Open(file)
-    if !exists('s:cmd') && !exists('g:netrw_browsex_viewer')
-      echoerr "No program to open this path found. See :help Open for more information."
-    else
-      exe 'Launch' s:cmd shellescape(a:file, 1)
-    endif
-  endfunction
-  command -complete=file -nargs=1 Open call s:Open(<q-args>)
-endif
-
-if !exists('g:netrw_regex_url')
-  let g:netrw_regex_url = '\%(\%(http\|ftp\|irc\)s\?\|file\)://\S\{-}'
-endif
-
+command -complete=shellcmd -nargs=1   Launch  call netrw#Launch(trim(<q-args>))
+command -complete=file     -nargs=1   Open    call netrw#Open(trim(<q-args>))
 " " }}}
 " Local Browsing Autocmds: {{{2
 augroup FileExplorer

--- a/runtime/plugin/netrwPlugin.vim
+++ b/runtime/plugin/netrwPlugin.vim
@@ -36,8 +36,8 @@ set cpo&vim
 " surpress output of command; use bang for GUI applications
 
 " set up redirection (avoids browser messages)
-" by default, g:netrw_suppress_gx_mesg is true
-if get(g:, ':netrw_suppress_gx_mesg', 1)
+" by default if not set, g:netrw_suppress_gx_mesg is true
+if get(g:, 'netrw_suppress_gx_mesg', 1)
   if &srr =~# "%s"
     let s:redir = printf(&srr, has("win32") ? "nul" : "/dev/null")
   else
@@ -96,7 +96,7 @@ if exists(':Launch') == 2
   elseif executable('open')
       let s:cmd = 'open'
   else
-    s:cmd = ''
+      let s:cmd = ''
   endif
   function s:Open(cmd, file)
     if empty(a:cmd) && !exists('g:netrw_browsex_viewer')

--- a/runtime/plugin/netrwPlugin.vim
+++ b/runtime/plugin/netrwPlugin.vim
@@ -5,6 +5,7 @@
 " Last Change:
 "   2024 May 08 by Vim Project: cleanup legacy Win9X checks
 "   2024 Oct 27 by Vim Project: cleanup gx mapping
+"   2024 Oct 28 by Vim Project: further improvements
 " Former Maintainer:   Charles E Campbell
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
 " Copyright:    Copyright (C) 1999-2021 Charles E. Campbell {{{1
@@ -53,7 +54,7 @@ if has('unix')
     " If cygstart provided, then assume Cygwin and use cygstart --hide; see man cygstart.
     if executable('cygstart')
       command -complete=shellcmd -nargs=1 -bang Launch
-          \ exe 'silent ! cygstart --hide' trim(<q-args>)  s:redir | redraw!
+          \ exe 'silent ! cygstart --hide' trim(<q-args>)  s:redir() | redraw!
     elseif !empty($MSYSTEM) && executable('start')
       " MSYS2/Git Bash comes by default without cygstart; see
       " https://www.msys2.org/wiki/How-does-MSYS2-differ-from-Cygwin


### PR DESCRIPTION
#### vim-patch:3d7e567: runtime(netrw): simplify gx file handling

It did not work very well, at least on Debian 12, and I am not sure Git
Bash and WSL, for example, were taken care of as maintenance stalled.

The whole logic was somewhat convoluted with some parts repeatedly invoking
failed commands.

The file handling was outdated, for example, nowadays Netscape is rarely
used, and also opinionated, for example mainly Microsoft Paint and Gimp for
Image files.

Instead, let's use (xdg-)open and similar commands on other systems
which respects the user's preferences.

closes: vim/vim#15721

https://github.com/vim/vim/commit/3d7e567ea7392e43a90a6ffb3cd49b71a7b59d1a

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>
Co-authored-by: Luca Saccarola <96259932+saccarosium@users.noreply.github.com>


#### vim-patch:7c96776: runtime(netrw): fix syntax error in netrwPlugin.vim

https://github.com/vim/vim/commit/7c96776729a671b7c5f6be81bc29d860920ea1c1

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:7019788: runtime(netrw): improve netrw's open-handling further

closes: vim/vim#15956

https://github.com/vim/vim/commit/70197885a8957071e4ab6816141ce6e8026635c6

Co-authored-by: Enno <Konfekt@users.noreply.github.com>


#### vim-patch:d69ffbe: runtime(netrw): add missing change for s:redir()

Somehow, that change got lost in commit 70197885

https://github.com/vim/vim/commit/d69ffbe4bc2196c4fc2b9377167a9a194213a686

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:aa2ce6f: runtime(netrw): fix filetype detection for remote files

while at it, remove the Decho comments in the s:NetrwOptionsRestore()
function

https://github.com/vim/vim/commit/aa2ce6f58005bc3b81be2bf42f84ffd01ce22d57

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9f32069: runtime(netrw): fix regression with x mapping on Cygwin

related: vim/vim#13687

https://github.com/vim/vim/commit/9f32069b8c4f74aa6af47e2f0ec07f2745feac57

Co-authored-by: Christian Brabandt <cb@256bit.org>
Co-authored-by: K.Takata <kentkt@csc.jp>


#### vim-patch:8b0fa7a: runtime(netrw): make :Launch/Open autoloadable

closes: vim/vim#15962

https://github.com/vim/vim/commit/8b0fa7a565d8aec306e5755307d182fa7d81e65f

Co-authored-by: Christian Brabandt <cb@256bit.org>
Co-authored-by: Aliaksei Budavei <0x000c70@gmail.com>


#### vim-patch:4d61800: runtime(netrw): fix E874 when browsing remote directory which contains `~` character

closes: vim/vim#15964

https://github.com/vim/vim/commit/4d618006ecfd2557806d8af488f70b3e46878d70

Co-authored-by: Tom Benham <tom.benham13@gmail.com>

Fix #30991