### PR TITLE
fix(inccommand): ensure cursor is where it belongs

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2550,6 +2550,9 @@ static bool cmdpreview_may_show(CommandLineState *s)
     goto end;
   }
 
+  // Cursor may be at the end of the message grid rather than at cmdspos.
+  // Place it there in case preview callback flushes it. #30696
+  cursorcmd();
   // Flush now: external cmdline may itself wish to update the screen which is
   // currently disallowed during cmdpreview(no longer needed in case that changes).
   cmdline_ui_flush();

--- a/test/functional/ui/inccommand_user_spec.lua
+++ b/test/functional/ui/inccommand_user_spec.lua
@@ -508,6 +508,39 @@ describe("'inccommand' for user commands", function()
     feed(':Test')
     eq('nosplit', api.nvim_get_option_value('inccommand', {}))
   end)
+
+  it('does not flush intermediate cursor position at end of message grid', function()
+    exec_lua([[
+      vim.api.nvim_create_user_command('Test', function() end, {
+        nargs = '*',
+        preview = function(_, _, _)
+          vim.api.nvim_buf_set_text(0, 0, 0, 1, -1, { "Preview" })
+          vim.cmd.sleep("1m")
+          return 1
+        end
+      })
+    ]])
+    local cursor_goto = screen._handle_grid_cursor_goto
+    screen._handle_grid_cursor_goto = function(...)
+      cursor_goto(...)
+      assert(screen._cursor.col < 12)
+    end
+    feed(':Test baz<Left><Left>arb')
+    screen:expect({
+      grid = [[
+        Preview                                 |
+          oh no, even more text                 |
+          will the text ever stop               |
+          oh well                               |
+          did the text stop                     |
+          why won't it stop                     |
+          make the text stop                    |
+                                                |
+        {1:~                                       }|*8
+        :Test barb^az                            |
+      ]],
+    })
+  end)
 end)
 
 describe("'inccommand' with multiple buffers", function()


### PR DESCRIPTION
Problem:  Inccommand preview callback may flush inaccurate cmdline cursor position.
Solution: Ensure cursor is where it belongs when doing command preview.

Fix #30696