### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/ftplugin/exports.vim
+++ b/runtime/ftplugin/exports.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin
+" Language:     exports(5) configuration file
+" Maintainer:	Matt Perry <matt@mattperry.com>
+" Last Change:	2025 Feb 13
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=:# commentstring=#\ %s
+setlocal formatoptions-=t formatoptions+=croql
+
+let b:undo_ftplugin = 'setl com< cms< fo<'

--- a/runtime/ftplugin/samba.vim
+++ b/runtime/ftplugin/samba.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin
+" Language:     smb.conf(5) configuration file
+" Maintainer:	Matt Perry <matt@mattperry.com>
+" Last Change:	2025 Feb 13
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=:;,:# commentstring=#\ %s
+setlocal formatoptions-=t formatoptions+=croql
+
+let b:undo_ftplugin = 'setl com< cms< fo<'


### PR DESCRIPTION
#### vim-patch:407319f: runtime(samba): include simple filetype plugin

closes: vim/vim#16626

https://github.com/vim/vim/commit/407319fe89d5df2c732937474479803d67761879

Co-authored-by: Matt Perry <matt@mattperry.com>


#### vim-patch:d7deeff: runtime(exports): include simple filetype plugin

closes: vim/vim#16625

https://github.com/vim/vim/commit/d7deeffe11f4db3cce19236ddb80831652a87e83

Co-authored-by: Matt Perry <matt@mattperry.com>