### PR TITLE
feat(diagnostic): store a unique quickfix list per title

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -874,7 +874,8 @@ setqflist({opts})                                 *vim.diagnostic.setqflist()*
                 • {open}? (`boolean`, default: `true`) Open quickfix list
                   after setting.
                 • {title}? (`string`) Title of quickfix list. Defaults to
-                  "Diagnostics".
+                  "Diagnostics". If there's already a quickfix list with this
+                  title, it's updated. If not, a new quickfix list is created.
                 • {severity}? (`vim.diagnostic.SeverityFilter`) See
                   |diagnostic-severity|.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -315,8 +315,8 @@ UI
   |hl-PmenuSel| and |hl-PmenuMatch| both inherit from |hl-Pmenu|, and
   |hl-PmenuMatchSel| inherits highlights from both |hl-PmenuSel| and
   |hl-PmenuMatch|.
-• |vim.diagnostic.setqflist()| updates existing diagnostics quickfix list if one
-  exists.
+• |vim.diagnostic.setqflist()| updates an existing quickfix list with the
+  given title if found
 
 • |ui-messages| content chunks now also contain the highlight group ID.
 


### PR DESCRIPTION
Previously, there was a singleton diagnostics quickfix list. Now we store one per title. This idea was first suggested by @mfussenegger in https://github.com/neovim/neovim/pull/30868#pullrequestreview-2385761374.