### PR TITLE
fix(treesitter): remove redundant on_bytes callback

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1605,8 +1605,7 @@ LanguageTree:register_cbs({cbs}, {recursive})
       • {cbs}        (`table<TSCallbackNameOn,function>`) An
                      |nvim_buf_attach()|-like table argument with the
                      following handlers:
-                     • `on_bytes` : see |nvim_buf_attach()|, but this will be
-                       called after the parsers callback.
+                     • `on_bytes` : see |nvim_buf_attach()|.
                      • `on_changedtree` : a callback that will be called every
                        time the tree has syntactical changes. It will be
                        passed two arguments: a table of the ranges (as node

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -93,9 +93,6 @@ function TSHighlighter.new(tree, opts)
   opts = opts or {} ---@type { queries: table<string,string> }
   self.tree = tree
   tree:register_cbs({
-    on_bytes = function(...)
-      self:on_bytes(...)
-    end,
     on_detach = function()
       self:on_detach()
     end,
@@ -212,13 +209,6 @@ function TSHighlighter:for_each_highlight_state(fn)
   for _, state in ipairs(self._highlight_states) do
     fn(state)
   end
-end
-
----@package
----@param start_row integer
----@param new_end integer
-function TSHighlighter:on_bytes(_, _, start_row, _, _, _, _, _, new_end)
-  api.nvim__redraw({ buf = self.bufnr, range = { start_row, start_row + new_end + 1 } })
 end
 
 ---@package

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -1037,7 +1037,7 @@ end
 
 --- Registers callbacks for the [LanguageTree].
 ---@param cbs table<TSCallbackNameOn,function> An [nvim_buf_attach()]-like table argument with the following handlers:
----           - `on_bytes` : see [nvim_buf_attach()], but this will be called _after_ the parsers callback.
+---           - `on_bytes` : see [nvim_buf_attach()].
 ---           - `on_changedtree` : a callback that will be called every time the tree has syntactical changes.
 ---              It will be passed two arguments: a table of the ranges (as node ranges) that
 ---              changed and the changed tree.


### PR DESCRIPTION
Problem:  Treesitter highlighter implements an on_bytes callback that
          just re-marks a buffer range for redraw. The edit that
          prompted the callback will already have done that.
Solution: Remove redundant on_bytes callback from the treesitter
          highlighter module.