### PR TITLE
vim-patch:9.1.1074: Strange error when heredoc marker starts with "trim"

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2456,7 +2456,8 @@ static int get_function_body(exarg_T *eap, garray_T *newlines, char *line_arg_in
                   && (!ASCII_ISALPHA(p[2]) || p[2] == 's')))) {
         // ":python <<" continues until a dot, like ":append"
         p = skipwhite(arg + 2);
-        if (strncmp(p, "trim", 4) == 0) {
+        if (strncmp(p, "trim", 4) == 0
+            && (p[4] == NUL || ascii_iswhite(p[4]))) {
           // Ignore leading white space.
           p = skipwhite(p + 4);
           heredoc_trimmedlen = (size_t)(skipwhite(theline) - theline);
@@ -2484,20 +2485,26 @@ static int get_function_body(exarg_T *eap, garray_T *newlines, char *line_arg_in
           }
           if (arg != NULL && strncmp(arg, "=<<", 3) == 0) {
             p = skipwhite(arg + 3);
+            bool has_trim = false;
             while (true) {
-              if (strncmp(p, "trim", 4) == 0) {
+              if (strncmp(p, "trim", 4) == 0
+                  && (p[4] == NUL || ascii_iswhite(p[4]))) {
                 // Ignore leading white space.
                 p = skipwhite(p + 4);
-                heredoc_trimmedlen = (size_t)(skipwhite(theline) - theline);
-                heredoc_trimmed = xmemdupz(theline, heredoc_trimmedlen);
+                has_trim = true;
                 continue;
               }
-              if (strncmp(p, "eval", 4) == 0) {
+              if (strncmp(p, "eval", 4) == 0
+                  && (p[4] == NUL || ascii_iswhite(p[4]))) {
                 // Ignore leading white space.
                 p = skipwhite(p + 4);
                 continue;
               }
               break;
+            }
+            if (has_trim) {
+              heredoc_trimmedlen = (size_t)(skipwhite(theline) - theline);
+              heredoc_trimmed = xmemdupz(theline, heredoc_trimmedlen);
             }
             skip_until = xmemdupz(p, (size_t)(skiptowhite(p) - p));
             do_concat = false;

--- a/test/old/testdir/test_let.vim
+++ b/test/old/testdir/test_let.vim
@@ -436,6 +436,24 @@ func Test_let_heredoc_fails()
     call assert_report('Caught exception: ' .. v:exception)
   endtry
 
+  try
+    let v =<< trim trimm
+    trimm
+    call assert_report('No exception thrown')
+  catch /E221:/
+  catch
+    call assert_report('Caught exception: ' .. v:exception)
+  endtry
+
+  try
+    let v =<< trim trim evall
+    evall
+    call assert_report('No exception thrown')
+  catch /E221:/
+  catch
+    call assert_report('Caught exception: ' .. v:exception)
+  endtry
+
   let text =<< trim END
   func WrongSyntax()
     let v =<< that there

--- a/test/old/testdir/test_perl.vim
+++ b/test/old/testdir/test_perl.vim
@@ -316,7 +316,10 @@ VIM::DoCommand('let s ..= "B"')
   perl << trim eof
     VIM::DoCommand('let s ..= "E"')
   eof
-  call assert_equal('ABCDE', s)
+  perl << trimm
+VIM::DoCommand('let s ..= "F"')
+trimm
+  call assert_equal('ABCDEF', s)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_python3.vim
+++ b/test/old/testdir/test_python3.vim
@@ -284,7 +284,10 @@ s+='B'
   python3 << trim eof
     s+='E'
   eof
-  call assert_equal('ABCDE', pyxeval('s'))
+  python3 << trimm
+s+='F'
+trimm
+  call assert_equal('ABCDEF', pyxeval('s'))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_pyx3.vim
+++ b/test/old/testdir/test_pyx3.vim
@@ -97,7 +97,10 @@ result+='B'
   pyx << trim eof
     result+='E'
   eof
-  call assert_equal('ABCDE', pyxeval('result'))
+  pyx << trimm
+result+='F'
+trimm
+  call assert_equal('ABCDEF', pyxeval('result'))
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_ruby.vim
+++ b/test/old/testdir/test_ruby.vim
@@ -439,7 +439,10 @@ Vim.command('let s ..= "B"')
   ruby << trim eof
     Vim.command('let s ..= "E"')
   eof
-  call assert_equal('ABCDE', s)
+ruby << trimm
+Vim.command('let s ..= "F"')
+trimm
+  call assert_equal('ABCDEF', s)
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1074: Strange error when heredoc marker starts with "trim"

Problem:  Strange error when heredoc marker starts with "trim".
Solution: Check for whitespace after "trim" or "eval" (zeertzjq)

For :python3 etc., a heredoc marker that starts with a lower-case letter
is valid, and when it starts with "trim" it works in a script but not in
a function, and this PR makes it works in a function.
For :let, a heredoc marker that starts with a lower-case letter is not
valid, but when it starts with "trim" or "eval" the error can be a bit
confusing in a function, and this PR make it less confusing.

closes: vim/vim#16574

https://github.com/vim/vim/commit/449c2e5454735fe1cfc8c21b2c6880d6bdf4cd6e