### PR TITLE
vim-patch:9.1.0987: filetype: cake files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -353,6 +353,7 @@ local extension = {
   cql = 'cqlang',
   crm = 'crm',
   cr = 'crystal',
+  cake = 'cs',
   csx = 'cs',
   cs = 'cs',
   csc = 'csc',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -195,7 +195,7 @@ func s:GetFilenameChecks() abort
     \ 'crm': ['file.crm'],
     \ 'crontab': ['crontab', 'crontab.file', '/etc/cron.d/file', 'any/etc/cron.d/file'],
     \ 'crystal': ['file.cr'],
-    \ 'cs': ['file.cs', 'file.csx'],
+    \ 'cs': ['file.cs', 'file.csx', 'file.cake'],
     \ 'csc': ['file.csc'],
     \ 'csdl': ['file.csdl'],
     \ 'csp': ['file.csp', 'file.fdr'],


### PR DESCRIPTION
Problem:  filetype: cake files are not recognized
Solution: detect '*.cake' files as cs filetype
          (Zoe Roux)

References:
https://cakebuild.net/

closes: vim/vim#16367

https://github.com/vim/vim/commit/a407573f30a978b3aa61532bbd9b0ae94a87dc32

Co-authored-by: Zoe Roux <zoe.roux@zoriya.dev>
