### PR TITLE
Fixed MAX_TIMEOUT value for 32-bit systems

### DIFF
--- a/runtime/lua/vim/_system.lua
+++ b/runtime/lua/vim/_system.lua
@@ -79,6 +79,7 @@ function SystemObj:_timeout(signal)
   self:kill(signal or SIG.TERM)
 end
 
+-- Use max 32-bit signed int value to avoid overflow on 32-bit systems. #31633
 local MAX_TIMEOUT = 2 ^ 31 - 1
 
 --- @param timeout? integer

--- a/runtime/lua/vim/_system.lua
+++ b/runtime/lua/vim/_system.lua
@@ -79,7 +79,7 @@ function SystemObj:_timeout(signal)
   self:kill(signal or SIG.TERM)
 end
 
-local MAX_TIMEOUT = 2 ^ 31
+local MAX_TIMEOUT = 2 ^ 31 - 1
 
 --- @param timeout? integer
 --- @return vim.SystemCompleted


### PR DESCRIPTION
The maximum signed value on 32-bit systems is 2 ^ 31 - 1. When using 2 ^ 31 for the default timeout, the value would overflow on such systems resulting in a negative value, which caused a stack trace when calling wait() without a timeout. Fixes #31633