### PR TITLE
fix(treesitter): prevent infinite recursion when parsing

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -575,7 +575,17 @@ function LanguageTree:_parse(range, timeout)
     range = range,
   })
 
+  ---@type vim.treesitter.LanguageTree[]
+  local children = {}
   for _, child in pairs(self._children) do
+    -- We must iterate over self-injections last to prevent infinite recursion.
+    if child:lang() ~= self:lang() then
+      children[#children + 1] = child
+    end
+  end
+  children[#children + 1] = self._children[self:lang()]
+
+  for _, child in ipairs(children) do
     if timeout == 0 then
       return self._trees, false
     end


### PR DESCRIPTION
This addresses a tricky bug discovered by @luukvbaal in the matrix chat. From my testing, this consistently fixes the issue. The solution is just to parse a language's self-injections after all other injections, which prevents what looks like some infinite recursion issues.

I'm not sure why it was the async parsing that caused this issue to present itself, I would think that it would have been a problem even with synchronous parsing :thinking: Maybe the issue is nonexistent when running only on a single pass (event loop iteration) somehow

NOTE: A separate issue was discussed where `:q` hangs, which is due to the fact that it will always wait until an async function completes and the callback is run. That is a separate issue, but shouldn't matter unless there are async functions that will run indefinitely. 