### PR TITLE
vim-patch:dd21c89: runtime(compiler): update eslint compiler

### DIFF
--- a/runtime/compiler/eslint.vim
+++ b/runtime/compiler/eslint.vim
@@ -1,13 +1,12 @@
 " Vim compiler file
 " Compiler:    ESLint for JavaScript
 " Maintainer:  Romain Lafourcade <romainlafourcade@gmail.com>
-" Last Change: 2020 August 20
-"	       2024 Apr 03 by The Vim Project (removed :CompilerSet definition)
+" Last Change: 2024 Nov 30
 
 if exists("current_compiler")
   finish
 endif
 let current_compiler = "eslint"
 
-CompilerSet makeprg=npx\ eslint\ --format\ compact
-CompilerSet errorformat=%f:\ line\ %l\\,\ col\ %c\\,\ %m,%-G%.%#
+CompilerSet makeprg=npx\ eslint\ --format\ stylish
+CompilerSet errorformat=%-P%f,\%\\s%#%l:%c\ %#\ %trror\ \ %m,\%\\s%#%l:%c\ %#\ %tarning\ \ %m,\%-Q,\%-G%.%#,


### PR DESCRIPTION
compact formatter is no longer distributed with eslint, so:

- switch to '--format stylish' in makeprg
- update 'errorformat' for the 'stylish' format output

fixes: vim/vim#16126
closes: vim/vim#16137

https://github.com/vim/vim/commit/dd21c8962680ba726ac1bf78ae106a4b6071450f

Co-authored-by: Romain Lafourcade <romainlafourcade@gmail.com>
