### PR TITLE
vim-patch:9.1.1080: filetype: Mill files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1074,6 +1074,7 @@ local extension = {
   sass = 'sass',
   sbt = 'sbt',
   scala = 'scala',
+  mill = 'scala',
   ss = 'scheme',
   scm = 'scheme',
   sld = 'scheme',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -671,7 +671,7 @@ func s:GetFilenameChecks() abort
     \ 'sas': ['file.sas'],
     \ 'sass': ['file.sass'],
     \ 'sbt': ['file.sbt'],
-    \ 'scala': ['file.scala'],
+    \ 'scala': ['file.scala', 'file.mill'],
     \ 'scheme': ['file.scm', 'file.ss', 'file.sld', 'file.stsg', 'any/local/share/supertux2/config', '.lips_repl_history'],
     \ 'scilab': ['file.sci', 'file.sce'],
     \ 'screen': ['.screenrc', 'screenrc'],


### PR DESCRIPTION
Problem:  filetype: Mill files are not recognized
Solution: detect '*.mill' files as scala filetype
          (author)

In the past [Mill](https://mill-build.org/mill/index.html) build files
were always `build.sc` and treated as Scala files. However as the 0.12.x
series of mill you can create a `build.mill` file. You can see a lot of
examples of this if you search
[GitHub](https://github.com/search?q=build.mill&type=code). This small
change just ensures that if you have a `*.mill` file it treats it as a
Scala file.

closes: vim/vim#16585

https://github.com/vim/vim/commit/9c8f9b10fcb177fb07684626b49118dd2d2540b5

Co-authored-by: Chris Kipp <ckipp@pm.me>
