### PR TITLE
vim-patch:9.1.0899: default for 'backspace' can be set in C code

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -39,7 +39,6 @@ Defaults                                                    *nvim-defaults*
 - 'autoindent' is enabled
 - 'autoread' is enabled (works in all UIs, including terminal)
 - 'background' defaults to "dark" (unless set automatically by the terminal/UI)
-- 'backspace' defaults to "indent,eol,start"
 - 'backupdir' defaults to .,~/.local/state/nvim/backup// (|xdg|), auto-created
 - 'belloff' defaults to "all"
 - 'comments' includes "fb:•"

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -1,6 +1,5 @@
 if exists('s:did_load')
   " Align Nvim defaults to Vim.
-  set backspace=
   set commentstring=/*\ %s\ */
   set complete=.,w,b,u,t,i
   set define=^\\s*#\\s*define

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -1198,8 +1198,8 @@ func Test_OptionSet()
   call assert_equal(g:opt[0], g:opt[1])
 
   " 14: Setting option backspace through :let"
-  let g:options = [['backspace', '', '', '', 'eol,indent,start', 'global', 'set']]
-  let &bs = "eol,indent,start"
+  let g:options = [['backspace', 'indent,eol,start', 'indent,eol,start', 'indent,eol,start', '', 'global', 'set']]
+  let &bs = ''
   call assert_equal([], g:options)
   call assert_equal(g:opt[0], g:opt[1])
 

--- a/test/old/testdir/test_digraph.vim
+++ b/test/old/testdir/test_digraph.vim
@@ -250,9 +250,12 @@ func Test_digraphs_option()
   call Put_Dig_BS("P","=")
   call assert_equal(['Р']+repeat(["₽"],2)+['П'], getline(line('.')-3,line('.')))
   " Not a digraph: this is different from <c-k>!
+  let _bs = &bs
+  set bs=
   call Put_Dig_BS("a","\<bs>")
   call Put_Dig_BS("\<bs>","a")
   call assert_equal(['','a'], getline(line('.')-1,line('.')))
+  let &bs = _bs
   " Grave
   call Put_Dig_BS("a","!")
   call Put_Dig_BS("!","e")

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -1509,7 +1509,7 @@ func Test_complete_item_refresh_always()
   set completefunc=Tcomplete
   exe "normal! iup\<C-X>\<C-U>\<BS>\<BS>\<BS>\<BS>\<BS>"
   call assert_equal('up', getline(1))
-  call assert_equal(2, g:CallCount)
+  call assert_equal(6, g:CallCount)
   set completeopt&
   set completefunc&
   bw!

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -496,7 +496,7 @@ func Test_set_completion_string_values()
   " but don't exhaustively validate their results.
   call assert_equal('single', getcompletion('set ambw=', 'cmdline')[0])
   call assert_match('light\|dark', getcompletion('set bg=', 'cmdline')[1])
-  call assert_equal('indent', getcompletion('set backspace=', 'cmdline')[0])
+  call assert_equal('indent,eol,start', getcompletion('set backspace=', 'cmdline')[0])
   call assert_equal('yes', getcompletion('set backupcopy=', 'cmdline')[1])
   call assert_equal('backspace', getcompletion('set belloff=', 'cmdline')[1])
   call assert_equal('min:', getcompletion('set briopt=', 'cmdline')[1])


### PR DESCRIPTION
#### vim-patch:9.1.0899: default for 'backspace' can be set in C code

Problem:  default for 'backspace' can be set in C code
Solution: promote the default for 'backspace' from defaults.vim to the C
          code (Luca Saccarola)

closes: vim/vim#16143

https://github.com/vim/vim/commit/959ef61430bdd8fb982b38bd3347d90251255cfc

N/A patches:
vim-patch:9.1.0895: default history value is too small
vim-patch:075aeea: runtime(doc): document changed default value for 'history'

Co-authored-by: Luca Saccarola <github.e41mv@aleeas.com>