### PR TITLE
fix(treesitter): proper #trim! range for nodes ending at col 0

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -593,6 +593,11 @@ local directive_handlers = {
     local start_row, start_col, end_row, end_col = node:range()
 
     local node_text = vim.split(vim.treesitter.get_node_text(node, bufnr), '\n')
+    if end_col == 0 then
+      -- get_node_text() will ignore the last line if the node ends at column 0
+      node_text[#node_text + 1] = ''
+    end
+
     local end_idx = #node_text
     local start_idx = 1
 
@@ -600,6 +605,9 @@ local directive_handlers = {
       while end_idx > 0 and node_text[end_idx]:find('^%s*$') do
         end_idx = end_idx - 1
         end_row = end_row - 1
+        -- set the end position to the last column of the next line, or 0 if we just trimmed the
+        -- last line
+        end_col = end_idx > 0 and #node_text[end_idx] or 0
       end
     end
     if trim_end_cols then
@@ -616,6 +624,7 @@ local directive_handlers = {
       while start_idx <= end_idx and node_text[start_idx]:find('^%s*$') do
         start_idx = start_idx + 1
         start_row = start_row + 1
+        start_col = 0
       end
     end
     if trim_start_cols and node_text[start_idx] then

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -696,14 +696,14 @@ print()
     end)
 
     it('trims only empty lines by default (backwards compatible)', function()
-      insert [[
+      insert(dedent [[
       ## Heading
 
       With some text
 
       ## And another
 
-      With some more]]
+      With some more here]])
 
       local query_text = [[
         ; query
@@ -716,8 +716,35 @@ print()
       end)
 
       eq({
-        { 'fold', { 0, 0, 3, 0 } },
-        { 'fold', { 4, 0, 7, 0 } },
+        { 'fold', { 0, 0, 2, 14 } },
+        { 'fold', { 4, 0, 6, 19 } },
+      }, run_query('markdown', query_text))
+    end)
+
+    it('can trim lines', function()
+      insert(dedent [[
+      - Fold list
+        - Fold list
+          - Fold list
+          - Fold list
+        - Fold list
+      - Fold list
+      ]])
+
+      local query_text = [[
+        ; query
+        ((list_item
+          (list)) @fold
+          (#trim! @fold 1 1 1 1))
+      ]]
+
+      exec_lua(function()
+        vim.treesitter.start(0, 'markdown')
+      end)
+
+      eq({
+        { 'fold', { 0, 0, 4, 13 } },
+        { 'fold', { 1, 2, 3, 15 } },
       }, run_query('markdown', query_text))
     end)
   end)


### PR DESCRIPTION
**Problem:** #30085 introduced char-wise folding support for `#trim!`, but the ranges were improperly calculated for nodes that end at column 0, due to the way `get_node_text` works

**Solution:** Add the blank line that `get_node_text` removes for for nodes ending at column 0. Also properly set column positions when performing linewise trims.

I apologize for not catching this sooner