### PR TITLE
build(deps)!: bump tree-sitter to HEAD

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -53,8 +53,8 @@ TREESITTER_MARKDOWN_SHA256 5dac48a6d971eb545aab665d59a18180d21963afc781bbf40f907
 TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/9515be4fc16d3dfe6fba5ae4a7a058f32bcf535d.tar.gz
 TREESITTER_SHA256 cbdea399736b55d61cfb581bc8d80620d487f4ec8f8d60b7fe00406e39a98d6d
 
-WASMTIME_URL https://github.com/bytecodealliance/wasmtime/archive/v25.0.3.tar.gz
-WASMTIME_SHA256 17850ca356fce6ea8bcd3847692b3233588ddf32ff31fcccac67ad06bcac0a3a
+WASMTIME_URL https://github.com/bytecodealliance/wasmtime/archive/v29.0.1.tar.gz
+WASMTIME_SHA256 b94b6c6fd6aebaf05d4c69c1b12b5dc217b0d42c1a95f435b33af63dddfa5304
 
 UNCRUSTIFY_URL https://github.com/uncrustify/uncrustify/archive/uncrustify-0.80.1.tar.gz
 UNCRUSTIFY_SHA256 0e2616ec2f78e12816388c513f7060072ff7942b42f1175eb28b24cb75aaec48

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -50,8 +50,8 @@ TREESITTER_QUERY_URL https://github.com/tree-sitter-grammars/tree-sitter-query/a
 TREESITTER_QUERY_SHA256 d3a423ab66dc62b2969625e280116678a8a22582b5ff087795222108db2f6a6e
 TREESITTER_MARKDOWN_URL https://github.com/tree-sitter-grammars/tree-sitter-markdown/archive/v0.3.2.tar.gz
 TREESITTER_MARKDOWN_SHA256 5dac48a6d971eb545aab665d59a18180d21963afc781bbf40f9077c06cb82ae5
-TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/v0.24.7.tar.gz
-TREESITTER_SHA256 7cbc13c974d6abe978cafc9da12d1e79e07e365c42af75e43ec1b5cdc03ed447
+TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/9515be4fc16d3dfe6fba5ae4a7a058f32bcf535d.tar.gz
+TREESITTER_SHA256 cbdea399736b55d61cfb581bc8d80620d487f4ec8f8d60b7fe00406e39a98d6d
 
 WASMTIME_URL https://github.com/bytecodealliance/wasmtime/archive/v25.0.3.tar.gz
 WASMTIME_SHA256 17850ca356fce6ea8bcd3847692b3233588ddf32ff31fcccac67ad06bcac0a3a

--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -65,10 +65,6 @@ LUA
 • *vim.highlight*	Renamed to |vim.hl|.
 • vim.validate(opts: table) Use form 1. See |vim.validate()|.
 
-TREESITTER
-• *TSNode:child_containing_descendant()* Use |TSNode:child_with_descendant()|
-  instead; it is identical except that it can return the descendant itself.
-
 VIMSCRIPT
 • *termopen()* Use |jobstart() with `{term: v:true}`.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -36,6 +36,12 @@ OPTIONS
 • 'jumpoptions' flag "unload" has been renamed to "clean".
 • The `msghistory` option has been removed in favor of 'messagesopt'.
 
+TREESITTER
+
+• *TSNode:child_containing_descendant()* has been removed in the tree-sitter
+  library and is no longer available; use |TSNode:child_with_descendant()|
+  instead.
+
 ==============================================================================
 BREAKING CHANGES                                                *news-breaking*
 
@@ -364,9 +370,8 @@ TREESITTER
 • |treesitter-directive-trim!| can trim all whitespace (not just empty lines)
   from both sides of a node.
 • |vim.treesitter.get_captures_at_pos()| now returns the `id` of each capture
-• New |TSNode:child_with_descendant()|, which is nearly identical to
-  |TSNode:child_containing_descendant()| except that it can return the
-  descendant itself.
+• New |TSNode:child_with_descendant()|, which efficiently gets the node's
+  child that contains a given node as descendant.
 • |LanguageTree:parse()| optionally supports asynchronous invocation, which is
   activated by passing the `on_parse` callback parameter.
 

--- a/runtime/lua/vim/treesitter/_meta/tsnode.lua
+++ b/runtime/lua/vim/treesitter/_meta/tsnode.lua
@@ -68,12 +68,6 @@ function TSNode:named_child_count() end
 --- @return TSNode?
 function TSNode:named_child(index) end
 
---- Get the node's child that contains {descendant}.
---- @param descendant TSNode
---- @return TSNode?
---- @deprecated
-function TSNode:child_containing_descendant(descendant) end
-
 --- Get the node's child that contains {descendant} (includes {descendant}).
 ---
 --- For example, with the following node hierarchy:

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -31,7 +31,7 @@ target_link_libraries(main_lib INTERFACE ${LUV_LIBRARY})
 find_package(Iconv REQUIRED)
 find_package(Libuv 1.28.0 REQUIRED)
 find_package(Lpeg REQUIRED)
-find_package(Treesitter 0.24.0 REQUIRED)
+find_package(Treesitter 0.25.0 REQUIRED)
 find_package(Unibilium 2.0 REQUIRED)
 find_package(UTF8proc REQUIRED)
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -49,7 +49,7 @@ if(ENABLE_LIBINTL)
 endif()
 
 if(ENABLE_WASMTIME)
-  find_package(Wasmtime 25.0.3 EXACT REQUIRED)
+  find_package(Wasmtime 29.0.1 EXACT REQUIRED)
   target_link_libraries(main_lib INTERFACE wasmtime)
   target_compile_definitions(nvim_bin PRIVATE HAVE_WASMTIME)
 endif()

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -218,7 +218,7 @@ static int add_language(lua_State *L, bool is_wasm)
                            ? load_language_from_wasm(L, path, lang_name)
                            : load_language_from_object(L, path, lang_name, symbol_name);
 
-  uint32_t lang_version = ts_language_version(lang);
+  uint32_t lang_version = ts_language_abi_version(lang);
   if (lang_version < TREE_SITTER_MIN_COMPATIBLE_LANGUAGE_VERSION
       || lang_version > TREE_SITTER_LANGUAGE_VERSION) {
     return luaL_error(L,
@@ -300,7 +300,7 @@ int tslua_inspect_lang(lua_State *L)
   lua_pushboolean(L, ts_language_is_wasm(lang));
   lua_setfield(L, -2, "_wasm");
 
-  lua_pushinteger(L, ts_language_version(lang));  // [retval, version]
+  lua_pushinteger(L, ts_language_abi_version(lang));  // [retval, version]
   lua_setfield(L, -2, "_abi_version");
 
   return 1;
@@ -476,7 +476,7 @@ static int parser_parse(lua_State *L)
 #undef BUFSIZE
     }
 
-    input = (TSInput){ (void *)buf, input_cb, TSInputEncodingUTF8 };
+    input = (TSInput){ (void *)buf, input_cb, TSInputEncodingUTF8, NULL };
     new_tree = ts_parser_parse(p, old_tree, input);
 
     break;
@@ -837,7 +837,6 @@ static struct luaL_Reg node_meta[] = {
   { "named_descendant_for_range", node_named_descendant_for_range },
   { "parent", node_parent },
   { "__has_ancestor", __has_ancestor },
-  { "child_containing_descendant", node_child_containing_descendant },
   { "child_with_descendant", node_child_with_descendant },
   { "iter_children", node_iter_children },
   { "next_sibling", node_next_sibling },
@@ -1178,15 +1177,6 @@ static int __has_ancestor(lua_State *L)
   }
 
   lua_pushboolean(L, false);
-  return 1;
-}
-
-static int node_child_containing_descendant(lua_State *L)
-{
-  TSNode node = node_check(L, 1);
-  TSNode descendant = node_check(L, 2);
-  TSNode child = ts_node_child_containing_descendant(node, descendant);
-  push_node(L, child, 1);
   return 1;
 }
 

--- a/test/functional/treesitter/node_spec.lua
+++ b/test/functional/treesitter/node_spec.lua
@@ -163,32 +163,6 @@ describe('treesitter node API', function()
     eq(3, lua_eval('child:byte_length()'))
   end)
 
-  it('child_containing_descendant() works', function()
-    insert([[
-      int main() {
-        int x = 3;
-      }]])
-
-    exec_lua(function()
-      local tree = vim.treesitter.get_parser(0, 'c'):parse()[1]
-      _G.root = tree:root()
-      _G.main = _G.root:child(0)
-      _G.body = _G.main:child(2)
-      _G.statement = _G.body:child(1)
-      _G.declarator = _G.statement:child(1)
-      _G.value = _G.declarator:child(1)
-    end)
-
-    eq(lua_eval('main:type()'), lua_eval('root:child_containing_descendant(value):type()'))
-    eq(lua_eval('body:type()'), lua_eval('main:child_containing_descendant(value):type()'))
-    eq(lua_eval('statement:type()'), lua_eval('body:child_containing_descendant(value):type()'))
-    eq(
-      lua_eval('declarator:type()'),
-      lua_eval('statement:child_containing_descendant(value):type()')
-    )
-    eq(vim.NIL, lua_eval('declarator:child_containing_descendant(value)'))
-  end)
-
   it('child_with_descendant() works', function()
     insert([[
       int main() {


### PR DESCRIPTION
Breaking change: `ts_node_child_containing_descendant()` was removed (but was introduced and superseded within the 0.11 dev cycle).

(Early testing for upcoming 0.25 release, which is a big one; the update will have to be backported since the ecosystem will quickly switch to ABI 15, making parsers unusable on Nvim 0.10 otherwise.)

Follow-up:

* [x] adapt to deprecations (`ts_language_abi_version`)
* [x] bump the minimal version to 0.25 (after release)
* [ ] expose `ts_language_metadata`, supertype info (?)
* [ ] migrate from `parser_timeout_micros` to callbacks