### PR TITLE
fix(treesitter): correctly parse queries with combined injections

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -59,7 +59,7 @@ function Query:_process_patterns()
       if is_directive(pred_name) then
         table.insert(directives, pattern)
         if vim.deep_equal(pattern, { 'set!', 'injection.combined' }) then
-          self._has_combined_injections = true
+          self.has_combined_injections = true
         end
         if vim.deep_equal(pattern, { 'set!', 'conceal_lines', '' }) then
           self.has_conceal_line = true


### PR DESCRIPTION
This was a stupid typo on my part, the property is not meant to be prefixed with an underscore