### PR TITLE
vim-patch:9.1.0839: filetype: leo files are not recognized

### DIFF
--- a/runtime/ftplugin/leo.vim
+++ b/runtime/ftplugin/leo.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin
+" Language:	Leo
+" Maintainer:	Riley Bruins <ribru17@gmail.com>
+" Last Change:	2024 Nov 03
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setl comments=:// commentstring=//\ %s
+
+let b:undo_ftplugin = 'setl com< cms<'

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -668,6 +668,7 @@ local extension = {
   journal = 'ledger',
   ldg = 'ledger',
   ledger = 'ledger',
+  leo = 'leo',
   less = 'less',
   lex = 'lex',
   lxx = 'lex',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -406,6 +406,7 @@ func s:GetFilenameChecks() abort
     \ 'lean': ['file.lean'],
     \ 'ledger': ['file.ldg', 'file.ledger', 'file.journal'],
     \ 'less': ['file.less'],
+    \ 'leo': ['file.leo'],
     \ 'lex': ['file.lex', 'file.l', 'file.lxx', 'file.l++'],
     \ 'lf': ['lfrc'],
     \ 'lftp': ['lftp.conf', '.lftprc', 'anylftp/rc', 'lftp/rc', 'some-lftp/rc'],


### PR DESCRIPTION
Problem:  filetype: leo files are not recognized
Solution: detect '*.leo' files as leo filetype, include
          a filetype plugin (Riley Bruins)

References:
https://github.com/ProvableHQ/leo

closes: vim/vim#15988

https://github.com/vim/vim/commit/93f65a4ab8168c766e4d3794607762b52762ef82

Co-authored-by: Riley Bruins <ribru17@hotmail.com>
