### PR TITLE
refactor(tests): merge `n.spawn`/`n.spawn_argv` into `n.new_session`

### DIFF
--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -9,7 +9,7 @@ local nvim_prog, command, fn = n.nvim_prog, n.command, n.fn
 local source, next_msg = n.source, n.next_msg
 local ok = t.ok
 local api = n.api
-local spawn, merge_args = n.spawn, n.merge_args
+local new_session, merge_args = n.new_session, n.merge_args
 local set_session = n.set_session
 local pcall_err = t.pcall_err
 local assert_alive = n.assert_alive
@@ -284,7 +284,7 @@ describe('server -> client', function()
     local nvim_argv = merge_args(n.nvim_argv, { '--headless' })
     local function connect_test(server, mode, address)
       local serverpid = fn.getpid()
-      local client = spawn(nvim_argv, false, nil, true)
+      local client = new_session(nvim_argv, false, nil, true)
       set_session(client)
 
       local clientpid = fn.getpid()
@@ -312,7 +312,7 @@ describe('server -> client', function()
     end
 
     it('via named pipe', function()
-      local server = spawn(nvim_argv)
+      local server = new_session(nvim_argv)
       set_session(server)
       local address = fn.serverlist()[1]
       local first = string.sub(address, 1, 1)
@@ -321,7 +321,7 @@ describe('server -> client', function()
     end)
 
     it('via ipv4 address', function()
-      local server = spawn(nvim_argv)
+      local server = new_session(nvim_argv)
       set_session(server)
       local status, address = pcall(fn.serverstart, '127.0.0.1:')
       if not status then
@@ -332,7 +332,7 @@ describe('server -> client', function()
     end)
 
     it('via ipv6 address', function()
-      local server = spawn(nvim_argv)
+      local server = new_session(nvim_argv)
       set_session(server)
       local status, address = pcall(fn.serverstart, '::1:')
       if not status then
@@ -343,7 +343,7 @@ describe('server -> client', function()
     end)
 
     it('via hostname', function()
-      local server = spawn(nvim_argv)
+      local server = new_session(nvim_argv)
       set_session(server)
       local address = fn.serverstart('localhost:')
       eq('localhost:', string.sub(address, 1, 10))
@@ -351,10 +351,10 @@ describe('server -> client', function()
     end)
 
     it('does not crash on receiving UI events', function()
-      local server = spawn(nvim_argv)
+      local server = new_session(nvim_argv)
       set_session(server)
       local address = fn.serverlist()[1]
-      local client = spawn(nvim_argv, false, nil, true)
+      local client = new_session(nvim_argv, false, nil, true)
       set_session(client)
 
       local id = fn.sockconnect('pipe', address, { rpc = true })

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -284,7 +284,7 @@ describe('server -> client', function()
     local nvim_argv = merge_args(n.nvim_argv, { '--headless' })
     local function connect_test(server, mode, address)
       local serverpid = fn.getpid()
-      local client = new_session(nvim_argv, false, nil, true)
+      local client = new_session(true, nvim_argv, false, nil)
       set_session(client)
 
       local clientpid = fn.getpid()
@@ -312,7 +312,7 @@ describe('server -> client', function()
     end
 
     it('via named pipe', function()
-      local server = new_session(nvim_argv)
+      local server = new_session(false, nvim_argv)
       set_session(server)
       local address = fn.serverlist()[1]
       local first = string.sub(address, 1, 1)
@@ -321,7 +321,7 @@ describe('server -> client', function()
     end)
 
     it('via ipv4 address', function()
-      local server = new_session(nvim_argv)
+      local server = new_session(false, nvim_argv)
       set_session(server)
       local status, address = pcall(fn.serverstart, '127.0.0.1:')
       if not status then
@@ -332,7 +332,7 @@ describe('server -> client', function()
     end)
 
     it('via ipv6 address', function()
-      local server = new_session(nvim_argv)
+      local server = new_session(false, nvim_argv)
       set_session(server)
       local status, address = pcall(fn.serverstart, '::1:')
       if not status then
@@ -343,7 +343,7 @@ describe('server -> client', function()
     end)
 
     it('via hostname', function()
-      local server = new_session(nvim_argv)
+      local server = new_session(false, nvim_argv)
       set_session(server)
       local address = fn.serverstart('localhost:')
       eq('localhost:', string.sub(address, 1, 10))
@@ -351,10 +351,10 @@ describe('server -> client', function()
     end)
 
     it('does not crash on receiving UI events', function()
-      local server = new_session(nvim_argv)
+      local server = new_session(false, nvim_argv)
       set_session(server)
       local address = fn.serverlist()[1]
-      local client = new_session(nvim_argv, false, nil, true)
+      local client = new_session(true, nvim_argv, false, nil)
       set_session(client)
 
       local id = fn.sockconnect('pipe', address, { rpc = true })

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -282,7 +282,7 @@ describe('server -> client', function()
   describe('connecting to another (peer) nvim', function()
     local function connect_test(server, mode, address)
       local serverpid = fn.getpid()
-      local client = n.new_session_keep(true)
+      local client = n.new_session(true)
       set_session(client)
 
       local clientpid = fn.getpid()
@@ -310,7 +310,7 @@ describe('server -> client', function()
     end
 
     it('via named pipe', function()
-      local server = n.new_session_keep(false)
+      local server = n.new_session(false)
       set_session(server)
       local address = fn.serverlist()[1]
       local first = string.sub(address, 1, 1)
@@ -319,7 +319,7 @@ describe('server -> client', function()
     end)
 
     it('via ipv4 address', function()
-      local server = n.new_session_keep(false)
+      local server = n.new_session(false)
       set_session(server)
       local status, address = pcall(fn.serverstart, '127.0.0.1:')
       if not status then
@@ -330,7 +330,7 @@ describe('server -> client', function()
     end)
 
     it('via ipv6 address', function()
-      local server = n.new_session_keep(false)
+      local server = n.new_session(false)
       set_session(server)
       local status, address = pcall(fn.serverstart, '::1:')
       if not status then
@@ -341,7 +341,7 @@ describe('server -> client', function()
     end)
 
     it('via hostname', function()
-      local server = n.new_session_keep(false)
+      local server = n.new_session(false)
       set_session(server)
       local address = fn.serverstart('localhost:')
       eq('localhost:', string.sub(address, 1, 10))
@@ -349,10 +349,10 @@ describe('server -> client', function()
     end)
 
     it('does not crash on receiving UI events', function()
-      local server = n.new_session_keep(false)
+      local server = n.new_session(false)
       set_session(server)
       local address = fn.serverlist()[1]
-      local client = n.new_session_keep(true)
+      local client = n.new_session(true)
       set_session(client)
 
       local id = fn.sockconnect('pipe', address, { rpc = true })

--- a/test/functional/api/server_requests_spec.lua
+++ b/test/functional/api/server_requests_spec.lua
@@ -9,7 +9,6 @@ local nvim_prog, command, fn = n.nvim_prog, n.command, n.fn
 local source, next_msg = n.source, n.next_msg
 local ok = t.ok
 local api = n.api
-local new_session, merge_args = n.new_session, n.merge_args
 local set_session = n.set_session
 local pcall_err = t.pcall_err
 local assert_alive = n.assert_alive
@@ -281,10 +280,9 @@ describe('server -> client', function()
   end)
 
   describe('connecting to another (peer) nvim', function()
-    local nvim_argv = merge_args(n.nvim_argv, { '--headless' })
     local function connect_test(server, mode, address)
       local serverpid = fn.getpid()
-      local client = new_session(true, nvim_argv, false, nil)
+      local client = n.new_session_keep(true)
       set_session(client)
 
       local clientpid = fn.getpid()
@@ -312,7 +310,7 @@ describe('server -> client', function()
     end
 
     it('via named pipe', function()
-      local server = new_session(false, nvim_argv)
+      local server = n.new_session_keep(false)
       set_session(server)
       local address = fn.serverlist()[1]
       local first = string.sub(address, 1, 1)
@@ -321,7 +319,7 @@ describe('server -> client', function()
     end)
 
     it('via ipv4 address', function()
-      local server = new_session(false, nvim_argv)
+      local server = n.new_session_keep(false)
       set_session(server)
       local status, address = pcall(fn.serverstart, '127.0.0.1:')
       if not status then
@@ -332,7 +330,7 @@ describe('server -> client', function()
     end)
 
     it('via ipv6 address', function()
-      local server = new_session(false, nvim_argv)
+      local server = n.new_session_keep(false)
       set_session(server)
       local status, address = pcall(fn.serverstart, '::1:')
       if not status then
@@ -343,7 +341,7 @@ describe('server -> client', function()
     end)
 
     it('via hostname', function()
-      local server = new_session(false, nvim_argv)
+      local server = n.new_session_keep(false)
       set_session(server)
       local address = fn.serverstart('localhost:')
       eq('localhost:', string.sub(address, 1, 10))
@@ -351,10 +349,10 @@ describe('server -> client', function()
     end)
 
     it('does not crash on receiving UI events', function()
-      local server = new_session(false, nvim_argv)
+      local server = n.new_session_keep(false)
       set_session(server)
       local address = fn.serverlist()[1]
-      local client = new_session(true, nvim_argv, false, nil)
+      local client = n.new_session_keep(true)
       set_session(client)
 
       local id = fn.sockconnect('pipe', address, { rpc = true })

--- a/test/functional/core/channels_spec.lua
+++ b/test/functional/core/channels_spec.lua
@@ -32,10 +32,10 @@ describe('channels', function()
   end)
 
   pending('can connect to socket', function()
-    local server = n.new_session_keep(true)
+    local server = n.new_session(true)
     set_session(server)
     local address = fn.serverlist()[1]
-    local client = n.new_session_keep(true)
+    local client = n.new_session(true)
     set_session(client)
     source(init)
 
@@ -62,7 +62,7 @@ describe('channels', function()
 
   it('dont crash due to garbage in rpc #23781', function()
     local client = get_session()
-    local server = n.new_session_keep(true)
+    local server = n.new_session(true)
     set_session(server)
     local address = fn.serverlist()[1]
     set_session(client)

--- a/test/functional/core/channels_spec.lua
+++ b/test/functional/core/channels_spec.lua
@@ -33,10 +33,10 @@ describe('channels', function()
   end)
 
   pending('can connect to socket', function()
-    local server = new_session(nvim_argv, nil, nil, true)
+    local server = new_session(true, nvim_argv, nil, nil)
     set_session(server)
     local address = fn.serverlist()[1]
-    local client = new_session(nvim_argv, nil, nil, true)
+    local client = new_session(true, nvim_argv, nil, nil)
     set_session(client)
     source(init)
 
@@ -63,7 +63,7 @@ describe('channels', function()
 
   it('dont crash due to garbage in rpc #23781', function()
     local client = get_session()
-    local server = new_session(nvim_argv, nil, nil, true)
+    local server = new_session(true, nvim_argv, nil, nil)
     set_session(server)
     local address = fn.serverlist()[1]
     set_session(client)

--- a/test/functional/core/channels_spec.lua
+++ b/test/functional/core/channels_spec.lua
@@ -5,7 +5,7 @@ local clear, eq, eval, next_msg, ok, source = n.clear, t.eq, n.eval, n.next_msg,
 local command, fn, api = n.command, n.fn, n.api
 local matches = t.matches
 local sleep = vim.uv.sleep
-local spawn, nvim_argv = n.spawn, n.nvim_argv
+local new_session, nvim_argv = n.new_session, n.nvim_argv
 local get_session, set_session = n.get_session, n.set_session
 local nvim_prog = n.nvim_prog
 local is_os = t.is_os
@@ -33,10 +33,10 @@ describe('channels', function()
   end)
 
   pending('can connect to socket', function()
-    local server = spawn(nvim_argv, nil, nil, true)
+    local server = new_session(nvim_argv, nil, nil, true)
     set_session(server)
     local address = fn.serverlist()[1]
-    local client = spawn(nvim_argv, nil, nil, true)
+    local client = new_session(nvim_argv, nil, nil, true)
     set_session(client)
     source(init)
 
@@ -63,7 +63,7 @@ describe('channels', function()
 
   it('dont crash due to garbage in rpc #23781', function()
     local client = get_session()
-    local server = spawn(nvim_argv, nil, nil, true)
+    local server = new_session(nvim_argv, nil, nil, true)
     set_session(server)
     local address = fn.serverlist()[1]
     set_session(client)

--- a/test/functional/core/channels_spec.lua
+++ b/test/functional/core/channels_spec.lua
@@ -5,7 +5,6 @@ local clear, eq, eval, next_msg, ok, source = n.clear, t.eq, n.eval, n.next_msg,
 local command, fn, api = n.command, n.fn, n.api
 local matches = t.matches
 local sleep = vim.uv.sleep
-local new_session, nvim_argv = n.new_session, n.nvim_argv
 local get_session, set_session = n.get_session, n.set_session
 local nvim_prog = n.nvim_prog
 local is_os = t.is_os
@@ -33,10 +32,10 @@ describe('channels', function()
   end)
 
   pending('can connect to socket', function()
-    local server = new_session(true, nvim_argv, nil, nil)
+    local server = n.new_session_keep(true)
     set_session(server)
     local address = fn.serverlist()[1]
-    local client = new_session(true, nvim_argv, nil, nil)
+    local client = n.new_session_keep(true)
     set_session(client)
     source(init)
 
@@ -63,7 +62,7 @@ describe('channels', function()
 
   it('dont crash due to garbage in rpc #23781', function()
     local client = get_session()
-    local server = new_session(true, nvim_argv, nil, nil)
+    local server = n.new_session_keep(true)
     set_session(server)
     local address = fn.serverlist()[1]
     set_session(client)

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -51,10 +51,10 @@ describe('fileio', function()
   end)
 
   local args = { '--clean', '--cmd', 'set nofsync directory=Xtest_startup_swapdir' }
-  local args2 = { '--embed', '--cmd', 'set nofsync directory=Xtest_startup_swapdir' }
   --- Starts a new nvim session and returns an attached screen.
   local function startup()
-    local screen_nvim = n.new_session_keep(false, { args = args2, merge = false })
+    local argv = vim.iter({ args, '--embed' }):flatten():totable()
+    local screen_nvim = n.new_session(false, { args = argv, merge = false })
     set_session(screen_nvim)
     local screen = Screen.new(70, 10)
     screen:set_default_attr_ids({

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -56,7 +56,7 @@ describe('fileio', function()
   local function startup(extra_args)
     extra_args = extra_args or {}
     local argv = vim.iter({ args, '--embed', extra_args }):flatten():totable()
-    local screen_nvim = new_session(argv)
+    local screen_nvim = new_session(false, argv)
     set_session(screen_nvim)
     local screen = Screen.new(70, 10)
     screen:set_default_attr_ids({

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -31,7 +31,6 @@ local feed_command = n.feed_command
 local skip = t.skip
 local is_os = t.is_os
 local is_ci = t.is_ci
-local new_session = n.new_session
 local set_session = n.set_session
 
 describe('fileio', function()
@@ -51,12 +50,11 @@ describe('fileio', function()
     rmdir('Xtest_backupdir with spaces')
   end)
 
-  local args = { nvim_prog, '--clean', '--cmd', 'set nofsync directory=Xtest_startup_swapdir' }
+  local args = { '--clean', '--cmd', 'set nofsync directory=Xtest_startup_swapdir' }
+  local args2 = { '--embed', '--cmd', 'set nofsync directory=Xtest_startup_swapdir' }
   --- Starts a new nvim session and returns an attached screen.
-  local function startup(extra_args)
-    extra_args = extra_args or {}
-    local argv = vim.iter({ args, '--embed', extra_args }):flatten():totable()
-    local screen_nvim = new_session(false, argv)
+  local function startup()
+    local screen_nvim = n.new_session_keep(false, { args = args2, merge = false })
     set_session(screen_nvim)
     local screen = Screen.new(70, 10)
     screen:set_default_attr_ids({
@@ -100,7 +98,8 @@ describe('fileio', function()
     eq('foozubbaz', trim(read_file('Xtest_startup_file1')))
 
     -- 4. Exit caused by deadly signal (+ 'swapfile').
-    local j = fn.jobstart(vim.iter({ args, '--embed' }):flatten():totable(), { rpc = true })
+    local j =
+      fn.jobstart(vim.iter({ nvim_prog, args, '--embed' }):flatten():totable(), { rpc = true })
     fn.rpcrequest(
       j,
       'nvim_exec2',

--- a/test/functional/core/fileio_spec.lua
+++ b/test/functional/core/fileio_spec.lua
@@ -31,7 +31,7 @@ local feed_command = n.feed_command
 local skip = t.skip
 local is_os = t.is_os
 local is_ci = t.is_ci
-local spawn = n.spawn
+local new_session = n.new_session
 local set_session = n.set_session
 
 describe('fileio', function()
@@ -56,7 +56,7 @@ describe('fileio', function()
   local function startup(extra_args)
     extra_args = extra_args or {}
     local argv = vim.iter({ args, '--embed', extra_args }):flatten():totable()
-    local screen_nvim = spawn(argv)
+    local screen_nvim = new_session(argv)
     set_session(screen_nvim)
     local screen = Screen.new(70, 10)
     screen:set_default_attr_ids({

--- a/test/functional/core/remote_spec.lua
+++ b/test/functional/core/remote_spec.lua
@@ -10,10 +10,8 @@ local expect = n.expect
 local fn = n.fn
 local insert = n.insert
 local nvim_prog = n.nvim_prog
-local new_argv = n.new_argv
 local neq = t.neq
 local set_session = n.set_session
-local new_session = n.new_session
 local tmpname = t.tmpname
 local write_file = t.write_file
 
@@ -32,8 +30,7 @@ describe('Remote', function()
   describe('connect to server and', function()
     local server
     before_each(function()
-      server = new_session(false, new_argv(), true)
-      set_session(server)
+      server = n.clear()
     end)
 
     after_each(function()
@@ -49,7 +46,7 @@ describe('Remote', function()
       -- to wait for the remote instance to exit and calling jobwait blocks
       -- the event loop. If the server event loop is blocked, it can't process
       -- our incoming --remote calls.
-      local client_starter = new_session(true, new_argv(), false, nil)
+      local client_starter = n.new_session_keep(true)
       set_session(client_starter)
       -- Call jobstart() and jobwait() in the same RPC request to reduce flakiness.
       eq(
@@ -144,15 +141,8 @@ describe('Remote', function()
 
   describe('exits with error on', function()
     local function run_and_check_exit_code(...)
-      local bogus_argv = new_argv(...)
-
-      -- Create an nvim instance just to run the remote-invoking nvim. We want
-      -- to wait for the remote instance to exit and calling jobwait blocks
-      -- the event loop. If the server event loop is blocked, it can't process
-      -- our incoming --remote calls.
-      clear()
-      -- Call jobstart() and jobwait() in the same RPC request to reduce flakiness.
-      eq({ 2 }, exec_lua([[return vim.fn.jobwait({ vim.fn.jobstart(...) })]], bogus_argv))
+      local p = n.spawn_wait { args = { ... } }
+      eq(2, p.status)
     end
     it('bogus subcommand', function()
       run_and_check_exit_code('--remote-bogus')

--- a/test/functional/core/remote_spec.lua
+++ b/test/functional/core/remote_spec.lua
@@ -13,7 +13,7 @@ local nvim_prog = n.nvim_prog
 local new_argv = n.new_argv
 local neq = t.neq
 local set_session = n.set_session
-local spawn = n.spawn
+local new_session = n.new_session
 local tmpname = t.tmpname
 local write_file = t.write_file
 
@@ -32,7 +32,7 @@ describe('Remote', function()
   describe('connect to server and', function()
     local server
     before_each(function()
-      server = spawn(new_argv(), true)
+      server = new_session(new_argv(), true)
       set_session(server)
     end)
 
@@ -49,7 +49,7 @@ describe('Remote', function()
       -- to wait for the remote instance to exit and calling jobwait blocks
       -- the event loop. If the server event loop is blocked, it can't process
       -- our incoming --remote calls.
-      local client_starter = spawn(new_argv(), false, nil, true)
+      local client_starter = new_session(new_argv(), false, nil, true)
       set_session(client_starter)
       -- Call jobstart() and jobwait() in the same RPC request to reduce flakiness.
       eq(

--- a/test/functional/core/remote_spec.lua
+++ b/test/functional/core/remote_spec.lua
@@ -46,7 +46,7 @@ describe('Remote', function()
       -- to wait for the remote instance to exit and calling jobwait blocks
       -- the event loop. If the server event loop is blocked, it can't process
       -- our incoming --remote calls.
-      local client_starter = n.new_session_keep(true)
+      local client_starter = n.new_session(true)
       set_session(client_starter)
       -- Call jobstart() and jobwait() in the same RPC request to reduce flakiness.
       eq(

--- a/test/functional/core/remote_spec.lua
+++ b/test/functional/core/remote_spec.lua
@@ -32,7 +32,7 @@ describe('Remote', function()
   describe('connect to server and', function()
     local server
     before_each(function()
-      server = new_session(new_argv(), true)
+      server = new_session(false, new_argv(), true)
       set_session(server)
     end)
 
@@ -49,7 +49,7 @@ describe('Remote', function()
       -- to wait for the remote instance to exit and calling jobwait blocks
       -- the event loop. If the server event loop is blocked, it can't process
       -- our incoming --remote calls.
-      local client_starter = new_session(new_argv(), false, nil, true)
+      local client_starter = new_session(true, new_argv(), false, nil)
       set_session(client_starter)
       -- Call jobstart() and jobwait() in the same RPC request to reduce flakiness.
       eq(

--- a/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
+++ b/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
@@ -17,7 +17,7 @@ local new_pipename = n.new_pipename
 local pesc = vim.pesc
 local os_kill = n.os_kill
 local set_session = n.set_session
-local spawn = n.spawn
+local new_session = n.new_session
 local async_meths = n.async_meths
 local expect_msg_seq = n.expect_msg_seq
 local pcall_err = t.pcall_err
@@ -56,7 +56,7 @@ describe("preserve and (R)ecover with custom 'directory'", function()
 
   local nvim0
   before_each(function()
-    nvim0 = spawn(new_argv())
+    nvim0 = new_session(new_argv())
     set_session(nvim0)
     rmdir(swapdir)
     mkdir(swapdir)
@@ -76,7 +76,7 @@ describe("preserve and (R)ecover with custom 'directory'", function()
 
   local function test_recover(swappath1)
     -- Start another Nvim instance.
-    local nvim2 = spawn({ nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed' }, true)
+    local nvim2 = new_session({ nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed' }, true)
     set_session(nvim2)
 
     exec(init)
@@ -141,7 +141,7 @@ describe('swapfile detection', function()
     set swapfile fileformat=unix nomodified undolevels=-1 nohidden
   ]]
   before_each(function()
-    nvim0 = spawn(new_argv())
+    nvim0 = new_session(new_argv())
     set_session(nvim0)
     rmdir(swapdir)
     mkdir(swapdir)
@@ -168,7 +168,7 @@ describe('swapfile detection', function()
     command('preserve')
 
     -- Start another Nvim instance.
-    local nvim2 = spawn({ nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed' }, true, nil, true)
+    local nvim2 = new_session({ nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed' }, true, nil, true)
     set_session(nvim2)
     local screen2 = Screen.new(256, 40)
     screen2._default_attr_ids = nil
@@ -251,7 +251,7 @@ describe('swapfile detection', function()
     command('preserve') -- Make sure the swap file exists.
     local nvimpid = fn.getpid()
 
-    local nvim1 = spawn(new_argv(), true, nil, true)
+    local nvim1 = new_session(new_argv(), true, nil, true)
     set_session(nvim1)
     local screen = Screen.new(75, 18)
     exec(init)
@@ -273,7 +273,7 @@ describe('swapfile detection', function()
       [1] = { bold = true, foreground = Screen.colors.SeaGreen }, -- MoreMsg
     })
 
-    local nvim1 = spawn(new_argv(), true, nil, true)
+    local nvim1 = new_session(new_argv(), true, nil, true)
     set_session(nvim1)
     screen:attach()
     exec(init)
@@ -292,7 +292,7 @@ describe('swapfile detection', function()
     ]])
     nvim1:close()
 
-    local nvim2 = spawn(new_argv(), true, nil, true)
+    local nvim2 = new_session(new_argv(), true, nil, true)
     set_session(nvim2)
     screen:attach()
     exec(init)

--- a/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
+++ b/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
@@ -12,12 +12,10 @@ local fn = n.fn
 local nvim_prog = n.nvim_prog
 local ok = t.ok
 local rmdir = n.rmdir
-local new_argv = n.new_argv
 local new_pipename = n.new_pipename
 local pesc = vim.pesc
 local os_kill = n.os_kill
 local set_session = n.set_session
-local new_session = n.new_session
 local async_meths = n.async_meths
 local expect_msg_seq = n.expect_msg_seq
 local pcall_err = t.pcall_err
@@ -56,7 +54,7 @@ describe("preserve and (R)ecover with custom 'directory'", function()
 
   local nvim0
   before_each(function()
-    nvim0 = new_session(false, new_argv())
+    nvim0 = n.new_session_keep(false)
     set_session(nvim0)
     rmdir(swapdir)
     mkdir(swapdir)
@@ -76,7 +74,8 @@ describe("preserve and (R)ecover with custom 'directory'", function()
 
   local function test_recover(swappath1)
     -- Start another Nvim instance.
-    local nvim2 = new_session(false, { nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed' }, true)
+    local nvim2 =
+      n.new_session_keep(false, { args = { '-u', 'NONE', '-i', 'NONE', '--embed' }, merge = false })
     set_session(nvim2)
 
     exec(init)
@@ -141,7 +140,7 @@ describe('swapfile detection', function()
     set swapfile fileformat=unix nomodified undolevels=-1 nohidden
   ]]
   before_each(function()
-    nvim0 = new_session(false, new_argv())
+    nvim0 = n.new_session_keep(false)
     set_session(nvim0)
     rmdir(swapdir)
     mkdir(swapdir)
@@ -168,7 +167,8 @@ describe('swapfile detection', function()
     command('preserve')
 
     -- Start another Nvim instance.
-    local nvim2 = new_session(true, { nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed' }, true, nil)
+    local nvim2 =
+      n.new_session_keep(true, { args = { '-u', 'NONE', '-i', 'NONE', '--embed' }, merge = false })
     set_session(nvim2)
     local screen2 = Screen.new(256, 40)
     screen2._default_attr_ids = nil
@@ -251,7 +251,7 @@ describe('swapfile detection', function()
     command('preserve') -- Make sure the swap file exists.
     local nvimpid = fn.getpid()
 
-    local nvim1 = new_session(true, new_argv(), true, nil)
+    local nvim1 = n.new_session_keep(true)
     set_session(nvim1)
     local screen = Screen.new(75, 18)
     exec(init)
@@ -273,7 +273,7 @@ describe('swapfile detection', function()
       [1] = { bold = true, foreground = Screen.colors.SeaGreen }, -- MoreMsg
     })
 
-    local nvim1 = new_session(true, new_argv(), true, nil)
+    local nvim1 = n.new_session_keep(true)
     set_session(nvim1)
     screen:attach()
     exec(init)
@@ -292,7 +292,7 @@ describe('swapfile detection', function()
     ]])
     nvim1:close()
 
-    local nvim2 = new_session(true, new_argv(), true, nil)
+    local nvim2 = n.new_session_keep(true)
     set_session(nvim2)
     screen:attach()
     exec(init)

--- a/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
+++ b/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
@@ -54,7 +54,7 @@ describe("preserve and (R)ecover with custom 'directory'", function()
 
   local nvim0
   before_each(function()
-    nvim0 = n.new_session_keep(false)
+    nvim0 = n.new_session(false)
     set_session(nvim0)
     rmdir(swapdir)
     mkdir(swapdir)
@@ -75,7 +75,7 @@ describe("preserve and (R)ecover with custom 'directory'", function()
   local function test_recover(swappath1)
     -- Start another Nvim instance.
     local nvim2 =
-      n.new_session_keep(false, { args = { '-u', 'NONE', '-i', 'NONE', '--embed' }, merge = false })
+      n.new_session(false, { args = { '-u', 'NONE', '-i', 'NONE', '--embed' }, merge = false })
     set_session(nvim2)
 
     exec(init)
@@ -140,7 +140,7 @@ describe('swapfile detection', function()
     set swapfile fileformat=unix nomodified undolevels=-1 nohidden
   ]]
   before_each(function()
-    nvim0 = n.new_session_keep(false)
+    nvim0 = n.new_session(false)
     set_session(nvim0)
     rmdir(swapdir)
     mkdir(swapdir)
@@ -168,7 +168,7 @@ describe('swapfile detection', function()
 
     -- Start another Nvim instance.
     local nvim2 =
-      n.new_session_keep(true, { args = { '-u', 'NONE', '-i', 'NONE', '--embed' }, merge = false })
+      n.new_session(true, { args = { '-u', 'NONE', '-i', 'NONE', '--embed' }, merge = false })
     set_session(nvim2)
     local screen2 = Screen.new(256, 40)
     screen2._default_attr_ids = nil
@@ -251,7 +251,7 @@ describe('swapfile detection', function()
     command('preserve') -- Make sure the swap file exists.
     local nvimpid = fn.getpid()
 
-    local nvim1 = n.new_session_keep(true)
+    local nvim1 = n.new_session(true)
     set_session(nvim1)
     local screen = Screen.new(75, 18)
     exec(init)
@@ -273,7 +273,7 @@ describe('swapfile detection', function()
       [1] = { bold = true, foreground = Screen.colors.SeaGreen }, -- MoreMsg
     })
 
-    local nvim1 = n.new_session_keep(true)
+    local nvim1 = n.new_session(true)
     set_session(nvim1)
     screen:attach()
     exec(init)
@@ -292,7 +292,7 @@ describe('swapfile detection', function()
     ]])
     nvim1:close()
 
-    local nvim2 = n.new_session_keep(true)
+    local nvim2 = n.new_session(true)
     set_session(nvim2)
     screen:attach()
     exec(init)

--- a/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
+++ b/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
@@ -56,7 +56,7 @@ describe("preserve and (R)ecover with custom 'directory'", function()
 
   local nvim0
   before_each(function()
-    nvim0 = new_session(new_argv())
+    nvim0 = new_session(false, new_argv())
     set_session(nvim0)
     rmdir(swapdir)
     mkdir(swapdir)
@@ -76,7 +76,7 @@ describe("preserve and (R)ecover with custom 'directory'", function()
 
   local function test_recover(swappath1)
     -- Start another Nvim instance.
-    local nvim2 = new_session({ nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed' }, true)
+    local nvim2 = new_session(false, { nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed' }, true)
     set_session(nvim2)
 
     exec(init)
@@ -141,7 +141,7 @@ describe('swapfile detection', function()
     set swapfile fileformat=unix nomodified undolevels=-1 nohidden
   ]]
   before_each(function()
-    nvim0 = new_session(new_argv())
+    nvim0 = new_session(false, new_argv())
     set_session(nvim0)
     rmdir(swapdir)
     mkdir(swapdir)
@@ -168,7 +168,7 @@ describe('swapfile detection', function()
     command('preserve')
 
     -- Start another Nvim instance.
-    local nvim2 = new_session({ nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed' }, true, nil, true)
+    local nvim2 = new_session(true, { nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed' }, true, nil)
     set_session(nvim2)
     local screen2 = Screen.new(256, 40)
     screen2._default_attr_ids = nil
@@ -251,7 +251,7 @@ describe('swapfile detection', function()
     command('preserve') -- Make sure the swap file exists.
     local nvimpid = fn.getpid()
 
-    local nvim1 = new_session(new_argv(), true, nil, true)
+    local nvim1 = new_session(true, new_argv(), true, nil)
     set_session(nvim1)
     local screen = Screen.new(75, 18)
     exec(init)
@@ -273,7 +273,7 @@ describe('swapfile detection', function()
       [1] = { bold = true, foreground = Screen.colors.SeaGreen }, -- MoreMsg
     })
 
-    local nvim1 = new_session(new_argv(), true, nil, true)
+    local nvim1 = new_session(true, new_argv(), true, nil)
     set_session(nvim1)
     screen:attach()
     exec(init)
@@ -292,7 +292,7 @@ describe('swapfile detection', function()
     ]])
     nvim1:close()
 
-    local nvim2 = new_session(new_argv(), true, nil, true)
+    local nvim2 = new_session(true, new_argv(), true, nil)
     set_session(nvim2)
     screen:attach()
     exec(init)

--- a/test/functional/ex_cmds/wundo_spec.lua
+++ b/test/functional/ex_cmds/wundo_spec.lua
@@ -5,7 +5,6 @@ local n = require('test.functional.testnvim')()
 local command = n.command
 local clear = n.clear
 local eval = n.eval
-local new_session = n.new_session
 local nvim_prog = n.nvim_prog
 local set_session = n.set_session
 
@@ -24,15 +23,11 @@ end)
 
 describe('u_* functions', function()
   it('safely fail on new, non-empty buffer', function()
-    local session = new_session(false, {
-      nvim_prog,
-      '-u',
-      'NONE',
-      '-i',
-      'NONE',
-      '--embed',
-      '-c',
-      'set undodir=. undofile',
+    local session = n.new_session_keep(false, {
+      args = {
+        '-c',
+        'set undodir=. undofile',
+      },
     })
     set_session(session)
     command('echo "True"') -- Should not error out due to crashed Neovim

--- a/test/functional/ex_cmds/wundo_spec.lua
+++ b/test/functional/ex_cmds/wundo_spec.lua
@@ -5,7 +5,6 @@ local n = require('test.functional.testnvim')()
 local command = n.command
 local clear = n.clear
 local eval = n.eval
-local nvim_prog = n.nvim_prog
 local set_session = n.set_session
 
 describe(':wundo', function()
@@ -23,7 +22,7 @@ end)
 
 describe('u_* functions', function()
   it('safely fail on new, non-empty buffer', function()
-    local session = n.new_session_keep(false, {
+    local session = n.new_session(false, {
       args = {
         '-c',
         'set undodir=. undofile',

--- a/test/functional/ex_cmds/wundo_spec.lua
+++ b/test/functional/ex_cmds/wundo_spec.lua
@@ -24,7 +24,7 @@ end)
 
 describe('u_* functions', function()
   it('safely fail on new, non-empty buffer', function()
-    local session = new_session({
+    local session = new_session(false, {
       nvim_prog,
       '-u',
       'NONE',

--- a/test/functional/ex_cmds/wundo_spec.lua
+++ b/test/functional/ex_cmds/wundo_spec.lua
@@ -5,7 +5,7 @@ local n = require('test.functional.testnvim')()
 local command = n.command
 local clear = n.clear
 local eval = n.eval
-local spawn = n.spawn
+local new_session = n.new_session
 local nvim_prog = n.nvim_prog
 local set_session = n.set_session
 
@@ -24,7 +24,7 @@ end)
 
 describe('u_* functions', function()
   it('safely fail on new, non-empty buffer', function()
-    local session = spawn({
+    local session = new_session({
       nvim_prog,
       '-u',
       'NONE',

--- a/test/functional/shada/marks_spec.lua
+++ b/test/functional/shada/marks_spec.lua
@@ -218,7 +218,7 @@ describe('ShaDa support code', function()
   -- -c temporary sets lnum to zero to make `+/pat` work, so calling setpcmark()
   -- during -c used to add item with zero lnum to jump list.
   it('does not create incorrect file for non-existent buffers when writing from -c', function()
-    local argv = n.new_argv {
+    local p = n.spawn_wait {
       args_rm = {
         '-i',
         '--embed', -- no --embed
@@ -232,12 +232,13 @@ describe('ShaDa support code', function()
         'qall',
       },
     }
-    eq('', fn.system(argv))
+    eq('', p:output())
+    eq(0, p.status)
     eq(0, exc_exec('rshada'))
   end)
 
   it('does not create incorrect file for non-existent buffers opened from -c', function()
-    local argv = n.new_argv {
+    local p = n.spawn_wait {
       args_rm = {
         '-i',
         '--embed', -- no --embed
@@ -251,7 +252,8 @@ describe('ShaDa support code', function()
         'autocmd VimEnter * qall',
       },
     }
-    eq('', fn.system(argv))
+    eq('', p:output())
+    eq(0, p.status)
     eq(0, exc_exec('rshada'))
   end)
 

--- a/test/functional/shada/shada_spec.lua
+++ b/test/functional/shada/shada_spec.lua
@@ -6,8 +6,8 @@ local uv = vim.uv
 local paths = t.paths
 
 local api, nvim_command, fn, eq = n.api, n.command, n.fn, t.eq
-local write_file, new_session, set_session, nvim_prog, exc_exec =
-  t.write_file, n.new_session, n.set_session, n.nvim_prog, n.exc_exec
+local write_file, set_session, nvim_prog, exc_exec =
+  t.write_file, n.set_session, n.nvim_prog, n.exc_exec
 local is_os = t.is_os
 local skip = t.skip
 
@@ -254,7 +254,7 @@ describe('ShaDa support code', function()
   it('does not crash when ShaDa file directory is not writable', function()
     skip(is_os('win'))
 
-    fn.mkdir(dirname, '', 0)
+    fn.mkdir(dirname, '', '0')
     eq(0, fn.filewritable(dirname))
     reset { shadafile = dirshada, args = { '--cmd', 'set shada=' } }
     api.nvim_set_option_value('shada', "'10", {})
@@ -270,11 +270,7 @@ end)
 
 describe('ShaDa support code', function()
   it('does not write NONE file', function()
-    local session = new_session(
-      false,
-      { nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed', '--headless', '--cmd', 'qall' },
-      true
-    )
+    local session = n.new_session_keep(false, { args = { '--cmd', 'qall' } })
     session:close()
     eq(nil, uv.fs_stat('NONE'))
     eq(nil, uv.fs_stat('NONE.tmp.a'))
@@ -282,8 +278,7 @@ describe('ShaDa support code', function()
 
   it('does not read NONE file', function()
     write_file('NONE', '\005\001\015\131\161na\162rX\194\162rc\145\196\001-')
-    local session =
-      new_session(false, { nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed', '--headless' }, true)
+    local session = n.new_session_keep(false, { merge = false, args = { '-u', 'NONE', '-i', 'NONE', '--embed', '--headless' } })
     set_session(session)
     eq('', fn.getreg('a'))
     session:close()

--- a/test/functional/shada/shada_spec.lua
+++ b/test/functional/shada/shada_spec.lua
@@ -269,13 +269,10 @@ end)
 
 describe('ShaDa support code', function()
   it('does not write NONE file', function()
-    local session = n.new_session(
-      false,
-      {
-        merge = false,
-        args = { '-u', 'NONE', '-i', 'NONE', '--embed', '--headless', '--cmd', 'qall' },
-      }
-    )
+    local session = n.new_session(false, {
+      merge = false,
+      args = { '-u', 'NONE', '-i', 'NONE', '--embed', '--headless', '--cmd', 'qall' },
+    })
     session:close()
     eq(nil, uv.fs_stat('NONE'))
     eq(nil, uv.fs_stat('NONE.tmp.a'))

--- a/test/functional/shada/shada_spec.lua
+++ b/test/functional/shada/shada_spec.lua
@@ -278,7 +278,10 @@ describe('ShaDa support code', function()
 
   it('does not read NONE file', function()
     write_file('NONE', '\005\001\015\131\161na\162rX\194\162rc\145\196\001-')
-    local session = n.new_session_keep(false, { merge = false, args = { '-u', 'NONE', '-i', 'NONE', '--embed', '--headless' } })
+    local session = n.new_session_keep(
+      false,
+      { merge = false, args = { '-u', 'NONE', '-i', 'NONE', '--embed', '--headless' } }
+    )
     set_session(session)
     eq('', fn.getreg('a'))
     session:close()

--- a/test/functional/shada/shada_spec.lua
+++ b/test/functional/shada/shada_spec.lua
@@ -6,8 +6,8 @@ local uv = vim.uv
 local paths = t.paths
 
 local api, nvim_command, fn, eq = n.api, n.command, n.fn, t.eq
-local write_file, spawn, set_session, nvim_prog, exc_exec =
-  t.write_file, n.spawn, n.set_session, n.nvim_prog, n.exc_exec
+local write_file, new_session, set_session, nvim_prog, exc_exec =
+  t.write_file, n.new_session, n.set_session, n.nvim_prog, n.exc_exec
 local is_os = t.is_os
 local skip = t.skip
 
@@ -270,7 +270,7 @@ end)
 
 describe('ShaDa support code', function()
   it('does not write NONE file', function()
-    local session = spawn(
+    local session = new_session(
       { nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed', '--headless', '--cmd', 'qall' },
       true
     )
@@ -281,7 +281,7 @@ describe('ShaDa support code', function()
 
   it('does not read NONE file', function()
     write_file('NONE', '\005\001\015\131\161na\162rX\194\162rc\145\196\001-')
-    local session = spawn({ nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed', '--headless' }, true)
+    local session = new_session({ nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed', '--headless' }, true)
     set_session(session)
     eq('', fn.getreg('a'))
     session:close()

--- a/test/functional/shada/shada_spec.lua
+++ b/test/functional/shada/shada_spec.lua
@@ -6,8 +6,7 @@ local uv = vim.uv
 local paths = t.paths
 
 local api, nvim_command, fn, eq = n.api, n.command, n.fn, t.eq
-local write_file, set_session, nvim_prog, exc_exec =
-  t.write_file, n.set_session, n.nvim_prog, n.exc_exec
+local write_file, set_session, exc_exec = t.write_file, n.set_session, n.exc_exec
 local is_os = t.is_os
 local skip = t.skip
 
@@ -270,7 +269,13 @@ end)
 
 describe('ShaDa support code', function()
   it('does not write NONE file', function()
-    local session = n.new_session_keep(false, { args = { '--cmd', 'qall' } })
+    local session = n.new_session(
+      false,
+      {
+        merge = false,
+        args = { '-u', 'NONE', '-i', 'NONE', '--embed', '--headless', '--cmd', 'qall' },
+      }
+    )
     session:close()
     eq(nil, uv.fs_stat('NONE'))
     eq(nil, uv.fs_stat('NONE.tmp.a'))
@@ -278,7 +283,7 @@ describe('ShaDa support code', function()
 
   it('does not read NONE file', function()
     write_file('NONE', '\005\001\015\131\161na\162rX\194\162rc\145\196\001-')
-    local session = n.new_session_keep(
+    local session = n.new_session(
       false,
       { merge = false, args = { '-u', 'NONE', '-i', 'NONE', '--embed', '--headless' } }
     )

--- a/test/functional/shada/shada_spec.lua
+++ b/test/functional/shada/shada_spec.lua
@@ -271,6 +271,7 @@ end)
 describe('ShaDa support code', function()
   it('does not write NONE file', function()
     local session = new_session(
+      false,
       { nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed', '--headless', '--cmd', 'qall' },
       true
     )
@@ -281,7 +282,8 @@ describe('ShaDa support code', function()
 
   it('does not read NONE file', function()
     write_file('NONE', '\005\001\015\131\161na\162rX\194\162rc\145\196\001-')
-    local session = new_session({ nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed', '--headless' }, true)
+    local session =
+      new_session(false, { nvim_prog, '-u', 'NONE', '-i', 'NONE', '--embed', '--headless' }, true)
     set_session(session)
     eq('', fn.getreg('a'))
     session:close()

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -26,7 +26,7 @@ local api = n.api
 local is_ci = t.is_ci
 local is_os = t.is_os
 local new_pipename = n.new_pipename
-local spawn_argv = n.spawn_argv
+local new_session_keep = n.new_session_keep
 local set_session = n.set_session
 local write_file = t.write_file
 local eval = n.eval
@@ -3320,8 +3320,8 @@ describe('TUI as a client', function()
   end)
 
   it('connects to remote instance (with its own TUI)', function()
-    local server_super = spawn_argv(false) -- equivalent to clear()
-    local client_super = spawn_argv(true)
+    local server_super = new_session_keep(false)
+    local client_super = new_session_keep(true)
 
     set_session(server_super)
     local server_pipe = new_pipename()
@@ -3395,8 +3395,8 @@ describe('TUI as a client', function()
   end)
 
   it('connects to remote instance (--headless)', function()
-    local server = spawn_argv(false) -- equivalent to clear()
-    local client_super = spawn_argv(true, { env = { NVIM_LOG_FILE = testlog } })
+    local server = new_session_keep(false)
+    local client_super = new_session_keep(true, { env = { NVIM_LOG_FILE = testlog } })
 
     set_session(server)
     local server_pipe = api.nvim_get_vvar('servername')
@@ -3462,8 +3462,8 @@ describe('TUI as a client', function()
   end)
 
   local function test_remote_tui_quit(status)
-    local server_super = spawn_argv(false) -- equivalent to clear()
-    local client_super = spawn_argv(true)
+    local server_super = new_session_keep(false)
+    local client_super = new_session_keep(true)
 
     set_session(server_super)
     local server_pipe = new_pipename()

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -26,7 +26,6 @@ local api = n.api
 local is_ci = t.is_ci
 local is_os = t.is_os
 local new_pipename = n.new_pipename
-local new_session_keep = n.new_session_keep
 local set_session = n.set_session
 local write_file = t.write_file
 local eval = n.eval
@@ -3320,8 +3319,8 @@ describe('TUI as a client', function()
   end)
 
   it('connects to remote instance (with its own TUI)', function()
-    local server_super = new_session_keep(false)
-    local client_super = new_session_keep(true)
+    local server_super = n.new_session(false)
+    local client_super = n.new_session(true)
 
     set_session(server_super)
     local server_pipe = new_pipename()
@@ -3395,8 +3394,8 @@ describe('TUI as a client', function()
   end)
 
   it('connects to remote instance (--headless)', function()
-    local server = new_session_keep(false)
-    local client_super = new_session_keep(true, { env = { NVIM_LOG_FILE = testlog } })
+    local server = n.new_session(false)
+    local client_super = n.new_session(true, { env = { NVIM_LOG_FILE = testlog } })
 
     set_session(server)
     local server_pipe = api.nvim_get_vvar('servername')
@@ -3462,8 +3461,8 @@ describe('TUI as a client', function()
   end)
 
   local function test_remote_tui_quit(status)
-    local server_super = new_session_keep(false)
-    local client_super = new_session_keep(true)
+    local server_super = n.new_session(false)
+    local client_super = n.new_session(true)
 
     set_session(server_super)
     local server_pipe = new_pipename()

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -457,13 +457,13 @@ end
 
 --- Starts a new Nvim process with the given args and returns a msgpack-RPC session.
 ---
+--- @param keep boolean Don't close the current global session.
 --- @param argv string[] Nvim CLI args
 --- @param merge boolean? true: merge args with the default args. false: use only the provided args.
 --- @param env string[]? Environment variables
---- @param keep boolean? Don't close the current global session.
 --- @param io_extra uv.uv_pipe_t? used for stdin_fd, see :help ui-option
 --- @return test.Session
-function M.new_session(argv, merge, env, keep, io_extra)
+function M.new_session(keep, argv, merge, env, io_extra)
   if not keep then
     M.check_close()
   end
@@ -482,7 +482,7 @@ end
 
 --- Starts a new, global Nvim session and clears the current one.
 ---
---- Note: Use `new_session(…, keep=true)` to start a session without clearing the current one.
+--- Note: Use `new_session()` to start a session without clearing the current one.
 ---
 --- Parameters are interpreted as startup args, OR a map with these keys:
 --- - args:       List: Args appended to the default `nvim_argv` set.
@@ -513,7 +513,7 @@ end
 --- @overload fun(keep: boolean, opts: test.new_argv.Opts): test.Session
 function M.new_session_keep(keep, ...)
   local argv, env, io_extra = M.new_argv(...)
-  return M.new_session(argv, nil, env, keep, io_extra)
+  return M.new_session(keep, argv, nil, env, io_extra)
 end
 
 --- Starts a (non-RPC, `--headless --listen "Tx"`) Nvim process, waits for exit, and returns result.

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -482,9 +482,9 @@ end
 ---
 --- @param ... string Nvim CLI args
 --- @return test.Session
---- @overload fun(opts: test.new_argv.Opts): test.Session
+--- @overload fun(opts: test.session.Opts): test.Session
 function M.clear(...)
-  M.set_session(M.new_session_keep(false, ...))
+  M.set_session(M.new_session(false, ...))
   return M.get_session()
 end
 
@@ -495,8 +495,8 @@ end
 --- @param keep boolean (default: false) Don't close the current global session.
 --- @param ... string Nvim CLI args
 --- @return test.Session
---- @overload fun(keep: boolean, opts: test.new_argv.Opts): test.Session
-function M.new_session_keep(keep, ...)
+--- @overload fun(keep: boolean, opts: test.session.Opts): test.Session
+function M.new_session(keep, ...)
   if not keep then
     M.check_close()
   end
@@ -511,7 +511,7 @@ end
 ---
 --- @param ... string Nvim CLI args
 --- @return test.ProcStream
---- @overload fun(opts: test.new_argv.Opts): test.ProcStream
+--- @overload fun(opts: test.session.Opts): test.ProcStream
 function M.spawn_wait(...)
   local opts = type(...) == 'string' and { args = { ... } } or ...
   opts.args_rm = opts.args_rm and opts.args_rm or {}
@@ -525,7 +525,7 @@ function M.spawn_wait(...)
   return proc
 end
 
---- @class test.new_argv.Opts
+--- @class test.session.Opts
 --- Nvim CLI args
 --- @field args? string[]
 --- Remove these args from the default `nvim_argv` args set. Ignored if `merge=false`.
@@ -537,15 +537,15 @@ end
 --- Used for stdin_fd, see `:help ui-option`
 --- @field io_extra? uv.uv_pipe_t
 
---- Builds an argument list for use in clear().
+--- Builds an argument list for use in `new_session()`, `clear()`, and `spawn_wait()`.
 ---
---- @param ... string See clear().
+--- @param ... string Nvim CLI args
 --- @return string[]
 --- @return string[]?
 --- @return uv.uv_pipe_t?
---- @overload fun(opts: test.new_argv.Opts): string[], string[]?, uv.uv_pipe_t?
+--- @overload fun(opts: test.session.Opts): string[], string[]?, uv.uv_pipe_t?
 function M.new_argv(...)
-  --- @type test.new_argv.Opts|string
+  --- @type test.session.Opts|string
   local opts = select(1, ...)
   local merge = type(opts) ~= 'table' and true or opts.merge ~= false
 

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -501,7 +501,7 @@ end
 --- @return test.Session
 --- @overload fun(opts: test.new_argv.Opts): test.Session
 function M.clear(...)
-  M.set_session(M.spawn_argv(false, ...))
+  M.set_session(M.new_session_keep(false, ...))
   return M.get_session()
 end
 
@@ -510,8 +510,8 @@ end
 --- @param keep boolean Don't close the current global session.
 --- @param ... string Nvim CLI args
 --- @return test.Session
---- @overload fun(opts: test.new_argv.Opts): test.Session
-function M.spawn_argv(keep, ...)
+--- @overload fun(keep: boolean, opts: test.new_argv.Opts): test.Session
+function M.new_session_keep(keep, ...)
   local argv, env, io_extra = M.new_argv(...)
   return M.new_session(argv, nil, env, keep, io_extra)
 end

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -455,15 +455,15 @@ function M.check_close()
   session = nil
 end
 
---- Starts `argv` process as a Nvim msgpack-RPC session.
+--- Starts a new Nvim process with the given args and returns a msgpack-RPC session.
 ---
---- @param argv string[]
---- @param merge boolean?
---- @param env string[]?
+--- @param argv string[] Nvim CLI args
+--- @param merge boolean? true: merge args with the default args. false: use only the provided args.
+--- @param env string[]? Environment variables
 --- @param keep boolean? Don't close the current global session.
 --- @param io_extra uv.uv_pipe_t? used for stdin_fd, see :help ui-option
 --- @return test.Session
-function M.spawn(argv, merge, env, keep, io_extra)
+function M.new_session(argv, merge, env, keep, io_extra)
   if not keep then
     M.check_close()
   end
@@ -480,9 +480,9 @@ function M.connect(file_or_address)
   return Session.new(stream)
 end
 
---- Starts (and returns) a new global Nvim session.
+--- Starts a new, global Nvim session and clears the current one.
 ---
---- Use `spawn_argv()` to get a new session without replacing the current global session.
+--- Note: Use `new_session(…, keep=true)` to start a session without clearing the current one.
 ---
 --- Parameters are interpreted as startup args, OR a map with these keys:
 --- - args:       List: Args appended to the default `nvim_argv` set.
@@ -513,7 +513,7 @@ end
 --- @overload fun(opts: test.new_argv.Opts): test.Session
 function M.spawn_argv(keep, ...)
   local argv, env, io_extra = M.new_argv(...)
-  return M.spawn(argv, nil, env, keep, io_extra)
+  return M.new_session(argv, nil, env, keep, io_extra)
 end
 
 --- Starts a (non-RPC, `--headless --listen "Tx"`) Nvim process, waits for exit, and returns result.

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -26,7 +26,7 @@ describe('screen', function()
   }
 
   before_each(function()
-    local screen_nvim = n.new_session_keep(false, { args = nvim_argv, merge = false })
+    local screen_nvim = n.new_session(false, { args = nvim_argv, merge = false })
     set_session(screen_nvim)
     screen = Screen.new()
   end)
@@ -766,7 +766,7 @@ describe('Screen default colors', function()
       'colorscheme vim',
       '--embed',
     }
-    local screen_nvim = n.new_session_keep(false, { args = nvim_argv, merge = false })
+    local screen_nvim = n.new_session(false, { args = nvim_argv, merge = false })
     set_session(screen_nvim)
     screen = Screen.new(53, 14, { rgb = true, ext_termcolors = termcolors or nil })
   end

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -2,7 +2,7 @@ local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
 
-local new_session, set_session, clear = n.new_session, n.set_session, n.clear
+local set_session, clear = n.set_session, n.clear
 local feed, command = n.feed, n.command
 local exec = n.exec
 local insert = n.insert
@@ -26,7 +26,7 @@ describe('screen', function()
   }
 
   before_each(function()
-    local screen_nvim = new_session(false, nvim_argv)
+    local screen_nvim = n.new_session_keep(false, { args = nvim_argv, merge = false })
     set_session(screen_nvim)
     screen = Screen.new()
   end)
@@ -766,7 +766,7 @@ describe('Screen default colors', function()
       'colorscheme vim',
       '--embed',
     }
-    local screen_nvim = new_session(false, nvim_argv)
+    local screen_nvim = n.new_session_keep(false, { args = nvim_argv, merge = false })
     set_session(screen_nvim)
     screen = Screen.new(53, 14, { rgb = true, ext_termcolors = termcolors or nil })
   end

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -26,7 +26,7 @@ describe('screen', function()
   }
 
   before_each(function()
-    local screen_nvim = new_session(nvim_argv)
+    local screen_nvim = new_session(false, nvim_argv)
     set_session(screen_nvim)
     screen = Screen.new()
   end)
@@ -766,7 +766,7 @@ describe('Screen default colors', function()
       'colorscheme vim',
       '--embed',
     }
-    local screen_nvim = new_session(nvim_argv)
+    local screen_nvim = new_session(false, nvim_argv)
     set_session(screen_nvim)
     screen = Screen.new(53, 14, { rgb = true, ext_termcolors = termcolors or nil })
   end

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -2,7 +2,7 @@ local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
 
-local spawn, set_session, clear = n.spawn, n.set_session, n.clear
+local new_session, set_session, clear = n.new_session, n.set_session, n.clear
 local feed, command = n.feed, n.command
 local exec = n.exec
 local insert = n.insert
@@ -26,7 +26,7 @@ describe('screen', function()
   }
 
   before_each(function()
-    local screen_nvim = spawn(nvim_argv)
+    local screen_nvim = new_session(nvim_argv)
     set_session(screen_nvim)
     screen = Screen.new()
   end)
@@ -766,7 +766,7 @@ describe('Screen default colors', function()
       'colorscheme vim',
       '--embed',
     }
-    local screen_nvim = spawn(nvim_argv)
+    local screen_nvim = new_session(nvim_argv)
     set_session(screen_nvim)
     screen = Screen.new(53, 14, { rgb = true, ext_termcolors = termcolors or nil })
   end


### PR DESCRIPTION
followup to #30384

- rename `n.spawn` to `n.new_session`
- drop `n.spawn_argv` and merges its functionality into `n.new_session`
- add `merge` flag to `test.session.Opts`