### PR TITLE
feat(lsp): return resolved config for vim.lsp.config[name]

### DIFF
--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -184,7 +184,7 @@ local function check_enabled_configs()
   vim.health.start('vim.lsp: Enabled Configurations')
 
   for name in vim.spairs(vim.lsp._enabled_configs) do
-    local config = vim.lsp._resolve_config(name)
+    local config = vim.lsp.config[name]
     local text = {} --- @type string[]
     text[#text + 1] = ('%s:'):format(name)
     for k, v in

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -6147,7 +6147,7 @@ describe('LSP', function()
           vim.lsp.config('*', { root_markers = { '.git' } })
           vim.lsp.config('foo', { cmd = { 'foo' } })
 
-          return vim.lsp._resolve_config('foo')
+          return vim.lsp.config['foo']
         end)
       )
     end)


### PR DESCRIPTION
Allows to retrieve the configuration as it will be used by `lsp.enable` - including the parts merged from `*` and rtp.

This is useful for explicit startup control
(`vim.lsp.start(vim.lsp.config[name])`)

Closes https://github.com/neovim/neovim/issues/31640
