### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -33,6 +33,7 @@
 "   2024 Oct 31 by Vim Project: add netrw#Launch() and netrw#Open() (#15962)
 "   2024 Oct 31 by Vim Project: fix E874 when browsing remote dir (#15964)
 "   2024 Nov 07 by Vim Project: use keeppatterns to prevent polluting the search history
+"   2024 Nov 07 by Vim Project: fix a few issues with netrw tree listing (#15996)
 "   }}}
 " Former Maintainer:	Charles E Campbell
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
@@ -678,11 +679,8 @@ endif
 "                == 4: Vexplore    style == 5: Vexplore!
 "                == 6: Texplore
 fun! netrw#Explore(indx,dosplit,style,...)
-"  call Dfunc("netrw#Explore(indx=".a:indx." dosplit=".a:dosplit." style=".a:style.",a:1<".a:1.">) &modified=".&modified." modifiable=".&modifiable." a:0=".a:0." win#".winnr()." buf#".bufnr("%")." ft=".&ft)
-"  call Decho("tab#".tabpagenr()." win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> line#".line(".")." col#".col(".")." winline#".winline()." wincol#".wincol(),'~'.expand("<slnum>"))
   if !exists("b:netrw_curdir")
    let b:netrw_curdir= getcwd()
-"   call Decho("set b:netrw_curdir<".b:netrw_curdir."> (used getcwd)",'~'.expand("<slnum>"))
   endif
 
   " record current file for Rexplore's benefit
@@ -696,17 +694,11 @@ fun! netrw#Explore(indx,dosplit,style,...)
   if !exists("g:netrw_cygwin") && has("win32")
    let curdir= substitute(curdir,'\','/','g')
   endif
-"  call Decho("curdir<".curdir.">  curfiledir<".curfiledir.">",'~'.expand("<slnum>"))
 
   " using completion, directories with spaces in their names (thanks, Bill Gates, for a truly dumb idea)
   " will end up with backslashes here.  Solution: strip off backslashes that precede white space and
   " try Explore again.
   if a:0 > 0
-"   call Decho('considering retry: a:1<'.a:1.'>: '.
-     \ ((a:1 =~ "\\\s")?                   'has backslash whitespace' : 'does not have backslash whitespace').', '.
-     \ ((filereadable(s:NetrwFile(a:1)))?  'is readable'              : 'is not readable').', '.
-     \ ((isdirectory(s:NetrwFile(a:1))))?  'is a directory'           : 'is not a directory',
-     \ '~'.expand("<slnum>"))
    if a:1 =~ "\\\s" && !filereadable(s:NetrwFile(a:1)) && !isdirectory(s:NetrwFile(a:1))
     let a1 = substitute(a:1, '\\\(\s\)', '\1', 'g')
     if a1 != a:1
@@ -717,6 +709,11 @@ fun! netrw#Explore(indx,dosplit,style,...)
   endif
 
   " save registers
+  if !has('nvim') && has("clipboard") && g:netrw_clipboard
+"   call Decho("(netrw#Explore) save @* and @+",'~'.expand("<slnum>"))
+   sil! let keepregstar = @*
+   sil! let keepregplus = @+
+  endif
   sil! let keepregslash= @/
 
   " if   dosplit
@@ -769,64 +766,45 @@ fun! netrw#Explore(indx,dosplit,style,...)
   NetrwKeepj norm! 0
 
   if a:0 > 0
-"   call Decho("case [a:0=".a:0."] > 0: a:1<".a:1.">",'~'.expand("<slnum>"))
    if a:1 =~ '^\~' && (has("unix") || (exists("g:netrw_cygwin") && g:netrw_cygwin))
-"    call Decho("..case a:1<".a:1.">: starts with ~ and unix or cygwin",'~'.expand("<slnum>"))
     let dirname= simplify(substitute(a:1,'\~',expand("$HOME"),''))
-"    call Decho("..using dirname<".dirname.">  (case: ~ && unix||cygwin)",'~'.expand("<slnum>"))
    elseif a:1 == '.'
-"    call Decho("..case a:1<".a:1.">: matches .",'~'.expand("<slnum>"))
     let dirname= simplify(exists("b:netrw_curdir")? b:netrw_curdir : getcwd())
     if dirname !~ '/$'
      let dirname= dirname."/"
     endif
-"    call Decho("..using dirname<".dirname.">  (case: ".(exists("b:netrw_curdir")? "b:netrw_curdir" : "getcwd()").")",'~'.expand("<slnum>"))
    elseif a:1 =~ '\$'
-"    call Decho("..case a:1<".a:1.">: matches ending $",'~'.expand("<slnum>"))
     let dirname= simplify(expand(a:1))
-"    call Decho("..using user-specified dirname<".dirname."> with $env-var",'~'.expand("<slnum>"))
    elseif a:1 !~ '^\*\{1,2}/' && a:1 !~ '^\a\{3,}://'
-"    call Decho("..case a:1<".a:1.">: other, not pattern or filepattern",'~'.expand("<slnum>"))
     let dirname= simplify(a:1)
-"    call Decho("..using user-specified dirname<".dirname.">",'~'.expand("<slnum>"))
    else
-"    call Decho("..case a:1: pattern or filepattern",'~'.expand("<slnum>"))
     let dirname= a:1
    endif
   else
    " clear explore
-"   call Decho("case a:0=".a:0.": clearing Explore list",'~'.expand("<slnum>"))
    call s:NetrwClearExplore()
-"   call Dret("netrw#Explore : cleared list")
    return
   endif
 
-"  call Decho("dirname<".dirname.">",'~'.expand("<slnum>"))
   if dirname =~ '\.\./\=$'
    let dirname= simplify(fnamemodify(dirname,':p:h'))
   elseif dirname =~ '\.\.' || dirname == '.'
    let dirname= simplify(fnamemodify(dirname,':p'))
   endif
-"  call Decho("dirname<".dirname.">  (after simplify)",'~'.expand("<slnum>"))
 
   if dirname =~ '^\*//'
    " starpat=1: Explore *//pattern   (current directory only search for files containing pattern)
-"   call Decho("case starpat=1: Explore *//pattern",'~'.expand("<slnum>"))
    let pattern= substitute(dirname,'^\*//\(.*\)$','\1','')
    let starpat= 1
-"   call Decho("..Explore *//pat: (starpat=".starpat.") dirname<".dirname."> -> pattern<".pattern.">",'~'.expand("<slnum>"))
    if &hls | let keepregslash= s:ExplorePatHls(pattern) | endif
 
   elseif dirname =~ '^\*\*//'
    " starpat=2: Explore **//pattern  (recursive descent search for files containing pattern)
-"   call Decho("case starpat=2: Explore **//pattern",'~'.expand("<slnum>"))
    let pattern= substitute(dirname,'^\*\*//','','')
    let starpat= 2
-"   call Decho("..Explore **//pat: (starpat=".starpat.") dirname<".dirname."> -> pattern<".pattern.">",'~'.expand("<slnum>"))
 
   elseif dirname =~ '/\*\*/'
    " handle .../**/.../filepat
-"   call Decho("case starpat=4: Explore .../**/.../filepat",'~'.expand("<slnum>"))
    let prefixdir= substitute(dirname,'^\(.\{-}\)\*\*.*$','\1','')
    if prefixdir =~ '^/' || (prefixdir =~ '^\a:/' && has("win32"))
     let b:netrw_curdir = prefixdir
@@ -835,30 +813,23 @@ fun! netrw#Explore(indx,dosplit,style,...)
    endif
    let dirname= substitute(dirname,'^.\{-}\(\*\*/.*\)$','\1','')
    let starpat= 4
-"   call Decho("..pwd<".getcwd()."> dirname<".dirname.">",'~'.expand("<slnum>"))
-"   call Decho("..case Explore ../**/../filepat (starpat=".starpat.")",'~'.expand("<slnum>"))
 
   elseif dirname =~ '^\*/'
    " case starpat=3: Explore */filepat   (search in current directory for filenames matching filepat)
    let starpat= 3
-"   call Decho("case starpat=3: Explore */filepat (starpat=".starpat.")",'~'.expand("<slnum>"))
 
   elseif dirname=~ '^\*\*/'
    " starpat=4: Explore **/filepat  (recursive descent search for filenames matching filepat)
    let starpat= 4
-"   call Decho("case starpat=4: Explore **/filepat (starpat=".starpat.")",'~'.expand("<slnum>"))
 
   else
    let starpat= 0
-"   call Decho("case starpat=0: default",'~'.expand("<slnum>"))
   endif
 
   if starpat == 0 && a:indx >= 0
    " [Explore Hexplore Vexplore Sexplore] [dirname]
-"   call Decho("case starpat==0 && a:indx=".a:indx.": dirname<".dirname.">, handles Explore Hexplore Vexplore Sexplore",'~'.expand("<slnum>"))
    if dirname == ""
     let dirname= curfiledir
-"    call Decho("..empty dirname, using current file's directory<".dirname.">",'~'.expand("<slnum>"))
    endif
    if dirname =~# '^scp://' || dirname =~ '^ftp://'
     call netrw#Nread(2,dirname)
@@ -874,10 +845,7 @@ fun! netrw#Explore(indx,dosplit,style,...)
     elseif dirname !~ '^/'
      let dirname= b:netrw_curdir."/".dirname
     endif
-"    call Decho("..calling LocalBrowseCheck(dirname<".dirname.">)",'~'.expand("<slnum>"))
     call netrw#LocalBrowseCheck(dirname)
-"    call Decho(" modified=".&modified." modifiable=".&modifiable." readonly=".&readonly,'~'.expand("<slnum>"))
-"    call Decho("tab#".tabpagenr()." win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> line#".line(".")." col#".col(".")." winline#".winline()." wincol#".wincol(),'~'.expand("<slnum>"))
    endif
    if exists("w:netrw_bannercnt")
     " done to handle P08-Ingelrest. :Explore will _Always_ go to the line just after the banner.
@@ -885,15 +853,6 @@ fun! netrw#Explore(indx,dosplit,style,...)
     exe w:netrw_bannercnt
    endif
 
-"   call Decho("curdir<".curdir.">",'~'.expand("<slnum>"))
-   " ---------------------------------------------------------------------
-   " Jan 24, 2013: not sure why the following was present.  See P08-Ingelrest
-"   if has("win32") || has("win95") || has("win64") || has("win16")
-"    NetrwKeepj call search('\<'.substitute(curdir,'^.*[/\\]','','e').'\>','cW')
-"   else
-"    NetrwKeepj call search('\<'.substitute(curdir,'^.*/','','e').'\>','cW')
-"   endif
-   " ---------------------------------------------------------------------
 
   " starpat=1: Explore *//pattern  (current directory only search for files containing pattern)
   " starpat=2: Explore **//pattern (recursive descent search for files containing pattern)
@@ -901,86 +860,75 @@ fun! netrw#Explore(indx,dosplit,style,...)
   " starpat=4: Explore **/filepat  (recursive descent search for filenames matching filepat)
   elseif a:indx <= 0
    " Nexplore, Pexplore, Explore: handle starpat
-"   call Decho("case a:indx<=0: Nexplore, Pexplore, <s-down>, <s-up> starpat=".starpat." a:indx=".a:indx,'~'.expand("<slnum>"))
    if !mapcheck("<s-up>","n") && !mapcheck("<s-down>","n") && exists("b:netrw_curdir")
-"    call Decho("..set up <s-up> and <s-down> maps",'~'.expand("<slnum>"))
     let s:didstarstar= 1
     nnoremap <buffer> <silent> <s-up>	:Pexplore<cr>
     nnoremap <buffer> <silent> <s-down>	:Nexplore<cr>
    endif
 
    if has("path_extra")
-"    call Decho("..starpat=".starpat.": has +path_extra",'~'.expand("<slnum>"))
     if !exists("w:netrw_explore_indx")
      let w:netrw_explore_indx= 0
     endif
 
     let indx = a:indx
-"    call Decho("..starpat=".starpat.": set indx= [a:indx=".indx."]",'~'.expand("<slnum>"))
 
     if indx == -1
      " Nexplore
-"     call Decho("..case Nexplore with starpat=".starpat.": (indx=".indx.")",'~'.expand("<slnum>"))
      if !exists("w:netrw_explore_list") " sanity check
       NetrwKeepj call netrw#ErrorMsg(s:WARNING,"using Nexplore or <s-down> improperly; see help for netrw-starstar",40)
+      if !has('nvim') && has("clipboard") && g:netrw_clipboard
+       if @* != keepregstar | sil! let @* = keepregstar | endif
+       if @+ != keepregplus | sil! let @+ = keepregplus | endif
+      endif
       sil! let @/ = keepregslash
-"      call Dret("netrw#Explore")
       return
      endif
      let indx= w:netrw_explore_indx
      if indx < 0                        | let indx= 0                           | endif
      if indx >= w:netrw_explore_listlen | let indx= w:netrw_explore_listlen - 1 | endif
      let curfile= w:netrw_explore_list[indx]
-"     call Decho("....indx=".indx." curfile<".curfile.">",'~'.expand("<slnum>"))
      while indx < w:netrw_explore_listlen && curfile == w:netrw_explore_list[indx]
       let indx= indx + 1
-"      call Decho("....indx=".indx." (Nexplore while loop)",'~'.expand("<slnum>"))
      endwhile
      if indx >= w:netrw_explore_listlen | let indx= w:netrw_explore_listlen - 1 | endif
-"     call Decho("....Nexplore: indx= [w:netrw_explore_indx=".w:netrw_explore_indx."]=".indx,'~'.expand("<slnum>"))
 
     elseif indx == -2
      " Pexplore
-"     call Decho("case Pexplore with starpat=".starpat.": (indx=".indx.")",'~'.expand("<slnum>"))
      if !exists("w:netrw_explore_list") " sanity check
       NetrwKeepj call netrw#ErrorMsg(s:WARNING,"using Pexplore or <s-up> improperly; see help for netrw-starstar",41)
+      if !has('nvim') && has("clipboard") && g:netrw_clipboard
+       if @* != keepregstar | sil! let @* = keepregstar | endif
+       if @+ != keepregplus | sil! let @+ = keepregplus | endif
+      endif
       sil! let @/ = keepregslash
-"      call Dret("netrw#Explore")
       return
      endif
      let indx= w:netrw_explore_indx
      if indx < 0                        | let indx= 0                           | endif
      if indx >= w:netrw_explore_listlen | let indx= w:netrw_explore_listlen - 1 | endif
      let curfile= w:netrw_explore_list[indx]
-"     call Decho("....indx=".indx." curfile<".curfile.">",'~'.expand("<slnum>"))
      while indx >= 0 && curfile == w:netrw_explore_list[indx]
       let indx= indx - 1
-"      call Decho("....indx=".indx." (Pexplore while loop)",'~'.expand("<slnum>"))
      endwhile
      if indx < 0                        | let indx= 0                           | endif
-"     call Decho("....Pexplore: indx= [w:netrw_explore_indx=".w:netrw_explore_indx."]=".indx,'~'.expand("<slnum>"))
 
     else
      " Explore -- initialize
      " build list of files to Explore with Nexplore/Pexplore
-"     call Decho("..starpat=".starpat.": case Explore: initialize (indx=".indx.")",'~'.expand("<slnum>"))
      NetrwKeepj keepalt call s:NetrwClearExplore()
      let w:netrw_explore_indx= 0
      if !exists("b:netrw_curdir")
       let b:netrw_curdir= getcwd()
      endif
-"     call Decho("....starpat=".starpat.": b:netrw_curdir<".b:netrw_curdir.">",'~'.expand("<slnum>"))
 
      " switch on starpat to build the w:netrw_explore_list of files
      if starpat == 1
       " starpat=1: Explore *//pattern  (current directory only search for files containing pattern)
-"      call Decho("..case starpat=".starpat.": build *//pattern list  (curdir-only srch for files containing pattern)  &hls=".&hls,'~'.expand("<slnum>"))
-"      call Decho("....pattern<".pattern.">",'~'.expand("<slnum>"))
       try
        exe "NetrwKeepj noautocmd vimgrep /".pattern."/gj ".fnameescape(b:netrw_curdir)."/*"
       catch /^Vim\%((\a\+)\)\=:E480/
        keepalt call netrw#ErrorMsg(s:WARNING,"no match with pattern<".pattern.">",76)
-"       call Dret("netrw#Explore : unable to find pattern<".pattern.">")
        return
       endtry
       let w:netrw_explore_list = s:NetrwExploreListUniq(map(getqflist(),'bufname(v:val.bufnr)'))
@@ -988,15 +936,16 @@ fun! netrw#Explore(indx,dosplit,style,...)
 
      elseif starpat == 2
       " starpat=2: Explore **//pattern (recursive descent search for files containing pattern)
-"      call Decho("..case starpat=".starpat.": build **//pattern list  (recursive descent files containing pattern)",'~'.expand("<slnum>"))
-"      call Decho("....pattern<".pattern.">",'~'.expand("<slnum>"))
       try
        exe "sil NetrwKeepj noautocmd keepalt vimgrep /".pattern."/gj "."**/*"
       catch /^Vim\%((\a\+)\)\=:E480/
        keepalt call netrw#ErrorMsg(s:WARNING,'no files matched pattern<'.pattern.'>',45)
        if &hls | let keepregslash= s:ExplorePatHls(pattern) | endif
+       if !has('nvim') && has("clipboard") && g:netrw_clipboard
+        if @* != keepregstar | sil! let @* = keepregstar | endif
+        if @+ != keepregplus | sil! let @+ = keepregplus | endif
+       endif
        sil! let @/ = keepregslash
-"       call Dret("netrw#Explore : no files matched pattern")
        return
       endtry
       let s:netrw_curdir       = b:netrw_curdir
@@ -1006,51 +955,43 @@ fun! netrw#Explore(indx,dosplit,style,...)
 
      elseif starpat == 3
       " starpat=3: Explore */filepat   (search in current directory for filenames matching filepat)
-"      call Decho("..case starpat=".starpat.": build */filepat list  (curdir-only srch filenames matching filepat)  &hls=".&hls,'~'.expand("<slnum>"))
       let filepat= substitute(dirname,'^\*/','','')
       let filepat= substitute(filepat,'^[%#<]','\\&','')
-"      call Decho("....b:netrw_curdir<".b:netrw_curdir.">",'~'.expand("<slnum>"))
-"      call Decho("....filepat<".filepat.">",'~'.expand("<slnum>"))
       let w:netrw_explore_list= s:NetrwExploreListUniq(split(expand(b:netrw_curdir."/".filepat),'\n'))
       if &hls | let keepregslash= s:ExplorePatHls(filepat) | endif
 
      elseif starpat == 4
       " starpat=4: Explore **/filepat  (recursive descent search for filenames matching filepat)
-"      call Decho("..case starpat=".starpat.": build **/filepat list  (recursive descent srch filenames matching filepat)  &hls=".&hls,'~'.expand("<slnum>"))
       let w:netrw_explore_list= s:NetrwExploreListUniq(split(expand(b:netrw_curdir."/".dirname),'\n'))
       if &hls | let keepregslash= s:ExplorePatHls(dirname) | endif
      endif " switch on starpat to build w:netrw_explore_list
 
      let w:netrw_explore_listlen = len(w:netrw_explore_list)
-"     call Decho("....w:netrw_explore_list<".string(w:netrw_explore_list).">",'~'.expand("<slnum>"))
-"     call Decho("....w:netrw_explore_listlen=".w:netrw_explore_listlen,'~'.expand("<slnum>"))
 
      if w:netrw_explore_listlen == 0 || (w:netrw_explore_listlen == 1 && w:netrw_explore_list[0] =~ '\*\*\/')
       keepalt NetrwKeepj call netrw#ErrorMsg(s:WARNING,"no files matched",42)
+      if !has('nvim') && has("clipboard") && g:netrw_clipboard
+        if @* != keepregstar | sil! let @* = keepregstar | endif
+        if @+ != keepregplus | sil! let @+ = keepregplus | endif
+      endif
       sil! let @/ = keepregslash
-"      call Dret("netrw#Explore : no files matched")
       return
      endif
     endif  " if indx ... endif
 
     " NetrwStatusLine support - for exploring support
     let w:netrw_explore_indx= indx
-"    call Decho("....w:netrw_explore_list<".join(w:netrw_explore_list,',')."> len=".w:netrw_explore_listlen,'~'.expand("<slnum>"))
 
     " wrap the indx around, but issue a note
     if indx >= w:netrw_explore_listlen || indx < 0
-"     call Decho("....wrap indx (indx=".indx." listlen=".w:netrw_explore_listlen.")",'~'.expand("<slnum>"))
      let indx                = (indx < 0)? ( w:netrw_explore_listlen - 1 ) : 0
      let w:netrw_explore_indx= indx
      keepalt NetrwKeepj call netrw#ErrorMsg(s:NOTE,"no more files match Explore pattern",43)
     endif
 
     exe "let dirfile= w:netrw_explore_list[".indx."]"
-"    call Decho("....dirfile=w:netrw_explore_list[indx=".indx."]= <".dirfile.">",'~'.expand("<slnum>"))
     let newdir= substitute(dirfile,'/[^/]*$','','e')
-"    call Decho("....newdir<".newdir.">",'~'.expand("<slnum>"))
 
-"    call Decho("....calling LocalBrowseCheck(newdir<".newdir.">)",'~'.expand("<slnum>"))
     call netrw#LocalBrowseCheck(newdir)
     if !exists("w:netrw_liststyle")
      let w:netrw_liststyle= g:netrw_liststyle
@@ -1064,20 +1005,20 @@ fun! netrw#Explore(indx,dosplit,style,...)
     let w:netrw_explore_bufnr   = bufnr("%")
     let w:netrw_explore_line    = line(".")
     keepalt NetrwKeepj call s:SetupNetrwStatusLine('%f %h%m%r%=%9*%{NetrwStatusLine()}')
-"    call Decho("....explore: mtchcnt=".w:netrw_explore_mtchcnt." bufnr=".w:netrw_explore_bufnr." line#".w:netrw_explore_line,'~'.expand("<slnum>"))
 
    else
-"    call Decho("..your vim does not have +path_extra",'~'.expand("<slnum>"))
     if !exists("g:netrw_quiet")
      keepalt NetrwKeepj call netrw#ErrorMsg(s:WARNING,"your vim needs the +path_extra feature for Exploring with **!",44)
     endif
+    if !has('nvim') && has("clipboard") && g:netrw_clipboard
+      if @* != keepregstar | sil! let @* = keepregstar | endif
+      if @+ != keepregplus | sil! let @+ = keepregplus | endif
+    endif
     sil! let @/ = keepregslash
-"    call Dret("netrw#Explore : missing +path_extra")
     return
    endif
 
   else
-"   call Decho("..default case: Explore newdir<".dirname.">",'~'.expand("<slnum>"))
    if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && dirname =~ '/'
     sil! unlet w:netrw_treedict
     sil! unlet w:netrw_treetop
@@ -1086,18 +1027,14 @@ fun! netrw#Explore(indx,dosplit,style,...)
    if !exists("b:netrw_curdir")
     NetrwKeepj call netrw#LocalBrowseCheck(getcwd())
    else
-    NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,newdir))
+    NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,newdir,0))
    endif
   endif
 
   " visual display of **/ **// */ Exploration files
-"  call Decho("w:netrw_explore_indx=".(exists("w:netrw_explore_indx")? w:netrw_explore_indx : "doesn't exist"),'~'.expand("<slnum>"))
-"  call Decho("b:netrw_curdir<".(exists("b:netrw_curdir")? b:netrw_curdir : "n/a").">",'~'.expand("<slnum>"))
   if exists("w:netrw_explore_indx") && exists("b:netrw_curdir")
-"   call Decho("s:explore_prvdir<".(exists("s:explore_prvdir")? s:explore_prvdir : "-doesn't exist-"),'~'.expand("<slnum>"))
    if !exists("s:explore_prvdir") || s:explore_prvdir != b:netrw_curdir
     " only update match list when current directory isn't the same as before
-"    call Decho("only update match list when current directory not the same as before",'~'.expand("<slnum>"))
     let s:explore_prvdir = b:netrw_curdir
     let s:explore_match  = ""
     let dirlen           = strlen(b:netrw_curdir)
@@ -1106,7 +1043,6 @@ fun! netrw#Explore(indx,dosplit,style,...)
     endif
     let prvfname= ""
     for fname in w:netrw_explore_list
-"     call Decho("fname<".fname.">",'~'.expand("<slnum>"))
      if fname =~ '^'.b:netrw_curdir
       if s:explore_match == ""
        let s:explore_match= '\<'.escape(strpart(fname,dirlen),g:netrw_markfileesc).'\>'
@@ -1122,7 +1058,6 @@ fun! netrw#Explore(indx,dosplit,style,...)
      endif
      let prvfname= fname
     endfor
-"    call Decho("explore_match<".s:explore_match.">",'~'.expand("<slnum>"))
     if has("syntax") && exists("g:syntax_on") && g:syntax_on
      exe "2match netrwMarkFile /".s:explore_match."/"
     endif
@@ -1132,15 +1067,17 @@ fun! netrw#Explore(indx,dosplit,style,...)
    2match none
    if exists("s:explore_match")  | unlet s:explore_match  | endif
    if exists("s:explore_prvdir") | unlet s:explore_prvdir | endif
-"   call Decho("cleared explore match list",'~'.expand("<slnum>"))
   endif
 
   " since Explore may be used to initialize netrw's browser,
   " there's no danger of a late FocusGained event on initialization.
   " Consequently, set s:netrw_events to 2.
   let s:netrw_events= 2
+  if !has('nvim') && has("clipboard") && g:netrw_clipboard
+   if @* != keepregstar | sil! let @* = keepregstar | endif
+   if @+ != keepregplus | sil! let @+ = keepregplus | endif
+  endif
   sil! let @/ = keepregslash
-"  call Dret("netrw#Explore : @/<".@/.">")
 endfun
 
 " ---------------------------------------------------------------------
@@ -1651,8 +1588,13 @@ fun! s:NetrwOptionsSave(vt)
    let {a:vt}netrw_dirkeep  = getcwd()
 "   call Decho("saving to ".a:vt."netrw_dirkeep<".{a:vt}netrw_dirkeep.">",'~'.expand("<slnum>"))
   endif
+  if !has('nvim') && has("clipboard") && g:netrw_clipboard
+   sil! let {a:vt}netrw_starkeep = @*
+   sil! let {a:vt}netrw_pluskeep = @+
+  endif
   sil! let {a:vt}netrw_slashkeep= @/
 
+"  call Decho("(s:NetrwOptionsSave) lines=".&lines)
 "  call Decho("settings buf#".bufnr("%")."<".bufname("%").">: ".((&l:ma == 0)? "no" : "")."ma ".((&l:mod == 0)? "no" : "")."mod ".((&l:bl == 0)? "no" : "")."bl ".((&l:ro == 0)? "no" : "")."ro fo=".&l:fo." a:vt=".a:vt,'~'.expand("<slnum>"))
 "  call Dret("s:NetrwOptionsSave : tab#".tabpagenr()." win#".winnr())
 endfun
@@ -1811,6 +1753,10 @@ fun! s:NetrwOptionsRestore(vt)
     call s:NetrwLcd(dirkeep)
     unlet {a:vt}netrw_dirkeep
    endif
+  endif
+  if !has('nvim') && has("clipboard") && g:netrw_clipboard
+   call s:NetrwRestoreSetting(a:vt."netrw_starkeep","@*")
+   call s:NetrwRestoreSetting(a:vt."netrw_pluskeep","@+")
   endif
   call s:NetrwRestoreSetting(a:vt."netrw_slashkeep","@/")
 
@@ -2770,36 +2716,27 @@ endfun
 " netrw#SetTreetop: resets the tree top to the current directory/specified directory {{{2
 "                   (implements the :Ntree command)
 fun! netrw#SetTreetop(iscmd,...)
-"  call Dfunc("netrw#SetTreetop(iscmd=".a:iscmd." ".((a:0 > 0)? a:1 : "").") a:0=".a:0)
-"  call Decho("w:netrw_treetop<".w:netrw_treetop.">")
 
   " iscmd==0: netrw#SetTreetop called using gn mapping
   " iscmd==1: netrw#SetTreetop called using :Ntree from the command line
-"  call Decho("(iscmd=".a:iscmd.": called using :Ntree from command line",'~'.expand("<slnum>"))
   " clear out the current tree
   if exists("w:netrw_treetop")
-"   call Decho("clearing out current tree",'~'.expand("<slnum>"))
    let inittreetop= w:netrw_treetop
    unlet w:netrw_treetop
   endif
   if exists("w:netrw_treedict")
-"   call Decho("freeing w:netrw_treedict",'~'.expand("<slnum>"))
    unlet w:netrw_treedict
   endif
-"  call Decho("inittreetop<".(exists("inittreetop")? inittreetop : "n/a").">")
 
   if (a:iscmd == 0 || a:1 == "") && exists("inittreetop")
    let treedir         = s:NetrwTreePath(inittreetop)
-"   call Decho("treedir<".treedir.">",'~'.expand("<slnum>"))
   else
    if isdirectory(s:NetrwFile(a:1))
-"    call Decho("a:1<".a:1."> is a directory",'~'.expand("<slnum>"))
     let treedir         = a:1
     let s:netrw_treetop = treedir
    elseif exists("b:netrw_curdir") && (isdirectory(s:NetrwFile(b:netrw_curdir."/".a:1)) || a:1 =~ '^\a\{3,}://')
     let treedir         = b:netrw_curdir."/".a:1
     let s:netrw_treetop = treedir
-"    call Decho("a:1<".a:1."> is NOT a directory, using treedir<".treedir.">",'~'.expand("<slnum>"))
    else
     " normally the cursor is left in the message window.
     " However, here this results in the directory being listed in the message window, which is not wanted.
@@ -2810,20 +2747,17 @@ fun! netrw#SetTreetop(iscmd,...)
     let s:netrw_treetop = getcwd()
    endif
   endif
-"  call Decho("treedir<".treedir.">",'~'.expand("<slnum>"))
 
   " determine if treedir is remote or local
   let islocal= expand("%") !~ '^\a\{3,}://'
-"  call Decho("islocal=".islocal,'~'.expand("<slnum>"))
 
   " browse the resulting directory
   if islocal
-   call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(islocal,treedir))
+   call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(islocal,treedir,0))
   else
-   call s:NetrwBrowse(islocal,s:NetrwBrowseChgDir(islocal,treedir))
+   call s:NetrwBrowse(islocal,s:NetrwBrowseChgDir(islocal,treedir,0))
   endif
 
-"  call Dret("netrw#SetTreetop")
 endfun
 
 " ===========================================
@@ -3681,16 +3615,11 @@ endfun
 "    Often called via:  Explore/e dirname/etc -> netrw#LocalBrowseCheck() -> s:NetrwBrowse()
 fun! s:NetrwBrowse(islocal,dirname)
   if !exists("w:netrw_liststyle")|let w:netrw_liststyle= g:netrw_liststyle|endif
-"  call Dfunc("s:NetrwBrowse(islocal=".a:islocal." dirname<".a:dirname.">) liststyle=".w:netrw_liststyle." ".g:loaded_netrw." buf#".bufnr("%")."<".bufname("%")."> win#".winnr())
-"  call Decho("fyi: modified=".&modified." modifiable=".&modifiable." readonly=".&readonly,'~'.expand("<slnum>"))
-"  call Decho("fyi: tab#".tabpagenr()." win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> line#".line(".")." col#".col(".")." winline#".winline()." wincol#".wincol(),'~'.expand("<slnum>"))
-"  call Dredir("ls!","s:NetrwBrowse")
 
   " save alternate-file's filename if w:netrw_rexlocal doesn't exist
   " This is useful when one edits a local file, then :e ., then :Rex
   if a:islocal && !exists("w:netrw_rexfile") && bufname("#") != ""
    let w:netrw_rexfile= bufname("#")
-"   call Decho("setting w:netrw_rexfile<".w:netrw_rexfile."> win#".winnr(),'~'.expand("<slnum>"))
   endif
 
   " s:NetrwBrowse : initialize history {{{3
@@ -3701,32 +3630,26 @@ fun! s:NetrwBrowse(islocal,dirname)
   " s:NetrwBrowse : simplify the dirname (especially for ".."s in dirnames) {{{3
   if a:dirname !~ '^\a\{3,}://'
    let dirname= simplify(a:dirname)
-"   call Decho("simplified dirname<".dirname.">")
   else
    let dirname= a:dirname
   endif
 
   " repoint t:netrw_lexbufnr if appropriate
   if exists("t:netrw_lexbufnr") && bufnr("%") == t:netrw_lexbufnr
-"   call Decho("set repointlexbufnr to true!")
    let repointlexbufnr= 1
   endif
 
   " s:NetrwBrowse : sanity checks: {{{3
   if exists("s:netrw_skipbrowse")
    unlet s:netrw_skipbrowse
-"   call Decho(" ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." filename<".expand("%")."> win#".winnr()." ft<".&ft.">",'~'.expand("<slnum>"))
-"   call Dret("s:NetrwBrowse : s:netrw_skipbrowse existed")
    return
   endif
   if !exists("*shellescape")
    NetrwKeepj call netrw#ErrorMsg(s:ERROR,"netrw can't run -- your vim is missing shellescape()",69)
-"   call Dret("s:NetrwBrowse : missing shellescape()")
    return
   endif
   if !exists("*fnameescape")
    NetrwKeepj call netrw#ErrorMsg(s:ERROR,"netrw can't run -- your vim is missing fnameescape()",70)
-"   call Dret("s:NetrwBrowse : missing fnameescape()")
    return
   endif
 
@@ -3736,53 +3659,39 @@ fun! s:NetrwBrowse(islocal,dirname)
   " s:NetrwBrowse : re-instate any marked files {{{3
   if has("syntax") && exists("g:syntax_on") && g:syntax_on
    if exists("s:netrwmarkfilelist_{bufnr('%')}")
-"    call Decho("clearing marked files",'~'.expand("<slnum>"))
     exe "2match netrwMarkFile /".s:netrwmarkfilemtch_{bufnr("%")}."/"
    endif
   endif
 
   if a:islocal && exists("w:netrw_acdkeep") && w:netrw_acdkeep
    " s:NetrwBrowse : set up "safe" options for local directory/file {{{3
-"   call Decho("handle w:netrw_acdkeep:",'~'.expand("<slnum>"))
-"   call Decho("NetrwKeepj lcd ".fnameescape(dirname)." (due to w:netrw_acdkeep=".w:netrw_acdkeep." - acd=".&acd.")",'~'.expand("<slnum>"))
    if s:NetrwLcd(dirname)
-"    call Dret("s:NetrwBrowse : lcd failure")
     return
    endif
-   "   call s:NetrwOptionsSafe() " tst952 failed with this enabled.
-"   call Decho("getcwd<".getcwd().">",'~'.expand("<slnum>"))
 
   elseif !a:islocal && dirname !~ '[\/]$' && dirname !~ '^"'
    " s:NetrwBrowse :  remote regular file handler {{{3
-"   call Decho("handle remote regular file: dirname<".dirname.">",'~'.expand("<slnum>"))
    if bufname(dirname) != ""
-"    call Decho("edit buf#".bufname(dirname)." in win#".winnr(),'~'.expand("<slnum>"))
     exe "NetrwKeepj b ".bufname(dirname)
    else
     " attempt transfer of remote regular file
-"    call Decho("attempt transfer as regular file<".dirname.">",'~'.expand("<slnum>"))
 
     " remove any filetype indicator from end of dirname, except for the
     " "this is a directory" indicator (/).
     " There shouldn't be one of those here, anyway.
     let path= substitute(dirname,'[*=@|]\r\=$','','e')
-"    call Decho("new path<".path.">",'~'.expand("<slnum>"))
     call s:RemotePathAnalysis(dirname)
 
     " s:NetrwBrowse : remote-read the requested file into current buffer {{{3
     call s:NetrwEnew(dirname)
     call s:NetrwOptionsSafe(a:islocal)
     setl ma noro
-"    call Decho("setl ma noro",'~'.expand("<slnum>"))
     let b:netrw_curdir = dirname
     let url            = s:method."://".((s:user == "")? "" : s:user."@").s:machine.(s:port ? ":".s:port : "")."/".s:path
     call s:NetrwBufRename(url)
     exe "sil! NetrwKeepj keepalt doau BufReadPre ".fnameescape(s:fname)
     sil call netrw#NetRead(2,url)
     " netrw.vim and tar.vim have already handled decompression of the tarball; avoiding gzip.vim error
-"    call Decho("url<".url.">",'~'.expand("<slnum>"))
-"    call Decho("s:path<".s:path.">",'~'.expand("<slnum>"))
-"    call Decho("s:fname<".s:fname.">",'~'.expand("<slnum>"))
     if s:path =~ '.bz2'
      exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(substitute(s:fname,'\.bz2$','',''))
     elseif s:path =~ '.gz'
@@ -3797,11 +3706,7 @@ fun! s:NetrwBrowse(islocal,dirname)
    " s:NetrwBrowse : save certain window-oriented variables into buffer-oriented variables {{{3
    call s:SetBufWinVars()
    call s:NetrwOptionsRestore("w:")
-"   call Decho("setl ma nomod",'~'.expand("<slnum>"))
    setl ma nomod noro
-"   call Decho(" ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
-
-"   call Dret("s:NetrwBrowse : file<".s:fname.">")
    return
   endif
 
@@ -3817,33 +3722,31 @@ fun! s:NetrwBrowse(islocal,dirname)
   NetrwKeepj call s:NetrwMenu(1)
 
   " get/set-up buffer {{{3
-"  call Decho("saving position across a buffer refresh",'~'.expand("<slnum>"))
   let svpos  = winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+
+  " NetrwGetBuffer might change buffers but s:rexposn_X was set for the
+  " previous buffer
+  let prevbufnr = bufnr('%')
   let reusing= s:NetrwGetBuffer(a:islocal,dirname)
+  if exists("s:rexposn_".prevbufnr)
+   let s:rexposn_{bufnr('%')} = s:rexposn_{prevbufnr}
+  endif
 
   " maintain markfile highlighting
   if has("syntax") && exists("g:syntax_on") && g:syntax_on
    if exists("s:netrwmarkfilemtch_{bufnr('%')}") && s:netrwmarkfilemtch_{bufnr("%")} != ""
-" "   call Decho("bufnr(%)=".bufnr('%'),'~'.expand("<slnum>"))
-" "   call Decho("exe 2match netrwMarkFile /".s:netrwmarkfilemtch_{bufnr("%")}."/",'~'.expand("<slnum>"))
     exe "2match netrwMarkFile /".s:netrwmarkfilemtch_{bufnr("%")}."/"
    else
-" "   call Decho("2match none",'~'.expand("<slnum>"))
     2match none
    endif
   endif
   if reusing && line("$") > 1
    call s:NetrwOptionsRestore("w:")
-"   call Decho("setl noma nomod nowrap",'~'.expand("<slnum>"))
    setl noma nomod nowrap
-"   call Decho("(set noma nomod nowrap)  ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
-"   call Dret("s:NetrwBrowse : re-using not-cleared buffer")
    return
   endif
 
   " set b:netrw_curdir to the new directory name {{{3
-"  call Decho("set b:netrw_curdir to the new directory name<".dirname."> (buf#".bufnr("%").")",'~'.expand("<slnum>"))
   let b:netrw_curdir= dirname
   if b:netrw_curdir =~ '[/\\]$'
    let b:netrw_curdir= substitute(b:netrw_curdir,'[/\\]$','','e')
@@ -3864,24 +3767,18 @@ fun! s:NetrwBrowse(islocal,dirname)
   if !a:islocal && b:netrw_curdir !~ '/$'
    let b:netrw_curdir= b:netrw_curdir.'/'
   endif
-"  call Decho("b:netrw_curdir<".b:netrw_curdir.">",'~'.expand("<slnum>"))
 
   " ------------
   " (local only) {{{3
   " ------------
   if a:islocal
-"   call Decho("local only:",'~'.expand("<slnum>"))
-
    " Set up ShellCmdPost handling.  Append current buffer to browselist
    call s:LocalFastBrowser()
 
   " handle g:netrw_keepdir: set vim's current directory to netrw's notion of the current directory {{{3
    if !g:netrw_keepdir
-"    call Decho("handle g:netrw_keepdir=".g:netrw_keepdir.": getcwd<".getcwd()."> acd=".&acd,'~'.expand("<slnum>"))
-"    call Decho("l:acd".(exists("&l:acd")? "=".&l:acd : " doesn't exist"),'~'.expand("<slnum>"))
     if !exists("&l:acd") || !&l:acd
      if s:NetrwLcd(b:netrw_curdir)
-"      call Dret("s:NetrwBrowse : lcd failure")
       return
      endif
     endif
@@ -3891,23 +3788,18 @@ fun! s:NetrwBrowse(islocal,dirname)
   " remote handling: {{{3
   " --------------------------------
   else
-"   call Decho("remote only:",'~'.expand("<slnum>"))
 
    " analyze dirname and g:netrw_list_cmd {{{3
-"   call Decho("b:netrw_curdir<".(exists("b:netrw_curdir")? b:netrw_curdir : "doesn't exist")."> dirname<".dirname.">",'~'.expand("<slnum>"))
    if dirname =~# "^NetrwTreeListing\>"
     let dirname= b:netrw_curdir
-"    call Decho("(dirname was <NetrwTreeListing>) dirname<".dirname.">",'~'.expand("<slnum>"))
    elseif exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("b:netrw_curdir")
     let dirname= substitute(b:netrw_curdir,'\\','/','g')
     if dirname !~ '/$'
      let dirname= dirname.'/'
     endif
     let b:netrw_curdir = dirname
-"    call Decho("(liststyle is TREELIST) dirname<".dirname.">",'~'.expand("<slnum>"))
    else
     let dirname = substitute(dirname,'\\','/','g')
-"    call Decho("(normal) dirname<".dirname.">",'~'.expand("<slnum>"))
    endif
 
    let dirpat  = '^\(\w\{-}\)://\(\w\+@\)\=\([^/]\+\)/\(.*\)$'
@@ -3916,14 +3808,10 @@ fun! s:NetrwBrowse(islocal,dirname)
      NetrwKeepj call netrw#ErrorMsg(s:ERROR,"netrw doesn't understand your dirname<".dirname.">",20)
     endif
     NetrwKeepj call s:NetrwOptionsRestore("w:")
-"    call Decho("setl noma nomod nowrap",'~'.expand("<slnum>"))
     setl noma nomod nowrap
-"    call Decho(" ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
-"    call Dret("s:NetrwBrowse : badly formatted dirname<".dirname.">")
     return
    endif
    let b:netrw_curdir= dirname
-"   call Decho("b:netrw_curdir<".b:netrw_curdir."> (remote)",'~'.expand("<slnum>"))
   endif  " (additional remote handling)
 
   " -------------------------------
@@ -3935,12 +3823,10 @@ fun! s:NetrwBrowse(islocal,dirname)
 
   " restore option(s)
   call s:NetrwOptionsRestore("w:")
-"  call Decho("tab#".tabpagenr()." win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> line#".line(".")." col#".col(".")." winline#".winline()." wincol#".wincol(),'~'.expand("<slnum>"))
 
   " If there is a rexposn: restore position with rexposn
   " Otherwise            : set rexposn
   if exists("s:rexposn_".bufnr("%"))
-"   call Decho("restoring posn to s:rexposn_".bufnr('%')."<".string(s:rexposn_{bufnr('%')}).">",'~'.expand("<slnum>"))
    NetrwKeepj call winrestview(s:rexposn_{bufnr('%')})
    if exists("w:netrw_bannercnt") && line(".") < w:netrw_bannercnt
     NetrwKeepj exe w:netrw_bannercnt
@@ -3950,28 +3836,22 @@ fun! s:NetrwBrowse(islocal,dirname)
   endif
   if v:version >= 700 && has("balloon_eval") && &beval == 0 && &l:bexpr == "" && !exists("g:netrw_nobeval")
    let &l:bexpr= "netrw#BalloonHelp()"
-"   call Decho("set up balloon help: l:bexpr=".&l:bexpr,'~'.expand("<slnum>"))
    setl beval
   endif
 
   " repoint t:netrw_lexbufnr if appropriate
   if exists("repointlexbufnr")
    let t:netrw_lexbufnr= bufnr("%")
-"   call Decho("repoint t:netrw_lexbufnr to #".t:netrw_lexbufnr)
   endif
 
   " restore position
   if reusing
-"   call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
    call winrestview(svpos)
   endif
 
   " The s:LocalBrowseRefresh() function is called by an autocmd
   " installed by s:LocalFastBrowser() when g:netrw_fastbrowse <= 1 (ie. slow or medium speed).
   " However, s:NetrwBrowse() causes the FocusGained event to fire the first time.
-"  call Decho("tab#".tabpagenr()." win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> line#".line(".")." col#".col(".")." winline#".winline()." wincol#".wincol(),'~'.expand("<slnum>"))
-"  call Decho("ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
-"  call Dret("s:NetrwBrowse : did PerformListing  ft<".&ft.">")
   return
 endfun
 
@@ -4464,41 +4344,30 @@ endfun
 "  islocal=0: remote browsing
 "         =1: local browsing
 fun! s:NetrwListStyle(islocal)
-"  call Dfunc("NetrwListStyle(islocal=".a:islocal.") w:netrw_liststyle=".w:netrw_liststyle)
-
   let ykeep             = @@
   let fname             = s:NetrwGetWord()
   if !exists("w:netrw_liststyle")|let w:netrw_liststyle= g:netrw_liststyle|endif
   let svpos            = winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
   let w:netrw_liststyle = (w:netrw_liststyle + 1) % s:MAXLIST
-"  call Decho("fname<".fname.">",'~'.expand("<slnum>"))
-"  call Decho("chgd w:netrw_liststyle to ".w:netrw_liststyle,'~'.expand("<slnum>"))
-"  call Decho("b:netrw_curdir<".(exists("b:netrw_curdir")? b:netrw_curdir : "doesn't exist").">",'~'.expand("<slnum>"))
 
   " repoint t:netrw_lexbufnr if appropriate
   if exists("t:netrw_lexbufnr") && bufnr("%") == t:netrw_lexbufnr
-"   call Decho("set repointlexbufnr to true!")
    let repointlexbufnr= 1
   endif
 
   if w:netrw_liststyle == s:THINLIST
    " use one column listing
-"   call Decho("use one column list",'~'.expand("<slnum>"))
    let g:netrw_list_cmd = substitute(g:netrw_list_cmd,' -l','','ge')
 
   elseif w:netrw_liststyle == s:LONGLIST
    " use long list
-"   call Decho("use long list",'~'.expand("<slnum>"))
    let g:netrw_list_cmd = g:netrw_list_cmd." -l"
 
   elseif w:netrw_liststyle == s:WIDELIST
    " give wide list
-"   call Decho("use wide list",'~'.expand("<slnum>"))
    let g:netrw_list_cmd = substitute(g:netrw_list_cmd,' -l','','ge')
 
   elseif exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
-"   call Decho("use tree list",'~'.expand("<slnum>"))
    let g:netrw_list_cmd = substitute(g:netrw_list_cmd,' -l','','ge')
 
   else
@@ -4508,25 +4377,19 @@ fun! s:NetrwListStyle(islocal)
    let g:netrw_list_cmd  = substitute(g:netrw_list_cmd,' -l','','ge')
   endif
   setl ma noro
-"  call Decho("setl ma noro",'~'.expand("<slnum>"))
 
   " clear buffer - this will cause NetrwBrowse/LocalBrowseCheck to do a refresh
-"  call Decho("clear buffer<".expand("%")."> with :%d",'~'.expand("<slnum>"))
   sil! NetrwKeepj %d _
   " following prevents tree listing buffer from being marked "modified"
-"  call Decho("setl nomod",'~'.expand("<slnum>"))
   setl nomod
-"  call Decho("ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
 
   " refresh the listing
-"  call Decho("refresh the listing",'~'.expand("<slnum>"))
-  NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
+  NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
   NetrwKeepj call s:NetrwCursor(0)
 
   " repoint t:netrw_lexbufnr if appropriate
   if exists("repointlexbufnr")
    let t:netrw_lexbufnr= bufnr("%")
-"   call Decho("repoint t:netrw_lexbufnr to #".t:netrw_lexbufnr)
   endif
 
   " restore position; keep cursor on the filename
@@ -4534,22 +4397,18 @@ fun! s:NetrwListStyle(islocal)
   NetrwKeepj call winrestview(svpos)
   let @@= ykeep
 
-"  call Dret("NetrwListStyle".(exists("w:netrw_liststyle")? ' : w:netrw_liststyle='.w:netrw_liststyle : ""))
 endfun
 
 " ---------------------------------------------------------------------
 " s:NetrwBannerCtrl: toggles the display of the banner {{{2
 fun! s:NetrwBannerCtrl(islocal)
-"  call Dfunc("s:NetrwBannerCtrl(islocal=".a:islocal.") g:netrw_banner=".g:netrw_banner)
-
   let ykeep= @@
   " toggle the banner (enable/suppress)
   let g:netrw_banner= !g:netrw_banner
 
   " refresh the listing
   let svpos= winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
-  call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
+  call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
 
   " keep cursor on the filename
   if g:netrw_banner && exists("w:netrw_bannercnt") && line(".") >= w:netrw_bannercnt
@@ -4577,24 +4436,20 @@ endfun
 "
 "  With bang: deletes files/directories from Netrw's bookmark system
 fun! s:NetrwBookmark(del,...)
-"  call Dfunc("s:NetrwBookmark(del=".a:del.",...) a:0=".a:0)
   if a:0 == 0
    if &ft == "netrw"
     let curbufnr = bufnr("%")
 
     if exists("s:netrwmarkfilelist_{curbufnr}")
      " for every filename in the marked list
-"     call Decho("bookmark every filename in marked list",'~'.expand("<slnum>"))
      let svpos  = winsaveview()
-"     call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
      let islocal= expand("%") !~ '^\a\{3,}://'
      for fname in s:netrwmarkfilelist_{curbufnr}
       if a:del|call s:DeleteBookmark(fname)|else|call s:MakeBookmark(fname)|endif
      endfor
      let curdir  = exists("b:netrw_curdir")? b:netrw_curdir : getcwd()
      call s:NetrwUnmarkList(curbufnr,curdir)
-     NetrwKeepj call s:NetrwRefresh(islocal,s:NetrwBrowseChgDir(islocal,'./'))
-"     call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+     NetrwKeepj call s:NetrwRefresh(islocal,s:NetrwBrowseChgDir(islocal,'./',0))
      NetrwKeepj call winrestview(svpos)
     else
      let fname= s:NetrwGetWord()
@@ -4603,7 +4458,6 @@ fun! s:NetrwBookmark(del,...)
 
    else
     " bookmark currently open file
-"    call Decho("bookmark currently open file",'~'.expand("<slnum>"))
     let fname= expand("%")
     if a:del|call s:DeleteBookmark(fname)|else|call s:MakeBookmark(fname)|endif
    endif
@@ -4614,7 +4468,6 @@ fun! s:NetrwBookmark(del,...)
    "  by deciding if the current file begins with an url
    "  Globbing cannot be done remotely.
    let islocal= expand("%") !~ '^\a\{3,}://'
-"   call Decho("bookmark specified file".((a:0>1)? "s" : ""),'~'.expand("<slnum>"))
    let i = 1
    while i <= a:0
     if islocal
@@ -4626,9 +4479,7 @@ fun! s:NetrwBookmark(del,...)
     else
      let mbfiles= [a:{i}]
     endif
-"    call Decho("mbfiles".string(mbfiles),'~'.expand("<slnum>"))
     for mbfile in mbfiles
-"     call Decho("mbfile<".mbfile.">",'~'.expand("<slnum>"))
      if a:del|call s:DeleteBookmark(mbfile)|else|call s:MakeBookmark(mbfile)|endif
     endfor
     let i= i + 1
@@ -4637,8 +4488,6 @@ fun! s:NetrwBookmark(del,...)
 
   " update the menu
   call s:NetrwBookmarkMenu()
-
-"  call Dret("s:NetrwBookmark")
 endfun
 
 " ---------------------------------------------------------------------
@@ -4710,58 +4559,55 @@ endfun
 "                       directory and a new directory name.  Also, if the
 "                       "new directory name" is actually a file,
 "                       NetrwBrowseChgDir() edits the file.
-fun! s:NetrwBrowseChgDir(islocal,newdir,...)
-"  call Dfunc("s:NetrwBrowseChgDir(islocal=".a:islocal."> newdir<".a:newdir.">) a:0=".a:0." win#".winnr()." curpos<".string(getpos("."))."> b:netrw_curdir<".(exists("b:netrw_curdir")? b:netrw_curdir : "").">")
-"  call Decho("tab#".tabpagenr()." win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> line#".line(".")." col#".col(".")." winline#".winline()." wincol#".wincol(),'~'.expand("<slnum>"))
-
+"    cursor=0: newdir is relative to b:netrw_curdir
+"          =1: newdir is relative to the path to the word under the cursor in
+"              tree view
+fun! s:NetrwBrowseChgDir(islocal,newdir,cursor,...)
   let ykeep= @@
   if !exists("b:netrw_curdir")
    " Don't try to change-directory: this can happen, for example, when netrw#ErrorMsg has been called
    " and the current window is the NetrwMessage window.
    let @@= ykeep
-"   call Decho("b:netrw_curdir doesn't exist!",'~'.expand("<slnum>"))
-"   call Decho("getcwd<".getcwd().">",'~'.expand("<slnum>"))
-"   call Dredir("ls!","s:NetrwBrowseChgDir")
-"   call Dret("s:NetrwBrowseChgDir")
    return
   endif
-"  call Decho("b:netrw_curdir<".b:netrw_curdir.">")
 
   " NetrwBrowseChgDir; save options and initialize {{{3
-"  call Decho("saving options",'~'.expand("<slnum>"))
   call s:SavePosn(s:netrw_posn)
   NetrwKeepj call s:NetrwOptionsSave("s:")
   NetrwKeepj call s:NetrwOptionsSafe(a:islocal)
-  if has("win32")
-   let dirname = substitute(b:netrw_curdir,'\\','/','ge')
+
+  let newdir = a:newdir
+  if a:cursor && exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treetop")
+   " dirname is the path to the word under the cursor
+   let dirname = s:NetrwTreePath(w:netrw_treetop)
+   " Remove trailing "/"
+   let dirname = substitute(dirname, "/$", "", "")
+
+   " If the word under the cursor is a directory (except for ../), NetrwTreePath
+   " returns the full path, including the word under the cursor, remove it
+   if newdir =~ "/$" && newdir != "../"
+    let dirname = fnamemodify(dirname, ":h")
+   endif
   else
    let dirname = b:netrw_curdir
   endif
-  let newdir    = a:newdir
+  if has("win32")
+   let dirname = substitute(dirname,'\\','/','ge')
+  endif
   let dolockout = 0
   let dorestore = 1
-"  call Decho("win#".winnr(),'~'.expand("<slnum>"))
-"  call Decho("dirname<".dirname.">",'~'.expand("<slnum>"))
-"  call Decho("newdir<".newdir.">",'~'.expand("<slnum>"))
 
   " ignore <cr>s when done in the banner
-"  call Decho('(s:NetrwBrowseChgDir) ignore [return]s when done in banner (g:netrw_banner='.g:netrw_banner.")",'~'.expand("<slnum>"))
   if g:netrw_banner
-"   call Decho("win#".winnr()." w:netrw_bannercnt=".(exists("w:netrw_bannercnt")? w:netrw_bannercnt : 'n/a')." line(.)#".line('.')." line($)#".line("#"),'~'.expand("<slnum>"))
    if exists("w:netrw_bannercnt") && line(".") < w:netrw_bannercnt && line("$") >= w:netrw_bannercnt
     if getline(".") =~# 'Quick Help'
-"     call Decho("#1: quickhelp=".g:netrw_quickhelp." ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
      let g:netrw_quickhelp= (g:netrw_quickhelp + 1)%len(s:QuickHelp)
-"     call Decho("#2: quickhelp=".g:netrw_quickhelp." ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
      setl ma noro nowrap
      NetrwKeepj call setline(line('.'),'"   Quick Help: <F1>:help  '.s:QuickHelp[g:netrw_quickhelp])
      setl noma nomod nowrap
      NetrwKeepj call s:NetrwOptionsRestore("s:")
-"     call Decho("ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
     endif
    endif
-"  else " Decho
-"   call Decho("g:netrw_banner=".g:netrw_banner." (no banner)",'~'.expand("<slnum>"))
   endif
 
   " set up o/s-dependent directory recognition pattern
@@ -4770,69 +4616,45 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
   else
    let dirpat= '[\/]$'
   endif
-"  call Decho("set up o/s-dependent directory recognition pattern: dirname<".dirname.">  dirpat<".dirpat.">",'~'.expand("<slnum>"))
 
   if dirname !~ dirpat
    " apparently vim is "recognizing" that it is in a directory and
    " is removing the trailing "/".  Bad idea, so let's put it back.
    let dirname= dirname.'/'
-"   call Decho("adjusting dirname<".dirname.'>  (put trailing "/" back)','~'.expand("<slnum>"))
   endif
 
-"  call Decho("[newdir<".newdir."> ".((newdir =~ dirpat)? "=~" : "!~")." dirpat<".dirpat.">] && [islocal=".a:islocal."] && [newdir is ".(isdirectory(s:NetrwFile(newdir))? "" : "not ")."a directory]",'~'.expand("<slnum>"))
   if newdir !~ dirpat && !(a:islocal && isdirectory(s:NetrwFile(s:ComposePath(dirname,newdir))))
    " ------------------------------
    " NetrwBrowseChgDir: edit a file {{{3
    " ------------------------------
-"   call Decho('edit-a-file: case "handling a file": win#'.winnr().' newdir<'.newdir.'> !~ dirpat<'.dirpat.">",'~'.expand("<slnum>"))
 
    " save position for benefit of Rexplore
    let s:rexposn_{bufnr("%")}= winsaveview()
-"   call Decho("edit-a-file: saving posn to s:rexposn_".bufnr("%")."<".string(s:rexposn_{bufnr("%")}).">",'~'.expand("<slnum>"))
-"   call Decho("edit-a-file: win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> ft=".&ft,'~'.expand("<slnum>"))
-"   call Decho("edit-a-file: w:netrw_liststyle=".(exists("w:netrw_liststyle")? w:netrw_liststyle : 'n/a')." w:netrw_treedict:".(exists("w:netrw_treedict")? "exists" : 'n/a')." newdir<".newdir.">",'~'.expand("<slnum>"))
 
    if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict") && newdir !~ '^\(/\|\a:\)'
-"    call Decho("edit-a-file: handle tree listing: w:netrw_treedict<".(exists("w:netrw_treedict")? string(w:netrw_treedict) : 'n/a').">",'~'.expand("<slnum>"))
-"    call Decho("edit-a-file: newdir<".newdir.">",'~'.expand("<slnum>"))
-"    let newdir = s:NetrwTreePath(s:netrw_treetop)
-"    call Decho("edit-a-file: COMBAK why doesn't this recognize file1's directory???")
-    let dirname= s:NetrwTreeDir(a:islocal)
-    "COMBAK : not working for a symlink -- but what about a regular file? a directory?
-"    call Decho("COMBAK : not working for a symlink -- but what about a regular file? a directory?")
-    " Feb 17, 2019: following if-else-endif restored -- wasn't editing a file in tree mode
     if dirname =~ '/$'
      let dirname= dirname.newdir
     else
      let dirname= dirname."/".newdir
     endif
-"    call Decho("edit-a-file: dirname<".dirname.">",'~'.expand("<slnum>"))
-"    call Decho("edit-a-file: tree listing",'~'.expand("<slnum>"))
    elseif newdir =~ '^\(/\|\a:\)'
-"    call Decho("edit-a-file: handle an url or path starting with /: <".newdir.">",'~'.expand("<slnum>"))
     let dirname= newdir
    else
     let dirname= s:ComposePath(dirname,newdir)
    endif
-"   call Decho("edit-a-file: handling a file: dirname<".dirname."> (a:0=".a:0.")",'~'.expand("<slnum>"))
    " this lets netrw#BrowseX avoid the edit
    if a:0 < 1
-"    call Decho("edit-a-file: (a:0=".a:0."<1) set up windows for editing<".fnameescape(dirname).">  didsplit=".(exists("s:didsplit")? s:didsplit : "doesn't exist"),'~'.expand("<slnum>"))
     NetrwKeepj call s:NetrwOptionsRestore("s:")
     let curdir= b:netrw_curdir
     if !exists("s:didsplit")
-"     "     call Decho("edit-a-file: s:didsplit does not exist; g:netrw_browse_split=".string(g:netrw_browse_split)." win#".winnr()." g:netrw_chgwin=".g:netrw_chgwin",'~'.expand("<slnum>"))
      if type(g:netrw_browse_split) == 3
       " open file in server
       " Note that g:netrw_browse_split is a List: [servername,tabnr,winnr]
-"      call Decho("edit-a-file: open file in server",'~'.expand("<slnum>"))
       call s:NetrwServerEdit(a:islocal,dirname)
-"      call Dret("s:NetrwBrowseChgDir")
       return
 
      elseif g:netrw_browse_split == 1
       " horizontally splitting the window first
-"      call Decho("edit-a-file: horizontally splitting window prior to edit",'~'.expand("<slnum>"))
       let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winheight(0))/100 : -g:netrw_winsize
       exe "keepalt ".(g:netrw_alto? "bel " : "abo ").winsz."wincmd s"
       if !&ea
@@ -4842,7 +4664,6 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
 
      elseif g:netrw_browse_split == 2
       " vertically splitting the window first
-"      call Decho("edit-a-file: vertically splitting window prior to edit",'~'.expand("<slnum>"))
       let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winwidth(0))/100 : -g:netrw_winsize
       exe "keepalt ".(g:netrw_alto? "top " : "bot ")."vert ".winsz."wincmd s"
       if !&ea
@@ -4852,7 +4673,6 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
 
      elseif g:netrw_browse_split == 3
       " open file in new tab
-"      call Decho("edit-a-file: opening new tab prior to edit",'~'.expand("<slnum>"))
       keepalt tabnew
       if !exists("b:netrw_curdir")
        let b:netrw_curdir= getcwd()
@@ -4861,21 +4681,17 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
 
      elseif g:netrw_browse_split == 4
       " act like "P" (ie. open previous window)
-"      call Decho("edit-a-file: use previous window for edit",'~'.expand("<slnum>"))
       if s:NetrwPrevWinOpen(2) == 3
        let @@= ykeep
-"       call Dret("s:NetrwBrowseChgDir")
        return
       endif
       call s:SetRexDir(a:islocal,curdir)
 
      else
       " handling a file, didn't split, so remove menu
-"      call Decho("edit-a-file: handling a file+didn't split, so remove menu",'~'.expand("<slnum>"))
       call s:NetrwMenu(0)
       " optional change to window
       if g:netrw_chgwin >= 1
-"       call Decho("edit-a-file: changing window to #".g:netrw_chgwin.": (due to g:netrw_chgwin)",'~'.expand("<slnum>"))
        if winnr("$")+1 == g:netrw_chgwin
        " if g:netrw_chgwin is set to one more than the last window, then
        " vertically split the last window to make that window available.
@@ -4899,21 +4715,17 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
      let dolockout= 1
     endif
     if a:islocal
-"     call Decho("edit-a-file: edit local file: exe e! ".fnameescape(dirname),'~'.expand("<slnum>"))
      " some like c-^ to return to the last edited file
      " others like c-^ to return to the netrw buffer
      " Apr 30, 2020: used to have e! here.  That can cause loss of a modified file,
      " so emit error E37 instead.
      call s:NetrwEditFile("e","",dirname)
-"     call Decho("edit-a-file: after e ".dirname.": hidden=".&hidden." bufhidden<".&bufhidden."> mod=".&mod,'~'.expand("<slnum>"))
-     " COMBAK -- cuc cul related
      call s:NetrwCursor(1)
      if &hidden || &bufhidden == "hide"
       " file came from vim's hidden storage.  Don't "restore" options with it.
       let dorestore= 0
      endif
     else
-"     call Decho("edit-a-file: remote file: NetrwBrowse will edit it",'~'.expand("<slnum>"))
     endif
 
     " handle g:Netrw_funcref -- call external-to-netrw functions
@@ -4921,12 +4733,9 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
     "   or as a list of function references.  It will ignore anything that's not
     "   a function reference.  See  :help Funcref  for information about function references.
     if exists("g:Netrw_funcref")
-"     call Decho("edit-a-file: handle optional Funcrefs",'~'.expand("<slnum>"))
      if type(g:Netrw_funcref) == 2
-"      call Decho("edit-a-file: handling a g:Netrw_funcref",'~'.expand("<slnum>"))
       NetrwKeepj call g:Netrw_funcref()
      elseif type(g:Netrw_funcref) == 3
-"      call Decho("edit-a-file: handling a list of g:Netrw_funcrefs",'~'.expand("<slnum>"))
       for Fncref in g:Netrw_funcref
        if type(Fncref) == 2
         NetrwKeepj call Fncref()
@@ -4940,7 +4749,6 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
    " ----------------------------------------------------
    " NetrwBrowseChgDir: just go to the new directory spec {{{3
    " ----------------------------------------------------
-"   call Decho('goto-newdir: case "just go to new directory spec": newdir<'.newdir.'>','~'.expand("<slnum>"))
    let dirname = newdir
    NetrwKeepj call s:SetRexDir(a:islocal,dirname)
    NetrwKeepj call s:NetrwOptionsRestore("s:")
@@ -4950,7 +4758,6 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
    " ---------------------------------------------
    " NetrwBrowseChgDir: refresh the directory list {{{3
    " ---------------------------------------------
-"   call Decho('(s:NetrwBrowseChgDir)refresh-dirlist: case "refresh directory listing": newdir == "./"','~'.expand("<slnum>"))
    NetrwKeepj call s:SetRexDir(a:islocal,dirname)
    norm! m`
 
@@ -4958,26 +4765,21 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
    " --------------------------------------
    " NetrwBrowseChgDir: go up one directory {{{3
    " --------------------------------------
-"   call Decho('(s:NetrwBrowseChgDir)go-up: case "go up one directory": newdir == "../"','~'.expand("<slnum>"))
 
    if w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict")
     " force a refresh
-"    call Decho("go-up: clear buffer<".expand("%")."> with :%d",'~'.expand("<slnum>"))
-"    call Decho("go-up: setl noro ma",'~'.expand("<slnum>"))
     setl noro ma
     NetrwKeepj %d _
    endif
 
    if has("amiga")
     " amiga
-"    call Decho('go-up: case "go up one directory": newdir == "../" and amiga','~'.expand("<slnum>"))
     if a:islocal
      let dirname= substitute(dirname,'^\(.*[/:]\)\([^/]\+$\)','\1','')
      let dirname= substitute(dirname,'/$','','')
     else
      let dirname= substitute(dirname,'^\(.*[/:]\)\([^/]\+/$\)','\1','')
     endif
-"    call Decho("go-up: amiga: dirname<".dirname."> (go up one dir)",'~'.expand("<slnum>"))
 
    elseif !g:netrw_cygwin && has("win32")
     " windows
@@ -4992,11 +4794,9 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
     if dirname =~ '^\a:$'
      let dirname= dirname.'/'
     endif
-"    call Decho("go-up: windows: dirname<".dirname."> (go up one dir)",'~'.expand("<slnum>"))
 
    else
     " unix or cygwin
-"    call Decho('(s:NetrwBrowseChgDir)go-up: case "go up one directory": newdir == "../" and unix or cygwin','~'.expand("<slnum>"))
     if a:islocal
      let dirname= substitute(dirname,'^\(.*\)/\([^/]\+\)/$','\1','')
      if dirname == ""
@@ -5005,7 +4805,6 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
     else
      let dirname= substitute(dirname,'^\(\a\{3,}://.\{-}/\{1,2}\)\(.\{-}\)\([^/]\+\)/$','\1\2','')
     endif
-"    call Decho("go-up: unix: dirname<".dirname."> (go up one dir)",'~'.expand("<slnum>"))
    endif
    NetrwKeepj call s:SetRexDir(a:islocal,dirname)
    norm! m`
@@ -5014,69 +4813,48 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
    " --------------------------------------
    " NetrwBrowseChgDir: Handle Tree Listing {{{3
    " --------------------------------------
-"   call Decho('(s:NetrwBrowseChgDir)tree-list: case liststyle is TREELIST and w:netrw_treedict exists','~'.expand("<slnum>"))
    " force a refresh (for TREELIST, NetrwTreeDir() will force the refresh)
-"   call Decho("tree-list: setl noro ma",'~'.expand("<slnum>"))
    setl noro ma
    if !(exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("b:netrw_curdir"))
-"    call Decho("tree-list: clear buffer<".expand("%")."> with :%d  (force refresh)",'~'.expand("<slnum>"))
     NetrwKeepj %d _
    endif
    let treedir      = s:NetrwTreeDir(a:islocal)
-"   call Decho("tree-list: treedir<".treedir.">",'~'.expand("<slnum>"))
    let s:treecurpos = winsaveview()
    let haskey       = 0
-"   call Decho("tree-list: w:netrw_treedict<".string(w:netrw_treedict).">",'~'.expand("<slnum>"))
 
    " search treedict for tree dir as-is
-"   call Decho("tree-list: search treedict for tree dir as-is",'~'.expand("<slnum>"))
    if has_key(w:netrw_treedict,treedir)
-"    call Decho('(s:NetrwBrowseChgDir)tree-list: ....searched for treedir<'.treedir.'> : found it!','~'.expand("<slnum>"))
     let haskey= 1
    else
-"    call Decho('(s:NetrwBrowseChgDir)tree-list: ....searched for treedir<'.treedir.'> : not found','~'.expand("<slnum>"))
    endif
 
    " search treedict for treedir with a [/@] appended
-"   call Decho("tree-list: search treedict for treedir with a [/@] appended",'~'.expand("<slnum>"))
    if !haskey && treedir !~ '[/@]$'
     if has_key(w:netrw_treedict,treedir."/")
      let treedir= treedir."/"
-"     call Decho('(s:NetrwBrowseChgDir)tree-list: ....searched.for treedir<'.treedir.'> found it!','~'.expand("<slnum>"))
      let haskey = 1
     else
-"     call Decho('(s:NetrwBrowseChgDir)tree-list: ....searched for treedir<'.treedir.'/> : not found','~'.expand("<slnum>"))
     endif
    endif
 
    " search treedict for treedir with any trailing / elided
-"   call Decho("tree-list: search treedict for treedir with any trailing / elided",'~'.expand("<slnum>"))
    if !haskey && treedir =~ '/$'
     let treedir= substitute(treedir,'/$','','')
     if has_key(w:netrw_treedict,treedir)
-"     call Decho('(s:NetrwBrowseChgDir)tree-list: ....searched.for treedir<'.treedir.'> found it!','~'.expand("<slnum>"))
      let haskey = 1
     else
-"     call Decho('(s:NetrwBrowseChgDir)tree-list: ....searched for treedir<'.treedir.'> : not found','~'.expand("<slnum>"))
     endif
    endif
 
-"   call Decho("haskey=".haskey,'~'.expand("<slnum>"))
    if haskey
     " close tree listing for selected subdirectory
-"    call Decho("tree-list: closing selected subdirectory<".dirname.">",'~'.expand("<slnum>"))
     call remove(w:netrw_treedict,treedir)
-"    call Decho("tree-list: removed     entry<".treedir."> from treedict",'~'.expand("<slnum>"))
-"    call Decho("tree-list: yielding treedict<".string(w:netrw_treedict).">",'~'.expand("<slnum>"))
     let dirname= w:netrw_treetop
    else
     " go down one directory
     let dirname= substitute(treedir,'/*$','/','')
-"    call Decho("tree-list: go down one dir: treedir<".treedir.">",'~'.expand("<slnum>"))
-"    call Decho("tree-list: ...            : dirname<".dirname.">",'~'.expand("<slnum>"))
    endif
    NetrwKeepj call s:SetRexDir(a:islocal,dirname)
-"   call Decho("setting s:treeforceredraw to true",'~'.expand("<slnum>"))
    let s:treeforceredraw = 1
 
   else
@@ -5084,7 +4862,6 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
    " NetrwBrowseChgDir: Go down one directory {{{3
    " ----------------------------------------
    let dirname    = s:ComposePath(dirname,newdir)
-"   call Decho("go down one dir: dirname<".dirname."> newdir<".newdir.">",'~'.expand("<slnum>"))
    NetrwKeepj call s:SetRexDir(a:islocal,dirname)
    norm! m`
   endif
@@ -5095,29 +4872,18 @@ fun! s:NetrwBrowseChgDir(islocal,newdir,...)
   if dorestore
    " dorestore is zero'd when a local file was hidden or bufhidden;
    " in such a case, we want to keep whatever settings it may have.
-"   call Decho("doing option restore (dorestore=".dorestore.")",'~'.expand("<slnum>"))
    NetrwKeepj call s:NetrwOptionsRestore("s:")
-"  else " Decho
-"   call Decho("skipping option restore (dorestore==0): hidden=".&hidden." bufhidden=".&bufhidden." mod=".&mod,'~'.expand("<slnum>"))
   endif
   if dolockout && dorestore
-"   call Decho("restore: filewritable(dirname<".dirname.">)=".filewritable(dirname),'~'.expand("<slnum>"))
    if filewritable(dirname)
-"    call Decho("restore: doing modification lockout settings: ma nomod noro",'~'.expand("<slnum>"))
-"    call Decho("restore: setl ma nomod noro",'~'.expand("<slnum>"))
     setl ma noro nomod
-"    call Decho("restore: ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
    else
-"    call Decho("restore: doing modification lockout settings: ma nomod ro",'~'.expand("<slnum>"))
-"    call Decho("restore: setl ma nomod noro",'~'.expand("<slnum>"))
     setl ma ro nomod
-"    call Decho("restore: ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
    endif
   endif
   call s:RestorePosn(s:netrw_posn)
   let @@= ykeep
 
-"  call Dret("s:NetrwBrowseChgDir <".dirname."> : curpos<".string(getpos(".")).">")
   return dirname
 endfun
 
@@ -5126,19 +4892,16 @@ endfun
 "    for thin, long, and wide: cursor placed just after banner
 "    for tree, keeps cursor on current filename
 fun! s:NetrwBrowseUpDir(islocal)
-"  call Dfunc("s:NetrwBrowseUpDir(islocal=".a:islocal.")")
   if exists("w:netrw_bannercnt") && line(".") < w:netrw_bannercnt-1
    " this test needed because occasionally this function seems to be incorrectly called
    " when multiple leftmouse clicks are taken when atop the one line help in the banner.
    " I'm allowing the very bottom line to permit a "-" exit so that one may escape empty
    " directories.
-"   call Dret("s:NetrwBrowseUpDir : cursor not in file area")
    return
   endif
 
   norm! 0
   if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict")
-"   call Decho("case: treestyle",'~'.expand("<slnum>"))
    let curline= getline(".")
    let swwline= winline() - 1
    if exists("w:netrw_treetop")
@@ -5152,22 +4915,18 @@ fun! s:NetrwBrowseUpDir(islocal)
    let curfile = getline(".")
    let curpath = s:NetrwTreePath(w:netrw_treetop)
    if a:islocal
-    call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,'../'))
+    call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,'../',0))
    else
-    call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,'../'))
+    call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,'../',0))
    endif
-"   call Decho("looking for curfile<^".s:treedepthstring.curfile.">",'~'.expand("<slnum>"))
-"   call Decho("having      curpath<".curpath.">",'~'.expand("<slnum>"))
    if w:netrw_treetop == '/'
      keepj call search('^\M'.curfile,"w")
    elseif curfile == '../'
      keepj call search('^\M'.curfile,"wb")
    else
-"    call Decho("search(^\\M".s:treedepthstring.curfile.") backwards"))
     while 1
      keepj call search('^\M'.s:treedepthstring.curfile,"wb")
      let treepath= s:NetrwTreePath(w:netrw_treetop)
-"     call Decho("..current treepath<".treepath.">",'~'.expand("<slnum>"))
      if treepath == curpath
       break
      endif
@@ -5175,7 +4934,6 @@ fun! s:NetrwBrowseUpDir(islocal)
    endif
 
   else
-"   call Decho("case: not treestyle",'~'.expand("<slnum>"))
    call s:SavePosn(s:netrw_posn)
    if exists("b:netrw_curdir")
     let curdir= b:netrw_curdir
@@ -5183,16 +4941,15 @@ fun! s:NetrwBrowseUpDir(islocal)
     let curdir= expand(getcwd())
    endif
    if a:islocal
-    call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,'../'))
+    call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,'../',0))
    else
-    call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,'../'))
+    call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,'../',0))
    endif
    call s:RestorePosn(s:netrw_posn)
    let curdir= substitute(curdir,'^.*[\/]','','')
    let curdir= '\<'. escape(curdir, '~'). '/'
    call search(curdir,'wc')
   endif
-"  call Dret("s:NetrwBrowseUpDir")
 endfun
 
 func s:redir()
@@ -5530,23 +5287,20 @@ endfun
 " ---------------------------------------------------------------------
 " s:NetrwChgPerm: (implements "gp") change file permission {{{2
 fun! s:NetrwChgPerm(islocal,curdir)
-"  call Dfunc("s:NetrwChgPerm(islocal=".a:islocal." curdir<".a:curdir.">)")
   let ykeep  = @@
   call inputsave()
   let newperm= input("Enter new permission: ")
   call inputrestore()
   let chgperm= substitute(g:netrw_chgperm,'\<FILENAME\>',s:ShellEscape(expand("<cfile>")),'')
   let chgperm= substitute(chgperm,'\<PERM\>',s:ShellEscape(newperm),'')
-"  call Decho("chgperm<".chgperm.">",'~'.expand("<slnum>"))
   call system(chgperm)
   if v:shell_error != 0
    NetrwKeepj call netrw#ErrorMsg(1,"changing permission on file<".expand("<cfile>")."> seems to have failed",75)
   endif
   if a:islocal
-   NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
+   NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
   endif
   let @@= ykeep
-"  call Dret("s:NetrwChgPerm")
 endfun
 
 " ---------------------------------------------------------------------
@@ -5627,8 +5381,6 @@ endfun
 " ---------------------------------------------------------------------
 " s:NetrwExploreListUniq: {{{2
 fun! s:NetrwExploreListUniq(explist)
-"  call Dfunc("s:NetrwExploreListUniq(explist<".string(a:explist).">)")
-
   " this assumes that the list is already sorted
   let newexplist= []
   for member in a:explist
@@ -5637,15 +5389,12 @@ fun! s:NetrwExploreListUniq(explist)
     let newexplist = newexplist + [ member ]
    endif
   endfor
-
-"  call Dret("s:NetrwExploreListUniq newexplist<".string(newexplist).">")
   return newexplist
 endfun
 
 " ---------------------------------------------------------------------
 " s:NetrwForceChgDir: (gd support) Force treatment as a directory {{{2
 fun! s:NetrwForceChgDir(islocal,newdir)
-"  call Dfunc("s:NetrwForceChgDir(islocal=".a:islocal." newdir<".a:newdir.">)")
   let ykeep= @@
   if a:newdir !~ '/$'
    " ok, looks like force is needed to get directory-style treatment
@@ -5656,15 +5405,13 @@ fun! s:NetrwForceChgDir(islocal,newdir)
    else
     let newdir= a:newdir.'/'
    endif
-"   call Decho("adjusting newdir<".newdir."> due to gd",'~'.expand("<slnum>"))
   else
    " should already be getting treatment as a directory
    let newdir= a:newdir
   endif
-  let newdir= s:NetrwBrowseChgDir(a:islocal,newdir)
+  let newdir= s:NetrwBrowseChgDir(a:islocal,newdir,0)
   call s:NetrwBrowse(a:islocal,newdir)
   let @@= ykeep
-"  call Dret("s:NetrwForceChgDir")
 endfun
 
 " ---------------------------------------------------------------------
@@ -5710,18 +5457,16 @@ endfun
 " ---------------------------------------------------------------------
 " s:NetrwForceFile: (gf support) Force treatment as a file {{{2
 fun! s:NetrwForceFile(islocal,newfile)
-"  call Dfunc("s:NetrwForceFile(islocal=".a:islocal." newdir<".a:newfile.">)")
   if a:newfile =~ '[/@*=|\\]$'
    let newfile= substitute(a:newfile,'.$','','')
   else
    let newfile= a:newfile
   endif
   if a:islocal
-   call s:NetrwBrowseChgDir(a:islocal,newfile)
+   call s:NetrwBrowseChgDir(a:islocal,newfile,0)
   else
-   call s:NetrwBrowse(a:islocal,s:NetrwBrowseChgDir(a:islocal,newfile))
+   call s:NetrwBrowse(a:islocal,s:NetrwBrowseChgDir(a:islocal,newfile,0))
   endif
-"  call Dret("s:NetrwForceFile")
 endfun
 
 " ---------------------------------------------------------------------
@@ -5732,24 +5477,18 @@ endfun
 "                           1: show not-hidden files
 "                           2: show hidden files only
 fun! s:NetrwHide(islocal)
-"  call Dfunc("NetrwHide(islocal=".a:islocal.") g:netrw_hide=".g:netrw_hide)
   let ykeep= @@
   let svpos= winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
 
   if exists("s:netrwmarkfilelist_{bufnr('%')}")
-"   call Decho("((g:netrw_hide == 1)? "unhide" : "hide")." files in markfilelist<".string(s:netrwmarkfilelist_{bufnr("%")}).">",'~'.expand("<slnum>"))
-"   call Decho("g:netrw_list_hide<".g:netrw_list_hide.">",'~'.expand("<slnum>"))
 
    " hide the files in the markfile list
    for fname in s:netrwmarkfilelist_{bufnr("%")}
-"    call Decho("match(g:netrw_list_hide<".g:netrw_list_hide.'> fname<\<'.fname.'\>>)='.match(g:netrw_list_hide,'\<'.fname.'\>')." l:isk=".&l:isk,'~'.expand("<slnum>"))
     if match(g:netrw_list_hide,'\<'.fname.'\>') != -1
      " remove fname from hiding list
      let g:netrw_list_hide= substitute(g:netrw_list_hide,'..\<'.escape(fname,g:netrw_fname_escape).'\>..','','')
      let g:netrw_list_hide= substitute(g:netrw_list_hide,',,',',','g')
      let g:netrw_list_hide= substitute(g:netrw_list_hide,'^,\|,$','','')
-"     call Decho("unhide: g:netrw_list_hide<".g:netrw_list_hide.">",'~'.expand("<slnum>"))
     else
      " append fname to hiding list
      if exists("g:netrw_list_hide") && g:netrw_list_hide != ""
@@ -5757,7 +5496,6 @@ fun! s:NetrwHide(islocal)
      else
       let g:netrw_list_hide= '\<'.escape(fname,g:netrw_fname_escape).'\>'
      endif
-"     call Decho("hide: g:netrw_list_hide<".g:netrw_list_hide.">",'~'.expand("<slnum>"))
     endif
    endfor
    NetrwKeepj call s:NetrwUnmarkList(bufnr("%"),b:netrw_curdir)
@@ -5771,64 +5509,49 @@ fun! s:NetrwHide(islocal)
    if g:netrw_hide && g:netrw_list_hide == ""
     NetrwKeepj call netrw#ErrorMsg(s:WARNING,"your hiding list is empty!",49)
     let @@= ykeep
-"    call Dret("NetrwHide")
     return
    endif
   endif
 
-  NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
-"  call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+  NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
   NetrwKeepj call winrestview(svpos)
   let @@= ykeep
-"  call Dret("NetrwHide")
 endfun
 
 " ---------------------------------------------------------------------
 " s:NetrwHideEdit: allows user to edit the file/directory hiding list {{{2
 fun! s:NetrwHideEdit(islocal)
-"  call Dfunc("NetrwHideEdit(islocal=".a:islocal.")")
-
   let ykeep= @@
   " save current cursor position
   let svpos= winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
 
   " get new hiding list from user
   call inputsave()
   let newhide= input("Edit Hiding List: ",g:netrw_list_hide)
   call inputrestore()
   let g:netrw_list_hide= newhide
-"  call Decho("new g:netrw_list_hide<".g:netrw_list_hide.">",'~'.expand("<slnum>"))
 
   " refresh the listing
-  sil NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,"./"))
+  sil NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,"./",0))
 
   " restore cursor position
-"  call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
   call winrestview(svpos)
   let @@= ykeep
-
-"  call Dret("NetrwHideEdit")
 endfun
 
 " ---------------------------------------------------------------------
 " s:NetrwHidden: invoked by "gh" {{{2
 fun! s:NetrwHidden(islocal)
-"  call Dfunc("s:NetrwHidden()")
   let ykeep= @@
   "  save current position
   let svpos  = winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
 
   if g:netrw_list_hide =~ '\(^\|,\)\\(^\\|\\s\\s\\)\\zs\\.\\S\\+'
    " remove .file pattern from hiding list
-"   call Decho("remove .file pattern from hiding list",'~'.expand("<slnum>"))
    let g:netrw_list_hide= substitute(g:netrw_list_hide,'\(^\|,\)\\(^\\|\\s\\s\\)\\zs\\.\\S\\+','','')
   elseif s:Strlen(g:netrw_list_hide) >= 1
-"   call Decho("add .file pattern from hiding list",'~'.expand("<slnum>"))
    let g:netrw_list_hide= g:netrw_list_hide . ',\(^\|\s\s\)\zs\.\S\+'
   else
-"   call Decho("set .file pattern as hiding list",'~'.expand("<slnum>"))
    let g:netrw_list_hide= '\(^\|\s\s\)\zs\.\S\+'
   endif
   if g:netrw_list_hide =~ '^,'
@@ -5836,11 +5559,9 @@ fun! s:NetrwHidden(islocal)
   endif
 
   " refresh screen and return to saved position
-  NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
-"  call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+  NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
   NetrwKeepj call winrestview(svpos)
   let @@= ykeep
-"  call Dret("s:NetrwHidden")
 endfun
 
 " ---------------------------------------------------------------------
@@ -5875,7 +5596,6 @@ fun! s:NetrwLeftmouse(islocal)
   if &ft != "netrw"
    return
   endif
-"  call Dfunc("s:NetrwLeftmouse(islocal=".a:islocal.")")
 
   let ykeep= @@
   " check if the status bar was clicked on instead of a file/directory name
@@ -5887,36 +5607,30 @@ fun! s:NetrwLeftmouse(islocal)
   let mouse_lnum = v:mouse_lnum
   let wlastline  = line('w$')
   let lastline   = line('$')
-"  call Decho("v:mouse_lnum=".mouse_lnum." line(w$)=".wlastline." line($)=".lastline." v:mouse_win=".v:mouse_win." winnr#".winnr(),'~'.expand("<slnum>"))
-"  call Decho("v:mouse_col =".v:mouse_col."     col=".col(".")."  wincol =".wincol()." winwidth   =".winwidth(0),'~'.expand("<slnum>"))
   if mouse_lnum >= wlastline + 1 || v:mouse_win != winnr()
    " appears to be a status bar leftmouse click
    let @@= ykeep
-"   call Dret("s:NetrwLeftmouse : detected a status bar leftmouse click")
    return
   endif
    " Dec 04, 2013: following test prevents leftmouse selection/deselection of directories and files in treelist mode
    " Windows are separated by vertical separator bars - but the mouse seems to be doing what it should when dragging that bar
    " without this test when its disabled.
    " May 26, 2014: edit file, :Lex, resize window -- causes refresh.  Reinstated a modified test.  See if problems develop.
-"   call Decho("v:mouse_col=".v:mouse_col." col#".col('.')." virtcol#".virtcol('.')." col($)#".col("$")." virtcol($)#".virtcol("$"),'~'.expand("<slnum>"))
    if v:mouse_col > virtcol('.')
     let @@= ykeep
-"    call Dret("s:NetrwLeftmouse : detected a vertical separator bar leftmouse click")
     return
    endif
 
   if a:islocal
    if exists("b:netrw_curdir")
-    NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,s:NetrwGetWord()))
+    NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,s:NetrwGetWord(),1))
    endif
   else
    if exists("b:netrw_curdir")
-    NetrwKeepj call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,s:NetrwGetWord()))
+    NetrwKeepj call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,s:NetrwGetWord(),1))
    endif
   endif
   let @@= ykeep
-"  call Dret("s:NetrwLeftmouse")
 endfun
 
 " ---------------------------------------------------------------------
@@ -5925,9 +5639,7 @@ fun! s:NetrwCLeftmouse(islocal)
   if &ft != "netrw"
    return
   endif
-"  call Dfunc("s:NetrwCLeftmouse(islocal=".a:islocal.")")
   call s:NetrwMarkFileTgt(a:islocal)
-"  call Dret("s:NetrwCLeftmouse")
 endfun
 
 " ---------------------------------------------------------------------
@@ -5940,39 +5652,30 @@ fun! s:NetrwServerEdit(islocal,fname)
 "  call Dfunc("s:NetrwServerEdit(islocal=".a:islocal.",fname<".a:fname.">)")
   let islocal = a:islocal%2      " =0: remote           =1: local
   let ctrlr   = a:islocal >= 2   " =0: <c-r> not used   =1: <c-r> used
-"  call Decho("islocal=".islocal." ctrlr=".ctrlr,'~'.expand("<slnum>"))
 
   if (islocal && isdirectory(s:NetrwFile(a:fname))) || (!islocal && a:fname =~ '/$')
    " handle directories in the local window -- not in the remote vim server
    " user must have closed the NETRWSERVER window.  Treat as normal editing from netrw.
-"   call Decho("handling directory in client window",'~'.expand("<slnum>"))
    let g:netrw_browse_split= 0
    if exists("s:netrw_browse_split") && exists("s:netrw_browse_split_".winnr())
     let g:netrw_browse_split= s:netrw_browse_split_{winnr()}
     unlet s:netrw_browse_split_{winnr()}
    endif
-   call s:NetrwBrowse(islocal,s:NetrwBrowseChgDir(islocal,a:fname))
-"   call Dret("s:NetrwServerEdit")
+   call s:NetrwBrowse(islocal,s:NetrwBrowseChgDir(islocal,a:fname,0))
    return
   endif
 
-"  call Decho("handling file in server window",'~'.expand("<slnum>"))
   if has("clientserver") && executable("gvim")
-"   call Decho("has clientserver and gvim",'~'.expand("<slnum>"))
 
     if exists("g:netrw_browse_split") && type(g:netrw_browse_split) == 3
-"     call Decho("g:netrw_browse_split=".string(g:netrw_browse_split),'~'.expand("<slnum>"))
      let srvrname = g:netrw_browse_split[0]
      let tabnum   = g:netrw_browse_split[1]
      let winnum   = g:netrw_browse_split[2]
 
      if serverlist() !~ '\<'.srvrname.'\>'
-"      call Decho("server not available; ctrlr=".ctrlr,'~'.expand("<slnum>"))
-
       if !ctrlr
        " user must have closed the server window and the user did not use <c-r>, but
        " used something like <cr>.
-"       call Decho("user must have closed server AND did not use ctrl-r",'~'.expand("<slnum>"))
        if exists("g:netrw_browse_split")
         unlet g:netrw_browse_split
        endif
@@ -5980,50 +5683,40 @@ fun! s:NetrwServerEdit(islocal,fname)
        if exists("s:netrw_browse_split_".winnr())
         let g:netrw_browse_split= s:netrw_browse_split_{winnr()}
        endif
-       call s:NetrwBrowseChgDir(islocal,a:fname)
-"       call Dret("s:NetrwServerEdit")
+       call s:NetrwBrowseChgDir(islocal,a:fname,0)
        return
 
       elseif has("win32") && executable("start")
        " start up remote netrw server under windows
-"       call Decho("starting up gvim server<".srvrname."> for windows",'~'.expand("<slnum>"))
        call system("start gvim --servername ".srvrname)
 
       else
        " start up remote netrw server under linux
-"       call Decho("starting up gvim server<".srvrname.">",'~'.expand("<slnum>"))
        call system("gvim --servername ".srvrname)
       endif
      endif
 
-"     call Decho("srvrname<".srvrname."> tabnum=".tabnum." winnum=".winnum." server-editing<".a:fname.">",'~'.expand("<slnum>"))
      call remote_send(srvrname,":tabn ".tabnum."\<cr>")
      call remote_send(srvrname,":".winnum."wincmd w\<cr>")
      call remote_send(srvrname,":e ".fnameescape(s:NetrwFile(a:fname))."\<cr>")
-
     else
 
      if serverlist() !~ '\<'.g:netrw_servername.'\>'
 
       if !ctrlr
-"       call Decho("server<".g:netrw_servername."> not available and ctrl-r not used",'~'.expand("<slnum>"))
        if exists("g:netrw_browse_split")
         unlet g:netrw_browse_split
        endif
        let g:netrw_browse_split= 0
-       call s:NetrwBrowse(islocal,s:NetrwBrowseChgDir(islocal,a:fname))
-"       call Dret("s:NetrwServerEdit")
+       call s:NetrwBrowse(islocal,s:NetrwBrowseChgDir(islocal,a:fname,0))
        return
 
       else
-"       call Decho("server<".g:netrw_servername."> not available but ctrl-r used",'~'.expand("<slnum>"))
        if has("win32") && executable("start")
         " start up remote netrw server under windows
-"        call Decho("starting up gvim server<".g:netrw_servername."> for windows",'~'.expand("<slnum>"))
         call system("start gvim --servername ".g:netrw_servername)
        else
         " start up remote netrw server under linux
-"        call Decho("starting up gvim server<".g:netrw_servername.">",'~'.expand("<slnum>"))
         call system("gvim --servername ".g:netrw_servername)
        endif
       endif
@@ -6031,7 +5724,6 @@ fun! s:NetrwServerEdit(islocal,fname)
 
      while 1
       try
-"       call Decho("remote-send: e ".a:fname,'~'.expand("<slnum>"))
        call remote_send(g:netrw_servername,":e ".fnameescape(s:NetrwFile(a:fname))."\<cr>")
        break
       catch /^Vim\%((\a\+)\)\=:E241/
@@ -6052,7 +5744,6 @@ fun! s:NetrwServerEdit(islocal,fname)
     call netrw#ErrorMsg(s:ERROR,"you need a gui-capable vim and client-server to use <ctrl-r>",98)
    endif
 
-"  call Dret("s:NetrwServerEdit")
 endfun
 
 " ---------------------------------------------------------------------
@@ -6176,7 +5867,6 @@ endfun
 " s:NetrwMakeDir: this function makes a directory (both local and remote) {{{2
 "                 implements the "d" mapping.
 fun! s:NetrwMakeDir(usrhost)
-"  call Dfunc("s:NetrwMakeDir(usrhost<".a:usrhost.">)")
 
   let ykeep= @@
   " get name of new directory from user.  A bare <CR> will skip.
@@ -6185,27 +5875,22 @@ fun! s:NetrwMakeDir(usrhost)
   call inputsave()
   let newdirname= input("Please give directory name: ")
   call inputrestore()
-"  call Decho("newdirname<".newdirname.">",'~'.expand("<slnum>"))
 
   if newdirname == ""
    let @@= ykeep
-"   call Dret("s:NetrwMakeDir : user aborted with bare <cr>")
    return
   endif
 
   if a:usrhost == ""
-"   call Decho("local mkdir",'~'.expand("<slnum>"))
 
    " Local mkdir:
    " sanity checks
    let fullnewdir= b:netrw_curdir.'/'.newdirname
-"   call Decho("fullnewdir<".fullnewdir.">",'~'.expand("<slnum>"))
    if isdirectory(s:NetrwFile(fullnewdir))
     if !exists("g:netrw_quiet")
      NetrwKeepj call netrw#ErrorMsg(s:WARNING,"<".newdirname."> is already a directory!",24)
     endif
     let @@= ykeep
-"    call Dret("s:NetrwMakeDir : directory<".newdirname."> exists previously")
     return
    endif
    if s:FileReadable(fullnewdir)
@@ -6213,7 +5898,6 @@ fun! s:NetrwMakeDir(usrhost)
      NetrwKeepj call netrw#ErrorMsg(s:WARNING,"<".newdirname."> is already a file!",25)
     endif
     let @@= ykeep
-"    call Dret("s:NetrwMakeDir : file<".newdirname."> exists previously")
     return
    endif
 
@@ -6228,21 +5912,16 @@ fun! s:NetrwMakeDir(usrhost)
    else
     let netrw_origdir= s:NetrwGetcwd(1)
     if s:NetrwLcd(b:netrw_curdir)
-"    call Dret("s:NetrwMakeDir : lcd failure")
      return
     endif
-"    call Decho("netrw_origdir<".netrw_origdir.">: lcd b:netrw_curdir<".fnameescape(b:netrw_curdir).">",'~'.expand("<slnum>"))
     call s:NetrwExe("sil! !".g:netrw_localmkdir.g:netrw_localmkdiropt.' '.s:ShellEscape(newdirname,1))
     if v:shell_error != 0
      let @@= ykeep
      call netrw#ErrorMsg(s:ERROR,"consider setting g:netrw_localmkdir<".g:netrw_localmkdir."> to something that works",80)
-"     call Dret("s:NetrwMakeDir : failed: sil! !".g:netrw_localmkdir.' '.s:ShellEscape(newdirname,1))
      return
     endif
     if !g:netrw_keepdir
-"     call Decho("restoring netrw_origdir since g:netrw_keepdir=".g:netrw_keepdir,'~'.expand("<slnum>"))
      if s:NetrwLcd(netrw_origdir)
-"     call Dret("s:NetrwBrowse : lcd failure")
       return
      endif
     endif
@@ -6250,126 +5929,95 @@ fun! s:NetrwMakeDir(usrhost)
 
    if v:shell_error == 0
     " refresh listing
-"    call Decho("refresh listing",'~'.expand("<slnum>"))
     let svpos= winsaveview()
-"    call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
-    call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./'))
-"    call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+    call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./',0))
     call winrestview(svpos)
    elseif !exists("g:netrw_quiet")
     call netrw#ErrorMsg(s:ERROR,"unable to make directory<".newdirname.">",26)
    endif
-"   redraw!
 
   elseif !exists("b:netrw_method") || b:netrw_method == 4
    " Remote mkdir:  using ssh
-"   call Decho("remote mkdir",'~'.expand("<slnum>"))
    let mkdircmd  = s:MakeSshCmd(g:netrw_mkdir_cmd)
    let newdirname= substitute(b:netrw_curdir,'^\%(.\{-}/\)\{3}\(.*\)$','\1','').newdirname
    call s:NetrwExe("sil! !".mkdircmd." ".s:ShellEscape(newdirname,1))
    if v:shell_error == 0
     " refresh listing
     let svpos= winsaveview()
-"    call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
-    NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./'))
-"    call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+    NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./',0))
     NetrwKeepj call winrestview(svpos)
    elseif !exists("g:netrw_quiet")
     NetrwKeepj call netrw#ErrorMsg(s:ERROR,"unable to make directory<".newdirname.">",27)
    endif
-"   redraw!
 
   elseif b:netrw_method == 2
    " Remote mkdir:  using ftp+.netrc
    let svpos= winsaveview()
-"   call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
-"   call Decho("b:netrw_curdir<".b:netrw_curdir.">",'~'.expand("<slnum>"))
    if exists("b:netrw_fname")
-"    call Decho("b:netrw_fname<".b:netrw_fname.">",'~'.expand("<slnum>"))
     let remotepath= b:netrw_fname
    else
     let remotepath= ""
    endif
    call s:NetrwRemoteFtpCmd(remotepath,g:netrw_remote_mkdir.' "'.newdirname.'"')
-   NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./'))
-"   call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+   NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./',0))
    NetrwKeepj call winrestview(svpos)
 
   elseif b:netrw_method == 3
    " Remote mkdir: using ftp + machine, id, passwd, and fname (ie. no .netrc)
    let svpos= winsaveview()
-"   call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
-"   call Decho("b:netrw_curdir<".b:netrw_curdir.">",'~'.expand("<slnum>"))
    if exists("b:netrw_fname")
-"    call Decho("b:netrw_fname<".b:netrw_fname.">",'~'.expand("<slnum>"))
     let remotepath= b:netrw_fname
    else
     let remotepath= ""
    endif
    call s:NetrwRemoteFtpCmd(remotepath,g:netrw_remote_mkdir.' "'.newdirname.'"')
-   NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./'))
-"   call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+   NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./',0))
    NetrwKeepj call winrestview(svpos)
   endif
 
   let @@= ykeep
-"  call Dret("s:NetrwMakeDir")
 endfun
 
 " ---------------------------------------------------------------------
 " s:TreeSqueezeDir: allows a shift-cr (gvim only) to squeeze the current tree-listing directory {{{2
 fun! s:TreeSqueezeDir(islocal)
-"  call Dfunc("s:TreeSqueezeDir(islocal=".a:islocal.")")
   if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict")
    " its a tree-listing style
    let curdepth = substitute(getline('.'),'^\(\%('.s:treedepthstring.'\)*\)[^'.s:treedepthstring.'].\{-}$','\1','e')
    let stopline = (exists("w:netrw_bannercnt")? (w:netrw_bannercnt + 1) : 1)
    let depth    = strchars(substitute(curdepth,' ','','g'))
    let srch     = -1
-"   call Decho("curdepth<".curdepth.'>','~'.expand("<slnum>"))
-"   call Decho("depth   =".depth,'~'.expand("<slnum>"))
-"   call Decho("stopline#".stopline,'~'.expand("<slnum>"))
-"   call Decho("curline#".line(".")."<".getline('.').'>','~'.expand("<slnum>"))
    if depth >= 2
     NetrwKeepj norm! 0
     let curdepthm1= substitute(curdepth,'^'.s:treedepthstring,'','')
     let srch      = search('^'.curdepthm1.'\%('.s:treedepthstring.'\)\@!','bW',stopline)
-"    call Decho("curdepthm1<".curdepthm1.'>','~'.expand("<slnum>"))
-"    call Decho("case depth>=2: srch<".srch.'>','~'.expand("<slnum>"))
    elseif depth == 1
     NetrwKeepj norm! 0
     let treedepthchr= substitute(s:treedepthstring,' ','','')
     let srch        = search('^[^'.treedepthchr.']','bW',stopline)
-"    call Decho("case depth==1: srch<".srch.'>','~'.expand("<slnum>"))
    endif
    if srch > 0
-"    call Decho("squeezing at line#".line(".").": ".getline('.'),'~'.expand("<slnum>"))
-    call s:NetrwBrowse(a:islocal,s:NetrwBrowseChgDir(a:islocal,s:NetrwGetWord()))
+    call s:NetrwBrowse(a:islocal,s:NetrwBrowseChgDir(a:islocal,s:NetrwGetWord(),1))
     exe srch
    endif
   endif
-"  call Dret("s:TreeSqueezeDir")
 endfun
 
 " ---------------------------------------------------------------------
 " s:NetrwMaps: {{{2
 fun! s:NetrwMaps(islocal)
-"  call Dfunc("s:NetrwMaps(islocal=".a:islocal.") b:netrw_curdir<".b:netrw_curdir.">")
 
   " mouse <Plug> maps: {{{3
   if g:netrw_mousemaps && g:netrw_retmap
 "   call Decho("set up Rexplore 2-leftmouse",'~'.expand("<slnum>"))
    if !hasmapto("<Plug>NetrwReturn")
     if maparg("<2-leftmouse>","n") == "" || maparg("<2-leftmouse>","n") =~ '^-$'
-"     call Decho("making map for 2-leftmouse",'~'.expand("<slnum>"))
      nmap <unique> <silent> <2-leftmouse>	<Plug>NetrwReturn
     elseif maparg("<c-leftmouse>","n") == ""
-"     call Decho("making map for c-leftmouse",'~'.expand("<slnum>"))
      nmap <unique> <silent> <c-leftmouse>	<Plug>NetrwReturn
     endif
    endif
    nno <silent> <Plug>NetrwReturn	:Rexplore<cr>
-"   call Decho("made <Plug>NetrwReturn map",'~'.expand("<slnum>"))
   endif
 
   " generate default <Plug> maps {{{3
@@ -6385,56 +6033,8 @@ fun! s:NetrwMaps(islocal)
   if !hasmapto('<Plug>NetrwServerEdit')        |nmap <buffer> <silent> <nowait> <c-r>	<Plug>NetrwServerEdit|endif
   if !hasmapto('<Plug>NetrwMakeDir')           |nmap <buffer> <silent> <nowait> d	<Plug>NetrwMakeDir|endif
   if !hasmapto('<Plug>NetrwBookHistHandler_gb')|nmap <buffer> <silent> <nowait> gb	<Plug>NetrwBookHistHandler_gb|endif
-" ---------------------------------------------------------------------
-"  if !hasmapto('<Plug>NetrwForceChgDir')       |nmap <buffer> <silent> <nowait> gd	<Plug>NetrwForceChgDir|endif
-"  if !hasmapto('<Plug>NetrwForceFile')         |nmap <buffer> <silent> <nowait> gf	<Plug>NetrwForceFile|endif
-"  if !hasmapto('<Plug>NetrwHidden')            |nmap <buffer> <silent> <nowait> gh	<Plug>NetrwHidden|endif
-"  if !hasmapto('<Plug>NetrwSetTreetop')        |nmap <buffer> <silent> <nowait> gn	<Plug>NetrwSetTreetop|endif
-"  if !hasmapto('<Plug>NetrwChgPerm')           |nmap <buffer> <silent> <nowait> gp	<Plug>NetrwChgPerm|endif
-"  if !hasmapto('<Plug>NetrwBannerCtrl')        |nmap <buffer> <silent> <nowait> I	<Plug>NetrwBannerCtrl|endif
-"  if !hasmapto('<Plug>NetrwListStyle')         |nmap <buffer> <silent> <nowait> i	<Plug>NetrwListStyle|endif
-"  if !hasmapto('<Plug>NetrwMarkMoveMF2Arglist')|nmap <buffer> <silent> <nowait> ma	<Plug>NetrwMarkMoveMF2Arglist|endif
-"  if !hasmapto('<Plug>NetrwMarkMoveArglist2MF')|nmap <buffer> <silent> <nowait> mA	<Plug>NetrwMarkMoveArglist2MF|endif
-"  if !hasmapto('<Plug>NetrwBookHistHandler_mA')|nmap <buffer> <silent> <nowait> mb	<Plug>NetrwBookHistHandler_mA|endif
-"  if !hasmapto('<Plug>NetrwBookHistHandler_mB')|nmap <buffer> <silent> <nowait> mB	<Plug>NetrwBookHistHandler_mB|endif
-"  if !hasmapto('<Plug>NetrwMarkFileCopy')      |nmap <buffer> <silent> <nowait> mc	<Plug>NetrwMarkFileCopy|endif
-"  if !hasmapto('<Plug>NetrwMarkFileDiff')      |nmap <buffer> <silent> <nowait> md	<Plug>NetrwMarkFileDiff|endif
-"  if !hasmapto('<Plug>NetrwMarkFileEdit')      |nmap <buffer> <silent> <nowait> me	<Plug>NetrwMarkFileEdit|endif
-"  if !hasmapto('<Plug>NetrwMarkFile')          |nmap <buffer> <silent> <nowait> mf	<Plug>NetrwMarkFile|endif
-"  if !hasmapto('<Plug>NetrwUnmarkList')        |nmap <buffer> <silent> <nowait> mF	<Plug>NetrwUnmarkList|endif
-"  if !hasmapto('<Plug>NetrwMarkFileGrep')      |nmap <buffer> <silent> <nowait> mg	<Plug>NetrwMarkFileGrep|endif
-"  if !hasmapto('<Plug>NetrwMarkHideSfx')       |nmap <buffer> <silent> <nowait> mh	<Plug>NetrwMarkHideSfx|endif
-"  if !hasmapto('<Plug>NetrwMarkFileMove')      |nmap <buffer> <silent> <nowait> mm	<Plug>NetrwMarkFileMove|endif
-"  if !hasmapto('<Plug>NetrwMarkFileRegexp')    |nmap <buffer> <silent> <nowait> mr	<Plug>NetrwMarkFileRegexp|endif
-"  if !hasmapto('<Plug>NetrwMarkFileSource')    |nmap <buffer> <silent> <nowait> ms	<Plug>NetrwMarkFileSource|endif
-"  if !hasmapto('<Plug>NetrwMarkFileTag')       |nmap <buffer> <silent> <nowait> mT	<Plug>NetrwMarkFileTag|endif
-"  if !hasmapto('<Plug>NetrwMarkFileTgt')       |nmap <buffer> <silent> <nowait> mt	<Plug>NetrwMarkFileTgt|endif
-"  if !hasmapto('<Plug>NetrwUnMarkFile')        |nmap <buffer> <silent> <nowait> mu	<Plug>NetrwUnMarkFile|endif
-"  if !hasmapto('<Plug>NetrwMarkFileVimCmd')    |nmap <buffer> <silent> <nowait> mv	<Plug>NetrwMarkFileVimCmd|endif
-"  if !hasmapto('<Plug>NetrwMarkFileExe_mx')    |nmap <buffer> <silent> <nowait> mx	<Plug>NetrwMarkFileExe_mx|endif
-"  if !hasmapto('<Plug>NetrwMarkFileExe_mX')    |nmap <buffer> <silent> <nowait> mX	<Plug>NetrwMarkFileExe_mX|endif
-"  if !hasmapto('<Plug>NetrwMarkFileCompress')  |nmap <buffer> <silent> <nowait> mz	<Plug>NetrwMarkFileCompress|endif
-"  if !hasmapto('<Plug>NetrwObtain')            |nmap <buffer> <silent> <nowait> O	<Plug>NetrwObtain|endif
-"  if !hasmapto('<Plug>NetrwSplit_o')           |nmap <buffer> <silent> <nowait> o	<Plug>NetrwSplit_o|endif
-"  if !hasmapto('<Plug>NetrwPreview')           |nmap <buffer> <silent> <nowait> p	<Plug>NetrwPreview|endif
-"  if !hasmapto('<Plug>NetrwPrevWinOpen')       |nmap <buffer> <silent> <nowait> P	<Plug>NetrwPrevWinOpen|endif
-"  if !hasmapto('<Plug>NetrwBookHistHandler_qb')|nmap <buffer> <silent> <nowait> qb	<Plug>NetrwBookHistHandler_qb|endif
-"  if !hasmapto('<Plug>NetrwFileInfo')          |nmap <buffer> <silent> <nowait> qf	<Plug>NetrwFileInfo|endif
-"  if !hasmapto('<Plug>NetrwMarkFileQFEL_qF')   |nmap <buffer> <silent> <nowait> qF	<Plug>NetrwMarkFileQFEL_qF|endif
-"  if !hasmapto('<Plug>NetrwMarkFileQFEL_qL')   |nmap <buffer> <silent> <nowait> qL	<Plug>NetrwMarkFileQFEL_qL|endif
-"  if !hasmapto('<Plug>NetrwSortStyle')         |nmap <buffer> <silent> <nowait> s	<Plug>NetrwSortStyle|endif
-"  if !hasmapto('<Plug>NetSortSequence')        |nmap <buffer> <silent> <nowait> S	<Plug>NetSortSequence|endif
-"  if !hasmapto('<Plug>NetrwSetTgt_Tb')         |nmap <buffer> <silent> <nowait> Tb	<Plug>NetrwSetTgt_Tb|endif
-"  if !hasmapto('<Plug>NetrwSetTgt_Th')         |nmap <buffer> <silent> <nowait> Th	<Plug>NetrwSetTgt_Th|endif
-"  if !hasmapto('<Plug>NetrwSplit_t')           |nmap <buffer> <silent> <nowait> t	<Plug>NetrwSplit_t|endif
-"  if !hasmapto('<Plug>NetrwBookHistHandler_u') |nmap <buffer> <silent> <nowait> u	<Plug>NetrwBookHistHandler_u|endif
-"  if !hasmapto('<Plug>NetrwBookHistHandler_U') |nmap <buffer> <silent> <nowait> U	<Plug>NetrwBookHistHandler_U|endif
-"  if !hasmapto('<Plug>NetrwSplit_v')           |nmap <buffer> <silent> <nowait> v	<Plug>NetrwSplit_v|endif
-"  if !hasmapto('<Plug>NetrwBrowseX')           |nmap <buffer> <silent> <nowait> x	<Plug>NetrwBrowseX|endif
-"  if !hasmapto('<Plug>NetrwLocalExecute')      |nmap <buffer> <silent> <nowait> X	<Plug>NetrwLocalExecute|endif
 
   if a:islocal
-"   call Decho("make local maps",'~'.expand("<slnum>"))
    " local normal-mode maps {{{3
    nnoremap <buffer> <silent> <Plug>NetrwHide_a			:<c-u>call <SID>NetrwHide(1)<cr>
    nnoremap <buffer> <silent> <Plug>NetrwBrowseUpDir		:<c-u>call <SID>NetrwBrowseUpDir(1)<cr>
@@ -6443,7 +6043,7 @@ fun! s:NetrwMaps(islocal)
    nnoremap <buffer> <silent> <Plug>NetrwBadd_cB		:<c-u>call <SID>NetrwBadd(1,1)<cr>
    nnoremap <buffer> <silent> <Plug>NetrwLcd			:<c-u>call <SID>NetrwLcd(b:netrw_curdir)<cr>
    nnoremap <buffer> <silent> <Plug>NetrwSetChgwin		:<c-u>call <SID>NetrwSetChgwin()<cr>
-   nnoremap <buffer> <silent> <Plug>NetrwLocalBrowseCheck	:<c-u>call netrw#LocalBrowseCheck(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord()))<cr>
+   nnoremap <buffer> <silent> <Plug>NetrwLocalBrowseCheck	:<c-u>call netrw#LocalBrowseCheck(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),1))<cr>
    nnoremap <buffer> <silent> <Plug>NetrwServerEdit		:<c-u>call <SID>NetrwServerEdit(3,<SID>NetrwGetWord())<cr>
    nnoremap <buffer> <silent> <Plug>NetrwMakeDir		:<c-u>call <SID>NetrwMakeDir("")<cr>
    nnoremap <buffer> <silent> <Plug>NetrwBookHistHandler_gb	:<c-u>call <SID>NetrwBookHistHandler(1,b:netrw_curdir)<cr>
@@ -6467,6 +6067,7 @@ fun! s:NetrwMaps(islocal)
    nnoremap <buffer> <silent> <nowait> mg	:<c-u>call <SID>NetrwMarkFileGrep(1)<cr>
    nnoremap <buffer> <silent> <nowait> mh	:<c-u>call <SID>NetrwMarkHideSfx(1)<cr>
    nnoremap <buffer> <silent> <nowait> mm	:<c-u>call <SID>NetrwMarkFileMove(1)<cr>
+   "nnoremap <buffer> <silent> <nowait> mp	:<c-u>call <SID>NetrwMarkFilePrint(1)<cr>
    nnoremap <buffer> <silent> <nowait> mr	:<c-u>call <SID>NetrwMarkFileRegexp(1)<cr>
    nnoremap <buffer> <silent> <nowait> ms	:<c-u>call <SID>NetrwMarkFileSource(1)<cr>
    nnoremap <buffer> <silent> <nowait> mT	:<c-u>call <SID>NetrwMarkFileTag(1)<cr>
@@ -6478,7 +6079,7 @@ fun! s:NetrwMaps(islocal)
    nnoremap <buffer> <silent> <nowait> mz	:<c-u>call <SID>NetrwMarkFileCompress(1)<cr>
    nnoremap <buffer> <silent> <nowait> O	:<c-u>call <SID>NetrwObtain(1)<cr>
    nnoremap <buffer> <silent> <nowait> o	:call <SID>NetrwSplit(3)<cr>
-   nnoremap <buffer> <silent> <nowait> p	:<c-u>call <SID>NetrwPreview(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),1))<cr>
+   nnoremap <buffer> <silent> <nowait> p	:<c-u>call <SID>NetrwPreview(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),1,1))<cr>
    nnoremap <buffer> <silent> <nowait> P	:<c-u>call <SID>NetrwPrevWinOpen(1)<cr>
    nnoremap <buffer> <silent> <nowait> qb	:<c-u>call <SID>NetrwBookHistHandler(2,b:netrw_curdir)<cr>
    nnoremap <buffer> <silent> <nowait> qf	:<c-u>call <SID>NetrwFileInfo(1,<SID>NetrwGetWord())<cr>
@@ -6492,10 +6093,10 @@ fun! s:NetrwMaps(islocal)
    nnoremap <buffer> <silent> <nowait> u	:<c-u>call <SID>NetrwBookHistHandler(4,expand("%"))<cr>
    nnoremap <buffer> <silent> <nowait> U	:<c-u>call <SID>NetrwBookHistHandler(5,expand("%"))<cr>
    nnoremap <buffer> <silent> <nowait> v	:call <SID>NetrwSplit(5)<cr>
-   nnoremap <buffer> <silent> <nowait> x	:<c-u>call netrw#BrowseX(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),0),0)"<cr>
+   nnoremap <buffer> <silent> <nowait> x	:<c-u>call netrw#BrowseX(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),1,0),0)"<cr>
    nnoremap <buffer> <silent> <nowait> X	:<c-u>call <SID>NetrwLocalExecute(expand("<cword>"))"<cr>
 
-   nnoremap <buffer> <silent> <nowait> r	:<c-u>let g:netrw_sort_direction= (g:netrw_sort_direction =~# 'n')? 'r' : 'n'<bar>exe "norm! 0"<bar>call <SID>NetrwRefresh(1,<SID>NetrwBrowseChgDir(1,'./'))<cr>
+   nnoremap <buffer> <silent> <nowait> r	:<c-u>let g:netrw_sort_direction= (g:netrw_sort_direction =~# 'n')? 'r' : 'n'<bar>exe "norm! 0"<bar>call <SID>NetrwRefresh(1,<SID>NetrwBrowseChgDir(1,'./',0))<cr>
    if !hasmapto('<Plug>NetrwHideEdit')
     nmap <buffer> <unique> <c-h> <Plug>NetrwHideEdit
    endif
@@ -6503,7 +6104,7 @@ fun! s:NetrwMaps(islocal)
    if !hasmapto('<Plug>NetrwRefresh')
     nmap <buffer> <unique> <c-l> <Plug>NetrwRefresh
    endif
-   nnoremap <buffer> <silent> <Plug>NetrwRefresh		<c-l>:call <SID>NetrwRefresh(1,<SID>NetrwBrowseChgDir(1,(exists("w:netrw_liststyle") && exists("w:netrw_treetop") && w:netrw_liststyle == 3)? w:netrw_treetop : './'))<cr>
+   nnoremap <buffer> <silent> <Plug>NetrwRefresh		<c-l>:call <SID>NetrwRefresh(1,<SID>NetrwBrowseChgDir(1,(exists("w:netrw_liststyle") && exists("w:netrw_treetop") && w:netrw_liststyle == 3)? w:netrw_treetop : './',0))<cr>
    if s:didstarstar || !mapcheck("<s-down>","n")
     nnoremap <buffer> <silent> <s-down>	:Nexplore<cr>
    endif
@@ -6547,7 +6148,6 @@ fun! s:NetrwMaps(islocal)
 
   else
    " remote normal-mode maps {{{3
-"   call Decho("make remote maps",'~'.expand("<slnum>"))
    call s:RemotePathAnalysis(b:netrw_curdir)
    nnoremap <buffer> <silent> <Plug>NetrwHide_a			:<c-u>call <SID>NetrwHide(0)<cr>
    nnoremap <buffer> <silent> <Plug>NetrwBrowseUpDir		:<c-u>call <SID>NetrwBrowseUpDir(0)<cr>
@@ -6556,8 +6156,8 @@ fun! s:NetrwMaps(islocal)
    nnoremap <buffer> <silent> <Plug>NetrwBadd_cB		:<c-u>call <SID>NetrwBadd(0,1)<cr>
    nnoremap <buffer> <silent> <Plug>NetrwLcd			:<c-u>call <SID>NetrwLcd(b:netrw_curdir)<cr>
    nnoremap <buffer> <silent> <Plug>NetrwSetChgwin		:<c-u>call <SID>NetrwSetChgwin()<cr>
-   nnoremap <buffer> <silent> <Plug>NetrwRefresh		:<c-u>call <SID>NetrwRefresh(0,<SID>NetrwBrowseChgDir(0,'./'))<cr>
-   nnoremap <buffer> <silent> <Plug>NetrwLocalBrowseCheck	:<c-u>call <SID>NetrwBrowse(0,<SID>NetrwBrowseChgDir(0,<SID>NetrwGetWord()))<cr>
+   nnoremap <buffer> <silent> <Plug>NetrwRefresh		:<c-u>call <SID>NetrwRefresh(0,<SID>NetrwBrowseChgDir(0,'./',0))<cr>
+   nnoremap <buffer> <silent> <Plug>NetrwLocalBrowseCheck	:<c-u>call <SID>NetrwBrowse(0,<SID>NetrwBrowseChgDir(0,<SID>NetrwGetWord(),1))<cr>
    nnoremap <buffer> <silent> <Plug>NetrwServerEdit		:<c-u>call <SID>NetrwServerEdit(2,<SID>NetrwGetWord())<cr>
    nnoremap <buffer> <silent> <Plug>NetrwBookHistHandler_gb	:<c-u>call <SID>NetrwBookHistHandler(1,b:netrw_curdir)<cr>
 " ---------------------------------------------------------------------
@@ -6579,6 +6179,7 @@ fun! s:NetrwMaps(islocal)
    nnoremap <buffer> <silent> <nowait> mg	:<c-u>call <SID>NetrwMarkFileGrep(0)<cr>
    nnoremap <buffer> <silent> <nowait> mh	:<c-u>call <SID>NetrwMarkHideSfx(0)<cr>
    nnoremap <buffer> <silent> <nowait> mm	:<c-u>call <SID>NetrwMarkFileMove(0)<cr>
+   "nnoremap <buffer> <silent> <nowait> mp	:<c-u>call <SID>NetrwMarkFilePrint(0)<cr>
    nnoremap <buffer> <silent> <nowait> mr	:<c-u>call <SID>NetrwMarkFileRegexp(0)<cr>
    nnoremap <buffer> <silent> <nowait> ms	:<c-u>call <SID>NetrwMarkFileSource(0)<cr>
    nnoremap <buffer> <silent> <nowait> mT	:<c-u>call <SID>NetrwMarkFileTag(0)<cr>
@@ -6590,13 +6191,13 @@ fun! s:NetrwMaps(islocal)
    nnoremap <buffer> <silent> <nowait> mz	:<c-u>call <SID>NetrwMarkFileCompress(0)<cr>
    nnoremap <buffer> <silent> <nowait> O	:<c-u>call <SID>NetrwObtain(0)<cr>
    nnoremap <buffer> <silent> <nowait> o	:call <SID>NetrwSplit(0)<cr>
-   nnoremap <buffer> <silent> <nowait> p	:<c-u>call <SID>NetrwPreview(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),1))<cr>
+   nnoremap <buffer> <silent> <nowait> p	:<c-u>call <SID>NetrwPreview(<SID>NetrwBrowseChgDir(1,<SID>NetrwGetWord(),1,1))<cr>
    nnoremap <buffer> <silent> <nowait> P	:<c-u>call <SID>NetrwPrevWinOpen(0)<cr>
    nnoremap <buffer> <silent> <nowait> qb	:<c-u>call <SID>NetrwBookHistHandler(2,b:netrw_curdir)<cr>
    nnoremap <buffer> <silent> <nowait> qf	:<c-u>call <SID>NetrwFileInfo(0,<SID>NetrwGetWord())<cr>
    nnoremap <buffer> <silent> <nowait> qF	:<c-u>call <SID>NetrwMarkFileQFEL(0,getqflist())<cr>
    nnoremap <buffer> <silent> <nowait> qL	:<c-u>call <SID>NetrwMarkFileQFEL(0,getloclist(v:count))<cr>
-   nnoremap <buffer> <silent> <nowait> r	:<c-u>let g:netrw_sort_direction= (g:netrw_sort_direction =~# 'n')? 'r' : 'n'<bar>exe "norm! 0"<bar>call <SID>NetrwBrowse(0,<SID>NetrwBrowseChgDir(0,'./'))<cr>
+   nnoremap <buffer> <silent> <nowait> r	:<c-u>let g:netrw_sort_direction= (g:netrw_sort_direction =~# 'n')? 'r' : 'n'<bar>exe "norm! 0"<bar>call <SID>NetrwBrowse(0,<SID>NetrwBrowseChgDir(0,'./',0))<cr>
    nnoremap <buffer> <silent> <nowait> s	:call <SID>NetrwSortStyle(0)<cr>
    nnoremap <buffer> <silent> <nowait> S	:<c-u>call <SID>NetSortSequence(0)<cr>
    nnoremap <buffer> <silent> <nowait> Tb	:<c-u>call <SID>NetrwSetTgt(0,'b',v:count1)<cr>
@@ -6605,7 +6206,7 @@ fun! s:NetrwMaps(islocal)
    nnoremap <buffer> <silent> <nowait> u	:<c-u>call <SID>NetrwBookHistHandler(4,b:netrw_curdir)<cr>
    nnoremap <buffer> <silent> <nowait> U	:<c-u>call <SID>NetrwBookHistHandler(5,b:netrw_curdir)<cr>
    nnoremap <buffer> <silent> <nowait> v	:call <SID>NetrwSplit(2)<cr>
-   nnoremap <buffer> <silent> <nowait> x	:<c-u>call netrw#BrowseX(<SID>NetrwBrowseChgDir(0,<SID>NetrwGetWord()),1)<cr>
+   nnoremap <buffer> <silent> <nowait> x	:<c-u>call netrw#BrowseX(<SID>NetrwBrowseChgDir(0,<SID>NetrwGetWord(),1),1)<cr>
    nmap     <buffer>          <nowait> gx	x
    if !hasmapto('<Plug>NetrwHideEdit')
     nmap <buffer> <c-h> <Plug>NetrwHideEdit
@@ -6622,7 +6223,7 @@ fun! s:NetrwMaps(islocal)
    let mapsafepath     = escape(s:path, s:netrw_map_escape)
    let mapsafeusermach = escape(((s:user == "")? "" : s:user."@").s:machine, s:netrw_map_escape)
 
-   nnoremap <buffer> <silent> <Plug>NetrwRefresh	:call <SID>NetrwRefresh(0,<SID>NetrwBrowseChgDir(0,'./'))<cr>
+   nnoremap <buffer> <silent> <Plug>NetrwRefresh	:call <SID>NetrwRefresh(0,<SID>NetrwBrowseChgDir(0,'./',0))<cr>
    if g:netrw_mousemaps == 1
     nmap <buffer> <leftmouse>		<Plug>NetrwLeftmouse
     nno  <buffer> <silent>		<Plug>NetrwLeftmouse	:exec "norm! \<lt>leftmouse>"<bar>call <SID>NetrwLeftmouse(0)<cr>
@@ -6654,8 +6255,6 @@ fun! s:NetrwMaps(islocal)
    " support user-specified maps
    call netrw#UserMaps(0)
   endif " }}}3
-
-"  call Dret("s:NetrwMaps")
 endfun
 
 " ---------------------------------------------------------------------
@@ -6709,7 +6308,6 @@ endfun
 " ---------------------------------------------------------------------
 " s:NetrwMarkTarget: implements :MT (mark target) {{{2
 fun! s:NetrwMarkTarget(...)
-"  call Dfunc("s:NetrwMarkTarget() a:0=".a:0)
   if a:0 == 0 || (a:0 == 1 && a:1 == "")
    let curdir = s:NetrwGetCurdir(1)
    let tgt    = b:netrw_curdir
@@ -6717,16 +6315,12 @@ fun! s:NetrwMarkTarget(...)
    let curdir = s:NetrwGetCurdir((a:1 =~ '^\a\{3,}://')? 0 : 1)
    let tgt    = a:1
   endif
-"  call Decho("tgt<".tgt.">",'~'.expand("<slnum>"))
   let s:netrwmftgt         = tgt
   let s:netrwmftgt_islocal = tgt !~ '^\a\{3,}://'
   let curislocal           = b:netrw_curdir !~ '^\a\{3,}://'
   let svpos                = winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
-  call s:NetrwRefresh(curislocal,s:NetrwBrowseChgDir(curislocal,'./'))
-"  call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+  call s:NetrwRefresh(curislocal,s:NetrwBrowseChgDir(curislocal,'./',0))
   call winrestview(svpos)
-"  call Dret("s:NetrwMarkTarget")
 endfun
 
 " ---------------------------------------------------------------------
@@ -6869,10 +6463,7 @@ endfun
 "                         mA: move the argument list to marked file list     (tomflist=1)
 "                            Uses the global marked file list
 fun! s:NetrwMarkFileArgList(islocal,tomflist)
-"  call Dfunc("s:NetrwMarkFileArgList(islocal=".a:islocal.",tomflist=".a:tomflist.")")
-
   let svpos    = winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
   let curdir   = s:NetrwGetCurdir(a:islocal)
   let curbufnr = bufnr("%")
 
@@ -6880,7 +6471,6 @@ fun! s:NetrwMarkFileArgList(islocal,tomflist)
    " mA: move argument list to marked file list
    while argc()
     let fname= argv(0)
-"    call Decho("exe argdel ".fname,'~'.expand("<slnum>"))
     exe "argdel ".fnameescape(fname)
     call s:NetrwMarkFile(a:islocal,fname)
    endwhile
@@ -6891,19 +6481,16 @@ fun! s:NetrwMarkFileArgList(islocal,tomflist)
 
     " for every filename in the marked list
     for fname in s:netrwmarkfilelist
-"     call Decho("exe argadd ".fname,'~'.expand("<slnum>"))
      exe "argadd ".fnameescape(fname)
     endfor	" for every file in the marked list
 
     " unmark list and refresh
     call s:NetrwUnmarkList(curbufnr,curdir)
-    NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
-"    call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+    NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
     NetrwKeepj call winrestview(svpos)
    endif
   endif
 
-"  call Dret("s:NetrwMarkFileArgList")
 endfun
 
 " ---------------------------------------------------------------------
@@ -6915,30 +6502,24 @@ endfun
 "                            g:netrw_compress        = "gzip"
 "                            g:netrw_decompress      = { ".gz" : "gunzip" , ".bz2" : "bunzip2" , ".zip" : "unzip" , ".tar" : "tar -xf", ".xz" : "unxz"}
 fun! s:NetrwMarkFileCompress(islocal)
-"  call Dfunc("s:NetrwMarkFileCompress(islocal=".a:islocal.")")
   let svpos    = winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
   let curdir   = s:NetrwGetCurdir(a:islocal)
   let curbufnr = bufnr("%")
 
   " sanity check
   if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
    NetrwKeepj call netrw#ErrorMsg(2,"there are no marked files in this window (:help netrw-mf)",66)
-"   call Dret("s:NetrwMarkFileCompress")
    return
   endif
-"  call Decho("sanity chk passed: s:netrwmarkfilelist_".curbufnr."<".string(s:netrwmarkfilelist_{curbufnr}),'~'.expand("<slnum>"))
 
   if exists("s:netrwmarkfilelist_{curbufnr}") && exists("g:netrw_compress") && exists("g:netrw_decompress")
 
    " for every filename in the marked list
    for fname in s:netrwmarkfilelist_{curbufnr}
     let sfx= substitute(fname,'^.\{-}\(\.\a\+\)$','\1','')
-"    call Decho("extracted sfx<".sfx.">",'~'.expand("<slnum>"))
     if exists("g:netrw_decompress['".sfx."']")
      " fname has a suffix indicating that its compressed; apply associated decompression routine
      let exe= g:netrw_decompress[sfx]
-"     call Decho("fname<".fname."> is compressed so decompress with <".exe.">",'~'.expand("<slnum>"))
      let exe= netrw#WinPath(exe)
      if a:islocal
       if g:netrw_keepdir
@@ -6971,11 +6552,9 @@ fun! s:NetrwMarkFileCompress(islocal)
    endfor	" for every file in the marked list
 
    call s:NetrwUnmarkList(curbufnr,curdir)
-   NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
-"   call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+   NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
    NetrwKeepj call winrestview(svpos)
   endif
-"  call Dret("s:NetrwMarkFileCompress")
 endfun
 
 " ---------------------------------------------------------------------
@@ -7315,9 +6894,7 @@ endfun
 "                     mx enbloc=0: Uses the local marked-file list, applies command to each file individually
 "                     mX enbloc=1: Uses the global marked-file list, applies command to entire list
 fun! s:NetrwMarkFileExe(islocal,enbloc)
-"  call Dfunc("s:NetrwMarkFileExe(islocal=".a:islocal.",enbloc=".a:enbloc.")")
   let svpos    = winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
   let curdir   = s:NetrwGetCurdir(a:islocal)
   let curbufnr = bufnr("%")
 
@@ -7326,19 +6903,15 @@ fun! s:NetrwMarkFileExe(islocal,enbloc)
     " sanity check
     if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
      NetrwKeepj call netrw#ErrorMsg(2,"there are no marked files in this window (:help netrw-mf)",66)
-"     call Dret("s:NetrwMarkFileExe")
      return
     endif
-"    call Decho("sanity chk passed: s:netrwmarkfilelist_".curbufnr."<".string(s:netrwmarkfilelist_{curbufnr}),'~'.expand("<slnum>"))
 
     if exists("s:netrwmarkfilelist_{curbufnr}")
      " get the command
      call inputsave()
      let cmd= input("Enter command: ","","file")
      call inputrestore()
-"     call Decho("cmd<".cmd.">",'~'.expand("<slnum>"))
      if cmd == ""
-"      call Dret("s:NetrwMarkFileExe : early exit, empty command")
       return
      endif
 
@@ -7358,10 +6931,8 @@ fun! s:NetrwMarkFileExe(islocal,enbloc)
        let xcmd= cmd.' '.fname
       endif
       if a:islocal
-"       call Decho("local: xcmd<".xcmd.">",'~'.expand("<slnum>"))
        let ret= system(xcmd)
       else
-"       call Decho("remote: xcmd<".xcmd.">",'~'.expand("<slnum>"))
        let ret= s:RemoteSystem(xcmd)
       endif
       if v:shell_error < 0
@@ -7382,8 +6953,7 @@ fun! s:NetrwMarkFileExe(islocal,enbloc)
    call s:NetrwUnmarkList(curbufnr,curdir)
 
    " refresh the listing
-   NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
-"   call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+   NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
    NetrwKeepj call winrestview(svpos)
   else
    NetrwKeepj call netrw#ErrorMsg(s:ERROR,"no files marked!",59)
@@ -7394,9 +6964,7 @@ fun! s:NetrwMarkFileExe(islocal,enbloc)
   call inputsave()
   let cmd= input("Enter command: ","","file")
   call inputrestore()
-"  call Decho("cmd<".cmd.">",'~'.expand("<slnum>"))
   if cmd == ""
-"   call Dret("s:NetrwMarkFileExe : early exit, empty command")
    return
   endif
   if cmd =~ '%'
@@ -7415,13 +6983,10 @@ fun! s:NetrwMarkFileExe(islocal,enbloc)
   call s:NetrwUnmarkAll()
 
   " refresh the listing
-  NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
-"  call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+  NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
   NetrwKeepj call winrestview(svpos)
 
  endif
-
-"  call Dret("s:NetrwMarkFileExe")
 endfun
 
 " ---------------------------------------------------------------------
@@ -7429,16 +6994,13 @@ endfun
 "                  as the marked file(s) (toggles suffix presence)
 "                  Uses the local marked file list.
 fun! s:NetrwMarkHideSfx(islocal)
-"  call Dfunc("s:NetrwMarkHideSfx(islocal=".a:islocal.")")
   let svpos    = winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
   let curbufnr = bufnr("%")
 
   " s:netrwmarkfilelist_{curbufnr}: the List of marked files
   if exists("s:netrwmarkfilelist_{curbufnr}")
 
    for fname in s:netrwmarkfilelist_{curbufnr}
-"     call Decho("s:NetrwMarkFileCopy: fname<".fname.">",'~'.expand("<slnum>"))
      " construct suffix pattern
      if fname =~ '\.'
       let sfxpat= "^.*".substitute(fname,'^.*\(\.[^. ]\+\)$','\1','')
@@ -7458,7 +7020,6 @@ fun! s:NetrwMarkHideSfx(islocal)
        let itemnum= itemnum + 1
       endfor
      endif
-"     call Decho("fname<".fname."> inhidelist=".inhidelist." sfxpat<".sfxpat.">",'~'.expand("<slnum>"))
      if inhidelist
       " remove sfxpat from list
       call remove(hidelist,itemnum)
@@ -7473,57 +7034,45 @@ fun! s:NetrwMarkHideSfx(islocal)
     endfor
 
    " refresh the listing
-   NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
-"   call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+   NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
    NetrwKeepj call winrestview(svpos)
   else
    NetrwKeepj call netrw#ErrorMsg(s:ERROR,"no files marked!",59)
   endif
-
-"  call Dret("s:NetrwMarkHideSfx")
 endfun
 
 " ---------------------------------------------------------------------
 " s:NetrwMarkFileVimCmd: (invoked by mv) execute arbitrary vim command on marked files, one at a time {{{2
 "                     Uses the local marked-file list.
 fun! s:NetrwMarkFileVimCmd(islocal)
-"  call Dfunc("s:NetrwMarkFileVimCmd(islocal=".a:islocal.")")
   let svpos    = winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
   let curdir   = s:NetrwGetCurdir(a:islocal)
   let curbufnr = bufnr("%")
 
   " sanity check
   if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
    NetrwKeepj call netrw#ErrorMsg(2,"there are no marked files in this window (:help netrw-mf)",66)
-"   call Dret("s:NetrwMarkFileVimCmd")
    return
   endif
-"  call Decho("sanity chk passed: s:netrwmarkfilelist_".curbufnr."<".string(s:netrwmarkfilelist_{curbufnr}),'~'.expand("<slnum>"))
 
   if exists("s:netrwmarkfilelist_{curbufnr}")
    " get the command
    call inputsave()
    let cmd= input("Enter vim command: ","","file")
    call inputrestore()
-"   call Decho("cmd<".cmd.">",'~'.expand("<slnum>"))
    if cmd == ""
-"    "   call Dret("s:NetrwMarkFileVimCmd : early exit, empty command")
     return
    endif
 
    " apply command to marked files.  Substitute: filename -> %
    " If no %, then append a space and the filename to the command
    for fname in s:netrwmarkfilelist_{curbufnr}
-"    call Decho("fname<".fname.">",'~'.expand("<slnum>"))
     if a:islocal
      1split
      exe "sil! NetrwKeepj keepalt e ".fnameescape(fname)
-"     call Decho("local<".fname.">: exe ".cmd,'~'.expand("<slnum>"))
      exe cmd
      exe "sil! keepalt wq!"
     else
-"     call Decho("remote<".fname.">: exe ".cmd." : NOT SUPPORTED YET",'~'.expand("<slnum>"))
      echo "sorry, \"mv\" not supported yet for remote files"
     endif
    endfor
@@ -7532,14 +7081,11 @@ fun! s:NetrwMarkFileVimCmd(islocal)
    call s:NetrwUnmarkList(curbufnr,curdir)
 
    " refresh the listing
-   NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
-"   call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+   NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
    NetrwKeepj call winrestview(svpos)
   else
    NetrwKeepj call netrw#ErrorMsg(s:ERROR,"no files marked!",59)
   endif
-
-"  call Dret("s:NetrwMarkFileVimCmd")
 endfun
 
 " ---------------------------------------------------------------------
@@ -7547,16 +7093,13 @@ endfun
 "                  as the marked file(s) (toggles suffix presence)
 "                  Uses the local marked file list.
 fun! s:NetrwMarkHideSfx(islocal)
-"  call Dfunc("s:NetrwMarkHideSfx(islocal=".a:islocal.")")
   let svpos    = winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
   let curbufnr = bufnr("%")
 
   " s:netrwmarkfilelist_{curbufnr}: the List of marked files
   if exists("s:netrwmarkfilelist_{curbufnr}")
 
    for fname in s:netrwmarkfilelist_{curbufnr}
-"     call Decho("s:NetrwMarkFileCopy: fname<".fname.">",'~'.expand("<slnum>"))
      " construct suffix pattern
      if fname =~ '\.'
       let sfxpat= "^.*".substitute(fname,'^.*\(\.[^. ]\+\)$','\1','')
@@ -7576,7 +7119,6 @@ fun! s:NetrwMarkHideSfx(islocal)
        let itemnum= itemnum + 1
       endfor
      endif
-"     call Decho("fname<".fname."> inhidelist=".inhidelist." sfxpat<".sfxpat.">",'~'.expand("<slnum>"))
      if inhidelist
       " remove sfxpat from list
       call remove(hidelist,itemnum)
@@ -7591,14 +7133,11 @@ fun! s:NetrwMarkHideSfx(islocal)
     endfor
 
    " refresh the listing
-   NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
-"   call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+   NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
    NetrwKeepj call winrestview(svpos)
   else
    NetrwKeepj call netrw#ErrorMsg(s:ERROR,"no files marked!",59)
   endif
-
-"  call Dret("s:NetrwMarkHideSfx")
 endfun
 
 " ---------------------------------------------------------------------
@@ -7802,6 +7341,46 @@ fun! s:NetrwMarkFileMove(islocal)
 endfun
 
 " ---------------------------------------------------------------------
+" s:NetrwMarkFilePrint: (invoked by mp) This function prints marked files {{{2
+"                       using the hardcopy command.  Local marked-file list only.
+fun! s:NetrwMarkFilePrint(islocal)
+"  call Dfunc("s:NetrwMarkFilePrint(islocal=".a:islocal.")")
+  let curbufnr= bufnr("%")
+
+  " sanity check
+  if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
+   NetrwKeepj call netrw#ErrorMsg(2,"there are no marked files in this window (:help netrw-mf)",66)
+"   call Dret("s:NetrwMarkFilePrint")
+   return
+  endif
+"  call Decho("sanity chk passed: s:netrwmarkfilelist_".curbufnr."<".string(s:netrwmarkfilelist_{curbufnr}),'~'.expand("<slnum>"))
+  let curdir= s:NetrwGetCurdir(a:islocal)
+
+  if exists("s:netrwmarkfilelist_{curbufnr}")
+   let netrwmarkfilelist = s:netrwmarkfilelist_{curbufnr}
+   call s:NetrwUnmarkList(curbufnr,curdir)
+   for fname in netrwmarkfilelist
+    if a:islocal
+     if g:netrw_keepdir
+      let fname= s:ComposePath(curdir,fname)
+     endif
+    else
+     let fname= curdir.fname
+    endif
+    1split
+    " the autocmds will handle both local and remote files
+"    call Decho("exe sil e ".escape(fname,' '),'~'.expand("<slnum>"))
+    exe "sil NetrwKeepj e ".fnameescape(fname)
+"    call Decho("hardcopy",'~'.expand("<slnum>"))
+    hardcopy
+    q
+   endfor
+   2match none
+  endif
+"  call Dret("s:NetrwMarkFilePrint")
+endfun
+
+" ---------------------------------------------------------------------
 " s:NetrwMarkFileRegexp: (invoked by mr) This function is used to mark {{{2
 "                        files when given a regexp (for which a prompt is
 "                        issued) (matches to name of files).
@@ -7926,28 +7505,22 @@ endfun
 " s:NetrwMarkFileTag: (invoked by mT) This function applies g:netrw_ctags to marked files {{{2
 "                     Uses the global markfilelist
 fun! s:NetrwMarkFileTag(islocal)
-"  call Dfunc("s:NetrwMarkFileTag(islocal=".a:islocal.")")
   let svpos    = winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
   let curdir   = s:NetrwGetCurdir(a:islocal)
   let curbufnr = bufnr("%")
 
   " sanity check
   if !exists("s:netrwmarkfilelist_{curbufnr}") || empty(s:netrwmarkfilelist_{curbufnr})
    NetrwKeepj call netrw#ErrorMsg(2,"there are no marked files in this window (:help netrw-mf)",66)
-"   call Dret("s:NetrwMarkFileTag")
    return
   endif
-"  call Decho("sanity chk passed: s:netrwmarkfilelist_".curbufnr."<".string(s:netrwmarkfilelist_{curbufnr}),'~'.expand("<slnum>"))
 
   if exists("s:netrwmarkfilelist")
-"   call Decho("s:netrwmarkfilelist".string(s:netrwmarkfilelist).">",'~'.expand("<slnum>"))
    let netrwmarkfilelist= join(map(deepcopy(s:netrwmarkfilelist), "s:ShellEscape(v:val,".!a:islocal.")"))
    call s:NetrwUnmarkAll()
 
    if a:islocal
 
-"    call Decho("call system(".g:netrw_ctags." ".netrwmarkfilelist.")",'~'.expand("<slnum>"))
     call system(g:netrw_ctags." ".netrwmarkfilelist)
     if v:shell_error
      call netrw#ErrorMsg(s:ERROR,"g:netrw_ctags<".g:netrw_ctags."> is not executable!",51)
@@ -7960,18 +7533,14 @@ fun! s:NetrwMarkFileTag(islocal)
     1split
     NetrwKeepj e tags
     let path= substitute(curdir,'^\(.*\)/[^/]*$','\1/','')
-"    call Decho("curdir<".curdir."> path<".path.">",'~'.expand("<slnum>"))
     exe 'NetrwKeepj %s/\t\(\S\+\)\t/\t'.escape(path,"/\n\r\\").'\1\t/e'
     call histdel("/",-1)
     wq!
    endif
    2match none
-   call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
-"   call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+   call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
    call winrestview(svpos)
   endif
-
-"  call Dret("s:NetrwMarkFileTag")
 endfun
 
 " ---------------------------------------------------------------------
@@ -7981,9 +7550,7 @@ endfun
 "     s:netrwmftgt_islocal : 0=target directory is remote
 "                            1=target directory is local
 fun! s:NetrwMarkFileTgt(islocal)
-" call Dfunc("s:NetrwMarkFileTgt(islocal=".a:islocal.")")
   let svpos  = winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
   let curdir = s:NetrwGetCurdir(a:islocal)
   let hadtgt = exists("s:netrwmftgt")
   if !exists("w:netrw_bannercnt")
@@ -7992,46 +7559,36 @@ fun! s:NetrwMarkFileTgt(islocal)
 
   " set up target
   if line(".") < w:netrw_bannercnt
-"   call Decho("set up target: line(.) < w:netrw_bannercnt=".w:netrw_bannercnt,'~'.expand("<slnum>"))
    " if cursor in banner region, use b:netrw_curdir for the target unless its already the target
    if exists("s:netrwmftgt") && exists("s:netrwmftgt_islocal") && s:netrwmftgt == b:netrw_curdir
-"    call Decho("cursor in banner region, and target already is <".b:netrw_curdir.">: removing target",'~'.expand("<slnum>"))
     unlet s:netrwmftgt s:netrwmftgt_islocal
     if g:netrw_fastbrowse <= 1
      call s:LocalBrowseRefresh()
     endif
-    call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
-"    call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+    call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
     call winrestview(svpos)
-"    call Dret("s:NetrwMarkFileTgt : removed target")
     return
    else
     let s:netrwmftgt= b:netrw_curdir
-"    call Decho("inbanner: s:netrwmftgt<".s:netrwmftgt.">",'~'.expand("<slnum>"))
    endif
 
   else
    " get word under cursor.
    "  * If directory, use it for the target.
    "  * If file, use b:netrw_curdir for the target
-"   call Decho("get word under cursor",'~'.expand("<slnum>"))
    let curword= s:NetrwGetWord()
    let tgtdir = s:ComposePath(curdir,curword)
    if a:islocal && isdirectory(s:NetrwFile(tgtdir))
     let s:netrwmftgt = tgtdir
-"    call Decho("local isdir: s:netrwmftgt<".s:netrwmftgt.">",'~'.expand("<slnum>"))
    elseif !a:islocal && tgtdir =~ '/$'
     let s:netrwmftgt = tgtdir
-"    call Decho("remote isdir: s:netrwmftgt<".s:netrwmftgt.">",'~'.expand("<slnum>"))
    else
     let s:netrwmftgt = curdir
-"    call Decho("isfile: s:netrwmftgt<".s:netrwmftgt.">",'~'.expand("<slnum>"))
    endif
   endif
   if a:islocal
    " simplify the target (eg. /abc/def/../ghi -> /abc/ghi)
    let s:netrwmftgt= simplify(s:netrwmftgt)
-"   call Decho("simplify: s:netrwmftgt<".s:netrwmftgt.">",'~'.expand("<slnum>"))
   endif
   if g:netrw_cygwin
    let s:netrwmftgt= substitute(system("cygpath ".s:ShellEscape(s:netrwmftgt)),'\n$','','')
@@ -8042,24 +7599,18 @@ fun! s:NetrwMarkFileTgt(islocal)
   " need to do refresh so that the banner will be updated
   "  s:LocalBrowseRefresh handles all local-browsing buffers when not fast browsing
   if g:netrw_fastbrowse <= 1
-"   call Decho("g:netrw_fastbrowse=".g:netrw_fastbrowse.", so refreshing all local netrw buffers",'~'.expand("<slnum>"))
    call s:LocalBrowseRefresh()
   endif
-"  call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
+"  call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
   if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
-   call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,w:netrw_treetop))
+   call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,w:netrw_treetop,0))
   else
-   call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
+   call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
   endif
-"  call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
   call winrestview(svpos)
   if !hadtgt
    sil! NetrwKeepj norm! j
   endif
-
-"  call Decho("getmatches=".string(getmatches()),'~'.expand("<slnum>"))
-"  call Decho("s:netrwmarkfilelist=".(exists("s:netrwmarkfilelist")? string(s:netrwmarkfilelist) : 'n/a'),'~'.expand("<slnum>"))
-"  call Dret("s:NetrwMarkFileTgt : netrwmftgt<".(exists("s:netrwmftgt")? s:netrwmftgt : "").">")
 endfun
 
 " ---------------------------------------------------------------------
@@ -8193,23 +7744,17 @@ endfun
 " ---------------------------------------------------------------------
 " s:NetSortSequence: allows user to edit the sorting sequence {{{2
 fun! s:NetSortSequence(islocal)
-"  call Dfunc("NetSortSequence(islocal=".a:islocal.")")
-
   let ykeep= @@
   let svpos= winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
   call inputsave()
   let newsortseq= input("Edit Sorting Sequence: ",g:netrw_sort_sequence)
   call inputrestore()
 
   " refresh the listing
   let g:netrw_sort_sequence= newsortseq
-  NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
-"  call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+  NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
   NetrwKeepj call winrestview(svpos)
   let @@= ykeep
-
-"  call Dret("NetSortSequence")
 endfun
 
 " ---------------------------------------------------------------------
@@ -8280,9 +7825,7 @@ endfun
 " Marked files suitable for use with 2match are in:
 "    s:netrwmarkfilemtch_#   -- used with 2match to display marked files
 fun! s:NetrwUnMarkFile(islocal)
-"  call Dfunc("s:NetrwUnMarkFile(islocal=".a:islocal.")")
   let svpos    = winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
   let curbufnr = bufnr("%")
 
   " unmark marked file list
@@ -8302,10 +7845,8 @@ fun! s:NetrwUnMarkFile(islocal)
   endwhile
   2match none
 
-"  call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
-"call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+"  call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
 call winrestview(svpos)
-"  call Dret("s:NetrwUnMarkFile")
 endfun
 
 " ---------------------------------------------------------------------
@@ -8440,69 +7981,47 @@ endfun
 "     choice = 2 : didn't save modified file, opened window
 "     choice = 3 : cancel open
 fun! s:NetrwPrevWinOpen(islocal)
-"  call Dfunc("s:NetrwPrevWinOpen(islocal=".a:islocal.") win#".winnr())
-
   let ykeep= @@
   " grab a copy of the b:netrw_curdir to pass it along to newly split windows
   let curdir = b:netrw_curdir
-"  call Decho("COMBAK#1: mod=".&mod." win#".winnr())
 
   " get last window number and the word currently under the cursor
   let origwin   = winnr()
   let lastwinnr = winnr("$")
-"  call Decho("origwin#".origwin." lastwinnr#".lastwinnr)
-"  call Decho("COMBAK#2: mod=".&mod." win#".winnr())
   let curword      = s:NetrwGetWord()
   let choice       = 0
   let s:prevwinopen= 1	" lets s:NetrwTreeDir() know that NetrwPrevWinOpen called it (s:NetrwTreeDir() will unlet s:prevwinopen)
-"  call Decho("COMBAK#3: mod=".&mod." win#".winnr())
   let s:treedir = s:NetrwTreeDir(a:islocal)
-"  call Decho("COMBAK#4: mod=".&mod." win#".winnr())
   let curdir    = s:treedir
-"  call Decho("COMBAK#5: mod=".&mod." win#".winnr())
-"  call Decho("winnr($)#".lastwinnr." curword<".curword.">",'~'.expand("<slnum>"))
-"  call Decho("COMBAK#6: mod=".&mod." win#".winnr())
 
   let didsplit = 0
   if lastwinnr == 1
    " if only one window, open a new one first
-"   call Decho("only one window, so open a new one (g:netrw_alto=".g:netrw_alto.")",'~'.expand("<slnum>"))
    " g:netrw_preview=0: preview window shown in a horizontally split window
    " g:netrw_preview=1: preview window shown in a vertically   split window
    if g:netrw_preview
     " vertically split preview window
     let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winwidth(0))/100 : -g:netrw_winsize
-"    call Decho("exe ".(g:netrw_alto? "top " : "bot ")."vert ".winsz."wincmd s",'~'.expand("<slnum>"))
     exe (g:netrw_alto? "top " : "bot ")."vert ".winsz."wincmd s"
    else
     " horizontally split preview window
     let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winheight(0))/100 : -g:netrw_winsize
-"    call Decho("exe ".(g:netrw_alto? "bel " : "abo ").winsz."wincmd s",'~'.expand("<slnum>"))
     exe (g:netrw_alto? "bel " : "abo ").winsz."wincmd s"
    endif
    let didsplit = 1
-"   call Decho("did split",'~'.expand("<slnum>"))
 
   else
-"   call Decho("COMBAK#7: mod=".&mod." win#".winnr())
    NetrwKeepj call s:SaveBufVars()
-"   call Decho("COMBAK#8: mod=".&mod." win#".winnr())
    let eikeep= &ei
-"   call Decho("COMBAK#9: mod=".&mod." win#".winnr())
    setl ei=all
-"   call Decho("COMBAK#10: mod=".&mod." win#".winnr())
    wincmd p
-"  call Decho("COMBAK#11: mod=".&mod)
-"   call Decho("wincmd p  (now in win#".winnr().") curdir<".curdir.">",'~'.expand("<slnum>"))
-"  call Decho("COMBAK#12: mod=".&mod)
 
    if exists("s:lexplore_win") && s:lexplore_win == winnr()
     " whoops -- user trying to open file in the Lexplore window.
     " Use Lexplore's opening-file window instead.
-"    call Decho("whoops -- user trying to open file in Lexplore Window. Use win#".g:netrw_chgwin." instead")
 "    exe g:netrw_chgwin."wincmd w"
      wincmd p
-     call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,s:NetrwGetWord()))
+     call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,s:NetrwGetWord(),1))
    endif
 
    " prevwinnr: the window number of the "prev" window
@@ -8513,28 +8032,20 @@ fun! s:NetrwPrevWinOpen(islocal)
    let prevbufname = bufname("%")
    let prevmod     = &mod
    let bnrcnt      = 0
-"   call Decho("COMBAK#13: mod=".&mod." win#".winnr())
    NetrwKeepj call s:RestoreBufVars()
-"   call Decho("after wincmd p: win#".winnr()." win($)#".winnr("$")." origwin#".origwin." &mod=".&mod." bufname(%)<".bufname("%")."> prevbufnr=".prevbufnr,'~'.expand("<slnum>"))
-"   call Decho("COMBAK#14: mod=".&mod." win#".winnr())
 
    " if the previous window's buffer has been changed (ie. its modified flag is set),
    " and it doesn't appear in any other extant window, then ask the
    " user if s/he wants to abandon modifications therein.
    if prevmod
-"    call Decho("detected that prev window's buffer has been modified: prevbufnr=".prevbufnr." winnr()#".winnr(),'~'.expand("<slnum>"))
     windo if winbufnr(0) == prevbufnr | let bnrcnt=bnrcnt+1 | endif
-"    call Decho("prevbufnr=".prevbufnr." bnrcnt=".bnrcnt." buftype=".&bt." winnr()=".winnr()." prevwinnr#".prevwinnr,'~'.expand("<slnum>"))
     exe prevwinnr."wincmd w"
-"    call Decho("COMBAK#15: mod=".&mod." win#".winnr())
 
     if bnrcnt == 1 && &hidden == 0
      " only one copy of the modified buffer in a window, and
      " hidden not set, so overwriting will lose the modified file.  Ask first...
      let choice = confirm("Save modified buffer<".prevbufname."> first?","&Yes\n&No\n&Cancel")
-"     call Decho("prevbufname<".prevbufname."> choice=".choice." current-winnr#".winnr(),'~'.expand("<slnum>"))
      let &ei= eikeep
-"     call Decho("COMBAK#16: mod=".&mod." win#".winnr())
 
      if choice == 1
       " Yes -- write file & then browse
@@ -8545,41 +8056,35 @@ fun! s:NetrwPrevWinOpen(islocal)
        exe origwin."wincmd w"
        let &ei = eikeep
        let @@  = ykeep
-"       call Dret("s:NetrwPrevWinOpen ".choice." : unable to write <".prevbufname.">")
        return choice
       endif
 
      elseif choice == 2
       " No -- don't worry about changed file, just browse anyway
-"      call Decho("don't worry about chgd file, just browse anyway (winnr($)#".winnr("$").")",'~'.expand("<slnum>"))
       echomsg "**note** changes to ".prevbufname." abandoned"
 
      else
       " Cancel -- don't do this
-"      call Decho("cancel, don't browse, switch to win#".origwin,'~'.expand("<slnum>"))
       exe origwin."wincmd w"
       let &ei= eikeep
       let @@ = ykeep
-"      call Dret("s:NetrwPrevWinOpen ".choice." : cancelled")
       return choice
      endif
     endif
    endif
    let &ei= eikeep
   endif
-"  call Decho("COMBAK#17: mod=".&mod." win#".winnr())
 
   " restore b:netrw_curdir (window split/enew may have lost it)
   let b:netrw_curdir= curdir
   if a:islocal < 2
    if a:islocal
-    call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(a:islocal,curword))
+    call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(a:islocal,curword,0))
    else
-    call s:NetrwBrowse(a:islocal,s:NetrwBrowseChgDir(a:islocal,curword))
+    call s:NetrwBrowse(a:islocal,s:NetrwBrowseChgDir(a:islocal,curword,0))
    endif
   endif
   let @@= ykeep
-"  call Dret("s:NetrwPrevWinOpen ".choice)
   return choice
 endfun
 
@@ -8886,32 +8391,25 @@ endfun
 "                    Called by NetrwMarkFileCopy()
 "                    Interfaces to s:NetrwRefresh() and s:LocalBrowseRefresh()
 fun! s:NetrwRefreshDir(islocal,dirname)
-"  call Dfunc("s:NetrwRefreshDir(islocal=".a:islocal." dirname<".a:dirname.">) g:netrw_fastbrowse=".g:netrw_fastbrowse)
   if g:netrw_fastbrowse == 0
    " slowest mode (keep buffers refreshed, local or remote)
-"   call Decho("slowest mode: keep buffers refreshed, local or remote",'~'.expand("<slnum>"))
    let tgtwin= bufwinnr(a:dirname)
-"   call Decho("tgtwin= bufwinnr(".a:dirname.")=".tgtwin,'~'.expand("<slnum>"))
 
    if tgtwin > 0
     " tgtwin is being displayed, so refresh it
     let curwin= winnr()
-"    call Decho("refresh tgtwin#".tgtwin." (curwin#".curwin.")",'~'.expand("<slnum>"))
     exe tgtwin."wincmd w"
-    NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
+    NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
     exe curwin."wincmd w"
 
    elseif bufnr(a:dirname) > 0
     let bn= bufnr(a:dirname)
-"    call Decho("bd bufnr(".a:dirname.")=".bn,'~'.expand("<slnum>"))
     exe "sil keepj bd ".bn
    endif
 
   elseif g:netrw_fastbrowse <= 1
-"   call Decho("medium-speed mode: refresh local buffers only",'~'.expand("<slnum>"))
    NetrwKeepj call s:LocalBrowseRefresh()
   endif
-"  call Dret("s:NetrwRefreshDir")
 endfun
 
 " ---------------------------------------------------------------------
@@ -9051,18 +8549,13 @@ endfun
 " =====================================================================
 " s:NetrwSortStyle: change sorting style (name - time - size - exten) and refresh display {{{2
 fun! s:NetrwSortStyle(islocal)
-"  call Dfunc("s:NetrwSortStyle(islocal=".a:islocal.") netrw_sort_by<".g:netrw_sort_by.">")
   NetrwKeepj call s:NetrwSaveWordPosn()
   let svpos= winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
 
   let g:netrw_sort_by= (g:netrw_sort_by =~# '^n')? 'time' : (g:netrw_sort_by =~# '^t')? 'size' : (g:netrw_sort_by =~# '^siz')? 'exten' : 'name'
   NetrwKeepj norm! 0
-  NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
-"  call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+  NetrwKeepj call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
   NetrwKeepj call winrestview(svpos)
-
-"  call Dret("s:NetrwSortStyle : netrw_sort_by<".g:netrw_sort_by.">")
 endfun
 
 " ---------------------------------------------------------------------
@@ -9074,7 +8567,6 @@ endfun
 "           =4 : local and t
 "           =5 : local and v
 fun! s:NetrwSplit(mode)
-"  call Dfunc("s:NetrwSplit(mode=".a:mode.") alto=".g:netrw_alto." altv=".g:netrw_altv)
 
   let ykeep= @@
   call s:SaveWinVars()
@@ -9083,17 +8575,15 @@ fun! s:NetrwSplit(mode)
    " remote and o
    let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winheight(0))/100 : -g:netrw_winsize
    if winsz == 0|let winsz= ""|endif
-"   call Decho("exe ".(g:netrw_alto? "bel " : "abo ").winsz."wincmd s",'~'.expand("<slnum>"))
    exe (g:netrw_alto? "bel " : "abo ").winsz."wincmd s"
    let s:didsplit= 1
    NetrwKeepj call s:RestoreWinVars()
-   NetrwKeepj call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,s:NetrwGetWord()))
+   NetrwKeepj call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,s:NetrwGetWord(),1))
    unlet s:didsplit
 
   elseif a:mode == 1
    " remote and t
-   let newdir  = s:NetrwBrowseChgDir(0,s:NetrwGetWord())
-"   call Decho("tabnew",'~'.expand("<slnum>"))
+   let newdir  = s:NetrwBrowseChgDir(0,s:NetrwGetWord(),1)
    tabnew
    let s:didsplit= 1
    NetrwKeepj call s:RestoreWinVars()
@@ -9104,22 +8594,20 @@ fun! s:NetrwSplit(mode)
    " remote and v
    let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winwidth(0))/100 : -g:netrw_winsize
    if winsz == 0|let winsz= ""|endif
-"   call Decho("exe ".(g:netrw_altv? "rightb " : "lefta ").winsz."wincmd v",'~'.expand("<slnum>"))
    exe (g:netrw_altv? "rightb " : "lefta ").winsz."wincmd v"
    let s:didsplit= 1
    NetrwKeepj call s:RestoreWinVars()
-   NetrwKeepj call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,s:NetrwGetWord()))
+   NetrwKeepj call s:NetrwBrowse(0,s:NetrwBrowseChgDir(0,s:NetrwGetWord(),1))
    unlet s:didsplit
 
   elseif a:mode == 3
    " local and o
    let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winheight(0))/100 : -g:netrw_winsize
    if winsz == 0|let winsz= ""|endif
-"   call Decho("exe ".(g:netrw_alto? "bel " : "abo ").winsz."wincmd s",'~'.expand("<slnum>"))
    exe (g:netrw_alto? "bel " : "abo ").winsz."wincmd s"
    let s:didsplit= 1
    NetrwKeepj call s:RestoreWinVars()
-   NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,s:NetrwGetWord()))
+   NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,s:NetrwGetWord(),1))
    unlet s:didsplit
 
   elseif a:mode == 4
@@ -9136,12 +8624,11 @@ fun! s:NetrwSplit(mode)
    exe "NetrwKeepj norm! ".netrw_line."G0".netrw_col."\<bar>"
    let &ei          = eikeep
    let netrw_curdir = s:NetrwTreeDir(0)
-"   call Decho("tabnew",'~'.expand("<slnum>"))
    tabnew
    let b:netrw_curdir = netrw_curdir
    let s:didsplit     = 1
    NetrwKeepj call s:RestoreWinVars()
-   NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,cursorword))
+   NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,cursorword,0))
    if &ft == "netrw"
     setl ei=all
     exe "NetrwKeepj norm! ".netrw_hline."G0z\<CR>"
@@ -9154,11 +8641,10 @@ fun! s:NetrwSplit(mode)
    " local and v
    let winsz= (g:netrw_winsize > 0)? (g:netrw_winsize*winwidth(0))/100 : -g:netrw_winsize
    if winsz == 0|let winsz= ""|endif
-"   call Decho("exe ".(g:netrw_altv? "rightb " : "lefta ").winsz."wincmd v",'~'.expand("<slnum>"))
    exe (g:netrw_altv? "rightb " : "lefta ").winsz."wincmd v"
    let s:didsplit= 1
    NetrwKeepj call s:RestoreWinVars()
-   NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,s:NetrwGetWord()))
+   NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,s:NetrwGetWord(),1))
    unlet s:didsplit
 
   else
@@ -9166,7 +8652,6 @@ fun! s:NetrwSplit(mode)
   endif
 
   let @@= ykeep
-"  call Dret("s:NetrwSplit")
 endfun
 
 " ---------------------------------------------------------------------
@@ -9236,91 +8721,49 @@ endfun
 " s:NetrwTreeDir: determine tree directory given current cursor position {{{2
 " (full path directory with trailing slash returned)
 fun! s:NetrwTreeDir(islocal)
-"  call Dfunc("s:NetrwTreeDir(islocal=".a:islocal.") getline(".line(".").")"."<".getline('.')."> b:netrw_curdir<".b:netrw_curdir."> tab#".tabpagenr()." win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> ft=".&ft)
-"  call Decho("Determine tree directory given current cursor position")
-"  call Decho("g:netrw_keepdir  =".(exists("g:netrw_keepdir")?   g:netrw_keepdir   : 'n/a'),'~'.expand("<slnum>"))
-"  call Decho("w:netrw_liststyle=".(exists("w:netrw_liststyle")? w:netrw_liststyle : 'n/a'),'~'.expand("<slnum>"))
-"  call Decho("w:netrw_treetop  =".(exists("w:netrw_treetop")?   w:netrw_treetop   : 'n/a'),'~'.expand("<slnum>"))
-"  call Decho("current line<".getline(".").">")
 
   if exists("s:treedir") && exists("s:prevwinopen")
    " s:NetrwPrevWinOpen opens a "previous" window -- and thus needs to and does call s:NetrwTreeDir early
-"   call Decho('s:NetrwPrevWinOpen opens a "previous" window -- and thus needs to and does call s:NetrwTreeDir early')
    let treedir= s:treedir
    unlet s:treedir
    unlet s:prevwinopen
-"   call Dret("s:NetrwTreeDir ".treedir.": early return since s:treedir existed previously")
    return treedir
   endif
   if exists("s:prevwinopen")
    unlet s:prevwinopen
   endif
-"  call Decho("COMBAK#18 : mod=".&mod." win#".winnr())
 
   if !exists("b:netrw_curdir") || b:netrw_curdir == ""
    let b:netrw_curdir= getcwd()
   endif
   let treedir = b:netrw_curdir
-"  call Decho("set initial treedir<".treedir.">",'~'.expand("<slnum>"))
-"  call Decho("COMBAK#19 : mod=".&mod." win#".winnr())
-
   let s:treecurpos= winsaveview()
-"  call Decho("saving posn to s:treecurpos<".string(s:treecurpos).">",'~'.expand("<slnum>"))
-"  call Decho("COMBAK#20 : mod=".&mod." win#".winnr())
 
   if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
-"   call Decho("w:netrw_liststyle is TREELIST:",'~'.expand("<slnum>"))
-"   call Decho("line#".line(".")." getline(.)<".getline('.')."> treecurpos<".string(s:treecurpos).">",'~'.expand("<slnum>"))
-"  call Decho("COMBAK#21 : mod=".&mod." win#".winnr())
 
    " extract tree directory if on a line specifying a subdirectory (ie. ends with "/")
    let curline= substitute(getline('.'),"\t -->.*$",'','')
    if curline =~ '/$'
-"    call Decho("extract tree subdirectory from current line",'~'.expand("<slnum>"))
     let treedir= substitute(getline('.'),'^\%('.s:treedepthstring.'\)*\([^'.s:treedepthstring.'].\{-}\)$','\1','e')
-"    call Decho("treedir<".treedir.">",'~'.expand("<slnum>"))
    elseif curline =~ '@$'
-"    call Decho("handle symbolic link from current line",'~'.expand("<slnum>"))
-    let potentialdir= resolve(substitute(substitute(getline('.'),'@.*$','','e'),'^|*\s*','','e'))
-"    call Decho("treedir<".treedir.">",'~'.expand("<slnum>"))
+    let potentialdir= resolve(s:NetrwTreePath(w:netrw_treetop))
    else
-"    call Decho("do not extract tree subdirectory from current line and set treedir to empty",'~'.expand("<slnum>"))
     let treedir= ""
    endif
-"  call Decho("COMBAK#22 : mod=".&mod." win#".winnr())
 
    " detect user attempting to close treeroot
-"   call Decho("check if user is attempting to close treeroot",'~'.expand("<slnum>"))
-"   call Decho(".win#".winnr()." buf#".bufnr("%")."<".bufname("%").">",'~'.expand("<slnum>"))
-"   call Decho(".getline(".line(".").")<".getline('.').'> '.((getline('.') =~# '^'.s:treedepthstring)? '=~#' : '!~').' ^'.s:treedepthstring,'~'.expand("<slnum>"))
    if curline !~ '^'.s:treedepthstring && getline('.') != '..'
-"    call Decho(".user may have attempted to close treeroot",'~'.expand("<slnum>"))
     " now force a refresh
-"    call Decho(".force refresh: clear buffer<".expand("%")."> with :%d",'~'.expand("<slnum>"))
     sil! NetrwKeepj %d _
-"    call Dret("s:NetrwTreeDir <".treedir."> : (side effect) s:treecurpos<".(exists("s:treecurpos")? string(s:treecurpos) : 'n/a').">")
     return b:netrw_curdir
-"   else " Decho
-"    call Decho(".user not attempting to close treeroot",'~'.expand("<slnum>"))
    endif
-"  call Decho("COMBAK#23 : mod=".&mod." win#".winnr())
-
-"   call Decho("islocal=".a:islocal." curline<".curline.">",'~'.expand("<slnum>"))
-"   call Decho("potentialdir<".potentialdir."> isdir=".isdirectory(potentialdir),'~'.expand("<slnum>"))
-"  call Decho("COMBAK#24 : mod=".&mod." win#".winnr())
 
    " COMBAK: a symbolic link may point anywhere -- so it will be used to start a new treetop
 "   if a:islocal && curline =~ '@$' && isdirectory(s:NetrwFile(potentialdir))
 "    let newdir          = w:netrw_treetop.'/'.potentialdir
-" "   call Decho("apply NetrwTreePath to newdir<".newdir.">",'~'.expand("<slnum>"))
-"    let treedir         = s:NetrwTreePath(newdir)
-"    let w:netrw_treetop = newdir
-" "   call Decho("newdir <".newdir.">",'~'.expand("<slnum>"))
-"   else
-"    call Decho("apply NetrwTreePath to treetop<".w:netrw_treetop.">",'~'.expand("<slnum>"))
     if a:islocal && curline =~ '@$'
       if isdirectory(s:NetrwFile(potentialdir))
-        let treedir = w:netrw_treetop.'/'.potentialdir.'/'
+        let treedir = potentialdir
         let w:netrw_treetop = treedir
       endif
     else
@@ -9328,29 +8771,21 @@ fun! s:NetrwTreeDir(islocal)
       let treedir = s:NetrwTreePath(w:netrw_treetop)
     endif
   endif
-"  call Decho("COMBAK#25 : mod=".&mod." win#".winnr())
 
   " sanity maintenance: keep those //s away...
   let treedir= substitute(treedir,'//$','/','')
-"  call Decho("treedir<".treedir.">",'~'.expand("<slnum>"))
-"  call Decho("COMBAK#26 : mod=".&mod." win#".winnr())
-
-"  call Dret("s:NetrwTreeDir <".treedir."> : (side effect) s:treecurpos<".(exists("s:treecurpos")? string(s:treecurpos) : 'n/a').">")
   return treedir
 endfun
 
 " ---------------------------------------------------------------------
 " s:NetrwTreeDisplay: recursive tree display {{{2
 fun! s:NetrwTreeDisplay(dir,depth)
-"  call Dfunc("NetrwTreeDisplay(dir<".a:dir."> depth<".a:depth.">)")
-
-  " insure that there are no folds
+  " ensure that there are no folds
   setl nofen
 
   " install ../ and shortdir
   if a:depth == ""
    call setline(line("$")+1,'../')
-"   call Decho("setline#".line("$")." ../ (depth is zero)",'~'.expand("<slnum>"))
   endif
   if a:dir =~ '^\a\{3,}://'
    if a:dir == w:netrw_treetop
@@ -9363,19 +8798,16 @@ fun! s:NetrwTreeDisplay(dir,depth)
    let shortdir= substitute(a:dir,'^.*/','','e')
    call setline(line("$")+1,a:depth.shortdir.'/')
   endif
-"  call Decho("setline#".line("$")." shortdir<".a:depth.shortdir.">",'~'.expand("<slnum>"))
   " append a / to dir if its missing one
   let dir= a:dir
 
   " display subtrees (if any)
   let depth= s:treedepthstring.a:depth
-"  call Decho("display subtrees with depth<".depth."> and current leaves",'~'.expand("<slnum>"))
 
   " implement g:netrw_hide for tree listings (uses g:netrw_list_hide)
   if     g:netrw_hide == 1
    " hide given patterns
    let listhide= split(g:netrw_list_hide,',')
-"   call Decho("listhide=".string(listhide))
    for pat in listhide
     call filter(w:netrw_treedict[dir],'v:val !~ "'.escape(pat,'\\').'"')
    endfor
@@ -9383,7 +8815,6 @@ fun! s:NetrwTreeDisplay(dir,depth)
   elseif g:netrw_hide == 2
    " show given patterns (only)
    let listhide= split(g:netrw_list_hide,',')
-"   call Decho("listhide=".string(listhide))
    let entries=[]
    for entry in w:netrw_treedict[dir]
     for pat in listhide
@@ -9398,77 +8829,57 @@ fun! s:NetrwTreeDisplay(dir,depth)
   if depth != ""
    " always remove "." and ".." entries when there's depth
    call filter(w:netrw_treedict[dir],'v:val !~ "\\.\\.$"')
+   call filter(w:netrw_treedict[dir],'v:val !~ "\\.\\./$"')
    call filter(w:netrw_treedict[dir],'v:val !~ "\\.$"')
+   call filter(w:netrw_treedict[dir],'v:val !~ "\\./$"')
   endif
 
-"  call Decho("for every entry in w:netrw_treedict[".dir."]=".string(w:netrw_treedict[dir]),'~'.expand("<slnum>"))
   for entry in w:netrw_treedict[dir]
    if dir =~ '/$'
     let direntry= substitute(dir.entry,'[@/]$','','e')
    else
     let direntry= substitute(dir.'/'.entry,'[@/]$','','e')
    endif
-"   call Decho("dir<".dir."> entry<".entry."> direntry<".direntry.">",'~'.expand("<slnum>"))
    if entry =~ '/$' && has_key(w:netrw_treedict,direntry)
-"    call Decho("<".direntry."> is a key in treedict - display subtree for it",'~'.expand("<slnum>"))
     NetrwKeepj call s:NetrwTreeDisplay(direntry,depth)
    elseif entry =~ '/$' && has_key(w:netrw_treedict,direntry.'/')
-"    call Decho("<".direntry."/> is a key in treedict - display subtree for it",'~'.expand("<slnum>"))
     NetrwKeepj call s:NetrwTreeDisplay(direntry.'/',depth)
    elseif entry =~ '@$' && has_key(w:netrw_treedict,direntry.'@')
-"    call Decho("<".direntry."/> is a key in treedict - display subtree for it",'~'.expand("<slnum>"))
-    NetrwKeepj call s:NetrwTreeDisplay(direntry.'/',depth)
+    NetrwKeepj call s:NetrwTreeDisplay(direntry.'@',depth)
    else
-"    call Decho("<".entry."> is not a key in treedict (no subtree)",'~'.expand("<slnum>"))
     sil! NetrwKeepj call setline(line("$")+1,depth.entry)
    endif
   endfor
-"  call Decho("displaying: ".string(getline(w:netrw_bannercnt,'$')))
-
-"  call Dret("NetrwTreeDisplay")
 endfun
 
 " ---------------------------------------------------------------------
 " s:NetrwRefreshTreeDict: updates the contents information for a tree (w:netrw_treedict) {{{2
 fun! s:NetrwRefreshTreeDict(dir)
-"  call Dfunc("s:NetrwRefreshTreeDict(dir<".a:dir.">)")
   if !exists("w:netrw_treedict")
-"   call Dret("s:NetrwRefreshTreeDict : w:netrw_treedict doesn't exist")
    return
   endif
 
   for entry in w:netrw_treedict[a:dir]
    let direntry= substitute(a:dir.'/'.entry,'[@/]$','','e')
-"   call Decho("a:dir<".a:dir."> entry<".entry."> direntry<".direntry.">",'~'.expand("<slnum>"))
 
    if entry =~ '/$' && has_key(w:netrw_treedict,direntry)
-"    call Decho("<".direntry."> is a key in treedict - display subtree for it",'~'.expand("<slnum>"))
     NetrwKeepj call s:NetrwRefreshTreeDict(direntry)
-    let liststar                   = s:NetrwGlob(direntry,'*',1)
-    let listdotstar                = s:NetrwGlob(direntry,'.*',1)
-    let w:netrw_treedict[direntry] = liststar + listdotstar
-"    call Decho("updating w:netrw_treedict[".direntry.']='.string(w:netrw_treedict[direntry]),'~'.expand("<slnum>"))
+    let filelist = s:NetrwLocalListingList(direntry,0)
+    let w:netrw_treedict[direntry] = sort(filelist)
 
    elseif entry =~ '/$' && has_key(w:netrw_treedict,direntry.'/')
-"    call Decho("<".direntry."/> is a key in treedict - display subtree for it",'~'.expand("<slnum>"))
     NetrwKeepj call s:NetrwRefreshTreeDict(direntry.'/')
-    let liststar   = s:NetrwGlob(direntry.'/','*',1)
-    let listdotstar= s:NetrwGlob(direntry.'/','.*',1)
-    let w:netrw_treedict[direntry]= liststar + listdotstar
-"    call Decho("updating w:netrw_treedict[".direntry.']='.string(w:netrw_treedict[direntry]),'~'.expand("<slnum>"))
+    let filelist = s:NetrwLocalListingList(direntry.'/',0)
+    let w:netrw_treedict[direntry] = sort(filelist)
 
    elseif entry =~ '@$' && has_key(w:netrw_treedict,direntry.'@')
-"    call Decho("<".direntry."/> is a key in treedict - display subtree for it",'~'.expand("<slnum>"))
     NetrwKeepj call s:NetrwRefreshTreeDict(direntry.'/')
     let liststar   = s:NetrwGlob(direntry.'/','*',1)
     let listdotstar= s:NetrwGlob(direntry.'/','.*',1)
-"    call Decho("updating w:netrw_treedict[".direntry.']='.string(w:netrw_treedict[direntry]),'~'.expand("<slnum>"))
 
    else
-"    call Decho('not updating w:netrw_treedict['.string(direntry).'] with entry<'.string(entry).'> (no subtree)','~'.expand("<slnum>"))
    endif
   endfor
-"  call Dret("s:NetrwRefreshTreeDict")
 endfun
 
 " ---------------------------------------------------------------------
@@ -9635,6 +9046,11 @@ fun! s:NetrwWideListing()
    let newcolstart = w:netrw_bannercnt + fpc
    let newcolend   = newcolstart + fpc - 1
 "   call Decho("bannercnt=".w:netrw_bannercnt." fpl=".w:netrw_fpl." fpc=".fpc." newcol[".newcolstart.",".newcolend."]",'~'.expand("<slnum>"))
+   if !has('nvim') && has("clipboard") && g:netrw_clipboard
+"    call Decho("(s:NetrwWideListing) save @* and @+",'~'.expand("<slnum>"))
+    sil! let keepregstar = @*
+    sil! let keepregplus = @+
+   endif
    while line("$") >= newcolstart
     if newcolend > line("$") | let newcolend= line("$") | endif
     let newcolqty= newcolend - newcolstart
@@ -9648,6 +9064,11 @@ fun! s:NetrwWideListing()
     exe "sil! NetrwKeepj ".newcolstart.','.newcolend.'d _'
     exe 'sil! NetrwKeepj '.w:netrw_bannercnt
    endwhile
+   if !has('nvim') && has("clipboard")
+"    call Decho("(s:NetrwWideListing) restore @* and @+",'~'.expand("<slnum>"))
+    if @* != keepregstar | sil! let @* = keepregstar | endif
+    if @+ != keepregplus | sil! let @+ = keepregplus | endif
+   endif
    exe "sil! NetrwKeepj ".w:netrw_bannercnt.',$s/\s\+$//e'
    NetrwKeepj call histdel("/",-1)
    exe 'nno <buffer> <silent> w	:call search(''^.\\|\s\s\zs\S'',''W'')'."\<cr>"
@@ -10366,15 +9787,11 @@ endfun
 " ---------------------------------------------------------------------
 " s:NetrwRemoteRm: remove/delete a remote file or directory {{{2
 fun! s:NetrwRemoteRm(usrhost,path) range
-"  call Dfunc("s:NetrwRemoteRm(usrhost<".a:usrhost."> path<".a:path.">) virtcol=".virtcol("."))
-"  call Decho("firstline=".a:firstline." lastline=".a:lastline,'~'.expand("<slnum>"))
   let svpos= winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
 
   let all= 0
   if exists("s:netrwmarkfilelist_{bufnr('%')}")
    " remove all marked files
-"   call Decho("remove all marked files with bufnr#".bufnr("%"),'~'.expand("<slnum>"))
    for fname in s:netrwmarkfilelist_{bufnr("%")}
     let ok= s:NetrwRemoteRmFile(a:path,fname,all)
     if ok =~# 'q\%[uit]'
@@ -10387,7 +9804,6 @@ fun! s:NetrwRemoteRm(usrhost,path) range
 
   else
    " remove files specified by range
-"   call Decho("remove files specified by range",'~'.expand("<slnum>"))
 
    " preparation for removing multiple files/directories
    let keepsol = &l:sol
@@ -10409,12 +9825,8 @@ fun! s:NetrwRemoteRm(usrhost,path) range
   endif
 
   " refresh the (remote) directory listing
-"  call Decho("refresh remote directory listing",'~'.expand("<slnum>"))
-  NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./'))
-"  call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+  NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./',0))
   NetrwKeepj call winrestview(svpos)
-
-"  call Dret("s:NetrwRemoteRm")
 endfun
 
 " ---------------------------------------------------------------------
@@ -10540,7 +9952,6 @@ endfun
 " ---------------------------------------------------------------------
 " s:NetrwRemoteRename: rename a remote file or directory {{{2
 fun! s:NetrwRemoteRename(usrhost,path) range
-"  call Dfunc("NetrwRemoteRename(usrhost<".a:usrhost."> path<".a:path.">)")
 
   " preparation for removing multiple files/directories
   let svpos      = winsaveview()
@@ -10551,10 +9962,8 @@ fun! s:NetrwRemoteRename(usrhost,path) range
   " rename files given by the markfilelist
   if exists("s:netrwmarkfilelist_{bufnr('%')}")
    for oldname in s:netrwmarkfilelist_{bufnr("%")}
-"    call Decho("oldname<".oldname.">",'~'.expand("<slnum>"))
     if exists("subfrom")
      let newname= substitute(oldname,subfrom,subto,'')
-"     call Decho("subfrom<".subfrom."> subto<".subto."> newname<".newname.">",'~'.expand("<slnum>"))
     else
      call inputsave()
      let newname= input("Moving ".oldname." to : ",oldname)
@@ -10563,7 +9972,6 @@ fun! s:NetrwRemoteRename(usrhost,path) range
       let subfrom = substitute(newname,'^s/\([^/]*\)/.*/$','\1','')
       let subto   = substitute(newname,'^s/[^/]*/\(.*\)/$','\1','')
       let newname = substitute(oldname,subfrom,subto,'')
-"      call Decho("subfrom<".subfrom."> subto<".subto."> newname<".newname.">",'~'.expand("<slnum>"))
      endif
     endif
 
@@ -10572,7 +9980,6 @@ fun! s:NetrwRemoteRename(usrhost,path) range
     else
      let oldname= s:ShellEscape(a:path.oldname)
      let newname= s:ShellEscape(a:path.newname)
-"     call Decho("system(netrw#WinPath(".rename_cmd.") ".oldname.' '.newname.")",'~'.expand("<slnum>"))
      let ret    = system(netrw#WinPath(rename_cmd).' '.oldname.' '.newname)
     endif
 
@@ -10588,7 +9995,6 @@ fun! s:NetrwRemoteRename(usrhost,path) range
     exe "NetrwKeepj ".ctr
 
     let oldname= s:NetrwGetWord()
-"   call Decho("oldname<".oldname.">",'~'.expand("<slnum>"))
 
     call inputsave()
     let newname= input("Moving ".oldname." to : ",oldname)
@@ -10599,7 +10005,6 @@ fun! s:NetrwRemoteRename(usrhost,path) range
     else
      let oldname= s:ShellEscape(a:path.oldname)
      let newname= s:ShellEscape(a:path.newname)
-"     call Decho("system(netrw#WinPath(".rename_cmd.") ".oldname.' '.newname.")",'~'.expand("<slnum>"))
      let ret    = system(netrw#WinPath(rename_cmd).' '.oldname.' '.newname)
     endif
 
@@ -10609,11 +10014,8 @@ fun! s:NetrwRemoteRename(usrhost,path) range
   endif
 
   " refresh the directory
-  NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./'))
-"  call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+  NetrwKeepj call s:NetrwRefresh(0,s:NetrwBrowseChgDir(0,'./',0))
   NetrwKeepj call winrestview(svpos)
-
-"  call Dret("NetrwRemoteRename")
 endfun
 
 " ==========================================
@@ -10740,17 +10142,11 @@ endfun
 " buffers to be refreshed after a user has executed some shell command,
 " on the chance that s/he removed/created a file/directory with it.
 fun! s:LocalBrowseRefresh()
-"  call Dfunc("s:LocalBrowseRefresh() tabpagenr($)=".tabpagenr("$"))
-"  call Decho("s:netrw_browselist =".(exists("s:netrw_browselist")?  string(s:netrw_browselist)  : '<n/a>'),'~'.expand("<slnum>"))
-"  call Decho("w:netrw_bannercnt  =".(exists("w:netrw_bannercnt")?   string(w:netrw_bannercnt)   : '<n/a>'),'~'.expand("<slnum>"))
-
   " determine which buffers currently reside in a tab
   if !exists("s:netrw_browselist")
-"   call Dret("s:LocalBrowseRefresh : browselist is empty")
    return
   endif
   if !exists("w:netrw_bannercnt")
-"   call Dret("s:LocalBrowseRefresh : don't refresh when focus not on netrw window")
    return
   endif
   if !empty(getcmdwintype())
@@ -10760,7 +10156,6 @@ fun! s:LocalBrowseRefresh()
   if exists("s:netrw_events") && s:netrw_events == 1
    " s:LocalFastBrowser gets called (indirectly) from a
    let s:netrw_events= 2
-"   call Dret("s:LocalBrowseRefresh : avoid initial double refresh")
    return
   endif
   let itab       = 1
@@ -10771,47 +10166,36 @@ fun! s:LocalBrowseRefresh()
    let itab       = itab + 1
    sil! tabn
   endwhile
-"  call Decho("buftablist".string(buftablist),'~'.expand("<slnum>"))
-"  call Decho("s:netrw_browselist<".(exists("s:netrw_browselist")? string(s:netrw_browselist) : "").">",'~'.expand("<slnum>"))
   "  GO through all buffers on netrw_browselist (ie. just local-netrw buffers):
   "   | refresh any netrw window
   "   | wipe out any non-displaying netrw buffer
   let curwinid = win_getid(winnr())
   let ibl    = 0
   for ibuf in s:netrw_browselist
-"   call Decho("bufwinnr(".ibuf.") index(buftablist,".ibuf.")=".index(buftablist,ibuf),'~'.expand("<slnum>"))
    if bufwinnr(ibuf) == -1 && index(buftablist,ibuf) == -1
     " wipe out any non-displaying netrw buffer
     " (ibuf not shown in a current window AND
     "  ibuf not in any tab)
-"    call Decho("wiping  buf#".ibuf,"<".bufname(ibuf).">",'~'.expand("<slnum>"))
     exe "sil! keepj bd ".fnameescape(ibuf)
     call remove(s:netrw_browselist,ibl)
-"    call Decho("browselist=".string(s:netrw_browselist),'~'.expand("<slnum>"))
     continue
    elseif index(tabpagebuflist(),ibuf) != -1
     " refresh any netrw buffer
-"    call Decho("refresh buf#".ibuf.'-> win#'.bufwinnr(ibuf),'~'.expand("<slnum>"))
     exe bufwinnr(ibuf)."wincmd w"
     if getline(".") =~# 'Quick Help'
      " decrement g:netrw_quickhelp to prevent refresh from changing g:netrw_quickhelp
      " (counteracts s:NetrwBrowseChgDir()'s incrementing)
      let g:netrw_quickhelp= g:netrw_quickhelp - 1
     endif
-"    call Decho("#3: quickhelp=".g:netrw_quickhelp,'~'.expand("<slnum>"))
     if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST
      NetrwKeepj call s:NetrwRefreshTreeDict(w:netrw_treetop)
     endif
-    NetrwKeepj call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./'))
+    NetrwKeepj call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./',0))
    endif
    let ibl= ibl + 1
-"   call Decho("bottom of s:netrw_browselist for loop: ibl=".ibl,'~'.expand("<slnum>"))
   endfor
-"  call Decho("restore window: win_gotoid(".curwinid.")")
   call win_gotoid(curwinid)
   let @@= ykeep
-
-"  call Dret("s:LocalBrowseRefresh")
 endfun
 
 " ---------------------------------------------------------------------
@@ -10833,22 +10217,15 @@ endfun
 "                       If :Explore used: it sets s:netrw_events to 2, so no FocusGained events are ignored.
 "                   =2: autocmds installed (doesn't ignore any FocusGained events)
 fun! s:LocalFastBrowser()
-"  call Dfunc("s:LocalFastBrowser() g:netrw_fastbrowse=".g:netrw_fastbrowse)
-"  call Decho("s:netrw_events        ".(exists("s:netrw_events")? "exists"            : 'n/a'),'~'.expand("<slnum>"))
-"  call Decho("autocmd: ShellCmdPost ".(exists("#ShellCmdPost")?  "already installed" : "not installed"),'~'.expand("<slnum>"))
-"  call Decho("autocmd: FocusGained  ".(exists("#FocusGained")?   "already installed" : "not installed"),'~'.expand("<slnum>"))
 
   " initialize browselist, a list of buffer numbers that the local browser has used
   if !exists("s:netrw_browselist")
-"   call Decho("initialize s:netrw_browselist",'~'.expand("<slnum>"))
    let s:netrw_browselist= []
   endif
 
   " append current buffer to fastbrowse list
   if empty(s:netrw_browselist) || bufnr("%") > s:netrw_browselist[-1]
-"   call Decho("appendng current buffer to browselist",'~'.expand("<slnum>"))
    call add(s:netrw_browselist,bufnr("%"))
-"   call Decho("browselist=".string(s:netrw_browselist),'~'.expand("<slnum>"))
   endif
 
   " enable autocmd events to handle refreshing/removing local browser buffers
@@ -10862,10 +10239,8 @@ fun! s:LocalFastBrowser()
    augroup AuNetrwEvent
     au!
     if has("win32")
-"     call Decho("installing autocmd: ShellCmdPost",'~'.expand("<slnum>"))
      au ShellCmdPost			*	call s:LocalBrowseRefresh()
     else
-"     call Decho("installing autocmds: ShellCmdPost FocusGained",'~'.expand("<slnum>"))
      au ShellCmdPost,FocusGained	*	call s:LocalBrowseRefresh()
     endif
    augroup END
@@ -10873,86 +10248,55 @@ fun! s:LocalFastBrowser()
   " user must have changed fastbrowse to its fast setting, so remove
   " the associated autocmd events
   elseif g:netrw_fastbrowse > 1 && exists("#ShellCmdPost") && exists("s:netrw_events")
-"   call Decho("remove AuNetrwEvent autcmd group",'~'.expand("<slnum>"))
    unlet s:netrw_events
    augroup AuNetrwEvent
     au!
    augroup END
    augroup! AuNetrwEvent
   endif
-
-"  call Dret("s:LocalFastBrowser : browselist<".string(s:netrw_browselist).">")
 endfun
 
-" ---------------------------------------------------------------------
-"  s:LocalListing: does the job of "ls" for local directories {{{2
-fun! s:LocalListing()
-"  call Dfunc("s:LocalListing()")
-"  call Decho("ro=".&l:ro." ma=".&l:ma." mod=".&l:mod." wrap=".&l:wrap." (filename<".expand("%")."> win#".winnr()." ft<".&ft.">)",'~'.expand("<slnum>"))
-"  call Decho("modified=".&modified." modifiable=".&modifiable." readonly=".&readonly,'~'.expand("<slnum>"))
-"  call Decho("tab#".tabpagenr()." win#".winnr()." buf#".bufnr("%")."<".bufname("%")."> line#".line(".")." col#".col(".")." winline#".winline()." wincol#".wincol(),'~'.expand("<slnum>"))
-
-"  if exists("b:netrw_curdir") |call Decho('b:netrw_curdir<'.b:netrw_curdir.">")  |else|call Decho("b:netrw_curdir doesn't exist",'~'.expand("<slnum>")) |endif
-"  if exists("g:netrw_sort_by")|call Decho('g:netrw_sort_by<'.g:netrw_sort_by.">")|else|call Decho("g:netrw_sort_by doesn't exist",'~'.expand("<slnum>"))|endif
-"  call Decho("g:netrw_banner=".g:netrw_banner.": banner ".(g:netrw_banner? "enabled" : "suppressed").": (line($)=".line("$")." byte2line(1)=".byte2line(1)." bannercnt=".w:netrw_bannercnt.")",'~'.expand("<slnum>"))
-
+fun! s:NetrwLocalListingList(dirname,setmaxfilenamelen)
   " get the list of files contained in the current directory
-  let dirname    = b:netrw_curdir
-  let dirnamelen = strlen(b:netrw_curdir)
+  let dirname    = a:dirname
+  let dirnamelen = strlen(dirname)
   let filelist   = s:NetrwGlob(dirname,"*",0)
   let filelist   = filelist + s:NetrwGlob(dirname,".*",0)
-"  call Decho("filelist=".string(filelist),'~'.expand("<slnum>"))
 
   if g:netrw_cygwin == 0 && has("win32")
-"   call Decho("filelist=".string(filelist),'~'.expand("<slnum>"))
-  elseif index(filelist,'..') == -1 && b:netrw_curdir !~ '/'
+  elseif index(filelist,'..') == -1 && dirname !~ '/'
     " include ../ in the glob() entry if its missing
-"   call Decho("forcibly including on \"..\"",'~'.expand("<slnum>"))
-   let filelist= filelist+[s:ComposePath(b:netrw_curdir,"../")]
-"   call Decho("filelist=".string(filelist),'~'.expand("<slnum>"))
+   let filelist= filelist+[s:ComposePath(dirname,"../")]
   endif
 
-"  call Decho("before while: dirname   <".dirname.">",'~'.expand("<slnum>"))
-"  call Decho("before while: dirnamelen<".dirnamelen.">",'~'.expand("<slnum>"))
-"  call Decho("before while: filelist  =".string(filelist),'~'.expand("<slnum>"))
-
-  if get(g:, 'netrw_dynamic_maxfilenamelen', 0)
+  if a:setmaxfilenamelen && get(g:, 'netrw_dynamic_maxfilenamelen', 0)
    let filelistcopy           = map(deepcopy(filelist),'fnamemodify(v:val, ":t")')
    let g:netrw_maxfilenamelen = max(map(filelistcopy,'len(v:val)')) + 1
-"   call Decho("dynamic_maxfilenamelen: filenames             =".string(filelistcopy),'~'.expand("<slnum>"))
-"   call Decho("dynamic_maxfilenamelen: g:netrw_maxfilenamelen=".g:netrw_maxfilenamelen,'~'.expand("<slnum>"))
   endif
-"  call Decho("g:netrw_banner=".g:netrw_banner.": banner ".(g:netrw_banner? "enabled" : "suppressed").": (line($)=".line("$")." byte2line(1)=".byte2line(1)." bannercnt=".w:netrw_bannercnt.")",'~'.expand("<slnum>"))
 
+  let resultfilelist = []
   for filename in filelist
-"   call Decho(" ",'~'.expand("<slnum>"))
-"   call Decho("for filename in filelist: filename<".filename.">",'~'.expand("<slnum>"))
 
    if getftype(filename) == "link"
     " indicate a symbolic link
-"    call Decho("indicate <".filename."> is a symbolic link with trailing @",'~'.expand("<slnum>"))
     let pfile= filename."@"
 
    elseif getftype(filename) == "socket"
     " indicate a socket
-"    call Decho("indicate <".filename."> is a socket with trailing =",'~'.expand("<slnum>"))
     let pfile= filename."="
 
    elseif getftype(filename) == "fifo"
     " indicate a fifo
-"    call Decho("indicate <".filename."> is a fifo with trailing |",'~'.expand("<slnum>"))
     let pfile= filename."|"
 
    elseif isdirectory(s:NetrwFile(filename))
     " indicate a directory
-"    call Decho("indicate <".filename."> is a directory with trailing /",'~'.expand("<slnum>"))
     let pfile= filename."/"
 
    elseif exists("b:netrw_curdir") && b:netrw_curdir !~ '^.*://' && !isdirectory(s:NetrwFile(filename))
     if has("win32")
      if filename =~ '\.[eE][xX][eE]$' || filename =~ '\.[cC][oO][mM]$' || filename =~ '\.[bB][aA][tT]$'
       " indicate an executable
-"      call Decho("indicate <".filename."> is executable with trailing *",'~'.expand("<slnum>"))
       let pfile= filename."*"
      else
       " normal file
@@ -10960,7 +10304,6 @@ fun! s:LocalListing()
      endif
     elseif executable(filename)
      " indicate an executable
-"     call Decho("indicate <".filename."> is executable with trailing *",'~'.expand("<slnum>"))
      let pfile= filename."*"
     else
      " normal file
@@ -10971,16 +10314,12 @@ fun! s:LocalListing()
     " normal file
     let pfile= filename
    endif
-"   call Decho("pfile<".pfile."> (after *@/ appending)",'~'.expand("<slnum>"))
 
    if pfile =~ '//$'
     let pfile= substitute(pfile,'//$','/','e')
-"    call Decho("change // to /: pfile<".pfile.">",'~'.expand("<slnum>"))
    endif
    let pfile= strpart(pfile,dirnamelen)
    let pfile= substitute(pfile,'^[/\\]','','e')
-"   call Decho("filename<".filename.">",'~'.expand("<slnum>"))
-"   call Decho("pfile   <".pfile.">",'~'.expand("<slnum>"))
 
    if w:netrw_liststyle == s:LONGLIST
     let longfile = printf("%-".g:netrw_maxfilenamelen."S",pfile)
@@ -10993,47 +10332,46 @@ fun! s:LocalListing()
     endif
     let fsz  = printf("%".szlen."S",sz)
     let pfile= longfile."  ".fsz." ".strftime(g:netrw_timefmt,getftime(filename))
-"    call Decho("longlist support: sz=".sz." fsz=".fsz,'~'.expand("<slnum>"))
    endif
 
    if     g:netrw_sort_by =~# "^t"
     " sort by time (handles time up to 1 quintillion seconds, US)
     " Decorate listing by prepending a timestamp/  .  Sorting will then be done based on time.
-"    call Decho("implementing g:netrw_sort_by=".g:netrw_sort_by." (time)")
-"    call Decho("getftime(".filename.")=".getftime(filename),'~'.expand("<slnum>"))
     let t  = getftime(filename)
     let ft = printf("%018d",t)
-"    call Decho("exe NetrwKeepj put ='".ft.'/'.pfile."'",'~'.expand("<slnum>"))
     let ftpfile= ft.'/'.pfile
-    sil! NetrwKeepj put=ftpfile
+    let resultfilelist += [ftpfile]
 
    elseif g:netrw_sort_by =~ "^s"
     " sort by size (handles file sizes up to 1 quintillion bytes, US)
-"    call Decho("implementing g:netrw_sort_by=".g:netrw_sort_by." (size)")
-"    call Decho("getfsize(".filename.")=".getfsize(filename),'~'.expand("<slnum>"))
     let sz   = getfsize(filename)
     let fsz  = printf("%018d",sz)
-"    call Decho("exe NetrwKeepj put ='".fsz.'/'.filename."'",'~'.expand("<slnum>"))
     let fszpfile= fsz.'/'.pfile
-    sil! NetrwKeepj put =fszpfile
+    let resultfilelist += [fszpfile]
 
    else
     " sort by name
-"    call Decho("implementing g:netrw_sort_by=".g:netrw_sort_by." (name)")
-"    call Decho("exe NetrwKeepj put ='".pfile."'",'~'.expand("<slnum>"))
-    sil! NetrwKeepj put=pfile
+    let resultfilelist += [pfile]
    endif
-"   call DechoBuf(bufnr("%"),"bufnr(%)")
+  endfor
+
+  return resultfilelist
+endfun
+
+" ---------------------------------------------------------------------
+"  s:LocalListing: does the job of "ls" for local directories {{{2
+fun! s:LocalListing()
+
+  let filelist = s:NetrwLocalListingList(b:netrw_curdir, 1)
+  for filename in filelist
+    sil! NetrwKeepj put =filename
   endfor
 
   " cleanup any windows mess at end-of-line
   sil! NetrwKeepj g/^$/d
   sil! NetrwKeepj %s/\r$//e
   call histdel("/",-1)
-"  call Decho("exe setl ts=".(g:netrw_maxfilenamelen+1),'~'.expand("<slnum>"))
   exe "setl ts=".(g:netrw_maxfilenamelen+1)
-
-"  call Dret("s:LocalListing")
 endfun
 
 " ---------------------------------------------------------------------
@@ -11067,7 +10405,6 @@ endfun
 " ---------------------------------------------------------------------
 " s:NetrwLocalRename: rename a local file or directory {{{2
 fun! s:NetrwLocalRename(path) range
-"  call Dfunc("NetrwLocalRename(path<".a:path.">)")
 
   if !exists("w:netrw_bannercnt")
    let w:netrw_bannercnt= b:netrw_bannercnt
@@ -11078,15 +10415,12 @@ fun! s:NetrwLocalRename(path) range
   let ctr       = a:firstline
   let svpos     = winsaveview()
   let all       = 0
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
 
   " rename files given by the markfilelist
   if exists("s:netrwmarkfilelist_{bufnr('%')}")
    for oldname in s:netrwmarkfilelist_{bufnr("%")}
-"    call Decho("oldname<".oldname.">",'~'.expand("<slnum>"))
     if exists("subfrom")
      let newname= substitute(oldname,subfrom,subto,'')
-"     call Decho("subfrom<".subfrom."> subto<".subto."> newname<".newname.">",'~'.expand("<slnum>"))
     else
      call inputsave()
      let newname= input("Moving ".oldname." to : ",oldname,"file")
@@ -11101,7 +10435,6 @@ fun! s:NetrwLocalRename(path) range
      if newname =~ '^s/'
       let subfrom = substitute(newname,'^s/\([^/]*\)/.*/$','\1','')
       let subto   = substitute(newname,'^s/[^/]*/\(.*\)/$','\1','')
-"      call Decho("subfrom<".subfrom."> subto<".subto."> newname<".newname.">",'~'.expand("<slnum>"))
       let newname = substitute(oldname,subfrom,subto,'')
      endif
     endif
@@ -11113,12 +10446,9 @@ fun! s:NetrwLocalRename(path) range
       let all= 1
      elseif response != "y" && response != "yes"
       " refresh the directory
-"      call Decho("refresh the directory listing",'~'.expand("<slnum>"))
-      NetrwKeepj call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./'))
-"      call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+      NetrwKeepj call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./',0))
       NetrwKeepj call winrestview(svpos)
       let @@= ykeep
-"      call Dret("NetrwLocalRename")
       return
      endif
     endif
@@ -11145,35 +10475,25 @@ fun! s:NetrwLocalRename(path) range
 
     NetrwKeepj norm! 0
     let oldname= s:ComposePath(a:path,curword)
-"    call Decho("oldname<".oldname.">",'~'.expand("<slnum>"))
 
     call inputsave()
     let newname= input("Moving ".oldname." to : ",substitute(oldname,'/*$','','e'))
     call inputrestore()
 
     call rename(oldname,newname)
-"    call Decho("renaming <".oldname."> to <".newname.">",'~'.expand("<slnum>"))
-
     let ctr= ctr + 1
    endwhile
   endif
 
   " refresh the directory
-"  call Decho("refresh the directory listing",'~'.expand("<slnum>"))
-  NetrwKeepj call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./'))
-"  call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+  NetrwKeepj call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./',0))
   NetrwKeepj call winrestview(svpos)
   let @@= ykeep
-
-"  call Dret("NetrwLocalRename")
 endfun
 
 " ---------------------------------------------------------------------
 " s:NetrwLocalRm: {{{2
 fun! s:NetrwLocalRm(path) range
-"  call Dfunc("s:NetrwLocalRm(path<".a:path.">)")
-"  call Decho("firstline=".a:firstline." lastline=".a:lastline,'~'.expand("<slnum>"))
-
   if !exists("w:netrw_bannercnt")
    let w:netrw_bannercnt= b:netrw_bannercnt
   endif
@@ -11183,11 +10503,9 @@ fun! s:NetrwLocalRm(path) range
   let ret   = 0
   let all   = 0
   let svpos = winsaveview()
-"  call Decho("saving posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
 
   if exists("s:netrwmarkfilelist_{bufnr('%')}")
    " remove all marked files
-"   call Decho("remove all marked files",'~'.expand("<slnum>"))
    for fname in s:netrwmarkfilelist_{bufnr("%")}
     let ok= s:NetrwLocalRmFile(a:path,fname,all)
     if ok =~# 'q\%[uit]' || ok == "no"
@@ -11200,7 +10518,6 @@ fun! s:NetrwLocalRm(path) range
 
   else
   " remove (multiple) files and directories
-"   call Decho("remove files in range [".a:firstline.",".a:lastline."]",'~'.expand("<slnum>"))
 
    let keepsol= &l:sol
    setl nosol
@@ -11230,15 +10547,11 @@ fun! s:NetrwLocalRm(path) range
   endif
 
   " refresh the directory
-"  call Decho("bufname<".bufname("%").">",'~'.expand("<slnum>"))
   if bufname("%") != "NetrwMessage"
-   NetrwKeepj call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./'))
-"   call Decho("restoring posn to svpos<".string(svpos).">",'~'.expand("<slnum>"))
+   NetrwKeepj call s:NetrwRefresh(1,s:NetrwBrowseChgDir(1,'./',0))
    NetrwKeepj call winrestview(svpos)
   endif
   let @@= ykeep
-
-"  call Dret("s:NetrwLocalRm")
 endfun
 
 " ---------------------------------------------------------------------
@@ -12407,29 +11720,24 @@ endfun
 " ---------------------------------------------------------------------
 " s:ShowLink: used to modify thin and tree listings to show links {{{2
 fun! s:ShowLink()
-" "  call Dfunc("s:ShowLink()")
-" "  call Decho("b:netrw_curdir<".(exists("b:netrw_curdir")? b:netrw_curdir : "doesn't exist").">",'~'.expand("<slnum>"))
-" "  call Decho(printf("line#%4d: %s",line("."),getline(".")),'~'.expand("<slnum>"))
   if exists("b:netrw_curdir")
    norm! $?\a
-   let fname   = b:netrw_curdir.'/'.s:NetrwGetWord()
+   if exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST && exists("w:netrw_treetop")
+    let basedir = s:NetrwTreePath(w:netrw_treetop)
+   else
+    let basedir = b:netrw_curdir.'/'
+   endif
+   let fname = basedir.s:NetrwGetWord()
    let resname = resolve(fname)
-" "   call Decho("fname         <".fname.">",'~'.expand("<slnum>"))
-" "   call Decho("resname       <".resname.">",'~'.expand("<slnum>"))
-" "   call Decho("b:netrw_curdir<".b:netrw_curdir.">",'~'.expand("<slnum>"))
-   if resname =~ '^\M'.b:netrw_curdir.'/'
-    let dirlen  = strlen(b:netrw_curdir)
-    let resname = strpart(resname,dirlen+1)
-" "    call Decho("resname<".resname.">  (b:netrw_curdir elided)",'~'.expand("<slnum>"))
+   if resname =~ '^\M'.basedir
+    let dirlen  = strlen(basedir)
+    let resname = strpart(resname,dirlen)
    endif
    let modline = getline(".")."\t --> ".resname
-" "   call Decho("fname  <".fname.">",'~'.expand("<slnum>"))
-" "   call Decho("modline<".modline.">",'~'.expand("<slnum>"))
    setl noro ma
    call setline(".",modline)
    setl ro noma nomod
   endif
-" "  call Dret("s:ShowLink".((exists("fname")? ' : '.fname : 'n/a')))
 endfun
 
 " ---------------------------------------------------------------------
@@ -12590,8 +11898,6 @@ endfun
 "               * interprets result
 "             See netrw#UserMaps()
 fun! s:UserMaps(islocal,funcname)
-"  call Dfunc("s:UserMaps(islocal=".a:islocal.",funcname<".a:funcname.">)")
-
   if !exists("b:netrw_curdir")
    let b:netrw_curdir= getcwd()
   endif
@@ -12600,30 +11906,22 @@ fun! s:UserMaps(islocal,funcname)
 
   if     type(result) == 1
    " if result from user's funcref is a string...
-"   call Decho("result string from user funcref<".result.">",'~'.expand("<slnum>"))
    if result == "refresh"
-"    call Decho("refreshing display",'~'.expand("<slnum>"))
-    call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
+    call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
    elseif result != ""
-"    call Decho("executing result<".result.">",'~'.expand("<slnum>"))
     exe result
    endif
 
   elseif type(result) == 3
    " if result from user's funcref is a List...
-"   call Decho("result List from user funcref<".string(result).">",'~'.expand("<slnum>"))
    for action in result
     if action == "refresh"
-"     call Decho("refreshing display",'~'.expand("<slnum>"))
-     call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./'))
+     call s:NetrwRefresh(a:islocal,s:NetrwBrowseChgDir(a:islocal,'./',0))
     elseif action != ""
-"     call Decho("executing action<".action.">",'~'.expand("<slnum>"))
      exe action
     endif
    endfor
   endif
-
-"  call Dret("s:UserMaps")
 endfun
 
 " ==========================

--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -32,6 +32,7 @@
 "   2024 Oct 30 by Vim Project: fix x mapping on cygwin (#13687)
 "   2024 Oct 31 by Vim Project: add netrw#Launch() and netrw#Open() (#15962)
 "   2024 Oct 31 by Vim Project: fix E874 when browsing remote dir (#15964)
+"   2024 Nov 07 by Vim Project: use keeppatterns to prevent polluting the search history
 "   }}}
 " Former Maintainer:	Charles E Campbell
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
@@ -9499,7 +9500,7 @@ fun! s:NetrwTreeListing(dirname)
    endif
 
    " update the dictionary for the current directory
-   exe "sil! NetrwKeepj ".w:netrw_bannercnt.',$g@^\.\.\=/$@d _'
+   exe "sil! NetrwKeepj keepp ".w:netrw_bannercnt.',$g@^\.\.\=/$@d _'
    let w:netrw_treedict[a:dirname]= getline(w:netrw_bannercnt,line("$"))
    exe "sil! NetrwKeepj ".w:netrw_bannercnt.",$d _"
 
@@ -9916,7 +9917,7 @@ fun! s:PerformListing(islocal)
   " resolve symbolic links if local and (thin or tree)
   if a:islocal && (w:netrw_liststyle == s:THINLIST || (exists("w:netrw_liststyle") && w:netrw_liststyle == s:TREELIST))
 "   call Decho("--resolve symbolic links if local and thin|tree",'~'.expand("<slnum>"))
-   sil! g/@$/call s:ShowLink()
+   sil! keepp g/@$/call s:ShowLink()
   endif
 
   if exists("w:netrw_bannercnt") && (line("$") >= w:netrw_bannercnt || !g:netrw_banner)

--- a/runtime/compiler/cppcheck.vim
+++ b/runtime/compiler/cppcheck.vim
@@ -1,7 +1,7 @@
 " vim compiler file
 " Compiler:	cppcheck (C++ static checker)
 " Maintainer:   Vincent B. (twinside@free.fr)
-" Last Change:  2024 Oct 17 by @Konfekt
+" Last Change:  2024 Nov 08 by @Konfekt
 
 if exists("current_compiler") | finish | endif
 let current_compiler = "cppcheck"
@@ -25,7 +25,7 @@ let &l:makeprg = 'cppcheck --quiet'
       \	          (filereadable('compile_commands.json') ? '--project=compile_commands.json' :
       \           (!empty(glob('*'..s:slash..'compile_commands.json', 1, 1)) ? '--project='..glob('*'..s:slash..'compile_commands.json', 1, 1)[0] :
       \	          (empty(&path) ? '' : '-I')..join(map(filter(split(&path, ','), 'isdirectory(v:val)'),'shellescape(v:val)'), ' -I')))))
-silent CompilerSet makeprg
+exe 'CompilerSet makeprg='..escape(&l:makeprg, ' "')
 
 CompilerSet errorformat=
   \%f:%l:%c:\ %tarning:\ %m,

--- a/runtime/compiler/cppcheck.vim
+++ b/runtime/compiler/cppcheck.vim
@@ -1,15 +1,13 @@
 " vim compiler file
 " Compiler:	cppcheck (C++ static checker)
 " Maintainer:   Vincent B. (twinside@free.fr)
-" Last Change:  2024 oct 17 by @Konfekt
+" Last Change:  2024 Oct 17 by @Konfekt
 
-if exists("cppcheck")
-  finish
-endif
+if exists("current_compiler") | finish | endif
 let current_compiler = "cppcheck"
 
 let s:cpo_save = &cpo
-set cpo-=C
+set cpo&vim
 
 let s:slash = has('win32')? '\' : '/'
 

--- a/runtime/compiler/mypy.vim
+++ b/runtime/compiler/mypy.vim
@@ -1,0 +1,19 @@
+" Vim compiler file
+" Compiler:	Mypy (Python static checker)
+" Maintainer:   @Konfekt
+" Last Change:	2024 Nov 07
+
+if exists("current_compiler") | finish | endif
+let current_compiler = "mypy"
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+" CompilerSet makeprg=mypy
+let &l:makeprg = 'mypy --show-column-numbers '
+	    \ ..get(b:, 'mypy_makeprg_params', get(g:, 'mypy_makeprg_params', '--strict --ignore-missing-imports'))
+exe 'CompilerSet makeprg='..escape(&l:makeprg, ' "')
+CompilerSet errorformat=%f:%l:%c:\ %t%*[^:]:\ %m
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/compiler/pylint.vim
+++ b/runtime/compiler/pylint.vim
@@ -1,13 +1,21 @@
 " Vim compiler file
-" Compiler:	Pylint for Python
-" Maintainer: Daniel Moch <daniel@danielmoch.com>
-" Last Change: 2016 May 20
-"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+" Compiler:     Pylint for Python
+" Maintainer:   Daniel Moch <daniel@danielmoch.com>
+" Last Change:  2024 Nov 07 by The Vim Project (added params variable)
 
-if exists("current_compiler")
-  finish
-endif
+if exists("current_compiler") | finish | endif
 let current_compiler = "pylint"
 
-CompilerSet makeprg=pylint\ --output-format=text\ --msg-template=\"{path}:{line}:{column}:{C}:\ [{symbol}]\ {msg}\"\ --reports=no
+let s:cpo_save = &cpo
+set cpo&vim
+
+" CompilerSet makeprg=ruff
+let &l:makeprg = 'pylint ' .
+      \ '--output-format=text --msg-template="{path}:{line}:{column}:{C}: [{symbol}] {msg}" --reports=no ' .
+      \ get(b:, "pylint_makeprg_params", get(g:, "pylint_makeprg_params",
+      \   (executable('getconf') ? '--jobs='..systemlist('getconf _NPROCESSORS_ONLN')[0] : '')))
+exe 'CompilerSet makeprg='..escape(&l:makeprg, ' "')
 CompilerSet errorformat=%A%f:%l:%c:%t:\ %m,%A%f:%l:\ %m,%A%f:(%l):\ %m,%-Z%p^%.%#,%-G%.%#
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/compiler/ruff.vim
+++ b/runtime/compiler/ruff.vim
@@ -1,0 +1,19 @@
+" Vim compiler file
+" Compiler:     Ruff (Python linter)
+" Maintainer:   @pbnj-dragon
+" Last Change:  2024 Nov 07
+
+if exists("current_compiler") | finish | endif
+let current_compiler = "ruff"
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+" CompilerSet makeprg=ruff
+let &l:makeprg= 'ruff check --output-format=concise '
+        \ ..get(b:, 'ruff_makeprg_params', get(g:, 'ruff_makeprg_params', '--preview'))
+exe 'CompilerSet makeprg='..escape(&l:makeprg, ' "')
+CompilerSet errorformat=%f:%l:%c:\ %m,%f:%l:\ %m,%f:%l:%c\ -\ %m,%f:
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1366,6 +1366,33 @@ being checked.  To disable this set g:perl_compiler_force_warnings to a zero
 value.  For example: >
 	let g:perl_compiler_force_warnings = 0
 
+MYPY TYPE CHECKER					*compiler-mypy*
+
+Commonly used compiler options can be added to 'makeprg' by setting the
+b/g:mypy_makeprg_params variable.  For example: >
+
+	let b:mypy_makeprg_params = "--warn-unused-ignores"
+
+The global default is "--strict --ignore-missing-imports".
+
+RUFF LINTER						*compiler-ruff*
+
+Commonly used compiler options can be added to 'makeprg' by setting the
+b/g:ruff_makeprg_params variable.  For example: >
+
+	let b:ruff_makeprg_params = "--max-line-length"..&textwidth
+
+The global default is "--preview".
+
+PYLINT LINTER						*compiler-pylint*
+
+Commonly used compiler options can be added to 'makeprg' by setting the
+b/g:pylint_makeprg_params variable.  For example: >
+
+	let b:pylint_makeprg_params = "--max-line-length"..&textwidth
+
+The global default is "--jobs=n" where n is the number of cores as reported
+by getconf, if executable. Otherwise it defaults to "".
 
 PYUNIT COMPILER						*compiler-pyunit*
 

--- a/runtime/syntax/8th.vim
+++ b/runtime/syntax/8th.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:     8th
-" Version:      23.09.01
-" Last Change:  2023 Dec 19
+" Version:      24.08
+" Last Change:  2024 Nov 07
 " Maintainer:   Ron Aaron <ron@aaron-tech.com>
 " URL:          https://8th-dev.com/
 " Filetypes:    *.8th
@@ -36,16 +36,16 @@ com! -nargs=+ Builtin syn keyword eighthBuiltin <args>
 
 
 Builtin  gen-secret 2fa:gen-secret gen-url 2fa:gen-url validate-code 2fa:validate-code cb AWS:cb cli AWS:cli
-Builtin  cmd AWS:cmd cp AWS:cp rc AWS:rc call DBUS:call init DBUS:init + DOM:+ - DOM:- attr! DOM:attr!
-Builtin  attr@ DOM:attr@ attrs DOM:attrs children DOM:children css-parse DOM:css-parse each DOM:each
-Builtin  find DOM:find new DOM:new type DOM:type ! G:! !if G:!if #! G:#! ## G:## #if G:#if ' G:' ( G:(
-Builtin  (* G:(* (:) G:(:) (code) G:(code) (defer) G:(defer) (dump) G:(dump) (getc) G:(getc) (gets) G:(gets)
+Builtin  cmd AWS:cmd cp AWS:cp rc AWS:rc LIBS DBUS:LIBS call DBUS:call init DBUS:init + DOM:+ - DOM:-
+Builtin  attr! DOM:attr! attr@ DOM:attr@ attrs DOM:attrs children DOM:children css-parse DOM:css-parse
+Builtin  each DOM:each find DOM:find new DOM:new type DOM:type ! G:! !if G:!if #! G:#! ## G:## #if G:#if
+Builtin  ' G:' ( G:( (:) G:(:) (code) G:(code) (defer) G:(defer) (dump) G:(dump) (getc) G:(getc) (gets) G:(gets)
 Builtin  (interp) G:(interp) (log) G:(log) (needs) G:(needs) (parseln) G:(parseln) (putc) G:(putc) (puts) G:(puts)
-Builtin  (stat) G:(stat) (with) G:(with) ) G:) +hook G:+hook +ref G:+ref ,# G:,# -- G:-- -----BEGIN G:-----BEGIN
+Builtin  (stat) G:(stat) (with) G:(with) ) G:) +hook G:+hook +ref G:+ref ,# G:,# -----BEGIN G:-----BEGIN
 Builtin  -Inf G:-Inf -Inf? G:-Inf? -hook G:-hook -ref G:-ref -rot G:-rot . G:. .# G:.# .hook G:.hook
 Builtin  .needs G:.needs .r G:.r .s G:.s .s-truncate G:.s-truncate .stats G:.stats .ver G:.ver .with G:.with
 Builtin  0; G:0; 2dip G:2dip 2drop G:2drop 2dup G:2dup 2nip G:2nip 2over G:2over 2swap G:2swap 2tuck G:2tuck
-Builtin  3drop G:3drop 3drop G:3drop 3dup G:3dup 3rev G:3rev 4drop G:4drop 8thdt? G:8thdt? 8thsku G:8thsku
+Builtin  3drop G:3drop 3drop G:3drop 3dup G:3dup 3rev G:3rev 4drop G:4drop 8thdt? G:8thdt? 8thsku? G:8thsku?
 Builtin  8thver? G:8thver? 8thvernum? G:8thvernum? : G:: ; G:; ;; G:;; ;;; G:;;; ;with G:;with >clip G:>clip
 Builtin  >json G:>json >kind G:>kind >n G:>n >r G:>r >s G:>s ?: G:?: ?@ G:?@ @ G:@ BITMAP: G:BITMAP:
 Builtin  ENUM: G:ENUM: FLAG: G:FLAG: I G:I Inf G:Inf Inf? G:Inf? J G:J K G:K NaN G:NaN NaN? G:NaN? SED-CHECK G:SED-CHECK
@@ -59,16 +59,17 @@ Builtin  counting-allocations G:counting-allocations cr G:cr critical: G:critica
 Builtin  curlang G:curlang curry G:curry curry: G:curry: decimal G:decimal default: G:default: defer: G:defer:
 Builtin  deferred: G:deferred: deg>rad G:deg>rad depth G:depth die G:die dip G:dip drop G:drop dstack G:dstack
 Builtin  dump G:dump dup G:dup dup>r G:dup>r dup? G:dup? e# G:e# enum: G:enum: error? G:error? eval G:eval
-Builtin  eval! G:eval! eval0 G:eval0 expect G:expect extra! G:extra! extra@ G:extra@ false G:false fnv G:fnv
-Builtin  fourth G:fourth free G:free func: G:func: getc G:getc getcwd G:getcwd getenv G:getenv gets G:gets
-Builtin  handler G:handler header G:header help G:help hex G:hex i: G:i: i; G:i; isa? G:isa? items-used G:items-used
-Builtin  jcall G:jcall jclass G:jclass jmethod G:jmethod json! G:json! json-8th> G:json-8th> json-nesting G:json-nesting
-Builtin  json-pretty G:json-pretty json-throw G:json-throw json> G:json> json@ G:json@ k32 G:k32 keep G:keep
-Builtin  l: G:l: last G:last lib G:lib libbin G:libbin libc G:libc literal G:literal locals: G:locals:
-Builtin  lock G:lock lock-to G:lock-to locked? G:locked? log G:log log-syslog G:log-syslog log-task G:log-task
-Builtin  log-time G:log-time log-time-local G:log-time-local long-days G:long-days long-months G:long-months
-Builtin  longjmp G:longjmp lookup G:lookup loop G:loop loop- G:loop- map? G:map? mark G:mark mark? G:mark?
-Builtin  mobile? G:mobile? n# G:n# name>os G:name>os name>sem G:name>sem ndrop G:ndrop needs G:needs
+Builtin  eval! G:eval! eval0 G:eval0 exit G:exit expect G:expect extra! G:extra! extra@ G:extra@ false G:false
+Builtin  fnv G:fnv fourth G:fourth free G:free func: G:func: getc G:getc getcwd G:getcwd getenv G:getenv
+Builtin  gets G:gets goto G:goto handler G:handler header G:header help G:help help_db G:help_db here G:here
+Builtin  hex G:hex i: G:i: i; G:i; isa? G:isa? items-used G:items-used jcall G:jcall jclass G:jclass
+Builtin  jmethod G:jmethod json! G:json! json-8th> G:json-8th> json-nesting G:json-nesting json-pretty G:json-pretty
+Builtin  json-throw G:json-throw json> G:json> json@ G:json@ k32 G:k32 keep G:keep l: G:l: last G:last
+Builtin  lib G:lib libbin G:libbin libc G:libc libimg G:libimg literal G:literal locals: G:locals: lock G:lock
+Builtin  lock-to G:lock-to locked? G:locked? log G:log log-syslog G:log-syslog log-task G:log-task log-time G:log-time
+Builtin  log-time-local G:log-time-local long-days G:long-days long-months G:long-months longjmp G:longjmp
+Builtin  lookup G:lookup loop G:loop loop- G:loop- map? G:map? mark G:mark mark? G:mark? mobile? G:mobile?
+Builtin  n# G:n# name>os G:name>os name>sem G:name>sem ndrop G:ndrop needs G:needs needs-throws G:needs-throws
 Builtin  new G:new next-arg G:next-arg nip G:nip noop G:noop not G:not nothrow G:nothrow ns G:ns ns: G:ns:
 Builtin  ns>ls G:ns>ls ns>s G:ns>s ns? G:ns? null G:null null; G:null; null? G:null? nullvar G:nullvar
 Builtin  number? G:number? of: G:of: off G:off on G:on onexit G:onexit only G:only op! G:op! or G:or
@@ -76,128 +77,132 @@ Builtin  os G:os os-names G:os-names os>long-name G:os>long-name os>name G:os>na
 Builtin  pack G:pack parse G:parse parse-csv G:parse-csv parse-date G:parse-date parsech G:parsech parseln G:parseln
 Builtin  parsews G:parsews pick G:pick poke G:poke pool-clear G:pool-clear pool-clear-all G:pool-clear-all
 Builtin  prior G:prior private G:private process-args G:process-args process-args-fancy G:process-args-fancy
-Builtin  process-args-help G:process-args-help process-args-vars G:process-args-vars prompt G:prompt
-Builtin  public G:public putc G:putc puts G:puts quote G:quote r! G:r! r> G:r> r@ G:r@ rad>deg G:rad>deg
-Builtin  rand-jit G:rand-jit rand-jsf G:rand-jsf rand-native G:rand-native rand-normal G:rand-normal
-Builtin  rand-pcg G:rand-pcg rand-pcg-seed G:rand-pcg-seed rand-range G:rand-range rand-select G:rand-select
-Builtin  randbuf-pcg G:randbuf-pcg random G:random rdrop G:rdrop recurse G:recurse recurse-stack G:recurse-stack
-Builtin  ref@ G:ref@ reg! G:reg! reg@ G:reg@ regbin@ G:regbin@ remaining-args G:remaining-args repeat G:repeat
-Builtin  required? G:required? requires G:requires reset G:reset roll G:roll rop! G:rop! rot G:rot rpick G:rpick
-Builtin  rreset G:rreset rroll G:rroll rstack G:rstack rswap G:rswap rusage G:rusage s>ns G:s>ns same? G:same?
-Builtin  scriptdir G:scriptdir scriptfile G:scriptfile sem G:sem sem-post G:sem-post sem-rm G:sem-rm
-Builtin  sem-wait G:sem-wait sem-wait? G:sem-wait? sem>name G:sem>name semi-throw G:semi-throw set-wipe G:set-wipe
-Builtin  setenv G:setenv setjmp G:setjmp settings! G:settings! settings![] G:settings![] settings@ G:settings@
-Builtin  settings@? G:settings@? settings@[] G:settings@[] sh G:sh sh$ G:sh$ short-days G:short-days
-Builtin  short-months G:short-months sleep G:sleep sleep-msec G:sleep-msec sleep-until G:sleep-until
-Builtin  slog G:slog space G:space stack-check G:stack-check stack-size G:stack-size step G:step sthrow G:sthrow
-Builtin  string? G:string? struct: G:struct: swap G:swap tab-hook G:tab-hook tell-conflict G:tell-conflict
-Builtin  tempdir G:tempdir tempfilename G:tempfilename third G:third throw G:throw thrownull G:thrownull
-Builtin  times G:times tlog G:tlog tri G:tri true G:true tuck G:tuck type-check G:type-check typeassert G:typeassert
-Builtin  uid G:uid uname G:uname unlock G:unlock unpack G:unpack until G:until until! G:until! while G:while
-Builtin  while! G:while! with: G:with: word? G:word? words G:words words-like G:words-like words/ G:words/
-Builtin  xchg G:xchg xor G:xor >auth HTTP:>auth (curry) I:(curry) notimpl I:notimpl sh I:sh trace-word I:trace-word
-Builtin  call JSONRPC:call auth-string OAuth:auth-string gen-nonce OAuth:gen-nonce params OAuth:params
-Builtin  call SOAP:call ! a:! + a:+ - a:- / a:/ 2each a:2each 2map a:2map 2map+ a:2map+ 2map= a:2map=
-Builtin  <> a:<> = a:= @ a:@ @? a:@? _@ a:_@ all a:all any a:any bsearch a:bsearch centroid a:centroid
-Builtin  clear a:clear close a:close cmp a:cmp diff a:diff dot a:dot each a:each each! a:each! each-par a:each-par
-Builtin  each-slice a:each-slice exists? a:exists? filter a:filter filter-par a:filter-par generate a:generate
-Builtin  group a:group indexof a:indexof insert a:insert intersect a:intersect join a:join len a:len
-Builtin  map a:map map+ a:map+ map-par a:map-par map= a:map= maxlen a:maxlen mean a:mean mean&variance a:mean&variance
-Builtin  merge a:merge new a:new op! a:op! open a:open pigeon a:pigeon pivot a:pivot pop a:pop push a:push
+Builtin  process-args-help G:process-args-help prompt G:prompt public G:public putc G:putc puts G:puts
+Builtin  quote G:quote r! G:r! r> G:r> r@ G:r@ rad>deg G:rad>deg rand-jit G:rand-jit rand-jsf G:rand-jsf
+Builtin  rand-native G:rand-native rand-normal G:rand-normal rand-pcg G:rand-pcg rand-pcg-seed G:rand-pcg-seed
+Builtin  rand-range G:rand-range rand-select G:rand-select randbuf-pcg G:randbuf-pcg random G:random
+Builtin  rdrop G:rdrop recurse G:recurse recurse-stack G:recurse-stack ref@ G:ref@ reg! G:reg! reg@ G:reg@
+Builtin  regbin@ G:regbin@ remaining-args G:remaining-args repeat G:repeat requires G:requires reset G:reset
+Builtin  roll G:roll rop! G:rop! rot G:rot rpick G:rpick rreset G:rreset rroll G:rroll rstack G:rstack
+Builtin  rswap G:rswap rusage G:rusage s>ns G:s>ns same? G:same? scriptdir G:scriptdir scriptfile G:scriptfile
+Builtin  sem G:sem sem-post G:sem-post sem-rm G:sem-rm sem-wait G:sem-wait sem-wait? G:sem-wait? sem>name G:sem>name
+Builtin  semi-throw G:semi-throw set-wipe G:set-wipe setenv G:setenv setjmp G:setjmp settings! G:settings!
+Builtin  settings![] G:settings![] settings@ G:settings@ settings@? G:settings@? settings@[] G:settings@[]
+Builtin  sh G:sh sh$ G:sh$ short-days G:short-days short-months G:short-months sleep G:sleep sleep-msec G:sleep-msec
+Builtin  sleep-until G:sleep-until slog G:slog space G:space stack-check G:stack-check stack-size G:stack-size
+Builtin  step G:step sthrow G:sthrow string? G:string? struct: G:struct: swap G:swap tab-hook G:tab-hook
+Builtin  tell-conflict G:tell-conflict tempdir G:tempdir tempfilename G:tempfilename third G:third throw G:throw
+Builtin  thrownull G:thrownull times G:times tlog G:tlog toggle G:toggle tri G:tri true G:true tuck G:tuck
+Builtin  type-check G:type-check typeassert G:typeassert uid G:uid uname G:uname unlock G:unlock unpack G:unpack
+Builtin  until G:until until! G:until! while G:while while! G:while! with: G:with: word? G:word? words G:words
+Builtin  words-like G:words-like words/ G:words/ xchg G:xchg xor G:xor >auth HTTP:>auth (curry) I:(curry)
+Builtin  appopts I:appopts notimpl I:notimpl sh I:sh trace-word I:trace-word call JSONRPC:call auth-string OAuth:auth-string
+Builtin  gen-nonce OAuth:gen-nonce params OAuth:params call SOAP:call ! a:! + a:+ - a:- / a:/ 2each a:2each
+Builtin  2len a:2len 2map a:2map 2map+ a:2map+ 2map= a:2map= <> a:<> = a:= @ a:@ @? a:@? _@ a:_@ _len a:_len
+Builtin  all a:all any a:any bsearch a:bsearch centroid a:centroid clear a:clear close a:close cmp a:cmp
+Builtin  diff a:diff dot a:dot each a:each each! a:each! each-par a:each-par each-slice a:each-slice
+Builtin  exists? a:exists? filter a:filter filter-par a:filter-par generate a:generate group a:group
+Builtin  indexof a:indexof insert a:insert intersect a:intersect join a:join len a:len map a:map map+ a:map+
+Builtin  map-par a:map-par map= a:map= maxlen a:maxlen mean a:mean mean&variance a:mean&variance merge a:merge
+Builtin  new a:new op! a:op! open a:open pigeon a:pigeon pivot a:pivot pop a:pop push a:push push' a:push'
 Builtin  qsort a:qsort randeach a:randeach reduce a:reduce reduce+ a:reduce+ remove a:remove rev a:rev
 Builtin  rindexof a:rindexof shift a:shift shuffle a:shuffle slice a:slice slice+ a:slice+ slide a:slide
 Builtin  smear a:smear sort a:sort split a:split squash a:squash switch a:switch union a:union uniq a:uniq
 Builtin  unzip a:unzip x a:x x-each a:x-each xchg a:xchg y a:y zip a:zip 8thdir app:8thdir asset app:asset
 Builtin  atrun app:atrun atrun app:atrun atrun app:atrun basedir app:basedir basename app:basename config-file-name app:config-file-name
 Builtin  current app:current datadir app:datadir display-moved app:display-moved exename app:exename
-Builtin  localechanged app:localechanged lowmem app:lowmem main app:main name app:name oncrash app:oncrash
-Builtin  opts! app:opts! opts@ app:opts@ orientation app:orientation orientation! app:orientation! pid app:pid
-Builtin  post-main app:post-main pre-main app:pre-main privdir app:privdir raise app:raise read-config app:read-config
-Builtin  read-config-map app:read-config-map read-config-var app:read-config-var request-perm app:request-perm
-Builtin  restart app:restart resumed app:resumed signal app:signal standalone app:standalone subdir app:subdir
-Builtin  suspended app:suspended sysquit app:sysquit terminated app:terminated timeout app:timeout trap app:trap
-Builtin  dawn astro:dawn do-dawn astro:do-dawn do-dusk astro:do-dusk do-rise astro:do-rise dusk astro:dusk
-Builtin  latitude astro:latitude location! astro:location! longitude astro:longitude sunrise astro:sunrise
-Builtin  genkeys auth:genkeys secret auth:secret session-id auth:session-id session-key auth:session-key
+Builtin  localechanged app:localechanged lowmem app:lowmem main app:main name app:name onback app:onback
+Builtin  oncrash app:oncrash opts! app:opts! opts@ app:opts@ orientation app:orientation orientation! app:orientation!
+Builtin  pid app:pid post-main app:post-main pre-main app:pre-main privdir app:privdir raise app:raise
+Builtin  read-config app:read-config read-config-map app:read-config-map read-config-var app:read-config-var
+Builtin  request-perm app:request-perm restart app:restart resumed app:resumed signal app:signal standalone app:standalone
+Builtin  standalone! app:standalone! subdir app:subdir suspended app:suspended sysquit app:sysquit terminated app:terminated
+Builtin  ticks app:ticks timeout app:timeout trap app:trap dawn astro:dawn do-dawn astro:do-dawn do-dusk astro:do-dusk
+Builtin  do-rise astro:do-rise dusk astro:dusk latitude astro:latitude location! astro:location! longitude astro:longitude
+Builtin  sunrise astro:sunrise genkeys auth:genkeys secret auth:secret session-id auth:session-id session-key auth:session-key
 Builtin  validate auth:validate ! b:! + b:+ / b:/ 1+ b:1+ 1- b:1- <> b:<> = b:= >base16 b:>base16 >base32 b:>base32
-Builtin  >base64 b:>base64 >base85 b:>base85 >hex b:>hex >mpack b:>mpack @ b:@ append b:append base16> b:base16>
-Builtin  base32> b:base32> base64> b:base64> base85> b:base85> bit! b:bit! bit@ b:bit@ clear b:clear
-Builtin  compress b:compress conv b:conv each b:each each! b:each! each-slice b:each-slice expand b:expand
-Builtin  fill b:fill getb b:getb hex> b:hex> len b:len mem> b:mem> move b:move mpack-compat b:mpack-compat
+Builtin  >base64 b:>base64 >base85 b:>base85 >hex b:>hex >mpack b:>mpack @ b:@ ICONVLIBS b:ICONVLIBS
+Builtin  append b:append base16> b:base16> base32> b:base32> base64> b:base64> base85> b:base85> bit! b:bit!
+Builtin  bit@ b:bit@ clear b:clear compress b:compress conv b:conv each b:each each! b:each! each-slice b:each-slice
+Builtin  expand b:expand fill b:fill getb b:getb hex> b:hex> len b:len mem> b:mem> move b:move mpack-compat b:mpack-compat
 Builtin  mpack-date b:mpack-date mpack-ignore b:mpack-ignore mpack> b:mpack> n! b:n! n+ b:n+ n@ b:n@
 Builtin  new b:new op b:op op! b:op! pad b:pad rev b:rev search b:search shmem b:shmem slice b:slice
 Builtin  splice b:splice ungetb b:ungetb unpad b:unpad writable b:writable xor b:xor +block bc:+block
 Builtin  .blocks bc:.blocks add-block bc:add-block block-hash bc:block-hash block@ bc:block@ first-block bc:first-block
 Builtin  hash bc:hash last-block bc:last-block load bc:load new bc:new save bc:save set-sql bc:set-sql
 Builtin  validate bc:validate validate-block bc:validate-block add bloom:add filter bloom:filter in? bloom:in?
-Builtin  parse bson:parse accept bt:accept ch! bt:ch! ch@ bt:ch@ connect bt:connect disconnect bt:disconnect
+Builtin  parse bson:parse LIBS bt:LIBS accept bt:accept ch! bt:ch! ch@ bt:ch@ connect bt:connect disconnect bt:disconnect
 Builtin  init bt:init leconnect bt:leconnect lescan bt:lescan listen bt:listen on? bt:on? read bt:read
 Builtin  scan bt:scan service? bt:service? services? bt:services? write bt:write * c:* * c:* + c:+ + c:+
-Builtin  = c:= = c:= >ri c:>ri >ri c:>ri abs c:abs abs c:abs arg c:arg arg c:arg conj c:conj conj c:conj
-Builtin  im c:im n> c:n> new c:new new c:new re c:re (.hebrew) cal:(.hebrew) (.islamic) cal:(.islamic)
-Builtin  .hebrew cal:.hebrew .islamic cal:.islamic >hebepoch cal:>hebepoch >jdn cal:>jdn Adar cal:Adar
-Builtin  Adar2 cal:Adar2 Adar2 cal:Adar2 Av cal:Av Elul cal:Elul Heshvan cal:Heshvan Iyar cal:Iyar Kislev cal:Kislev
-Builtin  Nissan cal:Nissan Shevat cal:Shevat Sivan cal:Sivan Tammuz cal:Tammuz Tevet cal:Tevet Tishrei cal:Tishrei
-Builtin  days-in-hebrew-year cal:days-in-hebrew-year displaying-hebrew cal:displaying-hebrew fixed>hebrew cal:fixed>hebrew
-Builtin  fixed>islamic cal:fixed>islamic gershayim cal:gershayim hanukkah cal:hanukkah hebrew-epoch cal:hebrew-epoch
-Builtin  hebrew>fixed cal:hebrew>fixed hebrewtoday cal:hebrewtoday hmonth-name cal:hmonth-name islamic.epoch cal:islamic.epoch
-Builtin  islamic>fixed cal:islamic>fixed islamictoday cal:islamictoday jdn> cal:jdn> last-day-of-hebrew-month cal:last-day-of-hebrew-month
+Builtin  = c:= = c:= >polar c:>polar >polar c:>polar >ri c:>ri >ri c:>ri ^ c:^ ^ c:^ abs c:abs abs c:abs
+Builtin  arg c:arg arg c:arg conj c:conj conj c:conj im c:im im c:im log c:log log c:log n> c:n> n> c:n>
+Builtin  new c:new new c:new polar> c:polar> polar> c:polar> re c:re re c:re (.hebrew) cal:(.hebrew)
+Builtin  (.islamic) cal:(.islamic) .hebrew cal:.hebrew .islamic cal:.islamic >hebepoch cal:>hebepoch
+Builtin  >jdn cal:>jdn Adar cal:Adar Adar2 cal:Adar2 Av cal:Av Elul cal:Elul Heshvan cal:Heshvan Iyar cal:Iyar
+Builtin  Kislev cal:Kislev Nissan cal:Nissan Shevat cal:Shevat Sivan cal:Sivan Tammuz cal:Tammuz Tevet cal:Tevet
+Builtin  Tishrei cal:Tishrei days-in-hebrew-year cal:days-in-hebrew-year displaying-hebrew cal:displaying-hebrew
+Builtin  fixed>hebrew cal:fixed>hebrew fixed>islamic cal:fixed>islamic gershayim cal:gershayim hanukkah cal:hanukkah
+Builtin  hebrew-epoch cal:hebrew-epoch hebrew-leap-year? cal:hebrew-leap-year? hebrew>fixed cal:hebrew>fixed
+Builtin  hebrewtoday cal:hebrewtoday hmonth-name cal:hmonth-name islamic.epoch cal:islamic.epoch islamic>fixed cal:islamic>fixed
+Builtin  islamictoday cal:islamictoday jdn> cal:jdn> last-day-of-hebrew-month cal:last-day-of-hebrew-month
 Builtin  number>hebrew cal:number>hebrew omer cal:omer pesach cal:pesach purim cal:purim rosh-chodesh? cal:rosh-chodesh?
 Builtin  rosh-hashanah cal:rosh-hashanah shavuot cal:shavuot taanit-esther cal:taanit-esther tisha-beav cal:tisha-beav
-Builtin  yom-haatsmaut cal:yom-haatsmaut yom-kippur cal:yom-kippur >redir con:>redir accept con:accept
-Builtin  accept-nl con:accept-nl accept-pwd con:accept-pwd alert con:alert ansi? con:ansi? black con:black
-Builtin  blue con:blue clreol con:clreol cls con:cls ctrld-empty con:ctrld-empty cyan con:cyan down con:down
-Builtin  file>history con:file>history free con:free getxy con:getxy gotoxy con:gotoxy green con:green
-Builtin  history-handler con:history-handler history>file con:history>file key con:key key? con:key?
-Builtin  left con:left load-history con:load-history magenta con:magenta max-history con:max-history
-Builtin  onBlack con:onBlack onBlue con:onBlue onCyan con:onCyan onGreen con:onGreen onMagenta con:onMagenta
-Builtin  onRed con:onRed onWhite con:onWhite onYellow con:onYellow print con:print red con:red redir> con:redir>
-Builtin  redir? con:redir? right con:right save-history con:save-history size? con:size? up con:up white con:white
-Builtin  yellow con:yellow >aes128gcm cr:>aes128gcm >aes256gcm cr:>aes256gcm >cp cr:>cp >cpe cr:>cpe
-Builtin  >decrypt cr:>decrypt >edbox cr:>edbox >encrypt cr:>encrypt >nbuf cr:>nbuf >rsabox cr:>rsabox
-Builtin  >uuid cr:>uuid aad? cr:aad? aes128box-sig cr:aes128box-sig aes128gcm> cr:aes128gcm> aes256box-sig cr:aes256box-sig
-Builtin  aes256gcm> cr:aes256gcm> aesgcm cr:aesgcm blakehash cr:blakehash chacha20box-sig cr:chacha20box-sig
-Builtin  chachapoly cr:chachapoly cipher! cr:cipher! cipher@ cr:cipher@ ciphers cr:ciphers cp> cr:cp>
-Builtin  cpe> cr:cpe> decrypt cr:decrypt decrypt+ cr:decrypt+ decrypt> cr:decrypt> ebox-sig cr:ebox-sig
-Builtin  ecc-curves cr:ecc-curves ecc-genkey cr:ecc-genkey ecc-secret cr:ecc-secret ecc-sign cr:ecc-sign
-Builtin  ecc-verify cr:ecc-verify ed25519 cr:ed25519 ed25519-secret cr:ed25519-secret ed25519-sign cr:ed25519-sign
-Builtin  ed25519-verify cr:ed25519-verify edbox-sig cr:edbox-sig edbox> cr:edbox> encrypt cr:encrypt
-Builtin  encrypt+ cr:encrypt+ encrypt> cr:encrypt> ensurekey cr:ensurekey genkey cr:genkey hash cr:hash
-Builtin  hash! cr:hash! hash+ cr:hash+ hash>b cr:hash>b hash>s cr:hash>s hash@ cr:hash@ hashes cr:hashes
-Builtin  hmac cr:hmac hotp cr:hotp iv? cr:iv? pem-read cr:pem-read pem-write cr:pem-write pwd-valid? cr:pwd-valid?
-Builtin  pwd/ cr:pwd/ pwd>hash cr:pwd>hash rand cr:rand randbuf cr:randbuf randkey cr:randkey restore cr:restore
-Builtin  root-certs cr:root-certs rsa_decrypt cr:rsa_decrypt rsa_encrypt cr:rsa_encrypt rsa_sign cr:rsa_sign
-Builtin  rsa_verify cr:rsa_verify rsabox-sig cr:rsabox-sig rsabox> cr:rsabox> rsagenkey cr:rsagenkey
+Builtin  yom-haatsmaut cal:yom-haatsmaut yom-kippur cal:yom-kippur >hsva clr:>hsva complement clr:complement
+Builtin  dist clr:dist gradient clr:gradient hsva> clr:hsva> invert clr:invert nearest-name clr:nearest-name
+Builtin  parse clr:parse >redir con:>redir accept con:accept accept-nl con:accept-nl accept-pwd con:accept-pwd
+Builtin  alert con:alert ansi? con:ansi? black con:black blue con:blue clreol con:clreol cls con:cls
+Builtin  ctrld-empty con:ctrld-empty cyan con:cyan down con:down file>history con:file>history free con:free
+Builtin  getxy con:getxy gotoxy con:gotoxy green con:green history-handler con:history-handler history>file con:history>file
+Builtin  init con:init key con:key key? con:key? left con:left load-history con:load-history magenta con:magenta
+Builtin  max-history con:max-history onBlack con:onBlack onBlue con:onBlue onCyan con:onCyan onGreen con:onGreen
+Builtin  onMagenta con:onMagenta onRed con:onRed onWhite con:onWhite onYellow con:onYellow print con:print
+Builtin  red con:red redir> con:redir> redir? con:redir? right con:right save-history con:save-history
+Builtin  size? con:size? up con:up white con:white yellow con:yellow >aes128gcm cr:>aes128gcm >aes256gcm cr:>aes256gcm
+Builtin  >cp cr:>cp >cpe cr:>cpe >decrypt cr:>decrypt >edbox cr:>edbox >encrypt cr:>encrypt >nbuf cr:>nbuf
+Builtin  >rsabox cr:>rsabox >uuid cr:>uuid aad? cr:aad? aes128box-sig cr:aes128box-sig aes128gcm> cr:aes128gcm>
+Builtin  aes256box-sig cr:aes256box-sig aes256gcm> cr:aes256gcm> aesgcm cr:aesgcm blakehash cr:blakehash
+Builtin  chacha20box-sig cr:chacha20box-sig chachapoly cr:chachapoly cipher! cr:cipher! cipher@ cr:cipher@
+Builtin  ciphers cr:ciphers cp> cr:cp> cpe> cr:cpe> decrypt cr:decrypt decrypt+ cr:decrypt+ decrypt> cr:decrypt>
+Builtin  ebox-sig cr:ebox-sig ecc-curves cr:ecc-curves ecc-genkey cr:ecc-genkey ecc-secret cr:ecc-secret
+Builtin  ecc-sign cr:ecc-sign ecc-verify cr:ecc-verify ed25519 cr:ed25519 ed25519-secret cr:ed25519-secret
+Builtin  ed25519-sign cr:ed25519-sign ed25519-verify cr:ed25519-verify edbox-sig cr:edbox-sig edbox> cr:edbox>
+Builtin  encrypt cr:encrypt encrypt+ cr:encrypt+ encrypt> cr:encrypt> ensurekey cr:ensurekey genkey cr:genkey
+Builtin  hash cr:hash hash! cr:hash! hash+ cr:hash+ hash>b cr:hash>b hash>s cr:hash>s hash@ cr:hash@
+Builtin  hashes cr:hashes hmac cr:hmac hotp cr:hotp iv? cr:iv? pem-read cr:pem-read pem-write cr:pem-write
+Builtin  pwd-valid? cr:pwd-valid? pwd/ cr:pwd/ pwd>hash cr:pwd>hash rand cr:rand randbuf cr:randbuf
+Builtin  randkey cr:randkey restore cr:restore root-certs cr:root-certs rsa_decrypt cr:rsa_decrypt rsa_encrypt cr:rsa_encrypt
+Builtin  rsa_sign cr:rsa_sign rsa_verify cr:rsa_verify rsabox-sig cr:rsabox-sig rsabox> cr:rsabox> rsagenkey cr:rsagenkey
 Builtin  save cr:save sbox-sig cr:sbox-sig sha1-hmac cr:sha1-hmac shard cr:shard tag? cr:tag? totp cr:totp
 Builtin  totp-epoch cr:totp-epoch totp-time-step cr:totp-time-step unshard cr:unshard uuid cr:uuid uuid> cr:uuid>
-Builtin  validate-pgp-sig cr:validate-pgp-sig validate-pwd cr:validate-pwd + d:+ +day d:+day +hour d:+hour
-Builtin  +min d:+min +msec d:+msec - d:- .time d:.time / d:/ = d:= >fixed d:>fixed >hmds d:>hmds >hmds: d:>hmds:
-Builtin  >msec d:>msec >unix d:>unix >ymd d:>ymd ?= d:?= Fri d:Fri Mon d:Mon Sat d:Sat Sun d:Sun Thu d:Thu
-Builtin  Tue d:Tue Wed d:Wed adjust-dst d:adjust-dst alarm d:alarm approx! d:approx! approx? d:approx?
-Builtin  approximates! d:approximates! between d:between cmp d:cmp d. d:d. default-now d:default-now
+Builtin  validate-pgp-sig cr:validate-pgp-sig validate-pwd cr:validate-pwd (.time) d:(.time) + d:+ +day d:+day
+Builtin  +hour d:+hour +min d:+min +msec d:+msec - d:- .time d:.time / d:/ = d:= >fixed d:>fixed >hmds d:>hmds
+Builtin  >hmds: d:>hmds: >msec d:>msec >unix d:>unix >ymd d:>ymd ?= d:?= Fri d:Fri Mon d:Mon Sat d:Sat
+Builtin  Sun d:Sun Thu d:Thu Tue d:Tue Wed d:Wed adjust-dst d:adjust-dst alarm d:alarm approx! d:approx!
+Builtin  approx? d:approx? approximates! d:approximates! between d:between cmp d:cmp d. d:d. default-now d:default-now
 Builtin  doy d:doy dst-ofs d:dst-ofs dst? d:dst? dstinfo d:dstinfo dstquery d:dstquery dstzones? d:dstzones?
 Builtin  elapsed-timer d:elapsed-timer elapsed-timer-hmds d:elapsed-timer-hmds elapsed-timer-msec d:elapsed-timer-msec
 Builtin  elapsed-timer-seconds d:elapsed-timer-seconds first-dow d:first-dow fixed> d:fixed> fixed>dow d:fixed>dow
 Builtin  format d:format join d:join last-dow d:last-dow last-month d:last-month last-week d:last-week
-Builtin  last-year d:last-year msec d:msec msec> d:msec> new d:new next-dow d:next-dow next-month d:next-month
-Builtin  next-week d:next-week next-year d:next-year parse d:parse parse-approx d:parse-approx parse-range d:parse-range
-Builtin  prev-dow d:prev-dow rfc5322 d:rfc5322 start-timer d:start-timer ticks d:ticks ticks/sec d:ticks/sec
-Builtin  timer d:timer timer-ctrl d:timer-ctrl tzadjust d:tzadjust unix> d:unix> unknown d:unknown unknown? d:unknown?
-Builtin  updatetz d:updatetz year@ d:year@ ymd d:ymd ymd> d:ymd> add-func db:add-func aes! db:aes! again? db:again?
+Builtin  last-year d:last-year leap? d:leap? mdays d:mdays msec d:msec msec> d:msec> new d:new next-dow d:next-dow
+Builtin  next-month d:next-month next-week d:next-week next-year d:next-year parse d:parse parse-approx d:parse-approx
+Builtin  parse-range d:parse-range prev-dow d:prev-dow rfc5322 d:rfc5322 start-timer d:start-timer ticks d:ticks
+Builtin  ticks/sec d:ticks/sec timer d:timer timer-ctrl d:timer-ctrl tzadjust d:tzadjust unix> d:unix>
+Builtin  unknown d:unknown unknown? d:unknown? updatetz d:updatetz year@ d:year@ ymd d:ymd ymd> d:ymd>
+Builtin  MYSQLLIB db:MYSQLLIB ODBCLIB db:ODBCLIB add-func db:add-func aes! db:aes! again? db:again?
 Builtin  begin db:begin bind db:bind bind-exec db:bind-exec bind-exec{} db:bind-exec{} close db:close
 Builtin  col db:col col{} db:col{} commit db:commit db db:db dbpush db:dbpush disuse db:disuse each db:each
 Builtin  err-handler db:err-handler exec db:exec exec-cb db:exec-cb exec-name db:exec-name exec{} db:exec{}
 Builtin  get db:get get-sub db:get-sub key db:key kind? db:kind? last-rowid db:last-rowid mysql? db:mysql?
 Builtin  odbc? db:odbc? open db:open open? db:open? prep-name db:prep-name prepare db:prepare query db:query
 Builtin  query-all db:query-all rekey db:rekey rollback db:rollback set db:set set-sub db:set-sub sql@ db:sql@
-Builtin  sql[] db:sql[] sql[np] db:sql[np] sql{np} db:sql{np} sql{} db:sql{} use db:use zip db:zip bp dbg:bp
-Builtin  bt dbg:bt except-task@ dbg:except-task@ go dbg:go line-info dbg:line-info prompt dbg:prompt
-Builtin  stop dbg:stop trace dbg:trace trace-enter dbg:trace-enter trace-leave dbg:trace-leave / f:/
-Builtin  >posix f:>posix abspath f:abspath absrel f:absrel append f:append associate f:associate atime f:atime
-Builtin  autodel f:autodel canwrite? f:canwrite? chmod f:chmod close f:close copy f:copy copydir f:copydir
-Builtin  create f:create ctime f:ctime dir? f:dir? dname f:dname eachbuf f:eachbuf eachline f:eachline
-Builtin  enssep f:enssep eof? f:eof? exec f:exec exists? f:exists? flush f:flush fname f:fname getb f:getb
-Builtin  getc f:getc getline f:getline getmod f:getmod glob f:glob glob-links f:glob-links glob-nocase f:glob-nocase
+Builtin  sql[] db:sql[] sql[np] db:sql[np] sql{np} db:sql{np} sql{} db:sql{} use db:use zip db:zip .state dbg:.state
+Builtin  bp dbg:bp bt dbg:bt except-task@ dbg:except-task@ go dbg:go prompt dbg:prompt see dbg:see stop dbg:stop
+Builtin  trace dbg:trace trace-enter dbg:trace-enter trace-leave dbg:trace-leave pso ds:pso / f:/ >posix f:>posix
+Builtin  abspath f:abspath absrel f:absrel append f:append associate f:associate atime f:atime autodel f:autodel
+Builtin  canwrite? f:canwrite? chmod f:chmod close f:close copy f:copy copydir f:copydir create f:create
+Builtin  ctime f:ctime dir? f:dir? dname f:dname eachbuf f:eachbuf eachline f:eachline enssep f:enssep
+Builtin  eof? f:eof? exec f:exec exists? f:exists? flush f:flush fname f:fname getb f:getb getc f:getc
+Builtin  getline f:getline getmod f:getmod glob f:glob glob-links f:glob-links glob-nocase f:glob-nocase
 Builtin  gunz f:gunz homedir f:homedir homedir! f:homedir! include f:include ioctl f:ioctl join f:join
 Builtin  launch f:launch link f:link link> f:link> link? f:link? lock f:lock mkdir f:mkdir mmap f:mmap
 Builtin  mmap-range f:mmap-range mmap-range? f:mmap-range? mtime f:mtime mv f:mv name@ f:name@ open f:open
@@ -209,9 +214,9 @@ Builtin  ungetc f:ungetc unzip f:unzip unzip-entry f:unzip-entry watch f:watch w
 Builtin  zip+ f:zip+ zip@ f:zip@ zipentry f:zipentry zipnew f:zipnew zipopen f:zipopen zipsave f:zipsave
 Builtin  atlas! font:atlas! atlas@ font:atlas@ default-size font:default-size default-size@ font:default-size@
 Builtin  info font:info ls font:ls measure font:measure new font:new oversample font:oversample pixels font:pixels
-Builtin  pixels? font:pixels? system font:system system font:system distance geo:distance km/deg-lat geo:km/deg-lat
-Builtin  km/deg-lon geo:km/deg-lon nearest geo:nearest +edge gr:+edge +edge+w gr:+edge+w +node gr:+node
-Builtin  connect gr:connect edges gr:edges edges! gr:edges! m! gr:m! m@ gr:m@ neighbors gr:neighbors
+Builtin  pixels? font:pixels? system font:system system font:system media? g:media? distance geo:distance
+Builtin  km/deg-lat geo:km/deg-lat km/deg-lon geo:km/deg-lon nearest geo:nearest +edge gr:+edge +edge+w gr:+edge+w
+Builtin  +node gr:+node connect gr:connect edges gr:edges edges! gr:edges! m! gr:m! m@ gr:m@ neighbors gr:neighbors
 Builtin  new gr:new node-edges gr:node-edges nodes gr:nodes traverse gr:traverse weight! gr:weight!
 Builtin  + h:+ clear h:clear cmp! h:cmp! len h:len max! h:max! new h:new peek h:peek pop h:pop push h:push
 Builtin  unique h:unique parse html:parse arm? hw:arm? camera hw:camera camera-img hw:camera-img camera-limits hw:camera-limits
@@ -219,163 +224,171 @@ Builtin  camera? hw:camera? cpu? hw:cpu? device? hw:device? displays? hw:display
 Builtin  finger-match hw:finger-match finger-support hw:finger-support gpio hw:gpio gpio! hw:gpio! gpio-mmap hw:gpio-mmap
 Builtin  gpio@ hw:gpio@ i2c hw:i2c i2c! hw:i2c! i2c!reg hw:i2c!reg i2c@ hw:i2c@ i2c@reg hw:i2c@reg isround? hw:isround?
 Builtin  iswatch? hw:iswatch? mac? hw:mac? mem? hw:mem? model? hw:model? poll hw:poll sensor hw:sensor
-Builtin  start hw:start stop hw:stop uid? hw:uid? fetch-full imap:fetch-full fetch-uid-mail imap:fetch-uid-mail
+Builtin  start hw:start stop hw:stop touch? hw:touch? uid? hw:uid? fetch-full imap:fetch-full fetch-uid-mail imap:fetch-uid-mail
 Builtin  login imap:login logout imap:logout new imap:new search imap:search select-inbox imap:select-inbox
 Builtin  >file img:>file >fmt img:>fmt copy img:copy crop img:crop data img:data desat img:desat draw img:draw
 Builtin  draw-sub img:draw-sub fill img:fill fillrect img:fillrect filter img:filter flip img:flip from-svg img:from-svg
 Builtin  line img:line new img:new pikchr img:pikchr pix! img:pix! pix@ img:pix@ qr-gen img:qr-gen qr-parse img:qr-parse
 Builtin  rect img:rect rotate img:rotate scale img:scale scroll img:scroll size img:size countries iso:countries
-Builtin  languages iso:languages utils/help library:utils/help find loc:find sort loc:sort ! m:! !? m:!?
-Builtin  + m:+ +? m:+? - m:- <> m:<> = m:= >arr m:>arr @ m:@ @? m:@? _! m:_! _@ m:_@ alias m:alias arr> m:arr>
-Builtin  bitmap m:bitmap clear m:clear data m:data each m:each exists? m:exists? filter m:filter ic m:ic
-Builtin  iter m:iter iter-all m:iter-all keys m:keys len m:len map m:map merge m:merge new m:new op! m:op!
-Builtin  open m:open slice m:slice vals m:vals xchg m:xchg zip m:zip ! mat:! * mat:* + mat:+ = mat:=
-Builtin  @ mat:@ affine mat:affine col mat:col data mat:data det mat:det dim? mat:dim? get-n mat:get-n
-Builtin  ident mat:ident inv mat:inv m. mat:m. minor mat:minor n* mat:n* new mat:new new-minor mat:new-minor
-Builtin  rotate mat:rotate row mat:row same-size? mat:same-size? scale mat:scale shear mat:shear trans mat:trans
-Builtin  translate mat:translate xform mat:xform 2console md:2console 2html md:2html 2nk md:2nk color meta:color
-Builtin  console meta:console gui meta:gui meta meta:meta ! n:! * n:* */ n:*/ + n:+ +! n:+! - n:- / n:/
-Builtin  /mod n:/mod 1+ n:1+ 1- n:1- < n:< = n:= > n:> >bool n:>bool BIGE n:BIGE BIGPI n:BIGPI E n:E
-Builtin  PI n:PI ^ n:^ _mod n:_mod abs n:abs acos n:acos acos n:acos andor n:andor asin n:asin asin n:asin
-Builtin  atan n:atan atan n:atan atan2 n:atan2 band n:band between n:between bfloat n:bfloat bic n:bic
+Builtin  languages iso:languages utils/help library:utils/help bearing loc:bearing find loc:find sort loc:sort
+Builtin  ! m:! !? m:!? + m:+ +? m:+? - m:- <> m:<> = m:= >arr m:>arr @ m:@ @? m:@? _! m:_! _@ m:_@ _@? m:_@?
+Builtin  alias m:alias arr> m:arr> bitmap m:bitmap clear m:clear data m:data each m:each exists? m:exists?
+Builtin  filter m:filter ic m:ic iter m:iter iter-all m:iter-all keys m:keys len m:len map m:map merge m:merge
+Builtin  new m:new op! m:op! open m:open slice m:slice vals m:vals xchg m:xchg zip m:zip ! mat:! * mat:*
+Builtin  + mat:+ = mat:= @ mat:@ affine mat:affine col mat:col data mat:data det mat:det dim? mat:dim?
+Builtin  get-n mat:get-n ident mat:ident inv mat:inv m. mat:m. minor mat:minor n* mat:n* new mat:new
+Builtin  new-minor mat:new-minor rotate mat:rotate row mat:row same-size? mat:same-size? scale mat:scale
+Builtin  shear mat:shear trans mat:trans translate mat:translate xform mat:xform 2console md:2console
+Builtin  2html md:2html 2nk md:2nk color meta:color console meta:console gui meta:gui meta meta:meta
+Builtin  ! n:! * n:* */ n:*/ + n:+ +! n:+! - n:- / n:/ /mod n:/mod 1+ n:1+ 1- n:1- < n:< = n:= > n:>
+Builtin  >bool n:>bool BIGE n:BIGE BIGPI n:BIGPI E n:E PI n:PI ^ n:^ _mod n:_mod abs n:abs acos n:acos
+Builtin  acosd n:acosd acosh n:acosh andor n:andor asin n:asin asind n:asind asinh n:asinh atan n:atan
+Builtin  atan2 n:atan2 atand n:atand atanh n:atanh band n:band between n:between bfloat n:bfloat bic n:bic
 Builtin  bint n:bint binv n:binv bnot n:bnot bor n:bor bxor n:bxor cast n:cast ceil n:ceil clamp n:clamp
-Builtin  cmp n:cmp comb n:comb cos n:cos cosd n:cosd emod n:emod exp n:exp expm1 n:expm1 expmod n:expmod
-Builtin  float n:float floor n:floor fmod n:fmod frac n:frac gcd n:gcd int n:int invmod n:invmod kind? n:kind?
-Builtin  lcm n:lcm lerp n:lerp ln n:ln ln1p n:ln1p lnerp n:lnerp max n:max median n:median min n:min
-Builtin  mod n:mod neg n:neg odd? n:odd? perm n:perm prime? n:prime? quantize n:quantize quantize! n:quantize!
-Builtin  r+ n:r+ range n:range rot32l n:rot32l rot32r n:rot32r round n:round round2 n:round2 rounding n:rounding
-Builtin  running-variance n:running-variance running-variance-finalize n:running-variance-finalize sgn n:sgn
-Builtin  shl n:shl shr n:shr sin n:sin sind n:sind sqr n:sqr sqrt n:sqrt tan n:tan tand n:tand trunc n:trunc
-Builtin  ~= n:~= ! net:! !? net:!? - net:- >base64url net:>base64url >url net:>url @ net:@ @? net:@?
-Builtin  CGI net:CGI DGRAM net:DGRAM INET4 net:INET4 INET6 net:INET6 PROTO_TCP net:PROTO_TCP PROTO_UDP net:PROTO_UDP
-Builtin  REMOTE_IP net:REMOTE_IP STREAM net:STREAM accept net:accept active? net:active? addrinfo>o net:addrinfo>o
-Builtin  again? net:again? alloc-and-read net:alloc-and-read alloc-buf net:alloc-buf base64url> net:base64url>
-Builtin  bind net:bind cgi-get net:cgi-get cgi-http-header net:cgi-http-header cgi-init net:cgi-init
-Builtin  cgi-init-stunnel net:cgi-init-stunnel cgi-out net:cgi-out close net:close closed? net:closed?
-Builtin  connect net:connect curnet net:curnet debug? net:debug? delete net:delete get net:get getaddrinfo net:getaddrinfo
-Builtin  getpeername net:getpeername head net:head ifaces? net:ifaces? ipv6? net:ipv6? listen net:listen
-Builtin  map>url net:map>url mime-type net:mime-type net-socket net:net-socket opts net:opts port-is-ssl? net:port-is-ssl?
+Builtin  cmp n:cmp comb n:comb cos n:cos cosd n:cosd cosh n:cosh emod n:emod erf n:erf erfc n:erfc exp n:exp
+Builtin  expm1 n:expm1 expmod n:expmod float n:float floor n:floor fmod n:fmod frac n:frac gcd n:gcd
+Builtin  int n:int invmod n:invmod kind? n:kind? lcm n:lcm lerp n:lerp ln n:ln ln1p n:ln1p lnerp n:lnerp
+Builtin  logistic n:logistic max n:max median n:median min n:min mod n:mod neg n:neg odd? n:odd? perm n:perm
+Builtin  prime? n:prime? quantize n:quantize quantize! n:quantize! r+ n:r+ range n:range rot32l n:rot32l
+Builtin  rot32r n:rot32r round n:round round2 n:round2 rounding n:rounding running-variance n:running-variance
+Builtin  running-variance-finalize n:running-variance-finalize sgn n:sgn shl n:shl shr n:shr sin n:sin
+Builtin  sincos n:sincos sind n:sind sinh n:sinh sqr n:sqr sqrt n:sqrt tan n:tan tand n:tand tanh n:tanh
+Builtin  trunc n:trunc ~= n:~= ! net:! !? net:!? - net:- >base64url net:>base64url >url net:>url @ net:@
+Builtin  @? net:@? CGI net:CGI DGRAM net:DGRAM INET4 net:INET4 INET6 net:INET6 PROTO_TCP net:PROTO_TCP
+Builtin  PROTO_UDP net:PROTO_UDP REMOTE_IP net:REMOTE_IP REMOTE_IP net:REMOTE_IP STREAM net:STREAM accept net:accept
+Builtin  active? net:active? addrinfo>o net:addrinfo>o again? net:again? alloc-and-read net:alloc-and-read
+Builtin  alloc-buf net:alloc-buf avail? net:avail? base64url> net:base64url> bind net:bind cgi-get net:cgi-get
+Builtin  cgi-http-header net:cgi-http-header cgi-init net:cgi-init cgi-init-stunnel net:cgi-init-stunnel
+Builtin  cgi-out net:cgi-out close net:close closed? net:closed? connect net:connect curnet net:curnet
+Builtin  debug? net:debug? delete net:delete dns net:dns get net:get getaddrinfo net:getaddrinfo getpeername net:getpeername
+Builtin  head net:head ifaces? net:ifaces? ipv6? net:ipv6? launch net:launch listen net:listen map>url net:map>url
+Builtin  mime-type net:mime-type net-socket net:net-socket opts net:opts port-is-ssl? net:port-is-ssl?
 Builtin  post net:post proxy! net:proxy! put net:put read net:read read-all net:read-all read-buf net:read-buf
 Builtin  recvfrom net:recvfrom s>url net:s>url sendto net:sendto server net:server setsockopt net:setsockopt
 Builtin  socket net:socket tcp-connect net:tcp-connect tlserr net:tlserr tlshello net:tlshello udp-connect net:udp-connect
-Builtin  url> net:url> user-agent net:user-agent vpncheck net:vpncheck wait net:wait webserver net:webserver
-Builtin  write net:write (begin) nk:(begin) (chart-begin) nk:(chart-begin) (chart-begin-colored) nk:(chart-begin-colored)
-Builtin  (chart-end) nk:(chart-end) (end) nk:(end) (group-begin) nk:(group-begin) (group-end) nk:(group-end)
-Builtin  (property) nk:(property) >img nk:>img addfont nk:addfont anti-alias nk:anti-alias any-clicked? nk:any-clicked?
-Builtin  bounds nk:bounds bounds! nk:bounds! button nk:button button-color nk:button-color button-label nk:button-label
-Builtin  button-set-behavior nk:button-set-behavior button-symbol nk:button-symbol button-symbol-label nk:button-symbol-label
-Builtin  center-rect nk:center-rect chart-add-slot nk:chart-add-slot chart-add-slot-colored nk:chart-add-slot-colored
-Builtin  chart-push nk:chart-push chart-push-slot nk:chart-push-slot checkbox nk:checkbox circle nk:circle
-Builtin  clicked? nk:clicked? close-this! nk:close-this! close-this? nk:close-this? close? nk:close?
-Builtin  color-picker nk:color-picker combo nk:combo combo-begin-color nk:combo-begin-color combo-begin-label nk:combo-begin-label
-Builtin  combo-cb nk:combo-cb combo-end nk:combo-end contextual-begin nk:contextual-begin contextual-close nk:contextual-close
+Builtin  url> net:url> user-agent net:user-agent valid-email? net:valid-email? vpncheck net:vpncheck
+Builtin  wait net:wait webserver net:webserver write net:write (begin) nk:(begin) (chart-begin) nk:(chart-begin)
+Builtin  (chart-begin-colored) nk:(chart-begin-colored) (chart-end) nk:(chart-end) (end) nk:(end) (group-begin) nk:(group-begin)
+Builtin  (group-end) nk:(group-end) (property) nk:(property) >img nk:>img GLLIBS nk:GLLIBS GLXLIBS nk:GLXLIBS
+Builtin  addfont nk:addfont anti-alias nk:anti-alias any-clicked? nk:any-clicked? bounds nk:bounds bounds! nk:bounds!
+Builtin  button nk:button button-color nk:button-color button-label nk:button-label button-set-behavior nk:button-set-behavior
+Builtin  button-symbol nk:button-symbol button-symbol-label nk:button-symbol-label chart-add-slot nk:chart-add-slot
+Builtin  chart-add-slot-colored nk:chart-add-slot-colored chart-push nk:chart-push chart-push-slot nk:chart-push-slot
+Builtin  checkbox nk:checkbox circle nk:circle clicked? nk:clicked? close-this! nk:close-this! close-this? nk:close-this?
+Builtin  close? nk:close? color-chooser nk:color-chooser color-picker nk:color-picker combo nk:combo
+Builtin  combo-begin-color nk:combo-begin-color combo-begin-label nk:combo-begin-label combo-cb nk:combo-cb
+Builtin  combo-end nk:combo-end contextual-begin nk:contextual-begin contextual-close nk:contextual-close
 Builtin  contextual-end nk:contextual-end contextual-item-image-text nk:contextual-item-image-text contextual-item-symbol-text nk:contextual-item-symbol-text
 Builtin  contextual-item-text nk:contextual-item-text cp! nk:cp! cp@ nk:cp@ curpos nk:curpos cursor-load nk:cursor-load
 Builtin  cursor-set nk:cursor-set cursor-show nk:cursor-show display-info nk:display-info display@ nk:display@
 Builtin  do nk:do down? nk:down? draw-image nk:draw-image draw-image-at nk:draw-image-at draw-image-centered nk:draw-image-centered
 Builtin  draw-sub-image nk:draw-sub-image draw-text nk:draw-text draw-text-centered nk:draw-text-centered
-Builtin  draw-text-high nk:draw-text-high draw-text-wrap nk:draw-text-wrap drivers nk:drivers edit-focus nk:edit-focus
-Builtin  edit-string nk:edit-string event nk:event event-boost nk:event-boost event-msec nk:event-msec
-Builtin  event-wait nk:event-wait event? nk:event? fill-arc nk:fill-arc fill-circle nk:fill-circle fill-color nk:fill-color
-Builtin  fill-poly nk:fill-poly fill-rect nk:fill-rect fill-rect-color nk:fill-rect-color fill-triangle nk:fill-triangle
-Builtin  finger nk:finger flags! nk:flags! flags@ nk:flags@ flash nk:flash fullscreen nk:fullscreen
-Builtin  gesture nk:gesture get nk:get get-row-height nk:get-row-height getfont nk:getfont getmap nk:getmap
-Builtin  getmap! nk:getmap! gl? nk:gl? grid nk:grid grid-push nk:grid-push group-scroll-ofs nk:group-scroll-ofs
-Builtin  group-scroll-ofs! nk:group-scroll-ofs! hovered? nk:hovered? hrule nk:hrule image nk:image init nk:init
-Builtin  input-button nk:input-button input-key nk:input-key input-motion nk:input-motion input-scroll nk:input-scroll
-Builtin  input-string nk:input-string key-down? nk:key-down? key-pressed? nk:key-pressed? key-released? nk:key-released?
-Builtin  label nk:label label-colored nk:label-colored label-wrap nk:label-wrap label-wrap-colored nk:label-wrap-colored
-Builtin  layout-bounds nk:layout-bounds layout-grid-begin nk:layout-grid-begin layout-grid-end nk:layout-grid-end
-Builtin  layout-push-dynamic nk:layout-push-dynamic layout-push-static nk:layout-push-static layout-push-variable nk:layout-push-variable
-Builtin  layout-ratio-from-pixel nk:layout-ratio-from-pixel layout-reset-row-height nk:layout-reset-row-height
-Builtin  layout-row nk:layout-row layout-row-begin nk:layout-row-begin layout-row-dynamic nk:layout-row-dynamic
-Builtin  layout-row-end nk:layout-row-end layout-row-height nk:layout-row-height layout-row-push nk:layout-row-push
-Builtin  layout-row-static nk:layout-row-static layout-row-template-begin nk:layout-row-template-begin
+Builtin  draw-text-high nk:draw-text-high draw-text-wrap nk:draw-text-wrap driver nk:driver drivers nk:drivers
+Builtin  dropped nk:dropped dropping nk:dropping edit-focus nk:edit-focus edit-string nk:edit-string
+Builtin  event nk:event event-boost nk:event-boost event-msec nk:event-msec event-wait nk:event-wait
+Builtin  event? nk:event? fill-arc nk:fill-arc fill-circle nk:fill-circle fill-color nk:fill-color fill-poly nk:fill-poly
+Builtin  fill-rect nk:fill-rect fill-rect-color nk:fill-rect-color fill-triangle nk:fill-triangle finger nk:finger
+Builtin  flags! nk:flags! flags@ nk:flags@ flash nk:flash fullscreen nk:fullscreen gesture nk:gesture
+Builtin  get nk:get get-row-height nk:get-row-height getfont nk:getfont getmap nk:getmap getmap! nk:getmap!
+Builtin  gl? nk:gl? grid nk:grid grid-peek nk:grid-peek grid-push nk:grid-push group-scroll-ofs nk:group-scroll-ofs
+Builtin  group-scroll-ofs! nk:group-scroll-ofs! hints nk:hints hovered? nk:hovered? hrule nk:hrule image nk:image
+Builtin  init nk:init input-button nk:input-button input-key nk:input-key input-motion nk:input-motion
+Builtin  input-scroll nk:input-scroll input-string nk:input-string key-down? nk:key-down? key-pressed? nk:key-pressed?
+Builtin  key-released? nk:key-released? knob nk:knob label nk:label label-colored nk:label-colored label-wrap nk:label-wrap
+Builtin  label-wrap-colored nk:label-wrap-colored layout-bounds nk:layout-bounds layout-grid-begin nk:layout-grid-begin
+Builtin  layout-grid-end nk:layout-grid-end layout-push-dynamic nk:layout-push-dynamic layout-push-static nk:layout-push-static
+Builtin  layout-push-variable nk:layout-push-variable layout-ratio-from-pixel nk:layout-ratio-from-pixel
+Builtin  layout-reset-row-height nk:layout-reset-row-height layout-row nk:layout-row layout-row-begin nk:layout-row-begin
+Builtin  layout-row-dynamic nk:layout-row-dynamic layout-row-end nk:layout-row-end layout-row-height nk:layout-row-height
+Builtin  layout-row-push nk:layout-row-push layout-row-static nk:layout-row-static layout-row-template-begin nk:layout-row-template-begin
 Builtin  layout-row-template-end nk:layout-row-template-end layout-space-begin nk:layout-space-begin
 Builtin  layout-space-end nk:layout-space-end layout-space-push nk:layout-space-push layout-widget-bounds nk:layout-widget-bounds
 Builtin  line-rel nk:line-rel line-to nk:line-to list-begin nk:list-begin list-end nk:list-end list-new nk:list-new
-Builtin  list-range nk:list-range m! nk:m! m@ nk:m@ make-style nk:make-style max-vertex-element nk:max-vertex-element
+Builtin  list-ofs nk:list-ofs list-range nk:list-range m! nk:m! m@ nk:m@ make-style nk:make-style max-vertex-element nk:max-vertex-element
 Builtin  maximize nk:maximize measure nk:measure measure-font nk:measure-font menu-begin nk:menu-begin
 Builtin  menu-close nk:menu-close menu-end nk:menu-end menu-item-image nk:menu-item-image menu-item-label nk:menu-item-label
 Builtin  menu-item-symbol nk:menu-item-symbol menubar-begin nk:menubar-begin menubar-end nk:menubar-end
 Builtin  minimize nk:minimize mouse-pos nk:mouse-pos move-back nk:move-back move-rel nk:move-rel move-to nk:move-to
 Builtin  msg nk:msg msgdlg nk:msgdlg ontop nk:ontop option nk:option pen-color nk:pen-color pen-width nk:pen-width
-Builtin  plot nk:plot plot-fn nk:plot-fn pop-font nk:pop-font popup-begin nk:popup-begin popup-close nk:popup-close
-Builtin  popup-end nk:popup-end popup-scroll-ofs nk:popup-scroll-ofs popup-scroll-ofs! nk:popup-scroll-ofs!
-Builtin  progress nk:progress prop-int nk:prop-int pt-in? nk:pt-in? pt-open nk:pt-open pt>local nk:pt>local
-Builtin  pt>rect nk:pt>rect pt>screen nk:pt>screen pt>x nk:pt>x pts>rect nk:pts>rect push-font nk:push-font
-Builtin  raise nk:raise rect! nk:rect! rect-center nk:rect-center rect-intersect nk:rect-intersect rect-ofs nk:rect-ofs
-Builtin  rect-open nk:rect-open rect-pad nk:rect-pad rect-rel nk:rect-rel rect-shrink nk:rect-shrink
-Builtin  rect-to nk:rect-to rect-union nk:rect-union rect/high nk:rect/high rect/wide nk:rect/wide rect= nk:rect=
-Builtin  rect>local nk:rect>local rect>pos nk:rect>pos rect>pts nk:rect>pts rect>pts4 nk:rect>pts4 rect>screen nk:rect>screen
-Builtin  rect>size nk:rect>size rect>x nk:rect>x rect@ nk:rect@ released? nk:released? render nk:render
-Builtin  render-timed nk:render-timed restore nk:restore rotate nk:rotate rotate-rel nk:rotate-rel save nk:save
-Builtin  scale nk:scale scancode? nk:scancode? screen-saver nk:screen-saver screen-size nk:screen-size
-Builtin  screen-win-close nk:screen-win-close selectable nk:selectable set nk:set set-font nk:set-font
-Builtin  set-num-vertices nk:set-num-vertices set-radius nk:set-radius setpos nk:setpos setwin nk:setwin
-Builtin  show nk:show slider nk:slider slider-int nk:slider-int space nk:space spacing nk:spacing stroke-arc nk:stroke-arc
-Builtin  stroke-circle nk:stroke-circle stroke-curve nk:stroke-curve stroke-line nk:stroke-line stroke-polygon nk:stroke-polygon
-Builtin  stroke-polyline nk:stroke-polyline stroke-rect nk:stroke-rect stroke-tri nk:stroke-tri style-from-table nk:style-from-table
-Builtin  swipe nk:swipe swipe-dir-threshold nk:swipe-dir-threshold swipe-threshold nk:swipe-threshold
-Builtin  text nk:text text-align nk:text-align text-font nk:text-font text-pad nk:text-pad text? nk:text?
-Builtin  timer-delay nk:timer-delay timer? nk:timer? tooltip nk:tooltip translate nk:translate tree-pop nk:tree-pop
-Builtin  tree-state-push nk:tree-state-push use-style nk:use-style vsync nk:vsync widget nk:widget widget-bounds nk:widget-bounds
+Builtin  pix! nk:pix! plot nk:plot plot-fn nk:plot-fn polygon nk:polygon pop-font nk:pop-font popup-begin nk:popup-begin
+Builtin  popup-close nk:popup-close popup-end nk:popup-end popup-scroll-ofs nk:popup-scroll-ofs popup-scroll-ofs! nk:popup-scroll-ofs!
+Builtin  progress nk:progress prop-int nk:prop-int pt-in? nk:pt-in? pt>local nk:pt>local pt>screen nk:pt>screen
+Builtin  push-font nk:push-font raise nk:raise rect-rel nk:rect-rel rect-to nk:rect-to rect>local nk:rect>local
+Builtin  rect>screen nk:rect>screen released? nk:released? render nk:render render-timed nk:render-timed
+Builtin  rendering nk:rendering restore nk:restore rotate nk:rotate rotate-rel nk:rotate-rel rtl! nk:rtl!
+Builtin  rtl? nk:rtl? save nk:save scale nk:scale scancode? nk:scancode? screen-saver nk:screen-saver
+Builtin  screen-size nk:screen-size screen-win-close nk:screen-win-close selectable nk:selectable set nk:set
+Builtin  set-font nk:set-font set-num-vertices nk:set-num-vertices set-radius nk:set-radius setpos nk:setpos
+Builtin  setwin nk:setwin show nk:show slider nk:slider slider-int nk:slider-int space nk:space spacing nk:spacing
+Builtin  stroke-arc nk:stroke-arc stroke-circle nk:stroke-circle stroke-curve nk:stroke-curve stroke-line nk:stroke-line
+Builtin  stroke-polygon nk:stroke-polygon stroke-polyline nk:stroke-polyline stroke-rect nk:stroke-rect
+Builtin  stroke-tri nk:stroke-tri style-from-table nk:style-from-table swipe nk:swipe swipe-dir-threshold nk:swipe-dir-threshold
+Builtin  swipe-threshold nk:swipe-threshold text nk:text text-align nk:text-align text-font nk:text-font
+Builtin  text-pad nk:text-pad text? nk:text? timer-delay nk:timer-delay timer? nk:timer? toast nk:toast
+Builtin  tooltip nk:tooltip translate nk:translate tree-pop nk:tree-pop tree-state-push nk:tree-state-push
+Builtin  triangle nk:triangle use-style nk:use-style vsync nk:vsync widget nk:widget widget-bounds nk:widget-bounds
 Builtin  widget-disable nk:widget-disable widget-fitting nk:widget-fitting widget-high nk:widget-high
 Builtin  widget-hovered? nk:widget-hovered? widget-mouse-click-down? nk:widget-mouse-click-down? widget-mouse-clicked? nk:widget-mouse-clicked?
-Builtin  widget-pos nk:widget-pos widget-size nk:widget-size widget-size nk:widget-size widget-wide nk:widget-wide
-Builtin  win nk:win win-bounds nk:win-bounds win-bounds! nk:win-bounds! win-close nk:win-close win-closed? nk:win-closed?
-Builtin  win-collapse nk:win-collapse win-collapsed? nk:win-collapsed? win-content-bounds nk:win-content-bounds
+Builtin  widget-pos nk:widget-pos widget-size nk:widget-size widget-size-allot nk:widget-size-allot
+Builtin  widget-wide nk:widget-wide win nk:win win-bounds nk:win-bounds win-bounds! nk:win-bounds! win-close nk:win-close
+Builtin  win-closed? nk:win-closed? win-collapse nk:win-collapse win-collapsed? nk:win-collapsed? win-content-bounds nk:win-content-bounds
 Builtin  win-focus nk:win-focus win-focused? nk:win-focused? win-hidden? nk:win-hidden? win-high nk:win-high
-Builtin  win-hovered? nk:win-hovered? win-pos nk:win-pos win-scroll-ofs nk:win-scroll-ofs win-scroll-ofs! nk:win-scroll-ofs!
-Builtin  win-show nk:win-show win-size nk:win-size win-wide nk:win-wide win? nk:win? x>pt nk:x>pt x>rect nk:x>rect
-Builtin  MAX ns:MAX ! o:! + o:+ +? o:+? ??? o:??? @ o:@ class o:class exec o:exec isa o:isa method o:method
-Builtin  mutate o:mutate new o:new super o:super chroot os:chroot devname os:devname docker? os:docker?
-Builtin  env os:env lang os:lang locales os:locales notify os:notify power-state os:power-state region os:region
-Builtin  waitpid os:waitpid bezier pdf:bezier bezierq pdf:bezierq circle pdf:circle color pdf:color
-Builtin  ellipse pdf:ellipse font pdf:font img pdf:img line pdf:line new pdf:new page pdf:page page-size pdf:page-size
-Builtin  rect pdf:rect save pdf:save size pdf:size text pdf:text text-rotate pdf:text-rotate text-size pdf:text-size
-Builtin  text-width pdf:text-width text-wrap pdf:text-wrap text-wrap-rotate pdf:text-wrap-rotate cast ptr:cast
+Builtin  win-hovered? nk:win-hovered? win-icon! nk:win-icon! win-pos nk:win-pos win-scroll-ofs nk:win-scroll-ofs
+Builtin  win-scroll-ofs! nk:win-scroll-ofs! win-show nk:win-show win-size nk:win-size win-title! nk:win-title!
+Builtin  win-wide nk:win-wide win? nk:win? MAX ns:MAX ! o:! + o:+ +? o:+? ??? o:??? @ o:@ class o:class
+Builtin  exec o:exec isa o:isa method o:method mutate o:mutate new o:new super o:super POSIX os:POSIX
+Builtin  chroot os:chroot devname os:devname docker? os:docker? env os:env lang os:lang locales os:locales
+Builtin  notify os:notify power-state os:power-state region os:region waitpid os:waitpid bezier pdf:bezier
+Builtin  bezierq pdf:bezierq circle pdf:circle color pdf:color ellipse pdf:ellipse font pdf:font img pdf:img
+Builtin  line pdf:line new pdf:new page pdf:page page-size pdf:page-size rect pdf:rect save pdf:save
+Builtin  size pdf:size text pdf:text text-rotate pdf:text-rotate text-size pdf:text-size text-width pdf:text-width
+Builtin  text-wrap pdf:text-wrap text-wrap-rotate pdf:text-wrap-rotate cast ptr:cast deref ptr:deref
 Builtin  len ptr:len null? ptr:null? pack ptr:pack unpack ptr:unpack unpack_orig ptr:unpack_orig publish pubsub:publish
 Builtin  qsize pubsub:qsize subscribe pubsub:subscribe + q:+ clear q:clear len q:len new q:new notify q:notify
 Builtin  overwrite q:overwrite peek q:peek pick q:pick pop q:pop push q:push remove q:remove shift q:shift
 Builtin  size q:size slide q:slide throwing q:throwing wait q:wait ++match r:++match +/ r:+/ +match r:+match
-Builtin  / r:/ @ r:@ len r:len match r:match new r:new rx r:rx str r:str * rat:* + rat:+ - rat:- / rat:/
-Builtin  >n rat:>n >s rat:>s new rat:new proper rat:proper ! s:! * s:* + s:+ - s:- / s:/ /scripts s:/scripts
-Builtin  <+ s:<+ <> s:<> = s:= =ic s:=ic >base64 s:>base64 >ucs2 s:>ucs2 @ s:@ append s:append base64> s:base64>
-Builtin  clear s:clear cmp s:cmp cmpi s:cmpi compress s:compress count-match s:count-match days! s:days!
-Builtin  dist s:dist each s:each each! s:each! eachline s:eachline escape s:escape expand s:expand fill s:fill
-Builtin  fold s:fold globmatch s:globmatch hexupr s:hexupr insert s:insert intl s:intl intl! s:intl!
-Builtin  lang s:lang lc s:lc lc? s:lc? len s:len lsub s:lsub ltrim s:ltrim map s:map months! s:months!
-Builtin  n> s:n> new s:new norm s:norm reduce s:reduce repinsert s:repinsert replace s:replace replace! s:replace!
-Builtin  rev s:rev rsearch s:rsearch rsub s:rsub rtrim s:rtrim scan-match s:scan-match script? s:script?
-Builtin  search s:search size s:size slice s:slice soundex s:soundex strfmap s:strfmap strfmt s:strfmt
-Builtin  term s:term text-wrap s:text-wrap tr s:tr translate s:translate trim s:trim tsub s:tsub uc s:uc
-Builtin  uc? s:uc? ucs2> s:ucs2> utf8? s:utf8? zt s:zt close sio:close enum sio:enum open sio:open opts! sio:opts!
-Builtin  opts@ sio:opts@ read sio:read write sio:write @ slv:@ auto slv:auto build slv:build constraint slv:constraint
-Builtin  dump slv:dump edit slv:edit named-variable slv:named-variable new slv:new relation slv:relation
-Builtin  reset slv:reset suggest slv:suggest term slv:term update slv:update v[] slv:v[] variable slv:variable
-Builtin  v{} slv:v{} new smtp:new send smtp:send apply-filter snd:apply-filter devices? snd:devices?
-Builtin  end-record snd:end-record filter snd:filter freq snd:freq gain snd:gain gain? snd:gain? init snd:init
-Builtin  len snd:len loop snd:loop loop? snd:loop? mix snd:mix new snd:new pause snd:pause play snd:play
-Builtin  played snd:played rate snd:rate ready? snd:ready? record snd:record resume snd:resume seek snd:seek
-Builtin  stop snd:stop stopall snd:stopall volume snd:volume volume? snd:volume? + st:+ . st:. clear st:clear
-Builtin  len st:len ndrop st:ndrop new st:new op! st:op! peek st:peek pick st:pick pop st:pop push st:push
-Builtin  roll st:roll shift st:shift size st:size slide st:slide swap st:swap throwing st:throwing >buf struct:>buf
-Builtin  arr> struct:arr> buf struct:buf buf> struct:buf> byte struct:byte double struct:double field! struct:field!
+Builtin  / r:/ @ r:@ len r:len match r:match match[] r:match[] matchall[] r:matchall[] new r:new rx r:rx
+Builtin  str r:str * rat:* + rat:+ - rat:- / rat:/ >n rat:>n >s rat:>s new rat:new proper rat:proper
+Builtin  ! rect:! /high rect:/high /wide rect:/wide = rect:= >a rect:>a >pts rect:>pts >pts4 rect:>pts4
+Builtin  @ rect:@ center rect:center center-pt rect:center-pt intersect rect:intersect new rect:new
+Builtin  new-pt rect:new-pt ofs rect:ofs open rect:open pad rect:pad pos rect:pos pt-open rect:pt-open
+Builtin  pt>a rect:pt>a pt>rect rect:pt>rect pts> rect:pts> restrict rect:restrict shrink rect:shrink
+Builtin  size rect:size union rect:union ! s:! * s:* + s:+ - s:- / s:/ /scripts s:/scripts /ws s:/ws
+Builtin  2len s:2len <+ s:<+ <> s:<> = s:= =ic s:=ic >base64 s:>base64 >ucs2 s:>ucs2 @ s:@ _len s:_len
+Builtin  append s:append base64> s:base64> clear s:clear cmp s:cmp cmpi s:cmpi compress s:compress count-match s:count-match
+Builtin  days! s:days! dist s:dist each s:each each! s:each! eachline s:eachline escape s:escape expand s:expand
+Builtin  fill s:fill fold s:fold gen-uid s:gen-uid globmatch s:globmatch hexupr s:hexupr insert s:insert
+Builtin  intl s:intl intl! s:intl! lang s:lang lc s:lc lc? s:lc? len s:len lsub s:lsub ltrim s:ltrim
+Builtin  map s:map months! s:months! n> s:n> new s:new norm s:norm reduce s:reduce repinsert s:repinsert
+Builtin  replace s:replace replace! s:replace! rev s:rev rsearch s:rsearch rsub s:rsub rtl s:rtl rtrim s:rtrim
+Builtin  scan-match s:scan-match script? s:script? search s:search size s:size slice s:slice soundex s:soundex
+Builtin  strfmap s:strfmap strfmt s:strfmt term s:term text-wrap s:text-wrap tr s:tr translate s:translate
+Builtin  trim s:trim tsub s:tsub uc s:uc uc? s:uc? ucs2> s:ucs2> utf8? s:utf8? zt s:zt close sio:close
+Builtin  enum sio:enum open sio:open opts! sio:opts! opts@ sio:opts@ read sio:read write sio:write @ slv:@
+Builtin  auto slv:auto build slv:build constraint slv:constraint dump slv:dump edit slv:edit named-variable slv:named-variable
+Builtin  new slv:new relation slv:relation reset slv:reset suggest slv:suggest term slv:term update slv:update
+Builtin  v[] slv:v[] variable slv:variable v{} slv:v{} new smtp:new send smtp:send apply-filter snd:apply-filter
+Builtin  devices? snd:devices? end-record snd:end-record filter snd:filter freq snd:freq gain snd:gain
+Builtin  gain? snd:gain? init snd:init len snd:len loop snd:loop loop? snd:loop? mix snd:mix new snd:new
+Builtin  pause snd:pause play snd:play played snd:played rate snd:rate ready? snd:ready? record snd:record
+Builtin  resume snd:resume seek snd:seek stop snd:stop stopall snd:stopall volume snd:volume volume? snd:volume?
+Builtin  + st:+ . st:. clear st:clear dot-depth st:dot-depth len st:len list st:list ndrop st:ndrop
+Builtin  new st:new op! st:op! peek st:peek pick st:pick pop st:pop push st:push roll st:roll shift st:shift
+Builtin  size st:size slide st:slide swap st:swap throwing st:throwing >buf struct:>buf arr> struct:arr>
+Builtin  buf struct:buf buf> struct:buf> byte struct:byte double struct:double field! struct:field!
 Builtin  field@ struct:field@ float struct:float ignore struct:ignore int struct:int long struct:long
-Builtin  struct; struct:struct; word struct:word ! t:! @ t:@ by-name t:by-name cor t:cor cor-drop t:cor-drop
-Builtin  curtask t:curtask def-queue t:def-queue def-stack t:def-stack done? t:done? dtor t:dtor err! t:err!
-Builtin  err? t:err? errno? t:errno? extra t:extra getq t:getq handler t:handler handler@ t:handler@
-Builtin  kill t:kill list t:list main t:main max-exceptions t:max-exceptions name! t:name! name@ t:name@
-Builtin  notify t:notify parent t:parent pop t:pop priority t:priority push t:push push! t:push! q-notify t:q-notify
-Builtin  q-wait t:q-wait qlen t:qlen result t:result set-affinity t:set-affinity setq t:setq start t:start
-Builtin  task t:task task-n t:task-n task-stop t:task-stop ticks t:ticks wait t:wait yield t:yield yield! t:yield!
-Builtin  add tree:add binary tree:binary bk tree:bk btree tree:btree cmp! tree:cmp! data tree:data del tree:del
-Builtin  find tree:find iter tree:iter next tree:next nodes tree:nodes parent tree:parent parse tree:parse
-Builtin  prev tree:prev root tree:root search tree:search trie tree:trie ! w:! (is) w:(is) @ w:@ alias: w:alias:
-Builtin  cb w:cb deprecate w:deprecate dlcall w:dlcall dlopen w:dlopen dlsym w:dlsym exec w:exec exec? w:exec?
-Builtin  ffifail w:ffifail find w:find forget w:forget is w:is name w:name undo w:undo close ws:close
-Builtin  decode ws:decode encode ws:encode encode-nomask ws:encode-nomask gen-accept-header ws:gen-accept-header
+Builtin  struct; struct:struct; word struct:word ! t:! @ t:@ by-name t:by-name curtask t:curtask def-queue t:def-queue
+Builtin  def-stack t:def-stack done? t:done? dtor t:dtor err! t:err! err? t:err? errno? t:errno? extra t:extra
+Builtin  getq t:getq handler t:handler handler@ t:handler@ kill t:kill list t:list main t:main max-exceptions t:max-exceptions
+Builtin  name! t:name! name@ t:name@ notify t:notify parent t:parent pop t:pop priority t:priority push t:push
+Builtin  push! t:push! q-notify t:q-notify q-wait t:q-wait qlen t:qlen result t:result set-affinity t:set-affinity
+Builtin  setq t:setq task t:task task-n t:task-n task-stop t:task-stop ticks t:ticks wait t:wait add tree:add
+Builtin  binary tree:binary bk tree:bk btree tree:btree cmp! tree:cmp! data tree:data del tree:del find tree:find
+Builtin  iter tree:iter next tree:next nodes tree:nodes parent tree:parent parse tree:parse prev tree:prev
+Builtin  root tree:root search tree:search trie tree:trie ! w:! (is) w:(is) @ w:@ alias: w:alias: cb w:cb
+Builtin  deprecate w:deprecate dlcall w:dlcall dlopen w:dlopen dlsym w:dlsym exec w:exec exec? w:exec?
+Builtin  ffifail w:ffifail find w:find forget w:forget is w:is name w:name undo w:undo xt w:xt xt> w:xt>
+Builtin  close ws:close decode ws:decode encode ws:encode encode-nomask ws:encode-nomask gen-accept-header ws:gen-accept-header
 Builtin  gen-accept-key ws:gen-accept-key opcodes ws:opcodes open ws:open >s xml:>s >txt xml:>txt md-init xml:md-init
 Builtin  md-parse xml:md-parse parse xml:parse parse-html xml:parse-html parse-stream xml:parse-stream
 Builtin  getmsg[] zmq:getmsg[] sendmsg[] zmq:sendmsg[]
@@ -413,8 +426,9 @@ syn match eighthBuiltin /db:bind-exec\[]/
 syn match eighthBuiltin /db:exec\[]/
 syn match eighthBuiltin /db:col\[]/
 
-" TODO
-syn region eighthComment start="\zs\\" end="$" contains=eighthTodo
+syn region eighthComment start="\zs\\" end="$" contains=eighthTodo,@Spell
+syn region eighthComment start="\zs--\s" end="$" contains=eighthTodo,@Spell
+syn region eighthComment start="\zs(\*\_[:space:]" end="\_[:space:]\*)\ze" contains=eightTodo,@Spell
 
 " The default methods for highlighting. Can be overriden later.
 hi def link eighthTodo Todo
@@ -452,6 +466,7 @@ hi def link jsonArray Special
 hi def link jsonNull Function
 hi def link jsonBool Boolean
 
+delcommand Builtin
 let b:current_syntax = "8th"
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/syntax/structurizr.vim
+++ b/runtime/syntax/structurizr.vim
@@ -1,10 +1,9 @@
 " Vim syntax file
 " Language:      Structurizr DSL
 " Maintainer:    Bastian Venthur <venthur@debian.org>
-" Last Change:   2022-05-22
+" Last Change:   2024-11-06
 " Remark:        For a language reference, see
-"                https://github.com/structurizr/dsl
-
+"                https://docs.structurizr.com/dsl/language
 
 if exists("b:current_syntax")
     finish
@@ -20,7 +19,11 @@ syn region scomment start="/\*" end="\*/"
 " keywords
 syn keyword skeyword animation
 syn keyword skeyword autoLayout
+syn keyword skeyword background
+syn keyword skeyword border
 syn keyword skeyword branding
+syn keyword skeyword color
+syn keyword skeyword colour
 syn keyword skeyword component
 syn keyword skeyword configuration
 syn keyword skeyword container
@@ -37,48 +40,74 @@ syn keyword skeyword element
 syn keyword skeyword enterprise
 syn keyword skeyword exclude
 syn keyword skeyword filtered
+syn keyword skeyword font
+syn keyword skeyword fontsize
 syn keyword skeyword group
 syn keyword skeyword healthcheck
+syn keyword skeyword height
+syn keyword skeyword icon
+syn keyword skeyword image
 syn keyword skeyword include
 syn keyword skeyword infrastructurenode
 syn keyword skeyword instances
+syn keyword skeyword logo
+syn keyword skeyword metadata
 syn keyword skeyword model
+syn keyword skeyword opacity
 syn keyword skeyword person
 syn keyword skeyword perspectives
 syn keyword skeyword properties
 syn keyword skeyword relationship
+syn keyword skeyword routing
+syn keyword skeyword scope
+syn keyword skeyword shape
 syn keyword skeyword softwaresystem
 syn keyword skeyword softwaresysteminstance
+syn keyword skeyword stroke
+syn keyword skeyword strokewidth
 syn keyword skeyword styles
 syn keyword skeyword systemcontext
 syn keyword skeyword systemlandscape
+syn keyword skeyword tag
 syn keyword skeyword tags
 syn keyword skeyword technology
 syn keyword skeyword terminology
 syn keyword skeyword theme
 syn keyword skeyword themes
+syn keyword skeyword thickness
+syn keyword skeyword this
 syn keyword skeyword title
 syn keyword skeyword url
 syn keyword skeyword users
 syn keyword skeyword views
+syn keyword skeyword visibility
+syn keyword skeyword width
 syn keyword skeyword workspace
 
 syn match skeyword "\!adrs\s\+"
-syn match skeyword "\!constant\s\+"
+syn match skeyword "\!components\s\+"
 syn match skeyword "\!docs\s\+"
+syn match skeyword "\!element\s\+"
+syn match skeyword "\!elements\s\+"
+syn match skeyword "\!extend\s\+"
 syn match skeyword "\!identifiers\s\+"
 syn match skeyword "\!impliedrelationships\s\+"
 syn match skeyword "\!include\s\+"
 syn match skeyword "\!plugin\s\+"
 syn match skeyword "\!ref\s\+"
+syn match skeyword "\!relationship\s\+"
+syn match skeyword "\!relationships\s\+"
 syn match skeyword "\!script\s\+"
 
 syn region sstring oneline start='"' end='"'
 
 syn region sblock start='{' end='}' fold transparent
 
+syn match soperator "\->\s+"
+
 hi def link sstring string
 hi def link scomment comment
 hi def link skeyword keyword
+hi def link soperator operator
 
 let b:current_syntax = "structurizr"


### PR DESCRIPTION
#### vim-patch:3780c11: runtime(compiler): fix typo in cppcheck compiler plugin

closes: vim/vim#16002

https://github.com/vim/vim/commit/3780c11267415ff57f261fcd3e1dea0c2c9d8dd0

Co-authored-by: Enno <Konfekt@users.noreply.github.com>


#### vim-patch:a063b22: runtime(netrw): prevent polluting the search history

https://github.com/vim/vim/commit/a063b22b3bbc1c7ad9d985b14d6e3c5b7c6e3eca

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:64a536d: runtime(netrw): fix several bugs in netrw tree listing

closes: vim/vim#15996

https://github.com/vim/vim/commit/64a536d4fa17ec176f574a01543e483a163622eb

Co-authored-by: Tom Benham <tom.benham13@gmail.com>


#### vim-patch:6d9a145: runtime(compiler): add mypy and ruff compiler; update pylint linter

mypy and ruff come from
https://github.com/Konfekt/vim-compilers/tree/master/compiler and the
former was added by @pbnj-dragon

closes: vim/vim#16007

https://github.com/vim/vim/commit/6d9a145d719857fe461d045adf3b61ec4b4bb53f

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>


#### vim-patch:6e410c9: runtime(8th): updated 8th syntax

closes: vim/vim#16005

https://github.com/vim/vim/commit/6e410c9112497206c12330ab8a827b9d061579a9

Co-authored-by: Ron Aaron <ron@aaron-tech.com>


#### vim-patch:39f52a6: runtime(structurizr): Update structurizr syntax

closes: vim/vim#16003

https://github.com/vim/vim/commit/39f52a62492086acef1e9dbd71e344447954deb5

Co-authored-by: Duke <emersonalmeidax@gmail.com>


#### vim-patch:0f60fbf: runtime(compiler): improve cppcheck

Properly escape the values for makeprg according to the :set rules

closes: vim/vim#16014

https://github.com/vim/vim/commit/0f60fbf6796b72111184a6734b702a93f8f8944b

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>