### PR TITLE
test: format C test files and fix clang-tidy warnings

### DIFF
--- a/test/functional/fixtures/printargs-test.c
+++ b/test/functional/fixtures/printargs-test.c
@@ -2,7 +2,7 @@
 
 int main(int argc, char **argv)
 {
-  for (int i=1; i<argc; i++) {
+  for (int i = 1; i < argc; i++) {
     printf("arg%d=%s;", i, argv[i]);
   }
   return 0;

--- a/test/functional/fixtures/shell-test.c
+++ b/test/functional/fixtures/shell-test.c
@@ -1,11 +1,12 @@
+#include <stdbool.h>
+#include <stdint.h>
 #include <stdio.h>
 #include <string.h>
-#include <stdint.h>
 #ifdef _MSC_VER
-#include <Windows.h>
-#define usleep(usecs) Sleep(usecs/1000)
+# include <Windows.h>
+# define usleep(usecs) Sleep(usecs/1000)
 #else
-#include <unistd.h>
+# include <unistd.h>
 #endif
 
 static void flush_wait(void)
@@ -56,7 +57,7 @@ int main(int argc, char **argv)
   if (argc >= 2) {
     if (strcmp(argv[1], "-t") == 0) {
       if (argc < 3) {
-        fprintf(stderr,"Missing prompt text for -t option\n");
+        fprintf(stderr, "Missing prompt text for -t option\n");
         return 5;
       } else {
         fprintf(stderr, "%s $ ", argv[2]);
@@ -107,18 +108,18 @@ int main(int argc, char **argv)
       char cmd[100];
       int arg;
 
-      while (1) {
+      while (true) {
         fprintf(stderr, "interact $ ");
 
         if (fgets(input, sizeof(input), stdin) == NULL) {
           break;  // EOF
         }
 
-        if(1 == sscanf(input, "%99s %d", cmd, &arg)) {
+        if (1 == sscanf(input, "%99s %d", cmd, &arg)) {
           arg = 0;
         }
         if (strcmp(cmd, "exit") == 0) {
-            return arg;
+          return arg;
         } else {
           fprintf(stderr, "command not found: %s\n", cmd);
         }

--- a/test/functional/fixtures/streams-test.c
+++ b/test/functional/fixtures/streams-test.c
@@ -1,6 +1,5 @@
 /// Helper program to exit and keep stdout open (like "xclip -i -loops 1").
 #include <stdio.h>
-
 #include <uv.h>
 
 int main(int argc, char **argv)
@@ -8,7 +7,7 @@ int main(int argc, char **argv)
   uv_loop_t *loop = uv_default_loop();
   uv_process_t child_req;
 
-  char * args[3];
+  char *args[3];
   args[0] = "sleep";
   args[1] = "10";
   args[2] = NULL;

--- a/test/unit/fixtures/multiqueue.c
+++ b/test/unit/fixtures/multiqueue.c
@@ -1,8 +1,9 @@
-#include <string.h>
 #include <stdlib.h>
-#include "nvim/event/multiqueue.h"
+#include <string.h>
+
 #include "multiqueue.h"
 
+#include "nvim/event/multiqueue.h"
 
 void ut_multiqueue_put(MultiQueue *self, const char *str)
 {

--- a/test/unit/fixtures/multiqueue.h
+++ b/test/unit/fixtures/multiqueue.h
@@ -1,4 +1,4 @@
 #include "nvim/event/multiqueue.h"
 
-void ut_multiqueue_put(MultiQueue *queue, const char *str);
-const char *ut_multiqueue_get(MultiQueue *queue);
+void ut_multiqueue_put(MultiQueue *self, const char *str);
+const char *ut_multiqueue_get(MultiQueue *self);

--- a/test/unit/fixtures/posix.h
+++ b/test/unit/fixtures/posix.h
@@ -1,8 +1,8 @@
-#include <unistd.h>
-#include <string.h>
 #include <errno.h>
-#include <sys/wait.h>
 #include <stdlib.h>
+#include <string.h>
+#include <sys/wait.h>
+#include <unistd.h>
 
 enum {
   kPOSIXErrnoEINTR = EINTR,

--- a/test/unit/fixtures/vterm_test.c
+++ b/test/unit/fixtures/vterm_test.c
@@ -1,15 +1,15 @@
-#include "vterm_test.h"
-
 #include <stdio.h>
+
+#include "vterm_test.h"
 
 int parser_text(const char bytes[], size_t len, void *user)
 {
   FILE *f = fopen(VTERM_TEST_FILE, "a");
   fprintf(f, "text ");
   size_t i;
-  for(i = 0; i < len; i++) {
+  for (i = 0; i < len; i++) {
     unsigned char b = (unsigned char)bytes[i];
-    if(b < 0x20 || b == 0x7f || (b >= 0x80 && b < 0xa0)) {
+    if (b < 0x20 || b == 0x7f || (b >= 0x80 && b < 0xa0)) {
       break;
     }
     fprintf(f, i ? ",%x" : "%x", b);
@@ -22,36 +22,37 @@ int parser_text(const char bytes[], size_t len, void *user)
 
 static void printchars(const char *s, size_t len, FILE *f)
 {
-  while(len--) {
+  while (len--) {
     fprintf(f, "%c", (s++)[0]);
   }
 }
 
-int parser_csi(const char *leader, const long args[], int argcount, const char *intermed, char command, void *user)
+int parser_csi(const char *leader, const long args[], int argcount, const char *intermed,
+               char command, void *user)
 {
   FILE *f = fopen(VTERM_TEST_FILE, "a");
   fprintf(f, "csi %02x", command);
 
-  if(leader && leader[0]) {
+  if (leader && leader[0]) {
     fprintf(f, " L=");
-    for(int i = 0; leader[i]; i++) {
+    for (int i = 0; leader[i]; i++) {
       fprintf(f, "%02x", leader[i]);
     }
   }
 
-  for(int i = 0; i < argcount; i++) {
+  for (int i = 0; i < argcount; i++) {
     char sep = i ? ',' : ' ';
 
-    if(args[i] == CSI_ARG_MISSING) {
+    if (args[i] == CSI_ARG_MISSING) {
       fprintf(f, "%c*", sep);
     } else {
       fprintf(f, "%c%ld%s", sep, CSI_ARG(args[i]), CSI_ARG_HAS_MORE(args[i]) ? "+" : "");
     }
   }
 
-  if(intermed && intermed[0]) {
+  if (intermed && intermed[0]) {
     fprintf(f, " I=");
-    for(int i = 0; intermed[i]; i++) {
+    for (int i = 0; intermed[i]; i++) {
       fprintf(f, "%02x", intermed[i]);
     }
   }
@@ -68,8 +69,8 @@ int parser_osc(int command, VTermStringFragment frag, void *user)
   FILE *f = fopen(VTERM_TEST_FILE, "a");
   fprintf(f, "osc ");
 
-  if(frag.initial) {
-    if(command == -1) {
+  if (frag.initial) {
+    if (command == -1) {
       fprintf(f, "[");
     } else {
       fprintf(f, "[%d;", command);
@@ -78,7 +79,7 @@ int parser_osc(int command, VTermStringFragment frag, void *user)
 
   printchars(frag.str, frag.len, f);
 
-  if(frag.final) {
+  if (frag.final) {
     fprintf(f, "]");
   }
 
@@ -93,16 +94,16 @@ int parser_dcs(const char *command, size_t commandlen, VTermStringFragment frag,
   FILE *f = fopen(VTERM_TEST_FILE, "a");
   fprintf(f, "dcs ");
 
-  if(frag.initial) {
+  if (frag.initial) {
     fprintf(f, "[");
-    for(size_t i = 0; i < commandlen; i++) {
+    for (size_t i = 0; i < commandlen; i++) {
       fprintf(f, "%c", command[i]);
     }
   }
 
-  printchars(frag.str, frag.len,f);
+  printchars(frag.str, frag.len, f);
 
-  if(frag.final) {
+  if (frag.final) {
     fprintf(f, "]");
   }
 
@@ -117,13 +118,13 @@ int parser_apc(VTermStringFragment frag, void *user)
   FILE *f = fopen(VTERM_TEST_FILE, "a");
   fprintf(f, "apc ");
 
-  if(frag.initial) {
+  if (frag.initial) {
     fprintf(f, "[");
   }
 
   printchars(frag.str, frag.len, f);
 
-  if(frag.final) {
+  if (frag.final) {
     fprintf(f, "]");
   }
 
@@ -138,13 +139,13 @@ int parser_pm(VTermStringFragment frag, void *user)
   FILE *f = fopen(VTERM_TEST_FILE, "a");
   fprintf(f, "pm ");
 
-  if(frag.initial) {
+  if (frag.initial) {
     fprintf(f, "[");
   }
 
-  printchars(frag.str, frag.len,f);
+  printchars(frag.str, frag.len, f);
 
-  if(frag.final) {
+  if (frag.final) {
     fprintf(f, "]");
   }
 
@@ -159,13 +160,13 @@ int parser_sos(VTermStringFragment frag, void *user)
   FILE *f = fopen(VTERM_TEST_FILE, "a");
   fprintf(f, "sos ");
 
-  if(frag.initial) {
+  if (frag.initial) {
     fprintf(f, "[");
   }
 
-  printchars(frag.str, frag.len,f);
+  printchars(frag.str, frag.len, f);
 
-  if(frag.final) {
+  if (frag.final) {
     fprintf(f, "]");
   }
 
@@ -179,14 +180,14 @@ int selection_set(VTermSelectionMask mask, VTermStringFragment frag, void *user)
 {
   FILE *f = fopen(VTERM_TEST_FILE, "a");
   fprintf(f, "selection-set mask=%04X ", mask);
-  if(frag.initial) {
+  if (frag.initial) {
     fprintf(f, "[");
-}
+  }
   printchars(frag.str, frag.len, f);
-  if(frag.final) {
+  if (frag.final) {
     fprintf(f, "]");
-}
-  fprintf(f,"\n");
+  }
+  fprintf(f, "\n");
 
   fclose(f);
   return 1;
@@ -195,7 +196,7 @@ int selection_set(VTermSelectionMask mask, VTermStringFragment frag, void *user)
 int selection_query(VTermSelectionMask mask, void *user)
 {
   FILE *f = fopen(VTERM_TEST_FILE, "a");
-  fprintf(f,"selection-query mask=%04X\n", mask);
+  fprintf(f, "selection-query mask=%04X\n", mask);
 
   fclose(f);
   return 1;
@@ -204,24 +205,24 @@ int selection_query(VTermSelectionMask mask, void *user)
 bool want_state_putglyph;
 int state_putglyph(VTermGlyphInfo *info, VTermPos pos, void *user)
 {
-  if(!want_state_putglyph) {
+  if (!want_state_putglyph) {
     return 1;
   }
 
   FILE *f = fopen(VTERM_TEST_FILE, "a");
   fprintf(f, "putglyph ");
-  for(int i = 0; i < VTERM_MAX_CHARS_PER_CELL && info->chars[i]; i++) {
+  for (int i = 0; i < VTERM_MAX_CHARS_PER_CELL && info->chars[i]; i++) {
     fprintf(f, i ? ",%x" : "%x", info->chars[i]);
   }
   fprintf(f, " %d %d,%d", info->width, pos.row, pos.col);
-  if(info->protected_cell) {
+  if (info->protected_cell) {
     fprintf(f, " prot");
   }
-  if(info->dwl) {
+  if (info->dwl) {
     fprintf(f, " dwl");
   }
-  if(info->dhl) {
-    fprintf(f, " dhl-%s", info->dhl == 1 ? "top" : info->dhl == 2 ? "bottom" : "?" );
+  if (info->dhl) {
+    fprintf(f, " dhl-%s", info->dhl == 1 ? "top" : info->dhl == 2 ? "bottom" : "?");
   }
   fprintf(f, "\n");
 
@@ -237,8 +238,8 @@ int state_movecursor(VTermPos pos, VTermPos oldpos, int visible, void *user)
   FILE *f = fopen(VTERM_TEST_FILE, "a");
   state_pos = pos;
 
-  if(want_state_movecursor) {
-    fprintf(f,"movecursor %d,%d\n", pos.row, pos.col);
+  if (want_state_movecursor) {
+    fprintf(f, "movecursor %d,%d\n", pos.row, pos.col);
   }
 
   fclose(f);
@@ -248,15 +249,15 @@ int state_movecursor(VTermPos pos, VTermPos oldpos, int visible, void *user)
 bool want_state_scrollrect;
 int state_scrollrect(VTermRect rect, int downward, int rightward, void *user)
 {
-  if(!want_state_scrollrect) {
+  if (!want_state_scrollrect) {
     return 0;
   }
 
   FILE *f = fopen(VTERM_TEST_FILE, "a");
 
-  fprintf(f,"scrollrect %d..%d,%d..%d => %+d,%+d\n",
-      rect.start_row, rect.end_row, rect.start_col, rect.end_col,
-      downward, rightward);
+  fprintf(f, "scrollrect %d..%d,%d..%d => %+d,%+d\n",
+          rect.start_row, rect.end_row, rect.start_col, rect.end_col,
+          downward, rightward);
 
   fclose(f);
   return 1;
@@ -265,14 +266,14 @@ int state_scrollrect(VTermRect rect, int downward, int rightward, void *user)
 bool want_state_moverect;
 int state_moverect(VTermRect dest, VTermRect src, void *user)
 {
-  if(!want_state_moverect) {
+  if (!want_state_moverect) {
     return 0;
   }
 
   FILE *f = fopen(VTERM_TEST_FILE, "a");
-  fprintf(f,"moverect %d..%d,%d..%d -> %d..%d,%d..%d\n",
-      src.start_row,  src.end_row,  src.start_col,  src.end_col,
-      dest.start_row, dest.end_row, dest.start_col, dest.end_col);
+  fprintf(f, "moverect %d..%d,%d..%d -> %d..%d,%d..%d\n",
+          src.start_row,  src.end_row,  src.start_col,  src.end_col,
+          dest.start_row, dest.end_row, dest.start_col, dest.end_col);
 
   fclose(f);
   return 1;
@@ -282,28 +283,26 @@ void print_color(const VTermColor *col)
 {
   FILE *f = fopen(VTERM_TEST_FILE, "a");
   if (VTERM_COLOR_IS_RGB(col)) {
-    fprintf(f,"rgb(%d,%d,%d", col->rgb.red, col->rgb.green, col->rgb.blue);
-  }
-  else if (VTERM_COLOR_IS_INDEXED(col)) {
-    fprintf(f,"idx(%d", col->indexed.idx);
-  }
-  else {
-    fprintf(f,"invalid(%d", col->type);
+    fprintf(f, "rgb(%d,%d,%d", col->rgb.red, col->rgb.green, col->rgb.blue);
+  } else if (VTERM_COLOR_IS_INDEXED(col)) {
+    fprintf(f, "idx(%d", col->indexed.idx);
+  } else {
+    fprintf(f, "invalid(%d", col->type);
   }
   if (VTERM_COLOR_IS_DEFAULT_FG(col)) {
-    fprintf(f,",is_default_fg");
+    fprintf(f, ",is_default_fg");
   }
   if (VTERM_COLOR_IS_DEFAULT_BG(col)) {
-    fprintf(f,",is_default_bg");
+    fprintf(f, ",is_default_bg");
   }
-  fprintf(f,")");
+  fprintf(f, ")");
   fclose(f);
 }
 
 bool want_state_settermprop;
 int state_settermprop(VTermProp prop, VTermValue *val, void *user)
 {
-  if(!want_state_settermprop) {
+  if (!want_state_settermprop) {
     return 1;
   }
 
@@ -311,28 +310,29 @@ int state_settermprop(VTermProp prop, VTermValue *val, void *user)
   FILE *f = fopen(VTERM_TEST_FILE, "a");
 
   VTermValueType type = vterm_get_prop_type(prop);
-  switch(type) {
-    case VTERM_VALUETYPE_BOOL:
-      fprintf(f,"settermprop %d %s\n", prop, val->boolean ? "true" : "false");
-      errcode = 1;
-      goto end;
-    case VTERM_VALUETYPE_INT:
-      fprintf(f,"settermprop %d %d\n", prop, val->number);
-      errcode = 1;
-      goto end;
-    case VTERM_VALUETYPE_STRING:
-      fprintf(f,"settermprop %d %s\"%.*s\"%s\n", prop,
-          val->string.initial ? "[" : "", (int)val->string.len, val->string.str, val->string.final ? "]" : "");
-      errcode=0;
-      goto end;
-    case VTERM_VALUETYPE_COLOR:
-      fprintf(f,"settermprop %d ", prop);
-      print_color(&val->color);
-      fprintf(f,"\n");
-      errcode=1;
-      goto end;
-    case VTERM_N_VALUETYPES:
-      goto end;
+  switch (type) {
+  case VTERM_VALUETYPE_BOOL:
+    fprintf(f, "settermprop %d %s\n", prop, val->boolean ? "true" : "false");
+    errcode = 1;
+    goto end;
+  case VTERM_VALUETYPE_INT:
+    fprintf(f, "settermprop %d %d\n", prop, val->number);
+    errcode = 1;
+    goto end;
+  case VTERM_VALUETYPE_STRING:
+    fprintf(f, "settermprop %d %s\"%.*s\"%s\n", prop,
+            val->string.initial ? "[" : "", (int)val->string.len, val->string.str,
+            val->string.final ? "]" : "");
+    errcode = 0;
+    goto end;
+  case VTERM_VALUETYPE_COLOR:
+    fprintf(f, "settermprop %d ", prop);
+    print_color(&val->color);
+    fprintf(f, "\n");
+    errcode = 1;
+    goto end;
+  case VTERM_N_VALUETYPES:
+    goto end;
   }
 
 end:
@@ -343,15 +343,15 @@ end:
 bool want_state_erase;
 int state_erase(VTermRect rect, int selective, void *user)
 {
-  if(!want_state_erase) {
+  if (!want_state_erase) {
     return 1;
   }
 
   FILE *f = fopen(VTERM_TEST_FILE, "a");
 
-  fprintf(f,"erase %d..%d,%d..%d%s\n",
-      rect.start_row, rect.end_row, rect.start_col, rect.end_col,
-      selective ? " selective" : "");
+  fprintf(f, "erase %d..%d,%d..%d%s\n",
+          rect.start_row, rect.end_row, rect.start_col, rect.end_col,
+          selective ? " selective" : "");
 
   fclose(f);
   return 1;
@@ -374,7 +374,7 @@ struct {
 
 int state_setpenattr(VTermAttr attr, VTermValue *val, void *user)
 {
-  switch(attr) {
+  switch (attr) {
   case VTERM_ATTR_BOLD:
     state_pen.bold = val->boolean;
     break;
@@ -422,13 +422,14 @@ int state_setpenattr(VTermAttr attr, VTermValue *val, void *user)
 }
 
 bool want_state_scrollback;
-int state_sb_clear(void *user) {
-  if(!want_state_scrollback) {
+int state_sb_clear(void *user)
+{
+  if (!want_state_scrollback) {
     return 1;
   }
 
   FILE *f = fopen(VTERM_TEST_FILE, "a");
-  fprintf(f,"sb_clear\n");
+  fprintf(f, "sb_clear\n");
   fclose(f);
 
   return 0;
@@ -437,18 +438,18 @@ int state_sb_clear(void *user) {
 bool want_screen_scrollback;
 int screen_sb_pushline(int cols, const VTermScreenCell *cells, void *user)
 {
-  if(!want_screen_scrollback) {
+  if (!want_screen_scrollback) {
     return 1;
   }
 
   int eol = cols;
-  while(eol && !cells[eol-1].chars[0]) {
+  while (eol && !cells[eol - 1].chars[0]) {
     eol--;
   }
 
   FILE *f = fopen(VTERM_TEST_FILE, "a");
   fprintf(f, "sb_pushline %d =", cols);
-  for(int c = 0; c < eol; c++) {
+  for (int c = 0; c < eol; c++) {
     fprintf(f, " %02X", cells[c].chars[0]);
   }
   fprintf(f, "\n");
@@ -460,13 +461,13 @@ int screen_sb_pushline(int cols, const VTermScreenCell *cells, void *user)
 
 int screen_sb_popline(int cols, VTermScreenCell *cells, void *user)
 {
-  if(!want_screen_scrollback) {
+  if (!want_screen_scrollback) {
     return 0;
   }
 
   // All lines of scrollback contain "ABCDE"
-  for(int col = 0; col < cols; col++) {
-    if(col < 5) {
+  for (int col = 0; col < cols; col++) {
+    if (col < 5) {
       cells[col].chars[0] = (uint32_t)('A' + col);
     } else {
       cells[col].chars[0] = 0;
@@ -476,14 +477,14 @@ int screen_sb_popline(int cols, VTermScreenCell *cells, void *user)
   }
 
   FILE *f = fopen(VTERM_TEST_FILE, "a");
-  fprintf(f,"sb_popline %d\n", cols);
+  fprintf(f, "sb_popline %d\n", cols);
   fclose(f);
   return 1;
 }
 
 int screen_sb_clear(void *user)
 {
-  if(!want_screen_scrollback) {
+  if (!want_screen_scrollback) {
     return 1;
   }
 
@@ -497,8 +498,8 @@ void term_output(const char *s, size_t len, void *user)
 {
   FILE *f = fopen(VTERM_TEST_FILE, "a");
   fprintf(f, "output ");
-  for(size_t i = 0; i < len; i++) {
-    fprintf(f, "%x%s", (unsigned char)s[i], i < len-1 ? "," : "\n");
+  for (size_t i = 0; i < len; i++) {
+    fprintf(f, "%x%s", (unsigned char)s[i], i < len - 1 ? "," : "\n");
   }
   fclose(f);
 }

--- a/test/unit/fixtures/vterm_test.h
+++ b/test/unit/fixtures/vterm_test.h
@@ -5,7 +5,8 @@
 #include "vterm/vterm.h"
 
 int parser_text(const char bytes[], size_t len, void *user);
-int parser_csi(const char *leader, const long args[], int argcount, const char *intermed, char command, void *user);
+int parser_csi(const char *leader, const long args[], int argcount, const char *intermed,
+               char command, void *user);
 int parser_osc(int command, VTermStringFragment frag, void *user);
 int parser_dcs(const char *command, size_t commandlen, VTermStringFragment frag, void *user);
 int parser_apc(VTermStringFragment frag, void *user);


### PR DESCRIPTION
It's probably not worth adding the C test files to regular formatting as
they're pretty much never touched, but ensuring the files are formatted
according to our standards and getting rid of warnings is a cheap
one-time fix.
