### PR TITLE
feat: add vim.fs.exists

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -234,6 +234,7 @@ LSP
 LUA
 
 • |vim.fs.rm()| can delete files and directories.
+• |vim.fs.exists()| can check whether file or directory exists.
 • |vim.validate()| now has a new signature which uses less tables,
   is more performant and easier to read.
 • |vim.str_byteindex()| and |vim.str_utfindex()| gained overload signatures

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -667,4 +667,14 @@ function M.rm(path, opts)
   end
 end
 
+--- @param filename string
+--- @return boolean
+function M.exists(filename)
+  local stat = uv.fs_stat(filename)
+  if stat then
+    return true
+  end
+  return false
+end
+
 return M


### PR DESCRIPTION
This is essentially upstreaming a modified version of util.path.exists
with the goal of upstreaming as much of non-configuration parts of
lspconfig to core as possible.
