### PR TITLE
refactor(channel): eliminate special case in on_proc_exit()

### DIFF
--- a/src/nvim/channel.h
+++ b/src/nvim/channel.h
@@ -40,7 +40,7 @@ struct Channel {
   CallbackReader on_data;
   CallbackReader on_stderr;
   Callback on_exit;
-  int exit_status;
+  int exit_status;  ///< Process exit-code (if the channel wraps a process).
 
   bool callback_busy;
   bool callback_scheduled;

--- a/src/nvim/event/proc.c
+++ b/src/nvim/event/proc.c
@@ -437,11 +437,6 @@ static void on_proc_exit(Proc *proc)
   Loop *loop = proc->loop;
   ILOG("child exited: pid=%d status=%d" PRIu64, proc->pid, proc->status);
 
-  // XXX: This assumes the TUI never spawns any other processes...?
-  if (ui_client_channel_id) {
-    exit_on_closed_chan(proc->status);
-  }
-
   // Process has terminated, but there could still be data to be read from the
   // OS. We are still in the libuv loop, so we cannot call code that polls for
   // more data directly. Instead delay the reading after the libuv loop by


### PR DESCRIPTION
Problem:
`on_proc_exit()` has a special-case that assumes the UI client will never spawn more than 1 child process.

Solution:
If the Nvim server exits, the stream EOF will trigger `rpc_close()` in the UI client, so we don't need the special case in `on_proc_exit`. Pass `Channel.exit_status` from `rpc_close()` so that the correct exit code is reflected.