### PR TITLE
fix(editorconfig): rename augroup

### DIFF
--- a/runtime/lua/editorconfig.lua
+++ b/runtime/lua/editorconfig.lua
@@ -151,7 +151,7 @@ function properties.trim_trailing_whitespace(bufnr, val)
   )
   if val == 'true' then
     vim.api.nvim_create_autocmd('BufWritePre', {
-      group = 'editorconfig',
+      group = 'nvim_editorconfig',
       buffer = bufnr,
       callback = function()
         local view = vim.fn.winsaveview()
@@ -163,7 +163,7 @@ function properties.trim_trailing_whitespace(bufnr, val)
   else
     vim.api.nvim_clear_autocmds({
       event = 'BufWritePre',
-      group = 'editorconfig',
+      group = 'nvim_editorconfig',
       buffer = bufnr,
     })
   end
@@ -180,7 +180,7 @@ function properties.insert_final_newline(bufnr, val)
   local endofline = val == 'true'
   if vim.bo[bufnr].endofline ~= endofline then
     vim.api.nvim_create_autocmd('BufWritePre', {
-      group = 'editorconfig',
+      group = 'nvim_editorconfig',
       buffer = bufnr,
       once = true,
       callback = function()

--- a/runtime/plugin/editorconfig.lua
+++ b/runtime/plugin/editorconfig.lua
@@ -1,4 +1,4 @@
-local group = vim.api.nvim_create_augroup('editorconfig', {})
+local group = vim.api.nvim_create_augroup('nvim_editorconfig', {})
 vim.api.nvim_create_autocmd({ 'BufNewFile', 'BufRead', 'BufFilePost' }, {
   group = group,
   callback = function(args)


### PR DESCRIPTION
Problem:
Builtin editorconfig plugin's augroup name conflicts with https://github.com/editorconfig/editorconfig-vim, overriding that plugin.

Solution:
Rename the augroup.