### PR TITLE
refactor(tui): disable kitty key event reporting

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -299,7 +299,7 @@ void tui_set_key_encoding(TUIData *tui)
     // Progressive enhancement flags:
     //   0b01   (1) Disambiguate escape codes
     //   0b10   (2) Report event types
-    out(tui, S_LEN("\x1b[>3u"));
+    out(tui, S_LEN("\x1b[>1u"));
     break;
   case kKeyEncodingXterm:
     out(tui, S_LEN("\x1b[>4;2m"));


### PR DESCRIPTION
Temporary measure for the stable release. Re-enable for nightly after 0.11 release.