### PR TITLE
vim-patch:189e24b: runtime(doc): include vietnamese.txt

### DIFF
--- a/runtime/doc/help.txt
+++ b/runtime/doc/help.txt
@@ -150,6 +150,7 @@ LANGUAGE SUPPORT
 |arabic.txt|		Arabic language support and editing
 |hebrew.txt|		Hebrew language support and editing
 |russian.txt|		Russian language support and editing
+|vietnamese.txt|	Vietnamese language support and editing
 
 ------------------------------------------------------------------------------
 INTEROP

--- a/runtime/doc/vietnamese.txt
+++ b/runtime/doc/vietnamese.txt
@@ -8,17 +8,15 @@
 ===============================================================================
 1. Introduction
 							*vietnamese-intro*
-
 Vim supports Vietnamese language in the following ways:
 
 - Built-in |vietnamese-keymap|, which allows you to type Vietnamese characters
   in |Insert-mode| and |search-commands| using US keyboard layout.
-- Localization in Vietnamese. See |vietnamese-l18n|
+- Localization in Vietnamese. See |vietnamese-l10n|
 
 ===============================================================================
 2. Vietnamese keymaps
 							*vietnamese-keymap*
-
 To switch between languages you can use your system native keyboard switcher,
 or use one of the Vietnamese keymaps included in the Vim distribution, like
 below >
@@ -37,7 +35,6 @@ Vim comes with the following Vietnamese keymaps:
 - *vietnamese-vni_utf-8*	VNI input method, |UTF-8| encoding.
 
                                                    *vietnamese-ime_diff*
-
 Since these keymaps were designed to be minimalistic, they do not support all
 features of the corresponding input methods. The differences are described
 below:
@@ -61,11 +58,10 @@ below:
 
 ===============================================================================
 3. Localization
-							*vietnamese-l18n*
-
-Vim |messages| are also available in Vietnamese.  If you wish to see messages in
-Vietnamese, you can run the command |:language| with an argument being the name
-of the Vietnamese locale.  For example, >
+							*vietnamese-l10n*
+Vim |messages| are also available in Vietnamese.  If you wish to see messages
+in Vietnamese, you can run the command |:language| with an argument being the
+name of the Vietnamese locale.  For example, >
 	:language vi_VN
 < or >
 	:language vi_VN.utf-8

--- a/runtime/doc/vietnamese.txt
+++ b/runtime/doc/vietnamese.txt
@@ -1,0 +1,77 @@
+*vietnamese.txt*   Nvim
+
+
+		  VIM REFERENCE MANUAL    by Phạm Bình An
+
+                                      Type |gO| to see the table of contents.
+
+===============================================================================
+1. Introduction
+							*vietnamese-intro*
+
+Vim supports Vietnamese language in the following ways:
+
+- Built-in |vietnamese-keymap|, which allows you to type Vietnamese characters
+  in |Insert-mode| and |search-commands| using US keyboard layout.
+- Localization in Vietnamese. See |vietnamese-l18n|
+
+===============================================================================
+2. Vietnamese keymaps
+							*vietnamese-keymap*
+
+To switch between languages you can use your system native keyboard switcher,
+or use one of the Vietnamese keymaps included in the Vim distribution, like
+below >
+    :set keymap=vietnamese-telex_utf-8
+<
+See |'keymap'| for more information.
+
+In the latter case, you can type Vietnamese even if you do not have a
+Vietnamese input method engine (IME) or you want Vim to be independent from a
+system-wide keyboard settings (when |'imdisable'| is set). You can also |:map|
+a key to switch between keyboards.
+
+Vim comes with the following Vietnamese keymaps:
+- *vietnamese-telex_utf-8*	Telex input method, |UTF-8| encoding.
+- *vietnamese-viqr_utf-8*	VIQR input method, |UTF-8| encoding.
+- *vietnamese-vni_utf-8*	VNI input method, |UTF-8| encoding.
+
+                                                   *vietnamese-ime_diff*
+
+Since these keymaps were designed to be minimalistic, they do not support all
+features of the corresponding input methods. The differences are described
+below:
+
+- You can only type each character individually, entering the base letter first
+  and then the diacritics later.  For example, to type the word `nến` using
+  |vietnamese-vni_utf-8|, you must type `ne61n`, not `nen61` or `ne6n1`
+- For characters with more than 1 diacritic, you need to type vowel mark before
+  tone mark. For example, to type `ồ` using |vietnamese-telex_utf-8|, you need
+  to type `oof`, not `ofo`.
+- With |vietnamese-telex_utf-8|, you need to type all uppercase letters to
+  produce uppercase characters with diacritics. For example, `Ừ` must be typed
+  as `UWF`.
+- With |vietnamese-telex_utf-8|, the escape character `\` from VNI is added,
+  hence the confusing `ooo` input to type `oo` is removed, which could lead to
+  ambiguities.  For example, to type the word `Đoòng`, you would type
+  `DDo\ofng`.
+- Simple Telex (both v1 and v2), including the `w[]{}` style, is not
+  supported.
+- Removing diacritics using `z` in Telex or `0` in VNI and VIQR is not supported.
+
+===============================================================================
+3. Localization
+							*vietnamese-l18n*
+
+Vim |messages| are also available in Vietnamese.  If you wish to see messages in
+Vietnamese, you can run the command |:language| with an argument being the name
+of the Vietnamese locale.  For example, >
+	:language vi_VN
+< or >
+	:language vi_VN.utf-8
+<
+Note that the name of the Vietnamese locale may vary depending on your system.
+See |mbyte-first| for details.
+
+===============================================================================
+vim:tw=78:ts=8:noet:ft=help:norl:

--- a/src/nvim/po/vi.po
+++ b/src/nvim/po/vi.po
@@ -4,219 +4,147 @@
 #
 msgid ""
 msgstr ""
-"Project-Id-Version: Vim 6.3 \n"
+"Project-Id-Version: PACKAGE VERSION\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2014-05-26 14:21+0200\n"
-"PO-Revision-Date: 2005-02-30 21:37+0400\n"
-"Last-Translator: Phan Vinh Thinh <teppi@vnlinux.org>\n"
+"POT-Creation-Date: 2024-12-03 22:06+0100\n"
+"PO-Revision-Date: 2024-12-03 22:07+0100\n"
+"Last-Translator: Phạm Bình An <111893501+brianhuster@users.noreply.github.com>\n"
 "Language-Team: Phan Vinh Thinh <teppi@vnlinux.org>\n"
-"Language: \n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
 "Content-Transfer-Encoding: 8bit\n"
 
-#: ../api/private/helpers.c:201
-#, fuzzy
-msgid "Unable to get option value"
-msgstr "E258: Không thể trả lời cho máy con"
-
-#: ../api/private/helpers.c:204
-msgid "internal error: unknown option type"
-msgstr ""
-
-#: ../buffer.c:92
-msgid "[Location List]"
-msgstr ""
-
-#: ../buffer.c:93
-msgid "[Quickfix List]"
-msgstr ""
-
-#: ../buffer.c:94
-msgid "E855: Autocommands caused command to abort"
-msgstr ""
-
-#: ../buffer.c:135
 msgid "E82: Cannot allocate any buffer, exiting..."
 msgstr "E82: Không thể phân chia bộ nhớ thậm chí cho một bộ đệm, thoát..."
 
-#: ../buffer.c:138
 msgid "E83: Cannot allocate buffer, using other one..."
 msgstr "E83: Không thể phân chia bộ nhớ cho bộ đệm, sử dụng bộ đệm khác..."
 
-#: ../buffer.c:763
 msgid "E515: No buffers were unloaded"
 msgstr "E515: Không có bộ đệm nào được bỏ nạp từ bộ nhớ"
 
-#: ../buffer.c:765
 msgid "E516: No buffers were deleted"
 msgstr "E516: Không có bộ đệm nào bị xóa"
 
-#: ../buffer.c:767
 msgid "E517: No buffers were wiped out"
 msgstr "E517: Không có bộ đệm nào được làm sạch"
 
-#: ../buffer.c:772
 msgid "1 buffer unloaded"
 msgstr "1 bộ đệm được bỏ nạp từ bộ nhớ"
 
-#: ../buffer.c:774
 #, c-format
 msgid "%d buffers unloaded"
 msgstr "%d bộ đệm được bỏ nạp từ bộ nhớ"
 
-#: ../buffer.c:777
 msgid "1 buffer deleted"
 msgstr "1 bộ đệm bị xóa"
 
-#: ../buffer.c:779
 #, c-format
 msgid "%d buffers deleted"
 msgstr "%d bộ đệm được bỏ nạp"
 
-#: ../buffer.c:782
 msgid "1 buffer wiped out"
 msgstr "1 bộ đệm được làm sạch"
 
-#: ../buffer.c:784
 #, c-format
 msgid "%d buffers wiped out"
 msgstr "%d bộ đệm được làm sạch"
 
-#: ../buffer.c:806
-msgid "E90: Cannot unload last buffer"
-msgstr "E90: Không thể bỏ nạp từ bộ nhớ bộ đệm cuối cùng"
-
-#: ../buffer.c:874
 msgid "E84: No modified buffer found"
 msgstr "E84: Không tìm thấy bộ đệm có thay đổi"
 
-#. back where we started, didn't find anything.
-#: ../buffer.c:903
 msgid "E85: There is no listed buffer"
 msgstr "E85: Không có bộ đệm được liệt kê"
 
-#: ../buffer.c:913
 #, c-format
-msgid "E86: Buffer %<PRId64> does not exist"
-msgstr "E86: Bộ đệm %<PRId64> không tồn tại"
+msgid "E86: Buffer %ld does not exist"
+msgstr "E86: Bộ đệm %ld không tồn tại"
 
-#: ../buffer.c:915
 msgid "E87: Cannot go beyond last buffer"
 msgstr "E87: Đây là bộ đệm cuối cùng"
 
-#: ../buffer.c:917
 msgid "E88: Cannot go before first buffer"
 msgstr "E88: Đây là bộ đệm đầu tiên"
 
-#: ../buffer.c:945
 #, c-format
-msgid ""
-"E89: No write since last change for buffer %<PRId64> (add ! to override)"
+msgid "E89: No write since last change for buffer %ld (add ! to override)"
 msgstr ""
-"E89: Thay đổi trong bộ đệm %<PRId64> chưa được ghi lại (thêm ! để thoát ra "
-"bằng mọi giá)"
+"E89: Thay đổi trong bộ đệm %ld chưa được ghi lại (thêm ! để thoát ra bằng "
+"mọi giá)"
 
-#. wrap around (may cause duplicates)
-#: ../buffer.c:1423
+msgid "E90: Cannot unload last buffer"
+msgstr "E90: Không thể bỏ nạp từ bộ nhớ bộ đệm cuối cùng"
+
 msgid "W14: Warning: List of file names overflow"
 msgstr "W14: Cảnh báo: Danh sách tên tập tin quá đầy"
 
-#: ../buffer.c:1555 ../quickfix.c:3361
 #, c-format
-msgid "E92: Buffer %<PRId64> not found"
-msgstr "E92: Bộ đệm %<PRId64> không được tìm thấy"
+msgid "E92: Buffer %ld not found"
+msgstr "E92: Bộ đệm %ld không được tìm thấy"
 
-#: ../buffer.c:1798
 #, c-format
 msgid "E93: More than one match for %s"
 msgstr "E93: Tìm thấy vài tương ứng với %s"
 
-#: ../buffer.c:1800
 #, c-format
 msgid "E94: No matching buffer for %s"
 msgstr "E94: Không có bộ đệm tương ứng với %s"
 
-#: ../buffer.c:2161
 #, c-format
-msgid "line %<PRId64>"
-msgstr "dòng %<PRId64>"
+msgid "line %ld"
+msgstr "dòng %ld"
 
-#: ../buffer.c:2233
 msgid "E95: Buffer with this name already exists"
 msgstr "E95: Đã có bộ đệm với tên như vậy"
 
-#: ../buffer.c:2498
 msgid " [Modified]"
 msgstr " [Đã thay đổi]"
 
-#: ../buffer.c:2501
 msgid "[Not edited]"
 msgstr "[Chưa soạn thảo]"
 
-#: ../buffer.c:2504
 msgid "[New file]"
 msgstr "[Tập tin mới]"
 
-#: ../buffer.c:2505
 msgid "[Read errors]"
 msgstr "[Lỗi đọc]"
 
-#: ../buffer.c:2506 ../buffer.c:3217 ../fileio.c:1807 ../screen.c:4895
-msgid "[RO]"
-msgstr "[Chỉ đọc]"
-
-#: ../buffer.c:2507 ../fileio.c:1807
 msgid "[readonly]"
 msgstr "[chỉ đọc]"
 
-#: ../buffer.c:2524
 #, c-format
 msgid "1 line --%d%%--"
 msgstr "1 dòng --%d%%--"
 
-#: ../buffer.c:2526
 #, c-format
-msgid "%<PRId64> lines --%d%%--"
-msgstr "%<PRId64> dòng --%d%%--"
+msgid "%ld lines --%d%%--"
+msgstr "%ld dòng --%d%%--"
 
-#: ../buffer.c:2530
 #, c-format
-msgid "line %<PRId64> of %<PRId64> --%d%%-- col "
-msgstr "dòng %<PRId64> của %<PRId64> --%d%%-- cột "
+msgid "line %ld of %ld --%d%%-- col "
+msgstr "dòng %ld của %ld --%d%%-- cột "
 
-#: ../buffer.c:2632 ../buffer.c:4292 ../memline.c:1554
-#, fuzzy
-msgid "[No Name]"
+msgid "[No file]"
 msgstr "[Không có tập tin]"
 
-#. must be a help buffer
-#: ../buffer.c:2667
 msgid "help"
 msgstr "trợ giúp"
 
-#: ../buffer.c:3225 ../screen.c:4883
-#, fuzzy
-msgid "[Help]"
+msgid "[help]"
 msgstr "[trợ giúp]"
 
-#: ../buffer.c:3254 ../screen.c:4887
 msgid "[Preview]"
 msgstr "[Xem trước]"
 
-#: ../buffer.c:3528
 msgid "All"
 msgstr "Tất cả"
 
-#: ../buffer.c:3528
 msgid "Bot"
 msgstr "Cuối"
 
-#: ../buffer.c:3531
 msgid "Top"
 msgstr "Đầu"
 
-#: ../buffer.c:4244
 msgid ""
 "\n"
 "# Buffer list:\n"
@@ -224,11 +152,12 @@ msgstr ""
 "\n"
 "# Danh sách bộ đệm:\n"
 
-#: ../buffer.c:4289
-msgid "[Scratch]"
-msgstr ""
+msgid "[Error List]"
+msgstr "[Danh sách lỗi]"
 
-#: ../buffer.c:4529
+msgid "[No File]"
+msgstr "[Không có tập tin]"
+
 msgid ""
 "\n"
 "--- Signs ---"
@@ -236,806 +165,300 @@ msgstr ""
 "\n"
 "--- Ký hiệu ---"
 
-#: ../buffer.c:4538
 #, c-format
 msgid "Signs for %s:"
 msgstr "Ký hiệu cho %s:"
 
-#: ../buffer.c:4543
 #, c-format
-msgid "    line=%<PRId64>  id=%d  name=%s"
-msgstr "    dòng=%<PRId64>  id=%d  tên=%s"
+msgid "    line=%ld  id=%d  name=%s"
+msgstr "    dòng=%ld  id=%d  tên=%s"
 
-#: ../cursor_shape.c:68
-msgid "E545: Missing colon"
-msgstr "E545: Thiếu dấu hai chấm"
-
-#: ../cursor_shape.c:70 ../cursor_shape.c:94
-msgid "E546: Illegal mode"
-msgstr "E546: Chế độ không cho phép"
-
-#: ../cursor_shape.c:134
-msgid "E548: digit expected"
-msgstr "E548: yêu cầu một số"
-
-#: ../cursor_shape.c:138
-msgid "E549: Illegal percentage"
-msgstr "E549: Tỷ lệ phần trăm không cho phép"
-
-#: ../diff.c:146
 #, c-format
-msgid "E96: Can not diff more than %<PRId64> buffers"
-msgstr ""
-"E96: Chỉ có thể theo dõi sự khác nhau trong nhiều nhất %<PRId64> bộ đệm"
+msgid "E96: Can not diff more than %ld buffers"
+msgstr "E96: Chỉ có thể theo dõi sự khác nhau trong nhiều nhất %ld bộ đệm"
 
-#: ../diff.c:753
-#, fuzzy
-msgid "E810: Cannot read or write temp files"
-msgstr "E557: Không thể mở tập tin termcap"
-
-#: ../diff.c:755
 msgid "E97: Cannot create diffs"
 msgstr "E97: Không thể tạo tập tin khác biệt (diff)"
 
-#: ../diff.c:966
-#, fuzzy
-msgid "E816: Cannot read patch output"
-msgstr "E98: Không thể đọc dữ liệu ra của lệnh diff"
+msgid "Patch file"
+msgstr "Tập tin vá lỗi (patch)"
 
-#: ../diff.c:1220
 msgid "E98: Cannot read diff output"
 msgstr "E98: Không thể đọc dữ liệu ra của lệnh diff"
 
-#: ../diff.c:2081
 msgid "E99: Current buffer is not in diff mode"
 msgstr "E99: Bộ đệm hiện thời không nằm trong chế độ khác biệt (diff)"
 
-#: ../diff.c:2100
-#, fuzzy
-msgid "E793: No other buffer in diff mode is modifiable"
-msgstr "E100: Không còn bộ đệm trong chế độ khác biệt (diff) nào nữa"
-
-#: ../diff.c:2102
 msgid "E100: No other buffer in diff mode"
 msgstr "E100: Không còn bộ đệm trong chế độ khác biệt (diff) nào nữa"
 
-#: ../diff.c:2112
 msgid "E101: More than two buffers in diff mode, don't know which one to use"
-msgstr ""
-"E101: Có nhiều hơn hai bộ đệm trong chế độ khác biệt (diff), không biết chọn"
+msgstr "E101: Có nhiều hơn hai bộ đệm trong chế độ khác biệt (diff), không biết nên chọn cái nào"
 
-#: ../diff.c:2141
 #, c-format
 msgid "E102: Can't find buffer \"%s\""
 msgstr "E102: Không tìm thấy bộ đệm \"%s\""
 
-#: ../diff.c:2152
 #, c-format
 msgid "E103: Buffer \"%s\" is not in diff mode"
 msgstr "E103: Bộ đệm \"%s\" không nằm trong chế độ khác biệt (diff)"
 
-#: ../diff.c:2193
-msgid "E787: Buffer changed unexpectedly"
-msgstr ""
-
-#: ../digraph.c:1598
 msgid "E104: Escape not allowed in digraph"
 msgstr "E104: Không cho phép dùng ký tự thoát Escape trong chữ ghép"
 
-#: ../digraph.c:1760
 msgid "E544: Keymap file not found"
 msgstr "E544: Không tìm thấy tập tin sơ đồ bàn phím"
 
-#: ../digraph.c:1785
 msgid "E105: Using :loadkeymap not in a sourced file"
 msgstr "E105: Câu lệnh :loadkeymap được sử dụng ngoài tập tin script"
 
-#: ../digraph.c:1821
-msgid "E791: Empty keymap entry"
-msgstr ""
-
-#: ../edit.c:82
 msgid " Keyword completion (^N^P)"
 msgstr " Tự động kết thúc cho từ khóa (^N^P)"
 
-#. ctrl_x_mode == 0, ^P/^N compl.
-#: ../edit.c:83
-#, fuzzy
-msgid " ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)"
+msgid " ^X mode (^E^Y^L^]^F^I^K^D^V^N^P)"
 msgstr " Chế độ ^X (^E^Y^L^]^F^I^K^D^V^N^P)"
 
-#: ../edit.c:85
-msgid " Whole line completion (^L^N^P)"
-msgstr " Tự động kết thúc cho cả dòng (^L^N^P)"
-
-#: ../edit.c:86
-msgid " File name completion (^F^N^P)"
-msgstr " Tự động kết thúc tên tập tin (^F^N^P)"
-
-#: ../edit.c:87
-msgid " Tag completion (^]^N^P)"
-msgstr " Tự động kết thúc thẻ đánh dấu (^]^N^P)"
-
-#: ../edit.c:88
-msgid " Path pattern completion (^N^P)"
-msgstr " Tự động kết thúc mẫu đường dẫn (^N^P)"
-
-#: ../edit.c:89
-msgid " Definition completion (^D^N^P)"
-msgstr " Tự động kết thúc định nghĩa (^D^N^P)"
-
-#: ../edit.c:91
-msgid " Dictionary completion (^K^N^P)"
-msgstr " Tự động kết thúc theo từ điển (^K^N^P)"
-
-#: ../edit.c:92
-msgid " Thesaurus completion (^T^N^P)"
-msgstr " Tự động kết thúc từ đồng âm (^T^N^P)"
-
-#: ../edit.c:93
-msgid " Command-line completion (^V^N^P)"
-msgstr " Tự động kết thúc dòng lệnh (^V^N^P)"
-
-#: ../edit.c:94
-#, fuzzy
-msgid " User defined completion (^U^N^P)"
-msgstr " Tự động kết thúc cho cả dòng (^L^N^P)"
-
-#: ../edit.c:95
-#, fuzzy
-msgid " Omni completion (^O^N^P)"
-msgstr " Tự động kết thúc thẻ đánh dấu (^]^N^P)"
-
-#: ../edit.c:96
-#, fuzzy
-msgid " Spelling suggestion (^S^N^P)"
-msgstr " Tự động kết thúc cho cả dòng (^L^N^P)"
-
-#: ../edit.c:97
 msgid " Keyword Local completion (^N^P)"
 msgstr " Tự động kết thúc nội bộ cho từ khóa (^N^P)"
 
-#: ../edit.c:100
+msgid " Whole line completion (^L^N^P)"
+msgstr " Tự động kết thúc cho cả dòng (^L^N^P)"
+
+msgid " File name completion (^F^N^P)"
+msgstr " Tự động kết thúc tên tập tin (^F^N^P)"
+
+msgid " Tag completion (^]^N^P)"
+msgstr " Tự động kết thúc thẻ đánh dấu (^]^N^P)"
+
+msgid " Path pattern completion (^N^P)"
+msgstr " Tự động kết thúc mẫu đường dẫn (^N^P)"
+
+msgid " Definition completion (^D^N^P)"
+msgstr " Tự động kết thúc định nghĩa (^D^N^P)"
+
+msgid " Dictionary completion (^K^N^P)"
+msgstr " Tự động kết thúc theo từ điển (^K^N^P)"
+
+msgid " Thesaurus completion (^T^N^P)"
+msgstr " Tự động kết thúc từ đồng âm (^T^N^P)"
+
+msgid " Command-line completion (^V^N^P)"
+msgstr " Tự động kết thúc dòng lệnh (^V^N^P)"
+
 msgid "Hit end of paragraph"
 msgstr "Kết thúc của đoạn văn"
 
-#: ../edit.c:101
-msgid "E839: Completion function changed window"
-msgstr ""
-
-#: ../edit.c:102
-msgid "E840: Completion function deleted text"
-msgstr ""
-
-#: ../edit.c:1847
-msgid "'dictionary' option is empty"
-msgstr "Không đưa ra giá trị của tùy chọn 'dictionary'"
-
-#: ../edit.c:1848
 msgid "'thesaurus' option is empty"
 msgstr "Không đưa ra giá trị của tùy chọn 'thesaurus'"
 
-#: ../edit.c:2655
+msgid "'dictionary' option is empty"
+msgstr "Không đưa ra giá trị của tùy chọn 'dictionary'"
+
 #, c-format
 msgid "Scanning dictionary: %s"
 msgstr "Quét từ điển: %s"
 
-#: ../edit.c:3079
 msgid " (insert) Scroll (^E/^Y)"
 msgstr " (chèn) Cuộn (^E/^Y)"
 
-#: ../edit.c:3081
 msgid " (replace) Scroll (^E/^Y)"
 msgstr " (thay thế) Cuộn (^E/^Y)"
 
-#: ../edit.c:3587
 #, c-format
 msgid "Scanning: %s"
 msgstr "Quét: %s"
 
-#: ../edit.c:3614
 msgid "Scanning tags."
 msgstr "Tìm kiếm trong số thẻ đánh dấu."
 
-#: ../edit.c:4519
 msgid " Adding"
 msgstr " Thêm"
 
-#. showmode might reset the internal line pointers, so it must
-#. * be called before line = ml_get(), or when this address is no
-#. * longer needed.  -- Acevedo.
-#.
-#: ../edit.c:4562
 msgid "-- Searching..."
 msgstr "-- Tìm kiếm..."
 
-#: ../edit.c:4618
 msgid "Back at original"
 msgstr "Từ ban đầu"
 
-#: ../edit.c:4621
 msgid "Word from other line"
 msgstr "Từ của dòng khác"
 
-#: ../edit.c:4624
 msgid "The only match"
 msgstr "Tương ứng duy nhất"
 
-#: ../edit.c:4680
 #, c-format
 msgid "match %d of %d"
 msgstr "Tương ứng %d của %d"
 
-#: ../edit.c:4684
 #, c-format
 msgid "match %d"
 msgstr "Tương ứng %d"
 
-#: ../eval.c:137
-#, fuzzy
-msgid "E18: Unexpected characters in :let"
-msgstr "E18: Ở trước '=' có các ký tự không mong đợi"
-
-#: ../eval.c:138
-#, fuzzy, c-format
-msgid "E684: list index out of range: %<PRId64>"
-msgstr "E322: số thứ tự dòng vượt quá giới hạn : %<PRId64>"
-
-#: ../eval.c:139
 #, c-format
-msgid "E121: Undefined variable: %s"
-msgstr "E121: Biến không xác định: %s"
+msgid "E106: Unknown variable: \"%s\""
+msgstr "E106: Biến không biết: \"%s\""
 
-#: ../eval.c:140
-msgid "E111: Missing ']'"
-msgstr "E111: Thiếu ']'"
-
-#: ../eval.c:141
-#, fuzzy, c-format
-msgid "E686: Argument of %s must be a List"
-msgstr "E487: Tham số phải là một số dương"
-
-#: ../eval.c:143
-#, fuzzy, c-format
-msgid "E712: Argument of %s must be a List or Dictionary"
-msgstr "E487: Tham số phải là một số dương"
-
-#: ../eval.c:144
-#, fuzzy
-msgid "E713: Cannot use empty key for Dictionary"
-msgstr "E214: Không tìm thấy tập tin tạm thời (temp) để ghi nhớ"
-
-#: ../eval.c:145
-#, fuzzy
-msgid "E714: List required"
-msgstr "E471: Cần chỉ ra tham số"
-
-#: ../eval.c:146
-#, fuzzy
-msgid "E715: Dictionary required"
-msgstr "E129: Cần tên hàm số"
-
-#: ../eval.c:147
-#, c-format
-msgid "E118: Too many arguments for function: %s"
-msgstr "E118: Quá nhiều tham số cho hàm: %s"
-
-#: ../eval.c:148
-#, c-format
-msgid "E716: Key not present in Dictionary: %s"
-msgstr ""
-
-#: ../eval.c:150
-#, c-format
-msgid "E122: Function %s already exists, add ! to replace it"
-msgstr "E122: Hàm số %s đã có, hãy thêm ! để thay thế nó."
-
-#: ../eval.c:151
-#, fuzzy
-msgid "E717: Dictionary entry already exists"
-msgstr "E95: Đã có bộ đệm với tên như vậy"
-
-#: ../eval.c:152
-#, fuzzy
-msgid "E718: Funcref required"
-msgstr "E129: Cần tên hàm số"
-
-#: ../eval.c:153
-#, fuzzy
-msgid "E719: Cannot use [:] with a Dictionary"
-msgstr "E360: Không chạy được shell với tùy chọn -f"
-
-#: ../eval.c:154
-#, c-format
-msgid "E734: Wrong variable type for %s="
-msgstr ""
-
-#: ../eval.c:155
-#, fuzzy, c-format
-msgid "E130: Unknown function: %s"
-msgstr "E117: Hàm số không biết: %s"
-
-#: ../eval.c:156
-#, c-format
-msgid "E461: Illegal variable name: %s"
-msgstr "E461: Tên biến không cho phép: %s"
-
-#: ../eval.c:157
-msgid "E806: using Float as a String"
-msgstr ""
-
-#: ../eval.c:1830
-msgid "E687: Less targets than List items"
-msgstr ""
-
-#: ../eval.c:1834
-msgid "E688: More targets than List items"
-msgstr ""
-
-#: ../eval.c:1906
-msgid "Double ; in list of variables"
-msgstr ""
-
-#: ../eval.c:2078
-#, fuzzy, c-format
-msgid "E738: Can't list variables for %s"
-msgstr "E138: Không thể ghi tập tin viminfo %s!"
-
-#: ../eval.c:2391
-msgid "E689: Can only index a List or Dictionary"
-msgstr ""
-
-#: ../eval.c:2396
-msgid "E708: [:] must come last"
-msgstr ""
-
-#: ../eval.c:2439
-msgid "E709: [:] requires a List value"
-msgstr ""
-
-#: ../eval.c:2674
-msgid "E710: List value has more items than target"
-msgstr ""
-
-#: ../eval.c:2678
-msgid "E711: List value has not enough items"
-msgstr ""
-
-#: ../eval.c:2867
-#, fuzzy
-msgid "E690: Missing \"in\" after :for"
-msgstr "E69: Thiếu ] sau %s%%["
-
-#: ../eval.c:3063
 #, c-format
 msgid "E107: Missing parentheses: %s"
 msgstr "E107: Thiếu dấu ngoặc: %s"
 
-#: ../eval.c:3263
 #, c-format
 msgid "E108: No such variable: \"%s\""
 msgstr "E108: Không có biến như vậy: \"%s\""
 
-#: ../eval.c:3333
-msgid "E743: variable nested too deep for (un)lock"
-msgstr ""
-
-#: ../eval.c:3630
 msgid "E109: Missing ':' after '?'"
 msgstr "E109: Thiếu ':' sau '?'"
 
-#: ../eval.c:3893
-msgid "E691: Can only compare List with List"
-msgstr ""
-
-#: ../eval.c:3895
-#, fuzzy
-msgid "E692: Invalid operation for Lists"
-msgstr "E449: Nhận được một biểu thức không cho phép"
-
-#: ../eval.c:3915
-msgid "E735: Can only compare Dictionary with Dictionary"
-msgstr ""
-
-#: ../eval.c:3917
-#, fuzzy
-msgid "E736: Invalid operation for Dictionary"
-msgstr "E116: Tham số cho hàm %s đưa ra không đúng"
-
-#: ../eval.c:3932
-msgid "E693: Can only compare Funcref with Funcref"
-msgstr ""
-
-#: ../eval.c:3934
-#, fuzzy
-msgid "E694: Invalid operation for Funcrefs"
-msgstr "E116: Tham số cho hàm %s đưa ra không đúng"
-
-#: ../eval.c:4277
-#, fuzzy
-msgid "E804: Cannot use '%' with Float"
-msgstr "E360: Không chạy được shell với tùy chọn -f"
-
-#: ../eval.c:4478
 msgid "E110: Missing ')'"
 msgstr "E110: Thiếu ')'"
 
-#: ../eval.c:4609
-#, fuzzy
-msgid "E695: Cannot index a Funcref"
-msgstr "E90: Không thể bỏ nạp từ bộ nhớ bộ đệm cuối cùng"
+msgid "E111: Missing ']'"
+msgstr "E111: Thiếu ']'"
 
-#: ../eval.c:4839
 #, c-format
 msgid "E112: Option name missing: %s"
 msgstr "E112: Không đưa ra tên tùy chọn: %s"
 
-#: ../eval.c:4855
 #, c-format
 msgid "E113: Unknown option: %s"
 msgstr "E113: Tùy chọn không biết: %s"
 
-#: ../eval.c:4904
 #, c-format
 msgid "E114: Missing quote: %s"
 msgstr "E114: Thiếu ngoặc kép: %s"
 
-#: ../eval.c:5020
 #, c-format
 msgid "E115: Missing quote: %s"
 msgstr "E115: Thiếu ngoặc kép: %s"
 
-#: ../eval.c:5084
-#, fuzzy, c-format
-msgid "E696: Missing comma in List: %s"
-msgstr "E405: Thiếu dấu bằng: %s"
-
-#: ../eval.c:5091
-#, fuzzy, c-format
-msgid "E697: Missing end of List ']': %s"
-msgstr "E398: Thiếu '=': %s"
-
-#: ../eval.c:6475
-#, fuzzy, c-format
-msgid "E720: Missing colon in Dictionary: %s"
-msgstr "E405: Thiếu dấu bằng: %s"
-
-#: ../eval.c:6499
-#, c-format
-msgid "E721: Duplicate key in Dictionary: \"%s\""
-msgstr ""
-
-#: ../eval.c:6517
-#, fuzzy, c-format
-msgid "E722: Missing comma in Dictionary: %s"
-msgstr "E527: Thiếu dấu phẩy"
-
-#: ../eval.c:6524
-#, fuzzy, c-format
-msgid "E723: Missing end of Dictionary '}': %s"
-msgstr "E126: Thiếu lệnh :endfunction"
-
-#: ../eval.c:6555
-#, fuzzy
-msgid "E724: variable nested too deep for displaying"
-msgstr "E22: Các script lồng vào nhau quá sâu"
-
-#: ../eval.c:7188
-#, fuzzy, c-format
-msgid "E740: Too many arguments for function %s"
-msgstr "E118: Quá nhiều tham số cho hàm: %s"
-
-#: ../eval.c:7190
 #, c-format
 msgid "E116: Invalid arguments for function %s"
 msgstr "E116: Tham số cho hàm %s đưa ra không đúng"
 
-#: ../eval.c:7377
 #, c-format
 msgid "E117: Unknown function: %s"
 msgstr "E117: Hàm số không biết: %s"
 
-#: ../eval.c:7383
+#, c-format
+msgid "E118: Too many arguments for function: %s"
+msgstr "E118: Quá nhiều tham số cho hàm: %s"
+
 #, c-format
 msgid "E119: Not enough arguments for function: %s"
 msgstr "E119: Không đủ tham số cho hàm: %s"
 
-#: ../eval.c:7387
 #, c-format
 msgid "E120: Using <SID> not in a script context: %s"
 msgstr "E120: Sử dụng <SID> ngoài script: %s"
 
-#: ../eval.c:7391
-#, c-format
-msgid "E725: Calling dict function without Dictionary: %s"
-msgstr ""
-
-#: ../eval.c:7453
-#, fuzzy
-msgid "E808: Number or Float required"
-msgstr "E521: Sau dấu = cần đưa ra một số"
-
-#: ../eval.c:7503
-#, fuzzy
-msgid "add() argument"
-msgstr "Tham số không được phép cho"
-
-#: ../eval.c:7907
-#, fuzzy
-msgid "E699: Too many arguments"
-msgstr "Có quá nhiều tham số soạn thảo"
-
-#: ../eval.c:8073
-#, fuzzy
-msgid "E785: complete() can only be used in Insert mode"
-msgstr "E328: Trình đơn chỉ có trong chế độ khác"
-
-#: ../eval.c:8156
 msgid "&Ok"
 msgstr "&Ok"
 
-#: ../eval.c:8676
-#, fuzzy, c-format
-msgid "E737: Key already exists: %s"
-msgstr "E227: đã có ánh xạ cho %s"
-
-#: ../eval.c:8692
-msgid "extend() argument"
-msgstr ""
-
-#: ../eval.c:8915
-#, fuzzy
-msgid "map() argument"
-msgstr " vim [các tham số] "
-
-#: ../eval.c:8916
-msgid "filter() argument"
-msgstr ""
-
-#: ../eval.c:9229
 #, c-format
 msgid "+-%s%3ld lines: "
 msgstr "+-%s%3ld dòng: "
 
-#: ../eval.c:9291
-#, fuzzy, c-format
-msgid "E700: Unknown function: %s"
-msgstr "E117: Hàm số không biết: %s"
+msgid ""
+"&OK\n"
+"&Cancel"
+msgstr ""
+"&OK\n"
+"&Hủy bỏ"
 
-#: ../eval.c:10729
 msgid "called inputrestore() more often than inputsave()"
 msgstr "Hàm số inputrestore() được gọi nhiều hơn hàm inputsave()"
 
-#: ../eval.c:10771
-#, fuzzy
-msgid "insert() argument"
-msgstr "Có quá nhiều tham số soạn thảo"
-
-#: ../eval.c:10841
-#, fuzzy
-msgid "E786: Range not allowed"
-msgstr "E481: Không cho phép sử dụng phạm vi"
-
-#: ../eval.c:11140
-#, fuzzy
-msgid "E701: Invalid type for len()"
-msgstr "E596: Phông chữ không đúng"
-
-#: ../eval.c:11980
-msgid "E726: Stride is zero"
-msgstr ""
-
-#: ../eval.c:11982
-msgid "E727: Start past end"
-msgstr ""
-
-#: ../eval.c:12024 ../eval.c:15297
-msgid "<empty>"
-msgstr ""
-
-#: ../eval.c:12282
-msgid "remove() argument"
-msgstr ""
-
-#: ../eval.c:12466
 msgid "E655: Too many symbolic links (cycle?)"
 msgstr "E655: Quá nhiều liên kết tượng trưng (vòng lặp?)"
 
-#: ../eval.c:12593
-msgid "reverse() argument"
-msgstr ""
+msgid "E240: No connection to Vim server"
+msgstr "E240: Không có kết nối với máy chủ Vim"
 
-#: ../eval.c:13721
-msgid "sort() argument"
-msgstr ""
+msgid "E277: Unable to read a server reply"
+msgstr "E277: Máy chủ không trả lời"
 
-#: ../eval.c:13721
-#, fuzzy
-msgid "uniq() argument"
-msgstr "Tham số không được phép cho"
+msgid "E258: Unable to send to client"
+msgstr "E258: Không thể trả lời cho máy con"
 
-#: ../eval.c:13776
-#, fuzzy
-msgid "E702: Sort compare function failed"
-msgstr "E237: Chọn máy in không thành công"
+#, c-format
+msgid "E241: Unable to send to %s"
+msgstr "E241: Không thể gửi tin nhắn tới %s"
 
-#: ../eval.c:13806
-msgid "E882: Uniq compare function failed"
-msgstr ""
-
-#: ../eval.c:14085
 msgid "(Invalid)"
 msgstr "(Không đúng)"
 
-#: ../eval.c:14590
-#, fuzzy
-msgid "E677: Error writing temp file"
-msgstr "E208: Lỗi ghi nhớ vào \"%s\""
-
-#: ../eval.c:16159
-msgid "E805: Using a Float as a Number"
-msgstr ""
-
-#: ../eval.c:16162
-msgid "E703: Using a Funcref as a Number"
-msgstr ""
-
-#: ../eval.c:16170
-msgid "E745: Using a List as a Number"
-msgstr ""
-
-#: ../eval.c:16173
-msgid "E728: Using a Dictionary as a Number"
-msgstr ""
-
-#: ../eval.c:16259
-msgid "E729: using Funcref as a String"
-msgstr ""
-
-#: ../eval.c:16262
-#, fuzzy
-msgid "E730: using List as a String"
-msgstr "E374: Thiếu ] trong chuỗi định dạng"
-
-#: ../eval.c:16265
-msgid "E731: using Dictionary as a String"
-msgstr ""
-
-#: ../eval.c:16619
-#, fuzzy, c-format
-msgid "E706: Variable type mismatch for: %s"
-msgstr "E93: Tìm thấy vài tương ứng với %s"
-
-#: ../eval.c:16705
-#, fuzzy, c-format
-msgid "E795: Cannot delete variable %s"
-msgstr "E46: Không thay đổi được biến chỉ đọc \"%s\""
-
-#: ../eval.c:16724
-#, fuzzy, c-format
-msgid "E704: Funcref variable name must start with a capital: %s"
-msgstr "E128: Tên hàm số phải bắt đầu với một chữ cái hoa: %s"
-
-#: ../eval.c:16732
 #, c-format
-msgid "E705: Variable name conflicts with existing function: %s"
-msgstr ""
+msgid "E121: Undefined variable: %s"
+msgstr "E121: Biến không xác định: %s"
 
-#: ../eval.c:16763
 #, c-format
-msgid "E741: Value is locked: %s"
-msgstr ""
+msgid "E461: Illegal variable name: %s"
+msgstr "E461: Tên biến không cho phép: %s"
 
-#: ../eval.c:16764 ../eval.c:16769 ../message.c:1839
-msgid "Unknown"
-msgstr "Không rõ"
+#, c-format
+msgid "E122: Function %s already exists, add ! to replace it"
+msgstr "E122: Hàm số %s đã có, hãy thêm ! để thay thế nó."
 
-#: ../eval.c:16768
-#, fuzzy, c-format
-msgid "E742: Cannot change value of %s"
-msgstr "E284: Không đặt được giá trị nội dung nhập vào (IC)"
-
-#: ../eval.c:16838
-msgid "E698: variable nested too deep for making a copy"
-msgstr ""
-
-#: ../eval.c:17249
 #, c-format
 msgid "E123: Undefined function: %s"
 msgstr "E123: Hàm số không xác định: %s"
 
-#: ../eval.c:17260
 #, c-format
 msgid "E124: Missing '(': %s"
 msgstr "E124: Thiếu '(': %s"
 
-#: ../eval.c:17293
-#, fuzzy
-msgid "E862: Cannot use g: here"
-msgstr "E284: Không đặt được giá trị nội dung nhập vào (IC)"
-
-#: ../eval.c:17312
 #, c-format
 msgid "E125: Illegal argument: %s"
 msgstr "E125: Tham số không cho phép: %s"
 
-#: ../eval.c:17323
-#, fuzzy, c-format
-msgid "E853: Duplicate argument name: %s"
-msgstr "E154: Thẻ ghi lặp lại \"%s\" trong tập tin %s"
-
-#: ../eval.c:17416
 msgid "E126: Missing :endfunction"
 msgstr "E126: Thiếu lệnh :endfunction"
 
-#: ../eval.c:17537
-#, fuzzy, c-format
-msgid "E707: Function name conflicts with variable: %s"
-msgstr "E128: Tên hàm số phải bắt đầu với một chữ cái hoa: %s"
-
-#: ../eval.c:17549
 #, c-format
 msgid "E127: Cannot redefine function %s: It is in use"
 msgstr "E127: Không thể định nghĩa lại hàm số %s: hàm đang được sử dụng"
 
-#: ../eval.c:17604
-#, fuzzy, c-format
-msgid "E746: Function name does not match script file name: %s"
-msgstr "E128: Tên hàm số phải bắt đầu với một chữ cái hoa: %s"
-
-#: ../eval.c:17716
 msgid "E129: Function name required"
 msgstr "E129: Cần tên hàm số"
 
-#: ../eval.c:17824
-#, fuzzy, c-format
-msgid "E128: Function name must start with a capital or \"s:\": %s"
+#, c-format
+msgid "E128: Function name must start with a capital: %s"
 msgstr "E128: Tên hàm số phải bắt đầu với một chữ cái hoa: %s"
 
-#: ../eval.c:17833
-#, fuzzy, c-format
-msgid "E884: Function name cannot contain a colon: %s"
-msgstr "E128: Tên hàm số phải bắt đầu với một chữ cái hoa: %s"
+#, c-format
+msgid "E130: Undefined function: %s"
+msgstr "E130: Hàm số %s chưa xác định"
 
-#: ../eval.c:18336
 #, c-format
 msgid "E131: Cannot delete function %s: It is in use"
 msgstr "E131: Không thể xóa hàm số %s: Hàm đang được sử dụng"
 
-#: ../eval.c:18441
 msgid "E132: Function call depth is higher than 'maxfuncdepth'"
 msgstr "E132: Độ sâu của lời gọi hàm số lớn hơn giá trị 'maxfuncdepth'"
 
-#: ../eval.c:18568
 #, c-format
 msgid "calling %s"
 msgstr "lời gọi %s"
 
-#: ../eval.c:18651
 #, c-format
 msgid "%s aborted"
 msgstr "%s dừng"
 
-#: ../eval.c:18653
 #, c-format
-msgid "%s returning #%<PRId64>"
-msgstr "%s trả lại #%<PRId64>"
+msgid "%s returning #%ld"
+msgstr "%s trả lại #%ld"
 
-#: ../eval.c:18670
-#, fuzzy, c-format
-msgid "%s returning %s"
+#, c-format
+msgid "%s returning \"%s\""
 msgstr "%s trả lại \"%s\""
 
-#: ../eval.c:18691 ../ex_cmds2.c:2695
 #, c-format
 msgid "continuing in %s"
 msgstr "tiếp tục trong %s"
 
-#: ../eval.c:18795
 msgid "E133: :return not inside a function"
 msgstr "E133: lệnh :return ở ngoài một hàm"
 
-#: ../eval.c:19159
 msgid ""
 "\n"
 "# global variables:\n"
@@ -1043,114 +466,260 @@ msgstr ""
 "\n"
 "# biến toàn cầu:\n"
 
-#: ../eval.c:19254
-msgid ""
-"\n"
-"\tLast set from "
+msgid "Entering Debug mode.  Type \"cont\" to continue."
+msgstr "Bật chế độ sửa lỗi (Debug). Gõ \"cont\" để tiếp tục."
+
+#, c-format
+msgid "line %ld: %s"
+msgstr "dòng %ld: %s"
+
+#, c-format
+msgid "cmd: %s"
+msgstr "câu lệnh: %s"
+
+#, c-format
+msgid "Breakpoint in \"%s%s\" line %ld"
+msgstr "Điểm dừng trên \"%s%s\" dòng %ld"
+
+#, c-format
+msgid "E161: Breakpoint not found: %s"
+msgstr "E161: Không tìm thấy điểm dừng: %s"
+
+msgid "No breakpoints defined"
+msgstr "Điểm dừng không được xác định"
+
+#, c-format
+msgid "%3d  %s %s  line %ld"
+msgstr "%3d  %s %s dòng %ld"
+
+msgid "Save As"
+msgstr "Ghi nhớ như"
+
+#, c-format
+msgid "Save changes to \"%.*s\"?"
+msgstr "Ghi nhớ thay đổi vào \"%.*s\"?"
+
+msgid "Untitled"
+msgstr "Chưa đặt tên"
+
+#, c-format
+msgid "E162: No write since last change for buffer \"%s\""
+msgstr "E162: Thay đổi chưa được ghi nhớ trong bộ đệm \"%s\""
+
+msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
 msgstr ""
-"\n"
-"\tLần cuối cùng tùy chọn thay đổi vào "
+"Cảnh báo: Chuyển tới bộ đệm khác không theo ý muốn (hãy kiểm tra câu lệnh tự "
+"động)"
 
-#: ../eval.c:19272
-#, fuzzy
-msgid "No old files"
-msgstr "Không có tập tin được tính đến"
+msgid "E163: There is only one file to edit"
+msgstr "E163: Chỉ có một tập tin để soạn thảo"
 
-#: ../ex_cmds.c:122
+msgid "E164: Cannot go before first file"
+msgstr "E164: Đây là tập tin đầu tiên"
+
+msgid "E165: Cannot go beyond last file"
+msgstr "E165: Đây là tập tin cuối cùng"
+
+# TODO: Capitalise first word of message?
+msgid "E666: Compiler not supported: %s"
+msgstr "E666: trình biên dịch không được hỗ trợ: %s"
+
+#, c-format
+msgid "Searching for \"%s\" in \"%s\""
+msgstr "Tìm kiếm \"%s\" trong \"%s\""
+
+#, c-format
+msgid "Searching for \"%s\""
+msgstr "Tìm kiếm \"%s\""
+
+#, c-format
+msgid "not found in 'runtimepath': \"%s\""
+msgstr "không tìm thấy trong 'runtimepath': \"%s\""
+
+msgid "Source Vim script"
+msgstr "Thực hiện script của Vim"
+
+#, c-format
+msgid "Cannot source a directory: \"%s\""
+msgstr "Không thể thực hiện một thư mục: \"%s\""
+
+#, c-format
+msgid "could not source \"%s\""
+msgstr "không thực hiện được \"%s\""
+
+#, c-format
+msgid "line %ld: could not source \"%s\""
+msgstr "dòng %ld: không thực hiện được \"%s\""
+
+#, c-format
+msgid "sourcing \"%s\""
+msgstr "thực hiện \"%s\""
+
+#, c-format
+msgid "line %ld: sourcing \"%s\""
+msgstr "dòng %ld: thực hiện \"%s\""
+
+#, c-format
+msgid "finished sourcing %s"
+msgstr "thực hiện xong %s"
+
+msgid "W15: Warning: Wrong line separator, ^M may be missing"
+msgstr "W15: Cảnh báo: Ký tự phân cách dòng không đúng. Rất có thể thiếu ^M"
+
+msgid "E167: :scriptencoding used outside of a sourced file"
+msgstr "E167: Lệnh :scriptencoding sử dụng ngoài tập tin script"
+
+msgid "E168: :finish used outside of a sourced file"
+msgstr "E168: Lệnh :finish sử dụng ngoài tập tin script"
+
+#, c-format
+msgid "Page %d"
+msgstr "Trang %d"
+
+msgid "No text to be printed"
+msgstr "Không có gì để in"
+
+#, c-format
+msgid "Printing page %d (%d%%)"
+msgstr "In trang %d (%d%%)"
+
+#, c-format
+msgid " Copy %d of %d"
+msgstr " Sao chép %d của %d"
+
+#, c-format
+msgid "Printed: %s"
+msgstr "Đã in: %s"
+
+msgid "Printing aborted"
+msgstr "In bị dừng"
+
+msgid "E455: Error writing to PostScript output file"
+msgstr "E455: Lỗi ghi nhớ vào tập tin PostScript"
+
+#, c-format
+msgid "E624: Can't open file \"%s\""
+msgstr "E624: Không thể mở tập tin \"%s\""
+
+#, c-format
+msgid "E457: Can't read PostScript resource file \"%s\""
+msgstr "E457: Không thể đọc tập tin tài nguyên PostScript \"%s\""
+
+# TODO: Capitalise first word of message?
+msgid "E618: File \"%s\" is not a PostScript resource file"
+msgstr "E618: \"%s\" không phải là tập tin tài nguyên PostScript"
+
+# TODO: Capitalise first word of message?
+msgid "E619: File \"%s\" is not a supported PostScript resource file"
+msgstr "E619: \"%s\" không phải là tập tin tài nguyên PostScript được hỗ trợ"
+
+#, c-format
+msgid "E621: \"%s\" resource file has wrong version"
+msgstr "E621: tập tin tài nguyên \"%s\" có phiên bản không đúng"
+
+msgid "E324: Can't open PostScript output file"
+msgstr "E324: Không thể mở tập tin PostScript"
+
+#, c-format
+msgid "E456: Can't open file \"%s\""
+msgstr "E456: Không thể mở tập tin \"%s\""
+
+msgid "E456: Can't find PostScript resource file \"prolog.ps\""
+msgstr "E456: Không tìm thấy tập tin tài nguyên PostScript \"prolog.ps\""
+
+#, c-format
+msgid "E456: Can't find PostScript resource file \"%s.ps\""
+msgstr "E456: Không tìm thấy tập tin tài nguyên PostScript \"%s.ps\""
+
+#, c-format
+msgid "E620: Unable to convert from multi-byte to \"%s\" encoding"
+msgstr "E620: Không thể chuyển từ các ký tự nhiều byte thành bảng mã \"%s\""
+
+msgid "Sending to printer..."
+msgstr "Gửi tới máy in..."
+
+msgid "E365: Failed to print PostScript file"
+msgstr "E365: In tập tin PostScript không thành công"
+
+msgid "Print job sent."
+msgstr "Đã gửi công việc in."
+
+#, c-format
+msgid "Current %slanguage: \"%s\""
+msgstr "Ngôn ngữ %shiện thời: \"%s\""
+
+#, c-format
+msgid "E197: Cannot set language to \"%s\""
+msgstr "E197: Không thể thay đổi ngôn ngữ thành \"%s\""
+
 #, c-format
 msgid "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 msgstr "<%s>%s%s  %d,  Hex %02x,  Octal %03o"
 
-#: ../ex_cmds.c:145
 #, c-format
 msgid "> %d, Hex %04x, Octal %o"
 msgstr "> %d, Hex %04x, Octal %o"
 
-#: ../ex_cmds.c:146
 #, c-format
 msgid "> %d, Hex %08x, Octal %o"
 msgstr "> %d, Hex %08x, Octal %o"
 
-#: ../ex_cmds.c:684
 msgid "E134: Move lines into themselves"
 msgstr "E134: Di chuyển các dòng lên chính chúng"
 
-#: ../ex_cmds.c:747
 msgid "1 line moved"
 msgstr "Đã di chuyển 1 dòng"
 
-#: ../ex_cmds.c:749
 #, c-format
-msgid "%<PRId64> lines moved"
-msgstr "Đã di chuyển %<PRId64> dòng"
+msgid "%ld lines moved"
+msgstr "Đã di chuyển %ld dòng"
 
-#: ../ex_cmds.c:1175
 #, c-format
-msgid "%<PRId64> lines filtered"
-msgstr "Đã lọc %<PRId64> dòng"
+msgid "%ld lines filtered"
+msgstr "Đã lọc %ld dòng"
 
-#: ../ex_cmds.c:1194
 msgid "E135: *Filter* Autocommands must not change current buffer"
 msgstr "E135: Các lệnh tự động *Filter* không được thay đổi bộ đệm hiện thời"
 
-#: ../ex_cmds.c:1244
 msgid "[No write since last change]\n"
 msgstr "[Thay đổi chưa được ghi nhớ]\n"
 
-#: ../ex_cmds.c:1424
 #, c-format
 msgid "%sviminfo: %s in line: "
 msgstr "%sviminfo: %s trên dòng: "
 
-#: ../ex_cmds.c:1431
 msgid "E136: viminfo: Too many errors, skipping rest of file"
 msgstr "E136: viminfo: Quá nhiều lỗi, phần còn lại của tập tin sẽ được bỏ qua"
 
-#: ../ex_cmds.c:1458
 #, c-format
 msgid "Reading viminfo file \"%s\"%s%s%s"
 msgstr "Đọc tập tin viminfo \"%s\"%s%s%s"
 
-#: ../ex_cmds.c:1460
 msgid " info"
 msgstr " thông tin"
 
-#: ../ex_cmds.c:1461
 msgid " marks"
 msgstr " dấu hiệu"
 
-#: ../ex_cmds.c:1462
-#, fuzzy
-msgid " oldfiles"
-msgstr "Không có tập tin được tính đến"
-
-#: ../ex_cmds.c:1463
 msgid " FAILED"
 msgstr " KHÔNG THÀNH CÔNG"
 
-#. avoid a wait_return for this message, it's annoying
-#: ../ex_cmds.c:1541
 #, c-format
 msgid "E137: Viminfo file is not writable: %s"
 msgstr "E137: Thiếu quyền ghi lên tập tin viminfo: %s"
 
-#: ../ex_cmds.c:1626
 #, c-format
 msgid "E138: Can't write viminfo file %s!"
 msgstr "E138: Không thể ghi tập tin viminfo %s!"
 
-#: ../ex_cmds.c:1635
 #, c-format
 msgid "Writing viminfo file \"%s\""
 msgstr "Ghi tập tin viminfo \"%s\""
 
-#. Write the info:
-#: ../ex_cmds.c:1720
 #, c-format
 msgid "# This viminfo file was generated by Vim %s.\n"
 msgstr "# Tập tin viminfo này được tự động tạo bởi Vim %s.\n"
 
-#: ../ex_cmds.c:1722
 msgid ""
 "# You may edit it if you're careful!\n"
 "\n"
@@ -1158,137 +727,88 @@ msgstr ""
 "# Bạn có thể sửa tập tin này, nhưng hãy thận trọng!\n"
 "\n"
 
-#: ../ex_cmds.c:1723
 msgid "# Value of 'encoding' when this file was written\n"
 msgstr "# Giá trị của tùy chọn 'encoding' vào thời điểm ghi tập tin\n"
 
-#: ../ex_cmds.c:1800
 msgid "Illegal starting char"
 msgstr "Ký tự đầu tiên không cho phép"
 
-#: ../ex_cmds.c:2162
+msgid "E139: File is loaded in another buffer"
+msgstr "E139: Tập tin được nạp trong bộ đệm khác"
+
 msgid "Write partial file?"
 msgstr "Ghi nhớ một phần tập tin?"
 
-#: ../ex_cmds.c:2166
 msgid "E140: Use ! to write partial buffer"
 msgstr "E140: Sử dụng ! để ghi nhớ một phần bộ đệm"
 
-#: ../ex_cmds.c:2281
-#, fuzzy, c-format
-msgid "Overwrite existing file \"%s\"?"
+#, c-format
+msgid "Overwrite existing file \"%.*s\"?"
 msgstr "Ghi đè lên tập tin đã có \"%.*s\"?"
 
-#: ../ex_cmds.c:2317
 #, c-format
-msgid "Swap file \"%s\" exists, overwrite anyway?"
-msgstr ""
+msgid "E141: No file name for buffer %ld"
+msgstr "E141: Không có tên tập tin cho bộ đệm %ld"
 
-#: ../ex_cmds.c:2326
-#, fuzzy, c-format
-msgid "E768: Swap file exists: %s (:silent! overrides)"
-msgstr "E13: Tập tin đã tồn tại (thêm ! để ghi chèn)"
-
-#: ../ex_cmds.c:2381
-#, c-format
-msgid "E141: No file name for buffer %<PRId64>"
-msgstr "E141: Không có tên tập tin cho bộ đệm %<PRId64>"
-
-#: ../ex_cmds.c:2412
 msgid "E142: File not written: Writing is disabled by 'write' option"
 msgstr "E142: Tập tin chưa được ghi nhớ: Ghi nhớ bị tắt bởi tùy chọn 'write'"
 
-#: ../ex_cmds.c:2434
-#, fuzzy, c-format
+#, c-format
 msgid ""
-"'readonly' option is set for \"%s\".\n"
+"'readonly' option is set for \"%.*s\".\n"
 "Do you wish to write anyway?"
 msgstr ""
 "Tùy chọn 'readonly' được đặt cho \"%.*s\".\n"
 "Ghi nhớ bằng mọi giá?"
 
-#: ../ex_cmds.c:2439
-#, c-format
-msgid ""
-"File permissions of \"%s\" are read-only.\n"
-"It may still be possible to write it.\n"
-"Do you wish to try?"
-msgstr ""
+msgid "Edit File"
+msgstr "Soạn thảo tập tin"
 
-#: ../ex_cmds.c:2451
-#, fuzzy, c-format
-msgid "E505: \"%s\" is read-only (add ! to override)"
-msgstr "là tập tin chỉ đọc (thêm ! để ghi nhớ bằng mọi giá)"
-
-#: ../ex_cmds.c:3120
 #, c-format
 msgid "E143: Autocommands unexpectedly deleted new buffer %s"
 msgstr "E143: Các lệnh tự động xóa bộ đệm mới ngoài ý muốn %s"
 
-#: ../ex_cmds.c:3313
-msgid "E144: non-numeric argument to :z"
+# TODO: Capitalise first word of message?
+msgid "E144: Non-numeric argument to :z"
 msgstr "E144: Tham số của lệnh :z phải là số"
 
-#: ../ex_cmds.c:3498
+msgid "E145: Shell commands not allowed in rvim"
+msgstr "E145: Không cho phép sử dụng lệnh shell trong rvim."
+
 msgid "E146: Regular expressions can't be delimited by letters"
 msgstr "E146: Không thể phân cách biểu thức chính quy bằng chữ cái"
 
-#: ../ex_cmds.c:3964
 #, c-format
 msgid "replace with %s (y/n/a/q/l/^E/^Y)?"
 msgstr "thay thế bằng %s? (y/n/a/q/l/^E/^Y)"
 
-#: ../ex_cmds.c:4379
 msgid "(Interrupted) "
 msgstr "(bị dừng)"
 
-#: ../ex_cmds.c:4384
-#, fuzzy
-msgid "1 match"
-msgstr "; tương ứng "
-
-#: ../ex_cmds.c:4384
 msgid "1 substitution"
 msgstr "1 thay thế"
 
-#: ../ex_cmds.c:4387
-#, fuzzy, c-format
-msgid "%<PRId64> matches"
-msgstr "%<PRId64> thay đổi"
-
-#: ../ex_cmds.c:4388
 #, c-format
-msgid "%<PRId64> substitutions"
-msgstr "%<PRId64> thay thế"
+msgid "%ld substitutions"
+msgstr "%ld thay thế"
 
-#: ../ex_cmds.c:4392
 msgid " on 1 line"
 msgstr " trên 1 dòng"
 
-#: ../ex_cmds.c:4395
 #, c-format
-msgid " on %<PRId64> lines"
-msgstr " trên %<PRId64> dòng"
+msgid " on %ld lines"
+msgstr " trên %ld dòng"
 
-#: ../ex_cmds.c:4438
 msgid "E147: Cannot do :global recursive"
 msgstr "E147: Không thực hiện được lệnh :global đệ qui"
 
-#: ../ex_cmds.c:4467
 msgid "E148: Regular expression missing from global"
 msgstr "E148: Thiếu biểu thức chính quy trong lệnh :global"
 
-#: ../ex_cmds.c:4508
 #, c-format
 msgid "Pattern found in every line: %s"
 msgstr "Tìm thấy tương ứng trên mọi dòng: %s"
 
-#: ../ex_cmds.c:4510
-#, fuzzy, c-format
-msgid "Pattern not found: %s"
-msgstr "Không tìm thấy mẫu (pattern)"
-
-#: ../ex_cmds.c:4587
 msgid ""
 "\n"
 "# Last Substitute String:\n"
@@ -1298,342 +818,138 @@ msgstr ""
 "# Chuỗi thay thế cuối cùng:\n"
 "$"
 
-#: ../ex_cmds.c:4679
 msgid "E478: Don't panic!"
 msgstr "E478: Hãy bình tĩnh, đừng hoảng hốt!"
 
-#: ../ex_cmds.c:4717
 #, c-format
 msgid "E661: Sorry, no '%s' help for %s"
 msgstr "E661: Rất tiếc, không có trợ giúp '%s' cho %s"
 
-#: ../ex_cmds.c:4719
 #, c-format
 msgid "E149: Sorry, no help for %s"
 msgstr "E149: Rất tiếc không có trợ giúp cho %s"
 
-#: ../ex_cmds.c:4751
 #, c-format
 msgid "Sorry, help file \"%s\" not found"
 msgstr "Xin lỗi, không tìm thấy tập tin trợ giúp \"%s\""
 
-#: ../ex_cmds.c:5323
 #, c-format
 msgid "E150: Not a directory: %s"
 msgstr "E150: %s không phải là một thư mục"
 
-#: ../ex_cmds.c:5446
 #, c-format
 msgid "E152: Cannot open %s for writing"
 msgstr "E152: Không thể mở %s để ghi"
 
-#: ../ex_cmds.c:5471
 #, c-format
 msgid "E153: Unable to open %s for reading"
 msgstr "E153: Không thể mở %s để đọc"
 
-#: ../ex_cmds.c:5500
 #, c-format
 msgid "E670: Mix of help file encodings within a language: %s"
 msgstr ""
 "E670: Tập tin trợ giúp sử dụng nhiều bảng mã khác nhau cho một ngôn ngữ: %s"
 
-#: ../ex_cmds.c:5565
-#, fuzzy, c-format
-msgid "E154: Duplicate tag \"%s\" in file %s/%s"
+#, c-format
+msgid "E154: Duplicate tag \"%s\" in file %s"
 msgstr "E154: Thẻ ghi lặp lại \"%s\" trong tập tin %s"
 
-#: ../ex_cmds.c:5687
 #, c-format
 msgid "E160: Unknown sign command: %s"
 msgstr "E160: Câu lệnh ký hiệu không biết: %s"
 
-#: ../ex_cmds.c:5704
 msgid "E156: Missing sign name"
 msgstr "E156: Thiếu tên ký hiệu"
 
-#: ../ex_cmds.c:5746
 msgid "E612: Too many signs defined"
 msgstr "E612: Định nghĩa quá nhiều ký hiệu"
 
-#: ../ex_cmds.c:5813
 #, c-format
 msgid "E239: Invalid sign text: %s"
 msgstr "E239: Văn bản ký hiệu không thích hợp: %s"
 
-#: ../ex_cmds.c:5844 ../ex_cmds.c:6035
 #, c-format
 msgid "E155: Unknown sign: %s"
 msgstr "E155: Ký hiệu không biết: %s"
 
-#: ../ex_cmds.c:5877
 msgid "E159: Missing sign number"
 msgstr "E159: Thiếu số của ký hiệu"
 
-#: ../ex_cmds.c:5971
 #, c-format
 msgid "E158: Invalid buffer name: %s"
 msgstr "E158: Tên bộ đệm không đúng: %s"
 
-#: ../ex_cmds.c:6008
 #, c-format
-msgid "E157: Invalid sign ID: %<PRId64>"
-msgstr "E157: ID của ký hiệu không đúng: %<PRId64>"
+msgid "E157: Invalid sign ID: %ld"
+msgstr "E157: ID của ký hiệu không đúng: %ld"
 
-#: ../ex_cmds.c:6066
+msgid " (NOT FOUND)"
+msgstr " (KHÔNG TÌM THẤY)"
+
 msgid " (not supported)"
 msgstr " (không được hỗ trợ)"
 
-#: ../ex_cmds.c:6169
 msgid "[Deleted]"
 msgstr "[bị xóa]"
 
-#: ../ex_cmds2.c:139
-msgid "Entering Debug mode.  Type \"cont\" to continue."
-msgstr "Bật chế độ sửa lỗi (Debug). Gõ \"cont\" để tiếp tục."
-
-#: ../ex_cmds2.c:143 ../ex_docmd.c:759
-#, c-format
-msgid "line %<PRId64>: %s"
-msgstr "dòng %<PRId64>: %s"
-
-#: ../ex_cmds2.c:145
-#, c-format
-msgid "cmd: %s"
-msgstr "câu lệnh: %s"
-
-#: ../ex_cmds2.c:322
-#, c-format
-msgid "Breakpoint in \"%s%s\" line %<PRId64>"
-msgstr "Điểm dừng trên \"%s%s\" dòng %<PRId64>"
-
-#: ../ex_cmds2.c:581
-#, c-format
-msgid "E161: Breakpoint not found: %s"
-msgstr "E161: Không tìm thấy điểm dừng: %s"
-
-#: ../ex_cmds2.c:611
-msgid "No breakpoints defined"
-msgstr "Điểm dừng không được xác định"
-
-#: ../ex_cmds2.c:617
-#, c-format
-msgid "%3d  %s %s  line %<PRId64>"
-msgstr "%3d  %s %s dòng %<PRId64>"
-
-#: ../ex_cmds2.c:942
-msgid "E750: First use \":profile start {fname}\""
-msgstr ""
-
-#: ../ex_cmds2.c:1269
-#, fuzzy, c-format
-msgid "Save changes to \"%s\"?"
-msgstr "Ghi nhớ thay đổi vào \"%.*s\"?"
-
-#: ../ex_cmds2.c:1271 ../ex_docmd.c:8851
-msgid "Untitled"
-msgstr "Chưa đặt tên"
-
-#: ../ex_cmds2.c:1421
-#, c-format
-msgid "E162: No write since last change for buffer \"%s\""
-msgstr "E162: Thay đổi chưa được ghi nhớ trong bộ đệm \"%s\""
-
-#: ../ex_cmds2.c:1480
-msgid "Warning: Entered other buffer unexpectedly (check autocommands)"
-msgstr ""
-"Cảnh báo: Chuyển tới bộ đệm khác không theo ý muốn (hãy kiểm tra câu lệnh tự "
-"động)"
-
-#: ../ex_cmds2.c:1826
-msgid "E163: There is only one file to edit"
-msgstr "E163: Chỉ có một tập tin để soạn thảo"
-
-#: ../ex_cmds2.c:1828
-msgid "E164: Cannot go before first file"
-msgstr "E164: Đây là tập tin đầu tiên"
-
-#: ../ex_cmds2.c:1830
-msgid "E165: Cannot go beyond last file"
-msgstr "E165: Đây là tập tin cuối cùng"
-
-#: ../ex_cmds2.c:2175
-#, c-format
-msgid "E666: compiler not supported: %s"
-msgstr "E666: trình biên dịch không được hỗ trợ: %s"
-
-#: ../ex_cmds2.c:2257
-#, c-format
-msgid "Searching for \"%s\" in \"%s\""
-msgstr "Tìm kiếm \"%s\" trong \"%s\""
-
-#: ../ex_cmds2.c:2284
-#, c-format
-msgid "Searching for \"%s\""
-msgstr "Tìm kiếm \"%s\""
-
-#: ../ex_cmds2.c:2307
-#, c-format
-msgid "not found in 'runtimepath': \"%s\""
-msgstr "không tìm thấy trong 'runtimepath': \"%s\""
-
-#: ../ex_cmds2.c:2472
-#, c-format
-msgid "Cannot source a directory: \"%s\""
-msgstr "Không thể thực hiện một thư mục: \"%s\""
-
-#: ../ex_cmds2.c:2518
-#, c-format
-msgid "could not source \"%s\""
-msgstr "không thực hiện được \"%s\""
-
-#: ../ex_cmds2.c:2520
-#, c-format
-msgid "line %<PRId64>: could not source \"%s\""
-msgstr "dòng %<PRId64>: không thực hiện được \"%s\""
-
-#: ../ex_cmds2.c:2535
-#, c-format
-msgid "sourcing \"%s\""
-msgstr "thực hiện \"%s\""
-
-#: ../ex_cmds2.c:2537
-#, c-format
-msgid "line %<PRId64>: sourcing \"%s\""
-msgstr "dòng %<PRId64>: thực hiện \"%s\""
-
-#: ../ex_cmds2.c:2693
-#, c-format
-msgid "finished sourcing %s"
-msgstr "thực hiện xong %s"
-
-#: ../ex_cmds2.c:2765
-#, fuzzy
-msgid "modeline"
-msgstr "Thêm 1 dòng"
-
-#: ../ex_cmds2.c:2767
-#, fuzzy
-msgid "--cmd argument"
-msgstr " vim [các tham số] "
-
-#: ../ex_cmds2.c:2769
-#, fuzzy
-msgid "-c argument"
-msgstr " vim [các tham số] "
-
-#: ../ex_cmds2.c:2771
-msgid "environment variable"
-msgstr ""
-
-#: ../ex_cmds2.c:2773
-#, fuzzy
-msgid "error handler"
-msgstr "Lỗi và sự gián đoạn"
-
-#: ../ex_cmds2.c:3020
-msgid "W15: Warning: Wrong line separator, ^M may be missing"
-msgstr "W15: Cảnh báo: Ký tự phân cách dòng không đúng. Rất có thể thiếu ^M"
-
-#: ../ex_cmds2.c:3139
-msgid "E167: :scriptencoding used outside of a sourced file"
-msgstr "E167: Lệnh :scriptencoding sử dụng ngoài tập tin script"
-
-#: ../ex_cmds2.c:3166
-msgid "E168: :finish used outside of a sourced file"
-msgstr "E168: Lệnh :finish sử dụng ngoài tập tin script"
-
-#: ../ex_cmds2.c:3389
-#, c-format
-msgid "Current %slanguage: \"%s\""
-msgstr "Ngôn ngữ %shiện thời: \"%s\""
-
-#: ../ex_cmds2.c:3404
-#, c-format
-msgid "E197: Cannot set language to \"%s\""
-msgstr "E197: Không thể thay đổi ngôn ngữ thành \"%s\""
-
-#. don't redisplay the window
-#. don't wait for return
-#: ../ex_docmd.c:387
 msgid "Entering Ex mode.  Type \"visual\" to go to Normal mode."
 msgstr ""
 "Chuyển vào chế độ Ex. Để chuyển về chế độ Thông thường hãy gõ \"visual\""
 
-#: ../ex_docmd.c:428
 msgid "E501: At end-of-file"
 msgstr "E501: Ở cuối tập tin"
 
-#: ../ex_docmd.c:513
 msgid "E169: Command too recursive"
 msgstr "E169: Câu lệnh quá đệ quy"
 
-#: ../ex_docmd.c:1006
 #, c-format
 msgid "E605: Exception not caught: %s"
 msgstr "E605: Trường hợp đặc biệt không được xử lý: %s"
 
-#: ../ex_docmd.c:1085
 msgid "End of sourced file"
 msgstr "Kết thúc tập tin script"
 
-#: ../ex_docmd.c:1086
 msgid "End of function"
 msgstr "Kết thúc của hàm số"
 
-#: ../ex_docmd.c:1628
 msgid "E464: Ambiguous use of user-defined command"
 msgstr "E464: Sự sử dụng không rõ ràng câu lệnh do người dùng định nghĩa"
 
-#: ../ex_docmd.c:1638
 msgid "E492: Not an editor command"
 msgstr "E492: Không phải là câu lệnh của trình soạn thảo"
 
-#: ../ex_docmd.c:1729
 msgid "E493: Backwards range given"
 msgstr "E493: Đưa ra phạm vi ngược lại"
 
-#: ../ex_docmd.c:1733
 msgid "Backwards range given, OK to swap"
 msgstr "Đưa ra phạm vi ngược lại, thay đổi vị trí hai giới hạn"
 
-#. append
-#. typed wrong
-#: ../ex_docmd.c:1787
 msgid "E494: Use w or w>>"
 msgstr "E494: Hãy sử dụng w hoặc w>>"
 
-#: ../ex_docmd.c:3454
-msgid "E319: The command is not available in this version"
+msgid "E319: Sorry, the command is not available in this version"
 msgstr "E319: Xin lỗi, câu lệnh này không có trong phiên bản này"
 
-#: ../ex_docmd.c:3752
 msgid "E172: Only one file name allowed"
 msgstr "E172: Chỉ cho phép sử dụng một tên tập tin"
 
-#: ../ex_docmd.c:4238
 msgid "1 more file to edit.  Quit anyway?"
 msgstr "Còn 1 tập tin nữa cần soạn thảo. Thoát?"
 
-#: ../ex_docmd.c:4242
 #, c-format
 msgid "%d more files to edit.  Quit anyway?"
 msgstr "Còn %d tập tin nữa chưa soạn thảo. Thoát?"
 
-#: ../ex_docmd.c:4248
 msgid "E173: 1 more file to edit"
 msgstr "E173: 1 tập tin nữa chờ soạn thảo."
 
-#: ../ex_docmd.c:4250
 #, c-format
-msgid "E173: %<PRId64> more files to edit"
-msgstr "E173: %<PRId64> tập tin nữa chưa soạn thảo."
+msgid "E173: %ld more files to edit"
+msgstr "E173: %ld tập tin nữa chưa soạn thảo."
 
-#: ../ex_docmd.c:4320
 msgid "E174: Command already exists: add ! to replace it"
 msgstr "E174: Đã có câu lệnh: Thêm ! để thay thế"
 
-#: ../ex_docmd.c:4432
 msgid ""
 "\n"
 "    Name        Args Range Complete  Definition"
@@ -1641,352 +957,252 @@ msgstr ""
 "\n"
 "    Tên\t\tTham_số Phạm_vi Phần_phụ Định_nghĩa"
 
-#: ../ex_docmd.c:4516
 msgid "No user-defined commands found"
 msgstr "Không tìm thấy câu lệnh do người dùng định nghĩa"
 
-#: ../ex_docmd.c:4538
 msgid "E175: No attribute specified"
 msgstr "E175: Không có tham số được chỉ ra"
 
-#: ../ex_docmd.c:4583
 msgid "E176: Invalid number of arguments"
 msgstr "E176: Số lượng tham số không đúng"
 
-#: ../ex_docmd.c:4594
 msgid "E177: Count cannot be specified twice"
 msgstr "E177: Số đếm không thể được chỉ ra hai lần"
 
-#: ../ex_docmd.c:4603
 msgid "E178: Invalid default value for count"
 msgstr "E178: Giá trị của số đếm theo mặc định không đúng"
 
-#: ../ex_docmd.c:4625
-#, fuzzy
-msgid "E179: argument required for -complete"
+# TODO: Capitalise first word of message?
+msgid "E179: Argument required for complete"
 msgstr "E179: yêu cầu đưa ra tham số để kết thúc"
 
-#: ../ex_docmd.c:4635
-#, c-format
-msgid "E181: Invalid attribute: %s"
-msgstr "E181: Thuộc tính không đúng: %s"
-
-#: ../ex_docmd.c:4678
-msgid "E182: Invalid command name"
-msgstr "E182: Tên câu lệnh không đúng"
-
-#: ../ex_docmd.c:4691
-msgid "E183: User defined commands must start with an uppercase letter"
-msgstr "E183: Câu lệnh người dùng định nghĩa phải bắt đầu với một ký tự hoa"
-
-#: ../ex_docmd.c:4696
-#, fuzzy
-msgid "E841: Reserved name, cannot be used for user defined command"
-msgstr "E464: Sự sử dụng không rõ ràng câu lệnh do người dùng định nghĩa"
-
-#: ../ex_docmd.c:4751
-#, c-format
-msgid "E184: No such user-defined command: %s"
-msgstr "E184: Không có câu lệnh người dùng định nghĩa như vậy: %s"
-
-#: ../ex_docmd.c:5219
 #, c-format
 msgid "E180: Invalid complete value: %s"
 msgstr "E180: Giá trị phần phụ không đúng: %s"
 
-#: ../ex_docmd.c:5225
 msgid "E468: Completion argument only allowed for custom completion"
 msgstr ""
 "E468: Tham số tự động kết thúc chỉ cho phép sử dụng với phần phụ đặc biệt"
 
-#: ../ex_docmd.c:5231
 msgid "E467: Custom completion requires a function argument"
 msgstr "E467: Phần phục đặc biệt yêu cầu một tham số của hàm"
 
-#: ../ex_docmd.c:5257
-#, fuzzy, c-format
-msgid "E185: Cannot find color scheme '%s'"
+#, c-format
+msgid "E181: Invalid attribute: %s"
+msgstr "E181: Thuộc tính không đúng: %s"
+
+msgid "E182: Invalid command name"
+msgstr "E182: Tên câu lệnh không đúng"
+
+msgid "E183: User defined commands must start with an uppercase letter"
+msgstr "E183: Câu lệnh người dùng định nghĩa phải bắt đầu với một ký tự hoa"
+
+#, c-format
+msgid "E184: No such user-defined command: %s"
+msgstr "E184: Không có câu lệnh người dùng định nghĩa như vậy: %s"
+
+#, c-format
+msgid "E185: Cannot find color scheme %s"
 msgstr "E185: Không tin thấy sơ đồ màu sắc %s"
 
-#: ../ex_docmd.c:5263
 msgid "Greetings, Vim user!"
 msgstr "Xin chào người dùng Vim!"
 
-#: ../ex_docmd.c:5431
-#, fuzzy
-msgid "E784: Cannot close last tab page"
-msgstr "E444: Không được đóng cửa sổ cuối cùng"
+msgid "Edit File in new window"
+msgstr "Soạn thảo tập tin trong cửa sổ mới"
 
-#: ../ex_docmd.c:5462
-#, fuzzy
-msgid "Already only one tab page"
-msgstr "Chỉ có một cửa sổ"
-
-#: ../ex_docmd.c:6004
-#, fuzzy, c-format
-msgid "Tab page %d"
-msgstr "Trang %d"
-
-#: ../ex_docmd.c:6295
 msgid "No swap file"
 msgstr "Không có tập tin swap"
 
-#: ../ex_docmd.c:6478
-#, fuzzy
-msgid "E747: Cannot change directory, buffer is modified (add ! to override)"
-msgstr ""
-"E509: Không tạo được tập tin lưu trữ (thêm ! để bỏ qua việc kiểm tra lại)"
+msgid "Append File"
+msgstr "Thêm tập tin"
 
-#: ../ex_docmd.c:6485
 msgid "E186: No previous directory"
 msgstr "E186: Không có thư mục trước"
 
-#: ../ex_docmd.c:6530
 msgid "E187: Unknown"
 msgstr "E187: Không rõ"
 
-#: ../ex_docmd.c:6610
 msgid "E465: :winsize requires two number arguments"
 msgstr "E465: câu lệnh :winsize yêu cầu hai tham số bằng số"
 
-#: ../ex_docmd.c:6655
+#, c-format
+msgid "Window position: X %d, Y %d"
+msgstr "Vị trí cửa sổ: X %d, Y %d"
+
 msgid "E188: Obtaining window position not implemented for this platform"
 msgstr "E188: Trên hệ thống này việc xác định vị trí cửa sổ không làm việc"
 
-#: ../ex_docmd.c:6662
 msgid "E466: :winpos requires two number arguments"
 msgstr "E466: câu lệnh :winpos yêu câu hai tham số bằng số"
 
-#: ../ex_docmd.c:7241
-#, fuzzy, c-format
-msgid "E739: Cannot create directory: %s"
-msgstr "Không thể thực hiện một thư mục: \"%s\""
+msgid "Save Redirection"
+msgstr "Chuyển hướng ghi nhớ"
 
-#: ../ex_docmd.c:7268
+msgid "Save View"
+msgstr "Ghi nhớ vẻ ngoài"
+
+msgid "Save Session"
+msgstr "Ghi nhớ buổi làm việc"
+
+msgid "Save Setup"
+msgstr "Ghi nhớ cấu hình"
+
 #, c-format
 msgid "E189: \"%s\" exists (add ! to override)"
 msgstr "E189: \"%s\" đã có (thêm !, để ghi đè)"
 
-#: ../ex_docmd.c:7273
 #, c-format
 msgid "E190: Cannot open \"%s\" for writing"
 msgstr "E190: Không mở được \"%s\" để ghi nhớ"
 
-#. set mark
-#: ../ex_docmd.c:7294
 msgid "E191: Argument must be a letter or forward/backward quote"
 msgstr "E191: Tham số phải là một chữ cái hoặc dấu ngoặc thẳng/ngược"
 
-#: ../ex_docmd.c:7333
 msgid "E192: Recursive use of :normal too deep"
 msgstr "E192: Sử dụng đệ quy lệnh :normal quá sâu"
 
-#: ../ex_docmd.c:7807
 msgid "E194: No alternate file name to substitute for '#'"
 msgstr "E194: Không có tên tập tin tương đương để thay thế '#'"
 
-#: ../ex_docmd.c:7841
-msgid "E495: no autocommand file name to substitute for \"<afile>\""
+# TODO: Capitalise first word of message?
+msgid "E495: No autocommand file name to substitute for \"<afile>\""
 msgstr "E495: Không có tên tập tin câu lệnh tự động để thay thế \"<afile>\""
 
-#: ../ex_docmd.c:7850
-msgid "E496: no autocommand buffer number to substitute for \"<abuf>\""
+# TODO: Capitalise first word of message?
+msgid "E496: No autocommand buffer number to substitute for \"<abuf>\""
 msgstr ""
 "E496: Không có số thứ tự bộ đệm câu lệnh tự động để thay thế \"<abuf>\""
 
-#: ../ex_docmd.c:7861
-msgid "E497: no autocommand match name to substitute for \"<amatch>\""
+# TODO: Capitalise first word of message?
+msgid "E497: No autocommand match name to substitute for \"<amatch>\""
 msgstr "E497: Không có tên tương ứng câu lệnh tự động để thay thế \"<amatch>\""
 
-#: ../ex_docmd.c:7870
-msgid "E498: no :source file name to substitute for \"<sfile>\""
+# TODO: Capitalise first word of message?
+msgid "E498: No :source file name to substitute for \"<sfile>\""
 msgstr "E498: không có tên tập tin :source để thay thế \"<sfile>\""
 
-#: ../ex_docmd.c:7876
-#, fuzzy
-msgid "E842: no line number to use for \"<slnum>\""
-msgstr "E498: không có tên tập tin :source để thay thế \"<sfile>\""
-
-#: ../ex_docmd.c:7903
-#, fuzzy, c-format
+#, no-c-format
 msgid "E499: Empty file name for '%' or '#', only works with \":p:h\""
 msgstr "E499: Tên tập tin rỗng cho '%' hoặc '#', chỉ làm việc với \":p:h\""
 
-#: ../ex_docmd.c:7905
 msgid "E500: Evaluates to an empty string"
 msgstr "E500: Kết quả của biểu thức là một chuỗi rỗng"
 
-#: ../ex_docmd.c:8838
 msgid "E195: Cannot open viminfo file for reading"
 msgstr "E195: Không thể mở tập tin viminfo để đọc"
 
-#: ../ex_eval.c:464
+msgid "E196: No digraphs in this version"
+msgstr "E196: Trong phiên bản này chữ ghép không được hỗ trợ"
+
 msgid "E608: Cannot :throw exceptions with 'Vim' prefix"
 msgstr ""
 "E608: Không thể thực hiện lệnh :throw cho những ngoại lệ với tiền tố 'Vim'"
 
-#. always scroll up, don't overwrite
-#: ../ex_eval.c:496
 #, c-format
 msgid "Exception thrown: %s"
 msgstr "Trường hợp ngoại lệ: %s"
 
-#: ../ex_eval.c:545
 #, c-format
 msgid "Exception finished: %s"
 msgstr "Kết thúc việc xử lý trường hợp ngoại lệ: %s"
 
-#: ../ex_eval.c:546
 #, c-format
 msgid "Exception discarded: %s"
 msgstr "Trường hợp ngoại lệ bị bỏ qua: %s"
 
-#: ../ex_eval.c:588 ../ex_eval.c:634
 #, c-format
-msgid "%s, line %<PRId64>"
-msgstr "%s, dòng %<PRId64>"
+msgid "%s, line %ld"
+msgstr "%s, dòng %ld"
 
-#. always scroll up, don't overwrite
-#: ../ex_eval.c:608
 #, c-format
 msgid "Exception caught: %s"
 msgstr "Xử lý trường hợp ngoại lệ: %s"
 
-#: ../ex_eval.c:676
 #, c-format
 msgid "%s made pending"
 msgstr "%s thực hiện việc chờ đợi"
 
-#: ../ex_eval.c:679
 #, c-format
 msgid "%s resumed"
 msgstr "%s được phục hồi lại"
 
-#: ../ex_eval.c:683
 #, c-format
 msgid "%s discarded"
 msgstr "%s bị bỏ qua"
 
-#: ../ex_eval.c:708
 msgid "Exception"
 msgstr "Trường hợp ngoại lệ"
 
-#: ../ex_eval.c:713
 msgid "Error and interrupt"
 msgstr "Lỗi và sự gián đoạn"
 
-#: ../ex_eval.c:715
 msgid "Error"
 msgstr "Lỗi"
 
-#. if (pending & CSTP_INTERRUPT)
-#: ../ex_eval.c:717
 msgid "Interrupt"
 msgstr "Sự gián đoạn"
 
-#: ../ex_eval.c:795
+# TODO: Capitalise first word of message?
 msgid "E579: :if nesting too deep"
 msgstr "E579: :if xếp lồng vào nhau quá sâu"
 
-#: ../ex_eval.c:830
 msgid "E580: :endif without :if"
 msgstr "E580: :endif không có :if"
 
-#: ../ex_eval.c:873
 msgid "E581: :else without :if"
 msgstr "E581: :else không có :if"
 
-#: ../ex_eval.c:876
 msgid "E582: :elseif without :if"
 msgstr "E582: :elseif không có :if"
 
-#: ../ex_eval.c:880
-msgid "E583: multiple :else"
+# TODO: Capitalise first word of message?
+msgid "E583: Multiple :else"
 msgstr "E583: phát hiện vài :else"
 
-#: ../ex_eval.c:883
 msgid "E584: :elseif after :else"
 msgstr "E584: :elseif sau :else"
 
-#: ../ex_eval.c:941
-#, fuzzy
-msgid "E585: :while/:for nesting too deep"
+msgid "E585: :while nesting too deep"
 msgstr "E585: :while xếp lồng vào nhau quá sâu"
 
-#: ../ex_eval.c:1028
-#, fuzzy
-msgid "E586: :continue without :while or :for"
+msgid "E586: :continue without :while"
 msgstr "E586: :continue không có :while"
 
-#: ../ex_eval.c:1061
-#, fuzzy
-msgid "E587: :break without :while or :for"
+msgid "E587: :break without :while"
 msgstr "E587: :break không có :while"
 
-#: ../ex_eval.c:1102
-#, fuzzy
-msgid "E732: Using :endfor with :while"
-msgstr "E170: Thiếu câu lệnh :endwhile"
-
-#: ../ex_eval.c:1104
-#, fuzzy
-msgid "E733: Using :endwhile with :for"
-msgstr "E170: Thiếu câu lệnh :endwhile"
-
-#: ../ex_eval.c:1247
 msgid "E601: :try nesting too deep"
 msgstr "E601: :try xếp lồng vào nhau quá sâu"
 
-#: ../ex_eval.c:1317
 msgid "E603: :catch without :try"
 msgstr "E603: :catch không có :try"
 
-#. Give up for a ":catch" after ":finally" and ignore it.
-#. * Just parse.
-#: ../ex_eval.c:1332
 msgid "E604: :catch after :finally"
 msgstr "E604: :catch đứng sau :finally"
 
-#: ../ex_eval.c:1451
 msgid "E606: :finally without :try"
 msgstr "E606: :finally không có :try"
 
-#. Give up for a multiple ":finally" and ignore it.
-#: ../ex_eval.c:1467
-msgid "E607: multiple :finally"
+# TODO: Capitalise first word of message?
+msgid "E607: Multiple :finally"
 msgstr "E607: phát hiện vài :finally"
 
-#: ../ex_eval.c:1571
 msgid "E602: :endtry without :try"
 msgstr "E602: :endtry không có :try"
 
-#: ../ex_eval.c:2026
 msgid "E193: :endfunction not inside a function"
 msgstr "E193: lệnh :endfunction chỉ được sử dụng trong một hàm số"
 
-#: ../ex_getln.c:1643
-#, fuzzy
-msgid "E788: Not allowed to edit another buffer now"
-msgstr "E48: Không cho phép trong hộp cát (sandbox)"
-
-#: ../ex_getln.c:1656
-#, fuzzy
-msgid "E811: Not allowed to change buffer information now"
-msgstr "E94: Không có bộ đệm tương ứng với %s"
-
-#: ../ex_getln.c:3178
 msgid "tagname"
 msgstr "tên thẻ ghi"
 
-#: ../ex_getln.c:3181
 msgid " kind file\n"
 msgstr " loại tập tin\n"
 
-#: ../ex_getln.c:4799
 msgid "'history' option is zero"
 msgstr "giá trị của tùy chọn 'history' bằng không"
 
-#: ../ex_getln.c:5046
 #, c-format
 msgid ""
 "\n"
@@ -1995,312 +1211,201 @@ msgstr ""
 "\n"
 "# %s, Lịch sử (bắt đầu từ mới nhất tới cũ nhất):\n"
 
-#: ../ex_getln.c:5047
 msgid "Command Line"
 msgstr "Dòng lệnh"
 
-#: ../ex_getln.c:5048
 msgid "Search String"
 msgstr "Chuỗi tìm kiếm"
 
-#: ../ex_getln.c:5049
 msgid "Expression"
 msgstr "Biểu thức"
 
-#: ../ex_getln.c:5050
 msgid "Input Line"
 msgstr "Dòng nhập"
 
-#: ../ex_getln.c:5117
 msgid "E198: cmd_pchar beyond the command length"
 msgstr "E198: cmd_pchar lớn hơn chiều dài câu lệnh"
 
-#: ../ex_getln.c:5279
 msgid "E199: Active window or buffer deleted"
 msgstr "E199: Cửa sổ hoặc bộ đệm hoạt động bị xóa"
 
-#: ../file_search.c:203
-msgid "E854: path too long for completion"
-msgstr ""
-
-#: ../file_search.c:446
-#, c-format
-msgid ""
-"E343: Invalid path: '**[number]' must be at the end of the path or be "
-"followed by '%s'."
-msgstr ""
-"E343: Đường dẫn đưa ra không đúng: '**[số]' phải ở cuối đường dẫn hoặc theo "
-"sau bởi '%s'"
-
-#: ../file_search.c:1505
-#, c-format
-msgid "E344: Can't find directory \"%s\" in cdpath"
-msgstr "E344: Không tìm thấy thư mục \"%s\" để chuyển thư mục"
-
-#: ../file_search.c:1508
-#, c-format
-msgid "E345: Can't find file \"%s\" in path"
-msgstr "E345: Không tìm thấy tập tin \"%s\" trong đường dẫn"
-
-#: ../file_search.c:1512
-#, c-format
-msgid "E346: No more directory \"%s\" found in cdpath"
-msgstr "E346: Trong đường dẫn thay đổi thư mục không còn có thư mục \"%s\" nữa"
-
-#: ../file_search.c:1515
-#, c-format
-msgid "E347: No more file \"%s\" found in path"
-msgstr "E347: Trong đường dẫn path không còn có tập tin \"%s\" nữa"
-
-#: ../fileio.c:137
-#, fuzzy
-msgid "E812: Autocommands changed buffer or buffer name"
-msgstr "E135: Các lệnh tự động *Filter* không được thay đổi bộ đệm hiện thời"
-
-#: ../fileio.c:368
 msgid "Illegal file name"
 msgstr "Tên tập tin không cho phép"
 
-#: ../fileio.c:395 ../fileio.c:476 ../fileio.c:2543 ../fileio.c:2578
 msgid "is a directory"
 msgstr "là một thư mục"
 
-#: ../fileio.c:397
 msgid "is not a file"
 msgstr "không phải là một tập tin"
 
-#: ../fileio.c:508 ../fileio.c:3522
 msgid "[New File]"
 msgstr "[Tập tin mới]"
 
-#: ../fileio.c:511
-msgid "[New DIRECTORY]"
-msgstr ""
-
-#: ../fileio.c:529 ../fileio.c:532
-msgid "[File too big]"
-msgstr ""
-
-#: ../fileio.c:534
 msgid "[Permission Denied]"
 msgstr "[Truy cập bị từ chối]"
 
-#: ../fileio.c:653
 msgid "E200: *ReadPre autocommands made the file unreadable"
 msgstr ""
 "E200: Câu lệnh tự động *ReadPre làm cho tập tin trở thành không thể đọc"
 
-#: ../fileio.c:655
 msgid "E201: *ReadPre autocommands must not change current buffer"
 msgstr "E201: Câu lệnh tự động *ReadPre không được thay đổi bộ đệm hoạt động"
 
-#: ../fileio.c:672
-msgid "Nvim: Reading from stdin...\n"
+msgid "Vim: Reading from stdin...\n"
 msgstr "Vim: Đọc từ đầu vào tiêu chuẩn stdin...\n"
 
-#. Re-opening the original file failed!
-#: ../fileio.c:909
+msgid "Reading from stdin..."
+msgstr "Đọc từ đầu vào tiêu chuẩn stdin..."
+
 msgid "E202: Conversion made file unreadable!"
 msgstr "E202: Sự biến đổi làm cho tập tin trở thành không thể đọc!"
 
-#. fifo or socket
-#: ../fileio.c:1782
 msgid "[fifo/socket]"
 msgstr "[fifo/socket]"
 
-#. fifo
-#: ../fileio.c:1788
 msgid "[fifo]"
 msgstr "[fifo]"
 
-#. or socket
-#: ../fileio.c:1794
 msgid "[socket]"
 msgstr "[socket]"
 
-#. or character special
-#: ../fileio.c:1801
-#, fuzzy
-msgid "[character special]"
-msgstr "1 ký tự"
+msgid "[RO]"
+msgstr "[Chỉ đọc]"
 
-#: ../fileio.c:1815
 msgid "[CR missing]"
 msgstr "[thiếu ký tự CR]"
 
-#: ../fileio.c:1819
+msgid "[NL found]"
+msgstr "[tìm thấy ký tự NL]"
+
 msgid "[long lines split]"
 msgstr "[dòng dài được chia nhỏ]"
 
-#: ../fileio.c:1823 ../fileio.c:3512
 msgid "[NOT converted]"
 msgstr "[KHÔNG được chuyển đổi]"
 
-#: ../fileio.c:1826 ../fileio.c:3515
 msgid "[converted]"
 msgstr "[đã chuyển bảng mã]"
 
-#: ../fileio.c:1831
-#, fuzzy, c-format
-msgid "[CONVERSION ERROR in line %<PRId64>]"
-msgstr "[BYTE KHÔNG CHO PHÉP trên dòng %<PRId64>]"
+msgid "[crypted]"
+msgstr "[đã mã hóa]"
 
-#: ../fileio.c:1835
+msgid "[CONVERSION ERROR]"
+msgstr "[LỖI CHUYỂN BẢNG MÃ]"
+
 #, c-format
-msgid "[ILLEGAL BYTE in line %<PRId64>]"
-msgstr "[BYTE KHÔNG CHO PHÉP trên dòng %<PRId64>]"
+msgid "[ILLEGAL BYTE in line %ld]"
+msgstr "[BYTE KHÔNG CHO PHÉP trên dòng %ld]"
 
-#: ../fileio.c:1838
 msgid "[READ ERRORS]"
 msgstr "[LỖI ĐỌC]"
 
-#: ../fileio.c:2104
 msgid "Can't find temp file for conversion"
 msgstr "Không tìm thấy tập tin tạm thời (temp) để chuyển bảng mã"
 
-#: ../fileio.c:2110
 msgid "Conversion with 'charconvert' failed"
 msgstr "Chuyển đổi nhờ 'charconvert' không được thực hiện"
 
-#: ../fileio.c:2113
 msgid "can't read output of 'charconvert'"
 msgstr "không đọc được đầu ra của 'charconvert'"
 
-#: ../fileio.c:2437
-#, fuzzy
-msgid "E676: No matching autocommands for acwrite buffer"
-msgstr "Không có câu lệnh tự động tương ứng"
-
-#: ../fileio.c:2466
 msgid "E203: Autocommands deleted or unloaded buffer to be written"
 msgstr "E203: Câu lệnh tự động đã xóa hoặc bỏ nạp bộ đệm cần ghi nhớ"
 
-#: ../fileio.c:2486
 msgid "E204: Autocommand changed number of lines in unexpected way"
 msgstr "E204: Câu lệnh tự động đã thay đổ số dòng theo cách không mong muốn"
 
-#: ../fileio.c:2548 ../fileio.c:2565
+msgid "NetBeans disallows writes of unmodified buffers"
+msgstr "NetBeans không cho phép ghi nhớ bộ đệm chưa có thay đổi nào"
+
+msgid "Partial writes disallowed for NetBeans buffers"
+msgstr "Ghi nhớ một phần bộ đệm NetBeans không được cho phép"
+
 msgid "is not a file or writable device"
 msgstr "không phải là một tập tin thay một thiết bị có thể ghi nhớ"
 
-#: ../fileio.c:2601
 msgid "is read-only (add ! to override)"
 msgstr "là tập tin chỉ đọc (thêm ! để ghi nhớ bằng mọi giá)"
 
-#: ../fileio.c:2886
 msgid "E506: Can't write to backup file (add ! to override)"
 msgstr ""
 "E506: Không thể ghi nhớ vào tập tin lưu trữ (thêm ! để ghi nhớ bằng mọi giá"
 
-#: ../fileio.c:2898
 msgid "E507: Close error for backup file (add ! to override)"
 msgstr "E507: Lỗi đóng tập tin lưu trữ (thêm ! để bỏ qua việc kiểm tra lại)"
 
-#: ../fileio.c:2901
 msgid "E508: Can't read file for backup (add ! to override)"
 msgstr ""
 "E508: Không đọc được tập tin lưu trữ (thêm ! để bỏ qua việc kiểm tra lại)"
 
-#: ../fileio.c:2923
 msgid "E509: Cannot create backup file (add ! to override)"
 msgstr ""
 "E509: Không tạo được tập tin lưu trữ (thêm ! để bỏ qua việc kiểm tra lại)"
 
-#: ../fileio.c:3008
 msgid "E510: Can't make backup file (add ! to override)"
 msgstr ""
 "E510: Không tạo được tập tin lưu trữ (thêm ! để bỏ qua việc kiểm tra lại)"
 
-#. Can't write without a tempfile!
-#: ../fileio.c:3121
 msgid "E214: Can't find temp file for writing"
 msgstr "E214: Không tìm thấy tập tin tạm thời (temp) để ghi nhớ"
 
-#: ../fileio.c:3134
 msgid "E213: Cannot convert (add ! to write without conversion)"
 msgstr ""
 "E213: Không thể chuyển đổi bảng mã (thêm ! để ghi nhớ mà không chuyển đổi)"
 
-#: ../fileio.c:3169
 msgid "E166: Can't open linked file for writing"
 msgstr "E166: Không thể mở tập tin liên kết để ghi nhớ"
 
-#: ../fileio.c:3173
 msgid "E212: Can't open file for writing"
 msgstr "E212: Không thể mở tập tin để ghi nhớ"
 
-#: ../fileio.c:3363
 msgid "E667: Fsync failed"
 msgstr "E667: Không thực hiện thành công hàm số fsync()"
 
-#: ../fileio.c:3398
 msgid "E512: Close failed"
 msgstr "E512: Thao tác đóng không thành công"
 
-#: ../fileio.c:3436
-#, fuzzy
-msgid "E513: write error, conversion failed (make 'fenc' empty to override)"
+# TODO: Capitalise first word of message?
+msgid "E513: Write error, conversion failed"
 msgstr "E513: Lỗi ghi nhớ, biến đổi không thành công"
 
-#: ../fileio.c:3441
-#, c-format
-msgid ""
-"E513: write error, conversion failed in line %<PRId64> (make 'fenc' empty to "
-"override)"
-msgstr ""
-
-#: ../fileio.c:3448
-msgid "E514: write error (file system full?)"
+# TODO: Capitalise first word of message?
+msgid "E514: Write error (file system full?)"
 msgstr "E514: lỗi ghi nhớ (không còn chỗ trống?)"
 
-#: ../fileio.c:3506
 msgid " CONVERSION ERROR"
 msgstr " LỖI BIẾN ĐỔI"
 
-#: ../fileio.c:3509
-#, fuzzy, c-format
-msgid " in line %<PRId64>;"
-msgstr "dòng %<PRId64>"
-
-#: ../fileio.c:3519
 msgid "[Device]"
 msgstr "[Thiết bị]"
 
-#: ../fileio.c:3522
 msgid "[New]"
 msgstr "[Mới]"
 
-#: ../fileio.c:3535
 msgid " [a]"
 msgstr " [a]"
 
-#: ../fileio.c:3535
 msgid " appended"
 msgstr " đã thêm"
 
-#: ../fileio.c:3537
 msgid " [w]"
 msgstr " [w]"
 
-#: ../fileio.c:3537
 msgid " written"
 msgstr " đã ghi"
 
-#: ../fileio.c:3579
 msgid "E205: Patchmode: can't save original file"
 msgstr "E205: Chế độ vá lỗi (patch): không thể ghi nhớ tập tin gốc"
 
-#: ../fileio.c:3602
-msgid "E206: patchmode: can't touch empty original file"
+# TODO: Capitalise first word of message?
+msgid "E206: Patchmode: can't touch empty original file"
 msgstr ""
 "E206: Chế độ vá lỗi (patch): không thể thay đổi tham số của tập tin gốc "
 "trống rỗng"
 
-#: ../fileio.c:3616
 msgid "E207: Can't delete backup file"
 msgstr "E207: Không thể xóa tập tin lưu trữ (backup)"
 
-#: ../fileio.c:3672
 msgid ""
 "\n"
 "WARNING: Original file may be lost or damaged\n"
@@ -2308,97 +1413,73 @@ msgstr ""
 "\n"
 "CẢNH BÁO: Tập tin gốc có thể bị mất hoặc bị hỏng\n"
 
-#: ../fileio.c:3675
 msgid "don't quit the editor until the file is successfully written!"
 msgstr ""
 "đừng thoát khởi trình soạn thảo, khi tập tin còn chưa được ghi nhớ thành cồng"
 
-#: ../fileio.c:3795
 msgid "[dos]"
 msgstr "[dos]"
 
-#: ../fileio.c:3795
 msgid "[dos format]"
 msgstr "[định dạng dos]"
 
-#: ../fileio.c:3801
 msgid "[mac]"
 msgstr "[mac]"
 
-#: ../fileio.c:3801
 msgid "[mac format]"
 msgstr "[định dạng mac]"
 
-#: ../fileio.c:3807
 msgid "[unix]"
 msgstr "[unix]"
 
-#: ../fileio.c:3807
 msgid "[unix format]"
 msgstr "[định dạng unix]"
 
-#: ../fileio.c:3831
 msgid "1 line, "
 msgstr "1 dòng, "
 
-#: ../fileio.c:3833
 #, c-format
-msgid "%<PRId64> lines, "
-msgstr "%<PRId64> dòng, "
+msgid "%ld lines, "
+msgstr "%ld dòng, "
 
-#: ../fileio.c:3836
 msgid "1 character"
 msgstr "1 ký tự"
 
-#: ../fileio.c:3838
 #, c-format
-msgid "%<PRId64> characters"
-msgstr "%<PRId64> ký tự"
+msgid "%ld characters"
+msgstr "%ld ký tự"
 
-#: ../fileio.c:3849
 msgid "[noeol]"
 msgstr "[noeol]"
 
-#: ../fileio.c:3849
 msgid "[Incomplete last line]"
 msgstr "[Dòng cuối cùng không đầy đủ]"
 
-#. don't overwrite messages here
-#. must give this prompt
-#. don't use emsg() here, don't want to flush the buffers
-#: ../fileio.c:3865
 msgid "WARNING: The file has been changed since reading it!!!"
 msgstr "CẢNH BÁO: Tập tin đã thay đổi so với thời điểm đọc!!!"
 
-#: ../fileio.c:3867
 msgid "Do you really want to write to it"
 msgstr "Bạn có chắc muốn ghi nhớ vào tập tin này"
 
-#: ../fileio.c:4648
 #, c-format
 msgid "E208: Error writing to \"%s\""
 msgstr "E208: Lỗi ghi nhớ vào \"%s\""
 
-#: ../fileio.c:4655
 #, c-format
 msgid "E209: Error closing \"%s\""
 msgstr "E209: Lỗi đóng \"%s\""
 
-#: ../fileio.c:4657
 #, c-format
 msgid "E210: Error reading \"%s\""
 msgstr "E210: Lỗi đọc \"%s\""
 
-#: ../fileio.c:4883
 msgid "E246: FileChangedShell autocommand deleted buffer"
 msgstr "E246: Bộ đệm bị xóa khi thực hiện câu lệnh tự động FileChangedShell"
 
-#: ../fileio.c:4894
-#, fuzzy, c-format
-msgid "E211: File \"%s\" no longer available"
+#, c-format
+msgid "E211: Warning: File \"%s\" no longer available"
 msgstr "E211: Cảnh báo: Tập tin \"%s\" không còn truy cập được nữa"
 
-#: ../fileio.c:4906
 #, c-format
 msgid ""
 "W12: Warning: File \"%s\" has changed and the buffer was changed in Vim as "
@@ -2407,44 +1488,28 @@ msgstr ""
 "W12: Cảnh báo: Tập tin \"%s\" và bộ đệm Vim đã thay đổi không phụ thuộc vào "
 "nhau"
 
-#: ../fileio.c:4907
-#, fuzzy
-msgid "See \":help W12\" for more info."
-msgstr "Hãy xem thông tin chi tiết trong \":help W11\"."
-
-#: ../fileio.c:4910
 #, c-format
 msgid "W11: Warning: File \"%s\" has changed since editing started"
 msgstr ""
 "W11: Cảnh báo: Tập tin \"%s\" đã thay đổi sau khi việc soạn thảo bắt đầu"
 
-#: ../fileio.c:4911
-msgid "See \":help W11\" for more info."
-msgstr "Hãy xem thông tin chi tiết trong \":help W11\"."
-
-#: ../fileio.c:4914
 #, c-format
 msgid "W16: Warning: Mode of file \"%s\" has changed since editing started"
 msgstr ""
 "W16: Cảnh báo: chế độ truy cập tới tập tin \"%s\" đã thay đổi sau khi bắt "
 "đầu soạn thảo"
 
-#: ../fileio.c:4915
-#, fuzzy
-msgid "See \":help W16\" for more info."
-msgstr "Hãy xem thông tin chi tiết trong \":help W11\"."
-
-#: ../fileio.c:4927
 #, c-format
 msgid "W13: Warning: File \"%s\" has been created after editing started"
 msgstr ""
 "W13: Cảnh báo: tập tin \"%s\" được tạo ra sau khi việc soạn thảo bắt đầu"
 
-#: ../fileio.c:4947
+msgid "See \":help W11\" for more info."
+msgstr "Hãy xem thông tin chi tiết trong \":help W11\"."
+
 msgid "Warning"
 msgstr "Cảnh báo"
 
-#: ../fileio.c:4948
 msgid ""
 "&OK\n"
 "&Load File"
@@ -2452,48 +1517,33 @@ msgstr ""
 "&OK\n"
 "&Nạp tập tin"
 
-#: ../fileio.c:5065
 #, c-format
 msgid "E462: Could not prepare for reloading \"%s\""
 msgstr "E462: Không thể chuẩn bị để nạp lại \"%s\""
 
-#: ../fileio.c:5078
 #, c-format
 msgid "E321: Could not reload \"%s\""
 msgstr "E321: Không thể nạp lại \"%s\""
 
-#: ../fileio.c:5601
 msgid "--Deleted--"
 msgstr "--Bị xóa--"
 
-#: ../fileio.c:5732
-#, c-format
-msgid "auto-removing autocommand: %s <buffer=%d>"
-msgstr ""
-
-#. the group doesn't exist
-#: ../fileio.c:5772
 #, c-format
 msgid "E367: No such group: \"%s\""
 msgstr "E367: Nhóm \"%s\" không tồn tại"
 
-#: ../fileio.c:5897
 #, c-format
 msgid "E215: Illegal character after *: %s"
 msgstr "E215: Ký tự không cho phép sau *: %s"
 
-#: ../fileio.c:5905
 #, c-format
 msgid "E216: No such event: %s"
 msgstr "E216: Sự kiện không có thật: %s"
 
-#: ../fileio.c:5907
 #, c-format
 msgid "E216: No such group or event: %s"
 msgstr "E216: Nhóm hoặc sự kiện không có thật: %s"
 
-#. Highlight title
-#: ../fileio.c:6090
 msgid ""
 "\n"
 "--- Autocommands ---"
@@ -2501,1717 +1551,132 @@ msgstr ""
 "\n"
 "--- Câu lệnh tự động ---"
 
-#: ../fileio.c:6293
-#, fuzzy, c-format
-msgid "E680: <buffer=%d>: invalid buffer number "
-msgstr "số của bộ đệm không đúng"
-
-#: ../fileio.c:6370
 msgid "E217: Can't execute autocommands for ALL events"
 msgstr "E217: Không thể thực hiện câu lệnh tự động cho MỌI sự kiện"
 
-#: ../fileio.c:6393
 msgid "No matching autocommands"
 msgstr "Không có câu lệnh tự động tương ứng"
 
-#: ../fileio.c:6831
-msgid "E218: autocommand nesting too deep"
+# TODO: Capitalise first word of message?
+msgid "E218: Autocommand nesting too deep"
 msgstr "E218: câu lệnh tự động xếp lồng vào nhau quá xâu"
 
-#: ../fileio.c:7143
 #, c-format
 msgid "%s Autocommands for \"%s\""
 msgstr "%s câu lệnh tự động cho \"%s\""
 
-#: ../fileio.c:7149
 #, c-format
 msgid "Executing %s"
 msgstr "Thực hiện %s"
 
-#: ../fileio.c:7211
 #, c-format
 msgid "autocommand %s"
 msgstr "câu lệnh tự động %s"
 
-#: ../fileio.c:7795
 msgid "E219: Missing {."
 msgstr "E219: Thiếu {."
 
-#: ../fileio.c:7797
 msgid "E220: Missing }."
 msgstr "E220: Thiếu }."
 
-#: ../fold.c:93
 msgid "E490: No fold found"
 msgstr "E490: Không tìm thấy nếp gấp"
 
-#: ../fold.c:544
 msgid "E350: Cannot create fold with current 'foldmethod'"
 msgstr ""
 "E350: Không thể tạo nếp gấp với giá trị hiện thời của tùy chọn 'foldmethod'"
 
-#: ../fold.c:546
 msgid "E351: Cannot delete fold with current 'foldmethod'"
 msgstr ""
 "E351: Không thể xóa nếp gấp với giá trị hiện thời của tùy chọn 'foldmethod'"
 
-#: ../fold.c:1784
-#, c-format
-msgid "+--%3ld lines folded "
-msgstr "+--%3ld dòng được gấp"
-
-#. buffer has already been read
-#: ../getchar.c:273
 msgid "E222: Add to read buffer"
 msgstr "E222: Thêm vào bộ đệm đang đọc"
 
-#: ../getchar.c:2040
-msgid "E223: recursive mapping"
+# TODO: Capitalise first word of message?
+msgid "E223: Recursive mapping"
 msgstr "E223: ánh xạ đệ quy"
 
-#: ../getchar.c:2849
-#, c-format
-msgid "E224: global abbreviation already exists for %s"
+# TODO: Capitalise first word of message?
+msgid "E224: Global abbreviation already exists for %s"
 msgstr "E224: đã có sự viết tắt toàn cầu cho %s"
 
-#: ../getchar.c:2852
-#, c-format
-msgid "E225: global mapping already exists for %s"
+# TODO: Capitalise first word of message?
+msgid "E225: Global mapping already exists for %s"
 msgstr "E225: đã có ánh xạ toàn cầu cho %s"
 
-#: ../getchar.c:2952
-#, c-format
-msgid "E226: abbreviation already exists for %s"
+# TODO: Capitalise first word of message?
+msgid "E226: Abbreviation already exists for %s"
 msgstr "E226: đã có sự viết tắt cho %s"
 
-#: ../getchar.c:2955
-#, c-format
-msgid "E227: mapping already exists for %s"
+# TODO: Capitalise first word of message?
+msgid "E227: Mapping already exists for %s"
 msgstr "E227: đã có ánh xạ cho %s"
 
-#: ../getchar.c:3008
 msgid "No abbreviation found"
 msgstr "Không tìm thấy viết tắt"
 
-#: ../getchar.c:3010
 msgid "No mapping found"
 msgstr "Không tìm thấy ánh xạ"
 
-#: ../getchar.c:3974
 msgid "E228: makemap: Illegal mode"
 msgstr "E228: makemap: Chế độ không cho phép"
 
-#. key value of 'cedit' option
-#. type of cmdline window or 0
-#. result of cmdline window or 0
-#: ../globals.h:924
-msgid "--No lines in buffer--"
-msgstr "-- Không có dòng nào trong bộ đệm --"
+msgid "<cannot open> "
+msgstr "<không thể mở> "
 
-#.
-#. * The error messages that can be shared are included here.
-#. * Excluded are errors that are only used once and debugging messages.
-#.
-#: ../globals.h:996
-msgid "E470: Command aborted"
-msgstr "E470: Câu lệnh bị dừng"
-
-#: ../globals.h:997
-msgid "E471: Argument required"
-msgstr "E471: Cần chỉ ra tham số"
-
-#: ../globals.h:998
-msgid "E10: \\ should be followed by /, ? or &"
-msgstr "E10: Sau \\ phải là các ký tự /, ? hoặc &"
-
-#: ../globals.h:1000
-msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
-msgstr "E11: Lỗi trong cửa sổ dòng lệnh; <CR> thực hiện, CTRL-C thoát"
-
-#: ../globals.h:1002
-msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
-msgstr ""
-"E12: Câu lệnh không cho phép từ exrc/vimrc trong thư mục hiện thời hoặc "
-"trong tìm kiếm thẻ ghi"
-
-#: ../globals.h:1003
-msgid "E171: Missing :endif"
-msgstr "E171: Thiếu câu lệnh :endif"
-
-#: ../globals.h:1004
-msgid "E600: Missing :endtry"
-msgstr "E600: Thiếu câu lệnh :endtry"
-
-#: ../globals.h:1005
-msgid "E170: Missing :endwhile"
-msgstr "E170: Thiếu câu lệnh :endwhile"
-
-#: ../globals.h:1006
-#, fuzzy
-msgid "E170: Missing :endfor"
-msgstr "E171: Thiếu câu lệnh :endif"
-
-#: ../globals.h:1007
-msgid "E588: :endwhile without :while"
-msgstr "E588: Câu lệnh :endwhile không có lệnh :while (1 cặp)"
-
-#: ../globals.h:1008
-#, fuzzy
-msgid "E588: :endfor without :for"
-msgstr "E580: :endif không có :if"
-
-#: ../globals.h:1009
-msgid "E13: File exists (add ! to override)"
-msgstr "E13: Tập tin đã tồn tại (thêm ! để ghi chèn)"
-
-#: ../globals.h:1010
-msgid "E472: Command failed"
-msgstr "E472: Không thực hiện thành công câu lệnh"
-
-#: ../globals.h:1011
-msgid "E473: Internal error"
-msgstr "E473: Lỗi nội bộ"
-
-#: ../globals.h:1012
-msgid "Interrupted"
-msgstr "Bị gián đoạn"
-
-#: ../globals.h:1013
-msgid "E14: Invalid address"
-msgstr "E14: Địa chỉ không cho phép"
-
-#: ../globals.h:1014
-msgid "E474: Invalid argument"
-msgstr "E474: Tham số không cho phép"
-
-#: ../globals.h:1015
 #, c-format
-msgid "E475: Invalid argument: %s"
-msgstr "E475: Tham số không cho phép: %s"
+msgid "E616: vim_SelFile: can't get font %s"
+msgstr "E616: vim_SelFile: không tìm thấy phông chữ %s"
 
-#: ../globals.h:1016
+msgid "E614: vim_SelFile: can't return to current directory"
+msgstr "E614: vim_SelFile: không trở lại được thư mục hiện thời"
+
+msgid "Pathname:"
+msgstr "Đường dẫn tới tập tin:"
+
+msgid "E615: vim_SelFile: can't get current directory"
+msgstr "E615: vim_SelFile: không tìm thấy thư mục hiện thời"
+
+msgid "OK"
+msgstr "Đồng ý"
+
+msgid "Cancel"
+msgstr "Hủy bỏ"
+
+msgid "Vim dialog"
+msgstr "Hộp thoại Vim"
+
+msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
+msgstr "Thanh cuộn: Không thể xác định hình học của thanh cuộn."
+
+msgid "E232: Cannot create BalloonEval with both message and callback"
+msgstr "E232: Không tạo được BalloonEval với cả thông báo và lời gọi ngược lại"
+
+msgid "E229: Cannot start the GUI"
+msgstr "E229: Không chạy được giao diện đồ họa GUI"
+
 #, c-format
-msgid "E15: Invalid expression: %s"
-msgstr "E15: Biểu thức không cho phép: %s"
+msgid "E230: Cannot read from \"%s\""
+msgstr "E230: Không đọc được từ \"%s\""
 
-#: ../globals.h:1017
-msgid "E16: Invalid range"
-msgstr "E16: Vùng không cho phép"
+msgid "E665: Cannot start GUI, no valid font found"
+msgstr ""
+"E665: Không chạy được giao diện đồ họa GUI, đưa ra phông chữ không đúng"
 
-#: ../globals.h:1018
-msgid "E476: Invalid command"
-msgstr "E476: Câu lệnh không cho phép"
+msgid "E231: 'guifontwide' invalid"
+msgstr "E231: 'guifontwide' có giá trị không đúng"
 
-#: ../globals.h:1019
+msgid "E599: Value of 'imactivatekey' is invalid"
+msgstr "E599: Giá trị của 'imactivatekey' không đúng"
+
 #, c-format
-msgid "E17: \"%s\" is a directory"
-msgstr "E17: \"%s\" là mộ thư mục"
+msgid "E254: Cannot allocate color %s"
+msgstr "E254: Không chỉ định được màu %s"
 
-#: ../globals.h:1020
-#, fuzzy
-msgid "E900: Invalid job id"
-msgstr "E49: Kích thước thanh cuộn không cho phép"
+msgid "Vim dialog..."
+msgstr "Hộp thoại Vim..."
 
-#: ../globals.h:1021
-msgid "E901: Job table is full"
-msgstr ""
-
-#: ../globals.h:1024
-#, c-format
-msgid "E364: Library call failed for \"%s()\""
-msgstr "E364: Gọi hàm số \"%s()\" của thư viện không thành công"
-
-#: ../globals.h:1026
-msgid "E19: Mark has invalid line number"
-msgstr "E19: Dấu hiệu chỉ đến một số thứ tự dòng không đúng"
-
-#: ../globals.h:1027
-msgid "E20: Mark not set"
-msgstr "E20: Dấu hiệu không được xác định"
-
-#: ../globals.h:1029
-msgid "E21: Cannot make changes, 'modifiable' is off"
-msgstr "E21: Không thể thay đổi, vì tùy chọn 'modifiable' bị tắt"
-
-#: ../globals.h:1030
-msgid "E22: Scripts nested too deep"
-msgstr "E22: Các script lồng vào nhau quá sâu"
-
-#: ../globals.h:1031
-msgid "E23: No alternate file"
-msgstr "E23: Không có tập tin xen kẽ"
-
-#: ../globals.h:1032
-msgid "E24: No such abbreviation"
-msgstr "E24: Không có chữ viết tắt như vậy"
-
-#: ../globals.h:1033
-msgid "E477: No ! allowed"
-msgstr "E477: Không cho phép !"
-
-#: ../globals.h:1035
-msgid "E25: Nvim does not have a built-in GUI"
-msgstr "E25: Không sử dụng được giao diện đồ họa vì không chọn khi biên dịch"
-
-#: ../globals.h:1036
-#, c-format
-msgid "E28: No such highlight group name: %s"
-msgstr "E28: Nhóm chiếu sáng cú pháp %s không tồn tại"
-
-#: ../globals.h:1037
-msgid "E29: No inserted text yet"
-msgstr "E29: Tạm thời chưa có văn bản được chèn"
-
-#: ../globals.h:1038
-msgid "E30: No previous command line"
-msgstr "E30: Không có dòng lệnh trước"
-
-#: ../globals.h:1039
-msgid "E31: No such mapping"
-msgstr "E31: Không có ánh xạ (mapping) như vậy"
-
-#: ../globals.h:1040
-msgid "E479: No match"
-msgstr "E479: Không có tương ứng"
-
-#: ../globals.h:1041
-#, c-format
-msgid "E480: No match: %s"
-msgstr "E480: Không có tương ứng: %s"
-
-#: ../globals.h:1042
-msgid "E32: No file name"
-msgstr "E32: Không có tên tập tin"
-
-#: ../globals.h:1044
-msgid "E33: No previous substitute regular expression"
-msgstr "E33: Không có biểu thức chính quy trước để thay thế"
-
-#: ../globals.h:1045
-msgid "E34: No previous command"
-msgstr "E34: Không có câu lệnh trước"
-
-#: ../globals.h:1046
-msgid "E35: No previous regular expression"
-msgstr "E35: Không có biểu thức chính quy trước"
-
-#: ../globals.h:1047
-msgid "E481: No range allowed"
-msgstr "E481: Không cho phép sử dụng phạm vi"
-
-#: ../globals.h:1048
-msgid "E36: Not enough room"
-msgstr "E36: Không đủ chỗ trống"
-
-#: ../globals.h:1049
-#, c-format
-msgid "E482: Can't create file %s"
-msgstr "E482: Không tạo được tập tin %s"
-
-#: ../globals.h:1050
-msgid "E483: Can't get temp file name"
-msgstr "E483: Không nhận được tên tập tin tạm thời (temp)"
-
-#: ../globals.h:1051
-#, c-format
-msgid "E484: Can't open file %s"
-msgstr "E484: Không mở được tập tin %s"
-
-#: ../globals.h:1052
-#, c-format
-msgid "E485: Can't read file %s"
-msgstr "E485: Không đọc được tập tin %s"
-
-#: ../globals.h:1054
-msgid "E37: No write since last change (add ! to override)"
-msgstr "E37: Thay đổi chưa được ghi nhớ (thêm ! để bỏ qua ghi nhớ)"
-
-#: ../globals.h:1055
-#, fuzzy
-msgid "E37: No write since last change"
-msgstr "[Thay đổi chưa được ghi nhớ]\n"
-
-#: ../globals.h:1056
-msgid "E38: Null argument"
-msgstr "E38: Tham sô bằng 0"
-
-#: ../globals.h:1057
-msgid "E39: Number expected"
-msgstr "E39: Yêu cầu một số"
-
-#: ../globals.h:1058
-#, c-format
-msgid "E40: Can't open errorfile %s"
-msgstr "E40: Không mở được tập tin lỗi %s"
-
-#: ../globals.h:1059
-msgid "E41: Out of memory!"
-msgstr "E41: Không đủ bộ nhớ!"
-
-#: ../globals.h:1060
-msgid "Pattern not found"
-msgstr "Không tìm thấy mẫu (pattern)"
-
-#: ../globals.h:1061
-#, c-format
-msgid "E486: Pattern not found: %s"
-msgstr "E486: Không tìm thấy mẫu (pattern): %s"
-
-#: ../globals.h:1062
-msgid "E487: Argument must be positive"
-msgstr "E487: Tham số phải là một số dương"
-
-#: ../globals.h:1064
-msgid "E459: Cannot go back to previous directory"
-msgstr "E459: Không quay lại được thư mục trước đó"
-
-#: ../globals.h:1066
-msgid "E42: No Errors"
-msgstr "E42: Không có lỗi"
-
-#: ../globals.h:1067
-msgid "E776: No location list"
-msgstr ""
-
-#: ../globals.h:1068
-msgid "E43: Damaged match string"
-msgstr "E43: Chuỗi tương ứng bị hỏng"
-
-#: ../globals.h:1069
-msgid "E44: Corrupted regexp program"
-msgstr "E44: Chương trình xử lý biểu thức chính quy bị hỏng"
-
-#: ../globals.h:1071
-msgid "E45: 'readonly' option is set (add ! to override)"
-msgstr "E45: Tùy chọn 'readonly' được bật (Hãy thêm ! để lờ đi)"
-
-#: ../globals.h:1073
-#, fuzzy, c-format
-msgid "E46: Cannot change read-only variable \"%s\""
-msgstr "E46: Không thay đổi được biến chỉ đọc \"%s\""
-
-#: ../globals.h:1075
-#, fuzzy, c-format
-msgid "E794: Cannot set variable in the sandbox: \"%s\""
-msgstr "E46: Không thay đổi được biến chỉ đọc \"%s\""
-
-#: ../globals.h:1076
-msgid "E47: Error while reading errorfile"
-msgstr "E47: Lỗi khi đọc tập tin lỗi"
-
-#: ../globals.h:1078
-msgid "E48: Not allowed in sandbox"
-msgstr "E48: Không cho phép trong hộp cát (sandbox)"
-
-#: ../globals.h:1080
-msgid "E523: Not allowed here"
-msgstr "E523: Không cho phép ở đây"
-
-#: ../globals.h:1082
-msgid "E359: Screen mode setting not supported"
-msgstr "E359: Chế độ màn hình không được hỗ trợ"
-
-#: ../globals.h:1083
-msgid "E49: Invalid scroll size"
-msgstr "E49: Kích thước thanh cuộn không cho phép"
-
-#: ../globals.h:1084
-msgid "E91: 'shell' option is empty"
-msgstr "E91: Tùy chọn 'shell' là một chuỗi rỗng"
-
-#: ../globals.h:1085
-msgid "E255: Couldn't read in sign data!"
-msgstr "E255: Không đọc được dữ liệu về ký tự!"
-
-#: ../globals.h:1086
-msgid "E72: Close error on swap file"
-msgstr "E72: Lỗi đóng tập tin trao đổi (swap)"
-
-#: ../globals.h:1087
-msgid "E73: tag stack empty"
-msgstr "E73: đống thẻ ghi rỗng"
-
-#: ../globals.h:1088
-msgid "E74: Command too complex"
-msgstr "E74: Câu lệnh quá phức tạp"
-
-#: ../globals.h:1089
-msgid "E75: Name too long"
-msgstr "E75: Tên quá dài"
-
-#: ../globals.h:1090
-msgid "E76: Too many ["
-msgstr "E76: Quá nhiều ký tự ["
-
-#: ../globals.h:1091
-msgid "E77: Too many file names"
-msgstr "E77: Quá nhiều tên tập tin"
-
-#: ../globals.h:1092
-msgid "E488: Trailing characters"
-msgstr "E488: Ký tự thừa ở đuôi"
-
-#: ../globals.h:1093
-msgid "E78: Unknown mark"
-msgstr "E78: Dấu hiệu không biết"
-
-#: ../globals.h:1094
-msgid "E79: Cannot expand wildcards"
-msgstr "E79: Không thực hiện được phép thế theo wildcard"
-
-#: ../globals.h:1096
-msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
-msgstr "E591: giá trị của 'winheight' không thể nhỏ hơn 'winminheight'"
-
-#: ../globals.h:1098
-msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
-msgstr "E592: giá trị của 'winwidth' không thể nhỏ hơn 'winminwidth'"
-
-#: ../globals.h:1099
-msgid "E80: Error while writing"
-msgstr "E80: Lỗi khi ghi nhớ"
-
-#: ../globals.h:1100
-msgid "Zero count"
-msgstr "Giá trị của bộ đếm bằng 0"
-
-#: ../globals.h:1101
-msgid "E81: Using <SID> not in a script context"
-msgstr "E81: Sử dụng <SID> ngoài phạm vi script"
-
-#: ../globals.h:1102
-#, fuzzy, c-format
-msgid "E685: Internal error: %s"
-msgstr "E473: Lỗi nội bộ"
-
-#: ../globals.h:1104
-msgid "E363: pattern uses more memory than 'maxmempattern'"
-msgstr ""
-
-#: ../globals.h:1105
-#, fuzzy
-msgid "E749: empty buffer"
-msgstr "E279: Đây không phải là bộ đệm SNiFF+"
-
-#: ../globals.h:1108
-#, fuzzy
-msgid "E682: Invalid search pattern or delimiter"
-msgstr "E383: Chuỗi tìm kiếm không đúng: %s"
-
-#: ../globals.h:1109
-msgid "E139: File is loaded in another buffer"
-msgstr "E139: Tập tin được nạp trong bộ đệm khác"
-
-#: ../globals.h:1110
-#, fuzzy, c-format
-msgid "E764: Option '%s' is not set"
-msgstr "E236: Phông chữ \"%s\" không có độ rộng cố định (fixed-width)"
-
-#: ../globals.h:1111
-#, fuzzy
-msgid "E850: Invalid register name"
-msgstr "E354: Tên sổ đăng ký không cho phép: '%s'"
-
-#: ../globals.h:1114
-msgid "search hit TOP, continuing at BOTTOM"
-msgstr "tìm kiếm sẽ được tiếp tục từ CUỐI tài liệu"
-
-#: ../globals.h:1115
-msgid "search hit BOTTOM, continuing at TOP"
-msgstr "tìm kiếm sẽ được tiếp tục từ ĐẦU tài liệu"
-
-#: ../if_cscope.c:85
-msgid "Add a new database"
-msgstr "Thêm một cơ sở dữ liệu mới"
-
-#: ../if_cscope.c:87
-msgid "Query for a pattern"
-msgstr "Yêu cầu theo một mẫu"
-
-#: ../if_cscope.c:89
-msgid "Show this message"
-msgstr "Hiển thị thông báo này"
-
-#: ../if_cscope.c:91
-msgid "Kill a connection"
-msgstr "Hủy kết nối"
-
-#: ../if_cscope.c:93
-msgid "Reinit all connections"
-msgstr "Khởi đầu lại tất cả các kết nối"
-
-#: ../if_cscope.c:95
-msgid "Show connections"
-msgstr "Hiển thị kết nối"
-
-#: ../if_cscope.c:101
-#, c-format
-msgid "E560: Usage: cs[cope] %s"
-msgstr "E560: Sử dụng: cs[cope] %s"
-
-#: ../if_cscope.c:225
-msgid "This cscope command does not support splitting the window.\n"
-msgstr "Câu lệnh cscope này không hỗ trợ việc chia (split) cửa sổ.\n"
-
-#: ../if_cscope.c:266
-msgid "E562: Usage: cstag <ident>"
-msgstr "E562: Sử dụng: cstag <tên>"
-
-#: ../if_cscope.c:313
-msgid "E257: cstag: tag not found"
-msgstr "E257: cstag: không tìm thấy thẻ ghi"
-
-#: ../if_cscope.c:461
-#, c-format
-msgid "E563: stat(%s) error: %d"
-msgstr "E563: lỗi stat(%s): %d"
-
-#: ../if_cscope.c:551
-#, c-format
-msgid "E564: %s is not a directory or a valid cscope database"
-msgstr ""
-"E564: %s không phải là một thư mục hoặc một cơ sở dữ liệu cscope thích hợp"
-
-#: ../if_cscope.c:566
-#, c-format
-msgid "Added cscope database %s"
-msgstr "Đã thêm cơ sở dữ liệu cscope %s"
-
-#: ../if_cscope.c:616
-#, c-format
-msgid "E262: error reading cscope connection %<PRId64>"
-msgstr "E262: lỗi lấy thông tin từ kết nối cscope %<PRId64>"
-
-#: ../if_cscope.c:711
-msgid "E561: unknown cscope search type"
-msgstr "E561: không rõ loại tìm kiếm cscope"
-
-#: ../if_cscope.c:752 ../if_cscope.c:789
-msgid "E566: Could not create cscope pipes"
-msgstr "E566: Không tạo được đường ống (pipe) cho cscope"
-
-#: ../if_cscope.c:767
-msgid "E622: Could not fork for cscope"
-msgstr "E622: Không thực hiện được fork() cho cscope"
-
-#: ../if_cscope.c:849
-#, fuzzy
-msgid "cs_create_connection setpgid failed"
-msgstr "thực hiện cs_create_connection không thành công"
-
-#: ../if_cscope.c:853 ../if_cscope.c:889
-msgid "cs_create_connection exec failed"
-msgstr "thực hiện cs_create_connection không thành công"
-
-#: ../if_cscope.c:863 ../if_cscope.c:902
-msgid "cs_create_connection: fdopen for to_fp failed"
-msgstr "cs_create_connection: thực hiện fdopen cho to_fp không thành công"
-
-#: ../if_cscope.c:865 ../if_cscope.c:906
-msgid "cs_create_connection: fdopen for fr_fp failed"
-msgstr "cs_create_connection: thực hiện fdopen cho fr_fp không thành công"
-
-#: ../if_cscope.c:890
-msgid "E623: Could not spawn cscope process"
-msgstr "E623: Chạy tiến trình cscope không thành công"
-
-#: ../if_cscope.c:932
-msgid "E567: no cscope connections"
-msgstr "E567: không có kết nối với cscope"
-
-#: ../if_cscope.c:1009
-#, c-format
-msgid "E469: invalid cscopequickfix flag %c for %c"
-msgstr "E469: cờ cscopequickfix %c cho %c không chính xác"
-
-#: ../if_cscope.c:1058
-#, c-format
-msgid "E259: no matches found for cscope query %s of %s"
-msgstr "E259: không tìm thấy tương ứng với yêu cầu cscope %s cho %s"
-
-#: ../if_cscope.c:1142
-msgid "cscope commands:\n"
-msgstr "các lệnh cscope:\n"
-
-#: ../if_cscope.c:1150
-#, fuzzy, c-format
-msgid "%-5s: %s%*s (Usage: %s)"
-msgstr "%-5s: %-30s (Sử dụng: %s)"
-
-#: ../if_cscope.c:1155
-msgid ""
-"\n"
-"       c: Find functions calling this function\n"
-"       d: Find functions called by this function\n"
-"       e: Find this egrep pattern\n"
-"       f: Find this file\n"
-"       g: Find this definition\n"
-"       i: Find files #including this file\n"
-"       s: Find this C symbol\n"
-"       t: Find this text string\n"
-msgstr ""
-
-#: ../if_cscope.c:1226
-msgid "E568: duplicate cscope database not added"
-msgstr "E568: cơ sở dữ liệu này của cscope đã được gắn vào từ trước"
-
-#: ../if_cscope.c:1335
-#, c-format
-msgid "E261: cscope connection %s not found"
-msgstr "E261: kết nối với cscope %s không được tìm thấy"
-
-#: ../if_cscope.c:1364
-#, c-format
-msgid "cscope connection %s closed"
-msgstr "kết nối %s với cscope đã bị đóng"
-
-#. should not reach here
-#: ../if_cscope.c:1486
-msgid "E570: fatal error in cs_manage_matches"
-msgstr "E570: lỗi nặng trong cs_manage_matches"
-
-#: ../if_cscope.c:1693
-#, c-format
-msgid "Cscope tag: %s"
-msgstr "Thẻ ghi cscope: %s"
-
-#: ../if_cscope.c:1711
-msgid ""
-"\n"
-"   #   line"
-msgstr ""
-"\n"
-"   #   dòng"
-
-#: ../if_cscope.c:1713
-msgid "filename / context / line\n"
-msgstr "tên tập tin / nội dung / dòng\n"
-
-#: ../if_cscope.c:1809
-#, c-format
-msgid "E609: Cscope error: %s"
-msgstr "E609: Lỗi cscope: %s"
-
-#: ../if_cscope.c:2053
-msgid "All cscope databases reset"
-msgstr "Khởi động lại tất cả cơ sở dữ liệu cscope"
-
-#: ../if_cscope.c:2123
-msgid "no cscope connections\n"
-msgstr "không có kết nối với cscope\n"
-
-#: ../if_cscope.c:2126
-msgid " # pid    database name                       prepend path\n"
-msgstr " # pid    tên cơ sở dữ liệu                   đường dẫn ban đầu\n"
-
-#: ../main.c:144
-#, fuzzy
-msgid "Unknown option argument"
-msgstr "Tùy chọn không biết"
-
-#: ../main.c:146
-msgid "Too many edit arguments"
-msgstr "Có quá nhiều tham số soạn thảo"
-
-#: ../main.c:148
-msgid "Argument missing after"
-msgstr "Thiếu tham số sau"
-
-#: ../main.c:150
-#, fuzzy
-msgid "Garbage after option argument"
-msgstr "Rác sau tùy chọn"
-
-#: ../main.c:152
-msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
-msgstr ""
-"Quá nhiều tham số \"+câu lệnh\", \"-c câu lệnh\" hoặc \"--cmd câu lệnh\""
-
-#: ../main.c:154
-msgid "Invalid argument for"
-msgstr "Tham số không được phép cho"
-
-#: ../main.c:294
-#, c-format
-msgid "%d files to edit\n"
-msgstr "%d tập tin để soạn thảo\n"
-
-#: ../main.c:1342
-msgid "Attempt to open script file again: \""
-msgstr "Thử mở tập tin script một lần nữa: \""
-
-#: ../main.c:1350
-msgid "Cannot open for reading: \""
-msgstr "Không mở để đọc được: \""
-
-#: ../main.c:1393
-msgid "Cannot open for script output: \""
-msgstr "Không mở cho đầu ra script được: \""
-
-#: ../main.c:1622
-msgid "Vim: Warning: Output is not to a terminal\n"
-msgstr "Vim: Cảnh báo: Đầu ra không hướng tới một terminal\n"
-
-#: ../main.c:1624
-msgid "Vim: Warning: Input is not from a terminal\n"
-msgstr "Vim: Cảnh báo: Đầu vào không phải đến từ một terminal\n"
-
-#. just in case..
-#: ../main.c:1891
-msgid "pre-vimrc command line"
-msgstr "dòng lệnh chạy trước khi thực hiện vimrc"
-
-#: ../main.c:1964
-#, c-format
-msgid "E282: Cannot read from \"%s\""
-msgstr "E282: Không đọc được từ \"%s\""
-
-#: ../main.c:2149
-msgid ""
-"\n"
-"More info with: \"vim -h\"\n"
-msgstr ""
-"\n"
-"Xem thông tin chi tiết với: \"vim -h\"\n"
-
-#: ../main.c:2178
-msgid "[file ..]       edit specified file(s)"
-msgstr "[tập tin ..]     soạn thảo (các) tập tin chỉ ra"
-
-#: ../main.c:2179
-msgid "-               read text from stdin"
-msgstr "-                đọc văn bản từ đầu vào stdin"
-
-#: ../main.c:2180
-msgid "-t tag          edit file where tag is defined"
-msgstr "-t thẻ ghi      soạn thảo tập tin từ chỗ thẻ ghi chỉ ra"
-
-#: ../main.c:2181
-msgid "-q [errorfile]  edit file with first error"
-msgstr "-q [tập tin lỗi] soạn thảo tập tin với lỗi đầu tiên"
-
-#: ../main.c:2187
-msgid ""
-"\n"
-"\n"
-"Usage:"
-msgstr ""
-"\n"
-"\n"
-"Sử dụng:"
-
-#: ../main.c:2189
-msgid " vim [arguments] "
-msgstr " vim [các tham số] "
-
-#: ../main.c:2193
-msgid ""
-"\n"
-"   or:"
-msgstr ""
-"\n"
-"   hoặc:"
-
-#: ../main.c:2196
-msgid ""
-"\n"
-"\n"
-"Arguments:\n"
-msgstr ""
-"\n"
-"\n"
-"Tham số:\n"
-
-#: ../main.c:2197
-msgid "--\t\t\tOnly file names after this"
-msgstr "--\t\t\tSau tham số chỉ đưa ra tên tập tin"
-
-#: ../main.c:2199
-msgid "--literal\t\tDon't expand wildcards"
-msgstr "--literal\t\tKhông thực hiện việc mở rộng wildcard"
-
-#: ../main.c:2201
-msgid "-v\t\t\tVi mode (like \"vi\")"
-msgstr "-v\t\t\tChế độ Vi (giống \"vi\")"
-
-#: ../main.c:2202
-msgid "-e\t\t\tEx mode (like \"ex\")"
-msgstr "-e\t\t\tChế độ Ex (giống \"ex\")"
-
-#: ../main.c:2203
-msgid "-E\t\t\tImproved Ex mode"
-msgstr ""
-
-#: ../main.c:2204
-msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
-msgstr "-s\t\t\tChế độ ít đưa thông báo (gói) (chỉ dành cho \"ex\")"
-
-#: ../main.c:2205
-msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
-msgstr "-d\t\t\tChế độ khác biệt, diff (giống \"vimdiff\")"
-
-#: ../main.c:2206
-msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
-msgstr "-y\t\t\tChế độ đơn giản (giống \"evim\", không có chế độ)"
-
-#: ../main.c:2207
-msgid "-R\t\t\tReadonly mode (like \"view\")"
-msgstr "-R\t\t\tChế độ chỉ đọc (giống \"view\")"
-
-#: ../main.c:2209
-msgid "-m\t\t\tModifications (writing files) not allowed"
-msgstr "-m\t\t\tKhông có khả năng ghi nhớ thay đổi (ghi nhớ tập tin)"
-
-#: ../main.c:2210
-msgid "-M\t\t\tModifications in text not allowed"
-msgstr "-M\t\t\tKhông có khả năng thay đổi văn bản"
-
-#: ../main.c:2211
-msgid "-b\t\t\tBinary mode"
-msgstr "-b\t\t\tChế độ nhị phân (binary)"
-
-#: ../main.c:2212
-msgid "-l\t\t\tLisp mode"
-msgstr "-l\t\t\tChế độ Lisp"
-
-#: ../main.c:2213
-msgid "-C\t\t\tCompatible with Vi: 'compatible'"
-msgstr "-C\t\t\tChế độ tương thích với Vi: 'compatible'"
-
-#: ../main.c:2214
-msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
-msgstr "-N\t\t\tChế độ không tương thích hoàn toàn với Vi: 'nocompatible'"
-
-#: ../main.c:2215
-msgid "-V[N][fname]\t\tBe verbose [level N] [log messages to fname]"
-msgstr ""
-
-#: ../main.c:2216
-msgid "-D\t\t\tDebugging mode"
-msgstr "-D\t\t\tChế độ sửa lỗi (debug)"
-
-#: ../main.c:2217
-msgid "-n\t\t\tNo swap file, use memory only"
-msgstr "-n\t\t\tKhông sử dụng tập tin swap, chỉ sử dụng bộ nhớ"
-
-#: ../main.c:2218
-msgid "-r\t\t\tList swap files and exit"
-msgstr "-r\t\t\tLiệt kê các tập tin swap rồi thoát"
-
-#: ../main.c:2219
-msgid "-r (with file name)\tRecover crashed session"
-msgstr "-r (với tên tập tin)\tPhục hồi lần soạn thảo gặp sự cố"
-
-#: ../main.c:2220
-msgid "-L\t\t\tSame as -r"
-msgstr "-L\t\t\tGiống với -r"
-
-#: ../main.c:2221
-msgid "-A\t\t\tstart in Arabic mode"
-msgstr "-A\t\t\tKhởi động vào chế độ Ả Rập"
-
-#: ../main.c:2222
-msgid "-H\t\t\tStart in Hebrew mode"
-msgstr "-H\t\t\tKhởi động vào chế độ Do thái"
-
-#: ../main.c:2223
-msgid "-F\t\t\tStart in Farsi mode"
-msgstr "-F\t\t\tKhởi động vào chế độ Farsi"
-
-#: ../main.c:2224
-msgid "-T <terminal>\tSet terminal type to <terminal>"
-msgstr "-T <terminal>\tĐặt loại terminal thành <terminal>"
-
-#: ../main.c:2225
-msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
-msgstr "-u <vimrc>\t\tSử dụng <vimrc> thay thế cho mọi .vimrc"
-
-#: ../main.c:2226
-msgid "--noplugin\t\tDon't load plugin scripts"
-msgstr "--noplugin\t\tKhông nạp bất kỳ script môđun nào"
-
-#: ../main.c:2227
-#, fuzzy
-msgid "-p[N]\t\tOpen N tab pages (default: one for each file)"
-msgstr "-o[N]\t\tMở N cửa sổ (theo mặc định: mỗi cửa sổ cho một tập tin)"
-
-#: ../main.c:2228
-msgid "-o[N]\t\tOpen N windows (default: one for each file)"
-msgstr "-o[N]\t\tMở N cửa sổ (theo mặc định: mỗi cửa sổ cho một tập tin)"
-
-#: ../main.c:2229
-msgid "-O[N]\t\tLike -o but split vertically"
-msgstr "-O[N]\t\tGiống với -o nhưng phân chia theo đường thẳng đứng"
-
-#: ../main.c:2230
-msgid "+\t\t\tStart at end of file"
-msgstr "+\t\t\tBắt đầu soạn thảo từ cuối tập tin"
-
-#: ../main.c:2231
-msgid "+<lnum>\t\tStart at line <lnum>"
-msgstr "+<lnum>\t\tBắt đầu soạn thảo từ dòng thứ <lnum> (số thứ tự của dòng)"
-
-#: ../main.c:2232
-msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
-msgstr "--cmd <câu lệnh>\tThực hiện <câu lệnh> trước khi nạp tập tin vimrc"
-
-#: ../main.c:2233
-msgid "-c <command>\t\tExecute <command> after loading the first file"
-msgstr "-c <câu lệnh>\t\tThực hiện <câu lệnh> sau khi nạp tập tin đầu tiên"
-
-#: ../main.c:2235
-msgid "-S <session>\t\tSource file <session> after loading the first file"
-msgstr "-S <session>\t\tThực hiện <session> sau khi nạp tập tin đầu tiên"
-
-#: ../main.c:2236
-msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
-msgstr ""
-"-s <scriptin>\tĐọc các lệnh của chế độ Thông thường từ tập tin <scriptin>"
-
-#: ../main.c:2237
-msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
-msgstr "-w <scriptout>\tThêm tất cả các lệnh đã gõ vào tập tin <scriptout>"
-
-#: ../main.c:2238
-msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
-msgstr "-W <scriptout>\tGhi nhớ tất cả các lệnh đã gõ vào tập tin <scriptout>"
-
-#: ../main.c:2240
-msgid "--startuptime <file>\tWrite startup timing messages to <file>"
-msgstr ""
-
-#: ../main.c:2242
-msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
-msgstr "-i <viminfo>\t\tSử dụng tập tin <viminfo> thay cho .viminfo"
-
-#: ../main.c:2243
-msgid "-h  or  --help\tPrint Help (this message) and exit"
-msgstr "-h hoặc --help\tHiển thị Trợ giúp (thông tin này) và thoát"
-
-#: ../main.c:2244
-msgid "--version\t\tPrint version information and exit"
-msgstr "--version\t\tĐưa ra thông tin về phiên bản Vim và thoát"
-
-#: ../mark.c:676
-msgid "No marks set"
-msgstr "Không có dấu hiệu nào được đặt."
-
-#: ../mark.c:678
-#, c-format
-msgid "E283: No marks matching \"%s\""
-msgstr "E283: Không có dấu hiệu tương ứng với \"%s\""
-
-#. Highlight title
-#: ../mark.c:687
-msgid ""
-"\n"
-"mark line  col file/text"
-msgstr ""
-"\n"
-"nhãn dòng  cột tập tin/văn bản"
-
-#. Highlight title
-#: ../mark.c:789
-msgid ""
-"\n"
-" jump line  col file/text"
-msgstr ""
-"\n"
-" bước_nhảy dòng  cột tập tin/văn bản"
-
-#. Highlight title
-#: ../mark.c:831
-msgid ""
-"\n"
-"change line  col text"
-msgstr ""
-"\n"
-"thay_đổi dòng  cột văn_bản"
-
-#: ../mark.c:1238
-msgid ""
-"\n"
-"# File marks:\n"
-msgstr ""
-"\n"
-"# Nhãn của tập tin:\n"
-
-#. Write the jumplist with -'
-#: ../mark.c:1271
-msgid ""
-"\n"
-"# Jumplist (newest first):\n"
-msgstr ""
-"\n"
-"# Danh sách bước nhảy (mới hơn đứng trước):\n"
-
-#: ../mark.c:1352
-msgid ""
-"\n"
-"# History of marks within files (newest to oldest):\n"
-msgstr ""
-"\n"
-"# Lịch sử các nhãn trong tập tin (từ mới nhất đến cũ nhất):\n"
-
-#: ../mark.c:1431
-msgid "Missing '>'"
-msgstr "Thiếu '>'"
-
-#: ../memfile.c:426
-msgid "E293: block was not locked"
-msgstr "E293: khối chưa bị khóa"
-
-#: ../memfile.c:799
-msgid "E294: Seek error in swap file read"
-msgstr "E294: Lỗi tìm kiếm khi đọc tập tin trao đổi (swap)"
-
-#: ../memfile.c:803
-msgid "E295: Read error in swap file"
-msgstr "E295: Lỗi đọc tập tin trao đổi (swap)"
-
-#: ../memfile.c:849
-msgid "E296: Seek error in swap file write"
-msgstr "E296: Lỗi tìm kiếm khi ghi nhớ tập tin trao đổi (swap)"
-
-#: ../memfile.c:865
-msgid "E297: Write error in swap file"
-msgstr "E297: Lỗi ghi nhớ tập tin trao đổi (swap)"
-
-#: ../memfile.c:1036
-msgid "E300: Swap file already exists (symlink attack?)"
-msgstr ""
-"E300: Tập tin trao đổi (swap) đã tồn tại (sử dụng liên kết mềm tấn công?)"
-
-#: ../memline.c:318
-msgid "E298: Didn't get block nr 0?"
-msgstr "E298: Chưa lấy khối số 0?"
-
-#: ../memline.c:361
-msgid "E298: Didn't get block nr 1?"
-msgstr "E298: Chưa lấy khối số 12?"
-
-#: ../memline.c:377
-msgid "E298: Didn't get block nr 2?"
-msgstr "E298: Chưa lấy khối số 2?"
-
-#. could not (re)open the swap file, what can we do????
-#: ../memline.c:465
-msgid "E301: Oops, lost the swap file!!!"
-msgstr "E301: Ối, mất tập tin trao đổi (swap)!!!"
-
-#: ../memline.c:477
-msgid "E302: Could not rename swap file"
-msgstr "E302: Không đổi được tên tập tin trao đổi (swap)"
-
-#: ../memline.c:554
-#, c-format
-msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
-msgstr ""
-"E303: Không mở được tập tin trao đổi (swap) cho \"%s\", nên không thể phục "
-"hồi"
-
-#: ../memline.c:666
-#, fuzzy
-msgid "E304: ml_upd_block0(): Didn't get block 0??"
-msgstr "E304: ml_timestamp: Chưa lấy khối số 0??"
-
-#. no swap files found
-#: ../memline.c:830
-#, c-format
-msgid "E305: No swap file found for %s"
-msgstr "E305: Không tìm thấy tập tin trao đổi (swap) cho %s"
-
-#: ../memline.c:839
-msgid "Enter number of swap file to use (0 to quit): "
-msgstr "Hãy nhập số của tập tin trao đổi (swap) muốn sử dụng (0 để thoát): "
-
-#: ../memline.c:879
-#, c-format
-msgid "E306: Cannot open %s"
-msgstr "E306: Không mở được %s"
-
-#: ../memline.c:897
-msgid "Unable to read block 0 from "
-msgstr "Không thể đọc khối số 0 từ "
-
-#: ../memline.c:900
-msgid ""
-"\n"
-"Maybe no changes were made or Vim did not update the swap file."
-msgstr ""
-"\n"
-"Chưa có thay đổi nào hoặc Vim không thể cập nhật tập tin trao đổi (swap)"
-
-#: ../memline.c:909
-msgid " cannot be used with this version of Vim.\n"
-msgstr " không thể sử dụng trong phiên bản Vim này.\n"
-
-#: ../memline.c:911
-msgid "Use Vim version 3.0.\n"
-msgstr "Hãy sử dụng Vim phiên bản 3.0.\n"
-
-#: ../memline.c:916
-#, c-format
-msgid "E307: %s does not look like a Vim swap file"
-msgstr "E307: %s không phải là tập tin trao đổi (swap) của Vim"
-
-#: ../memline.c:922
-msgid " cannot be used on this computer.\n"
-msgstr " không thể sử dụng trên máy tính này.\n"
-
-#: ../memline.c:924
-msgid "The file was created on "
-msgstr "Tập tin đã được tạo trên "
-
-#: ../memline.c:928
-msgid ""
-",\n"
-"or the file has been damaged."
-msgstr ""
-",\n"
-"hoặc tập tin đã bị hỏng."
-
-#: ../memline.c:945
-msgid " has been damaged (page size is smaller than minimum value).\n"
-msgstr ""
-
-#: ../memline.c:974
-#, c-format
-msgid "Using swap file \"%s\""
-msgstr "Đang sử dụng tập tin trao đổi (swap) \"%s\""
-
-#: ../memline.c:980
-#, c-format
-msgid "Original file \"%s\""
-msgstr "Tập tin gốc \"%s\""
-
-#: ../memline.c:995
-msgid "E308: Warning: Original file may have been changed"
-msgstr "E308: Cảnh báo: Tập tin gốc có thể đã bị thay đổi"
-
-#: ../memline.c:1061
-#, c-format
-msgid "E309: Unable to read block 1 from %s"
-msgstr "E309: Không đọc được khối số 1 từ %s"
-
-#: ../memline.c:1065
-msgid "???MANY LINES MISSING"
-msgstr "???THIẾU NHIỀU DÒNG"
-
-#: ../memline.c:1076
-msgid "???LINE COUNT WRONG"
-msgstr "???GIÁ TRỊ CỦA SỐ ĐẾM DÒNG BỊ SAI"
-
-#: ../memline.c:1082
-msgid "???EMPTY BLOCK"
-msgstr "???KHỐI RỖNG"
-
-#: ../memline.c:1103
-msgid "???LINES MISSING"
-msgstr "???THIẾU DÒNG"
-
-#: ../memline.c:1128
-#, c-format
-msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
-msgstr "E310: Khối 1 ID sai (%s không phải là tập tin .swp?)"
-
-#: ../memline.c:1133
-msgid "???BLOCK MISSING"
-msgstr "???THIẾU KHỐI"
-
-#: ../memline.c:1147
-msgid "??? from here until ???END lines may be messed up"
-msgstr "??? từ đây tới ???CUỐI, các dòng có thể đã bị hỏng"
-
-#: ../memline.c:1164
-msgid "??? from here until ???END lines may have been inserted/deleted"
-msgstr "??? từ đây tới ???CUỐI, các dòng có thể đã bị chèn hoặc xóa"
-
-#: ../memline.c:1181
-msgid "???END"
-msgstr "???CUỐI"
-
-#: ../memline.c:1238
-msgid "E311: Recovery Interrupted"
-msgstr "E311: Việc phục hồi bị gián đoạn"
-
-#: ../memline.c:1243
-msgid ""
-"E312: Errors detected while recovering; look for lines starting with ???"
-msgstr ""
-"E312: Phát hiện ra lỗi trong khi phục hồi; hãy xem những dòng bắt đầu với ???"
-
-#: ../memline.c:1245
-msgid "See \":help E312\" for more information."
-msgstr "Hãy xem thông tin bổ sung trong trợ giúp \":help E312\""
-
-#: ../memline.c:1249
-msgid "Recovery completed. You should check if everything is OK."
-msgstr "Việc phục hồi đã hoàn thành. Nên kiểm tra xem mọi thứ có ổn không."
-
-#: ../memline.c:1251
-msgid ""
-"\n"
-"(You might want to write out this file under another name\n"
-msgstr ""
-"\n"
-"(Có thể ghi nhớ tập tin với tên khác và so sánh với tập\n"
-
-#: ../memline.c:1252
-#, fuzzy
-msgid "and run diff with the original file to check for changes)"
-msgstr "gốc bằng chương trình diff).\n"
-
-#: ../memline.c:1254
-msgid "Recovery completed. Buffer contents equals file contents."
-msgstr ""
-
-#: ../memline.c:1255
-#, fuzzy
-msgid ""
-"\n"
-"You may want to delete the .swp file now.\n"
-"\n"
-msgstr ""
-"Sau đó hãy xóa tập tin .swp.\n"
-"\n"
-
-#. use msg() to start the scrolling properly
-#: ../memline.c:1327
-msgid "Swap files found:"
-msgstr "Tìm thấy tập tin trao đổi (swap):"
-
-#: ../memline.c:1446
-msgid "   In current directory:\n"
-msgstr "   Trong thư mục hiện thời:\n"
-
-#: ../memline.c:1448
-msgid "   Using specified name:\n"
-msgstr "   Với tên chỉ ra:\n"
-
-#: ../memline.c:1450
-msgid "   In directory "
-msgstr "   Trong thư mục   "
-
-#: ../memline.c:1465
-msgid "      -- none --\n"
-msgstr "      -- không --\n"
-
-#: ../memline.c:1527
-msgid "          owned by: "
-msgstr "          người sở hữu: "
-
-#: ../memline.c:1529
-msgid "   dated: "
-msgstr "    ngày: "
-
-#: ../memline.c:1532 ../memline.c:3231
-msgid "             dated: "
-msgstr "              ngày: "
-
-#: ../memline.c:1548
-msgid "         [from Vim version 3.0]"
-msgstr "         [từ Vim phiên bản 3.0]"
-
-#: ../memline.c:1550
-msgid "         [does not look like a Vim swap file]"
-msgstr "         [không phải là tập tin trao đổi (swap) của Vim]"
-
-#: ../memline.c:1552
-msgid "         file name: "
-msgstr "         tên tập tin: "
-
-#: ../memline.c:1558
-msgid ""
-"\n"
-"          modified: "
-msgstr ""
-"\n"
-"           thay đổi: "
-
-#: ../memline.c:1559
-msgid "YES"
-msgstr "CÓ"
-
-#: ../memline.c:1559
-msgid "no"
-msgstr "không"
-
-#: ../memline.c:1562
-msgid ""
-"\n"
-"         user name: "
-msgstr ""
-"\n"
-"      tên người dùng: "
-
-#: ../memline.c:1568
-msgid "   host name: "
-msgstr "    tên máy: "
-
-#: ../memline.c:1570
-msgid ""
-"\n"
-"         host name: "
-msgstr ""
-"\n"
-"           tên máy: "
-
-#: ../memline.c:1575
-msgid ""
-"\n"
-"        process ID: "
-msgstr ""
-"\n"
-"     ID tiến trình: "
-
-#: ../memline.c:1579
-msgid " (still running)"
-msgstr " (vẫn đang chạy)"
-
-#: ../memline.c:1586
-msgid ""
-"\n"
-"         [not usable on this computer]"
-msgstr ""
-"\n"
-"         [không sử dụng được trên máy tính này]"
-
-#: ../memline.c:1590
-msgid "         [cannot be read]"
-msgstr "         [không đọc được]"
-
-#: ../memline.c:1593
-msgid "         [cannot be opened]"
-msgstr "         [không mở được]"
-
-#: ../memline.c:1698
-msgid "E313: Cannot preserve, there is no swap file"
-msgstr "E313: Không cập nhật được tập tin trao đổi (swap) vì không tìm thấy nó"
-
-#: ../memline.c:1747
-msgid "File preserved"
-msgstr "Đã cập nhật tập tin trao đổi (swap)"
-
-#: ../memline.c:1749
-msgid "E314: Preserve failed"
-msgstr "E314: Cập nhật không thành công"
-
-#: ../memline.c:1819
-#, c-format
-msgid "E315: ml_get: invalid lnum: %<PRId64>"
-msgstr "E315: ml_get: giá trị lnum không đúng: %<PRId64>"
-
-#: ../memline.c:1851
-#, c-format
-msgid "E316: ml_get: cannot find line %<PRId64>"
-msgstr "E316: ml_get: không tìm được dòng %<PRId64>"
-
-#: ../memline.c:2236
-msgid "E317: pointer block id wrong 3"
-msgstr "E317: Giá trị của pointer khối số 3 không đúng"
-
-#: ../memline.c:2311
-msgid "stack_idx should be 0"
-msgstr "giá trị stack_idx phải bằng 0"
-
-#: ../memline.c:2369
-msgid "E318: Updated too many blocks?"
-msgstr "E318: Đã cập nhật quá nhiều khối?"
-
-#: ../memline.c:2511
-msgid "E317: pointer block id wrong 4"
-msgstr "E317: Giá trị của pointer khối số 4 không đúng"
-
-#: ../memline.c:2536
-msgid "deleted block 1?"
-msgstr "đã xóa khối số 1?"
-
-#: ../memline.c:2707
-#, c-format
-msgid "E320: Cannot find line %<PRId64>"
-msgstr "E320: Không tìm được dòng %<PRId64>"
-
-#: ../memline.c:2916
-msgid "E317: pointer block id wrong"
-msgstr "E317: giá trị của pointer khối không đúng"
-
-#: ../memline.c:2930
-msgid "pe_line_count is zero"
-msgstr "giá trị pe_line_count bằng không"
-
-#: ../memline.c:2955
-#, c-format
-msgid "E322: line number out of range: %<PRId64> past the end"
-msgstr "E322: số thứ tự dòng vượt quá giới hạn : %<PRId64>"
-
-#: ../memline.c:2959
-#, c-format
-msgid "E323: line count wrong in block %<PRId64>"
-msgstr "E323: giá trị đếm dòng không đúng trong khối %<PRId64>"
-
-#: ../memline.c:2999
-msgid "Stack size increases"
-msgstr "Kích thước của đống tăng lên"
-
-#: ../memline.c:3038
-msgid "E317: pointer block id wrong 2"
-msgstr "E317: Giá trị của cái chỉ (pointer) khối số 2 không đúng"
-
-#: ../memline.c:3070
-#, c-format
-msgid "E773: Symlink loop for \"%s\""
-msgstr ""
-
-#: ../memline.c:3221
-msgid "E325: ATTENTION"
-msgstr "E325: CHÚ Ý"
-
-#: ../memline.c:3222
-msgid ""
-"\n"
-"Found a swap file by the name \""
-msgstr ""
-"\n"
-"Tìm thấy một tập tin trao đổi (swap) với tên \""
-
-#: ../memline.c:3226
-msgid "While opening file \""
-msgstr "Khi mở tập tin: \""
-
-#: ../memline.c:3239
-msgid "      NEWER than swap file!\n"
-msgstr "                    MỚI hơn so với tập tin trao đổi (swap)\n"
-
-#: ../memline.c:3244
-#, fuzzy
-msgid ""
-"\n"
-"(1) Another program may be editing the same file.  If this is the case,\n"
-"    be careful not to end up with two different instances of the same\n"
-"    file when making changes."
-msgstr ""
-"\n"
-"(1) Rất có thể một chương trình khác đang soạn thảo tập tin.\n"
-"    Nếu như vậy, hãy cẩn thận khi thay đổi, làm sao để không thu\n"
-"    được hai phương án khác nhau của cùng một tập tin.\n"
-
-#: ../memline.c:3245
-#, fuzzy
-msgid "  Quit, or continue with caution.\n"
-msgstr "    Thoát hoặc tiếp tục với sự cẩn thận.\n"
-
-#: ../memline.c:3246
-#, fuzzy
-msgid "(2) An edit session for this file crashed.\n"
-msgstr ""
-"\n"
-"(2) Lần soạn thảo trước của tập tin này gặp sự cố.\n"
-
-#: ../memline.c:3247
-msgid "    If this is the case, use \":recover\" or \"nvim -r "
-msgstr ""
-"    Trong trường hợp này, hãy sử dụng câu lệnh \":recover\" hoặc \"nvim -r "
-
-#: ../memline.c:3249
-msgid ""
-"\"\n"
-"    to recover the changes (see \":help recovery\").\n"
-msgstr ""
-"\"\n"
-"    để phục hồi những thay đổi (hãy xem \":help recovery\").\n"
-
-#: ../memline.c:3250
-msgid "    If you did this already, delete the swap file \""
-msgstr ""
-"    Nếu đã thực hiện thao tác này rồi, thì hãy xóa tập tin trao đổi (swap) \""
-
-#: ../memline.c:3252
-msgid ""
-"\"\n"
-"    to avoid this message.\n"
-msgstr ""
-"\"\n"
-"    để tránh sự xuất hiện của thông báo này trong tương lai.\n"
-
-#: ../memline.c:3450 ../memline.c:3452
-msgid "Swap file \""
-msgstr "Tập tin trao đổi (swap) \""
-
-#: ../memline.c:3451 ../memline.c:3455
-msgid "\" already exists!"
-msgstr "\" đã có rồi!"
-
-#: ../memline.c:3457
-msgid "VIM - ATTENTION"
-msgstr "VIM - CHÚ Ý"
-
-#: ../memline.c:3459
-msgid "Swap file already exists!"
-msgstr "Tập tin trao đổi (swap) đã rồi!"
-
-#: ../memline.c:3464
-msgid ""
-"&Open Read-Only\n"
-"&Edit anyway\n"
-"&Recover\n"
-"&Quit\n"
-"&Abort"
-msgstr ""
-"&O Mở chỉ để đọc\n"
-"&E Vẫn soạn thảo\n"
-"&R Phục hồi\n"
-"&Q Thoát\n"
-"&A Gián đoạn"
-
-#: ../memline.c:3467
-#, fuzzy
-msgid ""
-"&Open Read-Only\n"
-"&Edit anyway\n"
-"&Recover\n"
-"&Delete it\n"
-"&Quit\n"
-"&Abort"
-msgstr ""
-"&O Mở chỉ để đọc\n"
-"&E Vẫn soạn thảo\n"
-"&R Phục hồi\n"
-"&Q Thoát\n"
-"&A Gián đoạn"
-
-#.
-#. * Change the ".swp" extension to find another file that can be used.
-#. * First decrement the last char: ".swo", ".swn", etc.
-#. * If that still isn't enough decrement the last but one char: ".svz"
-#. * Can happen when editing many "No Name" buffers.
-#.
-#. ".s?a"
-#. ".saa": tried enough, give up
-#: ../memline.c:3528
-msgid "E326: Too many swap files found"
-msgstr "E326: Tìm thấy quá nhiều tập tin trao đổi (swap)"
-
-#: ../memory.c:227
-#, c-format
-msgid "E342: Out of memory!  (allocating %<PRIu64> bytes)"
-msgstr "E342: Không đủ bộ nhớ! (phân chia %<PRIu64> byte)"
-
-#: ../menu.c:62
-msgid "E327: Part of menu-item path is not sub-menu"
-msgstr ""
-"E327: Một phần của đường dẫn tới phần tử của trình đơn không phải là trình "
-"đơn con"
-
-#: ../menu.c:63
-msgid "E328: Menu only exists in another mode"
-msgstr "E328: Trình đơn chỉ có trong chế độ khác"
-
-#: ../menu.c:64
-#, fuzzy, c-format
-msgid "E329: No menu \"%s\""
-msgstr "E329: Không có trình đơn với tên như vậy"
-
-#. Only a mnemonic or accelerator is not valid.
-#: ../menu.c:329
-msgid "E792: Empty menu name"
-msgstr ""
-
-#: ../menu.c:340
-msgid "E330: Menu path must not lead to a sub-menu"
-msgstr "E330: Đường dẫn tới trình đơn không được đưa tới trình đơn con"
-
-#: ../menu.c:365
-msgid "E331: Must not add menu items directly to menu bar"
-msgstr ""
-"E331: Các phần tử của trình đơn không thể thêm trực tiếp vào thanh trình đơn"
-
-#: ../menu.c:370
-msgid "E332: Separator cannot be part of a menu path"
-msgstr "E332: Cái phân chia không thể là một phần của đường dẫn tới trình đơn"
-
-#. Now we have found the matching menu, and we list the mappings
-#. Highlight title
-#: ../menu.c:762
-msgid ""
-"\n"
-"--- Menus ---"
-msgstr ""
-"\n"
-"--- Trình đơn ---"
-
-#: ../menu.c:1313
-msgid "E333: Menu path must lead to a menu item"
-msgstr "E333: Đường dẫn tới trình đơn phải đưa tới một phần tử cuả trình đơn"
-
-#: ../menu.c:1330
-#, c-format
-msgid "E334: Menu not found: %s"
-msgstr "E334: Không tìm thấy trình đơn: %s"
-
-#: ../menu.c:1396
-#, c-format
-msgid "E335: Menu not defined for %s mode"
-msgstr "E335: Trình đơn không được định nghĩa cho chế độ %s"
-
-#: ../menu.c:1426
-msgid "E336: Menu path must lead to a sub-menu"
-msgstr "E336: Đường dẫn tới trình đơn phải đưa tới một trình đơn con"
-
-#: ../menu.c:1447
-msgid "E337: Menu not found - check menu names"
-msgstr "E337: Không tìm thấy trình đơn - hãy kiểm tra tên trình đơn"
-
-#: ../message.c:423
-#, c-format
-msgid "Error detected while processing %s:"
-msgstr "Phát hiện lỗi khi xử lý %s:"
-
-#: ../message.c:445
-#, c-format
-msgid "line %4ld:"
-msgstr "dòng %4ld:"
-
-#: ../message.c:617
-#, c-format
-msgid "E354: Invalid register name: '%s'"
-msgstr "E354: Tên sổ đăng ký không cho phép: '%s'"
-
-#: ../message.c:986
-msgid "Interrupt: "
-msgstr "Gián đoạn: "
-
-#: ../message.c:988
-#, fuzzy
-msgid "Press ENTER or type command to continue"
-msgstr "Nhấn phím ENTER hoặc nhập câu lệnh để tiếp tục"
-
-#: ../message.c:1843
-#, fuzzy, c-format
-msgid "%s line %<PRId64>"
-msgstr "%s, dòng %<PRId64>"
-
-#: ../message.c:2392
-msgid "-- More --"
-msgstr "-- Còn nữa --"
-
-#: ../message.c:2398
-msgid " SPACE/d/j: screen/page/line down, b/u/k: up, q: quit "
-msgstr ""
-
-#: ../message.c:3021 ../message.c:3031
-msgid "Question"
-msgstr "Câu hỏi"
-
-#: ../message.c:3023
-msgid ""
-"&Yes\n"
-"&No"
-msgstr ""
-"&Có\n"
-"&Không"
-
-#: ../message.c:3033
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -4221,7 +1686,1513 @@ msgstr ""
 "&Không\n"
 "&Dừng"
 
-#: ../message.c:3045
+msgid "Input _Methods"
+msgstr "Phương pháp _nhập liệu"
+
+msgid "VIM - Search and Replace..."
+msgstr "VIM - Tìm kiếm và thay thế..."
+
+msgid "VIM - Search..."
+msgstr "VIM - Tìm kiếm..."
+
+msgid "Find what:"
+msgstr "Tìm kiếm gì:"
+
+msgid "Replace with:"
+msgstr "Thay thế bởi:"
+
+msgid "Match whole word only"
+msgstr "Chỉ tìm tương ứng hoàn toàn với từ"
+
+msgid "Match case"
+msgstr "Có tính kiểu chữ"
+
+msgid "Direction"
+msgstr "Hướng"
+
+msgid "Up"
+msgstr "Lên"
+
+msgid "Down"
+msgstr "Xuống"
+
+msgid "Find Next"
+msgstr "Tìm tiếp"
+
+msgid "Replace"
+msgstr "Thay thế"
+
+msgid "Replace All"
+msgstr "Thay thế tất cả"
+
+msgid "Vim: Received \"die\" request from session manager\n"
+msgstr "Vim: Nhận được yêu cầu \"chết\" (dừng) từ trình quản lý màn hình\n"
+
+msgid "Vim: Main window unexpectedly destroyed\n"
+msgstr "Vim: Cửa sổ chính đã bị đóng đột ngột\n"
+
+msgid "Font Selection"
+msgstr "Chọn phông chữ"
+
+msgid "Used CUT_BUFFER0 instead of empty selection"
+msgstr "Sử dụng CUT_BUFFER0 thay cho lựa chọn trống rỗng"
+
+msgid "Filter"
+msgstr "Đầu lọc"
+
+msgid "Directories"
+msgstr "Thư mục"
+
+msgid "Help"
+msgstr "Trợ giúp"
+
+msgid "Files"
+msgstr "Tập tin"
+
+msgid "Selection"
+msgstr "Lựa chọn"
+
+msgid "Undo"
+msgstr "Hủy thao tác"
+
+#, c-format
+msgid "E671: Cannot find window title \"%s\""
+msgstr "E671: Không tìm được tiêu đề cửa sổ \"%s\""
+
+#, c-format
+msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
+msgstr "E243: Tham số không được hỗ trợ: \"-%s\"; Hãy sử dụng phiên bản OLE."
+
+msgid "E672: Unable to open window inside MDI application"
+msgstr "E672: Không mở được cửa sổ bên trong ứng dụng MDI"
+
+msgid "Find string (use '\\\\' to find  a '\\')"
+msgstr "Tìm kiếm chuỗi (hãy sử dụng '\\\\' để tìm kiếm dấu '\\')"
+
+msgid "Find & Replace (use '\\\\' to find  a '\\')"
+msgstr "Tìm kiếm và Thay thế (hãy sử dụng '\\\\' để tìm kiếm dấu '\\')"
+
+msgid "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
+msgstr ""
+"Vim E458: Không chỉ định được bản ghi trong bảng màu, một vài màu có thể "
+"hiển thị không chính xác"
+
+#, c-format
+msgid "E250: Fonts for the following charsets are missing in fontset %s:"
+msgstr "E250: Trong bộ phông chữ %s thiếu phông cho các bảng mã sau:"
+
+#, c-format
+msgid "E252: Fontset name: %s"
+msgstr "E252: Bộ phông chữ: %s"
+
+#, c-format
+msgid "Font '%s' is not fixed-width"
+msgstr "Phông chữ '%s' không phải là phông có độ rộng cố định (fixed-width)"
+
+#, c-format
+msgid "E253: Fontset name: %s\n"
+msgstr "E253: Bộ phông chữ: %s\n"
+
+#, c-format
+msgid "Font0: %s\n"
+msgstr "Font0: %s\n"
+
+#, c-format
+msgid "Font1: %s\n"
+msgstr "Font1: %s\n"
+
+#, c-format
+msgid "Font%ld width is not twice that of font0\n"
+msgstr ""
+"Chiều rộng phông chữ font%ld phải lớn hơn hai lần so với chiều rộng font0\n"
+
+#, c-format
+msgid "Font0 width: %ld\n"
+msgstr "Chiều rộng font0: %ld\n"
+
+#, c-format
+msgid ""
+"Font1 width: %ld\n"
+"\n"
+msgstr ""
+"Chiều rộng font1: %ld\n"
+"\n"
+
+msgid "E256: Hangul automata ERROR"
+msgstr "E256: LỖI máy tự động Hangual (tiếng Hàn)"
+
+msgid "Add a new database"
+msgstr "Thêm một cơ sở dữ liệu mới"
+
+msgid "Query for a pattern"
+msgstr "Yêu cầu theo một mẫu"
+
+msgid "Show this message"
+msgstr "Hiển thị thông báo này"
+
+msgid "Kill a connection"
+msgstr "Hủy kết nối"
+
+msgid "Reinit all connections"
+msgstr "Khởi đầu lại tất cả các kết nối"
+
+msgid "Show connections"
+msgstr "Hiển thị kết nối"
+
+#, c-format
+msgid "E560: Usage: cs[cope] %s"
+msgstr "E560: Sử dụng: cs[cope] %s"
+
+msgid "This cscope command does not support splitting the window.\n"
+msgstr "Câu lệnh cscope này không hỗ trợ việc chia (split) cửa sổ.\n"
+
+msgid "E562: Usage: cstag <ident>"
+msgstr "E562: Sử dụng: cstag <tên>"
+
+# TODO: Capitalise first word of message?
+msgid "E257: cstag: Tag not found"
+msgstr "E257: cstag: không tìm thấy thẻ ghi"
+
+#, c-format
+msgid "E563: stat(%s) error: %d"
+msgstr "E563: lỗi stat(%s): %d"
+
+msgid "E563: stat error"
+msgstr "E563: lỗi stat"
+
+#, c-format
+msgid "E564: %s is not a directory or a valid cscope database"
+msgstr ""
+"E564: %s không phải là một thư mục hoặc một cơ sở dữ liệu cscope thích hợp"
+
+#, c-format
+msgid "Added cscope database %s"
+msgstr "Đã thêm cơ sở dữ liệu cscope %s"
+
+# TODO: Capitalise first word of message?
+msgid "E262: Error reading cscope connection %ld"
+msgstr "E262: lỗi lấy thông tin từ kết nối cscope %ld"
+
+# TODO: Capitalise first word of message?
+msgid "E561: Unknown cscope search type"
+msgstr "E561: không rõ loại tìm kiếm cscope"
+
+msgid "E566: Could not create cscope pipes"
+msgstr "E566: Không tạo được đường ống (pipe) cho cscope"
+
+msgid "E622: Could not fork for cscope"
+msgstr "E622: Không thực hiện được fork() cho cscope"
+
+msgid "cs_create_connection exec failed"
+msgstr "thực hiện cs_create_connection không thành công"
+
+msgid "E623: Could not spawn cscope process"
+msgstr "E623: Chạy tiến trình cscope không thành công"
+
+msgid "cs_create_connection: fdopen for to_fp failed"
+msgstr "cs_create_connection: thực hiện fdopen cho to_fp không thành công"
+
+msgid "cs_create_connection: fdopen for fr_fp failed"
+msgstr "cs_create_connection: thực hiện fdopen cho fr_fp không thành công"
+
+# TODO: Capitalise first word of message?
+msgid "E567: No cscope connections"
+msgstr "E567: không có kết nối với cscope"
+
+# TODO: Capitalise first word of message?
+msgid "E259: No matches found for cscope query %s of %s"
+msgstr "E259: không tìm thấy tương ứng với yêu cầu cscope %s cho %s"
+
+# TODO: Capitalise first word of message?
+msgid "E469: Invalid cscopequickfix flag %c for %c"
+msgstr "E469: cờ cscopequickfix %c cho %c không chính xác"
+
+msgid "cscope commands:\n"
+msgstr "các lệnh cscope:\n"
+
+#, c-format
+msgid "%-5s: %-30s (Usage: %s)"
+msgstr "%-5s: %-30s (Sử dụng: %s)"
+
+# TODO: Capitalise first word of message?
+msgid "E625: Cannot open cscope database: %s"
+msgstr "E625: không mở được cơ sở dữ liệu cscope: %s"
+
+# TODO: Capitalise first word of message?
+msgid "E626: Cannot get cscope database information"
+msgstr "E626: không lấy được thông tin về cơ sở dữ liệu cscope"
+
+# TODO: Capitalise first word of message?
+msgid "E568: Duplicate cscope database not added"
+msgstr "E568: cơ sở dữ liệu này của cscope đã được gắn vào từ trước"
+
+msgid "E569: maximum number of cscope connections reached"
+msgstr "E569: đã đạt tới số kết nối lớn nhất cho phép với cscope"
+
+# TODO: Capitalise first word of message?
+msgid "E261: Cscope connection %s not found"
+msgstr "E261: kết nối với cscope %s không được tìm thấy"
+
+#, c-format
+msgid "cscope connection %s closed"
+msgstr "kết nối %s với cscope đã bị đóng"
+
+# TODO: Capitalise first word of message?
+msgid "E570: Fatal error in cs_manage_matches"
+msgstr "E570: lỗi nặng trong cs_manage_matches"
+
+#, c-format
+msgid "Cscope tag: %s"
+msgstr "Thẻ ghi cscope: %s"
+
+msgid ""
+"\n"
+"   #   line"
+msgstr ""
+"\n"
+"   #   dòng"
+
+msgid "filename / context / line\n"
+msgstr "tên tập tin / nội dung / dòng\n"
+
+#, c-format
+msgid "E609: Cscope error: %s"
+msgstr "E609: Lỗi cscope: %s"
+
+msgid "All cscope databases reset"
+msgstr "Khởi động lại tất cả cơ sở dữ liệu cscope"
+
+msgid "no cscope connections\n"
+msgstr "không có kết nối với cscope\n"
+
+msgid " # pid    database name                       prepend path\n"
+msgstr " # pid    tên cơ sở dữ liệu                   đường dẫn ban đầu\n"
+
+msgid ""
+"E263: Sorry, this command is disabled, the Python library could not be "
+"loaded."
+msgstr ""
+"E263: Rất tiếc câu lệnh này không làm việc, vì thư viện Python chưa được nạp."
+
+msgid "E659: Cannot invoke Python recursively"
+msgstr "E659: Không thể gọi Python một cách đệ quy"
+
+msgid "can't delete OutputObject attributes"
+msgstr "Không xóa được thuộc tính OutputObject"
+
+msgid "softspace must be an integer"
+msgstr "giá trị softspace phải là một số nguyên"
+
+msgid "invalid attribute"
+msgstr "thuộc tính không đúng"
+
+msgid "writelines() requires list of strings"
+msgstr "writelines() yêu cầu một danh sách các chuỗi"
+
+msgid "E264: Python: Error initialising I/O objects"
+msgstr "E264: Python: Lỗi khi bắt đầu sử dụng vật thể I/O"
+
+msgid "invalid expression"
+msgstr "biểu thức không đúng"
+
+msgid "expressions disabled at compile time"
+msgstr "biểu thức bị tắt khi biên dịch"
+
+msgid "attempt to refer to deleted buffer"
+msgstr "cố chỉ đến bộ đệm đã bị xóa"
+
+msgid "line number out of range"
+msgstr "số thứ tự của dòng vượt quá giới hạn"
+
+#, c-format
+msgid "<buffer object (deleted) at %8lX>"
+msgstr "<vật thể của bộ đệm (bị xóa) tại %8lX>"
+
+msgid "invalid mark name"
+msgstr "tên dấu hiệu không đúng"
+
+msgid "no such buffer"
+msgstr "không có bộ đệm như vậy"
+
+msgid "attempt to refer to deleted window"
+msgstr "cố chỉ đến cửa sổ đã bị đóng"
+
+msgid "readonly attribute"
+msgstr "thuộc tính chỉ đọc"
+
+msgid "cursor position outside buffer"
+msgstr "vị trí con trỏ nằm ngoài bộ đệm"
+
+#, c-format
+msgid "<window object (deleted) at %.8lX>"
+msgstr "<vật thể của cửa sổ (bị xóa) tại %.8lX>"
+
+#, c-format
+msgid "<window object (unknown) at %.8lX>"
+msgstr "<vật thể của cửa sổ (không rõ) tại %.8lX>"
+
+#, c-format
+msgid "<window %d>"
+msgstr "<cửa sổ %d>"
+
+msgid "no such window"
+msgstr "không có cửa sổ như vậy"
+
+msgid "cannot save undo information"
+msgstr "không ghi được thông tin về việc hủy thao tác"
+
+msgid "cannot delete line"
+msgstr "không xóa được dòng"
+
+msgid "cannot replace line"
+msgstr "không thay thế được dòng"
+
+msgid "cannot insert line"
+msgstr "không chèn được dòng"
+
+msgid "string cannot contain newlines"
+msgstr "chuỗi không thể chứa ký tự dòng mới"
+
+msgid ""
+"E266: Sorry, this command is disabled, the Ruby library could not be loaded."
+msgstr ""
+"E266: Rất tiếc câu lệnh này không làm việc, vì thư viện Ruby chưa đượcnạp."
+
+# TODO: Capitalise first word of message?
+msgid "E273: Unknown longjmp status %d"
+msgstr "E273: không rõ trạng thái của longjmp %d"
+
+msgid "Toggle implementation/definition"
+msgstr "Bật tắt giữa thi hành/định nghĩa"
+
+msgid "Show base class of"
+msgstr "Hiển thị hạng cơ bản của"
+
+msgid "Show overridden member function"
+msgstr "Hiển thị hàm số bị nạp đè lên"
+
+msgid "Retrieve from file"
+msgstr "Nhận từ tập tin"
+
+msgid "Retrieve from project"
+msgstr "Nhận từ dự án"
+
+msgid "Retrieve from all projects"
+msgstr "Nhận từ tất cả các dự án"
+
+msgid "Retrieve"
+msgstr "Nhận"
+
+msgid "Show source of"
+msgstr "Hiển thị mã nguồn"
+
+msgid "Find symbol"
+msgstr "Tìm ký hiệu"
+
+msgid "Browse class"
+msgstr "Duyệt hạng"
+
+msgid "Show class in hierarchy"
+msgstr "Hiển thị hạng trong hệ thống cấp bậc"
+
+msgid "Show class in restricted hierarchy"
+msgstr "Hiển thị hạng trong hệ thống cấp bậc giới hạn"
+
+msgid "Xref refers to"
+msgstr "Xref chỉ đến"
+
+msgid "Xref referred by"
+msgstr "Liên kết đến xref từ"
+
+msgid "Xref has a"
+msgstr "Xref có một"
+
+msgid "Xref used by"
+msgstr "Xref được sử dụng bởi"
+
+msgid "Show docu of"
+msgstr "Hiển thị docu của"
+
+msgid "Generate docu for"
+msgstr "Tạo docu cho"
+
+msgid "not "
+msgstr "không "
+
+msgid "connected"
+msgstr "được kết nối"
+
+
+msgid "invalid buffer number"
+msgstr "số của bộ đệm không đúng"
+
+msgid "not implemented yet"
+msgstr "tạm thời chưa được thực thi"
+
+msgid "unknown option"
+msgstr "tùy chọn không rõ"
+
+msgid "cannot set line(s)"
+msgstr "không thể đặt (các) dòng"
+
+msgid "mark not set"
+msgstr "dấu hiệu chưa được đặt"
+
+#, c-format
+msgid "row %d column %d"
+msgstr "hàng %d cột %d"
+
+msgid "cannot insert/append line"
+msgstr "không thể chèn hoặc thêm dòng"
+
+msgid "unknown flag: "
+msgstr "cờ không biết: "
+
+msgid "unknown vimOption"
+msgstr "không rõ tùy chọn vimOption"
+
+msgid "keyboard interrupt"
+msgstr "sự gián đoạn của bàn phím"
+
+msgid "Vim error"
+msgstr "lỗi của vim"
+
+msgid "cannot create buffer/window command: object is being deleted"
+msgstr "không tạo được câu lệnh của bộ đệm hay của cửa sổ: vật thể đang bị xóa"
+
+msgid ""
+"cannot register callback command: buffer/window is already being deleted"
+msgstr "không đăng ký được câu lệnh gọi ngược: bộ đệm hoặc cửa sổ đang bị xóa"
+
+msgid ""
+"E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-dev@vim."
+"org"
+msgstr ""
+"E280: LỖI NẶNG CỦA TCL: bị hỏng danh sách liên kết!? Hãy thông báo việc "
+"nàyđến danh sách thư (mailing list) vim-dev@vim.org"
+
+msgid "cannot register callback command: buffer/window reference not found"
+msgstr ""
+"không đăng ký được câu lệnh gọi ngược: không tìm thấy liên kết đến bộ đệm "
+"hoặc cửa sổ"
+
+msgid ""
+"E571: Sorry, this command is disabled: the Tcl library could not be loaded."
+msgstr ""
+"E571: Rất tiếc là câu lệnh này không làm việc, vì thư viện Tcl chưa được nạp"
+
+msgid ""
+"E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim.org"
+msgstr ""
+"E281: LỖI TCL: mã thoát ra không phải là một số nguyên!? Hãy thông báo điều "
+"này đến danh sách thư (mailing list) vim-dev@vim.org"
+
+msgid "cannot get line"
+msgstr "không nhận được dòng"
+
+msgid "Unable to register a command server name"
+msgstr "Không đăng ký được một tên cho máy chủ câu lệnh"
+
+msgid "E248: Failed to send command to the destination program"
+msgstr "E248: Gửi câu lệnh vào chương trình khác không thành công"
+
+#, c-format
+msgid "E573: Invalid server id used: %s"
+msgstr "E573: Sử dụng id máy chủ không đúng: %s"
+
+msgid "E251: VIM instance registry property is badly formed.  Deleted!"
+msgstr "E251: Thuộc tính đăng ký của Vim được định dạng không đúng.  Xóa!"
+
+msgid "Unknown option"
+msgstr "Tùy chọn không biết"
+
+msgid "Too many edit arguments"
+msgstr "Có quá nhiều tham số soạn thảo"
+
+msgid "Argument missing after"
+msgstr "Thiếu tham số sau"
+
+msgid "Garbage after option"
+msgstr "Rác sau tùy chọn"
+
+msgid "Too many \"+command\", \"-c command\" or \"--cmd command\" arguments"
+msgstr ""
+"Quá nhiều tham số \"+câu lệnh\", \"-c câu lệnh\" hoặc \"--cmd câu lệnh\""
+
+msgid "Invalid argument for"
+msgstr "Tham số không được phép cho"
+
+msgid "This Vim was not compiled with the diff feature."
+msgstr "Vim không được biên dịch với tính năng hỗ trợ xem khác biệt (diff)."
+
+msgid "Attempt to open script file again: \""
+msgstr "Thử mở tập tin script một lần nữa: \""
+
+msgid "Cannot open for reading: \""
+msgstr "Không mở để đọc được: \""
+
+msgid "Cannot open for script output: \""
+msgstr "Không mở cho đầu ra script được: \""
+
+#, c-format
+msgid "%d files to edit\n"
+msgstr "%d tập tin để soạn thảo\n"
+
+msgid "Vim: Warning: Output is not to a terminal\n"
+msgstr "Vim: Cảnh báo: Đầu ra không hướng tới một terminal\n"
+
+msgid "Vim: Warning: Input is not from a terminal\n"
+msgstr "Vim: Cảnh báo: Đầu vào không phải đến từ một terminal\n"
+
+msgid "pre-vimrc command line"
+msgstr "dòng lệnh chạy trước khi thực hiện vimrc"
+
+#, c-format
+msgid "E282: Cannot read from \"%s\""
+msgstr "E282: Không đọc được từ \"%s\""
+
+msgid ""
+"\n"
+"More info with: \"vim -h\"\n"
+msgstr ""
+"\n"
+"Xem thông tin chi tiết với: \"vim -h\"\n"
+
+msgid "[file ..]       edit specified file(s)"
+msgstr "[tập tin ..]     soạn thảo (các) tập tin chỉ ra"
+
+msgid "-               read text from stdin"
+msgstr "-                đọc văn bản từ đầu vào stdin"
+
+msgid "-t tag          edit file where tag is defined"
+msgstr "-t thẻ ghi      soạn thảo tập tin từ chỗ thẻ ghi chỉ ra"
+
+msgid "-q [errorfile]  edit file with first error"
+msgstr "-q [tập tin lỗi] soạn thảo tập tin với lỗi đầu tiên"
+
+msgid ""
+"\n"
+"\n"
+"Usage:"
+msgstr ""
+"\n"
+"\n"
+"Sử dụng:"
+
+msgid " vim [arguments] "
+msgstr " vim [các tham số] "
+
+msgid ""
+"\n"
+"   or:"
+msgstr ""
+"\n"
+"   hoặc:"
+
+msgid ""
+"\n"
+"\n"
+"Arguments:\n"
+msgstr ""
+"\n"
+"\n"
+"Tham số:\n"
+
+msgid "--\t\t\tOnly file names after this"
+msgstr "--\t\t\tSau tham số chỉ đưa ra tên tập tin"
+
+msgid "--literal\t\tDon't expand wildcards"
+msgstr "--literal\t\tKhông thực hiện việc mở rộng wildcard"
+
+msgid "-register\t\tRegister this gvim for OLE"
+msgstr "-register\t\tĐăng ký gvim này cho OLE"
+
+msgid "-unregister\t\tUnregister gvim for OLE"
+msgstr "-unregister\t\tBỏ đăng ký gvim này cho OLE"
+
+msgid "-g\t\t\tRun using GUI (like \"gvim\")"
+msgstr "-g\t\t\tSử dụng giao diện đồ họa GUI (giống \"gvim\")"
+
+msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
+msgstr ""
+"-f  hoặc  --nofork\tTrong chương trình hoạt động: Không thực hiện fork khi "
+"chạy GUI"
+
+msgid "-v\t\t\tVi mode (like \"vi\")"
+msgstr "-v\t\t\tChế độ Vi (giống \"vi\")"
+
+msgid "-e\t\t\tEx mode (like \"ex\")"
+msgstr "-e\t\t\tChế độ Ex (giống \"ex\")"
+
+msgid "-s\t\t\tSilent (batch) mode (only for \"ex\")"
+msgstr "-s\t\t\tChế độ ít đưa thông báo (gói) (chỉ dành cho \"ex\")"
+
+msgid "-d\t\t\tDiff mode (like \"vimdiff\")"
+msgstr "-d\t\t\tChế độ khác biệt, diff (giống \"vimdiff\")"
+
+msgid "-y\t\t\tEasy mode (like \"evim\", modeless)"
+msgstr "-y\t\t\tChế độ đơn giản (giống \"evim\", không có chế độ)"
+
+msgid "-R\t\t\tReadonly mode (like \"view\")"
+msgstr "-R\t\t\tChế độ chỉ đọc (giống \"view\")"
+
+msgid "-Z\t\t\tRestricted mode (like \"rvim\")"
+msgstr "-Z\t\t\tChế độ hạn chế (giống \"rvim\")"
+
+msgid "-m\t\t\tModifications (writing files) not allowed"
+msgstr "-m\t\t\tKhông có khả năng ghi nhớ thay đổi (ghi nhớ tập tin)"
+
+msgid "-M\t\t\tModifications in text not allowed"
+msgstr "-M\t\t\tKhông có khả năng thay đổi văn bản"
+
+msgid "-b\t\t\tBinary mode"
+msgstr "-b\t\t\tChế độ nhị phân (binary)"
+
+msgid "-l\t\t\tLisp mode"
+msgstr "-l\t\t\tChế độ Lisp"
+
+msgid "-C\t\t\tCompatible with Vi: 'compatible'"
+msgstr "-C\t\t\tChế độ tương thích với Vi: 'compatible'"
+
+msgid "-N\t\t\tNot fully Vi compatible: 'nocompatible'"
+msgstr "-N\t\t\tChế độ không tương thích hoàn toàn với Vi: 'nocompatible'"
+
+msgid "-V[N]\t\tVerbose level"
+msgstr "-V[N]\t\tMức độ chi tiết của thông báo"
+
+msgid "-D\t\t\tDebugging mode"
+msgstr "-D\t\t\tChế độ sửa lỗi (debug)"
+
+msgid "-n\t\t\tNo swap file, use memory only"
+msgstr "-n\t\t\tKhông sử dụng tập tin swap, chỉ sử dụng bộ nhớ"
+
+msgid "-r\t\t\tList swap files and exit"
+msgstr "-r\t\t\tLiệt kê các tập tin swap rồi thoát"
+
+msgid "-r (with file name)\tRecover crashed session"
+msgstr "-r (với tên tập tin)\tPhục hồi lần soạn thảo gặp sự cố"
+
+msgid "-L\t\t\tSame as -r"
+msgstr "-L\t\t\tGiống với -r"
+
+msgid "-f\t\t\tDon't use newcli to open window"
+msgstr "-f\t\t\tKhông sử dụng newcli để mở cửa sổ"
+
+msgid "-dev <device>\t\tUse <device> for I/O"
+msgstr "-dev <thiết bị>\t\tSử dụng <thiết bị> cho I/O"
+
+msgid "-A\t\t\tStart in Arabic mode"
+msgstr "-A\t\t\tKhởi động vào chế độ Ả Rập"
+
+msgid "-H\t\t\tStart in Hebrew mode"
+msgstr "-H\t\t\tKhởi động vào chế độ Do thái"
+
+msgid "-F\t\t\tStart in Farsi mode"
+msgstr "-F\t\t\tKhởi động vào chế độ Farsi"
+
+msgid "-T <terminal>\tSet terminal type to <terminal>"
+msgstr "-T <terminal>\tĐặt loại terminal thành <terminal>"
+
+msgid "-u <vimrc>\t\tUse <vimrc> instead of any .vimrc"
+msgstr "-u <vimrc>\t\tSử dụng <vimrc> thay thế cho mọi .vimrc"
+
+msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
+msgstr "-U <gvimrc>\t\tSử dụng <gvimrc> thay thế cho mọi .gvimrc"
+
+msgid "--noplugin\t\tDon't load plugin scripts"
+msgstr "--noplugin\t\tKhông nạp bất kỳ script môđun nào"
+
+msgid "-o[N]\t\tOpen N windows (default: one for each file)"
+msgstr "-o[N]\t\tMở N cửa sổ (theo mặc định: mỗi cửa sổ cho một tập tin)"
+
+msgid "-O[N]\t\tLike -o but split vertically"
+msgstr "-O[N]\t\tGiống với -o nhưng phân chia theo đường thẳng đứng"
+
+msgid "+\t\t\tStart at end of file"
+msgstr "+\t\t\tBắt đầu soạn thảo từ cuối tập tin"
+
+msgid "+<lnum>\t\tStart at line <lnum>"
+msgstr "+<lnum>\t\tBắt đầu soạn thảo từ dòng thứ <lnum> (số thứ tự của dòng)"
+
+msgid "--cmd <command>\tExecute <command> before loading any vimrc file"
+msgstr "--cmd <câu lệnh>\tThực hiện <câu lệnh> trước khi nạp tập tin vimrc"
+
+msgid "-c <command>\t\tExecute <command> after loading the first file"
+msgstr "-c <câu lệnh>\t\tThực hiện <câu lệnh> sau khi nạp tập tin đầu tiên"
+
+msgid "-S <session>\t\tSource file <session> after loading the first file"
+msgstr "-S <session>\t\tThực hiện <session> sau khi nạp tập tin đầu tiên"
+
+msgid "-s <scriptin>\tRead Normal mode commands from file <scriptin>"
+msgstr ""
+"-s <scriptin>\tĐọc các lệnh của chế độ Thông thường từ tập tin <scriptin>"
+
+msgid "-w <scriptout>\tAppend all typed commands to file <scriptout>"
+msgstr "-w <scriptout>\tThêm tất cả các lệnh đã gõ vào tập tin <scriptout>"
+
+msgid "-W <scriptout>\tWrite all typed commands to file <scriptout>"
+msgstr "-W <scriptout>\tGhi nhớ tất cả các lệnh đã gõ vào tập tin <scriptout>"
+
+msgid "-x\t\t\tEdit encrypted files"
+msgstr "-x\t\t\tSoạn thảo tập tin đã mã hóa"
+
+msgid "-display <display>\tConnect Vim to this particular X-server"
+msgstr "-display <màn hình>\tKết nối Vim tới máy chủ X đã chỉ ra"
+
+msgid "-X\t\t\tDo not connect to X server"
+msgstr "-X\t\t\tKhông thực hiện việc kết nối tới máy chủ X"
+
+msgid "--remote <files>\tEdit <files> in a Vim server if possible"
+msgstr "--remote <tập tin>\tSoạn thảo <tập tin> trên máy chủ Vim nếu có thể"
+
+msgid "--remote-silent <files>  Same, don't complain if there is no server"
+msgstr ""
+"--remote-silent <tập tin>  Cũng vậy, nhưng không kêu ca dù không có máy chủ"
+
+msgid ""
+"--remote-wait <files>  As --remote but wait for files to have been edited"
+msgstr "--remote-wait <tập tin>  Cũng như --remote, nhưng chờ sự kết thúc"
+
+msgid ""
+"--remote-wait-silent <files>  Same, don't complain if there is no server"
+msgstr ""
+"--remote-wait-silent <tập tin>  Cũng vậy, nhưng không kêu ca dù không có máy "
+"chủ"
+
+msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
+msgstr "--remote-send <phím>\tGửi <phím> lên máy chủ Vim và thoát"
+
+msgid "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
+msgstr ""
+"--remote-expr <biểu thức>\tTính <biểu thức> trên máy chủ Vim và in ra kết quả"
+
+msgid "--serverlist\t\tList available Vim server names and exit"
+msgstr "--serverlist\t\tHiển thị danh sách máy chủ Vim và thoát"
+
+msgid "--servername <name>\tSend to/become the Vim server <name>"
+msgstr "--servername <tên>\tGửi lên (hoặc trở thành) máy chủ Vim với <tên>"
+
+msgid "-i <viminfo>\t\tUse <viminfo> instead of .viminfo"
+msgstr "-i <viminfo>\t\tSử dụng tập tin <viminfo> thay cho .viminfo"
+
+msgid "-h  or  --help\tPrint Help (this message) and exit"
+msgstr "-h hoặc --help\tHiển thị Trợ giúp (thông tin này) và thoát"
+
+msgid "--version\t\tPrint version information and exit"
+msgstr "--version\t\tĐưa ra thông tin về phiên bản Vim và thoát"
+
+msgid ""
+"\n"
+"Arguments recognised by gvim (Motif version):\n"
+msgstr ""
+"\n"
+"Tham số cho gvim (phiên bản Motif):\n"
+
+msgid ""
+"\n"
+"Arguments recognised by gvim (neXtaw version):\n"
+msgstr ""
+"\n"
+"Tham số cho gvim (phiên bản neXtaw):\n"
+
+msgid ""
+"\n"
+"Arguments recognised by gvim (Athena version):\n"
+msgstr ""
+"\n"
+"Tham số cho gvim (phiên bản Athena):\n"
+
+msgid "-display <display>\tRun Vim on <display>"
+msgstr "-display <màn hình>\tChạy Vim trong <màn hình> đã chỉ ra"
+
+msgid "-iconic\t\tStart Vim iconified"
+msgstr "-iconic\t\tChạy Vim ở dạng thu nhỏ"
+
+msgid "-name <name>\t\tUse resource as if vim was <name>"
+msgstr "-name <tên>\t\tSử dụng tài nguyên giống như khi vim có <tên>"
+
+msgid "\t\t\t  (Unimplemented)\n"
+msgstr "\t\t\t  (Chưa được thực thi)\n"
+
+msgid "-background <color>\tUse <color> for the background (also: -bg)"
+msgstr "-background <màu>\tSử dụng <màu> chỉ ra cho nền (cũng như: -bg)"
+
+msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
+msgstr ""
+"-foreground <màu>\tSử dụng <màu> cho văn bản thông thường (cũng như: -fg)"
+
+msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
+msgstr ""
+"-font <phông>\t\tSử dụng <phông> chữ cho văn bản thông thường (cũng như: -fn)"
+
+msgid "-boldfont <font>\tUse <font> for bold text"
+msgstr "-boldfont <phông>\tSử dụng <phông> chữ cho văn bản in đậm"
+
+msgid "-italicfont <font>\tUse <font> for italic text"
+msgstr "-italicfont <phông>\tSử dụng <phông> chữ cho văn bản in nghiêng"
+
+msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
+msgstr "-geometry <kích thước>\tSử dụng <kích thước> ban đầu (cũng như: -geom)"
+
+msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
+msgstr ""
+"-borderwidth <rộng>\tSử dụng đường viền có chiều <rộng> (cũng như: -bw)"
+
+msgid "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
+msgstr ""
+"-scrollbarwidth <rộng> Sử dụng thanh cuộn với chiều <rộng> (cũng như: -sw)"
+
+msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
+msgstr ""
+"-menuheight <cao>\tSử dụng thanh trình đơn với chiều <cao> (cũng như: -mh)"
+
+msgid "-reverse\t\tUse reverse video (also: -rv)"
+msgstr "-reverse\t\tSử dụng chế độ video đảo ngược (cũng như: -rv)"
+
+msgid "+reverse\t\tDon't use reverse video (also: +rv)"
+msgstr "+reverse\t\tKhông sử dụng chế độ video đảo ngược (cũng như: +rv)"
+
+msgid "-xrm <resource>\tSet the specified resource"
+msgstr "-xrm <tài nguyên>\tĐặt <tài nguyên> chỉ ra"
+
+msgid ""
+"\n"
+"Arguments recognised by gvim (RISC OS version):\n"
+msgstr ""
+"\n"
+"Tham số cho gvim (phiên bản RISC OS):\n"
+
+msgid "--columns <number>\tInitial width of window in columns"
+msgstr "--columns <số>\tChiều rộng ban đầu của cửa sổ tính theo số cột"
+
+msgid "--rows <number>\tInitial height of window in rows"
+msgstr "--rows <số>\tChiều cao ban đầu của cửa sổ tính theo số dòng"
+
+msgid ""
+"\n"
+"Arguments recognised by gvim (GTK+ version):\n"
+msgstr ""
+"\n"
+"Tham số cho gvim (phiên bản GTK+):\n"
+
+msgid "-display <display>\tRun Vim on <display> (also: --display)"
+msgstr ""
+"-display <màn hình>\tChạy Vim trên <màn hình> chỉ ra (cũng như: --display)"
+
+msgid "--role <role>\tSet a unique role to identify the main window"
+msgstr "--role <vai trò>\tĐặt <vai trò> duy nhất để nhận diện cửa sổ chính"
+
+msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
+msgstr "--socketid <xid>\tMở Vim bên trong thành phần GTK khác"
+
+msgid "-P <parent title>\tOpen Vim inside parent application"
+msgstr "-P <tiêu đề của mẹ>\tMở Vim bên trong ứng dụng mẹ"
+
+msgid "No display"
+msgstr "Không có màn hình"
+
+msgid ": Send failed.\n"
+msgstr ": Gửi không thành công.\n"
+
+msgid ": Send failed. Trying to execute locally\n"
+msgstr ": Gửi không thành công. Thử thực hiện nội bộ\n"
+
+#, c-format
+msgid "%d of %d edited"
+msgstr "đã soạn thảo %d từ %d"
+
+msgid "No display: Send expression failed.\n"
+msgstr "Không có màn hình: gửi biểu thức không thành công.\n"
+
+msgid ": Send expression failed.\n"
+msgstr ": Gửi biểu thức không thành công.\n"
+
+msgid "No marks set"
+msgstr "Không có dấu hiệu nào được đặt."
+
+#, c-format
+msgid "E283: No marks matching \"%s\""
+msgstr "E283: Không có dấu hiệu tương ứng với \"%s\""
+
+msgid ""
+"\n"
+"mark line  col file/text"
+msgstr ""
+"\n"
+"nhãn dòng  cột tập tin/văn bản"
+
+msgid ""
+"\n"
+" jump line  col file/text"
+msgstr ""
+"\n"
+" bước_nhảy dòng  cột tập tin/văn bản"
+
+msgid ""
+"\n"
+"change line  col text"
+msgstr ""
+"\n"
+"thay_đổi dòng  cột văn_bản"
+
+msgid ""
+"\n"
+"# File marks:\n"
+msgstr ""
+"\n"
+"# Nhãn của tập tin:\n"
+
+msgid ""
+"\n"
+"# Jumplist (newest first):\n"
+msgstr ""
+"\n"
+"# Danh sách bước nhảy (mới hơn đứng trước):\n"
+
+msgid ""
+"\n"
+"# History of marks within files (newest to oldest):\n"
+msgstr ""
+"\n"
+"# Lịch sử các nhãn trong tập tin (từ mới nhất đến cũ nhất):\n"
+
+msgid "Missing '>'"
+msgstr "Thiếu '>'"
+
+msgid "E543: Not a valid codepage"
+msgstr "E543: Bảng mã không cho phép"
+
+msgid "E284: Cannot set IC values"
+msgstr "E284: Không đặt được giá trị nội dung nhập vào (IC)"
+
+msgid "E285: Failed to create input context"
+msgstr "E285: Không tạo được nội dung nhập vào"
+
+msgid "E286: Failed to open input method"
+msgstr "E286: Việc thử mở phương pháp nhập không thành công"
+
+msgid "E287: Warning: Could not set destroy callback to IM"
+msgstr ""
+"E287: Cảnh báo: không đặt được sự gọi ngược hủy diệt thành phương pháp nhập"
+
+# TODO: Capitalise first word of message?
+msgid "E288: Input method doesn't support any style"
+msgstr "E288: phương pháp nhập không hỗ trợ bất kỳ phong cách (style) nào"
+
+# TODO: Capitalise first word of message?
+msgid "E289: Input method doesn't support my preedit type"
+msgstr "E289: phương pháp nhập không hỗ trợ loại soạn thảo trước của Vim"
+
+msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
+msgstr "E291: GTK+ cũ hơn 1.2.3. Vùng chỉ trạng thái không làm việc"
+
+# TODO: Capitalise first word of message?
+msgid "E293: Block was not locked"
+msgstr "E293: khối chưa bị khóa"
+
+msgid "E294: Seek error in swap file read"
+msgstr "E294: Lỗi tìm kiếm khi đọc tập tin trao đổi (swap)"
+
+msgid "E295: Read error in swap file"
+msgstr "E295: Lỗi đọc tập tin trao đổi (swap)"
+
+msgid "E296: Seek error in swap file write"
+msgstr "E296: Lỗi tìm kiếm khi ghi nhớ tập tin trao đổi (swap)"
+
+msgid "E297: Write error in swap file"
+msgstr "E297: Lỗi ghi nhớ tập tin trao đổi (swap)"
+
+msgid "E300: Swap file already exists (symlink attack?)"
+msgstr ""
+"E300: Tập tin trao đổi (swap) đã tồn tại (sử dụng liên kết mềm tấn công?)"
+
+msgid "E298: Didn't get block nr 0?"
+msgstr "E298: Chưa lấy khối số 0?"
+
+msgid "E298: Didn't get block nr 1?"
+msgstr "E298: Chưa lấy khối số 12?"
+
+msgid "E298: Didn't get block nr 2?"
+msgstr "E298: Chưa lấy khối số 2?"
+
+msgid "E301: Oops, lost the swap file!!!"
+msgstr "E301: Ối, mất tập tin trao đổi (swap)!!!"
+
+msgid "E302: Could not rename swap file"
+msgstr "E302: Không đổi được tên tập tin trao đổi (swap)"
+
+#, c-format
+msgid "E303: Unable to open swap file for \"%s\", recovery impossible"
+msgstr ""
+"E303: Không mở được tập tin trao đổi (swap) cho \"%s\", nên không thể phục "
+"hồi"
+
+msgid "E304: ml_timestamp: Didn't get block 0??"
+msgstr "E304: ml_timestamp: Chưa lấy khối số 0??"
+
+#, c-format
+msgid "E305: No swap file found for %s"
+msgstr "E305: Không tìm thấy tập tin trao đổi (swap) cho %s"
+
+msgid "Enter number of swap file to use (0 to quit): "
+msgstr "Hãy nhập số của tập tin trao đổi (swap) muốn sử dụng (0 để thoát): "
+
+#, c-format
+msgid "E306: Cannot open %s"
+msgstr "E306: Không mở được %s"
+
+msgid "Unable to read block 0 from "
+msgstr "Không thể đọc khối số 0 từ "
+
+msgid ""
+"\n"
+"Maybe no changes were made or Vim did not update the swap file."
+msgstr ""
+"\n"
+"Chưa có thay đổi nào hoặc Vim không thể cập nhật tập tin trao đổi (swap)"
+
+msgid " cannot be used with this version of Vim.\n"
+msgstr " không thể sử dụng trong phiên bản Vim này.\n"
+
+msgid "Use Vim version 3.0.\n"
+msgstr "Hãy sử dụng Vim phiên bản 3.0.\n"
+
+#, c-format
+msgid "E307: %s does not look like a Vim swap file"
+msgstr "E307: %s không phải là tập tin trao đổi (swap) của Vim"
+
+msgid " cannot be used on this computer.\n"
+msgstr " không thể sử dụng trên máy tính này.\n"
+
+msgid "The file was created on "
+msgstr "Tập tin đã được tạo trên "
+
+msgid ""
+",\n"
+"or the file has been damaged."
+msgstr ""
+",\n"
+"hoặc tập tin đã bị hỏng."
+
+#, c-format
+msgid "Using swap file \"%s\""
+msgstr "Đang sử dụng tập tin trao đổi (swap) \"%s\""
+
+#, c-format
+msgid "Original file \"%s\""
+msgstr "Tập tin gốc \"%s\""
+
+msgid "E308: Warning: Original file may have been changed"
+msgstr "E308: Cảnh báo: Tập tin gốc có thể đã bị thay đổi"
+
+#, c-format
+msgid "E309: Unable to read block 1 from %s"
+msgstr "E309: Không đọc được khối số 1 từ %s"
+
+msgid "???MANY LINES MISSING"
+msgstr "???THIẾU NHIỀU DÒNG"
+
+msgid "???LINE COUNT WRONG"
+msgstr "???GIÁ TRỊ CỦA SỐ ĐẾM DÒNG BỊ SAI"
+
+msgid "???EMPTY BLOCK"
+msgstr "???KHỐI RỖNG"
+
+msgid "???LINES MISSING"
+msgstr "???THIẾU DÒNG"
+
+#, c-format
+msgid "E310: Block 1 ID wrong (%s not a .swp file?)"
+msgstr "E310: Khối 1 ID sai (%s không phải là tập tin .swp?)"
+
+msgid "???BLOCK MISSING"
+msgstr "???THIẾU KHỐI"
+
+msgid "??? from here until ???END lines may be messed up"
+msgstr "??? từ đây tới ???CUỐI, các dòng có thể đã bị hỏng"
+
+msgid "??? from here until ???END lines may have been inserted/deleted"
+msgstr "??? từ đây tới ???CUỐI, các dòng có thể đã bị chèn hoặc xóa"
+
+msgid "???END"
+msgstr "???CUỐI"
+
+msgid "E311: Recovery Interrupted"
+msgstr "E311: Việc phục hồi bị gián đoạn"
+
+msgid ""
+"E312: Errors detected while recovering; look for lines starting with ???"
+msgstr ""
+"E312: Phát hiện ra lỗi trong khi phục hồi; hãy xem những dòng bắt đầu với ???"
+
+msgid "See \":help E312\" for more information."
+msgstr "Hãy xem thông tin bổ sung trong trợ giúp \":help E312\""
+
+msgid "Recovery completed. You should check if everything is OK."
+msgstr "Việc phục hồi đã hoàn thành. Nên kiểm tra xem mọi thứ có ổn không."
+
+msgid ""
+"\n"
+"(You might want to write out this file under another name\n"
+msgstr ""
+"\n"
+"(Có thể ghi nhớ tập tin với tên khác và so sánh với tập\n"
+
+msgid "and run diff with the original file to check for changes)\n"
+msgstr "gốc bằng chương trình diff).\n"
+
+msgid ""
+"Delete the .swp file afterwards.\n"
+"\n"
+msgstr ""
+"Sau đó hãy xóa tập tin .swp.\n"
+"\n"
+
+msgid "Swap files found:"
+msgstr "Tìm thấy tập tin trao đổi (swap):"
+
+msgid "   In current directory:\n"
+msgstr "   Trong thư mục hiện thời:\n"
+
+msgid "   Using specified name:\n"
+msgstr "   Với tên chỉ ra:\n"
+
+msgid "   In directory "
+msgstr "   Trong thư mục   "
+
+msgid "      -- none --\n"
+msgstr "      -- không --\n"
+
+msgid "          owned by: "
+msgstr "          người sở hữu: "
+
+msgid "   dated: "
+msgstr "    ngày: "
+
+msgid "             dated: "
+msgstr "              ngày: "
+
+msgid "         [from Vim version 3.0]"
+msgstr "         [từ Vim phiên bản 3.0]"
+
+msgid "         [does not look like a Vim swap file]"
+msgstr "         [không phải là tập tin trao đổi (swap) của Vim]"
+
+msgid "         file name: "
+msgstr "         tên tập tin: "
+
+msgid ""
+"\n"
+"          modified: "
+msgstr ""
+"\n"
+"           thay đổi: "
+
+msgid "YES"
+msgstr "CÓ"
+
+msgid "no"
+msgstr "không"
+
+msgid ""
+"\n"
+"         user name: "
+msgstr ""
+"\n"
+"      tên người dùng: "
+
+msgid "   host name: "
+msgstr "    tên máy: "
+
+msgid ""
+"\n"
+"         host name: "
+msgstr ""
+"\n"
+"           tên máy: "
+
+msgid ""
+"\n"
+"        process ID: "
+msgstr ""
+"\n"
+"     ID tiến trình: "
+
+msgid " (still running)"
+msgstr " (vẫn đang chạy)"
+
+msgid ""
+"\n"
+"         [not usable with this version of Vim]"
+msgstr ""
+"\n"
+"         [không sử dụng được với phiên bản này của Vim]"
+
+msgid ""
+"\n"
+"         [not usable on this computer]"
+msgstr ""
+"\n"
+"         [không sử dụng được trên máy tính này]"
+
+msgid "         [cannot be read]"
+msgstr "         [không đọc được]"
+
+msgid "         [cannot be opened]"
+msgstr "         [không mở được]"
+
+msgid "E313: Cannot preserve, there is no swap file"
+msgstr "E313: Không cập nhật được tập tin trao đổi (swap) vì không tìm thấy nó"
+
+msgid "File preserved"
+msgstr "Đã cập nhật tập tin trao đổi (swap)"
+
+msgid "E314: Preserve failed"
+msgstr "E314: Cập nhật không thành công"
+
+# TODO: Capitalise first word of message?
+msgid "E315: ml_get: Invalid lnum: %ld"
+msgstr "E315: ml_get: giá trị lnum không đúng: %ld"
+
+# TODO: Capitalise first word of message?
+msgid "E316: ml_get: Cannot find line %ld"
+msgstr "E316: ml_get: không tìm được dòng %ld"
+
+# TODO: Capitalise first word of message?
+msgid "E317: Pointer block id wrong 3"
+msgstr "E317: Giá trị của pointer khối số 3 không đúng"
+
+msgid "stack_idx should be 0"
+msgstr "giá trị stack_idx phải bằng 0"
+
+msgid "E318: Updated too many blocks?"
+msgstr "E318: Đã cập nhật quá nhiều khối?"
+
+# TODO: Capitalise first word of message?
+msgid "E317: Pointer block id wrong 4"
+msgstr "E317: Giá trị của pointer khối số 4 không đúng"
+
+msgid "deleted block 1?"
+msgstr "đã xóa khối số 1?"
+
+#, c-format
+msgid "E320: Cannot find line %ld"
+msgstr "E320: Không tìm được dòng %ld"
+
+# TODO: Capitalise first word of message?
+msgid "E317: Pointer block id wrong"
+msgstr "E317: giá trị của pointer khối không đúng"
+
+msgid "pe_line_count is zero"
+msgstr "giá trị pe_line_count bằng không"
+
+# TODO: Capitalise first word of message?
+msgid "E322: Line number out of range: %ld past the end"
+msgstr "E322: số thứ tự dòng vượt quá giới hạn : %ld"
+
+# TODO: Capitalise first word of message?
+msgid "E323: Line count wrong in block %ld"
+msgstr "E323: giá trị đếm dòng không đúng trong khối %ld"
+
+msgid "Stack size increases"
+msgstr "Kích thước của đống tăng lên"
+
+# TODO: Capitalise first word of message?
+msgid "E317: Pointer block id wrong 2"
+msgstr "E317: Giá trị của cái chỉ (pointer) khối số 2 không đúng"
+
+msgid "E325: ATTENTION"
+msgstr "E325: CHÚ Ý"
+
+msgid ""
+"\n"
+"Found a swap file by the name \""
+msgstr ""
+"\n"
+"Tìm thấy một tập tin trao đổi (swap) với tên \""
+
+msgid "While opening file \""
+msgstr "Khi mở tập tin: \""
+
+msgid "      NEWER than swap file!\n"
+msgstr "                    MỚI hơn so với tập tin trao đổi (swap)\n"
+
+msgid ""
+"\n"
+"(1) Another program may be editing the same file.\n"
+"    If this is the case, be careful not to end up with two\n"
+"    different instances of the same file when making changes.\n"
+msgstr ""
+"\n"
+"(1) Rất có thể một chương trình khác đang soạn thảo tập tin.\n"
+"    Nếu như vậy, hãy cẩn thận khi thay đổi, làm sao để không thu\n"
+"    được hai phương án khác nhau của cùng một tập tin.\n"
+
+msgid "    Quit, or continue with caution.\n"
+msgstr "    Thoát hoặc tiếp tục với sự cẩn thận.\n"
+
+msgid ""
+"\n"
+"(2) An edit session for this file crashed.\n"
+msgstr ""
+"\n"
+"(2) Lần soạn thảo trước của tập tin này gặp sự cố.\n"
+
+msgid "    If this is the case, use \":recover\" or \"vim -r "
+msgstr ""
+"    Trong trường hợp này, hãy sử dụng câu lệnh \":recover\" hoặc \"vim -r "
+
+msgid ""
+"\"\n"
+"    to recover the changes (see \":help recovery\").\n"
+msgstr ""
+"\"\n"
+"    để phục hồi những thay đổi (hãy xem \":help recovery\").\n"
+
+msgid "    If you did this already, delete the swap file \""
+msgstr ""
+"    Nếu đã thực hiện thao tác này rồi, thì hãy xóa tập tin trao đổi (swap) \""
+
+msgid ""
+"\"\n"
+"    to avoid this message.\n"
+msgstr ""
+"\"\n"
+"    để tránh sự xuất hiện của thông báo này trong tương lai.\n"
+
+msgid "Swap file \""
+msgstr "Tập tin trao đổi (swap) \""
+
+msgid "\" already exists!"
+msgstr "\" đã có rồi!"
+
+msgid "VIM - ATTENTION"
+msgstr "VIM - CHÚ Ý"
+
+msgid "Swap file already exists!"
+msgstr "Tập tin trao đổi (swap) đã rồi!"
+
+msgid ""
+"&Open Read-Only\n"
+"&Edit anyway\n"
+"&Recover\n"
+"&Quit\n"
+"&Abort"
+msgstr ""
+"&O Mở chỉ để đọc\n"
+"&E Vẫn soạn thảo\n"
+"&R Phục hồi\n"
+"&Q Thoát\n"
+"&A Gián đoạn"
+
+msgid ""
+"&Open Read-Only\n"
+"&Edit anyway\n"
+"&Recover\n"
+"&Quit\n"
+"&Abort\n"
+"&Delete it"
+msgstr ""
+"&O Mở chỉ để đọc\n"
+"&E Vẫn soạn thảo\n"
+"&R Phục hồi\n"
+"&Q Thoát\n"
+"&A Gián đoạn&D Xóa nó"
+
+msgid "E326: Too many swap files found"
+msgstr "E326: Tìm thấy quá nhiều tập tin trao đổi (swap)"
+
+msgid "E327: Part of menu-item path is not sub-menu"
+msgstr ""
+"E327: Một phần của đường dẫn tới phần tử của trình đơn không phải là trình "
+"đơn con"
+
+msgid "E328: Menu only exists in another mode"
+msgstr "E328: Trình đơn chỉ có trong chế độ khác"
+
+msgid "E329: No menu of that name"
+msgstr "E329: Không có trình đơn với tên như vậy"
+
+msgid "E330: Menu path must not lead to a sub-menu"
+msgstr "E330: Đường dẫn tới trình đơn không được đưa tới trình đơn con"
+
+msgid "E331: Must not add menu items directly to menu bar"
+msgstr ""
+"E331: Các phần tử của trình đơn không thể thêm trực tiếp vào thanh trình đơn"
+
+msgid "E332: Separator cannot be part of a menu path"
+msgstr "E332: Cái phân chia không thể là một phần của đường dẫn tới trình đơn"
+
+msgid ""
+"\n"
+"--- Menus ---"
+msgstr ""
+"\n"
+"--- Trình đơn ---"
+
+msgid "Tear off this menu"
+msgstr "Chia cắt trình đơn này"
+
+msgid "E333: Menu path must lead to a menu item"
+msgstr "E333: Đường dẫn tới trình đơn phải đưa tới một phần tử cuả trình đơn"
+
+#, c-format
+msgid "E334: Menu not found: %s"
+msgstr "E334: Không tìm thấy trình đơn: %s"
+
+#, c-format
+msgid "E335: Menu not defined for %s mode"
+msgstr "E335: Trình đơn không được định nghĩa cho chế độ %s"
+
+msgid "E336: Menu path must lead to a sub-menu"
+msgstr "E336: Đường dẫn tới trình đơn phải đưa tới một trình đơn con"
+
+msgid "E337: Menu not found - check menu names"
+msgstr "E337: Không tìm thấy trình đơn - hãy kiểm tra tên trình đơn"
+
+#, c-format
+msgid "Error detected while processing %s:"
+msgstr "Phát hiện lỗi khi xử lý %s:"
+
+#, c-format
+msgid "line %4ld:"
+msgstr "dòng %4ld:"
+
+msgid "[string too long]"
+msgstr "[chuỗi quá dài]"
+
+msgid "Messages maintainer: The Vim Project"
+msgstr ""
+"Bản dịch các thông báo sang tiếng Việt: Phan Vĩnh Thịnh <teppi@vnlinux.org>"
+
+msgid "Interrupt: "
+msgstr "Gián đoạn: "
+
+msgid "Hit ENTER to continue"
+msgstr "Nhấn phím ENTER để tiếp tục"
+
+msgid "Hit ENTER or type command to continue"
+msgstr "Nhấn phím ENTER hoặc nhập câu lệnh để tiếp tục"
+
+msgid "-- More --"
+msgstr "-- Còn nữa --"
+
+msgid " (RET/BS: line, SPACE/b: page, d/u: half page, q: quit)"
+msgstr " (RET/BS: dòng, SPACE/b: trang, d/u: nửa trang, q: thoát)"
+
+msgid " (RET: line, SPACE: page, d: half page, q: quit)"
+msgstr " (RET: dòng, SPACE: trang, d: nửa trang, q: thoát)"
+
+msgid "Question"
+msgstr "Câu hỏi"
+
+msgid ""
+"&Yes\n"
+"&No"
+msgstr ""
+"&Có\n"
+"&Không"
+
 msgid ""
 "&Yes\n"
 "&No\n"
@@ -4234,181 +3205,233 @@ msgstr ""
 "&Vứt bỏ tất cả\n"
 "&Dừng lại"
 
-#: ../message.c:3058
-#, fuzzy
-msgid "E766: Insufficient arguments for printf()"
-msgstr "E116: Tham số cho hàm %s đưa ra không đúng"
+msgid "Save File dialog"
+msgstr "Ghi nhớ tập tin"
 
-#: ../message.c:3119
-msgid "E807: Expected Float argument for printf()"
+msgid "Open File dialog"
+msgstr "Mở tập tin"
+
+msgid "E338: Sorry, no file browser in console mode"
 msgstr ""
+"E338: Xin lỗi nhưng không có trình duyệt tập tin trong chế độ kênh giao tác "
+"(console)"
 
-#: ../message.c:3873
-#, fuzzy
-msgid "E767: Too many arguments to printf()"
-msgstr "E118: Quá nhiều tham số cho hàm: %s"
-
-#: ../misc1.c:2256
 msgid "W10: Warning: Changing a readonly file"
 msgstr "W10: Cảnh báo: Thay đổi một tập tin chỉ có quyền đọc"
 
-#: ../misc1.c:2537
-msgid "Type number and <Enter> or click with mouse (empty cancels): "
-msgstr ""
-
-#: ../misc1.c:2539
-msgid "Type number and <Enter> (empty cancels): "
-msgstr ""
-
-#: ../misc1.c:2585
 msgid "1 more line"
 msgstr "Thêm 1 dòng"
 
-#: ../misc1.c:2588
 msgid "1 line less"
 msgstr "Bớt 1 dòng"
 
-#: ../misc1.c:2593
 #, c-format
-msgid "%<PRId64> more lines"
-msgstr "Thêm %<PRId64> dòng"
+msgid "%ld more lines"
+msgstr "Thêm %ld dòng"
 
-#: ../misc1.c:2596
 #, c-format
-msgid "%<PRId64> fewer lines"
-msgstr "Bớt %<PRId64> dòng"
+msgid "%ld fewer lines"
+msgstr "Bớt %ld dòng"
 
-#: ../misc1.c:2599
 msgid " (Interrupted)"
 msgstr " (Bị gián đoạn)"
 
-#: ../misc1.c:2635
-msgid "Beep!"
-msgstr ""
+msgid "Vim: preserving files...\n"
+msgstr "Vim: ghi nhớ các tập tin...\n"
 
-#: ../misc2.c:738
+msgid "Vim: Finished.\n"
+msgstr "Vim: Đã xong.\n"
+
+msgid "ERROR: "
+msgstr "LỖI: "
+
+#, c-format
+msgid ""
+"\n"
+"[bytes] total alloc-freed %lu-%lu, in use %lu, peak use %lu\n"
+msgstr ""
+"\n"
+"[byte] tổng phân phối-còn trống %lu-%lu, sử dụng %lu, píc sử dụng %lu\n"
+
+#, c-format
+msgid ""
+"[calls] total re/malloc()'s %lu, total free()'s %lu\n"
+"\n"
+msgstr ""
+"[gọi] tổng re/malloc() %lu, tổng free() %lu\n"
+"\n"
+
+msgid "E340: Line is becoming too long"
+msgstr "E340: Dòng đang trở thành quá dài"
+
+#, c-format
+msgid "E341: Internal error: lalloc(%ld, )"
+msgstr "E341: Lỗi nội bộ: lalloc(%ld, )"
+
+#, c-format
+msgid "E342: Out of memory!  (allocating %lu bytes)"
+msgstr "E342: Không đủ bộ nhớ! (phân chia %lu byte)"
+
 #, c-format
 msgid "Calling shell to execute: \"%s\""
 msgstr "Gọi shell để thực hiện: \"%s\""
 
-#: ../normal.c:183
-msgid "E349: No identifier under cursor"
-msgstr "E349: Không có tên ở vị trí con trỏ"
+msgid "E545: Missing colon"
+msgstr "E545: Thiếu dấu hai chấm"
 
-#: ../normal.c:1866
-#, fuzzy
-msgid "E774: 'operatorfunc' is empty"
-msgstr "E91: Tùy chọn 'shell' là một chuỗi rỗng"
+msgid "E546: Illegal mode"
+msgstr "E546: Chế độ không cho phép"
 
-#: ../normal.c:2637
+msgid "E547: Illegal mouseshape"
+msgstr "E547: Dạng trỏ chuột không cho phép"
+
+# TODO: Capitalise first word of message?
+msgid "E548: Digit expected"
+msgstr "E548: yêu cầu một số"
+
+msgid "E549: Illegal percentage"
+msgstr "E549: Tỷ lệ phần trăm không cho phép"
+
+msgid "Enter encryption key: "
+msgstr "Nhập mật khẩu để mã hóa: "
+
+msgid "Enter same key again: "
+msgstr "      Nhập lại mật khẩu:"
+
+msgid "Keys don't match!"
+msgstr "Hai mật khẩu không trùng nhau!"
+
+#, c-format
+msgid ""
+"E343: Invalid path: '**[number]' must be at the end of the path or be "
+"followed by '%s'."
+msgstr ""
+"E343: Đường dẫn đưa ra không đúng: '**[số]' phải ở cuối đường dẫn hoặc theo "
+"sau bởi '%s'"
+
+#, c-format
+msgid "E344: Can't find directory \"%s\" in cdpath"
+msgstr "E344: Không tìm thấy thư mục \"%s\" để chuyển thư mục"
+
+#, c-format
+msgid "E345: Can't find file \"%s\" in path"
+msgstr "E345: Không tìm thấy tập tin \"%s\" trong đường dẫn"
+
+#, c-format
+msgid "E346: No more directory \"%s\" found in cdpath"
+msgstr "E346: Trong đường dẫn thay đổi thư mục không còn có thư mục \"%s\" nữa"
+
+#, c-format
+msgid "E347: No more file \"%s\" found in path"
+msgstr "E347: Trong đường dẫn path không còn có tập tin \"%s\" nữa"
+
+msgid "E550: Missing colon"
+msgstr "E550: Thiếu dấu hai chấm"
+
+msgid "E551: Illegal component"
+msgstr "E551: Thành phần không cho phép"
+
+# TODO: Capitalise first word of message?
+msgid "E552: Digit expected"
+msgstr "E552: Cần chỉ ra một số"
+
+msgid "Cannot connect to Netbeans #2"
+msgstr "Không kết nối được với Netbeans #2"
+
+msgid "Cannot connect to Netbeans"
+msgstr "Không kết nối được với NetBeans"
+
+#, c-format
+msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
+msgstr ""
+"E668: Chế độ truy cập thông tin về liên kết với NetBeans không đúng: \"%s\""
+
+msgid "read from Netbeans socket"
+msgstr "đọc từ socket NetBeans"
+
+#, c-format
+msgid "E658: NetBeans connection lost for buffer %ld"
+msgstr "E658: Bị mất liên kết với NetBeans cho bộ đệm %ld"
+
 msgid "Warning: terminal cannot highlight"
 msgstr "Cảnh báo: terminal không thực hiện được sự chiếu sáng"
 
-#: ../normal.c:2807
 msgid "E348: No string under cursor"
 msgstr "E348: Không có chuỗi ở vị trí con trỏ"
 
-#: ../normal.c:3937
+msgid "E349: No identifier under cursor"
+msgstr "E349: Không có tên ở vị trí con trỏ"
+
 msgid "E352: Cannot erase folds with current 'foldmethod'"
 msgstr ""
 "E352: Không thể tẩy xóa nếp gấp với giá trị hiện thời của tùy chọn "
 "'foldmethod'"
 
-#: ../normal.c:5897
-msgid "E664: changelist is empty"
+# TODO: Capitalise first word of message?
+msgid "E664: Changelist is empty"
 msgstr "E664: danh sách những thay đổi trống rỗng"
 
-#: ../normal.c:5899
 msgid "E662: At start of changelist"
 msgstr "E662: Ở đầu danh sách những thay đổi"
 
-#: ../normal.c:5901
 msgid "E663: At end of changelist"
 msgstr "E663: Ở cuối danh sách những thay đổi"
 
-#: ../normal.c:7053
-msgid "Type  :quit<Enter>  to exit Nvim"
+msgid "Type  :quit<Enter>  to exit Vim"
 msgstr "Gõ :quit<Enter>  để thoát khỏi Vim"
 
-#: ../ops.c:248
 #, c-format
 msgid "1 line %sed 1 time"
 msgstr "Trên 1 dòng %s 1 lần"
 
-#: ../ops.c:250
 #, c-format
 msgid "1 line %sed %d times"
 msgstr "Trên 1 dòng %s %d lần"
 
-#: ../ops.c:253
 #, c-format
-msgid "%<PRId64> lines %sed 1 time"
-msgstr "Trên %<PRId64> dòng %s 1 lần"
+msgid "%ld lines %sed 1 time"
+msgstr "Trên %ld dòng %s 1 lần"
 
-#: ../ops.c:256
 #, c-format
-msgid "%<PRId64> lines %sed %d times"
-msgstr "Trên %<PRId64> dòng %s %d lần"
+msgid "%ld lines %sed %d times"
+msgstr "Trên %ld dòng %s %d lần"
 
-#: ../ops.c:592
 #, c-format
-msgid "%<PRId64> lines to indent... "
-msgstr "Thụt đầu %<PRId64> dòng..."
+msgid "%ld lines to indent... "
+msgstr "Thụt đầu %ld dòng..."
 
-#: ../ops.c:634
 msgid "1 line indented "
 msgstr "Đã thụt đầu 1 dòng"
 
-#: ../ops.c:636
 #, c-format
-msgid "%<PRId64> lines indented "
-msgstr "%<PRId64> dòng đã thụt đầu"
+msgid "%ld lines indented "
+msgstr "%ld dòng đã thụt đầu"
 
-#: ../ops.c:938
-#, fuzzy
-msgid "E748: No previously used register"
-msgstr "E186: Không có thư mục trước"
-
-#. must display the prompt
-#: ../ops.c:1433
 msgid "cannot yank; delete anyway"
 msgstr "sao chép không thành công; đã xóa"
 
-#: ../ops.c:1929
 msgid "1 line changed"
 msgstr "1 dòng đã thay đổi"
 
-#: ../ops.c:1931
 #, c-format
-msgid "%<PRId64> lines changed"
-msgstr "%<PRId64> đã thay đổi"
+msgid "%ld lines changed"
+msgstr "%ld đã thay đổi"
 
-#: ../ops.c:2521
-#, fuzzy
-msgid "block of 1 line yanked"
-msgstr "đã sao chép 1 dòng"
+#, c-format
+msgid "freeing %ld lines"
+msgstr "đã làm sạch %ld dòng"
 
-#: ../ops.c:2523
 msgid "1 line yanked"
 msgstr "đã sao chép 1 dòng"
 
-#: ../ops.c:2525
-#, fuzzy, c-format
-msgid "block of %<PRId64> lines yanked"
-msgstr "đã sao chép %<PRId64> dòng"
-
-#: ../ops.c:2528
 #, c-format
-msgid "%<PRId64> lines yanked"
-msgstr "đã sao chép %<PRId64> dòng"
+msgid "%ld lines yanked"
+msgstr "đã sao chép %ld dòng"
 
-#: ../ops.c:2710
 #, c-format
 msgid "E353: Nothing in register %s"
 msgstr "E353: Trong sổ đăng ký %s không có gì hết"
 
-#. Highlight title
-#: ../ops.c:3185
 msgid ""
 "\n"
 "--- Registers ---"
@@ -4416,11 +3439,9 @@ msgstr ""
 "\n"
 "--- Sổ đăng ký ---"
 
-#: ../ops.c:4455
 msgid "Illegal register name"
 msgstr "Tên sổ đăng ký không cho phép"
 
-#: ../ops.c:4533
 msgid ""
 "\n"
 "# Registers:\n"
@@ -4428,194 +3449,154 @@ msgstr ""
 "\n"
 "# Sổ đăng ký:\n"
 
-#: ../ops.c:4575
 #, c-format
 msgid "E574: Unknown register type %d"
 msgstr "E574: Loại sổ đăng ký không biết %d"
 
-#: ../ops.c:5089
 #, c-format
-msgid "%<PRId64> Cols; "
-msgstr "%<PRId64> Cột; "
+msgid "E354: Invalid register name: '%s'"
+msgstr "E354: Tên sổ đăng ký không cho phép: '%s'"
 
-#: ../ops.c:5097
 #, c-format
-msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
-"%<PRId64> of %<PRId64> Bytes"
-msgstr ""
-"Chọn %s%<PRId64> của %<PRId64> Dòng; %<PRId64> của %<PRId64> Từ; %<PRId64> "
-"của %<PRId64> Byte"
+msgid "%ld Cols; "
+msgstr "%ld Cột; "
 
-#: ../ops.c:5105
-#, fuzzy, c-format
-msgid ""
-"Selected %s%<PRId64> of %<PRId64> Lines; %<PRId64> of %<PRId64> Words; "
-"%<PRId64> of %<PRId64> Chars; %<PRId64> of %<PRId64> Bytes"
-msgstr ""
-"Chọn %s%<PRId64> của %<PRId64> Dòng; %<PRId64> của %<PRId64> Từ; %<PRId64> "
-"của %<PRId64> Byte"
-
-#: ../ops.c:5123
 #, c-format
-msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Byte "
-"%<PRId64> of %<PRId64>"
-msgstr ""
-"Cột %s của %s;  Dòng %<PRId64> của %<PRId64>; Từ %<PRId64> của %<PRId64>; "
-"Byte %<PRId64> của %<PRId64>"
+msgid "Selected %s%ld of %ld Lines; %ld of %ld Words; %ld of %ld Bytes"
+msgstr "Chọn %s%ld của %ld Dòng; %ld của %ld Từ; %ld của %ld Byte"
 
-#: ../ops.c:5133
-#, fuzzy, c-format
-msgid ""
-"Col %s of %s; Line %<PRId64> of %<PRId64>; Word %<PRId64> of %<PRId64>; Char "
-"%<PRId64> of %<PRId64>; Byte %<PRId64> of %<PRId64>"
-msgstr ""
-"Cột %s của %s;  Dòng %<PRId64> của %<PRId64>; Từ %<PRId64> của %<PRId64>; "
-"Byte %<PRId64> của %<PRId64>"
-
-#: ../ops.c:5146
 #, c-format
-msgid "(+%<PRId64> for BOM)"
-msgstr "(+%<PRId64> cho BOM)"
+msgid "Col %s of %s; Line %ld of %ld; Word %ld of %ld; Byte %ld of %ld"
+msgstr "Cột %s của %s;  Dòng %ld của %ld; Từ %ld của %ld; Byte %ld của %ld"
 
-#: ../option.c:1238
+#, c-format
+msgid "(+%ld for BOM)"
+msgstr "(+%ld cho BOM)"
+
 msgid "%<%f%h%m%=Page %N"
 msgstr "%<%f%h%m%=Trang %N"
 
-#: ../option.c:1574
 msgid "Thanks for flying Vim"
 msgstr "Xin cảm ơn đã sử dụng Vim"
 
-#. found a mismatch: skip
-#: ../option.c:2698
 msgid "E518: Unknown option"
 msgstr "E518: Tùy chọn không biết"
 
-#: ../option.c:2709
 msgid "E519: Option not supported"
 msgstr "E519: Tùy chọn không được hỗ trợ"
 
-#: ../option.c:2740
 msgid "E520: Not allowed in a modeline"
 msgstr "E520: Không cho phép trên dòng chế độ (modeline)"
 
-#: ../option.c:2815
-msgid "E846: Key code not set"
+msgid ""
+"\n"
+"\tLast set from "
 msgstr ""
+"\n"
+"\tLần cuối cùng tùy chọn thay đổi vào "
 
-#: ../option.c:2924
 msgid "E521: Number required after ="
 msgstr "E521: Sau dấu = cần đưa ra một số"
 
-#: ../option.c:3226 ../option.c:3864
 msgid "E522: Not found in termcap"
 msgstr "E522: Không tìm thấy trong termcap"
 
-#: ../option.c:3335
 #, c-format
 msgid "E539: Illegal character <%s>"
 msgstr "E539: Ký tự không cho phép <%s>"
 
-#: ../option.c:3862
 msgid "E529: Cannot set 'term' to empty string"
 msgstr "E529: Giá trị của tùy chọn 'term' không thể là một chuỗi trống rỗng"
 
-#: ../option.c:3885
+msgid "E530: Cannot change term in GUI"
+msgstr "E530: Không thể thay đổi terminal trong giao diện đồ họa GUI"
+
+msgid "E531: Use \":gui\" to start the GUI"
+msgstr "E531: Hãy sử dụng \":gui\" để chạy giao diện đồ họa GUI"
+
 msgid "E589: 'backupext' and 'patchmode' are equal"
 msgstr "E589: giá trị của tùy chọn 'backupext' và 'patchmode' bằng nhau"
 
-#: ../option.c:3964
-msgid "E834: Conflicts with value of 'listchars'"
-msgstr ""
+msgid "E617: Cannot be changed in the GTK+ 2 GUI"
+msgstr "E617: Không thể thay đổi trong giao diện đồ họa GTK+ 2"
 
-#: ../option.c:3966
-msgid "E835: Conflicts with value of 'fillchars'"
-msgstr ""
-
-#: ../option.c:4163
 msgid "E524: Missing colon"
 msgstr "E524: Thiếu dấu hai chấm"
 
-#: ../option.c:4165
 msgid "E525: Zero length string"
 msgstr "E525: Chuỗi có độ dài bằng không"
 
-#: ../option.c:4220
 #, c-format
 msgid "E526: Missing number after <%s>"
 msgstr "E526: Thiếu một số sau <%s>"
 
-#: ../option.c:4232
 msgid "E527: Missing comma"
 msgstr "E527: Thiếu dấu phẩy"
 
-#: ../option.c:4239
 msgid "E528: Must specify a ' value"
 msgstr "E528: Cần đưa ra một giá trị cho '"
 
-#: ../option.c:4271
 msgid "E595: contains unprintable or wide character"
 msgstr "E595: chứa ký tự không in ra hoặc ký tự với chiều rộng gấp đôi"
 
-#: ../option.c:4469
+msgid "E596: Invalid font(s)"
+msgstr "E596: Phông chữ không đúng"
+
+# TODO: Capitalise first word of message?
+msgid "E597: Can't select fontset"
+msgstr "E597: không chọn được bộ phông chữ"
+
+msgid "E598: Invalid fontset"
+msgstr "E598: Bộ phông chữ không đúng"
+
+# TODO: Capitalise first word of message?
+msgid "E533: Can't select wide font"
+msgstr "E533: không chọn được phông chữ với các ký tự có chiều rộng gấp đôi"
+
+msgid "E534: Invalid wide font"
+msgstr "E534: Phông chữ, với ký tự có chiều rộng gấp đôi, không đúng"
+
 #, c-format
 msgid "E535: Illegal character after <%c>"
 msgstr "E535: Ký tự sau <%c> không chính xác"
 
-#: ../option.c:4534
-msgid "E536: comma required"
+# TODO: Capitalise first word of message?
+msgid "E536: Comma required"
 msgstr "E536: cầu có dấu phẩy"
 
-#: ../option.c:4543
 #, c-format
 msgid "E537: 'commentstring' must be empty or contain %s"
 msgstr "E537: Giá trị của tùy chọn 'commentstring' phải rỗng hoặc chứa %s"
 
-#: ../option.c:4928
+msgid "E538: No mouse support"
+msgstr "E538: Chuột không được hỗ trợ"
+
 msgid "E540: Unclosed expression sequence"
 msgstr "E540: Dãy các biểu thức không đóng"
 
-#: ../option.c:4932
-msgid "E541: too many items"
-msgstr "E541: quá nhiều phần tử"
 
-#: ../option.c:4934
-msgid "E542: unbalanced groups"
+# TODO: Capitalise first word of message?
+msgid "E542: Unbalanced groups"
 msgstr "E542: các nhóm không cân bằng"
 
-#: ../option.c:5148
 msgid "E590: A preview window already exists"
 msgstr "E590: Cửa sổ xem trước đã có"
 
-#: ../option.c:5311
 msgid "W17: Arabic requires UTF-8, do ':set encoding=utf-8'"
 msgstr "W17: Tiếng Ả Rập yêu cầu sử dụng UTF-8, hãy nhập ':set encoding=utf-8'"
 
-#: ../option.c:5623
 #, c-format
 msgid "E593: Need at least %d lines"
 msgstr "E593: Cần ít nhất %d dòng"
 
-#: ../option.c:5631
 #, c-format
 msgid "E594: Need at least %d columns"
 msgstr "E594: Cần ít nhất %d cột"
 
-#: ../option.c:6011
 #, c-format
 msgid "E355: Unknown option: %s"
 msgstr "E355: Tùy chọn không biết: %s"
 
-#. There's another character after zeros or the string
-#. * is empty.  In both cases, we are trying to set a
-#. * num option using a string.
-#: ../option.c:6037
-#, fuzzy, c-format
-msgid "E521: Number required: &%s = '%s'"
-msgstr "E521: Sau dấu = cần đưa ra một số"
-
-#: ../option.c:6149
 msgid ""
 "\n"
 "--- Terminal codes ---"
@@ -4623,7 +3604,6 @@ msgstr ""
 "\n"
 "--- Mã terminal ---"
 
-#: ../option.c:6151
 msgid ""
 "\n"
 "--- Global option values ---"
@@ -4631,7 +3611,6 @@ msgstr ""
 "\n"
 "--- Giá trị tùy chọn toàn cầu ---"
 
-#: ../option.c:6153
 msgid ""
 "\n"
 "--- Local option values ---"
@@ -4639,7 +3618,6 @@ msgstr ""
 "\n"
 "--- Giá trị tùy chọn nội bộ ---"
 
-#: ../option.c:6155
 msgid ""
 "\n"
 "--- Options ---"
@@ -4647,21 +3625,127 @@ msgstr ""
 "\n"
 "--- Tùy chọn ---"
 
-#: ../option.c:6816
 msgid "E356: get_varp ERROR"
 msgstr "E356: LỖI get_varp"
 
-#: ../option.c:7696
 #, c-format
 msgid "E357: 'langmap': Matching character missing for %s"
 msgstr "E357: 'langmap': Thiếu ký tự tương ứng cho %s"
 
-#: ../option.c:7715
 #, c-format
 msgid "E358: 'langmap': Extra characters after semicolon: %s"
 msgstr "E358: 'langmap': Thừa ký tự sau dấu chấm phẩy: %s"
 
-#: ../os/shell.c:194
+msgid "cannot open "
+msgstr "không mở được "
+
+msgid "VIM: Can't open window!\n"
+msgstr "VIM: Không mở được cửa sổ!\n"
+
+msgid "Need Amigados version 2.04 or later\n"
+msgstr "Cần Amigados phiên bản 2.04 hoặc mới hơn\n"
+
+#, c-format
+msgid "Need %s version %ld\n"
+msgstr "Cần %s phiên bản %ld\n"
+
+msgid "Cannot open NIL:\n"
+msgstr "Không mở được NIL:\n"
+
+msgid "Cannot create "
+msgstr "Không tạo được "
+
+#, c-format
+msgid "Vim exiting with %d\n"
+msgstr "Thoát Vim với mã %d\n"
+
+msgid "cannot change console mode ?!\n"
+msgstr "không thay đổi được chế độ kênh giao tác (console)?!\n"
+
+msgid "mch_get_shellsize: not a console??\n"
+msgstr "mch_get_shellsize: không phải là kênh giao tác (console)??\n"
+
+msgid "E360: Cannot execute shell with -f option"
+msgstr "E360: Không chạy được shell với tùy chọn -f"
+
+msgid "Cannot execute "
+msgstr "Không chạy được "
+
+msgid "shell "
+msgstr "shell "
+
+msgid " returned\n"
+msgstr " thoát\n"
+
+msgid "ANCHOR_BUF_SIZE too small."
+msgstr "Giá trị ANCHOR_BUF_SIZE quá nhỏ."
+
+msgid "I/O ERROR"
+msgstr "LỖI I/O (NHẬP/XUẤT)"
+
+msgid "...(truncated)"
+msgstr "...(bị cắt bớt)"
+
+msgid "'columns' is not 80, cannot execute external commands"
+msgstr "Tùy chọn 'columns' khác 80, chương trình ngoại trú không thể thực hiện"
+
+msgid "E237: Printer selection failed"
+msgstr "E237: Chọn máy in không thành công"
+
+#, c-format
+msgid "to %s on %s"
+msgstr "tới %s trên %s"
+
+#, c-format
+msgid "E613: Unknown printer font: %s"
+msgstr "E613: Không rõ phông chữ của máy in: %s"
+
+#, c-format
+msgid "E238: Print error: %s"
+msgstr "E238: Lỗi in: %s"
+
+msgid "Unknown"
+msgstr "Không rõ"
+
+#, c-format
+msgid "Printing '%s'"
+msgstr "Đang in '%s'"
+
+#, c-format
+msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
+msgstr "E244: Tên bảng mã không cho phép \"%s\" trong tên phông chữ \"%s\""
+
+#, c-format
+msgid "E245: Illegal char '%c' in font name \"%s\""
+msgstr "E245: Ký tự không cho phép '%c' trong tên phông chữ \"%s\""
+
+msgid "Vim: Double signal, exiting\n"
+msgstr "Vim: Tín hiệu đôi, thoát\n"
+
+#, c-format
+msgid "Vim: Caught deadly signal %s\n"
+msgstr "Vim: Nhận được tín hiệu chết %s\n"
+
+msgid "Vim: Caught deadly signal\n"
+msgstr "Vim: Nhận được tín hiệu chết\n"
+
+#, c-format
+msgid "Opening the X display took %ld msec"
+msgstr "Mở màn hình X mất %ld mili giây"
+
+msgid ""
+"\n"
+"Vim: Got X error\n"
+msgstr ""
+"\n"
+"Vim: Lỗi X\n"
+
+msgid "Testing the X display failed"
+msgstr "Kiểm tra màn hình X không thành công"
+
+msgid "Opening the X display timed out"
+msgstr "Không mở được màn hình X trong thời gian cho phép (time out)"
+
 msgid ""
 "\n"
 "Cannot execute shell "
@@ -4669,7 +3753,13 @@ msgstr ""
 "\n"
 "Không chạy được shell "
 
-#: ../os/shell.c:439
+msgid ""
+"\n"
+"Cannot execute shell sh\n"
+msgstr ""
+"\n"
+"Không chạy được shell sh\n"
+
 msgid ""
 "\n"
 "shell returned "
@@ -4677,959 +3767,387 @@ msgstr ""
 "\n"
 "shell dừng làm việc "
 
-#: ../os_unix.c:465 ../os_unix.c:471
 msgid ""
 "\n"
-"Could not get security context for "
+"Cannot create pipes\n"
 msgstr ""
+"\n"
+"Không tạo được đường ống (pipe)\n"
 
-#: ../os_unix.c:479
 msgid ""
 "\n"
-"Could not set security context for "
+"Cannot fork\n"
 msgstr ""
+"\n"
+"Không thực hiện được fork()\n"
 
-#: ../os_unix.c:1558 ../os_unix.c:1647
-#, c-format
-msgid "dlerror = \"%s\""
+msgid ""
+"\n"
+"Command terminated\n"
 msgstr ""
+"\n"
+"Câu lệnh bị gián đoạn\n"
 
-#: ../path.c:1449
+msgid "XSMP lost ICE connection"
+msgstr "XSMP mất kết nối ICE"
+
+msgid "Opening the X display failed"
+msgstr "Mở màn hình X không thành công"
+
+msgid "XSMP handling save-yourself request"
+msgstr "XSMP xử lý yêu cầu tự động ghi nhớ"
+
+msgid "XSMP opening connection"
+msgstr "XSMP mở kết nối"
+
+msgid "XSMP ICE connection watch failed"
+msgstr "XSMP mất theo dõi kết nối ICE"
+
 #, c-format
-msgid "E447: Can't find file \"%s\" in path"
-msgstr "E447: Không tìm thấy tập tin \"%s\" trong đường dẫn"
+msgid "XSMP SmcOpenConnection failed: %s"
+msgstr "XSMP thực hiện SmcOpenConnection không thành công: %s"
 
-#: ../quickfix.c:359
+msgid "At line"
+msgstr "Tại dòng"
+
+msgid "Could not allocate memory for command line."
+msgstr "Không phân chia được bộ nhớ cho dòng lệnh."
+
+msgid "VIM Error"
+msgstr "Lỗi VIM"
+
+msgid "Could not load vim32.dll!"
+msgstr "Không nạp được vim32.dll!"
+
+msgid "Could not fix up function pointers to the DLL!"
+msgstr "Không sửa được cái chỉ (pointer) hàm số tới DLL!"
+
+#, c-format
+msgid "shell returned %d"
+msgstr "thoát shell với mã %d"
+
+#, c-format
+msgid "Vim: Caught %s event\n"
+msgstr "Vim: Nhận được sự kiện %s\n"
+
+msgid "close"
+msgstr "đóng"
+
+msgid "logoff"
+msgstr "thoát"
+
+msgid "shutdown"
+msgstr "tắt máy"
+
+msgid "E371: Command not found"
+msgstr "E371: Câu lệnh không tìm thấy"
+
+msgid ""
+"VIMRUN.EXE not found in your $PATH.\n"
+"External commands will not pause after completion.\n"
+"See  :help win32-vimrun  for more information."
+msgstr ""
+"Không tìm thấy VIMRUN.EXE trong $PATH.\n"
+"Lệnh ngoại trú sẽ không dừng lại sau khi hoàn thành.\n"
+"Thông tin chi tiết xem trong :help win32-vimrun"
+
+msgid "Vim Warning"
+msgstr "Cảnh báo Vim"
+
 #, c-format
 msgid "E372: Too many %%%c in format string"
 msgstr "E372: Quá nhiều %%%c trong chuỗi định dạng"
 
-#: ../quickfix.c:371
 #, c-format
 msgid "E373: Unexpected %%%c in format string"
 msgstr "E373: Không mong đợi %%%c trong chuỗi định dạng"
 
-#: ../quickfix.c:420
 msgid "E374: Missing ] in format string"
 msgstr "E374: Thiếu ] trong chuỗi định dạng"
 
-#: ../quickfix.c:431
 #, c-format
 msgid "E375: Unsupported %%%c in format string"
 msgstr "E375: %%%c không được hỗ trợ trong chuỗi định dạng"
 
-#: ../quickfix.c:448
 #, c-format
 msgid "E376: Invalid %%%c in format string prefix"
 msgstr "E376: Không cho phép %%%c trong tiền tố của chuỗi định dạng"
 
-#: ../quickfix.c:454
 #, c-format
 msgid "E377: Invalid %%%c in format string"
 msgstr "E377: Không cho phép %%%c trong chuỗi định dạng"
 
-#. nothing found
-#: ../quickfix.c:477
 msgid "E378: 'errorformat' contains no pattern"
 msgstr "E378: Trong giá trị 'errorformat' thiếu mẫu (pattern)"
 
-#: ../quickfix.c:695
 msgid "E379: Missing or empty directory name"
 msgstr "E379: Tên thư mục không được đưa ra hoặc bằng một chuỗi rỗng"
 
-#: ../quickfix.c:1305
 msgid "E553: No more items"
 msgstr "E553: Không còn phần tử nào nữa"
 
-#: ../quickfix.c:1674
 #, c-format
 msgid "(%d of %d)%s%s: "
 msgstr "(%d của %d)%s%s: "
 
-#: ../quickfix.c:1676
 msgid " (line deleted)"
 msgstr " (dòng bị xóa)"
 
-#: ../quickfix.c:1863
 msgid "E380: At bottom of quickfix stack"
 msgstr "E380: Ở dưới của đống sửa nhanh"
 
-#: ../quickfix.c:1869
 msgid "E381: At top of quickfix stack"
 msgstr "E381: Ở đầu của đống sửa nhanh"
 
-#: ../quickfix.c:1880
 #, c-format
 msgid "error list %d of %d; %d errors"
 msgstr "danh sách lỗi %d của %d; %d lỗi"
 
-#: ../quickfix.c:2427
 msgid "E382: Cannot write, 'buftype' option is set"
 msgstr "E382: Không ghi nhớ được, giá trị 'buftype' không phải là chuỗi rỗng"
 
-#: ../quickfix.c:2812
-msgid "E683: File name missing or invalid pattern"
-msgstr ""
-
-#: ../quickfix.c:2911
-#, fuzzy, c-format
-msgid "Cannot open file \"%s\""
-msgstr "E624: Không thể mở tập tin \"%s\""
-
-#: ../quickfix.c:3429
-#, fuzzy
-msgid "E681: Buffer is not loaded"
-msgstr "1 bộ đệm được bỏ nạp từ bộ nhớ"
-
-#: ../quickfix.c:3487
-#, fuzzy
-msgid "E777: String or List expected"
-msgstr "E548: yêu cầu một số"
-
-#: ../regexp.c:359
-#, c-format
-msgid "E369: invalid item in %s%%[]"
+# TODO: Capitalise first word of message?
+msgid "E369: Invalid item in %s%%[]"
 msgstr "E369: phần tử không cho phép trong %s%%[]"
 
-#: ../regexp.c:374
-#, fuzzy, c-format
-msgid "E769: Missing ] after %s["
-msgstr "E69: Thiếu ] sau %s%%["
-
-#: ../regexp.c:375
-#, c-format
-msgid "E53: Unmatched %s%%("
-msgstr "E53: Không có cặp cho %s%%("
-
-#: ../regexp.c:376
-#, c-format
-msgid "E54: Unmatched %s("
-msgstr "E54: Không có cặp cho %s("
-
-#: ../regexp.c:377
-#, c-format
-msgid "E55: Unmatched %s)"
-msgstr "E55: Không có cặp cho %s)"
-
-#: ../regexp.c:378
-msgid "E66: \\z( not allowed here"
-msgstr "E66: \\z( không thể sử dụng ở đây"
-
-#: ../regexp.c:379
-msgid "E67: \\z1 et al. not allowed here"
-msgstr "E67: \\z1 và tương tự không được sử dụng ở đây"
-
-#: ../regexp.c:380
-#, c-format
-msgid "E69: Missing ] after %s%%["
-msgstr "E69: Thiếu ] sau %s%%["
-
-#: ../regexp.c:381
-#, c-format
-msgid "E70: Empty %s%%[]"
-msgstr "E70: %s%%[] rỗng"
-
-#: ../regexp.c:1209 ../regexp.c:1224
 msgid "E339: Pattern too long"
 msgstr "E339: Mẫu (pattern) quá dài"
 
-#: ../regexp.c:1371
 msgid "E50: Too many \\z("
 msgstr "E50: Quá nhiều \\z("
 
-#: ../regexp.c:1378
 #, c-format
 msgid "E51: Too many %s("
 msgstr "E51: Quá nhiều %s("
 
-#: ../regexp.c:1427
 msgid "E52: Unmatched \\z("
 msgstr "E52: Không có cặp cho \\z("
 
-#: ../regexp.c:1637
 #, c-format
-msgid "E59: invalid character after %s@"
+msgid "E53: Unmatched %s%%("
+msgstr "E53: Không có cặp cho %s%%("
+
+#, c-format
+msgid "E54: Unmatched %s("
+msgstr "E54: Không có cặp cho %s("
+
+#, c-format
+msgid "E55: Unmatched %s)"
+msgstr "E55: Không có cặp cho %s)"
+
+#, c-format
+msgid "E56: %s* operand could be empty"
+msgstr "E56: operand %s* không thể rỗng"
+
+#, c-format
+msgid "E57: %s+ operand could be empty"
+msgstr "E57: operand %s+ không thể rỗng"
+
+# TODO: Capitalise first word of message?
+msgid "E59: Invalid character after %s@"
 msgstr "E59: ký tự không cho phép sau %s@"
 
-#: ../regexp.c:1672
+#, c-format
+msgid "E58: %s{ operand could be empty"
+msgstr "E58: operand %s{ không thể rỗng"
+
 #, c-format
 msgid "E60: Too many complex %s{...}s"
 msgstr "E60: Quá nhiều cấu trúc phức tạp %s{...}"
 
-#: ../regexp.c:1687
 #, c-format
 msgid "E61: Nested %s*"
 msgstr "E61: %s* lồng vào"
 
-#: ../regexp.c:1690
 #, c-format
 msgid "E62: Nested %s%c"
 msgstr "E62: %s%c lồng vào"
 
-#: ../regexp.c:1800
-msgid "E63: invalid use of \\_"
+# TODO: Capitalise first word of message?
+msgid "E63: Invalid use of \\_"
 msgstr "E63: không cho phép sử dụng \\_"
 
-#: ../regexp.c:1850
 #, c-format
 msgid "E64: %s%c follows nothing"
 msgstr "E64: %s%c không theo sau gì cả"
 
-#: ../regexp.c:1902
 msgid "E65: Illegal back reference"
 msgstr "E65: Không cho phép liên kết ngược lại"
 
-#: ../regexp.c:1943
+msgid "E66: \\z( not allowed here"
+msgstr "E66: \\z( không thể sử dụng ở đây"
+
+msgid "E67: \\z1 - \\z9 not allowed here"
+msgstr "E67: \\z1 và tương tự không được sử dụng ở đây"
+
 msgid "E68: Invalid character after \\z"
 msgstr "E68: Ký tự không cho phép sau \\z"
 
-#: ../regexp.c:2049 ../regexp_nfa.c:1296
-#, fuzzy, c-format
-msgid "E678: Invalid character after %s%%[dxouU]"
-msgstr "E71: Ký tự không cho phép sau %s%%"
+#, c-format
+msgid "E69: Missing ] after %s%%["
+msgstr "E69: Thiếu ] sau %s%%["
 
-#: ../regexp.c:2107
+#, c-format
+msgid "E70: Empty %s%%[]"
+msgstr "E70: %s%%[] rỗng"
+
 #, c-format
 msgid "E71: Invalid character after %s%%"
 msgstr "E71: Ký tự không cho phép sau %s%%"
 
-#: ../regexp.c:3017
 #, c-format
 msgid "E554: Syntax error in %s{...}"
 msgstr "E554: Lỗi cú pháp trong %s{...}"
 
-#: ../regexp.c:3805
+msgid "E361: Crash intercepted; regexp too complex?"
+msgstr "E361: Sự cố được ngăn chặn; biểu thức chính quy quá phức tạp?"
+
+# TODO: Capitalise first word of message?
+msgid "E363: Pattern caused out-of-stack error"
+msgstr "E363: sử dụng mẫu (pattern) gây ra lỗi out-of-stack"
+
 msgid "External submatches:\n"
 msgstr "Sự tương ứng con ngoài:\n"
 
-#: ../regexp.c:7022
-msgid ""
-"E864: \\%#= can only be followed by 0, 1, or 2. The automatic engine will be "
-"used "
-msgstr ""
-
-#: ../regexp_nfa.c:239
-msgid "E865: (NFA) Regexp end encountered prematurely"
-msgstr ""
-
-#: ../regexp_nfa.c:240
 #, c-format
-msgid "E866: (NFA regexp) Misplaced %c"
-msgstr ""
+msgid "+--%3ld lines folded "
+msgstr "+--%3ld dòng được gấp"
 
-#: ../regexp_nfa.c:242
-#, c-format
-msgid "E877: (NFA regexp) Invalid character class: %<PRId64>"
-msgstr ""
-
-#: ../regexp_nfa.c:1261
-#, c-format
-msgid "E867: (NFA) Unknown operator '\\z%c'"
-msgstr ""
-
-#: ../regexp_nfa.c:1387
-#, c-format
-msgid "E867: (NFA) Unknown operator '\\%%%c'"
-msgstr ""
-
-#: ../regexp_nfa.c:1802
-#, c-format
-msgid "E869: (NFA) Unknown operator '\\@%c'"
-msgstr ""
-
-#: ../regexp_nfa.c:1831
-msgid "E870: (NFA regexp) Error reading repetition limits"
-msgstr ""
-
-#. Can't have a multi follow a multi.
-#: ../regexp_nfa.c:1895
-msgid "E871: (NFA regexp) Can't have a multi follow a multi !"
-msgstr ""
-
-#. Too many `('
-#: ../regexp_nfa.c:2037
-msgid "E872: (NFA regexp) Too many '('"
-msgstr ""
-
-#: ../regexp_nfa.c:2042
-#, fuzzy
-msgid "E879: (NFA regexp) Too many \\z("
-msgstr "E50: Quá nhiều \\z("
-
-#: ../regexp_nfa.c:2066
-msgid "E873: (NFA regexp) proper termination error"
-msgstr ""
-
-#: ../regexp_nfa.c:2599
-msgid "E874: (NFA) Could not pop the stack !"
-msgstr ""
-
-#: ../regexp_nfa.c:3298
-msgid ""
-"E875: (NFA regexp) (While converting from postfix to NFA), too many states "
-"left on stack"
-msgstr ""
-
-#: ../regexp_nfa.c:3302
-msgid "E876: (NFA regexp) Not enough space to store the whole NFA "
-msgstr ""
-
-#: ../regexp_nfa.c:4571 ../regexp_nfa.c:4869
-msgid ""
-"Could not open temporary log file for writing, displaying on stderr ... "
-msgstr ""
-
-#: ../regexp_nfa.c:4840
-#, c-format
-msgid "(NFA) COULD NOT OPEN %s !"
-msgstr ""
-
-#: ../regexp_nfa.c:6049
-#, fuzzy
-msgid "Could not open temporary log file for writing "
-msgstr "E214: Không tìm thấy tập tin tạm thời (temp) để ghi nhớ"
-
-#: ../screen.c:7435
 msgid " VREPLACE"
 msgstr " THAY THẾ ẢO"
 
-#: ../screen.c:7437
 msgid " REPLACE"
 msgstr " THAY THẾ"
 
-#: ../screen.c:7440
 msgid " REVERSE"
 msgstr " NGƯỢC LẠI"
 
-#: ../screen.c:7441
 msgid " INSERT"
 msgstr " CHÈN"
 
-#: ../screen.c:7443
 msgid " (insert)"
 msgstr " (chèn)"
 
-#: ../screen.c:7445
 msgid " (replace)"
 msgstr " (thay thế)"
 
-#: ../screen.c:7447
 msgid " (vreplace)"
 msgstr " (thay thế ảo)"
 
-#: ../screen.c:7449
 msgid " Hebrew"
 msgstr " Do thái"
 
-#: ../screen.c:7454
 msgid " Arabic"
 msgstr " Ả rập"
 
-#: ../screen.c:7456
 msgid " (lang)"
 msgstr " (ngôn ngữ)"
 
-#: ../screen.c:7459
 msgid " (paste)"
 msgstr " (dán)"
 
-#: ../screen.c:7469
 msgid " VISUAL"
 msgstr " CHẾ ĐỘ VISUAL"
 
-#: ../screen.c:7470
 msgid " VISUAL LINE"
 msgstr " DÒNG VISUAL"
 
-#: ../screen.c:7471
 msgid " VISUAL BLOCK"
 msgstr " KHỐI VISUAL"
 
-#: ../screen.c:7472
 msgid " SELECT"
 msgstr " LỰA CHỌN"
 
-#: ../screen.c:7473
 msgid " SELECT LINE"
 msgstr " LỰA CHỌN DÒNG"
 
-#: ../screen.c:7474
 msgid " SELECT BLOCK"
 msgstr " LỰA CHỌN KHỐI"
 
-#: ../screen.c:7486 ../screen.c:7541
 msgid "recording"
 msgstr "đang ghi"
 
-#: ../search.c:487
+msgid "search hit TOP, continuing at BOTTOM"
+msgstr "tìm kiếm sẽ được tiếp tục từ CUỐI tài liệu"
+
+msgid "search hit BOTTOM, continuing at TOP"
+msgstr "tìm kiếm sẽ được tiếp tục từ ĐẦU tài liệu"
+
 #, c-format
 msgid "E383: Invalid search string: %s"
 msgstr "E383: Chuỗi tìm kiếm không đúng: %s"
 
-#: ../search.c:832
-#, c-format
-msgid "E384: search hit TOP without match for: %s"
+# TODO: Capitalise first word of message?
+msgid "E384: Search hit TOP without match for: %s"
 msgstr "E384: tìm kiếm kết thúc ở ĐẦU tập tin; không tìm thấy %s"
 
-#: ../search.c:835
-#, c-format
-msgid "E385: search hit BOTTOM without match for: %s"
+# TODO: Capitalise first word of message?
+msgid "E385: Search hit BOTTOM without match for: %s"
 msgstr "E385: tìm kiếm kết thúc ở CUỐI tập tin; không tìm thấy %s"
 
-#: ../search.c:1200
 msgid "E386: Expected '?' or '/'  after ';'"
 msgstr "E386: Mong đợi nhập '?' hoặc '/' sau ';'"
 
-#: ../search.c:4085
 msgid " (includes previously listed match)"
 msgstr " (gồm cả những tương ứng đã liệt kê trước đây)"
 
-#. cursor at status line
-#: ../search.c:4104
 msgid "--- Included files "
 msgstr "--- Tập tin tính đến "
 
-#: ../search.c:4106
 msgid "not found "
 msgstr "không tìm thấy "
 
-#: ../search.c:4107
 msgid "in path ---\n"
 msgstr "trong đường dẫn ---\n"
 
-#: ../search.c:4168
 msgid "  (Already listed)"
 msgstr " (Đã liệt kê)"
 
-#: ../search.c:4170
 msgid "  NOT FOUND"
 msgstr " KHÔNG TÌM THẤY"
 
-#: ../search.c:4211
 #, c-format
 msgid "Scanning included file: %s"
 msgstr "Quét trong tập tin được tính đến: %s"
 
-#: ../search.c:4216
-#, fuzzy, c-format
-msgid "Searching included file %s"
-msgstr "Quét trong tập tin được tính đến: %s"
-
-#: ../search.c:4405
 msgid "E387: Match is on current line"
 msgstr "E387: Tương ứng nằm trên dòng hiện tại"
 
-#: ../search.c:4517
 msgid "All included files were found"
 msgstr "Tìm thấy tất cả các tập tin được tính đến"
 
-#: ../search.c:4519
 msgid "No included files"
 msgstr "Không có tập tin được tính đến"
 
-#: ../search.c:4527
 msgid "E388: Couldn't find definition"
 msgstr "E388: Không tìm thấy định nghĩa"
 
-#: ../search.c:4529
 msgid "E389: Couldn't find pattern"
 msgstr "E389: Không tìm thấy mẫu (pattern)"
 
-#: ../search.c:4668
-#, fuzzy
-msgid "Substitute "
-msgstr "1 thay thế"
-
-#: ../search.c:4681
-#, c-format
-msgid ""
-"\n"
-"# Last %sSearch Pattern:\n"
-"~"
-msgstr ""
-
-#: ../spell.c:951
-#, fuzzy
-msgid "E759: Format error in spell file"
-msgstr "E297: Lỗi ghi nhớ tập tin trao đổi (swap)"
-
-#: ../spell.c:952
-msgid "E758: Truncated spell file"
-msgstr ""
-
-#: ../spell.c:953
-#, c-format
-msgid "Trailing text in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:954
-#, c-format
-msgid "Affix name too long in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:955
-#, fuzzy
-msgid "E761: Format error in affix file FOL, LOW or UPP"
-msgstr "E431: Lỗi định dạng trong tập tin thẻ ghi \"%s\""
-
-#: ../spell.c:957
-msgid "E762: Character in FOL, LOW or UPP is out of range"
-msgstr ""
-
-#: ../spell.c:958
-msgid "Compressing word tree..."
-msgstr ""
-
-#: ../spell.c:1951
-msgid "E756: Spell checking is not enabled"
-msgstr ""
-
-#: ../spell.c:2249
-#, c-format
-msgid "Warning: Cannot find word list \"%s.%s.spl\" or \"%s.ascii.spl\""
-msgstr ""
-
-#: ../spell.c:2473
-#, fuzzy, c-format
-msgid "Reading spell file \"%s\""
-msgstr "Đang sử dụng tập tin trao đổi (swap) \"%s\""
-
-#: ../spell.c:2496
-#, fuzzy
-msgid "E757: This does not look like a spell file"
-msgstr "E307: %s không phải là tập tin trao đổi (swap) của Vim"
-
-#: ../spell.c:2501
-msgid "E771: Old spell file, needs to be updated"
-msgstr ""
-
-#: ../spell.c:2504
-msgid "E772: Spell file is for newer version of Vim"
-msgstr ""
-
-#: ../spell.c:2602
-#, fuzzy
-msgid "E770: Unsupported section in spell file"
-msgstr "E297: Lỗi ghi nhớ tập tin trao đổi (swap)"
-
-#: ../spell.c:3762
-#, fuzzy, c-format
-msgid "Warning: region %s not supported"
-msgstr "E519: Tùy chọn không được hỗ trợ"
-
-#: ../spell.c:4550
-#, fuzzy, c-format
-msgid "Reading affix file %s ..."
-msgstr "Tìm kiếm tập tin thẻ ghi %s"
-
-#: ../spell.c:4589 ../spell.c:5635 ../spell.c:6140
-#, c-format
-msgid "Conversion failure for word in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:4630 ../spell.c:6170
-#, c-format
-msgid "Conversion in %s not supported: from %s to %s"
-msgstr ""
-
-#: ../spell.c:4642
-#, c-format
-msgid "Invalid value for FLAG in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:4655
-#, c-format
-msgid "FLAG after using flags in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:4723
-#, c-format
-msgid ""
-"Defining COMPOUNDFORBIDFLAG after PFX item may give wrong results in %s line "
-"%d"
-msgstr ""
-
-#: ../spell.c:4731
-#, c-format
-msgid ""
-"Defining COMPOUNDPERMITFLAG after PFX item may give wrong results in %s line "
-"%d"
-msgstr ""
-
-#: ../spell.c:4747
-#, c-format
-msgid "Wrong COMPOUNDRULES value in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:4771
-#, c-format
-msgid "Wrong COMPOUNDWORDMAX value in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:4777
-#, c-format
-msgid "Wrong COMPOUNDMIN value in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:4783
-#, c-format
-msgid "Wrong COMPOUNDSYLMAX value in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:4795
-#, c-format
-msgid "Wrong CHECKCOMPOUNDPATTERN value in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:4847
-#, c-format
-msgid "Different combining flag in continued affix block in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:4850
-#, fuzzy, c-format
-msgid "Duplicate affix in %s line %d: %s"
-msgstr "E154: Thẻ ghi lặp lại \"%s\" trong tập tin %s"
-
-#: ../spell.c:4871
-#, c-format
-msgid ""
-"Affix also used for BAD/RARE/KEEPCASE/NEEDAFFIX/NEEDCOMPOUND/NOSUGGEST in %s "
-"line %d: %s"
-msgstr ""
-
-#: ../spell.c:4893
-#, c-format
-msgid "Expected Y or N in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:4968
-#, c-format
-msgid "Broken condition in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:5091
-#, c-format
-msgid "Expected REP(SAL) count in %s line %d"
-msgstr ""
-
-#: ../spell.c:5120
-#, c-format
-msgid "Expected MAP count in %s line %d"
-msgstr ""
-
-#: ../spell.c:5132
-#, c-format
-msgid "Duplicate character in MAP in %s line %d"
-msgstr ""
-
-#: ../spell.c:5176
-#, c-format
-msgid "Unrecognized or duplicate item in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:5197
-#, c-format
-msgid "Missing FOL/LOW/UPP line in %s"
-msgstr ""
-
-#: ../spell.c:5220
-msgid "COMPOUNDSYLMAX used without SYLLABLE"
-msgstr ""
-
-#: ../spell.c:5236
-#, fuzzy
-msgid "Too many postponed prefixes"
-msgstr "Có quá nhiều tham số soạn thảo"
-
-#: ../spell.c:5238
-#, fuzzy
-msgid "Too many compound flags"
-msgstr "Có quá nhiều tham số soạn thảo"
-
-#: ../spell.c:5240
-msgid "Too many postponed prefixes and/or compound flags"
-msgstr ""
-
-#: ../spell.c:5250
-#, c-format
-msgid "Missing SOFO%s line in %s"
-msgstr ""
-
-#: ../spell.c:5253
-#, c-format
-msgid "Both SAL and SOFO lines in %s"
-msgstr ""
-
-#: ../spell.c:5331
-#, c-format
-msgid "Flag is not a number in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:5334
-#, c-format
-msgid "Illegal flag in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:5493 ../spell.c:5501
-#, c-format
-msgid "%s value differs from what is used in another .aff file"
-msgstr ""
-
-#: ../spell.c:5602
-#, fuzzy, c-format
-msgid "Reading dictionary file %s ..."
-msgstr "Quét từ điển: %s"
-
-#: ../spell.c:5611
-#, c-format
-msgid "E760: No word count in %s"
-msgstr ""
-
-#: ../spell.c:5669
-#, c-format
-msgid "line %6d, word %6d - %s"
-msgstr ""
-
-#: ../spell.c:5691
-#, fuzzy, c-format
-msgid "Duplicate word in %s line %d: %s"
-msgstr "Tìm thấy tương ứng trên mọi dòng: %s"
-
-#: ../spell.c:5694
-#, c-format
-msgid "First duplicate word in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:5746
-#, c-format
-msgid "%d duplicate word(s) in %s"
-msgstr ""
-
-#: ../spell.c:5748
-#, c-format
-msgid "Ignored %d word(s) with non-ASCII characters in %s"
-msgstr ""
-
-#: ../spell.c:6115
-#, fuzzy, c-format
-msgid "Reading word file %s ..."
-msgstr "Đọc từ đầu vào tiêu chuẩn stdin..."
-
-#: ../spell.c:6155
-#, c-format
-msgid "Duplicate /encoding= line ignored in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:6159
-#, c-format
-msgid "/encoding= line after word ignored in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:6180
-#, c-format
-msgid "Duplicate /regions= line ignored in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:6185
-#, c-format
-msgid "Too many regions in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:6198
-#, c-format
-msgid "/ line ignored in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:6224
-#, fuzzy, c-format
-msgid "Invalid region nr in %s line %d: %s"
-msgstr "E573: Sử dụng id máy chủ không đúng: %s"
-
-#: ../spell.c:6230
-#, c-format
-msgid "Unrecognized flags in %s line %d: %s"
-msgstr ""
-
-#: ../spell.c:6257
-#, c-format
-msgid "Ignored %d words with non-ASCII characters"
-msgstr ""
-
-#: ../spell.c:6656
-#, c-format
-msgid "Compressed %d of %d nodes; %d (%d%%) remaining"
-msgstr ""
-
-#: ../spell.c:7340
-msgid "Reading back spell file..."
-msgstr ""
-
-#. Go through the trie of good words, soundfold each word and add it to
-#. the soundfold trie.
-#: ../spell.c:7357
-msgid "Performing soundfolding..."
-msgstr ""
-
-#: ../spell.c:7368
-#, c-format
-msgid "Number of words after soundfolding: %<PRId64>"
-msgstr ""
-
-#: ../spell.c:7476
-#, c-format
-msgid "Total number of words: %d"
-msgstr ""
-
-#: ../spell.c:7655
-#, fuzzy, c-format
-msgid "Writing suggestion file %s ..."
-msgstr "Ghi tập tin viminfo \"%s\""
-
-#: ../spell.c:7707 ../spell.c:7927
-#, c-format
-msgid "Estimated runtime memory use: %d bytes"
-msgstr ""
-
-#: ../spell.c:7820
-msgid "E751: Output file name must not have region name"
-msgstr ""
-
-#: ../spell.c:7822
-#, fuzzy
-msgid "E754: Only up to 8 regions supported"
-msgstr "E519: Tùy chọn không được hỗ trợ"
-
-#: ../spell.c:7846
-#, fuzzy, c-format
-msgid "E755: Invalid region in %s"
-msgstr "E15: Biểu thức không cho phép: %s"
-
-#: ../spell.c:7907
-msgid "Warning: both compounding and NOBREAK specified"
-msgstr ""
-
-#: ../spell.c:7920
-#, fuzzy, c-format
-msgid "Writing spell file %s ..."
-msgstr "Ghi tập tin viminfo \"%s\""
-
-#: ../spell.c:7925
-msgid "Done!"
-msgstr ""
-
-#: ../spell.c:8034
-#, c-format
-msgid "E765: 'spellfile' does not have %<PRId64> entries"
-msgstr ""
-
-#: ../spell.c:8074
-#, c-format
-msgid "Word '%.*s' removed from %s"
-msgstr ""
-
-#: ../spell.c:8117
-#, c-format
-msgid "Word '%.*s' added to %s"
-msgstr ""
-
-#: ../spell.c:8381
-msgid "E763: Word characters differ between spell files"
-msgstr ""
-
-#: ../spell.c:8684
-msgid "Sorry, no suggestions"
-msgstr ""
-
-#: ../spell.c:8687
-#, fuzzy, c-format
-msgid "Sorry, only %<PRId64> suggestions"
-msgstr " trên %<PRId64> dòng"
-
-#. for when 'cmdheight' > 1
-#. avoid more prompt
-#: ../spell.c:8704
-#, fuzzy, c-format
-msgid "Change \"%.*s\" to:"
-msgstr "Ghi nhớ thay đổi vào \"%.*s\"?"
-
-#: ../spell.c:8737
-#, c-format
-msgid " < \"%.*s\""
-msgstr ""
-
-#: ../spell.c:8882
-#, fuzzy
-msgid "E752: No previous spell replacement"
-msgstr "E35: Không có biểu thức chính quy trước"
-
-#: ../spell.c:8925
-#, fuzzy, c-format
-msgid "E753: Not found: %s"
-msgstr "E334: Không tìm thấy trình đơn: %s"
-
-#: ../spell.c:9276
-#, fuzzy, c-format
-msgid "E778: This does not look like a .sug file: %s"
-msgstr "E307: %s không phải là tập tin trao đổi (swap) của Vim"
-
-#: ../spell.c:9282
-#, c-format
-msgid "E779: Old .sug file, needs to be updated: %s"
-msgstr ""
-
-#: ../spell.c:9286
-#, c-format
-msgid "E780: .sug file is for newer version of Vim: %s"
-msgstr ""
-
-#: ../spell.c:9295
-#, c-format
-msgid "E781: .sug file doesn't match .spl file: %s"
-msgstr ""
-
-#: ../spell.c:9305
-#, fuzzy, c-format
-msgid "E782: error while reading .sug file: %s"
-msgstr "E47: Lỗi khi đọc tập tin lỗi"
-
-#. This should have been checked when generating the .spl
-#. file.
-#: ../spell.c:11575
-msgid "E783: duplicate char in MAP entry"
-msgstr ""
-
-#: ../syntax.c:266
-msgid "No Syntax items defined for this buffer"
-msgstr "Không có phần tử cú pháp nào được định nghĩa cho bộ đệm này"
-
-#: ../syntax.c:3083 ../syntax.c:3104 ../syntax.c:3127
 #, c-format
 msgid "E390: Illegal argument: %s"
 msgstr "E390: Tham số không cho phép: %s"
 
-#: ../syntax.c:3299
 #, c-format
 msgid "E391: No such syntax cluster: %s"
 msgstr "E391: Không có cụm cú pháp như vậy: %s"
 
-#: ../syntax.c:3433
+msgid "No Syntax items defined for this buffer"
+msgstr "Không có phần tử cú pháp nào được định nghĩa cho bộ đệm này"
+
 msgid "syncing on C-style comments"
 msgstr "Đồng bộ hóa theo chú thích kiểu C"
 
-#: ../syntax.c:3439
 msgid "no syncing"
 msgstr "không đồng bộ hóa"
 
-#: ../syntax.c:3441
 msgid "syncing starts "
 msgstr "đồng bộ hóa bắt đầu "
 
-#: ../syntax.c:3443 ../syntax.c:3506
 msgid " lines before top line"
 msgstr " dòng trước dòng đầu tiên"
 
-#: ../syntax.c:3448
 msgid ""
 "\n"
 "--- Syntax sync items ---"
@@ -5637,7 +4155,6 @@ msgstr ""
 "\n"
 "--- Phần tử đồng bộ hóa cú pháp ---"
 
-#: ../syntax.c:3452
 msgid ""
 "\n"
 "syncing on items"
@@ -5645,7 +4162,6 @@ msgstr ""
 "\n"
 "đồng bộ hóa theo phần tử"
 
-#: ../syntax.c:3457
 msgid ""
 "\n"
 "--- Syntax items ---"
@@ -5653,274 +4169,197 @@ msgstr ""
 "\n"
 "--- Phần tử cú pháp ---"
 
-#: ../syntax.c:3475
 #, c-format
 msgid "E392: No such syntax cluster: %s"
 msgstr "E392: Không có cụm cú pháp như vậy: %s"
 
-#: ../syntax.c:3497
 msgid "minimal "
 msgstr "nhỏ nhất "
 
-#: ../syntax.c:3503
 msgid "maximal "
 msgstr "lớn nhất "
 
-#: ../syntax.c:3513
 msgid "; match "
 msgstr "; tương ứng "
 
-#: ../syntax.c:3515
 msgid " line breaks"
 msgstr " chuyển dòng"
 
-#: ../syntax.c:4076
-msgid "E395: contains argument not accepted here"
-msgstr "E395: không được sử dụng tham số contains ở đây"
-
-#: ../syntax.c:4096
-#, fuzzy
-msgid "E844: invalid cchar value"
-msgstr "E474: Tham số không cho phép"
-
-#: ../syntax.c:4107
 msgid "E393: group[t]here not accepted here"
 msgstr "E393: không được sử dụng group[t]here ở đây"
 
-#: ../syntax.c:4126
 #, c-format
 msgid "E394: Didn't find region item for %s"
 msgstr "E394: Phần tử vùng cho %s không tìm thấy"
 
-#: ../syntax.c:4188
+# TODO: Capitalise first word of message?
+msgid "E395: Contains argument not accepted here"
+msgstr "E395: không được sử dụng tham số contains ở đây"
+
+msgid "E396: containedin argument not accepted here"
+msgstr "E396: không được sử dụng tham số containedin ở đây"
+
 msgid "E397: Filename required"
 msgstr "E397: Yêu cầu tên tập tin"
 
-#: ../syntax.c:4221
-#, fuzzy
-msgid "E847: Too many syntax includes"
-msgstr "E77: Quá nhiều tên tập tin"
-
-#: ../syntax.c:4303
-#, fuzzy, c-format
-msgid "E789: Missing ']': %s"
-msgstr "E398: Thiếu '=': %s"
-
-#: ../syntax.c:4531
 #, c-format
 msgid "E398: Missing '=': %s"
 msgstr "E398: Thiếu '=': %s"
 
-#: ../syntax.c:4666
 #, c-format
 msgid "E399: Not enough arguments: syntax region %s"
 msgstr "E399: Không đủ tham số: vùng cú pháp %s"
 
-#: ../syntax.c:4870
-#, fuzzy
-msgid "E848: Too many syntax clusters"
-msgstr "E391: Không có cụm cú pháp như vậy: %s"
-
-#: ../syntax.c:4954
 msgid "E400: No cluster specified"
 msgstr "E400: Chưa chỉ ra cụm"
 
-#. end delimiter not found
-#: ../syntax.c:4986
 #, c-format
 msgid "E401: Pattern delimiter not found: %s"
 msgstr "E401: Không tìm thấy ký tự phân chia mẫu (pattern): %s"
 
-#: ../syntax.c:5049
 #, c-format
 msgid "E402: Garbage after pattern: %s"
 msgstr "E402: Rác ở sau mẫu (pattern): %s"
 
-#: ../syntax.c:5120
-msgid "E403: syntax sync: line continuations pattern specified twice"
+# TODO: Capitalise first word of message?
+msgid "E403: syntax sync: Line continuations pattern specified twice"
 msgstr "E403: đồng bộ hóa cú pháp: mẫu tiếp tục của dòng chỉ ra hai lần"
 
-#: ../syntax.c:5169
 #, c-format
 msgid "E404: Illegal arguments: %s"
 msgstr "E404: Tham số không cho phép: %s"
 
-#: ../syntax.c:5217
 #, c-format
 msgid "E405: Missing equal sign: %s"
 msgstr "E405: Thiếu dấu bằng: %s"
 
-#: ../syntax.c:5222
 #, c-format
 msgid "E406: Empty argument: %s"
 msgstr "E406: Tham số trống rỗng: %s"
 
-#: ../syntax.c:5240
 #, c-format
 msgid "E407: %s not allowed here"
 msgstr "E407: %s không được cho phép ở đây"
 
-#: ../syntax.c:5246
 #, c-format
 msgid "E408: %s must be first in contains list"
 msgstr "E408: %s phải là đầu tiên trong danh sách contains"
 
-#: ../syntax.c:5304
 #, c-format
 msgid "E409: Unknown group name: %s"
 msgstr "E409: Tên nhóm không biết: %s"
 
-#: ../syntax.c:5512
 #, c-format
 msgid "E410: Invalid :syntax subcommand: %s"
 msgstr "E410: Câu lệnh con :syntax không đúng: %s"
 
-#: ../syntax.c:5854
-msgid ""
-"  TOTAL      COUNT  MATCH   SLOWEST     AVERAGE   NAME               PATTERN"
-msgstr ""
-
-#: ../syntax.c:6146
-msgid "E679: recursive loop loading syncolor.vim"
-msgstr ""
-
-#: ../syntax.c:6256
-#, c-format
-msgid "E411: highlight group not found: %s"
+# TODO: Capitalise first word of message?
+msgid "E411: Highlight group not found: %s"
 msgstr "E411: không tìm thấy nhóm chiếu sáng cú pháp: %s"
 
-#: ../syntax.c:6278
 #, c-format
 msgid "E412: Not enough arguments: \":highlight link %s\""
 msgstr "E412: Không đủ tham số: \":highlight link %s\""
 
-#: ../syntax.c:6284
 #, c-format
 msgid "E413: Too many arguments: \":highlight link %s\""
 msgstr "E413: Quá nhiều tham số: \":highlight link %s\""
 
-#: ../syntax.c:6302
-msgid "E414: group has settings, highlight link ignored"
+# TODO: Capitalise first word of message?
+msgid "E414: Group has settings, highlight link ignored"
 msgstr "E414: nhóm có thiết lập riêng, chiếu sáng liên kết bị bỏ qua"
 
-#: ../syntax.c:6367
-#, c-format
-msgid "E415: unexpected equal sign: %s"
+# TODO: Capitalise first word of message?
+msgid "E415: Unexpected equal sign: %s"
 msgstr "E415: dấu bằng không được mong đợi: %s"
 
-#: ../syntax.c:6395
-#, c-format
-msgid "E416: missing equal sign: %s"
+# TODO: Capitalise first word of message?
+msgid "E416: Missing equal sign: %s"
 msgstr "E416: thiếu dấu bằng: %s"
 
-#: ../syntax.c:6418
-#, c-format
-msgid "E417: missing argument: %s"
+# TODO: Capitalise first word of message?
+msgid "E417: Missing argument: %s"
 msgstr "E417: thiếu tham số: %s"
 
-#: ../syntax.c:6446
 #, c-format
 msgid "E418: Illegal value: %s"
 msgstr "E418: Giá trị không cho phép: %s"
 
-#: ../syntax.c:6496
 msgid "E419: FG color unknown"
 msgstr "E419: Không rõ màu văn bản (FG)"
 
-#: ../syntax.c:6504
 msgid "E420: BG color unknown"
 msgstr "E420: Không rõ màu nền sau (BG)"
 
-#: ../syntax.c:6564
 #, c-format
 msgid "E421: Color name or number not recognized: %s"
 msgstr "E421: Tên hoặc số của màu không được nhận ra: %s"
 
-#: ../syntax.c:6714
-#, c-format
-msgid "E422: terminal code too long: %s"
+# TODO: Capitalise first word of message?
+msgid "E422: Terminal code too long: %s"
 msgstr "E422: mã terminal quá dài: %s"
 
-#: ../syntax.c:6753
 #, c-format
 msgid "E423: Illegal argument: %s"
 msgstr "E423: Tham số không cho phép: %s"
 
-#: ../syntax.c:6925
 msgid "E424: Too many different highlighting attributes in use"
 msgstr "E424: Sử dụng quá nhiều thuộc tính chiếu sáng cú pháp"
 
-#: ../syntax.c:7427
 msgid "E669: Unprintable character in group name"
 msgstr "E669: Ký tự không thể tin ra trong tên nhóm"
 
-#: ../highlight_group.c:1756
-msgid "E5248: Invalid character in group name"
-msgstr "E5248: Ký tự không cho phép trong tên nhóm"
+msgid "W18: Invalid character in group name"
+msgstr "W18: Ký tự không cho phép trong tên nhóm"
 
-#: ../syntax.c:7448
-msgid "E849: Too many highlight and syntax groups"
-msgstr ""
-
-#: ../tag.c:104
-msgid "E555: at bottom of tag stack"
+# TODO: Capitalise first word of message?
+msgid "E555: At bottom of tag stack"
 msgstr "E555: ở cuối đống thẻ ghi"
 
-#: ../tag.c:105
-msgid "E556: at top of tag stack"
+# TODO: Capitalise first word of message?
+msgid "E556: At top of tag stack"
 msgstr "E556: ở đầu đống thẻ ghi"
 
-#: ../tag.c:380
 msgid "E425: Cannot go before first matching tag"
 msgstr "E425: Không chuyển được tới vị trí ở trước thẻ ghi tương ứng đầu tiên"
 
-#: ../tag.c:504
-#, c-format
-msgid "E426: tag not found: %s"
+# TODO: Capitalise first word of message?
+msgid "E426: Tag not found: %s"
 msgstr "E426: không tìm thấy thẻ ghi: %s"
 
-#: ../tag.c:528
 msgid "  # pri kind tag"
 msgstr "  # pri loại thẻ ghi"
 
-#: ../tag.c:531
 msgid "file\n"
 msgstr "tập tin\n"
 
-#: ../tag.c:829
+msgid "Enter nr of choice (<CR> to abort): "
+msgstr "Hãy chọn số cần thiết (<CR> để dừng):"
+
 msgid "E427: There is only one matching tag"
 msgstr "E427: Chỉ có một thẻ ghi tương ứng"
 
-#: ../tag.c:831
 msgid "E428: Cannot go beyond last matching tag"
 msgstr "E428: Không chuyển được tới vị trí ở sau thẻ ghi tương ứng cuối cùng"
 
-#: ../tag.c:850
 #, c-format
 msgid "File \"%s\" does not exist"
 msgstr "Tập tin \"%s\" không tồn tại"
 
-#. Give an indication of the number of matching tags
-#: ../tag.c:859
 #, c-format
 msgid "tag %d of %d%s"
 msgstr "thẻ ghi %d của %d%s"
 
-#: ../tag.c:862
 msgid " or more"
 msgstr " và hơn nữa"
 
-#: ../tag.c:864
 msgid "  Using tag with different case!"
 msgstr " Đang sử dụng thẻ ghi với kiểu chữ khác!"
 
-#: ../tag.c:909
 #, c-format
 msgid "E429: File \"%s\" does not exist"
 msgstr "E429: Tập tin \"%s\" không tồn tại"
 
-#. Highlight title
-#: ../tag.c:960
 msgid ""
 "\n"
 "  # TO tag         FROM line  in file/text"
@@ -5928,79 +4367,58 @@ msgstr ""
 "\n"
 "  # TỚI thẻ ghi        TỪ   dòng  trong tập tin/văn bản"
 
-#: ../tag.c:1303
 #, c-format
 msgid "Searching tags file %s"
 msgstr "Tìm kiếm tập tin thẻ ghi %s"
 
-#: ../tag.c:1545
-msgid "Ignoring long line in tags file"
-msgstr ""
+#, c-format
+msgid "E430: Tag file path truncated for %s\n"
+msgstr "E430: Đường dẫn tới tập tin thẻ ghi bị cắt bớt cho %s\n"
 
-#: ../tag.c:1915
 #, c-format
 msgid "E431: Format error in tags file \"%s\""
 msgstr "E431: Lỗi định dạng trong tập tin thẻ ghi \"%s\""
 
-#: ../tag.c:1917
 #, c-format
-msgid "Before byte %<PRId64>"
-msgstr "Trước byte %<PRId64>"
+msgid "Before byte %ld"
+msgstr "Trước byte %ld"
 
-#: ../tag.c:1929
 #, c-format
 msgid "E432: Tags file not sorted: %s"
 msgstr "E432: Tập tin thẻ ghi chưa được sắp xếp: %s"
 
-#. never opened any tags file
-#: ../tag.c:1960
 msgid "E433: No tags file"
 msgstr "E433: Không có tập tin thẻ ghi"
 
-#: ../tag.c:2536
 msgid "E434: Can't find tag pattern"
 msgstr "E434: Không tìm thấy mẫu thẻ ghi"
 
-#: ../tag.c:2544
 msgid "E435: Couldn't find tag, just guessing!"
 msgstr "E435: Không tìm thấy thẻ ghi, đang thử đoán!"
 
-#: ../tag.c:2797
-#, c-format
-msgid "Duplicate field name: %s"
-msgstr ""
-
-#: ../term.c:1442
 msgid "' not known. Available builtin terminals are:"
 msgstr "' không rõ. Có các terminal gắn sẵn (builtin) sau:"
 
-#: ../term.c:1463
 msgid "defaulting to '"
 msgstr "theo mặc định '"
 
-#: ../term.c:1731
 msgid "E557: Cannot open termcap file"
 msgstr "E557: Không thể mở tập tin termcap"
 
-#: ../term.c:1735
 msgid "E558: Terminal entry not found in terminfo"
 msgstr "E558: Trong terminfo không có bản ghi nào về terminal này"
 
-#: ../term.c:1737
 msgid "E559: Terminal entry not found in termcap"
 msgstr "E559: Trong termcap không có bản ghi nào về terminal này"
 
-#: ../term.c:1878
 #, c-format
 msgid "E436: No \"%s\" entry in termcap"
 msgstr "E436: Trong termcap không có bản ghi \"%s\""
 
-#: ../term.c:2249
-msgid "E437: terminal capability \"cm\" required"
+# TODO: Capitalise first word of message?
+msgid "E437: Terminal capability \"cm\" required"
 msgstr "E437: cần khả năng của terminal \"cm\""
 
-#. Highlight title
-#: ../term.c:4376
 msgid ""
 "\n"
 "--- Terminal keys ---"
@@ -6008,176 +4426,110 @@ msgstr ""
 "\n"
 "--- Phím terminal ---"
 
-#: ../ui.c:481
+msgid "new shell started\n"
+msgstr "đã chạy shell mới\n"
+
 msgid "Vim: Error reading input, exiting...\n"
 msgstr "Vim: Lỗi đọc dữ liệu nhập, thoát...\n"
 
-#. This happens when the FileChangedRO autocommand changes the
-#. * file in a way it becomes shorter.
-#: ../undo.c:379
-msgid "E881: Line count changed unexpectedly"
-msgstr ""
+msgid "No undo possible; continue anyway"
+msgstr "Không thể hủy thao tác; tiếp tục thực hiện"
 
-#: ../undo.c:627
-#, fuzzy, c-format
-msgid "E828: Cannot open undo file for writing: %s"
-msgstr "E212: Không thể mở tập tin để ghi nhớ"
-
-#: ../undo.c:717
-#, c-format
-msgid "E825: Corrupted undo file (%s): %s"
-msgstr ""
-
-#: ../undo.c:1039
-msgid "Cannot write undo file in any directory in 'undodir'"
-msgstr ""
-
-#: ../undo.c:1074
-#, c-format
-msgid "Will not overwrite with undo file, cannot read: %s"
-msgstr ""
-
-#: ../undo.c:1092
-#, c-format
-msgid "Will not overwrite, this is not an undo file: %s"
-msgstr ""
-
-#: ../undo.c:1108
-msgid "Skipping undo file write, nothing to undo"
-msgstr ""
-
-#: ../undo.c:1121
-#, fuzzy, c-format
-msgid "Writing undo file: %s"
-msgstr "Ghi tập tin viminfo \"%s\""
-
-#: ../undo.c:1213
-#, fuzzy, c-format
-msgid "E829: write error in undo file: %s"
-msgstr "E297: Lỗi ghi nhớ tập tin trao đổi (swap)"
-
-#: ../undo.c:1280
-#, c-format
-msgid "Not reading undo file, owner differs: %s"
-msgstr ""
-
-#: ../undo.c:1292
-#, fuzzy, c-format
-msgid "Reading undo file: %s"
-msgstr "Đọc tập tin viminfo \"%s\"%s%s%s"
-
-#: ../undo.c:1299
-#, fuzzy, c-format
-msgid "E822: Cannot open undo file for reading: %s"
-msgstr "E195: Không thể mở tập tin viminfo để đọc"
-
-#: ../undo.c:1308
-#, fuzzy, c-format
-msgid "E823: Not an undo file: %s"
-msgstr "E484: Không mở được tập tin %s"
-
-#: ../undo.c:1313
-#, fuzzy, c-format
-msgid "E824: Incompatible undo file: %s"
-msgstr "E484: Không mở được tập tin %s"
-
-#: ../undo.c:1328
-msgid "File contents changed, cannot use undo info"
-msgstr ""
-
-#: ../undo.c:1497
-#, fuzzy, c-format
-msgid "Finished reading undo file %s"
-msgstr "thực hiện xong %s"
-
-#: ../undo.c:1586 ../undo.c:1812
-msgid "Already at oldest change"
-msgstr ""
-
-#: ../undo.c:1597 ../undo.c:1814
-msgid "Already at newest change"
-msgstr ""
-
-#: ../undo.c:1806
-#, fuzzy, c-format
-msgid "E830: Undo number %<PRId64> not found"
-msgstr "E92: Bộ đệm %<PRId64> không được tìm thấy"
-
-#: ../undo.c:1979
-msgid "E438: u_undo: line numbers wrong"
+# TODO: Capitalise first word of message?
+msgid "E438: u_undo: Line numbers wrong"
 msgstr "E438: u_undo: số thứ tự dòng không đúng"
 
-#: ../undo.c:2183
-#, fuzzy
-msgid "more line"
-msgstr "Thêm 1 dòng"
-
-#: ../undo.c:2185
-#, fuzzy
-msgid "more lines"
-msgstr "Thêm 1 dòng"
-
-#: ../undo.c:2187
-#, fuzzy
-msgid "line less"
-msgstr "Bớt 1 dòng"
-
-#: ../undo.c:2189
-#, fuzzy
-msgid "fewer lines"
-msgstr "Bớt %<PRId64> dòng"
-
-#: ../undo.c:2193
-#, fuzzy
-msgid "change"
+msgid "1 change"
 msgstr "duy nhất 1 thay đổi"
 
-#: ../undo.c:2195
-#, fuzzy
-msgid "changes"
-msgstr "duy nhất 1 thay đổi"
+#, c-format
+msgid "%ld changes"
+msgstr "%ld thay đổi"
 
-#: ../undo.c:2225
-#, fuzzy, c-format
-msgid "%<PRId64> %s; %s #%<PRId64>  %s"
-msgstr "Trên %<PRId64> dòng %s %d lần"
-
-#: ../undo.c:2228
-msgid "before"
-msgstr ""
-
-#: ../undo.c:2228
-msgid "after"
-msgstr ""
-
-#: ../undo.c:2325
-#, fuzzy
-msgid "Nothing to undo"
-msgstr "Không tìm thấy ánh xạ"
-
-#: ../undo.c:2330
-msgid "number changes  when               saved"
-msgstr ""
-
-#: ../undo.c:2360
-#, fuzzy, c-format
-msgid "%<PRId64> seconds ago"
-msgstr "%<PRId64> Cột; "
-
-#: ../undo.c:2372
-#, fuzzy
-msgid "E790: undojoin is not allowed after undo"
-msgstr "E407: %s không được cho phép ở đây"
-
-#: ../undo.c:2466
-msgid "E439: undo list corrupt"
+# TODO: Capitalise first word of message?
+msgid "E439: Undo list corrupt"
 msgstr "E439: danh sách hủy thao tác (undo) bị hỏng"
 
-#: ../undo.c:2495
-msgid "E440: undo line missing"
+# TODO: Capitalise first word of message?
+msgid "E440: Undo line missing"
 msgstr "E440: bị mất dòng hủy thao tác"
 
-#: ../version.c:600
+msgid ""
+"\n"
+"MS-Windows 16/32-bit GUI version"
+msgstr ""
+"\n"
+"Phiên bản với giao diện đồ họa GUI cho MS-Windows 16/32 bit"
+
+msgid ""
+"\n"
+"MS-Windows 32-bit GUI version"
+msgstr ""
+"\n"
+"Phiên bản với giao diện đồ họa GUI cho MS-Windows 32 bit"
+
+msgid " in Win32s mode"
+msgstr " trong chế độ Win32"
+
+msgid " with OLE support"
+msgstr " với hỗ trợ OLE"
+
+msgid ""
+"\n"
+"MS-Windows 32-bit console version"
+msgstr ""
+"\n"
+"Phiên bản console cho MS-Windows 32 bit"
+
+msgid ""
+"\n"
+"MS-Windows 16-bit version"
+msgstr ""
+"\n"
+"Phiên bản cho MS-Windows 16 bit"
+
+msgid ""
+"\n"
+"32-bit MS-DOS version"
+msgstr ""
+"\n"
+"Phiên bản cho MS-DOS 32 bit"
+
+msgid ""
+"\n"
+"16-bit MS-DOS version"
+msgstr ""
+"\n"
+"Phiên bản cho MS-DOS 16 bit"
+
+msgid ""
+"\n"
+"MacOS X (unix) version"
+msgstr ""
+"\n"
+"Phiên bản cho MacOS X (unix)"
+
+msgid ""
+"\n"
+"MacOS X version"
+msgstr ""
+"\n"
+"Phiên bản cho MacOS X"
+
+msgid ""
+"\n"
+"MacOS version"
+msgstr ""
+"\n"
+"Phiên bản cho MacOS"
+
+msgid ""
+"\n"
+"RISC OS version"
+msgstr ""
+"\n"
+"Phiên bản cho RISC OS"
+
 msgid ""
 "\n"
 "Included patches: "
@@ -6185,18 +4537,9 @@ msgstr ""
 "\n"
 "Bao gồm các bản vá lỗi: "
 
-#: ../version.c:627
-#, fuzzy
-msgid ""
-"\n"
-"Extra patches: "
-msgstr "Sự tương ứng con ngoài:\n"
-
-#: ../version.c:639 ../version.c:864
 msgid "Modified by "
 msgstr "Với các thay đổi bởi "
 
-#: ../version.c:646
 msgid ""
 "\n"
 "Compiled "
@@ -6204,11 +4547,9 @@ msgstr ""
 "\n"
 "Được biên dịch "
 
-#: ../version.c:649
 msgid "by "
 msgstr "bởi "
 
-#: ../version.c:660
 msgid ""
 "\n"
 "Huge version "
@@ -6216,1521 +4557,574 @@ msgstr ""
 "\n"
 "Phiên bản khổng lồ "
 
-#: ../version.c:661
+msgid ""
+"\n"
+"Big version "
+msgstr ""
+"\n"
+"Phiên bản lớn "
+
+msgid ""
+"\n"
+"Normal version "
+msgstr ""
+"\n"
+"Phiên bản thông thường "
+
+msgid ""
+"\n"
+"Small version "
+msgstr ""
+"\n"
+"Phiên bản nhỏ "
+
+msgid ""
+"\n"
+"Tiny version "
+msgstr ""
+"\n"
+"Phiên bản \"tí hon\" "
+
 msgid "without GUI."
 msgstr "không có giao diện đồ họa GUI."
 
-#: ../version.c:662
+msgid "with GTK2-GNOME GUI."
+msgstr "với giao diện đồ họa GUI GTK2-GNOME."
+
+msgid "with GTK-GNOME GUI."
+msgstr "với giao diện đồ họa GUI GTK-GNOME."
+
+msgid "with GTK2 GUI."
+msgstr "với giao diện đồ họa GUI GTK2."
+
+msgid "with GTK GUI."
+msgstr "với giao diện đồ họa GUI GTK."
+
+msgid "with X11-Motif GUI."
+msgstr "với giao diện đồ họa GUI X11-Motif."
+
+msgid "with X11-neXtaw GUI."
+msgstr "với giao diện đồ họa GUI X11-neXtaw."
+
+msgid "with X11-Athena GUI."
+msgstr "với giao diện đồ họa GUI X11-Athena."
+
+msgid "with BeOS GUI."
+msgstr "với giao diện đồ họa GUI BeOS."
+
+msgid "with Photon GUI."
+msgstr "với giao diện đồ họa GUI Photon."
+
+msgid "with GUI."
+msgstr "với giao diện đồ họa GUI."
+
+msgid "with Carbon GUI."
+msgstr "với giao diện đồ họa GUI Carbon."
+
+msgid "with Cocoa GUI."
+msgstr "với giao diện đồ họa GUI Cocoa."
+
+msgid "with (classic) GUI."
+msgstr "với giao diện đồ họa (cổ điển) GUI."
+
 msgid "  Features included (+) or not (-):\n"
 msgstr "  Tính năng có (+) hoặc không (-):\n"
 
-#: ../version.c:667
 msgid "   system vimrc file: \""
 msgstr "            tập tin vimrc chung cho hệ thống: \""
 
-#: ../version.c:672
 msgid "     user vimrc file: \""
 msgstr "         tập tin vimrc của người dùng: \""
 
-#: ../version.c:677
 msgid " 2nd user vimrc file: \""
 msgstr "  tập tin vimrc thứ hai của người dùng: \""
 
-#: ../version.c:682
 msgid " 3rd user vimrc file: \""
 msgstr "  tập tin vimrc thứ ba của người dùng: \""
 
-#: ../version.c:687
 msgid "      user exrc file: \""
 msgstr "         tập tin exrc của người dùng: \""
 
-#: ../version.c:692
 msgid "  2nd user exrc file: \""
 msgstr "  tập tin exrc thứ hai của người dùng: \""
 
-#: ../version.c:699
+msgid "  system gvimrc file: \""
+msgstr "            tập tin gvimrc chung cho hệ thống: \""
+
+msgid "    user gvimrc file: \""
+msgstr "         tập tin gvimrc của người dùng: \""
+
+msgid "2nd user gvimrc file: \""
+msgstr "  tập tin gvimrc thứ hai của người dùng: \""
+
+msgid "3rd user gvimrc file: \""
+msgstr "  tập tin gvimrc thứ ba của người dùng: \""
+
+msgid "    system menu file: \""
+msgstr "             tập tin trình đơn chung cho hệ thống: \""
+
 msgid "  fall-back for $VIM: \""
 msgstr "          giá trị $VIM theo mặc định: \""
 
-#: ../version.c:705
 msgid " f-b for $VIMRUNTIME: \""
 msgstr "   giá trị $VIMRUNTIME theo mặc định: \""
 
-#: ../version.c:709
 msgid "Compilation: "
 msgstr "Tham số biên dịch: "
 
-#: ../version.c:712
+msgid "Compiler: "
+msgstr "Trình biên dịch: "
+
 msgid "Linking: "
 msgstr "Liên kết: "
 
-#: ../version.c:717
 msgid "  DEBUG BUILD"
 msgstr "  BIÊN DỊCH SỬA LỖI (DEBUG)"
 
-#: ../version.c:767
 msgid "VIM - Vi IMproved"
 msgstr "VIM ::: Vi IMproved (Vi cải tiến) ::: Phiên bản tiếng Việt"
 
-#: ../version.c:769
 msgid "version "
 msgstr "phiên bản "
 
-#: ../version.c:770
 msgid "by Bram Moolenaar et al."
 msgstr "Do Bram Moolenaar và những người khác thực hiện"
 
-#: ../version.c:774
 msgid "Vim is open source and freely distributable"
 msgstr "Vim là chương trình mã nguồn mở và phân phối tự do"
 
-#: ../version.c:776
 msgid "Help poor children in Uganda!"
 msgstr "Hãy giúp đỡ trẻ em nghèo Uganda!"
 
-#: ../version.c:777
 msgid "type  :help iccf<Enter>       for information "
 msgstr "hãy gõ :help iccf<Enter>       để biết thêm thông tin"
 
-#: ../version.c:779
 msgid "type  :q<Enter>               to exit         "
 msgstr "    hãy gõ :q<Enter>               để thoát khỏi chương trình     "
 
-#: ../version.c:780
 msgid "type  :help<Enter>  or  <F1>  for on-line help"
 msgstr " hãy gõ :help<Enter> hoặc <F1>  để có được trợ giúp        "
 
-#: ../version.c:781
-msgid "type  :help version7<Enter>   for version info"
-msgstr "hãy gõ :help version7<Enter>   để biết về phiên bản này  "
+msgid "type  :help version9<Enter>   for version info"
+msgstr "hãy gõ :help version9<Enter>   để biết về phiên bản này  "
 
-#: ../version.c:784
 msgid "Running in Vi compatible mode"
 msgstr "Làm việc trong chế độ tương thích với Vi"
 
-#: ../version.c:785
 msgid "type  :set nocp<Enter>        for Vim defaults"
 msgstr "hãy gõ :set nocp<Enter>        để chuyển vào chế độ Vim     "
 
-#: ../version.c:786
 msgid "type  :help cp-default<Enter> for info on this"
 msgstr "hãy gõ :help cp-default<Enter> để có thêm thông tin về điều này"
 
-#: ../version.c:827
+msgid "menu  Help->Orphans           for information    "
+msgstr "trình đơn Trợ giúp->Mồ côi             để có thêm thông tin     "
+
+msgid "Running modeless, typed text is inserted"
+msgstr "Không chế độ, văn bản nhập vào sẽ được chèn"
+
+msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
+msgstr "trình đơn Soạn thảo->Thiết lập chung->Chế độ chèn                     "
+
+msgid "                              for two modes      "
+msgstr "                                 cho hai chế độ               "
+
+msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
+msgstr ""
+"trình đơn Soạn thảo->Thiết lập chung->Tương thích với Vi                "
+
+msgid "                              for Vim defaults   "
+msgstr ""
+"                                 để chuyển vào chế độ Vim mặc định       "
+
 msgid "Sponsor Vim development!"
 msgstr "Hãy giúp đỡ phát triển Vim!"
 
-#: ../version.c:828
 msgid "Become a registered Vim user!"
 msgstr "Hãy trở thành người dùng đăng ký của Vim!"
 
-#: ../version.c:831
 msgid "type  :help sponsor<Enter>    for information "
 msgstr "hãy gõ :help sponsor<Enter>    để biết thêm thông tin "
 
-#: ../version.c:832
 msgid "type  :help register<Enter>   for information "
 msgstr "hãy gõ :help register<Enter>   để biết thêm thông tin "
 
-#: ../version.c:834
 msgid "menu  Help->Sponsor/Register  for information    "
 msgstr "trình đơn Trợ giúp->Giúp đỡ/Đăng ký để biết thêm thông tin    "
 
-#: ../window.c:119
-msgid "Already only one window"
-msgstr "Chỉ có một cửa sổ"
+msgid "WARNING: Windows 95/98/ME detected"
+msgstr "CẢNH BÁO: nhận ra Windows 95/98/ME"
 
-#: ../window.c:224
+msgid "type  :help windows95<Enter>  for info on this"
+msgstr "hãy gõ :help windows95<Enter>  để biết thêm thông tin     "
+
 msgid "E441: There is no preview window"
 msgstr "E441: Không có cửa sổ xem trước"
 
-#: ../window.c:559
 msgid "E442: Can't split topleft and botright at the same time"
 msgstr ""
 "E442: Cửa sổ không thể đồng thời ở bên trái phía trên và bên phải phía dưới"
 
-#: ../window.c:1228
 msgid "E443: Cannot rotate when another window is split"
 msgstr "E443: Không đổi được chỗ khi cửa sổ khác được chia"
 
-#: ../window.c:1803
 msgid "E444: Cannot close last window"
 msgstr "E444: Không được đóng cửa sổ cuối cùng"
 
-#: ../window.c:1810
-#, fuzzy
-msgid "E813: Cannot close autocmd window"
-msgstr "E444: Không được đóng cửa sổ cuối cùng"
+msgid "Already only one window"
+msgstr "Chỉ có một cửa sổ"
 
-#: ../window.c:1814
-#, fuzzy
-msgid "E814: Cannot close window, only autocmd window would remain"
-msgstr "E444: Không được đóng cửa sổ cuối cùng"
-
-#: ../window.c:2717
 msgid "E445: Other window contains changes"
 msgstr "E445: Cửa sổ khác có thay đổi chưa được ghi nhớ"
 
-#: ../window.c:4805
 msgid "E446: No file name under cursor"
 msgstr "E446: Không có tên tập tin tại vị trí con trỏ"
 
-#~ msgid "[Error List]"
-#~ msgstr "[Danh sách lỗi]"
+#, c-format
+msgid "E447: Can't find file \"%s\" in path"
+msgstr "E447: Không tìm thấy tập tin \"%s\" trong đường dẫn"
 
-#~ msgid "[No File]"
-#~ msgstr "[Không có tập tin]"
+#, c-format
+msgid "E370: Could not load library %s"
+msgstr "E370: Không nạp được thư viện %s"
 
-#~ msgid "Patch file"
-#~ msgstr "Tập tin vá lỗi (patch)"
+msgid "Sorry, this command is disabled: the Perl library could not be loaded."
+msgstr "Xin lỗi, câu lệnh này bị tắt: không nạp được thư viện Perl."
 
-#~ msgid "E106: Unknown variable: \"%s\""
-#~ msgstr "E106: Biến không biết: \"%s\""
+msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
+msgstr ""
+"E299: Không cho phép sự tính toán Perl trong hộp cát mà không có môđun An "
+"toàn"
 
-#~ msgid ""
-#~ "&OK\n"
-#~ "&Cancel"
-#~ msgstr ""
-#~ "&OK\n"
-#~ "&Hủy bỏ"
+msgid "Edit with &multiple Vims"
+msgstr "Soạn thảo trong nhiều Vi&m"
 
-#~ msgid "E240: No connection to Vim server"
-#~ msgstr "E240: Không có kết nối với máy chủ Vim"
+msgid "Edit with single &Vim"
+msgstr "Soạn thảo trong một &Vim"
 
-#~ msgid "E277: Unable to read a server reply"
-#~ msgstr "E277: Máy chủ không trả lời"
+msgid "&Diff with Vim"
+msgstr "&So sánh (diff) qua Vim"
 
-#~ msgid "E241: Unable to send to %s"
-#~ msgstr "E241: Không thể gửi tin nhắn tới %s"
+msgid "Edit with &Vim"
+msgstr "Soạn thảo trong &Vim"
 
-#~ msgid "E130: Undefined function: %s"
-#~ msgstr "E130: Hàm số %s chưa xác định"
+msgid "Edit with existing Vim - &"
+msgstr "Soạn thảo trong Vim đã chạy - &"
 
-#~ msgid "Save As"
-#~ msgstr "Ghi nhớ như"
+msgid "Edits the selected file(s) with Vim"
+msgstr "Soạn thảo (các) tập tin đã chọn trong Vim"
 
-#~ msgid "Source Vim script"
-#~ msgstr "Thực hiện script của Vim"
+msgid "Error creating process: Check if gvim is in your path!"
+msgstr "Lỗi tạo tiến trình: Hãy kiểm tra xem gvim có trong đường dẫn không!"
 
-#~ msgid "Edit File"
-#~ msgstr "Soạn thảo tập tin"
+msgid "gvimext.dll error"
+msgstr "lỗi gvimext.dll"
 
-#~ msgid " (NOT FOUND)"
-#~ msgstr " (KHÔNG TÌM THẤY)"
+msgid "Path length too long!"
+msgstr "Đường dẫn quá dài!"
 
-#~ msgid "Edit File in new window"
-#~ msgstr "Soạn thảo tập tin trong cửa sổ mới"
+msgid "--No lines in buffer--"
+msgstr "-- Không có dòng nào trong bộ đệm --"
 
-#~ msgid "Append File"
-#~ msgstr "Thêm tập tin"
+msgid "E470: Command aborted"
+msgstr "E470: Câu lệnh bị dừng"
 
-#~ msgid "Window position: X %d, Y %d"
-#~ msgstr "Vị trí cửa sổ: X %d, Y %d"
+msgid "E471: Argument required"
+msgstr "E471: Cần chỉ ra tham số"
 
-#~ msgid "Save Redirection"
-#~ msgstr "Chuyển hướng ghi nhớ"
+msgid "E10: \\ should be followed by /, ? or &"
+msgstr "E10: Sau \\ phải là các ký tự /, ? hoặc &"
 
-#~ msgid "Save View"
-#~ msgstr "Ghi nhớ vẻ ngoài"
+msgid "E11: Invalid in command-line window; <CR> executes, CTRL-C quits"
+msgstr "E11: Lỗi trong cửa sổ dòng lệnh; <CR> thực hiện, CTRL-C thoát"
 
-#~ msgid "Save Session"
-#~ msgstr "Ghi nhớ buổi làm việc"
+msgid "E12: Command not allowed from exrc/vimrc in current dir or tag search"
+msgstr ""
+"E12: Câu lệnh không cho phép từ exrc/vimrc trong thư mục hiện thời hoặc "
+"trong tìm kiếm thẻ ghi"
 
-#~ msgid "Save Setup"
-#~ msgstr "Ghi nhớ cấu hình"
+msgid "E171: Missing :endif"
+msgstr "E171: Thiếu câu lệnh :endif"
 
-#~ msgid "E196: No digraphs in this version"
-#~ msgstr "E196: Trong phiên bản này chữ ghép không được hỗ trợ"
+msgid "E600: Missing :endtry"
+msgstr "E600: Thiếu câu lệnh :endtry"
 
-#~ msgid "[NL found]"
-#~ msgstr "[tìm thấy ký tự NL]"
+msgid "E170: Missing :endwhile"
+msgstr "E170: Thiếu câu lệnh :endwhile"
 
-#~ msgid "[crypted]"
-#~ msgstr "[đã mã hóa]"
+msgid "E588: :endwhile without :while"
+msgstr "E588: Câu lệnh :endwhile không có lệnh :while (1 cặp)"
 
-#~ msgid "[CONVERSION ERROR]"
-#~ msgstr "[LỖI CHUYỂN BẢNG MÃ]"
+msgid "E13: File exists (add ! to override)"
+msgstr "E13: Tập tin đã tồn tại (thêm ! để ghi chèn)"
 
-#~ msgid "NetBeans disallows writes of unmodified buffers"
-#~ msgstr "NetBeans không cho phép ghi nhớ bộ đệm chưa có thay đổi nào"
+msgid "E472: Command failed"
+msgstr "E472: Không thực hiện thành công câu lệnh"
 
-#~ msgid "Partial writes disallowed for NetBeans buffers"
-#~ msgstr "Ghi nhớ một phần bộ đệm NetBeans không được cho phép"
+#, c-format
+msgid "E234: Unknown fontset: %s"
+msgstr "E234: Không rõ bộ phông chữ: %s"
 
-#~ msgid "E460: The resource fork would be lost (add ! to override)"
-#~ msgstr ""
-#~ "E460: Nhánh tài nguyên sẽ bị mất (thêm ! để bỏ qua việc kiểm tra lại)"
+#, c-format
+msgid "E235: Unknown font: %s"
+msgstr "E235: Không rõ phông chữ: %s"
 
-#~ msgid "<cannot open> "
-#~ msgstr "<không thể mở> "
+#, c-format
+msgid "E236: Font \"%s\" is not fixed-width"
+msgstr "E236: Phông chữ \"%s\" không có độ rộng cố định (fixed-width)"
 
-#~ msgid "E616: vim_SelFile: can't get font %s"
-#~ msgstr "E616: vim_SelFile: không tìm thấy phông chữ %s"
+msgid "E473: Internal error"
+msgstr "E473: Lỗi nội bộ"
 
-#~ msgid "E614: vim_SelFile: can't return to current directory"
-#~ msgstr "E614: vim_SelFile: không trở lại được thư mục hiện thời"
+msgid "Interrupted"
+msgstr "Bị gián đoạn"
 
-#~ msgid "Pathname:"
-#~ msgstr "Đường dẫn tới tập tin:"
+msgid "E14: Invalid address"
+msgstr "E14: Địa chỉ không cho phép"
 
-#~ msgid "E615: vim_SelFile: can't get current directory"
-#~ msgstr "E615: vim_SelFile: không tìm thấy thư mục hiện thời"
+msgid "E474: Invalid argument"
+msgstr "E474: Tham số không cho phép"
 
-#~ msgid "OK"
-#~ msgstr "Đồng ý"
+#, c-format
+msgid "E475: Invalid argument: %s"
+msgstr "E475: Tham số không cho phép: %s"
 
-#~ msgid "Cancel"
-#~ msgstr "Hủy bỏ"
+#, c-format
+msgid "E15: Invalid expression: %s"
+msgstr "E15: Biểu thức không cho phép: %s"
 
-#~ msgid "Vim dialog"
-#~ msgstr "Hộp thoại Vim"
+msgid "E16: Invalid range"
+msgstr "E16: Vùng không cho phép"
 
-#~ msgid "Scrollbar Widget: Could not get geometry of thumb pixmap."
-#~ msgstr "Thanh cuộn: Không thể xác định hình học của thanh cuộn."
+msgid "E476: Invalid command"
+msgstr "E476: Câu lệnh không cho phép"
 
-#~ msgid "E232: Cannot create BalloonEval with both message and callback"
-#~ msgstr ""
-#~ "E232: Không tạo được BalloonEval với cả thông báo và lời gọi ngược lại"
+#, c-format
+msgid "E17: \"%s\" is a directory"
+msgstr "E17: \"%s\" là mộ thư mục"
 
-#~ msgid "E229: Cannot start the GUI"
-#~ msgstr "E229: Không chạy được giao diện đồ họa GUI"
+msgid "E18: Unexpected characters before '='"
+msgstr "E18: Ở trước '=' có các ký tự không mong đợi"
 
-#~ msgid "E230: Cannot read from \"%s\""
-#~ msgstr "E230: Không đọc được từ \"%s\""
+#, c-format
+msgid "E364: Library call failed for \"%s()\""
+msgstr "E364: Gọi hàm số \"%s()\" của thư viện không thành công"
 
-#~ msgid "E665: Cannot start GUI, no valid font found"
-#~ msgstr ""
-#~ "E665: Không chạy được giao diện đồ họa GUI, đưa ra phông chữ không đúng"
+#, c-format
+msgid "E448: Could not load library function %s"
+msgstr "E448: Nạp hàm số %s của thư viện không thành công"
 
-#~ msgid "E231: 'guifontwide' invalid"
-#~ msgstr "E231: 'guifontwide' có giá trị không đúng"
+msgid "E19: Mark has invalid line number"
+msgstr "E19: Dấu hiệu chỉ đến một số thứ tự dòng không đúng"
 
-#~ msgid "E599: Value of 'imactivatekey' is invalid"
-#~ msgstr "E599: Giá trị của 'imactivatekey' không đúng"
+msgid "E20: Mark not set"
+msgstr "E20: Dấu hiệu không được xác định"
 
-#~ msgid "E254: Cannot allocate color %s"
-#~ msgstr "E254: Không chỉ định được màu %s"
+msgid "E21: Cannot make changes, 'modifiable' is off"
+msgstr "E21: Không thể thay đổi, vì tùy chọn 'modifiable' bị tắt"
 
-#~ msgid "Vim dialog..."
-#~ msgstr "Hộp thoại Vim..."
+msgid "E22: Scripts nested too deep"
+msgstr "E22: Các script lồng vào nhau quá sâu"
 
-#~ msgid "Input _Methods"
-#~ msgstr "Phương pháp _nhập liệu"
+msgid "E23: No alternate file"
+msgstr "E23: Không có tập tin xen kẽ"
 
-#~ msgid "VIM - Search and Replace..."
-#~ msgstr "VIM - Tìm kiếm và thay thế..."
+msgid "E24: No such abbreviation"
+msgstr "E24: Không có chữ viết tắt như vậy"
 
-#~ msgid "VIM - Search..."
-#~ msgstr "VIM - Tìm kiếm..."
+msgid "E477: No ! allowed"
+msgstr "E477: Không cho phép !"
 
-#~ msgid "Find what:"
-#~ msgstr "Tìm kiếm gì:"
+msgid "E25: GUI cannot be used: Not enabled at compile time"
+msgstr "E25: Không sử dụng được giao diện đồ họa vì không chọn khi biên dịch"
 
-#~ msgid "Replace with:"
-#~ msgstr "Thay thế bởi:"
+msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
+msgstr "E26: Tiếng Do thái không được chọn khi biên dịch\n"
 
-#~ msgid "Match whole word only"
-#~ msgstr "Chỉ tìm tương ứng hoàn toàn với từ"
+msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
+msgstr "E27: Tiếng Farsi không được chọn khi biên dịch\n"
 
-#~ msgid "Match case"
-#~ msgstr "Có tính kiểu chữ"
+msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
+msgstr "E800: Tiếng Ả Rập không được chọn khi biên dịch\n"
 
-#~ msgid "Direction"
-#~ msgstr "Hướng"
+#, c-format
+msgid "E28: No such highlight group name: %s"
+msgstr "E28: Nhóm chiếu sáng cú pháp %s không tồn tại"
 
-#~ msgid "Up"
-#~ msgstr "Lên"
+msgid "E29: No inserted text yet"
+msgstr "E29: Tạm thời chưa có văn bản được chèn"
 
-#~ msgid "Down"
-#~ msgstr "Xuống"
+msgid "E30: No previous command line"
+msgstr "E30: Không có dòng lệnh trước"
 
-#~ msgid "Find Next"
-#~ msgstr "Tìm tiếp"
+msgid "E31: No such mapping"
+msgstr "E31: Không có ánh xạ (mapping) như vậy"
 
-#~ msgid "Replace"
-#~ msgstr "Thay thế"
+msgid "E479: No match"
+msgstr "E479: Không có tương ứng"
 
-#~ msgid "Replace All"
-#~ msgstr "Thay thế tất cả"
+#, c-format
+msgid "E480: No match: %s"
+msgstr "E480: Không có tương ứng: %s"
 
-#~ msgid "Vim: Received \"die\" request from session manager\n"
-#~ msgstr "Vim: Nhận được yêu cầu \"chết\" (dừng) từ trình quản lý màn hình\n"
+msgid "E32: No file name"
+msgstr "E32: Không có tên tập tin"
 
-#~ msgid "Vim: Main window unexpectedly destroyed\n"
-#~ msgstr "Vim: Cửa sổ chính đã bị đóng đột ngột\n"
+msgid "E33: No previous substitute regular expression"
+msgstr "E33: Không có biểu thức chính quy trước để thay thế"
 
-#~ msgid "Font Selection"
-#~ msgstr "Chọn phông chữ"
+msgid "E34: No previous command"
+msgstr "E34: Không có câu lệnh trước"
 
-#~ msgid "Used CUT_BUFFER0 instead of empty selection"
-#~ msgstr "Sử dụng CUT_BUFFER0 thay cho lựa chọn trống rỗng"
+msgid "E35: No previous regular expression"
+msgstr "E35: Không có biểu thức chính quy trước"
 
-#~ msgid "Filter"
-#~ msgstr "Đầu lọc"
+msgid "E481: No range allowed"
+msgstr "E481: Không cho phép sử dụng phạm vi"
 
-#~ msgid "Directories"
-#~ msgstr "Thư mục"
+msgid "E36: Not enough room"
+msgstr "E36: Không đủ chỗ trống"
 
-#~ msgid "Help"
-#~ msgstr "Trợ giúp"
+# TODO: Capitalise first word of message?
+msgid "E247: No registered server named \"%s\""
+msgstr "E247: máy chủ \"%s\" chưa đăng ký"
 
-#~ msgid "Files"
-#~ msgstr "Tập tin"
+#, c-format
+msgid "E482: Can't create file %s"
+msgstr "E482: Không tạo được tập tin %s"
 
-#~ msgid "Selection"
-#~ msgstr "Lựa chọn"
+msgid "E483: Can't get temp file name"
+msgstr "E483: Không nhận được tên tập tin tạm thời (temp)"
 
-#~ msgid "Undo"
-#~ msgstr "Hủy thao tác"
+#, c-format
+msgid "E484: Can't open file %s"
+msgstr "E484: Không mở được tập tin %s"
 
-#~ msgid "E671: Cannot find window title \"%s\""
-#~ msgstr "E671: Không tìm được tiêu đề cửa sổ \"%s\""
+#, c-format
+msgid "E485: Can't read file %s"
+msgstr "E485: Không đọc được tập tin %s"
 
-#~ msgid "E243: Argument not supported: \"-%s\"; Use the OLE version."
-#~ msgstr ""
-#~ "E243: Tham số không được hỗ trợ: \"-%s\"; Hãy sử dụng phiên bản OLE."
+msgid "E37: No write since last change (add ! to override)"
+msgstr "E37: Thay đổi chưa được ghi nhớ (thêm ! để bỏ qua ghi nhớ)"
 
-#~ msgid "E672: Unable to open window inside MDI application"
-#~ msgstr "E672: Không mở được cửa sổ bên trong ứng dụng MDI"
+msgid "E38: Null argument"
+msgstr "E38: Tham sô bằng 0"
 
-#~ msgid "Find string (use '\\\\' to find  a '\\')"
-#~ msgstr "Tìm kiếm chuỗi (hãy sử dụng '\\\\' để tìm kiếm dấu '\\')"
+msgid "E39: Number expected"
+msgstr "E39: Yêu cầu một số"
 
-#~ msgid "Find & Replace (use '\\\\' to find  a '\\')"
-#~ msgstr "Tìm kiếm và Thay thế (hãy sử dụng '\\\\' để tìm kiếm dấu '\\')"
+#, c-format
+msgid "E40: Can't open errorfile %s"
+msgstr "E40: Không mở được tập tin lỗi %s"
 
-#~ msgid ""
-#~ "Vim E458: Cannot allocate colormap entry, some colors may be incorrect"
-#~ msgstr ""
-#~ "Vim E458: Không chỉ định được bản ghi trong bảng màu, một vài màu có thể "
-#~ "hiển thị không chính xác"
+# TODO: Capitalise first word of message?
+msgid "E233: Cannot open display"
+msgstr "E233: không mở được màn hình"
 
-#~ msgid "E250: Fonts for the following charsets are missing in fontset %s:"
-#~ msgstr "E250: Trong bộ phông chữ %s thiếu phông cho các bảng mã sau:"
+msgid "E41: Out of memory!"
+msgstr "E41: Không đủ bộ nhớ!"
 
-#~ msgid "E252: Fontset name: %s"
-#~ msgstr "E252: Bộ phông chữ: %s"
+msgid "Pattern not found"
+msgstr "Không tìm thấy mẫu (pattern)"
 
-#~ msgid "Font '%s' is not fixed-width"
-#~ msgstr "Phông chữ '%s' không phải là phông có độ rộng cố định (fixed-width)"
+#, c-format
+msgid "E486: Pattern not found: %s"
+msgstr "E486: Không tìm thấy mẫu (pattern): %s"
 
-#~ msgid "E253: Fontset name: %s\n"
-#~ msgstr "E253: Bộ phông chữ: %s\n"
+msgid "E487: Argument must be positive"
+msgstr "E487: Tham số phải là một số dương"
 
-#~ msgid "Font0: %s\n"
-#~ msgstr "Font0: %s\n"
+msgid "E459: Cannot go back to previous directory"
+msgstr "E459: Không quay lại được thư mục trước đó"
 
-#~ msgid "Font1: %s\n"
-#~ msgstr "Font1: %s\n"
+msgid "E42: No Errors"
+msgstr "E42: Không có lỗi"
 
-#~ msgid "Font%<PRId64> width is not twice that of font0\n"
-#~ msgstr ""
-#~ "Chiều rộng phông chữ font%<PRId64> phải lớn hơn hai lần so với chiều rộng "
-#~ "font0\n"
+msgid "E43: Damaged match string"
+msgstr "E43: Chuỗi tương ứng bị hỏng"
 
-#~ msgid "Font0 width: %<PRId64>\n"
-#~ msgstr "Chiều rộng font0: %<PRId64>\n"
+msgid "E44: Corrupted regexp program"
+msgstr "E44: Chương trình xử lý biểu thức chính quy bị hỏng"
 
-#~ msgid ""
-#~ "Font1 width: %<PRId64>\n"
-#~ "\n"
-#~ msgstr ""
-#~ "Chiều rộng font1: %<PRId64>\n"
-#~ "\n"
+msgid "E45: 'readonly' option is set (add ! to override)"
+msgstr "E45: Tùy chọn 'readonly' được bật (Hãy thêm ! để lờ đi)"
 
-#~ msgid "E256: Hangul automata ERROR"
-#~ msgstr "E256: LỖI máy tự động Hangual (tiếng Hàn)"
+#, c-format
+msgid "E46: Cannot set read-only variable \"%s\""
+msgstr "E46: Không thay đổi được biến chỉ đọc \"%s\""
 
-#~ msgid "E563: stat error"
-#~ msgstr "E563: lỗi stat"
+msgid "E47: Error while reading errorfile"
+msgstr "E47: Lỗi khi đọc tập tin lỗi"
 
-#~ msgid "E625: cannot open cscope database: %s"
-#~ msgstr "E625: không mở được cơ sở dữ liệu cscope: %s"
+msgid "E48: Not allowed in sandbox"
+msgstr "E48: Không cho phép trong hộp cát (sandbox)"
 
-#~ msgid "E626: cannot get cscope database information"
-#~ msgstr "E626: không lấy được thông tin về cơ sở dữ liệu cscope"
+msgid "E523: Not allowed here"
+msgstr "E523: Không cho phép ở đây"
 
-#~ msgid "E569: maximum number of cscope connections reached"
-#~ msgstr "E569: đã đạt tới số kết nối lớn nhất cho phép với cscope"
+msgid "E359: Screen mode setting not supported"
+msgstr "E359: Chế độ màn hình không được hỗ trợ"
 
-#~ msgid ""
-#~ "E263: Sorry, this command is disabled, the Python library could not be "
-#~ "loaded."
-#~ msgstr ""
-#~ "E263: Rất tiếc câu lệnh này không làm việc, vì thư viện Python chưa được "
-#~ "nạp."
+msgid "E49: Invalid scroll size"
+msgstr "E49: Kích thước thanh cuộn không cho phép"
 
-#~ msgid "E659: Cannot invoke Python recursively"
-#~ msgstr "E659: Không thể gọi Python một cách đệ quy"
+msgid "E91: 'shell' option is empty"
+msgstr "E91: Tùy chọn 'shell' là một chuỗi rỗng"
 
-#~ msgid "can't delete OutputObject attributes"
-#~ msgstr "Không xóa được thuộc tính OutputObject"
+msgid "E255: Couldn't read in sign data!"
+msgstr "E255: Không đọc được dữ liệu về ký tự!"
 
-#~ msgid "softspace must be an integer"
-#~ msgstr "giá trị softspace phải là một số nguyên"
+msgid "E72: Close error on swap file"
+msgstr "E72: Lỗi đóng tập tin trao đổi (swap)"
 
-#~ msgid "invalid attribute"
-#~ msgstr "thuộc tính không đúng"
+# TODO: Capitalise first word of message?
+msgid "E73: Tag stack empty"
+msgstr "E73: đống thẻ ghi rỗng"
 
-#~ msgid "writelines() requires list of strings"
-#~ msgstr "writelines() yêu cầu một danh sách các chuỗi"
+msgid "E74: Command too complex"
+msgstr "E74: Câu lệnh quá phức tạp"
 
-#~ msgid "E264: Python: Error initialising I/O objects"
-#~ msgstr "E264: Python: Lỗi khi bắt đầu sử dụng vật thể I/O"
+msgid "E75: Name too long"
+msgstr "E75: Tên quá dài"
 
-#~ msgid "invalid expression"
-#~ msgstr "biểu thức không đúng"
+msgid "E76: Too many ["
+msgstr "E76: Quá nhiều ký tự ["
 
-#~ msgid "expressions disabled at compile time"
-#~ msgstr "biểu thức bị tắt khi biên dịch"
+msgid "E77: Too many file names"
+msgstr "E77: Quá nhiều tên tập tin"
 
-#~ msgid "attempt to refer to deleted buffer"
-#~ msgstr "cố chỉ đến bộ đệm đã bị xóa"
+msgid "E488: Trailing characters"
+msgstr "E488: Ký tự thừa ở đuôi"
 
-#~ msgid "line number out of range"
-#~ msgstr "số thứ tự của dòng vượt quá giới hạn"
+msgid "E78: Unknown mark"
+msgstr "E78: Dấu hiệu không biết"
 
-#~ msgid "<buffer object (deleted) at %8lX>"
-#~ msgstr "<vật thể của bộ đệm (bị xóa) tại %8lX>"
+msgid "E79: Cannot expand wildcards"
+msgstr "E79: Không thực hiện được phép thế theo wildcard"
 
-#~ msgid "invalid mark name"
-#~ msgstr "tên dấu hiệu không đúng"
+msgid "E591: 'winheight' cannot be smaller than 'winminheight'"
+msgstr "E591: giá trị của 'winheight' không thể nhỏ hơn 'winminheight'"
 
-#~ msgid "no such buffer"
-#~ msgstr "không có bộ đệm như vậy"
+msgid "E592: 'winwidth' cannot be smaller than 'winminwidth'"
+msgstr "E592: giá trị của 'winwidth' không thể nhỏ hơn 'winminwidth'"
 
-#~ msgid "attempt to refer to deleted window"
-#~ msgstr "cố chỉ đến cửa sổ đã bị đóng"
+msgid "E80: Error while writing"
+msgstr "E80: Lỗi khi ghi nhớ"
 
-#~ msgid "readonly attribute"
-#~ msgstr "thuộc tính chỉ đọc"
+msgid "Zero count"
+msgstr "Giá trị của bộ đếm bằng 0"
 
-#~ msgid "cursor position outside buffer"
-#~ msgstr "vị trí con trỏ nằm ngoài bộ đệm"
+msgid "E81: Using <SID> not in a script context"
+msgstr "E81: Sử dụng <SID> ngoài phạm vi script"
 
-#~ msgid "<window object (deleted) at %.8lX>"
-#~ msgstr "<vật thể của cửa sổ (bị xóa) tại %.8lX>"
+msgid "E449: Invalid expression received"
+msgstr "E449: Nhận được một biểu thức không cho phép"
 
-#~ msgid "<window object (unknown) at %.8lX>"
-#~ msgstr "<vật thể của cửa sổ (không rõ) tại %.8lX>"
+msgid "E463: Region is guarded, cannot modify"
+msgstr "E463: Không thể thay đổi vùng đã được bảo vệ"
 
-#~ msgid "<window %d>"
-#~ msgstr "<cửa sổ %d>"
+msgid "No tutorial with that name found"
+msgstr "Không tìm thấy hướng dẫn (tutorial) có tên đó"
 
-#~ msgid "no such window"
-#~ msgstr "không có cửa sổ như vậy"
-
-#~ msgid "cannot save undo information"
-#~ msgstr "không ghi được thông tin về việc hủy thao tác"
-
-#~ msgid "cannot delete line"
-#~ msgstr "không xóa được dòng"
-
-#~ msgid "cannot replace line"
-#~ msgstr "không thay thế được dòng"
-
-#~ msgid "cannot insert line"
-#~ msgstr "không chèn được dòng"
-
-#~ msgid "string cannot contain newlines"
-#~ msgstr "chuỗi không thể chứa ký tự dòng mới"
-
-#~ msgid ""
-#~ "E266: Sorry, this command is disabled, the Ruby library could not be "
-#~ "loaded."
-#~ msgstr ""
-#~ "E266: Rất tiếc câu lệnh này không làm việc, vì thư viện Ruby chưa đượcnạp."
-
-#~ msgid "E273: unknown longjmp status %d"
-#~ msgstr "E273: không rõ trạng thái của longjmp %d"
-
-#~ msgid "Toggle implementation/definition"
-#~ msgstr "Bật tắt giữa thi hành/định nghĩa"
-
-#~ msgid "Show base class of"
-#~ msgstr "Hiển thị hạng cơ bản của"
-
-#~ msgid "Show overridden member function"
-#~ msgstr "Hiển thị hàm số bị nạp đè lên"
-
-#~ msgid "Retrieve from file"
-#~ msgstr "Nhận từ tập tin"
-
-#~ msgid "Retrieve from project"
-#~ msgstr "Nhận từ dự án"
-
-#~ msgid "Retrieve from all projects"
-#~ msgstr "Nhận từ tất cả các dự án"
-
-#~ msgid "Retrieve"
-#~ msgstr "Nhận"
-
-#~ msgid "Show source of"
-#~ msgstr "Hiển thị mã nguồn"
-
-#~ msgid "Find symbol"
-#~ msgstr "Tìm ký hiệu"
-
-#~ msgid "Browse class"
-#~ msgstr "Duyệt hạng"
-
-#~ msgid "Show class in hierarchy"
-#~ msgstr "Hiển thị hạng trong hệ thống cấp bậc"
-
-#~ msgid "Show class in restricted hierarchy"
-#~ msgstr "Hiển thị hạng trong hệ thống cấp bậc giới hạn"
-
-#~ msgid "Xref refers to"
-#~ msgstr "Xref chỉ đến"
-
-#~ msgid "Xref referred by"
-#~ msgstr "Liên kết đến xref từ"
-
-#~ msgid "Xref has a"
-#~ msgstr "Xref có một"
-
-#~ msgid "Xref used by"
-#~ msgstr "Xref được sử dụng bởi"
-
-#~ msgid "Show docu of"
-#~ msgstr "Hiển thị docu của"
-
-#~ msgid "Generate docu for"
-#~ msgstr "Tạo docu cho"
-
-#~ msgid ""
-#~ "Cannot connect to SNiFF+. Check environment (sniffemacs must be found in "
-#~ "$PATH).\n"
-#~ msgstr ""
-#~ "Không kết nối được tới SNiFF+. Hãy kiểm tra cấu hình môi trường."
-#~ "(sniffemacs phải được chỉ ra trong biến $PATH).\n"
-
-#~ msgid "E274: Sniff: Error during read. Disconnected"
-#~ msgstr "E274: Sniff: Lỗi trong thời gian đọc. Ngắt kết nối"
-
-#~ msgid "SNiFF+ is currently "
-#~ msgstr "Trong thời điểm hiện nay SNiFF+ "
-
-#~ msgid "not "
-#~ msgstr "không "
-
-#~ msgid "connected"
-#~ msgstr "được kết nối"
-
-#~ msgid "E275: Unknown SNiFF+ request: %s"
-#~ msgstr "E275: không rõ yêu cầu của SNiFF+: %s"
-
-#~ msgid "E276: Error connecting to SNiFF+"
-#~ msgstr "E276: Lỗi kết nối với SNiFF+"
-
-#~ msgid "E278: SNiFF+ not connected"
-#~ msgstr "E278: SNiFF+ chưa được kết nối"
-
-#~ msgid "Sniff: Error during write. Disconnected"
-#~ msgstr "Sniff: Lỗi trong thời gian ghi nhớ. Ngắt kết nối"
-
-#~ msgid "not implemented yet"
-#~ msgstr "tạm thời chưa được thực thi"
-
-#~ msgid "unknown option"
-#~ msgstr "tùy chọn không rõ"
-
-#~ msgid "cannot set line(s)"
-#~ msgstr "không thể đặt (các) dòng"
-
-#~ msgid "mark not set"
-#~ msgstr "dấu hiệu chưa được đặt"
-
-#~ msgid "row %d column %d"
-#~ msgstr "hàng %d cột %d"
-
-#~ msgid "cannot insert/append line"
-#~ msgstr "không thể chèn hoặc thêm dòng"
-
-#~ msgid "unknown flag: "
-#~ msgstr "cờ không biết: "
-
-#~ msgid "unknown vimOption"
-#~ msgstr "không rõ tùy chọn vimOption"
-
-#~ msgid "keyboard interrupt"
-#~ msgstr "sự gián đoạn của bàn phím"
-
-#~ msgid "vim error"
-#~ msgstr "lỗi của vim"
-
-#~ msgid "cannot create buffer/window command: object is being deleted"
-#~ msgstr ""
-#~ "không tạo được câu lệnh của bộ đệm hay của cửa sổ: vật thể đang bị xóa"
-
-#~ msgid ""
-#~ "cannot register callback command: buffer/window is already being deleted"
-#~ msgstr ""
-#~ "không đăng ký được câu lệnh gọi ngược: bộ đệm hoặc cửa sổ đang bị xóa"
-
-#~ msgid ""
-#~ "E280: TCL FATAL ERROR: reflist corrupt!? Please report this to vim-"
-#~ "dev@vim.org"
-#~ msgstr ""
-#~ "E280: LỖI NẶNG CỦA TCL: bị hỏng danh sách liên kết!? Hãy thông báo việc "
-#~ "nàyđến danh sách thư (mailing list) vim-dev@vim.org"
-
-#~ msgid "cannot register callback command: buffer/window reference not found"
-#~ msgstr ""
-#~ "không đăng ký được câu lệnh gọi ngược: không tìm thấy liên kết đến bộ đệm "
-#~ "hoặc cửa sổ"
-
-#~ msgid ""
-#~ "E571: Sorry, this command is disabled: the Tcl library could not be "
-#~ "loaded."
-#~ msgstr ""
-#~ "E571: Rất tiếc là câu lệnh này không làm việc, vì thư viện Tcl chưa được "
-#~ "nạp"
-
-#~ msgid ""
-#~ "E281: TCL ERROR: exit code is not int!? Please report this to vim-dev@vim."
-#~ "org"
-#~ msgstr ""
-#~ "E281: LỖI TCL: mã thoát ra không phải là một số nguyên!? Hãy thông báo "
-#~ "điều này đến danh sách thư (mailing list) vim-dev@vim.org"
-
-#~ msgid "cannot get line"
-#~ msgstr "không nhận được dòng"
-
-#~ msgid "Unable to register a command server name"
-#~ msgstr "Không đăng ký được một tên cho máy chủ câu lệnh"
-
-#~ msgid "E248: Failed to send command to the destination program"
-#~ msgstr "E248: Gửi câu lệnh vào chương trình khác không thành công"
-
-#~ msgid "E251: VIM instance registry property is badly formed.  Deleted!"
-#~ msgstr "E251: Thuộc tính đăng ký của Vim được định dạng không đúng.  Xóa!"
-
-#~ msgid "This Vim was not compiled with the diff feature."
-#~ msgstr "Vim không được biên dịch với tính năng hỗ trợ xem khác biệt (diff)."
-
-#~ msgid "-register\t\tRegister this gvim for OLE"
-#~ msgstr "-register\t\tĐăng ký gvim này cho OLE"
-
-#~ msgid "-unregister\t\tUnregister gvim for OLE"
-#~ msgstr "-unregister\t\tBỏ đăng ký gvim này cho OLE"
-
-#~ msgid "-g\t\t\tRun using GUI (like \"gvim\")"
-#~ msgstr "-g\t\t\tSử dụng giao diện đồ họa GUI (giống \"gvim\")"
-
-#~ msgid "-f  or  --nofork\tForeground: Don't fork when starting GUI"
-#~ msgstr ""
-#~ "-f  hoặc  --nofork\tTrong chương trình hoạt động: Không thực hiện fork "
-#~ "khi chạy GUI"
-
-#~ msgid "-V[N]\t\tVerbose level"
-#~ msgstr "-V[N]\t\tMức độ chi tiết của thông báo"
-
-#~ msgid "-f\t\t\tDon't use newcli to open window"
-#~ msgstr "-f\t\t\tKhông sử dụng newcli để mở cửa sổ"
-
-#~ msgid "-dev <device>\t\tUse <device> for I/O"
-#~ msgstr "-dev <thiết bị>\t\tSử dụng <thiết bị> cho I/O"
-
-#~ msgid "-U <gvimrc>\t\tUse <gvimrc> instead of any .gvimrc"
-#~ msgstr "-U <gvimrc>\t\tSử dụng <gvimrc> thay thế cho mọi .gvimrc"
-
-#~ msgid "-x\t\t\tEdit encrypted files"
-#~ msgstr "-x\t\t\tSoạn thảo tập tin đã mã hóa"
-
-#~ msgid "-display <display>\tConnect vim to this particular X-server"
-#~ msgstr "-display <màn hình>\tKết nối vim tới máy chủ X đã chỉ ra"
-
-#~ msgid "-X\t\t\tDo not connect to X server"
-#~ msgstr "-X\t\t\tKhông thực hiện việc kết nối tới máy chủ X"
-
-#~ msgid "--remote <files>\tEdit <files> in a Vim server if possible"
-#~ msgstr "--remote <tập tin>\tSoạn thảo <tập tin> trên máy chủ Vim nếu có thể"
-
-#~ msgid "--remote-silent <files>  Same, don't complain if there is no server"
-#~ msgstr ""
-#~ "--remote-silent <tập tin>  Cũng vậy, nhưng không kêu ca dù không có máy "
-#~ "chủ"
-
-#~ msgid ""
-#~ "--remote-wait <files>  As --remote but wait for files to have been edited"
-#~ msgstr "--remote-wait <tập tin>  Cũng như --remote, nhưng chờ sự kết thúc"
-
-#~ msgid ""
-#~ "--remote-wait-silent <files>  Same, don't complain if there is no server"
-#~ msgstr ""
-#~ "--remote-wait-silent <tập tin>  Cũng vậy, nhưng không kêu ca dù không có "
-#~ "máy chủ"
-
-#~ msgid "--remote-send <keys>\tSend <keys> to a Vim server and exit"
-#~ msgstr "--remote-send <phím>\tGửi <phím> lên máy chủ Vim và thoát"
-
-#~ msgid ""
-#~ "--remote-expr <expr>\tEvaluate <expr> in a Vim server and print result"
-#~ msgstr ""
-#~ "--remote-expr <biểu thức>\tTính <biểu thức> trên máy chủ Vim và in ra kết "
-#~ "quả"
-
-#~ msgid "--serverlist\t\tList available Vim server names and exit"
-#~ msgstr "--serverlist\t\tHiển thị danh sách máy chủ Vim và thoát"
-
-#~ msgid "--servername <name>\tSend to/become the Vim server <name>"
-#~ msgstr "--servername <tên>\tGửi lên (hoặc trở thành) máy chủ Vim với <tên>"
-
-#~ msgid ""
-#~ "\n"
-#~ "Arguments recognised by gvim (Motif version):\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Tham số cho gvim (phiên bản Motif):\n"
-
-#~ msgid ""
-#~ "\n"
-#~ "Arguments recognised by gvim (neXtaw version):\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Tham số cho gvim (phiên bản neXtaw):\n"
-
-#~ msgid ""
-#~ "\n"
-#~ "Arguments recognised by gvim (Athena version):\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Tham số cho gvim (phiên bản Athena):\n"
-
-#~ msgid "-display <display>\tRun vim on <display>"
-#~ msgstr "-display <màn hình>\tChạy vim trong <màn hình> đã chỉ ra"
-
-#~ msgid "-iconic\t\tStart vim iconified"
-#~ msgstr "-iconic\t\tChạy vim ở dạng thu nhỏ"
-
-#~ msgid "-name <name>\t\tUse resource as if vim was <name>"
-#~ msgstr "-name <tên>\t\tSử dụng tài nguyên giống như khi vim có <tên>"
-
-#~ msgid "\t\t\t  (Unimplemented)\n"
-#~ msgstr "\t\t\t  (Chưa được thực thi)\n"
-
-#~ msgid "-background <color>\tUse <color> for the background (also: -bg)"
-#~ msgstr "-background <màu>\tSử dụng <màu> chỉ ra cho nền (cũng như: -bg)"
-
-#~ msgid "-foreground <color>\tUse <color> for normal text (also: -fg)"
-#~ msgstr ""
-#~ "-foreground <màu>\tSử dụng <màu> cho văn bản thông thường (cũng như: -fg)"
-
-#~ msgid "-font <font>\t\tUse <font> for normal text (also: -fn)"
-#~ msgstr ""
-#~ "-font <phông>\t\tSử dụng <phông> chữ cho văn bản thông thường (cũng như: -"
-#~ "fn)"
-
-#~ msgid "-boldfont <font>\tUse <font> for bold text"
-#~ msgstr "-boldfont <phông>\tSử dụng <phông> chữ cho văn bản in đậm"
-
-#~ msgid "-italicfont <font>\tUse <font> for italic text"
-#~ msgstr "-italicfont <phông>\tSử dụng <phông> chữ cho văn bản in nghiêng"
-
-#~ msgid "-geometry <geom>\tUse <geom> for initial geometry (also: -geom)"
-#~ msgstr ""
-#~ "-geometry <kích thước>\tSử dụng <kích thước> ban đầu (cũng như: -geom)"
-
-#~ msgid "-borderwidth <width>\tUse a border width of <width> (also: -bw)"
-#~ msgstr ""
-#~ "-borderwidth <rộng>\tSử dụng đường viền có chiều <rộng> (cũng như: -bw)"
-
-#~ msgid ""
-#~ "-scrollbarwidth <width>  Use a scrollbar width of <width> (also: -sw)"
-#~ msgstr ""
-#~ "-scrollbarwidth <rộng> Sử dụng thanh cuộn với chiều <rộng> (cũng như: -sw)"
-
-#~ msgid "-menuheight <height>\tUse a menu bar height of <height> (also: -mh)"
-#~ msgstr ""
-#~ "-menuheight <cao>\tSử dụng thanh trình đơn với chiều <cao> (cũng như: -mh)"
-
-#~ msgid "-reverse\t\tUse reverse video (also: -rv)"
-#~ msgstr "-reverse\t\tSử dụng chế độ video đảo ngược (cũng như: -rv)"
-
-#~ msgid "+reverse\t\tDon't use reverse video (also: +rv)"
-#~ msgstr "+reverse\t\tKhông sử dụng chế độ video đảo ngược (cũng như: +rv)"
-
-#~ msgid "-xrm <resource>\tSet the specified resource"
-#~ msgstr "-xrm <tài nguyên>\tĐặt <tài nguyên> chỉ ra"
-
-#~ msgid ""
-#~ "\n"
-#~ "Arguments recognised by gvim (RISC OS version):\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Tham số cho gvim (phiên bản RISC OS):\n"
-
-#~ msgid "--columns <number>\tInitial width of window in columns"
-#~ msgstr "--columns <số>\tChiều rộng ban đầu của cửa sổ tính theo số cột"
-
-#~ msgid "--rows <number>\tInitial height of window in rows"
-#~ msgstr "--rows <số>\tChiều cao ban đầu của cửa sổ tính theo số dòng"
-
-#~ msgid ""
-#~ "\n"
-#~ "Arguments recognised by gvim (GTK+ version):\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Tham số cho gvim (phiên bản GTK+):\n"
-
-#~ msgid "-display <display>\tRun vim on <display> (also: --display)"
-#~ msgstr ""
-#~ "-display <màn hình>\tChạy vim trên <màn hình> chỉ ra (cũng như: --display)"
-
-#~ msgid "--role <role>\tSet a unique role to identify the main window"
-#~ msgstr "--role <vai trò>\tĐặt <vai trò> duy nhất để nhận diện cửa sổ chính"
-
-#~ msgid "--socketid <xid>\tOpen Vim inside another GTK widget"
-#~ msgstr "--socketid <xid>\tMở Vim bên trong thành phần GTK khác"
-
-#~ msgid "-P <parent title>\tOpen Vim inside parent application"
-#~ msgstr "-P <tiêu đề của mẹ>\tMở Vim bên trong ứng dụng mẹ"
-
-#~ msgid "No display"
-#~ msgstr "Không có màn hình"
-
-#~ msgid ": Send failed.\n"
-#~ msgstr ": Gửi không thành công.\n"
-
-#~ msgid ": Send failed. Trying to execute locally\n"
-#~ msgstr ": Gửi không thành công. Thử thực hiện nội bộ\n"
-
-#~ msgid "%d of %d edited"
-#~ msgstr "đã soạn thảo %d từ %d"
-
-#~ msgid "No display: Send expression failed.\n"
-#~ msgstr "Không có màn hình: gửi biểu thức không thành công.\n"
-
-#~ msgid ": Send expression failed.\n"
-#~ msgstr ": Gửi biểu thức không thành công.\n"
-
-#~ msgid "E543: Not a valid codepage"
-#~ msgstr "E543: Bảng mã không cho phép"
-
-#~ msgid "E285: Failed to create input context"
-#~ msgstr "E285: Không tạo được nội dung nhập vào"
-
-#~ msgid "E286: Failed to open input method"
-#~ msgstr "E286: Việc thử mở phương pháp nhập không thành công"
-
-#~ msgid "E287: Warning: Could not set destroy callback to IM"
-#~ msgstr ""
-#~ "E287: Cảnh báo: không đặt được sự gọi ngược hủy diệt thành phương pháp "
-#~ "nhập"
-
-#~ msgid "E288: input method doesn't support any style"
-#~ msgstr "E288: phương pháp nhập không hỗ trợ bất kỳ phong cách (style) nào"
-
-#~ msgid "E289: input method doesn't support my preedit type"
-#~ msgstr "E289: phương pháp nhập không hỗ trợ loại soạn thảo trước của Vim"
-
-#~ msgid "E290: over-the-spot style requires fontset"
-#~ msgstr "E290: phong cách over-the-spot yêu cầu một bộ phông chữ"
-
-#~ msgid "E291: Your GTK+ is older than 1.2.3. Status area disabled"
-#~ msgstr "E291: GTK+ cũ hơn 1.2.3. Vùng chỉ trạng thái không làm việc"
-
-#~ msgid "E292: Input Method Server is not running"
-#~ msgstr "E292: Máy chủ phương pháp nhập liệu chưa được chạy"
-
-#~ msgid ""
-#~ "\n"
-#~ "         [not usable with this version of Vim]"
-#~ msgstr ""
-#~ "\n"
-#~ "         [không sử dụng được với phiên bản này của Vim]"
-
-#~ msgid ""
-#~ "&Open Read-Only\n"
-#~ "&Edit anyway\n"
-#~ "&Recover\n"
-#~ "&Quit\n"
-#~ "&Abort\n"
-#~ "&Delete it"
-#~ msgstr ""
-#~ "&O Mở chỉ để đọc\n"
-#~ "&E Vẫn soạn thảo\n"
-#~ "&R Phục hồi\n"
-#~ "&Q Thoát\n"
-#~ "&A Gián đoạn&D Xóa nó"
-
-#~ msgid "Tear off this menu"
-#~ msgstr "Chia cắt trình đơn này"
-
-#~ msgid "[string too long]"
-#~ msgstr "[chuỗi quá dài]"
-
-#~ msgid "Hit ENTER to continue"
-#~ msgstr "Nhấn phím ENTER để tiếp tục"
-
-#~ msgid " (RET/BS: line, SPACE/b: page, d/u: half page, q: quit)"
-#~ msgstr " (RET/BS: dòng, SPACE/b: trang, d/u: nửa trang, q: thoát)"
-
-#~ msgid " (RET: line, SPACE: page, d: half page, q: quit)"
-#~ msgstr " (RET: dòng, SPACE: trang, d: nửa trang, q: thoát)"
-
-#~ msgid "Save File dialog"
-#~ msgstr "Ghi nhớ tập tin"
-
-#~ msgid "Open File dialog"
-#~ msgstr "Mở tập tin"
-
-#~ msgid "E338: Sorry, no file browser in console mode"
-#~ msgstr ""
-#~ "E338: Xin lỗi nhưng không có trình duyệt tập tin trong chế độ kênh giao "
-#~ "tác (console)"
-
-#~ msgid "Vim: preserving files...\n"
-#~ msgstr "Vim: ghi nhớ các tập tin...\n"
-
-#~ msgid "Vim: Finished.\n"
-#~ msgstr "Vim: Đã xong.\n"
-
-#~ msgid "ERROR: "
-#~ msgstr "LỖI: "
-
-#~ msgid ""
-#~ "\n"
-#~ "[bytes] total alloc-freed %<PRIu64>-%<PRIu64>, in use %<PRIu64>, peak use "
-#~ "%<PRIu64>\n"
-#~ msgstr ""
-#~ "\n"
-#~ "[byte] tổng phân phối-còn trống %<PRIu64>-%<PRIu64>, sử dụng %<PRIu64>, "
-#~ "píc sử dụng %<PRIu64>\n"
-
-#~ msgid ""
-#~ "[calls] total re/malloc()'s %<PRIu64>, total free()'s %<PRIu64>\n"
-#~ "\n"
-#~ msgstr ""
-#~ "[gọi] tổng re/malloc() %<PRIu64>, tổng free() %<PRIu64>\n"
-#~ "\n"
-
-#~ msgid "E340: Line is becoming too long"
-#~ msgstr "E340: Dòng đang trở thành quá dài"
-
-#~ msgid "E341: Internal error: lalloc(%<PRId64>, )"
-#~ msgstr "E341: Lỗi nội bộ: lalloc(%<PRId64>, )"
-
-#~ msgid "E547: Illegal mouseshape"
-#~ msgstr "E547: Dạng trỏ chuột không cho phép"
-
-#~ msgid "Enter encryption key: "
-#~ msgstr "Nhập mật khẩu để mã hóa: "
-
-#~ msgid "Enter same key again: "
-#~ msgstr "      Nhập lại mật khẩu:"
-
-#~ msgid "Keys don't match!"
-#~ msgstr "Hai mật khẩu không trùng nhau!"
-
-#~ msgid "Cannot connect to Netbeans #2"
-#~ msgstr "Không kết nối được với Netbeans #2"
-
-#~ msgid "Cannot connect to Netbeans"
-#~ msgstr "Không kết nối được với NetBeans"
-
-#~ msgid "E668: Wrong access mode for NetBeans connection info file: \"%s\""
-#~ msgstr ""
-#~ "E668: Chế độ truy cập thông tin về liên kết với NetBeans không đúng: \"%s"
-#~ "\""
-
-#~ msgid "read from Netbeans socket"
-#~ msgstr "đọc từ socket NetBeans"
-
-#~ msgid "E658: NetBeans connection lost for buffer %<PRId64>"
-#~ msgstr "E658: Bị mất liên kết với NetBeans cho bộ đệm %<PRId64>"
-
-#~ msgid "freeing %<PRId64> lines"
-#~ msgstr "đã làm sạch %<PRId64> dòng"
-
-#~ msgid "E530: Cannot change term in GUI"
-#~ msgstr "E530: Không thể thay đổi terminal trong giao diện đồ họa GUI"
-
-#~ msgid "E531: Use \":gui\" to start the GUI"
-#~ msgstr "E531: Hãy sử dụng \":gui\" để chạy giao diện đồ họa GUI"
-
-#~ msgid "E617: Cannot be changed in the GTK+ 2 GUI"
-#~ msgstr "E617: Không thể thay đổi trong giao diện đồ họa GTK+ 2"
-
-#~ msgid "E597: can't select fontset"
-#~ msgstr "E597: không chọn được bộ phông chữ"
-
-#~ msgid "E598: Invalid fontset"
-#~ msgstr "E598: Bộ phông chữ không đúng"
-
-#~ msgid "E533: can't select wide font"
-#~ msgstr "E533: không chọn được phông chữ với các ký tự có chiều rộng gấp đôi"
-
-#~ msgid "E534: Invalid wide font"
-#~ msgstr "E534: Phông chữ, với ký tự có chiều rộng gấp đôi, không đúng"
-
-#~ msgid "E538: No mouse support"
-#~ msgstr "E538: Chuột không được hỗ trợ"
-
-#~ msgid "cannot open "
-#~ msgstr "không mở được "
-
-#~ msgid "VIM: Can't open window!\n"
-#~ msgstr "VIM: Không mở được cửa sổ!\n"
-
-#~ msgid "Need Amigados version 2.04 or later\n"
-#~ msgstr "Cần Amigados phiên bản 2.04 hoặc mới hơn\n"
-
-#~ msgid "Need %s version %<PRId64>\n"
-#~ msgstr "Cần %s phiên bản %<PRId64>\n"
-
-#~ msgid "Cannot open NIL:\n"
-#~ msgstr "Không mở được NIL:\n"
-
-#~ msgid "Cannot create "
-#~ msgstr "Không tạo được "
-
-#~ msgid "Vim exiting with %d\n"
-#~ msgstr "Thoát Vim với mã %d\n"
-
-#~ msgid "cannot change console mode ?!\n"
-#~ msgstr "không thay đổi được chế độ kênh giao tác (console)?!\n"
-
-#~ msgid "mch_get_shellsize: not a console??\n"
-#~ msgstr "mch_get_shellsize: không phải là kênh giao tác (console)??\n"
-
-#~ msgid "Cannot execute "
-#~ msgstr "Không chạy được "
-
-#~ msgid "shell "
-#~ msgstr "shell "
-
-#~ msgid " returned\n"
-#~ msgstr " thoát\n"
-
-#~ msgid "ANCHOR_BUF_SIZE too small."
-#~ msgstr "Giá trị ANCHOR_BUF_SIZE quá nhỏ."
-
-#~ msgid "I/O ERROR"
-#~ msgstr "LỖI I/O (NHẬP/XUẤT)"
-
-#~ msgid "...(truncated)"
-#~ msgstr "...(bị cắt bớt)"
-
-#~ msgid "'columns' is not 80, cannot execute external commands"
-#~ msgstr ""
-#~ "Tùy chọn 'columns' khác 80, chương trình ngoại trú không thể thực hiện"
-
-#~ msgid "to %s on %s"
-#~ msgstr "tới %s trên %s"
-
-#~ msgid "E613: Unknown printer font: %s"
-#~ msgstr "E613: Không rõ phông chữ của máy in: %s"
-
-#~ msgid "E238: Print error: %s"
-#~ msgstr "E238: Lỗi in: %s"
-
-#~ msgid "Printing '%s'"
-#~ msgstr "Đang in '%s'"
-
-#~ msgid "E244: Illegal charset name \"%s\" in font name \"%s\""
-#~ msgstr "E244: Tên bảng mã không cho phép \"%s\" trong tên phông chữ \"%s\""
-
-#~ msgid "E245: Illegal char '%c' in font name \"%s\""
-#~ msgstr "E245: Ký tự không cho phép '%c' trong tên phông chữ \"%s\""
-
-#~ msgid "Vim: Double signal, exiting\n"
-#~ msgstr "Vim: Tín hiệu đôi, thoát\n"
-
-#~ msgid "Vim: Caught deadly signal %s\n"
-#~ msgstr "Vim: Nhận được tín hiệu chết %s\n"
-
-#~ msgid "Vim: Caught deadly signal\n"
-#~ msgstr "Vim: Nhận được tín hiệu chết\n"
-
-#~ msgid "Opening the X display took %<PRId64> msec"
-#~ msgstr "Mở màn hình X mất %<PRId64> mili giây"
-
-#~ msgid ""
-#~ "\n"
-#~ "Vim: Got X error\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Vim: Lỗi X\n"
-
-#~ msgid "Testing the X display failed"
-#~ msgstr "Kiểm tra màn hình X không thành công"
-
-#~ msgid "Opening the X display timed out"
-#~ msgstr "Không mở được màn hình X trong thời gian cho phép (time out)"
-
-#~ msgid ""
-#~ "\n"
-#~ "Cannot execute shell sh\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Không chạy được shell sh\n"
-
-#~ msgid ""
-#~ "\n"
-#~ "Cannot create pipes\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Không tạo được đường ống (pipe)\n"
-
-#~ msgid ""
-#~ "\n"
-#~ "Cannot fork\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Không thực hiện được fork()\n"
-
-#~ msgid ""
-#~ "\n"
-#~ "Command terminated\n"
-#~ msgstr ""
-#~ "\n"
-#~ "Câu lệnh bị gián đoạn\n"
-
-#~ msgid "XSMP lost ICE connection"
-#~ msgstr "XSMP mất kết nối ICE"
-
-#~ msgid "Opening the X display failed"
-#~ msgstr "Mở màn hình X không thành công"
-
-#~ msgid "XSMP handling save-yourself request"
-#~ msgstr "XSMP xử lý yêu cầu tự động ghi nhớ"
-
-#~ msgid "XSMP opening connection"
-#~ msgstr "XSMP mở kết nối"
-
-#~ msgid "XSMP ICE connection watch failed"
-#~ msgstr "XSMP mất theo dõi kết nối ICE"
-
-#~ msgid "XSMP SmcOpenConnection failed: %s"
-#~ msgstr "XSMP thực hiện SmcOpenConnection không thành công: %s"
-
-#~ msgid "At line"
-#~ msgstr "Tại dòng"
-
-#~ msgid "Could not allocate memory for command line."
-#~ msgstr "Không phân chia được bộ nhớ cho dòng lệnh."
-
-#~ msgid "VIM Error"
-#~ msgstr "Lỗi VIM"
-
-#~ msgid "Could not load vim32.dll!"
-#~ msgstr "Không nạp được vim32.dll!"
-
-#~ msgid "Could not fix up function pointers to the DLL!"
-#~ msgstr "Không sửa được cái chỉ (pointer) hàm số tới DLL!"
-
-#~ msgid "shell returned %d"
-#~ msgstr "thoát shell với mã %d"
-
-#~ msgid "Vim: Caught %s event\n"
-#~ msgstr "Vim: Nhận được sự kiện %s\n"
-
-#~ msgid "close"
-#~ msgstr "đóng"
-
-#~ msgid "logoff"
-#~ msgstr "thoát"
-
-#~ msgid "shutdown"
-#~ msgstr "tắt máy"
-
-#~ msgid "E371: Command not found"
-#~ msgstr "E371: Câu lệnh không tìm thấy"
-
-#~ msgid ""
-#~ "VIMRUN.EXE not found in your $PATH.\n"
-#~ "External commands will not pause after completion.\n"
-#~ "See  :help win32-vimrun  for more information."
-#~ msgstr ""
-#~ "Không tìm thấy VIMRUN.EXE trong $PATH.\n"
-#~ "Lệnh ngoại trú sẽ không dừng lại sau khi hoàn thành.\n"
-#~ "Thông tin chi tiết xem trong :help win32-vimrun"
-
-#~ msgid "Vim Warning"
-#~ msgstr "Cảnh báo Vim"
-
-#~ msgid "E56: %s* operand could be empty"
-#~ msgstr "E56: operand %s* không thể rỗng"
-
-#~ msgid "E57: %s+ operand could be empty"
-#~ msgstr "E57: operand %s+ không thể rỗng"
-
-#~ msgid "E58: %s{ operand could be empty"
-#~ msgstr "E58: operand %s{ không thể rỗng"
-
-#~ msgid "E361: Crash intercepted; regexp too complex?"
-#~ msgstr "E361: Sự cố được ngăn chặn; biểu thức chính quy quá phức tạp?"
-
-#~ msgid "E363: pattern caused out-of-stack error"
-#~ msgstr "E363: sử dụng mẫu (pattern) gây ra lỗi out-of-stack"
-
-#~ msgid "E396: containedin argument not accepted here"
-#~ msgstr "E396: không được sử dụng tham số containedin ở đây"
-
-#~ msgid "Enter nr of choice (<CR> to abort): "
-#~ msgstr "Hãy chọn số cần thiết (<CR> để dừng):"
-
-#~ msgid "E430: Tag file path truncated for %s\n"
-#~ msgstr "E430: Đường dẫn tới tập tin thẻ ghi bị cắt bớt cho %s\n"
-
-#~ msgid "new shell started\n"
-#~ msgstr "đã chạy shell mới\n"
-
-#~ msgid "No undo possible; continue anyway"
-#~ msgstr "Không thể hủy thao tác; tiếp tục thực hiện"
-
-#~ msgid ""
-#~ "\n"
-#~ "MS-Windows 16/32-bit GUI version"
-#~ msgstr ""
-#~ "\n"
-#~ "Phiên bản với giao diện đồ họa GUI cho MS-Windows 16/32 bit"
-
-#~ msgid ""
-#~ "\n"
-#~ "MS-Windows 32-bit GUI version"
-#~ msgstr ""
-#~ "\n"
-#~ "Phiên bản với giao diện đồ họa GUI cho MS-Windows 32 bit"
-
-#~ msgid " in Win32s mode"
-#~ msgstr " trong chế độ Win32"
-
-#~ msgid " with OLE support"
-#~ msgstr " với hỗ trợ OLE"
-
-#~ msgid ""
-#~ "\n"
-#~ "MS-Windows 32-bit console version"
-#~ msgstr ""
-#~ "\n"
-#~ "Phiên bản console cho MS-Windows 32 bit"
-
-#~ msgid ""
-#~ "\n"
-#~ "MS-Windows 16-bit version"
-#~ msgstr ""
-#~ "\n"
-#~ "Phiên bản cho MS-Windows 16 bit"
-
-#~ msgid ""
-#~ "\n"
-#~ "32-bit MS-DOS version"
-#~ msgstr ""
-#~ "\n"
-#~ "Phiên bản cho MS-DOS 32 bit"
-
-#~ msgid ""
-#~ "\n"
-#~ "16-bit MS-DOS version"
-#~ msgstr ""
-#~ "\n"
-#~ "Phiên bản cho MS-DOS 16 bit"
-
-#~ msgid ""
-#~ "\n"
-#~ "MacOS X (unix) version"
-#~ msgstr ""
-#~ "\n"
-#~ "Phiên bản cho MacOS X (unix)"
-
-#~ msgid ""
-#~ "\n"
-#~ "MacOS X version"
-#~ msgstr ""
-#~ "\n"
-#~ "Phiên bản cho MacOS X"
-
-#~ msgid ""
-#~ "\n"
-#~ "MacOS version"
-#~ msgstr ""
-#~ "\n"
-#~ "Phiên bản cho MacOS"
-
-#~ msgid ""
-#~ "\n"
-#~ "RISC OS version"
-#~ msgstr ""
-#~ "\n"
-#~ "Phiên bản cho RISC OS"
-
-#~ msgid ""
-#~ "\n"
-#~ "Big version "
-#~ msgstr ""
-#~ "\n"
-#~ "Phiên bản lớn "
-
-#~ msgid ""
-#~ "\n"
-#~ "Normal version "
-#~ msgstr ""
-#~ "\n"
-#~ "Phiên bản thông thường "
-
-#~ msgid ""
-#~ "\n"
-#~ "Small version "
-#~ msgstr ""
-#~ "\n"
-#~ "Phiên bản nhỏ "
-
-#~ msgid ""
-#~ "\n"
-#~ "Tiny version "
-#~ msgstr ""
-#~ "\n"
-#~ "Phiên bản \"tí hon\" "
-
-#~ msgid "with GTK2-GNOME GUI."
-#~ msgstr "với giao diện đồ họa GUI GTK2-GNOME."
-
-#~ msgid "with GTK-GNOME GUI."
-#~ msgstr "với giao diện đồ họa GUI GTK-GNOME."
-
-#~ msgid "with GTK2 GUI."
-#~ msgstr "với giao diện đồ họa GUI GTK2."
-
-#~ msgid "with GTK GUI."
-#~ msgstr "với giao diện đồ họa GUI GTK."
-
-#~ msgid "with X11-Motif GUI."
-#~ msgstr "với giao diện đồ họa GUI X11-Motif."
-
-#~ msgid "with X11-neXtaw GUI."
-#~ msgstr "với giao diện đồ họa GUI X11-neXtaw."
-
-#~ msgid "with X11-Athena GUI."
-#~ msgstr "với giao diện đồ họa GUI X11-Athena."
-
-#~ msgid "with BeOS GUI."
-#~ msgstr "với giao diện đồ họa GUI BeOS."
-
-#~ msgid "with Photon GUI."
-#~ msgstr "với giao diện đồ họa GUI Photon."
-
-#~ msgid "with GUI."
-#~ msgstr "với giao diện đồ họa GUI."
-
-#~ msgid "with Carbon GUI."
-#~ msgstr "với giao diện đồ họa GUI Carbon."
-
-#~ msgid "with Cocoa GUI."
-#~ msgstr "với giao diện đồ họa GUI Cocoa."
-
-#~ msgid "with (classic) GUI."
-#~ msgstr "với giao diện đồ họa (cổ điển) GUI."
-
-#~ msgid "  system gvimrc file: \""
-#~ msgstr "            tập tin gvimrc chung cho hệ thống: \""
-
-#~ msgid "    user gvimrc file: \""
-#~ msgstr "         tập tin gvimrc của người dùng: \""
-
-#~ msgid "2nd user gvimrc file: \""
-#~ msgstr "  tập tin gvimrc thứ hai của người dùng: \""
-
-#~ msgid "3rd user gvimrc file: \""
-#~ msgstr "  tập tin gvimrc thứ ba của người dùng: \""
-
-#~ msgid "    system menu file: \""
-#~ msgstr "             tập tin trình đơn chung cho hệ thống: \""
-
-#~ msgid "Compiler: "
-#~ msgstr "Trình biên dịch: "
-
-#~ msgid "menu  Help->Orphans           for information    "
-#~ msgstr "trình đơn Trợ giúp->Mồ côi             để có thêm thông tin     "
-
-#~ msgid "Running modeless, typed text is inserted"
-#~ msgstr "Không chế độ, văn bản nhập vào sẽ được chèn"
-
-#~ msgid "menu  Edit->Global Settings->Toggle Insert Mode  "
-#~ msgstr ""
-#~ "trình đơn Soạn thảo->Thiết lập chung->Chế độ chèn                     "
-
-#~ msgid "                              for two modes      "
-#~ msgstr "                                 cho hai chế độ               "
-
-#~ msgid "menu  Edit->Global Settings->Toggle Vi Compatible"
-#~ msgstr ""
-#~ "trình đơn Soạn thảo->Thiết lập chung->Tương thích với Vi                "
-
-#~ msgid "                              for Vim defaults   "
-#~ msgstr ""
-#~ "                                 để chuyển vào chế độ Vim mặc định       "
-
-#~ msgid "WARNING: Windows 95/98/ME detected"
-#~ msgstr "CẢNH BÁO: nhận ra Windows 95/98/ME"
-
-#~ msgid "type  :help windows95<Enter>  for info on this"
-#~ msgstr "hãy gõ :help windows95<Enter>  để biết thêm thông tin     "
-
-#~ msgid "E370: Could not load library %s"
-#~ msgstr "E370: Không nạp được thư viện %s"
-
-#~ msgid ""
-#~ "Sorry, this command is disabled: the Perl library could not be loaded."
-#~ msgstr "Xin lỗi, câu lệnh này bị tắt: không nạp được thư viện Perl."
-
-#~ msgid "E299: Perl evaluation forbidden in sandbox without the Safe module"
-#~ msgstr ""
-#~ "E299: Không cho phép sự tính toán Perl trong hộp cát mà không có môđun An "
-#~ "toàn"
-
-#~ msgid "Edit with &multiple Vims"
-#~ msgstr "Soạn thảo trong nhiều Vi&m"
-
-#~ msgid "Edit with single &Vim"
-#~ msgstr "Soạn thảo trong một &Vim"
-
-#~ msgid "&Diff with Vim"
-#~ msgstr "&So sánh (diff) qua Vim"
-
-#~ msgid "Edit with &Vim"
-#~ msgstr "Soạn thảo trong &Vim"
-
-#~ msgid "Edit with existing Vim - &"
-#~ msgstr "Soạn thảo trong Vim đã chạy - &"
-
-#~ msgid "Edits the selected file(s) with Vim"
-#~ msgstr "Soạn thảo (các) tập tin đã chọn trong Vim"
-
-#~ msgid "Error creating process: Check if gvim is in your path!"
-#~ msgstr "Lỗi tạo tiến trình: Hãy kiểm tra xem gvim có trong đường dẫn không!"
-
-#~ msgid "gvimext.dll error"
-#~ msgstr "lỗi gvimext.dll"
-
-#~ msgid "Path length too long!"
-#~ msgstr "Đường dẫn quá dài!"
-
-#~ msgid "E234: Unknown fontset: %s"
-#~ msgstr "E234: Không rõ bộ phông chữ: %s"
-
-#~ msgid "E235: Unknown font: %s"
-#~ msgstr "E235: Không rõ phông chữ: %s"
-
-#~ msgid "E448: Could not load library function %s"
-#~ msgstr "E448: Nạp hàm số %s của thư viện không thành công"
-
-#~ msgid "E26: Hebrew cannot be used: Not enabled at compile time\n"
-#~ msgstr "E26: Tiếng Do thái không được chọn khi biên dịch\n"
-
-#~ msgid "E27: Farsi cannot be used: Not enabled at compile time\n"
-#~ msgstr "E27: Tiếng Farsi không được chọn khi biên dịch\n"
-
-#~ msgid "E800: Arabic cannot be used: Not enabled at compile time\n"
-#~ msgstr "E800: Tiếng Ả Rập không được chọn khi biên dịch\n"
-
-#~ msgid "E247: no registered server named \"%s\""
-#~ msgstr "E247: máy chủ \"%s\" chưa đăng ký"
-
-#~ msgid "E233: cannot open display"
-#~ msgstr "E233: không mở được màn hình"
-
-#~ msgid "E463: Region is guarded, cannot modify"
-#~ msgstr "E463: Không thể thay đổi vùng đã được bảo vệ"
+msgid "Only one argument accepted (check spaces)"
+msgstr "Chỉ chấp nhận một tham số (vui lòng kiểm tra dấu cách)"


### PR DESCRIPTION
Since Vietnamese keymaps in Vim is quite differences from the corresponding input methods, let's document the Vietnamese specifics in vietnames.txt

related: vim/vim#16144

https://github.com/vim/vim/commit/189e24bb1441abe87387a4e21c4387bbf2eac718



vim-patch::9.1.0902

Problem:    
            1. Vim's built-in Vietnamese keymaps have some important
            differences from the correspond Vietnamese input methods, but they
            are undocumented
            2. For some reason, the file vi.po in Neovim is so different
               from that of Vim, and it also contains many mistakes in
               translation, compared to that of Vim

Solution:   
            Add vietnamese.txt
            Copy the file vi.po from Vim to Neovim

https://github.com/vim/vim/commit/8a52587ee05a360cad4d42322200775fc74a4430