### PR TITLE
ci: downgrade to clang 19

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -16,7 +16,7 @@ if [[ $os == Linux ]]; then
 
   if [[ $CC == clang ]]; then
     DEFAULT_CLANG_VERSION=$(echo |  clang -dM -E - | grep __clang_major | awk '{print $3}')
-    CLANG_VERSION=20
+    CLANG_VERSION=19
     if ((DEFAULT_CLANG_VERSION >= CLANG_VERSION)); then
       echo "Default clang version is $DEFAULT_CLANG_VERSION, which is equal or larger than wanted version $CLANG_VERSION. Aborting!"
       exit 1


### PR DESCRIPTION
Clang 20 is still in development at the time of this commit and is
unsuitable for CI.
