### PR TITLE
test: use spawn_wait() instead of system()

### DIFF
--- a/test/functional/core/exit_spec.lua
+++ b/test/functional/core/exit_spec.lua
@@ -8,8 +8,6 @@ local feed = n.feed
 local eval = n.eval
 local eq = t.eq
 local run = n.run
-local fn = n.fn
-local nvim_prog = n.nvim_prog
 local pcall_err = t.pcall_err
 local exec_capture = n.exec_capture
 local poke_eventloop = n.poke_eventloop
@@ -69,8 +67,8 @@ describe(':cquit', function()
       poke_eventloop()
       assert_alive()
     else
-      fn.system({ nvim_prog, '-u', 'NONE', '-i', 'NONE', '--headless', '--cmd', cmdline })
-      eq(exit_code, eval('v:shell_error'))
+      local p = n.spawn_wait('--cmd', cmdline)
+      eq(exit_code, p.status)
     end
   end
 

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -77,22 +77,9 @@ describe('startup', function()
   end)
 
   it('--startuptime does not crash on error #31125', function()
-    eq(
-      "E484: Can't open file .",
-      fn.system({
-        nvim_prog,
-        '-u',
-        'NONE',
-        '-i',
-        'NONE',
-        '--headless',
-        '--startuptime',
-        '.',
-        '-c',
-        '42cquit',
-      })
-    )
-    eq(42, api.nvim_get_vvar('shell_error'))
+    local p = n.spawn_wait('--startuptime', '.', '-c', '42cquit')
+    eq("E484: Can't open file .", p.stderr)
+    eq(42, p.status)
   end)
 
   it('-D does not hang #12647', function()
@@ -184,7 +171,7 @@ describe('startup', function()
 
     it('Lua-error sets Nvim exitcode', function()
       local proc = n.spawn_wait('-l', 'test/functional/fixtures/startup-fail.lua')
-      matches('E5113: .* my pearls!!', proc.output)
+      matches('E5113: .* my pearls!!', proc:output())
       eq(1, proc.status)
 
       eq(0, eval('v:shell_error'))
@@ -606,15 +593,15 @@ describe('startup', function()
   it('fails on --embed with -es/-Es/-l', function()
     matches(
       'nvim[.exe]*: %-%-embed conflicts with %-es/%-Es/%-l',
-      fn.system({ nvim_prog, '--embed', '-es' })
+      n.spawn_wait('--embed', '-es').stderr
     )
     matches(
       'nvim[.exe]*: %-%-embed conflicts with %-es/%-Es/%-l',
-      fn.system({ nvim_prog, '--embed', '-Es' })
+      n.spawn_wait('--embed', '-Es').stderr
     )
     matches(
       'nvim[.exe]*: %-%-embed conflicts with %-es/%-Es/%-l',
-      fn.system({ nvim_prog, '--embed', '-l', 'foo.lua' })
+      n.spawn_wait('--embed', '-l', 'foo.lua').stderr
     )
   end)
 
@@ -698,20 +685,8 @@ describe('startup', function()
   end)
 
   it('get command line arguments from v:argv', function()
-    local out = fn.system({
-      nvim_prog,
-      '-u',
-      'NONE',
-      '-i',
-      'NONE',
-      '--headless',
-      '--cmd',
-      nvim_set,
-      '-c',
-      [[echo v:argv[-1:] len(v:argv) > 1]],
-      '+q',
-    })
-    eq("['+q'] 1", out)
+    local p = n.spawn_wait('--cmd', nvim_set, '-c', [[echo v:argv[-1:] len(v:argv) > 1]], '+q')
+    eq("['+q'] 1", p.stderr)
   end)
 end)
 

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -106,20 +106,15 @@ describe('vim.ui_attach', function()
   end)
 
   it('does not crash on exit', function()
-    fn.system({
-      n.nvim_prog,
-      '-u',
-      'NONE',
-      '-i',
-      'NONE',
+    local p = n.spawn_wait(
       '--cmd',
       [[ lua ns = vim.api.nvim_create_namespace 'testspace' ]],
       '--cmd',
       [[ lua vim.ui_attach(ns, {ext_popupmenu=true}, function() end) ]],
       '--cmd',
-      'quitall!',
-    })
-    eq(0, n.eval('v:shell_error'))
+      'quitall!'
+    )
+    eq(0, p.status)
   end)
 
   it('can receive accurate message kinds even if they are history', function()

--- a/test/functional/options/defaults_spec.lua
+++ b/test/functional/options/defaults_spec.lua
@@ -14,7 +14,6 @@ local api = n.api
 local command = n.command
 local clear = n.clear
 local exc_exec = n.exc_exec
-local exec_lua = n.exec_lua
 local eval = n.eval
 local eq = t.eq
 local ok = t.ok
@@ -929,17 +928,12 @@ describe('stdpath()', function()
     assert_alive() -- Check for crash. #8393
 
     -- Check that Nvim rejects invalid APPNAMEs
-    -- Call jobstart() and jobwait() in the same RPC request to reduce flakiness.
     local function test_appname(testAppname, expected_exitcode)
-      local lua_code = string.format(
-        [[
-        local child = vim.fn.jobstart({ vim.v.progpath, '--clean', '--headless', '--listen', 'x', '+qall!' }, { env = { NVIM_APPNAME = %q } })
-        return vim.fn.jobwait({ child }, %d)[1]
-      ]],
-        testAppname,
-        3000
-      )
-      eq(expected_exitcode, exec_lua(lua_code))
+      local p = n.spawn_wait({
+        args = { '--listen', 'x', '+qall!' },
+        env = { NVIM_APPNAME = testAppname },
+      })
+      eq(expected_exitcode, p.status)
     end
     -- Invalid appnames:
     test_appname('a/../b', 1)

--- a/test/functional/terminal/highlight_spec.lua
+++ b/test/functional/terminal/highlight_spec.lua
@@ -6,7 +6,6 @@ local tt = require('test.functional.testterm')
 local feed, clear = n.feed, n.clear
 local api = n.api
 local testprg, command = n.testprg, n.command
-local nvim_prog_abs = n.nvim_prog_abs
 local fn = n.fn
 local nvim_set = n.nvim_set
 local is_os = t.is_os
@@ -151,7 +150,7 @@ it(':terminal highlight has lower precedence than editor #9964', function()
   })
   -- Child nvim process in :terminal (with cterm colors).
   fn.jobstart({
-    nvim_prog_abs(),
+    n.nvim_prog,
     '-n',
     '-u',
     'NORC',

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -318,16 +318,6 @@ function M.stop()
   assert(session):stop()
 end
 
-function M.nvim_prog_abs()
-  -- system(['build/bin/nvim']) does not work for whatever reason. It must
-  -- be executable searched in $PATH or something starting with / or ./.
-  if M.nvim_prog:match('[/\\]') then
-    return M.request('nvim_call_function', 'fnamemodify', { M.nvim_prog, ':p' })
-  else
-    return M.nvim_prog
-  end
-end
-
 -- Use for commands which expect nvim to quit.
 -- The first argument can also be a timeout.
 function M.expect_exit(fn_or_timeout, ...)
@@ -526,7 +516,7 @@ function M.spawn_argv(keep, ...)
   return M.spawn(argv, nil, env, keep, io_extra)
 end
 
---- Starts a (`--headless`, non-RPC) Nvim process, waits for exit, and returns output + info.
+--- Starts a (non-RPC, `--headless --listen "Tx"`) Nvim process, waits for exit, and returns result.
 ---
 --- @param ... string Nvim CLI args
 --- @return test.ProcStream
@@ -537,6 +527,7 @@ function M.spawn_wait(...)
   table.insert(opts.args_rm, '--embed')
   local argv, env, io_extra = M.new_argv(opts)
   local proc = ProcStream.spawn(argv, env, io_extra)
+  proc.collect_text = true
   proc:read_start()
   proc:wait()
   proc:close()


### PR DESCRIPTION
followup to #30384

Problem:
Tests that need to check `nvim` CLI behavior (no RPC session) create their own ad-hoc `system()` wrappers.

Solution:
- Use `n.spawn_wait` instead of `system()`.
- Bonus: this also improves the tests by explicitly checking for `stdout` or `stderr`. And if a signal is raised, `ProcStream.status` will reflect it.