### PR TITLE
vim-patch:9.1.0996: ComplMatchIns may highlight wrong text

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -966,7 +966,11 @@ static void ins_compl_insert_bytes(char *p, int len)
 /// -1 mean normal item.
 int ins_compl_col_range_attr(int col)
 {
-  if (col >= compl_col && col < compl_ins_end_col) {
+  if (get_cot_flags() & kOptCotFlagFuzzy) {
+    return -1;
+  }
+
+  if (col >= (compl_col + (int)compl_leader.size) && col < compl_ins_end_col) {
     return syn_name2attr("ComplMatchIns");
   }
 

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -5853,6 +5853,39 @@ describe('builtin popupmenu', function()
           {2:-- INSERT --}                    |
         ]])
         feed('<Esc>')
+
+        -- Does not highlight the compl leader
+        command('set cot+=menuone,noselect')
+        feed('S<C-X><C-O>')
+        local pum_start = [[
+          {10:^                                }|
+          {n:foo            }{1:                 }|
+          {n:bar            }{1:                 }|
+          {n:你好           }{1:                 }|
+          {1:~                               }|*15
+          {2:-- }{8:Back at original}             |
+        ]]
+        screen:expect(pum_start)
+        feed('f<C-N>')
+        screen:expect([[
+          {10:f}{9:oo}{10:^                             }|
+          {s:foo            }{1:                 }|
+          {1:~                               }|*17
+          {2:-- }{5:match 1 of 3}                 |
+        ]])
+        feed('<C-E><ESC>')
+
+        command('set cot+=fuzzy')
+        feed('S<C-X><C-O>')
+        screen:expect(pum_start)
+        feed('f<C-N>')
+        screen:expect([[
+          {10:foo^                             }|
+          {s:foo            }{1:                 }|
+          {1:~                               }|*17
+          {2:-- }{5:match 1 of 3}                 |
+        ]])
+        feed('<Esc>')
       end)
     end
   end

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1817,6 +1817,20 @@ func Test_pum_matchins_highlight_combine()
   call VerifyScreenDump(buf, 'Test_pum_matchins_combine_06', {})
   call term_sendkeys(buf, "\<Esc>")
 
+  " Does not highlight the compl leader
+  call TermWait(buf)
+  call term_sendkeys(buf, ":set cot+=menuone,noselect\<CR>")
+  call TermWait(buf)
+  call term_sendkeys(buf, "S\<C-X>\<C-O>f\<C-N>")
+  call VerifyScreenDump(buf, 'Test_pum_matchins_combine_07', {})
+  call term_sendkeys(buf, "\<C-E>\<Esc>")
+
+  call term_sendkeys(buf, ":set cot+=fuzzy\<CR>")
+  call TermWait(buf)
+  call term_sendkeys(buf, "S\<C-X>\<C-O>f\<C-N>")
+  call VerifyScreenDump(buf, 'Test_pum_matchins_combine_08', {})
+  call term_sendkeys(buf, "\<C-E>\<Esc>")
+
   call StopVimInTerminal(buf)
 endfunc
 


### PR DESCRIPTION
Problem:  ComplMatchIns may highlight wrong text
Solution: don't highlight in case of fuzzy match,
          skip-highlight when not inserting anything
          (glepnir)

closes: vim/vim#16404

https://github.com/vim/vim/commit/e890887b8052561ac5f8dce218e578ed28599cc6