### PR TITLE
fix: multigrid screenstring()/getmousepos()

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6426,11 +6426,7 @@ static void screenchar_adjust(ScreenGrid **grid, int *row, int *col)
   // have its own buffer, this should just read from it instead.
   msg_scroll_flush();
 
-  *grid = ui_comp_get_grid_at_coord(*row, *col);
-
-  // Make `row` and `col` relative to the grid
-  *row -= (*grid)->comp_row;
-  *col -= (*grid)->comp_col;
+  *grid = ui_comp_get_grid_at_coord(row, col);
 }
 
 /// "screenattr()" function

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -1912,6 +1912,8 @@ void f_getmousepos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   int col = mouse_col;
   int grid = mouse_grid;
   varnumber_T winid = 0;
+  varnumber_T screenrow = row + 1;
+  varnumber_T screencol = col + 1;
   varnumber_T winrow = 0;
   varnumber_T wincol = 0;
   linenr_T lnum = 0;
@@ -1920,11 +1922,8 @@ void f_getmousepos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
   tv_dict_alloc_ret(rettv);
   dict_T *d = rettv->vval.v_dict;
-
-  tv_dict_add_nr(d, S_LEN("screenrow"), (varnumber_T)mouse_row + 1);
-  tv_dict_add_nr(d, S_LEN("screencol"), (varnumber_T)mouse_col + 1);
-
   win_T *wp = mouse_find_win(&grid, &row, &col);
+
   if (wp != NULL) {
     int height = wp->w_height + wp->w_hsep_height + wp->w_status_height;
     // The height is adjusted by 1 when there is a bottom border. This is not
@@ -1939,8 +1938,14 @@ void f_getmousepos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
         column = col + 1;
       }
     }
+    if (mouse_grid > 0) {
+      screenrow += wp->w_winrow;
+      screencol += wp->w_wincol;
+    }
   }
   tv_dict_add_nr(d, S_LEN("winid"), winid);
+  tv_dict_add_nr(d, S_LEN("screenrow"), screenrow);
+  tv_dict_add_nr(d, S_LEN("screencol"), screencol);
   tv_dict_add_nr(d, S_LEN("winrow"), winrow);
   tv_dict_add_nr(d, S_LEN("wincol"), wincol);
   tv_dict_add_nr(d, S_LEN("line"), (varnumber_T)lnum);

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -314,13 +314,28 @@ ScreenGrid *ui_comp_mouse_focus(int row, int col)
 }
 
 /// Compute which grid is on top at supplied screen coordinates
-ScreenGrid *ui_comp_get_grid_at_coord(int row, int col)
+ScreenGrid *ui_comp_get_grid_at_coord(int *row, int *col)
 {
-  for (ssize_t i = (ssize_t)kv_size(layers) - 1; i > 0; i--) {
-    ScreenGrid *grid = kv_A(layers, i);
-    if (row >= grid->comp_row && row < grid->comp_row + grid->rows
-        && col >= grid->comp_col && col < grid->comp_col + grid->cols) {
-      return grid;
+  if (ui_has(kUIMultigrid)) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+      ScreenGrid *grid = &wp->w_grid_alloc;
+      if (wp && grid && !grid->comp_disabled
+          && *row >= wp->w_winrow && *row < wp->w_winrow + wp->w_height
+          && *col >= wp->w_wincol && *col < wp->w_wincol + wp->w_width) {
+        *row -= wp->w_winrow;
+        *col -= wp->w_wincol;
+        return grid;
+      }
+    }
+  } else {
+    for (ssize_t i = (ssize_t)kv_size(layers) - 1; i > 0; i--) {
+      ScreenGrid *grid = kv_A(layers, i);
+      if (*row >= grid->comp_row && *row < grid->comp_row + grid->rows
+          && *col >= grid->comp_col && *col < grid->comp_col + grid->cols) {
+        *row -= grid->comp_row;
+        *col -= grid->comp_col;
+        return grid;
+      }
     }
   }
   return &default_grid;

--- a/test/functional/ui/multigrid_spec.lua
+++ b/test/functional/ui/multigrid_spec.lua
@@ -1184,6 +1184,7 @@ describe('ext_multigrid', function()
       it, ^sed do eiusmo                                    |
       {1:~                                                    }|*4
     ]]}
+    eq({screencol = 5, coladd = 0, screenrow = 2, column = 58, winrow = 2, line = 1, wincol = 5, winid = 1001}, fn.getmousepos())
 
     screen:try_resize_grid(4, 80, 2)
     screen:expect{grid=[[
@@ -1708,6 +1709,39 @@ describe('ext_multigrid', function()
       {1:~                             }|*3
     ]]}
     eq('eiusmo', fn.getreg('"'))
+  end)
+
+  it('getmousepos() screenstring() return collect value', function()
+    command('set mouse=a')
+    insert('abcd\nefgh')
+    command('vnew')
+    insert('ijkl\nmnop')
+    command('new')
+    insert('qrst\nuvwx')
+
+    api.nvim_input_mouse('left', 'press', '', 1, 1, 0)
+    eq({screencol = 1, coladd = 0, screenrow = 2, column = 1, winrow = 2, line = 2, wincol = 1, winid = 1002}, fn.getmousepos())
+
+    api.nvim_input_mouse('left', 'press', '', 2, 0, 1)
+    eq({screencol = 29, coladd = 0, screenrow = 1, column = 2, winrow = 1, line = 1, wincol = 2, winid = 1000}, fn.getmousepos())
+
+    api.nvim_input_mouse('left', 'press', '', 4, 0, 1)
+    eq({screencol = 2, coladd = 0, screenrow = 8, column = 2, winrow = 1, line = 1, wincol = 2, winid = 1001}, fn.getmousepos())
+
+    api.nvim_input_mouse('left', 'press', '', 5, 0, 1)
+    eq({screencol = 2, coladd = 0, screenrow = 1, column = 2, winrow = 1, line = 1, wincol = 2, winid = 1002}, fn.getmousepos())
+
+    eq('q', fn.screenstring(1, 1))
+    eq('t', fn.screenstring(1, 4))
+    eq('u', fn.screenstring(2, 1))
+
+    eq('i', fn.screenstring(8, 1))
+    eq('l', fn.screenstring(8, 4))
+    eq('m', fn.screenstring(9, 1))
+
+    eq('a', fn.screenstring(1, 28))
+    eq('d', fn.screenstring(1, 31))
+    eq('e', fn.screenstring(2, 28))
   end)
 
   it('supports mouse drag with mouse=a', function()


### PR DESCRIPTION
fix #29135

`getmousepos()` and `screenstring()` to return proper values on `ext_multigrid` enabled.