### PR TITLE
docs: standardize doc for ChanInfo/ChanOpen autocmds/v:event

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -353,15 +353,11 @@ BufWritePost			After writing the whole buffer to a file
 ChanInfo			State of channel changed, for instance the
 				client of a RPC channel described itself.
 				Sets these |v:event| keys:
-				    info
-				See |nvim_get_chan_info()| for the format of
-				the info Dictionary.
+				    info	as from |nvim_get_chan_info()|
 							*ChanOpen*
 ChanOpen			Just after a channel was opened.
 				Sets these |v:event| keys:
-				    info
-				See |nvim_get_chan_info()| for the format of
-				the info Dictionary.
+				    info	as from |nvim_get_chan_info()|
 							*CmdUndefined*
 CmdUndefined			When a user command is used but it isn't
 				defined.  Useful for defining a command only

--- a/runtime/doc/vvars.txt
+++ b/runtime/doc/vvars.txt
@@ -152,6 +152,7 @@ v:event
 		                   an aborting condition (e.g. |c_Esc| or
 		                   |c_CTRL-C| for |CmdlineLeave|).
 		  chan             |channel-id|
+		  info             Dict of arbitrary event data.
 		  cmdlevel         Level of cmdline.
 		  cmdtype          Type of cmdline, |cmdline-char|.
 		  cwd              Current working directory.

--- a/runtime/lua/vim/_meta/vvars.lua
+++ b/runtime/lua/vim/_meta/vvars.lua
@@ -160,6 +160,7 @@ vim.v.errors = ...
 ---                    an aborting condition (e.g. `c_Esc` or
 ---                    `c_CTRL-C` for `CmdlineLeave`).
 ---   chan             `channel-id`
+---   info             Dict of arbitrary event data.
 ---   cmdlevel         Level of cmdline.
 ---   cmdtype          Type of cmdline, `cmdline-char`.
 ---   cwd              Current working directory.

--- a/src/nvim/vvars.lua
+++ b/src/nvim/vvars.lua
@@ -171,6 +171,7 @@ M.vars = {
                          an aborting condition (e.g. |c_Esc| or
                          |c_CTRL-C| for |CmdlineLeave|).
         chan             |channel-id|
+        info             Dict of arbitrary event data.
         cmdlevel         Level of cmdline.
         cmdtype          Type of cmdline, |cmdline-char|.
         cwd              Current working directory.


### PR DESCRIPTION
Problem:
ChanInfo/ChanOpen autocmd doc not standard; their v:event key not documented in :he v:event.

Solution:
Update the docs.