### PR TITLE
fix(treesitter): compute folds on_changedtree only if not nil

### DIFF
--- a/runtime/lua/vim/treesitter/_fold.lua
+++ b/runtime/lua/vim/treesitter/_fold.lua
@@ -387,7 +387,9 @@ function M.foldexpr(lnum)
 
     parser:register_cbs({
       on_changedtree = function(tree_changes)
-        on_changedtree(bufnr, foldinfos[bufnr], tree_changes)
+        if foldinfos[bufnr] then
+          on_changedtree(bufnr, foldinfos[bufnr], tree_changes)
+        end
       end,
 
       on_bytes = function(_, _, start_row, start_col, _, old_row, old_col, _, new_row, new_col, _)


### PR DESCRIPTION
Not easy to reproduce, but recently often when I do `:e` on an already opened file I get this error:
```
Error executing vim.schedule lua callback: ...-nightly/share/nvim/runtime/lua/vim/treesitter/_fold.lua:77: attempt to index local 'info' (a nil value)
stack traceback:
        ...-nightly/share/nvim/runtime/lua/vim/treesitter/_fold.lua:77: in function 'compute_folds_levels'
        ...-nightly/share/nvim/runtime/lua/vim/treesitter/_fold.lua:295: in function 'fn'
        ...-nightly/share/nvim/runtime/lua/vim/treesitter/_fold.lua:267: in function <...-nightly/share/nvim/runtime/lua/vim/treesitter/_fold.lua:263>
```

I'm using lsp folds with this config:
```lua
vim.o.foldmethod = "expr"
vim.o.foldexpr = "v:lua.vim.treesitter.foldexpr()"
vim.o.foldtext = "v:lua.vim.treesitter.foldtext()"
vim.o.foldlevel = 1
vim.o.foldenable = false
```

I've only noticed this for Roslyn LSP for csharp but I'm not sure if this is server-specific.

I'm not sure about the fix either. I mean, it should work, but not sure if this is the best approach. Certainly, it's one with as few changes as possible.

Checking for nil could be done higher, outside `compute_folds_levels`. Open to suggestions.