### PR TITLE
fix(lsp): add foldingrange method support check

### DIFF
--- a/runtime/lua/vim/lsp/_folding_range.lua
+++ b/runtime/lua/vim/lsp/_folding_range.lua
@@ -271,7 +271,9 @@ local function setup(bufnr)
     buffer = bufnr,
     callback = function(args)
       local client = assert(vim.lsp.get_client_by_id(args.data.client_id))
-      request(bufnr, client)
+      if client:supports_method(vim.lsp.protocol.Methods.textDocument_foldingRange, bufnr) then
+        request(bufnr, client)
+      end
     end,
   })
   api.nvim_create_autocmd('LspNotify', {


### PR DESCRIPTION
Problem: The folding_range request method assumes that the client supports the method

Solution: Add a capability guard to the call