### PR TITLE
build!: turn off translations by default

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -66,7 +66,9 @@ API
 
 BUILD
 
-On Windows, only building with the UCRT runtime is supported.
+• On Windows, only building with the UCRT runtime is supported.
+• Translations are turned off by default. Enable by building Nvim with the
+  CMake flag `ENABLE_TRANSLATIONS=ON`.
 
 DEFAULTS
 

--- a/src/nvim/po/CMakeLists.txt
+++ b/src/nvim/po/CMakeLists.txt
@@ -1,3 +1,8 @@
+option(ENABLE_TRANSLATIONS "Localizations to build" OFF)
+if(NOT ENABLE_TRANSLATIONS)
+  return()
+endif()
+
 find_package(Gettext REQUIRED)
 find_program(XGETTEXT_PRG xgettext)
 find_program(ICONV_PRG iconv)
@@ -7,8 +12,7 @@ mark_as_advanced(
   ICONV_PRG
   XGETTEXT_PRG)
 
-option(ENABLE_LANGUAGES "Localizations to build" ON)
-if(ENABLE_LANGUAGES)
+if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
   set(LANGUAGES
     af
     ca
@@ -36,9 +40,7 @@ if(ENABLE_LANGUAGES)
     vi
     zh_CN.UTF-8
     zh_TW.UTF-8)
-endif()
 
-if(HAVE_WORKING_LIBINTL AND GETTEXT_FOUND AND XGETTEXT_PRG AND ICONV_PRG)
   set(ENV{OLD_PO_FILE_INPUT} yes)
   set(ENV{OLD_PO_FILE_OUTPUT} yes)
 

--- a/test/cmakeconfig/paths.lua.in
+++ b/test/cmakeconfig/paths.lua.in
@@ -5,6 +5,7 @@ for p in ("${TEST_INCLUDE_DIRS}" .. ";"):gmatch("[^;]+") do
   table.insert(M.include_paths, p)
 end
 
+M.translations_enabled = "${ENABLE_TRANSLATIONS}" == "ON"
 M.vterm_test_file = "${VTERM_TEST_FILE}"
 M.test_build_dir = "${CMAKE_BINARY_DIR}"
 M.test_source_path = "${CMAKE_SOURCE_DIR}"

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -2424,6 +2424,7 @@ end)
 
 describe('ui/msg_puts_printf', function()
   it('output multibyte characters correctly', function()
+    skip(not t.translations_enabled(), 'Nvim not built with ENABLE_TRANSLATIONS')
     local screen
     local cmd = ''
     local locale_dir = test_build_dir .. '/share/locale/ja/LC_MESSAGES'

--- a/test/testutil.lua
+++ b/test/testutil.lua
@@ -840,4 +840,8 @@ function M.skip_fragile(pending_fn, cond)
   return false
 end
 
+function M.translations_enabled()
+  return M.paths.translations_enabled
+end
+
 return M


### PR DESCRIPTION
The translation step prolongs the build time too much to be enabled by
default. Enable it by passing cmake flag `ENABLE_TRANSLATIONS=ON`.
