### PR TITLE
fix(diagnostic): preserve cursor position when opening quickfix list

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -853,7 +853,9 @@ local function set_list(loclist, opts)
     vim.fn.setqflist({}, ' ', { title = title, items = items })
   end
   if open then
+    local winid = api.nvim_get_current_win()
     api.nvim_command(loclist and 'lwindow' or 'botright cwindow')
+    api.nvim_set_current_win(winid)
   end
 end
 

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -3210,6 +3210,27 @@ describe('vim.diagnostic', function()
 
       assert(loc_list[1].lnum < loc_list[2].lnum)
     end)
+
+    it('preserves cursor position when opened', function()
+      local winid = api.nvim_get_current_win()
+      local curpos = api.nvim_win_get_position(winid)
+      exec_lua(function()
+        vim.api.nvim_win_set_buf(0, _G.diagnostic_bufnr)
+
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Lower Diagnostic', 1, 1, 1, 1),
+        })
+
+        vim.diagnostic.set(_G.other_ns, _G.diagnostic_bufnr, {
+          _G.make_warning('Farther Diagnostic', 4, 4, 4, 4),
+        })
+
+        vim.diagnostic.setloclist({ open = true })
+      end)
+
+      eq(winid, api.nvim_get_current_win())
+      eq(curpos, api.nvim_win_get_position(winid))
+    end)
   end)
 
   describe('match()', function()


### PR DESCRIPTION
When diagnostics are set in the quickfix or location list with vim.diagnostic.setqflist or vim.diagnostic.setloclist, the cursor position should be preserved instead of jumping into the list's window.

---

Ref: https://github.com/neovim/neovim/pull/31371#pullrequestreview-2468606640

Should this be configurable? Leaning towards making it not configurable for now and we can add a knob if/when someone asks for it. Open to other opinions though.