### PR TITLE
feat: add vim.fs.relpath

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3148,6 +3148,23 @@ vim.fs.parents({start})                                     *vim.fs.parents()*
         (`nil`)
         (`string?`)
 
+vim.fs.relpath({base}, {target}, {opts})                    *vim.fs.relpath()*
+    Gets `target` path relative to `base`, or `nil` if `base` is not an
+    ancestor.
+
+    Example: >lua
+        vim.fs.relpath('/var', '/var/lib') -- 'lib'
+        vim.fs.relpath('/var', '/usr/bin') -- nil
+<
+
+    Parameters: ~
+      • {base}    (`string`)
+      • {target}  (`string`)
+      • {opts}    (`table?`) Reserved for future use
+
+    Return: ~
+        (`string?`)
+
 vim.fs.rm({path}, {opts})                                        *vim.fs.rm()*
     WARNING: This feature is experimental/unstable.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -277,6 +277,7 @@ LUA
   supporting two new parameters, `encoding` and `strict_indexing`.
 • |vim.json.encode()| has an option to enable forward slash escaping
 • |vim.fs.abspath()| converts paths to absolute paths.
+• |vim.fs.relpath()| gets relative path compared to base path.
 
 OPTIONS
 

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -741,4 +741,37 @@ function M.abspath(path)
   return M.joinpath(cwd, path)
 end
 
+--- Gets `target` path relative to `base`, or `nil` if `base` is not an ancestor.
+---
+--- Example:
+---
+--- ```lua
+--- vim.fs.relpath('/var', '/var/lib') -- 'lib'
+--- vim.fs.relpath('/var', '/usr/bin') -- nil
+--- ```
+---
+--- @param base string
+--- @param target string
+--- @param opts table? Reserved for future use
+--- @return string|nil
+function M.relpath(base, target, opts)
+  vim.validate('base', base, 'string')
+  vim.validate('target', target, 'string')
+  vim.validate('opts', opts, 'table', true)
+
+  base = vim.fs.normalize(vim.fs.abspath(base))
+  target = vim.fs.normalize(vim.fs.abspath(target))
+  if base == target then
+    return '.'
+  end
+
+  local prefix = ''
+  if iswin then
+    prefix, base = split_windows_path(base)
+  end
+  base = prefix .. base .. (base ~= '/' and '/' or '')
+
+  return vim.startswith(target, base) and target:sub(#base + 1) or nil
+end
+
 return M

--- a/test/testutil.lua
+++ b/test/testutil.lua
@@ -22,13 +22,6 @@ local M = {
   paths = Paths,
 }
 
---- @param p string
---- @return string
-local function relpath(p)
-  p = vim.fs.normalize(p)
-  return (p:gsub('^' .. uv.cwd, ''))
-end
-
 --- @param path string
 --- @return boolean
 function M.isdir(path)
@@ -45,14 +38,15 @@ end
 --- (Only on Windows) Replaces yucky "\\" slashes with delicious "/" slashes in a string, or all
 --- string values in a table (recursively).
 ---
---- @param obj string|table
---- @return any
+--- @generic T: string|table
+--- @param obj T
+--- @return T|nil
 function M.fix_slashes(obj)
   if not M.is_os('win') then
     return obj
   end
   if type(obj) == 'string' then
-    local ret = obj:gsub('\\', '/')
+    local ret = string.gsub(obj, '\\', '/')
     return ret
   elseif type(obj) == 'table' then
     --- @cast obj table<any,any>
@@ -482,7 +476,8 @@ function M.check_cores(app, force) -- luacheck: ignore
   -- "./Xtest-tmpdir/" => "Xtest%-tmpdir"
   local local_tmpdir = nil
   if tmpdir_is_local and tmpdir then
-    local_tmpdir = vim.pesc(relpath(tmpdir):gsub('^[ ./]+', ''):gsub('%/+$', ''))
+    local_tmpdir =
+      vim.pesc(vim.fs.relpath(assert(vim.uv.cwd()), tmpdir):gsub('^[ ./]+', ''):gsub('%/+$', ''))
   end
 
   local db_cmd --- @type string


### PR DESCRIPTION
This is needed to replace the nvim-lspconfig function is_descendant that
some lspconfg configurations still use.
