### PR TITLE
fix(events): don't expand `args.file` for Lua callback (#31473)

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3496,9 +3496,9 @@ nvim_create_autocmd({event}, {opts})                   *nvim_create_autocmd()*
                    • event: (string) name of the triggered event
                      |autocmd-events|
                    • group: (number|nil) autocommand group id, if any
-                   • match: (string) expanded value of <amatch>
-                   • buf: (number) expanded value of <abuf>
-                   • file: (string) expanded value of <afile>
+                   • file: (string) <afile> (not expanded to a full path)
+                   • match: (string) <amatch> (expanded to a full path)
+                   • buf: (number) <abuf>
                    • data: (any) arbitrary data passed from
                      |nvim_exec_autocmds()|                       *event-data*
                  • command (string) optional: Vim command to execute on event.

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -956,9 +956,9 @@ function vim.api.nvim_create_augroup(name, opts) end
 ---               • event: (string) name of the triggered event
 ---                 `autocmd-events`
 ---               • group: (number|nil) autocommand group id, if any
----               • match: (string) expanded value of <amatch>
----               • buf: (number) expanded value of <abuf>
----               • file: (string) expanded value of <afile>
+---               • file: (string) <afile> (not expanded to a full path)
+---               • match: (string) <amatch> (expanded to a full path)
+---               • buf: (number) <abuf>
 ---               • data: (any) arbitrary data passed from
 ---                 `nvim_exec_autocmds()`                        *event-data*
 ---             • command (string) optional: Vim command to execute on event.

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -386,9 +386,9 @@ cleanup:
 ///                 - id: (number) autocommand id
 ///                 - event: (string) name of the triggered event |autocmd-events|
 ///                 - group: (number|nil) autocommand group id, if any
-///                 - match: (string) expanded value of [<amatch>]
-///                 - buf: (number) expanded value of [<abuf>]
-///                 - file: (string) expanded value of [<afile>]
+///                 - file: (string) [<afile>] (not expanded to a full path)
+///                 - match: (string) [<amatch>] (expanded to a full path)
+///                 - buf: (number) [<abuf>]
 ///                 - data: (any) arbitrary data passed from [nvim_exec_autocmds()] [event-data]()
 ///             - command (string) optional: Vim command to execute on event. Cannot be used with
 ///             {callback}

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1665,7 +1665,9 @@ bool apply_autocmds_group(event_T event, char *fname, char *fname_io, bool force
   } else {
     autocmd_fname = fname_io;
   }
+  char *afile_orig = NULL;  ///< Unexpanded <afile>
   if (autocmd_fname != NULL) {
+    afile_orig = xstrdup(autocmd_fname);
     // Allocate MAXPATHL for when eval_vars() resolves the fullpath.
     autocmd_fname = xstrnsave(autocmd_fname, MAXPATHL);
   }
@@ -1783,6 +1785,7 @@ bool apply_autocmds_group(event_T event, char *fname, char *fname_io, bool force
     // save vector size, to avoid an endless loop when more patterns
     // are added when executing autocommands
     .ausize = kv_size(autocmds[(int)event]),
+    .afile_orig = afile_orig,
     .fname = fname,
     .sfname = sfname,
     .tail = tail,
@@ -1850,6 +1853,7 @@ bool apply_autocmds_group(event_T event, char *fname, char *fname_io, bool force
   autocmd_nested = save_autocmd_nested;
   xfree(SOURCING_NAME);
   estack_pop();
+  xfree(afile_orig);
   xfree(autocmd_fname);
   autocmd_fname = save_autocmd_fname;
   autocmd_fname_full = save_autocmd_fname_full;
@@ -2014,8 +2018,8 @@ static bool call_autocmd_callback(const AutoCmd *ac, const AutoPatCmd *apc)
     MAXSIZE_TEMP_DICT(data, 7);
     PUT_C(data, "id", INTEGER_OBJ(ac->id));
     PUT_C(data, "event", CSTR_AS_OBJ(event_nr2name(apc->event)));
+    PUT_C(data, "file", CSTR_AS_OBJ(apc->afile_orig));
     PUT_C(data, "match", CSTR_AS_OBJ(autocmd_match));
-    PUT_C(data, "file", CSTR_AS_OBJ(autocmd_fname));
     PUT_C(data, "buf", INTEGER_OBJ(autocmd_bufnr));
 
     if (apc->data) {

--- a/src/nvim/autocmd_defs.h
+++ b/src/nvim/autocmd_defs.h
@@ -52,6 +52,7 @@ struct AutoPatCmd_S {
   AutoPat *lastpat;         ///< Last matched AutoPat
   size_t auidx;             ///< Current autocmd index to execute
   size_t ausize;            ///< Saved AutoCmd vector size
+  char *afile_orig;         ///< Unexpanded <afile>
   char *fname;              ///< Fname to match with
   char *sfname;             ///< Sfname to match with
   char *tail;               ///< Tail of fname


### PR DESCRIPTION
Problem:  In an autocommand Lua callback whether `args.file` is expanded
          depends on whether `expand('<afile>')` has been called.
Solution: Always use the unexpanded file name for `args.file`.

Related to #31306 and vim/vim#16106. This doesn't provide `sfname`, but
at least makes `args.file` have a consistent value.
