### PR TITLE
vim-patch:9.1.0900: Vim9: digraph_getlist() does not accept bool arg

### DIFF
--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1954,16 +1954,16 @@ void f_digraph_get(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 /// "digraph_getlist()" function
 void f_digraph_getlist(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
+  if (tv_check_for_opt_bool_arg(argvars, 0) == FAIL) {
+    return;
+  }
+
   bool flag_list_all;
 
   if (argvars[0].v_type == VAR_UNKNOWN) {
     flag_list_all = false;
   } else {
-    bool error = false;
-    varnumber_T flag = tv_get_number_chk(&argvars[0], &error);
-    if (error) {
-      return;
-    }
+    varnumber_T flag = tv_get_bool(&argvars[0]);
     flag_list_all = flag != 0;
   }
 

--- a/test/old/testdir/test_digraph.vim
+++ b/test/old/testdir/test_digraph.vim
@@ -607,8 +607,10 @@ func Test_digraph_getlist_function()
   " of digraphs returned.
   call assert_equal(digraph_getlist()->len(), digraph_getlist(0)->len())
   call assert_notequal(digraph_getlist()->len(), digraph_getlist(1)->len())
+  call assert_equal(digraph_getlist()->len(), digraph_getlist(v:false)->len())
+  call assert_notequal(digraph_getlist()->len(), digraph_getlist(v:true)->len())
 
-  call assert_fails('call digraph_getlist(0z12)', 'E974: Using a Blob as a Number')
+  call assert_fails('call digraph_getlist(0z12)', 'E1212: Bool required for argument 1')
 endfunc
 
 


### PR DESCRIPTION
#### vim-patch:9.1.0900: Vim9: digraph_getlist() does not accept bool arg

Problem:  Vim9: digraph_getlist() does not accept bool argument
          (Maxim Kim)
Solution: accept boolean as first argument (Yegappan Lakshmanan)

closes: vim/vim#16159

https://github.com/vim/vim/commit/198ada3d9f48c6556d20c4115ec500555b118aad

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>