### PR TITLE
vim-patch:8.2.{0825,1445,2505},9.0.1142,9.1.{1063,1066,1071}

### DIFF
--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -2660,7 +2660,7 @@ int tv_dict_add_func(dict_T *const d, const char *const key, const size_t key_le
   dictitem_T *const item = tv_dict_item_alloc_len(key, key_len);
 
   item->di_tv.v_type = VAR_FUNC;
-  item->di_tv.vval.v_string = xstrdup(fp->uf_name);
+  item->di_tv.vval.v_string = xmemdupz(fp->uf_name, fp->uf_namelen);
   if (tv_dict_add(d, item) == FAIL) {
     tv_dict_item_free(item);
     return FAIL;

--- a/src/nvim/eval/typval_defs.h
+++ b/src/nvim/eval/typval_defs.h
@@ -357,9 +357,10 @@ struct ufunc {
   funccall_T *uf_scoped;       ///< l: local variables for closure
   char *uf_name_exp;    ///< if "uf_name[]" starts with SNR the name with
                         ///< "<SNR>" as a string, otherwise NULL
-  char uf_name[];    ///< Name of function (actual size equals name);
-                     ///< can start with <SNR>123_
-                     ///< (<SNR> is K_SPECIAL KS_EXTRA KE_SNR)
+  size_t uf_namelen;    ///< Length of uf_name (excluding the NUL)
+  char uf_name[];       ///< Name of function (actual size equals name);
+                        ///< can start with <SNR>123_
+                        ///< (<SNR> is K_SPECIAL KS_EXTRA KE_SNR)
 };
 
 struct partial_S {

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2867,6 +2867,7 @@ void ex_function(exarg_T *eap)
         if (tv_dict_add(fudi.fd_dict, fudi.fd_di) == FAIL) {
           xfree(fudi.fd_di);
           xfree(fp);
+          fp = NULL;
           goto erret;
         }
       } else {
@@ -2887,6 +2888,7 @@ void ex_function(exarg_T *eap)
       hi->hi_key = UF2HIKEY(fp);
     } else if (hash_add(&func_hashtab, UF2HIKEY(fp)) == FAIL) {
       xfree(fp);
+      fp = NULL;
       goto erret;
     }
     fp->uf_refcount = 1;

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2918,13 +2918,14 @@ void ex_function(exarg_T *eap)
   goto ret_free;
 
 erret:
-  ga_clear_strings(&newargs);
-  ga_clear_strings(&default_args);
   if (fp != NULL) {
+    // these were set to "newargs" and "default_args", which are cleared below
     ga_init(&fp->uf_args, (int)sizeof(char *), 1);
     ga_init(&fp->uf_def_args, (int)sizeof(char *), 1);
   }
 errret_2:
+  ga_clear_strings(&newargs);
+  ga_clear_strings(&default_args);
   ga_clear_strings(&newlines);
   if (free_fp) {
     xfree(fp);

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2825,11 +2825,11 @@ void ex_function(exarg_T *eap)
           && (fp->uf_script_ctx.sc_sid != current_sctx.sc_sid
               || fp->uf_script_ctx.sc_seq == current_sctx.sc_seq)) {
         emsg_funcname(e_funcexts, name);
-        goto erret;
+        goto errret_keep;
       }
       if (fp->uf_calls > 0) {
         emsg_funcname(N_("E127: Cannot redefine function %s: It is in use"), name);
-        goto erret;
+        goto errret_keep;
       }
       if (fp->uf_refcount > 1) {
         // This function is referenced somewhere, don't redefine it but
@@ -2961,9 +2961,6 @@ erret:
     ga_init(&fp->uf_def_args, (int)sizeof(char *), 1);
   }
 errret_2:
-  ga_clear_strings(&newargs);
-  ga_clear_strings(&default_args);
-  ga_clear_strings(&newlines);
   if (fp != NULL) {
     XFREE_CLEAR(fp->uf_name_exp);
   }
@@ -2971,6 +2968,10 @@ errret_2:
     xfree(fp);
     fp = NULL;
   }
+errret_keep:
+  ga_clear_strings(&newargs);
+  ga_clear_strings(&default_args);
+  ga_clear_strings(&newlines);
 ret_free:
   xfree(line_to_free);
   xfree(fudi.fd_newkey);

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -891,7 +891,6 @@ static void func_clear_items(ufunc_T *fp)
   ga_clear_strings(&(fp->uf_args));
   ga_clear_strings(&(fp->uf_def_args));
   ga_clear_strings(&(fp->uf_lines));
-  XFREE_CLEAR(fp->uf_name_exp);
 
   if (fp->uf_flags & FC_LUAREF) {
     api_free_luaref(fp->uf_luaref);
@@ -930,6 +929,8 @@ static void func_free(ufunc_T *fp)
   if ((fp->uf_flags & (FC_DELETED | FC_REMOVED)) == 0) {
     func_remove(fp);
   }
+
+  XFREE_CLEAR(fp->uf_name_exp);
   xfree(fp);
 }
 

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -3672,12 +3672,11 @@ bool do_return(exarg_T *eap, bool reanimate, bool is_cmd, void *rettv)
 char *get_return_cmd(void *rettv)
 {
   char *s = NULL;
+  char *tofree = NULL;
   size_t slen = 0;
 
   if (rettv != NULL) {
-    char *tofree = NULL;
     tofree = s = encode_tv2echo((typval_T *)rettv, NULL);
-    xfree(tofree);
   }
   if (s == NULL) {
     s = "";
@@ -3688,10 +3687,11 @@ char *get_return_cmd(void *rettv)
   xstrlcpy(IObuff, ":return ", IOSIZE);
   xstrlcpy(IObuff + 8, s, IOSIZE - 8);
   size_t IObufflen = 8 + slen;
-  if (slen + 8 >= IOSIZE) {
+  if (IObufflen >= IOSIZE) {
     STRCPY(IObuff + IOSIZE - 4, "...");
-    IObufflen += 3;
+    IObufflen = IOSIZE - 1;
   }
+  xfree(tofree);
   return xstrnsave(IObuff, IObufflen);
 }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7400,8 +7400,7 @@ char *eval_vars(char *src, const char *srcstart, size_t *usedlen, linenr_T *lnum
         *errormsg = _(e_usingsid);
         return NULL;
       }
-      snprintf(strbuf, sizeof(strbuf), "<SNR>%" PRIdSCID "_",
-               current_sctx.sc_sid);
+      snprintf(strbuf, sizeof(strbuf), "<SNR>%" PRIdSCID "_", current_sctx.sc_sid);
       result = strbuf;
       break;
 

--- a/src/nvim/keycodes.c
+++ b/src/nvim/keycodes.c
@@ -917,7 +917,7 @@ char *replace_termcodes(const char *const from, const size_t from_len, char **co
           result[dlen++] = (char)K_SPECIAL;
           result[dlen++] = (char)KS_EXTRA;
           result[dlen++] = KE_SNR;
-          snprintf(result + dlen, buf_len - dlen, "%" PRId64, (int64_t)sid);
+          snprintf(result + dlen, buf_len - dlen, "%" PRIdSCID, sid);
           dlen += strlen(result + dlen);
           result[dlen++] = '_';
           continue;

--- a/test/old/testdir/test_user_func.vim
+++ b/test/old/testdir/test_user_func.vim
@@ -910,4 +910,36 @@ func Test_func_curly_brace_invalid_name()
   delfunc Fail
 endfunc
 
+func Test_func_return_in_try_verbose()
+  func TryReturnList()
+    try
+      return [1, 2, 3]
+    endtry
+  endfunc
+  func TryReturnNumber()
+    try
+      return 123
+    endtry
+  endfunc
+  func TryReturnOverlongString()
+    try
+      return repeat('a', 9999)
+    endtry
+  endfunc
+
+  " This should not cause heap-use-after-free
+  call assert_match('\n:return \[1, 2, 3\] made pending\n',
+                  \ execute('14verbose call TryReturnList()'))
+  " This should not cause stack-use-after-scope
+  call assert_match('\n:return 123 made pending\n',
+                  \ execute('14verbose call TryReturnNumber()'))
+  " An overlong string is truncated
+  call assert_match('\n:return a\{100,}\.\.\.',
+                  \ execute('14verbose call TryReturnOverlongString()'))
+
+  delfunc TryReturnList
+  delfunc TryReturnNumber
+  delfunc TryReturnOverlongString
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_user_func.vim
+++ b/test/old/testdir/test_user_func.vim
@@ -421,12 +421,48 @@ func Test_func_def_error()
   call assert_fails('exe l', 'E717:')
 
   " Define an autoload function with an incorrect file name
-  call writefile(['func foo#Bar()', 'return 1', 'endfunc'], 'Xscript')
+  call writefile(['func foo#Bar()', 'return 1', 'endfunc'], 'Xscript', 'D')
   call assert_fails('source Xscript', 'E746:')
-  call delete('Xscript')
 
   " Try to list functions using an invalid search pattern
   call assert_fails('function /\%(/', 'E53:')
+
+  " Use a script-local function to cover uf_name_exp.
+  func s:TestRedefine(arg1 = 1, arg2 = 10)
+    let caught_E122 = 0
+    try
+      func s:TestRedefine(arg1 = 1, arg2 = 10)
+      endfunc
+    catch /E122:/
+      let caught_E122 = 1
+    endtry
+    call assert_equal(1, caught_E122)
+
+    let caught_E127 = 0
+    try
+      func! s:TestRedefine(arg1 = 1, arg2 = 10)
+      endfunc
+    catch /E127:/
+      let caught_E127 = 1
+    endtry
+    call assert_equal(1, caught_E127)
+
+    " The failures above shouldn't cause heap-use-after-free here.
+    return [a:arg1 + a:arg2, expand('<stack>')]
+  endfunc
+
+  let stacks = []
+  " Call the function twice.
+  " Failing to redefine a function shouldn't clear its argument list.
+  for i in range(2)
+    let [val, stack] = s:TestRedefine(1000)
+    call assert_equal(1010, val)
+    call assert_match(expand('<SID>') .. 'TestRedefine\[20\]$', stack)
+    call add(stacks, stack)
+  endfor
+  call assert_equal(stacks[0], stacks[1])
+
+  delfunc s:TestRedefine
 endfunc
 
 " Test for deleting a function


### PR DESCRIPTION
#### vim-patch:8.2.0825: def_function() may return pointer that was freed

Problem:    def_function() may return pointer that was freed.
Solution:   Set "fp" to NULL after freeing it.

https://github.com/vim/vim/commit/a14e6975478adeddcc2161edc1ec611016aa89f3

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.1445: Vim9: function expanded name is cleared when sourcing again

Problem:    Vim9: function expanded name is cleared when sourcing a script
            again.
Solution:   Only clear the expanded name when deleting the function.

https://github.com/vim/vim/commit/c4ce36d48698669f81ec90f7c9dc9ab8c362e538

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2505: Vim9: crash after defining function with invalid return type

Problem:    Vim9: crash after defining function with invalid return type.
Solution:   Clear function growarrays.  Fix memory leak.

https://github.com/vim/vim/commit/31842cd0772b557eb9584a13740430db29de8a51

Cherry-pick free_fp from patch 8.2.3812.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.0.1142: crash and/or memory leak when redefining function

Problem:    Crash and/or memory leak when redefining function after error.
Solution:   Clear pointer after making a copy.  Clear arrays on failure.

https://github.com/vim/vim/commit/f057171d8b562c72334fd7c15c89ff787358ce3a

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.1.1063: too many strlen() calls in userfunc.c

Problem:  too many strlen() calls in userfunc.c
Solution: refactor userfunc.c and remove calls to strlen(),
          drop set_ufunc_name() and roll it into alloc_ufunc(),
          check for out-of-memory condition in trans_function_name_ext()
          (John Marriott)

closes: vim/vim#16537

https://github.com/vim/vim/commit/b32800f7c51c866dc0e87244eb4902540982309d

Add missing change to call_user_func() from patch 8.1.1007.
Consistently use PRIdSCID instead of PRId64 for script IDs.

Co-authored-by: John Marriott <basilisk@internode.on.net>


#### vim-patch:9.1.1066: heap-use-after-free and stack-use-after-scope with :14verbose

Problem:  heap-use-after-free and stack-use-after-scope with :14verbose
          when using :return and :try (after 9.1.1063).
Solution: Move back the vim_free(tofree) and the scope of numbuf[].
          (zeertzjq)

closes: vim/vim#16563

https://github.com/vim/vim/commit/2101230f4013860dbafcb0cab3f4e6bc92fb6f35


#### vim-patch:9.1.1071: args missing after failing to redefine a function

Problem:  Arguments of a function are missing after failing to redefine
          it (after 8.2.2505), and heap-use-after-free with script-local
          function (after 9.1.1063).
Solution: Don't clear arguments or free uf_name_exp when failing to
          redefine an existing function (zeertzjq)

closes: vim/vim#16567

https://github.com/vim/vim/commit/04d2a3fdc051d6a419dc0ea4de7a9640cefccd31