### PR TITLE
fix(lsp): avoid `Invalid window id` error when unsetting `b:lsp_floating_preview`

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1346,7 +1346,7 @@ local function close_preview_window(winnr, bufnrs)
     pcall(api.nvim_del_augroup_by_name, augroup)
     local buf = vim.w[winnr].buf_hold_win
     if buf and api.nvim_buf_is_valid(buf) then
-      vim.b[buf].lsp_floating_window = nil
+      vim.b[buf].lsp_floating_preview = nil
     end
     pcall(api.nvim_win_close, winnr, true)
   end)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1344,9 +1344,11 @@ local function close_preview_window(winnr, bufnrs)
 
     local augroup = 'preview_window_' .. winnr
     pcall(api.nvim_del_augroup_by_name, augroup)
-    local buf = vim.w[winnr].buf_hold_win
-    if buf and api.nvim_buf_is_valid(buf) then
-      vim.b[buf].lsp_floating_preview = nil
+    if api.nvim_win_is_valid(winnr) then
+      local buf = vim.w[winnr].buf_hold_win
+      if buf and api.nvim_buf_is_valid(buf) then
+        vim.b[buf].lsp_floating_preview = nil
+      end
     end
     pcall(api.nvim_win_close, winnr, true)
   end)


### PR DESCRIPTION
This PR improves the changes made by PR #31303

Problem 1:
The variable we want to unset here is `lsp_floating_preview`, not `lsp_floating_window`.

Solution 1:
Change `lsp_floating_window` to `lsp_floating_preview`.

---

Problem 2:
`local buf = vim.w[winnr].buf_hold_win` throws the following error when `winnr` is an invalid window ID.

```text
Error executing vim.schedule lua callback: /usr/local/share/nvim/runtime/lua/vim/lsp/util.lua:1347
: scoped variable: Invalid window id: 1002
stack traceback:
        [C]: in function '__index'
        /usr/local/share/nvim/runtime/lua/vim/lsp/util.lua:1347: in function </usr/local/share/nvim/runtime/lua/vim/lsp/util.lua:1339>
```

Solution 2:
Check if `winnr` is valid: `if api.nvim_win_is_valid(winnr) then ... end`