### PR TITLE
vim-patch:9.1.0841: tests: still preferring python2 over python3

### DIFF
--- a/test/old/testdir/shared.vim
+++ b/test/old/testdir/shared.vim
@@ -35,12 +35,20 @@ func PythonProg()
   if has('unix')
     " We also need the job feature or the pkill command to make sure the server
     " can be stopped.
-    if !(executable('python') && (has('job') || executable('pkill')))
+    if !(has('job') || executable('pkill'))
       return ''
     endif
-    let s:python = 'python'
+    if executable('python3')
+      let s:python = 'python3'
+    elseif executable('python')
+      let s:python = 'python'
+    else
+      return ''
+    end
   elseif has('win32')
     " Use Python Launcher for Windows (py.exe) if available.
+    " NOTE: if you get a "Python was not found" error, disable the Python
+    " shortcuts in "Windows menu / Settings / Manage App Execution Aliases".
     if executable('py.exe')
       let s:python = 'py.exe'
     elseif executable('python.exe')

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -727,8 +727,8 @@ func Test_fullcommand()
         \ ':5s':        'substitute',
         \ "'<,'>s":     'substitute',
         \ ":'<,'>s":    'substitute',
-        \ 'CheckUni':   'CheckUnix',
-        \ 'CheckUnix':  'CheckUnix',
+        \ 'CheckLin':   'CheckLinux',
+        \ 'CheckLinux': 'CheckLinux',
   \ }
 
   for [in, want] in items(tests)


### PR DESCRIPTION
#### vim-patch:9.1.0841: tests: still preferring python2 over python3

Problem:  tests: still preferring python2 over python3
Solution: prefer Python 3 when picking a Python program in Vim tests,
          by checking for the more specific python version first and
          only when python3 not found, check for the python binary
          (Yee Cheng Chin)

Most OSes have Python 3 mapped to `python3` instead of `python`. Vim
tests should prioritize using that instead of Python 2 in case that is
still installed on the host system.

closes: vim/vim#15986

https://github.com/vim/vim/commit/cef8ab2c75841cee1cd72266aa662fbe54fc0acc

Cherry-pick test changes from patch 8.2.{2824,4684}.

Co-authored-by: Yee Cheng Chin <ychin.git@gmail.com>