### PR TITLE
fix(ui): no fast context for prompt message kinds

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1083,7 +1083,9 @@ vim.ui_attach({ns}, {options}, {callback})                   *vim.ui_attach()*
     |ui-popupmenu| and the sections below for event format for respective
     events.
 
-    Callbacks for `msg_show` events are executed in |api-fast| context.
+    Callbacks for `msg_show` events are executed in |api-fast| context unless
+    Nvim will wait for input, in which case messages should be shown
+    immediately.
 
     Excessive errors inside the callback will result in forced detachment.
 

--- a/runtime/lua/vim/_meta/builtin.lua
+++ b/runtime/lua/vim/_meta/builtin.lua
@@ -233,7 +233,9 @@ function vim.wait(time, callback, interval, fast_only) end
 --- {callback} receives event name plus additional parameters. See |ui-popupmenu|
 --- and the sections below for event format for respective events.
 ---
---- Callbacks for `msg_show` events are executed in |api-fast| context.
+--- Callbacks for `msg_show` events are executed in |api-fast| context unless
+--- Nvim will wait for input, in which case messages should be shown
+--- immediately.
 ---
 --- Excessive errors inside the callback will result in forced detachment.
 ---

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -717,6 +717,13 @@ void ui_call_event(char *name, bool fast, Array args)
 {
   bool handled = false;
   UIEventCallback *event_cb;
+
+  // Prompt messages should be shown immediately so must be safe
+  if (strcmp(name, "msg_show") == 0) {
+    char *kind = args.items[0].data.string.data;
+    fast = !kind || (strncmp(kind, "confirm", 7) != 0 && strcmp(kind, "return_prompt") != 0);
+  }
+
   map_foreach(&ui_event_cbs, ui_event_ns_id, event_cb, {
     Error err = ERROR_INIT;
     uint32_t ns_id = ui_event_ns_id;


### PR DESCRIPTION
Problem:  No longer able to show prompt messages with vim.ui_attach(). 
Solution: Do not execute callback in fast context for prompt message
          kinds. These events must be safe to show the incoming message
          so the event itself serves to indicate that the message
          should be shown immediately.