### PR TITLE
fix(terminal): don't crash on unprintable chars

### DIFF
--- a/src/nvim/vterm/screen.c
+++ b/src/nvim/vterm/screen.c
@@ -909,7 +909,7 @@ int vterm_screen_get_cell(const VTermScreen *screen, VTermPos pos, VTermScreenCe
     return 0;
   }
 
-  cell->schar = intcell->schar;
+  cell->schar = (intcell->schar == (uint32_t)-1) ? 0 : intcell->schar;
 
   cell->attrs.bold = intcell->pen.bold;
   cell->attrs.underline = intcell->pen.underline;

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -435,6 +435,19 @@ describe(':terminal buffer', function()
     ]])
   end)
 
+  it('handles unprintable chars', function()
+    local screen = Screen.new(50, 7)
+    feed 'i'
+    local chan = api.nvim_open_term(0, {})
+    api.nvim_chan_send(chan, '\239\187\191') -- '\xef\xbb\xbf'
+    screen:expect([[
+      {18:<feff>}^                                            |
+                                                        |*5
+      {5:-- TERMINAL --}                                    |
+    ]])
+    eq('\239\187\191', api.nvim_get_current_line())
+  end)
+
   it("handles bell respecting 'belloff' and 'visualbell'", function()
     local screen = Screen.new(50, 7)
     local chan = api.nvim_open_term(0, {})


### PR DESCRIPTION
fixes #31897