### PR TITLE
vim-patch:9.1.1158: :verbose set has wrong file name with :compiler!

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -734,7 +734,7 @@ void ex_compiler(exarg_T *eap)
 
   if (eap->forceit) {
     // ":compiler! {name}" sets global options
-    do_cmdline_cmd("command -nargs=* CompilerSet set <args>");
+    do_cmdline_cmd("command -nargs=* -keepscript CompilerSet set <args>");
   } else {
     // ":compiler! {name}" sets local options.
     // To remain backwards compatible "current_compiler" is always


### PR DESCRIPTION
#### vim-patch:9.1.1158: :verbose set has wrong file name with :compiler!

Problem:  :verbose set has wrong file name with :compiler!
Solution: Add -keepscript (zeertzjq)

closes: vim/vim#16752

https://github.com/vim/vim/commit/5e8b2268e180cbf5079ea6dbe9c8fd29c3e3133c