### PR TITLE
fix(tests): remove the __extension__ keyword  in filter_complex_blocks

### DIFF
--- a/test/unit/testutil.lua
+++ b/test/unit/testutil.lua
@@ -151,6 +151,9 @@ local function filter_complex_blocks(body)
         or string.find(line, 'mach_vm_range_recipe')
       )
     then
+      -- Remove GCC's extension keyword which is just used to disable warnings.
+      line = string.gsub(line, '__extension__', '')
+
       -- HACK: remove bitfields from specific structs as luajit can't seem to handle them.
       if line:find('struct VTermState') then
         line = string.gsub(line, 'state : 8;', 'state;')


### PR DESCRIPTION
**Problem:** This keyword is used by GCC and Clang to prevent `-Wpedantic` (and other options) from emitting warnings for many GNU C extensions [\[1\]](https://gcc.gnu.org/onlinedocs/gcc/Alternate-Keywords.html). This is used heavily in [Alpine Linux](https://alpinelinux.org) through [musl libc](https://musl.libc.org) and [foritfy-headers](https://github.com/jvoisin/fortify-headers). Without filtering the `__extension__` keyword some type definitions are duplicated. For example, `struct timeval` is defined once as

```C
struct timeval { time_t tv_sec; suseconds_t tv_usec; };
```

and once as:

```C
__extension__ struct timeval { time_t tv_sec; suseconds_t tv_usec; };
```

Without this patch, the LuaJIT C parser doesn't recognize that these definitions are equivalent, causing unit test to fail on Alpine Linux.

**Solution:** Filter out the keyword in `filter_complex_blocks`.