### PR TITLE
docs(api): nvim_set_decoration_provider callback return type

### DIFF
--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -227,10 +227,10 @@ error('Cannot require a meta file')
 --- @field do_source? boolean
 
 --- @class vim.api.keyset.set_decoration_provider
---- @field on_start? fun(_: "start", tick: integer)
+--- @field on_start? fun(_: "start", tick: integer): boolean?
 --- @field on_buf? fun(_: "buf", bufnr: integer, tick: integer)
---- @field on_win? fun(_: "win", winid: integer, bufnr: integer, toprow: integer, botrow: integer)
---- @field on_line? fun(_: "line", winid: integer, bufnr: integer, row: integer)
+--- @field on_win? fun(_: "win", winid: integer, bufnr: integer, toprow: integer, botrow: integer): boolean?
+--- @field on_line? fun(_: "line", winid: integer, bufnr: integer, row: integer): boolean?
 --- @field on_end? fun(_: "end", tick: integer)
 --- @field _on_hl_def? fun(_: "hl_def")
 --- @field _on_spell_nav? fun(_: "spell_nav")

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -13,10 +13,11 @@ typedef struct {
 
 typedef struct {
   OptionalKeys is_set__set_decoration_provider_;
-  LuaRefOf(("start" _, Integer tick)) on_start;
+  LuaRefOf(("start" _, Integer tick), *Boolean) on_start;
   LuaRefOf(("buf" _, Integer bufnr, Integer tick)) on_buf;
-  LuaRefOf(("win" _, Integer winid, Integer bufnr, Integer toprow, Integer botrow)) on_win;
-  LuaRefOf(("line" _, Integer winid, Integer bufnr, Integer row)) on_line;
+  LuaRefOf(("win" _, Integer winid, Integer bufnr, Integer toprow, Integer botrow),
+           *Boolean) on_win;
+  LuaRefOf(("line" _, Integer winid, Integer bufnr, Integer row), *Boolean) on_line;
   LuaRefOf(("end" _, Integer tick)) on_end;
   LuaRefOf(("hl_def" _)) _on_hl_def;
   LuaRefOf(("spell_nav" _)) _on_spell_nav;


### PR DESCRIPTION
This PR fixes the following luals diagnosis.

```lua
local ns = vim.api.nvim_create_namespace("test")
vim.api.nvim_set_decoration_provider(ns, {
  on_win = function()
    return false -- Annotations specify that at most 0 return value(s) are required, found 1 returned here instead.
  end,
})
```
