### PR TITLE
fix(lua): don't override script ID from :source

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7646,22 +7646,8 @@ hashtab_T *find_var_ht_dict(const char *name, const size_t name_len, const char 
                  || current_sctx.sc_sid == SID_LUA)
              && current_sctx.sc_sid <= script_items.ga_len) {
     // For anonymous scripts without a script item, create one now so script vars can be used
-    if (current_sctx.sc_sid == SID_LUA) {
-      // try to resolve lua filename & line no so it can be shown in lastset messages.
-      nlua_set_sctx(&current_sctx);
-      if (current_sctx.sc_sid != SID_LUA) {
-        // Great we have valid location. Now here this out we'll create a new
-        // script context with the name and lineno of this one. why ?
-        // for behavioral consistency. With this different anonymous exec from
-        // same file can't access each others script local stuff. We need to do
-        // this all other cases except this will act like that otherwise.
-        bool should_free;
-        // should_free is ignored as script_ctx will be resolved to a fname
-        // and new_script_item() will consume it.
-        char *sc_name = get_scriptname(current_sctx, &should_free);
-        new_script_item(sc_name, &current_sctx.sc_sid);
-      }
-    }
+    // Try to resolve lua filename & linenr so it can be shown in last-set messages.
+    nlua_set_sctx(&current_sctx);
     if (current_sctx.sc_sid == SID_STR || current_sctx.sc_sid == SID_LUA) {
       // Create SID if s: scope is accessed from Lua or anon Vimscript. #15994
       new_script_item(NULL, &current_sctx.sc_sid);

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -2110,7 +2110,8 @@ bool nlua_execute_on_key(int c, char *typed_buf)
 // @param[out] current
 void nlua_set_sctx(sctx_T *current)
 {
-  if (p_verbose <= 0 || current->sc_sid != SID_LUA) {
+  if (p_verbose <= 0 || (current->sc_sid > 0 && current->sc_lnum > 0)
+      || !script_is_lua(current->sc_sid)) {
     return;
   }
   lua_State *const lstate = global_lstate;
@@ -2119,6 +2120,7 @@ void nlua_set_sctx(sctx_T *current)
   // Files where internal wrappers are defined so we can ignore them
   // like vim.o/opt etc are defined in _options.lua
   char *ignorelist[] = {
+    "vim/_editor.lua",
     "vim/_options.lua",
     "vim/keymap.lua",
   };
@@ -2153,7 +2155,8 @@ void nlua_set_sctx(sctx_T *current)
   if (sid > 0) {
     xfree(source_path);
   } else {
-    new_script_item(source_path, &sid);
+    scriptitem_T *si = new_script_item(source_path, &sid);
+    si->sn_lua = true;
   }
   current->sc_sid = sid;
   current->sc_seq = -1;

--- a/src/nvim/runtime_defs.h
+++ b/src/nvim/runtime_defs.h
@@ -49,6 +49,7 @@ typedef struct {
   scriptvar_T *sn_vars;         ///< stores s: variables for this script
 
   char *sn_name;
+  bool sn_lua;                  ///< true for a lua script
   bool sn_prof_on;              ///< true when script is/was profiled
   bool sn_pr_force;             ///< forceit: profile functions in this script
   proftime_T sn_pr_child;       ///< time set when going into first child


### PR DESCRIPTION
Problem:  When setting an option, mapping etc. from Lua without -V1, the
          script ID is set to SID_LUA even if there already is a script
          ID assigned by :source.
Solution: Don't set script ID to SID_LUA if it is already a Lua script.
          Also add _editor.lua to ignorelist to make script context more
          useful when using vim.cmd().

Fix #32598
