### PR TITLE
vim-patch:9.0.1391: "clear" macros are not always used

### DIFF
--- a/src/nvim/debugger.c
+++ b/src/nvim/debugger.c
@@ -110,13 +110,11 @@ void do_debug(char *cmd)
   }
   if (debug_oldval != NULL) {
     smsg(0, _("Oldval = \"%s\""), debug_oldval);
-    xfree(debug_oldval);
-    debug_oldval = NULL;
+    XFREE_CLEAR(debug_oldval);
   }
   if (debug_newval != NULL) {
     smsg(0, _("Newval = \"%s\""), debug_newval);
-    xfree(debug_newval);
-    debug_newval = NULL;
+    XFREE_CLEAR(debug_newval);
   }
   char *sname = estack_sfile(ESTACK_NONE);
   if (sname != NULL) {

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2908,8 +2908,7 @@ void ex_function(exarg_T *eap)
         fudi.fd_di = tv_dict_item_alloc(fudi.fd_newkey);
         if (tv_dict_add(fudi.fd_dict, fudi.fd_di) == FAIL) {
           xfree(fudi.fd_di);
-          xfree(fp);
-          fp = NULL;
+          XFREE_CLEAR(fp);
           goto erret;
         }
       } else {
@@ -2967,8 +2966,7 @@ errret_2:
     XFREE_CLEAR(fp->uf_name_exp);
   }
   if (free_fp) {
-    xfree(fp);
-    fp = NULL;
+    XFREE_CLEAR(fp);
   }
 errret_keep:
   ga_clear_strings(&newargs);

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5226,7 +5226,7 @@ void buf_copy_options(buf_T *buf, int flags)
       // or to a help buffer.
       if (dont_do_help) {
         buf->b_p_isk = save_p_isk;
-        if (p_vts && p_vts != empty_string_option && !buf->b_p_vts_array) {
+        if (p_vts && *p_vts != NUL && !buf->b_p_vts_array) {
           tabstop_set(p_vts, &buf->b_p_vts_array);
         } else {
           buf->b_p_vts_array = NULL;
@@ -5239,7 +5239,7 @@ void buf_copy_options(buf_T *buf, int flags)
         COPY_OPT_SCTX(buf, kBufOptTabstop);
         buf->b_p_vts = xstrdup(p_vts);
         COPY_OPT_SCTX(buf, kBufOptVartabstop);
-        if (p_vts && p_vts != empty_string_option && !buf->b_p_vts_array) {
+        if (p_vts && *p_vts != NUL && !buf->b_p_vts_array) {
           tabstop_set(p_vts, &buf->b_p_vts_array);
         } else {
           buf->b_p_vts_array = NULL;


### PR DESCRIPTION
#### vim-patch:9.0.1391: "clear" macros are not always used

Problem:    "clear" macros are not always used.
Solution:   Use ALLOC_ONE, VIM_CLEAR, CLEAR_POINTER and CLEAR_FIELD in more
            places. (Yegappan Lakshmanan, closes vim/vim#12104)

https://github.com/vim/vim/commit/960dcbd098c761dd623bec9492d5391ff6e8dceb

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>