### PR TITLE
vim-patch:3d75ec7: runtime(compiler): improve svelte-check

### DIFF
--- a/runtime/compiler/svelte-check.vim
+++ b/runtime/compiler/svelte-check.vim
@@ -1,19 +1,21 @@
 " Vim compiler file
 " Compiler:	svelte-check
 " Maintainer:	@Konfekt
-" Last Change:	2025 Feb 22
+" Last Change:	2025 Feb 27
 
 if exists("current_compiler") | finish | endif
 let current_compiler = "svelte-check"
 
 CompilerSet makeprg=npx\ svelte-check\ --output\ machine
-CompilerSet errorformat=%*\\d\ %t%*\\a\ \"%f\"\ %l:%c\ %m
+CompilerSet errorformat=%*\\d\ %t%*\\a\ \"%f\"\ %l:%c\ \"%m\",
+CompilerSet errorformat+=%-G%*\\d\ START\ %.%#,
+CompilerSet errorformat+=%-G%*\\d\ COMPLETED\ %.%#,
 CompilerSet errorformat+=%-G%.%#
 
 " " Fall-back for versions of svelte-check that don't support --output machine
 " " before  May 2020 https://github.com/sveltejs/language-tools/commit/9f7a90379d287a41621a5e78af5b010a8ab810c3
 " " which is before the first production release 1.1.31 of Svelte-Check
 " CompilerSet makeprg=npx\ svelte-check
-" CompilerSet errorformat=%E%f:%l:%c,
-" CompilerSet errorformat+=%+ZError\:\ %m,
-" CompilerSet errorformat+=%-G%.%#
+" CompilerSet errorformat=%A%f:%l:%c,
+" CompilerSet errorformat+=%C%t%*\\a\\:\ %m,
+" CompilerSet errorformat+=%-G%.%#,


### PR DESCRIPTION
closes: vim/vim#16749

https://github.com/vim/vim/commit/3d75ec7401850e8a80ae7ab5ad1b84f47bc32095

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>
