### PR TITLE
fix(ftplugin): change PHP commentstring to '// %s'

### DIFF
--- a/runtime/ftplugin/php.lua
+++ b/runtime/ftplugin/php.lua
@@ -1,0 +1,3 @@
+vim.bo.commentstring = '// %s'
+
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring<'


### PR DESCRIPTION
Problem:
Currently, `'commentstring'` of PHP is set to `/* %s */`. However, this doesn't play nice with Vim's builtin comment plugin because the plugin is based on line commenting instead of block commenting. And when writing PHP, people often use `// %s` for line commenting instead of `/* %s */`

Solution:
Change `'commentstring'` to `// %s` for PHP.