### PR TITLE
vim-patch:5e7f43b: runtime(termdebug): allow to use decimal signs

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -509,6 +509,7 @@ If the current window has enough horizontal space, it will be vertically split
 and the Var window will be shown side by side with the source code window (and
 the height options won't be used).
 
+
 Communication ~
 						*termdebug-communication*
 There is another, hidden, buffer, which is used for Vim to communicate with
@@ -601,15 +602,19 @@ If there is no g:termdebug_config you can use: >vim
 Change default signs ~
 							*termdebug_signs*
 Termdebug uses the hex number of the breakpoint ID in the signcolumn to
-represent breakpoints. if it is greater than "0xFF", then it will be displayed
+represent breakpoints. If it is greater than "0xFF", then it will be displayed
 as "F+", due to we really only have two screen cells for the sign.
+You may also use decimal breakpoint signs instead, in which case IDs greater
+than 99 will be displayed as "9+".
 
-If you want to customize the breakpoint signs: >vim
+If you want to customize the breakpoint signs to show `>>` in the signcolumn: >vim
 	let g:termdebug_config['sign'] = '>>'
+If you would like to use decimal (base 10) breakpoint signs: >vim
+	let g:termdebug_config['sign_decimal'] = 1
 If there is no g:terminal_config yet you can use: >vim
 	let g:termdebug_config = {'sign': '>>'}
-
-After this, breakpoints will be displayed as `>>` in the signcolumn.
+Likewise, to enable decimal signs: >vim
+	let g:termdebug_config = {'sign_decimal': 1}
 
 
 Vim window width ~

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1688,10 +1688,14 @@ func s:CreateBreakpoint(id, subid, enabled)
       let hiName = "debugBreakpoint"
     endif
     let label = ''
-    if exists('g:termdebug_config')
-      let label = get(g:termdebug_config, 'sign', '')
-    endif
-    if label == ''
+    if exists('g:termdebug_config') && has_key(g:termdebug_config, 'sign')
+      let label = g:termdebug_config['sign']
+    elseif exists('g:termdebug_config') && has_key(g:termdebug_config, 'sign_decimal')
+      let label = printf('%02d', a:id)
+      if a:id > 99
+        let label = '9+'
+      endif
+    else
       let label = printf('%02X', a:id)
       if a:id > 255
         let label = 'F+'


### PR DESCRIPTION
#### vim-patch:5e7f43b: runtime(termdebug): allow to use decimal signs

closes: vim/vim#16011

https://github.com/vim/vim/commit/5e7f43b6ac2ac23d4fbfded75827a13f981d9a96

Co-authored-by: Ella Moss <ella.moss@utah.edu>
Co-authored-by: Christian Brabandt <cb@256bit.org>