### PR TITLE
Fix "vim_snprintf() positional arguments" failures on 32-bit systems

### DIFF
--- a/test/unit/strings_spec.lua
+++ b/test/unit/strings_spec.lua
@@ -140,7 +140,13 @@ end)
 
 describe('vim_snprintf()', function()
   local function a(expected, buf, bsize, fmt, ...)
-    eq(#expected, strings.vim_snprintf(buf, bsize, fmt, ...))
+    local args = { ... }
+    local ctx = string.format('snprintf(buf, %d, "%s"', bsize, fmt)
+    for _, x in ipairs(args) do
+      ctx = ctx .. ', ' .. tostring(x)
+    end
+    ctx = ctx .. string.format(') = %s', expected)
+    eq(#expected, strings.vim_snprintf(buf, bsize, fmt, ...), ctx)
     if bsize > 0 then
       local actual = ffi.string(buf, math.min(#expected + 1, bsize))
       eq(expected:sub(1, bsize - 1) .. '\0', actual)

--- a/test/unit/strings_spec.lua
+++ b/test/unit/strings_spec.lua
@@ -1,12 +1,19 @@
 local t = require('test.unit.testutil')
 local itp = t.gen_itp(it)
 
+local child_call_once = t.child_call_once
 local cimport = t.cimport
 local eq = t.eq
 local ffi = t.ffi
 local to_cstr = t.to_cstr
 
 local strings = cimport('stdlib.h', './src/nvim/strings.h', './src/nvim/memory.h')
+
+local UVARNUM_TYPE
+
+child_call_once(function()
+  UVARNUM_TYPE = ffi.typeof('uvarnumber_T')
+end)
 
 describe('vim_strsave_escaped()', function()
   local vim_strsave_escaped = function(s, chars)
@@ -153,6 +160,9 @@ describe('vim_snprintf()', function()
     end
   end
 
+  local function uv(n)
+    return ffi.cast(UVARNUM_TYPE, n)
+  end
   local function i(n)
     return ffi.cast('int', n)
   end
@@ -187,7 +197,7 @@ describe('vim_snprintf()', function()
       a('  1234567', buf, bsize, '%9ld', l(1234567))
       a('1234567  ', buf, bsize, '%-9ld', l(1234567))
       a('deadbeef', buf, bsize, '%x', u(0xdeadbeef))
-      a('001100', buf, bsize, '%06b', u(12))
+      a('001100', buf, bsize, '%06b', uv(12))
       a('one two', buf, bsize, '%s %s', 'one', 'two')
       a('1.234000', buf, bsize, '%f', 1.234)
       a('1.234000e+00', buf, bsize, '%e', 1.234)
@@ -229,10 +239,10 @@ describe('vim_snprintf()', function()
       a('three one two', buf, bsize, '%3$s %1$s %2$s', 'one', 'two', 'three')
       a('1234567', buf, bsize, '%1$d', i(1234567))
       a('deadbeef', buf, bsize, '%1$x', u(0xdeadbeef))
-      a('001100', buf, bsize, '%2$0*1$b', i(6), u(12))
-      a('001100', buf, bsize, '%1$0.*2$b', u(12), i(6))
+      a('001100', buf, bsize, '%2$0*1$b', i(6), uv(12))
+      a('001100', buf, bsize, '%1$0.*2$b', uv(12), i(6))
       a('one two', buf, bsize, '%1$s %2$s', 'one', 'two')
-      a('001100', buf, bsize, '%06b', u(12))
+      a('001100', buf, bsize, '%06b', uv(12))
       a('two one', buf, bsize, '%2$s %1$s', 'one', 'two')
       a('1.234000', buf, bsize, '%1$f', 1.234)
       a('1.234000e+00', buf, bsize, '%1$e', 1.234)


### PR DESCRIPTION
    ERROR    test/unit/testutil.lua @ 785: vim_snprintf() positional arguments
    test/unit/testutil.lua:757: test/unit/testutil.lua:741: (string) '
    test/unit/strings_spec.lua:143: Expected objects to be the same.
    Passed in:
    (number) 6400
    Expected:
    (number) 6'
    exit code: 256

When 9.0.1856 was ported, the numbers being formatted as binary were cast
to "unsigned int" rather than uvarnumber_T, as is done upstream.