### PR TITLE
vim-patch:9.1.0873: filetype: Vivado files are not recognized

### DIFF
--- a/runtime/ftplugin/mss.vim
+++ b/runtime/ftplugin/mss.vim
@@ -1,0 +1,16 @@
+" Vim filetype plugin file
+" Language:	Vivado mss file
+" Last Change:	2024 Oct 22
+" Document:	https://docs.amd.com/r/2020.2-English/ug1400-vitis-embedded/Microprocessor-Software-Specification-MSS
+" Maintainer:	Wu, Zhenyu <wuzhenyu@ustc.edu>
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=b:#,fb:-
+setlocal commentstring=#\ %s
+
+let b:match_words = '\<BEGIN\>:\<END\>'
+let b:undo_ftplugin = "setl com< cms< | unlet b:match_words"

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -792,6 +792,7 @@ local extension = {
   mof = 'msidl',
   odl = 'msidl',
   msql = 'msql',
+  mss = 'mss',
   mu = 'mupad',
   mush = 'mush',
   mustache = 'mustache',

--- a/runtime/syntax/mss.vim
+++ b/runtime/syntax/mss.vim
@@ -1,0 +1,23 @@
+" Vim syntax file
+" Language:	Vivado mss file
+" Maintainer:	The Vim Project <https://github.com/vim/vim>
+" Last Change:	2024 Oct 22
+" Document:	https://docs.amd.com/r/2020.2-English/ug1400-vitis-embedded/Microprocessor-Software-Specification-MSS
+" Maintainer:	Wu, Zhenyu <wuzhenyu@ustc.edu>
+
+if exists("b:current_syntax")
+  finish
+endif
+
+syn case ignore
+syn match	mssComment	"#.*$" contains=@Spell
+syn keyword	mssKeyword	BEGIN END PARAMETER
+syn keyword	mssType		OS PROCESSOR DRIVER LIBRARY
+syn keyword	mssConstant	VERSION PROC_INSTANCE HW_INSTANCE OS_NAME OS_VER DRIVER_NAME DRIVER_VER LIBRARY_NAME LIBRARY_VER STDIN STDOUT XMDSTUB_PERIPHERAL ARCHIVER COMPILER COMPILER_FLAGS EXTRA_COMPILER_FLAGS
+
+hi def link mssComment		Comment
+hi def link mssKeyword		Keyword
+hi def link mssType		Type
+hi def link mssConstant		Constant
+
+let b:current_syntax = "mss"

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -504,6 +504,7 @@ func s:GetFilenameChecks() abort
     \ 'mplayerconf': ['mplayer.conf', '/.mplayer/config', 'any/.mplayer/config'],
     \ 'mrxvtrc': ['mrxvtrc', '.mrxvtrc'],
     \ 'msidl': ['file.odl', 'file.mof'],
+    \ 'mss': ['file.mss'],
     \ 'msql': ['file.msql'],
     \ 'mojo': ['file.mojo', 'file.🔥'],
     \ 'msmtp': ['.msmtprc'],


### PR DESCRIPTION
Problem:  filetype: Vivado files are not recognized
Solution: detect '*.mss' files as 'mss' filetype
          (Wu, Zhenyu)

references:
https://docs.amd.com/r/2020.2-English/ug1400-vitis-embedded/Microprocessor-Software-Specification-MSS

closes: vim/vim#15907

https://github.com/vim/vim/commit/a87462a498a883e12ad7699b26bd28f4600b68c6

Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>
