### PR TITLE
fix(Man.lua): trigger completion even without arguments

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -576,9 +576,8 @@ function M.man_complete(arg_lead, cmd_line, _)
   end
 
   if #args == 1 then
-    -- returning full completion is laggy. Require some arg_lead to complete
-    -- return complete('', '', '')
-    return {}
+    -- XXX: This (full completion) is laggy, but without it tab-complete is broken. #31512
+    return complete('', '', '')
   end
 
   if arg_lead:match('^[^()]+%([^()]*$') then


### PR DESCRIPTION
closes: #31512

It is slow to return all the manual entries but it is something that the user expects.