### PR TITLE
fix(win): prevent floating window creation during cleanup

### DIFF
--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -46,6 +46,9 @@
 /// @param config  must already have been validated!
 win_T *win_new_float(win_T *wp, bool last, WinConfig fconfig, Error *err)
 {
+  if (check_split_disallowed_err(curwin, err)) {
+    return NULL;
+  }
   if (wp == NULL) {
     tabpage_T *tp = NULL;
     win_T *tp_last = last ? lastwin : lastwin_nofloating();


### PR DESCRIPTION
When closing a tab page, creating a floating window during the cleanup process (via WinLeave autocmd) would cause a segmentation fault. This happened because the frame cleanup was already in progress when the floating window creation was attempted.

The fix extends the existing split_disallowed mechanism to floating windows by adding a check in win_new_float(). This ensures that floating windows cannot be created during cleanup, preventing the segfault.

Example that previously caused a segfault but now shows a proper error:
```lua
vim.api.nvim_create_autocmd('WinLeave', {
  callback = function()
    vim.api.nvim_open_win(0, false, {
      relative = 'editor',
      row = 3, col = 3,
      width = 12, height = 3
    })
  end
})
```

Now instead of segfaulting, it shows a proper error message:
```
Error detected while processing WinLeave Autocommands for "*":
Error executing lua callback: Failed to create window
stack traceback:
        [C]: in function 'nvim_open_win'
```

Fixes #522