### PR TITLE
fix(yank): ensure registers "+ and "* behave consistently without clipboard provider

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -914,16 +914,6 @@ yankreg_T *get_yank_register(int regname, int mode)
       && get_clipboard(regname, &reg, false)) {
     // reg is set to clipboard contents.
     return reg;
-  } else if (mode == YREG_PUT && (regname == '*' || regname == '+')) {
-    // in case clipboard not available and we aren't actually pasting,
-    // return an empty register
-    static yankreg_T empty_reg = { .y_array = NULL };
-    return &empty_reg;
-  } else if (mode != YREG_YANK
-             && (regname == 0 || regname == '"' || regname == '*' || regname == '+')
-             && y_previous != NULL) {
-    // in case clipboard not available, paste from previous used register
-    return y_previous;
   }
 
   int i = op_reg_index(regname);


### PR DESCRIPTION
Problem: When the clipboard provider is unavailable, writing to `"+` and `"*` registers shows an error but still stores data. However, pasting from them (`"+p`) unexpectedly falls back to `""`, leading to inconsistent behavior.

Solution: Ensure `"+` and `"*` registers behave like normal named registers when the clipboard provider is unavailable, preventing fallback to `""` and ensuring predictable yank and paste operations.