### PR TITLE
fix(api): nvim_get_option_value does not clean up temp buffer on FileType event error

### DIFF
--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -166,6 +166,14 @@ Object nvim_get_option_value(String name, Dict(option) *opts, Error *err)
 
   buf_T *ftbuf = do_ft_buf(filetype, &aco, err);
   if (ERROR_SET(err)) {
+    if (ftbuf != NULL) {
+      // restore curwin/curbuf and a few other things
+      aucmd_restbuf(&aco);
+
+      assert(curbuf != ftbuf);  // safety check
+      wipe_buffer(ftbuf, false);
+    }
+
     return (Object)OBJECT_INIT;
   }
 

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -161,6 +161,18 @@ describe('vim.filetype', function()
       end
     end
   end)
+
+  it('.get_option() cleans up buffer on error', function()
+    api.nvim_create_autocmd('FileType', { pattern = 'foo', command = 'lua error()' })
+
+    local buf = api.nvim_get_current_buf()
+
+    exec_lua(function()
+      pcall(vim.filetype.get_option, 'foo', 'lisp')
+    end)
+
+    eq(buf, api.nvim_get_current_buf())
+  end)
 end)
 
 describe('filetype.lua', function()


### PR DESCRIPTION
Fixes that if there's an error in `FileType` autocmd, then the filetype get opt buffer doesn't get cleaned up