### PR TITLE
fix(lsp): reset the applied hints when processing the `refresh` request

### DIFF
--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -94,6 +94,10 @@ function M.on_refresh(err, _, ctx)
   for _, bufnr in ipairs(vim.lsp.get_buffers_by_client_id(ctx.client_id)) do
     for _, winid in ipairs(api.nvim_list_wins()) do
       if api.nvim_win_get_buf(winid) == bufnr then
+        local bufstate = bufstates[bufnr]
+        if bufstate then
+          bufstates[bufnr].applied = {}
+        end
         util._refresh(ms.textDocument_inlayHint, { bufnr = bufnr })
       end
     end

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -94,8 +94,7 @@ function M.on_refresh(err, _, ctx)
   for _, bufnr in ipairs(vim.lsp.get_buffers_by_client_id(ctx.client_id)) do
     for _, winid in ipairs(api.nvim_list_wins()) do
       if api.nvim_win_get_buf(winid) == bufnr then
-        local bufstate = bufstates[bufnr]
-        if bufstate then
+        if bufstates[bufnr] then
           bufstates[bufnr].applied = {}
         end
         util._refresh(ms.textDocument_inlayHint, { bufnr = bufnr })


### PR DESCRIPTION
Closes https://github.com/neovim/neovim/issues/32248.
Closes https://github.com/neovim/neovim/issues/32283.

I guess this bug means that our `workspace/inlayHint/refresh` handler has never worked correctly because we treat the new hints we receive as applied and ignore them.

Considering this, I will add two tests (along with one for https://github.com/neovim/neovim/pull/32426). I forgot how to use the test suite, so I would need to do this later in this PR or a follow-up PR if this PR is merged first.