### PR TITLE
build(deps): bump tree-sitter to v0.25.0

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -50,8 +50,8 @@ TREESITTER_QUERY_URL https://github.com/tree-sitter-grammars/tree-sitter-query/a
 TREESITTER_QUERY_SHA256 d3a423ab66dc62b2969625e280116678a8a22582b5ff087795222108db2f6a6e
 TREESITTER_MARKDOWN_URL https://github.com/tree-sitter-grammars/tree-sitter-markdown/archive/v0.3.2.tar.gz
 TREESITTER_MARKDOWN_SHA256 5dac48a6d971eb545aab665d59a18180d21963afc781bbf40f9077c06cb82ae5
-TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/9515be4fc16d3dfe6fba5ae4a7a058f32bcf535d.tar.gz
-TREESITTER_SHA256 cbdea399736b55d61cfb581bc8d80620d487f4ec8f8d60b7fe00406e39a98d6d
+TREESITTER_URL https://github.com/tree-sitter/tree-sitter/archive/v0.25.0.tar.gz
+TREESITTER_SHA256 3729e98e54a41a4c03f4f6c0be580d14ed88c113d75acf15397b16e05cf91129
 
 WASMTIME_URL https://github.com/bytecodealliance/wasmtime/archive/v29.0.1.tar.gz
 WASMTIME_SHA256 b94b6c6fd6aebaf05d4c69c1b12b5dc217b0d42c1a95f435b33af63dddfa5304


### PR DESCRIPTION
https://github.com/tree-sitter/tree-sitter/releases/tag/v0.25.0

Relevant: 

> Parsing and Querying should be cancelled using the "progress callback", rather than setting a timeout or a cancellation flag, which are now deprecated. To do so, use the "parse/query with options" function in the bindings you choose to use, in the next release the old way of timing out parsing will be removed, which allows us to get rid of our dependency on the time.h headers in the core library.

@lewis6991 @ribru17 FYI and for public record.