### PR TITLE
fix: ensure we've selected the diagnostics quickfix list

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -865,7 +865,16 @@ local function set_list(loclist, opts)
     end
   end
   if open then
-    api.nvim_command(loclist and 'lwindow' or 'botright cwindow')
+    if loclist then
+      api.nvim_command('lwindow')
+    else
+      -- First navigate to the diagnostics quickfix list.
+      local nr = vim.fn.getqflist({ id = _qf_id, nr = 0 }).nr
+      api.nvim_command(nr .. 'chistory')
+
+      -- Now open the quickfix list.
+      api.nvim_command('botright cwindow')
+    end
   end
 end
 


### PR DESCRIPTION
Previously, when updating the quickfix diagnostics list, we'd update it, and then open the quickfix buffer, but there was no guarantee that the quickfix buffer would be displaying the quickfix diagnostics list (it could very possibly be displaying some other quickfix list!).

This fixes things so we first select the quickfix list before opening the quickfix buffer. If `open` is not specified, the behavior is the same as before: we update the diagnostics quickfix list, but do not navigate to it.

This fixes https://github.com/neovim/neovim/issues/31540.