### PR TITLE
fix(docs): set local foldexpr with lsp

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -882,8 +882,9 @@ foldexpr({lnum})                                          *vim.lsp.foldexpr()*
           callback = function(args)
             local client = vim.lsp.get_client_by_id(args.data.client_id)
             if client:supports_method('textDocument/foldingRange') then
-              vim.wo.foldmethod = 'expr'
-              vim.wo.foldexpr = 'v:lua.vim.lsp.foldexpr()'
+              local win = vim.api.nvim_get_current_win()
+              vim.wo[win][0].foldmethod = 'expr'
+              vim.wo[win][0].foldexpr = 'v:lua.vim.lsp.foldexpr()'
             end
           end,
         })

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1393,8 +1393,9 @@ end
 ---   callback = function(args)
 ---     local client = vim.lsp.get_client_by_id(args.data.client_id)
 ---     if client:supports_method('textDocument/foldingRange') then
----       vim.wo.foldmethod = 'expr'
----       vim.wo.foldexpr = 'v:lua.vim.lsp.foldexpr()'
+---       local win = vim.api.nvim_get_current_win()
+---       vim.wo[win][0].foldmethod = 'expr'
+---       vim.wo[win][0].foldexpr = 'v:lua.vim.lsp.foldexpr()'
 ---     end
 ---   end,
 --- })


### PR DESCRIPTION
Problem: `:setlocal fde<` on LspDetach does not work with this example.

Solution: Set 'fde' local by specifying win and buf.

From :h vim.wo:

> Like `:setlocal` if setting a |global-local| option or if {bufnr} is
> provided, like `:set` otherwise.

This allows me to switch back to using TS folds whenever I want.