### PR TITLE
docs(lsp): update an outdated example and mark optional parameters

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -974,7 +974,7 @@ Lua module: vim.lsp.client                                        *lsp-client*
       • {dynamic_capabilities}  (`lsp.DynamicCapabilities`)
       • {request}               (`fun(self: vim.lsp.Client, method: string, params: table?, handler: lsp.Handler?, bufnr: integer?): boolean, integer?`)
                                 See |Client:request()|.
-      • {request_sync}          (`fun(self: vim.lsp.Client, method: string, params: table, timeout_ms: integer?, bufnr: integer): {err: lsp.ResponseError?, result:any}?, string?`)
+      • {request_sync}          (`fun(self: vim.lsp.Client, method: string, params: table, timeout_ms: integer?, bufnr: integer?): {err: lsp.ResponseError?, result:any}?, string?`)
                                 See |Client:request_sync()|.
       • {notify}                (`fun(self: vim.lsp.Client, method: string, params: table?): boolean`)
                                 See |Client:notify()|.
@@ -1177,7 +1177,7 @@ Client:request({method}, {params}, {handler}, {bufnr})
       • {method}   (`string`) LSP method name.
       • {params}   (`table?`) LSP request params.
       • {handler}  (`lsp.Handler?`) Response |lsp-handler| for this method.
-      • {bufnr}    (`integer?`) Buffer handle. 0 for current (default).
+      • {bufnr}    (`integer?`) (default: 0) Buffer handle, or 0 for current.
 
     Return (multiple): ~
         (`boolean`) status indicates whether the request was successful. If it
@@ -1199,7 +1199,8 @@ Client:request_sync({method}, {params}, {timeout_ms}, {bufnr})
       • {params}      (`table`) LSP request params.
       • {timeout_ms}  (`integer?`) Maximum time in milliseconds to wait for a
                       result. Defaults to 1000
-      • {bufnr}       (`integer`) Buffer handle (0 for current).
+      • {bufnr}       (`integer?`) integer (default: 0) Buffer handle, or 0
+                      for current.
 
     Return (multiple): ~
         (`{err: lsp.ResponseError?, result:any}?`) `result` and `err` from the

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1199,8 +1199,8 @@ Client:request_sync({method}, {params}, {timeout_ms}, {bufnr})
       • {params}      (`table`) LSP request params.
       • {timeout_ms}  (`integer?`) Maximum time in milliseconds to wait for a
                       result. Defaults to 1000
-      • {bufnr}       (`integer?`) integer (default: 0) Buffer handle, or 0
-                      for current.
+      • {bufnr}       (`integer?`) (default: 0) Buffer handle, or 0 for
+                      current.
 
     Return (multiple): ~
         (`{err: lsp.ResponseError?, result:any}?`) `result` and `err` from the
@@ -1384,7 +1384,7 @@ format({opts})                                          *vim.lsp.buf.format()*
                   predicate are included. Example: >lua
                     -- Never request typescript-language-server for formatting
                     vim.lsp.buf.format {
-                      filter = function(client) return client.name ~= "tsserver" end
+                      filter = function(client) return client.name ~= "ts_ls" end
                     }
 <
                 • {async}? (`boolean`, default: false) If true the method

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -487,7 +487,7 @@ end
 --- ```lua
 --- -- Never request typescript-language-server for formatting
 --- vim.lsp.buf.format {
----   filter = function(client) return client.name ~= "tsserver" end
+---   filter = function(client) return client.name ~= "ts_ls" end
 --- }
 --- ```
 --- @field filter? fun(client: vim.lsp.Client): boolean?

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -636,7 +636,7 @@ end
 --- @param method string LSP method name.
 --- @param params? table LSP request params.
 --- @param handler? lsp.Handler Response |lsp-handler| for this method.
---- @param bufnr? integer Buffer handle. 0 for current (default).
+--- @param bufnr? integer (default: 0) Buffer handle, or 0 for current.
 --- @return boolean status indicates whether the request was successful.
 ---     If it is `false`, then it will always be `false` (the client has shutdown).
 --- @return integer? request_id Can be used with |Client:cancel_request()|.
@@ -715,7 +715,7 @@ end
 --- @param params table LSP request params.
 --- @param timeout_ms integer? Maximum time in milliseconds to wait for
 ---                                a result. Defaults to 1000
---- @param bufnr integer Buffer handle (0 for current).
+--- @param bufnr? integer integer (default: 0) Buffer handle, or 0 for current.
 --- @return {err: lsp.ResponseError?, result:any}? `result` and `err` from the |lsp-handler|.
 ---                 `nil` is the request was unsuccessful
 --- @return string? err On timeout, cancel or error, where `err` is a

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -715,7 +715,7 @@ end
 --- @param params table LSP request params.
 --- @param timeout_ms integer? Maximum time in milliseconds to wait for
 ---                                a result. Defaults to 1000
---- @param bufnr? integer integer (default: 0) Buffer handle, or 0 for current.
+--- @param bufnr? integer (default: 0) Buffer handle, or 0 for current.
 --- @return {err: lsp.ResponseError?, result:any}? `result` and `err` from the |lsp-handler|.
 ---                 `nil` is the request was unsuccessful
 --- @return string? err On timeout, cancel or error, where `err` is a


### PR DESCRIPTION
## Problem:
* bufnr is actually optional in `Client:request_sync`
* `tsserver` was renamed to `ts_ls` in `nvim-lspconfig`

## Solution:
Fix them.