### PR TITLE
docs(vvars): adds windows field to vim.v.event

### DIFF
--- a/runtime/doc/vvars.txt
+++ b/runtime/doc/vvars.txt
@@ -192,6 +192,7 @@ v:event
 		  reason           Reason for completion being done. |CompleteDone|
 		  complete_word    The word that was selected, empty if abandoned complete.
 		  complete_type    See |complete_info_mode|
+		  windows          List of window IDs that changed on |WinResized|
 
 				*v:exception* *exception-variable*
 v:exception

--- a/runtime/lua/vim/_meta/vvars.lua
+++ b/runtime/lua/vim/_meta/vvars.lua
@@ -199,6 +199,7 @@ vim.v.errors = ...
 ---   reason           Reason for completion being done. `CompleteDone`
 ---   complete_word    The word that was selected, empty if abandoned complete.
 ---   complete_type    See `complete_info_mode`
+---   windows          List of window IDs that changed on `WinResized`
 --- @type vim.v.event
 vim.v.event = ...
 

--- a/runtime/lua/vim/_meta/vvars_extra.lua
+++ b/runtime/lua/vim/_meta/vvars_extra.lua
@@ -75,3 +75,5 @@ error('Cannot require a meta file')
 --- @field reason? string Reason for completion being done. |CompleteDone|
 --- The word that was selected, empty if abandoned complete. @field complete_word? string
 --- @field complete_type? string See |complete_info_mode|
+--- List of window IDs that changed on |WinResized|
+--- @field windows? integer[]

--- a/src/nvim/vvars.lua
+++ b/src/nvim/vvars.lua
@@ -214,6 +214,7 @@ M.vars = {
         reason           Reason for completion being done. |CompleteDone|
         complete_word    The word that was selected, empty if abandoned complete.
         complete_type    See |complete_info_mode|
+        windows          List of window IDs that changed on |WinResized|
     ]=],
   },
   exception = {


### PR DESCRIPTION
Adds a missing field from lua type definition.
Follows up work in: https://github.com/neovim/neovim/pull/31510