### PR TITLE
vim-patch:56957ed: runtime(misc): add support for bzip3 to tar, vimball and gzip plugins

### DIFF
--- a/runtime/plugin/gzip.vim
+++ b/runtime/plugin/gzip.vim
@@ -1,6 +1,6 @@
 " Vim plugin for editing compressed files.
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2025 Feb 06
+" Last Change:	2025 Feb 28
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Exit quickly when:
@@ -20,11 +20,12 @@ augroup gzip
   " The functions are defined in autoload/gzip.vim.
   "
   " Set binary mode before reading the file.
-  autocmd BufReadPre,FileReadPre	*.gz,*.bz2,*.Z,*.lzma,*.xz,*.lz,*.zst,*.br,*.lzo,*.lz4 setlocal bin
+  autocmd BufReadPre,FileReadPre	*.gz,*.bz2,*.bz3,*.Z,*.lzma,*.xz,*.lz,*.zst,*.br,*.lzo,*.lz4 setlocal bin
 
   " Use "gzip -d" and similar commands, gunzip isn't always available.
   autocmd BufReadPost,FileReadPost	*.br call gzip#read("brotli -d --rm")
   autocmd BufReadPost,FileReadPost	*.bz2 call gzip#read("bzip2 -d")
+  autocmd BufReadPost,FileReadPost	*.bz3 call gzip#read("bzip3 -d")
   autocmd BufReadPost,FileReadPost	*.gz  call gzip#read("gzip -dn")
   autocmd BufReadPost,FileReadPost	*.lz  call gzip#read("lzip -d")
   autocmd BufReadPost,FileReadPost	*.lz4 call gzip#read("lz4 -d -q --rm")
@@ -36,6 +37,7 @@ augroup gzip
 
   autocmd BufWritePost,FileWritePost	*.br  call gzip#write("brotli --rm")
   autocmd BufWritePost,FileWritePost	*.bz2 call gzip#write("bzip2")
+  autocmd BufWritePost,FileWritePost	*.bz3 call gzip#write("bzip3")
   autocmd BufWritePost,FileWritePost	*.gz  call gzip#write("gzip")
   autocmd BufWritePost,FileWritePost	*.lz  call gzip#write("lzip")
   autocmd BufWritePost,FileWritePost	*.lz4  call gzip#write("lz4 -q --rm")
@@ -47,6 +49,7 @@ augroup gzip
 
   autocmd FileAppendPre			*.br call gzip#appre("brotli -d --rm")
   autocmd FileAppendPre			*.bz2 call gzip#appre("bzip2 -d")
+  autocmd FileAppendPre			*.bz3 call gzip#appre("bzip3 -d")
   autocmd FileAppendPre			*.gz  call gzip#appre("gzip -dn")
   autocmd FileAppendPre			*.lz   call gzip#appre("lzip -d")
   autocmd FileAppendPre			*.lz4 call gzip#appre("lz4 -d -q --rm")
@@ -58,6 +61,7 @@ augroup gzip
 
   autocmd FileAppendPost		*.br call gzip#write("brotli --rm")
   autocmd FileAppendPost		*.bz2 call gzip#write("bzip2")
+  autocmd FileAppendPost		*.bz3 call gzip#write("bzip3")
   autocmd FileAppendPost		*.gz  call gzip#write("gzip")
   autocmd FileAppendPost		*.lz call gzip#write("lzip")
   autocmd FileAppendPost		*.lz4 call gzip#write("lz4 --rm")

--- a/runtime/plugin/tarPlugin.vim
+++ b/runtime/plugin/tarPlugin.vim
@@ -38,6 +38,7 @@ augroup tar
   au BufReadCmd   *.lrp			call tar#Browse(expand("<amatch>"))
   au BufReadCmd   *.tar			call tar#Browse(expand("<amatch>"))
   au BufReadCmd   *.tar.bz2		call tar#Browse(expand("<amatch>"))
+  au BufReadCmd   *.tar.bz3		call tar#Browse(expand("<amatch>"))
   au BufReadCmd   *.tar.gz		call tar#Browse(expand("<amatch>"))
   au BufReadCmd   *.tar.lz4		call tar#Browse(expand("<amatch>"))
   au BufReadCmd   *.tar.lzma		call tar#Browse(expand("<amatch>"))


### PR DESCRIPTION
fixes: vim/vim#16751
closes: vim/vim#16755

https://github.com/vim/vim/commit/56957ed4109fb0c37922c6c37d5926cfe0a3313b

Co-authored-by: Jim Zhou <jimzhouzzy@gmail.com>

---

`vimball` and `getscript` are N/A in Nvim.
