### PR TITLE
perf(treesitter): don't fetch parser for each fold line

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -284,6 +284,8 @@ PERFORMANCE
   highlighting.
 • LSP diagnostics and inlay hints are de-duplicated (new requests cancel
   inflight requests). This greatly improves performance with slow LSP servers.
+• 10x speedup for |vim.treesitter.foldexpr()| (when no parser exists for the
+  buffer).
 
 PLUGINS
 


### PR DESCRIPTION
**Problem:** The treesitter `foldexpr` calls `get_parser()` for each line in the buffer when calculating folds. This can be incredibly slow for buffers where a parser cannot be found (because the result is not cached), and exponentially more so when the user has many `runtimepath`s.

**Solution:** Only fetch the parser when it is needed; that is, only when initializing fold data for a buffer.

close #27422

---

There was some discussion about this in #30164 and #27422 (which I believe this can supercede). It was kind of determined that users should just not set `vim.treesitter.foldexpr()` for buffers where a parser cannot be found. But this change easily fixes that performance issue, and allows users to just globally set the foldexpr to the treesitter one without a second thought.

For reference, I have this in my config to prevent extremely slow buffer loading:

```lua
create_autocmd('FileType', {
  callback = function(ev)
    local lang = vim.treesitter.language.get_lang(vim.bo[ev.buf].ft) --[[@as string]]
    if
      vim.treesitter.get_parser(ev.buf, lang, { error = false })
      and vim.treesitter.query.get(lang, 'folds')
    then
      vim.wo.foldexpr = 'v:lua.vim.treesitter.foldexpr()'
    end
  end,
})
```

that is not intuitive for the user. Being able to just set the foldexpr globally is a great help.

Effectively, this PR changes the situation from:

- Set the foldexpr globally and be punished when a parser cannot be found for your buffer

to:

- Set the foldexpr globally and if no parser is found, you will incur no performance hit

---

#### Benchmark

When running `nvim --clean +'lua vim.wo.foldmethod="expr"; vim.wo.foldexpr="v:lua.vim.treesitter.foldexpr()"'` on [the big linux file™](https://raw.githubusercontent.com/torvalds/linux/master/drivers/gpu/drm/amd/include/asic_reg/dcn/dcn_3_2_0_sh_mask.h) (renamed to `.txt` to show the case of no parser being found):

<details>
  <summary>Show results</summary>

**Before:**

```
--- Startup times for process: Primary (or UI client) ---

times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.002  000.002: --- NVIM STARTING ---
000.173  000.171: event init
000.313  000.140: early init
000.363  000.050: locale set
000.429  000.065: init first window
001.070  000.641: inits 1
001.078  000.008: window checked
001.133  000.055: parsing arguments
007.866  006.356  006.356: require('vim.shared')
008.317  000.044  000.044: require('vim.inspect')
008.573  000.247  000.247: require('vim._options')
008.581  000.710  000.419: require('vim._editor')
008.582  007.094  000.028: require('vim._init_packages')
008.585  000.359: init lua interpreter
010.109  001.523: nvim_ui_attach
010.543  000.435: nvim_set_client_info
010.546  000.002: --- NVIM STARTED ---

--- Startup times for process: Embedded ---

times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.002  000.002: --- NVIM STARTING ---
000.101  000.099: event init
000.170  000.069: early init
000.208  000.038: locale set
000.239  000.031: init first window
000.725  000.487: inits 1
000.736  000.011: window checked
000.765  000.028: parsing arguments
006.009  004.945  004.945: require('vim.shared')
006.424  000.038  000.038: require('vim.inspect')
006.677  000.245  000.245: require('vim._options')
006.680  000.667  000.385: require('vim._editor')
006.682  005.636  000.024: require('vim._init_packages')
006.684  000.284: init lua interpreter
006.768  000.083: expanding arguments
006.817  000.050: inits 2
007.079  000.261: init highlight
007.081  000.002: waiting for UI
007.288  000.207: done waiting for UI
007.302  000.014: clear screen
007.665  000.042  000.042: require('vim.keymap')
008.203  000.899  000.857: require('vim._defaults')
008.205  000.005: init default mappings & autocommands
008.294  000.038  000.038: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/ftplugin.vim
008.357  000.019  000.019: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/indent.vim
008.363  000.101: sourcing vimrc file(s)
008.528  000.009  000.009: sourcing /nix/store/frnxwjw9lpsycd6qqk974la85426syaa-ghostty-1.0.0/share/nvim/site/ftdetect/ghostty.vim
008.627  000.009  000.009: sourcing /etc/profiles/per-user/whoami/share/nvim/site/ftdetect/ghostty.vim
008.642  000.241  000.222: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/filetype.lua
008.776  000.056  000.056: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/syntax/synload.vim
008.890  000.220  000.164: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/syntax/syntax.vim
012.557  000.378  000.378: sourcing /etc/profiles/per-user/whoami/share/nvim/site/plugin/fzf.vim
012.981  000.121  000.121: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/gzip.vim
015.451  000.154  000.154: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/pack/dist/opt/matchit/plugin/matchit.vim
015.995  002.996  002.841: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/matchit.vim
016.120  000.107  000.107: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/matchparen.vim
016.338  000.203  000.203: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/netrwPlugin.vim
016.401  000.039  000.039: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/rplugin.vim
016.467  000.047  000.047: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/shada.vim
016.507  000.013  000.013: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/spellfile.vim
016.595  000.069  000.069: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/tarPlugin.vim
016.634  000.011  000.011: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/tutor.vim
016.785  000.128  000.128: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/zipPlugin.vim
016.865  000.038  000.038: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/editorconfig.lua
016.928  000.040  000.040: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/man.lua
021.682  004.695  004.695: require('vim.termcap')
021.735  000.040  000.040: require('vim.text')
021.746  004.798  000.063: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/osc52.lua
021.806  000.036  000.036: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/tohtml.lua
021.857  004.009: loading rtp plugins
023.778  001.921: loading packages
023.780  000.002: loading after plugins
023.799  000.019: inits 3
023.806  000.007: reading ShaDa
105.599  001.897  001.897: require('vim.filetype')
106.558  000.793  000.793: require('vim.filetype.detect')
107.209  000.038  000.038: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/ftplugin/text.vim
108.299  000.046  000.046: require('vim.F')
108.485  000.180  000.180: require('editorconfig')
108.750  000.261  000.261: require('vim.fs')
109.293  082.270: opening buffers
109.321  000.028: BufEnter autocommands
109.326  000.005: editing files in windows
109.348  000.023: executing command arguments
110.671  000.080  000.080: require('vim.treesitter.language')
110.692  000.017  000.017: require('vim.func')
110.728  000.030  000.030: require('vim.func._memoize')
110.743  000.438  000.312: require('vim.treesitter.query')
110.816  000.071  000.071: require('vim.treesitter._range')
110.824  000.810  000.300: require('vim.treesitter.languagetree')
110.829  000.997  000.188: require('vim.treesitter')
110.992  000.159  000.159: require('vim.treesitter._fold')
8337.082  8226.577: VimEnter autocommands
8337.095  000.013: UIEnter autocommands
8337.097  000.002: before starting main loop
8337.737  000.640: first screen update
8337.741  000.004: --- NVIM STARTED ---
```

**After:**

```
--- Startup times for process: Primary (or UI client) ---

times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.002  000.002: --- NVIM STARTING ---
000.125  000.122: event init
000.228  000.103: early init
000.271  000.043: locale set
000.318  000.047: init first window
000.874  000.556: inits 1
000.880  000.006: window checked
000.923  000.043: parsing arguments
006.988  005.754  005.754: require('vim.shared')
007.460  000.040  000.040: require('vim.inspect')
007.773  000.300  000.300: require('vim._options')
007.777  000.782  000.442: require('vim._editor')
007.778  006.562  000.026: require('vim._init_packages')
007.783  000.298: init lua interpreter
009.557  001.774: nvim_ui_attach
010.079  000.522: nvim_set_client_info
010.081  000.002: --- NVIM STARTED ---

--- Startup times for process: Embedded ---

times in msec
 clock   self+sourced   self:  sourced script
 clock   elapsed:              other lines

000.001  000.001: --- NVIM STARTING ---
000.128  000.127: event init
000.242  000.114: early init
000.290  000.047: locale set
000.336  000.046: init first window
000.911  000.575: inits 1
000.923  000.012: window checked
000.964  000.042: parsing arguments
007.379  006.053  006.053: require('vim.shared')
007.818  000.039  000.039: require('vim.inspect')
008.057  000.229  000.229: require('vim._options')
008.061  000.678  000.410: require('vim._editor')
008.063  006.776  000.045: require('vim._init_packages')
008.065  000.325: init lua interpreter
008.171  000.106: expanding arguments
008.217  000.046: inits 2
008.483  000.266: init highlight
008.486  000.002: waiting for UI
008.709  000.223: done waiting for UI
008.724  000.015: clear screen
009.107  000.044  000.044: require('vim.keymap')
009.697  000.970  000.926: require('vim._defaults')
009.700  000.006: init default mappings & autocommands
009.865  000.101  000.101: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/ftplugin.vim
009.938  000.019  000.019: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/indent.vim
009.946  000.126: sourcing vimrc file(s)
010.192  000.026  000.026: sourcing /nix/store/frnxwjw9lpsycd6qqk974la85426syaa-ghostty-1.0.0/share/nvim/site/ftdetect/ghostty.vim
010.313  000.006  000.006: sourcing /etc/profiles/per-user/whoami/share/nvim/site/ftdetect/ghostty.vim
010.331  000.328  000.296: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/filetype.lua
010.543  000.080  000.080: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/syntax/synload.vim
010.738  000.359  000.279: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/syntax/syntax.vim
013.913  000.397  000.397: sourcing /etc/profiles/per-user/whoami/share/nvim/site/plugin/fzf.vim
014.367  000.140  000.140: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/gzip.vim
016.717  000.139  000.139: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/pack/dist/opt/matchit/plugin/matchit.vim
017.245  002.858  002.719: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/matchit.vim
017.367  000.104  000.104: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/matchparen.vim
017.587  000.205  000.205: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/netrwPlugin.vim
017.648  000.038  000.038: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/rplugin.vim
017.713  000.046  000.046: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/shada.vim
017.750  000.012  000.012: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/spellfile.vim
017.838  000.068  000.068: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/tarPlugin.vim
017.876  000.011  000.011: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/tutor.vim
018.016  000.120  000.120: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/zipPlugin.vim
018.072  000.027  000.027: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/editorconfig.lua
018.134  000.040  000.040: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/man.lua
022.922  004.731  004.731: require('vim.termcap')
022.969  000.038  000.038: require('vim.text')
022.984  004.831  000.062: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/osc52.lua
023.025  000.020  000.020: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/plugin/tohtml.lua
023.074  003.524: loading rtp plugins
025.021  001.947: loading packages
025.023  000.002: loading after plugins
025.032  000.008: inits 3
025.039  000.007: reading ShaDa
107.962  001.548  001.548: require('vim.filetype')
108.912  000.814  000.814: require('vim.filetype.detect')
109.479  000.033  000.033: sourcing /home/whoami/Documents/CodeProjects/neovim/runtime/ftplugin/text.vim
110.598  000.050  000.050: require('vim.F')
110.782  000.179  000.179: require('editorconfig')
110.971  000.185  000.185: require('vim.fs')
111.118  083.269: opening buffers
111.138  000.020: BufEnter autocommands
111.140  000.002: editing files in windows
111.155  000.014: executing command arguments
111.988  000.056  000.056: require('vim.treesitter.language')
112.007  000.015  000.015: require('vim.func')
112.049  000.038  000.038: require('vim.func._memoize')
112.059  000.389  000.280: require('vim.treesitter.query')
112.119  000.058  000.058: require('vim.treesitter._range')
112.125  000.709  000.261: require('vim.treesitter.languagetree')
112.128  000.842  000.133: require('vim.treesitter')
112.284  000.153  000.153: require('vim.treesitter._fold')
303.373  191.223: VimEnter autocommands
303.381  000.008: UIEnter autocommands
303.384  000.002: before starting main loop
303.952  000.569: first screen update
303.956  000.004: --- NVIM STARTED ---
```

</details>