### PR TITLE
vim-patch:9.1.1104: CI: using Ubuntu 22.04 Github runners

### DIFF
--- a/test/old/testdir/test_messages.vim
+++ b/test/old/testdir/test_messages.vim
@@ -391,7 +391,7 @@ endfunc
 func Test_echo_verbose_system()
   CheckRunVimInTerminal
   CheckUnix    " needs the "seq" command
-  CheckNotMac  " doesn't use /tmp
+  CheckNotMac  " the macos TMPDIR is too long for snapshot testing
 
   let buf = RunVimInTerminal('', {'rows': 10})
   call term_sendkeys(buf, ":4 verbose echo system('seq 20')\<CR>")


### PR DESCRIPTION
#### vim-patch:9.1.1104: CI: using Ubuntu 22.04 Github runners

Problem:  CI: uses Ubuntu 22.04 runners
Solution: Switch to Ubuntu 24.04 runners, make a few adjustments for
          different $TMPDIR (Drew Vogel)

closes: vim/vim#16442

https://github.com/vim/vim/commit/f0ed0e6f6304d2eb6f43866126912c139778257d

Co-authored-by: Drew Vogel <dvogel@github>