### PR TITLE
fix(messages): better formatting for ext_messages

### DIFF
--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -1714,6 +1714,7 @@ void listdigraphs(bool use_headers)
 {
   result_T previous = 0;
 
+  msg_ext_set_kind("list_cmd");
   msg_putchar('\n');
 
   const digr_T *dp = digraphdefault;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2222,6 +2222,7 @@ static void msg_puts_display(const char *str, int maxlen, int hl_id, int recurse
     size_t len = maxlen < 0 ? strlen(str) : strnlen(str, (size_t)maxlen);
     ga_concat_len(&msg_ext_last_chunk, str, len);
     msg_ext_cur_len += len;
+    msg_col += (int)mb_string2cells(str);
     // When message ends in newline, reset variables used to format message: msg_advance().
     assert(len > 0);
     if (str[len - 1] == '\n') {

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1121,7 +1121,7 @@ stack traceback:
     ]],
       messages = {
         {
-          content = { { 'wildmenu  wildmode' } },
+          content = { { 'wildmenu  wildmode\n' } },
           history = false,
           kind = 'wildlist',
         },
@@ -1334,6 +1334,21 @@ stack traceback:
     ]])
     feed('i')
     n.assert_alive()
+  end)
+
+  it(':digraph contains newlines', function()
+    command('digraph')
+    screen:expect({
+      condition = function()
+        local nl = 0
+        eq('list_cmd', screen.messages[1].kind)
+        for _, chunk in ipairs(screen.messages[1].content) do
+          nl = nl + (chunk[2]:find('\n') and 1 or 0)
+        end
+        eq(682, nl)
+        screen.messages = {}
+      end,
+    })
   end)
 end)
 


### PR DESCRIPTION
Problem:  Message grid newline formatting based on `msg_col` is not
          utilized with ext_messages.
Solution: Increment `msg_col` with the cell width of the chunk. Allowing
          message code that uses `msg_col` to determine when to place a
          newline to do so. E.g. when the message goes beyond `Columns`;
          this is not necessarily where the ext_messages implementation
          would want to place a newline, but it is a best guess. Message
          parsing and manipulation is still possible.