### PR TITLE
vim-patch:9.1.{1139,1141}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -305,6 +305,8 @@ int open_buffer(bool read_stdin, exarg_T *eap, int flags_arg)
     if (read_fifo) {
       curbuf->b_p_bin = save_bin;
       if (retval == OK) {
+        // don't add READ_FIFO here, otherwise we won't be able to
+        // detect the encoding
         retval = read_buffer(false, eap, flags);
       }
     }

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -353,10 +353,11 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
     }
   }
 
-  if (!read_buffer && !read_stdin && !read_fifo) {
+  if (!read_stdin && fname != NULL) {
     perm = os_getperm(fname);
     // On Unix it is possible to read a directory, so we have to
     // check for it before os_open().
+  }
 
 #ifdef OPEN_CHR_FILES
 # define IS_CHR_DEV(perm, fname) S_ISCHR(perm) && is_dev_fd_file(fname)
@@ -364,6 +365,7 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
 # define IS_CHR_DEV(perm, fname) false
 #endif
 
+  if (!read_stdin && !read_buffer && !read_fifo) {
     if (perm >= 0 && !S_ISREG(perm)                 // not a regular file ...
         && !S_ISFIFO(perm)                          // ... or fifo
         && !S_ISSOCK(perm)                          // ... or socket

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -355,8 +355,6 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
 
   if (!read_stdin && fname != NULL) {
     perm = os_getperm(fname);
-    // On Unix it is possible to read a directory, so we have to
-    // check for it before os_open().
   }
 
 #ifdef OPEN_CHR_FILES
@@ -372,6 +370,8 @@ int readfile(char *fname, char *sfname, linenr_T from, linenr_T lines_to_skip,
         && !(IS_CHR_DEV(perm, fname))
         // ... or a character special file named /dev/fd/<n>
         ) {
+      // On Unix it is possible to read a directory, so we have to
+      // check for it before os_open().
       if (S_ISDIR(perm)) {
         if (!silent) {
           filemess(curbuf, fname, _(msg_is_a_directory));

--- a/test/old/testdir/test_startup_utf8.vim
+++ b/test/old/testdir/test_startup_utf8.vim
@@ -60,6 +60,34 @@ func Test_read_fifo_utf8()
   call delete('Xtestout')
 endfunc
 
+func Test_detect_fifo()
+  CheckUnix
+  " Using bash/zsh's process substitution.
+  if executable('bash')
+    set shell=bash
+  elseif executable('zsh')
+    set shell=zsh
+  else
+    throw 'Skipped: bash or zsh is required'
+  endif
+  let linesin = ['one', 'two']
+  call writefile(linesin, 'Xtestin_fifo', 'D')
+  let after = [
+	\ 'call writefile(split(execute(":mess"), "\\n"), "Xtestout")',
+	\ 'quit!',
+	\ ]
+  " if RunVim([], after, '<(cat Xtestin_fifo)')
+  if RunVim(['set shortmess-=F'], after, '<(cat Xtestin_fifo)')
+    let lines = readfile('Xtestout')
+    call assert_match('\[fifo\]', lines[0])
+    " call assert_match('\[fifo\]', lines[1])
+  else
+    call assert_equal('', 'RunVim failed.')
+  endif
+
+  call delete('Xtestout')
+endfunc
+
 func Test_detect_ambiwidth()
   CheckRunVimInTerminal
 


### PR DESCRIPTION
#### vim-patch:9.1.1139: [fifo] is not displayed when editing a fifo

Problem:  [fifo] is not displayed when editing a fifo
          (after v7.4.2189)
Solution: stat the filename and detect the type correctly

closes: vim/vim#16705

https://github.com/vim/vim/commit/f1c3134ee1f263e537212a3072e8aa4cb7e8d953

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.1141: Misplaced comment in readfile()

Problem:  Misplaced comment in readfile().
          (after v9.1.1139)
Solution: Move the comment above S_ISDIR().
          (zeertzjq)

closes: vim/vim#16714

https://github.com/vim/vim/commit/b8989fb860808bbcb0e90b2ba597f66a092277d8