### PR TITLE
docs(build): fix msys2 install example

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -131,7 +131,8 @@ https://github.com/cascent/neovim-cygwin was built on Cygwin 2.9.0. Newer `libuv
 1. From the MSYS2 shell, install these packages:
    ```
    pacman -S \
-       mingw-w64-ucrt-x86_64-{gcc,cmake,make,ninja,diffutils}
+       mingw-w64-ucrt-x86_64-gcc \
+       mingw-w64-x86_64-{cmake,make,ninja,diffutils}
    ```
 2. From the Windows Command Prompt (`cmd.exe`), set up the `PATH` and build.
 


### PR DESCRIPTION
I messed up with my previous PR #31312 the updated example correctly installs gcc for the UCRT environment but the build tools cannot be installed with that environment prefix (but pacman doesn't seem to error out). Sorry about the confusion.