### PR TITLE
ci!: store artifact shasums in a single shasum.txt file

### DIFF
--- a/.github/workflows/notes.md
+++ b/.github/workflows/notes.md
@@ -77,16 +77,3 @@ glibc 2.31 or newer is required. Or you may try the (unsupported) [builds for ol
 - Install by [package manager](https://github.com/neovim/neovim/blob/master/INSTALL.md#install-from-package)
 
 ## SHA256 Checksums
-
-```
-${SHA_APPIMAGE_ARM64}
-${SHA_APPIMAGE_ARM64_ZSYNC}
-${SHA_LINUX_ARM64_TAR}
-${SHA_APPIMAGE_X86_64}
-${SHA_APPIMAGE_X86_64_ZSYNC}
-${SHA_LINUX_X86_64_TAR}
-${SHA_MACOS_ARM64}
-${SHA_MACOS_X86_64}
-${SHA_WIN_64_MSI}
-${SHA_WIN_64_ZIP}
-```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -72,7 +72,7 @@ jobs:
         run: cpack --config build/CPackConfig.cmake -G TGZ
       - uses: actions/upload-artifact@v4
         with:
-          name: appimage-${{ matrix.arch }}
+          name: nvim-appimage-${{ matrix.arch }}
           path: |
             build/bin/nvim-linux-${{ matrix.arch }}.appimage
             build/bin/nvim-linux-${{ matrix.arch }}.appimage.zsync
@@ -198,60 +198,23 @@ jobs:
           git push origin :stable || true
       # `sha256sum` outputs <sha> <path>, so we cd into each dir to drop the
       # containing folder from the output.
-      - name: Generate Linux x86_64 SHA256 checksums
-        run: |
-          cd ./nvim-linux-x86_64
-          sha256sum nvim-linux-x86_64.tar.gz > nvim-linux-x86_64.tar.gz.sha256sum
-          echo "SHA_LINUX_X86_64_TAR=$(cat nvim-linux-x86_64.tar.gz.sha256sum)" >> $GITHUB_ENV
-      - name: Generate Linux arm64 SHA256 checksums
-        run: |
-          cd ./nvim-linux-arm64
-          sha256sum nvim-linux-arm64.tar.gz > nvim-linux-arm64.tar.gz.sha256sum
-          echo "SHA_LINUX_ARM64_TAR=$(cat nvim-linux-arm64.tar.gz.sha256sum)" >> $GITHUB_ENV
-      - name: Generate AppImage x64_64 SHA256 checksums
-        run: |
-          cd ./appimage-x86_64
-          sha256sum nvim-linux-x86_64.appimage > nvim-linux-x86_64.appimage.sha256sum
-          echo "SHA_APPIMAGE_X86_64=$(cat nvim-linux-x86_64.appimage.sha256sum)" >> $GITHUB_ENV
-      - name: Generate AppImage x86_64 Zsync SHA256 checksums
-        run: |
-          cd ./appimage-x86_64
-          sha256sum nvim-linux-x86_64.appimage.zsync > nvim-linux-x86_64.appimage.zsync.sha256sum
-          echo "SHA_APPIMAGE_X86_64_ZSYNC=$(cat nvim-linux-x86_64.appimage.zsync.sha256sum)" >> $GITHUB_ENV
-      - name: Generate AppImage x64_64 SHA256 checksums
-        run: |
-          cd ./appimage-arm64
-          sha256sum nvim-linux-arm64.appimage > nvim-linux-arm64.appimage.sha256sum
-          echo "SHA_APPIMAGE_ARM64=$(cat nvim-linux-arm64.appimage.sha256sum)" >> $GITHUB_ENV
-      - name: Generate AppImage arm64 Zsync SHA256 checksums
-        run: |
-          cd ./appimage-arm64
-          sha256sum nvim-linux-arm64.appimage.zsync > nvim-linux-arm64.appimage.zsync.sha256sum
-          echo "SHA_APPIMAGE_ARM64_ZSYNC=$(cat nvim-linux-arm64.appimage.zsync.sha256sum)" >> $GITHUB_ENV
-      - name: Generate macos x86_64 SHA256 checksums
-        run: |
-          cd ./nvim-macos-x86_64
-          sha256sum nvim-macos-x86_64.tar.gz > nvim-macos-x86_64.tar.gz.sha256sum
-          echo "SHA_MACOS_X86_64=$(cat nvim-macos-x86_64.tar.gz.sha256sum)" >> $GITHUB_ENV
-      - name: Generate macos arm64 SHA256 checksums
-        run: |
-          cd ./nvim-macos-arm64
-          sha256sum nvim-macos-arm64.tar.gz > nvim-macos-arm64.tar.gz.sha256sum
-          echo "SHA_MACOS_ARM64=$(cat nvim-macos-arm64.tar.gz.sha256sum)" >> $GITHUB_ENV
-      - name: Generate Win64 SHA256 checksums
-        run: |
-          cd ./nvim-win64
-          sha256sum nvim-win64.zip > nvim-win64.zip.sha256sum
-          echo "SHA_WIN_64_ZIP=$(cat nvim-win64.zip.sha256sum)" >> $GITHUB_ENV
-          sha256sum nvim-win64.msi > nvim-win64.msi.sha256sum
-          echo "SHA_WIN_64_MSI=$(cat nvim-win64.msi.sha256sum)" >> $GITHUB_ENV
+      - run: |
+          for i in nvim-*; do
+              (
+                  cd $i || exit
+                  sha256sum * >> $GITHUB_WORKSPACE/shasum.txt
+              )
+          done
       - name: Publish release
         env:
           NVIM_VERSION: ${{ needs.linux.outputs.version }}
           DEBUG: api
         run: |
           envsubst < "$GITHUB_WORKSPACE/.github/workflows/notes.md" > "$RUNNER_TEMP/notes.md"
+          echo '```' >> "$RUNNER_TEMP/notes.md"
+          cat shasum.txt >> "$RUNNER_TEMP/notes.md"
+          echo '```' >> "$RUNNER_TEMP/notes.md"
           if [ "$TAG_NAME" != "nightly" ]; then
-            gh release create stable $PRERELEASE --notes-file "$RUNNER_TEMP/notes.md" --title "$SUBJECT" --target $GITHUB_SHA nvim-macos-x86_64/* nvim-macos-arm64/* nvim-linux-x86_64/* nvim-linux-arm64/* appimage-x86_64/* appimage-arm64/* nvim-win64/*
+            gh release create stable $PRERELEASE --notes-file "$RUNNER_TEMP/notes.md" --title "$SUBJECT" --target $GITHUB_SHA nvim-macos-x86_64/* nvim-macos-arm64/* nvim-linux-x86_64/* nvim-linux-arm64/* nvim-appimage-x86_64/* nvim-appimage-arm64/* nvim-win64/* shasum.txt
           fi
-          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/notes.md" --title "$SUBJECT" --target $GITHUB_SHA nvim-macos-x86_64/* nvim-macos-arm64/* nvim-linux-x86_64/* nvim-linux-arm64/* appimage-x86_64/* appimage-arm64/* nvim-win64/*
+          gh release create $TAG_NAME $PRERELEASE --notes-file "$RUNNER_TEMP/notes.md" --title "$SUBJECT" --target $GITHUB_SHA nvim-macos-x86_64/* nvim-macos-arm64/* nvim-linux-x86_64/* nvim-linux-arm64/* nvim-appimage-x86_64/* nvim-appimage-arm64/* nvim-win64/* shasum.txt


### PR DESCRIPTION
Users can parse this file to get the shasum they require.