### PR TITLE
fix(treesitter): recalculate folds upon VimEnter

### DIFF
--- a/runtime/lua/vim/treesitter/_fold.lua
+++ b/runtime/lua/vim/treesitter/_fold.lua
@@ -370,7 +370,7 @@ function M.foldexpr(lnum)
 
   if not foldinfos[bufnr] then
     foldinfos[bufnr] = FoldInfo.new(bufnr)
-    api.nvim_create_autocmd('BufUnload', {
+    api.nvim_create_autocmd({ 'BufUnload', 'VimEnter' }, {
       buffer = bufnr,
       once = true,
       callback = function()


### PR DESCRIPTION
**Problem:** In the case where the user sets the treesitter foldexpr upon startup in their `init.lua`, the fold info will be calculated before the parser has been loaded in, meaning folds will be properly calculated until edits or `:e`.

**Solution:** Refresh fold information upon `VimEnter` as a sanity check to ensure that a parser really doesn't exist before always returning `'0'` in the foldexpr.

See https://github.com/neovim/neovim/pull/32233#issuecomment-2619542935 (cc @luukvbaal )