### PR TITLE
feat(lsp)!: refactor vim.lsp.buf.format

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1318,14 +1318,13 @@ format({opts})                                          *vim.lsp.buf.format()*
                   (client.id) matching this field.
                 • {name}? (`string`) Restrict formatting to the client with
                   name (client.name) matching this field.
-                • {range}?
-                  (`{start:[integer,integer],end:[integer, integer]}|{start:[integer,integer],end:[integer,integer]}[]`,
-                  default: current selection in visual mode, `nil` in other
-                  modes, formatting the full buffer) Range to format. Table
-                  must contain `start` and `end` keys with {row,col} tuples
-                  using (1,0) indexing. Can also be a list of tables that
-                  contain `start` and `end` keys as described above, in which
-                  case `textDocument/rangesFormatting` support is required.
+                • {range}? (`lsp.Range|lsp.Range[]`, default: current
+                  selection in visual mode, `nil` in other modes, formatting
+                  the full buffer) Range to format. Table must contain `start`
+                  and `end` keys with {row,col} tuples using (1,0) indexing.
+                  Can also be a list of tables that contain `start` and `end`
+                  keys as described above, in which case
+                  `textDocument/rangesFormatting` support is required.
 
 hover({config})                                          *vim.lsp.buf.hover()*
     Displays hover information about the symbol under the cursor in a floating
@@ -1914,13 +1913,15 @@ make_floating_popup_options({width}, {height}, {opts})
         (`vim.api.keyset.win_config`)
 
                                        *vim.lsp.util.make_formatting_params()*
-make_formatting_params({options})
+make_formatting_params({options}, {bufnr})
     Creates a `DocumentFormattingParams` object for the current buffer and
     cursor position.
 
     Parameters: ~
       • {options}  (`lsp.FormattingOptions?`) with valid `FormattingOptions`
                    entries
+      • {bufnr}    (`integer?`) buffer handle or 0 for current, defaults to
+                   current
 
     Return: ~
         (`lsp.DocumentFormattingParams`) object

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1326,7 +1326,7 @@ format({opts})                                          *vim.lsp.buf.format()*
                   keys as described above, in which case
                   `textDocument/rangesFormatting` support is required.
 
-hover({config})                                          *vim.lsp.buf.hover()*
+hover({opts})                                            *vim.lsp.buf.hover()*
     Displays hover information about the symbol under the cursor in a floating
     window. The window will be dismissed on cursor move. Calling the function
     twice will jump into the floating window (thus by default, "KK" will open
@@ -1335,7 +1335,7 @@ hover({config})                                          *vim.lsp.buf.hover()*
     can scroll the contents the same as you would any other buffer.
 
     Parameters: ~
-      • {config}  (`vim.lsp.buf.hover.Opts?`) See |vim.lsp.buf.hover.Opts|.
+      • {opts}  (`vim.lsp.buf.hover.Opts?`) See |vim.lsp.buf.hover.Opts|.
 
 implementation({opts})                          *vim.lsp.buf.implementation()*
     Lists all the implementations for the symbol under the cursor in the
@@ -1391,13 +1391,13 @@ rename({new_name}, {opts})                              *vim.lsp.buf.rename()*
                       ones where client.name matches this field.
                     • {bufnr}? (`integer`) (default: current buffer)
 
-signature_help({config})                        *vim.lsp.buf.signature_help()*
+signature_help({opts})                          *vim.lsp.buf.signature_help()*
     Displays signature information about the symbol under the cursor in a
     floating window.
 
     Parameters: ~
-      • {config}  (`vim.lsp.buf.signature_help.Opts?`) See
-                  |vim.lsp.buf.signature_help.Opts|.
+      • {opts}  (`vim.lsp.buf.signature_help.Opts?`) See
+                |vim.lsp.buf.signature_help.Opts|.
 
 type_definition({opts})                        *vim.lsp.buf.type_definition()*
     Jumps to the definition of the type of the symbol under the cursor.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -93,6 +93,8 @@ LSP
   can no longer be configured with |vim.lsp.with()|.
   Instead use: >lua
     vim.diagnostic.config(config, vim.lsp.diagnostic.get_namespace(client_id))
+• |vim.lsp.buf.format()| no longer triggers the global handlers from
+  `vim.lsp.handlers`
 <
 
 LUA

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -30,10 +30,10 @@ end
 --- In the floating window, all commands and mappings are available as usual,
 --- except that "q" dismisses the window.
 --- You can scroll the contents the same as you would any other buffer.
---- @param config? vim.lsp.buf.hover.Opts
-function M.hover(config)
-  config = config or {}
-  config.focus_id = ms.textDocument_hover
+--- @param opts? vim.lsp.buf.hover.Opts
+function M.hover(opts)
+  opts = opts or {}
+  opts.focus_id = ms.textDocument_hover
 
   lsp.buf_request_all(0, ms.textDocument_hover, client_positional_params(), function(results, ctx)
     if api.nvim_get_current_buf() ~= ctx.bufnr then
@@ -54,7 +54,7 @@ function M.hover(config)
     end
 
     if vim.tbl_isempty(results1) then
-      if config.silent ~= true then
+      if opts.silent ~= true then
         vim.notify('No information available')
       end
       return
@@ -94,13 +94,13 @@ function M.hover(config)
     contents[#contents] = nil
 
     if vim.tbl_isempty(contents) then
-      if config.silent ~= true then
+      if opts.silent ~= true then
         vim.notify('No information available')
       end
       return
     end
 
-    lsp.util.open_floating_preview(contents, format, config)
+    lsp.util.open_floating_preview(contents, format, opts)
   end)
 end
 
@@ -290,15 +290,14 @@ local sig_help_ns = api.nvim_create_namespace('vim_lsp_signature_help')
 --- @class vim.lsp.buf.signature_help.Opts : vim.lsp.util.open_floating_preview.Opts
 --- @field silent? boolean
 
--- TODO(lewis6991): support multiple clients
 --- Displays signature information about the symbol under the cursor in a
 --- floating window.
---- @param config? vim.lsp.buf.signature_help.Opts
-function M.signature_help(config)
+--- @param opts? vim.lsp.buf.signature_help.Opts
+function M.signature_help(opts)
   local method = ms.textDocument_signatureHelp
 
-  config = config and vim.deepcopy(config) or {}
-  config.focus_id = method
+  opts = opts and vim.deepcopy(opts) or {}
+  opts.focus_id = method
 
   lsp.buf_request_all(0, method, client_positional_params(), function(results, ctx)
     if api.nvim_get_current_buf() ~= ctx.bufnr then
@@ -309,7 +308,7 @@ function M.signature_help(config)
     local signatures = process_signature_help_results(results)
 
     if not next(signatures) then
-      if config.silent ~= true then
+      if opts.silent ~= true then
         print('No signature help available')
       end
       return
@@ -334,8 +333,8 @@ function M.signature_help(config)
 
       local sfx = total > 1 and string.format(' (%d/%d) (<C-s> to cycle)', idx, total) or ''
       local title = string.format('Signature Help: %s%s', client.name, sfx)
-      if config.border then
-        config.title = title
+      if opts.border then
+        opts.title = title
       else
         table.insert(lines, 1, '# ' .. title)
         if hl then
@@ -344,9 +343,9 @@ function M.signature_help(config)
         end
       end
 
-      config._update_win = update_win
+      opts._update_win = update_win
 
-      local buf, win = util.open_floating_preview(lines, 'markdown', config)
+      local buf, win = util.open_floating_preview(lines, 'markdown', opts)
 
       if hl then
         vim.api.nvim_buf_clear_namespace(buf, sig_help_ns, 0, -1)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -2019,16 +2019,17 @@ end
 --- Creates a `DocumentFormattingParams` object for the current buffer and cursor position.
 ---
 ---@param options lsp.FormattingOptions? with valid `FormattingOptions` entries
+---@param bufnr? integer buffer handle or 0 for current, defaults to current
 ---@return lsp.DocumentFormattingParams object
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting
-function M.make_formatting_params(options)
+function M.make_formatting_params(options, bufnr)
   validate('options', options, 'table', true)
   options = vim.tbl_extend('keep', options or {}, {
     tabSize = M.get_effective_tabstop(),
     insertSpaces = vim.bo.expandtab,
   })
   return {
-    textDocument = { uri = vim.uri_from_bufnr(0) },
+    textDocument = { uri = vim.uri_from_bufnr(bufnr or 0) },
     options = options,
   }
 end


### PR DESCRIPTION
Inline the handlers from vim.lsp.handlers.

- multi-cient: the timeout now applies to the whole of
  `vim.lsp.buf.format()` instead of the timeout for each request.