### PR TITLE
feat(column): apply appropriate numhl highlight to virt_lines

### DIFF
--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -720,7 +720,7 @@ bool win_may_fill(win_T *wp)
 /// @return Number of filler lines above lnum
 int win_get_fill(win_T *wp, linenr_T lnum)
 {
-  int virt_lines = decor_virt_lines(wp, lnum - 1, lnum, NULL, true);
+  int virt_lines = decor_virt_lines(wp, lnum - 1, lnum, NULL, NULL, true);
 
   // be quick when there are no filler lines
   if (diffopt_filler()) {
@@ -920,7 +920,7 @@ int plines_m_win(win_T *wp, linenr_T first, linenr_T last, int max)
 /// Mainly used for calculating scrolling offsets.
 int plines_m_win_fill(win_T *wp, linenr_T first, linenr_T last)
 {
-  int count = last - first + 1 + decor_virt_lines(wp, first - 1, last, NULL, false);
+  int count = last - first + 1 + decor_virt_lines(wp, first - 1, last, NULL, NULL, false);
 
   if (diffopt_filler()) {
     for (int lnum = first; lnum <= last; lnum++) {

--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -427,7 +427,7 @@ describe('Signs', function()
       feed('<C-Y>')
       -- number column on virtual lines should be empty
       screen:expect([[
-        {8:    }VIRT LINES                                       |
+        {9:    }VIRT LINES                                       |
         {101: >> }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
         {9:    }aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
         {9:    }aa^a                                              |


### PR DESCRIPTION
Problem:  Number and statuscolumn highlighting for virtual lines does
          not take always take on numhl highlights.
Solution: Apply the appropriate numhl highlight to the number/statuscolumn
          of virtual lines, fetching the numhl highlight of the line above
          for `virt_line_above == false` lines.