### PR TITLE
fix(cmdline): prevent cmdline_show events after exiting cmdline

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -951,6 +951,8 @@ theend:
   kv_destroy(ccline.last_colors.colors);
 
   char *p = ccline.cmdbuff;
+  // Prevent show events triggered by a (vim.ui_attach) hide callback.
+  ccline.cmdbuff = NULL;
 
   if (ui_has(kUICmdline)) {
     ui_call_cmdline_hide(ccline.level, s->gotesc);
@@ -965,8 +967,6 @@ theend:
 
   if (did_save_ccline) {
     restore_cmdline(&save_ccline);
-  } else {
-    ccline.cmdbuff = NULL;
   }
 
   return (uint8_t *)p;
@@ -3415,6 +3415,10 @@ static void draw_cmdline(int start, int len)
 
 static void ui_ext_cmdline_show(CmdlineInfo *line)
 {
+  if (line->cmdbuff == NULL) {
+    return;
+  }
+
   Arena arena = ARENA_EMPTY;
   Array content;
   if (cmdline_star) {


### PR DESCRIPTION
Problem:  If a (vim.ui_attach) cmdline_hide callback triggers a redraw,
          it may cause cmdline_show events for an already exited cmdline.
Solution: Avoid emitting cmdline_show event when ccline.cmdbuff is
          already NULL. Unset ccline.cmdbuff before emitting cmdline_hide.