### PR TITLE
feat(treesitter): show which nodes are missing in InspectTree

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -381,6 +381,7 @@ TREESITTER
   queries in addition to overriding.
 • |LanguageTree:is_valid()| now accepts a range parameter to narrow the scope
   of the validity check.
+• |:InspectTree| now shows which nodes are missing.
 
 TUI
 

--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -224,9 +224,12 @@ function TSTreeView:draw(bufnr)
 
     local text ---@type string
     if item.node:named() then
-      text = string.format('(%s', item.node:type())
+      text = string.format('(%s%s', item.node:missing() and 'MISSING ' or '', item.node:type())
     else
       text = string.format('%q', item.node:type()):gsub('\n', 'n')
+      if item.node:missing() then
+        text = string.format('(MISSING %s)', text)
+      end
     end
     if item.field then
       text = string.format('%s: %s', item.field, text)


### PR DESCRIPTION
Now `:InspectTree` will show missing nodes as e.g. `(MISSING identifier)` or `(MISSING ";")` rather than just `(identifier)` or `";"`. This is doable because the `MISSING` keyword is now valid query syntax.