### PR TITLE
fix(lsp): vim.lsp.start failed when an existing client has no workspace_folders

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -211,7 +211,7 @@ local function reuse_client_default(client, config)
 
   for _, config_folder in ipairs(config_folders) do
     local found = false
-    for _, client_folder in ipairs(client.workspace_folders) do
+    for _, client_folder in ipairs(client.workspace_folders or {}) do
       if config_folder.uri == client_folder.uri then
         found = true
         break

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1854,6 +1854,20 @@ describe('LSP', function()
         end,
       }
     end)
+
+    it('vim.lsp.start when existing client has no workspace_folders', function()
+      exec_lua(create_server_definition)
+      eq(
+        { 2, 'foo', 'foo' },
+        exec_lua(function()
+          local server = _G._create_server()
+          vim.lsp.start { cmd = server.cmd, name = 'foo' }
+          vim.lsp.start { cmd = server.cmd, name = 'foo', root_dir = 'bar' }
+          local foos = vim.lsp.get_clients()
+          return { #foos, foos[1].name, foos[2].name }
+        end)
+      )
+    end)
   end)
 
   describe('parsing tests', function()
@@ -6119,20 +6133,6 @@ describe('LSP', function()
         })
       )
     end)
-  end)
-
-  it('vim.lsp.start when existing client has no workspace_folders', function()
-    exec_lua(create_server_definition)
-    eq(
-      { 2, 'foo', 'foo' },
-      exec_lua(function()
-        local server = _G._create_server()
-        vim.lsp.start { cmd = server.cmd, name = 'foo' }
-        vim.lsp.start { cmd = server.cmd, name = 'foo', root_dir = 'bar' }
-        local foos = vim.lsp.get_clients()
-        return { #foos, foos[1].name, foos[2].name }
-      end)
-    )
   end)
 
   describe('vim.lsp.config() and vim.lsp.enable()', function()

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -6121,6 +6121,20 @@ describe('LSP', function()
     end)
   end)
 
+  it('vim.lsp.start when existing client has no workspace_folders', function()
+    exec_lua(create_server_definition)
+    eq(
+      { 2, 'foo', 'foo' },
+      exec_lua(function()
+        local server = _G._create_server()
+        vim.lsp.start { cmd = server.cmd, name = 'foo' }
+        vim.lsp.start { cmd = server.cmd, name = 'foo', root_dir = 'bar' }
+        local foos = vim.lsp.get_clients()
+        return { #foos, foos[1].name, foos[2].name }
+      end)
+    )
+  end)
+
   describe('vim.lsp.config() and vim.lsp.enable()', function()
     it('can merge settings from "*"', function()
       eq(


### PR DESCRIPTION
## Problem
Seems a regression of https://github.com/neovim/neovim/pull/31340.

`nvim -l repro.lua`:
```lua
vim.lsp.start { cmd = { 'lua-language-server' }, name = 'lua_ls' }
vim.lsp.start { cmd = { 'lua-language-server' }, name = 'lua_ls', root_dir = 'foo' }

-- swaped case will be ok:
-- vim.lsp.start { cmd = { 'lua-language-server' }, name = 'lua_ls', root_dir = 'foo' }
-- vim.lsp.start { cmd = { 'lua-language-server' }, name = 'lua_ls' }
```

Failed with:
```
E5113: Error while calling lua chunk: /home/phan/b/neovim/runtime/lua/vim/lsp.lua:214: bad argument #1 to 'ipairs' (table expected, got nil)
stack traceback:
        [C]: in function 'ipairs'
        /home/phan/b/neovim/runtime/lua/vim/lsp.lua:214: in function 'reuse_client'
        /home/phan/b/neovim/runtime/lua/vim/lsp.lua:629: in function 'start'
        repro.lua:34: in main chunk
```
