### PR TITLE
vim-patch:9.1.1108: 'smoothscroll' gets stuck with 'listchars' "eol"

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -341,8 +341,8 @@ static void changed_common(buf_T *buf, linenr_T lnum, colnr_T col, linenr_T lnum
           && (last < wp->w_topline
               || (wp->w_topline >= lnum
                   && wp->w_topline < lnume
-                  && win_linetabsize(wp, wp->w_topline, ml_get_buf(buf, wp->w_topline), MAXCOL)
-                  <= (wp->w_skipcol + sms_marker_overlap(wp, -1))))) {
+                  && (linetabsize_eol(wp, wp->w_topline)
+                      <= wp->w_skipcol + sms_marker_overlap(wp, -1))))) {
         wp->w_skipcol = 0;
       }
 

--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -130,7 +130,7 @@ static int coladvance2(win_T *wp, pos_T *pos, bool addspaces, bool finetune, col
         && wp->w_width_inner != 0
         && wcol >= (colnr_T)width
         && width > 0) {
-      csize = linetabsize(wp, pos->lnum);
+      csize = linetabsize_eol(wp, pos->lnum);
       if (csize > 0) {
         csize--;
       }

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -5225,7 +5225,7 @@ void nv_g_home_m_cmd(cmdarg_T *cap)
     // When ending up below 'smoothscroll' marker, move just beyond it so
     // that skipcol is not adjusted later.
     if (curwin->w_skipcol > 0 && curwin->w_cursor.lnum == curwin->w_topline) {
-      int overlap = sms_marker_overlap(curwin, -1);
+      int overlap = sms_marker_overlap(curwin, curwin->w_width_inner - width2);
       if (overlap > 0 && i == curwin->w_skipcol) {
         i += overlap;
       }

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -75,9 +75,17 @@ int linetabsize_col(int startvcol, char *s)
 
 /// Return the number of cells line "lnum" of window "wp" will take on the
 /// screen, taking into account the size of a tab and inline virtual text.
+/// Doesn't count the size of 'listchars' "eol".
 int linetabsize(win_T *wp, linenr_T lnum)
 {
   return win_linetabsize(wp, lnum, ml_get_buf(wp->w_buffer, lnum), MAXCOL);
+}
+
+/// Like linetabsize(), but counts the size of 'listchars' "eol".
+int linetabsize_eol(win_T *wp, linenr_T lnum)
+{
+  return linetabsize(wp, lnum)
+         + ((wp->w_p_list && wp->w_p_lcs_chars.eol != NUL) ? 1 : 0);
 }
 
 static const uint32_t inline_filter[4] = {[kMTMetaInline] = kMTFilterSelect };

--- a/src/nvim/plines.h
+++ b/src/nvim/plines.h
@@ -73,6 +73,7 @@ static inline int linetabsize_str(char *s)
 }
 
 /// Like linetabsize_str(), but for a given window instead of the current one.
+/// Doesn't count the size of 'listchars' "eol".
 ///
 /// @param wp
 /// @param line

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -1219,4 +1219,59 @@ func Test_smooth_long_scrolloff()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_smoothscroll_listchars_eol()
+  call NewWindow(10, 40)
+  setlocal list listchars=eol:$ scrolloff=0 smoothscroll
+  call setline(1, repeat('-', 40))
+  call append(1, repeat(['foobar'], 10))
+
+  normal! G
+  call assert_equal(2, line('w0'))
+  call assert_equal(0, winsaveview().skipcol)
+
+  exe "normal! \<C-Y>"
+  call assert_equal(1, line('w0'))
+  call assert_equal(40, winsaveview().skipcol)
+
+  exe "normal! \<C-Y>"
+  call assert_equal(1, line('w0'))
+  call assert_equal(0, winsaveview().skipcol)
+
+  exe "normal! \<C-Y>"
+  call assert_equal(1, line('w0'))
+  call assert_equal(0, winsaveview().skipcol)
+
+  exe "normal! \<C-E>"
+  call assert_equal(1, line('w0'))
+  call assert_equal(40, winsaveview().skipcol)
+
+  exe "normal! \<C-E>"
+  call assert_equal(2, line('w0'))
+  call assert_equal(0, winsaveview().skipcol)
+
+  for ve in ['', 'all', 'onemore']
+    let &virtualedit = ve
+    normal! gg
+    call assert_equal(1, line('w0'))
+    call assert_equal(0, winsaveview().skipcol)
+
+    exe "normal! \<C-E>"
+    redraw  " redrawing should not cause another scroll
+    call assert_equal(1, line('w0'))
+    call assert_equal(40, winsaveview().skipcol)
+
+    exe "normal! \<C-E>"
+    redraw
+    call assert_equal(2, line('w0'))
+    call assert_equal(0, winsaveview().skipcol)
+
+    if ve != 'all'
+      call assert_equal([0, 2, 1, 0], getpos('.'))
+    endif
+  endfor
+
+  set virtualedit&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1108: 'smoothscroll' gets stuck with 'listchars' "eol"

Problem:  'smoothscroll' gets stuck with 'listchars' "eol".
Solution: Count size of 'listchars' "eol" in line size when scrolling.
          (zeertzjq)

fixes: neovim/neovim#32405
closes: vim/vim#16627

https://github.com/vim/vim/commit/2c47ab8fcd7188fa87053c757ea86b0d846c06c1