### PR TITLE
ci(test): disable ubuntu arm

### DIFF
--- a/.github/workflows/notes.md
+++ b/.github/workflows/notes.md
@@ -36,7 +36,7 @@ Note: On Windows "Server" you may need to [install vcruntime140.dll](https://lea
 
 ### Linux (x86_64)
 
-glibc 2.31 or newer is required. Or you may try the (unsupported) [builds for older glibc](https://github.com/neovim/neovim-releases).
+glibc 2.35 or newer is required. Or you may try the (unsupported) [builds for older glibc](https://github.com/neovim/neovim-releases).
 
 #### AppImage
 
@@ -54,7 +54,7 @@ glibc 2.31 or newer is required. Or you may try the (unsupported) [builds for ol
 2. Extract: `tar xzvf nvim-linux-x86_64.tar.gz`
 3. Run `./nvim-linux-x86_64/bin/nvim`
 
-### Linux (arm64)
+### Linux (arm64) - Untested
 
 #### AppImage
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -111,7 +111,7 @@ jobs:
             { runner: ubuntu-24.04, os: ubuntu, flavor: asan, cc: clang, flags: -D ENABLE_ASAN_UBSAN=ON },
             { runner: ubuntu-24.04, os: ubuntu, flavor: tsan, cc: clang, flags: -D ENABLE_TSAN=ON },
             { runner: ubuntu-24.04, os: ubuntu, flavor: release, cc: gcc, flags: -D CMAKE_BUILD_TYPE=Release },
-            { runner: ubuntu-24.04-arm, os: ubuntu, flavor: arm, cc: gcc, flags: -D CMAKE_BUILD_TYPE=RelWithDebInfo },
+            # { runner: ubuntu-24.04-arm, os: ubuntu, flavor: arm, cc: gcc, flags: -D CMAKE_BUILD_TYPE=RelWithDebInfo },
             { runner: macos-13, os: macos, flavor: intel, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
             { runner: macos-15, os: macos, flavor: arm, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
             { runner: ubuntu-24.04, os: ubuntu, flavor: puc-lua, cc: gcc, deps_flags: -D USE_BUNDLED_LUAJIT=OFF -D USE_BUNDLED_LUA=ON, flags: -D PREFER_LUA=ON },

--- a/runtime/doc/support.txt
+++ b/runtime/doc/support.txt
@@ -13,11 +13,11 @@ Supported platforms					 *supported-platforms*
 
 `System`          `Tier`      `Versions`                  `Tested versions`
 Linux (x86_64)   1      >= 2.6.32, glibc >= 2.12     Ubuntu 24.04
-Linux (arm64)    1      >= 2.6.32, glibc >= 2.12     Ubuntu 24.04
 macOS (x86_64)   1      >= 11                        macOS 13
 macOS (arm64)    1      >= 11                        macOS 15
 Windows 64-bit   1      >= Windows 10 Version 1809   Windows Server 2022
 FreeBSD          1      >= 10                        FreeBSD 14
+Linux (arm64)    2      >= 2.6.32, glibc >= 2.12
 OpenBSD          2      >= 7
 MinGW            2      MinGW-w64
 Windows 64-bit   3      < Windows 10 Version 1809


### PR DESCRIPTION
There are too many flakes and intermittent failures to reliably use it.
Disable it for the time being until things stabilize.