### PR TITLE
vim-patch:9.1.0905: Missing information in CompleteDone event

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -463,6 +463,10 @@ CompleteDone			After Insert mode completion is done.  Either
 				|v:completed_item| gives the completed item.
 
 				Sets these |v:event| keys:
+				    complete_word	The word that was
+							selected, empty if
+							abandoned complete.
+				    complete_type	|complete_info_mode|
 				    reason	Reason for completion being
 						done. Can be one of:
 						- "accept": completion was

--- a/runtime/doc/vvars.txt
+++ b/runtime/doc/vvars.txt
@@ -189,6 +189,8 @@ v:event
 		                   changing window  (or tab) on |DirChanged|.
 		  status           Job status or exit code, -1 means "unknown". |TermClose|
 		  reason           Reason for completion being done. |CompleteDone|
+		  complete_word    The word that was selected, empty if abandoned complete.
+		  complete_type    See |complete_info_mode|
 
 				*v:exception* *exception-variable*
 v:exception

--- a/runtime/lua/vim/_meta/vvars.lua
+++ b/runtime/lua/vim/_meta/vvars.lua
@@ -197,6 +197,8 @@ vim.v.errors = ...
 ---                    changing window  (or tab) on `DirChanged`.
 ---   status           Job status or exit code, -1 means "unknown". `TermClose`
 ---   reason           Reason for completion being done. `CompleteDone`
+---   complete_word    The word that was selected, empty if abandoned complete.
+---   complete_type    See `complete_info_mode`
 --- @type any
 vim.v.event = ...
 

--- a/src/nvim/vvars.lua
+++ b/src/nvim/vvars.lua
@@ -208,6 +208,8 @@ M.vars = {
                          changing window  (or tab) on |DirChanged|.
         status           Job status or exit code, -1 means "unknown". |TermClose|
         reason           Reason for completion being done. |CompleteDone|
+        complete_word    The word that was selected, empty if abandoned complete.
+        complete_type    See |complete_info_mode|
     ]=],
   },
   exception = {


### PR DESCRIPTION
Problem:  Missing information in CompleteDone event
Solution: add complete_word and complete_type to v:event dict
          (glepnir)

closes: vim/vim#16153

https://github.com/vim/vim/commit/1c5a120a701fcf558617c4e70b5a447778f0e51d