### PR TITLE
vim-patch:partial:9.1.0851: too many strlen() calls in getchar.c

### DIFF
--- a/src/nvim/getchar_defs.h
+++ b/src/nvim/getchar_defs.h
@@ -9,6 +9,7 @@
 /// structure used to store one block of the stuff/redo/recording buffers
 typedef struct buffblock {
   struct buffblock *b_next;  ///< pointer to next buffblock
+  size_t b_strlen;      ///< length of b_str, excluding the NUL
   char b_str[1];        ///< contents (actually longer)
 } buffblock_T;
 
@@ -18,6 +19,7 @@ typedef struct {
   buffblock_T *bh_curr;  ///< buffblock for appending
   size_t bh_index;       ///< index for reading
   size_t bh_space;       ///< space in bh_curr for appending
+  bool bh_create_newblock;  ///< create a new block?
 } buffheader_T;
 
 typedef struct {


### PR DESCRIPTION
#### vim-patch:partial:9.1.0851: too many strlen() calls in getchar.c

Problem:  too many strlen() calls in getchar.c
Solution: refactor code and reduce strlen() calls
          (John Marriott)

closes: vim/vim#16017

https://github.com/vim/vim/commit/e7a1bbf2102ecd2083613ff18d7d46c45d1e568e

Co-authored-by: John Marriott <basilisk@internode.on.net>