### PR TITLE
fix(treesitter): stop async parsing if buffer is invalid

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -474,13 +474,18 @@ function LanguageTree:_async_parse(range, on_parse)
     return
   end
 
-  local buf = vim.b[self._source]
+  local source = self._source
+  local buf = vim.b[source]
   local ct = buf.changedtick
   local total_parse_time = 0
   local redrawtime = vim.o.redrawtime
   local timeout = not vim.g._ts_force_sync_parsing and default_parse_timeout_ms or nil
 
   local function step()
+    if type(source) == 'number' and not vim.api.nvim_buf_is_valid(source) then
+      return nil
+    end
+
     -- If buffer was changed in the middle of parsing, reset parse state
     if buf.changedtick ~= ct then
       ct = buf.changedtick


### PR DESCRIPTION
Problem: Error occurs if delete buffer in the middle of parsing.
Solution: Check if buffer is valid in parsing.

- Erorr
```
Error executing vim.schedule lua callback: ...m/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:485: scoped variable: Invalid buffer id: 957
stack traceback:
	[C]: in function '__index'
	...m/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:485: in function <...m/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:483>
```
- Reproduce script
```lua
local bufnr = vim.api.nvim_create_buf(false, true)
local many_lines = vim.fn["repeat"]({ "local test = 'a'" }, 100000)
vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, many_lines)
vim.cmd.buffer(bufnr)
vim.bo.filetype = "lua"
vim.schedule(function()
  vim.api.nvim_buf_delete(bufnr, { force = true })
end)
```
