### PR TITLE
vim-patch:a95d6a3: runtime(doc): remove stray sentence in pi_netrw.txt

### DIFF
--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -1538,7 +1538,7 @@ OPENING FILES AND LAUNCHING APPS                 *netrw-gx* *:Open* *:Launch* {{
 Netrw determines which special handler by the following method:
 
   * if |g:netrw_browsex_viewer| exists, then it will be used to attempt to
-    view files.  Examples of useful settings (place into your <.vimrc>):
+    view files.
     If the viewer you wish to use does not support handling of a remote URL
     directory, set |g:netrw_browsex_support_remote| to 0.
   * otherwise:


### PR DESCRIPTION
#### vim-patch:a95d6a3: runtime(doc): remove stray sentence in pi_netrw.txt

closes: vim/vim#15971

https://github.com/vim/vim/commit/a95d6a3d641dd065cccb1e76863dd3450ee5ce04

Co-authored-by: S. B. Tam <cpplearner@outlook.com>