### PR TITLE
g:{filetype}_no_treesitter variables are added

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1386,6 +1386,12 @@ will force TeX highlighting for a particular buffer.  It has to be
 set before turning syntax highlighting on for the buffer or
 loading a file.
 
+HELP						*html.vim* *ft-help-syntax*
+
+						*g:help_no_treesitter*
+By default, use treesitter over syntax.  It is disabled by setting
+g:help_no_treesitter to true.
+
 
 HTML						*html.vim* *ft-html-syntax*
 
@@ -1863,6 +1869,10 @@ lua_version and lua_subversion. For example, to activate Lua
 
 	:let lua_version = 5
 	:let lua_subversion = 1
+<
+						*g:lua_no_treesitter*
+By default, use treesitter over syntax.  It is disabled by setting
+g:lua_no_treesitter to true.
 
 
 MAIL						*mail.vim* *ft-mail.vim*
@@ -2671,6 +2681,12 @@ set to highlight commands only available in Quake 3 Arena: >
 
 Any combination of these three variables is legal, but might highlight more
 commands than are actually available to you by the game.
+
+QUERY						*ft-query-syntax*
+
+						*g:query_no_treesitter*
+By default, use treesitter over syntax.  It is disabled by setting
+g:query_no_treesitter to true.
 
 
 R							*r.vim* *ft-r-syntax*

--- a/runtime/ftplugin/help.lua
+++ b/runtime/ftplugin/help.lua
@@ -1,5 +1,7 @@
 -- use treesitter over syntax (for highlighted code blocks)
-vim.treesitter.start()
+if not vim.fn.get(vim.g, 'help_no_treesitter', 0) then
+  vim.treesitter.start()
+end
 
 -- Add custom highlights for list in `:h highlight-groups`.
 local bufname = vim.fs.normalize(vim.api.nvim_buf_get_name(0))

--- a/runtime/ftplugin/lua.lua
+++ b/runtime/ftplugin/lua.lua
@@ -1,4 +1,6 @@
 -- use treesitter over syntax
-vim.treesitter.start()
+if not vim.fn.get(vim.g, 'vim_no_treesitter', 0) then
+  vim.treesitter.start()
+end
 
 vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n call v:lua.vim.treesitter.stop()'

--- a/runtime/ftplugin/query.lua
+++ b/runtime/ftplugin/query.lua
@@ -8,7 +8,9 @@ end
 -- Do not set vim.b.did_ftplugin = 1 to allow loading of ftplugin/lisp.vim
 
 -- use treesitter over syntax
-vim.treesitter.start()
+if not vim.fn.get(vim.g, 'query_no_treesitter', 0) then
+  vim.treesitter.start()
+end
 
 -- set omnifunc
 vim.bo.omnifunc = 'v:lua.vim.treesitter.query.omnifunc'


### PR DESCRIPTION
Problem: Current `vim.treesitter.start()` cannot be disabled by users in ftplugins.

Solution: Add `g:{filetype}_no_treesitter` variables.