### PR TITLE
vim-patch:4f010c9: runtime(vim): Update base-syntax, always match continuation comments to EOL

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -1117,8 +1117,8 @@ endif
 syn match	vimShebang	"\%^#!.*" display
 
 syn match	vimContinue		"^\s*\zs\\"
-syn match         vimContinueComment	'^\s*\zs["#]\\ .*'
-syn match         vim9ContinueComment	"^\s*\zs#\\ .*"
+syn match	vimContinueComment	'^\s*\zs["#]\\ .*' extend
+syn match	vim9ContinueComment	"^\s*\zs#\\ .*"	 extend
 syn cluster	vimContinue	contains=vimContinue,vimContinueComment
 syn cluster	vim9Continue	contains=vimContinue,vim9ContinueComment
 


### PR DESCRIPTION
#### vim-patch:4f010c9: runtime(vim): Update base-syntax, always match continuation comments to EOL

closes: vim/vim#16630

https://github.com/vim/vim/commit/4f010c90bdcb56a9c72cfee4d6fe3130b88616f8

Co-authored-by: Doug Kearns <dougkearns@gmail.com>