### PR TITLE
fix(lua): prevent SIGSEGV when lua error is NULL in libuv_worker

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -276,10 +276,9 @@ static int nlua_luv_thread_common_cfpcall(lua_State *lstate, int nargs, int nres
 #endif
     }
     const char *error = lua_tostring(lstate, -1);
-
     loop_schedule_deferred(&main_loop,
                            event_create(nlua_luv_error_event,
-                                        xstrdup(error),
+                                        error != NULL ? xstrdup(error) : NULL,
                                         (void *)(intptr_t)(is_callback
                                                            ? kThreadCallback
                                                            : kThread)));

--- a/test/functional/lua/thread_spec.lua
+++ b/test/functional/lua/thread_spec.lua
@@ -19,6 +19,26 @@ describe('thread', function()
     screen = Screen.new(50, 10)
   end)
 
+  it('handle non-string error', function()
+    exec_lua [[
+      local thread = vim.uv.new_thread(function()
+        error()
+      end)
+      vim.uv.thread_join(thread)
+    ]]
+
+    screen:expect([[
+                                                        |
+      {1:~                                                 }|*5
+      {3:                                                  }|
+      {9:Error in luv thread:}                              |
+      {9:[NULL]}                                            |
+      {6:Press ENTER or type command to continue}^           |
+    ]])
+    feed('<cr>')
+    assert_alive()
+  end)
+
   it('entry func is executed in protected mode', function()
     exec_lua [[
       local thread = vim.uv.new_thread(function()


### PR DESCRIPTION
Problem:

![image](https://github.com/user-attachments/assets/c2f0e2cd-0800-4b6a-af9f-921082be1951)

Calling `xstrdup` with a NULL pointer causes a SIGSEGV if `lua_tostring` returns NULL in `nlua_luv_thread_common_cfpcall`.

Crash stack trace:

```plain
Thread 2 Crashed:: libuv-worker
0   libsystem_platform.dylib      	       0x19d114184 _platform_strlen + 4
1   nvim                          	       0x100abc5b4 xstrdup + 32 (memory.c:469)
2   nvim                          	       0x100a69e74 nlua_luv_thread_common_cfpcall + 280 (executor.c:281)
3   nvim                          	       0x100a69cec nlua_luv_thread_cfpcall + 56 (executor.c:246)
4   nvim                          	       0x100d000c8 luv_work_cb + 488 (work.c:107)
5   nvim                          	       0x100d4765c lj_BC_FUNCC + 44
6   nvim                          	       0x100d5dfbc lua_pcall + 228 (lj_api.c:1151)
7   nvim                          	       0x100a69cec nlua_luv_thread_cfpcall + 56 (executor.c:246)
8   nvim                          	       0x100a69d48 nlua_luv_thread_cfcpcall + 80 (executor.c:254)
9   nvim                          	       0x100cffcd4 luv_work_cb_wrapper + 80 (work.c:155)
10  nvim                          	       0x100db5130 uv__queue_work + 44
11  nvim                          	       0x100db5a88 worker + 708
12  libsystem_pthread.dylib       	       0x19d0e02e4 _pthread_start + 136
13  libsystem_pthread.dylib       	       0x19d0db0fc thread_start + 8
```

Solution:
Check if `lua_tostring` returns NULL and pass NULL to `event_create` to avoid the crash.

Result:

![image](https://github.com/user-attachments/assets/d6f628f3-2b15-4c42-8f55-95519866f5b3)
