### PR TITLE
fix(log): RPC log format

### DIFF
--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -44,17 +44,20 @@
 
 static void log_request(char *dir, uint64_t channel_id, uint32_t req_id, const char *name)
 {
-  DLOGN("RPC %s %" PRIu64 ": %s id=%u: %s\n", dir, channel_id, REQ, req_id, name);
+  logmsg(LOGLVL_DBG, "RPC: ", NULL, -1, false, "%s %" PRIu64 ": %s id=%u: %s\n", dir, channel_id,
+         REQ, req_id, name);
 }
 
 static void log_response(char *dir, uint64_t channel_id, char *kind, uint32_t req_id)
 {
-  DLOGN("RPC %s %" PRIu64 ": %s id=%u\n", dir, channel_id, kind, req_id);
+  logmsg(LOGLVL_DBG, "RPC: ", NULL, -1, false, "%s %" PRIu64 ": %s id=%u\n", dir, channel_id, kind,
+         req_id);
 }
 
 static void log_notify(char *dir, uint64_t channel_id, const char *name)
 {
-  DLOGN("RPC %s %" PRIu64 ": %s %s\n", dir, channel_id, NOT, name);
+  logmsg(LOGLVL_DBG, "RPC: ", NULL, -1, false, "%s %" PRIu64 ": %s %s\n", dir, channel_id, NOT,
+         name);
 }
 
 #else


### PR DESCRIPTION
Problem:
RPC log messages show `log_notify` function name, which is not useful:

    DBG 2025-02-04T22:28:02.419 ui.37862   log_notify:57: RPC -> 3: [notify]    nvim_ui_set_focus
    DBG 2025-02-04T22:28:02.419 nvim.37863.0 log_notify:57: RPC <- 1: [notify]    nvim_ui_set_focus

Solution:
Call logmsg() directly.

    DBG 2025-02-04T22:42:00.104 ui.40680   RPC: -> 3: [notify]    nvim_ui_attach
    DBG 2025-02-04T22:42:00.104 ui.40680   RPC: -> 3: [notify]    nvim_set_client_info