### PR TITLE
vim-patch:df4a7d7: runtime(tiasm): use correct syntax name tiasm in syntax script

### DIFF
--- a/runtime/syntax/tiasm.vim
+++ b/runtime/syntax/tiasm.vim
@@ -99,4 +99,4 @@ hi def link tiasmIdentifier	Identifier
 hi def link tiasmType		Type
 hi def link tiasmFunction	Function
 
-let b:current_syntax = "lineartiasm"
+let b:current_syntax = "tiasm"


### PR DESCRIPTION
#### vim-patch:df4a7d7: runtime(tiasm):  use correct syntax name tiasm in syntax script

closes: vim/vim#16416

https://github.com/vim/vim/commit/df4a7d761740d59a4f911c9e13ac620a459cdea6

Co-authored-by: Wu, Zhenyu <wuzhenyu@ustc.edu>