### PR TITLE
fix(lua): remove vim.loader.disable()

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2496,7 +2496,7 @@ vim.loader.enable({enable})                              *vim.loader.enable()*
     • adds the libs loader
     • removes the default Nvim loader
 
-    Disable (`enable=true`):
+    Disable (`enable=false`):
     • removes the loaders
     • adds the default Nvim loader
 

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2485,21 +2485,23 @@ vim.validate({name}, {value}, {validator}, {optional}, {message})
 ==============================================================================
 Lua module: vim.loader                                            *vim.loader*
 
-vim.loader.disable()                                    *vim.loader.disable()*
+vim.loader.enable({enable})                              *vim.loader.enable()*
     WARNING: This feature is experimental/unstable.
 
-    Disables the experimental Lua module loader:
-    • removes the loaders
-    • adds the default Nvim loader
+    Enables or disables the experimental Lua module loader:
 
-vim.loader.enable()                                      *vim.loader.enable()*
-    WARNING: This feature is experimental/unstable.
-
-    Enables the experimental Lua module loader:
-    • overrides loadfile
+    Enable (`enable=true`):
+    • overrides |loadfile()|
     • adds the Lua loader using the byte-compilation cache
     • adds the libs loader
     • removes the default Nvim loader
+
+    Disable (`enable=true`):
+    • removes the loaders
+    • adds the default Nvim loader
+
+    Parameters: ~
+      • {enable}  (`boolean?`) true/nil to enable, false to disable
 
 vim.loader.find({modname}, {opts})                         *vim.loader.find()*
     WARNING: This feature is experimental/unstable.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -11,12 +11,16 @@ For changes in the previous release, see |news-0.10|.
                                        Type |gO| to see the table of contents.
 
 ==============================================================================
-BREAKING CHANGES IN HEAD                                    *news-breaking-dev*
+BREAKING CHANGES IN HEAD OR EXPERIMENTAL                    *news-breaking-dev*
 
               ====== Remove this section before release. ======
 
 The following changes to UNRELEASED features were made during the development
 cycle (Nvim HEAD, the "master" branch).
+
+EXPERIMENTS
+
+• Removed `vim.loader.disable()`. Use `vim.loader.enable(false)` instead.
 
 OPTIONS
 

--- a/test/functional/lua/loader_spec.lua
+++ b/test/functional/lua/loader_spec.lua
@@ -10,7 +10,17 @@ local eq = t.eq
 describe('vim.loader', function()
   before_each(clear)
 
-  it('can work in compatibility with --luamod-dev #27413', function()
+  it('can be disabled', function()
+    exec_lua(function()
+      local orig_loader = _G.loadfile
+      vim.loader.enable()
+      assert(orig_loader ~= _G.loadfile)
+      vim.loader.enable(false)
+      assert(orig_loader == _G.loadfile)
+    end)
+  end)
+
+  it('works with --luamod-dev #27413', function()
     clear({ args = { '--luamod-dev' } })
     exec_lua(function()
       vim.loader.enable()
@@ -31,7 +41,7 @@ describe('vim.loader', function()
     end)
   end)
 
-  it('handles changing files (#23027)', function()
+  it('handles changing files #23027', function()
     exec_lua(function()
       vim.loader.enable()
     end)
@@ -63,7 +73,7 @@ describe('vim.loader', function()
     )
   end)
 
-  it('handles % signs in modpath (#24491)', function()
+  it('handles % signs in modpath #24491', function()
     exec_lua [[
       vim.loader.enable()
     ]]
@@ -82,7 +92,7 @@ describe('vim.loader', function()
     eq(2, exec_lua('return loadfile(...)()', tmp2))
   end)
 
-  it('correct indent on error message (#29809)', function()
+  it('indents error message #29809', function()
     local errmsg = exec_lua [[
       vim.loader.enable()
       local _, errmsg = pcall(require, 'non_existent_module')


### PR DESCRIPTION
Problem:
`vim.loader.disable` does not conform to `:help dev-name-common` and `:help dev-patterns`.

Solution:
- Add `enable` parameter to `vim.loader.enable`
- Remove `vim.loader.disable`
- Note the change in `:help news-breaking-dev` (HEAD changes).
  - This is not a breaking change (except to "HEAD") because `vim.loader` is marked "experimental".

previous: 26765e8461c1ba1e9a351632212cf89900221781