### PR TITLE
refactor(options): use `vim.inspect()` for converting OptVal to string

### DIFF
--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -1720,7 +1720,7 @@ describe('API', function()
     end)
   end)
 
-  describe('nvim_get_option_value, nvim_set_option_value', function()
+  describe('nvim_{get,set}_option_value', function()
     it('works', function()
       ok(api.nvim_get_option_value('equalalways', {}))
       api.nvim_set_option_value('equalalways', false, {})
@@ -1792,11 +1792,11 @@ describe('API', function()
         pcall_err(api.nvim_set_option_value, 'scrolloff', {}, {})
       )
       eq(
-        "Invalid value for option 'scrolloff': expected number, got boolean true",
+        "Invalid value for option 'scrolloff': expected number, got boolean: true",
         pcall_err(api.nvim_set_option_value, 'scrolloff', true, {})
       )
       eq(
-        'Invalid value for option \'scrolloff\': expected number, got string "wrong"',
+        'Invalid value for option \'scrolloff\': expected number, got string: "wrong"',
         pcall_err(api.nvim_set_option_value, 'scrolloff', 'wrong', {})
       )
     end)


### PR DESCRIPTION
Problem: Currently we have handcrafted code for converting an OptVal to its string representation. This may be fine for now, but it will be significantly tougher to implement once we add Array or Dictionary options. It also adds room for inconsistency between different methods of converting any object to a string.

Solution: Use `vim.inspect()` under the hood to convert an `OptVal` to a string. This ensures that the function is future-proofed for Array, Dictionary and Function option values, and also guarantees consistency with our Lua object-to-string conversion.
