### PR TITLE
fix: change @private to @nodoc for vim.log.levels and vim.opt*

### DIFF
--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -56,7 +56,7 @@ vim._extra = {
   inspect_pos = true,
 }
 
---- @private
+--- @nodoc
 vim.log = {
   --- @enum vim.log.levels
   levels = {

--- a/runtime/lua/vim/_options.lua
+++ b/runtime/lua/vim/_options.lua
@@ -922,11 +922,11 @@ function Option:prepend(value) end -- luacheck: no unused
 ---@diagnostic disable-next-line:unused-local used for gen_vimdoc
 function Option:remove(value) end -- luacheck: no unused
 
----@private
+--- @nodoc
 vim.opt = create_option_accessor()
 
----@private
+--- @nodoc
 vim.opt_local = create_option_accessor('local')
 
----@private
+--- @nodoc
 vim.opt_global = create_option_accessor('global')


### PR DESCRIPTION
Problem:

I noticed that https://github.com/CppCXY/emmylua-analyzer-rust is (properly?) showing a diagnostic for access to `vim.log.levels.*` and `vim.opt_local`, etc:

```bash
"The property is private and cannot be accessed outside the class."
```

I'm not sure why these are marked `@private`, which was done by @lewis6991 in be74807e

If this patch isn't accepted, I can add a comment with the reasoning for why they are private.

Solution:

Per @lewis6991 these should be @nodoc