### PR TITLE
fix(ui): send multigrid message position and size when the UI is refreshed

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2521,6 +2521,14 @@ void msg_reset_scroll(void)
   msg_grid_scroll_discount = 0;
 }
 
+void msg_ui_refresh(void)
+{
+  if (ui_has(kUIMultigrid) && msg_grid.chars) {
+    ui_call_grid_resize(msg_grid.handle, msg_grid.cols, msg_grid.rows);
+    ui_ext_msg_set_pos(msg_grid_pos, msg_scrolled);
+  }
+}
+
 /// Increment "msg_scrolled".
 static void inc_msg_scrolled(void)
 {

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -229,6 +229,7 @@ void ui_refresh(void)
     }
     msg_scroll_flush();
   }
+  msg_ui_refresh();
 
   if (!ui_active()) {
     return;

--- a/test/functional/ui/multigrid_spec.lua
+++ b/test/functional/ui/multigrid_spec.lua
@@ -2857,4 +2857,71 @@ describe('ext_multigrid', function()
       }})
     end)
   end)
+
+  it('message grid is shown at the correct position remote re-attach', function()
+    feed(':test')
+    local expected = {
+        grid = [[
+        ## grid 1
+          [2:-----------------------------------------------------]|*12
+          {11:[No Name]                                            }|
+          [3:-----------------------------------------------------]|
+        ## grid 2
+                                                               |
+          {1:~                                                    }|*11
+        ## grid 3
+          :test^                                                |
+        ]],
+        win_pos = {
+        [2] = {
+          height = 12,
+          startcol = 0,
+          startrow = 0,
+          width = 53,
+          win = 1000
+        }
+      },
+        win_viewport = {
+        [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+      },
+        win_viewport_margins = {
+        [2] = {
+          bottom = 0,
+          left = 0,
+          right = 0,
+          top = 0,
+          win = 1000
+        }
+      },
+      reset = true
+    }
+    screen:expect(expected)
+    feed('<cr>')
+    screen:detach()
+    screen:attach()
+    feed(':test')
+    screen:expect(expected)
+  end)
+end)
+
+it('headless attach with showcmd', function()
+  clear{args={'--headless'}}
+  local screen = Screen.new(80, 24, {ext_multigrid=true})
+  command('set showcmd')
+  feed('1234')
+  screen:expect({
+    grid = [[
+    ## grid 1
+      [2:--------------------------------------------------------------------------------]|*23
+      [3:--------------------------------------------------------------------------------]|
+    ## grid 2
+      ^                                                                                |
+      {1:~                                                                               }|*22
+    ## grid 3
+                                                                           1234       |
+    ]],
+    win_viewport = {
+      [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+    },
+  })
 end)

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -973,6 +973,10 @@ function Screen:_reset()
   self.wildmenu_items = nil
   self.wildmenu_pos = nil
   self._grid_win_extmarks = {}
+  self.msg_grid = nil
+  self.msg_grid_pos = nil
+  self.msg_scrolled = false
+  self.msg_sep_char = nil
 end
 
 --- @param cursor_style_enabled boolean


### PR DESCRIPTION
### Problem

The message grid position and size were not sent when a multigrid UI attaches, which causes it to show up in the wrong location. This occurs in at least two different situations
1. When a multigrid ui reattaches after first disconnecting
2. When nvim is started in `--headless` mode and a multigrid UI is attached

### Solution
Send the message position and size when the UI is refreshed. This might send too often, but I think it's safer to do that way, since it didn't seem to work when calling it from the attach function.

* fixes https://github.com/neovim/neovim/issues/30581