### PR TITLE
vim-patch:9.1.0855: setting 'cmdheight' may cause missing output

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6814,11 +6814,13 @@ void command_height(void)
       // Recompute window positions.
       win_comp_pos();
 
-      // clear the lines added to cmdline
-      if (full_screen) {
-        grid_clear(&default_grid, cmdline_row, Rows, 0, Columns, 0);
+      if (!need_wait_return) {
+        // clear the lines added to cmdline
+        if (full_screen) {
+          grid_clear(&default_grid, cmdline_row, Rows, 0, Columns, 0);
+        }
+        msg_row = cmdline_row;
       }
-      msg_row = cmdline_row;
       redraw_cmdline = true;
       return;
     }

--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -139,10 +139,17 @@ describe('cmdline', function()
     ]])
   end)
 
-  it("setting 'cmdheight' works after outputting two messages vim-patch:9.0.0665", function()
+  -- oldtest: Test_changing_cmdheight()
+  it("changing 'cmdheight'", function()
     local screen = Screen.new(60, 8)
     exec([[
       set cmdheight=1 laststatus=2
+      func EchoOne()
+        set laststatus=2 cmdheight=1
+        echo 'foo'
+        echo 'bar'
+        set cmdheight=2
+      endfunc
       func EchoTwo()
         set laststatus=2
         set cmdheight=5
@@ -151,6 +158,8 @@ describe('cmdline', function()
         set cmdheight=1
       endfunc
     ]])
+
+    -- setting 'cmdheight' works after outputting two messages
     feed(':call EchoTwo()')
     screen:expect([[
                                                                   |
@@ -164,6 +173,17 @@ describe('cmdline', function()
       {1:~                                                           }|*5
       {3:[No Name]                                                   }|
                                                                   |
+    ]])
+
+    -- increasing 'cmdheight' doesn't clear the messages that need hit-enter
+    feed(':call EchoOne()<CR>')
+    screen:expect([[
+                                                                  |
+      {1:~                                                           }|*3
+      {3:                                                            }|
+      foo                                                         |
+      bar                                                         |
+      {6:Press ENTER or type command to continue}^                     |
     ]])
   end)
 

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -271,6 +271,12 @@ func Test_changing_cmdheight()
 
   let lines =<< trim END
       set cmdheight=1 laststatus=2
+      func EchoOne()
+        set laststatus=2 cmdheight=1
+        echo 'foo'
+        echo 'bar'
+        set cmdheight=2
+      endfunc
       func EchoTwo()
         set laststatus=2
         set cmdheight=5
@@ -305,6 +311,10 @@ func Test_changing_cmdheight()
   " setting 'cmdheight' works after outputting two messages
   call term_sendkeys(buf, ":call EchoTwo()\<CR>")
   call VerifyScreenDump(buf, 'Test_changing_cmdheight_6', {})
+
+  " increasing 'cmdheight' doesn't clear the messages that need hit-enter
+  call term_sendkeys(buf, ":call EchoOne()\<CR>")
+  call VerifyScreenDump(buf, 'Test_changing_cmdheight_7', {})
 
   " clean up
   call StopVimInTerminal(buf)


### PR DESCRIPTION
Fix #22646

#### vim-patch:9.1.0855: setting 'cmdheight' may cause hit-enter-prompt

Problem:  setting 'cmdheight' may cause hit-enter-prompt and echo output
          to be missing
Solution: Before cleaning the cmdline, check the need_wait_return flag
          (nwounkn)

closes: vim/vim#13432

https://github.com/vim/vim/commit/2e48567007f2becd484a3c3dd0706bf3a0beeae7

Co-authored-by: nwounkn <nwounkn@gmail.com>