### PR TITLE
vim-patch:9.1.0883: message history cleanup is missing some tests

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4295,6 +4295,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			global
 	Determines how many entries are remembered in the |:messages| history.
 	The maximum value is 10000.
+	Setting it to zero clears the message history.
 
 						*'nrformats'* *'nf'*
 'nrformats' 'nf'	string	(default "bin,hex")

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -4381,6 +4381,7 @@ vim.go.mouset = vim.go.mousetime
 
 --- Determines how many entries are remembered in the `:messages` history.
 --- The maximum value is 10000.
+--- Setting it to zero clears the message history.
 ---
 --- @type integer
 vim.o.msghistory = 500

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -982,11 +982,6 @@ static void add_msg_hist_multihl(const char *s, int len, int hl_id, bool multili
     return;
   }
 
-  // Don't let the message history get too big
-  while (msg_hist_len > p_mhi) {
-    delete_first_msg();
-  }
-
   // allocate an entry and add the message at the end of the history
   struct msg_hist *p = xmalloc(sizeof(struct msg_hist));
   if (s) {
@@ -1018,6 +1013,8 @@ static void add_msg_hist_multihl(const char *s, int len, int hl_id, bool multili
     first_msg_hist = last_msg_hist;
   }
   msg_hist_len++;
+
+  check_msg_hist();
 }
 
 /// Delete the first (oldest) message from the history.
@@ -1039,6 +1036,14 @@ int delete_first_msg(void)
   xfree(p);
   msg_hist_len--;
   return OK;
+}
+
+void check_msg_hist(void)
+{
+  // Don't let the message history get too big
+  while (msg_hist_len > 0 && msg_hist_len > p_mhi) {
+    (void)delete_first_msg();
+  }
 }
 
 /// :messages command implementation

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2199,6 +2199,13 @@ static const char *did_set_modified(optset_T *args)
   return NULL;
 }
 
+/// Process the updated 'msghistory' option value.
+static const char *did_set_msghistory(optset_T *args FUNC_ATTR_UNUSED)
+{
+  check_msg_hist();
+  return NULL;
+}
+
 /// Process the updated 'number' or 'relativenumber' option value.
 static const char *did_set_number_relativenumber(optset_T *args)
 {

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -5894,10 +5894,12 @@ return {
     },
     {
       abbreviation = 'mhi',
+      cb = 'did_set_msghistory',
       defaults = { if_true = 500 },
       desc = [=[
         Determines how many entries are remembered in the |:messages| history.
         The maximum value is 10000.
+        Setting it to zero clears the message history.
       ]=],
       full_name = 'msghistory',
       scope = { 'global' },

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -4160,4 +4160,30 @@ func Test_cd_bslash_completion_windows()
   let &shellslash = save_shellslash
 endfunc
 
+func Test_msghistory()
+  " After setting 'msghistory' to 2 and outputting a message 4 times with
+  " :echomsg, is the number of output lines of :messages 2?
+  set msghistory=2
+  echomsg 'foo'
+  echomsg 'bar'
+  echomsg 'baz'
+  echomsg 'foobar'
+  call assert_equal(['baz', 'foobar'], GetMessages())
+
+  " When the number of messages is 10 and 'msghistory' is changed to 5, is the
+  " number of output lines of :messages 5?
+  set msghistory=10
+  for num in range(1, 10)
+    echomsg num
+  endfor
+  set msghistory=5
+  call assert_equal(5, len(GetMessages()))
+
+  " Check empty list
+  set msghistory=0
+  call assert_true(empty(GetMessages()))
+
+  set msghistory&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0883: message history cleanup is missing some tests

Problem:  message history cleanup is missing some tests
Solution: Add tests, refactor common code into did_set_msghistory()
          (Shougo Matsushita)

closes: vim/vim#16078

https://github.com/vim/vim/commit/9f860a14c308f7a9a27a6850d36790615717a710

Co-authored-by: Shougo Matsushita <Shougo.Matsu@gmail.com>
Co-authored-by: zeertzjq <zeertzjq@outlook.com>
Co-authored-by: Milly <milly.ca@gmail.com>