### PR TITLE
vim-patch:9.1.1125: cannot loop through pum menu with multiline items

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1296,7 +1296,7 @@ static int ins_compl_build_pum(void)
             compl_shown_match = comp;
           }
         }
-        if (!shown_match_ok && comp == compl_shown_match && !compl_no_select) {
+        if (!shown_match_ok && comp == compl_shown_match) {
           cur = i;
           shown_match_ok = true;
         }

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2873,6 +2873,14 @@ func Test_complete_fuzzy_match()
   call assert_equal("for", g:abbr)
   call assert_equal(2, g:selected)
 
+  set cot=menu,menuone,noselect,fuzzy
+  call feedkeys("i\<C-R>=CompAnother()\<CR>\<C-N>\<C-N>\<C-N>\<C-N>", 'tx')
+  call assert_equal("foo", g:word)
+  call feedkeys("i\<C-R>=CompAnother()\<CR>\<C-P>", 'tx')
+  call assert_equal("foo", g:word)
+  call feedkeys("i\<C-R>=CompAnother()\<CR>\<C-P>\<C-P>", 'tx')
+  call assert_equal("for", g:abbr)
+
   " clean up
   set omnifunc=
   bw!


### PR DESCRIPTION
#### vim-patch:9.1.1125: cannot loop through pum menu with multiline items

Problem:  cannot loop through pum menu with multiline items with
          fuzzy and noselect in 'completeopt' (Tomasz N)
Solution: remove unnecessary compl_no_select condition (glepnir)

closes: vim/vim#16674

https://github.com/vim/vim/commit/3af0a8d8f5b090a6a4b085e7b6ee0f5f87eda399

Co-authored-by: glepnir <glephunter@gmail.com>