### PR TITLE
fix(lsp): noisy "Cannot find request" logs

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -620,10 +620,12 @@ function Client:_process_request(id, req_type, bufnr, method)
     )
     return
   elseif not pending and not cur_request then
-    log.error(
-      self._log_prefix,
-      ('Cannot find request with id %d whilst attempting to %s'):format(id, req_type)
-    )
+    if req_type ~= 'cancel' then
+      log.error(
+        self._log_prefix,
+        ('Cannot find request with id %d whilst attempting to %s'):format(id, req_type)
+      )
+    end
     return
   end
 


### PR DESCRIPTION
Problem:
This log message appears very often:

    [ERROR] … client.lua:617 "LSP[luals]" "Cannot find request with id 223 whilst attempting to cancel"
    [ERROR] … client.lua:617 "LSP[luals]" "Cannot find request with id 224 whilst attempting to cancel"
    [ERROR] … client.lua:617 "LSP[luals]" "Cannot find request with id 225 whilst attempting to cancel"
    [ERROR] … client.lua:617 "LSP[luals]" "Cannot find request with id 229 whilst attempting to cancel"

Solution:
Skip this log if the request was canceled.

fix #32277