### PR TITLE
feat(options): add support for multitype options

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -53,7 +53,7 @@ achieve special effects.  These options come in three forms:
 			  'lines'
 			Warning: This may have a lot of side effects.
 
-					    *:set-args* *:set=* *E487* *E521*
+					    *:set-args* *:set=* *E487* *E521* *E5399*
 :se[t] {option}={value}		or
 :se[t] {option}:{value}
 			Set string or number option to {value}.

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1720,7 +1720,7 @@ describe('API', function()
     end)
   end)
 
-  describe('nvim_get_option_value, nvim_set_option_value', function()
+  describe('nvim_{get,set}_option_value', function()
     it('works', function()
       ok(api.nvim_get_option_value('equalalways', {}))
       api.nvim_set_option_value('equalalways', false, {})
@@ -1792,11 +1792,11 @@ describe('API', function()
         pcall_err(api.nvim_set_option_value, 'scrolloff', {}, {})
       )
       eq(
-        "Invalid value for option 'scrolloff': expected number, got boolean true",
+        "Invalid value for option 'scrolloff': expected number, got boolean: true",
         pcall_err(api.nvim_set_option_value, 'scrolloff', true, {})
       )
       eq(
-        'Invalid value for option \'scrolloff\': expected number, got string "wrong"',
+        'Invalid value for option \'scrolloff\': expected number, got string: "wrong"',
         pcall_err(api.nvim_set_option_value, 'scrolloff', 'wrong', {})
       )
     end)


### PR DESCRIPTION
Problem: We don't support multitype options in the codebase.

Solution: Add preliminary support for options with multiple types, this will allow converting the callback options (`'*func'`, `'*expr'` options) to use actual Lua functions under the hood, as well as allow converting the list options to Array / Dictionary options.

Depends on #31405.