### PR TITLE
feat(ui): include compositor info with multigrid

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -174,6 +174,7 @@ TUI
 UI
 
 • |:checkhealth| shows a summary in the header for every healthcheck.
+• |ui-multigrid| provides composition information and absolute coordinates.
 
 VIMSCRIPT
 

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -609,12 +609,31 @@ tabs.
 	size). If the window was previously hidden, it should now be shown
 	again.
 
-["win_float_pos", grid, win, anchor, anchor_grid, anchor_row, anchor_col, mouse_enabled, zindex] ~
-	Display or reconfigure floating window `win`. The window should be
-	displayed above another grid `anchor_grid` at the specified position
-	`anchor_row` and `anchor_col`. For the meaning of `anchor` and more details
-	of positioning, see |nvim_open_win()|. `mouse_enabled` is true if the
-	window can receive mouse events.
+["win_float_pos", grid, win, anchor, anchor_grid, anchor_row, anchor_col, mouse_enabled, zindex, compindex, screen_row, screen_col] ~
+	Display or reconfigure floating window `win`.
+
+	There are two alternative ways of positioning the window
+	  -  Manually - The window should be displayed above another grid
+	     `anchor_grid` at the specified position `anchor_row` and
+	     `anchor_col`. For the meaning of `anchor` and more details of
+	     positioning, see |nvim_open_win()|. NOTE: you have to manually
+	     ensure that the window fits the screen, possibly by further
+	     reposition it. Ignore `screen_row` and `screen_col` in this case.
+	  - Let nvim take care of the positioning - You can ignore `anchor`
+	    and display the window at `screen_row` and `screen_col`.
+
+	`mouse_enabled` is true if the window can receive mouse events.
+
+	`zindex` is the configured zindex, while `compindex` is the exact
+	rendering order of the windows determined by nvim. To render exactly
+	like the TUI, first render all the non-floating windows, then render
+	in the `compindex` order, overwriting any floating window cells.
+	Finally, blend the floating window cells against the non-floating
+	background. To add more blending, you can group the windows by zindex,
+	and blend between the layers. But note that windows inside the same
+	zindex should still overwrite previous cells inside the same layer
+	without blending. This ensures that plugins that render multiple
+	windows, to add borders for example, work as expected.
 
 ["win_external_pos", grid, win] ~
 	Display or reconfigure external window `win`. The window should be
@@ -627,7 +646,7 @@ tabs.
 ["win_close", grid] ~
 	Close the window.
 
-["msg_set_pos", grid, row, scrolled, sep_char] ~
+["msg_set_pos", grid, row, scrolled, sep_char, zindex, compindex] ~
 	Display messages on `grid`.  The grid will be displayed at `row` on
 	the default grid (grid=1), covering the full column width. `scrolled`
 	indicates whether the message area has been scrolled to cover other
@@ -637,6 +656,10 @@ tabs.
 
 	When |ui-messages| is active, no message grid is used, and this event
 	will not be sent.
+
+	`zindex` and `compindex` have the same meaning as for `win_float_pos`.
+	The `zindex` always has a fixed value of 200 and included for
+	completeness.
 
 ["win_viewport", grid, win, topline, botline, curline, curcol, line_count, scroll_delta] ~
 	Indicates the range of buffer text displayed in the window, as well

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -102,7 +102,8 @@ void win_pos(Integer grid, Window win, Integer startrow, Integer startcol, Integ
              Integer height)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void win_float_pos(Integer grid, Window win, String anchor, Integer anchor_grid, Float anchor_row,
-                   Float anchor_col, Boolean mouse_enabled, Integer zindex)
+                   Float anchor_col, Boolean mouse_enabled, Integer zindex, Integer compindex,
+                   Integer screen_row, Integer screen_col)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void win_external_pos(Integer grid, Window win)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
@@ -111,7 +112,8 @@ void win_hide(Integer grid)
 void win_close(Integer grid)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 
-void msg_set_pos(Integer grid, Integer row, Boolean scrolled, String sep_char)
+void msg_set_pos(Integer grid, Integer row, Boolean scrolled, String sep_char, Integer zindex,
+                 Integer compindex)
   FUNC_API_SINCE(6) FUNC_API_COMPOSITOR_IMPL FUNC_API_CLIENT_IGNORE;
 
 void win_viewport(Integer grid, Window win, Integer topline, Integer botline, Integer curline,

--- a/src/nvim/grid_defs.h
+++ b/src/nvim/grid_defs.h
@@ -102,11 +102,13 @@ struct ScreenGrid {
   // compositor should momentarily ignore the grid. Used internally when
   // moving around grids etc.
   bool comp_disabled;
+
+  bool composition_updated;
 };
 
 #define SCREEN_GRID_INIT { 0, NULL, NULL, NULL, NULL, NULL, 0, 0, false, \
                            false, 0, 0, NULL, false, true, 0, \
-                           0, 0, 0, 0, 0,  false }
+                           0, 0, 0, 0, 0,  false, true }
 
 typedef struct {
   int args[3];

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -171,7 +171,9 @@ static void ui_ext_msg_set_pos(int row, bool scrolled)
   char buf[MAX_SCHAR_SIZE];
   size_t size = schar_get(buf, curwin->w_p_fcs_chars.msgsep);
   ui_call_msg_set_pos(msg_grid.handle, row, scrolled,
-                      (String){ .data = buf, .size = size });
+                      (String){ .data = buf, .size = size }, msg_grid.zindex,
+                      (int)msg_grid.comp_index);
+  msg_grid.composition_updated = false;
 }
 
 void msg_grid_set_pos(int row, bool scrolled)
@@ -2525,6 +2527,13 @@ void msg_ui_refresh(void)
 {
   if (ui_has(kUIMultigrid) && msg_grid.chars) {
     ui_call_grid_resize(msg_grid.handle, msg_grid.cols, msg_grid.rows);
+    ui_ext_msg_set_pos(msg_grid_pos, msg_scrolled);
+  }
+}
+
+void msg_ui_flush(void)
+{
+  if (ui_has(kUIMultigrid) && msg_grid.chars && msg_grid.composition_updated) {
     ui_ext_msg_set_pos(msg_grid_pos, msg_scrolled);
   }
 }

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -545,6 +545,9 @@ void ui_flush(void)
   if (pending_cursor_update) {
     ui_call_grid_cursor_goto(cursor_grid_handle, cursor_row, cursor_col);
     pending_cursor_update = false;
+    // The cursor move might change the composition order, so flush again to update the windows that
+    // changed
+    win_ui_flush(false);
   }
   if (pending_mode_info_update) {
     Arena arena = ARENA_EMPTY;

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -117,17 +117,20 @@ void ui_comp_layers_adjust(size_t layer_idx, bool raise)
     while (layer_idx < size - 1 && layer->zindex > layers.items[layer_idx + 1]->zindex) {
       layers.items[layer_idx] = layers.items[layer_idx + 1];
       layers.items[layer_idx]->comp_index = layer_idx;
+      layers.items[layer_idx]->composition_updated = true;
       layer_idx++;
     }
   } else {
     while (layer_idx > 0 && layer->zindex < layers.items[layer_idx - 1]->zindex) {
       layers.items[layer_idx] = layers.items[layer_idx - 1];
       layers.items[layer_idx]->comp_index = layer_idx;
+      layers.items[layer_idx]->composition_updated = true;
       layer_idx--;
     }
   }
   layers.items[layer_idx] = layer;
   layer->comp_index = layer_idx;
+  layer->composition_updated = true;
 }
 
 /// Places `grid` at (col,row) position with (width * height) size.
@@ -140,6 +143,7 @@ bool ui_comp_put_grid(ScreenGrid *grid, int row, int col, int height, int width,
                       bool on_top)
 {
   bool moved;
+  grid->composition_updated = true;
 
   grid->comp_height = height;
   grid->comp_width = width;
@@ -193,12 +197,14 @@ bool ui_comp_put_grid(ScreenGrid *grid, int row, int col, int height, int width,
     for (size_t i = kv_size(layers) - 1; i > insert_at; i--) {
       kv_A(layers, i) = kv_A(layers, i - 1);
       kv_A(layers, i)->comp_index = i;
+      kv_A(layers, i)->composition_updated = true;
     }
     kv_A(layers, insert_at) = grid;
 
     grid->comp_row = row;
     grid->comp_col = col;
     grid->comp_index = insert_at;
+    grid->composition_updated = true;
   }
   if (moved && valid && ui_comp_should_draw()) {
     compose_area(grid->comp_row, grid->comp_row + grid->rows,
@@ -222,9 +228,11 @@ void ui_comp_remove_grid(ScreenGrid *grid)
   for (size_t i = grid->comp_index; i < kv_size(layers) - 1; i++) {
     kv_A(layers, i) = kv_A(layers, i + 1);
     kv_A(layers, i)->comp_index = i;
+    kv_A(layers, i)->composition_updated = true;
   }
   (void)kv_pop(layers);
   grid->comp_index = 0;
+  grid->composition_updated = true;
 
   // recompose the area under the grid
   // inefficient when being overlapped: only draw up to grid->comp_index
@@ -256,9 +264,11 @@ void ui_comp_raise_grid(ScreenGrid *grid, size_t new_index)
   for (size_t i = old_index; i < new_index; i++) {
     kv_A(layers, i) = kv_A(layers, i + 1);
     kv_A(layers, i)->comp_index = i;
+    kv_A(layers, i)->composition_updated = true;
   }
   kv_A(layers, new_index) = grid;
   grid->comp_index = new_index;
+  grid->composition_updated = true;
   for (size_t i = old_index; i < new_index; i++) {
     ScreenGrid *grid2 = kv_A(layers, i);
     int startcol = MAX(grid->comp_col, grid2->comp_col);
@@ -272,7 +282,7 @@ void ui_comp_raise_grid(ScreenGrid *grid, size_t new_index)
 
 void ui_comp_grid_cursor_goto(Integer grid_handle, Integer r, Integer c)
 {
-  if (!ui_comp_should_draw() || !ui_comp_set_grid((int)grid_handle)) {
+  if (!ui_comp_set_grid((int)grid_handle)) {
     return;
   }
   int cursor_row = curgrid->comp_row + (int)r;
@@ -593,8 +603,10 @@ bool ui_comp_set_screen_valid(bool valid)
   return old_val;
 }
 
-void ui_comp_msg_set_pos(Integer grid, Integer row, Boolean scrolled, String sep_char)
+void ui_comp_msg_set_pos(Integer grid, Integer row, Boolean scrolled, String sep_char,
+                         Integer zindex, Integer compindex)
 {
+  msg_grid.composition_updated = true;
   msg_grid.comp_row = (int)row;
   if (scrolled && row > 0) {
     msg_sep_row = (int)row - 1;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -62,6 +62,7 @@
 #include "nvim/os/os_defs.h"
 #include "nvim/path.h"
 #include "nvim/plines.h"
+#include "nvim/popupmenu.h"
 #include "nvim/pos_defs.h"
 #include "nvim/quickfix.h"
 #include "nvim/search.h"
@@ -804,6 +805,12 @@ void ui_ext_win_position(win_T *wp, bool validate)
 {
   wp->w_pos_changed = false;
   if (!wp->w_floating) {
+    if (ui_has(kUIMultigrid)) {
+      // Windows on the default grid don't necessarily have comp_col and comp_row set
+      // But the rest of the calculations relies on it
+      wp->w_grid_alloc.comp_col = wp->w_wincol;
+      wp->w_grid_alloc.comp_row = wp->w_winrow;
+    }
     ui_call_win_pos(wp->w_grid_alloc.handle, wp->handle, wp->w_winrow,
                     wp->w_wincol, wp->w_width, wp->w_height);
     return;
@@ -852,50 +859,51 @@ void ui_ext_win_position(win_T *wp, bool validate)
     if (resort) {
       ui_comp_layers_adjust(wp->w_grid_alloc.comp_index, raise);
     }
-    if (ui_has(kUIMultigrid)) {
-      String anchor = cstr_as_string(float_anchor_str[c.anchor]);
-      if (!c.hide) {
+    bool valid = (wp->w_redr_type == 0 || ui_has(kUIMultigrid));
+    if (!valid && !validate) {
+      wp->w_pos_changed = true;
+      return;
+    }
+
+    // TODO(bfredl): ideally, compositor should work like any multigrid UI
+    // and use standard win_pos events.
+    bool east = c.anchor & kFloatAnchorEast;
+    bool south = c.anchor & kFloatAnchorSouth;
+
+    int comp_row = (int)row - (south ? wp->w_height_outer : 0);
+    int comp_col = (int)col - (east ? wp->w_width_outer : 0);
+    int above_ch = wp->w_config.zindex < kZIndexMessages ? (int)p_ch : 0;
+    comp_row += grid->comp_row;
+    comp_col += grid->comp_col;
+    comp_row = MAX(MIN(comp_row, Rows - wp->w_height_outer - above_ch), 0);
+    if (!c.fixed || east) {
+      comp_col = MAX(MIN(comp_col, Columns - wp->w_width_outer), 0);
+    }
+    wp->w_winrow = comp_row;
+    wp->w_wincol = comp_col;
+
+    if (!c.hide) {
+      ui_comp_put_grid(&wp->w_grid_alloc, comp_row, comp_col,
+                       wp->w_height_outer, wp->w_width_outer, valid, false);
+      if (ui_has(kUIMultigrid)) {
+        String anchor = cstr_as_string(float_anchor_str[c.anchor]);
         ui_call_win_float_pos(wp->w_grid_alloc.handle, wp->handle, anchor,
                               grid->handle, row, col, c.mouse,
-                              wp->w_grid_alloc.zindex);
-      } else {
-        ui_call_win_hide(wp->w_grid_alloc.handle);
+                              wp->w_grid_alloc.zindex, (int)wp->w_grid_alloc.comp_index,
+                              wp->w_winrow,
+                              wp->w_wincol);
+      }
+      ui_check_cursor_grid(wp->w_grid_alloc.handle);
+      wp->w_grid_alloc.mouse_enabled = wp->w_config.mouse;
+      if (!valid) {
+        wp->w_grid_alloc.valid = false;
+        redraw_later(wp, UPD_NOT_VALID);
       }
     } else {
-      bool valid = (wp->w_redr_type == 0);
-      if (!valid && !validate) {
-        wp->w_pos_changed = true;
-        return;
+      if (ui_has(kUIMultigrid)) {
+        ui_call_win_hide(wp->w_grid_alloc.handle);
       }
-      // TODO(bfredl): ideally, compositor should work like any multigrid UI
-      // and use standard win_pos events.
-      bool east = c.anchor & kFloatAnchorEast;
-      bool south = c.anchor & kFloatAnchorSouth;
-
-      int comp_row = (int)row - (south ? wp->w_height_outer : 0);
-      int comp_col = (int)col - (east ? wp->w_width_outer : 0);
-      int above_ch = wp->w_config.zindex < kZIndexMessages ? (int)p_ch : 0;
-      comp_row += grid->comp_row;
-      comp_col += grid->comp_col;
-      comp_row = MAX(MIN(comp_row, Rows - wp->w_height_outer - above_ch), 0);
-      if (!c.fixed || east) {
-        comp_col = MAX(MIN(comp_col, Columns - wp->w_width_outer), 0);
-      }
-      wp->w_winrow = comp_row;
-      wp->w_wincol = comp_col;
-
-      if (!c.hide) {
-        ui_comp_put_grid(&wp->w_grid_alloc, comp_row, comp_col,
-                         wp->w_height_outer, wp->w_width_outer, valid, false);
-        ui_check_cursor_grid(wp->w_grid_alloc.handle);
-        wp->w_grid_alloc.mouse_enabled = wp->w_config.mouse;
-        if (!valid) {
-          wp->w_grid_alloc.valid = false;
-          redraw_later(wp, UPD_NOT_VALID);
-        }
-      } else {
-        ui_comp_remove_grid(&wp->w_grid_alloc);
-      }
+      ui_comp_remove_grid(&wp->w_grid_alloc);
     }
   } else {
     ui_call_win_external_pos(wp->w_grid_alloc.handle, wp->handle);
@@ -7456,18 +7464,25 @@ void win_get_tabwin(handle_T id, int *tabnr, int *winnr)
 void win_ui_flush(bool validate)
 {
   FOR_ALL_TAB_WINDOWS(tp, wp) {
-    if (wp->w_pos_changed && wp->w_grid_alloc.chars != NULL) {
+    if ((wp->w_pos_changed || wp->w_grid_alloc.composition_updated)
+        && wp->w_grid_alloc.chars != NULL) {
       if (tp == curtab) {
         ui_ext_win_position(wp, validate);
       } else {
         ui_call_win_hide(wp->w_grid_alloc.handle);
         wp->w_pos_changed = false;
       }
+      wp->w_grid_alloc.composition_updated = false;
     }
     if (tp == curtab) {
       ui_ext_win_viewport(wp);
     }
   }
+  // The popupmenu could also have moved or changed its comp_index
+  pum_ui_flush();
+
+  // And the message
+  msg_ui_flush();
 }
 
 win_T *lastwin_nofloating(void)

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -1147,7 +1147,7 @@ describe('float window', function()
       local buf = api.nvim_create_buf(false,false)
       local win = api.nvim_open_win(buf, false, {relative='editor', width=20, height=2, row=2, col=5})
       local expected_pos = {
-          [4]={1001, 'NW', 1, 2, 5, true},
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 },
       }
 
       if multigrid then
@@ -1179,6 +1179,8 @@ describe('float window', function()
       api.nvim_win_set_config(win, {relative='editor', row=0, col=10})
       expected_pos[4][4] = 0
       expected_pos[4][5] = 10
+      expected_pos[4][9] = 0
+      expected_pos[4][10] = 10
       if multigrid then
         screen:expect{grid=[[
         ## grid 1
@@ -1247,7 +1249,7 @@ describe('float window', function()
           {1:               }|
           {2:~              }|
         ]], float_pos={
-          [5] = {1002, "NW", 4, 2, 10, true};
+          [5] = { 1002, "NW", 4, 2, 10, true, 50, 1, 2, 30 };
         }}
       else
         screen:expect([[
@@ -1264,7 +1266,25 @@ describe('float window', function()
       api.nvim_win_set_config(win, {fixed=false})
 
       if multigrid then
-        screen:expect_unchanged()
+        screen:expect{grid = [[
+        ## grid 1
+          [2:-------------------]{5:│}[4:--------------------]|*5
+          {5:[No Name]           }{4:[No Name]           }|
+          [3:----------------------------------------]|
+        ## grid 2
+                             |
+          {0:~                  }|*4
+        ## grid 3
+                                                  |
+        ## grid 4
+          ^                    |
+          {0:~                   }|*4
+        ## grid 5
+          {1:               }|
+          {2:~              }|
+        ]], float_pos={
+          [5] = {1002, "NW", 4, 2, 10, true, 50, 1, 2, 25};
+        }}
       else
         screen:expect([[
                              {5:│}^                    |
@@ -1288,7 +1308,7 @@ describe('float window', function()
       local buf = api.nvim_create_buf(false,false)
       local win = api.nvim_open_win(buf, false, {relative='editor', width=20, height=2, row=2, col=5})
       local expected_pos = {
-          [4]={1001, 'NW', 1, 2, 5, true},
+        [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 },
       }
 
       if multigrid then
@@ -1320,6 +1340,8 @@ describe('float window', function()
       api.nvim_win_set_config(win, {relative='editor', row=0, col=10})
       expected_pos[4][4] = 0
       expected_pos[4][5] = 10
+      expected_pos[4][9] = 0
+      expected_pos[4][10] = 10
       if multigrid then
         screen:expect{grid=[[
         ## grid 1
@@ -1409,7 +1431,7 @@ describe('float window', function()
           {18:  2 }{15:y               }|
           {18:  3 }{15:                }|
           {16:~                   }|
-        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true}}}
+        ]], float_pos = {[4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10}}}
       else
         screen:expect([[
           {14:  1 }^x                                   |
@@ -1439,7 +1461,7 @@ describe('float window', function()
         ## grid 4
           {18:  1 }{15:                }|
           {16:~                   }|*3
-        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true}}}
+        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10}}}
       else
         screen:expect([[
           {14:  1 }^x                                   |
@@ -1475,7 +1497,7 @@ describe('float window', function()
             {22:y           }|
             {22:            }|
           ]], float_pos={
-          [5] = {1002, "NW", 2, 3, 3, true, 50};
+          [5] = {1002, "NW", 2, 3, 3, true, 50, 1, 3, 3};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 4, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
           [5] = {win = 1002, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
@@ -1523,7 +1545,7 @@ describe('float window', function()
           {15:x                   }|
           {15:y                   }|
           {15:                    }|*2
-        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true}}}
+        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10}}}
       else
         screen:expect{grid=[[
           {19:   }{20:  1 }{22:^x}{21:                                }|
@@ -1555,7 +1577,7 @@ describe('float window', function()
           {19:  }{15:y                 }|
           {19:  }{15:                  }|
           {15:                    }|
-        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true}}}
+        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10}}}
 
       else
         screen:expect([[
@@ -1586,7 +1608,7 @@ describe('float window', function()
                                                   |
         ## grid 4
           {15:                    }|*4
-        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true}}}
+        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10}}}
       else
         screen:expect([[
           {19:   }{20:  1 }{22:^x}{21:                                }|
@@ -1623,7 +1645,7 @@ describe('float window', function()
           {15:x                   }|
           {15:y                   }|
           {15:                    }|*2
-        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true}}}
+        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10}}}
       else
         screen:expect{grid=[[
           {19:   }{20:  1 }{22:^x}{21:                                }|
@@ -1655,7 +1677,7 @@ describe('float window', function()
           {19:  }{15:y                 }|
           {19:  }{15:                  }|
           {15:                    }|
-        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true}}}
+        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10}}}
 
       else
         screen:expect([[
@@ -1686,7 +1708,7 @@ describe('float window', function()
                                                   |
         ## grid 4
           {15:                    }|*4
-        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true}}}
+        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10}}}
       else
         screen:expect([[
           {19:   }{20:  1 }{22:^x}{21:                                }|
@@ -1726,7 +1748,7 @@ describe('float window', function()
             {15:y                   }|
             {15:                    }|*2
           ]],
-          float_pos = { [4] = { 1001, "NW", 1, 4, 10, true, 50 } },
+          float_pos = { [4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10} },
         })
       else
         screen:expect([[
@@ -1775,7 +1797,7 @@ describe('float window', function()
           {17:n̈̊}{1: BORDAA  }{17:n̈̊}|
           {5:\}{7:ååååååååå}{5:x}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -1811,7 +1833,7 @@ describe('float window', function()
           {5:<}{1: halloj! }{5:>}|
           {5:<}{1: BORDAA  }{5:>}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -1850,7 +1872,7 @@ describe('float window', function()
           {1: BORDAA  }|
           {5:---------}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -1899,7 +1921,7 @@ describe('float window', function()
           {1: BORDAA  }{26: }|
           {25: }{26:         }|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 6, curline = 5, curcol = 0, linecount = 6, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -2006,7 +2028,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -2051,7 +2073,7 @@ describe('float window', function()
             {2:~        }|
           ]],
           float_pos = {
-            [4] = { 1001, "NW", 1, 2, 5, true, 50 },
+            [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 },
           },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -2095,7 +2117,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -2129,7 +2151,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -2163,7 +2185,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -2197,7 +2219,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -2234,7 +2256,7 @@ describe('float window', function()
             {5:╚═════════╝}|
           ]],
           float_pos = {
-          [4] = {1001, "NW", 1, 2, 5, true, 50};
+          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
         },
           win_viewport = {
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -2295,7 +2317,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚}{11:Left}{5:═════╝}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -2329,7 +2351,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═}{11:Center}{5:══╝}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -2363,7 +2385,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚════}{11:Right}{5:╝}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -2397,7 +2419,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════}{11:🦄BB}{5:╝}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -2434,7 +2456,7 @@ describe('float window', function()
             {5:╚══════}{11:new}{5:╝}|
           ]],
           float_pos = {
-          [4] = {1001, "NW", 1, 2, 5, true, 50};
+          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
         },
           win_viewport = {
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -2495,7 +2517,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚════}{11:Right}{5:╝}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -2529,7 +2551,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═}{11:Center}{5:══╝}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -2563,7 +2585,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚}{11:Left}{5:═════╝}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -2603,7 +2625,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════}{11:🦄}{7:BB}{5:╝}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -2642,7 +2664,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚}🦄{7:BB}{5:═════╝}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true }
+          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -2712,7 +2734,7 @@ describe('float window', function()
           {5:│}{2:~                                       }{5:│}|*6
           {5:└────────────────────────────────────────┘}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 0, 0, true, 201 }
+          [4] = { 1001, "NW", 1, 0, 0, true, 201, 2, 0, 0 }
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -2752,7 +2774,7 @@ describe('float window', function()
           {5:║}{1:^         }{5:║}|
           {5:╚═════════╝}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 0, 5, true };
+          [4] = { 1001, "NW", 1, 0, 5, true, 50, 1, 0, 5 };
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 2, curcol = 0, linecount = 3, sum_scroll_delta = 0};
@@ -2792,8 +2814,8 @@ describe('float window', function()
           {1: abb            }|
           {13: acc            }|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 0, 5, true, 50 };
-          [5] = { -1, "NW", 4, 4, 0, false, 100 };
+          [4] = { 1001, "NW", 1, 0, 5, true, 50, 1, 0, 5 };
+          [5] = { -1, "NW", 4, 4, 0, false, 100, 2, 4, 5 };
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount=1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 2, curcol = 3, linecount=3, sum_scroll_delta = 0};
@@ -2831,7 +2853,7 @@ describe('float window', function()
           {5:║}{1:ac^c      }{5:║}|
           {5:╚═════════╝}|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 0, 5, true };
+          [4] = { 1001, "NW", 1, 0, 5, true, 50, 1, 0, 5 };
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 2, curcol = 2, linecount = 3, sum_scroll_delta = 0};
@@ -2875,8 +2897,8 @@ describe('float window', function()
           {1: bar }|
           {1: baz }|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 0, 5, true };
-          [5] = { -1, "NW", 4, 4, 2, false, 250 };
+          [4] = { 1001, "NW", 1, 0, 5, true, 50, 1, 0, 5 };
+          [5] = { -1, "NW", 4, 4, 2, false, 250, 3, 4, 7 };
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 2, curcol = 2, linecount = 3, sum_scroll_delta = 0};
@@ -2919,7 +2941,7 @@ describe('float window', function()
           {1:abb acc  }|
           {2:~        }|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 5, true, 50};
+          [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -2950,7 +2972,7 @@ describe('float window', function()
           {1:abb acc  }|
           {2:~        }|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 5, true, 50};
+          [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0,  5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 4, linecount = 2, sum_scroll_delta = 0};
@@ -2983,7 +3005,7 @@ describe('float window', function()
           {1:^         }|
           {2:~        }|*2
         ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 5, true, 50};
+          [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -3023,8 +3045,8 @@ describe('float window', function()
           {1:^   }|
           {2:~  }|*2
         ]], float_pos={
-          [5] = {1002, "NW", 1, 0, 5, true, 50};
-          [4] = {1001, "NW", 1, 0, 0, true, 50};
+          [4] = {1001, "NW", 1, 0, 0, true, 50, 1, 0, 0};
+          [5] = {1002, "NW", 1, 0, 5, true, 50, 2, 0, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -3056,8 +3078,8 @@ describe('float window', function()
           {1:^   }|
           {2:~  }|*2
         ]], float_pos={
-          [5] = {1002, "NW", 1, 0, 5, true, 50};
-          [4] = {1001, "NW", 1, 0, 0, true, 50};
+          [4] = {1001, "NW", 1, 0, 0, true, 50, 1, 0, 0};
+          [5] = {1002, "NW", 1, 0, 5, true, 50, 2, 0, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -3091,7 +3113,7 @@ describe('float window', function()
         ## grid 4
           {1:x}|
         ]], float_pos={
-          [4] = {1001, "NW", 2, 0, 4, false}
+          [4] = {1001, "NW", 2, 0, 4, false, 50, 1, 0, 4}
         }}
       else
         screen:expect([[
@@ -3115,7 +3137,7 @@ describe('float window', function()
         ## grid 4
           {1:x}|
         ]], float_pos={
-          [4] = {1001, "NW", 2, 0, 15, false}
+          [4] = {1001, "NW", 2, 0, 15, false, 50, 1, 0, 15}
         }}
       else
         screen:expect([[
@@ -3195,8 +3217,8 @@ describe('float window', function()
             ^                                        |
             {0:~                                       }|
           ]], float_pos={
-            [5] = {1002, "NW", 1, 6, 0, true, 50};
-            [6] = {1003, "NW", 1, 6, 0, true, 50};
+            [5] = {1002, "NW", 1, 6, 0, true, 50, 1, 6, 0};
+            [6] = {1003, "NW", 1, 6, 0, true, 50, 2, 6, 0};
           }, win_viewport={
             [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
             [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -3384,7 +3406,7 @@ describe('float window', function()
           {1:                    }|
           {2:~                   }|
         ]], float_pos={
-          [5] = {1002, "NW", 4, 0, 10, true}
+          [5] = {1002, "NW", 4, 0, 10, true, 50, 1, 4, 10}
         }}
       else
         screen:expect([[
@@ -3423,7 +3445,7 @@ describe('float window', function()
           {1:                    }|
           {2:~                   }|
         ]], float_pos={
-          [5] = {1002, "NW", 4, 1, 1, true}
+          [5] = {1002, "NW", 4, 1, 1, true, 50, 1, 5, 1}
         }}
       else
         screen:expect([[
@@ -3462,7 +3484,7 @@ describe('float window', function()
           {1:                    }|
           {2:~                   }|
         ]], float_pos={
-          [5] = {1002, "SW", 4, 0, 3, true}
+          [5] = {1002, "SW", 4, 0, 3, true, 50, 1, 2, 3}
         }}
       else
         screen:expect([[
@@ -3501,7 +3523,7 @@ describe('float window', function()
           {1:                    }|
           {2:~                   }|
         ]], float_pos={
-          [5] = {1002, "NW", 2, 1, 10, true}
+          [5] = {1002, "NW", 2, 1, 10, true, 50, 1, 1, 10}
         }}
       else
         screen:expect([[
@@ -3540,7 +3562,7 @@ describe('float window', function()
           {1:                    }|
           {2:~                   }|
         ]], float_pos={
-          [5] = {1002, "SE", 2, 3, 39, true}
+          [5] = {1002, "SE", 2, 3, 39, true, 50, 1, 1, 19}
         }}
       else
         screen:expect([[
@@ -3579,7 +3601,7 @@ describe('float window', function()
           {1:                    }|
           {2:~                   }|
         ]], float_pos={
-          [5] = {1002, "NE", 4, 0, 50, true}
+          [5] = {1002, "NE", 4, 0, 50, true, 50, 1, 4, 20}
         }, win_viewport = {
           [2] = {
               topline = 0,
@@ -3691,7 +3713,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]], float_pos={
-          [5] = {1002, "NW", 4, 1, 14, true}
+          [5] = {1002, "NW", 4, 1, 14, true, 50, 1, 7, 14 }
         }}
       else
         screen:expect([[
@@ -3734,7 +3756,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]], float_pos={
-          [5] = {1002, "NE", 4, 0, 14, true}
+          [5] = {1002, "NE", 4, 0, 14, true, 50, 1, 6, 3}
         }}
       else
         screen:expect([[
@@ -3777,7 +3799,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]], float_pos={
-          [5] = {1002, "SE", 4, 1, 14, true}
+          [5] = {1002, "SE", 4, 1, 14, true, 50, 1, 3, 3}
         }}
       else
         screen:expect([[
@@ -3820,7 +3842,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]], float_pos={
-          [5] = {1002, "SW", 4, 0, 14, true}
+          [5] = {1002, "SW", 4, 0, 14, true, 50, 1, 2, 14}
         }}
       else
         screen:expect([[
@@ -3904,14 +3926,14 @@ describe('float window', function()
         ## grid 12
           {1:8    }|
         ]], float_pos={
-          [5] = {1002, "NW", 1, 1, 10, true, 50};
-          [6] = {1003, "NW", 1, 1, 30, true, 50};
-          [7] = {1004, "NE", 5, 1, 0, true, 50};
-          [8] = {1005, "NE", 6, 1, 0, true, 50};
-          [9] = {1006, "SE", 7, 0, 0, true, 50};
-          [10] = {1007, "SE", 8, 0, 0, true, 50};
-          [11] = {1008, "SW", 9, 0, 5, true, 50};
-          [12] = {1009, "SW", 10, 0, 5, true, 50};
+          [5] = {1002, "NW", 1, 1, 10, true, 50, 5, 1, 10};
+          [6] = {1003, "NW", 1, 1, 30, true, 50, 1, 1, 30};
+          [7] = {1004, "NE", 5, 1, 0, true, 50, 6, 2, 5};
+          [8] = {1005, "NE", 6, 1, 0, true, 50, 2, 2, 25};
+          [9] = {1006, "SE", 7, 0, 0, true, 50, 7, 1, 0};
+          [10] = {1007, "SE", 8, 0, 0, true, 50, 3, 1, 20};
+          [11] = {1008, "SW", 9, 0, 5, true, 50, 8, 0, 5};
+          [12] = {1009, "SW", 10, 0, 5, true, 50, 4, 0, 25};
         }}
       else
         screen:expect([[
@@ -3971,14 +3993,14 @@ describe('float window', function()
         ## grid 12
           {1:8    }|
         ]], float_pos={
-          [5] = {1002, "NE", 8, 1, 0, true, 50};
-          [6] = {1003, "NE", 12, 1, 0, true, 50};
-          [7] = {1004, "SE", 5, 0, 0, true, 50};
-          [8] = {1005, "NW", 1, 1, 30, true, 50};
-          [9] = {1006, "SW", 10, 0, 5, true, 50};
-          [10] = {1007, "SE", 6, 0, 0, true, 50};
-          [11] = {1008, "SW", 7, 0, 5, true, 50};
-          [12] = {1009, "NW", 1, 1, 10, true, 50};
+          [5] = {1002, "NE", 8, 1, 0, true, 50, 5, 2, 25};
+          [6] = {1003, "NE", 12, 1, 0, true, 50, 1, 2, 5};
+          [7] = {1004, "SE", 5, 0, 0, true, 50, 6, 1, 20};
+          [8] = {1005, "NW", 1, 1, 30, true, 50, 2, 1, 30};
+          [9] = {1006, "SW", 10, 0, 5, true, 50, 7, 0, 5};
+          [10] = {1007, "SE", 6, 0, 0, true, 50, 3, 1, 0};
+          [11] = {1008, "SW", 7, 0, 5, true, 50, 8, 0, 25};
+          [12] = {1009, "NW", 1, 1, 10, true, 50, 4, 1, 10};
         }}
       else
         screen:expect([[
@@ -4058,7 +4080,7 @@ describe('float window', function()
         ## grid 4
           {1:some info!  }|
         ]], float_pos={
-          [4] = { 1001, "NW", 2, 3, 2, true }
+          [4] = { 1001, "NW", 2, 3, 2, true, 50, 1, 3, 2 }
         }}
       else
         screen:expect{grid=[[
@@ -4087,7 +4109,7 @@ describe('float window', function()
         ## grid 4
           {1:some info!  }|
         ]], float_pos={
-          [4] = { 1001, "NW", 2, 2, 2, true },
+          [4] = { 1001, "NW", 2, 2, 2, true, 50, 1, 2, 2 },
         }}
       else
         screen:expect{grid=[[
@@ -4114,7 +4136,7 @@ describe('float window', function()
         ## grid 4
           {1:some info!  }|
         ]], float_pos={
-          [4] = { 1001, "NW", 2, 1, 32, true }
+          [4] = { 1001, "NW", 2, 1, 32, true, 50, 1, 1, 32 }
         }}
       else
         -- note: appears misaligned due to cursor
@@ -4144,7 +4166,7 @@ describe('float window', function()
         ## grid 4
           {1:some info!  }|
         ]], float_pos={
-          [4] = { 1001, "NW", 2, 2, 7, true }
+          [4] = { 1001, "NW", 2, 2, 7, true, 50, 1, 2, 7 }
         }}
       else
         screen:expect{grid=[[
@@ -4175,7 +4197,7 @@ describe('float window', function()
         ## grid 4
           {1:some info!  }|
         ]], float_pos={
-          [4] = { 1001, "SW", 2, 1, 7, true }
+          [4] = { 1001, "SW", 2, 1, 7, true, 50, 1, 0, 7 }
         }}
       else
         screen:expect{grid=[[
@@ -4213,7 +4235,7 @@ describe('float window', function()
           ^                    |
           {0:~                   }|*8
         ]], float_pos={
-          [4] = { 1001, "SW", 2, 8, 0, true }
+          [4] = { 1001, "SW", 2, 8, 0, true, 50, 1, 7, 0 }
         }}
       else
         screen:expect{grid=[[
@@ -4248,7 +4270,7 @@ describe('float window', function()
         ## grid 4
           {1:some info!  }|
         ]], float_pos={
-          [4] = { 1001, "NW", 2, 2, 5, true }
+          [4] = { 1001, "NW", 2, 2, 5, true, 50, 1, 2, 5 }
         }}
       else
         screen:expect{grid=[[
@@ -4279,7 +4301,7 @@ describe('float window', function()
         ## grid 4
           {1:some info!  }|
         ]], float_pos={
-          [4] = { 1001, "NW", 2, 3, 7, true }
+          [4] = { 1001, "NW", 2, 3, 7, true, 50, 1, 3, 7 }
         }}
       else
         screen:expect{grid=[[
@@ -4307,7 +4329,7 @@ describe('float window', function()
         ## grid 4
           {1:some info!  }|
         ]], float_pos={
-          [4] = { 1001, "NW", 2, 2, 0, true }
+          [4] = { 1001, "NW", 2, 2, 0, true, 50, 1, 2, 0 }
         }}
       else
         screen:expect{grid=[[
@@ -4359,7 +4381,7 @@ describe('float window', function()
         ## grid 4
           {1:some floaty text    }|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 3, 1, true}
+          [4] = {1001, "NW", 1, 3, 1, true, 50, 1, 3, 1}
         }}
       else
         screen:expect([[
@@ -4408,9 +4430,6 @@ describe('float window', function()
       local buf = api.nvim_create_buf(false,false)
       api.nvim_buf_set_lines(buf, 0, -1, true, {'such', 'very', 'float'})
       local win = api.nvim_open_win(buf, false, {relative='editor', width=15, height=4, row=2, col=10})
-      local expected_pos = {
-          [4]={1001, 'NW', 1, 2, 10, true},
-      }
       if multigrid then
         screen:expect{grid=[[
         ## grid 1
@@ -4426,7 +4445,9 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
           {2:~              }|
-        ]], float_pos=expected_pos}
+        ]], float_pos={
+          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
+        }}
       else
         screen:expect([[
           ^                                        |
@@ -4455,7 +4476,9 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
           {2:~              }|
-        ]], float_pos=expected_pos}
+        ]], float_pos={
+          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 10 },
+        }}
       else
         screen:expect([[
           ^          {1:such           }               |
@@ -4482,7 +4505,9 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
           {2:~              }|
-        ]], float_pos=expected_pos}
+        ]], float_pos={
+          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 10 },
+        }}
       else
         screen:expect([[
           ^          {1:such           }               |
@@ -4508,7 +4533,9 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
           {2:~              }|
-        ]], float_pos=expected_pos}
+        ]], float_pos={
+          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 10 },
+        }}
       else
         screen:expect([[
           ^          {1:such           }               |
@@ -4532,7 +4559,9 @@ describe('float window', function()
           {1:very           }|
           {1:^float          }|
           {2:~              }|
-        ]], float_pos=expected_pos}
+        ]], float_pos={
+          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 10 },
+        }}
       else
         screen:expect([[
                     {1:such           }               |
@@ -4557,7 +4586,9 @@ describe('float window', function()
           {1:very           }|
           {1:^float          }|
           {2:~              }|
-        ]], float_pos=expected_pos}
+        ]], float_pos={
+          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
+        }}
       else
         screen:expect([[
                                                   |
@@ -4586,7 +4617,9 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos=expected_pos}
+        ]], float_pos={
+          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
+        }}
       else
         screen:expect([[
                                                   |
@@ -4614,7 +4647,9 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos=expected_pos}
+        ]], float_pos={
+          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
+        }}
       else
         screen:expect([[
                                     |
@@ -4642,7 +4677,9 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos=expected_pos}
+        ]], float_pos={
+          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
+        }}
       else
         screen:expect([[
                                    |
@@ -4670,7 +4707,9 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos=expected_pos}
+        ]], float_pos={
+          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 9 },
+        }}
       else
         screen:expect([[
                                   |
@@ -4698,7 +4737,9 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos=expected_pos}
+        ]], float_pos={
+          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 1 },
+        }}
       else
         screen:expect([[
                           |
@@ -4726,7 +4767,9 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos=expected_pos}
+        ]], float_pos={
+          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 0 },
+        }}
       else
         screen:expect([[
                          |
@@ -4754,7 +4797,9 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos=expected_pos}
+        ]], float_pos={
+          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 0 },
+        }}
       else
         screen:expect([[
                         |
@@ -4782,7 +4827,9 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos=expected_pos}
+        ]], float_pos={
+          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 0 },
+        }}
       else
         screen:expect([[
                       |
@@ -4810,7 +4857,9 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos=expected_pos}
+        ]], float_pos={
+          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 0 },
+        }}
       else
         screen:expect([[
           {1:^such        }|
@@ -4833,7 +4882,9 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos=expected_pos}
+        ]], float_pos={
+          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
+        }}
       else
         screen:expect([[
                                                   |
@@ -4849,7 +4900,7 @@ describe('float window', function()
 
     it('does not crash with inccommand #9379', function()
       local expected_pos = {
-        [4]={1001, 'NW', 1, 2, 0, true},
+        [4]={ 1001, 'NW', 1, 2, 0, true, 50, 1, 2, 0},
       }
 
       command("set inccommand=split")
@@ -4977,7 +5028,7 @@ describe('float window', function()
             {7:^            }|
             {12:~           }|*3
           ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true},
+            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5},
           }}
         else
           screen:expect([[
@@ -5011,8 +5062,8 @@ describe('float window', function()
             {1: word           }|
             {1: longtext       }|
           ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true, 50},
-            [5] = {-1, "NW", 4, 1, 1, false, 100}
+            [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 },
+            [5] = { -1, "NW", 4, 1, 1, false, 100, 2, 3, 6 }
           }}
         else
           screen:expect([[
@@ -5041,7 +5092,7 @@ describe('float window', function()
             {7:x a^a        }|
             {12:~           }|*3
           ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true},
+            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5},
           }}
 
         else
@@ -5074,8 +5125,8 @@ describe('float window', function()
             {1:yy             }|
             {1:zz             }|
           ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true, 50},
-            [5] = {-1, "NW", 2, 1, 0, false, 100}
+            [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 },
+            [5] = { -1, "NW", 2, 1, 0, false, 100, 2, 1, 0 }
           }}
         else
           screen:expect([[
@@ -5103,7 +5154,7 @@ describe('float window', function()
             {7:x aa        }|
             {12:~           }|*3
           ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true},
+            [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 },
           }}
         else
           screen:expect([[
@@ -5136,8 +5187,8 @@ describe('float window', function()
             {1: undefine       }|
             {1: unplace        }|
           ]], float_pos={
-            [5] = {-1, "SW", 1, 6, 5, false, 250};
-            [4] = {1001, "NW", 1, 2, 5, true, 50};
+            [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 };
+            [5] = { -1, "SW", 1, 6, 5, false, 250, 3, 4, 5 };
           }}
         else
           screen:expect{grid=[[
@@ -5171,7 +5222,7 @@ describe('float window', function()
             {7:x aa^        }|
             {12:~           }|*3
           ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true},
+            [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 },
           }, popupmenu={
             anchor = {4, 0, 2}, items = items, pos = 0
           }}
@@ -5202,7 +5253,7 @@ describe('float window', function()
             {7:x a^a        }|
             {12:~           }|*3
           ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true},
+            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5},
           }}
         else
           screen:expect([[
@@ -5231,7 +5282,7 @@ describe('float window', function()
             {7:x aa        }|
             {12:~           }|*3
           ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true},
+            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5},
           }, popupmenu={
             anchor = {2, 0, 0}, items = items, pos = 0
           }}
@@ -5262,7 +5313,7 @@ describe('float window', function()
             {7:x aa        }|
             {12:~           }|*3
           ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true},
+            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5},
           }}
         else
           screen:expect([[
@@ -5297,7 +5348,7 @@ describe('float window', function()
             {1:word           }|
             {1:longtext       }|
           ]], float_pos={
-            [4] = {-1, "NW", 2, 1, 0, false, 100}}
+            [4] = {-1, "NW", 2, 1, 0, false, 100, 1, 1, 0}}
           }
         else
           screen:expect([[
@@ -5331,8 +5382,8 @@ describe('float window', function()
             {15:some info   }|
             {15:about item  }|
           ]], float_pos={
-            [4] = {-1, "NW", 2, 1, 0, false, 100},
-            [5] = {1001, "NW", 2, 1, 12, true, 50},
+            [5] = {1001, "NW", 2, 1, 12, true, 50, 1, 1, 12},
+            [4] = {-1, "NW", 2, 1, 0, false, 100, 2, 1, 0},
           }}
         else
           screen:expect([[
@@ -5362,7 +5413,7 @@ describe('float window', function()
             {15:some info   }|
             {15:about item  }|
           ]], float_pos={
-            [5] = {1001, "NW", 2, 1, 12, true},
+            [5] = {1001, "NW", 2, 1, 12, true, 50, 1, 1, 12},
           }}
         else
           screen:expect([[
@@ -5412,7 +5463,7 @@ describe('float window', function()
             {1:word           }|
             {1:longtext       }|
           ]], float_pos={
-            [4] = {-1, "NW", 2, 1, 0, false, 100},
+            [4] = {-1, "NW", 2, 1, 0, false, 100, 1, 1, 0},
           }}
         else
           screen:expect([[
@@ -5467,7 +5518,7 @@ describe('float window', function()
           here                |
           float               |
         ]], float_pos={
-          [4] = {1001, "NW", 1, 2, 5, true, 50};
+          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
@@ -5496,7 +5547,7 @@ describe('float window', function()
         win = api.nvim_open_win(buf, false, {relative='editor', width=20, height=2, row=2, col=5})
         api.nvim_buf_set_lines(buf,0,-1,true,{"y"})
         expected_pos = {
-          [4]={1001, 'NW', 1, 2, 5, true}
+          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}
         }
         if multigrid then
           screen:expect{grid=[[
@@ -6020,7 +6071,9 @@ describe('float window', function()
           ## grid 4
             {1:^y                   }|
             {2:~                   }|*5
-          ]], float_pos=expected_pos}
+          ]], float_pos={
+            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 0, 5}
+          }}
         else
           screen:expect([[
             x    {1:^y                   }               |
@@ -6149,7 +6202,9 @@ describe('float window', function()
           ## grid 4
             {1:^y                                       }|
             {2:~                                       }|
-          ]], float_pos=expected_pos}
+          ]], float_pos={
+            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 0}
+          }}
         else
           screen:expect([[
             x                                       |
@@ -6611,8 +6666,8 @@ describe('float window', function()
             {1:^y                   }|
             {2:~                   }|
           ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true},
-            [5] = {1002, "NW", 1, 4, 8, true}
+            [5] = {1002, "NW", 1, 4, 8, true, 50, 2, 4, 8},
+            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}
           }}
         else
           screen:expect([[
@@ -6641,7 +6696,7 @@ describe('float window', function()
             {1:^y                   }|
             {2:~                   }|
           ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true},
+            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5},
           }}
         else
           screen:expect([[
@@ -7317,7 +7372,7 @@ describe('float window', function()
           {1:bar                 }|
           {1:baz                 }|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 2, 5, true, 50};
+          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
@@ -7338,7 +7393,7 @@ describe('float window', function()
           {1:bar                 }|
           {1:baz                 }|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 2, 5, true, 50};
+          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
@@ -7359,7 +7414,7 @@ describe('float window', function()
           {27:ba}{1:^r                 }|
           {1:baz                 }|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 2, 5, true, 50};
+          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 1, curcol = 2, linecount = 3, sum_scroll_delta = 0};
@@ -7420,7 +7475,7 @@ describe('float window', function()
           {5:│}{1:baz                 }{5:│}|
           {5:└────────────────────┘}|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 5, true, 50};
+          [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
@@ -7443,7 +7498,7 @@ describe('float window', function()
           {5:│}{1:baz                 }{5:│}|
           {5:└────────────────────┘}|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 5, true, 50};
+          [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
@@ -7466,7 +7521,7 @@ describe('float window', function()
           {5:│}{1:baz                 }{5:│}|
           {5:└────────────────────┘}|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 5, true, 50};
+          [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 1, curcol = 2, linecount = 3, sum_scroll_delta = 0};
@@ -7527,7 +7582,7 @@ describe('float window', function()
           {1:bar                 }|
           {1:baz                 }|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 5, true, 50};
+          [4] = {1001, "NW", 1, 1, 5, true, 50, 1, 1, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
@@ -7549,7 +7604,7 @@ describe('float window', function()
           {1:bar                 }|
           {1:baz                 }|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 5, true, 50};
+          [4] = {1001, "NW", 1, 1, 5, true, 50, 1, 1, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
@@ -7571,7 +7626,7 @@ describe('float window', function()
           {27:ba}{1:^r                 }|
           {1:baz                 }|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 5, true, 50};
+          [4] = {1001, "NW", 1, 1, 5, true, 50, 1, 1, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 1, curcol = 2, linecount = 3, sum_scroll_delta = 0};
@@ -7720,7 +7775,7 @@ describe('float window', function()
           {5:│}{1:                    }{5:│}|*3
           {5:└────────────────────┘}|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 5, true, 50};
+          [4] = { 1001, "NW", 1, 0, 5, true, 50, 1, 0, 5 };
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
@@ -7775,7 +7830,7 @@ describe('float window', function()
           {5:│}{2:~                   }{5:│}|
           {5:└────────────────────┘}|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 5, true, 50};
+          [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 4, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
@@ -7810,7 +7865,7 @@ describe('float window', function()
           {5:│}{19:│}{1:                   }{5:│}|
           {5:└────────────────────┘}|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 5, true, 50};
+          [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
@@ -7914,7 +7969,7 @@ describe('float window', function()
           {1:test           }|
           {1:               }|
           {1:popup    text  }|
-        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true}}}
+        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}}}
       else
         screen:expect([[
           Ut enim ad minim veniam, quis nostrud             |
@@ -7950,7 +8005,7 @@ describe('float window', function()
           {9:test           }|
           {9:               }|
           {9:popup    text  }|
-        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true}}, unchanged=true}
+        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}}, unchanged=true}
       else
         screen:expect([[
           Ut enim ad minim veniam, quis nostrud             |
@@ -7987,7 +8042,7 @@ describe('float window', function()
           {13:test           }|
           {13:               }|
           {13:popup    text  }|
-        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true}}}
+        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}}}
       else
         screen:expect([[
           Ut enim ad minim veniam, quis nostrud             |
@@ -8032,7 +8087,7 @@ describe('float window', function()
           {9:test           }|
           {9:               }|
           {10:popup    text}{9:  }|
-        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true}}}
+        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}}}
       else
         screen:expect([[
           Ut enim ad minim veniam, quis nostrud             |
@@ -8068,7 +8123,7 @@ describe('float window', function()
           {9:test           }|
           {9:               }|
           {11:popup    text}{9:  }|
-        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true}}, unchanged=true}
+        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}}, unchanged=true}
       else
         screen:expect([[
           Ut enim ad minim veniam, quis nostrud             |
@@ -8104,7 +8159,7 @@ describe('float window', function()
         ## grid 4
           {11:popup    text}{9:  }|
           {12:~              }|*2
-        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true}}}
+        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}}}
       else
         api.nvim_input_mouse('wheel', 'down', '', 0, 4, 7)
         screen:expect([[
@@ -8147,7 +8202,7 @@ describe('float window', function()
           {17:│}{11:popup    text}{18:  }{17:│}|
           {17:│}{19:~              }{17:│}|*2
           {17:└}{23:Footer}{17:─────────┘}|
-        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true}}}
+        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}}}
       else
         screen:expect([[
           Ut enim ad minim veniam, quis nostrud             |
@@ -8184,7 +8239,7 @@ describe('float window', function()
         ## grid 4
           {1:口   }|*2
           {1:     }|
-        ]], float_pos={ [4] = { 1001, "NW", 1, 0, 11, true } }}
+        ]], float_pos={ [4] = { 1001, "NW", 1, 0, 11, true, 50, 1, 0, 11 } }}
       else
         screen:expect([[
           # TODO: 测 {1:口   }信息的准确性            |
@@ -8246,7 +8301,7 @@ describe('float window', function()
           {5:  x x  x   x}|
           {5:            }|
         ]], float_pos={
-          [5] = { 1002, "NW", 1, 0, 11, true }
+          [5] = { 1002, "NW", 1, 0, 11, true, 50, 1, 0, 11 }
         }}
       else
         screen:expect([[
@@ -8275,7 +8330,7 @@ describe('float window', function()
           {5:  x x  x   x}|
           {5:            }|
         ]], float_pos={
-          [5] = { 1002, "NW", 1, 0, 12, true }
+          [5] = { 1002, "NW", 1, 0, 12, true, 50, 1, 0, 12 }
         }}
       else
         screen:expect([[
@@ -8338,8 +8393,8 @@ describe('float window', function()
           [1] = {foreground = Screen.colors.Blue1, bold = true};
           [2] = {background = Screen.colors.LightMagenta};
         }, float_pos={
-           [4] = { 1001, "NW", 1, 1, 1, true },
-           [5] = { 1002, "NW", 1, 0, 0, true }
+            [4] = {1001, "NW", 1, 1, 1, true, 50, 2, 1, 1},
+            [5] = {1002, "NW", 1, 0, 0, true, 50, 1, 0, 0}
         }}
       else
         screen:expect([[
@@ -8391,8 +8446,8 @@ describe('float window', function()
           [1] = {foreground = Screen.colors.Blue1, bold = true};
           [2] = {background = Screen.colors.LightMagenta};
         }, float_pos={
-          [4] = { 1001, "NW", 1, 1, 1, true },
-          [5] = { 1002, "NW", 1, 0, 0, true }
+          [4] = { 1001, "NW", 1, 1, 1, true, 50, 2, 1, 1 },
+          [5] = { 1002, "NW", 1, 0, 0, true, 50, 1, 0, 0 }
         }}
       else
         screen:expect([[
@@ -8426,7 +8481,7 @@ describe('float window', function()
           {7:                    }|
           {7:~                   }|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true };
+          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -8471,9 +8526,9 @@ describe('float window', function()
           {17:^            }|
           {17:~           }|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true };
-          [5] = { 1002, "NW", 1, 3, 8, true };
-          [6] = { 1003, "NW", 1, 4, 10, true };
+          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
+          [5] = {1002, "NW", 1, 3, 8, true, 50, 2, 3, 8};
+          [6] = {1003, "NW", 1, 4, 10, true, 50, 3, 4, 10};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount=1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount=1, sum_scroll_delta = 0};
@@ -8490,6 +8545,61 @@ describe('float window', function()
           {0:~         }{17:~           }{0:                  }|
                                                   |
         ]]}
+      end
+
+      -- This should bring win into focus on top
+      api.nvim_set_current_win(win)
+      if multigrid then
+        screen:expect({
+          grid = [[
+          ## grid 1
+            [2:----------------------------------------]|*6
+            [3:----------------------------------------]|
+          ## grid 2
+                                                    |
+            {0:~                                       }|*5
+          ## grid 3
+                                                    |
+          ## grid 4
+            {7:^                    }|
+            {7:~                   }|
+          ## grid 5
+            {1:                }|
+            {1:~               }|
+          ## grid 6
+            {17:            }|
+            {17:~           }|
+          ]],
+          win_pos = {
+          [2] = {
+            height = 6,
+            startcol = 0,
+            startrow = 0,
+            width = 40,
+            win = 1000
+          }
+        },
+          float_pos = {
+          [4] = {1001, "NW", 1, 2, 5, true, 50, 3, 2, 5};
+          [5] = {1002, "NW", 1, 3, 8, true, 50, 1, 3, 8};
+          [6] = {1003, "NW", 1, 4, 10, true, 50, 2, 4, 10};
+        },
+          win_viewport = {
+          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+          [5] = {win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+          [6] = {win = 1003, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+        }})
+      else
+        screen:expect([[
+                                                  |
+          {0:~                                       }|
+          {0:~    }{7:^                    }{0:               }|
+          {0:~    }{7:~                   }{0:               }|
+          {0:~       }{1:~ }{17:            }{1:  }{0:                }|
+          {0:~         }{17:~           }{0:                  }|
+                                                  |
+        ]])
       end
     end)
 
@@ -8512,7 +8622,7 @@ describe('float window', function()
           {7:                    }|
           {7:~                   }|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true };
+          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -8557,9 +8667,9 @@ describe('float window', function()
           {1:                }|
           {1:~               }|
         ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true };
-          [5] = { 1002, "NW", 1, 4, 10, true };
-          [6] = { 1003, "NW", 1, 3, 8, true };
+          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
+          [5] = {1002, "NW", 1, 4, 10, true, 50, 3, 4, 10};
+          [6] = {1003, "NW", 1, 3, 8, true, 50, 2, 3, 8};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -8576,6 +8686,61 @@ describe('float window', function()
           {0:~         }{17:~           }{0:                  }|
                                                   |
         ]]}
+      end
+
+      -- This should bring win into focus on top
+      api.nvim_set_current_win(win)
+      if multigrid then
+        screen:expect({
+          grid = [[
+          ## grid 1
+            [2:----------------------------------------]|*6
+            [3:----------------------------------------]|
+          ## grid 2
+                                                    |
+            {0:~                                       }|*5
+          ## grid 3
+                                                    |
+          ## grid 4
+            {7:^                    }|
+            {7:~                   }|
+          ## grid 5
+            {17:            }|
+            {17:~           }|
+          ## grid 6
+            {1:                }|
+            {1:~               }|
+          ]],
+          win_pos = {
+          [2] = {
+            height = 6,
+            startcol = 0,
+            startrow = 0,
+            width = 40,
+            win = 1000
+          }
+        },
+          float_pos = {
+          [4] = {1001, "NW", 1, 2, 5, true, 50, 3, 2, 5};
+          [5] = {1002, "NW", 1, 4, 10, true, 50, 2, 4, 10};
+          [6] = {1003, "NW", 1, 3, 8, true, 50, 1, 3, 8};
+        },
+          win_viewport = {
+          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+          [5] = {win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+          [6] = {win = 1003, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+        }})
+      else
+        screen:expect([[
+                                                  |
+          {0:~                                       }|
+          {0:~    }{7:^                    }{0:               }|
+          {0:~    }{7:~                   }{0:               }|
+          {0:~       }{1:~ }{17:            }{1:  }{0:                }|
+          {0:~         }{17:~           }{0:                  }|
+                                                  |
+        ]])
       end
     end)
 
@@ -8608,9 +8773,9 @@ describe('float window', function()
           {8:                    }|
           {8:~                   }|*2
         ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 5, true, 30};
-          [5] = {1002, "NW", 1, 2, 6, true, 50};
-          [6] = {1003, "NW", 1, 3, 7, true, 40};
+          [4] = {1001, "NW", 1, 1, 5, true, 30, 1, 1, 5};
+          [5] = {1002, "NW", 1, 2, 6, true, 50, 3, 2, 6};
+          [6] = {1003, "NW", 1, 3, 7, true, 40, 2, 3, 7};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -8660,8 +8825,8 @@ describe('float window', function()
             {5:│}{8:~                   }{5:│}|*2
             {5:└────────────────────┘}|
           ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 5, true, 400};
-          [6] = {1003, "NW", 1, 3, 7, true, 300};
+          [4] = {1001, "NW", 1, 1, 5, true, 400, 3, 1, 5};
+          [6] = {1003, "NW", 1, 3, 7, true, 300, 2, 2, 7};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -8711,8 +8876,8 @@ describe('float window', function()
             {5:└────────────────────┘}|
           ]],
           float_pos = {
-          [4] = {1001, "NW", 1, 1, 5, true, 100};
-          [6] = {1003, "NW", 1, 3, 7, true, 150};
+          [4] = {1001, "NW", 1, 1, 5, true, 100, 1, 1, 5 };
+          [6] = {1003, "NW", 1, 3, 7, true, 150, 2, 1, 7 };
         },
           win_viewport = {
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -8775,7 +8940,7 @@ describe('float window', function()
           {1:               }|
           {2:~              }|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 5, true, 50};
+          [4] = {1001, "NW", 1, 1, 5, true, 50, 1, 1, 5};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -8811,7 +8976,7 @@ describe('float window', function()
           {5:│}{2:~              }{5:│}|*2
           {5:└───────────────┘}|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 4, true, 50};
+          [4] = {1001, "NW", 1, 0, 4, true, 50, 1, 0, 4};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -8851,7 +9016,7 @@ describe('float window', function()
           {5:│}{1:                                        }{5:│}|*4
           {5:└────────────────────────────────────────┘}|
         ]], float_pos={
-          [4] = {1001, "SW", 1, 9, 0, true, 50};
+          [4] = {1001, "SW", 1, 9, 0, true, 50, 1, 3, 0};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -8885,7 +9050,7 @@ describe('float window', function()
           {5:│}{1:                                        }{5:│}|*2
           {5:└────────────────────────────────────────┘}|
         ]], float_pos={
-          [4] = {1001, "SW", 1, 9, 0, true, 50};
+          [4] = {1001, "SW", 1, 9, 0, true, 50, 1, 5, 0};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -8941,7 +9106,7 @@ describe('float window', function()
           {5:│}{1:                                        }{5:│}|*4
           {5:└────────────────────────────────────────┘}|
         ]], float_pos={
-          [4] = {1001, "SW", 1, 8, 0, true, 50};
+          [4] = {1001, "SW", 1, 8, 0, true, 50, 1, 2, 0};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -8982,7 +9147,7 @@ describe('float window', function()
           {5:│}{1:                                        }{5:│}|*4
           {5:└────────────────────────────────────────┘}|
         ]], float_pos={
-          [4] = {1001, "SW", 1, 8, 0, true, 50};
+          [4] = { 1001, "SW", 1, 8, 0, true, 50, 1, 4, 0 };
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -9015,7 +9180,7 @@ describe('float window', function()
           {5:│}{1:                                        }{5:│}|*2
           {5:└────────────────────────────────────────┘}|
         ]], float_pos={
-          [4] = {1001, "SW", 1, 8, 0, true, 50};
+          [4] = {1001, "SW", 1, 8, 0, true, 50, 1, 4, 0};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -9059,7 +9224,7 @@ describe('float window', function()
         local float_opts = {relative = 'editor', row = 1, col = 1, width = 10, height = 10}
         api.nvim_open_win(api.nvim_create_buf(false, false), true, float_opts)
         if multigrid then
-          screen:expect({float_pos = {[4] = {1001, 'NW', 1, 1, 1, true}}})
+          screen:expect({float_pos = {[4] = {1001, 'NW', 1, 1, 1, true, 50, 1, 0, 1}}})
         end
         command(cmd)
         exec_lua([[
@@ -9102,7 +9267,7 @@ describe('float window', function()
           {1:cd  }|
           {2:~   }|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 1, true, 50};
+          [4] = {1001, "NW", 1, 1, 1, true, 50, 1, 1, 1};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0};
@@ -9134,7 +9299,7 @@ describe('float window', function()
           {1:c^d  }|
           {2:~   }|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 1, true, 50};
+          [4] = {1001, "NW", 1, 1, 1, true, 50, 1, 1, 1};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0};
@@ -9171,7 +9336,7 @@ describe('float window', function()
           {5:│}{2:~   }{5:│}|
           {5:└────┘}|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 1, true, 50};
+          [4] = {1001, "NW", 1, 1, 1, true, 50, 1, 1, 1};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0};
@@ -9206,7 +9371,7 @@ describe('float window', function()
           {5:│}{2:~   }{5:│}|
           {5:└────┘}|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 1, true, 50};
+          [4] = { 1001, "NW", 1, 1, 1, true, 50, 1, 1, 1 };
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0};
@@ -9244,7 +9409,7 @@ describe('float window', function()
           {5:│}{1:cd  }{5:│}|
           {5:└────┘}|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 1, true, 50};
+          [4] = {1001, "NW", 1, 1, 1, true, 50, 1, 1, 1};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0};
@@ -9279,7 +9444,7 @@ describe('float window', function()
           {5:│}{1:c^d  }{5:│}|
           {5:└────┘}|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 1, true, 50};
+          [4] = {1001, "NW", 1, 1, 1, true, 50, 1, 1, 1};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0};
@@ -9321,7 +9486,7 @@ describe('float window', function()
           {5:│}{2:    ~}{5:│}|
           {5:└─────┘}|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 1, true, 50};
+          [4] = {1001, "NW", 1, 1, 1, true, 50, 1, 1, 1};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 3, curline = 1, curcol = 2, linecount = 2, sum_scroll_delta = 0};
@@ -9344,7 +9509,7 @@ describe('float window', function()
       local buf = api.nvim_create_buf(false,false)
       local win = api.nvim_open_win(buf, false, {relative='editor', width=10, height=2, row=2, col=5, hide = true})
       local expected_pos = {
-          [4]={1001, 'NW', 1, 2, 5, true},
+          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5},
       }
 
       if multigrid then
@@ -9452,10 +9617,10 @@ describe('float window', function()
       api.nvim_open_win(buf_c, false, config_c)
       api.nvim_open_win(buf_d, false, config_d)
       local expected_pos = {
-          [4]={1001, 'NW', 1, 5, 5, true, 50},
-          [5]={1002, 'NW', 1, 7, 7, true, 70},
-          [6]={1003, 'NW', 1, 9, 9, true, 90},
-          [7]={1004, 'NW', 1, 10, 10, true, 100},
+        [4] = {1001, "NW", 1, 5, 5, true, 50, 1, 0, 5},
+        [5] = {1002, "NW", 1, 7, 7, true, 70, 2, 0, 7},
+        [6] = {1003, "NW", 1, 9, 9, true, 90, 3, 0, 9},
+        [7] = {1004, "NW", 1, 10, 10, true, 100, 4, 2, 10},
       }
       if multigrid then
         screen:expect{grid=[[
@@ -9616,7 +9781,7 @@ describe('float window', function()
             {5:│}{1:^     }{5:│}|
             {5:└─────┘}|
           ]], float_pos={
-            [4] = {1001, "NW", 1, 100, 1, true, 50};
+            [4] = {1001, "NW", 1, 100, 1, true, 50, 1, 1, 1};
           }, win_viewport={
             [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
             [4] = {win = 1001, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -9649,7 +9814,7 @@ describe('float window', function()
           {5:│}{1:^     }{5:│}|
           {5:└─────┘}|
         ]], float_pos={
-          [4] = {1001, "NW", 1, 100, 1, true, 300};
+          [4] = {1001, "NW", 1, 100, 1, true, 300, 2, 4, 1};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
@@ -9709,7 +9874,7 @@ describe('float window', function()
             {1:     }|
             {2:~    }|
           ]], float_pos={
-          [4] = {1001, "NW", 2, 0, 0, true, 50};
+            [4] = {1001, "NW", 2, 0, 0, true, 50, 1, 0, 0};
         }, win_viewport={
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};

--- a/test/functional/ui/multigrid_spec.lua
+++ b/test/functional/ui/multigrid_spec.lua
@@ -671,7 +671,7 @@ describe('ext_multigrid', function()
         {21:     }|
         {22:~    }|*4
       ]], float_pos={
-        [4] = {1001, "SE", 2, 16, 58, true, 50};
+        [4] = {1001, "SE", 2, 16, 58, true, 50, 1, 8, 48};
       }}
     end)
 
@@ -693,7 +693,7 @@ describe('ext_multigrid', function()
         {24: foo}|
         {21: bar}|
       ]], float_pos={
-        [4] = {-1, "NW", 2, 15, 55, false, 100};
+        [4] = {-1, "NW", 2, 15, 55, false, 100, 1, 15, 55};
       }}
       feed('<C-E><Esc>')
 
@@ -715,7 +715,7 @@ describe('ext_multigrid', function()
         {24:            oof}|
         {21:            rab}|
       ]], float_pos={
-        [4] = {-1, "NW", 2, 16, 45, false, 100};
+        [4] = {-1, "NW", 2, 16, 45, false, 100, 1, 16, 45};
       }}
       feed('<C-E><Esc>')
 
@@ -737,7 +737,7 @@ describe('ext_multigrid', function()
         {24: undefine       }|
         {21: unplace        }|
       ]], float_pos={
-        [4] = {-1, "SW", 1, 13, 5, false, 250};
+        [4] = {-1, "SW", 1, 13, 5, false, 250, 2, 11, 5};
       }}
     end)
 
@@ -1346,7 +1346,7 @@ describe('ext_multigrid', function()
     ## grid 6
       {21: Copy }|
     ]], float_pos={
-      [6] = {-1, "NW", 2, 2, 5, false, 250};
+      [6] = {-1, "NW", 2, 2, 5, false, 250, 2, 7, 36};
     }}
     feed('<Down><CR>')
     screen:expect{grid=[[
@@ -1420,7 +1420,7 @@ describe('ext_multigrid', function()
     ## grid 6
       {21: Copy }|
     ]], float_pos={
-      [6] = {-1, "NW", 4, 1, 63, false, 250};
+      [6] = {-1, "NW", 4, 1, 63, false, 250, 2, 1, 63};
     }}
     feed('<Down><CR>')
     screen:expect{grid=[[
@@ -1542,7 +1542,7 @@ describe('ext_multigrid', function()
     ## grid 6
       {21: Copy }|
     ]], float_pos={
-      [6] = {-1, "SW", 4, 9, 0, false, 250};
+      [6] = {-1, "SW", 4, 9, 0, false, 250, 2, 14, 0};
     }}
     feed('<Down><CR>')
     screen:expect{grid=[[
@@ -1674,7 +1674,7 @@ describe('ext_multigrid', function()
     ## grid 6
       {21: Copy }|
     ]], float_pos={
-      [6] = {-1, "NW", 4, 10, 0, false, 250};
+      [6] = {-1, "NW", 4, 10, 0, false, 250, 2, 16, 0};
     }}
     feed('<Down><CR>')
     screen:expect{grid=[[

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -1229,7 +1229,7 @@ describe('builtin popupmenu', function()
           {n:hh             }{s: }|
         ]],
           float_pos = {
-            [5] = { -1, 'NW', 2, 2, 0, false, 100 },
+            [5] = { -1, 'NW', 2, 2, 0, false, 100, 1, 11, 0 },
           },
         }
       else
@@ -1287,7 +1287,7 @@ describe('builtin popupmenu', function()
           {n:hh             }{s: }|
         ]],
           float_pos = {
-            [5] = { -1, 'NW', 2, 2, 0, false, 100 },
+            [5] = { -1, 'NW', 2, 2, 0, false, 100, 1, 2, 0 },
           },
         }
       else
@@ -1363,7 +1363,7 @@ describe('builtin popupmenu', function()
           {n:mm             }{s: }|
         ]],
           float_pos = {
-            [5] = { -1, 'SW', 2, 12, 0, false, 100 },
+            [5] = { -1, 'SW', 2, 12, 0, false, 100, 1, 4, 0 },
           },
         }
       else
@@ -1439,7 +1439,7 @@ describe('builtin popupmenu', function()
           {n:ii             }{s: }|
         ]],
           float_pos = {
-            [5] = { -1, 'SW', 2, 8, 0, false, 100 },
+            [5] = { -1, 'SW', 2, 8, 0, false, 100, 1, 8, 0 },
           },
         }
       else
@@ -1514,7 +1514,7 @@ describe('builtin popupmenu', function()
           {n:hh             }{s: }|
         ]],
           float_pos = {
-            [5] = { -1, 'SW', 2, 8, 0, false, 100 },
+            [5] = { -1, 'SW', 2, 8, 0, false, 100, 1, 0, 0 },
           },
         }
       else
@@ -1599,7 +1599,7 @@ describe('builtin popupmenu', function()
               {n:ab6            }{s: }|
             ]],
             float_pos = {
-              [5] = { -1, 'SW', 2, 6, 0, false, 100 },
+              [5] = { -1, 'SW', 2, 6, 0, false, 100, 1, 9, 0 },
             },
           })
         else
@@ -1677,7 +1677,7 @@ describe('builtin popupmenu', function()
               {n:ab5            }{s: }|
             ]],
             float_pos = {
-              [5] = { -1, 'SW', 2, 5, 0, false, 100 },
+              [5] = { -1, 'SW', 2, 5, 0, false, 100, 1, 9, 0 },
             },
           })
         else
@@ -1736,7 +1736,7 @@ describe('builtin popupmenu', function()
             {n:three          }|
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 1, 0, false, 100 },
+            [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 },
           },
         })
       else
@@ -1773,7 +1773,7 @@ describe('builtin popupmenu', function()
             {1:~                               }|*2
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 1, 0, false, 100 },
+            [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 5, 0 },
           },
         })
       else
@@ -1831,7 +1831,7 @@ describe('builtin popupmenu', function()
             {n:aa7bb          }{s: }|
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 1, 0, false, 100 },
+            [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 },
           },
         })
       else
@@ -1974,8 +1974,8 @@ describe('builtin popupmenu', function()
               },
             },
             float_pos = {
-              [5] = { -1, 'NW', 2, 1, 0, false, 100 },
-              [4] = { 1001, 'NW', 1, 1, 19, false, 50 },
+              [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
+              [4] = { 1001, 'NW', 1, 1, 19, false, 50, 1, 1, 19 },
             },
             win_viewport = {
               [2] = {
@@ -2054,8 +2054,8 @@ describe('builtin popupmenu', function()
               },
             },
             float_pos = {
-              [5] = { -1, 'NW', 2, 1, 0, false, 100 },
-              [4] = { 1001, 'NW', 1, 1, 15, false, 50 },
+              [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
+              [4] = { 1001, 'NW', 1, 1, 15, false, 50, 1, 1, 15 },
             },
             win_viewport = {
               [2] = {
@@ -2131,7 +2131,7 @@ describe('builtin popupmenu', function()
               },
             },
             float_pos = {
-              [5] = { -1, 'NW', 2, 1, 0, false, 100 },
+              [5] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 },
             },
             win_viewport = {
               [2] = {
@@ -2211,8 +2211,8 @@ describe('builtin popupmenu', function()
               },
             },
             float_pos = {
-              [5] = { -1, 'NW', 2, 1, 0, false, 100 },
-              [4] = { 1001, 'NW', 1, 1, 19, false, 50 },
+              [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
+              [4] = { 1001, 'NW', 1, 1, 19, false, 50, 1, 1, 19 },
             },
             win_viewport = {
               [2] = {
@@ -2295,8 +2295,8 @@ describe('builtin popupmenu', function()
               },
             },
             float_pos = {
-              [5] = { -1, 'NW', 2, 1, 18, false, 100 },
-              [4] = { 1001, 'NW', 1, 1, 13, false, 50 },
+              [5] = { -1, 'NW', 2, 1, 18, false, 100, 2, 1, 18 },
+              [4] = { 1001, 'NW', 1, 1, 13, false, 50, 1, 1, 13 },
             },
             win_viewport = {
               [2] = {
@@ -2383,8 +2383,8 @@ describe('builtin popupmenu', function()
               },
             },
             float_pos = {
-              [5] = { -1, 'NW', 2, 1, 0, false, 100 },
-              [4] = { 1001, 'NW', 1, 1, 19, false, 50 },
+              [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
+              [4] = { 1001, 'NW', 1, 1, 19, false, 50, 1, 1, 19 },
             },
             win_viewport = {
               [2] = {
@@ -2475,8 +2475,8 @@ describe('builtin popupmenu', function()
               },
             },
             float_pos = {
-              [5] = { 1001, 'NW', 1, 1, 19, false, 50 },
-              [4] = { -1, 'NW', 2, 1, 0, false, 100 },
+              [5] = { 1001, 'NW', 1, 1, 19, false, 50, 1, 1, 19 },
+              [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
             },
             win_viewport = {
               [2] = {
@@ -2599,7 +2599,7 @@ describe('builtin popupmenu', function()
           {n: aac            }|
         ]],
           float_pos = {
-            [5] = { -1, 'NW', 4, 2, 3, false, 100 },
+            [5] = { -1, 'NW', 4, 2, 3, false, 100, 1, 2, 3 },
           },
         }
       else
@@ -2641,7 +2641,7 @@ describe('builtin popupmenu', function()
           {n: aac            }|
         ]],
           float_pos = {
-            [5] = { -1, 'NW', 2, 3, 1, false, 100 },
+            [5] = { -1, 'NW', 2, 3, 1, false, 100, 1, 3, 13 },
           },
         }
       else
@@ -2685,7 +2685,7 @@ describe('builtin popupmenu', function()
           {n: aaabcdef}|
         ]],
           float_pos = {
-            [5] = { -1, 'NW', 2, 3, 11, false, 100 },
+            [5] = { -1, 'NW', 2, 3, 11, false, 100, 1, 3, 23 },
           },
         }
       else
@@ -2730,7 +2730,7 @@ describe('builtin popupmenu', function()
           {n: aac            }{s: }|
         ]],
           float_pos = {
-            [5] = { -1, 'NW', 2, 4, -1, false, 100 },
+            [5] = { -1, 'NW', 2, 4, -1, false, 100, 1, 4, 11 },
           },
         }
       else
@@ -2852,7 +2852,7 @@ describe('builtin popupmenu', function()
             {s: Est            }{c: }|
           ]],
           float_pos = {
-            [5] = { -1, 'NW', 4, 1, 3, false, 100 },
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 },
           },
         })
       else
@@ -2914,7 +2914,7 @@ describe('builtin popupmenu', function()
             {s: Est            }{c: }|
           ]],
           float_pos = {
-            [5] = { -1, 'NW', 4, 1, 3, false, 100 },
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 },
           },
         })
       else
@@ -2975,7 +2975,7 @@ describe('builtin popupmenu', function()
             {s: est            }|
           ]],
           float_pos = {
-            [5] = { -1, 'NW', 4, 1, 3, false, 100 },
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 },
           },
         })
       else
@@ -3035,7 +3035,7 @@ describe('builtin popupmenu', function()
             {s: est            }|
           ]],
           float_pos = {
-            [5] = { -1, 'NW', 4, 1, 3, false, 100 },
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 },
           },
         })
       else
@@ -3088,7 +3088,7 @@ describe('builtin popupmenu', function()
             {s: est            }|
           ]],
           float_pos = {
-            [5] = { -1, 'NW', 4, 1, 3, false, 100 },
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 },
           },
         })
       else
@@ -3140,7 +3140,7 @@ describe('builtin popupmenu', function()
             {s: est            }|
           ]],
           float_pos = {
-            [5] = { -1, 'NW', 4, 1, 3, false, 100 },
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 },
           },
         })
       else
@@ -3201,7 +3201,7 @@ describe('builtin popupmenu', function()
             {s: est            }|
           ]],
           float_pos = {
-            [5] = { -1, 'NW', 4, 1, 3, false, 100 },
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 },
           },
         })
       else
@@ -3261,7 +3261,7 @@ describe('builtin popupmenu', function()
             {n: est            }|
           ]],
           float_pos = {
-            [5] = { -1, 'NW', 4, 1, 3, false, 100 },
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 },
           },
         })
       else
@@ -3321,7 +3321,7 @@ describe('builtin popupmenu', function()
             {n: est            }|
           ]],
           float_pos = {
-            [5] = { -1, 'NW', 4, 1, 3, false, 100 },
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 },
           },
         })
       else
@@ -3381,7 +3381,7 @@ describe('builtin popupmenu', function()
             {n: eö                 }|
           ]],
           float_pos = {
-            [5] = { -1, 'NW', 4, 1, 2, false, 100 },
+            [5] = { -1, 'NW', 4, 1, 2, false, 100, 1, 1, 2 },
           },
         })
       else
@@ -3440,7 +3440,7 @@ describe('builtin popupmenu', function()
             {n: eö             }|
           ]],
           float_pos = {
-            [5] = { -1, 'NW', 4, 1, 2, false, 100 },
+            [5] = { -1, 'NW', 4, 1, 2, false, 100, 1, 1, 2 },
           },
         })
       else
@@ -3499,7 +3499,7 @@ describe('builtin popupmenu', function()
             {n: eö             }|
           ]],
           float_pos = {
-            [5] = { -1, 'NW', 4, 1, 2, false, 100 },
+            [5] = { -1, 'NW', 4, 1, 2, false, 100, 1, 1, 2 },
           },
         })
       else
@@ -3551,7 +3551,7 @@ describe('builtin popupmenu', function()
             {n: bar            }|
           ]],
           float_pos = {
-            [5] = { -1, 'NW', 4, 1, 4, false, 100 },
+            [5] = { -1, 'NW', 4, 1, 4, false, 100, 1, 1, 4 },
           },
         })
       else
@@ -3643,7 +3643,7 @@ describe('builtin popupmenu', function()
             {n: thing }|
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 1, 25, false, 100 },
+            [4] = { -1, 'NW', 2, 1, 25, false, 100, 1, 1, 25 },
           },
         })
       else
@@ -3678,7 +3678,7 @@ describe('builtin popupmenu', function()
             {s:thing          }|
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 2, 0, false, 100 },
+            [4] = { -1, 'NW', 2, 2, 0, false, 100, 1, 2, 0 },
           },
         })
       else
@@ -3714,7 +3714,7 @@ describe('builtin popupmenu', function()
             {n: thing }|
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 1, 25, false, 100 },
+            [4] = { -1, 'NW', 2, 1, 25, false, 100, 1, 1, 25 },
           },
         })
       else
@@ -3749,7 +3749,7 @@ describe('builtin popupmenu', function()
             {n:thing          }|
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 2, 0, false, 100 },
+            [4] = { -1, 'NW', 2, 2, 0, false, 100, 1, 2, 0 },
           },
         })
       else
@@ -3784,7 +3784,7 @@ describe('builtin popupmenu', function()
             {n: thing          }|
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 1, 27, false, 100 },
+            [4] = { -1, 'NW', 2, 1, 27, false, 100, 1, 1, 27 },
           },
         })
       else
@@ -3819,7 +3819,7 @@ describe('builtin popupmenu', function()
             {n: thing          }|
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 2, 3, false, 100 },
+            [4] = { -1, 'NW', 2, 2, 3, false, 100, 1, 2, 3 },
           },
         })
       else
@@ -3856,7 +3856,7 @@ describe('builtin popupmenu', function()
             {n: thing          }|
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 2, 3, false, 100 },
+            [4] = { -1, 'NW', 2, 2, 3, false, 100, 1, 2, 3 },
           },
         })
       else
@@ -3888,7 +3888,7 @@ describe('builtin popupmenu', function()
             {n: thing          }|
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 2, 3, false, 100 },
+            [4] = { -1, 'NW', 2, 2, 3, false, 100, 1, 2, 3 },
           },
         })
       else
@@ -3919,7 +3919,7 @@ describe('builtin popupmenu', function()
             {n: thing   }|
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 2, 10, false, 100 },
+            [4] = { -1, 'NW', 2, 2, 10, false, 100, 1, 2, 10 },
           },
         })
       else
@@ -3960,7 +3960,7 @@ describe('builtin popupmenu', function()
             {n: thing }|
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 1, 25, false, 100 },
+            [4] = { -1, 'NW', 2, 1, 25, false, 100, 1, 1, 25 },
           },
         })
       else
@@ -3996,7 +3996,7 @@ describe('builtin popupmenu', function()
             {n: thing       }|
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 3, 3, false, 100 },
+            [4] = { -1, 'NW', 2, 3, 3, false, 100, 1, 3, 3 },
           },
         })
       else
@@ -4058,7 +4058,7 @@ describe('builtin popupmenu', function()
             {n:          gniht }|
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 1, 2, false, 100 },
+            [4] = { -1, 'NW', 2, 1, 2, false, 100, 1, 1, 2 },
           },
         })
       else
@@ -4092,7 +4092,7 @@ describe('builtin popupmenu', function()
             {n:          gniht }|
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 1, 2, false, 100 },
+            [4] = { -1, 'NW', 2, 1, 2, false, 100, 1, 1, 2 },
           },
         })
       else
@@ -4176,7 +4176,7 @@ describe('builtin popupmenu', function()
             {n: unplace        }|
           ]],
           float_pos = {
-            [4] = { -1, 'SW', 1, 19, 5, false, 250 },
+            [4] = { -1, 'SW', 1, 19, 5, false, 250, 2, 13, 5 },
           },
         })
       else
@@ -4224,7 +4224,7 @@ describe('builtin popupmenu', function()
           {s: }{n:         eciohc }|
         ]],
           float_pos = {
-            [5] = { -1, 'NW', 4, 1, -11, false, 100 },
+            [5] = { -1, 'NW', 4, 1, -11, false, 100, 1, 1, 9 },
           },
         }
       else
@@ -4261,7 +4261,7 @@ describe('builtin popupmenu', function()
           {s: }{n:         eciohc}|
         ]],
           float_pos = {
-            [5] = { -1, 'NW', 4, 2, 4, false, 100 },
+            [5] = { -1, 'NW', 4, 2, 4, false, 100, 1, 2, 24 },
           },
         }
       else
@@ -4328,7 +4328,7 @@ describe('builtin popupmenu', function()
           {n:jump           }{s: }|
         ]],
           float_pos = {
-            [5] = { -1, 'SW', 1, 5, 0, false, 250 },
+            [5] = { -1, 'SW', 1, 5, 0, false, 250, 2, 3, 0 },
           },
         }
       else
@@ -5061,7 +5061,7 @@ describe('builtin popupmenu', function()
             {n: unplace        }|
           ]],
           float_pos = {
-            [4] = { -1, 'SW', 1, 9, 5, false, 250 },
+            [4] = { -1, 'SW', 1, 9, 5, false, 250, 2, 3, 5 },
           },
         })
       else
@@ -5423,7 +5423,7 @@ describe('builtin popupmenu', function()
           {n: choice}{s: }|
         ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 1, 24, false, 100 },
+            [4] = { -1, 'NW', 2, 1, 24, false, 100, 1, 1, 24 },
           },
         }
       else
@@ -5462,7 +5462,7 @@ describe('builtin popupmenu', function()
           {n: thing }|
         ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 1, 25, false, 100 },
+            [4] = { -1, 'NW', 2, 1, 25, false, 100, 1, 1, 25 },
           },
         }
       else
@@ -5505,7 +5505,7 @@ describe('builtin popupmenu', function()
           {s: 123456789_123456789_123456789_a }|
           {n: 123456789_123456789_123456789_b }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100, 1, 3, 11 } },
         })
       else
         screen:expect([[
@@ -5539,7 +5539,7 @@ describe('builtin popupmenu', function()
           {s: 1234567...}|
           {n: 1234567...}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100, 1, 3, 11 } },
         })
       else
         screen:expect([[
@@ -5573,7 +5573,7 @@ describe('builtin popupmenu', function()
           {s: 123456789_1234567...}|
           {n: 123456789_1234567...}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100, 1, 3, 11 } },
         })
       else
         screen:expect([[
@@ -5607,7 +5607,7 @@ describe('builtin popupmenu', function()
           {s: 12345...}|
           {n: 12345...}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100, 1, 3, 11 } },
         })
       else
         screen:expect([[
@@ -5642,7 +5642,7 @@ describe('builtin popupmenu', function()
           {s: 12345...}|
           {n: 12345...}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 4, 11, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 4, 11, false, 100, 1, 4, 11 } },
         })
       else
         screen:expect([[
@@ -5695,7 +5695,7 @@ describe('builtin popupmenu', function()
           {n:abcdefghij                     }|
           {n:上下左右                       }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
         })
       else
         screen:expect([[
@@ -5729,7 +5729,7 @@ describe('builtin popupmenu', function()
           {n:abcdefghij}|
           {n:上下左右  }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
         })
       else
         screen:expect([[
@@ -5763,7 +5763,7 @@ describe('builtin popupmenu', function()
           {n:jihgfedcba}|
           {n:  右左下上}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 50, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 50, false, 100, 1, 1, 50 } },
         })
       else
         screen:expect([[
@@ -5798,7 +5798,7 @@ describe('builtin popupmenu', function()
           {n:ab}|
           {n:上}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
         })
       else
         screen:expect([[
@@ -5847,7 +5847,7 @@ describe('builtin popupmenu', function()
           {n:bar barKind...}|
           {n:baz bazKind...}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
         })
       else
         screen:expect([[
@@ -5879,7 +5879,7 @@ describe('builtin popupmenu', function()
           {n:...dniKrab rab}|
           {n:...dniKzab zab}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 18, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 18, false, 100, 1, 1, 18 } },
         })
       else
         screen:expect([[
@@ -5912,7 +5912,7 @@ describe('builtin popupmenu', function()
           {n:bar barKin...}|
           {n:baz bazKin...}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
         })
       else
         screen:expect([[
@@ -5944,7 +5944,7 @@ describe('builtin popupmenu', function()
           {n:...niKrab rab}|
           {n:...niKzab zab}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 19, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 19, false, 100, 1, 1, 19 } },
         })
       else
         screen:expect([[
@@ -5996,7 +5996,7 @@ describe('builtin popupmenu', function()
         ## grid 4
           {n: 一二三四五六七八九>}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 12, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 12, false, 100, 1, 1, 12 } },
         })
       else
         screen:expect([[
@@ -6023,7 +6023,7 @@ describe('builtin popupmenu', function()
         ## grid 4
           {n: 一二三 四五六 七八>}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 12, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 12, false, 100, 1, 1, 12 } },
         })
       else
         screen:expect([[
@@ -6051,7 +6051,7 @@ describe('builtin popupmenu', function()
         ## grid 4
           {n:<九八七六五四三二一 }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
         })
       else
         screen:expect([[
@@ -6078,7 +6078,7 @@ describe('builtin popupmenu', function()
         ## grid 4
           {n:<八七 六五四 三二一 }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
         })
       else
         screen:expect([[
@@ -6130,7 +6130,7 @@ describe('builtin popupmenu', function()
           {n: 一二三四五六七八九>}{c: }|*2
           {n: 一二三四五六七八九>}{s: }|*2
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 11, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 11, false, 100, 1, 1, 11 } },
         })
       else
         screen:expect([[
@@ -6159,7 +6159,7 @@ describe('builtin popupmenu', function()
           {n: abcdef ghijkl mnopq}{c: }|*2
           {n: 一二三 四五六 七八>}{s: }|*2
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 11, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 11, false, 100, 1, 1, 11 } },
         })
       else
         screen:expect([[
@@ -6189,7 +6189,7 @@ describe('builtin popupmenu', function()
           {c: }{n:<九八七六五四三二一 }|*2
           {s: }{n:<九八七六五四三二一 }|*2
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
         })
       else
         screen:expect([[
@@ -6218,7 +6218,7 @@ describe('builtin popupmenu', function()
           {c: }{n:qponm lkjihg fedcba }|*2
           {s: }{n:<八七 六五四 三二一 }|*2
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
         })
       else
         screen:expect([[
@@ -6263,7 +6263,7 @@ describe('builtin popupmenu', function()
           {n: bar }|
           {n: baz }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250, 2, 1, 3 } },
         })
       else
         feed('<RightMouse><4,0>')
@@ -6293,7 +6293,7 @@ describe('builtin popupmenu', function()
           {n: bar }|
           {n: baz }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250, 2, 1, 3 } },
         })
       else
         screen:expect([[
@@ -6322,7 +6322,7 @@ describe('builtin popupmenu', function()
           {s: bar }|
           {n: baz }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250, 2, 1, 3 } },
         })
       else
         screen:expect([[
@@ -6374,7 +6374,7 @@ describe('builtin popupmenu', function()
           {n: bar }|
           {n: baz }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 3, 19, false, 250 } },
+          float_pos = { [4] = { -1, 'NW', 2, 3, 19, false, 250, 2, 3, 19 } },
         })
       else
         feed('<RightMouse><20,2>')
@@ -6403,7 +6403,7 @@ describe('builtin popupmenu', function()
           {n: bar }|
           {n: baz }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 17, false, 250 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 17, false, 250, 2, 1, 17 } },
         }
       else
         feed('<RightMouse><18,0>')
@@ -6433,7 +6433,7 @@ describe('builtin popupmenu', function()
           {n: bar }|
           {n: baz }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 3, 19, false, 250 } },
+          float_pos = { [4] = { -1, 'NW', 2, 3, 19, false, 250, 2, 3, 19 } },
         })
       else
         feed('<RightMouse><20,2>')
@@ -6486,7 +6486,7 @@ describe('builtin popupmenu', function()
           {n: bar }|
           {n: baz }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250, 2, 1, 3 } },
         })
       else
         feed('<RightMouse><4,0>')
@@ -6516,7 +6516,7 @@ describe('builtin popupmenu', function()
           {n: bar }|
           {s: baz }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250, 2, 1, 3 } },
         })
       else
         feed('<RightDrag><6,3>')
@@ -6571,7 +6571,7 @@ describe('builtin popupmenu', function()
           {n: bar }|
           {n: baz }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250, 2, 1, 3 } },
         })
       else
         feed('<RightMouse><4,0>')
@@ -6602,7 +6602,7 @@ describe('builtin popupmenu', function()
           {n: bar }|
           {n: baz }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250, 2, 1, 3 } },
         })
       else
         feed('<ScrollWheelUp><4,0>')
@@ -6633,7 +6633,7 @@ describe('builtin popupmenu', function()
           {n: bar }|
           {s: baz }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250, 2, 1, 3 } },
         })
       else
         feed('<MouseMove><6,3>')
@@ -6664,7 +6664,7 @@ describe('builtin popupmenu', function()
           {s: bar }|
           {n: baz }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250, 2, 1, 3 } },
         })
       else
         feed('<ScrollWheelDown><6,3>')
@@ -6726,7 +6726,7 @@ describe('builtin popupmenu', function()
           ^popup menu test                 |
           {1:~                               }|
         ]],
-          float_pos = { [4] = { -1, 'SW', 5, 1, 19, false, 250 } },
+          float_pos = { [4] = { -1, 'SW', 5, 1, 19, false, 250, 2, 1, 19 } },
         })
       else
         feed('<RightMouse><20,4>')
@@ -6797,7 +6797,7 @@ describe('builtin popupmenu', function()
           ^popup menu test |
           {1:~               }|
         ]],
-          float_pos = { [4] = { -1, 'SW', 6, 1, 12, false, 250 } },
+          float_pos = { [4] = { -1, 'SW', 6, 1, 12, false, 250, 2, 1, 28 } },
         })
       else
         feed('<RightMouse><30,4>')
@@ -6871,7 +6871,7 @@ describe('builtin popupmenu', function()
           {2:WINBAR          }|
           ^popup menu test |
         ]],
-          float_pos = { [4] = { -1, 'SW', 6, 1, 12, false, 250 } },
+          float_pos = { [4] = { -1, 'SW', 6, 1, 12, false, 250, 2, 1, 28 } },
         })
       else
         feed('<RightMouse><30,4>')
@@ -6948,7 +6948,7 @@ describe('builtin popupmenu', function()
           {2:WINBAR          }|
           ^popup menu test |
         ]],
-          float_pos = { [4] = { -1, 'NW', 1, 1, 19, false, 250 } },
+          float_pos = { [4] = { -1, 'NW', 1, 1, 19, false, 250, 2, 1, 19 } },
         }
       else
         no_sel_screen = {
@@ -7050,7 +7050,7 @@ describe('builtin popupmenu', function()
           {2:WINBAR          }|
           popup menu test |
         ]],
-          float_pos = { [4] = { -1, 'NW', 1, 1, 17, false, 250 } },
+          float_pos = { [4] = { -1, 'NW', 1, 1, 17, false, 250, 2, 1, 17 } },
         }
       else
         no_sel_screen = {
@@ -7288,7 +7288,7 @@ describe('builtin popupmenu', function()
             {n: Select All      }|
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 1, 33, false, 250 },
+            [4] = { -1, 'NW', 2, 1, 33, false, 250, 2, 1, 33 },
           },
         })
       else
@@ -7337,7 +7337,7 @@ describe('builtin popupmenu', function()
             {n:      llA tceleS }|
           ]],
           float_pos = {
-            [4] = { -1, 'NW', 2, 1, 0, false, 250 },
+            [4] = { -1, 'NW', 2, 1, 0, false, 250, 2, 1, 0 },
           },
         })
       else

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -953,11 +953,13 @@ function Screen:_handle_grid_resize(grid, width, height)
   }
 end
 
-function Screen:_handle_msg_set_pos(grid, row, scrolled, char)
+function Screen:_handle_msg_set_pos(grid, row, scrolled, char, zindex, compindex)
   self.msg_grid = grid
   self.msg_grid_pos = row
   self.msg_scrolled = scrolled
   self.msg_sep_char = char
+  self.msg_zindex = zindex
+  self.msg_compindex = compindex
 end
 
 function Screen:_handle_flush() end


### PR DESCRIPTION
### Problem
The UI multigrid protocol does not include enough information to render the UI like the TUI. Both the rendering order and position information are missing.  Furthermore, the lack of position information breaks basic functionality like `screenchar(), screenstring() and getmousepos()`, so many plugins are broken. Especially, the lack of mouse support is quite embarrassing for a GUI and have bothered the Neovide maintainers for a long time.

### Solution
Partially run the compositor, and include the compositor information in the protocol, `compindex`, `abs_row`, and `abs_col` are included. You can also pass grid 0 to `nvim_input_mouse`, to let nvim determine the grid. 

The usage of this information is optional, and UIs are still allowed to position the floating windows as they like. But in that case, they still have to pass the grid id to `nvim_input_mouse`, and of course `getmousepos()` and similar does not work in that case.

**NOTE:** This includes the following, which need to be merged first, so only the last commit in this PR is relevant for reviewing
* https://github.com/neovim/neovim/pull/32440
* https://github.com/neovim/neovim/pull/32470

This fixes the following issues
* fixes https://github.com/neovim/neovim/issues/30586
* fixes https://github.com/neovim/neovim/issues/30581
* fixes https://github.com/neovim/neovim/issues/24801

**The information below is not relevant anymore**: The testing functionality and actual fixes for `screenchar` and `getmousepos` have been removed from this PR, and will be added in follow up PR


In order to be able to test this, a new test variable `NVIM_TEST_FORCE_MULTIGRID` has been added. This forces `nvim` to run with multigrid enabled, but the code in `screen.lua` emulates the non-multigrid mode, so that almost the whole test suite can be run. Note that this is a manual option for now, but I suppose it could be added to the CI at some point. The whole test suite passes with `NVIM_TEST_FORCE_MULTIGRID=1`, but some tests are disabled due to the following known bugs: #24802, #31811,  #24705. Additionally, there's an unreported bug that the multgrid UI fails to resize when a message is showing.

And some minor behaviour differences have been dealt with using conditionals. For example, in multigrid the cursor moves when the window is moved, while it stays in place in the TUI. And the TUI clears the command-line when it's resized in one of the tests, which to me looks like a bug.

Some additional test framework fixes were also done:
* make testing of ext_cmdline optional
* reset of cmdline abort state only when the expectation has finished


These changes also lay the foundation for running both multigrid and non-multigrid at the same time, or even to deprecate everything else than multigrid in the future. I'm not sure what's missing, I have not tested, but to me it looks very close. Almost all the multigrid specific code is now a simple `if ui_has(kUIMultigrid)` rather than `if/else`. One difference is `ext_cmdline`, which reports different grid ids and offsets depending on if multigrid is enabled or not. I did not want to fix that, since it's a breaking change.

This has been tested on the Neovide side here: https://github.com/neovide/neovide/pull/2919

Other attempts to partially fix some of these issuses
* https://github.com/neovim/neovim/pull/31788
* https://github.com/neovim/neovim/pull/29316