### PR TITLE
feat(treesitter): allow is_valid() to accept a range

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -355,6 +355,8 @@ TREESITTER
   descendant itself.
 • |LanguageTree:parse()| optionally supports asynchronous invocation, which is
   activated by passing the `on_parse` callback parameter.
+• |LanguageTree:is_valid()| can be passed a range which narrows the validity
+  check.
 
 TUI
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1551,7 +1551,8 @@ LanguageTree:invalidate({reload})                  *LanguageTree:invalidate()*
     Parameters: ~
       • {reload}  (`boolean?`)
 
-LanguageTree:is_valid({exclude_children})            *LanguageTree:is_valid()*
+                                                     *LanguageTree:is_valid()*
+LanguageTree:is_valid({exclude_children}, {range})
     Returns whether this LanguageTree is valid, i.e., |LanguageTree:trees()|
     reflects the latest state of the source. If invalid, user should call
     |LanguageTree:parse()|.
@@ -1559,6 +1560,9 @@ LanguageTree:is_valid({exclude_children})            *LanguageTree:is_valid()*
     Parameters: ~
       • {exclude_children}  (`boolean?`) whether to ignore the validity of
                             children (default `false`)
+      • {range}             (`boolean|Range?`) range to check for validity
+                            (entire tree is checked if the value is
+                            `boolean|nil`)
 
     Return: ~
         (`boolean`)


### PR DESCRIPTION
This commit allows `LanguageTree:is_valid()` to accept a range parameter which will narrow the scope of the validity check. This allows the tree to return earlier much more often in the highlighter, saving lots of CPU cycles (especially when re-parsing would've taken multiple event loop iterations).

Fixes #32075