### PR TITLE
fix(lsp): set floating window filetype after context setup

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1568,8 +1568,6 @@ function M.open_floating_preview(contents, syntax, opts)
   if do_stylize then
     local width = M._make_floating_popup_size(contents, opts)
     contents = M._normalize_markdown(contents, { width = width })
-    vim.bo[floating_bufnr].filetype = 'markdown'
-    vim.treesitter.start(floating_bufnr)
   else
     -- Clean up input: trim empty lines
     contents = vim.split(table.concat(contents, '\n'), '\n', { trimempty = true })
@@ -1635,9 +1633,6 @@ function M.open_floating_preview(contents, syntax, opts)
     })
   end
 
-  if do_stylize then
-    vim.wo[floating_winnr].conceallevel = 2
-  end
   vim.wo[floating_winnr].foldenable = false -- Disable folding.
   vim.wo[floating_winnr].wrap = opts.wrap -- Soft wrapping.
   vim.wo[floating_winnr].breakindent = true -- Slightly better list presentation.
@@ -1645,6 +1640,12 @@ function M.open_floating_preview(contents, syntax, opts)
 
   vim.bo[floating_bufnr].modifiable = false
   vim.bo[floating_bufnr].bufhidden = 'wipe'
+
+  if do_stylize then
+    vim.wo[floating_winnr].conceallevel = 2
+    vim.bo[floating_bufnr].filetype = 'markdown'
+    vim.treesitter.start(floating_bufnr)
+  end
 
   return floating_bufnr, floating_winnr
 end


### PR DESCRIPTION
## Problem:
The filetype for the floating window buffer is being set before its context is fully initialized. This results in `FileType` events not receiving the correct context.

## Solution:
Set the filetype after the floating preview window and its buffer variables are fully configured to ensure proper context is provided.