### PR TITLE
fix(api): update "range" windows in nvim__redraw

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -219,8 +219,8 @@ end
 ---@package
 ---@param changes Range6[]
 function TSHighlighter:on_changedtree(changes)
-  for _, ch in ipairs(changes) do
-    api.nvim__redraw({ buf = self.bufnr, range = { ch[1], ch[4] + 1 } })
+  for i, ch in ipairs(changes) do
+    api.nvim__redraw({ buf = self.bufnr, range = { ch[1], ch[4] + 1 }, flush = i == #changes })
   end
 end
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2396,13 +2396,13 @@ void nvim__redraw(Dict(redraw) *opts, Error *err)
       last = rbuf->b_ml.ml_line_count;
     }
     redraw_buf_range_later(rbuf, first, last);
+    opts->flush = HAS_KEY(opts, redraw, flush) ? opts->flush : true;
   }
 
-  bool flush = opts->flush;
   if (opts->tabline) {
     // Flush later in case tabline was just hidden or shown for the first time.
     if (redraw_tabline && firstwin->w_lines_valid == 0) {
-      flush = true;
+      opts->flush = true;
     } else {
       draw_tabline();
     }
@@ -2416,23 +2416,23 @@ void nvim__redraw(Dict(redraw) *opts, Error *err)
     if (win == NULL) {
       FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
         if (buf == NULL || wp->w_buffer == buf) {
-          redraw_status(wp, opts, &flush);
+          redraw_status(wp, opts, &opts->flush);
         }
       }
     } else {
-      redraw_status(win, opts, &flush);
+      redraw_status(win, opts, &opts->flush);
     }
   }
 
   win_T *cwin = win ? win : curwin;
   // Allow moving cursor to recently opened window and make sure it is drawn #28868.
   if (opts->cursor && (!cwin->w_grid.target || !cwin->w_grid.target->valid)) {
-    flush = true;
+    opts->flush = true;
   }
 
   // Redraw pending screen updates when explicitly requested or when determined
   // that it is necessary to properly draw other requested components.
-  if (flush && !cmdpreview) {
+  if (opts->flush && !cmdpreview) {
     update_screen();
   }
 


### PR DESCRIPTION
Problem:  nvim__redraw's "range" marks a buffer range for redraw, and subsequently
          flushes the UI without updating the windows containing that buffer.
Solution: Implicitly update the screen, unless specified otherwise.
          Only update the screen with the last call of the treesitter
          on_changedtree() callback.