### PR TITLE
vim-patch:51754c8: runtime(editorconfig): set omnifunc to syntaxcomplete func

### DIFF
--- a/runtime/ftplugin/editorconfig.vim
+++ b/runtime/ftplugin/editorconfig.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 " Language:	EditorConfig
 " Maintainer:	Riley Bruins <ribru17@gmail.com>
-" Last Change:	2024 Jul 06
+" Last Change:	2025 Jan 10
 
 if exists('b:did_ftplugin')
   finish
@@ -10,4 +10,6 @@ let b:did_ftplugin = 1
 
 setl comments=:#,:; commentstring=#\ %s
 
-let b:undo_ftplugin = 'setl com< cms<'
+setl omnifunc=syntaxcomplete#Complete
+
+let b:undo_ftplugin = 'setl com< cms< ofu<'


### PR DESCRIPTION
closes: vim/vim#16419

https://github.com/vim/vim/commit/51754c8a498c39592250a077f56db89dd261995d

Co-authored-by: Yochem van Rosmalen <git@yochem.nl>
