### PR TITLE
vim-patch:8.2.{0849,0931},9.1.1081

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -4597,6 +4597,7 @@ has({feature})                                                           *has()*
 			fname_case	Case in file names matters (for Darwin and MS-Windows
 					this is not present).
 			gui_running	Nvim has a GUI.
+			hurd		GNU/Hurd system.
 			iconv		Can use |iconv()| for conversion.
 			linux		Linux system.
 			mac		MacOS system.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -4148,6 +4148,7 @@ function vim.fn.globpath(path, expr, nosuf, list, allinks) end
 ---   fname_case  Case in file names matters (for Darwin and MS-Windows
 ---       this is not present).
 ---   gui_running  Nvim has a GUI.
+---   hurd    GNU/Hurd system.
 ---   iconv    Can use |iconv()| for conversion.
 ---   linux    Linux system.
 ---   mac    MacOS system.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -5119,6 +5119,7 @@ M.funcs = {
       	fname_case	Case in file names matters (for Darwin and MS-Windows
       			this is not present).
       	gui_running	Nvim has a GUI.
+      	hurd		GNU/Hurd system.
       	iconv		Can use |iconv()| for conversion.
       	linux		Linux system.
       	mac		MacOS system.

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3075,8 +3075,11 @@ static void f_gettext(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 static void f_has(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
   static const char *const has_list[] = {
-#if defined(BSD) && !defined(__APPLE__)
+#if defined(BSD) && !defined(__APPLE__) && !defined(__GNU__)
     "bsd",
+#endif
+#ifdef __GNU__
+    "hurd",
 #endif
 #ifdef __linux__
     "linux",

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -2711,11 +2711,10 @@ endfunc
 
 func Test_platform_name()
   " The system matches at most only one name.
-  let names = ['amiga', 'beos', 'bsd', 'hpux', 'linux', 'mac', 'qnx', 'sun', 'vms', 'win32', 'win32unix']
+  let names = ['amiga', 'bsd', 'hpux', 'linux', 'mac', 'qnx', 'sun', 'vms', 'win32', 'win32unix']
   call assert_inrange(0, 1, len(filter(copy(names), 'has(v:val)')))
 
   " Is Unix?
-  call assert_equal(has('beos'), has('beos') && has('unix'))
   call assert_equal(has('bsd'), has('bsd') && has('unix'))
   call assert_equal(has('hpux'), has('hpux') && has('unix'))
   call assert_equal(has('linux'), has('linux') && has('unix'))
@@ -2727,7 +2726,6 @@ func Test_platform_name()
 
   if has('unix') && executable('uname')
     let uname = system('uname')
-    call assert_equal(uname =~? 'BeOS', has('beos'))
     " GNU userland on BSD kernels (e.g., GNU/kFreeBSD) don't have BSD defined
     call assert_equal(uname =~? '\%(GNU/k\w\+\)\@<!BSD\|DragonFly', has('bsd'))
     call assert_equal(uname =~? 'HP-UX', has('hpux'))

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -2717,6 +2717,7 @@ func Test_platform_name()
   " Is Unix?
   call assert_equal(has('bsd'), has('bsd') && has('unix'))
   call assert_equal(has('hpux'), has('hpux') && has('unix'))
+  call assert_equal(has('hurd'), has('hurd') && has('unix'))
   call assert_equal(has('linux'), has('linux') && has('unix'))
   call assert_equal(has('mac'), has('mac') && has('unix'))
   call assert_equal(has('qnx'), has('qnx') && has('unix'))
@@ -2734,6 +2735,7 @@ func Test_platform_name()
     call assert_equal(uname =~? 'QNX', has('qnx'))
     call assert_equal(uname =~? 'SunOS', has('sun'))
     call assert_equal(uname =~? 'CYGWIN\|MSYS', has('win32unix'))
+    call assert_equal(uname =~? 'GNU', has('hurd'))
   endif
 endfunc
 

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -2655,36 +2655,6 @@ func Test_func_exists_on_reload()
   delfunc ExistingFunction
 endfunc
 
-func Test_platform_name()
-  " The system matches at most only one name.
-  let names = ['amiga', 'beos', 'bsd', 'hpux', 'linux', 'mac', 'qnx', 'sun', 'vms', 'win32', 'win32unix']
-  call assert_inrange(0, 1, len(filter(copy(names), 'has(v:val)')))
-
-  " Is Unix?
-  call assert_equal(has('beos'), has('beos') && has('unix'))
-  call assert_equal(has('bsd'), has('bsd') && has('unix'))
-  call assert_equal(has('hpux'), has('hpux') && has('unix'))
-  call assert_equal(has('linux'), has('linux') && has('unix'))
-  call assert_equal(has('mac'), has('mac') && has('unix'))
-  call assert_equal(has('qnx'), has('qnx') && has('unix'))
-  call assert_equal(has('sun'), has('sun') && has('unix'))
-  call assert_equal(has('win32'), has('win32') && !has('unix'))
-  call assert_equal(has('win32unix'), has('win32unix') && has('unix'))
-
-  if has('unix') && executable('uname')
-    let uname = system('uname')
-    call assert_equal(uname =~? 'BeOS', has('beos'))
-    " GNU userland on BSD kernels (e.g., GNU/kFreeBSD) don't have BSD defined
-    call assert_equal(uname =~? '\%(GNU/k\w\+\)\@<!BSD\|DragonFly', has('bsd'))
-    call assert_equal(uname =~? 'HP-UX', has('hpux'))
-    call assert_equal(uname =~? 'Linux', has('linux'))
-    call assert_equal(uname =~? 'Darwin', has('mac'))
-    call assert_equal(uname =~? 'QNX', has('qnx'))
-    call assert_equal(uname =~? 'SunOS', has('sun'))
-    call assert_equal(uname =~? 'CYGWIN\|MSYS', has('win32unix'))
-  endif
-endfunc
-
 " Test confirm({msg} [, {choices} [, {default} [, {type}]]])
 func Test_confirm()
   CheckUnix
@@ -2737,6 +2707,36 @@ func Test_confirm()
   call assert_fails('call confirm("Are you sure?", [])', 'E730:')
   call assert_fails('call confirm("Are you sure?", "&Yes\n&No\n", [])', 'E745:')
   call assert_fails('call confirm("Are you sure?", "&Yes\n&No\n", 0, [])', 'E730:')
+endfunc
+
+func Test_platform_name()
+  " The system matches at most only one name.
+  let names = ['amiga', 'beos', 'bsd', 'hpux', 'linux', 'mac', 'qnx', 'sun', 'vms', 'win32', 'win32unix']
+  call assert_inrange(0, 1, len(filter(copy(names), 'has(v:val)')))
+
+  " Is Unix?
+  call assert_equal(has('beos'), has('beos') && has('unix'))
+  call assert_equal(has('bsd'), has('bsd') && has('unix'))
+  call assert_equal(has('hpux'), has('hpux') && has('unix'))
+  call assert_equal(has('linux'), has('linux') && has('unix'))
+  call assert_equal(has('mac'), has('mac') && has('unix'))
+  call assert_equal(has('qnx'), has('qnx') && has('unix'))
+  call assert_equal(has('sun'), has('sun') && has('unix'))
+  call assert_equal(has('win32'), has('win32') && !has('unix'))
+  call assert_equal(has('win32unix'), has('win32unix') && has('unix'))
+
+  if has('unix') && executable('uname')
+    let uname = system('uname')
+    call assert_equal(uname =~? 'BeOS', has('beos'))
+    " GNU userland on BSD kernels (e.g., GNU/kFreeBSD) don't have BSD defined
+    call assert_equal(uname =~? '\%(GNU/k\w\+\)\@<!BSD\|DragonFly', has('bsd'))
+    call assert_equal(uname =~? 'HP-UX', has('hpux'))
+    call assert_equal(uname =~? 'Linux', has('linux'))
+    call assert_equal(uname =~? 'Darwin', has('mac'))
+    call assert_equal(uname =~? 'QNX', has('qnx'))
+    call assert_equal(uname =~? 'SunOS', has('sun'))
+    call assert_equal(uname =~? 'CYGWIN\|MSYS', has('win32unix'))
+  endif
 endfunc
 
 func Test_readdir()


### PR DESCRIPTION
#### vim-patch:8.2.0849: BeOS code is not maintained and probably unused

Problem:    BeOS code is not maintained and probably unused.
Solution:   Remove the BeOS code. (Emir Sari, closes vim/vim#5817)

https://github.com/vim/vim/commit/041c7107f23d3b49ab62c1d7e36af90421db8b63

N/A patches for version.c:
vim-patch:8.2.0931: some remarks about BeOS remain

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.1.1081: has('bsd') is true for GNU/Hurd

Problem:  has('bsd') is true for GNU/Hurd
Solution: exclude GNU/Hurd from BSD feature flag
          (Zhaoming Luo)

GNU/Hurd, like Mac OS X, is a BSD-based system. It should exclude
has('bsd') feature just like what Mac OS X does. The __GNU__ pre-defined
macro indicates it's compiled for GNU/Hurd.

closes: vim/vim#16580

https://github.com/vim/vim/commit/a41dfcd55b1744b44a47d2fc3feb5d5f6207a556

Co-authored-by: Zhaoming Luo <zhmingluo@163.com>
