### PR TITLE
perf(lsp): use faster version of str_byteindex

### DIFF
--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -764,8 +764,7 @@ function vim.str_byteindex(s, encoding, index, strict_indexing)
     return vim._str_byteindex(s, old_index, use_utf16) or error('index out of range')
   end
 
-  -- Note we bypass vim.validate for performance reasons
-
+  -- Avoid vim.validate for performance.
   if type(s) ~= 'string' or type(index) ~= 'number' then
     vim.validate('s', s, 'string')
     vim.validate('index', index, 'number')

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -764,8 +764,12 @@ function vim.str_byteindex(s, encoding, index, strict_indexing)
     return vim._str_byteindex(s, old_index, use_utf16) or error('index out of range')
   end
 
-  vim.validate('s', s, 'string')
-  vim.validate('index', index, 'number')
+  -- Note we bypass vim.validate for performance reasons
+
+  if type(s) ~= 'string' or type(index) ~= 'number' then
+    vim.validate('s', s, 'string')
+    vim.validate('index', index, 'number')
+  end
 
   local len = #s
 
@@ -773,11 +777,15 @@ function vim.str_byteindex(s, encoding, index, strict_indexing)
     return 0
   end
 
-  vim.validate('encoding', encoding, function(v)
-    return utfs[v], 'invalid encoding'
-  end)
+  if not utfs[encoding] then
+    vim.validate('encoding', encoding, function(v)
+      return utfs[v], 'invalid encoding'
+    end)
+  end
 
-  vim.validate('strict_indexing', strict_indexing, 'boolean', true)
+  if strict_indexing ~= nil and type(strict_indexing) ~= 'boolean' then
+    vim.validate('strict_indexing', strict_indexing, 'boolean', true)
+  end
   if strict_indexing == nil then
     strict_indexing = true
   end
@@ -828,8 +836,11 @@ function vim.str_utfindex(s, encoding, index, strict_indexing)
     return col32, col16
   end
 
-  vim.validate('s', s, 'string')
-  vim.validate('index', index, 'number', true)
+  if type(s) ~= 'string' or (index ~= nil and type(index) ~= 'number') then
+    vim.validate('s', s, 'string')
+    vim.validate('index', index, 'number', true)
+  end
+
   if not index then
     index = math.huge
     strict_indexing = false
@@ -839,11 +850,15 @@ function vim.str_utfindex(s, encoding, index, strict_indexing)
     return 0
   end
 
-  vim.validate('encoding', encoding, function(v)
-    return utfs[v], 'invalid encoding'
-  end)
+  if not utfs[encoding] then
+    vim.validate('encoding', encoding, function(v)
+      return utfs[v], 'invalid encoding'
+    end)
+  end
 
-  vim.validate('strict_indexing', strict_indexing, 'boolean', true)
+  if strict_indexing ~= nil and type(strict_indexing) ~= 'boolean' then
+    vim.validate('strict_indexing', strict_indexing, 'boolean', true)
+  end
   if strict_indexing == nil then
     strict_indexing = true
   end

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -1142,7 +1142,7 @@ end
 --- @param mod T
 --- @return T
 function vim._defer_require(root, mod)
-  return setmetatable({}, {
+  return setmetatable({ _submodules = mod }, {
     ---@param t table<string, any>
     ---@param k string
     __index = function(t, k)


### PR DESCRIPTION
perf(lsp): optimize input validation in str_byteindex

The semantic tokens response handler contains a hot loop which makes
lots of calls to vim.str_byteindex which takes most of the time of the
entire handler.

Optimized input validation in vim.str_byteindex. Should be roughly
4x faster.

    name                              total    count      avg
    ────────────────────────────────────────────────
    vim.str_byteindex (original)   635.67ms   263048   2.42us
    vim.str_byteindex (new)        159.20ms   263016   0.61us
    vim._str_byteindex             190.01ms   786164   0.24us