### PR TITLE
feat(clipboard)!: use OSC 52 as fallback clipboard provider

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -169,6 +169,14 @@ function! provider#clipboard#Executable() abort
     let s:copy['*'] = s:copy['+']
     let s:paste['*'] = s:paste['+']
     return 'tmux'
+  elseif get(get(g:, 'termfeatures', {}), 'osc52') && &clipboard ==# ''
+    " Don't use OSC 52 when 'clipboard' is set. It can be slow and cause a lot
+    " of user prompts. Users can opt-in to it by setting g:clipboard manually.
+    let s:copy['+'] = v:lua.require'vim.ui.clipboard.osc52'.copy('+')
+    let s:copy['*'] = v:lua.require'vim.ui.clipboard.osc52'.copy('*')
+    let s:paste['+'] = v:lua.require'vim.ui.clipboard.osc52'.paste('+')
+    let s:paste['*'] = v:lua.require'vim.ui.clipboard.osc52'.paste('*')
+    return 'OSC 52'
   endif
 
   let s:err = 'clipboard: No clipboard tool. :help clipboard'

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -174,7 +174,9 @@ TREESITTER
 
 TUI
 
-• TODO
+• OSC 52 is used as a fallback clipboard provider when no other
+  |clipboard-tool| is found, even when not using SSH |clipboard-osc52|. To
+  disable OSC 52 queries, set the "osc52" key of |g:termfeatures| to false.
 
 VIMSCRIPT
 

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -259,23 +259,21 @@ For Windows WSL, try this g:clipboard definition:
 							    *clipboard-osc52*
 Nvim bundles a clipboard provider that allows copying to the system clipboard
 using OSC 52. OSC 52 is an Operating System Command control sequence that
-writes the copied text to the terminal emulator. If the terminal emulator
-supports OSC 52 then it will write the copied text into the system clipboard.
+causes the terminal emulator to write to or read from the system clipboard.
 
-Nvim will attempt to automatically determine if the host terminal emulator
-supports the OSC 52 sequence and enable the OSC 52 clipboard provider if it
-does as long as all of the following are true:
+When Nvim is running in the |TUI|, it will automatically attempt to determine if
+the host terminal emulator supports OSC 52. If it does, then Nvim will use OSC
+52 for copying and pasting if no other |clipboard-tool| is found and when
+'clipboard' is unset.
 
-  • Nvim is running in the |TUI|
-  • |g:clipboard| is unset
-  • 'clipboard' is not set to "unnamed" or "unnamedplus"
-  • $SSH_TTY is set
-
-If any of the above conditions are not met then the OSC 52 clipboard provider
-will not be used by default and Nvim will fall back to discovering a
-|clipboard-tool| through the usual process.
-
-To force Nvim to use the OSC 52 provider you can use the following
+							*g:termfeatures*
+To disable the automatic detection, set the "osc52" key of |g:termfeatures| to
+|v:false| in the |config| file. Example: >lua
+	local termfeatures = vim.g.termfeatures or {}
+	termfeatures.osc52 = false
+	vim.g.termfeatures = termfeatures
+<
+To force Nvim to always use the OSC 52 provider you can use the following
 |g:clipboard| definition: >lua
 
     vim.g.clipboard = {

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -3184,7 +3184,6 @@ describe('TUI', function()
           local req = args.data
           local payload = req:match('^\027P%+q([%x;]+)$')
           if payload and vim.text.hexdecode(payload) == 'Ms' then
-            vim.g.xtgettcap = 'Ms'
             local resp = string.format('\027P1+r%s=%s\027\\', payload, vim.text.hexencode('\027]52;;\027\\'))
             vim.api.nvim_chan_send(vim.bo[args.buf].channel, resp)
             return true
@@ -3202,9 +3201,6 @@ describe('TUI', function()
     }, {
       env = {
         VIMRUNTIME = os.getenv('VIMRUNTIME'),
-
-        -- Only queries when SSH_TTY is set
-        SSH_TTY = '/dev/pts/1',
       },
     })
 
@@ -3212,8 +3208,7 @@ describe('TUI', function()
 
     local child_session = n.connect(child_server)
     retry(nil, 1000, function()
-      eq('Ms', eval("get(g:, 'xtgettcap', '')"))
-      eq({ true, 'OSC 52' }, { child_session:request('nvim_eval', 'g:clipboard.name') })
+      eq({ true, { osc52 = true } }, { child_session:request('nvim_eval', 'g:termfeatures') })
     end)
   end)
 end)


### PR DESCRIPTION
We currently enable the OSC 52 clipboard provider by setting g:clipboard when a list of conditions are met, one of which is that $SSH_TTY must be set. We include this condition because often OSC 52 is not the best clipboard provider, so if there are "local" providers available Nvim should prefer those over OSC 52.

However, if no other providers are available, Nvim should use OSC 52 even when $SSH_TTY is not set. When a user is in an SSH session then the checks for the other clipboard providers will still (typically) fail, so OSC 52 continues to be enabled by default in SSH sessions.

This is marked as a breaking change because there are some cases where OSC 52 wasn't enabled before and is now (or vice versa). However, I think this provides a better default user experience.

:christmas_tree: 