### PR TITLE
fix(treesitter): injections highlighting order

### DIFF
--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -251,6 +251,7 @@ error('Cannot require a meta file')
 --- @field invalidate? boolean
 --- @field ephemeral? boolean
 --- @field priority? integer
+--- @field subpriority? integer
 --- @field right_gravity? boolean
 --- @field end_right_gravity? boolean
 --- @field virt_lines? any[]

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -203,11 +203,11 @@ function TSHighlighter:prepare_highlight_states(srow, erow)
   end)
 end
 
----@param fn fun(state: vim.treesitter.highlighter.State)
+---@param fn fun(state: vim.treesitter.highlighter.State, index: number)
 ---@package
 function TSHighlighter:for_each_highlight_state(fn)
-  for _, state in ipairs(self._highlight_states) do
-    fn(state)
+  for i, state in ipairs(self._highlight_states) do
+    fn(state, i)
   end
 end
 
@@ -281,7 +281,7 @@ end
 ---@param line integer
 ---@param is_spell_nav boolean
 local function on_line_impl(self, buf, line, is_spell_nav)
-  self:for_each_highlight_state(function(state)
+  self:for_each_highlight_state(function(state, state_i)
     local root_node = state.tstree:root()
     local root_start_row, _, root_end_row, _ = root_node:range()
 
@@ -333,6 +333,7 @@ local function on_line_impl(self, buf, line, is_spell_nav)
             hl_group = hl,
             ephemeral = true,
             priority = priority,
+            subpriority = state_i,
             conceal = conceal,
             spell = spell,
             url = url,

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -203,7 +203,7 @@ function TSHighlighter:prepare_highlight_states(srow, erow)
   end)
 end
 
----@param fn fun(state: vim.treesitter.highlighter.State, index: number)
+---@param fn fun(state: vim.treesitter.highlighter.State, index: integer)
 ---@package
 function TSHighlighter:for_each_highlight_state(fn)
   for i, state in ipairs(self._highlight_states) do

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -658,6 +658,14 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     virt_lines.priority = (DecorPriority)opts->priority;
   }
 
+  uint16_t subpriority = 0;
+  if (HAS_KEY(opts, set_extmark, subpriority)) {
+    VALIDATE_RANGE((opts->subpriority >= 0 && opts->subpriority <= UINT16_MAX), "priority", {
+      goto error;
+    });
+    subpriority = (uint16_t)opts->subpriority;
+  }
+
   if (HAS_KEY(opts, set_extmark, sign_text)) {
     sign.text[0] = 0;
     VALIDATE_S(init_sign_text(NULL, sign.text, opts->sign_text.data), "sign_text", "", {
@@ -751,15 +759,18 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     }
 
     if (kv_size(virt_text.data.virt_text)) {
-      decor_range_add_virt(&decor_state, r, c, line2, col2, decor_put_vt(virt_text, NULL), true);
+      decor_range_add_virt(&decor_state, r, c, line2, col2,
+                           decor_put_vt(virt_text, NULL), subpriority, true);
     }
     if (kv_size(virt_lines.data.virt_lines)) {
-      decor_range_add_virt(&decor_state, r, c, line2, col2, decor_put_vt(virt_lines, NULL), true);
+      decor_range_add_virt(&decor_state, r, c, line2, col2,
+                           decor_put_vt(virt_lines, NULL), subpriority, true);
     }
     if (has_hl) {
       DecorSignHighlight sh = decor_sh_from_inline(hl);
       sh.url = url;
-      decor_range_add_sh(&decor_state, r, c, line2, col2, &sh, true, (uint32_t)ns_id, id);
+      decor_range_add_sh(&decor_state, r, c, line2, col2,
+                         &sh, subpriority, true, (uint32_t)ns_id, id);
     }
   } else {
     if (opts->ephemeral) {

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -39,6 +39,7 @@ typedef struct {
   Boolean invalidate;
   Boolean ephemeral;
   Integer priority;
+  Integer subpriority;
   Boolean right_gravity;
   Boolean end_right_gravity;
   Array virt_lines;

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -36,10 +36,9 @@ typedef struct {
   int start_col;
   int end_row;
   int end_col;
-  int ordering;  ///< range insertion order
-  DecorPriority priority;
   bool owned;  ///< ephemeral decoration, free memory immediately
   DecorRangeKind kind;
+  uint64_t priority;  ///< range insertion order, subpriority << 32, hl priority << 48.
   // next pointers MUST NOT be used, these are separate ranges
   // vt->next could be pointing to freelist memory at this point
   union {


### PR DESCRIPTION
### Problem

1. Highlights from injections might get obscured by parent highlights with the same priority. See https://github.com/neovim/neovim/issues/31777
2. Ephemeral and regular extmarks with the same priorities might change the order they appear depending on how they are redrawn. See https://github.com/neovim/neovim/pull/30869#issuecomment-2430570060

### Solution

Add `subpriority` field to `nvim_buf_set_extmarks()` `opts` that allows further control over the order of highlights. 

1 is fixed by drawing each highlight state with a higher subpriority than the previous. Regular `priority` values still work as expected. Subpriority only breaks the ties in favor of child injections.
2 is fixed by making regular extmarks use subpriority of 0 when drawn. The highlighter starts subpriorities from 1, so ephemeral extmarks are always drawn on top of regular extmarks with the same priority. 

Should `subpriority` be documented?

fix https://github.com/neovim/neovim/issues/31777