### PR TITLE
feat: incremental injection parsing

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -306,6 +306,8 @@ PERFORMANCE
   queries.
 • Treesitter highlighting is now asynchronous. To force synchronous parsing,
   use `vim.g._ts_force_sync_parsing = true`.
+• Treesitter injections are searched incrementally (when possible).
+  Editing large files with treesitter highlighting is significantly faster.
 • Treesitter folding is now calculated asynchronously.
 
 PLUGINS

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -560,17 +560,24 @@ The language injection behavior can also be configured by some properties
 associated with patterns:
 
     • `injection.language` - can be used to hard-code the name of a specific
-    language.
+      language.
     • `injection.combined` - indicates that all of the matching nodes in the
-    tree should have their content parsed as one nested document.
+      tree should have their content parsed as one nested document.
     • `injection.include-children` - indicates that the `@injection.content`
-    node's entire text should be re-parsed, including the text of its child
-    nodes. By default, child nodes' text will be excluded from the injected
-    document.
+      node's entire text should be re-parsed, including the text of its child
+      nodes. By default, child nodes' text will be excluded from the injected
+      document.
     • `injection.self` - indicates that the node's text should be parsed with
       the same language as the node's LanguageTree.
     • `injection.parent` - indicates that the captured node’s text should
       be parsed with the same language as the node's parent LanguageTree.
+    • nvim.injection-root - which capture should be used as the "root" of the
+      match. If all patterns in a query have a "root" node, injections can
+      be parsed incrementally. A "root" node in a pattern is such a node
+      for which, whether the pattern matches on it or not, depends only on
+      the text content within its range (including descendants), and node
+      types of its descendants or ancestors. Must not be the root node of
+      the grammar.
 
 ==============================================================================
 VIM.TREESITTER                                                *lua-treesitter*
@@ -1448,6 +1455,8 @@ Query:iter_matches({node}, {source}, {start}, {stop}, {opts})
                     IDs to a single (last) node instead of the full list of
                     matching nodes. This option is only for backward
                     compatibility and will be removed in a future release.
+                  • byte_begin
+                  • byte_end
 
     Return: ~
         (`fun(): integer, table<integer, TSNode[]>, vim.treesitter.query.TSMetadata, TSTree`)

--- a/runtime/lua/vim/treesitter/_byte_range.lua
+++ b/runtime/lua/vim/treesitter/_byte_range.lua
@@ -1,0 +1,167 @@
+local bit = require('bit')
+local rshift = bit.rshift
+
+local M = {}
+
+--- Indices are 0-based.
+local function memmove(dst, dst_begin, src, src_begin, count)
+  -- Accessing an undefined field of a global variable
+  -- luacheck: push ignore 143
+  if table.move then
+    table.move(src, 1 + src_begin, 1 + src_begin + count - 1, 1 + dst_begin, dst)
+    -- luacheck: pop
+  else
+    if dst == src then
+      if dst_begin == src_begin then
+        return
+      end
+      assert(dst_begin <= src_begin, 'Not implemented')
+    end
+
+    for i = 1, count do
+      dst[dst_begin + i] = src[src_begin + i]
+    end
+  end
+end
+
+---@param ranges [integer, integer][] Sorted, non-overlapping.
+---@param edit_b integer
+---@param edit_e_old integer
+---@return integer index
+function M.ranges_find_first_edited(ranges, edit_b, edit_e_old)
+  local bi = 1
+  local ei = 1 + #ranges
+  while bi < ei do
+    local mi = rshift(bi + ei, 1)
+    local meb = ranges[mi][2]
+
+    -- see tree-sitter ts_subtree_edit()
+    local cmp ---@type boolean
+    if edit_b == edit_e_old then
+      cmp = edit_b <= meb
+    else
+      cmp = edit_b < meb
+    end
+
+    if cmp then
+      ei = mi
+    else
+      bi = mi + 1
+    end
+  end
+
+  return ei
+end
+
+---Find 0-based [`begin_i`, `end_i`) that the given range is next to or intersects.
+---@param ranges [integer, integer][] Sorted, non-overlapping.
+---@param byte_b integer
+---@param byte_e integer
+---@return integer begin_i 0-based.
+---@return integer end_i 0-based.
+local function ranges_find_touching(ranges, byte_b, byte_e)
+  -- Find first range that the given range can be combined with.
+  -- Find first range that the given range is before.
+  local bi = 0
+  local ei = #ranges
+  -- to continue searching the second position.
+  local end_in_sync = true
+  ---@type integer
+  local bi_end
+  ---@type integer
+  local ei_end
+
+  while bi < ei do
+    local mi = rshift(bi + ei, 1)
+    local mid_beg = ranges[1 + mi][1]
+    local mid_end = ranges[1 + mi][2]
+
+    local satisfied_begin = byte_b <= mid_end
+    local satisfied_end = byte_e < mid_beg
+    if satisfied_begin ~= satisfied_end and end_in_sync then
+      end_in_sync = false
+      bi_end = bi
+      ei_end = ei
+    end
+    if satisfied_begin then
+      ei = mi
+    else
+      bi = mi + 1
+    end
+  end
+
+  if end_in_sync then
+    ei_end = ei
+  else
+    while bi_end < ei_end do
+      local mi = rshift(bi_end + ei_end, 1)
+      local mid_beg = ranges[1 + mi][1]
+      if byte_e < mid_beg then
+        ei_end = mi
+      else
+        bi_end = mi + 1
+      end
+    end
+  end
+
+  return ei, ei_end
+end
+
+---Inserts a range into a sorted array of non-overlapping (possibly touching) ranges.
+---After insertion, ranges are not overlapping, and not touching the inserted range.
+---@param ranges [integer, integer][]
+---@param byte_b integer
+---@param byte_e integer
+function M.ranges_insert(ranges, byte_b, byte_e)
+  local count = #ranges
+  local b, e = ranges_find_touching(ranges, byte_b, byte_e)
+
+  if b < e then
+    ranges[1 + b][1] = math.min(byte_b, ranges[1 + b][1])
+    ranges[1 + b][2] = math.max(byte_e, ranges[1 + e - 1][2])
+
+    if e - b > 1 then
+      local move_begin = b + 1
+      local move_count = count - e
+      memmove(ranges, move_begin, ranges, e, move_count)
+      for i = move_begin + move_count, count - 1 do
+        ranges[1 + i] = nil
+      end
+    end
+  else
+    table.insert(ranges, 1 + b, { byte_b, byte_e })
+  end
+end
+
+---Edit a range like teee-sitter would've edited a node.
+---But only if the edit itersects the range.
+---@param range [integer, integer]
+---@param edit_b integer
+---@param edit_e_old integer
+---@param edit_e_new integer
+function M.adjust_if_intersects(range, edit_b, edit_e_old, edit_e_new)
+  -- See `ts_subtree_edit()` in tree-sitter.
+  if range[1] >= edit_e_old then
+    -- Edit is entirely before the range.
+    return
+  elseif edit_b < range[1] then
+    -- Edit starts before the range and ends inside/after.
+    -- Move the tree to the end of the edit and shrink accordingly.
+    range[1] = M.clamp(edit_e_new)
+    range[2] = M.clamp(range[1] + math.max(range[2] - edit_e_old, 0))
+  elseif edit_b < range[2] or (edit_b == range[2] and edit_b == edit_e_old) then
+    -- Edit starts inside the range.
+    -- Include the edit in the range (yes, even if old_end is outside the range).
+    range[2] = M.clamp(edit_e_new + math.max(range[2] - edit_e_old, 0))
+  end
+  -- else the edit is entirely after the range.
+end
+
+local max = 2 ^ 32 - 1
+
+---@param byte integer
+function M.clamp(byte)
+  return math.min(math.max(0, byte), max)
+end
+
+return M

--- a/runtime/lua/vim/treesitter/_meta/misc.lua
+++ b/runtime/lua/vim/treesitter/_meta/misc.lua
@@ -71,8 +71,6 @@ function TSQueryCursor:next_match() end
 
 --- @param node TSNode
 --- @param query TSQuery
---- @param start integer?
---- @param stop integer?
---- @param opts? { max_start_depth?: integer, match_limit?: integer}
+--- @param opts? { max_start_depth?: integer, match_limit?: integer, row_begin?: integer, col_begin?: integer, row_end?: integer, col_end?: integer, byte_begin?: integer, byte_end?: integer }
 --- @return TSQueryCursor
-function vim._create_ts_querycursor(node, query, start, stop, opts) end
+function vim._create_ts_querycursor(node, query, opts) end

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -4,7 +4,7 @@ local Range = require('vim.treesitter._range')
 
 local ns = api.nvim_create_namespace('treesitter/highlighter')
 
----@alias vim.treesitter.highlighter.Iter fun(end_line: integer|nil): integer, TSNode, vim.treesitter.query.TSMetadata, TSQueryMatch
+---@alias vim.treesitter.highlighter.Iter fun(end_line: integer|nil): integer, TSNode, vim.treesitter.query.TSMetadata, TSQueryMatch, TSTree
 
 ---@class (private) vim.treesitter.highlighter.Query
 ---@field private _query vim.treesitter.Query?

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -923,10 +923,15 @@ function Query:iter_captures(node, source, start, stop)
   end
 
   start, stop = value_or_node_range(start, stop, node)
+  local opts = {
+    match_limit = 256,
+    row_begin = start,
+    row_end = stop,
+  }
 
   -- Copy the tree to ensure it is valid during the entire lifetime of the iterator
   local tree = node:tree():copy()
-  local cursor = vim._create_ts_querycursor(node, self.query, start, stop, { match_limit = 256 })
+  local cursor = vim._create_ts_querycursor(node, self.query, opts)
 
   -- For faster checks that a match is not in the cache.
   local highest_cached_match_id = -1
@@ -1012,21 +1017,31 @@ end
 --- - all (boolean) When `false` (default `true`), the returned table maps capture IDs to a single
 ---   (last) node instead of the full list of matching nodes. This option is only for backward
 ---   compatibility and will be removed in a future release.
+---   - byte_begin
+---   - byte_end
 ---
 ---@return (fun(): integer, table<integer, TSNode[]>, vim.treesitter.query.TSMetadata, TSTree): pattern id, match, metadata, tree
 function Query:iter_matches(node, source, start, stop, opts)
-  opts = opts or {}
-  opts.match_limit = opts.match_limit or 256
-
   if type(source) == 'number' and source == 0 then
     source = api.nvim_get_current_buf()
   end
 
-  start, stop = value_or_node_range(start, stop, node)
+  if type(start) == 'table' then
+    opts = start
+    opts.match_limit = opts.match_limit or 256
+  else
+    opts = opts or {}
+    opts.match_limit = opts.match_limit or 256
 
-  -- Copy the tree to ensure it is valid during the entire lifetime of the iterator
+    start, stop = value_or_node_range(start, stop, node)
+    opts.row_begin = start
+    opts.col_begin = 0
+    opts.row_end = stop
+    opts.col_end = 0
+  end
+
   local tree = node:tree():copy()
-  local cursor = vim._create_ts_querycursor(node, self.query, start, stop, opts)
+  local cursor = vim._create_ts_querycursor(node, self.query, opts)
 
   local function iter()
     local match = cursor:next_match()

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1293,39 +1293,59 @@ static struct luaL_Reg querycursor_meta[] = {
   { NULL, NULL }
 };
 
+static inline bool set_uint32(lua_State *L, int idx, char const *name, uint32_t *res)
+  FUNC_ATTR_ALWAYS_INLINE FUNC_ATTR_NONNULL_ALL
+{
+  lua_getfield(L, idx, name);
+  if (lua_isnil(L, -1)) {
+    lua_pop(L, 1);
+    return false;
+  }
+  *res = (uint32_t)MIN(MAX(0U, lua_tointeger(L, -1)), UINT32_MAX);
+  lua_pop(L, 1);
+  return true;
+}
+
 int tslua_push_querycursor(lua_State *L)
 {
   TSNode node = node_check(L, 1);
 
   TSQuery *query = query_check(L, 2);
   TSQueryCursor *cursor = ts_query_cursor_new();
-  ts_query_cursor_exec(cursor, query, node);
 
-  if (lua_gettop(L) >= 3) {
-    uint32_t start = (uint32_t)luaL_checkinteger(L, 3);
-    uint32_t end = lua_gettop(L) >= 4 ? (uint32_t)luaL_checkinteger(L, 4) : MAXLNUM;
-    ts_query_cursor_set_point_range(cursor, (TSPoint){ start, 0 }, (TSPoint){ end, 0 });
-  }
+  luaL_argcheck(L, lua_istable(L, 3), 3, "table expected");
 
-  if (lua_gettop(L) >= 5 && !lua_isnil(L, 5)) {
-    luaL_argcheck(L, lua_istable(L, 5), 5, "table expected");
-    lua_pushnil(L);  // [dict, ..., nil]
-    while (lua_next(L, 5)) {
-      // [dict, ..., key, value]
-      if (lua_type(L, -2) == LUA_TSTRING) {
-        char *k = (char *)lua_tostring(L, -2);
-        if (strequal("max_start_depth", k)) {
-          uint32_t max_start_depth = (uint32_t)lua_tointeger(L, -1);
-          ts_query_cursor_set_max_start_depth(cursor, max_start_depth);
-        } else if (strequal("match_limit", k)) {
-          uint32_t match_limit = (uint32_t)lua_tointeger(L, -1);
-          ts_query_cursor_set_match_limit(cursor, match_limit);
-        }
-      }
-      // pop the value; lua_next will pop the key.
-      lua_pop(L, 1);  // [dict, ..., key]
+  TSPoint begin_pos = (TSPoint){ 0, 0 };
+  TSPoint end_pos = (TSPoint){ UINT32_MAX, UINT32_MAX };
+  if (set_uint32(L, 3, "row_begin", &begin_pos.row)) {
+    if (!set_uint32(L, 3, "col_begin", &begin_pos.column)) {
+      begin_pos.column = 0;
     }
   }
+  if (set_uint32(L, 3, "row_end", &end_pos.row)) {
+    if (!set_uint32(L, 3, "col_end", &end_pos.column)) {
+      end_pos.column = 0;
+    }
+  }
+  ts_query_cursor_set_point_range(cursor, begin_pos, end_pos);
+
+  uint32_t begin_byte = 0;
+  uint32_t end_byte = UINT32_MAX;
+  set_uint32(L, 3, "byte_begin", &begin_byte);
+  set_uint32(L, 3, "byte_end", &end_byte);
+  ts_query_cursor_set_byte_range(cursor, begin_byte, end_byte);
+
+  uint32_t max_start_depth;
+  if (set_uint32(L, 3, "max_start_depth", &max_start_depth)) {
+    ts_query_cursor_set_max_start_depth(cursor, max_start_depth);
+  }
+
+  uint32_t match_limit;
+  if (set_uint32(L, 3, "match_limit", &match_limit)) {
+    ts_query_cursor_set_match_limit(cursor, match_limit);
+  }
+
+  ts_query_cursor_exec(cursor, query, node);
 
   TSQueryCursor **ud = lua_newuserdata(L, sizeof(*ud));  // [node, query, ..., udata]
   *ud = cursor;

--- a/test/benchmark/treesitter_spec.lua
+++ b/test/benchmark/treesitter_spec.lua
@@ -47,4 +47,137 @@ describe('treesitter perf', function()
       return vim.uv.hrtime() - start
     ]]
   end)
+
+  it('editing a large file with injection query', function()
+    local total_ns = exec_lua(function()
+      vim.cmd('enew')
+
+      local src_lines = {
+        'int main() {',
+        'int a = func(12, 32, 43);',
+        'int b = 7;',
+        'if (a > b) {',
+        'printf("local a = 5");',
+        '}',
+        'else if (a == b) {',
+        'rintf("local a = 6");',
+        '}',
+        '}',
+      }
+      local lines = {}
+      for _ = 1, 500 do
+        for _, line in ipairs(src_lines) do
+          table.insert(lines, line)
+        end
+      end
+      vim.api.nvim_buf_set_lines(0, 0, -1, true, lines)
+
+      local parser = vim.treesitter.get_parser(0, 'c', {
+        injections = {
+          c = [=[
+            ((call_expression
+              function: (identifier) @_function
+              arguments: (argument_list
+                .
+                (string_literal
+                  (string_content) @injection.content)
+                )) @_root
+              (#eq? @_function "printf")
+              (#set! nvim.injection-root @_root)
+              (#set! injection.language "lua"))
+
+            ((call_expression
+              function: (identifier) @_function
+              arguments: (argument_list
+                (_)
+                .
+                  (string_literal
+                    (string_content) @injection.content)
+                )) @_root
+              (#eq? @_function "fprintf")
+              (#set! nvim.injection-root @_root)
+              (#set! injection.language "printf"))
+
+            ((preproc_arg) @injection.content
+              (#set! nvim.injection-root @injection.content)
+              (#set! injection.language "c"))
+
+            ((comment) @injection.content
+              (#set! nvim.injection-root @injection.content)
+              (#set! injection.language "comment"))
+
+            ((comment) @injection.content
+              (#set! nvim.injection-root @injection.content)
+              (#match? @injection.content "/\\*!([a-zA-Z]+:)?re2c")
+              (#set! injection.language "re2c"))
+
+            ((comment) @injection.content
+              (#set! nvim.injection-root @injection.content)
+              (#lua-match? @injection.content "/[*\/][!*\/]<?[^a-zA-Z]")
+              (#set! injection.language "doxygen"))
+          ]=],
+          lua = [=[
+            ((function_call
+              name: [
+                (identifier) @_cdef_identifier
+                (_ _ (identifier) @_cdef_identifier)
+              ]
+              arguments: (arguments (string content: _ @injection.content))) @_root
+              (#set! nvim.injection-root @_root)
+              (#set! injection.language "c")
+              (#eq? @_cdef_identifier "cdef"))
+
+            ((function_call
+              name: (_) @_vimcmd_identifier
+              arguments: (arguments
+                (string content: _ @injection.content))) @_root
+              (#set! nvim.injection-root @_root)
+              (#set! injection.language "vim")
+              (#eq? @_vimcmd_identifier "vim.cmd" "vim.api.nvim_command"))
+
+            ((function_call
+              name: (_) @_vimcmd_identifier
+              arguments: (arguments (string content: _ @injection.content) .)) @_root
+              (#set! nvim.injection-root @_root)
+              (#set! injection.language "query")
+              (#eq? @_vimcmd_identifier "vim.treesitter.query.set"))
+
+            ((function_call
+              name: (_) @_vimcmd_identifier
+              arguments: (arguments
+                . (_) . (string content: _ @_method) .
+                (string content: _ @injection.content))) @_root
+              (#any-of? @_vimcmd_identifier "vim.rpcrequest" "vim.rpcnotify")
+              (#eq? @_method "nvim_exec_lua")
+              (#set! nvim.injection-root @_root)
+              (#set! injection.language "lua"))
+
+            ; exec_lua [[ ... ]] in functionaltests
+            ((function_call
+              name: (identifier) @_function
+              arguments: (arguments
+                (string content: (string_content) @injection.content))) @_root
+              (#eq? @_function "exec_lua")
+              (#set! nvim.injection-root @_root)
+              (#set! injection.language "lua"))
+          ]=],
+        },
+      })
+      parser:parse(true)
+
+      local btime = vim.uv.hrtime()
+      for i = 0, 99 do
+        local off = i * 10
+        vim.api.nvim_buf_set_text(0, off + 2, 8, off + 2, 8, { '12' })
+        parser:parse(true)
+        vim.api.nvim_buf_set_text(0, off + 7, 0, off + 7, 5, { 'test' })
+        parser:parse(true)
+      end
+      local etime = vim.uv.hrtime()
+
+      return etime - btime
+    end)
+
+    print('total (ms): ' .. string.format('%.2f', total_ns * 0.001 * 0.001))
+  end)
 end)

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -461,12 +461,12 @@ describe('treesitter highlighting (C)', function()
       local parser = vim.treesitter.get_parser(0, 'c')
       local query = vim.treesitter.query.parse('c', '(declaration) @decl')
 
-      local nodes = {}
+      local region = {}
       for _, node in query:iter_captures(parser:parse()[1]:root(), 0, 0, 19) do
-        table.insert(nodes, node)
+        table.insert(region, { node:range(true) })
       end
 
-      parser:set_included_regions({ nodes })
+      parser:set_included_regions({ region })
 
       vim.treesitter.highlighter.new(parser, { queries = { c = '(identifier) @type' } })
     end)

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -503,7 +503,17 @@ describe('treesitter highlighting (C)', function()
     exec_lua(function()
       local parser = vim.treesitter.get_parser(0, 'c', {
         injections = {
-          c = '(preproc_def (preproc_arg) @injection.content (#set! injection.language "c")) (preproc_function_def value: (preproc_arg) @injection.content (#set! injection.language "c"))',
+          c = [[
+            (preproc_def
+              (preproc_arg) @injection.content
+              (#set! nvim.injection-root @injection.content)
+              (#set! injection.language "c"))
+
+            (preproc_function_def
+              value: (preproc_arg) @injection.content
+              (#set! nvim.injection-root @injection.content)
+              (#set! injection.language "c"))
+          ]],
         },
       })
       local highlighter = vim.treesitter.highlighter
@@ -522,7 +532,17 @@ describe('treesitter highlighting (C)', function()
       vim.treesitter.language.register('c', 'foo')
       local parser = vim.treesitter.get_parser(0, 'c', {
         injections = {
-          c = '(preproc_def (preproc_arg) @injection.content (#set! injection.language "foo")) (preproc_function_def value: (preproc_arg) @injection.content (#set! injection.language "foo"))',
+          c = [[
+          (preproc_def
+            (preproc_arg) @injection.content
+            (#set! nvim.injection-root @injection.content)
+            (#set! injection.language "foo"))
+
+            (preproc_function_def
+              value: (preproc_arg) @injection.content
+              (#set! nvim.injection-root @injection.content)
+              (#set! injection.language "foo"))
+          ]],
         },
       })
       local highlighter = vim.treesitter.highlighter
@@ -542,8 +562,17 @@ describe('treesitter highlighting (C)', function()
     ]])
 
     exec_lua(function()
-      local injection_query =
-        '(preproc_def (preproc_arg) @injection.content (#set! injection.language "c")) (preproc_function_def value: (preproc_arg) @injection.content (#set! injection.language "c"))'
+      local injection_query = [[
+        (preproc_def
+          (preproc_arg) @injection.content
+          (#set! nvim.injection-root @injection.content)
+          (#set! injection.language "c"))
+
+        (preproc_function_def
+          value: (preproc_arg) @injection.content
+          (#set! nvim.injection-root @injection.content)
+          (#set! injection.language "c"))
+        ]]
       vim.treesitter.query.set('c', 'highlights', hl_query_c)
       vim.treesitter.query.set('c', 'injections', injection_query)
 
@@ -1005,7 +1034,12 @@ describe('treesitter highlighting (help)', function()
     exec_lua(function()
       local parser = vim.treesitter.get_parser(0, 'lua', {
         injections = {
-          lua = '(string content: (_) @injection.content (#set! injection.language lua))',
+          lua = [[
+           (string
+            content: (_) @injection.content
+            (#set! nvim.injection-root @injection.content)
+            (#set! injection.language lua))
+          ]],
         },
       })
 


### PR DESCRIPTION
Implemented incremental injection parsing as described in https://github.com/neovim/neovim/issues/31809.

Adding `#set! injection.root @some_capture` to all patterns in `injections.scm` enables the optimization.

This improves performance when viewing/editing large files, as injections only within the visible range are parsed, and only the changed ranges are reparsed when editing the buffer.

Closes https://github.com/neovim/neovim/issues/31809