### PR TITLE
vim-patch:9.1.0826: filetype: sway files are not recognized

### DIFF
--- a/runtime/ftplugin/sway.vim
+++ b/runtime/ftplugin/sway.vim
@@ -1,0 +1,15 @@
+" Vim filetype plugin
+" Language:	Sway
+" Maintainer:	Riley Bruins <ribru17@gmail.com>
+" Last Change:	2024 Nov 01
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setl commentstring=//\ %s
+" From Rust comments
+setl comments=s0:/*!,ex:*/,s1:/*,mb:*,ex:*/,:///,://!,://
+
+let b:undo_ftplugin = 'setl com< cms<'

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1151,6 +1151,7 @@ local extension = {
   sface = 'surface',
   svelte = 'svelte',
   svg = 'svg',
+  sw = 'sway',
   swift = 'swift',
   swiftinterface = 'swift',
   swig = 'swig',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -726,6 +726,7 @@ func s:GetFilenameChecks() abort
     \ 'svelte': ['file.svelte'],
     \ 'svg': ['file.svg'],
     \ 'svn': ['svn-commitfile.tmp', 'svn-commit-file.tmp', 'svn-commit.tmp'],
+    \ 'sway': ['file.sw'],
     \ 'swayconfig': ['/home/user/.sway/config', '/home/user/.config/sway/config', '/etc/sway/config', '/etc/xdg/sway/config'],
     \ 'swift': ['file.swift', 'file.swiftinterface'],
     \ 'swiftgyb': ['file.swift.gyb'],


### PR DESCRIPTION
Problem:  filetype: sway files are not recognized
Solution: detect '*.sw' files as sway filetype, include
          a filetype plugin (Riley Bruins)

References:
 https://github.com/FuelLabs/sway.

Comments taken from their syntax documentation. File extension taken
from the same documentation/GitHub's own recognition of these file types

closes: vim/vim#15973

https://github.com/vim/vim/commit/84b5b1c660beb2f9e27de70687e41d39a023ae81

Co-authored-by: Riley Bruins <ribru17@hotmail.com>
