### PR TITLE
fix(inspect): use correct default highlight

### DIFF
--- a/runtime/lua/vim/_inspector.lua
+++ b/runtime/lua/vim/_inspector.lua
@@ -186,7 +186,7 @@ function vim.show_pos(bufnr, row, col, filter)
         capture,
         string.format(
           'priority: %d   language: %s',
-          capture.metadata.priority or vim.hl.priorities.treesitter,
+          capture.metadata.priority or vim.highlight.priorities.treesitter,
           capture.lang
         )
       )


### PR DESCRIPTION
Problem: `vim.highlight` was renamed on `master`, breaking the
backported fix.

Solution: Use old name.

Fixup for 650dcbbafea581353ae75a8377a0b108d1b26761
