### PR TITLE
Can skip defaults.lua from user configuration

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -350,6 +350,11 @@ These existing features changed their behavior.
   `%t%(\ %M%)%(\ \(%{expand(\"%:~:h\")}\)%)%a\ -\ Nvim`. This is only an
   implementation simplification, not a behavior change.
 
+• Default `_defaults.lua` is loaded after user config. `_defaults.lua` loading
+  is disabled when "g:skip_defaults_lua" variables are set.
+  See |startup|.
+
+
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*
 

--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -515,7 +515,18 @@ accordingly, proceeding as follows:
 <	Skipped if ":syntax off" was called or if the "-u NONE" command
 	line argument was given.
 
-10. Load the plugin scripts.					*load-plugins*
+10. Load "_defaults.lua" script.
+	It enables default configuration.
+	Skipped if "g:skip_defaults_lua" variables are set.
+
+	- g:skip_defaults_lua : Disable all default configuration
+	- g:skip_defaults_lua_commands : Disable default commands
+	- g:skip_defaults_lua_mappings : Disable |default-mappings|
+	- g:skip_defaults_lua_menus : Disable default menus
+	- g:skip_defaults_lua_autocmds : Disable |default-autocmds|
+	- g:skip_defaults_lua_options : Disable default options
+
+11. Load the plugin scripts.					*load-plugins*
 	This does the same as the command: >
 		:runtime! plugin/**/*.{vim,lua}
 <	The result is that all directories in 'runtimepath' will be searched
@@ -545,21 +556,21 @@ accordingly, proceeding as follows:
 	if packages have been found, but that should not add a directory
 	ending in "after".
 
-11. Set 'shellpipe' and 'shellredir'
+12. Set 'shellpipe' and 'shellredir'
 	The 'shellpipe' and 'shellredir' options are set according to the
 	value of the 'shell' option, unless they have been set before.
 	This means that Nvim will figure out the values of 'shellpipe' and
 	'shellredir' for you, unless you have set them yourself.
 
-12. Set 'updatecount' to zero, if "-n" command argument used.
+13. Set 'updatecount' to zero, if "-n" command argument used.
 
-13. Set binary options if the |-b| flag was given.
+14. Set binary options if the |-b| flag was given.
 
-14. Read the |shada-file|.
+15. Read the |shada-file|.
 
-15. Read the quickfix file if the |-q| flag was given, or exit on failure.
+16. Read the quickfix file if the |-q| flag was given, or exit on failure.
 
-16. Open all windows
+17. Open all windows
 	When the |-o| flag was given, windows will be opened (but not
 	displayed yet).
 	When the |-p| flag was given, tab pages will be created (but not
@@ -569,7 +580,7 @@ accordingly, proceeding as follows:
 	Buffers for all windows will be loaded, without triggering |BufAdd|
 	autocommands.
 
-17. Execute startup commands
+18. Execute startup commands
 	If a |-t| flag was given, the tag is jumped to.
 	Commands given with |-c| and |+cmd| are executed.
 	The starting flag is reset, has("vim_starting") will now return zero.

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -1,5 +1,9 @@
+if vim.fn.get(vim.g, 'skip_defaults_lua', 0) then
+  return
+end
+
 --- Default user commands
-do
+if not vim.fn.get(vim.g, 'skip_defaults_lua_commands', 0) then
   vim.api.nvim_create_user_command('Inspect', function(cmd)
     if cmd.bang then
       vim.print(vim.inspect_pos())
@@ -27,7 +31,7 @@ do
 end
 
 --- Default mappings
-do
+if not vim.fn.get(vim.g, 'skip_defaults_lua_mappings', 0) then
   --- Default maps for * and # in visual mode.
   ---
   --- See |v_star-default| and |v_#-default|
@@ -380,7 +384,7 @@ do
 end
 
 --- Default menus
-do
+if not vim.fn.get(vim.g, 'skip_defaults_lua_menus', 0) then
   --- Right click popup menu
   vim.cmd([[
     anoremenu PopUp.Go\ to\ definition      <Cmd>lua vim.lsp.buf.definition()<CR>
@@ -428,7 +432,7 @@ do
 end
 
 --- Default autocommands. See |default-autocmds|
-do
+if not vim.fn.get(vim.g, 'skip_defaults_lua_autocmds', 0) then
   local nvim_terminal_augroup = vim.api.nvim_create_augroup('nvim_terminal', {})
   vim.api.nvim_create_autocmd('BufReadCmd', {
     pattern = 'term://*',
@@ -805,7 +809,7 @@ do
 end
 
 --- Default options
-do
+if not vim.fn.get(vim.g, 'skip_defaults_lua_options', 0) then
   --- Default 'grepprg' to ripgrep if available.
   if vim.fn.executable('rg') == 1 then
     -- Use -uu to make ripgrep not check ignore files/skip dot-files

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -429,10 +429,6 @@ int main(int argc, char **argv)
     }
   }
 
-  nlua_init_defaults();
-
-  TIME_MSG("init default mappings & autocommands");
-
   bool vimrc_none = strequal(params.use_vimrc, "NONE");
 
   // Reset 'loadplugins' for "-u NONE" before "--cmd" arguments.
@@ -461,6 +457,10 @@ int main(int argc, char **argv)
     // disable syntax highlighting with `:syntax off` if they wish.
     syn_maybe_enable();
   }
+
+  nlua_init_defaults();
+
+  TIME_MSG("init default mappings & autocommands");
 
   // Read all the plugin files.
   load_plugins();


### PR DESCRIPTION
Fix #31506 

Current problem: `_default.lua` loading cannot be disabled by user

Solution: `_defaults.lua` can be skipped by `g:skip_defaults_lua` variable like Vim's defaults.vim

current problem:  `grepprg` option is overwritten force.