### PR TITLE
misc: keep deprecated vim.loader.disable stub

### DIFF
--- a/runtime/lua/vim/loader.lua
+++ b/runtime/lua/vim/loader.lua
@@ -446,6 +446,12 @@ function M.enable(enable)
   end
 end
 
+--- @deprecated
+function M.disable()
+  vim.deprecate('vim.loader.disable', 'vim.loader.enable(false)', '0.12')
+  vim.loader.enable(false)
+end
+
 --- Tracks the time spent in a function
 --- @generic F: function
 --- @param f F


### PR DESCRIPTION
Transitional stub to minimize breaking change pain, to be removed after 0.11 release.

See discussion in https://github.com/neovim/neovim/pull/31344. `vim.loader` is documented as "experimental" but doesn't have the `_` prefix to indicate this. Since it is a "public" symbol it should have a deprecation warning.

This uses the expedited deprecation cycle (removed after 1 release rather than 2) since it is an experimental feature.