### PR TITLE
vim-patch:9.1.0951: filetype: jshell files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -616,6 +616,7 @@ local extension = {
   janet = 'janet',
   jav = 'java',
   java = 'java',
+  jsh = 'java',
   jj = 'javacc',
   jjt = 'javacc',
   es = 'javascript',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -374,7 +374,7 @@ func s:GetFilenameChecks() abort
     \ 'jal': ['file.jal', 'file.JAL'],
     \ 'jam': ['file.jpl', 'file.jpr', 'JAM-file.file', 'JAM.file', 'Prl-file.file', 'Prl.file'],
     \ 'janet': ['file.janet'],
-    \ 'java': ['file.java', 'file.jav'],
+    \ 'java': ['file.java', 'file.jav', 'file.jsh'],
     \ 'javacc': ['file.jj', 'file.jjt'],
     \ 'javascript': ['file.js', 'file.jsm', 'file.javascript', 'file.es', 'file.mjs', 'file.cjs', '.node_repl_history', '.bun_repl_history', 'deno_history.txt'],
     \ 'javascript.glimmer': ['file.gjs'],


### PR DESCRIPTION
Problem:  filetype: jshell files are not recognized
Solution: detect '*.jsh' files as java filetype
          (Konfekt)

closes: vim/vim#16260

https://github.com/vim/vim/commit/62e3014ab1146d7f78694c97fc6974f1af2cc5af

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>
