### PR TITLE
vim-patch:9.1.0929: filetype: lalrpop files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -672,6 +672,7 @@ local extension = {
   k = 'kwt',
   ACE = 'lace',
   ace = 'lace',
+  lalrpop = 'lalrpop',
   latte = 'latte',
   lte = 'latte',
   ld = 'ld',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -404,6 +404,7 @@ func s:GetFilenameChecks() abort
     \ 'kscript': ['file.ks'],
     \ 'kwt': ['file.k'],
     \ 'lace': ['file.ace', 'file.ACE'],
+    \ 'lalrpop': ['file.lalrpop'],
     \ 'latte': ['file.latte', 'file.lte'],
     \ 'ld': ['file.ld', 'any/usr/lib/aarch64-xilinx-linux/ldscripts/aarch64elf32b.x'],
     \ 'ldapconf': ['ldap.conf', '.ldaprc', 'ldaprc'],


### PR DESCRIPTION
Problem:  filetype: lalrpop files are not recognized
Solution: detect '*.lalrpop' files as lalrpop filetype
          (David Thievon)

References:
https://github.com/lalrpop/lalrpop

closes: vim/vim#16223

https://github.com/vim/vim/commit/5a2e0cf5f11c611c9b01f1bd6e7294edf0dd2bf4

Co-authored-by: David Thievon <pdkfan@gmail.com>
