### PR TITLE
feat(lsp): multi-client support for signature_help

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1911,7 +1911,7 @@ make_floating_popup_options({width}, {height}, {opts})
                   |vim.lsp.util.open_floating_preview.Opts|.
 
     Return: ~
-        (`table`) Options
+        (`vim.api.keyset.win_config`)
 
                                        *vim.lsp.util.make_formatting_params()*
 make_formatting_params({options})

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -209,6 +209,8 @@ LSP
   `textDocument/rangesFormatting` request).
 • |vim.lsp.buf.code_action()| actions show client name when there are multiple
   clients.
+• |vim.lsp.buf.signature_help()| can now cycle through different signatures
+  using `<C-s>` and also support multiple clients.
 
 LUA
 


### PR DESCRIPTION
Signatures can be cycled using `<C-s>` when the user enters the floating
window.

![image](https://github.com/user-attachments/assets/3e704096-826b-417d-9859-ed8cea0b6bcf)
