### PR TITLE
fix(extmark): clearer error message for invalid ephemeral mark usage

### DIFF
--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -817,7 +817,8 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     }
   } else {
     if (opts->ephemeral) {
-      api_set_error(err, kErrorTypeException, "not yet implemented");
+      api_set_error(err, kErrorTypeException,
+                    "cannot set emphemeral mark outside of a decoration provider");
       goto error;
     }
 


### PR DESCRIPTION
Found this error message pretty cryptic when I encountered it, thought this new one could be more useful/informative