### PR TITLE
feat(lsp): add `vim.lsp.config` and `vim.lsp.enable`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -28,31 +28,114 @@ Follow these steps to get LSP features:
    upstream installation instructions. You can find language servers here:
    https://microsoft.github.io/language-server-protocol/implementors/servers/
 
-2. Use |vim.lsp.start()| to start the LSP server (or attach to an existing
-   one) when a file is opened. Example: >lua
-    -- Create an event handler for the FileType autocommand
-    vim.api.nvim_create_autocmd('FileType', {
-      -- This handler will fire when the buffer's 'filetype' is "python"
-      pattern = 'python',
-      callback = function(args)
-        vim.lsp.start({
-          name = 'my-server-name',
-          cmd = {'name-of-language-server-executable', '--option', 'arg1', 'arg2'},
+2. Use |vim.lsp.config()| to define a configuration for an LSP client.
+    Example: >lua
+      vim.lsp.config['luals'] = {
+        -- Command and arguments to start the server.
+        cmd = { 'lua-language-server' }
 
-          -- Set the "root directory" to the parent directory of the file in the
-          -- current buffer (`args.buf`) that contains either a "setup.py" or a
-          -- "pyproject.toml" file. Files that share a root directory will reuse
-          -- the connection to the same LSP server.
-          root_dir = vim.fs.root(args.buf, {'setup.py', 'pyproject.toml'}),
-        })
-      end,
-    })
+        -- Filetypes to automatically attach to.
+        filetypes = { 'lua' },
+
+        -- Sets the "root directory" to the parent directory of the file in the
+        -- current buffer that contains either a ".luarc.json" or a
+        -- ".luarc.jsonc" file. Files that share a root directory will reuse
+        -- the connection to the same LSP server.
+        root_markers = { '.luarc.json', '.luarc.jsonc' },
+
+        -- Specific settings to send to the server. The schema for this is
+        -- defined by the server. For example the schema for lua-language-server
+        -- can be found here https://raw.githubusercontent.com/LuaLS/vscode-lua/master/setting/schema.json
+        settings = {
+          Lua = {
+            runtime = {
+              version = 'LuaJIT',
+            }
+          }
+        }
+      }
 <
-3. Check that the buffer is attached to the server: >vim
-    :checkhealth lsp
+3. Use |vim.lsp.enable()| to enable a configuration.
+   Example: >lua
+     vim.lsp.enable('luals')
+<
+4. Check that the buffer is attached to the server: >vim
+    :checkhealth vim.lsp
+<
+5. (Optional) Configure keymaps and autocommands to use LSP features.
+   |lsp-attach|
 
-4. (Optional) Configure keymaps and autocommands to use LSP features. |lsp-config|
+                                                        *lsp-config*
 
+Configurations for LSP clients is done via |vim.lsp.config()|.
+
+When an LSP client starts, it resolves a configuration by merging
+configurations, in increasing priority, from the following:
+
+1. Configuration defined for the `'*'` name.
+
+2. Configuration from the result of sourcing all `lsp/<name>.lua` files
+   in 'runtimepath' for a server of name `name`.
+
+   Note: because of this, calls to |vim.lsp.config()| in `lsp/*.lua` are
+   treated independently to other calls. This ensures configurations
+   defined in `lsp/*.lua` have a lower priority.
+
+3. Configurations defined anywhere else.
+
+Note: The merge semantics of configurations follow the behaviour of
+|vim.tbl_deep_extend()|.
+
+Example:
+
+Given: >lua
+  -- Defined in init.lua
+  vim.lsp.config('*', {
+    capabilities = {
+      textDocument = {
+        semanticTokens = {
+          multilineTokenSupport = true,
+        }
+      }
+    }
+    root_markers = { '.git' },
+  })
+
+  -- Defined in ../lsp/clangd.lua
+  vim.lsp.config('clangd', {
+    cmd = { 'clangd' },
+    root_markers = { '.clangd', 'compile_commands.json' },
+    filetypes = { 'c', 'cpp' },
+  })
+
+  -- Defined in init.lua
+  vim.lsp.config('clangd', {
+    filetypes = { 'c' },
+  })
+<
+Results in the configuration: >lua
+  {
+    -- From the clangd configuration in <rtp>/lsp/clangd.lua
+    cmd = { 'clangd' },
+
+    -- From the clangd configuration in <rtp>/lsp/clangd.lua
+    -- Overrides the * configuration in init.lua
+    root_markers = { '.clangd', 'compile_commands.json' },
+
+    -- From the clangd configuration in init.lua
+    -- Overrides the * configuration in init.lua
+    filetypes = { 'c' },
+
+    -- From the * configuration in init.lua
+    capabilities = {
+      textDocument = {
+        semanticTokens = {
+          multilineTokenSupport = true,
+        }
+      }
+    }
+  }
+<
                                                         *lsp-defaults*
 When the Nvim LSP client starts it enables diagnostics |vim.diagnostic| (see
 |vim.diagnostic.config()| to customize). It also sets various default options,
@@ -98,7 +181,7 @@ To override or delete any of the above defaults, set or unset the options on
       end,
     })
 <
-                                                        *lsp-config*
+                                                        *lsp-attach*
 To use other LSP features, set keymaps and other buffer options on
 |LspAttach|. Not all language servers provide the same capabilities. Use
 capability checks to ensure you only use features supported by the language
@@ -107,16 +190,16 @@ server. Example: >lua
     vim.api.nvim_create_autocmd('LspAttach', {
       callback = function(args)
         local client = vim.lsp.get_client_by_id(args.data.client_id)
-        if client.supports_method('textDocument/implementation') then
+        if client:supports_method('textDocument/implementation') then
           -- Create a keymap for vim.lsp.buf.implementation
         end
 
-        if client.supports_method('textDocument/completion') then
+        if client:supports_method('textDocument/completion') then
           -- Enable auto-completion
           vim.lsp.completion.enable(true, client.id, args.buf, {autotrigger = true})
         end
 
-        if client.supports_method('textDocument/formatting') then
+        if client:supports_method('textDocument/formatting') then
           -- Format the current buffer on save
           vim.api.nvim_create_autocmd('BufWritePre', {
             buffer = args.buf,
@@ -465,7 +548,7 @@ EVENTS                                                            *lsp-events*
 LspAttach                                                          *LspAttach*
     After an LSP client attaches to a buffer. The |autocmd-pattern| is the
     name of the buffer. When used from Lua, the client ID is passed to the
-    callback in the "data" table. See |lsp-config| for an example.
+    callback in the "data" table. See |lsp-attach| for an example.
 
 LspDetach                                                          *LspDetach*
     Just before an LSP client detaches from a buffer. The |autocmd-pattern|
@@ -478,7 +561,7 @@ LspDetach                                                          *LspDetach*
         local client = vim.lsp.get_client_by_id(args.data.client_id)
 
         -- Remove the autocommand to format the buffer on save, if it exists
-        if client.supports_method('textDocument/formatting') then
+        if client:supports_method('textDocument/formatting') then
           vim.api.nvim_clear_autocmds({
             event = 'BufWritePre',
             buffer = args.buf,
@@ -590,6 +673,27 @@ LspTokenUpdate                                                *LspTokenUpdate*
 ==============================================================================
 Lua module: vim.lsp                                                 *lsp-core*
 
+*vim.lsp.Config*
+    Extends: |vim.lsp.ClientConfig|
+
+
+    Fields: ~
+      • {cmd}?           (`string[]|fun(dispatchers: vim.lsp.rpc.Dispatchers): vim.lsp.rpc.PublicClient`)
+                         See `cmd` in |vim.lsp.ClientConfig|.
+      • {filetypes}?     (`string[]`) Filetypes the client will attach to, if
+                         activated by `vim.lsp.enable()`. If not provided,
+                         then the client will attach to all filetypes.
+      • {root_markers}?  (`string[]`) Directory markers (.e.g. '.git/') where
+                         the LSP server will base its workspaceFolders,
+                         rootUri, and rootPath on initialization. Unused if
+                         `root_dir` is provided.
+      • {reuse_client}?  (`fun(client: vim.lsp.Client, config: vim.lsp.ClientConfig): boolean`)
+                         Predicate used to decide if a client should be
+                         re-used. Used on all running clients. The default
+                         implementation re-uses a client if name and root_dir
+                         matches.
+
+
 buf_attach_client({bufnr}, {client_id})          *vim.lsp.buf_attach_client()*
     Implements the `textDocument/did…` notifications required to track a
     buffer for any language server.
@@ -689,7 +793,7 @@ commands                                                    *vim.lsp.commands*
     value is a function which is called if any LSP action (code action, code
     lenses, ...) triggers the command.
 
-    If a LSP response contains a command for which no matching entry is
+    If an LSP response contains a command for which no matching entry is
     available in this registry, the command will be executed via the LSP
     server using `workspace/executeCommand`.
 
@@ -697,6 +801,65 @@ commands                                                    *vim.lsp.commands*
     String command: String arguments?: any[]
 
     The second argument is the `ctx` of |lsp-handler|
+
+config({name}, {cfg})                                       *vim.lsp.config()*
+    Update the configuration for an LSP client.
+
+    Use name '*' to set default configuration for all clients.
+
+    Can also be table-assigned to redefine the configuration for a client.
+
+    Examples:
+    • Add a root marker for all clients: >lua
+        vim.lsp.config('*', {
+          root_markers = { '.git' },
+        })
+<
+    • Add additional capabilities to all clients: >lua
+        vim.lsp.config('*', {
+          capabilities = {
+            textDocument = {
+              semanticTokens = {
+                multilineTokenSupport = true,
+              }
+            }
+          }
+        })
+<
+    • (Re-)define the configuration for clangd: >lua
+        vim.lsp.config.clangd = {
+          cmd = {
+            'clangd',
+            '--clang-tidy',
+            '--background-index',
+            '--offset-encoding=utf-8',
+          },
+          root_markers = { '.clangd', 'compile_commands.json' },
+          filetypes = { 'c', 'cpp' },
+        }
+<
+    • Get configuration for luals: >lua
+        local cfg = vim.lsp.config.luals
+<
+
+    Parameters: ~
+      • {name}  (`string`)
+      • {cfg}   (`vim.lsp.Config`) See |vim.lsp.Config|.
+
+enable({name}, {enable})                                    *vim.lsp.enable()*
+    Enable an LSP server to automatically start when opening a buffer.
+
+    Uses configuration defined with `vim.lsp.config`.
+
+    Examples: >lua
+          vim.lsp.enable('clangd')
+
+          vim.lsp.enable({'luals', 'pyright'})
+<
+
+    Parameters: ~
+      • {name}    (`string|string[]`) Name(s) of client(s) to enable.
+      • {enable}  (`boolean?`) `true|nil` to enable, `false` to disable.
 
 foldclose({kind}, {winid})                               *vim.lsp.foldclose()*
     Close all {kind} of folds in the the window with {winid}.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -237,6 +237,9 @@ LSP
 • Functions in |vim.lsp.Client| can now be called as methods.
 • Implemented LSP folding: |vim.lsp.foldexpr()|
   https://microsoft.github.io/language-server-protocol/specification/#textDocument_foldingRange
+• |vim.lsp.config()| has been added to define default configurations for
+  servers. In addition, configurations can be specified in `lsp/<name>.lua`.
+• |vim.lsp.enable()| has been added to enable servers.
 
 LUA
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4810,6 +4810,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  indent/	indent scripts |indent-expression|
 	  keymap/	key mapping files |mbyte-keymap|
 	  lang/		menu translations |:menutrans|
+	  lsp/		LSP client configurations |lsp-config|
 	  lua/		|Lua| plugins
 	  menu.vim	GUI menus |menu.vim|
 	  pack/		packages |:packadd|

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5010,6 +5010,7 @@ vim.go.ruf = vim.go.rulerformat
 ---   indent/	indent scripts `indent-expression`
 ---   keymap/	key mapping files `mbyte-keymap`
 ---   lang/		menu translations `:menutrans`
+---   lsp/		LSP client configurations `lsp-config`
 ---   lua/		`Lua` plugins
 ---   menu.vim	GUI menus `menu.vim`
 ---   pack/		packages `:packadd`

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -359,16 +359,6 @@ local function get_name(id, config)
   return tostring(id)
 end
 
---- @generic T
---- @param x elem_or_list<T>?
---- @return T[]
-local function ensure_list(x)
-  if type(x) == 'table' then
-    return x
-  end
-  return { x }
-end
-
 --- @nodoc
 --- @param config vim.lsp.ClientConfig
 --- @return vim.lsp.Client?
@@ -395,13 +385,13 @@ function Client.create(config)
     settings = config.settings or {},
     flags = config.flags or {},
     get_language_id = config.get_language_id or default_get_language_id,
-    capabilities = config.capabilities or lsp.protocol.make_client_capabilities(),
+    capabilities = config.capabilities,
     workspace_folders = lsp._get_workspace_folders(config.workspace_folders or config.root_dir),
     root_dir = config.root_dir,
     _before_init_cb = config.before_init,
-    _on_init_cbs = ensure_list(config.on_init),
-    _on_exit_cbs = ensure_list(config.on_exit),
-    _on_attach_cbs = ensure_list(config.on_attach),
+    _on_init_cbs = vim._ensure_list(config.on_init),
+    _on_exit_cbs = vim._ensure_list(config.on_exit),
+    _on_attach_cbs = vim._ensure_list(config.on_attach),
     _on_error_cb = config.on_error,
     _trace = get_trace(config.trace),
 
@@ -416,6 +406,9 @@ function Client.create(config)
     --- @deprecated use client.progress instead
     messages = { name = name, messages = {}, progress = {}, status = {} },
   }
+
+  self.capabilities =
+    vim.tbl_deep_extend('force', lsp.protocol.make_client_capabilities(), self.capabilities or {})
 
   --- @class lsp.DynamicCapabilities
   --- @nodoc

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -1409,4 +1409,14 @@ function vim._resolve_bufnr(bufnr)
   return bufnr
 end
 
+--- @generic T
+--- @param x elem_or_list<T>?
+--- @return T[]
+function vim._ensure_list(x)
+  if type(x) == 'table' then
+    return x
+  end
+  return { x }
+end
+
 return vim

--- a/scripts/gen_vimdoc.lua
+++ b/scripts/gen_vimdoc.lua
@@ -515,6 +515,8 @@ local function inline_type(obj, classes)
   elseif desc == '' then
     if ty_islist then
       desc = desc .. 'A list of objects with the following fields:'
+    elseif cls.parent then
+      desc = desc .. fmt('Extends |%s| with the additional fields:', cls.parent)
     else
       desc = desc .. 'A table with the following fields:'
     end

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -6755,6 +6755,7 @@ return {
           indent/	indent scripts |indent-expression|
           keymap/	key mapping files |mbyte-keymap|
           lang/		menu translations |:menutrans|
+          lsp/		LSP client configurations |lsp-config|
           lua/		|Lua| plugins
           menu.vim	GUI menus |menu.vim|
           pack/		packages |:packadd|

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -6098,15 +6098,6 @@ describe('LSP', function()
       end
 
       eq(is_os('mac') or is_os('win'), check_registered(nil)) -- start{_client}() defaults to make_client_capabilities().
-      eq(false, check_registered(vim.empty_dict()))
-      eq(
-        false,
-        check_registered({
-          workspace = {
-            ignoreMe = true,
-          },
-        })
-      )
       eq(
         false,
         check_registered({
@@ -6126,6 +6117,90 @@ describe('LSP', function()
             },
           },
         })
+      )
+    end)
+  end)
+
+  describe('vim.lsp.config() and vim.lsp.enable()', function()
+    it('can merge settings from "*"', function()
+      eq(
+        {
+          name = 'foo',
+          cmd = { 'foo' },
+          root_markers = { '.git' },
+        },
+        exec_lua(function()
+          vim.lsp.config('*', { root_markers = { '.git' } })
+          vim.lsp.config('foo', { cmd = { 'foo' } })
+
+          return vim.lsp._resolve_config('foo')
+        end)
+      )
+    end)
+
+    it('sets up an autocmd', function()
+      eq(
+        1,
+        exec_lua(function()
+          vim.lsp.config('foo', {
+            cmd = { 'foo' },
+            root_markers = { '.foorc' },
+          })
+          vim.lsp.enable('foo')
+          return #vim.api.nvim_get_autocmds({
+            group = 'nvim.lsp.enable',
+            event = 'FileType',
+          })
+        end)
+      )
+    end)
+
+    it('attaches to buffers', function()
+      exec_lua(create_server_definition)
+
+      local tmp1 = t.tmpname(true)
+      local tmp2 = t.tmpname(true)
+
+      exec_lua(function()
+        local server = _G._create_server({
+          handlers = {
+            initialize = function(_, _, callback)
+              callback(nil, { capabilities = {} })
+            end,
+          },
+        })
+
+        vim.lsp.config('foo', {
+          cmd = server.cmd,
+          filetypes = { 'foo' },
+          root_markers = { '.foorc' },
+        })
+
+        vim.lsp.config('bar', {
+          cmd = server.cmd,
+          filetypes = { 'bar' },
+          root_markers = { '.foorc' },
+        })
+
+        vim.lsp.enable('foo')
+        vim.lsp.enable('bar')
+
+        vim.cmd.edit(tmp1)
+        vim.bo.filetype = 'foo'
+        _G.foo_buf = vim.api.nvim_get_current_buf()
+
+        vim.cmd.edit(tmp2)
+        vim.bo.filetype = 'bar'
+        _G.bar_buf = vim.api.nvim_get_current_buf()
+      end)
+
+      eq(
+        { 1, 'foo', 1, 'bar' },
+        exec_lua(function()
+          local foos = vim.lsp.get_clients({ bufnr = assert(_G.foo_buf) })
+          local bars = vim.lsp.get_clients({ bufnr = assert(_G.bar_buf) })
+          return { #foos, foos[1].name, #bars, bars[1].name }
+        end)
       )
     end)
   end)


### PR DESCRIPTION
## Problem

- Setting up LSP clients require unnecessary boilerplate.
- LSP configuration has no system.

## Solution

Add `vim.lsp.enable()` and `vim.lsp.config()`.

### Design goals/requirements:
- Default configuration of a server can be distributed across multiple sources.
  - And via RTP discovery.
- Default configuration can be specified for all servers.
  - Can extend capabilities of all clients.
- Configuration _can_ be project specific.

### Proposal:

- Two new API's:
  - `vim.lsp.config(name, cfg)`:
    - Used to define configurations for servers of name.
    - Can be used like a table or called as a function.
      - Use `vim.lsp.config(name, cfg)` to extend a configuration
      - Use `vim.lsp.config[name] = cfg` to define a configuration 
    - Use `vim.lsp.confg('*', cfg)` to specify default config for all
      servers.
    - Examples:
      ```lua
      -- Set default root marker for all clients
      vim.lsp.config('*', {
        root_markers = { '.git' },
      })

      -- Set default configuration for clangd but don't enable it
      vim.lsp.config.clangd = {
        cmd = {
          'clangd',
          '--clang-tidy',
          '--background-index',
          '--offset-encoding=utf-8',
        },
        root_markers = { '.clangd', 'compile_commands.json' },
        filetypes = { 'c', 'cpp' },
      }
      ```
  - `vim.lsp.enable(name)`
    - Used to enable servers of name. Uses configuration defined via `vim.lsp.config()`.
    -  Examples:
       ```lua
       vim.lsp.enable('clangd')
       ```
- Client configuration sources `lsp/<name>.lua` to resolve configurations.
   - Only done once per enabled configuration.
   - Redone if `vim.lsp.config[name]` is accessed (read or modified).

### Notes:

- Instead of adding `vim.lsp.config(name, cfg)` I considered
  `vim.lsp.enable(name, cfg, config_only)` where
  `vim.lsp.enable(name, cfg, true) === vim.lsp.config(name, cfg)`.

  I decided against this since I felt a `config_only` field is slightly more confusing, harder to explain and less generally appealing than having `vim.lsp.config`. There is also some parallel to
  `vim.diagnostic.enable` and `vim.diagnostic.config`.

  If there is pushback to this, then I can remove that from this PR, and add it to a separate future PR for further consideration.

- This PR doesn't provide a full solution for project specific config, but I'm pretty sure doesn't inhibit it. Though I think for most cases using things like `workspace/didChangeConfiguration` in `on_attach` or `LspAttach` should be sufficient.

- This PR is not intended to be the final end goal of LSP configuration but just a medium term stepping stone that moves us forward in the right direction.

  Going forward I'd expect us to add some options into the native option system to complement (or replace) what is added here:

  - Buffer local options:
    - `:setlocal lsp+=clangd`
    - `:setlocal root_marker+=compile_commands.json`

  - LSP namespaced specific options:
    - `:set lsp_servers.clangd.cmd=['clangd']`

- Continuation of #18506

### Todo:

- [x] News
- [x] Documentation
- [x] Tests
- [x] Health check

### Future considerations

- Consider allowing a table to be returned from `lsp/*.lua`.
- Better accommodate project specific configurations.