### PR TITLE
fix(lsp): ensure floating window width can fit title

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1417,6 +1417,11 @@ function M._make_floating_popup_size(contents, opts)
   -- make sure borders are always inside the screen
   width = math.min(width, screen_width - border_width)
 
+  -- Make sure that the width is large enough to fit the title.
+  if opts.title then
+    width = math.max(width, vim.fn.strdisplaywidth(opts.title))
+  end
+
   if wrap_at then
     wrap_at = math.min(wrap_at, width)
   end

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3528,6 +3528,20 @@ describe('LSP', function()
         end)
       )
     end)
+
+    it('considers title when computing width', function()
+      eq(
+        { 17, 2 },
+        exec_lua(function()
+          return {
+            vim.lsp.util._make_floating_popup_size(
+              { 'foo', 'bar' },
+              { title = 'A very long title' }
+            ),
+          }
+        end)
+      )
+    end)
   end)
 
   describe('lsp.util.trim.trim_empty_lines', function()


### PR DESCRIPTION
If the content is narrow, the title is truncated:
<img width="406" alt="image" src="https://github.com/user-attachments/assets/869d37b3-59cb-480d-b0bf-10bc55db7e3a" />

With this change:
<img width="396" alt="image" src="https://github.com/user-attachments/assets/a61ae099-4d19-472e-8ee0-260032e5fd43" />
