### PR TITLE
vim-patch:9.1.1001: ComplMatchIns highlight hard to read on light background

### DIFF
--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -20,7 +20,7 @@
   "R:SpellRare,L:SpellLocal,+:Pmenu,=:PmenuSel,k:PmenuMatch,<:PmenuMatchSel,[:PmenuKind," \
   "]:PmenuKindSel,{:PmenuExtra,}:PmenuExtraSel,x:PmenuSbar,X:PmenuThumb,*:TabLine,#:TabLineSel," \
   "_:TabLineFill,!:CursorColumn,.:CursorLine,o:ColorColumn,q:QuickFixLine,z:StatusLineTerm," \
-  "Z:StatusLineTermNC,g:MsgArea,0:Whitespace,I:NormalNC"
+  "Z:StatusLineTermNC,g:MsgArea,h:ComplMatchIns,0:Whitespace,I:NormalNC"
 
 // Default values for 'errorformat'.
 // The "%f|%l| %m" one is used for when the contents of the quickfix window is


### PR DESCRIPTION
#### vim-patch:9.1.1001: ComplMatchIns highlight hard to read on light background

Problem:  ComplMatchIns highlight hard to read on light background
          (after v9.1.0996)
Solution: define the highlighting group cleared, it should be configured in
          colorschemes separately (glepnir)

closes: vim/vim#16414

https://github.com/vim/vim/commit/ad409876d9cf7e565f99c5e21b9e2e400a83a4d4

Co-authored-by: glepnir <glephunter@gmail.com>