### PR TITLE
fix(diagnostic): only update stored quickfix id when we create a new quickfix

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -867,7 +867,9 @@ local function set_list(loclist, opts)
     })
 
     -- Get the id of the newly created quickfix list.
-    _qf_id = vim.fn.getqflist({ id = 0 }).id
+    if _qf_id == nil then
+      _qf_id = vim.fn.getqflist({ id = 0 }).id
+    end
   end
   if open then
     api.nvim_command(loclist and 'lwindow' or 'botright cwindow')


### PR DESCRIPTION
The old code would always update `_qf_id` with the current quickfix, even if you're currently looking at a completely different, non-diagnostics quickfix list. This completely defeats the intent of <https://github.com/neovim/neovim/pull/30868>, whoops!