### PR TITLE
feat(filetype): support bun.lock file as jsonc

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1636,6 +1636,7 @@ local filename = {
   ['.luaurc'] = 'jsonc',
   ['.swrc'] = 'jsonc',
   ['.vsconfig'] = 'jsonc',
+  ['bun.lock'] = 'jsonc',
   ['.justfile'] = 'just',
   ['justfile'] = 'just',
   ['Justfile'] = 'just',


### PR DESCRIPTION
> The bun.lock file is JSONC (like tsconfig.json)

see https://bun.sh/blog/bun-lock-text-lockfile#tooling-compatibility