### PR TITLE
feat(startup): distinct exitcodes for config/-c vs -l error

### DIFF
--- a/runtime/doc/starting.txt
+++ b/runtime/doc/starting.txt
@@ -193,10 +193,15 @@ argument.
                 disables most prompts and messages. Unrelated to |-s|.
                 See also |-S| to run script files.
 
+                Sets exit code as follows:
+                • 0 on success
+                • 1 on config error (including -u/-c/--cmd)
+                • 2 on -l script error
+
                 -es reads/executes stdin as Ex commands. >
                         printf "put ='foo'\n%%print\n" | nvim -es
 
-<                -Es reads stdin as text (into buffer 1).  Use |-c| or "+" to
+<               -Es reads stdin as text (into buffer 1).  Use |-c| or "+" to
                 send commands. >
                         printf "foo\n" | nvim -Es +"%print"
 
@@ -218,8 +223,14 @@ argument.
 -l {script} [args]
                 Executes Lua {script} non-interactively (no UI) with optional
                 [args] after processing any preceding Nvim |cli-arguments|,
-                then exits. Exits 1 on Lua error. See |-S| to run multiple Lua
-                scripts without args, with a UI.
+                then exits. See |-S| to run multiple Lua scripts without args,
+                with a UI.
+
+                Sets exit code as follows:
+                • 0 on success
+                • 1 on config error (including -u/-c/--cmd)
+                • 2 on -l script error
+
                                                                     *lua-args*
                 All [args] are treated as {script} arguments and stored in the
                 Lua `_G.arg` global table, thus "-l" ends processing of Nvim

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -181,10 +181,11 @@ EXTERN bool did_endif INIT( = false);        // just had ":endif"
 EXTERN int did_emsg;                        // incremented by emsg() when a
                                             // message is displayed or thrown
 EXTERN bool called_vim_beep;                // set if vim_beep() is called
-EXTERN bool did_emsg_syntax;                // did_emsg set because of a
-                                            // syntax error
+EXTERN bool did_emsg_syntax;                // did_emsg set by a syntax error
 EXTERN int called_emsg;                     // always incremented by emsg()
-EXTERN int ex_exitval INIT( = 0);            // exit value for ex mode
+EXTERN int ex_exitval INIT( = 0);            // Exitcode for script mode (`exmode_active`).
+                                             //   1: Vimscript error
+                                             //   2: Lua error
 EXTERN bool emsg_on_display INIT( = false);  // there is an error message
 EXTERN bool rc_did_emsg INIT( = false);      // vim_regcomp() called emsg()
 
@@ -568,8 +569,7 @@ EXTERN bool finish_op INIT( = false);    // true while an operator is pending
 EXTERN int opcount INIT( = 0);           // count for pending operator
 EXTERN int motion_force INIT( = 0);      // motion force for pending operator
 
-// Ex Mode (Q) state
-EXTERN bool exmode_active INIT( = false);  // true if Ex mode is active
+EXTERN bool exmode_active INIT( = false);  // Script mode (-es) or Ex mode (gQ).
 
 /// Flag set when normal_check() should return 0 when entering Ex mode.
 EXTERN bool pending_exmode_active INIT( = false);

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -684,7 +684,7 @@ int main(int argc, char **argv)
       msg_putchar('\n');
       msg_didout = false;
     }
-    getout(lua_ok ? 0 : 1);
+    getout(lua_ok ? ex_exitval : 2);
   }
 
   TIME_MSG("before starting main loop");
@@ -746,6 +746,8 @@ void os_exit(int r)
 }
 
 /// Exit properly
+///
+/// @param exitval Exitcode, may be added to `ex_exitval`.
 void getout(int exitval)
   FUNC_ATTR_NORETURN
 {
@@ -755,8 +757,7 @@ void getout(int exitval)
   // make sure startuptimes have been flushed
   time_finish();
 
-  // On error during Ex mode, exit with a non-zero code.
-  // POSIX requires this, although it's not 100% clear from the standard.
+  // Exit nonzero on error during Ex/script mode (-es). POSIX requirement.
   if (exmode_active) {
     exitval += ex_exitval;
   }
@@ -1350,7 +1351,7 @@ static void command_line_scan(mparm_T *parmp)
           break;
         }
         FALLTHROUGH;
-      case 'S':    // "-S {file}" execute Vim script
+      case 'S':    // "-S {file}" execute Vimscript/Lua
       case 'i':    // "-i {shada}" use for ShaDa file
       case 'l':    // "-l {file}" Lua mode
       case 'u':    // "-u {vimrc}" vim inits file

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -156,7 +156,7 @@ describe('startup', function()
       eq(1, proc.status)
     end)
 
-    it('os.exit() sets Nvim exitcode', function()
+    it('sets exitcode from os.exit()', function()
       -- tricky: LeakSanitizer triggers on os.exit() and disrupts the return value, disable it
       exec_lua [[
         local asan_options = os.getenv('ASAN_OPTIONS') or ''
@@ -165,6 +165,7 @@ describe('startup', function()
         end
         vim.uv.os_setenv('ASAN_OPTIONS', asan_options .. ':detect_leaks=0')
       ]]
+
       -- nvim -l foo.lua -arg1 -- a b c
       assert_l_out(
         [[
@@ -179,18 +180,64 @@ describe('startup', function()
       eq(73, eval('v:shell_error'))
     end)
 
-    it('Lua-error sets Nvim exitcode', function()
+    it('sets exitcode=1 on config or -c (not -l) error', function()
+      assert_l_out(function(out)
+        return matches('Error detected while processing command line:\nnooo\nok', out)
+      end, { '+echoerr "nooo"', '-l', '-', 'print("ok")' }, nil, '-', 'print("ok")')
+      eq(1, eval('v:shell_error'))
+
+      local p = n.spawn_wait({
+        args = {
+          '-u',
+          'test/functional/fixtures/startup-fail.vim',
+          '-l',
+          'test/functional/fixtures/startup.lua',
+        },
+        merge = false,
+      })
+      eq(1, p.status)
+    end)
+
+    it('sets exitcode=2 if BOTH config and -l fail', function()
+      local p = n.spawn_wait({
+        args = {
+          '-u',
+          'test/functional/fixtures/startup-fail.vim',
+          '-l',
+          'test/functional/fixtures/startup-fail.lua',
+        },
+        merge = false,
+      })
+      eq(2, p.status)
+    end)
+
+    it('sets exitcode=2 on -l code error', function()
       local proc = n.spawn_wait('-l', 'test/functional/fixtures/startup-fail.lua')
       matches('E5113: .* my pearls!!', proc:output())
       eq(0, proc.signal)
-      eq(1, proc.status)
+      eq(2, proc.status)
 
       eq(0, eval('v:shell_error'))
       matches(
         'E5113: .* %[string "error%("whoa"%)"%]:1: whoa',
         fn.system({ nvim_prog, '-l', '-' }, 'error("whoa")')
       )
-      eq(1, eval('v:shell_error'))
+      eq(2, eval('v:shell_error'))
+    end)
+
+    it('sets exitcode from :cquit regardless of -l or config failures', function()
+      eq(0, eval('v:shell_error'))
+
+      -- :cquit from config.
+      matches(
+        'foo from config',
+        fn.system({ nvim_prog, '-c', 'echo "foo from config"', '-l', '-' }, 'vim.cmd[[73cquit]]')
+      )
+      eq(73, eval('v:shell_error'))
+
+      -- :cquit from -l code.
+      fn.system({ nvim_prog, '-c', '74cquit', '-l', '-' }, 'error("not reached")')
+      eq(74, eval('v:shell_error'))
     end)
 
     it('executes stdin "-"', function()
@@ -664,6 +711,30 @@ describe('startup', function()
     end
   end)
 
+  it('-es/-Es sets exitcode on script error', function()
+    for _, arg in ipairs({ '-es', '-Es' }) do
+      local out = fn.system({ nvim_prog, arg, '-V1', '+echoerr "nooo"' })
+      matches('nooo', out)
+      eq(1, eval('v:shell_error'))
+      out = fn.system({ nvim_prog, arg, '-V1', '+throw "excepooo"' })
+      eq(1, eval('v:shell_error'))
+      matches('excepooo', out)
+      out = fn.system({
+        nvim_prog,
+        arg,
+        '-V1',
+        '+echo "fine"',
+        '-u',
+        'test/functional/fixtures/startup-fail.vim',
+      })
+      eq(1, eval('v:shell_error'))
+      matches('E605: Exception not caught: failed in TestFail', out)
+      -- Reset v:shell_error.
+      fn.system({ nvim_prog, arg, '-V1', '+echo "okay"' })
+      eq(0, eval('v:shell_error'))
+    end
+  end)
+
   it('fails on --embed with -es/-Es/-l', function()
     matches(
       'nvim[.exe]*: %-%-embed conflicts with %-es/%-Es/%-l',
@@ -808,7 +879,7 @@ describe('startup', function()
     ]])
   end)
 
-  it('-e sets ex mode', function()
+  it('-e sets Ex mode', function()
     clear('-e')
     local screen = Screen.new(25, 3)
     -- Verify we set the proper mode both before and after :vi.

--- a/test/functional/fixtures/startup-fail.vim
+++ b/test/functional/fixtures/startup-fail.vim
@@ -1,0 +1,9 @@
+" Test "nvim -es -u foo.vim" with a Vimscript error.
+
+func! TestFail() abort
+  if 1
+    throw 'failed in TestFail'
+  endif
+endfunc
+
+call TestFail()


### PR DESCRIPTION
followup to #21723

# Problem

- Exit code is always 1 for all kinds of failures.
- `nvim -l` exits with success even if there is a config/-c error:
  ```
  echo 'print(vim.v.servername)' | nvim -c "throw 'foo'" -l -
  ```

# Solution

For `nvim -l` set a different exit code for config errors (`-u`, `-c`) vs `-l` (Lua code) errors.


