### PR TITLE
defaults: disable 'number', 'relativenumber', and 'signcolumn' in terminal buffers

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -186,6 +186,9 @@ nvim_terminal:
     - 'textwidth' set to 0
     - 'nowrap'
     - 'nolist'
+    - 'nonumber'
+    - 'norelativenumber'
+    - 'signcolumn' set to "no"
     - 'winhighlight' uses |hl-StatusLineTerm| and |hl-StatusLineTermNC| in
       place of |hl-StatusLine| and |hl-StatusLineNC|
 

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -492,6 +492,9 @@ do
       vim.bo.textwidth = 0
       vim.wo[0][0].wrap = false
       vim.wo[0][0].list = false
+      vim.wo[0][0].number = false
+      vim.wo[0][0].relativenumber = false
+      vim.wo[0][0].signcolumn = 'no'
 
       -- This is gross. Proper list options support when?
       local winhl = vim.o.winhighlight

--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -511,7 +511,7 @@ describe('buffer cursor position is correct in terminal with number column', fun
 
   before_each(function()
     clear()
-    command('set number')
+    command('au TermOpen * set number')
   end)
 
   describe('in a line with no multibyte chars or trailing spaces,', function()


### PR DESCRIPTION
Users who wish to have line numbers enabled in the terminal can use an autocommand:

```vim
au TermOpen * setlocal number relativenumber
```