### PR TITLE
feat(runtime): add support for switching between if-else and switch statements in C files using `%`

### DIFF
--- a/runtime/ftplugin/c.lua
+++ b/runtime/ftplugin/c.lua
@@ -12,3 +12,6 @@ if vim.fn.isdirectory('/usr/include') == 1 then
 end
 
 vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring< define< include< path<'
+vim.b.match_words = vim.b.match_words..
+  ",\\<switch\\>:\\<case\\>:\\<default\\>".. -- (switches)
+  ",\\(else\\s\\+\\)\\@<!if\\>:\\<else\\s\\+if\\>:\\<else\\(\\s\\+if\\)\\@!\\>".. -- (if else if else statements)

--- a/runtime/ftplugin/c.lua
+++ b/runtime/ftplugin/c.lua
@@ -14,4 +14,4 @@ end
 vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring< define< include< path<'
 vim.b.match_words = vim.b.match_words..
   ",\\<switch\\>:\\<case\\>:\\<default\\>".. -- (switches)
-  ",\\(else\\s\\+\\)\\@<!if\\>:\\<else\\s\\+if\\>:\\<else\\(\\s\\+if\\)\\@!\\>".. -- (if else if else statements)
+  ",\\(else\\s\\+\\)\\@<!if\\>:\\<else\\s\\+if\\>:\\<else\\(\\s\\+if\\)\\@!\\>" -- (if else if else statements)


### PR DESCRIPTION
Problem:
even though you can switch between if else statements using matchit in a lot of files, you currently can't do that in c, even though it should be a simple regex

Solution:
extend the vim.b.match_words option in the c filetype plugin so that it includes the regexes for switching if else and switch statements.