### PR TITLE
vim-patch:fc61cfd: runtime(vim): Update matchit pattern, no Vim9 short names

### DIFF
--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -1,9 +1,9 @@
 " Vim filetype plugin
 " Language:		Vim
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
-" Last Change:		2024 Apr 13
-" 			2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+" Last Change:		2025 Jan 3
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
+" Contributors:		Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -103,8 +103,8 @@ if exists("loaded_matchit")
 	\ '\<try\>:\%(\%(^\||\)\s*\)\@<=\<cat\%[ch]\>:\%(\%(^\||\)\s*\)\@<=\<fina\%[lly]\>:\%(\%(^\||\)\s*\)\@<=\<endt\%[ry]\>,' ..
 	\ '\<aug\%[roup]\s\+\%(END\>\)\@!\S:\<aug\%[roup]\s\+END\>,' ..
 	\ '\<class\>:\<endclass\>,' ..
-	\ '\<inte\%[rface]\>:\<endinterface\>,' ..
-	\ '\<enu\%[m]\>:\<endenum\>,'
+	\ '\<interface\>:\<endinterface\>,' ..
+	\ '\<enum\>:\<endenum\>,'
 
   " Ignore syntax region commands and settings, any 'en*' would clobber
   " if-endif.


### PR DESCRIPTION
#### vim-patch:fc61cfd: runtime(vim): Update matchit pattern, no Vim9 short names

Abbreviated :enum and :interface commands are no longer supported.

https://github.com/vim/vim/commit/fc61cfd60e6d99765d1a68d39d6613e0917c7c56

Co-authored-by: Doug Kearns <dougkearns@gmail.com>