### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -86,6 +86,13 @@ command.  There are however, two general exceptions:
    end of the motion is moved to the end of the previous line and the motion
    becomes inclusive.  Example: "}" moves to the first line after a paragraph,
    but "d}" will not include that line.
+
+					*inclusive-motion-selection-exclusive*
+When 'selection' is "exclusive", |Visual| mode is active and an inclusive
+motion has been used, the cursor position will be adjusted by another
+character to the right, so that visual selction includes the expected text and
+can be acted upon.
+
 						*exclusive-linewise*
 2. If the motion is exclusive, the end of the motion is in column 1 and the
    start of the motion was at or before the first non-blank in the line, the

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4982,6 +4982,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	selection.
 	When "old" is used and 'virtualedit' allows the cursor to move past
 	the end of line the line break still isn't included.
+	When "exclusive" is used, cursor position in visual mode will be
+	adjusted for inclusive motions |inclusive-motion-selection-exclusive|.
 	Note that when "exclusive" is used and selecting from the end
 	backwards, you cannot include the last character of a line, when
 	starting in Normal mode and 'virtualedit' empty.

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -985,6 +985,8 @@ CTRL-W g }						*CTRL-W_g}*
 		position isn't changed.  Useful example: >
 			:pedit +/fputc /usr/include/stdio.h
 <
+		Also see |++opt| and |+cmd|.
+
 							*:ps* *:psearch*
 :[range]ps[earch][!] [count] [/]pattern[/]
 		Works like |:ijump| but shows the found match in the preview

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5214,6 +5214,8 @@ vim.go.sect = vim.go.sections
 --- selection.
 --- When "old" is used and 'virtualedit' allows the cursor to move past
 --- the end of line the line break still isn't included.
+--- When "exclusive" is used, cursor position in visual mode will be
+--- adjusted for inclusive motions `inclusive-motion-selection-exclusive`.
 --- Note that when "exclusive" is used and selecting from the end
 --- backwards, you cannot include the last character of a line, when
 --- starting in Normal mode and 'virtualedit' empty.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7011,6 +7011,8 @@ return {
         selection.
         When "old" is used and 'virtualedit' allows the cursor to move past
         the end of line the line break still isn't included.
+        When "exclusive" is used, cursor position in visual mode will be
+        adjusted for inclusive motions |inclusive-motion-selection-exclusive|.
         Note that when "exclusive" is used and selecting from the end
         backwards, you cannot include the last character of a line, when
         starting in Normal mode and 'virtualedit' empty.


### PR DESCRIPTION
#### vim-patch:ed89206: runtime(doc): add a note about inclusive motions and exclusive selection

related: vim/vim#16202

https://github.com/vim/vim/commit/ed89206efe404a94e8424ccfe03c978fd93470f1

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:fbe9a69: runtime(doc): Add a reference to |++opt| and |+cmd| at `:h :pedit`

closes: vim/vim#16217

https://github.com/vim/vim/commit/fbe9a6903a5b66d5b546a5a080726cba50372df5

Co-authored-by: Yinzuo Jiang <jiangyinzuo@foxmail.com>