### PR TITLE
docs(diagnostic): add comma in vim diagnostic config example

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -122,7 +122,7 @@ with |vim.notify()|: >lua
     -- Users can configure the handler
     vim.diagnostic.config({
       ["my/notify"] = {
-        log_level = vim.log.levels.INFO
+        log_level = vim.log.levels.INFO,
 
         -- This handler will only receive "error" diagnostics.
         severity = vim.diagnostic.severity.ERROR,


### PR DESCRIPTION
About this issue: https://github.com/neovim/neovim/issues/32499