### PR TITLE
fix(cmdline): always show cmdline when it is a prompt

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2815,8 +2815,10 @@ char *getcmdline_prompt(const int firstc, const char *const prompt, const int hl
   ccline.one_key = one_key;
   ccline.mouse_used = mouse_used;
 
+  const bool cmd_silent_saved = cmd_silent;
   int msg_silent_saved = msg_silent;
   msg_silent = 0;
+  cmd_silent = false;  // Want to see the prompt.
 
   char *const ret = (char *)command_line_enter(firstc, 1, 0, false);
   ccline.redraw_state = kCmdRedrawNone;
@@ -2825,6 +2827,7 @@ char *getcmdline_prompt(const int firstc, const char *const prompt, const int hl
     restore_cmdline(&save_ccline);
   }
   msg_silent = msg_silent_saved;
+  cmd_silent = cmd_silent_saved;
   // Restore msg_col, the prompt from input() may have changed it.
   // But only if called recursively and the commandline is therefore being
   // restored to an old one; if not, the input() prompt stays on the screen,
@@ -4792,9 +4795,6 @@ void get_user_input(const typval_T *const argvars, typval_T *const rettv, const 
     }
   }
 
-  const bool cmd_silent_save = cmd_silent;
-
-  cmd_silent = false;  // Want to see the prompt.
   // Only the part of the message after the last NL is considered as
   // prompt for the command line, unlsess cmdline is externalized
   const char *p = prompt;
@@ -4829,5 +4829,4 @@ void get_user_input(const typval_T *const argvars, typval_T *const rettv, const 
   // Since the user typed this, no need to wait for return.
   need_wait_return = false;
   msg_didout = false;
-  cmd_silent = cmd_silent_save;
 }

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -1038,6 +1038,18 @@ describe('cmdline redraw', function()
     ]],
     }
   end)
+
+  it('silent prompt', function()
+    command([[nmap <silent> T :call confirm("Save changes?", "&Yes\n&No\n&Cancel")<CR>]])
+    feed('T')
+    screen:expect([[
+                               |
+      {3:                         }|
+                               |
+      {6:Save changes?}            |
+      {6:[Y]es, (N)o, (C)ancel: }^  |
+    ]])
+  end)
 end)
 
 describe('statusline is redrawn on entering cmdline', function()


### PR DESCRIPTION
Cmdline prompts should ignore `cmd_silent`.