### PR TITLE
vim-patch:9.1.1070: Cannot control cursor positioning of getchar()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -3114,6 +3114,14 @@ getchar([{expr} [, {opts}]])                                         *getchar()*
 		The optional argument {opts} is a Dict and supports the
 		following items:
 
+			cursor		A String specifying cursor behavior
+					when waiting for a character.
+					"hide": hide the cursor.
+					"keep": keep current cursor unchanged.
+					"msg": move cursor to message area.
+					(default: automagically decide
+					between "keep" and "msg")
+
 			number		If |TRUE|, return a Number when getting
 					a single character.
 					If |FALSE|, the return value is always

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -410,6 +410,11 @@ UI
 • |:checkhealth| can display in a floating window, controlled by the
   |g:health| variable.
 
+VIMSCRIPT
+
+• |getchar()| and |getcharstr()| have optional {opts} |Dict| argument to control:
+  cursor behavior, return type, and whether to simplify the returned key.
+
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*
 

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -2781,6 +2781,14 @@ function vim.fn.getchangelist(buf) end
 --- The optional argument {opts} is a Dict and supports the
 --- following items:
 ---
+---   cursor    A String specifying cursor behavior
+---       when waiting for a character.
+---       "hide": hide the cursor.
+---       "keep": keep current cursor unchanged.
+---       "msg": move cursor to message area.
+---       (default: automagically decide
+---       between "keep" and "msg")
+---
 ---   number    If |TRUE|, return a Number when getting
 ---       a single character.
 ---       If |FALSE|, the return value is always

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -3507,6 +3507,14 @@ M.funcs = {
       The optional argument {opts} is a Dict and supports the
       following items:
 
+      	cursor		A String specifying cursor behavior
+      			when waiting for a character.
+      			"hide": hide the cursor.
+      			"keep": keep current cursor unchanged.
+      			"msg": move cursor to message area.
+      			(default: automagically decide
+      			between "keep" and "msg")
+
       	number		If |TRUE|, return a Number when getting
       			a single character.
       			If |FALSE|, the return value is always

--- a/test/functional/vimscript/getchar_spec.lua
+++ b/test/functional/vimscript/getchar_spec.lua
@@ -1,0 +1,92 @@
+local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
+
+local clear = n.clear
+local exec = n.exec
+local feed = n.feed
+local async_command = n.async_meths.nvim_command
+
+describe('getchar()', function()
+  before_each(clear)
+
+  -- oldtest: Test_getchar_cursor_position()
+  it('cursor positioning', function()
+    local screen = Screen.new(40, 6)
+    exec([[
+      call setline(1, ['foobar', 'foobar', 'foobar'])
+      call cursor(3, 6)
+    ]])
+    screen:expect([[
+      foobar                                  |*2
+      fooba^r                                  |
+      {1:~                                       }|*2
+                                              |
+    ]])
+
+    -- Default: behaves like "msg" when immediately after printing a message,
+    -- even if :sleep moved cursor elsewhere.
+    for _, cmd in ipairs({
+      'echo 1234 | call getchar()',
+      'echo 1234 | call getchar(-1, {})',
+      "echo 1234 | call getchar(-1, #{cursor: 'msg'})",
+      'echo 1234 | sleep 1m | call getchar()',
+      'echo 1234 | sleep 1m | call getchar(-1, {})',
+      "echo 1234 | sleep 1m | call getchar(-1, #{cursor: 'msg'})",
+    }) do
+      async_command(cmd)
+      screen:expect([[
+        foobar                                  |*3
+        {1:~                                       }|*2
+        1234^                                    |
+      ]])
+      feed('a')
+      screen:expect([[
+        foobar                                  |*2
+        fooba^r                                  |
+        {1:~                                       }|*2
+        1234                                    |
+      ]])
+    end
+
+    -- Default: behaves like "keep" when not immediately after printing a message.
+    for _, cmd in ipairs({
+      'call getchar()',
+      'call getchar(-1, {})',
+      "call getchar(-1, #{cursor: 'keep'})",
+      "echo 1234 | sleep 1m | call getchar(-1, #{cursor: 'keep'})",
+    }) do
+      async_command(cmd)
+      screen:expect_unchanged()
+      feed('a')
+      screen:expect_unchanged()
+    end
+
+    async_command("call getchar(-1, #{cursor: 'msg'})")
+    screen:expect([[
+      foobar                                  |*3
+      {1:~                                       }|*2
+      ^1234                                    |
+    ]])
+    feed('a')
+    screen:expect([[
+      foobar                                  |*2
+      fooba^r                                  |
+      {1:~                                       }|*2
+      1234                                    |
+    ]])
+
+    async_command("call getchar(-1, #{cursor: 'hide'})")
+    screen:expect([[
+      foobar                                  |*3
+      {1:~                                       }|*2
+      1234                                    |
+    ]])
+    feed('a')
+    screen:expect([[
+      foobar                                  |*2
+      fooba^r                                  |
+      {1:~                                       }|*2
+      1234                                    |
+    ]])
+  end)
+end)


### PR DESCRIPTION
#### vim-patch:9.1.1070: Cannot control cursor positioning of getchar()

Problem:  Cannot control cursor positioning of getchar().
Solution: Add "cursor" flag to {opts}, with possible values "hide",
          "keep" and "msg".

related: vim/vim#10603
closes: vim/vim#16569

https://github.com/vim/vim/commit/edf0f7db28f87611368e158210e58ed30f673098