### PR TITLE
vim-patch:85a50fe: runtime(doc): fix confusing docs for 'completeitemalign'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1520,10 +1520,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 					*'completeitemalign'* *'cia'*
 'completeitemalign' 'cia'	string	(default "abbr,kind,menu")
 			global
-	A comma-separated list of |complete-items| that controls the alignment
-	and display order of items in the popup menu during Insert mode
-	completion. The supported values are abbr, kind, and menu. These
-	options allow to customize how the completion items are shown in the
+	A comma-separated list of strings that controls the alignment and
+	display order of items in the popup menu during Insert mode
+	completion.  The supported values are "abbr", "kind", and "menu".
+	These values allow customizing how |complete-items| are shown in the
 	popup menu.  Note: must always contain those three values in any
 	order.
 

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1044,10 +1044,10 @@ vim.o.cfu = vim.o.completefunc
 vim.bo.completefunc = vim.o.completefunc
 vim.bo.cfu = vim.bo.completefunc
 
---- A comma-separated list of `complete-items` that controls the alignment
---- and display order of items in the popup menu during Insert mode
---- completion. The supported values are abbr, kind, and menu. These
---- options allow to customize how the completion items are shown in the
+--- A comma-separated list of strings that controls the alignment and
+--- display order of items in the popup menu during Insert mode
+--- completion.  The supported values are "abbr", "kind", and "menu".
+--- These values allow customizing how `complete-items` are shown in the
 --- popup menu.  Note: must always contain those three values in any
 --- order.
 ---

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1466,10 +1466,10 @@ local options = {
       flags = true,
       deny_duplicates = true,
       desc = [=[
-        A comma-separated list of |complete-items| that controls the alignment
-        and display order of items in the popup menu during Insert mode
-        completion. The supported values are abbr, kind, and menu. These
-        options allow to customize how the completion items are shown in the
+        A comma-separated list of strings that controls the alignment and
+        display order of items in the popup menu during Insert mode
+        completion.  The supported values are "abbr", "kind", and "menu".
+        These values allow customizing how |complete-items| are shown in the
         popup menu.  Note: must always contain those three values in any
         order.
       ]=],


### PR DESCRIPTION
#### vim-patch:85a50fe: runtime(doc): fix confusing docs for 'completeitemalign'

closes: vim/vim#16743

https://github.com/vim/vim/commit/85a50fe825ba11a35ce654f7313b4350e3ba4b52