### PR TITLE
feat(vim.fs.find): add option to switch to depth-first search [skip ci]

### DIFF
--- a/find.lua
+++ b/find.lua
@@ -1,0 +1,74 @@
+-- local function counter(start)
+--     local i = start
+--     return function()
+--         i = i + 1
+--         return i
+--     end
+-- end
+--
+-- for i in counter(100000000) do
+--     vim.print(i)
+-- end
+
+local function isdir(f)
+  return (vim.uv.fs_stat(f) or {}).type == 'directory'
+end
+
+---@diagnostic disable
+local function parents(startdir)
+  local dir = startdir
+  ---@return string?
+  return function()
+    if dir == vim.fs.dirname(dir) then
+      return nil
+    end
+    dir = vim.fs.dirname(dir)
+    return dir
+  end
+end
+
+---@diagnostic disable
+local function children(startdir)
+  local alldirs = { startdir }
+  return function()
+    if #alldirs == 0 then
+      return nil
+    end
+    local dirs = {}
+    local dir = table.remove(alldirs, 1)
+    for d in vim.fs.dir(dir) do
+      local d = vim.fs.joinpath(dir, d)
+      if isdir(d) then
+        dirs[#dirs + 1] = d
+      end
+    end
+    vim.list_extend(alldirs, dirs)
+    return dir
+  end
+end
+
+-- local file_custom = io.open('custom', 'a')
+-- local file_builtin = io.open('builtin', 'a')
+--
+-- local startpath = vim.uv.cwd()
+--
+-- local custom_dirs = {}
+-- for d in children(startpath) do
+--   custom_dirs[#custom_dirs+1]= d
+-- end
+-- for _, d in vim.spairs(custom_dirs) do
+--   file_custom:write(d .. '\n')
+-- end
+--
+-- local builtin_dirs = {}
+-- for d in vim.fs.dir(startpath, { depth = math.huge }) do
+--   if isdir(d) then
+--     builtin_dirs[#builtin_dirs+1]= vim.fs.abspath(d)
+--   end
+-- end
+-- for _, d in vim.spairs(builtin_dirs) do
+--   file_builtin:write(d .. '\n')
+-- end
+--
+-- file_custom:close()
+-- file_builtin:close()

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -219,6 +219,10 @@ end
 --- Follow symbolic links.
 --- (default: `true`)
 --- @field follow? boolean
+---
+--- Use DFS
+--- (default: `false`)
+--- @field dfs? boolean
 
 --- Find files or directories (or other items as specified by `opts.type`) in the given path.
 ---
@@ -266,6 +270,7 @@ function M.find(names, opts)
   vim.validate('type', opts.type, 'string', true)
   vim.validate('limit', opts.limit, 'number', true)
   vim.validate('follow', opts.follow, 'boolean', true)
+  vim.validate('dfs', opts.dfs, 'boolean', true)
 
   if type(names) == 'string' then
     names = { names }
@@ -274,6 +279,24 @@ function M.find(names, opts)
   local path = opts.path or assert(uv.cwd())
   local stop = opts.stop
   local limit = opts.limit or 1
+
+  if opts.dfs then
+    opts.dfs = false
+    local matches = {}
+    if type(names) == 'function' then
+      return vim.fs.find(names, opts)
+    end
+    for _, name in ipairs(names) do
+      local match = vim.fs.find(name, opts)
+      if match then
+        vim.list_extend(matches, match)
+      end
+      if #matches >= limit then
+        return matches
+      end
+    end
+    return matches
+  end
 
   local matches = {} --- @type string[]
 

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -254,6 +254,52 @@ describe('vim.fs', function()
       eq({ nvim_dir }, vim.fs.find(name, { path = parent, upward = true, type = 'directory' }))
     end)
 
+    it('works with opts.dfs', function()
+      eq(
+        {
+          test_source_path .. '/test/functional/example_spec.lua',
+          test_source_path .. '/test/functional/fixtures/CMakeLists.txt',
+        },
+        vim.fs.find(
+          { 'CMakeLists.txt', 'example_spec.lua' },
+          { path = test_source_path .. '/test/functional', limit = 2, dfs = false }
+        )
+      )
+      eq(
+        {
+          test_source_path .. '/test/functional/fixtures/CMakeLists.txt',
+          test_source_path .. '/test/functional/example_spec.lua',
+        },
+        vim.fs.find(
+          { 'CMakeLists.txt', 'example_spec.lua' },
+          { path = test_source_path .. '/test/functional', limit = 2, dfs = true }
+        )
+      )
+
+      eq(
+        {
+          test_source_path .. '/test/functional/example_spec.lua',
+          test_source_path .. '/test/CMakeLists.txt',
+          test_source_path .. '/CMakeLists.txt',
+        },
+        vim.fs.find(
+          { 'CMakeLists.txt', 'example_spec.lua' },
+          { path = test_source_path .. '/test/functional', limit = 3, upward = true, dfs = false }
+        )
+      )
+      eq(
+        {
+          test_source_path .. '/test/CMakeLists.txt',
+          test_source_path .. '/CMakeLists.txt',
+          test_source_path .. '/test/functional/example_spec.lua',
+        },
+        vim.fs.find(
+          { 'CMakeLists.txt', 'example_spec.lua' },
+          { path = test_source_path .. '/test/functional', limit = 3, upward = true, dfs = true }
+        )
+      )
+    end)
+
     it('follows symlinks', function()
       local build_dir = test_source_path .. '/build' ---@type string
       local symlink = test_source_path .. '/build_link' ---@type string


### PR DESCRIPTION
It's needed to replace util.root_patterns in lspconfig.