### PR TITLE
fix(Man): completion on Mac

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -21,9 +21,12 @@ end
 local function system(cmd, silent, env)
   local r = vim.system(cmd, { env = env, timeout = 10000 }):wait()
 
-  if r.code ~= 0 and not silent then
-    local cmd_str = table.concat(cmd, ' ')
-    man_error(string.format("command error '%s': %s", cmd_str, r.stderr))
+  if not silent then
+    if r.code ~= 0 then
+      local cmd_str = table.concat(cmd, ' ')
+      man_error(string.format("command error '%s': %s", cmd_str, r.stderr))
+    end
+    assert(r.stdout ~= '')
   end
 
   return assert(r.stdout)

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -263,4 +263,14 @@ describe(':Man', function()
       { '1', 'other_man' },
     }, get_search_history('other_man(1)'))
   end)
+
+  it('can complete', function()
+    t.skip(t.is_os('mac') and t.is_arch('x86_64'), 'not supported on intel mac')
+    eq(
+      true,
+      exec_lua(function()
+        return #require('man').man_complete('f', 'Man g') > 0
+      end)
+    )
+  end)
 end)

--- a/test/testutil.lua
+++ b/test/testutil.lua
@@ -409,6 +409,17 @@ function M.is_os(s)
   )
 end
 
+local architecture = uv.os_uname().machine
+
+--- @param s 'x86_64'|'arm64'
+--- @return boolean
+function M.is_arch(s)
+  if not (s == 'x86_64' or s == 'arm64') then
+    error('unknown architecture: ' .. tostring(s))
+  end
+  return s == architecture
+end
+
 local tmpname_id = 0
 local tmpdir = os.getenv('TMPDIR') or os.getenv('TEMP')
 local tmpdir_is_local = not not (tmpdir and tmpdir:find('Xtest'))


### PR DESCRIPTION
Problem:
`man -w` does not work on recent versions of MacOs.

Solution:
Make it so an empty result is interpreted as an error unless silent=true

closes: https://github.com/neovim/neovim/issues/31512