### PR TITLE
ci(news): treat deprecated.txt as part of news.txt

### DIFF
--- a/.github/workflows/news.yml
+++ b/.github/workflows/news.yml
@@ -20,7 +20,7 @@ jobs:
             type="$(echo "$message" | sed -E 's|([[:alpha:]]+)(\(.*\))?!?:.*|\1|')"
             breaking="$(echo "$message" | sed -E 's|[[:alpha:]]+(\(.*\))?!:.*|breaking-change|')"
             if [[ "$type" == "feat" ]] || [[ "$type" == "perf" ]] || [[ "$breaking" == "breaking-change" ]]; then
-              ! git diff HEAD~${{ github.event.pull_request.commits }}..HEAD --quiet runtime/doc/news.txt ||
+              ! git diff HEAD~${{ github.event.pull_request.commits }}..HEAD --quiet runtime/doc/news.txt runtime/doc/deprecated.txt ||
               {
                 echo "
                   Pull request includes a new feature, performance improvement


### PR DESCRIPTION
This is because we reference to deprecated.txt from news.txt, so
deprecation news updates are made only in deprecated.txt.
