### PR TITLE
vim-patch:9.1.0869: Problem: curswant not set on gm in folded line

### DIFF
--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5249,6 +5249,12 @@ void nv_g_home_m_cmd(cmdarg_T *cap)
     curwin->w_valid &= ~VALID_WCOL;
   }
   curwin->w_set_curswant = true;
+  if (hasAnyFolding(curwin)) {
+    validate_cheight(curwin);
+    if (curwin->w_cline_folded) {
+      update_curswant_force();
+    }
+  }
   adjust_skipcol();
 }
 

--- a/test/functional/legacy/normal_spec.lua
+++ b/test/functional/legacy/normal_spec.lua
@@ -102,4 +102,33 @@ describe('normal', function()
       ]],
     })
   end)
+
+  -- oldtest: Test_normal_gm()
+  it('gm sets curswant correctly', function()
+    screen:try_resize(75, 10)
+    exec([[
+      call setline(1, repeat(["  abcd\tefgh\tij"], 10))
+      call cursor(1, 1)
+    ]])
+    feed('jVjzf')
+    -- gm
+    feed('gmk')
+    eq(18, fn.virtcol('.'))
+    -- g0
+    feed('gj0k')
+    eq(1, fn.virtcol('.'))
+    -- g^
+    feed('jg^k')
+    eq(3, fn.virtcol('.'))
+    exec('call cursor(10, 1)')
+    -- gm
+    feed('gmk')
+    eq(18, fn.virtcol('.'))
+    -- g0
+    feed('gj0k')
+    eq(1, fn.virtcol('.'))
+    -- g^
+    feed('jg^k')
+    eq(3, fn.virtcol('.'))
+  end)
 end)

--- a/test/old/testdir/test_curswant.vim
+++ b/test/old/testdir/test_curswant.vim
@@ -1,4 +1,7 @@
-" Tests for curswant not changing when setting an option
+" Tests for not changing curswant
+
+source check.vim
+source term_util.vim
 
 func Test_curswant()
   new
@@ -19,5 +22,50 @@ func Test_curswant()
   let &ttimeoutlen=&ttimeoutlen
   call assert_equal(7, winsaveview().curswant)
 
-  enew!
+  bw!
 endfunc
+
+func Test_normal_gm()
+  CheckRunVimInTerminal
+  let lines =<< trim END
+    call setline(1, repeat(["  abcd\tefgh\tij"], 10))
+    call cursor(1, 1)
+  END
+  call writefile(lines, 'XtestCurswant', 'D')
+  let buf = RunVimInTerminal('-S XtestCurswant', #{rows: 10})
+  if has("folding")
+    call term_sendkeys(buf, "jVjzf")
+    " gm
+    call term_sendkeys(buf, "gmk")
+    call term_sendkeys(buf, ":echo virtcol('.')\<cr>")
+    call WaitFor({-> term_getline(buf, 10) =~ '^18\s\+'})
+    " g0
+    call term_sendkeys(buf, "jg0k")
+    call term_sendkeys(buf, ":echo virtcol('.')\<cr>")
+    call WaitFor({-> term_getline(buf, 10) =~ '^1\s\+'})
+    " g^
+    call term_sendkeys(buf, "jg^k")
+    call term_sendkeys(buf, ":echo virtcol('.')\<cr>")
+    call WaitFor({-> term_getline(buf, 10) =~ '^3\s\+'})
+  endif
+  call term_sendkeys(buf, ":call cursor(10, 1)\<cr>")
+  " gm
+  call term_sendkeys(buf, "gmk")
+  call term_sendkeys(buf, ":echo virtcol('.')\<cr>")
+  call term_wait(buf)
+  call WaitFor({-> term_getline(buf, 10) =~ '^18\s\+'})
+  " g0
+  call term_sendkeys(buf, "g0k")
+  call term_sendkeys(buf, ":echo virtcol('.')\<cr>")
+  call WaitFor({-> term_getline(buf, 10) =~ '^1\s\+'})
+  " g^
+  call term_sendkeys(buf, "g^k")
+  call term_sendkeys(buf, ":echo virtcol('.')\<cr>")
+  call WaitFor({-> term_getline(buf, 10) =~ '^3\s\+'})
+  " clean up
+  call StopVimInTerminal(buf)
+  wincmd p
+  wincmd c
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0869: Problem: curswant not set on gm in folded line

Problem:  curswant not set on gm in folded line
          (citizenmatt)
Solution: in a folded line, call update_curswant_force()

closes: vim/vim#11994
closes: vim/vim#15398

https://github.com/vim/vim/commit/9848face747ba91282d34a96dcb966bcb410bf2b

Co-authored-by: Christian Brabandt <cb@256bit.org>