### PR TITLE
vim-patch:9.1.0890: %! item not allowed for 'rulerformat'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5917,6 +5917,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	All fields except the {item} are optional.  A single percent sign can
 	be given as "%%".
 
+							*stl-%!*
 	When the option starts with "%!" then it is used as an expression,
 	evaluated and the result is used as the option value.  Example: >vim
 		set statusline=%!MyStatusLine()

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -6311,6 +6311,7 @@ vim.wo.stc = vim.wo.statuscolumn
 --- All fields except the {item} are optional.  A single percent sign can
 --- be given as "%%".
 ---
+--- 						*stl-%!*
 --- When the option starts with "%!" then it is used as an expression,
 --- evaluated and the result is used as the option value.  Example:
 ---

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -8407,6 +8407,7 @@ return {
         All fields except the {item} are optional.  A single percent sign can
         be given as "%%".
 
+        						*stl-%!*
         When the option starts with "%!" then it is used as an expression,
         evaluated and the result is used as the option value.  Example: >vim
         	set statusline=%!MyStatusLine()

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -2191,7 +2191,11 @@ static const char *did_set_statustabline_rulerformat(optset_T *args, bool rulerf
     if (wid && *s == '(' && (errmsg = check_stl_option(p_ruf)) == NULL) {
       ru_wid = wid;
     } else {
-      errmsg = check_stl_option(p_ruf);
+      // Validate the flags in 'rulerformat' only if it doesn't point to
+      // a custom function ("%!" flag).
+      if ((*varp)[1] != '!') {
+        errmsg = check_stl_option(p_ruf);
+      }
     }
   } else if (rulerformat || s[0] != '%' || s[1] != '!') {
     // check 'statusline', 'winbar', 'tabline' or 'statuscolumn'

--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -216,6 +216,22 @@ describe('cmdline', function()
                 longish   |
     ]]
   end)
+
+  -- oldtest: Test_rulerformat_function()
+  it("'rulerformat' can use %!", function()
+    local screen = Screen.new(40, 2)
+    exec([[
+      func TestRulerFn()
+        return '10,20%=30%%'
+      endfunc
+    ]])
+    api.nvim_set_option_value('ruler', true, {})
+    api.nvim_set_option_value('rulerformat', '%!TestRulerFn()', {})
+    screen:expect([[
+      ^                                        |
+                            10,20         30% |
+    ]])
+  end)
 end)
 
 describe('cmdwin', function()

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -4036,6 +4036,27 @@ func Test_rulerformat_position()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test for using "%!" in 'rulerformat' to use a function
+func Test_rulerformat_function()
+  CheckScreendump
+
+  let lines =<< trim END
+    func TestRulerFn()
+      return '10,20%=30%%'
+    endfunc
+  END
+  call writefile(lines, 'Xrulerformat_function', 'D')
+
+  let buf = RunVimInTerminal('-S Xrulerformat_function', #{rows: 2, cols: 40})
+  call term_sendkeys(buf, ":set ruler rulerformat=%!TestRulerFn()\<CR>")
+  call term_sendkeys(buf, ":redraw!\<CR>")
+  call term_wait(buf)
+  call VerifyScreenDump(buf, 'Test_rulerformat_function', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_getcompletion_usercmd()
   command! -nargs=* -complete=command TestCompletion echo <q-args>
 


### PR DESCRIPTION
Fix #31278

#### vim-patch:9.1.0890: %! item not allowed for 'rulerformat'

Problem:  %! item not allowed for 'rulerformat'
          (yatinlala)
Solution: also allow to use %! for rulerformat option
          (Yegappan Lakshmanan)

closes: vim/vim#16118

https://github.com/vim/vim/commit/ac023e8baae65584537aa3c11494dad6f71770af

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>