### PR TITLE
vim-patch:b69cd52: runtime(misc): Add support for lz4 to tar & gzip plugin

### DIFF
--- a/runtime/autoload/tar.vim
+++ b/runtime/autoload/tar.vim
@@ -1,6 +1,5 @@
-" tar.vim: Handles browsing tarfiles
-"            AUTOLOAD PORTION
-" Date:		Nov 11, 2024
+" tar.vim: Handles browsing tarfiles -  AUTOLOAD PORTION
+" Date:		Feb 06, 2025
 " Version:	32b  (with modifications from the Vim Project)
 " Maintainer:	This runtime file is looking for a new maintainer.
 " Former Maintainer: Charles E Campbell
@@ -17,7 +16,6 @@
 "               By using this plugin, you agree that in no event will the
 "               copyright holder be liable for any damages resulting from
 "               the use of this software.
-"     call inputsave()|call input("Press <cr> to continue")|call inputrestore()
 " ---------------------------------------------------------------------
 " Load Once: {{{1
 if &cp || exists("g:loaded_tar")
@@ -32,8 +30,6 @@ if v:version < 702
 endif
 let s:keepcpo= &cpo
 set cpo&vim
-"DechoTabOn
-"call Decho("loading autoload/tar.vim")
 
 " ---------------------------------------------------------------------
 "  Default Settings: {{{1
@@ -96,7 +92,6 @@ if !exists("g:tar_shq")
  else
   let g:tar_shq= "'"
  endif
-" call Decho("g:tar_shq<".g:tar_shq.">")
 endif
 
 " ----------------
@@ -106,29 +101,23 @@ endif
 " ---------------------------------------------------------------------
 " tar#Browse: {{{2
 fun! tar#Browse(tarfile)
-"  call Dfunc("tar#Browse(tarfile<".a:tarfile.">)")
   let repkeep= &report
   set report=10
 
   " sanity checks
   if !executable(g:tar_cmd)
    redraw!
-"   call Decho('***error*** (tar#Browse) "'.g:tar_cmd.'" not available on your system')
    echohl Error | echo '***error*** (tar#Browse) "'.g:tar_cmd.'" not available on your system'
    let &report= repkeep
-"   call Dret("tar#Browse")
    return
   endif
   if !filereadable(a:tarfile)
-"   call Decho('a:tarfile<'.a:tarfile.'> not filereadable')
    if a:tarfile !~# '^\a\+://'
     " if it's an url, don't complain, let url-handlers such as vim do its thing
     redraw!
-"    call Decho("***error*** (tar#Browse) File not readable<".a:tarfile.">")
     echohl Error | echo "***error*** (tar#Browse) File not readable<".a:tarfile.">" | echohl None
    endif
    let &report= repkeep
-"   call Dret("tar#Browse : file<".a:tarfile."> not readable")
    return
   endif
   if &ma != 1
@@ -144,7 +133,6 @@ fun! tar#Browse(tarfile)
   set ft=tar
 
   " give header
-"  call Decho("printing header")
   let lastline= line("$")
   call setline(lastline+1,'" tar.vim version '.g:loaded_tar)
   call setline(lastline+2,'" Browsing tarfile '.a:tarfile)
@@ -161,10 +149,10 @@ fun! tar#Browse(tarfile)
   let curlast= line("$")
 
   if tarfile =~# '\.\(gz\)$'
-"   call Decho("1: exe silent r! gzip -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - ")
    exe "sil! r! gzip -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
 
-  elseif tarfile =~# '\.\(tgz\)$' || tarfile =~# '\.\(tbz\)$' || tarfile =~# '\.\(txz\)$' || tarfile =~# '\.\(tzst\)$'
+  elseif tarfile =~# '\.\(tgz\)$' || tarfile =~# '\.\(tbz\)$' || tarfile =~# '\.\(txz\)$' ||
+                          \ tarfile =~# '\.\(tzst\)$' || tarfile =~# '\.\(tlz4\)$'
    if has("unix") && executable("file")
     let filekind= system("file ".shellescape(tarfile,1))
    else
@@ -177,36 +165,34 @@ fun! tar#Browse(tarfile)
     exe "sil! r! xz -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
    elseif filekind =~ "Zstandard"
     exe "sil! r! zstd --decompress --stdout -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
+   elseif filekind =~ "LZ4"
+    exe "sil! r! lz4 --decompress --stdout -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
    else
     exe "sil! r! gzip -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
    endif
 
   elseif tarfile =~# '\.lrp'
-"   call Decho("2: exe silent r! cat -- ".shellescape(tarfile,1)."|gzip -d -c -|".g:tar_cmd." -".g:tar_browseoptions." - ")
    exe "sil! r! cat -- ".shellescape(tarfile,1)."|gzip -d -c -|".g:tar_cmd." -".g:tar_browseoptions." - "
   elseif tarfile =~# '\.\(bz2\|tbz\|tb2\)$'
-"   call Decho("3: exe silent r! bzip2 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - ")
    exe "sil! r! bzip2 -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
   elseif tarfile =~# '\.\(lzma\|tlz\)$'
-"   call Decho("3: exe silent r! lzma -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - ")
    exe "sil! r! lzma -d -c -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
   elseif tarfile =~# '\.\(xz\|txz\)$'
-"   call Decho("3: exe silent r! xz --decompress --stdout -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - ")
    exe "sil! r! xz --decompress --stdout -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
   elseif tarfile =~# '\.\(zst\|tzst\)$'
    exe "sil! r! zstd --decompress --stdout -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
+  elseif tarfile =~# '\.\(lz4\|tlz4\)$'
+   exe "sil! r! lz4 --decompress --stdout -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_browseoptions." - "
   else
    if tarfile =~ '^\s*-'
     " A file name starting with a dash is taken as an option.  Prepend ./ to avoid that.
     let tarfile = substitute(tarfile, '-', './-', '')
    endif
-"   call Decho("4: exe silent r! ".g:tar_cmd." -".g:tar_browseoptions." ".shellescape(tarfile,0))
    exe "sil! r! ".g:tar_cmd." -".g:tar_browseoptions." ".shellescape(tarfile,1)
   endif
   if v:shell_error != 0
    redraw!
    echohl WarningMsg | echo "***warning*** (tar#Browse) please check your g:tar_browseoptions<".g:tar_browseoptions.">"
-"   call Dret("tar#Browse : a:tarfile<".a:tarfile.">")
    return
   endif
   "
@@ -237,29 +223,24 @@ fun! tar#Browse(tarfile)
   endif
 
   let &report= repkeep
-"  call Dret("tar#Browse : b:tarfile<".b:tarfile.">")
 endfun
 
 " ---------------------------------------------------------------------
 " TarBrowseSelect: {{{2
 fun! s:TarBrowseSelect()
-"  call Dfunc("TarBrowseSelect() b:tarfile<".b:tarfile."> curfile<".expand("%").">")
   let repkeep= &report
   set report=10
   let fname= getline(".")
-"  call Decho("fname<".fname.">")
 
   if !exists("g:tar_secure") && fname =~ '^\s*-\|\s\+-'
    redraw!
    echohl WarningMsg | echo '***warning*** (tar#BrowseSelect) rejecting tarfile member<'.fname.'> because of embedded "-"'
-"   call Dret('tar#BrowseSelect : rejecting tarfile member<'.fname.'> because of embedded "-"')
    return
   endif
 
   " sanity check
   if fname =~ '^"'
    let &report= repkeep
-"   call Dret("TarBrowseSelect")
    return
   endif
 
@@ -283,19 +264,17 @@ fun! s:TarBrowseSelect()
   exe 'com! -buffer -nargs=? -complete=file TarDiff	:call tar#Diff(<q-args>,"'.fnameescape(fname).'")'
 
   let &report= repkeep
-"  call Dret("TarBrowseSelect : s:tblfile_".winnr()."<".s:tblfile_{winnr()}.">")
 endfun
 
 " ---------------------------------------------------------------------
 " tar#Read: {{{2
 fun! tar#Read(fname,mode)
-"  call Dfunc("tar#Read(fname<".a:fname.">,mode=".a:mode.")")
   let repkeep= &report
   set report=10
   let tarfile = substitute(a:fname,'tarfile:\(.\{-}\)::.*$','\1','')
   let fname   = substitute(a:fname,'tarfile:.\{-}::\(.*\)$','\1','')
 
-" changing the directory to the temporary earlier to allow tar to extract the file with permissions intact
+  " changing the directory to the temporary earlier to allow tar to extract the file with permissions intact
   if !exists("*mkdir")
    redraw!
    echohl Error | echo "***error*** (tar#Write) sorry, mkdir() doesn't work on your system" | echohl None
@@ -333,8 +312,6 @@ fun! tar#Read(fname,mode)
    " assuming cygwin
    let tarfile=substitute(system("cygpath -u ".shellescape(tarfile,0)),'\n$','','e')
   endif
-"  call Decho("tarfile<".tarfile.">")
-"  call Decho("fname<".fname.">")
 
   if  fname =~ '\.bz2$' && executable("bzcat")
    let decmp= "|bzcat"
@@ -350,6 +327,9 @@ fun! tar#Read(fname,mode)
    let doro = 1
   elseif  fname =~ '\.zst$' && executable("zstdcat")
    let decmp= "|zstdcat"
+   let doro = 1
+  elseif  fname =~ '\.lz4$' && executable("lz4cat")
+   let decmp= "|lz4cat"
    let doro = 1
   else
    let decmp=""
@@ -400,12 +380,14 @@ fun! tar#Read(fname,mode)
   elseif tarfile =~# '\.\(xz\|txz\)$'
    exe "sil! r! xz --decompress --stdout -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_readoptions." - ".tar_secure.shellescape(fname,1).decmp
    exe "read ".fname
+  elseif tarfile =~# '\.\(lz4\|tlz4\)$'
+   exe "sil! r! lz4 --decompress --stdout -- ".shellescape(tarfile,1)." | ".g:tar_cmd." -".g:tar_readoptions." - ".tar_secure.shellescape(fname,1).decmp
+   exe "read ".fname
   else
    if tarfile =~ '^\s*-'
     " A file name starting with a dash is taken as an option.  Prepend ./ to avoid that.
     let tarfile = substitute(tarfile, '-', './-', '')
    endif
-"   call Decho("8: exe silent r! ".g:tar_cmd." -".g:tar_readoptions.tar_secure.shellescape(tarfile,1)." ".shellescape(fname,1).decmp)
    exe "silent r! ".g:tar_cmd." -".g:tar_readoptions.shellescape(tarfile,1)." ".tar_secure.shellescape(fname,1).decmp
    exe "read ".fname
   endif
@@ -432,16 +414,13 @@ if v:shell_error != 0
   set nomod
 
   let &report= repkeep
-"  call Dret("tar#Read : b:tarfile<".b:tarfile.">")
 endfun
 
 " ---------------------------------------------------------------------
 " tar#Write: {{{2
 fun! tar#Write(fname)
-"  call Dfunc("tar#Write(fname<".a:fname.">) b:tarfile<".b:tarfile."> tblfile_".winnr()."<".s:tblfile_{winnr()}.">")
   let repkeep= &report
   set report=10
-  
   " temporary buffer variable workaround because too fucking tired. but it works now
   let curdir= b:curdir
   let tmpdir= b:tmpdir
@@ -449,16 +428,13 @@ fun! tar#Write(fname)
   if !exists("g:tar_secure") && a:fname =~ '^\s*-\|\s\+-'
    redraw!
    echohl WarningMsg | echo '***warning*** (tar#Write) rejecting tarfile member<'.a:fname.'> because of embedded "-"'
-"   call Dret('tar#Write : rejecting tarfile member<'.fname.'> because of embedded "-"')
    return
   endif
 
   " sanity checks
   if !executable(g:tar_cmd)
    redraw!
-"   call Decho('***error*** (tar#Browse) "'.g:tar_cmd.'" not available on your system')
    let &report= repkeep
-"   call Dret("tar#Write")
    return
   endif
 
@@ -470,42 +446,37 @@ fun! tar#Write(fname)
    call system("bzip2 -d -- ".shellescape(tarfile,0))
    let tarfile = substitute(tarfile,'\.bz2','','e')
    let compress= "bzip2 -- ".shellescape(tarfile,0)
-"   call Decho("compress<".compress.">")
   elseif tarfile =~# '\.gz'
    call system("gzip -d -- ".shellescape(tarfile,0))
    let tarfile = substitute(tarfile,'\.gz','','e')
    let compress= "gzip -- ".shellescape(tarfile,0)
-"   call Decho("compress<".compress.">")
   elseif tarfile =~# '\.tgz'
    call system("gzip -d -- ".shellescape(tarfile,0))
    let tarfile = substitute(tarfile,'\.tgz','.tar','e')
    let compress= "gzip -- ".shellescape(tarfile,0)
    let tgz     = 1
-"   call Decho("compress<".compress.">")
   elseif tarfile =~# '\.xz'
    call system("xz -d -- ".shellescape(tarfile,0))
    let tarfile = substitute(tarfile,'\.xz','','e')
    let compress= "xz -- ".shellescape(tarfile,0)
-"   call Decho("compress<".compress.">")
   elseif tarfile =~# '\.zst'
    call system("zstd --decompress --rm -- ".shellescape(tarfile,0))
    let tarfile = substitute(tarfile,'\.zst','','e')
    let compress= "zstd --rm -- ".shellescape(tarfile,0)
+  elseif tarfile =~# '\.lz4'
+   call system("lz4 --decompress --rm -- ".shellescape(tarfile,0))
+   let tarfile = substitute(tarfile,'\.lz4','','e')
+   let compress= "lz4 --rm -- ".shellescape(tarfile,0)
   elseif tarfile =~# '\.lzma'
    call system("lzma -d -- ".shellescape(tarfile,0))
    let tarfile = substitute(tarfile,'\.lzma','','e')
    let compress= "lzma -- ".shellescape(tarfile,0)
-"   call Decho("compress<".compress.">")
   endif
-"  call Decho("tarfile<".tarfile.">")
 
   if v:shell_error != 0
    redraw!
-"   call Decho("***error*** (tar#Write) sorry, unable to update ".tarfile." with ".fname)
    echohl Error | echo "***error*** (tar#Write) sorry, unable to update ".tarfile." with ".fname | echohl None
   else
-
-"   call Decho("tarfile<".tarfile."> fname<".fname.">")
 
    if fname =~ '/'
     let dirpath = substitute(fname,'/[^/]\+$','','e')
@@ -521,7 +492,6 @@ fun! tar#Write(fname)
     " A file name starting with a dash may be taken as an option.  Prepend ./ to avoid that.
     let tarfile = substitute(tarfile, '-', './-', '')
    endif
-"   call Decho("tarfile<".tarfile."> fname<".fname.">")
 
    if exists("g:tar_secure")
     let tar_secure= " -- "
@@ -534,26 +504,20 @@ fun! tar#Write(fname)
    endif
 
    " delete old file from tarfile
-"   call Decho("system(".g:tar_cmd." ".g:tar_delfile." ".shellescape(tarfile,0)." -- ".shellescape(fname,0).")")
    call system(g:tar_cmd." ".g:tar_delfile." ".shellescape(tarfile,0).tar_secure.shellescape(fname,0))
    if v:shell_error != 0
     redraw!
-"    call Decho("***error*** (tar#Write) sorry, unable to update ".fnameescape(tarfile)." with ".fnameescape(fname))
     echohl Error | echo "***error*** (tar#Write) sorry, unable to update ".fnameescape(tarfile)." with ".fnameescape(fname) | echohl None
    else
 
     " update tarfile with new file
-"    call Decho(g:tar_cmd." -".g:tar_writeoptions." ".shellescape(tarfile,0).tar_secure.shellescape(fname,0))
     call system(g:tar_cmd." -".g:tar_writeoptions." ".shellescape(tarfile,0).tar_secure.shellescape(fname,0))
     if v:shell_error != 0
      redraw!
-"     call Decho("***error*** (tar#Write) sorry, unable to update ".fnameescape(tarfile)." with ".fnameescape(fname))
      echohl Error | echo "***error*** (tar#Write) sorry, unable to update ".fnameescape(tarfile)." with ".fnameescape(fname) | echohl None
     elseif exists("compress")
-"     call Decho("call system(".compress.")")
      call system(compress)
      if exists("tgz")
-"      call Decho("rename(".tarfile.".gz,".substitute(tarfile,'\.tar$','.tgz','e').")")
       call rename(tarfile.".gz",substitute(tarfile,'\.tar$','.tgz','e'))
      endif
     endif
@@ -561,7 +525,6 @@ fun! tar#Write(fname)
 
    " support writing tarfiles across a network
    if s:tblfile_{winnr()} =~ '^\a\+://'
-"    call Decho("handle writing <".tarfile."> across network to <".s:tblfile_{winnr()}.">")
     let tblfile= s:tblfile_{winnr()}
     1split|noswapfile enew
     let binkeep= &l:binary
@@ -583,13 +546,11 @@ fun! tar#Write(fname)
   setlocal nomod
 
   let &report= repkeep
-"  call Dret("tar#Write")
 endfun
 
 " ---------------------------------------------------------------------
 " tar#Diff: {{{2
 fun! tar#Diff(userfname,fname)
-"  call Dfunc("tar#Diff(userfname<".a:userfname."> fname<".a:fname.")")
   let fname= a:fname
   if a:userfname != ""
    let fname= a:userfname
@@ -607,133 +568,126 @@ fun! tar#Diff(userfname,fname)
    redraw!
    echo "***warning*** unable to read file<".fname.">"
   endif
-"  call Dret("tar#Diff")
 endfun
 
 " ---------------------------------------------------------------------
 " tar#Extract: extract a file from a (possibly compressed) tar archive {{{2
 fun! tar#Extract()
-"  call Dfunc("tar#Extract()")
 
   let repkeep= &report
   set report=10
   let fname= getline(".")
-"  call Decho("fname<".fname.">")
 
   if !exists("g:tar_secure") && fname =~ '^\s*-\|\s\+-'
    redraw!
    echohl WarningMsg | echo '***warning*** (tar#BrowseSelect) rejecting tarfile member<'.fname.'> because of embedded "-"'
-"   call Dret('tar#BrowseSelect : rejecting tarfile member<'.fname.'> because of embedded "-"')
    return
   endif
 
   " sanity check
   if fname =~ '^"'
    let &report= repkeep
-"   call Dret("TarBrowseSelect")
    return
   endif
 
   let tarball = expand("%")
-"  call Decho("tarball<".tarball.">")
   let tarbase = substitute(tarball,'\..*$','','')
-"  call Decho("tarbase<".tarbase.">")
 
   let extractcmd= netrw#WinPath(g:tar_extractcmd)
   if filereadable(tarbase.".tar")
-"   call Decho("system(".extractcmd." ".shellescape(tarbase).".tar ".shellescape(fname).")")
    call system(extractcmd." ".shellescape(tarbase).".tar ".shellescape(fname))
    if v:shell_error != 0
     echohl Error | echo "***error*** ".extractcmd." ".tarbase.".tar ".fname.": failed!" | echohl NONE
-"    call Decho("***error*** ".extractcmd." ".tarbase.".tar ".fname.": failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
   elseif filereadable(tarbase.".tgz")
    let extractcmd= substitute(extractcmd,"-","-z","")
-"   call Decho("system(".extractcmd." ".shellescape(tarbase).".tgz ".shellescape(fname).")")
    call system(extractcmd." ".shellescape(tarbase).".tgz ".shellescape(fname))
    if v:shell_error != 0
     echohl Error | echo "***error*** ".extractcmd." ".tarbase.".tgz ".fname.": failed!" | echohl NONE
-"    call Decho("***error*** ".extractcmd."t ".tarbase.".tgz ".fname.": failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
   elseif filereadable(tarbase.".tar.gz")
    let extractcmd= substitute(extractcmd,"-","-z","")
-"   call Decho("system(".extractcmd." ".shellescape(tarbase).".tar.gz ".shellescape(fname).")")
    call system(extractcmd." ".shellescape(tarbase).".tar.gz ".shellescape(fname))
    if v:shell_error != 0
     echohl Error | echo "***error*** ".extractcmd." ".tarbase.".tar.gz ".fname.": failed!" | echohl NONE
-"    call Decho("***error*** ".extractcmd." ".tarbase.".tar.gz ".fname.": failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
   elseif filereadable(tarbase.".tbz")
    let extractcmd= substitute(extractcmd,"-","-j","")
-"   call Decho("system(".extractcmd." ".shellescape(tarbase).".tbz ".shellescape(fname).")")
    call system(extractcmd." ".shellescape(tarbase).".tbz ".shellescape(fname))
    if v:shell_error != 0
     echohl Error | echo "***error*** ".extractcmd."j ".tarbase.".tbz ".fname.": failed!" | echohl NONE
-"    call Decho("***error*** ".extractcmd."j ".tarbase.".tbz ".fname.": failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
   elseif filereadable(tarbase.".tar.bz2")
    let extractcmd= substitute(extractcmd,"-","-j","")
-"   call Decho("system(".extractcmd." ".shellescape(tarbase).".tar.bz2 ".shellescape(fname).")")
    call system(extractcmd." ".shellescape(tarbase).".tar.bz2 ".shellescape(fname))
    if v:shell_error != 0
     echohl Error | echo "***error*** ".extractcmd."j ".tarbase.".tar.bz2 ".fname.": failed!" | echohl NONE
-"    call Decho("***error*** ".extractcmd."j ".tarbase.".tar.bz2 ".fname.": failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
   elseif filereadable(tarbase.".txz")
    let extractcmd= substitute(extractcmd,"-","-J","")
-"   call Decho("system(".extractcmd." ".shellescape(tarbase).".txz ".shellescape(fname).")")
    call system(extractcmd." ".shellescape(tarbase).".txz ".shellescape(fname))
    if v:shell_error != 0
     echohl Error | echo "***error*** ".extractcmd." ".tarbase.".txz ".fname.": failed!" | echohl NONE
-"    call Decho("***error*** ".extractcmd." ".tarbase.".txz ".fname.": failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
   elseif filereadable(tarbase.".tar.xz")
    let extractcmd= substitute(extractcmd,"-","-J","")
-"   call Decho("system(".extractcmd." ".shellescape(tarbase).".tar.xz ".shellescape(fname).")")
    call system(extractcmd." ".shellescape(tarbase).".tar.xz ".shellescape(fname))
    if v:shell_error != 0
     echohl Error | echo "***error*** ".extractcmd." ".tarbase.".tar.xz ".fname.": failed!" | echohl NONE
-"    call Decho("***error*** ".extractcmd." ".tarbase.".tar.xz ".fname.": failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
   elseif filereadable(tarbase.".tzst")
    let extractcmd= substitute(extractcmd,"-","--zstd","")
-"   call Decho("system(".extractcmd." ".shellescape(tarbase).".tzst ".shellescape(fname).")")
    call system(extractcmd." ".shellescape(tarbase).".tzst ".shellescape(fname))
    if v:shell_error != 0
     echohl Error | echo "***error*** ".extractcmd." ".tarbase.".tzst ".fname.": failed!" | echohl NONE
-"    call Decho("***error*** ".extractcmd." ".tarbase.".tzst ".fname.": failed!")
    else
     echo "***note*** successfully extracted ".fname
    endif
 
   elseif filereadable(tarbase.".tar.zst")
    let extractcmd= substitute(extractcmd,"-","--zstd","")
-"   call Decho("system(".extractcmd." ".shellescape(tarbase).".tar.zst ".shellescape(fname).")")
    call system(extractcmd." ".shellescape(tarbase).".tar.zst ".shellescape(fname))
    if v:shell_error != 0
     echohl Error | echo "***error*** ".extractcmd." ".tarbase.".tar.zst ".fname.": failed!" | echohl NONE
-"    call Decho("***error*** ".extractcmd." ".tarbase.".tar.zst ".fname.": failed!")
+   else
+    echo "***note*** successfully extracted ".fname
+   endif
+
+  elseif filereadable(tarbase.".tlz4")
+   let extractcmd= substitute(extractcmd,"-","-I lz4","")
+   call system(extractcmd." ".shellescape(tarbase).".tlz4 ".shellescape(fname))
+   if v:shell_error != 0
+    echohl Error | echo "***error*** ".extractcmd." ".tarbase.".tlz4 ".fname.": failed!" | echohl NONE
+   else
+    echo "***note*** successfully extracted ".fname
+   endif
+
+  elseif filereadable(tarbase.".tar.lz4")
+   let extractcmd= substitute(extractcmd,"-","-I lz4","")
+   call system(extractcmd." ".shellescape(tarbase).".tar.lz4".shellescape(fname))
+   if v:shell_error != 0
+    echohl Error | echo "***error*** ".extractcmd." ".tarbase.".tar.lz4 ".fname.": failed!" | echohl NONE
    else
     echo "***note*** successfully extracted ".fname
    endif
@@ -741,14 +695,11 @@ fun! tar#Extract()
 
   " restore option
   let &report= repkeep
-
-"  call Dret("tar#Extract")
 endfun
 
 " ---------------------------------------------------------------------
 " s:Rmdir: {{{2
 fun! s:Rmdir(fname)
-"  call Dfunc("Rmdir(fname<".a:fname.">)")
   if has("unix")
    call system("/bin/rm -rf -- ".shellescape(a:fname,0))
   elseif has("win32") || has("win95") || has("win64") || has("win16")
@@ -758,7 +709,6 @@ fun! s:Rmdir(fname)
     call system("del /S ".shellescape(a:fname,0))
    endif
   endif
-"  call Dret("Rmdir")
 endfun
 
 " =====================================================================

--- a/runtime/doc/pi_gzip.txt
+++ b/runtime/doc/pi_gzip.txt
@@ -28,12 +28,13 @@ The plugin installs autocommands to intercept reading and writing of files
 with these extensions:
 
 	extension	compression >
-	*.Z		compress (Lempel-Ziv)
-	*.gz		gzip
 	*.bz2		bzip2
+	*.gz		gzip
+	*.lz		lzip
+	*.lz4		lz4
 	*.lzma		lzma
 	*.xz		xz
-	*.lz		lzip
+	*.Z		compress (Lempel-Ziv)
 	*.zst		zstd
 
 That's actually the only thing you need to know.  There are no options.

--- a/runtime/plugin/gzip.vim
+++ b/runtime/plugin/gzip.vim
@@ -1,6 +1,6 @@
 " Vim plugin for editing compressed files.
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2023 Aug 10
+" Last Change:	2025 Feb 06
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Exit quickly when:
@@ -20,42 +20,50 @@ augroup gzip
   " The functions are defined in autoload/gzip.vim.
   "
   " Set binary mode before reading the file.
-  " Use "gzip -d", gunzip isn't always available.
-  autocmd BufReadPre,FileReadPre	*.gz,*.bz2,*.Z,*.lzma,*.xz,*.lz,*.zst,*.br,*.lzo setlocal bin
-  autocmd BufReadPost,FileReadPost	*.gz  call gzip#read("gzip -dn")
-  autocmd BufReadPost,FileReadPost	*.bz2 call gzip#read("bzip2 -d")
-  autocmd BufReadPost,FileReadPost	*.Z   call gzip#read("uncompress")
-  autocmd BufReadPost,FileReadPost	*.lzma call gzip#read("lzma -d")
-  autocmd BufReadPost,FileReadPost	*.xz  call gzip#read("xz -d")
-  autocmd BufReadPost,FileReadPost	*.lz  call gzip#read("lzip -d")
-  autocmd BufReadPost,FileReadPost	*.zst call gzip#read("zstd -d --rm")
+  autocmd BufReadPre,FileReadPre	*.gz,*.bz2,*.Z,*.lzma,*.xz,*.lz,*.zst,*.br,*.lzo,*.lz4 setlocal bin
+
+  " Use "gzip -d" and similar commands, gunzip isn't always available.
   autocmd BufReadPost,FileReadPost	*.br call gzip#read("brotli -d --rm")
+  autocmd BufReadPost,FileReadPost	*.bz2 call gzip#read("bzip2 -d")
+  autocmd BufReadPost,FileReadPost	*.gz  call gzip#read("gzip -dn")
+  autocmd BufReadPost,FileReadPost	*.lz  call gzip#read("lzip -d")
+  autocmd BufReadPost,FileReadPost	*.lz4 call gzip#read("lz4 -d -q --rm")
+  autocmd BufReadPost,FileReadPost	*.lzma call gzip#read("lzma -d")
   autocmd BufReadPost,FileReadPost	*.lzo call gzip#read("lzop -d -U")
-  autocmd BufWritePost,FileWritePost	*.gz  call gzip#write("gzip")
-  autocmd BufWritePost,FileWritePost	*.bz2 call gzip#write("bzip2")
-  autocmd BufWritePost,FileWritePost	*.Z   call gzip#write("compress -f")
-  autocmd BufWritePost,FileWritePost	*.lzma call gzip#write("lzma -z")
-  autocmd BufWritePost,FileWritePost	*.xz  call gzip#write("xz -z")
-  autocmd BufWritePost,FileWritePost	*.lz  call gzip#write("lzip")
-  autocmd BufWritePost,FileWritePost	*.zst  call gzip#write("zstd --rm")
+  autocmd BufReadPost,FileReadPost	*.xz  call gzip#read("xz -d")
+  autocmd BufReadPost,FileReadPost	*.Z   call gzip#read("uncompress")
+  autocmd BufReadPost,FileReadPost	*.zst call gzip#read("zstd -d --rm")
+
   autocmd BufWritePost,FileWritePost	*.br  call gzip#write("brotli --rm")
+  autocmd BufWritePost,FileWritePost	*.bz2 call gzip#write("bzip2")
+  autocmd BufWritePost,FileWritePost	*.gz  call gzip#write("gzip")
+  autocmd BufWritePost,FileWritePost	*.lz  call gzip#write("lzip")
+  autocmd BufWritePost,FileWritePost	*.lz4  call gzip#write("lz4 -q --rm")
+  autocmd BufWritePost,FileWritePost	*.lzma call gzip#write("lzma -z")
   autocmd BufWritePost,FileWritePost	*.lzo  call gzip#write("lzop -U")
-  autocmd FileAppendPre			*.gz  call gzip#appre("gzip -dn")
-  autocmd FileAppendPre			*.bz2 call gzip#appre("bzip2 -d")
-  autocmd FileAppendPre			*.Z   call gzip#appre("uncompress")
-  autocmd FileAppendPre			*.lzma call gzip#appre("lzma -d")
-  autocmd FileAppendPre			*.xz   call gzip#appre("xz -d")
-  autocmd FileAppendPre			*.lz   call gzip#appre("lzip -d")
-  autocmd FileAppendPre			*.zst call gzip#appre("zstd -d --rm")
+  autocmd BufWritePost,FileWritePost	*.xz  call gzip#write("xz -z")
+  autocmd BufWritePost,FileWritePost	*.Z   call gzip#write("compress -f")
+  autocmd BufWritePost,FileWritePost	*.zst  call gzip#write("zstd --rm")
+
   autocmd FileAppendPre			*.br call gzip#appre("brotli -d --rm")
+  autocmd FileAppendPre			*.bz2 call gzip#appre("bzip2 -d")
+  autocmd FileAppendPre			*.gz  call gzip#appre("gzip -dn")
+  autocmd FileAppendPre			*.lz   call gzip#appre("lzip -d")
+  autocmd FileAppendPre			*.lz4 call gzip#appre("lz4 -d -q --rm")
+  autocmd FileAppendPre			*.lzma call gzip#appre("lzma -d")
   autocmd FileAppendPre			*.lzo call gzip#appre("lzop -d -U")
-  autocmd FileAppendPost		*.gz  call gzip#write("gzip")
-  autocmd FileAppendPost		*.bz2 call gzip#write("bzip2")
-  autocmd FileAppendPost		*.Z   call gzip#write("compress -f")
-  autocmd FileAppendPost		*.lzma call gzip#write("lzma -z")
-  autocmd FileAppendPost		*.xz call gzip#write("xz -z")
-  autocmd FileAppendPost		*.lz call gzip#write("lzip")
-  autocmd FileAppendPost		*.zst call gzip#write("zstd --rm")
+  autocmd FileAppendPre			*.xz   call gzip#appre("xz -d")
+  autocmd FileAppendPre			*.Z   call gzip#appre("uncompress")
+  autocmd FileAppendPre			*.zst call gzip#appre("zstd -d --rm")
+
   autocmd FileAppendPost		*.br call gzip#write("brotli --rm")
+  autocmd FileAppendPost		*.bz2 call gzip#write("bzip2")
+  autocmd FileAppendPost		*.gz  call gzip#write("gzip")
+  autocmd FileAppendPost		*.lz call gzip#write("lzip")
+  autocmd FileAppendPost		*.lz4 call gzip#write("lz4 --rm")
+  autocmd FileAppendPost		*.lzma call gzip#write("lzma -z")
   autocmd FileAppendPost		*.lzo call gzip#write("lzop -U")
+  autocmd FileAppendPost		*.xz call gzip#write("xz -z")
+  autocmd FileAppendPost		*.Z   call gzip#write("compress -f")
+  autocmd FileAppendPost		*.zst call gzip#write("zstd --rm")
 augroup END

--- a/runtime/plugin/tarPlugin.vim
+++ b/runtime/plugin/tarPlugin.vim
@@ -1,4 +1,5 @@
 " tarPlugin.vim -- a Vim plugin for browsing tarfiles
+"
 " Original was copyright (c) 2002, Michael C. Toren <mct@toren.net>
 " Modified by Charles E. Campbell
 " Distributed under the GNU General Public License.
@@ -34,18 +35,20 @@ augroup tar
    au FileWriteCmd tarfile::*/*	call tar#Write(expand("<amatch>"))
   endif
 
-  au BufReadCmd   *.tar.gz		call tar#Browse(expand("<amatch>"))
-  au BufReadCmd   *.tar			call tar#Browse(expand("<amatch>"))
   au BufReadCmd   *.lrp			call tar#Browse(expand("<amatch>"))
+  au BufReadCmd   *.tar			call tar#Browse(expand("<amatch>"))
   au BufReadCmd   *.tar.bz2		call tar#Browse(expand("<amatch>"))
+  au BufReadCmd   *.tar.gz		call tar#Browse(expand("<amatch>"))
+  au BufReadCmd   *.tar.lz4		call tar#Browse(expand("<amatch>"))
+  au BufReadCmd   *.tar.lzma		call tar#Browse(expand("<amatch>"))
+  au BufReadCmd   *.tar.xz		call tar#Browse(expand("<amatch>"))
   au BufReadCmd   *.tar.Z		call tar#Browse(expand("<amatch>"))
+  au BufReadCmd   *.tar.zst		call tar#Browse(expand("<amatch>"))
   au BufReadCmd   *.tbz			call tar#Browse(expand("<amatch>"))
   au BufReadCmd   *.tgz			call tar#Browse(expand("<amatch>"))
-  au BufReadCmd   *.tar.lzma	call tar#Browse(expand("<amatch>"))
-  au BufReadCmd   *.tar.xz		call tar#Browse(expand("<amatch>"))
+  au BufReadCmd   *.tlz4		call tar#Browse(expand("<amatch>"))
   au BufReadCmd   *.txz			call tar#Browse(expand("<amatch>"))
-  au BufReadCmd   *.tar.zst		call tar#Browse(expand("<amatch>"))
-  au BufReadCmd   *.tzst			call tar#Browse(expand("<amatch>"))
+  au BufReadCmd   *.tzst		call tar#Browse(expand("<amatch>"))
 augroup END
 
 " ---------------------------------------------------------------------


### PR DESCRIPTION
#### vim-patch:b69cd52: runtime(misc): Add support for lz4 to tar & gzip plugin

while at it, clean up the tar plugin a bit and sort the patterns for the
tar and gzip plugin

References:
- https://github.com/lz4/lz4
- https://lz4.org/

closes: vim/vim#16591

https://github.com/vim/vim/commit/b69cd52447584cedadc1513aa3acd5b4cd9f4340

Co-authored-by: Corpulent Robin <177767857+corpulentrobin@users.noreply.github.com>