### PR TITLE
feat(diagnostic): inherit parent 'path' option in open_float

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1962,6 +1962,7 @@ function M.open_float(opts, ...)
     opts.focus_id = scope
   end
   local float_bufnr, winnr = vim.lsp.util.open_floating_preview(lines, 'plaintext', opts)
+  vim.bo[float_bufnr].path = vim.bo[bufnr].path
   for i, hl in ipairs(highlights) do
     local line = lines[i]
     local prefix_len = hl.prefix and hl.prefix.length or 0


### PR DESCRIPTION
Diagnostics sometimes contain stack traces, it's useful being able to
use `CTRL-W F` on them to open related files from within the diagnostic
window.
