### PR TITLE
fix(lsp): clear word when expand multi-lines word

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -493,6 +493,7 @@ local function trigger(bufnr, clients)
       end
     end
     local start_col = (server_start_boundary or word_boundary) + 1
+    Context.cursor = { cursor_row, start_col }
     vim.fn.complete(start_col, matches)
   end)
 
@@ -569,8 +570,14 @@ local function on_complete_done()
     end
 
     -- Remove the already inserted word.
-    local start_char = cursor_col - #completed_item.word
-    api.nvim_buf_set_text(bufnr, cursor_row, start_char, cursor_row, cursor_col, { '' })
+    api.nvim_buf_set_text(
+      bufnr,
+      Context.cursor[1] - 1,
+      Context.cursor[2] - 1,
+      cursor_row,
+      cursor_col,
+      { '' }
+    )
   end
 
   local function apply_snippet_and_command()

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -1078,4 +1078,42 @@ describe('vim.lsp.completion: integration', function()
       end)
     )
   end)
+
+  it('#clear multiple-lines word', function()
+    local completion_list = {
+      isIncomplete = false,
+      items = {
+        {
+          label = 'then...end',
+          sortText = '0001',
+          insertText = 'then\n\t$0\nend',
+          kind = 15,
+          insertTextFormat = 2,
+        },
+      },
+    }
+    exec_lua(function()
+      vim.o.completeopt = 'menuone,noselect'
+    end)
+    create_server('dummy', completion_list)
+    feed('Sif true <C-X><C-O>')
+    retry(nil, nil, function()
+      eq(
+        1,
+        exec_lua(function()
+          return vim.fn.pumvisible()
+        end)
+      )
+    end)
+    feed('<C-n><C-y>')
+    eq(
+      { true, { 'if true then', '\t', 'end' } },
+      exec_lua(function()
+        return {
+          vim.snippet.active({ direction = 1 }),
+          vim.api.nvim_buf_get_lines(0, 0, -1, true),
+        }
+      end)
+    )
+  end)
 end)


### PR DESCRIPTION
Problem: When expanding a completion item that contains a multi-line word, the word is not deleted correctly.

Solution: If the word contains a line break, delete the text from Context.cursor to the current cursor position.