### PR TITLE
fix(treesitter): add 'QuitPre' event to autocommands in inspect_tree

### DIFF
--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -527,7 +527,7 @@ function M.inspect_tree(opts)
     end,
   })
 
-  api.nvim_create_autocmd({ 'BufHidden', 'BufUnload' }, {
+  api.nvim_create_autocmd({ 'BufHidden', 'BufUnload', 'QuitPre' }, {
     group = group,
     buffer = buf,
     once = true,


### PR DESCRIPTION
Problem: Quitting source buffer for ```:InspectTree``` command raises ```E855``` when source buffer and tree views are the only open buffers as addressed in #30986.

Solution: Add ```QuitPre``` event to autocmd handling closing/hiding the source buffer to close all open tree views. This allows nvim to quit when source and tree buffers are the only open windows.