### PR TITLE
docs: more accurate typing for LSP references context

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1446,7 +1446,7 @@ references({context}, {opts})                       *vim.lsp.buf.references()*
     window.
 
     Parameters: ~
-      • {context}  (`table?`) Context for the request
+      • {context}  (`lsp.ReferenceContext?`) Context for the request
       • {opts}     (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.
 
     See also: ~

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -736,7 +736,7 @@ end
 
 --- Lists all the references to the symbol under the cursor in the quickfix window.
 ---
----@param context (table|nil) Context for the request
+---@param context lsp.ReferenceContext? Context for the request
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_references
 ---@param opts? vim.lsp.ListOpts
 function M.references(context, opts)


### PR DESCRIPTION
**Problem:** The `context` parameter for `references()` is just typed as a table, which is unhelpful.

**Solution:** Properly type it as an `lsp.ReferenceContext`!