### PR TITLE
ci: work around flaky python tests

### DIFF
--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -31,6 +31,13 @@ jobs:
           cmake --preset ci -D CMAKE_BUILD_TYPE='RelWithDebInfo' ${{ inputs.build_flags }}
           cmake --build build
 
+      # FIXME(dundargoc): this workaround is needed as the python3 provider
+      # tests suddenly started to become extremely flaky, and this removes the
+      # flakiness for some reason.
+      - uses: actions/setup-python@v4
+        with:
+          python-version: '3.13'
+
       - name: Install test deps
         run: |
           $PSNativeCommandArgumentPassing = 'Legacy'


### PR DESCRIPTION
It's the same workaround as 88ed9ffcd1c022811ebc8818e153fe94e4741671,
which was later removed in f707ce76acb86e064d549dc762f5636af072d3c5
after it turned out to be stable after a while.