### PR TITLE
refactor(api): convert to Integer when id already exists

### DIFF
--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -62,7 +62,7 @@ Integer nvim_create_namespace(String name)
 {
   handle_T id = map_get(String, int)(&namespace_ids, name);
   if (id > 0) {
-    return id;
+    return (Integer)id;
   }
   id = next_namespace_id++;
   if (name.size > 0) {


### PR DESCRIPTION
Problem: when ns id already exists there just return id without convert to Integer in nvim_create_namespace

Solution: convert return id to Integer when ns id exists