### PR TITLE
fix(lsp): vim.lsp.ClientConfig.commands type

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1047,7 +1047,7 @@ Lua module: vim.lsp.client                                        *lsp-client*
       • {settings}?           (`table`) Map with language server specific
                               settings. See the {settings} in
                               |vim.lsp.Client|.
-      • {commands}?           (`table<string,fun(command: lsp.Command, ctx: table)>`)
+      • {commands}?           (`table<string, {[1]:function}|vim.api.keyset.user_command>`)
                               Table that maps string of clientside commands to
                               user-defined functions. Commands passed to
                               start_client take precedence over the global

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -81,7 +81,7 @@ local validate = vim.validate
 --- Commands passed to start_client take precedence over the global command registry. Each key
 --- must be a unique command name, and the value is a function which is called if any LSP action
 --- (code action, code lenses, ...) triggers the command.
---- @field commands? table<string,fun(command: lsp.Command, ctx: table)>
+--- @field commands? table<string, {[1]:function}|vim.api.keyset.user_command>
 ---
 --- Values to pass in the initialization request as `initializationOptions`. See `initialize` in
 --- the LSP spec.


### PR DESCRIPTION
This PR fixes thet types of vim.lsp.ClientConfig commands

The current definition:

```lua
--- @field commands? table<string,fun(command: lsp.Command, ctx: table)>
```

fails validation when passed to `nvim-lspconfig` [here](https://github.com/neovim/nvim-lspconfig/blob/dafd61d6533bd90ecf6e2a3a972298fdddc74d82/lua/lspconfig/configs.lua?plain=1#L86-L93)
