### PR TITLE
fix(tests): filter out lines with __typeof__ keyword

### DIFF
--- a/test/unit/testutil.lua
+++ b/test/unit/testutil.lua
@@ -146,6 +146,8 @@ local function filter_complex_blocks(body)
         or string.find(line, 'value_init_')
         or string.find(line, 'UUID_NULL') -- static const uuid_t UUID_NULL = {...}
         or string.find(line, 'inline _Bool')
+        -- used by musl libc headers on 32-bit arches via __REDIR marco
+        or string.find(line, '__typeof__')
         -- used by macOS headers
         or string.find(line, 'typedef enum : ')
         or string.find(line, 'mach_vm_range_recipe')


### PR DESCRIPTION
**Problem:** On 32-bit architectures, [musl libc](https://musl.libc.org) makes heavy use of `__typeof__` as part of its [`__REDIR` macro](https://git.musl-libc.org/cgit/musl/tree/include/features.h?h=v1.2.5#n38) for optional backwards compatibility with 32-bit `time_t` values [\[1\]](https://git.musl-libc.org/cgit/musl/commit/?id=c0450320940c8c45f3847f2d0a22c0ebc545b291). Unfortunately, the `__typeof__` keyword is not supported by the LuaJIT C parser.

**Solution:** Filter out the keyword in `filter_complex_blocks`.