### PR TITLE
fix(api): set script context consistently

### DIFF
--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -475,19 +475,16 @@ Integer nvim_create_autocmd(uint64_t channel_id, Object event, Dict(create_autoc
     int retval;
 
     FOREACH_ITEM(patterns, pat, {
-      WITH_SCRIPT_CONTEXT(channel_id, {
-        retval = autocmd_register(autocmd_id,
-                                  event_nr,
-                                  pat.data.string.data,
-                                  (int)pat.data.string.size,
-                                  au_group,
-                                  opts->once,
-                                  opts->nested,
-                                  desc,
-                                  handler_cmd,
-                                  &handler_fn);
-      });
-
+      retval = autocmd_register(autocmd_id,
+                                event_nr,
+                                pat.data.string.data,
+                                (int)pat.data.string.size,
+                                au_group,
+                                opts->once,
+                                opts->nested,
+                                desc,
+                                handler_cmd,
+                                &handler_fn);
       if (retval == FAIL) {
         api_set_error(err, kErrorTypeException, "Failed to set autocmd");
         goto cleanup;
@@ -621,20 +618,17 @@ Integer nvim_create_augroup(uint64_t channel_id, String name, Dict(create_augrou
   char *augroup_name = name.data;
   bool clear_autocmds = GET_BOOL_OR_TRUE(opts, create_augroup, clear);
 
-  int augroup = -1;
-  WITH_SCRIPT_CONTEXT(channel_id, {
-    augroup = augroup_add(augroup_name);
-    if (augroup == AUGROUP_ERROR) {
-      api_set_error(err, kErrorTypeException, "Failed to set augroup");
-      return -1;
-    }
+  int augroup = augroup_add(augroup_name);
+  if (augroup == AUGROUP_ERROR) {
+    api_set_error(err, kErrorTypeException, "Failed to set augroup");
+    return -1;
+  }
 
-    if (clear_autocmds) {
-      FOR_ALL_AUEVENTS(event) {
-        aucmd_del_for_event_and_group(event, augroup);
-      }
+  if (clear_autocmds) {
+    FOR_ALL_AUEVENTS(event) {
+      aucmd_del_for_event_and_group(event, augroup);
     }
-  });
+  }
 
   return augroup;
 }

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -650,9 +650,7 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Arena
       msg_col = 0;  // prevent leading spaces
     }
 
-    WITH_SCRIPT_CONTEXT(channel_id, {
-      execute_cmd(&ea, &cmdinfo, false);
-    });
+    execute_cmd(&ea, &cmdinfo, false);
 
     if (opts->output) {
       capture_ga = save_capture_ga;
@@ -1144,13 +1142,11 @@ void create_user_command(uint64_t channel_id, String name, Object command, Dict(
     });
   }
 
-  WITH_SCRIPT_CONTEXT(channel_id, {
-    if (uc_add_command(name.data, name.size, rep, argt, def, flags, context, compl_arg,
-                       compl_luaref, preview_luaref, addr_type_arg, luaref, force) != OK) {
-      api_set_error(err, kErrorTypeException, "Failed to create user command");
-      // Do not goto err, since uc_add_command now owns luaref, compl_luaref, and compl_arg
-    }
-  });
+  if (uc_add_command(name.data, name.size, rep, argt, def, flags, context, compl_arg,
+                     compl_luaref, preview_luaref, addr_type_arg, luaref, force) != OK) {
+    api_set_error(err, kErrorTypeException, "Failed to create user command");
+    // Do not goto err, since uc_add_command now owns luaref, compl_luaref, and compl_arg
+  }
 
   return;
 

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -797,9 +797,7 @@ static void set_option_to(uint64_t channel_id, void *to, OptScope scope, String 
       ? 0
       : ((scope == kOptScopeGlobal) ? OPT_GLOBAL : OPT_LOCAL);
 
-  WITH_SCRIPT_CONTEXT(channel_id, {
-    set_option_value_for(name.data, opt_idx, optval, opt_flags, scope, to, err);
-  });
+  set_option_value_for(name.data, opt_idx, optval, opt_flags, scope, to, err);
 }
 
 /// @deprecated Use nvim_exec_lua() instead.

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -256,9 +256,7 @@ void nvim_set_option_value(uint64_t channel_id, String name, Object value, Dict(
     return;
   });
 
-  WITH_SCRIPT_CONTEXT(channel_id, {
-    set_option_value_for(name.data, opt_idx, optval, opt_flags, scope, to, err);
-  });
+  set_option_value_for(name.data, opt_idx, optval, opt_flags, scope, to, err);
 }
 
 /// Gets the option information for all options.

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -183,10 +183,3 @@ typedef struct {
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/private/helpers.h.generated.h"
 #endif
-
-#define WITH_SCRIPT_CONTEXT(channel_id, code) \
-  do { \
-    const sctx_T save_current_sctx = api_set_sctx(channel_id); \
-    code; \
-    current_sctx = save_current_sctx; \
-  } while (0);

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -187,9 +187,7 @@ void nvim_set_hl(uint64_t channel_id, Integer ns_id, String name, Dict(highlight
 
   HlAttrs attrs = dict2hlattrs(val, true, &link_id, err);
   if (!ERROR_SET(err)) {
-    WITH_SCRIPT_CONTEXT(channel_id, {
-      ns_hl_def((NS)ns_id, hl_id, attrs, link_id, val);
-    });
+    ns_hl_def((NS)ns_id, hl_id, attrs, link_id, val);
   }
 }
 

--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -86,8 +86,6 @@ String exec_impl(uint64_t channel_id, String src, Dict(exec_opts) *opts, Error *
       msg_col = 0;  // prevent leading spaces
     }
 
-    const sctx_T save_current_sctx = api_set_sctx(channel_id);
-
     do_source_str(src.data, "nvim_exec2()");
     if (opts->output) {
       capture_ga = save_capture_ga;
@@ -95,8 +93,6 @@ String exec_impl(uint64_t channel_id, String src, Dict(exec_opts) *opts, Error *
       // Put msg_col back where it was, since nothing should have been written.
       msg_col = save_msg_col;
     }
-
-    current_sctx = save_current_sctx;
   });
 
   if (ERROR_SET(err)) {

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -2706,8 +2706,6 @@ void modify_keymap(uint64_t channel_id, Buffer buffer, bool is_unmap, String mod
     return;
   }
 
-  const sctx_T save_current_sctx = api_set_sctx(channel_id);
-
   MapArguments parsed_args = MAP_ARGUMENTS_INIT;
   if (opts) {
     parsed_args.nowait = opts->nowait;
@@ -2813,7 +2811,6 @@ void modify_keymap(uint64_t channel_id, Buffer buffer, bool is_unmap, String mod
   }  // switch
 
 fail_and_free:
-  current_sctx = save_current_sctx;
   NLUA_CLEAR_REF(parsed_args.rhs_lua);
   xfree(parsed_args.rhs);
   xfree(parsed_args.orig_rhs);

--- a/test/functional/ex_cmds/verbose_spec.lua
+++ b/test/functional/ex_cmds/verbose_spec.lua
@@ -191,9 +191,6 @@ TestHL2        xxx guibg=Green
   end)
 
   it('"Last set" for command defined by nvim_command', function()
-    if cmd == 'luafile' then
-      pending('nvim_command does not set the script context')
-    end
     local result = exec_capture(':verbose command Bdelete')
     eq(
       string.format(


### PR DESCRIPTION
Move the saving and restoring of script context to wrapper code around
API calls, so that every API sets script context consistently.