### PR TITLE
fix(docs): replace `yxx` mappings with `g==`

### DIFF
--- a/runtime/doc/helphelp.txt
+++ b/runtime/doc/helphelp.txt
@@ -193,7 +193,7 @@ Jump to specific subjects by using tags.  This can be done in two ways:
 
 Use CTRL-T or CTRL-O to jump back.
 Use ":q" to close the help window.
-Use `yxx` to execute the current Lua/Vimscript code block.
+Use `g==` to execute the current Lua/Vimscript code block.
 
 If there are several matches for an item you are looking for, this is how you
 can jump to each one of them:

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -221,7 +221,7 @@ DIAGNOSTICS
 
 EDITOR
 
-• Use |yxx| in :help docs to execute Lua and Vimscript code examples.
+• Use |g==| in :help docs to execute Lua and Vimscript code examples.
 • Improved |paste| handling for redo (dot-repeat) and macros (|recording|):
   • Redoing a large paste is significantly faster and ignores 'autoindent'.
   • Replaying a macro with |@| also replays pasted text.

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -166,7 +166,7 @@ directory indicated in the request. >lua
   })
 
 To try it out, select the above code and source it with `:'<,'>lua` (or
-`yxx`), then run this command in a :terminal buffer: >
+`g==`), then run this command in a :terminal buffer: >
 
     printf "\033]7;file://./foo/bar\033\\"
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1336,7 +1336,7 @@ parse({lang}, {query})                          *vim.treesitter.query.parse()*
       `info.captures`).
     • `info.patterns`: information about predicates.
 
-    Example (to try it, use `yxx` or select the code then run `:'<,'>lua`): >lua
+    Example (to try it, use `g==` or select the code then run `:'<,'>lua`): >lua
         local query = vim.treesitter.query.parse('vimdoc', [[
           ; query
           ((h1) @str

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -554,8 +554,8 @@ gO			Show a filetype-specific, navigable "outline" of the
 							*:sl!* *:sleep!*
 :[N]sl[eep]! [N][m]	Same as above, but hide the cursor.
 
-							*yxx*
-yxx			Executes the current code block.
+							*g==*
+g==			Executes the current code block.
 
 			Works in |help| buffers.
 

--- a/runtime/ftplugin/help.lua
+++ b/runtime/ftplugin/help.lua
@@ -57,7 +57,7 @@ for _, match, metadata in query:iter_matches(tree:root(), 0, 0, -1) do
 
     if name == 'code' then
       vim.api.nvim_buf_set_extmark(0, run_message_ns, start, 0, {
-        virt_text = { { 'Run with `yxx`', 'LspCodeLens' } },
+        virt_text = { { 'Run with `g==`', 'LspCodeLens' } },
       })
       local code = vim.treesitter.get_node_text(node, 0)
       local lang_node = match[metadata[id].lang][1] --[[@as TSNode]]
@@ -69,7 +69,7 @@ for _, match, metadata in query:iter_matches(tree:root(), 0, 0, -1) do
   end
 end
 
-vim.keymap.set('n', 'yxx', function()
+vim.keymap.set('n', 'g==', function()
   local pos = vim.api.nvim_win_get_cursor(0)[1]
   local code_block = code_blocks[pos]
   if not code_block then
@@ -82,5 +82,5 @@ vim.keymap.set('n', 'yxx', function()
 end, { buffer = true })
 
 vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '')
-  .. '\n exe "nunmap <buffer> gO" | exe "nunmap <buffer> yxx"'
+  .. '\n exe "nunmap <buffer> gO" | exe "nunmap <buffer> g=="'
 vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | call v:lua.vim.treesitter.stop()'

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -292,7 +292,7 @@ end)
 ---   - `captures`: a list of unique capture names defined in the query (alias: `info.captures`).
 ---   - `info.patterns`: information about predicates.
 ---
---- Example (to try it, use `yxx` or select the code then run `:'<,'>lua`):
+--- Example (to try it, use `g==` or select the code then run `:'<,'>lua`):
 --- ```lua
 --- local query = vim.treesitter.query.parse('vimdoc', [[
 ---   ; query


### PR DESCRIPTION
Problem: `yx` prefix is not the best fit for "execute code" mappings.

Solution: use `g=` (in the form of `g==` currently) as it is more
  popularized as "execute code" mapping.
  For example, in 'tpope/vim-scriptease'.

------

Addresses #31904 changes.