### PR TITLE
feat(lsp): add support for completionItem.command resolving

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -610,13 +610,14 @@ local function on_complete_done()
       clear_word()
       if err then
         vim.notify_once(err.message, vim.log.levels.WARN)
-      elseif result and result.additionalTextEdits then
-        lsp.util.apply_text_edits(result.additionalTextEdits, bufnr, position_encoding)
+      elseif result then
+        if result.additionalTextEdits then
+          lsp.util.apply_text_edits(result.additionalTextEdits, bufnr, position_encoding)
+        end
         if result.command then
           completion_item.command = result.command
         end
       end
-
       apply_snippet_and_command()
     end, bufnr)
   else

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -458,6 +458,7 @@ function protocol.make_client_capabilities()
           resolveSupport = {
             properties = {
               'additionalTextEdits',
+              'command',
             },
           },
           tagSupport = {


### PR DESCRIPTION
`command` was already resolved via a `completionItem/resolve` request
but only if `additionalTextEdits` were also present, and the
`resolveSupport` capability wasn't listed.

Closes https://github.com/neovim/neovim/issues/32406
