### PR TITLE
vim-patch:9.1.1018: v9.1.0743 causes regression with diff mode

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -1622,6 +1622,11 @@ static void process_hunk(diff_T **dpp, diff_T **dprevp, int idx_orig, int idx_ne
     } else {
       // second overlap of new block with existing block
       dp->df_count[idx_new] += (linenr_T)hunk->count_new;
+      if ((dp->df_lnum[idx_new] + dp->df_count[idx_new] - 1)
+          > curtab->tp_diffbuf[idx_new]->b_ml.ml_line_count) {
+        dp->df_count[idx_new] = curtab->tp_diffbuf[idx_new]->b_ml.ml_line_count
+                                - dp->df_lnum[idx_new] + 1;
+      }
     }
 
     // Adjust the size of the block to include all the lines to the
@@ -1632,6 +1637,11 @@ static void process_hunk(diff_T **dpp, diff_T **dprevp, int idx_orig, int idx_ne
     if (off < 0) {
       // new change ends in existing block, adjust the end
       dp->df_count[idx_new] += -off;
+      if ((dp->df_lnum[idx_new] + dp->df_count[idx_new] - 1)
+          > curtab->tp_diffbuf[idx_new]->b_ml.ml_line_count) {
+        dp->df_count[idx_new] = curtab->tp_diffbuf[idx_new]->b_ml.ml_line_count
+                                - dp->df_lnum[idx_new] + 1;
+      }
       off = 0;
     }
 

--- a/test/functional/ui/diff_spec.lua
+++ b/test/functional/ui/diff_spec.lua
@@ -2044,6 +2044,26 @@ it('diff mode overlapped diff blocks will be merged', function()
     {2:Xdifile1    Xdifile2    }{3:Xdifile3   }|
                                        |
   ]])
+
+  WriteDiffFiles3('a\nb\nc', 'd\ne', 'b\nf')
+  screen:expect([[
+    {7:  }{27:a}{4:        }│{7:  }{27:d}{4:        }│{7:  }{27:^b}{4:        }|
+    {7:  }{27:b}{4:        }│{7:  }{27:e}{4:        }│{7:  }{27:f}{4:        }|
+    {7:  }{22:c        }│{7:  }{23:---------}│{7:  }{23:---------}|
+    {1:~          }│{1:~          }│{1:~          }|*15
+    {2:Xdifile1    Xdifile2    }{3:Xdifile3   }|
+                                       |
+  ]])
+
+  WriteDiffFiles3('a\nb\nc', 'd\ne', 'b')
+  screen:expect([[
+    {7:  }{27:a}{4:        }│{7:  }{27:d}{4:        }│{7:  }{27:^b}{4:        }|
+    {7:  }{27:b}{4:        }│{7:  }{27:e}{4:        }│{7:  }{23:---------}|
+    {7:  }{22:c        }│{7:  }{23:---------}│{7:  }{23:---------}|
+    {1:~          }│{1:~          }│{1:~          }|*15
+    {2:Xdifile1    Xdifile2    }{3:Xdifile3   }|
+                                       |
+  ]])
 end)
 
 -- oldtest: Test_diff_topline_noscroll()

--- a/test/old/testdir/test_diffmode.vim
+++ b/test/old/testdir/test_diffmode.vim
@@ -2004,6 +2004,12 @@ func Test_diff_overlapped_diff_blocks_will_be_merged()
   call WriteDiffFiles3(buf, ["a", "b", "c"], ["a", "x", "c"], ["a", "b", "y", "c"])
   call VerifyBoth(buf, "Test_diff_overlapped_3.37", "")
 
+  call WriteDiffFiles3(buf, ["a", "b", "c"], ["d", "e"], ["b", "f"])
+  call VerifyBoth(buf, "Test_diff_overlapped_3.38", "")
+
+  call WriteDiffFiles3(buf, ["a", "b", "c"], ["d", "e"], ["b"])
+  call VerifyBoth(buf, "Test_diff_overlapped_3.39", "")
+
   call StopVimInTerminal(buf)
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.1018: v9.1.0743 causes regression with diff mode

Problem:  v9.1.0743 causes regression with diff mode
Solution: Fix the regression with overlapping regions

closes: vim/vim#16454

https://github.com/vim/vim/commit/01f6509fb2de1627cc4ec2c109cd0aa2e3346d50

Co-authored-by: Yukihiro Nakadaira <yukihiro.nakadaira@gmail.com>