### PR TITLE
feat(api): add err field to nvim_echo() opts

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -662,6 +662,8 @@ nvim_echo({chunks}, {history}, {opts})                           *nvim_echo()*
                    `hl_group` element can be omitted for no highlight.
       • {history}  if true, add to |message-history|.
       • {opts}     Optional parameters.
+                   • err: Treat the message like |:echoerr|. Omitted `hlgroup`
+                     uses |hl-ErrorMsg| instead.
                    • verbose: Message is printed as a result of 'verbose'
                      option. If Nvim was invoked with -V3log_file, the message
                      will be redirected to the log_file and suppressed from

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -669,23 +669,6 @@ nvim_echo({chunks}, {history}, {opts})                           *nvim_echo()*
                      will be redirected to the log_file and suppressed from
                      direct output.
 
-nvim_err_write({str})                                       *nvim_err_write()*
-    Writes a message to the Vim error buffer. Does not append "\n", the
-    message is buffered (won't display) until a linefeed is written.
-
-    Parameters: ~
-      • {str}  Message
-
-nvim_err_writeln({str})                                   *nvim_err_writeln()*
-    Writes a message to the Vim error buffer. Appends "\n", so the buffer is
-    flushed (and displayed).
-
-    Parameters: ~
-      • {str}  Message
-
-    See also: ~
-      • nvim_err_write()
-
 nvim_eval_statusline({str}, {opts})                   *nvim_eval_statusline()*
     Evaluates statusline string.
 
@@ -1155,13 +1138,6 @@ nvim_open_term({buffer}, {opts})                            *nvim_open_term()*
 
     Return: ~
         Channel id, or 0 on error
-
-nvim_out_write({str})                                       *nvim_out_write()*
-    Writes a message to the Vim output buffer. Does not append "\n", the
-    message is buffered (won't display) until a linefeed is written.
-
-    Parameters: ~
-      • {str}  Message
 
 nvim_paste({data}, {crlf}, {phase})                             *nvim_paste()*
     Pastes at cursor (in any mode), and sets "redo" so dot (|.|) will repeat

--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -18,6 +18,9 @@ DEPRECATED IN 0.11					*deprecated-0.11*
 API
 • nvim_subscribe()	Plugins must maintain their own "multicast" channels list.
 • nvim_unsubscribe()	Plugins must maintain their own "multicast" channels list.
+• nvim_out_write()	Use |nvim_echo()|.
+• nvim_err_write()	Use |nvim_echo()| with `{err=true}`.
+• nvim_err_writeln()	Use |nvim_echo()| with `{err=true}`.
 
 DIAGNOSTICS
 • *vim.diagnostic.goto_next()*	Use |vim.diagnostic.jump()| with `{count=1, float=true}` instead.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -178,6 +178,8 @@ API
 
 • Improved API "meta" docstrings and :help documentation.
 • |nvim__ns_set()| can set properties for a namespace
+• |nvim_echo()| `err` field to print error messages and `chunks` accepts
+  highlight group IDs.
 
 DEFAULTS
 

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -224,7 +224,7 @@ do
     local function cmd(opts)
       local ok, err = pcall(vim.api.nvim_cmd, opts, {})
       if not ok then
-        vim.api.nvim_err_writeln(err:sub(#'Vim:' + 1))
+        vim.api.nvim_echo({ { err:sub(#'Vim:' + 1) } }, true, { err = true })
       end
     end
 

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -58,6 +58,7 @@ vim._extra = {
 
 --- @private
 vim.log = {
+  --- @enum vim.log.levels
   levels = {
     TRACE = 0,
     DEBUG = 1,
@@ -620,13 +621,8 @@ end
 ---@param opts table|nil Optional parameters. Unused by default.
 ---@diagnostic disable-next-line: unused-local
 function vim.notify(msg, level, opts) -- luacheck: no unused args
-  if level == vim.log.levels.ERROR then
-    vim.api.nvim_err_writeln(msg)
-  elseif level == vim.log.levels.WARN then
-    vim.api.nvim_echo({ { msg, 'WarningMsg' } }, true, {})
-  else
-    vim.api.nvim_echo({ { msg } }, true, {})
-  end
+  local chunks = { { msg, level == vim.log.levels.WARN and 'WarningMsg' or nil } }
+  vim.api.nvim_echo(chunks, true, { err = level == vim.log.levels.ERROR })
 end
 
 do

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1111,17 +1111,12 @@ function vim.api.nvim_del_var(name) end
 ---   redirected to the log_file and suppressed from direct output.
 function vim.api.nvim_echo(chunks, history, opts) end
 
---- Writes a message to the Vim error buffer. Does not append "\n", the
---- message is buffered (won't display) until a linefeed is written.
----
---- @param str string Message
+--- @deprecated
+--- @param str string
 function vim.api.nvim_err_write(str) end
 
---- Writes a message to the Vim error buffer. Appends "\n", so the buffer is
---- flushed (and displayed).
----
---- @see vim.api.nvim_err_write
---- @param str string Message
+--- @deprecated
+--- @param str string
 function vim.api.nvim_err_writeln(str) end
 
 --- Evaluates a Vimscript `expression`. Dicts and Lists are recursively expanded.
@@ -1861,10 +1856,8 @@ function vim.api.nvim_open_term(buffer, opts) end
 --- @return integer # Window handle, or 0 on error
 function vim.api.nvim_open_win(buffer, enter, config) end
 
---- Writes a message to the Vim output buffer. Does not append "\n", the
---- message is buffered (won't display) until a linefeed is written.
----
---- @param str string Message
+--- @deprecated
+--- @param str string
 function vim.api.nvim_out_write(str) end
 
 --- Parse command line.

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1104,6 +1104,8 @@ function vim.api.nvim_del_var(name) end
 --- `hl_group` element can be omitted for no highlight.
 --- @param history boolean if true, add to `message-history`.
 --- @param opts vim.api.keyset.echo_opts Optional parameters.
+--- - err: Treat the message like `:echoerr`. Omitted `hlgroup`
+---   uses `hl-ErrorMsg` instead.
 --- - verbose: Message is printed as a result of 'verbose' option.
 ---   If Nvim was invoked with -V3log_file, the message will be
 ---   redirected to the log_file and suppressed from direct output.

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -88,6 +88,7 @@ error('Cannot require a meta file')
 --- @field pattern? string|string[]
 
 --- @class vim.api.keyset.echo_opts
+--- @field err? boolean
 --- @field verbose? boolean
 
 --- @class vim.api.keyset.empty

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -702,14 +702,14 @@ local wait_result_reason = { [-1] = 'timeout', [-2] = 'interrupted', [-3] = 'err
 ---
 --- @param ... string List to write to the buffer
 local function err_message(...)
-  local message = table.concat(vim.iter({ ... }):flatten():totable())
+  local chunks = { { table.concat({ ... }) } }
   if vim.in_fast_event() then
     vim.schedule(function()
-      api.nvim_err_writeln(message)
+      vim.api.nvim_echo(chunks, true, { err = true })
       api.nvim_command('redraw')
     end)
   else
-    api.nvim_err_writeln(message)
+    vim.api.nvim_echo(chunks, true, { err = true })
     api.nvim_command('redraw')
   end
 end

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -582,9 +582,8 @@ NSC['window/showMessage'] = function(_, params, ctx)
   if message_type == protocol.MessageType.Error then
     err_message('LSP[', client_name, '] ', message)
   else
-    --- @type string
-    local message_type_name = protocol.MessageType[message_type]
-    api.nvim_out_write(string.format('LSP[%s][%s] %s\n', client_name, message_type_name, message))
+    message = ('LSP[%s][%s] %s\n'):format(client_name, protocol.MessageType[message_type], message)
+    api.nvim_echo({ { message } }, true, { err = true })
   end
   return params
 end

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -325,6 +325,7 @@ typedef struct {
 } Dict(cmd_opts);
 
 typedef struct {
+  Boolean err;
   Boolean verbose;
 } Dict(echo_opts);
 

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -776,7 +776,7 @@ char *api_typename(ObjectType t)
   UNREACHABLE;
 }
 
-HlMessage parse_hl_msg(Array chunks, Error *err)
+HlMessage parse_hl_msg(Array chunks, bool is_err, Error *err)
 {
   HlMessage hl_msg = KV_INITIAL_VALUE;
   for (size_t i = 0; i < chunks.size; i++) {
@@ -791,7 +791,7 @@ HlMessage parse_hl_msg(Array chunks, Error *err)
 
     String str = copy_string(chunk.items[0].data.string, NULL);
 
-    int hl_id = 0;
+    int hl_id = is_err ? HLF_E : 0;
     if (chunk.size == 2) {
       hl_id = object_to_hl_id(chunk.items[1], "text highlight", err);
     }

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -86,8 +86,6 @@
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
 
-#define LINE_BUFFER_MIN_SIZE 4096
-
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/vim.c.generated.h"
 #endif
@@ -806,37 +804,6 @@ void nvim_echo(Array chunks, Boolean history, Dict(echo_opts) *opts, Error *err)
 
 error:
   hl_msg_free(hl_msg);
-}
-
-/// Writes a message to the Vim output buffer. Does not append "\n", the
-/// message is buffered (won't display) until a linefeed is written.
-///
-/// @param str Message
-void nvim_out_write(String str)
-  FUNC_API_SINCE(1)
-{
-  write_msg(str, false, false);
-}
-
-/// Writes a message to the Vim error buffer. Does not append "\n", the
-/// message is buffered (won't display) until a linefeed is written.
-///
-/// @param str Message
-void nvim_err_write(String str)
-  FUNC_API_SINCE(1)
-{
-  write_msg(str, true, false);
-}
-
-/// Writes a message to the Vim error buffer. Appends "\n", so the buffer is
-/// flushed (and displayed).
-///
-/// @param str Message
-/// @see nvim_err_write()
-void nvim_err_writeln(String str)
-  FUNC_API_SINCE(1)
-{
-  write_msg(str, true, true);
 }
 
 /// Gets the current list of buffer handles
@@ -1662,55 +1629,6 @@ Array nvim_list_chans(Arena *arena)
   FUNC_API_SINCE(4)
 {
   return channel_all_info(arena);
-}
-
-/// Writes a message to vim output or error buffer. The string is split
-/// and flushed after each newline. Incomplete lines are kept for writing
-/// later.
-///
-/// @param message  Message to write
-/// @param to_err   true: message is an error (uses `emsg` instead of `msg`)
-/// @param writeln  Append a trailing newline
-static void write_msg(String message, bool to_err, bool writeln)
-{
-  static StringBuilder out_line_buf = KV_INITIAL_VALUE;
-  static StringBuilder err_line_buf = KV_INITIAL_VALUE;
-  StringBuilder *line_buf = to_err ? &err_line_buf : &out_line_buf;
-
-#define PUSH_CHAR(c) \
-  if (kv_max(*line_buf) == 0) { \
-    kv_resize(*line_buf, LINE_BUFFER_MIN_SIZE); \
-  } \
-  if (c == NL) { \
-    kv_push(*line_buf, NUL); \
-    if (to_err) { \
-      emsg(line_buf->items); \
-    } else { \
-      msg(line_buf->items, 0); \
-    } \
-    if (msg_silent == 0) { \
-      msg_didout = true; \
-    } \
-    kv_drop(*line_buf, kv_size(*line_buf)); \
-    kv_resize(*line_buf, LINE_BUFFER_MIN_SIZE); \
-  } else if (c == NUL) { \
-    kv_push(*line_buf, NL); \
-  } else { \
-    kv_push(*line_buf, c); \
-  }
-
-  no_wait_return++;
-  for (uint32_t i = 0; i < message.size; i++) {
-    if (got_int) {
-      break;
-    }
-    PUSH_CHAR(message.data[i]);
-  }
-  if (writeln) {
-    PUSH_CHAR(NL);
-  }
-  no_wait_return--;
-  msg_end();
 }
 
 // Functions used for testing purposes

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -775,13 +775,15 @@ void nvim_set_vvar(String name, Object value, Error *err)
 ///                `hl_group` element can be omitted for no highlight.
 /// @param history  if true, add to |message-history|.
 /// @param opts  Optional parameters.
+///          - err: Treat the message like |:echoerr|. Omitted `hlgroup`
+///            uses |hl-ErrorMsg| instead.
 ///          - verbose: Message is printed as a result of 'verbose' option.
 ///            If Nvim was invoked with -V3log_file, the message will be
 ///            redirected to the log_file and suppressed from direct output.
 void nvim_echo(Array chunks, Boolean history, Dict(echo_opts) *opts, Error *err)
   FUNC_API_SINCE(7)
 {
-  HlMessage hl_msg = parse_hl_msg(chunks, err);
+  HlMessage hl_msg = parse_hl_msg(chunks, opts->err, err);
   if (ERROR_SET(err)) {
     goto error;
   }
@@ -790,7 +792,7 @@ void nvim_echo(Array chunks, Boolean history, Dict(echo_opts) *opts, Error *err)
     verbose_enter();
   }
 
-  msg_multihl(hl_msg, history ? "echomsg" : "echo", history);
+  msg_multihl(hl_msg, opts->err ? "echoerr" : history ? "echomsg" : "echo", history, opts->err);
 
   if (opts->verbose) {
     verbose_leave();

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7968,8 +7968,7 @@ void ex_execute(exarg_T *eap)
     } else if (eap->cmdidx == CMD_echoerr) {
       // We don't want to abort following commands, restore did_emsg.
       int save_did_emsg = did_emsg;
-      msg_ext_set_kind("echoerr");
-      emsg_multiline(ga.ga_data, true);
+      emsg_multiline(ga.ga_data, "echoerr", HLF_E, true);
       if (!force_abort) {
         did_emsg = save_did_emsg;
       }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -982,7 +982,7 @@ void handle_did_throw(void)
   if (messages != NULL) {
     do {
       msglist_T *next = messages->next;
-      emsg_multiline(messages->msg, messages->multiline);
+      emsg_multiline(messages->msg, "emsg", HLF_E, messages->multiline);
       xfree(messages->msg);
       xfree(messages->sfile);
       xfree(messages);

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -958,7 +958,7 @@ static void nlua_print_event(void **argv)
   HlMessage msg = KV_INITIAL_VALUE;
   HlMessageChunk chunk = { { .data = argv[0], .size = (size_t)(intptr_t)argv[1] - 1 }, 0 };
   kv_push(msg, chunk);
-  msg_multihl(msg, "lua_print", true);
+  msg_multihl(msg, "lua_print", true, false);
 }
 
 /// Print as a Vim message

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3680,6 +3680,30 @@ describe('API', function()
       async_meths.nvim_echo({ { 'msg\nmsg' }, { 'msg' } }, false, {})
       eq('', exec_capture('messages'))
     end)
+
+    it('can print error message', function()
+      async_meths.nvim_echo({ { 'Error\nMessage' } }, false, { err = true })
+      screen:expect([[
+                                                |
+        {1:~                                       }|*3
+        {3:                                        }|
+        {9:Error}                                   |
+        {9:Message}                                 |
+        {6:Press ENTER or type command to continue}^ |
+      ]])
+      feed(':messages<CR>')
+      screen:expect([[
+        ^                                        |
+        {1:~                                       }|*6
+                                                |
+      ]])
+      async_meths.nvim_echo({ { 'Error' }, { 'Message', 'Special' } }, false, { err = true })
+      screen:expect([[
+        ^                                        |
+        {1:~                                       }|*6
+        {9:Error}{16:Message}                            |
+      ]])
+    end)
   end)
 
   describe('nvim_open_term', function()

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -315,6 +315,21 @@ describe('ui/ext_messages', function()
     })
     feed('<Esc>')
     command('set showmode')
+
+    -- kind=echoerr for nvim_echo() err
+    feed(':call nvim_echo([["Error"], ["Message", "Special"]], 1, #{ err:1 })<CR>')
+    screen:expect({
+      cmdline = { {
+        abort = false,
+      } },
+      messages = {
+        {
+          content = { { 'Error', 9, 6 }, { 'Message', 16, 99 } },
+          history = true,
+          kind = 'echoerr',
+        },
+      },
+    })
   end)
 
   it(':echoerr', function()


### PR DESCRIPTION
**feat(api): add err field to nvim_echo() opts**

Problem:  We want to deprecate `nvim_err_write(ln)()` but there is no
          obvious replacement. Meanwhile we already have `nvim_echo()`
          with an `opts` argument.
Solution: Add `err` argument to `nvim_echo()` that directly maps to
          `:echoerr`.

**feat(api): deprecate nvim_out/err_write(ln)**

Resolve #31871