### PR TITLE
docs: Update broken install steps for Linux binary

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -108,7 +108,7 @@ For arm64:
 The [Releases](https://github.com/neovim/neovim/releases) page provides pre-built binaries for Linux systems.
 
 ```sh
-curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux64.tar.gz
+curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.tar.gz
 sudo rm -rf /opt/nvim
 sudo tar -C /opt -xzf nvim-linux64.tar.gz
 ```

--- a/INSTALL.md
+++ b/INSTALL.md
@@ -110,12 +110,12 @@ The [Releases](https://github.com/neovim/neovim/releases) page provides pre-buil
 ```sh
 curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.tar.gz
 sudo rm -rf /opt/nvim
-sudo tar -C /opt -xzf nvim-linux64.tar.gz
+sudo tar -C /opt -xzf nvim-linux-x86_64.tar.gz
 ```
 
 Then add this to your shell config (`~/.bashrc`, `~/.zshrc`, ...):
 
-    export PATH="$PATH:/opt/nvim-linux64/bin"
+    export PATH="$PATH:/opt/nvim-linux-x86_64/bin"
 
 ### AppImage ("universal" Linux package)
 


### PR DESCRIPTION
Problem: Linux pre-built binary install code block wasn't updated with the new artifact names. 

Solution: Teensy change to update the path to the artifact. Added `-x86` in three places.