### PR TITLE
fix(float): allow setting title/footer without explicitly setting border

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -1240,11 +1240,6 @@ static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fco
       api_set_error(err, kErrorTypeValidation, "non-float cannot have 'title'");
       goto fail;
     }
-    // title only work with border
-    if (!HAS_KEY_X(config, border) && !fconfig->border) {
-      api_set_error(err, kErrorTypeException, "title requires border to be set");
-      goto fail;
-    }
 
     parse_bordertext(config->title, kBorderTextTitle, fconfig, err);
     if (ERROR_SET(err)) {
@@ -1265,11 +1260,6 @@ static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fco
   if (HAS_KEY_X(config, footer)) {
     if (is_split) {
       api_set_error(err, kErrorTypeValidation, "non-float cannot have 'footer'");
-      goto fail;
-    }
-    // footer only work with border
-    if (!HAS_KEY_X(config, border) && !fconfig->border) {
-      api_set_error(err, kErrorTypeException, "footer requires border to be set");
       goto fail;
     }
 

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -2078,10 +2078,6 @@ describe('float window', function()
 
     it('validates title title_pos', function()
       local buf = api.nvim_create_buf(false,false)
-      eq("title requires border to be set",
-         pcall_err(api.nvim_open_win,buf, false, {
-          relative='editor', width=9, height=2, row=2, col=5, title='Title',
-         }))
       eq("title_pos requires title to be set",
          pcall_err(api.nvim_open_win,buf, false, {
           relative='editor', width=9, height=2, row=2, col=5,
@@ -2112,10 +2108,6 @@ describe('float window', function()
 
     it('validates footer footer_pos', function()
       local buf = api.nvim_create_buf(false,false)
-      eq("footer requires border to be set",
-         pcall_err(api.nvim_open_win,buf, false, {
-          relative='editor', width=9, height=2, row=2, col=5, footer='Footer',
-         }))
       eq("footer_pos requires footer to be set",
          pcall_err(api.nvim_open_win,buf, false, {
           relative='editor', width=9, height=2, row=2, col=5,
@@ -2188,6 +2180,49 @@ describe('float window', function()
 
       api.nvim_win_close(win, false)
       assert_alive()
+    end)
+
+    it('no border with title and footer', function()
+      local buf = api.nvim_create_buf(false, false)
+      api.nvim_buf_set_lines(buf, 0, -1, true, { 'Hello' })
+      api.nvim_open_win(buf, false, {
+        relative='editor', width=9, height=2, row=2, col=5,
+        title = 'Title', footer = 'Footer'
+      })
+
+      if multigrid then
+        screen:expect({
+          grid = [[
+          ## grid 1
+            [2:----------------------------------------]|*6
+            [3:----------------------------------------]|
+          ## grid 2
+            ^                                        |
+            {0:~                                       }|*5
+          ## grid 3
+                                                    |
+          ## grid 4
+            {1:Hello    }|
+            {2:~        }|
+          ]],
+          float_pos = {
+            [4] = { 1001, "NW", 1, 2, 5, true, 50 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        })
+      else
+        screen:expect([[
+          ^                                        |
+          {0:~                                       }|
+          {0:~    }{1:Hello    }{0:                          }|
+          {0:~    }{2:~        }{0:                          }|
+          {0:~                                       }|*2
+                                                  |
+        ]])
+      end
     end)
 
     it('border with title', function()


### PR DESCRIPTION
Problem: setting title and/or footer without explicitly setting border
  shows "title/footer/ requires border to be set" error.
  At the same time, explicitly setting `border = "none"` (which is
  default) shows expected no-border-no-title-no-footer window without
  error.

Solution: allow setting title/footer without explicitly setting border.