### PR TITLE
feat(terminal)!: cursor shape and blink

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -38,6 +38,10 @@ DIAGNOSTICS
 - The "cursor_position" parameter of |vim.diagnostic.JumpOpts| is renamed to
   "pos"
 
+HIGHLIGHTS
+• *TermCursorNC*	As of Nvim 0.11, unfocused |terminal| windows no
+			longer have any cursor.
+
 TREESITTER
 • *TSNode:child_containing_descendant()*	Use
   |TSNode:child_with_descendant()| instead; it is identical except that it can

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -87,6 +87,11 @@ EVENTS
 • |vim.ui_attach()| callbacks for |ui-messages| `msg_show` events are executed in
   |api-fast| context.
 
+HIGHLIGHTS
+
+• |TermCursorNC| is removed and no longer supported. Unfocused terminals no
+  longer have a cursor.
+
 LSP
 
 • Improved rendering of LSP hover docs. |K-lsp-default|
@@ -281,6 +286,12 @@ TERMINAL
   'scrollback' are not reflown.
 • The |terminal| now supports OSC 8 escape sequences and will display
   hyperlinks in supporting host terminals.
+• The |terminal| now uses the actual cursor, rather than a "virtual" cursor.
+  This means that escape codes sent by applications running in a terminal
+  buffer can change the cursor shape and visibility. However, it also
+  means that the |TermCursorNC| highlight group is no longer supported: an
+  unfocused terminal window will have no cursor at all (so there is nothing to
+  highlight).
 
 TREESITTER
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2977,7 +2977,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	An |OptionSet| autocmd can be used to set it up to match automatically.
 
 				*'guicursor'* *'gcr'* *E545* *E546* *E548* *E549*
-'guicursor' 'gcr'	string	(default "n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20")
+'guicursor' 'gcr'	string	(default "n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20,t:block-blinkon500-blinkoff500-TermCursor")
 			global
 	Configures the cursor style for each mode. Works in the GUI and many
 	terminals.  See |tui-cursor-shape|.
@@ -3005,6 +3005,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		ci	Command-line Insert mode
 		cr	Command-line Replace mode
 		sm	showmatch in Insert mode
+		t	Terminal mode
 		a	all modes
 	The argument-list is a dash separated list of these arguments:
 		hor{N}	horizontal bar, {N} percent of the character height
@@ -3021,7 +3022,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 			cursor is not shown.  Times are in msec.  When one of
 			the numbers is zero, there is no blinking. E.g.: >vim
 				set guicursor=n:blinkon0
-<			- Default is "blinkon0" for each mode.
+<
+			Default is "blinkon0" for each mode.
 		{group-name}
 			Highlight group that decides the color and font of the
 			cursor.

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5159,8 +5159,6 @@ EndOfBuffer	Filler lines (~) after the end of the buffer.
 		By default, this is highlighted like |hl-NonText|.
 							*hl-TermCursor*
 TermCursor	Cursor in a focused terminal.
-							*hl-TermCursorNC*
-TermCursorNC	Cursor in an unfocused terminal.
 							*hl-ErrorMsg*
 ErrorMsg	Error messages on the command line.
 							*hl-WinSeparator*

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -101,7 +101,7 @@ Configuration					*terminal-config*
 
 Options:		'modified', 'scrollback'
 Events:			|TermOpen|, |TermEnter|, |TermLeave|, |TermClose|
-Highlight groups:	|hl-TermCursor|, |hl-TermCursorNC|
+Highlight groups:	|hl-TermCursor|
 
 Terminal sets local defaults for some options, which may differ from your
 global configuration.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -325,7 +325,6 @@ Highlight groups:
 - |hl-MsgSeparator| highlights separator for scrolled messages
 - |hl-Substitute|
 - |hl-TermCursor|
-- |hl-TermCursorNC|
 - |hl-WinSeparator| highlights window separators
 - |hl-Whitespace| highlights 'listchars' whitespace
 - |hl-WinBar| highlights 'winbar'

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -2783,6 +2783,7 @@ vim.go.gp = vim.go.grepprg
 --- 	ci	Command-line Insert mode
 --- 	cr	Command-line Replace mode
 --- 	sm	showmatch in Insert mode
+--- 	t	Terminal mode
 --- 	a	all modes
 --- The argument-list is a dash separated list of these arguments:
 --- 	hor{N}	horizontal bar, {N} percent of the character height
@@ -2802,7 +2803,8 @@ vim.go.gp = vim.go.grepprg
 --- ```vim
 --- 			set guicursor=n:blinkon0
 --- ```
---- - Default is "blinkon0" for each mode.
+---
+--- 		Default is "blinkon0" for each mode.
 --- 	{group-name}
 --- 		Highlight group that decides the color and font of the
 --- 		cursor.
@@ -2848,7 +2850,7 @@ vim.go.gp = vim.go.grepprg
 ---
 ---
 --- @type string
-vim.o.guicursor = "n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20"
+vim.o.guicursor = "n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20,t:block-blinkon500-blinkoff500-TermCursor"
 vim.o.gcr = vim.o.guicursor
 vim.go.guicursor = vim.o.guicursor
 vim.go.gcr = vim.go.guicursor

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -63,7 +63,7 @@ syn keyword vimGroup contained	Comment Constant String Character Number Boolean 
 syn keyword vimHLGroup contained ErrorMsg IncSearch ModeMsg NonText StatusLine StatusLineNC EndOfBuffer VertSplit DiffText PmenuSbar TabLineSel TabLineFill Cursor lCursor QuickFixLine CursorLineSign CursorLineFold CurSearch PmenuKind PmenuKindSel PmenuMatch PmenuMatchSel PmenuExtra PmenuExtraSel Normal Directory LineNr CursorLineNr MoreMsg Question Search SpellBad SpellCap SpellRare SpellLocal PmenuThumb Pmenu PmenuSel SpecialKey Title WarningMsg WildMenu Folded FoldColumn SignColumn Visual DiffAdd DiffChange DiffDelete TabLine CursorColumn CursorLine ColorColumn MatchParen StatusLineTerm StatusLineTermNC CursorIM LineNrAbove LineNrBelow
 syn match vimHLGroup contained "\<Conceal\>"
 syn keyword vimOnlyHLGroup contained	Menu Scrollbar ToolbarButton ToolbarLine Tooltip VisualNOS
-syn keyword nvimHLGroup contained	FloatBorder FloatFooter FloatTitle MsgSeparator NormalFloat NormalNC Substitute TermCursor TermCursorNC VisualNC Whitespace WinBar WinBarNC WinSeparator
+syn keyword nvimHLGroup contained	FloatBorder FloatFooter FloatTitle MsgSeparator NormalFloat NormalNC Substitute TermCursor VisualNC Whitespace WinBar WinBarNC WinSeparator
 "}}}2
 syn case match
 

--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -341,9 +341,11 @@ void check_cursor_col(win_T *win)
   } else if (win->w_cursor.col >= len) {
     // Allow cursor past end-of-line when:
     // - in Insert mode or restarting Insert mode
+    // - in Terminal mode
     // - in Visual mode and 'selection' isn't "old"
     // - 'virtualedit' is set
     if ((State & MODE_INSERT) || restart_edit
+        || (State & MODE_TERMINAL)
         || (VIsual_active && *p_sel != 'o')
         || (cur_ve_flags & kOptVeFlagOnemore)
         || virtual_active(win)) {

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -45,6 +45,7 @@ cursorentry_T shape_table[SHAPE_IDX_COUNT] = {
   { "more", 0, 0, 0,   0,   0,   0, 0, 0, "m", SHAPE_MOUSE },
   { "more_lastline", 0, 0, 0,   0,   0,   0, 0, 0, "ml", SHAPE_MOUSE },
   { "showmatch", 0, 0, 0, 100, 100, 100, 0, 0, "sm", SHAPE_CURSOR },
+  { "terminal", 0, 0, 0, 0, 0, 0, 0, 0, "t", SHAPE_CURSOR },
 };
 
 /// Converts cursor_shapes into an Array of Dictionaries
@@ -321,6 +322,8 @@ int cursor_get_mode_idx(void)
 {
   if (State == MODE_SHOWMATCH) {
     return SHAPE_IDX_SM;
+  } else if (State == MODE_TERMINAL) {
+    return SHAPE_IDX_TERM;
   } else if (State & VREPLACE_FLAG) {
     return SHAPE_IDX_R;
   } else if (State & REPLACE_FLAG) {

--- a/src/nvim/cursor_shape.h
+++ b/src/nvim/cursor_shape.h
@@ -23,7 +23,8 @@ typedef enum {
   SHAPE_IDX_MORE   = 14,      ///< Hit-return or More
   SHAPE_IDX_MOREL  = 15,      ///< Hit-return or More in last line
   SHAPE_IDX_SM     = 16,      ///< showing matching paren
-  SHAPE_IDX_COUNT  = 17,
+  SHAPE_IDX_TERM   = 17,      ///< Terminal mode
+  SHAPE_IDX_COUNT  = 18,
 } ModeShape;
 
 typedef enum {

--- a/src/nvim/highlight.h
+++ b/src/nvim/highlight.h
@@ -15,7 +15,6 @@ EXTERN const char *hlf_names[] INIT( = {
   [HLF_8] = "SpecialKey",
   [HLF_EOB] = "EndOfBuffer",
   [HLF_TERM] = "TermCursor",
-  [HLF_TERMNC] = "TermCursorNC",
   [HLF_AT] = "NonText",
   [HLF_D] = "Directory",
   [HLF_E] = "ErrorMsg",

--- a/src/nvim/highlight_defs.h
+++ b/src/nvim/highlight_defs.h
@@ -63,7 +63,6 @@ typedef enum {
                   ///< displayed different from what it is
   HLF_EOB,        ///< after the last line in the buffer
   HLF_TERM,       ///< terminal cursor focused
-  HLF_TERMNC,     ///< terminal cursor unfocused
   HLF_AT,         ///< @ characters at end of screen, characters that don't really exist in the text
   HLF_D,          ///< directories in CTRL-D listing
   HLF_E,          ///< error messages

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -178,7 +178,6 @@ static const char *highlight_init_both[] = {
   "default link StatusLineTermNC StatusLineNC",
   "default link TabLine          StatusLineNC",
   "default link TabLineFill      TabLine",
-  "default link TermCursorNC     NONE",
   "default link VertSplit        WinSeparator",
   "default link VisualNOS        Visual",
   "default link Whitespace       NonText",

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -12,7 +12,7 @@
 // option_vars.h: definition of global variables for settable options
 
 #define HIGHLIGHT_INIT \
-  "8:SpecialKey,~:EndOfBuffer,z:TermCursor,Z:TermCursorNC,@:NonText,d:Directory,e:ErrorMsg," \
+  "8:SpecialKey,~:EndOfBuffer,z:TermCursor,@:NonText,d:Directory,e:ErrorMsg," \
   "i:IncSearch,l:Search,y:CurSearch,m:MoreMsg,M:ModeMsg,n:LineNr,a:LineNrAbove,b:LineNrBelow," \
   "N:CursorLineNr,G:CursorLineSign,O:CursorLineFold,r:Question,s:StatusLine,S:StatusLineNC," \
   "c:VertSplit,t:Title,v:Visual,V:VisualNOS,w:WarningMsg,W:WildMenu,f:Folded,F:FoldColumn," \

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3631,7 +3631,9 @@ return {
     {
       abbreviation = 'gcr',
       cb = 'did_set_guicursor',
-      defaults = { if_true = 'n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20' },
+      defaults = {
+        if_true = 'n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20,t:block-blinkon500-blinkoff500-TermCursor',
+      },
       deny_duplicates = true,
       desc = [=[
         Configures the cursor style for each mode. Works in the GUI and many
@@ -3660,6 +3662,7 @@ return {
         	ci	Command-line Insert mode
         	cr	Command-line Replace mode
         	sm	showmatch in Insert mode
+        	t	Terminal mode
         	a	all modes
         The argument-list is a dash separated list of these arguments:
         	hor{N}	horizontal bar, {N} percent of the character height
@@ -3676,7 +3679,8 @@ return {
         		cursor is not shown.  Times are in msec.  When one of
         		the numbers is zero, there is no blinking. E.g.: >vim
         			set guicursor=n:blinkon0
-        <			- Default is "blinkon0" for each mode.
+        <
+        		Default is "blinkon0" for each mode.
         	{group-name}
         		Highlight group that decides the color and font of the
         		cursor.

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -138,14 +138,20 @@ void state_handle_k_event(void)
 /// Return true if in the current mode we need to use virtual.
 bool virtual_active(win_T *wp)
 {
-  unsigned cur_ve_flags = get_ve_flags(wp);
-
   // While an operator is being executed we return "virtual_op", because
   // VIsual_active has already been reset, thus we can't check for "block"
   // being used.
   if (virtual_op != kNone) {
     return virtual_op;
   }
+
+  // In Terminal mode the cursor can be positioned anywhere by the application
+  if (State & MODE_TERMINAL) {
+    return true;
+  }
+
+  unsigned cur_ve_flags = get_ve_flags(wp);
+
   return cur_ve_flags == kOptVeFlagAll
          || ((cur_ve_flags & kOptVeFlagBlock) && VIsual_active && VIsual_mode == Ctrl_V)
          || ((cur_ve_flags & kOptVeFlagInsert) && (State & MODE_INSERT));

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1339,7 +1339,7 @@ static void tui_set_mode(TUIData *tui, ModeShape mode)
   case SHAPE_VER:
     shape = 5; break;
   }
-  UNIBI_SET_NUM_VAR(tui->params[0], shape + (int)(c.blinkon == 0));
+  UNIBI_SET_NUM_VAR(tui->params[0], shape + (int)(c.blinkon == 0 || c.blinkoff == 0));
   unibi_out_ext(tui, tui->unibi_ext.set_cursor_style);
 }
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3765,7 +3765,7 @@ describe('API', function()
       screen:expect {
         grid = [[
                                                           |
-        {1:~}{102: }{4:                                       }{1:         }|
+        {1:~}{4:^                                        }{1:         }|
         {1:~}{4:                                        }{1:         }|*4
         {1:~                                                 }|*3
         {5:-- TERMINAL --}                                    |
@@ -3781,7 +3781,7 @@ describe('API', function()
       screen:expect {
         grid = [[
                                                           |
-        {1:~}{4:herrejösses!}{102: }{4:                           }{1:         }|
+        {1:~}{4:herrejösses!^                            }{1:         }|
         {1:~}{4:                                        }{1:         }|*4
         {1:~                                                 }|*3
         {5:-- TERMINAL --}                                    |

--- a/test/functional/autocmd/focus_spec.lua
+++ b/test/functional/autocmd/focus_spec.lua
@@ -47,7 +47,7 @@ describe('autoread TUI FocusGained/FocusLost', function()
 
     screen:expect {
       grid = [[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
                                                         |
@@ -57,7 +57,7 @@ describe('autoread TUI FocusGained/FocusLost', function()
     feed_command('edit ' .. path)
     screen:expect {
       grid = [[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:xtest-foo                                         }|
       :edit xtest-foo                                   |
@@ -68,7 +68,7 @@ describe('autoread TUI FocusGained/FocusLost', function()
     feed_data('\027[O')
     screen:expect {
       grid = [[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:xtest-foo                                         }|
       :edit xtest-foo                                   |
@@ -83,7 +83,7 @@ describe('autoread TUI FocusGained/FocusLost', function()
 
     screen:expect {
       grid = [[
-      {1:l}ine 1                                            |
+      ^line 1                                            |
       line 2                                            |
       line 3                                            |
       line 4                                            |

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -1198,7 +1198,7 @@ describe('jobs', function()
     })
     -- Wait for startup to complete, so that all terminal responses are received.
     screen:expect([[
-      {1: }                                                 |
+      ^                                                  |
       ~                                                 |*3
       {1:[No Name]                       0,0-1          All}|
                                                         |
@@ -1208,7 +1208,7 @@ describe('jobs', function()
     feed(':q<CR>')
     screen:expect([[
                                                         |
-      [Process exited 0]{1: }                               |
+      [Process exited 0]^                                |
                                                         |*4
       {3:-- TERMINAL --}                                    |
     ]])

--- a/test/functional/core/log_spec.lua
+++ b/test/functional/core/log_spec.lua
@@ -46,7 +46,7 @@ describe('log', function()
         env = env,
       })
       screen:expect([[
-        {1: }                                                 |
+        ^                                                  |
         ~                                                 |*4
                                                           |
         {3:-- TERMINAL --}                                    |

--- a/test/functional/core/main_spec.lua
+++ b/test/functional/core/main_spec.lua
@@ -120,7 +120,7 @@ describe('command-line option', function()
       feed('i:cq<CR>')
       screen:expect([[
                                                 |
-        [Process exited 1]{2: }                     |
+        [Process exited 1]^                      |
                                                 |*5
         {5:-- TERMINAL --}                          |
       ]])

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -1153,7 +1153,7 @@ describe('user config init', function()
         -- `i` to enter Terminal mode, `a` to allow
         feed('ia')
         screen:expect([[
-                                                            |
+          ^                                                  |
           ~                                                 |*4
           [No Name]                       0,0-1          All|
                                                             |
@@ -1162,7 +1162,7 @@ describe('user config init', function()
         feed(':echo g:exrc_file<CR>')
         screen:expect(string.format(
           [[
-                                                            |
+          ^                                                  |
           ~                                                 |*4
           [No Name]                       0,0-1          All|
           %s%s|

--- a/test/functional/legacy/highlight_spec.lua
+++ b/test/functional/legacy/highlight_spec.lua
@@ -29,8 +29,8 @@ describe(':highlight', function()
                                          |
       TermCursor     {2:xxx} {18:cterm=}reverse   |
                          {18:gui=}reverse     |
-      TermCursorNC   xxx cleared         |
       NonText        {1:xxx} {18:ctermfg=}12      |
+                         {18:gui=}bold        |
       {6:-- More --}^                         |
     ]])
     feed('q')

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -263,7 +263,7 @@ describe('vim.ui_attach', function()
       ]],
       messages = {
         {
-          content = { { 'E122: Function Foo already exists, add ! to replace it', 9, 7 } },
+          content = { { 'E122: Function Foo already exists, add ! to replace it', 9, 6 } },
           kind = 'emsg',
         },
       },
@@ -280,7 +280,7 @@ describe('vim.ui_attach', function()
       ]],
       messages = {
         {
-          content = { { 'replace with Replacement (y/n/a/q/l/^E/^Y)?', 6, 19 } },
+          content = { { 'replace with Replacement (y/n/a/q/l/^E/^Y)?', 6, 18 } },
           kind = 'confirm_sub',
         },
       },
@@ -348,7 +348,7 @@ describe('vim.ui_attach', function()
         foo^                                     |
         {1:~                                       }|*4
       ]],
-      showmode = { { '-- INSERT --', 5, 12 } },
+      showmode = { { '-- INSERT --', 5, 11 } },
     })
     feed('<esc>:1mes clear<cr>:mes<cr>')
     screen:expect({
@@ -375,7 +375,7 @@ describe('vim.ui_attach', function()
             {
               'Error executing vim.schedule lua callback: [string "<nvim>"]:2: attempt to index global \'err\' (a nil value)\nstack traceback:\n\t[string "<nvim>"]:2: in function <[string "<nvim>"]:2>',
               9,
-              7,
+              6,
             },
           },
           kind = 'lua_error',
@@ -385,13 +385,13 @@ describe('vim.ui_attach', function()
             {
               'Error executing vim.schedule lua callback: [string "<nvim>"]:2: attempt to index global \'err\' (a nil value)\nstack traceback:\n\t[string "<nvim>"]:2: in function <[string "<nvim>"]:2>',
               9,
-              7,
+              6,
             },
           },
           kind = 'lua_error',
         },
         {
-          content = { { 'Press ENTER or type command to continue', 100, 19 } },
+          content = { { 'Press ENTER or type command to continue', 100, 18 } },
           kind = 'return_prompt',
         },
       },

--- a/test/functional/terminal/altscreen_spec.lua
+++ b/test/functional/terminal/altscreen_spec.lua
@@ -35,13 +35,13 @@ describe(':terminal altscreen', function()
       line6                                             |
       line7                                             |
       line8                                             |
-      {1: }                                                 |
+      ^                                                  |
       {3:-- TERMINAL --}                                    |
     ]])
     enter_altscreen()
     screen:expect([[
                                                         |*5
-      {1: }                                                 |
+      ^                                                  |
       {3:-- TERMINAL --}                                    |
     ]])
     eq(10, api.nvim_buf_line_count(0))
@@ -68,7 +68,7 @@ describe(':terminal altscreen', function()
         line6                                             |
         line7                                             |
         line8                                             |
-        {1: }                                                 |
+        ^                                                  |
         {3:-- TERMINAL --}                                    |
       ]])
       feed('<c-\\><c-n>gg')
@@ -103,7 +103,7 @@ describe(':terminal altscreen', function()
         line14                                            |
         line15                                            |
         line16                                            |
-        {1: }                                                 |
+        ^                                                  |
         {3:-- TERMINAL --}                                    |
       ]])
     end)
@@ -132,7 +132,7 @@ describe(':terminal altscreen', function()
       screen:expect([[
                                                           |*2
         rows: 4, cols: 50                                 |
-        {1: }                                                 |
+        ^                                                  |
         {3:-- TERMINAL --}                                    |
       ]])
     end
@@ -160,7 +160,7 @@ describe(':terminal altscreen', function()
           line5                                             |
           line6                                             |
           line7                                             |
-          line8                                             |
+          ^line8                                             |
           {3:-- TERMINAL --}                                    |
         ]])
       end)

--- a/test/functional/terminal/api_spec.lua
+++ b/test/functional/terminal/api_spec.lua
@@ -33,7 +33,7 @@ describe('api', function()
   it('qa! RPC request during insert-mode', function()
     screen:expect {
       grid = [[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*4
                                                         |
       {3:-- TERMINAL --}                                    |
@@ -45,7 +45,7 @@ describe('api', function()
 
     -- Wait for socket creation.
     screen:expect([[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*4
       ]] .. socket_name .. [[                       |
       {3:-- TERMINAL --}                                    |
@@ -57,7 +57,7 @@ describe('api', function()
     tt.feed_data('i[tui] insert-mode')
     -- Wait for stdin to be processed.
     screen:expect([[
-      [tui] insert-mode{1: }                                |
+      [tui] insert-mode^                                 |
       {4:~                                                 }|*4
       {3:-- INSERT --}                                      |
       {3:-- TERMINAL --}                                    |
@@ -73,7 +73,7 @@ describe('api', function()
       [tui] insert-mode                                 |
       [socket 1] this is more t                         |
       han 25 columns                                    |
-      [socket 2] input{1: }                                 |
+      [socket 2] input^                                  |
       {4:~                        }                         |
       {3:-- INSERT --}                                      |
       {3:-- TERMINAL --}                                    |

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -89,7 +89,7 @@ describe(':terminal buffer', function()
       feed('<c-\\><c-n>')
       screen:expect([[
         tty ready                                         |
-        {2:^ }                                                 |
+        ^                                                  |
                                                           |*5
       ]])
     end)
@@ -109,7 +109,7 @@ describe(':terminal buffer', function()
     feed('<c-\\><c-n>dd')
     screen:expect([[
       tty ready                                         |
-      {2:^ }                                                 |
+      ^                                                  |
                                                         |*4
       {8:E21: Cannot make changes, 'modifiable' is off}     |
     ]])
@@ -122,7 +122,7 @@ describe(':terminal buffer', function()
     screen:expect([[
       ^tty ready                                         |
       appended tty ready                                |*2
-      {2: }                                                 |
+                                                        |
                                                         |*2
       :let @a = "appended " . @a                        |
     ]])
@@ -142,7 +142,7 @@ describe(':terminal buffer', function()
     screen:expect([[
       ^tty ready                                         |
       appended tty ready                                |
-      {2: }                                                 |
+                                                        |
                                                         |*3
       :put a                                            |
     ]])
@@ -151,7 +151,7 @@ describe(':terminal buffer', function()
     screen:expect([[
       tty ready                                         |
       appended tty ready                                |*2
-      {2: }                                                 |
+                                                        |
                                                         |
       ^                                                  |
       :6put a                                           |
@@ -198,7 +198,7 @@ describe(':terminal buffer', function()
       {4:~                                                 }|
       {5:==========                                        }|
       rows: 2, cols: 50                                 |
-      {2: }                                                 |
+                                                        |
       {18:==========                                        }|
                                                         |
     ]])
@@ -234,7 +234,7 @@ describe(':terminal buffer', function()
     command('set rightleft')
     screen:expect([[
                                                ydaer ytt|
-      {1:a}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
                                                         |*4
       {3:-- TERMINAL --}                                    |
     ]])
@@ -277,7 +277,7 @@ describe(':terminal buffer', function()
     screen:expect {
       grid = [[
       tty ready                                         |
-      {2:^ }                                                 |
+      ^                                                  |
                                                         |*4
       {3:-- (terminal) --}                                  |
     ]],
@@ -288,7 +288,7 @@ describe(':terminal buffer', function()
     screen:expect {
       grid = [[
       tty ready                                         |
-      {2: }                                                 |
+                                                        |
                                                         |*4
       :let g:x = 17^                                     |
     ]],
@@ -298,7 +298,7 @@ describe(':terminal buffer', function()
     screen:expect {
       grid = [[
       tty ready                                         |
-      {1: }                                                 |
+      ^                                                  |
                                                         |*4
       {3:-- TERMINAL --}                                    |
     ]],
@@ -534,7 +534,7 @@ describe('terminal input', function()
       'while 1 | redraw | echo keytrans(getcharstr()) | endwhile',
     })
     screen:expect([[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:[No Name]                       0,0-1          All}|
                                                         |
@@ -594,7 +594,7 @@ describe('terminal input', function()
                                                           |
         {4:~                                                 }|*3
         {5:[No Name]                       0,0-1          All}|
-        %s{1: }{MATCH: *}|
+        %s^ {MATCH: *}|
         {3:-- TERMINAL --}                                    |
       ]]):format(key))
     end
@@ -624,7 +624,7 @@ if is_os('win') then
       > :: appended :: tty ready                        |
       > :: tty ready                                    |
       > :: appended :: tty ready                        |
-      ^> {2: }                                               |
+      ^>                                                 |
       :let @a = @a . "\n:: appended " . @a . "\n\n"     |
       ]])
       -- operator count is also taken into consideration
@@ -635,7 +635,7 @@ if is_os('win') then
       > :: appended :: tty ready                        |
       > :: tty ready                                    |
       > :: appended :: tty ready                        |
-      ^> {2: }                                               |
+      ^>                                                 |
       :let @a = @a . "\n:: appended " . @a . "\n\n"     |
       ]])
     end)
@@ -649,7 +649,7 @@ if is_os('win') then
                                                         |
       > :: tty ready                                    |
       > :: appended :: tty ready                        |
-      > {2: }                                               |
+      >                                                 |
                                                         |
       ^                                                  |
       :put a                                            |
@@ -662,7 +662,7 @@ if is_os('win') then
       > :: appended :: tty ready                        |
       > :: tty ready                                    |
       > :: appended :: tty ready                        |
-      ^> {2: }                                               |
+      ^>                                                 |
       :6put a                                           |
       ]])
     end)

--- a/test/functional/terminal/mouse_spec.lua
+++ b/test/functional/terminal/mouse_spec.lua
@@ -32,7 +32,7 @@ describe(':terminal mouse', function()
       line28                                            |
       line29                                            |
       line30                                            |
-      {1: }                                                 |
+      ^                                                  |
       {3:-- TERMINAL --}                                    |
     ]])
   end)
@@ -107,7 +107,7 @@ describe(':terminal mouse', function()
           line29                                            |
           line30                                            |
           mouse enabled                                     |
-          {1: }                                                 |
+          ^                                                  |
           {3:-- TERMINAL --}                                    |
         ]])
       end)
@@ -121,7 +121,7 @@ describe(':terminal mouse', function()
           line29                                            |
           line30                                            |
           mouse enabled                                     |
-           "#{1: }                                              |
+           "#^                                               |
           {3:-- TERMINAL --}                                    |
         ]])
         feed('<LeftDrag><2,2>')
@@ -131,7 +131,7 @@ describe(':terminal mouse', function()
           line29                                            |
           line30                                            |
           mouse enabled                                     |
-             @##{1: }                                           |
+             @##^                                            |
           {3:-- TERMINAL --}                                    |
         ]])
         feed('<LeftDrag><3,2>')
@@ -141,7 +141,7 @@ describe(':terminal mouse', function()
           line29                                            |
           line30                                            |
           mouse enabled                                     |
-                @$#{1: }                                        |
+                @$#^                                         |
           {3:-- TERMINAL --}                                    |
         ]])
         feed('<LeftRelease><3,2>')
@@ -151,7 +151,7 @@ describe(':terminal mouse', function()
           line29                                            |
           line30                                            |
           mouse enabled                                     |
-                   #$#{1: }                                     |
+                   #$#^                                      |
           {3:-- TERMINAL --}                                    |
         ]])
       end)
@@ -165,7 +165,7 @@ describe(':terminal mouse', function()
           line29                                            |
           line30                                            |
           mouse enabled                                     |
-          `!!{1: }                                              |
+          `!!^                                               |
           {3:-- TERMINAL --}                                    |
         ]])
       end)
@@ -179,7 +179,7 @@ describe(':terminal mouse', function()
           line29                                            |
           line30                                            |
           mouse enabled                                     |
-           "#{1: }                                              |
+           "#^                                               |
           {3:-- TERMINAL --}                                    |
         ]])
         feed('<ScrollWheelUp><1,2>')
@@ -189,7 +189,7 @@ describe(':terminal mouse', function()
           line29                                            |
           line30                                            |
           mouse enabled                                     |
-             `"#{1: }                                           |
+             `"#^                                            |
           {3:-- TERMINAL --}                                    |
         ]])
         feed('<LeftDrag><2,2>')
@@ -199,7 +199,7 @@ describe(':terminal mouse', function()
           line29                                            |
           line30                                            |
           mouse enabled                                     |
-                @##{1: }                                        |
+                @##^                                         |
           {3:-- TERMINAL --}                                    |
         ]])
         feed('<ScrollWheelUp><2,2>')
@@ -209,7 +209,7 @@ describe(':terminal mouse', function()
           line29                                            |
           line30                                            |
           mouse enabled                                     |
-                   `##{1: }                                     |
+                   `##^                                      |
           {3:-- TERMINAL --}                                    |
         ]])
         feed('<LeftRelease><2,2>')
@@ -219,7 +219,7 @@ describe(':terminal mouse', function()
           line29                                            |
           line30                                            |
           mouse enabled                                     |
-                      ###{1: }                                  |
+                      ###^                                   |
           {3:-- TERMINAL --}                                    |
         ]])
       end)
@@ -237,7 +237,7 @@ describe(':terminal mouse', function()
           {7: 13 }line30                                        |
           {7: 14 }mouse enabled                                 |
           {7: 15 }rows: 6, cols: 46                             |
-          {7: 16 }{2: }                                             |
+          {7: 16 }                                              |
                                                             |
         ]])
         -- If click on the coordinate (0,1) of the region of the terminal
@@ -249,7 +249,7 @@ describe(':terminal mouse', function()
           {7: 13 }line30                                        |
           {7: 14 }mouse enabled                                 |
           {7: 15 }rows: 6, cols: 46                             |
-          {7: 16 } !"{1: }                                          |
+          {7: 16 } !"^                                           |
           {3:-- TERMINAL --}                                    |
         ]])
       end)
@@ -261,7 +261,7 @@ describe(':terminal mouse', function()
           line30                                            |
           mouse enabled                                     |
           rows: 5, cols: 50                                 |
-          {1: }                                                 |
+          ^                                                  |
           ==========                                        |
           {3:-- TERMINAL --}                                    |
         ]])
@@ -271,7 +271,7 @@ describe(':terminal mouse', function()
           line30                                            |
           mouse enabled                                     |
           rows: 5, cols: 50                                 |
-          {2:^ }                                                 |
+          ^                                                  |
           ==========                                        |
                                                             |
         ]])
@@ -280,7 +280,7 @@ describe(':terminal mouse', function()
           mouse enabled                                     |
           rows: 5, cols: 50                                 |
           rows: 4, cols: 50                                 |
-          {2:^ }                                                 |
+          ^                                                  |
           ==========                                        |
                                                             |*2
         ]])
@@ -293,7 +293,7 @@ describe(':terminal mouse', function()
           line30                  │{4:~                        }|
           mouse enabled           │{4:~                        }|
           rows: 5, cols: 24       │{4:~                        }|
-          {1: }                       │{4:~                        }|
+          ^                        │{4:~                        }|
           ==========               ==========               |
           {3:-- TERMINAL --}                                    |
         ]])
@@ -303,7 +303,7 @@ describe(':terminal mouse', function()
           line30                  │{4:~                        }|
           mouse enabled           │{4:~                        }|
           rows: 5, cols: 24       │{4:~                        }|
-          {2:^ }                       │{4:~                        }|
+          ^                        │{4:~                        }|
           ==========               ==========               |
                                                             |
         ]])
@@ -313,7 +313,7 @@ describe(':terminal mouse', function()
           mouse enabled          │{4:~                         }|
           rows: 5, cols: 24      │{4:~                         }|
           rows: 5, cols: 23      │{4:~                         }|
-          {2:^ }                      │{4:~                         }|
+          ^                       │{4:~                         }|
           ==========              ==========                |
                                                             |
         ]])
@@ -327,7 +327,7 @@ describe(':terminal mouse', function()
           line30                                            |
           mouse enabled                                     |
           rows: 5, cols: 50                                 |
-          {1: }                                                 |
+          ^                                                  |
           {3:-- TERMINAL --}                                    |
         ]])
         feed('<LeftMouse><0,0>')
@@ -337,7 +337,7 @@ describe(':terminal mouse', function()
           line30                                            |
           mouse enabled                                     |
           rows: 5, cols: 50                                 |
-          {2:^ }                                                 |
+          ^                                                  |
                                                             |
         ]])
         command('set showtabline=2 tabline=TABLINE | startinsert')
@@ -347,7 +347,7 @@ describe(':terminal mouse', function()
           mouse enabled                                     |
           rows: 5, cols: 50                                 |
           rows: 4, cols: 50                                 |
-          {1: }                                                 |
+          ^                                                  |
           {3:-- TERMINAL --}                                    |
         ]])
         feed('<LeftMouse><0,0>')
@@ -357,7 +357,7 @@ describe(':terminal mouse', function()
           mouse enabled                                     |
           rows: 5, cols: 50                                 |
           rows: 4, cols: 50                                 |
-          {2:^ }                                                 |
+          ^                                                  |
                                                             |
         ]])
         command('setlocal winbar= | startinsert')
@@ -367,7 +367,7 @@ describe(':terminal mouse', function()
           rows: 5, cols: 50                                 |
           rows: 4, cols: 50                                 |
           rows: 5, cols: 50                                 |
-          {1: }                                                 |
+          ^                                                  |
           {3:-- TERMINAL --}                                    |
         ]])
         feed('<LeftMouse><0,0>')
@@ -377,7 +377,7 @@ describe(':terminal mouse', function()
           rows: 5, cols: 50                                 |
           rows: 4, cols: 50                                 |
           rows: 5, cols: 50                                 |
-          {2:^ }                                                 |
+          ^                                                  |
                                                             |
         ]])
       end)
@@ -391,7 +391,7 @@ describe(':terminal mouse', function()
           line29                   │line29                  |
           line30                   │line30                  |
           rows: 5, cols: 25        │rows: 5, cols: 25       |
-          {2:^ }                        │{2: }                       |
+          ^                         │                        |
           ==========                ==========              |
           :vsp                                              |
         ]])
@@ -401,7 +401,7 @@ describe(':terminal mouse', function()
           {4:~                        }│line30                  |
           {4:~                        }│rows: 5, cols: 25       |
           {4:~                        }│rows: 5, cols: 24       |
-          {4:~                        }│{2: }                       |
+          {4:~                        }│                        |
           ==========                ==========              |
           :enew | set number                                |
         ]])
@@ -411,7 +411,7 @@ describe(':terminal mouse', function()
           {7: 28 }line                 │line30                  |
           {7: 29 }line                 │rows: 5, cols: 25       |
           {7: 30 }line                 │rows: 5, cols: 24       |
-          {7: 31 }^                     │{2: }                       |
+          {7: 31 }^                     │                        |
           ==========                ==========              |
                                                             |
         ]])
@@ -421,7 +421,7 @@ describe(':terminal mouse', function()
           {7: 28 }line                 │line30                  |
           {7: 29 }line                 │rows: 5, cols: 25       |
           {7: 30 }line                 │rows: 5, cols: 24       |
-          {7: 31 }                     │{1: }                       |
+          {7: 31 }                     │^                        |
           ==========                ==========              |
           {3:-- TERMINAL --}                                    |
         ]])
@@ -434,7 +434,7 @@ describe(':terminal mouse', function()
           {7: 28 }line                 │rows: 5, cols: 25       |
           {7: 29 }line                 │rows: 5, cols: 24       |
           {7: 30 }line                 │mouse enabled           |
-          {7: 31 }                     │{1: }                       |
+          {7: 31 }                     │^                        |
           ==========                ==========              |
           {3:-- TERMINAL --}                                    |
         ]])
@@ -447,7 +447,7 @@ describe(':terminal mouse', function()
           {7: 22 }line                 │rows: 5, cols: 25       |
           {7: 23 }line                 │rows: 5, cols: 24       |
           {7: 24 }line                 │mouse enabled           |
-          {7: 25 }line                 │{1: }                       |
+          {7: 25 }line                 │^                        |
           ==========                ==========              |
           {3:-- TERMINAL --}                                    |
         ]])
@@ -457,7 +457,7 @@ describe(':terminal mouse', function()
           {7: 27 }line                 │rows: 5, cols: 25       |
           {7: 28 }line                 │rows: 5, cols: 24       |
           {7: 29 }line                 │mouse enabled           |
-          {7: 30 }line                 │{1: }                       |
+          {7: 30 }line                 │^                        |
           ==========                ==========              |
           {3:-- TERMINAL --}                                    |
         ]])
@@ -468,7 +468,7 @@ describe(':terminal mouse', function()
           {7: 17 }line                 │rows: 5, cols: 25       |
           {7: 18 }line                 │rows: 5, cols: 24       |
           {7: 19 }line                 │mouse enabled           |
-          {7: 20 }line                 │{1: }                       |
+          {7: 20 }line                 │^                        |
           ==========                ==========              |
           {3:-- TERMINAL --}                                    |
         ]])
@@ -483,7 +483,7 @@ describe(':terminal mouse', function()
           {7:  2 }linelinelinelineline │rows: 5, cols: 25       |
           {7:  3 }linelinelinelineline │rows: 5, cols: 24       |
           {7:  4 }linelinelinelineline │mouse enabled           |
-          {7:  5 }linelinelinelineline │{1: }                       |
+          {7:  5 }linelinelinelineline │^                        |
           ==========                ==========              |
           {3:-- TERMINAL --}                                    |
         ]])
@@ -493,7 +493,7 @@ describe(':terminal mouse', function()
           {7:  2 }nelinelineline       │rows: 5, cols: 25       |
           {7:  3 }nelinelineline       │rows: 5, cols: 24       |
           {7:  4 }nelinelineline       │mouse enabled           |
-          {7:  5 }nelinelineline       │{1: }                       |
+          {7:  5 }nelinelineline       │^                        |
           ==========                ==========              |
           {3:-- TERMINAL --}                                    |
         ]])
@@ -504,7 +504,7 @@ describe(':terminal mouse', function()
           {7:  2 }nelinelinelineline   │rows: 5, cols: 25       |
           {7:  3 }nelinelinelineline   │rows: 5, cols: 24       |
           {7:  4 }nelinelinelineline   │mouse enabled           |
-          {7:  5 }nelinelinelineline   │{1: }                       |
+          {7:  5 }nelinelinelineline   │^                        |
           ==========                ==========              |
           {3:-- TERMINAL --}                                    |
         ]])
@@ -517,7 +517,7 @@ describe(':terminal mouse', function()
           {7: 28 }l^ine                 │rows: 5, cols: 25       |
           {7: 29 }line                 │rows: 5, cols: 24       |
           {7: 30 }line                 │mouse enabled           |
-          {7: 31 }                     │{2: }                       |
+          {7: 31 }                     │                        |
           ==========                ==========              |
                                                             |
         ]])
@@ -531,7 +531,7 @@ describe(':terminal mouse', function()
           {7: 28 }line                 │rows: 5, cols: 25       |
           {7: 29 }line                 │rows: 5, cols: 24       |
           {7: 30 }line                 │mouse enabled           |
-          {7: 31 }^                     │{2: }                       |
+          {7: 31 }^                     │                        |
           ==========                ==========              |
                                                             |
         ]])
@@ -541,7 +541,7 @@ describe(':terminal mouse', function()
           rows: 5, cols: 24        │rows: 5, cols: 24       |
           mouse enabled            │mouse enabled           |
           rows: 5, cols: 25        │rows: 5, cols: 25       |
-          {2:^ }                        │{2: }                       |
+          ^                         │                        |
           ==========                ==========              |
           :bn                                               |
         ]])
@@ -551,7 +551,7 @@ describe(':terminal mouse', function()
           {7: 28 }line                 │mouse enabled           |
           {7: 29 }line                 │rows: 5, cols: 25       |
           {7: 30 }line                 │rows: 5, cols: 24       |
-          {7: 31 }^                     │{2: }                       |
+          {7: 31 }^                     │                        |
           ==========                ==========              |
           :bn                                               |
         ]])

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -39,7 +39,7 @@ describe(':terminal scrollback', function()
         line28                        |
         line29                        |
         line30                        |
-        {1: }                             |
+        ^                              |
         {3:-- TERMINAL --}                |
       ]])
     end)
@@ -67,7 +67,7 @@ describe(':terminal scrollback', function()
         line2                         |
         line3                         |
         line4                         |
-        {1: }                             |
+        ^                              |
         {3:-- TERMINAL --}                |
       ]])
     end)
@@ -84,7 +84,7 @@ describe(':terminal scrollback', function()
           line3                         |
           line4                         |
           line5                         |
-          {1: }                             |
+          ^                              |
           {3:-- TERMINAL --}                |
         ]])
         eq(7, api.nvim_buf_line_count(0))
@@ -102,7 +102,7 @@ describe(':terminal scrollback', function()
             line5                         |
             line6                         |
             line7                         |
-            line8{1: }                        |
+            line8^                         |
             {3:-- TERMINAL --}                |
           ]])
 
@@ -135,7 +135,7 @@ describe(':terminal scrollback', function()
             line5                         |
             line6                         |
             line7                         |
-            ^line8{2: }                        |
+            ^line8                         |
                                           |
           ]])
         end)
@@ -151,7 +151,7 @@ describe(':terminal scrollback', function()
           line3                       |
           line4                       |
           rows: 5, cols: 28           |
-          {2:^ }                           |
+          ^                            |
                                       |
         ]])
       end
@@ -168,7 +168,7 @@ describe(':terminal scrollback', function()
           screen:expect([[
             rows: 5, cols: 28         |
             rows: 3, cols: 26         |
-            {2:^ }                         |
+            ^                          |
                                       |
           ]])
           eq(8, api.nvim_buf_line_count(0))
@@ -201,7 +201,7 @@ describe(':terminal scrollback', function()
         screen:expect([[
           tty ready                     |
           rows: 4, cols: 30             |
-          {1: }                             |
+          ^                              |
                                         |
           {3:-- TERMINAL --}                |
         ]])
@@ -220,7 +220,7 @@ describe(':terminal scrollback', function()
           screen:expect([[
             rows: 4, cols: 30             |
             rows: 3, cols: 30             |
-            {1: }                             |
+            ^                              |
             {3:-- TERMINAL --}                |
           ]])
           eq(4, api.nvim_buf_line_count(0))
@@ -235,7 +235,7 @@ describe(':terminal scrollback', function()
           screen:expect([[
             rows: 4, cols: 30             |
             rows: 3, cols: 30             |
-            {1: }                             |
+            ^                              |
             {3:-- TERMINAL --}                |
           ]])
         end)
@@ -252,14 +252,14 @@ describe(':terminal scrollback', function()
         line2                         |
         line3                         |
         line4                         |
-        {1: }                             |
+        ^                              |
         {3:-- TERMINAL --}                |
       ]])
       screen:try_resize(screen._width, screen._height - 3)
       screen:expect([[
         line4                         |
         rows: 3, cols: 30             |
-        {1: }                             |
+        ^                              |
         {3:-- TERMINAL --}                |
       ]])
       eq(7, api.nvim_buf_line_count(0))
@@ -278,7 +278,7 @@ describe(':terminal scrollback', function()
           line4                         |
           rows: 3, cols: 30             |
           rows: 4, cols: 30             |
-          {1: }                             |
+          ^                              |
           {3:-- TERMINAL --}                |
         ]])
       end
@@ -300,7 +300,7 @@ describe(':terminal scrollback', function()
             rows: 3, cols: 30             |
             rows: 4, cols: 30             |
             rows: 7, cols: 30             |
-            {1: }                             |
+            ^                              |
             {3:-- TERMINAL --}                |
           ]])
           eq(9, api.nvim_buf_line_count(0))
@@ -337,7 +337,7 @@ describe(':terminal scrollback', function()
               rows: 4, cols: 30             |
               rows: 7, cols: 30             |
               rows: 11, cols: 30            |
-              {1: }                             |
+              ^                              |
                                             |
               {3:-- TERMINAL --}                |
             ]])
@@ -362,7 +362,7 @@ describe(':terminal prints more lines than the screen height and exits', functio
       line8                         |
       line9                         |
                                     |
-      [Process exited 0]{2: }           |
+      [Process exited 0]^            |
       {5:-- TERMINAL --}                |
     ]])
     feed('<cr>')
@@ -454,7 +454,7 @@ describe("'scrollback' option", function()
         39: line                      |
         40: line                      |
                                       |
-        ${1: }                            |
+        $^                             |
         {3:-- TERMINAL --}                |
       ]],
       }
@@ -493,7 +493,7 @@ describe("'scrollback' option", function()
         line28                        |
         line29                        |
         line30                        |
-        {1: }                             |
+        ^                              |
         {3:-- TERMINAL --}                |
       ]])
     local term_height = 6 -- Actual terminal screen height, not the scrollback
@@ -634,7 +634,7 @@ describe('pending scrollback line handling', function()
     screen:expect [[
       hi                            |*4
                                     |
-      [Process exited 0]{2: }           |
+      [Process exited 0]^            |
       {3:-- TERMINAL --}                |
     ]]
     assert_alive()

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -59,7 +59,7 @@ describe('TUI', function()
       'colorscheme vim',
     })
     screen:expect([[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
                                                         |
@@ -105,7 +105,7 @@ describe('TUI', function()
     -- Need buffer rows to provoke the behavior.
     feed_data(':edit test/functional/fixtures/bigfile.txt\n')
     screen:expect([[
-      {1:0}000;<control>;Cc;0;BN;;;;;N;NULL;;;;             |
+      ^0000;<control>;Cc;0;BN;;;;;N;NULL;;;;             |
       0001;<control>;Cc;0;BN;;;;;N;START OF HEADING;;;; |
       0002;<control>;Cc;0;BN;;;;;N;START OF TEXT;;;;    |
       0003;<control>;Cc;0;BN;;;;;N;END OF TEXT;;;;      |
@@ -155,7 +155,7 @@ describe('TUI', function()
       {8:FAIL 0}                                            |
       {8:FAIL 1}                                            |
       {8:FAIL 2}                                            |
-      {10:-- More --}{1: }                                       |
+      {10:-- More --}^                                        |
       {3:-- TERMINAL --}                                    |
     ]],
     }
@@ -170,7 +170,7 @@ describe('TUI', function()
       {8:FAIL 1}                                            |
       {8:FAIL 2}                                            |
                                                         |*2
-      {10:-- More --}{1: }                                       |
+      {10:-- More --}^                                        |
       {3:-- TERMINAL --}                                    |
     ]],
     }
@@ -186,7 +186,7 @@ describe('TUI', function()
       {8:FAIL 3}                                            |
       {8:FAIL 4}                                            |
       {8:FAIL 5}                                            |
-      {10:-- More --}{1: }                                       |
+      {10:-- More --}^                                        |
       {3:-- TERMINAL --}                                    |
     ]],
     }
@@ -199,7 +199,7 @@ describe('TUI', function()
       {8:FAIL 3}                                            |
       {8:FAIL 4}                                            |
       {8:FAIL 5}                                            |
-      {10:-- More --}{1: }                                       |
+      {10:-- More --}^                                        |
       {3:-- TERMINAL --}                                    |
     ]],
     }
@@ -210,7 +210,7 @@ describe('TUI', function()
       {8:FAIL 3}                                            |
       {8:FAIL 4}                                            |
       {8:FAIL 5}                                            |
-      {10:-- More --}{1: }                                       |
+      {10:-- More --}^                                        |
       {3:-- TERMINAL --}                                    |
     ]],
     }
@@ -221,7 +221,7 @@ describe('TUI', function()
       :call ManyErr()                                   |
       {8:Error detected while processing function ManyErr:} |
       {11:line    2:}                                        |
-      {10:-- More --}{1: }                                       |
+      {10:-- More --}^                                        |
       {3:-- TERMINAL --}                                    |
     ]],
     }
@@ -237,7 +237,7 @@ describe('TUI', function()
       {8:FAIL 2}                                            |
       {8:FAIL 3}                                            |
       {8:FAIL 4}                                            |
-      {10:-- More --}{1: }                                       |
+      {10:-- More --}^                                        |
       {3:-- TERMINAL --}                                    |
     ]],
     }
@@ -245,7 +245,7 @@ describe('TUI', function()
     feed_data('\003')
     screen:expect {
       grid = [[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*6
       {5:[No Name]                                         }|
                                                         |
@@ -259,7 +259,7 @@ describe('TUI', function()
     screen:expect([[
       abc                                               |
       test1                                             |
-      test2{1: }                                            |
+      test2^                                             |
       {4:~                                                 }|
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -269,7 +269,7 @@ describe('TUI', function()
     screen:expect([[
       abc                                               |
       test1                                             |
-      test{1:2}                                             |
+      test^2                                             |
       {4:~                                                 }|
       {5:[No Name] [+]                                     }|
                                                         |
@@ -287,14 +287,14 @@ describe('TUI', function()
       alt-j                                             |
       alt-k                                             |
       alt-l                                             |
-      {1: }                                                 |
+      ^                                                  |
       {5:[No Name] [+]                                     }|
                                                         |
       {3:-- TERMINAL --}                                    |
     ]])
     feed_data('gg')
     screen:expect([[
-      {1:a}lt-d                                             |
+      ^alt-d                                             |
       alt-f                                             |
       alt-g                                             |
       alt-h                                             |
@@ -309,7 +309,7 @@ describe('TUI', function()
     -- ALT+j inserts "ê". Nvim does not (#3982).
     feed_data('i\022\027j')
     screen:expect([[
-      <M-j>{1: }                                            |
+      <M-j>^                                             |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -329,7 +329,7 @@ describe('TUI', function()
     )
     feed_data('\027[27u;')
     screen:expect([[
-      ESCsemicolo{1:n}                                      |
+      ESCsemicolo^n                                      |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
                                                         |
@@ -343,7 +343,7 @@ describe('TUI', function()
   it('interprets <Esc><Nul> as <M-C-Space> #17198', function()
     feed_data('i\022\027\000')
     screen:expect([[
-      <M-C-Space>{1: }                                      |
+      <M-C-Space>^                                       |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -357,7 +357,7 @@ describe('TUI', function()
     feed_data('\022\022') -- ctrl+v
     feed_data('\022\013') -- ctrl+m
     screen:expect([[
-      {6:^G^V^M}{1: }                                           |
+      {6:^G^V^M}^                                            |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -376,7 +376,7 @@ describe('TUI', function()
       {}
     )
     screen:expect([[
-      {11:  1 }{1:0}----1----2----3----4│{11:  1 }0----1----2----3----|
+      {11:  1 }^0----1----2----3----4│{11:  1 }0----1----2----3----|
       {11:  2 }0----1----2----3----4│{11:  2 }0----1----2----3----|
       {11:  3 }0----1----2----3----4│{11:  3 }0----1----2----3----|
       {11:  4 }0----1----2----3----4│{11:  4 }0----1----2----3----|
@@ -391,7 +391,7 @@ describe('TUI', function()
       api.nvim_input_mouse('wheel', 'down', '', 0, 0, 7)
     end
     screen:expect([[
-      {11:  2 }{1:0}----1----2----3----4│{11:  1 }0----1----2----3----|
+      {11:  2 }^0----1----2----3----4│{11:  1 }0----1----2----3----|
       {11:  3 }0----1----2----3----4│{11:  2 }0----1----2----3----|
       {11:  4 }0----1----2----3----4│{11:  3 }0----1----2----3----|
       {11:  5 }0----1----2----3----4│{11:  4 }0----1----2----3----|
@@ -406,7 +406,7 @@ describe('TUI', function()
       api.nvim_input_mouse('wheel', 'down', '', 0, 0, 47)
     end
     screen:expect([[
-      {11:  2 }{1:0}----1----2----3----4│{11:  2 }0----1----2----3----|
+      {11:  2 }^0----1----2----3----4│{11:  2 }0----1----2----3----|
       {11:  3 }0----1----2----3----4│{11:  3 }0----1----2----3----|
       {11:  4 }0----1----2----3----4│{11:  4 }0----1----2----3----|
       {11:  5 }0----1----2----3----4│{11:  5 }0----1----2----3----|
@@ -421,7 +421,7 @@ describe('TUI', function()
       api.nvim_input_mouse('wheel', 'right', '', 0, 0, 7)
     end
     screen:expect([[
-      {11:  2 }{1:-}---1----2----3----4-│{11:  2 }0----1----2----3----|
+      {11:  2 }^----1----2----3----4-│{11:  2 }0----1----2----3----|
       {11:  3 }----1----2----3----4-│{11:  3 }0----1----2----3----|
       {11:  4 }----1----2----3----4-│{11:  4 }0----1----2----3----|
       {11:  5 }----1----2----3----4-│{11:  5 }0----1----2----3----|
@@ -436,7 +436,7 @@ describe('TUI', function()
       api.nvim_input_mouse('wheel', 'right', '', 0, 0, 47)
     end
     screen:expect([[
-      {11:  2 }{1:-}---1----2----3----4-│{11:  2 }----1----2----3----4|
+      {11:  2 }^----1----2----3----4-│{11:  2 }----1----2----3----4|
       {11:  3 }----1----2----3----4-│{11:  3 }----1----2----3----4|
       {11:  4 }----1----2----3----4-│{11:  4 }----1----2----3----4|
       {11:  5 }----1----2----3----4-│{11:  5 }----1----2----3----4|
@@ -451,7 +451,7 @@ describe('TUI', function()
       api.nvim_input_mouse('wheel', 'down', 'S', 0, 0, 7)
     end
     screen:expect([[
-      {11:  5 }{1:-}---1----2----3----4-│{11:  2 }----1----2----3----4|
+      {11:  5 }^----1----2----3----4-│{11:  2 }----1----2----3----4|
       {11:  6 }----1----2----3----4-│{11:  3 }----1----2----3----4|
       {11:  7 }----1----2----3----4-│{11:  4 }----1----2----3----4|
       {11:  8 }----1----2----3----4-│{11:  5 }----1----2----3----4|
@@ -466,7 +466,7 @@ describe('TUI', function()
       api.nvim_input_mouse('wheel', 'down', 'S', 0, 0, 47)
     end
     screen:expect([[
-      {11:  5 }{1:-}---1----2----3----4-│{11:  5 }----1----2----3----4|
+      {11:  5 }^----1----2----3----4-│{11:  5 }----1----2----3----4|
       {11:  6 }----1----2----3----4-│{11:  6 }----1----2----3----4|
       {11:  7 }----1----2----3----4-│{11:  7 }----1----2----3----4|
       {11:  8 }----1----2----3----4-│{11:  8 }----1----2----3----4|
@@ -481,7 +481,7 @@ describe('TUI', function()
       api.nvim_input_mouse('wheel', 'right', 'S', 0, 0, 7)
     end
     screen:expect([[
-      {11:  5 }{1:-}---6----7----8----9 │{11:  5 }----1----2----3----4|
+      {11:  5 }^----6----7----8----9 │{11:  5 }----1----2----3----4|
       {11:  6 }----6----7----8----9 │{11:  6 }----1----2----3----4|
       {11:  7 }----6----7----8----9 │{11:  7 }----1----2----3----4|
       {11:  8 }----6----7----8----9 │{11:  8 }----1----2----3----4|
@@ -496,7 +496,7 @@ describe('TUI', function()
       api.nvim_input_mouse('wheel', 'right', 'S', 0, 0, 47)
     end
     screen:expect([[
-      {11:  5 }{1:-}---6----7----8----9 │{11:  5 }5----6----7----8----|
+      {11:  5 }^----6----7----8----9 │{11:  5 }5----6----7----8----|
       {11:  6 }----6----7----8----9 │{11:  6 }5----6----7----8----|
       {11:  7 }----6----7----8----9 │{11:  7 }5----6----7----8----|
       {11:  8 }----6----7----8----9 │{11:  8 }5----6----7----8----|
@@ -512,7 +512,7 @@ describe('TUI', function()
     end
     screen:expect([[
       {11:  4 }----6----7----8----9 │{11:  5 }5----6----7----8----|
-      {11:  5 }{1:-}---6----7----8----9 │{11:  6 }5----6----7----8----|
+      {11:  5 }^----6----7----8----9 │{11:  6 }5----6----7----8----|
       {11:  6 }----6----7----8----9 │{11:  7 }5----6----7----8----|
       {11:  7 }----6----7----8----9 │{11:  8 }5----6----7----8----|
       {5:[No Name] [+]             }{1:[No Name] [+]           }|
@@ -527,7 +527,7 @@ describe('TUI', function()
     end
     screen:expect([[
       {11:  4 }----6----7----8----9 │{11:  4 }5----6----7----8----|
-      {11:  5 }{1:-}---6----7----8----9 │{11:  5 }5----6----7----8----|
+      {11:  5 }^----6----7----8----9 │{11:  5 }5----6----7----8----|
       {11:  6 }----6----7----8----9 │{11:  6 }5----6----7----8----|
       {11:  7 }----6----7----8----9 │{11:  7 }5----6----7----8----|
       {5:[No Name] [+]             }{1:[No Name] [+]           }|
@@ -542,7 +542,7 @@ describe('TUI', function()
     end
     screen:expect([[
       {11:  4 }5----6----7----8----9│{11:  4 }5----6----7----8----|
-      {11:  5 }5{1:-}---6----7----8----9│{11:  5 }5----6----7----8----|
+      {11:  5 }5^----6----7----8----9│{11:  5 }5----6----7----8----|
       {11:  6 }5----6----7----8----9│{11:  6 }5----6----7----8----|
       {11:  7 }5----6----7----8----9│{11:  7 }5----6----7----8----|
       {5:[No Name] [+]             }{1:[No Name] [+]           }|
@@ -557,7 +557,7 @@ describe('TUI', function()
     end
     screen:expect([[
       {11:  4 }5----6----7----8----9│{11:  4 }-5----6----7----8---|
-      {11:  5 }5{1:-}---6----7----8----9│{11:  5 }-5----6----7----8---|
+      {11:  5 }5^----6----7----8----9│{11:  5 }-5----6----7----8---|
       {11:  6 }5----6----7----8----9│{11:  6 }-5----6----7----8---|
       {11:  7 }5----6----7----8----9│{11:  7 }-5----6----7----8---|
       {5:[No Name] [+]             }{1:[No Name] [+]           }|
@@ -574,7 +574,7 @@ describe('TUI', function()
       {11:  1 }5----6----7----8----9│{11:  4 }-5----6----7----8---|
       {11:  2 }5----6----7----8----9│{11:  5 }-5----6----7----8---|
       {11:  3 }5----6----7----8----9│{11:  6 }-5----6----7----8---|
-      {11:  4 }5{1:-}---6----7----8----9│{11:  7 }-5----6----7----8---|
+      {11:  4 }5^----6----7----8----9│{11:  7 }-5----6----7----8---|
       {5:[No Name] [+]             }{1:[No Name] [+]           }|
                                                         |
       {3:-- TERMINAL --}                                    |
@@ -589,7 +589,7 @@ describe('TUI', function()
       {11:  1 }5----6----7----8----9│{11:  1 }-5----6----7----8---|
       {11:  2 }5----6----7----8----9│{11:  2 }-5----6----7----8---|
       {11:  3 }5----6----7----8----9│{11:  3 }-5----6----7----8---|
-      {11:  4 }5{1:-}---6----7----8----9│{11:  4 }-5----6----7----8---|
+      {11:  4 }5^----6----7----8----9│{11:  4 }-5----6----7----8---|
       {5:[No Name] [+]             }{1:[No Name] [+]           }|
                                                         |
       {3:-- TERMINAL --}                                    |
@@ -604,7 +604,7 @@ describe('TUI', function()
       {11:  1 }0----1----2----3----4│{11:  1 }-5----6----7----8---|
       {11:  2 }0----1----2----3----4│{11:  2 }-5----6----7----8---|
       {11:  3 }0----1----2----3----4│{11:  3 }-5----6----7----8---|
-      {11:  4 }0----1----2----3----{1:4}│{11:  4 }-5----6----7----8---|
+      {11:  4 }0----1----2----3----^4│{11:  4 }-5----6----7----8---|
       {5:[No Name] [+]             }{1:[No Name] [+]           }|
                                                         |
       {3:-- TERMINAL --}                                    |
@@ -619,7 +619,7 @@ describe('TUI', function()
       {11:  1 }0----1----2----3----4│{11:  1 }0----1----2----3----|
       {11:  2 }0----1----2----3----4│{11:  2 }0----1----2----3----|
       {11:  3 }0----1----2----3----4│{11:  3 }0----1----2----3----|
-      {11:  4 }0----1----2----3----{1:4}│{11:  4 }0----1----2----3----|
+      {11:  4 }0----1----2----3----^4│{11:  4 }0----1----2----3----|
       {5:[No Name] [+]             }{1:[No Name] [+]           }|
                                                         |
       {3:-- TERMINAL --}                                    |
@@ -660,7 +660,7 @@ describe('TUI', function()
       api.nvim_input_mouse('right', 'press', '', 0, 0, 4)
     end
     screen:expect([[
-      {1:p}opup menu test                                   |
+      ^popup menu test                                   |
       {4:~  }{13: foo }{4:                                          }|
       {4:~  }{13: bar }{4:                                          }|
       {4:~  }{13: baz }{4:                                          }|
@@ -680,7 +680,7 @@ describe('TUI', function()
       api.nvim_input_mouse('wheel', 'up', '', 0, 0, 4)
     end
     screen:expect([[
-      {1:p}opup menu test                                   |
+      ^popup menu test                                   |
       {4:~  }{14: foo }{4:                                          }|
       {4:~  }{13: bar }{4:                                          }|
       {4:~  }{13: baz }{4:                                          }|
@@ -694,7 +694,7 @@ describe('TUI', function()
       api.nvim_input_mouse('move', '', '', 0, 3, 6)
     end
     screen:expect([[
-      {1:p}opup menu test                                   |
+      ^popup menu test                                   |
       {4:~  }{13: foo }{4:                                          }|
       {4:~  }{13: bar }{4:                                          }|
       {4:~  }{14: baz }{4:                                          }|
@@ -708,7 +708,7 @@ describe('TUI', function()
       api.nvim_input_mouse('wheel', 'down', '', 0, 3, 6)
     end
     screen:expect([[
-      {1:p}opup menu test                                   |
+      ^popup menu test                                   |
       {4:~  }{13: foo }{4:                                          }|
       {4:~  }{14: bar }{4:                                          }|
       {4:~  }{13: baz }{4:                                          }|
@@ -722,7 +722,7 @@ describe('TUI', function()
       api.nvim_input_mouse('left', 'press', '', 0, 2, 6)
     end
     screen:expect([[
-      {1:p}opup menu test                                   |
+      ^popup menu test                                   |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
       :let g:menustr = 'bar'                            |
@@ -740,7 +740,7 @@ describe('TUI', function()
       api.nvim_input_mouse('right', 'press', '', 0, 2, 44)
     end
     screen:expect([[
-      {1:p}opup menu test                                   |
+      ^popup menu test                                   |
       {4:~                                                 }|*2
       {4:~                                          }{13: foo }{4:  }|
       {5:[No Name] [+]                              }{13: bar }{5:  }|
@@ -753,7 +753,7 @@ describe('TUI', function()
       api.nvim_input_mouse('right', 'drag', '', 0, 5, 47)
     end
     screen:expect([[
-      {1:p}opup menu test                                   |
+      ^popup menu test                                   |
       {4:~                                                 }|*2
       {4:~                                          }{13: foo }{4:  }|
       {5:[No Name] [+]                              }{13: bar }{5:  }|
@@ -766,7 +766,7 @@ describe('TUI', function()
       api.nvim_input_mouse('right', 'release', '', 0, 5, 47)
     end
     screen:expect([[
-      {1:p}opup menu test                                   |
+      ^popup menu test                                   |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
       :let g:menustr = 'baz'                            |
@@ -805,7 +805,7 @@ describe('TUI', function()
     feed_data(fn.nr2char(57415)) -- KP_EQUAL
     screen:expect([[
       0123456789./*-+                                   |
-      ={1: }                                                |
+      =^                                                 |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -814,7 +814,7 @@ describe('TUI', function()
     feed_data(fn.nr2char(57417)) -- KP_LEFT
     screen:expect([[
       0123456789./*-+                                   |
-      {1:=}                                                 |
+      ^=                                                 |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -823,7 +823,7 @@ describe('TUI', function()
     feed_data(fn.nr2char(57418)) -- KP_RIGHT
     screen:expect([[
       0123456789./*-+                                   |
-      ={1: }                                                |
+      =^                                                 |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -831,7 +831,7 @@ describe('TUI', function()
     ]])
     feed_data(fn.nr2char(57419)) -- KP_UP
     screen:expect([[
-      0{1:1}23456789./*-+                                   |
+      0^123456789./*-+                                   |
       =                                                 |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
@@ -841,7 +841,7 @@ describe('TUI', function()
     feed_data(fn.nr2char(57420)) -- KP_DOWN
     screen:expect([[
       0123456789./*-+                                   |
-      ={1: }                                                |
+      =^                                                 |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -850,7 +850,7 @@ describe('TUI', function()
     feed_data(fn.nr2char(57425)) -- KP_INSERT
     screen:expect([[
       0123456789./*-+                                   |
-      ={1: }                                                |
+      =^                                                 |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
       {3:-- REPLACE --}                                     |
@@ -859,7 +859,7 @@ describe('TUI', function()
     feed_data('\027[27u') -- ESC
     screen:expect([[
       0123456789./*-+                                   |
-      {1:=}                                                 |
+      ^=                                                 |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
                                                         |
@@ -867,7 +867,7 @@ describe('TUI', function()
     ]])
     feed_data('\027[57417;5u') -- CTRL + KP_LEFT
     screen:expect([[
-      {1:0}123456789./*-+                                   |
+      ^0123456789./*-+                                   |
       =                                                 |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
@@ -876,7 +876,7 @@ describe('TUI', function()
     ]])
     feed_data('\027[57418;2u') -- SHIFT + KP_RIGHT
     screen:expect([[
-      0123456789{1:.}/*-+                                   |
+      0123456789^./*-+                                   |
       =                                                 |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
@@ -885,7 +885,7 @@ describe('TUI', function()
     ]])
     feed_data(fn.nr2char(57426)) -- KP_DELETE
     screen:expect([[
-      0123456789{1:/}*-+                                    |
+      0123456789^/*-+                                    |
       =                                                 |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
@@ -894,7 +894,7 @@ describe('TUI', function()
     ]])
     feed_data(fn.nr2char(57423)) -- KP_HOME
     screen:expect([[
-      {1:0}123456789/*-+                                    |
+      ^0123456789/*-+                                    |
       =                                                 |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
@@ -903,7 +903,7 @@ describe('TUI', function()
     ]])
     feed_data(fn.nr2char(57424)) -- KP_END
     screen:expect([[
-      0123456789/*-{1:+}                                    |
+      0123456789/*-^+                                    |
       =                                                 |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
@@ -921,7 +921,7 @@ describe('TUI', function()
     )
     screen:expect([[
       {12: + [No Name]  + [No Name] }{3: [No Name] }{1:            }{12:X}|
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*2
       {5:[No Name]                                         }|
                                                         |
@@ -930,7 +930,7 @@ describe('TUI', function()
     feed_data('\027[57421;5u') -- CTRL + KP_PAGE_UP
     screen:expect([[
       {12: + [No Name] }{3: + [No Name] }{12: [No Name] }{1:            }{12:X}|
-      0123456789/*-{1:+}                                    |
+      0123456789/*-^+                                    |
       =                                                 |
       {4:~                                                 }|
       {5:[No Name] [+]                                     }|
@@ -940,7 +940,7 @@ describe('TUI', function()
     feed_data('\027[57422;5u') -- CTRL + KP_PAGE_DOWN
     screen:expect([[
       {12: + [No Name]  + [No Name] }{3: [No Name] }{1:            }{12:X}|
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*2
       {5:[No Name]                                         }|
                                                         |
@@ -961,7 +961,7 @@ describe('TUI', function()
     feed_data('\022\027[57379;48u') -- Shift + Alt + Ctrl + Super + Meta + F16
     screen:expect([[
       <D-j><T-k><T-D-CR><M-T-C-S-D-BS>                  |
-      <D-F13><T-F14><T-D-F15><M-T-C-S-D-F16>{1: }           |
+      <D-F13><T-F14><T-D-F15><M-T-C-S-D-F16>^            |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -973,7 +973,7 @@ describe('TUI', function()
     -- "bracketed paste"
     feed_data('i""\027i\027[200~')
     screen:expect([[
-      "{1:"}                                                |
+      "^"                                                |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -982,7 +982,7 @@ describe('TUI', function()
     feed_data('pasted from terminal')
     expect_child_buf_lines({ '"pasted from terminal"' })
     screen:expect([[
-      "pasted from terminal{1:"}                            |
+      "pasted from terminal^"                            |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -994,7 +994,7 @@ describe('TUI', function()
     feed_data('\027[27u') -- ESC: go to Normal mode.
     wait_for_mode('n')
     screen:expect([[
-      "pasted from termina{1:l}"                            |
+      "pasted from termina^l"                            |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
                                                         |
@@ -1005,7 +1005,7 @@ describe('TUI', function()
     expect_child_buf_lines({ '"pasted from terminapasted from terminalpasted from terminall"' })
     screen:expect([[
       "pasted from terminapasted from terminalpasted fro|
-      m termina{1:l}l"                                      |
+      m termina^ll"                                      |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
                                                         |
@@ -1027,7 +1027,7 @@ describe('TUI', function()
       this is line 1                                    |
       this is line 2                                    |
       line 3 is here                                    |
-      {1: }                                                 |
+      ^                                                  |
       {5:[No Name] [+]                                     }|
                                                         |
       {3:-- TERMINAL --}                                    |
@@ -1037,7 +1037,7 @@ describe('TUI', function()
     screen:expect([[
       this{16: is line 1}                                    |
       {16:this is line 2}                                    |
-      {16:line}{1: }3 is here                                    |
+      {16:line}^ 3 is here                                    |
                                                         |
       {5:[No Name] [+]                                     }|
       {3:-- SELECT --}                                      |
@@ -1047,7 +1047,7 @@ describe('TUI', function()
     feed_data('just paste it™')
     feed_data('\027[201~')
     screen:expect([[
-      thisjust paste it{1:™}3 is here                       |
+      thisjust paste it^™3 is here                       |
                                                         |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
@@ -1084,7 +1084,7 @@ describe('TUI', function()
     feed_data('i')
     screen:expect([[
       tty ready                                         |
-      {1: }                                                 |
+      ^                                                  |
                                                         |*2
       {19:^^^^^^^                                           }|
       {3:-- TERMINAL --}                                    |*2
@@ -1094,7 +1094,7 @@ describe('TUI', function()
     feed_data('\027[201~')
     screen:expect([[
       tty ready                                         |
-      hallo{1: }                                            |
+      hallo^                                             |
                                                         |*2
       {19:^^^^^^^                                           }|
       {3:-- TERMINAL --}                                    |*2
@@ -1111,7 +1111,7 @@ describe('TUI', function()
     local expected_grid1 = [[
       line 1                                            |
       ESC:{6:^[} / CR:                                      |
-      {1:x}                                                 |
+      ^x                                                 |
       {4:~                                                 }|
       {5:[No Name] [+]                   3,1            All}|
                                                         |
@@ -1126,7 +1126,7 @@ describe('TUI', function()
       ESC:{6:^[} / CR:                                      |
       xline 1                                           |
       ESC:{6:^[} / CR:                                      |
-      {1:x}                                                 |
+      ^x                                                 |
       {5:[No Name] [+]                   5,1            Bot}|
                                                         |
       {3:-- TERMINAL --}                                    |
@@ -1165,7 +1165,7 @@ describe('TUI', function()
                                                         |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
-      :"{1:"}                                               |
+      :"^"                                               |
       {3:-- TERMINAL --}                                    |
     ]])
     -- "bracketed paste"
@@ -1179,7 +1179,7 @@ describe('TUI', function()
                                                         |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
-      :"line 1{1:"}                                         |
+      :"line 1^"                                         |
       {3:-- TERMINAL --}                                    |
     ]])
     -- Dot-repeat/redo.
@@ -1188,7 +1188,7 @@ describe('TUI', function()
     feed_data('.')
     screen:expect([[
       foo                                               |*2
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|
       {5:[No Name] [+]                                     }|
                                                         |
@@ -1235,7 +1235,7 @@ describe('TUI', function()
     wait_for_mode('n')
     screen:expect([[
       foo                                               |
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
                                                         |
@@ -1249,7 +1249,7 @@ describe('TUI', function()
       {5:                                                  }|
       {8:paste: Error executing lua: [string "<nvim>"]:4: f}|
       {8:ake fail}                                          |
-      {10:Press ENTER or type command to continue}{1: }          |
+      {10:Press ENTER or type command to continue}^           |
       {3:-- TERMINAL --}                                    |
     ]])
     -- Remaining chunks are discarded after vim.paste() failure.
@@ -1265,7 +1265,7 @@ describe('TUI', function()
     feed_data('.')
     screen:expect([[
       foo                                               |*2
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|
       {5:[No Name] [+]                                     }|
                                                         |
@@ -1275,7 +1275,7 @@ describe('TUI', function()
     feed_data('ityped input...\027[27u')
     screen:expect([[
       foo                                               |*2
-      typed input..{1:.}                                    |
+      typed input..^.                                    |
       {4:~                                                 }|
       {5:[No Name] [+]                                     }|
                                                         |
@@ -1288,7 +1288,7 @@ describe('TUI', function()
       foo                                               |
       typed input...line A                              |
       line B                                            |
-      {1: }                                                 |
+      ^                                                  |
       {5:[No Name] [+]                                     }|
                                                         |
       {3:-- TERMINAL --}                                    |
@@ -1352,7 +1352,7 @@ describe('TUI', function()
       {5:                                                  }|
       {8:paste: Error executing lua: Vim:E21: Cannot make c}|
       {8:hanges, 'modifiable' is off}                       |
-      {10:Press ENTER or type command to continue}{1: }          |
+      {10:Press ENTER or type command to continue}^           |
       {3:-- TERMINAL --}                                    |
     ]])
     feed_data('\n') -- <Enter> to dismiss hit-enter prompt
@@ -1361,7 +1361,7 @@ describe('TUI', function()
     screen:expect([[
       success 1                                         |
       success 2                                         |
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|
       {5:[No Name] [+]                                     }|
                                                         |
@@ -1380,7 +1380,7 @@ describe('TUI', function()
     expected = expected .. ' end'
     screen:expect([[
       zzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzzz|
-      zzzzzzzzzzzzzz end{1: }                               |
+      zzzzzzzzzzzzzz end^                                |
       {4:~                                                 }|*2
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -1399,7 +1399,7 @@ describe('TUI', function()
                                                         |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
-      :<{1: }                                               |
+      :<^                                                |
       {3:-- TERMINAL --}                                    |
     ]])
   end)
@@ -1420,7 +1420,7 @@ describe('TUI', function()
       item 2997                                         |
       item 2998                                         |
       item 2999                                         |
-      item 3000 end{1: }                                    |
+      item 3000 end^                                     |
       {5:[No Name] [+]                   3000,14        Bot}|
       {3:-- INSERT --}                                      |
       {3:-- TERMINAL --}                                    |
@@ -1433,7 +1433,7 @@ describe('TUI', function()
       item 2997                                         |
       item 2998                                         |
       item 2999                                         |
-      item 3000 en{1:d}d                                    |
+      item 3000 en^dd                                    |
       {5:[No Name] [+]                   5999,13        Bot}|
                                                         |
       {3:-- TERMINAL --}                                    |
@@ -1457,7 +1457,7 @@ describe('TUI', function()
                                                         |
       pasted from terminal (1)                          |
       {6:^[}[200~                                           |
-      {1: }                                                 |
+      ^                                                  |
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
       {3:-- TERMINAL --}                                    |
@@ -1472,7 +1472,7 @@ describe('TUI', function()
     -- Send "stop paste" sequence.
     feed_data('\027[201~')
     screen:expect([[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
       {3:-- INSERT --}                                      |
@@ -1487,7 +1487,7 @@ describe('TUI', function()
     feed_data('\027[2')
     feed_data('00~pasted from terminal\027[201~')
     screen:expect([[
-      pasted from terminal{1: }                             |
+      pasted from terminal^                              |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -1502,7 +1502,7 @@ describe('TUI', function()
     feed_data('\027[200~pasted from terminal\027[20')
     feed_data('1~')
     screen:expect([[
-      pasted from terminal{1: }                             |
+      pasted from terminal^                              |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -1524,7 +1524,7 @@ describe('TUI', function()
     wait_for_mode('i')
     feed_data('\027[200~pasted') -- phase 1
     screen:expect([[
-      pasted{1: }                                           |
+      pasted^                                            |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -1532,7 +1532,7 @@ describe('TUI', function()
     ]])
     feed_data(' from terminal') -- phase 2
     screen:expect([[
-      pasted from terminal{1: }                             |
+      pasted from terminal^                              |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -1568,7 +1568,7 @@ describe('TUI', function()
     feed_data('\028\014') -- crtl+\ ctrl+N
     feed_data(':set termguicolors?\n')
     screen:expect([[
-      {5:^}{6:G}                                                |
+      {6:^^G}                                                |
       {2:~                                                 }|*3
       {3:[No Name] [+]                                     }|
       notermguicolors                                   |
@@ -1577,7 +1577,7 @@ describe('TUI', function()
 
     feed_data(':set termguicolors\n')
     screen:expect([[
-      {7:^}{8:G}                                                |
+      {8:^^G}                                                |
       {9:~}{10:                                                 }|*3
       {3:[No Name] [+]                                     }|
       :set termguicolors                                |
@@ -1586,7 +1586,7 @@ describe('TUI', function()
 
     feed_data(':set notermguicolors\n')
     screen:expect([[
-      {5:^}{6:G}                                                |
+      {6:^^G}                                                |
       {2:~                                                 }|*3
       {3:[No Name] [+]                                     }|
       :set notermguicolors                              |
@@ -1634,7 +1634,7 @@ describe('TUI', function()
     child_exec_lua('vim.cmd.terminal(...)', testprg('tty-test'))
     screen:expect {
       grid = [[
-      {1:t}ty ready                                         |
+      ^tty ready                                         |
                                                         |*3
       {2:^^^^^^^                                           }|
                                                         |
@@ -1646,7 +1646,7 @@ describe('TUI', function()
     )
     screen:expect {
       grid = [[
-      {1:t}ty ready                                         |
+      ^tty ready                                         |
       {4:text}{5:color}text                                     |
                                                         |*2
       {2:^^^^^^^                                           }|
@@ -1658,7 +1658,7 @@ describe('TUI', function()
     feed_data(':set notermguicolors\n')
     screen:expect {
       grid = [[
-      {1:t}ty ready                                         |
+      ^tty ready                                         |
       {4:text}colortext                                     |
                                                         |*2
       {6:^^^^^^^}{7:                                           }|
@@ -1681,7 +1681,7 @@ describe('TUI', function()
     child_session:request('nvim_set_hl', 0, 'Visual', { undercurl = true })
     feed_data('ifoobar\027V')
     screen:expect([[
-      {5:fooba}{1:r}                                            |
+      {5:fooba}^r                                            |
       {4:~                                                 }|*3
       {2:[No Name] [+]                                     }|
       {3:-- VISUAL LINE --}                                 |
@@ -1689,7 +1689,7 @@ describe('TUI', function()
     ]])
     child_session:request('nvim_set_hl', 0, 'Visual', { underdouble = true })
     screen:expect([[
-      {6:fooba}{1:r}                                            |
+      {6:fooba}^r                                            |
       {4:~                                                 }|*3
       {2:[No Name] [+]                                     }|
       {3:-- VISUAL LINE --}                                 |
@@ -1777,7 +1777,7 @@ describe('TUI', function()
     child_session:request('nvim_set_option_value', 'listchars', 'eol:$', { win = 0 })
     feed_data('gg')
     local singlewidth_screen = [[
-      {13:℃}{12:℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃}|
+      {12:^℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃}|
       {12:℃℃℃℃℃℃℃℃℃℃}{15:$}{12:                                       }|
       ℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃℃|
       ℃℃℃℃℃℃℃℃℃℃{4:$}                                       |
@@ -1788,7 +1788,7 @@ describe('TUI', function()
     -- When grid assumes "℃" to be double-width but host terminal assumes it to be single-width,
     -- the second cell of "℃" is a space and the attributes of the "℃" are applied to it.
     local doublewidth_screen = [[
-      {13:℃}{12: ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ }|
+      {12:^℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ }|
       {12:℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ }|
       {12:℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ }{15:$}{12:                             }|
       ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ ℃ {4:@@@@}|
@@ -1821,7 +1821,7 @@ describe('TUI', function()
     child_session:request('nvim_set_option_value', 'listchars', 'eol:$', { win = 0 })
     feed_data('gg')
     local singlewidth_screen = [[
-      {13:✓}{12:✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓}|
+      {12:^✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓}|
       {12:✓✓✓✓✓✓✓✓✓✓}{15:$}{12:                                       }|
       ✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓✓|
       ✓✓✓✓✓✓✓✓✓✓{4:$}                                       |
@@ -1832,7 +1832,7 @@ describe('TUI', function()
     -- When grid assumes "✓" to be double-width but host terminal assumes it to be single-width,
     -- the second cell of "✓" is a space and the attributes of the "✓" are applied to it.
     local doublewidth_screen = [[
-      {13:✓}{12: ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ }|
+      {12:^✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ }|
       {12:✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ }|
       {12:✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ }{15:$}{12:                             }|
       ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ ✓ {4:@@@@}|
@@ -1870,7 +1870,7 @@ describe('TUI', function()
     -- Close the :intro message and redraw the lines.
     feed_data('\n')
     screen:expect([[
-      {13:Ꝩ}{12:ꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨ}|
+      {12:^ꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨ}|
       {12:ꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨ}|*310
       {12:ꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨ℃ }|
       b                                                                     |
@@ -1912,7 +1912,7 @@ describe('TUI', function()
     -- Close the :intro message and redraw the lines.
     feed_data('\n')
     screen:expect([[
-      {1:Ꝩ}ꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨ|
+      ^ꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨ|
       ꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨꝨ|*325
       {3:-- TERMINAL --}                                                     |
     ]])
@@ -1925,7 +1925,7 @@ describe('TUI', function()
     feed_data ':set visualbell\n'
     screen:expect {
       grid = [[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
       :set visualbell                                   |
@@ -1939,7 +1939,7 @@ describe('TUI', function()
     feed_data 'i'
     screen:expect {
       grid = [[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
       {3:-- INSERT --}                                      |
@@ -1954,7 +1954,7 @@ describe('TUI', function()
       grid = [[
       Vim: Caught deadly signal 'SIGTERM'               |
                                                         |*2
-      [Process exited 1]{1: }                               |
+      [Process exited 1]^                                |
                                                         |*2
       {3:-- TERMINAL --}                                    |
     ]],
@@ -1981,7 +1981,7 @@ describe('TUI', function()
       [5] = { bold = true },
     })
     screen:expect([[
-      {1: }                                                 |
+      ^                                                  |
       {2:~}{3:                                                 }|*3
       {4:[No Name]                                         }|
                                                         |
@@ -1989,7 +1989,7 @@ describe('TUI', function()
     ]])
     feed_data('i')
     screen:expect([[
-      {1: }                                                 |
+      ^                                                  |
       {2:~}{3:                                                 }|*3
       {4:[No Name]                                         }|
       {5:-- INSERT --}                                      |
@@ -2000,7 +2000,7 @@ describe('TUI', function()
   it('redraws on SIGWINCH even if terminal size is unchanged #23411', function()
     child_session:request('nvim_echo', { { 'foo' } }, false, {})
     screen:expect([[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
       foo                                               |
@@ -2008,7 +2008,7 @@ describe('TUI', function()
     ]])
     exec_lua([[vim.uv.kill(vim.fn.jobpid(vim.bo.channel), 'sigwinch')]])
     screen:expect([[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
                                                         |
@@ -2031,7 +2031,7 @@ describe('TUI', function()
     ]])
     feed_data('\003')
     screen:expect([[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
       Type  :qa  and press <Enter> to exit Nvim         |
@@ -2046,7 +2046,7 @@ describe('TUI', function()
       {1:foo}                                               |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
-      /foo{1: }                                             |
+      /foo^                                              |
       {3:-- TERMINAL --}                                    |
     ]])
     screen:sleep(10)
@@ -2055,7 +2055,7 @@ describe('TUI', function()
       foo                                               |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
-      /foob{1: }                                            |
+      /foob^                                             |
       {3:-- TERMINAL --}                                    |
     ]])
     screen:sleep(10)
@@ -2064,7 +2064,7 @@ describe('TUI', function()
       foo                                               |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
-      /fooba{1: }                                           |
+      /fooba^                                            |
       {3:-- TERMINAL --}                                    |
     ]])
   end)
@@ -2194,7 +2194,7 @@ describe('TUI', function()
     local screen = tt.setup_child_nvim({ '--clean', '-l', script_file })
     screen:expect {
       grid = [[
-      {1: }                                                 |
+      ^                                                  |
       ~                                                 |*3
       [No Name]                       0,0-1          All|
                                                         |
@@ -2207,7 +2207,7 @@ describe('TUI', function()
       Xargv0nvim                                        |
       --embed                                           |
       --clean                                           |
-      {1:X}argv0nvim                                        |
+      ^Xargv0nvim                                        |
       [No Name] [+]                   5,1            Bot|
       4 more lines                                      |
       {3:-- TERMINAL --}                                    |
@@ -2233,7 +2233,7 @@ describe('TUI', function()
       :q                                                |
       abc                                               |
                                                         |
-      [Process exited 0]{1: }                               |
+      [Process exited 0]^                                |
                                                         |
       {3:-- TERMINAL --}                                    |
     ]])
@@ -2254,7 +2254,7 @@ describe('TUI', function()
     })
     screen:expect {
       grid = [[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
                                                         |
@@ -2264,7 +2264,7 @@ describe('TUI', function()
 
     command([[call chansend(b:terminal_job_id, "\<C-h>")]])
     screen:expect([[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
       <C-h>                                             |
@@ -2287,7 +2287,7 @@ describe('TUI', function()
     }, { cols = 80 })
     screen:expect {
       grid = [[
-      {1:1}st line                                                                        |
+      ^1st line                                                                        |
                                                                                       |*2
       2nd line                                                                        |
       {5:[No Name] [+]                                                 1,1            All}|
@@ -2300,7 +2300,7 @@ describe('TUI', function()
       grid = [[
       1st line                                                                        |
                                                                                       |
-      {1: }                                                                               |
+      ^                                                                                |
       2nd line                                                                        |
       {5:[No Name] [+]                                                 1,161          All}|
                                                                                       |
@@ -2320,7 +2320,7 @@ describe('TUI', function()
     }, { extra_rows = 10, cols = 66 })
     screen:expect {
       grid = [[
-                                                                        |
+            ^                                                            |
             aabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabb|*12
             aabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabba@@@|
       [No Name] [+]                                   1,0-1          Top|
@@ -2339,7 +2339,7 @@ describe('TUI', function()
     -- 500-cell limit, so the buffer is flushed after these spaces.
     screen:expect {
       grid = [[
-                                                                        |
+            ^                                                            |
             aabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabb|*12
             aabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabbaabba@@@|
       [No Name] [+]                                   1,0-1          Top|
@@ -2366,7 +2366,7 @@ describe('TUI', function()
 
     screen:expect {
       grid = [[
-      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       ~                                                 |*3
       [No Name] [+]                   1,1            All|
                                                         |
@@ -2378,7 +2378,8 @@ describe('TUI', function()
     feed_data(':set columns=12\n')
     screen:expect {
       grid = [[
-      aaaaaaaaaaaa                                      |*4
+      ^aaaaaaaaaaaa                                      |
+      aaaaaaaaaaaa                                      |*3
       < [+] 1,1                                         |
                                                         |
       -- TERMINAL --                                    |
@@ -2416,7 +2417,7 @@ describe('TUI UIEnter/UILeave', function()
     })
     screen:expect {
       grid = [[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
                                                         |
@@ -2426,7 +2427,7 @@ describe('TUI UIEnter/UILeave', function()
     feed_data(':echo g:evs\n')
     screen:expect {
       grid = [[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
       ['VimEnter', 'UIEnter']                           |
@@ -2457,7 +2458,7 @@ describe('TUI FocusGained/FocusLost', function()
     })
 
     screen:expect([[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
                                                         |
@@ -2479,7 +2480,7 @@ describe('TUI FocusGained/FocusLost', function()
     retry(2, 3 * screen.timeout, function()
       feed_data('\027[I')
       screen:expect([[
-        {1: }                                                 |
+        ^                                                  |
         {4:~                                                 }|*3
         {5:[No Name]                                         }|
         gained                                            |
@@ -2488,7 +2489,7 @@ describe('TUI FocusGained/FocusLost', function()
 
       feed_data('\027[O')
       screen:expect([[
-        {1: }                                                 |
+        ^                                                  |
         {4:~                                                 }|*3
         {5:[No Name]                                         }|
         lost                                              |
@@ -2502,7 +2503,7 @@ describe('TUI FocusGained/FocusLost', function()
     feed_data('i')
     screen:expect {
       grid = [[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
       :set noshowmode                                   |
@@ -2512,7 +2513,7 @@ describe('TUI FocusGained/FocusLost', function()
     retry(2, 3 * screen.timeout, function()
       feed_data('\027[I')
       screen:expect([[
-        {1: }                                                 |
+        ^                                                  |
         {4:~                                                 }|*3
         {5:[No Name]                                         }|
         gained                                            |
@@ -2520,7 +2521,7 @@ describe('TUI FocusGained/FocusLost', function()
       ]])
       feed_data('\027[O')
       screen:expect([[
-        {1: }                                                 |
+        ^                                                  |
         {4:~                                                 }|*3
         {5:[No Name]                                         }|
         lost                                              |
@@ -2538,7 +2539,7 @@ describe('TUI FocusGained/FocusLost', function()
                                                         |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
-      :{1: }                                                |
+      :^                                                 |
       {3:-- TERMINAL --}                                    |
     ]])
     feed_data('\027[O')
@@ -2547,7 +2548,7 @@ describe('TUI FocusGained/FocusLost', function()
                                                         |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
-      :{1: }                                                |
+      :^                                                 |
       {3:-- TERMINAL --}                                    |
     ]],
       unchanged = true,
@@ -2590,7 +2591,7 @@ describe('TUI FocusGained/FocusLost', function()
     -- Wait for terminal to be ready.
     screen:expect {
       grid = [[
-      {1:r}eady $ zia                                       |
+      ^ready $ zia                                       |
                                                         |
       [Process exited 0]                                |
                                                         |*2
@@ -2602,7 +2603,7 @@ describe('TUI FocusGained/FocusLost', function()
     feed_data('\027[I')
     screen:expect {
       grid = [[
-      {1:r}eady $ zia                                       |
+      ^ready $ zia                                       |
                                                         |
       [Process exited 0]                                |
                                                         |*2
@@ -2614,7 +2615,7 @@ describe('TUI FocusGained/FocusLost', function()
 
     feed_data('\027[O')
     screen:expect([[
-      {1:r}eady $ zia                                       |
+      ^ready $ zia                                       |
                                                         |
       [Process exited 0]                                |
                                                         |*2
@@ -2634,7 +2635,7 @@ describe('TUI FocusGained/FocusLost', function()
       msg3                                              |
       msg4                                              |
       msg5                                              |
-      {10:Press ENTER or type command to continue}{1: }          |
+      {10:Press ENTER or type command to continue}^           |
       {3:-- TERMINAL --}                                    |
     ]],
     }
@@ -2647,7 +2648,7 @@ describe('TUI FocusGained/FocusLost', function()
       msg3                                              |
       msg4                                              |
       msg5                                              |
-      {10:Press ENTER or type command to continue}{1: }          |
+      {10:Press ENTER or type command to continue}^           |
       {3:-- TERMINAL --}                                    |
     ]],
       unchanged = true,
@@ -2690,7 +2691,7 @@ describe("TUI 't_Co' (terminal colors)", function()
 
     screen:expect(string.format(
       [[
-      {1: }                                                 |
+      ^                                                  |
       %s|*4
                                                         |
       {3:-- TERMINAL --}                                    |
@@ -2701,7 +2702,7 @@ describe("TUI 't_Co' (terminal colors)", function()
     feed_data(':echo &t_Co\n')
     screen:expect(string.format(
       [[
-      {1: }                                                 |
+      ^                                                  |
       %s|*4
       %-3s                                               |
       {3:-- TERMINAL --}                                    |
@@ -3028,7 +3029,7 @@ describe('TUI', function()
     -- Wait for TUI to start.
     feed_data('Gitext')
     screen:expect([[
-      text{1: }                                             |
+      text^                                              |
       {4:~                                                 }|*4
       {3:-- INSERT --}                                      |
       {3:-- TERMINAL --}                                    |
@@ -3045,7 +3046,7 @@ describe('TUI', function()
     nvim_tui()
 
     screen:expect([[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*4
                                                         |
       {3:-- TERMINAL --}                                    |
@@ -3055,7 +3056,7 @@ describe('TUI', function()
 
     screen:expect {
       grid = [[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*4
                                                         |
       {3:-- TERMINAL --}                                    |
@@ -3305,7 +3306,7 @@ describe('TUI bg color', function()
       'autocmd OptionSet background echo "did OptionSet, yay!"',
     })
     screen:expect([[
-      {1: }                                                 |
+      ^                                                  |
       {3:~}                                                 |*3
       {5:[No Name]                       0,0-1          All}|
       did OptionSet, yay!                               |
@@ -3343,7 +3344,7 @@ describe('TUI as a client', function()
     feed_data('iHello, World')
     screen_server:expect {
       grid = [[
-      Hello, World{1: }                                     |
+      Hello, World^                                      |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -3353,7 +3354,7 @@ describe('TUI as a client', function()
     feed_data('\027')
     screen_server:expect {
       grid = [[
-      Hello, Worl{1:d}                                      |
+      Hello, Worl^d                                      |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
                                                         |
@@ -3370,7 +3371,7 @@ describe('TUI as a client', function()
 
     screen_client:expect {
       grid = [[
-      Hello, Worl{1:d}                                      |
+      Hello, Worl^d                                      |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
                                                         |
@@ -3383,7 +3384,7 @@ describe('TUI as a client', function()
     feed_data('0:set lines=3\n')
     screen_server:expect {
       grid = [[
-      {1:a}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       {5:[No Name] [+]                                     }|
                                                         |*4
       {3:-- TERMINAL --}                                    |
@@ -3414,7 +3415,7 @@ describe('TUI as a client', function()
 
     screen_client:expect {
       grid = [[
-      Halloj{1:!}                                           |
+      Halloj^!                                           |
       {4:~                                                 }|*4
                                                         |
       {3:-- TERMINAL --}                                    |
@@ -3428,7 +3429,7 @@ describe('TUI as a client', function()
       grid = [[
       Vim: Caught deadly signal 'SIGTERM'               |
                                                         |*2
-      [Process exited 1]{1: }                               |
+      [Process exited 1]^                                |
                                                         |*2
       {3:-- TERMINAL --}                                    |
     ]],
@@ -3457,7 +3458,7 @@ describe('TUI as a client', function()
     screen:expect([[
       Remote ui failed to start: {MATCH:.*}|
                                                                   |
-      [Process exited 1]{1: }                                         |
+      [Process exited 1]^                                          |
                                                                   |*3
       {3:-- TERMINAL --}                                              |
     ]])
@@ -3483,7 +3484,7 @@ describe('TUI as a client', function()
     })
     screen_server:expect {
       grid = [[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*3
       {5:[No Name]                                         }|
                                                         |
@@ -3494,7 +3495,7 @@ describe('TUI as a client', function()
     feed_data('iHello, World')
     screen_server:expect {
       grid = [[
-      Hello, World{1: }                                     |
+      Hello, World^                                      |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
       {3:-- INSERT --}                                      |
@@ -3504,7 +3505,7 @@ describe('TUI as a client', function()
     feed_data('\027')
     screen_server:expect {
       grid = [[
-      Hello, Worl{1:d}                                      |
+      Hello, Worl^d                                      |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
                                                         |
@@ -3521,7 +3522,7 @@ describe('TUI as a client', function()
 
     screen_client:expect {
       grid = [[
-      Hello, Worl{1:d}                                      |
+      Hello, Worl^d                                      |
       {4:~                                                 }|*3
       {5:[No Name] [+]                                     }|
                                                         |
@@ -3536,7 +3537,7 @@ describe('TUI as a client', function()
     screen_server:expect {
       grid = [[
                                                         |
-      [Process exited ]] .. status .. [[]{1: }{MATCH:%s+}|
+      [Process exited ]] .. status .. [[]^ {MATCH:%s+}|
                                                         |*4
       {3:-- TERMINAL --}                                    |
     ]],
@@ -3545,7 +3546,7 @@ describe('TUI as a client', function()
     screen_client:expect {
       grid = [[
                                                         |
-      [Process exited ]] .. status .. [[]{1: }{MATCH:%s+}|
+      [Process exited ]] .. status .. [[]^ {MATCH:%s+}|
                                                         |*4
       {3:-- TERMINAL --}                                    |
     ]],

--- a/test/functional/terminal/window_spec.lua
+++ b/test/functional/terminal/window_spec.lua
@@ -62,7 +62,7 @@ describe(':terminal window', function()
       screen:expect([[
         {7:1 }tty ready                                       |
         {7:2 }rows: 6, cols: 48                               |
-        {7:3 }{1: }                                               |
+        {7:3 }^                                                |
         {7:4 }                                                |
         {7:5 }                                                |
         {7:6 }                                                |
@@ -73,7 +73,7 @@ describe(':terminal window', function()
         {7:1 }tty ready                                       |
         {7:2 }rows: 6, cols: 48                               |
         {7:3 }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUV|
-        {7:4 }WXYZ{1: }                                           |
+        {7:4 }WXYZ^                                            |
         {7:5 }                                                |
         {7:6 }                                                |
         {3:-- TERMINAL --}                                    |
@@ -87,7 +87,7 @@ describe(':terminal window', function()
         {7:       2 }rows: 6, cols: 48                        |
         {7:       3 }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNO|
         {7:       4 }PQRSTUVWXYZrows: 6, cols: 41             |
-        {7:       5 }{1: }                                        |
+        {7:       5 }^                                         |
         {7:       6 }                                         |
         {3:-- TERMINAL --}                                    |
       ]])
@@ -98,7 +98,7 @@ describe(':terminal window', function()
         {7:       3 }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNO|
         {7:       4 }PQRSTUVWXYZrows: 6, cols: 41             |
         {7:       5 } abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMN|
-        {7:       6 }OPQRSTUVWXYZ{1: }                            |
+        {7:       6 }OPQRSTUVWXYZ^                             |
         {3:-- TERMINAL --}                                    |
       ]])
     end)
@@ -110,7 +110,7 @@ describe(':terminal window', function()
       screen:expect([[
         {7:++1  }tty ready                                    |
         {7:++2  }rows: 6, cols: 45                            |
-        {7:++3  }{1: }                                            |
+        {7:++3  }^                                             |
         {7:++4  }                                             |
         {7:++5  }                                             |
         {7:++6  }                                             |
@@ -123,7 +123,7 @@ describe(':terminal window', function()
         {7:++6  }                                             |
         {7:++7  }                                             |
         {7:++8  }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRS|
-        {7:++9  }TUVWXYZ{1: }                                     |
+        {7:++9  }TUVWXYZ^                                      |
         {3:-- TERMINAL --}                                    |
       ]])
       feed_data('\nabcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ')
@@ -133,7 +133,7 @@ describe(':terminal window', function()
         {7:++ 9  }STUVWXYZ                                    |
         {7:++10  }abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQR|
         {7:++11  }STUVWXYZrows: 6, cols: 44                   |
-        {7:++12  }{1: }                                           |
+        {7:++12  }^                                            |
         {3:-- TERMINAL --}                                    |
       ]])
     end)
@@ -144,7 +144,7 @@ describe(':terminal window', function()
       feed([[<C-\><C-N>]])
       screen:expect([[
         tty ready                                         |
-        {2:^ }                                                 |
+        ^                                                  |
                                                           |*5
       ]])
       feed(':set colorcolumn=20<CR>i')
@@ -153,7 +153,7 @@ describe(':terminal window', function()
     it('wont show the color column', function()
       screen:expect([[
         tty ready                                         |
-        {1: }                                                 |
+        ^                                                  |
                                                           |*4
         {3:-- TERMINAL --}                                    |
       ]])
@@ -170,7 +170,7 @@ describe(':terminal window', function()
         line2                                             |
         line3                                             |
         line4                                             |
-        {1: }                                                 |
+        ^                                                  |
         {3:-- TERMINAL --}                                    |
       ]])
     end)
@@ -184,7 +184,7 @@ describe(':terminal window', function()
         line2                                             |
         line3                                             |
         line4                                             |
-        {2: }                                                 |
+                                                          |
                                                           |
       ]])
     end)
@@ -206,7 +206,7 @@ describe(':terminal with multigrid', function()
       [3:--------------------------------------------------]|
     ## grid 2
       tty ready                                         |
-      {1: }                                                 |
+      ^                                                  |
                                                         |*4
     ## grid 3
       {3:-- TERMINAL --}                                    |
@@ -223,7 +223,7 @@ describe(':terminal with multigrid', function()
       ## grid 2
         tty ready           |
         rows: 10, cols: 20  |
-        {1: }                   |
+        ^                    |
                             |*7
       ## grid 3
         {3:-- TERMINAL --}                                    |
@@ -241,7 +241,7 @@ describe(':terminal with multigrid', function()
       ## grid 2
         rows: 10, cols: 20                                                    |
         rows: 3, cols: 70                                                     |
-        {1: }                                                                     |
+        ^                                                                      |
       ## grid 3
         {3:-- TERMINAL --}                                    |
       ]])
@@ -260,7 +260,7 @@ describe(':terminal with multigrid', function()
         rows: 10, cols: 20                                |
         rows: 3, cols: 70                                 |
         rows: 6, cols: 50                                 |
-        {1: }                                                 |
+        ^                                                  |
                                                           |
       ## grid 3
         {3:-- TERMINAL --}                                    |

--- a/test/functional/terminal/window_split_tab_spec.lua
+++ b/test/functional/terminal/window_split_tab_spec.lua
@@ -49,7 +49,7 @@ describe(':terminal', function()
       ==========                                        |
       tty ready                                         |
       rows: 5, cols: 50                                 |
-      {2: }                                                 |
+                                                        |
                                                         |*2
       ==========                                        |
       :2split                                           |
@@ -61,7 +61,7 @@ describe(':terminal', function()
       ==========                                        |
       ^tty ready                                         |
       rows: 5, cols: 50                                 |
-      {2: }                                                 |
+                                                        |
                                                         |*2
       ==========                                        |
       :wincmd p                                         |
@@ -77,7 +77,7 @@ describe(':terminal', function()
     command('bprevious')
     screen:expect([[
       tty ready                                         |
-      ^foo{2: }                                              |
+      ^foo                                               |
                                                         |*8
     ]])
   end)
@@ -102,7 +102,7 @@ describe(':terminal', function()
     screen:expect([[
       tty ready                                      |
       rows: 7, cols: 47                              |
-      {2: }                                              |
+                                                     |
                                                      |*3
       ^                                               |
                                                      |
@@ -112,7 +112,7 @@ describe(':terminal', function()
       tty ready                                |
       rows: 7, cols: 47                        |
       rows: 4, cols: 41                        |
-      {2:^ }                                        |
+      ^                                         |
                                                |
     ]])
   end)

--- a/test/functional/testterm.lua
+++ b/test/functional/testterm.lua
@@ -29,6 +29,10 @@ function M.feed_termcode(data)
   M.feed_data('\027' .. data)
 end
 
+function M.feed_csi(data)
+  M.feed_termcode('[' .. data)
+end
+
 function M.make_lua_executor(session)
   return function(code, ...)
     local status, rv = session:request('nvim_exec_lua', code, { ... })
@@ -78,6 +82,9 @@ end
 function M.set_undercurl()
   M.feed_termcode('[4:3m')
 end
+function M.set_reverse()
+  M.feed_termcode('[7m')
+end
 function M.set_strikethrough()
   M.feed_termcode('[9m')
 end
@@ -108,7 +115,6 @@ function M.setup_screen(extra_rows, cmd, cols, env, screen_opts)
   cols = cols and cols or 50
 
   api.nvim_command('highlight TermCursor cterm=reverse')
-  api.nvim_command('highlight TermCursorNC ctermbg=11')
   api.nvim_command('highlight StatusLineTerm ctermbg=2 ctermfg=0')
   api.nvim_command('highlight StatusLineTermNC ctermbg=2 ctermfg=8')
 
@@ -154,7 +160,7 @@ function M.setup_screen(extra_rows, cmd, cols, env, screen_opts)
     local empty_line = (' '):rep(cols)
     local expected = {
       'tty ready' .. (' '):rep(cols - 9),
-      '{1: }' .. (' '):rep(cols - 1),
+      '^' .. (' '):rep(cols),
       empty_line,
       empty_line,
       empty_line,

--- a/test/functional/ui/cursor_spec.lua
+++ b/test/functional/ui/cursor_spec.lua
@@ -190,6 +190,19 @@ describe('ui/cursor', function()
         attr_lm = {},
         short_name = 'sm',
       },
+      [18] = {
+        blinkoff = 500,
+        blinkon = 500,
+        blinkwait = 0,
+        cell_percentage = 0,
+        cursor_shape = 'block',
+        name = 'terminal',
+        hl_id = 3,
+        id_lm = 3,
+        attr = { reverse = true },
+        attr_lm = { reverse = true },
+        short_name = 't',
+      },
     }
 
     screen:expect(function()
@@ -245,17 +258,20 @@ describe('ui/cursor', function()
         end
       end
       if m.hl_id then
-        m.hl_id = 66
+        m.hl_id = 65
         m.attr = { background = Screen.colors.DarkGray }
       end
       if m.id_lm then
-        m.id_lm = 73
+        m.id_lm = 72
+        m.attr_lm = {}
       end
     end
 
     -- Assert the new expectation.
     screen:expect(function()
-      eq(expected_mode_info, screen._mode_info)
+      for i, v in ipairs(expected_mode_info) do
+        eq(v, screen._mode_info[i])
+      end
       eq(true, screen._cursor_style_enabled)
       eq('normal', screen.mode)
     end)

--- a/test/functional/ui/hlstate_spec.lua
+++ b/test/functional/ui/hlstate_spec.lua
@@ -227,7 +227,7 @@ describe('ext_hlstate detailed highlights', function()
     command(("enew | call termopen(['%s'])"):format(testprg('tty-test')))
     screen:expect([[
       ^tty ready                               |
-      {1: }                                       |
+                                              |
                                               |*5
       {7:                                        }|
     ]])
@@ -242,7 +242,7 @@ describe('ext_hlstate detailed highlights', function()
       screen:expect([[
         ^tty ready                               |
         x {5:y z}                                   |
-        {1: }                                       |
+                                                |
                                                 |*4
         {7:                                        }|
       ]])
@@ -250,7 +250,7 @@ describe('ext_hlstate detailed highlights', function()
       screen:expect([[
         ^tty ready                               |
         x {2:y }{3:z}                                   |
-        {1: }                                       |
+                                                |
                                                 |*4
         {7:                                        }|
       ]])
@@ -268,7 +268,7 @@ describe('ext_hlstate detailed highlights', function()
     else
       screen:expect([[
         ^tty ready                               |
-        x {4:y}{2: }{3:z}                                   |
+        x {2:y }{3:z}                                   |
                                                 |*5
         {7:                                        }|
       ]])

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -49,7 +49,7 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { '\ntest\n[O]k: ', 6, 11 } },
+          content = { { '\ntest\n[O]k: ', 6, 10 } },
           kind = 'confirm',
         },
       },
@@ -77,7 +77,7 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { '\ntest\n[O]k: ', 6, 11 } },
+          content = { { '\ntest\n[O]k: ', 6, 10 } },
           kind = 'confirm',
         },
       },
@@ -91,7 +91,7 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { '\ntest\n[O]k: ', 6, 11 } },
+          content = { { '\ntest\n[O]k: ', 6, 10 } },
           kind = 'confirm',
         },
         {
@@ -99,7 +99,7 @@ describe('ui/ext_messages', function()
           kind = 'echo',
         },
         {
-          content = { { 'Press ENTER or type command to continue', 6, 19 } },
+          content = { { 'Press ENTER or type command to continue', 6, 18 } },
           kind = 'return_prompt',
         },
       },
@@ -116,7 +116,7 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { 'replace with X (y/n/a/q/l/^E/^Y)?', 6, 19 } },
+          content = { { 'replace with X (y/n/a/q/l/^E/^Y)?', 6, 18 } },
           kind = 'confirm_sub',
         },
       },
@@ -135,7 +135,7 @@ describe('ui/ext_messages', function()
       ]],
       messages = {
         {
-          content = { { 'W10: Warning: Changing a readonly file', 19, 27 } },
+          content = { { 'W10: Warning: Changing a readonly file', 19, 26 } },
           kind = 'wmsg',
         },
       },
@@ -151,7 +151,7 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { 'search hit BOTTOM, continuing at TOP', 19, 27 } },
+          content = { { 'search hit BOTTOM, continuing at TOP', 19, 26 } },
           kind = 'wmsg',
         },
       },
@@ -167,15 +167,15 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { 'Error detected while processing :', 9, 7 } },
+          content = { { 'Error detected while processing :', 9, 6 } },
           kind = 'emsg',
         },
         {
-          content = { { 'E605: Exception not caught: foo', 9, 7 } },
+          content = { { 'E605: Exception not caught: foo', 9, 6 } },
           kind = 'emsg',
         },
         {
-          content = { { 'Press ENTER or type command to continue', 6, 19 } },
+          content = { { 'Press ENTER or type command to continue', 6, 18 } },
           kind = 'return_prompt',
         },
       },
@@ -225,15 +225,15 @@ describe('ui/ext_messages', function()
         {
           content = {
             { '\nErrorMsg      ' },
-            { 'xxx', 9, 7 },
+            { 'xxx', 9, 6 },
             { ' ' },
-            { 'ctermfg=', 18, 6 },
+            { 'ctermfg=', 18, 5 },
             { '15 ' },
-            { 'ctermbg=', 18, 6 },
+            { 'ctermbg=', 18, 5 },
             { '1 ' },
-            { 'guifg=', 18, 6 },
+            { 'guifg=', 18, 5 },
             { 'White ' },
-            { 'guibg=', 18, 6 },
+            { 'guibg=', 18, 5 },
             { 'Red' },
           },
           kind = 'list_cmd',
@@ -250,7 +250,7 @@ describe('ui/ext_messages', function()
       {1:~                        }|*4
     ]],
       messages = { {
-        content = { { 'raa', 9, 7 } },
+        content = { { 'raa', 9, 6 } },
         kind = 'echoerr',
       } },
     }
@@ -277,15 +277,15 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { 'bork', 9, 7 } },
+          content = { { 'bork', 9, 6 } },
           kind = 'echoerr',
         },
         {
-          content = { { 'fail', 9, 7 } },
+          content = { { 'fail', 9, 6 } },
           kind = 'echoerr',
         },
         {
-          content = { { 'Press ENTER or type command to continue', 6, 19 } },
+          content = { { 'Press ENTER or type command to continue', 6, 18 } },
           kind = 'return_prompt',
         },
       },
@@ -299,19 +299,19 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { 'bork', 9, 7 } },
+          content = { { 'bork', 9, 6 } },
           kind = 'echoerr',
         },
         {
-          content = { { 'fail', 9, 7 } },
+          content = { { 'fail', 9, 6 } },
           kind = 'echoerr',
         },
         {
-          content = { { 'extrafail', 9, 7 } },
+          content = { { 'extrafail', 9, 6 } },
           kind = 'echoerr',
         },
         {
-          content = { { 'Press ENTER or type command to continue', 6, 19 } },
+          content = { { 'Press ENTER or type command to continue', 6, 18 } },
           kind = 'return_prompt',
         },
       },
@@ -333,7 +333,7 @@ describe('ui/ext_messages', function()
       {1:~                        }|*4
     ]],
       messages = { {
-        content = { { 'problem', 9, 7 } },
+        content = { { 'problem', 9, 6 } },
         kind = 'echoerr',
       } },
       cmdline = {
@@ -361,15 +361,15 @@ describe('ui/ext_messages', function()
       {1:~                        }|*4
     ]],
       msg_history = {
-        { kind = 'echoerr', content = { { 'raa', 9, 7 } } },
-        { kind = 'echoerr', content = { { 'bork', 9, 7 } } },
-        { kind = 'echoerr', content = { { 'fail', 9, 7 } } },
-        { kind = 'echoerr', content = { { 'extrafail', 9, 7 } } },
-        { kind = 'echoerr', content = { { 'problem', 9, 7 } } },
+        { kind = 'echoerr', content = { { 'raa', 9, 6 } } },
+        { kind = 'echoerr', content = { { 'bork', 9, 6 } } },
+        { kind = 'echoerr', content = { { 'fail', 9, 6 } } },
+        { kind = 'echoerr', content = { { 'extrafail', 9, 6 } } },
+        { kind = 'echoerr', content = { { 'problem', 9, 6 } } },
       },
       messages = {
         {
-          content = { { 'Press ENTER or type command to continue', 6, 19 } },
+          content = { { 'Press ENTER or type command to continue', 6, 18 } },
           kind = 'return_prompt',
         },
       },
@@ -394,7 +394,7 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { 'bork\nfail', 9, 7 } },
+          content = { { 'bork\nfail', 9, 6 } },
           kind = 'echoerr',
         },
       },
@@ -408,13 +408,13 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { 'Press ENTER or type command to continue', 6, 19 } },
+          content = { { 'Press ENTER or type command to continue', 6, 18 } },
           kind = 'return_prompt',
         },
       },
       msg_history = {
         {
-          content = { { 'bork\nfail', 9, 7 } },
+          content = { { 'bork\nfail', 9, 6 } },
           kind = 'echoerr',
         },
       },
@@ -462,7 +462,7 @@ describe('ui/ext_messages', function()
         { content = { { 'x                     #1' } }, kind = 'list_cmd' },
         { content = { { 'y                     #2' } }, kind = 'list_cmd' },
         {
-          content = { { 'Press ENTER or type command to continue', 6, 19 } },
+          content = { { 'Press ENTER or type command to continue', 6, 18 } },
           kind = 'return_prompt',
         },
       },
@@ -477,7 +477,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
-      showmode = { { '-- INSERT --', 5, 12 } },
+      showmode = { { '-- INSERT --', 5, 11 } },
     }
 
     feed('alphpabet<cr>alphanum<cr>')
@@ -488,7 +488,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*2
     ]],
-      showmode = { { '-- INSERT --', 5, 12 } },
+      showmode = { { '-- INSERT --', 5, 11 } },
     }
 
     feed('<c-x>')
@@ -499,7 +499,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*2
     ]],
-      showmode = { { '-- ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)', 5, 12 } },
+      showmode = { { '-- ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)', 5, 11 } },
     }
 
     feed('<c-p>')
@@ -515,7 +515,7 @@ describe('ui/ext_messages', function()
         items = { { 'alphpabet', '', '', '' }, { 'alphanum', '', '', '' } },
         pos = 1,
       },
-      showmode = { { '-- Keyword Local completion (^N^P) ', 5, 12 }, { 'match 1 of 2', 6, 19 } },
+      showmode = { { '-- Keyword Local completion (^N^P) ', 5, 11 }, { 'match 1 of 2', 6, 18 } },
     }
 
     -- echomsg and showmode don't overwrite each other, this is the same
@@ -537,7 +537,7 @@ describe('ui/ext_messages', function()
         content = { { 'stuff' } },
         kind = 'echomsg',
       } },
-      showmode = { { '-- Keyword Local completion (^N^P) ', 5, 12 }, { 'match 1 of 2', 6, 19 } },
+      showmode = { { '-- Keyword Local completion (^N^P) ', 5, 11 }, { 'match 1 of 2', 6, 18 } },
     }
 
     feed('<c-p>')
@@ -557,7 +557,7 @@ describe('ui/ext_messages', function()
         content = { { 'stuff' } },
         kind = 'echomsg',
       } },
-      showmode = { { '-- Keyword Local completion (^N^P) ', 5, 12 }, { 'match 2 of 2', 6, 19 } },
+      showmode = { { '-- Keyword Local completion (^N^P) ', 5, 11 }, { 'match 2 of 2', 6, 18 } },
     }
 
     feed('<esc>:messages<cr>')
@@ -574,7 +574,7 @@ describe('ui/ext_messages', function()
       } },
       messages = {
         {
-          content = { { 'Press ENTER or type command to continue', 6, 19 } },
+          content = { { 'Press ENTER or type command to continue', 6, 18 } },
           kind = 'return_prompt',
         },
       },
@@ -588,7 +588,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
-      showmode = { { 'recording @q', 5, 12 } },
+      showmode = { { 'recording @q', 5, 11 } },
     }
 
     feed('i')
@@ -597,7 +597,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
-      showmode = { { '-- INSERT --recording @q', 5, 12 } },
+      showmode = { { '-- INSERT --recording @q', 5, 11 } },
     }
 
     feed('<esc>')
@@ -606,7 +606,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
-      showmode = { { 'recording @q', 5, 12 } },
+      showmode = { { 'recording @q', 5, 11 } },
     }
 
     feed('q')
@@ -625,7 +625,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
-      showmode = { { 'recording @q', 5, 12 } },
+      showmode = { { 'recording @q', 5, 11 } },
       mode = 'normal',
     }
 
@@ -635,7 +635,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
-      showmode = { { 'recording @q', 5, 12 } },
+      showmode = { { 'recording @q', 5, 11 } },
       mode = 'insert',
     }
 
@@ -645,7 +645,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
-      showmode = { { 'recording @q', 5, 12 } },
+      showmode = { { 'recording @q', 5, 11 } },
       mode = 'normal',
     }
 
@@ -667,7 +667,7 @@ describe('ui/ext_messages', function()
         ^                         |
         {1:~                        }|*4
       ]],
-      ruler = { { '0,0-1   All', 9, 62 } },
+      ruler = { { '0,0-1   All', 9, 61 } },
     })
     command('hi clear MsgArea')
     feed('i')
@@ -676,7 +676,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
-      showmode = { { '-- INSERT --', 5, 12 } },
+      showmode = { { '-- INSERT --', 5, 11 } },
       ruler = { { '0,1     All' } },
     }
     feed('abcde<cr>12345<esc>')
@@ -714,7 +714,7 @@ describe('ui/ext_messages', function()
         {17:123}45                    |
         {1:~                        }|*3
       ]],
-      showmode = { { '-- VISUAL BLOCK --', 5, 12 } },
+      showmode = { { '-- VISUAL BLOCK --', 5, 11 } },
       showcmd = { { '2x3' } },
       ruler = { { '1,3     All' } },
     })
@@ -795,7 +795,7 @@ describe('ui/ext_messages', function()
       {1:~                        }|*4
     ]],
       messages = { {
-        content = { { 'bork', 9, 7 } },
+        content = { { 'bork', 9, 6 } },
         kind = 'echoerr',
       } },
     }
@@ -820,7 +820,7 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { 'E117: Unknown function: nosuchfunction', 9, 7 } },
+          content = { { 'E117: Unknown function: nosuchfunction', 9, 6 } },
           kind = 'emsg',
         },
       },
@@ -835,12 +835,12 @@ describe('ui/ext_messages', function()
       msg_history = {
         { kind = 'echomsg', content = { { 'howdy' } } },
         { kind = '', content = { { 'Type  :qa  and press <Enter> to exit Nvim' } } },
-        { kind = 'echoerr', content = { { 'bork', 9, 7 } } },
-        { kind = 'emsg', content = { { 'E117: Unknown function: nosuchfunction', 9, 7 } } },
+        { kind = 'echoerr', content = { { 'bork', 9, 6 } } },
+        { kind = 'emsg', content = { { 'E117: Unknown function: nosuchfunction', 9, 6 } } },
       },
       messages = {
         {
-          content = { { 'Press ENTER or type command to continue', 6, 19 } },
+          content = { { 'Press ENTER or type command to continue', 6, 18 } },
           kind = 'return_prompt',
         },
       },
@@ -913,7 +913,7 @@ stack traceback:
 	[C]: in function 'error'
 	[string ":lua"]:1: in main chunk]],
               9,
-              7,
+              6,
             },
           },
           kind = 'lua_error',
@@ -933,7 +933,7 @@ stack traceback:
       messages = {
         {
           content = {
-            { "Error invoking 'test_method' on channel 1:\ncomplete\nerror\n\nmessage", 9, 7 },
+            { "Error invoking 'test_method' on channel 1:\ncomplete\nerror\n\nmessage", 9, 6 },
           },
           kind = 'rpc_error',
         },
@@ -1062,7 +1062,7 @@ stack traceback:
     ]],
       messages = {
         {
-          content = { { 'wow, ', 10, 9 }, { 'such\n\nvery ', 9, 7 }, { 'color', 8, 13 } },
+          content = { { 'wow, ', 10, 8 }, { 'such\n\nvery ', 9, 6 }, { 'color', 8, 12 } },
           kind = 'echomsg',
         },
       },
@@ -1087,13 +1087,13 @@ stack traceback:
     ]],
       messages = {
         {
-          content = { { 'Press ENTER or type command to continue', 6, 19 } },
+          content = { { 'Press ENTER or type command to continue', 6, 18 } },
           kind = 'return_prompt',
         },
       },
       msg_history = {
         {
-          content = { { 'wow, ', 10, 9 }, { 'such\n\nvery ', 9, 7 }, { 'color', 8, 13 } },
+          content = { { 'wow, ', 10, 8 }, { 'such\n\nvery ', 9, 6 }, { 'color', 8, 12 } },
           kind = 'echomsg',
         },
       },
@@ -1753,7 +1753,7 @@ describe('ui/ext_messages', function()
       {1:~                }type  :help iccf{18:<Enter>}       for information {1:                 }|
       {1:~                                                                               }|*5
     ]]
-    local showmode = { { '-- INSERT --', 5, 12 } }
+    local showmode = { { '-- INSERT --', 5, 11 } }
     screen:expect(introscreen)
 
     -- <c-l> (same as :mode) does _not_ clear intro message
@@ -1828,7 +1828,7 @@ describe('ui/ext_messages', function()
     ]],
       messages = {
         {
-          content = { { 'Press ENTER or type command to continue', 6, 19 } },
+          content = { { 'Press ENTER or type command to continue', 6, 18 } },
           kind = 'return_prompt',
         },
       },

--- a/test/functional/ui/output_spec.lua
+++ b/test/functional/ui/output_spec.lua
@@ -34,7 +34,7 @@ describe('shell command :!', function()
       n.nvim_set .. ' notermguicolors',
     })
     screen:expect([[
-      {1: }                                                 |
+      ^                                                  |
       {4:~                                                 }|*4
                                                         |
       {3:-- TERMINAL --}                                    |
@@ -78,7 +78,7 @@ describe('shell command :!', function()
       29999: foo                                        |
       30000: foo                                        |
                                                         |
-      {10:Press ENTER or type command to continue}{1: }          |
+      {10:Press ENTER or type command to continue}^           |
       {3:-- TERMINAL --}                                    |
     ]],
       {

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -967,11 +967,11 @@ function Screen:_handle_mode_info_set(cursor_style_enabled, mode_info)
   self._cursor_style_enabled = cursor_style_enabled
   for _, item in pairs(mode_info) do
     -- attr IDs are not stable, but their value should be
-    if item.attr_id ~= nil then
+    if item.attr_id ~= nil and self._attr_table[item.attr_id] ~= nil then
       item.attr = self._attr_table[item.attr_id][1]
       item.attr_id = nil
     end
-    if item.attr_id_lm ~= nil then
+    if item.attr_id_lm ~= nil and self._attr_table[item.attr_id_lm] ~= nil then
       item.attr_lm = self._attr_table[item.attr_id_lm][1]
       item.attr_id_lm = nil
     end


### PR DESCRIPTION
When a terminal application running inside the terminal emulator sets the cursor shape or blink status of the cursor, update the cursor in the parent terminal to match.

This removes the "virtual cursor" that has been in use by the terminal emulator since the beginning. The original rationale for using the virtual cursor was to avoid having to support additional UI methods to change the cursor color for other (non-TUI) UIs, instead relying on the TermCursor and TermCursorNC highlight groups.

The TermCursor highlight group is now used in the default `'guicursor'` value, which has a new entry for Terminal mode. However, the TermCursorNC highlight group is no longer supported: since terminal windows now use the real cursor, when the window is not focused there is no cursor displayed in the window at all, so there is nothing to highlight. Users can still use the `StatusLineTermNC` highlight group to differentiate non-focused terminal windows.

BREAKING CHANGE: The TermCursorNC highlight group is no longer supported.

Fixes #3681.
Fixes https://github.com/neovim/neovim/issues/20325.
