### PR TITLE
fix(lsp): open_floating_preview() zindex relative to current window

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -883,7 +883,7 @@ function M.make_floating_popup_options(width, height, opts)
     style = 'minimal',
     width = width,
     border = opts.border or default_border,
-    zindex = opts.zindex or 50,
+    zindex = opts.zindex or (api.nvim_win_get_config(0).zindex or 49) + 1,
     title = title,
     title_pos = title_pos,
   }

--- a/test/functional/plugin/lsp/utils_spec.lua
+++ b/test/functional/plugin/lsp/utils_spec.lua
@@ -301,4 +301,32 @@ describe('vim.lsp.util', function()
       end)
     end)
   end)
+
+  it('open_floating_preview zindex greater than current window', function()
+    local screen = Screen.new()
+    exec_lua(function()
+      vim.api.nvim_open_win(0, true, {
+        relative = 'editor',
+        border = 'single',
+        height = 11,
+        width = 51,
+        row = 2,
+        col = 2,
+      })
+      vim.keymap.set('n', 'K', function()
+        vim.lsp.util.open_floating_preview({ 'foo' }, '', { border = 'single' })
+      end, {})
+    end)
+    feed('K')
+    screen:expect([[
+      ┌───────────────────────────────────────────────────┐|
+      │{4:^                                                   }│|
+      │┌───┐{11:                                              }│|
+      ││{4:foo}│{11:                                              }│|
+      │└───┘{11:                                              }│|
+      │{11:~                                                  }│|*7
+      └───────────────────────────────────────────────────┘|
+                                                           |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:  open_floating_preview() may be hidden behind current window if
          that is floating and has a higher zindex.
Solution: Open floating preview with zindex higher than current window.

Fix #31543