### PR TITLE
vim-patch: update lua ftplugin

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -695,7 +695,18 @@ To enable the recognition of Markdown comments each time after removing
 re-source "javaformat.vim" for Vim versions greater than `8.2.1397`: >
 	runtime autoload/javaformat.vim
 <
+LUA							*ft-lua-plugin*
 
+					*g:lua_version* *g:lua_subversion*
+Lua filetype's 'includeexpr' and |ft-lua-syntax| highlighting use the global
+variables "g:lua_version" and "g:lua_subversion" to determine the version of
+Lua to use (5.3 is the default)
+
+For example, to use Lua 5.1, set the variables like this: >
+
+	let g:lua_version = 5
+	let g:lua_subversion = 1
+<
 MAIL							*ft-mail-plugin*
 
 Options:

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1870,13 +1870,9 @@ instead, and the name of your source file should be `*.pike`
 
 LUA						*lua.vim* *ft-lua-syntax*
 
-The Lua syntax file can be used for versions 4.0, 5.0, 5.1 and 5.2 (5.2 is
-the default). You can select one of these versions using the global variables
-lua_version and lua_subversion. For example, to activate Lua
-5.1 syntax highlighting, set the variables like this: >
-
-	:let lua_version = 5
-	:let lua_subversion = 1
+The Lua syntax file can be used for versions 4.0, 5.0+. You can select one of
+these versions using the global variables |g:lua_version| and
+|g:lua_subversion|.
 
 
 MAIL						*mail.vim* *ft-mail.vim*

--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -5,7 +5,7 @@
 " Contributor:		Dorai Sitaram <ds26@gte.com>
 "			C.D. MacEachern <craig.daniel.maceachern@gmail.com>
 "			Phạm Bình An <phambinhanctb2004@gmail.com>
-" Last Change:		2025 Feb 25
+" Last Change:		2025 Feb 27
 
 if exists("b:did_ftplugin")
   finish
@@ -31,11 +31,11 @@ setlocal formatoptions-=t formatoptions+=croql
 
 let &l:define = '\<function\|\<local\%(\s\+function\)\='
 
-let &l:include = '\v<((do|load)file|require)[^''"]*[''"]\zs[^''"]+'
-setlocal includeexpr=LuaInclude(v:fname)
+let &l:include = '\<\%(\%(do\|load\)file\|require\)\s*('
+setlocal includeexpr=s:LuaInclude(v:fname)
 setlocal suffixesadd=.lua
 
-let b:undo_ftplugin = "setlocal cms< com< def< fo< inc< inex< sua<"
+let b:undo_ftplugin = "setl cms< com< def< fo< inc< inex< sua<"
 
 if exists("loaded_matchit") && !exists("b:match_words")
   let b:match_ignorecase = 0
@@ -66,10 +66,10 @@ if exists("s:loaded_lua") || &cp
 endif
 let s:loaded_lua = 1
 
-function LuaInclude(fname) abort
+function s:LuaInclude(fname) abort
   let lua_ver = str2float(printf("%d.%02d", g:lua_version, g:lua_subversion))
   let fname = tr(a:fname, '.', '/')
-  let paths = lua_ver >= 5.03 ?  [ fname.'.lua', fname.'/init.lua' ] : [ fname.'.lua' ]
+  let paths = lua_ver >= 5.03 ? [fname .. ".lua", fname .. "/init.lua"] : [fname .. ".lua"]
   for path in paths
     if filereadable(path)
       return path

--- a/runtime/syntax/lua.vim
+++ b/runtime/syntax/lua.vim
@@ -2,7 +2,7 @@
 " Language:     Lua 4.0, Lua 5.0, Lua 5.1, Lua 5.2 and Lua 5.3
 " Maintainer:   Marcus Aurelius Farias <masserahguard-lua 'at' yahoo com>
 " First Author: Carlos Augusto Teixeira Mendes <cmendes 'at' inf puc-rio br>
-" Last Change:  2022 Sep 07
+" Last Change:  2025 Feb 25
 " Options:      lua_version = 4 or 5
 "               lua_subversion = 0 (for 4.0 or 5.0)
 "                               or 1, 2, 3 (for 5.1, 5.2 or 5.3)
@@ -16,6 +16,7 @@ endif
 let s:cpo_save = &cpo
 set cpo&vim
 
+" keep in sync with ftplugin/lua.vim
 if !exists("lua_version")
   " Default is lua 5.3
   let lua_version = 5


### PR DESCRIPTION
#### vim-patch:00a00f5: runtime(lua): Update lua ftplugin and documentation

Problem:
- The doc says the default `g:lua_subversion` is 2, but in fact it is 3
  (see `runtime/syntax/lua.vim`)
- `includeexpr` doesn't work with module in `init.lua`

Solution:
- Update documentation
- Assign value to option `&include`
- Add function `LuaInclude` and assign it to `l:&includeexpr`

closes: vim/vim#16655

https://github.com/vim/vim/commit/00a00f5d3fc8dcf08e959c207a90f5902abc6a08

Co-authored-by: brianhuster <phambinhanctb2004@gmail.com>
Co-authored-by: dkearns <dougkearns@gmail.com>


#### vim-patch:0b82054: runtime(lua): Improve 'include' and make '*expr' functions script-local

- Prevent 'include' from matching variable assignments as calls to
  require() and others.
- Use script-local functions for 'includeexpr' and 'foldexpr'.
- Formatting fixes.

closes: vim/vim#16746

https://github.com/vim/vim/commit/0b8205484b703b4a5a569cd1b0ed876bbb13901f

Co-authored-by: Doug Kearns <dougkearns@gmail.com>