### PR TITLE
vim-patch:9.1.0948: Missing cmdline completion for :pbuffer

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -2001,6 +2001,7 @@ static const char *set_context_by_cmdname(const char *cmd, cmdidx_T cmdidx, expa
     FALLTHROUGH;
   case CMD_buffer:
   case CMD_sbuffer:
+  case CMD_pbuffer:
   case CMD_checktime:
     xp->xp_context = EXPAND_BUFFERS;
     xp->xp_pattern = (char *)arg;

--- a/test/old/testdir/test_preview.vim
+++ b/test/old/testdir/test_preview.vim
@@ -47,8 +47,19 @@ func Test_window_preview_from_pbuffer()
   edit Xpreview.c
   const buf_num = bufnr('%')
   enew
+
+  call feedkeys(":pbuffer Xpre\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"pbuffer Xpreview.c", @:)
+
   call assert_equal(1, winnr('$'))
   exe 'pbuffer ' .  buf_num
+  call assert_equal(2, winnr('$'))
+  call assert_equal(0, &previewwindow)
+
+  call s:goto_preview_and_close()
+
+  call assert_equal(1, winnr('$'))
+  pbuffer Xpreview.c
   call assert_equal(2, winnr('$'))
   call assert_equal(0, &previewwindow)
 


### PR DESCRIPTION
#### vim-patch:9.1.0948: Missing cmdline completion for :pbuffer

Problem:  Missing cmdline completion for :pbuffer.
Solution: Add cmdline completion for :pbuffer like :buffer.
          (zeertzjq)

closes: vim/vim#16251

https://github.com/vim/vim/commit/3baf19a2b144b215c5b537c3c1b3b80a79b0fe99