### PR TITLE
feat(runtime): news plugin for development builds

### DIFF
--- a/runtime/lua/news.lua
+++ b/runtime/lua/news.lua
@@ -1,0 +1,91 @@
+local M = {}
+
+local news_path = vim.fs.normalize('$VIMRUNTIME/doc/news.txt')
+local cache_path = vim.fs.normalize(vim.fn.stdpath('state') .. '/news.txt')
+
+-- create empty cache file or attempts to write/diff with it will fail later
+if not vim.uv.fs_stat(cache_path) then
+  local fh = assert(io.open(cache_path, 'w+'),
+    string.format('Could not create file at %s: ', cache_path))
+  fh:write('')
+  fh:flush()
+  fh:close()
+end
+
+--- @private
+--- Schedule the caching of news.txt file contents using an autocommand.
+--- We don't want to cache immediately when this is called, because then
+--- there would be no more diff to view if user calls `:News` manually.
+local function _schedule_caching_of_news()
+  local augroup = vim.api.nvim_create_augroup('news_cache', {})
+
+  vim.api.nvim_create_autocmd('VimLeave', {
+    desc = 'Cache contents of runtime news.txt file.',
+    group = augroup,
+    nested = true,
+    callback = function()
+      local cache_file = assert(io.open(cache_path, 'w+'))
+      local news_file = assert(io.open(news_path, 'r'))
+
+      local news = news_file:read('*a')
+      news_file:close()
+
+      cache_file:write(news)
+      cache_file:flush()
+      cache_file:close()
+    end
+  })
+end
+
+--- @private
+--- @return boolean
+local function _hashes_match()
+  local cache_file = assert(io.open(cache_path, 'r'))
+  local news_file = assert(io.open(news_path, 'r'))
+
+  local news = news_file:read('*a')
+  local news_hash = vim.fn.sha256(news)
+  news_file:close()
+
+  local cache = cache_file:read('*a')
+  local cache_hash = vim.fn.sha256(cache)
+  cache_file:close()
+
+  return news_hash == cache_hash
+end
+
+---@private
+---Return true if the contents of news.txt should be cached.
+---@return boolean
+local function _should_cache_news()
+  local current_version = vim.version()
+
+  if vim.version.lt(vim.g.NVIM_VERSION, current_version) then
+    vim.g.NVIM_VERSION = current_version
+    return true
+  elseif vim.version.eq(vim.g.NVIM_VERSION, current_version) then
+    -- news file contents may have, and does, change even when versions match
+    if _hashes_match() then
+      return false
+    else
+      return true
+    end
+  end
+
+  -- odd situations like cache vim.version() > current vim.version()
+  return false
+end
+
+function M.check_for_news_changes()
+  if not vim.g.NVIM_VERSION then
+    vim.g.NVIM_VERSION = vim.version()
+    _schedule_caching_of_news()
+  else
+    if _should_cache_news() then
+      vim.notify_once('News.txt updated - run `:News` to view diff', vim.log.levels.INFO, {})
+      _schedule_caching_of_news()
+    end
+  end
+end
+
+return M

--- a/runtime/plugin/news.lua
+++ b/runtime/plugin/news.lua
@@ -1,10 +1,10 @@
--- skip when nvim is a release build
-if vim.version().prerelease ~= "dev" then
+-- skip if user code explicitly disables
+if vim.g.news_check == false then
   return
 end
 
--- skip if user code explicitly disables
-if vim.g.news_check == false then
+-- skip when nvim is a release build
+if vim.version().prerelease ~= "dev" then
   return
 end
 

--- a/runtime/plugin/news.lua
+++ b/runtime/plugin/news.lua
@@ -3,13 +3,18 @@ if vim.g.news_check == false then
   return
 end
 
--- skip when nvim is a release build
+-- skip when nvim is not a prerelease build
 if vim.version().prerelease ~= "dev" then
   return
 end
 
 -- skip in embedded situations
 if vim.g.vscode or vim.g.started_by_firenvim then
+  return
+end
+
+-- skip if nvim was started clean, which by default loads builtin plugins
+if vim.list_contains(vim.v.argv, '--clean') then
   return
 end
 

--- a/runtime/plugin/news.lua
+++ b/runtime/plugin/news.lua
@@ -1,0 +1,53 @@
+-- skip when nvim is a release build
+if vim.version().prerelease ~= "dev" then
+  return
+end
+
+-- skip if user code explicitly disables
+if vim.g.news_check == false then
+  return
+end
+
+-- skip in embedded situations
+if vim.g.vscode or vim.g.started_by_firenvim then
+  return
+end
+
+-- skip if nvim was started as a Lua interpreter
+if vim.list_contains(vim.v.argv, '-l') then
+  return
+end
+
+-- skip if we can't read/write the shada file, for example it is
+-- set to 'NONE' by `--clean` or `-i NONE` command line flags
+if vim.o.shadafile == 'NONE' then
+  return
+end
+
+-- skip if missing ability to store/read global vars in shada file
+if not vim.o.shada:match('!') then
+  return
+end
+
+vim.g.news_check = {}
+
+vim.api.nvim_create_user_command('News', function()
+  local news_path = vim.fs.normalize('$VIMRUNTIME/doc/news.txt')
+  local cache_path = vim.fs.normalize(vim.fn.stdpath('state') .. '/news.txt')
+  vim.cmd.tabedit(news_path)
+  vim.cmd.diffsplit(cache_path)
+end, {
+  desc = 'Show a diff of changes to the runtime news.txt file.'
+})
+
+local augroup = vim.api.nvim_create_augroup("news", {})
+
+-- Q: maybe vim.defer_fn(cb, 4000) instead, so we aren't tied to CursorHold?
+vim.api.nvim_create_autocmd('CursorHold', {
+  group = augroup,
+  desc = 'Notifies user of changes to the news.txt file.',
+  once = true,
+  callback = function()
+    require('news').check_for_news_changes()
+  end
+})

--- a/test/functional/fixtures/startup-plugin-news.lua
+++ b/test/functional/fixtures/startup-plugin-news.lua
@@ -1,0 +1,6 @@
+-- Test 'nvim -l foo.lua ..' does not load runtime plugin
+local function main()
+  print(vim.g.news_check)
+end
+
+main()

--- a/test/functional/plugin/news_spec.lua
+++ b/test/functional/plugin/news_spec.lua
@@ -1,0 +1,73 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local api = n.api
+local clear = n.clear
+local eq = t.eq
+local fn = n.fn
+local matches = t.matches
+
+describe('news_plugin:', function()
+  it('loads', function()
+    -- `-u` would stop the news plugin from loading at all
+    -- `-i NONE` turns off shada, which this plugin requires to load
+    clear({ args_rm = { '-u', '-i' } })
+    eq(1, fn.exists('news_check'))
+  end)
+
+  describe('is skipped when', function()
+    it('user disables via global variable', function()
+      clear({ args_rm = { '-u', '-i' } })
+      api.nvim_set_var('news_check', false)
+      eq(false, api.nvim_get_var('news_check'))
+    end)
+
+    it('nvim was started by firenvim', function()
+      clear({
+        args = { '--cmd', 'let g:started_by_firenvim = v:true' },
+        args_rm = { '-u', '-i' }
+      })
+      eq(0, fn.exists('news_check'))
+    end)
+
+    it('nvim was started by vscode-neovim', function()
+      clear({
+        args = { '--cmd', 'let g:vscode = v:true' },
+        args_rm = { '-u', '-i' }
+      })
+      eq(0, fn.exists('news_check'))
+    end)
+
+    -- Q: Does this need to be tested? hacky workaround to get it to work
+    -- running in the test instance because --embed conflicts with -l
+    it('nvim was started as Lua interpreter with -l', function()
+      local p = n.spawn_wait({
+        args_rm = {
+          '--embed',
+          '-u',
+        },
+        args = {
+          '-l',
+          'test/functional/fixtures/startup-plugin-news.lua',
+        }
+      })
+      matches('nil', p:output())
+    end)
+
+    it('shada is turned off', function()
+      clear({
+        args = { '-i', 'NONE' },
+        args_rm = { '-u' }
+      })
+      eq(0, fn.exists('news_check'))
+    end)
+
+    it('shada is missing ability to store/read global vars', function()
+      clear({
+        args = { '--cmd', "set shada='100" },
+        args_rm = { '-u', '-i' },
+      })
+      eq(0, fn.exists('news_check'))
+    end)
+  end)
+end)

--- a/test/functional/plugin/news_spec.lua
+++ b/test/functional/plugin/news_spec.lua
@@ -22,6 +22,14 @@ describe('news_plugin:', function()
       eq(false, api.nvim_get_var('news_check'))
     end)
 
+    it('nvim was started clean (--clean)', function()
+      clear({
+        args = { '--clean' },
+        args_rm = { '-u', '-i' }
+      })
+      eq(0, fn.exists('news_check'))
+    end)
+
     it('nvim was started by firenvim', function()
       clear({
         args = { '--cmd', 'let g:started_by_firenvim = v:true' },


### PR DESCRIPTION
Would (partially?) close #21431
previous: https://github.com/neovim/neovim/pull/23350

I tried to balance being too annoying about asking the user everytime nvim is started by instead notifying the user of changes to news.txt and hinting at the ex command to run to see the diff. I'm open to any changes. Initially I had asked the user on startup a y/n question to show the diff, but that quickly got annoying.

@gpanders I studied your runtime plugin while doing this, so it would be great if you could help review it

@justinmk any thoughts would be appreciated!

Edit to clarify: opt out completely with `vim.g.news_check = false` (or equivalent vim script `let g:news_check = v:false`) - it's the first check we make