### PR TITLE
vim-patch:ea0e41a: runtime(doc): make tag alignment more consistent in filetype.txt

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -597,7 +597,7 @@ To disable this behavior, set the following variable in your vimrc: >
 	let g:gdscript_recommended_style = 0
 
 
-GIT COMMIT                                              *ft-gitcommit-plugin*
+GIT COMMIT						*ft-gitcommit-plugin*
 
 One command, :DiffGitCached, is provided to show a diff of the current commit
 in the preview window.  It is equivalent to calling "git diff --cached" plus
@@ -778,7 +778,7 @@ An alternative to using `MANPAGER` in shell can be redefined `man`, for example:
           nvim "+hide Man $1"
      }
 
-MARKDOWN                                                *ft-markdown-plugin*
+MARKDOWN						*ft-markdown-plugin*
 
 To enable folding use this: >
 	let g:markdown_folding = 1
@@ -870,7 +870,7 @@ To enable this behavior, set the following variable in your vimrc: >
 	let g:rst_style = 1
 
 
-RNOWEB							      *ft-rnoweb-plugin*
+RNOWEB							*ft-rnoweb-plugin*
 
 The 'formatexpr' option is set dynamically with different values for R code
 and for LaTeX code. If you prefer that 'formatexpr' is not set, add to your


### PR DESCRIPTION
#### vim-patch:ea0e41a: runtime(doc): make tag alignment more consistent in filetype.txt

closes: vim/vim#16169

https://github.com/vim/vim/commit/ea0e41a1152378358975e5021ea9f5540dabf542

Omit Lua folding.

N/A patch:
vim-patch:fdfcce5: runtime(lua): add optional lua function folding