### PR TITLE
vim-patch:9.1.{1013,1017}

### DIFF
--- a/src/nvim/errors.h
+++ b/src/nvim/errors.h
@@ -129,6 +129,7 @@ EXTERN const char e_missingparen[] INIT(= N_("E107: Missing parentheses: %s"));
 EXTERN const char e_empty_buffer[] INIT(= N_("E749: Empty buffer"));
 EXTERN const char e_nobufnr[] INIT(= N_("E86: Buffer %" PRId64 " does not exist"));
 
+EXTERN const char e_unknown_function_str[] INIT(= N_("E117: Unknown function: %s"));
 EXTERN const char e_str_not_inside_function[] INIT(= N_("E193: %s not inside a function"));
 
 EXTERN const char e_invalpat[] INIT(= N_("E682: Invalid search pattern or delimiter"));

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -575,22 +575,29 @@ static void f_call(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   if (func == NULL || *func == NUL) {
     return;         // type error, empty name or null function
   }
+  char *p = func;
+  char *tofree = trans_function_name(&p, false, TFN_INT|TFN_QUIET, NULL, NULL);
+  if (tofree == NULL) {
+    emsg_funcname(e_unknown_function_str, func);
+    return;
+  }
+  func = tofree;
 
   dict_T *selfdict = NULL;
   if (argvars[2].v_type != VAR_UNKNOWN) {
     if (tv_check_for_dict_arg(argvars, 2) == FAIL) {
-      if (owned) {
-        func_unref(func);
-      }
-      return;
+      goto done;
     }
     selfdict = argvars[2].vval.v_dict;
   }
 
   func_call(func, &argvars[1], partial, selfdict, rettv);
+
+done:
   if (owned) {
     func_unref(func);
   }
+  xfree(tofree);
 }
 
 /// "changenr()" function

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -548,8 +548,7 @@ static void f_byte2line(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 /// "call(func, arglist [, dict])" function
 static void f_call(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
-  if (argvars[1].v_type != VAR_LIST) {
-    emsg(_(e_listreq));
+  if (tv_check_for_list_arg(argvars, 1) == FAIL) {
     return;
   }
   if (argvars[1].vval.v_list == NULL) {
@@ -575,13 +574,16 @@ static void f_call(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   if (func == NULL || *func == NUL) {
     return;         // type error, empty name or null function
   }
-  char *p = func;
-  char *tofree = trans_function_name(&p, false, TFN_INT|TFN_QUIET, NULL, NULL);
-  if (tofree == NULL) {
-    emsg_funcname(e_unknown_function_str, func);
-    return;
+  char *tofree = NULL;
+  if (argvars[0].v_type == VAR_STRING) {
+    char *p = func;
+    tofree = trans_function_name(&p, false, TFN_INT|TFN_QUIET, NULL, NULL);
+    if (tofree == NULL) {
+      emsg_funcname(e_unknown_function_str, func);
+      return;
+    }
+    func = tofree;
   }
-  func = tofree;
 
   dict_T *selfdict = NULL;
   if (argvars[2].v_type != VAR_UNKNOWN) {

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -78,7 +78,6 @@ static funccall_T *current_funccal = NULL;
 // item in it is still being used.
 static funccall_T *previous_funccal = NULL;
 
-static const char *e_unknown_function_str = N_("E117: Unknown function: %s");
 static const char *e_funcexts = N_("E122: Function %s already exists, add ! to replace it");
 static const char *e_funcdict = N_("E717: Dictionary entry already exists");
 static const char *e_funcref = N_("E718: Funcref required");

--- a/test/functional/vimscript/ctx_functions_spec.lua
+++ b/test/functional/vimscript/ctx_functions_spec.lua
@@ -188,7 +188,10 @@ describe('context functions', function()
       function RestoreFuncs()
         call ctxpop()
       endfunction
+
+      let g:sid = expand('<SID>')
       ]])
+      local sid = api.nvim_get_var('sid')
 
       eq('Hello, World!', exec_capture([[call Greet('World')]]))
       eq(
@@ -200,11 +203,11 @@ describe('context functions', function()
       call('DeleteSFuncs')
 
       eq(
-        'function Greet, line 1: Vim(call):E117: Unknown function: s:greet',
+        ('function Greet, line 1: Vim(call):E117: Unknown function: %sgreet'):format(sid),
         pcall_err(command, [[call Greet('World')]])
       )
       eq(
-        'function GreetAll, line 1: Vim(call):E117: Unknown function: s:greet_all',
+        ('function GreetAll, line 1: Vim(call):E117: Unknown function: %sgreet_all'):format(sid),
         pcall_err(command, [[call GreetAll('World', 'One', 'Two', 'Three')]])
       )
 

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -2672,7 +2672,9 @@ endfunc
 func Test_call()
   call assert_equal(3, call('len', [123]))
   call assert_equal(3, 'len'->call([123]))
-  call assert_fails("call call('len', 123)", 'E714:')
+  call assert_equal(4, call({ x -> len(x) }, ['xxxx']))
+  call assert_equal(2, call(function('len'), ['xx']))
+  call assert_fails("call call('len', 123)", 'E1211:')
   call assert_equal(0, call('', []))
   call assert_equal(0, call('len', v:_null_list))
 

--- a/test/old/testdir/test_user_func.vim
+++ b/test/old/testdir/test_user_func.vim
@@ -380,7 +380,7 @@ func Test_script_local_func()
   " Try to call a script local function in global scope
   let lines =<< trim [CODE]
     :call assert_fails('call s:Xfunc()', 'E81:')
-    :call assert_fails('let x = call("<SID>Xfunc", [])', 'E120:')
+    :call assert_fails('let x = call("<SID>Xfunc", [])', ['E81:', 'E117:'])
     :call writefile(v:errors, 'Xresult')
     :qall
 


### PR DESCRIPTION
#### vim-patch:9.1.1013: Vim9: Regression caused by patch v9.1.0646

Problem:  Vim9: Regression caused by patch v9.1.0646
Solution: Translate the function name before invoking it in call()
          (Yegappan Lakshmanan)

closes: vim/vim#16445

https://github.com/vim/vim/commit/6289f9159102e0855bedc566636b5e7ca6ced72c

N/A patch:
vim-patch:8.2.4176: Vim9: cannot use imported function with call()

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.1.1017: Vim9: Patch 9.1.1013 causes a few problems

Problem:  Vim9: Patch 9.1.1013 causes a few problems
Solution: Translate the function name only when it is a string
          (Yegappan Lakshmanan)

closes: vim/vim#16450

https://github.com/vim/vim/commit/9904cbca4132f7376246a1a31305eb53e9530023

Cherry-pick call() change from patch 9.0.0345.

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>