### PR TITLE
vim-patch:df67fc0: runtime(sh): set shellcheck as the compiler for supported shells

### DIFF
--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -5,6 +5,7 @@
 " Contributor:		Enno Nagel <ennonagel+vim@gmail.com>
 "			Eisuke Kawashima
 " Last Change:		2024 Sep 19 by Vim Project (compiler shellcheck)
+"			2024 Dec 29 by Vim Project (improve setting shellcheck compiler)
 
 if exists("b:did_ftplugin")
   finish
@@ -44,7 +45,11 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   let b:undo_ftplugin ..= " | unlet! b:browsefilter"
 endif
 
-if get(b:, "is_bash", 0)
+let s:is_sh = get(b:, "is_sh", get(g:, "is_sh", 0))
+let s:is_bash = get(b:, "is_bash", get(g:, "is_bash", 0))
+let s:is_kornshell = get(b:, "is_kornshell", get(g:, "is_kornshell", 0))
+
+if s:is_bash
   if exists(':terminal') == 2
     command! -buffer -nargs=1 ShKeywordPrg silent exe ':term bash -c "help "<args>" 2>/dev/null || man "<args>""'
   else
@@ -52,14 +57,21 @@ if get(b:, "is_bash", 0)
   endif
   setlocal keywordprg=:ShKeywordPrg
   let b:undo_ftplugin ..= " | setl kp< | sil! delc -buffer ShKeywordPrg"
+endif
 
+if (s:is_sh || s:is_bash || s:is_kornshell) && executable('shellcheck')
   if !exists('current_compiler')
     compiler shellcheck
+    let b:undo_ftplugin ..= ' | compiler make'
   endif
-  let b:undo_ftplugin .= ' | compiler make'
+elseif s:is_bash
+  if !exists('current_compiler')
+    compiler bash
+    let b:undo_ftplugin ..= ' | compiler make'
+  endif
 endif
 
 let &cpo = s:save_cpo
-unlet s:save_cpo
+unlet s:save_cpo s:is_sh s:is_bash s:is_kornshell
 
 " vim: nowrap sw=2 sts=2 ts=8 noet:


### PR DESCRIPTION
closes: vim/vim#16311

https://github.com/vim/vim/commit/df67fc0e6994bc92f3d82edc6269e158875defad

Co-authored-by: Luca Saccarola <github.e41mv@aleeas.com>
