### PR TITLE
docs(diagnostic): clarify `DiagnosticChanged` granularity

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -373,7 +373,7 @@ EVENTS                                                  *diagnostic-events*
                                                         *DiagnosticChanged*
 DiagnosticChanged       After diagnostics have changed. When used from Lua,
                         the new diagnostics are passed to the autocmd
-                        callback in the "data" table.
+                        callback in the "data" table. Triggered per buffer.
 
 Example: >lua
 


### PR DESCRIPTION
Problem: No user documentation about how granular `DiagnosticChanged`
  is triggered and it is not 100% clear from other parts of help page.
  Specifically, `vim.diagnostic.reset()` because can be called for all
  buffers.

Solution: Add explicit mention that it is triggered per buffer.