### PR TITLE
vim-patch:a234a46: runtime(doc): fix typo in usr_02.txt

### DIFF
--- a/runtime/doc/usr_02.txt
+++ b/runtime/doc/usr_02.txt
@@ -684,8 +684,8 @@ Summary:					*help-summary*  >
 	:help E128
 <    takes you to the |:function| command
 
-27) Documenction for packages distributed with Vim have the form package-<name>.
-     So >
+27) Documentation for packages distributed with Vim have the form
+     package-<name>. So >
 	:help package-termdebug
 <
     will bring you to the help section for the included termdebug plugin and


### PR DESCRIPTION
#### vim-patch:a234a46: runtime(doc): fix typo in usr_02.txt

https://github.com/vim/vim/commit/a234a46651ef174549792bd64d4bef64a32072bb

Co-authored-by: Christian Brabandt <cb@256bit.org>