### PR TITLE
fix(coverity): integer handling issues (INTEGER_OVERFLOW)

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2239,6 +2239,7 @@ static void msg_puts_display(const char *str, int maxlen, int hl_id, int recurse
     ga_concat_len(&msg_ext_last_chunk, str, len);
     msg_ext_cur_len += len;
     // When message ends in newline, reset variables used to format message: msg_advance().
+    assert(len > 0);
     if (str[len - 1] == '\n') {
       msg_ext_cur_len = 0;
       msg_col = 0;


### PR DESCRIPTION
```
CID 516419:  Integer handling issues  (INTEGER_OVERFLOW)
/src/nvim/message.c: 2242 in msg_puts_display()
2236         }
2237         // Concat pieces with the same highlight
2238         size_t len = maxlen < 0 ? strlen(str) : strnlen(str, (size_t)maxlen);
2239         ga_concat_len(&msg_ext_last_chunk, str, len);
2240         msg_ext_cur_len += len;
2241         // When message ends in newline, reset variables used to format message: msg_advance().
>>>     CID 516419:  Integer handling issues  (INTEGER_OVERFLOW)
>>>     Expression "len - 1UL", which is equal to 18446744073709551615, where "len" is known to be equal to 0, underflows the type that receives it, an unsigned integer 64 bits wide.
2242         if (str[len - 1] == '\n') {
2243           msg_ext_cur_len = 0;
2244           msg_col = 0;
2245         }
2246         return;
2247       }
```