### PR TITLE
fix(health): better layout of vim.treesitter health check

### DIFF
--- a/runtime/lua/vim/treesitter/health.lua
+++ b/runtime/lua/vim/treesitter/health.lua
@@ -4,10 +4,21 @@ local health = vim.health
 
 --- Performs a healthcheck for treesitter integration
 function M.check()
+  health.start('Treesitter features')
+
+  health.info(
+    string.format(
+      'Treesitter ABI support: min %d, max %d',
+      vim.treesitter.minimum_language_version,
+      ts.language_version
+    )
+  )
+
+  local can_wasm = vim._ts_add_language_from_wasm ~= nil
+  health.info(string.format('WASM parser support: %s', tostring(can_wasm)))
+
+  health.start('Treesitter parsers')
   local parsers = vim.api.nvim_get_runtime_file('parser/*', true)
-
-  health.info(string.format('Nvim runtime ABI version: %d', ts.language_version))
-
   for _, parser in pairs(parsers) do
     local parsername = vim.fn.fnamemodify(parser, ':t:r')
     local is_loadable, err_or_nil = pcall(ts.language.add, parsername)
@@ -28,9 +39,6 @@ function M.check()
       )
     end
   end
-
-  local can_wasm = vim._ts_add_language_from_wasm ~= nil
-  health.info(string.format('Can load WASM parsers: %s', tostring(can_wasm)))
 end
 
 return M


### PR DESCRIPTION
Problem: Long lists of available parsers make it hard to see WASM
status.

Solution: Add separate headings for "treesitter features" (ABI, WASM)
and "treesitter parsers". Also add minimum supported ABI version.
(Also fix misleading "Nvim runtime ABI support".)

After:
```
vim.treesitter:                       require("vim.treesitter.health").check()

Treesitter features ~
- Treesitter ABI support: min 13, max 14
- WASM parser support: false

Treesitter parsers ~
- OK Parser: ada                  ABI: 14, path: /Users/clason/.local/share/nvim/site/parser/ada.so
```
