### PR TITLE
fix(treesitter): don't spam query errors in the highlighter

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -232,7 +232,12 @@ end
 ---@return vim.treesitter.highlighter.Query
 function TSHighlighter:get_query(lang)
   if not self._queries[lang] then
-    self._queries[lang] = TSHighlighterQuery.new(lang)
+    local success, result = pcall(TSHighlighterQuery.new, lang)
+    if not success then
+      self:destroy()
+      error(result)
+    end
+    self._queries[lang] = result
   end
 
   return self._queries[lang]


### PR DESCRIPTION
**Problem:** An erroneous query in the treesitter highlighter gives a deluge of errors that makes the editor almost unusable.

**Solution:** Detach the highlighter after an error is detected, so that it only gets displayed once (per highlighter instance).

Closes #13959 (I think? depending on if this is deemed an acceptable solution)