### PR TITLE
fix(docs): use syntactically correct Lua code example

### DIFF
--- a/runtime/doc/lua-guide.txt
+++ b/runtime/doc/lua-guide.txt
@@ -153,7 +153,7 @@ its functions if this succeeds and prints an error message otherwise:
     if not ok then
       print("Module had an error")
     else
-      mymod.function()
+      mymod.func()
     end
 <
 In contrast to |:source|, |require()| not only searches through all `lua/` directories


### PR DESCRIPTION
`function` is a reserved keyword in Lua and can not be used in the `mymod.function` form.