### PR TITLE
fix(ui): avoid redundant ext_cmdline events

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -692,8 +692,11 @@ int update_screen(void)
 
   decor_providers_invoke_end();
 
-  // either cmdline is cleared, not drawn or mode is last drawn
-  cmdline_was_last_drawn = false;
+  // Either cmdline is cleared, not drawn or mode is last drawn.
+  // This does not (necessarily) overwrite an external cmdline.
+  if (!ui_has(kUICmdline)) {
+    cmdline_was_last_drawn = false;
+  }
   return OK;
 }
 

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -202,7 +202,7 @@ describe('vim.ui_attach', function()
     feed([[:call confirm("Save changes?", "&Yes\n&No\n&Cancel")<CR>]])
     screen:expect({
       grid = [[
-        ^5                                       |
+        ^4                                       |
         {1:~                                       }|*4
       ]],
       cmdline = {
@@ -224,7 +224,7 @@ describe('vim.ui_attach', function()
     feed('n')
     screen:expect({
       grid = [[
-        ^5                                       |
+        ^4                                       |
         {1:~                                       }|*4
       ]],
       cmdline = { { abort = false } },


### PR DESCRIPTION
Problem:  cmdline_show is emitted unnecessarily each event
          loop iteration, because `cmdline_was_last_drawn` is never set.
Solution: Keep track of whether the cmdline was last drawn to avoid
          unnecessarily emitting `cmdline_show`. Set `redraw_state` to
          emit `cmdline_pos` when emitting `CursorMovedC`. Only emit
          `cmdline_pos` when cmdline was last drawn.