### PR TITLE
fix(messages): no message kind for :undo messages

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -805,6 +805,7 @@ must handle.
 		"quickfix"	Quickfix navigation message
 		"search_cmd"	Entered search command
 		"search_count"	Search count message ("S" flag of 'shortmess')
+		"undo"		|:undo| and |:redo| message
 		"wildlist"	'wildmode' "list" message
 		"wmsg"		Warning ("search hit BOTTOM", |W10|, …)
 	    New kinds may be added in the future; clients should treat unknown

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1862,6 +1862,7 @@ static void u_doit(int startcount, bool quiet, bool do_buf_event)
     u_oldcount = -1;
   }
 
+  msg_ext_set_kind("undo");
   int count = startcount;
   while (count--) {
     // Do the change warning now, so that it triggers FileChangedRO when

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -240,6 +240,36 @@ describe('ui/ext_messages', function()
         },
       },
     })
+
+    -- undo
+    feed('uu')
+    screen:expect({
+      grid = [[
+        ^                         |
+        {1:~                        }|*4
+      ]],
+      messages = {
+        {
+          content = { { 'Already at oldest change' } },
+          kind = 'undo',
+        },
+      },
+    })
+
+    feed('<C-r><C-r><C-r>')
+    screen:expect({
+      grid = [[
+        line 1                   |
+        line^                     |
+        {1:~                        }|*3
+      ]],
+      messages = {
+        {
+          content = { { 'Already at newest change' } },
+          kind = 'undo',
+        },
+      },
+    })
   end)
 
   it(':echoerr', function()


### PR DESCRIPTION
Problem: cannot handle `:undo` and `:redo` messages in a special way, e.g. replace one by another.

Solution: add `undo` kind.