### PR TITLE
fix(lsp): make passing false to vim.lsp.enable() disable given LSP(s)

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -546,7 +546,7 @@ function lsp.enable(name, enable)
     if nm == '*' then
       error('Invalid name')
     end
-    lsp._enabled_configs[nm] = enable == false and nil or {}
+    lsp._enabled_configs[nm] = enable ~= false and {} or nil
   end
 
   if not next(lsp._enabled_configs) then


### PR DESCRIPTION

Problem:
Per the documentation, passing `false` as the `enable` parameter of
`vim.lsp.enable()` should disable the given LSP(s), but it does not work
due to a logic error.

Specifically, `enable == false and nil or {}` will always evaluate to
`{}` because `nil` is falsy.

Solution:
Correct the conditional statement.
