### PR TITLE
feat(options): writetimestamp

### DIFF
--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -42,6 +42,7 @@
 #include "nvim/os/fs_defs.h"
 #include "nvim/os/input.h"
 #include "nvim/os/os_defs.h"
+#include "nvim/os/time.h"
 #include "nvim/path.h"
 #include "nvim/pos_defs.h"
 #include "nvim/sha256.h"
@@ -1770,6 +1771,12 @@ restore_backup:
         xstrlcat(IObuff, shortmess(SHM_WRI) ? _(" [a]") : _(" appended"), IOSIZE);
       } else {
         xstrlcat(IObuff, shortmess(SHM_WRI) ? _(" [w]") : _(" written"), IOSIZE);
+      }
+      if (strlen(p_wt) > 0) {
+        char ctime_buf[100];
+        os_ctimefmt(ctime_buf, sizeof(ctime_buf), false, p_wt);
+        xstrlcat(IObuff, _(" "), IOSIZE);
+        xstrlcat(IObuff, ctime_buf, IOSIZE);
       }
     }
 

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -618,6 +618,7 @@ EXTERN int p_write;             ///< 'write'
 EXTERN int p_wa;                ///< 'writeany'
 EXTERN int p_wb;                ///< 'writebackup'
 EXTERN OptInt p_wd;             ///< 'writedelay'
+EXTERN char *p_wt;              ///< 'writetimestamp'
 EXTERN int p_cdh;               ///< 'cdhome'
 
 // Value for b_p_ul indicating the global value must be used.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -10464,6 +10464,24 @@ local options = {
       type = 'number',
       varname = 'p_wd',
     },
+    {
+      abbreviation = 'wt',
+      defaults = { if_true = '' },
+      desc = [=[
+        Display a timestamp in the given format when writing to a file.
+        Examples: >vim
+        	set writetimestamp=%H:%M:%S
+        	set writetimestamp=%a\ %b\ %d\ %H:%M:%S\ %Y
+        	set writetimestamp=
+        	set writetimestamp=at\ %r\ %Z
+        <
+      ]=],
+      full_name = 'writetimestamp',
+      scope = { 'global' },
+      short_desc = N_('display timestamp when writing to a file'),
+      type = 'string',
+      varname = 'p_wt',
+    },
   },
 }
 

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -130,14 +130,15 @@ struct tm *os_localtime(struct tm *result) FUNC_ATTR_NONNULL_ALL
   return os_localtime_r(&rawtime, result);
 }
 
-/// Portable version of POSIX ctime_r()
+/// Gets the current Unix timestamp using a format string.
 ///
 /// @param clock[in]
 /// @param result[out] Pointer to a 'char' where the result should be placed
 /// @param result_len length of result buffer
+/// @param format format string
 /// @return human-readable string of current local time
-char *os_ctime_r(const time_t *restrict clock, char *restrict result, size_t result_len,
-                 bool add_newline)
+char *os_ctimefmt_r(const time_t *restrict clock, char *restrict result,
+                    size_t result_len, bool add_newline, const char *format)
   FUNC_ATTR_NONNULL_ALL FUNC_ATTR_NONNULL_RET
 {
   struct tm clock_local;
@@ -147,7 +148,7 @@ char *os_ctime_r(const time_t *restrict clock, char *restrict result, size_t res
     xstrlcpy(result, _("(Invalid)"), result_len - 1);
   } else {
     // xgettext:no-c-format
-    if (strftime(result, result_len - 1, _("%a %b %d %H:%M:%S %Y"), clock_local_ptr) == 0) {
+    if (strftime(result, result_len - 1, format, clock_local_ptr) == 0) {
       // Quoting "man strftime":
       // > If the length of the result string (including the terminating
       // > null byte) would exceed max bytes, then strftime() returns 0,
@@ -159,6 +160,33 @@ char *os_ctime_r(const time_t *restrict clock, char *restrict result, size_t res
     xstrlcat(result, "\n", result_len);
   }
   return result;
+}
+
+/// Portable version of POSIX ctime_r()
+///
+/// @param clock[in]
+/// @param result[out] Pointer to a 'char' where the result should be placed
+/// @param result_len length of result buffer
+/// @return human-readable string of current local time
+char *os_ctime_r(const time_t *restrict clock, char *restrict result, size_t result_len,
+                 bool add_newline)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_NONNULL_RET
+{
+  const char *ctime_posix_format = _("%a %b %d %H:%M:%S %Y");
+  return os_ctimefmt_r(clock, result, result_len, add_newline, ctime_posix_format);
+}
+
+/// Gets the current Unix timestamp using a format string.
+///
+/// @param result[out] Pointer to a 'char' where the result should be placed
+/// @param result_len length of result buffer
+/// @param format format string
+/// @return human-readable string of current local time
+char *os_ctimefmt(char *result, size_t result_len, bool add_newline, const char *format)
+  FUNC_ATTR_NONNULL_ALL FUNC_ATTR_NONNULL_RET
+{
+  time_t rawtime = time(NULL);
+  return os_ctimefmt_r(&rawtime, result, result_len, add_newline, format);
 }
 
 /// Gets the current Unix timestamp and adjusts it to local time.

--- a/test/functional/options/writetimestamp_spec.lua
+++ b/test/functional/options/writetimestamp_spec.lua
@@ -1,0 +1,68 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local clear = n.clear
+local command = n.command
+local eq = t.eq
+local exec_capture = n.exec_capture
+local mkdir = t.mkdir
+local rmdir = n.rmdir
+
+
+describe("'writetimestamp'", function()
+  local tmpdir = 'Xtest_options_writetimestamp'
+
+  setup(function()
+    rmdir(tmpdir)
+    mkdir(tmpdir)
+  end)
+
+  teardown(function()
+    rmdir(tmpdir)
+  end)
+
+  before_each(function()
+    clear()
+  end)
+
+  it('setting writetimestamp', function()
+    local fname = tmpdir .. 'file.txt'
+    local write_output = '"' .. fname .. '"' .. ' [New] 0L, 0B written'
+    local format_string = ''
+
+    os.remove(fname)
+    command('write ' .. fname)
+    eq(exec_capture('messages'), write_output)
+    clear()
+    os.remove(fname)
+
+    format_string = '%H:%M:%S'                      -- 9: " HH:MM:SS"
+    command('set writetimestamp=' .. format_string)
+    command('write ' .. fname)
+    eq(string.len(exec_capture('messages')), string.len(write_output) + 9)
+    clear()
+    os.remove(fname)
+
+    format_string = '%a\\ %b\\ %d\\ %H:%M:%S\\ %Y'  -- 25: " WKD MON DD HH:MM:SS YYYY"
+    command('set writetimestamp=' .. format_string)
+    command('write ' .. fname)
+    eq(string.len(exec_capture('messages')), string.len(write_output) + 25)
+    clear()
+    os.remove(fname)
+
+    format_string = 'at\\ %r\\ %Z'                  -- 19: " at HH:MM:SS XM TMZ"
+    command('set writetimestamp=' .. format_string)
+    command('write ' .. fname)
+    eq(string.len(exec_capture('messages')), string.len(write_output) + 19)
+    clear()
+    os.remove(fname)
+
+    format_string = ''                              -- 0: ""
+    command('set writetimestamp=' .. format_string)
+    command('write ' .. fname)
+    eq(exec_capture('messages'), write_output)
+    clear()
+    os.remove(fname)
+  end)
+end)
+


### PR DESCRIPTION
New option `writetimestamp` `wt` that can be set to a format string. This will cause a timestamp to be displayed after writing or appending a file. Disabled if empty.

Created `os_ctimefmt()` which is like `os_ctime()` with an additional argument to accept a format string for the timestamp.

`os_ctime_r()` used a constant format string, moved the core logic into `os_ctimefmt_r()` for increased flexibility.

<img width="750" alt=":set writetimestamp=%H:%M:%S" src="https://github.com/user-attachments/assets/8002b09d-efc9-4a68-bdde-28919c7870e7" />
