### PR TITLE
feat(ex_cmds): :sleep! hides the cursor while sleeping

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1569,6 +1569,8 @@ tag		command		action ~
 |:sign|		:sig[n]		manipulate signs
 |:silent|	:sil[ent]	run a command silently
 |:sleep|	:sl[eep]	do nothing for a few seconds
+|:sleep!|	:sl[eep]!	do nothing for a few seconds, without the
+				cursor visible
 |:slast|	:sla[st]	split window and go to last file in the
 				argument list
 |:smagic|	:sm[agic]	:substitute with 'magic'

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -552,8 +552,7 @@ gO			Show a filetype-specific, navigable "outline" of the
 			Queued messages are processed during the sleep.
 
 							*:sl!* *:sleep!*
-:[N]sl[eep]! [N][m]	Same as above. Unlike Vim, it does not hide the
-			cursor. |vim-differences|
+:[N]sl[eep]! [N][m]	Same as above, but hide the cursor.
 
 ==============================================================================
 2. Using Vim like less or more					*less*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -670,7 +670,6 @@ Commands:
 - :promptrepl
 - :scriptversion (always version 1)
 - :shell
-- :sleep! (does not hide the cursor; same as :sleep)
 - :smile
 - :tearoff
 - :cstag

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6101,7 +6101,9 @@ static void ex_sleep(exarg_T *eap)
   default:
     semsg(_(e_invarg2), eap->arg); return;
   }
-  do_sleep(len, false);
+
+  // Hide the cursor if invoked with !
+  do_sleep(len, eap->forceit);
 }
 
 /// Sleep for "msec" milliseconds, but return early on CTRL-C.

--- a/test/functional/ui/cursor_spec.lua
+++ b/test/functional/ui/cursor_spec.lua
@@ -361,4 +361,38 @@ describe('ui/cursor', function()
       end
     end)
   end)
+
+  it(':sleep does not hide cursor when sleeping', function()
+    n.feed(':sleep 100m | echo 42\n')
+    screen:expect({
+      grid = [[
+      ^                         |
+      {1:~                        }|*3
+      :sleep 100m | echo 42    |
+    ]],
+      timeout = 100,
+    })
+    screen:expect([[
+      ^                         |
+      {1:~                        }|*3
+      42                       |
+    ]])
+  end)
+
+  it(':sleep! hides cursor when sleeping', function()
+    n.feed(':sleep! 100m | echo 42\n')
+    screen:expect({
+      grid = [[
+                               |
+      {1:~                        }|*3
+      :sleep! 100m | echo 42   |
+    ]],
+      timeout = 100,
+    })
+    screen:expect([[
+      ^                         |
+      {1:~                        }|*3
+      42                       |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:  :sleep! not hiding the cursor is an arbitrary difference from
          Vim without obvious justification, and Vim's behavior isn't
          easily achievable in Nvim.
Solution: Make :sleep! hide the cursor while sleeping.

Ref:
https://github.com/neovim/neovim/commit/6a01b3fcc361960e559db459e1524418bc76dd66
https://github.com/neovim/neovim/commit/b5c0ade43790cf18f6a54858ddad30d8d9667cf9
