### PR TITLE
fix(lsp): ensure minimum height for floating popup

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1432,7 +1432,7 @@ function M._make_floating_popup_size(contents, opts)
       if vim.tbl_isempty(line_widths) then
         for _, line in ipairs(contents) do
           local line_width = vim.fn.strdisplaywidth(line:gsub('%z', '\n'))
-          height = height + math.ceil(line_width / wrap_at)
+          height = height + math.max(1, math.ceil(line_width / wrap_at))
         end
       else
         for i = 1, #contents do

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3501,6 +3501,19 @@ describe('LSP', function()
         end)
       )
     end)
+    it('handles empty line', function()
+      exec_lua(function()
+        _G.contents = {
+          '',
+        }
+      end)
+      eq(
+        { 20, 1 },
+        exec_lua(function()
+          return { vim.lsp.util._make_floating_popup_size(_G.contents, { width = 20 }) }
+        end)
+      )
+    end)
   end)
 
   describe('lsp.util.trim.trim_empty_lines', function()


### PR DESCRIPTION
For a long time, I’ve been quite annoyed because the floating window for hover and signature help always cuts off a few lines, forcing me to jump into the floating window to see the full documentation. Recently, I finally had the time to investigate the issue and found out that the `_make_floating_popup_size` function counts empty lines as having zero height.

before:
![image](https://github.com/user-attachments/assets/c417ae4d-a2d4-4b2c-99f4-8b3cf5691f5b)
after:
![image](https://github.com/user-attachments/assets/00ced71c-c8bd-4816-99f4-4281ca44e46c)

Related: #25612 