### PR TITLE
test(screen): adjust screen state to more closely follow stylua

### DIFF
--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -404,7 +404,7 @@ describe('treesitter highlighting (C)', function()
       ]],
     })
 
-    feed 'u'
+    feed 'u:<esc>'
 
     screen:expect({
       grid = [[
@@ -425,7 +425,7 @@ describe('treesitter highlighting (C)', function()
             }                                                            |
           }                                                              |
         ^}                                                                |
-        19 changes; before #2  0 seconds ago                             |
+                                                                         |
       ]],
     })
   end)


### PR DESCRIPTION
Before:
```lua
screen:expect({        | screen:expect({
  grid = [[            |   grid = [[
    {10:>!}a        |  |     line ^1                   |
    {7:  }b        |   |     {1:~                        }|*4
    {10:>>}c        |  |   ]], messages={ {
    {7:  }^         |  |     content = { { "\ntest\n[O]k: ", 6, 11 } },
    {1:~          }|*9 |     kind = "confirm"
               |       |   } }
  ]]                   | })
})
```

After:
```lua
screen:expect([[       | screen:expect({
  {10:>!}a          |  |   grid = [[
  {7:  }b          |   |     line ^1                   |
  {10:>>}c          |  |     {1:~                        }|*4
  {7:  }^           |  |   ]],
  {1:~            }|*9 |   messages = { {
               |       |     content = { { "\ntest\n[O]k: ", 6, 11 } },
]])                    |     kind = "confirm"
                       |   } },
                       | })
```