### PR TITLE
fix(main): allow nvim -es to be used interactively with a TTY

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -388,7 +388,7 @@ int main(int argc, char **argv)
   debug_break_level = params.use_debug_break_level;
 
   // Read ex-commands if invoked with "-es".
-  if (!stdin_isatty && !params.input_istext && silent_mode && exmode_active) {
+  if (!params.input_istext && silent_mode && exmode_active) {
     input_start();
   }
 


### PR DESCRIPTION
When nvim -es is specified, the user enters ex mode and we don't enable the terminal UI.  In the modern day, the user is typically using this for scripting, but this also serves an important functionality as an editor of last resort when the user finds themselves without a terminal. ex mode is fully functional even on dumb terminals or when the terminfo database is broken, and this can allow a user to recover their system.

However, there's no reason that a user shouldn't be able to use this more interactively even if they do have a TTY.  This is not a common thing to want to do, but it should be possible.  There are some users who prefer an editor that does not take up the entire terminal, but may enjoy the flexibility and functionality of Neovim, so ex mode may be a good fit for them.

At the moment, though, Neovim breaks this use case by explicitly checking for a missing terminal before enabling input.  As a result, since we've enabled silent mode, we have no terminal UI to read data from and we don't read from standard input, so we just silently read nothing, and exit.

This is definitely not what the user wanted or what they asked for, and it's bizarre to make this work only when the user is missing a TTY, so let's just skip the TTY check altogether here so it works the same regardless.

Skip the test assertions on Windows because there the terminal outputs extra escape sequences we don't want and don't control. However, on other operating systems, this test needs to verify that the output is exactly as specified and doesn't contain any escape sequences, since users specifically will not want colors or other text with -es.
