### PR TITLE
feat(ui): use builtin completion popupmenu with ext_cmdline

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3475,8 +3475,8 @@ nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
                       like a tooltip near the buffer text).
                   • row: Row position in units of "screen cell height", may be
                     fractional.
-                  • col: Column position in units of "screen cell width", may
-                    be fractional.
+                  • col: Column position in units of screen cell width, may be
+                    fractional.
                   • focusable: Enable focus by user actions (wincmds, mouse
                     events). Defaults to true. Non-focusable windows can be
                     entered by |nvim_set_current_win()|, or, when the `mouse`
@@ -3558,6 +3558,9 @@ nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
                     cursor will be invisible when focused on it.
                   • vertical: Split vertically |:vertical|.
                   • split: Split direction: "left", "right", "above", "below".
+                  • _cmdline_offset: (EXPERIMENTAL) When provided, anchor the
+                    |cmdline-completion| popupmenu to this window, with an
+                    offset in screen cell width.
 
     Return: ~
         |window-ID|, or 0 on error

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1771,8 +1771,7 @@ function vim.api.nvim_open_term(buffer, opts) end
 ---     - `row=0` and `col=0` if `anchor` is "SW" or "SE"
 ---       (thus like a tooltip near the buffer text).
 --- - row: Row position in units of "screen cell height", may be fractional.
---- - col: Column position in units of "screen cell width", may be
----          fractional.
+--- - col: Column position in units of screen cell width, may be fractional.
 --- - focusable: Enable focus by user actions (wincmds, mouse events).
 ---     Defaults to true. Non-focusable windows can be entered by
 ---     `nvim_set_current_win()`, or, when the `mouse` field is set to true,
@@ -1852,6 +1851,8 @@ function vim.api.nvim_open_term(buffer, opts) end
 ---         focused on it.
 --- - vertical: Split vertically `:vertical`.
 --- - split: Split direction: "left", "right", "above", "below".
+--- - _cmdline_offset: (EXPERIMENTAL) When provided, anchor the `cmdline-completion`
+---   popupmenu to this window, with an offset in screen cell width.
 --- @return integer # |window-ID|, or 0 on error
 function vim.api.nvim_open_win(buffer, enter, config) end
 

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -312,6 +312,7 @@ error('Cannot require a meta file')
 --- @field noautocmd? boolean
 --- @field fixed? boolean
 --- @field hide? boolean
+--- @field _cmdline_offset? integer
 
 --- @class vim.api.keyset.win_text_height
 --- @field start_row? integer

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -135,6 +135,7 @@ typedef struct {
   Boolean noautocmd;
   Boolean fixed;
   Boolean hide;
+  Integer _cmdline_offset;
 } Dict(win_config);
 
 typedef struct {

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -995,6 +995,7 @@ typedef struct {
   bool noautocmd;
   bool fixed;
   bool hide;
+  int _cmdline_offset;
 } WinConfig;
 
 #define WIN_CONFIG_INIT ((WinConfig){ .height = 0, .width = 0, \
@@ -1008,7 +1009,8 @@ typedef struct {
                                       .style = kWinStyleUnused, \
                                       .noautocmd = false, \
                                       .hide = false, \
-                                      .fixed = false })
+                                      .fixed = false, \
+                                      ._cmdline_offset = INT_MAX })
 
 // Structure to store last cursor position and topline.  Used by check_lnums()
 // and reset_lnums().

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -372,7 +372,7 @@ static int cmdline_pum_create(CmdlineInfo *ccline, expand_T *xp, char **matches,
 
   // Compute the popup menu starting column
   char *endpos = showtail ? showmatches_gettail(xp->xp_pattern, true) : xp->xp_pattern;
-  if (ui_has(kUICmdline)) {
+  if (ui_has(kUICmdline) && cmdline_win == NULL) {
     compl_startcol = (int)(endpos - ccline->cmdbuff);
   } else {
     compl_startcol = cmd_screencol((int)(endpos - ccline->cmdbuff));
@@ -1091,13 +1091,8 @@ int showmatches(expand_T *xp, bool wildmenu)
     showtail = cmd_showtail;
   }
 
-  bool compl_use_pum = (ui_has(kUICmdline)
-                        ? ui_has(kUIPopupmenu)
-                        : wildmenu && (wop_flags & kOptWopFlagPum))
-                       || ui_has(kUIWildmenu);
-
-  if (compl_use_pum) {
-    // cmdline completion popup menu (with wildoptions=pum)
+  if (((!ui_has(kUICmdline) || cmdline_win != NULL) && wildmenu && (wop_flags & kOptWopFlagPum))
+      || ui_has(kUIWildmenu) || (ui_has(kUICmdline) && ui_has(kUIPopupmenu))) {
     return cmdline_pum_create(ccline, xp, matches, numMatches, showtail);
   }
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2999,10 +2999,9 @@ static int cmd_startcol(void)
 int cmd_screencol(int bytepos)
 {
   int m;  // maximum column
-
   int col = cmd_startcol();
   if (KeyTyped) {
-    m = Columns * Rows;
+    m = cmdline_win ? cmdline_win->w_view_width * cmdline_win->w_view_height : Columns * Rows;
     if (m < 0) {        // overflow, Columns or Rows at weird value
       m = MAXCOL;
     }

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -746,6 +746,7 @@ EXTERN int cmdwin_level INIT( = 0);   ///< cmdline recursion level
 EXTERN buf_T *cmdwin_buf INIT( = NULL);  ///< buffer of cmdline window or NULL
 EXTERN win_T *cmdwin_win INIT( = NULL);  ///< window of cmdline window or NULL
 EXTERN win_T *cmdwin_old_curwin INIT( = NULL);  ///< curwin before opening cmdline window or NULL
+EXTERN win_T *cmdline_win INIT( = NULL);  ///< window in use by ext_cmdline
 
 EXTERN char no_lines_msg[] INIT( = N_("--No lines in buffer--"));
 

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -320,6 +320,101 @@ describe('vim.ui_attach', function()
       },
     })
   end)
+
+  it('ext_cmdline completion popupmenu', function()
+    screen:try_resize(screen._width, 10)
+    screen:add_extra_attr_ids { [100] = { background = Screen.colors.Black } }
+    exec_lua([[
+      vim.o.wildoptions = 'pum'
+      local buf = vim.api.nvim_create_buf(false, true)
+      vim.cmd('call setline(1, range(1, 10))')
+      _G.win = vim.api.nvim_open_win(buf, false, {
+        relative = 'editor',
+        col = 3,
+        row = 3,
+        width = 20,
+        height = 1,
+        style = 'minimal',
+        focusable = false,
+        zindex = 300,
+        _cmdline_offset = 0,
+      })
+      vim.ui_attach(ns, { ext_cmdline = true }, function(event, content, _, firstc)
+        if event == 'cmdline_show' then
+          local prompt = vim.api.nvim_win_get_config(_G.win)._cmdline_offset == 0
+          prompt = (prompt and firstc or 'Excommand:') .. content[1][2]
+          vim.api.nvim_buf_set_lines(buf, -2, -1, false, { prompt })
+          vim.api.nvim_win_set_cursor(_G.win, { 1, #prompt })
+          vim.api.nvim__redraw({ win = _G.win, cursor = true, flush = true })
+        end
+        return true
+      end)
+      vim.api.nvim_set_hl(0, 'Pmenu', {})
+    ]])
+    feed(':call buf<tab>')
+    screen:expect([[
+      1                                       |
+      2                                       |
+      3                                       |
+      4  :call bufadd^(                        |
+      5       {12: bufadd(         }{100: }              |
+      6        bufexists(      {100: }              |
+      7        buffer_exists(  {12: }              |
+      8        buffer_name(    {12: }              |
+      9        buffer_number(  {12: }              |
+                                              |
+    ]])
+    exec_lua([[
+      vim.api.nvim_win_set_config(_G.win, {
+        relative = 'editor',
+        col = 0,
+        row = 1000,
+        width = 1000,
+        height = 1,
+      })
+      vim.api.nvim__redraw({flush = true})
+    ]])
+    screen:expect([[
+      1                                       |
+      2                                       |
+      3                                       |
+      4                                       |
+      5       {12: bufadd(         }{100: }              |
+      6        bufexists(      {100: }              |
+      7        buffer_exists(  {12: }              |
+      8        buffer_name(    {12: }              |
+      9        buffer_number(  {12: }              |
+      :call bufadd^(                           |
+    ]])
+    feed('<tab>')
+    screen:expect([[
+      1     bufadd(         {100: }                 |
+      2    {12: bufexists(      }{100: }                 |
+      3     buffer_exists(  {100: }                 |
+      4     buffer_name(    {100: }                 |
+      5     buffer_number(  {100: }                 |
+      6     buflisted(      {100: }                 |
+      7     bufload(        {12: }                 |
+      8     bufloaded(      {12: }                 |
+      9     bufname(        {12: }                 |
+      :call bufexists^(                        |
+    ]])
+    -- Test different offset (e.g. for custom prompt)
+    exec_lua('vim.api.nvim_win_set_config(_G.win, { _cmdline_offset = 9 })')
+    feed('<Esc>:call buf<Tab>')
+    screen:expect([[
+      1             {12: bufadd(         }{100: }        |
+      2              bufexists(      {100: }        |
+      3              buffer_exists(  {100: }        |
+      4              buffer_name(    {100: }        |
+      5              buffer_number(  {100: }        |
+      6              buflisted(      {100: }        |
+      7              bufload(        {12: }        |
+      8              bufloaded(      {12: }        |
+      9              bufname(        {12: }        |
+      Excommand:call bufadd^(                  |
+    ]])
+  end)
 end)
 
 describe('vim.ui_attach', function()


### PR DESCRIPTION
Problem:  UIs implementing ext_cmdline/message must also implement
          ext_popupmenu in order to get cmdline completion with
          wildoptions+=pum.
Solution: Allow marking a window as the ext_cmdline window through
          nvim_open_win(), including prompt offset. Anchor the cmdline-
          completion popupmenu to this window.