### PR TITLE
vim-patch:9.1.0892: the max value of 'cmdheight' is limited by other tabpages

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -396,7 +396,7 @@ void check_screensize(void)
 {
   // Limit Rows and Columns to avoid an overflow in Rows * Columns.
   // need room for one window and command line
-  Rows = MIN(MAX(Rows, min_rows()), 1000);
+  Rows = MIN(MAX(Rows, min_rows_for_all_tabpages()), 1000);
   Columns = MIN(MAX(Columns, MIN_COLUMNS), 10000);
 }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2764,10 +2764,11 @@ static const char *check_num_option_bounds(OptIndex opt_idx, OptInt *newval, cha
 
   switch (opt_idx) {
   case kOptLines:
-    if (*newval < min_rows() && full_screen) {
-      vim_snprintf(errbuf, errbuflen, _("E593: Need at least %d lines"), min_rows());
+    if (*newval < min_rows_for_all_tabpages() && full_screen) {
+      vim_snprintf(errbuf, errbuflen, _("E593: Need at least %d lines"),
+                   min_rows_for_all_tabpages());
       errmsg = errbuf;
-      *newval = min_rows();
+      *newval = min_rows_for_all_tabpages();
     }
     // True max size is defined by check_screensize().
     *newval = MIN(*newval, INT_MAX);

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6189,7 +6189,7 @@ const char *did_set_winminheight(optset_T *args FUNC_ATTR_UNUSED)
   // loop until there is a 'winminheight' that is possible
   while (p_wmh > 0) {
     const int room = Rows - (int)p_ch;
-    const int needed = min_rows();
+    const int needed = min_rows_for_all_tabpages();
     if (room >= needed) {
       break;
     }
@@ -7067,6 +7067,22 @@ int last_stl_height(bool morewin)
 /// Return the minimal number of rows that is needed on the screen to display
 /// the current number of windows.
 int min_rows(void)
+{
+  if (firstwin == NULL) {       // not initialized yet
+    return MIN_LINES;
+  }
+
+  int total = frame_minheight(curtab->tp_topframe, NULL);
+  total += tabline_height() + global_stl_height();
+  if (p_ch > 0) {
+    total += 1;           // count the room for the command line
+  }
+  return total;
+}
+
+/// Return the minimal number of rows that is needed on the screen to display
+/// the current number of windows for all tab pages.
+int min_rows_for_all_tabpages(void)
 {
   if (firstwin == NULL) {       // not initialized yet
     return MIN_LINES;

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -2255,13 +2255,46 @@ func Test_opt_default()
 endfunc
 
 " Test for the 'cmdheight' option
-func Test_cmdheight()
+func Test_opt_cmdheight()
   %bw!
   let ht = &lines
   set cmdheight=9999
   call assert_equal(1, winheight(0))
   call assert_equal(ht - 1, &cmdheight)
   set cmdheight&
+
+  " The status line should be taken into account.
+  set laststatus=2
+  set cmdheight=9999
+  call assert_equal(ht - 2, &cmdheight)
+  set cmdheight& laststatus=1  " Accommodate Nvim default
+
+  " The tabline should be taken into account only non-GUI.
+  set showtabline=2
+  set cmdheight=9999
+  if has('gui_running')
+    call assert_equal(ht - 1, &cmdheight)
+  else
+    call assert_equal(ht - 2, &cmdheight)
+  endif
+  set cmdheight& showtabline&
+
+  " The 'winminheight' should be taken into account.
+  set winheight=3 winminheight=3
+  split
+  set cmdheight=9999
+  call assert_equal(ht - 8, &cmdheight)
+  %bw!
+  set cmdheight& winminheight& winheight&
+
+  " Only the windows in the current tabpage are taken into account.
+  set winheight=3 winminheight=3 showtabline=0
+  split
+  tabnew
+  set cmdheight=9999
+  call assert_equal(ht - 3, &cmdheight)
+  %bw!
+  set cmdheight& winminheight& winheight& showtabline&
 endfunc
 
 " To specify a control character as an option value, '^' can be used

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -55,6 +55,27 @@ func Test_window_cmd_cmdwin_with_vsp()
   set ls&vim
 endfunc
 
+func Test_cmdheight_not_changed()
+  throw 'Skipped: N/A'
+  set cmdheight=2
+  set winminheight=0
+  augroup Maximize
+    autocmd WinEnter * wincmd _
+  augroup END
+  split
+  tabnew
+  tabfirst
+  call assert_equal(2, &cmdheight)
+
+  tabonly!
+  only
+  set winminheight& cmdheight&
+  augroup Maximize
+    au!
+  augroup END
+  augroup! Maximize
+endfunc
+
 " Test for jumping to windows
 func Test_window_jump()
   new


### PR DESCRIPTION
#### vim-patch:9.1.0892: the max value of 'cmdheight' is limited by other tabpages

Problem:  the max value of 'cmdheight' is limited by other tabpages
Solution: Limit the maximum value of 'cmdheight' to the current tabpage only.
          (Milly)

The Help says that cmdheight is local to the tab page, but says nothing
about the maximum value depending on the state of all tab pages. Users
may wonder why they can't increase cmdheight when there are still rows
available on the current tab page. This PR changes the behavior of
cmdheight so that its maximum value depends only on the state of the
current tab page.

Also, since magic numbers were embedded in various places with the
minimum value of cmdheight being 1, we defined a constant to make it
easier to understand.

closes: vim/vim#16131

https://github.com/vim/vim/commit/2cddf0e85a7f8304476397e1c51dcd0e41835ac3

Cherry-pick Test_cmdheight_not_changed() from patch 9.0.0187.

Co-authored-by: Milly <milly.ca@gmail.com>