### PR TITLE
feat(defaults): add new `[` and `]` pending operators

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -195,6 +195,7 @@ EDITOR
   "~/" are now expanded to the user's profile directory, not a relative path
   to a literal "~" directory.
 • |hl-PmenuMatch| and |hl-PmenuMatchSel| show matched text in completion popup.
+• Added new [ / ] cursor-aware operators. See |[-default| / |]-default|.
 
 EVENTS
 

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -610,4 +610,64 @@ gc			Text object for the largest contiguous block of
 			`gcgc` uncomments a comment block; `dgc` deletes it).
 			Works only in Operator-pending mode.
 
+==============================================================================
+3. Directional Operators			*[-default* *]-default*
+
+{operator}[{object}	Do `{operator}` from `{object}` to the start to the cursor.
+{operator}]{object}	Do `{operator}` from the cursor to `{object}` end.
+
+Some useful examples include:
+
+- `d[a}`	Delete around the start of a {}-pair to the cursor.
+- `d]a}`	Delete around the cursor to the end of a {}-pair.
+- `gc[ip`	Comment from the start of the paragraph to the cursor.
+- `gc]ip`	Comment from the cursor to the end of the paragraph.
+- `gw[ip`	Format from the start of the paragraph to the cursor.
+- `gw]ip`	Format from the cursor to the end of the paragraph.
+- `v[ip`	Select from the start of the paragraph to the cursor.
+- `v]ip`	Select from the cursor to the end of the paragraph.
+- `y[ib`	Yank inside start of a ()-pair to the cursor.
+- `y]ib`	Yank inside the cursor to the end of a ()-pair.
+
+etc etc.
+
+This works with many {operator}-{object} pairs.
+Using `[` / `]` also work with text-object plugins!
+
+------------------------------------------------------------------------------
+Custom Text Objects
+
+For example
+
+Using https://github.com/nvim-treesitter/nvim-treesitter-textobjects
+enables mappings like:
+
+- `V]ic`	Select lines from the cursor to the end of a class.
+- `V[ic`	Select lines from the start of a class to the cursor.
+- `V]if`	Select lines from the cursor to the end of a function.
+- `V[if`	Select lines from the start of a function to the cursor.
+
+Treesitter is not required. For example https://github.com/kana/vim-textobj-indent
+lets you operate on indented blocks.
+
+- `c[ii`	Change from start of the indented-lines to the cursor.
+- `c]ii`	Change from the cursor to the end of the indented-lines.
+
+etc.
+
+------------------------------------------------------------------------------
+Custom Text Operators
+
+Previously we talked about using `[` and `]` with custom text objects like
+`ic`, `if`, `ii`. `[` and `]` also work with custom text operators!
+
+For example
+
+Using https://github.com/ralismark/opsort.vim enables mappings like:
+
+- `gs]ip`	Sort from the cursor to the end of a paragraph.
+- `gs[ip`	Sort from the start of a paragraph to the cursor.
+
+As you can see, the `[` / `]` operators are very flexible!
+
  vim:noet:tw=78:ts=8:ft=help:norl:

--- a/runtime/lua/vim/_cursor.lua
+++ b/runtime/lua/vim/_cursor.lua
@@ -1,0 +1,111 @@
+--- All function(s) that can be called externally by other Lua modules.
+---
+--- If a function's signature here changes in some incompatible way, this
+--- package must get a new **major** version.
+---
+---@module 'vim._cursor'
+---
+
+local M = {}
+
+local _Direction = { down = 'down', up = 'up' }
+
+---@class vim._cursor.Options
+---    Describe which way to adjust the cursor and how.
+---@field count number
+---    The number of times to call the command. Usually is just `1`.
+---@field direction "down" | "up"
+---    Which way to crop the text object. "up" means "operate from the cursor's
+---    position to the up/left-most position" and "down" means "operate from
+---    the cursor's position (including the cursor's current line, if
+---    applicable) to the down/right-most position".
+
+local _CURSOR
+---@type string
+local _DIRECTION
+---@type string
+local _OPERATOR
+---@type string
+local _OPERATOR_FUNCTION
+
+--- Check if the operatorfunc that is running will run on a whole-line.
+---
+--- See Also:
+---     :help g@
+---
+---@param mode "block" | "char" | "line"
+---@return boolean # If `mode` is meant to run on the full-line (ignores column data).
+---
+local function _is_line_mode(mode)
+  return mode == 'line'
+end
+
+--- Execute the original operatorfunc but crop it based on the cursor position.
+---
+--- Important:
+---     You must call `prepare()` once before this function can be called.
+---
+---@param mode "block" | "char" | "line"
+---    The caller context. See `:help :map-operator` for details.
+---
+function M.operatorfunc(mode)
+  vim.fn.setpos('.', _CURSOR)
+  vim.o.operatorfunc = _OPERATOR_FUNCTION
+  ---@type string
+  local mode_character
+  local is_line = _is_line_mode(mode)
+
+  if is_line then
+    mode_character = "'" -- Includes only line information
+  else
+    mode_character = '`' -- Includes column information
+  end
+
+  ---@type string
+  local direction
+  local inclusive_toggle = ''
+
+  if _DIRECTION == _Direction.up then
+    direction = '['
+
+    if not is_line then
+      local buffer, row, column, offset = unpack(vim.fn.getpos("'" .. direction))
+      ---@cast row number
+
+      if column > #vim.fn.getline(row) then
+        row = row + 1
+        column = 0
+      end
+
+      vim.fn.setpos("'" .. direction, { buffer, row, column, offset })
+    end
+  else
+    direction = ']'
+
+    local buffer, row, column, offset = unpack(vim.fn.getpos("'" .. direction))
+    ---@cast row number
+
+    if not is_line and column == #vim.fn.getline(row) then
+      -- NOTE: Move the mark past the current cursor column
+      inclusive_toggle = 'v'
+    else
+      vim.fn.setpos("'" .. direction, { buffer, row, column + 1, offset })
+    end
+  end
+
+  vim.fn.feedkeys(_OPERATOR .. inclusive_toggle .. mode_character .. direction)
+end
+
+--- Remember anything that we will need to recall once we execute `operatorfunc`.
+---
+---@param options vim._cursor.Options
+---    Mapping data that must be remembered before `operatorfunc` is called.
+---
+function M.prepare(options)
+  _DIRECTION = options.direction
+  _OPERATOR = vim.v.operator
+  _CURSOR = vim.fn.getpos('.')
+  _OPERATOR_FUNCTION = vim.o.operatorfunc
+end
+
+return M

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -151,6 +151,35 @@ do
     vim.keymap.set({ 'o' }, 'gc', textobject_rhs, { desc = 'Comment textobject' })
   end
 
+  --- Default maps for directional operators.
+  ---
+  --- See |[-default| and |]-default|.
+  do
+    local function omap(keys, options, desc)
+      vim.keymap.set('o', keys, function()
+        local data = vim.tbl_extend('force', options, { count = vim.v.count1 })
+
+        require('vim._cursor').prepare(data)
+
+        return string.format(
+          "<Esc>:<C-U>set operatorfunc=v:lua.require'vim._cursor'.operatorfunc<CR>%sg@",
+          data.count
+        )
+      end, { expr = true, silent = true, desc = desc })
+    end
+
+    omap(
+      '[',
+      { direction = 'up' },
+      "Run from the start of the text object to the cursor's current position"
+    )
+    omap(
+      ']',
+      { direction = 'down' },
+      "Run from the cursor's current position to the end of the text object"
+    )
+  end
+
   --- Default maps for LSP functions.
   ---
   --- These are mapped unconditionally to avoid different behavior depending on whether an LSP

--- a/test/functional/lua/cursor_pending_operator_spec.lua
+++ b/test/functional/lua/cursor_pending_operator_spec.lua
@@ -1,0 +1,1428 @@
+--- Make sure the basic functionality of cursor-text-object works.
+
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local api = n.api
+local clear = n.clear
+local eq = t.eq
+local exec_lua = n.exec_lua
+local fn = n.fn
+
+--- Get the lines of `buffer`.
+---
+---@param buffer number # A 1-or-more identifier for the Vim buffer.
+---@return string # The text in `buffer`.
+---
+local function get_lines(buffer)
+  return fn.join(api.nvim_buf_get_lines(buffer, 0, -1, false), '\n')
+end
+
+--- Run `keys` from NORMAL mode.
+---
+---@param keys string Some command to run. e.g. `d]ap`.
+---
+local function call_command(keys)
+  exec_lua(function()
+    vim.cmd('normal ' .. keys)
+  end)
+end
+
+--- Create a new Vim buffer with `text` contents.
+---
+---@param text string All of the text to add into the buffer.
+---@param file_type string? Apply a type to the newly created buffer.
+---@return number # A 1-or-more identifier for the Vim buffer.
+---@return number # A 1-or-more identifier for the Vim window.
+---
+local function make_buffer(text, file_type)
+  local buffer = api.nvim_create_buf(false, false)
+  api.nvim_set_current_buf(buffer)
+
+  if file_type then
+    api.nvim_set_option_value('filetype', file_type, {})
+  end
+
+  api.nvim_buf_set_lines(buffer, 0, -1, false, fn.split(text, '\n'))
+
+  return buffer, api.nvim_get_current_win()
+end
+
+--- Make sure `input` becomes `expected` when `keys` are called.
+---
+---@param cursor {[1]: number, [2]: number} The row & column position. (row=1-or-more, column=0-or-more).
+---@param keys string Some command to run. e.g. `d]ap`.
+---@param input string The buffer's original text.
+---@param expected string The text that we expect to get after calling `keys`.
+---
+local function run_simple_test(cursor, keys, input, expected)
+  local buffer, window = make_buffer(input)
+  api.nvim_win_set_cursor(window, cursor)
+
+  call_command(keys)
+
+  eq(expected, get_lines(buffer))
+end
+
+--- Initialize 'commentstring' so `:help gc` related tests work as expected.
+---
+---@param text string The template for creating comments. e.g. `"# %s"`.
+---@param buffer number A 0-or-more Vim buffer ID.
+---
+local function set_commentstring(text, buffer)
+  api.nvim_set_option_value('commentstring', text, { buf = buffer })
+end
+
+before_each(function()
+  clear({ args_rm = { '--cmd' }, args = { '--clean' } })
+end)
+
+describe('basic', function()
+  it('works with inner count', function()
+    run_simple_test(
+      { 2, 0 },
+      'd]2ap',
+      [[
+      some text
+          more text <-- NOTE: The cursor will be set here
+          even more lines!
+      still part of the paragraph
+
+      another paragraph
+      with text in it
+
+      last paragraph
+      ]],
+      [[
+      some text
+      last paragraph
+      ]]
+    )
+  end)
+
+  it('works with outer count', function()
+    run_simple_test(
+      { 2, 0 },
+      '2d]ap',
+      [[
+      some text
+          more text <-- NOTE: The cursor will be set here
+          even more lines!
+      still part of the paragraph
+
+      another paragraph
+      with text in it
+
+      last paragraph
+      ]],
+      [[
+      some text
+      last paragraph
+      ]]
+    )
+  end)
+end)
+
+describe(':help c', function()
+  describe('down', function()
+    it('works cap', function()
+      run_simple_test(
+        { 2, 0 },
+        'c]ap',
+        [[
+        some text
+            more text <-- NOTE: The cursor will be set here
+            even more lines!
+        still part of the paragraph
+
+        another paragraph
+        with text in it
+        ]],
+        [[
+        some text
+
+        another paragraph
+        with text in it
+        ]]
+      )
+    end)
+
+    it('works ca}', function()
+      run_simple_test(
+        { 3, 0 },
+        'c]a}',
+        [[
+        {
+            some text
+                more text  <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+
+            more lines
+        }
+
+        {
+            another paragraph
+            with text in it
+        }
+        ]],
+        [[
+        {
+            some text
+
+
+        {
+            another paragraph
+            with text in it
+        }
+        ]]
+      )
+    end)
+  end)
+
+  describe('up', function()
+    it('works cap', function()
+      run_simple_test(
+        { 7, 0 },
+        'c[ap',
+        [[
+        some text
+            more text
+            even more lines!
+        still part of the paragraph
+
+        first line, second paragraph
+        another paragraph  <-- NOTE: The cursor will be set here
+        with text in it
+        ]],
+        [[
+        some text
+            more text
+            even more lines!
+        still part of the paragraph
+
+
+        with text in it
+        ]]
+      )
+    end)
+
+    it('works ca}', function()
+      run_simple_test(
+        { 3, 0 },
+        'c[a}',
+        [[
+        {
+            some text
+                more text  <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+
+            more lines
+        }
+
+        {
+            another paragraph
+            with text in it
+        }
+        ]],
+        [[
+
+                more text  <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+
+            more lines
+        }
+
+        {
+            another paragraph
+            with text in it
+        }
+        ]]
+      )
+    end)
+  end)
+end)
+
+describe(':help d', function()
+  describe('down', function()
+    it('works with da)', function()
+      run_simple_test(
+        { 3, 0 },
+        'd]a)',
+        [[
+        (
+            some text
+                more text  <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+
+            more lines
+        )
+
+        (
+            another paragraph
+            with text in it
+        )
+        ]],
+        [[
+        (
+            some text
+
+
+        (
+            another paragraph
+            with text in it
+        )
+        ]]
+      )
+    end)
+
+    it('works with da]', function()
+      run_simple_test(
+        { 3, 0 },
+        'd]a]',
+        [[
+        [
+            some text
+                more text  <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+
+            more lines
+        ]
+
+        [
+            another paragraph
+            with text in it
+        ]
+        ]],
+        [[
+        [
+            some text
+
+
+        [
+            another paragraph
+            with text in it
+        ]
+        ]]
+      )
+    end)
+
+    it('works with da}', function()
+      run_simple_test(
+        { 3, 0 },
+        'd]a}',
+        [[
+        {
+            some text
+                more text  <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+
+            more lines
+        }
+
+        {
+            another paragraph
+            with text in it
+        }
+        ]],
+        [[
+        {
+            some text
+
+
+        {
+            another paragraph
+            with text in it
+        }
+        ]]
+      )
+    end)
+
+    it('works with dap - 3 paragraphs', function()
+      run_simple_test(
+        { 4, 0 },
+        'd]ap',
+        [[
+        first first
+
+        second 1
+        second 2  <-- NOTE: The cursor will be set here
+        second 3
+
+        third paragraph
+        ]],
+        [[
+        first first
+
+        second 1
+        third paragraph
+        ]]
+      )
+    end)
+
+    it('works with dap', function()
+      run_simple_test(
+        { 2, 0 },
+        'd]ap',
+        [[
+        some text
+            more text <-- NOTE: The cursor will be set here
+            even more lines!
+        still part of the paragraph
+
+        another paragraph
+        with text in it
+        ]],
+        [[
+        some text
+        another paragraph
+        with text in it
+        ]]
+      )
+    end)
+
+    it('works with das', function()
+      run_simple_test(
+        { 1, 28 },
+        'd]as',
+        [[
+        some sentences. With text and stuff
+        multiple lines.
+        other code
+        ]],
+        [[
+        some sentences. Withother code
+        ]]
+      )
+    end)
+
+    it('works with dat', function()
+      run_simple_test(
+        { 3, 0 },
+        'd]at',
+        [[
+        <foo>
+            some text
+                more text <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+        </foo>
+        ]],
+        [[
+        <foo>
+            some text
+
+        ]]
+      )
+    end)
+
+    it('works with di)', function()
+      run_simple_test(
+        { 3, 0 },
+        'd]i)',
+        [[
+        (
+            some lines
+            and more things  <-- NOTE: The cursor will be set here
+            last in the paragraph
+
+            last bits
+        )
+
+        (
+            another one
+        )
+        ]],
+        [[
+        (
+            some lines
+        )
+
+        (
+            another one
+        )
+        ]]
+      )
+    end)
+
+    it('works with di]', function()
+      run_simple_test(
+        { 3, 0 },
+        'd]i]',
+        [[
+        [
+            some lines
+            and more things  <-- NOTE: The cursor will be set here
+            last in the paragraph
+
+            last bits
+        ]
+
+        [
+            another one
+        ]
+        ]],
+        [[
+        [
+            some lines
+        ]
+
+        [
+            another one
+        ]
+        ]]
+      )
+    end)
+
+    it('works with di}', function()
+      run_simple_test(
+        { 3, 0 },
+        'd]i}',
+        [[
+        {
+            some lines
+            and more things  <-- NOTE: The cursor will be set here
+            last in the paragraph
+
+            last bits
+        }
+
+        {
+            another one
+        }
+        ]],
+        [[
+        {
+            some lines
+        }
+
+        {
+            another one
+        }
+        ]]
+      )
+    end)
+
+    it('works with dip', function()
+      run_simple_test(
+        { 2, 0 },
+        'd]ip',
+        [[
+        some text
+            more text  <-- NOTE: The cursor will be set here
+            even more lines!
+        still part of the paragraph
+
+        another paragraph
+        with text in it
+        ]],
+        [[
+        some text
+
+        another paragraph
+        with text in it
+        ]]
+      )
+    end)
+
+    it('works with dis', function()
+      run_simple_test(
+        { 1, 22 },
+        'd]is',
+        'some sentences. With text and stuff\nmultiple lines\nother code',
+        'some sentences. With t'
+      )
+    end)
+
+    it('works with dit', function()
+      run_simple_test(
+        { 3, 0 },
+        'd]it',
+        [[
+        <foo>
+            some text
+                more text  <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+        </foo>
+        ]],
+        [[
+        <foo>
+            some text
+</foo>
+        ]]
+      )
+    end)
+  end)
+
+  describe('single-line', function()
+    describe('left', function()
+      it('works with daW', function()
+        run_simple_test({ 1, 11 }, 'd[aW', 'sometext.morethings', 'rethings')
+      end)
+
+      it('works with das', function()
+        run_simple_test(
+          { 1, 19 },
+          'd[as',
+          'some sentences. With text and stuff. other code',
+          'some sentences. h text and stuff. other code'
+        )
+      end)
+
+      it('works with daw', function()
+        run_simple_test({ 1, 2 }, 'd[aw', 'sometext.morethings', 'metext.morethings')
+      end)
+
+      it('works with da[', function()
+        run_simple_test({ 1, 15 }, 'd[a[', 'some text [ inner text ] t', 'some text er text ] t')
+      end)
+
+      it('works with da{', function()
+        run_simple_test({ 1, 15 }, 'd[a{', 'some text { inner text }   ', 'some text er text }   ')
+      end)
+
+      it('works with dis', function()
+        run_simple_test(
+          { 1, 23 },
+          'd[is',
+          'some sentences. With text and stuff. other code',
+          'some sentences. xt and stuff. other code'
+        )
+      end)
+
+      it('works with di[', function()
+        run_simple_test({ 1, 15 }, 'd[i[', 'some text [ inner text ]   ', 'some text [er text ]   ')
+      end)
+
+      it('works with di{', function()
+        run_simple_test({ 1, 15 }, 'd[i{', 'some text { inner text }   ', 'some text {er text }   ')
+      end)
+    end)
+
+    describe('right', function()
+      it('works with daW', function()
+        run_simple_test({ 1, 2 }, 'd]aW', 'sometext.morethings', 'so')
+      end)
+
+      it('works with daw', function()
+        run_simple_test({ 1, 2 }, 'd]aw', 'sometext.morethings', 'so.morethings')
+      end)
+
+      it('works with da]', function()
+        run_simple_test({ 1, 15 }, 'd]a]', 'some text [ inner text ]   ', 'some text [ inn   ')
+      end)
+
+      it('works with da}', function()
+        run_simple_test({ 1, 15 }, 'd]a}', 'some text { inner text }   ', 'some text { inn   ')
+      end)
+
+      it('works with di]', function()
+        run_simple_test({ 1, 15 }, 'd]i]', 'some text [ inner text ]   ', 'some text [ inn]   ')
+      end)
+
+      it('works with di}', function()
+        run_simple_test({ 1, 15 }, 'd[i}', 'some text { inner text }   ', 'some text {er text }   ')
+      end)
+    end)
+  end)
+
+  describe('up', function()
+    it('works with da)', function()
+      run_simple_test(
+        { 7, 0 },
+        'd[a)',
+        [[
+        (
+            some text
+                more text
+                even more lines!
+            still part of the paragraph
+
+            more lines  <-- NOTE: The cursor will be set here
+            last line
+        )
+
+        (
+            another paragraph
+            with text in it
+        )
+        ]],
+        [[
+            more lines  <-- NOTE: The cursor will be set here
+            last line
+        )
+
+        (
+            another paragraph
+            with text in it
+        )
+        ]]
+      )
+    end)
+
+    it('works with da]', function()
+      run_simple_test(
+        { 3, 22 },
+        'd[a]',
+        [[
+        [
+            some text
+                more text  <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+
+            more lines
+        ]
+
+        [
+            another paragraph
+            with text in it
+        ]
+        ]],
+        [[
+        ext  <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+
+            more lines
+        ]
+
+        [
+            another paragraph
+            with text in it
+        ]
+        ]]
+      )
+    end)
+
+    it('works with da}', function()
+      run_simple_test(
+        { 3, 24 },
+        'd[a}',
+        [[
+        {
+            some text
+                more text  <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+
+            more lines
+        }
+
+        {
+            another paragraph
+            with text in it
+        }
+        ]],
+        [[
+        t  <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+
+            more lines
+        }
+
+        {
+            another paragraph
+            with text in it
+        }
+        ]]
+      )
+    end)
+
+    it('works with dat', function()
+      run_simple_test(
+        { 3, 0 },
+        'd[at',
+        [[
+        <foo>
+            some text
+                more text <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+        </foo>
+        ]],
+        [[
+                more text <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+        </foo>
+        ]]
+      )
+    end)
+
+    it('works with dap', function()
+      run_simple_test(
+        { 7, 0 },
+        'd[ap',
+        [[
+        some text
+            more text
+            even more lines!
+        still part of the paragraph
+
+        first line, second paragraph
+        another paragraph  <-- NOTE: The cursor will be set here
+        with text in it
+        ]],
+        [[
+        some text
+            more text
+            even more lines!
+        still part of the paragraph
+
+        with text in it
+        ]]
+      )
+    end)
+
+    it('works with di)', function()
+      run_simple_test(
+        { 3, 0 },
+        'd[i)',
+        [[
+        (
+            some text
+                more text  <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+
+            more lines
+        )
+
+        (
+            another paragraph
+            with text in it
+        )
+        ]],
+        [[
+        (
+                even more lines!
+            still part of the paragraph
+
+            more lines
+        )
+
+        (
+            another paragraph
+            with text in it
+        )
+        ]]
+      )
+    end)
+
+    it('works with di]', function()
+      run_simple_test(
+        { 3, 0 },
+        'd[i]',
+        [[
+        [
+            some text
+                more text  <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+
+            more lines
+        ]
+
+        [
+            another paragraph
+            with text in it
+        ]
+        ]],
+        [[
+        [
+                even more lines!
+            still part of the paragraph
+
+            more lines
+        ]
+
+        [
+            another paragraph
+            with text in it
+        ]
+        ]]
+      )
+    end)
+
+    it('works with di}', function()
+      run_simple_test(
+        { 3, 0 },
+        'd[i}',
+        [[
+        {
+            some text
+                more text  <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+
+            more lines
+        }
+
+        {
+            another paragraph
+            with text in it
+        }
+        ]],
+        [[
+        {
+                even more lines!
+            still part of the paragraph
+
+            more lines
+        }
+
+        {
+            another paragraph
+            with text in it
+        }
+        ]]
+      )
+    end)
+
+    it('works with dip', function()
+      run_simple_test(
+        { 2, 23 },
+        'd[ip',
+        [[
+        some text
+            more text <-- NOTE: The cursor will be set here
+            even more lines!
+        still part of the paragraph
+
+        another paragraph
+        with text in it
+        ]],
+        [[
+            even more lines!
+        still part of the paragraph
+
+        another paragraph
+        with text in it
+        ]]
+      )
+    end)
+
+    it('works with dis', function()
+      run_simple_test(
+        { 1, 19 },
+        'd[is',
+        'some sentences. With text and stuff. other code',
+        'some sentences. h text and stuff. other code'
+      )
+    end)
+
+    it('works with dit - 001', function()
+      run_simple_test(
+        { 3, 0 },
+        'd[it',
+        [[
+        <foo>
+            some text
+                more text <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+        </foo>
+        ]],
+        [[
+        <foo>
+                more text <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+        </foo>
+        ]]
+      )
+    end)
+
+    it('works with dit - 002 - Include characters', function()
+      run_simple_test(
+        { 3, 23 },
+        'd[it',
+        [[
+        <foo>  some text
+            some text
+                more text <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+        </foo>
+        ]],
+        [[
+        <foo>xt <-- NOTE: The cursor will be set here
+                even more lines!
+            still part of the paragraph
+        </foo>
+        ]]
+      )
+    end)
+  end)
+end)
+
+describe(':help gU', function()
+  describe('down', function()
+    it('works with gUip', function()
+      run_simple_test(
+        { 5, 0 },
+        'gU]ip',
+        [[
+        aaaa
+        bbbbb
+
+        ccccc
+        ddddddddddd  <-- NOTE: The cursor will be set here
+        eeeeeeeee
+
+        fffff
+        ]],
+        [[
+        aaaa
+        bbbbb
+
+        ccccc
+        DDDDDDDDDDD  <-- NOTE: THE CURSOR WILL BE SET HERE
+        EEEEEEEEE
+
+        fffff
+        ]]
+      )
+    end)
+  end)
+
+  describe('up', function()
+    it('works with gUip', function()
+      run_simple_test(
+        { 5, 0 },
+        'gU[ip',
+        [[
+        aaaa
+        bbbbb
+
+        ccccc
+        ddddddddddd  <-- NOTE: The cursor will be set here
+        eeeeeeeee
+
+        fffff
+        ]],
+        [[
+        aaaa
+        bbbbb
+
+        CCCCC
+        DDDDDDDDDDD  <-- NOTE: THE CURSOR WILL BE SET HERE
+        eeeeeeeee
+
+        fffff
+        ]]
+      )
+    end)
+  end)
+end)
+
+describe(':help gc', function()
+  describe('down', function()
+    it('works with gcip', function()
+      local buffer, window = make_buffer(
+        [[
+                def foo() -> None:
+                    """Some function."""  <-- NOTE: The cursor will be set here
+                    print("do stuff")
+
+                    for _ in range(10):
+                        print("stuff")
+                ]],
+        'python'
+      )
+      api.nvim_win_set_cursor(window, { 2, 0 })
+      set_commentstring('# %s')
+
+      call_command('gc]ip')
+
+      eq(
+        [[
+                def foo() -> None:
+                    # """Some function."""  <-- NOTE: The cursor will be set here
+                    # print("do stuff")
+
+                    for _ in range(10):
+                        print("stuff")
+                ]],
+        get_lines(buffer)
+      )
+    end)
+  end)
+
+  describe('up', function()
+    it('works with gcip', function()
+      local buffer, window = make_buffer(
+        [[
+                def foo() -> None:
+                    """Some function."""  <-- NOTE: The cursor will be set here
+                    print("do stuff")
+
+                    for _ in range(10):
+                        print("stuff")
+                ]],
+        'python'
+      )
+      api.nvim_win_set_cursor(window, { 2, 0 })
+      set_commentstring('# %s', buffer)
+
+      call_command('gc[ip')
+
+      eq(
+        [[
+                # def foo() -> None:
+                #     """Some function."""  <-- NOTE: The cursor will be set here
+                    print("do stuff")
+
+                    for _ in range(10):
+                        print("stuff")
+                ]],
+        get_lines(buffer)
+      )
+    end)
+  end)
+end)
+
+describe(':help gu', function()
+  describe('down', function()
+    it('works with guip', function()
+      run_simple_test(
+        { 5, 0 },
+        'gu]ip',
+        [[
+        aaaa
+        bbbbb
+
+        ccccc
+        ddDddDddDdd  <-- NOTE: The cursor will be set here
+        eeeEeEEee
+
+        fffff
+        ]],
+        [[
+        aaaa
+        bbbbb
+
+        ccccc
+        ddddddddddd  <-- note: the cursor will be set here
+        eeeeeeeee
+
+        fffff
+        ]]
+      )
+    end)
+  end)
+
+  describe('up', function()
+    it('works with guip', function()
+      run_simple_test(
+        { 5, 0 },
+        'gu[ip',
+        [[
+        aaaa
+        bbbbb
+
+        cCCcc
+        ddDddDddDdd  <-- NOTE: The cursor will be set here
+        eeeEeEEee
+
+        fffff
+        ]],
+        [[
+        aaaa
+        bbbbb
+
+        ccccc
+        ddddddddddd  <-- note: the cursor will be set here
+        eeeEeEEee
+
+        fffff
+        ]]
+      )
+    end)
+  end)
+end)
+
+describe(':help g~', function()
+  describe('down', function()
+    it('works with g~ip', function()
+      run_simple_test(
+        { 5, 0 },
+        'g~]ip',
+        [[
+        aaaa
+        bbbbb
+
+        cCCcc
+        ddDddDddDdd  <-- NOTE: The cursor will be set here
+        eeeEeEEee
+
+        fffff
+        ]],
+        [[
+        aaaa
+        bbbbb
+
+        cCCcc
+        DDdDDdDDdDD  <-- note: tHE CURSOR WILL BE SET HERE
+        EEEeEeeEE
+
+        fffff
+        ]]
+      )
+    end)
+  end)
+
+  describe('up', function()
+    it('works with g~ip', function()
+      run_simple_test(
+        { 5, 0 },
+        'g~[ip',
+        [[
+        aaaa
+        bbbbb
+
+        cCCcc
+        ddDddDddDdd  <-- NOTE: The cursor will be set here
+        eeeEeEEee
+
+        fffff
+        ]],
+        [[
+        aaaa
+        bbbbb
+
+        CccCC
+        DDdDDdDDdDD  <-- note: tHE CURSOR WILL BE SET HERE
+        eeeEeEEee
+
+        fffff
+        ]]
+      )
+    end)
+  end)
+end)
+
+describe(':help y', function()
+  describe('down', function()
+    it('works with yap', function()
+      local _, window = make_buffer([[
+                aaaa
+                bbbb  <-- NOTE: The cursor will be set here
+                    cccc
+
+                next
+                lines
+                    blah
+
+                ]])
+      api.nvim_win_set_cursor(window, { 2, 0 })
+
+      call_command('y]ap')
+
+      eq(
+        [[
+                bbbb  <-- NOTE: The cursor will be set here
+                    cccc
+
+]],
+        fn.getreg('')
+      )
+    end)
+  end)
+
+  describe('up', function()
+    it('works with yap', function()
+      local _, window = make_buffer([[
+                aaaa
+                bbbb  <-- NOTE: The cursor will be set here
+                    cccc
+
+                next
+                lines
+                    blah
+
+                ]])
+      api.nvim_win_set_cursor(window, { 2, 0 })
+
+      call_command('y[ap')
+
+      eq(
+        '                aaaa\n                bbbb  <-- NOTE: The cursor will be set here\n',
+        fn.getreg('')
+      )
+    end)
+  end)
+end)
+
+describe('marks', function()
+  describe("marks - '", function()
+    describe('down', function()
+      it('works with yank', function()
+        local buffer, window = make_buffer([[
+                    aaaa
+                    bbbb  <-- NOTE: The cursor will be set here
+                        cccc
+
+                    next
+                    lines
+                        blah
+
+                    ]])
+        api.nvim_win_set_cursor(window, { 2, 0 })
+
+        api.nvim_buf_set_mark(buffer, 'b', 6, 18, {})
+
+        call_command("y]'b")
+
+        eq(
+          [[
+                    bbbb  <-- NOTE: The cursor will be set here
+                        cccc
+
+                    next
+                    lines
+]],
+          fn.getreg('')
+        )
+      end)
+    end)
+
+    describe('up', function()
+      it('works with yank', function()
+        local buffer, window = make_buffer([[
+                    aaaa
+                    bbbb
+                        cccc
+
+                    next
+                    lines <-- NOTE: The cursor will be set here
+                        blah
+
+                    ]])
+        api.nvim_win_set_cursor(window, { 6, 19 })
+
+        api.nvim_buf_set_mark(buffer, 'b', 2, 19, {})
+
+        call_command("y['b")
+
+        eq(
+          [[
+                    bbbb
+                        cccc
+
+                    next
+                    lines <-- NOTE: The cursor will be set here
+]],
+          fn.getreg('')
+        )
+      end)
+    end)
+  end)
+
+  describe('marks - `', function()
+    describe('down', function()
+      it('works with yank', function()
+        local buffer, window = make_buffer([[
+                    aaaa
+                    bbbb  <-- NOTE: The cursor will be set here
+                        cccc
+
+                    next
+                    lines
+                        blah
+
+                    ]])
+        api.nvim_win_set_cursor(window, { 2, 22 })
+
+        api.nvim_buf_set_mark(buffer, 'b', 6, 22, {})
+
+        call_command('y]`b')
+
+        eq(
+          [[bb  <-- NOTE: The cursor will be set here
+                        cccc
+
+                    next
+                    li]],
+          fn.getreg('')
+        )
+      end)
+    end)
+
+    describe('up', function()
+      it('works with yank', function()
+        local buffer, window = make_buffer([[
+                    aaaa
+                    bbbb
+                        cccc
+
+                    next
+                    lines <-- NOTE: The cursor will be set here
+                        blah
+
+                    ]])
+        api.nvim_win_set_cursor(window, { 6, 23 })
+
+        api.nvim_buf_set_mark(buffer, 'b', 2, 23, {})
+
+        call_command('y[`b')
+
+        eq(
+          [[b
+                        cccc
+
+                    next
+                    lin]],
+          fn.getreg('')
+        )
+      end)
+    end)
+  end)
+end)
+
+describe('scenario', function()
+  it('works with a curly function - da{', function()
+    run_simple_test(
+      { 3, 0 },
+      'd[a{',
+      fn.join({
+        'void main() {',
+        '  something',
+        '  ttttt <-- NOTE: The cursor will be set here',
+        '  fffff',
+        '}',
+      }, '\n'),
+      fn.join(
+        { 'void main() ', '  ttttt <-- NOTE: The cursor will be set here', '  fffff', '}' },
+        '\n'
+      )
+    )
+  end)
+
+  it('works with a curly function - di{', function()
+    run_simple_test(
+      { 3, 0 },
+      'd[i{',
+      [[
+      void main() {
+        something
+        ttttt <-- NOTE: The cursor will be set here
+        fffff
+      }
+      ]],
+      [[
+      void main() {
+        fffff
+      }
+      ]]
+    )
+  end)
+end)


### PR DESCRIPTION
Closes: https://github.com/neovim/neovim/issues/30729

This PR introduces two new pending operators: `[` and `]`.

In Neovim/Vim, `dip` deletes a paragraph under the current cursor. This PR now supports two new mappings, `d[ip` and `d]ip`.

- `d[ip` means "delete from the start of the paragraph to the current cursor position"
- `d]ip` means "delete from the current cursor position to the bottom of the paragraph"

Most `{operator}{object}` pairs, for example `dap`, `yip`, `cas`, `daw`, etc etc now have a `{operator}[{object}` and `{operator}]{object}` equivalent.

And of course, this works for custom text objects / plugins. These new `[` and `]` pending operators greatly improve the flexibility and expressiveness of Vim text objects!


## How It Works
When a user types `d]ap`, we ...

1. Save the user's current cursor, `v:operator`, `operatorfunc`, and other details as needed
2. Replace `operatorfunc` with our own.
3. Immediately execute the replaced `operatorfunc`.

And once executing...

1. Restore the previous cursor position, previous `v:operator`, and `operatorfunc`
2. If `[` or `]` was pressed, nudge the Vim `'[` or `']` marks if needed
3. Execute the operation

For anyone familiar, this PR is a lua version of [vim-ninja-feet](https://github.com/tommcdo/vim-ninja-feet). Props goes to Tom for the awesome idea!


## Considerations For Reviewers
Here's some extra things that are not in the PR but could be useful / importing to consider.


### Question 1 - Should the operator include / exclude the current line (for line-wise text objects)?

<details>
<summary>Click to expand</summary>

When operating over whole-lines, `[` can be thought of "searching up" for lines and is `]` "searching down". When that happens, should the current cursor's line be included in the search?

For example take this paragraph of text

```
aaa
bbbb  <-- NOTE: The user's cursor is here
cc
```

If we `d]ip` should the `bbbb` line also be deleted? What about if we use `d[ip`? Should the `bbbb` line be deleted or ignored also?

Currently this PR does "always delete the line, whether we call `[` or `]`".

I was thinking maybe this could be solved in one of two ways.


#### Idea 1 - 4 mappings
Instead of providing `[` and `]` we provide `[/[[` and `]/]]`. So `d[ap` could include the cursor line and `d[[ap` could exclude the cursor line. A user could decide while typing if they care to include the line or not.

(Note: I think Idea 2 is better, see below)

#### Idea 2 - Configuration
If we anticipate that a user would always want to include the cursor line / exclude it then there isn't a need to provide a separate mapping for it. Instead we could provide configuration values such as.

```
g:inclusive_pending_cursor = nil / "both" (default, this PR's behavior)
g:inclusive_pending_cursor = "up" (only include the cursor's line if using `[`)
g:inclusive_pending_cursor = "down" (only include the cursor's line if using `]`)
g:inclusive_pending_cursor = "none" (never include the cursor's line)
```

And if the user actually did want the "4 mappings" solution they could define their own omap that temporarily sets `g:inclusive_pending_cursor` before running the regular omap. Which I think makes this idea more flexible than the previous idea.
</details>


### Question 2 - Do we want to consider column info even if the text object is a line?

<details>
<summary>Click to expand</summary>

Text objects like `ip` (e.g. `dip`) operate on whole-lines. Currently, the PR respects this. When a user calls `d[ip`, it respects only the cursor's row and ignores the cursor's column position.

In visual terms imagine you have text like this

```
aaa
bb|your cursor here|tt
cc
```

Typing `d[ip` would result in this:

```
cc
```

If we considered the cursor's column position, the result instead would be

```
tt
cc
```

If a user did want to delete the whole row they could still do it by calling `dd` after calling `d[ip`. But I admit it is a bit wordy. What do you all think?
</details>