### PR TITLE
vim-patch:9.1.1086: completion doesn't work with multi lines

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1539,7 +1539,8 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
     ptr = line + v;  // "line" may have been updated
   }
 
-  if ((State & MODE_INSERT) && in_curline && ins_compl_win_active(wp)) {
+  if ((State & MODE_INSERT) && ins_compl_win_active(wp)
+      && (in_curline || ins_compl_lnum_in_range(lnum))) {
     area_highlighting = true;
   }
 
@@ -1787,8 +1788,9 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
         }
 
         // Check if ComplMatchIns highlight is needed.
-        if ((State & MODE_INSERT) && in_curline && ins_compl_win_active(wp)) {
-          int ins_match_attr = ins_compl_col_range_attr((int)(ptr - line));
+        if ((State & MODE_INSERT) && ins_compl_win_active(wp)
+            && (in_curline || ins_compl_lnum_in_range(lnum))) {
+          int ins_match_attr = ins_compl_col_range_attr(lnum, (int)(ptr - line));
           if (ins_match_attr > 0) {
             search_attr = hl_combine_attr(search_attr, ins_match_attr);
           }

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -5935,6 +5935,114 @@ describe('builtin popupmenu', function()
         ]])
         feed('<C-E><Esc>')
       end)
+
+      -- oldtest: Test_pum_complete_with_special_characters()
+      it('multi-line completion', function()
+        exec([[
+          func Omni_test(findstart, base)
+            if a:findstart
+              return col(".")
+            endif
+            return [#{word: "func ()\n\t\nend", abbr: "function ()",}, #{word: "foobar"}, #{word: "你好\n\t\n我好"}]
+          endfunc
+          set omnifunc=Omni_test
+        ]])
+
+        feed('S<C-X><C-O>')
+        screen:expect([[
+          func ()                         |
+                                          |
+          end^                             |
+          {s:function ()    }{1:                 }|
+          {n:foobar         }{1:                 }|
+          {n:你好^@  ^@我好 }{1:                 }|
+          {1:~                               }|*13
+          {2:-- }{5:match 1 of 3}                 |
+        ]])
+
+        feed('<C-N>')
+        screen:expect([[
+          foobar^                          |
+          {n:function ()    }{1:                 }|
+          {s:foobar         }{1:                 }|
+          {n:你好^@  ^@我好 }{1:                 }|
+          {1:~                               }|*15
+          {2:-- }{5:match 2 of 3}                 |
+        ]])
+        feed('<C-E><ESC>')
+
+        feed('Shello  hero<ESC>hhhhha<C-X><C-O>')
+        screen:expect([[
+          hello func ()                   |
+                                          |
+          end^ hero                        |
+          {1:~    }{s: function ()    }{1:           }|
+          {1:~    }{n: foobar         }{1:           }|
+          {1:~    }{n: 你好^@  ^@我好 }{1:           }|
+          {1:~                               }|*13
+          {2:-- }{5:match 1 of 3}                 |
+        ]])
+
+        feed('<C-N>')
+        screen:expect([[
+          hello foobar^ hero               |
+          {1:~    }{n: function ()    }{1:           }|
+          {1:~    }{s: foobar         }{1:           }|
+          {1:~    }{n: 你好^@  ^@我好 }{1:           }|
+          {1:~                               }|*15
+          {2:-- }{5:match 2 of 3}                 |
+        ]])
+
+        feed('<C-N>')
+        screen:expect([[
+          hello 你好                      |
+                                          |
+          我好^ hero                       |
+          {1:~  }{n: function ()    }{1:             }|
+          {1:~  }{n: foobar         }{1:             }|
+          {1:~  }{s: 你好^@  ^@我好 }{1:             }|
+          {1:~                               }|*13
+          {2:-- }{5:match 3 of 3}                 |
+        ]])
+
+        feed('<C-N>')
+        screen:expect([[
+          hello ^ hero                     |
+          {1:~    }{n: function ()    }{1:           }|
+          {1:~    }{n: foobar         }{1:           }|
+          {1:~    }{n: 你好^@  ^@我好 }{1:           }|
+          {1:~                               }|*15
+          {2:-- }{8:Back at original}             |
+        ]])
+        feed('<C-E><ESC>')
+
+        command(':hi ComplMatchIns guifg=red')
+        feed('S<C-X><C-O>')
+        screen:expect([[
+          {8:func ()}                         |
+          {8:        }                        |
+          {8:end}^                             |
+          {s:function ()    }{1:                 }|
+          {n:foobar         }{1:                 }|
+          {n:你好^@  ^@我好 }{1:                 }|
+          {1:~                               }|*13
+          {2:-- }{5:match 1 of 3}                 |
+        ]])
+        feed('<C-E><ESC>')
+
+        feed('Shello  hero<ESC>hhhhha<C-X><C-O>')
+        screen:expect([[
+          hello {8:func ()}                   |
+          {8:        }                        |
+          {8:end^ }hero                        |
+          {1:~    }{s: function ()    }{1:           }|
+          {1:~    }{n: foobar         }{1:           }|
+          {1:~    }{n: 你好^@  ^@我好 }{1:           }|
+          {1:~                               }|*13
+          {2:-- }{5:match 1 of 3}                 |
+        ]])
+        feed('<C-E><ESC>')
+      end)
     end
   end
 

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1885,4 +1885,59 @@ func Test_popup_completion_many_ctrlp()
   bw!
 endfunc
 
+func Test_pum_complete_with_special_characters()
+  CheckScreendump
+
+  let lines =<< trim END
+    func Omni_test(findstart, base)
+      if a:findstart
+        return col(".")
+      endif
+      return [#{word: "func ()\n\t\nend", abbr: "function ()",}, #{word: "foobar"}, #{word: "你好\n\t\n我好"}]
+    endfunc
+    set omnifunc=Omni_test
+  END
+
+  call writefile(lines, 'Xpreviewscript', 'D')
+  let buf = RunVimInTerminal('-S Xpreviewscript', #{rows: 12})
+  call term_sendkeys(buf, "S\<C-X>\<C-O>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_pum_with_special_characters_01', {})
+
+  call term_sendkeys(buf, "\<C-N>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_pum_with_special_characters_02', {})
+  call term_sendkeys(buf, "\<C-E>\<Esc>")
+
+  call term_sendkeys(buf, "Shello  hero\<ESC>hhhhha\<C-X>\<C-O>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_pum_with_special_characters_03', {})
+
+  call term_sendkeys(buf, "\<C-N>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_pum_with_special_characters_04', {})
+
+  call term_sendkeys(buf, "\<C-N>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_pum_with_special_characters_05', {})
+
+  call term_sendkeys(buf, "\<C-N>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_pum_with_special_characters_06', {})
+  call term_sendkeys(buf, "\<C-E>\<Esc>")
+
+  call term_sendkeys(buf, ":hi ComplMatchIns ctermfg=red\<CR>")
+  call TermWait(buf, 50)
+  call term_sendkeys(buf, "S\<C-X>\<C-O>")
+  call VerifyScreenDump(buf, 'Test_pum_with_special_characters_07', {})
+  call term_sendkeys(buf, "\<C-E>\<Esc>")
+
+  call term_sendkeys(buf, "Shello  hero\<ESC>hhhhha\<C-X>\<C-O>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_pum_with_special_characters_08', {})
+  call term_sendkeys(buf, "\<C-E>\<Esc>")
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  completion doesn't work with multi lines
          (Łukasz Jan Niemier)
Solution: handle linebreaks in completion code as expected
          (glepnir)

fixes: vim/vim#2505
closes: vim/vim#15373

https://github.com/vim/vim/commit/76bdb82527a13b5b2baa8f7d7ce14b4d5dc05b82