### PR TITLE
feat(ftplugin): set 'omnifunc' of Lua to 'v:lua.vim.lua_omnifunc'

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1502,6 +1502,12 @@ both major engines implemented element, even if this is not in standards it
 will be suggested. All other elements are not placed in suggestion list.
 
 
+LUA                                                     *ft-lua-omni*
+
+Lua |ftplugin| sets |'omnifunc'| to `"v:lua.vim.lua_omnifunc"`. See
+|vim.lua_omnifunc()|.
+
+
 PHP							*ft-php-omni*
 
 Completion of PHP code requires a tags file for completion of data from

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1504,8 +1504,7 @@ will be suggested. All other elements are not placed in suggestion list.
 
 LUA                                                     *ft-lua-omni*
 
-Lua |ftplugin| sets |'omnifunc'| to `"v:lua.vim.lua_omnifunc"`. See
-|vim.lua_omnifunc()|.
+Lua |ftplugin| sets 'omnifunc' to |vim.lua_omnifunc()|.
 
 
 PHP							*ft-php-omni*

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -235,6 +235,9 @@ DEFAULTS
     • |[b|, |]b|, |[B|, |]B| navigate through the |buffer-list|
     • |[<Space>|, |]<Space>| add an empty line above and below the cursor
 
+• Options:
+  • Lua |ftplugin| sets |'omnifunc'| to `"v:lua.vim.lua_omnifunc"`.
+
 • Snippet:
   • `<Tab>` in Insert and Select mode maps to `vim.snippet.jump({ direction = 1 })`
     when a snippet is active and jumpable forwards.

--- a/runtime/ftplugin/lua.lua
+++ b/runtime/ftplugin/lua.lua
@@ -1,4 +1,7 @@
 -- use treesitter over syntax
 vim.treesitter.start()
 
-vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n call v:lua.vim.treesitter.stop()'
+vim.bo.omnifunc = 'v:lua.vim.lua_omnifunc'
+
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '')
+  .. '\n call v:lua.vim.treesitter.stop() \n setl omnifunc<'


### PR DESCRIPTION
Problem:
- Many other ftplugin have defined 'omnifunc', but the Lua one doesn't define one, even though there is `vim.lua_omnifunc()`
- Users may want "stupid" completion if they break their config and have to fix it with `nvim --clean`

Solution:
Set 'omnifunc' to 'v:lua.vim.lua_omnifunc' in ftplugin/lua.lua

TODO
- [x] insert.txt (`:h ft-lua-omni`)
- [x] news.txt (Under new features -> defaults -> options)