### PR TITLE
fix(marks): check gravity at range bounds when deleting text

### DIFF
--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -249,7 +249,7 @@ describe('API/extmarks', function()
     set_extmark(ns, 2, 1, 0, { right_gravity = false })
     eq({ { 1, 0, 0 }, { 2, 1, 0 } }, get_extmarks(ns, { 0, 0 }, { -1, -1 }))
     feed('u')
-    eq({ { 1, 0, 0 }, { 2, 1, 0 } }, get_extmarks(ns, { 0, 0 }, { -1, -1 }))
+    eq({ { 1, 0, 0 }, { 2, 0, 0 } }, get_extmarks(ns, { 0, 0 }, { -1, -1 }))
     api.nvim_buf_clear_namespace(0, ns, 0, -1)
   end)
 


### PR DESCRIPTION
Problem:  Marks that are properly restored by the splice associated with
          an undo edit, are unnecessarily pushed to the undo header. This
          results in incorrect mark tracking in the "copy_only"
          save/restore completion path.
Solution: Avoid pushing left gravity marks at the beginning of the range,
          and right gravity marks at the end of the range, to the undo
          header.

Fix #31465