### PR TITLE
build: make makefile work on msys

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,14 @@
 ifeq ($(OS),Windows_NT)
+  ifeq '$(findstring ;,$(PATH))' ';'
+    UNIX_LIKE := FALSE
+  else
+    UNIX_LIKE := TRUE
+  endif
+else
+  UNIX_LIKE := TRUE
+endif
+
+ifeq ($(UNIX_LIKE),FALSE)
   SHELL := powershell.exe
   .SHELLFLAGS := -NoProfile -NoLogo
   MKDIR := @$$null = new-item -itemtype directory -force


### PR DESCRIPTION
Relying on $(OS) doesn't work as it's too naive, so we check if $PATH
contains a colon instead.

Closes https://github.com/neovim/neovim/issues/31027
