### PR TITLE
vim-patch:9.1.1077: included syntax items do not understand contains=TOP

### DIFF
--- a/src/nvim/syntax.h
+++ b/src/nvim/syntax.h
@@ -7,25 +7,26 @@
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
 enum {
-  HL_CONTAINED   = 0x01,     ///< not used on toplevel
-  HL_TRANSP      = 0x02,     ///< has no highlighting
-  HL_ONELINE     = 0x04,     ///< match within one line only
-  HL_HAS_EOL     = 0x08,     ///< end pattern that matches with $
-  HL_SYNC_HERE   = 0x10,     ///< sync point after this item (syncing only)
-  HL_SYNC_THERE  = 0x20,     ///< sync point at current line (syncing only)
-  HL_MATCH       = 0x40,     ///< use match ID instead of item ID
-  HL_SKIPNL      = 0x80,     ///< nextgroup can skip newlines
-  HL_SKIPWHITE   = 0x100,    ///< nextgroup can skip white space
-  HL_SKIPEMPTY   = 0x200,    ///< nextgroup can skip empty lines
-  HL_KEEPEND     = 0x400,    ///< end match always kept
-  HL_EXCLUDENL   = 0x800,    ///< exclude NL from match
-  HL_DISPLAY     = 0x1000,   ///< only used for displaying, not syncing
-  HL_FOLD        = 0x2000,   ///< define fold
-  HL_EXTEND      = 0x4000,   ///< ignore a keepend
-  HL_MATCHCONT   = 0x8000,   ///< match continued from previous line
-  HL_TRANS_CONT  = 0x10000,  ///< transparent item without contains arg
-  HL_CONCEAL     = 0x20000,  ///< can be concealed
-  HL_CONCEALENDS = 0x40000,  ///< can be concealed
+  HL_CONTAINED         = 0x01,     ///< not used on toplevel
+  HL_TRANSP            = 0x02,     ///< has no highlighting
+  HL_ONELINE           = 0x04,     ///< match within one line only
+  HL_HAS_EOL           = 0x08,     ///< end pattern that matches with $
+  HL_SYNC_HERE         = 0x10,     ///< sync point after this item (syncing only)
+  HL_SYNC_THERE        = 0x20,     ///< sync point at current line (syncing only)
+  HL_MATCH             = 0x40,     ///< use match ID instead of item ID
+  HL_SKIPNL            = 0x80,     ///< nextgroup can skip newlines
+  HL_SKIPWHITE         = 0x100,    ///< nextgroup can skip white space
+  HL_SKIPEMPTY         = 0x200,    ///< nextgroup can skip empty lines
+  HL_KEEPEND           = 0x400,    ///< end match always kept
+  HL_EXCLUDENL         = 0x800,    ///< exclude NL from match
+  HL_DISPLAY           = 0x1000,   ///< only used for displaying, not syncing
+  HL_FOLD              = 0x2000,   ///< define fold
+  HL_EXTEND            = 0x4000,   ///< ignore a keepend
+  HL_MATCHCONT         = 0x8000,   ///< match continued from previous line
+  HL_TRANS_CONT        = 0x10000,  ///< transparent item without contains arg
+  HL_CONCEAL           = 0x20000,  ///< can be concealed
+  HL_CONCEALENDS       = 0x40000,  ///< can be concealed
+  HL_INCLUDED_TOPLEVEL = 0x80000,  ///< toplevel item in included syntax, allowed by contains=TOP
 };
 
 #define SYN_GROUP_STATIC(s) syn_check_group(S_LEN(s))

--- a/test/old/testdir/test_syntax.vim
+++ b/test/old/testdir/test_syntax.vim
@@ -944,7 +944,7 @@ func Test_syn_contained_transparent()
 endfunc
 
 func Test_syn_include_contains_TOP()
-  let l:case = "TOP in included syntax means its group list name"
+  let l:case = "TOP in included syntax refers to top level of that included syntax"
   new
   syntax include @INCLUDED syntax/c.vim
   syntax region FencedCodeBlockC start=/```c/ end=/```/ contains=@INCLUDED
@@ -955,6 +955,18 @@ func Test_syn_include_contains_TOP()
   " cCppOutElse has contains=TOP
   let l:expected = ["cType"]
   eval AssertHighlightGroups(5, 1, l:expected, 1, l:case)
+  syntax clear
+  bw!
+endfunc
+
+func Test_syn_include_contains_TOP_excluding()
+  new
+  syntax include @INCLUDED syntax/c.vim
+  syntax region FencedCodeBlockC start=/```c/ end=/```/ contains=@INCLUDED
+
+  call setline(1,  ['```c', '#if 0', 'int', '#else', 'int', '#if', '#endif', '```' ])
+  let l:expected = ["cCppOutElse", "cConditional"]
+  eval AssertHighlightGroups(6, 1, l:expected, 1)
   syntax clear
   bw!
 endfunc


### PR DESCRIPTION
Fix #20456

#### vim-patch:9.1.1077: included syntax items do not understand contains=TOP

Problem:  Syntax engine interpreted contains=TOP as matching nothing
          inside included files, since :syn-include forces HL_CONTAINED
          on for every included item. After 8.2.2761, interprets
          contains=TOP as contains=@INCLUDED, which is also not correct
          since it doesn't respect exclusions, and doesn't work if there
          is no @INCLUDED cluster.
Solution: revert patch 8.2.2761, instead track groups that have had
          HL_CONTAINED forced, and interpret contains=TOP and
          contains=CONTAINED using this. (Theodore Dubois)

closes: vim/vim#16571

https://github.com/vim/vim/commit/f50d5364d790619a3b982a3ad3658b5a10daf511

Co-authored-by: Theodore Dubois <tblodt@icloud.com>