### PR TITLE
replace deprecated:ts_node_child_containing_descendant

### DIFF
--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -1185,7 +1185,7 @@ static int node_child_containing_descendant(lua_State *L)
 {
   TSNode node = node_check(L, 1);
   TSNode descendant = node_check(L, 2);
-  TSNode child = ts_node_child_containing_descendant(node, descendant);
+  TSNode child = ts_node_child_with_descendant(node, descendant);
   push_node(L, child, 1);
   return 1;
 }


### PR DESCRIPTION
https://github.com/tree-sitter/tree-sitter/commit/344a88c4fb968cc789049a378e0cc988c4253751 removed the deprecated method `ts_node_child_containing_descendant` from `<tree_sitter/api.h>`.