### PR TITLE
fix(log): report only when $TMPDIR is set

### DIFF
--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3277,7 +3277,7 @@ static void vim_mktempdir(void)
     if (!os_isdir(tmp)) {
       if (strequal("$TMPDIR", temp_dirs[i])) {
         if (!os_getenv("TMPDIR")) {
-          WLOG("$TMPDIR is unset");
+          DLOG("$TMPDIR is unset");
         } else {
           WLOG("$TMPDIR tempdir not a directory (or does not exist): \"%s\"", tmp);
         }


### PR DESCRIPTION
## Problem

Since 8a2aec99, without `$TMPDIR` set, `nvim --cmd 'call tempname() | quit'` will always append one line to log:
```
WRN 2025-01-21T11:54:39.579 nvim.138603.0 vim_mktempdir:3279: $TMPDIR tempdir not a directory (or does not exist): $TMPDIR
```

After 8a236c24, the log information is more accurated, but this still write log once everytime start nvim:
```
WRN 2025-01-21T12:00:57.881 nvim.143483.0 vim_mktempdir:3280: $TMPDIR is unset
```

This won't be a problem for those start neovim rarely. But for plugin like https://github.com/ibhagwan/fzf-lua, it often build fzf cli spawning neovim instances (https://github.com/ibhagwan/fzf-lua/blob/c5df6f2b5b8147d1696a577e46036ea3c06c8657/lua/fzf-lua/shell.lua#L101), and then appending log file several times on every key type. It will have a impact on performance when the log file became huge.
```
WRN 2025-01-21T12:06:46.131 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:06:46.168 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:06:46.309 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:06:46.584 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:06:46.870 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:06:48.385 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:06:48.421 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:06:49.021 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:06:49.346 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:06:50.095 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:06:53.756 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:06:53.794 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:06:54.683 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:06:55.920 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:08:04.684 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:08:04.831 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:08:04.909 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:08:04.917 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:08:05.158 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:08:05.246 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:08:05.421 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:08:05.458 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
WRN 2025-01-21T12:08:05.622 c/nvim.149038.0 vim_mktempdir:3280: $TMPDIR is unset
```

## Solution

Just keep silent when `$TMPDIR` is unset.
