### PR TITLE
docs(gh): use new issue types

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,6 +1,6 @@
 name: Bug Report
 description: Report a problem in Nvim
-labels: [bug]
+type: 'bug'
 body:
 
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,6 +1,6 @@
 name: Feature request
 description: Request an enhancement for Nvim
-labels: [enhancement]
+type: 'enhancement'
 body:
 
   - type: markdown

--- a/.github/ISSUE_TEMPLATE/lsp_bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/lsp_bug_report.yml
@@ -1,7 +1,8 @@
 name: Language server (LSP) client bug
 description: Report an issue with Nvim LSP
 title: "LSP: "
-labels: [bug, lsp]
+type: bug
+labels: [lsp]
 body:
 
   - type: markdown


### PR DESCRIPTION
Advantage: Easier visibility, better filtering, can be extended to new custom issue types (have to be defined for the org).

Tested on https://github.com/nvim-treesitter/nvim-treesitter/issues