### PR TITLE
feat(terminal): propagate DECSET/DECRST to TermRequest

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1004,9 +1004,10 @@ TermClose			When a |terminal| job ends.
 				Sets these |v:event| keys:
 				    status
 							*TermRequest*
-TermRequest			When a |:terminal| child process emits an OSC
-				or DCS sequence. Sets |v:termrequest|. The
-				|event-data| is the request string.
+TermRequest			When a |:terminal| child process emits an OSC,
+				DCS, DECSET, or DECRST sequence. Sets
+				|v:termrequest|. The |event-data| is the
+				request string.
 							*TermResponse*
 TermResponse			When Nvim receives an OSC or DCS response from
 				the host terminal. Sets |v:termresponse|. The

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -319,6 +319,7 @@ TERMINAL
   unfocused terminal window will have no cursor at all (so there is nothing to
   highlight).
 • |jobstart()| gained the "term" flag.
+• |TermRequest| events are emitted for DECSET/DECRST sequences.
 
 TREESITTER
 

--- a/runtime/doc/vvars.txt
+++ b/runtime/doc/vvars.txt
@@ -663,10 +663,10 @@ v:t_string	Value of |String| type.  Read-only.  See: |type()|
 
 				*v:termrequest* *termrequest-variable*
 v:termrequest
-		The value of the most recent OSC or DCS control sequence
-		sent from a process running in the embedded |terminal|.
-		This can be read in a |TermRequest| event handler to respond
-		to queries from embedded applications.
+		The value of the most recent OSC, DCS, DECSET, or DECRST
+		control sequence sent from a process running in the embedded
+		|terminal|. This can be read in a |TermRequest| event handler
+		to respond to queries from embedded applications.
 
 				*v:termresponse* *termresponse-variable*
 v:termresponse

--- a/runtime/lua/vim/_meta/vvars.lua
+++ b/runtime/lua/vim/_meta/vvars.lua
@@ -700,10 +700,10 @@ vim.v.t_number = ...
 --- @type integer
 vim.v.t_string = ...
 
---- The value of the most recent OSC or DCS control sequence
---- sent from a process running in the embedded `terminal`.
---- This can be read in a `TermRequest` event handler to respond
---- to queries from embedded applications.
+--- The value of the most recent OSC, DCS, DECSET, or DECRST
+--- control sequence sent from a process running in the embedded
+--- `terminal`. This can be read in a `TermRequest` event handler
+--- to respond to queries from embedded applications.
 --- @type string
 vim.v.termrequest = ...
 

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -192,6 +192,7 @@ static VTermScreenCallbacks vterm_screen_callbacks = {
   .moverect = term_moverect,
   .movecursor = term_movecursor,
   .settermprop = term_settermprop,
+  .setdecmode = term_setdecmode,
   .bell = term_bell,
   .sb_pushline = term_sb_push,  // Called before a line goes offscreen.
   .sb_popline = term_sb_pop,
@@ -1263,6 +1264,20 @@ static int term_settermprop(VTermProp prop, VTermValue *val, void *data)
     return 0;
   }
 
+  return 1;
+}
+
+static int term_setdecmode(int mode, bool val, void *data)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (!has_event(EVENT_TERMREQUEST)) {
+    return 1;
+  }
+
+  Terminal *term = data;
+  StringBuilder request = KV_INITIAL_VALUE;
+  kv_printf(request, "\x1b[?%d%c", mode, val ? 'h' : 'l');
+  schedule_termrequest(term, request.items, request.size);
   return 1;
 }
 

--- a/src/nvim/vterm/screen.c
+++ b/src/nvim/vterm/screen.c
@@ -442,6 +442,16 @@ static int settermprop(VTermProp prop, VTermValue *val, void *user)
   return 1;
 }
 
+static int setdecmode(int mode, bool val, void *user)
+{
+  VTermScreen *screen = user;
+  if (screen->callbacks && screen->callbacks->setdecmode) {
+    return (*screen->callbacks->setdecmode)(mode, val, screen->cbdata);
+  }
+
+  return 1;
+}
+
 static int bell(void *user)
 {
   VTermScreen *screen = user;
@@ -836,6 +846,7 @@ static VTermStateCallbacks state_cbs = {
   .erase = &erase,
   .setpenattr = &setpenattr,
   .settermprop = &settermprop,
+  .setdecmode = &setdecmode,
   .bell = &bell,
   .resize = &resize,
   .setlineinfo = &setlineinfo,

--- a/src/nvim/vterm/state.c
+++ b/src/nvim/vterm/state.c
@@ -821,7 +821,11 @@ static void set_dec_mode(VTermState *state, int num, int val)
 
   default:
     DEBUG_LOG("libvterm: Unknown DEC mode %d\n", num);
-    return;
+    break;
+  }
+
+  if (state->callbacks && state->callbacks->setdecmode) {
+    (*state->callbacks->setdecmode)(num, val, state->cbdata);
   }
 }
 

--- a/src/nvim/vterm/vterm_defs.h
+++ b/src/nvim/vterm/vterm_defs.h
@@ -109,6 +109,7 @@ typedef struct {
   int (*moverect)(VTermRect dest, VTermRect src, void *user);
   int (*movecursor)(VTermPos pos, VTermPos oldpos, int visible, void *user);
   int (*settermprop)(VTermProp prop, VTermValue *val, void *user);
+  int (*setdecmode)(int mode, bool val, void *user);
   int (*bell)(void *user);
   int (*resize)(int rows, int cols, void *user);
   int (*sb_pushline)(int cols, const VTermScreenCell *cells, void *user);
@@ -261,6 +262,7 @@ typedef struct {
   int (*initpen)(void *user);
   int (*setpenattr)(VTermAttr attr, VTermValue *val, void *user);
   int (*settermprop)(VTermProp prop, VTermValue *val, void *user);
+  int (*setdecmode)(int mode, bool val, void *user);
   int (*bell)(void *user);
   int (*resize)(int rows, int cols, VTermStateFields *fields, void *user);
   int (*setlineinfo)(int row, const VTermLineInfo *newinfo, const VTermLineInfo *oldinfo,

--- a/src/nvim/vvars.lua
+++ b/src/nvim/vvars.lua
@@ -799,10 +799,10 @@ M.vars = {
   termrequest = {
     type = 'string',
     desc = [=[
-      The value of the most recent OSC or DCS control sequence
-      sent from a process running in the embedded |terminal|.
-      This can be read in a |TermRequest| event handler to respond
-      to queries from embedded applications.
+      The value of the most recent OSC, DCS, DECSET, or DECRST
+      control sequence sent from a process running in the embedded
+      |terminal|. This can be read in a |TermRequest| event handler
+      to respond to queries from embedded applications.
     ]=],
   },
   termresponse = {


### PR DESCRIPTION
Modify vterm to add a new callback for when a DEC mode is set or reset. This callback emits a TermRequest event with the DECSET/DECRST sequence used.

This shouldn't be too noisy as DEC modes don't change that often (the noisiest mode will likely be bracketed paste since many shells enable that mode at the prompt and then disable it before running a command).

Ref: https://github.com/neovim/neovim/issues/31652#issuecomment-2578127646