### PR TITLE
refactor(treesitter): use coroutines for resuming _parse() logic

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -379,6 +379,8 @@ TREESITTER
   activated by passing the `on_parse` callback parameter.
 • |vim.treesitter.query.set()| can now inherit and/or extend runtime file
   queries in addition to overriding.
+• |LanguageTree:is_valid()| now accepts a range parameter to narrow the scope
+  of the validity check.
 
 TUI
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1581,7 +1581,8 @@ LanguageTree:invalidate({reload})                  *LanguageTree:invalidate()*
     Parameters: ~
       • {reload}  (`boolean?`)
 
-LanguageTree:is_valid({exclude_children})            *LanguageTree:is_valid()*
+                                                     *LanguageTree:is_valid()*
+LanguageTree:is_valid({exclude_children}, {range})
     Returns whether this LanguageTree is valid, i.e., |LanguageTree:trees()|
     reflects the latest state of the source. If invalid, user should call
     |LanguageTree:parse()|.
@@ -1589,6 +1590,7 @@ LanguageTree:is_valid({exclude_children})            *LanguageTree:is_valid()*
     Parameters: ~
       • {exclude_children}  (`boolean?`) whether to ignore the validity of
                             children (default `false`)
+      • {range}             (`Range?`) range to check for validity
 
     Return: ~
         (`boolean`)

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -633,7 +633,7 @@ int x = INT_MAX;
         }, get_ranges())
 
         n.feed('7ggI//<esc>')
-        exec_lua([[parser:parse({6, 7})]])
+        exec_lua([[parser:parse({5, 6})]])
         eq('table', exec_lua('return type(parser:children().c)'))
         eq(2, exec_lua('return #parser:children().c:trees()'))
         eq({


### PR DESCRIPTION
This means that all work previously done by a `_parse()` iteration will be kept in future iterations. This prevents it from running indefinitely in some cases where the file is very large and there are 2+ injections.

This PR also allows `is_valid()` to accept a range, which narrows the area for which to check the tree for validity. This fixes #32075 with the downside that the `_valid` table can no longer be compressed to a `true` value. However, I would argue that this loss is very minimal because the compression happens almost never for large files (which is where it actually needs to happen)

close #32050 
close #32077