### PR TITLE
feat(messages): confirm kind for z=, :tselect, inputlist()

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -791,7 +791,8 @@ must handle.
 	    Name indicating the message kind:
 		"" (empty)	Unknown (consider a |feature-request|)
 		"bufwrite"	|:write| message
-		"confirm"	|confirm()| or |:confirm| dialog
+		"confirm"	Message preceding a prompt (|:confirm|,
+				|confirm()|, |inputlist()|, |z=,|, …)
 		"emsg"		Error (|errors|, internal error, |:throw|, …)
 		"echo"		|:echo| message
 		"echomsg"	|:echomsg| message

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3556,7 +3556,7 @@ static void f_inputlist(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     return;
   }
 
-  msg_ext_set_kind("list_cmd");
+  msg_ext_set_kind("confirm");
   msg_start();
   msg_row = Rows - 1;   // for when 'cmdheight' > 1
   lines_left = Rows;    // avoid more prompt

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -516,7 +516,7 @@ void spell_suggest(int count)
   spell_find_suggest(line + curwin->w_cursor.col, badlen, &sug, limit,
                      true, need_cap, true);
 
-  msg_ext_set_kind("list_cmd");
+  msg_ext_set_kind("confirm");
   if (GA_EMPTY(&sug.su_ga)) {
     msg(_("Sorry, no suggestions"), 0);
   } else if (count > 0) {

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -813,6 +813,7 @@ static void print_tag_list(bool new_tag, bool use_tagstack, int num_matches, cha
   if (msg_col == 0) {
     msg_didout = false;     // overwrite previous message
   }
+  msg_ext_set_kind("confirm");
   msg_start();
   msg_puts_hl(_("  # pri kind tag"), HLF_T, false);
   msg_clr_eos();

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -33,6 +33,7 @@ describe('ui/ext_messages', function()
     screen = Screen.new(25, 5, { rgb = true, ext_messages = true, ext_popupmenu = true })
     screen:add_extra_attr_ids {
       [100] = { undercurl = true, special = Screen.colors.Red },
+      [101] = { foreground = Screen.colors.Magenta1, bold = true },
     }
   end)
   after_each(function()
@@ -391,10 +392,52 @@ describe('ui/ext_messages', function()
       },
     })
 
+    feed('<CR>')
+    n.add_builddir_to_rtp()
+    feed(':help<CR>:tselect<CR>')
+    local tagfile = t.paths.test_build_dir .. '/runtime/doc/help.txt'
+    if t.is_os('win') then
+      tagfile = tagfile:gsub('/', '\\')
+    end
+    screen:expect({
+      grid = [[
+        ^*help.txt*      Nvim     |
+                                 |
+        {3:help.txt [Help][RO]      }|
+        line                     |
+        {2:<i_messages_spec [+][RO] }|
+      ]],
+      cmdline = {
+        {
+          content = { { '' } },
+          hl_id = 0,
+          pos = 0,
+          prompt = 'Type number and <Enter> (q or empty cancels): ',
+        },
+      },
+      messages = {
+        {
+          content = {
+            { '  # pri kind tag', 101, 23 },
+            { '\n                        ' },
+            { 'file\n', 101, 23 },
+            { '> 1 F        ' },
+            { 'help.txt', 101, 23 },
+            { ' \n                        ' },
+            { tagfile, 18, 5 },
+            { '\n               *help.txt*\n' },
+          },
+          history = false,
+          kind = 'confirm',
+        },
+      },
+    })
+    feed('<CR>:bd<CR>')
+
     -- kind=shell for :!cmd messages
     local cmd = t.is_os('win') and 'echo stdout& echo stderr>&2& exit 3'
       or '{ echo stdout; echo stderr >&2; exit 3; }'
-    feed(('<CR>:!%s<CR>'):format(cmd))
+    feed((':!%s<CR>'):format(cmd))
     screen:expect({
       cmdline = { { abort = false } },
       messages = {
@@ -1266,7 +1309,7 @@ stack traceback:
         {
           content = { { 'Change "helllo" to:\n 1 "Hello"\n 2 "Hallo"\n 3 "Hullo"\n' } },
           history = false,
-          kind = 'list_cmd',
+          kind = 'confirm',
         },
       },
     })
@@ -1289,7 +1332,7 @@ stack traceback:
         {
           content = { { 'Change "helllo" to:\n 1 "Hello"\n 2 "Hallo"\n 3 "Hullo"\n' } },
           history = false,
-          kind = 'list_cmd',
+          kind = 'confirm',
         },
       },
     })
@@ -1321,7 +1364,7 @@ stack traceback:
         {
           content = { { 'input0\ninput1\n' } },
           history = false,
-          kind = 'list_cmd',
+          kind = 'confirm',
         },
       },
     })


### PR DESCRIPTION
Problem:  Messages preceding a `cmdline_show->prompt` event can not be
          distinguished as such when receiving the event. (But since
          `msg_show` handlers should be scheduled, one can already check
          whether a prompt is active when displaying the message.)
Solution: Rather than add a new kind again, use the `confirm` kind.
          Could be seen as slightly misleading where it is more of
          a choice rather than a confirmation, but that already applies
          to `confirm()` as well...

Fix #32301
Fix #32380