### PR TITLE
fix(ci): only run vim-patches workflow on neovim/neovim

### DIFF
--- a/.github/workflows/vim_patches.yml
+++ b/.github/workflows/vim_patches.yml
@@ -6,6 +6,7 @@ on:
 
 jobs:
   update-vim-patches:
+    if: github.repository_owner == 'neovim'
     runs-on: ubuntu-latest
     permissions:
       contents: write


### PR DESCRIPTION
Problem: The default for forks is to run all workflows, which results in
a "failed workflow run" error every day

Solution: check if the repository owner is the Neovim organisation.

Fixes: #32313.

I'n not 100% sure this works, but the [Github docs](https://docs.github.com/en/actions/writing-workflows/choosing-when-your-workflow-runs/using-conditions-to-control-job-execution#example-only-run-job-for-specific-repository) make it seems like this would work. Maybe CI-legend @dundargoc can step in :)