### PR TITLE
fix(treesitter): clip combined injection ranges

### DIFF
--- a/runtime/lua/vim/treesitter/_range.lua
+++ b/runtime/lua/vim/treesitter/_range.lua
@@ -115,6 +115,19 @@ function M.intercepts(r1, r2)
 end
 
 ---@private
+---@param r1 Range6
+---@param r2 Range6
+---@return Range6?
+function M.intersection(r1, r2)
+  if not M.intercepts(r1, r2) then
+    return nil
+  end
+  local rs = M.cmp_pos.le(r1[1], r1[2], r2[1], r2[2]) and r2 or r1
+  local re = M.cmp_pos.ge(r1[4], r1[5], r2[4], r2[5]) and r2 or r1
+  return { rs[1], rs[2], rs[3], re[4], re[5], re[6] }
+end
+
+---@private
 ---@param r Range
 ---@return integer, integer, integer, integer
 function M.unpack4(r)


### PR DESCRIPTION
Clips child regions to not spill out of parent regions within `languagetree.lua`, and only applies highlights within those regions in `highlighter.lua`. Some screenshots:

### Before

![image](https://github.com/user-attachments/assets/e8fc1e88-94f8-4657-8bac-9c8e30650055)

### After

![image](https://github.com/user-attachments/assets/3afa3206-cb6b-4b84-a5ec-358089460c80)

---

Supercedes #21310, fixes #21309