### PR TITLE
test(unit/strings_spec): show ctx when vim_snprintf content check fails

### DIFF
--- a/test/unit/strings_spec.lua
+++ b/test/unit/strings_spec.lua
@@ -156,7 +156,7 @@ describe('vim_snprintf()', function()
     eq(#expected, strings.vim_snprintf(buf, bsize, fmt, ...), ctx)
     if bsize > 0 then
       local actual = ffi.string(buf, math.min(#expected + 1, bsize))
-      eq(expected:sub(1, bsize - 1) .. '\0', actual)
+      eq(expected:sub(1, bsize - 1) .. '\0', actual, ctx)
     end
   end
 


### PR DESCRIPTION
Same idea as a7be4b7bf857, but that only showed the context if the length of the string differed. Since these tests check both string length and string content, the ctx should be provided for both.

    ERROR    test/unit/testutil.lua @ 797: vim_snprintf() positional arguments
    test/unit/testutil.lua:769: test/unit/testutil.lua:753: (string) '
    test/unit/strings_spec.lua:159: snprintf(buf, 4, "%1$0.*2$b", 12ULL, cdata<int>: 0xf78c8ed8) = 001100
    Expected objects to be the same.
    Passed in:
    (string) '000'
    Expected:
    (string) '001''