### PR TITLE
fix(editorconfig): fix indent style for `local.mk`

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -13,6 +13,6 @@ max_line_length = 100
 [*.py]
 indent_size = 4
 
-[{Makefile,**/Makefile,runtime/doc/*.txt}]
+[{Makefile,**/Makefile,*.mk,runtime/doc/*.txt}]
 indent_style = tab
 indent_size = 8


### PR DESCRIPTION
Problem: `local.mk` (see `contrib/local.mk.example`) uses spaces for
indentation if `EditorConfig` support is enabled, but `make` syntax
requires tab indents for recipes by default. The `.editorconfig` file
does not specify `indent_style` for `.mk` files, so the catch-all style
is used.

Solution: use tab indentation for `*.mk` files in `.editorconfig`