### PR TITLE
vim-patch:9.1.0830: using wrong highlight group for spaces for popupmenu

### DIFF
--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -657,11 +657,14 @@ void pum_redraw(void)
     pum_align_order(order);
     int basic_width = items_width_array[order[0]];  // first item width
     bool last_isabbr = order[2] == CPT_ABBR;
+    int orig_attr = -1;
+
     for (int j = 0; j < 3; j++) {
       int item_type = order[j];
       hlf = hlfs[item_type];
       attr = win_hl_attr(curwin, (int)hlf);
-      int orig_attr = attr;
+      attr = hl_combine_attr(win_hl_attr(curwin, HLF_PNI), attr);
+      orig_attr = attr;
       int user_abbr_hlattr = pum_array[idx].pum_user_abbr_hlattr;
       int user_kind_hlattr = pum_array[idx].pum_user_kind_hlattr;
       if (item_type == CPT_ABBR && user_abbr_hlattr > 0) {
@@ -670,7 +673,6 @@ void pum_redraw(void)
       if (item_type == CPT_KIND && user_kind_hlattr > 0) {
         attr = hl_combine_attr(attr, user_kind_hlattr);
       }
-      attr = hl_combine_attr(win_hl_attr(curwin, HLF_PNI), attr);
       int width = 0;
       char *s = NULL;
       p = pum_get_item(idx, item_type);
@@ -796,9 +798,9 @@ void pum_redraw(void)
     }
 
     if (pum_rl) {
-      grid_line_fill(col_off - pum_width + 1, grid_col + 1, schar_from_ascii(' '), attr);
+      grid_line_fill(col_off - pum_width + 1, grid_col + 1, schar_from_ascii(' '), orig_attr);
     } else {
-      grid_line_fill(grid_col, col_off + pum_width, schar_from_ascii(' '), attr);
+      grid_line_fill(grid_col, col_off + pum_width, schar_from_ascii(' '), orig_attr);
     }
 
     if (pum_scrollbar > 0) {

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -5190,9 +5190,17 @@ describe('builtin popupmenu', function()
       -- oldtest: Test_pum_user_abbr_hlgroup()
       it('custom abbr_hlgroup override', function()
         exec([[
-          func CompleteFunc( findstart, base )
+          let s:var = 0
+          func CompleteFunc(findstart, base)
             if a:findstart
               return 0
+            endif
+            if s:var == 1
+              return {
+                    \ 'words': [
+                    \ { 'word': 'aword1', 'abbr_hlgroup': 'StrikeFake' },
+                    \ { 'word': '你好', 'abbr_hlgroup': 'StrikeFake' },
+                    \]}
             endif
             return {
                   \ 'words': [
@@ -5200,6 +5208,9 @@ describe('builtin popupmenu', function()
                   \ { 'word': 'aword2', 'menu': 'extra text 2', 'kind': 'W', },
                   \ { 'word': '你好', 'menu': 'extra text 3', 'kind': 'W', 'abbr_hlgroup': 'StrikeFake' },
                   \]}
+          endfunc
+          func ChangeVar()
+            let s:var = 1
           endfunc
           set completeopt=menu
           set completefunc=CompleteFunc
@@ -5241,6 +5252,17 @@ describe('builtin popupmenu', function()
           {dn:你好}{n:   W extra text 3 }{1:          }|
           {1:~                               }|*15
           {2:-- }{5:match 2 of 3}                 |
+        ]])
+        feed('<C-E><Esc>')
+
+        command('call ChangeVar()')
+        feed('S<C-X><C-U>')
+        screen:expect([[
+          aword1^                          |
+          {ds:aword1}{s:         }{1:                 }|
+          {dn:你好}{n:           }{1:                 }|
+          {1:~                               }|*16
+          {2:-- }{5:match 1 of 2}                 |
         ]])
         feed('<C-E><Esc>')
       end)

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1509,9 +1509,17 @@ endfunc
 func Test_pum_user_abbr_hlgroup()
   CheckScreendump
   let lines =<< trim END
-    func CompleteFunc( findstart, base )
+    let s:var = 0
+    func CompleteFunc(findstart, base)
       if a:findstart
         return 0
+      endif
+      if s:var == 1
+        return {
+              \ 'words': [
+              \ { 'word': 'aword1', 'abbr_hlgroup': 'StrikeFake' },
+              \ { 'word': '你好', 'abbr_hlgroup': 'StrikeFake' },
+              \]}
       endif
       return {
             \ 'words': [
@@ -1519,6 +1527,9 @@ func Test_pum_user_abbr_hlgroup()
             \ { 'word': 'aword2', 'menu': 'extra text 2', 'kind': 'W', },
             \ { 'word': '你好', 'menu': 'extra text 3', 'kind': 'W', 'abbr_hlgroup': 'StrikeFake' },
             \]}
+    endfunc
+    func ChangeVar()
+      let s:var = 1
     endfunc
     set completeopt=menu
     set completefunc=CompleteFunc
@@ -1547,13 +1558,20 @@ func Test_pum_user_abbr_hlgroup()
   call VerifyScreenDump(buf, 'Test_pum_highlights_14', {})
   call term_sendkeys(buf, "\<C-E>\<Esc>")
 
+  call TermWait(buf)
+  call term_sendkeys(buf, ":call ChangeVar()\<CR>")
+  call TermWait(buf)
+  call term_sendkeys(buf, "S\<C-X>\<C-U>")
+  call VerifyScreenDump(buf, 'Test_pum_highlights_17', {})
+  call term_sendkeys(buf, "\<C-E>\<Esc>")
+
   call StopVimInTerminal(buf)
 endfunc
 
 func Test_pum_user_kind_hlgroup()
   CheckScreendump
   let lines =<< trim END
-    func CompleteFunc( findstart, base )
+    func CompleteFunc(findstart, base)
       if a:findstart
         return 0
       endif


### PR DESCRIPTION
#### vim-patch:9.1.0830: using wrong highlight group for spaces for popupmenu

Problem:  using wrong highlight group for spaces for popupmenu
Solution: use original attribute instead of combined attributed
          (glepnir)

closes: vim/vim#15978

https://github.com/vim/vim/commit/bc10be7a4060748ed1876ab91cf53a2a8701ac13

Co-authored-by: glepnir <glephunter@gmail.com>