### PR TITLE
fix(treesitter): always highlight each visible line

### DIFF
--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -513,6 +513,52 @@ describe('treesitter highlighting (C)', function()
     screen:expect { grid = injection_grid_expected_c }
   end)
 
+  it('supports combined injections #31777', function()
+    insert([=[
+      -- print([[
+      -- some
+      -- random
+      -- text
+      -- here]])
+    ]=])
+
+    exec_lua(function()
+      local parser = vim.treesitter.get_parser(0, 'lua', {
+        injections = {
+          lua = [[
+          ; query
+          ((comment_content) @injection.content
+            (#set! injection.self)
+            (#set! injection.combined))
+          ]],
+        },
+      })
+      local highlighter = vim.treesitter.highlighter
+      highlighter.new(parser, {
+        queries = {
+          lua = [[
+            ; query
+            (string) @string
+            (comment) @comment
+            (function_call (identifier) @function.call)
+            [ "(" ")" ] @punctuation.bracket
+          ]],
+        },
+      })
+    end)
+
+    screen:expect([=[
+        {18:-- }{25:print}{16:(}{26:[[}                                                    |
+      {26:  -- some}                                                        |
+      {26:  -- random}                                                      |
+      {26:  -- text}                                                        |
+      {26:  -- here]]}{16:)}                                                     |
+      ^                                                                 |
+      {1:~                                                                }|*11
+                                                                       |
+    ]=])
+  end)
+
   it("supports injecting by ft name in metadata['injection.language']", function()
     insert(injection_text_c)
 


### PR DESCRIPTION
This change ensures that all visible lines are highlighted, resolving issues where some lines were missed.

The downside of this change is that now each line uses its own query iterator. From my testing it doesn't look like this is a noticeable performance regression, but I would like some scrutinous input on this just in case.

Alternative to #31853, fixes #31777

Simply put, all this PR does is remove the `next_row` logic and run `iter_captures` for each redrawn line

---

Note that if, in `on_win`, we were given pairs of ranges, or perhaps if `on_win` fired multiple times for the same window for each non-folded visible range, then we could make smarter use of the query iterators.

That is, for the following buffer:

```
some
code
-- PRETEND THIS IS FIVE FOLDED LINES
more
code
```

currently, `on_win` gives us a line range from 0 to 8, and `on_line` fires for lines 0, 1, 7, and 8 (the non-folded lines). If `on_win` told us which ranges to skip due to folding, we wouldn't have to create an iterator for each line in `on_line`. Another benefit would be that we wouldn't have to parse everything inside the fold, e.g. in the case of a 200,000 line fold which causes an extremely slow parse