### PR TITLE
fix(messages): lsp window/showMessage is not an error

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -702,14 +702,14 @@ local wait_result_reason = { [-1] = 'timeout', [-2] = 'interrupted', [-3] = 'err
 ---
 --- @param ... string List to write to the buffer
 local function err_message(...)
-  local chunks = { { table.concat({ ... }) } }
+  local chunks = { { table.concat(vim.iter({ ... }):flatten():totable()) } }
   if vim.in_fast_event() then
     vim.schedule(function()
-      vim.api.nvim_echo(chunks, true, { err = true })
+      api.nvim_echo(chunks, true, { err = true })
       api.nvim_command('redraw')
     end)
   else
-    vim.api.nvim_echo(chunks, true, { err = true })
+    api.nvim_echo(chunks, true, { err = true })
     api.nvim_command('redraw')
   end
 end

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -583,7 +583,7 @@ NSC['window/showMessage'] = function(_, params, ctx)
     err_message('LSP[', client_name, '] ', message)
   else
     message = ('LSP[%s][%s] %s\n'):format(client_name, protocol.MessageType[message_type], message)
-    api.nvim_echo({ { message } }, true, { err = true })
+    api.nvim_echo({ { message } }, true, {})
   end
   return params
 end

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -951,10 +951,9 @@ theend:
   kv_destroy(ccline.last_colors.colors);
 
   char *p = ccline.cmdbuff;
-  // Prevent show events triggered by a (vim.ui_attach) hide callback.
-  ccline.cmdbuff = NULL;
 
   if (ui_has(kUICmdline)) {
+    ccline.redraw_state = kCmdRedrawNone;
     ui_call_cmdline_hide(ccline.level, s->gotesc);
     msg_ext_clear_later();
   }
@@ -967,6 +966,8 @@ theend:
 
   if (did_save_ccline) {
     restore_cmdline(&save_ccline);
+  } else {
+    ccline.cmdbuff = NULL;
   }
 
   return (uint8_t *)p;
@@ -3415,10 +3416,6 @@ static void draw_cmdline(int start, int len)
 
 static void ui_ext_cmdline_show(CmdlineInfo *line)
 {
-  if (line->cmdbuff == NULL) {
-    return;
-  }
-
   Arena arena = ARENA_EMPTY;
   Array content;
   if (cmdline_star) {


### PR DESCRIPTION
**fix(messages): lsp window/showMessage is not an error**

Ref https://github.com/neovim/neovim/discussions/32015

**refactor(cmdline): more idiomatic way to avoid cmdline_show**

Problem:  Fix applied in #32033 can be more idiomatic.
Solution: Unset redraw_state instead of cmdbuff.