### PR TITLE
vim-patch:9.1.{0984,0991}: getstacktrace(), v:stacktrace

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4182,6 +4182,21 @@ getscriptinfo([{opts}])                                        *getscriptinfo()*
                 Return: ~
                   (`vim.fn.getscriptinfo.ret[]`)
 
+getstacktrace()                                                *getstacktrace()*
+		Returns the current stack trace of Vim scripts.
+		Stack trace is a |List|, of which each item is a |Dictionary|
+		with the following items:
+		    funcref	The funcref if the stack is at the function,
+				otherwise this item is not exist.
+		    event	The string of the event description if the
+				stack is at autocmd event, otherwise this item
+				is not exist.
+		    lnum	The line number of the script on the stack.
+		    filepath	The file path of the script on the stack.
+
+                Return: ~
+                  (`table[]`)
+
 gettabinfo([{tabnr}])                                             *gettabinfo()*
 		If {tabnr} is not specified, then information about all the
 		tab pages is returned as a |List|. Each List item is a

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4186,12 +4186,12 @@ getstacktrace()                                                *getstacktrace()*
 		Returns the current stack trace of Vim scripts.
 		Stack trace is a |List|, of which each item is a |Dictionary|
 		with the following items:
-		    funcref	The funcref if the stack is at the function,
-				otherwise this item is not exist.
+		    funcref	The funcref if the stack is at a function,
+				otherwise this item is omitted.
 		    event	The string of the event description if the
-				stack is at autocmd event, otherwise this item
-				is not exist.
-		    lnum	The line number of the script on the stack.
+				stack is at an autocmd event, otherwise this
+				item is omitted.
+		    lnum	The line number in the script on the stack.
 		    filepath	The file path of the script on the stack.
 
                 Return: ~

--- a/runtime/doc/eval.txt
+++ b/runtime/doc/eval.txt
@@ -2848,7 +2848,8 @@ in the variable |v:exception|: >
 	:    echo "Number thrown.  Value is" v:exception
 
 You may also be interested where an exception was thrown.  This is stored in
-|v:throwpoint|.  Note that "v:exception" and "v:throwpoint" are valid for the
+|v:throwpoint|.  And you can obtain the stack trace from |v:stacktrace|.
+Note that "v:exception", "v:stacktrace" and "v:throwpoint" are valid for the
 exception most recently caught as long it is not finished.
    Example: >
 

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -1103,7 +1103,8 @@ Various:					*various-functions*
 	did_filetype()		check if a FileType autocommand was used
 	eventhandler()		check if invoked by an event handler
 	getpid()		get process ID of Vim
-	getscriptinfo()		get list of sourced vim scripts
+	getscriptinfo()		get list of sourced Vim scripts
+	getstacktrace()		get current stack trace of Vim scripts
 
 	libcall()		call a function in an external library
 	libcallnr()		idem, returning a number

--- a/runtime/doc/vvars.txt
+++ b/runtime/doc/vvars.txt
@@ -6,7 +6,8 @@
 
 Predefined variables                                             *vvars*
 
-Some variables can be set by the user, but the type cannot be changed.
+Most variables are read-only, when a variable can be set by the user, it will
+be mentioned at the variable description below. The type cannot be changed.
 
                                        Type |gO| to see the table of contents.
 
@@ -195,7 +196,8 @@ v:event
 				*v:exception* *exception-variable*
 v:exception
 		The value of the exception most recently caught and not
-		finished.  See also |v:throwpoint| and |throw-variables|.
+		finished.  See also |v:stacktrace|, |v:throwpoint|, and
+		|throw-variables|.
 		Example: >vim
 		  try
 		    throw "oops"
@@ -586,6 +588,13 @@ v:shell_error
 		  endif
 <
 
+				*v:stacktrace* *stacktrace-variable*
+v:stacktrace
+		The stack trace of the exception most recently caught and
+		not finished.  Refer to |getstacktrace()| for the structure of
+		stack trace.  See also |v:exception|, |v:throwpoint|, and
+		|throw-variables|.
+
 				*v:statusmsg* *statusmsg-variable*
 v:statusmsg
 		Last given status message.
@@ -679,7 +688,7 @@ v:this_session
 v:throwpoint
 		The point where the exception most recently caught and not
 		finished was thrown.  Not set when commands are typed.  See
-		also |v:exception| and |throw-variables|.
+		also |v:exception|, |v:stacktrace|, and |throw-variables|.
 		Example: >vim
 		  try
 		    throw "oops"

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3770,6 +3770,20 @@ function vim.fn.getregtype(regname) end
 --- @return vim.fn.getscriptinfo.ret[]
 function vim.fn.getscriptinfo(opts) end
 
+--- Returns the current stack trace of Vim scripts.
+--- Stack trace is a |List|, of which each item is a |Dictionary|
+--- with the following items:
+---     funcref  The funcref if the stack is at the function,
+---     otherwise this item is not exist.
+---     event  The string of the event description if the
+---     stack is at autocmd event, otherwise this item
+---     is not exist.
+---     lnum  The line number of the script on the stack.
+---     filepath  The file path of the script on the stack.
+---
+--- @return table[]
+function vim.fn.getstacktrace() end
+
 --- If {tabnr} is not specified, then information about all the
 --- tab pages is returned as a |List|. Each List item is a
 --- |Dictionary|.  Otherwise, {tabnr} specifies the tab page

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3773,12 +3773,12 @@ function vim.fn.getscriptinfo(opts) end
 --- Returns the current stack trace of Vim scripts.
 --- Stack trace is a |List|, of which each item is a |Dictionary|
 --- with the following items:
----     funcref  The funcref if the stack is at the function,
----     otherwise this item is not exist.
+---     funcref  The funcref if the stack is at a function,
+---     otherwise this item is omitted.
 ---     event  The string of the event description if the
----     stack is at autocmd event, otherwise this item
----     is not exist.
----     lnum  The line number of the script on the stack.
+---     stack is at an autocmd event, otherwise this
+---     item is omitted.
+---     lnum  The line number in the script on the stack.
 ---     filepath  The file path of the script on the stack.
 ---
 --- @return table[]

--- a/runtime/lua/vim/_meta/vvars.lua
+++ b/runtime/lua/vim/_meta/vvars.lua
@@ -203,7 +203,8 @@ vim.v.errors = ...
 vim.v.event = ...
 
 --- The value of the exception most recently caught and not
---- finished.  See also `v:throwpoint` and `throw-variables`.
+--- finished.  See also `v:stacktrace`, `v:throwpoint`, and
+--- `throw-variables`.
 --- Example:
 ---
 --- ```vim
@@ -616,6 +617,13 @@ vim.v.servername = ...
 --- @type integer
 vim.v.shell_error = ...
 
+--- The stack trace of the exception most recently caught and
+--- not finished.  Refer to `getstacktrace()` for the structure of
+--- stack trace.  See also `v:exception`, `v:throwpoint`, and
+--- `throw-variables`.
+--- @type table[]
+vim.v.stacktrace = ...
+
 --- Last given status message.
 --- Modifiable (can be set).
 --- @type string
@@ -718,7 +726,7 @@ vim.v.this_session = ...
 
 --- The point where the exception most recently caught and not
 --- finished was thrown.  Not set when commands are typed.  See
---- also `v:exception` and `throw-variables`.
+--- also `v:exception`, `v:stacktrace`, and `throw-variables`.
 --- Example:
 ---
 --- ```vim

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -270,6 +270,7 @@ static struct vimvar {
   VV(VV_COLLATE,          "collate",          VAR_STRING, VV_RO),
   VV(VV_EXITING,          "exiting",          VAR_NUMBER, VV_RO),
   VV(VV_MAXCOL,           "maxcol",           VAR_NUMBER, VV_RO),
+  VV(VV_STACKTRACE,       "stacktrace",       VAR_LIST, VV_RO),
   // Neovim
   VV(VV_STDERR,           "stderr",           VAR_NUMBER, VV_RO),
   VV(VV_MSGPACK_TYPES,    "msgpack_types",    VAR_DICT, VV_RO),

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -167,6 +167,7 @@ typedef enum {
   VV_COLLATE,
   VV_EXITING,
   VV_MAXCOL,
+  VV_STACKTRACE,
   // Nvim
   VV_STDERR,
   VV_MSGPACK_TYPES,

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4676,12 +4676,12 @@ M.funcs = {
       Returns the current stack trace of Vim scripts.
       Stack trace is a |List|, of which each item is a |Dictionary|
       with the following items:
-          funcref	The funcref if the stack is at the function,
-      		otherwise this item is not exist.
+          funcref	The funcref if the stack is at a function,
+      		otherwise this item is omitted.
           event	The string of the event description if the
-      		stack is at autocmd event, otherwise this item
-      		is not exist.
-          lnum	The line number of the script on the stack.
+      		stack is at an autocmd event, otherwise this
+      		item is omitted.
+          lnum	The line number in the script on the stack.
           filepath	The file path of the script on the stack.
     ]=],
     name = 'getstacktrace',

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4670,6 +4670,25 @@ M.funcs = {
     returns = 'vim.fn.getscriptinfo.ret[]',
     signature = 'getscriptinfo([{opts}])',
   },
+  getstacktrace = {
+    args = 0,
+    desc = [=[
+      Returns the current stack trace of Vim scripts.
+      Stack trace is a |List|, of which each item is a |Dictionary|
+      with the following items:
+          funcref	The funcref if the stack is at the function,
+      		otherwise this item is not exist.
+          event	The string of the event description if the
+      		stack is at autocmd event, otherwise this item
+      		is not exist.
+          lnum	The line number of the script on the stack.
+          filepath	The file path of the script on the stack.
+    ]=],
+    name = 'getstacktrace',
+    params = {},
+    returns = 'table[]',
+    signature = 'getstacktrace()',
+  },
   gettabinfo = {
     args = { 0, 1 },
     base = 1,

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -2633,6 +2633,30 @@ int tv_dict_add_allocated_str(dict_T *const d, const char *const key, const size
   return OK;
 }
 
+/// Add a function entry to dictionary.
+///
+/// @param[out]  d  Dictionary to add entry to.
+/// @param[in]  key  Key to add.
+/// @param[in]  key_len  Key length.
+/// @param[in]  fp  Function to add.
+///
+/// @return OK in case of success, FAIL when key already exists.
+int tv_dict_add_func(dict_T *const d, const char *const key, const size_t key_len,
+                     ufunc_T *const fp)
+  FUNC_ATTR_NONNULL_ARG(1, 2, 4)
+{
+  dictitem_T *const item = tv_dict_item_alloc_len(key, key_len);
+
+  item->di_tv.v_type = VAR_FUNC;
+  item->di_tv.vval.v_string = xstrdup(fp->uf_name);
+  if (tv_dict_add(d, item) == FAIL) {
+    tv_dict_item_free(item);
+    return FAIL;
+  }
+  func_ref(item->di_tv.vval.v_string);
+  return OK;
+}
+
 //{{{2 Operations on the whole dict
 
 /// Clear all the keys of a Dictionary. "d" remains a valid empty Dictionary.

--- a/src/nvim/ex_eval_defs.h
+++ b/src/nvim/ex_eval_defs.h
@@ -2,6 +2,7 @@
 
 #include <stdbool.h>
 
+#include "nvim/eval/typval_defs.h"
 #include "nvim/pos_defs.h"
 
 /// A list used for saving values of "emsg_silent".  Used by ex_try() to save the
@@ -107,6 +108,7 @@ struct vim_exception {
   msglist_T *messages;  ///< message(s) causing error exception
   char *throw_name;     ///< name of the throw point
   linenr_T throw_lnum;  ///< line number of the throw point
+  list_T *stacktrace;   ///< stacktrace
   except_T *caught;     ///< next exception on the caught stack
 };
 

--- a/src/nvim/vvars.lua
+++ b/src/nvim/vvars.lua
@@ -220,7 +220,8 @@ M.vars = {
     type = 'string',
     desc = [=[
       The value of the exception most recently caught and not
-      finished.  See also |v:throwpoint| and |throw-variables|.
+      finished.  See also |v:stacktrace|, |v:throwpoint|, and
+      |throw-variables|.
       Example: >vim
         try
           throw "oops"
@@ -701,6 +702,15 @@ M.vars = {
       <
     ]=],
   },
+  stacktrace = {
+    type = 'table[]',
+    desc = [=[
+      The stack trace of the exception most recently caught and
+      not finished.  Refer to |getstacktrace()| for the structure of
+      stack trace.  See also |v:exception|, |v:throwpoint|, and
+      |throw-variables|.
+    ]=],
+  },
   statusmsg = {
     type = 'string',
     desc = [=[
@@ -823,7 +833,7 @@ M.vars = {
     desc = [=[
       The point where the exception most recently caught and not
       finished was thrown.  Not set when commands are typed.  See
-      also |v:exception| and |throw-variables|.
+      also |v:exception|, |v:stacktrace|, and |throw-variables|.
       Example: >vim
         try
           throw "oops"

--- a/test/old/testdir/test_stacktrace.vim
+++ b/test/old/testdir/test_stacktrace.vim
@@ -1,5 +1,7 @@
 " Test for getstacktrace() and v:stacktrace
 
+source vim9.vim
+
 let s:thisfile = expand('%:p')
 let s:testdir = s:thisfile->fnamemodify(':h')
 
@@ -34,7 +36,7 @@ func Test_getstacktrace()
   source Xscript1
   call Xfunc1()
   call AssertStacktrace([
-        \ #{funcref: funcref('Test_getstacktrace'), lnum: 35, filepath: s:thisfile},
+        \ #{funcref: funcref('Test_getstacktrace'), lnum: 37, filepath: s:thisfile},
         \ #{funcref: funcref('Xfunc1'), lnum: 5, filepath: Filepath('Xscript1')},
         \ #{funcref: funcref('Xfunc2'), lnum: 4, filepath: Filepath('Xscript2')},
         \ ], g:stacktrace)
@@ -61,7 +63,7 @@ func Test_getstacktrace_event()
   source Xscript1
   source Xscript2
   call AssertStacktrace([
-       \ #{funcref: funcref('Test_getstacktrace_event'), lnum: 62, filepath: s:thisfile},
+       \ #{funcref: funcref('Test_getstacktrace_event'), lnum: 64, filepath: s:thisfile},
        \ #{event: 'SourcePre Autocommands for "*"', lnum: 7, filepath: Filepath('Xscript1')},
        \ #{funcref: funcref('Xfunc'), lnum: 4, filepath: Filepath('Xscript1')},
        \ ], g:stacktrace)
@@ -98,10 +100,33 @@ func Test_vstacktrace()
   endtry
   call assert_equal([], v:stacktrace)
   call AssertStacktrace([
-       \ #{funcref: funcref('Test_vstacktrace'), lnum: 95, filepath: s:thisfile},
+       \ #{funcref: funcref('Test_vstacktrace'), lnum: 97, filepath: s:thisfile},
        \ #{funcref: funcref('Xfunc1'), lnum: 5, filepath: Filepath('Xscript1')},
        \ #{funcref: funcref('Xfunc2'), lnum: 4, filepath: Filepath('Xscript2')},
        \ ], stacktrace)
+endfunc
+
+func Test_zzz_stacktrace_vim9()
+  let lines =<< trim [SCRIPT]
+  var stacktrace = getstacktrace()
+  assert_notequal([], stacktrace)
+  for d in stacktrace
+    assert_true(has_key(d, 'lnum'))
+  endfor
+  try
+    throw 'Exception from s:Func'
+  catch
+    assert_notequal([], v:stacktrace)
+    assert_equal(len(stacktrace), len(v:stacktrace))
+    for d in v:stacktrace
+      assert_true(has_key(d, 'lnum'))
+    endfor
+  endtry
+  [SCRIPT]
+  call CheckDefSuccess(lines)
+  " FIXME: v:stacktrace is not cleared after the exception handling, and this
+  " test has to be run as the last one because of this.
+  " call assert_equal([], v:stacktrace)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_stacktrace.vim
+++ b/test/old/testdir/test_stacktrace.vim
@@ -1,0 +1,107 @@
+" Test for getstacktrace() and v:stacktrace
+
+let s:thisfile = expand('%:p')
+let s:testdir = s:thisfile->fnamemodify(':h')
+
+func Filepath(name)
+  return s:testdir .. '/' .. a:name
+endfunc
+
+func AssertStacktrace(expect, actual)
+  call assert_equal(#{lnum: 581, filepath: Filepath('runtest.vim')}, a:actual[0])
+  call assert_equal(a:expect, a:actual[-len(a:expect):])
+endfunc
+
+func Test_getstacktrace()
+  let g:stacktrace = []
+  let lines1 =<< trim [SCRIPT]
+  " Xscript1
+  source Xscript2
+  func Xfunc1()
+    " Xfunc1
+    call Xfunc2()
+  endfunc
+  [SCRIPT]
+  let lines2 =<< trim [SCRIPT]
+  " Xscript2
+  func Xfunc2()
+    " Xfunc2
+    let g:stacktrace = getstacktrace()
+  endfunc
+  [SCRIPT]
+  call writefile(lines1, 'Xscript1', 'D')
+  call writefile(lines2, 'Xscript2', 'D')
+  source Xscript1
+  call Xfunc1()
+  call AssertStacktrace([
+        \ #{funcref: funcref('Test_getstacktrace'), lnum: 35, filepath: s:thisfile},
+        \ #{funcref: funcref('Xfunc1'), lnum: 5, filepath: Filepath('Xscript1')},
+        \ #{funcref: funcref('Xfunc2'), lnum: 4, filepath: Filepath('Xscript2')},
+        \ ], g:stacktrace)
+  unlet g:stacktrace
+endfunc
+
+func Test_getstacktrace_event()
+  let g:stacktrace = []
+  let lines1 =<< trim [SCRIPT]
+  " Xscript1
+  func Xfunc()
+    " Xfunc
+    let g:stacktrace = getstacktrace()
+  endfunc
+  augroup test_stacktrace
+    autocmd SourcePre * call Xfunc()
+  augroup END
+  [SCRIPT]
+  let lines2 =<< trim [SCRIPT]
+  " Xscript2
+  [SCRIPT]
+  call writefile(lines1, 'Xscript1', 'D')
+  call writefile(lines2, 'Xscript2', 'D')
+  source Xscript1
+  source Xscript2
+  call AssertStacktrace([
+       \ #{funcref: funcref('Test_getstacktrace_event'), lnum: 62, filepath: s:thisfile},
+       \ #{event: 'SourcePre Autocommands for "*"', lnum: 7, filepath: Filepath('Xscript1')},
+       \ #{funcref: funcref('Xfunc'), lnum: 4, filepath: Filepath('Xscript1')},
+       \ ], g:stacktrace)
+  augroup test_stacktrace
+    autocmd!
+  augroup END
+  unlet g:stacktrace
+endfunc
+
+func Test_vstacktrace()
+  let lines1 =<< trim [SCRIPT]
+  " Xscript1
+  source Xscript2
+  func Xfunc1()
+    " Xfunc1
+    call Xfunc2()
+  endfunc
+  [SCRIPT]
+  let lines2 =<< trim [SCRIPT]
+  " Xscript2
+  func Xfunc2()
+    " Xfunc2
+    throw 'Exception from Xfunc2'
+  endfunc
+  [SCRIPT]
+  call writefile(lines1, 'Xscript1', 'D')
+  call writefile(lines2, 'Xscript2', 'D')
+  source Xscript1
+  call assert_equal([], v:stacktrace)
+  try
+    call Xfunc1()
+  catch
+    let stacktrace = v:stacktrace
+  endtry
+  call assert_equal([], v:stacktrace)
+  call AssertStacktrace([
+       \ #{funcref: funcref('Test_vstacktrace'), lnum: 95, filepath: s:thisfile},
+       \ #{funcref: funcref('Xfunc1'), lnum: 5, filepath: Filepath('Xscript1')},
+       \ #{funcref: funcref('Xfunc2'), lnum: 4, filepath: Filepath('Xscript2')},
+       \ ], stacktrace)
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.0984: exception handling can be improved

Problem:  exception handling can be improved
Solution: add v:stacktrace and getstacktrace()

closes: vim/vim#16360

https://github.com/vim/vim/commit/663d18d6102f40d14e36096ec590445e61026ed6

Co-authored-by: ichizok <gclient.gaap@gmail.com>
Co-authored-by: Naruhiko Nishino <naru123456789@gmail.com>


#### vim-patch:9.1.0991: v:stacktrace has wrong type in Vim9 script

Problem:  v:stacktrace has wrong type in Vim9 script.
Solution: Change the type to t_list_dict_any.  Fix grammar in docs.
          (zeertzjq)

closes: vim/vim#16390

https://github.com/vim/vim/commit/6655bef33047b826e0ccb8c686f3f57e47161b1c