### PR TITLE
[FIX] #32097 Dircolors, termguicolors variable undefined

### DIFF
--- a/runtime/syntax/dircolors.vim
+++ b/runtime/syntax/dircolors.vim
@@ -85,6 +85,9 @@ endfunction
 function! s:get_hi_str(color, place) abort
     if a:color >= 0 && a:color <= 255
         if has('gui_running') || &termguicolors
+            if ! exists("s:termguicolors")
+              call s:set_guicolors()
+            endif
             return ' gui' . a:place . '=' . s:termguicolors[a:color]
         elseif a:color <= 7 || &t_Co == 256 || &t_Co == 88
             return ' cterm' . a:place . '=' . a:color


### PR DESCRIPTION
fix https://github.com/neovim/neovim/issues/32097

`neovim` added `termguicolors` support, on top of `vim`'s `dircolors` syntax in contribution  **syntax: fix dircolors plugin to support termguicolors** https://github.com/neovim/neovim/pull/8175 (2018).

The currently proposed fix is aiming to introduce minimal changes on top of that enhancement.

## Issue

Current `dircolors` syntax setup doesn't seem prepared for `termguicolors` settings changing at runtime.

### Details

The syndrome described in the Bug Report is triggered by `termguicolors` being altered by automated settup taking effect after `runtime/syntax/dircolors.vim` was initially evaluated.

1. Script-local array variable `s:termguicolors` (*not* to be confused with the global `termguicolors` option) is [set up](https://github.com/neovim/neovim/blob/master/runtime/syntax/dircolors.vim#L208) when the script is loaded, depending on the value of the global `termguicolors` setting -- at the time. 
2. However, the global `termguicolors` settings can be altered altered later.
   - Other default setup (like  [this one](https://github.com/neovim/neovim/blob/master/runtime/lua/vim/_defaults.lua#L708)) may apply
   - [Introducting](https://github.com/neovim/neovim/blob/master/runtime/lua/vim/_defaults.lua#L566) a `VimEnter` autocommand, to set `termguicolors`
   - NOTE: This autocommand is executed after `dircolors` syntax initialization.
3. Later on, when `dircolors` syntax internal colors may be referred, the script-local (`s:termguicolors`) variable is not defined

## Solution

Keeping in mind that `termguicolors` may change on the fly, initializing internal structures before referred -- in case it was not yet initialized.