### PR TITLE
docs: Correct name of nvim_create_autocmd in example

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -722,7 +722,7 @@ foldexpr({lnum})                                          *vim.lsp.foldexpr()*
 
     To use, check for the "textDocument/foldingRange" capability in an
     |LspAttach| autocommand. Example: >lua
-        vim.api.nvim_create_autocommand('LspAttach', {
+        vim.api.nvim_create_autocmd('LspAttach', {
           callback = function(args)
             local client = vim.lsp.get_client_by_id(args.data.client_id)
             if client:supports_method('textDocument/foldingRange') then


### PR DESCRIPTION
Example documentation for LSP folding contains invalid API function `nvim_create_autocommand`, it should be `nvim_create_autocmd`.