### PR TITLE
fix(messages): list_cmd kind for :registers, :au[g]

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -554,6 +554,7 @@ void do_augroup(char *arg, bool del_group)
     current_augroup = augroup_add(arg);
   } else {  // ":aug": list the group names
     msg_start();
+    msg_ext_set_kind("list_cmd");
 
     String name;
     int value;
@@ -855,6 +856,7 @@ void do_autocmd(exarg_T *eap, char *arg_in, int forceit)
   // Print header when showing autocommands.
   if (is_showing) {
     // Highlight title
+    msg_ext_set_kind("list_cmd");
     msg_puts_title(_("\n--- Autocommands ---"));
 
     if (*arg == '*' || *arg == '|' || *arg == NUL) {

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -3162,6 +3162,8 @@ void msg_ext_ui_flush(void)
   if (!ui_has(kUIMessages)) {
     msg_ext_kind = NULL;
     return;
+  } else if (msg_ext_skip_flush) {
+    return;
   }
 
   msg_ext_emit_chunk();

--- a/src/nvim/message.h
+++ b/src/nvim/message.h
@@ -34,6 +34,8 @@ extern MessageHistoryEntry *first_msg_hist;
 extern MessageHistoryEntry *last_msg_hist;
 
 EXTERN bool msg_ext_need_clear INIT( = false);
+// Set to true to force grouping a set of message chunks into a single `cmdline_show` event.
+EXTERN bool msg_ext_skip_flush INIT( = false);
 
 /// allocated grid for messages. Used when display+=msgsep is set, or
 /// ext_multigrid is active. See also the description at msg_scroll_flush()

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3770,10 +3770,16 @@ void ex_display(exarg_T *eap)
   }
   int hl_id = HLF_8;
 
+  msg_ext_set_kind("list_cmd");
+  msg_ext_skip_flush = true;
   // Highlight title
   msg_puts_title(_("\nType Name Content"));
   for (int i = -1; i < NUM_REGISTERS && !got_int; i++) {
     int name = get_register_name(i);
+    if (arg != NULL && vim_strchr(arg, name) == NULL) {
+      continue;             // did not ask for this register
+    }
+
     switch (get_reg_type(name, NULL)) {
     case kMTLineWise:
       type = 'l'; break;
@@ -3781,10 +3787,6 @@ void ex_display(exarg_T *eap)
       type = 'c'; break;
     default:
       type = 'b'; break;
-    }
-
-    if (arg != NULL && vim_strchr(arg, name) == NULL) {
-      continue;             // did not ask for this register
     }
 
     if (i == -1) {
@@ -3890,6 +3892,7 @@ void ex_display(exarg_T *eap)
     msg_puts("\n  c  \"=   ");
     dis_msg(expr_line, false);
   }
+  msg_ext_skip_flush = false;
 }
 
 /// display a string for do_dis()

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -43,11 +43,12 @@ describe('ui/ext_messages', function()
   it('msg_clear follows msg_show kind of confirm', function()
     feed('iline 1<esc>')
     feed(':call confirm("test")<cr>')
+    local s1 = [[
+      line ^1                   |
+      {1:~                        }|*4
+    ]]
     screen:expect({
-      grid = [[
-        line ^1                   |
-        {1:~                        }|*4
-      ]],
+      grid = s1,
       cmdline = {
         {
           content = { { '' } },
@@ -65,13 +66,7 @@ describe('ui/ext_messages', function()
       },
     })
     feed('<cr>')
-    screen:expect({
-      grid = [[
-        line ^1                   |
-        {1:~                        }|*4
-      ]],
-      cmdline = { { abort = false } },
-    })
+    screen:expect({ grid = s1, cmdline = { { abort = false } } })
   end)
 
   it('msg_show kinds', function()
@@ -79,12 +74,13 @@ describe('ui/ext_messages', function()
 
     -- confirm is now cmdline prompt
     feed(':echo confirm("test")<cr>')
+    local s1 = [[
+      line 1                   |
+      line ^2                   |
+      {1:~                        }|*3
+    ]]
     screen:expect({
-      grid = [[
-        line 1                   |
-        line ^2                   |
-        {1:~                        }|*3
-      ]],
+      grid = s1,
       cmdline = {
         {
           content = { { '' } },
@@ -103,11 +99,7 @@ describe('ui/ext_messages', function()
     })
     feed('<cr>')
     screen:expect({
-      grid = [[
-        line 1                   |
-        line ^2                   |
-        {1:~                        }|*3
-      ]],
+      grid = s1,
       cmdline = { { abort = false } },
       messages = {
         {
@@ -169,13 +161,9 @@ describe('ui/ext_messages', function()
     })
 
     -- kind=wmsg ('wrapscan' after search reaches EOF)
-    feed('uG$/i<cr>')
+    feed('uG$/i<CR>G$')
     screen:expect {
-      grid = [[
-      l^ine 1                   |
-      line 2                   |
-      {1:~                        }|*3
-    ]],
+      grid = s1,
       cmdline = { { abort = false } },
       messages = {
         {
@@ -189,6 +177,7 @@ describe('ui/ext_messages', function()
     -- kind=emsg after :throw
     feed(':throw "foo"<cr>')
     screen:expect {
+      grid = s1,
       cmdline = { { abort = false } },
       messages = {
         {
@@ -212,13 +201,9 @@ describe('ui/ext_messages', function()
     -- kind=quickfix after :cnext
     feed('<c-c>')
     command("caddexpr [expand('%').':1:line1',expand('%').':2:line2']")
-    feed(':cnext<cr>')
+    feed(':cnext<CR>$')
     screen:expect {
-      grid = [[
-      line 1                   |
-      ^line 2                   |
-      {1:~                        }|*3
-    ]],
+      grid = s1,
       cmdline = { { abort = false } },
       messages = {
         {
@@ -230,13 +215,9 @@ describe('ui/ext_messages', function()
     }
 
     -- search_cmd
-    feed('?line<cr>')
+    feed('?line<CR>G$')
     screen:expect({
-      grid = [[
-        ^line 1                   |
-        line 2                   |
-        {1:~                        }|*3
-      ]],
+      grid = s1,
       cmdline = { { abort = false } },
       messages = {
         {
@@ -248,8 +229,9 @@ describe('ui/ext_messages', function()
     })
 
     -- highlight
-    feed(':filter character highlight<CR>')
+    feed('G$:filter character highlight<CR>')
     screen:expect({
+      grid = s1,
       cmdline = { { abort = false } },
       messages = {
         {
@@ -287,12 +269,13 @@ describe('ui/ext_messages', function()
     })
 
     feed('<C-r><C-r><C-r>')
+    local s2 = [[
+      line 1                   |
+      line^                     |
+      {1:~                        }|*3
+    ]]
     screen:expect({
-      grid = [[
-        line 1                   |
-        line^                     |
-        {1:~                        }|*3
-      ]],
+      grid = s2,
       messages = {
         {
           content = { { 'Already at newest change' } },
@@ -306,6 +289,7 @@ describe('ui/ext_messages', function()
     command('set noshowmode')
     feed('i<C-n>')
     screen:expect({
+      grid = s2,
       messages = {
         {
           content = { { 'The only match' } },
@@ -314,12 +298,13 @@ describe('ui/ext_messages', function()
         },
       },
     })
-    feed('<Esc>')
+    feed('<Esc>l')
     command('set showmode')
 
     -- kind=echoerr for nvim_echo() err
     feed(':call nvim_echo([["Error"], ["Message", "Special"]], 1, #{ err:1 })<CR>')
     screen:expect({
+      grid = s2,
       cmdline = { { abort = false } },
       messages = {
         {
@@ -333,6 +318,7 @@ describe('ui/ext_messages', function()
     -- kind=verbose for nvim_echo() verbose
     feed(':call nvim_echo([["Verbose Message"]], 1, #{ verbose:1 })<CR>')
     screen:expect({
+      grid = s2,
       cmdline = { { abort = false } },
       messages = {
         {
@@ -346,6 +332,7 @@ describe('ui/ext_messages', function()
     -- kind=verbose for :verbose messages
     feed(':1verbose filter Diff[AC] hi<CR>')
     screen:expect({
+      grid = s2,
       cmdline = { { abort = false } },
       messages = {
         {
@@ -439,6 +426,7 @@ describe('ui/ext_messages', function()
       or '{ echo stdout; echo stderr >&2; exit 3; }'
     feed((':!%s<CR>'):format(cmd))
     screen:expect({
+      grid = s2,
       cmdline = { { abort = false } },
       messages = {
         {
@@ -465,6 +453,41 @@ describe('ui/ext_messages', function()
           content = { { 'Press ENTER or type command to continue', 6, 18 } },
           history = false,
           kind = 'return_prompt',
+        },
+      },
+    })
+
+    feed('<CR>:registers .<CR>')
+    screen:expect({
+      grid = s2,
+      cmdline = { {
+        abort = false,
+      } },
+      messages = {
+        {
+          content = { { '\nType Name Content', 101, 23 }, { '\n  c  ".   ' } },
+          history = false,
+          kind = 'list_cmd',
+        },
+      },
+    })
+
+    feed(':au ChanInfo * foo<CR>:au ChanInfo<CR>')
+    screen:expect({
+      grid = s2,
+      cmdline = { {
+        abort = false,
+      } },
+      messages = {
+        {
+          content = {
+            { '\n--- Autocommands ---', 101, 23 },
+            { '\n' },
+            { 'ChanInfo', 101, 23 },
+            { '\n*foo' },
+          },
+          history = false,
+          kind = 'list_cmd',
         },
       },
     })


### PR DESCRIPTION
Problem:  No kind for `:registers/autocmd/augroup` messages. `:registers`
          chunks are emitted as separate `msg_show` events.
Solution: Add the `list_cmd` kind to the message. Introduce a new
          `msg_ext_skip_flush` variable to set to true around a
          group of to be paired message chunks.

Fix #32525
Fix #32542