### PR TITLE
fix(messages): improve deadly signal messages

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -845,8 +845,9 @@ void preserve_exit(const char *errmsg)
     // For TUI: exit alternate screen so that the error messages can be seen.
     ui_client_stop();
   }
-  if (errmsg != NULL) {
-    fprintf(stderr, "%s\n", errmsg);
+  if (errmsg != NULL && errmsg[0] != NUL) {
+    size_t has_eol = '\n' == errmsg[strlen(errmsg) - 1];
+    fprintf(stderr, has_eol ? "%s" : "%s\n", errmsg);
   }
   if (ui_client_channel_id) {
     os_exit(1);
@@ -857,7 +858,7 @@ void preserve_exit(const char *errmsg)
   FOR_ALL_BUFFERS(buf) {
     if (buf->b_ml.ml_mfp != NULL && buf->b_ml.ml_mfp->mf_fname != NULL) {
       if (errmsg != NULL) {
-        fprintf(stderr, "Vim: preserving files...\r\n");
+        fprintf(stderr, "Nvim: preserving files...\n");
       }
       ml_sync_all(false, false, true);  // preserve all swap files
       break;
@@ -867,7 +868,7 @@ void preserve_exit(const char *errmsg)
   ml_close_all(false);              // close all memfiles, without deleting
 
   if (errmsg != NULL) {
-    fprintf(stderr, "Vim: Finished.\r\n");
+    fprintf(stderr, "Nvim: Finished.\n");
   }
 
   getout(1);

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -175,7 +175,7 @@ static void deadly_signal(int signum)
 
   ILOG("got signal %d (%s)", signum, signal_name(signum));
 
-  snprintf(IObuff, IOSIZE, "Vim: Caught deadly signal '%s'\r\n", signal_name(signum));
+  snprintf(IObuff, IOSIZE, "Nvim: Caught deadly signal '%s'\n", signal_name(signum));
 
   // Preserve files and exit.
   preserve_exit(IObuff);

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -1951,10 +1951,10 @@ describe('TUI', function()
     exec_lua([[vim.uv.kill(vim.fn.jobpid(vim.bo.channel), 'sigterm')]])
     screen:expect {
       grid = [[
-      Vim: Caught deadly signal 'SIGTERM'               |
-                                                        |*2
+      Nvim: Caught deadly signal 'SIGTERM'              |
+                                                        |
       [Process exited 1]^                                |
-                                                        |*2
+                                                        |*3
       {3:-- TERMINAL --}                                    |
     ]],
     }
@@ -3337,9 +3337,7 @@ describe('TUI bg color', function()
   end)
 end)
 
--- These tests require `tt` because --headless/--embed
--- does not initialize the TUI.
-describe('TUI as a client', function()
+describe('TUI client', function()
   after_each(function()
     os.remove(testlog)
   end)
@@ -3449,10 +3447,10 @@ describe('TUI as a client', function()
     exec_lua([[vim.uv.kill(vim.fn.jobpid(vim.bo.channel), 'sigterm')]])
     screen_client:expect {
       grid = [[
-      Vim: Caught deadly signal 'SIGTERM'               |
-                                                        |*2
+      Nvim: Caught deadly signal 'SIGTERM'              |
+                                                        |
       [Process exited 1]^                                |
-                                                        |*2
+                                                        |*3
       {3:-- TERMINAL --}                                    |
     ]],
     }


### PR DESCRIPTION
Problem:
Deadly signal messages mention "Vim", and add redundant newlines.

Solution:
- Update the messages.
- Don't add an extra newline.