### PR TITLE
test(autocmd/termxx_spec): fix TextChangedT test flakiness

### DIFF
--- a/test/functional/autocmd/termxx_spec.lua
+++ b/test/functional/autocmd/termxx_spec.lua
@@ -213,9 +213,11 @@ describe('autocmd TextChangedT', function()
   end)
 
   it('cannot delete terminal buffer', function()
-    command([[autocmd TextChangedT * call nvim_input('<CR>') | bwipe!]])
+    command('autocmd TextChangedT * bwipe!')
     tt.feed_data('a')
     screen:expect({ any = 'E937: ' })
+    feed('<CR>')
+    command('autocmd! TextChangedT')
     matches(
       '^E937: Attempt to delete a buffer that is in use: term://',
       api.nvim_get_vvar('errmsg')


### PR DESCRIPTION
Problem:  The E937 error appears for too short in TextChangedT test.
Solution: Only feed an Enter key after seeing the error.
