### PR TITLE
vim-patch:d402ba8: runtime(netrw): upstream snapshot of v175

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -35,7 +35,7 @@ if exists("s:needspatches")
   endfor
 endif
 
-let g:loaded_netrw = "v174"
+let g:loaded_netrw = "v175"
 
 let s:keepcpo= &cpo
 setl cpo&vim

--- a/runtime/pack/dist/opt/netrw/autoload/netrwSettings.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrwSettings.vim
@@ -1,7 +1,7 @@
 " Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Former Maintainer: Charles E Campbell
 " Upstream: <https://github.com/saccarosium/netrw.vim>
-" Copyright:    Copyright (C) 1999-2007 Charles E. Campbell {{{1
+" Copyright:    Copyright (C) 1999-2007 Charles E. Campbell {{{
 "               Permission is hereby granted to use and distribute this code,
 "               with or without modifications, provided that this copyright
 "               notice is copied with it. Like anything else that's free,
@@ -9,13 +9,13 @@
 "               warranty of any kind, either expressed or implied. By using
 "               this plugin, you agree that in no event will the copyright
 "               holder be liable for any damages resulting from the use
-"               of this software.
+"               of this software. }}}
 
-" Load Once: {{{1
-if exists("g:loaded_netrwSettings") || &cp
-  finish
+if &cp || exists("g:loaded_netrwSettings")
+    finish
 endif
-let g:loaded_netrwSettings = "v174"
+
+let g:loaded_netrwSettings = "v175"
 if v:version < 700
  echohl WarningMsg
  echo "***warning*** this version of netrwSettings needs vim 7.0"
@@ -23,220 +23,220 @@ if v:version < 700
  finish
 endif
 
-" ---------------------------------------------------------------------
-" NetrwSettings: {{{1
-fun! netrwSettings#NetrwSettings()
-  " this call is here largely just to insure that netrw has been loaded
-  call netrw#WinPath("")
-  if !exists("g:loaded_netrw")
-   echohl WarningMsg | echomsg "***sorry*** netrw needs to be loaded prior to using NetrwSettings" | echohl None
-   return
-  endif
+" NetrwSettings: {{{
 
-  above wincmd s
-  enew
-  setlocal noswapfile bh=wipe
-  set ft=vim
-  file Netrw\ Settings
+function! netrwSettings#NetrwSettings()
+    " this call is here largely just to insure that netrw has been loaded
+    call netrw#WinPath("")
+    if !exists("g:loaded_netrw")
+        echohl WarningMsg
+        echomsg "***sorry*** netrw needs to be loaded prior to using NetrwSettings"
+        echohl None
+        return
+    endif
 
-  " these variables have the following default effects when they don't
-  " exist (ie. have not been set by the user in his/her .vimrc)
-  if !exists("g:netrw_liststyle")
-   let g:netrw_liststyle= 0
-   let g:netrw_list_cmd= "ssh HOSTNAME ls -FLa"
-  endif
-  if !exists("g:netrw_silent")
-   let g:netrw_silent= 0
-  endif
-  if !exists("g:netrw_use_nt_rcp")
-   let g:netrw_use_nt_rcp= 0
-  endif
-  if !exists("g:netrw_ftp")
-   let g:netrw_ftp= 0
-  endif
-  if !exists("g:netrw_ignorenetrc")
-   let g:netrw_ignorenetrc= 0
-  endif
+    above wincmd s
+    enew
+    setlocal noswapfile bh=wipe
+    set ft=vim
+    file Netrw\ Settings
 
-  put ='+ ---------------------------------------------'
-  put ='+  NetrwSettings:  by Charles E. Campbell'
-  put ='+ Press <F1> with cursor atop any line for help'
-  put ='+ ---------------------------------------------'
-  let s:netrw_settings_stop= line(".")
+    " these variables have the following default effects when they don't
+    " exist (ie. have not been set by the user in his/her .vimrc)
+    if !exists("g:netrw_liststyle")
+        let g:netrw_liststyle= 0
+        let g:netrw_list_cmd= "ssh HOSTNAME ls -FLa"
+    endif
+    if !exists("g:netrw_silent")
+        let g:netrw_silent= 0
+    endif
+    if !exists("g:netrw_use_nt_rcp")
+        let g:netrw_use_nt_rcp= 0
+    endif
+    if !exists("g:netrw_ftp")
+        let g:netrw_ftp= 0
+    endif
+    if !exists("g:netrw_ignorenetrc")
+        let g:netrw_ignorenetrc= 0
+    endif
 
-  put =''
-  put ='+ Netrw Protocol Commands'
-  put = 'let g:netrw_dav_cmd           = '.g:netrw_dav_cmd
-  put = 'let g:netrw_fetch_cmd         = '.g:netrw_fetch_cmd
-  put = 'let g:netrw_ftp_cmd           = '.g:netrw_ftp_cmd
-  put = 'let g:netrw_http_cmd          = '.g:netrw_http_cmd
-  put = 'let g:netrw_rcp_cmd           = '.g:netrw_rcp_cmd
-  put = 'let g:netrw_rsync_cmd         = '.g:netrw_rsync_cmd
-  put = 'let g:netrw_scp_cmd           = '.g:netrw_scp_cmd
-  put = 'let g:netrw_sftp_cmd          = '.g:netrw_sftp_cmd
-  put = 'let g:netrw_ssh_cmd           = '.g:netrw_ssh_cmd
-  let s:netrw_protocol_stop= line(".")
-  put = ''
+    put ='+ ---------------------------------------------'
+    put ='+  NetrwSettings:  by Charles E. Campbell'
+    put ='+ Press <F1> with cursor atop any line for help'
+    put ='+ ---------------------------------------------'
+    let s:netrw_settings_stop= line(".")
 
-  put ='+Netrw Transfer Control'
-  put = 'let g:netrw_cygwin            = '.g:netrw_cygwin
-  put = 'let g:netrw_ftp               = '.g:netrw_ftp
-  put = 'let g:netrw_ftpmode           = '.g:netrw_ftpmode
-  put = 'let g:netrw_ignorenetrc       = '.g:netrw_ignorenetrc
-  put = 'let g:netrw_sshport           = '.g:netrw_sshport
-  put = 'let g:netrw_silent            = '.g:netrw_silent
-  put = 'let g:netrw_use_nt_rcp        = '.g:netrw_use_nt_rcp
-  let s:netrw_xfer_stop= line(".")
-  put =''
-  put ='+ Netrw Messages'
-  put ='let g:netrw_use_errorwindow    = '.g:netrw_use_errorwindow
+    put =''
+    put ='+ Netrw Protocol Commands'
+    put = 'let g:netrw_dav_cmd = '.g:netrw_dav_cmd
+    put = 'let g:netrw_fetch_cmd = '.g:netrw_fetch_cmd
+    put = 'let g:netrw_ftp_cmd = '.g:netrw_ftp_cmd
+    put = 'let g:netrw_http_cmd = '.g:netrw_http_cmd
+    put = 'let g:netrw_rcp_cmd = '.g:netrw_rcp_cmd
+    put = 'let g:netrw_rsync_cmd = '.g:netrw_rsync_cmd
+    put = 'let g:netrw_scp_cmd = '.g:netrw_scp_cmd
+    put = 'let g:netrw_sftp_cmd = '.g:netrw_sftp_cmd
+    put = 'let g:netrw_ssh_cmd = '.g:netrw_ssh_cmd
+    let s:netrw_protocol_stop= line(".")
+    put = ''
 
-  put = ''
-  put ='+ Netrw Browser Control'
-  if exists("g:netrw_altfile")
-   put = 'let g:netrw_altfile   = '.g:netrw_altfile
-  else
-   put = 'let g:netrw_altfile   = 0'
-  endif
-  put = 'let g:netrw_alto              = '.g:netrw_alto
-  put = 'let g:netrw_altv              = '.g:netrw_altv
-  put = 'let g:netrw_banner            = '.g:netrw_banner
-  if exists("g:netrw_bannerbackslash")
-   put = 'let g:netrw_bannerbackslash   = '.g:netrw_bannerbackslash
-  else
-   put = '\" let g:netrw_bannerbackslash   = (not defined)'
-  endif
-  put = 'let g:netrw_browse_split      = '.g:netrw_browse_split
-  if exists("g:netrw_browsex_viewer")
-   put = 'let g:netrw_browsex_viewer   = '.g:netrw_browsex_viewer
-  else
-   put = '\" let g:netrw_browsex_viewer   = (not defined)'
-  endif
-  put = 'let g:netrw_compress          = '.g:netrw_compress
-  if exists("g:Netrw_corehandler")
-   put = 'let g:Netrw_corehandler      = '.g:Netrw_corehandler
-  else
-   put = '\" let g:Netrw_corehandler      = (not defined)'
-  endif
-  put = 'let g:netrw_ctags             = '.g:netrw_ctags
-  put = 'let g:netrw_cursor            = '.g:netrw_cursor
-  let decompressline= line("$")
-  put = 'let g:netrw_decompress        = '.string(g:netrw_decompress)
-  if exists("g:netrw_dynamic_maxfilenamelen")
-   put = 'let g:netrw_dynamic_maxfilenamelen='.g:netrw_dynamic_maxfilenamelen
-  else
-   put = '\" let g:netrw_dynamic_maxfilenamelen= (not defined)'
-  endif
-  put = 'let g:netrw_dirhistmax        = '.g:netrw_dirhistmax
-  put = 'let g:netrw_errorlvl          = '.g:netrw_errorlvl
-  put = 'let g:netrw_fastbrowse        = '.g:netrw_fastbrowse
-  let fnameescline= line("$")
-  put = 'let g:netrw_fname_escape      = '.string(g:netrw_fname_escape)
-  put = 'let g:netrw_ftp_browse_reject = '.g:netrw_ftp_browse_reject
-  put = 'let g:netrw_ftp_list_cmd      = '.g:netrw_ftp_list_cmd
-  put = 'let g:netrw_ftp_sizelist_cmd  = '.g:netrw_ftp_sizelist_cmd
-  put = 'let g:netrw_ftp_timelist_cmd  = '.g:netrw_ftp_timelist_cmd
-  let globescline= line("$")
-  put = 'let g:netrw_glob_escape       = '.string(g:netrw_glob_escape)
-  put = 'let g:netrw_hide              = '.g:netrw_hide
-  if exists("g:netrw_home")
-   put = 'let g:netrw_home              = '.g:netrw_home
-  else
-   put = '\" let g:netrw_home              = (not defined)'
-  endif
-  put = 'let g:netrw_keepdir           = '.g:netrw_keepdir
-  put = 'let g:netrw_list_cmd          = '.g:netrw_list_cmd
-  put = 'let g:netrw_list_hide         = '.g:netrw_list_hide
-  put = 'let g:netrw_liststyle         = '.g:netrw_liststyle
-  put = 'let g:netrw_localcopycmd      = '.g:netrw_localcopycmd
-  put = 'let g:netrw_localcopycmdopt   = '.g:netrw_localcopycmdopt
-  put = 'let g:netrw_localmkdir        = '.g:netrw_localmkdir
-  put = 'let g:netrw_localmkdiropt     = '.g:netrw_localmkdiropt
-  put = 'let g:netrw_localmovecmd      = '.g:netrw_localmovecmd
-  put = 'let g:netrw_localmovecmdopt   = '.g:netrw_localmovecmdopt
-  put = 'let g:netrw_maxfilenamelen    = '.g:netrw_maxfilenamelen
-  put = 'let g:netrw_menu              = '.g:netrw_menu
-  put = 'let g:netrw_mousemaps         = '.g:netrw_mousemaps
-  put = 'let g:netrw_mkdir_cmd         = '.g:netrw_mkdir_cmd
-  if exists("g:netrw_nobeval")
-   put = 'let g:netrw_nobeval           = '.g:netrw_nobeval
-  else
-   put = '\" let g:netrw_nobeval           = (not defined)'
-  endif
-  put = 'let g:netrw_remote_mkdir      = '.g:netrw_remote_mkdir
-  put = 'let g:netrw_preview           = '.g:netrw_preview
-  put = 'let g:netrw_rename_cmd        = '.g:netrw_rename_cmd
-  put = 'let g:netrw_retmap            = '.g:netrw_retmap
-  put = 'let g:netrw_rm_cmd            = '.g:netrw_rm_cmd
-  put = 'let g:netrw_rmdir_cmd         = '.g:netrw_rmdir_cmd
-  put = 'let g:netrw_rmf_cmd           = '.g:netrw_rmf_cmd
-  put = 'let g:netrw_sort_by           = '.g:netrw_sort_by
-  put = 'let g:netrw_sort_direction    = '.g:netrw_sort_direction
-  put = 'let g:netrw_sort_options      = '.g:netrw_sort_options
-  put = 'let g:netrw_sort_sequence     = '.g:netrw_sort_sequence
-  put = 'let g:netrw_servername        = '.g:netrw_servername
-  put = 'let g:netrw_special_syntax    = '.g:netrw_special_syntax
-  put = 'let g:netrw_ssh_browse_reject = '.g:netrw_ssh_browse_reject
-  put = 'let g:netrw_ssh_cmd           = '.g:netrw_ssh_cmd
-  put = 'let g:netrw_scpport           = '.g:netrw_scpport
-  put = 'let g:netrw_sepchr            = '.g:netrw_sepchr
-  put = 'let g:netrw_sshport           = '.g:netrw_sshport
-  put = 'let g:netrw_timefmt           = '.g:netrw_timefmt
-  let tmpfileescline= line("$")
-  put ='let g:netrw_tmpfile_escape...'
-  put = 'let g:netrw_use_noswf         = '.g:netrw_use_noswf
-  put = 'let g:netrw_xstrlen           = '.g:netrw_xstrlen
-  put = 'let g:netrw_winsize           = '.g:netrw_winsize
+    put ='+Netrw Transfer Control'
+    put = 'let g:netrw_cygwin = '.g:netrw_cygwin
+    put = 'let g:netrw_ftp = '.g:netrw_ftp
+    put = 'let g:netrw_ftpmode = '.g:netrw_ftpmode
+    put = 'let g:netrw_ignorenetrc = '.g:netrw_ignorenetrc
+    put = 'let g:netrw_sshport = '.g:netrw_sshport
+    put = 'let g:netrw_silent = '.g:netrw_silent
+    put = 'let g:netrw_use_nt_rcp = '.g:netrw_use_nt_rcp
+    let s:netrw_xfer_stop= line(".")
+    put =''
+    put ='+ Netrw Messages'
+    put ='let g:netrw_use_errorwindow = '.g:netrw_use_errorwindow
 
-  put =''
-  put ='+ For help, place cursor on line and press <F1>'
+    put = ''
+    put ='+ Netrw Browser Control'
+    if exists("g:netrw_altfile")
+        put = 'let g:netrw_altfile = '.g:netrw_altfile
+    else
+        put = 'let g:netrw_altfile = 0'
+    endif
+    put = 'let g:netrw_alto = '.g:netrw_alto
+    put = 'let g:netrw_altv = '.g:netrw_altv
+    put = 'let g:netrw_banner = '.g:netrw_banner
+    if exists("g:netrw_bannerbackslash")
+        put = 'let g:netrw_bannerbackslash = '.g:netrw_bannerbackslash
+    else
+        put = '\" let g:netrw_bannerbackslash = (not defined)'
+    endif
+    put = 'let g:netrw_browse_split = '.g:netrw_browse_split
+    if exists("g:netrw_browsex_viewer")
+        put = 'let g:netrw_browsex_viewer = '.g:netrw_browsex_viewer
+    else
+        put = '\" let g:netrw_browsex_viewer = (not defined)'
+    endif
+    put = 'let g:netrw_compress = '.g:netrw_compress
+    if exists("g:Netrw_corehandler")
+        put = 'let g:Netrw_corehandler = '.g:Netrw_corehandler
+    else
+        put = '\" let g:Netrw_corehandler = (not defined)'
+    endif
+    put = 'let g:netrw_ctags = '.g:netrw_ctags
+    put = 'let g:netrw_cursor = '.g:netrw_cursor
+    let decompressline= line("$")
+    put = 'let g:netrw_decompress = '.string(g:netrw_decompress)
+    if exists("g:netrw_dynamic_maxfilenamelen")
+        put = 'let g:netrw_dynamic_maxfilenamelen='.g:netrw_dynamic_maxfilenamelen
+    else
+        put = '\" let g:netrw_dynamic_maxfilenamelen= (not defined)'
+    endif
+    put = 'let g:netrw_dirhistmax = '.g:netrw_dirhistmax
+    put = 'let g:netrw_errorlvl = '.g:netrw_errorlvl
+    put = 'let g:netrw_fastbrowse = '.g:netrw_fastbrowse
+    let fnameescline= line("$")
+    put = 'let g:netrw_fname_escape = '.string(g:netrw_fname_escape)
+    put = 'let g:netrw_ftp_browse_reject = '.g:netrw_ftp_browse_reject
+    put = 'let g:netrw_ftp_list_cmd = '.g:netrw_ftp_list_cmd
+    put = 'let g:netrw_ftp_sizelist_cmd = '.g:netrw_ftp_sizelist_cmd
+    put = 'let g:netrw_ftp_timelist_cmd = '.g:netrw_ftp_timelist_cmd
+    let globescline= line("$")
+    put = 'let g:netrw_glob_escape = '.string(g:netrw_glob_escape)
+    put = 'let g:netrw_hide = '.g:netrw_hide
+    if exists("g:netrw_home")
+        put = 'let g:netrw_home = '.g:netrw_home
+    else
+        put = '\" let g:netrw_home = (not defined)'
+    endif
+    put = 'let g:netrw_keepdir = '.g:netrw_keepdir
+    put = 'let g:netrw_list_cmd = '.g:netrw_list_cmd
+    put = 'let g:netrw_list_hide = '.g:netrw_list_hide
+    put = 'let g:netrw_liststyle = '.g:netrw_liststyle
+    put = 'let g:netrw_localcopycmd = '.g:netrw_localcopycmd
+    put = 'let g:netrw_localcopycmdopt = '.g:netrw_localcopycmdopt
+    put = 'let g:netrw_localmkdir = '.g:netrw_localmkdir
+    put = 'let g:netrw_localmkdiropt = '.g:netrw_localmkdiropt
+    put = 'let g:netrw_localmovecmd = '.g:netrw_localmovecmd
+    put = 'let g:netrw_localmovecmdopt = '.g:netrw_localmovecmdopt
+    put = 'let g:netrw_maxfilenamelen = '.g:netrw_maxfilenamelen
+    put = 'let g:netrw_menu = '.g:netrw_menu
+    put = 'let g:netrw_mousemaps = '.g:netrw_mousemaps
+    put = 'let g:netrw_mkdir_cmd = '.g:netrw_mkdir_cmd
+    if exists("g:netrw_nobeval")
+        put = 'let g:netrw_nobeval = '.g:netrw_nobeval
+    else
+        put = '\" let g:netrw_nobeval = (not defined)'
+    endif
+    put = 'let g:netrw_remote_mkdir = '.g:netrw_remote_mkdir
+    put = 'let g:netrw_preview = '.g:netrw_preview
+    put = 'let g:netrw_rename_cmd = '.g:netrw_rename_cmd
+    put = 'let g:netrw_retmap = '.g:netrw_retmap
+    put = 'let g:netrw_rm_cmd = '.g:netrw_rm_cmd
+    put = 'let g:netrw_rmdir_cmd = '.g:netrw_rmdir_cmd
+    put = 'let g:netrw_rmf_cmd = '.g:netrw_rmf_cmd
+    put = 'let g:netrw_sort_by = '.g:netrw_sort_by
+    put = 'let g:netrw_sort_direction = '.g:netrw_sort_direction
+    put = 'let g:netrw_sort_options = '.g:netrw_sort_options
+    put = 'let g:netrw_sort_sequence = '.g:netrw_sort_sequence
+    put = 'let g:netrw_servername = '.g:netrw_servername
+    put = 'let g:netrw_special_syntax = '.g:netrw_special_syntax
+    put = 'let g:netrw_ssh_browse_reject = '.g:netrw_ssh_browse_reject
+    put = 'let g:netrw_ssh_cmd = '.g:netrw_ssh_cmd
+    put = 'let g:netrw_scpport = '.g:netrw_scpport
+    put = 'let g:netrw_sepchr = '.g:netrw_sepchr
+    put = 'let g:netrw_sshport = '.g:netrw_sshport
+    put = 'let g:netrw_timefmt = '.g:netrw_timefmt
+    let tmpfileescline= line("$")
+    put ='let g:netrw_tmpfile_escape...'
+    put = 'let g:netrw_use_noswf = '.g:netrw_use_noswf
+    put = 'let g:netrw_xstrlen = '.g:netrw_xstrlen
+    put = 'let g:netrw_winsize = '.g:netrw_winsize
 
-  1d
-  silent %s/^+/"/e
-  res 99
-  silent %s/= \([^0-9].*\)$/= '\1'/e
-  silent %s/= $/= ''/e
-  1
+    put =''
+    put ='+ For help, place cursor on line and press <F1>'
 
-  call setline(decompressline,"let g:netrw_decompress        = ".substitute(string(g:netrw_decompress),"^'\\(.*\\)'$",'\1',''))
-  call setline(fnameescline,  "let g:netrw_fname_escape      = '".escape(g:netrw_fname_escape,"'")."'")
-  call setline(globescline,   "let g:netrw_glob_escape       = '".escape(g:netrw_glob_escape,"'")."'")
-  call setline(tmpfileescline,"let g:netrw_tmpfile_escape    = '".escape(g:netrw_tmpfile_escape,"'")."'")
+    1d
+    silent %s/^+/"/e
+    res 99
+    silent %s/= \([^0-9].*\)$/= '\1'/e
+    silent %s/= $/= ''/e
+    1
 
-  set nomod
+    call setline(decompressline, "let g:netrw_decompress = ".substitute(string(g:netrw_decompress),"^'\\(.*\\)'$",'\1',''))
+    call setline(fnameescline, "let g:netrw_fname_escape = '".escape(g:netrw_fname_escape,"'")."'")
+    call setline(globescline, "let g:netrw_glob_escape = '".escape(g:netrw_glob_escape,"'")."'")
+    call setline(tmpfileescline, "let g:netrw_tmpfile_escape = '".escape(g:netrw_tmpfile_escape,"'")."'")
 
-  nmap <buffer> <silent> <F1>                       :call NetrwSettingHelp()<cr>
-  nnoremap <buffer> <silent> <leftmouse> <leftmouse>:call NetrwSettingHelp()<cr>
-  let tmpfile= tempname()
-  exe 'au BufWriteCmd	Netrw\ Settings	silent w! '.tmpfile.'|so '.tmpfile.'|call delete("'.tmpfile.'")|set nomod'
-endfun
+    set nomod
 
-" ---------------------------------------------------------------------
-" NetrwSettingHelp: {{{2
-fun! NetrwSettingHelp()
-"  call Dfunc("NetrwSettingHelp()")
-  let curline = getline(".")
-  if curline =~ '='
-   let varhelp = substitute(curline,'^\s*let ','','e')
-   let varhelp = substitute(varhelp,'\s*=.*$','','e')
-"   call Decho("trying help ".varhelp)
-   try
-    exe "he ".varhelp
-   catch /^Vim\%((\a\+)\)\=:E149/
-   	echo "***sorry*** no help available for <".varhelp.">"
-   endtry
-  elseif line(".") < s:netrw_settings_stop
-   he netrw-settings
-  elseif line(".") < s:netrw_protocol_stop
-   he netrw-externapp
-  elseif line(".") < s:netrw_xfer_stop
-   he netrw-variables
-  else
-   he netrw-browse-var
-  endif
-"  call Dret("NetrwSettingHelp")
-endfun
+    nmap <buffer> <silent> <F1> :call NetrwSettingHelp()<cr>
+    nnoremap <buffer> <silent> <leftmouse> <leftmouse> :call NetrwSettingHelp()<cr>
+    let tmpfile= tempname()
+    exe 'au BufWriteCmd	Netrw\ Settings	silent w! '.tmpfile.'|so '.tmpfile.'|call delete("'.tmpfile.'")|set nomod'
+endfunction
 
-" ---------------------------------------------------------------------
-" Modelines: {{{1
-" vim:ts=8 fdm=marker
+" }}}
+" NetrwSettingHelp: {{{
+
+function! NetrwSettingHelp()
+    let curline = getline(".")
+    if curline =~ '='
+        let varhelp = substitute(curline,'^\s*let ','','e')
+        let varhelp = substitute(varhelp,'\s*=.*$','','e')
+        try
+            exe "he ".varhelp
+        catch /^Vim\%((\a\+)\)\=:E149/
+            echo "***sorry*** no help available for <".varhelp.">"
+        endtry
+    elseif line(".") < s:netrw_settings_stop
+        he netrw-settings
+    elseif line(".") < s:netrw_protocol_stop
+        he netrw-externapp
+    elseif line(".") < s:netrw_xfer_stop
+        he netrw-variables
+    else
+        he netrw-browse-var
+    endif
+endfunction
+
+" }}}
+
+" vim:ts=8 sts=4 sw=4 et fdm=marker

--- a/runtime/pack/dist/opt/netrw/autoload/netrw_gitignore.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw_gitignore.vim
@@ -12,7 +12,7 @@
 "  let g:netrw_list_hide = netrw_gitignore#Hide()
 "  let g:netrw_list_hide = netrw_gitignore#Hide() . 'more,hide,patterns'
 "
-" Copyright:    Copyright (C) 2013 Bruno Sutic {{{1
+" Copyright:    Copyright (C) 2013 Bruno Sutic {{{
 "               Permission is hereby granted to use and distribute this code,
 "               with or without modifications, provided that this copyright
 "               notice is copied with it. Like anything else that's free,
@@ -20,7 +20,10 @@
 "               warranty of any kind, either expressed or implied. By using
 "               this plugin, you agree that in no event will the copyright
 "               holder be liable for any damages resulting from the use
-"               of this software.
+"               of this software. }}}
+
 function! netrw_gitignore#Hide(...)
-  return substitute(substitute(system('git ls-files --other --ignored --exclude-standard --directory'), '\n', ',', 'g'), ',$', '', '')
+    return substitute(substitute(system('git ls-files --other --ignored --exclude-standard --directory'), '\n', ',', 'g'), ',$', '', '')
 endfunction
+
+" vim:ts=8 sts=4 sw=4 et fdm=marker

--- a/runtime/pack/dist/opt/netrw/plugin/netrwPlugin.vim
+++ b/runtime/pack/dist/opt/netrw/plugin/netrwPlugin.vim
@@ -1,7 +1,7 @@
 " Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Former Maintainer: Charles E Campbell
 " Upstream: <https://github.com/saccarosium/netrw.vim>
-" Copyright:    Copyright (C) 1999-2021 Charles E. Campbell {{{1
+" Copyright:    Copyright (C) 1999-2021 Charles E. Campbell {{{
 "               Permission is hereby granted to use and distribute this code,
 "               with or without modifications, provided that this copyright
 "               notice is copied with it. Like anything else that's free,
@@ -9,214 +9,206 @@
 "               *as is* and comes with no warranty of any kind, either
 "               expressed or implied. By using this plugin, you agree that
 "               in no event will the copyright holder be liable for any damages
-"               resulting from the use of this software.
+"               resulting from the use of this software. }}}
 
-" Load Once: {{{1
 if &cp || exists("g:loaded_netrwPlugin")
-  finish
+    finish
 endif
-let g:loaded_netrwPlugin = "v174"
+
+let g:loaded_netrwPlugin = "v175"
+
 let s:keepcpo = &cpo
 set cpo&vim
-"DechoRemOn
 
-" ---------------------------------------------------------------------
-" Public Interface: {{{1
+" Commands Launch/URL: {{{
 
-" Commands Launch/URL {{{2
-command -complete=shellcmd -nargs=1   Launch  call netrw#Launch(trim(<q-args>))
-command -complete=file     -nargs=1   Open    call netrw#Open(trim(<q-args>))
-" " }}}
-" Local Browsing Autocmds: {{{2
+command -complete=shellcmd -nargs=1 Launch call netrw#Launch(trim(<q-args>))
+command -complete=file -nargs=1 Open call netrw#Open(trim(<q-args>))
+
+" }}}
+" Local Browsing Autocmds: {{{
+
 augroup FileExplorer
-  au!
-  au BufLeave *  if &ft != "netrw"|let w:netrw_prvfile= expand("%:p")|endif
-  au BufEnter * sil call s:LocalBrowse(expand("<amatch>"))
-  au VimEnter * sil call s:VimEnter(expand("<amatch>"))
-  if has("win32")
-    au BufEnter .* sil call s:LocalBrowse(expand("<amatch>"))
-  endif
+    au!
+    au BufLeave * if &ft != "netrw"|let w:netrw_prvfile= expand("%:p")|endif
+    au BufEnter * sil call s:LocalBrowse(expand("<amatch>"))
+    au VimEnter * sil call s:VimEnter(expand("<amatch>"))
+    if has("win32")
+        au BufEnter .* sil call s:LocalBrowse(expand("<amatch>"))
+    endif
 augroup END
 
-" Network Browsing Reading Writing: {{{2
+" }}}
+" Network Browsing Reading Writing: {{{
+
 augroup Network
-  au!
-  au BufReadCmd   file://*                                                                                      call netrw#FileUrlEdit(expand("<amatch>"))
-  au BufReadCmd   ftp://*,rcp://*,scp://*,http://*,https://*,dav://*,davs://*,rsync://*,sftp://*        exe "sil doau BufReadPre ".fnameescape(expand("<amatch>"))|call netrw#Nread(2,expand("<amatch>"))|exe "sil doau BufReadPost ".fnameescape(expand("<amatch>"))
-  au FileReadCmd  ftp://*,rcp://*,scp://*,http://*,file://*,https://*,dav://*,davs://*,rsync://*,sftp://*       exe "sil doau FileReadPre ".fnameescape(expand("<amatch>"))|call netrw#Nread(1,expand("<amatch>"))|exe "sil doau FileReadPost ".fnameescape(expand("<amatch>"))
-  au BufWriteCmd  ftp://*,rcp://*,scp://*,http://*,file://*,dav://*,davs://*,rsync://*,sftp://*                 exe "sil doau BufWritePre ".fnameescape(expand("<amatch>"))|exe 'Nwrite '.fnameescape(expand("<amatch>"))|exe "sil doau BufWritePost ".fnameescape(expand("<amatch>"))
-  au FileWriteCmd ftp://*,rcp://*,scp://*,http://*,file://*,dav://*,davs://*,rsync://*,sftp://*                 exe "sil doau FileWritePre ".fnameescape(expand("<amatch>"))|exe "'[,']".'Nwrite '.fnameescape(expand("<amatch>"))|exe "sil doau FileWritePost ".fnameescape(expand("<amatch>"))
-  try
-    au SourceCmd   ftp://*,rcp://*,scp://*,http://*,file://*,https://*,dav://*,davs://*,rsync://*,sftp://*      exe 'Nsource '.fnameescape(expand("<amatch>"))
-  catch /^Vim\%((\a\+)\)\=:E216/
-    au SourcePre   ftp://*,rcp://*,scp://*,http://*,file://*,https://*,dav://*,davs://*,rsync://*,sftp://*      exe 'Nsource '.fnameescape(expand("<amatch>"))
-  endtry
+    au!
+    au BufReadCmd file://* call netrw#FileUrlEdit(expand("<amatch>"))
+    au BufReadCmd ftp://*,rcp://*,scp://*,http://*,https://*,dav://*,davs://*,rsync://*,sftp://* exe "sil doau BufReadPre ".fnameescape(expand("<amatch>"))|call netrw#Nread(2,expand("<amatch>"))|exe "sil doau BufReadPost ".fnameescape(expand("<amatch>"))
+    au FileReadCmd ftp://*,rcp://*,scp://*,http://*,file://*,https://*,dav://*,davs://*,rsync://*,sftp://* exe "sil doau FileReadPre ".fnameescape(expand("<amatch>"))|call netrw#Nread(1,expand("<amatch>"))|exe "sil doau FileReadPost ".fnameescape(expand("<amatch>"))
+    au BufWriteCmd ftp://*,rcp://*,scp://*,http://*,file://*,dav://*,davs://*,rsync://*,sftp://* exe "sil doau BufWritePre ".fnameescape(expand("<amatch>"))|exe 'Nwrite '.fnameescape(expand("<amatch>"))|exe "sil doau BufWritePost ".fnameescape(expand("<amatch>"))
+    au FileWriteCmd ftp://*,rcp://*,scp://*,http://*,file://*,dav://*,davs://*,rsync://*,sftp://* exe "sil doau FileWritePre ".fnameescape(expand("<amatch>"))|exe "'[,']".'Nwrite '.fnameescape(expand("<amatch>"))|exe "sil doau FileWritePost ".fnameescape(expand("<amatch>"))
+    try
+        au SourceCmd   ftp://*,rcp://*,scp://*,http://*,file://*,https://*,dav://*,davs://*,rsync://*,sftp://* exe 'Nsource '.fnameescape(expand("<amatch>"))
+    catch /^Vim\%((\a\+)\)\=:E216/
+        au SourcePre   ftp://*,rcp://*,scp://*,http://*,file://*,https://*,dav://*,davs://*,rsync://*,sftp://* exe 'Nsource '.fnameescape(expand("<amatch>"))
+    endtry
 augroup END
 
-" Commands: :Nread, :Nwrite, :NetUserPass {{{2
-com! -count=1 -nargs=*  Nread           let s:svpos= winsaveview()<bar>call netrw#NetRead(<count>,<f-args>)<bar>call winrestview(s:svpos)
-com! -range=% -nargs=*  Nwrite          let s:svpos= winsaveview()<bar><line1>,<line2>call netrw#NetWrite(<f-args>)<bar>call winrestview(s:svpos)
-com! -nargs=*           NetUserPass     call NetUserPass(<f-args>)
-com! -nargs=*           Nsource         let s:svpos= winsaveview()<bar>call netrw#NetSource(<f-args>)<bar>call winrestview(s:svpos)
-com! -nargs=?           Ntree           call netrw#SetTreetop(1,<q-args>)
+" }}}
+" Commands: :Nread, :Nwrite, :NetUserPass {{{
 
-" Commands: :Explore, :Sexplore, Hexplore, Vexplore, Lexplore {{{2
-com! -nargs=* -bar -bang -count=0 -complete=dir Explore         call netrw#Explore(<count>,0,0+<bang>0,<q-args>)
-com! -nargs=* -bar -bang -count=0 -complete=dir Sexplore        call netrw#Explore(<count>,1,0+<bang>0,<q-args>)
-com! -nargs=* -bar -bang -count=0 -complete=dir Hexplore        call netrw#Explore(<count>,1,2+<bang>0,<q-args>)
-com! -nargs=* -bar -bang -count=0 -complete=dir Vexplore        call netrw#Explore(<count>,1,4+<bang>0,<q-args>)
-com! -nargs=* -bar       -count=0 -complete=dir Texplore        call netrw#Explore(<count>,0,6        ,<q-args>)
-com! -nargs=* -bar -bang                        Nexplore        call netrw#Explore(-1,0,0,<q-args>)
-com! -nargs=* -bar -bang                        Pexplore        call netrw#Explore(-2,0,0,<q-args>)
-com! -nargs=* -bar -bang -count=0 -complete=dir Lexplore        call netrw#Lexplore(<count>,<bang>0,<q-args>)
+command! -count=1 -nargs=* Nread let s:svpos= winsaveview()<bar>call netrw#NetRead(<count>,<f-args>)<bar>call winrestview(s:svpos)
+command! -range=% -nargs=* Nwrite let s:svpos= winsaveview()<bar><line1>,<line2>call netrw#NetWrite(<f-args>)<bar>call winrestview(s:svpos)
+command! -nargs=* NetUserPass call NetUserPass(<f-args>)
+command! -nargs=* Nsource let s:svpos= winsaveview()<bar>call netrw#NetSource(<f-args>)<bar>call winrestview(s:svpos)
+command! -nargs=? Ntree call netrw#SetTreetop(1,<q-args>)
 
-" Commands: NetrwSettings {{{2
-com! -nargs=0   NetrwSettings   call netrwSettings#NetrwSettings()
-com! -bang      NetrwClean      call netrw#Clean(<bang>0)
+" }}}
+" Commands: :Explore, :Sexplore, Hexplore, Vexplore, Lexplore {{{
 
-" Maps:
+command! -nargs=* -bar -bang -count=0 -complete=dir Explore call netrw#Explore(<count>, 0, 0+<bang>0, <q-args>)
+command! -nargs=* -bar -bang -count=0 -complete=dir Sexplore call netrw#Explore(<count>, 1, 0+<bang>0, <q-args>)
+command! -nargs=* -bar -bang -count=0 -complete=dir Hexplore call netrw#Explore(<count>, 1, 2+<bang>0, <q-args>)
+command! -nargs=* -bar -bang -count=0 -complete=dir Vexplore call netrw#Explore(<count>, 1, 4+<bang>0, <q-args>)
+command! -nargs=* -bar -count=0 -complete=dir Texplore call netrw#Explore(<count>, 0, 6, <q-args>)
+command! -nargs=* -bar -bang -count=0 -complete=dir Lexplore call netrw#Lexplore(<count>, <bang>0, <q-args>)
+command! -nargs=* -bar -bang Nexplore call netrw#Explore(-1, 0, 0, <q-args>)
+command! -nargs=* -bar -bang Pexplore call netrw#Explore(-2, 0, 0, <q-args>)
+
+" }}}
+" Commands: NetrwSettings {{{
+
+command! -nargs=0 NetrwSettings call netrwSettings#NetrwSettings()
+command! -bang NetrwClean call netrw#Clean(<bang>0)
+
+" }}}
+" Maps: {{{
+
 if !exists("g:netrw_nogx")
-  if maparg('gx','n') == ""
-    if !hasmapto('<Plug>NetrwBrowseX')
-      nmap <unique> gx <Plug>NetrwBrowseX
+    if maparg('gx','n') == ""
+        if !hasmapto('<Plug>NetrwBrowseX')
+            nmap <unique> gx <Plug>NetrwBrowseX
+        endif
+        nno <silent> <Plug>NetrwBrowseX :call netrw#BrowseX(netrw#GX(),netrw#CheckIfRemote(netrw#GX()))<cr>
     endif
-    nno <silent> <Plug>NetrwBrowseX :call netrw#BrowseX(netrw#GX(),netrw#CheckIfRemote(netrw#GX()))<cr>
-  endif
-  if maparg('gx','x') == ""
-    if !hasmapto('<Plug>NetrwBrowseXVis')
-      xmap <unique> gx <Plug>NetrwBrowseXVis
+    if maparg('gx','x') == ""
+        if !hasmapto('<Plug>NetrwBrowseXVis')
+            xmap <unique> gx <Plug>NetrwBrowseXVis
+        endif
+        xno <silent> <Plug>NetrwBrowseXVis :<c-u>call netrw#BrowseXVis()<cr>
     endif
-    xno <silent> <Plug>NetrwBrowseXVis :<c-u>call netrw#BrowseXVis()<cr>
-  endif
 endif
+
 if exists("g:netrw_usetab") && g:netrw_usetab
-  if maparg('<c-tab>','n') == ""
-    nmap <unique> <c-tab> <Plug>NetrwShrink
-  endif
-  nno <silent> <Plug>NetrwShrink :call netrw#Shrink()<cr>
+    if maparg('<c-tab>','n') == ""
+        nmap <unique> <c-tab> <Plug>NetrwShrink
+    endif
+    nno <silent> <Plug>NetrwShrink :call netrw#Shrink()<cr>
 endif
 
-" ---------------------------------------------------------------------
-" LocalBrowse: invokes netrw#LocalBrowseCheck() on directory buffers {{{2
-fun! s:LocalBrowse(dirname)
-  " Unfortunate interaction -- only DechoMsg debugging calls can be safely used here.
-  " Otherwise, the BufEnter event gets triggered when attempts to write to
-  " the DBG buffer are made.
+" }}}
+" LocalBrowse: invokes netrw#LocalBrowseCheck() on directory buffers {{{
 
-  if !exists("s:vimentered")
-    " If s:vimentered doesn't exist, then the VimEnter event hasn't fired.  It will,
-    " and so s:VimEnter() will then be calling this routine, but this time with s:vimentered defined.
-    "   call Dfunc("s:LocalBrowse(dirname<".a:dirname.">)  (s:vimentered doesn't exist)")
-    "   call Dret("s:LocalBrowse")
-    return
-  endif
-
-  "  call Dfunc("s:LocalBrowse(dirname<".a:dirname.">)  (s:vimentered=".s:vimentered.")")
-
-  if has("amiga")
-    " The check against '' is made for the Amiga, where the empty
-    " string is the current directory and not checking would break
-    " things such as the help command.
-    "   call Decho("(LocalBrowse) dirname<".a:dirname.">  (isdirectory, amiga)")
-    if a:dirname != '' && isdirectory(a:dirname)
-      sil! call netrw#LocalBrowseCheck(a:dirname)
-      if exists("w:netrw_bannercnt") && line('.') < w:netrw_bannercnt
-        exe w:netrw_bannercnt
-      endif
+function! s:LocalBrowse(dirname)
+    " do not trigger in the terminal
+    " https://github.com/vim/vim/issues/16463
+    if &buftype ==# 'terminal'
+        return
     endif
 
-  elseif isdirectory(a:dirname)
-    "   call Decho("(LocalBrowse) dirname<".a:dirname."> ft=".&ft."  (isdirectory, not amiga)")
-    "   call Dredir("LocalBrowse ft last set: ","verbose set ft")
-    " Jul 13, 2021: for whatever reason, preceding the following call with
-    " a   sil!  causes an unbalanced if-endif vim error
-    call netrw#LocalBrowseCheck(a:dirname)
-    if exists("w:netrw_bannercnt") && line('.') < w:netrw_bannercnt
-      exe w:netrw_bannercnt
+    if !exists("s:vimentered")
+        " If s:vimentered doesn't exist, then the VimEnter event hasn't fired.  It will,
+        " and so s:VimEnter() will then be calling this routine, but this time with s:vimentered defined.
+        return
     endif
 
-  else
-    " not a directory, ignore it
-    "   call Decho("(LocalBrowse) dirname<".a:dirname."> not a directory, ignoring...")
-  endif
+    if has("amiga")
+        " The check against '' is made for the Amiga, where the empty
+        " string is the current directory and not checking would break
+        " things such as the help command.
+        if a:dirname != '' && isdirectory(a:dirname)
+            sil! call netrw#LocalBrowseCheck(a:dirname)
+            if exists("w:netrw_bannercnt") && line('.') < w:netrw_bannercnt
+                exe w:netrw_bannercnt
+            endif
+        endif
+    elseif isdirectory(a:dirname)
+        " Jul 13, 2021: for whatever reason, preceding the following call with
+        " a   sil!  causes an unbalanced if-endif vim error
+        call netrw#LocalBrowseCheck(a:dirname)
+        if exists("w:netrw_bannercnt") && line('.') < w:netrw_bannercnt
+            exe w:netrw_bannercnt
+        endif
+    endif
+endfunction
 
-  "  call Dret("s:LocalBrowse")
-endfun
-
-" ---------------------------------------------------------------------
-" s:VimEnter: after all vim startup stuff is done, this function is called. {{{2
+" }}}
+" s:VimEnter: after all vim startup stuff is done, this function is called. {{{
 "             Its purpose: to look over all windows and run s:LocalBrowse() on
 "             them, which checks if they're directories and will create a directory
 "             listing when appropriate.
 "             It also sets s:vimentered, letting s:LocalBrowse() know that s:VimEnter()
 "             has already been called.
-fun! s:VimEnter(dirname)
-  "  call Dfunc("s:VimEnter(dirname<".a:dirname.">) expand(%)<".expand("%").">")
-  if has('nvim') || v:version < 802
-    " Johann Höchtl: reported that the call range... line causes an E488: Trailing characters
-    "                error with neovim. I suspect its because neovim hasn't updated with recent
-    "                vim patches. As is, this code will have problems with popup terminals
-    "                instantiated before the VimEnter event runs.
-    " Ingo Karkat  : E488 also in Vim 8.1.1602
-    let curwin       = winnr()
-    let s:vimentered = 1
-    windo call s:LocalBrowse(expand("%:p"))
-    exe curwin."wincmd w"
-  else
-    " the following complicated expression comes courtesy of lacygoill; largely does the same thing as the windo and
-    " wincmd which are commented out, but avoids some side effects. Allows popup terminal before VimEnter.
-    let s:vimentered = 1
-    call range(1, winnr('$'))->map({_, v -> win_execute(win_getid(v), 'call expand("%:p")->s:LocalBrowse()')})
-  endif
-  "  call Dret("s:VimEnter")
-endfun
+function! s:VimEnter(dirname)
+    if has('nvim') || v:version < 802
+        " Johann Höchtl: reported that the call range... line causes an E488: Trailing characters
+        "                error with neovim. I suspect its because neovim hasn't updated with recent
+        "                vim patches. As is, this code will have problems with popup terminals
+        "                instantiated before the VimEnter event runs.
+        " Ingo Karkat  : E488 also in Vim 8.1.1602
+        let curwin       = winnr()
+        let s:vimentered = 1
+        windo call s:LocalBrowse(expand("%:p"))
+        exe curwin."wincmd w"
+    else
+        " the following complicated expression comes courtesy of lacygoill; largely does the same thing as the windo and
+        " wincmd which are commented out, but avoids some side effects. Allows popup terminal before VimEnter.
+        let s:vimentered = 1
+        call range(1, winnr('$'))->map({_, v -> win_execute(win_getid(v), 'call expand("%:p")->s:LocalBrowse()')})
+    endif
+endfunction
 
-" ---------------------------------------------------------------------
-" NetrwStatusLine: {{{1
-fun! NetrwStatusLine()
-  "  let g:stlmsg= "Xbufnr=".w:netrw_explore_bufnr." bufnr=".bufnr("%")." Xline#".w:netrw_explore_line." line#".line(".")
-  if !exists("w:netrw_explore_bufnr") || w:netrw_explore_bufnr != bufnr("%") || !exists("w:netrw_explore_line") || w:netrw_explore_line != line(".") || !exists("w:netrw_explore_list")
-    let &stl= s:netrw_explore_stl
-    if exists("w:netrw_explore_bufnr")|unlet w:netrw_explore_bufnr|endif
-    if exists("w:netrw_explore_line")|unlet w:netrw_explore_line|endif
-    return ""
-  else
-    return "Match ".w:netrw_explore_mtchcnt." of ".w:netrw_explore_listlen
-  endif
-endfun
+" }}}
+" NetrwStatusLine: {{{
 
-" ------------------------------------------------------------------------
-" NetUserPass: set username and password for subsequent ftp transfer {{{1
+function! NetrwStatusLine()
+    if !exists("w:netrw_explore_bufnr") || w:netrw_explore_bufnr != bufnr("%") || !exists("w:netrw_explore_line") || w:netrw_explore_line != line(".") || !exists("w:netrw_explore_list")
+        let &stl= s:netrw_explore_stl
+        unlet! w:netrw_explore_bufnr w:netrw_explore_line
+        return ""
+    else
+        return "Match ".w:netrw_explore_mtchcnt." of ".w:netrw_explore_listlen
+    endif
+endfunction
+
+" }}}
+" NetUserPass: set username and password for subsequent ftp transfer {{{
 "   Usage:  :call NetUserPass()                 -- will prompt for userid and password
 "           :call NetUserPass("uid")            -- will prompt for password
 "           :call NetUserPass("uid","password") -- sets global userid and password
-fun! NetUserPass(...)
-
-  " get/set userid
-  if a:0 == 0
-    "  call Dfunc("NetUserPass(a:0<".a:0.">)")
-    if !exists("g:netrw_uid") || g:netrw_uid == ""
-      " via prompt
-      let g:netrw_uid= input('Enter username: ')
+function! NetUserPass(...)
+    " get/set userid
+    if a:0 == 0
+        if !exists("g:netrw_uid") || g:netrw_uid == ""
+            " via prompt
+            let g:netrw_uid= input('Enter username: ')
+        endif
+    else  " from command line
+        let g:netrw_uid= a:1
     endif
-  else  " from command line
-    "  call Dfunc("NetUserPass(a:1<".a:1.">) {")
-    let g:netrw_uid= a:1
-  endif
 
-  " get password
-  if a:0 <= 1 " via prompt
-    "  call Decho("a:0=".a:0." case <=1:")
-    let g:netrw_passwd= inputsecret("Enter Password: ")
-  else " from command line
-    "  call Decho("a:0=".a:0." case >1: a:2<".a:2.">")
-    let g:netrw_passwd=a:2
-  endif
-  "  call Dret("NetUserPass")
-endfun
+    " get password
+    if a:0 <= 1 " via prompt
+        let g:netrw_passwd= inputsecret("Enter Password: ")
+    else " from command line
+        let g:netrw_passwd=a:2
+    endif
+endfunction
 
-" ------------------------------------------------------------------------
-" Modelines And Restoration: {{{1
+" }}}
+
 let &cpo= s:keepcpo
 unlet s:keepcpo
-" vim:ts=8 sts=2 sw=2 et fdm=marker
+
+" vim:ts=8 sts=4 sw=4 et fdm=marker

--- a/runtime/pack/dist/opt/netrw/syntax/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/syntax/netrw.vim
@@ -4,142 +4,146 @@
 " Language: Netrw Listing Syntax
 
 if exists("b:current_syntax")
- finish
+    finish
 endif
 
-" Directory List Syntax Highlighting: {{{1
-syn cluster NetrwGroup		contains=netrwHide,netrwSortBy,netrwSortSeq,netrwQuickHelp,netrwVersion,netrwCopyTgt
-syn cluster NetrwTreeGroup	contains=netrwDir,netrwSymLink,netrwExe
+let b:current_syntax = "netrwlist"
 
-syn match  netrwPlain		"\(\S\+ \)*\S\+"					contains=netrwLink,@NoSpell
-syn match  netrwSpecial		"\%(\S\+ \)*\S\+[*|=]\ze\%(\s\{2,}\|$\)"		contains=netrwClassify,@NoSpell
-syn match  netrwDir		"\.\{1,2}/"						contains=netrwClassify,@NoSpell
-syn match  netrwDir		"\%(\S\+ \)*\S\+/\ze\%(\s\{2,}\|$\)"			contains=netrwClassify,@NoSpell
-syn match  netrwSizeDate	"\<\d\+\s\d\{1,2}/\d\{1,2}/\d\{4}\s"	skipwhite	contains=netrwDateSep,@NoSpell	nextgroup=netrwTime
-syn match  netrwSymLink		"\%(\S\+ \)*\S\+@\ze\%(\s\{2,}\|$\)"  			contains=netrwClassify,@NoSpell
-syn match  netrwExe		"\%(\S\+ \)*\S*[^~]\*\ze\%(\s\{2,}\|$\)" 		contains=netrwClassify,@NoSpell
+" Directory List Syntax Highlighting: {{{
+
+syn cluster NetrwGroup contains=netrwHide,netrwSortBy,netrwSortSeq,netrwQuickHelp,netrwVersion,netrwCopyTgt
+syn cluster NetrwTreeGroup contains=netrwDir,netrwSymLink,netrwExe
+
+syn match netrwPlain "\(\S\+ \)*\S\+" contains=netrwLink,@NoSpell
+syn match netrwSpecial "\%(\S\+ \)*\S\+[*|=]\ze\%(\s\{2,}\|$\)" contains=netrwClassify,@NoSpell
+syn match netrwDir "\.\{1,2}/" contains=netrwClassify,@NoSpell
+syn match netrwDir "\%(\S\+ \)*\S\+/\ze\%(\s\{2,}\|$\)" contains=netrwClassify,@NoSpell
+syn match netrwSizeDate "\<\d\+\s\d\{1,2}/\d\{1,2}/\d\{4}\s" skipwhite contains=netrwDateSep,@NoSpell nextgroup=netrwTime
+syn match netrwSymLink "\%(\S\+ \)*\S\+@\ze\%(\s\{2,}\|$\)" contains=netrwClassify,@NoSpell
+syn match netrwExe "\%(\S\+ \)*\S*[^~]\*\ze\%(\s\{2,}\|$\)" contains=netrwClassify,@NoSpell
 if has("gui_running") && (&enc == 'utf-8' || &enc == 'utf-16' || &enc == 'ucs-4')
-syn match  netrwTreeBar		"^\%([-+|│] \)\+"					contains=netrwTreeBarSpace	nextgroup=@netrwTreeGroup
+    syn match netrwTreeBar "^\%([-+|│] \)\+" contains=netrwTreeBarSpace nextgroup=@netrwTreeGroup
 else
-syn match  netrwTreeBar		"^\%([-+|] \)\+"					contains=netrwTreeBarSpace	nextgroup=@netrwTreeGroup
+    syn match netrwTreeBar "^\%([-+|] \)\+" contains=netrwTreeBarSpace nextgroup=@netrwTreeGroup
 endif
-syn match  netrwTreeBarSpace	" "					contained
+syn match netrwTreeBarSpace " " contained
 
-syn match  netrwClassify	"[*=|@/]\ze\%(\s\{2,}\|$\)"		contained
-syn match  netrwDateSep		"/"					contained
-syn match  netrwTime		"\d\{1,2}:\d\{2}:\d\{2}"		contained	contains=netrwTimeSep
-syn match  netrwTimeSep		":"
+syn match netrwClassify "[*=|@/]\ze\%(\s\{2,}\|$\)" contained
+syn match netrwDateSep "/" contained
+syn match netrwTime "\d\{1,2}:\d\{2}:\d\{2}" contained contains=netrwTimeSep
+syn match netrwTimeSep ":"
 
-syn match  netrwComment		'".*\%(\t\|$\)'						contains=@NetrwGroup,@NoSpell
-syn match  netrwHide		'^"\s*\(Hid\|Show\)ing:'	skipwhite		contains=@NoSpell		nextgroup=netrwHidePat
-syn match  netrwSlash		"/"				contained
-syn match  netrwHidePat		"[^,]\+"			contained skipwhite	contains=@NoSpell		nextgroup=netrwHideSep
-syn match  netrwHideSep		","				contained skipwhite					nextgroup=netrwHidePat
-syn match  netrwSortBy		"Sorted by"			contained transparent skipwhite				nextgroup=netrwList
-syn match  netrwSortSeq		"Sort sequence:"		contained transparent skipwhite			 	nextgroup=netrwList
-syn match  netrwCopyTgt		"Copy/Move Tgt:"		contained transparent skipwhite				nextgroup=netrwList
-syn match  netrwList		".*$"				contained		contains=netrwComma,@NoSpell
-syn match  netrwComma		","				contained
-syn region netrwQuickHelp	matchgroup=Comment start="Quick Help:\s\+" end="$"	contains=netrwHelpCmd,netrwQHTopic,@NoSpell	keepend contained
-syn match  netrwHelpCmd		"\S\+\ze:"			contained skipwhite	contains=@NoSpell		nextgroup=netrwCmdSep
-syn match  netrwQHTopic		"([a-zA-Z &]\+)"		contained skipwhite
-syn match  netrwCmdSep		":"				contained nextgroup=netrwCmdNote
-syn match  netrwCmdNote		".\{-}\ze  "			contained		contains=@NoSpell
-syn match  netrwVersion		"(netrw.*)"			contained		contains=@NoSpell
-syn match  netrwLink		"-->"				contained skipwhite
+syn match netrwComment '".*\%(\t\|$\)' contains=@NetrwGroup,@NoSpell
+syn match netrwHide '^"\s*\(Hid\|Show\)ing:' skipwhite contains=@NoSpell nextgroup=netrwHidePat
+syn match netrwSlash "/" contained
+syn match netrwHidePat "[^,]\+" contained skipwhite contains=@NoSpell nextgroup=netrwHideSep
+syn match netrwHideSep "," contained skipwhite nextgroup=netrwHidePat
+syn match netrwSortBy "Sorted by" contained transparent skipwhite nextgroup=netrwList
+syn match netrwSortSeq "Sort sequence:" contained transparent skipwhite nextgroup=netrwList
+syn match netrwCopyTgt "Copy/Move Tgt:" contained transparent skipwhite nextgroup=netrwList
+syn match netrwList ".*$" contained contains=netrwComma,@NoSpell
+syn match netrwComma "," contained
+syn region netrwQuickHelp matchgroup=Comment start="Quick Help:\s\+" end="$" contains=netrwHelpCmd,netrwQHTopic,@NoSpell keepend contained
+syn match netrwHelpCmd "\S\+\ze:" contained skipwhite contains=@NoSpell nextgroup=netrwCmdSep
+syn match netrwQHTopic "([a-zA-Z &]\+)" contained skipwhite
+syn match netrwCmdSep ":" contained nextgroup=netrwCmdNote
+syn match netrwCmdNote ".\{-}\ze " contained contains=@NoSpell
+syn match netrwVersion "(netrw.*)" contained contains=@NoSpell
+syn match netrwLink "-->" contained skipwhite
 
-" -----------------------------
-" Special filetype highlighting {{{1
-" -----------------------------
+" }}}
+" Special filetype highlighting {{{
+
 if exists("g:netrw_special_syntax") && g:netrw_special_syntax
- if exists("+suffixes") && &suffixes != ""
-  let suflist= join(split(&suffixes,','))
-  let suflist= escape(substitute(suflist," ",'\\|','g'),'.~')
-  exe "syn match netrwSpecFile '\\(\\S\\+ \\)*\\S*\\(".suflist."\\)\\>'  contains=netrwTreeBar,@NoSpell"
- endif
- syn match netrwBak		"\(\S\+ \)*\S\+\.bak\>"					contains=netrwTreeBar,@NoSpell
- syn match netrwCompress	"\(\S\+ \)*\S\+\.\%(gz\|bz2\|Z\|zip\)\>"		contains=netrwTreeBar,@NoSpell
- if has("unix")
-  syn match netrwCoreDump	"\<core\%(\.\d\+\)\=\>"					contains=netrwTreeBar,@NoSpell
- endif
- syn match netrwLex		"\(\S\+ \)*\S\+\.\%(l\|lex\)\>"				contains=netrwTreeBar,@NoSpell
- syn match netrwYacc		"\(\S\+ \)*\S\+\.y\>"					contains=netrwTreeBar,@NoSpell
- syn match netrwData		"\(\S\+ \)*\S\+\.dat\>"					contains=netrwTreeBar,@NoSpell
- syn match netrwDoc		"\(\S\+ \)*\S\+\.\%(doc\|txt\|pdf\|ps\|docx\)\>"	contains=netrwTreeBar,@NoSpell
- syn match netrwHdr		"\(\S\+ \)*\S\+\.\%(h\|hpp\)\>"				contains=netrwTreeBar,@NoSpell
- syn match netrwLib		"\(\S\+ \)*\S*\.\%(a\|so\|lib\|dll\)\>"			contains=netrwTreeBar,@NoSpell
- syn match netrwMakeFile	"\<[mM]akefile\>\|\(\S\+ \)*\S\+\.mak\>"		contains=netrwTreeBar,@NoSpell
- syn match netrwObj		"\(\S\+ \)*\S*\.\%(o\|obj\)\>"				contains=netrwTreeBar,@NoSpell
- syn match netrwPix		"\c\(\S\+ \)*\S*\.\%(bmp\|fits\=\|gif\|je\=pg\|pcx\|ppc\|pgm\|png\|ppm\|psd\|rgb\|tif\|xbm\|xcf\)\>"	contains=netrwTreeBar,@NoSpell
- syn match netrwTags		"\<\(ANmenu\|ANtags\)\>"				contains=netrwTreeBar,@NoSpell
- syn match netrwTags    	"\<tags\>"						contains=netrwTreeBar,@NoSpell
- syn match netrwTilde		"\(\S\+ \)*\S\+\~\*\=\>"				contains=netrwTreeBar,@NoSpell
- syn match netrwTmp		"\<tmp\(\S\+ \)*\S\+\>\|\(\S\+ \)*\S*tmp\>"		contains=netrwTreeBar,@NoSpell
+    if exists("+suffixes") && &suffixes != ""
+        let suflist= join(split(&suffixes,','))
+        let suflist= escape(substitute(suflist," ",'\\|','g'),'.~')
+        exe "syn match netrwSpecFile '\\(\\S\\+ \\)*\\S*\\(".suflist."\\)\\>' contains=netrwTreeBar,@NoSpell"
+    endif
+    syn match netrwBak "\(\S\+ \)*\S\+\.bak\>" contains=netrwTreeBar,@NoSpell
+    syn match netrwCompress "\(\S\+ \)*\S\+\.\%(gz\|bz2\|Z\|zip\)\>" contains=netrwTreeBar,@NoSpell
+    if has("unix")
+        syn match netrwCoreDump "\<core\%(\.\d\+\)\=\>" contains=netrwTreeBar,@NoSpell
+    endif
+    syn match netrwLex "\(\S\+ \)*\S\+\.\%(l\|lex\)\>" contains=netrwTreeBar,@NoSpell
+    syn match netrwYacc "\(\S\+ \)*\S\+\.y\>" contains=netrwTreeBar,@NoSpell
+    syn match netrwData "\(\S\+ \)*\S\+\.dat\>" contains=netrwTreeBar,@NoSpell
+    syn match netrwDoc "\(\S\+ \)*\S\+\.\%(doc\|txt\|pdf\|ps\|docx\)\>" contains=netrwTreeBar,@NoSpell
+    syn match netrwHdr "\(\S\+ \)*\S\+\.\%(h\|hpp\)\>" contains=netrwTreeBar,@NoSpell
+    syn match netrwLib "\(\S\+ \)*\S*\.\%(a\|so\|lib\|dll\)\>" contains=netrwTreeBar,@NoSpell
+    syn match netrwMakeFile "\<[mM]akefile\>\|\(\S\+ \)*\S\+\.mak\>" contains=netrwTreeBar,@NoSpell
+    syn match netrwObj "\(\S\+ \)*\S*\.\%(o\|obj\)\>" contains=netrwTreeBar,@NoSpell
+    syn match netrwPix "\c\(\S\+ \)*\S*\.\%(bmp\|fits\=\|gif\|je\=pg\|pcx\|ppc\|pgm\|png\|ppm\|psd\|rgb\|tif\|xbm\|xcf\)\>" contains=netrwTreeBar,@NoSpell
+    syn match netrwTags "\<\(ANmenu\|ANtags\)\>" contains=netrwTreeBar,@NoSpell
+    syn match netrwTags "\<tags\>" contains=netrwTreeBar,@NoSpell
+    syn match netrwTilde "\(\S\+ \)*\S\+\~\*\=\>" contains=netrwTreeBar,@NoSpell
+    syn match netrwTmp "\<tmp\(\S\+ \)*\S\+\>\|\(\S\+ \)*\S*tmp\>" contains=netrwTreeBar,@NoSpell
 endif
 
-" ---------------------------------------------------------------------
-" Highlighting Links: {{{1
+" }}}
+" Highlighting Links: {{{
+
 if !exists("did_drchip_netrwlist_syntax")
- let did_drchip_netrwlist_syntax= 1
- hi default link netrwClassify	Function
- hi default link netrwCmdSep	Delimiter
- hi default link netrwComment	Comment
- hi default link netrwDir	Directory
- hi default link netrwHelpCmd	Function
- hi default link netrwQHTopic	Number
- hi default link netrwHidePat	Statement
- hi default link netrwHideSep	netrwComment
- hi default link netrwList	Statement
- hi default link netrwVersion	Identifier
- hi default link netrwSymLink	Question
- hi default link netrwExe	PreProc
- hi default link netrwDateSep	Delimiter
+    let did_drchip_netrwlist_syntax= 1
+    hi default link netrwClassify Function
+    hi default link netrwCmdSep Delimiter
+    hi default link netrwComment Comment
+    hi default link netrwDir Directory
+    hi default link netrwHelpCmd Function
+    hi default link netrwQHTopic Number
+    hi default link netrwHidePat Statement
+    hi default link netrwHideSep netrwComment
+    hi default link netrwList Statement
+    hi default link netrwVersion Identifier
+    hi default link netrwSymLink Question
+    hi default link netrwExe PreProc
+    hi default link netrwDateSep Delimiter
 
- hi default link netrwTreeBar	Special
- hi default link netrwTimeSep	netrwDateSep
- hi default link netrwComma	netrwComment
- hi default link netrwHide	netrwComment
- hi default link netrwMarkFile	TabLineSel
- hi default link netrwLink	Special
+    hi default link netrwTreeBar Special
+    hi default link netrwTimeSep netrwDateSep
+    hi default link netrwComma netrwComment
+    hi default link netrwHide netrwComment
+    hi default link netrwMarkFile TabLineSel
+    hi default link netrwLink Special
 
- " special syntax highlighting (see :he g:netrw_special_syntax)
- hi default link netrwCoreDump	WarningMsg
- hi default link netrwData	Folded
- hi default link netrwHdr	netrwPlain
- hi default link netrwLex	netrwPlain
- hi default link netrwLib	DiffChange
- hi default link netrwMakefile	DiffChange
- hi default link netrwYacc	netrwPlain
- hi default link netrwPix	Special
+    " special syntax highlighting (see :he g:netrw_special_syntax)
+    hi default link netrwCoreDump WarningMsg
+    hi default link netrwData Folded
+    hi default link netrwHdr netrwPlain
+    hi default link netrwLex netrwPlain
+    hi default link netrwLib DiffChange
+    hi default link netrwMakefile DiffChange
+    hi default link netrwYacc netrwPlain
+    hi default link netrwPix Special
 
- hi default link netrwBak	netrwGray
- hi default link netrwCompress	netrwGray
- hi default link netrwSpecFile	netrwGray
- hi default link netrwObj	netrwGray
- hi default link netrwTags	netrwGray
- hi default link netrwTilde	netrwGray
- hi default link netrwTmp	netrwGray
+    hi default link netrwBak netrwGray
+    hi default link netrwCompress netrwGray
+    hi default link netrwSpecFile netrwGray
+    hi default link netrwObj netrwGray
+    hi default link netrwTags netrwGray
+    hi default link netrwTilde netrwGray
+    hi default link netrwTmp netrwGray
 endif
 
- " set up netrwGray to be understated (but not Ignore'd or Conceal'd, as those
- " can be hard/impossible to read). Users may override this in a colorscheme by
- " specifying netrwGray highlighting.
- redir => s:netrwgray
-  sil hi netrwGray
- redir END
- if s:netrwgray !~ 'guifg'
-  if has("gui") && has("gui_running")
-   if &bg == "dark"
-    exe "hi netrwGray gui=NONE guifg=gray30"
-   else
-    exe "hi netrwGray gui=NONE guifg=gray70"
-   endif
-  else
-   hi link netrwGray	Folded
-  endif
- endif
+" set up netrwGray to be understated (but not Ignore'd or Conceal'd, as those
+" can be hard/impossible to read). Users may override this in a colorscheme by
+" specifying netrwGray highlighting.
+redir => s:netrwgray
+sil hi netrwGray
+redir END
 
-" Current Syntax: {{{1
-let   b:current_syntax = "netrwlist"
-" ---------------------------------------------------------------------
-" vim: ts=8 fdm=marker
+if s:netrwgray !~ 'guifg'
+    if has("gui") && has("gui_running")
+        if &bg == "dark"
+            exe "hi netrwGray gui=NONE guifg=gray30"
+        else
+            exe "hi netrwGray gui=NONE guifg=gray70"
+        endif
+    else
+        hi link netrwGray Folded
+    endif
+endif
+
+" }}}
+
+" vim:ts=8 sts=4 sw=4 et fdm=marker

--- a/runtime/pack/dist/opt/netrw/syntax/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/syntax/netrw.vim
@@ -1,4 +1,4 @@
-Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
+" Maintainer: Luca Saccarola <github.e41mv@aleeas.com>
 " Former Maintainer: Charles E Campbell
 " Upstream: <https://github.com/saccarosium/netrw.vim>
 " Language: Netrw Listing Syntax


### PR DESCRIPTION
Relevant commits:
- release: netrw v175
- fix: prevent netrw to load into the built-in terminal
- fix: restore correctly cpo settings
- fix(docs): mispelled original authors name
- chore: move viml files to new formatting standard

fixes: vim/vim#16463
closes: vim/vim#16465

https://github.com/vim/vim/commit/d402ba81e256b21e73a98ec809bd4a9482613553

Co-authored-by: Luca Saccarola <github.e41mv@aleeas.com>
