### PR TITLE
feat(lua): vim.on_key() can disable mapping

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1398,6 +1398,9 @@ vim.on_key({fn}, {ns_id}, {opts})                               *vim.on_key()*
       • {ns_id}  (`integer?`) Namespace ID. If nil or 0, generates and returns
                  a new |nvim_create_namespace()| id.
       • {opts}   (`table?`) Optional parameters
+                 • {mapping}? (boolean, default true) When false, key mapping
+                   is disabled; use with caution. If all the keys are
+                   discarded, set this and mappings do not get in the way.
 
     Return: ~
         (`integer`) Namespace id associated with {fn}. Or count of all

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -165,6 +165,7 @@ API
 • Added experimental |nvim__exec_lua_fast()| to allow remote API clients to
   execute code while nvim is blocking for input.
 • |vim.secure.trust()| accepts `path` for the `allow` action.
+• |vim.on_key()| accepts `mapping` boolean in the `opts` table.
 
 BUILD
 

--- a/runtime/lua/vim/_core/editor.lua
+++ b/runtime/lua/vim/_core/editor.lua
@@ -572,6 +572,30 @@ do
 end
 
 local on_key_cbs = {} --- @type table<integer,[function, table]>
+local on_key_mapping_enabled = true --- @type boolean
+
+--- Used by "C"'s vgetc() to check if some on_key handler is disabling mapping.
+---
+--- @return boolean true to disable mapping
+function vim._on_key_no_mapping()
+  return not on_key_mapping_enabled
+end
+
+--- Check if mapping should be disabled.
+local function check_on_key_mapping_enabled()
+  local enabled = true
+  for _, v in pairs(on_key_cbs) do
+    local opts = v[2]
+    if not opts.mapping then
+      enabled = false
+      break
+    end
+  end
+  --if on_key_mapping_enabled ~= enabled then
+  --  vim.print(string.format("check_on_key_mapping_enabled switched to %s", enabled))
+  --end
+  on_key_mapping_enabled = enabled
+end
 
 --- Adds Lua function {fn} with namespace id {ns_id} as a listener to every,
 --- yes every, input key.
@@ -596,6 +620,9 @@ local on_key_cbs = {} --- @type table<integer,[function, table]>
 ---@param ns_id integer? Namespace ID. If nil or 0, generates and returns a
 ---                      new |nvim_create_namespace()| id.
 ---@param opts table? Optional parameters
+---              - {mapping}? (boolean, default true) When false, key mapping is
+---                disabled; use with caution. If all the keys are discarded,
+---                set this and mappings do not get in the way.
 ---
 ---@see |keytrans()|
 ---
@@ -610,12 +637,14 @@ function vim.on_key(fn, ns_id, opts)
   vim.validate('ns_id', ns_id, 'number', true)
   vim.validate('opts', opts, 'table', true)
   opts = opts or {}
+  opts.mapping = not (opts.mapping == false)
 
   if ns_id == nil or ns_id == 0 then
     ns_id = vim.api.nvim_create_namespace('')
   end
 
   on_key_cbs[ns_id] = fn and { fn, opts }
+  check_on_key_mapping_enabled()
   return ns_id
 end
 

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1642,9 +1642,12 @@ int vgetc(void)
     // if peeking records more
     last_recorded_len -= last_vgetc_recorded_len;
 
+    bool on_key_no_mapping = nlua_execute_on_key_no_mapping();
     while (true) {              // this is done twice if there are modifiers
       bool did_inc = false;
-      if (mod_mask) {           // no mapping after modifier has been read
+      // No mapping after modifier has been read
+      // or when on_key options have disabled mapping.
+      if (mod_mask || on_key_no_mapping) {
         no_mapping++;
         allow_keys++;
         did_inc = true;         // mod_mask may change value

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -2076,6 +2076,30 @@ char *nlua_register_table_as_callable(const typval_T *const arg)
   return name;
 }
 
+/// @return true to disable mapping
+bool nlua_execute_on_key_no_mapping(void)
+{
+  lua_State *const lstate = global_lstate;
+
+  // [ vim ]
+  lua_getglobal(lstate, "vim");
+
+  // [ vim, vim._on_key_no_mapping ]
+  lua_getfield(lstate, -1, "_on_key_no_mapping");
+  luaL_checktype(lstate, -1, LUA_TFUNCTION);
+
+  bool on_key_no_mapping = false;
+  // Ignore an error (error impossible?), mapping is enabled.
+  if (!lua_pcall(lstate, 0, 1, 0)) {
+    on_key_no_mapping = lua_toboolean(lstate, -1);
+  }
+
+  // [ vim, result ]
+  lua_pop(lstate, 2);
+
+  return on_key_no_mapping;
+}
+
 /// @return true to discard the key
 bool nlua_execute_on_key(int c, char *typed_buf)
 {

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -2196,6 +2196,27 @@ stack traceback:
       expect('21')
       eq('', eval('v:errmsg'))
     end)
+
+    it('disable mapping', function()
+      exec_lua [[
+        keys_mapped = {}
+        keys_unmapped = {}
+        vim.keymap.set('', 'll', '0')
+        local ns_id
+
+        local function testit(map_flag, result)
+          ns_id = vim.on_key(function(buf, typed_buf)
+            table.insert(result, buf)
+          end, ns_id, {mapping = map_flag})
+          vim.fn.feedkeys('llll', 't')
+          vim.fn.feedkeys('', 'x')
+        end
+        testit(true, keys_mapped)
+        testit(false, keys_unmapped)
+      ]]
+      eq('00', exec_lua [[return table.concat(keys_mapped, '')]])
+      eq('llll', exec_lua [[return table.concat(keys_unmapped, '')]])
+    end)
   end)
 
   describe('vim.wait', function()


### PR DESCRIPTION
Problem: emulating vim popup, for filter, requires temporarily disabling mapping. https://github.com/neovim/neovim/issues/30741#issuecomment-2451195906