### PR TITLE
feat(lsp)!: make `offset_encoding` required

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1956,8 +1956,7 @@ make_given_range_params({start_pos}, {end_pos}, {bufnr}, {offset_encoding})
       • {offset_encoding}  (`'utf-8'|'utf-16'|'utf-32'`)
 
     Return: ~
-        (`table`) { textDocument = { uri = `current_file_uri` }, range = {
-        start = `start_position`, end = `end_position` } }
+        (`{ textDocument: { uri: lsp.DocumentUri }, range: lsp.Range }`)
 
                                          *vim.lsp.util.make_position_params()*
 make_position_params({window}, {offset_encoding})
@@ -1988,8 +1987,7 @@ make_range_params({window}, {offset_encoding})
       • {offset_encoding}  (`"utf-8"|"utf-16"|"utf-32"`)
 
     Return: ~
-        (`table`) { textDocument = { uri = `current_file_uri` }, range = {
-        start = `current_position`, end = `current_position` } }
+        (`{ textDocument: { uri: lsp.DocumentUri }, range: lsp.Range }`)
 
                                     *vim.lsp.util.make_text_document_params()*
 make_text_document_params({bufnr})

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1953,8 +1953,7 @@ make_given_range_params({start_pos}, {end_pos}, {bufnr}, {offset_encoding})
                            selection.
       • {bufnr}            (`integer?`) buffer handle or 0 for current,
                            defaults to current
-      • {offset_encoding}  (`'utf-8'|'utf-16'|'utf-32'?`) defaults to
-                           `offset_encoding` of first client of `bufnr`
+      • {offset_encoding}  (`'utf-8'|'utf-16'|'utf-32'`)
 
     Return: ~
         (`table`) { textDocument = { uri = `current_file_uri` }, range = {
@@ -1968,9 +1967,7 @@ make_position_params({window}, {offset_encoding})
     Parameters: ~
       • {window}           (`integer?`) window handle or 0 for current,
                            defaults to current
-      • {offset_encoding}  (`'utf-8'|'utf-16'|'utf-32'?`) defaults to
-                           `offset_encoding` of first client of buffer of
-                           `window`
+      • {offset_encoding}  (`'utf-8'|'utf-16'|'utf-32'`)
 
     Return: ~
         (`lsp.TextDocumentPositionParams`)
@@ -1988,9 +1985,7 @@ make_range_params({window}, {offset_encoding})
     Parameters: ~
       • {window}           (`integer?`) window handle or 0 for current,
                            defaults to current
-      • {offset_encoding}  (`"utf-8"|"utf-16"|"utf-32"?`) defaults to
-                           `offset_encoding` of first client of buffer of
-                           `window`
+      • {offset_encoding}  (`"utf-8"|"utf-16"|"utf-32"`)
 
     Return: ~
         (`table`) { textDocument = { uri = `current_file_uri` }, range = {

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -95,6 +95,9 @@ LSP
   Instead use: >lua
     vim.diagnostic.config(config, vim.lsp.diagnostic.get_namespace(client_id))
 <
+• |vim.lsp.util.make_position_params()|, |vim.lsp.util.make_range_params()|
+  and |vim.lsp.util.make_given_range_params()| now require the `offset_encoding`
+  parameter.
 
 LUA
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1925,8 +1925,7 @@ end
 ---
 ---@param window integer? window handle or 0 for current, defaults to current
 ---@param offset_encoding "utf-8"|"utf-16"|"utf-32"
----@return table { textDocument = { uri = `current_file_uri` }, range = { start =
----`current_position`, end = `current_position` } }
+---@return { textDocument: { uri: lsp.DocumentUri }, range: lsp.Range }
 function M.make_range_params(window, offset_encoding)
   local buf = api.nvim_win_get_buf(window or 0)
   if offset_encoding == nil then
@@ -1952,8 +1951,7 @@ end
 --- Defaults to the end of the last visual selection.
 ---@param bufnr integer? buffer handle or 0 for current, defaults to current
 ---@param offset_encoding 'utf-8'|'utf-16'|'utf-32'
----@return table { textDocument = { uri = `current_file_uri` }, range = { start =
----`start_position`, end = `end_position` } }
+---@return { textDocument: { uri: lsp.DocumentUri }, range: lsp.Range }
 function M.make_given_range_params(start_pos, end_pos, bufnr, offset_encoding)
   validate('start_pos', start_pos, 'table', true)
   validate('end_pos', end_pos, 'table', true)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1848,12 +1848,11 @@ function M.try_trim_markdown_code_blocks(lines)
 end
 
 ---@param window integer?: window handle or 0 for current, defaults to current
----@param offset_encoding? 'utf-8'|'utf-16'|'utf-32'? defaults to `offset_encoding` of first client of buffer of `window`
+---@param offset_encoding 'utf-8'|'utf-16'|'utf-32'
 local function make_position_param(window, offset_encoding)
   window = window or 0
   local buf = api.nvim_win_get_buf(window)
   local row, col = unpack(api.nvim_win_get_cursor(window))
-  offset_encoding = offset_encoding or M._get_offset_encoding(buf)
   row = row - 1
   local line = api.nvim_buf_get_lines(buf, row, row + 1, true)[1]
   if not line then
@@ -1868,13 +1867,19 @@ end
 --- Creates a `TextDocumentPositionParams` object for the current buffer and cursor position.
 ---
 ---@param window integer?: window handle or 0 for current, defaults to current
----@param offset_encoding 'utf-8'|'utf-16'|'utf-32'? defaults to `offset_encoding` of first client of buffer of `window`
+---@param offset_encoding 'utf-8'|'utf-16'|'utf-32'
 ---@return lsp.TextDocumentPositionParams
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocumentPositionParams
 function M.make_position_params(window, offset_encoding)
   window = window or 0
   local buf = api.nvim_win_get_buf(window)
-  offset_encoding = offset_encoding or M._get_offset_encoding(buf)
+  if offset_encoding == nil then
+    vim.notify_once(
+      'warning: offset_encoding is required, using the offset_encoding from the first client',
+      vim.log.levels.WARN
+    )
+    offset_encoding = M._get_offset_encoding(buf)
+  end
   return {
     textDocument = M.make_text_document_params(buf),
     position = make_position_param(window, offset_encoding),
@@ -1904,7 +1909,7 @@ function M._get_offset_encoding(bufnr)
       offset_encoding = this_offset_encoding
     elseif offset_encoding ~= this_offset_encoding then
       vim.notify_once(
-        'warning: multiple different client offset_encodings detected for buffer, this is not supported yet',
+        'warning: multiple different client offset_encodings detected for buffer, vim.lsp.util._get_offset_encoding() uses the offset_encoding from the first client',
         vim.log.levels.WARN
       )
     end
@@ -1919,12 +1924,18 @@ end
 --- `textDocument/rangeFormatting`.
 ---
 ---@param window integer? window handle or 0 for current, defaults to current
----@param offset_encoding "utf-8"|"utf-16"|"utf-32"? defaults to `offset_encoding` of first client of buffer of `window`
+---@param offset_encoding "utf-8"|"utf-16"|"utf-32"
 ---@return table { textDocument = { uri = `current_file_uri` }, range = { start =
 ---`current_position`, end = `current_position` } }
 function M.make_range_params(window, offset_encoding)
   local buf = api.nvim_win_get_buf(window or 0)
-  offset_encoding = offset_encoding or M._get_offset_encoding(buf)
+  if offset_encoding == nil then
+    vim.notify_once(
+      'warning: offset_encoding is required, using the offset_encoding from the first client',
+      vim.log.levels.WARN
+    )
+    offset_encoding = M._get_offset_encoding(buf)
+  end
   local position = make_position_param(window, offset_encoding)
   return {
     textDocument = M.make_text_document_params(buf),
@@ -1940,7 +1951,7 @@ end
 ---@param end_pos [integer,integer]? {row,col} mark-indexed position.
 --- Defaults to the end of the last visual selection.
 ---@param bufnr integer? buffer handle or 0 for current, defaults to current
----@param offset_encoding 'utf-8'|'utf-16'|'utf-32'? defaults to `offset_encoding` of first client of `bufnr`
+---@param offset_encoding 'utf-8'|'utf-16'|'utf-32'
 ---@return table { textDocument = { uri = `current_file_uri` }, range = { start =
 ---`start_position`, end = `end_position` } }
 function M.make_given_range_params(start_pos, end_pos, bufnr, offset_encoding)
@@ -1948,7 +1959,13 @@ function M.make_given_range_params(start_pos, end_pos, bufnr, offset_encoding)
   validate('end_pos', end_pos, 'table', true)
   validate('offset_encoding', offset_encoding, 'string', true)
   bufnr = bufnr or api.nvim_get_current_buf()
-  offset_encoding = offset_encoding or M._get_offset_encoding(bufnr)
+  if offset_encoding == nil then
+    vim.notify_once(
+      'warning: offset_encoding is required, using the offset_encoding from the first client',
+      vim.log.levels.WARN
+    )
+    offset_encoding = M._get_offset_encoding(bufnr)
+  end
   --- @type [integer, integer]
   local A = { unpack(start_pos or api.nvim_buf_get_mark(bufnr, '<')) }
   --- @type [integer, integer]

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1887,6 +1887,7 @@ function M.make_position_params(window, offset_encoding)
 end
 
 --- Utility function for getting the encoding of the first LSP client on the given buffer.
+---@deprecated
 ---@param bufnr integer buffer handle or 0 for current, defaults to current
 ---@return string encoding first client if there is one, nil otherwise
 function M._get_offset_encoding(bufnr)


### PR DESCRIPTION
## Background
Since [version 3.17](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocuments), LSP supports specifying the position encoding (aka offset encoding) supported by the client through `positionEncoding`.
Since https://github.com/neovim/neovim/pull/31209, nvim now fully supports `utf-8`, `utf-16`, and `utf-32` encodings.

## Problem
In the past, nvim assumed that all clients in the same buffer had the same `offset_encoding`, so:
* nvim provides `vim.lsp._get_offset_encoding()` to get `offset_encoding`, but this function is incorrect because `offset_encoding` is essentially related to the client, not the buffer. If a buffer has multiple clients, it will only return the `offset_encoding` of the first client, which is unsafe, because their `offset_encoding` values ​​may be different;
* Based on the strategy of `vim.lsp._get_offset_encoding()`, `vim.lsp.util.make_position_params()`, `vim.lsp.util.make_range_params()`, and `vim.lsp.util.make_given_range_params()` do not require the caller to pass `offset_encoding`, which is unsafe.
* https://github.com/neovim/neovim/issues/25272

## Solution
* Deprecated `vim.lsp._get_offset_encoding()`;
* Change the signatures of `vim.lsp.util.make_position_params()`, `vim.lsp.util.make_range_params()`, and `vim.lsp.util.make_given_range_params()` to require the caller to pass `offset_encoding`.


## Possible Future Changes
* Deprecate `vim.lsp.make_given_range_params()`?
`vim.lsp.make_range()` supports optional parameters, allowing these two functions to be merged into one. However, the default values of `start_pos` and `end_pos` in `vim.lsp.make_given_range_params()` are the area selected in the previous visual mode, which is not equivalent to `vim.lsp.make_range()`;
* Rename `offset_encoding` to `position_encoding`?
The name `offsetEncoding` should come from [clangd](https://clangd.llvm.org/extensions#utf-8-offsets), as LSP initially did not support it, so this was an extension of clangd at that time. However, after version 3.17, LSP supported the same functionality, but it is called `positionEncoding`, so it may be worth considering synchronizing with upstream changes.