### PR TITLE
fix(treesitter)!: enforce buffer is loaded when creating parser

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -175,6 +175,7 @@ TREESITTER
   the tree before returning. Scripts must call |LanguageTree:parse()| explicitly. >lua
     local p = vim.treesitter.get_parser(0, 'c')
     p:parse()
+• |vim.treesitter.get_parser()| expects its buffer to be loaded.
 <
 
 TUI

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -123,13 +123,6 @@ void try_leave(const TryState *const tstate, Error *const err)
     discard_current_exception();
   }
 
-  assert(msg_list == &tstate->private_msg_list);
-  assert(*msg_list == NULL);
-  assert(current_exception == NULL);
-  assert(!got_int);
-  assert(!did_throw);
-  assert(!need_rethrow);
-  assert(!did_emsg);
   // Restore the exception context.
   msg_list = (msglist_T **)tstate->msg_list;
   current_exception = tstate->current_exception;

--- a/test/functional/treesitter/fold_spec.lua
+++ b/test/functional/treesitter/fold_spec.lua
@@ -811,17 +811,19 @@ t2]])
     ]]
 
     -- foldexpr will return '0' for all lines
-    local levels = get_fold_levels() ---@type integer[]
-    eq(19, #levels)
-    for lnum, level in ipairs(levels) do
-      eq('0', level, string.format("foldlevel[%d] == %s; expected '0'", lnum, level))
+    local function expect_no_folds()
+      local levels = get_fold_levels() ---@type integer[]
+      eq(19, #levels)
+      for lnum, level in ipairs(levels) do
+        eq('0', level, string.format("foldlevel[%d] == %s; expected '0'", lnum, level))
+      end
     end
+    expect_no_folds()
 
     -- reload buffer as c filetype to simulate new parser being found
     feed('GA// vim: ft=c<Esc>')
     command([[write | edit]])
-
-    eq({
+    local foldlevels = {
       [1] = '>1',
       [2] = '1',
       [3] = '1',
@@ -841,6 +843,14 @@ t2]])
       [17] = '3',
       [18] = '2',
       [19] = '1',
-    }, get_fold_levels())
+    }
+    eq(foldlevels, get_fold_levels())
+
+    -- only changing filetype should change the parser again
+    command('set ft=some_filetype_without_treesitter_parser')
+    expect_no_folds()
+
+    command('set ft=c')
+    eq(foldlevels, get_fold_levels())
   end)
 end)


### PR DESCRIPTION
**fix(api): remove invalid assertions**

Problem: `try_leave()` assertions moved in #31600 no longer hold.
Solution: Remove the assertions.

**fix(treesitter): avoid computing fold levels for empty buffer**

Problem:  Computing fold levels for an empty buffer (somehow) breaks the
          parser state, resulting in a broken highlighter and foldexpr.
          Cached foldexpr parser is invalid after filetype has changed.
Solution: Avoid computing fold levels for empty buffer.
          Clear cached foldinfos upon `FileType`.

**fix(treesitter)!: enforce buffer is loaded when creating parser**
Problem: `vim.treesitter._create_parser()` silently loads the buffer,
					bypassing the swapfile prompt.
Solution: Error for an unloaded buffer, `:edit` an unloaded buffer in
					`vim.treesitter.start()` instead.

Fix #32359