### PR TITLE
fix(checkhealth): failed if 'lua' in plugin name

### DIFF
--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -118,7 +118,7 @@ local function filepath_to_healthcheck(path)
     func = 'health#' .. name .. '#check'
     filetype = 'v'
   else
-    local subpath = path:gsub('.*lua/', '')
+    local subpath = path:gsub('.*/lua/', '')
     if vim.fs.basename(subpath) == 'health.lua' then
       -- */health.lua
       name = vim.fs.dirname(subpath)


### PR DESCRIPTION
Problem: checkhealth failed if 'lua' in plugin name.
* e.g. `lua/fzf-lua/health.lua` -> `/health.lua` (expected `fzf-lua/health.lua`)
* e.g. `nvim-tree.lua`, `copilot.lua`...

Solution: trim full path rather than plugin name.
