### PR TITLE
feat(options)!: disallow setting options to sentinel value

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -115,6 +115,8 @@ OPTIONS
   and boolean |global-local| options instead of removing the local value.
 • Setting |hidden-options| now gives an error. In particular, setting
   'noshellslash' is now only allowed on Windows.
+• Setting the local value of |'scrolloff'| or |'sidescrolloff'| to `-1` now gives an
+  error. Use `:set {option}<` instead to unset the local option value.
 
 PLUGINS
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4897,10 +4897,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	you set it to a very large value (999) the cursor line will always be
 	in the middle of the window (except at the start or end of the file or
 	when long lines wrap).
-	After using the local value, go back the global value with one of
-	these two: >vim
-		setlocal scrolloff<
-		setlocal scrolloff=-1
+	After using the local value, go back the global value with this: >vim
+		set scrolloff<
 <	For scrolling horizontally see 'sidescrolloff'.
 
 						*'scrollopt'* *'sbo'*
@@ -5522,10 +5520,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	to a large value (like 999) has the effect of keeping the cursor
 	horizontally centered in the window, as long as one does not come too
 	close to the beginning of the line.
-	After using the local value, go back the global value with one of
-	these two: >vim
-		setlocal sidescrolloff<
-		setlocal sidescrolloff=-1
+	After using the local value, go back the global value with this: >vim
+		set sidescrolloff<
 <
 	Example: Try this together with 'sidescroll' and 'listchars' as
 		 in the following example to never allow the cursor to move
@@ -6672,8 +6668,6 @@ A jump table for the options with a short description can be found at |Q_op|.
 	current buffer: >vim
 		setlocal ul=-1
 <	This helps when you run out of memory for a single change.
-
-	The local value is set to -123456 when the global value is to be used.
 
 	Also see |clear-undo|.
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -362,6 +362,7 @@ Options:
 - 'mousescroll' amount to scroll by when scrolling with a mouse
 - 'pumblend'    pseudo-transparent popupmenu
 - 'scrollback'
+- |'scrolloff'|, |'sidescrolloff'| cannot be set to `-1`
 - 'shortmess'
     - "F" flag does not affect output from autocommands.
     - "q" flag fully hides macro recording message.

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5112,12 +5112,10 @@ vim.go.sj = vim.go.scrolljump
 --- you set it to a very large value (999) the cursor line will always be
 --- in the middle of the window (except at the start or end of the file or
 --- when long lines wrap).
---- After using the local value, go back the global value with one of
---- these two:
+--- After using the local value, go back the global value with this:
 ---
 --- ```vim
---- 	setlocal scrolloff<
---- 	setlocal scrolloff=-1
+--- 	set scrolloff<
 --- ```
 --- For scrolling horizontally see 'sidescrolloff'.
 ---
@@ -5845,12 +5843,10 @@ vim.go.ss = vim.go.sidescroll
 --- to a large value (like 999) has the effect of keeping the cursor
 --- horizontally centered in the window, as long as one does not come too
 --- close to the beginning of the line.
---- After using the local value, go back the global value with one of
---- these two:
+--- After using the local value, go back the global value with this:
 ---
 --- ```vim
---- 	setlocal sidescrolloff<
---- 	setlocal sidescrolloff=-1
+--- 	set sidescrolloff<
 --- ```
 ---
 --- Example: Try this together with 'sidescroll' and 'listchars' as
@@ -7224,8 +7220,6 @@ vim.bo.udf = vim.bo.undofile
 --- 	setlocal ul=-1
 --- ```
 --- This helps when you run out of memory for a single change.
----
---- The local value is set to -123456 when the global value is to be used.
 ---
 --- Also see `clear-undo`.
 ---

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -1015,7 +1015,7 @@ void ex_mkrc(exarg_T *eap)
     if (!failed && view_session) {
       if (put_line(fd,
                    "let s:so_save = &g:so | let s:siso_save = &g:siso"
-                   " | setg so=0 siso=0 | setl so=-1 siso=-1") == FAIL) {
+                   " | setg so=0 siso=0 | set so< siso<") == FAIL) {
         failed = true;
       }
       if (eap->cmdidx == CMD_mksession) {

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1244,11 +1244,10 @@ static void do_one_set_option(int opt_flags, char **argp, bool *did_show, char *
   }
 
   uint8_t nextchar = (uint8_t)(*p);  // next non-white char after option name
-  uint32_t flags = 0;  // flags for current option
-  void *varp = NULL;  // pointer to variable for current option
-
-  flags = options[opt_idx].flags;
-  varp = get_varp_scope(&(options[opt_idx]), opt_flags);
+  // flags for current option
+  uint32_t flags = options[opt_idx].flags;
+  // pointer to variable for current option
+  void *varp = get_varp_scope(&(options[opt_idx]), opt_flags);
 
   if (validate_opt_idx(curwin, opt_idx, opt_flags, flags, prefix, errmsg) == FAIL) {
     return;
@@ -1325,8 +1324,7 @@ static void do_one_set_option(int opt_flags, char **argp, bool *did_show, char *
     return;
   }
 
-  *errmsg = set_option(opt_idx, varp, newval, opt_flags, 0, false, op == OP_NONE, errbuf,
-                       errbuflen);
+  *errmsg = set_option(opt_idx, newval, opt_flags, 0, false, op == OP_NONE, errbuf, errbuflen);
 }
 
 /// Parse 'arg' for option settings.
@@ -2746,15 +2744,14 @@ static void do_spelllang_source(win_T *win)
 /// Check the bounds of numeric options.
 ///
 /// @param          opt_idx    Index in options[] table. Must not be kOptInvalid.
-/// @param[in]      varp       Pointer to option variable.
 /// @param[in,out]  newval     Pointer to new option value. Will be set to bound checked value.
 /// @param[out]     errbuf     Buffer for error message. Cannot be NULL.
 /// @param          errbuflen  Length of error buffer.
 ///
 /// @return Error message, if any.
-static const char *check_num_option_bounds(OptIndex opt_idx, void *varp, OptInt *newval,
-                                           char *errbuf, size_t errbuflen)
-  FUNC_ATTR_NONNULL_ARG(4)
+static const char *check_num_option_bounds(OptIndex opt_idx, OptInt *newval, char *errbuf,
+                                           size_t errbuflen)
+  FUNC_ATTR_NONNULL_ARG(3)
 {
   const char *errmsg = NULL;
 
@@ -2787,9 +2784,7 @@ static const char *check_num_option_bounds(OptIndex opt_idx, void *varp, OptInt 
     }
     break;
   case kOptScroll:
-    if (varp == &(curwin->w_p_scr)
-        && (*newval <= 0
-            || (*newval > curwin->w_height_inner && curwin->w_height_inner > 0))
+    if ((*newval <= 0 || (*newval > curwin->w_height_inner && curwin->w_height_inner > 0))
         && full_screen) {
       if (*newval != 0) {
         errmsg = e_scroll;
@@ -2807,13 +2802,12 @@ static const char *check_num_option_bounds(OptIndex opt_idx, void *varp, OptInt 
 /// Validate and bound check option value.
 ///
 /// @param          opt_idx    Index in options[] table. Must not be kOptInvalid.
-/// @param[in]      varp       Pointer to option variable.
 /// @param[in,out]  newval     Pointer to new option value. Will be set to bound checked value.
 /// @param[out]     errbuf     Buffer for error message. Cannot be NULL.
 /// @param          errbuflen  Length of error buffer.
 ///
 /// @return Error message, if any.
-static const char *validate_num_option(OptIndex opt_idx, void *varp, OptInt *newval, char *errbuf,
+static const char *validate_num_option(OptIndex opt_idx, OptInt *newval, char *errbuf,
                                        size_t errbuflen)
 {
   OptInt value = *newval;
@@ -2823,145 +2817,137 @@ static const char *validate_num_option(OptIndex opt_idx, void *varp, OptInt *new
     return e_invarg;
   }
 
-  if (varp == &p_wh) {
+  switch (opt_idx) {
+  case kOptHelpheight:
+  case kOptTitlelen:
+  case kOptUpdatecount:
+  case kOptReport:
+  case kOptUpdatetime:
+  case kOptSidescroll:
+  case kOptFoldlevel:
+  case kOptShiftwidth:
+  case kOptTextwidth:
+  case kOptWritedelay:
+  case kOptTimeoutlen:
+    if (value < 0) {
+      return e_positive;
+    }
+    break;
+  case kOptWinheight:
     if (value < 1) {
       return e_positive;
     } else if (p_wmh > value) {
       return e_winheight;
     }
-  } else if (varp == &p_hh) {
-    if (value < 0) {
-      return e_positive;
-    }
-  } else if (varp == &p_wmh) {
+    break;
+  case kOptWinminheight:
     if (value < 0) {
       return e_positive;
     } else if (value > p_wh) {
       return e_winheight;
     }
-  } else if (varp == &p_wiw) {
+    break;
+  case kOptWinwidth:
     if (value < 1) {
       return e_positive;
     } else if (p_wmw > value) {
       return e_winwidth;
     }
-  } else if (varp == &p_wmw) {
+    break;
+  case kOptWinminwidth:
     if (value < 0) {
       return e_positive;
     } else if (value > p_wiw) {
       return e_winwidth;
     }
-  } else if (varp == &p_mco) {
+    break;
+  case kOptMaxcombine:
     *newval = MAX_MCO;
-  } else if (varp == &p_titlelen) {
-    if (value < 0) {
-      return e_positive;
-    }
-  } else if (varp == &p_uc) {
-    if (value < 0) {
-      return e_positive;
-    }
-  } else if (varp == &p_ch) {
+    break;
+  case kOptCmdheight:
     if (value < 0) {
       return e_positive;
     } else {
       p_ch_was_zero = value == 0;
     }
-  } else if (varp == &p_tm) {
-    if (value < 0) {
-      return e_positive;
-    }
-  } else if (varp == &p_hi) {
+    break;
+  case kOptHistory:
     if (value < 0) {
       return e_positive;
     } else if (value > 10000) {
       return e_invarg;
     }
-  } else if (varp == &p_pyx) {
+    break;
+  case kOptPyxversion:
     if (value == 0) {
       *newval = 3;
     } else if (value != 3) {
       return e_invarg;
     }
-  } else if (varp == &p_re) {
+    break;
+  case kOptRegexpengine:
     if (value < 0 || value > 2) {
       return e_invarg;
     }
-  } else if (varp == &p_report) {
-    if (value < 0) {
-      return e_positive;
-    }
-  } else if (varp == &p_so) {
+    break;
+  case kOptScrolloff:
     if (value < 0 && full_screen) {
       return e_positive;
     }
-  } else if (varp == &p_siso) {
+    break;
+  case kOptSidescrolloff:
     if (value < 0 && full_screen) {
       return e_positive;
     }
-  } else if (varp == &p_cwh) {
+    break;
+  case kOptCmdwinheight:
     if (value < 1) {
       return e_positive;
     }
-  } else if (varp == &p_ut) {
-    if (value < 0) {
-      return e_positive;
-    }
-  } else if (varp == &p_ss) {
-    if (value < 0) {
-      return e_positive;
-    }
-  } else if (varp == &curwin->w_p_fdl || varp == &curwin->w_allbuf_opt.wo_fdl) {
-    if (value < 0) {
-      return e_positive;
-    }
-  } else if (varp == &curwin->w_p_cole || varp == &curwin->w_allbuf_opt.wo_cole) {
+    break;
+  case kOptConceallevel:
     if (value < 0) {
       return e_positive;
     } else if (value > 3) {
       return e_invarg;
     }
-  } else if (varp == &curwin->w_p_nuw || varp == &curwin->w_allbuf_opt.wo_nuw) {
+    break;
+  case kOptNumberwidth:
     if (value < 1) {
       return e_positive;
     } else if (value > MAX_NUMBERWIDTH) {
       return e_invarg;
     }
-  } else if (varp == &curbuf->b_p_iminsert || varp == &p_iminsert) {
+    break;
+  case kOptIminsert:
     if (value < 0 || value > B_IMODE_LAST) {
       return e_invarg;
     }
-  } else if (varp == &curbuf->b_p_imsearch || varp == &p_imsearch) {
+    break;
+  case kOptImsearch:
     if (value < -1 || value > B_IMODE_LAST) {
       return e_invarg;
     }
-  } else if (varp == &curbuf->b_p_channel || varp == &p_channel) {
+    break;
+  case kOptChannel:
     return e_invarg;
-  } else if (varp == &curbuf->b_p_scbk || varp == &p_scbk) {
+  case kOptScrollback:
     if (value < -1 || value > SB_MAX) {
       return e_invarg;
     }
-  } else if (varp == &curbuf->b_p_sw || varp == &p_sw) {
-    if (value < 0) {
-      return e_positive;
-    }
-  } else if (varp == &curbuf->b_p_ts || varp == &p_ts) {
+    break;
+  case kOptTabstop:
     if (value < 1) {
       return e_positive;
     } else if (value > TABSTOP_MAX) {
       return e_invarg;
     }
-  } else if (varp == &curbuf->b_p_tw || varp == &p_tw) {
-    if (value < 0) {
-      return e_positive;
-    }
-  } else if (varp == &p_wd) {
-    if (value < 0) {
-      return e_positive;
-    }
+    break;
+  default:
+    break;
   }
 
-  return check_num_option_bounds(opt_idx, varp, newval, errbuf, errbuflen);
+  return check_num_option_bounds(opt_idx, newval, errbuf, errbuflen);
 }
 
 /// Called after an option changed: check if something needs to be redrawn.
@@ -3588,10 +3574,9 @@ static const char *did_set_option(OptIndex opt_idx, void *varp, OptVal old_value
 /// Validate the new value for an option.
 ///
 /// @param  opt_idx         Index in options[] table. Must not be kOptInvalid.
-/// @param  varp            Pointer to option variable.
 /// @param  newval[in,out]  New option value. Might be modified.
-static const char *validate_option_value(const OptIndex opt_idx, void *varp, OptVal *newval,
-                                         int opt_flags, char *errbuf, size_t errbuflen)
+static const char *validate_option_value(const OptIndex opt_idx, OptVal *newval, int opt_flags,
+                                         char *errbuf, size_t errbuflen)
 {
   const char *errmsg = NULL;
   vimoption_T *opt = &options[opt_idx];
@@ -3615,7 +3600,7 @@ static const char *validate_option_value(const OptIndex opt_idx, void *varp, Opt
     errmsg = errbuf;
   } else if (newval->type == kOptValTypeNumber) {
     // Validate and bound check num option values.
-    errmsg = validate_num_option(opt_idx, varp, &newval->data.number, errbuf, errbuflen);
+    errmsg = validate_num_option(opt_idx, &newval->data.number, errbuf, errbuflen);
   }
 
   return errmsg;
@@ -3624,7 +3609,6 @@ static const char *validate_option_value(const OptIndex opt_idx, void *varp, Opt
 /// Set the value of an option using an OptVal.
 ///
 /// @param       opt_idx         Index in options[] table. Must not be kOptInvalid.
-/// @param[in]   varp            Option variable pointer, cannot be NULL.
 /// @param       value           New option value. Might get freed.
 /// @param       opt_flags       Option flags.
 /// @param       set_sid         Script ID. Special values:
@@ -3636,17 +3620,16 @@ static const char *validate_option_value(const OptIndex opt_idx, void *varp, Opt
 /// @param       errbuflen       Length of error buffer.
 ///
 /// @return  NULL on success, an untranslated error message on error.
-static const char *set_option(const OptIndex opt_idx, void *varp, OptVal value, int opt_flags,
-                              scid_T set_sid, const bool direct, const bool value_replaced,
-                              char *errbuf, size_t errbuflen)
-  FUNC_ATTR_NONNULL_ARG(2)
+static const char *set_option(const OptIndex opt_idx, OptVal value, int opt_flags, scid_T set_sid,
+                              const bool direct, const bool value_replaced, char *errbuf,
+                              size_t errbuflen)
 {
   assert(opt_idx != kOptInvalid);
 
   const char *errmsg = NULL;
 
   if (!direct) {
-    errmsg = validate_option_value(opt_idx, varp, &value, opt_flags, errbuf, errbuflen);
+    errmsg = validate_option_value(opt_idx, &value, opt_flags, errbuf, errbuflen);
 
     if (errmsg != NULL) {
       optval_free(value);
@@ -3663,11 +3646,9 @@ static const char *set_option(const OptIndex opt_idx, void *varp, OptVal value, 
   const bool is_opt_local_unset = is_option_local_value_unset(opt_idx);
 
   // When using ":set opt=val" for a global option with a local value the local value will be reset,
-  // use the global value here.
-  if (scope_both && option_is_global_local(opt_idx)) {
-    varp = opt->var;
-  }
-
+  // use the global value in that case.
+  void *varp
+    = scope_both && option_is_global_local(opt_idx) ? opt->var : get_varp_scope(opt, opt_flags);
   void *varp_local = get_varp_scope(opt, OPT_LOCAL);
   void *varp_global = get_varp_scope(opt, OPT_GLOBAL);
 
@@ -3741,16 +3722,11 @@ void set_option_direct(OptIndex opt_idx, OptVal value, int opt_flags, scid_T set
 {
   static char errbuf[IOSIZE];
 
-  vimoption_T *opt = get_option(opt_idx);
-
   if (is_option_hidden(opt_idx)) {
     return;
   }
 
-  const bool scope_both = (opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0;
-  void *varp = get_varp_scope(opt, scope_both ? OPT_LOCAL : opt_flags);
-
-  const char *errmsg = set_option(opt_idx, varp, optval_copy(value), opt_flags, set_sid, true, true,
+  const char *errmsg = set_option(opt_idx, optval_copy(value), opt_flags, set_sid, true, true,
                                   errbuf, sizeof(errbuf));
   assert(errmsg == NULL);
   (void)errmsg;  // ignore unused warning
@@ -3812,13 +3788,7 @@ const char *set_option_value(const OptIndex opt_idx, const OptVal value, int opt
     return _(e_sandbox);
   }
 
-  void *varp = get_varp_scope(&(options[opt_idx]), opt_flags);
-  if (varp == NULL) {
-    // hidden option is not changed
-    return NULL;
-  }
-
-  return set_option(opt_idx, varp, optval_copy(value), opt_flags, 0, false, true, errbuf,
+  return set_option(opt_idx, optval_copy(value), opt_flags, 0, false, true, errbuf,
                     sizeof(errbuf));
 }
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -6729,10 +6729,8 @@ return {
         you set it to a very large value (999) the cursor line will always be
         in the middle of the window (except at the start or end of the file or
         when long lines wrap).
-        After using the local value, go back the global value with one of
-        these two: >vim
-        	setlocal scrolloff<
-        	setlocal scrolloff=-1
+        After using the local value, go back the global value with this: >vim
+        	set scrolloff<
         <	For scrolling horizontally see 'sidescrolloff'.
       ]=],
       full_name = 'scrolloff',
@@ -7644,10 +7642,8 @@ return {
         to a large value (like 999) has the effect of keeping the cursor
         horizontally centered in the window, as long as one does not come too
         close to the beginning of the line.
-        After using the local value, go back the global value with one of
-        these two: >vim
-        	setlocal sidescrolloff<
-        	setlocal sidescrolloff=-1
+        After using the local value, go back the global value with this: >vim
+        	set sidescrolloff<
         <
         Example: Try this together with 'sidescroll' and 'listchars' as
         	 in the following example to never allow the cursor to move
@@ -9290,8 +9286,6 @@ return {
         current buffer: >vim
         	setlocal ul=-1
         <	This helps when you run out of memory for a single change.
-
-        The local value is set to -123456 when the global value is to be used.
 
         Also see |clear-undo|.
       ]=],

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -2205,7 +2205,7 @@ describe('lua stdlib', function()
     exec_lua [[vim.o.scrolloff = 100]]
     exec_lua [[vim.wo.scrolloff = 200]]
     eq(200, fn.luaeval 'vim.wo.scrolloff')
-    exec_lua [[vim.wo.scrolloff = -1]]
+    exec_lua [[vim.wo.scrolloff = nil]]
     eq(100, fn.luaeval 'vim.wo.scrolloff')
     exec_lua [[
     vim.wo[0][0].scrolloff = 200

--- a/test/functional/options/num_options_spec.lua
+++ b/test/functional/options/num_options_spec.lua
@@ -69,6 +69,8 @@ describe(':set validation', function()
     should_fail('sidescroll', -1, 'E487')
     should_fail('cmdwinheight', 0, 'E487')
     should_fail('updatetime', -1, 'E487')
+    should_fail('scrolloff', -1, 'E487')
+    should_fail('sidescrolloff', -1, 'E487')
 
     should_fail('foldlevel', -5, 'E487')
     should_fail('foldcolumn', '13', 'E474')
@@ -80,22 +82,6 @@ describe(':set validation', function()
     feed_command('setglobal window=-10')
     api.nvim_set_option_value('window', -10, {})
     eq(23, api.nvim_get_option_value('window', {}))
-    eq('', eval('v:errmsg'))
-
-    -- 'scrolloff' and 'sidescrolloff' can have a -1 value when
-    -- set for the current window, but not globally
-    feed_command('setglobal scrolloff=-1')
-    eq('E487', eval('v:errmsg'):match('E%d*'))
-
-    feed_command('setglobal sidescrolloff=-1')
-    eq('E487', eval('v:errmsg'):match('E%d*'))
-
-    feed_command('let v:errmsg=""')
-
-    feed_command('setlocal scrolloff=-1')
-    eq('', eval('v:errmsg'))
-
-    feed_command('setlocal sidescrolloff=-1')
     eq('', eval('v:errmsg'))
   end)
 

--- a/test/old/testdir/gen_opt_test.vim
+++ b/test/old/testdir/gen_opt_test.vim
@@ -22,11 +22,11 @@ while search("^'[^']*'.*\\n.*|global-local", 'W')
   let fullname = getline('.')->matchstr("^'\\zs[^']*")
   let global_locals[fullname] = ''
 endwhile
-call extend(global_locals, #{
-      \ scrolloff: -1,
-      \ sidescrolloff: -1,
-      \ undolevels: -123456,
-      \})
+"call extend(global_locals, #{
+"      \ scrolloff: -1,
+"      \ sidescrolloff: -1,
+"      \ undolevels: -123456,
+"      \})
 
 " Get local-noglobal options.
 " "key" is full-name of the option.
@@ -438,7 +438,8 @@ for option in options
 	endfor
       endfor
       " Testing to clear the local value and switch back to the global value.
-      if global_locals->has_key(fullname)
+      "if global_locals->has_key(fullname)
+      if option.type == 'string' && global_locals->has_key(fullname)
 	let switchback_val = global_locals[fullname]
 	call add(script, $'setlocal {opt}={switchback_val}')
 	call add(script, $'call assert_equal(&g:{fullname}, &{fullname})')

--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -1135,7 +1135,8 @@ func Test_scrolloff()
   set sessionoptions+=localoptions
   setlocal so=1 siso=1
   mksession! Xtest_mks.out
-  setlocal so=-1 siso=-1
+  "setlocal so=-1 siso=-1
+  set so< siso<
   source Xtest_mks.out
   call assert_equal(1, &l:so)
   call assert_equal(1, &l:siso)

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -1394,8 +1394,8 @@ func Test_local_scrolloff()
   call assert_equal(-1, &l:so)
   setlocal so=0
   call assert_equal(0, &so)
-  setlocal so=-1
-  call assert_equal(8, &so)
+  "setlocal so=-1
+  "call assert_equal(8, &so)
 
   call assert_equal(7, &siso)
   setlocal siso=3
@@ -1412,8 +1412,8 @@ func Test_local_scrolloff()
   call assert_equal(-1, &l:siso)
   setlocal siso=0
   call assert_equal(0, &siso)
-  setlocal siso=-1
-  call assert_equal(4, &siso)
+  "setlocal siso=-1
+  "call assert_equal(4, &siso)
 
   close
   set so&


### PR DESCRIPTION
Problem: We internally use sentinel values for global-local options to represent an unset local value for global-local options. These values should be considered to be an implementation detail, and therefore should not be represented anywhere in the docs, and should also not be directly settable as an option value, and instead should be set only through `set option<`.

Solution: Remove reference of sentinel values from documentation, and make it an error to set an option to those values. This is imperative because the future goal is to remove the need for sentinel values entirely by using a separate internal mechanism to indicate an unset local value for options with multiple scopes.

Ref: #25672 #29314
