### PR TITLE
vim-patch:9.1.1136: Match highlighting marks a buffer region as changed

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -2098,10 +2098,7 @@ static void foldUpdateIEMS(win_T *const wp, linenr_T top, linenr_T bot)
   // this in other situations, the changed lines will be redrawn anyway and
   // this method can cause the whole window to be updated.
   if (end != bot) {
-    if (wp->w_redraw_top == 0 || wp->w_redraw_top > top) {
-      wp->w_redraw_top = top;
-    }
-    wp->w_redraw_bot = MAX(wp->w_redraw_bot, end);
+    redraw_win_range_later(wp, top, end);
   }
 
   invalid_top = 0;

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -190,19 +190,7 @@ static int match_add(win_T *wp, const char *const grp, const char *const pat, in
 
     // Calculate top and bottom lines for redrawing area
     if (toplnum != 0) {
-      if (wp->w_buffer->b_mod_set) {
-        if (wp->w_buffer->b_mod_top > toplnum) {
-          wp->w_buffer->b_mod_top = toplnum;
-        }
-        if (wp->w_buffer->b_mod_bot < botlnum) {
-          wp->w_buffer->b_mod_bot = botlnum;
-        }
-      } else {
-        wp->w_buffer->b_mod_set = true;
-        wp->w_buffer->b_mod_top = toplnum;
-        wp->w_buffer->b_mod_bot = botlnum;
-        wp->w_buffer->b_mod_xlines = 0;
-      }
+      redraw_win_range_later(wp, toplnum, botlnum);
       m->mit_toplnum = toplnum;
       m->mit_botlnum = botlnum;
       rtype = UPD_VALID;
@@ -268,19 +256,7 @@ static int match_delete(win_T *wp, int id, bool perr)
   vim_regfree(cur->mit_match.regprog);
   xfree(cur->mit_pattern);
   if (cur->mit_toplnum != 0) {
-    if (wp->w_buffer->b_mod_set) {
-      if (wp->w_buffer->b_mod_top > cur->mit_toplnum) {
-        wp->w_buffer->b_mod_top = cur->mit_toplnum;
-      }
-      if (wp->w_buffer->b_mod_bot < cur->mit_botlnum) {
-        wp->w_buffer->b_mod_bot = cur->mit_botlnum;
-      }
-    } else {
-      wp->w_buffer->b_mod_set = true;
-      wp->w_buffer->b_mod_top = cur->mit_toplnum;
-      wp->w_buffer->b_mod_bot = cur->mit_botlnum;
-      wp->w_buffer->b_mod_xlines = 0;
-    }
+    redraw_win_range_later(wp, cur->mit_toplnum, cur->mit_botlnum);
     rtype = UPD_VALID;
   }
   xfree(cur->mit_pos_array);


### PR DESCRIPTION
Problem:  Match highlighting marks a buffer region to be redrawn as if
          its buffer text was changed, unnecessarily invoking syntax code.
Solution: Set the `w_redraw_top/bot` variables instead of the b_mod_* ones
          (Luuk van Baal)

https://github.com/vim/vim/commit/7bbb0f357e9f9d3a737dac75e4b5ba7dfbf3ecc1