### PR TITLE
vim-patch:9.1.0862: 'wildmenu' not enabled by default in nocp mode

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -89,7 +89,6 @@ Defaults                                                    *nvim-defaults*
 - 'undodir' defaults to ~/.local/state/nvim/undo// (|xdg|), auto-created
 - 'viewoptions' includes "unix,slash", excludes "options"
 - 'viminfo' includes "!"
-- 'wildmenu' is enabled
 - 'wildoptions' defaults to "pum,tagfile"
 
 - |editorconfig| plugin is enabled, .editorconfig settings are applied.


### PR DESCRIPTION
#### vim-patch:9.1.0862: 'wildmenu' not enabled by default in nocp mode

Problem:  'wildmenu' not enabled by default in nocp mode
Solution: promote the default Vim value to true, it has been enabled
          in defaults.vim anyhow, so remove it there (Luca Saccarola)

closes: vim/vim#16055

https://github.com/vim/vim/commit/437bc13ea101835511bf4b5029c84482c1e30e62

Co-authored-by: Luca Saccarola <github.e41mv@aleeas.com>