### PR TITLE
fix(terminal): disable CSIu encoding

### DIFF
--- a/src/nvim/vterm/keyboard.c
+++ b/src/nvim/vterm/keyboard.c
@@ -25,29 +25,32 @@ void vterm_keyboard_unichar(VTerm *vt, uint32_t c, VTermModifier mod)
     return;
   }
 
-  int needs_CSIu;
+  bool needs_CSIu = false;
   switch (c) {
   // Special Ctrl- letters that can't be represented elsewise
   case 'i':
   case 'j':
   case 'm':
   case '[':
-    needs_CSIu = 1;
+    // CSIu encoding is disabled #31926
+    //needs_CSIu = true;
     break;
   // Ctrl-\ ] ^ _ don't need CSUu
   case '\\':
   case ']':
   case '^':
   case '_':
-    needs_CSIu = 0;
     break;
   // Shift-space needs CSIu
   case ' ':
-    needs_CSIu = !!(mod & VTERM_MOD_SHIFT);
+    // CSIu encoding is disabled #31926
+    //needs_CSIu = !!(mod & VTERM_MOD_SHIFT);
     break;
   // All other characters needs CSIu except for letters a-z
   default:
-    needs_CSIu = (c < 'a' || c > 'z');
+    // CSIu encoding is disabled #31926
+    //needs_CSIu = (c < 'a' || c > 'z');
+    break;
   }
 
   // ALT we can just prefix with ESC; anything else requires CSI u
@@ -187,7 +190,8 @@ void vterm_keyboard_key(VTerm *vt, VTermKey key, VTermModifier mod)
 
   case KEYCODE_LITERAL:
                         case_LITERAL:
-    if (mod & (VTERM_MOD_SHIFT|VTERM_MOD_CTRL)) {
+    // CSIu encoding is disabled #31926
+    if (mod & /*(VTERM_MOD_SHIFT|VTERM_MOD_CTRL)*/ 0) {
       vterm_push_output_sprintf_ctrl(vt, C1_CSI, "%d;%du", k.literal, mod + 1);
     } else {
       vterm_push_output_sprintf(vt, mod & VTERM_MOD_ALT ? ESC_S "%c" : "%c", k.literal);


### PR DESCRIPTION
Resolves: https://github.com/neovim/neovim/issues/24093

vterm unconditionally uses the CSIu encoding proposed in [1]. This is roughly equivalent to the "Disambiguate escape codes" mode of the kitty keyboard protocol. However, because it's enabled unconditionally (and not enabled explicitly by an application), applications will receive escape sequences they don't understand (e.g. CSI 13 ; 2 u for Shift+Enter).

We _could_ teach vterm to understand the escape sequence for applications to opt-in to the "Disambiguate escape codes" mode and only use CSIu encoding when that mode is enabled, but then another problem arises: Nvim itself does not disambiguate those keys so by the time the user's input arrives at vterm, it is impossible to distinguish between e.g. `<C-I>` and `<Tab>` (even though these keys are encoded separately when received by the parent terminal!). If we supported the kitty sequence to enable the CSIu encoding then we wouldn't actually be disambiguating some escape codes, so the mode doesn't actually work properly.

Instead, we just disable CSIu encoding completely for now. If Nvim's input processing is ever changed so that `<C-I>` and `<Tab>` remain disambiguated, allowing us to send separate keys to vterm, then we could enable support for kitty's sequence to enable the disambiguate mode.

[1]: http://www.leonerd.org.uk/hacks/fixterms/