### PR TITLE
vim-patch:9.1.1124: No test for 'listchars' "precedes" with double-width char

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2576,15 +2576,15 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
 
     // Handle the case where we are in column 0 but not on the first
     // character of the line and the user wants us to show us a
-    // special character (via 'listchars' option "precedes:<char>".
+    // special character (via 'listchars' option "precedes:<char>").
     if (lcs_prec_todo != NUL
         && wp->w_p_list
         && (wp->w_p_wrap ? (wp->w_skipcol > 0 && wlv.row == 0) : wp->w_leftcol > 0)
         && wlv.filler_todo <= 0
         && mb_schar != NUL) {
-      mb_schar = wp->w_p_lcs_chars.prec;
       lcs_prec_todo = NUL;
-      if (schar_cells(mb_schar) > 1) {
+      // TODO(zeertzjq): handle the n_extra > 0 case
+      if (schar_cells(mb_schar) > 1 && wlv.n_extra == 0) {
         // Double-width character being overwritten by the "precedes"
         // character, need to fill up half the character.
         wlv.sc_extra = schar_from_ascii(MB_FILLER_CHAR);
@@ -2593,6 +2593,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
         wlv.n_attr = 2;
         wlv.extra_attr = win_hl_attr(wp, HLF_AT);
       }
+      mb_schar = wp->w_p_lcs_chars.prec;
       mb_c = schar_get_first_codepoint(mb_schar);
       saved_attr3 = wlv.char_attr;  // save current attr
       wlv.char_attr = win_hl_attr(wp, HLF_AT);  // overwriting char_attr

--- a/test/old/testdir/test_listchars.vim
+++ b/test/old/testdir/test_listchars.vim
@@ -647,7 +647,7 @@ func Test_listchars_foldcolumn()
       vsplit
       windo set signcolumn=yes foldcolumn=1 winminwidth=0 nowrap list listchars=extends:>,precedes:<
   END
-  call writefile(lines, 'XTest_listchars')
+  call writefile(lines, 'XTest_listchars', 'D')
 
   let buf = RunVimInTerminal('-S XTest_listchars', {'rows': 10, 'cols': 60})
 
@@ -670,8 +670,36 @@ func Test_listchars_foldcolumn()
 
   " clean up
   call StopVimInTerminal(buf)
-  call delete('XTest_listchars')
 endfunc
 
+func Test_listchars_precedes_with_wide_char()
+  new
+  setlocal nowrap list listchars=eol:$,precedes:!
+  call setline(1, '123口456')
+  call assert_equal(['123口456$ '], ScreenLines(1, 10))
+  let attr = screenattr(1, 9)
+  normal! zl
+  call assert_equal(['!3口456$  '], ScreenLines(1, 10))
+  call assert_equal(attr, screenattr(1, 1))
+  normal! zl
+  call assert_equal(['!口456$   '], ScreenLines(1, 10))
+  call assert_equal(attr, screenattr(1, 1))
+  normal! zl
+  call assert_equal(['!<456$    '], ScreenLines(1, 10))
+  call assert_equal(attr, screenattr(1, 1))
+  call assert_equal(attr, screenattr(1, 2))
+  normal! zl
+  " TODO: should it be '!' instead of '<' here?
+  call assert_equal(['<456$     '], ScreenLines(1, 10))
+  call assert_equal(attr, screenattr(1, 1))
+  normal! zl
+  call assert_equal(['!56$      '], ScreenLines(1, 10))
+  call assert_equal(attr, screenattr(1, 1))
+  normal! zl
+  call assert_equal(['!6$       '], ScreenLines(1, 10))
+  call assert_equal(attr, screenattr(1, 1))
+
+  bw!
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1124: No test for 'listchars' "precedes" with double-width char

Problem:  No test for 'listchars' "precedes" with double-width char.
Solution: Add a test and fix a typo in code (zeertzjq).

closes: vim/vim#16675

https://github.com/vim/vim/commit/08a83a033a32c0f5bc42eaa63162c21c369cb4ae

Cherry-pick test_listchars.vim changes from patch 9.0.0625.
Fix a regression from #30014 by moving the mb_schar assignment after the
double-width check.