### PR TITLE
docs: change augroup names to new convention

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1222,10 +1222,10 @@ Thus you can resize the command-line window, but not others.
 The |getcmdwintype()| function returns the type of the command-line being
 edited as described in |cmdwin-char|.
 
-Nvim defines this default CmdWinEnter autocmd in the "nvim_cmdwin" group: >
+Nvim defines this default CmdWinEnter autocmd in the "nvim.cmdwin" group: >
     autocmd CmdWinEnter [:>] syntax sync minlines=1 maxlines=1
 <
-You can disable this in your config with "autocmd! nvim_cmdwin". |default-autocmds|
+You can disable this in your config with "autocmd! nvim.cmdwin". |default-autocmds|
 
 
 AUTOCOMMANDS

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -170,7 +170,7 @@ DEFAULT AUTOCOMMANDS
 Default autocommands exist in the following groups. Use ":autocmd! {group}" to
 remove them and ":autocmd {group}" to see how they're defined.
 
-nvim_terminal:
+nvim.terminal:
 - BufReadCmd: Treats "term://" buffers as |terminal| buffers. |terminal-start|
 - TermClose: A |terminal| buffer started with no arguments (which thus uses
   'shell') and which exits with no error is closed automatically.
@@ -193,10 +193,10 @@ nvim_terminal:
     - 'winhighlight' uses |hl-StatusLineTerm| and |hl-StatusLineTermNC| in
       place of |hl-StatusLine| and |hl-StatusLineNC|
 
-nvim_cmdwin:
+nvim.cmdwin:
 - CmdwinEnter: Limits syntax sync to maxlines=1 in the |cmdwin|.
 
-nvim_swapfile:
+nvim.swapfile:
 - SwapExists: Skips the swapfile prompt (sets |v:swapchoice| to "e") when the
   swapfile is owned by a running Nvim process. Shows |W325| "Ignoring
   swapfile…" message.


### PR DESCRIPTION
Ref: 09e01437c968be4c6e9f6bb3ac8811108c58008c
