### PR TITLE
docs(cmake): clarify build preset descriptions

### DIFF
--- a/CMakePresets.json
+++ b/CMakePresets.json
@@ -10,7 +10,7 @@
     {
       "name": "default",
       "displayName": "RelWithDebInfo",
-      "description": "Enables optimizations (-O2) with debug information",
+      "description": "Enables optimizations with debug information",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "RelWithDebInfo"
       },
@@ -19,7 +19,7 @@
     {
       "name": "debug",
       "displayName": "Debug",
-      "description": "Disables optimizations (-O0), enables debug information",
+      "description": "No optimizations, enables debug information",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Debug"
       },
@@ -28,7 +28,7 @@
     {
       "name": "release",
       "displayName": "Release",
-      "description": "Same as RelWithDebInfo, but disables debug information",
+      "description": "Optimized for performance, disables debug information",
       "cacheVariables": {
         "CMAKE_BUILD_TYPE": "Release"
       },


### PR DESCRIPTION
Update the build preset descriptions in CMakePresets.json to more accurately reflect our actual build configurations and compiler behavior.

* RelWithDebInfo
    * Explicitly mention that we keep assertions enabled by not defining `-DNDEBUG`, typicaly RelWithDebInfo builds remove assertions.
* Debug
    * Removed specific mention of -O0 optimization flag, because cmake not define `-O0` in many cases.
* Release
    * Revised the description to better distinguish it from RelWithDebInfo. Highlights its unique characteristics: maximum optimization (-O3 vs -O2), no debug info ( '' vs -g), disabled assertions.

NOTE, cmake build type configs in GCC (and Clang, it includes GCC config).

* https://github.com/Kitware/CMake/blob/ef6f5774fa07c36f799533202a790b9648c0648a/Modules/Compiler/GNU.cmake

```cmake
  # Initial configuration flags.
  string(APPEND CMAKE_${lang}_FLAGS_INIT " ")
  string(APPEND CMAKE_${lang}_FLAGS_DEBUG_INIT " -g")
  string(APPEND CMAKE_${lang}_FLAGS_MINSIZEREL_INIT " -Os")
  string(APPEND CMAKE_${lang}_FLAGS_RELEASE_INIT " -O3")
  string(APPEND CMAKE_${lang}_FLAGS_RELWITHDEBINFO_INIT " -O2 -g")
```

# Motivation

These changes help prevent confusion by making our build configuration descriptions match the actual compiler behavior in our project.
