### PR TITLE
fix(messages): bug and unwanted truncation in msg_outtrans_long

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -3142,8 +3142,9 @@ static bool color_cmdline(CmdlineInfo *colored_ccline)
 
 #define PRINT_ERRMSG(...) \
   do { \
+    msg_scroll = true; \
     msg_putchar('\n'); \
-    msg_printf_hl(HLF_E, __VA_ARGS__); \
+    smsg(HLF_E, __VA_ARGS__); \
     printed_errmsg = true; \
   } while (0)
   bool ret = true;

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -258,7 +258,7 @@ void op_shift(oparg_T *oap, bool curs_top, int amount)
     vim_snprintf(IObuff, IOSIZE,
                  NGETTEXT(msg_line_single, msg_line_plural, oap->line_count),
                  (int64_t)oap->line_count, op, amount);
-    msg_hl_keep(IObuff, 0, true, false);
+    msg_keep(IObuff, 0, true, false);
   }
 
   if ((cmdmod.cmod_flags & CMOD_LOCKMARKS) == 0) {

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2937,7 +2937,7 @@ static void qf_jump_print_msg(qf_info_T *qi, int qf_index, qfline_T *qf_ptr, buf
     msg_scroll = false;
   }
   msg_ext_set_kind("quickfix");
-  msg_hl_keep(gap->ga_data, 0, true, false);
+  msg_keep(gap->ga_data, 0, true, false);
   msg_scroll = (int)i;
 
   qfga_clear();

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2596,12 +2596,12 @@ static void u_undo_end(bool did_undo, bool absolute, bool quiet)
     check_pos(curbuf, &VIsual);
   }
 
-  smsg_hl_keep(0, _("%" PRId64 " %s; %s #%" PRId64 "  %s"),
-               u_oldcount < 0 ? (int64_t)-u_oldcount : (int64_t)u_oldcount,
-               _(msgstr),
-               did_undo ? _("before") : _("after"),
-               uhp == NULL ? 0 : (int64_t)uhp->uh_seq,
-               msgbuf);
+  smsg_keep(0, _("%" PRId64 " %s; %s #%" PRId64 "  %s"),
+            u_oldcount < 0 ? (int64_t)-u_oldcount : (int64_t)u_oldcount,
+            _(msgstr),
+            did_undo ? _("before") : _("after"),
+            uhp == NULL ? 0 : (int64_t)uhp->uh_seq,
+            msgbuf);
 }
 
 /// Put the timestamp of an undo header in "buf[buflen]" in a nice format.


### PR DESCRIPTION
- Small typo/bug in msg_outtrans_long passing string length as "hist" argument.
- Avoid truncating message in msg_outtrans_long with ext_messages as a
  followup to #21709.
- Remove _hl from msg_keep and smsg_keep as there is no variant without hl_id.
- msg_printf_hl is removed (identical to smsg except that it sets
  `msg_scroll = true`, seemingly as a caveat to force a more prompt in
  cmdline mode). Move this logic to the only the only place this was
  used in ex_getln.c.