### PR TITLE
fix: show previews for nomodifiable buffers

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -319,6 +319,8 @@ PLUGINS
 
 • EditorConfig
   • spelling_language property is now supported.
+• 'inccommand' incremental preview can run on 'nomodifiable' buffers and
+  restores their 'modifiable' state
 
 STARTUP
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -168,6 +168,7 @@ typedef struct {
   pos_T save_b_op_end;
   varnumber_T save_changedtick;
   CpUndoInfo undo_info;
+  int save_b_p_ma;
 } CpBufInfo;
 
 typedef struct {
@@ -2419,6 +2420,7 @@ static void cmdpreview_prepare(CpInfo *cpinfo)
     if (!set_has(ptr_t, &saved_bufs, buf)) {
       CpBufInfo cp_bufinfo;
       cp_bufinfo.buf = buf;
+      cp_bufinfo.save_b_p_ma = buf->b_p_ma;
       cp_bufinfo.save_b_p_ul = buf->b_p_ul;
       cp_bufinfo.save_b_changed = buf->b_changed;
       cp_bufinfo.save_b_op_start = buf->b_op_start;
@@ -2509,6 +2511,7 @@ static void cmdpreview_restore_state(CpInfo *cpinfo)
     }
 
     buf->b_p_ul = cp_bufinfo.save_b_p_ul;        // Restore 'undolevels'
+    buf->b_p_ma = cp_bufinfo.save_b_p_ma;        // Restore 'modifiable'
   }
 
   for (size_t i = 0; i < cpinfo->win_info.size; i++) {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2704,7 +2704,6 @@ static int command_line_changed(CommandLineState *s)
       && current_sctx.sc_sid == 0    // only if interactive
       && *p_icm != NUL       // 'inccommand' is set
       && !exmode_active      // not in ex mode
-      && curbuf->b_p_ma      // buffer is modifiable
       && cmdline_star == 0   // not typing a password
       && !vpeekc_any()
       && cmdpreview_may_show(s)) {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -163,12 +163,12 @@ typedef struct {
 typedef struct {
   buf_T *buf;
   OptInt save_b_p_ul;
+  int save_b_p_ma;
   int save_b_changed;
   pos_T save_b_op_start;
   pos_T save_b_op_end;
   varnumber_T save_changedtick;
   CpUndoInfo undo_info;
-  int save_b_p_ma;
 } CpBufInfo;
 
 typedef struct {

--- a/test/functional/ui/inccommand_user_spec.lua
+++ b/test/functional/ui/inccommand_user_spec.lua
@@ -253,7 +253,7 @@ describe("'inccommand' for user commands", function()
     ]]
   end)
 
-  it("restores 'modifiable'", function()
+  it("can preview 'nomodifiable' buffer", function()
     exec_lua([[
       vim.api.nvim_create_user_command("PreviewTest", function() end, {
         preview = function(ev)
@@ -263,33 +263,23 @@ describe("'inccommand' for user commands", function()
         end,
       })
     ]])
+    command('set inccommand=split')
 
     command('set nomodifiable')
     eq(false, api.nvim_get_option_value('modifiable', { buf = 0 }))
 
     feed(':PreviewTest')
+
     screen:expect([[
       cats                                    |
-      {1:~                                       }|*15
+      {1:~                                       }|*8
+      {3:[No Name] [+]                           }|
+                                              |
+      {1:~                                       }|*4
+      {2:[Preview]                               }|
       :PreviewTest^                            |
     ]])
     feed('<Esc>')
-
-    eq(false, api.nvim_get_option_value('modifiable', { buf = 0 }))
-  end)
-
-  it("can preview 'nomodifiable' buffer", function()
-    exec_lua([[
-      vim.api.nvim_create_user_command("PreviewTest", function() end, {
-        preview = function(ev)
-          return 2
-        end,
-      })
-    ]])
-    command('set nomodifiable')
-    command('set inccommand=split')
-    feed(':PreviewTest')
-
     screen:expect([[
         text on line 1                        |
         more text on line 2                   |
@@ -299,13 +289,12 @@ describe("'inccommand' for user commands", function()
         did the text stop                     |
         why won't it stop                     |
         make the text stop                    |
+      ^                                        |
+      {1:~                                       }|*7
                                               |
-      {3:[No Name] [+]                           }|
-                                              |
-      {1:~                                       }|*4
-      {2:[Preview]                               }|
-      :PreviewTest^                            |
     ]])
+
+    eq(false, api.nvim_get_option_value('modifiable', { buf = 0 }))
   end)
 
   it('works with inccommand=nosplit', function()


### PR DESCRIPTION
closes #32016

The test fails if I add the check back in