### PR TITLE
vim-patch:9.1.1135: 'suffixesadd' doesn't work with multiple items

### DIFF
--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -856,6 +856,7 @@ char *vim_findfile(void *search_ctx_arg)
 
             // Try without extra suffix and then with suffixes
             // from 'suffixesadd'.
+            len = file_path.size;
             char *suf = search_ctx->ffsc_tagfile ? "" : curbuf->b_p_sua;
             while (true) {
               // if file exists and we didn't already find it
@@ -916,8 +917,8 @@ char *vim_findfile(void *search_ctx_arg)
                 break;
               }
               assert(MAXPATHL >= file_path.size);
-              file_path.size += copy_option_part(&suf, file_path.data + file_path.size,
-                                                 MAXPATHL - file_path.size, ",");
+              file_path.size = len + copy_option_part(&suf, file_path.data + len,
+                                                      MAXPATHL - len, ",");
             }
           }
         } else {
@@ -1515,20 +1516,20 @@ char *find_file_in_path_option(char *ptr, size_t len, int options, int first, ch
         }
 
         // When the file doesn't exist, try adding parts of 'suffixesadd'.
+        size_t NameBufflen = l;
         char *suffix = suffixes;
         while (true) {
           if ((os_path_exists(NameBuff)
                && (find_what == FINDFILE_BOTH
-                   || ((find_what == FINDFILE_DIR)
-                       == os_isdir(NameBuff))))) {
-            file_name = xmemdupz(NameBuff, l);
+                   || ((find_what == FINDFILE_DIR) == os_isdir(NameBuff))))) {
+            file_name = xmemdupz(NameBuff, NameBufflen);
             goto theend;
           }
           if (*suffix == NUL) {
             break;
           }
           assert(MAXPATHL >= l);
-          l += copy_option_part(&suffix, NameBuff + l, MAXPATHL - l, ",");
+          NameBufflen = l + copy_option_part(&suffix, NameBuff + l, MAXPATHL - l, ",");
         }
       }
     }

--- a/test/old/testdir/test_findfile.vim
+++ b/test/old/testdir/test_findfile.vim
@@ -222,6 +222,36 @@ func Test_finddir_error()
   call assert_fails('call finddir("x", repeat("x", 5000))', 'E854:')
 endfunc
 
+func Test_findfile_with_suffixesadd()
+  let save_path = &path
+  let save_dir = getcwd()
+  set path=,,
+  call mkdir('Xfinddir1', 'pR')
+  cd Xfinddir1
+
+  call writefile([], 'foo.c', 'D')
+  call writefile([], 'bar.cpp', 'D')
+  call writefile([], 'baz.cc', 'D')
+  call writefile([], 'foo.o', 'D')
+  call writefile([], 'bar.o', 'D')
+  call writefile([], 'baz.o', 'D')
+
+  set suffixesadd=.c,.cpp
+  call assert_equal('foo.c', findfile('foo'))
+  call assert_equal('./foo.c', findfile('./foo'))
+  call assert_equal('bar.cpp', findfile('bar'))
+  call assert_equal('./bar.cpp', findfile('./bar'))
+  call assert_equal('', findfile('baz'))
+  call assert_equal('', findfile('./baz'))
+  set suffixesadd+=.cc
+  call assert_equal('baz.cc', findfile('baz'))
+  call assert_equal('./baz.cc', findfile('./baz'))
+
+  set suffixesadd&
+  call chdir(save_dir)
+  let &path = save_path
+endfunc
+
 " Test for the :find, :sfind and :tabfind commands
 func Test_find_cmd()
   new

--- a/test/old/testdir/test_gf.vim
+++ b/test/old/testdir/test_gf.vim
@@ -361,4 +361,36 @@ func Test_gf_switchbuf()
   %bw!
 endfunc
 
+func Test_gf_with_suffixesadd()
+  let cwd = getcwd()
+  let dir = 'Xtestgf_sua_dir'
+  call mkdir(dir, 'R')
+  call chdir(dir)
+
+  call writefile([], 'foo.c', 'D')
+  call writefile([], 'bar.cpp', 'D')
+  call writefile([], 'baz.cc', 'D')
+  call writefile([], 'foo.o', 'D')
+  call writefile([], 'bar.o', 'D')
+  call writefile([], 'baz.o', 'D')
+
+  new
+  setlocal path=,, suffixesadd=.c,.cpp
+  call setline(1, ['./foo', './bar', './baz'])
+  exe "normal! gg\<C-W>f"
+  call assert_equal('foo.c', expand('%:t'))
+  close
+  exe "normal! 2gg\<C-W>f"
+  call assert_equal('bar.cpp', expand('%:t'))
+  close
+  call assert_fails('exe "normal! 3gg\<C-W>f"', 'E447:')
+  setlocal suffixesadd+=.cc
+  exe "normal! 3gg\<C-W>f"
+  call assert_equal('baz.cc', expand('%:t'))
+  close
+
+  %bwipe!
+  call chdir(cwd)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fix #32559

#### vim-patch:9.1.1135: 'suffixesadd' doesn't work with multiple items

Problem:  'suffixesadd' doesn't work with multiple items
          (after 9.1.1122).
Solution: Don't concat multiple suffixes together.
          (zeertzjq)

closes: vim/vim#16699

https://github.com/vim/vim/commit/bf595ae4ac9ecc1e0620664177072926ed3679ff