### PR TITLE
fix(build): <termios.h> is system-dependent

### DIFF
--- a/src/nvim/tui/termkey/termkey.c
+++ b/src/nvim/tui/termkey/termkey.c
@@ -13,7 +13,10 @@
 #include "nvim/tui/termkey/termkey_defs.h"
 
 #ifndef _WIN32
-# include <termios.h>
+// Include these directly instead of <termios.h> which is system-dependent. #31704
+# include <poll.h>  // IWYU pragma: keep
+# include <strings.h>  // IWYU pragma: keep
+# include <unistd.h>  // IWYU pragma: keep
 #else
 # include <io.h>
 #endif


### PR DESCRIPTION
Problem:
Since 2a7d0ed6145bf3f8b139c2694563f460f829813a, build fails with glibc version 2.28 / RHEL8 (where `termios.h` does not include unistd.h and is therefore missing `_POSIX_VDISABLE`):

    …/src/nvim/tui/termkey/termkey.c: In function 'termkey_start':
    …/src/nvim/tui/termkey/termkey.c:516:31: error: '_POSIX_VDISABLE' undeclared (first use in this function)
      516 |         termios.c_cc[VQUIT] = _POSIX_VDISABLE;
          |                               ^~~~~~~~~~~~~~~
    …/src/nvim/tui/termkey/termkey.c:516:31: note: each undeclared identifier is reported only once for each function it appears in

Solution:
- Undo the `<termios.h>` change and mark the imports with `IWYU pragma: keep`.

fix #31704