### PR TITLE
vim-patch:9.{0.1675,1.1091}

### DIFF
--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -231,10 +231,10 @@ func RunTheTest(test)
   echo prefix .. 'Executing ' .. a:test
 
   if has('timers')
-    " No test should take longer than 30 seconds.  If it takes longer we
+    " No test should take longer than 45 seconds.  If it takes longer we
     " assume we are stuck and need to break out.
     let test_timeout_timer =
-          \ timer_start(RunningWithValgrind() ? 50000 : 30000, 'TestTimeout')
+          \ timer_start(RunningWithValgrind() ? 90000 : 45000, 'TestTimeout')
     let g:timeout_start = localtime()
   endif
 

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -96,6 +96,9 @@ set shellslash
 " Common with all tests on all systems.
 source setup.vim
 
+" Needed for RunningWithValgrind().
+source shared.vim
+
 " For consistency run all tests with 'nocompatible' set.
 " This also enables use of line continuation.
 set nocp viminfo+=nviminfo
@@ -206,12 +209,18 @@ unlet! name
 func TestTimeout(id)
   split test.log
   call append(line('$'), '')
-  call append(line('$'), 'Test timed out: ' .. g:testfunc)
+
+  let text = 'Test timed out: ' .. g:testfunc
+  if g:timeout_start > 0
+    let text ..= strftime(' after %s seconds', localtime() - g:timeout_start)
+  endif
+  call append(line('$'), text)
   write
-  call add(v:errors, 'Test timed out: ' . g:testfunc)
+  call add(v:errors, text)
 
   cquit! 42
 endfunc
+let g:timeout_start = 0
 
 func RunTheTest(test)
   let prefix = ''
@@ -224,7 +233,9 @@ func RunTheTest(test)
   if has('timers')
     " No test should take longer than 30 seconds.  If it takes longer we
     " assume we are stuck and need to break out.
-    let test_timeout_timer = timer_start(30000, 'TestTimeout')
+    let test_timeout_timer =
+          \ timer_start(RunningWithValgrind() ? 50000 : 30000, 'TestTimeout')
+    let g:timeout_start = localtime()
   endif
 
   " Avoid stopping at the "hit enter" prompt
@@ -298,6 +309,7 @@ func RunTheTest(test)
 
   if has('timers')
     call timer_stop(test_timeout_timer)
+    let g:timeout_start = 0
   endif
 
   " Clear any autocommands and put back the catch-all for SwapExists.
@@ -351,7 +363,7 @@ func RunTheTest(test)
 
   " close any split windows
   while winnr('$') > 1
-    bwipe!
+    noswapfile bwipe!
   endwhile
 
   " May be editing some buffer, wipe it out.  Then we may end up in another


### PR DESCRIPTION
#### vim-patch:9.0.1675: test may run into timeout when using valgrind

Problem:    Test may run into timeout when using valgrind.
Solution:   Use a longer timeout when using valgrind.

https://github.com/vim/vim/commit/7c2beb48ef46cf5f1ed7e8512ef5a7c9099e5ae4

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.1.1091: tests: timeout might be a bit too small

Problem:  tests: timeout might be a bit too small
Solution: increase the test timeout from 30 to 45 seconds

related: vim/vim#16599

https://github.com/vim/vim/commit/ec7a4e4d69d17821292048bfa85801fcfa476228

Co-authored-by: Christian Brabandt <cb@256bit.org>