### PR TITLE
feat(marks): virtual lines support horizontal scrolling

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2651,6 +2651,12 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {opts})
                   • virt_lines_above: place virtual lines above instead.
                   • virt_lines_leftcol: Place virtual lines in the leftmost
                     column of the window, bypassing sign and number columns.
+                  • virt_lines_overflow: controls how to handle virtual lines
+                    wider than the window. Currently takes the one of the
+                    following values:
+                    • "trunc": truncate virtual lines on the right (default).
+                    • "scroll": virtual lines can scroll horizontally with
+                      'nowrap', otherwise the same as "trunc".
                   • ephemeral : for use with |nvim_set_decoration_provider()|
                     callbacks. The mark will only be used for the current
                     redraw cycle, and not be permantently stored in the

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -201,9 +201,12 @@ API
 • |nvim_echo()| `err` field to print error messages and `chunks` accepts
   highlight group IDs.
 • |nvim_open_win()| `relative` field can be set to "laststatus" and "tabline".
-• |nvim_buf_set_extmark()| `hl_group` field can be an array of layered groups
+• |nvim_buf_set_extmark()| new field `virt_lines_overflow` accepts value `scroll` to
+  enable horizontal scrolling for virtual lines with 'nowrap'.
+  right aligned text that truncates before covering up buffer text.
+• |nvim_buf_set_extmark()| `hl_group` field can be an array of layered groups.
 • |vim.hl.range()| now has a optional `timeout` field which allows for a timed highlight
-• |nvim_buf_set_extmark()| virt_text_pos accepts `eol_right_align` to
+• |nvim_buf_set_extmark()| `virt_text_pos` field accepts value `eol_right_align` to
   allow for right aligned text that truncates before covering up buffer text.
 
 DEFAULTS

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -641,7 +641,11 @@ function vim.api.nvim_buf_line_count(buffer) end
 --- - virt_lines_leftcol: Place virtual lines in the leftmost
 ---                       column of the window, bypassing
 ---                       sign and number columns.
----
+--- - virt_lines_overflow: controls how to handle virtual lines wider
+---     than the window. Currently takes the one of the following values:
+---   - "trunc": truncate virtual lines on the right (default).
+---   - "scroll": virtual lines can scroll horizontally with 'nowrap',
+---      otherwise the same as "trunc".
 --- - ephemeral : for use with `nvim_set_decoration_provider()`
 ---     callbacks. The mark will only be used for the current
 ---     redraw cycle, and not be permantently stored in the

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -258,6 +258,7 @@ error('Cannot require a meta file')
 --- @field virt_lines? any[]
 --- @field virt_lines_above? boolean
 --- @field virt_lines_leftcol? boolean
+--- @field virt_lines_overflow? string
 --- @field strict? boolean
 --- @field sign_text? string
 --- @field sign_hl_group? integer|string

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -45,6 +45,7 @@ typedef struct {
   Array virt_lines;
   Boolean virt_lines_above;
   Boolean virt_lines_leftcol;
+  String virt_lines_overflow;
   Boolean strict;
   String sign_text;
   HLGroupID sign_hl_group;

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -64,7 +64,7 @@
 #define NIL ((Object)OBJECT_INIT)
 #define NULL_STRING ((String)STRING_INIT)
 
-#define HAS_KEY(d, typ, key) (((d)->is_set__##typ##_ & (1 << KEYSET_OPTIDX_##typ##__##key)) != 0)
+#define HAS_KEY(d, typ, key) (((d)->is_set__##typ##_ & (1ULL << KEYSET_OPTIDX_##typ##__##key)) != 0)
 
 #define GET_BOOL_OR_TRUE(d, typ, key) (HAS_KEY(d, typ, key) ? (d)->key : true)
 
@@ -75,7 +75,7 @@
   kv_push_c(dict, ((KeyValuePair) { .key = cstr_as_string(k), .value = v }))
 
 #define PUT_KEY(d, typ, key, v) \
-  do { (d).is_set__##typ##_ |= (1 << KEYSET_OPTIDX_##typ##__##key); (d).key = v; } while (0)
+  do { (d).is_set__##typ##_ |= (1ULL << KEYSET_OPTIDX_##typ##__##key); (d).key = v; } while (0)
 
 #define ADD(array, item) \
   kv_push(array, item)

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -1169,15 +1169,17 @@ void decor_to_dict_legacy(Dict *dict, DecorInline decor, bool hl_name, Arena *ar
 
   if (virt_lines) {
     Array all_chunks = arena_array(arena, kv_size(virt_lines->data.virt_lines));
-    bool virt_lines_leftcol = false;
+    int virt_lines_flags = 0;
     for (size_t i = 0; i < kv_size(virt_lines->data.virt_lines); i++) {
-      virt_lines_leftcol = kv_A(virt_lines->data.virt_lines, i).left_col;
+      virt_lines_flags = kv_A(virt_lines->data.virt_lines, i).flags;
       Array chunks = virt_text_to_array(kv_A(virt_lines->data.virt_lines, i).line, hl_name, arena);
       ADD(all_chunks, ARRAY_OBJ(chunks));
     }
     PUT_C(*dict, "virt_lines", ARRAY_OBJ(all_chunks));
     PUT_C(*dict, "virt_lines_above", BOOLEAN_OBJ(virt_lines->flags & kVTLinesAbove));
-    PUT_C(*dict, "virt_lines_leftcol", BOOLEAN_OBJ(virt_lines_leftcol));
+    PUT_C(*dict, "virt_lines_leftcol", BOOLEAN_OBJ(virt_lines_flags & kVLLeftcol));
+    PUT_C(*dict, "virt_lines_overflow",
+          CSTR_AS_OBJ(virt_lines_flags & kVLScroll ? "scroll" : "trunc"));
     priority = virt_lines->priority;
   }
 

--- a/src/nvim/decoration_defs.h
+++ b/src/nvim/decoration_defs.h
@@ -26,7 +26,14 @@ typedef enum {
   kVPosWinCol,
 } VirtTextPos;
 
-typedef kvec_t(struct virt_line { VirtText line; bool left_col; }) VirtLines;
+/// Flags for virtual lines
+enum {
+  kVLLeftcol = 1,  ///< Start at left window edge, ignoring number column, etc.
+  kVLScroll = 2,   ///< Can scroll horizontally with 'nowrap'
+  // kVLWrap = 4,
+};
+
+typedef kvec_t(struct virt_line { VirtText line; int flags; }) VirtLines;
 
 typedef uint16_t DecorPriority;
 #define DECOR_PRIORITY_BASE 0x1000

--- a/test/functional/api/extmark_spec.lua
+++ b/test/functional/api/extmark_spec.lua
@@ -124,6 +124,10 @@ describe('API/extmarks', function()
     )
     eq("Invalid 'hl_mode': 'foo'", pcall_err(set_extmark, ns, marks[2], 0, 0, { hl_mode = 'foo' }))
     eq(
+      "Invalid 'virt_lines_overflow': 'foo'",
+      pcall_err(set_extmark, ns, marks[2], 0, 0, { virt_lines_overflow = 'foo' })
+    )
+    eq(
       "Invalid 'id': expected Integer, got Array",
       pcall_err(set_extmark, ns, {}, 0, 0, { end_col = 1, end_row = 1 })
     )
@@ -1576,11 +1580,6 @@ describe('API/extmarks', function()
       virt_text_hide = true,
       virt_text_pos = 'right_align',
     })
-    set_extmark(ns, marks[2], 0, 0, {
-      priority = 0,
-      virt_text = { { '', 'Macro' }, { '', { 'Type', 'Search' } }, { '' } },
-      virt_text_win_col = 1,
-    })
     eq({
       0,
       0,
@@ -1607,12 +1606,20 @@ describe('API/extmarks', function()
         },
         virt_lines_above = true,
         virt_lines_leftcol = true,
+        virt_lines_overflow = 'trunc',
         virt_text = { { 'text', 'Macro' }, { '???' }, { 'stack', { 'Type', 'Search' } } },
         virt_text_repeat_linebreak = false,
         virt_text_hide = true,
         virt_text_pos = 'right_align',
       },
     }, get_extmark_by_id(ns, marks[1], { details = true }))
+
+    set_extmark(ns, marks[2], 0, 0, {
+      priority = 0,
+      virt_text = { { '', 'Macro' }, { '', { 'Type', 'Search' } }, { '' } },
+      virt_text_repeat_linebreak = true,
+      virt_text_win_col = 1,
+    })
     eq({
       0,
       0,
@@ -1621,13 +1628,35 @@ describe('API/extmarks', function()
         right_gravity = true,
         priority = 0,
         virt_text = { { '', 'Macro' }, { '', { 'Type', 'Search' } }, { '' } },
-        virt_text_repeat_linebreak = false,
+        virt_text_repeat_linebreak = true,
         virt_text_hide = false,
         virt_text_pos = 'win_col',
         virt_text_win_col = 1,
       },
     }, get_extmark_by_id(ns, marks[2], { details = true }))
-    set_extmark(ns, marks[3], 0, 0, { cursorline_hl_group = 'Statement' })
+
+    set_extmark(ns, marks[3], 0, 0, {
+      priority = 0,
+      ui_watched = true,
+      virt_lines = { { { '', 'Macro' }, { '' }, { '', '' } } },
+      virt_lines_overflow = 'scroll',
+    })
+    eq({
+      0,
+      0,
+      {
+        ns_id = 1,
+        right_gravity = true,
+        ui_watched = true,
+        priority = 0,
+        virt_lines = { { { '', 'Macro' }, { '' }, { '', '' } } },
+        virt_lines_above = false,
+        virt_lines_leftcol = false,
+        virt_lines_overflow = 'scroll',
+      },
+    }, get_extmark_by_id(ns, marks[3], { details = true }))
+
+    set_extmark(ns, marks[4], 0, 0, { cursorline_hl_group = 'Statement' })
     eq({
       0,
       0,
@@ -1637,8 +1666,9 @@ describe('API/extmarks', function()
         priority = 4096,
         right_gravity = true,
       },
-    }, get_extmark_by_id(ns, marks[3], { details = true }))
-    set_extmark(ns, marks[4], 0, 0, {
+    }, get_extmark_by_id(ns, marks[4], { details = true }))
+
+    set_extmark(ns, marks[5], 0, 0, {
       end_col = 1,
       conceal = 'a',
       spell = true,
@@ -1655,8 +1685,9 @@ describe('API/extmarks', function()
         right_gravity = true,
         spell = true,
       },
-    }, get_extmark_by_id(ns, marks[4], { details = true }))
-    set_extmark(ns, marks[5], 0, 0, {
+    }, get_extmark_by_id(ns, marks[5], { details = true }))
+
+    set_extmark(ns, marks[6], 0, 0, {
       end_col = 1,
       spell = false,
     })
@@ -1671,7 +1702,8 @@ describe('API/extmarks', function()
         right_gravity = true,
         spell = false,
       },
-    }, get_extmark_by_id(ns, marks[5], { details = true }))
+    }, get_extmark_by_id(ns, marks[6], { details = true }))
+
     api.nvim_buf_clear_namespace(0, ns, 0, -1)
     -- legacy sign mark includes sign name
     command('sign define sign1 text=s1 texthl=Title linehl=LineNR numhl=Normal culhl=CursorLine')

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -4949,7 +4949,6 @@ if (h->n_buckets < new_n_buckets) { // expand
     ]]}
   end)
 
-
   it('works with hard TABs', function()
     insert(example_text2)
     feed 'gg'
@@ -5018,6 +5017,140 @@ if (h->n_buckets < new_n_buckets) { // expand
       {8:  8 }}                                             |
                                                         |
     ]]}
+  end)
+
+  it('scrolls horizontally with virt_lines_overflow = "scroll" #31000', function()
+    command('set nowrap signcolumn=yes')
+    insert('abcdefghijklmnopqrstuvwxyz')
+    api.nvim_buf_set_extmark(0, ns, 0, 0, {
+      virt_lines = {
+        { { '12αβ̳γ̲口=', 'Special' }, { '❤️345678', 'Special' } },
+        { { '123\t45\t678', 'NonText' } },
+      },
+      virt_lines_overflow = 'scroll',
+    })
+    screen:expect([[
+      {7:  }abcdefghijklmnopqrstuvwxy^z                      |
+      {7:  }{16:12αβ̳γ̲口=❤️345678}                                |
+      {7:  }{1:123     45      678}                             |
+      {1:~                                                 }|*8
+                                                        |
+    ]])
+    feed('zl')
+    screen:expect([[
+      {7:  }bcdefghijklmnopqrstuvwxy^z                       |
+      {7:  }{16:2αβ̳γ̲口=❤️345678}                                 |
+      {7:  }{1:23     45      678}                              |
+      {1:~                                                 }|*8
+                                                        |
+    ]])
+    feed('zl')
+    screen:expect([[
+      {7:  }cdefghijklmnopqrstuvwxy^z                        |
+      {7:  }{16:αβ̳γ̲口=❤️345678}                                  |
+      {7:  }{1:3     45      678}                               |
+      {1:~                                                 }|*8
+                                                        |
+    ]])
+    feed('zl')
+    screen:expect([[
+      {7:  }defghijklmnopqrstuvwxy^z                         |
+      {7:  }{16:β̳γ̲口=❤️345678}                                   |
+      {7:  }{1:     45      678}                                |
+      {1:~                                                 }|*8
+                                                        |
+    ]])
+    feed('zl')
+    screen:expect([[
+      {7:  }efghijklmnopqrstuvwxy^z                          |
+      {7:  }{16:γ̲口=❤️345678}                                    |
+      {7:  }{1:    45      678}                                 |
+      {1:~                                                 }|*8
+                                                        |
+    ]])
+    feed('zl')
+    screen:expect([[
+      {7:  }fghijklmnopqrstuvwxy^z                           |
+      {7:  }{16:口=❤️345678}                                     |
+      {7:  }{1:   45      678}                                  |
+      {1:~                                                 }|*8
+                                                        |
+    ]])
+    feed('zl')
+    screen:expect([[
+      {7:  }ghijklmnopqrstuvwxy^z                            |
+      {7:  }{16: =❤️345678}                                      |
+      {7:  }{1:  45      678}                                   |
+      {1:~                                                 }|*8
+                                                        |
+    ]])
+    feed('zl')
+    screen:expect([[
+      {7:  }hijklmnopqrstuvwxy^z                             |
+      {7:  }{16:=❤️345678}                                       |
+      {7:  }{1: 45      678}                                    |
+      {1:~                                                 }|*8
+                                                        |
+    ]])
+    feed('zl')
+    screen:expect([[
+      {7:  }ijklmnopqrstuvwxy^z                              |
+      {7:  }{16:❤️345678}                                        |
+      {7:  }{1:45      678}                                     |
+      {1:~                                                 }|*8
+                                                        |
+    ]])
+    feed('zl')
+    screen:expect([[
+      {7:  }jklmnopqrstuvwxy^z                               |
+      {7:  }{16: 345678}                                         |
+      {7:  }{1:5      678}                                      |
+      {1:~                                                 }|*8
+                                                        |
+    ]])
+    feed('zl')
+    screen:expect([[
+      {7:  }klmnopqrstuvwxy^z                                |
+      {7:  }{16:345678}                                          |
+      {7:  }{1:      678}                                       |
+      {1:~                                                 }|*8
+                                                        |
+    ]])
+    feed('zl')
+    screen:expect([[
+      {7:  }lmnopqrstuvwxy^z                                 |
+      {7:  }{16:45678}                                           |
+      {7:  }{1:     678}                                        |
+      {1:~                                                 }|*8
+                                                        |
+    ]])
+    feed('zl')
+    screen:expect([[
+      {7:  }mnopqrstuvwxy^z                                  |
+      {7:  }{16:5678}                                            |
+      {7:  }{1:    678}                                         |
+      {1:~                                                 }|*8
+                                                        |
+    ]])
+    api.nvim_buf_set_extmark(0, ns, 0, 1, {
+      virt_lines = { { { '123\t45\t67', 'NonText' } } },
+      virt_lines_leftcol = true,
+      virt_lines_overflow = 'trunc',
+    })
+    api.nvim_buf_set_extmark(0, ns, 0, 2, {
+      virt_lines = { { { '123\t45\t6', 'NonText' } } },
+      virt_lines_leftcol = false,
+      virt_lines_overflow = 'trunc',
+    })
+    screen:expect([[
+      {7:  }mnopqrstuvwxy^z                                  |
+      {7:  }{16:5678}                                            |
+      {7:  }{1:    678}                                         |
+      {1:123     45      67}                                |
+      {7:  }{1:123     45      6}                               |
+      {1:~                                                 }|*6
+                                                        |
+    ]])
   end)
 
   it('does not show twice if end_row or end_col is specified #18622', function()


### PR DESCRIPTION
Add a new field `virt_lines_overflow` that enables horizontal scrolling
for virtual lines when set to "scroll".

Ref https://github.com/neovim/neovim/issues/18282#issuecomment-2667771187
Close #31000
