### PR TITLE
feat(term): report terminal size in pixels

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -56,6 +56,8 @@ with these (optional) keys:
 			Only from |--embed| UI on startup. |ui-startup-stdin|
 - `stdin_tty`		Tells if `stdin` is a `tty` or not.
 - `stdout_tty`		Tells if `stdout` is a `tty` or not.
+- `pixel_width`		Sets the window width in pixels (default 0).
+- `pixel_height`	Sets the window height in pixels (default 0).
 
 Specifying an unknown option is an error; UIs can check the |api-metadata|
 `ui_options` key for supported options.

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -274,6 +274,10 @@ error('Cannot require a meta file')
 --- @field url? string
 --- @field scoped? boolean
 
+--- @class vim.api.keyset.ui_resize
+--- @field pixel_width? integer
+--- @field pixel_height? integer
+
 --- @class vim.api.keyset.user_command
 --- @field addr? any
 --- @field bang? boolean

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -424,6 +424,12 @@ typedef struct {
 } Dict(ns_opts);
 
 typedef struct {
+  OptionalKeys is_set__ui_resize_;
+  Integer pixel_width;
+  Integer pixel_height;
+} Dict(ui_resize);
+
+typedef struct {
   OptionalKeys is_set___shada_search_pat_;
   Boolean magic DictKey(sm);
   Boolean smartcase DictKey(sc);

--- a/src/nvim/api/ui.h
+++ b/src/nvim/api/ui.h
@@ -2,6 +2,7 @@
 
 #include <stdint.h>  // IWYU pragma: keep
 
+#include "nvim/api/keysets_defs.h"  // IWYU pragma: keep
 #include "nvim/api/private/defs.h"  // IWYU pragma: keep
 #include "nvim/highlight_defs.h"  // IWYU pragma: keep
 #include "nvim/macros_defs.h"

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -101,6 +101,8 @@ EXTERN struct nvim_stats_s {
 #define DFLT_ROWS       24              // default value for 'lines'
 EXTERN int Rows INIT( = DFLT_ROWS);     // nr of rows in the screen
 EXTERN int Columns INIT( = DFLT_COLS);  // nr of columns in the screen
+EXTERN int XPixels INIT( = 0);
+EXTERN int YPixels INIT( = 0);
 
 // When vgetc() is called, it sets mod_mask to the set of modifiers that are
 // held down based on the MOD_MASK_* symbols that are read first.

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -679,8 +679,8 @@ static void handle_unknown_csi(TermInput *input, const TermKeyKey *key)
         // In-band resize event (DEC private mode 2048)
         int height_chars = args[1];
         int width_chars = args[2];
-        tui_set_size(input->tui_data, width_chars, height_chars);
-        ui_client_set_size(width_chars, height_chars);
+        tui_set_size(input->tui_data, width_chars, height_chars, 0, 0);
+        ui_client_set_size(width_chars, height_chars, 0, 0);
       }
     }
     break;

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -197,6 +197,8 @@ void ui_refresh(void)
 
   int width = INT_MAX;
   int height = INT_MAX;
+  int pixel_width = INT_MAX;
+  int pixel_height = INT_MAX;
   bool ext_widgets[kUIExtCount];
   bool inclusive = ui_override();
   memset(ext_widgets, !!ui_active(), ARRAY_SIZE(ext_widgets));
@@ -205,6 +207,12 @@ void ui_refresh(void)
     RemoteUI *ui = uis[i];
     width = MIN(ui->width, width);
     height = MIN(ui->height, height);
+    if (ui->pixel_width > 0) {
+      pixel_width = MIN(ui->pixel_width, pixel_width);
+    }
+    if (ui->pixel_height > 0) {
+      pixel_height = MIN(ui->pixel_height, pixel_height);
+    }
     for (UIExtension j = 0; (int)j < kUIExtCount; j++) {
       ext_widgets[j] &= (ui->ui_ext[j] || inclusive);
     }
@@ -247,6 +255,12 @@ void ui_refresh(void)
   int save_p_lz = p_lz;
   p_lz = false;  // convince redrawing() to return true ...
   screen_resize(width, height);
+  if (pixel_width < INT_MAX) {
+    XPixels = pixel_width;
+  }
+  if (pixel_height < INT_MAX) {
+    YPixels = pixel_height;
+  }
   p_lz = save_p_lz;
 
   ui_mode_info_set();
@@ -682,9 +696,11 @@ Array ui_array(Arena *arena)
   Array all_uis = arena_array(arena, ui_count);
   for (size_t i = 0; i < ui_count; i++) {
     RemoteUI *ui = uis[i];
-    Dict info = arena_dict(arena, 10 + kUIExtCount);
+    Dict info = arena_dict(arena, 12 + kUIExtCount);
     PUT_C(info, "width", INTEGER_OBJ(ui->width));
     PUT_C(info, "height", INTEGER_OBJ(ui->height));
+    PUT_C(info, "pixel_width", INTEGER_OBJ(ui->pixel_width));
+    PUT_C(info, "pixel_height", INTEGER_OBJ(ui->pixel_height));
     PUT_C(info, "rgb", BOOLEAN_OBJ(ui->rgb));
     PUT_C(info, "override", BOOLEAN_OBJ(ui->override));
 

--- a/src/nvim/ui_defs.h
+++ b/src/nvim/ui_defs.h
@@ -39,6 +39,8 @@ typedef struct {
   int height;
   int pum_nlines;  ///< actual nr. lines shown in PUM
   bool pum_pos;  ///< UI reports back pum position?
+  int pixel_width;
+  int pixel_height;
   double pum_row;
   double pum_col;
   double pum_height;

--- a/test/functional/api/ui_spec.lua
+++ b/test/functional/api/ui_spec.lua
@@ -59,7 +59,7 @@ describe('nvim_ui_attach()', function()
       pcall_err(api.nvim_ui_attach, 80, 24, { stdout_tty = 'foo' })
     )
 
-    eq('UI not attached to channel: 1', pcall_err(request, 'nvim_ui_try_resize', 40, 10))
+    eq('UI not attached to channel: 1', pcall_err(request, 'nvim_ui_try_resize', 40, 10, {}))
     eq('UI not attached to channel: 1', pcall_err(request, 'nvim_ui_set_option', 'rgb', true))
     eq('UI not attached to channel: 1', pcall_err(request, 'nvim_ui_detach'))
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3170,6 +3170,8 @@ describe('API', function()
           term_colors = 0,
           term_name = '',
           width = 20,
+          pixel_width = 0,
+          pixel_height = 0,
         },
       }
 

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -1887,6 +1887,8 @@ describe('TUI', function()
         term_colors = 256,
         term_name = exp_term,
         width = 50,
+        pixel_width = 0,
+        pixel_height = 0,
       },
     }
     local _, rv = child_session:request('nvim_list_uis')

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -3058,7 +3058,7 @@ aliquip ex ea commodo consequat.]]
     }
 
     -- not processed while command is executing
-    async_meths.nvim_ui_try_resize(35, 5)
+    async_meths.nvim_ui_try_resize(35, 5, {})
 
     -- TODO(bfredl): ideally it should be processed just
     -- before the "press ENTER" prompt though

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -311,7 +311,7 @@ end
 function Screen:try_resize(columns, rows)
   self._width = columns
   self._height = rows
-  self.uimeths.try_resize(columns, rows)
+  self.uimeths.try_resize(columns, rows, {})
 end
 
 function Screen:try_resize_grid(grid, columns, rows)


### PR DESCRIPTION
Terminal pixel size is currently reported as 0, which prevents some programs from working in the built-in terminal, notably programs displaying images (see https://github.com/neovim/neovim/issues/32189).

To be able to report terminal pixel size correctly we need to track it alongside the terminal size in cells. In order to do that UIs need to keep track and report their pixel size, which means changes to the API of `nvim_ui_attach` and `nvim_ui_try_resize`. That means this PR depends on https://github.com/neovim/neovim/issues/31903 to be resolved.

Currently, this PR implements a proof of concept. Terminal pixel size reporting works as is and reports the correct total size of the TUI (or the smallest values of multiple TUIs in the `--headless` and more general `--remote-ui` case).

The following things need to be done to consider the pixel size reporting useable:
- [x] Make `nvim_list_uis` report pixel sizes
- [x] Properly update API based on https://github.com/neovim/neovim/issues/31903
- [ ] Use floats for pixel sizes
- [ ] Maybe handle different terminals in TUI (could be delegated to follow up PR)

The following needs to be done for builtin term ioctl reporting:
- [ ] Correct pixel sizes to only include the inner terminal size

The following things need to be done before this PR is in a mergeable state:
- [x] Check proper default values are set and handled
- [ ] Update docs
- [ ] Implement new tests
- [x] Fix old tests