### PR TITLE
docs(eval): search viml function return lnum or 0

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -8262,7 +8262,7 @@ search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]]) *search()*
                   • {skip} (`string|function?`)
 
                 Return: ~
-                  (`any`)
+                  (`integer`)
 
 searchcount([{options}])                                         *searchcount()*
 		Get or update the last search count, like what is displayed

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -7518,7 +7518,7 @@ function vim.fn.screenstring(row, col) end
 --- @param stopline? integer
 --- @param timeout? integer
 --- @param skip? string|function
---- @return any
+--- @return integer
 function vim.fn.search(pattern, flags, stopline, timeout, skip) end
 
 --- Get or update the last search count, like what is displayed

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -9154,6 +9154,7 @@ M.funcs = {
       { 'timeout', 'integer' },
       { 'skip', 'string|function' },
     },
+    returns = 'integer',
     signature = 'search({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])',
   },
   searchcount = {


### PR DESCRIPTION
Problem: search() return line number when found otherwise 0

Soliton: add returns with integer