### PR TITLE
fix(api): don't override Vimscript SID

### DIFF
--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -1049,32 +1049,18 @@ const char *get_default_stl_hl(win_T *wp, bool use_winbar, int stc_hl_id)
   }
 }
 
-int find_sid(uint64_t channel_id)
-{
-  switch (channel_id) {
-  case VIML_INTERNAL_CALL:
-  // TODO(autocmd): Figure out what this should be
-  // return SID_API_CLIENT;
-  case LUA_INTERNAL_CALL:
-    return SID_LUA;
-  default:
-    return SID_API_CLIENT;
-  }
-}
-
 /// Sets sctx for API calls.
 ///
-/// @param channel_id     api clients id. Used to determine if it's a internal
-///                       call or a rpc call.
-/// @return returns       previous value of current_sctx. To be used
-///                       to be used for restoring sctx to previous state.
+/// @param channel_id  api client id to determine if it's a internal or RPC call.
+///
+/// @return  previous value of current_sctx. To be used later for restoring sctx.
 sctx_T api_set_sctx(uint64_t channel_id)
 {
   sctx_T old_current_sctx = current_sctx;
   if (channel_id != VIML_INTERNAL_CALL) {
-    current_sctx.sc_sid =
-      channel_id == LUA_INTERNAL_CALL ? SID_LUA : SID_API_CLIENT;
+    current_sctx.sc_sid = channel_id == LUA_INTERNAL_CALL ? SID_LUA : SID_API_CLIENT;
     current_sctx.sc_lnum = 0;
+    current_sctx.sc_chan = channel_id;
   }
   return old_current_sctx;
 }

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -186,13 +186,7 @@ typedef struct {
 
 #define WITH_SCRIPT_CONTEXT(channel_id, code) \
   do { \
-    const sctx_T save_current_sctx = current_sctx; \
-    const uint64_t save_channel_id = current_channel_id; \
-    current_sctx.sc_sid = \
-      (channel_id) == LUA_INTERNAL_CALL ? SID_LUA : SID_API_CLIENT; \
-    current_sctx.sc_lnum = 0; \
-    current_channel_id = channel_id; \
+    const sctx_T save_current_sctx = api_set_sctx(channel_id); \
     code; \
-    current_channel_id = save_channel_id; \
     current_sctx = save_current_sctx; \
   } while (0);

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -208,7 +208,7 @@ typedef struct {
   OptInt wo_winbl;
 #define w_p_winbl w_onebuf_opt.wo_winbl  // 'winblend'
 
-  LastSet wo_script_ctx[kWinOptCount];  // SCTXs for window-local options
+  sctx_T wo_script_ctx[kWinOptCount];  // SCTXs for window-local options
 #define w_p_script_ctx w_onebuf_opt.wo_script_ctx
 } winopt_T;
 
@@ -510,7 +510,7 @@ struct file_buffer {
   // or contents of the file being edited.
   bool b_p_initialized;                 // set when options initialized
 
-  LastSet b_p_script_ctx[kBufOptCount];  // SCTXs for buffer-local options
+  sctx_T b_p_script_ctx[kBufOptCount];  // SCTXs for buffer-local options
 
   int b_p_ai;                   ///< 'autoindent'
   int b_p_ai_nopaste;           ///< b_p_ai saved for paste mode

--- a/src/nvim/eval/typval_defs.h
+++ b/src/nvim/eval/typval_defs.h
@@ -286,13 +286,8 @@ typedef struct {
   scid_T sc_sid;     ///< script ID
   int sc_seq;        ///< sourcing sequence number
   linenr_T sc_lnum;  ///< line number
+  uint64_t sc_chan;  ///< Only used when sc_sid is SID_API_CLIENT.
 } sctx_T;
-
-/// Stores an identifier of a script or channel that last set an option.
-typedef struct {
-  sctx_T script_ctx;       /// script context where the option was last set
-  uint64_t channel_id;     /// Only used when script_id is SID_API_CLIENT.
-} LastSet;
 
 enum { MAX_FUNC_ARGS = 20, };  ///< Maximum number of function arguments
 enum { VAR_SHORT_LEN = 20, };  ///< Short variable name length

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1747,7 +1747,7 @@ static char *eval_includeexpr(const char *const ptr, const size_t len)
 {
   const sctx_T save_sctx = current_sctx;
   set_vim_var_string(VV_FNAME, ptr, (ptrdiff_t)len);
-  current_sctx = curbuf->b_p_script_ctx[kBufOptIncludeexpr].script_ctx;
+  current_sctx = curbuf->b_p_script_ctx[kBufOptIncludeexpr];
 
   char *res = eval_to_string_safe(curbuf->b_p_inex,
                                   was_set_insecurely(curwin, kOptIncludeexpr, OPT_LOCAL),

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -1731,7 +1731,7 @@ char *get_foldtext(win_T *wp, linenr_T lnum, linenr_T lnume, foldinfo_T foldinfo
 
       curwin = wp;
       curbuf = wp->w_buffer;
-      current_sctx = wp->w_p_script_ctx[kWinOptFoldtext].script_ctx;
+      current_sctx = wp->w_p_script_ctx[kWinOptFoldtext];
 
       emsg_off++;  // handle exceptions, but don't display errors
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -298,9 +298,7 @@ EXTERN bool garbage_collect_at_exit INIT( = false);
 #define SID_STR         (-10)     // for sourcing a string with no script item
 
 // Script CTX being sourced or was sourced to define the current function.
-EXTERN sctx_T current_sctx INIT( = { 0, 0, 0 });
-// ID of the current channel making a client API call
-EXTERN uint64_t current_channel_id INIT( = 0);
+EXTERN sctx_T current_sctx INIT( = { 0, 0, 0, 0 });
 /// Last channel that invoked 'nvim_input` or got FocusGained.
 EXTERN uint64_t current_ui INIT( = 0);
 

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -1181,7 +1181,7 @@ int get_expr_indent(void)
     sandbox++;
   }
   textlock++;
-  current_sctx = curbuf->b_p_script_ctx[kBufOptIndentexpr].script_ctx;
+  current_sctx = curbuf->b_p_script_ctx[kBufOptIndentexpr];
 
   // Need to make a copy, the 'indentexpr' option could be changed while
   // evaluating it.

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -191,5 +191,5 @@ typedef struct {
   opt_expand_cb_T opt_expand_cb;
 
   OptVal def_val;                    ///< default value
-  LastSet last_set;                  ///< script in which the option was last set
+  sctx_T script_ctx;                 ///< script in which the option was last set
 } vimoption_T;

--- a/src/nvim/profile.c
+++ b/src/nvim/profile.c
@@ -616,11 +616,7 @@ static void func_dump_profile(FILE *fd)
         }
         if (fp->uf_script_ctx.sc_sid != 0) {
           bool should_free;
-          const LastSet last_set = (LastSet){
-            .script_ctx = fp->uf_script_ctx,
-            .channel_id = 0,
-          };
-          char *p = get_scriptname(last_set, &should_free);
+          char *p = get_scriptname(fp->uf_script_ctx, &should_free);
           fprintf(fd, "    Defined: %s:%" PRIdLINENR "\n",
                   p, fp->uf_script_ctx.sc_lnum);
           if (should_free) {

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -270,17 +270,13 @@ list_T *stacktrace_create(void)
       ufunc_T *const fp = entry->es_info.ufunc;
       const sctx_T sctx = fp->uf_script_ctx;
       bool filepath_alloced = false;
-      char *filepath = sctx.sc_sid > 0
-                       ? get_scriptname((LastSet){ .script_ctx = sctx },
-                                        &filepath_alloced) : "";
+      char *filepath = sctx.sc_sid > 0 ? get_scriptname(sctx, &filepath_alloced) : "";
       lnum += sctx.sc_lnum;
       stacktrace_push_item(l, fp, NULL, lnum, filepath, filepath_alloced);
     } else if (entry->es_type == ETYPE_AUCMD) {
       const sctx_T sctx = entry->es_info.aucmd->script_ctx;
       bool filepath_alloced = false;
-      char *filepath = sctx.sc_sid > 0
-                       ? get_scriptname((LastSet){ .script_ctx = sctx },
-                                        &filepath_alloced) : "";
+      char *filepath = sctx.sc_sid > 0 ? get_scriptname(sctx, &filepath_alloced) : "";
       lnum += sctx.sc_lnum;
       stacktrace_push_item(l, NULL, entry->es_name, lnum, filepath, filepath_alloced);
     }
@@ -2426,11 +2422,11 @@ void scriptnames_slash_adjust(void)
 
 /// Get a pointer to a script name.  Used for ":verbose set".
 /// Message appended to "Last set from "
-char *get_scriptname(LastSet last_set, bool *should_free)
+char *get_scriptname(sctx_T script_ctx, bool *should_free)
 {
   *should_free = false;
 
-  switch (last_set.script_ctx.sc_sid) {
+  switch (script_ctx.sc_sid) {
   case SID_MODELINE:
     return _("modeline");
   case SID_CMDARG:
@@ -2446,15 +2442,15 @@ char *get_scriptname(LastSet last_set, bool *should_free)
   case SID_LUA:
     return _("Lua (run Nvim with -V1 for more details)");
   case SID_API_CLIENT:
-    snprintf(IObuff, IOSIZE, _("API client (channel id %" PRIu64 ")"), last_set.channel_id);
+    snprintf(IObuff, IOSIZE, _("API client (channel id %" PRIu64 ")"), script_ctx.sc_chan);
     return IObuff;
   case SID_STR:
     return _("anonymous :source");
   default: {
-    char *const sname = SCRIPT_ITEM(last_set.script_ctx.sc_sid)->sn_name;
+    char *const sname = SCRIPT_ITEM(script_ctx.sc_sid)->sn_name;
     if (sname == NULL) {
       snprintf(IObuff, IOSIZE, _("anonymous :source (script id %d)"),
-               last_set.script_ctx.sc_sid);
+               script_ctx.sc_sid);
       return IObuff;
     }
 

--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -865,7 +865,7 @@ int fex_format(linenr_T lnum, long count, int c)
 
   // Make a copy, the option could be changed while calling it.
   char *fex = xstrdup(curbuf->b_p_fex);
-  current_sctx = curbuf->b_p_script_ctx[kBufOptFormatexpr].script_ctx;
+  current_sctx = curbuf->b_p_script_ctx[kBufOptFormatexpr];
 
   // Evaluate the function.
   if (use_sandbox) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6714,8 +6714,8 @@ void win_comp_scroll(win_T *wp)
 
   if (wp->w_p_scr != old_w_p_scr) {
     // Used by "verbose set scroll".
-    wp->w_p_script_ctx[kWinOptScroll].script_ctx.sc_sid = SID_WINLAYOUT;
-    wp->w_p_script_ctx[kWinOptScroll].script_ctx.sc_lnum = 0;
+    wp->w_p_script_ctx[kWinOptScroll].sc_sid = SID_WINLAYOUT;
+    wp->w_p_script_ctx[kWinOptScroll].sc_lnum = 0;
   }
 }
 


### PR DESCRIPTION
Problem:  When calling an API from Vimscript to set an option, mapping,
          etc., :verbose shows that it's set from an API client.
Solution: Don't override current_sctx.sc_sid when calling an API from
          Vimscript. Also fix the inverse case where API channel id is
          not set when calling an API from RPC. Move channel id into
          sctx_T to make saving and restoring easier.

Related #8329