### PR TITLE
docs(build): suggest ucrt64 for msys2 builds

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -131,12 +131,12 @@ https://github.com/cascent/neovim-cygwin was built on Cygwin 2.9.0. Newer `libuv
 1. From the MSYS2 shell, install these packages:
    ```
    pacman -S \
-       mingw-w64-x86_64-{gcc,cmake,make,ninja,diffutils}
+       mingw-w64-ucrt-x86_64-{gcc,cmake,make,ninja,diffutils}
    ```
 2. From the Windows Command Prompt (`cmd.exe`), set up the `PATH` and build.
 
    ```cmd
-   set PATH=c:\msys64\mingw64\bin;c:\msys64\usr\bin;%PATH%
+   set PATH=c:\msys64\ucrt64\bin;c:\msys64\usr\bin;%PATH%
    ```
 3. You have two options:
     - Build using `cmake` and `Ninja` generator:


### PR DESCRIPTION
Since the default invocation would install the non-ucrt gcc package, the build would fail now that UCRT is not supported for Neovim any more. Relates to #22534.
I am creating a draft PR in accordance with the contributing guidelines.