### PR TITLE
fix(man.lua): do not try to add `Attrs.None` highlights

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -201,8 +201,10 @@ local function highlight_man_page()
   api.nvim_buf_set_lines(0, 0, -1, false, lines)
 
   for _, hl in ipairs(hls) do
-    --- @diagnostic disable-next-line: deprecated
-    api.nvim_buf_add_highlight(0, -1, HlGroups[hl.attr], hl.row, hl.start, hl.final)
+    if hl.attr ~= Attrs.None then
+      --- @diagnostic disable-next-line: deprecated
+      api.nvim_buf_add_highlight(0, -1, HlGroups[hl.attr], hl.row, hl.start, hl.final)
+    end
   end
 
   vim.bo.modifiable = mod


### PR DESCRIPTION
Before the 7121983c45d92349a6532f32dcde9f425e30781e refactoring this loop added highlights from a `buf_hls` list that had filtered out elements with `Attrs.None`. After the refactoring this added highlights from `hls` directly, and those elements would fail with e.g.:

    $ nvim 'man://math.h(0)'
    Error detected while processing command line:
    Error executing Lua callback: /usr/share/nvim/runtime/lua/man.lua:205: Invalid 'hl_group': Expected Lua string
    stack traceback:
            [C]: in function 'nvim_buf_add_highlight'
            /usr/share/nvim/runtime/lua/man.lua:205: in function 'highlight_man_page'
            /usr/share/nvim/runtime/lua/man.lua:632: in function 'init_pager'
            /usr/share/nvim/runtime/plugin/man.lua:9: in function </usr/share/nvim/runtime/plugin/man.lua:6>