### PR TITLE
docs: mention new terminal defaults

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -58,6 +58,8 @@ DEFAULTS
 • |]d-default| and |[d-default| accept a count.
 • |[D-default| and |]D-default| jump to the first and last diagnostic in the
   current buffer, respectively.
+• 'number', 'relativenumber', and 'signcolumn' are disabled in |terminal|
+  buffers. See |terminal-config| for an example of changing these defaults.
 
 DIAGNOSTICS
 

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -108,6 +108,9 @@ global configuration.
 
 - 'list' is disabled
 - 'wrap' is disabled
+- 'number' is disabled
+- 'relativenumber' is disabled
+- 'signcolumn' is set to "no"
 
 You can change the defaults with a TermOpen autocommand: >vim
     au TermOpen * setlocal list


### PR DESCRIPTION
Follow up to https://github.com/neovim/neovim/pull/31443 (forgot to update news.txt and also found one other place in the docs that needed to be updated).