### PR TITLE
docs: fix type

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -121,7 +121,7 @@ Then add this to your shell config (`~/.bashrc`, `~/.zshrc`, ...):
 
 The [Releases](https://github.com/neovim/neovim/releases) page provides an [AppImage](https://appimage.org) that runs on most Linux systems. No installation is needed, just download `nvim-linux-x86_64.appimage` and run it. (It might not work if your Linux distribution is more than 4 years old.) The following instructions assume an `x86_64` architecture; on ARM Linux replace with `arm64`.
 
-    curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux-86_64.appimage
+    curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.appimage
     chmod u+x nvim-linux-x86_64.appimage
     ./nvim-linux-x86_64.appimage
 


### PR DESCRIPTION
Missing 'x' from x86_64 in the download link