### PR TITLE
ci: match files instead of directories

### DIFF
--- a/.github/actions/cache/action.yml
+++ b/.github/actions/cache/action.yml
@@ -28,6 +28,6 @@ runs:
     - uses: actions/cache@v4
       with:
         path: .deps
-        key: ${{ env.CACHE_KEY }}-${{ steps.image.outputs.version }}-${{ hashFiles('cmake**',
-          '.github/**', 'CMakeLists.txt',
+        key: ${{ env.CACHE_KEY }}-${{ steps.image.outputs.version }}-${{ hashFiles('cmake*/**/*',
+          '.github/**/*', 'CMakeLists.txt',
           'runtime/CMakeLists.txt', 'src/nvim/**/CMakeLists.txt') }}

--- a/scripts/lintcommit.lua
+++ b/scripts/lintcommit.lua
@@ -102,6 +102,10 @@ local function validate_commit(commit_message)
       return [[Scope can't be empty]]
     end
 
+    if scope == 'ci' then
+      return [[Scope can't be "ci", use it as a type instead]]
+    end
+
     if vim.startswith(scope, 'nvim_') then
       return [[Scope should be "api" instead of "nvim_..."]]
     end


### PR DESCRIPTION
The pattern match (which tries to match directories directly) in the `hashFiles()` function is incorrect, see https://github.com/actions/toolkit/blob/bb2278e5cfbb40afc20890c415e9ffa836631cd5/packages/glob/src/internal-hash-files.ts#L28