### PR TITLE
vim-patch:9918120: runtime(filetype): Improve Verilog detection by checking for modules definition

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1777,7 +1777,7 @@ function M.v(_, bufnr)
         or line:find('%(%*') and not line:find('/[/*].*%(%*')
       then
         return 'coq'
-      elseif findany(line, { ';%s*$', ';%s*/[/*]', '^%s*module' }) then
+      elseif findany(line, { ';%s*$', ';%s*/[/*]', '^%s*module%s+%w+%s*%(' }) then
         return 'verilog'
       end
     end

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1763,7 +1763,7 @@ function M.v(_, bufnr)
     return vim.g.filetype_v
   end
   local in_comment = 0
-  for _, line in ipairs(getlines(bufnr, 1, 200)) do
+  for _, line in ipairs(getlines(bufnr, 1, 500)) do
     if line:find('^%s*/%*') then
       in_comment = 1
     end
@@ -1777,7 +1777,7 @@ function M.v(_, bufnr)
         or line:find('%(%*') and not line:find('/[/*].*%(%*')
       then
         return 'coq'
-      elseif findany(line, { ';%s*$', ';%s*/[/*]' }) then
+      elseif findany(line, { ';%s*$', ';%s*/[/*]', '^%s*module' }) then
         return 'verilog'
       end
     end


### PR DESCRIPTION
While at it, also increase the maximum number of lines to check to 500.

fixes: vim/vim#16513

https://github.com/vim/vim/commit/99181205c5f8284a30f839107a12932924168f17

Co-authored-by: Christian Brabandt <cb@256bit.org>
