### PR TITLE
docs(treesitter): add parentheses to conceal example

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -497,7 +497,7 @@ convention, nodes to be concealed are captured as `@conceal`, but any capture
 can be used. For example, the following query can be used to hide code block
 delimiters in Markdown: >query
 
-    (fenced_code_block_delimiter @conceal (#set! conceal ""))
+    ((fenced_code_block_delimiter) @conceal (#set! conceal ""))
 <
 It is also possible to replace a node with a single character, which (unlike
 legacy syntax) can be given a custom highlight. For example, the following


### PR DESCRIPTION
There's a syntax error in this example:
![image](https://github.com/user-attachments/assets/f7483cd9-a9f2-4eb1-bf8f-1c55247322c6)
