### PR TITLE
fix(filetype): normalize full path before matching with patterns

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2873,7 +2873,7 @@ function M.match(args)
     name = normalize_path(name)
 
     -- First check for the simple case where the full path exists as a key
-    local path = fn.fnamemodify(name, ':p')
+    local path = normalize_path(fn.fnamemodify(name, ':p'))
     ft, on_detect = dispatch(filename[path], path, bufnr)
     if ft then
       return ft, on_detect

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2565,6 +2565,15 @@ local function normalize_path(path, as_pattern)
   return normal
 end
 
+local abspath = function(x)
+  return fn.fnamemodify(x, ':p')
+end
+if fn.has('win32') == 1 then
+  abspath = function(x)
+    return (fn.fnamemodify(x, ':p'):gsub('\\', '/'))
+  end
+end
+
 --- @class vim.filetype.add.filetypes
 --- @inlinedoc
 --- @field pattern? vim.filetype.mapping
@@ -2873,7 +2882,7 @@ function M.match(args)
     name = normalize_path(name)
 
     -- First check for the simple case where the full path exists as a key
-    local path = normalize_path(fn.fnamemodify(name, ':p'))
+    local path = abspath(name)
     ft, on_detect = dispatch(filename[path], path, bufnr)
     if ft then
       return ft, on_detect

--- a/test/functional/lua/filetype_spec.lua
+++ b/test/functional/lua/filetype_spec.lua
@@ -173,6 +173,23 @@ describe('vim.filetype', function()
 
     eq(buf, api.nvim_get_current_buf())
   end)
+
+  it('matches full paths', function()
+    mkdir('Xfiletype')
+    command('lcd Xfiletype')
+    eq(
+      'Xfiletype',
+      exec_lua(function()
+        vim.filetype.add({
+          pattern = {
+            ['.*/Xfiletype/Xfilename'] = 'Xfiletype',
+          },
+        })
+        return vim.filetype.match({ filename = 'Xfilename' })
+      end)
+    )
+    rmdir('Xfiletype')
+  end)
 end)
 
 describe('filetype.lua', function()


### PR DESCRIPTION
Problem:
On Windows, treesitter query files are not recognized as such when opened from inside their directory, because the full path returned from fnamemodify(_, ':p') contains backslashes, while the filetype patterns expect forward slashes.

Solution:
Normalize the result of fnamemodify(_, ':p') before trying to match it to filetype patterns.