### PR TITLE
docs: fix stdpath typing

### DIFF
--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -9351,6 +9351,14 @@ function vim.fn.stdioopen(opts) end
 --- @return string|string[]
 function vim.fn.stdpath(what) end
 
+--- @param what 'cache'|'config'|'data'|'log'|'run'|'state'
+--- @return string
+function vim.fn.stdpath(what) end
+
+--- @param what 'config_dirs'|'data_dirs'
+--- @return string[]
+function vim.fn.stdpath(what) end
+
 --- Convert String {string} to a Float.  This mostly works the
 --- same as when using a floating point number in an expression,
 --- see |floating-point-format|.  But it's a bit more permissive.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -11250,6 +11250,20 @@ M.funcs = {
     returns = 'string|string[]',
     signature = 'stdpath({what})',
   },
+  stdpath__1 = {
+    args = 1,
+    fast = true,
+    name = 'stdpath',
+    params = { { 'what', "'cache'|'config'|'data'|'log'|'run'|'state'" } },
+    returns = 'string',
+  },
+  stdpath__2 = {
+    args = 1,
+    fast = true,
+    name = 'stdpath',
+    params = { { 'what', "'config_dirs'|'data_dirs'" } },
+    returns = 'string[]',
+  },
   str2float = {
     args = 1,
     base = 1,


### PR DESCRIPTION
Problem: diagnostics say `stdpath('config')` return `string|string[]` but it's should return a `string`.
To avoid warnings require explitly `--[[@as string]]`.

Solution: overload it to make typing more accurate.
