### PR TITLE
refactor(options): generic expand and did_set callbacks

### DIFF
--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -4947,7 +4947,7 @@ vim.wo.rl = vim.wo.rightleft
 --- This is useful for languages such as Hebrew, Arabic and Farsi.
 --- The 'rightleft' option must be set for 'rightleftcmd' to take effect.
 ---
---- @type 'search'
+--- @type string
 vim.o.rightleftcmd = "search"
 vim.o.rlc = vim.o.rightleftcmd
 vim.wo.rightleftcmd = vim.o.rightleftcmd

--- a/src/nvim/generators/gen_options.lua
+++ b/src/nvim/generators/gen_options.lua
@@ -1,39 +1,6 @@
-local options_file = arg[1]
-local options_enum_file = arg[2]
-local options_map_file = arg[3]
-local option_vars_file = arg[4]
-
-local opt_fd = assert(io.open(options_file, 'w'))
-local opt_enum_fd = assert(io.open(options_enum_file, 'w'))
-local opt_map_fd = assert(io.open(options_map_file, 'w'))
-local opt_vars_fd = assert(io.open(option_vars_file, 'w'))
-
-local w = function(s)
-  if s:match('^    %.') then
-    opt_fd:write(s .. ',\n')
-  else
-    opt_fd:write(s .. '\n')
-  end
-end
-
---- @param s string
-local function enum_w(s)
-  opt_enum_fd:write(s .. '\n')
-end
-
---- @param s string
-local function map_w(s)
-  opt_map_fd:write(s .. '\n')
-end
-
-local function vars_w(s)
-  opt_vars_fd:write(s .. '\n')
-end
-
 --- @module 'nvim.options'
 local options = require('options')
 local options_meta = options.options
-
 local cstr = options.cstr
 local valid_scopes = options.valid_scopes
 
@@ -43,198 +10,20 @@ local function get_values_var(o)
   return ('opt_%s_values'):format(o.abbreviation or o.full_name)
 end
 
---- Options for each scope.
---- @type table<string, vim.option_meta[]>
-local scope_options = {}
-for _, scope in ipairs(valid_scopes) do
-  scope_options[scope] = {}
-end
-
 --- @param s string
 --- @return string
-local lowercase_to_titlecase = function(s)
+local function lowercase_to_titlecase(s)
   return table.concat(vim.tbl_map(function(word) --- @param word string
     return word:sub(1, 1):upper() .. word:sub(2)
   end, vim.split(s, '[-_]')))
 end
 
--- Generate options enum file
-enum_w('// IWYU pragma: private, include "nvim/option_defs.h"')
-enum_w('')
-
---- Map of option name to option index
---- @type table<string, string>
-local option_index = {}
-
--- Generate option index enum and populate the `option_index` and `scope_option` dicts.
-enum_w('typedef enum {')
-enum_w('  kOptInvalid = -1,')
-
-for i, o in ipairs(options_meta) do
-  local enum_val_name = 'kOpt' .. lowercase_to_titlecase(o.full_name)
-  enum_w(('  %s = %u,'):format(enum_val_name, i - 1))
-
-  option_index[o.full_name] = enum_val_name
-
-  if o.abbreviation then
-    option_index[o.abbreviation] = enum_val_name
-  end
-
-  if o.alias then
-    o.alias = type(o.alias) == 'string' and { o.alias } or o.alias
-
-    for _, v in ipairs(o.alias) do
-      option_index[v] = enum_val_name
-    end
-  end
-
-  for _, scope in ipairs(o.scope) do
-    table.insert(scope_options[scope], o)
-  end
-end
-
-enum_w('  // Option count')
-enum_w('#define kOptCount ' .. tostring(#options_meta))
-enum_w('} OptIndex;')
-
 --- @param scope string
 --- @param option_name string
 --- @return string
-local get_scope_option = function(scope, option_name)
+local function get_scope_option(scope, option_name)
   return ('k%sOpt%s'):format(lowercase_to_titlecase(scope), lowercase_to_titlecase(option_name))
 end
-
--- Generate option index enum for each scope
-for _, scope in ipairs(valid_scopes) do
-  enum_w('')
-
-  local scope_name = lowercase_to_titlecase(scope)
-  enum_w('typedef enum {')
-  enum_w(('  %s = -1,'):format(get_scope_option(scope, 'Invalid')))
-
-  for idx, option in ipairs(scope_options[scope]) do
-    enum_w(('  %s = %u,'):format(get_scope_option(scope, option.full_name), idx - 1))
-  end
-
-  enum_w(('  // %s option count'):format(scope_name))
-  enum_w(('#define %s %d'):format(get_scope_option(scope, 'Count'), #scope_options[scope]))
-  enum_w(('} %sOptIndex;'):format(scope_name))
-end
-
--- Generate reverse lookup from option scope index to option index for each scope.
-for _, scope in ipairs(valid_scopes) do
-  enum_w('')
-  enum_w(('EXTERN const OptIndex %s_opt_idx[] INIT( = {'):format(scope))
-  for _, option in ipairs(scope_options[scope]) do
-    local idx = option_index[option.full_name]
-    enum_w(('  [%s] = %s,'):format(get_scope_option(scope, option.full_name), idx))
-  end
-  enum_w('});')
-end
-
-opt_enum_fd:close()
-
--- Generate option index map.
-local hashy = require('generators.hashy')
-local neworder, hashfun = hashy.hashy_hash('find_option', vim.tbl_keys(option_index), function(idx)
-  return ('option_hash_elems[%s].name'):format(idx)
-end)
-
-map_w('static const struct { const char *name; OptIndex opt_idx; } option_hash_elems[] = {')
-
-for _, name in ipairs(neworder) do
-  assert(option_index[name] ~= nil)
-  map_w(('  { .name = "%s", .opt_idx = %s },'):format(name, option_index[name]))
-end
-
-map_w('};\n')
-map_w('static ' .. hashfun)
-
-opt_map_fd:close()
-
-vars_w('// IWYU pragma: private, include "nvim/option_vars.h"')
-
--- Generate enums for option flags.
-for _, option in ipairs(options_meta) do
-  if option.flags and (type(option.flags) == 'table' or option.values) then
-    vars_w('')
-    vars_w('typedef enum {')
-
-    local opt_name = lowercase_to_titlecase(option.abbreviation or option.full_name)
-    --- @type table<string,integer>
-    local enum_values
-
-    if type(option.flags) == 'table' then
-      enum_values = option.flags --[[ @as table<string,integer> ]]
-    else
-      enum_values = {}
-      for i, flag_name in ipairs(option.values) do
-        assert(type(flag_name) == 'string')
-        enum_values[flag_name] = math.pow(2, i - 1)
-      end
-    end
-
-    -- Sort the keys by the flag value so that the enum can be generated in order.
-    --- @type string[]
-    local flag_names = vim.tbl_keys(enum_values)
-    table.sort(flag_names, function(a, b)
-      return enum_values[a] < enum_values[b]
-    end)
-
-    for _, flag_name in pairs(flag_names) do
-      vars_w(
-        ('  kOpt%sFlag%s = 0x%02x,'):format(
-          opt_name,
-          lowercase_to_titlecase(flag_name:gsub(':$', '')),
-          enum_values[flag_name]
-        )
-      )
-    end
-
-    vars_w(('} Opt%sFlags;'):format(opt_name))
-  end
-end
-
--- Generate valid values for each option.
-for _, option in ipairs(options_meta) do
-  --- @param prefix string
-  --- @param values vim.option_valid_values
-  local function preorder_traversal(prefix, values)
-    vars_w('')
-    vars_w(
-      ('EXTERN const char *(%s_values[%s]) INIT( = {'):format(prefix, #vim.tbl_keys(values) + 1)
-    )
-
-    --- @type [string,vim.option_valid_values][]
-    local children = {}
-
-    for _, value in ipairs(values) do
-      if type(value) == 'string' then
-        vars_w(('  "%s",'):format(value))
-      else
-        assert(type(value) == 'table' and type(value[1]) == 'string' and type(value[2]) == 'table')
-
-        vars_w(('  "%s",'):format(value[1]))
-        table.insert(children, value)
-      end
-    end
-
-    vars_w('  NULL')
-    vars_w('});')
-
-    for _, value in pairs(children) do
-      -- Remove trailing colon from the added prefix to prevent syntax errors.
-      preorder_traversal(prefix .. '_' .. value[1]:gsub(':$', ''), value[2])
-    end
-  end
-
-  -- Since option values can be nested, we need to do preorder traversal to generate the values.
-  if option.values then
-    preorder_traversal(('opt_%s'):format(option.abbreviation or option.full_name), option.values)
-  end
-end
-
-opt_vars_fd:close()
 
 local redraw_flags = {
   ui_option = 'kOptFlagUIOption',
@@ -259,28 +48,29 @@ local list_flags = {
 --- @param o vim.option_meta
 --- @return string
 local function get_flags(o)
-  --- @type string
-  local flags = '0'
+  --- @type string[]
+  local flags = { '0' }
 
   --- @param f string
-  local add_flag = function(f)
-    flags = flags .. '|' .. f
+  local function add_flag(f)
+    table.insert(flags, f)
   end
 
   if o.list then
     add_flag(list_flags[o.list])
   end
-  if o.redraw then
-    for _, r_flag in ipairs(o.redraw) do
-      add_flag(redraw_flags[r_flag])
-    end
+
+  for _, r_flag in ipairs(o.redraw or {}) do
+    add_flag(redraw_flags[r_flag])
   end
+
   if o.expand then
     add_flag('kOptFlagExpand')
     if o.expand == 'nodefault' then
       add_flag('kOptFlagNoDefExp')
     end
   end
+
   for _, flag_desc in ipairs({
     { 'nodefault', 'NoDefault' },
     { 'no_mkrc', 'NoMkrc' },
@@ -295,13 +85,14 @@ local function get_flags(o)
     { 'modelineexpr', 'MLE' },
     { 'func' },
   }) do
-    local key_name = flag_desc[1]
-    local def_name = 'kOptFlag' .. (flag_desc[2] or lowercase_to_titlecase(key_name))
+    local key_name, flag_suffix = flag_desc[1], flag_desc[2]
     if o[key_name] then
+      local def_name = 'kOptFlag' .. (flag_suffix or lowercase_to_titlecase(key_name))
       add_flag(def_name)
     end
   end
-  return flags
+
+  return table.concat(flags, '|')
 end
 
 --- @param opt_type vim.option_type
@@ -345,35 +136,15 @@ local function get_scope_idx(o)
   return ('{\n%s\n    }'):format(table.concat(strs, ',\n'))
 end
 
---- @param c string|string[]
---- @param base_string? string
---- @return string
-local function get_cond(c, base_string)
-  local cond_string = base_string or '#if '
-  if type(c) == 'table' then
-    cond_string = cond_string .. get_cond(c[1], '')
-    for i, subc in ipairs(c) do
-      if i > 1 then
-        cond_string = cond_string .. ' && ' .. get_cond(subc, '')
-      end
-    end
-  elseif c:sub(1, 1) == '!' then
-    cond_string = cond_string .. '!defined(' .. c:sub(2) .. ')'
-  else
-    cond_string = cond_string .. 'defined(' .. c .. ')'
-  end
-  return cond_string
-end
-
 --- @param s string
 --- @return string
-local static_cstr_as_string = function(s)
+local function static_cstr_as_string(s)
   return ('{ .data = %s, .size = sizeof(%s) - 1 }'):format(s, s)
 end
 
 --- @param v vim.option_value|function
 --- @return string
-local get_opt_val = function(v)
+local function get_opt_val(v)
   --- @type vim.option_type
   local v_type
 
@@ -391,6 +162,7 @@ local get_opt_val = function(v)
     elseif v_type == 'number' then
       v = ('%iL'):format(v)
     elseif v_type == 'string' then
+      --- @cast v string
       v = static_cstr_as_string(cstr(v))
     end
   end
@@ -401,7 +173,7 @@ end
 --- @param d vim.option_value|function
 --- @param n string
 --- @return string
-local get_defaults = function(d, n)
+local function get_defaults(d, n)
   if d == nil then
     error("option '" .. n .. "' should have a default value")
   end
@@ -410,103 +182,373 @@ end
 
 --- @param i integer
 --- @param o vim.option_meta
-local function dump_option(i, o)
-  w('  [' .. ('%u'):format(i - 1) .. ']={')
-  w('    .fullname=' .. cstr(o.full_name))
+--- @param write fun(...: string)
+local function dump_option(i, o, write)
+  write('  [', ('%u'):format(i - 1) .. ']={')
+  write('    .fullname=', cstr(o.full_name))
   if o.abbreviation then
-    w('    .shortname=' .. cstr(o.abbreviation))
+    write('    .shortname=', cstr(o.abbreviation))
   end
-  w('    .type=' .. opt_type_enum(o.type))
-  w('    .flags=' .. get_flags(o))
-  w('    .scope_flags=' .. get_scope_flags(o))
-  w('    .scope_idx=' .. get_scope_idx(o))
-  w('    .values=' .. (o.values and get_values_var(o) or 'NULL'))
-  w('    .values_len=' .. (o.values and #o.values or '0'))
-  w('    .flags_var=' .. (o.flags_varname and ('&%s'):format(o.flags_varname) or 'NULL'))
+  write('    .type=', opt_type_enum(o.type))
+  write('    .flags=', get_flags(o))
+  write('    .scope_flags=', get_scope_flags(o))
+  write('    .scope_idx=', get_scope_idx(o))
+  write('    .values=', (o.values and get_values_var(o) or 'NULL'))
+  write('    .values_len=', (o.values and #o.values or '0'))
+  write('    .flags_var=', (o.flags_varname and ('&%s'):format(o.flags_varname) or 'NULL'))
   if o.enable_if then
-    w(get_cond(o.enable_if))
+    write(('#if defined(%s)'):format(o.enable_if))
   end
 
   local is_window_local = #o.scope == 1 and o.scope[1] == 'win'
 
-  if not is_window_local then
-    if o.varname then
-      w('    .var=&' .. o.varname)
-    elseif o.immutable then
-      -- Immutable options can directly point to the default value.
-      w(('    .var=&options[%u].def_val.data'):format(i - 1))
-    else
-      -- Option must be immutable or have a variable.
-      assert(false)
-    end
+  if is_window_local then
+    write('    .var=NULL')
+  elseif o.varname then
+    write('    .var=&', o.varname)
+  elseif o.immutable then
+    -- Immutable options can directly point to the default value.
+    write(('    .var=&options[%u].def_val.data'):format(i - 1))
   else
-    w('    .var=NULL')
-  end
-  w('    .immutable=' .. (o.immutable and 'true' or 'false'))
-
-  if o.cb then
-    w('    .opt_did_set_cb=' .. o.cb)
+    error('Option must be immutable or have a variable.')
   end
 
-  if o.expand_cb then
-    w('    .opt_expand_cb=' .. o.expand_cb)
-  end
+  write('    .immutable=', (o.immutable and 'true' or 'false'))
+  write('    .opt_did_set_cb=', o.cb or 'NULL')
+  write('    .opt_expand_cb=', o.expand_cb or 'NULL')
 
   if o.enable_if then
-    w('#else')
+    write('#else')
     -- Hidden option directly points to default value.
-    w(('    .var=&options[%u].def_val.data'):format(i - 1))
+    write(('    .var=&options[%u].def_val.data'):format(i - 1))
     -- Option is always immutable on the false branch of `enable_if`.
-    w('    .immutable=true')
-    w('#endif')
+    write('    .immutable=true')
+    write('#endif')
   end
-  if o.defaults then
-    if o.defaults.condition then
-      w(get_cond(o.defaults.condition))
+
+  if not o.defaults then
+    write('    .def_val=NIL_OPTVAL')
+  elseif o.defaults.condition then
+    write(('#if defined(%s)'):format(o.defaults.condition))
+    write('    .def_val=', get_defaults(o.defaults.if_true, o.full_name))
+    if o.defaults.if_false then
+      write('#else')
+      write('    .def_val=', get_defaults(o.defaults.if_false, o.full_name))
     end
-    w('    .def_val=' .. get_defaults(o.defaults.if_true, o.full_name))
-    if o.defaults.condition then
-      if o.defaults.if_false then
-        w('#else')
-        w('    .def_val=' .. get_defaults(o.defaults.if_false, o.full_name))
-      end
-      w('#endif')
-    end
+    write('#endif')
   else
-    w('    .def_val=NIL_OPTVAL')
+    write('    .def_val=', get_defaults(o.defaults.if_true, o.full_name))
   end
-  w('  },')
+
+  write('  },')
 end
 
 --- @param o vim.option_meta
---- @return vim.option_meta
 local function preprocess(o)
-  o = vim.deepcopy(o)
-
   if o.values then
     o.cb = o.cb or 'did_set_str_generic'
     o.expand_cb = o.expand_cb or 'expand_set_str_generic'
   end
 
-  return o
+  if type(o.alias) == 'string' then
+    o.alias = {
+      o.alias --[[@as string]],
+    }
+  end
 end
 
--- Generate options[] array.
-w([[
-#include "nvim/ex_docmd.h"
-#include "nvim/ex_getln.h"
-#include "nvim/insexpand.h"
-#include "nvim/mapping.h"
-#include "nvim/ops.h"
-#include "nvim/option.h"
-#include "nvim/optionstr.h"
-#include "nvim/quickfix.h"
-#include "nvim/runtime.h"
-#include "nvim/tag.h"
-#include "nvim/window.h"
+--- @param prefix string
+--- @param values vim.option_valid_values
+local function preorder_traversal(prefix, values)
+  local out = {} --- @type string[]
 
-static vimoption_T options[] = {]])
-for i, o in ipairs(options.options) do
-  dump_option(i, preprocess(o))
+  local function add(s)
+    table.insert(out, s)
+  end
+
+  add('')
+  add(('EXTERN const char *(%s_values[%s]) INIT( = {'):format(prefix, #vim.tbl_keys(values) + 1))
+
+  --- @type [string,vim.option_valid_values][]
+  local children = {}
+
+  for _, value in ipairs(values) do
+    if type(value) == 'string' then
+      add(('  "%s",'):format(value))
+    else
+      assert(type(value) == 'table' and type(value[1]) == 'string' and type(value[2]) == 'table')
+      add(('  "%s",'):format(value[1]))
+      table.insert(children, value)
+    end
+  end
+
+  add('  NULL')
+  add('});')
+
+  for _, value in pairs(children) do
+    -- Remove trailing colon from the added prefix to prevent syntax errors.
+    add(preorder_traversal(prefix .. '_' .. value[1]:gsub(':$', ''), value[2]))
+  end
+
+  return table.concat(out, '\n')
 end
-w('};')
+
+--- @param o vim.option_meta
+--- @return string
+local function gen_opt_enum(o)
+  local out = {} --- @type string[]
+
+  local function add(s)
+    table.insert(out, s)
+  end
+
+  add('')
+  add('typedef enum {')
+
+  local opt_name = lowercase_to_titlecase(o.abbreviation or o.full_name)
+  --- @type table<string,integer>
+  local enum_values
+
+  if type(o.flags) == 'table' then
+    enum_values = o.flags --[[ @as table<string,integer> ]]
+  else
+    enum_values = {}
+    for i, flag_name in ipairs(o.values) do
+      assert(type(flag_name) == 'string')
+      enum_values[flag_name] = math.pow(2, i - 1)
+    end
+  end
+
+  -- Sort the keys by the flag value so that the enum can be generated in order.
+  --- @type string[]
+  local flag_names = vim.tbl_keys(enum_values)
+  table.sort(flag_names, function(a, b)
+    return enum_values[a] < enum_values[b]
+  end)
+
+  for _, flag_name in pairs(flag_names) do
+    add(
+      ('  kOpt%sFlag%s = 0x%02x,'):format(
+        opt_name,
+        lowercase_to_titlecase(flag_name:gsub(':$', '')),
+        enum_values[flag_name]
+      )
+    )
+  end
+
+  add(('} Opt%sFlags;'):format(opt_name))
+
+  return table.concat(out, '\n')
+end
+
+--- @param output_file string
+--- @return table<string,string> options_index Map of option name to option index
+local function gen_enums(output_file)
+  --- Options for each scope.
+  --- @type table<string, vim.option_meta[]>
+  local scope_options = {}
+  for _, scope in ipairs(valid_scopes) do
+    scope_options[scope] = {}
+  end
+
+  local fd = assert(io.open(output_file, 'w'))
+
+  --- @param s string
+  local function write(s)
+    fd:write(s)
+    fd:write('\n')
+  end
+
+  -- Generate options enum file
+  write('// IWYU pragma: private, include "nvim/option_defs.h"')
+  write('')
+
+  --- Map of option name to option index
+  --- @type table<string, string>
+  local option_index = {}
+
+  -- Generate option index enum and populate the `option_index` and `scope_option` dicts.
+  write('typedef enum {')
+  write('  kOptInvalid = -1,')
+
+  for i, o in ipairs(options_meta) do
+    local enum_val_name = 'kOpt' .. lowercase_to_titlecase(o.full_name)
+    write(('  %s = %u,'):format(enum_val_name, i - 1))
+
+    option_index[o.full_name] = enum_val_name
+
+    if o.abbreviation then
+      option_index[o.abbreviation] = enum_val_name
+    end
+
+    local alias = o.alias or {} --[[@as string[] ]]
+    for _, v in ipairs(alias) do
+      option_index[v] = enum_val_name
+    end
+
+    for _, scope in ipairs(o.scope) do
+      table.insert(scope_options[scope], o)
+    end
+  end
+
+  write('  // Option count')
+  write('#define kOptCount ' .. tostring(#options_meta))
+  write('} OptIndex;')
+
+  -- Generate option index enum for each scope
+  for _, scope in ipairs(valid_scopes) do
+    write('')
+
+    local scope_name = lowercase_to_titlecase(scope)
+    write('typedef enum {')
+    write(('  %s = -1,'):format(get_scope_option(scope, 'Invalid')))
+
+    for idx, option in ipairs(scope_options[scope]) do
+      write(('  %s = %u,'):format(get_scope_option(scope, option.full_name), idx - 1))
+    end
+
+    write(('  // %s option count'):format(scope_name))
+    write(('#define %s %d'):format(get_scope_option(scope, 'Count'), #scope_options[scope]))
+    write(('} %sOptIndex;'):format(scope_name))
+  end
+
+  -- Generate reverse lookup from option scope index to option index for each scope.
+  for _, scope in ipairs(valid_scopes) do
+    write('')
+    write(('EXTERN const OptIndex %s_opt_idx[] INIT( = {'):format(scope))
+    for _, option in ipairs(scope_options[scope]) do
+      local idx = option_index[option.full_name]
+      write(('  [%s] = %s,'):format(get_scope_option(scope, option.full_name), idx))
+    end
+    write('});')
+  end
+
+  fd:close()
+
+  return option_index
+end
+
+--- @param output_file string
+--- @param option_index table<string,string>
+local function gen_map(output_file, option_index)
+  -- Generate option index map.
+  local hashy = require('generators.hashy')
+
+  local neworder, hashfun = hashy.hashy_hash(
+    'find_option',
+    vim.tbl_keys(option_index),
+    function(idx)
+      return ('option_hash_elems[%s].name'):format(idx)
+    end
+  )
+
+  local fd = assert(io.open(output_file, 'w'))
+
+  --- @param s string
+  local function write(s)
+    fd:write(s)
+    fd:write('\n')
+  end
+
+  write('static const struct { const char *name; OptIndex opt_idx; } option_hash_elems[] = {')
+
+  for _, name in ipairs(neworder) do
+    assert(option_index[name] ~= nil)
+    write(('  { .name = "%s", .opt_idx = %s },'):format(name, option_index[name]))
+  end
+
+  write('};')
+  write('')
+  write('static ' .. hashfun)
+
+  fd:close()
+end
+
+--- @param output_file string
+local function gen_vars(output_file)
+  local fd = assert(io.open(output_file, 'w'))
+
+  --- @param s string
+  local function write(s)
+    fd:write(s)
+    fd:write('\n')
+  end
+
+  write('// IWYU pragma: private, include "nvim/option_vars.h"')
+
+  -- Generate enums for option flags.
+  for _, o in ipairs(options_meta) do
+    if o.flags and (type(o.flags) == 'table' or o.values) then
+      write(gen_opt_enum(o))
+    end
+  end
+
+  -- Generate valid values for each option.
+  for _, option in ipairs(options_meta) do
+    -- Since option values can be nested, we need to do preorder traversal to generate the values.
+    if option.values then
+      local values_var = ('opt_%s'):format(option.abbreviation or option.full_name)
+      write(preorder_traversal(values_var, option.values))
+    end
+  end
+
+  fd:close()
+end
+
+--- @param output_file string
+local function gen_options(output_file)
+  local fd = assert(io.open(output_file, 'w'))
+
+  --- @param ... string
+  local function write(...)
+    local s = table.concat({ ... }, '')
+    fd:write(s)
+    if s:match('^    %.') then
+      fd:write(',')
+    end
+    fd:write('\n')
+  end
+
+  -- Generate options[] array.
+  write([[
+  #include "nvim/ex_docmd.h"
+  #include "nvim/ex_getln.h"
+  #include "nvim/insexpand.h"
+  #include "nvim/mapping.h"
+  #include "nvim/ops.h"
+  #include "nvim/option.h"
+  #include "nvim/optionstr.h"
+  #include "nvim/quickfix.h"
+  #include "nvim/runtime.h"
+  #include "nvim/tag.h"
+  #include "nvim/window.h"
+
+  static vimoption_T options[] = {]])
+
+  for i, o in ipairs(options_meta) do
+    dump_option(i, o, write)
+  end
+
+  write('};')
+
+  fd:close()
+end
+
+local function main()
+  local options_file = arg[1]
+  local options_enum_file = arg[2]
+  local options_map_file = arg[3]
+  local option_vars_file = arg[4]
+
+  -- pre-process options_meta
+  for _, o in ipairs(options_meta) do
+    preprocess(o)
+  end
+
+  local option_index = gen_enums(options_enum_file)
+  gen_map(options_map_file, option_index)
+  gen_vars(option_vars_file)
+  gen_options(options_file)
+end
+
+main()

--- a/src/nvim/generators/gen_options.lua
+++ b/src/nvim/generators/gen_options.lua
@@ -243,20 +243,6 @@ local function dump_option(i, o, write)
   write('  },')
 end
 
---- @param o vim.option_meta
-local function preprocess(o)
-  if o.values then
-    o.cb = o.cb or 'did_set_str_generic'
-    o.expand_cb = o.expand_cb or 'expand_set_str_generic'
-  end
-
-  if type(o.alias) == 'string' then
-    o.alias = {
-      o.alias --[[@as string]],
-    }
-  end
-end
-
 --- @param prefix string
 --- @param values vim.option_valid_values
 local function preorder_traversal(prefix, values)
@@ -539,11 +525,6 @@ local function main()
   local options_enum_file = arg[2]
   local options_map_file = arg[3]
   local option_vars_file = arg[4]
-
-  -- pre-process options_meta
-  for _, o in ipairs(options_meta) do
-    preprocess(o)
-  end
 
   local option_index = gen_enums(options_enum_file)
   gen_map(options_map_file, option_index)

--- a/src/nvim/generators/hashy.lua
+++ b/src/nvim/generators/hashy.lua
@@ -55,7 +55,7 @@ function M.build_pos_hash(strings)
 end
 
 function M.switcher(put, tab, maxlen, worst_buck_size)
-  local neworder = {}
+  local neworder = {} --- @type string[]
   put '  switch (len) {\n'
   local bucky = worst_buck_size > 1
   for len = 1, maxlen do

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5715,6 +5715,7 @@ int ExpandStringSetting(expand_T *xp, regmatch_T *regmatch, int *numMatches, cha
 
   optexpand_T args = {
     .oe_varp = get_varp_scope(&options[expand_option_idx], expand_option_flags),
+    .oe_idx = expand_option_idx,
     .oe_append = expand_option_append,
     .oe_regmatch = regmatch,
     .oe_xp = xp,

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -134,6 +134,7 @@ typedef const char *(*opt_did_set_cb_T)(optset_T *args);
 typedef struct {
   /// Pointer to the option variable. It's always a string.
   char *oe_varp;
+  OptIndex oe_idx;
   /// The original option value, escaped.
   char *oe_opt_value;
 
@@ -174,8 +175,12 @@ typedef struct {
   void *var;                         ///< global option: pointer to variable;
                                      ///< window-local option: NULL;
                                      ///< buffer-local option: global value
+  unsigned *flags_var;
   ssize_t scope_idx[kOptScopeSize];  ///< index of option at every scope.
   bool immutable;                    ///< option is immutable, trying to set it will give an error.
+
+  const char **values;               ///< possible values for string options
+  const size_t values_len;           ///< length of values array
 
   /// callback function to invoke after an option is modified to validate and
   /// apply the new value.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -14,7 +14,7 @@
 --- @field scope vim.option_scope[]
 --- @field deny_duplicates? boolean
 --- @field enable_if? string
---- @field defaults? vim.option_defaults
+--- @field defaults? vim.option_defaults|vim.option_value|fun(): string
 --- @field values? vim.option_valid_values
 --- @field flags? true|table<string,integer>
 --- @field secure? true
@@ -42,14 +42,14 @@
 --- @field condition? string
 ---    string: #ifdef string
 ---    !string: #ifndef string
---- @field if_true integer|boolean|string|fun(): string
---- @field if_false? integer|boolean|string
+--- @field if_true vim.option_value|fun(): string
+--- @field if_false? vim.option_value
 --- @field doc? string Default to show in options.txt
---- @field meta? integer|boolean|string Default to use in Lua meta files
+--- @field meta? string Default to use in Lua meta files
 
 --- @alias vim.option_scope 'global'|'buf'|'win'
 --- @alias vim.option_type 'boolean'|'number'|'string'
---- @alias vim.option_value boolean|number|string
+--- @alias vim.option_value boolean|integer|string
 --- @alias vim.option_valid_values (string|[string,vim.option_valid_values])[]
 
 --- @alias vim.option_redraw
@@ -86,7 +86,7 @@ local function N_(s) -- luacheck: ignore 211 (currently unused)
 end
 
 -- luacheck: ignore 621
-return {
+local options = {
   cstr = cstr,
   --- @type string[]
   valid_scopes = { 'global', 'buf', 'win' },
@@ -95,7 +95,7 @@ return {
   options = {
     {
       abbreviation = 'al',
-      defaults = { if_true = 224 },
+      defaults = 224,
       full_name = 'aleph',
       scope = { 'global' },
       short_desc = N_('ASCII code of the letter Aleph (Hebrew)'),
@@ -104,7 +104,7 @@ return {
     },
     {
       abbreviation = 'ari',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Allow CTRL-_ in Insert mode.  This is default off, to avoid that users
         that accidentally type CTRL-_ instead of SHIFT-_ get into reverse
@@ -119,7 +119,7 @@ return {
     {
       abbreviation = 'ambw',
       cb = 'did_set_ambiwidth',
-      defaults = { if_true = 'single' },
+      defaults = 'single',
       values = { 'single', 'double' },
       desc = [=[
         Tells Vim what to do with characters with East Asian Width Class
@@ -163,7 +163,7 @@ return {
     {
       abbreviation = 'arab',
       cb = 'did_set_arabic',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         This option can be set to start editing Arabic text.
         Setting this option will:
@@ -188,7 +188,7 @@ return {
     },
     {
       abbreviation = 'arshape',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When on and 'termbidi' is off, the required visual character
         corrections that need to take place for displaying the Arabic language
@@ -213,7 +213,7 @@ return {
     {
       abbreviation = 'acd',
       cb = 'did_set_autochdir',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When on, Vim will change the current working directory whenever you
         open a file, switch buffers, delete a buffer or open/close a window.
@@ -230,7 +230,7 @@ return {
     },
     {
       abbreviation = 'ai',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         Copy indent from current line when starting a new line (typing <CR>
         in Insert mode or when using the "o" or "O" command).  If you do not
@@ -252,7 +252,7 @@ return {
     },
     {
       abbreviation = 'ar',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When a file has been detected to have been changed outside of Vim and
         it has not been changed inside of Vim, automatically read it again.
@@ -272,7 +272,7 @@ return {
     },
     {
       abbreviation = 'aw',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Write the contents of the file, if it has been modified, on each
         `:next`, `:rewind`, `:last`, `:first`, `:previous`, `:stop`,
@@ -297,7 +297,7 @@ return {
     },
     {
       abbreviation = 'awa',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Like 'autowrite', but also used for commands ":edit", ":enew", ":quit",
         ":qall", ":exit", ":xit", ":recover" and closing the Vim window.
@@ -313,7 +313,7 @@ return {
     {
       abbreviation = 'bg',
       cb = 'did_set_background',
-      defaults = { if_true = 'dark' },
+      defaults = 'dark',
       values = { 'light', 'dark' },
       desc = [=[
         When set to "dark" or "light", adjusts the default color groups for
@@ -348,7 +348,7 @@ return {
     {
       abbreviation = 'bs',
       cb = 'did_set_backspace',
-      defaults = { if_true = 'indent,eol,start' },
+      defaults = 'indent,eol,start',
       values = { 'indent', 'eol', 'start', 'nostop' },
       deny_duplicates = true,
       desc = [=[
@@ -375,7 +375,7 @@ return {
     },
     {
       abbreviation = 'bk',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Make a backup before overwriting a file.  Leave it around after the
         file has been successfully written.  If you do not want to keep the
@@ -475,7 +475,7 @@ return {
     },
     {
       abbreviation = 'bdir',
-      defaults = { if_true = '' },
+      defaults = '',
       deny_duplicates = true,
       desc = [=[
         List of directories for the backup file, separated with commas.
@@ -531,7 +531,7 @@ return {
     {
       abbreviation = 'bex',
       cb = 'did_set_backupext_or_patchmode',
-      defaults = { if_true = '~' },
+      defaults = '~',
       desc = [=[
         String which is appended to a file name to make the name of the
         backup file.  The default is quite unusual, because this avoids
@@ -595,7 +595,7 @@ return {
     },
     {
       abbreviation = 'bo',
-      defaults = { if_true = 'all' },
+      defaults = 'all',
       values = {
         'all',
         'backspace',
@@ -669,7 +669,7 @@ return {
     {
       abbreviation = 'bin',
       cb = 'did_set_binary',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         This option should be set before editing a binary file.  You can also
         use the |-b| Vim argument.  When this option is switched on a few
@@ -707,7 +707,7 @@ return {
     },
     {
       cb = 'did_set_eof_eol_fixeol_bomb',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When writing a file and the following conditions are met, a BOM (Byte
         Order Mark) is prepended to the file:
@@ -755,7 +755,7 @@ return {
     },
     {
       abbreviation = 'bri',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Every wrapped line will continue visually indented (same amount of
         space as the beginning of that line), thus preserving horizontal blocks
@@ -770,7 +770,7 @@ return {
     {
       abbreviation = 'briopt',
       cb = 'did_set_breakindentopt',
-      defaults = { if_true = '' },
+      defaults = '',
       -- Keep this in sync with briopt_check().
       values = { 'shift:', 'min:', 'sbr', 'list:', 'column:' },
       deny_duplicates = true,
@@ -833,7 +833,7 @@ return {
     {
       abbreviation = 'bh',
       cb = 'did_set_bufhidden',
-      defaults = { if_true = '' },
+      defaults = '',
       values = { '', 'hide', 'unload', 'delete', 'wipe' },
       desc = [=[
         This option specifies what happens when a buffer is no longer
@@ -866,7 +866,7 @@ return {
     {
       abbreviation = 'bl',
       cb = 'did_set_buflisted',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When this option is set, the buffer shows up in the buffer list.  If
         it is reset it is not used for ":bnext", "ls", the Buffers menu, etc.
@@ -885,7 +885,7 @@ return {
     {
       abbreviation = 'bt',
       cb = 'did_set_buftype',
-      defaults = { if_true = '' },
+      defaults = '',
       values = {
         '',
         'acwrite',
@@ -952,7 +952,7 @@ return {
     },
     {
       abbreviation = 'cmp',
-      defaults = { if_true = 'internal,keepascii' },
+      defaults = 'internal,keepascii',
       values = { 'internal', 'keepascii' },
       flags = true,
       deny_duplicates = true,
@@ -977,7 +977,7 @@ return {
     },
     {
       abbreviation = 'cdh',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When on, |:cd|, |:tcd| and |:lcd| without an argument changes the
         current working directory to the |$HOME| directory like in Unix.
@@ -1051,7 +1051,7 @@ return {
       varname = 'p_cedit',
     },
     {
-      defaults = { if_true = 0 },
+      defaults = 0,
       desc = [=[
         |channel| connected to the buffer, or 0 if no channel is connected.
         In a |:terminal| buffer this is the terminal channel.
@@ -1068,7 +1068,7 @@ return {
     {
       abbreviation = 'ccv',
       cb = 'did_set_optexpr',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         An expression that is used for character encoding conversion.  It is
         evaluated when a file that is to be read or has been written has a
@@ -1124,7 +1124,7 @@ return {
     },
     {
       abbreviation = 'cin',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Enables automatic C program indenting.  See 'cinkeys' to set the keys
         that trigger reindenting in insert mode and 'cinoptions' to set your
@@ -1145,7 +1145,7 @@ return {
     },
     {
       abbreviation = 'cink',
-      defaults = { if_true = '0{,0},0),0],:,0#,!^F,o,O,e' },
+      defaults = '0{,0},0),0],:,0#,!^F,o,O,e',
       deny_duplicates = true,
       desc = [=[
         A list of keys that, when typed in Insert mode, cause reindenting of
@@ -1164,7 +1164,7 @@ return {
     {
       abbreviation = 'cino',
       cb = 'did_set_cinoptions',
-      defaults = { if_true = '' },
+      defaults = '',
       deny_duplicates = true,
       desc = [=[
         The 'cinoptions' affect the way 'cindent' reindents lines in a C
@@ -1180,7 +1180,7 @@ return {
     },
     {
       abbreviation = 'cinsd',
-      defaults = { if_true = 'public,protected,private' },
+      defaults = 'public,protected,private',
       deny_duplicates = true,
       desc = [=[
         Keywords that are interpreted as a C++ scope declaration by |cino-g|.
@@ -1198,7 +1198,7 @@ return {
     },
     {
       abbreviation = 'cinw',
-      defaults = { if_true = 'if,else,while,do,for,switch' },
+      defaults = 'if,else,while,do,for,switch',
       deny_duplicates = true,
       desc = [=[
         These keywords start an extra indent in the next line when
@@ -1217,7 +1217,7 @@ return {
     },
     {
       abbreviation = 'cb',
-      defaults = { if_true = '' },
+      defaults = '',
       values = { 'unnamed', 'unnamedplus' },
       flags = true,
       desc = [=[
@@ -1256,7 +1256,7 @@ return {
     {
       abbreviation = 'ch',
       cb = 'did_set_cmdheight',
-      defaults = { if_true = 1 },
+      defaults = 1,
       desc = [=[
         Number of screen lines to use for the command-line.  Helps avoiding
         |hit-enter| prompts.
@@ -1281,7 +1281,7 @@ return {
     },
     {
       abbreviation = 'cwh',
-      defaults = { if_true = 7 },
+      defaults = 7,
       desc = [=[
         Number of screen lines to use for the command-line window. |cmdwin|
       ]=],
@@ -1294,7 +1294,7 @@ return {
     {
       abbreviation = 'cc',
       cb = 'did_set_colorcolumn',
-      defaults = { if_true = '' },
+      defaults = '',
       deny_duplicates = true,
       desc = [=[
         'colorcolumn' is a comma-separated list of screen columns that are
@@ -1349,7 +1349,7 @@ return {
     {
       abbreviation = 'com',
       cb = 'did_set_comments',
-      defaults = { if_true = 's1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-,fb:•' },
+      defaults = 's1:/*,mb:*,ex:*/,://,b:#,:%,:XCOMM,n:>,fb:-,fb:•',
       deny_duplicates = true,
       desc = [=[
         A comma-separated list of strings that can start a comment line.  See
@@ -1367,7 +1367,7 @@ return {
     {
       abbreviation = 'cms',
       cb = 'did_set_commentstring',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         A template for a comment.  The "%s" in the value is replaced with the
         comment text, and should be padded with a space when possible.
@@ -1382,7 +1382,7 @@ return {
     },
     {
       abbreviation = 'cp',
-      defaults = { if_true = false },
+      defaults = false,
       full_name = 'compatible',
       scope = { 'global' },
       short_desc = N_('No description'),
@@ -1392,7 +1392,7 @@ return {
     {
       abbreviation = 'cpt',
       cb = 'did_set_complete',
-      defaults = { if_true = '.,w,b,u,t' },
+      defaults = '.,w,b,u,t',
       values = { '.', 'w', 'b', 'u', 'k', 'kspell', 's', 'i', 'd', ']', 't', 'U', 'f' },
       deny_duplicates = true,
       desc = [=[
@@ -1440,7 +1440,7 @@ return {
     {
       abbreviation = 'cfu',
       cb = 'did_set_completefunc',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         This option specifies a function to be used for Insert mode completion
         with CTRL-X CTRL-U. |i_CTRL-X_CTRL-U|
@@ -1462,7 +1462,7 @@ return {
     {
       abbreviation = 'cia',
       cb = 'did_set_completeitemalign',
-      defaults = { if_true = 'abbr,kind,menu' },
+      defaults = 'abbr,kind,menu',
       flags = true,
       deny_duplicates = true,
       desc = [=[
@@ -1483,7 +1483,7 @@ return {
     {
       abbreviation = 'cot',
       cb = 'did_set_completeopt',
-      defaults = { if_true = 'menu,preview' },
+      defaults = 'menu,preview',
       values = {
         'menu',
         'menuone',
@@ -1549,7 +1549,7 @@ return {
     {
       abbreviation = 'csl',
       cb = 'did_set_completeslash',
-      defaults = { if_true = '' },
+      defaults = '',
       values = { '', 'slash', 'backslash' },
       desc = [=[
         		only modifiable in MS-Windows
@@ -1573,7 +1573,7 @@ return {
     {
       abbreviation = 'cocu',
       cb = 'did_set_concealcursor',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         Sets the modes in which text in the cursor line can also be concealed.
         When the current mode is listed then concealing happens just like in
@@ -1601,7 +1601,7 @@ return {
     },
     {
       abbreviation = 'cole',
-      defaults = { if_true = 0 },
+      defaults = 0,
       desc = [=[
         Determine how text with the "conceal" syntax attribute |:syn-conceal|
         is shown:
@@ -1630,7 +1630,7 @@ return {
     },
     {
       abbreviation = 'cf',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When 'confirm' is on, certain operations that would normally
         fail because of unsaved changes to a buffer, e.g. ":q" and ":e",
@@ -1649,7 +1649,7 @@ return {
     },
     {
       abbreviation = 'ci',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Copy the structure of the existing lines indent when autoindenting a
         new line.  Normally the new indent is reconstructed by a series of
@@ -1670,7 +1670,7 @@ return {
     {
       abbreviation = 'cpo',
       cb = 'did_set_cpoptions',
-      defaults = { if_true = macros('CPO_VIM', 'string') },
+      defaults = macros('CPO_VIM', 'string'),
       desc = [=[
         A sequence of single character flags.  When a character is present
         this indicates Vi-compatible behavior.  This is used for things where
@@ -1912,7 +1912,7 @@ return {
     },
     {
       abbreviation = 'crb',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When this option is set, as the cursor in the current
         window moves other cursorbound windows (windows that also have
@@ -1929,7 +1929,7 @@ return {
     },
     {
       abbreviation = 'cuc',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Highlight the screen column of the cursor with CursorColumn
         |hl-CursorColumn|.  Useful to align text.  Will make screen redrawing
@@ -1948,7 +1948,7 @@ return {
     },
     {
       abbreviation = 'cul',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Highlight the text line of the cursor with CursorLine |hl-CursorLine|.
         Useful to easily spot the cursor.  Will make screen redrawing slower.
@@ -1964,7 +1964,7 @@ return {
     {
       abbreviation = 'culopt',
       cb = 'did_set_cursorlineopt',
-      defaults = { if_true = 'both' },
+      defaults = 'both',
       -- Keep this in sync with fill_culopt_flags().
       values = { 'line', 'screenline', 'number', 'both' },
       flags = {
@@ -1996,7 +1996,7 @@ return {
       type = 'string',
     },
     {
-      defaults = { if_true = '' },
+      defaults = '',
       values = { 'msg', 'throw', 'beep' },
       desc = [=[
         These values can be used:
@@ -2020,7 +2020,7 @@ return {
     },
     {
       abbreviation = 'def',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         Pattern to be used to find a macro definition.  It is a search
         pattern, just like for the "/" command.  This option is used for the
@@ -2050,7 +2050,7 @@ return {
     },
     {
       abbreviation = 'deco',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         If editing Unicode and this option is set, backspace and Normal mode
         "x" delete each combining character on its own.  When it is off (the
@@ -2070,7 +2070,7 @@ return {
     },
     {
       abbreviation = 'dict',
-      defaults = { if_true = '' },
+      defaults = '',
       deny_duplicates = true,
       desc = [=[
         List of file names, separated by commas, that are used to lookup words
@@ -2107,7 +2107,7 @@ return {
     },
     {
       cb = 'did_set_diff',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Join the current window in the group of windows that shows differences
         between files.  See |diff-mode|.
@@ -2122,7 +2122,7 @@ return {
     {
       abbreviation = 'dex',
       cb = 'did_set_optexpr',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         Expression which is evaluated to obtain a diff file (either ed-style
         or unified-style) from two versions of a file.  See |diff-diffexpr|.
@@ -2140,7 +2140,7 @@ return {
     {
       abbreviation = 'dip',
       cb = 'did_set_diffopt',
-      defaults = { if_true = 'internal,filler,closeoff' },
+      defaults = 'internal,filler,closeoff',
       -- Keep this in sync with diffopt_changed().
       values = {
         'filler',
@@ -2281,7 +2281,7 @@ return {
     },
     {
       abbreviation = 'dg',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Enable the entering of digraphs in Insert mode with {char1} <BS>
         {char2}.  See |digraphs|.
@@ -2294,7 +2294,7 @@ return {
     },
     {
       abbreviation = 'dir',
-      defaults = { if_true = '' },
+      defaults = '',
       deny_duplicates = true,
       desc = [=[
         List of directory names for the swap file, separated with commas.
@@ -2352,7 +2352,7 @@ return {
     {
       abbreviation = 'dy',
       cb = 'did_set_display',
-      defaults = { if_true = 'lastline' },
+      defaults = 'lastline',
       values = { 'lastline', 'truncate', 'uhex', 'msgsep' },
       flags = true,
       deny_duplicates = true,
@@ -2386,7 +2386,7 @@ return {
     },
     {
       abbreviation = 'ead',
-      defaults = { if_true = 'both' },
+      defaults = 'both',
       values = { 'both', 'ver', 'hor' },
       desc = [=[
         Tells when the 'equalalways' option applies:
@@ -2402,7 +2402,7 @@ return {
     },
     {
       abbreviation = 'ed',
-      defaults = { if_true = false },
+      defaults = false,
       full_name = 'edcompatible',
       scope = { 'global' },
       short_desc = N_('No description'),
@@ -2412,7 +2412,7 @@ return {
     {
       abbreviation = 'emo',
       cb = 'did_set_emoji',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When on all Unicode emoji characters are considered to be full width.
         This excludes "text emoji" characters, which are normally displayed as
@@ -2433,7 +2433,7 @@ return {
     {
       abbreviation = 'enc',
       cb = 'did_set_encoding',
-      defaults = { if_true = macros('ENC_DFLT', 'string') },
+      defaults = macros('ENC_DFLT', 'string'),
       deny_in_modelines = true,
       desc = [=[
         String-encoding used internally and for |RPC| communication.
@@ -2450,7 +2450,7 @@ return {
     {
       abbreviation = 'eof',
       cb = 'did_set_eof_eol_fixeol_bomb',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Indicates that a CTRL-Z character was found at the end of the file
         when reading it.  Normally only happens when 'fileformat' is "dos".
@@ -2470,7 +2470,7 @@ return {
     {
       abbreviation = 'eol',
       cb = 'did_set_eof_eol_fixeol_bomb',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When writing a file and this option is off and the 'binary' option
         is on, or 'fixeol' option is off, no <EOL> will be written for the
@@ -2496,7 +2496,7 @@ return {
     {
       abbreviation = 'ea',
       cb = 'did_set_equalalways',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When on, all the windows are automatically made the same size after
         splitting or closing a window.  This also happens the moment the
@@ -2521,7 +2521,7 @@ return {
     },
     {
       abbreviation = 'ep',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         External program to use for "=" command.  When this option is empty
         the internal formatting functions are used; either 'lisp', 'cindent'
@@ -2541,7 +2541,7 @@ return {
     },
     {
       abbreviation = 'eb',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Ring the bell (beep or screen flash) for error messages.  This only
         makes a difference for error messages, the bell will be used always
@@ -2557,7 +2557,7 @@ return {
     },
     {
       abbreviation = 'ef',
-      defaults = { if_true = macros('DFLT_ERRORFILE', 'string') },
+      defaults = macros('DFLT_ERRORFILE', 'string'),
       desc = [=[
         Name of the errorfile for the QuickFix mode (see |:cf|).
         When the "-q" command-line argument is used, 'errorfile' is set to the
@@ -2597,7 +2597,7 @@ return {
     {
       abbreviation = 'ei',
       cb = 'did_set_eventignore',
-      defaults = { if_true = '' },
+      defaults = '',
       deny_duplicates = true,
       desc = [=[
         A list of autocommand event names, which are to be ignored.
@@ -2617,7 +2617,7 @@ return {
     },
     {
       abbreviation = 'et',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         In Insert mode: Use the appropriate number of spaces to insert a
         <Tab>.  Spaces are used in indents with the '>' and '<' commands and
@@ -2632,7 +2632,7 @@ return {
     },
     {
       abbreviation = 'ex',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Automatically execute .nvim.lua, .nvimrc, and .exrc files in the
         current directory, if the file is in the |trust| list. Use |:trust| to
@@ -2655,7 +2655,7 @@ return {
     {
       abbreviation = 'fenc',
       cb = 'did_set_encoding',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         File-content encoding for the current buffer. Conversion is done with
         iconv() or as specified with 'charconvert'.
@@ -2707,7 +2707,7 @@ return {
     },
     {
       abbreviation = 'fencs',
-      defaults = { if_true = 'ucs-bom,utf-8,default,latin1' },
+      defaults = 'ucs-bom,utf-8,default,latin1',
       deny_duplicates = true,
       desc = [=[
         This is a list of character encodings considered when starting to edit
@@ -2887,7 +2887,7 @@ return {
     {
       abbreviation = 'ft',
       cb = 'did_set_filetype_or_syntax',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         When this option is set, the FileType autocommand event is triggered.
         All autocommands that match with the value of this option will be
@@ -2922,7 +2922,7 @@ return {
     {
       abbreviation = 'fcs',
       cb = 'did_set_chars_option',
-      defaults = { if_true = '' },
+      defaults = '',
       deny_duplicates = true,
       desc = [=[
         Characters to fill the statuslines, vertical separators and special
@@ -2997,7 +2997,7 @@ return {
     {
       abbreviation = 'ffu',
       cb = 'did_set_findfunc',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         Function that is called to obtain the filename(s) for the |:find|
         command.  When this option is empty, the internal |file-searching|
@@ -3057,7 +3057,7 @@ return {
     {
       abbreviation = 'fixeol',
       cb = 'did_set_eof_eol_fixeol_bomb',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When writing a file and this option is on, <EOL> at the end of file
         will be restored if missing.  Turn this option off if you want to
@@ -3076,7 +3076,7 @@ return {
     },
     {
       abbreviation = 'fcl',
-      defaults = { if_true = '' },
+      defaults = '',
       values = { 'all' },
       deny_duplicates = true,
       desc = [=[
@@ -3094,7 +3094,7 @@ return {
     },
     {
       abbreviation = 'fdc',
-      defaults = { if_true = '0' },
+      defaults = '0',
       values = {
         'auto',
         'auto:1',
@@ -3134,7 +3134,7 @@ return {
     },
     {
       abbreviation = 'fen',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When off, all folds are open.  This option can be used to quickly
         switch between showing all text unfolded and viewing the text with
@@ -3153,7 +3153,7 @@ return {
     {
       abbreviation = 'fde',
       cb = 'did_set_foldexpr',
-      defaults = { if_true = '0' },
+      defaults = '0',
       desc = [=[
         The expression used for when 'foldmethod' is "expr".  It is evaluated
         for each line to obtain its fold level.  The context is set to the
@@ -3178,7 +3178,7 @@ return {
     {
       abbreviation = 'fdi',
       cb = 'did_set_foldignore',
-      defaults = { if_true = '#' },
+      defaults = '#',
       desc = [=[
         Used only when 'foldmethod' is "indent".  Lines starting with
         characters in 'foldignore' will get their fold level from surrounding
@@ -3194,7 +3194,7 @@ return {
     {
       abbreviation = 'fdl',
       cb = 'did_set_foldlevel',
-      defaults = { if_true = 0 },
+      defaults = 0,
       desc = [=[
         Sets the fold level: Folds with a higher level will be closed.
         Setting this option to zero will close all folds.  Higher numbers will
@@ -3210,7 +3210,7 @@ return {
     },
     {
       abbreviation = 'fdls',
-      defaults = { if_true = -1 },
+      defaults = -1,
       desc = [=[
         Sets 'foldlevel' when starting to edit another buffer in a window.
         Useful to always start editing with all folds closed (value zero),
@@ -3232,7 +3232,7 @@ return {
     {
       abbreviation = 'fmr',
       cb = 'did_set_foldmarker',
-      defaults = { if_true = '{{{,}}}' },
+      defaults = '{{{,}}}',
       deny_duplicates = true,
       desc = [=[
         The start and end marker used when 'foldmethod' is "marker".  There
@@ -3251,7 +3251,7 @@ return {
     {
       abbreviation = 'fdm',
       cb = 'did_set_foldmethod',
-      defaults = { if_true = 'manual' },
+      defaults = 'manual',
       values = { 'manual', 'expr', 'marker', 'indent', 'syntax', 'diff' },
       desc = [=[
         The kind of folding used for the current window.  Possible values:
@@ -3271,7 +3271,7 @@ return {
     {
       abbreviation = 'fml',
       cb = 'did_set_foldminlines',
-      defaults = { if_true = 1 },
+      defaults = 1,
       desc = [=[
         Sets the number of screen lines above which a fold can be displayed
         closed.  Also for manually closed folds.  With the default value of
@@ -3290,7 +3290,7 @@ return {
     {
       abbreviation = 'fdn',
       cb = 'did_set_foldnestmax',
-      defaults = { if_true = 20 },
+      defaults = 20,
       desc = [=[
         Sets the maximum nesting of folds for the "indent" and "syntax"
         methods.  This avoids that too many folds will be created.  Using more
@@ -3304,7 +3304,7 @@ return {
     },
     {
       abbreviation = 'fdo',
-      defaults = { if_true = 'block,hor,mark,percent,quickfix,search,tag,undo' },
+      defaults = 'block,hor,mark,percent,quickfix,search,tag,undo',
       values = {
         'all',
         'block',
@@ -3364,7 +3364,7 @@ return {
     {
       abbreviation = 'fdt',
       cb = 'did_set_optexpr',
-      defaults = { if_true = 'foldtext()' },
+      defaults = 'foldtext()',
       desc = [=[
         An expression which is used to specify the text displayed for a closed
         fold.  The context is set to the script where 'foldexpr' was set,
@@ -3391,7 +3391,7 @@ return {
     {
       abbreviation = 'fex',
       cb = 'did_set_optexpr',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         Expression which is evaluated to format a range of lines for the |gq|
         operator or automatic formatting (see 'formatoptions').  When this
@@ -3443,7 +3443,7 @@ return {
     },
     {
       abbreviation = 'flp',
-      defaults = { if_true = '^\\s*\\d\\+[\\]:.)}\\t ]\\s*' },
+      defaults = '^\\s*\\d\\+[\\]:.)}\\t ]\\s*',
       desc = [=[
         A pattern that is used to recognize a list header.  This is used for
         the "n" flag in 'formatoptions'.
@@ -3464,7 +3464,7 @@ return {
     {
       abbreviation = 'fo',
       cb = 'did_set_formatoptions',
-      defaults = { if_true = macros('DFLT_FO_VIM', 'string') },
+      defaults = macros('DFLT_FO_VIM', 'string'),
       desc = [=[
         This is a sequence of letters which describes how automatic
         formatting is to be done.
@@ -3483,7 +3483,7 @@ return {
     },
     {
       abbreviation = 'fp',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         The name of an external program that will be used to format the lines
         selected with the |gq| operator.  The program must take the input on
@@ -3507,7 +3507,7 @@ return {
     },
     {
       abbreviation = 'fs',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When on, the OS function fsync() will be called after saving a file
         (|:write|, |writefile()|, …), |swap-file|, |undo-persistence| and |shada-file|.
@@ -3533,7 +3533,7 @@ return {
     },
     {
       abbreviation = 'gd',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When on, the ":substitute" flag 'g' is default on.  This means that
         all matches in a line are substituted instead of one.  When a 'g' flag
@@ -3557,7 +3557,7 @@ return {
     },
     {
       abbreviation = 'gfm',
-      defaults = { if_true = macros('DFLT_GREPFORMAT', 'string') },
+      defaults = macros('DFLT_GREPFORMAT', 'string'),
       deny_duplicates = true,
       desc = [=[
         Format to recognize for the ":grep" command output.
@@ -3616,9 +3616,7 @@ return {
     {
       abbreviation = 'gcr',
       cb = 'did_set_guicursor',
-      defaults = {
-        if_true = 'n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20,t:block-blinkon500-blinkoff500-TermCursor',
-      },
+      defaults = 'n-v-c-sm:block,i-ci-ve:ver25,r-cr-o:hor20,t:block-blinkon500-blinkoff500-TermCursor',
       deny_duplicates = true,
       desc = [=[
         Configures the cursor style for each mode. Works in the GUI and many
@@ -3717,7 +3715,7 @@ return {
     },
     {
       abbreviation = 'gfn',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         This is a list of fonts which will be used for the GUI version of Vim.
         In its simplest form the value is just one font name.  When
@@ -3789,7 +3787,7 @@ return {
     },
     {
       abbreviation = 'gfw',
-      defaults = { if_true = '' },
+      defaults = '',
       deny_duplicates = true,
       desc = [=[
         Comma-separated list of fonts to be used for double-width characters.
@@ -3925,7 +3923,7 @@ return {
     },
     {
       abbreviation = 'gtl',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         When non-empty describes the text to use in a label of the GUI tab
         pages line.  When empty and when the result is empty Vim will use a
@@ -3951,7 +3949,7 @@ return {
     },
     {
       abbreviation = 'gtt',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         When non-empty describes the text to use in a tooltip for the GUI tab
         pages line.  When empty Vim will use a default tooltip.
@@ -3997,7 +3995,7 @@ return {
     {
       abbreviation = 'hh',
       cb = 'did_set_helpheight',
-      defaults = { if_true = 20 },
+      defaults = 20,
       desc = [=[
         Minimal initial height of the help window when it is opened with the
         ":help" command.  The initial height of the help window is half of the
@@ -4042,7 +4040,7 @@ return {
     },
     {
       abbreviation = 'hid',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When off a buffer is unloaded (including loss of undo information)
         when it is |abandon|ed.  When on a buffer becomes hidden when it is
@@ -4068,7 +4066,7 @@ return {
     {
       abbreviation = 'hl',
       cb = 'did_set_highlight',
-      defaults = { if_true = macros('HIGHLIGHT_INIT', 'string') },
+      defaults = macros('HIGHLIGHT_INIT', 'string'),
       deny_duplicates = true,
       full_name = 'highlight',
       list = 'onecomma',
@@ -4079,7 +4077,7 @@ return {
     },
     {
       abbreviation = 'hi',
-      defaults = { if_true = 10000 },
+      defaults = 10000,
       desc = [=[
         A history of ":" commands, and a history of previous search patterns
         is remembered.  This option decides how many entries may be stored in
@@ -4095,7 +4093,7 @@ return {
     },
     {
       abbreviation = 'hk',
-      defaults = { if_true = false },
+      defaults = false,
       full_name = 'hkmap',
       scope = { 'global' },
       short_desc = N_('No description'),
@@ -4104,7 +4102,7 @@ return {
     },
     {
       abbreviation = 'hkp',
-      defaults = { if_true = false },
+      defaults = false,
       full_name = 'hkmapp',
       scope = { 'global' },
       short_desc = N_('No description'),
@@ -4114,7 +4112,7 @@ return {
     {
       abbreviation = 'hls',
       cb = 'did_set_hlsearch',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When there is a previous search pattern, highlight all its matches.
         The |hl-Search| highlight group determines the highlighting for all
@@ -4164,7 +4162,7 @@ return {
     },
     {
       cb = 'did_set_iconstring',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         When this option is not empty, it will be used for the icon text of
         the window.  This happens only when the 'icon' option is on.
@@ -4184,7 +4182,7 @@ return {
     {
       abbreviation = 'ic',
       cb = 'did_set_ignorecase',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Ignore case in search patterns, |cmdline-completion|, when
         searching in the tags file, and |expr-==|.
@@ -4200,7 +4198,7 @@ return {
     },
     {
       abbreviation = 'imc',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When set the Input Method is always on when starting to edit a command
         line, unless entering a search pattern (see 'imsearch' for that).
@@ -4235,7 +4233,7 @@ return {
     {
       abbreviation = 'imi',
       cb = 'did_set_iminsert',
-      defaults = { if_true = macros('B_IMODE_NONE', 'number') },
+      defaults = macros('B_IMODE_NONE', 'number'),
       desc = [=[
         Specifies whether :lmap or an Input Method (IM) is to be used in
         Insert mode.  Valid values:
@@ -4260,7 +4258,7 @@ return {
     },
     {
       abbreviation = 'ims',
-      defaults = { if_true = macros('B_IMODE_USE_INSERT', 'number') },
+      defaults = macros('B_IMODE_USE_INSERT', 'number'),
       desc = [=[
         Specifies whether :lmap or an Input Method (IM) is to be used when
         entering a search pattern.  Valid values:
@@ -4283,7 +4281,7 @@ return {
     {
       abbreviation = 'icm',
       cb = 'did_set_inccommand',
-      defaults = { if_true = 'nosplit' },
+      defaults = 'nosplit',
       values = { 'nosplit', 'split', '' },
       desc = [=[
         When nonempty, shows the effects of |:substitute|, |:smagic|,
@@ -4308,7 +4306,7 @@ return {
     },
     {
       abbreviation = 'inc',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         Pattern to be used to find an include command.  It is a search
         pattern, just like for the "/" command (See |pattern|).  This option
@@ -4330,7 +4328,7 @@ return {
     {
       abbreviation = 'inex',
       cb = 'did_set_optexpr',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         Expression to be used to transform the string found with the 'include'
         option to a file name.  Mostly useful to change "." to "/" for Java: >vim
@@ -4371,7 +4369,7 @@ return {
     },
     {
       abbreviation = 'is',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         While typing a search command, show where the pattern, as it was typed
         so far, matches.  The matched string is highlighted.  If the pattern
@@ -4414,7 +4412,7 @@ return {
     {
       abbreviation = 'inde',
       cb = 'did_set_optexpr',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         Expression which is evaluated to obtain the proper indent for a line.
         It is used when a new line is created, for the |=| operator and
@@ -4466,7 +4464,7 @@ return {
     },
     {
       abbreviation = 'indk',
-      defaults = { if_true = '0{,0},0),0],:,0#,!^F,o,O,e' },
+      defaults = '0{,0},0),0],:,0#,!^F,o,O,e',
       deny_duplicates = true,
       desc = [=[
         A list of keys that, when typed in Insert mode, cause reindenting of
@@ -4483,7 +4481,7 @@ return {
     },
     {
       abbreviation = 'inf',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When doing keyword completion in insert mode |ins-completion|, and
         'ignorecase' is also on, the case of the match is adjusted depending
@@ -4502,7 +4500,7 @@ return {
     },
     {
       abbreviation = 'im',
-      defaults = { if_true = false },
+      defaults = false,
       full_name = 'insertmode',
       scope = { 'global' },
       short_desc = N_('No description'),
@@ -4608,7 +4606,7 @@ return {
     {
       abbreviation = 'isk',
       cb = 'did_set_iskeyword',
-      defaults = { if_true = '@,48-57,_,192-255' },
+      defaults = '@,48-57,_,192-255',
       deny_duplicates = true,
       desc = [=[
         Keywords are used in searching and recognizing with many commands:
@@ -4634,7 +4632,7 @@ return {
     {
       abbreviation = 'isp',
       cb = 'did_set_isopt',
-      defaults = { if_true = '@,161-255' },
+      defaults = '@,161-255',
       deny_duplicates = true,
       desc = [=[
         The characters given by this option are displayed directly on the
@@ -4674,7 +4672,7 @@ return {
     },
     {
       abbreviation = 'js',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Insert two spaces after a '.', '?' and '!' with a join command.
         Otherwise only one space is inserted.
@@ -4687,7 +4685,7 @@ return {
     },
     {
       abbreviation = 'jop',
-      defaults = { if_true = 'clean' },
+      defaults = 'clean',
       values = { 'stack', 'view', 'clean' },
       flags = true,
       deny_duplicates = true,
@@ -4717,7 +4715,7 @@ return {
     {
       abbreviation = 'kmp',
       cb = 'did_set_keymap',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         Name of a keyboard mapping.  See |mbyte-keymap|.
         Setting this option to a valid keymap name has the side effect of
@@ -4737,7 +4735,7 @@ return {
     {
       abbreviation = 'km',
       cb = 'did_set_keymodel',
-      defaults = { if_true = '' },
+      defaults = '',
       values = { 'startsel', 'stopsel' },
       deny_duplicates = true,
       desc = [=[
@@ -4790,7 +4788,7 @@ return {
     {
       abbreviation = 'lmap',
       cb = 'did_set_langmap',
-      defaults = { if_true = '' },
+      defaults = '',
       deny_duplicates = true,
       desc = [=[
         This option allows switching your keyboard into a special language
@@ -4844,7 +4842,7 @@ return {
     },
     {
       abbreviation = 'lm',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         Language to use for menu translation.  Tells which file is loaded
         from the "lang" directory in 'runtimepath': >vim
@@ -4875,7 +4873,7 @@ return {
     {
       abbreviation = 'lnr',
       cb = 'did_set_langnoremap',
-      defaults = { if_true = true },
+      defaults = true,
       full_name = 'langnoremap',
       scope = { 'global' },
       short_desc = N_("do not apply 'langmap' to mapped characters"),
@@ -4885,7 +4883,7 @@ return {
     {
       abbreviation = 'lrm',
       cb = 'did_set_langremap',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When off, setting 'langmap' does not apply to characters resulting from
         a mapping.  If setting 'langmap' disables some of your mappings, make
@@ -4900,7 +4898,7 @@ return {
     {
       abbreviation = 'ls',
       cb = 'did_set_laststatus',
-      defaults = { if_true = 2 },
+      defaults = 2,
       desc = [=[
         The value of this option influences when the last window will have a
         status line:
@@ -4920,7 +4918,7 @@ return {
     },
     {
       abbreviation = 'lz',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When this option is set, the screen will not be redrawn while
         executing macros, registers and other commands that have not been
@@ -4938,7 +4936,7 @@ return {
     },
     {
       abbreviation = 'lbr',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         If on, Vim will wrap long lines at a character in 'breakat' rather
         than at the last character that fits on the screen.  Unlike
@@ -4984,7 +4982,7 @@ return {
     },
     {
       abbreviation = 'lsp',
-      defaults = { if_true = 0 },
+      defaults = 0,
       desc = [=[
         		only in the GUI
         Number of pixel lines inserted between characters.  Useful if the font
@@ -5004,7 +5002,7 @@ return {
     },
     {
       cb = 'did_set_lisp',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Lisp mode: When <Enter> is typed in insert mode set the indent for
         the next line to Lisp standards (well, sort of).  Also happens with
@@ -5024,7 +5022,7 @@ return {
     {
       abbreviation = 'lop',
       cb = 'did_set_lispoptions',
-      defaults = { if_true = '' },
+      defaults = '',
       values = { 'expr:0', 'expr:1' },
       deny_duplicates = true,
       desc = [=[
@@ -5062,7 +5060,7 @@ return {
       varname = 'p_lispwords',
     },
     {
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         List mode: By default, show tabs as ">", trailing spaces as "-", and
         non-breakable space characters as "+". Useful to see the difference
@@ -5090,7 +5088,7 @@ return {
     {
       abbreviation = 'lcs',
       cb = 'did_set_chars_option',
-      defaults = { if_true = 'tab:> ,trail:-,nbsp:+' },
+      defaults = 'tab:> ,trail:-,nbsp:+',
       deny_duplicates = true,
       desc = [=[
         Strings to use in 'list' mode and for the |:list| command.  It is a
@@ -5201,7 +5199,7 @@ return {
     },
     {
       abbreviation = 'lpl',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When on the plugin scripts are loaded when starting up |load-plugins|.
         This option can be reset in your |vimrc| file to disable the loading
@@ -5216,7 +5214,7 @@ return {
       varname = 'p_lpl',
     },
     {
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         Changes the special characters that can be used in search patterns.
         See |pattern|.
@@ -5234,7 +5232,7 @@ return {
     },
     {
       abbreviation = 'mef',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         Name of the errorfile for the |:make| command (see |:make_makeprg|)
         and the |:grep| command.
@@ -5259,7 +5257,7 @@ return {
     {
       abbreviation = 'menc',
       cb = 'did_set_encoding',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         Encoding used for reading the output of external commands.  When empty,
         encoding is not converted.
@@ -5282,7 +5280,7 @@ return {
     },
     {
       abbreviation = 'mp',
-      defaults = { if_true = 'make' },
+      defaults = 'make',
       desc = [=[
         Program to use for the ":make" command.  See |:make_makeprg|.
         This option may contain '%' and '#' characters (see  |:_%| and |:_#|),
@@ -5311,7 +5309,7 @@ return {
     {
       abbreviation = 'mps',
       cb = 'did_set_matchpairs',
-      defaults = { if_true = '(:),{:},[:]' },
+      defaults = '(:),{:},[:]',
       deny_duplicates = true,
       desc = [=[
         Characters that form pairs.  The |%| command jumps from one to the
@@ -5339,7 +5337,7 @@ return {
     },
     {
       abbreviation = 'mat',
-      defaults = { if_true = 5 },
+      defaults = 5,
       desc = [=[
         Tenths of a second to show the matching paren, when 'showmatch' is
         set.  Note that this is not in milliseconds, like other options that
@@ -5353,7 +5351,7 @@ return {
     },
     {
       abbreviation = 'mco',
-      defaults = { if_true = macros('MAX_MCO', 'number') },
+      defaults = macros('MAX_MCO', 'number'),
       full_name = 'maxcombine',
       scope = { 'global' },
       short_desc = N_('maximum nr of combining characters displayed'),
@@ -5362,7 +5360,7 @@ return {
     },
     {
       abbreviation = 'mfd',
-      defaults = { if_true = 100 },
+      defaults = 100,
       desc = [=[
         Maximum depth of function calls for user functions.  This normally
         catches endless recursion.  When using a recursive function with
@@ -5381,7 +5379,7 @@ return {
     },
     {
       abbreviation = 'mmd',
-      defaults = { if_true = 1000 },
+      defaults = 1000,
       desc = [=[
         Maximum number of times a mapping is done without resulting in a
         character to be used.  This normally catches endless mappings, like
@@ -5398,7 +5396,7 @@ return {
     },
     {
       abbreviation = 'mmp',
-      defaults = { if_true = 1000 },
+      defaults = 1000,
       desc = [=[
         Maximum amount of memory (in Kbyte) to use for pattern matching.
         The maximum value is about 2000000.  Use this to work without a limit.
@@ -5421,7 +5419,7 @@ return {
     },
     {
       abbreviation = 'mis',
-      defaults = { if_true = 25 },
+      defaults = 25,
       desc = [=[
         Maximum number of items to use in a menu.  Used for menus that are
         generated from a list of items, e.g., the Buffers menu.  Changing this
@@ -5436,7 +5434,7 @@ return {
     {
       abbreviation = 'mopt',
       cb = 'did_set_messagesopt',
-      defaults = { if_true = 'hit-enter,history:500' },
+      defaults = 'hit-enter,history:500',
       values = { 'hit-enter', 'wait:', 'history:' },
       flags = true,
       deny_duplicates = true,
@@ -5470,7 +5468,7 @@ return {
     {
       abbreviation = 'msm',
       cb = 'did_set_mkspellmem',
-      defaults = { if_true = '460000,2000,500' },
+      defaults = '460000,2000,500',
       desc = [=[
         Parameters for |:mkspell|.  This tunes when to start compressing the
         word tree.  Compression can be slow when there are many words, but
@@ -5535,7 +5533,7 @@ return {
     },
     {
       abbreviation = 'mle',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When on allow some options that are an expression to be set in the
         modeline.  Check the option for whether it is affected by
@@ -5552,7 +5550,7 @@ return {
     },
     {
       abbreviation = 'mls',
-      defaults = { if_true = 5 },
+      defaults = 5,
       desc = [=[
         If 'modeline' is on 'modelines' gives the number of lines that is
         checked for set commands.  If 'modeline' is off or 'modelines' is zero
@@ -5568,7 +5566,7 @@ return {
     {
       abbreviation = 'ma',
       cb = 'did_set_modifiable',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When off the buffer contents cannot be changed.  The 'fileformat' and
         'fileencoding' options also can't be changed.
@@ -5585,7 +5583,7 @@ return {
     {
       abbreviation = 'mod',
       cb = 'did_set_modified',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When on, the buffer is considered to be modified.  This option is set
         when:
@@ -5618,7 +5616,7 @@ return {
       varname = 'p_mod',
     },
     {
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When on, listings pause when the whole screen is filled.  You will get
         the |more-prompt|.  When this option is off there are no pauses, the
@@ -5632,7 +5630,7 @@ return {
     },
     {
       cb = 'did_set_mouse',
-      defaults = { if_true = 'nvi' },
+      defaults = 'nvi',
       desc = [=[
         Enables mouse support. For example, to enable the mouse in Normal mode
         and Visual mode: >vim
@@ -5681,7 +5679,7 @@ return {
     },
     {
       abbreviation = 'mousef',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         The window that the mouse pointer is on is automatically activated.
         When changing the window layout or window focus in another way, the
@@ -5698,7 +5696,7 @@ return {
     },
     {
       abbreviation = 'mh',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         		only in the GUI
         When on, the mouse pointer is hidden when characters are typed.
@@ -5713,7 +5711,7 @@ return {
     },
     {
       abbreviation = 'mousem',
-      defaults = { if_true = 'popup_setpos' },
+      defaults = 'popup_setpos',
       values = { 'extend', 'popup', 'popup_setpos' },
       desc = [=[
         Sets the model to use for the mouse.  The name mostly specifies what
@@ -5772,7 +5770,7 @@ return {
     },
     {
       abbreviation = 'mousemev',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When on, mouse move events are delivered to the input queue and are
         available for mapping. The default, off, avoids the mouse movement
@@ -5789,7 +5787,7 @@ return {
     },
     {
       cb = 'did_set_mousescroll',
-      defaults = { if_true = 'ver:3,hor:6' },
+      defaults = 'ver:3,hor:6',
       values = { 'hor:', 'ver:' },
       desc = [=[
         This option controls the number of lines / columns to scroll by when
@@ -5897,7 +5895,7 @@ return {
     },
     {
       abbreviation = 'mouset',
-      defaults = { if_true = 500 },
+      defaults = 500,
       desc = [=[
         Defines the maximum time in msec between two mouse clicks for the
         second click to be recognized as a multi click.
@@ -5910,7 +5908,7 @@ return {
     },
     {
       abbreviation = 'nf',
-      defaults = { if_true = 'bin,hex' },
+      defaults = 'bin,hex',
       values = { 'bin', 'octal', 'hex', 'alpha', 'unsigned', 'blank' },
       deny_duplicates = true,
       desc = [=[
@@ -5965,7 +5963,7 @@ return {
     {
       abbreviation = 'nu',
       cb = 'did_set_number_relativenumber',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Print the line number in front of each line.  When the 'n' option is
         excluded from 'cpoptions' a wrapped line will not use the column of
@@ -5998,7 +5996,7 @@ return {
     {
       abbreviation = 'nuw',
       cb = 'did_set_numberwidth',
-      defaults = { if_true = 4 },
+      defaults = 4,
       desc = [=[
         Minimal number of columns to use for the line number.  Only relevant
         when the 'number' or 'relativenumber' option is set or printing lines
@@ -6020,7 +6018,7 @@ return {
     {
       abbreviation = 'ofu',
       cb = 'did_set_omnifunc',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         This option specifies a function to be used for Insert mode omni
         completion with CTRL-X CTRL-O. |i_CTRL-X_CTRL-O|
@@ -6043,7 +6041,7 @@ return {
     },
     {
       abbreviation = 'odev',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         		only for Windows
         Enable reading and writing from devices.  This may get Vim stuck on a
@@ -6061,7 +6059,7 @@ return {
     {
       abbreviation = 'opfunc',
       cb = 'did_set_operatorfunc',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         This option specifies a function to be called by the |g@| operator.
         See |:map-operator| for more info and an example.  The value can be
@@ -6105,7 +6103,7 @@ return {
     },
     {
       abbreviation = 'para',
-      defaults = { if_true = 'IPLPPPQPP TPHPLIPpLpItpplpipbp' },
+      defaults = 'IPLPPPQPP TPHPLIPpLpItpplpipbp',
       desc = [=[
         Specifies the nroff macros that separate paragraphs.  These are pairs
         of two letters (see |object-motions|).
@@ -6118,7 +6116,7 @@ return {
     },
     {
       cb = 'did_set_paste',
-      defaults = { if_true = false },
+      defaults = false,
       full_name = 'paste',
       pri_mkrc = true,
       scope = { 'global' },
@@ -6128,7 +6126,7 @@ return {
     },
     {
       abbreviation = 'pt',
-      defaults = { if_true = '' },
+      defaults = '',
       full_name = 'pastetoggle',
       scope = { 'global' },
       short_desc = N_('No description'),
@@ -6138,7 +6136,7 @@ return {
     {
       abbreviation = 'pex',
       cb = 'did_set_optexpr',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         Expression which is evaluated to apply a patch to a file and generate
         the resulting new version of the file.  See |diff-patchexpr|.
@@ -6155,7 +6153,7 @@ return {
     {
       abbreviation = 'pm',
       cb = 'did_set_backupext_or_patchmode',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         When non-empty the oldest version of a file is kept.  This can be used
         to keep the original version of a file if you are changing files in a
@@ -6184,7 +6182,7 @@ return {
     },
     {
       abbreviation = 'pa',
-      defaults = { if_true = '.,,' },
+      defaults = '.,,',
       deny_duplicates = true,
       desc = [=[
         This is a list of directories which will be searched when using the
@@ -6246,7 +6244,7 @@ return {
     },
     {
       abbreviation = 'pi',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When changing the indent of the current line, preserve as much of the
         indent structure as possible.  Normally the indent is replaced by a
@@ -6269,7 +6267,7 @@ return {
     },
     {
       abbreviation = 'pvh',
-      defaults = { if_true = 12 },
+      defaults = 12,
       desc = [=[
         Default height for a preview window.  Used for |:ptag| and associated
         commands.  Used for |CTRL-W_}| when no count is given.
@@ -6283,7 +6281,7 @@ return {
     {
       abbreviation = 'pvw',
       cb = 'did_set_previewwindow',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Identifies the preview window.  Only one window can have this option
         set.  It's normally not set directly, but by using one of the commands
@@ -6298,7 +6296,7 @@ return {
       type = 'boolean',
     },
     {
-      defaults = { if_true = true },
+      defaults = true,
       full_name = 'prompt',
       scope = { 'global' },
       short_desc = N_('enable prompt in Ex mode'),
@@ -6308,7 +6306,7 @@ return {
     {
       abbreviation = 'pb',
       cb = 'did_set_pumblend',
-      defaults = { if_true = 0 },
+      defaults = 0,
       desc = [=[
         Enables pseudo-transparency for the |popup-menu|. Valid values are in
         the range of 0 for fully opaque popupmenu (disabled) to 100 for fully
@@ -6332,7 +6330,7 @@ return {
     },
     {
       abbreviation = 'ph',
-      defaults = { if_true = 0 },
+      defaults = 0,
       desc = [=[
         Maximum number of items to show in the popup menu
         (|ins-completion-menu|). Zero means "use available screen space".
@@ -6345,7 +6343,7 @@ return {
     },
     {
       abbreviation = 'pw',
-      defaults = { if_true = 15 },
+      defaults = 15,
       desc = [=[
         Minimum width for the popup menu (|ins-completion-menu|).  If the
         cursor column + 'pumwidth' exceeds screen width, the popup menu is
@@ -6359,7 +6357,7 @@ return {
     },
     {
       abbreviation = 'pyx',
-      defaults = { if_true = 3 },
+      defaults = 3,
       desc = [=[
         Specifies the python version used for pyx* functions and commands
         |python_x|.  As only Python 3 is supported, this always has the value
@@ -6378,7 +6376,7 @@ return {
     {
       abbreviation = 'qftf',
       cb = 'did_set_quickfixtextfunc',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         This option specifies a function to be used to get the text to display
         in the quickfix and location list windows.  This can be used to
@@ -6402,7 +6400,7 @@ return {
     },
     {
       abbreviation = 'qe',
-      defaults = { if_true = '\\' },
+      defaults = '\\',
       desc = [=[
         The characters that are used to escape quotes in a string.  Used for
         objects like a', a" and a` |a'|.
@@ -6419,7 +6417,7 @@ return {
     {
       abbreviation = 'ro',
       cb = 'did_set_readonly',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         If on, writes fail unless you use a '!'.  Protects you from
         accidentally overwriting a file.  Default on when Vim is started
@@ -6440,7 +6438,7 @@ return {
     },
     {
       abbreviation = 'rdb',
-      defaults = { if_true = '' },
+      defaults = '',
       values = {
         'compositor',
         'nothrottle',
@@ -6492,7 +6490,7 @@ return {
     },
     {
       abbreviation = 'rdt',
-      defaults = { if_true = 2000 },
+      defaults = 2000,
       desc = [=[
         Time in milliseconds for redrawing the display.  Applies to
         'hlsearch', 'inccommand', |:match| highlighting, syntax highlighting,
@@ -6512,7 +6510,7 @@ return {
     },
     {
       abbreviation = 're',
-      defaults = { if_true = 0 },
+      defaults = 0,
       desc = [=[
         This selects the default regexp engine. |two-engines|
         The possible values are:
@@ -6536,7 +6534,7 @@ return {
     {
       abbreviation = 'rnu',
       cb = 'did_set_number_relativenumber',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Show the line number relative to the line with the cursor in front of
         each line. Relative line numbers help you use the |count| you can
@@ -6563,7 +6561,7 @@ return {
       type = 'boolean',
     },
     {
-      defaults = { if_true = true },
+      defaults = true,
       full_name = 'remap',
       scope = { 'global' },
       short_desc = N_('No description'),
@@ -6571,7 +6569,7 @@ return {
       immutable = true,
     },
     {
-      defaults = { if_true = 2 },
+      defaults = 2,
       desc = [=[
         Threshold for reporting number of lines changed.  When the number of
         changed lines is more than 'report' a message will be given for most
@@ -6587,7 +6585,7 @@ return {
     },
     {
       abbreviation = 'ri',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Inserting characters in Insert mode will work backwards.  See "typing
         backwards" |ins-reverse|.  This option can be toggled with the CTRL-_
@@ -6601,7 +6599,7 @@ return {
     },
     {
       abbreviation = 'rl',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When on, display orientation becomes right-to-left, i.e., characters
         that are stored in the file appear from the right to the left.
@@ -6621,7 +6619,7 @@ return {
     },
     {
       abbreviation = 'rlc',
-      defaults = { if_true = 'search' },
+      defaults = 'search',
       values = { 'search' },
       desc = [=[
         Each word in this option enables the command line editing to work in
@@ -6641,7 +6639,7 @@ return {
     },
     {
       abbreviation = 'ru',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         Show the line and column number of the cursor position, separated by a
         comma.  When there is room, the relative position of the displayed
@@ -6676,7 +6674,7 @@ return {
     {
       abbreviation = 'ruf',
       cb = 'did_set_rulerformat',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         When this option is not empty, it determines the content of the ruler
         string, as displayed for the 'ruler' option.
@@ -6848,7 +6846,7 @@ return {
     {
       abbreviation = 'scb',
       cb = 'did_set_scrollbind',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         See also |scroll-binding|.  When this option is set, scrolling the
         current window also scrolls other scrollbind windows (windows that
@@ -6867,7 +6865,7 @@ return {
     },
     {
       abbreviation = 'sj',
-      defaults = { if_true = 1 },
+      defaults = 1,
       desc = [=[
         Minimal number of lines to scroll when the cursor gets off the
         screen (e.g., with "j").  Not used for scroll commands (e.g., CTRL-E,
@@ -6884,7 +6882,7 @@ return {
     },
     {
       abbreviation = 'so',
-      defaults = { if_true = 0 },
+      defaults = 0,
       desc = [=[
         Minimal number of screen lines to keep above and below the cursor.
         This will make some context visible around where you are working.  If
@@ -6905,7 +6903,7 @@ return {
     },
     {
       abbreviation = 'sbo',
-      defaults = { if_true = 'ver,jump' },
+      defaults = 'ver,jump',
       values = { 'ver', 'hor', 'jump' },
       deny_duplicates = true,
       desc = [=[
@@ -6946,7 +6944,7 @@ return {
     },
     {
       abbreviation = 'sect',
-      defaults = { if_true = 'SHNHH HUnhsh' },
+      defaults = 'SHNHH HUnhsh',
       desc = [=[
         Specifies the nroff macros that separate sections.  These are pairs of
         two letters (See |object-motions|).  The default makes a section start
@@ -6959,7 +6957,7 @@ return {
       varname = 'p_sections',
     },
     {
-      defaults = { if_true = false },
+      defaults = false,
       full_name = 'secure',
       scope = { 'global' },
       secure = true,
@@ -6970,7 +6968,7 @@ return {
     {
       abbreviation = 'sel',
       cb = 'did_set_selection',
-      defaults = { if_true = 'inclusive' },
+      defaults = 'inclusive',
       values = { 'inclusive', 'exclusive', 'old' },
       desc = [=[
         This option defines the behavior of the selection.  It is only used
@@ -7001,7 +6999,7 @@ return {
     },
     {
       abbreviation = 'slm',
-      defaults = { if_true = '' },
+      defaults = '',
       values = { 'mouse', 'key', 'cmd' },
       deny_duplicates = true,
       desc = [=[
@@ -7023,7 +7021,7 @@ return {
     {
       abbreviation = 'ssop',
       cb = 'did_set_sessionoptions',
-      defaults = { if_true = 'blank,buffers,curdir,folds,help,tabpages,winsize,terminal' },
+      defaults = 'blank,buffers,curdir,folds,help,tabpages,winsize,terminal',
       -- Also used for 'viewoptions'.
       values = {
         'buffers',
@@ -7229,7 +7227,7 @@ return {
     {
       abbreviation = 'sdf',
       alias = { 'vif', 'viminfofile' },
-      defaults = { if_true = '' },
+      defaults = '',
       deny_duplicates = true,
       desc = [=[
         When non-empty, overrides the file name used for |shada| (viminfo).
@@ -7483,7 +7481,7 @@ return {
     },
     {
       abbreviation = 'stmp',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When on, use temp files for shell commands.  When off use a pipe.
         When using a pipe is not possible temp files are used anyway.
@@ -7504,7 +7502,7 @@ return {
     },
     {
       abbreviation = 'sxe',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         When 'shellxquote' is set to "(" then the characters listed in this
         option will be escaped with a '^' character.  This makes it possible
@@ -7547,7 +7545,7 @@ return {
     },
     {
       abbreviation = 'sr',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Round indent to multiple of 'shiftwidth'.  Applies to > and <
         commands.  CTRL-T and CTRL-D in Insert mode always round the indent to
@@ -7562,7 +7560,7 @@ return {
     {
       abbreviation = 'sw',
       cb = 'did_set_shiftwidth_tabstop',
-      defaults = { if_true = 8 },
+      defaults = 8,
       desc = [=[
         Number of spaces to use for each step of (auto)indent.  Used for
         |'cindent'|, |>>|, |<<|, etc.
@@ -7578,7 +7576,7 @@ return {
     {
       abbreviation = 'shm',
       cb = 'did_set_shortmess',
-      defaults = { if_true = 'ltToOCF' },
+      defaults = 'ltToOCF',
       desc = [=[
         This option helps to avoid all the |hit-enter| prompts caused by file
         messages, for example with CTRL-G, and to avoid some other messages.
@@ -7648,7 +7646,7 @@ return {
     {
       abbreviation = 'sbr',
       cb = 'did_set_showbreak',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         String to put at the start of lines that have been wrapped.  Useful
         values are "> " or "+++ ": >vim
@@ -7676,7 +7674,7 @@ return {
     },
     {
       abbreviation = 'sc',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         Show (partial) command in the last line of the screen.  Set this
         option off if your terminal is slow.
@@ -7699,7 +7697,7 @@ return {
     {
       abbreviation = 'sloc',
       cb = 'did_set_showcmdloc',
-      defaults = { if_true = 'last' },
+      defaults = 'last',
       values = { 'last', 'statusline', 'tabline' },
       desc = [=[
         This option can be used to display the (partially) entered command in
@@ -7722,7 +7720,7 @@ return {
     },
     {
       abbreviation = 'sft',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When completing a word in insert mode (see |ins-completion|) from the
         tags file, show both the tag name and a tidied-up form of the search
@@ -7741,7 +7739,7 @@ return {
     },
     {
       abbreviation = 'sm',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When a bracket is inserted, briefly jump to the matching one.  The
         jump is only done if the match can be seen on the screen.  The time to
@@ -7767,7 +7765,7 @@ return {
     },
     {
       abbreviation = 'smd',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         If in Insert, Replace or Visual mode put a message on the last line.
         The |hl-ModeMsg| highlight group determines the highlighting.
@@ -7782,7 +7780,7 @@ return {
     {
       abbreviation = 'stal',
       cb = 'did_set_showtabline',
-      defaults = { if_true = 1 },
+      defaults = 1,
       desc = [=[
         The value of this option specifies when the line with tab page labels
         will be displayed:
@@ -7802,7 +7800,7 @@ return {
     },
     {
       abbreviation = 'ss',
-      defaults = { if_true = 1 },
+      defaults = 1,
       desc = [=[
         The minimal number of columns to scroll horizontally.  Used only when
         the 'wrap' option is off and the cursor is moved off of the screen.
@@ -7818,7 +7816,7 @@ return {
     },
     {
       abbreviation = 'siso',
-      defaults = { if_true = 0 },
+      defaults = 0,
       desc = [=[
         The minimal number of screen columns to keep to the left and to the
         right of the cursor if 'nowrap' is set.  Setting this option to a
@@ -7850,7 +7848,7 @@ return {
     {
       abbreviation = 'scl',
       cb = 'did_set_signcolumn',
-      defaults = { if_true = 'auto' },
+      defaults = 'auto',
       values = {
         'yes',
         'no',
@@ -7901,7 +7899,7 @@ return {
     },
     {
       abbreviation = 'scs',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Override the 'ignorecase' option if the search pattern contains upper
         case characters.  Only used when the search pattern is typed and
@@ -7918,7 +7916,7 @@ return {
     },
     {
       abbreviation = 'si',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Do smart autoindenting when starting a new line.  Works for C-like
         programs, but can also be used for other languages.  'cindent' does
@@ -7948,7 +7946,7 @@ return {
     },
     {
       abbreviation = 'sta',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When on, a <Tab> in front of a line inserts blanks according to
         'shiftwidth'.  'tabstop' or 'softtabstop' is used in other places.  A
@@ -7970,7 +7968,7 @@ return {
     {
       abbreviation = 'sms',
       cb = 'did_set_smoothscroll',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Scrolling works with screen lines.  When 'wrap' is set and the first
         line in the window wraps part of it may not be visible, as if it is
@@ -7988,7 +7986,7 @@ return {
     },
     {
       abbreviation = 'sts',
-      defaults = { if_true = 0 },
+      defaults = 0,
       desc = [=[
         Number of spaces that a <Tab> counts for while performing editing
         operations, like inserting a <Tab> or using <BS>.  It "feels" like
@@ -8014,7 +8012,7 @@ return {
     },
     {
       cb = 'did_set_spell',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When on spell checking will be done.  See |spell|.
         The languages are specified with 'spelllang'.
@@ -8028,7 +8026,7 @@ return {
     {
       abbreviation = 'spc',
       cb = 'did_set_spellcapcheck',
-      defaults = { if_true = '[.?!]\\_[\\])\'"\\t ]\\+' },
+      defaults = '[.?!]\\_[\\])\'"\\t ]\\+',
       desc = [=[
         Pattern to locate the end of a sentence.  The following word will be
         checked to start with a capital letter.  If not then it is highlighted
@@ -8050,7 +8048,7 @@ return {
     {
       abbreviation = 'spf',
       cb = 'did_set_spellfile',
-      defaults = { if_true = '' },
+      defaults = '',
       deny_duplicates = true,
       desc = [=[
         Name of the word list file where words are added for the |zg| and |zw|
@@ -8087,7 +8085,7 @@ return {
     {
       abbreviation = 'spl',
       cb = 'did_set_spelllang',
-      defaults = { if_true = 'en' },
+      defaults = 'en',
       deny_duplicates = true,
       desc = [=[
         A comma-separated list of word list names.  When the 'spell' option is
@@ -8139,7 +8137,7 @@ return {
     {
       abbreviation = 'spo',
       cb = 'did_set_spelloptions',
-      defaults = { if_true = '' },
+      defaults = '',
       values = { 'camel', 'noplainbuffer' },
       flags = true,
       deny_duplicates = true,
@@ -8165,7 +8163,7 @@ return {
     {
       abbreviation = 'sps',
       cb = 'did_set_spellsuggest',
-      defaults = { if_true = 'best' },
+      defaults = 'best',
       -- Keep this in sync with spell_check_sps().
       values = { 'best', 'fast', 'double', 'expr:', 'file:', 'timeout:' },
       deny_duplicates = true,
@@ -8247,7 +8245,7 @@ return {
     },
     {
       abbreviation = 'sb',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When on, splitting a window will put the new window below the current
         one. |:split|
@@ -8260,7 +8258,7 @@ return {
     },
     {
       abbreviation = 'spk',
-      defaults = { if_true = 'cursor' },
+      defaults = 'cursor',
       values = { 'cursor', 'screen', 'topline' },
       desc = [=[
         The value of this option determines the scroll behavior when opening,
@@ -8284,7 +8282,7 @@ return {
     },
     {
       abbreviation = 'spr',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When on, splitting a window will put the new window right of the
         current one. |:vsplit|
@@ -8297,7 +8295,7 @@ return {
     },
     {
       abbreviation = 'sol',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When "on" the commands listed below move the cursor to the first
         non-blank of the line.  When off the cursor is kept in the same column
@@ -8321,7 +8319,7 @@ return {
     {
       abbreviation = 'stc',
       cb = 'did_set_statuscolumn',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         When non-empty, this option determines the content of the area to the
         side of a window, normally containing the fold, sign and number columns.
@@ -8386,7 +8384,7 @@ return {
     {
       abbreviation = 'stl',
       cb = 'did_set_statusline',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         When non-empty, this option determines the content of the status line.
         Also see |status-line|.
@@ -8611,7 +8609,7 @@ return {
     },
     {
       abbreviation = 'su',
-      defaults = { if_true = '.bak,~,.o,.h,.info,.swp,.obj' },
+      defaults = '.bak,~,.o,.h,.info,.swp,.obj',
       deny_duplicates = true,
       desc = [=[
         Files with these suffixes get a lower priority when multiple files
@@ -8634,7 +8632,7 @@ return {
     },
     {
       abbreviation = 'sua',
-      defaults = { if_true = '' },
+      defaults = '',
       deny_duplicates = true,
       desc = [=[
         Comma-separated list of suffixes, which are used when searching for a
@@ -8652,7 +8650,7 @@ return {
     {
       abbreviation = 'swf',
       cb = 'did_set_swapfile',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         Use a swapfile for the buffer.  This option can be reset when a
         swapfile is not wanted for a specific buffer.  For example, with
@@ -8682,7 +8680,7 @@ return {
     },
     {
       abbreviation = 'swb',
-      defaults = { if_true = 'uselast' },
+      defaults = 'uselast',
       values = { 'useopen', 'usetab', 'split', 'newtab', 'vsplit', 'uselast' },
       flags = true,
       deny_duplicates = true,
@@ -8725,7 +8723,7 @@ return {
     },
     {
       abbreviation = 'smc',
-      defaults = { if_true = 3000 },
+      defaults = 3000,
       desc = [=[
         Maximum column in which to search for syntax items.  In long lines the
         text after this column is not highlighted and following lines may not
@@ -8744,7 +8742,7 @@ return {
     {
       abbreviation = 'syn',
       cb = 'did_set_filetype_or_syntax',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         When this option is set, the syntax with this name is loaded, unless
         syntax highlighting has been switched off with ":syntax off".
@@ -8780,7 +8778,7 @@ return {
     },
     {
       abbreviation = 'tcl',
-      defaults = { if_true = '' },
+      defaults = '',
       values = { 'left', 'uselast' },
       flags = true,
       deny_duplicates = true,
@@ -8806,7 +8804,7 @@ return {
     {
       abbreviation = 'tal',
       cb = 'did_set_tabline',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         When non-empty, this option determines the content of the tab pages
         line at the top of the Vim window.  When empty Vim will use a default
@@ -8839,7 +8837,7 @@ return {
     },
     {
       abbreviation = 'tpm',
-      defaults = { if_true = 50 },
+      defaults = 50,
       desc = [=[
         Maximum number of tab pages to be opened by the |-p| command line
         argument or the ":tab all" command. |tabpage|
@@ -8853,7 +8851,7 @@ return {
     {
       abbreviation = 'ts',
       cb = 'did_set_shiftwidth_tabstop',
-      defaults = { if_true = 8 },
+      defaults = 8,
       desc = [=[
         Number of spaces that a <Tab> in the file counts for.  Also see
         the |:retab| command, and the 'softtabstop' option.
@@ -8904,7 +8902,7 @@ return {
     },
     {
       abbreviation = 'tbs',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When searching for a tag (e.g., for the |:ta| command), Vim can either
         use a binary search or a linear search in a tags file.  Binary
@@ -8964,7 +8962,7 @@ return {
     {
       abbreviation = 'tc',
       cb = 'did_set_tagcase',
-      defaults = { if_true = 'followic' },
+      defaults = 'followic',
       values = { 'followic', 'ignore', 'match', 'followscs', 'smart' },
       flags = true,
       desc = [=[
@@ -8986,7 +8984,7 @@ return {
     {
       abbreviation = 'tfu',
       cb = 'did_set_tagfunc',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         This option specifies a function to be used to perform tag searches.
         The function gets the tag pattern and should return a List of matching
@@ -9007,7 +9005,7 @@ return {
     },
     {
       abbreviation = 'tl',
-      defaults = { if_true = 0 },
+      defaults = 0,
       desc = [=[
         If non-zero, tags are significant up to this number of characters.
       ]=],
@@ -9019,7 +9017,7 @@ return {
     },
     {
       abbreviation = 'tr',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         If on and using a tags file in another directory, file names in that
         tags file are relative to the directory where the tags file is.
@@ -9032,7 +9030,7 @@ return {
     },
     {
       abbreviation = 'tag',
-      defaults = { if_true = './tags;,tags' },
+      defaults = './tags;,tags',
       deny_duplicates = true,
       desc = [=[
         Filenames for the tag command, separated by spaces or commas.  To
@@ -9064,7 +9062,7 @@ return {
     },
     {
       abbreviation = 'tgst',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When on, the |tagstack| is used normally.  When off, a ":tag" or
         ":tselect" command with an argument will not push the tag onto the
@@ -9082,7 +9080,7 @@ return {
     },
     {
       abbreviation = 'tbidi',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         The terminal is in charge of Bi-directionality of text (as specified
         by Unicode).  The terminal is also expected to do the required shaping
@@ -9101,7 +9099,7 @@ return {
     },
     {
       abbreviation = 'tenc',
-      defaults = { if_true = '' },
+      defaults = '',
       full_name = 'termencoding',
       scope = { 'global' },
       short_desc = N_('Terminal encoding'),
@@ -9110,7 +9108,7 @@ return {
     },
     {
       abbreviation = 'tgc',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Enables 24-bit RGB color in the |TUI|.  Uses "gui" |:highlight|
         attributes instead of "cterm" attributes. |guifg|
@@ -9129,7 +9127,7 @@ return {
     },
     {
       abbreviation = 'tpf',
-      defaults = { if_true = 'BS,HT,ESC,DEL' },
+      defaults = 'BS,HT,ESC,DEL',
       values = { 'BS', 'HT', 'FF', 'ESC', 'DEL', 'C0', 'C1' },
       flags = true,
       deny_duplicates = true,
@@ -9161,7 +9159,7 @@ return {
       flags_varname = 'tpf_flags',
     },
     {
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         If the host terminal supports it, buffer all screen updates
         made during a redraw cycle so that each screen is displayed in
@@ -9176,7 +9174,7 @@ return {
       varname = 'p_termsync',
     },
     {
-      defaults = { if_true = false },
+      defaults = false,
       full_name = 'terse',
       scope = { 'global' },
       short_desc = N_('No description'),
@@ -9186,7 +9184,7 @@ return {
     {
       abbreviation = 'tw',
       cb = 'did_set_textwidth',
-      defaults = { if_true = 0 },
+      defaults = 0,
       desc = [=[
         Maximum width of text that is being inserted.  A longer line will be
         broken after white space to get this width.  A zero value disables
@@ -9204,7 +9202,7 @@ return {
     },
     {
       abbreviation = 'tsr',
-      defaults = { if_true = '' },
+      defaults = '',
       deny_duplicates = true,
       desc = [=[
         List of file names, separated by commas, that are used to lookup words
@@ -9234,7 +9232,7 @@ return {
     {
       abbreviation = 'tsrfu',
       cb = 'did_set_thesaurusfunc',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         This option specifies a function to be used for thesaurus completion
         with CTRL-X CTRL-T. |i_CTRL-X_CTRL-T| See |compl-thesaurusfunc|.
@@ -9254,7 +9252,7 @@ return {
     },
     {
       abbreviation = 'top',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When on: The tilde command "~" behaves like an operator.
       ]=],
@@ -9266,7 +9264,7 @@ return {
     },
     {
       abbreviation = 'to',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         This option and 'timeoutlen' determine the behavior when part of a
         mapped key sequence has been received. For example, if <c-f> is
@@ -9281,7 +9279,7 @@ return {
     },
     {
       abbreviation = 'tm',
-      defaults = { if_true = 1000 },
+      defaults = 1000,
       desc = [=[
         Time in milliseconds to wait for a mapped sequence to complete.
       ]=],
@@ -9293,7 +9291,7 @@ return {
     },
     {
       cb = 'did_set_title_icon',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When on, the title of the window will be set to the value of
         'titlestring' (if it is not empty), or to:
@@ -9315,7 +9313,7 @@ return {
     },
     {
       cb = 'did_set_titlelen',
-      defaults = { if_true = 85 },
+      defaults = 85,
       desc = [=[
         Gives the percentage of 'columns' to use for the length of the window
         title.  When the title is longer, only the end of the path name is
@@ -9334,7 +9332,7 @@ return {
       varname = 'p_titlelen',
     },
     {
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         If not empty, this option will be used to set the window title when
         exiting.  Only if 'title' is enabled.
@@ -9351,7 +9349,7 @@ return {
     },
     {
       cb = 'did_set_titlestring',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         When this option is not empty, it will be used for the title of the
         window.  This happens only when the 'title' option is on.
@@ -9387,7 +9385,7 @@ return {
       varname = 'p_titlestring',
     },
     {
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         This option and 'ttimeoutlen' determine the behavior when part of a
         key code sequence has been received by the |TUI|.
@@ -9410,7 +9408,7 @@ return {
     },
     {
       abbreviation = 'ttm',
-      defaults = { if_true = 50 },
+      defaults = 50,
       desc = [=[
         Time in milliseconds to wait for a key code sequence to complete. Also
         used for CTRL-\ CTRL-N and CTRL-\ CTRL-G when part of a command has
@@ -9425,7 +9423,7 @@ return {
     },
     {
       abbreviation = 'tf',
-      defaults = { if_true = true },
+      defaults = true,
       full_name = 'ttyfast',
       no_mkrc = true,
       scope = { 'global' },
@@ -9435,7 +9433,7 @@ return {
     },
     {
       abbreviation = 'udir',
-      defaults = { if_true = '' },
+      defaults = '',
       deny_duplicates = true,
       desc = [=[
         List of directory names for undo files, separated with commas.
@@ -9472,7 +9470,7 @@ return {
     {
       abbreviation = 'udf',
       cb = 'did_set_undofile',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When on, Vim automatically saves undo history to an undo file when
         writing a buffer to a file, and restores undo history from the same
@@ -9492,7 +9490,7 @@ return {
     {
       abbreviation = 'ul',
       cb = 'did_set_undolevels',
-      defaults = { if_true = 1000 },
+      defaults = 1000,
       desc = [=[
         Maximum number of changes that can be undone.  Since undo information
         is kept in memory, higher numbers will cause more memory to be used.
@@ -9520,7 +9518,7 @@ return {
     },
     {
       abbreviation = 'ur',
-      defaults = { if_true = 10000 },
+      defaults = 10000,
       desc = [=[
         Save the whole buffer for undo when reloading it.  This applies to the
         ":e!" command and reloading for when the buffer changed outside of
@@ -9543,7 +9541,7 @@ return {
     {
       abbreviation = 'uc',
       cb = 'did_set_updatecount',
-      defaults = { if_true = 200 },
+      defaults = 200,
       desc = [=[
         After typing this many characters the swap file will be written to
         disk.  When zero, no swap file will be created at all (see chapter on
@@ -9565,7 +9563,7 @@ return {
     },
     {
       abbreviation = 'ut',
-      defaults = { if_true = 4000 },
+      defaults = 4000,
       desc = [=[
         If this many milliseconds nothing is typed the swap file will be
         written to disk (see |crash-recovery|).  Also used for the
@@ -9580,7 +9578,7 @@ return {
     {
       abbreviation = 'vsts',
       cb = 'did_set_varsofttabstop',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         A list of the number of spaces that a <Tab> counts for while editing,
         such as inserting a <Tab> or using <BS>.  It "feels" like variable-
@@ -9608,7 +9606,7 @@ return {
     {
       abbreviation = 'vts',
       cb = 'did_set_vartabstop',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         A list of the number of spaces that a <Tab> in the file counts for,
         separated by commas.  Each value corresponds to one tab, with the
@@ -9630,7 +9628,7 @@ return {
     },
     {
       abbreviation = 'vbs',
-      defaults = { if_true = 0 },
+      defaults = 0,
       desc = [=[
         Sets the verbosity level.  Also set by |-V| and |:verbose|.
 
@@ -9669,7 +9667,7 @@ return {
     {
       abbreviation = 'vfile',
       cb = 'did_set_verbosefile',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         When not empty all messages are written in a file with this name.
         When the file exists messages are appended.
@@ -9691,7 +9689,7 @@ return {
     },
     {
       abbreviation = 'vdir',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         Name of the directory where to store files for |:mkview|.
         This option cannot be set from a |modeline| or in the |sandbox|, for
@@ -9708,7 +9706,7 @@ return {
     {
       abbreviation = 'vop',
       cb = 'did_set_str_generic',
-      defaults = { if_true = 'folds,cursor,curdir' },
+      defaults = 'folds,cursor,curdir',
       flags = true,
       deny_duplicates = true,
       desc = [=[
@@ -9737,7 +9735,7 @@ return {
     {
       abbreviation = 've',
       cb = 'did_set_virtualedit',
-      defaults = { if_true = '' },
+      defaults = '',
       values = { 'block', 'insert', 'all', 'onemore', 'none', 'NONE' },
       flags = {
         Block = 5,
@@ -9787,7 +9785,7 @@ return {
     },
     {
       abbreviation = 'vb',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Use visual bell instead of beeping.  Also see 'errorbells'.
       ]=],
@@ -9798,7 +9796,7 @@ return {
       varname = 'p_vb',
     },
     {
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         Give a warning message when a shell command is used while the buffer
         has been changed.
@@ -9812,7 +9810,7 @@ return {
     {
       abbreviation = 'ww',
       cb = 'did_set_whichwrap',
-      defaults = { if_true = 'b,s' },
+      defaults = 'b,s',
       desc = [=[
         Allow specified keys that move the cursor left/right to move to the
         previous/next line when the cursor is on the first/last character in
@@ -9883,7 +9881,7 @@ return {
     {
       abbreviation = 'wcm',
       cb = 'did_set_wildchar',
-      defaults = { if_true = 0 },
+      defaults = 0,
       desc = [=[
         'wildcharm' works exactly like 'wildchar', except that it is
         recognized when used inside a macro.  You can find "spare" command-line
@@ -9902,7 +9900,7 @@ return {
     },
     {
       abbreviation = 'wig',
-      defaults = { if_true = '' },
+      defaults = '',
       deny_duplicates = true,
       desc = [=[
         A list of file patterns.  A file that matches with one of these
@@ -9926,7 +9924,7 @@ return {
     },
     {
       abbreviation = 'wic',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         When set case is ignored when completing file names and directories.
         Has no effect when 'fileignorecase' is set.
@@ -9941,7 +9939,7 @@ return {
     },
     {
       abbreviation = 'wmnu',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         When 'wildmenu' is on, command-line completion operates in an enhanced
         mode.  On pressing 'wildchar' (usually <Tab>) to invoke completion,
@@ -9990,7 +9988,7 @@ return {
     {
       abbreviation = 'wim',
       cb = 'did_set_wildmode',
-      defaults = { if_true = 'full' },
+      defaults = 'full',
       -- Keep this in sync with check_opt_wim().
       values = { 'full', 'longest', 'list', 'lastused' },
       flags = true,
@@ -10049,7 +10047,7 @@ return {
     },
     {
       abbreviation = 'wop',
-      defaults = { if_true = 'pum,tagfile' },
+      defaults = 'pum,tagfile',
       values = { 'fuzzy', 'tagfile', 'pum' },
       flags = true,
       deny_duplicates = true,
@@ -10082,7 +10080,7 @@ return {
     },
     {
       abbreviation = 'wak',
-      defaults = { if_true = 'menu' },
+      defaults = 'menu',
       values = { 'yes', 'menu', 'no' },
       desc = [=[
         		only used in Win32
@@ -10110,7 +10108,7 @@ return {
     {
       abbreviation = 'wbr',
       cb = 'did_set_winbar',
-      defaults = { if_true = '' },
+      defaults = '',
       desc = [=[
         When non-empty, this option enables the window bar and determines its
         contents. The window bar is a bar that's shown at the top of every
@@ -10137,7 +10135,7 @@ return {
     {
       abbreviation = 'winbl',
       cb = 'did_set_winblend',
-      defaults = { if_true = 0 },
+      defaults = 0,
       desc = [=[
         Enables pseudo-transparency for a floating window. Valid values are in
         the range of 0 for fully opaque window (disabled) to 100 for fully
@@ -10177,7 +10175,7 @@ return {
     },
     {
       abbreviation = 'wfb',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         If enabled, the window and the buffer it is displaying are paired.
         For example, attempting to change the buffer with |:edit| will fail.
@@ -10192,7 +10190,7 @@ return {
     },
     {
       abbreviation = 'wfh',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Keep the window height when windows are opened or closed and
         'equalalways' is set.  Also for |CTRL-W_=|.  Set by default for the
@@ -10207,7 +10205,7 @@ return {
     },
     {
       abbreviation = 'wfw',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Keep the window width when windows are opened or closed and
         'equalalways' is set.  Also for |CTRL-W_=|.
@@ -10222,7 +10220,7 @@ return {
     {
       abbreviation = 'wh',
       cb = 'did_set_winheight',
-      defaults = { if_true = 1 },
+      defaults = 1,
       desc = [=[
         Minimal number of lines for the current window.  This is not a hard
         minimum, Vim will use fewer lines if there is not enough room.  If the
@@ -10251,7 +10249,7 @@ return {
     {
       abbreviation = 'winhl',
       cb = 'did_set_winhighlight',
-      defaults = { if_true = '' },
+      defaults = '',
       deny_duplicates = true,
       desc = [=[
         Window-local highlights.  Comma-delimited list of highlight
@@ -10283,7 +10281,7 @@ return {
     {
       abbreviation = 'wmh',
       cb = 'did_set_winminheight',
-      defaults = { if_true = 1 },
+      defaults = 1,
       desc = [=[
         The minimal height of a window, when it's not the current window.
         This is a hard minimum, windows will never become smaller.
@@ -10304,7 +10302,7 @@ return {
     {
       abbreviation = 'wmw',
       cb = 'did_set_winminwidth',
-      defaults = { if_true = 1 },
+      defaults = 1,
       desc = [=[
         The minimal width of a window, when it's not the current window.
         This is a hard minimum, windows will never become smaller.
@@ -10326,7 +10324,7 @@ return {
     {
       abbreviation = 'wiw',
       cb = 'did_set_winwidth',
-      defaults = { if_true = 20 },
+      defaults = 20,
       desc = [=[
         Minimal number of columns for the current window.  This is not a hard
         minimum, Vim will use fewer columns if there is not enough room.  If
@@ -10347,7 +10345,7 @@ return {
     },
     {
       cb = 'did_set_wrap',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         This option changes how text is displayed.  It doesn't change the text
         in the buffer, see 'textwidth' for that.
@@ -10373,7 +10371,7 @@ return {
     },
     {
       abbreviation = 'wm',
-      defaults = { if_true = 0 },
+      defaults = 0,
       desc = [=[
         Number of characters from the right window border where wrapping
         starts.  When typing text beyond this limit, an <EOL> will be inserted
@@ -10391,7 +10389,7 @@ return {
     },
     {
       abbreviation = 'ws',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         Searches wrap around the end of the file.  Also applies to |]s| and
         |[s|, searching for spelling mistakes.
@@ -10404,7 +10402,7 @@ return {
       varname = 'p_ws',
     },
     {
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         Allows writing files.  When not set, writing a file is not allowed.
         Can be used for a view-only mode, where modifications to the text are
@@ -10420,7 +10418,7 @@ return {
     },
     {
       abbreviation = 'wa',
-      defaults = { if_true = false },
+      defaults = false,
       desc = [=[
         Allows writing to any file with no need for "!" override.
       ]=],
@@ -10432,7 +10430,7 @@ return {
     },
     {
       abbreviation = 'wb',
-      defaults = { if_true = true },
+      defaults = true,
       desc = [=[
         Make a backup before overwriting a file.  The backup is removed after
         the file was successfully written, unless the 'backup' option is
@@ -10455,7 +10453,7 @@ return {
     },
     {
       abbreviation = 'wd',
-      defaults = { if_true = 0 },
+      defaults = 0,
       desc = [=[
         Only takes effect together with 'redrawdebug'.
         The number of milliseconds to wait after each line or each flush
@@ -10468,3 +10466,29 @@ return {
     },
   },
 }
+
+--- @param o vim.option_meta
+local function preprocess(o)
+  if o.values then
+    o.cb = o.cb or 'did_set_str_generic'
+    o.expand_cb = o.expand_cb or 'expand_set_str_generic'
+  end
+
+  if type(o.alias) == 'string' then
+    o.alias = {
+      o.alias --[[@as string]],
+    }
+  end
+
+  if type(o.defaults) ~= 'table' then
+    o.defaults = {
+      if_true = o.defaults --[[@as string|boolean|number ]],
+    }
+  end
+end
+
+for _, o in ipairs(options.options) do
+  preprocess(o)
+end
+
+return options

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7,6 +7,7 @@
 --- @field alias? string|string[]
 --- @field short_desc? string|fun(): string
 --- @field varname? string
+--- @field flags_varname? string
 --- @field type vim.option_type
 --- @field immutable? boolean
 --- @field list? 'comma'|'onecomma'|'commacolon'|'onecommacolon'|'flags'|'flagscomma'
@@ -29,7 +30,11 @@
 --- @field no_mkrc? true
 --- @field alloced? true
 --- @field redraw? vim.option_redraw[]
+---
+--- If not provided and `values` is present, then is set to 'did_set_str_generic'
 --- @field cb? string
+---
+--- If not provided and `values` is present, then is set to 'expand_set_str_generic'
 --- @field expand_cb? string
 --- @field tags? string[]
 
@@ -148,7 +153,6 @@ return {
         set to one of CJK locales.  See Unicode Standard Annex #11
         (https://www.unicode.org/reports/tr11).
       ]=],
-      expand_cb = 'expand_set_ambiwidth',
       full_name = 'ambiwidth',
       redraw = { 'all_windows', 'ui_option' },
       scope = { 'global' },
@@ -335,7 +339,6 @@ return {
         will change.  To use other settings, place ":highlight" commands AFTER
         the setting of the 'background' option.
       ]=],
-      expand_cb = 'expand_set_background',
       full_name = 'background',
       scope = { 'global' },
       short_desc = N_('"dark" or "light", used for highlight colors'),
@@ -363,7 +366,6 @@ return {
         When the value is empty, Vi compatible backspacing is used, none of
         the ways mentioned for the items above are possible.
       ]=],
-      expand_cb = 'expand_set_backspace',
       full_name = 'backspace',
       list = 'onecomma',
       scope = { 'global' },
@@ -463,13 +465,13 @@ return {
         the system may refuse to do this.  In that case the "auto" value will
         again not rename the file.
       ]=],
-      expand_cb = 'expand_set_backupcopy',
       full_name = 'backupcopy',
       list = 'onecomma',
       scope = { 'global', 'buf' },
       short_desc = N_("make backup as a copy, don't rename the file"),
       type = 'string',
       varname = 'p_bkc',
+      flags_varname = 'bkc_flags',
     },
     {
       abbreviation = 'bdir',
@@ -593,7 +595,6 @@ return {
     },
     {
       abbreviation = 'bo',
-      cb = 'did_set_belloff',
       defaults = { if_true = 'all' },
       values = {
         'all',
@@ -657,13 +658,13 @@ return {
         indicate that an error occurred. It can be silenced by adding the
         "error" keyword.
       ]=],
-      expand_cb = 'expand_set_belloff',
       full_name = 'belloff',
       list = 'comma',
       scope = { 'global' },
       short_desc = N_('do not ring the bell for these reasons'),
       type = 'string',
       varname = 'p_bo',
+      flags_varname = 'bo_flags',
     },
     {
       abbreviation = 'bin',
@@ -802,7 +803,6 @@ return {
         		    added for the 'showbreak' setting.
         		    (default: off)
       ]=],
-      expand_cb = 'expand_set_breakindentopt',
       full_name = 'breakindentopt',
       list = 'onecomma',
       redraw = { 'current_buffer' },
@@ -856,7 +856,6 @@ return {
         This option is used together with 'buftype' and 'swapfile' to specify
         special kinds of buffers.   See |special-buffers|.
       ]=],
-      expand_cb = 'expand_set_bufhidden',
       full_name = 'bufhidden',
       noglob = true,
       scope = { 'buf' },
@@ -943,7 +942,6 @@ return {
         without saving.  For writing there must be matching |BufWriteCmd|,
         |FileWriteCmd| or |FileAppendCmd| autocommands.
       ]=],
-      expand_cb = 'expand_set_buftype',
       full_name = 'buftype',
       noglob = true,
       scope = { 'buf' },
@@ -954,7 +952,6 @@ return {
     },
     {
       abbreviation = 'cmp',
-      cb = 'did_set_casemap',
       defaults = { if_true = 'internal,keepascii' },
       values = { 'internal', 'keepascii' },
       flags = true,
@@ -970,13 +967,13 @@ return {
         		case mapping, the current locale is not effective.
         		This probably only matters for Turkish.
       ]=],
-      expand_cb = 'expand_set_casemap',
       full_name = 'casemap',
       list = 'onecomma',
       scope = { 'global' },
       short_desc = N_('specifies how case of letters is changed'),
       type = 'string',
       varname = 'p_cmp',
+      flags_varname = 'cmp_flags',
     },
     {
       abbreviation = 'cdh',
@@ -1220,7 +1217,6 @@ return {
     },
     {
       abbreviation = 'cb',
-      cb = 'did_set_clipboard',
       defaults = { if_true = '' },
       values = { 'unnamed', 'unnamedplus' },
       flags = true,
@@ -1249,13 +1245,13 @@ return {
         		"*". See |clipboard|.
       ]=],
       deny_duplicates = true,
-      expand_cb = 'expand_set_clipboard',
       full_name = 'clipboard',
       list = 'onecomma',
       scope = { 'global' },
       short_desc = N_('use the clipboard as the unnamed register'),
       type = 'string',
       varname = 'p_cb',
+      flags_varname = 'cb_flags',
     },
     {
       abbreviation = 'ch',
@@ -1433,7 +1429,6 @@ return {
         based expansion (e.g., dictionary |i_CTRL-X_CTRL-K|, included patterns
         |i_CTRL-X_CTRL-I|, tags |i_CTRL-X_CTRL-]| and normal expansions).
       ]=],
-      expand_cb = 'expand_set_complete',
       full_name = 'complete',
       list = 'onecomma',
       scope = { 'buf' },
@@ -1543,13 +1538,13 @@ return {
         	    list of alternatives, but not how the candidates are
         	    collected (using different completion types).
       ]=],
-      expand_cb = 'expand_set_completeopt',
       full_name = 'completeopt',
       list = 'onecomma',
       scope = { 'global', 'buf' },
       short_desc = N_('options for Insert mode completion'),
       type = 'string',
       varname = 'p_cot',
+      flags_varname = 'cot_flags',
     },
     {
       abbreviation = 'csl',
@@ -1570,7 +1565,6 @@ return {
         command line completion the global value is used.
       ]=],
       enable_if = 'BACKSLASH_IN_FILENAME',
-      expand_cb = 'expand_set_completeslash',
       full_name = 'completeslash',
       scope = { 'buf' },
       type = 'string',
@@ -1994,7 +1988,6 @@ return {
 
         "line" and "screenline" cannot be used together.
       ]=],
-      expand_cb = 'expand_set_cursorlineopt',
       full_name = 'cursorlineopt',
       list = 'onecomma',
       redraw = { 'current_window', 'highlight_only' },
@@ -2003,7 +1996,6 @@ return {
       type = 'string',
     },
     {
-      cb = 'did_set_debug',
       defaults = { if_true = '' },
       values = { 'msg', 'throw', 'beep' },
       desc = [=[
@@ -2019,7 +2011,6 @@ return {
         'indentexpr'.
       ]=],
       -- TODO(lewis6991): bug, values currently cannot be combined
-      expand_cb = 'expand_set_debug',
       full_name = 'debug',
       list = 'comma',
       scope = { 'global' },
@@ -2384,7 +2375,6 @@ return {
         The "@" character can be changed by setting the "lastline" item in
         'fillchars'.  The character is highlighted with |hl-NonText|.
       ]=],
-      expand_cb = 'expand_set_display',
       full_name = 'display',
       list = 'onecomma',
       redraw = { 'all_windows' },
@@ -2392,10 +2382,10 @@ return {
       short_desc = N_('list of flags for how to display text'),
       type = 'string',
       varname = 'p_dy',
+      flags_varname = 'dy_flags',
     },
     {
       abbreviation = 'ead',
-      cb = 'did_set_eadirection',
       defaults = { if_true = 'both' },
       values = { 'both', 'ver', 'hor' },
       desc = [=[
@@ -2404,7 +2394,6 @@ return {
         	hor	horizontally, height of windows is not affected
         	both	width and height of windows is affected
       ]=],
-      expand_cb = 'expand_set_eadirection',
       full_name = 'eadirection',
       scope = { 'global' },
       short_desc = N_("in which direction 'equalalways' works"),
@@ -2422,7 +2411,7 @@ return {
     },
     {
       abbreviation = 'emo',
-      cb = 'did_set_ambiwidth',
+      cb = 'did_set_emoji',
       defaults = { if_true = true },
       desc = [=[
         When on all Unicode emoji characters are considered to be full width.
@@ -2803,7 +2792,6 @@ return {
         option is set, because the file would be different when written.
         This option cannot be changed when 'modifiable' is off.
       ]=],
-      expand_cb = 'expand_set_fileformat',
       full_name = 'fileformat',
       no_mkrc = true,
       redraw = { 'curswant', 'statuslines' },
@@ -2814,7 +2802,7 @@ return {
     },
     {
       abbreviation = 'ffs',
-      cb = 'did_set_fileformats',
+      cb = 'did_set_str_generic',
       defaults = {
         condition = 'USE_CRNL',
         if_true = 'dos,unix',
@@ -2869,7 +2857,7 @@ return {
           used.
         Also see |file-formats|.
       ]=],
-      expand_cb = 'expand_set_fileformat',
+      expand_cb = 'expand_set_str_generic',
       full_name = 'fileformats',
       list = 'onecomma',
       scope = { 'global' },
@@ -3088,7 +3076,6 @@ return {
     },
     {
       abbreviation = 'fcl',
-      cb = 'did_set_foldclose',
       defaults = { if_true = '' },
       values = { 'all' },
       deny_duplicates = true,
@@ -3097,7 +3084,6 @@ return {
         its level is higher than 'foldlevel'.  Useful if you want folds to
         automatically close when moving out of them.
       ]=],
-      expand_cb = 'expand_set_foldclose',
       full_name = 'foldclose',
       list = 'onecomma',
       redraw = { 'current_window' },
@@ -3108,7 +3094,6 @@ return {
     },
     {
       abbreviation = 'fdc',
-      cb = 'did_set_foldcolumn',
       defaults = { if_true = '0' },
       values = {
         'auto',
@@ -3141,7 +3126,6 @@ return {
             "[1-9]":      to display a fixed number of columns
         See |folding|.
       ]=],
-      expand_cb = 'expand_set_foldcolumn',
       full_name = 'foldcolumn',
       redraw = { 'current_window' },
       scope = { 'win' },
@@ -3278,7 +3262,6 @@ return {
         |fold-syntax|	syntax	    Syntax highlighting items specify folds.
         |fold-diff|	diff	    Fold text that is not changed.
       ]=],
-      expand_cb = 'expand_set_foldmethod',
       full_name = 'foldmethod',
       redraw = { 'current_window' },
       scope = { 'win' },
@@ -3321,7 +3304,6 @@ return {
     },
     {
       abbreviation = 'fdo',
-      cb = 'did_set_foldopen',
       defaults = { if_true = 'block,hor,mark,percent,quickfix,search,tag,undo' },
       values = {
         'all',
@@ -3370,7 +3352,6 @@ return {
         To close folds you can re-apply 'foldlevel' with the |zx| command or
         set the 'foldclose' option to "all".
       ]=],
-      expand_cb = 'expand_set_foldopen',
       full_name = 'foldopen',
       list = 'onecomma',
       redraw = { 'curswant' },
@@ -3378,6 +3359,7 @@ return {
       short_desc = N_('for which commands a fold will be opened'),
       type = 'string',
       varname = 'p_fdo',
+      flags_varname = 'fdo_flags',
     },
     {
       abbreviation = 'fdt',
@@ -4318,7 +4300,6 @@ return {
         'redrawtime') then 'inccommand' is automatically disabled until
         |Command-line-mode| is done.
       ]=],
-      expand_cb = 'expand_set_inccommand',
       full_name = 'inccommand',
       scope = { 'global' },
       short_desc = N_('Live preview of substitution'),
@@ -4706,7 +4687,6 @@ return {
     },
     {
       abbreviation = 'jop',
-      cb = 'did_set_jumpoptions',
       defaults = { if_true = 'clean' },
       values = { 'stack', 'view', 'clean' },
       flags = true,
@@ -4726,13 +4706,13 @@ return {
           clean         Remove unloaded buffers from the jumplist.
         		EXPERIMENTAL: this flag may change in the future.
       ]=],
-      expand_cb = 'expand_set_jumpoptions',
       full_name = 'jumpoptions',
       list = 'onecomma',
       scope = { 'global' },
       short_desc = N_('Controls the behavior of the jumplist'),
       type = 'string',
       varname = 'p_jop',
+      flags_varname = 'jop_flags',
     },
     {
       abbreviation = 'kmp',
@@ -4770,7 +4750,6 @@ return {
         Special keys in this context are the cursor keys, <End>, <Home>,
         <PageUp> and <PageDown>.
       ]=],
-      expand_cb = 'expand_set_keymodel',
       full_name = 'keymodel',
       list = 'onecomma',
       scope = { 'global' },
@@ -5057,7 +5036,6 @@ return {
         Note that when using 'indentexpr' the `=` operator indents all the
         lines, otherwise the first line is not indented (Vi-compatible).
       ]=],
-      expand_cb = 'expand_set_lispoptions',
       full_name = 'lispoptions',
       list = 'onecomma',
       scope = { 'buf' },
@@ -5482,7 +5460,6 @@ return {
         		Setting it to zero clears the message history.
         		This item must always be present.
       ]=],
-      expand_cb = 'expand_set_messagesopt',
       full_name = 'messagesopt',
       list = 'onecommacolon',
       scope = { 'global' },
@@ -5736,7 +5713,6 @@ return {
     },
     {
       abbreviation = 'mousem',
-      cb = 'did_set_mousemodel',
       defaults = { if_true = 'popup_setpos' },
       values = { 'extend', 'popup', 'popup_setpos' },
       desc = [=[
@@ -5788,7 +5764,6 @@ return {
             "g<LeftMouse>"  is "<C-LeftMouse>	(jump to tag under mouse click)
             "g<RightMouse>" is "<C-RightMouse>	("CTRL-T")
       ]=],
-      expand_cb = 'expand_set_mousemodel',
       full_name = 'mousemodel',
       scope = { 'global' },
       short_desc = N_('changes meaning of mouse buttons'),
@@ -5835,7 +5810,6 @@ return {
         <	Will make Nvim scroll 5 lines at a time when scrolling vertically, and
         scroll 2 columns at a time when scrolling horizontally.
       ]=],
-      expand_cb = 'expand_set_mousescroll',
       full_name = 'mousescroll',
       list = 'comma',
       scope = { 'global' },
@@ -5936,7 +5910,6 @@ return {
     },
     {
       abbreviation = 'nf',
-      cb = 'did_set_nrformats',
       defaults = { if_true = 'bin,hex' },
       values = { 'bin', 'octal', 'hex', 'alpha', 'unsigned', 'blank' },
       deny_duplicates = true,
@@ -5982,7 +5955,6 @@ return {
         considered decimal.  This also happens for numbers that are not
         recognized as octal or hex.
       ]=],
-      expand_cb = 'expand_set_nrformats',
       full_name = 'nrformats',
       list = 'onecomma',
       scope = { 'buf' },
@@ -6468,7 +6440,6 @@ return {
     },
     {
       abbreviation = 'rdb',
-      cb = 'did_set_redrawdebug',
       defaults = { if_true = '' },
       values = {
         'compositor',
@@ -6517,6 +6488,7 @@ return {
       short_desc = N_('Changes the way redrawing works (debug)'),
       type = 'string',
       varname = 'p_rdb',
+      flags_varname = 'rdb_flags',
     },
     {
       abbreviation = 'rdt',
@@ -6649,7 +6621,6 @@ return {
     },
     {
       abbreviation = 'rlc',
-      cb = 'did_set_rightleftcmd',
       defaults = { if_true = 'search' },
       values = { 'search' },
       desc = [=[
@@ -6661,8 +6632,8 @@ return {
         This is useful for languages such as Hebrew, Arabic and Farsi.
         The 'rightleft' option must be set for 'rightleftcmd' to take effect.
       ]=],
-      expand_cb = 'expand_set_rightleftcmd',
       full_name = 'rightleftcmd',
+      list = 'comma',
       redraw = { 'current_window' },
       scope = { 'win' },
       short_desc = N_('commands for which editing works right-to-left'),
@@ -6934,7 +6905,6 @@ return {
     },
     {
       abbreviation = 'sbo',
-      cb = 'did_set_scrollopt',
       defaults = { if_true = 'ver,jump' },
       values = { 'ver', 'hor', 'jump' },
       deny_duplicates = true,
@@ -6967,7 +6937,6 @@ return {
         When 'diff' mode is active there always is vertical scroll binding,
         even when "ver" isn't there.
       ]=],
-      expand_cb = 'expand_set_scrollopt',
       full_name = 'scrollopt',
       list = 'onecomma',
       scope = { 'global' },
@@ -7024,7 +6993,6 @@ return {
         backwards, you cannot include the last character of a line, when
         starting in Normal mode and 'virtualedit' empty.
       ]=],
-      expand_cb = 'expand_set_selection',
       full_name = 'selection',
       scope = { 'global' },
       short_desc = N_('what type of selection to use'),
@@ -7033,7 +7001,6 @@ return {
     },
     {
       abbreviation = 'slm',
-      cb = 'did_set_selectmode',
       defaults = { if_true = '' },
       values = { 'mouse', 'key', 'cmd' },
       deny_duplicates = true,
@@ -7046,7 +7013,6 @@ return {
            cmd		when using "v", "V" or CTRL-V
         See |Select-mode|.
       ]=],
-      expand_cb = 'expand_set_selectmode',
       full_name = 'selectmode',
       list = 'onecomma',
       scope = { 'global' },
@@ -7120,13 +7086,13 @@ return {
         If you leave out "options" many things won't work well after restoring
         the session.
       ]=],
-      expand_cb = 'expand_set_sessionoptions',
       full_name = 'sessionoptions',
       list = 'onecomma',
       scope = { 'global' },
       short_desc = N_('options for |:mksession|'),
       type = 'string',
       varname = 'p_ssop',
+      flags_varname = 'ssop_flags',
     },
     {
       abbreviation = 'sd',
@@ -7748,7 +7714,6 @@ return {
         place the text.  Without a custom 'statusline' or 'tabline' it will be
         displayed in a convenient location.
       ]=],
-      expand_cb = 'expand_set_showcmdloc',
       full_name = 'showcmdloc',
       scope = { 'global' },
       short_desc = N_('change location of partial command'),
@@ -7928,7 +7893,6 @@ return {
            "number"	display signs in the 'number' column. If the number
         		column is not present, then behaves like "auto".
       ]=],
-      expand_cb = 'expand_set_signcolumn',
       full_name = 'signcolumn',
       redraw = { 'current_window' },
       scope = { 'win' },
@@ -8190,7 +8154,6 @@ return {
         		designated regions of the buffer are spellchecked in
         		this case.
       ]=],
-      expand_cb = 'expand_set_spelloptions',
       full_name = 'spelloptions',
       list = 'onecomma',
       redraw = { 'current_buffer', 'highlight_only' },
@@ -8274,7 +8237,6 @@ return {
         security reasons.
       ]=],
       expand = true,
-      expand_cb = 'expand_set_spellsuggest',
       full_name = 'spellsuggest',
       list = 'onecomma',
       scope = { 'global' },
@@ -8298,7 +8260,6 @@ return {
     },
     {
       abbreviation = 'spk',
-      cb = 'did_set_splitkeep',
       defaults = { if_true = 'cursor' },
       values = { 'cursor', 'screen', 'topline' },
       desc = [=[
@@ -8315,7 +8276,6 @@ return {
         with the previous cursor position. For "screen", the text cannot always
         be kept on the same screen line when 'wrap' is enabled.
       ]=],
-      expand_cb = 'expand_set_splitkeep',
       full_name = 'splitkeep',
       scope = { 'global' },
       short_desc = N_('determines scroll behavior for split windows'),
@@ -8722,7 +8682,6 @@ return {
     },
     {
       abbreviation = 'swb',
-      cb = 'did_set_switchbuf',
       defaults = { if_true = 'uselast' },
       values = { 'useopen', 'usetab', 'split', 'newtab', 'vsplit', 'uselast' },
       flags = true,
@@ -8756,13 +8715,13 @@ return {
         If a window has 'winfixbuf' enabled, 'switchbuf' is currently not
         applied to the split window.
       ]=],
-      expand_cb = 'expand_set_switchbuf',
       full_name = 'switchbuf',
       list = 'onecomma',
       scope = { 'global' },
       short_desc = N_('sets behavior when switching to another buffer'),
       type = 'string',
       varname = 'p_swb',
+      flags_varname = 'swb_flags',
     },
     {
       abbreviation = 'smc',
@@ -8821,7 +8780,6 @@ return {
     },
     {
       abbreviation = 'tcl',
-      cb = 'did_set_tabclose',
       defaults = { if_true = '' },
       values = { 'left', 'uselast' },
       flags = true,
@@ -8837,13 +8795,13 @@ return {
         		possible.  This option takes precedence over the
         		others.
       ]=],
-      expand_cb = 'expand_set_tabclose',
       full_name = 'tabclose',
       list = 'onecomma',
       scope = { 'global' },
       short_desc = N_('which tab page to focus when closing a tab'),
       type = 'string',
       varname = 'p_tcl',
+      flags_varname = 'tcl_flags',
     },
     {
       abbreviation = 'tal',
@@ -9018,12 +8976,12 @@ return {
            match	Match case
            smart	Ignore case unless an upper case letter is used
       ]=],
-      expand_cb = 'expand_set_tagcase',
       full_name = 'tagcase',
       scope = { 'global', 'buf' },
       short_desc = N_('how to handle case when searching in tags files'),
       type = 'string',
       varname = 'p_tc',
+      flags_varname = 'tc_flags',
     },
     {
       abbreviation = 'tfu',
@@ -9171,7 +9129,6 @@ return {
     },
     {
       abbreviation = 'tpf',
-      cb = 'did_set_termpastefilter',
       defaults = { if_true = 'BS,HT,ESC,DEL' },
       values = { 'BS', 'HT', 'FF', 'ESC', 'DEL', 'C0', 'C1' },
       flags = true,
@@ -9196,12 +9153,12 @@ return {
 
            C1	    Control characters 0x80...0x9F
       ]=],
-      expand_cb = 'expand_set_termpastefilter',
       full_name = 'termpastefilter',
       list = 'onecomma',
       scope = { 'global' },
       type = 'string',
       varname = 'p_tpf',
+      flags_varname = 'tpf_flags',
     },
     {
       defaults = { if_true = true },
@@ -9750,7 +9707,7 @@ return {
     },
     {
       abbreviation = 'vop',
-      cb = 'did_set_viewoptions',
+      cb = 'did_set_str_generic',
       defaults = { if_true = 'folds,cursor,curdir' },
       flags = true,
       deny_duplicates = true,
@@ -9768,13 +9725,14 @@ return {
            slash	|deprecated| Always enabled. Uses "/" in filenames.
            unix		|deprecated| Always enabled. Uses "\n" line endings.
       ]=],
-      expand_cb = 'expand_set_sessionoptions',
+      expand_cb = 'expand_set_str_generic',
       full_name = 'viewoptions',
       list = 'onecomma',
       scope = { 'global' },
       short_desc = N_('specifies what to save for :mkview'),
       type = 'string',
       varname = 'p_vop',
+      flags_varname = 'vop_flags',
     },
     {
       abbreviation = 've',
@@ -9818,7 +9776,6 @@ return {
         not get a warning for it.
         When combined with other words, "none" is ignored.
       ]=],
-      expand_cb = 'expand_set_virtualedit',
       full_name = 'virtualedit',
       list = 'onecomma',
       redraw = { 'curswant' },
@@ -9826,6 +9783,7 @@ return {
       short_desc = N_('when to use virtual editing'),
       type = 'string',
       varname = 'p_ve',
+      flags_varname = 've_flags',
     },
     {
       abbreviation = 'vb',
@@ -10082,7 +10040,6 @@ return {
         <	Complete longest common string, then list alternatives.
         More info here: |cmdline-completion|.
       ]=],
-      expand_cb = 'expand_set_wildmode',
       full_name = 'wildmode',
       list = 'onecommacolon',
       scope = { 'global' },
@@ -10092,7 +10049,6 @@ return {
     },
     {
       abbreviation = 'wop',
-      cb = 'did_set_wildoptions',
       defaults = { if_true = 'pum,tagfile' },
       values = { 'fuzzy', 'tagfile', 'pum' },
       flags = true,
@@ -10116,17 +10072,16 @@ return {
         			d	#define
         			f	function
       ]=],
-      expand_cb = 'expand_set_wildoptions',
       full_name = 'wildoptions',
       list = 'onecomma',
       scope = { 'global' },
       short_desc = N_('specifies how command line completion is done'),
       type = 'string',
       varname = 'p_wop',
+      flags_varname = 'wop_flags',
     },
     {
       abbreviation = 'wak',
-      cb = 'did_set_winaltkeys',
       defaults = { if_true = 'menu' },
       values = { 'yes', 'menu', 'no' },
       desc = [=[
@@ -10146,7 +10101,6 @@ return {
         key is never used for the menu.
         This option is not used for <F10>; on Win32.
       ]=],
-      expand_cb = 'expand_set_winaltkeys',
       full_name = 'winaltkeys',
       scope = { 'global' },
       short_desc = N_('when the windows system handles ALT keys'),

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -80,23 +80,23 @@ static char SHM_ALL[] = { SHM_RO, SHM_MOD, SHM_LINES,
 /// option values.
 void didset_string_options(void)
 {
-  opt_strings_flags(p_cmp, opt_cmp_values, &cmp_flags, true);
-  opt_strings_flags(p_bkc, opt_bkc_values, &bkc_flags, true);
-  opt_strings_flags(p_bo, opt_bo_values, &bo_flags, true);
-  opt_strings_flags(p_cot, opt_cot_values, &cot_flags, true);
-  opt_strings_flags(p_ssop, opt_ssop_values, &ssop_flags, true);
-  opt_strings_flags(p_vop, opt_ssop_values, &vop_flags, true);
-  opt_strings_flags(p_fdo, opt_fdo_values, &fdo_flags, true);
-  opt_strings_flags(p_dy, opt_dy_values, &dy_flags, true);
-  opt_strings_flags(p_jop, opt_jop_values, &jop_flags, true);
-  opt_strings_flags(p_rdb, opt_rdb_values, &rdb_flags, true);
-  opt_strings_flags(p_tc, opt_tc_values, &tc_flags, false);
-  opt_strings_flags(p_tpf, opt_tpf_values, &tpf_flags, true);
-  opt_strings_flags(p_ve, opt_ve_values, &ve_flags, true);
-  opt_strings_flags(p_swb, opt_swb_values, &swb_flags, true);
-  opt_strings_flags(p_tcl, opt_tcl_values, &tcl_flags, true);
-  opt_strings_flags(p_wop, opt_wop_values, &wop_flags, true);
-  opt_strings_flags(p_cb, opt_cb_values, &cb_flags, true);
+  check_str_opt(kOptCasemap, NULL);
+  check_str_opt(kOptBackupcopy, NULL);
+  check_str_opt(kOptBelloff, NULL);
+  check_str_opt(kOptCompleteopt, NULL);
+  check_str_opt(kOptSessionoptions, NULL);
+  check_str_opt(kOptViewoptions, NULL);
+  check_str_opt(kOptFoldopen, NULL);
+  check_str_opt(kOptDisplay, NULL);
+  check_str_opt(kOptJumpoptions, NULL);
+  check_str_opt(kOptRedrawdebug, NULL);
+  check_str_opt(kOptTagcase, NULL);
+  check_str_opt(kOptTermpastefilter, NULL);
+  check_str_opt(kOptVirtualedit, NULL);
+  check_str_opt(kOptSwitchbuf, NULL);
+  check_str_opt(kOptTabclose, NULL);
+  check_str_opt(kOptWildoptions, NULL);
+  check_str_opt(kOptClipboard, NULL);
 }
 
 char *illegal_char(char *errbuf, size_t errbuflen, int c)
@@ -222,7 +222,7 @@ int check_signcolumn(char *scl, win_T *wp)
     return FAIL;
   }
 
-  if (check_opt_strings(val, opt_scl_values, false) == OK) {
+  if (opt_strings_flags(val, opt_scl_values, NULL, false) == OK) {
     if (wp == NULL) {
       return OK;
     }
@@ -358,11 +358,40 @@ static const char *did_set_opt_flags(char *val, const char **values, unsigned *f
   return NULL;
 }
 
-/// An option that accepts a list of string values is changed.
-/// e.g. 'nrformats', 'scrollopt', 'wildoptions', etc.
-static const char *did_set_opt_strings(char *val, const char **values, bool list)
+static const char **opt_values(OptIndex idx, size_t *values_len)
 {
-  return did_set_opt_flags(val, values, NULL, list);
+  OptIndex idx1 = idx == kOptViewoptions ? kOptSessionoptions
+                                         : idx == kOptFileformats ? kOptFileformat
+                                                                  : idx;
+
+  vimoption_T *opt = get_option(idx1);
+  if (values_len != NULL) {
+    *values_len = opt->values_len;
+  }
+  return opt->values;
+}
+
+static int check_str_opt(OptIndex idx, char **varp)
+{
+  vimoption_T *opt = get_option(idx);
+  if (varp == NULL) {
+    varp = opt->var;
+  }
+  bool list = opt->flags & (kOptFlagComma | kOptFlagOneComma);
+  const char **values = opt_values(idx, NULL);
+  return opt_strings_flags(*varp, values, opt->flags_var, list);
+}
+
+int expand_set_str_generic(optexpand_T *args, int *numMatches, char ***matches)
+{
+  size_t values_len;
+  const char **values = opt_values(args->oe_idx, &values_len);
+  return expand_set_opt_string(args, values, values_len, numMatches, matches);
+}
+
+const char *did_set_str_generic(optset_T *args)
+{
+  return check_str_opt(args->os_idx, args->os_varp) != OK ? e_invarg : NULL;
 }
 
 /// An option which is a list of flags is set.  Valid values are in "flags".
@@ -490,28 +519,30 @@ static int expand_set_opt_listflag(optexpand_T *args, char *flags, int *numMatch
 }
 
 /// The 'ambiwidth' option is changed.
-const char *did_set_ambiwidth(optset_T *args FUNC_ATTR_UNUSED)
+const char *did_set_ambiwidth(optset_T *args)
 {
-  if (check_opt_strings(p_ambw, opt_ambw_values, false) != OK) {
+  const char *errmsg = did_set_str_generic(args);
+  if (errmsg != NULL) {
+    return errmsg;
+  }
+  return check_chars_options();
+}
+
+/// The 'emoji' option is changed.
+const char *did_set_emoji(optset_T *args)
+{
+  if (check_str_opt(kOptAmbiwidth, NULL) != OK) {
     return e_invarg;
   }
   return check_chars_options();
 }
 
-int expand_set_ambiwidth(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_ambw_values,
-                               ARRAY_SIZE(opt_ambw_values) - 1,
-                               numMatches,
-                               matches);
-}
-
 /// The 'background' option is changed.
 const char *did_set_background(optset_T *args)
 {
-  if (check_opt_strings(p_bg, opt_bg_values, false) != OK) {
-    return e_invarg;
+  const char *errmsg = did_set_str_generic(args);
+  if (errmsg != NULL) {
+    return errmsg;
   }
 
   if (args->os_oldval.string.data[0] == *p_bg) {
@@ -545,15 +576,6 @@ const char *did_set_background(optset_T *args)
   return NULL;
 }
 
-int expand_set_background(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_bg_values,
-                               ARRAY_SIZE(opt_bg_values) - 1,
-                               numMatches,
-                               matches);
-}
-
 /// The 'backspace' option is changed.
 const char *did_set_backspace(optset_T *args FUNC_ATTR_UNUSED)
 {
@@ -561,19 +583,9 @@ const char *did_set_backspace(optset_T *args FUNC_ATTR_UNUSED)
     if (*p_bs != '2') {
       return e_invarg;
     }
-  } else if (check_opt_strings(p_bs, opt_bs_values, true) != OK) {
-    return e_invarg;
+    return NULL;
   }
-  return NULL;
-}
-
-int expand_set_backspace(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_bs_values,
-                               ARRAY_SIZE(opt_bs_values) - 1,
-                               numMatches,
-                               matches);
+  return did_set_str_generic(args);
 }
 
 /// The 'backupcopy' option is changed.
@@ -613,15 +625,6 @@ const char *did_set_backupcopy(optset_T *args)
   return NULL;
 }
 
-int expand_set_backupcopy(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_bkc_values,
-                               ARRAY_SIZE(opt_bkc_values) - 1,
-                               numMatches,
-                               matches);
-}
-
 /// The 'backupext' or the 'patchmode' option is changed.
 const char *did_set_backupext_or_patchmode(optset_T *args FUNC_ATTR_UNUSED)
 {
@@ -631,21 +634,6 @@ const char *did_set_backupext_or_patchmode(optset_T *args FUNC_ATTR_UNUSED)
   }
 
   return NULL;
-}
-
-/// The 'belloff' option is changed.
-const char *did_set_belloff(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_flags(p_bo, opt_bo_values, &bo_flags, true);
-}
-
-int expand_set_belloff(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_bo_values,
-                               ARRAY_SIZE(opt_bo_values) - 1,
-                               numMatches,
-                               matches);
 }
 
 /// The 'breakat' option is changed.
@@ -682,29 +670,11 @@ const char *did_set_breakindentopt(optset_T *args)
   return NULL;
 }
 
-int expand_set_breakindentopt(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_briopt_values,
-                               ARRAY_SIZE(opt_briopt_values) - 1,
-                               numMatches,
-                               matches);
-}
-
 /// The 'bufhidden' option is changed.
 const char *did_set_bufhidden(optset_T *args)
 {
   buf_T *buf = (buf_T *)args->os_buf;
-  return did_set_opt_strings(buf->b_p_bh, opt_bh_values, false);
-}
-
-int expand_set_bufhidden(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_bh_values,
-                               ARRAY_SIZE(opt_bh_values) - 1,
-                               numMatches,
-                               matches);
+  return did_set_opt_flags(buf->b_p_bh, opt_bh_values, NULL, false);
 }
 
 /// The 'buftype' option is changed.
@@ -715,7 +685,7 @@ const char *did_set_buftype(optset_T *args)
   // When 'buftype' is set, check for valid value.
   if ((buf->terminal && buf->b_p_bt[0] != 't')
       || (!buf->terminal && buf->b_p_bt[0] == 't')
-      || check_opt_strings(buf->b_p_bt, opt_bt_values, false) != OK) {
+      || opt_strings_flags(buf->b_p_bt, opt_bt_values, NULL, false) != OK) {
     return e_invarg;
   }
   if (win->w_status_height || global_stl_height()) {
@@ -725,30 +695,6 @@ const char *did_set_buftype(optset_T *args)
   buf->b_help = (buf->b_p_bt[0] == 'h');
   redraw_titles();
   return NULL;
-}
-
-int expand_set_buftype(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_bt_values,
-                               ARRAY_SIZE(opt_bt_values) - 1,
-                               numMatches,
-                               matches);
-}
-
-/// The 'casemap' option is changed.
-const char *did_set_casemap(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_flags(p_cmp, opt_cmp_values, &cmp_flags, true);
-}
-
-int expand_set_casemap(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_cmp_values,
-                               ARRAY_SIZE(opt_cmp_values) - 1,
-                               numMatches,
-                               matches);
 }
 
 /// The global 'listchars' or 'fillchars' option is changed.
@@ -832,21 +778,6 @@ const char *did_set_cinoptions(optset_T *args)
   parse_cino(buf);
 
   return NULL;
-}
-
-/// The 'clipboard' option is changed.
-const char *did_set_clipboard(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_flags(p_cb, opt_cb_values, &cb_flags, true);
-}
-
-int expand_set_clipboard(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_cb_values,
-                               ARRAY_SIZE(opt_cb_values) - 1,
-                               numMatches,
-                               matches);
 }
 
 /// The 'colorcolumn' option is changed.
@@ -940,15 +871,6 @@ const char *did_set_complete(optset_T *args)
   return NULL;
 }
 
-int expand_set_complete(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_cpt_values,
-                               ARRAY_SIZE(opt_cpt_values) - 1,
-                               numMatches,
-                               matches);
-}
-
 /// The 'completeitemalign' option is changed.
 const char *did_set_completeitemalign(optset_T *args)
 {
@@ -1009,7 +931,7 @@ const char *did_set_completeopt(optset_T *args FUNC_ATTR_UNUSED)
     buf->b_cot_flags = 0;
   }
 
-  if (check_opt_strings(cot, opt_cot_values, true) != OK) {
+  if (opt_strings_flags(cot, opt_cot_values, NULL, true) != OK) {
     return e_invarg;
   }
 
@@ -1020,34 +942,16 @@ const char *did_set_completeopt(optset_T *args FUNC_ATTR_UNUSED)
   return NULL;
 }
 
-int expand_set_completeopt(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_cot_values,
-                               ARRAY_SIZE(opt_cot_values) - 1,
-                               numMatches,
-                               matches);
-}
-
 #ifdef BACKSLASH_IN_FILENAME
 /// The 'completeslash' option is changed.
 const char *did_set_completeslash(optset_T *args)
 {
   buf_T *buf = (buf_T *)args->os_buf;
-  if (check_opt_strings(p_csl, opt_csl_values, false) != OK
-      || check_opt_strings(buf->b_p_csl, opt_csl_values, false) != OK) {
+  if (opt_strings_flags(p_csl, opt_csl_values, NULL, false) != OK
+      || opt_strings_flags(buf->b_p_csl, opt_csl_values, NULL, false) != OK) {
     return e_invarg;
   }
   return NULL;
-}
-
-int expand_set_completeslash(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_csl_values,
-                               ARRAY_SIZE(opt_csl_values) - 1,
-                               numMatches,
-                               matches);
 }
 #endif
 
@@ -1091,37 +995,10 @@ const char *did_set_cursorlineopt(optset_T *args)
   return NULL;
 }
 
-int expand_set_cursorlineopt(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_culopt_values,
-                               ARRAY_SIZE(opt_culopt_values) - 1,
-                               numMatches,
-                               matches);
-}
-
-/// The 'debug' option is changed.
-const char *did_set_debug(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_strings(p_debug, opt_debug_values, true);
-}
-
-int expand_set_debug(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_debug_values,
-                               ARRAY_SIZE(opt_debug_values) - 1,
-                               numMatches,
-                               matches);
-}
-
 /// The 'diffopt' option is changed.
 const char *did_set_diffopt(optset_T *args FUNC_ATTR_UNUSED)
 {
-  if (diffopt_changed() == FAIL) {
-    return e_invarg;
-  }
-  return NULL;
+  return diffopt_changed() == FAIL ? e_invarg : NULL;
 }
 
 int expand_set_diffopt(optexpand_T *args, int *numMatches, char ***matches)
@@ -1142,46 +1019,19 @@ int expand_set_diffopt(optexpand_T *args, int *numMatches, char ***matches)
     return FAIL;
   }
 
-  return expand_set_opt_string(args,
-                               opt_dip_values,
-                               ARRAY_SIZE(opt_dip_values) - 1,
-                               numMatches,
-                               matches);
+  return expand_set_str_generic(args, numMatches, matches);
 }
 
 /// The 'display' option is changed.
-const char *did_set_display(optset_T *args FUNC_ATTR_UNUSED)
+const char *did_set_display(optset_T *args)
 {
-  if (opt_strings_flags(p_dy, opt_dy_values, &dy_flags, true) != OK) {
-    return e_invarg;
+  const char *errmsg = did_set_str_generic(args);
+  if (errmsg != NULL) {
+    return errmsg;
   }
   init_chartab();
   msg_grid_validate();
   return NULL;
-}
-
-int expand_set_display(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_dy_values,
-                               ARRAY_SIZE(opt_dy_values) - 1,
-                               numMatches,
-                               matches);
-}
-
-/// The 'eadirection' option is changed.
-const char *did_set_eadirection(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_strings(p_ead, opt_ead_values, false);
-}
-
-int expand_set_eadirection(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_ead_values,
-                               ARRAY_SIZE(opt_ead_values) - 1,
-                               numMatches,
-                               matches);
 }
 
 /// One of the 'encoding', 'fileencoding' or 'makeencoding'
@@ -1259,14 +1109,17 @@ int expand_set_eventignore(optexpand_T *args, int *numMatches, char ***matches)
 const char *did_set_fileformat(optset_T *args)
 {
   buf_T *buf = (buf_T *)args->os_buf;
-  char **varp = (char **)args->os_varp;
   const char *oldval = args->os_oldval.string.data;
   int opt_flags = args->os_flags;
   if (!MODIFIABLE(buf) && !(opt_flags & OPT_GLOBAL)) {
     return e_modifiable;
-  } else if (check_opt_strings(*varp, opt_ff_values, false) != OK) {
-    return e_invarg;
   }
+
+  const char *errmsg = did_set_str_generic(args);
+  if (errmsg != NULL) {
+    return errmsg;
+  }
+
   redraw_titles();
   // update flag in swap file
   ml_setflags(buf);
@@ -1278,15 +1131,6 @@ const char *did_set_fileformat(optset_T *args)
   return NULL;
 }
 
-int expand_set_fileformat(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_ff_values,
-                               ARRAY_SIZE(opt_ff_values) - 1,
-                               numMatches,
-                               matches);
-}
-
 /// Function given to ExpandGeneric() to obtain the possible arguments of the
 /// fileformat options.
 char *get_fileformat_name(expand_T *xp FUNC_ATTR_UNUSED, int idx)
@@ -1296,12 +1140,6 @@ char *get_fileformat_name(expand_T *xp FUNC_ATTR_UNUSED, int idx)
   }
 
   return (char *)opt_ff_values[idx];
-}
-
-/// The 'fileformats' option is changed.
-const char *did_set_fileformats(optset_T *args)
-{
-  return did_set_opt_strings(p_ffs, opt_ff_values, true);
 }
 
 /// The 'filetype' or the 'syntax' option is changed.
@@ -1320,40 +1158,6 @@ const char *did_set_filetype_or_syntax(optset_T *args)
   args->os_value_checked = true;
 
   return NULL;
-}
-
-/// The 'foldclose' option is changed.
-const char *did_set_foldclose(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_strings(p_fcl, opt_fcl_values, true);
-}
-
-int expand_set_foldclose(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_fcl_values,
-                               ARRAY_SIZE(opt_fcl_values) - 1,
-                               numMatches,
-                               matches);
-}
-
-/// The 'foldcolumn' option is changed.
-const char *did_set_foldcolumn(optset_T *args)
-{
-  char **varp = (char **)args->os_varp;
-  if (**varp == NUL || check_opt_strings(*varp, opt_fdc_values, false) != OK) {
-    return e_invarg;
-  }
-  return NULL;
-}
-
-int expand_set_foldcolumn(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_fdc_values,
-                               ARRAY_SIZE(opt_fdc_values) - 1,
-                               numMatches,
-                               matches);
 }
 
 /// The 'foldexpr' option is changed.
@@ -1402,40 +1206,16 @@ const char *did_set_foldmarker(optset_T *args)
 /// The 'foldmethod' option is changed.
 const char *did_set_foldmethod(optset_T *args)
 {
-  win_T *win = (win_T *)args->os_win;
-  char **varp = (char **)args->os_varp;
-  if (check_opt_strings(*varp, opt_fdm_values, false) != OK || **varp == NUL) {
-    return e_invarg;
+  const char *errmsg = did_set_str_generic(args);
+  if (errmsg != NULL) {
+    return errmsg;
   }
+  win_T *win = (win_T *)args->os_win;
   foldUpdateAll(win);
   if (foldmethodIsDiff(win)) {
     newFoldLevel();
   }
   return NULL;
-}
-
-int expand_set_foldmethod(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_fdm_values,
-                               ARRAY_SIZE(opt_fdm_values) - 1,
-                               numMatches,
-                               matches);
-}
-
-/// The 'foldopen' option is changed.
-const char *did_set_foldopen(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_flags(p_fdo, opt_fdo_values, &fdo_flags, true);
-}
-
-int expand_set_foldopen(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_fdo_values,
-                               ARRAY_SIZE(opt_fdo_values) - 1,
-                               numMatches,
-                               matches);
 }
 
 /// The 'formatoptions' option is changed.
@@ -1516,16 +1296,7 @@ const char *did_set_inccommand(optset_T *args FUNC_ATTR_UNUSED)
   if (cmdpreview) {
     return e_invarg;
   }
-  return did_set_opt_strings(p_icm, opt_icm_values, false);
-}
-
-int expand_set_inccommand(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_icm_values,
-                               ARRAY_SIZE(opt_icm_values) - 1,
-                               numMatches,
-                               matches);
+  return did_set_str_generic(args);
 }
 
 /// The 'iskeyword' option is changed.
@@ -1557,21 +1328,6 @@ const char *did_set_isopt(optset_T *args)
     return e_invarg;                  // error in value
   }
   return NULL;
-}
-
-/// The 'jumpoptions' option is changed.
-const char *did_set_jumpoptions(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_flags(p_jop, opt_jop_values, &jop_flags, true);
-}
-
-int expand_set_jumpoptions(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_jop_values,
-                               ARRAY_SIZE(opt_jop_values) - 1,
-                               numMatches,
-                               matches);
 }
 
 /// The 'keymap' option has changed.
@@ -1629,21 +1385,13 @@ const char *did_set_keymap(optset_T *args)
 /// The 'keymodel' option is changed.
 const char *did_set_keymodel(optset_T *args FUNC_ATTR_UNUSED)
 {
-  if (check_opt_strings(p_km, opt_km_values, true) != OK) {
-    return e_invarg;
+  const char *errmsg = did_set_str_generic(args);
+  if (errmsg != NULL) {
+    return errmsg;
   }
   km_stopsel = (vim_strchr(p_km, 'o') != NULL);
   km_startsel = (vim_strchr(p_km, 'a') != NULL);
   return NULL;
-}
-
-int expand_set_keymodel(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_km_values,
-                               ARRAY_SIZE(opt_km_values) - 1,
-                               numMatches,
-                               matches);
 }
 
 /// The 'lispoptions' option is changed.
@@ -1655,15 +1403,6 @@ const char *did_set_lispoptions(optset_T *args)
     return e_invarg;
   }
   return NULL;
-}
-
-int expand_set_lispoptions(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_lop_values,
-                               ARRAY_SIZE(opt_lop_values) - 1,
-                               numMatches,
-                               matches);
 }
 
 /// The 'matchpairs' option is changed.
@@ -1702,15 +1441,6 @@ const char *did_set_messagesopt(optset_T *args FUNC_ATTR_UNUSED)
   return NULL;
 }
 
-int expand_set_messagesopt(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_mopt_values,
-                               ARRAY_SIZE(opt_mopt_values) - 1,
-                               numMatches,
-                               matches);
-}
-
 /// The 'mkspellmem' option is changed.
 const char *did_set_mkspellmem(optset_T *args FUNC_ATTR_UNUSED)
 {
@@ -1731,21 +1461,6 @@ const char *did_set_mouse(optset_T *args)
 int expand_set_mouse(optexpand_T *args, int *numMatches, char ***matches)
 {
   return expand_set_opt_listflag(args, MOUSE_ALL, numMatches, matches);
-}
-
-/// The 'mousemodel' option is changed.
-const char *did_set_mousemodel(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_strings(p_mousem, opt_mousem_values, false);
-}
-
-int expand_set_mousemodel(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_mousem_values,
-                               ARRAY_SIZE(opt_mousem_values) - 1,
-                               numMatches,
-                               matches);
 }
 
 /// Handle setting 'mousescroll'.
@@ -1813,32 +1528,6 @@ const char *did_set_mousescroll(optset_T *args FUNC_ATTR_UNUSED)
   return NULL;
 }
 
-int expand_set_mousescroll(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_mousescroll_values,
-                               ARRAY_SIZE(opt_mousescroll_values) - 1,
-                               numMatches,
-                               matches);
-}
-
-/// The 'nrformats' option is changed.
-const char *did_set_nrformats(optset_T *args)
-{
-  char **varp = (char **)args->os_varp;
-
-  return did_set_opt_strings(*varp, opt_nf_values, true);
-}
-
-int expand_set_nrformats(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_nf_values,
-                               ARRAY_SIZE(opt_nf_values) - 1,
-                               numMatches,
-                               matches);
-}
-
 /// One of the '*expr' options is changed:, 'diffexpr', 'foldexpr', 'foldtext',
 /// 'formatexpr', 'includeexpr', 'indentexpr', 'patchexpr' and 'charconvert'.
 const char *did_set_optexpr(optset_T *args)
@@ -1855,60 +1544,18 @@ const char *did_set_optexpr(optset_T *args)
   return NULL;
 }
 
-/// The 'redrawdebug' option is changed.
-const char *did_set_redrawdebug(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_flags(p_rdb, opt_rdb_values, &rdb_flags, true);
-}
-
-/// The 'rightleftcmd' option is changed.
-const char *did_set_rightleftcmd(optset_T *args)
-{
-  char **varp = (char **)args->os_varp;
-
-  // Currently only "search" is a supported value.
-  if (**varp != NUL && strcmp(*varp, "search") != 0) {
-    return e_invarg;
-  }
-
-  return NULL;
-}
-
-int expand_set_rightleftcmd(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_rlc_values,
-                               ARRAY_SIZE(opt_rlc_values) - 1,
-                               numMatches,
-                               matches);
-}
-
 /// The 'rulerformat' option is changed.
 const char *did_set_rulerformat(optset_T *args)
 {
   return did_set_statustabline_rulerformat(args, true, false);
 }
 
-/// The 'scrollopt' option is changed.
-const char *did_set_scrollopt(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_strings(p_sbo, opt_sbo_values, true);
-}
-
-int expand_set_scrollopt(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_sbo_values,
-                               ARRAY_SIZE(opt_sbo_values) - 1,
-                               numMatches,
-                               matches);
-}
-
 /// The 'selection' option is changed.
 const char *did_set_selection(optset_T *args FUNC_ATTR_UNUSED)
 {
-  if (*p_sel == NUL || check_opt_strings(p_sel, opt_sel_values, false) != OK) {
-    return e_invarg;
+  const char *errmsg = did_set_str_generic(args);
+  if (errmsg != NULL) {
+    return errmsg;
   }
   if (VIsual_active) {
     // Visual selection may be drawn differently.
@@ -1917,35 +1564,12 @@ const char *did_set_selection(optset_T *args FUNC_ATTR_UNUSED)
   return NULL;
 }
 
-int expand_set_selection(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_sel_values,
-                               ARRAY_SIZE(opt_sel_values) - 1,
-                               numMatches,
-                               matches);
-}
-
-/// The 'selectmode' option is changed.
-const char *did_set_selectmode(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_strings(p_slm, opt_slm_values, true);
-}
-
-int expand_set_selectmode(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_slm_values,
-                               ARRAY_SIZE(opt_slm_values) - 1,
-                               numMatches,
-                               matches);
-}
-
 /// The 'sessionoptions' option is changed.
 const char *did_set_sessionoptions(optset_T *args)
 {
-  if (opt_strings_flags(p_ssop, opt_ssop_values, &ssop_flags, true) != OK) {
-    return e_invarg;
+  const char *errmsg = did_set_str_generic(args);
+  if (errmsg != NULL) {
+    return errmsg;
   }
   if ((ssop_flags & kOptSsopFlagCurdir) && (ssop_flags & kOptSsopFlagSesdir)) {
     // Don't allow both "sesdir" and "curdir".
@@ -1954,15 +1578,6 @@ const char *did_set_sessionoptions(optset_T *args)
     return e_invarg;
   }
   return NULL;
-}
-
-int expand_set_sessionoptions(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_ssop_values,
-                               ARRAY_SIZE(opt_ssop_values) - 1,
-                               numMatches,
-                               matches);
 }
 
 const char *did_set_shada(optset_T *args)
@@ -2044,22 +1659,13 @@ const char *did_set_showbreak(optset_T *args)
 /// The 'showcmdloc' option is changed.
 const char *did_set_showcmdloc(optset_T *args FUNC_ATTR_UNUSED)
 {
-  const char *errmsg = did_set_opt_strings(p_sloc, opt_sloc_values, false);
+  const char *errmsg = did_set_str_generic(args);
 
   if (errmsg == NULL) {
     comp_col();
   }
 
   return errmsg;
-}
-
-int expand_set_showcmdloc(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_sloc_values,
-                               ARRAY_SIZE(opt_sloc_values) - 1,
-                               numMatches,
-                               matches);
 }
 
 /// The 'signcolumn' option is changed.
@@ -2077,15 +1683,6 @@ const char *did_set_signcolumn(optset_T *args)
     win->w_nrwidth_line_count = 0;
   }
   return NULL;
-}
-
-int expand_set_signcolumn(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_scl_values,
-                               ARRAY_SIZE(opt_scl_values) - 1,
-                               numMatches,
-                               matches);
 }
 
 /// The 'spellcapcheck' option is changed.
@@ -2140,15 +1737,6 @@ const char *did_set_spelloptions(optset_T *args)
   return NULL;
 }
 
-int expand_set_spelloptions(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_spo_values,
-                               ARRAY_SIZE(opt_spo_values) - 1,
-                               numMatches,
-                               matches);
-}
-
 /// The 'spellsuggest' option is changed.
 const char *did_set_spellsuggest(optset_T *args FUNC_ATTR_UNUSED)
 {
@@ -2156,30 +1744,6 @@ const char *did_set_spellsuggest(optset_T *args FUNC_ATTR_UNUSED)
     return e_invarg;
   }
   return NULL;
-}
-
-int expand_set_spellsuggest(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_sps_values,
-                               ARRAY_SIZE(opt_sps_values) - 1,
-                               numMatches,
-                               matches);
-}
-
-/// The 'splitkeep' option is changed.
-const char *did_set_splitkeep(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_strings(p_spk, opt_spk_values, false);
-}
-
-int expand_set_splitkeep(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_spk_values,
-                               ARRAY_SIZE(opt_spk_values) - 1,
-                               numMatches,
-                               matches);
 }
 
 /// The 'statuscolumn' option is changed.
@@ -2237,36 +1801,6 @@ static const char *did_set_statustabline_rulerformat(optset_T *args, bool rulerf
   return errmsg;
 }
 
-/// The 'switchbuf' option is changed.
-const char *did_set_switchbuf(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_flags(p_swb, opt_swb_values, &swb_flags, true);
-}
-
-int expand_set_switchbuf(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_swb_values,
-                               ARRAY_SIZE(opt_swb_values) - 1,
-                               numMatches,
-                               matches);
-}
-
-/// The 'tabclose' option is changed.
-const char *did_set_tabclose(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_flags(p_tcl, opt_tcl_values, &tcl_flags, true);
-}
-
-int expand_set_tabclose(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_tcl_values,
-                               ARRAY_SIZE(opt_tcl_values) - 1,
-                               numMatches,
-                               matches);
-}
-
 /// The 'tabline' option is changed.
 const char *did_set_tabline(optset_T *args)
 {
@@ -2293,35 +1827,10 @@ const char *did_set_tagcase(optset_T *args)
   if ((opt_flags & OPT_LOCAL) && *p == NUL) {
     // make the local value empty: use the global value
     *flags = 0;
-  } else if (*p == NUL
-             || opt_strings_flags(p, opt_tc_values, flags, false) != OK) {
+  } else if (opt_strings_flags(p, opt_tc_values, flags, false) != OK) {
     return e_invarg;
   }
   return NULL;
-}
-
-int expand_set_tagcase(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_tc_values,
-                               ARRAY_SIZE(opt_tc_values) - 1,
-                               numMatches,
-                               matches);
-}
-
-/// The 'termpastefilter' option is changed.
-const char *did_set_termpastefilter(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_flags(p_tpf, opt_tpf_values, &tpf_flags, true);
-}
-
-int expand_set_termpastefilter(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_tpf_values,
-                               ARRAY_SIZE(opt_tpf_values) - 1,
-                               numMatches,
-                               matches);
 }
 
 /// The 'titlestring' or the 'iconstring' option is changed.
@@ -2420,12 +1929,6 @@ const char *did_set_verbosefile(optset_T *args)
   return NULL;
 }
 
-/// The 'viewoptions' option is changed.
-const char *did_set_viewoptions(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_flags(p_vop, opt_ssop_values, &vop_flags, true);
-}
-
 /// The 'virtualedit' option is changed.
 const char *did_set_virtualedit(optset_T *args)
 {
@@ -2455,15 +1958,6 @@ const char *did_set_virtualedit(optset_T *args)
   return NULL;
 }
 
-int expand_set_virtualedit(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_ve_values,
-                               ARRAY_SIZE(opt_ve_values) - 1,
-                               numMatches,
-                               matches);
-}
-
 /// The 'whichwrap' option is changed.
 const char *did_set_whichwrap(optset_T *args)
 {
@@ -2488,48 +1982,6 @@ const char *did_set_wildmode(optset_T *args FUNC_ATTR_UNUSED)
   return NULL;
 }
 
-int expand_set_wildmode(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_wim_values,
-                               ARRAY_SIZE(opt_wim_values) - 1,
-                               numMatches,
-                               matches);
-}
-
-/// The 'wildoptions' option is changed.
-const char *did_set_wildoptions(optset_T *args FUNC_ATTR_UNUSED)
-{
-  return did_set_opt_flags(p_wop, opt_wop_values, &wop_flags, true);
-}
-
-int expand_set_wildoptions(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_wop_values,
-                               ARRAY_SIZE(opt_wop_values) - 1,
-                               numMatches,
-                               matches);
-}
-
-/// The 'winaltkeys' option is changed.
-const char *did_set_winaltkeys(optset_T *args FUNC_ATTR_UNUSED)
-{
-  if (*p_wak == NUL || check_opt_strings(p_wak, opt_wak_values, false) != OK) {
-    return e_invarg;
-  }
-  return NULL;
-}
-
-int expand_set_winaltkeys(optexpand_T *args, int *numMatches, char ***matches)
-{
-  return expand_set_opt_string(args,
-                               opt_wak_values,
-                               ARRAY_SIZE(opt_wak_values) - 1,
-                               numMatches,
-                               matches);
-}
-
 /// The 'winbar' option is changed.
 const char *did_set_winbar(optset_T *args)
 {
@@ -2550,16 +2002,6 @@ const char *did_set_winhighlight(optset_T *args)
 int expand_set_winhighlight(optexpand_T *args, int *numMatches, char ***matches)
 {
   return expand_set_opt_generic(args, get_highlight_name, numMatches, matches);
-}
-
-/// Check an option that can be a range of string values.
-///
-/// @param list  when true: accept a list of values
-///
-/// @return  OK for correct value, FAIL otherwise. Empty is always OK.
-static int check_opt_strings(char *val, const char **values, bool list)
-{
-  return opt_strings_flags(val, values, NULL, list);
 }
 
 /// Handle an option that can be a range of string values.
@@ -2606,7 +2048,7 @@ static int opt_strings_flags(const char *val, const char **values, unsigned *fla
 /// @return  OK if "p" is a valid fileformat name, FAIL otherwise.
 int check_ff_value(char *p)
 {
-  return check_opt_strings(p, opt_ff_values, false);
+  return opt_strings_flags(p, opt_ff_values, NULL, false);
 }
 
 static const char e_conflicts_with_value_of_listchars[]


### PR DESCRIPTION
#    Problem:

Many options have similar callbacks to check that the values are valid.

#    Solution:

Generalize these callbacks into a single function that reads the option table.
