### PR TITLE
fix(treesitter): show proper node name error messages

### DIFF
--- a/test/functional/treesitter/query_spec.lua
+++ b/test/functional/treesitter/query_spec.lua
@@ -722,7 +722,25 @@ void ui_refresh(void)
       eq(exp, pcall_err(exec_lua, "vim.treesitter.query.parse('c', ...)", cquery))
     end
 
-    -- Invalid node type
+    -- Invalid node types
+    test(
+      '.../query.lua:0: Query error at 1:2. Invalid node type ">\\">>":\n'
+        .. '">\\">>" @operator\n'
+        .. ' ^',
+      '">\\">>" @operator'
+    )
+    test(
+      '.../query.lua:0: Query error at 1:2. Invalid node type "\\\\":\n'
+        .. '"\\\\" @operator\n'
+        .. ' ^',
+      '"\\\\" @operator'
+    )
+    test(
+      '.../query.lua:0: Query error at 1:2. Invalid node type ">>>":\n'
+        .. '">>>" @operator\n'
+        .. ' ^',
+      '">>>" @operator'
+    )
     test(
       '.../query.lua:0: Query error at 1:2. Invalid node type "dentifier":\n'
         .. '(dentifier) @variable\n'


### PR DESCRIPTION
**Problem:** Currently node names with non-alphanumeric, non underscore/hyphen characters (only possible with anonymous nodes) are not given a proper error message. See tree-sitter/tree-sitter#3892 for more details.

**Solution:** Apply a different scanning logic to anonymous nodes to correctly identify the entire node name (i.e., up until the final double quote)