### PR TITLE
refactor(treesitter): always return valid range in parse()

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -380,10 +380,7 @@ function LanguageTree:_parse_regions(range, timeout)
         return changes, no_regions_parsed, total_parse_time, false
       end
 
-      -- Pass ranges if this is an initial parse
-      local cb_changes = self._trees[i] and tree_changes or tree:included_ranges(true)
-
-      self:_do_callback('changedtree', cb_changes, tree)
+      self:_do_callback('changedtree', tree_changes, tree)
       self._trees[i] = tree
       vim.list_extend(changes, tree_changes)
 

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -500,7 +500,8 @@ static int parser_parse(lua_State *L)
   // The new tree will be pushed to the stack, without copy, ownership is now to the lua GC.
   // Old tree is owned by lua GC since before
   uint32_t n_ranges = 0;
-  TSRange *changed = old_tree ? ts_tree_get_changed_ranges(old_tree, new_tree, &n_ranges) : NULL;
+  TSRange *changed = old_tree ? ts_tree_get_changed_ranges(old_tree, new_tree, &n_ranges)
+                              : ts_tree_included_ranges(new_tree, &n_ranges);
 
   push_tree(L, new_tree);  // [tree]
 


### PR DESCRIPTION
When running an initial parse, the parse function returns an empty table rather than an actual range. In `languagetree.lua`, we manually check if a parse was incremental to determine the changed parse region. This commit makes it so a range is always returned (in the C side) and simplifies the language tree code a bit.

It also makes it so that the logger no longer shows empty ranges upon running an initial parse.