### PR TITLE
fix: completion.enable(false,...) deletes invalid augroup

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -615,6 +615,12 @@ local function on_complete_done()
   end
 end
 
+---@param bufnr integer
+---@return string
+local function get_augroup(bufnr)
+  return string.format('nvim.lsp.completion_%d', bufnr)
+end
+
 --- @class vim.lsp.completion.BufferOpts
 --- @field autotrigger? boolean  Default: false When true, completion triggers automatically based on the server's `triggerCharacters`.
 --- @field convert? fun(item: lsp.CompletionItem): table Transforms an LSP CompletionItem to |complete-items|.
@@ -639,8 +645,7 @@ local function enable_completions(client_id, bufnr, opts)
     })
 
     -- Set up autocommands.
-    local group =
-      api.nvim_create_augroup(string.format('nvim.lsp.completion_%d', bufnr), { clear = true })
+    local group = api.nvim_create_augroup(get_augroup(bufnr), { clear = true })
     api.nvim_create_autocmd('CompleteDone', {
       group = group,
       buffer = bufnr,
@@ -708,7 +713,7 @@ local function disable_completions(client_id, bufnr)
   handle.clients[client_id] = nil
   if not next(handle.clients) then
     buf_handles[bufnr] = nil
-    api.nvim_del_augroup_by_name(string.format('vim/lsp/completion-%d', bufnr))
+    api.nvim_del_augroup_by_name(get_augroup(bufnr))
   else
     for char, clients in pairs(handle.triggers) do
       --- @param c vim.lsp.Client


### PR DESCRIPTION
Currently, after doing the below on a buffer:
```lua
vim.lsp.completion.enable(true, client.id, bufnr)
vim.lsp.completion.enable(false, client.id, bufnr)
```

I get:
```
Error detected while processing LspDetach Autocommands for "*":
Error executing lua callback: ...ed-nightly/share/nvim/runtime/lua/vim/lsp/completion.lua:701: Vim:E367: No such group: "vim/lsp/completion-22"
stack traceback:
        [C]: in function 'nvim_del_augroup_by_name'
        ...ed-nightly/share/nvim/runtime/lua/vim/lsp/completion.lua:701: in function 'disable_completions'
        ...ed-nightly/share/nvim/runtime/lua/vim/lsp/completion.lua:724: in function 'enable'
        ...-hm/lua/pde/lsp/capabilities/textDocument_completion.lua:158: in function 'detach'
        /home/konrad/.config/neovim-pde-hm/lua/pde/lsp/init.lua:24: in function 'detach'
        /home/konrad/.config/neovim-pde-hm/lua/pde/lsp/init.lua:206: in function </home/konrad/.config/neovim-pde-hm/lua/pde/lsp/init.lua:202>
        [C]: in function 'nvim_exec_autocmds'
        ...vim-unwrapped-nightly/share/nvim/runtime/lua/vim/lsp.lua:815: in function 'buf_detach_client'
        ...vim-unwrapped-nightly/share/nvim/runtime/lua/vim/lsp.lua:911: in function <...vim-unwrapped-nightly/share/nvim/runtime/lua/vim/lsp.lua:908>
```

After further investigation, seems like a different augroup name is used on creation, and different on deletion.

In this PR a function this is fixed by introducing a function to generate this name.