### PR TITLE
fix(treesitter): uv_dlclose after uv_dlerror

### DIFF
--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -128,9 +128,9 @@ static const TSLanguage *load_language_from_object(lua_State *L, const char *pat
 {
   uv_lib_t lib;
   if (uv_dlopen(path, &lib)) {
+    xstrlcpy(IObuff, uv_dlerror(&lib), sizeof(IObuff));
     uv_dlclose(&lib);
-    luaL_error(L, "Failed to load parser for language '%s': uv_dlopen: %s",
-               lang_name, uv_dlerror(&lib));
+    luaL_error(L, "Failed to load parser for language '%s': uv_dlopen: %s", lang_name, IObuff);
   }
 
   char symbol_buf[128];
@@ -138,8 +138,9 @@ static const TSLanguage *load_language_from_object(lua_State *L, const char *pat
 
   TSLanguage *(*lang_parser)(void);
   if (uv_dlsym(&lib, symbol_buf, (void **)&lang_parser)) {
+    xstrlcpy(IObuff, uv_dlerror(&lib), sizeof(IObuff));
     uv_dlclose(&lib);
-    luaL_error(L, "Failed to load parser: uv_dlsym: %s", uv_dlerror(&lib));
+    luaL_error(L, "Failed to load parser: uv_dlsym: %s", IObuff);
   }
 
   TSLanguage *lang = lang_parser();


### PR DESCRIPTION
**Problem**: `uv_dlclose` clears `lib->errmsg`, so `uv_dlerror` always returns `no error`
https://github.com/libuv/libuv/blob/e59e2a9e49c96feffebdfd44915320e32a91a957/src/unix/dl.c#L41

**Solution**: get error message before closing