### PR TITLE
vim-patch:9.1.1059: completion: input text deleted with preinsert when adding leader

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3469,7 +3469,8 @@ static int get_next_default_completion(ins_compl_next_state_T *st, pos_T *start_
     int len;
     char *ptr = ins_compl_get_next_word_or_line(st->ins_buf, st->cur_match_pos,
                                                 &len, &cont_s_ipos);
-    if (ptr == NULL) {
+    if (ptr == NULL
+        || (ins_compl_has_preinsert() && strcmp(ptr, compl_pattern.data) == 0)) {
       continue;
     }
     if (ins_compl_add_infercase(ptr, len, p_ic,
@@ -3728,7 +3729,7 @@ void ins_compl_delete(bool new_leader)
   int col = compl_col + (compl_status_adding() ? compl_length : orig_col);
   bool has_preinsert = ins_compl_preinsert_effect();
   if (has_preinsert) {
-    col = compl_col + (int)ins_compl_leader_len() - compl_length;
+    col += (int)ins_compl_leader_len();
     curwin->w_cursor.col = compl_ins_end_col;
   }
 

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -3051,6 +3051,10 @@ function Test_completeopt_preinsert()
   call assert_equal("hello hero", getline('.'))
   call assert_equal(2, col('.'))
 
+  call feedkeys("Shello hero\<CR>h\<C-X>\<C-N>er", 'tx')
+  call assert_equal("hero", getline('.'))
+  call assert_equal(3, col('.'))
+
   " can not work with fuzzy
   set cot+=fuzzy
   call feedkeys("S\<C-X>\<C-O>", 'tx')


### PR DESCRIPTION
#### vim-patch:9.1.1059: completion: input text deleted with preinsert when adding leader

Problem:  completion: input text deleted with preinsert when adding leader
Solution: remove compl_length and check the ptr for being equal
          to pattern when preinsert is active (glepnir)

closes: vim/vim#16545

https://github.com/vim/vim/commit/bfb4eea7869b0118221cd145a774d74191ce6130

Co-authored-by: glepnir <glephunter@gmail.com>