### PR TITLE
vim-patch:9.1.0993: New 'cmdheight' behavior may be surprising

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -2872,8 +2872,6 @@ static const char *validate_num_option(OptIndex opt_idx, OptInt *newval, char *e
   case kOptCmdheight:
     if (value < 0) {
       return e_positive;
-    } else {
-      p_ch_was_zero = value == 0;
     }
     break;
   case kOptHistory:

--- a/src/nvim/window.h
+++ b/src/nvim/window.h
@@ -35,9 +35,6 @@ enum {
 
 EXTERN int tabpage_move_disallowed INIT( = 0);  ///< moving tabpages around disallowed
 
-/// Set to true if 'cmdheight' was explicitly set to 0.
-EXTERN bool p_ch_was_zero INIT( = false);
-
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "window.h.generated.h"
 #endif

--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -175,19 +175,17 @@ describe('cmdline', function()
       {3:[No Name]                                                   }|
                                                                   |*5
     ]])
-    feed(':set cmdheight-=1<CR>')
 
     -- using more space moves the status line up
     feed(':set cmdheight+=1<CR>')
     screen:expect([[
       ^                                                            |
-      {1:~                                                           }|
       {3:[No Name]                                                   }|
-                                                                  |*5
+                                                                  |*6
     ]])
 
     -- reducing cmdheight moves status line down
-    feed(':set cmdheight-=2<CR>')
+    feed(':set cmdheight-=3<CR>')
     screen:expect([[
       ^                                                            |
       {1:~                                                           }|*3
@@ -230,6 +228,16 @@ describe('cmdline', function()
       foo                                                         |
       bar                                                         |
       {6:Press ENTER or type command to continue}^                     |
+    ]])
+
+    -- window commands do not reduce 'cmdheight' to value lower than :set by user
+    feed('<CR>:wincmd _<CR>')
+    screen:expect([[
+      ^                                                            |
+      {1:~                                                           }|*4
+      {3:[No Name]                                                   }|
+      :wincmd _                                                   |
+                                                                  |
     ]])
   end)
 

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -294,17 +294,16 @@ func Test_changing_cmdheight()
   " :resize now also changes 'cmdheight' accordingly
   call term_sendkeys(buf, ":set cmdheight+=1\<CR>")
   call VerifyScreenDump(buf, 'Test_changing_cmdheight_2', {})
-  call term_sendkeys(buf, ":set cmdheight-=1\<CR>")
 
   " using more space moves the status line up
   call term_sendkeys(buf, ":set cmdheight+=1\<CR>")
   call VerifyScreenDump(buf, 'Test_changing_cmdheight_3', {})
 
   " reducing cmdheight moves status line down
-  call term_sendkeys(buf, ":set cmdheight-=2\<CR>")
+  call term_sendkeys(buf, ":set cmdheight-=3\<CR>")
   call VerifyScreenDump(buf, 'Test_changing_cmdheight_4', {})
 
-  " reducing window size and then setting cmdheight 
+  " reducing window size and then setting cmdheight
   call term_sendkeys(buf, ":resize -1\<CR>")
   call term_sendkeys(buf, ":set cmdheight=1\<CR>")
   call VerifyScreenDump(buf, 'Test_changing_cmdheight_5', {})
@@ -313,9 +312,13 @@ func Test_changing_cmdheight()
   call term_sendkeys(buf, ":call EchoTwo()\<CR>")
   call VerifyScreenDump(buf, 'Test_changing_cmdheight_6', {})
 
-  " decreasing 'cmdheight' doesn't clear the messages that need hit-enter
+  " increasing 'cmdheight' doesn't clear the messages that need hit-enter
   call term_sendkeys(buf, ":call EchoOne()\<CR>")
   call VerifyScreenDump(buf, 'Test_changing_cmdheight_7', {})
+
+  " window commands do not reduce 'cmdheight' to value lower than :set by user
+  call term_sendkeys(buf, "\<CR>:wincmd _\<CR>")
+  call VerifyScreenDump(buf, 'Test_changing_cmdheight_8', {})
 
   " clean up
   call StopVimInTerminal(buf)


### PR DESCRIPTION
Problem:  Although patch 9.1.0990 fixed a real problem/inconsistency,
          it also introduced new behavior that may break BWC and/or be
          unexpected. Before 9.1.0990, window commands could make the
          topframe smaller (without changing 'cmdheight'; quirk that is
          now fixed), but did not allow extending the topframe beyond
          the 'cmdheight' set by the user. After 9.1.0990, the user can
          reduce the 'cmdheight' below the value they set explicitly,
          through window commands, which may lead to confusion.
          (aftere v9.1.0990)
Solution: Store the value explicitly set by the user and clamp the
          'cmdheight' when resizing the topframe. This also applies to
          dragging laststatus, which in contrast to window commands
          _did_ allow reducing the 'cmdheight' to values below the one
          set by the user. So with this patch there is still new
          behavior, but I think in a way that is less surprising.
          While at it, also fix a Coverity warning, introduced in
          v9.1.0990 (Luuk van Baal)

https://github.com/vim/vim/commit/c97e8695353565d6b20adffa48aad47f6e09967f

Fix #22449