### PR TITLE
vim-patch:6c57c30: runtime(compiler): include a basic bash syntax checker compiler

### DIFF
--- a/runtime/compiler/bash.vim
+++ b/runtime/compiler/bash.vim
@@ -1,0 +1,12 @@
+" Vim compiler file
+" Compiler:     Bash Syntax Checker
+" Maintainer:   @konfekt
+" Last Change:  2024 Dec 27
+
+if exists("current_compiler")
+   finish
+endif
+let current_compiler = "bash"
+
+CompilerSet makeprg=bash\ -n
+CompilerSet errorformat=%f:\ line\ %l:\ %m


### PR DESCRIPTION
See @saccarosium 's suggestion at
https://github.com/vim/vim/pull/16311#issuecomment-2563447885

closes: vim/vim#16314

https://github.com/vim/vim/commit/6c57c30ad43f5e0d040f7d432ceb5d61fc6ab651

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>
