### PR TITLE
feat(ftplugin):  add 'commentstring' '> %s' for mail

### DIFF
--- a/runtime/ftplugin/mail.vim
+++ b/runtime/ftplugin/mail.vim
@@ -24,6 +24,9 @@ endif
 " Set 'formatoptions' to break text lines and keep the comment leader ">".
 setlocal fo+=tcql
 
+" Set commentstring to quoting sign ">" so comment shortcuts can be used to
+" edit quoted parts of mail
+setlocal commentstring=>\ %s
 " Add n:> to 'comments, in case it was removed elsewhere
 setlocal comments+=n:>
 


### PR DESCRIPTION
Problem: When editing mail with Nvim, one could expect the commenting mechanism in mail files to work by adding or removing quotation signs for quoted email replies. This is not only due to the "similar feel" of the action to commenting, but especially because the commenting mechanism has no other apparent use when writing an email.

Solution: Add commentstring to `> %s` to be used in files of type mail.

(I tried to follow the contribution guidelines as best as I could, if I made a grave oversight I am sorry, I am very new to this. I am unsure if I should have created a draft PR first, but as far as I can have understood there is nothing else that would be missing, so I would be happy over feedback)