### PR TITLE
fix(messages): proper multiline Lua print() messages

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -796,6 +796,7 @@ must handle.
 		"echomsg"	|:echomsg| message
 		"echoerr"	|:echoerr| message
 		"lua_error"	Error in |:lua| code
+		"lua_print"	|print()| from |:lua| code
 		"rpc_error"	Error response from |rpcrequest()|
 		"return_prompt"	|press-enter| prompt after a multiple messages
 		"quickfix"	Quickfix navigation message

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -1151,21 +1151,16 @@ end
 --- @param ... any
 --- @return any # given arguments.
 function vim.print(...)
-  if vim.in_fast_event() then
-    print(...)
-    return ...
-  end
-
+  local msg = {}
   for i = 1, select('#', ...) do
     local o = select(i, ...)
     if type(o) == 'string' then
-      vim.api.nvim_out_write(o)
+      table.insert(msg, o)
     else
-      vim.api.nvim_out_write(vim.inspect(o, { newline = '\n', indent = '  ' }))
+      table.insert(msg, vim.inspect(o, { newline = '\n', indent = '  ' }))
     end
-    vim.api.nvim_out_write('\n')
   end
-
+  print(table.concat(msg, '\n'))
   return ...
 end
 

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7881,7 +7881,7 @@ void ex_echo(exarg_T *eap)
       char *tofree = encode_tv2echo(&rettv, NULL);
       if (*tofree != NUL) {
         msg_ext_set_kind("echo");
-        msg_multiline(tofree, echo_hl_id, true, false, &need_clear);
+        msg_multiline(cstr_as_string(tofree), echo_hl_id, true, false, &need_clear);
       }
       xfree(tofree);
     }

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -189,7 +189,7 @@ void do_ascii(exarg_T *eap)
                    transchar(c), buf1, buf2, cval, cval, cval);
     }
 
-    msg_multiline(IObuff, 0, true, false, &need_clear);
+    msg_multiline(cstr_as_string(IObuff), 0, true, false, &need_clear);
 
     off += (size_t)utf_ptr2len(data);  // needed for overlong ascii?
   }
@@ -224,7 +224,7 @@ void do_ascii(exarg_T *eap)
                    c, c, c);
     }
 
-    msg_multiline(IObuff, 0, true, false, &need_clear);
+    msg_multiline(cstr_as_string(IObuff), 0, true, false, &need_clear);
 
     off += (size_t)utf_ptr2len(data + off);  // needed for overlong ascii?
   }

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -951,41 +951,10 @@ static void nlua_common_free_all_mem(lua_State *lstate)
 
 static void nlua_print_event(void **argv)
 {
-  char *str = argv[0];
-  const size_t len = (size_t)(intptr_t)argv[1] - 1;  // exclude final NUL
-
-  for (size_t i = 0; i < len;) {
-    if (got_int) {
-      break;
-    }
-    const size_t start = i;
-    while (i < len) {
-      switch (str[i]) {
-      case NUL:
-        str[i] = NL;
-        i++;
-        continue;
-      case NL:
-        // TODO(bfredl): use proper multiline msg? Probably should implement
-        // print() in lua in terms of nvim_message(), when it is available.
-        str[i] = NUL;
-        i++;
-        break;
-      default:
-        i++;
-        continue;
-      }
-      break;
-    }
-    msg(str + start, 0);
-    if (msg_silent == 0) {
-      msg_didout = true;  // Make blank lines work properly
-    }
-  }
-  if (len && str[len - 1] == NUL) {  // Last was newline
-    msg("", 0);
-  }
-  xfree(str);
+  HlMessage msg = KV_INITIAL_VALUE;
+  HlMessageChunk chunk = { { .data = argv[0], .size = (size_t)(intptr_t)argv[1] - 1 }, 0 };
+  kv_push(msg, chunk);
+  msg_multihl(msg, "lua_print", true);
 }
 
 /// Print as a Vim message

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -279,10 +279,8 @@ describe('startup', function()
 
       -- nvim <vim args> -l foo.lua <vim args>
       assert_l_out(
-        -- luacheck: ignore 611 (Line contains only whitespaces)
         [[
             wrap
-          
           bufs:
           nvim args: 7
           lua args: { "-c", "set wrap?",

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -152,7 +152,7 @@ describe('vim.ui_attach', function()
         'msg_history_show',
         {
           { 'echomsg', { { 0, 'message1', 0 } } },
-          { '', { { 0, 'message2', 0 } } },
+          { 'lua_print', { { 0, 'message2', 0 } } },
           { 'echomsg', { { 0, 'message3', 0 } } },
         },
       },

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1114,6 +1114,33 @@ stack traceback:
     })
     eq(showmode, 1)
   end)
+
+  it('emits single message for multiline print())', function()
+    exec_lua([[print("foo\nbar\nbaz")]])
+    screen:expect({
+      messages = {
+        {
+          content = { { 'foo\nbar\nbaz' } },
+          kind = 'lua_print',
+        },
+      },
+    })
+    exec_lua([[print(vim.inspect({ foo = "bar" }))]])
+    screen:expect({
+      grid = [[
+        ^                         |
+        {1:~                        }|*4
+      ]],
+      messages = {
+        {
+          content = { { '{\n  foo = "bar"\n}' } },
+          kind = 'lua_print',
+        },
+      },
+    })
+    exec_lua([[vim.print({ foo = "bar" })]])
+    screen:expect_unchanged()
+  end)
 end)
 
 describe('ui/builtin messages', function()
@@ -2068,8 +2095,6 @@ aliquip ex ea commodo consequat.]]
   end)
 
   it('can be quit with Lua #11224 #16537', function()
-    -- NOTE: adds "4" to message history, although not displayed initially
-    --       (triggered the more prompt).
     screen:try_resize(40, 5)
     feed(':lua for i=0,10 do print(i) end<cr>')
     screen:expect {
@@ -2099,13 +2124,13 @@ aliquip ex ea commodo consequat.]]
       {4:-- More --}^                              |
     ]],
     }
-    feed('j')
+    feed('G')
     screen:expect {
       grid = [[
-      1                                       |
-      2                                       |
-      3                                       |
-      4                                       |
+      7                                       |
+      8                                       |
+      9                                       |
+      10                                      |
       {4:Press ENTER or type command to continue}^ |
     ]],
     }


### PR DESCRIPTION
Problem:  Separate message emitted for each newline present in Lua
          print() arguments.
Solution: Make msg_multiline() handle NUL bytes. Refactor print() to use
          msg_multiline(). Refactor vim.print() to use print().


Fix #21044