### PR TITLE
fix(lsp): reuse client if configs match and no root dir

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -201,23 +201,28 @@ local function reuse_client_default(client, config)
   end
 
   local config_folders = lsp._get_workspace_folders(config.workspace_folders or config.root_dir)
-    or {}
-  local config_folders_included = 0
 
-  if not next(config_folders) then
-    return false
+  if not config_folders or not next(config_folders) then
+    -- Reuse if the client was configured with no workspace folders
+    local client_config_folders =
+      lsp._get_workspace_folders(client.config.workspace_folders or client.config.root_dir)
+    return not client_config_folders or not next(client_config_folders)
   end
 
   for _, config_folder in ipairs(config_folders) do
+    local found = false
     for _, client_folder in ipairs(client.workspace_folders) do
       if config_folder.uri == client_folder.uri then
-        config_folders_included = config_folders_included + 1
+        found = true
         break
       end
     end
+    if not found then
+      return false
+    end
   end
 
-  return config_folders_included == #config_folders
+  return true
 end
 
 --- Reset defaults set by `set_defaults`.

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -731,9 +731,10 @@ describe('vim.lsp.completion: item conversion', function()
   )
 end)
 
+--- @param name string
 --- @param completion_result lsp.CompletionList
 --- @return integer
-local function create_server(completion_result)
+local function create_server(name, completion_result)
   return exec_lua(function()
     local server = _G._create_server({
       capabilities = {
@@ -751,7 +752,7 @@ local function create_server(completion_result)
     local bufnr = vim.api.nvim_get_current_buf()
     vim.api.nvim_win_set_buf(0, bufnr)
     return vim.lsp.start({
-      name = 'dummy',
+      name = name,
       cmd = server.cmd,
       on_attach = function(client, bufnr0)
         vim.lsp.completion.enable(true, client.id, bufnr0, {
@@ -800,7 +801,7 @@ describe('vim.lsp.completion: protocol', function()
   end
 
   it('fetches completions and shows them using complete on trigger', function()
-    create_server({
+    create_server('dummy', {
       isIncomplete = false,
       items = {
         {
@@ -892,7 +893,7 @@ describe('vim.lsp.completion: protocol', function()
   end)
 
   it('merges results from multiple clients', function()
-    create_server({
+    create_server('dummy1', {
       isIncomplete = false,
       items = {
         {
@@ -900,7 +901,7 @@ describe('vim.lsp.completion: protocol', function()
         },
       },
     })
-    create_server({
+    create_server('dummy2', {
       isIncomplete = false,
       items = {
         {
@@ -933,7 +934,7 @@ describe('vim.lsp.completion: protocol', function()
         },
       },
     }
-    local client_id = create_server(completion_list)
+    local client_id = create_server('dummy', completion_list)
 
     exec_lua(function()
       _G.called = false
@@ -970,7 +971,7 @@ describe('vim.lsp.completion: protocol', function()
   end)
 
   it('enable(…,{convert=fn}) custom word/abbr format', function()
-    create_server({
+    create_server('dummy', {
       isIncomplete = false,
       items = {
         {
@@ -1012,7 +1013,7 @@ describe('vim.lsp.completion: integration', function()
     exec_lua(function()
       vim.o.completeopt = 'menuone,noselect'
     end)
-    create_server(completion_list)
+    create_server('dummy', completion_list)
     feed('i world<esc>0ih<c-x><c-o>')
     retry(nil, nil, function()
       eq(


### PR DESCRIPTION
Problem:
An LSP configuration that creates client with no root_dir or
workspace_folders can result in vim.lsp.enable attaching to it multiple
times.

Solution:
When checking existing clients add a special case that unconditionally
re-uses the client that specific clients is already attached to the
buffer and the config is identical.

---

Not 100% happy with this, but I believe the test is sound.

Another solution would be to add a `bufnr` param to `reuse_client`.