### PR TITLE
fix(lsp): Show correct activeParameter on vim.lsp.buf.signature_help

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -315,6 +315,7 @@ local function process_signature_help_results(results)
       local result = r.result --- @type lsp.SignatureHelp
       if result and result.signatures and result.signatures[1] then
         for _, sig in ipairs(result.signatures) do
+          sig.activeParameter = sig.activeParameter or result.activeParameter
           signatures[#signatures + 1] = { client, sig }
         end
       end


### PR DESCRIPTION
- On some lsps the `textDocument/signatureHelp` response, only includes the `activeParameter` field on the `lsp.SignatureHelp` type.
```lua
{
  {
    result = {
      activeParameter = 2,
      signatures = {
        {
          documentation = {
            kind = "markdown",
            value = ""
          },
          label = "getBuyers(ctx context.Context, orderDB boil.ContextExecutor, supplierID string) ([]*BuyerWithLocation, error)",
          parameters = {
            {
              label = "ctx context.Context"
            },
            {
              label = "orderDB boil.ContextExecutor"
            },
            {
              label = "supplierID string"
            }
          }
        }
      }
    }
  }
}
```

- This change ensures we retain this information before showing the signature information

### Video

* Using the reproduction steps from the linked issue.
[![asciicast](https://asciinema.org/a/702394.svg)](https://asciinema.org/a/702394)

### Context

Closes #32381