### PR TITLE
fix(defaults): improve visual search mappings

### DIFF
--- a/test/functional/editor/defaults_spec.lua
+++ b/test/functional/editor/defaults_spec.lua
@@ -119,7 +119,9 @@ describe('default', function()
           [[testing <CR> /?\!3]],
           [[testing <CR> /?\!4]],
         })
-        n.feed('gg0vf!o*')
+        n.feed('gg0vf!')
+        n.poke_eventloop()
+        n.feed('*')
         screen:expect([[
           {3:testing <CR> /?\!}1                                          |
           {4:^testing <CR> /?\!}2                                          |
@@ -127,7 +129,7 @@ describe('default', function()
           {3:testing <CR> /?\!}4                                          |
           {1:~                                                           }|*2
           {2:[No Name] [+]                             2,1            All}|
-          /\Vtesting <CR> \/?\\!                    [2/4]             |
+          /\Vtesting <CR> /?\\!                     [2/4]             |
         ]])
         n.feed('n')
         screen:expect([[
@@ -137,9 +139,11 @@ describe('default', function()
           {3:testing <CR> /?\!}4                                          |
           {1:~                                                           }|*2
           {2:[No Name] [+]                             3,1            All}|
-          /\Vtesting <CR> \/?\\!                    [3/4]             |
+          /\Vtesting <CR> /?\\!                     [3/4]             |
         ]])
-        n.feed('G0vf!o#')
+        n.feed('G0vf!')
+        n.poke_eventloop()
+        n.feed('#')
         screen:expect([[
           {3:testing <CR> /?\!}1                                          |
           {3:testing <CR> /?\!}2                                          |


### PR DESCRIPTION
Problem:  The behavior of the visual search mappings aren't consistent with their normal mode counterparts.
  - The count isn't considered
  - Searching with an empty selection will match every character in the buffer
  - Searching backwards only jumps back when the cursor is positioned at the start of the selection.

Solution:
  - Issue `n` `v:count1` times
  - Error out and exit visual mode when the selection is empty
  - Detect when the cursor is at the start of the selection, and adjust the count accordingly

Also, use the search register instead of the more error-prone approach of feeding the entire search string as an expression