### PR TITLE
fix(grid): double grid_line_start() with ext_messages

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1092,9 +1092,13 @@ int showmode(void)
   win_T *ruler_win = curwin->w_status_height == 0 ? curwin : lastwin_nofloating();
   if (redrawing() && ruler_win->w_status_height == 0 && global_stl_height() == 0
       && !(p_ch == 0 && !ui_has(kUIMessages))) {
-    grid_line_start(&msg_grid_adj, Rows - 1);
+    if (!ui_has(kUIMessages)) {
+      grid_line_start(&msg_grid_adj, Rows - 1);
+    }
     win_redr_ruler(ruler_win);
-    grid_line_flush();
+    if (!ui_has(kUIMessages)) {
+      grid_line_flush();
+    }
   }
 
   redraw_cmdline = false;

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1159,6 +1159,21 @@ stack traceback:
     exec_lua([[vim.print({ foo = "bar" })]])
     screen:expect_unchanged()
   end)
+
+  it('ruler redraw does not crash due to double grid_line_start()', function()
+    exec_lua([[
+      local ns = vim.api.nvim_create_namespace('')
+      vim.ui_attach(ns, { ext_messages = true }, function(event, ...)
+        if event == 'msg_ruler' then
+          vim.api.nvim__redraw({ flush = true })
+        end
+      end)
+      vim.o.ruler = true
+      vim.o.laststatus = 0
+    ]])
+    feed('i')
+    n.assert_alive()
+  end)
 end)
 
 describe('ui/builtin messages', function()


### PR DESCRIPTION
Problem:  Hit double grid_line_start() assert when redrawing from
          ext_messages msg_ruler event.
Solution: Do not start() batched grid calls when win_redr_ruler() will not
          puts() anything.