### PR TITLE
vim-patch:26113e5: runtime(doc): Include netrw-gp in TOC

### DIFF
--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -54,9 +54,10 @@ Copyright: Copyright (C) 2017 Charles E Campbell    *netrw-copyright*
       Browsing With A Horizontally Split Window...........|netrw-o|
       Browsing With A New Tab.............................|netrw-t|
       Browsing With A Vertically Split Window.............|netrw-v|
-      Change File Permission..............................|netrw-gp|
-      Change Listing Style.(thin wide long tree)..........|netrw-i|
+      Change Listing Style (thin wide long tree)..........|netrw-i|
       Changing To A Bookmarked Directory..................|netrw-gb|
+      Quick hide/unhide of dot-files......................|netrw-gh|
+      Changing local-only File Permission.................|netrw-gp|
       Changing To A Predecessor Directory.................|netrw-u|
       Changing To A Successor Directory...................|netrw-U|
       Customizing Browsing With A Special Handler.........|netrw-x|


### PR DESCRIPTION
#### vim-patch:26113e5: runtime(doc): Include netrw-gp in TOC

closes: vim/vim#7627

https://github.com/vim/vim/commit/26113e5ae3c4762ab718d5f006afa71f67e6f459

Co-authored-by: Ernesto Elsäßer <ernesto.elsaesser@me.com>