### PR TITLE
vim-patch:9.1.1048: crash after scrolling and pasting in silent Ex mode

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2490,7 +2490,10 @@ int pagescroll(Direction dir, int count, bool half)
     if (!nochange) {
       // Place cursor at top or bottom of window.
       validate_botline(curwin);
-      curwin->w_cursor.lnum = (dir == FORWARD ? curwin->w_topline : curwin->w_botline - 1);
+      linenr_T lnum = (dir == FORWARD ? curwin->w_topline : curwin->w_botline - 1);
+      // In silent Ex mode the value of w_botline - 1 may be 0,
+      // but cursor lnum needs to be at least 1.
+      curwin->w_cursor.lnum = MAX(lnum, 1);
     }
   }
 

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -1338,11 +1338,27 @@ func Test_scroll_in_ex_mode()
       call writefile(['done'], 'Xdone')
       qa!
   END
-  call writefile(lines, 'Xscript')
+  call writefile(lines, 'Xscript', 'D')
   call assert_equal(1, RunVim([], [], '--clean -X -Z -e -s -S Xscript'))
   call assert_equal(['done'], readfile('Xdone'))
 
-  call delete('Xscript')
+  call delete('Xdone')
+endfunc
+
+func Test_scroll_and_paste_in_ex_mode()
+  throw 'Skipped: does not work when Nvim is run from :!'
+  " This used to crash because of moving cursor to line 0.
+  let lines =<< trim END
+      v/foo/vi|YY9PYQ
+      v/bar/vi|YY9PYQ
+      v/bar/exe line('.') == 1 ? "vi|Y\<C-B>9PYQ" : "vi|YQ"
+      call writefile(['done'], 'Xdone')
+      qa!
+  END
+  call writefile(lines, 'Xscript', 'D')
+  call assert_equal(1, RunVim([], [], '-u NONE -i NONE -n -X -Z -e -s -S Xscript'))
+  call assert_equal(['done'], readfile('Xdone'))
+
   call delete('Xdone')
 endfunc
 
@@ -4303,4 +4319,5 @@ func Test_normal_go()
 
   bwipe!
 endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
#### vim-patch:9.1.1048: crash after scrolling and pasting in silent Ex mode

Problem:  Crash after scrolling and pasting in silent Ex mode.
          (fizz-is-on-the-way)
Solution: Don't move cursor to line 0 when scrolling.
          (zeertzjq)

closes: vim/vim#16506

https://github.com/vim/vim/commit/df098fedbc2c481e91ea7e6207dab90359a92cc3