### PR TITLE
fix(lsp): check for valid buf before processing semantic tokens response

### DIFF
--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -337,6 +337,10 @@ function STHighlighter:process_response(response, client, version)
     return
   end
 
+  if not api.nvim_buf_is_valid(self.bufnr) then
+    return
+  end
+
   -- if we have a response to a delta request, update the state of our tokens
   -- appropriately. if it's a full response, just use that
   local tokens ---@type integer[]
@@ -376,8 +380,10 @@ function STHighlighter:process_response(response, client, version)
   current_result.highlights = highlights
   current_result.namespace_cleared = false
 
-  -- redraw all windows displaying buffer
-  api.nvim__redraw({ buf = self.bufnr, valid = true })
+  -- redraw all windows displaying buffer (if still valid)
+  if api.nvim_buf_is_valid(self.bufnr) then
+    api.nvim__redraw({ buf = self.bufnr, valid = true })
+  end
 end
 
 --- @param bufnr integer


### PR DESCRIPTION
Problem: There is no check for buffer validity before processing
  semantic tokens response. This can lead to `Invalid buffer id` error
  if processing request takes a long time and the buffer is wiped out.

  For example, this can happen after by accident navigating to a buffer
  from different project which leads to first loading project's
  workspace and *then* processing semantic tokens. During that time
  a buffer can be wiped out, as navigation to it was by accident.

Solution: Add extra check for buffer validity before processing semantic
  tokens response.