### PR TITLE
vim-patch:060107c: runtime(doc): fix typo in g:termdebug_config

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -611,7 +611,7 @@ If you want to customize the breakpoint signs to show `>>` in the signcolumn: >v
 	let g:termdebug_config['sign'] = '>>'
 If you would like to use decimal (base 10) breakpoint signs: >vim
 	let g:termdebug_config['sign_decimal'] = 1
-If there is no g:terminal_config yet you can use: >vim
+If the variable g:termdebug_config does not yet exist, you can use: >vim
 	let g:termdebug_config = {'sign': '>>'}
 Likewise, to enable decimal signs: >vim
 	let g:termdebug_config = {'sign_decimal': 1}


### PR DESCRIPTION
#### vim-patch:060107c: runtime(doc): fix typo in g:termdebug_config

closes: vim/vim#16023

https://github.com/vim/vim/commit/060107cbc40a68b30d81e5531a1c8dde91fc9b59