### PR TITLE
vim-patch:9.1.1057: Superfluous cleanup steps in test_ins_complete.vim

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3755,15 +3755,16 @@ void ins_compl_insert(bool in_compl_func, bool move_cursor)
 {
   int compl_len = get_compl_len();
   bool preinsert = ins_compl_has_preinsert();
-  char *str = compl_shown_match->cp_str.data;
+  char *cp_str = compl_shown_match->cp_str.data;
+  size_t cp_str_len = compl_shown_match->cp_str.size;
   size_t leader_len = ins_compl_leader_len();
 
   // Make sure we don't go over the end of the string, this can happen with
   // illegal bytes.
-  if (compl_len < (int)compl_shown_match->cp_str.size) {
-    ins_compl_insert_bytes(str + compl_len, -1);
+  if (compl_len < (int)cp_str_len) {
+    ins_compl_insert_bytes(cp_str + compl_len, -1);
     if (preinsert && move_cursor) {
-      curwin->w_cursor.col -= (colnr_T)(strlen(str) - leader_len);
+      curwin->w_cursor.col -= (colnr_T)(cp_str_len - leader_len);
     }
   }
   compl_used_match = !(match_at_original_text(compl_shown_match) || preinsert);

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2928,7 +2928,6 @@ func Test_complete_info_matches()
   call assert_false(has_key(g:compl_info, 'matches'))
 
   bw!
-  bw!
   unlet g:what
   delfunc ShownInfo
   set cot&
@@ -2958,7 +2957,6 @@ func Test_complete_info_completed()
   call feedkeys("Go\<C-X>\<C-N>\<F5>\<Esc>dd", 'tx')
   call assert_equal({}, g:compl_info)
 
-  bw!
   bw!
   delfunc ShownInfo
   set cot&
@@ -3021,7 +3019,7 @@ function Test_completeopt_preinsert()
   call assert_equal("hello  fobar wo", getline('.'))
   call feedkeys("\<C-E>\<ESC>", 'tx')
 
-  " confrim
+  " confirm
   call feedkeys("S\<C-X>\<C-O>f\<C-Y>", 'tx')
   call assert_equal("fobar", getline('.'))
   call assert_equal(5, col('.'))
@@ -3074,11 +3072,9 @@ function Test_completeopt_preinsert()
   call assert_equal(5, col('.'))
 
   bw!
-  bw!
   set cot&
   set omnifunc&
   delfunc Omni_test
-  autocmd! CompleteChanged
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
#### vim-patch:9.1.1057: Superfluous cleanup steps in test_ins_complete.vim

Problem:  Superfluous cleanup steps in test_ins_complete.vim.
Solution: Remove unnecessary :bw! and :autocmd! commands.
          Also remove unnecessary STRLEN() in insexpand.c
          (zeertzjq)

closes: vim/vim#16542

https://github.com/vim/vim/commit/8297e2cee337c626c6691e81b25e1f1897c71b86