### PR TITLE
docs: Drop `--beta` since this channel isn't available anymore on snap store

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -302,7 +302,7 @@ Neovim nightly and stable are available on the [snap store](https://snapcraft.io
 **Stable Builds**
 
 ```sh
-sudo snap install --beta nvim --classic
+sudo snap install nvim --classic
 ```
 
 **Nightly Builds**


### PR DESCRIPTION
Since now the `neovim` snap `nvim` is only available on `stable` and `edge` and for `stable` there is no need to specify the channel since it's the default one that snap command line utility will try to install from.