### PR TITLE
replace deprecated:ts_node_child_containing_descendent with ts_node_child_with_descendent

### DIFF
--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1185,7 +1185,7 @@ static int node_child_containing_descendant(lua_State *L)
 {
   TSNode node = node_check(L, 1);
   TSNode descendant = node_check(L, 2);
-  TSNode child = ts_node_child_containing_descendant(node, descendant);
+  TSNode child = ts_node_child_with_descendant(node, descendant);
   push_node(L, child, 1);
   return 1;
 }


### PR DESCRIPTION
https://github.com/tree-sitter/tree-sitter/commit/344a88c4fb968cc789049a378e0cc988c4253751 removed the `ts_node_child_containing_descendent` method from `<tree_sitter/api.h>` in favor of `ts_node_child_with_descendent`.

This was causing build errors on Gentoo, so just replacing this with the alternative worked.
I'm sorry if the PR's lacking anything, I"m new to this thing.