### PR TITLE
docs(treesitter): fix grammar and clarity in query syntax note

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -70,8 +70,9 @@ adds arbitrary metadata and conditional data to a match.
 
 Queries are written in a lisp-like language documented in
 https://tree-sitter.github.io/tree-sitter/using-parsers#query-syntax
-Note: The predicates listed there page differ from those Nvim supports. See
-|treesitter-predicates| for a complete list of predicates supported by Nvim.
+Note: The predicates listed on that page differ from the ones Nvim supports.
+See |treesitter-predicates| for a complete list of predicates supported by
+Nvim.
 
 Nvim looks for queries as `*.scm` files in a `queries` directory under
 `runtimepath`, where each file contains queries for a specific language and

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -70,9 +70,8 @@ adds arbitrary metadata and conditional data to a match.
 
 Queries are written in a lisp-like language documented in
 https://tree-sitter.github.io/tree-sitter/using-parsers#query-syntax
-Note: The predicates listed on that page differ from the ones Nvim supports.
-See |treesitter-predicates| for a complete list of predicates supported by
-Nvim.
+Note: The predicates listed there differ from those Nvim supports. See
+|treesitter-predicates| for a complete list of predicates supported by Nvim.
 
 Nvim looks for queries as `*.scm` files in a `queries` directory under
 `runtimepath`, where each file contains queries for a specific language and


### PR DESCRIPTION
Correct "there page" to "on that page" and rephrase "those Nvim supports" to "the ones Nvim supports" for improved readability.