### PR TITLE
fix(lsp): unify get_completion_word for textEdits/insertText

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -132,7 +132,7 @@ end
 --- @return string
 local function get_completion_word(item, prefix, match)
   if item.insertTextFormat == protocol.InsertTextFormat.Snippet then
-    if item.textEdit then
+    if item.textEdit or (item.insertText and item.insertText ~= '') then
       -- Use label instead of text if text has different starting characters.
       -- label is used as abbr (=displayed), but word is used for filtering
       -- This is required for things like postfix completion.
@@ -154,8 +154,6 @@ local function get_completion_word(item, prefix, match)
       else
         return word
       end
-    elseif item.insertText and item.insertText ~= '' then
-      return parse_snippet(item.insertText)
     else
       return item.label
     end

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -562,11 +562,22 @@ describe('vim.lsp.completion: item conversion', function()
           range = range0,
         },
       },
+      -- luals for snippet
+      {
+        insertText = 'for ${1:index}, ${2:value} in ipairs(${3:t}) do\n\t$0\nend',
+        insertTextFormat = 2,
+        kind = 15,
+        label = 'for .. ipairs',
+      },
     }
     local expected = {
       {
         abbr = 'copyOf(Collection<? extends E> coll) : List<E>',
         word = 'copyOf',
+      },
+      {
+        abbr = 'for .. ipairs',
+        word = 'for .. ipairs',
       },
       {
         abbr = 'insert',


### PR DESCRIPTION
Problem:

After https://github.com/neovim/neovim/pull/32377 selecting snippets
provided by luals inserted the multi-line text before accepting the
candidates. That's inconsistent with servers who provide `textEdit`
instead of `insertText` and having lines shift up/down while cycling
through the completion candidates is a bit irritating.

Solution:

Use the logic used for `textEdit` snippets also for `insertText`
