### PR TITLE
revert "feat(ftplugin): set 'omnifunc' of Lua to 'v:lua.vim.lua_omnifunc'"

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1502,11 +1502,6 @@ both major engines implemented element, even if this is not in standards it
 will be suggested. All other elements are not placed in suggestion list.
 
 
-LUA                                                     *ft-lua-omni*
-
-Lua |ftplugin| sets 'omnifunc' to |vim.lua_omnifunc()|.
-
-
 PHP							*ft-php-omni*
 
 Completion of PHP code requires a tags file for completion of data from

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -239,9 +239,6 @@ DEFAULTS
     • |[b|, |]b|, |[B|, |]B| navigate through the |buffer-list|
     • |[<Space>|, |]<Space>| add an empty line above and below the cursor
 
-• Options:
-  • Lua |ftplugin| sets |'omnifunc'| to `"v:lua.vim.lua_omnifunc"`.
-
 • Snippet:
   • `<Tab>` in Insert and Select mode maps to `vim.snippet.jump({ direction = 1 })`
     when a snippet is active and jumpable forwards.

--- a/runtime/ftplugin/lua.lua
+++ b/runtime/ftplugin/lua.lua
@@ -1,7 +1,4 @@
 -- use treesitter over syntax
 vim.treesitter.start()
 
-vim.bo.omnifunc = 'v:lua.vim.lua_omnifunc'
-
-vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '')
-  .. '\n call v:lua.vim.treesitter.stop() \n setl omnifunc<'
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n call v:lua.vim.treesitter.stop()'


### PR DESCRIPTION
neovim/neovim#32491 breaks the default `vim.lsp.omnifunc` when luals attaches.

