### PR TITLE
fix(lsp): autotrigger should only trigger on client's triggerCharacters

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -518,11 +518,14 @@ local function on_insert_char_pre(handle)
   end
 
   local char = api.nvim_get_vvar('char')
-  if not completion_timer and handle.triggers[char] then
+  local matched_clients = handle.triggers[char]
+  if not completion_timer and matched_clients then
     completion_timer = assert(vim.uv.new_timer())
     completion_timer:start(25, 0, function()
       reset_timer()
-      vim.schedule(M.trigger)
+      vim.schedule(function()
+        trigger(api.nvim_get_current_buf(), matched_clients)
+      end)
     end)
   end
 end

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -770,13 +770,14 @@ end)
 
 --- @param name string
 --- @param completion_result lsp.CompletionList
+--- @param trigger_chars? string[]
 --- @return integer
-local function create_server(name, completion_result)
+local function create_server(name, completion_result, trigger_chars)
   return exec_lua(function()
     local server = _G._create_server({
       capabilities = {
         completionProvider = {
-          triggerCharacters = { '.' },
+          triggerCharacters = trigger_chars or { '.' },
         },
       },
       handlers = {
@@ -793,6 +794,7 @@ local function create_server(name, completion_result)
       cmd = server.cmd,
       on_attach = function(client, bufnr0)
         vim.lsp.completion.enable(true, client.id, bufnr0, {
+          autotrigger = trigger_chars ~= nil,
           convert = function(item)
             return { abbr = item.label:gsub('%b()', '') }
           end,
@@ -954,6 +956,39 @@ describe('vim.lsp.completion: protocol', function()
       eq(2, #matches)
       eq('hello', matches[1].word)
       eq('hallo', matches[2].word)
+    end)
+  end)
+
+  it('insert char triggers clients matching trigger characters', function()
+    local results1 = {
+      isIncomplete = false,
+      items = {
+        {
+          label = 'hello',
+        },
+      },
+    }
+    create_server('dummy1', results1, { 'e' })
+    local results2 = {
+      isIncomplete = false,
+      items = {
+        {
+          label = 'hallo',
+        },
+      },
+    }
+    create_server('dummy2', results2, { 'h' })
+
+    feed('h')
+    exec_lua(function()
+      vim.v.char = 'h'
+      vim.cmd.startinsert()
+      vim.api.nvim_exec_autocmds('InsertCharPre', {})
+    end)
+
+    assert_matches(function(matches)
+      eq(1, #matches)
+      eq('hallo', matches[1].word)
     end)
   end)
 


### PR DESCRIPTION
Problem: `autotrigger` option of `vim.lsp.completion.enable()` would trigger all clients, as long as it matched at least one client's `triggerCharacters`.

Solution: trigger only the clients with triggerCharacters matching the character. overtriggering still happens if any client returns `isIncomplete=true` (this case is more involved).

For example: jdtls is really slow client especially on a big java codebase. All responses from it are laggy, if you send it requests too fast or for strange triggerCharacters, it will destabilize, start returning errors, etc. But it is worth the pain to trigger it for its triggerCharacters (e.g. `.`).

I have "fast clients" I'd like to use on other trigger characters, e.g. `[a-zA-Z0-9_]`, which just do treesitter locals, snippets, etc. But currently, I can't use them without also triggering the slow jdtls, too. With this patch, everything works together wonderfully, as clients are only triggered on the characters they should be.

This issue might just be a simple oversight: the code goes to great efforts to track a mapping of `char -> client[]` but then doesn't use the return value when actually triggering.

I could use guidance on lua testing: I understand the existing tests, but I don't see how to test the `autotrigger`. 