### PR TITLE
feat(terminal)!: include cursor position in TermRequest event data

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1004,22 +1004,32 @@ TermClose			When a |terminal| job ends.
 				    status
 							*TermRequest*
 TermRequest			When a |:terminal| child process emits an OSC,
-				DCS or APC sequence. Sets |v:termrequest|. The
-				|event-data| is the request string.
+				DCS, or APC sequence. Sets |v:termrequest|. The
+				|event-data| is a table with the following
+				fields:
+
+				- sequence: the received sequence
+				- cursor: (1,0)-indexed, buffer-relative
+				  position of the cursor when the sequence was
+				  received
+
 							*TermResponse*
 TermResponse			When Nvim receives an OSC or DCS response from
 				the host terminal. Sets |v:termresponse|. The
-				|event-data| is the response string. May be
-				triggered during another event (file I/O,
-				a shell command, or anything else that takes
-				time). Example: >lua
+				|event-data| is a table with the following fields:
+
+				- sequence: the received sequence
+
+				May be triggered during another event (file
+				I/O, a shell command, or anything else that
+				takes time). Example: >lua
 
 				-- Query the terminal palette for the RGB value of color 1
 				-- (red) using OSC 4
 				vim.api.nvim_create_autocmd('TermResponse', {
 				  once = true,
 				  callback = function(args)
-				    local resp = args.data
+				    local resp = args.data.sequence
 				    local r, g, b = resp:match("\027%]4;1;rgb:(%w+)/(%w+)/(%w+)")
 				  end,
 				})

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -111,6 +111,9 @@ EVENTS
     • `history` argument indicating if the message was added to the history.
     • new message kinds: "bufwrite", "completion", "list_cmd", "lua_print",
       "search_cmd", "shell_out/err/ret", "undo", "verbose", wildlist".
+• |TermRequest| and |TermResponse| |event-data| is now a table. The "sequence"
+  field contains the received sequence. |TermRequest| also contains a "cursor"
+  field indicating the cursor's position when the sequence was received.
 
 HIGHLIGHTS
 
@@ -396,6 +399,8 @@ TERMINAL
   codes" mode is currently supported.
 • The |terminal| emits a |TermRequest| autocommand event when the child process
   emits an APC control sequence.
+• |TermRequest| has a "cursor" field in its |event-data| indicating the
+  cursor position when the sequence was received.
 
 TREESITTER
 

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -144,8 +144,8 @@ directory indicated in the request. >lua
   vim.api.nvim_create_autocmd({ 'TermRequest' }, {
     desc = 'Handles OSC 7 dir change requests',
     callback = function(ev)
-      if string.sub(vim.v.termrequest, 1, 4) == '\x1b]7;' then
-        local dir = string.gsub(vim.v.termrequest, '\x1b]7;file://[^/]*', '')
+      if string.sub(ev.data.sequence, 1, 4) == '\x1b]7;' then
+        local dir = string.gsub(ev.data.sequence, '\x1b]7;file://[^/]*', '')
         if vim.fn.isdirectory(dir) == 0 then
           vim.notify('invalid dir: '..dir)
           return

--- a/runtime/lua/tohtml.lua
+++ b/runtime/lua/tohtml.lua
@@ -205,7 +205,9 @@ local function try_query_terminal_color(color)
     once = true,
     callback = function(args)
       hex = '#'
-        .. table.concat({ args.data:match('\027%]%d+;%d*;?rgb:(%w%w)%w%w/(%w%w)%w%w/(%w%w)%w%w') })
+        .. table.concat({
+          args.data.sequence:match('\027%]%d+;%d*;?rgb:(%w%w)%w%w/(%w%w)%w%w/(%w%w)%w%w'),
+        })
     end,
   })
   if type(color) == 'number' then

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -515,8 +515,8 @@ do
       if channel == 0 then
         return
       end
-      local fg_request = args.data == '\027]10;?'
-      local bg_request = args.data == '\027]11;?'
+      local fg_request = args.data.sequence == '\027]10;?'
+      local bg_request = args.data.sequence == '\027]11;?'
       if fg_request or bg_request then
         -- WARN: This does not return the actual foreground/background color,
         -- but rather returns:
@@ -712,7 +712,7 @@ do
         nested = true,
         desc = "Update the value of 'background' automatically based on the terminal emulator's background color",
         callback = function(args)
-          local resp = args.data ---@type string
+          local resp = args.data.sequence ---@type string
           local r, g, b = parseosc11(resp)
           if r and g and b then
             local rr = parsecolor(r)
@@ -788,7 +788,7 @@ do
           group = group,
           nested = true,
           callback = function(args)
-            local resp = args.data ---@type string
+            local resp = args.data.sequence ---@type string
             local decrqss = resp:match('^\027P1%$r([%d;:]+)m$')
 
             if decrqss then

--- a/runtime/lua/vim/termcap.lua
+++ b/runtime/lua/vim/termcap.lua
@@ -34,7 +34,7 @@ function M.query(caps, cb)
   local id = vim.api.nvim_create_autocmd('TermResponse', {
     nested = true,
     callback = function(args)
-      local resp = args.data ---@type string
+      local resp = args.data.sequence ---@type string
       local k, rest = resp:match('^\027P1%+r(%x+)(.*)$')
       if k and rest then
         local cap = vim.text.hexdecode(k)

--- a/runtime/lua/vim/ui/clipboard/osc52.lua
+++ b/runtime/lua/vim/ui/clipboard/osc52.lua
@@ -25,7 +25,7 @@ function M.paste(reg)
     local contents = nil
     local id = vim.api.nvim_create_autocmd('TermResponse', {
       callback = function(args)
-        local resp = args.data ---@type string
+        local resp = args.data.sequence ---@type string
         local encoded = resp:match('\027%]52;%w?;([A-Za-z0-9+/=]*)')
         if encoded then
           contents = vim.base64.decode(encoded)

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -507,7 +507,11 @@ void nvim_ui_term_event(uint64_t channel_id, String event, Object value, Error *
 
     const String termresponse = value.data.string;
     set_vim_var_string(VV_TERMRESPONSE, termresponse.data, (ptrdiff_t)termresponse.size);
-    apply_autocmds_group(EVENT_TERMRESPONSE, NULL, NULL, false, AUGROUP_ALL, NULL, NULL, &value);
+
+    MAXSIZE_TEMP_DICT(data, 1);
+    PUT_C(data, "sequence", value);
+    apply_autocmds_group(EVENT_TERMRESPONSE, NULL, NULL, false, AUGROUP_ALL, NULL, NULL,
+                         &DICT_OBJ(data));
   }
 }
 

--- a/test/functional/editor/defaults_spec.lua
+++ b/test/functional/editor/defaults_spec.lua
@@ -10,7 +10,7 @@ local Screen = require('test.functional.ui.screen')
 
 describe('default', function()
   describe('autocommands', function()
-    it('nvim_terminal.TermClose closes terminal with default shell on success', function()
+    it('nvim.terminal.TermClose closes terminal with default shell on success', function()
       n.clear()
       n.api.nvim_set_option_value('shell', n.testprg('shell-test'), {})
       n.command('set shellcmdflag=EXIT shellredir= shellpipe= shellquote= shellxquote=')

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -215,7 +215,7 @@ describe('TUI', function()
       _G.termresponse = nil
       vim.api.nvim_create_autocmd('TermResponse', {
         once = true,
-        callback = function(ev) _G.termresponse = ev.data end,
+        callback = function(ev) _G.termresponse = ev.data.sequence end,
       })
     ]])
     feed_data('\027P0$r\027\\')
@@ -2199,7 +2199,7 @@ describe('TUI', function()
       vim.api.nvim_create_autocmd('TermRequest', {
         buffer = buf,
         callback = function(args)
-          local req = args.data
+          local req = args.data.sequence
           if not req then
             return
           end
@@ -3171,12 +3171,12 @@ describe('TUI', function()
     exec_lua([[
       vim.api.nvim_create_autocmd('TermRequest', {
         callback = function(args)
-          local req = args.data
-          local payload = req:match('^\027P%+q([%x;]+)$')
-          if payload then
+          local req = args.data.sequence
+          local sequence = req:match('^\027P%+q([%x;]+)$')
+          if sequence then
             local t = {}
-            for cap in vim.gsplit(payload, ';') do
-              local resp = string.format('\027P1+r%s\027\\', payload)
+            for cap in vim.gsplit(sequence, ';') do
+              local resp = string.format('\027P1+r%s\027\\', sequence)
               vim.api.nvim_chan_send(vim.bo[args.buf].channel, resp)
               t[vim.text.hexdecode(cap)] = true
             end
@@ -3222,7 +3222,7 @@ describe('TUI', function()
     exec_lua([[
       vim.api.nvim_create_autocmd('TermRequest', {
         callback = function(args)
-          local req = args.data
+          local req = args.data.sequence
           vim.g.termrequest = req
           local xtgettcap = req:match('^\027P%+q([%x;]+)$')
           if xtgettcap then
@@ -3274,10 +3274,10 @@ describe('TUI', function()
     exec_lua([[
       vim.api.nvim_create_autocmd('TermRequest', {
         callback = function(args)
-          local req = args.data
-          local payload = req:match('^\027P%+q([%x;]+)$')
-          if payload and vim.text.hexdecode(payload) == 'Ms' then
-            local resp = string.format('\027P1+r%s=%s\027\\', payload, vim.text.hexencode('\027]52;;\027\\'))
+          local req = args.data.sequence
+          local sequence = req:match('^\027P%+q([%x;]+)$')
+          if sequence and vim.text.hexdecode(sequence) == 'Ms' then
+            local resp = string.format('\027P1+r%s=%s\027\\', sequence, vim.text.hexencode('\027]52;;\027\\'))
             vim.api.nvim_chan_send(vim.bo[args.buf].channel, resp)
             return true
           end
@@ -3353,7 +3353,7 @@ describe('TUI bg color', function()
     exec_lua([[
       vim.api.nvim_create_autocmd('TermRequest', {
         callback = function(args)
-          local req = args.data
+          local req = args.data.sequence
           if req == '\027]11;?' then
             vim.g.oscrequest = true
             return true


### PR DESCRIPTION
When a plugin registers a TermRequest handler there is currently no way for the handler to know where the terminal's cursor position was when the sequence was received. This is often useful information, e.g. for OSC 133 sequences which are used to annotate shell prompts.

Modify the event data for the TermRequest autocommand to be a table instead of just a string. The "sequence" field of the table contains the sequence string and the "cursor" field contains the cursor position when the sequence was received.

To maintain consistency between TermRequest and TermResponse (and to future proof the latter), TermResponse's event data is also updated to be a table with a "sequence" field.

BREAKING CHANGE: event data for TermRequest and TermResponse is now a table

---

This enables plugins to do things like add signs to terminal buffers to indicate shell prompts. Demo:

[Screencast from 2024-12-17 10-44-18.webm](https://github.com/user-attachments/assets/120059fc-6d47-4349-8b93-2d019de95e14)
