### PR TITLE
vim-patch:d181baf: runtime(typst): synchronize updates from the upstream typst.vim

### DIFF
--- a/runtime/autoload/typst.vim
+++ b/runtime/autoload/typst.vim
@@ -1,6 +1,6 @@
 " Language:    Typst
 " Maintainer:  Gregory Anders
-" Last Change: 2024 Oct 21
+" Last Change: 2024 Nov 02
 " Based on:    https://github.com/kaarmu/typst.vim
 
 function! typst#indentexpr() abort
@@ -18,6 +18,9 @@ function! typst#indentexpr() abort
     " Use last indent for block comments
     if l:synname == 'typstCommentBlock'
         return l:ind
+    " do not change the indents of bullet lists
+    elseif l:synname == 'typstMarkupBulletList'
+        return indent(a:lnum)
     endif
 
     if l:pline =~ '\v[{[(]\s*$'

--- a/runtime/syntax/typst.vim
+++ b/runtime/syntax/typst.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:    Typst
 " Maintainer:  Gregory Anders <greg@gpanders.com>
-" Last Change: 2024-07-14
+" Last Change: 2024 Nov 02
 " Based on:    https://github.com/kaarmu/typst.vim
 
 if exists('b:current_syntax')
@@ -18,8 +18,8 @@ syntax cluster typstCommon
 " Common > Comment {{{2
 syntax cluster typstComment
     \ contains=typstCommentBlock,typstCommentLine
-syntax match typstCommentBlock
-    \ #/\*\%(\_.\{-}\)\*/#
+syntax region typstCommentBlock
+    \ start="/\*" end="\*/" keepend
     \ contains=typstCommentTodo,@Spell
 syntax match typstCommentLine
     \ #//.*#


### PR DESCRIPTION
2 commits included from the upstream:

- https://github.com/kaarmu/typst.vim/commit/2a4a0e0662f2f882403af7200b4249c564a621ab
- https://github.com/kaarmu/typst.vim/commit/50e89f481102d5c9ef6990b9f8086c0c7d64bff6

https://github.com/vim/vim/commit/d181bafd0bb53f3caaf15a95a329a31d8208206b

Co-authored-by: Yinzuo Jiang <jiangyinzuo@foxmail.com>
