### PR TITLE
fix(lsp): hover keymap

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -365,7 +365,9 @@ function lsp._set_defaults(client, bufnr)
       and is_empty_or_default(bufnr, 'keywordprg')
       and vim.fn.maparg('K', 'n', false, false) == ''
     then
-      vim.keymap.set('n', 'K', vim.lsp.buf.hover, { buffer = bufnr, desc = 'vim.lsp.buf.hover()' })
+      vim.keymap.set('n', 'K', function()
+        vim.lsp.buf.hover()
+      end, { buffer = bufnr, desc = 'vim.lsp.buf.hover()' })
     end
   end)
   if client.supports_method(ms.textDocument_diagnostic) then

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -466,10 +466,17 @@ describe('LSP', function()
               true,
               exec_lua(function()
                 local keymap --- @type table<string,any>
+                local called = false
+                local origin = vim.lsp.buf.hover
+                vim.lsp.buf.hover = function()
+                  called = true
+                end
                 vim._with({ buf = _G.BUFFER }, function()
                   keymap = vim.fn.maparg('K', 'n', false, true)
                 end)
-                return keymap.callback == vim.lsp.buf.hover
+                keymap.callback()
+                vim.lsp.buf.hover = origin
+                return called
               end)
             )
             client.stop()
@@ -480,13 +487,13 @@ describe('LSP', function()
           eq('', get_buf_option('omnifunc'))
           eq('', get_buf_option('formatexpr'))
           eq(
-            '',
+            true,
             exec_lua(function()
               local keymap --- @type string
               vim._with({ buf = _G.BUFFER }, function()
                 keymap = vim.fn.maparg('K', 'n', false, false)
               end)
-              return keymap
+              return keymap:match('<Lua %d+: .+/runtime/lua/vim/lsp%.lua:%d+>') ~= nil
             end)
           )
         end,


### PR DESCRIPTION
the default `K` keymap for `vim.lsp.buf.hover()` is implemented differently to the other default lsp keymaps

e.g.

```lua
-- https://github.com/neovim/neovim/blob/7d771c3eeef5b4dca9ebc5ed6f7ca03f2b26b6bc/runtime/lua/vim/_defaults.lua#L170-L172
vim.keymap.set('n', 'grr', function()
    vim.lsp.buf.references()
end, { desc = 'vim.lsp.buf.references()' })
```

vs

```lua
-- https://github.com/neovim/neovim/blob/7d771c3eeef5b4dca9ebc5ed6f7ca03f2b26b6bc/runtime/lua/vim/lsp.lua#L368
vim.keymap.set('n', 'K', vim.lsp.buf.hover, { buffer = bufnr, desc = 'vim.lsp.buf.hover()' })
```

this makes it impossible to override the options of `hover` but still keep the default keymap

i.e.

```lua
-- this works
local signature_help = vim.lsp.buf.signature_help
---@param config vim.lsp.buf.signature_help.Opts
---@diagnostic disable-next-line: duplicate-set-field
vim.lsp.buf.signature_help = function(config)
    signature_help(vim.tbl_extend("force", config or {}, { border = "rounded" }))
end

-- this does not
local hover = vim.lsp.buf.hover
---@param config vim.lsp.buf.hover.Opts
---@diagnostic disable-next-line: duplicate-set-field
vim.lsp.buf.hover = function(config)
    hover(vim.tbl_extend("force", config or {}, {
        border = "rounded",
        title = client.name,
        title_pos = "left",
    }))
end

```
