### PR TITLE
vim-patch:partial:9.1.1050: too many strlen() calls in os_unix.c

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -370,8 +370,8 @@ static bool is_executable_in_path(const char *name, char **abspath)
   char *path = xstrdup(path_env);
 #endif
 
-  size_t buf_len = strlen(name) + strlen(path) + 2;
-  char *buf = xmalloc(buf_len);
+  const size_t bufsize = strlen(name) + strlen(path) + 2;
+  char *buf = xmalloc(bufsize);
 
   // Walk through all entries in $PATH to check if "name" exists there and
   // is an executable file.
@@ -382,7 +382,7 @@ static bool is_executable_in_path(const char *name, char **abspath)
 
     // Combine the $PATH segment with `name`.
     xmemcpyz(buf, p, (size_t)(e - p));
-    (void)append_path(buf, name, buf_len);
+    (void)append_path(buf, name, bufsize);
 
 #ifdef MSWIN
     if (is_executable_ext(buf, abspath)) {

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -1208,10 +1208,11 @@ static void read_input(StringBuilder *buf)
   size_t len = 0;
   linenr_T lnum = curbuf->b_op_start.lnum;
   char *lp = ml_get(lnum);
+  size_t lplen = (size_t)ml_get_len(lnum);
 
   while (true) {
-    size_t l = strlen(lp + written);
-    if (l == 0) {
+    lplen -= written;
+    if (lplen == 0) {
       len = 0;
     } else if (lp[written] == NL) {
       // NL -> NUL translation
@@ -1219,11 +1220,11 @@ static void read_input(StringBuilder *buf)
       kv_push(*buf, NUL);
     } else {
       char *s = vim_strchr(lp + written, NL);
-      len = s == NULL ? l : (size_t)(s - (lp + written));
+      len = s == NULL ? lplen : (size_t)(s - (lp + written));
       kv_concat_len(*buf, lp + written, len);
     }
 
-    if (len == l) {
+    if (len == lplen) {
       // Finished a line, add a NL, unless this line should not have one.
       if (lnum != curbuf->b_op_end.lnum
           || (!curbuf->b_p_bin && curbuf->b_p_fixeol)
@@ -1236,6 +1237,7 @@ static void read_input(StringBuilder *buf)
         break;
       }
       lp = ml_get(lnum);
+      lplen = (size_t)ml_get_len(lnum);
       written = 0;
     } else if (len > 0) {
       written += len;


### PR DESCRIPTION
#### vim-patch:partial:9.1.1050: too many strlen() calls in os_unix.c

Problem:  too many strlen() calls in os_unix.c
Solution: refactor os_unix.c and remove calls to strlen()
          (John Marriott)

closes: vim/vim#16496

https://github.com/vim/vim/commit/efc41a5958bf25b352e0916af5f57dafbbb44f17

Omit os_expand_wildcards() change: Nvim's code is more complicated and
harder to refactor.

Co-authored-by: John Marriott <basilisk@internode.on.net>