### PR TITLE
feat: windows normalize path after vim.fs.joinpath

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3062,8 +3062,11 @@ vim.fs.find({names}, {opts})                                   *vim.fs.find()*
         items
 
 vim.fs.joinpath({...})                                     *vim.fs.joinpath()*
-    Concatenate directories and/or file paths into a single path with
-    normalization (e.g., `"foo/"` and `"bar"` get joined to `"foo/bar"`)
+    Concatenates partial paths into one path. Slashes are normalized
+    (redundant slashes are removed, and on Windows backslashes are replaced
+    with forward-slashes) (e.g., `"foo/"` and `"/bar"` get joined to
+    `"foo/bar"`) (windows: e.g `"a\foo\"` and `"\bar"` are joined to
+    `"a/foo/bar"`)
 
     Attributes: ~
         Since: 0.10.0

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -105,14 +105,19 @@ function M.basename(file)
   return file:match('/$') and '' or (file:match('[^/]*$'))
 end
 
---- Concatenate directories and/or file paths into a single path with normalization
---- (e.g., `"foo/"` and `"bar"` get joined to `"foo/bar"`)
+--- Concatenates partial paths into one path. Slashes are normalized (redundant slashes are removed, and on Windows backslashes are replaced with forward-slashes)
+--- (e.g., `"foo/"` and `"/bar"` get joined to `"foo/bar"`)
+--- (windows: e.g `"a\foo\"` and `"\bar"` are joined to `"a/foo/bar"`)
 ---
 ---@since 12
 ---@param ... string
 ---@return string
 function M.joinpath(...)
-  return (table.concat({ ... }, '/'):gsub('//+', '/'))
+  local path = table.concat({ ... }, '/')
+  if iswin then
+    path = path:gsub('\\', '/')
+  end
+  return (path:gsub('//+', '/'))
 end
 
 ---@alias Iterator fun(): string?, string?

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -323,6 +323,20 @@ describe('vim.fs', function()
       eq('foo/bar/baz', vim.fs.joinpath('foo', 'bar', 'baz'))
       eq('foo/bar/baz', vim.fs.joinpath('foo', '/bar/', '/baz'))
     end)
+    it('rewrites backslashes on Windows', function()
+      if is_os('win') then
+        eq('foo/bar/baz/zub/', vim.fs.joinpath([[foo]], [[\\bar\\\\baz]], [[zub\]]))
+      else
+        eq([[foo/\\bar\\\\baz/zub\]], vim.fs.joinpath([[foo]], [[\\bar\\\\baz]], [[zub\]]))
+      end
+    end)
+    it('strips redundant slashes', function()
+      if is_os('win') then
+        eq('foo/bar/baz/zub/', vim.fs.joinpath([[foo//]], [[\\bar\\\\baz]], [[zub\]]))
+      else
+        eq('foo/bar/baz/zub/', vim.fs.joinpath([[foo]], [[//bar////baz]], [[zub/]]))
+      end
+    end)
   end)
 
   describe('normalize()', function()


### PR DESCRIPTION
## Description
Hello!

I have been working with neovim a while when developing this plugin [easy-dotnet.nvim](https://github.com/GustavEikaas/easy-dotnet.nvim). Given the nature of this plugin there is quite a lot of work in resolving paths. Pretty often I read a file, get a partial path and then have to concatenate two parts of a path together. For this I use `vim.fs.joinpath`. The luadoc for the function reads as follows 
```lua
--- Concatenate directories and/or file paths into a single path with normalization
--- (e.g., `"foo/"` and `"bar"` get joined to `"foo/bar"`)
```
One thing I noticed after a while is that the "normalization" it refers to only applies between the parts being concatenated. It does not impact the parts being joined together. This resulted in me having to always `vim.fs.normalize` around the paths after joining. This would ensure clean and fully compatible paths. 

I wouldnt consider `vim.fs.joinpath` to be buggy, but the word quirky comes to mind. There might be good reasons for not applying normalization to the entire path (not that I can think of any). But if there is can we update the luadoc with more examples to fully capture the behaviour? Whats also interesting to note is that `:gsub('//+', '/')` strips out duplicate `/` but pays no attention to `\`

## Examples of this behaviour in the wild 
- [#160 easy-dotnet.nvim](https://github.com/GustavEikaas/easy-dotnet.nvim/pull/160/files#diff-387a51eeb83581adeff4281e9238e7e91cdd1615c6c19d2d84a87cec5d27b151R158)
- [#149 easy-dotnet.nvim](https://github.com/GustavEikaas/easy-dotnet.nvim/pull/149/files#diff-3a973d76d2eb1ec0b2252e59200543785e714d8cb33b34e2fc3f5cf5864e6800R6)
- [#110 easy-dotnet.nvim](https://github.com/GustavEikaas/easy-dotnet.nvim/pull/110/files#diff-17054b1b101af4c8f772007883695f3583bb3c409bcfc77b162306c7a8020656R7)
- [roslyn.nvim](https://github.com/seblj/roslyn.nvim/blob/47d97e0a3f81b778409e742877b8b03fdf6c762d/lua/roslyn/sln/utils.lua#L15-L16)


## Suggestion
My suggested fix is for `vim.fs.joinpath` to normalize the entire path after the operation. I cant see any consequence in doing this.

### Before
```lua
vim.fs.joinpath("C:\\Users\\Vim\\",  "btw")
-- Output
-- "C:\Users\Vim\/btw"
```
### After
```lua
vim.fs.joinpath("C:\\Users\\Vim\\",  "btw")
-- Output
-- "C:/Users/Vim/btw"
```

### Considerations
- Why would anyone want mixed separators in their paths?
- How can anyone rely on mixed separators in their paths? (breaking change argument)
- Is there a performance cost worth considering? (no)

I couldnt find any existing issue on this
I will fix the failing tests if this functionality is wanted
Any input would be greatly appreciated!
