### PR TITLE
vim-patch:210c49b: runtime(compiler): update pylint linter

### DIFF
--- a/runtime/compiler/pylint.vim
+++ b/runtime/compiler/pylint.vim
@@ -12,8 +12,7 @@ set cpo&vim
 " CompilerSet makeprg=ruff
 let &l:makeprg = 'pylint ' .
       \ '--output-format=text --msg-template="{path}:{line}:{column}:{C}: [{symbol}] {msg}" --reports=no ' .
-      \ get(b:, "pylint_makeprg_params", get(g:, "pylint_makeprg_params",
-      \   (executable('getconf') ? '--jobs='..systemlist('getconf _NPROCESSORS_ONLN')[0] : '')))
+      \ get(b:, "pylint_makeprg_params", get(g:, "pylint_makeprg_params", '--jobs=0'))
 exe 'CompilerSet makeprg='..escape(&l:makeprg, ' "')
 CompilerSet errorformat=%A%f:%l:%c:%t:\ %m,%A%f:%l:\ %m,%A%f:(%l):\ %m,%-Z%p^%.%#,%-G%.%#
 

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1380,7 +1380,7 @@ RUFF LINTER						*compiler-ruff*
 Commonly used compiler options can be added to 'makeprg' by setting the
 b/g:ruff_makeprg_params variable.  For example: >
 
-	let b:ruff_makeprg_params = "--max-line-length"..&textwidth
+	let b:ruff_makeprg_params = "--max-line-length "..&textwidth
 
 The global default is "--preview".
 
@@ -1389,10 +1389,9 @@ PYLINT LINTER						*compiler-pylint*
 Commonly used compiler options can be added to 'makeprg' by setting the
 b/g:pylint_makeprg_params variable.  For example: >
 
-	let b:pylint_makeprg_params = "--max-line-length"..&textwidth
+	let b:pylint_makeprg_params = "--max-line-length "..&textwidth
 
-The global default is "--jobs=n" where n is the number of cores as reported
-by getconf, if executable. Otherwise it defaults to "".
+The global default is "--jobs=0" to use (almost) all cores.
 
 PYUNIT COMPILER						*compiler-pyunit*
 


### PR DESCRIPTION
#### vim-patch:210c49b: runtime(compiler): update pylint linter

closes: vim/vim#16039

https://github.com/vim/vim/commit/210c49bbe8b2edf15fd4fbbc089ec128e4c9c0c9

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>