### PR TITLE
fix(api): don't try to get/set option for invalid option name

### DIFF
--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -95,7 +95,7 @@ static int validate_option_value_args(Dict(option) *opts, char *name, OptIndex *
     }
   }
 
-  return OK;
+  return ERROR_SET(err) ? FAIL : OK;
 #undef HAS_KEY_X
 }
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1770,6 +1770,11 @@ describe('API', function()
     end)
 
     it('validation', function()
+      eq("Unknown option 'foobar'", pcall_err(api.nvim_set_option_value, 'foobar', 'baz', {}))
+      eq(
+        "Unknown option 'foobar'",
+        pcall_err(api.nvim_set_option_value, 'foobar', 'baz', { win = api.nvim_get_current_win() })
+      )
       eq(
         "Invalid 'scope': expected 'local' or 'global'",
         pcall_err(api.nvim_get_option_value, 'scrolloff', { scope = 'bogus' })


### PR DESCRIPTION
Problem: `validate_option_value_args()` returns `OK` even if option name is invalid or if option doesn't have the supported scope, which leads to Neovim still trying to erroneously get/set the option in those cases, which can lead to an assertion failure when `option_has_scope()` is invoked. This issue miraculously doesn't exist in release builds since the assertion is skipped and `(get/set)_option_value_for` returns if there is an error set, but that is not the intended location for that error to be caught.

Solution: Make `validate_option_value_args()` return `FAIL` if there is an error set, which causes the API option functions to return early instead of trying to get/set an invalid option.