### PR TITLE
Backport #32483 to release-0.10

### DIFF
--- a/test/unit/testutil.lua
+++ b/test/unit/testutil.lua
@@ -151,6 +151,9 @@ local function filter_complex_blocks(body)
         or string.find(line, 'mach_vm_range_recipe')
       )
     then
+      -- Remove GCC's extension keyword which is just used to disable warnings.
+      line = string.gsub(line, '__extension__', '')
+
       result[#result + 1] = line
     end
   end


### PR DESCRIPTION
#### fix(tests): remove the __extension__ keyword  in filter_complex_blocks (#32483)
