### PR TITLE
vim-patch:9.1.1000: tests: ruby tests fail with Ruby 3.4

### DIFF
--- a/test/old/testdir/test_ruby.vim
+++ b/test/old/testdir/test_ruby.vim
@@ -282,7 +282,7 @@ func Test_ruby_Vim_buffer_get()
   call assert_match('Xfoo1$', rubyeval('Vim::Buffer[1].name'))
   call assert_match('Xfoo2$', rubyeval('Vim::Buffer[2].name'))
   call assert_fails('ruby print Vim::Buffer[3].name',
-        \           "NoMethodError: undefined method `name' for nil")
+        \           "NoMethodError")
   %bwipe
 endfunc
 
@@ -364,7 +364,7 @@ func Test_ruby_Vim_evaluate_dict()
   redir => l:out
   ruby d = Vim.evaluate("d"); print d
   redir END
-  call assert_equal(['{"a"=>"foo", "b"=>123}'], split(l:out, "\n"))
+  call assert_equal(['{"a"=>"foo","b"=>123}'], split(substitute(l:out, '\s', '', 'g'), "\n"))
 endfunc
 
 " Test Vim::message({msg}) (display message {msg})
@@ -384,7 +384,7 @@ func Test_ruby_print()
   call assert_equal('1.23', RubyPrint('1.23'))
   call assert_equal('Hello World!', RubyPrint('"Hello World!"'))
   call assert_equal('[1, 2]', RubyPrint('[1, 2]'))
-  call assert_equal('{"k1"=>"v1", "k2"=>"v2"}', RubyPrint('({"k1" => "v1", "k2" => "v2"})'))
+  call assert_equal('{"k1"=>"v1","k2"=>"v2"}', substitute(RubyPrint('({"k1" => "v1", "k2" => "v2"})'), '\s', '', 'g'))
   call assert_equal('true', RubyPrint('true'))
   call assert_equal('false', RubyPrint('false'))
   call assert_equal('', RubyPrint('nil'))


### PR DESCRIPTION
#### vim-patch:9.1.1000: tests: ruby tests fail with Ruby 3.4

Problem:  tests: ruby tests fail with Ruby 3.4
Solution: adjust expected output for Ruby 3.4
          (Yee Cheng Chin)

Vim's Ruby tests relied on explicit matching of output texts which are
fragile in design. Ruby 3.4 has changed the output slightly (using
'name' instead of `name', and also using more spaces in dictionary
printouts). Modify the Vim tests to be less fragile to such changes.

closes: vim/vim#16411

https://github.com/vim/vim/commit/ebea31e454b9a1731cde845226f2c28ca5c097b1

Co-authored-by: Yee Cheng Chin <ychin.git@gmail.com>