### PR TITLE
vim-patch:9.1.1107: cannot loop through completion menu with fuzzy

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1295,8 +1295,6 @@ static int ins_compl_build_pum(void)
           if (!compl_no_select) {
             compl_shown_match = comp;
           }
-        } else if (!fuzzy_sort && i == 0 && !compl_no_select) {
-          compl_shown_match = shown_compl;
         }
         if (!shown_match_ok && comp == compl_shown_match && !compl_no_select) {
           cur = i;
@@ -1325,6 +1323,12 @@ static int ins_compl_build_pum(void)
 
   if (compl_match_arraysize == 0) {
     return -1;
+  }
+
+  if (fuzzy_filter && !fuzzy_sort && !compl_no_select && !shown_match_ok) {
+    compl_shown_match = shown_compl;
+    shown_match_ok = true;
+    cur = 0;
   }
 
   assert(compl_match_arraysize >= 0);

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2767,6 +2767,8 @@ func Test_complete_fuzzy_match()
   func OnPumChange()
     let g:item = get(v:event, 'completed_item', {})
     let g:word = get(g:item, 'word', v:null)
+    let g:abbr = get(g:item, 'abbr', v:null)
+    let g:selected = get(complete_info(['selected']), 'selected')
   endfunction
 
   augroup AAAAA_Group
@@ -2857,6 +2859,20 @@ func Test_complete_fuzzy_match()
   call feedkeys("S\<C-x>\<C-o>fooB\<C-Y>", 'tx')
   call assert_equal('fooBaz', getline('.'))
 
+  set cot=menuone,fuzzy,nosort
+  func CompAnother()
+    call complete(col('.'), [#{word: "do" }, #{word: "echo"}, #{word: "for (${1:expr1}, ${2:expr2}, ${3:expr3}) {\n\t$0\n}", abbr: "for" }, #{word: "foo"}])
+    return ''
+  endfunc
+  call feedkeys("i\<C-R>=CompAnother()\<CR>\<C-N>\<C-N>", 'tx')
+  call assert_equal("for", g:abbr)
+  call assert_equal(2, g:selected)
+
+  set cot+=noinsert
+  call feedkeys("i\<C-R>=CompAnother()\<CR>f", 'tx')
+  call assert_equal("for", g:abbr)
+  call assert_equal(2, g:selected)
+
   " clean up
   set omnifunc=
   bw!
@@ -2866,8 +2882,11 @@ func Test_complete_fuzzy_match()
   delfunc OnPumChange
   delfunc Omni_test
   delfunc Comp
+  delfunc CompAnother
   unlet g:item
   unlet g:word
+  unlet g:selected
+  unlet g:abbr
 endfunc
 
 " Check that tie breaking is stable for completeopt+=fuzzy (which should


### PR DESCRIPTION
#### vim-patch:9.1.1107: cannot loop through completion menu with fuzzy

Problem:  cannot loop through completion menu with fuzzy and nosort in
          'completeopt'
          (Tomasz N)
Solution: Reset cur to zero and update compl_shown_match when
          'completeopt' contains "nosort" but not "noselect"
          (glepnir)

closes: vim/vim#16629

https://github.com/vim/vim/commit/c0b7ca406ba18640c56e2746d6f6d03549d53072

Co-authored-by: glepnir <glephunter@gmail.com>