### PR TITLE
fix(tui): ensure all pending escape sequences are processed before exiting

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -643,24 +643,17 @@ static void handle_unknown_csi(TermInput *input, const TermKeyKey *key)
     switch (initial) {
     case '?':
       // Kitty keyboard protocol query response.
-      if (input->waiting_for_kkp_response) {
-        input->waiting_for_kkp_response = false;
-        input->key_encoding = kKeyEncodingKitty;
-        tui_set_key_encoding(input->tui_data);
-      }
-
+      input->key_encoding = kKeyEncodingKitty;
       break;
     }
     break;
   case 'c':
     switch (initial) {
     case '?':
-      // Primary Device Attributes response
-      if (input->waiting_for_kkp_response) {
-        input->waiting_for_kkp_response = false;
-
-        // Enable the fallback key encoding (if any)
-        tui_set_key_encoding(input->tui_data);
+      // Primary Device Attributes (DA1) response
+      if (input->callbacks.primary_device_attr) {
+        input->callbacks.primary_device_attr(input->tui_data);
+        input->callbacks.primary_device_attr = NULL;
       }
 
       break;

--- a/src/nvim/tui/input.h
+++ b/src/nvim/tui/input.h
@@ -17,6 +17,10 @@ typedef enum {
   kKeyEncodingXterm,   ///< Xterm's modifyOtherKeys encoding (XTMODKEYS)
 } KeyEncoding;
 
+typedef struct {
+  void (*primary_device_attr)(TUIData *tui);
+} TermInputCallbacks;
+
 #define KEY_BUFFER_SIZE 0x1000
 typedef struct {
   int in_fd;
@@ -24,8 +28,7 @@ typedef struct {
   int8_t paste;
   bool ttimeout;
 
-  bool waiting_for_kkp_response;  ///< True if we are expecting to receive a response to a query for
-                                  ///< Kitty keyboard protocol support
+  TermInputCallbacks callbacks;
 
   KeyEncoding key_encoding;       ///< The key encoding used by the terminal emulator
 


### PR DESCRIPTION
Neovim disables a number of terminal modes when it exits, some of which cause the terminal to send asynchronous events to Neovim. It's possible that Neovim exits before the terminal has received and processed all of the sequences to disable these modes, causing the terminal to emit one of these asynchronous sequences after Neovim has already exited. If this happens, then the sequence is received by the user's shell (or some other program that is not Neovim).

When Neovim exits, it now emits a Device Attributes request (DA1) after disabling all of the different modes. When the terminal responds to this request we know that it has already received all of our other sequences disabling the other modes. At that point, it should not be emitting any further asynchronous sequences. This means the process of exiting Neovim is now asynchronous as well since it depends on receiving the DA1 response from the terminal.

Fixes: #31885
Fixes: #32769
