### PR TITLE
fix(treesitter): close InspectTree/EditQuery window on BufUnload

### DIFF
--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -527,7 +527,7 @@ function M.inspect_tree(opts)
     end,
   })
 
-  api.nvim_create_autocmd('BufHidden', {
+  api.nvim_create_autocmd({ 'BufHidden', 'BufUnload' }, {
     group = group,
     buffer = buf,
     once = true,
@@ -665,10 +665,10 @@ function M.edit_query(lang)
       api.nvim_buf_clear_namespace(query_buf, edit_ns, 0, -1)
     end,
   })
-  api.nvim_create_autocmd('BufHidden', {
+  api.nvim_create_autocmd({ 'BufHidden', 'BufUnload' }, {
     group = group,
     buffer = buf,
-    desc = 'Close the editor window when the source buffer is hidden',
+    desc = 'Close the editor window when the source buffer is hidden or unloaded',
     once = true,
     callback = function()
       close_win(query_win)


### PR DESCRIPTION
Problem:  The window opened :InspectTree or :EditQuery isn't closed when
          the source buffer is unloaded, even though it is closed when
          the buffer is hidden.
Solution: Also close the window on BufUnload.
