### PR TITLE
feat(defaults): zS triggers Inspect command

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1903,7 +1903,7 @@ vim.inspect_pos({bufnr}, {row}, {col}, {filter})           *vim.inspect_pos()*
 vim.show_pos({bufnr}, {row}, {col}, {filter})                 *vim.show_pos()*
     Show all the items at a given buffer position.
 
-    Can also be shown with `:Inspect`.                              *:Inspect*
+    Can also be shown with `:Inspect`, mapped to `zS` in normal mode. *:Inspect*
 
     Attributes: ~
         Since: 0.9.0

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -176,6 +176,7 @@ DEFAULTS
     • |[t|, |]t|, |[T|, |]T|, |[CTRL-T|, |]CTRL-T| navigate through the |tag-matchlist|
     • |[a|, |]a|, |[A|, |]A| navigate through the |argument-list|
     • |[b|, |]b|, |[B|, |]B| navigate through the |buffer-list|
+  • |zS-default| in Normal mode maps to |:Inspect|
 
 • Snippet:
   • `<Tab>` in Insert and Select mode maps to `vim.snippet.jump({ direction = 1 })`

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4816,8 +4816,8 @@ You can see all the groups currently active with this command: >
 This will open a new window containing all highlight group names, displayed
 in their own color.
                                                         *zS-default*
-You can see a short summary of the the highlight groups applied to a given
-position using the keymapping `zS` in normal mode. |default-mappings|
+You can view the highlight groups applied to a given position using the
+|:Inspect| command, which is mapped to `zS` in normal mode. |default-mappings|
 
 						*:colo* *:colorscheme* *E185*
 :colo[rscheme]		Output the name of the currently active color scheme.

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4815,6 +4815,9 @@ You can see all the groups currently active with this command: >
     :so $VIMRUNTIME/syntax/hitest.vim
 This will open a new window containing all highlight group names, displayed
 in their own color.
+                                                        *zS-default*
+You can see a short summary of the the highlight groups applied to a given
+position using the keymapping `zS` in normal mode. |default-mappings|
 
 						*:colo* *:colorscheme* *E185*
 :colo[rscheme]		Output the name of the currently active color scheme.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -165,6 +165,7 @@ of these in your config by simply removing the mapping, e.g. ":unmap Y".
 - |[b|, |]b|, |[B|, |]B|
 - Nvim LSP client defaults |lsp-defaults|
   - K |K-lsp-default|
+- zS |zS-default|
 
 DEFAULT AUTOCOMMANDS
                                                         *default-autocmds*

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -68,7 +68,7 @@ do
   --- https://github.com/tpope/vim-scriptease style mapping for `:Inspect`.
   ---
   --- See |zS-default|
-  vim.keymap.set('n', 'zS', '<Cmd>Inspect<CR>', { desc = ':help zS-default' })
+  vim.keymap.set('n', 'zS', vim.show_pos, { desc = ':help zS-default' })
 
   --- Set undo points when deleting text in insert mode.
   ---

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -65,6 +65,11 @@ do
     desc = ':help CTRL-L-default',
   })
 
+  --- https://github.com/tpope/vim-scriptease style mapping for `:Inspect`.
+  ---
+  --- See |zS-default|
+  vim.keymap.set('n', 'zS', '<Cmd>Inspect<CR>', { desc = ':help zS-default' })
+
   --- Set undo points when deleting text in insert mode.
   ---
   --- See |i_CTRL-U-default| and |i_CTRL-W-default|


### PR DESCRIPTION
Problem: no map to quickly see what highlights are applied to item under cursor
(A) Solution: map zS in normal mode, vim-scriptease style.