### PR TITLE
vim-patch:30377e0: runtime(lyrics): support milliseconds in syntax script

### DIFF
--- a/runtime/syntax/lyrics.vim
+++ b/runtime/syntax/lyrics.vim
@@ -2,7 +2,7 @@
 " Language:     LyRiCs
 " Maintainer:   ObserverOfTime <chronobserver@disroot.org>
 " Filenames:    *.lrc
-" Last Change:  2024 Sep 20
+" Last Change:  2025 Jan 13
 
 if exists('b:current_syntax')
     finish
@@ -23,7 +23,7 @@ syn match lrcTagName contained nextgroup=lrcTagValue
 syn match lrcTagValue /:\zs.\+\ze\]/ contained
 
 " Lyrics
-syn match lrcLyricTime /^\s*\(\[\d\d:\d\d\.\d\d\]\)\+/
+syn match lrcLyricTime /^\s*\(\[\d\d:\d\d\.\d\d\d\?\]\)\+/
             \ contains=lrcNumber nextgroup=lrcLyricLine
 syn match lrcLyricLine /.*$/ contained contains=lrcWordTime,@Spell
 syn match lrcWordTime /<\d\d:\d\d\.\d\d>/ contained contains=lrcNumber,@NoSpell


### PR DESCRIPTION
The following tool creates LRC files using three fractional digits after
the seconds (i.e. milliseconds).

References:
https://github.com/magic-akari/lrc-maker
https://lrc-maker.github.io/

closes: vim/vim#16436

https://github.com/vim/vim/commit/30377e0fe084496911e108cbb33c84cf075e6e33

Co-authored-by: Denilson Sá Maia <denilsonsa@gmail.com>
