### PR TITLE
feat(mouse)!: default 'mouse' to "a"

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4145,7 +4145,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	listing continues until finished.
 
 							*'mouse'*
-'mouse'			string	(default "nvi")
+'mouse'			string	(default "a")
 			global
 	Enables mouse support. For example, to enable the mouse in Normal mode
 	and Visual mode: >vim

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -4250,7 +4250,7 @@ vim.go.more = vim.o.more
 --- 'selectmode'	whether to start Select mode or Visual mode
 ---
 --- @type string
-vim.o.mouse = "nvi"
+vim.o.mouse = "a"
 vim.go.mouse = vim.o.mouse
 
 --- The window that the mouse pointer is on is automatically activated.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -5475,7 +5475,7 @@ return {
     },
     {
       cb = 'did_set_mouse',
-      defaults = { if_true = 'nvi' },
+      defaults = { if_true = 'a' },
       desc = [=[
         Enables mouse support. For example, to enable the mouse in Normal mode
         and Visual mode: >vim


### PR DESCRIPTION
Problem: By default button2 does not paste to command line with a gui.
Solution: change 'mouse' default so it's consistent with vim.
BREAKING CHANGE: 'mouse' default to "a" (was "nvi").

-----

It currently works with `nvim TUI` since it seems to ignore the `'mouse'` `"c"` flag (a bug); the `gui`s honor this flag. In any event the current default `'mouse'` setting is contrary to the vim behavior.

`vim` doc
```
'mouse'			string	(default "", "a" for GUI and Win32,
					set to "a" or "nvi" in |defaults.vim|)
```

Running `vim` or `gvim` 
```
:verbose set mouse?
  mouse=a
Last set from /junk/install/vim/share/vim/vim91/defaults.vim line 84
```
At least on my system, the default is `'mouse'` set to `"a"`. That setting seems most consistent with `neovim`'s philosophy.
