### PR TITLE
clipboard: remove !empty($TMUX)

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -158,7 +158,7 @@ function! provider#clipboard#Executable() abort
     let s:copy['*'] = s:copy['+']
     let s:paste['*'] = s:paste['+']
     return 'termux-clipboard'
-  elseif !empty($TMUX) && executable('tmux')
+  elseif executable('tmux') && (!empty($TMUX) || 0 == jobwait([jobstart(['tmux', 'list-buffers'])], 2000)[0])
     let tmux_v = v:lua.vim.version.parse(system(['tmux', '-V']))
     if !empty(tmux_v) && !v:lua.vim.version.lt(tmux_v, [3,2,0])
       let s:copy['+'] = ['tmux', 'load-buffer', '-w', '-']


### PR DESCRIPTION
$TMUX is unnecessary:

tmux new -d
echo foobar | tmux load-buffer -
tmux save-buffer -

It is like lemonade:

lemonade server &
lemonade copy foobar
lemonade paste
