### PR TITLE
feat(lsp): add select kind in showMessageRequest

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -90,6 +90,7 @@ RSC[ms.window_showMessageRequest] = function(_, params)
   local co, is_main = coroutine.running()
   if co and not is_main then
     local opts = {
+      kind = 'lsp_message',
       prompt = params.message .. ': ',
       format_item = function(action)
         return (action.title:gsub('\r\n', '\\r\\n')):gsub('\n', '\\n')


### PR DESCRIPTION
^^

Motivation: I use `dressing.nvim`, which allows one to use [different `select` implementations](https://github.com/stevearc/dressing.nvim?tab=readme-ov-file#advanced-configuration). I would like to customize the picker when coming from this request, but it's a bit tricky because it doesn't include the `kind` (and filtering on the `prompt` is a bit flaky IMO).