### PR TITLE
vim-patch:9.1.0849: there are a few typos in the source

### DIFF
--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -349,7 +349,7 @@ processing a quickfix or location list command, it will be aborted.
 			Example: >
     :g/mypattern/caddexpr expand("%") .. ":" .. line(".") ..  ":" .. getline(".")
 <
-						*:lad* *:addd* *:laddexpr*
+						*:lad* *:ladd* *:laddexpr*
 :lad[dexpr] {expr}	Same as ":caddexpr", except the location list for the
 			current window is used instead of the quickfix list.
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -2196,7 +2196,7 @@ To specify elements that should not be concealed, set the following variable: >
 
 	:let g:pandoc#syntax#conceal#blacklist = []
 
-This is a list of the rules wich can be used here:
+This is a list of the rules which can be used here:
 
   - titleblock
   - image

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2261,7 +2261,7 @@ int do_ecmd(int fnum, char *ffname, char *sfname, exarg_T *eap, linenr_T newlnum
     if (buf == NULL) {
       goto theend;
     }
-    // autocommands try to edit a file that is goind to be removed, abort
+    // autocommands try to edit a file that is going to be removed, abort
     if (buf_locked(buf)) {
       // window was split, but not editing the new buffer, reset b_nwindows again
       if (oldwin == NULL

--- a/test/old/testdir/test_diffmode.vim
+++ b/test/old/testdir/test_diffmode.vim
@@ -2007,7 +2007,7 @@ func Test_diff_overlapped_diff_blocks_will_be_merged()
   call StopVimInTerminal(buf)
 endfunc
 
-" switching windows in diff mode caused an unneccessary scroll
+" switching windows in diff mode caused an unnecessary scroll
 func Test_diff_topline_noscroll()
   CheckScreendump
 


### PR DESCRIPTION
#### vim-patch:9.1.0849: there are a few typos in the source

Problem:  there are a few typos in the source.
Solution: Correct typos (zeertzjq).

closes: vim/vim#16026

https://github.com/vim/vim/commit/7c5152826f61bc968ba539ff6db3a55e75556bf2