### PR TITLE
fix(lsp): don't use completion filterText if prefix is empty

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -231,6 +231,9 @@ end
 ---@param prefix string
 ---@return boolean
 local function match_item_by_value(value, prefix)
+  if prefix == '' then
+    return true
+  end
   if vim.o.completeopt:find('fuzzy') ~= nil then
     return next(vim.fn.matchfuzzy({ value }, prefix)) ~= nil
   end

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -239,13 +239,18 @@ describe('vim.lsp.completion: item conversion', function()
           },
         },
       }
-      local expected = {
+      assert_completion_matches('<mo', items, {
         {
           abbr = 'module',
           word = '<module',
         },
-      }
-      assert_completion_matches('<mo', items, expected)
+      })
+      assert_completion_matches('', items, {
+        {
+          abbr = 'module',
+          word = 'module',
+        },
+      })
     end)
 
     it('fuzzy matches on label when filterText is missing', function()


### PR DESCRIPTION
Follow up to https://github.com/neovim/neovim/pull/32072

If there is no prefix (e.g. at the start of word boundary or a line), it
always used the `filterText` because the `match` function always
returned false.
