### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -1501,7 +1501,7 @@ For example, special handlers for links Markdown and HTML are
         return matchstr(getline('.')[col('.')-1:],
           \ '\[.\{-}\](\zs' .. g:netrw_regex_url .. '\ze\(\s\+.\{-}\)\?)')
       endif
-    return ''
+      return ''
     finally
       call winrestview(save_view)
     endtry
@@ -1516,7 +1516,7 @@ For example, special handlers for links Markdown and HTML are
         return matchstr(getline('.')[col('.') - 1 : ],
           \ 'href=["'.."'"..']\?\zs\S\{-}\ze["'.."'"..']\?/\?>')
       endif
-    return ''
+      return ''
     finally
       call winrestview(save_view)
     endtry

--- a/runtime/doc/pi_netrw.txt
+++ b/runtime/doc/pi_netrw.txt
@@ -1501,9 +1501,9 @@ For example, special handlers for links Markdown and HTML are
         return matchstr(getline('.')[col('.')-1:],
           \ '\[.\{-}\](\zs' .. g:netrw_regex_url .. '\ze\(\s\+.\{-}\)\?)')
       endif
+    return ''
     finally
       call winrestview(save_view)
-      return ''
     endtry
   endfunction
 
@@ -1516,9 +1516,9 @@ For example, special handlers for links Markdown and HTML are
         return matchstr(getline('.')[col('.') - 1 : ],
           \ 'href=["'.."'"..']\?\zs\S\{-}\ze["'.."'"..']\?/\?>')
       endif
+    return ''
     finally
       call winrestview(save_view)
-      return ''
     endtry
   endfunction
 <


### PR DESCRIPTION
#### vim-patch:8b96858: runtime(doc): improve examples for netrw-handler functions

https://github.com/vim/vim/commit/8b96858996c4bdc68c055d2ef4afa5f88eda455e

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9b05326: runtime(doc): improve indentation in examples for netrw-handler

related: vim/vim#16043

https://github.com/vim/vim/commit/9b05326afdb0359a2dd40470b2b47a6e422662e9

Co-authored-by: Christian Brabandt <cb@256bit.org>