### PR TITLE
feat: log incriminating vim function

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1179,7 +1179,10 @@ int nlua_call(lua_State *lstate)
   size_t name_len;
   const char *name = luaL_checklstring(lstate, 1, &name_len);
   if (!nlua_is_deferred_safe() && !viml_func_is_fast(name)) {
-    return luaL_error(lstate, e_fast_api_disabled, "Vimscript function");
+    size_t length = MIN(strlen(name), 100) + sizeof("Vimscript function \"\"");
+    vim_snprintf(IObuff, length, "Vimscript function \"%s\"", name);
+    int ret = luaL_error(lstate, e_fast_api_disabled, IObuff);
+    return ret;
   }
 
   int nargs = lua_gettop(lstate) - 1;

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1355,6 +1355,22 @@ describe('lua stdlib', function()
     )
   end)
 
+  it('vim.call fails in fast context', function()
+    local screen = Screen.new(120, 10)
+    exec_lua([[
+      local timer = vim.uv.new_timer()
+      timer:start(0, 0, function()
+        timer:close()
+        vim.call('sin', 0.0)
+      end)
+    ]])
+    screen:expect({
+      any = pesc('E5560: Vimscript function "sin" must not be called in a fast event context'),
+    })
+    feed('<CR>')
+    assert_alive()
+  end)
+
   it('vim.fn errors when calling API function', function()
     matches(
       'Tried to call API function with vim.fn: use vim.api.nvim_get_current_line instead',


### PR DESCRIPTION

    I got this error when running a plugin tests:
```
    ✱Error executing callback:
    ...6ya-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/tasks.lua:100: Async task failed without callback: The coroutine failed with this message:
    ...ya-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/logger.lua:51: E5560: Vimscript function (mkdir) must not be called in a fast event context
    stack traceback:
            [C]: in function 'require'
            lua/rocks/adapter.lua:164: in function 'init_site_symlinks_async'
            lua/rocks/adapter.lua:207: in function 'synchronise_site_symlinks'
            lua/rocks/adapter.lua:199: in function 'ensure_site_links'
            lua/rocks/adapter.lua:213: in function 'func'
            ...6ya-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/tasks.lua:169: in function <...6ya-lua5.1-nvim-nio-1.10.1-1/share/lua/5.1/nio/tasks.lua:168>
    stack traceback:
    ===
```
this patch adds the name of the function used in fast event context.


NB: I cant' format locally because:

```
[ 79%] Building CXX object CMakeFiles/uncrustify.dir/src/unc_tools.cpp.o
[ 79%] Building CXX object CMakeFiles/uncrustify.dir/src/unicode.cpp.o
[ 82%] Building CXX object CMakeFiles/uncrustify.dir/src/universalindentgui.cpp.o
[ 82%] Building CXX object CMakeFiles/uncrustify.dir/src/width.cpp.o
[ 82%] Building CXX object CMakeFiles/uncrustify.dir/src/options.cpp.o
[ 82%] Building CXX object CMakeFiles/uncrustify.dir/src/option_enum.cpp.o
[ 85%] Linking CXX executable /home/teto/neovim/build/usr/bin/uncrustify
[100%] Built target uncrustify
[  0%] Performing install step for 'uncrustify'
[  0%] Generating version header
-- Unable to determine version from source tree; fallback version '0.80.1_f' will be used
-- (This is normal if you are building from a zip / tarball)
[  0%] Built target generate_version_header
[100%] Built target uncrustify
Install the project...
-- Install configuration: "Release"
CMake Error at cmake_install.cmake:52 (file):
  file INSTALL cannot find "/home/teto/neovim/build/usr/bin/uncrustify": No
  such file or directory.


make[5]: *** [Makefile:130: install] Error 1
make[4]: *** [CMakeFiles/uncrustify.dir/build.make:106: build/src/uncrustify-stamp/uncrustify-install] Error 2
make[3]: *** [CMakeFiles/Makefile2:676: CMakeFiles/uncrustify.dir/all] Error 2
make[2]: *** [CMakeFiles/Makefile2:580: CMakeFiles/format.dir/rule] Error 2
make[1]: *** [Makefile:281: format] Error 2
make[1]: Leaving directory '/home/teto/neovim/build'
make: *** [Makefile:142: format] Error 2
```