### PR TITLE
vim-patch:9.1.0981: tests: typo in test_filetype.vim

### DIFF
--- a/runtime/syntax/lnkmap.vim
+++ b/runtime/syntax/lnkmap.vim
@@ -2,7 +2,7 @@
 " Language:	TI Linker map
 " Document:	https://downloads.ti.com/docs/esd/SPRUI03A/Content/SPRUI03A_HTML/linker_description.html
 " Maintainer:	Wu, Zhenyu <wuzhenyu@ustc.edu>
-" Last Change:	2024 Dec 25
+" Last Change:	2024 Dec 30
 
 if exists("b:current_syntax")
   finish
@@ -19,7 +19,7 @@ syn match lnkmapFile			'[^ =]\+\%(\.\S\+\)\+\>'
 syn match lnkmapLibFile			'[^ =]\+\.lib\>'
 syn match lnkmapAttrib			'\<[RWIX]\+\>'
 syn match lnkmapAttrib			'\s\zs--HOLE--\ze\%\(\s\|$\)'
-syn keyword lnkmapAttrib		UNINITIALIZED
+syn keyword lnkmapAttrib		UNINITIALIZED DESCT
 
 
 hi def link lnkmapTime			Comment

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -2773,7 +2773,7 @@ func Test_map_file()
   call assert_equal('lnkmap', &filetype)
   bwipe!
 
-  " TI linker map file
+  " UMN mapserver config file
   call writefile(['MAP', 'NAME "local-demo"', 'END'], 'Xfile.map', 'D')
   split Xfile.map
   call assert_equal('map', &filetype)


### PR DESCRIPTION
#### vim-patch:9.1.0981: tests: typo in test_filetype.vim

Problem:  tests: typo in test_filetype.vim
Solution: fix comment, update lnkmap syntax file and add
          DESCT keyword
          (Wu, Zhenyu)

closes: vim/vim#16348

https://github.com/vim/vim/commit/2bee7e43e137bcef62e6872791e2be7ce9c32703

Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>