### PR TITLE
vim-patch:9.1.{1121,1126}

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1913,7 +1913,7 @@ static void ins_compl_new_leader(void)
     compl_restarting = false;
   }
 
-  compl_enter_selects = !compl_used_match;
+  compl_enter_selects = !compl_used_match && compl_selected_item != -1;
 
   // Show the popup menu with a different set of matches.
   ins_compl_show_pum();
@@ -2301,7 +2301,6 @@ bool ins_compl_prep(int c)
 {
   bool retval = false;
   const int prev_mode = ctrl_x_mode;
-  bool handle_enter = ((c == CAR || c == NL || c == K_KENTER) && compl_selected_item == -1);
 
   // Forget any previous 'special' messages if this is actually
   // a ^X mode key - bar ^R, in which case we wait to see what it gives us.
@@ -2368,12 +2367,6 @@ bool ins_compl_prep(int c)
          && !ins_compl_pum_key(c))
         || ctrl_x_mode == CTRL_X_FINISHED) {
       retval = ins_compl_stop(c, prev_mode, retval);
-      // When it is the Enter key and no selected item, return false, and
-      // continue processing the Enter key to insert a new line in the
-      // edit function.
-      if (retval && handle_enter) {
-        retval = false;
-      }
     }
   } else if (ctrl_x_mode == CTRL_X_LOCAL_MSG) {
     // Trigger the CompleteDone event to give scripts a chance to act

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1744,6 +1744,7 @@ void ins_compl_clear(void)
   compl_cont_status = 0;
   compl_started = false;
   compl_matches = 0;
+  compl_selected_item = -1;
   compl_ins_end_col = 0;
   API_CLEAR_STRING(compl_pattern);
   API_CLEAR_STRING(compl_leader);
@@ -2300,6 +2301,7 @@ bool ins_compl_prep(int c)
 {
   bool retval = false;
   const int prev_mode = ctrl_x_mode;
+  bool handle_enter = ((c == CAR || c == NL || c == K_KENTER) && compl_selected_item == -1);
 
   // Forget any previous 'special' messages if this is actually
   // a ^X mode key - bar ^R, in which case we wait to see what it gives us.
@@ -2366,6 +2368,12 @@ bool ins_compl_prep(int c)
          && !ins_compl_pum_key(c))
         || ctrl_x_mode == CTRL_X_FINISHED) {
       retval = ins_compl_stop(c, prev_mode, retval);
+      // When it is the Enter key and no selected item, return false, and
+      // continue processing the Enter key to insert a new line in the
+      // edit function.
+      if (retval && handle_enter) {
+        retval = false;
+      }
     }
   } else if (ctrl_x_mode == CTRL_X_LOCAL_MSG) {
     // Trigger the CompleteDone event to give scripts a chance to act

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -460,7 +460,7 @@ describe('completion', function()
         June]])
     end)
 
-    it('Enter does not select original text', function()
+    it('Enter inserts newline at original text after adding leader', function()
       feed('iJ<C-x><C-u>')
       poke_eventloop()
       feed('u')
@@ -506,21 +506,23 @@ describe('completion', function()
       ]])
     end)
 
-    it('Enter selects original text after adding leader and insert newline', function()
+    it('Enter inserts newline at original text after adding leader', function()
       feed('iJ<C-x><C-u>')
       poke_eventloop()
       feed('u')
       poke_eventloop()
       feed('<CR>')
-      expect([[Ju
-]])
+      expect([[
+        Ju
+        ]])
       feed('<Esc>')
       poke_eventloop()
       -- The behavior should be the same when completion has been interrupted,
       -- which can happen interactively if the completion function is slow.
       feed('ggVGSJ<C-x><C-u>u<CR>')
-      expect([[Ju
-]])
+      expect([[
+        Ju
+        ]])
     end)
   end)
 

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -506,19 +506,21 @@ describe('completion', function()
       ]])
     end)
 
-    it('Enter selects original text after adding leader', function()
+    it('Enter selects original text after adding leader and insert newline', function()
       feed('iJ<C-x><C-u>')
       poke_eventloop()
       feed('u')
       poke_eventloop()
       feed('<CR>')
-      expect('Ju')
+      expect([[Ju
+]])
       feed('<Esc>')
       poke_eventloop()
       -- The behavior should be the same when completion has been interrupted,
       -- which can happen interactively if the completion function is slow.
-      feed('SJ<C-x><C-u>u<CR>')
-      expect('Ju')
+      feed('ggVGSJ<C-x><C-u>u<CR>')
+      expect([[Ju
+]])
     end)
   end)
 

--- a/test/functional/legacy/edit_spec.lua
+++ b/test/functional/legacy/edit_spec.lua
@@ -94,7 +94,7 @@ describe('edit', function()
   end)
 
   -- oldtest: Test_edit_CAR()
-  it('insert a newline when pressing Enter, even if the pum is visible', function()
+  it('Enter inserts newline with pum at original text after adding leader', function()
     local screen = Screen.new(10, 6)
     command('set cot=menu,menuone,noselect')
     feed('Shello hero<CR>h<C-X><C-N>e')

--- a/test/functional/legacy/edit_spec.lua
+++ b/test/functional/legacy/edit_spec.lua
@@ -92,4 +92,28 @@ describe('edit', function()
                                                                   |
     ]])
   end)
+
+  -- oldtest: Test_edit_CAR()
+  it('insert a newline when pressing Enter, even if the pum is visible', function()
+    local screen = Screen.new(10, 6)
+    command('set cot=menu,menuone,noselect')
+    feed('Shello hero<CR>h<C-X><C-N>e')
+    screen:expect([[
+      hello hero  |
+      he^          |
+      {4:hello       }|
+      {4:hero        }|
+      {1:~           }|
+      {5:--}          |
+    ]])
+
+    feed('<CR>')
+    screen:expect([[
+      hello hero  |
+      he          |
+      ^            |
+      {1:~           }|*2
+      {5:-- INSERT --}|
+    ]])
+  end)
 end)

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -602,7 +602,7 @@ func Test_edit_CTRL_I()
   call assert_equal([include, 'two', ''], getline(1, '$'))
   call feedkeys("2ggC\<c-x>\<tab>\<down>\<down>\<cr>\<esc>", 'tnix')
   call assert_equal([include, 'three', ''], getline(1, '$'))
-  call feedkeys("2ggC\<c-x>\<tab>\<down>\<down>\<down>\<C-y>\<esc>", 'tnix')
+  call feedkeys("2ggC\<c-x>\<tab>\<down>\<down>\<down>\<cr>\<esc>", 'tnix')
   call assert_equal([include, '', ''], getline(1, '$'))
   call delete("Xinclude.txt")
   bw!
@@ -631,7 +631,7 @@ func Test_edit_CTRL_K()
   %d
   call setline(1, 'A')
   call cursor(1, 1)
-  call feedkeys("A\<c-x>\<c-k>\<down>\<down>\<down>\<C-Y>\<esc>", 'tnix')
+  call feedkeys("A\<c-x>\<c-k>\<down>\<down>\<down>\<cr>\<esc>", 'tnix')
   call assert_equal(['A'], getline(1, '$'))
   %d
   call setline(1, 'A')

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -200,7 +200,7 @@ func Test_edit_07()
     endif
   endfu
   au InsertCharPre <buffer> :call DoIt()
-  call feedkeys("A\<f5>\<c-p>u\<cr>\<c-l>\<cr>", 'tx')
+  call feedkeys("A\<f5>\<c-p>u\<C-Y>\<c-l>\<cr>", 'tx')
   call assert_equal(["Jan\<c-l>",''], 1->getline('$'))
   %d
   call setline(1, 'J')
@@ -602,7 +602,7 @@ func Test_edit_CTRL_I()
   call assert_equal([include, 'two', ''], getline(1, '$'))
   call feedkeys("2ggC\<c-x>\<tab>\<down>\<down>\<cr>\<esc>", 'tnix')
   call assert_equal([include, 'three', ''], getline(1, '$'))
-  call feedkeys("2ggC\<c-x>\<tab>\<down>\<down>\<down>\<cr>\<esc>", 'tnix')
+  call feedkeys("2ggC\<c-x>\<tab>\<down>\<down>\<down>\<C-y>\<esc>", 'tnix')
   call assert_equal([include, '', ''], getline(1, '$'))
   call delete("Xinclude.txt")
   bw!
@@ -631,7 +631,7 @@ func Test_edit_CTRL_K()
   %d
   call setline(1, 'A')
   call cursor(1, 1)
-  call feedkeys("A\<c-x>\<c-k>\<down>\<down>\<down>\<cr>\<esc>", 'tnix')
+  call feedkeys("A\<c-x>\<c-k>\<down>\<down>\<down>\<C-Y>\<esc>", 'tnix')
   call assert_equal(['A'], getline(1, '$'))
   %d
   call setline(1, 'A')
@@ -2286,6 +2286,17 @@ func Test_edit_backspace_smarttab_virtual_text()
   call CloseWindow()
   call prop_type_delete('theprop')
   set smarttab&
+endfunc
+
+func Test_edit_CAR()
+  set cot=menu,menuone,noselect
+  new
+
+  call feedkeys("Shello hero\<CR>h\<C-x>\<C-N>e\<CR>", 'tx')
+  call assert_equal(['hello hero', 'he', ''], getline(1, '$'))
+
+  bw!
+  set cot&
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2837,7 +2837,7 @@ func Test_complete_fuzzy_match()
   call setline(1, ['Text', 'ToText', ''])
   call cursor(2, 1)
   call feedkeys("STe\<C-X>\<C-N>x\<CR>\<Esc>0", 'tx!')
-  call assert_equal('Tex', getline('.'))
+  call assert_equal('Tex', getline(line('.') - 1))
 
   " test case for nosort option
   set cot=menuone,menu,noinsert,fuzzy,nosort

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -988,7 +988,7 @@ func Test_popup_complete_backwards()
   call setline(1, ['Post', 'Port', 'Po'])
   let expected=['Post', 'Port', 'Port']
   call cursor(3,2)
-  call feedkeys("A\<C-X>". repeat("\<C-P>", 3). "rt\<cr>", 'tx')
+  call feedkeys("A\<C-X>". repeat("\<C-P>", 3). "rt\<C-Y>", 'tx')
   call assert_equal(expected, getline(1,'$'))
   bwipe!
 endfunc
@@ -998,7 +998,7 @@ func Test_popup_complete_backwards_ctrl_p()
   call setline(1, ['Post', 'Port', 'Po'])
   let expected=['Post', 'Port', 'Port']
   call cursor(3,2)
-  call feedkeys("A\<C-P>\<C-N>rt\<cr>", 'tx')
+  call feedkeys("A\<C-P>\<C-N>rt\<C-Y>", 'tx')
   call assert_equal(expected, getline(1,'$'))
   bwipe!
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.1121: Enter does not insert newline with "noselect"

Problem:  Enter does not insert newline with "noselect" when the pum is
          visible (lifepillar)
Solution: When Enter is pressed and no complete-item is selected,
          ins_compl_prep returns false, and the edit function continues
          processing Enter to insert a new line. (glepnir)

fixes: vim/vim#1653
closes: vim/vim#16653

https://github.com/vim/vim/commit/07f0dbe3aa326fdf4d0f1b1cf7d79df89e91fc6e


#### vim-patch:9.1.1126: patch 9.1.1121 used a wrong way to handle enter

Problem:  patch 9.1.1121 used a wrong way to handle enter
Solution: compl_enter_selects also needs to consider the selected item
          in ins_compl_new_leader() (glepnir)

closes: vim/vim#16673

https://github.com/vim/vim/commit/44180416981000ad0bc5db4686889892e7a05cdd