### PR TITLE
vim-patch:5647c91: runtime(doc): add reference to extendnew() at extend()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -2167,7 +2167,8 @@ extend({expr1}, {expr2} [, {expr3}])                                  *extend()*
 		When {expr3} is omitted then "force" is assumed.
 
 		{expr1} is changed when {expr2} is not empty.  If necessary
-		make a copy of {expr1} first.
+		make a copy of {expr1} first or use |extendnew()| to return a
+		new List/Dictionary.
 		{expr2} remains unchanged.
 		When {expr1} is locked and {expr2} is not empty the operation
 		fails.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -1928,7 +1928,8 @@ function vim.fn.expandcmd(string, options) end
 --- When {expr3} is omitted then "force" is assumed.
 ---
 --- {expr1} is changed when {expr2} is not empty.  If necessary
---- make a copy of {expr1} first.
+--- make a copy of {expr1} first or use |extendnew()| to return a
+--- new List/Dictionary.
 --- {expr2} remains unchanged.
 --- When {expr1} is locked and {expr2} is not empty the operation
 --- fails.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -2481,7 +2481,8 @@ M.funcs = {
       When {expr3} is omitted then "force" is assumed.
 
       {expr1} is changed when {expr2} is not empty.  If necessary
-      make a copy of {expr1} first.
+      make a copy of {expr1} first or use |extendnew()| to return a
+      new List/Dictionary.
       {expr2} remains unchanged.
       When {expr1} is locked and {expr2} is not empty the operation
       fails.


### PR DESCRIPTION
#### vim-patch:5647c91: runtime(doc): add reference to extendnew() at extend()

related: vim/vim#16607

https://github.com/vim/vim/commit/5647c91355f1ff3a1030c737bf5133bb7da5bb76

Co-authored-by: Christian Brabandt <cb@256bit.org>