### PR TITLE
fix(diagnostic): support function type of float in open_float()

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -547,7 +547,7 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
                              Use virtual lines for diagnostics.
       • {signs}?             (`boolean|vim.diagnostic.Opts.Signs|fun(namespace: integer, bufnr:integer): vim.diagnostic.Opts.Signs`, default: `true`)
                              Use signs for diagnostics |diagnostic-signs|.
-      • {float}?             (`boolean|vim.diagnostic.Opts.Float|fun(namespace: integer, bufnr:integer): vim.diagnostic.Opts.Float`)
+      • {float}?             (`boolean|vim.diagnostic.Opts.Float|fun(namespace?: integer|integer[], bufnr:integer): vim.diagnostic.Opts.Float`)
                              Options for floating windows. See
                              |vim.diagnostic.Opts.Float|.
       • {status}?            (`vim.diagnostic.Opts.Status`) Options for the

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -92,7 +92,7 @@ end
 --- @field signs? boolean|vim.diagnostic.Opts.Signs|fun(namespace: integer, bufnr:integer): vim.diagnostic.Opts.Signs
 ---
 --- Options for floating windows. See |vim.diagnostic.Opts.Float|.
---- @field float? boolean|vim.diagnostic.Opts.Float|fun(namespace: integer, bufnr:integer): vim.diagnostic.Opts.Float
+--- @field float? boolean|vim.diagnostic.Opts.Float|fun(namespace?: integer|integer[], bufnr:integer): vim.diagnostic.Opts.Float
 ---
 --- Options for the statusline component.
 --- @field status? vim.diagnostic.Opts.Status
@@ -2408,10 +2408,13 @@ function M.open_float(opts, ...)
     -- Resolve options with user settings from vim.diagnostic.config
     -- Unlike the other decoration functions (e.g. set_virtual_text, set_signs, etc.) `open_float`
     -- does not have a dedicated table for configuration options; instead, the options are mixed in
-    -- with its `opts` table which also includes "keyword" parameters. So we create a dedicated
-    -- options table that inherits missing keys from the global configuration before resolving.
-    local t = global_diagnostic_options.float
-    local float_opts = vim.tbl_extend('keep', opts, type(t) == 'table' and t or {})
+    -- with its `opts` table. We create a dedicated options table (`float_opts`) that inherits
+    -- missing keys from the global configuration (`global_diagnostic_options.float`), which can
+    -- be a table or a function.
+    local o = global_diagnostic_options
+    local t = type(o.float) == 'table' and o.float
+      or (type(o.float) == 'function' and o.float(opts.namespace, bufnr) or {})
+    local float_opts = vim.tbl_extend('keep', opts, t)
     opts = get_resolved_options({ float = float_opts }, nil, bufnr).float
   end
 


### PR DESCRIPTION
Problem: the float field of vim.diagnostic.config can be a function type but function was ignored in open_float function.

Solution: check global_diagnostic_options.float type before use for funciton type

Fix #31573