### PR TITLE
vim-patch:70881ba: runtime(dockerfile): do not set commentstring in syntax script

### DIFF
--- a/runtime/ftplugin/dockerfile.vim
+++ b/runtime/ftplugin/dockerfile.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 " Language:	Dockerfile
 " Maintainer:   Honza Pokorny <http://honza.ca>
-" Last Change:	2014 Aug 29
+" Last Change:	2024 Dec 20
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -11,6 +11,6 @@ endif
 " Don't load another plugin for this buffer
 let b:did_ftplugin = 1
 
-let b:undo_ftplugin = "setl commentstring<"
-
 setlocal commentstring=#\ %s
+
+let b:undo_ftplugin = "setl commentstring<"

--- a/runtime/syntax/dockerfile.vim
+++ b/runtime/syntax/dockerfile.vim
@@ -1,6 +1,6 @@
 " dockerfile.vim - Syntax highlighting for Dockerfiles
 " Maintainer:   Honza Pokorny <https://honza.ca>
-" Last Change:  2024 Jul 03
+" Last Change:  2024 Dec 20
 " License:      BSD
 
 " https://docs.docker.com/engine/reference/builder/
@@ -35,7 +35,6 @@ syntax region dockerfileShell  contained keepend start=/\v/ skip=/\v\\\_./ end=/
 syntax region dockerfileValue  contained keepend start=/\v/ skip=/\v\\\_./ end=/\v$/ contains=dockerfileString
 
 syntax region dockerfileComment start=/\v^\s*#/ end=/\v$/ contains=@Spell
-set commentstring=#\ %s
 
 hi def link dockerfileString String
 hi def link dockerfileKeyword Keyword


### PR DESCRIPTION
Fix #31649

https://github.com/vim/vim/commit/70881ba195d267d01df912294ddc5b5d525bba3d

Co-authored-by: Christian Brabandt <cb@256bit.org>
