### PR TITLE
fix(lsp): hover border type can be string

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1872,7 +1872,8 @@ Lua module: vim.lsp.util                                            *lsp-util*
                          floating window with the same {focus_id}
       • {offset_x}?      (`integer`) offset to add to `col`
       • {offset_y}?      (`integer`) offset to add to `row`
-      • {border}?        (`(string|[string,string])[]`) override `border`
+      • {border}?        (`string|(string|[string,string])[]`) override
+                         `border`
       • {zindex}?        (`integer`) override `zindex`, defaults to 50
       • {title}?         (`string`)
       • {title_pos}?     (`'left'|'center'|'right'`)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1485,7 +1485,7 @@ end
 ---
 --- offset to add to `row`
 --- @field offset_y? integer
---- @field border? (string|[string,string])[] override `border`
+--- @field border? string|(string|[string,string])[] override `border`
 --- @field zindex? integer override `zindex`, defaults to 50
 --- @field title? string
 --- @field title_pos? 'left'|'center'|'right'


### PR DESCRIPTION
Border type can also be a string as defined in `api-win_config`