### PR TITLE
fix(lsp): cancel pending requests before refreshing

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -2162,6 +2162,11 @@ function M._refresh(method, opts)
         local first = vim.fn.line('w0', window)
         local last = vim.fn.line('w$', window)
         for _, client in ipairs(clients) do
+          for rid, req in pairs(client.requests) do
+            if req.method == method and req.type == 'pending' and req.bufnr == bufnr then
+              client:cancel_request(rid)
+            end
+          end
           client:request(method, {
             textDocument = textDocument,
             range = make_line_range_params(bufnr, first - 1, last - 1, client.offset_encoding),


### PR DESCRIPTION
Problem:
Diagnostics and inlay hints can be expensive to calculate, and we shouldn't stack them as this can cause noticeable lag.

Solution:
Check for duplicate inflight requests and cancel them before issuing a new one. This ensures that only the latest request is processed, improving performance and preventing potential conflicts.

This is part of an issue uncovered here:
https://github.com/seblj/roslyn.nvim/issues/93

Open as draft whilst some more people test it