### PR TITLE
perf(treesitter): cache queries strongly

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -292,6 +292,9 @@ PERFORMANCE
   inflight requests). This greatly improves performance with slow LSP servers.
 • 10x speedup for |vim.treesitter.foldexpr()| (when no parser exists for the
   buffer).
+• Strong |treesitter-query| caching makes repeat  |vim.treesitter.query.get()|
+  and |vim.treesitter.query.parse()| calls significantly faster for large
+  queries.
 
 PLUGINS
 


### PR DESCRIPTION
**Problem:** Query parsing uses a weak cache which is invalidated frequently

**Solution:** Make the cache strong, and invalidate it manually when necessary (that is, when `rtp` is changed or `query.set()` is called)

Closes #31969