### PR TITLE
vim-patch:9.1.0915: GVim: default font size a bit too small

### DIFF
--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -55,6 +55,10 @@ silent! endwhile
 
 " In the GUI we can always change the screen size.
 if has('gui_running')
+  if has('gui_gtk')
+    " to keep screendump size unchanged
+    set guifont=Monospace\ 10
+  endif
   set columns=80 lines=25
 endif
 

--- a/test/old/testdir/test_highlight.vim
+++ b/test/old/testdir/test_highlight.vim
@@ -785,8 +785,8 @@ func Test_1_highlight_Normalgroup_exists()
   if !has('gui_running')
     call assert_match('hi Normal\s*clear', hlNormal)
   elseif has('gui_gtk2') || has('gui_gnome') || has('gui_gtk3')
-    " expect is DEFAULT_FONT of gui_gtk_x11.c
-    call assert_match('hi Normal\s*font=Monospace 10', hlNormal)
+    " expect is DEFAULT_FONT of gui_gtk_x11.c (any size)
+    call assert_match('hi Normal\s*font=Monospace\>', hlNormal)
   elseif has('gui_motif')
     " expect is DEFAULT_FONT of gui_x11.c
     call assert_match('hi Normal\s*font=7x13', hlNormal)


### PR DESCRIPTION
#### vim-patch:9.1.0915: GVim: default font size a bit too small

Problem:  GVim: default font size a bit too small
Solution: increase guifont size to 12 pt on GTK builds
          of gVim (matveyt).

closes: vim/vim#16178

https://github.com/vim/vim/commit/ad3b6a3340a4ab02c1e5bc4a6d6a5fb858b671d3

Co-authored-by: matveyt <matthewtarasov@yandex.ru>