### PR TITLE
build(windows)!: drop cat and tee executables from windows

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -156,8 +156,6 @@ endif()
 if(WIN32)
   include(GetBinaryDeps)
 
-  GetExecutable(TARGET cat)
-  GetExecutable(TARGET tee)
   GetExecutable(TARGET xxd)
 
   GetBinaryDep(TARGET win32yank_X86_64

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -19,10 +19,6 @@ LPEG_SHA256 4b155d67d2246c1ffa7ad7bc466c1ea899bbc40fef0257cc9c03cecbaed4352a
 LUA_COMPAT53_URL https://github.com/lunarmodules/lua-compat-5.3/archive/v0.13.tar.gz
 LUA_COMPAT53_SHA256 f5dc30e7b1fda856ee4d392be457642c1f0c259264a9b9bfbcb680302ce88fc2
 
-CAT_URL https://github.com/neovim/deps/raw/21c5e8bdda33521a6ed497b315e03265a2785cbc/opt/cat.exe
-CAT_SHA256 93b8d307bb15af3968920bdea3beb869a49d166f9164853c58a4e6ffdcae61c6
-TEE_URL https://github.com/neovim/deps/raw/21c5e8bdda33521a6ed497b315e03265a2785cbc/opt/tee.exe
-TEE_SHA256 950eea4e17fa3a7e89fa2c55374037b5797b3f1a54fea1304634884ab42ec14d
 XXD_URL https://github.com/neovim/deps/raw/21c5e8bdda33521a6ed497b315e03265a2785cbc/opt/xxd.exe
 XXD_SHA256 7a581e3882d28161cc52850f9a11d634b3eaf2c029276f093c1ed4c90e45a10c
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -770,8 +770,6 @@ if(WIN32)
   set(EXTERNAL_BLOBS_SCRIPT
     "file(MAKE_DIRECTORY \"${PROJECT_BINARY_DIR}/windows_runtime_deps/platforms\")")
   foreach(DEP_FILE IN ITEMS
-      cat.exe
-      tee.exe
       win32yank.exe
       xxd.exe)
   get_filename_component(DEP_FILE_DIR ${DEP_FILE} DIRECTORY)


### PR DESCRIPTION
The legitimacy of the binaries can't be guaranteed and poses a security
risk. A replacement version of these may be introduced in the future in
a more secure manner.

Closes https://github.com/neovim/neovim/issues/32431.