### PR TITLE
perf(treesitter): don't block when finding injection ranges

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -343,6 +343,8 @@ PERFORMANCE
 • |LanguageTree:parse()| now only runs the injection query on the provided
   range (as long as the language does not have a combined injection),
   significantly improving |treesitter-highlight| performance.
+• Treesitter injection query iteration is now asynchronous, making edits in
+  large buffers with combined injections much quicker.
 
 PLUGINS
 


### PR DESCRIPTION
**Problem:** Currently, parsing is asynchronous, but it involves a (sometimes lengthy) step which finds all injection ranges for a tree by iterating over that language's injection queries. This causes edits in large files to be extremely slow, and also causes a long stutter during the initial parse of a large file.

**Solution:** Break up the injection query iteration over multiple event loop iterations.

---

Closes #20283

This PR implements the first part of [Lewis' comment here](https://github.com/neovim/neovim/pull/31631#issuecomment-2586447791).

### Before
[before.webm](https://github.com/user-attachments/assets/5ab0380d-4b26-487d-bd4d-bfb06d43f4cf)

### After
[after.webm](https://github.com/user-attachments/assets/d14bffc3-7fb9-4270-9711-671e7ff52cf9)

Note that highlight reapplication can lag behind insertions, I'm assuming this will be helped by the incremental injection parsing/validation