### PR TITLE
refactor(man.lua): various changes

### DIFF
--- a/runtime/plugin/man.lua
+++ b/runtime/plugin/man.lua
@@ -8,9 +8,9 @@ vim.api.nvim_create_user_command('Man', function(params)
   if params.bang then
     man.init_pager()
   else
-    local ok, err = pcall(man.open_page, params.count, params.smods, params.fargs)
-    if not ok then
-      vim.notify(man.errormsg or err, vim.log.levels.ERROR)
+    local err = man.open_page(params.count, params.smods, params.fargs)
+    if err then
+      vim.notify('man.lua: ' .. err, vim.log.levels.ERROR)
     end
   end
 end, {
@@ -31,6 +31,9 @@ vim.api.nvim_create_autocmd('BufReadCmd', {
   pattern = 'man://*',
   nested = true,
   callback = function(params)
-    require('man').read_page(vim.fn.matchstr(params.match, 'man://\\zs.*'))
+    local err = require('man').read_page(assert(params.match:match('man://(.*)')))
+    if err then
+      vim.notify('man.lua: ' .. err, vim.log.levels.ERROR)
+    end
   end,
 })

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -21,13 +21,12 @@ local function get_search_history(name)
     local man = require('man')
     local res = {}
     --- @diagnostic disable-next-line:duplicate-set-field
-    man.find_path = function(sect, name0)
+    man._find_path = function(name0, sect)
       table.insert(res, { sect, name0 })
       return nil
     end
-    local ok, rv = pcall(man.open_page, -1, { tab = 0 }, args)
-    assert(not ok)
-    assert(rv and rv:match('no manual entry'))
+    local err = man.open_page(-1, { tab = 0 }, args)
+    assert(err and err:match('no manual entry'))
     return res
   end)
 end
@@ -225,7 +224,7 @@ describe(':Man', function()
     matches('^/.+', actual_file)
     local args = { nvim_prog, '--headless', '+:Man ' .. actual_file, '+q' }
     matches(
-      ('Error detected while processing command line:\r\n' .. 'man.lua: "no manual entry for %s"'):format(
+      ('Error detected while processing command line:\r\n' .. 'man.lua: no manual entry for %s'):format(
         pesc(actual_file)
       ),
       fn.system(args, { '' })
@@ -235,8 +234,8 @@ describe(':Man', function()
 
   it('tries variants with spaces, underscores #22503', function()
     eq({
-      { '', 'NAME WITH SPACES' },
-      { '', 'NAME_WITH_SPACES' },
+      { vim.NIL, 'NAME WITH SPACES' },
+      { vim.NIL, 'NAME_WITH_SPACES' },
     }, get_search_history('NAME WITH SPACES'))
     eq({
       { '3', 'some other man' },
@@ -255,8 +254,8 @@ describe(':Man', function()
       { 'n', 'some_other_man' },
     }, get_search_history('n some other man'))
     eq({
-      { '', '123some other man' },
-      { '', '123some_other_man' },
+      { vim.NIL, '123some other man' },
+      { vim.NIL, '123some_other_man' },
     }, get_search_history('123some other man'))
     eq({
       { '1', 'other_man' },
@@ -265,11 +264,10 @@ describe(':Man', function()
   end)
 
   it('can complete', function()
-    t.skip(t.is_os('mac') and t.is_arch('x86_64'), 'not supported on intel mac')
     eq(
       true,
       exec_lua(function()
-        return #require('man').man_complete('f', 'Man g') > 0
+        return #require('man').man_complete('f', 'Man f') > 0
       end)
     )
   end)


### PR DESCRIPTION
- Replace all uses of vim.regex with simpler Lua patterns.
- Replace all uses of vim.fn.substitute with string.gsub.
- Rework error handling so expected errors are passed back via a return.
  - These get routed up an passed to `vim.notify()`
  - Any other errors will cause a stack trace.
- Reworked the module initialization of `localfile_arg`
- Updated all type annotations.
- Refactored CLI completion by introduction a parse_cmdline()
  function.
- Simplified `show_toc()`
- Refactor highlighting
- Inline some functions
- Fix completion on MacOS 13 and earlier.
  - Prefer `manpath -q` over `man -w`
- Make completion more efficient by avoiding vim.fn.sort and vim.fn.uniq
  - Reimplement using a single loop