### PR TITLE
ci(win): update setup-python action to v5

### DIFF
--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -31,13 +31,6 @@ jobs:
           cmake --preset ci -D CMAKE_BUILD_TYPE='RelWithDebInfo' ${{ inputs.build_flags }}
           cmake --build build
 
-      # FIXME(dundargoc): this workaround is needed as the python3 provider
-      # tests suddenly started to become extremely flaky, and this removes the
-      # flakiness for some reason.
-      - uses: actions/setup-python@v5
-        with:
-          python-version: '3.13'
-
       - name: Install test deps
         run: |
           $PSNativeCommandArgumentPassing = 'Legacy'

--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -34,7 +34,7 @@ jobs:
       # FIXME(dundargoc): this workaround is needed as the python3 provider
       # tests suddenly started to become extremely flaky, and this removes the
       # flakiness for some reason.
-      - uses: actions/setup-python@v4
+      - uses: actions/setup-python@v5
         with:
           python-version: '3.13'
 


### PR DESCRIPTION
Problem: GHA complains about deprecated Node version in windows test.

Solution: Update setup-python action to use Node.js v20.