### PR TITLE
vim-patch:9.1.1127: preinsert text is not cleaned up correctly

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -562,10 +562,10 @@ static int insert_execute(VimState *state, int key)
   // Special handling of keys while the popup menu is visible or wanted
   // and the cursor is still in the completed word.  Only when there is
   // a match, skip this when no matches were found.
-  if (ins_compl_active()
-      && pum_wanted()
-      && curwin->w_cursor.col >= ins_compl_col()
-      && ins_compl_has_shown_match()) {
+  bool ins_completion = ins_compl_active()
+                        && curwin->w_cursor.col >= ins_compl_col()
+                        && ins_compl_has_shown_match();
+  if (ins_completion && pum_wanted()) {
     // BS: Delete one character from "compl_leader".
     if ((s->c == K_BS || s->c == Ctrl_H)
         && curwin->w_cursor.col > ins_compl_col()
@@ -615,6 +615,8 @@ static int insert_execute(VimState *state, int key)
         ins_compl_delete(false);
       }
     }
+  } else if (ins_completion && !pum_wanted() && ins_compl_preinsert_effect()) {
+    ins_compl_delete(false);
   }
 
   // Prepare for or stop CTRL-X mode. This doesn't do completion, but it does

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -3102,6 +3102,11 @@ function Test_completeopt_preinsert()
   call assert_equal("fobar", getline('.'))
   call assert_equal(5, col('.'))
 
+  set cot=preinsert
+  call feedkeys("Sfoo1 foo2\<CR>f\<C-X>\<C-N>bar", 'tx')
+  call assert_equal("fbar", getline('.'))
+  call assert_equal(4, col('.'))
+
   bw!
   set cot&
   set omnifunc&


### PR DESCRIPTION
#### vim-patch:9.1.1127: preinsert text is not cleaned up correctly

Problem:  when 'completeopt' is set to preinsert the preinserted text is
          not cleared when adding new leader (Yee Cheng Chin)
Solution: add a condition to delete preinsert text in edit function
          (glepnir)

closes: vim/vim#16672

https://github.com/vim/vim/commit/52fd867f5e8a371653ee4fb6664593c82030f855

Co-authored-by: glepnir <glephunter@gmail.com>