### PR TITLE
feat: scoped injections

### DIFF
--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -374,22 +374,22 @@ int x = INT_MAX;
         eq(5, exec_lua('return #parser:children().c:trees()'))
         eq({
           { 0, 0, 7, 0 }, -- root tree
+          { 1, 26, 1, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
+          { 2, 29, 2, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
           { 3, 14, 3, 17 }, -- VALUE 123
           { 4, 15, 4, 18 }, -- VALUE1 123
           { 5, 15, 5, 18 }, -- VALUE2 123
-          { 1, 26, 1, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
-          { 2, 29, 2, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
         }, get_ranges())
 
         n.feed('ggo<esc>')
         eq(5, exec_lua('return #parser:children().c:trees()'))
         eq({
           { 0, 0, 8, 0 }, -- root tree
+          { 2, 26, 2, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
+          { 3, 29, 3, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
           { 4, 14, 4, 17 }, -- VALUE 123
           { 5, 15, 5, 18 }, -- VALUE1 123
           { 6, 15, 6, 18 }, -- VALUE2 123
-          { 2, 26, 2, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
-          { 3, 29, 3, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
         }, get_ranges())
       end)
     end)
@@ -412,11 +412,11 @@ int x = INT_MAX;
         eq(2, exec_lua('return #parser:children().c:trees()'))
         eq({
           { 0, 0, 7, 0 }, -- root tree
+          { 1, 26, 2, 66 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
+          -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
           { 3, 14, 5, 18 }, -- VALUE 123
           -- VALUE1 123
           -- VALUE2 123
-          { 1, 26, 2, 66 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
-          -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
         }, get_ranges())
 
         n.feed('ggo<esc>')
@@ -424,11 +424,11 @@ int x = INT_MAX;
         eq(2, exec_lua('return #parser:children().c:trees()'))
         eq({
           { 0, 0, 8, 0 }, -- root tree
+          { 2, 26, 3, 66 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
+          -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
           { 4, 14, 6, 18 }, -- VALUE 123
           -- VALUE1 123
           -- VALUE2 123
-          { 2, 26, 3, 66 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
-          -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
         }, get_ranges())
 
         n.feed('7ggI//<esc>')
@@ -437,10 +437,10 @@ int x = INT_MAX;
         eq(2, exec_lua('return #parser:children().c:trees()'))
         eq({
           { 0, 0, 8, 0 }, -- root tree
-          { 4, 14, 5, 18 }, -- VALUE 123
-          -- VALUE1 123
           { 2, 26, 3, 66 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
           -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
+          { 4, 14, 5, 18 }, -- VALUE 123
+          -- VALUE1 123
         }, get_ranges())
       end)
     end)
@@ -463,22 +463,22 @@ int x = INT_MAX;
         eq(5, exec_lua('return #parser:children().c:trees()'))
         eq({
           { 0, 0, 7, 0 }, -- root tree
+          { 1, 26, 1, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
+          { 2, 29, 2, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
           { 3, 14, 3, 17 }, -- VALUE 123
           { 4, 15, 4, 18 }, -- VALUE1 123
           { 5, 15, 5, 18 }, -- VALUE2 123
-          { 1, 26, 1, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
-          { 2, 29, 2, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
         }, get_ranges())
 
         n.feed('ggo<esc>')
         eq(5, exec_lua('return #parser:children().c:trees()'))
         eq({
           { 0, 0, 8, 0 }, -- root tree
+          { 2, 26, 2, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
+          { 3, 29, 3, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
           { 4, 14, 4, 17 }, -- VALUE 123
           { 5, 15, 5, 18 }, -- VALUE1 123
           { 6, 15, 6, 18 }, -- VALUE2 123
-          { 2, 26, 2, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
-          { 3, 29, 3, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
         }, get_ranges())
       end)
     end)
@@ -500,11 +500,11 @@ int x = INT_MAX;
         eq('table', exec_lua('return type(parser:children().c)'))
         eq({
           { 0, 0, 7, 0 }, -- root tree
+          { 1, 26, 1, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
+          { 2, 29, 2, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
           { 3, 16, 3, 16 }, -- VALUE 123
           { 4, 17, 4, 17 }, -- VALUE1 123
           { 5, 17, 5, 17 }, -- VALUE2 123
-          { 1, 26, 1, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
-          { 2, 29, 2, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
         }, get_ranges())
       end)
       it('should list all directives', function()


### PR DESCRIPTION
### Problem

Some injections need multiple ranges of nodes to capture all content. But they are not "combined", because they have a defined scope, e.g. their common parent node.
For example, template strings in JavaScript consist of multiple `string_fragment` and `template_substitution` nodes (in any order). An injection only needs to parse string fragments, and not substitutions, since e.g. this file:

```js
html`
<div ${1 > 2} some-attr="</div>"></div>
<div attr="some ${1 > 2} more text"></div>
`
```

gets highlighted like this:
![image](https://github.com/user-attachments/assets/60e5ebb4-96cd-4055-b536-d5c1fdacc9a3)

Because:

1. Template substitutions might confuse the parser. Line 2 is incorrect because the HTML parser thinks that JavaScript `>` is closing the `<div>`

2. Child injections may obscure the template substitutions. Line 3 is incorrect because there is a special injection in html that tries to fix that by interpreting the value of the argument as javascript if it looks like a template substitution, but it doesn't work if the substitution is not the entire argument ([see injection](https://github.com/nvim-treesitter/nvim-treesitter/blob/7e0fcf0d456fc5818da1af35b1a3f5c784fce457/queries/html_tags/injections.scm#L57)).

### Solution

Add special "scoped" injections, which allow multiple matches to contribute to the same injection region, but that are scoped by an `@injection.root` node.

Result:
![image](https://github.com/user-attachments/assets/50cbc0e6-18a3-46f1-9b62-d6f2e0de6675)

There can still be incorrect highlighting, since highlight ranges (and node text in the predicate?) are not clamped to the tree region. See: https://github.com/neovim/neovim/pull/26827#issuecomment-2560245776

### Running locally

Requires modifying nvim-treesitter queries, so I used the `minimal.lua` from the issue template:

<details>

patch.diff:
```diff
diff --git a/queries/ecma/injections.scm b/queries/ecma/injections.scm
index 04abafc..2c4dca2 100644
--- a/queries/ecma/injections.scm
+++ b/queries/ecma/injections.scm
@@ -10,12 +10,12 @@
   function: (identifier) @injection.language
   arguments: [
     (arguments
-      (template_string) @injection.content)
-    (template_string) @injection.content
+      (template_string (string_fragment) @injection.content) @injection.root)
+    (template_string (string_fragment) @injection.content) @injection.root
   ]
   (#lua-match? @injection.language "^[a-zA-Z][a-zA-Z0-9]*$")
-  (#offset! @injection.content 0 1 0 -1)
   (#set! injection.include-children)
+  (#set! injection.scoped)
   ; Languages excluded from auto-injection due to special rules
   ; - svg uses the html parser
   ; - css uses the styled parser
diff --git a/queries/html_tags/injections.scm b/queries/html_tags/injections.scm
index 5b78e37..cf39f79 100644
--- a/queries/html_tags/injections.scm
+++ b/queries/html_tags/injections.scm
@@ -51,22 +51,6 @@
   (#eq? @_attr "style")
   (#set! injection.language "css"))
 
-; lit-html style template interpolation
-; <a @click=${e => console.log(e)}>
-; <a @click="${e => console.log(e)}">
-((attribute
-  (quoted_attribute_value
-    (attribute_value) @injection.content))
-  (#lua-match? @injection.content "%${")
-  (#offset! @injection.content 0 2 0 -1)
-  (#set! injection.language "javascript"))
-
-((attribute
-  (attribute_value) @injection.content)
-  (#lua-match? @injection.content "%${")
-  (#offset! @injection.content 0 2 0 -2)
-  (#set! injection.language "javascript"))
-
 ; <input pattern="[0-9]"> or <input pattern=[0-9]>
 (element
   (_
```

minimal.lua:
```lua
-- nvim_treesitter commit is 7e0fcf0d456fc5818da1af35b1a3f5c784fce457
for name, url in pairs {
  nvim_treesitter = 'https://github.com/nvim-treesitter/nvim-treesitter.git',
  'https://github.com/rose-pine/neovim.git'
} do
  local install_path = vim.fn.fnamemodify('nvim_issue/' .. name, ':p')
  if vim.fn.isdirectory(install_path) == 0 then
    vim.fn.system { 'git', 'clone', '--depth=1', url, install_path }
  end
  vim.opt.runtimepath:append(install_path)
end

require'nvim-treesitter.configs'.setup {
  sync_install = true,
  ensure_installed = { "javascript", "html" },
  highlight = { enable = true },
}

vim.cmd[[!cd ./nvim_issue/nvim_treesitter && git apply ../../patch.diff]]

require'rose-pine'.setup{
  variant = 'main',
  styles = {
    bold = false,
    italic = false,
    transparency = false,
  },
}

vim.cmd('colorscheme rose-pine')

vim.api.nvim_buf_set_lines(0, 0, -1, true, {
  [[html`]],
  [[<div ${1 > 2} some-attr="</div>"></div>]],
  [[<div attr="some ${1 > 2} more text"></div>]],
  [[`]],
})
vim.treesitter.start(0, 'javascript')
```

(patch and minimal in the same directory).

```shell
nvim --clean -u minimal.lua
```

</details>