### PR TITLE
fix(docs): lsp - wrong override comment

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -119,7 +119,7 @@ Results in the configuration: >lua
     root_markers = { '.clangd', 'compile_commands.json' },
 
     -- From the clangd configuration in init.lua
-    -- Overrides the * configuration in init.lua
+    -- Overrides the clangd configuration in <rtp>/lsp/clangd.lua
     filetypes = { 'c' },
 
     -- From the * configuration in init.lua


### PR DESCRIPTION
based on the examples above:
- the `<rtp>/lsp/clangd.lua` filetypes are overridden
- not the `*` config in init.lua

```
  -- Defined in init.lua
  vim.lsp.config('*', {
    capabilities = {
      textDocument = {
        semanticTokens = {
          multilineTokenSupport = true,
        }
      }
    },
    root_markers = { '.git' },
  })
  -- Defined in ../lsp/clangd.lua
  return {
    cmd = { 'clangd' },
    root_markers = { '.clangd', 'compile_commands.json' },
    filetypes = { 'c', 'cpp' },
  }
  -- Defined in init.lua
  vim.lsp.config('clangd', {
    filetypes = { 'c' },
  })
  ```
  
Correct:
  ```
  -- From the clangd configuration in init.lua
  -- Overrides the clangd configuration in <rtp>/lsp/clangd.lua
 filetypes = { 'c' },
 ```