### PR TITLE
fix(terminal): avoid more `busy_start` lacking `busy_stop`

### DIFF
--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -382,6 +382,31 @@ describe(':terminal cursor', function()
       ^                                                  |
                                                         |*5
     ]])
+
+    feed('i')
+    screen:expect([[
+      tty ready                                         |
+                                                        |*5
+      {3:-- TERMINAL --}                                    |
+    ]])
+
+    -- Cursor currently hidden; request to show it while in a TermLeave autocmd.
+    -- Process events (via :sleep) to handle the escape sequence immediately.
+    command([[autocmd TermLeave * ++once call chansend(b:terminal_job_id, "\e[?25h") | sleep 1m]])
+    feed([[<C-\><C-N>]]) -- Exit terminal mode
+    screen:expect([[
+      tty ready                                         |
+      ^                                                  |
+                                                        |*5
+    ]])
+
+    feed('i')
+    screen:expect([[
+      tty ready                                         |
+      ^                                                  |
+                                                        |*4
+      {3:-- TERMINAL --}                                    |
+    ]])
   end)
 end)
 


### PR DESCRIPTION
Problem: after #32458, it may still be possible for `busy_start` UI events to be emitted without matching `busy_stop`s in the terminal.

Solution: do `terminal_enter`'s cursor visibility check immediately after setting/restoring State so it occurs before events. This ensures that if pending escape sequences are processed while in `terminal_enter`, the cursor's initial visibility is set before `is_focused` is checked by `term_settermprop`.

As a result, we can move the call to `showmode` back to where it was originally.