### PR TITLE
fix(api): validate option name for `nvim_get_option()`

### DIFF
--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -646,6 +646,10 @@ static Object get_option_from(void *from, OptScope scope, String name, Error *er
   });
 
   OptIndex opt_idx = find_option(name.data);
+  VALIDATE_S(opt_idx != kOptInvalid, "option name", name.data, {
+    return (Object)OBJECT_INIT;
+  });
+
   OptVal value = NIL_OPTVAL;
 
   if (option_has_scope(opt_idx, scope)) {


### PR DESCRIPTION
Problem: `nvim_get_option()` doesn't validate the option name, which leads to an assertion failure.

Solution: Validate option name in `nvim_get_option()`.

Fix #31894
