### PR TITLE
vim-patch:partial:a01148d: runtime(doc): Expand docs on :! vs. :term

### DIFF
--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -282,6 +282,16 @@ gx			Opens the current filepath or URL (decided by
 			requires using the call operator (&). >
 				:!Write-Output "1`n2" | & "C:\Windows\System32\sort.exe" /r
 <
+			Vim builds command line using options 'shell', 'shcf',
+			'sxq' and 'shq' in the following order:
+			`&sh &shcf &sxq &shq {cmd} &shq &sxq`
+			So setting both 'sxq' and 'shq' is possible but rarely
+			useful.  Additional escaping inside `{cmd}` may also
+			be due to 'sxe' option.
+
+			Also, all |cmdline-special| characters in {cmd} are
+			replaced by Vim before passing them to shell.
+
 							*E34*
 			Any "!" in {cmd} is replaced with the previous
 			external command (see also 'cpoptions'), unless


### PR DESCRIPTION
#### vim-patch:partial:a01148d: runtime(doc): Expand docs on :! vs. :term

closes: vim/vim#16089

https://github.com/vim/vim/commit/a01148d2cb2f8d2820a5b95474d11db0d1802360

Co-authored-by: matveyt <matthewtarasov@yandex.ru>