### PR TITLE
fix(move): 'scrolloff' cursor correction no longer handles folds properly

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2294,7 +2294,8 @@ void cursor_correct(win_T *wp)
   int below = wp->w_filler_rows;  // screen lines below botline
   while ((above < above_wanted || below < below_wanted) && topline < botline) {
     if (below < below_wanted && (below <= above || above >= above_wanted)) {
-      below += plines_win_full(wp, botline, &botline, NULL, true, true);
+      below += plines_win_full(wp, botline, NULL, NULL, true, true);
+      hasFolding(wp, botline, &botline, NULL);
       botline--;
     }
     if (above < above_wanted && (above < below || below >= below_wanted)) {

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -884,7 +884,7 @@ int plines_win_col(win_T *wp, linenr_T lnum, long column)
 ///
 /// @param[in]  wp               window the line is in
 /// @param[in]  lnum             line number
-/// @param[out] nextp            if not NULL, the line after a fold
+/// @param[out] nextp            if not NULL, the last line of a fold
 /// @param[out] foldedp          if not NULL, whether lnum is on a fold
 /// @param[in]  cache            whether to use the window's cache for folds
 /// @param[in]  limit_winheight  when true limit to window height

--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -2744,4 +2744,23 @@ describe('folded lines', function()
   describe('without ext_multigrid', function()
     with_ext_multigrid(false)
   end)
+
+  it("do not interfere with corrected cursor position for 'scrolloff'", function()
+    local screen = Screen.new(40, 7)
+    exec([[
+      call setline(1, range(10))
+      6,7fold
+      set scrolloff=1
+      norm L
+    ]])
+    screen:expect([[
+      0                                       |
+      1                                       |
+      2                                       |
+      3                                       |
+      ^4                                       |
+      {13:+--  2 lines: 5·························}|
+                                              |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:  f58e7d5f passed `&botline` to `plines_win_full()`, (probably)
          assuming it would be set to the first line of the fold.
Solution: Reinstate call to `hasFolding()` to do so.