### PR TITLE
vim-patch:9.1.1130: 'listchars' "precedes" is not drawn on Tabs.

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2581,6 +2581,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, s
         && wp->w_p_list
         && (wp->w_p_wrap ? (wp->w_skipcol > 0 && wlv.row == 0) : wp->w_leftcol > 0)
         && wlv.filler_todo <= 0
+        && wlv.skip_cells <= 0
         && mb_schar != NUL) {
       lcs_prec_todo = NUL;
       // TODO(zeertzjq): handle the n_extra > 0 case

--- a/test/old/testdir/test_listchars.vim
+++ b/test/old/testdir/test_listchars.vim
@@ -678,6 +678,7 @@ func Test_listchars_precedes_with_wide_char()
   call setline(1, '123口456')
   call assert_equal(['123口456$ '], ScreenLines(1, 10))
   let attr = screenattr(1, 9)
+
   normal! zl
   call assert_equal(['!3口456$  '], ScreenLines(1, 10))
   call assert_equal(attr, screenattr(1, 1))
@@ -689,8 +690,7 @@ func Test_listchars_precedes_with_wide_char()
   call assert_equal(attr, screenattr(1, 1))
   call assert_equal(attr, screenattr(1, 2))
   normal! zl
-  " TODO: should it be '!' instead of '<' here?
-  call assert_equal(['<456$     '], ScreenLines(1, 10))
+  call assert_equal(['!456$     '], ScreenLines(1, 10))
   call assert_equal(attr, screenattr(1, 1))
   normal! zl
   call assert_equal(['!56$      '], ScreenLines(1, 10))
@@ -698,6 +698,27 @@ func Test_listchars_precedes_with_wide_char()
   normal! zl
   call assert_equal(['!6$       '], ScreenLines(1, 10))
   call assert_equal(attr, screenattr(1, 1))
+
+  bw!
+endfunc
+
+func Test_listchars_precedes_with_tab()
+  new
+  setlocal nowrap list listchars=eol:$,precedes:!,tab:<->
+  call setline(1, "1234\t56")
+  let expected_line = '1234<-->56$ '
+  call assert_equal([expected_line], ScreenLines(1, 12))
+  let expected_attrs = mapnew(range(1, 12), 'screenattr(1, v:val)')
+  let attr = expected_attrs[-2]
+
+  for i in range(8)
+    normal! zl
+    let expected_line = '!' .. expected_line[2:] .. ' '
+    let expected_attrs = [attr] + expected_attrs[2:] + expected_attrs[-1:]
+    call assert_equal([expected_line], ScreenLines(1, 12))
+    let attrs = mapnew(range(1, 12), 'screenattr(1, v:val)')
+    call assert_equal(expected_attrs, attrs)
+  endfor
 
   bw!
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.1130: 'listchars' "precedes" is not drawn on Tabs.

Problem:  'listchars' "precedes" is not drawn on Tabs.
Solution: Only draw 'listchars' "precedes" when not skipping over cells.
          (zeertzjq)

closes: vim/vim#16691

https://github.com/vim/vim/commit/13f100e9328b1344fec79806791eb3f5234d4ccc