### PR TITLE
feat(lua): better filter private fields from command line completion

### DIFF
--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -913,6 +913,7 @@ function vim._expand_pat(pat, env)
 
   local match_part = string.sub(last_part, search_index, #last_part)
   local prefix_match_pat = string.sub(pat, 1, #pat - #match_part) or ''
+  local last_char = string.sub(last_part, #last_part)
 
   local final_env = env
 
@@ -971,6 +972,7 @@ function vim._expand_pat(pat, env)
         type(k) == 'string'
         and string.sub(k, 1, string.len(match_part)) == match_part
         and k:match('^[_%w]+$') ~= nil -- filter out invalid identifiers for field, e.g. 'foo#bar'
+        and (last_char ~= '.' or string.sub(k, 1, 1) ~= '_') -- don't include private fields after '.'
       then
         keys[k] = true
       end

--- a/test/functional/lua/command_line_completion_spec.lua
+++ b/test/functional/lua/command_line_completion_spec.lua
@@ -107,6 +107,30 @@ describe('nlua_expand_pat', function()
     eq({ { 'set' }, 11 }, get_completions('vim.keymap.se'))
   end)
 
+  it('should exclude private fields after "."', function()
+    eq(
+      { { 'bar' }, 4 },
+      get_completions('foo.', {
+        foo = {
+          _bar = true,
+          bar = true,
+        },
+      })
+    )
+  end)
+
+  it('should include private fields after "._"', function()
+    eq(
+      { { '_bar' }, 4 },
+      get_completions('foo._', {
+        foo = {
+          _bar = true,
+          bar = true,
+        },
+      })
+    )
+  end)
+
   it('should be able to interpolate globals', function()
     eq(
       { {


### PR DESCRIPTION
Trying to handle part 1 of https://github.com/neovim/neovim/issues/21660.

Not sure if we want to only apply this logic to `vim` modules. The current approach applies for all.