### PR TITLE
vim-patch:9.1.0860: tests: mouse_shape tests use hard code sleep value

### DIFF
--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -3958,8 +3958,7 @@ func Test_mouse_shape_after_failed_change()
   END
   call writefile(lines, 'Xmouseshape.vim', 'D')
   call RunVim([], [], "-g -S Xmouseshape.vim")
-  sleep 300m
-  call assert_equal(['busy', 'arrow'], readfile('Xmouseshapes'))
+  call WaitForAssert({-> assert_equal(['busy', 'arrow'], readfile('Xmouseshapes'))}, 300)
 
   call delete('Xmouseshapes')
 endfunc
@@ -3990,8 +3989,7 @@ func Test_mouse_shape_after_cancelling_gr()
   END
   call writefile(lines, 'Xmouseshape.vim', 'D')
   call RunVim([], [], "-g -S Xmouseshape.vim")
-  sleep 300m
-  call assert_equal(['beam', 'arrow'], readfile('Xmouseshapes'))
+  call WaitForAssert({-> assert_equal(['beam', 'arrow'], readfile('Xmouseshapes'))}, 300)
 
   call delete('Xmouseshapes')
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.0860: tests: mouse_shape tests use hard code sleep value

Problem:  tests: mouse_shape tests use hard code sleep value
          (Bram Moolenaar)
Solution: Use WaitForAssert() instead (Yee Cheng Chin)

related: vim/vim#12157
closes: vim/vim#16042

https://github.com/vim/vim/commit/24078e39cd10b8a65af5297ebe12ddf1e550167a

Co-authored-by: Yee Cheng Chin <ychin.git@gmail.com>