### PR TITLE
vim-patch:9.1.1028: too many strlen() calls in screen.c

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2580,9 +2580,9 @@ int compute_foldcolumn(win_T *wp, int col)
 {
   int fdc = win_fdccol_count(wp);
   int wmw = wp == curwin && p_wmw == 0 ? 1 : (int)p_wmw;
-  int wwidth = wp->w_grid.cols;
+  int n = wp->w_grid.cols - (col + wmw);
 
-  return MIN(fdc, wwidth - (col + wmw));
+  return MIN(fdc, n);
 }
 
 /// Return the width of the 'number' and 'relativenumber' column.

--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -772,8 +772,7 @@ void draw_tabline(void)
 
       if (modified || wincount > 1) {
         if (wincount > 1) {
-          vim_snprintf(NameBuff, MAXPATHL, "%d", wincount);
-          int len = (int)strlen(NameBuff);
+          int len = vim_snprintf(NameBuff, MAXPATHL, "%d", wincount);
           if (col + len >= Columns - 3) {
             break;
           }
@@ -798,7 +797,8 @@ void draw_tabline(void)
           len -= ptr2cells(p);
           MB_PTR_ADV(p);
         }
-        len = MIN(len, Columns - col - 1);
+        int n = Columns - col - 1;
+        len = MIN(len, n);
 
         grid_line_puts(col, p, -1, attr);
         col += len;
@@ -832,7 +832,8 @@ void draw_tabline(void)
 
     // Draw the 'showcmd' information if 'showcmdloc' == "tabline".
     if (p_sc && *p_sloc == 't') {
-      const int sc_width = MIN(10, (int)Columns - col - (tabcount > 1) * 3);
+      int n = Columns - col - (tabcount > 1) * 3;
+      const int sc_width = MIN(10, n);
 
       if (sc_width > 0) {
         grid_line_puts(Columns - sc_width - (tabcount > 1) * 2,


### PR DESCRIPTION
Problem:  too many strlen() calls in screen.c
Solution: refactor screen.c and remove calls to strlen(),
          verify that leadmultispace != NULL (John Marriott)

closes: vim/vim#16460

https://github.com/vim/vim/commit/c15de972e8131def2f506bb9eb6b306ca089629c