### PR TITLE
fix(log): unintuitive message for undefined $TMPDIR

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3279,7 +3279,7 @@ static void vim_mktempdir(void)
         if (!os_getenv("TMPDIR")) {
           WLOG("$TMPDIR is unset or null");
         } else {
-          WLOG("$TMPDIR tempdir not a directory (or does not exist): %s", tmp);
+          WLOG("$TMPDIR tempdir not a directory (or does not exist): \"%s\"", tmp);
         }
       }
       continue;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3277,7 +3277,7 @@ static void vim_mktempdir(void)
     if (!os_isdir(tmp)) {
       if (strequal("$TMPDIR", temp_dirs[i])) {
         if (!os_getenv("TMPDIR")) {
-          WLOG("$TMPDIR is unset or null");
+          WLOG("$TMPDIR is unset");
         } else {
           WLOG("$TMPDIR tempdir not a directory (or does not exist): \"%s\"", tmp);
         }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3276,7 +3276,11 @@ static void vim_mktempdir(void)
     expand_env((char *)temp_dirs[i], tmp, TEMP_FILE_PATH_MAXLEN - 64);
     if (!os_isdir(tmp)) {
       if (strequal("$TMPDIR", temp_dirs[i])) {
-        WLOG("$TMPDIR tempdir not a directory (or does not exist): %s", tmp);
+        if (!os_getenv("TMPDIR")) {
+          WLOG("$TMPDIR is unset or null");
+        } else {
+          WLOG("$TMPDIR tempdir not a directory (or does not exist): %s", tmp);
+        }
       }
       continue;
     }


### PR DESCRIPTION
fixes #31757
Problem:
If $TMPDIR is unset or null, logs show that
$TMPDIR is not directory.

Solution:
Check if $TMPDIR is unset or empty and output log accurately