### PR TITLE
fix(lsp): resize hover window for concealed lines

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1649,8 +1649,14 @@ function M.open_floating_preview(contents, syntax, opts)
 
   if do_stylize then
     vim.wo[floating_winnr].conceallevel = 2
+    vim.wo[floating_winnr].concealcursor = 'n'
     vim.bo[floating_bufnr].filetype = 'markdown'
     vim.treesitter.start(floating_bufnr)
+    if not opts.height then
+      -- Reduce window height if TS highlighter conceals code block backticks.
+      local conceal_height = api.nvim_win_text_height(floating_winnr, {}).all
+      api.nvim_win_set_height(floating_winnr, conceal_height)
+    end
   end
 
   return floating_bufnr, floating_winnr

--- a/test/functional/plugin/lsp/utils_spec.lua
+++ b/test/functional/plugin/lsp/utils_spec.lua
@@ -329,4 +329,32 @@ describe('vim.lsp.util', function()
                                                            |
     ]])
   end)
+
+  it('open_floating_preview height reduced for concealed lines', function()
+    local screen = Screen.new()
+    screen:add_extra_attr_ids({
+      [100] = {
+        background = Screen.colors.LightMagenta,
+        foreground = Screen.colors.Brown,
+        bold = true,
+      },
+      [101] = { background = Screen.colors.LightMagenta, foreground = Screen.colors.Blue },
+      [102] = { background = Screen.colors.LightMagenta, foreground = Screen.colors.DarkCyan },
+    })
+    exec_lua([[
+      vim.g.syntax_on = false
+      vim.lsp.util.open_floating_preview({ '```lua', 'local foo', '```' }, 'markdown', {
+        border = 'single',
+        focus = false,
+      })
+    ]])
+    screen:expect([[
+      ^                                                     |
+      ┌─────────┐{1:                                          }|
+      │{100:local}{101: }{102:foo}│{1:                                          }|
+      └─────────┘{1:                                          }|
+      {1:~                                                    }|*9
+                                                           |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:  Height of a (markdown) `vim.lsp.util.open_floating_preview()`
          window can be reduced to account for concealed lines (after #31324).
Solution: Set the window height to the text height of the preview window.
          Set 'concealcursor' to avoid unconcealing the cursorline when
          entering the hover window.