### PR TITLE
fix(runtime): avoid E31 in ftplugin

### DIFF
--- a/runtime/ftplugin/checkhealth.lua
+++ b/runtime/ftplugin/checkhealth.lua
@@ -10,5 +10,5 @@ vim.keymap.set('n', '[[', function()
 end, { buffer = 0, silent = false, desc = 'Jump to previous section' })
 
 vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '')
-  .. '\n exe "nunmap <buffer> gO"'
-  .. '\n exe "nunmap <buffer> ]]" | exe "nunmap <buffer> [["'
+  .. '\n sil! exe "nunmap <buffer> gO"'
+  .. '\n sil! exe "nunmap <buffer> ]]" | sil! exe "nunmap <buffer> [["'

--- a/runtime/ftplugin/help.lua
+++ b/runtime/ftplugin/help.lua
@@ -118,6 +118,6 @@ vim.keymap.set('n', 'g==', function()
 end, { buffer = true })
 
 vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '')
-  .. '\n exe "nunmap <buffer> gO" | exe "nunmap <buffer> g=="'
-  .. '\n exe "nunmap <buffer> ]]" | exe "nunmap <buffer> [["'
+  .. '\n sil! exe "nunmap <buffer> gO" | sil! exe "nunmap <buffer> g=="'
+  .. '\n sil! exe "nunmap <buffer> ]]" | sil! exe "nunmap <buffer> [["'
 vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | call v:lua.vim.treesitter.stop()'

--- a/runtime/ftplugin/markdown.lua
+++ b/runtime/ftplugin/markdown.lua
@@ -10,5 +10,5 @@ vim.keymap.set('n', '[[', function()
 end, { buffer = 0, silent = false, desc = 'Jump to previous section' })
 
 vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '')
-  .. '\n exe "nunmap <buffer> gO"'
-  .. '\n exe "nunmap <buffer> ]]" | exe "nunmap <buffer> [["'
+  .. '\n sil! exe "nunmap <buffer> gO"'
+  .. '\n sil! exe "nunmap <buffer> ]]" | sil! exe "nunmap <buffer> [["'


### PR DESCRIPTION
Problem: After https://github.com/neovim/neovim/commit/2e5b560482fb76342387e7183283efe9d431f114, `nvim --clean README.md` then `:setf markdown` will show errmsg:
```
Error detected while processing FileType Autocommands for "*"..function <SNR>1_LoadFTPlugin:
line    2:
E31: No such mapping
E31: No such mapping
```

Solution: use `sil!` wrap `nunmap`.
