### PR TITLE
vim-patch:9.1.0903: potential overflow in spell_soundfold_wsal()

### DIFF
--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -3141,7 +3141,7 @@ static void spell_soundfold_wsal(slang_T *slang, const char *inword, char *res)
               c = *ws;
             }
             if (strstr(s, "^^") != NULL) {
-              if (c != NUL) {
+              if (c != NUL && reslen < MAXWLEN) {
                 wres[reslen++] = c;
               }
               memmove(word, word + i + 1, sizeof(int) * (size_t)(wordlen - (i + 1) + 1));


### PR DESCRIPTION
Problem:  potential overflow in spell_soundfold_wsal() Solution: Protect wres from buffer overflow, by checking the
          length (Zdenek Dohnal)

Error: OVERRUN (CWE-119):
vim91/src/spell.c:3819: cond_const: Checking "reslen < 254" implies that "reslen" is 254 on the false branch.
vim91/src/spell.c:3833: incr: Incrementing "reslen". The value of "reslen" is now 255.
vim91/src/spell.c:3792: overrun-local: Overrunning array "wres" of 254 4-byte elements at element index 254 (byte offset 1019) using index "reslen - 1" (which evaluates to 254).
 3789|   		    {
 3790|   			// rule with '<' is used
 3791|-> 			if (reslen > 0 && ws != NULL && *ws != NUL
 3792|   				&& (wres[reslen - 1] == c
 3793|   						    || wres[reslen - 1] == *ws))

Error: OVERRUN (CWE-119):
vim91/src/spell.c:3819: cond_const: Checking "reslen < 254" implies that "reslen" is 254 on the false branch.
vim91/src/spell.c:3833: overrun-local: Overrunning array "wres" of 254 4-byte elements at element index 254 (byte offset 1019) using index "reslen++" (which evaluates to 254).
 3831|                         {
 3832|                             if (c != NUL)
 3833|->                               wres[reslen++] = c;
 3834|                             mch_memmove(word, word + i + 1,
 3835|                                        sizeof(int) * (wordlen -
(i + 1) + 1));

related: vim/vim#16163

https://github.com/vim/vim/commit/39a94d20487794aeb722c21e84f8816e217f0cfe