### PR TITLE
fix: vim.diagnostic.config does not take func as float config

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -435,7 +435,7 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
                        file or not. Similar to 'wrapscan'.
       • {severity}?    (`vim.diagnostic.SeverityFilter`) See
                        |diagnostic-severity|.
-      • {float}?       (`boolean|vim.diagnostic.Opts.Float`, default: `false`)
+      • {float}?       (`boolean|vim.diagnostic.Opts.Float|fun(namespace: integer, bufnr:integer): vim.diagnostic.Opts.Float`, default: `false`)
                        If `true`, call |vim.diagnostic.open_float()| after
                        moving. If a table, pass the table as the {opts}
                        parameter to |vim.diagnostic.open_float()|. Unless

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1018,9 +1018,18 @@ local function goto_diagnostic(diagnostic, opts)
     vim.cmd('normal! zv')
   end)
 
-  local float_opts = opts.float
+  --- @type vim.diagnostic.Opts.Float
+  local float_opts
+
+  if type(opts.float) == 'table' then
+    float_opts = opts.float --[[@as vim.diagnostic.Opts.Float]]
+  elseif type(opts.float) == 'function' then
+    float_opts = opts.float(diagnostic.namespace, diagnostic.bufnr)
+  elseif opts.float then
+    float_opts = {}
+  end
+
   if float_opts then
-    float_opts = type(float_opts) == 'table' and float_opts or {}
     vim.schedule(function()
       M.open_float(vim.tbl_extend('keep', float_opts, {
         bufnr = api.nvim_win_get_buf(winid),
@@ -1308,7 +1317,7 @@ end
 --- Unless overridden, the float will show diagnostics at the new cursor
 --- position (as if "cursor" were passed to the "scope" option).
 --- (default: `false`)
---- @field float? boolean|vim.diagnostic.Opts.Float
+--- @field float? boolean|vim.diagnostic.Opts.Float|fun(namespace: integer, bufnr:integer): vim.diagnostic.Opts.Float
 ---
 --- Window ID
 --- (default: `0`)


### PR DESCRIPTION
Fixes: https://github.com/neovim/neovim/issues/32022

Unfortunately I don't know how to test this in NixOS. Though I can successfully build the project launching `nvim` in build directory will result in following error. Hope anyone else check it or is there a way to get around this error?

```
Error detected while processing /home/s1n7ax/.config/nvim/init.lua:
E5113: Error while calling lua chunk: vim/_init_packages.lua:0: module 'vim.uri' not found:
``` 