### PR TITLE
fix(float): nvim_win_set_config cannot set title/footer independently

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -895,7 +895,7 @@ static void parse_bordertext(Object bordertext, BorderTextType bordertext_type, 
   *is_present = true;
 }
 
-static bool parse_bordertext_pos(String bordertext_pos, BorderTextType bordertext_type,
+static bool parse_bordertext_pos(win_T *wp, String bordertext_pos, BorderTextType bordertext_type,
                                  WinConfig *fconfig, Error *err)
 {
   AlignTextPos *align;
@@ -909,7 +909,9 @@ static bool parse_bordertext_pos(String bordertext_pos, BorderTextType bordertex
   }
 
   if (bordertext_pos.size == 0) {
-    *align = kAlignLeft;
+    if (!wp) {
+      *align = kAlignLeft;
+    }
     return true;
   }
 
@@ -1250,7 +1252,7 @@ static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fco
     }
 
     // handles unset 'title_pos' same as empty string
-    if (!parse_bordertext_pos(config->title_pos, kBorderTextTitle, fconfig, err)) {
+    if (!parse_bordertext_pos(wp, config->title_pos, kBorderTextTitle, fconfig, err)) {
       goto fail;
     }
   } else {
@@ -1277,7 +1279,7 @@ static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fco
     }
 
     // handles unset 'footer_pos' same as empty string
-    if (!parse_bordertext_pos(config->footer_pos, kBorderTextFooter, fconfig, err)) {
+    if (!parse_bordertext_pos(wp, config->footer_pos, kBorderTextFooter, fconfig, err)) {
       goto fail;
     }
   } else {

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -2333,6 +2333,61 @@ describe('float window', function()
                                                   |
         ]]}
       end
+
+      -- reuse before title pos
+      api.nvim_win_set_config(win, {title= 'new'})
+      if multigrid then
+        screen:expect({
+          grid = [[
+          ## grid 1
+            [2:----------------------------------------]|*6
+            [3:----------------------------------------]|
+          ## grid 2
+            ^                                        |
+            {0:~                                       }|*5
+          ## grid 3
+                                                    |
+          ## grid 4
+            {5:╔══════}{11:new}{5:╗}|
+            {5:║}{1: halloj! }{5:║}|
+            {5:║}{1: BORDAA  }{5:║}|
+            {5:╚═════════╝}|
+          ]],
+          float_pos = {
+          [4] = {1001, "NW", 1, 2, 5, true, 50};
+        },
+          win_viewport = {
+          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
+        },
+          win_viewport_margins = {
+          [2] = {
+            bottom = 0,
+            left = 0,
+            right = 0,
+            top = 0,
+            win = 1000
+          },
+          [4] = {
+            bottom = 1,
+            left = 1,
+            right = 1,
+            top = 1,
+            win = 1001
+          }
+        },
+        })
+      else
+        screen:expect([[
+          ^                                        |
+          {0:~                                       }|
+          {0:~    }{5:╔══════}{11:new}{5:╗}{0:                        }|
+          {0:~    }{5:║}{1: halloj! }{5:║}{0:                        }|
+          {0:~    }{5:║}{1: BORDAA  }{5:║}{0:                        }|
+          {0:~    }{5:╚═════════╝}{0:                        }|
+                                                  |
+        ]])
+      end
     end)
 
     it('border with footer', function()
@@ -2477,6 +2532,61 @@ describe('float window', function()
           {0:~    }{5:╚═════}{11:🦄BB}{5:╝}{0:                        }|
                                                   |
         ]]}
+      end
+
+      -- reuse before footer pos
+      api.nvim_win_set_config(win, { footer = 'new' })
+      if multigrid then
+        screen:expect({
+          grid = [[
+          ## grid 1
+            [2:----------------------------------------]|*6
+            [3:----------------------------------------]|
+          ## grid 2
+            ^                                        |
+            {0:~                                       }|*5
+          ## grid 3
+                                                    |
+          ## grid 4
+            {5:╔═════════╗}|
+            {5:║}{1: halloj! }{5:║}|
+            {5:║}{1: BORDAA  }{5:║}|
+            {5:╚══════}{11:new}{5:╝}|
+          ]],
+          float_pos = {
+          [4] = {1001, "NW", 1, 2, 5, true, 50};
+        },
+          win_viewport = {
+          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
+        },
+          win_viewport_margins = {
+          [2] = {
+            bottom = 0,
+            left = 0,
+            right = 0,
+            top = 0,
+            win = 1000
+          },
+          [4] = {
+            bottom = 1,
+            left = 1,
+            right = 1,
+            top = 1,
+            win = 1001
+          }
+        },
+        })
+      else
+        screen:expect([[
+          ^                                        |
+          {0:~                                       }|
+          {0:~    }{5:╔═════════╗}{0:                        }|
+          {0:~    }{5:║}{1: halloj! }{5:║}{0:                        }|
+          {0:~    }{5:║}{1: BORDAA  }{5:║}{0:                        }|
+          {0:~    }{5:╚══════}{11:new}{5:╝}{0:                        }|
+                                                  |
+        ]])
       end
     end)
 
@@ -8710,38 +8820,58 @@ describe('float window', function()
           ## grid 3
                                                     |
           ## grid 4
-            {5:╔}{11:win_100}{5:═════════════╗}|
+            {5:╔══════}{11:win_100}{5:═══════╗}|
             {5:║}{7:                    }{5:║}|
             {5:║}{7:~                   }{5:║}|*2
             {5:╚════════════════════╝}|
           ## grid 6
-            {5:┌}{11:win_150}{5:─────────────┐}|
+            {5:┌──────}{11:win_150}{5:───────┐}|
             {5:│}{8:                    }{5:│}|
             {5:│}{8:~                   }{5:│}|*2
             {5:└────────────────────┘}|
-          ]], float_pos={
+          ]],
+          float_pos = {
           [4] = {1001, "NW", 1, 1, 5, true, 100};
           [6] = {1003, "NW", 1, 3, 7, true, 150};
-        }, win_viewport={
+        },
+          win_viewport = {
           [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
           [6] = {win = 1003, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }, win_viewport_margins={
-          [2] = { bottom = 0, left = 0, right = 0, top = 0, win = 1000 },
-          [4] = { bottom = 1, left = 1, right = 1, top = 1, win = 1001 },
-          [6] = { bottom = 1, left = 1, right = 1, top = 1, win = 1003 }
-        }})
-      else
-        screen:expect({
-          grid = [[
-            ^                                        |
-            {0:~    }{5:╔}{11:w}{5:┌}{11:win_150}{5:─────────────┐}{0:           }|
-            {0:~    }{5:║}{7: }{5:│}{8:                    }{5:│}{0:           }|
-            {0:~    }{5:║}{7:~}{5:│}{8:~                   }{5:│}{0:           }|*2
-            {0:~    }{5:╚═└────────────────────┘}{0:           }|
-                                                    |
-          ]]
+        },
+          win_viewport_margins = {
+          [2] = {
+            bottom = 0,
+            left = 0,
+            right = 0,
+            top = 0,
+            win = 1000
+          },
+          [4] = {
+            bottom = 1,
+            left = 1,
+            right = 1,
+            top = 1,
+            win = 1001
+          },
+          [6] = {
+            bottom = 1,
+            left = 1,
+            right = 1,
+            top = 1,
+            win = 1003
+          }
+        },
         })
+      else
+        screen:expect([[
+          ^                                        |
+          {0:~    }{5:╔═┌──────}{11:win_150}{5:───────┐}{0:           }|
+          {0:~    }{5:║}{7: }{5:│}{8:                    }{5:│}{0:           }|
+          {0:~    }{5:║}{7:~}{5:│}{8:~                   }{5:│}{0:           }|*2
+          {0:~    }{5:╚═└────────────────────┘}{0:           }|
+                                                  |
+        ]])
       end
     end)
 
@@ -9724,4 +9854,3 @@ describe('float window', function()
     with_ext_multigrid(false)
   end)
 end)
-


### PR DESCRIPTION
Problem: reset win config doesn't take before title footer pos value

Solution: reuse before titile footer pos value

Fix #31992