### PR TITLE
fix(startup): report --startuptime error to stderr

### DIFF
--- a/src/nvim/profile.c
+++ b/src/nvim/profile.c
@@ -956,7 +956,7 @@ void time_init(const char *fname, const char *proc_name)
   const size_t bufsize = 8192;  // Big enough for the entire --startuptime report.
   time_fd = fopen(fname, "a");
   if (time_fd == NULL) {
-    semsg(_(e_notopen), fname);
+    fprintf(stderr, _(e_notopen), fname);
     return;
   }
   startuptime_buf = xmalloc(sizeof(char) * (bufsize + 1));
@@ -968,8 +968,7 @@ void time_init(const char *fname, const char *proc_name)
     XFREE_CLEAR(startuptime_buf);
     fclose(time_fd);
     time_fd = NULL;
-    ELOG("time_init: setvbuf failed: %d %s", r, uv_err_name(r));
-    semsg("time_init: setvbuf failed: %d %s", r, uv_err_name(r));
+    fprintf(stderr, "time_init: setvbuf failed: %d %s", r, uv_err_name(r));
     return;
   }
   fprintf(time_fd, "--- Startup times for process: %s ---\n", proc_name);

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -74,6 +74,25 @@ describe('startup', function()
     assert_log("require%('vim%._editor'%)", testfile, 100)
   end)
 
+  it('--startuptime does not crash on error #31125', function()
+    eq(
+      "E484: Can't open file .",
+      fn.system({
+        nvim_prog,
+        '-u',
+        'NONE',
+        '-i',
+        'NONE',
+        '--headless',
+        '--startuptime',
+        '.',
+        '-c',
+        '42cquit',
+      })
+    )
+    eq(42, api.nvim_get_vvar('shell_error'))
+  end)
+
   it('-D does not hang #12647', function()
     clear()
     local screen


### PR DESCRIPTION
Problem:  Crash when initializing for --startuptime errors.
Solution: Report the error to stderr, as neither logging nor messages
          have been initialized yet.

Fix #31125
