### PR TITLE
docs(api): new line between list items

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -22,6 +22,7 @@ MessagePack-RPC protocol with these extra (out-of-spec) constraints:
 
 1. Responses must be given in reverse order of requests (like "unwinding
    a stack").
+
 2. Nvim processes all messages (requests and notifications) in the order they
    are received.
 


### PR DESCRIPTION
In web doc, list items messed into a same line.

<img width="952" alt="image" src="https://github.com/user-attachments/assets/958a08be-0043-4de8-be3d-c9dd4c646389" />
