### PR TITLE
docs(treesitter): fix TSNode:range() type signature

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -832,7 +832,7 @@ TSNode:range({include_bytes})                                 *TSNode:range()*
     • end byte (if {include_bytes} is `true`)
 
     Parameters: ~
-      • {include_bytes}  (`boolean?`)
+      • {include_bytes}  (`false?`)
 
     Return (multiple): ~
         (`integer`)

--- a/runtime/ftplugin/help.lua
+++ b/runtime/ftplugin/help.lua
@@ -53,7 +53,7 @@ for _, match, metadata in query:iter_matches(tree:root(), 0, 0, -1) do
   for id, nodes in pairs(match) do
     local name = query.captures[id]
     local node = nodes[1]
-    local start, _, end_ = node:parent():range() --[[@as integer]]
+    local start, _, end_ = node:parent():range()
 
     if name == 'code' then
       vim.api.nvim_buf_set_extmark(0, run_message_ns, start, 0, {

--- a/runtime/lua/vim/treesitter/_meta/tsnode.lua
+++ b/runtime/lua/vim/treesitter/_meta/tsnode.lua
@@ -103,18 +103,9 @@ function TSNode:end_() end
 --- - end row
 --- - end column
 --- - end byte (if {include_bytes} is `true`)
---- @param include_bytes boolean?
---- @return integer, integer, integer, integer
-function TSNode:range(include_bytes) end
-
---- @nodoc
 --- @param include_bytes false?
 --- @return integer, integer, integer, integer
-function TSNode:range(include_bytes) end
-
---- @nodoc
---- @param include_bytes true
---- @return integer, integer, integer, integer, integer, integer
+--- @overload fun(self: TSNode, include_bytes: true): integer, integer, integer, integer, integer, integer
 function TSNode:range(include_bytes) end
 
 --- Get the node's type as a string.


### PR DESCRIPTION
Uses an overload to properly annotate the different return type based on the input parameter.