### PR TITLE
feat(default): bind `vim.lsp.buf.signature_help` in select mode

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -167,7 +167,7 @@ DEFAULTS
   • |gri| in Normal mode maps to |vim.lsp.buf.implementation()|
   • |gO| in Normal mode maps to |vim.lsp.buf.document_symbol()|
   • |gra| in Normal and Visual mode maps to |vim.lsp.buf.code_action()|
-  • CTRL-S in Insert mode maps to |vim.lsp.buf.signature_help()|
+  • CTRL-S in Insert and Select mode maps to |vim.lsp.buf.signature_help()|
   • Mouse |popup-menu| includes an "Open in web browser" item when you right-click
     on a URL.
   • Mouse |popup-menu| includes a "Go to definition" item when LSP is active

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -179,7 +179,7 @@ do
       vim.lsp.buf.document_symbol()
     end, { desc = 'vim.lsp.buf.document_symbol()' })
 
-    vim.keymap.set('i', '<C-S>', function()
+    vim.keymap.set({ 'i', 's' }, '<C-S>', function()
       vim.lsp.buf.signature_help()
     end, { desc = 'vim.lsp.buf.signature_help()' })
   end


### PR DESCRIPTION
Select mode is usually used to select the expanded snippet. Suppose the LSP server's completion includes function parameters. In that case, nvim will select a parameter and enter selection mode, so `vim.lsp.buf.signature_help` is useful for select mode and is also consistent.