### PR TITLE
fix(runtime): let match(it+paren) skips use treesitter

### DIFF
--- a/runtime/pack/dist/opt/matchit/doc/matchit.txt
+++ b/runtime/pack/dist/opt/matchit/doc/matchit.txt
@@ -237,6 +237,8 @@ supported by matchit.vim:
 	S:foo becomes (current syntax item) !~ foo
 	r:foo becomes (line before cursor) =~ foo
 	R:foo becomes (line before cursor) !~ foo
+	t:foo becomes (current treesitter captures) =~ foo
+	T:foo becomes (current treesitter captures) !~ foo
 (The "s" is meant to suggest "syntax", and the "r" is meant to suggest
 "regular expression".)
 

--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -109,6 +109,10 @@ func s:Highlight_Matching_Pair()
 
   if !has("syntax") || !exists("g:syntax_on")
     let s_skip = "0"
+  elseif exists("b:ts_highlight") && &syntax != 'on'
+    let s_skip = "match(v:lua.vim.treesitter.get_captures_at_cursor(), '"
+          \ .. 'string\|character\|singlequote\|escape\|symbol\|comment'
+          \ .. "') != -1"
   else
     " Build an expression that detects whether the current cursor position is
     " in certain syntax types (string, comment, etc.), for use as


### PR DESCRIPTION
Problem: When treesitter is enabled, by default syntax groups are not defined, but these
groups are used to identify where to skip matches in matchit and matchparen.

Solution: This patch does three things:
1. If syntax is enabled regardless of treesitter (`vim.bo.syntax='on'`):
   Use original implementation.
2. If treesitter is enabled and syntax is not:
   Match the syntax groups (i.e. `comment\|string`) against treesitter captures
   to check for skipped groups.
3. Add an explicit treesitter syntax for marking captures to skip:
   matchit uses `b:match_skip` to determine what counts as skippable
   Where 's:comment\|string' uses a match of the named syntax groups against
   a regex match of comment\|string, 't:comment\|string' now uses vim regex
   to match against the names of the treesitter capture groups.

ref #15462