### PR TITLE
docs: typo fix in nvim_buf_set_extmark

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2653,8 +2653,7 @@ nvim_buf_set_extmark({buffer}, {ns_id}, {line}, {col}, {opts})
                     column of the window, bypassing sign and number columns.
                   • ephemeral : for use with |nvim_set_decoration_provider()|
                     callbacks. The mark will only be used for the current
-                    redraw cycle, and not be permantently stored in the
-                    buffer.
+                    redraw cycle, and not be permanently stored in the buffer.
                   • right_gravity : boolean that indicates the direction the
                     extmark will be shifted in when new text is inserted (true
                     for right, false for left). Defaults to true.

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -644,8 +644,7 @@ function vim.api.nvim_buf_line_count(buffer) end
 ---
 --- - ephemeral : for use with `nvim_set_decoration_provider()`
 ---     callbacks. The mark will only be used for the current
----     redraw cycle, and not be permantently stored in the
----     buffer.
+---     redraw cycle, and not be permanently stored in the buffer.
 --- - right_gravity : boolean that indicates the direction
 ---     the extmark will be shifted in when new text is inserted
 ---     (true for right, false for left). Defaults to true.

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -451,8 +451,7 @@ Array nvim_buf_get_extmarks(Buffer buffer, Integer ns_id, Object start, Object e
 ///
 ///               - ephemeral : for use with |nvim_set_decoration_provider()|
 ///                   callbacks. The mark will only be used for the current
-///                   redraw cycle, and not be permantently stored in the
-///                   buffer.
+///                   redraw cycle, and not be permanently stored in the buffer.
 ///               - right_gravity : boolean that indicates the direction
 ///                   the extmark will be shifted in when new text is inserted
 ///                   (true for right, false for left). Defaults to true.


### PR DESCRIPTION
permantently -> permanently