### PR TITLE
fix(getchar): do not simplify keycodes in terminal mode

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1518,9 +1518,11 @@ int merge_modifiers(int c_arg, int *modifiers)
 
   if (*modifiers & MOD_MASK_CTRL) {
     if ((c >= '`' && c <= 0x7f) || (c >= '@' && c <= '_')) {
-      c &= 0x1f;
-      if (c == NUL) {
-        c = K_ZERO;
+      if (!(State & MODE_TERMINAL) || !(c == 'I' || c == 'J' || c == 'M' || c == '[')) {
+        c &= 0x1f;
+        if (c == NUL) {
+          c = K_ZERO;
+        }
       }
     } else if (c == '6') {
       // CTRL-6 is equivalent to CTRL-^

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -625,6 +625,74 @@ describe('terminal input', function()
       ]]):format(key))
     end
   end)
+
+  -- TODO(bfredl): getcharstr() erases the distinction between <C-I> and <Tab>.
+  -- If it was enhanced or replaced this could get folded into the test above.
+  it('can send TAB/C-I and ESC/C-[ separately', function()
+    clear()
+    local screen = tt.setup_child_nvim({
+      '-u',
+      'NONE',
+      '-i',
+      'NONE',
+      '--cmd',
+      'colorscheme vim',
+      '--cmd',
+      'set notermguicolors',
+      '--cmd',
+      'noremap <Tab> <cmd>echo "Tab!"<cr>',
+      '--cmd',
+      'noremap <C-i> <cmd>echo "Ctrl-I!"<cr>',
+      '--cmd',
+      'noremap <Esc> <cmd>echo "Esc!"<cr>',
+      '--cmd',
+      'noremap <C-[> <cmd>echo "Ctrl-[!"<cr>',
+    })
+
+    screen:expect([[
+      ^                                                  |
+      {4:~                                                 }|*3
+      {5:[No Name]                       0,0-1          All}|
+                                                        |
+      {3:-- TERMINAL --}                                    |
+    ]])
+
+    feed('<tab>')
+    screen:expect([[
+      ^                                                  |
+      {4:~                                                 }|*3
+      {5:[No Name]                       0,0-1          All}|
+      Tab!                                              |
+      {3:-- TERMINAL --}                                    |
+    ]])
+
+    feed('<c-i>')
+    screen:expect([[
+      ^                                                  |
+      {4:~                                                 }|*3
+      {5:[No Name]                       0,0-1          All}|
+      Ctrl-I!                                           |
+      {3:-- TERMINAL --}                                    |
+    ]])
+
+    feed('<Esc>')
+    screen:expect([[
+      ^                                                  |
+      {4:~                                                 }|*3
+      {5:[No Name]                       0,0-1          All}|
+      Esc!                                              |
+      {3:-- TERMINAL --}                                    |
+    ]])
+
+    feed('<c-[>')
+    screen:expect([[
+      ^                                                  |
+      {4:~                                                 }|*3
+      {5:[No Name]                       0,0-1          All}|
+      Ctrl-[!                                           |
+      {3:-- TERMINAL --}                                    |
+    ]])
+  end)
 end)
 
 if is_os('win') then


### PR DESCRIPTION
The code represents a useful pattern in normal mode where remapping `<tab>` will implicitly also remap `<c-i>` unless you remap that explicitly. This however relies on the _unmapped_ behavior being identical which is not true in terminal mode, as vterm can distinguish these keys.

Vim seems to entangle this with kitty keyboard mode detection which is irrelevant for us. Conditional fallbacks depending on keyboard mode could be done completely inside `vterm/` without `getchar.c` getting involved, I would think.

ref https://github.com/neovim/neovim/pull/31926#issuecomment-2580000207