### PR TITLE
fix(lsp): schedule call to vim.lsp.start for async root_dir

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -513,7 +513,9 @@ local function lsp_enable_callback(bufnr)
         ---@param root_dir string
         config.root_dir(function(root_dir)
           config.root_dir = root_dir
-          start(config)
+          vim.schedule(function()
+            start(config)
+          end)
         end)
       else
         start(config)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -6246,37 +6246,42 @@ describe('LSP', function()
       )
     end)
 
-    it('supports a function for root_dir', function()
+    it('supports async function for root_dir', function()
       exec_lua(create_server_definition)
 
       local tmp1 = t.tmpname(true)
-
-      eq(
-        'some_dir',
-        exec_lua(function()
-          local server = _G._create_server({
-            handlers = {
-              initialize = function(_, _, callback)
-                callback(nil, { capabilities = {} })
-              end,
-            },
-          })
-
-          vim.lsp.config('foo', {
-            cmd = server.cmd,
-            filetypes = { 'foo' },
-            root_dir = function(cb)
-              cb('some_dir')
+      exec_lua(function()
+        local server = _G._create_server({
+          handlers = {
+            initialize = function(_, _, callback)
+              callback(nil, { capabilities = {} })
             end,
-          })
-          vim.lsp.enable('foo')
+          },
+        })
 
-          vim.cmd.edit(assert(tmp1))
-          vim.bo.filetype = 'foo'
+        vim.lsp.config('foo', {
+          cmd = server.cmd,
+          filetypes = { 'foo' },
+          root_dir = function(cb)
+            vim.system({ 'sleep', '0' }, {}, function()
+              cb('some_dir')
+            end)
+          end,
+        })
+        vim.lsp.enable('foo')
 
-          return vim.lsp.get_clients({ bufnr = vim.api.nvim_get_current_buf() })[1].root_dir
-        end)
-      )
+        vim.cmd.edit(assert(tmp1))
+        vim.bo.filetype = 'foo'
+      end)
+
+      retry(nil, 1000, function()
+        eq(
+          'some_dir',
+          exec_lua(function()
+            return vim.lsp.get_clients({ bufnr = vim.api.nvim_get_current_buf() })[1].root_dir
+          end)
+        )
+      end)
     end)
   end)
 end)


### PR DESCRIPTION
When `root_dir` is a function it can (and often will) call the provided callback function in a fast API context (e.g. in the `on_exit` handler of `vim.system`). When the callback function is executed we should ensure that it runs vim.lsp.start on the main event loop.