### PR TITLE
feat(ui)!: emit prompt "messages" as cmdline events

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1086,9 +1086,8 @@ vim.ui_attach({ns}, {options}, {callback})                   *vim.ui_attach()*
     |ui-popupmenu| and the sections below for event format for respective
     events.
 
-    Callbacks for `msg_show` events are executed in |api-fast| context unless
-    Nvim will wait for input, in which case messages should be shown
-    immediately.
+    Callbacks for `msg_show` events are executed in |api-fast| context;
+    showing the message should be scheduled.
 
     Excessive errors inside the callback will result in forced detachment.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -93,12 +93,15 @@ EVENTS
 • |vim.ui_attach()| callbacks for |ui-messages| `msg_show` events are executed in
   |api-fast| context.
 • New/enhanced arguments in these existing UI events:
-  • `cmdline_show`: `hl_id` argument to highlight the prompt text.
   • `cmdline_hide`: `abort` argument indicating if the cmdline was aborted.
+  • `cmdline_show`:
+    • Prompts that were previously emitted as `msg_show` events, are now routed
+      through `cmdline_show`.
+    • `hl_id` argument to highlight the prompt text.
   • `msg_show`:
     • `history` argument indicating if the message was added to the history.
-    • new message kinds: "bufwrite", "completion", "list_cmd",
-      "lua_print", "number_prompt", "search_cmd", "undo", "wildlist".
+    • new message kinds: "bufwrite", "completion", "list_cmd", "lua_print",
+      "search_cmd", "undo", "wildlist".
 
 HIGHLIGHTS
 

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -792,7 +792,6 @@ must handle.
 		"" (empty)	Unknown (consider a |feature-request|)
 		"bufwrite"	|:write| message
 		"confirm"	|confirm()| or |:confirm| dialog
-		"confirm_sub"	|:substitute| confirm dialog |:s_c|
 		"emsg"		Error (|errors|, internal error, |:throw|, …)
 		"echo"		|:echo| message
 		"echomsg"	|:echomsg| message
@@ -802,7 +801,6 @@ must handle.
 		"lua_error"	Error in |:lua| code
 		"lua_print"	|print()| from |:lua| code
 		"rpc_error"	Error response from |rpcrequest()|
-		"number_prompt"	Number input prompt (|inputlist()|, |z=|, …)
 		"return_prompt"	|press-enter| prompt after a multiple messages
 		"quickfix"	Quickfix navigation message
 		"search_cmd"	Entered search command

--- a/runtime/lua/vim/_meta/builtin.lua
+++ b/runtime/lua/vim/_meta/builtin.lua
@@ -233,9 +233,8 @@ function vim.wait(time, callback, interval, fast_only) end
 --- {callback} receives event name plus additional parameters. See |ui-popupmenu|
 --- and the sections below for event format for respective events.
 ---
---- Callbacks for `msg_show` events are executed in |api-fast| context unless
---- Nvim will wait for input, in which case messages should be shown
---- immediately.
+--- Callbacks for `msg_show` events are executed in |api-fast| context; showing
+--- the message should be scheduled.
 ---
 --- Excessive errors inside the callback will result in forced detachment.
 ---

--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -350,7 +350,7 @@ static int check_mtime(buf_T *buf, FileInfo *file_info)
     msg_silent = 0;     // Must give this prompt.
     // Don't use emsg() here, don't want to flush the buffers.
     msg(_("WARNING: The file has been changed since reading it!!!"), HLF_E);
-    if (ask_yesno(_("Do you really want to write to it"), true) == 'n') {
+    if (ask_yesno(_("Do you really want to write to it")) == 'n') {
       return FAIL;
     }
     msg_scroll = false;  // Always overwrite the file message now.

--- a/src/nvim/debugger.c
+++ b/src/nvim/debugger.c
@@ -153,8 +153,7 @@ void do_debug(char *cmd)
     debug_break_level = -1;
 
     xfree(cmdline);
-    cmdline = getcmdline_prompt('>', NULL, 0, EXPAND_NOTHING, NULL,
-                                CALLBACK_NONE);
+    cmdline = getcmdline_prompt('>', NULL, 0, EXPAND_NOTHING, NULL, CALLBACK_NONE, false, NULL);
 
     debug_break_level = n;
     if (typeahead_saved) {

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3557,10 +3557,10 @@ static void f_inputlist(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   });
 
   // Ask for choice.
-  bool mouse_used;
-  int selected = prompt_for_number(&mouse_used);
+  bool mouse_used = false;
+  int selected = prompt_for_input(NULL, 0, false, &mouse_used);
   if (mouse_used) {
-    selected -= lines_left;
+    selected = tv_list_len(argvars[0].vval.v_list) - (cmdline_row - mouse_row);
   }
 
   rettv->vval.v_number = selected;

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3707,12 +3707,9 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
           // Loop until 'y', 'n', 'q', CTRL-E or CTRL-Y typed.
           while (subflags.do_ask) {
             if (exmode_active) {
-              char *prompt;
-              char *resp;
-              colnr_T sc, ec;
-
               print_line_no_prefix(lnum, subflags.do_number, subflags.do_list);
 
+              colnr_T sc, ec;
               getvcol(curwin, &curwin->w_cursor, &sc, NULL, NULL);
               curwin->w_cursor.col = MAX(regmatch.endpos[0].col - 1, 0);
 
@@ -3724,10 +3721,11 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
                 ec += numw;
               }
 
-              prompt = xmallocz((size_t)ec + 1);
+              char *prompt = xmallocz((size_t)ec + 1);
               memset(prompt, ' ', (size_t)sc);
               memset(prompt + sc, '^', (size_t)(ec - sc) + 1);
-              resp = getcmdline_prompt(-1, prompt, 0, EXPAND_NOTHING, NULL, CALLBACK_NONE);
+              char *resp = getcmdline_prompt(-1, prompt, 0, EXPAND_NOTHING, NULL,
+                                             CALLBACK_NONE, false, NULL);
               msg_putchar('\n');
               xfree(prompt);
               if (resp != NULL) {
@@ -3794,35 +3792,14 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
               redraw_later(curwin, UPD_SOME_VALID);
 
               curwin->w_p_fen = save_p_fen;
-              if (msg_row == Rows - 1) {
-                msg_didout = false;                     // avoid a scroll-up
-              }
-              msg_starthere();
-              i = msg_scroll;
-              msg_scroll = 0;                           // truncate msg when
-                                                        // needed
-              msg_no_more = true;
-              msg_ext_set_kind("confirm_sub");
-              // Same highlight as wait_return().
-              smsg(HLF_R, _("replace with %s (y/n/a/q/l/^E/^Y)?"), sub);
-              msg_no_more = false;
-              msg_scroll = i;
-              if (!ui_has(kUIMessages)) {
-                ui_cursor_goto(msg_row, msg_col);
-              }
-              RedrawingDisabled = temp;
 
-              no_mapping++;                     // don't map this key
-              allow_keys++;                     // allow special keys
-              typed = plain_vgetc();
-              no_mapping--;
-              allow_keys--;
+              snprintf(IObuff, IOSIZE, _("replace with %s (y/n/a/q/l/^E/^Y)?"), sub);
+              char *prompt = xstrdup(IObuff);
+              typed = prompt_for_input(prompt, HLF_R, true, NULL);
+              xfree(prompt);
 
-              // clear the question
-              msg_didout = false;               // don't scroll up
-              msg_col = 0;
-              gotocmdline(true);
               p_lz = save_p_lz;
+              RedrawingDisabled = temp;
 
               // restore the line
               if (orig_line != NULL) {
@@ -4808,7 +4785,7 @@ void ex_oldfiles(exarg_T *eap)
   // File selection prompt on ":browse oldfiles"
   if (cmdmod.cmod_flags & CMOD_BROWSE) {
     quit_more = false;
-    nr = prompt_for_number(false);
+    nr = prompt_for_input(NULL, 0, false, NULL);
     msg_starthere();
     if (nr > 0 && nr <= tv_list_len(l)) {
       const char *const p = tv_list_find_str(l, nr - 1);

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -2201,7 +2201,7 @@ static char *do_one_cmd(char **cmdlinep, int flags, cstack_T *cstack, LineGetter
           errormsg = _("E493: Backwards range given");
           goto doend;
         }
-        if (ask_yesno(_("Backwards range given, OK to swap"), false) != 'y') {
+        if (ask_yesno(_("Backwards range given, OK to swap")) != 'y') {
           goto doend;
         }
       }

--- a/src/nvim/ex_getln_defs.h
+++ b/src/nvim/ex_getln_defs.h
@@ -65,4 +65,6 @@ struct cmdline_info {
   char special_char;            ///< last putcmdline char (used for redraws)
   bool special_shift;           ///< shift of last putcmdline char
   CmdRedraw redraw_state;       ///< needed redraw for external cmdline
+  bool one_key;                 ///< return after one key press for button prompt
+  bool *mouse_used;             ///< mouse clicked in prompt
 };

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -804,8 +804,7 @@ void ml_recover(bool checkext)
       // list the names of the swapfiles
       recover_names(fname, true, NULL, 0, NULL);
       msg_putchar('\n');
-      msg_puts(_("Enter number of swap file to use (0 to quit): "));
-      i = get_number(false, NULL);
+      i = prompt_for_input(_("Enter number of swap file to use (0 to quit): "), 0, false, NULL);
       if (i < 1 || i > len) {
         goto theend;
       }

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -444,7 +444,7 @@ void spell_suggest(int count)
   char wcopy[MAXWLEN + 2];
   suginfo_T sug;
   suggest_T *stp;
-  bool mouse_used;
+  bool mouse_used = false;
   int selected = count;
   int badlen = 0;
   int msg_scroll_save = msg_scroll;
@@ -594,15 +594,11 @@ void spell_suggest(int count)
     cmdmsg_rl = false;
     msg_col = 0;
     // Ask for choice.
-    selected = prompt_for_number(&mouse_used);
-
-    if (ui_has(kUIMessages)) {
-      ui_call_msg_clear();
-    }
-
+    selected = prompt_for_input(NULL, 0, false, &mouse_used);
     if (mouse_used) {
-      selected -= lines_left;
+      selected = sug.su_ga.ga_len + 1 - (cmdline_row - mouse_row);
     }
+
     lines_left = Rows;                  // avoid more prompt
     // don't delay for 'smd' in normal_cmd()
     msg_scroll = msg_scroll_save;

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -668,7 +668,7 @@ void do_tag(char *tag, int type, int count, int forceit, bool verbose)
 
       if (ask_for_selection) {
         // Ask to select a tag from the list.
-        int i = prompt_for_number(NULL);
+        int i = prompt_for_input(NULL, 0, false, NULL);
         if (i <= 0 || i > num_matches || got_int) {
           // no valid choice: don't change anything
           if (use_tagstack) {

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -717,10 +717,10 @@ void ui_call_event(char *name, bool fast, Array args)
   bool handled = false;
   UIEventCallback *event_cb;
 
-  // Prompt messages should be shown immediately so must be safe
+  // Return prompt is still a non-fast event, other prompt messages are
+  // followed by a "cmdline_show" event.
   if (strcmp(name, "msg_show") == 0) {
-    char *kind = args.items[0].data.string.data;
-    fast = !kind || ((strncmp(kind, "confirm", 7) != 0 && strstr(kind, "_prompt") == NULL));
+    fast = !strequal(args.items[0].data.string.data, "return_prompt");
   }
 
   map_foreach(&ui_event_cbs, ui_event_ns_id, event_cb, {

--- a/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
+++ b/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
@@ -220,6 +220,7 @@ describe('swapfile detection', function()
         .. [[%.swp"]],
     }
     feed('e') -- Chose "Edit" at the swap dialog.
+    screen2:expect({ any = pesc('E5555: API call: Vim(edit):E325: ATTENTION') })
     feed('<c-c>')
     screen2:expect(expected_no_dialog)
 
@@ -535,10 +536,6 @@ describe('quitting swapfile dialog on startup stops TUI properly', function()
       )
     end)
     api.nvim_chan_send(chan, 'q')
-    retry(nil, nil, function()
-      eq('Press ENTER or type command to continue', eval("getline('$')->trim(' ', 2)"))
-    end)
-    api.nvim_chan_send(chan, '\r')
     retry(nil, nil, function()
       eq(
         { '', '[Process exited 1]', '' },

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -270,48 +270,6 @@ describe('vim.ui_attach', function()
         },
       },
     })
-    -- No fast context for prompt message kinds
-    feed(':%s/Function/Replacement/c<cr>')
-    screen:expect({
-      grid = [[
-        ^E122: {10:Function} Foo already exists, add !|
-         to replace it                          |
-        replace with Replacement (y/n/a/q/l/^E/^|
-        Y)?                                     |
-        {1:~                                       }|
-      ]],
-      cmdline = { { abort = false } },
-      messages = {
-        {
-          content = { { 'replace with Replacement (y/n/a/q/l/^E/^Y)?', 6, 18 } },
-          history = true,
-          kind = 'confirm_sub',
-        },
-      },
-    })
-    feed('<esc>:call inputlist(["Select:", "One", "Two"])<cr>')
-    screen:expect({
-      grid = [[
-        E122: {10:Function} Foo already exists, add !|
-         to replace it                          |
-        Type number and <Enter> or click with th|
-        e mouse (q or empty cancels):           |
-        {1:^~                                       }|
-      ]],
-      cmdline = { { abort = false } },
-      messages = {
-        {
-          content = { { 'Select:\nOne\nTwo\n' } },
-          history = false,
-          kind = 'list_cmd',
-        },
-        {
-          content = { { 'Type number and <Enter> or click with the mouse (q or empty cancels): ' } },
-          history = false,
-          kind = 'number_prompt',
-        },
-      },
-    })
   end)
 end)
 

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -1485,31 +1485,28 @@ describe('cmdheight=0', function()
   it('when substitute text', function()
     command('set cmdheight=0 noruler laststatus=3')
     feed('ifoo<ESC>')
-    screen:expect {
-      grid = [[
+    screen:try_resize(screen._width, 6)
+    screen:expect([[
       fo^o                      |
-      {1:~                        }|*3
+      {1:~                        }|*4
       {3:[No Name] [+]            }|
-    ]],
-    }
+    ]])
 
     feed(':%s/foo/bar/gc<CR>')
-    screen:expect {
-      grid = [[
+    screen:expect([[
       {2:foo}                      |
-      {1:~                        }|*3
-      {6:replace wi...q/l/^E/^Y)?}^ |
-    ]],
-    }
+      {3:                         }|
+                               |*2
+      {6:replace with bar (y/n/a/q}|
+      {6:/l/^E/^Y)?}^               |
+    ]])
 
     feed('y')
-    screen:expect {
-      grid = [[
+    screen:expect([[
       ^bar                      |
-      {1:~                        }|*3
+      {1:~                        }|*4
       {3:[No Name] [+]            }|
-    ]],
-    }
+    ]])
 
     assert_alive()
   end)

--- a/test/functional/ui/input_spec.lua
+++ b/test/functional/ui/input_spec.lua
@@ -368,7 +368,7 @@ describe('input non-printable chars', function()
       "Xtest-overwrite"                                           |
       {9:WARNING: The file has been changed since reading it!!!}      |
       {6:Do you really want to write to it (y/n)?}u                   |
-      {6:Do you really want to write to it (y/n)?}                    |
+      {6:Do you really want to write to it (y/n)?}{18:^E}                  |
       {6:Do you really want to write to it (y/n)?}^                    |
     ]])
 
@@ -379,7 +379,7 @@ describe('input non-printable chars', function()
       "Xtest-overwrite"                                           |
       {9:WARNING: The file has been changed since reading it!!!}      |
       {6:Do you really want to write to it (y/n)?}u                   |
-      {6:Do you really want to write to it (y/n)?}                    |
+      {6:Do you really want to write to it (y/n)?}{18:^E}                  |
       {6:Do you really want to write to it (y/n)?}n                   |
       {6:Press ENTER or type command to continue}^                     |
     ]])

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -42,55 +42,75 @@ describe('ui/ext_messages', function()
   it('msg_clear follows msg_show kind of confirm', function()
     feed('iline 1<esc>')
     feed(':call confirm("test")<cr>')
-    screen:expect {
+    screen:expect({
       grid = [[
-      line ^1                   |
-      {1:~                        }|*4
-    ]],
-      cmdline = { { abort = false } },
+        line ^1                   |
+        {1:~                        }|*4
+      ]],
+      cmdline = {
+        {
+          content = { { '' } },
+          hl_id = 10,
+          pos = 0,
+          prompt = '[O]k: ',
+        },
+      },
       messages = {
         {
-          content = { { '\ntest\n[O]k: ', 6, 10 } },
+          content = { { '\ntest\n', 6, 10 } },
           history = false,
           kind = 'confirm',
         },
       },
-    }
-
+    })
     feed('<cr>')
-    screen:expect {
+    screen:expect({
       grid = [[
-      line ^1                   |
-      {1:~                        }|*4
-    ]],
-    }
+        line ^1                   |
+        {1:~                        }|*4
+      ]],
+      cmdline = { { abort = false } },
+    })
   end)
 
   it('msg_show kinds', function()
     feed('iline 1\nline 2<esc>')
 
-    -- kind=confirm
+    -- confirm is now cmdline prompt
     feed(':echo confirm("test")<cr>')
-    screen:expect {
+    screen:expect({
       grid = [[
-      line 1                   |
-      line ^2                   |
-      {1:~                        }|*3
-    ]],
-      cmdline = { { abort = false } },
+        line 1                   |
+        line ^2                   |
+        {1:~                        }|*3
+      ]],
+      cmdline = {
+        {
+          content = { { '' } },
+          hl_id = 10,
+          pos = 0,
+          prompt = '[O]k: ',
+        },
+      },
       messages = {
         {
-          content = { { '\ntest\n[O]k: ', 6, 10 } },
+          content = { { '\ntest\n', 6, 10 } },
           history = false,
           kind = 'confirm',
         },
       },
-    }
-    feed('<cr><cr>')
-    screen:expect {
+    })
+    feed('<cr>')
+    screen:expect({
+      grid = [[
+        line 1                   |
+        line ^2                   |
+        {1:~                        }|*3
+      ]],
+      cmdline = { { abort = false } },
       messages = {
         {
-          content = { { '\ntest\n[O]k: ', 6, 10 } },
+          content = { { '\ntest\n', 6, 10 } },
           history = false,
           kind = 'confirm',
         },
@@ -105,38 +125,39 @@ describe('ui/ext_messages', function()
           kind = 'return_prompt',
         },
       },
-    }
-    feed('<cr><cr>')
+    })
+    feed('<cr>')
 
-    -- kind=confirm_sub
+    -- :substitute confirm is now cmdline prompt
     feed(':%s/i/X/gc<cr>')
-    screen:expect {
+    screen:expect({
       grid = [[
-      l{2:i}ne 1                   |
-      l{10:i}ne ^2                   |
-      {1:~                        }|*3
-    ]],
-      cmdline = { { abort = false } },
-      messages = {
+        l{2:^i}ne 1                   |
+        l{10:i}ne 2                   |
+        {1:~                        }|*3
+      ]],
+      cmdline = {
         {
-          content = { { 'replace with X (y/n/a/q/l/^E/^Y)?', 6, 18 } },
-          history = true,
-          kind = 'confirm_sub',
+          content = { { '' } },
+          hl_id = 18,
+          pos = 0,
+          prompt = 'replace with X (y/n/a/q/l/^E/^Y)?',
         },
       },
-    }
+    })
     feed('nq')
 
     -- kind=wmsg (editing readonly file)
     command('write ' .. fname)
     command('set readonly nohls')
     feed('G$x')
-    screen:expect {
+    screen:expect({
       grid = [[
         line 1                   |
-        line ^2                   |
+        line^                     |
         {1:~                        }|*3
       ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = { { 'W10: Warning: Changing a readonly file', 19, 26 } },
@@ -144,7 +165,7 @@ describe('ui/ext_messages', function()
           kind = 'wmsg',
         },
       },
-    }
+    })
 
     -- kind=wmsg ('wrapscan' after search reaches EOF)
     feed('uG$/i<cr>')
@@ -1122,20 +1143,22 @@ stack traceback:
     feed('z=')
     screen:expect({
       grid = [[
-        {100:helllo}                   |
-        {1:~                        }|*3
-        {1:^~                        }|
+        {100:^helllo}                   |
+        {1:~                        }|*4
       ]],
+      cmdline = {
+        {
+          content = { { '' } },
+          hl_id = 0,
+          pos = 0,
+          prompt = 'Type number and <Enter> or click with the mouse (q or empty cancels):',
+        },
+      },
       messages = {
         {
           content = { { 'Change "helllo" to:\n 1 "Hello"\n 2 "Hallo"\n 3 "Hullo"\n' } },
           history = false,
           kind = 'list_cmd',
-        },
-        {
-          content = { { 'Type number and <Enter> or click with the mouse (q or empty cancels): ' } },
-          history = false,
-          kind = 'number_prompt',
         },
       },
     })
@@ -1143,36 +1166,34 @@ stack traceback:
     feed('1')
     screen:expect({
       grid = [[
-        {100:helllo}                   |
-        {1:~                        }|*3
-        {1:^~                        }|
+        {100:^helllo}                   |
+        {1:~                        }|*4
       ]],
+      cmdline = {
+        {
+          content = { { '1' } },
+          hl_id = 0,
+          pos = 1,
+          prompt = 'Type number and <Enter> or click with the mouse (q or empty cancels):',
+        },
+      },
       messages = {
         {
           content = { { 'Change "helllo" to:\n 1 "Hello"\n 2 "Hallo"\n 3 "Hullo"\n' } },
           history = false,
           kind = 'list_cmd',
         },
-        {
-          content = { { 'Type number and <Enter> or click with the mouse (q or empty cancels): ' } },
-          history = false,
-          kind = 'number_prompt',
-        },
-        {
-          content = { { '1' } },
-          history = false,
-          kind = '',
-        },
       },
     })
 
     feed('<cr>')
-    screen:expect {
+    screen:expect({
       grid = [[
-      ^Hello                    |
-      {1:~                        }|*4
-    ]],
-    }
+        ^Hello                    |
+        {1:~                        }|*4
+      ]],
+      cmdline = { { abort = false } },
+    })
   end)
 
   it('supports nvim_echo messages with multiple attrs', function()

--- a/test/functional/vimscript/null_spec.lua
+++ b/test/functional/vimscript/null_spec.lua
@@ -116,7 +116,7 @@ describe('NULL', function()
     null_expr_test(
       'is accepted as an empty list by inputlist()',
       '[feedkeys("\\n"), inputlist(L)]',
-      'Type number and <Enter> or click with the mouse (q or empty cancels): ',
+      '',
       { 0, 0 }
     )
     null_expr_test(

--- a/test/old/testdir/test_spell.vim
+++ b/test/old/testdir/test_spell.vim
@@ -471,7 +471,9 @@ func Test_spellsuggest_option_number()
   \ .. "Change \"baord\" to:\n"
   \ .. " 1 \"board\"\n"
   \ .. " 2 \"bard\"\n"
-  \ .. "Type number and <Enter> or click with the mouse (q or empty cancels): ", a)
+  "\ Nvim: Prompt message is sent to cmdline prompt.
+  "\ .. "Type number and <Enter> or click with the mouse (q or empty cancels): ", a)
+  \ , a)
 
   set spell spellsuggest=0
   call assert_equal("\nSorry, no suggestions", execute('norm $z='))
@@ -509,7 +511,9 @@ func Test_spellsuggest_option_expr()
   \ .. " 1 \"BARD\"\n"
   \ .. " 2 \"BOARD\"\n"
   \ .. " 3 \"BROAD\"\n"
-  \ .. "Type number and <Enter> or click with the mouse (q or empty cancels): ", a)
+  "\ Nvim: Prompt message is sent to cmdline prompt.
+  "\ .. "Type number and <Enter> or click with the mouse (q or empty cancels): ", a)
+  \ , a)
 
   " With verbose, z= should show the score i.e. word length with
   " our SpellSuggest() function.
@@ -521,7 +525,9 @@ func Test_spellsuggest_option_expr()
   \ .. " 1 \"BARD\"                      (4 - 0)\n"
   \ .. " 2 \"BOARD\"                     (5 - 0)\n"
   \ .. " 3 \"BROAD\"                     (5 - 0)\n"
-  \ .. "Type number and <Enter> or click with the mouse (q or empty cancels): ", a)
+  "\ Nvim: Prompt message is sent to cmdline prompt.
+  "\ .. "Type number and <Enter> or click with the mouse (q or empty cancels): ", a)
+  \ , a)
 
   set spell& spellsuggest& verbose&
   bwipe!

--- a/test/old/testdir/test_tagjump.vim
+++ b/test/old/testdir/test_tagjump.vim
@@ -1231,8 +1231,10 @@ func Test_tselect_listing()
   2 FS  v    first             Xfoo
                typeref:typename:char 
                2
-Type number and <Enter> (q or empty cancels): 
 [DATA]
+" Type number and <Enter> (q or empty cancels):
+" Nvim: Prompt message is sent to cmdline prompt.
+
   call assert_equal(expected, l)
 
   call delete('Xtags')


### PR DESCRIPTION
Problem:  Prompts are emitted as message events, where cmdline events
          are more appropriate. The user input is also emitted as
          message events in fast context, so cannot be displayed with
          vim.ui_attach().
Solution: Ask for user input through cmdline prompts.