### PR TITLE
docs(annotation): added missing `link` field

### DIFF
--- a/runtime/lua/vim/_meta/api_keysets_extra.lua
+++ b/runtime/lua/vim/_meta/api_keysets_extra.lua
@@ -159,6 +159,7 @@ error('Cannot require a meta file')
 --- @field bg? integer
 --- @field sp? integer
 --- @field default? true
+--- @field link? string
 --- @field blend? integer
 --- @field cterm? vim.api.keyset.hl_info.cterm
 


### PR DESCRIPTION
`vim.api.nvim_get_hl` returns `vim.api.keyset.get_hl_info`, which can contain `link` but the definition for `vim.api.keyset.get_hl_info` is missing that key, which causes llscheck + lua-language-server to think the code is an error.

```lua
vim.api.nvim_set_hl(0, "FooBarFizzBuzz", {link="Normal"})
print(vim.inspect(vim.api.nvim_get_hl(0, {name="FooBarFizzBuzz"})))
```
prints
```
{
  link = "Normal"
}
```