### PR TITLE
fix(uri): add escape char for RFC2732 in `uri_encode()` (#31270)

### DIFF
--- a/runtime/lua/vim/uri.lua
+++ b/runtime/lua/vim/uri.lua
@@ -15,7 +15,7 @@ local PATTERNS = {
   rfc2396 = "^A-Za-z0-9%-_.!~*'()",
   -- RFC 2732
   -- https://tools.ietf.org/html/rfc2732
-  rfc2732 = "^A-Za-z0-9%-_.!~*'()[]",
+  rfc2732 = "^A-Za-z0-9%-_.!~*'()%[%]",
   -- RFC 3986
   -- https://tools.ietf.org/html/rfc3986#section-2.2
   rfc3986 = "^A-Za-z0-9%-._~!$&'()*+,;=:@/",

--- a/test/functional/lua/uri_spec.lua
+++ b/test/functional/lua/uri_spec.lua
@@ -252,4 +252,12 @@ describe('URI methods', function()
       end
     )
   end)
+
+  describe('encode to uri', function()
+    it('rfc2732 including brackets', function()
+      exec_lua("str = '[:]'")
+      exec_lua("rfc = 'rfc2732'")
+      eq('[%3a]', exec_lua('return vim.uri_encode(str, rfc)'))
+    end)
+  end)
 end)


### PR DESCRIPTION
**Problem:**
The brackets in the RFC2732 regular expression are currently unescaped, causing them to be misinterpreted as special characters denoting character groups rather than as literal characters. See #31270 for detailed examples.

**Solution:**
Escape the brackets.