### PR TITLE
feat(lsp): deprecate non-method client functions

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -56,6 +56,14 @@ LSP
 	No longer support client to server response handlers. Only server to
 	client requests/notification handlers are supported.
 • *vim.lsp.handlers.signature_help()*	Use |vim.lsp.buf.signature_help()| instead.
+• `client.request()`			Use |Client:request()| instead.
+• `client.request_sync()`		Use |Client:request_sync()| instead.
+• `client.notify()`			Use |Client:notify()| instead.
+• `client.cancel_request()`		Use |Client:cancel_request()| instead.
+• `client.stop()`			Use |Client:stop()| instead.
+• `client.is_stopped()`			Use |Client:is_stopped()| instead.
+• `client.supports_method()`		Use |Client:supports_method()| instead.
+• `client.on_attach()`			Use |Client:on_attach()| instead.
 
 ------------------------------------------------------------------------------
 DEPRECATED IN 0.10					*deprecated-0.10*

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -972,54 +972,24 @@ Lua module: vim.lsp.client                                        *lsp-client*
       • {capabilities}          (`lsp.ClientCapabilities`) The capabilities
                                 provided by the client (editor or tool)
       • {dynamic_capabilities}  (`lsp.DynamicCapabilities`)
-      • {request}               (`fun(method: string, params: table?, handler: lsp.Handler?, bufnr: integer?): boolean, integer?`)
-                                Sends a request to the server. This is a thin
-                                wrapper around {client.rpc.request} with some
-                                additional checking. If {handler} is not
-                                specified and if there's no respective global
-                                handler, then an error will occur. Returns:
-                                {status}, {client_id}?. {status} is a boolean
-                                indicating if the notification was successful.
-                                If it is `false`, then it will always be
-                                `false` (the client has shutdown). If {status}
-                                is `true`, the function returns {request_id}
-                                as the second result. You can use this with
-                                `client.cancel_request(request_id)` to cancel
-                                the request.
-      • {request_sync}          (`fun(method: string, params: table?, timeout_ms: integer?, bufnr: integer): {err: lsp.ResponseError?, result:any}?, string?`)
-                                err # a dict
-      • {notify}                (`fun(method: string, params: table?): boolean`)
-                                Sends a notification to an LSP server.
-                                Returns: a boolean to indicate if the
-                                notification was successful. If it is false,
-                                then it will always be false (the client has
-                                shutdown).
-      • {cancel_request}        (`fun(id: integer): boolean`) Cancels a
-                                request with a given request id. Returns: same
-                                as `notify()`.
-      • {stop}                  (`fun(force?: boolean)`) Stops a client,
-                                optionally with force. By default, it will
-                                just ask the server to shutdown without force.
-                                If you request to stop a client which has
-                                previously been requested to shutdown, it will
-                                automatically escalate and force shutdown.
-      • {on_attach}             (`fun(bufnr: integer)`) Runs the on_attach
-                                function from the client's config if it was
-                                defined. Useful for buffer-local setup.
-      • {supports_method}       (`fun(method: string, opts?: {bufnr: integer?}): boolean`)
-                                Checks if a client supports a given method.
-                                Always returns true for unknown off-spec
-                                methods. {opts} is a optional
-                                `{bufnr?: integer}` table. Some language
-                                server capabilities can be file specific.
-      • {is_stopped}            (`fun(): boolean`) Checks whether a client is
-                                stopped. Returns: true if the client is fully
-                                stopped.
+      • {request}               (`fun(self: vim.lsp.Client, method: string, params: table?, handler: lsp.Handler?, bufnr: integer?): boolean, integer?`)
+                                See |Client:request()|.
+      • {request_sync}          (`fun(self: vim.lsp.Client, method: string, params: table, timeout_ms: integer?, bufnr: integer): {err: lsp.ResponseError?, result:any}?, string?`)
+                                See |Client:request_sync()|.
+      • {notify}                (`fun(self: vim.lsp.Client, method: string, params: table?): boolean`)
+                                See |Client:notify()|.
+      • {cancel_request}        (`fun(self: vim.lsp.Client, id: integer): boolean`)
+                                See |Client:cancel_request()|.
+      • {stop}                  (`fun(self: vim.lsp.Client, force: boolean?)`)
+                                See |Client:stop()|.
+      • {is_stopped}            (`fun(self: vim.lsp.Client): boolean`) See
+                                |Client:is_stopped()|.
       • {exec_cmd}              (`fun(self: vim.lsp.Client, command: lsp.Command, context: {bufnr?: integer}?, handler: lsp.Handler?)`)
-                                Execute a lsp command, either via client
-                                command function (if available) or via
-                                workspace/executeCommand (if supported by the
-                                server)
+                                See |Client:exec_cmd()|.
+      • {on_attach}             (`fun(self: vim.lsp.Client, bufnr: integer)`)
+                                See |Client:on_attach()|.
+      • {supports_method}       (`fun(self: vim.lsp.Client, method: string, bufnr: integer?)`)
+                                See |Client:supports_method()|.
 
 *vim.lsp.Client.Progress*
     Extends: |vim.Ringbuf|
@@ -1150,6 +1120,18 @@ Lua module: vim.lsp.client                                        *lsp-client*
                               on initialization.
 
 
+Client:cancel_request({id})                          *Client:cancel_request()*
+    Cancels a request with a given request id.
+
+    Parameters: ~
+      • {id}  (`integer`) id of request to cancel
+
+    Return: ~
+        (`boolean`) status indicating if the notification was successful.
+
+    See also: ~
+      • |Client:notify()|
+
 Client:exec_cmd({command}, {context}, {handler})           *Client:exec_cmd()*
     Execute a lsp command, either via client command function (if available)
     or via workspace/executeCommand (if supported by the server)
@@ -1158,6 +1140,95 @@ Client:exec_cmd({command}, {context}, {handler})           *Client:exec_cmd()*
       • {command}  (`lsp.Command`)
       • {context}  (`{bufnr?: integer}?`)
       • {handler}  (`lsp.Handler?`) only called if a server command
+
+Client:is_stopped()                                      *Client:is_stopped()*
+    Checks whether a client is stopped.
+
+    Return: ~
+        (`boolean`) true if client is stopped or in the process of being
+        stopped; false otherwise
+
+Client:notify({method}, {params})                            *Client:notify()*
+    Sends a notification to an LSP server.
+
+    Parameters: ~
+      • {method}  (`string`) LSP method name.
+      • {params}  (`table?`) LSP request params.
+
+    Return: ~
+        (`boolean`) status indicating if the notification was successful. If
+        it is false, then the client has shutdown.
+
+Client:on_attach({bufnr})                                 *Client:on_attach()*
+    Runs the on_attach function from the client's config if it was defined.
+    Useful for buffer-local setup.
+
+    Parameters: ~
+      • {bufnr}  (`integer`) Buffer number
+
+                                                            *Client:request()*
+Client:request({method}, {params}, {handler}, {bufnr})
+    Sends a request to the server.
+
+    This is a thin wrapper around {client.rpc.request} with some additional
+    checks for capabilities and handler availability.
+
+    Parameters: ~
+      • {method}   (`string`) LSP method name.
+      • {params}   (`table?`) LSP request params.
+      • {handler}  (`lsp.Handler?`) Response |lsp-handler| for this method.
+      • {bufnr}    (`integer?`) Buffer handle. 0 for current (default).
+
+    Return (multiple): ~
+        (`boolean`) status indicates whether the request was successful. If it
+        is `false`, then it will always be `false` (the client has shutdown).
+        (`integer?`) request_id Can be used with |Client:cancel_request()|.
+        `nil` is request failed.
+
+    See also: ~
+      • |vim.lsp.buf_request_all()|
+
+                                                       *Client:request_sync()*
+Client:request_sync({method}, {params}, {timeout_ms}, {bufnr})
+    Sends a request to the server and synchronously waits for the response.
+
+    This is a wrapper around |Client:request()|
+
+    Parameters: ~
+      • {method}      (`string`) LSP method name.
+      • {params}      (`table`) LSP request params.
+      • {timeout_ms}  (`integer?`) Maximum time in milliseconds to wait for a
+                      result. Defaults to 1000
+      • {bufnr}       (`integer`) Buffer handle (0 for current).
+
+    Return (multiple): ~
+        (`{err: lsp.ResponseError?, result:any}?`) `result` and `err` from the
+        |lsp-handler|. `nil` is the request was unsuccessful
+        (`string?`) err On timeout, cancel or error, where `err` is a string
+        describing the failure reason.
+
+    See also: ~
+      • |vim.lsp.buf_request_sync()|
+
+Client:stop({force})                                           *Client:stop()*
+    Stops a client, optionally with force.
+
+    By default, it will just request the server to shutdown without force. If
+    you request to stop a client which has previously been requested to
+    shutdown, it will automatically escalate and force shutdown.
+
+    Parameters: ~
+      • {force}  (`boolean?`)
+
+Client:supports_method({method}, {bufnr})           *Client:supports_method()*
+    Checks if a client supports a given method. Always returns true for
+    unknown off-spec methods.
+
+    Note: Some language server capabilities can be file specific.
+
+    Parameters: ~
+      • {method}  (`string`)
+      • {bufnr}   (`integer?`)
 
 
 ==============================================================================
@@ -1599,12 +1670,12 @@ get({filter})                                       *vim.lsp.inlay_hint.get()*
         local hint = vim.lsp.inlay_hint.get({ bufnr = 0 })[1] -- 0 for current buffer
 
         local client = vim.lsp.get_client_by_id(hint.client_id)
-        local resp = client.request_sync('inlayHint/resolve', hint.inlay_hint, 100, 0)
+        local resp = client:request_sync('inlayHint/resolve', hint.inlay_hint, 100, 0)
         local resolved_hint = assert(resp and resp.result, resp.err)
         vim.lsp.util.apply_text_edits(resolved_hint.textEdits, 0, client.encoding)
 
         location = resolved_hint.label[1].location
-        client.request('textDocument/hover', {
+        client:request('textDocument/hover', {
           textDocument = { uri = location.uri },
           position = location.range.start,
         })

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1937,12 +1937,10 @@ vim.show_pos({bufnr}, {row}, {col}, {filter})                 *vim.show_pos()*
 *vim.Ringbuf*
 
     Fields: ~
-      • {clear}  (`fun()`) Clear all items
-      • {push}   (`fun(item: T)`) Adds an item, overriding the oldest item if
-                 the buffer is full.
-      • {pop}    (`fun(): T?`) Removes and returns the first unread item
-      • {peek}   (`fun(): T?`) Returns the first unread item without removing
-                 it
+      • {clear}  (`fun()`) See |Ringbuf:clear()|.
+      • {push}   (`fun(item: T)`) See |Ringbuf:push()|.
+      • {pop}    (`fun(): T?`) See |Ringbuf:pop()|.
+      • {peek}   (`fun(): T?`) See |Ringbuf:peek()|.
 
 
 Ringbuf:clear()                                              *Ringbuf:clear()*

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -218,6 +218,7 @@ LSP
 • The client now supports `'utf-8'` and `'utf-32'` position encodings.
 • |vim.lsp.buf.hover()| now highlights hover ranges using the
   |hl-LspReferenceTarget| highlight group.
+• Functions in |vim.lsp.Client| can now be called as methods.
 
 LUA
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -349,17 +349,17 @@ end
 ---@param bufnr integer
 function lsp._set_defaults(client, bufnr)
   if
-    client.supports_method(ms.textDocument_definition) and is_empty_or_default(bufnr, 'tagfunc')
+    client:supports_method(ms.textDocument_definition) and is_empty_or_default(bufnr, 'tagfunc')
   then
     vim.bo[bufnr].tagfunc = 'v:lua.vim.lsp.tagfunc'
   end
   if
-    client.supports_method(ms.textDocument_completion) and is_empty_or_default(bufnr, 'omnifunc')
+    client:supports_method(ms.textDocument_completion) and is_empty_or_default(bufnr, 'omnifunc')
   then
     vim.bo[bufnr].omnifunc = 'v:lua.vim.lsp.omnifunc'
   end
   if
-    client.supports_method(ms.textDocument_rangeFormatting)
+    client:supports_method(ms.textDocument_rangeFormatting)
     and is_empty_or_default(bufnr, 'formatprg')
     and is_empty_or_default(bufnr, 'formatexpr')
   then
@@ -367,14 +367,14 @@ function lsp._set_defaults(client, bufnr)
   end
   vim._with({ buf = bufnr }, function()
     if
-      client.supports_method(ms.textDocument_hover)
+      client:supports_method(ms.textDocument_hover)
       and is_empty_or_default(bufnr, 'keywordprg')
       and vim.fn.maparg('K', 'n', false, false) == ''
     then
       vim.keymap.set('n', 'K', vim.lsp.buf.hover, { buffer = bufnr, desc = 'vim.lsp.buf.hover()' })
     end
   end)
-  if client.supports_method(ms.textDocument_diagnostic) then
+  if client:supports_method(ms.textDocument_diagnostic) then
     lsp.diagnostic._enable(bufnr)
   end
 end
@@ -485,12 +485,12 @@ local function text_document_did_save_handler(bufnr)
     local name = api.nvim_buf_get_name(bufnr)
     local old_name = changetracking._get_and_set_name(client, bufnr, name)
     if old_name and name ~= old_name then
-      client.notify(ms.textDocument_didClose, {
+      client:notify(ms.textDocument_didClose, {
         textDocument = {
           uri = vim.uri_from_fname(old_name),
         },
       })
-      client.notify(ms.textDocument_didOpen, {
+      client:notify(ms.textDocument_didOpen, {
         textDocument = {
           version = 0,
           uri = uri,
@@ -506,7 +506,7 @@ local function text_document_did_save_handler(bufnr)
       if type(save_capability) == 'table' and save_capability.includeText then
         included_text = text(bufnr)
       end
-      client.notify(ms.textDocument_didSave, {
+      client:notify(ms.textDocument_didSave, {
         textDocument = {
           uri = uri,
         },
@@ -527,10 +527,10 @@ local function buf_detach_client(bufnr, client)
 
   changetracking.reset_buf(client, bufnr)
 
-  if client.supports_method(ms.textDocument_didClose) then
+  if client:supports_method(ms.textDocument_didClose) then
     local uri = vim.uri_from_bufnr(bufnr)
     local params = { textDocument = { uri = uri } }
-    client.notify(ms.textDocument_didClose, params)
+    client:notify(ms.textDocument_didClose, params)
   end
 
   client.attached_buffers[bufnr] = nil
@@ -564,12 +564,12 @@ local function buf_attach(bufnr)
           },
           reason = protocol.TextDocumentSaveReason.Manual, ---@type integer
         }
-        if client.supports_method(ms.textDocument_willSave) then
-          client.notify(ms.textDocument_willSave, params)
+        if client:supports_method(ms.textDocument_willSave) then
+          client:notify(ms.textDocument_willSave, params)
         end
-        if client.supports_method(ms.textDocument_willSaveWaitUntil) then
+        if client:supports_method(ms.textDocument_willSaveWaitUntil) then
           local result, err =
-            client.request_sync(ms.textDocument_willSaveWaitUntil, params, 1000, ctx.buf)
+            client:request_sync(ms.textDocument_willSaveWaitUntil, params, 1000, ctx.buf)
           if result and result.result then
             util.apply_text_edits(result.result, ctx.buf, client.offset_encoding)
           elseif err then
@@ -603,8 +603,8 @@ local function buf_attach(bufnr)
       local params = { textDocument = { uri = uri } }
       for _, client in ipairs(clients) do
         changetracking.reset_buf(client, bufnr)
-        if client.supports_method(ms.textDocument_didClose) then
-          client.notify(ms.textDocument_didClose, params)
+        if client:supports_method(ms.textDocument_didClose) then
+          client:notify(ms.textDocument_didClose, params)
         end
       end
       for _, client in ipairs(clients) do
@@ -662,7 +662,7 @@ function lsp.buf_attach_client(bufnr, client_id)
   -- Send didOpen for the client if it is initialized. If it isn't initialized
   -- then it will send didOpen on initialize.
   if client.initialized then
-    client:_on_attach(bufnr)
+    client:on_attach(bufnr)
   end
   return true
 end
@@ -740,13 +740,13 @@ function lsp.stop_client(client_id, force)
   for _, id in ipairs(ids) do
     if type(id) == 'table' then
       if id.stop then
-        id.stop(force)
+        id:stop(force)
       end
     else
       --- @cast id -vim.lsp.Client
       local client = all_clients[id]
       if client then
-        client.stop(force)
+        client:stop(force)
       end
     end
   end
@@ -790,7 +790,7 @@ function lsp.get_clients(filter)
       and (filter.id == nil or client.id == filter.id)
       and (filter.bufnr == nil or client.attached_buffers[bufnr])
       and (filter.name == nil or client.name == filter.name)
-      and (filter.method == nil or client.supports_method(filter.method, { bufnr = filter.bufnr }))
+      and (filter.method == nil or client:supports_method(filter.method, filter.bufnr))
       and (filter._uninitialized or client.initialized)
     then
       clients[#clients + 1] = client
@@ -812,7 +812,7 @@ api.nvim_create_autocmd('VimLeavePre', {
     local active_clients = lsp.get_clients()
     log.info('exit_handler', active_clients)
     for _, client in pairs(all_clients) do
-      client.stop()
+      client:stop()
     end
 
     local timeouts = {} --- @type table<integer,integer>
@@ -847,7 +847,7 @@ api.nvim_create_autocmd('VimLeavePre', {
       if not vim.wait(max_timeout, check_clients_closed, poll_time) then
         for client_id, client in pairs(active_clients) do
           if timeouts[client_id] ~= nil then
-            client.stop(true)
+            client:stop(true)
           end
         end
       end
@@ -883,11 +883,11 @@ function lsp.buf_request(bufnr, method, params, handler, on_unsupported)
   local clients = lsp.get_clients({ bufnr = bufnr })
   local client_request_ids = {} --- @type table<integer,integer>
   for _, client in ipairs(clients) do
-    if client.supports_method(method, { bufnr = bufnr }) then
+    if client:supports_method(method, bufnr) then
       method_supported = true
 
       local cparams = type(params) == 'function' and params(client, bufnr) or params --[[@as table?]]
-      local request_success, request_id = client.request(method, cparams, handler, bufnr)
+      local request_success, request_id = client:request(method, cparams, handler, bufnr)
       -- This could only fail if the client shut down in the time since we looked
       -- it up and we did the request, which should be rare.
       if request_success then
@@ -910,7 +910,7 @@ function lsp.buf_request(bufnr, method, params, handler, on_unsupported)
   local function _cancel_all_requests()
     for client_id, request_id in pairs(client_request_ids) do
       local client = all_clients[client_id]
-      client.cancel_request(request_id)
+      client:cancel_request(request_id)
     end
   end
 
@@ -1049,7 +1049,7 @@ function lsp.formatexpr(opts)
   end
   local bufnr = api.nvim_get_current_buf()
   for _, client in pairs(lsp.get_clients({ bufnr = bufnr })) do
-    if client.supports_method(ms.textDocument_rangeFormatting) then
+    if client:supports_method(ms.textDocument_rangeFormatting) then
       local params = util.make_formatting_params()
       local end_line = vim.fn.getline(end_lnum) --[[@as string]]
       local end_col = vim.str_utfindex(end_line, client.offset_encoding)
@@ -1065,7 +1065,7 @@ function lsp.formatexpr(opts)
         },
       }
       local response =
-        client.request_sync(ms.textDocument_rangeFormatting, params, timeout_ms, bufnr)
+        client:request_sync(ms.textDocument_rangeFormatting, params, timeout_ms, bufnr)
       if response and response.result then
         lsp.util.apply_text_edits(response.result, bufnr, client.offset_encoding)
         return 0

--- a/runtime/lua/vim/lsp/_changetracking.lua
+++ b/runtime/lua/vim/lsp/_changetracking.lua
@@ -40,7 +40,7 @@ local M = {}
 --- @class vim.lsp.CTGroupState
 --- @field buffers table<integer,vim.lsp.CTBufferState>
 --- @field debounce integer debounce duration in ms
---- @field clients table<integer, table> clients using this state. {client_id, client}
+--- @field clients table<integer, vim.lsp.Client> clients using this state. {client_id, client}
 
 ---@param group vim.lsp.CTGroup
 ---@return string
@@ -273,8 +273,8 @@ local function send_changes(bufnr, sync_kind, state, buf_state)
   end
   local uri = vim.uri_from_bufnr(bufnr)
   for _, client in pairs(state.clients) do
-    if not client.is_stopped() and vim.lsp.buf_is_attached(bufnr, client.id) then
-      client.notify(protocol.Methods.textDocument_didChange, {
+    if not client:is_stopped() and vim.lsp.buf_is_attached(bufnr, client.id) then
+      client:notify(protocol.Methods.textDocument_didChange, {
         textDocument = {
           uri = uri,
           version = util.buf_versions[bufnr],

--- a/runtime/lua/vim/lsp/_tagfunc.lua
+++ b/runtime/lua/vim/lsp/_tagfunc.lua
@@ -59,7 +59,7 @@ local function query_definition(pattern)
       remaining = remaining - 1
     end
     local params = util.make_position_params(win, client.offset_encoding)
-    client.request(ms.textDocument_definition, params, on_response, bufnr)
+    client:request(ms.textDocument_definition, params, on_response, bufnr)
   end
   vim.wait(1000, function()
     return remaining == 0

--- a/runtime/lua/vim/lsp/_watchfiles.lua
+++ b/runtime/lua/vim/lsp/_watchfiles.lua
@@ -116,7 +116,7 @@ function M.register(reg, client_id)
               local params = {
                 changes = change_queues[client_id],
               }
-              client.notify(ms.workspace_didChangeWatchedFiles, params)
+              client:notify(ms.workspace_didChangeWatchedFiles, params)
               queue_timers[client_id] = nil
               change_queues[client_id] = nil
               change_cache[client_id] = nil

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -219,70 +219,28 @@ local validate = vim.validate
 --- @field private registrations table<string,lsp.Registration[]>
 --- @field dynamic_capabilities lsp.DynamicCapabilities
 ---
---- Sends a request to the server.
---- This is a thin wrapper around {client.rpc.request} with some additional
---- checking.
---- If {handler} is not specified and if there's no respective global
---- handler, then an error will occur.
---- Returns: {status}, {client_id}?. {status} is a boolean indicating if
---- the notification was successful. If it is `false`, then it will always
---- be `false` (the client has shutdown).
---- If {status} is `true`, the function returns {request_id} as the second
---- result. You can use this with `client.cancel_request(request_id)` to cancel
---- the request.
---- @field request fun(method: string, params: table?, handler: lsp.Handler?, bufnr: integer?): boolean, integer?
----
---- Sends a request to the server and synchronously waits for the response.
---- This is a wrapper around {client.request}
---- Returns: { err=err, result=result }, a dict, where `err` and `result`
---- come from the |lsp-handler|. On timeout, cancel or error, returns `(nil,
---- err)` where `err` is a string describing the failure reason. If the request
---- was unsuccessful returns `nil`.
---- @field request_sync fun(method: string, params: table?, timeout_ms: integer?, bufnr: integer): {err: lsp.ResponseError|nil, result:any}|nil, string|nil err # a dict
----
---- Sends a notification to an LSP server.
---- Returns: a boolean to indicate if the notification was successful. If
---- it is false, then it will always be false (the client has shutdown).
---- @field notify fun(method: string, params: table?): boolean
----
---- Cancels a request with a given request id.
---- Returns: same as `notify()`.
---- @field cancel_request fun(id: integer): boolean
----
---- Stops a client, optionally with force.
---- By default, it will just ask the server to shutdown without force.
---- If you request to stop a client which has previously been requested to
---- shutdown, it will automatically escalate and force shutdown.
---- @field stop fun(force?: boolean)
----
---- Runs the on_attach function from the client's config if it was defined.
---- Useful for buffer-local setup.
---- @field on_attach fun(bufnr: integer)
----
 --- @field private _before_init_cb? vim.lsp.client.before_init_cb
 --- @field private _on_attach_cbs vim.lsp.client.on_attach_cb[]
 --- @field private _on_init_cbs vim.lsp.client.on_init_cb[]
 --- @field private _on_exit_cbs vim.lsp.client.on_exit_cb[]
 --- @field private _on_error_cb? fun(code: integer, err: string)
----
---- Checks if a client supports a given method.
---- Always returns true for unknown off-spec methods.
---- {opts} is a optional `{bufnr?: integer}` table.
---- Some language server capabilities can be file specific.
---- @field supports_method fun(method: string, opts?: {bufnr: integer?}): boolean
----
---- Checks whether a client is stopped.
---- Returns: true if the client is fully stopped.
---- @field is_stopped fun(): boolean
 local Client = {}
 Client.__index = Client
 
---- @param cls table
---- @param meth any
---- @return function
-local function method_wrapper(cls, meth)
-  return function(...)
-    return meth(cls, ...)
+--- @param obj table<string,any>
+--- @param cls table<string,function>
+--- @param name string
+local function method_wrapper(obj, cls, name)
+  local meth = assert(cls[name])
+  obj[name] = function(...)
+    local arg = select(1, ...)
+    if arg and getmetatable(arg) == cls then
+      -- First argument is self, call meth directly
+      return meth(...)
+    end
+    vim.deprecate('client.' .. name, 'client:' .. name, '0.13')
+    -- First argument is not self, insert it
+    return meth(obj, ...)
   end
 end
 
@@ -499,24 +457,23 @@ function Client.create(config)
     end,
   }
 
-  self.request = method_wrapper(self, Client._request)
-  self.request_sync = method_wrapper(self, Client._request_sync)
-  self.notify = method_wrapper(self, Client._notify)
-  self.cancel_request = method_wrapper(self, Client._cancel_request)
-  self.stop = method_wrapper(self, Client._stop)
-  self.is_stopped = method_wrapper(self, Client._is_stopped)
-  self.on_attach = method_wrapper(self, Client._on_attach)
-  self.supports_method = method_wrapper(self, Client._supports_method)
-
   --- @type table<string|integer, string> title of unfinished progress sequences by token
   self.progress.pending = {}
 
   --- @type vim.lsp.rpc.Dispatchers
   local dispatchers = {
-    notification = method_wrapper(self, Client._notification),
-    server_request = method_wrapper(self, Client._server_request),
-    on_error = method_wrapper(self, Client._on_error),
-    on_exit = method_wrapper(self, Client._on_exit),
+    notification = function(...)
+      return self:_notification(...)
+    end,
+    server_request = function(...)
+      return self:_server_request(...)
+    end,
+    on_error = function(...)
+      return self:_on_error(...)
+    end,
+    on_exit = function(...)
+      return self:_on_exit(...)
+    end,
   }
 
   -- Start the RPC client.
@@ -532,6 +489,15 @@ function Client.create(config)
   end
 
   setmetatable(self, Client)
+
+  method_wrapper(self, Client, 'request')
+  method_wrapper(self, Client, 'request_sync')
+  method_wrapper(self, Client, 'notify')
+  method_wrapper(self, Client, 'cancel_request')
+  method_wrapper(self, Client, 'stop')
+  method_wrapper(self, Client, 'is_stopped')
+  method_wrapper(self, Client, 'on_attach')
+  method_wrapper(self, Client, 'supports_method')
 
   return self
 end
@@ -616,7 +582,7 @@ function Client:initialize()
     end
 
     if next(self.settings) then
-      self:_notify(ms.workspace_didChangeConfiguration, { settings = self.settings })
+      self:notify(ms.workspace_didChangeConfiguration, { settings = self.settings })
     end
 
     -- If server is being restarted, make sure to re-attach to any previously attached buffers.
@@ -628,7 +594,7 @@ function Client:initialize()
     for buf in pairs(reattach_bufs) do
       -- The buffer may have been detached in the on_init callback.
       if self.attached_buffers[buf] then
-        self:_on_attach(buf)
+        self:on_attach(buf)
       end
     end
 
@@ -645,14 +611,14 @@ end
 --- Returns the default handler if the user hasn't set a custom one.
 ---
 --- @param method (string) LSP method name
---- @return lsp.Handler|nil handler for the given method, if defined, or the default from |vim.lsp.handlers|
+--- @return lsp.Handler? handler for the given method, if defined, or the default from |vim.lsp.handlers|
 function Client:_resolve_handler(method)
   return self.handlers[method] or lsp.handlers[method]
 end
 
 --- Returns the buffer number for the given {bufnr}.
 ---
---- @param bufnr (integer|nil) Buffer number to resolve. Defaults to current buffer
+--- @param bufnr integer? Buffer number to resolve. Defaults to current buffer
 --- @return integer bufnr
 local function resolve_bufnr(bufnr)
   validate('bufnr', bufnr, 'number', true)
@@ -662,7 +628,6 @@ local function resolve_bufnr(bufnr)
   return bufnr
 end
 
---- @private
 --- Sends a request to the server.
 ---
 --- This is a thin wrapper around {client.rpc.request} with some additional
@@ -671,15 +636,14 @@ end
 --- @param method string LSP method name.
 --- @param params? table LSP request params.
 --- @param handler? lsp.Handler Response |lsp-handler| for this method.
---- @param bufnr integer Buffer handle (0 for current).
---- @return boolean status, integer? request_id {status} is a bool indicating
---- whether the request was successful. If it is `false`, then it will
---- always be `false` (the client has shutdown). If it was
---- successful, then it will return {request_id} as the
---- second result. You can use this with `client.cancel_request(request_id)`
+--- @param bufnr? integer Buffer handle. 0 for current (default).
+--- @return boolean status indicates whether the request was successful.
+---     If it is `false`, then it will always be `false` (the client has shutdown).
+--- @return integer? request_id Can be used with |Client:cancel_request()|.
+---                             `nil` is request failed.
 --- to cancel the-request.
 --- @see |vim.lsp.buf_request_all()|
-function Client:_request(method, params, handler, bufnr)
+function Client:request(method, params, handler, bufnr)
   if not handler then
     handler = assert(
       self:_resolve_handler(method),
@@ -688,8 +652,8 @@ function Client:_request(method, params, handler, bufnr)
   end
   -- Ensure pending didChange notifications are sent so that the server doesn't operate on a stale state
   changetracking.flush(self, bufnr)
-  local version = lsp.util.buf_versions[bufnr]
   bufnr = resolve_bufnr(bufnr)
+  local version = lsp.util.buf_versions[bufnr]
   log.debug(self._log_prefix, 'client.request', self.id, method, params, handler, bufnr)
   local success, request_id = self.rpc.request(method, params, function(err, result)
     local context = {
@@ -743,29 +707,27 @@ local function err_message(...)
   end
 end
 
---- @private
 --- Sends a request to the server and synchronously waits for the response.
 ---
---- This is a wrapper around {client.request}
+--- This is a wrapper around |Client:request()|
 ---
---- @param method (string) LSP method name.
---- @param params (table) LSP request params.
---- @param timeout_ms (integer|nil) Maximum time in milliseconds to wait for
+--- @param method string LSP method name.
+--- @param params table LSP request params.
+--- @param timeout_ms integer? Maximum time in milliseconds to wait for
 ---                                a result. Defaults to 1000
---- @param bufnr (integer) Buffer handle (0 for current).
---- @return {err: lsp.ResponseError|nil, result:any}|nil, string|nil err # a dict, where
---- `err` and `result` come from the |lsp-handler|.
---- On timeout, cancel or error, returns `(nil, err)` where `err` is a
---- string describing the failure reason. If the request was unsuccessful
---- returns `nil`.
+--- @param bufnr integer Buffer handle (0 for current).
+--- @return {err: lsp.ResponseError?, result:any}? `result` and `err` from the |lsp-handler|.
+---                 `nil` is the request was unsuccessful
+--- @return string? err On timeout, cancel or error, where `err` is a
+---                 string describing the failure reason.
 --- @see |vim.lsp.buf_request_sync()|
-function Client:_request_sync(method, params, timeout_ms, bufnr)
+function Client:request_sync(method, params, timeout_ms, bufnr)
   local request_result = nil
   local function _sync_handler(err, result)
     request_result = { err = err, result = result }
   end
 
-  local success, request_id = self:_request(method, params, _sync_handler, bufnr)
+  local success, request_id = self:request(method, params, _sync_handler, bufnr)
   if not success then
     return nil
   end
@@ -776,22 +738,20 @@ function Client:_request_sync(method, params, timeout_ms, bufnr)
 
   if not wait_result then
     if request_id then
-      self:_cancel_request(request_id)
+      self:cancel_request(request_id)
     end
     return nil, wait_result_reason[reason]
   end
   return request_result
 end
 
---- @package
 --- Sends a notification to an LSP server.
 ---
 --- @param method string LSP method name.
---- @param params table|nil LSP request params.
---- @return boolean status true if the notification was successful.
---- If it is false, then it will always be false
---- (the client has shutdown).
-function Client:_notify(method, params)
+--- @param params table? LSP request params.
+--- @return boolean status indicating if the notification was successful.
+---                        If it is false, then the client has shutdown.
+function Client:notify(method, params)
   if method ~= ms.textDocument_didChange then
     changetracking.flush(self)
   end
@@ -814,13 +774,12 @@ function Client:_notify(method, params)
   return client_active
 end
 
---- @private
 --- Cancels a request with a given request id.
 ---
---- @param id (integer) id of request to cancel
---- @return boolean status true if notification was successful. false otherwise
---- @see |vim.lsp.client.notify()|
-function Client:_cancel_request(id)
+--- @param id integer id of request to cancel
+--- @return boolean status indicating if the notification was successful.
+--- @see |Client:notify()|
+function Client:cancel_request(id)
   validate('id', id, 'number')
   local request = self.requests[id]
   if request and request.type == 'pending' then
@@ -834,15 +793,14 @@ function Client:_cancel_request(id)
   return self.rpc.notify(ms.dollar_cancelRequest, { id = id })
 end
 
---- @private
 --- Stops a client, optionally with force.
 ---
---- By default, it will just ask the - server to shutdown without force. If
+--- By default, it will just request the server to shutdown without force. If
 --- you request to stop a client which has previously been requested to
 --- shutdown, it will automatically escalate and force shutdown.
 ---
---- @param force boolean|nil
-function Client:_stop(force)
+--- @param force? boolean
+function Client:stop(force)
   local rpc = self.rpc
 
   if rpc.is_closing() then
@@ -961,12 +919,11 @@ function Client:_get_registration(method, bufnr)
   end
 end
 
---- @private
 --- Checks whether a client is stopped.
 ---
 --- @return boolean # true if client is stopped or in the process of being
 --- stopped; false otherwise
-function Client:_is_stopped()
+function Client:is_stopped()
   return self.rpc.is_closing()
 end
 
@@ -1008,7 +965,7 @@ function Client:exec_cmd(command, context, handler)
     command = cmdname,
     arguments = command.arguments,
   }
-  self.request(ms.workspace_executeCommand, params, handler, context.bufnr)
+  self:request(ms.workspace_executeCommand, params, handler, context.bufnr)
 end
 
 --- Default handler for the 'textDocument/didOpen' LSP notification.
@@ -1016,14 +973,14 @@ end
 --- @param bufnr integer Number of the buffer, or 0 for current
 function Client:_text_document_did_open_handler(bufnr)
   changetracking.init(self, bufnr)
-  if not self.supports_method(ms.textDocument_didOpen) then
+  if not self:supports_method(ms.textDocument_didOpen) then
     return
   end
   if not api.nvim_buf_is_loaded(bufnr) then
     return
   end
 
-  self.notify(ms.textDocument_didOpen, {
+  self:notify(ms.textDocument_didOpen, {
     textDocument = {
       version = lsp.util.buf_versions[bufnr],
       uri = vim.uri_from_bufnr(bufnr),
@@ -1044,8 +1001,9 @@ function Client:_text_document_did_open_handler(bufnr)
 end
 
 --- Runs the on_attach function from the client's config if it was defined.
+--- Useful for buffer-local setup.
 --- @param bufnr integer Buffer number
-function Client:_on_attach(bufnr)
+function Client:on_attach(bufnr)
   self:_text_document_did_open_handler(bufnr)
 
   lsp._set_defaults(self, bufnr)
@@ -1080,10 +1038,18 @@ function Client:write_error(code, err)
   err_message(self._log_prefix, ': Error ', client_error, ': ', vim.inspect(err))
 end
 
---- @private
+--- Checks if a client supports a given method.
+--- Always returns true for unknown off-spec methods.
+---
+--- Note: Some language server capabilities can be file specific.
 --- @param method string
---- @param opts? {bufnr: integer?}
-function Client:_supports_method(method, opts)
+--- @param bufnr? integer
+function Client:supports_method(method, bufnr)
+  -- Deprecated form
+  if type(bufnr) == 'table' then
+    --- @diagnostic disable-next-line:no-unknown
+    bufnr = bufnr.bufnr
+  end
   local required_capability = lsp._request_name_to_capability[method]
   -- if we don't know about the method, assume that the client supports it.
   if not required_capability then
@@ -1096,12 +1062,12 @@ function Client:_supports_method(method, opts)
   local rmethod = lsp._resolve_to_request[method]
   if rmethod then
     if self:_supports_registration(rmethod) then
-      local reg = self:_get_registration(rmethod, opts and opts.bufnr)
+      local reg = self:_get_registration(rmethod, bufnr)
       return vim.tbl_get(reg or {}, 'registerOptions', 'resolveProvider') or false
     end
   else
     if self:_supports_registration(method) then
-      return self:_get_registration(method, opts and opts.bufnr) ~= nil
+      return self:_get_registration(method, bufnr) ~= nil
     end
   end
   return false
@@ -1202,7 +1168,7 @@ function Client:_add_workspace_folder(dir)
 
   local wf = assert(get_workspace_folders(dir))
 
-  self:_notify(ms.workspace_didChangeWorkspaceFolders, {
+  self:notify(ms.workspace_didChangeWorkspaceFolders, {
     event = { added = wf, removed = {} },
   })
 
@@ -1217,7 +1183,7 @@ end
 function Client:_remove_workspace_folder(dir)
   local wf = assert(get_workspace_folders(dir))
 
-  self:_notify(ms.workspace_didChangeWorkspaceFolders, {
+  self:notify(ms.workspace_didChangeWorkspaceFolders, {
     event = { added = {}, removed = wf },
   })
 

--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -231,7 +231,7 @@ local function resolve_lenses(lenses, bufnr, client_id, callback)
       countdown()
     else
       assert(client)
-      client.request(ms.codeLens_resolve, lens, function(_, result)
+      client:request(ms.codeLens_resolve, lens, function(_, result)
         if api.nvim_buf_is_loaded(bufnr) and result and result.command then
           lens.command = result.command
           -- Eager display to have some sort of incremental feedback

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -404,7 +404,7 @@ local function request(clients, bufnr, win, callback)
   for _, client in pairs(clients) do
     local client_id = client.id
     local params = lsp.util.make_position_params(win, client.offset_encoding)
-    local ok, request_id = client.request(ms.textDocument_completion, params, function(err, result)
+    local ok, request_id = client:request(ms.textDocument_completion, params, function(err, result)
       responses[client_id] = { err = err, result = result }
       remaining_requests = remaining_requests - 1
       if remaining_requests == 0 then
@@ -421,7 +421,7 @@ local function request(clients, bufnr, win, callback)
     for client_id, request_id in pairs(request_ids) do
       local client = lsp.get_client_by_id(client_id)
       if client then
-        client.cancel_request(request_id)
+        client:cancel_request(request_id)
       end
     end
   end
@@ -582,7 +582,7 @@ local function on_complete_done()
     local changedtick = vim.b[bufnr].changedtick
 
     --- @param result lsp.CompletionItem
-    client.request(ms.completionItem_resolve, completion_item, function(err, result)
+    client:request(ms.completionItem_resolve, completion_item, function(err, result)
       if changedtick ~= vim.b[bufnr].changedtick then
         return
       end

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -122,12 +122,12 @@ end
 --- local hint = vim.lsp.inlay_hint.get({ bufnr = 0 })[1] -- 0 for current buffer
 ---
 --- local client = vim.lsp.get_client_by_id(hint.client_id)
---- local resp = client.request_sync('inlayHint/resolve', hint.inlay_hint, 100, 0)
+--- local resp = client:request_sync('inlayHint/resolve', hint.inlay_hint, 100, 0)
 --- local resolved_hint = assert(resp and resp.result, resp.err)
 --- vim.lsp.util.apply_text_edits(resolved_hint.textEdits, 0, client.encoding)
 ---
 --- location = resolved_hint.label[1].location
---- client.request('textDocument/hover', {
+--- client:request('textDocument/hover', {
 ---   textDocument = { uri = location.uri },
 ---   position = location.range.start,
 --- })

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -273,7 +273,7 @@ function STHighlighter:send_request()
     if client and current_result.version ~= version and active_request.version ~= version then
       -- cancel stale in-flight request
       if active_request.request_id then
-        client.cancel_request(active_request.request_id)
+        client:cancel_request(active_request.request_id)
         active_request = {}
         state.active_request = active_request
       end
@@ -288,7 +288,7 @@ function STHighlighter:send_request()
         method = method .. '/delta'
         params.previousResultId = current_result.result_id
       end
-      local success, request_id = client.request(method, params, function(err, response, ctx)
+      local success, request_id = client:request(method, params, function(err, response, ctx)
         -- look client up again using ctx.client_id instead of using a captured
         -- client object
         local c = vim.lsp.get_client_by_id(ctx.client_id)
@@ -519,7 +519,7 @@ function STHighlighter:reset()
     if state.active_request.request_id then
       local client = vim.lsp.get_client_by_id(client_id)
       assert(client)
-      client.cancel_request(state.active_request.request_id)
+      client:cancel_request(state.active_request.request_id)
       state.active_request = {}
     end
   end
@@ -547,7 +547,7 @@ function STHighlighter:mark_dirty(client_id)
   if state.active_request.request_id then
     local client = vim.lsp.get_client_by_id(client_id)
     assert(client)
-    client.cancel_request(state.active_request.request_id)
+    client:cancel_request(state.active_request.request_id)
     state.active_request = {}
   end
 end

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -2122,7 +2122,7 @@ function M._refresh(method, opts)
         local first = vim.fn.line('w0', window)
         local last = vim.fn.line('w$', window)
         for _, client in ipairs(clients) do
-          client.request(method, {
+          client:request(method, {
             textDocument = textDocument,
             range = make_line_range_params(bufnr, first - 1, last - 1, client.offset_encoding),
           }, nil, bufnr)
@@ -2131,7 +2131,7 @@ function M._refresh(method, opts)
     end
   else
     for _, client in ipairs(clients) do
-      client.request(method, {
+      client:request(method, {
         textDocument = textDocument,
         range = make_line_range_params(
           bufnr,

--- a/scripts/luacats_parser.lua
+++ b/scripts/luacats_parser.lua
@@ -1,9 +1,6 @@
 local luacats_grammar = require('scripts.luacats_grammar')
 
---- @class nvim.luacats.parser.param
---- @field name string
---- @field type string
---- @field desc string
+--- @class nvim.luacats.parser.param : nvim.luacats.Param
 
 --- @class nvim.luacats.parser.return
 --- @field name string
@@ -41,21 +38,14 @@ local luacats_grammar = require('scripts.luacats_grammar')
 --- @field notes? nvim.luacats.parser.note[]
 --- @field see? nvim.luacats.parser.note[]
 
---- @class nvim.luacats.parser.field
---- @field name string
---- @field type string
---- @field desc string
---- @field access? 'private'|'package'|'protected'
+--- @class nvim.luacats.parser.field : nvim.luacats.Field
+--- @field classvar? string
 --- @field nodoc? true
 
---- @class nvim.luacats.parser.class
---- @field kind 'class'
---- @field parent? string
---- @field name string
---- @field desc string
+--- @class nvim.luacats.parser.class : nvim.luacats.Class
+--- @field desc? string
 --- @field nodoc? true
 --- @field inlinedoc? true
---- @field access? 'private'|'package'|'protected'
 --- @field fields nvim.luacats.parser.field[]
 --- @field notes? string[]
 
@@ -332,7 +322,10 @@ local function process_lua_line(line, state, classes, classvars, has_indent)
         end
 
         -- Add method as the field to the class
-        table.insert(classes[class].fields, fun2field(cur_obj))
+        local cls = classes[class]
+        local field = fun2field(cur_obj)
+        field.classvar = cur_obj.classvar
+        table.insert(cls.fields, field)
         return
       end
 

--- a/test/functional/plugin/lsp/testutil.lua
+++ b/test/functional/plugin/lsp/testutil.lua
@@ -182,16 +182,17 @@ function M.test_rpc_server(config)
     )
   end
   local client = setmetatable({}, {
-    __index = function(_, name)
+    __index = function(t, name)
       -- Workaround for not being able to yield() inside __index for Lua 5.1 :(
       -- Otherwise I would just return the value here.
-      return function(...)
+      return function(arg1, ...)
+        local ismethod = arg1 == t
         return exec_lua(function(...)
-          if type(_G.TEST_RPC_CLIENT[name]) == 'function' then
-            return _G.TEST_RPC_CLIENT[name](...)
-          else
-            return _G.TEST_RPC_CLIENT[name]
+          local client = _G.TEST_RPC_CLIENT
+          if type(client[name]) == 'function' then
+            return client[name](ismethod and client or arg1, ...)
           end
+          return client[name]
         end, ...)
       end
     end,

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -232,7 +232,7 @@ describe('LSP', function()
           -- client is a dummy object which will queue up commands to be run
           -- once the server initializes. It can't accept lua callbacks or
           -- other types that may be unserializable for now.
-          client.stop()
+          client:stop()
         end,
         -- If the program timed out, then code will be nil.
         on_exit = function(code, signal)
@@ -254,8 +254,8 @@ describe('LSP', function()
       test_rpc_server {
         test_name = 'basic_init',
         on_init = function(client)
-          client.notify('test')
-          client.stop()
+          client:notify('test')
+          client:stop()
         end,
         on_exit = function(code, signal)
           eq(101, code, 'exit code') -- See fake-lsp-server.lua
@@ -275,7 +275,7 @@ describe('LSP', function()
       test_rpc_server({
         test_name = 'basic_init_did_change_configuration',
         on_init = function(client, _)
-          client.stop()
+          client:stop()
         end,
         on_exit = function(code, signal)
           eq(0, code, 'exit code')
@@ -333,9 +333,9 @@ describe('LSP', function()
         test_name = 'basic_init',
         on_init = function(client)
           eq(0, client.server_capabilities().textDocumentSync.change)
-          client.request('shutdown')
-          client.notify('exit')
-          client.stop()
+          client:request('shutdown')
+          client:notify('exit')
+          client:stop()
         end,
         on_exit = function(code, signal)
           eq(0, code, 'exit code')
@@ -377,7 +377,7 @@ describe('LSP', function()
         end,
         on_init = function(_client)
           client = _client
-          client.notify('finish')
+          client:notify('finish')
         end,
         on_exit = function(code, signal)
           eq(0, code, 'exit code')
@@ -395,7 +395,7 @@ describe('LSP', function()
                 return vim.lsp.buf_is_attached(_G.BUFFER, _G.TEST_RPC_CLIENT_ID)
               end)
             )
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -430,7 +430,7 @@ describe('LSP', function()
               return vim.lsp.buf_attach_client(_G.BUFFER, _G.TEST_RPC_CLIENT_ID)
             end)
           )
-          client.notify('finish')
+          client:notify('finish')
         end,
         on_handler = function(_, _, ctx)
           if ctx.method == 'finish' then
@@ -439,7 +439,7 @@ describe('LSP', function()
               return vim.lsp.buf_detach_client(_G.BUFFER, _G.TEST_RPC_CLIENT_ID)
             end)
             eq('basic_init', api.nvim_get_var('lsp_detached'))
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -472,7 +472,7 @@ describe('LSP', function()
                 return keymap.callback == vim.lsp.buf.hover
               end)
             )
-            client.stop()
+            client:stop()
           end
         end,
         on_exit = function(_, _)
@@ -524,7 +524,7 @@ describe('LSP', function()
             eq('v:lua.vim.lsp.tagfunc', get_buf_option('tagfunc', BUFFER_1))
             eq('v:lua.vim.lsp.omnifunc', get_buf_option('omnifunc', BUFFER_2))
             eq('v:lua.vim.lsp.formatexpr()', get_buf_option('formatexpr', BUFFER_2))
-            client.stop()
+            client:stop()
           end
         end,
         on_exit = function(_, _)
@@ -554,7 +554,7 @@ describe('LSP', function()
             eq('tfu', get_buf_option('tagfunc'))
             eq('ofu', get_buf_option('omnifunc'))
             eq('fex', get_buf_option('formatexpr'))
-            client.stop()
+            client:stop()
           end
         end,
         on_exit = function(_, _)
@@ -711,10 +711,10 @@ describe('LSP', function()
               ctx.method,
               result
             )
-            client.notify('workspace/configuration', server_result)
+            client:notify('workspace/configuration', server_result)
           end
           if ctx.method == 'shutdown' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -756,7 +756,7 @@ describe('LSP', function()
       test_rpc_server {
         test_name = 'basic_check_capabilities',
         on_init = function(client)
-          client.stop()
+          client:stop()
           local full_kind = exec_lua(function()
             return require 'vim.lsp.protocol'.TextDocumentSyncKind.Full
           end)
@@ -798,7 +798,7 @@ describe('LSP', function()
               vim.api.nvim_exec_autocmds('BufWritePost', { buffer = _G.BUFFER, modeline = false })
             end)
           else
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -898,7 +898,7 @@ describe('LSP', function()
               end)
             end)
           else
-            client.stop()
+            client:stop()
           end
         end,
       })
@@ -929,20 +929,20 @@ describe('LSP', function()
               vim.api.nvim_exec_autocmds('BufWritePost', { buffer = _G.BUFFER, modeline = false })
             end)
           else
-            client.stop()
+            client:stop()
           end
         end,
       }
     end)
 
-    it('client.supports_methods() should validate capabilities', function()
+    it('client:supports_methods() should validate capabilities', function()
       local expected_handlers = {
         { NIL, {}, { method = 'shutdown', client_id = 1 } },
       }
       test_rpc_server {
         test_name = 'capabilities_for_client_supports_method',
         on_init = function(client)
-          client.stop()
+          client:stop()
           local expected_sync_capabilities = {
             change = 1,
             openClose = true,
@@ -958,11 +958,11 @@ describe('LSP', function()
           eq(true, client.server_capabilities().codeLensProvider.resolveProvider)
 
           -- known methods for resolved capabilities
-          eq(true, client.supports_method('textDocument/hover'))
-          eq(false, client.supports_method('textDocument/definition'))
+          eq(true, client:supports_method('textDocument/hover'))
+          eq(false, client:supports_method('textDocument/definition'))
 
           -- unknown methods are assumed to be supported.
-          eq(true, client.supports_method('unknown-method'))
+          eq(true, client:supports_method('unknown-method'))
         end,
         on_exit = function(code, signal)
           eq(0, code, 'exit code')
@@ -989,7 +989,7 @@ describe('LSP', function()
           end)
         end,
         on_init = function(client)
-          client.stop()
+          client:stop()
           exec_lua(function()
             vim.lsp.buf.type_definition()
           end)
@@ -1018,7 +1018,7 @@ describe('LSP', function()
             end)
           end,
           on_init = function(client)
-            client.stop()
+            client:stop()
             exec_lua(function()
               vim.lsp.buf.type_definition()
             end)
@@ -1042,7 +1042,7 @@ describe('LSP', function()
       test_rpc_server {
         test_name = 'check_forward_request_cancelled',
         on_init = function(_client)
-          _client.request('error_code_test')
+          _client:request('error_code_test')
           client = _client
         end,
         on_exit = function(code, signal)
@@ -1053,7 +1053,7 @@ describe('LSP', function()
         on_handler = function(err, _, ctx)
           eq(table.remove(expected_handlers), { err, {}, ctx }, 'expected handler')
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -1072,7 +1072,7 @@ describe('LSP', function()
       test_rpc_server {
         test_name = 'check_forward_content_modified',
         on_init = function(_client)
-          _client.request('error_code_test')
+          _client:request('error_code_test')
           client = _client
         end,
         on_exit = function(code, signal)
@@ -1084,10 +1084,10 @@ describe('LSP', function()
           eq(table.remove(expected_handlers), { err, _, ctx }, 'expected handler')
           -- if ctx.method == 'error_code_test' then client.notify("finish") end
           if ctx.method ~= 'finish' then
-            client.notify('finish')
+            client:notify('finish')
           end
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -1103,13 +1103,13 @@ describe('LSP', function()
         test_name = 'check_pending_request_tracked',
         on_init = function(_client)
           client = _client
-          client.request('slow_request')
+          client:request('slow_request')
           local request = exec_lua(function()
             return _G.TEST_RPC_CLIENT.requests[2]
           end)
           eq('slow_request', request.method)
           eq('pending', request.type)
-          client.notify('release')
+          client:notify('release')
         end,
         on_exit = function(code, signal)
           eq(0, code, 'exit code')
@@ -1123,10 +1123,10 @@ describe('LSP', function()
               return _G.TEST_RPC_CLIENT.requests[2]
             end)
             eq(nil, request)
-            client.notify('finish')
+            client:notify('finish')
           end
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -1141,14 +1141,14 @@ describe('LSP', function()
         test_name = 'check_cancel_request_tracked',
         on_init = function(_client)
           client = _client
-          client.request('slow_request')
-          client.cancel_request(2)
+          client:request('slow_request')
+          client:cancel_request(2)
           local request = exec_lua(function()
             return _G.TEST_RPC_CLIENT.requests[2]
           end)
           eq('slow_request', request.method)
           eq('cancel', request.type)
-          client.notify('release')
+          client:notify('release')
         end,
         on_exit = function(code, signal)
           eq(0, code, 'exit code')
@@ -1162,7 +1162,7 @@ describe('LSP', function()
           end)
           eq(nil, request)
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -1178,19 +1178,19 @@ describe('LSP', function()
         test_name = 'check_tracked_requests_cleared',
         on_init = function(_client)
           client = _client
-          client.request('slow_request')
+          client:request('slow_request')
           local request = exec_lua(function()
             return _G.TEST_RPC_CLIENT.requests[2]
           end)
           eq('slow_request', request.method)
           eq('pending', request.type)
-          client.cancel_request(2)
+          client:cancel_request(2)
           request = exec_lua(function()
             return _G.TEST_RPC_CLIENT.requests[2]
           end)
           eq('slow_request', request.method)
           eq('cancel', request.type)
-          client.notify('release')
+          client:notify('release')
         end,
         on_exit = function(code, signal)
           eq(0, code, 'exit code')
@@ -1204,10 +1204,10 @@ describe('LSP', function()
               return _G.TEST_RPC_CLIENT.requests[2]
             end)
             eq(nil, request)
-            client.notify('finish')
+            client:notify('finish')
           end
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -1225,11 +1225,11 @@ describe('LSP', function()
           command('let g:requests = 0')
           command('autocmd LspRequest * let g:requests+=1')
           client = _client
-          client.request('slow_request')
+          client:request('slow_request')
           eq(1, eval('g:requests'))
-          client.cancel_request(2)
+          client:cancel_request(2)
           eq(2, eval('g:requests'))
-          client.notify('release')
+          client:notify('release')
         end,
         on_exit = function(code, signal)
           eq(0, code, 'exit code')
@@ -1240,10 +1240,10 @@ describe('LSP', function()
         on_handler = function(err, _, ctx)
           eq(table.remove(expected_handlers), { err, {}, ctx }, 'expected handler')
           if ctx.method == 'slow_request' then
-            client.notify('finish')
+            client:notify('finish')
           end
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -1277,7 +1277,7 @@ describe('LSP', function()
           end)
           eq(full_kind, client.server_capabilities().textDocumentSync.change)
           eq(true, client.server_capabilities().textDocumentSync.openClose)
-          client.notify('finish')
+          client:notify('finish')
         end,
         on_exit = function(code, signal)
           eq(0, code, 'exit code')
@@ -1286,7 +1286,7 @@ describe('LSP', function()
         on_handler = function(err, result, ctx)
           eq(table.remove(expected_handlers), { err, result, ctx }, 'expected handler')
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -1333,11 +1333,11 @@ describe('LSP', function()
         end,
         on_handler = function(err, result, ctx)
           if ctx.method == 'start' then
-            client.notify('finish')
+            client:notify('finish')
           end
           eq(table.remove(expected_handlers), { err, result, ctx }, 'expected handler')
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -1378,11 +1378,11 @@ describe('LSP', function()
         end,
         on_handler = function(err, result, ctx)
           if ctx.method == 'start' then
-            client.notify('finish')
+            client:notify('finish')
           end
           eq(table.remove(expected_handlers), { err, result, ctx }, 'expected handler')
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -1428,11 +1428,11 @@ describe('LSP', function()
                 'boop',
               })
             end)
-            client.notify('finish')
+            client:notify('finish')
           end
           eq(table.remove(expected_handlers), { err, result, ctx }, 'expected handler')
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -1479,11 +1479,11 @@ describe('LSP', function()
                 'boop',
               })
             end)
-            client.notify('finish')
+            client:notify('finish')
           end
           eq(table.remove(expected_handlers), { err, result, ctx }, 'expected handler')
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -1529,7 +1529,7 @@ describe('LSP', function()
         end,
         on_init = function(_client)
           client = _client
-          eq(true, client.supports_method('textDocument/inlayHint'))
+          eq(true, client:supports_method('textDocument/inlayHint'))
           exec_lua(function()
             assert(vim.lsp.buf_attach_client(_G.BUFFER, _G.TEST_RPC_CLIENT_ID))
           end)
@@ -1545,11 +1545,11 @@ describe('LSP', function()
             end)
           end
           if ctx.method == 'textDocument/inlayHint' then
-            client.notify('finish')
+            client:notify('finish')
           end
           eq(table.remove(expected_handlers), { err, result, ctx }, 'expected handler')
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -1598,11 +1598,11 @@ describe('LSP', function()
                 '123boop',
               })
             end)
-            client.notify('finish')
+            client:notify('finish')
           end
           eq(table.remove(expected_handlers), { err, result, ctx }, 'expected handler')
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -1652,11 +1652,11 @@ describe('LSP', function()
                 '123boop',
               })
             end)
-            client.notify('finish')
+            client:notify('finish')
           end
           eq(table.remove(expected_handlers), { err, result, ctx }, 'expected handler')
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -1699,11 +1699,11 @@ describe('LSP', function()
         on_handler = function(err, result, ctx)
           if ctx.method == 'start' then
             n.command('normal! 1Go')
-            client.notify('finish')
+            client:notify('finish')
           end
           eq(table.remove(expected_handlers), { err, result, ctx }, 'expected handler')
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -1752,11 +1752,11 @@ describe('LSP', function()
                 'boop',
               })
             end)
-            client.notify('finish')
+            client:notify('finish')
           end
           eq(table.remove(expected_handlers), { err, result, ctx }, 'expected handler')
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -1806,11 +1806,11 @@ describe('LSP', function()
               })
               vim.api.nvim_command(_G.BUFFER .. 'bwipeout')
             end)
-            client.notify('finish')
+            client:notify('finish')
           end
           eq(table.remove(expected_handlers), { err, result, ctx }, 'expected handler')
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -1830,7 +1830,7 @@ describe('LSP', function()
         on_setup = function() end,
         on_init = function(_client)
           client = _client
-          client.stop(true)
+          client:stop(true)
         end,
         on_exit = function(code, signal)
           eq(0, code, 'exit code')
@@ -1882,7 +1882,7 @@ describe('LSP', function()
         on_handler = function(err, result, ctx)
           eq(table.remove(expected_handlers), { err, result, ctx }, 'expected handler')
           if ctx.method == 'finish' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -2348,7 +2348,7 @@ describe('LSP', function()
       test_rpc_server {
         test_name = 'basic_init',
         on_init = function(client, _)
-          client.stop()
+          client:stop()
         end,
         -- If the program timed out, then code will be nil.
         on_exit = function(code, signal)
@@ -4284,7 +4284,7 @@ describe('LSP', function()
                   end)
                 )
               end
-              client.stop()
+              client:stop()
             end
           end,
         }
@@ -4331,7 +4331,7 @@ describe('LSP', function()
                 return type(vim.lsp.commands['dummy2'])
               end)
             )
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -4372,7 +4372,7 @@ describe('LSP', function()
               vim.lsp.buf.code_action()
             end)
           elseif ctx.method == 'shutdown' then
-            client.stop()
+            client:stop()
           end
         end,
       })
@@ -4447,7 +4447,7 @@ describe('LSP', function()
                 return type(vim.lsp.commands['executed_type_annotate'])
               end)
             )
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -4564,7 +4564,7 @@ describe('LSP', function()
             end)
             eq({ command = 'Dummy', title = 'Lens1' }, cmd)
           elseif ctx.method == 'shutdown' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -4653,7 +4653,7 @@ describe('LSP', function()
             end)
             eq({ command = 'Dummy', title = 'Lens2' }, response)
           elseif ctx.method == 'shutdown' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -4762,7 +4762,7 @@ describe('LSP', function()
             return notify_msg
           end)
           eq('[LSP] Format request failed, no matching language servers.', notify_msg)
-          client.stop()
+          client:stop()
         end,
       }
     end)
@@ -4795,7 +4795,7 @@ describe('LSP', function()
             end)
             eq(nil, notify_msg)
           elseif ctx.method == 'shutdown' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -4836,7 +4836,7 @@ describe('LSP', function()
             end)
             eq(nil, notify_msg)
           elseif ctx.method == 'shutdown' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -4883,7 +4883,7 @@ describe('LSP', function()
             end)
             eq(nil, notify_msg)
           elseif ctx.method == 'shutdown' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -4930,7 +4930,7 @@ describe('LSP', function()
             end)
             eq({ handler_called = true }, result)
           elseif ctx.method == 'shutdown' then
-            client.stop()
+            client:stop()
           end
         end,
       }
@@ -5477,7 +5477,7 @@ describe('LSP', function()
           result[#result + 1] = {
             method = method,
             fname = fname,
-            supported = client.supports_method(method, { bufnr = bufnr }),
+            supported = client:supports_method(method, { bufnr = bufnr }),
           }
         end
 


### PR DESCRIPTION
Deprecated:
- `client.request()` -> `client:request()`
- `client.request_sync()` -> `client:request_sync()`
- `client.notify()` -> `client:notify()`
- `client.cancel_request()` -> `client:cancel_request()`
- `client.stop()` -> `client:stop()`
- `client.is_stopped()` `client:is_stopped()`
- `client.supports_method()` -> `client:supports_method()`
- `client.on_attach()` -> `client:on_attach()`

Fixed docgen to link class fields to the full function doc.
