### PR TITLE
docs(float): Add tag `floating-windows`

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -453,7 +453,7 @@ Example using the API from Vimscript: >vim
 
 
 ==============================================================================
-Floating windows                                                 *api-floatwin*
+Floating windows				*api-floatwin* *floating-windows*
 
 Floating windows ("floats") are displayed on top of normal windows.  This is
 useful to implement simple widgets, such as tooltips displayed next to the


### PR DESCRIPTION
Problem:
- It was hard for me to find documents about "floating windows" in Nvim
- ~~Due to the difference in terms between Nvim (floating windows) and Vim (popup windows), people transitioning from Vim may also find it hard to find the relevant doc in Nvim~~
- ~~The tag `extmark` seems redundant for me (we already have `extmarks`)~~

Solution:
- Add tags `api-floating-windows` and `popupwin`
- ~~Remove tag `extmark`~~