### PR TITLE
vim-patch:9.1.0940: Wrong cursor shape with "gq" and 'indentexpr' executes :normal

### DIFF
--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -35,6 +35,7 @@
 #include "nvim/strings.h"
 #include "nvim/textformat.h"
 #include "nvim/textobject.h"
+#include "nvim/ui.h"
 #include "nvim/undo.h"
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
@@ -1049,12 +1050,18 @@ void format_lines(linenr_T line_count, bool avoid_fex)
         State = MODE_INSERT;         // for open_line()
         smd_save = p_smd;
         p_smd = false;
+
         insertchar(NUL, INSCHAR_FORMAT
                    + (do_comments ? INSCHAR_DO_COM : 0)
                    + (do_comments && do_comments_list ? INSCHAR_COM_LIST : 0)
                    + (avoid_fex ? INSCHAR_NO_FEX : 0), second_indent);
+
         State = old_State;
         p_smd = smd_save;
+        // Cursor shape may have been updated (e.g. by :normal) in insertchar(),
+        // so it needs to be updated here.
+        ui_cursor_shape();
+
         second_indent = -1;
         // at end of par.: need to set indent of next par.
         need_set_indent = is_end_par;

--- a/test/functional/ui/mode_spec.lua
+++ b/test/functional/ui/mode_spec.lua
@@ -94,6 +94,46 @@ describe('ui mode_change event', function()
     }
   end)
 
+  -- oldtest: Test_indent_norm_with_gq()
+  it('is restored to Normal mode after "gq" indents using :normal #12309', function()
+    screen:try_resize(60, 6)
+    n.exec([[
+      func Indent()
+        exe "normal! \<Ignore>"
+        return 0
+      endfunc
+
+      setlocal indentexpr=Indent()
+      call setline(1, [repeat('a', 80), repeat('b', 80)])
+    ]])
+
+    feed('ggVG')
+    screen:expect {
+      grid = [[
+      {17:aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa}|
+      {17:aaaaaaaaaaaaaaaaaaaa}                                        |
+      ^b{17:bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb}|
+      {17:bbbbbbbbbbbbbbbbbbbb}                                        |
+      {1:~                                                           }|
+      {5:-- VISUAL LINE --}                                           |
+    ]],
+      mode = 'visual',
+    }
+
+    feed('gq')
+    screen:expect {
+      grid = [[
+      aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
+      aaaaaaaaaaaaaaaaaaaa                                        |
+      ^bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb|
+      bbbbbbbbbbbbbbbbbbbb                                        |
+      {1:~                                                           }|
+                                                                  |
+    ]],
+      mode = 'normal',
+    }
+  end)
+
   it('works in insert mode', function()
     feed('i')
     screen:expect {


### PR DESCRIPTION
Fix #12309

#### vim-patch:9.1.0940: Wrong cursor shape with "gq" and 'indentexpr' executes :normal

Problem:  Wrong cursor shape with "gq" and 'indentexpr' executes :normal
Solution: Update cursor and mouse shape after restoring old_State.
          (zeertzjq)

closes: vim/vim#16241

Solution: Update cursor and mouse shape after restoring old_State.

https://github.com/vim/vim/commit/6c3027744e71937b24829135ba072090d7d52bc3