### PR TITLE
vim-patch:9.1.0898: runtime(compiler): pytest compiler not included

### DIFF
--- a/runtime/compiler/pytest.vim
+++ b/runtime/compiler/pytest.vim
@@ -1,0 +1,103 @@
+" Vim compiler file
+" Compiler:     Pytest (Python testing framework)
+" Maintainer:   @Konfekt and @mgedmin
+" Last Change:  2024 Nov 28
+
+if exists("current_compiler") | finish | endif
+let current_compiler = "pytest"
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+" CompilerSet makeprg=pytest
+if has('unix')
+  execute $'CompilerSet makeprg=/usr/bin/env\ PYTHONWARNINGS=ignore\ pytest\ {escape(get(b:, 'pytest_makeprg_params', get(g:, 'pytest_makeprg_params', '--tb=short --quiet')), ' \|"')}'
+elseif has('win32')
+  execute $'CompilerSet makeprg=set\ PYTHONWARNINGS=ignore\ &&\ pytest\ {escape(get(b:, 'pytest_makeprg_params', get(g:, 'pytest_makeprg_params', '--tb=short --quiet')), ' \|"')}'
+else
+  CompilerSet makeprg=pytest\ --tb=short\ --quiet
+  execute $'CompilerSet makeprg=pytest\ {escape(get(b:, 'pytest_makeprg_params', get(g:, 'pytest_makeprg_params', '--tb=short --quiet')), ' \|"')}'
+endif
+
+" Pytest syntax errors                                          {{{2
+
+" Reset error format so that sourcing .vimrc again and again doesn't grow it
+" without bounds
+setlocal errorformat&
+
+" For the record, the default errorformat is this:
+"
+"   %*[^"]"%f"%*\D%l: %m
+"   "%f"%*\D%l: %m
+"   %-G%f:%l: (Each undeclared identifier is reported only once
+"   %-G%f:%l: for each function it appears in.)
+"   %-GIn file included from %f:%l:%c:
+"   %-GIn file included from %f:%l:%c\,
+"   %-GIn file included from %f:%l:%c
+"   %-GIn file included from %f:%l
+"   %-G%*[ ]from %f:%l:%c
+"   %-G%*[ ]from %f:%l:
+"   %-G%*[ ]from %f:%l\,
+"   %-G%*[ ]from %f:%l
+"   %f:%l:%c:%m
+"   %f(%l):%m
+"   %f:%l:%m
+"   "%f"\, line %l%*\D%c%*[^ ] %m
+"   %D%*\a[%*\d]: Entering directory %*[`']%f'
+"   %X%*\a[%*\d]: Leaving directory %*[`']%f'
+"   %D%*\a: Entering directory %*[`']%f'
+"   %X%*\a: Leaving directory %*[`']%f'
+"   %DMaking %*\a in %f
+"   %f|%l| %m
+"
+" and sometimes it misfires, so let's fix it up a bit
+" (TBH I don't even know what compiler produces filename(lineno) so why even
+" have it?)
+setlocal errorformat-=%f(%l):%m
+
+" Sometimes Vim gets confused about ISO-8601 timestamps and thinks they're
+" filenames; this is a big hammer that ignores anything filename-like on lines
+" that start with at least two spaces, possibly preceded by a number and
+" optional punctuation
+setlocal errorformat^=%+G%\\d%#%.%\\=\ \ %.%#
+
+" Similar, but when the entire line starts with a date
+setlocal errorformat^=%+G\\d\\d\\d\\d-\\d\\d-\\d\\d\ \\d\\d:\\d\\d%.%#
+
+" make: *** [Makefile:14: target] Error 1
+setlocal errorformat^=%+Gmake:\ ***\ %.%#
+
+" FAILED tests.py::test_with_params[YYYY-MM-DD:HH:MM:SS] - Exception: bla bla
+setlocal errorformat^=%+GFAILED\ %.%#
+
+" AssertionError: assert ...YYYY-MM-DD:HH:MM:SS...
+setlocal errorformat^=%+GAssertionError:\ %.%#
+
+" --- /path/to/file:before  YYYY-MM-DD HH:MM:SS.ssssss
+setlocal errorformat^=---%f:%m
+
+" +++ /path/to/file:before  YYYY-MM-DD HH:MM:SS.ssssss
+setlocal errorformat^=+++%f:%m
+
+" Sometimes pytest prepends an 'E' marker at the beginning of a traceback line
+setlocal errorformat+=E\ %#File\ \"%f\"\\,\ line\ %l%.%#
+
+" Python tracebacks (unittest + doctest output)                 {{{2
+
+" This collapses the entire traceback into just the last file+lineno,
+" which is convenient when you want to jump to the line that failed (and not
+" the top-level entry point), but it makes it impossible to see the full
+" traceback, which sucks.
+""setlocal errorformat+=
+""            \File\ \"%f\"\\,\ line\ %l%.%#,
+""            \%C\ %.%#,
+""            \%-A\ \ File\ \"unittest%.py\"\\,\ line\ %.%#,
+""            \%-A\ \ File\ \"%f\"\\,\ line\ 0%.%#,
+""            \%A\ \ File\ \"%f\"\\,\ line\ %l%.%#,
+""            \%Z%[%^\ ]%\\@=%m
+setlocal errorformat+=File\ \"%f\"\\,\ line\ %l\\,%#%m
+
+exe 'CompilerSet errorformat='..escape(&l:errorformat, ' \|"')
+
+let &cpo = s:cpo_save
+unlet s:cpo_save

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1517,6 +1517,13 @@ Useful values for the 'makeprg' options therefore are:
  setlocal makeprg=./alltests.py " Run a testsuite
  setlocal makeprg=python\ %:S   " Run a single testcase
 
+PYTEST COMPILER						*compiler-pytest*
+Commonly used compiler options can be added to 'makeprg' by setting the
+b/g:pytest_makeprg_params variable.  For example: >
+
+  let b:pytest_makeprg_params = "--verbose --no-summary --disable-warnings"
+
+The global default is "--tb=short --quiet"; Python warnings are suppressed.
 
 TEX COMPILER						*compiler-tex*
 

--- a/runtime/ftplugin/python.vim
+++ b/runtime/ftplugin/python.vim
@@ -3,8 +3,9 @@
 " Maintainer:	Tom Picton <tom@tompicton.com>
 " Previous Maintainer: James Sully <sullyj3@gmail.com>
 " Previous Maintainer: Johannes Zellner <johannes@zellner.org>
-" Last Change:	2024/05/13
-" https://github.com/tpict/vim-ftplugin-python
+" Repository: https://github.com/tpict/vim-ftplugin-python
+" Last Change: 2024/05/13
+"              2024 Nov 30 use pytest compiler (#16130)
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -134,6 +135,11 @@ elseif executable('python')
   setlocal keywordprg=python\ -m\ pydoc
 endif
 
+if expand('%:t') =~# '\v^test_.*\.py$|_test\.py$' && executable('pytest')
+  compiler pytest
+  let &l:makeprg .= ' %:S'
+endif
+
 " Script for filetype switching to undo the local stuff we may have changed
 let b:undo_ftplugin = 'setlocal cinkeys<'
       \ . '|setlocal comments<'
@@ -148,6 +154,7 @@ let b:undo_ftplugin = 'setlocal cinkeys<'
       \ . '|setlocal softtabstop<'
       \ . '|setlocal suffixesadd<'
       \ . '|setlocal tabstop<'
+      \ . '|setlocal makeprg<'
       \ . '|silent! nunmap <buffer> [M'
       \ . '|silent! nunmap <buffer> [['
       \ . '|silent! nunmap <buffer> []'

--- a/test/old/testdir/test_compiler.vim
+++ b/test/old/testdir/test_compiler.vim
@@ -65,10 +65,10 @@ func Test_compiler_completion()
   call assert_match('^"compiler ' .. clist .. '$', @:)
 
   call feedkeys(":compiler p\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_match('"compiler pandoc pbx perl\( p[a-z_]\+\)\+ pylint pyunit', @:)
+  call assert_match('"compiler pandoc pbx perl\( p[a-z_]\+\)\+ pyunit', @:)
 
   call feedkeys(":compiler! p\<C-A>\<C-B>\"\<CR>", 'tx')
-  call assert_match('"compiler! pandoc pbx perl\( p[a-z_]\+\)\+ pylint pyunit', @:)
+  call assert_match('"compiler! pandoc pbx perl\( p[a-z_]\+\)\+ pyunit', @:)
 endfunc
 
 func Test_compiler_error()


### PR DESCRIPTION
Problem:  runtime(compiler): pytest compiler not included
Solution: include pytest compiler, update the compiler completion test
          (Konfekt)

closes: vim/vim#16130

https://github.com/vim/vim/commit/3c2596a9e967910143d41fbb9615614ab36d43a7

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>
