### PR TITLE
vim-patch:9.1.1069: preinsert text completions not deleted with <C-W>/<C-U>

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2228,6 +2228,10 @@ static bool ins_compl_stop(const int c, const int prev_mode, bool retval)
     retval = true;
   }
 
+  if ((c == Ctrl_W || c == Ctrl_U) && ins_compl_preinsert_effect()) {
+    ins_compl_delete(false);
+  }
+
   auto_format(false, true);
 
   // Trigger the CompleteDonePre event to give scripts a chance to

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -3042,6 +3042,14 @@ function Test_completeopt_preinsert()
   call assert_equal("fo ", getline('.'))
   call assert_equal(3, col('.'))
 
+  call feedkeys("She\<C-X>\<C-N>\<C-U>", 'tx')
+  call assert_equal("", getline('.'))
+  call assert_equal(1, col('.'))
+
+  call feedkeys("She\<C-X>\<C-N>\<C-W>", 'tx')
+  call assert_equal("", getline('.'))
+  call assert_equal(1, col('.'))
+
   " whole line
   call feedkeys("Shello hero\<CR>\<C-X>\<C-L>", 'tx')
   call assert_equal("hello hero", getline('.'))


### PR DESCRIPTION
Problem:  preinsert text completions not deleted with \<C-W>/\<C-U>
          (ddad431, after v9.1.1059)
Solution: handle <C-W> or <C-U> specifically and clear the completion
          (glepnir)

closes: vim/vim#16565

https://github.com/vim/vim/commit/001c26cd6194fba2bfccb06dec30fdc9e1410e62