### PR TITLE
feat(marks): add conceal_lines to nvim_buf_set_extmark()

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2698,6 +2698,10 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {opts})
                     When a character is supplied it is used as |:syn-cchar|.
                     "hl_group" is used as highlight for the cchar if provided,
                     otherwise it defaults to |hl-Conceal|.
+                  • conceal_lines: string which should be empty. When
+                    provided, lines in the range are not drawn at all
+                    (according to 'conceallevel'); the next unconcealed line
+                    is drawn instead.
                   • spell: boolean indicating that spell checking should be
                     performed within this extmark
                   • ui_watched: boolean that indicates the mark should be

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -202,13 +202,14 @@ API
 • |nvim_echo()| `err` field to print error messages and `chunks` accepts
   highlight group IDs.
 • |nvim_open_win()| `relative` field can be set to "laststatus" and "tabline".
-• |nvim_buf_set_extmark()| new field `virt_lines_overflow` accepts value `scroll` to
-  enable horizontal scrolling for virtual lines with 'nowrap'.
-  right aligned text that truncates before covering up buffer text.
-• |nvim_buf_set_extmark()| `hl_group` field can be an array of layered groups.
+• Additions to |nvim_buf_set_extmark()|:
+  • `conceal_lines` field to conceal an entire line.
+  • `hl_group` field can be an array of layered groups.
+  • `virt_text_pos` field accepts value `eol_right_align` to allow for right
+    aligned text that truncates before covering up buffer text.
+  • `virt_lines_overflow` field accepts value `scroll` to enable horizontal
+    scrolling for virtual lines with 'nowrap'.
 • |vim.hl.range()| now has a optional `timeout` field which allows for a timed highlight
-• |nvim_buf_set_extmark()| `virt_text_pos` field accepts value `eol_right_align` to
-  allow for right aligned text that truncates before covering up buffer text.
 
 DEFAULTS
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -401,6 +401,8 @@ TREESITTER
 • |LanguageTree:is_valid()| now accepts a range parameter to narrow the scope
   of the validity check.
 • |:InspectTree| now shows which nodes are missing.
+• Bundled markdown highlight queries use `conceal_lines` metadata to conceal
+  code block fence lines vertically.
 
 TUI
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -492,10 +492,10 @@ capture marks comments as to be checked: >query
 There is also `@nospell` which disables spellchecking regions with `@spell`.
 
                                                 *treesitter-highlight-conceal*
-Treesitter highlighting supports |conceal| via the `conceal` metadata. By
-convention, nodes to be concealed are captured as `@conceal`, but any capture
-can be used. For example, the following query can be used to hide code block
-delimiters in Markdown: >query
+Treesitter highlighting supports |conceal| via the `conceal` and `conceal_lines`
+metadata. By convention, nodes to be concealed are captured as `@conceal`, but
+any capture can be used. For example, the following query can be used to hide
+code block delimiters in Markdown: >query
 
     ((fenced_code_block_delimiter) @conceal (#set! conceal ""))
 <
@@ -506,7 +506,13 @@ still highlighted the same as other operators: >query
 
     "!=" @operator (#set! conceal "≠")
 <
-Conceals specified in this way respect 'conceallevel'.
+To conceal an entire line (do not draw it at all), a query with `conceal_lines`
+metadata can be used: >query
+
+    ((comment) @comment @spell
+      (#set! conceal_lines ""))
+<
+Conceals specified in this way respect 'conceallevel' and 'concealcursor'.
 
 Note that although you can use any string for `conceal`, only the first
 character will be used: >query

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -685,6 +685,10 @@ function vim.api.nvim_buf_line_count(buffer) end
 ---     When a character is supplied it is used as `:syn-cchar`.
 ---     "hl_group" is used as highlight for the cchar if provided,
 ---     otherwise it defaults to `hl-Conceal`.
+--- - conceal_lines: string which should be empty. When
+---     provided, lines in the range are not drawn at all
+---     (according to 'conceallevel'); the next unconcealed line
+---     is drawn instead.
 --- - spell: boolean indicating that spell checking should be
 ---     performed within this extmark
 --- - ui_watched: boolean that indicates the mark should be drawn

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -266,6 +266,7 @@ error('Cannot require a meta file')
 --- @field line_hl_group? integer|string
 --- @field cursorline_hl_group? integer|string
 --- @field conceal? string
+--- @field conceal_lines? string
 --- @field spell? boolean
 --- @field ui_watched? boolean
 --- @field undo_restore? boolean

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -236,6 +236,7 @@ error('Cannot require a meta file')
 --- @field on_end? fun(_: "end", tick: integer)
 --- @field _on_hl_def? fun(_: "hl_def")
 --- @field _on_spell_nav? fun(_: "spell_nav")
+--- @field _on_conceal_line? fun(_: "conceal_line")
 
 --- @class vim.api.keyset.set_extmark
 --- @field id? integer

--- a/runtime/queries/markdown/highlights.scm
+++ b/runtime/queries/markdown/highlights.scm
@@ -49,12 +49,14 @@
 
 (fenced_code_block
   (fenced_code_block_delimiter) @markup.raw.block
-  (#set! conceal ""))
+  (#set! conceal "")
+  (#set! conceal_lines ""))
 
 (fenced_code_block
   (info_string
     (language) @label
-    (#set! conceal "")))
+    (#set! conceal "")
+    (#set! conceal_lines "")))
 
 (link_destination) @markup.link.url
 

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -1049,6 +1049,7 @@ void nvim_set_decoration_provider(Integer ns_id, Dict(set_decoration_provider) *
     { "on_end", &opts->on_end, &p->redraw_end },
     { "_on_hl_def", &opts->_on_hl_def, &p->hl_def },
     { "_on_spell_nav", &opts->_on_spell_nav, &p->spell_nav },
+    { "_on_conceal_line", &opts->_on_conceal_line, &p->conceal_line },
     { NULL, NULL, NULL },
   };
 

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -53,6 +53,7 @@ typedef struct {
   HLGroupID line_hl_group;
   HLGroupID cursorline_hl_group;
   String conceal;
+  String conceal_lines;
   Boolean spell;
   Boolean ui_watched;
   Boolean undo_restore;

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -21,6 +21,7 @@ typedef struct {
   LuaRefOf(("end" _, Integer tick)) on_end;
   LuaRefOf(("hl_def" _)) _on_hl_def;
   LuaRefOf(("spell_nav" _)) _on_spell_nav;
+  LuaRefOf(("conceal_line" _)) _on_conceal_line;
 } Dict(set_decoration_provider);
 
 typedef struct {

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -813,6 +813,7 @@ typedef struct {
   uint16_t wl_size;             // height in screen lines
   char wl_valid;                // true values are valid for text in buffer
   char wl_folded;               // true when this is a range of folded lines
+  linenr_T wl_foldend;          // last buffer line number for folded line
   linenr_T wl_lastlnum;         // last buffer line number for logical line
 } wline_T;
 

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1313,23 +1313,18 @@ struct window_S {
   linenr_T w_statuscol_line_count;      // line count when 'statuscolumn' width was computed.
   int w_nrwidth_width;                  // nr of chars to print line count.
 
-  qf_info_T *w_llist;                 // Location list for this window
+  qf_info_T *w_llist;                   // Location list for this window
   // Location list reference used in the location list window.
   // In a non-location list window, w_llist_ref is NULL.
   qf_info_T *w_llist_ref;
 
-  // Status line click definitions
-  StlClickDefinition *w_status_click_defs;
-  // Size of the w_status_click_defs array
-  size_t w_status_click_defs_size;
+  StlClickDefinition *w_status_click_defs;      // Status line click definitions
+  size_t w_status_click_defs_size;              // Size of the w_status_click_defs array
+  StlClickDefinition *w_winbar_click_defs;      // Window bar click definitions
+  size_t w_winbar_click_defs_size;              // Size of the w_winbar_click_defs array
+  StlClickDefinition *w_statuscol_click_defs;   // Status column click definitions
+  size_t w_statuscol_click_defs_size;           // Size of the w_statuscol_click_defs array
 
-  // Window bar click definitions
-  StlClickDefinition *w_winbar_click_defs;
-  // Size of the w_winbar_click_defs array
-  size_t w_winbar_click_defs_size;
-
-  // Status column click definitions
-  StlClickDefinition *w_statuscol_click_defs;
-  // Size of the w_statuscol_click_defs array
-  size_t w_statuscol_click_defs_size;
+  buf_T *w_conceal_line_buf;                    // buffer in win when first invoked
+  bool w_conceal_line_provider;                 // whether conceal_line provider is active
 };

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -205,9 +205,10 @@ static void changed_lines_invalidate_win(win_T *wp, linenr_T lnum, colnr_T col, 
         } else if (xtra != 0) {
           // line below change
           wp->w_lines[i].wl_lnum += xtra;
+          wp->w_lines[i].wl_foldend += xtra;
           wp->w_lines[i].wl_lastlnum += xtra;
         }
-      } else if (wp->w_lines[i].wl_lastlnum >= lnum) {
+      } else if (wp->w_lines[i].wl_foldend >= lnum) {
         // change somewhere inside this range of folded lines,
         // may need to be redrawn
         wp->w_lines[i].wl_valid = false;

--- a/src/nvim/decoration_defs.h
+++ b/src/nvim/decoration_defs.h
@@ -54,6 +54,7 @@ enum {
   kSHSpellOn = 16,
   kSHSpellOff = 32,
   kSHConceal = 64,
+  kSHConcealLines = 128,
 };
 
 typedef struct {

--- a/src/nvim/decoration_defs.h
+++ b/src/nvim/decoration_defs.h
@@ -152,6 +152,7 @@ typedef struct {
   LuaRef redraw_end;
   LuaRef hl_def;
   LuaRef spell_nav;
+  LuaRef conceal_line;
   int hl_valid;
   bool hl_cached;
 

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -24,6 +24,7 @@
 #include "nvim/change.h"
 #include "nvim/charset.h"
 #include "nvim/cursor.h"
+#include "nvim/decoration.h"
 #include "nvim/diff.h"
 #include "nvim/drawscreen.h"
 #include "nvim/errors.h"
@@ -2107,7 +2108,7 @@ int diff_check_with_linestatus(win_T *wp, linenr_T lnum, int *linestatus)
   }
 
   // A closed fold never has filler lines.
-  if (hasFolding(wp, lnum, NULL, NULL)) {
+  if (hasFolding(wp, lnum, NULL, NULL) || decor_conceal_line(wp, lnum - 1, false)) {
     return 0;
   }
 

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1019,6 +1019,7 @@ static int get_rightmost_vcol(win_T *wp, const int *color_cols)
 /// @param endrow       last grid row to be redrawn
 /// @param col_rows     set to the height of the line when only updating the columns,
 ///                     otherwise set to 0
+/// @param concealed    only draw virtual lines belonging to the line above
 /// @param spv          'spell' related variables kept between calls for "wp"
 /// @param foldinfo     fold info for this line
 /// @param[in, out] providers  decoration providers active this line
@@ -1026,8 +1027,8 @@ static int get_rightmost_vcol(win_T *wp, const int *color_cols)
 ///                            or explicitly return `false`.
 ///
 /// @return             the number of last row the line occupies.
-int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, spellvars_T *spv,
-             foldinfo_T foldinfo)
+int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, bool concealed,
+             spellvars_T *spv, foldinfo_T foldinfo)
 {
   colnr_T vcol_prev = -1;             // "wlv.vcol" of previous character
   ScreenGrid *grid = &wp->w_grid;     // grid specific to the window
@@ -1125,14 +1126,14 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
   };
 
   buf_T *buf = wp->w_buffer;
-  const bool end_fill = (lnum == buf->b_ml.ml_line_count + 1);
+  // Not drawing text when line is concealed or drawing filler lines beyond last line.
+  const bool draw_text = !concealed && (lnum != buf->b_ml.ml_line_count + 1);
 
-  if (col_rows == 0) {
+  if (col_rows == 0 && draw_text) {
     // To speed up the loop below, set extra_check when there is linebreak,
     // trailing white space and/or syntax processing to be done.
     extra_check = wp->w_p_lbr;
-    if (syntax_present(wp) && !wp->w_s->b_syn_error && !wp->w_s->b_syn_slow
-        && !has_foldtext && !end_fill) {
+    if (syntax_present(wp) && !wp->w_s->b_syn_error && !wp->w_s->b_syn_slow && !has_foldtext) {
       // Prepare for syntax highlighting in this line.  When there is an
       // error, stop syntax highlighting.
       int save_did_emsg = did_emsg;
@@ -1149,9 +1150,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
       }
     }
 
-    if (!end_fill) {
-      decor_providers_invoke_line(wp, lnum - 1);
-    }
+    decor_providers_invoke_line(wp, lnum - 1);
 
     has_decor = decor_redraw_line(wp, lnum - 1, &decor_state);
 
@@ -1334,7 +1333,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
   int line_attr_save = wlv.line_attr;
   int line_attr_lowprio_save = wlv.line_attr_lowprio;
 
-  if (spv->spv_has_spell && col_rows == 0) {
+  if (spv->spv_has_spell && col_rows == 0 && draw_text) {
     // Prepare for spell checking.
     extra_check = true;
 
@@ -1360,7 +1359,6 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
       char *line = ml_get_buf(wp->w_buffer, lnum + 1);
       spell_cat_line(nextline + SPWORDLEN, line, SPWORDLEN);
     }
-    assert(!end_fill);
     char *line = ml_get_buf(wp->w_buffer, lnum);
 
     // If current line is empty, check first word in next line for capital.
@@ -1397,7 +1395,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
   }
 
   // current line
-  char *line = end_fill ? "" : ml_get_buf(wp->w_buffer, lnum);
+  char *line = draw_text ? ml_get_buf(wp->w_buffer, lnum) : "";
   // current position in "line"
   char *ptr = line;
 
@@ -1408,7 +1406,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
   const schar_T lcs_eol = wp->w_p_lcs_chars.eol;  // 'eol' value
   schar_T lcs_prec_todo = wp->w_p_lcs_chars.prec;  // 'prec' until it's been used, then NUL
 
-  if (wp->w_p_list && !has_foldtext && !end_fill) {
+  if (wp->w_p_list && !has_foldtext && draw_text) {
     if (wp->w_p_lcs_chars.space
         || wp->w_p_lcs_chars.multispace != NULL
         || wp->w_p_lcs_chars.leadmultispace != NULL
@@ -1580,7 +1578,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
     }
   }
 
-  if (col_rows == 0 && !has_foldtext && !end_fill) {
+  if (col_rows == 0 && draw_text && !has_foldtext) {
     const int v = (int)(ptr - line);
     area_highlighting |= prepare_search_hl_line(wp, lnum, v,
                                                 &line, &screen_search_hl, &search_attr,
@@ -1648,7 +1646,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
         if (wp->w_redr_statuscol) {
           break;
         }
-        if (!end_fill) {
+        if (draw_text) {
           // Get the line again as evaluating 'statuscolumn' may free it.
           line = ml_get_buf(wp->w_buffer, lnum);
           ptr = line + v;
@@ -1684,7 +1682,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
             break;
           }
           wlv.filler_todo--;
-          if (wlv.filler_todo == 0 && (wp->w_botfill || end_fill)) {
+          if (wlv.filler_todo == 0 && (wp->w_botfill || !draw_text)) {
             break;
           }
           // win_line_start(wp, &wlv);
@@ -3036,8 +3034,8 @@ end_check:
       virt_line_index = -1;
       virt_line_flags = 0;
       // When the filler lines are actually below the last line of the
-      // file, don't draw the line itself, break here.
-      if (wlv.filler_todo == 0 && (wp->w_botfill || end_fill)) {
+      // file, or we are not drawing text for this line, break here.
+      if (wlv.filler_todo == 0 && (wp->w_botfill || !draw_text)) {
         break;
       }
     }

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -194,7 +194,7 @@ bool hasFoldingWin(win_T *const win, const linenr_T lnum, linenr_T *const firstp
     const int x = find_wl_entry(win, lnum);
     if (x >= 0) {
       first = win->w_lines[x].wl_lnum;
-      last = win->w_lines[x].wl_lastlnum;
+      last = win->w_lines[x].wl_foldend;
       had_folded = win->w_lines[x].wl_folded;
     }
   }
@@ -971,7 +971,7 @@ int find_wl_entry(win_T *win, linenr_T lnum)
       if (lnum < win->w_lines[i].wl_lnum) {
         return -1;
       }
-      if (lnum <= win->w_lines[i].wl_lastlnum) {
+      if (lnum <= win->w_lines[i].wl_foldend) {
         return i;
       }
     }

--- a/src/nvim/marktree.h
+++ b/src/nvim/marktree.h
@@ -33,6 +33,7 @@
 #define MT_FLAG_DECOR_SIGNHL (((uint16_t)1) << 10)
 #define MT_FLAG_DECOR_VIRT_LINES (((uint16_t)1) << 11)
 #define MT_FLAG_DECOR_VIRT_TEXT_INLINE (((uint16_t)1) << 12)
+#define MT_FLAG_DECOR_CONCEAL_LINES (((uint16_t)1) << 13)
 
 // These _must_ be last to preserve ordering of marks
 #define MT_FLAG_RIGHT_GRAVITY (((uint16_t)1) << 14)
@@ -42,8 +43,8 @@
                              | MT_FLAG_DECOR_SIGNHL | MT_FLAG_DECOR_VIRT_LINES \
                              | MT_FLAG_DECOR_VIRT_TEXT_INLINE)
 
-#define MT_FLAG_EXTERNAL_MASK (MT_FLAG_DECOR_MASK | MT_FLAG_NO_UNDO \
-                               | MT_FLAG_INVALIDATE | MT_FLAG_INVALID)
+#define MT_FLAG_EXTERNAL_MASK (MT_FLAG_DECOR_MASK | MT_FLAG_NO_UNDO | MT_FLAG_INVALIDATE \
+                               | MT_FLAG_INVALID | MT_FLAG_DECOR_CONCEAL_LINES)
 
 // this is defined so that start and end of the same range have adjacent ids
 #define MARKTREE_END_FLAG ((uint64_t)1)
@@ -105,6 +106,11 @@ static inline bool mt_decor_any(MTKey key)
 static inline bool mt_decor_sign(MTKey key)
 {
   return key.flags & (MT_FLAG_DECOR_SIGNTEXT | MT_FLAG_DECOR_SIGNHL);
+}
+
+static inline bool mt_conceal_lines(MTKey key)
+{
+  return key.flags & MT_FLAG_DECOR_CONCEAL_LINES;
 }
 
 static inline uint16_t mt_flags(bool right_gravity, bool no_undo, bool invalidate, bool decor_ext)

--- a/src/nvim/marktree_defs.h
+++ b/src/nvim/marktree_defs.h
@@ -22,13 +22,12 @@ typedef struct {
 } MTPos;
 #define MTPos(r, c) ((MTPos){ .row = (r), .col = (c) })
 
-// Currently there are four counts, which makes for a uint32_t[4] per node
-// which makes for nice autovectorization into a single XMM or NEON register
 typedef enum {
   kMTMetaInline,
   kMTMetaLines,
   kMTMetaSignHL,
   kMTMetaSignText,
+  kMTMetaConcealLines,
   kMTMetaCount,  // sentinel, must be last
 } MetaIndex;
 

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6436,9 +6436,9 @@ void win_fix_scroll(bool resize)
 
         // Add difference in height and row to botline.
         if (diff > 0) {
-          cursor_down_inner(wp, diff);
+          cursor_down_inner(wp, diff, false);
         } else {
-          cursor_up_inner(wp, -diff);
+          cursor_up_inner(wp, -diff, false);
         }
 
         // Scroll to put the new cursor position at the bottom of the
@@ -6485,11 +6485,11 @@ static void win_fix_cursor(bool normal)
   linenr_T lnum = wp->w_cursor.lnum;
 
   wp->w_cursor.lnum = wp->w_topline;
-  cursor_down_inner(wp, so);
+  cursor_down_inner(wp, so, false);
   linenr_T top = wp->w_cursor.lnum;
 
   wp->w_cursor.lnum = wp->w_botline - 1;
-  cursor_up_inner(wp, so);
+  cursor_up_inner(wp, so, false);
   linenr_T bot = wp->w_cursor.lnum;
 
   wp->w_cursor.lnum = lnum;
@@ -6583,7 +6583,7 @@ void scroll_to_fraction(win_T *wp, int prev_height)
         hasFolding(wp, lnum, &lnum, NULL);
         if (lnum == 1) {
           // first line in buffer is folded
-          line_size = 1;
+          line_size = !decor_conceal_line(wp, lnum - 1, false);
           sline--;
           break;
         }

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -1556,6 +1556,7 @@ describe('API/extmarks', function()
   it('can get details', function()
     set_extmark(ns, marks[1], 0, 0, {
       conceal = 'c',
+      conceal_lines = '',
       cursorline_hl_group = 'Statement',
       end_col = 0,
       end_right_gravity = true,
@@ -1585,6 +1586,7 @@ describe('API/extmarks', function()
       0,
       {
         conceal = 'c',
+        conceal_lines = '',
         cursorline_hl_group = 'Statement',
         end_col = 0,
         end_right_gravity = true,

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -1152,14 +1152,16 @@ describe('treesitter highlighting (markdown)', function()
     })
   end)
 
-  it('works with spellchecked and smoothscrolled topline', function()
-    insert([[
+  local code_block = [[
 - $f(0)=\sum_{k=1}^{\infty}\frac{2}{\pi^{2}k^{2}}+\lim_{w \to 0}x$.
 
 ```c
 printf('Hello World!');
 ```
-    ]])
+    ]]
+
+  it('works with spellchecked and smoothscrolled topline', function()
+    insert(code_block)
     command('set spell smoothscroll')
     feed('gg<C-E>')
     screen:add_extra_attr_ids({ [100] = { undercurl = true, special = Screen.colors.Red } })
@@ -1173,6 +1175,105 @@ printf('Hello World!');
                                                 |
       ]],
     })
+  end)
+
+  it('works with concealed lines', function()
+    insert(code_block)
+    screen:expect({
+      grid = [[
+                                                |
+        {18:```}{15:c}                                    |
+        {25:printf}{16:(}{26:'Hello World!'}{16:);}                 |
+        {18:```}                                     |
+           ^                                     |
+                                                |
+      ]],
+    })
+    feed('ggj')
+    command('set number conceallevel=3')
+    screen:expect({
+      grid = [[
+        {8:  1 }{16:- }$f(0)=\sum_{k=1}^{\infty}\frac{2}{|
+        {8:    }\pi^{2}k^{2}}+\lim_{w \to 0}x$.     |
+        {8:  2 }^                                    |
+        {8:  4 }{25:printf}{16:(}{26:'Hello World!'}{16:);}             |
+        {8:  6 }                                    |
+                                                |
+      ]],
+    })
+    feed('j')
+    screen:expect({
+      grid = [[
+        {8:  1 }{16:- }$f(0)=\sum_{k=1}^{\infty}\frac{2}{|
+        {8:    }\pi^{2}k^{2}}+\lim_{w \to 0}x$.     |
+        {8:  2 }                                    |
+        {8:  3 }{18:^```}{15:c}                                |
+        {8:  4 }{25:printf}{16:(}{26:'Hello World!'}{16:);}             |
+                                                |
+      ]],
+    })
+    feed('j')
+    screen:expect({
+      grid = [[
+        {8:  1 }{16:- }$f(0)=\sum_{k=1}^{\infty}\frac{2}{|
+        {8:    }\pi^{2}k^{2}}+\lim_{w \to 0}x$.     |
+        {8:  2 }                                    |
+        {8:  4 }{25:^printf}{16:(}{26:'Hello World!'}{16:);}             |
+        {8:  6 }                                    |
+                                                |
+      ]],
+    })
+    feed('j')
+    screen:expect({
+      grid = [[
+        {8:  1 }{16:- }$f(0)=\sum_{k=1}^{\infty}\frac{2}{|
+        {8:    }\pi^{2}k^{2}}+\lim_{w \to 0}x$.     |
+        {8:  2 }                                    |
+        {8:  4 }{25:printf}{16:(}{26:'Hello World!'}{16:);}             |
+        {8:  5 }{18:^```}                                 |
+                                                |
+      ]],
+    })
+    -- Concealed lines highlight until changed botline
+    screen:try_resize(screen._width, 16)
+    feed('y3k30P:<Esc><C-F><C-B>')
+    screen:expect([[
+      {8:  1 }{16:- }$f(0)=\sum_{k=1}^{\infty}\frac{2}{|
+      {8:    }\pi^{2}k^{2}}+\lim_{w \to 0}x$.     |
+      {8:  2 }                                    |
+      {8:  4 }{25:printf}{16:(}{26:'Hello World!'}{16:);}             |
+      {8:  6 }                                    |
+      {8:  8 }{25:printf}{16:(}{26:'Hello World!'}{16:);}             |
+      {8: 10 }                                    |
+      {8: 12 }{25:printf}{16:(}{26:'Hello World!'}{16:);}             |
+      {8: 14 }                                    |
+      {8: 16 }{25:printf}{16:(}{26:'Hello World!'}{16:);}             |
+      {8: 18 }                                    |
+      {8: 20 }{25:printf}{16:(}{26:'Hello World!'}{16:);}             |
+      {8: 22 }                                    |
+      {8: 24 }{25:printf}{16:(}{26:'Hello World!'}{16:);}             |
+      {8: 25 }{18:^```}                                 |
+                                              |
+    ]])
+    feed('G')
+    screen:expect([[
+      {8: 98 }                                    |
+      {8:100 }{25:printf}{16:(}{26:'Hello World!'}{16:);}             |
+      {8:102 }                                    |
+      {8:104 }{25:printf}{16:(}{26:'Hello World!'}{16:);}             |
+      {8:106 }                                    |
+      {8:108 }{25:printf}{16:(}{26:'Hello World!'}{16:);}             |
+      {8:110 }                                    |
+      {8:112 }{25:printf}{16:(}{26:'Hello World!'}{16:);}             |
+      {8:114 }                                    |
+      {8:116 }{25:printf}{16:(}{26:'Hello World!'}{16:);}             |
+      {8:118 }                                    |
+      {8:120 }{25:printf}{16:(}{26:'Hello World!'}{16:);}             |
+      {8:122 }                                    |
+      {8:124 }{25:printf}{16:(}{26:'Hello World!'}{16:);}             |
+      {8:126 }   ^                                 |
+                                              |
+    ]])
   end)
 end)
 

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2625,6 +2625,227 @@ describe('extmark decorations', function()
                                                         |
     ]])
   end)
+
+  it ('conceal_lines', function()
+    insert(example_text)
+    exec('set number conceallevel=3')
+    feed('ggj')
+    local not_concealed = {
+      grid = [[
+        {2:  1 }for _,item in ipairs(items) do                |
+        {2:  2 }^    local text, hl_id_cell, count = unpack(ite|
+        {2:    }m)                                            |
+        {2:  3 }    if hl_id_cell ~= nil then                 |
+        {2:  4 }        hl_id = hl_id_cell                    |
+        {2:  5 }    end                                       |
+        {2:  6 }    for _ = 1, (count or 1) do                |
+        {2:  7 }        local cell = line[colpos]             |
+        {2:  8 }        cell.text = text                      |
+        {2:  9 }        cell.hl_id = hl_id                    |
+        {2: 10 }        colpos = colpos+1                     |
+        {2: 11 }    end                                       |
+        {2: 12 }end                                           |
+        {1:~                                                 }|
+                                                          |
+      ]]
+    }
+    screen:expect(not_concealed)
+    api.nvim_buf_set_extmark(0, ns, 1, 0, { conceal_lines = "" })
+    screen:expect_unchanged()
+    feed('j')
+    local concealed = {
+      grid = [[
+        {2:  1 }for _,item in ipairs(items) do                |
+        {2:  3 }^    if hl_id_cell ~= nil then                 |
+        {2:  4 }        hl_id = hl_id_cell                    |
+        {2:  5 }    end                                       |
+        {2:  6 }    for _ = 1, (count or 1) do                |
+        {2:  7 }        local cell = line[colpos]             |
+        {2:  8 }        cell.text = text                      |
+        {2:  9 }        cell.hl_id = hl_id                    |
+        {2: 10 }        colpos = colpos+1                     |
+        {2: 11 }    end                                       |
+        {2: 12 }end                                           |
+        {1:~                                                 }|*3
+                                                          |
+      ]]
+    }
+    screen:expect(concealed)
+    feed('k')
+    screen:expect(not_concealed)
+    exec('set concealcursor=n')
+    screen:expect(concealed)
+    api.nvim_buf_set_extmark(0, ns, 3, 0, { conceal_lines = "" })
+    screen:expect({
+      grid = [[
+        {2:  1 }for _,item in ipairs(items) do                |
+        {2:  3 }^    if hl_id_cell ~= nil then                 |
+        {2:  5 }    end                                       |
+        {2:  6 }    for _ = 1, (count or 1) do                |
+        {2:  7 }        local cell = line[colpos]             |
+        {2:  8 }        cell.text = text                      |
+        {2:  9 }        cell.hl_id = hl_id                    |
+        {2: 10 }        colpos = colpos+1                     |
+        {2: 11 }    end                                       |
+        {2: 12 }end                                           |
+        {1:~                                                 }|*4
+                                                          |
+      ]]
+    })
+    feed('kjj')
+    screen:expect_unchanged()
+    api.nvim_buf_set_extmark(0, ns, 4, 0, { conceal_lines = "" })
+    feed('kjjjC')
+    screen:expect({
+      grid = [[
+        {2:  1 }for _,item in ipairs(items) do                |
+        {2:  3 }    if hl_id_cell ~= nil then                 |
+        {2:  5 }^                                              |
+        {2:  6 }    for _ = 1, (count or 1) do                |
+        {2:  7 }        local cell = line[colpos]             |
+        {2:  8 }        cell.text = text                      |
+        {2:  9 }        cell.hl_id = hl_id                    |
+        {2: 10 }        colpos = colpos+1                     |
+        {2: 11 }    end                                       |
+        {2: 12 }end                                           |
+        {1:~                                                 }|*4
+        {24:-- INSERT --}                                      |
+      ]]
+    })
+    feed('<esc>')
+    screen:expect({
+      grid = [[
+        {2:  1 }for _,item in ipairs(items) do                |
+        {2:  3 }    if hl_id_cell ~= nil then                 |
+        {2:  6 }^    for _ = 1, (count or 1) do                |
+        {2:  7 }        local cell = line[colpos]             |
+        {2:  8 }        cell.text = text                      |
+        {2:  9 }        cell.hl_id = hl_id                    |
+        {2: 10 }        colpos = colpos+1                     |
+        {2: 11 }    end                                       |
+        {2: 12 }end                                           |
+        {1:~                                                 }|*5
+                                                          |
+      ]]
+    })
+    feed('kji')
+    screen:expect({
+      grid = [[
+        {2:  1 }for _,item in ipairs(items) do                |
+        {2:  3 }    if hl_id_cell ~= nil then                 |
+        {2:  5 }^                                              |
+        {2:  6 }    for _ = 1, (count or 1) do                |
+        {2:  7 }        local cell = line[colpos]             |
+        {2:  8 }        cell.text = text                      |
+        {2:  9 }        cell.hl_id = hl_id                    |
+        {2: 10 }        colpos = colpos+1                     |
+        {2: 11 }    end                                       |
+        {2: 12 }end                                           |
+        {1:~                                                 }|*4
+        {24:-- INSERT --}                                      |
+      ]]
+    })
+    feed('conceal text')
+    screen:expect({
+      grid = [[
+        {2:  1 }for _,item in ipairs(items) do                |
+        {2:  3 }    if hl_id_cell ~= nil then                 |
+        {2:  5 }conceal text^                                  |
+        {2:  6 }    for _ = 1, (count or 1) do                |
+        {2:  7 }        local cell = line[colpos]             |
+        {2:  8 }        cell.text = text                      |
+        {2:  9 }        cell.hl_id = hl_id                    |
+        {2: 10 }        colpos = colpos+1                     |
+        {2: 11 }    end                                       |
+        {2: 12 }end                                           |
+        {1:~                                                 }|*4
+        {24:-- INSERT --}                                      |
+      ]]
+    })
+    feed('<esc>')
+    screen:expect({
+      grid = [[
+        {2:  1 }for _,item in ipairs(items) do                |
+        {2:  3 }    if hl_id_cell ~= nil then                 |
+        {2:  6 }    for _ =^ 1, (count or 1) do                |
+        {2:  7 }        local cell = line[colpos]             |
+        {2:  8 }        cell.text = text                      |
+        {2:  9 }        cell.hl_id = hl_id                    |
+        {2: 10 }        colpos = colpos+1                     |
+        {2: 11 }    end                                       |
+        {2: 12 }end                                           |
+        {1:~                                                 }|*5
+                                                          |
+      ]]
+    })
+    feed('ggzfj')
+    screen:expect({
+      grid = [[
+        {2:  1 }{33:^+--  2 lines: for _,item in ipairs(items) do··}|
+        {2:  3 }    if hl_id_cell ~= nil then                 |
+        {2:  6 }    for _ = 1, (count or 1) do                |
+        {2:  7 }        local cell = line[colpos]             |
+        {2:  8 }        cell.text = text                      |
+        {2:  9 }        cell.hl_id = hl_id                    |
+        {2: 10 }        colpos = colpos+1                     |
+        {2: 11 }    end                                       |
+        {2: 12 }end                                           |
+        {1:~                                                 }|*5
+                                                          |
+      ]]
+    })
+    feed('j')
+    screen:expect({
+      grid = [[
+        {2:  1 }{33:+--  2 lines: for _,item in ipairs(items) do··}|
+        {2:  3 }^    if hl_id_cell ~= nil then                 |
+        {2:  6 }    for _ = 1, (count or 1) do                |
+        {2:  7 }        local cell = line[colpos]             |
+        {2:  8 }        cell.text = text                      |
+        {2:  9 }        cell.hl_id = hl_id                    |
+        {2: 10 }        colpos = colpos+1                     |
+        {2: 11 }    end                                       |
+        {2: 12 }end                                           |
+        {1:~                                                 }|*5
+                                                          |
+      ]]
+    })
+    feed('ggzdjzfj')
+    screen:expect({
+      grid = [[
+        {2:  1 }for _,item in ipairs(items) do                |
+        {2:  6 }^    for _ = 1, (count or 1) do                |
+        {2:  7 }        local cell = line[colpos]             |
+        {2:  8 }        cell.text = text                      |
+        {2:  9 }        cell.hl_id = hl_id                    |
+        {2: 10 }        colpos = colpos+1                     |
+        {2: 11 }    end                                       |
+        {2: 12 }end                                           |
+        {1:~                                                 }|*6
+                                                          |
+      ]]
+    })
+    feed('jj')
+    screen:expect_unchanged()
+    -- Below virtual line belonging to line above concealed line is drawn.
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_lines = { { { 'line 1 below' } } } })
+    -- Above virtual line belonging to concealed line isn't.
+    api.nvim_buf_set_extmark(0, ns, 1, 0, {
+      virt_lines = { { { 'line 2 above' } } },
+      virt_lines_above = true
+    })
+    screen:expect([[
+      {2:  1 }for _,item in ipairs(items) do                |
+      {2:    }line 1 below                                  |
+      {2:  6 }^    for _ = 1, (count or 1) do                |
+      {2:  9 }        cell.hl_id = hl_id                    |
+      {2: 10 }        colpos = colpos+1                     |
+      {2: 11 }    end                                       |
+      {2: 12 }end                                           |
+      {1:~                                                 }|*7
+                                                        |
+    ]])
+  end)
 end)
 
 describe('decorations: inline virtual text', function()


### PR DESCRIPTION
**feat(marks): add conceal_lines to nvim_buf_set_extmark()**

Implement an extmark property that conceals lines vertically.

**feat(treesitter): vertical conceal for conceal nodes**

TSHighlighter now places marks for conceal_lines metadata. A new
internal decor provider callback _on_conceal_line was added that
instructs the highlighter to place conceal_lines marks whenever the
editor needs to know whether a line is concealed. The bundled markdown
queries use `conceal_lines` metadata to conceal code block fence lines.

Work on #25718