### PR TITLE
fix(terminal): set cursor cell percentage

### DIFF
--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1961,9 +1961,11 @@ static void refresh_cursor(Terminal *term)
     break;
   case VTERM_PROP_CURSORSHAPE_UNDERLINE:
     shape_table[SHAPE_IDX_TERM].shape = SHAPE_HOR;
+    shape_table[SHAPE_IDX_TERM].percentage = 20;
     break;
   case VTERM_PROP_CURSORSHAPE_BAR_LEFT:
     shape_table[SHAPE_IDX_TERM].shape = SHAPE_VER;
+    shape_table[SHAPE_IDX_TERM].percentage = 25;
     break;
   }
 

--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -152,7 +152,7 @@ describe(':terminal cursor', function()
     end)
   end)
 
-  it('can be modified by application #3681', function()
+  it('can be modified by application #3681 #31685', function()
     skip(is_os('win'), '#31587')
 
     local states = {
@@ -181,7 +181,15 @@ describe(':terminal cursor', function()
             eq(0, screen._mode_info[terminal_mode_idx].blinkon)
             eq(0, screen._mode_info[terminal_mode_idx].blinkoff)
           end
+
           eq(v.shape, screen._mode_info[terminal_mode_idx].cursor_shape)
+
+          -- Cell percentages are hard coded for each shape in terminal.c
+          if v.shape == 'horizontal' then
+            eq(20, screen._mode_info[terminal_mode_idx].cell_percentage)
+          elseif v.shape == 'vertical' then
+            eq(25, screen._mode_info[terminal_mode_idx].cell_percentage)
+          end
         end,
       })
     end


### PR DESCRIPTION
Fixes: https://github.com/neovim/neovim/issues/31685

cc @fredizzimo. I took your suggestion and set the percentage to 25 for vertical cursors and 20 for horizontal. This isn't configurable for now (I'll wait until enough people ask for it, because it's not clear how we even would make this configurable: the escape sequence to modify the cursor shape can't specify parameters such as the width).

Btw I noticed while testing in Neovide that the cursor doesn't blink, even when it is configured to. Is this a known issue in Neovide or is this something else broken in core?