### PR TITLE
vim-patch:b5e7da1: runtime(doc): mention 'iskeyword' at :h charclass()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -936,7 +936,7 @@ charclass({string})                                                *charclass()*
 		The character class is one of:
 			0	blank
 			1	punctuation
-			2	word character
+			2	word character (depends on 'iskeyword')
 			3	emoji
 			other	specific Unicode class
 		The class is used in patterns and word motions.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -809,7 +809,7 @@ function vim.fn.char2nr(string, utf8) end
 --- The character class is one of:
 ---   0  blank
 ---   1  punctuation
----   2  word character
+---   2  word character (depends on 'iskeyword')
 ---   3  emoji
 ---   other  specific Unicode class
 --- The class is used in patterns and word motions.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -1111,7 +1111,7 @@ M.funcs = {
       The character class is one of:
       	0	blank
       	1	punctuation
-      	2	word character
+      	2	word character (depends on 'iskeyword')
       	3	emoji
       	other	specific Unicode class
       The class is used in patterns and word motions.


### PR DESCRIPTION
#### vim-patch:b5e7da1: runtime(doc): mention 'iskeyword' at :h charclass()

https://github.com/vim/vim/commit/b5e7da1f27241f7d770d342009e2fb443e45e6ce

Co-authored-by: Christian Brabandt <cb@256bit.org>