### PR TITLE
perf(test): pre-spawn neovim instances

### DIFF
--- a/test/functional/core/log_spec.lua
+++ b/test/functional/core/log_spec.lua
@@ -70,15 +70,15 @@ describe('log', function()
       __NVIM_TEST_LOG = '1',
     })
     -- Example:
-    --    ERR 2024-09-11T16:41:17.539 ui/c/T2.47826.0 ui_client_run:165: test log message
-    local tid = _G._nvim_test_id
-    assert_log(' ui/c/' .. tid .. '%.%d+%.%d +ui_client_run:%d+: test log message', testlog, 100)
+    --    ERR 2024-09-11T16:41:17.539 ui/c/S2.47826.0 ui_client_run:165: test log message
+    local sid = _G._nvim_session_id
+    assert_log(' ui/c/' .. sid .. '%.%d+%.%d +ui_client_run:%d+: test log message', testlog, 100)
   end)
 
   it('formats messages with session name or test id', function()
     -- Examples:
-    --    ERR 2024-09-11T16:44:33.794 T3.49429.0 server_init:58: test log message
-    --    ERR 2024-09-11T16:44:33.823 c/T3.49429.0 server_init:58: test log message
+    --    ERR 2024-09-11T16:44:33.794 S3.49429.0 server_init:58: test log message
+    --    ERR 2024-09-11T16:44:33.823 c/S3.49429.0 server_init:58: test log message
 
     clear({
       env = {
@@ -88,8 +88,8 @@ describe('log', function()
       },
     })
 
-    local tid = _G._nvim_test_id
-    assert_log(tid .. '%.%d+%.%d +server_init:%d+: test log message', testlog, 100)
+    local sid = _G._nvim_session_id
+    assert_log(sid .. '%.%d+%.%d +server_init:%d+: test log message', testlog, 100)
 
     exec_lua([[
       local j1 = vim.fn.jobstart({ vim.v.progpath, '-es', '-V1', '+foochild', '+qa!' }, vim.empty_dict())
@@ -97,6 +97,6 @@ describe('log', function()
     ]])
 
     -- Child Nvim spawned by jobstart() prepends "c/" to parent name.
-    assert_log('c/' .. tid .. '%.%d+%.%d +server_init:%d+: test log message', testlog, 100)
+    assert_log('c/' .. sid .. '%.%d+%.%d +server_init:%d+: test log message', testlog, 100)
   end)
 end)

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -701,10 +701,11 @@ describe('messages', function()
       hide buffer a.txt
 
       autocmd CursorHold * buf b.txt | w | echo "'b' written"
+
+      set updatetime=50
+      normal! 0$
     ]])
 
-    command('set updatetime=50')
-    feed('0$')
     screen:expect([[
       ^hi                                      |
       {1:~                                       }|*4

--- a/test/functional/ui/diff_spec.lua
+++ b/test/functional/ui/diff_spec.lua
@@ -9,6 +9,7 @@ local insert = n.insert
 local write_file = t.write_file
 local dedent = t.dedent
 local exec = n.exec
+local exec_lua = n.exec_lua
 local eq = t.eq
 local api = n.api
 
@@ -1561,6 +1562,18 @@ it('diff mode overlapped diff blocks will be merged', function()
   write_file('Xdiin1', 'a\nb')
   write_file('Xdinew1', 'x\nx')
   write_file('Xdiout1', '1c1\n2c2')
+
+  -- see: https://github.com/neovim/neovim/pull/32644#issuecomment-2715655096
+  exec_lua(function()
+    for _, buf in ipairs(vim.api.nvim_list_bufs()) do
+      pcall(function()
+        vim.api.nvim_buf_call(buf, function()
+          vim.cmd('edit!')
+        end)
+      end)
+    end
+  end)
+
   command('set diffexpr=DiffExprStub()')
   screen:expect([[
     {7:  }{27:a}{4:              }│{7:  }{27:^x}{4:              }|


### PR DESCRIPTION
Functional tests call `clear()` before each test, which spawns a new neovim instance, and start using it immediately after. This forces each test to wait until the newly spawned neovim is ready.

Added a queue of 10 neovim instances that are spawned before they are needed. When `clear()` is called, the oldest instance in the queue is used. This makes it more likely that the instance is ready by the time it is needed. Queue is refilled when instances are removed from it.

This reduces total time taken by functional tests.

Note:

Since instances are created before the tests that use them, we can't use `_G._nvim_test_id` from https://github.com/neovim/neovim/pull/8519 in e.g. `test/functional/core/log_spec.lua`, since we can't know which test will use which instance. New `_G._nvim_session_id` is introduced, which is set when the session is set.

Other places like making a temporary directory of printing the name of the test still use `_G._nvim_test_id`.

Also some of the calls to `clear()` have arguments, but since we can't predict which arguments will be passed, the optimization doesn't apply to them.

### Results

|| current | new |
|-|-|-|
ubuntu asan clang functionaltest | 14m 54s | 12m 38s |
ubuntu tsan clang functionaltest | 15m 56s | 14m 41s |
ubuntu release gcc functionaltest | 6m 30s | 6m 15s |
macos intel clang functionaltest | 9m 36s | 7m 44s |
macos arm clang functionaltest | 6m 29s | 5m 40s |
ubuntu puc-lua gcc functionaltest | 6m 46s | 6m 28s |
windows / windows (functional) | 11m 35s | 8m 34s |


<details>

<summary>data</summary>

current:
1. https://github.com/vanaigr/neovim/actions/runs/13501048829
2. https://github.com/vanaigr/neovim/actions/runs/13512336529
3. https://github.com/neovim/neovim/actions/runs/13549176090
4. https://github.com/neovim/neovim/actions/runs/13548758242
5. https://github.com/neovim/neovim/actions/runs/13548725467

||1|2|3|4|5|
|-|-|-|-|-|-|
| ubuntu asan clang functionaltest | 15m 26s | 14m 29s | 14m 59s | 14m 32s | 15m 2s |
| ubuntu tsan clang functionaltest | 15m 15s | 15m 57s | 16m 19s | 17m 3s | 15m 5s |
| ubuntu release gcc functionaltest | 6m 35s | 6m 19s | 6m 38s | 6m 18s | 6m 41s |
| macos intel clang functionaltest | 11m 25s | 8m 37s | 8m 51s | 9m 2s | 10m 5s |
| macos arm clang functionaltest | 6m 28s | 6m 33s | 6m 51s | 6m 19s | 6m 12s |
| ubuntu puc-lua gcc functionaltest | 6m 39s | 6m 41s | 6m 50s | 6m 46s | 6m 56s |
| windows / windows (functional) | 12m 24s | 11m 42s | 11m 20s | 11m 20s | 11m 10s |


new:
1. https://github.com/vanaigr/neovim/actions/runs/13550052710
2. https://github.com/vanaigr/neovim/actions/runs/13549525879
3. https://github.com/vanaigr/neovim/actions/runs/13539200286

||1|2|3|
|-|-|-|-|
| ubuntu asan clang functionaltest | 12m 25s | 12m 53s | 12m 36s |
| ubuntu tsan clang functionaltest | 15m 6s | 14m 14s | 14m 42s |
| ubuntu release gcc functionaltest | 6m 28s | 6m 11s | 6m 7s |
| macos intel clang functionaltest | 7m 8s | 8m 32s | 7m 31s |
| macos arm clang functionaltest | 5m 57s | 5m 23s | 5m 41s |
| ubuntu puc-lua gcc functionaltest | 6m 17s | 6m 41s | 6m 25s |
| windows / windows (functional) | 8m 36s | 8m 40s | 8m 25s |


```python
def average_times(time_lists):
    averaged_times = []
    for times in time_lists:
        total_seconds = sum(m * 60 + s for m, s in times)
        avg_seconds = round(total_seconds / len(times))
        avg_minutes, avg_seconds = divmod(avg_seconds, 60)
        averaged_times.append(f"{avg_minutes}m {avg_seconds}s")
    return averaged_times

time_data = [
    # [(12, 25), (12, 53), (12, 36)],
    ...
]

print(average_times(time_data))
```

</details>