### PR TITLE
feat(test): support and document lua test case debugging

### DIFF
--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -48,6 +48,16 @@ M.nvim_argv = {
   'unlet g:colors_name',
   '--embed',
 }
+if os.getenv('OSV_PORT') then
+  table.insert(M.nvim_argv, '--cmd')
+  table.insert(
+    M.nvim_argv,
+    string.format(
+      "lua require('osv').launch({ port = %s, blocking = true })",
+      os.getenv('OSV_PORT')
+    )
+  )
+end
 
 -- Directory containing nvim.
 M.nvim_dir = M.nvim_prog:gsub('[/\\][^/\\]+$', '')


### PR DESCRIPTION
Similar to how there is a `GDB` environment variable to let the nvim
test instances to be run under `gdbserver` this adds a `OSV_PORT`
variable to start nvim test instances with `osv` in blocking mode to let
a debug client attach to it for debugging of `exec_lua` code blocks.


![recording](https://github.com/user-attachments/assets/9f7c3d7a-69bf-4f57-91a7-239696dd2800)


(I haven't really used this yet, so not sure what other limitations or caveats exist)