### PR TITLE
feat: normalize path after joining

### DIFF
--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -112,7 +112,7 @@ end
 ---@param ... string
 ---@return string
 function M.joinpath(...)
-  return (table.concat({ ... }, '/'):gsub('//+', '/'))
+  return M.normalize((table.concat({ ... }, '/'):gsub('//+', '/')))
 end
 
 ---@alias Iterator fun(): string?, string?


### PR DESCRIPTION
## Description
Hello!

I have been working with neovim a while when developing this plugin [easy-dotnet.nvim](https://github.com/GustavEikaas/easy-dotnet.nvim). Given the nature of this plugin there is quite a lot of work in resolving paths. Pretty often I read a file, get a partial path and then have to concatenate two parts of a path together. For this I use `vim.fs.joinpath`. The luadoc for the function reads as follows 
```lua
--- Concatenate directories and/or file paths into a single path with normalization
--- (e.g., `"foo/"` and `"bar"` get joined to `"foo/bar"`)
```
One thing I noticed after a while is that the "normalization" it refers to only applies between the parts being concatenated. It does not impact the parts being joined together. This resulted in me having to always `vim.fs.normalize` around the paths after joining. This would ensure clean and fully compatible paths. 

I wouldnt consider `vim.fs.joinpath` to be buggy, but the word quirky comes to mind. There might be good reasons for not applying normalization to the entire path (not that I can think of any). But if there is can we update the luadoc with more examples to fully capture the behaviour? 

## Suggestion
My suggested fix is for `vim.fs.joinpath` to normalize the entire path after the operation. I cant see any consequence in doing this.

### Before
```lua
vim.fs.joinpath("C:\\Users\\Vim\\",  "btw")
-- Output
-- "C:\Users\Vim\/btw"
```
### After
```lua
vim.fs.joinpath("C:\\Users\\Vim\\",  "btw")
-- Output
-- "C:/Users/Vim/btw"
```

### Considerations
- Why would anyone want mixed separators in their paths?
- How can anyone rely on mixed separators in their paths? (breaking change argument)
- Is there a performance cost worth considering? (no)

Any input would be greatly appreciated!
