### PR TITLE
vim-patch:f2e08a1: runtime(doc): Fix documentation typos

### DIFF
--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -984,6 +984,7 @@ CTRL-W g }						*CTRL-W_g}*
 		If [N] is not given, the current buffer remains being edited.
 		See |:buffer-!| for [!].  This will also edit a buffer that is
 		not in the buffer list, without setting the 'buflisted' flag.
+		Also see |+cmd|.
 
 							*:ped* *:pedit*
 :ped[it][!] [++opt] [+cmd] {file}


### PR DESCRIPTION
#### vim-patch:f2e08a1: runtime(doc): Fix documentation typos

closes: vim/vim#16333

https://github.com/vim/vim/commit/f2e08a1e54e1e6f594edac5cd971ac2e03896a07

Numbers with quotes are N/A.

Co-authored-by: h-east <h.east.727@gmail.com>