### PR TITLE
fix(treesitter) Set modeline=false in TSHighlighter:destroy

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -160,7 +160,10 @@ function TSHighlighter:destroy()
     vim.bo[self.bufnr].spelloptions = self.orig_spelloptions
     vim.b[self.bufnr].ts_highlight = nil
     if vim.g.syntax_on == 1 then
-      api.nvim_exec_autocmds('FileType', { group = 'syntaxset', buffer = self.bufnr })
+      api.nvim_exec_autocmds(
+        'FileType',
+        { group = 'syntaxset', buffer = self.bufnr, modeline = false }
+      )
     end
   end
 end


### PR DESCRIPTION
Fix #32220

Problem:
  TSHighlighter:destroy() may cause double-processing of the modeline
  and failure of b:undo_ftplugin.

Solution:
  As suggested by @seandewar 

  Disable modeline in TSHighlighter:destroy() by setting modeline=false if executing syntaxset autocommands
  for the FileType event.