### PR TITLE
defaults: disable 'foldcolumn' in terminal buffers

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -58,8 +58,8 @@ DEFAULTS
 • |]d-default| and |[d-default| accept a count.
 • |[D-default| and |]D-default| jump to the first and last diagnostic in the
   current buffer, respectively.
-• 'number', 'relativenumber', and 'signcolumn' are disabled in |terminal|
-  buffers. See |terminal-config| for an example of changing these defaults.
+• 'number', 'relativenumber', 'signcolumn', and 'foldcolumn' are disabled in
+  |terminal| buffers. See |terminal-config| for an example of changing these defaults.
 
 DIAGNOSTICS
 

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -111,6 +111,7 @@ global configuration.
 - 'number' is disabled
 - 'relativenumber' is disabled
 - 'signcolumn' is set to "no"
+- 'foldcolumn' is set to "0"
 
 You can change the defaults with a TermOpen autocommand: >vim
     au TermOpen * setlocal list

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -189,6 +189,7 @@ nvim_terminal:
     - 'nonumber'
     - 'norelativenumber'
     - 'signcolumn' set to "no"
+    - 'foldcolumn' set to "0"
     - 'winhighlight' uses |hl-StatusLineTerm| and |hl-StatusLineTermNC| in
       place of |hl-StatusLine| and |hl-StatusLineNC|
 

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -495,6 +495,7 @@ do
       vim.wo[0][0].number = false
       vim.wo[0][0].relativenumber = false
       vim.wo[0][0].signcolumn = 'no'
+      vim.wo[0][0].foldcolumn = '0'
 
       -- This is gross. Proper list options support when?
       local winhl = vim.o.winhighlight


### PR DESCRIPTION
Follow up to #31443. The new terminal defaults are very sane and in the same vein I think it is a good idea to also by default disable foldcolumn since none of the default fold methods make sense for terminals and there is a minimal change that the user would want the fold column there by default when using an in editor terminal. I also want to make it clear I am not looking for this to lead to tons of default terminal buffer default settings, just that the `foldcolumn` seems to achieve the same goals as disabling sign and number columns.


Let me know what you think!

EDIT: looks like the commit linter doesn't like the commit name. I can happily change it if necessary, but it seems like it is the format used previously so I am thinking this is a false negative,