### PR TITLE
fix: fix broken wasmtime build

### DIFF
--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -17,6 +17,8 @@
 
 #ifdef HAVE_WASMTIME
 # include <wasm.h>
+
+# include "nvim/os/fs.h"
 #endif
 
 #include "nvim/api/private/helpers.h"


### PR DESCRIPTION
Regression from 2a7d0ed6145bf3f8b139c2694563f460f829813a, which removed
header that is only needed if wasmtime support is enabled. Prevent this
from happening again by wrapping the include in a `HAVE_WASMTIME` check.
