### PR TITLE
vim-patch:9.1.1157: command completion wrong for input()

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -242,7 +242,12 @@ int nextwild(expand_T *xp, int type, int options, bool escape)
   char *p2;
 
   if (xp->xp_numfiles == -1) {
-    set_expand_context(xp);
+    if (ccline->input_fn && ccline->xp_context == EXPAND_COMMANDS) {
+      // Expand commands typed in input() function
+      set_cmd_context(xp, ccline->cmdbuff, ccline->cmdlen, ccline->cmdpos, false);
+    } else {
+      set_expand_context(xp);
+    }
     if (xp->xp_context == EXPAND_LUA) {
       nlua_expand_pat(xp);
     }

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -2071,6 +2071,11 @@ func Test_input_func()
 
   call assert_fails("call input('F:', '', 'invalid')", 'E180:')
   call assert_fails("call input('F:', '', [])", 'E730:')
+
+  " Test for using 'command' as the completion function
+  call feedkeys(":let c = input('Command? ', '', 'command')\<CR>"
+        \ .. "echo bufnam\<C-A>\<CR>", 'xt')
+  call assert_equal('echo bufname(', c)
 endfunc
 
 " Test for the inputdialog() function


### PR DESCRIPTION
#### vim-patch:9.1.1157: command completion wrong for input()

Problem:  command completion wrong for input()
          (Cdrman Fu)
Solution: Set commandline completion context explicitly
          (Jim Zhou)

closes: vim/vim#16733

https://github.com/vim/vim/commit/3255af850e8bab35c30fce4177bb5ba4a941e6ce

Co-authored-by: Jim Zhou <csd_189@163.com>