### PR TITLE
test(terminal/cursor_spec): remove unnecessary busy handlers

### DIFF
--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -381,9 +381,6 @@ describe('buffer cursor position is correct in terminal without number column', 
     }, {
       cols = 70,
     })
-    -- Also check for real cursor position, as it is used for stuff like input methods
-    screen._handle_busy_start = function() end
-    screen._handle_busy_stop = function() end
     screen:expect([[
                                                                             |*4
       Entering Ex mode.  Type "visual" to go to Normal mode.                |
@@ -692,9 +689,6 @@ describe('buffer cursor position is correct in terminal with number column', fun
     }, {
       cols = 70,
     })
-    -- Also check for real cursor position, as it is used for stuff like input methods
-    screen._handle_busy_start = function() end
-    screen._handle_busy_stop = function() end
     screen:expect([[
       {7:  1 }                                                                  |
       {7:  2 }                                                                  |


### PR DESCRIPTION
They are no longer necessary after #31562, as busy_start and busy_stop
are no longer emitted by terminal buffers with visible cursor.
