### PR TITLE
fix(inspector): update semantic token namespace

### DIFF
--- a/runtime/lua/tohtml.lua
+++ b/runtime/lua/tohtml.lua
@@ -492,7 +492,7 @@ local function _styletable_extmarks_highlight(state, extmark, namespaces)
   end
   ---TODO(altermo) LSP semantic tokens (and some other extmarks) are only
   ---generated in visible lines, and not in the whole buffer.
-  if (namespaces[extmark[4].ns_id] or ''):find('vim_lsp_semantic_tokens') then
+  if (namespaces[extmark[4].ns_id] or ''):find('nvim.lsp.semantic_tokens') then
     notify('lsp semantic tokens are not supported, HTML may be incorrect')
     return
   end
@@ -514,7 +514,7 @@ local function _styletable_extmarks_virt_text(state, extmark, namespaces)
   end
   ---TODO(altermo) LSP semantic tokens (and some other extmarks) are only
   ---generated in visible lines, and not in the whole buffer.
-  if (namespaces[extmark[4].ns_id] or ''):find('vim_lsp_inlayhint') then
+  if (namespaces[extmark[4].ns_id] or ''):find('nvim.lsp.inlayhint') then
     notify('lsp inlay hints are not supported, HTML may be incorrect')
     return
   end

--- a/runtime/lua/vim/_inspector.lua
+++ b/runtime/lua/vim/_inspector.lua
@@ -128,13 +128,13 @@ function vim.inspect_pos(bufnr, row, col, filter)
 
   if filter.semantic_tokens then
     results.semantic_tokens = vim.tbl_filter(function(extmark)
-      return extmark.ns:find('vim_lsp_semantic_tokens') == 1
+      return extmark.ns:find('nvim.lsp.semantic_tokens') == 1
     end, extmarks)
   end
 
   if filter.extmarks then
     results.extmarks = vim.tbl_filter(function(extmark)
-      return extmark.ns:find('vim_lsp_semantic_tokens') ~= 1
+      return extmark.ns:find('nvim.lsp.semantic_tokens') ~= 1
         and (filter.extmarks == 'all' or extmark.opts.hl_group)
     end, extmarks)
   end


### PR DESCRIPTION
This updates the extmark namespace to search for when filtering out semantic tokens to match the new namespace style recently introduced.