### PR TITLE
feat(defaults): dot-repeat [<Space>

### DIFF
--- a/runtime/lua/vim/_buf.lua
+++ b/runtime/lua/vim/_buf.lua
@@ -1,0 +1,23 @@
+local M = {}
+
+--- Adds one or more blank lines above or below the cursor.
+-- TODO: move to _defaults.lua once it is possible to assign a Lua function to options #25672
+--- @param above? boolean Place blank line(s) above the cursor
+local function add_blank(above)
+  local offset = above and 1 or 0
+  local repeated = vim.fn['repeat']({ '' }, vim.v.count1)
+  local linenr = vim.api.nvim_win_get_cursor(0)[1]
+  vim.api.nvim_buf_set_lines(0, linenr - offset, linenr - offset, true, repeated)
+end
+
+-- TODO: move to _defaults.lua once it is possible to assign a Lua function to options #25672
+function M.space_above()
+  add_blank(true)
+end
+
+-- TODO: move to _defaults.lua once it is possible to assign a Lua function to options #25672
+function M.space_below()
+  add_blank()
+end
+
+return M

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -366,16 +366,16 @@ do
 
     -- Add empty lines
     vim.keymap.set('n', '[<Space>', function()
-      local repeated = vim.fn['repeat']({ '' }, vim.v.count1)
-      local linenr = vim.api.nvim_win_get_cursor(0)[1]
-      vim.api.nvim_buf_set_lines(0, linenr - 1, linenr - 1, true, repeated)
-    end, { desc = 'Add empty line above cursor' })
+      -- TODO: update once it is possible to assign a Lua function to options #25672
+      vim.go.operatorfunc = "v:lua.require'vim._buf'.space_above"
+      return 'g@l'
+    end, { expr = true, desc = 'Add empty line above cursor' })
 
     vim.keymap.set('n', ']<Space>', function()
-      local repeated = vim.fn['repeat']({ '' }, vim.v.count1)
-      local linenr = vim.api.nvim_win_get_cursor(0)[1]
-      vim.api.nvim_buf_set_lines(0, linenr, linenr, true, repeated)
-    end, { desc = 'Add empty line below cursor' })
+      -- TODO: update once it is possible to assign a Lua function to options #25672
+      vim.go.operatorfunc = "v:lua.require'vim._buf'.space_below"
+      return 'g@l'
+    end, { expr = true, desc = 'Add empty line below cursor' })
   end
 end
 

--- a/test/functional/editor/defaults_spec.lua
+++ b/test/functional/editor/defaults_spec.lua
@@ -175,6 +175,30 @@ describe('default', function()
 
           first line]])
         end)
+
+        it('supports dot repetition', function()
+          n.clear({ args_rm = { '--cmd' } })
+          n.insert([[first line]])
+          n.feed('[<Space>')
+          n.feed('.')
+          n.expect([[
+
+
+          first line]])
+        end)
+
+        it('supports dot repetition and a count', function()
+          n.clear({ args_rm = { '--cmd' } })
+          n.insert([[first line]])
+          n.feed('[<Space>')
+          n.feed('3.')
+          n.expect([[
+
+
+
+
+          first line]])
+        end)
       end)
 
       describe(']<Space>', function()
@@ -195,6 +219,29 @@ describe('default', function()
           first line
 
 
+
+
+          ]])
+        end)
+
+        it('supports dot repetition', function()
+          n.clear({ args_rm = { '--cmd' } })
+          n.insert([[first line]])
+          n.feed(']<Space>')
+          n.feed('.')
+          n.expect([[
+          first line
+
+          ]])
+        end)
+
+        it('supports dot repetition and a count', function()
+          n.clear({ args_rm = { '--cmd' } })
+          n.insert([[first line]])
+          n.feed(']<Space>')
+          n.feed('2.')
+          n.expect([[
+          first line
 
 
           ]])


### PR DESCRIPTION
Problem: `[<Space>` and `]<Space>` do not support repetition.

Solution: use `operatorfunc` and `g@l` to make these mappings dot repeatable.