### PR TITLE
Revert "refactor(options): set option value for non-current context directly"

### DIFF
--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -649,8 +649,8 @@ static Object get_option_from(void *from, OptScope scope, String name, Error *er
   OptVal value = NIL_OPTVAL;
 
   if (option_has_scope(opt_idx, scope)) {
-    value = get_option_value_from(opt_idx, option_ctx_from(scope, from),
-                                  scope == kOptScopeGlobal ? OPT_GLOBAL : OPT_LOCAL);
+    value = get_option_value_for(opt_idx, scope == kOptScopeGlobal ? OPT_GLOBAL : OPT_LOCAL,
+                                 scope, from, err);
     if (ERROR_SET(err)) {
       return (Object)OBJECT_INIT;
     }
@@ -701,11 +701,7 @@ static void set_option_to(uint64_t channel_id, void *to, OptScope scope, String 
       : ((scope == kOptScopeGlobal) ? OPT_GLOBAL : OPT_LOCAL);
 
   WITH_SCRIPT_CONTEXT(channel_id, {
-    const char *errmsg
-      = set_option_value_for(opt_idx, optval, option_ctx_from(scope, to), opt_flags);
-    if (errmsg) {
-      api_set_error(err, kErrorTypeException, "%s", errmsg);
-    }
+    set_option_value_for(name.data, opt_idx, optval, opt_flags, scope, to, err);
   });
 }
 

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -157,8 +157,8 @@ Object nvim_get_option_value(String name, Dict(option) *opts, Error *err)
   void *from = NULL;
   char *filetype = NULL;
 
-  if (!validate_option_value_args(opts, name.data, &opt_idx, &opt_flags, &scope, &from, &filetype,
-                                  err)) {
+  if (!validate_option_value_args(opts, name.data, &opt_idx, &opt_flags, &scope, &from,
+                                  &filetype, err)) {
     return (Object)OBJECT_INIT;
   }
 
@@ -182,7 +182,7 @@ Object nvim_get_option_value(String name, Dict(option) *opts, Error *err)
     from = ftbuf;
   }
 
-  OptVal value = get_option_value_from(opt_idx, option_ctx_from(scope, from), opt_flags);
+  OptVal value = get_option_value_for(opt_idx, opt_flags, scope, from, err);
 
   if (ftbuf != NULL) {
     // restore curwin/curbuf and a few other things
@@ -257,11 +257,7 @@ void nvim_set_option_value(uint64_t channel_id, String name, Object value, Dict(
   });
 
   WITH_SCRIPT_CONTEXT(channel_id, {
-    const char *errmsg
-      = set_option_value_for(opt_idx, optval, option_ctx_from(scope, to), opt_flags);
-    if (errmsg) {
-      api_set_error(err, kErrorTypeException, "%s", errmsg);
-    }
+    set_option_value_for(name.data, opt_idx, optval, opt_flags, scope, to, err);
   });
 }
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -983,10 +983,10 @@ Buffer nvim_create_buf(Boolean listed, Boolean scratch, Error *err)
     buf_copy_options(buf, BCO_ENTER | BCO_NOHELP);
 
     if (scratch) {
-      set_option_direct_for(kOptBufhidden, STATIC_CSTR_AS_OPTVAL("hide"),
-                            option_ctx_from(kOptScopeBuf, buf), OPT_LOCAL, 0);
-      set_option_direct_for(kOptBuftype, STATIC_CSTR_AS_OPTVAL("nofile"),
-                            option_ctx_from(kOptScopeBuf, buf), OPT_LOCAL, 0);
+      set_option_direct_for(kOptBufhidden, STATIC_CSTR_AS_OPTVAL("hide"), OPT_LOCAL, 0,
+                            kOptScopeBuf, buf);
+      set_option_direct_for(kOptBuftype, STATIC_CSTR_AS_OPTVAL("nofile"), OPT_LOCAL, 0,
+                            kOptScopeBuf, buf);
       assert(buf->b_ml.ml_mfp->mf_fd < 0);  // ml_open() should not have opened swapfile already
       buf->b_p_swf = false;
       buf->b_p_ml = false;

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1251,82 +1251,56 @@ bool check_nomodeline(char **argp)
   return true;
 }
 
-/// Prepare for executing autocommands for (hidden) buffer `buf` on window `win`
-/// If the buffer of `win` is not `buf`, switch the buffer of `win` to `buf` temporarily.
+/// Prepare for executing autocommands for (hidden) buffer `buf`.
+/// If the current buffer is not in any visible window, put it in a temporary
+/// floating window using an entry in `aucmd_win[]`.
+/// Set `curbuf` and `curwin` to match `buf`.
 ///
-/// @param  aco      Structure to save values in.
-/// @param  buf      New curbuf.
-/// @param  win      New curwin.
-void aucmd_prepbuf_win(aco_save_T *aco, buf_T *buf, win_T *win)
+/// @param aco  structure to save values in
+/// @param buf  new curbuf
+void aucmd_prepbuf(aco_save_T *aco, buf_T *buf)
 {
-  bool need_append = false;  // Append `aucmd_win` to the window list.
-  int auc_idx = -1;  // Index of aucmd_win[] to use. -1 if not using aucmd_win[].
+  win_T *win;
+  bool need_append = true;  // Append `aucmd_win` to the window list.
 
-  aco->save_curtab_handle = -1;
-  aco->save_buf_handle = -1;
-
-  if (win == NULL) {
-    // Window not provided. Find a window that is for the new buffer
-    if (buf == curbuf) {  // be quick when buf is curbuf
-      win = curwin;
-    } else {
-      win = NULL;
-      FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-        if (wp->w_buffer == buf) {
-          win = wp;
-          break;
-        }
-      }
-    }
-
-    // Allocate a window when needed.
-    if (win == NULL) {
-      for (auc_idx = 0; auc_idx < AUCMD_WIN_COUNT; auc_idx++) {
-        if (!aucmd_win[auc_idx].auc_win_used) {
-          break;
-        }
-      }
-
-      if (auc_idx == AUCMD_WIN_COUNT) {
-        kv_push(aucmd_win_vec, ((aucmdwin_T){
-          .auc_win = NULL,
-          .auc_win_used = false,
-        }));
-      }
-
-      if (aucmd_win[auc_idx].auc_win == NULL) {
-        win_alloc_aucmd_win(auc_idx);
-      } else {
-        need_append = true;
-      }
-      win = aucmd_win[auc_idx].auc_win;
-      aucmd_win[auc_idx].auc_win_used = true;
-    }
+  // Find a window that is for the new buffer
+  if (buf == curbuf) {  // be quick when buf is curbuf
+    win = curwin;
   } else {
-    tabpage_T *tp = win_find_tabpage(win);
-
-    // If the window is in another tab page, switch to that tab page temporarily.
-    if (tp != curtab) {
-      aco->save_curtab_handle = curtab->handle;
-      unuse_tabpage(curtab);
-      use_tabpage(tp);
+    win = NULL;
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+      if (wp->w_buffer == buf) {
+        win = wp;
+        break;
+      }
     }
   }
 
-  // If the buffer of the window is not the target buffer, switch to it temporarily.
-  if (win->w_buffer != buf) {
-    if (auc_idx == -1) {
-      // No need to store old buffer for aucmd_win[].
-      aco->save_buf_handle = win->w_buffer->handle;
-      win->w_buffer->b_nwindows--;
+  // Allocate a window when needed.
+  win_T *auc_win = NULL;
+  int auc_idx = AUCMD_WIN_COUNT;
+  if (win == NULL) {
+    for (auc_idx = 0; auc_idx < AUCMD_WIN_COUNT; auc_idx++) {
+      if (!aucmd_win[auc_idx].auc_win_used) {
+        break;
+      }
     }
 
-    win->w_buffer = buf;
-    win->w_s = &buf->b_s;
-    buf->b_nwindows++;
+    if (auc_idx == AUCMD_WIN_COUNT) {
+      kv_push(aucmd_win_vec, ((aucmdwin_T){
+        .auc_win = NULL,
+        .auc_win_used = false,
+      }));
+    }
+
+    if (aucmd_win[auc_idx].auc_win == NULL) {
+      win_alloc_aucmd_win(auc_idx);
+      need_append = false;
+    }
+    auc_win = aucmd_win[auc_idx].auc_win;
+    aucmd_win[auc_idx].auc_win_used = true;
   }
 
-  aco->use_aucmd_win_idx = auc_idx;
   aco->save_curwin_handle = curwin->handle;
   aco->save_prevwin_handle = prevwin == NULL ? 0 : prevwin->handle;
   aco->save_State = State;
@@ -1334,15 +1308,26 @@ void aucmd_prepbuf_win(aco_save_T *aco, buf_T *buf, win_T *win)
     aco->save_prompt_insert = curbuf->b_prompt_insert;
   }
 
-  if (auc_idx >= 0) {
-    // There is no window for "buf", use "win". To minimize the side effects, insert it in the
-    // current tab page. Anything related to a window (e.g., setting folds) may have unexpected
-    // results.
-    win_init_empty(win);  // Set cursor and topline to safe values.
+  if (win != NULL) {
+    // There is a window for "buf" in the current tab page, make it the
+    // curwin.  This is preferred, it has the least side effects (esp. if
+    // "buf" is curbuf).
+    aco->use_aucmd_win_idx = -1;
+    curwin = win;
+  } else {
+    // There is no window for "buf", use "auc_win".  To minimize the side
+    // effects, insert it in the current tab page.
+    // Anything related to a window (e.g., setting folds) may have
+    // unexpected results.
+    aco->use_aucmd_win_idx = auc_idx;
+    auc_win->w_buffer = buf;
+    auc_win->w_s = &buf->b_s;
+    buf->b_nwindows++;
+    win_init_empty(auc_win);  // set cursor and topline to safe values
 
-    // Make sure w_localdir, tp_localdir and globaldir are NULL to avoid a chdir() in
-    // win_enter_ext().
-    XFREE_CLEAR(win->w_localdir);
+    // Make sure w_localdir, tp_localdir and globaldir are NULL to avoid a
+    // chdir() in win_enter_ext().
+    XFREE_CLEAR(auc_win->w_localdir);
     aco->tp_localdir = curtab->tp_localdir;
     curtab->tp_localdir = NULL;
     aco->globaldir = globaldir;
@@ -1350,41 +1335,28 @@ void aucmd_prepbuf_win(aco_save_T *aco, buf_T *buf, win_T *win)
 
     block_autocmds();  // We don't want BufEnter/WinEnter autocommands.
     if (need_append) {
-      win_append(lastwin, win, NULL);
-      pmap_put(int)(&window_handles, win->handle, win);
-      win_config_float(win, win->w_config);
+      win_append(lastwin, auc_win, NULL);
+      pmap_put(int)(&window_handles, auc_win->handle, auc_win);
+      win_config_float(auc_win, auc_win->w_config);
     }
     // Prevent chdir() call in win_enter_ext(), through do_autochdir()
     const int save_acd = p_acd;
     p_acd = false;
-    // No redrawing and don't set the window title
+    // no redrawing and don't set the window title
     RedrawingDisabled++;
-    win_enter(win, false);
+    win_enter(auc_win, false);
     RedrawingDisabled--;
     p_acd = save_acd;
     unblock_autocmds();
+    curwin = auc_win;
   }
-
-  curwin = win;
   curbuf = buf;
   aco->new_curwin_handle = curwin->handle;
   set_bufref(&aco->new_curbuf, curbuf);
 
-  // Disable the Visual area, the position may be invalid in another buffer
+  // disable the Visual area, the position may be invalid in another buffer
   aco->save_VIsual_active = VIsual_active;
   VIsual_active = false;
-}
-
-/// Prepare for executing autocommands for (hidden) buffer `buf`.
-/// If the current buffer is not in any visible window, put it in a temporary
-/// floating window using an entry in `aucmd_win[]`.
-/// Set `curbuf` and `curwin` to match `buf`.
-///
-/// @param  aco  structure to save values in
-/// @param  buf  new curbuf
-void aucmd_prepbuf(aco_save_T *aco, buf_T *buf)
-{
-  aucmd_prepbuf_win(aco, buf, NULL);
 }
 
 /// Cleanup after executing autocommands for a (hidden) buffer.
@@ -1475,19 +1447,6 @@ win_found:
       curwin->w_topfill = 0;
     }
   } else {
-    // Restore old buffer of new window if it was changed.
-    if (aco->save_buf_handle != -1) {
-      win_T *new_win = win_find_by_handle(aco->new_curwin_handle);
-      buf_T *new_win_buf = handle_get_buffer(aco->save_buf_handle);
-
-      if (new_win != NULL && new_win_buf != NULL) {
-        new_win->w_buffer->b_nwindows--;
-        new_win->w_buffer = new_win_buf;
-        new_win->w_s = &new_win_buf->b_s;
-        new_win_buf->b_nwindows++;
-      }
-    }
-
     // Restore curwin.  Use the window ID, a window may have been closed
     // and the memory re-used for another one.
     win_T *const save_curwin = win_find_by_handle(aco->save_curwin_handle);
@@ -1522,13 +1481,6 @@ win_found:
   check_cursor(curwin);  // just in case lines got deleted
   if (VIsual_active) {
     check_pos(curbuf, &VIsual);
-  }
-
-  // Switch back to the original tab page if it was switched.
-  if (aco->save_curtab_handle != -1) {
-    tabpage_T *save_curtab = handle_get_tabpage(aco->save_curtab_handle);
-    unuse_tabpage(curtab);
-    use_tabpage(save_curtab);
   }
 }
 

--- a/src/nvim/autocmd_defs.h
+++ b/src/nvim/autocmd_defs.h
@@ -14,18 +14,16 @@
 /// Struct to save values in before executing autocommands for a buffer that is
 /// not the current buffer.
 typedef struct {
-  int use_aucmd_win_idx;             ///< index in aucmd_win[] if >= 0
-  handle_T save_curwin_handle;       ///< ID of saved curwin
-  handle_T save_curtab_handle;       ///< ID of saved curtab. -1 if not switched.
-  handle_T new_curwin_handle;        ///< ID of new curwin
-  handle_T save_buf_handle;          ///< ID of saved buffer of new curwin. -1 if not switched.
-  handle_T save_prevwin_handle;      ///< ID of saved prevwin
-  bufref_T new_curbuf;               ///< new curbuf
-  char *tp_localdir;                 ///< saved value of tp_localdir
-  char *globaldir;                   ///< saved value of globaldir
-  bool save_VIsual_active;           ///< saved VIsual_active
-  int save_State;                    ///< saved State
-  int save_prompt_insert;            ///< saved b_prompt_insert
+  int use_aucmd_win_idx;          ///< index in aucmd_win[] if >= 0
+  handle_T save_curwin_handle;    ///< ID of saved curwin
+  handle_T new_curwin_handle;     ///< ID of new curwin
+  handle_T save_prevwin_handle;   ///< ID of saved prevwin
+  bufref_T new_curbuf;            ///< new curbuf
+  char *tp_localdir;              ///< saved value of tp_localdir
+  char *globaldir;                ///< saved value of globaldir
+  bool save_VIsual_active;        ///< saved VIsual_active
+  int save_State;                 ///< saved State
+  int save_prompt_insert;         ///< saved b_prompt_insert
 } aco_save_T;
 
 typedef struct {

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1391,8 +1391,8 @@ void diff_win_options(win_T *wp, bool addbuf)
     }
     wp->w_p_fdm_save = xstrdup(wp->w_p_fdm);
   }
-  set_option_direct_for(kOptFoldmethod, STATIC_CSTR_AS_OPTVAL("diff"),
-                        option_ctx_from(kOptScopeWin, wp), OPT_LOCAL, 0);
+  set_option_direct_for(kOptFoldmethod, STATIC_CSTR_AS_OPTVAL("diff"), OPT_LOCAL, 0,
+                        kOptScopeWin, wp);
 
   if (!wp->w_p_diff) {
     wp->w_p_fen_save = wp->w_p_fen;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5294,7 +5294,7 @@ static char *findfunc_find_file(char *findarg, size_t findarg_len, int count)
 /// Returns NULL on success and an error message on failure.
 const char *did_set_findfunc(optset_T *args)
 {
-  buf_T *buf = args->os_ctx.buf;
+  buf_T *buf = (buf_T *)args->os_buf;
   int retval;
 
   if (args->os_flags & OPT_LOCAL) {

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2409,7 +2409,7 @@ static void copy_global_to_buflocal_cb(Callback *globcb, Callback *bufcb)
 /// lambda expression.
 const char *did_set_completefunc(optset_T *args)
 {
-  buf_T *buf = args->os_ctx.buf;
+  buf_T *buf = (buf_T *)args->os_buf;
   if (option_set_callback_func(buf->b_p_cfu, &cfu_cb) == FAIL) {
     return e_invarg;
   }
@@ -2430,7 +2430,7 @@ void set_buflocal_cfu_callback(buf_T *buf)
 /// lambda expression.
 const char *did_set_omnifunc(optset_T *args)
 {
-  buf_T *buf = args->os_ctx.buf;
+  buf_T *buf = (buf_T *)args->os_buf;
   if (option_set_callback_func(buf->b_p_ofu, &ofu_cb) == FAIL) {
     return e_invarg;
   }
@@ -2451,7 +2451,7 @@ void set_buflocal_ofu_callback(buf_T *buf)
 /// lambda expression.
 const char *did_set_thesaurusfunc(optset_T *args FUNC_ATTR_UNUSED)
 {
-  buf_T *buf = args->os_ctx.buf;
+  buf_T *buf = (buf_T *)args->os_buf;
   int retval;
 
   if (args->os_flags & OPT_LOCAL) {

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -81,12 +81,6 @@ typedef struct {
   OptValData data;
 } OptVal;
 
-/// Context that an option is being set for.
-typedef struct {
-  win_T *win;
-  buf_T *buf;
-} OptCtx;
-
 /// :set operator types
 typedef enum {
   OP_NONE = 0,
@@ -128,7 +122,8 @@ typedef struct {
   /// length of the error buffer
   size_t os_errbuflen;
 
-  OptCtx os_ctx;
+  void *os_win;
+  void *os_buf;
 } optset_T;
 
 /// Type for the callback function that is invoked after an option value is
@@ -197,12 +192,3 @@ typedef struct {
   OptVal def_val;                    ///< default value
   LastSet last_set;                  ///< script in which the option was last set
 } vimoption_T;
-
-/// Execute code with autocmd context
-#define WITH_AUCMD_CONTEXT(ctx, code) \
-  do { \
-    aco_save_T _aco; \
-    aucmd_prepbuf_win(&_aco, ctx.buf, ctx.win); \
-    code; \
-    aucmd_restbuf(&_aco); \
-  } while (0)

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -567,7 +567,7 @@ int expand_set_backspace(optexpand_T *args, int *numMatches, char ***matches)
 /// The 'backupcopy' option is changed.
 const char *did_set_backupcopy(optset_T *args)
 {
-  buf_T *buf = args->os_ctx.buf;
+  buf_T *buf = (buf_T *)args->os_buf;
   const char *oldval = args->os_oldval.string.data;
   int opt_flags = args->os_flags;
   char *bkc = p_bkc;
@@ -655,7 +655,7 @@ const char *did_set_breakat(optset_T *args FUNC_ATTR_UNUSED)
 /// The 'breakindentopt' option is changed.
 const char *did_set_breakindentopt(optset_T *args)
 {
-  win_T *win = args->os_ctx.win;
+  win_T *win = (win_T *)args->os_win;
   char **varp = (char **)args->os_varp;
 
   if (briopt_check(*varp, varp == &win->w_p_briopt ? win : NULL) == FAIL) {
@@ -682,7 +682,7 @@ int expand_set_breakindentopt(optexpand_T *args, int *numMatches, char ***matche
 /// The 'bufhidden' option is changed.
 const char *did_set_bufhidden(optset_T *args)
 {
-  buf_T *buf = args->os_ctx.buf;
+  buf_T *buf = (buf_T *)args->os_buf;
   return did_set_opt_strings(buf->b_p_bh, opt_bh_values, false);
 }
 
@@ -698,8 +698,8 @@ int expand_set_bufhidden(optexpand_T *args, int *numMatches, char ***matches)
 /// The 'buftype' option is changed.
 const char *did_set_buftype(optset_T *args)
 {
-  buf_T *buf = args->os_ctx.buf;
-  win_T *win = args->os_ctx.win;
+  buf_T *buf = (buf_T *)args->os_buf;
+  win_T *win = (win_T *)args->os_win;
   // When 'buftype' is set, check for valid value.
   if ((buf->terminal && buf->b_p_bt[0] != 't')
       || (!buf->terminal && buf->b_p_bt[0] == 't')
@@ -780,7 +780,7 @@ static const char *did_set_global_chars_option(win_T *win, char *val, CharsOptio
 /// The 'fillchars' option or the 'listchars' option is changed.
 const char *did_set_chars_option(optset_T *args)
 {
-  win_T *win = args->os_ctx.win;
+  win_T *win = (win_T *)args->os_win;
   char **varp = (char **)args->os_varp;
   const char *errmsg = NULL;
 
@@ -815,7 +815,7 @@ int expand_set_chars_option(optexpand_T *args, int *numMatches, char ***matches)
 /// The 'cinoptions' option is changed.
 const char *did_set_cinoptions(optset_T *args)
 {
-  buf_T *buf = args->os_ctx.buf;
+  buf_T *buf = (buf_T *)args->os_buf;
   // TODO(vim): recognize errors
   parse_cino(buf);
 
@@ -840,7 +840,7 @@ int expand_set_clipboard(optexpand_T *args, int *numMatches, char ***matches)
 /// The 'colorcolumn' option is changed.
 const char *did_set_colorcolumn(optset_T *args)
 {
-  win_T *win = args->os_ctx.win;
+  win_T *win = (win_T *)args->os_win;
   char **varp = (char **)args->os_varp;
   return check_colorcolumn(*varp, varp == &win->w_p_cc ? win : NULL);
 }
@@ -985,7 +985,7 @@ const char *did_set_completeitemalign(optset_T *args)
 /// The 'completeopt' option is changed.
 const char *did_set_completeopt(optset_T *args FUNC_ATTR_UNUSED)
 {
-  buf_T *buf = args->os_ctx.buf;
+  buf_T *buf = (buf_T *)args->os_buf;
   char *cot = p_cot;
   unsigned *flags = &cot_flags;
 
@@ -1021,7 +1021,7 @@ int expand_set_completeopt(optexpand_T *args, int *numMatches, char ***matches)
 /// The 'completeslash' option is changed.
 const char *did_set_completeslash(optset_T *args)
 {
-  buf_T *buf = args->os_ctx.buf;
+  buf_T *buf = (buf_T *)args->os_buf;
   if (check_opt_strings(p_csl, opt_csl_values, false) != OK
       || check_opt_strings(buf->b_p_csl, opt_csl_values, false) != OK) {
     return e_invarg;
@@ -1068,7 +1068,7 @@ int expand_set_cpoptions(optexpand_T *args, int *numMatches, char ***matches)
 /// The 'cursorlineopt' option is changed.
 const char *did_set_cursorlineopt(optset_T *args)
 {
-  win_T *win = args->os_ctx.win;
+  win_T *win = (win_T *)args->os_win;
   char **varp = (char **)args->os_varp;
 
   // This could be changed to use opt_strings_flags() instead.
@@ -1176,12 +1176,12 @@ int expand_set_eadirection(optexpand_T *args, int *numMatches, char ***matches)
 /// options is changed.
 const char *did_set_encoding(optset_T *args)
 {
-  buf_T *buf = args->os_ctx.buf;
+  buf_T *buf = (buf_T *)args->os_buf;
   char **varp = (char **)args->os_varp;
   int opt_flags = args->os_flags;
   // Get the global option to compare with, otherwise we would have to check
   // two values for all local options.
-  char **gvarp = (char **)get_varp_scope_from(get_option(args->os_idx), OPT_GLOBAL, args->os_ctx);
+  char **gvarp = (char **)get_option_varp_scope_from(args->os_idx, OPT_GLOBAL, buf, NULL);
 
   if (gvarp == &p_fenc) {
     if (!MODIFIABLE(buf) && opt_flags != OPT_GLOBAL) {
@@ -1246,7 +1246,7 @@ int expand_set_eventignore(optexpand_T *args, int *numMatches, char ***matches)
 /// The 'fileformat' option is changed.
 const char *did_set_fileformat(optset_T *args)
 {
-  buf_T *buf = args->os_ctx.buf;
+  buf_T *buf = (buf_T *)args->os_buf;
   char **varp = (char **)args->os_varp;
   const char *oldval = args->os_oldval.string.data;
   int opt_flags = args->os_flags;
@@ -1347,7 +1347,7 @@ int expand_set_foldcolumn(optexpand_T *args, int *numMatches, char ***matches)
 /// The 'foldexpr' option is changed.
 const char *did_set_foldexpr(optset_T *args)
 {
-  win_T *win = args->os_ctx.win;
+  win_T *win = (win_T *)args->os_win;
   did_set_optexpr(args);
   if (foldmethodIsExpr(win)) {
     foldUpdateAll(win);
@@ -1358,7 +1358,7 @@ const char *did_set_foldexpr(optset_T *args)
 /// The 'foldignore' option is changed.
 const char *did_set_foldignore(optset_T *args)
 {
-  win_T *win = args->os_ctx.win;
+  win_T *win = (win_T *)args->os_win;
   if (foldmethodIsIndent(win)) {
     foldUpdateAll(win);
   }
@@ -1368,7 +1368,7 @@ const char *did_set_foldignore(optset_T *args)
 /// The 'foldmarker' option is changed.
 const char *did_set_foldmarker(optset_T *args)
 {
-  win_T *win = args->os_ctx.win;
+  win_T *win = (win_T *)args->os_win;
   char **varp = (char **)args->os_varp;
   char *p = vim_strchr(*varp, ',');
 
@@ -1390,7 +1390,7 @@ const char *did_set_foldmarker(optset_T *args)
 /// The 'foldmethod' option is changed.
 const char *did_set_foldmethod(optset_T *args)
 {
-  win_T *win = args->os_ctx.win;
+  win_T *win = (win_T *)args->os_win;
   char **varp = (char **)args->os_varp;
   if (check_opt_strings(*varp, opt_fdm_values, false) != OK || **varp == NUL) {
     return e_invarg;
@@ -1536,7 +1536,7 @@ const char *did_set_iskeyword(optset_T *args)
 /// changed.
 const char *did_set_isopt(optset_T *args)
 {
-  buf_T *buf = args->os_ctx.buf;
+  buf_T *buf = (buf_T *)args->os_buf;
   // 'isident', 'iskeyword', 'isprint' or 'isfname' option: refill g_chartab[]
   // If the new option is invalid, use old value.
   // 'lisp' option: refill g_chartab[] for '-' char
@@ -1565,7 +1565,7 @@ int expand_set_jumpoptions(optexpand_T *args, int *numMatches, char ***matches)
 /// The 'keymap' option has changed.
 const char *did_set_keymap(optset_T *args)
 {
-  buf_T *buf = args->os_ctx.buf;
+  buf_T *buf = (buf_T *)args->os_buf;
   char **varp = (char **)args->os_varp;
   int opt_flags = args->os_flags;
 
@@ -2053,7 +2053,7 @@ int expand_set_showcmdloc(optexpand_T *args, int *numMatches, char ***matches)
 /// The 'signcolumn' option is changed.
 const char *did_set_signcolumn(optset_T *args)
 {
-  win_T *win = args->os_ctx.win;
+  win_T *win = (win_T *)args->os_win;
   char **varp = (char **)args->os_varp;
   const char *oldval = args->os_oldval.string.data;
   if (check_signcolumn(*varp, varp == &win->w_p_scl ? win : NULL) != OK) {
@@ -2079,7 +2079,7 @@ int expand_set_signcolumn(optexpand_T *args, int *numMatches, char ***matches)
 /// The 'spellcapcheck' option is changed.
 const char *did_set_spellcapcheck(optset_T *args)
 {
-  win_T *win = args->os_ctx.win;
+  win_T *win = (win_T *)args->os_win;
   // When 'spellcapcheck' is set compile the regexp program.
   return compile_cap_prog(win->w_s);
 }
@@ -2113,7 +2113,7 @@ const char *did_set_spelllang(optset_T *args)
 /// The 'spelloptions' option is changed.
 const char *did_set_spelloptions(optset_T *args)
 {
-  win_T *win = args->os_ctx.win;
+  win_T *win = (win_T *)args->os_win;
   int opt_flags = args->os_flags;
   const char *val = args->os_newval.string.data;
 
@@ -2189,7 +2189,7 @@ const char *did_set_statusline(optset_T *args)
 static const char *did_set_statustabline_rulerformat(optset_T *args, bool rulerformat,
                                                      bool statuscolumn)
 {
-  win_T *win = args->os_ctx.win;
+  win_T *win = (win_T *)args->os_win;
   char **varp = (char **)args->os_varp;
   if (rulerformat) {       // reset ru_wid first
     ru_wid = 0;
@@ -2264,7 +2264,7 @@ const char *did_set_tabline(optset_T *args)
 /// The 'tagcase' option is changed.
 const char *did_set_tagcase(optset_T *args)
 {
-  buf_T *buf = args->os_ctx.buf;
+  buf_T *buf = (buf_T *)args->os_buf;
   int opt_flags = args->os_flags;
 
   unsigned *flags;
@@ -2337,7 +2337,7 @@ const char *did_set_titlestring(optset_T *args)
 /// The 'varsofttabstop' option is changed.
 const char *did_set_varsofttabstop(optset_T *args)
 {
-  buf_T *buf = args->os_ctx.buf;
+  buf_T *buf = (buf_T *)args->os_buf;
   char **varp = (char **)args->os_varp;
 
   if (!(*varp)[0] || ((*varp)[0] == '0' && !(*varp)[1])) {
@@ -2367,8 +2367,8 @@ const char *did_set_varsofttabstop(optset_T *args)
 /// The 'varstabstop' option is changed.
 const char *did_set_vartabstop(optset_T *args)
 {
-  buf_T *buf = args->os_ctx.buf;
-  win_T *win = args->os_ctx.win;
+  buf_T *buf = (buf_T *)args->os_buf;
+  win_T *win = (win_T *)args->os_win;
   char **varp = (char **)args->os_varp;
 
   if (!(*varp)[0] || ((*varp)[0] == '0' && !(*varp)[1])) {
@@ -2417,7 +2417,7 @@ const char *did_set_viewoptions(optset_T *args FUNC_ATTR_UNUSED)
 /// The 'virtualedit' option is changed.
 const char *did_set_virtualedit(optset_T *args)
 {
-  win_T *win = args->os_ctx.win;
+  win_T *win = (win_T *)args->os_win;
 
   char *ve = p_ve;
   unsigned *flags = &ve_flags;
@@ -2527,7 +2527,7 @@ const char *did_set_winbar(optset_T *args)
 /// The 'winhighlight' option is changed.
 const char *did_set_winhighlight(optset_T *args)
 {
-  win_T *win = args->os_ctx.win;
+  win_T *win = (win_T *)args->os_win;
   char **varp = (char **)args->os_varp;
   if (!parse_winhl_opt(*varp, varp == &win->w_p_winhl ? win : NULL)) {
     return e_invarg;

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -228,7 +228,7 @@ static Callback tfu_cb;          // 'tagfunc' callback function
 /// a function (string), or function(<name>) or funcref(<name>) or a lambda.
 const char *did_set_tagfunc(optset_T *args)
 {
-  buf_T *buf = args->os_ctx.buf;
+  buf_T *buf = (buf_T *)args->os_buf;
 
   callback_free(&tfu_cb);
   callback_free(&buf->b_tfu_cb);

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -411,8 +411,8 @@ win_T *win_float_create(bool enter, bool new_buf)
       return handle_error_and_cleanup(wp, &err);
     }
     buf->b_p_bl = false;  // unlist
-    set_option_direct_for(kOptBufhidden, STATIC_CSTR_AS_OPTVAL("wipe"),
-                          option_ctx_from(kOptScopeBuf, buf), OPT_LOCAL, 0);
+    set_option_direct_for(kOptBufhidden, STATIC_CSTR_AS_OPTVAL("wipe"), OPT_LOCAL, 0,
+                          kOptScopeBuf, buf);
     win_set_buf(wp, buf, &err);
     if (ERROR_SET(&err)) {
       return handle_error_and_cleanup(wp, &err);

--- a/test/functional/lua/with_spec.lua
+++ b/test/functional/lua/with_spec.lua
@@ -882,7 +882,11 @@ describe('vim._with', function()
       eq({
         bo = { cms_cur = '// %s', cms_other = '-- %s', ul_cur = 250, ul_other = -123456 },
         wo = { ve_cur = 'insert', ve_other = 'block', winbl_cur = 25, winbl_other = 10 },
-        go = { cms = '-- %s', ul = 0, ve = 'none', winbl = 50, lmap = 'xy,yx' },
+        -- Global `winbl` inside context ideally should be untouched and equal
+        -- to 50. It seems to be equal to 0 because `context.buf` uses
+        -- `aucmd_prepbuf` C approach which has no guarantees about window or
+        -- window option values inside context.
+        go = { cms = '-- %s', ul = 0, ve = 'none', winbl = 0, lmap = 'xy,yx' },
       }, out.inner)
       eq(out.before, out.after)
     end)


### PR DESCRIPTION
Reverts neovim/neovim#31112
Fixes #31923
Fixes #31925