### PR TITLE
fix(treesitter): keep tree view open when source window is still open

### DIFF
--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -530,8 +530,13 @@ function M.inspect_tree(opts)
   api.nvim_create_autocmd({ 'BufHidden', 'BufUnload', 'QuitPre' }, {
     group = group,
     buffer = buf,
-    once = true,
     callback = function()
+      -- don't close inpector window if source buffer
+      -- has more than one open window
+      if #vim.fn.win_findbuf(buf) > 1 then
+        return
+      end
+
       -- close all tree windows
       for _, window in pairs(vim.fn.win_findbuf(b)) do
         close_win(window)

--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -541,6 +541,8 @@ function M.inspect_tree(opts)
       for _, window in pairs(vim.fn.win_findbuf(b)) do
         close_win(window)
       end
+
+      return true
     end,
   })
 end


### PR DESCRIPTION
Problem: When there is a tree view opened by ```:InspectTree``` and the source buffer is open in multiple windows, closing one of the source windows will lead to the tree view being closed as well. This bug was introduced by #31181. Related issue: #31196

Solution: Check how many source windows are open when trying to quit one. If there are more than one, keep the tree view(s) open. If the only source window is closed, also close the tree view(s).

This should close #31196.