### PR TITLE
fix(treesitter)!: higher priorities for injected trees

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -660,10 +660,10 @@ vim.hl.on_yank({opts})                                      *vim.hl.on_yank()*
 vim.hl.priorities                                          *vim.hl.priorities*
     Table with default priorities used for highlighting:
     • `syntax`: `50`, used for standard syntax highlighting
-    • `treesitter`: `100`, used for treesitter-based highlighting
-    • `semantic_tokens`: `125`, used for LSP semantic token highlighting
-    • `diagnostics`: `150`, used for code analysis such as diagnostics
-    • `user`: `200`, used for user-triggered highlights such as LSP document
+    • `treesitter`: `5000`, used for treesitter-based highlighting
+    • `semantic_tokens`: `10000`, used for LSP semantic token highlighting
+    • `diagnostics`: `15000`, used for code analysis such as diagnostics
+    • `user`: `20000`, used for user-triggered highlights such as LSP document
       symbols or `on_yank` autocommands
 
                                                               *vim.hl.range()*

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -103,6 +103,8 @@ HIGHLIGHTS
 
 • |TermCursorNC| is removed and no longer supported. Unfocused terminals no
   longer have a cursor.
+• |vim.hl.priorities| were magnified to allow greater highlight specificity
+  (see |treesitter-highlight-priority|).
 
 LSP
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -510,13 +510,18 @@ Conceals specified in this way respect 'conceallevel'.
 
                                                *treesitter-highlight-priority*
 Treesitter uses |nvim_buf_set_extmark()| to set highlights with a default
-priority of 100. This enables plugins to set a highlighting priority lower or
+priority of 5000. This enables plugins to set a highlighting priority lower or
 higher than treesitter. It is also possible to change the priority of an
 individual query pattern manually by setting its `"priority"` metadata
 attribute: >query
 
-    ((super_important_node) @superimportant (#set! priority 105))
+    ((super_important_node) @superimportant (#set! priority 5100))
 <
+NOTE: Priorities of injected trees are increased so that they have precedence
+over their parent trees. The offset amount is determined by their nesting
+level. For example, an injection within the root tree has its priority
+increased by `1`, and an injection within an injection has its priority
+increased by `2`, etc.
 
 ==============================================================================
 TREESITTER LANGUAGE INJECTIONS                *treesitter-language-injections*
@@ -1526,7 +1531,7 @@ LanguageTree:for_each_tree({fn})                *LanguageTree:for_each_tree()*
     Note: This includes the invoking tree's child trees as well.
 
     Parameters: ~
-      • {fn}  (`fun(tree: TSTree, ltree: vim.treesitter.LanguageTree)`)
+      • {fn}  (`fun(tree: TSTree, ltree: vim.treesitter.LanguageTree, nesting_level: integer)`)
 
 LanguageTree:included_regions()              *LanguageTree:included_regions()*
     Gets the set of included regions managed by this LanguageTree. This can be

--- a/runtime/lua/vim/hl.lua
+++ b/runtime/lua/vim/hl.lua
@@ -4,17 +4,17 @@ local M = {}
 
 --- Table with default priorities used for highlighting:
 --- - `syntax`: `50`, used for standard syntax highlighting
---- - `treesitter`: `100`, used for treesitter-based highlighting
---- - `semantic_tokens`: `125`, used for LSP semantic token highlighting
---- - `diagnostics`: `150`, used for code analysis such as diagnostics
---- - `user`: `200`, used for user-triggered highlights such as LSP document
+--- - `treesitter`: `5000`, used for treesitter-based highlighting
+--- - `semantic_tokens`: `10000`, used for LSP semantic token highlighting
+--- - `diagnostics`: `15000`, used for code analysis such as diagnostics
+--- - `user`: `20000`, used for user-triggered highlights such as LSP document
 ---   symbols or `on_yank` autocommands
 M.priorities = {
   syntax = 50,
-  treesitter = 100,
-  semantic_tokens = 125,
-  diagnostics = 150,
-  user = 200,
+  treesitter = 5000,
+  semantic_tokens = 10000,
+  diagnostics = 15000,
+  user = 20000,
 }
 
 --- @class vim.hl.range.Opts

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -57,6 +57,7 @@ end
 ---@field next_row integer
 ---@field iter vim.treesitter.highlighter.Iter?
 ---@field highlighter_query vim.treesitter.highlighter.Query
+---@field priority_offset integer
 
 ---@nodoc
 ---@class vim.treesitter.highlighter
@@ -172,7 +173,7 @@ end
 function TSHighlighter:prepare_highlight_states(srow, erow)
   self._highlight_states = {}
 
-  self.tree:for_each_tree(function(tstree, tree)
+  self.tree:for_each_tree(function(tstree, tree, nesting_level)
     if not tstree then
       return
     end
@@ -199,6 +200,7 @@ function TSHighlighter:prepare_highlight_states(srow, erow)
       next_row = 0,
       iter = nil,
       highlighter_query = highlighter_query,
+      priority_offset = nesting_level,
     })
   end)
 end
@@ -319,7 +321,9 @@ local function on_line_impl(self, buf, line, is_spell_nav)
         local priority = (
           tonumber(metadata.priority or metadata[capture] and metadata[capture].priority)
           or vim.hl.priorities.treesitter
-        ) + spell_pri_offset
+        )
+          + spell_pri_offset
+          + state.priority_offset
 
         -- The "conceal" attribute can be set at the pattern level or on a particular capture
         local conceal = metadata.conceal or metadata[capture] and metadata[capture].conceal

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -467,14 +467,20 @@ end
 ---
 --- Note: This includes the invoking tree's child trees as well.
 ---
----@param fn fun(tree: TSTree, ltree: vim.treesitter.LanguageTree)
+---@param fn fun(tree: TSTree, ltree: vim.treesitter.LanguageTree, nesting_level: integer)
 function LanguageTree:for_each_tree(fn)
+  self:_for_each_tree_impl(fn, 0)
+end
+
+---@param fn fun(tree: TSTree, ltree: vim.treesitter.LanguageTree, nesting_level: integer)
+---@param nesting_level integer
+function LanguageTree:_for_each_tree_impl(fn, nesting_level)
   for _, tree in pairs(self._trees) do
-    fn(tree, self)
+    fn(tree, self, nesting_level)
   end
 
   for _, child in pairs(self._children) do
-    child:for_each_tree(fn)
+    child:_for_each_tree_impl(fn, nesting_level + 1)
   end
 end
 


### PR DESCRIPTION
This commit also shifts the default priorities of the semantic token, diagnostic, and user groups up by 50.

---

Fixes #31777 by adding a priority offset for injected trees, offsetting by 1 for each level of nesting. See [this discussion](https://github.com/neovim/neovim/pull/31812#discussion_r1900358792)

This also makes the change in https://github.com/nvim-treesitter/nvim-treesitter/pull/4905/commits/f8340f2331f85ab6d9ceef5654e61c3a947c340e no longer necessary, and resolves [this comment](https://github.com/neovim/neovim/pull/31812#issuecomment-2569663663)