### PR TITLE
fix(diagnostic): silence chistory command

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -874,7 +874,7 @@ local function set_list(loclist, opts)
     if not loclist then
       -- First navigate to the diagnostics quickfix list.
       local nr = vim.fn.getqflist({ id = qf_id, nr = 0 }).nr
-      api.nvim_command(nr .. 'chistory')
+      api.nvim_command(('silent %dchistory'):format(nr))
 
       -- Now open the quickfix list.
       api.nvim_command('botright cwindow')


### PR DESCRIPTION
vim.diagnostic.set_list() uses chistory to restore the actively selected entry whenever necessary. This however also results in it displaying some output in the message bar, but this output isn't useful (and can even be distracting) when opening the quickfix window. This fixes this by silencing the chistory command.