### PR TITLE
fix(lua): pop retval for fast context LuaRef

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1587,8 +1587,8 @@ Object nlua_call_ref_ctx(bool fast, LuaRef ref, const char *name, Array args, Lu
     if (nlua_fast_cfpcall(lstate, nargs, 1, -1) < 0) {
       // error is already scheduled, set anyways to convey failure.
       api_set_error(err, kErrorTypeException, "fast context failure");
+      return NIL;
     }
-    return NIL;
   } else if (nlua_pcall(lstate, nargs, 1)) {
     // if err is passed, the caller will deal with the error.
     if (err) {

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -420,4 +420,13 @@ describe('vim.ui_attach', function()
       ]],
     })
   end)
+
+  it('sourcing invalid file does not crash #32166', function()
+    exec_lua([[
+      local ns = vim.api.nvim_create_namespace("")
+      vim.ui_attach(ns, { ext_messages = true }, function() end)
+    ]])
+    feed((':luafile %s<CR>'):format(testlog))
+    n.assert_alive()
+  end)
 end)


### PR DESCRIPTION
Problem:  nlua_call_ref_ctx() does not pop the return value in fast
          context that did not error.
Solution: Fall through to end; calling nlua_call_pop_retval().

Fix #32166