### PR TITLE
build: add luals check

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -58,6 +58,10 @@ jobs:
         run: cmake --build build --target lintlua-stylua
 
       - if: success() || failure() && steps.abort_job.outputs.status == 'success'
+        name: luals
+        run: cmake --build build --target luals
+
+      - if: success() || failure() && steps.abort_job.outputs.status == 'success'
         name: luacheck
         run: cmake --build build --target lintlua-luacheck
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -321,3 +321,33 @@ if(USE_BUNDLED_BUSTED)
 else()
   add_custom_target(lua_dev_deps)
 endif()
+
+if (CMAKE_SYSTEM_PROCESSOR MATCHES arm64)
+  set(LUALS_ARCH arm64)
+else()
+  set(LUALS_ARCH x64)
+endif()
+
+set(LUALS_VERSION 3.13.6)
+set(LUALS "lua-language-server-${LUALS_VERSION}-${CMAKE_SYSTEM_NAME}-${LUALS_ARCH}")
+set(LUALS_TARBALL ${LUALS}.tar.gz)
+set(LUALS_URL https://github.com/LuaLS/lua-language-server/releases/download/${LUALS_VERSION}/${LUALS_TARBALL})
+
+ExternalProject_Add(download_luals
+  URL ${LUALS_URL}
+  DOWNLOAD_DIR ${DEPS_DOWNLOAD_DIR}/luals
+  SOURCE_DIR ${DEPS_BIN_DIR}/luals
+  CONFIGURE_COMMAND ""
+  BUILD_COMMAND ""
+  INSTALL_COMMAND ""
+  EXCLUDE_FROM_ALL TRUE
+  DOWNLOAD_NO_PROGRESS TRUE
+  CMAKE_CACHE_ARGS ${DEPS_CMAKE_CACHE_ARGS})
+
+file(GLOB_RECURSE LUAFILES runtime/*.lua)
+add_target(luals
+  COMMAND ${DEPS_BIN_DIR}/luals/bin/lua-language-server --configpath=${PROJECT_SOURCE_DIR}/.luarc.json --check=${PROJECT_SOURCE_DIR}/runtime
+  DEPENDS ${LUAFILES}
+  CUSTOM_COMMAND_ARGS USES_TERMINAL)
+
+add_dependencies(luals download_luals)

--- a/Makefile
+++ b/Makefile
@@ -126,7 +126,7 @@ functionaltest-lua: | nvim
 	$(CMAKE) --build build --target functionaltest
 
 FORMAT=formatc formatlua format
-LINT=lintlua lintsh lintc clang-analyzer lintcommit lintdoc lint
+LINT=lintlua lintsh lintc clang-analyzer lintcommit lintdoc lint luals
 TEST=functionaltest unittest
 generated-sources benchmark $(FORMAT) $(LINT) $(TEST) doc: | build/.ran-cmake
 	$(CMAKE) --build build --target $@

--- a/runtime/autoload/ccomplete.lua
+++ b/runtime/autoload/ccomplete.lua
@@ -5,7 +5,8 @@
 
 -- Ignore "value assigned to a local variable is unused" because
 --  we can't guarantee that local variables will be used by plugins
--- luacheck: ignore 311
+-- luacheck: ignore
+--- @diagnostic disable
 
 local vim9 = require('_vim9script')
 local M = {}

--- a/runtime/lua/coxpcall.lua
+++ b/runtime/lua/coxpcall.lua
@@ -39,6 +39,7 @@ end
 -------------------------------------------------------------------------------
 -- Implements xpcall with coroutines
 -------------------------------------------------------------------------------
+---@diagnostic disable-next-line
 local performResume
 local oldpcall, oldxpcall = pcall, xpcall
 local pack = table.pack or function(...) return {n = select("#", ...), ...} end

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -7,7 +7,7 @@
 -- so this wouldn't be a separate case to consider)
 
 ---@nodoc
-_G.vim = _G.vim or {}
+_G.vim = _G.vim or {} --[[@as table]] -- TODO(lewis6991): better fix for flaky luals
 
 ---@generic T
 ---@param orig T

--- a/runtime/pack/dist/opt/cfilter/plugin/cfilter.lua
+++ b/runtime/pack/dist/opt/cfilter/plugin/cfilter.lua
@@ -5,7 +5,8 @@
 
 -- Ignore "value assigned to a local variable is unused" because
 --  we can't guarantee that local variables will be used by plugins
--- luacheck: ignore 311
+-- luacheck: ignore
+--- @diagnostic disable
 
 local vim9 = require('_vim9script')
 local M = {}


### PR DESCRIPTION
This automatically downloads and uses the correct luals binary for the
currently used system. `make luals` will run luals on all lua files in
`runtime`.

We download lua-language-server manually instead of relying on
contributors downloading it on their own (like with stylua) as
lua-language-server is updated frequently which may cause unnecessary
friction. Therefore, we download a pinned version of luals which we then
can manually bump when needed. This can be re-evaluated if luals becomes
more stable in the future.

Currently this is not run when using `make lint` since cmake style "file
caching" doesn't seem possible at the moment. This is because checking a
single file doesn't seem to work.

Work on https://github.com/neovim/neovim/issues/24563.