### PR TITLE
vim-patch: update runtime files

### DIFF
--- a/runtime/autoload/netrw.vim
+++ b/runtime/autoload/netrw.vim
@@ -35,6 +35,7 @@
 "   2024 Nov 07 by Vim Project: use keeppatterns to prevent polluting the search history
 "   2024 Nov 07 by Vim Project: fix a few issues with netrw tree listing (#15996)
 "   2024 Nov 10 by Vim Project: directory symlink not resolved in tree view (#16020)
+"   2024 Nov 14 by Vim Project: small fixes to netrw#BrowseX (#16056)
 "   }}}
 " Former Maintainer:	Charles E Campbell
 " GetLatestVimScripts: 1075 1 :AutoInstall: netrw.vim
@@ -4999,7 +5000,7 @@ if has('unix')
     let args = a:args
     exe 'silent !' ..
       \ ((args =~? '\v<\f+\.(exe|com|bat|cmd)>') ?
-      \ 'cmd.exe /c start "" /b ' .. args :
+      \ 'cmd.exe /c start /b ' .. args :
       \ 'nohup ' .. args .. ' ' .. s:redir() .. ' &')
       \ | redraw!
   endfun
@@ -5078,10 +5079,7 @@ endif
 "              given filename; typically this means given their extension.
 "              0=local, 1=remote
 fun! netrw#BrowseX(fname,remote)
-  if a:remote == 0 && isdirectory(a:fname)
-   " if its really just a local directory, then do a "gf" instead
-   exe "e ".a:fname
-  elseif a:remote == 1 && a:fname !~ '^https\=:' && a:fname =~ '/$'
+  if a:remote == 1 && a:fname !~ '^https\=:' && a:fname =~ '/$'
    " remote directory, not a webpage access, looks like an attempt to do a directory listing
    norm! gf
   endif

--- a/runtime/indent/sh.vim
+++ b/runtime/indent/sh.vim
@@ -7,6 +7,8 @@
 " License:             Vim (see :h license)
 " Repository:          https://github.com/chrisbra/vim-sh-indent
 " Changelog:
+"          20241411  - Detect dash character in function keyword for
+"                      bash mode (issue #16049)
 "          20190726  - Correctly skip if keywords in syntax comments
 "                      (issue #17)
 "          20190603  - Do not indent in zsh filetypes with an `if` in comments
@@ -195,7 +197,9 @@ endfunction
 function! s:is_function_definition(line)
   return a:line =~ '^\s*\<\k\+\>\s*()\s*{' ||
        \ a:line =~ '^\s*{' ||
-       \ a:line =~ '^\s*function\s*\k\+\s*\%(()\)\?\s*{'
+       \ a:line =~ '^\s*function\s*\k\+\s*\%(()\)\?\s*{' ||
+       \ ((&ft is# 'zsh' || s:is_bash()) &&
+       \  a:line =~ '^\s*function\s*\S\+\s*\%(()\)\?\s*{' )
 endfunction
 
 function! s:is_array(line)

--- a/runtime/indent/testdir/bash.in
+++ b/runtime/indent/testdir/bash.in
@@ -1,0 +1,22 @@
+#!/bin/bash
+# vim: set ft=bash sw=2 noet:
+
+# START_INDENT
+a = 10
+b = 20
+
+function add() {
+c = $((a + b))
+}
+
+function print {
+# do nothing
+}
+
+if [[ $c -ge 15 ]];
+then
+print("ok")
+else
+print("not ok")
+fi
+# END_INDENT

--- a/runtime/indent/testdir/bash.ok
+++ b/runtime/indent/testdir/bash.ok
@@ -1,0 +1,22 @@
+#!/bin/bash
+# vim: set ft=bash sw=2 noet:
+
+# START_INDENT
+a = 10
+b = 20
+
+function add() {
+  c = $((a + b))
+}
+
+function print {
+  # do nothing
+}
+
+if [[ $c -ge 15 ]];
+then
+  print("ok")
+else
+  print("not ok")
+fi
+# END_INDENT

--- a/runtime/syntax/cfg.vim
+++ b/runtime/syntax/cfg.vim
@@ -2,6 +2,7 @@
 " Language:	Good old CFG files
 " Maintainer:	Igor N. Prischepoff (igor@tyumbit.ru, pri_igor@mail.ru)
 " Last change:	2012 Aug 11
+" 2024 Nov 14 by Vim project:  // only denotes a comment when starting a line (#16051)
 
 " quit when a syntax file was already loaded
 if exists ("b:current_syntax")
@@ -27,17 +28,17 @@ syn match CfgSection	    "{.*}"
 syn match  CfgString	"\".*\"" contained
 syn match  CfgString    "'.*'"   contained
 
-" Comments (Everything before '#' or '//' or ';')
+" Comments (Everything before '#' or ';' or leading '//')
 syn match  CfgComment	"#.*"
 syn match  CfgComment	";.*"
-syn match  CfgComment	"\/\/.*"
+syn match  CfgComment	"^\s*\/\/.*"
 
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet
 hi def link CfgOnOff     Label
-hi def link CfgComment	Comment
-hi def link CfgSection	Type
-hi def link CfgString	String
+hi def link CfgComment	 Comment
+hi def link CfgSection	 Type
+hi def link CfgString	 String
 hi def link CfgParams    Keyword
 hi def link CfgValues    Constant
 hi def link CfgDirectory Directory


### PR DESCRIPTION
- **vim-patch:460799d: runtime(netrw): small fixes to netrw#BrowseX**
- **vim-patch:0acd3ab: runtime(sh): better function support for bash/zsh in indent script**
- **vim-patch:7c3b65e: runtime(cfg): only consider leading // as starting a comment**
