### PR TITLE
vim-patch:8dc98bf: runtime(chordpro): update syntax script

### DIFF
--- a/runtime/syntax/chordpro.vim
+++ b/runtime/syntax/chordpro.vim
@@ -2,6 +2,7 @@
 " Language:     ChordPro 6 (https://www.chordpro.org)
 " Maintainer:   Niels Bo Andersen <niels@niboan.dk>
 " Last Change:  2022-04-15
+" 2024 Dec 31:  add "keys" as syntax keyword (via: https://groups.google.com/g/vim_dev/c/vP4epus0euM/m/mNoDY6hsCQAJ)
 
 " Quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -104,7 +105,7 @@ syn match chordproStandardMetadata /instrument\.description/ contained
 syn match chordproStandardMetadata /user\.name/ contained
 syn match chordproStandardMetadata /user\.fullname/ contained
 
-syn keyword chordproDefineKeyword contained frets fingers
+syn keyword chordproDefineKeyword contained frets fingers keys
 syn match chordproDefineKeyword /base-fret/ contained
 
 syn match chordproArgumentsNumber /\d\+/ contained


### PR DESCRIPTION
References:
https://chordpro.org/beta/directives-define/#defining-chords-for-keyboard-instruments

https://github.com/vim/vim/commit/8dc98bf427d62501d9ecbb48d20ae2633c3db187

Co-authored-by: nibo <nibo@relim.de>
