### PR TITLE
vim-patch:9.1.1076: vim_strnchr() is strange and unnecessary

### DIFF
--- a/runtime/doc/dev_vimpatch.txt
+++ b/runtime/doc/dev_vimpatch.txt
@@ -184,7 +184,6 @@ information.
   mch_memmove                                             memmove
   vim_memset copy_chars copy_spaces                       memset
   vim_strbyte                                             strchr
-  vim_strnchr                                            strnchr
   vim_strncpy strncpy                               xstrlcpy/xmemcpyz
   vim_strcat strncat                                     xstrlcat
   VIM_ISWHITE                                          ascii_iswhite

--- a/src/nvim/linematch.c
+++ b/src/nvim/linematch.c
@@ -32,12 +32,8 @@ struct diffcmppath_S {
 static size_t line_len(const mmfile_t *m)
 {
   char *s = m->ptr;
-  size_t n = (size_t)m->size;
-  char *end = strnchr(s, &n, '\n');
-  if (end) {
-    return (size_t)(end - s);
-  }
-  return (size_t)m->size;
+  char *end = memchr(s, '\n', (size_t)m->size);
+  return end ? (size_t)(end - s) : (size_t)m->size;
 }
 
 #define MATCH_CHAR_MAX_LEN 800
@@ -148,9 +144,9 @@ static int count_n_matched_chars(mmfile_t **sp, const size_t n, bool iwhite)
 mmfile_t fastforward_buf_to_lnum(mmfile_t s, linenr_T lnum)
 {
   for (int i = 0; i < lnum - 1; i++) {
-    size_t n = (size_t)s.size;
-    s.ptr = strnchr(s.ptr, &n, '\n');
-    s.size = (int)n;
+    char *line_end = memchr(s.ptr, '\n', (size_t)s.size);
+    s.size = line_end ? (int)(s.size - (line_end - s.ptr)) : 0;
+    s.ptr = line_end;
     if (!s.ptr) {
       break;
     }

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -498,20 +498,6 @@ char *vim_strchr(const char *const string, const int c)
   }
 }
 
-// Sized version of strchr that can handle embedded NULs.
-// Adjusts n to the new size.
-char *strnchr(const char *p, size_t *n, int c)
-{
-  while (*n > 0) {
-    if (*p == c) {
-      return (char *)p;
-    }
-    p++;
-    (*n)--;
-  }
-  return NULL;
-}
-
 // Sort an array of strings.
 
 static int sort_compare(const void *s1, const void *s2)


### PR DESCRIPTION
#### vim-patch:9.1.1076: vim_strnchr() is strange and unnecessary

Problem:  vim_strnchr() is strange and unnecessary (after v9.1.1009)
Solution: Remove vim_strnchr() and use memchr() instead.  Also remove a
          comment referencing an #if that is no longer present.

vim_strnchr() is strange in several ways:
- It's named like vim_strchr(), but unlike vim_strchr() it doesn't
  support finding a multibyte char.
- Its logic is similar to vim_strbyte(), but unlike vim_strbyte() it
  uses char instead of char_u.
- It takes a pointer as its size argument, which isn't convenient for
  all its callers.
- It allows embedded NULs, unlike other "strn*" functions which stop
  when encountering a NUL byte.

In comparison, memchr() also allows embedded NULs, and it converts bytes
in the string to (unsigned char).

closes: vim/vim#16579

https://github.com/vim/vim/commit/34e1e8de91ff4a8922d454e3147ea425784aa0a0