### PR TITLE
feat(ui): additional arguments for cmdline_show/hide events

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -86,6 +86,11 @@ EVENTS
 
 • |vim.ui_attach()| callbacks for |ui-messages| `msg_show` events are executed in
   |api-fast| context.
+• Various additions for the following UI events:
+  • `cmdline_show`: `hl_id` to highlight the prompt text.
+  • `cmdline_hide`: `abort` indicating if the cmdline was aborted.
+  • `msg_show`: new message kinds: "bufwrite", "completion", "list_cmd",
+    "lua_print", "number_prompt", "search_cmd", "undo", "wildlist".
 
 HIGHLIGHTS
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -86,11 +86,13 @@ EVENTS
 
 • |vim.ui_attach()| callbacks for |ui-messages| `msg_show` events are executed in
   |api-fast| context.
-• Various additions for the following UI events:
-  • `cmdline_show`: `hl_id` to highlight the prompt text.
-  • `cmdline_hide`: `abort` indicating if the cmdline was aborted.
-  • `msg_show`: new message kinds: "bufwrite", "completion", "list_cmd",
-    "lua_print", "number_prompt", "search_cmd", "undo", "wildlist".
+• New/enhanced arguments in these existing UI events:
+  • `cmdline_show`: `hl_id` argument to highlight the prompt text.
+  • `cmdline_hide`: `abort` argument indicating if the cmdline was aborted.
+  • `msg_show`:
+    • `history` argument indicating if the message was added to the history.
+    • new message kinds: "bufwrite", "completion", "list_cmd",
+      "lua_print", "number_prompt", "search_cmd", "undo", "wildlist".
 
 HIGHLIGHTS
 

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -784,7 +784,7 @@ will be set to zero, but can be changed and used for the replacing cmdline or
 message window. Cmdline state is emitted as |ui-cmdline| events, which the UI
 must handle.
 
-["msg_show", kind, content, replace_last] ~
+["msg_show", kind, content, replace_last, history] ~
 	Display a message to the user.
 
 	kind
@@ -826,6 +826,9 @@ must handle.
 		   that are still visible.
 	    true:  Replace the message in the most-recent `msg_show` call,
 		   but any other visible message should still remain.
+
+	history
+	    True if the message was added to the |:messages| history.
 
 ["msg_clear"] ~
 	Clear all messages currently displayed by "msg_show". (Messages sent

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -715,7 +715,7 @@ Activated by the `ext_cmdline` |ui-option|.
 This UI extension delegates presentation of the |cmdline| (except 'wildmenu').
 For command-line 'wildmenu' UI events, activate |ui-popupmenu|.
 
-["cmdline_show", content, pos, firstc, prompt, indent, level] ~
+["cmdline_show", content, pos, firstc, prompt, indent, level, hl_id] ~
         content: List of [attrs, string]
 	         [[{}, "t"], [attrs, "est"], ...]
 
@@ -728,8 +728,8 @@ For command-line 'wildmenu' UI events, activate |ui-popupmenu|.
 	`firstc` and `prompt` are text, that if non-empty should be
 	displayed in front of the command line. `firstc` always indicates
 	built-in command lines such as `:` (ex command) and `/` `?` (search),
-	while `prompt` is an |input()| prompt. `indent` tells how many spaces
-	the content should be indented.
+	while `prompt` is an |input()| prompt, highlighted with `hl_id`.
+	`indent` tells how many spaces the content should be indented.
 
 	The Nvim command line can be invoked recursively, for instance by
 	typing `<c-r>=` at the command line prompt. The `level` field is used
@@ -749,8 +749,9 @@ For command-line 'wildmenu' UI events, activate |ui-popupmenu|.
 
 	Should be hidden at next cmdline_show.
 
-["cmdline_hide"] ~
-	Hide the cmdline.
+["cmdline_hide", abort] ~
+	Hide the cmdline. `abort` is true if the cmdline is hidden after an
+	aborting condition (|c_Esc| or |c_CTRL-C|).
 
 ["cmdline_block_show", lines] ~
 	Show a block of context to the current command line. For example if

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -136,13 +136,13 @@ void tabline_update(Tabpage current, Array tabs, Buffer current_buffer, Array bu
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 
 void cmdline_show(Array content, Integer pos, String firstc, String prompt, Integer indent,
-                  Integer level)
+                  Integer level, Integer hl_id)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 void cmdline_pos(Integer pos, Integer level)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 void cmdline_special_char(String c, Boolean shift, Integer level)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
-void cmdline_hide(Integer level)
+void cmdline_hide(Integer level, Boolean abort)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 void cmdline_block_show(Array lines)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -158,7 +158,7 @@ void wildmenu_select(Integer selected)
 void wildmenu_hide(void)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 
-void msg_show(String kind, Array content, Boolean replace_last)
+void msg_show(String kind, Array content, Boolean replace_last, Boolean history)
   FUNC_API_SINCE(6) FUNC_API_FAST FUNC_API_REMOTE_ONLY;
 void msg_clear(void)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -956,7 +956,7 @@ theend:
   char *p = ccline.cmdbuff;
 
   if (ui_has(kUICmdline)) {
-    ui_call_cmdline_hide(ccline.level);
+    ui_call_cmdline_hide(ccline.level, s->gotesc);
     msg_ext_clear_later();
   }
   if (!cmd_silent) {
@@ -3422,8 +3422,7 @@ static void ui_ext_cmdline_show(CmdlineInfo *line)
   ui_call_cmdline_show(content, line->cmdpos,
                        cstr_as_string(charbuf),
                        cstr_as_string((line->cmdprompt)),
-                       line->cmdindent,
-                       line->level);
+                       line->cmdindent, line->level, line->hl_id);
   if (line->special_char) {
     charbuf[0] = line->special_char;
     ui_call_cmdline_special_char(cstr_as_string(charbuf),
@@ -4477,7 +4476,7 @@ static int open_cmdwin(void)
   invalidate_botline(curwin);
   if (ui_has(kUICmdline)) {
     ccline.redraw_state = kCmdRedrawNone;
-    ui_call_cmdline_hide(ccline.level);
+    ui_call_cmdline_hide(ccline.level, false);
   }
   redraw_later(curwin, UPD_SOME_VALID);
 

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -153,6 +153,7 @@ static sattr_T msg_ext_last_attr = -1;
 static int msg_ext_last_hl_id;
 static size_t msg_ext_cur_len = 0;
 
+static bool msg_ext_history = false;  ///< message was added to history
 static bool msg_ext_overwrite = false;  ///< will overwrite last message
 static int msg_ext_visible = 0;  ///< number of messages currently visible
 
@@ -988,7 +989,7 @@ static void add_msg_hist(const char *s, int len, int hl_id, bool multiline)
 static void add_msg_hist_multihl(const char *s, int len, int hl_id, bool multiline,
                                  HlMessage multihl)
 {
-  if (msg_hist_off || msg_silent != 0) {
+  if (msg_hist_off || msg_silent != 0 || (s != NULL && *s == NUL)) {
     hl_msg_free(multihl);
     return;
   }
@@ -999,12 +1000,13 @@ static void add_msg_hist_multihl(const char *s, int len, int hl_id, bool multili
     if (len < 0) {
       len = (int)strlen(s);
     }
+    assert(len > 0);
     // remove leading and trailing newlines
-    while (len > 0 && *s == '\n') {
+    while (*s == '\n') {
       s++;
       len--;
     }
-    while (len > 0 && s[len - 1] == '\n') {
+    while (s[len - 1] == '\n') {
       len--;
     }
     p->msg = xmemdupz(s, (size_t)len);
@@ -1024,6 +1026,7 @@ static void add_msg_hist_multihl(const char *s, int len, int hl_id, bool multili
     first_msg_hist = last_msg_hist;
   }
   msg_hist_len++;
+  msg_ext_history = true;
 
   check_msg_hist();
 }
@@ -3159,13 +3162,14 @@ void msg_ext_ui_flush(void)
   msg_ext_emit_chunk();
   if (msg_ext_chunks->size > 0) {
     Array *tofree = msg_ext_init_chunks();
-    ui_call_msg_show(cstr_as_string(msg_ext_kind), *tofree, msg_ext_overwrite);
+    ui_call_msg_show(cstr_as_string(msg_ext_kind), *tofree, msg_ext_overwrite, msg_ext_history);
     api_free_array(*tofree);
     xfree(tofree);
     if (!msg_ext_overwrite) {
       msg_ext_visible++;
     }
     msg_ext_overwrite = false;
+    msg_ext_history = false;
     msg_ext_kind = NULL;
   }
 }

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -265,6 +265,7 @@ describe('vim.ui_attach', function()
       messages = {
         {
           content = { { 'E122: Function Foo already exists, add ! to replace it', 9, 6 } },
+          history = true,
           kind = 'emsg',
         },
       },
@@ -283,6 +284,7 @@ describe('vim.ui_attach', function()
       messages = {
         {
           content = { { 'replace with Replacement (y/n/a/q/l/^E/^Y)?', 6, 18 } },
+          history = true,
           kind = 'confirm_sub',
         },
       },
@@ -300,10 +302,12 @@ describe('vim.ui_attach', function()
       messages = {
         {
           content = { { 'Select:\nOne\nTwo\n' } },
+          history = false,
           kind = 'list_cmd',
         },
         {
           content = { { 'Type number and <Enter> or click with the mouse (q or empty cancels): ' } },
+          history = false,
           kind = 'number_prompt',
         },
       },
@@ -382,6 +386,7 @@ describe('vim.ui_attach', function()
               6,
             },
           },
+          history = true,
           kind = 'lua_error',
         },
         {
@@ -392,10 +397,12 @@ describe('vim.ui_attach', function()
               6,
             },
           },
+          history = true,
           kind = 'lua_error',
         },
         {
           content = { { 'Press ENTER or type command to continue', 100, 18 } },
+          history = false,
           kind = 'return_prompt',
         },
       },

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -261,6 +261,7 @@ describe('vim.ui_attach', function()
         lled in a fast event context            |
         {1:~                                       }|
       ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = { { 'E122: Function Foo already exists, add ! to replace it', 9, 6 } },
@@ -278,6 +279,7 @@ describe('vim.ui_attach', function()
         Y)?                                     |
         {1:~                                       }|
       ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = { { 'replace with Replacement (y/n/a/q/l/^E/^Y)?', 6, 18 } },
@@ -294,6 +296,7 @@ describe('vim.ui_attach', function()
         e mouse (q or empty cancels):           |
         {1:^~                                       }|
       ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = { { 'Select:\nOne\nTwo\n' } },
@@ -359,6 +362,7 @@ describe('vim.ui_attach', function()
         {9:back from ns: 1.}                        |
         {100:Press ENTER or type command to continue}^ |
       ]],
+      cmdline = { { abort = false } },
     })
     feed('<cr>')
     -- Also when scheduled

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -91,25 +91,27 @@ local function test_cmdline(linegrid)
       {1:~                        }|*3
                                |
     ]],
+      cmdline = { { abort = true } },
     }
   end)
 
   it('works with input()', function()
     feed(':call input("input", "default")<cr>')
-    screen:expect {
+    screen:expect({
       grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+        ^                         |
+        {1:~                        }|*3
+                                 |
+      ]],
       cmdline = {
         {
-          prompt = 'input',
           content = { { 'default' } },
+          hl_id = 0,
           pos = 7,
+          prompt = 'input',
         },
       },
-    }
+    })
 
     feed('<cr>')
     screen:expect {
@@ -118,6 +120,7 @@ local function test_cmdline(linegrid)
       {1:~                        }|*3
                                |
     ]],
+      cmdline = { { abort = false } },
     }
   end)
 
@@ -210,6 +213,7 @@ local function test_cmdline(linegrid)
           content = { { 'xx3' } },
           pos = 3,
         },
+        { abort = false },
       },
     }
 
@@ -220,6 +224,7 @@ local function test_cmdline(linegrid)
       {1:~                        }|*3
                                |
     ]],
+      cmdline = { { abort = true } },
     }
   end)
 
@@ -294,6 +299,7 @@ local function test_cmdline(linegrid)
       {1:~                        }|*3
                                |
     ]],
+      cmdline = { { abort = false } },
     }
 
     -- Try once more, to check buffer is reinitialized. #8007
@@ -324,6 +330,7 @@ local function test_cmdline(linegrid)
       {1:~                        }|*3
                                |
     ]],
+      cmdline = { { abort = false } },
     }
   end)
 
@@ -353,6 +360,7 @@ local function test_cmdline(linegrid)
       {3:[Command Line]           }|
                                |
     ]],
+      cmdline = { { abort = false } },
     }
 
     -- nested cmdline
@@ -404,6 +412,7 @@ local function test_cmdline(linegrid)
       {3:[Command Line]           }|
                                |
     ]],
+      cmdline = { [2] = { abort = true } },
     }
 
     feed('<c-c>')
@@ -452,6 +461,7 @@ local function test_cmdline(linegrid)
       cmdline = {
         {
           prompt = 'secret:',
+          hl_id = 0,
           content = { { '******' } },
           pos = 6,
         },
@@ -495,6 +505,7 @@ local function test_cmdline(linegrid)
       cmdline = {
         {
           prompt = '>',
+          hl_id = 0,
           content = {
             { '(', 30 },
             { 'a' },
@@ -797,11 +808,14 @@ local function test_cmdline(linegrid)
     -- This used to send an invalid event where pos where larger than the total
     -- length of content. Checked in _handle_cmdline_show.
     feed('<esc>')
-    screen:expect([[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]])
+    screen:expect({
+      grid = [[
+        ^                         |
+        {1:~                        }|*3
+                                 |
+      ]],
+      cmdline = { { abort = true } },
+    })
   end)
 
   it('does not move cursor to curwin #20309', function()
@@ -826,6 +840,30 @@ local function test_cmdline(linegrid)
         pos = 0,
       } },
     }
+  end)
+
+  it('show prompt hl_id', function()
+    screen:expect([[
+      ^                         |
+      {1:~                        }|*3
+                               |
+    ]])
+    feed(':echohl Error | call input("Prompt:")<CR>')
+    screen:expect({
+      grid = [[
+        ^                         |
+        {1:~                        }|*3
+                                 |
+      ]],
+      cmdline = {
+        {
+          content = { { '' } },
+          hl_id = 237,
+          pos = 0,
+          prompt = 'Prompt:',
+        },
+      },
+    })
   end)
 end
 

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -51,6 +51,7 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { '\ntest\n[O]k: ', 6, 10 } },
+          history = false,
           kind = 'confirm',
         },
       },
@@ -80,6 +81,7 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { '\ntest\n[O]k: ', 6, 10 } },
+          history = false,
           kind = 'confirm',
         },
       },
@@ -89,14 +91,17 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { '\ntest\n[O]k: ', 6, 10 } },
+          history = false,
           kind = 'confirm',
         },
         {
           content = { { '1' } },
+          history = false,
           kind = 'echo',
         },
         {
           content = { { 'Press ENTER or type command to continue', 6, 18 } },
+          history = false,
           kind = 'return_prompt',
         },
       },
@@ -115,6 +120,7 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { 'replace with X (y/n/a/q/l/^E/^Y)?', 6, 18 } },
+          history = true,
           kind = 'confirm_sub',
         },
       },
@@ -134,6 +140,7 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { 'W10: Warning: Changing a readonly file', 19, 26 } },
+          history = true,
           kind = 'wmsg',
         },
       },
@@ -151,6 +158,7 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { 'search hit BOTTOM, continuing at TOP', 19, 26 } },
+          history = true,
           kind = 'wmsg',
         },
       },
@@ -163,14 +171,17 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { 'Error detected while processing :', 9, 6 } },
+          history = true,
           kind = 'emsg',
         },
         {
           content = { { 'E605: Exception not caught: foo', 9, 6 } },
+          history = true,
           kind = 'emsg',
         },
         {
           content = { { 'Press ENTER or type command to continue', 6, 18 } },
+          history = false,
           kind = 'return_prompt',
         },
       },
@@ -190,6 +201,7 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { '(2 of 2): line2' } },
+          history = true,
           kind = 'quickfix',
         },
       },
@@ -204,10 +216,13 @@ describe('ui/ext_messages', function()
         {1:~                        }|*3
       ]],
       cmdline = { { abort = false } },
-      messages = { {
-        content = { { '?line ' } },
-        kind = 'search_cmd',
-      } },
+      messages = {
+        {
+          content = { { '?line ' } },
+          history = false,
+          kind = 'search_cmd',
+        },
+      },
     })
 
     -- highlight
@@ -227,6 +242,7 @@ describe('ui/ext_messages', function()
             { 'links to', 18, 5 },
             { ' SpecialChar' },
           },
+          history = false,
           kind = 'list_cmd',
         },
       },
@@ -242,6 +258,7 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { 'Already at oldest change' } },
+          history = true,
           kind = 'undo',
         },
       },
@@ -257,6 +274,7 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { 'Already at newest change' } },
+          history = true,
           kind = 'undo',
         },
       },
@@ -269,6 +287,7 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { 'The only match' } },
+          history = false,
           kind = 'completion',
         },
       },
@@ -285,10 +304,13 @@ describe('ui/ext_messages', function()
       {1:~                        }|*4
     ]],
       cmdline = { { abort = false } },
-      messages = { {
-        content = { { 'raa', 9, 6 } },
-        kind = 'echoerr',
-      } },
+      messages = {
+        {
+          content = { { 'raa', 9, 6 } },
+          history = true,
+          kind = 'echoerr',
+        },
+      },
     }
 
     -- cmdline in a later input cycle clears error message
@@ -315,14 +337,17 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { 'bork', 9, 6 } },
+          history = true,
           kind = 'echoerr',
         },
         {
           content = { { 'fail', 9, 6 } },
+          history = true,
           kind = 'echoerr',
         },
         {
           content = { { 'Press ENTER or type command to continue', 6, 18 } },
+          history = false,
           kind = 'return_prompt',
         },
       },
@@ -338,18 +363,22 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { 'bork', 9, 6 } },
+          history = true,
           kind = 'echoerr',
         },
         {
           content = { { 'fail', 9, 6 } },
+          history = true,
           kind = 'echoerr',
         },
         {
           content = { { 'extrafail', 9, 6 } },
+          history = true,
           kind = 'echoerr',
         },
         {
           content = { { 'Press ENTER or type command to continue', 6, 18 } },
+          history = false,
           kind = 'return_prompt',
         },
       },
@@ -370,10 +399,13 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
-      messages = { {
-        content = { { 'problem', 9, 6 } },
-        kind = 'echoerr',
-      } },
+      messages = {
+        {
+          content = { { 'problem', 9, 6 } },
+          history = true,
+          kind = 'echoerr',
+        },
+      },
       cmdline = {
         {
           prompt = 'foo> ',
@@ -411,6 +443,7 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { 'Press ENTER or type command to continue', 6, 18 } },
+          history = false,
           kind = 'return_prompt',
         },
       },
@@ -437,6 +470,7 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { 'bork\nfail', 9, 6 } },
+          history = true,
           kind = 'echoerr',
         },
       },
@@ -452,6 +486,7 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { 'Press ENTER or type command to continue', 6, 18 } },
+          history = false,
           kind = 'return_prompt',
         },
       },
@@ -477,7 +512,7 @@ describe('ui/ext_messages', function()
     ]],
       cmdline = { { abort = false } },
       messages = {
-        { content = { { '/line      W [1/2]' } }, kind = 'search_count' },
+        { content = { { '/line      W [1/2]' } }, kind = 'search_count', history = false },
       },
     }
 
@@ -489,7 +524,7 @@ describe('ui/ext_messages', function()
       {1:~                        }|*3
     ]],
       messages = {
-        { content = { { '/line        [2/2]' } }, kind = 'search_count' },
+        { content = { { '/line        [2/2]' } }, kind = 'search_count', history = false },
       },
     }
   end)
@@ -504,10 +539,11 @@ describe('ui/ext_messages', function()
     ]],
       cmdline = { { abort = false } },
       messages = {
-        { content = { { 'x                     #1' } }, kind = 'list_cmd' },
-        { content = { { 'y                     #2' } }, kind = 'list_cmd' },
+        { content = { { 'x                     #1' } }, kind = 'list_cmd', history = false },
+        { content = { { 'y                     #2' } }, kind = 'list_cmd', history = false },
         {
           content = { { 'Press ENTER or type command to continue', 6, 18 } },
+          history = false,
           kind = 'return_prompt',
         },
       },
@@ -578,10 +614,13 @@ describe('ui/ext_messages', function()
         items = { { 'alphpabet', '', '', '' }, { 'alphanum', '', '', '' } },
         pos = 1,
       },
-      messages = { {
-        content = { { 'stuff' } },
-        kind = 'echomsg',
-      } },
+      messages = {
+        {
+          content = { { 'stuff' } },
+          history = true,
+          kind = 'echomsg',
+        },
+      },
       showmode = { { '-- Keyword Local completion (^N^P) ', 5, 11 }, { 'match 1 of 2', 6, 18 } },
     }
 
@@ -598,10 +637,13 @@ describe('ui/ext_messages', function()
         items = { { 'alphpabet', '', '', '' }, { 'alphanum', '', '', '' } },
         pos = 0,
       },
-      messages = { {
-        content = { { 'stuff' } },
-        kind = 'echomsg',
-      } },
+      messages = {
+        {
+          content = { { 'stuff' } },
+          history = true,
+          kind = 'echomsg',
+        },
+      },
       showmode = { { '-- Keyword Local completion (^N^P) ', 5, 11 }, { 'match 2 of 2', 6, 18 } },
     }
 
@@ -621,6 +663,7 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { 'Press ENTER or type command to continue', 6, 18 } },
+          history = false,
           kind = 'return_prompt',
         },
       },
@@ -813,10 +856,13 @@ describe('ui/ext_messages', function()
       {1:~                        }|*4
     ]],
       cmdline = { { abort = false } },
-      messages = { {
-        content = { { 'howdy' } },
-        kind = 'echomsg',
-      } },
+      messages = {
+        {
+          content = { { 'howdy' } },
+          history = true,
+          kind = 'echomsg',
+        },
+      },
     }
 
     -- always test a message without kind. If this one gets promoted to a
@@ -830,6 +876,7 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { 'Type  :qa  and press <Enter> to exit Nvim' } },
+          history = true,
           kind = '',
         },
       },
@@ -842,10 +889,13 @@ describe('ui/ext_messages', function()
       {1:~                        }|*4
     ]],
       cmdline = { { abort = false } },
-      messages = { {
-        content = { { 'bork', 9, 6 } },
-        kind = 'echoerr',
-      } },
+      messages = {
+        {
+          content = { { 'bork', 9, 6 } },
+          history = true,
+          kind = 'echoerr',
+        },
+      },
     }
 
     feed(':echo "xyz"<cr>')
@@ -855,10 +905,13 @@ describe('ui/ext_messages', function()
       {1:~                        }|*4
     ]],
       cmdline = { { abort = false } },
-      messages = { {
-        content = { { 'xyz' } },
-        kind = 'echo',
-      } },
+      messages = {
+        {
+          content = { { 'xyz' } },
+          history = false,
+          kind = 'echo',
+        },
+      },
     }
 
     feed(':call nosuchfunction()<cr>')
@@ -871,6 +924,7 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { 'E117: Unknown function: nosuchfunction', 9, 6 } },
+          history = true,
           kind = 'emsg',
         },
       },
@@ -892,6 +946,7 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { 'Press ENTER or type command to continue', 6, 18 } },
+          history = false,
           kind = 'return_prompt',
         },
       },
@@ -948,7 +1003,7 @@ describe('ui/ext_messages', function()
         {1:~                        }|*4
       ]],
       cmdline = { {
-        abort = false
+        abort = false,
       } },
     })
     eq(0, eval('&cmdheight'))
@@ -976,6 +1031,7 @@ stack traceback:
               6,
             },
           },
+          history = true,
           kind = 'lua_error',
         },
       },
@@ -996,6 +1052,7 @@ stack traceback:
           content = {
             { "Error invoking 'test_method' on channel 1:\ncomplete\nerror\n\nmessage", 9, 6 },
           },
+          history = true,
           kind = 'rpc_error',
         },
       },
@@ -1023,6 +1080,7 @@ stack traceback:
             { '*', 18, 1 },
             { ' k' },
           },
+          history = false,
           kind = 'list_cmd',
         },
       },
@@ -1043,6 +1101,7 @@ stack traceback:
       messages = {
         {
           content = { { 'wildmenu  wildmode' } },
+          history = false,
           kind = 'wildlist',
         },
       },
@@ -1070,10 +1129,12 @@ stack traceback:
       messages = {
         {
           content = { { 'Change "helllo" to:\n 1 "Hello"\n 2 "Hallo"\n 3 "Hullo"\n' } },
+          history = false,
           kind = 'list_cmd',
         },
         {
           content = { { 'Type number and <Enter> or click with the mouse (q or empty cancels): ' } },
+          history = false,
           kind = 'number_prompt',
         },
       },
@@ -1089,14 +1150,17 @@ stack traceback:
       messages = {
         {
           content = { { 'Change "helllo" to:\n 1 "Hello"\n 2 "Hallo"\n 3 "Hullo"\n' } },
+          history = false,
           kind = 'list_cmd',
         },
         {
           content = { { 'Type number and <Enter> or click with the mouse (q or empty cancels): ' } },
+          history = false,
           kind = 'number_prompt',
         },
         {
           content = { { '1' } },
+          history = false,
           kind = '',
         },
       },
@@ -1125,6 +1189,7 @@ stack traceback:
       messages = {
         {
           content = { { 'wow, ', 10, 8 }, { 'such\n\nvery ', 9, 6 }, { 'color', 8, 12 } },
+          history = true,
           kind = 'echomsg',
         },
       },
@@ -1138,7 +1203,11 @@ stack traceback:
     ]],
       cmdline = { { abort = false } },
       messages = {
-        { content = { { '\n  1 %a   "[No Name]"                    line 1' } }, kind = 'list_cmd' },
+        {
+          content = { { '\n  1 %a   "[No Name]"                    line 1' } },
+          kind = 'list_cmd',
+          history = false,
+        },
       },
     }
 
@@ -1152,6 +1221,7 @@ stack traceback:
       messages = {
         {
           content = { { 'Press ENTER or type command to continue', 6, 18 } },
+          history = false,
           kind = 'return_prompt',
         },
       },
@@ -1176,7 +1246,11 @@ stack traceback:
     command('write ' .. fname)
     screen:expect({
       messages = {
-        { content = { { string.format('"%s" [New] 0L, 0B written', fname) } }, kind = 'bufwrite' },
+        {
+          content = { { string.format('"%s" [New] 0L, 0B written', fname) } },
+          kind = 'bufwrite',
+          history = true,
+        },
       },
     })
   end)
@@ -1203,6 +1277,7 @@ stack traceback:
       messages = {
         {
           content = { { 'foo\nbar\nbaz' } },
+          history = true,
           kind = 'lua_print',
         },
       },
@@ -1216,6 +1291,7 @@ stack traceback:
       messages = {
         {
           content = { { '{\n  foo = "bar"\n}' } },
+          history = true,
           kind = 'lua_print',
         },
       },
@@ -1894,6 +1970,7 @@ describe('ui/ext_messages', function()
       messages = {
         {
           content = { { 'Press ENTER or type command to continue', 6, 18 } },
+          history = false,
           kind = 'return_prompt',
         },
       },
@@ -1975,7 +2052,7 @@ describe('ui/ext_messages', function()
     ]],
       cmdline = { { abort = false } },
       messages = {
-        { content = { { '  cmdheight=0' } }, kind = 'list_cmd' },
+        { content = { { '  cmdheight=0' } }, kind = 'list_cmd', history = false },
       },
     })
 
@@ -1992,7 +2069,7 @@ describe('ui/ext_messages', function()
     ]],
       cmdline = { { abort = false } },
       messages = {
-        { content = { { '  laststatus=3' } }, kind = 'list_cmd' },
+        { content = { { '  laststatus=3' } }, kind = 'list_cmd', history = false },
       },
     })
 
@@ -2013,7 +2090,7 @@ describe('ui/ext_messages', function()
     ]],
       cmdline = { { abort = false } },
       messages = {
-        { content = { { '  cmdheight=0' } }, kind = 'list_cmd' },
+        { content = { { '  cmdheight=0' } }, kind = 'list_cmd', history = false },
       },
     })
   end)

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -47,6 +47,7 @@ describe('ui/ext_messages', function()
       line ^1                   |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = { { '\ntest\n[O]k: ', 6, 10 } },
@@ -75,6 +76,7 @@ describe('ui/ext_messages', function()
       line ^2                   |
       {1:~                        }|*3
     ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = { { '\ntest\n[O]k: ', 6, 10 } },
@@ -109,6 +111,7 @@ describe('ui/ext_messages', function()
       l{10:i}ne ^2                   |
       {1:~                        }|*3
     ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = { { 'replace with X (y/n/a/q/l/^E/^Y)?', 6, 18 } },
@@ -144,6 +147,7 @@ describe('ui/ext_messages', function()
       line 2                   |
       {1:~                        }|*3
     ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = { { 'search hit BOTTOM, continuing at TOP', 19, 26 } },
@@ -155,6 +159,7 @@ describe('ui/ext_messages', function()
     -- kind=emsg after :throw
     feed(':throw "foo"<cr>')
     screen:expect {
+      cmdline = { { abort = false } },
       messages = {
         {
           content = { { 'Error detected while processing :', 9, 6 } },
@@ -181,6 +186,7 @@ describe('ui/ext_messages', function()
       ^line 2                   |
       {1:~                        }|*3
     ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = { { '(2 of 2): line2' } },
@@ -197,6 +203,7 @@ describe('ui/ext_messages', function()
         line 2                   |
         {1:~                        }|*3
       ]],
+      cmdline = { { abort = false } },
       messages = { {
         content = { { '?line ' } },
         kind = 'search_cmd',
@@ -206,6 +213,7 @@ describe('ui/ext_messages', function()
     -- highlight
     feed(':filter character highlight<CR>')
     screen:expect({
+      cmdline = { { abort = false } },
       messages = {
         {
           content = {
@@ -276,6 +284,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
       messages = { {
         content = { { 'raa', 9, 6 } },
         kind = 'echoerr',
@@ -302,6 +311,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = { { 'bork', 9, 6 } },
@@ -324,6 +334,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = { { 'bork', 9, 6 } },
@@ -366,6 +377,7 @@ describe('ui/ext_messages', function()
       cmdline = {
         {
           prompt = 'foo> ',
+          hl_id = 0,
           content = { { '' } },
           pos = 0,
         },
@@ -378,6 +390,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
     }
     eq('solution', eval('x'))
 
@@ -387,6 +400,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
       msg_history = {
         { kind = 'echoerr', content = { { 'raa', 9, 6 } } },
         { kind = 'echoerr', content = { { 'bork', 9, 6 } } },
@@ -419,6 +433,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = { { 'bork\nfail', 9, 6 } },
@@ -433,6 +448,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = { { 'Press ENTER or type command to continue', 6, 18 } },
@@ -459,6 +475,7 @@ describe('ui/ext_messages', function()
       {10:line} 2                   |
       {1:~                        }|*3
     ]],
+      cmdline = { { abort = false } },
       messages = {
         { content = { { '/line      W [1/2]' } }, kind = 'search_count' },
       },
@@ -485,6 +502,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
       messages = {
         { content = { { 'x                     #1' } }, kind = 'list_cmd' },
         { content = { { 'y                     #2' } }, kind = 'list_cmd' },
@@ -595,6 +613,7 @@ describe('ui/ext_messages', function()
       alphpabe^t                |
       {1:~                        }|*2
     ]],
+      cmdline = { { abort = false } },
       msg_history = { {
         content = { { 'stuff' } },
         kind = 'echomsg',
@@ -793,6 +812,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
       messages = { {
         content = { { 'howdy' } },
         kind = 'echomsg',
@@ -821,6 +841,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
       messages = { {
         content = { { 'bork', 9, 6 } },
         kind = 'echoerr',
@@ -833,6 +854,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
       messages = { {
         content = { { 'xyz' } },
         kind = 'echo',
@@ -845,6 +867,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = { { 'E117: Unknown function: nosuchfunction', 9, 6 } },
@@ -859,6 +882,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
       msg_history = {
         { kind = 'echomsg', content = { { 'howdy' } } },
         { kind = '', content = { { 'Type  :qa  and press <Enter> to exit Nvim' } } },
@@ -892,11 +916,14 @@ describe('ui/ext_messages', function()
     }
 
     feed('<cr>')
-    screen:expect([[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]])
+    screen:expect({
+      grid = [[
+        ^                         |
+        {1:~                        }|*3
+                                 |
+      ]],
+      cmdline = { { abort = false } },
+    })
     eq(1, eval('&cmdheight'))
 
     feed(':set cmdheight=0')
@@ -915,10 +942,15 @@ describe('ui/ext_messages', function()
       },
     }
     feed('<cr>')
-    screen:expect([[
-      ^                         |
-      {1:~                        }|*4
-    ]])
+    screen:expect({
+      grid = [[
+        ^                         |
+        {1:~                        }|*4
+      ]],
+      cmdline = { {
+        abort = false
+      } },
+    })
     eq(0, eval('&cmdheight'))
   end)
 
@@ -929,6 +961,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = {
@@ -957,6 +990,7 @@ stack traceback:
       ^                         |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = {
@@ -981,6 +1015,7 @@ stack traceback:
     feed(':map<cr>')
 
     screen:expect {
+      cmdline = { { abort = false } },
       messages = {
         {
           content = {
@@ -1101,6 +1136,7 @@ stack traceback:
       ^                         |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
       messages = {
         { content = { { '\n  1 %a   "[No Name]"                    line 1' } }, kind = 'list_cmd' },
       },
@@ -1112,6 +1148,7 @@ stack traceback:
       ^                         |
       {1:~                        }|*4
     ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = { { 'Press ENTER or type command to continue', 6, 18 } },
@@ -1853,6 +1890,7 @@ describe('ui/ext_messages', function()
                        type  :help iccf{18:<Enter>}       for information                  |
                                                                                       |*5
     ]],
+      cmdline = { { abort = false } },
       messages = {
         {
           content = { { 'Press ENTER or type command to continue', 6, 18 } },
@@ -1935,6 +1973,7 @@ describe('ui/ext_messages', function()
       {1:~                                                                               }|*10
       {3:[No Name]                                                                       }|
     ]],
+      cmdline = { { abort = false } },
       messages = {
         { content = { { '  cmdheight=0' } }, kind = 'list_cmd' },
       },
@@ -1951,6 +1990,7 @@ describe('ui/ext_messages', function()
       {1:~                                                                               }|*9
       {3:[No Name]                                                                       }|
     ]],
+      cmdline = { { abort = false } },
       messages = {
         { content = { { '  laststatus=3' } }, kind = 'list_cmd' },
       },
@@ -1971,6 +2011,7 @@ describe('ui/ext_messages', function()
       {1:~                                                                               }|*10
       {3:[No Name]                                                                       }|
     ]],
+      cmdline = { { abort = false } },
       messages = {
         { content = { { '  cmdheight=0' } }, kind = 'list_cmd' },
       },

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1369,12 +1369,12 @@ function Screen:_handle_wildmenu_hide()
   self.wildmenu_items, self.wildmenu_pos = nil, nil
 end
 
-function Screen:_handle_msg_show(kind, chunks, replace_last)
+function Screen:_handle_msg_show(kind, chunks, replace_last, history)
   local pos = #self.messages
   if not replace_last or pos == 0 then
     pos = pos + 1
   end
-  self.messages[pos] = { kind = kind, content = chunks }
+  self.messages[pos] = { kind = kind, content = chunks, history = history }
 end
 
 function Screen:_handle_msg_clear()
@@ -1490,7 +1490,11 @@ function Screen:_extstate_repr(attr_state)
 
   local messages = {}
   for i, entry in ipairs(self.messages) do
-    messages[i] = { kind = entry.kind, content = self:_chunks_repr(entry.content, attr_state) }
+    messages[i] = {
+      kind = entry.kind,
+      content = self:_chunks_repr(entry.content, attr_state),
+      history = entry.history,
+    }
   end
 
   local msg_history = {}


### PR DESCRIPTION
**feat(ui): additional arguments for cmdline_show/hide events**

Problem:  Unable to tell what highlight the prompt part of a
          cmdline_show event should have, and whether cmdline_hide was
          emitted after aborting.
Solution: Add additional arguments hl_id to cmdline_show, and abort to
          cmdline_hide.

**feat(ui): specify whether msg_show event is added to history**

Pass along whether message in msg_show event is added to the internal
:messages history.

Fix #31643.