### PR TITLE
vim-patch:8.2.2993: 'fileencodings' default value should depend on 'encoding'

### DIFF
--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -2252,6 +2252,14 @@ func Test_opt_default()
   call assert_equal('vt', &formatoptions)
   set formatoptions&vim
   call assert_equal('tcq', &formatoptions)
+
+  call assert_equal('ucs-bom,utf-8,default,latin1', &fencs)
+  set fencs=latin1
+  set fencs&
+  call assert_equal('ucs-bom,utf-8,default,latin1', &fencs)
+  set fencs=latin1
+  set all&
+  call assert_equal('ucs-bom,utf-8,default,latin1', &fencs)
 endfunc
 
 " Test for the 'cmdheight' option


### PR DESCRIPTION
#### vim-patch:8.2.2993: 'fileencodings' default value should depend on 'encoding'

Problem:    'fileencodings' default value should depend on 'encoding'. (Gary
            Johnson)
Solution:   When 'encoding' is "utf-8" use a different default value for
            'fileencodings'.

https://github.com/vim/vim/commit/5ffefbb35aba2448099314a9e09714d2f3b2b1bd

Co-authored-by: Bram Moolenaar <Bram@vim.org>