### PR TITLE
perf(treesitter): calculate folds asynchronously

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -305,6 +305,7 @@ PERFORMANCE
   queries.
 • Treesitter highlighting is now asynchronous. To force synchronous parsing,
   use `vim.g._ts_force_sync_parsing = true`.
+• Treesitter folding is now calculated asynchronously.
 
 PLUGINS
 


### PR DESCRIPTION
**Problem:** The treesitter `foldexpr` runs synchronous parses to
calculate fold levels, which eliminates async parsing performance in the
highlighter.

**Solution:** Migrate the `foldexpr` to also calculate and apply fold
levels asynchronously.