### PR TITLE
docs(api): remove @private from VersionRange:has

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3998,6 +3998,7 @@ vim.version.range({spec})                                *vim.version.range()*
         (`table?`) A table with the following fields:
         • {from} (`vim.Version`)
         • {to}? (`vim.Version`)
+        • {has} (`fun(self: vim.VersionRange, version: string|vim.Version)`)
 
     See also: ~
       • https://github.com/npm/node-semver#ranges

--- a/runtime/lua/vim/version.lua
+++ b/runtime/lua/vim/version.lua
@@ -227,8 +227,7 @@ end
 ---@field to? vim.Version
 local VersionRange = {}
 
---- @private
----
+---@nodoc
 ---@param version string|vim.Version
 function VersionRange:has(version)
   if type(version) == 'string' then


### PR DESCRIPTION
Remove `@private` from the `VersionRange:has` API, as I believe it was marked as such incorrectly. Rationale is that `:h vim.version.range` mentions its use:

```
    `:has()` checks if a version is in the range (inclusive `from`, exclusive
    `to`).

    Example:
        local r = vim.version.range('1.0.0 - 2.0.0')
        print(r:has('1.9.9'))       -- true
        print(r:has('2.0.0'))       -- false
        print(r:has(vim.version())) -- check against current Nvim version
```

And it's not marked with underscore as the other private parts as quoted by the doc:
>Note that underscore-prefixed functions (e.g. "_os_proc_children") are
>internal/private and must not be used by plugins.
