### PR TITLE
fix(lsp): prefer `on_list` over `loclist` in default handler

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1446,7 +1446,7 @@ Lua module: vim.lsp.buf                                              *lsp-buf*
                         vim.lsp.buf.references(nil, { on_list = on_list })
 <
       • {loclist}?  (`boolean`) Whether to use the |location-list| or the
-                    |quickfix| list. >lua
+                    |quickfix| list in the default handler. >lua
                         vim.lsp.buf.definition({ loclist = true })
                         vim.lsp.buf.references(nil, { loclist = false })
 <

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -254,7 +254,7 @@ end
 --- ```
 --- @field on_list? fun(t: vim.lsp.LocationOpts.OnList)
 ---
---- Whether to use the |location-list| or the |quickfix| list.
+--- Whether to use the |location-list| or the |quickfix| list in the default handler.
 --- ```lua
 --- vim.lsp.buf.definition({ loclist = true })
 --- vim.lsp.buf.references(nil, { loclist = false })

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -247,12 +247,12 @@ local function response_to_list(map_result, entity, title_fn)
     local items = map_result(result, ctx.bufnr)
 
     local list = { title = title, items = items, context = ctx }
-    if config.loclist then
-      vim.fn.setloclist(0, {}, ' ', list)
-      vim.cmd.lopen()
-    elseif config.on_list then
+    if config.on_list then
       assert(vim.is_callable(config.on_list), 'on_list is not a function')
       config.on_list(list)
+    elseif config.loclist then
+      vim.fn.setloclist(0, {}, ' ', list)
+      vim.cmd.lopen()
     else
       vim.fn.setqflist({}, ' ', list)
       vim.cmd('botright copen')


### PR DESCRIPTION
Problem: setting `loclist = true` makes `on_list` being ignored. This
  was not a problem before, but with `vim.lsp.buf.document_symbol` using
  `loclist = true` as default it is needed to explicitly pass `loclist =
  false` in order to use custom `on_list`.

Solution: prefer `on_list` over `loclist` and document the latter as
  taking effect only in the default handler.

------

Related to #32070