### PR TITLE
build: Fix RelWithDebInfo optimization flags

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -149,11 +149,6 @@ set(NVIM_API_LEVEL 13)        # Bump this after any API/stdlib change.
 set(NVIM_API_LEVEL_COMPAT 0)  # Adjust this after a _breaking_ API change.
 set(NVIM_API_PRERELEASE true)
 
-# Build-type: RelWithDebInfo
-# /Og means something different in MSVC
-if(CMAKE_C_COMPILER_ID MATCHES "GNU" OR CMAKE_C_COMPILER_ID MATCHES "Clang")
-   set(CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO} -Og -g")
-endif()
 # We _want_ assertions in RelWithDebInfo build-type.
 if(CMAKE_C_FLAGS_RELWITHDEBINFO MATCHES DNDEBUG)
   string(REPLACE "-DNDEBUG" "" CMAKE_C_FLAGS_RELWITHDEBINFO "${CMAKE_C_FLAGS_RELWITHDEBINFO}")

--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,7 +10,7 @@
     {
       "name": "default",
       "displayName": "RelWithDebInfo",
-      "description": "Enables optimizations (-Og or -O2) with debug information",
+      "description": "Enables optimizations (-O2) with debug information",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       },

--- a/contrib/local.mk.example
+++ b/contrib/local.mk.example
@@ -14,7 +14,7 @@
 #
 # - Debug:          Disables optimizations (-O0), enables debug information.
 #
-# - RelWithDebInfo: Enables optimizations (-Og or -O2) with debug information.
+# - RelWithDebInfo: Enables optimizations (-O2) with debug information.
 #
 # - MinSizeRel:     Enables all -O2 optimization that do not typically
 #                   increase code size, and performs further optimizations


### PR DESCRIPTION

The RelWithDebInfo build type was using redundant optimization flags.
Before this PR, RelWithDebInfo builds generated by redundant flags like this:

```
Compilation: /usr/bin/cc -O2 -g -Og -g
```

this PR fix this:

```
Compilation: /usr/bin/cc -O2 -g
```

# Motivation

The `CMAKE_C_FLAGS_RELWITHDEBINFO` variable was being modified in a way that caused duplicate `-Og` and `-g` flags to be added. The resulting flags were `-O2 -g -Og -g`.

*   `-Og` (Optimize for debugging) and `-O2` (Optimize for performance) are different optimization levels. We can't use both at once.
*   The duplicate `-g` flag is redundant and no effect.

multiple -O flags has no effect for code, just redundant.

> If you use multiple -O options, with or without level numbers, the last such option is the one that is effective.

https://gcc.gnu.org/onlinedocs/gcc/Optimize-Options.html

### Before this PR

```
:verbose version
NVIM v0.11.0-dev-1443+ge00cd1ab40
Build type: RelWithDebInfo
LuaJIT 2.1.1734355927
Compilation: /usr/bin/cc -O2 -g -Og -g -flto -fno-fat-lto-ob
jects -Wall -Wextra -pedantic -Wno-unused-parameter -Wstrict
-prototypes -std=gnu99 -Wshadow -Wconversion -Wvla -Wdouble-
promotion -Wmissing-noreturn -Wmissing-format-attribute -Wmi
ssing-prototypes -fsigned-char -fstack-protector-strong -Wno
-conversion -fno-common -Wno-unused-result -Wimplicit-fallth
rough -fdiagnostics-color=always  -DUNIT_TESTING -D_GNU_SOUR
CE -DINCLUDE_GENERATED_DECLARATIONS -DUTF8PROC_STATIC -I/hom
e/sys9kdr/workspace/neovim/.deps/usr/include/luajit-2.1 -I/h
ome/sys9kdr/workspace/neovim/.deps/usr/include -I/home/sys9k
dr/workspace/neovim/build/src/nvim/auto -I/home/sys9kdr/work
space/neovim/build/include -I/home/sys9kdr/workspace/neovim/
build/cmake.config -I/home/sys9kdr/workspace/neovim/src -I/u
sr/include

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/usr/local/share/nvim"
```

### After this PR

```
:verbose version
NVIM v0.11.0-dev-e00cd1ab4-dirty
Build type: RelWithDebInfo
LuaJIT 2.1.1734355927
Compilation: /usr/bin/cc -O2 -g -flto -fno-fat-lto-objects -
Wall -Wextra -pedantic -Wno-unused-parameter -Wstrict-protot
ypes -std=gnu99 -Wshadow -Wconversion -Wvla -Wdouble-promoti
on -Wmissing-noreturn -Wmissing-format-attribute -Wmissing-p
rototypes -fsigned-char -fstack-protector-strong -Wno-conver
sion -fno-common -Wno-unused-result -Wimplicit-fallthrough -
fdiagnostics-color=always  -DUNIT_TESTING -D_GNU_SOURCE -DIN
CLUDE_GENERATED_DECLARATIONS -DUTF8PROC_STATIC -I/home/sys9k
dr/workspace/neovim-fork/.deps/usr/include/luajit-2.1 -I/hom
e/sys9kdr/workspace/neovim-fork/.deps/usr/include -I/home/sy
s9kdr/workspace/neovim-fork/build/src/nvim/auto -I/home/sys9
kdr/workspace/neovim-fork/build/include -I/home/sys9kdr/work
space/neovim-fork/build/cmake.config -I/home/sys9kdr/workspa
ce/neovim-fork/src -I/usr/include

   system vimrc file: "$VIM/sysinit.vim"
  fall-back for $VIM: "/usr/local/share/nvim"

Run :checkhealth for more info
```
