### PR TITLE
fix(inspect): always show priority

### DIFF
--- a/runtime/lua/vim/_inspector.lua
+++ b/runtime/lua/vim/_inspector.lua
@@ -178,7 +178,7 @@ function vim.show_pos(bufnr, row, col, filter)
     if data.hl_group ~= data.hl_group_link then
       append('links to ', 'MoreMsg')
       append(data.hl_group_link, data.hl_group_link)
-      append(' ')
+      append('   ')
     end
     if comment then
       append(comment, 'Comment')
@@ -193,9 +193,11 @@ function vim.show_pos(bufnr, row, col, filter)
     for _, capture in ipairs(items.treesitter) do
       item(
         capture,
-        capture.metadata.priority
-            and string.format('%s priority: %d', capture.lang, capture.metadata.priority)
-          or capture.lang
+        string.format(
+          'priority: %d   language: %s',
+          capture.metadata.priority or vim.hl.priorities.treesitter,
+          capture.lang
+        )
       )
     end
     nl()


### PR DESCRIPTION
Problem: It is not obvious if a treesitter highlight priority shown in
`:Inspect` is higher or lower than the default.

Solution: Also print default priority (`vim.hl.priorities.treesitter`).
Add padding for better readability.

Follow-up to #31496 

**Question:** Should we still print the `language`? Strictly speaking it's redundant with the highlight group suffix and adds visual clutter; we also don't show it for semantic tokens.

<img width="512" alt="Screenshot 2024-12-07 at 11 01 04" src="https://github.com/user-attachments/assets/79413f8f-823e-4972-bfc2-bd9567a5c6dc">

