### PR TITLE
docs(Open): add reference in documentation

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2638,6 +2638,8 @@ vim.ui.open({path}, {opt})                                     *vim.ui.open()*
     `explorer.exe`, Linux `xdg-open`, …), or returns (but does not show) an
     error message on failure.
 
+    Can also be invoked with `:Open`.                                  *:Open*
+
     Expands "~/" and environment variables in filesystem paths.
 
     Examples: >lua

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -108,6 +108,8 @@ end
 --- Opens `path` with the system default handler (macOS `open`, Windows `explorer.exe`, Linux
 --- `xdg-open`, …), or returns (but does not show) an error message on failure.
 ---
+--- Can also be invoked with `:Open`. [:Open]()
+---
 --- Expands "~/" and environment variables in filesystem paths.
 ---
 --- Examples:


### PR DESCRIPTION
Adds documentation for the `Open` command introduced in #32506. The reference is added in the same section as `vim.ui.open` because it is simply a wrapper around it.