### PR TITLE
vim-patch:9.1.{0832,0835}

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5173,7 +5173,7 @@ static Callback *get_findfunc_callback(void)
   return *curbuf->b_p_ffu != NUL ? &curbuf->b_ffu_cb : &ffu_cb;
 }
 
-/// Call 'findfunc' to obtain the list of file names.
+/// Call 'findfunc' to obtain a list of file names.
 static list_T *call_findfunc(char *pat, BoolVarValue cmdcomplete)
 {
   const sctx_T saved_sctx = current_sctx;
@@ -5294,12 +5294,16 @@ const char *did_set_findfunc(optset_T *args)
   buf_T *buf = (buf_T *)args->os_buf;
   int retval;
 
-  if (*buf->b_p_ffu != NUL) {
+  if (args->os_flags & OPT_LOCAL) {
     // buffer-local option set
     retval = option_set_callback_func(buf->b_p_ffu, &buf->b_ffu_cb);
   } else {
     // global option set
     retval = option_set_callback_func(p_ffu, &ffu_cb);
+    // when using :set, free the local callback
+    if (!(args->os_flags & OPT_GLOBAL)) {
+      callback_free(&buf->b_ffu_cb);
+    }
   }
 
   if (retval == FAIL) {

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -655,6 +655,9 @@ const char *did_set_backupcopy(optset_T *args)
   if (opt_flags & OPT_LOCAL) {
     bkc = buf->b_p_bkc;
     flags = &buf->b_bkc_flags;
+  } else if (!(opt_flags & OPT_GLOBAL)) {
+    // When using :set, clear the local flags.
+    buf->b_bkc_flags = 0;
   }
 
   if ((opt_flags & OPT_LOCAL) && *bkc == NUL) {
@@ -1070,6 +1073,9 @@ const char *did_set_completeopt(optset_T *args FUNC_ATTR_UNUSED)
   if (args->os_flags & OPT_LOCAL) {
     cot = buf->b_p_cot;
     flags = &buf->b_cot_flags;
+  } else if (!(args->os_flags & OPT_GLOBAL)) {
+    // When using :set, clear the local flags.
+    buf->b_cot_flags = 0;
   }
 
   if (check_opt_strings(cot, p_cot_values, true) != OK) {

--- a/test/old/testdir/test_findfile.vim
+++ b/test/old/testdir/test_findfile.vim
@@ -364,7 +364,7 @@ func Test_findfunc()
 
   " Error cases
 
-  " Function that doesn't any argument
+  " Function that doesn't take any arguments
   func FindFuncNoArg()
   endfunc
   set findfunc=FindFuncNoArg
@@ -479,6 +479,41 @@ func Test_findfunc_scriptlocal_func()
   call assert_equal(expand('<SID>') .. 'FindFuncScript', &findfunc)
   call assert_equal(expand('<SID>') .. 'FindFuncScript', &l:findfunc)
   call assert_equal('', &g:findfunc)
+  let g:FindFuncArg = ''
+  find abc
+  call assert_equal('abc', g:FindFuncArg)
+  bw!
+
+  new | only
+  set findfunc=
+  setlocal findfunc=NoSuchFunc
+  setglobal findfunc=s:FindFuncScript
+  call assert_equal('NoSuchFunc', &findfunc)
+  call assert_equal('NoSuchFunc', &l:findfunc)
+  call assert_equal(expand('<SID>') .. 'FindFuncScript', &g:findfunc)
+  new | only
+  call assert_equal(expand('<SID>') .. 'FindFuncScript', &findfunc)
+  call assert_equal(expand('<SID>') .. 'FindFuncScript', &g:findfunc)
+  call assert_equal('', &l:findfunc)
+  let g:FindFuncArg = ''
+  find abc
+  call assert_equal('abc', g:FindFuncArg)
+  bw!
+
+  new | only
+  set findfunc=
+  setlocal findfunc=NoSuchFunc
+  set findfunc=s:FindFuncScript
+  call assert_equal(expand('<SID>') .. 'FindFuncScript', &findfunc)
+  call assert_equal(expand('<SID>') .. 'FindFuncScript', &g:findfunc)
+  call assert_equal('', &l:findfunc)
+  let g:FindFuncArg = ''
+  find abc
+  call assert_equal('abc', g:FindFuncArg)
+  new | only
+  call assert_equal(expand('<SID>') .. 'FindFuncScript', &findfunc)
+  call assert_equal(expand('<SID>') .. 'FindFuncScript', &g:findfunc)
+  call assert_equal('', &l:findfunc)
   let g:FindFuncArg = ''
   find abc
   call assert_equal('abc', g:FindFuncArg)

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2268,6 +2268,7 @@ func Test_thesaurusfunc_callback()
     call add(g:TsrFunc3Args, [a:findstart, a:base])
     return a:findstart ? 0 : []
   endfunc
+
   set tsrfu=s:TsrFunc3
   new
   call setline(1, 'script1')
@@ -2283,6 +2284,46 @@ func Test_thesaurusfunc_callback()
   call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
   call assert_equal([[1, ''], [0, 'script2']], g:TsrFunc3Args)
   bw!
+
+  new | only
+  set thesaurusfunc=
+  setlocal thesaurusfunc=NoSuchFunc
+  setglobal thesaurusfunc=s:TsrFunc3
+  call assert_equal('NoSuchFunc', &thesaurusfunc)
+  call assert_equal('NoSuchFunc', &l:thesaurusfunc)
+  call assert_equal('s:TsrFunc3', &g:thesaurusfunc)
+  new | only
+  call assert_equal('s:TsrFunc3', &thesaurusfunc)
+  call assert_equal('s:TsrFunc3', &g:thesaurusfunc)
+  call assert_equal('', &l:thesaurusfunc)
+  call setline(1, 'script1')
+  let g:TsrFunc3Args = []
+  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'script1']], g:TsrFunc3Args)
+  bw!
+
+  new | only
+  set thesaurusfunc=
+  setlocal thesaurusfunc=NoSuchFunc
+  set thesaurusfunc=s:TsrFunc3
+  call assert_equal('s:TsrFunc3', &thesaurusfunc)
+  call assert_equal('s:TsrFunc3', &g:thesaurusfunc)
+  call assert_equal('', &l:thesaurusfunc)
+  call setline(1, 'script1')
+  let g:TsrFunc3Args = []
+  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'script1']], g:TsrFunc3Args)
+  setlocal bufhidden=wipe
+  new | only!
+  call assert_equal('s:TsrFunc3', &thesaurusfunc)
+  call assert_equal('s:TsrFunc3', &g:thesaurusfunc)
+  call assert_equal('', &l:thesaurusfunc)
+  call setline(1, 'script1')
+  let g:TsrFunc3Args = []
+  call feedkeys("A\<C-X>\<C-T>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'script1']], g:TsrFunc3Args)
+  bw!
+
   delfunc s:TsrFunc3
 
   " invalid return value

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -950,6 +950,46 @@ func Test_completeopt_buffer_local()
   call assert_equal('menu', &completeopt)
   call assert_equal('menu', &g:completeopt)
 
+  new | only
+  call setline(1, ['foofoo', 'foobar', 'foobaz', ''])
+  set completeopt&
+  setlocal completeopt=menu,fuzzy,noinsert
+  setglobal completeopt=menu,longest
+  call assert_equal('menu,fuzzy,noinsert', &completeopt)
+  call assert_equal('menu,fuzzy,noinsert', &l:completeopt)
+  call assert_equal('menu,longest', &g:completeopt)
+  call feedkeys("Gccf\<C-X>\<C-N>bz\<C-Y>", 'tnix')
+  call assert_equal('foobaz', getline('.'))
+  setlocal bufhidden=wipe
+  new | only!
+  call setline(1, ['foofoo', 'foobar', 'foobaz', ''])
+  call assert_equal('menu,longest', &completeopt)
+  call assert_equal('menu,longest', &g:completeopt)
+  call assert_equal('', &l:completeopt)
+  call feedkeys("Gccf\<C-X>\<C-N>\<C-X>\<C-Z>", 'tnix')
+  call assert_equal('foo', getline('.'))
+  bwipe!
+
+  new | only
+  call setline(1, ['foofoo', 'foobar', 'foobaz', ''])
+  set completeopt&
+  setlocal completeopt=menu,fuzzy,noinsert
+  set completeopt=menu,longest
+  call assert_equal('menu,longest', &completeopt)
+  call assert_equal('menu,longest', &g:completeopt)
+  call assert_equal('', &l:completeopt)
+  call feedkeys("Gccf\<C-X>\<C-N>\<C-X>\<C-Z>", 'tnix')
+  call assert_equal('foo', getline('.'))
+  setlocal bufhidden=wipe
+  new | only!
+  call setline(1, ['foofoo', 'foobar', 'foobaz', ''])
+  call assert_equal('menu,longest', &completeopt)
+  call assert_equal('menu,longest', &g:completeopt)
+  call assert_equal('', &l:completeopt)
+  call feedkeys("Gccf\<C-X>\<C-N>\<C-X>\<C-Z>", 'tnix')
+  call assert_equal('foo', getline('.'))
+  bwipe!
+
   set completeopt&
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.0832: :set doesn't work for 'cot' and 'bkc' after :setlocal

Problem:  :set doesn't work for 'cot' and 'bkc' after :setlocal.
Solution: clear the local flags when using :set (zeertzjq).

closes: vim/vim#15981

https://github.com/vim/vim/commit/46dcd84d242db6b053cb5b777c896cede9ad9b27


#### vim-patch:9.1.0835: :setglobal doesn't work properly for 'ffu' and 'tsrfu'

Problem:  :setglobal doesn't work properly for 'ffu' and 'tsrfu' when
          the local value is set (after v9.1.0831)
Solution: Check os_flags instead of buffer option variable (zeertzjq).

closes: vim/vim#15980

https://github.com/vim/vim/commit/6eda269600b5ca952f28e808c662f67e581933d7