### PR TITLE
vim-patch:partial:9598a63: runtime(doc): add package-<name> helptags for included packages

### DIFF
--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -538,9 +538,9 @@ EXECUTE A COMMAND IN ALL THE BUFFERS IN QUICKFIX OR LOCATION LIST:
 <			Otherwise it works the same as `:ldo`.
 
 FILTERING A QUICKFIX OR LOCATION LIST:
-				    *cfilter-plugin* *:Cfilter* *:Lfilter*
+		    *cfilter-plugin* *:Cfilter* *:Lfilter* *package-cfilter*
 If you have too many entries in a quickfix list, you can use the cfilter
-plugin to reduce the number of entries.  Load the plugin with: >
+plugin to reduce the number of entries.  Load the plugin with: >vim
 
     packadd cfilter
 

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -207,7 +207,7 @@ Use |jobwait()| to check if the terminal job has finished: >vim
     let running = jobwait([&channel], 0)[0] == -1
 <
 ==============================================================================
-:Termdebug plugin				*terminal-debug*
+:Termdebug plugin	*terminal-debug* *terminal-debugger* *package-termdebug*
 
 The Terminal debugging plugin can be used to debug a program with gdb and view
 the source code in a Vim window.  Since this is completely contained inside

--- a/runtime/doc/usr_02.txt
+++ b/runtime/doc/usr_02.txt
@@ -684,6 +684,13 @@ Summary:					*help-summary*  >
 	:help E128
 <    takes you to the |:function| command
 
+27) Documenction for packages distributed with Vim have the form package-<name>.
+     So >
+	:help package-termdebug
+<
+    will bring you to the help section for the included termdebug plugin and
+    how to enable it.
+
 
 ==============================================================================
 

--- a/runtime/doc/usr_05.txt
+++ b/runtime/doc/usr_05.txt
@@ -235,7 +235,7 @@ an archive or as a repository.  For an archive you can follow these steps:
 	   else.
 
 
-Adding nohlsearch package				*nohlsearch-install*
+Adding nohlsearch package	*nohlsearch-install* *package-nohlsearch*
 
 Load the plugin with this command: >
 	packadd nohlsearch

--- a/runtime/doc/usr_25.txt
+++ b/runtime/doc/usr_25.txt
@@ -190,15 +190,15 @@ This results in the following:
 	story. ~
 
 
-JUSTIFYING TEXT
+JUSTIFYING TEXT			*justify* *:Justify* *Justify()* *package-justify*
 
 Vim has no built-in way of justifying text.  However, there is a neat macro
 package that does the job.  To use this package, execute the following
-command: >
+command: >vim
 
 	:packadd justify
 
-Or put this line in your |vimrc|: >
+Or put this line in your |vimrc|: >vim
 
 	packadd! justify
 


### PR DESCRIPTION
#### vim-patch:partial:9598a63: runtime(doc): add package-\<name> helptags for included packages

Improve how to find the justify package

closes: vim/vim#16420

https://github.com/vim/vim/commit/9598a6369bce32d3da831e8968caf4625985ac3c

Co-authored-by: Christian Brabandt <cb@256bit.org>
Co-authored-by: Peter Benjamin <petermbenjamin@gmail.com>