### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1190,7 +1190,7 @@ tag		command		action ~
 |:breakdel|	:breakd[el]	delete a debugger breakpoint
 |:breaklist|	:breakl[ist]	list debugger breakpoints
 |:browse|	:bro[wse]	use file selection dialog
-|:bufdo|	:bufdo		execute command in each listed buffer
+|:bufdo|	:bufd[o]	execute command in each listed buffer
 |:buffers|	:buffers	list all files in the buffer list
 |:bunload|	:bun[load]	unload a specific buffer
 |:bwipeout|	:bw[ipeout]	really delete a buffer
@@ -1206,7 +1206,7 @@ tag		command		action ~
 |:cafter|	:caf[ter]	go to error after current cursor
 |:call|		:cal[l]		call a function
 |:catch|	:cat[ch]	part of a :try command
-|:cbefore|	:cbef[ore]	go to error before current cursor
+|:cbefore|	:cbe[fore]	go to error before current cursor
 |:cbelow|	:cbel[ow]	go to error below current line
 |:cbottom|	:cbo[ttom]	scroll to the bottom of the quickfix window
 |:cbuffer|	:cb[uffer]	parse error messages and jump to first error
@@ -1262,6 +1262,7 @@ tag		command		action ~
 |:delete|	:d[elete]	delete lines
 |:debug|	:deb[ug]	run a command in debugging mode
 |:debuggreedy|	:debugg[reedy]	read debug mode commands from normal input
+|:defer|	:defe[r]	call function when current function is done
 |:delcommand|	:delc[ommand]	delete user-defined command
 |:delfunction|	:delf[unction]	delete a user function
 |:delmarks|	:delm[arks]	delete marks
@@ -1271,7 +1272,7 @@ tag		command		action ~
 |:diffpatch|	:diffp[atch]	apply a patch and show differences
 |:diffput|	:diffpu[t]	remove differences in other buffer
 |:diffsplit|	:diffs[plit]	show differences with another file
-|:diffthis|	:diffthis	make current window a diff window
+|:diffthis|	:difft[his]	make current window a diff window
 |:digraphs|	:dig[raphs]	show or enter digraphs
 |:display|	:di[splay]	display registers
 |:djump|	:dj[ump]	jump to #define
@@ -1334,7 +1335,7 @@ tag		command		action ~
 |:highlight|	:hi[ghlight]	specify highlighting methods
 |:hide|		:hid[e]		hide current buffer for a command
 |:history|	:his[tory]	print a history list
-|:horizontal|	:hor[izontal]	following window command work horizontally
+|:horizontal|	:ho[rizontal]	following window command work horizontally
 |:insert|	:i[nsert]	insert text
 |:iabbrev|	:ia[bbrev]	like ":abbrev" but for Insert mode
 |:iabclear|	:iabc[lear]	like ":abclear" but for Insert mode
@@ -1372,7 +1373,7 @@ tag		command		action ~
 |:last|		:la[st]		go to the last file in the argument list
 |:language|	:lan[guage]	set the language (locale)
 |:later|	:lat[er]	go to newer change, redo
-|:lbefore|	:lbef[ore]	go to location before current cursor
+|:lbefore|	:lbe[fore]	go to location before current cursor
 |:lbelow|	:lbel[ow]	go to location below current line
 |:lbottom|	:lbo[ttom]	scroll to the bottom of the location window
 |:lbuffer|	:lb[uffer]	parse locations and jump to first location
@@ -1410,7 +1411,7 @@ tag		command		action ~
 |:lockmarks|	:loc[kmarks]	following command keeps marks where they are
 |:lockvar|	:lockv[ar]	lock variables
 |:lolder|	:lol[der]	go to older location list
-|:lopen|	:lope[n]	open location window
+|:lopen|	:lop[en]	open location window
 |:lprevious|	:lp[revious]	go to previous location
 |:lpfile|	:lpf[ile]	go to last location in previous file
 |:lrewind|	:lr[ewind]	go to the specified location, default first one
@@ -1618,7 +1619,7 @@ tag		command		action ~
 |:tNext|	:tN[ext]	jump to previous matching tag
 |:tabNext|	:tabN[ext]	go to previous tab page
 |:tabclose|	:tabc[lose]	close current tab page
-|:tabdo|	:tabdo		execute command in each tab page
+|:tabdo|	:tabd[o]	execute command in each tab page
 |:tabedit|	:tabe[dit]	edit a file in a new tab page
 |:tabfind|	:tabf[ind]	find file in 'path', edit it in a new tab page
 |:tabfirst|	:tabfir[st]	go to first tab page
@@ -1687,7 +1688,7 @@ tag		command		action ~
 |:vsplit|	:vs[plit]	split current window vertically
 |:vunmap|	:vu[nmap]	like ":unmap" but for Visual+Select mode
 |:vunmenu|	:vunme[nu]	remove menu for Visual+Select mode
-|:windo|	:windo		execute command in each window
+|:windo|	:wind[o]	execute command in each window
 |:write|	:w[rite]	write to a file
 |:wNext|	:wN[ext]	write to a file and go to previous file in
 				argument list

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1335,7 +1335,7 @@ tag		command		action ~
 |:highlight|	:hi[ghlight]	specify highlighting methods
 |:hide|		:hid[e]		hide current buffer for a command
 |:history|	:his[tory]	print a history list
-|:horizontal|	:ho[rizontal]	following window command work horizontally
+|:horizontal|	:hor[izontal]	following window command work horizontally
 |:insert|	:i[nsert]	insert text
 |:iabbrev|	:ia[bbrev]	like ":abbrev" but for Insert mode
 |:iabclear|	:iabc[lear]	like ":abclear" but for Insert mode

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -253,8 +253,8 @@ and 'winminwidth' are relevant.
 		will be equalized only vertically.
 		Doesn't work for |:execute| and |:normal|.
 
-						*:ho* *:horizontal*
-:ho[rizontal] {cmd}
+						*:hor* *:horizontal*
+:hor[izontal] {cmd}
 		Execute {cmd}.  Currently only makes a difference for
 		the following commands:
 		- `:wincmd =`: equalize windows only horizontally.

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -253,8 +253,8 @@ and 'winminwidth' are relevant.
 		will be equalized only vertically.
 		Doesn't work for |:execute| and |:normal|.
 
-						*:hor* *:horizontal*
-:hor[izontal] {cmd}
+						*:ho* *:horizontal*
+:ho[rizontal] {cmd}
 		Execute {cmd}.  Currently only makes a difference for
 		the following commands:
 		- `:wincmd =`: equalize windows only horizontally.
@@ -941,8 +941,8 @@ set in the preview window to be able to recognize it.  The 'winfixheight'
 option is set to have it keep the same height when opening/closing other
 windows.
 
-						*:pta* *:ptag*
-:pta[g][!] [tagname]
+						*:pt* *:ptag*
+:pt[ag][!] [tagname]
 		Does ":tag[!] [tagname]" and shows the found tag in a
 		"Preview" window without changing the current buffer or cursor
 		position.  If a "Preview" window already exists, it is re-used


### PR DESCRIPTION
#### vim-patch:0c3e57b: runtime(doc): update index.txt, windows.txt and version9.txt

closes: vim/vim#16357

https://github.com/vim/vim/commit/0c3e57b403e0e3a1fefca7bbd5ad4cb950eea616

Co-authored-by: h-east <h.east.727@gmail.com>
Co-authored-by: Aliaksei Budavei <32549825+zzzyxwvut@users.noreply.github.com>


#### vim-patch:fd77161: runtime(doc): update doc for :horizontal

Revert the documentation for :horizontal from commit
0c3e57b403e0e3a1fefc because :horizontal cannot be shortened to :ho

closes: vim/vim#16362

https://github.com/vim/vim/commit/fd771613b3e59923b1a82a5ed9036c82899d133b

Co-authored-by: h-east <h.east.727@gmail.com>