### PR TITLE
feat(lsp): option to highlight hover range

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -338,13 +338,16 @@ Highlight groups that are meant to be used by |vim.lsp.buf.document_highlight()|
 You can see more about the differences in types here:
 https://microsoft.github.io/language-server-protocol/specification#textDocument_documentHighlight
 
-                                                           *hl-LspReferenceText*
+                                                         *hl-LspReferenceText*
 LspReferenceText          used for highlighting "text" references
-                                                           *hl-LspReferenceRead*
+                                                         *hl-LspReferenceRead*
 LspReferenceRead          used for highlighting "read" references
-                                                          *hl-LspReferenceWrite*
+                                                        *hl-LspReferenceWrite*
 LspReferenceWrite         used for highlighting "write" references
-                                                          *hl-LspInlayHint*
+                                                       *hl-LspReferenceTarget*
+LspReferenceTarget        used for highlighting reference targets (e.g. in a
+                          hover range)
+                                                             *hl-LspInlayHint*
 LspInlayHint              used for highlighting inlay hints
 
 
@@ -1334,6 +1337,14 @@ hover({config})                                          *vim.lsp.buf.hover()*
     the hover window and focus it). In the floating window, all commands and
     mappings are available as usual, except that "q" dismisses the window. You
     can scroll the contents the same as you would any other buffer.
+
+    Note: to disable hover highlights, add the following to your config: >lua
+        vim.api.nvim_create_autocmd('ColorScheme', {
+          callback = function()
+            vim.api.nvim_set_hl(0, 'LspReferenceTarget', {})
+          end,
+        })
+<
 
     Parameters: ~
       • {config}  (`vim.lsp.buf.hover.Opts?`) See |vim.lsp.buf.hover.Opts|.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -216,6 +216,8 @@ LSP
 • |vim.lsp.buf.signature_help()| can now cycle through different signatures
   using `<C-s>` and also support multiple clients.
 • The client now supports `'utf-8'` and `'utf-32'` position encodings.
+• |vim.lsp.buf.hover()| now highlights hover ranges using the
+  |hl-LspReferenceTarget| highlight group.
 
 LUA
 

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -215,6 +215,7 @@ static const char *highlight_init_both[] = {
   "default link LspReferenceRead            LspReferenceText",
   "default link LspReferenceText            Visual",
   "default link LspReferenceWrite           LspReferenceText",
+  "default link LspReferenceTarget          LspReferenceText",
   "default link LspSignatureActiveParameter Visual",
   "default link SnippetTabstop              Visual",
 


### PR DESCRIPTION
**Problem:** Despite the LSP providing the option for language servers to specify a range with a hover response (for highlighting), Neovim does not give the option to highlight this range.

**Solution:** Add an option to `buf.hover()` which causes this range to be highlighted.

### Before
![image](https://github.com/user-attachments/assets/9d816688-d47c-46e3-addf-c4784a983471)

### After
![image](https://github.com/user-attachments/assets/ab39c027-b34d-40ef-8b32-09f6631a8065)
