### PR TITLE
fix(marks): ineffective conceal_line callback optimization

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -431,7 +431,7 @@ end
 function TSHighlighter._on_conceal_line(_, _, buf, row)
   local self = TSHighlighter.active[buf]
   if not self or not self._conceal_line or self._conceal_checked[row] then
-    return self and self._conceal_line
+    return
   end
 
   -- Do not affect potentially populated highlight state.
@@ -440,7 +440,6 @@ function TSHighlighter._on_conceal_line(_, _, buf, row)
   self:prepare_highlight_states(row, row)
   on_line_impl(self, buf, row, false, true)
   self._highlight_states = highlight_states
-  return true
 end
 
 ---@private

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -413,8 +413,7 @@ struct file_buffer {
                                 // negative when lines were deleted
   kvec_t(WinInfo *) b_wininfo;  // list of last used info for each window
   disptick_T b_mod_tick_syn;    // last display tick syntax was updated
-  disptick_T b_mod_tick_decor;  // last display tick decoration providers
-                                // where invoked
+  disptick_T b_mod_tick_decor;  // last display tick decoration providers were invoked
 
   int64_t b_mtime;              // last change time of original file
   int64_t b_mtime_ns;           // nanoseconds of last change time
@@ -1324,7 +1323,4 @@ struct window_S {
   size_t w_winbar_click_defs_size;              // Size of the w_winbar_click_defs array
   StlClickDefinition *w_statuscol_click_defs;   // Status column click definitions
   size_t w_statuscol_click_defs_size;           // Size of the w_statuscol_click_defs array
-
-  buf_T *w_conceal_line_buf;                    // buffer in win when first invoked
-  bool w_conceal_line_provider;                 // whether conceal_line provider is active
 };

--- a/src/nvim/decoration_provider.h
+++ b/src/nvim/decoration_provider.h
@@ -6,8 +6,6 @@
 #include "nvim/macros_defs.h"
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-EXTERN bool provider_active INIT( = false);
-
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "decoration_provider.h.generated.h"
 #endif

--- a/test/functional/plugin/lsp/utils_spec.lua
+++ b/test/functional/plugin/lsp/utils_spec.lua
@@ -366,5 +366,21 @@ describe('vim.lsp.util', function()
       {1:~                                                    }|*9
                                                            |
     ]])
+    -- Correct height when float inherits 'conceallevel' >= 2 #32639
+    command('close | set conceallevel=2')
+    exec_lua([[
+      vim.lsp.util.open_floating_preview({ '```lua', 'local foo', '```' }, 'markdown', {
+        border = 'single',
+        focus = false,
+      })
+    ]])
+    screen:expect([[
+      ^                                                     |
+      ┌─────────┐{1:                                          }|
+      │{100:local}{101: }{102:foo}│{1:                                          }|
+      └─────────┘{1:                                          }|
+      {1:~                                                    }|*9
+                                                           |
+    ]])
   end)
 end)


### PR DESCRIPTION
Problem:  _on_conceal_line callbacks are not invoked if callback has not
          let Nvim know it wants to receive them. But this may change on
          factors other than what is currently checked (changed buffer).
Solution: Forego this optimization, callback is still guarded behind
          'conceallevel'.

Fix #32639