### PR TITLE
feat(term): trigger TermRequest for APC

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1004,8 +1004,8 @@ TermClose			When a |terminal| job ends.
 				Sets these |v:event| keys:
 				    status
 							*TermRequest*
-TermRequest			When a |:terminal| child process emits an OSC
-				or DCS sequence. Sets |v:termrequest|. The
+TermRequest			When a |:terminal| child process emits an OSC,
+				DCS or APC sequence. Sets |v:termrequest|. The
 				|event-data| is the request string.
 							*TermResponse*
 TermResponse			When Nvim receives an OSC or DCS response from

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -372,6 +372,8 @@ TERMINAL
 • The |terminal| has experimental support for the Kitty keyboard protocol
   (sometimes called "CSI u" key encoding). Only the "Disambiguate escape
   codes" mode is currently supported.
+• The |terminal| emits a |TermRequest| autocommand event when the child process
+  emits an APC control sequence.
 
 TREESITTER
 

--- a/runtime/doc/vvars.txt
+++ b/runtime/doc/vvars.txt
@@ -663,7 +663,7 @@ v:t_string	Value of |String| type.  Read-only.  See: |type()|
 
 				*v:termrequest* *termrequest-variable*
 v:termrequest
-		The value of the most recent OSC or DCS control sequence
+		The value of the most recent OSC, DCS or APC control sequence
 		sent from a process running in the embedded |terminal|.
 		This can be read in a |TermRequest| event handler to respond
 		to queries from embedded applications.

--- a/runtime/lua/vim/_meta/vvars.lua
+++ b/runtime/lua/vim/_meta/vvars.lua
@@ -700,7 +700,7 @@ vim.v.t_number = ...
 --- @type integer
 vim.v.t_string = ...
 
---- The value of the most recent OSC or DCS control sequence
+--- The value of the most recent OSC, DCS or APC control sequence
 --- sent from a process running in the embedded `terminal`.
 --- This can be read in a `TermRequest` event handler to respond
 --- to queries from embedded applications.

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -183,10 +183,10 @@ struct terminal {
 
   bool color_set[16];
 
-  char *selection_buffer;  /// libvterm selection buffer
-  StringBuilder selection;  /// Growable array containing full selection data
+  char *selection_buffer;  ///< libvterm selection buffer
+  StringBuilder selection;  ///< Growable array containing full selection data
 
-  StringBuilder termrequest_buffer;  /// Growable array containing unfinished request payload
+  StringBuilder termrequest_buffer;  ///< Growable array containing unfinished request payload
 
   size_t refcount;                  // reference count
 };

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -315,7 +315,7 @@ static int on_osc(int command, VTermStringFragment frag, void *user)
   }
   kv_concat_len(term->termrequest_buffer, frag.str, frag.len);
   if (frag.final) {
-    char *payload = xmemdupz(term->termrequest_buffer.items, term->termrequest_buffer.size);
+    char *payload = xmemdup(term->termrequest_buffer.items, term->termrequest_buffer.size);
     schedule_termrequest(user, payload, term->termrequest_buffer.size);
   }
   return 1;
@@ -338,7 +338,7 @@ static int on_dcs(const char *command, size_t commandlen, VTermStringFragment fr
   }
   kv_concat_len(term->termrequest_buffer, frag.str, frag.len);
   if (frag.final) {
-    char *payload = xmemdupz(term->termrequest_buffer.items, term->termrequest_buffer.size);
+    char *payload = xmemdup(term->termrequest_buffer.items, term->termrequest_buffer.size);
     schedule_termrequest(user, payload, term->termrequest_buffer.size);
   }
   return 1;
@@ -361,7 +361,7 @@ static int on_apc(VTermStringFragment frag, void *user)
   }
   kv_concat_len(term->termrequest_buffer, frag.str, frag.len);
   if (frag.final) {
-    char *payload = xmemdupz(term->termrequest_buffer.items, term->termrequest_buffer.size);
+    char *payload = xmemdup(term->termrequest_buffer.items, term->termrequest_buffer.size);
     schedule_termrequest(user, payload, term->termrequest_buffer.size);
   }
   return 1;

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -330,12 +330,29 @@ static int on_dcs(const char *command, size_t commandlen, VTermStringFragment fr
   return 1;
 }
 
+static int on_apc(VTermStringFragment frag, void *user)
+{
+  if (frag.str == NULL || frag.len == 0) {
+    return 0;
+  }
+
+  if (!has_event(EVENT_TERMREQUEST)) {
+    return 1;
+  }
+
+  StringBuilder request = KV_INITIAL_VALUE;
+  kv_printf(request, "\x1b_");
+  kv_concat_len(request, frag.str, frag.len);
+  schedule_termrequest(user, request.items, request.size);
+  return 1;
+}
+
 static VTermStateFallbacks vterm_fallbacks = {
   .control = NULL,
   .csi = NULL,
   .osc = on_osc,
   .dcs = on_dcs,
-  .apc = NULL,
+  .apc = on_apc,
   .pm = NULL,
   .sos = NULL,
 };

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -315,8 +315,8 @@ static int on_osc(int command, VTermStringFragment frag, void *user)
   }
   kv_concat_len(term->termrequest_buffer, frag.str, frag.len);
   if (frag.final) {
-    schedule_termrequest(user, term->termrequest_buffer.items, term->termrequest_buffer.size);
-    kv_init(term->termrequest_buffer);
+    char *payload = xmemdupz(term->termrequest_buffer.items, term->termrequest_buffer.size);
+    schedule_termrequest(user, payload, term->termrequest_buffer.size);
   }
   return 1;
 }
@@ -338,8 +338,8 @@ static int on_dcs(const char *command, size_t commandlen, VTermStringFragment fr
   }
   kv_concat_len(term->termrequest_buffer, frag.str, frag.len);
   if (frag.final) {
-    schedule_termrequest(user, term->termrequest_buffer.items, term->termrequest_buffer.size);
-    kv_init(term->termrequest_buffer);
+    char *payload = xmemdupz(term->termrequest_buffer.items, term->termrequest_buffer.size);
+    schedule_termrequest(user, payload, term->termrequest_buffer.size);
   }
   return 1;
 }
@@ -361,8 +361,8 @@ static int on_apc(VTermStringFragment frag, void *user)
   }
   kv_concat_len(term->termrequest_buffer, frag.str, frag.len);
   if (frag.final) {
-    schedule_termrequest(user, term->termrequest_buffer.items, term->termrequest_buffer.size);
-    kv_init(term->termrequest_buffer);
+    char *payload = xmemdupz(term->termrequest_buffer.items, term->termrequest_buffer.size);
+    schedule_termrequest(user, payload, term->termrequest_buffer.size);
   }
   return 1;
 }

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -334,7 +334,7 @@ static int on_dcs(const char *command, size_t commandlen, VTermStringFragment fr
 
 static int on_apc(VTermStringFragment frag, void *user)
 {
-  struct terminal *term = user;
+  Terminal *term = user;
   if (frag.str == NULL || frag.len == 0) {
     return 0;
   }
@@ -344,6 +344,9 @@ static int on_apc(VTermStringFragment frag, void *user)
   }
 
   if (frag.initial) {
+    if (kv_size(term->termrequest_buffer) > 0) {
+      kv_drop(term->termrequest_buffer, kv_size(term->termrequest_buffer));
+    }
     kv_printf(term->termrequest_buffer, "\x1b_");
   }
   kv_concat_len(term->termrequest_buffer, frag.str, frag.len);

--- a/src/nvim/vvars.lua
+++ b/src/nvim/vvars.lua
@@ -799,7 +799,7 @@ M.vars = {
   termrequest = {
     type = 'string',
     desc = [=[
-      The value of the most recent OSC or DCS control sequence
+      The value of the most recent OSC, DCS or APC control sequence
       sent from a process running in the embedded |terminal|.
       This can be read in a |TermRequest| event handler to respond
       to queries from embedded applications.

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -350,6 +350,17 @@ describe(':terminal buffer', function()
     eq(termbuf, eval('g:termbuf'))
   end)
 
+  it('emits TermRequest events for APC', function()
+    local term = api.nvim_open_term(0, {})
+
+    -- cwd will be inserted in a file URI, which cannot contain backs
+    local cwd = t.fix_slashes(fn.getcwd())
+    local parent = cwd:match('^(.+/)')
+    local expected = '\027_Gfile://host' .. parent
+    api.nvim_chan_send(term, string.format('%s\027\\', expected))
+    eq(expected, eval('v:termrequest'))
+  end)
+
   it('TermRequest synchronization #27572', function()
     command('autocmd! nvim.terminal TermRequest')
     local term = exec_lua([[


### PR DESCRIPTION
See https://github.com/neovim/neovim/issues/32402.

This triggers a `TermRequest` any time a APC `VTermStringFragment` is received.

- [x] need handle not yet terminated requests, either by waiting for `\e\\` before triggering or implementing a request type parameter on the event data, currently it will always prepend `\e_` as the identifying string.
- [x] implement test
- [x] update docs