### PR TITLE
vim-patch:f30eb4a: runtime(qf): Update syntax file, match second delimiter

### DIFF
--- a/runtime/syntax/qf.vim
+++ b/runtime/syntax/qf.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
-" Language:	Quickfix window
-" Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2023 Aug 10
+" Language:		Quickfix window
+" Maintainer:		The Vim Project <https://github.com/vim/vim>
+" Last Change:		2025 Feb 07
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a syntax file was already loaded
@@ -9,11 +9,14 @@ if exists("b:current_syntax")
   finish
 endif
 
-" A bunch of useful C keywords
-syn match	qfFileName	"^[^|]*" nextgroup=qfSeparator
-syn match	qfSeparator	"|" nextgroup=qfLineNr contained
-syn match	qfLineNr	"[^|]*" contained contains=qfError
-syn match	qfError		"error" contained
+syn match	qfFileName	"^[^|]*"	   nextgroup=qfSeparator1
+syn match	qfSeparator1	"|"	 contained nextgroup=qfLineNr
+syn match	qfLineNr	"[^|]*"	 contained nextgroup=qfSeparator2 contains=@qfType
+syn match	qfSeparator2	"|"	 contained nextgroup=qfText
+syn match	qfText		".*"	 contained
+
+syn match	qfError		"error"	 contained
+syn cluster	qfType	contains=qfError
 
 " Hide file name and line number for help outline (TOC).
 if has_key(w:, 'qf_toc') || get(w:, 'quickfix_title') =~# '\<TOC$'
@@ -22,9 +25,13 @@ if has_key(w:, 'qf_toc') || get(w:, 'quickfix_title') =~# '\<TOC$'
 endif
 
 " The default highlighting.
-hi def link qfFileName	Directory
-hi def link qfLineNr	LineNr
-hi def link qfError	Error
+hi def link qfFileName		Directory
+hi def link qfLineNr		LineNr
+hi def link qfSeparator1	Delimiter
+hi def link qfSeparator2	Delimiter
+hi def link qfText		Normal
+
+hi def link qfError		Error
 
 let b:current_syntax = "qf"
 

--- a/test/functional/ui/quickfix_spec.lua
+++ b/test/functional/ui/quickfix_spec.lua
@@ -12,18 +12,22 @@ describe('quickfix selection highlight', function()
 
     screen = Screen.new(25, 10)
     screen:set_default_attr_ids({
-      [1] = { bold = true, foreground = Screen.colors.Blue },
+      [1] = { foreground = Screen.colors.Blue, bold = true },
       [2] = { reverse = true },
       [3] = { foreground = Screen.colors.Brown },
-      [4] = { bold = true, reverse = true },
-      [5] = { background = Screen.colors.Green },
-      [6] = { foreground = Screen.colors.Brown, background = Screen.colors.Green },
-      [7] = { background = Screen.colors.Red },
-      [8] = { foreground = Screen.colors.Brown, background = Screen.colors.Red },
-      [9] = { background = Screen.colors.Fuchsia },
-      [10] = { foreground = Screen.colors.Red, background = Screen.colors.Fuchsia },
-      [11] = { foreground = Screen.colors.Red },
-      [12] = { foreground = Screen.colors.Brown, background = Screen.colors.Fuchsia },
+      [4] = { reverse = true, bold = true },
+      [5] = { background = Screen.colors.WebGreen },
+      [6] = { background = Screen.colors.WebGreen, foreground = Screen.colors.Brown },
+      [7] = { background = Screen.colors.Red1 },
+      [8] = { background = Screen.colors.Red1, foreground = Screen.colors.Brown },
+      [9] = { background = Screen.colors.Magenta },
+      [10] = { background = Screen.colors.Magenta, foreground = Screen.colors.Red1 },
+      [11] = { foreground = Screen.colors.Red1 },
+      [12] = { background = Screen.colors.Magenta, foreground = Screen.colors.Brown },
+      [13] = { background = Screen.colors.WebGreen, foreground = Screen.colors.SlateBlue },
+      [14] = { foreground = Screen.colors.SlateBlue },
+      [15] = { foreground = Screen.colors.SlateBlue, background = Screen.colors.Red1 },
+      [16] = { foreground = Screen.colors.SlateBlue, background = Screen.colors.Fuchsia },
     })
 
     api.nvim_set_option_value('errorformat', '%m %l', {})
@@ -59,12 +63,12 @@ describe('quickfix selection highlight', function()
     screen:expect([[
       Line 1                   |
       {2:[No Name] [+]            }|
-      {5:^|}{6:1}{5:| Line                 }|
-      |{3:2}| Line                 |
-      |{3:3}| Line                 |
-      |{3:4}| Line                 |
-      |{3:5}| Line                 |
-      ||                       |
+      {13:^|}{6:1}{13:|}{5: Line                 }|
+      {14:|}{3:2}{14:|} Line                 |
+      {14:|}{3:3}{14:|} Line                 |
+      {14:|}{3:4}{14:|} Line                 |
+      {14:|}{3:5}{14:|} Line                 |
+      {14:||}                       |
       {4:[Quickfix List]          }|
                                |
     ]])
@@ -74,12 +78,12 @@ describe('quickfix selection highlight', function()
     screen:expect([[
       Line 1                   |
       {2:[No Name] [+]            }|
-      |{3:1}| Line                 |
-      {5:^|}{6:2}{5:| Line                 }|
-      |{3:3}| Line                 |
-      |{3:4}| Line                 |
-      |{3:5}| Line                 |
-      ||                       |
+      {14:|}{3:1}{14:|} Line                 |
+      {13:^|}{6:2}{13:|}{5: Line                 }|
+      {14:|}{3:3}{14:|} Line                 |
+      {14:|}{3:4}{14:|} Line                 |
+      {14:|}{3:5}{14:|} Line                 |
+      {14:||}                       |
       {4:[Quickfix List]          }|
                                |
     ]])
@@ -93,12 +97,12 @@ describe('quickfix selection highlight', function()
     screen:expect([[
       Line 1                   |
       {2:[No Name] [+]            }|
-      {7:^|}{8:1}{7:| Line                 }|
-      |{3:2}| Line                 |
-      |{3:3}| Line                 |
-      |{3:4}| Line                 |
-      |{3:5}| Line                 |
-      ||                       |
+      {15:^|}{8:1}{15:|}{7: Line                 }|
+      {14:|}{3:2}{14:|} Line                 |
+      {14:|}{3:3}{14:|} Line                 |
+      {14:|}{3:4}{14:|} Line                 |
+      {14:|}{3:5}{14:|} Line                 |
+      {14:||}                       |
       {4:[Quickfix List]          }|
                                |
     ]])
@@ -108,12 +112,12 @@ describe('quickfix selection highlight', function()
     screen:expect([[
       Line 1                   |
       {2:[No Name] [+]            }|
-      |{3:1}| Line                 |
-      {7:^|}{8:2}{7:| Line                 }|
-      |{3:3}| Line                 |
-      |{3:4}| Line                 |
-      |{3:5}| Line                 |
-      ||                       |
+      {14:|}{3:1}{14:|} Line                 |
+      {15:^|}{8:2}{15:|}{7: Line                 }|
+      {14:|}{3:3}{14:|} Line                 |
+      {14:|}{3:4}{14:|} Line                 |
+      {14:|}{3:5}{14:|} Line                 |
+      {14:||}                       |
       {4:[Quickfix List]          }|
                                |
     ]])
@@ -130,11 +134,11 @@ describe('quickfix selection highlight', function()
       {9:Line 1                   }|
       {2:[No Name] [+]            }|
       {10:^|1| Line                 }|
-      |{3:2}| Line                 |
-      |{3:3}| Line                 |
-      |{3:4}| Line                 |
-      |{3:5}| Line                 |
-      ||                       |
+      {14:|}{3:2}{14:|} Line                 |
+      {14:|}{3:3}{14:|} Line                 |
+      {14:|}{3:4}{14:|} Line                 |
+      {14:|}{3:5}{14:|} Line                 |
+      {14:||}                       |
       {4:[Quickfix List]          }|
                                |
     ]])
@@ -145,11 +149,11 @@ describe('quickfix selection highlight', function()
       {9:Line 1                   }|
       {2:[No Name] [+]            }|
       {11:|1| Line                 }|
-      {9:^|}{12:2}{9:| Line                 }|
-      |{3:3}| Line                 |
-      |{3:4}| Line                 |
-      |{3:5}| Line                 |
-      ||                       |
+      {16:^|}{12:2}{16:|}{9: Line                 }|
+      {14:|}{3:3}{14:|} Line                 |
+      {14:|}{3:4}{14:|} Line                 |
+      {14:|}{3:5}{14:|} Line                 |
+      {14:||}                       |
       {4:[Quickfix List]          }|
                                |
     ]])
@@ -165,12 +169,12 @@ describe('quickfix selection highlight', function()
     screen:expect([[
       {9:Line 1                   }|
       {2:[No Name] [+]            }|
-      {7:^|}{8:1}{7:| Line                 }|
-      |{3:2}| Line                 |
-      |{3:3}| Line                 |
-      |{3:4}| Line                 |
-      |{3:5}| Line                 |
-      ||                       |
+      {15:^|}{8:1}{15:|}{7: Line                 }|
+      {14:|}{3:2}{14:|} Line                 |
+      {14:|}{3:3}{14:|} Line                 |
+      {14:|}{3:4}{14:|} Line                 |
+      {14:|}{3:5}{14:|} Line                 |
+      {14:||}                       |
       {4:[Quickfix List]          }|
                                |
     ]])
@@ -180,12 +184,12 @@ describe('quickfix selection highlight', function()
     screen:expect([[
       {9:Line 1                   }|
       {2:[No Name] [+]            }|
-      {7:|}{8:1}{7:| Line                 }|
-      {9:^|}{12:2}{9:| Line                 }|
-      |{3:3}| Line                 |
-      |{3:4}| Line                 |
-      |{3:5}| Line                 |
-      ||                       |
+      {15:|}{8:1}{15:|}{7: Line                 }|
+      {16:^|}{12:2}{16:|}{9: Line                 }|
+      {14:|}{3:3}{14:|} Line                 |
+      {14:|}{3:4}{14:|} Line                 |
+      {14:|}{3:5}{14:|} Line                 |
+      {14:||}                       |
       {4:[Quickfix List]          }|
                                |
     ]])


### PR DESCRIPTION
Match both | separators and link to the Delimiter highlight group.

fixes vim/vim#16584
closes: vim/vim#16590

https://github.com/vim/vim/commit/f30eb4a17084eea741a9eb09ba47dd501412283d

Co-authored-by: Doug Kearns <dougkearns@gmail.com>
