### PR TITLE
ci(release): bump ubuntu images to 22.04

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -43,12 +43,12 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        runner: [ ubuntu-20.04, ubuntu-24.04-arm ]
+        runner: [ ubuntu-22.04, ubuntu-22.04-arm ]
         include:
-          - runner: ubuntu-20.04
+          - runner: ubuntu-22.04
             arch: x86_64
             cc: gcc-10
-          - runner: ubuntu-24.04-arm
+          - runner: ubuntu-22.04-arm
             arch: arm64
     runs-on: ${{ matrix.runner }}
     env:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
             { runner: ubuntu-24.04, os: ubuntu, flavor: asan, cc: clang, flags: -D ENABLE_ASAN_UBSAN=ON },
             { runner: ubuntu-24.04, os: ubuntu, flavor: tsan, cc: clang, flags: -D ENABLE_TSAN=ON },
             { runner: ubuntu-24.04, os: ubuntu, flavor: release, cc: gcc, flags: -D CMAKE_BUILD_TYPE=Release },
-            { runner: ubuntu-24.04-arm, os: ubuntu, flavor: arm, cc: gcc, flags: -D CMAKE_BUILD_TYPE=RelWithDebInfo },
+            { runner: ubuntu-22.04-arm, os: ubuntu, flavor: arm, cc: gcc, flags: -D CMAKE_BUILD_TYPE=RelWithDebInfo },
             { runner: macos-13, os: macos, flavor: intel, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
             { runner: macos-15, os: macos, flavor: arm, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
             { runner: ubuntu-24.04, os: ubuntu, flavor: puc-lua, cc: gcc, deps_flags: -D USE_BUNDLED_LUAJIT=OFF -D USE_BUNDLED_LUA=ON, flags: -D PREFER_LUA=ON },


### PR DESCRIPTION
Problem: The `ubuntu-20.04` runner image is being deprecated starting
2025-02-01 with full removal slated for 2025-04-01, see
https://github.com/actions/runner-images/issues/11101

Solution: Bump image to `ubuntu-22.04` and drop image to
`ubuntu-22.04-arm` to be consistent (also for tests).

Since several brownout periods are scheduled for March, it's better to
do this now.
