### PR TITLE
fix(messages): attaching/detaching ext_messages causes asserts

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -312,7 +312,7 @@ void msg_multihl(HlMessage hl_msg, const char *kind, bool history, bool err)
     } else {
       msg_multiline(chunk.text, chunk.hl_id, true, false, &need_clear);
     }
-    assert(msg_ext_kind == kind);
+    assert(!ui_has(kUIMessages) || msg_ext_kind == kind);
   }
   if (history && kv_size(hl_msg)) {
     add_msg_hist_multihl(NULL, 0, 0, true, hl_msg);

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -223,10 +223,10 @@ void ui_refresh(void)
   // Reset 'cmdheight' for all tabpages when ext_messages toggles.
   if (had_message != ui_ext[kUIMessages]) {
     set_option_value(kOptCmdheight, NUMBER_OPTVAL(had_message), 0);
-    command_height();
     FOR_ALL_TABS(tp) {
       tp->tp_ch_used = had_message;
     }
+    msg_scroll_flush();
   }
 
   if (!ui_active()) {


### PR DESCRIPTION
Problem:  Assert hit related to message kind, which is reset after a
          all ext_messages UIs are detached, so the assertion is
          expectedly false. Assert hit related to message grid variables
          after an ext_messages UI attaches while message grid is scrolled.
Solution: Don't check message kind assertion if no ext_messages UI is
          attached. Flush message grid when first/last ext_messages UI
          attaches/detaches.

Resolve #21056, #22914, #28331