### PR TITLE
refactor(api): always use TRY_WRAP

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -42,8 +42,10 @@
 
 /// Start block that may cause Vimscript exceptions while evaluating another code
 ///
-/// Used when caller is supposed to be operating when other Vimscript code is being
-/// processed and that “other Vimscript code” must not be affected.
+/// Used just in case caller is supposed to be operating when other Vimscript code
+/// is being processed and that “other Vimscript code” must not be affected.
+///
+/// @warning Avoid calling directly; use TRY_WRAP instead.
 ///
 /// @param[out]  tstate  Location where try state should be saved.
 void try_enter(TryState *const tstate)
@@ -55,75 +57,33 @@ void try_enter(TryState *const tstate)
     .current_exception = current_exception,
     .msg_list = (const msglist_T *const *)msg_list,
     .private_msg_list = NULL,
-    .trylevel = trylevel,
     .got_int = got_int,
     .did_throw = did_throw,
     .need_rethrow = need_rethrow,
     .did_emsg = did_emsg,
   };
+  // `msg_list` controls the collection of abort-causing non-exception errors,
+  // which would otherwise be ignored.  This pattern is from do_cmdline().
   msg_list = &tstate->private_msg_list;
   current_exception = NULL;
-  trylevel = 1;
   got_int = false;
   did_throw = false;
   need_rethrow = false;
   did_emsg = false;
-}
-
-/// End try block, set the error message if any and restore previous state
-///
-/// @warning Return is consistent with most functions (false on error), not with
-///          try_end (true on error).
-///
-/// @param[in]  tstate  Previous state to restore.
-/// @param[out]  err  Location where error should be saved.
-///
-/// @return false if error occurred, true otherwise.
-bool try_leave(const TryState *const tstate, Error *const err)
-  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_WARN_UNUSED_RESULT
-{
-  const bool ret = !try_end(err);
-  assert(trylevel == 0);
-  assert(!need_rethrow);
-  assert(!got_int);
-  assert(!did_throw);
-  assert(!did_emsg);
-  assert(msg_list == &tstate->private_msg_list);
-  assert(*msg_list == NULL);
-  assert(current_exception == NULL);
-  msg_list = (msglist_T **)tstate->msg_list;
-  current_exception = tstate->current_exception;
-  trylevel = tstate->trylevel;
-  got_int = tstate->got_int;
-  did_throw = tstate->did_throw;
-  need_rethrow = tstate->need_rethrow;
-  did_emsg = tstate->did_emsg;
-  return ret;
-}
-
-/// Starts a block that may cause Vimscript exceptions; must be mirrored by `try_end()` call.
-///
-/// Note: use `TRY_WRAP` instead (except in `FUNC_API_FAST` functions such as nvim_get_runtime_file).
-///
-/// To be used as a replacement of `:try … catch … endtry` in C code, in cases
-/// when error flag could not already be set. If there may be pending error
-/// state at the time try_start() is executed which needs to be preserved,
-/// try_enter()/try_leave() pair should be used instead.
-void try_start(void)
-{
   trylevel++;
 }
 
-/// Ends a `try_start` block; sets error message if any and returns true if an error occurred.
+/// Ends a `try_enter` block; sets error message if any.
 ///
-/// Note: use `TRY_WRAP` instead (except in `FUNC_API_FAST` functions such as nvim_get_runtime_file).
+/// @warning Avoid calling directly; use TRY_WRAP instead.
 ///
-/// @param err Pointer to the stack-allocated error object
-/// @return true if an error occurred
-bool try_end(Error *err)
+/// @param[out] err Pointer to the stack-allocated error object
+void try_leave(const TryState *const tstate, Error *const err)
+  FUNC_ATTR_NONNULL_ALL
 {
   // Note: all globals manipulated here should be saved/restored in
   // try_enter/try_leave.
+  assert(trylevel > 0);
   trylevel--;
 
   // Set by emsg(), affects aborting().  See also enter_cleanup().
@@ -166,7 +126,20 @@ bool try_end(Error *err)
     discard_current_exception();
   }
 
-  return ERROR_SET(err);
+  assert(msg_list == &tstate->private_msg_list);
+  assert(*msg_list == NULL);
+  assert(current_exception == NULL);
+  assert(!got_int);
+  assert(!did_throw);
+  assert(!need_rethrow);
+  assert(!did_emsg);
+  // Restore the exception context.
+  msg_list = (msglist_T **)tstate->msg_list;
+  current_exception = tstate->current_exception;
+  got_int = tstate->got_int;
+  did_throw = tstate->did_throw;
+  need_rethrow = tstate->need_rethrow;
+  did_emsg = tstate->did_emsg;
 }
 
 /// Recursively expands a vimscript value in a dict

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -147,27 +147,19 @@ typedef struct {
   except_T *current_exception;
   msglist_T *private_msg_list;
   const msglist_T *const *msg_list;
-  int trylevel;
   int got_int;
   bool did_throw;
   int need_rethrow;
   int did_emsg;
 } TryState;
 
-// `msg_list` controls the collection of abort-causing non-exception errors,
-// which would otherwise be ignored.  This pattern is from do_cmdline().
-//
 // TODO(bfredl): prepare error-handling at "top level" (nv_event).
 #define TRY_WRAP(err, code) \
   do { \
-    msglist_T **saved_msg_list = msg_list; \
-    msglist_T *private_msg_list; \
-    msg_list = &private_msg_list; \
-    private_msg_list = NULL; \
-    try_start(); \
+    TryState tstate; \
+    try_enter(&tstate); \
     code; \
-    try_end(err); \
-    msg_list = saved_msg_list;  /* Restore the exception context. */ \
+    try_leave(&tstate, err); \
   } while (0)
 
 // Execute code with cursor position saved and restored and textlock active.

--- a/src/nvim/api/tabpage.c
+++ b/src/nvim/api/tabpage.c
@@ -146,11 +146,9 @@ void nvim_tabpage_set_win(Tabpage tabpage, Window win, Error *err)
   }
 
   if (tp == curtab) {
-    try_start();
-    win_goto(wp);
-    if (!try_end(err) && curwin != wp) {
-      api_set_error(err, kErrorTypeException, "Failed to switch to window %d", win);
-    }
+    TRY_WRAP(err, {
+      win_goto(wp);
+    });
   } else if (tp->tp_curwin != wp) {
     tp->tp_prevwin = tp->tp_curwin;
     tp->tp_curwin = wp;

--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -78,24 +78,24 @@ String exec_impl(uint64_t channel_id, String src, Dict(exec_opts) *opts, Error *
     capture_ga = &capture_local;
   }
 
-  try_start();
-  if (opts->output) {
-    msg_silent++;
-    msg_col = 0;  // prevent leading spaces
-  }
+  TRY_WRAP(err, {
+    if (opts->output) {
+      msg_silent++;
+      msg_col = 0;  // prevent leading spaces
+    }
 
-  const sctx_T save_current_sctx = api_set_sctx(channel_id);
+    const sctx_T save_current_sctx = api_set_sctx(channel_id);
 
-  do_source_str(src.data, "nvim_exec2()");
-  if (opts->output) {
-    capture_ga = save_capture_ga;
-    msg_silent = save_msg_silent;
-    // Put msg_col back where it was, since nothing should have been written.
-    msg_col = save_msg_col;
-  }
+    do_source_str(src.data, "nvim_exec2()");
+    if (opts->output) {
+      capture_ga = save_capture_ga;
+      msg_silent = save_msg_silent;
+      // Put msg_col back where it was, since nothing should have been written.
+      msg_col = save_msg_col;
+    }
 
-  current_sctx = save_current_sctx;
-  try_end(err);
+    current_sctx = save_current_sctx;
+  });
 
   if (ERROR_SET(err)) {
     goto theend;

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -368,19 +368,16 @@ void nvim_win_hide(Window window, Error *err)
   }
 
   tabpage_T *tabpage = win_find_tabpage(win);
-  TryState tstate;
-  try_enter(&tstate);
-
-  // Never close the autocommand window.
-  if (is_aucmd_win(win)) {
-    emsg(_(e_autocmd_close));
-  } else if (tabpage == curtab) {
-    win_close(win, false, false);
-  } else {
-    win_close_othertab(win, false, tabpage);
-  }
-
-  vim_ignored = try_leave(&tstate, err);
+  TRY_WRAP(err, {
+    // Never close the autocommand window.
+    if (is_aucmd_win(win)) {
+      emsg(_(e_autocmd_close));
+    } else if (tabpage == curtab) {
+      win_close(win, false, false);
+    } else {
+      win_close_othertab(win, false, tabpage);
+    }
+  });
 }
 
 /// Closes the window (like |:close| with a |window-ID|).
@@ -400,10 +397,9 @@ void nvim_win_close(Window window, Boolean force, Error *err)
   }
 
   tabpage_T *tabpage = win_find_tabpage(win);
-  TryState tstate;
-  try_enter(&tstate);
-  ex_win_close(force, win, tabpage == curtab ? NULL : tabpage);
-  vim_ignored = try_leave(&tstate, err);
+  TRY_WRAP(err, {
+    ex_win_close(force, win, tabpage == curtab ? NULL : tabpage);
+  });
 }
 
 /// Calls a function with window as temporary current window.

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -3933,7 +3933,7 @@ static bool switch_option_context(void *const ctx, OptScope scope, void *const f
         == FAIL) {
       restore_win_noblock(switchwin, true);
 
-      if (try_end(err)) {
+      if (ERROR_SET(err)) {
         return false;
       }
       api_set_error(err, kErrorTypeException, "Problem while switching windows");


### PR DESCRIPTION
Problem:  Two separate try/end wrappers, that only marginally differ by
          restoring a few variables. Wrappers that don't restore
          previous state are dangerous to use in "api-fast" functions.
Solution: Remove wrappers that don't restore the previous state.
          Always use TRY_WRAP.

Continues #31595, #31596 