### PR TITLE
fix(messages): better formatting for :highlight with ext_messages

### DIFF
--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -1887,8 +1887,7 @@ bool syn_list_header(const bool did_header, const int outlen, const int id, bool
     if (got_int) {
       return true;
     }
-    msg_outtrans(hl_table[id - 1].sg_name, 0, false);
-    name_col = msg_col;
+    msg_col = name_col = msg_outtrans(hl_table[id - 1].sg_name, 0, false);
     endcol = 15;
   } else if ((ui_has(kUIMessages) || msg_silent) && !force_newline) {
     msg_putchar(' ');

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2129,8 +2129,8 @@ void msg_puts_len(const char *const str, const ptrdiff_t len, int hl_id, bool hi
   // If redirection is on, also write to the redirection file.
   redir_write(str, len);
 
-  // Don't print anything when using ":silent cmd".
-  if (msg_silent != 0) {
+  // Don't print anything when using ":silent cmd" or empty message.
+  if (msg_silent != 0 || *str == NUL) {
     return;
   }
 
@@ -2238,6 +2238,11 @@ static void msg_puts_display(const char *str, int maxlen, int hl_id, int recurse
     size_t len = maxlen < 0 ? strlen(str) : strnlen(str, (size_t)maxlen);
     ga_concat_len(&msg_ext_last_chunk, str, len);
     msg_ext_cur_len += len;
+    // When message ends in newline, reset variables used to format message: msg_advance().
+    if (str[len - 1] == '\n') {
+      msg_ext_cur_len = 0;
+      msg_col = 0;
+    }
     return;
   }
 

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -84,11 +84,6 @@ describe('ui/ext_messages', function()
     }
     feed('<cr><cr>')
     screen:expect {
-      grid = [[
-      line 1                   |
-      line ^2                   |
-      {1:~                        }|*3
-    ]],
       messages = {
         {
           content = { { '\ntest\n[O]k: ', 6, 10 } },
@@ -160,11 +155,6 @@ describe('ui/ext_messages', function()
     -- kind=emsg after :throw
     feed(':throw "foo"<cr>')
     screen:expect {
-      grid = [[
-      l^ine 1                   |
-      line 2                   |
-      {1:~                        }|*3
-    ]],
       messages = {
         {
           content = { { 'Error detected while processing :', 9, 6 } },
@@ -214,27 +204,20 @@ describe('ui/ext_messages', function()
     })
 
     -- highlight
-    feed(':hi ErrorMsg<cr>')
+    feed(':filter character highlight<CR>')
     screen:expect({
-      grid = [[
-        ^line 1                   |
-        line 2                   |
-        {1:~                        }|*3
-      ]],
       messages = {
         {
           content = {
-            { '\nErrorMsg      ' },
-            { 'xxx', 9, 6 },
+            { '\n@character     ' },
+            { 'xxx', 26, 150 },
             { ' ' },
-            { 'ctermfg=', 18, 5 },
-            { '15 ' },
-            { 'ctermbg=', 18, 5 },
-            { '1 ' },
-            { 'guifg=', 18, 5 },
-            { 'White ' },
-            { 'guibg=', 18, 5 },
-            { 'Red' },
+            { 'links to', 18, 5 },
+            { ' Character\n@character.special ' },
+            { 'xxx', 16, 151 },
+            { ' ' },
+            { 'links to', 18, 5 },
+            { ' SpecialChar' },
           },
           kind = 'list_cmd',
         },


### PR DESCRIPTION
Also avoid going down message callstack with empty message, and remove expected grid for some tests where it did not change, and we are just testing for expected messages.

Fix #31624