### PR TITLE
vim-patch:9.1.1003: [security]: heap-buffer-overflow with visual mode

### DIFF
--- a/src/nvim/arglist.c
+++ b/src/nvim/arglist.c
@@ -31,6 +31,7 @@
 #include "nvim/memline_defs.h"
 #include "nvim/memory.h"
 #include "nvim/message.h"
+#include "nvim/normal.h"
 #include "nvim/option.h"
 #include "nvim/option_vars.h"
 #include "nvim/os/input.h"
@@ -1095,6 +1096,10 @@ static void do_arg_all(int count, int forceit, int keep_tabs)
   arglist_locked = true;
 
   tabpage_T *const new_lu_tp = curtab;
+
+  // Stop Visual mode, the cursor and "VIsual" may very well be invalid after
+  // switching to another buffer.
+  reset_VIsual_and_resel();
 
   // Try closing all windows that are not in the argument list.
   // Also close windows that are not full width;

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1860,7 +1860,7 @@ int gchar_pos(pos_T *pos)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   // When searching columns is sometimes put at the end of a line.
-  if (pos->col == MAXCOL) {
+  if (pos->col == MAXCOL || pos->col > ml_get_len(pos->lnum)) {
     return NUL;
   }
   return utf_ptr2char(ml_get_pos(pos));

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -4345,6 +4345,7 @@ void charwise_block_prep(pos_T start, pos_T end, struct block_def *bdp, linenr_T
   colnr_T endcol = MAXCOL;
   colnr_T cs, ce;
   char *p = ml_get(lnum);
+  int plen = ml_get_len(lnum);
 
   bdp->startspaces = 0;
   bdp->endspaces = 0;
@@ -4394,7 +4395,7 @@ void charwise_block_prep(pos_T start, pos_T end, struct block_def *bdp, linenr_T
     bdp->textlen = endcol - startcol + inclusive;
   }
   bdp->textcol = startcol;
-  bdp->textstart = p + startcol;
+  bdp->textstart = startcol <= plen ? p + startcol : p;
 }
 
 /// Handle the add/subtract operator.

--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -470,7 +470,7 @@ func Test_Visual_Block()
 	      \ "\t{",
 	      \ "\t}"], getline(1, '$'))
 
-  close!
+  bw!
 endfunc
 
 " Test for 'p'ut in visual block mode
@@ -1082,7 +1082,7 @@ func Test_star_register()
 
   delmarks < >
   call assert_fails('*yank', 'E20:')
-  close!
+  bw!
 endfunc
 
 " Test for changing text in visual mode with 'exclusive' selection
@@ -1098,7 +1098,7 @@ func Test_exclusive_selection()
   call assert_equal('l      one', getline(1))
   set virtualedit&
   set selection&
-  close!
+  bw!
 endfunc
 
 " Test for starting linewise visual with a count.
@@ -1155,7 +1155,7 @@ func Test_visual_inner_block()
   8,9d
   call cursor(5, 1)
   call assert_beeps('normal ViBiB')
-  close!
+  bw!
 endfunc
 
 func Test_visual_put_in_block()
@@ -2762,6 +2762,24 @@ func Test_visual_block_exclusive_selection_adjusted()
   call assert_equal([0, 4, 9, 0], getpos("'>"))
   bwipe!
   set selection&vim
+endfunc
+
+" the following caused a Heap-Overflow, because Vim was accessing outside of a
+" line end
+func Test_visual_pos_buffer_heap_overflow()
+  set virtualedit=all
+  args Xa Xb
+  all
+  call setline(1, ['', '', ''])
+  call cursor(3, 1)
+  wincmd w
+  call setline(1, 'foobar')
+  normal! $lv0
+  all
+  call setreg('"', 'baz')
+  normal! [P
+  set virtualedit=
+  bw! Xa Xb
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1003: [security]: heap-buffer-overflow with visual mode

Problem:  [security]: heap-buffer-overflow with visual mode when
          using :all, causing Vim trying to access beyond end-of-line
          (gandalf)
Solution: Reset visual mode on :all, validate position in gchar_pos()
          and charwise_block_prep()

This fixes CVE-2025-22134

Github Advisory:
https://github.com/vim/vim/security/advisories/GHSA-5rgf-26wj-48v8

https://github.com/vim/vim/commit/c9a1e257f1630a0866447e53a564f7ff96a80ead

Co-authored-by: Christian Brabandt <cb@256bit.org>