### PR TITLE
vim-patch:9.1.0888: leftcol property not available in getwininfo()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4315,6 +4315,8 @@ getwininfo([{winid}])                                             *getwininfo()*
 			botline		last complete displayed buffer line
 			bufnr		number of buffer in the window
 			height		window height (excluding winbar)
+			leftcol		first column displayed; only used when
+					'wrap' is off
 			loclist		1 if showing a location list
 			quickfix	1 if quickfix or location list window
 			terminal	1 if a terminal window

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3885,6 +3885,8 @@ function vim.fn.gettext(text) end
 ---   botline    last complete displayed buffer line
 ---   bufnr    number of buffer in the window
 ---   height    window height (excluding winbar)
+---   leftcol    first column displayed; only used when
+---       'wrap' is off
 ---   loclist    1 if showing a location list
 ---   quickfix  1 if quickfix or location list window
 ---   terminal  1 if a terminal window

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4800,6 +4800,8 @@ M.funcs = {
       	botline		last complete displayed buffer line
       	bufnr		number of buffer in the window
       	height		window height (excluding winbar)
+      	leftcol		first column displayed; only used when
+      			'wrap' is off
       	loclist		1 if showing a location list
       	quickfix	1 if quickfix or location list window
       	terminal	1 if a terminal window

--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -326,6 +326,7 @@ static dict_T *get_win_info(win_T *wp, int16_t tpnr, int16_t winnr)
   tv_dict_add_nr(dict, S_LEN("winrow"), wp->w_winrow + 1);
   tv_dict_add_nr(dict, S_LEN("topline"), wp->w_topline);
   tv_dict_add_nr(dict, S_LEN("botline"), wp->w_botline - 1);
+  tv_dict_add_nr(dict, S_LEN("leftcol"), wp->w_leftcol);
   tv_dict_add_nr(dict, S_LEN("winbar"), wp->w_winbar_height);
   tv_dict_add_nr(dict, S_LEN("width"), wp->w_width_inner);
   tv_dict_add_nr(dict, S_LEN("bufnr"), wp->w_buffer->b_fnum);

--- a/test/old/testdir/test_bufwintabinfo.vim
+++ b/test/old/testdir/test_bufwintabinfo.vim
@@ -114,6 +114,18 @@ func Test_getbufwintabinfo()
   wincmd t | only
 endfunc
 
+function Test_get_wininfo_leftcol()
+  set nowrap
+  set winwidth=10
+  vsp
+  call setline(1, ['abcdefghijklmnopqrstuvwxyz'])
+  norm! 5zl
+  call assert_equal(5, getwininfo()[0].leftcol)
+  bwipe!
+  set wrap&
+  set winwidth&
+endfunc
+
 function Test_get_buf_options()
   let opts = bufnr()->getbufvar('&')
   call assert_equal(v:t_dict, type(opts))


### PR DESCRIPTION
#### vim-patch:9.1.0888: leftcol property not available in getwininfo()

Problem:  leftcol property not available in getwininfo()
Solution: add leftcol property property (glepnir)

closes: vim/vim#16119

https://github.com/vim/vim/commit/0a850673e3d4193d55f47bcbbc0b0da5f155307d

Co-authored-by: glepnir <glephunter@gmail.com>