### PR TITLE
refactor(options): remove `os_(buf|win)`

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5291,18 +5291,17 @@ static char *findfunc_find_file(char *findarg, size_t findarg_len, int count)
 /// Returns NULL on success and an error message on failure.
 const char *did_set_findfunc(optset_T *args)
 {
-  buf_T *buf = (buf_T *)args->os_buf;
   int retval;
 
   if (args->os_flags & OPT_LOCAL) {
     // buffer-local option set
-    retval = option_set_callback_func(buf->b_p_ffu, &buf->b_ffu_cb);
+    retval = option_set_callback_func(curbuf->b_p_ffu, &curbuf->b_ffu_cb);
   } else {
     // global option set
     retval = option_set_callback_func(p_ffu, &ffu_cb);
     // when using :set, free the local callback
     if (!(args->os_flags & OPT_GLOBAL)) {
-      callback_free(&buf->b_ffu_cb);
+      callback_free(&curbuf->b_ffu_cb);
     }
   }
 

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2370,11 +2370,10 @@ static void copy_global_to_buflocal_cb(Callback *globcb, Callback *bufcb)
 /// lambda expression.
 const char *did_set_completefunc(optset_T *args)
 {
-  buf_T *buf = (buf_T *)args->os_buf;
-  if (option_set_callback_func(buf->b_p_cfu, &cfu_cb) == FAIL) {
+  if (option_set_callback_func(curbuf->b_p_cfu, &cfu_cb) == FAIL) {
     return e_invarg;
   }
-  set_buflocal_cfu_callback(buf);
+  set_buflocal_cfu_callback(curbuf);
   return NULL;
 }
 
@@ -2391,11 +2390,10 @@ void set_buflocal_cfu_callback(buf_T *buf)
 /// lambda expression.
 const char *did_set_omnifunc(optset_T *args)
 {
-  buf_T *buf = (buf_T *)args->os_buf;
-  if (option_set_callback_func(buf->b_p_ofu, &ofu_cb) == FAIL) {
+  if (option_set_callback_func(curbuf->b_p_ofu, &ofu_cb) == FAIL) {
     return e_invarg;
   }
-  set_buflocal_ofu_callback(buf);
+  set_buflocal_ofu_callback(curbuf);
   return NULL;
 }
 
@@ -2412,18 +2410,17 @@ void set_buflocal_ofu_callback(buf_T *buf)
 /// lambda expression.
 const char *did_set_thesaurusfunc(optset_T *args FUNC_ATTR_UNUSED)
 {
-  buf_T *buf = (buf_T *)args->os_buf;
   int retval;
 
   if (args->os_flags & OPT_LOCAL) {
     // buffer-local option set
-    retval = option_set_callback_func(buf->b_p_tsrfu, &buf->b_tsrfu_cb);
+    retval = option_set_callback_func(curbuf->b_p_tsrfu, &curbuf->b_tsrfu_cb);
   } else {
     // global option set
     retval = option_set_callback_func(p_tsrfu, &tsrfu_cb);
     // when using :set, free the local callback
     if (!(args->os_flags & OPT_GLOBAL)) {
-      callback_free(&buf->b_tsrfu_cb);
+      callback_free(&curbuf->b_tsrfu_cb);
     }
   }
 

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -113,9 +113,6 @@ typedef struct {
   char *os_errbuf;
   /// length of the error buffer
   size_t os_errbuflen;
-
-  void *os_win;
-  void *os_buf;
 } optset_T;
 
 /// Type for the callback function that is invoked after an option value is

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -229,20 +229,18 @@ static Callback tfu_cb;          // 'tagfunc' callback function
 /// a function (string), or function(<name>) or funcref(<name>) or a lambda.
 const char *did_set_tagfunc(optset_T *args)
 {
-  buf_T *buf = (buf_T *)args->os_buf;
-
   callback_free(&tfu_cb);
-  callback_free(&buf->b_tfu_cb);
+  callback_free(&curbuf->b_tfu_cb);
 
-  if (*buf->b_p_tfu == NUL) {
+  if (*curbuf->b_p_tfu == NUL) {
     return NULL;
   }
 
-  if (option_set_callback_func(buf->b_p_tfu, &tfu_cb) == FAIL) {
+  if (option_set_callback_func(curbuf->b_p_tfu, &tfu_cb) == FAIL) {
     return e_invarg;
   }
 
-  callback_copy(&buf->b_tfu_cb, &tfu_cb);
+  callback_copy(&curbuf->b_tfu_cb, &tfu_cb);
   return NULL;
 }
 


### PR DESCRIPTION
Problem: An option can only ever be set for the current buffer / window. Functions like `set_option_value_for` set the option value for another buffer/window by temporarily switching the current buffer/window. As a result, `os_(buf|win)` are always set to the current buffer/window. This makes them entirely redundant.

Solution: Remove `os_(buf|win)` and replace every instance of them with `curbuf` or `curwin`

Supersedes #31060

CC: @zeertzjq 