### PR TITLE
feat(main): expand file ~\ or ~/ prefix on Windows

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1442,6 +1442,17 @@ scripterror:
       ga_grow(&global_alist.al_ga, 1);
       char *p = xstrdup(argv[0]);
 
+      // On Windows expand "~\" or "~/" prefix in file names to profile directory.
+#ifdef MSWIN
+      if (*p == '~' && (p[1] == '\\' || p[1] == '/')) {
+        size_t size = strlen(os_get_homedir()) + strlen(p);
+        char *tilde_expanded = xmalloc(size);
+        snprintf(tilde_expanded, size, "%s%s", os_get_homedir(), p + 1);
+        xfree(p);
+        p = tilde_expanded;
+      }
+#endif
+
       if (parmp->diff_mode && os_isdir(p) && GARGCOUNT > 0
           && !os_isdir(alist_name(&GARGLIST[0]))) {
         char *r = concat_fnames(p, path_tail(alist_name(&GARGLIST[0])), true);

--- a/test/functional/core/main_spec.lua
+++ b/test/functional/core/main_spec.lua
@@ -193,4 +193,26 @@ describe('command-line option', function()
     matches('Run "nvim %-V1 %-v"', fn.system({ nvim_prog_abs(), '-v' }))
     matches('Compilation: .*Run :checkhealth', fn.system({ nvim_prog_abs(), '-V1', '-v' }))
   end)
+
+  if is_os('win') then
+    for _, prefix in ipairs({ '~/', '~\\' }) do
+      it('expands ' .. prefix .. ' on Windows', function()
+        local fname = os.getenv('USERPROFILE') .. '\\nvim_test.txt'
+        finally(function()
+          os.remove(fname)
+        end)
+        write_file(fname, 'some text')
+        eq(
+          'some text',
+          fn.system({
+            nvim_prog_abs(),
+            '-es',
+            '+%print',
+            '+q',
+            prefix .. 'nvim_test.txt',
+          }):gsub('\n', '')
+        )
+      end)
+    end
+  end
 end)


### PR DESCRIPTION
Followup to #28515:

Rename the static os_homedir() to os_uv_homedir() to emphasize that it is a wrapper around a libuv function.

Add the function os_get_homedir() to os/env.c to return the cached homedir value as a const. Must be called after homedir is initialized or it fails.

The difference between this function and the static os_uv_homedir() is that the latter gets the homedir from libuv and is used to initialize homedir in init_homedir(), while os_get_homedir() just returns homedir as a const if it's initialized and is public.

Use the os_get_homedir() accessor for ~/ expansion on Windows to make the code more concise.

Add a Windows section to main_spec.lua with tests for expanding ~/ and ~\ prefixes for files passed in on the command-line.

Signed-off-by: Rafael Kitover <rkitover@gmail.com>
(cherry picked from commit 1a1c766049826b6049610edda8f72eac1f75b38d)