### PR TITLE
fix(treesitter.foldexpr): only refresh valid buffers

### DIFF
--- a/runtime/lua/vim/treesitter/_fold.lua
+++ b/runtime/lua/vim/treesitter/_fold.lua
@@ -378,8 +378,10 @@ api.nvim_create_autocmd('OptionSet', {
   pattern = { 'foldminlines', 'foldnestmax' },
   desc = 'Refresh treesitter folds',
   callback = function()
-    local bufs = vim.v.option_type == 'local' and { api.nvim_get_current_buf() }
-      or vim.tbl_keys(foldinfos)
+    local buf = api.nvim_get_current_buf()
+    local bufs = vim.v.option_type == 'global' and vim.tbl_keys(foldinfos)
+      or foldinfos[buf] and { buf }
+      or {}
     for _, bufnr in ipairs(bufs) do
       foldinfos[bufnr] = FoldInfo.new()
       api.nvim_buf_call(bufnr, function()


### PR DESCRIPTION
Followup #31764

Problem: autocmd to refresh folds always uses the current buffer if the option type is local. However, the current buffer may not have a parser, and thus the assert that checks for a parser could fail.

Solution: check if the foldinfo contains the buffer, and only refresh if so.