### PR TITLE
vim-patch:9.1.1005: completion text is highlighted even with no pattern found

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -970,7 +970,7 @@ int ins_compl_col_range_attr(int col)
     return -1;
   }
 
-  if (col >= (compl_col + (int)compl_leader.size) && col < compl_ins_end_col) {
+  if (col >= (compl_col + (int)ins_compl_leader_len()) && col < compl_ins_end_col) {
     return syn_name2attr("ComplMatchIns");
   }
 

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -5885,7 +5885,16 @@ describe('builtin popupmenu', function()
           {1:~                               }|*17
           {2:-- }{5:match 1 of 3}                 |
         ]])
-        feed('<Esc>')
+        feed('<C-E><Esc>')
+
+        command('set cot-=fuzzy')
+        feed('Sf<C-N>')
+        screen:expect([[
+          {10:f^                               }|
+          {1:~                               }|*18
+          {2:-- }{6:Pattern not found}            |
+        ]])
+        feed('<C-E><Esc>')
       end)
     end
   end

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1830,6 +1830,13 @@ func Test_pum_matchins_highlight_combine()
   call term_sendkeys(buf, "S\<C-X>\<C-O>f\<C-N>")
   call VerifyScreenDump(buf, 'Test_pum_matchins_combine_08', {})
   call term_sendkeys(buf, "\<C-E>\<Esc>")
+  call TermWait(buf)
+
+  call term_sendkeys(buf, ":set cot-=fuzzy\<CR>")
+  call TermWait(buf)
+  call term_sendkeys(buf, "Sf\<C-N>")
+  call VerifyScreenDump(buf, 'Test_pum_matchins_combine_09', {})
+  call term_sendkeys(buf, "\<C-E>\<Esc>")
 
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.1005: completion text is highlighted even with no pattern found

Problem:  completion text is highlighted even with no pattern found
Solution: use ins_compl_leader_len() instead of checking
          compl_leader.length (glepnir)

closes: vim/vim#16422

https://github.com/vim/vim/commit/9fddb8ae770be3e16545dd4c2f4cfaad8f62cb40

Co-authored-by: glepnir <glephunter@gmail.com>