### PR TITLE
vim-patch:e064051: runtime(c): add new constexpr keyword to syntax file (C23)

### DIFF
--- a/runtime/syntax/c.vim
+++ b/runtime/syntax/c.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:		C
 " Maintainer:		The Vim Project <https://github.com/vim/vim>
-" Last Change:		2025 Jan 15
+" Last Change:		2025 Jan 18
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
@@ -317,6 +317,9 @@ syn keyword	cStructure	struct union enum
 syn keyword	cStorageClass	static register auto volatile extern const
 if !exists("c_no_c99") && !s:in_cpp_family
   syn keyword	cStorageClass	inline restrict
+endif
+if (s:ft ==# "c" && !exists("c_no_c23")) || (s:in_cpp_family && !exists("cpp_no_cpp11"))
+  syn keyword	cStorageClass	constexpr
 endif
 if !exists("c_no_c11")
   syn keyword	cStorageClass	_Alignas alignas


### PR DESCRIPTION
closes: vim/vim#16471

https://github.com/vim/vim/commit/e06405181a6189aa56e917c1a7e5090a33b07a8a

Co-authored-by: Doug Kearns <dougkearns@gmail.com>
