### PR TITLE
fix(treesitter): detect trees with outdated regions in `is_valid()`

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -318,7 +318,13 @@ function LanguageTree:is_valid(exclude_children, range)
     end
     -- TODO: Efficiently search for possibly intersecting regions using a binary search
     for i, region in pairs(self:included_regions()) do
-      if not valid_regions[i] and intercepts_region(region, range) then
+      if
+        not valid_regions[i]
+        and (
+          intercepts_region(region, range)
+          or (self._trees[i] and intercepts_region(self._trees[i]:included_ranges(false), range))
+        )
+      then
         return false
       end
     end

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -891,6 +891,39 @@ describe('treesitter highlighting (lua)', function()
       ]],
     })
   end)
+
+  it('removes outdated highlights', function()
+    insert('-- int main() {}' .. string.rep("\nprint('test')", 20) .. '\n-- int other() {}')
+
+    exec_lua(function()
+      vim.cmd.norm('gg')
+      vim.treesitter.query.set(
+        'lua',
+        'injections',
+        [[((comment_content) @injection.content
+            (#set! injection.combined)
+            (#set! injection.language "c"))]]
+      )
+      vim.bo.filetype = 'lua'
+      vim.treesitter.start()
+    end)
+
+    screen:expect([[
+      {18:^-- }{16:int}{18: }{25:main}{16:()}{18: }{16:{}}                                                 |
+      {16:print(}{26:'test'}{16:)}                                                    |*16
+                                                                       |
+    ]])
+
+    exec_lua(function()
+      vim.cmd.norm('gg0dw')
+    end)
+
+    screen:expect([[
+      {25:^int} {25:main}{16:()} {16:{}}                                                    |
+      {16:print(}{26:'test'}{16:)}                                                    |*16
+                                                                       |
+    ]])
+  end)
 end)
 
 describe('treesitter highlighting (help)', function()


### PR DESCRIPTION
**Problem:** https://github.com/neovim/neovim/pull/32082/commits/8543aa406c4ae88cc928372b2f8105005cdd0a80 introduced a regression from the bug fixed in #26723, meaning outdated highlights remain in buffers with combined injections.

**Solution:** Apply the same logic in that PR to `is_valid()`, and also add a regression test for this case.