### PR TITLE
vim-patch:partial:624bb83: runtime(doc): Tweak documentation style a bit

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -1046,8 +1046,8 @@ To enable: >
 	let g:typst_folding = 1
 <
 							*g:typst_foldnested*
-When |TRUE| the Typst filetype plugin will fold nested heading under their parents
-(default: |TRUE|)
+When |TRUE| the Typst filetype plugin will fold nested heading under their
+parents. (default: |TRUE|)
 
 To disable: >
 	let g:typst_foldnested = 0

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -154,7 +154,7 @@ or auto suspended with nohlsearch plugin.  See |nohlsearch-install|.
 
 
 When 'shortmess' does not include the "S" flag, Vim will automatically show an
-index, on which the cursor is. This can look like this: >
+index, on which the cursor is.  This can look like this: >
 
   [1/5]		Cursor is on first of 5 matches.
   [1/>99]	Cursor is on first of more than 99 matches.
@@ -743,7 +743,7 @@ overview.
 	\([a-z]\+\)\zs,\1		",abc" in "abc,abc"
 
 \@123<=
-	Like "\@<=" but only look back 123 bytes. This avoids trying lots
+	Like "\@<=" but only look back 123 bytes.  This avoids trying lots
 	of matches that are known to fail and make executing the pattern very
 	slow.  Example, check if there is a "<" just before "span":
 		/<\@1<=span
@@ -769,7 +769,7 @@ overview.
 	\(\/\/.*\)\@<!in	"in" which is not after "//"
 
 \@123<!
-	Like "\@<!" but only look back 123 bytes. This avoids trying lots of
+	Like "\@<!" but only look back 123 bytes.  This avoids trying lots of
 	matches that are known to fail and make executing the pattern very
 	slow.
 
@@ -892,7 +892,7 @@ $	At end of pattern or in front of "\|", "\)" or "\n" ('magic' on):
 	inside the Visual area put it at the start and just before the end of
 	the pattern, e.g.: >
 		/\%Vfoo.*ba\%Vr
-<	This also works if only "foo bar" was Visually selected. This: >
+<	This also works if only "foo bar" was Visually selected.  This: >
 		/\%Vfoo.*bar\%V
 <	would match "foo bar" if the Visual selection continues after the "r".
 	Only works for the current buffer.
@@ -999,7 +999,7 @@ $	At end of pattern or in front of "\|", "\)" or "\n" ('magic' on):
 <	To match all characters after the current virtual column (where the
 	cursor is): >
 		/\%>.v.*
-<	Column 17 is not included, because this is a |/zero-width| match. To
+<	Column 17 is not included, because this is a |/zero-width| match.  To
 	include the column use: >
 		/^.*\%17v.
 <	This command does the same thing, but also matches when there is no
@@ -1123,11 +1123,11 @@ x	A single character, with no special meaning, matches itself
 	in the collection: "[^xyz]" matches anything but 'x', 'y' and 'z'.
 	- If two characters in the sequence are separated by '-', this is
 	  shorthand for the full list of ASCII characters between them.  E.g.,
-	  "[0-9]" matches any decimal digit. If the starting character exceeds
-	  the ending character, e.g. [c-a], E944 occurs. Non-ASCII characters
+	  "[0-9]" matches any decimal digit.  If the starting character exceeds
+	  the ending character, e.g. [c-a], E944 occurs.  Non-ASCII characters
 	  can be used, but the character values must not be more than 256 apart
-	  in the old regexp engine. For example, searching by [\u3000-\u4000]
-	  after setting re=1 emits a E945 error. Prepending \%#=2 will fix it.
+	  in the old regexp engine.  For example, searching by [\u3000-\u4000]
+	  after setting re=1 emits a E945 error.  Prepending \%#=2 will fix it.
 	- A character class expression is evaluated to the set of characters
 	  belonging to that character class.  The following character classes
 	  are supported:
@@ -1193,7 +1193,7 @@ x	A single character, with no special meaning, matches itself
 	  any character that's not in "^]-\bdertnoUux".  "[\xyz]" matches '\',
 	  'x', 'y' and 'z'.  It's better to use "\\" though, future expansions
 	  may use other characters after '\'.
-	- Omitting the trailing ] is not considered an error. "[]" works like
+	- Omitting the trailing ] is not considered an error.  "[]" works like
 	  "[]]", it matches the ']' character.
 	- The following translations are accepted when the 'l' flag is not
 	  included in 'cpoptions':
@@ -1425,14 +1425,14 @@ Finally, these constructs are unique to Perl:
 		display you may get unexpected results.  That is because Vim
 		looks for a match in the line where redrawing starts.
 
-		Also see |matcharg()| and |getmatches()|. The former returns
+		Also see |matcharg()| and |getmatches()|.  The former returns
 		the highlight group and pattern of a previous |:match|
 		command.  The latter returns a list with highlight groups and
 		patterns defined by both |matchadd()| and |:match|.
 
 		Highlighting matches using |:match| are limited to three
 		matches (aside from |:match|, |:2match| and |:3match| are
-		available). |matchadd()| does not have this limitation and in
+		available).  |matchadd()| does not have this limitation and in
 		addition makes it possible to prioritize matches.
 
 		Another example, which highlights all characters in virtual
@@ -1461,7 +1461,7 @@ Finally, these constructs are unique to Perl:
 		with the lowest number has priority if several match at the
 		same position.  It uses the match id 3.
 		The ":3match" command is used by (older Vims) |matchparen|
-		plugin. You are suggested to use ":match" for manual matching
+		plugin.  You are suggested to use ":match" for manual matching
 		and ":2match" for another plugin or even better make use of
 		the more flexible |matchadd()| (and similar) functions instead.
 
@@ -1470,10 +1470,10 @@ Finally, these constructs are unique to Perl:
 
 Fuzzy matching refers to matching strings using a non-exact search string.
 Fuzzy matching will match a string, if all the characters in the search string
-are present anywhere in the string in the same order. Case is ignored.  In a
+are present anywhere in the string in the same order.  Case is ignored.  In a
 matched string, other characters can be present between two consecutive
-characters in the search string. If the search string has multiple words, then
-each word is matched separately. So the words in the search string can be
+characters in the search string.  If the search string has multiple words, then
+each word is matched separately.  So the words in the search string can be
 present in any order in a string.
 
 Fuzzy matching assigns a score for each matched string based on the following
@@ -1492,8 +1492,8 @@ will match the strings "GetPattern", "PatternGet", "getPattern", "patGetter",
 "getSomePattern", "MatchpatternGet" etc.
 
 The functions |matchfuzzy()| and |matchfuzzypos()| can be used to fuzzy search
-a string in a List of strings. The matchfuzzy() function returns a List of
-matching strings. The matchfuzzypos() functions returns the List of matches,
+a string in a List of strings.  The matchfuzzy() function returns a List of
+matching strings.  The matchfuzzypos() functions returns the List of matches,
 the matching positions and the fuzzy match scores.
 
 The "f" flag of `:vimgrep` enables fuzzy matching.

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -1533,7 +1533,7 @@ Associated setting variables:
 	|g:netrw_nogx|	prevent gx map while editing
 	|g:netrw_suppress_gx_mesg| controls gx's suppression of browser messages
 
-OPENING FILES AND LAUNCHING APPS                 *netrw-gx* *:Open* *:Launch* {{{2
+OPENING FILES AND LAUNCHING APPS	*netrw-gx* *:Open* *:Launch* {{{2
 
 Netrw determines which special handler by the following method:
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1209,20 +1209,20 @@ on" command in your .vimrc file.
 When you edit an existing Fortran file, the syntax script will assume free
 source form if the fortran_free_source variable has been set, and assumes
 fixed source form if the fortran_fixed_source variable has been set.  Suppose
-neither of these variables have been set. In that case, the syntax script attempts to
-determine which source form has been used by examining the file extension
-using conventions common to the ifort, gfortran, Cray, NAG, and PathScale
-compilers (.f, .for, .f77 for fixed-source, .f90, .f95, .f03, .f08 for
-free-source). No default is used for the .fpp and .ftn file extensions because
-different compilers treat them differently. If none of this works, then the
-script examines the first five columns of the first 500 lines of your file. If
-no signs of free source form are detected, then the file is assumed to be in
-fixed source form.  The algorithm should work in the vast majority of cases.
-In some cases, such as a file that begins with 500 or more full-line comments,
-the script may incorrectly decide that the code is in fixed form.  If that
-happens, just add a non-comment statement beginning anywhere in the first five
-columns of the first twenty-five lines, save (:w), and then reload (:e!) the
-file.
+neither of these variables have been set. In that case, the syntax script
+attempts to determine which source form has been used by examining the file
+extension using conventions common to the ifort, gfortran, Cray, NAG, and
+PathScale compilers (.f, .for, .f77 for fixed-source, .f90, .f95, .f03, .f08
+for free-source).  No default is used for the .fpp and .ftn file extensions
+because different compilers treat them differently. If none of this works,
+then the script examines the first five columns of the first 500 lines of your
+file. If no signs of free source form are detected, then the file is assumed
+to be in fixed source form.  The algorithm should work in the vast majority of
+cases.  In some cases, such as a file that begins with 500 or more full-line
+comments, the script may incorrectly decide that the code is in fixed form.
+If that happens, just add a non-comment statement beginning anywhere in the
+first five columns of the first twenty-five lines, save (:w), and then reload
+(:e!) the file.
 
 Vendor extensions ~
 Fixed-form Fortran requires a maximum line length of 72 characters but the
@@ -1753,9 +1753,9 @@ define the vim variable 'lace_case_insensitive' in your startup file: >
 LF (LFRC)		*lf.vim* *ft-lf-syntax* *g:lf_shell_syntax*
 						*b:lf_shell_syntax*
 
-For the lf file manager configuration files (lfrc) the shell commands
-syntax highlighting can be changed globally and per buffer by setting
-a different 'include' command search pattern using these variables:
+For the lf file manager configuration files (lfrc) the shell commands syntax
+highlighting can be changed globally and per buffer by setting a different
+'include' command search pattern using these variables: >
 	let g:lf_shell_syntax = "syntax/dosbatch.vim"
 	let b:lf_shell_syntax = "syntax/zsh.vim"
 
@@ -2065,9 +2065,10 @@ set "msql_minlines" to the value you desire.  Example: >
 	:let msql_minlines = 200
 
 
-NEOMUTT			*neomutt.vim* *ft-neomuttrc-syntax* *ft-neomuttlog-syntax*
+NEOMUTT					*neomutt.vim* *ft-neomuttrc-syntax*
+					*ft-neomuttlog-syntax*
 
-To disable the default NeoMutt log colors >
+To disable the default NeoMutt log colors: >
 
 	:let g:neolog_disable_default_colors = 1
 
@@ -2236,9 +2237,9 @@ specified. Default = 1 >
 
 	:let g:pandoc#syntax#codeblocks#embeds#use = 1
 
-For specify what languages and using what syntax files to highlight embeds. This is a
-list of language names. When the language pandoc and vim use don't match, you
-can use the "PANDOC=VIM" syntax. For example: >
+For specify what languages and using what syntax files to highlight embeds.
+This is a list of language names. When the language pandoc and vim use don't
+match, you can use the "PANDOC=VIM" syntax. For example: >
 
 	:let g:pandoc#syntax#codeblocks#embeds#langs = ["ruby", "bash=sh"]
 
@@ -3446,7 +3447,7 @@ set "tf_minlines" to the value you desire.  Example: >
 	:let tf_minlines = your choice
 <
 TYPESCRIPT				*typescript.vim* *ft-typescript-syntax*
-				*typescriptreact.vim* *ft-typescriptreact-syntax*
+			    *typescriptreact.vim* *ft-typescriptreact-syntax*
 
 There is one option to control the TypeScript syntax highlighting.
 

--- a/runtime/doc/undo.txt
+++ b/runtime/doc/undo.txt
@@ -184,7 +184,7 @@ g-			Go to older text state.  With a count repeat that many
 g+			Go to newer text state.  With a count repeat that many
 			times.
 							*:lat* *:later*
-:lat[er] {count}		Go to newer text state {count} times.
+:lat[er] {count}	Go to newer text state {count} times.
 :lat[er] {N}s		Go to newer text state about {N} seconds later.
 :lat[er] {N}m		Go to newer text state about {N} minutes later.
 :lat[er] {N}h		Go to newer text state about {N} hours later.


### PR DESCRIPTION
#### vim-patch:partial:624bb83: runtime(doc): Tweak documentation style a bit

closes: vim/vim#11419

https://github.com/vim/vim/commit/624bb83619cbd685b1902b016ca3ececfc1c135c

Skip syncolor.vim and v:colornames

Co-authored-by: h-east <h.east.727@gmail.com>