### PR TITLE
fix(tui): include ST to get Cs (set_cursor_color) capability augmented

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -2382,7 +2382,7 @@ static void augment_terminfo(TUIData *tui, const char *term, int vte_version, in
     } else if ((xterm || hterm || rxvt || tmux || alacritty || st)
                && (vte_version == 0 || vte_version >= 3900)) {
       // Supported in urxvt, newer VTE.
-      // Supported in st, but currently lacks entry in ncurses definitions  #32217
+      // Supported in st, but currently missing in ncurses definitions. #32217
       tui->unibi_ext.set_cursor_color = (int)unibi_add_ext_str(ut, "ext.set_cursor_color",
                                                                "\033]12;%p1%s\007");
     }

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -2379,8 +2379,8 @@ static void augment_terminfo(TUIData *tui, const char *term, int vte_version, in
       // would use a tmux control sequence and an extra if(screen) test.
       tui->unibi_ext.set_cursor_color =
         (int)unibi_add_ext_str(ut, NULL, TMUX_WRAP(tmux, "\033]Pl%p1%06x\033\\"));
-    } else if (((xterm || hterm || rxvt || tmux || alacritty)
-               && (vte_version == 0 || vte_version >= 3900)) || st) {
+    } else if ((xterm || hterm || rxvt || tmux || alacritty || st)
+               && (vte_version == 0 || vte_version >= 3900)) {
       // Supported in urxvt, newer VTE.
       // Supported in st, but currently lacks entry in ncurses definitions  #32217
       tui->unibi_ext.set_cursor_color = (int)unibi_add_ext_str(ut, "ext.set_cursor_color",

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -2294,6 +2294,7 @@ static void augment_terminfo(TUIData *tui, const char *term, int vte_version, in
   bool putty = terminfo_is_term_family(term, "putty");
   bool screen = terminfo_is_term_family(term, "screen");
   bool tmux = terminfo_is_term_family(term, "tmux") || !!os_getenv("TMUX");
+  bool st = terminfo_is_term_family(term, "st");
   bool iterm = terminfo_is_term_family(term, "iterm")
                || terminfo_is_term_family(term, "iterm2")
                || terminfo_is_term_family(term, "iTerm.app")
@@ -2378,9 +2379,10 @@ static void augment_terminfo(TUIData *tui, const char *term, int vte_version, in
       // would use a tmux control sequence and an extra if(screen) test.
       tui->unibi_ext.set_cursor_color =
         (int)unibi_add_ext_str(ut, NULL, TMUX_WRAP(tmux, "\033]Pl%p1%06x\033\\"));
-    } else if ((xterm || hterm || rxvt || tmux || alacritty)
-               && (vte_version == 0 || vte_version >= 3900)) {
+    } else if (((xterm || hterm || rxvt || tmux || alacritty)
+               && (vte_version == 0 || vte_version >= 3900)) || st) {
       // Supported in urxvt, newer VTE.
+      // Supported in st, but currently lacks entry in ncurses definitions  #32217
       tui->unibi_ext.set_cursor_color = (int)unibi_add_ext_str(ut, "ext.set_cursor_color",
                                                                "\033]12;%p1%s\007");
     }


### PR DESCRIPTION
Problem:
Nvim's 'guicursor' does not change the cursor color in ST because Nvim's builtin terminfo for ST lacks a Cs entry, even though ST does support the cursor color to be set via termcodes.

Solution:
Thomas Dickey has added a to-do item to add the Cs entry for st into ncurses, from which Nvim's builtin terminfos are generated.  In the mean time, this fix includes ST as a separate condition for a branch in `augment_terminfo()` that manually adds the Cs extended unibilium capability.

Test coverage:
Ran `make test`, some variable amount (4-6) tests failed, but this was also the case on the master branch and none related to tui.c

fix #32217