### PR TITLE
vim-patch:668e9f2: runtime(filetype): don't detect string interpolation as angular

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -757,7 +757,7 @@ function M.html(_, bufnr)
     if
       matchregex(
         line,
-        [[@\(if\|for\|defer\|switch\)\|\*\(ngIf\|ngFor\|ngSwitch\|ngTemplateOutlet\)\|ng-template\|ng-content\|{{.*}}]]
+        [[@\(if\|for\|defer\|switch\)\|\*\(ngIf\|ngFor\|ngSwitch\|ngTemplateOutlet\)\|ng-template\|ng-content]]
       )
     then
       return 'htmlangular'


### PR DESCRIPTION
fixes: vim/vim#16375

https://github.com/vim/vim/commit/668e9f24037fc7c362ffdf5fc1d5c5b1a8b0e855

Co-authored-by: Christian Brabandt <cb@256bit.org>
