### PR TITLE
feat(lsp): return table from lsp/ files on runtimepath

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -74,12 +74,8 @@ configurations, in increasing priority, from the following:
 
 1. Configuration defined for the `'*'` name.
 
-2. Configuration from the result of sourcing all `lsp/<name>.lua` files
-   in 'runtimepath' for a server of name `name`.
-
-   Note: because of this, calls to |vim.lsp.config()| in `lsp/*.lua` are
-   treated independently to other calls. This ensures configurations
-   defined in `lsp/*.lua` have a lower priority.
+2. Configuration from the result of merging all tables returned by
+   `lsp/<name>.lua` files in 'runtimepath' for a server of name `name`.
 
 3. Configurations defined anywhere else.
 
@@ -102,11 +98,11 @@ Given: >lua
   })
 
   -- Defined in ../lsp/clangd.lua
-  vim.lsp.config('clangd', {
+  return {
     cmd = { 'clangd' },
     root_markers = { '.clangd', 'compile_commands.json' },
     filetypes = { 'c', 'cpp' },
-  })
+  }
 
   -- Defined in init.lua
   vim.lsp.config('clangd', {

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -22,6 +22,12 @@ EXPERIMENTS
 
 • Removed `vim.loader.disable()`. Use `vim.loader.enable(false)` instead.
 
+LSP
+
+• `lsp/` runtimepath files should return a table instead of calling
+  |vim.lsp.config()| (or assigning to `vim.lsp.config`). See |lsp-config|
+
+
 OPTIONS
 
 • 'jumpoptions' flag "unload" has been renamed to "clean".


### PR DESCRIPTION
Problem: LSP configs on the runtimepath must have the same name as the LSP server and must also explicitly set the name in vim.lsp.config. This is redundant and creates a footgun where a user may accidentally use the wrong name when assigning to the vim.lsp.config table.

Solution: Return a table from lsp/ runtimepath files instead

---

Example for `lsp/lua-language-server.lua`:

**Before**

```lua
-- Footgun: the key to vim.lsp.config _must_ be the same as the filename or else it's an error
vim.lsp.config["lua-language-server"] = {
  ...
}
```

**After**

```lua
-- LSP name isn't repeated, inferred from the filename
return {
  ...
}
```