### PR TITLE
refactor(highlight): make enum of builtin highlights start with 1

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2161,11 +2161,11 @@ Dict nvim_eval_statusline(String str, Dict(eval_statusline) *opts, Arena *arena,
     if (num_id) {
       stc_hl_id = num_id;
     } else if (statuscol.use_cul) {
-      stc_hl_id = HLF_CLN + 1;
+      stc_hl_id = HLF_CLN;
     } else if (wp->w_p_rnu) {
-      stc_hl_id = (lnum < wp->w_cursor.lnum ? HLF_LNA : HLF_LNB) + 1;
+      stc_hl_id = (lnum < wp->w_cursor.lnum ? HLF_LNA : HLF_LNB);
     } else {
-      stc_hl_id = HLF_N + 1;
+      stc_hl_id = HLF_N;
     }
 
     set_vim_var_nr(VV_LNUM, lnum);

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -220,14 +220,14 @@ static void au_show_for_event(int group, event_T event, const char *pat)
         // show the group name, if it's not the default group
         if (ac->pat->group != AUGROUP_DEFAULT) {
           if (last_group_name == NULL) {
-            msg_puts_hl(get_deleted_augroup(), HLF_E + 1, false);
+            msg_puts_hl(get_deleted_augroup(), HLF_E, false);
           } else {
-            msg_puts_hl(last_group_name, HLF_T + 1, false);
+            msg_puts_hl(last_group_name, HLF_T, false);
           }
           msg_puts("  ");
         }
         // show the event name
-        msg_puts_hl(event_nr2name(event), HLF_T + 1, false);
+        msg_puts_hl(event_nr2name(event), HLF_T, false);
       }
 
       // Show pattern only if it changed.
@@ -260,7 +260,7 @@ static void au_show_for_event(int group, event_T event, const char *pat)
         size_t msglen = 100;
         char *msg = xmallocz(msglen);
         if (ac->exec.type == CALLABLE_CB) {
-          msg_puts_hl(exec_to_string, HLF_8 + 1, false);
+          msg_puts_hl(exec_to_string, HLF_8, false);
           snprintf(msg, msglen, " [%s]", ac->desc);
         } else {
           snprintf(msg, msglen, "%s [%s]", exec_to_string, ac->desc);
@@ -268,7 +268,7 @@ static void au_show_for_event(int group, event_T event, const char *pat)
         msg_outtrans(msg, 0, false);
         XFREE_CLEAR(msg);
       } else if (ac->exec.type == CALLABLE_CB) {
-        msg_puts_hl(exec_to_string, HLF_8 + 1, false);
+        msg_puts_hl(exec_to_string, HLF_8, false);
       } else {
         msg_outtrans(exec_to_string, 0, false);
       }

--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -350,7 +350,7 @@ static int check_mtime(buf_T *buf, FileInfo *file_info)
     msg_scroll = true;  // Don't overwrite messages here.
     msg_silent = 0;     // Must give this prompt.
     // Don't use emsg() here, don't want to flush the buffers.
-    msg(_("WARNING: The file has been changed since reading it!!!"), HLF_E + 1);
+    msg(_("WARNING: The file has been changed since reading it!!!"), HLF_E);
     if (ask_yesno(_("Do you really want to write to it"), true) == 'n') {
       return FAIL;
     }
@@ -1881,7 +1881,7 @@ nofail:
 
     retval = FAIL;
     if (end == 0) {
-      const int hl_id = HLF_E + 1;  // Set highlight for error messages.
+      const int hl_id = HLF_E;  // Set highlight for error messages.
       msg_puts_hl(_("\nWARNING: Original file may be lost or damaged\n"), hl_id, true);
       msg_puts_hl(_("don't quit the editor until the file is successfully written!"), hl_id, true);
 

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -89,9 +89,9 @@ void change_warning(buf_T *buf, int col)
     if (msg_row == Rows - 1) {
       msg_col = col;
     }
-    msg_source(HLF_W + 1);
+    msg_source(HLF_W);
     msg_ext_set_kind("wmsg");
-    msg_puts_hl(_(w_readonly), HLF_W + 1, true);
+    msg_puts_hl(_(w_readonly), HLF_W, true);
     set_vim_var_string(VV_WARNINGMSG, _(w_readonly), -1);
     msg_clr_eos();
     msg_end();

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -986,12 +986,12 @@ static void showmatches_oneline(expand_T *xp, char **matches, int numMatches, in
   int lastlen = 999;
   for (int j = linenr; j < numMatches; j += lines) {
     if (xp->xp_context == EXPAND_TAGS_LISTFILES) {
-      msg_outtrans(matches[j], HLF_D + 1, false);
+      msg_outtrans(matches[j], HLF_D, false);
       p = matches[j] + strlen(matches[j]) + 1;
       msg_advance(maxlen + 1);
       msg_puts(p);
       msg_advance(maxlen + 3);
-      msg_outtrans_long(p + 2, HLF_D + 1);
+      msg_outtrans_long(p + 2, HLF_D);
       break;
     }
     for (int i = maxlen - lastlen; --i >= 0;) {
@@ -1028,7 +1028,7 @@ static void showmatches_oneline(expand_T *xp, char **matches, int numMatches, in
       isdir = false;
       p = SHOW_MATCH(j);
     }
-    lastlen = msg_outtrans(p, isdir ? HLF_D + 1 : 0, false);
+    lastlen = msg_outtrans(p, isdir ? HLF_D : 0, false);
   }
   if (msg_col > 0) {  // when not wrapped around
     msg_clr_eos();
@@ -1119,10 +1119,10 @@ int showmatches(expand_T *xp, bool wildmenu)
     }
 
     if (xp->xp_context == EXPAND_TAGS_LISTFILES) {
-      msg_puts_hl(_("tagname"), HLF_T + 1, false);
+      msg_puts_hl(_("tagname"), HLF_T, false);
       msg_clr_eos();
       msg_advance(maxlen - 3);
-      msg_puts_hl(_(" kind file\n"), HLF_T + 1, false);
+      msg_puts_hl(_(" kind file\n"), HLF_T, false);
     }
 
     // list the files line by line

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1707,7 +1707,7 @@ static void digraph_header(const char *msg)
   if (msg_col > 0) {
     msg_putchar('\n');
   }
-  msg_outtrans(msg, HLF_CM + 1, false);
+  msg_outtrans(msg, HLF_CM, false);
   msg_putchar('\n');
 }
 
@@ -1871,7 +1871,7 @@ static void printdigraph(const digr_T *dp, result_T *previous)
   p += utf_char2bytes(dp->result, p);
 
   *p = NUL;
-  msg_outtrans(buf, HLF_8 + 1, false);
+  msg_outtrans(buf, HLF_8, false);
   p = buf;
   if (char2cells(dp->result) == 1) {
     *p++ = ' ';

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -952,7 +952,7 @@ int showmode(void)
 
     // Position on the last line in the window, column 0
     msg_pos_mode();
-    int hl_id = HLF_CM + 1;  // Highlight mode
+    int hl_id = HLF_CM;  // Highlight mode
 
     // When the screen is too narrow to show the entire mode message,
     // avoid scrolling and truncate instead.
@@ -987,7 +987,7 @@ int showmode(void)
           }
           if (edit_submode_extra != NULL) {
             msg_puts_hl(" ", hl_id, false);  // Add a space in between.
-            int sub_id = edit_submode_highl < HLF_COUNT ? (int)edit_submode_highl + 1 : hl_id;
+            int sub_id = edit_submode_highl < HLF_COUNT ? (int)edit_submode_highl : hl_id;
             msg_puts_hl(edit_submode_extra, sub_id, false);
           }
         }
@@ -1133,7 +1133,7 @@ void clearmode(void)
   msg_ext_ui_flush();
   msg_pos_mode();
   if (reg_recording != 0) {
-    recording_mode(HLF_CM + 1);
+    recording_mode(HLF_CM);
   }
   msg_clr_eos();
   msg_ext_flush_showmode();

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -1342,7 +1342,7 @@ static void f_diff_hlID(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       hlID = HLF_CHD;  // Changed line.
     }
   }
-  rettv->vval.v_number = hlID == (hlf_T)0 ? 0 : (hlID + 1);
+  rettv->vval.v_number = hlID;
 }
 
 /// "empty({expr})" function

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3805,7 +3805,7 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
               msg_no_more = true;
               msg_ext_set_kind("confirm_sub");
               // Same highlight as wait_return().
-              smsg(HLF_R + 1, _("replace with %s (y/n/a/q/l/^E/^Y)?"), sub);
+              smsg(HLF_R, _("replace with %s (y/n/a/q/l/^E/^Y)?"), sub);
               msg_no_more = false;
               msg_scroll = i;
               if (!ui_has(kUIMessages)) {

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -450,7 +450,7 @@ int buf_write_all(buf_T *buf, bool forceit)
                           1, buf->b_ml.ml_line_count, NULL,
                           false, forceit, true, false));
   if (curbuf != old_curbuf) {
-    msg_source(HLF_W + 1);
+    msg_source(HLF_W);
     msg(_("Warning: Entered other buffer unexpectedly (check autocommands)"), 0);
   }
   return retval;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5501,7 +5501,7 @@ static void ex_tabs(exarg_T *eap)
 
     msg_putchar('\n');
     vim_snprintf(IObuff, IOSIZE, _("Tab page %d"), tabcount++);
-    msg_outtrans(IObuff, HLF_T + 1, false);
+    msg_outtrans(IObuff, HLF_T, false);
     os_breakcheck();
 
     FOR_ALL_WINDOWS_IN_TAB(wp, tp) {
@@ -7776,7 +7776,7 @@ void verify_command(char *cmd)
   if (strcmp("smile", cmd) != 0) {
     return;  // acceptable non-existing command
   }
-  int a = HLF_E + 1;
+  int a = HLF_E;
   msg(" #xxn`          #xnxx`        ,+x@##@Mz;`        .xxx"
       "xxxxxxnz+,      znnnnnnnnnnnnnnnn.", a);
   msg(" n###z          x####`      :x##########W+`      ,###"

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -811,7 +811,7 @@ static uint8_t *command_line_enter(int firstc, int count, int indent, bool clear
     if (!tl_ret && ERROR_SET(&err)) {
       msg_putchar('\n');
       msg_scroll = true;
-      msg_puts_hl(err.msg, HLF_E + 1, true);
+      msg_puts_hl(err.msg, HLF_E, true);
       api_clear_error(&err);
       redrawcmd();
     }
@@ -2660,7 +2660,7 @@ static void do_autocmd_cmdlinechanged(int firstc)
     if (!tl_ret && ERROR_SET(&err)) {
       msg_putchar('\n');
       msg_scroll = true;
-      msg_puts_hl(err.msg, HLF_E + 1, true);
+      msg_puts_hl(err.msg, HLF_E, true);
       api_clear_error(&err);
       redrawcmd();
     }
@@ -3141,7 +3141,7 @@ static bool color_cmdline(CmdlineInfo *colored_ccline)
 #define PRINT_ERRMSG(...) \
   do { \
     msg_putchar('\n'); \
-    msg_printf_hl(HLF_E + 1, __VA_ARGS__); \
+    msg_printf_hl(HLF_E, __VA_ARGS__); \
     printed_errmsg = true; \
   } while (0)
   bool ret = true;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3035,9 +3035,9 @@ int buf_check_timestamp(buf_T *buf)
     } else {
       if (!autocmd_busy) {
         msg_start();
-        msg_puts_hl(tbuf, HLF_E + 1, true);
+        msg_puts_hl(tbuf, HLF_E, true);
         if (*mesg2 != NUL) {
-          msg_puts_hl(mesg2, HLF_W + 1, true);
+          msg_puts_hl(mesg2, HLF_W, true);
         }
         msg_clr_eos();
         msg_end();

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -48,7 +48,7 @@ static Set(cstr_t) urls = SET_INIT;
 
 /// highlight entries private to a namespace
 static Map(ColorKey, ColorItem) ns_hls;
-typedef int NSHlAttr[HLF_COUNT + 1];
+typedef int NSHlAttr[HLF_COUNT];
 static PMap(int) ns_hl_attr;
 
 void highlight_init(void)
@@ -371,8 +371,8 @@ void update_window_hl(win_T *wp, bool invalid)
   bool float_win = wp->w_floating && !wp->w_config.external;
   if (float_win && hl_def[HLF_NFLOAT] != 0 && ns_id > 0) {
     wp->w_hl_attr_normal = hl_def[HLF_NFLOAT];
-  } else if (hl_def[HLF_COUNT] > 0) {
-    wp->w_hl_attr_normal = hl_def[HLF_COUNT];
+  } else if (hl_def[HLF_NONE] > 0) {
+    wp->w_hl_attr_normal = hl_def[HLF_NONE];
   } else if (float_win) {
     wp->w_hl_attr_normal = HL_ATTR(HLF_NFLOAT) > 0
                            ? HL_ATTR(HLF_NFLOAT) : highlight_attr[HLF_NFLOAT];
@@ -433,7 +433,7 @@ void update_ns_hl(int ns_id)
   }
   int *hl_attrs = **alloc;
 
-  for (int hlf = 0; hlf < HLF_COUNT; hlf++) {
+  for (int hlf = 1; hlf < HLF_COUNT; hlf++) {
     int id = syn_check_group(hlf_names[hlf], strlen(hlf_names[hlf]));
     bool optional = (hlf == HLF_INACTIVE || hlf == HLF_NFLOAT);
     hl_attrs[hlf] = hl_get_ui_attr(ns_id, hlf, id, optional);
@@ -444,7 +444,7 @@ void update_ns_hl(int ns_id)
   //
   // haha, tema engine go brrr
   int normality = syn_check_group(S_LEN("Normal"));
-  hl_attrs[HLF_COUNT] = hl_get_ui_attr(ns_id, -1, normality, true);
+  hl_attrs[HLF_NONE] = hl_get_ui_attr(ns_id, -1, normality, true);
 
   // hl_get_ui_attr might have invalidated the decor provider
   p = get_decor_provider(ns_id, true);
@@ -461,7 +461,7 @@ int win_bg_attr(win_T *wp)
   }
 
   if (wp == curwin || hl_attr_active[HLF_INACTIVE] == 0) {
-    return hl_attr_active[HLF_COUNT];
+    return hl_attr_active[HLF_NONE];
   } else {
     return hl_attr_active[HLF_INACTIVE];
   }

--- a/src/nvim/highlight.h
+++ b/src/nvim/highlight.h
@@ -84,7 +84,7 @@ EXTERN const char *hlf_names[] INIT( = {
   [HLF_TSNC] = "StatusLineTermNC",
 });
 
-EXTERN int highlight_attr[HLF_COUNT + 1];     // Highl. attr for each context.
+EXTERN int highlight_attr[HLF_COUNT];     // Highl. attr for each context.
 EXTERN int highlight_attr_last[HLF_COUNT];  // copy for detecting changed groups
 EXTERN int highlight_user[9];                   // User[1-9] attributes
 EXTERN int highlight_stlnc[9];                  // On top of user

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -58,7 +58,8 @@ typedef struct {
 /// Values for index in highlight_attr[].
 /// When making changes, also update hlf_names in highlight.h!
 typedef enum {
-  HLF_8 = 0,      ///< Meta & special keys listed with ":map", text that is
+  HLF_NONE = 0,   ///< no UI highlight active
+  HLF_8,          ///< Meta & special keys listed with ":map", text that is
                   ///< displayed different from what it is
   HLF_EOB,        ///< after the last line in the buffer
   HLF_TERM,       ///< terminal cursor focused

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1621,7 +1621,7 @@ static void highlight_list_one(const int id)
   if (sgp->sg_link && !got_int) {
     syn_list_header(didh, 0, id, true);
     didh = true;
-    msg_puts_hl("links to", HLF_D + 1, false);
+    msg_puts_hl("links to", HLF_D, false);
     msg_putchar(' ');
     msg_outtrans(hl_table[hl_table[id - 1].sg_link - 1].sg_name, 0, false);
   }
@@ -1751,8 +1751,8 @@ static bool highlight_list_arg(const int id, bool didh, const int type, int iarg
   didh = true;
   if (!got_int) {
     if (*name != NUL) {
-      msg_puts_hl(name, HLF_D + 1, false);
-      msg_puts_hl("=", HLF_D + 1, false);
+      msg_puts_hl(name, HLF_D, false);
+      msg_puts_hl("=", HLF_D, false);
     }
     msg_outtrans(ts, 0, false);
   }
@@ -2047,7 +2047,7 @@ static int syn_add_group(const char *name, size_t len)
       return 0;
     } else if (!ASCII_ISALNUM(c) && c != '_' && c != '.' && c != '@' && c != '-') {
       // '.' and '@' are allowed characters for use with treesitter capture names.
-      msg_source(HLF_W + 1);
+      msg_source(HLF_W);
       emsg(_(e_highlight_group_name_invalid_char));
       return 0;
     }
@@ -2246,8 +2246,11 @@ void highlight_changed(void)
 
   need_highlight_changed = false;
 
+  // sentinel value. used when no highlight is active
+  highlight_attr[HLF_NONE] = 0;
+
   /// Translate builtin highlight groups into attributes for quick lookup.
-  for (int hlf = 0; hlf < HLF_COUNT; hlf++) {
+  for (int hlf = 1; hlf < HLF_COUNT; hlf++) {
     int id = syn_check_group(hlf_names[hlf], strlen(hlf_names[hlf]));
     if (id == 0) {
       abort();
@@ -2274,9 +2277,6 @@ void highlight_changed(void)
       highlight_attr_last[hlf] = highlight_attr[hlf];
     }
   }
-
-  // sentinel value. used when no highlight namespace is active
-  highlight_attr[HLF_COUNT] = 0;
 
   // Setup the user highlights
   //
@@ -2361,7 +2361,7 @@ void set_context_in_highlight_cmd(expand_T *xp, const char *arg)
 static void highlight_list(void)
 {
   for (int i = 10; --i >= 0;) {
-    highlight_list_two(i, HLF_D + 1);
+    highlight_list_two(i, HLF_D);
   }
   for (int i = 40; --i >= 0;) {
     highlight_list_two(99, 0);

--- a/src/nvim/input.c
+++ b/src/nvim/input.c
@@ -55,7 +55,7 @@ int ask_yesno(const char *const str, const bool direct)
   int r = ' ';
   while (r != 'y' && r != 'n') {
     // same highlighting as for wait_return()
-    smsg(HLF_R + 1, "%s (y/n)?", str);
+    smsg(HLF_R, "%s (y/n)?", str);
     if (direct) {
       r = get_keystroke(NULL);
     } else {

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -473,7 +473,7 @@ bool check_compl_option(bool dict_opt)
     ctrl_x_mode = CTRL_X_NORMAL;
     edit_submode = NULL;
     msg((dict_opt ? _("'dictionary' option is empty") : _("'thesaurus' option is empty")),
-        HLF_E + 1);
+        HLF_E);
     if (emsg_silent == 0 && !in_assert_fails) {
       vim_beep(BO_COMPL);
       setcursor();
@@ -1564,7 +1564,7 @@ static void ins_compl_files(int count, char **files, bool thesaurus, int flags,
       msg_hist_off = true;  // reset in msg_trunc()
       vim_snprintf(IObuff, IOSIZE,
                    _("Scanning dictionary: %s"), files[i]);
-      msg_trunc(IObuff, true, HLF_R + 1);
+      msg_trunc(IObuff, true, HLF_R);
     }
 
     if (fp == NULL) {
@@ -3046,7 +3046,7 @@ static int process_next_cpt_value(ins_compl_next_state_T *st, int *compl_type_ar
                    : st->ins_buf->b_sfname == NULL
                    ? st->ins_buf->b_fname
                    : st->ins_buf->b_sfname);
-      msg_trunc(IObuff, true, HLF_R + 1);
+      msg_trunc(IObuff, true, HLF_R);
     }
   } else if (*st->e_cpt == NUL) {
     status = INS_COMPL_CPT_END;
@@ -3074,7 +3074,7 @@ static int process_next_cpt_value(ins_compl_next_state_T *st, int *compl_type_ar
       if (!shortmess(SHM_COMPLETIONSCAN)) {
         msg_hist_off = true;  // reset in msg_trunc()
         vim_snprintf(IObuff, IOSIZE, "%s", _("Scanning tags."));
-        msg_trunc(IObuff, true, HLF_R + 1);
+        msg_trunc(IObuff, true, HLF_R);
       }
     }
 

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -239,9 +239,9 @@ static void showmap(mapblock_T *mp, bool local)
   } while (len < 12);
 
   if (mp->m_noremap == REMAP_NONE) {
-    msg_puts_hl("*", HLF_8 + 1, false);
+    msg_puts_hl("*", HLF_8, false);
   } else if (mp->m_noremap == REMAP_SCRIPT) {
-    msg_puts_hl("&", HLF_8 + 1, false);
+    msg_puts_hl("&", HLF_8, false);
   } else {
     msg_putchar(' ');
   }
@@ -256,10 +256,10 @@ static void showmap(mapblock_T *mp, bool local)
   // the rhs, and not M-x etc, true gets both -- webb
   if (mp->m_luaref != LUA_NOREF) {
     char *str = nlua_funcref_str(mp->m_luaref, NULL);
-    msg_puts_hl(str, HLF_8 + 1, false);
+    msg_puts_hl(str, HLF_8, false);
     xfree(str);
   } else if (mp->m_str[0] == NUL) {
-    msg_puts_hl("<Nop>", HLF_8 + 1, false);
+    msg_puts_hl("<Nop>", HLF_8, false);
   } else {
     msg_outtrans_special(mp->m_str, false, 0);
   }

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -959,7 +959,7 @@ static void show_one_mark(int c, char *arg, pos_T *p, char *name_arg, int curren
         snprintf(IObuff, IOSIZE, " %c %6" PRIdLINENR " %4d ", c, p->lnum, p->col);
         msg_outtrans(IObuff, 0, false);
         if (name != NULL) {
-          msg_outtrans(name, current ? HLF_D + 1 : 0, false);
+          msg_outtrans(name, current ? HLF_D : 0, false);
         }
       }
     }
@@ -1083,7 +1083,7 @@ void ex_jumps(exarg_T *eap)
                i > curwin->w_jumplistidx ? i - curwin->w_jumplistidx : curwin->w_jumplistidx - i,
                curwin->w_jumplist[i].fmark.mark.lnum, curwin->w_jumplist[i].fmark.mark.col);
       msg_outtrans(IObuff, 0, false);
-      msg_outtrans(name, curwin->w_jumplist[i].fmark.fnum == curbuf->b_fnum ? HLF_D + 1 : 0, false);
+      msg_outtrans(name, curwin->w_jumplist[i].fmark.fnum == curbuf->b_fnum ? HLF_D : 0, false);
       xfree(name);
       os_breakcheck();
     }
@@ -1120,7 +1120,7 @@ void ex_changes(exarg_T *eap)
                curbuf->b_changelist[i].mark.col);
       msg_outtrans(IObuff, 0, false);
       char *name = mark_line(&curbuf->b_changelist[i].mark, 17);
-      msg_outtrans(name, HLF_D + 1, false);
+      msg_outtrans(name, HLF_D, false);
       xfree(name);
       os_breakcheck();
     }

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -852,7 +852,7 @@ void ml_recover(bool checkext)
   // be set to the real value below.
   mfp->mf_page_size = MIN_SWAP_PAGE_SIZE;
 
-  int hl_id = HLF_E + 1;
+  int hl_id = HLF_E;
   // try to read block 0
   if ((hp = mf_get(mfp, 0, 1)) == NULL) {
     msg_start();

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -808,7 +808,7 @@ static void show_menus_recursive(vimmenu_T *menu, int modes, int depth)
       msg_puts(" ");
     }
     // Same highlighting as for directories!?
-    msg_outtrans(menu->name, HLF_D + 1, false);
+    msg_outtrans(menu->name, HLF_D, false);
   }
 
   if (menu != NULL && menu->children == NULL) {
@@ -841,7 +841,7 @@ static void show_menus_recursive(vimmenu_T *menu, int modes, int depth)
         }
         msg_puts(" ");
         if (*menu->strings[bit] == NUL) {
-          msg_puts_hl("<Nop>", HLF_8 + 1, false);
+          msg_puts_hl("<Nop>", HLF_8, false);
         } else {
           msg_outtrans_special(menu->strings[bit], false, 0);
         }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -609,7 +609,7 @@ void msg_source(int hl_id)
   }
   p = get_emsg_lnum();
   if (p != NULL) {
-    msg(p, HLF_N + 1);
+    msg(p, HLF_N);
     xfree(p);
     last_sourcing_lnum = SOURCING_LNUM;      // only once for each line
   }
@@ -738,7 +738,7 @@ bool emsg_multiline(const char *s, bool multiline)
   }
 
   emsg_on_display = true;     // remember there is an error message
-  int hl_id = HLF_E + 1;      // set highlight mode for error messages
+  int hl_id = HLF_E;      // set highlight mode for error messages
   if (msg_scrolled != 0) {
     need_wait_return = true;  // needed in case emsg() is called after
   }                           // wait_return() has reset need_wait_return
@@ -1342,7 +1342,7 @@ static void hit_return_msg(bool newline_sb)
     msg_puts(_("Interrupt: "));
   }
 
-  msg_puts_hl(_("Press ENTER or type command to continue"), HLF_R + 1, false);
+  msg_puts_hl(_("Press ENTER or type command to continue"), HLF_R, false);
   if (!msg_use_printf()) {
     msg_clr_eos();
   }
@@ -1587,7 +1587,7 @@ int msg_outtrans_len(const char *msgstr, int len, int hl_id, bool hist)
           msg_puts_len(plain_start, str - plain_start, hl_id, hist);
         }
         plain_start = str + mb_l;
-        msg_puts_hl(transchar_buf(NULL, c), hl_id == 0 ? HLF_8 + 1 : hl_id, false);
+        msg_puts_hl(transchar_buf(NULL, c), hl_id == 0 ? HLF_8 : hl_id, false);
         retval += char2cells(c);
       }
       len -= mb_l - 1;
@@ -1601,7 +1601,7 @@ int msg_outtrans_len(const char *msgstr, int len, int hl_id, bool hist)
           msg_puts_len(plain_start, str - plain_start, hl_id, hist);
         }
         plain_start = str + 1;
-        msg_puts_hl(s, hl_id == 0 ? HLF_8 + 1 : hl_id, false);
+        msg_puts_hl(s, hl_id == 0 ? HLF_8 : hl_id, false);
         retval += (int)strlen(s);
       } else {
         retval++;
@@ -1662,7 +1662,7 @@ int msg_outtrans_special(const char *strstart, bool from, int maxlen)
   }
   const char *str = strstart;
   int retval = 0;
-  int hl_id = HLF_8 + 1;
+  int hl_id = HLF_8;
 
   while (*str != NUL) {
     const char *text;
@@ -1938,13 +1938,13 @@ void msg_prt_line(const char *s, bool list)
                : curwin->w_p_lcs_chars.tab1;
           sc_extra = curwin->w_p_lcs_chars.tab2;
           sc_final = curwin->w_p_lcs_chars.tab3;
-          hl_id = HLF_0 + 1;
+          hl_id = HLF_0;
         }
       } else if (c == NUL && list && curwin->w_p_lcs_chars.eol != NUL) {
         p_extra = "";
         n_extra = 1;
         sc = curwin->w_p_lcs_chars.eol;
-        hl_id = HLF_AT + 1;
+        hl_id = HLF_AT;
         s--;
       } else if (c != NUL && (n = byte2cells(c)) > 1) {
         n_extra = n - 1;
@@ -1952,7 +1952,7 @@ void msg_prt_line(const char *s, bool list)
         sc = schar_from_ascii(*p_extra++);
         // Use special coloring to be able to distinguish <hex> from
         // the same in plain text.
-        hl_id = HLF_0 + 1;
+        hl_id = HLF_0;
       } else if (c == ' ') {
         if (lead != NULL && s <= lead && in_multispace
             && curwin->w_p_lcs_chars.leadmultispace != NULL) {
@@ -1960,23 +1960,23 @@ void msg_prt_line(const char *s, bool list)
           if (curwin->w_p_lcs_chars.leadmultispace[multispace_pos] == NUL) {
             multispace_pos = 0;
           }
-          hl_id = HLF_0 + 1;
+          hl_id = HLF_0;
         } else if (lead != NULL && s <= lead && curwin->w_p_lcs_chars.lead != NUL) {
           sc = curwin->w_p_lcs_chars.lead;
-          hl_id = HLF_0 + 1;
+          hl_id = HLF_0;
         } else if (trail != NULL && s > trail) {
           sc = curwin->w_p_lcs_chars.trail;
-          hl_id = HLF_0 + 1;
+          hl_id = HLF_0;
         } else if (in_multispace
                    && curwin->w_p_lcs_chars.multispace != NULL) {
           sc = curwin->w_p_lcs_chars.multispace[multispace_pos++];
           if (curwin->w_p_lcs_chars.multispace[multispace_pos] == NUL) {
             multispace_pos = 0;
           }
-          hl_id = HLF_0 + 1;
+          hl_id = HLF_0;
         } else if (list && curwin->w_p_lcs_chars.space != NUL) {
           sc = curwin->w_p_lcs_chars.space;
-          hl_id = HLF_0 + 1;
+          hl_id = HLF_0;
         } else {
           sc = schar_from_ascii(' ');  // SPACE!
         }
@@ -2007,7 +2007,7 @@ void msg_puts(const char *s)
 
 void msg_puts_title(const char *s)
 {
-  msg_puts_hl(s, HLF_T + 1, false);
+  msg_puts_hl(s, HLF_T, false);
 }
 
 /// Show a message in such a way that it always fits in the line.  Cut out a
@@ -2021,7 +2021,7 @@ void msg_outtrans_long(const char *longstr, int hl_id)
   if (len > room && room >= 20) {
     slen = (room - 3) / 2;
     msg_outtrans_len(longstr, slen, hl_id, false);
-    msg_puts_hl("...", HLF_8 + 1, false);
+    msg_puts_hl("...", HLF_8, false);
   }
   msg_outtrans_len(longstr + len - slen, slen, hl_id, len);
 }
@@ -3316,7 +3316,7 @@ void give_warning(const char *message, bool hl)
   set_vim_var_string(VV_WARNINGMSG, message, -1);
   XFREE_CLEAR(keep_msg);
   if (hl) {
-    keep_msg_hl_id = HLF_W + 1;
+    keep_msg_hl_id = HLF_W;
   } else {
     keep_msg_hl_id = 0;
   }
@@ -3659,7 +3659,7 @@ void display_confirm_msg(void)
   confirm_msg_used++;
   if (confirm_msg != NULL) {
     msg_ext_set_kind("confirm");
-    msg_puts_hl(confirm_msg, HLF_M + 1, false);
+    msg_puts_hl(confirm_msg, HLF_M, false);
   }
   confirm_msg_used--;
 }

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3653,7 +3653,7 @@ void ex_display(exarg_T *eap)
   if (arg != NULL && *arg == NUL) {
     arg = NULL;
   }
-  int hl_id = HLF_8 + 1;
+  int hl_id = HLF_8;
 
   // Highlight title
   msg_puts_title(_("\nType Name Content"));

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1901,8 +1901,8 @@ static const char *did_set_arabic(optset_T *args)
     if (strcmp(p_enc, "utf-8") != 0) {
       static char *w_arabic = N_("W17: Arabic requires UTF-8, do ':set encoding=utf-8'");
 
-      msg_source(HLF_W + 1);
-      msg(_(w_arabic), HLF_W + 1);
+      msg_source(HLF_W);
+      msg(_(w_arabic), HLF_W);
       set_vim_var_string(VV_WARNINGMSG, _(w_arabic), -1);
     }
 

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -3195,7 +3195,7 @@ static void qf_list_entry(qfline_T *qfp, int qf_idx, bool cursel)
   }
 
   msg_putchar('\n');
-  msg_outtrans(IObuff, cursel ? HLF_QFL + 1 : qfFile_hl_id, false);
+  msg_outtrans(IObuff, cursel ? HLF_QFL : qfFile_hl_id, false);
 
   if (qfp->qf_lnum != 0) {
     msg_puts_hl(":", qfSep_hl_id, false);
@@ -3277,15 +3277,15 @@ void qf_list(exarg_T *eap)
   // that this depends on syntax items defined in the qf.vim syntax file
   qfFile_hl_id = syn_name2id("qfFileName");
   if (qfFile_hl_id == 0) {
-    qfFile_hl_id = HLF_D + 1;
+    qfFile_hl_id = HLF_D;
   }
   qfSep_hl_id = syn_name2id("qfSeparator");
   if (qfSep_hl_id == 0) {
-    qfSep_hl_id = HLF_D + 1;
+    qfSep_hl_id = HLF_D;
   }
   qfLine_hl_id = syn_name2id("qfLineNr");
   if (qfLine_hl_id == 0) {
-    qfLine_hl_id = HLF_N + 1;
+    qfLine_hl_id = HLF_N;
   }
 
   if (qfl->qf_nonevalid) {

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3772,7 +3772,7 @@ void find_pattern_in_path(char *ptr, Direction dir, size_t len, bool whole, bool
           if (new_fname != NULL) {
             // using "new_fname" is more reliable, e.g., when
             // 'includeexpr' is set.
-            msg_outtrans(new_fname, HLF_D + 1, false);
+            msg_outtrans(new_fname, HLF_D, false);
           } else {
             // Isolate the file name.
             // Include the surrounding "" or <> if present.
@@ -3806,7 +3806,7 @@ void find_pattern_in_path(char *ptr, Direction dir, size_t len, bool whole, bool
             }
             char save_char = p[i];
             p[i] = NUL;
-            msg_outtrans(p, HLF_D + 1, false);
+            msg_outtrans(p, HLF_D, false);
             p[i] = save_char;
           }
 
@@ -3858,7 +3858,7 @@ void find_pattern_in_path(char *ptr, Direction dir, size_t len, bool whole, bool
             vim_snprintf(IObuff, IOSIZE,
                          _("Scanning included file: %s"),
                          new_fname);
-            msg_trunc(IObuff, true, HLF_R + 1);
+            msg_trunc(IObuff, true, HLF_R);
           } else if (p_verbose >= 5) {
             verbose_enter();
             smsg(0, _("Searching included file %s"), new_fname);
@@ -4233,7 +4233,7 @@ static void show_pat_in_path(char *line, int type, bool did_show, int action, FI
       msg_puts(IObuff);
       snprintf(IObuff, IOSIZE, "%4" PRIdLINENR, *lnum);  // Show line nr.
       // Highlight line numbers.
-      msg_puts_hl(IObuff, HLF_N + 1, false);
+      msg_puts_hl(IObuff, HLF_N, false);
       msg_puts(" ");
     }
     msg_prt_line(line, false);

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -270,7 +270,7 @@ static void sign_list_placed(buf_T *rbuf, char *group)
   while (buf != NULL && !got_int) {
     if (buf_has_signs(buf)) {
       vim_snprintf(lbuf, MSG_BUF_LEN, _("Signs for %s:"), buf->b_fname);
-      msg_puts_hl(lbuf, HLF_D + 1, false);
+      msg_puts_hl(lbuf, HLF_D, false);
       msg_putchar('\n');
     }
 

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -585,7 +585,7 @@ void win_redr_ruler(win_T *wp)
     MAXSIZE_TEMP_ARRAY(chunk, 3);
     ADD_C(chunk, INTEGER_OBJ(attr));
     ADD_C(chunk, CSTR_AS_OBJ(buffer));
-    ADD_C(chunk, INTEGER_OBJ(HLF_MSG + 1));
+    ADD_C(chunk, INTEGER_OBJ(HLF_MSG));
     assert(attr == HL_ATTR(HLF_MSG));
     ADD_C(content, ARRAY_OBJ(chunk));
     ui_call_msg_ruler(content);
@@ -1632,7 +1632,7 @@ stcsign:
         schar_T fold_buf[9];
         fill_foldcolumn(wp, stcp->foldinfo, (linenr_T)get_vim_var_nr(VV_LNUM),
                         0, fdc, NULL, fold_buf);
-        stl_items[curitem].minwid = -((stcp->use_cul ? HLF_CLF : HLF_FC) + 1);
+        stl_items[curitem].minwid = -(stcp->use_cul ? HLF_CLF : HLF_FC);
         size_t buflen = 0;
         // TODO(bfredl): this is very backwards. we must support schar_T
         // being used directly in 'statuscolumn'
@@ -1653,7 +1653,7 @@ stcsign:
             buf_tmp[signlen++] = ' ';
             buf_tmp[signlen++] = ' ';
             buf_tmp[signlen] = NUL;
-            stl_items[curitem].minwid = -((stcp->use_cul ? HLF_CLS : HLF_SC) + 1);
+            stl_items[curitem].minwid = -(stcp->use_cul ? HLF_CLS : HLF_SC);
           }
         }
         stl_items[curitem++].type = Highlight;

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -3346,7 +3346,7 @@ static void syn_list_one(const int id, const bool syncing, const bool link_only)
     KEYVALUE_ENTRY(HL_SKIPEMPTY, "skipempty"),
   };
 
-  const int hl_id = HLF_D + 1;      // highlight like directories
+  const int hl_id = HLF_D;      // highlight like directories
 
   // list the keywords for "id"
   if (!syncing) {
@@ -3451,9 +3451,9 @@ static void syn_list_cluster(int id)
 
   msg_advance(endcol);
   if (SYN_CLSTR(curwin->w_s)[id].scl_list != NULL) {
-    put_id_list("cluster", SYN_CLSTR(curwin->w_s)[id].scl_list, HLF_D + 1);
+    put_id_list("cluster", SYN_CLSTR(curwin->w_s)[id].scl_list, HLF_D);
   } else {
-    msg_puts_hl("cluster", HLF_D + 1, false);
+    msg_puts_hl("cluster", HLF_D, false);
     msg_puts("=NONE");
   }
 }

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -736,7 +736,7 @@ void do_tag(char *tag, int type, int count, int forceit, bool verbose)
         }
         if ((num_matches > prev_num_matches || new_tag)
             && num_matches > 1) {
-          msg(IObuff, ic ? HLF_W + 1 : 0);
+          msg(IObuff, ic ? HLF_W : 0);
           msg_scroll = true;  // Don't overwrite this message.
         } else {
           give_warning(IObuff, ic);
@@ -815,10 +815,10 @@ static void print_tag_list(bool new_tag, bool use_tagstack, int num_matches, cha
     msg_didout = false;     // overwrite previous message
   }
   msg_start();
-  msg_puts_hl(_("  # pri kind tag"), HLF_T + 1, false);
+  msg_puts_hl(_("  # pri kind tag"), HLF_T, false);
   msg_clr_eos();
   taglen_advance(taglen);
-  msg_puts_hl(_("file\n"), HLF_T + 1, false);
+  msg_puts_hl(_("file\n"), HLF_T, false);
 
   for (int i = 0; i < num_matches && !got_int; i++) {
     parse_match(matches[i], &tagp);
@@ -839,7 +839,7 @@ static void print_tag_list(bool new_tag, bool use_tagstack, int num_matches, cha
       msg_outtrans_len(tagp.tagkind, (int)(tagp.tagkind_end - tagp.tagkind), 0, false);
     }
     msg_advance(13);
-    msg_outtrans_len(tagp.tagname, (int)(tagp.tagname_end - tagp.tagname), HLF_T + 1, false);
+    msg_outtrans_len(tagp.tagname, (int)(tagp.tagname_end - tagp.tagname), HLF_T, false);
     msg_putchar(' ');
     taglen_advance(taglen);
 
@@ -847,7 +847,7 @@ static void print_tag_list(bool new_tag, bool use_tagstack, int num_matches, cha
     // it and put "..." in the middle
     const char *p = tag_full_fname(&tagp);
     if (p != NULL) {
-      msg_outtrans(p, HLF_D + 1, false);
+      msg_outtrans(p, HLF_D, false);
       XFREE_CLEAR(p);
     }
     if (msg_col > 0) {
@@ -880,7 +880,7 @@ static void print_tag_list(bool new_tag, bool use_tagstack, int num_matches, cha
           continue;
         }
         // print all other extra fields
-        int hl_id = HLF_CM + 1;
+        int hl_id = HLF_CM;
         while (*p && *p != '\r' && *p != '\n') {
           if (msg_col + ptr2cells(p) >= Columns) {
             msg_putchar('\n');
@@ -1126,7 +1126,7 @@ void do_tags(exarg_T *eap)
                    tagstack[i].tagname,
                    tagstack[i].fmark.mark.lnum);
       msg_outtrans(IObuff, 0, false);
-      msg_outtrans(name, tagstack[i].fmark.fnum == curbuf->b_fnum ? HLF_D + 1 : 0, false);
+      msg_outtrans(name, tagstack[i].fmark.fnum == curbuf->b_fnum ? HLF_D : 0, false);
       xfree(name);
     }
   }

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -358,8 +358,8 @@ void vim_beep(unsigned val)
   // a script or executing a function give the user a hint where the beep
   // comes from.
   if (vim_strchr(p_debug, 'e') != NULL) {
-    msg_source(HLF_W + 1);
-    msg(_("Beep!"), HLF_W + 1);
+    msg_source(HLF_W);
+    msg(_("Beep!"), HLF_W);
   }
 }
 

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2712,7 +2712,7 @@ void ex_undolist(exarg_T *eap)
     sort_strings(ga.ga_data, ga.ga_len);
 
     msg_start();
-    msg_puts_hl(_("number changes  when               saved"), HLF_T + 1, false);
+    msg_puts_hl(_("number changes  when               saved"), HLF_T, false);
     for (int i = 0; i < ga.ga_len && !got_int; i++) {
       msg_putchar('\n');
       if (got_int) {

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -494,7 +494,7 @@ static void uc_list(char *name, size_t name_len)
         msg_putchar(' ');
       }
 
-      msg_outtrans(cmd->uc_name, HLF_D + 1, false);
+      msg_outtrans(cmd->uc_name, HLF_D, false);
       len = strlen(cmd->uc_name) + 4;
 
       do {
@@ -585,7 +585,7 @@ static void uc_list(char *name, size_t name_len)
 
       if (cmd->uc_luaref != LUA_NOREF) {
         char *fn = nlua_funcref_str(cmd->uc_luaref, NULL);
-        msg_puts_hl(fn, HLF_8 + 1, false);
+        msg_puts_hl(fn, HLF_8, false);
         xfree(fn);
         // put the description on a new line
         if (*cmd->uc_rep != NUL) {


### PR DESCRIPTION
This makes it possible to use HLF_ values directly as highlight id:s and avoids +1 adjustments especially around messages.