### PR TITLE
refactor(options): remove code for multitype options

### DIFF
--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -843,11 +843,10 @@ static char *ex_let_option(char *arg, typval_T *const tv, const bool is_const,
     goto theend;
   }
 
-  // Don't assume current and new values are of the same type in order to future-proof the code for
-  // when an option can have multiple types.
-  const bool is_num = ((curval.type == kOptValTypeNumber || curval.type == kOptValTypeBoolean)
-                       && (newval.type == kOptValTypeNumber || newval.type == kOptValTypeBoolean));
-  const bool is_string = curval.type == kOptValTypeString && newval.type == kOptValTypeString;
+  // Current value and new value must have the same type.
+  assert(curval.type == newval.type);
+  const bool is_num = curval.type == kOptValTypeNumber || curval.type == kOptValTypeBoolean;
+  const bool is_string = curval.type == kOptValTypeString;
 
   if (op != NULL && *op != '=') {
     if (!hidden && is_num) {  // number or bool
@@ -1896,8 +1895,6 @@ static void getwinvar(typval_T *argvars, typval_T *rettv, int off)
 ///
 /// @return  Typval converted to OptVal. Must be freed by caller.
 ///          Returns NIL_OPTVAL for invalid option name.
-///
-/// TODO(famiu): Refactor this to support multitype options.
 static OptVal tv_to_optval(typval_T *tv, OptIndex opt_idx, const char *option, bool *error)
 {
   OptVal value = NIL_OPTVAL;

--- a/src/nvim/generators/gen_options.lua
+++ b/src/nvim/generators/gen_options.lua
@@ -314,21 +314,6 @@ end
 
 --- @param o vim.option_meta
 --- @return string
-local function get_type_flags(o)
-  local opt_types = (type(o.type) == 'table') and o.type or { o.type }
-  local type_flags = '0'
-  assert(type(opt_types) == 'table')
-
-  for _, opt_type in ipairs(opt_types) do
-    assert(type(opt_type) == 'string')
-    type_flags = ('%s | (1 << %s)'):format(type_flags, opt_type_enum(opt_type))
-  end
-
-  return type_flags
-end
-
---- @param o vim.option_meta
---- @return string
 local function get_scope_flags(o)
   local scope_flags = '0'
 
@@ -427,8 +412,8 @@ local function dump_option(i, o)
   if o.abbreviation then
     w('    .shortname=' .. cstr(o.abbreviation))
   end
+  w('    .type=' .. opt_type_enum(o.type))
   w('    .flags=' .. get_flags(o))
-  w('    .type_flags=' .. get_type_flags(o))
   w('    .scope_flags=' .. get_scope_flags(o))
   w('    .scope_idx=' .. get_scope_idx(o))
   if o.enable_if then

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -54,9 +54,6 @@ typedef enum {
   kOptValTypeNumber,
   kOptValTypeString,
 } OptValType;
-/// Always update this whenever a new option type is added.
-#define kOptValTypeSize (kOptValTypeString + 1)
-typedef uint32_t OptTypeFlags;
 
 /// Scopes that an option can support.
 typedef enum {
@@ -99,7 +96,6 @@ typedef struct {
   int os_flags;
 
   /// Old value of the option.
-  /// TODO(famiu): Convert `os_oldval` and `os_newval` to `OptVal` to accommodate multitype options.
   OptValData os_oldval;
   /// New value of the option.
   OptValData os_newval;
@@ -173,7 +169,7 @@ typedef struct {
   char *fullname;                    ///< full option name
   char *shortname;                   ///< permissible abbreviation
   uint32_t flags;                    ///< see above
-  OptTypeFlags type_flags;           ///< option type flags, see OptValType
+  OptValType type;                   ///< option type
   OptScopeFlags scope_flags;         ///< option scope flags, see OptScope
   void *var;                         ///< global option: pointer to variable;
                                      ///< window-local option: NULL;

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7,7 +7,7 @@
 --- @field alias? string|string[]
 --- @field short_desc? string|fun(): string
 --- @field varname? string
---- @field type vim.option_type|vim.option_type[]
+--- @field type vim.option_type
 --- @field immutable? boolean
 --- @field list? 'comma'|'onecomma'|'commacolon'|'onecommacolon'|'flags'|'flagscomma'
 --- @field scope vim.option_scope[]


### PR DESCRIPTION
Problem: It was decided on Matrix chat that multitype options won't be necessary for Neovim options, and that options should only have a single canonical type. Therefore the code for supporting multitype options is unnecessary.

Solution: Remove the additional code that's used to provide multitype option support.
