### PR TITLE
fix(api): make `nvim_set_hl()` respect all `cterm` attributes

### DIFF
--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -1100,6 +1100,9 @@ HlAttrs dict2hlattrs(Dict(highlight) *dict, bool use_rgb, int *link_id, Error *e
     CHECK_FLAG(cterm, cterm_mask, italic, , HL_ITALIC);
     CHECK_FLAG(cterm, cterm_mask, underline, , HL_UNDERLINE);
     CHECK_FLAG(cterm, cterm_mask, undercurl, , HL_UNDERCURL);
+    CHECK_FLAG(cterm, cterm_mask, underdouble, , HL_UNDERDOUBLE);
+    CHECK_FLAG(cterm, cterm_mask, underdotted, , HL_UNDERDOTTED);
+    CHECK_FLAG(cterm, cterm_mask, underdashed, , HL_UNDERDASHED);
     CHECK_FLAG(cterm, cterm_mask, standout, , HL_STANDOUT);
     CHECK_FLAG(cterm, cterm_mask, strikethrough, , HL_STRIKETHROUGH);
     CHECK_FLAG(cterm, cterm_mask, altfont, , HL_ALTFONT);

--- a/test/functional/api/highlight_spec.lua
+++ b/test/functional/api/highlight_spec.lua
@@ -309,6 +309,15 @@ describe('API: set highlight', function()
     eq({ underdotted = true }, api.nvim_get_hl_by_name('Test_hl', true))
   end)
 
+  it('can set all underline cterm attributes #31385', function()
+    local ns = get_ns()
+    local attrs = { 'underline', 'undercurl', 'underdouble', 'underdotted', 'underdashed' }
+    for _, attr in ipairs(attrs) do
+      api.nvim_set_hl(ns, 'Test_' .. attr, { cterm = { [attr] = true } })
+      eq({ [attr] = true }, api.nvim_get_hl_by_name('Test_' .. attr, false))
+    end
+  end)
+
   it('can set a highlight in the global namespace', function()
     api.nvim_set_hl(0, 'Test_hl', highlight2_config)
     eq(


### PR DESCRIPTION
Fix #31385. Also added a test, but as it seems like a typo/undercopypaste, maybe not worth it?