### PR TITLE
fix(defaults): don't replace keycodes in Visual search mappings

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -49,10 +49,10 @@ do
 
     vim.keymap.set('x', '*', function()
       return _visual_search('/')
-    end, { desc = ':help v_star-default', expr = true, silent = true })
+    end, { desc = ':help v_star-default', expr = true, replace_keycodes = false })
     vim.keymap.set('x', '#', function()
       return _visual_search('?')
-    end, { desc = ':help v_#-default', expr = true, silent = true })
+    end, { desc = ':help v_#-default', expr = true, replace_keycodes = false })
   end
 
   --- Map Y to y$. This mimics the behavior of D and C. See |Y-default|

--- a/test/functional/editor/defaults_spec.lua
+++ b/test/functional/editor/defaults_spec.lua
@@ -94,6 +94,74 @@ describe('default', function()
   end)
 
   describe('key mappings', function()
+    describe('Visual mode search mappings', function()
+      it('handle various chars properly', function()
+        n.clear({ args_rm = { '--cmd' } })
+        local screen = Screen.new(60, 8)
+        screen:set_default_attr_ids({
+          [1] = { foreground = Screen.colors.NvimDarkGray4 },
+          [2] = {
+            foreground = Screen.colors.NvimDarkGray3,
+            background = Screen.colors.NvimLightGray3,
+          },
+          [3] = {
+            foreground = Screen.colors.NvimLightGrey1,
+            background = Screen.colors.NvimDarkYellow,
+          },
+          [4] = {
+            foreground = Screen.colors.NvimDarkGrey1,
+            background = Screen.colors.NvimLightYellow,
+          },
+        })
+        n.api.nvim_buf_set_lines(0, 0, -1, true, {
+          [[testing <CR> /?\!1]],
+          [[testing <CR> /?\!2]],
+          [[testing <CR> /?\!3]],
+          [[testing <CR> /?\!4]],
+        })
+        n.feed('gg0vf!o*')
+        screen:expect([[
+          {3:testing <CR> /?\!}1                                          |
+          {4:^testing <CR> /?\!}2                                          |
+          {3:testing <CR> /?\!}3                                          |
+          {3:testing <CR> /?\!}4                                          |
+          {1:~                                                           }|*2
+          {2:[No Name] [+]                             2,1            All}|
+          /\Vtesting <CR> \/?\\!                    [2/4]             |
+        ]])
+        n.feed('n')
+        screen:expect([[
+          {3:testing <CR> /?\!}1                                          |
+          {3:testing <CR> /?\!}2                                          |
+          {4:^testing <CR> /?\!}3                                          |
+          {3:testing <CR> /?\!}4                                          |
+          {1:~                                                           }|*2
+          {2:[No Name] [+]                             3,1            All}|
+          /\Vtesting <CR> \/?\\!                    [3/4]             |
+        ]])
+        n.feed('G0vf!o#')
+        screen:expect([[
+          {3:testing <CR> /?\!}1                                          |
+          {3:testing <CR> /?\!}2                                          |
+          {4:^testing <CR> /?\!}3                                          |
+          {3:testing <CR> /?\!}4                                          |
+          {1:~                                                           }|*2
+          {2:[No Name] [+]                             3,1            All}|
+          ?\Vtesting <CR> /?\\!                     [3/4]             |
+        ]])
+        n.feed('n')
+        screen:expect([[
+          {3:testing <CR> /?\!}1                                          |
+          {4:^testing <CR> /?\!}2                                          |
+          {3:testing <CR> /?\!}3                                          |
+          {3:testing <CR> /?\!}4                                          |
+          {1:~                                                           }|*2
+          {2:[No Name] [+]                             2,1            All}|
+          ?\Vtesting <CR> /?\\!                     [2/4]             |
+        ]])
+      end)
+    end)
+
     describe('unimpaired-style mappings', function()
       it('show the command ouptut when successful', function()
         n.clear({ args_rm = { '--cmd' } })


### PR DESCRIPTION
Also remove "silent" to be more consistent with Normal mode search.

Fix #31435
