### PR TITLE
feat: add API for getting file permissions in octal

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3528,6 +3528,20 @@ getfperm({fname})                                                   *getfperm()*
                 Return: ~
                   (`string`)
 
+getfpermoctal({fname})                                         *getfpermoctal()*
+		This is a copy of |getfperm()|, but the result is in octal (like o744).
+		The result is a String, which is the read, write, and execute
+		permissions of the given file {fname}, represented in octal, with an o
+		prepended.
+		If {fname} does not exist or its directory cannot be read, an
+		empty string is returned.
+
+                Parameters: ~
+                  • {fname} (`string`)
+
+                Return: ~
+                  (`string`)
+
 getfsize({fname})                                                   *getfsize()*
 		The result is a Number, which is the size in bytes of the
 		given file {fname}.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -167,6 +167,7 @@ The following new features were added.
 API
 
 • |nvim__ns_set()| can set properties for a namespace
+• |vim.fn.getfpermoctal()| can get the file permissions in octal
 
 DEFAULTS
 

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3154,6 +3154,17 @@ function vim.fn.getfontname(name) end
 --- @return string
 function vim.fn.getfperm(fname) end
 
+--- This is a copy of |getfperm()|, but the result is in octal (like o744).
+--- The result is a String, which is the read, write, and execute
+--- permissions of the given file {fname}, represented in octal, with an o
+--- prepended.
+--- If {fname} does not exist or its directory cannot be read, an
+--- empty string is returned.
+---
+--- @param fname string
+--- @return string
+function vim.fn.getfpermoctal(fname) end
+
 --- The result is a Number, which is the size in bytes of the
 --- given file {fname}.
 --- If {fname} is a directory, 0 is returned.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -3952,6 +3952,24 @@ M.funcs = {
     returns = 'string',
     signature = 'getfperm({fname})',
   },
+  getfpermoctal = {
+    args = 1,
+    base = 1,
+    desc = [=[
+      This is a copy of |getfperm()|, but the result is in octal (like o744).
+      The result is a String, which is the read, write, and execute
+      permissions of the given file {fname}, represented in octal, with an o
+      prepended.
+      If {fname} does not exist or its directory cannot be read, an
+      empty string is returned.
+    ]=],
+    fast = true,
+    name = 'getfpermoctal',
+    params = { { 'fname', 'string' } },
+    returns = 'string',
+    signature = 'getfpermoctal({fname})',
+  },
+
   getfsize = {
     args = 1,
     base = 1,

--- a/src/nvim/eval/fs.c
+++ b/src/nvim/eval/fs.c
@@ -409,6 +409,22 @@ void f_getfperm(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   rettv->vval.v_string = perm;
 }
 
+/// "getfpermoctal({fname})" function
+void f_getfpermoctal(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+{
+  char *octal_perm = NULL;
+
+  const char *filename = tv_get_string(&argvars[0]);
+  int32_t file_perm = os_getperm(filename);
+  if (file_perm >= 0) {
+    octal_perm = xmalloc(5);
+    int statchmod = file_perm & (S_IRWXU | S_IRWXG | S_IRWXO);
+    snprintf(octal_perm, sizeof(octal_perm), "o%o", statchmod);
+  }
+  rettv->v_type = VAR_STRING;
+  rettv->vval.v_string = octal_perm;
+}
+
 /// "getfsize({fname})" function
 void f_getfsize(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {


### PR DESCRIPTION
Problem: There is currently no API to return the current file permissions in octal.

Solution: Add one. The `getfpermoctal` API function returns the current file permissions, in octal.