### PR TITLE
fix(lsp): ensure watcher cancel

### DIFF
--- a/runtime/lua/vim/lsp/_watchfiles.lua
+++ b/runtime/lua/vim/lsp/_watchfiles.lua
@@ -174,6 +174,7 @@ function M.cancel(client_id)
       cancel()
     end
   end
+  cancels[client_id] = nil
 end
 
 return M

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -805,6 +805,8 @@ function Client:stop(force)
     return
   end
 
+  vim.lsp._watchfiles.cancel(self.id)
+
   if force or not self.initialized or self._graceful_shutdown_failed then
     rpc.terminate()
     return
@@ -819,7 +821,6 @@ function Client:stop(force)
       rpc.terminate()
       self._graceful_shutdown_failed = true
     end
-    vim.lsp._watchfiles.cancel(self.id)
   end)
 end
 


### PR DESCRIPTION
* Cancel watcher in the "force" case.
* Cancel watcher outside the async callback. It seems nvim doesn't wait async jobs on quitting, leaving detached inotifywait processes.
* Clean up cancelling callbacks.