### PR TITLE
fix(lsp): document_symbol should use loclist as default

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1445,12 +1445,11 @@ Lua module: vim.lsp.buf                                              *lsp-buf*
                         vim.lsp.buf.definition({ on_list = on_list })
                         vim.lsp.buf.references(nil, { on_list = on_list })
 <
-
-                    If you prefer loclist instead of qflist: >lua
+      • {loclist}?  (`boolean`) Whether to use the |location-list| or the
+                    |quickfix| list. >lua
                         vim.lsp.buf.definition({ loclist = true })
-                        vim.lsp.buf.references(nil, { loclist = true })
+                        vim.lsp.buf.references(nil, { loclist = false })
 <
-      • {loclist}?  (`boolean`)
 
 *vim.lsp.LocationOpts*
     Extends: |vim.lsp.ListOpts|
@@ -1553,7 +1552,7 @@ document_highlight()                        *vim.lsp.buf.document_highlight()*
     |hl-LspReferenceWrite|
 
 document_symbol({opts})                        *vim.lsp.buf.document_symbol()*
-    Lists all symbols in the current buffer in the quickfix window.
+    Lists all symbols in the current buffer in the |location-list|.
 
     Parameters: ~
       • {opts}  (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -26,6 +26,9 @@ LSP
 
 • `lsp/` runtimepath files should return a table instead of calling
   |vim.lsp.config()| (or assigning to `vim.lsp.config`). See |lsp-config|
+• `vim.lsp.buf.document_symbol()` uses the |location-list| by default. Use
+  `vim.lsp.buf.document_symbol({ loclist = false })` to use the |quickfix|
+  list.
 
 
 OPTIONS

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -252,13 +252,13 @@ end
 --- vim.lsp.buf.definition({ on_list = on_list })
 --- vim.lsp.buf.references(nil, { on_list = on_list })
 --- ```
+--- @field on_list? fun(t: vim.lsp.LocationOpts.OnList)
 ---
---- If you prefer loclist instead of qflist:
+--- Whether to use the |location-list| or the |quickfix| list.
 --- ```lua
 --- vim.lsp.buf.definition({ loclist = true })
---- vim.lsp.buf.references(nil, { loclist = true })
+--- vim.lsp.buf.references(nil, { loclist = false })
 --- ```
---- @field on_list? fun(t: vim.lsp.LocationOpts.OnList)
 --- @field loclist? boolean
 
 --- @class vim.lsp.LocationOpts.OnList
@@ -796,9 +796,10 @@ function M.references(context, opts)
   end
 end
 
---- Lists all symbols in the current buffer in the quickfix window.
+--- Lists all symbols in the current buffer in the |location-list|.
 --- @param opts? vim.lsp.ListOpts
 function M.document_symbol(opts)
+  opts = vim.tbl_deep_extend('keep', opts or {}, { loclist = true })
   local params = { textDocument = util.make_text_document_params() }
   request_with_opts(ms.textDocument_documentSymbol, params, opts)
 end


### PR DESCRIPTION
Problem: Not able to open document symbols for different buffers

Solution: Use the location list as default.

To switch back to previous behavior (qflist):

  vim.lsp.buf.document_symbol({ loclist = false })

Fixes: #31832
