### PR TITLE
vim-patch:9.1.0870: too many strlen() calls in eval.c

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -7848,8 +7848,8 @@ static void f_substitute(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
       || flg == NULL) {
     rettv->vval.v_string = NULL;
   } else {
-    rettv->vval.v_string = do_string_sub((char *)str, (char *)pat,
-                                         (char *)sub, expr, (char *)flg);
+    rettv->vval.v_string = do_string_sub((char *)str, strlen(str), (char *)pat,
+                                         (char *)sub, expr, (char *)flg, NULL);
   }
 }
 


### PR DESCRIPTION
#### vim-patch:9.1.0870: too many strlen() calls in eval.c

Problem:  too many strlen() calls in eval.c
Solution: Refactor eval.c to remove calls to STRLEN()
          (John Marriott)

closes: vim/vim#16066

https://github.com/vim/vim/commit/bd4614f43d0eac4aff743132bab8e53b015ac801

Co-authored-by: John Marriott <basilisk@internode.on.net>