### PR TITLE
fix(api): only flush nvim__redraw when necessary

### DIFF
--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -65,7 +65,7 @@ function M.on_inlayhint(err, result, ctx)
   if num_unprocessed == 0 then
     client_hints[client_id] = {}
     bufstate.version = ctx.version
-    api.nvim__redraw({ buf = bufnr, valid = true })
+    api.nvim__redraw({ buf = bufnr, valid = true, flush = false })
     return
   end
 
@@ -81,7 +81,7 @@ function M.on_inlayhint(err, result, ctx)
 
   client_hints[client_id] = new_lnum_hints
   bufstate.version = ctx.version
-  api.nvim__redraw({ buf = bufnr, valid = true })
+  api.nvim__redraw({ buf = bufnr, valid = true, flush = false })
 end
 
 --- |lsp-handler| for the method `workspace/inlayHint/refresh`
@@ -215,7 +215,7 @@ local function clear(bufnr)
     end
   end
   api.nvim_buf_clear_namespace(bufnr, namespace, 0, -1)
-  api.nvim__redraw({ buf = bufnr, valid = true })
+  api.nvim__redraw({ buf = bufnr, valid = true, flush = false })
 end
 
 --- Disable inlay hints for a buffer

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -219,8 +219,8 @@ end
 ---@package
 ---@param changes Range6[]
 function TSHighlighter:on_changedtree(changes)
-  for i, ch in ipairs(changes) do
-    api.nvim__redraw({ buf = self.bufnr, range = { ch[1], ch[4] + 1 }, flush = i == #changes })
+  for _, ch in ipairs(changes) do
+    api.nvim__redraw({ buf = self.bufnr, range = { ch[1], ch[4] + 1 }, flush = false })
   end
 end
 


### PR DESCRIPTION
Problem:  Not possible to only set a "redraw later" type with
          nvim__redraw, which seems to be desired for the
          treesitter highlighter.
Solution: Do not update the screen when "flush" is explicitly set to
          false and only redraw later types are present. In that case,
          do not call ui_flush() either.

Fix #31246