### PR TITLE
fix(api): add callbackpath in nvim_get_autocmds

### DIFF
--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -287,6 +287,10 @@ Array nvim_get_autocmds(Dict(get_autocmds) *opts, Arena *arena, Error *err)
 
       if (ac->exec.type == CALLABLE_CB) {
         PUT_C(autocmd_info, "command", STRING_OBJ(STRING_INIT));
+        char *exec_to_string = aucmd_exec_to_string(ac, ac->exec);
+        if (exec_to_string) {
+          PUT_C(autocmd_info, "callbackpath", CSTR_AS_OBJ(exec_to_string));
+        }
 
         Callback *cb = &ac->exec.callable.cb;
         switch (cb->type) {


### PR DESCRIPTION
Problem: missing autocmd callback path like autocmd ex command output

Solution: add callbackpath

PS: ex autocmd displays callbackpath instead of the actual defined path because lua sctx is not yet complete.
Not sure if this is what #31039 needs. maybe it's necessary to add the cbpath because this is the same as the autocmd output.