### PR TITLE
fix(lsp): delete b:lsp_floating_preview buf var after win close

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1344,6 +1344,10 @@ local function close_preview_window(winnr, bufnrs)
 
     local augroup = 'preview_window_' .. winnr
     pcall(api.nvim_del_augroup_by_name, augroup)
+    local buf = vim.w[winnr].buf_hold_win
+    if buf and api.nvim_buf_is_valid(buf) then
+      vim.b[buf].lsp_floating_window = nil
+    end
     pcall(api.nvim_win_close, winnr, true)
   end)
 end
@@ -1609,6 +1613,7 @@ function M.open_floating_preview(contents, syntax, opts)
       { silent = true, noremap = true, nowait = true }
     )
     close_preview_autocmd(opts.close_events, floating_winnr, { floating_bufnr, bufnr })
+    vim.w[floating_winnr].buf_hold_win = bufnr
 
     -- save focus_id
     if opts.focus_id then


### PR DESCRIPTION
Problem: After floating preview window closed the buf var still exist

Solution: delete  after floating window closed.

Fix #31289
