### PR TITLE
vim-patch:9.1.1015: Coverity complains about dereferencing NULL value

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1658,7 +1658,7 @@ static void foldDelMarker(buf_T *buf, linenr_T lnum, char *marker, size_t marker
     if (*cms != NUL) {
       // Also delete 'commentstring' if it matches.
       char *cms2 = strstr(cms, "%s");
-      if (p - line >= cms2 - cms
+      if (cms2 != NULL && p - line >= cms2 - cms
           && strncmp(p - (cms2 - cms), cms, (size_t)(cms2 - cms)) == 0
           && strncmp(p + len, cms2 + 2, strlen(cms2 + 2)) == 0) {
         p -= cms2 - cms;


### PR DESCRIPTION
#### vim-patch:9.1.1015: Coverity complains about dereferencing NULL value

Problem:  Coverity complains about dereferencing NULL value
Solution: Check that cms2 is not null

closes: vim/vim#16438

https://github.com/vim/vim/commit/1ac53b84ada3a992f320566737e66fa00d48611f

Co-authored-by: Christian Brabandt <cb@256bit.org>