### PR TITLE
vim-patch:9.1.1143: illegal memory access when putting a register

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3623,7 +3623,7 @@ error:
       // Put the '] mark on the first byte of the last inserted character.
       // Correct the length for change in indent.
       curbuf->b_op_end.lnum = new_lnum;
-      col = (colnr_T)y_array[y_size - 1].size - lendiff;
+      col = MAX(0, (colnr_T)y_array[y_size - 1].size - lendiff);
       if (col > 1) {
         curbuf->b_op_end.col = col - 1;
         if (y_array[y_size - 1].size > 0) {

--- a/test/functional/legacy/register_spec.lua
+++ b/test/functional/legacy/register_spec.lua
@@ -1,0 +1,25 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local clear = n.clear
+local exec = n.exec
+local assert_alive = n.assert_alive
+local fn = n.fn
+local eq = t.eq
+
+describe('registers', function()
+  before_each(clear)
+
+  -- oldtest: Test_register_cursor_column_negative()
+  it('no negative column when pasting', function()
+    exec([[
+      f XREGISTER
+      call setline(1, 'abcdef a')
+      call setreg("a", "\n", 'c')
+      call cursor(1, 7)
+      call feedkeys("i\<C-R>\<C-P>azyx$#\<esc>", 't')
+    ]])
+    assert_alive()
+    eq('XREGISTER', fn.bufname())
+  end)
+end)

--- a/test/old/testdir/test_registers.vim
+++ b/test/old/testdir/test_registers.vim
@@ -1006,4 +1006,21 @@ func Test_insert_small_delete_replace_mode()
   bwipe!
 endfunc
 
+" this caused an illegal memory access and a crash
+func Test_register_cursor_column_negative()
+  CheckRunVimInTerminal
+  let script =<< trim END
+    f XREGISTER
+    call setline(1, 'abcdef a')
+    call setreg("a", "\n", 'c')
+    call cursor(1, 7)
+    call feedkeys("i\<C-R>\<C-P>azyx$#\<esc>", 't')
+  END
+  call writefile(script, 'XRegister123', 'D')
+  let buf = RunVimInTerminal('-S XRegister123', {})
+  call term_sendkeys(buf, "\<c-g>")
+  call WaitForAssert({-> assert_match('XREGISTER', term_getline(buf, 19))})
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1143: illegal memory access when putting a register

Problem:  illegal memory access when putting a register
Solution: make sure cursor column doesn't become negative

https://github.com/vim/vim/commit/e0029daa3599529d9d438cc51c7ada8580297a39

Co-authored-by: Christian Brabandt <cb@256bit.org>