### PR TITLE
vim-patch:4927dae: runtime(compiler): fix escaping of arguments passed to :CompilerSet

### DIFF
--- a/runtime/compiler/cppcheck.vim
+++ b/runtime/compiler/cppcheck.vim
@@ -1,7 +1,7 @@
 " vim compiler file
 " Compiler:	cppcheck (C++ static checker)
 " Maintainer:   Vincent B. (twinside@free.fr)
-" Last Change:  2024 Nov 08 by @Konfekt
+" Last Change:  2024 Nov 19 by @Konfekt
 
 if exists("current_compiler") | finish | endif
 let current_compiler = "cppcheck"
@@ -25,7 +25,7 @@ let &l:makeprg = 'cppcheck --quiet'
       \	          (filereadable('compile_commands.json') ? '--project=compile_commands.json' :
       \           (!empty(glob('*'..s:slash..'compile_commands.json', 1, 1)) ? '--project='..glob('*'..s:slash..'compile_commands.json', 1, 1)[0] :
       \	          (empty(&path) ? '' : '-I')..join(map(filter(split(&path, ','), 'isdirectory(v:val)'),'shellescape(v:val)'), ' -I')))))
-exe 'CompilerSet makeprg='..escape(&l:makeprg, ' "')
+exe 'CompilerSet makeprg='..escape(&l:makeprg, ' \|"')
 
 CompilerSet errorformat=
   \%f:%l:%c:\ %tarning:\ %m,

--- a/runtime/compiler/groff.vim
+++ b/runtime/compiler/groff.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:     Groff
 " Maintainer:   Konfekt
-" Last Change:	2024 Sep 8
+" Last Change:	2024 Nov 19
 "
 " Expects output file extension, say `:make html` or `:make pdf`.
 " Supported devices as of Sept 2024 are: (x)html, pdf, ps, dvi, lj4, lbp ...
@@ -30,7 +30,7 @@ execute 'CompilerSet makeprg=groff'..escape(
     \ ' '..s:groff_compiler_lang()..
     \ ' -K'..get(b:, 'groff_compiler_encoding', get(g:, 'groff_compiler_encoding', 'utf8'))..
     \ ' '..get(b:, 'groff_compiler_args', get(g:, 'groff_compiler_args', ''))..
-    \ ' -mom -T$* -- %:S > %:r:S.$*', ' ')
+    \ ' -mom -T$* -- %:S > %:r:S.$*', ' \|"')
 " From Gavin Freeborn's https://github.com/Gavinok/vim-troff under Vim License
 " https://github.com/Gavinok/vim-troff/blob/91017b1423caa80aba541c997909a4f810edd275/compiler/troff.vim#L39
 CompilerSet errorformat=%o:<standard\ input>\ (%f):%l:%m,

--- a/runtime/compiler/mypy.vim
+++ b/runtime/compiler/mypy.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:	Mypy (Python static checker)
 " Maintainer:   @Konfekt
-" Last Change:	2024 Nov 07
+" Last Change:	2024 Nov 19
 
 if exists("current_compiler") | finish | endif
 let current_compiler = "mypy"
@@ -12,7 +12,7 @@ set cpo&vim
 " CompilerSet makeprg=mypy
 let &l:makeprg = 'mypy --show-column-numbers '
 	    \ ..get(b:, 'mypy_makeprg_params', get(g:, 'mypy_makeprg_params', '--strict --ignore-missing-imports'))
-exe 'CompilerSet makeprg='..escape(&l:makeprg, ' "')
+exe 'CompilerSet makeprg='..escape(&l:makeprg, ' \|"')
 CompilerSet errorformat=%f:%l:%c:\ %t%*[^:]:\ %m
 
 let &cpo = s:cpo_save

--- a/runtime/compiler/pandoc.vim
+++ b/runtime/compiler/pandoc.vim
@@ -1,7 +1,7 @@
 " Vim compiler file
 " Compiler:     Pandoc
 " Maintainer:   Konfekt
-" Last Change:	2024 Sep 8
+" Last Change:	2024 Nov 19
 "
 " Expects output file extension, say `:make html` or `:make pdf`.
 " Passes additional arguments to pandoc, say `:make html --self-contained`.
@@ -56,7 +56,7 @@ execute 'CompilerSet makeprg=pandoc'..escape(
     \ ' '..s:PandocLang()..
     \ ' --from='..s:PandocFiletype(&filetype)..
     \ ' '..get(b:, 'pandoc_compiler_args', get(g:, 'pandoc_compiler_args', ''))..
-    \ ' --output %:r:S.$* -- %:S', ' ')
+    \ ' --output %:r:S.$* -- %:S', ' \|"')
 CompilerSet errorformat=\"%f\",\ line\ %l:\ %m
 
 let &cpo = s:keepcpo

--- a/runtime/compiler/powershell.vim
+++ b/runtime/compiler/powershell.vim
@@ -3,8 +3,9 @@
 " URL: https://github.com/PProvost/vim-ps1
 " Contributors: Enno Nagel
 " Last Change: 2024 Mar 29
-"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
-"		2024 Apr 05 by The Vim Project (avoid leaving behind g:makeprg)
+"		2024 Apr 03 by the Vim Project (removed :CompilerSet definition)
+"		2024 Apr 05 by the Vim Project (avoid leaving behind g:makeprg)
+"		2024 Nov 19 by the Vim Project (properly escape makeprg setting)
 
 if exists("current_compiler")
   finish
@@ -49,7 +50,7 @@ let s:makeprg = g:ps1_makeprg_cmd .. ' %:p:S'
 "         + CategoryInfo          : ObjectNotFound: (Write-Ouput:String) [], CommandNotFoundException
 "         + FullyQualifiedErrorId : CommandNotFoundException
 
-execute 'CompilerSet makeprg=' .. escape(s:makeprg, ' ')
+execute 'CompilerSet makeprg=' .. escape(s:makeprg, ' \|"')
 
 " Showing error in context with underlining.
 CompilerSet errorformat=%+G+%m

--- a/runtime/compiler/pylint.vim
+++ b/runtime/compiler/pylint.vim
@@ -2,6 +2,7 @@
 " Compiler:     Pylint for Python
 " Maintainer:   Daniel Moch <daniel@danielmoch.com>
 " Last Change:  2024 Nov 07 by The Vim Project (added params variable)
+"		2024 Nov 19 by the Vim Project (properly escape makeprg setting)
 
 if exists("current_compiler") | finish | endif
 let current_compiler = "pylint"
@@ -13,7 +14,7 @@ set cpo&vim
 let &l:makeprg = 'pylint ' .
       \ '--output-format=text --msg-template="{path}:{line}:{column}:{C}: [{symbol}] {msg}" --reports=no ' .
       \ get(b:, "pylint_makeprg_params", get(g:, "pylint_makeprg_params", '--jobs=0'))
-exe 'CompilerSet makeprg='..escape(&l:makeprg, ' "')
+exe 'CompilerSet makeprg='..escape(&l:makeprg, ' \|"')
 CompilerSet errorformat=%A%f:%l:%c:%t:\ %m,%A%f:%l:\ %m,%A%f:(%l):\ %m,%-Z%p^%.%#,%-G%.%#
 
 let &cpo = s:cpo_save

--- a/runtime/compiler/ruff.vim
+++ b/runtime/compiler/ruff.vim
@@ -2,6 +2,7 @@
 " Compiler:     Ruff (Python linter)
 " Maintainer:   @pbnj-dragon
 " Last Change:  2024 Nov 07
+"		2024 Nov 19 by the Vim Project (properly escape makeprg setting)
 
 if exists("current_compiler") | finish | endif
 let current_compiler = "ruff"
@@ -12,7 +13,7 @@ set cpo&vim
 " CompilerSet makeprg=ruff
 let &l:makeprg= 'ruff check --output-format=concise '
         \ ..get(b:, 'ruff_makeprg_params', get(g:, 'ruff_makeprg_params', '--preview'))
-exe 'CompilerSet makeprg='..escape(&l:makeprg, ' "')
+exe 'CompilerSet makeprg='..escape(&l:makeprg, ' \|"')
 CompilerSet errorformat=%f:%l:%c:\ %m,%f:%l:\ %m,%f:%l:%c\ -\ %m,%f:
 
 let &cpo = s:cpo_save

--- a/runtime/compiler/tex.vim
+++ b/runtime/compiler/tex.vim
@@ -3,8 +3,9 @@
 " Maintainer:   Artem Chuprina <ran@ran.pp.ru>
 " Contributors: Enno Nagel
 " Last Change:  2024 Mar 29
-"		2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
-"		2024 Apr 05 by The Vim Project (avoid leaving behind g:makeprg)
+"		2024 Apr 03 by the Vim Project (removed :CompilerSet definition)
+"		2024 Apr 05 by the Vim Project (avoid leaving behind g:makeprg)
+"		2024 Nov 19 by the Vim Project (properly escape makeprg setting)
 
 if exists("current_compiler")
 	finish
@@ -27,7 +28,7 @@ if exists('b:tex_ignore_makefile') || exists('g:tex_ignore_makefile') ||
 		let current_compiler = "latex"
 	endif
 	let s:makeprg=current_compiler .. ' -interaction=nonstopmode'
-	execute 'CompilerSet makeprg=' .. escape(s:makeprg, ' ')
+	execute 'CompilerSet makeprg=' .. escape(s:makeprg, ' \|"')
 else
 	let current_compiler = 'make'
 endif


### PR DESCRIPTION
See newly added help entry referring to option-backslash

closes: vim/vim#16084

https://github.com/vim/vim/commit/4927daef608d4bbcdce8a1098cdeeaed3112c849

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>
