### PR TITLE
ci: add arm64 runner

### DIFF
--- a/.github/scripts/install_deps.sh
+++ b/.github/scripts/install_deps.sh
@@ -30,7 +30,7 @@ if [[ $os == Linux ]]; then
   fi
 
   if [[ -n $TEST ]]; then
-    sudo apt-get install -y locales-all cpanminus attr libattr1-dev gdb inotify-tools
+    sudo apt-get install -y locales-all cpanminus attr libattr1-dev gdb inotify-tools xdg-utils
 
     # Use default CC to avoid compilation problems when installing Python modules
     CC=cc python3 -m pip -q install --user --upgrade --break-system-packages pynvim

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -204,37 +204,6 @@ jobs:
   windows:
     uses: ./.github/workflows/test_windows.yml
 
-  # This job tests the following things:
-  # - Check if MinSizeRel and RelWithDebInfo compiles correctly.
-  # - Test the above build types with the GCC compiler specifically.
-  #   Empirically the difference in warning levels between GCC and other
-  #   compilers is particularly big.
-  # - Test if the build works with multi-config generators. We mostly use
-  #   single-config generators so it's nice to have a small sanity check for
-  #   multi-config.
-  build-types:
-    runs-on: ubuntu-24.04
-    timeout-minutes: 10
-    env:
-      CC: gcc
-    steps:
-      - uses: actions/checkout@v4
-      - uses: ./.github/actions/setup
-
-      - name: Build third-party deps
-        run: |
-          cmake -S cmake.deps -B .deps -G "Ninja Multi-Config"
-          cmake --build .deps
-
-      - name: Configure
-        run: cmake --preset ci -G "Ninja Multi-Config"
-
-      - name: RelWithDebInfo
-        run: cmake --build build --config RelWithDebInfo
-
-      - name: MinSizeRel
-        run: cmake --build build --config MinSizeRel
-
   with-external-deps:
     runs-on: ubuntu-24.04
     timeout-minutes: 10

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -107,6 +107,7 @@ jobs:
             { runner: ubuntu-24.04, os: ubuntu, flavor: asan, cc: clang, flags: -D ENABLE_ASAN_UBSAN=ON },
             { runner: ubuntu-24.04, os: ubuntu, flavor: tsan, cc: clang, flags: -D ENABLE_TSAN=ON },
             { runner: ubuntu-24.04, os: ubuntu, flavor: release, cc: gcc, flags: -D CMAKE_BUILD_TYPE=Release },
+            { runner: ubuntu-24.04-arm, os: ubuntu, flavor: arm, cc: gcc, flags: -D CMAKE_BUILD_TYPE=RelWithDebInfo },
             { runner: macos-13, os: macos, flavor: intel, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
             { runner: macos-15, os: macos, flavor: arm, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
             { runner: ubuntu-24.04, os: ubuntu, flavor: puc-lua, cc: gcc, deps_flags: -D USE_BUNDLED_LUAJIT=OFF -D USE_BUNDLED_LUA=ON, flags: -D PREFER_LUA=ON },

--- a/runtime/doc/support.txt
+++ b/runtime/doc/support.txt
@@ -12,7 +12,8 @@ Support                                                              *support*
 Supported platforms					 *supported-platforms*
 
 `System`          `Tier`      `Versions`                  `Tested versions`
-Linux            1      >= 2.6.32, glibc >= 2.12     Ubuntu 24.04
+Linux (x86_64)   1      >= 2.6.32, glibc >= 2.12     Ubuntu 24.04
+Linux (arm64)    1      >= 2.6.32, glibc >= 2.12     Ubuntu 24.04
 macOS (Intel)    1      >= 11                        macOS 13
 macOS (M1)       1      >= 11                        macOS 15
 Windows 64-bit   1      >= Windows 10 Version 1809   Windows Server 2022


### PR DESCRIPTION
Problem: No tests on Linux Arm.

Solution: Add tests on Linux Arm with `RelWithDebInfo`.   Remove duplicate and low-leverage `build-types` job.