### PR TITLE
fix(comment): always get innermost ts commentstring

### DIFF
--- a/runtime/lua/vim/_comment.lua
+++ b/runtime/lua/vim/_comment.lua
@@ -37,7 +37,7 @@ local function get_commentstring(ref_position)
     for _, ft in ipairs(filetypes) do
       local cur_cs = vim.filetype.get_option(ft, 'commentstring')
       if cur_cs ~= '' and level > res_level then
-        ts_cs = cur_cs
+        ts_cs, res_level = cur_cs, level
       end
     end
 


### PR DESCRIPTION
~The `level > res_level` is always true since `level >= 1`, and `res_level` is never reassigned~