### PR TITLE
fix(checkhealth): disable 'listchars'

### DIFF
--- a/runtime/ftplugin/checkhealth.vim
+++ b/runtime/ftplugin/checkhealth.vim
@@ -8,11 +8,11 @@ endif
 
 runtime! ftplugin/help.vim
 
-setlocal wrap breakindent linebreak
+setlocal wrap breakindent linebreak nolist
 let &l:iskeyword='!-~,^*,^|,^",192-255'
 
 if exists("b:undo_ftplugin")
-  let b:undo_ftplugin .= "|setl wrap< bri< lbr< kp< isk<"
+  let b:undo_ftplugin .= "|setl wrap< bri< lbr< kp< isk< list<"
 else
-  let b:undo_ftplugin = "setl wrap< bri< lbr< kp< isk<"
+  let b:undo_ftplugin = "setl wrap< bri< lbr< kp< isk< list<"
 endif


### PR DESCRIPTION
Problem:
'listchars' (in particular multispace) breaks visual heading due to
`Whitespace` highlight group.

Solution:
Disable 'list' (and thus all listchars) by default for `checkhealth`
files.

Fixes #31145
