### PR TITLE
vim-patch:9.1.1021: string might be used without a trailing NUL

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -103,7 +103,8 @@ void win_redr_status(win_T *wp)
          || bufIsChanged(wp->w_buffer)
          || wp->w_buffer->b_p_ro)
         && plen < MAXPATHL - 1) {
-      *(p + plen++) = ' ';
+      *(p + plen++) = ' ';        // replace NUL with space
+      *(p + plen) = NUL;          // NUL terminate the string
     }
     if (bt_help(wp->w_buffer)) {
       plen += snprintf(p + plen, MAXPATHL - (size_t)plen, "%s", _("[Help]"));


### PR DESCRIPTION
#### vim-patch:9.1.1021: string might be used without a trailing NUL

Problem:  string might be used without a trailing NUL (after v9.1.0997)
Solution: Make sure that the buffer is NUL terminated

closes: vim/vim#16457

https://github.com/vim/vim/commit/70dfc374ec72634a0a61aea8344178779675d516

Co-authored-by: John Marriott <basilisk@internode.on.net>