### PR TITLE
fix(lua): wrong script context for option set by func from nvim_exec2

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -2106,12 +2106,20 @@ bool nlua_execute_on_key(int c, char *typed_buf)
   return discard;
 }
 
-// Sets the editor "script context" during Lua execution. Used by :verbose.
-// @param[out] current
+/// Sets the editor "script context" during Lua execution. Used by :verbose.
+/// @param[out] current
 void nlua_set_sctx(sctx_T *current)
 {
-  if (p_verbose <= 0 || (current->sc_sid > 0 && current->sc_lnum > 0)
-      || !script_is_lua(current->sc_sid)) {
+  if (!script_is_lua(current->sc_sid)) {
+    return;
+  }
+
+  // This function is called after adding SOURCING_LNUM to sc_lnum.
+  // SOURCING_LNUM can sometimes be non-zero (e.g. with ETYPE_UFUNC),
+  // but it's unrelated to the line number in Lua scripts.
+  current->sc_lnum = 0;
+
+  if (p_verbose <= 0) {
     return;
   }
   lua_State *const lstate = global_lstate;

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1813,12 +1813,12 @@ sctx_T *get_option_sctx(OptIndex opt_idx)
 void set_option_sctx(OptIndex opt_idx, int opt_flags, sctx_T script_ctx)
 {
   bool both = (opt_flags & (OPT_LOCAL | OPT_GLOBAL)) == 0;
-  nlua_set_sctx(&script_ctx);
 
   // Modeline already has the line number set.
   if (!(opt_flags & OPT_MODELINE)) {
     script_ctx.sc_lnum += SOURCING_LNUM;
   }
+  nlua_set_sctx(&script_ctx);
 
   // Remember where the option was set.  For local options need to do that
   // in the buffer or window structure.

--- a/test/functional/ex_cmds/verbose_spec.lua
+++ b/test/functional/ex_cmds/verbose_spec.lua
@@ -23,7 +23,7 @@ local function last_set_lua_verbose_tests(cmd, v1)
 
     write_file(
       script_file,
-      [[
+      [=[
 vim.api.nvim_set_option_value('hlsearch', false, {})
 vim.bo.expandtab = true
 vim.opt.number = true
@@ -70,8 +70,17 @@ endfunction\
 let &tw = s:return80()\
 ", {})
 
+local set_list = ([[
+  func SetList()
+%s
+    set list
+  endfunc
+  call SetList()
+]]):format(('\n'):rep(1234))
+vim.api.nvim_exec2(set_list, {})
+
 vim.api.nvim_create_autocmd('User', { pattern = 'set_mouse', callback = cb })
-]]
+]=]
     )
     exec(cmd .. ' ' .. script_file)
     exec('doautocmd User set_mouse')
@@ -255,6 +264,19 @@ TestHL2        xxx guibg=Green
   textwidth=80
 	Last set from %s]],
         loc
+      ),
+      result
+    )
+  end)
+
+  it('for option set by function in nvim_exec2', function()
+    local result = exec_capture(':verbose set list?')
+    eq(
+      string.format(
+        [[
+  list
+	Last set from %s]],
+        get_last_set_location(54)
       ),
       result
     )


### PR DESCRIPTION
Problem:  Wrong script context for option set by function defined by
          nvim_exec2 in a Lua script.
Solution: Call nlua_set_sctx() after adding SOURCING_LNUM and always set
          sc_lnum for a Lua script.

This is a bug discovered when testing #28486. Not sure if this actually
happens in practice, but it's easy to fix and required for #28486.
