### PR TITLE
fix(memline): don't check line count for closed memline

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1875,6 +1875,11 @@ static char *ml_get_buf_impl(buf_T *buf, linenr_T lnum, bool will_change)
   static int recursive = 0;
   static char questions[4];
 
+  if (buf->b_ml.ml_mfp == NULL) {       // there are no lines
+    buf->b_ml.ml_line_len = 1;
+    return "";
+  }
+
   if (lnum > buf->b_ml.ml_line_count) {  // invalid line number
     if (recursive == 0) {
       // Avoid giving this message for a recursive call, may happen when
@@ -1891,11 +1896,6 @@ errorret:
     return questions;
   }
   lnum = MAX(lnum, 1);  // pretend line 0 is line 1
-
-  if (buf->b_ml.ml_mfp == NULL) {       // there are no lines
-    buf->b_ml.ml_line_len = 1;
-    return "";
-  }
 
   // See if it is the same line as requested last time.
   // Otherwise may need to flush last used line.

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -305,6 +305,24 @@ describe('lua buffer event callbacks: on_lines', function()
     n.assert_alive()
   end)
 
+  it('no invalid lnum error for closed memline in on_detach #31251', function()
+    eq(vim.NIL, exec_lua('return _G.did_detach'))
+    exec_lua([[
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, { '' })
+      local bufname = 'buf2'
+      local buf = vim.api.nvim_create_buf(false, true)
+      vim.api.nvim_buf_set_name(buf, bufname)
+      vim.bo[buf].bufhidden = 'wipe'
+      vim.cmd('vertical diffsplit '..bufname)
+      vim.api.nvim_buf_attach(0, false, { on_detach = function()
+        vim.cmd("redraw")
+        _G.did_detach = true
+      end})
+      vim.cmd.bdelete()
+    ]])
+    eq(true, exec_lua('return _G.did_detach'))
+  end)
+
   it('#12718 lnume', function()
     api.nvim_buf_set_lines(0, 0, -1, true, { '1', '2', '3' })
     exec_lua(function()


### PR DESCRIPTION
Problem:  Error thrown for invalid line number which may be accessed
          in an `on_detach` callback at which point line count is
          intentionally set to 0.
Solution: Move empty memline check to before line number check.

Fix #31251
Fix #32349