### PR TITLE
vim-patch:9.1.1155: Mode message not cleared after :silent message

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1679,7 +1679,7 @@ int msg_outtrans_len(const char *msgstr, int len, int hl_id, bool hist)
 
   // When drawing over the command line no need to clear it later or remove
   // the mode message.
-  if (msg_row >= cmdline_row && msg_col == 0) {
+  if (msg_silent == 0 && len > 0 && msg_row >= cmdline_row && msg_col == 0) {
     clear_cmdline = false;
     mode_displayed = false;
   }

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -87,6 +87,33 @@ describe('messages', function()
     ]])
   end)
 
+  -- oldtest: Test_mode_cleared_after_silent_message()
+  it('mode is cleared properly after slient message', function()
+    screen = Screen.new(60, 10)
+    exec([[
+      edit XsilentMessageMode.txt
+      call setline(1, 'foobar')
+      autocmd TextChanged * silent update
+    ]])
+    finally(function()
+      os.remove('XsilentMessageMode.txt')
+    end)
+
+    feed('v')
+    screen:expect([[
+      ^foobar                                                      |
+      {1:~                                                           }|*8
+      {5:-- VISUAL --}                                                |
+    ]])
+
+    feed('d')
+    screen:expect([[
+      ^oobar                                                       |
+      {1:~                                                           }|*8
+                                                                  |
+    ]])
+  end)
+
   describe('more prompt', function()
     before_each(function()
       command('set more')

--- a/test/old/testdir/test_messages.vim
+++ b/test/old/testdir/test_messages.vim
@@ -387,6 +387,29 @@ func Test_message_not_cleared_after_mode()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_mode_cleared_after_silent_message()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+    edit XsilentMessageMode.txt
+    call setline(1, 'foobar')
+    autocmd TextChanged * silent update
+  END
+  call writefile(lines, 'XsilentMessageMode', 'D')
+  let buf = RunVimInTerminal('-S XsilentMessageMode', {'rows': 10})
+
+  call term_sendkeys(buf, 'v')
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_mode_cleared_after_silent_message_1', {})
+
+  call term_sendkeys(buf, 'd')
+  call TermWait(buf)
+  call VerifyScreenDump(buf, 'Test_mode_cleared_after_silent_message_2', {})
+
+  call StopVimInTerminal(buf)
+  call delete('XsilentMessageMode.txt')
+endfunc
+
 " Test verbose message before echo command
 func Test_echo_verbose_system()
   CheckRunVimInTerminal


### PR DESCRIPTION
#### vim-patch:9.1.1155: Mode message not cleared after :silent message

Problem:  Mode message not cleared after :silent message
          (after 9.0.1634).
Solution: Don't reset mode_displayed when the message is empty.
          (zeertzjq)

fixes: neovim/neovim#32641
closes: vim/vim#16744

https://github.com/vim/vim/commit/fce1fa5b618458f6f10028faadc9a9ddc227fe76