### PR TITLE
feat(lsp): support function for client root_dir

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -683,6 +683,13 @@ Lua module: vim.lsp                                                 *lsp-core*
                          the LSP server will base its workspaceFolders,
                          rootUri, and rootPath on initialization. Unused if
                          `root_dir` is provided.
+      • {root_dir}?      (`string|fun(cb:fun(string))`) Directory where the
+                         LSP server will base its workspaceFolders, rootUri,
+                         and rootPath on initialization. If a function, it
+                         accepts a single callback argument which must be
+                         called with the value of root_dir to use. The LSP
+                         server will not be started until the callback is
+                         called.
       • {reuse_client}?  (`fun(client: vim.lsp.Client, config: vim.lsp.ClientConfig): boolean`)
                          Predicate used to decide if a client should be
                          re-used. Used on all running clients. The default

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -6245,5 +6245,38 @@ describe('LSP', function()
         end)
       )
     end)
+
+    it('supports a function for root_dir', function()
+      exec_lua(create_server_definition)
+
+      local tmp1 = t.tmpname(true)
+
+      eq(
+        'some_dir',
+        exec_lua(function()
+          local server = _G._create_server({
+            handlers = {
+              initialize = function(_, _, callback)
+                callback(nil, { capabilities = {} })
+              end,
+            },
+          })
+
+          vim.lsp.config('foo', {
+            cmd = server.cmd,
+            filetypes = { 'foo' },
+            root_dir = function(cb)
+              cb('some_dir')
+            end,
+          })
+          vim.lsp.enable('foo')
+
+          vim.cmd.edit(assert(tmp1))
+          vim.bo.filetype = 'foo'
+
+          return vim.lsp.get_clients({ bufnr = vim.api.nvim_get_current_buf() })[1].root_dir
+        end)
+      )
+    end)
   end)
 end)


### PR DESCRIPTION
If root_dir is a function it is evaluated when the client is created to determine the root directory.

This enables dynamically determining the root directory based on e.g. project or directory structure (example: finding a parent Cargo.toml file that contains "[workspace]" in a Rust project).