### PR TITLE
vim-patch:9.1.1085: filetype: cmmt files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1191,6 +1191,7 @@ local extension = {
   svh = 'systemverilog',
   sv = 'systemverilog',
   cmm = 'trace32',
+  cmmt = 'trace32',
   t32 = 'trace32',
   td = 'tablegen',
   tak = 'tak',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -813,7 +813,7 @@ func s:GetFilenameChecks() abort
     \ 'tmux': ['tmuxfile.conf', '.tmuxfile.conf', '.tmux-file.conf', '.tmux.conf', 'tmux-file.conf', 'tmux.conf', 'tmux.conf.local'],
     \ 'toml': ['file.toml', 'Gopkg.lock', 'Pipfile', '/home/user/.cargo/config', '.black'],
     \ 'tpp': ['file.tpp'],
-    \ 'trace32': ['file.cmm', 'file.t32'],
+    \ 'trace32': ['file.cmm', 'file.cmmt', 'file.t32'],
     \ 'treetop': ['file.treetop'],
     \ 'trig': ['file.trig'],
     \ 'trustees': ['trustees.conf'],


### PR DESCRIPTION
Problem:  filetype: cmmt files are not recognized
Solution: detect '*.cmmt' as trace32 filetype
          (Christian Sax)

"*.cmmt" files use the same syntax as regular TRACE32 scripts,
but are intended as a kind of script template.

closes: vim/vim#16598

https://github.com/vim/vim/commit/746fe54d4f16ad1c5694cccc8bc8d93a97c050e1

Co-authored-by: Christoph Sax <c_sax@mailbox.org>
