### PR TITLE
Added missing return types for the auto-generated Lua documentation

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1407,7 +1407,7 @@ ctxset({context} [, {index}])                                         *ctxset()*
                   • {index} (`integer?`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 ctxsize()                                                            *ctxsize()*
 		Returns the size of the |context-stack|.
@@ -1618,7 +1618,7 @@ did_filetype()                                                  *did_filetype()*
 		file.
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 diff_filler({lnum})                                              *diff_filler()*
 		Returns the number of filler lines above line {lnum}.
@@ -1633,7 +1633,7 @@ diff_filler({lnum})                                              *diff_filler()*
                   • {lnum} (`integer`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 diff_hlID({lnum}, {col})                                           *diff_hlID()*
 		Returns the highlight ID for diff mode at line {lnum} column
@@ -1674,7 +1674,7 @@ digraph_get({chars})                                       *digraph_get()* *E121
                   • {chars} (`string`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 digraph_getlist([{listall}])                                 *digraph_getlist()*
 		Return a list of digraphs.  If the {listall} argument is given
@@ -1695,7 +1695,7 @@ digraph_getlist([{listall}])                                 *digraph_getlist()*
                   • {listall} (`boolean?`)
 
                 Return: ~
-                  (`any`)
+                  (`string[][]`)
 
 digraph_set({chars}, {digraph})                                  *digraph_set()*
 		Add digraph {chars} to the list.  {chars} must be a string
@@ -1756,7 +1756,7 @@ empty({expr})                                                          *empty()*
                   • {expr} (`any`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 environ()                                                            *environ()*
 		Return all of environment variables as dictionary. You can
@@ -1783,7 +1783,7 @@ escape({string}, {chars})                                             *escape()*
                   • {chars} (`string`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 eval({string})                                                          *eval()*
 		Evaluate {string} and return the result.  Especially useful to
@@ -2666,7 +2666,7 @@ foreach({expr1}, {expr2})                                            *foreach()*
                   • {expr2} (`string|function`)
 
                 Return: ~
-                  (`any`)
+                  (`string|table`)
 
 fullcommand({name})                                              *fullcommand()*
 		Get the full command name from a short abbreviated command
@@ -3000,7 +3000,7 @@ getbufline({buf}, {lnum} [, {end}])                               *getbufline()*
                   • {end} (`integer?`)
 
                 Return: ~
-                  (`any`)
+                  (`string[]`)
 
 getbufoneline({buf}, {lnum})                                   *getbufoneline()*
 		Just like `getbufline()` but only get one line and return it
@@ -3295,7 +3295,7 @@ getcmdscreenpos()                                            *getcmdscreenpos()*
 		|setcmdline()|.
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 getcmdtype()                                                      *getcmdtype()*
 		Return the current command-line type. Possible return values
@@ -4299,7 +4299,7 @@ gettext({text})                                                      *gettext()*
                   • {text} (`string`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 getwininfo([{winid}])                                             *getwininfo()*
 		Returns information about windows as a |List| with Dictionaries.
@@ -4467,7 +4467,7 @@ glob2regpat({string})                                            *glob2regpat()*
                   • {string} (`string`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 globpath({path}, {expr} [, {nosuf} [, {list} [, {allinks}]]])       *globpath()*
 		Perform glob() for String {expr} on all directories in {path}
@@ -4824,7 +4824,7 @@ iconv({string}, {from}, {to})                                          *iconv()*
                   • {to} (`string`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 id({expr})                                                                *id()*
 		Returns a |String| which is a unique identifier of the
@@ -4847,7 +4847,7 @@ id({expr})                                                                *id()*
                   • {expr} (`any`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 indent({lnum})                                                        *indent()*
 		The result is a Number, which is indent of line {lnum} in the
@@ -4897,7 +4897,7 @@ index({object}, {expr} [, {start} [, {ic}]])                           *index()*
                   • {ic} (`boolean?`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 indexof({object}, {expr} [, {opts}])                                 *indexof()*
 		Returns the index of an item in {object} where {expr} is
@@ -4944,7 +4944,7 @@ indexof({object}, {expr} [, {opts}])                                 *indexof()*
                   • {opts} (`table?`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 input({prompt} [, {text} [, {completion}]])                            *input()*
 
@@ -4954,7 +4954,7 @@ input({prompt} [, {text} [, {completion}]])                            *input()*
                   • {completion} (`string?`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 input({opts})
 		The result is a String, which is whatever the user typed on
@@ -5071,7 +5071,7 @@ input({opts})
                   • {opts} (`table`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 inputlist({textlist})                                              *inputlist()*
 		{textlist} must be a |List| of strings.  This |List| is
@@ -5103,7 +5103,7 @@ inputrestore()                                                  *inputrestore()*
 		Returns TRUE when there is nothing to restore, FALSE otherwise.
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 inputsave()                                                        *inputsave()*
 		Preserve typeahead (also from mappings) and clear it, so that
@@ -5114,7 +5114,7 @@ inputsave()                                                        *inputsave()*
 		Returns TRUE when out of memory, FALSE otherwise.
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 inputsecret({prompt} [, {text}])                                 *inputsecret()*
 		This function acts much like the |input()| function with but
@@ -5132,7 +5132,7 @@ inputsecret({prompt} [, {text}])                                 *inputsecret()*
                   • {text} (`string?`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 insert({object}, {item} [, {idx}])                                    *insert()*
 		When {object} is a |List| or a |Blob| insert {item} at the start
@@ -5183,10 +5183,10 @@ invert({expr})                                                        *invert()*
 <
 
                 Parameters: ~
-                  • {expr} (`number`)
+                  • {expr} (`integer`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 isabsolutepath({path})                                        *isabsolutepath()*
 		The result is a Number, which is |TRUE| when {path} is an
@@ -5399,7 +5399,7 @@ jobstart({cmd} [, {opts}])                                          *jobstart()*
                   • {opts} (`table?`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 jobstop({id})                                                        *jobstop()*
 		Stop |job-id| {id} by sending SIGTERM to the job process. If
@@ -5415,7 +5415,7 @@ jobstop({id})                                                        *jobstop()*
                   • {id} (`integer`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 jobwait({jobs} [, {timeout}])                                        *jobwait()*
 		Waits for jobs and their |on_exit| handlers to complete.
@@ -5461,7 +5461,7 @@ join({list} [, {sep}])                                                  *join()*
                   • {sep} (`string?`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 json_decode({expr})                                              *json_decode()*
 		Convert {expr} from JSON object.  Accepts |readfile()|-style
@@ -5500,7 +5500,7 @@ json_encode({expr})                                              *json_encode()*
                   • {expr} (`any`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 keys({dict})                                                            *keys()*
 		Return a |List| with all the keys of {dict}.  The |List| is in
@@ -5510,7 +5510,7 @@ keys({dict})                                                            *keys()*
                   • {dict} (`table`)
 
                 Return: ~
-                  (`any`)
+                  (`string[]`)
 
 keytrans({string})                                                  *keytrans()*
 		Turn the internal byte representation of keys into a form that
@@ -5523,7 +5523,7 @@ keytrans({string})                                                  *keytrans()*
                   • {string} (`string`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 len({expr})                                                         *len()* *E701*
 		The result is a Number, which is the length of the argument.
@@ -5537,10 +5537,10 @@ len({expr})                                                         *len()* *E70
 		Otherwise an error is given and returns zero.
 
                 Parameters: ~
-                  • {expr} (`any`)
+                  • {expr} (`any[]`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 libcall({libname}, {funcname}, {argument})                 *libcall()* *E364* *E368*
 		Call function {funcname} in the run-time library {libname}
@@ -5666,7 +5666,7 @@ lispindent({lnum})                                                *lispindent()*
                   • {lnum} (`integer`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 list2blob({list})                                                  *list2blob()*
 		Return a Blob concatenating all the number values in {list}.
@@ -5682,7 +5682,7 @@ list2blob({list})                                                  *list2blob()*
                   • {list} (`any[]`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 list2str({list} [, {utf8}])                                         *list2str()*
 		Convert each number in {list} to a character string can
@@ -5705,14 +5705,14 @@ list2str({list} [, {utf8}])                                         *list2str()*
                   • {utf8} (`boolean?`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 localtime()                                                        *localtime()*
 		Return the current time, measured as seconds since 1st Jan
 		1970.  See also |strftime()|, |strptime()| and |getftime()|.
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 log({expr})                                                              *log()*
 		Return the natural logarithm (base e) of {expr} as a |Float|.
@@ -5729,7 +5729,7 @@ log({expr})                                                              *log()*
                   • {expr} (`number`)
 
                 Return: ~
-                  (`any`)
+                  (`number`)
 
 log10({expr})                                                          *log10()*
 		Return the logarithm of Float {expr} to base 10 as a |Float|.
@@ -5745,7 +5745,7 @@ log10({expr})                                                          *log10()*
                   • {expr} (`number`)
 
                 Return: ~
-                  (`any`)
+                  (`number`)
 
 luaeval({expr} [, {expr}])                                           *luaeval()*
 		Evaluate Lua expression {expr} and return its result converted
@@ -6714,7 +6714,7 @@ min({expr})                                                              *min()*
                   • {expr} (`any`)
 
                 Return: ~
-                  (`any`)
+                  (`number`)
 
 mkdir({name} [, {flags} [, {prot}]])                              *mkdir()* *E739*
 		Create directory {name}.
@@ -6762,7 +6762,7 @@ mkdir({name} [, {flags} [, {prot}]])                              *mkdir()* *E73
                   • {prot} (`string?`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 mode([{expr}])                                                          *mode()*
 		Return a string that indicates the current mode.
@@ -6937,7 +6937,7 @@ nextnonblank({lnum})                                            *nextnonblank()*
                   • {lnum} (`integer`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 nr2char({expr} [, {utf8}])                                           *nr2char()*
 		Return a string with a single character, which has the number
@@ -6959,7 +6959,7 @@ nr2char({expr} [, {utf8}])                                           *nr2char()*
                   • {utf8} (`boolean?`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 nvim_...({...})                                      *nvim_...()* *E5555* *eval-api*
 		Call nvim |api| functions. The type checking of arguments will
@@ -7016,7 +7016,7 @@ pathshorten({path} [, {len}])                                    *pathshorten()*
                   • {len} (`integer?`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 perleval({expr})                                                    *perleval()*
 		Evaluate |perl| expression {expr} and return its result
@@ -7056,7 +7056,7 @@ pow({x}, {y})                                                            *pow()*
                   • {y} (`number`)
 
                 Return: ~
-                  (`any`)
+                  (`number`)
 
 prevnonblank({lnum})                                            *prevnonblank()*
 		Return the line number of the first line at or above {lnum}
@@ -7071,7 +7071,7 @@ prevnonblank({lnum})                                            *prevnonblank()*
                   • {lnum} (`integer`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 printf({fmt}, {expr1} ...)                                            *printf()*
 		Return a String with {fmt}, where "%" items are replaced by
@@ -7901,7 +7901,7 @@ rename({from}, {to})                                                  *rename()*
                   • {to} (`string`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 repeat({expr}, {count})                                               *repeat()*
 		Repeat {expr} {count} times and return the concatenated
@@ -7937,7 +7937,7 @@ resolve({filename})                                             *resolve()* *E65
                   • {filename} (`string`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 reverse({object})                                                    *reverse()*
 		Reverse the order of items in {object}.  {object} can be a
@@ -7974,7 +7974,7 @@ round({expr})                                                          *round()*
                   • {expr} (`number`)
 
                 Return: ~
-                  (`any`)
+                  (`number`)
 
 rpcnotify({channel}, {event} [, {args}...])                        *rpcnotify()*
 		Sends {event} to {channel} via |RPC| and returns immediately.
@@ -7989,7 +7989,7 @@ rpcnotify({channel}, {event} [, {args}...])                        *rpcnotify()*
                   • {...} (`any`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 rpcrequest({channel}, {method} [, {args}...])                     *rpcrequest()*
 		Sends a request to {channel} to invoke {method} via
@@ -8033,7 +8033,7 @@ screenattr({row}, {col})                                          *screenattr()*
                   • {col} (`integer`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 screenchar({row}, {col})                                          *screenchar()*
 		The result is a Number, which is the character at position
@@ -8050,7 +8050,7 @@ screenchar({row}, {col})                                          *screenchar()*
                   • {col} (`integer`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 screenchars({row}, {col})                                        *screenchars()*
 		The result is a |List| of Numbers.  The first number is the same
@@ -8064,7 +8064,7 @@ screenchars({row}, {col})                                        *screenchars()*
                   • {col} (`integer`)
 
                 Return: ~
-                  (`any`)
+                  (`integer[]`)
 
 screencol()                                                        *screencol()*
 		The result is a Number, which is the current screen column of
@@ -8082,7 +8082,7 @@ screencol()                                                        *screencol()*
 <
 
                 Return: ~
-                  (`any`)
+                  (`integer[]`)
 
 screenpos({winid}, {lnum}, {col})                                  *screenpos()*
 		The result is a Dict with the screen position of the text
@@ -8125,7 +8125,7 @@ screenrow()                                                        *screenrow()*
 		Note: Same restrictions as with |screencol()|.
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 screenstring({row}, {col})                                      *screenstring()*
 		The result is a String that contains the base character and
@@ -8140,7 +8140,7 @@ screenstring({row}, {col})                                      *screenstring()*
                   • {col} (`integer`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]]) *search()*
 		Search for regexp pattern {pattern}.  The search starts at the
@@ -8567,7 +8567,7 @@ serverlist()                                                      *serverlist()*
 <
 
                 Return: ~
-                  (`any`)
+                  (`string[]`)
 
 serverstart([{address}])                                         *serverstart()*
 		Opens a socket or named pipe at {address} and listens for
@@ -8607,7 +8607,7 @@ serverstart([{address}])                                         *serverstart()*
                   • {address} (`string?`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 serverstop({address})                                             *serverstop()*
 		Closes the pipe or socket at {address}.
@@ -8619,7 +8619,7 @@ serverstop({address})                                             *serverstop()*
                   • {address} (`string`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 setbufline({buf}, {lnum}, {text})                                 *setbufline()*
 		Set line {lnum} to {text} in buffer {buf}.  This works like
@@ -8652,7 +8652,7 @@ setbufline({buf}, {lnum}, {text})                                 *setbufline()*
                   • {text} (`string|string[]`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 setbufvar({buf}, {varname}, {val})                                 *setbufvar()*
 		Set option or local variable {varname} in buffer {buf} to
@@ -8772,7 +8772,7 @@ setcmdline({str} [, {pos}])                                       *setcmdline()*
                   • {pos} (`integer?`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 setcmdpos({pos})                                                   *setcmdpos()*
 		Set the cursor position in the command line to byte position
@@ -9104,7 +9104,7 @@ setqflist({list} [, {action} [, {what}]])                          *setqflist()*
                   • {what} (`vim.fn.setqflist.what?`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 setreg({regname}, {value} [, {options}])                              *setreg()*
 		Set the register {regname} to {value}.
@@ -9275,7 +9275,7 @@ sha256({string})                                                      *sha256()*
                   • {string} (`string`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 shellescape({string} [, {special}])                              *shellescape()*
 		Escape {string} for use as a shell command argument.
@@ -9314,7 +9314,7 @@ shellescape({string} [, {special}])                              *shellescape()*
                   • {special} (`boolean?`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 shiftwidth([{col}])                                               *shiftwidth()*
 		Returns the effective value of 'shiftwidth'. This is the
@@ -9792,7 +9792,7 @@ simplify({filename})                                                *simplify()*
                   • {filename} (`string`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 sin({expr})                                                              *sin()*
 		Return the sine of {expr}, measured in radians, as a |Float|.
@@ -9808,7 +9808,7 @@ sin({expr})                                                              *sin()*
                   • {expr} (`number`)
 
                 Return: ~
-                  (`any`)
+                  (`number`)
 
 sinh({expr})                                                            *sinh()*
 		Return the hyperbolic sine of {expr} as a |Float| in the range
@@ -9971,7 +9971,7 @@ soundfold({word})                                                  *soundfold()*
                   • {word} (`string`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 spellbadword([{sentence}])                                      *spellbadword()*
 		Without argument: The result is the badly spelled word under
@@ -10030,7 +10030,7 @@ spellsuggest({word} [, {max} [, {capital}]])                    *spellsuggest()*
                   • {capital} (`boolean?`)
 
                 Return: ~
-                  (`any`)
+                  (`string[]`)
 
 split({string} [, {pattern} [, {keepempty}]])                          *split()*
 		Make a |List| out of {string}.  When {pattern} is omitted or
@@ -10063,7 +10063,7 @@ split({string} [, {pattern} [, {keepempty}]])                          *split()*
                   • {keepempty} (`boolean?`)
 
                 Return: ~
-                  (`any`)
+                  (`string[]`)
 
 sqrt({expr})                                                            *sqrt()*
 		Return the non-negative square root of Float {expr} as a
@@ -11188,7 +11188,7 @@ termopen({cmd} [, {opts}])                                          *termopen()*
                   • {opts} (`table?`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 test_garbagecollect_now()                            *test_garbagecollect_now()*
 		Like |garbagecollect()|, but executed right away.  This must
@@ -11649,7 +11649,7 @@ virtcol2col({winid}, {lnum}, {col})                              *virtcol2col()*
                   • {col} (`integer`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 visualmode([{expr}])                                              *visualmode()*
 		The result is a String, which describes the last Visual mode
@@ -11673,7 +11673,7 @@ visualmode([{expr}])                                              *visualmode()*
                   • {expr} (`boolean?`)
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 wait({timeout}, {condition} [, {interval}])                             *wait()*
 		Waits until {condition} evaluates to |TRUE|, where {condition}
@@ -11815,7 +11815,7 @@ win_id2win({expr})                                                *win_id2win()*
                   • {expr} (`integer`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 win_move_separator({nr}, {offset})                        *win_move_separator()*
 		Move window {nr}'s vertical separator (i.e., the right border)
@@ -12040,7 +12040,7 @@ winnr([{arg}])                                                         *winnr()*
                   • {arg} (`string|integer?`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 winrestcmd()                                                      *winrestcmd()*
 		Returns a sequence of |:resize| commands that should restore
@@ -12054,7 +12054,7 @@ winrestcmd()                                                      *winrestcmd()*
 <
 
                 Return: ~
-                  (`any`)
+                  (`string`)
 
 winrestview({dict})                                              *winrestview()*
 		Uses the |Dictionary| returned by |winsaveview()| to restore
@@ -12126,7 +12126,7 @@ winwidth({nr})                                                      *winwidth()*
                   • {nr} (`integer`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 wordcount()                                                        *wordcount()*
 		The result is a dictionary of byte/chars/word statistics for
@@ -12216,11 +12216,11 @@ xor({expr}, {expr})                                                      *xor()*
 <
 
                 Parameters: ~
-                  • {expr} (`number`)
-                  • {expr1} (`number`)
+                  • {expr} (`integer`)
+                  • {expr1} (`integer`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 ==============================================================================
 2. Matching a pattern in a String			*string-match*

--- a/runtime/lua/vim/_meta/api_keysets_extra.lua
+++ b/runtime/lua/vim/_meta/api_keysets_extra.lua
@@ -159,6 +159,7 @@ error('Cannot require a meta file')
 --- @field bg? integer
 --- @field sp? integer
 --- @field default? true
+--- @field link? string
 --- @field blend? integer
 --- @field cterm? vim.api.keyset.hl_info.cterm
 

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -1228,7 +1228,7 @@ function vim.fn.ctxpush(types) end
 ---
 --- @param context table
 --- @param index? integer
---- @return any
+--- @return integer
 function vim.fn.ctxset(context, index) end
 
 --- Returns the size of the |context-stack|.
@@ -1421,7 +1421,7 @@ function vim.fn.dictwatcherdel(dict, pattern, callback) end
 --- editing another buffer to set 'filetype' and load a syntax
 --- file.
 ---
---- @return any
+--- @return integer
 function vim.fn.did_filetype() end
 
 --- Returns the number of filler lines above line {lnum}.
@@ -1433,7 +1433,7 @@ function vim.fn.did_filetype() end
 --- Returns 0 if the current window is not in diff mode.
 ---
 --- @param lnum integer
---- @return any
+--- @return integer
 function vim.fn.diff_filler(lnum) end
 
 --- Returns the highlight ID for diff mode at line {lnum} column
@@ -1468,7 +1468,7 @@ function vim.fn.diff_hlID(lnum, col) end
 --- <
 ---
 --- @param chars string
---- @return any
+--- @return string
 function vim.fn.digraph_get(chars) end
 
 --- Return a list of digraphs.  If the {listall} argument is given
@@ -1486,7 +1486,7 @@ function vim.fn.digraph_get(chars) end
 --- <
 ---
 --- @param listall? boolean
---- @return any
+--- @return string[][]
 function vim.fn.digraph_getlist(listall) end
 
 --- Add digraph {chars} to the list.  {chars} must be a string
@@ -1538,7 +1538,7 @@ function vim.fn.digraph_setlist(digraphlist) end
 --- - A |Blob| is empty when its length is zero.
 ---
 --- @param expr any
---- @return any
+--- @return integer
 function vim.fn.empty(expr) end
 
 --- Return all of environment variables as dictionary. You can
@@ -1561,7 +1561,7 @@ function vim.fn.environ() end
 ---
 --- @param string string
 --- @param chars string
---- @return any
+--- @return string
 function vim.fn.escape(string, chars) end
 
 --- Evaluate {string} and return the result.  Especially useful to
@@ -2368,7 +2368,7 @@ function vim.fn.foldtextresult(lnum) end
 ---
 --- @param expr1 string|table
 --- @param expr2 string|function
---- @return any
+--- @return string|table
 function vim.fn.foreach(expr1, expr2) end
 
 --- Get the full command name from a short abbreviated command
@@ -2675,7 +2675,7 @@ function vim.fn.getbufinfo(dict) end
 --- @param buf integer|string
 --- @param lnum integer
 --- @param end_? integer
---- @return any
+--- @return string[]
 function vim.fn.getbufline(buf, lnum, end_) end
 
 --- Just like `getbufline()` but only get one line and return it
@@ -2943,7 +2943,7 @@ function vim.fn.getcmdprompt() end
 --- Also see |getcmdpos()|, |setcmdpos()|, |getcmdline()| and
 --- |setcmdline()|.
 ---
---- @return any
+--- @return integer
 function vim.fn.getcmdscreenpos() end
 
 --- Return the current command-line type. Possible return values
@@ -3869,7 +3869,7 @@ function vim.fn.gettagstack(winnr) end
 --- strings.
 ---
 --- @param text string
---- @return any
+--- @return string
 function vim.fn.gettext(text) end
 
 --- Returns information about windows as a |List| with Dictionaries.
@@ -4020,7 +4020,7 @@ function vim.fn.glob(expr, nosuf, list, alllinks) end
 --- a backslash usually means a path separator.
 ---
 --- @param string string
---- @return any
+--- @return string
 function vim.fn.glob2regpat(string) end
 
 --- Perform glob() for String {expr} on all directories in {path}
@@ -4354,7 +4354,7 @@ function vim.fn.hostname() end
 --- @param string string
 --- @param from string
 --- @param to string
---- @return any
+--- @return string
 function vim.fn.iconv(string, from, to) end
 
 --- Returns a |String| which is a unique identifier of the
@@ -4374,7 +4374,7 @@ function vim.fn.iconv(string, from, to) end
 --- reuse identifiers of the garbage-collected ones.
 ---
 --- @param expr any
---- @return any
+--- @return string
 function vim.fn.id(expr) end
 
 --- The result is a Number, which is indent of line {lnum} in the
@@ -4418,7 +4418,7 @@ function vim.fn.indent(lnum) end
 --- @param expr any
 --- @param start? integer
 --- @param ic? boolean
---- @return any
+--- @return integer
 function vim.fn.index(object, expr, start, ic) end
 
 --- Returns the index of an item in {object} where {expr} is
@@ -4462,14 +4462,14 @@ function vim.fn.index(object, expr, start, ic) end
 --- @param object any
 --- @param expr any
 --- @param opts? table
---- @return any
+--- @return integer
 function vim.fn.indexof(object, expr, opts) end
 
 ---
 --- @param prompt string
 --- @param text? string
 --- @param completion? string
---- @return any
+--- @return string
 function vim.fn.input(prompt, text, completion) end
 
 --- The result is a String, which is whatever the user typed on
@@ -4583,7 +4583,7 @@ function vim.fn.input(prompt, text, completion) end
 --- <
 ---
 --- @param opts table
---- @return any
+--- @return string
 function vim.fn.input(opts) end
 
 --- @deprecated
@@ -4618,7 +4618,7 @@ function vim.fn.inputlist(textlist) end
 --- called.  Calling it more often is harmless though.
 --- Returns TRUE when there is nothing to restore, FALSE otherwise.
 ---
---- @return any
+--- @return integer
 function vim.fn.inputrestore() end
 
 --- Preserve typeahead (also from mappings) and clear it, so that
@@ -4628,7 +4628,7 @@ function vim.fn.inputrestore() end
 --- many inputrestore() calls.
 --- Returns TRUE when out of memory, FALSE otherwise.
 ---
---- @return any
+--- @return integer
 function vim.fn.inputsave() end
 
 --- This function acts much like the |input()| function with but
@@ -4643,7 +4643,7 @@ function vim.fn.inputsave() end
 ---
 --- @param prompt string
 --- @param text? string
---- @return any
+--- @return string
 function vim.fn.inputsecret(prompt, text) end
 
 --- When {object} is a |List| or a |Blob| insert {item} at the start
@@ -4689,8 +4689,8 @@ function vim.fn.interrupt() end
 ---   let bits = invert(bits)
 --- <
 ---
---- @param expr number
---- @return any
+--- @param expr integer
+--- @return integer
 function vim.fn.invert(expr) end
 
 --- The result is a Number, which is |TRUE| when {path} is an
@@ -4890,7 +4890,7 @@ function vim.fn.jobsend(...) end
 ---
 --- @param cmd string|string[]
 --- @param opts? table
---- @return any
+--- @return integer
 function vim.fn.jobstart(cmd, opts) end
 
 --- Stop |job-id| {id} by sending SIGTERM to the job process. If
@@ -4903,7 +4903,7 @@ function vim.fn.jobstart(cmd, opts) end
 --- exited or stopped.
 ---
 --- @param id integer
---- @return any
+--- @return integer
 function vim.fn.jobstop(id) end
 
 --- Waits for jobs and their |on_exit| handlers to complete.
@@ -4943,7 +4943,7 @@ function vim.fn.jobwait(jobs, timeout) end
 ---
 --- @param list any[]
 --- @param sep? string
---- @return any
+--- @return string
 function vim.fn.join(list, sep) end
 
 --- Convert {expr} from JSON object.  Accepts |readfile()|-style
@@ -4976,14 +4976,14 @@ function vim.fn.json_decode(expr) end
 --- |Blob|s are converted to arrays of the individual bytes.
 ---
 --- @param expr any
---- @return any
+--- @return string
 function vim.fn.json_encode(expr) end
 
 --- Return a |List| with all the keys of {dict}.  The |List| is in
 --- arbitrary order.  Also see |items()| and |values()|.
 ---
 --- @param dict table
---- @return any
+--- @return string[]
 function vim.fn.keys(dict) end
 
 --- Turn the internal byte representation of keys into a form that
@@ -4993,7 +4993,7 @@ function vim.fn.keys(dict) end
 --- <  <C-Home>
 ---
 --- @param string string
---- @return any
+--- @return string
 function vim.fn.keytrans(string) end
 
 --- @deprecated
@@ -5012,8 +5012,8 @@ function vim.fn.last_buffer_nr() end
 --- |Dictionary| is returned.
 --- Otherwise an error is given and returns zero.
 ---
---- @param expr any
---- @return any
+--- @param expr any[]
+--- @return integer
 function vim.fn.len(expr) end
 
 --- Call function {funcname} in the run-time library {libname}
@@ -5124,7 +5124,7 @@ function vim.fn.line2byte(lnum) end
 --- When {lnum} is invalid, -1 is returned.
 ---
 --- @param lnum integer
---- @return any
+--- @return integer
 function vim.fn.lispindent(lnum) end
 
 --- Return a Blob concatenating all the number values in {list}.
@@ -5137,7 +5137,7 @@ function vim.fn.lispindent(lnum) end
 --- |blob2list()| does the opposite.
 ---
 --- @param list any[]
---- @return any
+--- @return string
 function vim.fn.list2blob(list) end
 
 --- Convert each number in {list} to a character string can
@@ -5157,13 +5157,13 @@ function vim.fn.list2blob(list) end
 ---
 --- @param list any[]
 --- @param utf8? boolean
---- @return any
+--- @return string
 function vim.fn.list2str(list, utf8) end
 
 --- Return the current time, measured as seconds since 1st Jan
 --- 1970.  See also |strftime()|, |strptime()| and |getftime()|.
 ---
---- @return any
+--- @return integer
 function vim.fn.localtime() end
 
 --- Return the natural logarithm (base e) of {expr} as a |Float|.
@@ -5177,7 +5177,7 @@ function vim.fn.localtime() end
 --- <  5.0
 ---
 --- @param expr number
---- @return any
+--- @return number
 function vim.fn.log(expr) end
 
 --- Return the logarithm of Float {expr} to base 10 as a |Float|.
@@ -5190,7 +5190,7 @@ function vim.fn.log(expr) end
 --- <  -2.0
 ---
 --- @param expr number
---- @return any
+--- @return number
 function vim.fn.log10(expr) end
 
 --- {expr1} must be a |List|, |String|, |Blob| or |Dictionary|.
@@ -6090,7 +6090,7 @@ function vim.fn.menu_info(name, mode) end
 --- an error.  An empty |List| or |Dictionary| results in zero.
 ---
 --- @param expr any
---- @return any
+--- @return number
 function vim.fn.min(expr) end
 
 --- Create directory {name}.
@@ -6135,7 +6135,7 @@ function vim.fn.min(expr) end
 --- @param name string
 --- @param flags? string
 --- @param prot? string
---- @return any
+--- @return integer
 function vim.fn.mkdir(name, flags, prot) end
 
 --- Return a string that indicates the current mode.
@@ -6298,7 +6298,7 @@ function vim.fn.msgpackparse(data) end
 --- See also |prevnonblank()|.
 ---
 --- @param lnum integer
---- @return any
+--- @return integer
 function vim.fn.nextnonblank(lnum) end
 
 --- Return a string with a single character, which has the number
@@ -6317,7 +6317,7 @@ function vim.fn.nextnonblank(lnum) end
 ---
 --- @param expr integer
 --- @param utf8? boolean
---- @return any
+--- @return string
 function vim.fn.nr2char(expr, utf8) end
 
 --- Bitwise OR on the two arguments.  The arguments are converted
@@ -6351,7 +6351,7 @@ vim.fn['or'] = function(expr, expr1) end
 ---
 --- @param path string
 --- @param len? integer
---- @return any
+--- @return string
 function vim.fn.pathshorten(path, len) end
 
 --- Evaluate |perl| expression {expr} and return its result
@@ -6385,7 +6385,7 @@ function vim.fn.perleval(expr) end
 ---
 --- @param x number
 --- @param y number
---- @return any
+--- @return number
 function vim.fn.pow(x, y) end
 
 --- Return the line number of the first line at or above {lnum}
@@ -6397,7 +6397,7 @@ function vim.fn.pow(x, y) end
 --- Also see |nextnonblank()|.
 ---
 --- @param lnum integer
---- @return any
+--- @return integer
 function vim.fn.prevnonblank(lnum) end
 
 --- Return a String with {fmt}, where "%" items are replaced by
@@ -7172,7 +7172,7 @@ function vim.fn.remove(dict, key) end
 ---
 --- @param from string
 --- @param to string
---- @return any
+--- @return integer
 function vim.fn.rename(from, to) end
 
 --- Repeat {expr} {count} times and return the concatenated
@@ -7202,7 +7202,7 @@ vim.fn['repeat'] = function(expr, count) end
 --- path name) and also keeps a trailing path separator.
 ---
 --- @param filename string
---- @return any
+--- @return string
 function vim.fn.resolve(filename) end
 
 --- Reverse the order of items in {object}.  {object} can be a
@@ -7233,7 +7233,7 @@ function vim.fn.reverse(object) end
 --- <  -5.0
 ---
 --- @param expr number
---- @return any
+--- @return number
 function vim.fn.round(expr) end
 
 --- Sends {event} to {channel} via |RPC| and returns immediately.
@@ -7245,7 +7245,7 @@ function vim.fn.round(expr) end
 --- @param channel integer
 --- @param event string
 --- @param ... any
---- @return any
+--- @return integer
 function vim.fn.rpcnotify(channel, event, ...) end
 
 --- Sends a request to {channel} to invoke {method} via
@@ -7302,7 +7302,7 @@ function vim.fn.rubyeval(expr) end
 ---
 --- @param row integer
 --- @param col integer
---- @return any
+--- @return integer
 function vim.fn.screenattr(row, col) end
 
 --- The result is a Number, which is the character at position
@@ -7316,7 +7316,7 @@ function vim.fn.screenattr(row, col) end
 ---
 --- @param row integer
 --- @param col integer
---- @return any
+--- @return integer
 function vim.fn.screenchar(row, col) end
 
 --- The result is a |List| of Numbers.  The first number is the same
@@ -7327,7 +7327,7 @@ function vim.fn.screenchar(row, col) end
 ---
 --- @param row integer
 --- @param col integer
---- @return any
+--- @return integer[]
 function vim.fn.screenchars(row, col) end
 
 --- The result is a Number, which is the current screen column of
@@ -7344,7 +7344,7 @@ function vim.fn.screenchars(row, col) end
 ---   noremap GG <Cmd>echom screencol()<CR>
 --- <
 ---
---- @return any
+--- @return integer[]
 function vim.fn.screencol() end
 
 --- The result is a Dict with the screen position of the text
@@ -7383,7 +7383,7 @@ function vim.fn.screenpos(winid, lnum, col) end
 ---
 --- Note: Same restrictions as with |screencol()|.
 ---
---- @return any
+--- @return integer
 function vim.fn.screenrow() end
 
 --- The result is a String that contains the base character and
@@ -7395,7 +7395,7 @@ function vim.fn.screenrow() end
 ---
 --- @param row integer
 --- @param col integer
---- @return any
+--- @return string
 function vim.fn.screenstring(row, col) end
 
 --- Search for regexp pattern {pattern}.  The search starts at the
@@ -7800,7 +7800,7 @@ function vim.fn.searchpos(pattern, flags, stopline, timeout, skip) end
 ---   echo serverlist()
 --- <
 ---
---- @return any
+--- @return string[]
 function vim.fn.serverlist() end
 
 --- Opens a socket or named pipe at {address} and listens for
@@ -7837,7 +7837,7 @@ function vim.fn.serverlist() end
 --- <
 ---
 --- @param address? string
---- @return any
+--- @return string
 function vim.fn.serverstart(address) end
 
 --- Closes the pipe or socket at {address}.
@@ -7846,7 +7846,7 @@ function vim.fn.serverstart(address) end
 --- address in |serverlist()|.
 ---
 --- @param address string
---- @return any
+--- @return integer
 function vim.fn.serverstop(address) end
 
 --- Set line {lnum} to {text} in buffer {buf}.  This works like
@@ -7876,7 +7876,7 @@ function vim.fn.serverstop(address) end
 --- @param buf integer|string
 --- @param lnum integer
 --- @param text string|string[]
---- @return any
+--- @return integer
 function vim.fn.setbufline(buf, lnum, text) end
 
 --- Set option or local variable {varname} in buffer {buf} to
@@ -7981,7 +7981,7 @@ function vim.fn.setcharsearch(dict) end
 ---
 --- @param str string
 --- @param pos? integer
---- @return any
+--- @return integer
 function vim.fn.setcmdline(str, pos) end
 
 --- Set the cursor position in the command line to byte position
@@ -8291,7 +8291,7 @@ function vim.fn.setpos(expr, list) end
 --- @param list vim.quickfix.entry[]
 --- @param action? string
 --- @param what? vim.fn.setqflist.what
---- @return any
+--- @return integer
 function vim.fn.setqflist(list, action, what) end
 
 --- Set the register {regname} to {value}.
@@ -8444,7 +8444,7 @@ function vim.fn.setwinvar(nr, varname, val) end
 --- checksum of {string}.
 ---
 --- @param string string
---- @return any
+--- @return string
 function vim.fn.sha256(string) end
 
 --- Escape {string} for use as a shell command argument.
@@ -8480,7 +8480,7 @@ function vim.fn.sha256(string) end
 ---
 --- @param string string
 --- @param special? boolean
---- @return any
+--- @return string
 function vim.fn.shellescape(string, special) end
 
 --- Returns the effective value of 'shiftwidth'. This is the
@@ -8932,7 +8932,7 @@ function vim.fn.sign_unplacelist(list) end
 --- links before simplifying the path name, use |resolve()|.
 ---
 --- @param filename string
---- @return any
+--- @return string
 function vim.fn.simplify(filename) end
 
 --- Return the sine of {expr}, measured in radians, as a |Float|.
@@ -8945,7 +8945,7 @@ function vim.fn.simplify(filename) end
 --- <  0.763301
 ---
 --- @param expr number
---- @return any
+--- @return number
 function vim.fn.sin(expr) end
 
 --- Return the hyperbolic sine of {expr} as a |Float| in the range
@@ -9093,7 +9093,7 @@ function vim.fn.sort(list, how, dict) end
 --- the method can be quite slow.
 ---
 --- @param word string
---- @return any
+--- @return string
 function vim.fn.soundfold(word) end
 
 --- Without argument: The result is the badly spelled word under
@@ -9146,7 +9146,7 @@ function vim.fn.spellbadword(sentence) end
 --- @param word string
 --- @param max? integer
 --- @param capital? boolean
---- @return any
+--- @return string[]
 function vim.fn.spellsuggest(word, max, capital) end
 
 --- Make a |List| out of {string}.  When {pattern} is omitted or
@@ -9176,7 +9176,7 @@ function vim.fn.spellsuggest(word, max, capital) end
 --- @param string string
 --- @param pattern? string
 --- @param keepempty? boolean
---- @return any
+--- @return string[]
 function vim.fn.split(string, pattern, keepempty) end
 
 --- Return the non-negative square root of Float {expr} as a
@@ -10179,7 +10179,7 @@ function vim.fn.tempname() end
 ---
 --- @param cmd string|string[]
 --- @param opts? table
---- @return any
+--- @return integer
 function vim.fn.termopen(cmd, opts) end
 
 --- Return a list with information about timers.
@@ -10579,7 +10579,7 @@ function vim.fn.virtcol(expr, list, winid) end
 --- @param winid integer
 --- @param lnum integer
 --- @param col integer
---- @return any
+--- @return integer
 function vim.fn.virtcol2col(winid, lnum, col) end
 
 --- The result is a String, which describes the last Visual mode
@@ -10600,7 +10600,7 @@ function vim.fn.virtcol2col(winid, lnum, col) end
 --- the old value is returned.  See |non-zero-arg|.
 ---
 --- @param expr? boolean
---- @return any
+--- @return string
 function vim.fn.visualmode(expr) end
 
 --- Waits until {condition} evaluates to |TRUE|, where {condition}
@@ -10717,7 +10717,7 @@ function vim.fn.win_id2tabwin(expr) end
 --- Return 0 if the window cannot be found in the current tabpage.
 ---
 --- @param expr integer
---- @return any
+--- @return integer
 function vim.fn.win_id2win(expr) end
 
 --- Move window {nr}'s vertical separator (i.e., the right border)
@@ -10915,7 +10915,7 @@ function vim.fn.winline() end
 --- <
 ---
 --- @param arg? string|integer
---- @return any
+--- @return integer
 function vim.fn.winnr(arg) end
 
 --- Returns a sequence of |:resize| commands that should restore
@@ -10928,7 +10928,7 @@ function vim.fn.winnr(arg) end
 ---   exe cmd
 --- <
 ---
---- @return any
+--- @return string
 function vim.fn.winrestcmd() end
 
 --- Uses the |Dictionary| returned by |winsaveview()| to restore
@@ -10993,7 +10993,7 @@ function vim.fn.winsaveview() end
 --- option.
 ---
 --- @param nr integer
---- @return any
+--- @return integer
 function vim.fn.winwidth(nr) end
 
 --- The result is a dictionary of byte/chars/word statistics for
@@ -11078,7 +11078,7 @@ function vim.fn.writefile(object, fname, flags) end
 ---   let bits = xor(bits, 0x80)
 --- <
 ---
---- @param expr number
---- @param expr1 number
---- @return any
+--- @param expr integer
+--- @param expr1 integer
+--- @return integer
 function vim.fn.xor(expr, expr1) end

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -1639,6 +1639,7 @@ M.funcs = {
     ]=],
     name = 'ctxset',
     params = { { 'context', 'table' }, { 'index', 'integer' } },
+    returns = 'integer',
     signature = 'ctxset({context} [, {index}])',
   },
   ctxsize = {
@@ -1869,6 +1870,7 @@ M.funcs = {
     fast = true,
     name = 'did_filetype',
     params = {},
+    returns = 'integer',
     signature = 'did_filetype()',
   },
   diff_filler = {
@@ -1886,6 +1888,7 @@ M.funcs = {
     ]=],
     name = 'diff_filler',
     params = { { 'lnum', 'integer' } },
+    returns = 'integer',
     signature = 'diff_filler({lnum})',
   },
   diff_hlID = {
@@ -1930,6 +1933,7 @@ M.funcs = {
     ]=],
     name = 'digraph_get',
     params = { { 'chars', 'string' } },
+    returns = 'string',
     signature = 'digraph_get({chars})',
   },
   digraph_getlist = {
@@ -1952,6 +1956,7 @@ M.funcs = {
     ]=],
     name = 'digraph_getlist',
     params = { { 'listall', 'boolean' } },
+    returns = 'string[][]',
     signature = 'digraph_getlist([{listall}])',
   },
   digraph_set = {
@@ -2016,6 +2021,7 @@ M.funcs = {
     ]=],
     name = 'empty',
     params = { { 'expr', 'any' } },
+    returns = 'integer',
     signature = 'empty({expr})',
   },
   environ = {
@@ -2048,6 +2054,7 @@ M.funcs = {
     fast = true,
     name = 'escape',
     params = { { 'string', 'string' }, { 'chars', 'string' } },
+    returns = 'string',
     signature = 'escape({string}, {chars})',
   },
   eval = {
@@ -3018,6 +3025,7 @@ M.funcs = {
     ]=],
     name = 'foreach',
     params = { { 'expr1', 'string|table' }, { 'expr2', 'string|function' } },
+    returns = 'string|table',
     signature = 'foreach({expr1}, {expr2})',
   },
   foreground = {
@@ -3372,6 +3380,7 @@ M.funcs = {
     ]=],
     name = 'getbufline',
     params = { { 'buf', 'integer|string' }, { 'lnum', 'integer' }, { 'end', 'integer' } },
+    returns = 'string[]',
     signature = 'getbufline({buf}, {lnum} [, {end}])',
   },
   getbufoneline = {
@@ -3700,6 +3709,7 @@ M.funcs = {
     ]=],
     name = 'getcmdscreenpos',
     params = {},
+    returns = 'integer',
     signature = 'getcmdscreenpos()',
   },
   getcmdtype = {
@@ -4781,6 +4791,7 @@ M.funcs = {
     ]=],
     name = 'gettext',
     params = { { 'text', 'string' } },
+    returns = 'string',
     signature = 'gettext({text})',
   },
   getwininfo = {
@@ -4965,6 +4976,7 @@ M.funcs = {
     ]=],
     name = 'glob2regpat',
     params = { { 'string', 'string' } },
+    returns = 'string',
     signature = 'glob2regpat({string})',
   },
   globpath = {
@@ -5372,6 +5384,7 @@ M.funcs = {
     fast = true,
     name = 'iconv',
     params = { { 'string', 'string' }, { 'from', 'string' }, { 'to', 'string' } },
+    returns = 'string',
     signature = 'iconv({string}, {from}, {to})',
   },
   id = {
@@ -5395,6 +5408,7 @@ M.funcs = {
     ]=],
     name = 'id',
     params = { { 'expr', 'any' } },
+    returns = 'string',
     signature = 'id({expr})',
   },
   indent = {
@@ -5447,6 +5461,7 @@ M.funcs = {
     ]=],
     name = 'index',
     params = { { 'object', 'any' }, { 'expr', 'any' }, { 'start', 'integer' }, { 'ic', 'boolean' } },
+    returns = 'integer',
     signature = 'index({object}, {expr} [, {start} [, {ic}]])',
   },
   indexof = {
@@ -5494,6 +5509,7 @@ M.funcs = {
     ]=],
     name = 'indexof',
     params = { { 'object', 'any' }, { 'expr', 'any' }, { 'opts', 'table' } },
+    returns = 'integer',
     signature = 'indexof({object}, {expr} [, {opts}])',
   },
   input = {
@@ -5502,6 +5518,7 @@ M.funcs = {
     desc = '',
     name = 'input',
     params = { { 'prompt', 'string' }, { 'text', 'string' }, { 'completion', 'string' } },
+    returns = 'string',
     signature = 'input({prompt} [, {text} [, {completion}]])',
   },
   input__1 = {
@@ -5621,6 +5638,7 @@ M.funcs = {
     ]=],
     name = 'input',
     params = { { 'opts', 'table' } },
+    returns = 'string',
     signature = 'input({opts})',
   },
   inputdialog = {
@@ -5667,6 +5685,7 @@ M.funcs = {
     ]=],
     name = 'inputrestore',
     params = {},
+    returns = 'integer',
     signature = 'inputrestore()',
   },
   inputsave = {
@@ -5680,6 +5699,7 @@ M.funcs = {
     ]=],
     name = 'inputsave',
     params = {},
+    returns = 'integer',
     signature = 'inputsave()',
   },
   inputsecret = {
@@ -5699,6 +5719,7 @@ M.funcs = {
     ]=],
     name = 'inputsecret',
     params = { { 'prompt', 'string' }, { 'text', 'string' } },
+    returns = 'string',
     signature = 'inputsecret({prompt} [, {text}])',
   },
   insert = {
@@ -5756,7 +5777,8 @@ M.funcs = {
       <
     ]=],
     name = 'invert',
-    params = { { 'expr', 'number' } },
+    params = { { 'expr', 'integer' } },
+    returns = 'integer',
     signature = 'invert({expr})',
   },
   isabsolutepath = {
@@ -6006,6 +6028,7 @@ M.funcs = {
     ]=],
     name = 'jobstart',
     params = { { 'cmd', 'string|string[]' }, { 'opts', 'table' } },
+    returns = 'integer',
     signature = 'jobstart({cmd} [, {opts}])',
   },
   jobstop = {
@@ -6022,6 +6045,7 @@ M.funcs = {
     ]=],
     name = 'jobstop',
     params = { { 'id', 'integer' } },
+    returns = 'integer',
     signature = 'jobstop({id})',
   },
   jobwait = {
@@ -6069,6 +6093,7 @@ M.funcs = {
     ]=],
     name = 'join',
     params = { { 'list', 'any[]' }, { 'sep', 'string' } },
+    returns = 'string',
     signature = 'join({list} [, {sep}])',
   },
   json_decode = {
@@ -6112,6 +6137,7 @@ M.funcs = {
     ]=],
     name = 'json_encode',
     params = { { 'expr', 'any' } },
+    returns = 'string',
     signature = 'json_encode({expr})',
   },
   keys = {
@@ -6124,6 +6150,7 @@ M.funcs = {
     ]=],
     name = 'keys',
     params = { { 'dict', 'table' } },
+    returns = 'string[]',
     signature = 'keys({dict})',
   },
   keytrans = {
@@ -6139,6 +6166,7 @@ M.funcs = {
     ]=],
     name = 'keytrans',
     params = { { 'string', 'string' } },
+    returns = 'string',
     signature = 'keytrans({string})',
   },
   last_buffer_nr = {
@@ -6165,7 +6193,8 @@ M.funcs = {
 
     ]=],
     name = 'len',
-    params = { { 'expr', 'any' } },
+    params = { { 'expr', 'any[]' } },
+    returns = 'integer',
     signature = 'len({expr})',
     tags = { 'E701' },
   },
@@ -6300,6 +6329,7 @@ M.funcs = {
     ]=],
     name = 'lispindent',
     params = { { 'lnum', 'integer' } },
+    returns = 'integer',
     signature = 'lispindent({lnum})',
   },
   list2blob = {
@@ -6318,6 +6348,7 @@ M.funcs = {
     ]=],
     name = 'list2blob',
     params = { { 'list', 'any[]' } },
+    returns = 'string',
     signature = 'list2blob({list})',
   },
   list2str = {
@@ -6342,6 +6373,7 @@ M.funcs = {
     ]=],
     name = 'list2str',
     params = { { 'list', 'any[]' }, { 'utf8', 'boolean' } },
+    returns = 'string',
     signature = 'list2str({list} [, {utf8}])',
   },
   localtime = {
@@ -6351,6 +6383,7 @@ M.funcs = {
     ]=],
     name = 'localtime',
     params = {},
+    returns = 'integer',
     signature = 'localtime()',
   },
   log = {
@@ -6371,6 +6404,7 @@ M.funcs = {
     float_func = 'log',
     name = 'log',
     params = { { 'expr', 'number' } },
+    returns = 'number',
     signature = 'log({expr})',
   },
   log10 = {
@@ -6390,6 +6424,7 @@ M.funcs = {
     float_func = 'log10',
     name = 'log10',
     params = { { 'expr', 'number' } },
+    returns = 'number',
     signature = 'log10({expr})',
   },
   luaeval = {
@@ -7422,6 +7457,7 @@ M.funcs = {
     ]=],
     name = 'min',
     params = { { 'expr', 'any' } },
+    returns = 'number',
     signature = 'min({expr})',
   },
   mkdir = {
@@ -7470,6 +7506,7 @@ M.funcs = {
     ]=],
     name = 'mkdir',
     params = { { 'name', 'string' }, { 'flags', 'string' }, { 'prot', 'string' } },
+    returns = 'integer',
     signature = 'mkdir({name} [, {flags} [, {prot}]])',
     tags = { 'E739' },
   },
@@ -7649,6 +7686,7 @@ M.funcs = {
     ]=],
     name = 'nextnonblank',
     params = { { 'lnum', 'integer' } },
+    returns = 'integer',
     signature = 'nextnonblank({lnum})',
   },
   nr2char = {
@@ -7672,6 +7710,7 @@ M.funcs = {
     ]=],
     name = 'nr2char',
     params = { { 'expr', 'integer' }, { 'utf8', 'boolean' } },
+    returns = 'string',
     signature = 'nr2char({expr} [, {utf8}])',
   },
   nvim_api__ = {
@@ -7733,6 +7772,7 @@ M.funcs = {
     ]=],
     name = 'pathshorten',
     params = { { 'path', 'string' }, { 'len', 'integer' } },
+    returns = 'string',
     signature = 'pathshorten({path} [, {len}])',
   },
   perleval = {
@@ -7776,6 +7816,7 @@ M.funcs = {
     ]=],
     name = 'pow',
     params = { { 'x', 'number' }, { 'y', 'number' } },
+    returns = 'number',
     signature = 'pow({x}, {y})',
   },
   prevnonblank = {
@@ -7793,6 +7834,7 @@ M.funcs = {
     ]=],
     name = 'prevnonblank',
     params = { { 'lnum', 'integer' } },
+    returns = 'integer',
     signature = 'prevnonblank({lnum})',
   },
   printf = {
@@ -8682,6 +8724,7 @@ M.funcs = {
     ]=],
     name = 'rename',
     params = { { 'from', 'string' }, { 'to', 'string' } },
+    returns = 'integer',
     signature = 'rename({from}, {to})',
   },
   ['repeat'] = {
@@ -8724,6 +8767,7 @@ M.funcs = {
     fast = true,
     name = 'resolve',
     params = { { 'filename', 'string' } },
+    returns = 'string',
     signature = 'resolve({filename})',
   },
   reverse = {
@@ -8765,6 +8809,7 @@ M.funcs = {
     float_func = 'round',
     name = 'round',
     params = { { 'expr', 'number' } },
+    returns = 'number',
     signature = 'round({expr})',
   },
   rpcnotify = {
@@ -8778,6 +8823,7 @@ M.funcs = {
     ]=],
     name = 'rpcnotify',
     params = { { 'channel', 'integer' }, { 'event', 'string' }, { '...', 'any' } },
+    returns = 'integer',
     signature = 'rpcnotify({channel}, {event} [, {args}...])',
   },
   rpcrequest = {
@@ -8849,6 +8895,7 @@ M.funcs = {
     ]=],
     name = 'screenattr',
     params = { { 'row', 'integer' }, { 'col', 'integer' } },
+    returns = 'integer',
     signature = 'screenattr({row}, {col})',
   },
   screenchar = {
@@ -8867,6 +8914,7 @@ M.funcs = {
     ]=],
     name = 'screenchar',
     params = { { 'row', 'integer' }, { 'col', 'integer' } },
+    returns = 'integer',
     signature = 'screenchar({row}, {col})',
   },
   screenchars = {
@@ -8882,6 +8930,7 @@ M.funcs = {
     ]=],
     name = 'screenchars',
     params = { { 'row', 'integer' }, { 'col', 'integer' } },
+    returns = 'integer[]',
     signature = 'screenchars({row}, {col})',
   },
   screencol = {
@@ -8902,6 +8951,7 @@ M.funcs = {
     ]=],
     name = 'screencol',
     params = {},
+    returns = 'integer[]',
     signature = 'screencol()',
   },
   screenpos = {
@@ -8947,6 +8997,7 @@ M.funcs = {
     ]=],
     name = 'screenrow',
     params = {},
+    returns = 'integer',
     signature = 'screenrow()',
   },
   screenstring = {
@@ -8963,6 +9014,7 @@ M.funcs = {
     ]=],
     name = 'screenstring',
     params = { { 'row', 'integer' }, { 'col', 'integer' } },
+    returns = 'string',
     signature = 'screenstring({row}, {col})',
   },
   search = {
@@ -9404,6 +9456,7 @@ M.funcs = {
     ]=],
     name = 'serverlist',
     params = {},
+    returns = 'string[]',
     signature = 'serverlist()',
   },
   serverstart = {
@@ -9444,6 +9497,7 @@ M.funcs = {
     ]=],
     name = 'serverstart',
     params = { { 'address', 'string' } },
+    returns = 'string',
     signature = 'serverstart([{address}])',
   },
   serverstop = {
@@ -9456,6 +9510,7 @@ M.funcs = {
     ]=],
     name = 'serverstop',
     params = { { 'address', 'string' } },
+    returns = 'integer',
     signature = 'serverstop({address})',
   },
   setbufline = {
@@ -9489,6 +9544,7 @@ M.funcs = {
     ]=],
     name = 'setbufline',
     params = { { 'buf', 'integer|string' }, { 'lnum', 'integer' }, { 'text', 'string|string[]' } },
+    returns = 'integer',
     signature = 'setbufline({buf}, {lnum}, {text})',
   },
   setbufvar = {
@@ -9614,6 +9670,7 @@ M.funcs = {
     ]=],
     name = 'setcmdline',
     params = { { 'str', 'string' }, { 'pos', 'integer' } },
+    returns = 'integer',
     signature = 'setcmdline({str} [, {pos}])',
   },
   setcmdpos = {
@@ -9964,6 +10021,7 @@ M.funcs = {
       { 'action', 'string' },
       { 'what', 'vim.fn.setqflist.what' },
     },
+    returns = 'integer',
     signature = 'setqflist({list} [, {action} [, {what}]])',
   },
   setreg = {
@@ -10140,6 +10198,7 @@ M.funcs = {
     ]=],
     name = 'sha256',
     params = { { 'string', 'string' } },
+    returns = 'string',
     signature = 'sha256({string})',
   },
   shellescape = {
@@ -10180,6 +10239,7 @@ M.funcs = {
     ]=],
     name = 'shellescape',
     params = { { 'string', 'string' }, { 'special', 'boolean' } },
+    returns = 'string',
     signature = 'shellescape({string} [, {special}])',
   },
   shiftwidth = {
@@ -10694,6 +10754,7 @@ M.funcs = {
     ]=],
     name = 'simplify',
     params = { { 'filename', 'string' } },
+    returns = 'string',
     signature = 'simplify({filename})',
   },
   sin = {
@@ -10713,6 +10774,7 @@ M.funcs = {
     float_func = 'sin',
     name = 'sin',
     params = { { 'expr', 'number' } },
+    returns = 'number',
     signature = 'sin({expr})',
   },
   sinh = {
@@ -10879,6 +10941,7 @@ M.funcs = {
     ]=],
     name = 'soundfold',
     params = { { 'word', 'string' } },
+    returns = 'string',
     signature = 'soundfold({word})',
   },
   spellbadword = {
@@ -10940,6 +11003,7 @@ M.funcs = {
     ]=],
     name = 'spellsuggest',
     params = { { 'word', 'string' }, { 'max', 'integer' }, { 'capital', 'boolean' } },
+    returns = 'string[]',
     signature = 'spellsuggest({word} [, {max} [, {capital}]])',
   },
   split = {
@@ -10973,6 +11037,7 @@ M.funcs = {
     ]=],
     name = 'split',
     params = { { 'string', 'string' }, { 'pattern', 'string' }, { 'keepempty', 'boolean' } },
+    returns = 'string[]',
     signature = 'split({string} [, {pattern} [, {keepempty}]])',
   },
   sqrt = {
@@ -12209,6 +12274,7 @@ M.funcs = {
     ]=],
     name = 'termopen',
     params = { { 'cmd', 'string|string[]' }, { 'opts', 'table' } },
+    returns = 'integer',
     signature = 'termopen({cmd} [, {opts}])',
   },
   test_garbagecollect_now = {
@@ -12718,6 +12784,7 @@ M.funcs = {
     ]=],
     name = 'virtcol2col',
     params = { { 'winid', 'integer' }, { 'lnum', 'integer' }, { 'col', 'integer' } },
+    returns = 'integer',
     signature = 'virtcol2col({winid}, {lnum}, {col})',
   },
   visualmode = {
@@ -12742,6 +12809,7 @@ M.funcs = {
     ]=],
     name = 'visualmode',
     params = { { 'expr', 'boolean' } },
+    returns = 'string',
     signature = 'visualmode([{expr}])',
   },
   wait = {
@@ -12899,6 +12967,7 @@ M.funcs = {
     ]=],
     name = 'win_id2win',
     params = { { 'expr', 'integer' } },
+    returns = 'integer',
     signature = 'win_id2win({expr})',
   },
   win_move_separator = {
@@ -13145,6 +13214,7 @@ M.funcs = {
     ]=],
     name = 'winnr',
     params = { { 'arg', 'string|integer' } },
+    returns = 'integer',
     signature = 'winnr([{arg}])',
   },
   winrestcmd = {
@@ -13161,6 +13231,7 @@ M.funcs = {
     ]=],
     name = 'winrestcmd',
     params = {},
+    returns = 'string',
     signature = 'winrestcmd()',
   },
   winrestview = {
@@ -13240,6 +13311,7 @@ M.funcs = {
     ]=],
     name = 'winwidth',
     params = { { 'nr', 'integer' } },
+    returns = 'integer',
     signature = 'winwidth({nr})',
   },
   wordcount = {
@@ -13335,7 +13407,8 @@ M.funcs = {
       <
     ]=],
     name = 'xor',
-    params = { { 'expr', 'number' }, { 'expr', 'number' } },
+    params = { { 'expr', 'integer' }, { 'expr', 'integer' } },
+    returns = 'integer',
     signature = 'xor({expr}, {expr})',
   },
 }


### PR DESCRIPTION
A number of Lua annotations are missing `---@return` annotations, this PR is a pass at adding them.

I didn't add everything because of some reason or another. If curious, please see the sections below

<details>
<summary>Some type annotations should use `---@generic` - but out of scope for this PR, IMO</summary>

LuaLS supports "generic" types. See
https://github.com/LuaLS/lua-language-server/wiki/Annotations#generic

For example `:h deepcopy` takes argument `deepcopy({expr} [, {noref}])` and
returns a copy of it. So the function should ideally not return `any` like it
currently does but instead return the type of whatever `{expr}` is.

`scripts/gen_eval_files.lua` would probably need to be updated to handle that
and I considered it out of scope for this PR.

Here some functions that could benefit from `---@generic`.

- `:h deepcopy`
- `:h get`
- `:h items`
- `:h keys`
- `:h max`
- `:h min`
- `:h reduce`
- `:h sort`
- `:h values`

A future PR for these would be good.
</details>

<details>
<summary>Unsure how to handle primitive literals</summary>

A number of functions have explicit return types like "returns 0 on success or -1 on
failure". (Many) others are "return 0 as FALSE and 1 as TRUE". Some do the opposite. And
rare functions even have non-specific returns like `:h win_splitmove` that returns 0 for
success but non-zero for failure (there's no specificly defined failure value)

Anyway I was inclined to change the return values to be literal like
`---@returns 0 | 1` where-appropriate but I didn't want to assume anything. So
I opted out on this PR

For reference, these are the functions I found so far:

- `did_filetype` - 0 == FALSE, 1 == TRUE
- `inputrestore` - "Returns TRUE when there is nothing to restore, FALSE otherwise."
    - TRUE means "did nothing" and FALSE means "did something"
- `inputsave` - "Returns TRUE when out of memory, FALSE otherwise."
    - This means that unlike the others, TRUE actually is a fail condition
- `jobstart` - 0 / -1 == failure, 1-or-more if success
    - I guess in this one case `integer` would actually be correct
- `mkdir` - 0 == FALSE, 1 == TRUE
- `serverstop` - 0 == FALSE, 1 == TRUE
- `setbufline` - 1 == fail, 0 == success
- `setqflist` - 0 == success -1 == failure
- `wildmenumode` - 0 == FALSE, 1 == TRUE
- `win_move_separator` - 0 == FALSE, 1 == TRUE
- `win_move_statusline` - 0 == FALSE, 1 == TRUE
- `win_splitmove` - "Returns zero for success, non-zero for failure."
- `writefile` - 0 == success -1 == failure
</details>

<details>
<summary>Recommended To Use Custom Types</summary>

Some functions could use a proper `---@class` definition. For example `:h
vim.api.nvim_get_hl()` returns `vim.api.keyset.get_hl_info`.

I assumed I would define those in `vim/_meta/api_keysets_extra.lua` but didn't
know if there were preferred naming conventions. So I figured a follow-up PR for
that would be best.

These are the functions that could use custom class types, assuming an
equivalent doesn't already exist:

- `:h getcellwidths()`
- `:h getcursorcharpos()`
- `:h getmatches()`
- `:h gettagstack()`
- `:h menu_get()`
- `:h setcellwidths()`
- `:h taglist()`
- `:h timer_info()`
- `:h win_id2tabwin()`
- `:h win_screenpos()`
- `:h wordcount()`
</details>

<details>
<summary>Not Sure</summary>

All situations where I wasn't sure of the type (and an explanation of why)

- `digraph_get` - technically the type is char but lua has only string. So I guess just
  string?
- `funcref` is another weird one
- `sqrt()` can return a number or NaN. Would we define a fake NaN class and include that as a return type. e.g. `number | NaN`?
</details>