### PR TITLE
Implement vim.img._terminal to support basic functionality needed for backends

### DIFF
--- a/runtime/lua/vim/img.lua
+++ b/runtime/lua/vim/img.lua
@@ -1,4 +1,5 @@
 local img = vim._defer_require('vim.img', {
+  _backend = ...,  --- @module 'vim.img._backend'
   _image = ...,    --- @module 'vim.img._image'
 })
 
@@ -9,6 +10,34 @@ local img = vim._defer_require('vim.img', {
 ---@return vim.img.Image
 function img.load(opts)
   return img._image:new(opts)
+end
+  ---@class vim.img.Protocol "iterm2"|"kitty"|"sixel"
+
+---@class vim.img.Opts: vim.img.Backend.RenderOpts
+---@field backend? vim.img.Protocol|vim.img.Backend
+
+---Displays the image within the terminal used by neovim.
+---@param image vim.img.Image
+---@param opts? vim.img.Opts
+function img.show(image, opts)
+  opts = opts or {}
+
+  local backend = opts.backend
+
+  -- For named protocols, grab the appropriate backend, failing
+  -- if there is not a default backend for the specified protocol.
+  if type(backend) == "string" then
+    local protocol = backend
+    backend = img._backend[protocol]
+    assert(backend, "unsupported backend: " .. protocol)
+  end
+
+  ---@cast backend vim.img.Backend
+  backend.render(image, {
+    pos = opts.pos,
+    size = opts.size,
+    crop = opts.crop,
+  })
 end
 
 return img

--- a/runtime/lua/vim/img.lua
+++ b/runtime/lua/vim/img.lua
@@ -1,6 +1,7 @@
 local img = vim._defer_require('vim.img', {
   _backend = ...,  --- @module 'vim.img._backend'
   _image = ...,    --- @module 'vim.img._image'
+  _terminal = ..., --- @module 'vim.img._terminal'
 })
 
 ---Loads an image into memory, returning a wrapper around the image.

--- a/runtime/lua/vim/img.lua
+++ b/runtime/lua/vim/img.lua
@@ -1,0 +1,14 @@
+local img = vim._defer_require('vim.img', {
+  _image = ...,    --- @module 'vim.img._image'
+})
+
+---Loads an image into memory, returning a wrapper around the image.
+---
+---Accepts `data` as base64-encoded bytes, or a `filename` that will be loaded.
+---@param opts {data?:string, filename?:string}
+---@return vim.img.Image
+function img.load(opts)
+  return img._image:new(opts)
+end
+
+return img

--- a/runtime/lua/vim/img/_backend.lua
+++ b/runtime/lua/vim/img/_backend.lua
@@ -1,0 +1,15 @@
+---@class vim.img.Backend
+local M = {}
+
+---@class vim.img.Backend.RenderOpts
+---@field crop? {x:integer, y:integer, width:integer, height:integer} units are pixels
+---@field pos? {row:integer, col:integer} units are cells
+---@field size? {width:integer, height:integer} units are cells
+
+---@param image vim.img.Image
+---@param opts? vim.img.Backend.RenderOpts
+---@diagnostic disable-next-line
+function M.render(image, opts) end
+
+return {
+}

--- a/runtime/lua/vim/img/_image.lua
+++ b/runtime/lua/vim/img/_image.lua
@@ -1,0 +1,97 @@
+---@class vim.img.Image
+---@field name string|nil name of the image if loaded from disk
+---@field data string|nil base64 encoded data
+local M = {}
+M.__index = M
+
+---Creates a new image instance.
+---@param opts? {data?:string, filename?:string}
+---@return vim.img.Image
+function M:new(opts)
+  opts = opts or {}
+
+  local instance = {}
+  setmetatable(instance, M)
+
+  instance.data = opts.data
+  if not instance.data and opts.filename then
+    instance:load_from_file(opts.filename)
+  end
+
+  return instance
+end
+
+---Returns true if the image is loaded into memory.
+---@return boolean
+function M:is_loaded()
+  return self.data ~= nil
+end
+
+---Returns the size of the base64 encoded image.
+---@return integer
+function M:size()
+  return string.len(self.data or "")
+end
+
+---Loads data for an image from a file, replacing any existing data.
+---If a callback provided, will load asynchronously; otherwise, is blocking.
+---@param filename string
+---@param cb fun(err:string|nil, image:vim.img.Image|nil)
+---@overload fun(filename:string):vim.img.Image
+function M:load_from_file(filename, cb)
+  local name = vim.fn.fnamemodify(filename, ":t:r")
+
+  if not cb then
+    local stat = vim.uv.fs_stat(filename)
+    assert(stat, "unable to stat " .. filename)
+
+    local fd = vim.uv.fs_open(filename, "r", 644) --[[ @type integer|nil ]]
+    assert(fd, "unable to open " .. filename)
+
+    local data = vim.uv.fs_read(fd, stat.size, -1) --[[ @type string|nil ]]
+    assert(data, "unable to read " .. filename)
+
+    self.name = name
+    self.data = vim.base64.encode(data)
+    return self
+  end
+
+  ---@param err string|nil
+  ---@return boolean
+  local function report_err(err)
+    if err then
+      vim.schedule(function() cb(err) end)
+    end
+
+    return err ~= nil
+  end
+
+  vim.uv.fs_stat(filename, function(err, stat)
+    if report_err(err) then return end
+    if not stat then
+      report_err("missing stat")
+      return
+    end
+
+    vim.uv.fs_open(filename, "r", 644, function(err, fd)
+      if report_err(err) then return end
+      if not fd then
+        report_err("missing fd")
+        return
+      end
+
+      vim.uv.fs_read(fd, stat.size, -1, function(err, data)
+        if report_err(err) then return end
+
+        vim.uv.fs_close(fd, function() end)
+
+        self.name = name
+        self.data = vim.base64.encode(data or "")
+
+        vim.schedule(function() cb(nil, self) end)
+      end)
+    end)
+  end)
+end
+
+return M

--- a/runtime/lua/vim/img/_terminal.lua
+++ b/runtime/lua/vim/img/_terminal.lua
@@ -1,0 +1,69 @@
+---@class vim.img.terminal
+---@field private __tty_name string
+local M = {}
+
+local TERM_CODE = {
+  BEL = "\x07", -- aka ^G
+  ESC = "\x1B", -- aka ^[ aka \033
+}
+
+---Retrieve the tty name used by the editor.
+---
+---E.g. /dev/ttys008
+---@return string|nil
+local function get_tty_name()
+  -- Leverage tty, which reads the terminal name
+  local handle = io.popen("tty 2>/dev/null")
+  if not handle then return nil end
+  local result = handle:read("*a")
+  handle:close()
+  result = vim.fn.trim(result)
+  if result == "" then return nil end
+  return result
+end
+
+---Returns the name of the tty associated with the terminal.
+---@return string
+function M.tty_name()
+  if not M.__tty_name then
+    M.__tty_name = assert(get_tty_name(), "failed to read editor tty name")
+  end
+
+  return M.__tty_name
+end
+
+---Writes data to the editor tty.
+---@param ... string|number
+function M.write(...)
+  local handle = io.open(M.tty_name(), "w")
+  if not handle then
+    error("failed to open " .. M.tty_name())
+  end
+  handle:write(...)
+  handle:close()
+end
+
+---@class vim.img.terminal.cursor
+M.cursor = {}
+
+---@param x integer
+---@param y integer
+---@param save? boolean
+function M.cursor.move(x, y, save)
+  if save then M.cursor.save() end
+  M.write(TERM_CODE.ESC .. "[" .. y .. ";" .. x .. "H")
+  vim.uv.sleep(1)
+end
+
+function M.cursor.save()
+  M.write(TERM_CODE.ESC .. "[s")
+end
+
+function M.cursor.restore()
+  M.write(TERM_CODE.ESC .. "[u")
+end
+
+---Terminal escape codes.
+M.code = TERM_CODE
+
+return M


### PR DESCRIPTION
Implements a `vim.img._terminal` module that supports writing to the tty tied to neovim as well as basic operations to manipulate the cursor, needed for backend implementations.

---
[//]: # (BEGIN SAPLING FOOTER)
Stack created with [Sapling](https://sapling-scm.com). Best reviewed with [ReviewStack](https://reviewstack.dev/neovim/neovim/pull/31394).
* #31398
* #31397
* #31396
* #31395
* __->__ #31394
* #31393
* #31392