### PR TITLE
fix(lsp): completion insertion position bug

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -468,8 +468,7 @@ local function trigger(bufnr, clients)
         Context.isIncomplete = Context.isIncomplete or result.isIncomplete
         local client = lsp.get_client_by_id(client_id)
         local encoding = client and client.offset_encoding or 'utf-16'
-        local client_matches
-        client_matches, server_start_boundary = M._convert_results(
+        local client_matches, boundary = M._convert_results(
           line,
           cursor_row - 1,
           cursor_col,
@@ -479,7 +478,10 @@ local function trigger(bufnr, clients)
           result,
           encoding
         )
-        vim.list_extend(matches, client_matches)
+        if next(client_matches) then
+          vim.list_extend(matches, client_matches)
+          server_start_boundary = boundary
+        end
       end
     end
     local start_col = (server_start_boundary or word_boundary) + 1


### PR DESCRIPTION
Problem: Currently, the completion result insertion position depends on
either the `word_boundary` or the `server_start_boundary` from **the last
server response**. When last `server_start_boundary` is nil , the insert position
**only** relies on `word_boundary` rather than `word_boundary` or the
previously response obtained `server_start_boundary`. As a result, the insert
position may be incorrect.

Solution: Update `server_start_boundary` only when the server responses with
match list.

Related: #31382 
