### PR TITLE
fix(lua): SIGSEGV in luv callback with error(nil)

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -221,7 +221,7 @@ static int nlua_fast_cfpcall(lua_State *lstate, int nargs, int nresult, int flag
     const char *error = lua_tostring(lstate, -1);
 
     multiqueue_put(main_loop.events, nlua_luv_error_event,
-                   xstrdup(error), (void *)(intptr_t)kCallback);
+                   error != NULL ? xstrdup(error) : NULL, (void *)(intptr_t)kCallback);
     lua_pop(lstate, 1);  // error message
     retval = -status;
   } else {  // LUA_OK


### PR DESCRIPTION
Problem:
luv callback `vim.uv.new_timer():start(0, 0, function() error() end)`
causes SIGSEGV, since `xstrdup` on NULL return by `lua_tostring`.
(similar to
https://github.com/neovim/neovim/commit/a5b1b83a2693ffa7a5a0a22b3693d36ea60051be)

Solution:
Check NULL before `xstrdup`.
