### PR TITLE
fix(inspect): show priority for treesitter highlights

### DIFF
--- a/runtime/lua/vim/_inspector.lua
+++ b/runtime/lua/vim/_inspector.lua
@@ -191,7 +191,12 @@ function vim.show_pos(bufnr, row, col, filter)
     append('Treesitter', 'Title')
     nl()
     for _, capture in ipairs(items.treesitter) do
-      item(capture, capture.lang)
+      item(
+        capture,
+        capture.metadata.priority
+            and string.format('%s priority: %d', capture.lang, capture.metadata.priority)
+          or capture.lang
+      )
     end
     nl()
   end


### PR DESCRIPTION
Problem: `:Inspect` does not show priority for treesitter highlights,
leading to confusion why sometimes earlier highlights override later
highlights.

Solution: Also print priority metadata if set.

<img width="546" alt="Screenshot 2024-12-06 at 19 21 29" src="https://github.com/user-attachments/assets/61e3ba92-8f37-45e0-a884-b1dd074cf360">

