### PR TITLE
fix(defaults): omit empty line from unimpaired mapping messages

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -222,8 +222,8 @@ do
     --- Execute a command and print errors without a stacktrace.
     --- @param opts table Arguments to |nvim_cmd()|
     local function cmd(opts)
-      local _, err = pcall(vim.api.nvim_cmd, opts, {})
-      if err then
+      local ok, err = pcall(vim.api.nvim_cmd, opts, {})
+      if not ok then
         vim.api.nvim_err_writeln(err:sub(#'Vim:' + 1))
       end
     end

--- a/test/functional/editor/defaults_spec.lua
+++ b/test/functional/editor/defaults_spec.lua
@@ -95,7 +95,34 @@ describe('default', function()
 
   describe('key mappings', function()
     describe('unimpaired-style mappings', function()
-      it('do not show a full stack trace #30625', function()
+      it('show the command ouptut when successful', function()
+        n.clear({ args_rm = { '--cmd' } })
+        local screen = Screen.new(40, 8)
+        n.fn.setqflist({
+          { filename = 'file1', text = 'item1' },
+          { filename = 'file2', text = 'item2' },
+        })
+
+        n.feed(']q')
+
+        screen:set_default_attr_ids({
+          [1] = { foreground = Screen.colors.NvimDarkGrey4 },
+          [2] = {
+            background = Screen.colors.NvimLightGray3,
+            foreground = Screen.colors.NvimDarkGrey3,
+          },
+        })
+        screen:expect({
+          grid = [[
+            ^                                        |
+            {1:~                                       }|*5
+            {2:file2                 0,0-1          All}|
+            (2 of 2): item2                         |
+          ]],
+        })
+      end)
+
+      it('do not show a full stack trace when unsuccessful #30625', function()
         n.clear({ args_rm = { '--cmd' } })
         local screen = Screen.new(40, 8)
         screen:set_default_attr_ids({


### PR DESCRIPTION
Problem:
The default unimpaired mappings display an empty line after the
command's output. This results (with default configuration) in the
`Press ENTER or type command to continue` prompt to be displayed, like
so:
<img width="498" alt="image" src="https://github.com/user-attachments/assets/f0f61cc2-1be8-4b1f-8f6c-77846b4dd6fa">

Solution:
The cause is that we're checking the second return value from
`pcall(vim.api.nvim_cmd, opts, {})` to determine whether the call was
successful. `nvim_cmd` returns an empty string on success, so this value
is an empty string in the successful path which we then display.

The fix is simple: check the first return value instead which is the
"status code" of the call. 

After my change:
<img width="501" alt="image" src="https://github.com/user-attachments/assets/029eba56-cbba-41d2-a2e2-1e5dda6ba528">


