### PR TITLE
vim-patch:9.1.0926: filetype: Pixi lock files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1874,6 +1874,7 @@ local filename = {
   ['.clangd'] = 'yaml',
   ['.clang-format'] = 'yaml',
   ['.clang-tidy'] = 'yaml',
+  ['pixi.lock'] = 'yaml',
   ['yarn.lock'] = 'yaml',
   matplotlibrc = 'yaml',
   ['.condarc'] = 'yaml',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -890,7 +890,7 @@ func s:GetFilenameChecks() abort
     \ 'xslt': ['file.xsl', 'file.xslt'],
     \ 'yacc': ['file.yy', 'file.yxx', 'file.y++'],
     \ 'yaml': ['file.yaml', 'file.yml', 'file.eyaml', 'any/.bundle/config', '.clangd', '.clang-format', '.clang-tidy', 'file.mplstyle', 'matplotlibrc', 'yarn.lock',
-    \          '/home/user/.kube/config', '.condarc', 'condarc'],
+    \          '/home/user/.kube/config', '.condarc', 'condarc', 'pixi.lock'],
     \ 'yang': ['file.yang'],
     \ 'yuck': ['file.yuck'],
     \ 'z8a': ['file.z8a'],


### PR DESCRIPTION
Problem:  filetype: Pixi lock files are not recognized
Solution: detect "pixi.lock" file as yaml filetype
          (Brandon Maier)

Reference:
https://pixi.sh/latest/features/lockfile/

closes: vim/vim#16212

https://github.com/vim/vim/commit/7d1bb90dcf711c732a49e0a45e56028a4853a17d

Co-authored-by: Brandon Maier <brandon.maier@gmail.com>
