### PR TITLE
build: fix `make install` on cmake 3.13 and 3.14

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -157,7 +157,7 @@ distclean:
 	$(MAKE) clean
 
 install: checkprefix nvim
-	$(CMAKE) --install build
+	$(CMAKE_GENERATOR) -C build install
 
 appimage:
 	bash scripts/genappimage.sh


### PR DESCRIPTION
Closes https://github.com/neovim/neovim/issues/30756.