### PR TITLE
feat(lsp): allow disabling LSP default options

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -56,9 +56,11 @@ Follow these steps to get LSP features:
                                                         *lsp-defaults*
 When the Nvim LSP client starts it enables diagnostics |vim.diagnostic| (see
 |vim.diagnostic.config()| to customize). It also sets various default options,
-listed below, if (1) the language server supports the functionality and (2)
-the options are empty or were set by the builtin runtime (ftplugin) files. The
-options are not restored when the LSP client is stopped or detached.
+listed below, if (1) `lsp_defaults` was set to `true` (by default) in the
+|vim.lsp.ClientConfig| object passed to |vim.lsp.start()|, and (2) the
+language server supports the functionality, and (3) the options are empty or
+were set by the builtin runtime (ftplugin) files. The options are not restored
+when the LSP client is stopped or detached.
 
 - 'omnifunc' is set to |vim.lsp.omnifunc()|, use |i_CTRL-X_CTRL-O| to trigger
   completion.
@@ -84,8 +86,16 @@ If not wanted, these keymaps can be removed at any time using
 |vim.keymap.del()| or |:unmap| (see also |gr-default|).
 
                                                         *lsp-defaults-disable*
-To override or delete any of the above defaults, set or unset the options on
-|LspAttach|: >lua
+To disable the above defaults, pass a |vim.lsp.ClientConfig| object to
+|vim.lsp.start()| with field `lsp_defaults` set to `false`: >lua
+
+vim.lsp.start {
+  ..., -- Other configuration omitted.
+  lsp_defaults = false,
+}
+<
+
+Alternatively, set or unset the options on |LspAttach|: >lua
 
     vim.api.nvim_create_autocmd('LspAttach', {
       callback = function(args)
@@ -1120,6 +1130,10 @@ Lua module: vim.lsp.client                                        *lsp-client*
       • {root_dir}?           (`string`) Directory where the LSP server will
                               base its workspaceFolders, rootUri, and rootPath
                               on initialization.
+      • {lsp_defaults}?       (`boolean`) Allow various default options to be
+                              set for language server upon attach.
+                              |lsp-defaults| (default: true)
+
 
 
 Client:cancel_request({id})                          *Client:cancel_request()*

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -132,6 +132,10 @@ local validate = vim.validate
 ---
 --- Directory where the LSP server will base its workspaceFolders, rootUri, and rootPath on initialization.
 --- @field root_dir? string
+---
+--- Allow various default options to be set for language server upon attach. |lsp-defaults|
+--- (default: true)
+--- @field lsp_defaults? boolean
 
 --- @class vim.lsp.Client.Progress: vim.Ringbuf<{token: integer|string, value: any}>
 --- @field pending table<lsp.ProgressToken,lsp.LSPAny>
@@ -327,6 +331,7 @@ local function validate_config(config)
   validate('offset_encoding', config.offset_encoding, 'string', true)
   validate('flags', config.flags, 'table', true)
   validate('get_language_id', config.get_language_id, 'function', true)
+  validate('lsp_defaults', config.lsp_defaults, 'boolean', true)
 
   assert(
     (
@@ -1014,7 +1019,9 @@ end
 function Client:on_attach(bufnr)
   self:_text_document_did_open_handler(bufnr)
 
-  lsp._set_defaults(self, bufnr)
+  if self.config.lsp_defaults then
+    lsp._set_defaults(self, bufnr)
+  end
 
   api.nvim_exec_autocmds('LspAttach', {
     buffer = bufnr,

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -124,8 +124,10 @@ end
 RSC[ms.client_registerCapability] = function(_, params, ctx)
   local client = assert(vim.lsp.get_client_by_id(ctx.client_id))
   client:_register(params.registrations)
-  for bufnr in pairs(client.attached_buffers) do
-    vim.lsp._set_defaults(client, bufnr)
+  if client.config.lsp_defaults then
+    for bufnr in pairs(client.attached_buffers) do
+      vim.lsp._set_defaults(client, bufnr)
+    end
   end
   return vim.NIL
 end


### PR DESCRIPTION
Problem: Nvim forcibly sets certain buffer-local options (and `K`) upon LSP attach which may not be always desirable - users may have their own choices for `formatprg`, or are fine with the ones specified by the shipped ftplugins, or just want to keep a blank option to use the default value (e.g. `keywordprg`, `:Man` by default).
It seems to me the only way to effectively revert this is via a hackish workaround with `LspAttach` autocmd,
which probably only brings confusion to newcomers why their `after/ftplugin` setups just don't work, and why was it designed that way. [It may also give rise to more instances of Heisenbugs.](https://www.reddit.com/r/neovim/comments/1dz25hq/finding_the_culprit/)

Solution: Add a new field `lsp_defaults` to `vim.lsp.ClientConfig`. By default `true` where default options are set on LSP attach as usual; when set to `false` these options won't be touched at all as all callings to `vim.lsp._set_defaults` will be skipped. Example:

```lua
vim.lsp.start {
  cmd = { 'haskell-language-server-wrapper', '--lsp' },
  name = 'hls',
  root_dir = vim.fs.root(0, { 'stack.yaml', 'package.yaml', '*.cabal' }),
  lsp_defaults = false
}
```

That's basically my proposal. Cannot guarantee best design - maybe use some `g:lsp_defaults` variable to list out LSPs that we'd prefer defaults options, or use as a default value for this new field so we don't need to specify `lsp_defaults = false` every time. But we'll see.