### PR TITLE
vim-patch:8.2.{2933,2934,2935},9.1.1083

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5248,13 +5248,20 @@ static void str_to_reg(yankreg_T *y_ptr, MotionType yank_type, const char *str, 
          start < end + extraline;
          start += line_len + 1, lnum++) {
       int charlen = 0;
-      const char *line_end;
-      for (line_end = start; line_end < end; line_end++) {
+
+      const char *line_end = start;
+      while (line_end < end) {  // find the end of the line
         if (*line_end == '\n') {
           break;
         }
         if (yank_type == kMTBlockWise) {
           charlen += utf_ptr2cells_len(line_end, (int)(end - line_end));
+        }
+
+        if (*line_end == NUL) {
+          line_end++;  // registers can have NUL chars
+        } else {
+          line_end += utf_ptr2len_len(line_end, (int)(end - line_end));
         }
       }
       assert(line_end - start >= 0);

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -5236,10 +5236,11 @@ static void str_to_reg(yankreg_T *y_ptr, MotionType yank_type, const char *str, 
   // Find the end of each line and save it into the array.
   if (str_list) {
     for (char **ss = (char **)str; *ss != NULL; ss++, lnum++) {
-      int charlen = mb_charlen(*ss);
-      size_t ss_len = strlen(*ss);
-      pp[lnum] = cbuf_to_string(*ss, ss_len);
-      maxlen = MAX(maxlen, (size_t)charlen);
+      pp[lnum] = cstr_to_string(*ss);
+      if (yank_type == kMTBlockWise) {
+        size_t charlen = mb_string2cells(*ss);
+        maxlen = MAX(maxlen, charlen);
+      }
     }
   } else {
     size_t line_len;
@@ -5252,7 +5253,9 @@ static void str_to_reg(yankreg_T *y_ptr, MotionType yank_type, const char *str, 
         if (*line_end == '\n') {
           break;
         }
-        charlen += utf_ptr2cells_len(line_end, (int)(end - line_end));
+        if (yank_type == kMTBlockWise) {
+          charlen += utf_ptr2cells_len(line_end, (int)(end - line_end));
+        }
       }
       assert(line_end - start >= 0);
       line_len = (size_t)(line_end - start);

--- a/test/old/testdir/test_registers.vim
+++ b/test/old/testdir/test_registers.vim
@@ -435,6 +435,23 @@ func Test_set_register()
   enew!
 endfunc
 
+" Test for blockwise register width calculations
+func Test_set_register_blockwise_width()
+  " Test for regular calculations and overriding the width
+  call setreg('a', "12\n1234\n123", 'b')
+  call assert_equal("\<c-v>4", getreginfo('a').regtype)
+  call setreg('a', "12\n1234\n123", 'b1')
+  call assert_equal("\<c-v>1", getreginfo('a').regtype)
+  call setreg('a', "12\n1234\n123", 'b6')
+  call assert_equal("\<c-v>6", getreginfo('a').regtype)
+
+  " Test for Unicode parsing
+  call setreg('a', "z😅😅z\n12345", 'b')
+  call assert_equal("\<c-v>6", getreginfo('a').regtype)
+  call setreg('a', ["z😅😅z", "12345"], 'b')
+  call assert_equal("\<c-v>6", getreginfo('a').regtype)
+endfunc
+
 " Test for clipboard registers (* and +)
 func Test_clipboard_regs()
   throw 'skipped: needs clipboard=autoselect,autoselectplus'


### PR DESCRIPTION
#### vim-patch:8.2.2933: when 'clipboard' is "unnamed" zp does not work correctly

Problem:    When 'clipboard' is "unnamed" zp and zP do not work correctly.
Solution:   Pass -1 to str_to_reg() and fix computing the character width
            instead of using the byte length. (Christian Brabandt,
            closes vim/vim#8317)

https://github.com/vim/vim/commit/6e0b553fa12fc5ad5d8ee3d8457e7cb16f38b56f

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2934: ASAN error when using text from the clipboard

Problem:    ASAN error when using text from the clipboard.
Solution:   Get width of each character.

https://github.com/vim/vim/commit/24951a67c24e75ec4ff7506f8e2e789ccd786e89

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:8.2.2935: calculating register width is not always needed

Problem:    Calculating register width is not always needed. (Christian
            Brabandt)
Solution:   Only calculate the width when the type is MBLOCK.

https://github.com/vim/vim/commit/6c4c404c580fadd69e39297a6cb4b214f2fcb6d6

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.1.1083: setreg() doesn't correctly handle mbyte chars in blockwise mode

Problem:  setreg() doesn't correctly handle mbyte chars in blockwise
          mode
Solution: use mb_ptr2len_len function pointer (Yee Cheng Chin)

setreg() will automatically calculate the width when a blockwise mode is
specified, but it does not properly calculate the line widths of mbyte
characters when value is passed as newline-terminated string. It does
work when value is passed as a list of lines though.

Fix this by properly using the mbyte function pointer to increment the
loop counter.

closes: vim/vim#16596

https://github.com/vim/vim/commit/a17f8bfb282805ee8ded014089d3094ef6dbf913

Co-authored-by: Yee Cheng Chin <ychin.git@gmail.com>