### PR TITLE
fix(ui)!: always use multiple grids internally

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1147,8 +1147,9 @@ nvim_input_mouse({button}, {action}, {modifier}, {grid}, {row}, {col})
                     press, except that the "-" separator is optional, so
                     "C-A-", "c-a" and "CA" can all be used to specify
                     Ctrl+Alt+click.
-      • {grid}      (`integer`) Grid number if the client uses |ui-multigrid|,
-                    else 0.
+      • {grid}      (`integer`) Grid number (used by |ui-multigrid| client),
+                    or 0 to let Nvim decide positioning of windows. For more
+                    information, see |dev-ui-multigrid|
       • {row}       (`integer`) Mouse row-position (zero-based, like redraw
                     events)
       • {col}       (`integer`) Mouse column-position (zero-based, like redraw

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -685,5 +685,23 @@ External UIs are expected to implement these common features:
 - Handle the "restart" UI event so that |:restart| works.
 - Detect capslock and show an indicator if capslock is active.
 
+Multigrid UI ~
+                                                        *dev-ui-multigrid*
+- A multigrid UI should display floating windows using one of the following
+  methods, using the `win_float_pos` |ui-multigrid| event. Different methods
+  can be selected for each window as needed.
+
+  1. Let Nvim determine the position and z-order of the windows. This can be
+  achieved by using the `compindex`, `screen_row`, and `screen_col` information from
+  the `win_float_pos` UI event. To allow Nvim to automatically determine the grid,
+  the UI should call `nvim_input_mouse` with 0 as the `grid` parameter.
+  2. Use the `anchor`, `anchor_grid`, `anchor_row`, `anchor_col`, and `zindex` as
+  references for positioning the windows. If windows are outside the screen,
+  it is the UI's responsibility to reposition and/or resize them. Since Nvim
+  lacks information about actual window placement in this case, the UI must
+  call `nvim_input_mouse` with the actual grid id, factoring in `mouse_enabled`.
+  Note: Some API functions may return unexpected results for these windows due
+  to the missing information.
+- For external windows, the grid id should also be passed to `nvim_input_mouse`.
 
  vim:tw=78:ts=8:sw=4:et:ft=help:norl:

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -338,6 +338,7 @@ UI
   • "Error executing Lua:" changed to "Lua:".
 • 'busy' status is shown in default statusline with symbol ◐
 • Improved LSP signature help rendering.
+• Multigrid UIs can call nvim_input_mouse with grid 0 to let Nvim decide the grid.
 
 VIMSCRIPT
 

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1606,7 +1606,8 @@ function vim.api.nvim_input(keys) end
 --- The same specifiers are used as for a key press, except
 --- that the "-" separator is optional, so "C-A-", "c-a"
 --- and "CA" can all be used to specify Ctrl+Alt+click.
---- @param grid integer Grid number if the client uses `ui-multigrid`, else 0.
+--- @param grid integer Grid number (used by `ui-multigrid` client), or 0 to let Nvim decide positioning of
+--- windows. For more information, see [dev-ui-multigrid]
 --- @param row integer Mouse row-position (zero-based, like redraw events)
 --- @param col integer Mouse column-position (zero-based, like redraw events)
 function vim.api.nvim_input_mouse(button, action, modifier, grid, row, col) end

--- a/src/gen/c_grammar.lua
+++ b/src/gen/c_grammar.lua
@@ -198,6 +198,7 @@ local fattr = (
   + attr('FUNC_API_TEXTLOCK', 'textlock')
   + attr('FUNC_API_REMOTE_IMPL', 'remote_impl')
   + attr('FUNC_API_COMPOSITOR_IMPL', 'compositor_impl')
+  + attr('FUNC_API_MULTIGRID_IMPL', 'multigrid_impl')
   + attr('FUNC_API_CLIENT_IMPL', 'client_impl')
   + attr('FUNC_API_CLIENT_IGNORE', 'client_ignore')
   + (P('FUNC_') * rep(alpha) * opt(fill * paren(rep(1 - P(')') * any))))

--- a/src/gen/gen_api_ui_events.lua
+++ b/src/gen/gen_api_ui_events.lua
@@ -145,6 +145,10 @@ for i = 1, #events do
       call_output:write('  UI_CALL')
       write_signature(call_output, ev, '!ui->composed, ' .. ev.name .. ', ui', true)
       call_output:write(';\n')
+    elseif ev.multigrid_impl then
+      call_output:write('  UI_CALL')
+      write_signature(call_output, ev, '!ui->composed, ' .. ev.name .. ', ui', true)
+      call_output:write(';\n')
     else
       call_output:write('  UI_CALL')
       write_signature(call_output, ev, 'true, ' .. ev.name .. ', ui', true)
@@ -163,14 +167,25 @@ for i = 1, #events do
     call_output:write('}\n\n')
   end
 
-  if (not ev.remote_only) and not ev.noexport and not ev.client_impl and not ev.client_ignore then
+  if
+    not ev.remote_only
+    and not ev.noexport
+    and not ev.client_impl
+    and not ev.client_ignore
+    and not ev.multigrid_impl
+  then
     call_ui_event_method(client_output, ev)
   end
 end
 
 local client_events = {}
 for _, ev in ipairs(events) do
-  if (not ev.noexport) and ((not ev.remote_only) or ev.client_impl) and not ev.client_ignore then
+  if
+    not ev.noexport
+    and ((not ev.remote_only) or ev.client_impl)
+    and not ev.client_ignore
+    and not ev.multigrid_impl
+  then
     client_events[ev.name] = ev
   end
 end

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -93,7 +93,7 @@ void grid_scroll(Integer grid, Integer top, Integer bot, Integer left, Integer r
                  Integer cols)
   FUNC_API_SINCE(5) FUNC_API_REMOTE_IMPL FUNC_API_COMPOSITOR_IMPL;
 void grid_destroy(Integer grid)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_MULTIGRID_IMPL;
 
 // For performance and simplicity, we use the dense screen representation
 // in internal code, such as compositor and TUI. The remote_ui module will
@@ -104,17 +104,17 @@ void raw_line(Integer grid, Integer row, Integer startcol, Integer endcol, Integ
 
 void win_pos(Integer grid, Window win, Integer startrow, Integer startcol, Integer width,
              Integer height)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_MULTIGRID_IMPL;
 void win_float_pos(Integer grid, Window win, String anchor, Integer anchor_grid, Float anchor_row,
                    Float anchor_col, Boolean mouse_enabled, Integer zindex, Integer compindex,
                    Integer screen_row, Integer screen_col)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_MULTIGRID_IMPL;
 void win_external_pos(Integer grid, Window win)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_MULTIGRID_IMPL;
 void win_hide(Integer grid)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_MULTIGRID_IMPL;
 void win_close(Integer grid)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_MULTIGRID_IMPL;
 
 void msg_set_pos(Integer grid, Integer row, Boolean scrolled, String sep_char, Integer zindex,
                  Integer compindex)
@@ -126,7 +126,7 @@ void win_viewport(Integer grid, Window win, Integer topline, Integer botline, In
 
 void win_viewport_margins(Integer grid, Window win, Integer top, Integer bottom, Integer left,
                           Integer right)
-  FUNC_API_SINCE(12) FUNC_API_CLIENT_IGNORE;
+  FUNC_API_SINCE(12) FUNC_API_MULTIGRID_IMPL;
 
 void win_extmark(Integer grid, Window win, Integer ns_id, Integer mark_id, Integer row, Integer col)
   FUNC_API_SINCE(10) FUNC_API_REMOTE_ONLY;

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -382,7 +382,8 @@ Integer nvim_input(uint64_t channel_id, String keys)
 ///                 The same specifiers are used as for a key press, except
 ///                 that the "-" separator is optional, so "C-A-", "c-a"
 ///                 and "CA" can all be used to specify Ctrl+Alt+click.
-/// @param grid Grid number if the client uses |ui-multigrid|, else 0.
+/// @param grid Grid number (used by |ui-multigrid| client), or 0 to let Nvim decide positioning of
+///             windows. For more information, see [dev-ui-multigrid]
 /// @param row Mouse row-position (zero-based, like redraw events)
 /// @param col Mouse column-position (zero-based, like redraw events)
 /// @param[out] err Error details, if any

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2013,7 +2013,7 @@ static void getchar_common(typval_T *argvars, typval_T *rettv, bool allow_number
         int winnr = 1;
         // Find the window at the mouse coordinates and compute the
         // text position.
-        win_T *const win = mouse_find_win(&grid, &row, &col);
+        win_T *const win = mouse_find_win_inner(&grid, &row, &col);
         if (win == NULL) {
           return;
         }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -170,6 +170,7 @@ static void ui_ext_msg_set_pos(int row, bool scrolled)
   ui_call_msg_set_pos(msg_grid.handle, row, scrolled,
                       (String){ .data = buf, .size = size }, msg_grid.zindex,
                       (int)msg_grid.comp_index);
+  ui_comp_put_grid(&msg_grid, row, 0, msg_grid.rows, msg_grid.cols, true, true);
   msg_grid.pending_comp_index_update = false;
 }
 
@@ -2636,7 +2637,7 @@ void msg_ui_refresh(void)
 
 void msg_ui_flush(void)
 {
-  if (ui_has(kUIMultigrid) && msg_grid.chars && msg_grid.pending_comp_index_update) {
+  if (msg_grid.chars && msg_grid.pending_comp_index_update) {
     ui_ext_msg_set_pos(msg_grid_pos, msg_scrolled);
   }
 }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2628,7 +2628,7 @@ void msg_reset_scroll(void)
 
 void msg_ui_refresh(void)
 {
-  if (ui_has(kUIMultigrid) && msg_grid.chars) {
+  if (msg_grid.chars) {
     ui_call_grid_resize(msg_grid.handle, msg_grid.cols, msg_grid.rows);
     ui_ext_msg_set_pos(msg_grid_pos, msg_scrolled);
   }

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -235,7 +235,7 @@ static int get_fpos_of_mouse(pos_T *mpos)
   }
 
   // find the window where the row is in
-  win_T *wp = mouse_find_win(&grid, &row, &col);
+  win_T *wp = mouse_find_win_inner(&grid, &row, &col);
   if (wp == NULL) {
     return IN_UNKNOWN;
   }
@@ -663,7 +663,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, int count, bool fixindent)
     int click_grid = mouse_grid;
     int click_row = mouse_row;
     int click_col = mouse_col;
-    win_T *wp = mouse_find_win(&click_grid, &click_row, &click_col);
+    win_T *wp = mouse_find_win_inner(&click_grid, &click_row, &click_col);
     if (wp == NULL) {
       return false;
     }
@@ -1093,7 +1093,7 @@ void ins_mousescroll(int dir)
     int grid = mouse_grid;
     int row = mouse_row;
     int col = mouse_col;
-    curwin = mouse_find_win(&grid, &row, &col);
+    curwin = mouse_find_win_inner(&grid, &row, &col);
     if (curwin == NULL) {
       curwin = old_curwin;
       return;
@@ -1263,8 +1263,8 @@ retnomove:
   }
 
   // find the window where the row is in and adjust "row" and "col" to be
-  // relative to top-left of the window
-  win_T *wp = mouse_find_win(&grid, &row, &col);
+  // relative to top-left of the window inner area
+  win_T *wp = mouse_find_win_inner(&grid, &row, &col);
   if (wp == NULL) {
     return IN_UNKNOWN;
   }
@@ -1581,7 +1581,7 @@ void nv_mousescroll(cmdarg_T *cap)
     int grid = mouse_grid;
     int row = mouse_row;
     int col = mouse_col;
-    curwin = mouse_find_win(&grid, &row, &col);
+    curwin = mouse_find_win_inner(&grid, &row, &col);
     if (curwin == NULL) {
       curwin = old_curwin;
       return;
@@ -1695,10 +1695,10 @@ bool mouse_comp_pos(win_T *win, int *rowp, int *colp, linenr_T *lnump)
 }
 
 /// Find the window at "grid" position "*rowp" and "*colp".  The positions are
-/// updated to become relative to the top-left of the window.
+/// updated to become relative to the top-left inner area of the window.
 ///
 /// @return NULL when something is wrong.
-win_T *mouse_find_win(int *gridp, int *rowp, int *colp)
+win_T *mouse_find_win_inner(int *gridp, int *rowp, int *colp)
 {
   win_T *wp_grid = mouse_find_grid_win(gridp, rowp, colp);
   if (wp_grid) {
@@ -1740,6 +1740,20 @@ win_T *mouse_find_win(int *gridp, int *rowp, int *colp)
   return NULL;
 }
 
+/// Find the window at "grid" position "*rowp" and "*colp".  The positions are
+/// updated to become relative to the top-left of the window.
+///
+/// @return NULL when something is wrong.
+win_T *mouse_find_win_outer(int *gridp, int *rowp, int *colp)
+{
+  win_T *wp = mouse_find_win_inner(gridp, rowp, colp);
+  if (wp) {
+    *rowp += wp->w_winrow_off;
+    *colp += wp->w_wincol_off;
+  }
+  return wp;
+}
+
 static win_T *mouse_find_grid_win(int *gridp, int *rowp, int *colp)
 {
   if (*gridp == msg_grid.handle) {
@@ -1755,18 +1769,26 @@ static win_T *mouse_find_grid_win(int *gridp, int *rowp, int *colp)
     }
   } else if (*gridp == 0) {
     ScreenGrid *grid = ui_comp_mouse_focus(*rowp, *colp);
-    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-      if (&wp->w_grid_alloc != grid) {
-        continue;
-      }
+    if (grid == &pum_grid) {
       *gridp = grid->handle;
-      *rowp -= grid->comp_row + wp->w_grid.row_offset;
-      *colp -= grid->comp_col + wp->w_grid.col_offset;
-      return wp;
+      *rowp -= grid->comp_row;
+      *colp -= grid->comp_col;
+      // The popup menu doesn't have a window, so return NULL
+      return NULL;
+    } else {
+      FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+        if (&wp->w_grid_alloc != grid) {
+          continue;
+        }
+        *gridp = grid->handle;
+        *rowp -= wp->w_winrow + wp->w_grid.row_offset;
+        *colp -= wp->w_wincol + wp->w_grid.col_offset;
+        return wp;
+      }
     }
 
-    // no float found, click on the default grid
-    // TODO(bfredl): grid can be &pum_grid, allow select pum items by mouse?
+    // No grid found, return the default grid. With multigrid this happens for split separators for
+    // example.
     *gridp = DEFAULT_GRID_HANDLE;
   }
   return NULL;
@@ -1877,7 +1899,7 @@ static void mouse_check_grid(colnr_T *vcolp, int *flagsp)
   int click_col = mouse_col;
 
   // XXX: this doesn't change click_grid if it is 1, even with multigrid
-  if (mouse_find_win(&click_grid, &click_row, &click_col) != curwin
+  if (mouse_find_win_inner(&click_grid, &click_row, &click_col) != curwin
       // Only use vcols[] after the window was redrawn.  Mainly matters
       // for tests, a user would not click before redrawing.
       || curwin->w_redr_type != 0) {
@@ -1931,7 +1953,7 @@ void f_getmousepos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   tv_dict_add_nr(d, S_LEN("screenrow"), (varnumber_T)mouse_row + 1);
   tv_dict_add_nr(d, S_LEN("screencol"), (varnumber_T)mouse_col + 1);
 
-  win_T *wp = mouse_find_win(&grid, &row, &col);
+  win_T *wp = mouse_find_win_inner(&grid, &row, &col);
   if (wp != NULL) {
     int height = wp->w_height + wp->w_hsep_height + wp->w_status_height;
     // The height is adjusted by 1 when there is a bottom border. This is not

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -1323,7 +1323,7 @@ static void pum_position_at_mouse(int min_width)
   pum_win_row_offset = 0;
   pum_win_col_offset = 0;
 
-  if (ui_has(kUIMultigrid) && grid == 0) {
+  if (grid == 0) {
     mouse_find_win_outer(&grid, &row, &col);
   }
   if (grid > 1) {
@@ -1564,13 +1564,7 @@ void pum_make_popup(const char *path_name, int use_mouse_pos)
     mouse_col = curwin->w_grid.col_offset
                 + (curwin->w_p_rl ? curwin->w_view_width - curwin->w_wcol - 1
                                   : curwin->w_wcol);
-    if (ui_has(kUIMultigrid)) {
-      mouse_grid = curwin->w_grid.target->handle;
-    } else if (curwin->w_grid.target != &default_grid) {
-      mouse_grid = 0;
-      mouse_row += curwin->w_winrow;
-      mouse_col += curwin->w_wincol;
-    }
+    mouse_grid = curwin->w_grid.target->handle;
   }
 
   vimmenu_T *menu = menu_find(path_name);

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -626,14 +626,12 @@ void pum_redraw(void)
   } else if (invalid_grid) {
     grid_invalidate(&pum_grid);
   }
-  if (ui_has(kUIMultigrid)) {
-    const char *anchor = pum_above ? "SW" : "NW";
-    int row_off = pum_above ? -pum_height : 0;
-    ui_call_win_float_pos(pum_grid.handle, -1, cstr_as_string(anchor), pum_anchor_grid,
-                          pum_row - row_off - pum_win_row_offset, pum_left_col - pum_win_col_offset,
-                          false, pum_grid.zindex, (int)pum_grid.comp_index, pum_grid.comp_row,
-                          pum_grid.comp_col);
-  }
+  const char *anchor = pum_above ? "SW" : "NW";
+  int row_off = pum_above ? -pum_height : 0;
+  ui_call_win_float_pos(pum_grid.handle, -1, cstr_as_string(anchor), pum_anchor_grid,
+                        pum_row - row_off - pum_win_row_offset, pum_left_col - pum_win_col_offset,
+                        false, pum_grid.zindex, (int)pum_grid.comp_index, pum_grid.comp_row,
+                        pum_grid.comp_col);
 
   int scroll_range = pum_size - pum_height;
   // Never display more than we have
@@ -1221,10 +1219,8 @@ void pum_check_clear(void)
       ui_call_popupmenu_hide();
     } else {
       ui_comp_remove_grid(&pum_grid);
-      if (ui_has(kUIMultigrid)) {
-        ui_call_win_close(pum_grid.handle);
-        ui_call_grid_destroy(pum_grid.handle);
-      }
+      ui_call_win_close(pum_grid.handle);
+      ui_call_grid_destroy(pum_grid.handle);
       // TODO(bfredl): consider keeping float grids allocated.
       grid_free(&pum_grid);
     }
@@ -1585,7 +1581,7 @@ void pum_make_popup(const char *path_name, int use_mouse_pos)
 
 void pum_ui_flush(void)
 {
-  if (ui_has(kUIMultigrid) && pum_is_drawn && !pum_external && pum_grid.handle != 0
+  if (pum_is_drawn && !pum_external && pum_grid.handle != 0
       && pum_grid.pending_comp_index_update) {
     const char *anchor = pum_above ? "SW" : "NW";
     int row_off = pum_above ? -pum_height : 0;

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -1907,7 +1907,7 @@ static bool send_mouse_event(Terminal *term, int c)
   int row = mouse_row;
   int col = mouse_col;
   int grid = mouse_grid;
-  win_T *mouse_win = mouse_find_win(&grid, &row, &col);
+  win_T *mouse_win = mouse_find_win_inner(&grid, &row, &col);
   if (mouse_win == NULL) {
     goto end;
   }

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -318,6 +318,15 @@ ScreenGrid *ui_comp_mouse_focus(int row, int col)
       return grid;
     }
   }
+  if (ui_has(kUIMultigrid)) {
+    FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
+      ScreenGrid *grid = &wp->w_grid_alloc;
+      if (grid->mouse_enabled && row >= wp->w_winrow && row < wp->w_winrow + grid->rows
+          && col >= wp->w_wincol && col < wp->w_wincol + grid->cols) {
+        return grid;
+      }
+    }
+  }
   return NULL;
 }
 

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -29,6 +29,7 @@
 #include "nvim/types_defs.h"
 #include "nvim/ui.h"
 #include "nvim/ui_compositor.h"
+#include "nvim/ui_defs.h"
 
 #include "ui_compositor.c.generated.h"
 
@@ -38,6 +39,8 @@ kvec_t(ScreenGrid *) layers = KV_INITIAL_VALUE;
 static size_t bufsize = 0;
 static schar_T *linebuf;
 static sattr_T *attrbuf;
+static schar_T *bg_linebuf;
+static sattr_T *bg_attrbuf;
 
 #ifndef NDEBUG
 static int chk_width = 0, chk_height = 0;
@@ -66,6 +69,8 @@ void ui_comp_free_all_mem(void)
   kv_destroy(layers);
   xfree(linebuf);
   xfree(attrbuf);
+  XFREE_CLEAR(bg_linebuf);
+  XFREE_CLEAR(bg_attrbuf);
 }
 #endif
 
@@ -89,6 +94,8 @@ void ui_comp_detach(RemoteUI *ui)
   if (composed_uis == 0) {
     XFREE_CLEAR(linebuf);
     XFREE_CLEAR(attrbuf);
+    XFREE_CLEAR(bg_linebuf);
+    XFREE_CLEAR(bg_attrbuf);
     bufsize = 0;
   }
   ui->composed = false;
@@ -96,7 +103,7 @@ void ui_comp_detach(RemoteUI *ui)
 
 bool ui_comp_should_draw(void)
 {
-  return composed_uis != 0 && valid_screen;
+  return composed_uis != 0 && valid_screen && linebuf;
 }
 
 /// Raises or lowers the layer, syncing comp_index with zindex.
@@ -141,31 +148,33 @@ bool ui_comp_put_grid(ScreenGrid *grid, int row, int col, int height, int width,
                       bool on_top)
 {
   bool moved;
-  grid->pending_comp_index_update = true;
 
-  grid->comp_height = height;
-  grid->comp_width = width;
   if (grid->comp_index != 0) {
-    moved = (row != grid->comp_row) || (col != grid->comp_col);
+    moved = row != grid->comp_row || col != grid->comp_col || height != grid->comp_height
+            || width != grid->comp_width;
     if (ui_comp_should_draw()) {
       // Redraw the area covered by the old position, and is not covered
       // by the new position. Disable the grid so that compose_area() will not
       // use it.
       grid->comp_disabled = true;
+      // Top
       compose_area(grid->comp_row, row,
-                   grid->comp_col, grid->comp_col + grid->cols);
+                   grid->comp_col, grid->comp_col + grid->comp_width);
+      // Left
       if (grid->comp_col < col) {
-        compose_area(MAX(row, grid->comp_row),
-                     MIN(row + height, grid->comp_row + grid->rows),
+        compose_area(grid->comp_row,
+                     grid->comp_row + grid->comp_height,
                      grid->comp_col, col);
       }
-      if (col + width < grid->comp_col + grid->cols) {
-        compose_area(MAX(row, grid->comp_row),
-                     MIN(row + height, grid->comp_row + grid->rows),
-                     col + width, grid->comp_col + grid->cols);
+      // Right
+      if (col + width < grid->comp_col + grid->comp_width) {
+        compose_area(grid->comp_row,
+                     grid->comp_row + grid->comp_height,
+                     col + width, grid->comp_col + grid->comp_width);
       }
-      compose_area(row + height, grid->comp_row + grid->rows,
-                   grid->comp_col, grid->comp_col + grid->cols);
+      // Bottom
+      compose_area(row + height, grid->comp_row + grid->comp_height,
+                   grid->comp_col, grid->comp_col + grid->comp_width);
       grid->comp_disabled = false;
     }
     grid->comp_row = row;
@@ -174,6 +183,9 @@ bool ui_comp_put_grid(ScreenGrid *grid, int row, int col, int height, int width,
     moved = true;
 #ifndef NDEBUG
     for (size_t i = 0; i < kv_size(layers); i++) {
+      if (kv_A(layers, i)->comp_index != i) {
+        abort();
+      }
       if (kv_A(layers, i) == grid) {
         abort();
       }
@@ -199,11 +211,13 @@ bool ui_comp_put_grid(ScreenGrid *grid, int row, int col, int height, int width,
     }
     kv_A(layers, insert_at) = grid;
 
-    grid->comp_row = row;
-    grid->comp_col = col;
     grid->comp_index = insert_at;
     grid->pending_comp_index_update = true;
   }
+  grid->comp_row = row;
+  grid->comp_col = col;
+  grid->comp_height = height;
+  grid->comp_width = width;
   if (moved && valid && ui_comp_should_draw()) {
     compose_area(grid->comp_row, grid->comp_row + grid->rows,
                  grid->comp_col, grid->comp_col + grid->cols);
@@ -352,38 +366,32 @@ ScreenGrid *ui_comp_get_grid_at_coord(int row, int col)
   return &default_grid;
 }
 
-/// Baseline implementation. This is always correct, but we can sometimes
-/// do something more efficient (where efficiency means smaller deltas to
-/// the downstream UI.)
-static void compose_line(Integer row, Integer startcol, Integer endcol, LineFlags flags)
+static void compose_bg_or_fg_line(int row, int startcol, int endcol, int skipstart, int skipend,
+                                  LineFlags flags, bool is_bg)
 {
-  // If rightleft is set, startcol may be -1. In such cases, the assertions
-  // will fail because no overlap is found. Adjust startcol to prevent it.
-  startcol = MAX(startcol, 0);
-  // in case we start on the right half of a double-width char, we need to
-  // check the left half. But skip it in output if it wasn't doublewidth.
-  int skipstart = 0;
-  int skipend = 0;
-  if (startcol > 0 && (flags & kLineFlagInvalid)) {
-    startcol--;
-    skipstart = 1;
-  }
-  if (endcol < default_grid.cols && (flags & kLineFlagInvalid)) {
-    endcol++;
-    skipend = 1;
-  }
-
-  int col = (int)startcol;
-  ScreenGrid *grid = NULL;
   schar_T *bg_line = &default_grid.chars[default_grid.line_offset[row]
                                          + (size_t)startcol];
   sattr_T *bg_attrs = &default_grid.attrs[default_grid.line_offset[row]
                                           + (size_t)startcol];
+  schar_T *dest_line = linebuf;
+  sattr_T *dest_attrs = attrbuf;
+  if (is_bg) {
+    dest_line = bg_linebuf;
+    dest_attrs = bg_attrbuf;
+  } else {
+    bg_line = bg_linebuf;
+    bg_attrs = bg_attrbuf;
+  }
 
+  ScreenGrid *grid = NULL;
+  int col = startcol;
   while (col < endcol) {
     int until = 0;
     for (size_t i = 0; i < kv_size(layers); i++) {
       ScreenGrid *g = kv_A(layers, i);
+      if (is_bg && g->zindex > 0) {
+        break;
+      }
       // compose_line may have been called after a shrinking operation but
       // before the resize has actually been applied. Therefore, we need to
       // first check to see if any grids have pending updates to width/height,
@@ -409,23 +417,23 @@ static void compose_line(Integer row, Integer startcol, Integer endcol, LineFlag
     assert(until <= default_grid.cols);
     size_t n = (size_t)(until - col);
 
-    if (row == msg_sep_row && grid->comp_index <= msg_grid.comp_index) {
+    if (!is_bg && row == msg_sep_row && grid->comp_index <= msg_grid.comp_index) {
       // TODO(bfredl): when we implement borders around floating windows, then
       // msgsep can just be a border "around" the message grid.
       grid = &msg_grid;
       sattr_T msg_sep_attr = (sattr_T)HL_ATTR(HLF_MSGSEP);
       for (int i = col; i < until; i++) {
-        linebuf[i - startcol] = msg_sep_char;
-        attrbuf[i - startcol] = msg_sep_attr;
+        dest_line[i - startcol] = msg_sep_char;
+        dest_attrs[i - startcol] = msg_sep_attr;
       }
     } else {
       size_t off = grid->line_offset[row - grid->comp_row]
                    + (size_t)(col - grid->comp_col);
-      memcpy(linebuf + (col - startcol), grid->chars + off, n * sizeof(*linebuf));
-      memcpy(attrbuf + (col - startcol), grid->attrs + off, n * sizeof(*attrbuf));
+      memcpy(dest_line + (col - startcol), grid->chars + off, n * sizeof(*linebuf));
+      memcpy(dest_attrs + (col - startcol), grid->attrs + off, n * sizeof(*attrbuf));
       if (grid->comp_col + grid->cols > until
           && grid->chars[off + n] == NUL) {
-        linebuf[until - 1 - startcol] = schar_from_ascii(' ');
+        dest_line[until - 1 - startcol] = schar_from_ascii(' ');
         if (col == startcol && n == 1) {
           skipstart = 0;
         }
@@ -438,38 +446,40 @@ static void compose_line(Integer row, Integer startcol, Integer endcol, LineFlag
       for (int i = col - (int)startcol; i < until - startcol; i += width) {
         width = 1;
         // negative space
-        bool thru = (linebuf[i] == schar_from_ascii(' ')
+        bool thru = (dest_line[i] == schar_from_ascii(' ')
                      || linebuf[i] == schar_from_char(L'\u2800')) && bg_line[i] != NUL;
         if (i + 1 < endcol - startcol && bg_line[i + 1] == NUL) {
           width = 2;
-          thru &= (linebuf[i + 1] == schar_from_ascii(' ')
+          thru &= (dest_line[i + 1] == schar_from_ascii(' ')
                    || linebuf[i + 1] == schar_from_char(L'\u2800'));
         }
-        attrbuf[i] = (sattr_T)hl_blend_attrs(bg_attrs[i], attrbuf[i], &thru);
+        dest_attrs[i] = (sattr_T)hl_blend_attrs(bg_attrs[i], dest_attrs[i], &thru);
         if (width == 2) {
-          attrbuf[i + 1] = (sattr_T)hl_blend_attrs(bg_attrs[i + 1],
-                                                   attrbuf[i + 1], &thru);
+          dest_attrs[i + 1] = (sattr_T)hl_blend_attrs(bg_attrs[i + 1],
+                                                      dest_attrs[i + 1], &thru);
         }
         if (thru) {
-          memcpy(linebuf + i, bg_line + i, (size_t)width * sizeof(linebuf[i]));
+          memcpy(dest_line + i, bg_line + i, (size_t)width * sizeof(dest_line[i]));
         }
       }
     }
 
     // Tricky: if overlap caused a doublewidth char to get cut-off, must
     // replace the visible half with a space.
-    if (linebuf[col - startcol] == NUL) {
-      linebuf[col - startcol] = schar_from_ascii(' ');
+    if (dest_line[col - startcol] == NUL) {
+      if (!is_bg) {
+        dest_line[col - startcol] = schar_from_ascii(' ');
+      }
       if (col == endcol - 1) {
         skipend = 0;
       }
-    } else if (col == startcol && n > 1 && linebuf[1] == NUL) {
+    } else if (col == startcol && n > 1 && dest_line[1] == NUL) {
       skipstart = 0;
     }
 
     col = until;
   }
-  if (linebuf[endcol - startcol - 1] == NUL) {
+  if (dest_line[endcol - startcol - 1] == NUL) {
     skipend = 0;
   }
 
@@ -480,19 +490,47 @@ static void compose_line(Integer row, Integer startcol, Integer endcol, LineFlag
     flags = flags & ~kLineFlagWrap;
   }
 
-  for (int i = skipstart; i < (endcol - skipend) - startcol; i++) {
-    if (attrbuf[i] < 0) {
-      if (rdb_flags & kOptRdbFlagInvalid) {
-        abort();
-      } else {
-        attrbuf[i] = 0;
+  if (!is_bg) {
+    for (int i = skipstart; i < (endcol - skipend) - startcol; i++) {
+      if (dest_attrs[i] < 0) {
+        dest_attrs[i] = 0;
+        if (rdb_flags & kOptRdbFlagInvalid) {
+          // abort();
+        } else {}
       }
     }
+    ui_composed_call_raw_line(1, row, startcol + skipstart,
+                              endcol - skipend, endcol - skipend, 0, flags,
+                              (const schar_T *)linebuf + skipstart,
+                              (const sattr_T *)attrbuf + skipstart);
   }
-  ui_composed_call_raw_line(1, row, startcol + skipstart,
-                            endcol - skipend, endcol - skipend, 0, flags,
-                            (const schar_T *)linebuf + skipstart,
-                            (const sattr_T *)attrbuf + skipstart);
+}
+
+/// Baseline implementation. This is always correct, but we can sometimes
+/// do something more efficient (where efficiency means smaller deltas to
+/// the downstream UI.)
+static void compose_line(Integer row, Integer startcol, Integer endcol, LineFlags flags)
+{
+  // If rightleft is set, startcol may be -1. In such cases, the assertions
+  // will fail because no overlap is found. Adjust startcol to prevent it.
+  startcol = MAX(startcol, 0);
+  // in case we start on the right half of a double-width char, we need to
+  // check the left half. But skip it in output if it wasn't doublewidth.
+  int skipstart = 0;
+  int skipend = 0;
+  if (startcol > 0 && (flags & kLineFlagInvalid)) {
+    startcol--;
+    skipstart = 1;
+  }
+  if (endcol < default_grid.cols && (flags & kLineFlagInvalid)) {
+    endcol++;
+    skipend = 1;
+  }
+
+  // Compose the bg (all grids with zindex = 0) first
+  compose_bg_or_fg_line(row, startcol, endcol, skipstart, skipend, flags, true);
+  // Then the fg
+  compose_bg_or_fg_line(row, startcol, endcol, skipstart, skipend, flags, false);
 }
 
 static void compose_debug(Integer startrow, Integer endrow, Integer startcol, Integer endcol,
@@ -716,6 +754,10 @@ void ui_comp_grid_resize(Integer grid, Integer width, Integer height)
       xfree(attrbuf);
       linebuf = xmalloc(new_bufsize * sizeof(*linebuf));
       attrbuf = xmalloc(new_bufsize * sizeof(*attrbuf));
+      xfree(bg_linebuf);
+      xfree(bg_attrbuf);
+      bg_linebuf = xmalloc(new_bufsize * sizeof(*linebuf));
+      bg_attrbuf = xmalloc(new_bufsize * sizeof(*attrbuf));
       bufsize = new_bufsize;
     }
   }

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2825,8 +2825,6 @@ static void do_intro_line(int row, char *mesg, bool colon)
     col = 0;
   }
 
-  grid_line_start((!colon && ui_has(kUIMultigrid)) ? &firstwin->w_grid : &default_gridview, row);
-
   // Split up in parts to highlight <> items differently.
   for (char *p = mesg; *p != NUL; p += l) {
     for (l = 0;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -899,14 +899,12 @@ void ui_ext_win_position(win_T *wp, bool validate)
     if (!c.hide) {
       ui_comp_put_grid(&wp->w_grid_alloc, comp_row, comp_col,
                        wp->w_height_outer, wp->w_width_outer, valid, false);
-      if (ui_has(kUIMultigrid)) {
-        String anchor = cstr_as_string(float_anchor_str[c.anchor]);
-        ui_call_win_float_pos(wp->w_grid_alloc.handle, wp->handle, anchor,
-                              grid->handle, row, col, c.mouse,
-                              wp->w_grid_alloc.zindex, (int)wp->w_grid_alloc.comp_index,
-                              wp->w_winrow,
-                              wp->w_wincol);
-      }
+      String anchor = cstr_as_string(float_anchor_str[c.anchor]);
+      ui_call_win_float_pos(wp->w_grid_alloc.handle, wp->handle, anchor,
+                            grid->handle, row, col, c.mouse,
+                            wp->w_grid_alloc.zindex, (int)wp->w_grid_alloc.comp_index,
+                            wp->w_winrow,
+                            wp->w_wincol);
       ui_check_cursor_grid(wp->w_grid_alloc.handle);
       wp->w_grid_alloc.mouse_enabled = wp->w_config.mouse;
       if (!valid) {
@@ -914,9 +912,7 @@ void ui_ext_win_position(win_T *wp, bool validate)
         redraw_later(wp, UPD_NOT_VALID);
       }
     } else {
-      if (ui_has(kUIMultigrid)) {
-        ui_call_win_hide(wp->w_grid_alloc.handle);
-      }
+      ui_call_win_hide(wp->w_grid_alloc.handle);
       ui_comp_remove_grid(&wp->w_grid_alloc);
     }
   } else {
@@ -2836,9 +2832,7 @@ int win_close(win_T *win, bool free_buf, bool force)
   split_disallowed++;
 
   bool was_floating = win->w_floating;
-  if (ui_has(kUIMultigrid)) {
-    ui_call_win_close(win->w_grid_alloc.handle);
-  }
+  ui_call_win_close(win->w_grid_alloc.handle);
 
   if (win->w_floating) {
     ui_comp_remove_grid(&win->w_grid_alloc);
@@ -5364,7 +5358,7 @@ void win_free(win_T *wp, tabpage_T *tp)
 
 void win_free_grid(win_T *wp, bool reinit)
 {
-  if (wp->w_grid_alloc.handle != 0 && ui_has(kUIMultigrid)) {
+  if (wp->w_grid_alloc.handle != 0) {
     ui_call_grid_destroy(wp->w_grid_alloc.handle);
   }
   grid_free(&wp->w_grid_alloc);
@@ -6753,11 +6747,9 @@ void win_set_inner_size(win_T *wp, bool valid_cursor)
   wp->w_winrow_off = wp->w_border_adj[0] + wp->w_winbar_height;
   wp->w_wincol_off = wp->w_border_adj[3];
 
-  if (ui_has(kUIMultigrid)) {
-    ui_call_win_viewport_margins(wp->w_grid_alloc.handle, wp->handle,
-                                 wp->w_winrow_off, wp->w_border_adj[2],
-                                 wp->w_wincol_off, wp->w_border_adj[1]);
-  }
+  ui_call_win_viewport_margins(wp->w_grid_alloc.handle, wp->handle,
+                               wp->w_winrow_off, wp->w_border_adj[2],
+                               wp->w_wincol_off, wp->w_border_adj[1]);
 
   wp->w_redr_status = true;
 }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5187,6 +5187,8 @@ win_T *win_alloc(win_T *after, bool hidden)
   new_wp->handle = ++last_win_id;
   pmap_put(int)(&window_handles, new_wp->handle, new_wp);
 
+  new_wp->w_grid_alloc.mouse_enabled = true;
+
   grid_assign_handle(&new_wp->w_grid_alloc);
 
   // Init w: variables.

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -192,7 +192,7 @@ void win_config_float(win_T *wp, WinConfig fconfig)
     int row = mouse_row;
     int col = mouse_col;
     int grid = mouse_grid;
-    win_T *mouse_win = mouse_find_win(&grid, &row, &col);
+    win_T *mouse_win = mouse_find_win_inner(&grid, &row, &col);
     if (mouse_win != NULL) {
       fconfig.relative = kFloatRelativeWindow;
       fconfig.row += row;

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -218,6 +218,7 @@ void win_config_float(win_T *wp, WinConfig fconfig)
     }
   }
 
+  // Multigrid allows the floating windows to be bigger than the screen
   if (!ui_has(kUIMultigrid)) {
     wp->w_height = MIN(wp->w_height, Rows - win_border_height(wp));
     wp->w_width = MIN(wp->w_width, Columns - win_border_width(wp));

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -5640,8 +5640,8 @@ describe('API', function()
     api.nvim__redraw({ tabline = true })
     screen:expect({
       grid = [[
-        {2:^tabline                                                     }|
-        {5:winbar                        }│{8:statuscolumn}foobar           |
+        {2:tabline                                                     }|
+        {5:^winbar                        }│{8:statuscolumn}foobar           |
         foobaz                        │{1:~                            }|
         {3:statusline3                    }{2:statusline3                  }|
         :echo getchar()                                             |
@@ -5653,8 +5653,8 @@ describe('API', function()
     api.nvim__redraw({ statusline = true, tabline = true })
     screen:expect({
       grid = [[
-        {2:^tabline2                                                    }|
-        {5:winbar                        }│{8:statuscolumn}foobar           |
+        {2:tabline2                                                    }|
+        {5:^winbar                        }│{8:statuscolumn}foobar           |
         foobaz                        │{1:~                            }|
         {3:statusline4                    }{2:statusline4                  }|
         :echo getchar()                                             |
@@ -5668,13 +5668,14 @@ describe('API', function()
     api.nvim__redraw({ statuscolumn = true, statusline = true, tabline = true, winbar = true })
     screen:expect({
       grid = [[
-        {2:^tabline3                                                    }|
-        {5:winbar2                       }│{5:winbar2                      }|
+        {2:tabline3                                                    }|
+        {5:^winbar2                       }│{5:winbar2                      }|
         {8:statuscolumn2}foobaz           │{8:statuscolumn}foobar           |
         {3:statusline5                    }{2:statusline5                  }|
         :echo getchar()                                             |
       ]],
     })
+
     -- Can update status widget for a specific window
     feed('<CR><CR>')
     command('let g:status=0')

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1072,7 +1072,7 @@ describe('completion', function()
       {5:-- Keyword completion (^N^P) }{19:Back at original}               |
     ]],
       popupmenu = {
-        anchor = { 1, 3, 0 },
+        anchor = { 2, 3, 0 },
         items = { { 'foo', '', '', '' }, { 'foobar', '', '', '' } },
         pos = -1,
       },
@@ -1092,7 +1092,7 @@ describe('completion', function()
       {5:-- Keyword completion (^N^P) }{19:Back at original}               |
     ]],
       popupmenu = {
-        anchor = { 1, 3, 0 },
+        anchor = { 2, 3, 0 },
         items = { { 'foobar', '', '', '' } },
         pos = -1,
       },

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -65,7 +65,7 @@ describe('vim.ui_attach', function()
         0,
         0,
         0,
-        1,
+        2,
       },
     }
 

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -971,7 +971,7 @@ describe('float window', function()
     api.nvim_win_set_config(win, api.nvim_win_get_config(win))
   end)
 
-  local function with_ext_multigrid(multigrid)
+  local function with_ext_multigrid(multigrid, send_mouse_grid)
     local screen, attrs
     before_each(function()
       screen = Screen.new(40, 7, { ext_multigrid = multigrid })
@@ -6164,8 +6164,12 @@ describe('float window', function()
       end)
 
       local function test_float_mouse_focus()
-        if multigrid then
+        if send_mouse_grid then
           api.nvim_input_mouse('left', 'press', '', 4, 0, 0)
+        else
+          api.nvim_input_mouse('left', 'press', '', 0, 2, 5)
+        end
+        if multigrid then
           screen:expect {
             grid = [[
           ## grid 1
@@ -6183,7 +6187,6 @@ describe('float window', function()
             float_pos = expected_pos,
           }
         else
-          api.nvim_input_mouse('left', 'press', '', 0, 2, 5)
           screen:expect([[
             x                                       |
             {0:~                                       }|
@@ -6194,8 +6197,12 @@ describe('float window', function()
           ]])
         end
 
-        if multigrid then
+        if send_mouse_grid then
           api.nvim_input_mouse('left', 'press', '', 2, 0, 0)
+        else
+          api.nvim_input_mouse('left', 'press', '', 0, 0, 0)
+        end
+        if multigrid then
           screen:expect {
             grid = [[
           ## grid 1
@@ -6213,7 +6220,6 @@ describe('float window', function()
             float_pos = expected_pos,
           }
         else
-          api.nvim_input_mouse('left', 'press', '', 0, 0, 0)
           screen:expect([[
             ^x                                       |
             {0:~                                       }|
@@ -6237,27 +6243,53 @@ describe('float window', function()
       local function test_float_mouse_no_focus()
         api.nvim_buf_set_lines(0, -1, -1, true, { 'a' })
         expected_pos[4][6] = false
-        if multigrid then
+        if send_mouse_grid then
           api.nvim_input_mouse('left', 'press', '', 4, 0, 0)
-          screen:expect {
-            grid = [[
-          ## grid 1
-            [2:----------------------------------------]|*6
-            [3:----------------------------------------]|
-          ## grid 2
-            ^x                                       |
-            a                                       |
-            {0:~                                       }|*4
-          ## grid 3
-                                                    |
-          ## grid 4
-            {1:y                   }|
-            {2:~                   }|
-          ]],
-            float_pos = expected_pos,
-          }
         else
           api.nvim_input_mouse('left', 'press', '', 0, 2, 5)
+        end
+        if multigrid then
+          if send_mouse_grid then
+            -- Sending input to grid 4 is a user error, you are not supposed to pass a grid
+            -- that isn't focusable. In this case, nothing happens and the input is not passed
+            -- through to grid 4, like normally happens when you pass grid 0.
+            screen:expect {
+              grid = [[
+            ## grid 1
+              [2:----------------------------------------]|*6
+              [3:----------------------------------------]|
+            ## grid 2
+              ^x                                       |
+              a                                       |
+              {0:~                                       }|*4
+            ## grid 3
+                                                      |
+            ## grid 4
+              {1:y                   }|
+              {2:~                   }|
+            ]],
+              float_pos = expected_pos,
+            }
+          else
+            screen:expect {
+              grid = [[
+            ## grid 1
+              [2:----------------------------------------]|*6
+              [3:----------------------------------------]|
+            ## grid 2
+              x                                       |
+              ^a                                       |
+              {0:~                                       }|*4
+            ## grid 3
+                                                      |
+            ## grid 4
+              {1:y                   }|
+              {2:~                   }|
+            ]],
+              float_pos = expected_pos,
+            }
+          end
+        else
           screen:expect([[
             x                                       |
             ^a                                       |
@@ -6268,8 +6300,12 @@ describe('float window', function()
           ]])
         end
 
-        if multigrid then
+        if send_mouse_grid then
           api.nvim_input_mouse('left', 'press', '', 2, 0, 0)
+        else
+          api.nvim_input_mouse('left', 'press', '', 0, 0, 0)
+        end
+        if multigrid then
           screen:expect {
             grid = [[
           ## grid 1
@@ -6289,7 +6325,6 @@ describe('float window', function()
             unchanged = true,
           }
         else
-          api.nvim_input_mouse('left', 'press', '', 0, 0, 0)
           screen:expect([[
             ^x                                       |
             a                                       |
@@ -7959,7 +7994,11 @@ describe('float window', function()
           },
         }
 
-        api.nvim_input_mouse('left', 'press', '', 4, 0, 0)
+        if send_mouse_grid then
+          api.nvim_input_mouse('left', 'press', '', 4, 0, 0)
+        else
+          api.nvim_input_mouse('left', 'press', '', 0, 2, 5)
+        end
         screen:expect {
           grid = [[
         ## grid 1
@@ -7982,7 +8021,11 @@ describe('float window', function()
           },
         }
 
-        api.nvim_input_mouse('left', 'drag', '', 4, 1, 2)
+        if send_mouse_grid then
+          api.nvim_input_mouse('left', 'drag', '', 4, 1, 2)
+        else
+          api.nvim_input_mouse('left', 'drag', '', 0, 3, 7)
+        end
         screen:expect {
           grid = [[
         ## grid 1
@@ -8074,7 +8117,11 @@ describe('float window', function()
           },
         }
 
-        api.nvim_input_mouse('left', 'press', '', 4, 1, 1)
+        if send_mouse_grid then
+          api.nvim_input_mouse('left', 'press', '', 4, 1, 1)
+        else
+          api.nvim_input_mouse('left', 'press', '', 0, 1, 6)
+        end
         screen:expect {
           grid = [[
         ## grid 1
@@ -8099,7 +8146,11 @@ describe('float window', function()
           },
         }
 
-        api.nvim_input_mouse('left', 'drag', '', 4, 2, 3)
+        if send_mouse_grid then
+          api.nvim_input_mouse('left', 'drag', '', 4, 2, 3)
+        else
+          api.nvim_input_mouse('left', 'drag', '', 0, 2, 8)
+        end
         screen:expect {
           grid = [[
         ## grid 1
@@ -8193,7 +8244,11 @@ describe('float window', function()
           },
         }
 
-        api.nvim_input_mouse('left', 'press', '', 4, 1, 0)
+        if send_mouse_grid then
+          api.nvim_input_mouse('left', 'press', '', 4, 1, 0)
+        else
+          api.nvim_input_mouse('left', 'press', '', 0, 2, 5)
+        end
         screen:expect {
           grid = [[
         ## grid 1
@@ -8217,7 +8272,11 @@ describe('float window', function()
           },
         }
 
-        api.nvim_input_mouse('left', 'drag', '', 4, 2, 2)
+        if send_mouse_grid then
+          api.nvim_input_mouse('left', 'drag', '', 4, 2, 2)
+        else
+          api.nvim_input_mouse('left', 'drag', '', 0, 3, 7)
+        end
         screen:expect {
           grid = [[
         ## grid 1
@@ -8304,7 +8363,11 @@ describe('float window', function()
           {0:~                   }|*2
         ]])
 
-        api.nvim_input_mouse('left', 'press', '', 4, 2, 2)
+        if send_mouse_grid then
+          api.nvim_input_mouse('left', 'press', '', 4, 2, 2)
+        else
+          api.nvim_input_mouse('left', 'press', '', 0, 2, 22)
+        end
         screen:expect([[
         ## grid 1
           [2:-------------------]{5:│}[4:--------------------]|*5
@@ -8322,7 +8385,11 @@ describe('float window', function()
           {0:~                   }|*2
         ]])
 
-        api.nvim_input_mouse('left', 'drag', '', 4, 1, 1)
+        if send_mouse_grid then
+          api.nvim_input_mouse('left', 'drag', '', 4, 1, 1)
+        else
+          api.nvim_input_mouse('left', 'drag', '', 0, 1, 21)
+        end
         screen:expect([[
         ## grid 1
           [2:-------------------]{5:│}[4:--------------------]|*5
@@ -8409,21 +8476,21 @@ describe('float window', function()
         }
       end
 
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('left', 'press', '', 4, 3, 1)
       else
         api.nvim_input_mouse('left', 'press', '', 0, 3, 6)
       end
       eq({ 0, 3, 1, 0, 1 }, fn.getcurpos())
 
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('left', 'press', '', 4, 3, 2)
       else
         api.nvim_input_mouse('left', 'press', '', 0, 3, 7)
       end
       eq({ 0, 3, 1, 0, 2 }, fn.getcurpos())
 
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('left', 'press', '', 4, 3, 10)
       else
         api.nvim_input_mouse('left', 'press', '', 0, 3, 15)
@@ -8470,8 +8537,12 @@ describe('float window', function()
         }
       end
 
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('left', 'press', '', 4, 2, 1)
+      else
+        api.nvim_input_mouse('left', 'press', '', 0, 2, 6)
+      end
+      if multigrid then
         screen:expect {
           grid = [[
         ## grid 1
@@ -8496,7 +8567,6 @@ describe('float window', function()
           },
         }
       else
-        api.nvim_input_mouse('left', 'press', '', 0, 2, 6)
         screen:expect {
           grid = [[
                {5:┌────────────────────┐}             |
@@ -8510,21 +8580,21 @@ describe('float window', function()
         }
       end
 
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('left', 'press', '', 4, 2, 2)
       else
         api.nvim_input_mouse('left', 'press', '', 0, 2, 7)
       end
       eq({ 0, 2, 1, 0, 1 }, fn.getcurpos())
 
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('left', 'press', '', 4, 2, 3)
       else
         api.nvim_input_mouse('left', 'press', '', 0, 2, 8)
       end
       eq({ 0, 2, 1, 0, 2 }, fn.getcurpos())
 
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('left', 'press', '', 4, 2, 11)
       else
         api.nvim_input_mouse('left', 'press', '', 0, 2, 16)
@@ -8840,8 +8910,12 @@ describe('float window', function()
       end
 
       -- Test scrolling by mouse
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('wheel', 'down', '', 4, 2, 2)
+      else
+        api.nvim_input_mouse('wheel', 'down', '', 0, 4, 7)
+      end
+      if multigrid then
         screen:expect {
           grid = [[
         ## grid 1
@@ -8865,7 +8939,6 @@ describe('float window', function()
           float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
         }
       else
-        api.nvim_input_mouse('wheel', 'down', '', 0, 4, 7)
         screen:expect([[
           Ut enim ad minim veniam, quis nostrud             |
           exercitation ullamco laboris nisi ut aliquip ex   |
@@ -11047,10 +11120,15 @@ describe('float window', function()
     end)
   end
 
-  describe('with ext_multigrid', function()
-    with_ext_multigrid(true)
+  describe('with ext_multigrid and actual mouse grid', function()
+    with_ext_multigrid(true, true)
   end)
+
+  describe('with ext_multigrid and mouse grid 0', function()
+    with_ext_multigrid(true, false)
+  end)
+
   describe('without ext_multigrid', function()
-    with_ext_multigrid(false)
+    with_ext_multigrid(false, false)
   end)
 end)

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -1016,7 +1016,7 @@ describe('float window', function()
     it('can be created and reconfigured', function()
       local buf = api.nvim_create_buf(false, false)
       local win = api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 2, row = 2, col = 5 })
-      local expected_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } }
+      local expected_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } }
 
       if multigrid then
         screen:expect {
@@ -1130,7 +1130,7 @@ describe('float window', function()
           {1:               }|
           {2:~              }|
         ]],
-          float_pos = { [5] = { 1002, 'NW', 4, 2, 10, true, 50, 1, 2, 30 } },
+          float_pos = { [5] = { 1002, 'NW', 4, 2, 10, true, 50, 3, 2, 30 } },
         }
       else
         screen:expect([[
@@ -1165,7 +1165,7 @@ describe('float window', function()
           {1:               }|
           {2:~              }|
         ]],
-          float_pos = { [5] = { 1002, 'NW', 4, 2, 10, true, 50, 1, 2, 25 } },
+          float_pos = { [5] = { 1002, 'NW', 4, 2, 10, true, 50, 3, 2, 25 } },
         }
       else
         screen:expect([[
@@ -1189,7 +1189,7 @@ describe('float window', function()
       command('set wd=1')
       local buf = api.nvim_create_buf(false, false)
       local win = api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 2, row = 2, col = 5 })
-      local expected_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } }
+      local expected_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } }
 
       if multigrid then
         screen:expect {
@@ -1344,7 +1344,7 @@ describe('float window', function()
           {18:  3 }{15:                }|
           {16:~                   }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 2, 2, 10 } },
         }
       else
         screen:expect([[
@@ -1377,7 +1377,7 @@ describe('float window', function()
           {18:  1 }{15:                }|
           {16:~                   }|*3
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 2, 2, 10 } },
         }
       else
         screen:expect([[
@@ -1414,7 +1414,7 @@ describe('float window', function()
             {22:y           }|
             {22:            }|
           ]],
-          float_pos = { [5] = { 1002, 'NW', 2, 3, 3, true, 50, 1, 3, 3 } },
+          float_pos = { [5] = { 1002, 'NW', 2, 3, 3, true, 50, 2, 3, 3 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 4, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
             [5] = { win = 1002, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
@@ -1466,7 +1466,7 @@ describe('float window', function()
           {15:y                   }|
           {15:                    }|*2
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 2, 2, 10 } },
         }
       else
         screen:expect {
@@ -1503,7 +1503,7 @@ describe('float window', function()
           {19:  }{15:                  }|
           {15:                    }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 2, 2, 10 } },
         }
       else
         screen:expect([[
@@ -1536,7 +1536,7 @@ describe('float window', function()
         ## grid 4
           {15:                    }|*4
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 2, 2, 10 } },
         }
       else
         screen:expect([[
@@ -1576,7 +1576,7 @@ describe('float window', function()
           {15:y                   }|
           {15:                    }|*2
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 2, 2, 10 } },
         }
       else
         screen:expect {
@@ -1613,7 +1613,7 @@ describe('float window', function()
           {19:  }{15:                  }|
           {15:                    }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 2, 2, 10 } },
         }
       else
         screen:expect([[
@@ -1646,7 +1646,7 @@ describe('float window', function()
         ## grid 4
           {15:                    }|*4
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 2, 2, 10 } },
         }
       else
         screen:expect([[
@@ -1687,7 +1687,7 @@ describe('float window', function()
             {15:y                   }|
             {15:                    }|*2
           ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 2, 2, 10 } },
         })
       else
         screen:expect([[
@@ -1739,7 +1739,7 @@ describe('float window', function()
           {17:n̈̊}{1: BORDAA  }{17:n̈̊}|
           {5:\}{7:ååååååååå}{5:x}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -1779,7 +1779,7 @@ describe('float window', function()
           {5:<}{1: halloj! }{5:>}|
           {5:<}{1: BORDAA  }{5:>}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -1821,7 +1821,7 @@ describe('float window', function()
           {1: BORDAA  }|
           {5:---------}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -1874,7 +1874,7 @@ describe('float window', function()
           {1: BORDAA  }{26: }|
           {25: }{26:         }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 6, curline = 5, curcol = 0, linecount = 6, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -2004,7 +2004,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -2056,7 +2056,7 @@ describe('float window', function()
             {1:Hello    }|
             {2:~        }|
           ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -2105,7 +2105,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -2143,7 +2143,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -2181,7 +2181,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -2219,7 +2219,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -2258,7 +2258,7 @@ describe('float window', function()
             {5:║}{1: BORDAA  }{5:║}|
             {5:╚═════════╝}|
           ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -2312,7 +2312,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚}{11:Left}{5:═════╝}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -2350,7 +2350,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═}{11:Center}{5:══╝}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -2388,7 +2388,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚════}{11:Right}{5:╝}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -2426,7 +2426,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════}{11:🦄BB}{5:╝}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -2465,7 +2465,7 @@ describe('float window', function()
             {5:║}{1: BORDAA  }{5:║}|
             {5:╚══════}{11:new}{5:╝}|
           ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -2521,7 +2521,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚════}{11:Right}{5:╝}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -2559,7 +2559,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═}{11:Center}{5:══╝}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -2597,7 +2597,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚}{11:Left}{5:═════╝}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -2643,7 +2643,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════}{11:🦄}{7:BB}{5:╝}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -2688,7 +2688,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚}🦄{7:BB}{5:═════╝}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -2767,7 +2767,7 @@ describe('float window', function()
           {5:│}{2:~                                       }{5:│}|*6
           {5:└────────────────────────────────────────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 0, 0, true, 201, 2, 0, 0 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 0, 0, true, 201, 3, 0, 0 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -2814,7 +2814,7 @@ describe('float window', function()
           {5:║}{1:^         }{5:║}|
           {5:╚═════════╝}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 0, 5, true, 50, 2, 0, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 2, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
@@ -2859,8 +2859,8 @@ describe('float window', function()
           {13: acc            }|
         ]],
           float_pos = {
-            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
-            [5] = { -1, 'NW', 4, 4, 0, false, 100, 2, 4, 5 },
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 2, 0, 5 },
+            [5] = { -1, 'NW', 4, 4, 0, false, 100, 3, 4, 5 },
           },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -2903,7 +2903,7 @@ describe('float window', function()
           {5:║}{1:ac^c      }{5:║}|
           {5:╚═════════╝}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 0, 5, true, 50, 2, 0, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 2, curcol = 2, linecount = 3, sum_scroll_delta = 0 },
@@ -2952,8 +2952,8 @@ describe('float window', function()
           {1: baz }|
         ]],
           float_pos = {
-            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
-            [5] = { -1, 'NW', 4, 4, 2, false, 250, 3, 4, 7 },
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 2, 0, 5 },
+            [5] = { -1, 'NW', 4, 4, 2, false, 250, 4, 4, 7 },
           },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -3175,7 +3175,7 @@ describe('float window', function()
           {1:abb acc  }|
           {2:~        }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 0, 5, true, 50, 2, 0, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -3210,7 +3210,7 @@ describe('float window', function()
           {1:abb acc  }|
           {2:~        }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 0, 5, true, 50, 2, 0, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 4, linecount = 2, sum_scroll_delta = 0 },
@@ -3247,7 +3247,7 @@ describe('float window', function()
           {1:^         }|
           {2:~        }|*2
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 0, 5, true, 50, 2, 0, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -3292,8 +3292,8 @@ describe('float window', function()
           {2:~  }|*2
         ]],
           float_pos = {
-            [4] = { 1001, 'NW', 1, 0, 0, true, 50, 1, 0, 0 },
-            [5] = { 1002, 'NW', 1, 0, 5, true, 50, 2, 0, 5 },
+            [4] = { 1001, 'NW', 1, 0, 0, true, 50, 2, 0, 0 },
+            [5] = { 1002, 'NW', 1, 0, 5, true, 50, 3, 0, 5 },
           },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -3331,8 +3331,8 @@ describe('float window', function()
           {2:~  }|*2
         ]],
           float_pos = {
-            [4] = { 1001, 'NW', 1, 0, 0, true, 50, 1, 0, 0 },
-            [5] = { 1002, 'NW', 1, 0, 5, true, 50, 2, 0, 5 },
+            [4] = { 1001, 'NW', 1, 0, 0, true, 50, 2, 0, 0 },
+            [5] = { 1002, 'NW', 1, 0, 5, true, 50, 3, 0, 5 },
           },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -3371,7 +3371,7 @@ describe('float window', function()
         ## grid 4
           {1:x}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 2, 0, 4, false, 50, 1, 0, 4 } },
+          float_pos = { [4] = { 1001, 'NW', 2, 0, 4, false, 50, 2, 0, 4 } },
         }
       else
         screen:expect([[
@@ -3396,7 +3396,7 @@ describe('float window', function()
         ## grid 4
           {1:x}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 2, 0, 15, false, 50, 1, 0, 15 } },
+          float_pos = { [4] = { 1001, 'NW', 2, 0, 15, false, 50, 2, 0, 15 } },
         }
       else
         screen:expect([[
@@ -3478,8 +3478,8 @@ describe('float window', function()
             {0:~                                       }|
           ]],
             float_pos = {
-              [5] = { 1002, 'NW', 1, 6, 0, true, 50, 1, 6, 0 },
-              [6] = { 1003, 'NW', 1, 6, 0, true, 50, 2, 6, 0 },
+              [5] = { 1002, 'NW', 1, 6, 0, true, 50, 6, 6, 0 },
+              [6] = { 1003, 'NW', 1, 6, 0, true, 50, 5, 6, 0 },
             },
             win_viewport = {
               [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -3694,7 +3694,7 @@ describe('float window', function()
           {1:                    }|
           {2:~                   }|
         ]],
-          float_pos = { [5] = { 1002, 'NW', 4, 0, 10, true, 50, 1, 4, 10 } },
+          float_pos = { [5] = { 1002, 'NW', 4, 0, 10, true, 50, 3, 4, 10 } },
         }
       else
         screen:expect([[
@@ -3734,7 +3734,7 @@ describe('float window', function()
           {1:                    }|
           {2:~                   }|
         ]],
-          float_pos = { [5] = { 1002, 'NW', 4, 1, 1, true, 50, 1, 5, 1 } },
+          float_pos = { [5] = { 1002, 'NW', 4, 1, 1, true, 50, 3, 5, 1 } },
         }
       else
         screen:expect([[
@@ -3774,7 +3774,7 @@ describe('float window', function()
           {1:                    }|
           {2:~                   }|
         ]],
-          float_pos = { [5] = { 1002, 'SW', 4, 0, 3, true, 50, 1, 2, 3 } },
+          float_pos = { [5] = { 1002, 'SW', 4, 0, 3, true, 50, 3, 2, 3 } },
         }
       else
         screen:expect([[
@@ -3814,7 +3814,7 @@ describe('float window', function()
           {1:                    }|
           {2:~                   }|
         ]],
-          float_pos = { [5] = { 1002, 'NW', 2, 1, 10, true, 50, 1, 1, 10 } },
+          float_pos = { [5] = { 1002, 'NW', 2, 1, 10, true, 50, 3, 1, 10 } },
         }
       else
         screen:expect([[
@@ -3854,7 +3854,7 @@ describe('float window', function()
           {1:                    }|
           {2:~                   }|
         ]],
-          float_pos = { [5] = { 1002, 'SE', 2, 3, 39, true, 50, 1, 1, 19 } },
+          float_pos = { [5] = { 1002, 'SE', 2, 3, 39, true, 50, 3, 1, 19 } },
         }
       else
         screen:expect([[
@@ -3894,7 +3894,7 @@ describe('float window', function()
           {1:                    }|
           {2:~                   }|
         ]],
-          float_pos = { [5] = { 1002, 'NE', 4, 0, 50, true, 50, 1, 4, 20 } },
+          float_pos = { [5] = { 1002, 'NE', 4, 0, 50, true, 50, 3, 4, 20 } },
           win_viewport = {
             [2] = { topline = 0, botline = 3, curline = 0, curcol = 3, linecount = 2, sum_scroll_delta = 0, win = 1000 },
             [4] = { topline = 0, botline = 3, curline = 0, curcol = 3, linecount = 2, sum_scroll_delta = 0, win = 1001 },
@@ -3983,7 +3983,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]],
-          float_pos = { [5] = { 1002, 'NW', 4, 1, 14, true, 50, 1, 7, 14 } },
+          float_pos = { [5] = { 1002, 'NW', 4, 1, 14, true, 50, 3, 7, 14 } },
         }
       else
         screen:expect([[
@@ -4027,7 +4027,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]],
-          float_pos = { [5] = { 1002, 'NE', 4, 0, 14, true, 50, 1, 6, 3 } },
+          float_pos = { [5] = { 1002, 'NE', 4, 0, 14, true, 50, 3, 6, 3 } },
         }
       else
         screen:expect([[
@@ -4071,7 +4071,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]],
-          float_pos = { [5] = { 1002, 'SE', 4, 1, 14, true, 50, 1, 3, 3 } },
+          float_pos = { [5] = { 1002, 'SE', 4, 1, 14, true, 50, 3, 3, 3 } },
         }
       else
         screen:expect([[
@@ -4115,7 +4115,7 @@ describe('float window', function()
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
         ]],
-          float_pos = { [5] = { 1002, 'SW', 4, 0, 14, true, 50, 1, 2, 14 } },
+          float_pos = { [5] = { 1002, 'SW', 4, 0, 14, true, 50, 3, 2, 14 } },
         }
       else
         screen:expect([[
@@ -4201,13 +4201,13 @@ describe('float window', function()
           {1:8    }|
         ]],
           float_pos = {
-            [5] = { 1002, 'NW', 1, 1, 10, true, 50, 5, 1, 10 },
-            [6] = { 1003, 'NW', 1, 1, 30, true, 50, 1, 1, 30 },
-            [7] = { 1004, 'NE', 5, 1, 0, true, 50, 6, 2, 5 },
-            [8] = { 1005, 'NE', 6, 1, 0, true, 50, 2, 2, 25 },
-            [9] = { 1006, 'SE', 7, 0, 0, true, 50, 7, 1, 0 },
-            [10] = { 1007, 'SE', 8, 0, 0, true, 50, 3, 1, 20 },
-            [11] = { 1008, 'SW', 9, 0, 5, true, 50, 8, 0, 5 },
+            [5] = { 1002, 'NW', 1, 1, 10, true, 50, 6, 1, 10 },
+            [6] = { 1003, 'NW', 1, 1, 30, true, 50, 2, 1, 30 },
+            [7] = { 1004, 'NE', 5, 1, 0, true, 50, 7, 2, 5 },
+            [8] = { 1005, 'NE', 6, 1, 0, true, 50, 3, 2, 25 },
+            [9] = { 1006, 'SE', 7, 0, 0, true, 50, 8, 1, 0 },
+            [10] = { 1007, 'SE', 8, 0, 0, true, 50, 4, 1, 20 },
+            [11] = { 1008, 'SW', 9, 0, 5, true, 50, 9, 0, 5 },
             [12] = { 1009, 'SW', 10, 0, 5, true, 50, 4, 0, 25 },
           },
         }
@@ -4271,14 +4271,14 @@ describe('float window', function()
           {1:8    }|
         ]],
           float_pos = {
-            [5] = { 1002, 'NE', 8, 1, 0, true, 50, 5, 2, 25 },
-            [6] = { 1003, 'NE', 12, 1, 0, true, 50, 1, 2, 5 },
-            [7] = { 1004, 'SE', 5, 0, 0, true, 50, 6, 1, 20 },
-            [8] = { 1005, 'NW', 1, 1, 30, true, 50, 2, 1, 30 },
-            [9] = { 1006, 'SW', 10, 0, 5, true, 50, 7, 0, 5 },
-            [10] = { 1007, 'SE', 6, 0, 0, true, 50, 3, 1, 0 },
-            [11] = { 1008, 'SW', 7, 0, 5, true, 50, 8, 0, 25 },
-            [12] = { 1009, 'NW', 1, 1, 10, true, 50, 4, 1, 10 },
+            [5] = { 1002, 'NE', 8, 1, 0, true, 50, 6, 2, 25 },
+            [6] = { 1003, 'NE', 12, 1, 0, true, 50, 2, 2, 5 },
+            [7] = { 1004, 'SE', 5, 0, 0, true, 50, 7, 1, 20 },
+            [8] = { 1005, 'NW', 1, 1, 30, true, 50, 3, 1, 30 },
+            [9] = { 1006, 'SW', 10, 0, 5, true, 50, 8, 0, 5 },
+            [10] = { 1007, 'SE', 6, 0, 0, true, 50, 4, 1, 0 },
+            [11] = { 1008, 'SW', 7, 0, 5, true, 50, 9, 0, 25 },
+            [12] = { 1009, 'NW', 1, 1, 10, true, 50, 5, 1, 10 },
           },
         }
       else
@@ -4364,7 +4364,7 @@ describe('float window', function()
         ## grid 4
           {1:some info!  }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 2, 3, 2, true, 50, 1, 3, 2 } },
+          float_pos = { [4] = { 1001, 'NW', 2, 3, 2, true, 50, 2, 3, 2 } },
         }
       else
         screen:expect {
@@ -4410,7 +4410,7 @@ describe('float window', function()
         ## grid 4
           {1:some info!  }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 2, 2, 2, true, 50, 1, 2, 2 } },
+          float_pos = { [4] = { 1001, 'NW', 2, 2, 2, true, 50, 2, 2, 2 } },
         }
       else
         screen:expect {
@@ -4439,7 +4439,7 @@ describe('float window', function()
         ## grid 4
           {1:some info!  }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 2, 1, 32, true, 50, 1, 1, 32 } },
+          float_pos = { [4] = { 1001, 'NW', 2, 1, 32, true, 50, 2, 1, 32 } },
         }
       else
         -- note: appears misaligned due to cursor
@@ -4472,7 +4472,7 @@ describe('float window', function()
         ## grid 4
           {1:some info!  }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 2, 2, 7, true, 50, 1, 2, 7 } },
+          float_pos = { [4] = { 1001, 'NW', 2, 2, 7, true, 50, 2, 2, 7 } },
         }
       else
         screen:expect {
@@ -4506,7 +4506,7 @@ describe('float window', function()
         ## grid 4
           {1:some info!  }|
         ]],
-          float_pos = { [4] = { 1001, 'SW', 2, 1, 7, true, 50, 1, 0, 7 } },
+          float_pos = { [4] = { 1001, 'SW', 2, 1, 7, true, 50, 2, 0, 7 } },
         }
       else
         screen:expect {
@@ -4548,7 +4548,7 @@ describe('float window', function()
           {0:~                   }|*8
         ]],
           float_pos = {
-            [4] = { 1001, 'SW', 2, 8, 0, true, 50, 1, 7, 0 },
+            [4] = { 1001, 'SW', 2, 8, 0, true, 50, 3, 7, 0 },
           },
         }
       else
@@ -4587,7 +4587,7 @@ describe('float window', function()
         ## grid 4
           {1:some info!  }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 2, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 2, 2, 5, true, 50, 2, 2, 5 } },
         }
       else
         screen:expect {
@@ -4621,7 +4621,7 @@ describe('float window', function()
         ## grid 4
           {1:some info!  }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 2, 3, 7, true, 50, 1, 3, 7 } },
+          float_pos = { [4] = { 1001, 'NW', 2, 3, 7, true, 50, 2, 3, 7 } },
         }
       else
         screen:expect {
@@ -4652,7 +4652,7 @@ describe('float window', function()
         ## grid 4
           {1:some info!  }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 2, 2, 0, true, 50, 1, 2, 0 } },
+          float_pos = { [4] = { 1001, 'NW', 2, 2, 0, true, 50, 2, 2, 0 } },
         }
       else
         screen:expect {
@@ -4707,7 +4707,7 @@ describe('float window', function()
         ## grid 4
           {1:some floaty text    }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 3, 1, true, 50, 1, 3, 1 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 3, 1, true, 50, 2, 3, 1 } },
         }
       else
         screen:expect([[
@@ -4773,7 +4773,7 @@ describe('float window', function()
           {1:float          }|
           {2:~              }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 2, 2, 10 } },
         }
       else
         screen:expect([[
@@ -4805,7 +4805,7 @@ describe('float window', function()
           {1:float          }|
           {2:~              }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 2, 0, 10 } },
         }
       else
         screen:expect([[
@@ -4835,7 +4835,7 @@ describe('float window', function()
           {1:float          }|
           {2:~              }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 2, 0, 10 } },
         }
       else
         screen:expect([[
@@ -4864,7 +4864,7 @@ describe('float window', function()
           {1:float          }|
           {2:~              }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 2, 0, 10 } },
         }
       else
         screen:expect([[
@@ -4891,7 +4891,7 @@ describe('float window', function()
           {1:^float          }|
           {2:~              }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 2, 0, 10 } },
         }
       else
         screen:expect([[
@@ -4919,7 +4919,7 @@ describe('float window', function()
           {1:^float          }|
           {2:~              }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 2, 2, 10 } },
         }
       else
         screen:expect([[
@@ -4951,7 +4951,7 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 2, 2, 10 } },
         }
       else
         screen:expect([[
@@ -4982,7 +4982,7 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 2, 2, 10 } },
         }
       else
         screen:expect([[
@@ -5013,7 +5013,7 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 2, 2, 10 } },
         }
       else
         screen:expect([[
@@ -5044,7 +5044,7 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 9 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 2, 2, 9 } },
         }
       else
         screen:expect([[
@@ -5075,7 +5075,7 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 1 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 2, 2, 1 } },
         }
       else
         screen:expect([[
@@ -5106,7 +5106,7 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 0 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 2, 2, 0 } },
         }
       else
         screen:expect([[
@@ -5137,7 +5137,7 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 0 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 2, 2, 0 } },
         }
       else
         screen:expect([[
@@ -5168,7 +5168,7 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 0 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 2, 2, 0 } },
         }
       else
         screen:expect([[
@@ -5199,7 +5199,7 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 0 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 2, 0, 0 } },
         }
       else
         screen:expect([[
@@ -5225,7 +5225,7 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 10, true, 50, 2, 2, 10 } },
         }
       else
         screen:expect([[
@@ -5241,7 +5241,7 @@ describe('float window', function()
     end)
 
     it('does not crash with inccommand #9379', function()
-      local expected_pos = { [4] = { 1001, 'NW', 1, 2, 0, true, 50, 1, 2, 0 } }
+      local expected_pos = { [4] = { 1001, 'NW', 1, 2, 0, true, 50, 2, 2, 0 } }
       command('set inccommand=split')
       command('set laststatus=2')
       local buf = api.nvim_create_buf(false, false)
@@ -5374,7 +5374,7 @@ describe('float window', function()
             {7:^            }|
             {12:~           }|*3
           ]],
-            float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+            float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           }
         else
           screen:expect([[
@@ -5410,8 +5410,8 @@ describe('float window', function()
             {1: longtext       }|
           ]],
             float_pos = {
-              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
-              [5] = { -1, 'NW', 4, 1, 1, false, 100, 2, 3, 6 },
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 },
+              [5] = { -1, 'NW', 4, 1, 1, false, 100, 3, 3, 6 },
             },
           }
         else
@@ -5442,7 +5442,7 @@ describe('float window', function()
             {7:x a^a        }|
             {12:~           }|*3
           ]],
-            float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+            float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           }
         else
           screen:expect([[
@@ -5476,8 +5476,8 @@ describe('float window', function()
             {1:zz             }|
           ]],
             float_pos = {
-              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
-              [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 },
+              [5] = { -1, 'NW', 2, 1, 0, false, 100, 3, 1, 0 },
             },
           }
         else
@@ -5507,7 +5507,7 @@ describe('float window', function()
             {7:x aa        }|
             {12:~           }|*3
           ]],
-            float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+            float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           }
         else
           screen:expect([[
@@ -5542,8 +5542,8 @@ describe('float window', function()
             {1: unplace        }|
           ]],
             float_pos = {
-              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
-              [5] = { -1, 'SW', 1, 6, 5, false, 250, 3, 4, 5 },
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 },
+              [5] = { -1, 'SW', 1, 6, 5, false, 250, 4, 4, 5 },
             },
           }
         else
@@ -5581,7 +5581,7 @@ describe('float window', function()
             {7:x aa^        }|
             {12:~           }|*3
           ]],
-            float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+            float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
             popupmenu = { anchor = { 4, 0, 2 }, items = items, pos = 0 },
           }
         else
@@ -5593,7 +5593,7 @@ describe('float window', function()
             {0:~    }{12:~           }{0:                       }|*3
             {3:-- INSERT --}                            |
           ]],
-            popupmenu = { anchor = { 1, 2, 7 }, items = items, pos = 0 },
+            popupmenu = { anchor = { 4, 0, 2 }, items = items, pos = 0 },
           }
         end
 
@@ -5613,7 +5613,7 @@ describe('float window', function()
             {7:x a^a        }|
             {12:~           }|*3
           ]],
-            float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+            float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           }
         else
           screen:expect([[
@@ -5643,7 +5643,7 @@ describe('float window', function()
             {7:x aa        }|
             {12:~           }|*3
           ]],
-            float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+            float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
             popupmenu = { anchor = { 2, 0, 0 }, items = items, pos = 0 },
           }
         else
@@ -5655,7 +5655,7 @@ describe('float window', function()
             {0:~    }{12:~           }{0:                       }|*3
             {3:-- INSERT --}                            |
           ]],
-            popupmenu = { anchor = { 1, 0, 0 }, items = items, pos = 0 },
+            popupmenu = { anchor = { 2, 0, 0 }, items = items, pos = 0 },
           }
         end
 
@@ -5675,7 +5675,7 @@ describe('float window', function()
             {7:x aa        }|
             {12:~           }|*3
           ]],
-            float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+            float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           }
         else
           screen:expect([[
@@ -5711,7 +5711,7 @@ describe('float window', function()
             {1:word           }|
             {1:longtext       }|
           ]],
-            float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
+            float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 } },
           }
         else
           screen:expect([[
@@ -5747,8 +5747,8 @@ describe('float window', function()
             {15:about item  }|
           ]],
             float_pos = {
-              [5] = { 1001, 'NW', 2, 1, 12, true, 50, 1, 1, 12 },
-              [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
+              [5] = { 1001, 'NW', 2, 1, 12, true, 50, 2, 1, 12 },
+              [4] = { -1, 'NW', 2, 1, 0, false, 100, 3, 1, 0 },
             },
           }
         else
@@ -5780,7 +5780,7 @@ describe('float window', function()
             {15:some info   }|
             {15:about item  }|
           ]],
-            float_pos = { [5] = { 1001, 'NW', 2, 1, 12, true, 50, 1, 1, 12 } },
+            float_pos = { [5] = { 1001, 'NW', 2, 1, 12, true, 50, 2, 1, 12 } },
           }
         else
           screen:expect([[
@@ -5831,7 +5831,7 @@ describe('float window', function()
             {1:word           }|
             {1:longtext       }|
           ]],
-            float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
+            float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 } },
           }
         else
           screen:expect([[
@@ -5887,7 +5887,7 @@ describe('float window', function()
           here                |
           float               |
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
@@ -5909,7 +5909,17 @@ describe('float window', function()
 
     describe('handles :wincmd', function()
       local win
-      local expected_pos
+      local expected_pos = function(opts)
+        opts = opts or {}
+        local defaults = {
+          focusable = true,
+          compindex = 2,
+        }
+        opts = vim.tbl_extend('keep', opts, defaults)
+        return {
+          [4] = { 1001, 'NW', 1, 2, 5, opts.focusable, 50, opts.compindex, 2, 5 },
+        }
+      end
       before_each(function()
         -- the default, but be explicit:
         command('set laststatus=1')
@@ -5918,7 +5928,6 @@ describe('float window', function()
         local buf = api.nvim_create_buf(false, false)
         win = api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 2, row = 2, col = 5 })
         api.nvim_buf_set_lines(buf, 0, -1, true, { 'y' })
-        expected_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } }
         if multigrid then
           screen:expect {
             grid = [[
@@ -5934,7 +5943,7 @@ describe('float window', function()
             {1:y                   }|
             {2:~                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -5965,7 +5974,7 @@ describe('float window', function()
             {1:^y                   }|
             {2:~                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -5994,7 +6003,7 @@ describe('float window', function()
             {1:y                   }|
             {2:~                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -6010,7 +6019,6 @@ describe('float window', function()
 
       it('w with focusable=false', function()
         api.nvim_win_set_config(win, { focusable = false })
-        expected_pos[4][6] = false
         feed('<c-w>wi') -- i to provoke redraw
         if multigrid then
           screen:expect {
@@ -6027,7 +6035,7 @@ describe('float window', function()
             {1:y                   }|
             {2:~                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { focusable = false },
           }
         else
           screen:expect([[
@@ -6039,7 +6047,6 @@ describe('float window', function()
             {3:-- INSERT --}                            |
           ]])
         end
-
         feed('<esc><c-w>w')
         if multigrid then
           screen:expect {
@@ -6056,7 +6063,7 @@ describe('float window', function()
             {1:y                   }|
             {2:~                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { focusable = false },
           }
         else
           screen:expect([[
@@ -6120,7 +6127,7 @@ describe('float window', function()
             {1:^y                   }|
             {2:~                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -6149,7 +6156,7 @@ describe('float window', function()
             {1:y                   }|
             {2:~                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -6184,7 +6191,7 @@ describe('float window', function()
             {1:^y                   }|
             {2:~                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -6217,7 +6224,7 @@ describe('float window', function()
             {1:y                   }|
             {2:~                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -6242,7 +6249,6 @@ describe('float window', function()
 
       local function test_float_mouse_no_focus()
         api.nvim_buf_set_lines(0, -1, -1, true, { 'a' })
-        expected_pos[4][6] = false
         if send_mouse_grid then
           api.nvim_input_mouse('left', 'press', '', 4, 0, 0)
         else
@@ -6268,7 +6274,7 @@ describe('float window', function()
               {1:y                   }|
               {2:~                   }|
             ]],
-              float_pos = expected_pos,
+              float_pos = expected_pos { focusable = false },
             }
           else
             screen:expect {
@@ -6286,7 +6292,7 @@ describe('float window', function()
               {1:y                   }|
               {2:~                   }|
             ]],
-              float_pos = expected_pos,
+              float_pos = expected_pos { focusable = false },
             }
           end
         else
@@ -6321,7 +6327,7 @@ describe('float window', function()
             {1:y                   }|
             {2:~                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { focusable = false },
             unchanged = true,
           }
         else
@@ -6384,7 +6390,7 @@ describe('float window', function()
             {1:y                   }|
             {2:~                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -6413,7 +6419,7 @@ describe('float window', function()
             {1:^y                   }|
             {2:~                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -6442,7 +6448,7 @@ describe('float window', function()
             {1:y                   }|
             {2:~                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -6473,7 +6479,7 @@ describe('float window', function()
             {1:^y                   }|
             {2:~                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -6502,7 +6508,7 @@ describe('float window', function()
             {1:^y                   }|
             {2:~                   }|*2
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -6530,7 +6536,7 @@ describe('float window', function()
           ## grid 4
             {1:^y                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -6558,7 +6564,7 @@ describe('float window', function()
             {1:^y                   }|
             {2:~                   }|*3
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -6586,7 +6592,9 @@ describe('float window', function()
             {1:^y                   }|
             {2:~                   }|*5
           ]],
-            float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 0, 5 } },
+            float_pos = {
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 0, 5 },
+            },
           }
         else
           screen:expect([[
@@ -6614,7 +6622,7 @@ describe('float window', function()
             {1:^y                   }|
             {2:~                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -6643,7 +6651,7 @@ describe('float window', function()
             {1:^y                    }|
             {2:~                    }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -6672,7 +6680,7 @@ describe('float window', function()
             {1:^y          }|
             {2:~          }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -6701,7 +6709,7 @@ describe('float window', function()
             {1:^y              }|
             {2:~              }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -6730,7 +6738,9 @@ describe('float window', function()
             {1:^y                                       }|
             {2:~                                       }|
           ]],
-            float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 0 } },
+            float_pos = {
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 0 },
+            },
           }
         else
           screen:expect([[
@@ -6767,7 +6777,7 @@ describe('float window', function()
             ^x                                       |
             {0:~                                       }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { compindex = 3 },
           }
         else
           screen:expect([[
@@ -6803,7 +6813,7 @@ describe('float window', function()
             x                                       |
             {0:~                                       }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { compindex = 3 },
           }
         else
           screen:expect([[
@@ -6839,7 +6849,7 @@ describe('float window', function()
             x                                       |
             {0:~                                       }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { compindex = 3 },
           }
         else
           screen:expect([[
@@ -6875,7 +6885,7 @@ describe('float window', function()
             ^x                                       |
             {0:~                                       }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { compindex = 3 },
           }
         else
           screen:expect([[
@@ -6913,7 +6923,7 @@ describe('float window', function()
             ^y                                       |
             {0:~                                       }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { compindex = 3 },
           }
         else
           screen:expect([[
@@ -6949,7 +6959,7 @@ describe('float window', function()
             y                                       |
             {0:~                                       }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { compindex = 3 },
           }
         else
           screen:expect([[
@@ -6985,7 +6995,7 @@ describe('float window', function()
             y                                       |
             {0:~                                       }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { compindex = 3 },
           }
         else
           screen:expect([[
@@ -7023,7 +7033,7 @@ describe('float window', function()
             ^                                        |
             {0:~                                       }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { compindex = 3 },
           }
         else
           screen:expect([[
@@ -7061,7 +7071,7 @@ describe('float window', function()
             ^                                        |
             {0:~                                       }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { compindex = 3 },
           }
         else
           screen:expect([[
@@ -7097,7 +7107,7 @@ describe('float window', function()
             ^x                   |
             {0:~                   }|*4
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { compindex = 3 },
           }
         else
           screen:expect([[
@@ -7133,7 +7143,7 @@ describe('float window', function()
             ^                    |
             {0:~                   }|*4
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { compindex = 3 },
           }
         else
           screen:expect([[
@@ -7169,7 +7179,7 @@ describe('float window', function()
             ^                    |
             {0:~                   }|*4
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { compindex = 3 },
           }
         else
           screen:expect([[
@@ -7230,8 +7240,8 @@ describe('float window', function()
             {2:~                   }|
           ]],
             float_pos = {
-              [5] = { 1002, 'NW', 1, 4, 8, true, 50, 2, 4, 8 },
-              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+              [5] = { 1002, 'NW', 1, 4, 8, true, 50, 3, 4, 8 },
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 },
             },
           }
         else
@@ -7262,7 +7272,9 @@ describe('float window', function()
             {1:^y                   }|
             {2:~                   }|
           ]],
-            float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+            float_pos = {
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 },
+            },
           }
         else
           screen:expect([[
@@ -7341,7 +7353,7 @@ describe('float window', function()
             {1:y                   }|
             {2:~                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -7372,7 +7384,7 @@ describe('float window', function()
             {1:^y                   }|
             {2:~                   }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -7409,7 +7421,7 @@ describe('float window', function()
             ^x                                       |
             {0:~                                       }|
         ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { compindex = 3 },
           }
         else
           screen:expect([[
@@ -7469,7 +7481,7 @@ describe('float window', function()
             x                                       |
             {0:~                                       }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { compindex = 3 },
           }
         else
           screen:expect([[
@@ -7506,7 +7518,7 @@ describe('float window', function()
             x                                       |
             {0:~                                       }|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { compindex = 3 },
           }
         else
           screen:expect([[
@@ -7556,7 +7568,6 @@ describe('float window', function()
 
         if multigrid then
           api.nvim_win_set_config(0, { external = true, width = 30, height = 2 })
-          expected_pos = { [4] = { external = true } }
           screen:expect {
             grid = [[
           ## grid 1
@@ -7572,7 +7583,7 @@ describe('float window', function()
             ^y                             |
             {0:~                             }|
           ]],
-            float_pos = expected_pos,
+            float_pos = { [4] = { external = true } },
           }
         else
           eq("UI doesn't support external windows", pcall_err(api.nvim_win_set_config, 0, { external = true, width = 30, height = 2 }))
@@ -7619,7 +7630,7 @@ describe('float window', function()
             {5:│}{2:~                   }{5:│}|
             {5:└────────────────────┘}|
           ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -7696,7 +7707,7 @@ describe('float window', function()
             ^x                   |
             {0:~                   }|
         ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { compindex = 5 },
           }
         else
           screen:expect([[
@@ -7744,7 +7755,7 @@ describe('float window', function()
             3                  |
             {0:~                  }|
         ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos { compindex = 5 },
           }
         else
           screen:expect([[
@@ -7843,7 +7854,7 @@ describe('float window', function()
                                                     |
             {0:~                                       }|*4
         ]],
-            float_pos = expected_pos,
+            float_pos = expected_pos(),
           }
         else
           screen:expect([[
@@ -7987,7 +7998,9 @@ describe('float window', function()
           {1:bar                 }|
           {1:baz                 }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
@@ -8014,7 +8027,9 @@ describe('float window', function()
           {1:bar                 }|
           {1:baz                 }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
@@ -8041,7 +8056,9 @@ describe('float window', function()
           {27:ba}{1:^r                 }|
           {1:baz                 }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 1, curcol = 2, linecount = 3, sum_scroll_delta = 0 },
@@ -8110,7 +8127,9 @@ describe('float window', function()
           {5:│}{1:baz                 }{5:│}|
           {5:└────────────────────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 2, 0, 5 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
@@ -8139,7 +8158,9 @@ describe('float window', function()
           {5:│}{1:baz                 }{5:│}|
           {5:└────────────────────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 2, 0, 5 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
@@ -8168,7 +8189,9 @@ describe('float window', function()
           {5:│}{1:baz                 }{5:│}|
           {5:└────────────────────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 2, 0, 5 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 1, curcol = 2, linecount = 3, sum_scroll_delta = 0 },
@@ -8237,7 +8260,9 @@ describe('float window', function()
           {1:bar                 }|
           {1:baz                 }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 1, 5, true, 50, 1, 1, 5 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 5, true, 50, 2, 1, 5 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
@@ -8265,7 +8290,9 @@ describe('float window', function()
           {1:bar                 }|
           {1:baz                 }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 1, 5, true, 50, 1, 1, 5 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 5, true, 50, 2, 1, 5 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
@@ -8293,7 +8320,9 @@ describe('float window', function()
           {27:ba}{1:^r                 }|
           {1:baz                 }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 1, 5, true, 50, 1, 1, 5 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 5, true, 50, 2, 1, 5 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 1, curcol = 2, linecount = 3, sum_scroll_delta = 0 },
@@ -8458,7 +8487,9 @@ describe('float window', function()
           {5:│}{1:                    }{5:│}|*3
           {5:└────────────────────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 2, 0, 5 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
@@ -8517,7 +8548,9 @@ describe('float window', function()
           {5:│}{2:~                   }{5:│}|
           {5:└────────────────────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 2, 0, 5 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 4, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
@@ -8560,7 +8593,9 @@ describe('float window', function()
           {5:│}{19:│}{1:                   }{5:│}|
           {5:└────────────────────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 2, 0, 5 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
@@ -8679,7 +8714,7 @@ describe('float window', function()
           {1:               }|
           {1:popup    text  }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
         }
       else
         screen:expect([[
@@ -8718,7 +8753,7 @@ describe('float window', function()
           {9:               }|
           {9:popup    text  }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           unchanged = true,
         }
       else
@@ -8802,7 +8837,7 @@ describe('float window', function()
           {13:               }|
           {13:popup    text  }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
         }
       else
         screen:expect([[
@@ -8853,7 +8888,7 @@ describe('float window', function()
           {9:               }|
           {10:popup    text}{9:  }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
         }
       else
         screen:expect([[
@@ -8892,7 +8927,7 @@ describe('float window', function()
           {9:               }|
           {11:popup    text}{9:  }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
           unchanged = true,
         }
       else
@@ -8936,7 +8971,7 @@ describe('float window', function()
           {11:popup    text}{9:  }|
           {12:~              }|*2
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 } },
         }
       else
         screen:expect([[
@@ -9083,7 +9118,7 @@ describe('float window', function()
           {1:口   }|*2
           {1:     }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 0, 11, true, 50, 1, 0, 11 } },
+          float_pos = { [4] = { 1001, 'NW', 1, 0, 11, true, 50, 2, 0, 11 } },
         }
       else
         screen:expect([[
@@ -9147,7 +9182,9 @@ describe('float window', function()
           {5:  x x  x   x}|
           {5:            }|
         ]],
-          float_pos = { [5] = { 1002, 'NW', 1, 0, 11, true, 50, 1, 0, 11 } },
+          float_pos = {
+            [5] = { 1002, 'NW', 1, 0, 11, true, 50, 2, 0, 11 },
+          },
         }
       else
         screen:expect([[
@@ -9177,7 +9214,9 @@ describe('float window', function()
           {5:  x x  x   x}|
           {5:            }|
         ]],
-          float_pos = { [5] = { 1002, 'NW', 1, 0, 12, true, 50, 1, 0, 12 } },
+          float_pos = {
+            [5] = { 1002, 'NW', 1, 0, 12, true, 50, 2, 0, 12 },
+          },
         }
       else
         screen:expect([[
@@ -9243,8 +9282,8 @@ describe('float window', function()
             [2] = { background = Screen.colors.LightMagenta },
           },
           float_pos = {
-            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 2, 1, 1 },
-            [5] = { 1002, 'NW', 1, 0, 0, true, 50, 1, 0, 0 },
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 3, 1, 1 },
+            [5] = { 1002, 'NW', 1, 0, 0, true, 50, 2, 0, 0 },
           },
         }
       else
@@ -9300,8 +9339,8 @@ describe('float window', function()
             [2] = { background = Screen.colors.LightMagenta },
           },
           float_pos = {
-            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 2, 1, 1 },
-            [5] = { 1002, 'NW', 1, 0, 0, true, 50, 1, 0, 0 },
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 3, 1, 1 },
+            [5] = { 1002, 'NW', 1, 0, 0, true, 50, 2, 0, 0 },
           },
         }
       else
@@ -9337,7 +9376,9 @@ describe('float window', function()
           {7:                    }|
           {7:~                   }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -9387,9 +9428,9 @@ describe('float window', function()
           {17:~           }|
         ]],
           float_pos = {
-            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
-            [5] = { 1002, 'NW', 1, 3, 8, true, 50, 2, 3, 8 },
-            [6] = { 1003, 'NW', 1, 4, 10, true, 50, 3, 4, 10 },
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 },
+            [5] = { 1002, 'NW', 1, 3, 8, true, 50, 3, 3, 8 },
+            [6] = { 1003, 'NW', 1, 4, 10, true, 50, 4, 4, 10 },
           },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -9437,9 +9478,9 @@ describe('float window', function()
           ]],
           win_pos = { [2] = { height = 6, startcol = 0, startrow = 0, width = 40, win = 1000 } },
           float_pos = {
-            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 3, 2, 5 },
-            [5] = { 1002, 'NW', 1, 3, 8, true, 50, 1, 3, 8 },
-            [6] = { 1003, 'NW', 1, 4, 10, true, 50, 2, 4, 10 },
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 4, 2, 5 },
+            [5] = { 1002, 'NW', 1, 3, 8, true, 50, 2, 3, 8 },
+            [6] = { 1003, 'NW', 1, 4, 10, true, 50, 3, 4, 10 },
           },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -9481,7 +9522,9 @@ describe('float window', function()
           {7:                    }|
           {7:~                   }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -9531,9 +9574,9 @@ describe('float window', function()
           {1:~               }|
         ]],
           float_pos = {
-            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
-            [5] = { 1002, 'NW', 1, 4, 10, true, 50, 3, 4, 10 },
-            [6] = { 1003, 'NW', 1, 3, 8, true, 50, 2, 3, 8 },
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 },
+            [5] = { 1002, 'NW', 1, 4, 10, true, 50, 4, 4, 10 },
+            [6] = { 1003, 'NW', 1, 3, 8, true, 50, 3, 3, 8 },
           },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -9581,9 +9624,9 @@ describe('float window', function()
           ]],
           win_pos = { [2] = { height = 6, startcol = 0, startrow = 0, width = 40, win = 1000 } },
           float_pos = {
-            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 3, 2, 5 },
-            [5] = { 1002, 'NW', 1, 4, 10, true, 50, 2, 4, 10 },
-            [6] = { 1003, 'NW', 1, 3, 8, true, 50, 1, 3, 8 },
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 4, 2, 5 },
+            [5] = { 1002, 'NW', 1, 4, 10, true, 50, 3, 4, 10 },
+            [6] = { 1003, 'NW', 1, 3, 8, true, 50, 2, 3, 8 },
           },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -9636,9 +9679,9 @@ describe('float window', function()
           {8:~                   }|*2
         ]],
           float_pos = {
-            [4] = { 1001, 'NW', 1, 1, 5, true, 30, 1, 1, 5 },
-            [5] = { 1002, 'NW', 1, 2, 6, true, 50, 3, 2, 6 },
-            [6] = { 1003, 'NW', 1, 3, 7, true, 40, 2, 3, 7 },
+            [4] = { 1001, 'NW', 1, 1, 5, true, 30, 2, 1, 5 },
+            [5] = { 1002, 'NW', 1, 2, 6, true, 50, 4, 2, 6 },
+            [6] = { 1003, 'NW', 1, 3, 7, true, 40, 3, 3, 7 },
           },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -9697,8 +9740,8 @@ describe('float window', function()
             {5:└────────────────────┘}|
           ]],
           float_pos = {
-            [4] = { 1001, 'NW', 1, 1, 5, true, 400, 3, 1, 5 },
-            [6] = { 1003, 'NW', 1, 3, 7, true, 300, 2, 2, 7 },
+            [4] = { 1001, 'NW', 1, 1, 5, true, 400, 4, 1, 5 },
+            [6] = { 1003, 'NW', 1, 3, 7, true, 300, 3, 2, 7 },
           },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -9755,8 +9798,8 @@ describe('float window', function()
             {5:└────────────────────┘}|
           ]],
           float_pos = {
-            [4] = { 1001, 'NW', 1, 1, 5, true, 100, 1, 1, 5 },
-            [6] = { 1003, 'NW', 1, 3, 7, true, 150, 2, 1, 7 },
+            [4] = { 1001, 'NW', 1, 1, 5, true, 100, 2, 1, 5 },
+            [6] = { 1003, 'NW', 1, 3, 7, true, 150, 3, 1, 7 },
           },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -9802,7 +9845,9 @@ describe('float window', function()
           {1:               }|
           {2:~              }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 1, 5, true, 50, 1, 1, 5 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 5, true, 50, 2, 1, 5 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -9842,7 +9887,9 @@ describe('float window', function()
           {5:│}{2:~              }{5:│}|*2
           {5:└───────────────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 0, 4, true, 50, 1, 0, 4 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 4, true, 50, 2, 0, 4 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -9896,7 +9943,9 @@ describe('float window', function()
           {5:│}{1:                                        }{5:│}|*4
           {5:└────────────────────────────────────────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'SW', 1, 9, 0, true, 50, 1, 3, 0 } },
+          float_pos = {
+            [4] = { 1001, 'SW', 1, 9, 0, true, 50, 2, 3, 0 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -9937,7 +9986,9 @@ describe('float window', function()
           {5:│}{1:                                        }{5:│}|*2
           {5:└────────────────────────────────────────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'SW', 1, 9, 0, true, 50, 1, 5, 0 } },
+          float_pos = {
+            [4] = { 1001, 'SW', 1, 9, 0, true, 50, 2, 5, 0 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -10011,7 +10062,9 @@ describe('float window', function()
           {5:│}{1:                                        }{5:│}|*4
           {5:└────────────────────────────────────────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'SW', 1, 8, 0, true, 50, 1, 2, 0 } },
+          float_pos = {
+            [4] = { 1001, 'SW', 1, 8, 0, true, 50, 2, 2, 0 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -10059,7 +10112,9 @@ describe('float window', function()
           {5:│}{1:                                        }{5:│}|*4
           {5:└────────────────────────────────────────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'SW', 1, 8, 0, true, 50, 1, 4, 0 } },
+          float_pos = {
+            [4] = { 1001, 'SW', 1, 8, 0, true, 50, 2, 4, 0 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -10096,7 +10151,9 @@ describe('float window', function()
           {5:│}{1:                                        }{5:│}|*2
           {5:└────────────────────────────────────────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'SW', 1, 8, 0, true, 50, 1, 4, 0 } },
+          float_pos = {
+            [4] = { 1001, 'SW', 1, 8, 0, true, 50, 2, 4, 0 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -10148,7 +10205,7 @@ describe('float window', function()
         local float_opts = { relative = 'editor', row = 1, col = 1, width = 10, height = 10 }
         api.nvim_open_win(api.nvim_create_buf(false, false), true, float_opts)
         if multigrid then
-          screen:expect({ float_pos = { [4] = { 1001, 'NW', 1, 1, 1, true, 50, 1, 0, 1 } } })
+          screen:expect({ float_pos = { [4] = { 1001, 'NW', 1, 1, 1, true, 50, 2, 0, 1 } } })
         end
         command(cmd)
         exec_lua([[
@@ -10192,7 +10249,9 @@ describe('float window', function()
           {1:cd  }|
           {2:~   }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 1, 1, true, 50, 1, 1, 1 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 2, 1, 1 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0 },
@@ -10228,7 +10287,9 @@ describe('float window', function()
           {1:c^d  }|
           {2:~   }|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 1, 1, true, 50, 1, 1, 1 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 2, 1, 1 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0 },
@@ -10269,7 +10330,9 @@ describe('float window', function()
           {5:│}{2:~   }{5:│}|
           {5:└────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 1, 1, true, 50, 1, 1, 1 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 2, 1, 1 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0 },
@@ -10308,7 +10371,9 @@ describe('float window', function()
           {5:│}{2:~   }{5:│}|
           {5:└────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 1, 1, true, 50, 1, 1, 1 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 2, 1, 1 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0 },
@@ -10350,7 +10415,9 @@ describe('float window', function()
           {5:│}{1:cd  }{5:│}|
           {5:└────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 1, 1, true, 50, 1, 1, 1 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 2, 1, 1 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0 },
@@ -10389,7 +10456,9 @@ describe('float window', function()
           {5:│}{1:c^d  }{5:│}|
           {5:└────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 1, 1, true, 50, 1, 1, 1 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 2, 1, 1 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0 },
@@ -10435,7 +10504,9 @@ describe('float window', function()
           {5:│}{2:    ~}{5:│}|
           {5:└─────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 1, 1, true, 50, 1, 1, 1 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 2, 1, 1 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 3, curline = 1, curcol = 2, linecount = 2, sum_scroll_delta = 0 },
@@ -10461,7 +10532,7 @@ describe('float window', function()
       local buf = api.nvim_create_buf(false, false)
       local win = api.nvim_open_win(buf, false, { relative = 'editor', width = 10, height = 2, row = 2, col = 5, hide = true })
       local expected_pos = {
-        [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+        [4] = { 1001, 'NW', 1, 2, 5, true, 50, 2, 2, 5 },
       }
 
       if multigrid then
@@ -10745,10 +10816,10 @@ describe('float window', function()
       api.nvim_open_win(buf_c, false, config_c)
       api.nvim_open_win(buf_d, false, config_d)
       local expected_pos = {
-        [4] = { 1001, 'NW', 1, 5, 5, true, 50, 1, 0, 5 },
-        [5] = { 1002, 'NW', 1, 7, 7, true, 70, 2, 0, 7 },
-        [6] = { 1003, 'NW', 1, 9, 9, true, 90, 3, 0, 9 },
-        [7] = { 1004, 'NW', 1, 10, 10, true, 100, 4, 2, 10 },
+        [4] = { 1001, 'NW', 1, 5, 5, true, 50, 2, 0, 5 },
+        [5] = { 1002, 'NW', 1, 7, 7, true, 70, 3, 0, 7 },
+        [6] = { 1003, 'NW', 1, 9, 9, true, 90, 4, 0, 9 },
+        [7] = { 1004, 'NW', 1, 10, 10, true, 100, 5, 2, 10 },
       }
       if multigrid then
         screen:expect {
@@ -10924,7 +10995,9 @@ describe('float window', function()
             {5:│}{1:^     }{5:│}|
             {5:└─────┘}|
           ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 100, 1, true, 50, 1, 1, 1 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 100, 1, true, 50, 2, 1, 1 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -10961,7 +11034,9 @@ describe('float window', function()
           {5:│}{1:^     }{5:│}|
           {5:└─────┘}|
         ]],
-          float_pos = { [4] = { 1001, 'NW', 1, 100, 1, true, 300, 2, 4, 1 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 100, 1, true, 300, 3, 4, 1 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -11024,7 +11099,9 @@ describe('float window', function()
             {1:     }|
             {2:~    }|
           ]],
-          float_pos = { [4] = { 1001, 'NW', 2, 0, 0, true, 50, 1, 0, 0 } },
+          float_pos = {
+            [4] = { 1001, 'NW', 2, 0, 0, true, 50, 2, 0, 0 },
+          },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
             [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -711,7 +711,7 @@ describe('ui/ext_messages', function()
         {1:~                        }|*2
       ]],
       popupmenu = {
-        anchor = { 1, 2, 0 },
+        anchor = { 2, 2, 0 },
         items = { { 'alphpabet', '', '', '' }, { 'alphanum', '', '', '' } },
         pos = 1,
       },
@@ -732,7 +732,7 @@ describe('ui/ext_messages', function()
         {1:~                        }|*2
       ]],
       popupmenu = {
-        anchor = { 1, 2, 0 },
+        anchor = { 2, 2, 0 },
         items = { { 'alphpabet', '', '', '' }, { 'alphanum', '', '', '' } },
         pos = 1,
       },
@@ -752,7 +752,7 @@ describe('ui/ext_messages', function()
         {1:~                        }|*2
       ]],
       popupmenu = {
-        anchor = { 1, 2, 0 },
+        anchor = { 2, 2, 0 },
         items = { { 'alphpabet', '', '', '' }, { 'alphanum', '', '', '' } },
         pos = 0,
       },

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -10,1882 +10,1869 @@ local command = n.command
 local exec = n.exec
 
 describe('ui/mouse/input', function()
-  local screen
+  local function with_ext_multigrid(multigrid)
+    local screen
 
-  before_each(function()
-    clear()
-    api.nvim_set_option_value('mouse', 'a', {})
-    api.nvim_set_option_value('list', true, {})
-    -- NB: this is weird, but mostly irrelevant to the test
-    -- So I didn't bother to change it
-    command('set listchars=eol:$')
-    command('setl listchars=nbsp:x')
-    screen = Screen.new(25, 5)
-    screen:add_extra_attr_ids {
-      [100] = {
-        bold = true,
-        background = Screen.colors.LightGrey,
-        foreground = Screen.colors.Blue1,
-      },
-    }
-    command('set mousemodel=extend')
-    feed('itesting<cr>mouse<cr>support and selection<esc>')
-    screen:expect({
-      any = {
-        'testing                  ',
-        'mouse                    ',
-        'support and selectio%^n    ',
-      },
-    })
-  end)
+    before_each(function()
+      clear()
+      api.nvim_set_option_value('mouse', 'a', {})
+      api.nvim_set_option_value('list', true, {})
+      -- NB: this is weird, but mostly irrelevant to the test
+      -- So I didn't bother to change it
+      command('set listchars=eol:$')
+      command('setl listchars=nbsp:x')
 
-  it('single left click moves cursor', function()
-    feed('<LeftMouse><2,1>')
-    screen:expect({
-      any = 'mo%^use',
-      mouse_enabled = true,
-    })
-    feed('<LeftMouse><0,0>')
-    screen:expect({
-      any = '%^testing',
-    })
-  end)
-
-  it("in external ui works with unset 'mouse'", function()
-    api.nvim_set_option_value('mouse', '', {})
-    feed('<LeftMouse><2,1>')
-    screen:expect({
-      any = 'mo%^use',
-      mouse_enabled = false,
-    })
-    feed('<LeftMouse><0,0>')
-    screen:expect({
-      any = '%^testing',
-    })
-  end)
-
-  it('double left click enters visual mode', function()
-    feed('<LeftMouse><0,0>')
-    feed('<LeftRelease><0,0>')
-    feed('<LeftMouse><0,0>')
-    feed('<LeftRelease><0,0>')
-    screen:expect({
-      any = {
-        '{17:testin}%^g',
-        'VISUAL',
-      },
-    })
-  end)
-
-  it('triple left click enters visual line mode', function()
-    feed('<LeftMouse><0,0>')
-    feed('<LeftRelease><0,0>')
-    feed('<LeftMouse><0,0>')
-    feed('<LeftRelease><0,0>')
-    feed('<LeftMouse><0,0>')
-    feed('<LeftRelease><0,0>')
-    screen:expect({
-      any = {
-        '%^t{17:esting}',
-        'VISUAL LINE',
-      },
-    })
-  end)
-
-  it('quadruple left click enters visual block mode', function()
-    feed('<LeftMouse><0,0>')
-    feed('<LeftRelease><0,0>')
-    feed('<LeftMouse><0,0>')
-    feed('<LeftRelease><0,0>')
-    feed('<LeftMouse><0,0>')
-    feed('<LeftRelease><0,0>')
-    feed('<LeftMouse><0,0>')
-    feed('<LeftRelease><0,0>')
-    screen:expect({
-      any = {
-        '%^testing',
-        'VISUAL BLOCK',
-      },
-    })
-  end)
-
-  describe('tab drag', function()
-    it('in tabline on filler space moves tab to the end', function()
-      feed_command('%delete')
-      insert('this is foo')
-      feed_command('silent file foo | tabnew | file bar')
-      insert('this is bar')
-      screen:expect({
-        any = {
-          '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-          'this is ba%^r{1:%$}',
+      screen = Screen.new(25, 5, { ext_multigrid = multigrid })
+      screen:add_extra_attr_ids {
+        [100] = {
+          bold = true,
+          background = Screen.colors.LightGrey,
+          foreground = Screen.colors.Blue1,
         },
-      })
-      feed('<LeftMouse><4,0>')
+      }
+      command('set mousemodel=extend')
+      feed('itesting<cr>mouse<cr>support and selection<esc>')
       screen:expect({
         any = {
-          '{5: %+ foo }{24: %+ bar }{2:          }{24:X}',
-          'this is fo%^o',
-        },
-      })
-      feed('<LeftDrag><14,0>')
-      screen:expect({
-        any = {
-          '{24: %+ bar }{5: %+ foo }{2:          }{24:X}',
-          'this is fo%^o',
+          'testing                  ',
+          'mouse                    ',
+          'support and selectio%^n    ',
         },
       })
     end)
 
-    it('in tabline to the left moves tab left', function()
-      feed_command('%delete')
-      insert('this is foo')
-      feed_command('silent file foo | tabnew | file bar')
-      insert('this is bar')
+    it('single left click moves cursor', function()
+      feed('<LeftMouse><2,1>')
       screen:expect({
-        any = {
-          '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-          'this is ba%^r{1:%$}',
-        },
+        any = 'mo%^use',
+        mouse_enabled = true,
       })
-      feed('<LeftMouse><11,0>')
-      -- Prevent the case where screen:expect() with "unchanged" returns too early,
-      -- causing the click position to be overwritten by the next drag.
-      poke_eventloop()
+      feed('<LeftMouse><0,0>')
       screen:expect({
-        any = {
-          '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-          'this is ba%^r{1:%$}',
-        },
-        unchanged = true,
+        any = '%^testing',
       })
-      feed('<LeftDrag><6,0>')
+    end)
+
+    it("in external ui works with unset 'mouse'", function()
+      api.nvim_set_option_value('mouse', '', {})
+      feed('<LeftMouse><2,1>')
+      screen:expect({
+        any = 'mo%^use',
+        mouse_enabled = false,
+      })
+      feed('<LeftMouse><0,0>')
+      screen:expect({
+        any = '%^testing',
+      })
+    end)
+
+    it('double left click enters visual mode', function()
+      feed('<LeftMouse><0,0>')
+      feed('<LeftRelease><0,0>')
+      feed('<LeftMouse><0,0>')
+      feed('<LeftRelease><0,0>')
       screen:expect({
         any = {
-          '{5: %+ bar }{24: %+ foo }{2:          }{24:X}',
-          'this is ba%^r{1:%$}',
+          '{17:testin}%^g',
+          'VISUAL',
         },
       })
     end)
 
-    it('in tabline to the right moves tab right', function()
-      feed_command('%delete')
-      insert('this is foo')
-      feed_command('silent file foo | tabnew | file bar')
-      insert('this is bar')
+    it('triple left click enters visual line mode', function()
+      feed('<LeftMouse><0,0>')
+      feed('<LeftRelease><0,0>')
+      feed('<LeftMouse><0,0>')
+      feed('<LeftRelease><0,0>')
+      feed('<LeftMouse><0,0>')
+      feed('<LeftRelease><0,0>')
       screen:expect({
         any = {
-          '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-          'this is ba%^r{1:%$}',
-        },
-      })
-      feed('<LeftMouse><4,0>')
-      screen:expect({
-        any = {
-          '{5: %+ foo }{24: %+ bar }{2:          }{24:X}',
-          'this is fo%^o',
-        },
-      })
-      feed('<LeftDrag><7,0>')
-      screen:expect({
-        any = {
-          '{24: %+ bar }{5: %+ foo }{2:          }{24:X}',
-          'this is fo%^o',
+          '%^t{17:esting}',
+          'VISUAL LINE',
         },
       })
     end)
 
-    it('out of tabline under filler space moves tab to the end', function()
-      feed_command('%delete')
-      insert('this is foo')
-      feed_command('silent file foo | tabnew | file bar')
-      insert('this is bar')
+    it('quadruple left click enters visual block mode', function()
+      feed('<LeftMouse><0,0>')
+      feed('<LeftRelease><0,0>')
+      feed('<LeftMouse><0,0>')
+      feed('<LeftRelease><0,0>')
+      feed('<LeftMouse><0,0>')
+      feed('<LeftRelease><0,0>')
+      feed('<LeftMouse><0,0>')
+      feed('<LeftRelease><0,0>')
       screen:expect({
         any = {
-          '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-          'this is ba%^r{1:%$}',
+          '%^testing',
+          'VISUAL BLOCK',
         },
       })
-      feed('<LeftMouse><4,0>')
+    end)
+
+    describe('tab drag', function()
+      it('in tabline on filler space moves tab to the end', function()
+        feed_command('%delete')
+        insert('this is foo')
+        feed_command('silent file foo | tabnew | file bar')
+        insert('this is bar')
+        screen:expect({
+          any = {
+            '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
+            'this is ba%^r{1:%$}',
+          },
+        })
+        feed('<LeftMouse><4,0>')
+        screen:expect({
+          any = {
+            '{5: %+ foo }{24: %+ bar }{2:          }{24:X}',
+            'this is fo%^o',
+          },
+        })
+        feed('<LeftDrag><14,0>')
+        screen:expect({
+          any = {
+            '{24: %+ bar }{5: %+ foo }{2:          }{24:X}',
+            'this is fo%^o',
+          },
+        })
+      end)
+
+      it('in tabline to the left moves tab left', function()
+        feed_command('%delete')
+        insert('this is foo')
+        feed_command('silent file foo | tabnew | file bar')
+        insert('this is bar')
+        screen:expect({
+          any = {
+            '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
+            'this is ba%^r{1:%$}',
+          },
+        })
+        feed('<LeftMouse><11,0>')
+        -- Prevent the case where screen:expect() with "unchanged" returns too early,
+        -- causing the click position to be overwritten by the next drag.
+        poke_eventloop()
+        screen:expect({
+          any = {
+            '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
+            'this is ba%^r{1:%$}',
+          },
+          unchanged = true,
+        })
+        feed('<LeftDrag><6,0>')
+        screen:expect({
+          any = {
+            '{5: %+ bar }{24: %+ foo }{2:          }{24:X}',
+            'this is ba%^r{1:%$}',
+          },
+        })
+      end)
+
+      it('in tabline to the right moves tab right', function()
+        feed_command('%delete')
+        insert('this is foo')
+        feed_command('silent file foo | tabnew | file bar')
+        insert('this is bar')
+        screen:expect({
+          any = {
+            '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
+            'this is ba%^r{1:%$}',
+          },
+        })
+        feed('<LeftMouse><4,0>')
+        screen:expect({
+          any = {
+            '{5: %+ foo }{24: %+ bar }{2:          }{24:X}',
+            'this is fo%^o',
+          },
+        })
+        feed('<LeftDrag><7,0>')
+        screen:expect({
+          any = {
+            '{24: %+ bar }{5: %+ foo }{2:          }{24:X}',
+            'this is fo%^o',
+          },
+        })
+      end)
+
+      it('out of tabline under filler space moves tab to the end', function()
+        feed_command('%delete')
+        insert('this is foo')
+        feed_command('silent file foo | tabnew | file bar')
+        insert('this is bar')
+        screen:expect({
+          any = {
+            '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
+            'this is ba%^r{1:%$}',
+          },
+        })
+        feed('<LeftMouse><4,0>')
+        screen:expect({
+          any = {
+            '{5: %+ foo }{24: %+ bar }{2:          }{24:X}',
+            'this is fo%^o',
+          },
+        })
+        feed('<LeftDrag><4,1>')
+        screen:expect({
+          any = {
+            '{5: %+ foo }{24: %+ bar }{2:          }{24:X}',
+            'this is fo%^o',
+          },
+          unchanged = true,
+        })
+        feed('<LeftDrag><14,1>')
+        screen:expect({
+          any = {
+            '{24: %+ bar }{5: %+ foo }{2:          }{24:X}',
+            'this is fo%^o',
+          },
+        })
+      end)
+
+      it('out of tabline to the left moves tab left', function()
+        feed_command('%delete')
+        insert('this is foo')
+        feed_command('silent file foo | tabnew | file bar')
+        insert('this is bar')
+        screen:expect({
+          any = {
+            '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
+            'this is ba%^r{1:%$}',
+          },
+        })
+        feed('<LeftMouse><11,0>')
+        -- Prevent the case where screen:expect() with "unchanged" returns too early,
+        -- causing the click position to be overwritten by the next drag.
+        poke_eventloop()
+        screen:expect({
+          any = {
+            '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
+            'this is ba%^r{1:%$}',
+          },
+          unchanged = true,
+        })
+        feed('<LeftDrag><11,1>')
+        screen:expect({
+          any = {
+            '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
+            'this is ba%^r{1:%$}',
+          },
+          unchanged = true,
+        })
+        feed('<LeftDrag><6,1>')
+        screen:expect({
+          any = {
+            '{5: %+ bar }{24: %+ foo }{2:          }{24:X}',
+            'this is ba%^r{1:%$}',
+          },
+        })
+      end)
+
+      it('out of tabline to the right moves tab right', function()
+        feed_command('%delete')
+        insert('this is foo')
+        feed_command('silent file foo | tabnew | file bar')
+        insert('this is bar')
+        screen:expect({
+          any = {
+            '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
+            'this is ba%^r{1:%$}',
+          },
+        })
+        feed('<LeftMouse><4,0>')
+        screen:expect({
+          any = {
+            '{5: %+ foo }{24: %+ bar }{2:          }{24:X}',
+            'this is fo%^o',
+          },
+        })
+        feed('<LeftDrag><4,1>')
+        screen:expect({
+          any = {
+            '{5: %+ foo }{24: %+ bar }{2:          }{24:X}',
+            'this is fo%^o',
+          },
+          unchanged = true,
+        })
+        feed('<LeftDrag><7,1>')
+        screen:expect({
+          any = {
+            '{24: %+ bar }{5: %+ foo }{2:          }{24:X}',
+            'this is fo%^o',
+          },
+        })
+      end)
+    end)
+
+    describe('tabline', function()
+      it('left click in default tabline (tabpage label) switches to tab', function()
+        feed_command('%delete')
+        insert('this is foo')
+        feed_command('silent file foo | tabnew | file bar')
+        insert('this is bar')
+        screen:expect({
+          any = {
+            '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
+            'this is ba%^r{1:%$}',
+          },
+        })
+        feed('<LeftMouse><4,0>')
+        screen:expect({
+          any = {
+            '{5: %+ foo }{24: %+ bar }{2:          }{24:X}',
+            'this is fo%^o',
+          },
+        })
+        feed('<LeftMouse><6,0>')
+        screen:expect_unchanged()
+        feed('<LeftMouse><10,0>')
+        screen:expect({
+          any = {
+            '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
+            'this is ba%^r{1:%$}',
+          },
+        })
+        feed('<LeftMouse><12,0>')
+        screen:expect_unchanged()
+      end)
+
+      it('left click in default tabline (blank space) switches tab', function()
+        feed_command('%delete')
+        insert('this is foo')
+        feed_command('silent file foo | tabnew | file bar')
+        insert('this is bar')
+        screen:expect({
+          any = {
+            '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
+            'this is ba%^r{1:%$}',
+          },
+        })
+        feed('<LeftMouse><20,0>')
+        screen:expect({
+          any = {
+            '{5: %+ foo }{24: %+ bar }{2:          }{24:X}',
+            'this is fo%^o',
+          },
+        })
+        feed('<LeftMouse><22,0>')
+        screen:expect({
+          any = {
+            '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
+            'this is ba%^r{1:%$}',
+          },
+        })
+      end)
+
+      it('left click in default tabline (close label) closes tab', function()
+        api.nvim_set_option_value('hidden', true, {})
+        feed_command('%delete')
+        insert('this is foo')
+        feed_command('silent file foo | tabnew | file bar')
+        insert('this is bar')
+        screen:expect({
+          any = {
+            '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
+            'this is ba%^r{1:%$}',
+          },
+        })
+        feed('<LeftMouse><24,0>')
+        screen:expect({
+          any = {
+            'this is fo%^o',
+          },
+          none = {
+            '{24:X}',
+            '%+ foo',
+            '%+ bar',
+          },
+        })
+      end)
+
+      it('double click in default tabline opens new tab before', function()
+        feed_command('%delete')
+        insert('this is foo')
+        feed_command('silent file foo | tabnew | file bar')
+        insert('this is bar')
+        screen:expect({
+          any = {
+            '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
+            'this is ba%^r{1:%$}',
+          },
+        })
+        feed('<2-LeftMouse><4,0>')
+        screen:expect({
+          any = {
+            '{5:  Name] }{24: %+ foo  %+ bar }{2:  }{24:X}|',
+            '{1:%^$}',
+          },
+        })
+        command('tabclose')
+        screen:expect({
+          any = {
+            '{5: %+ foo }{24: %+ bar }{2:          }{24:X}|',
+            'this is fo%^o',
+          },
+        })
+        feed('<2-LeftMouse><20,0>')
+        screen:expect({
+          any = {
+            '{24: %+ foo  %+ bar }{5:  Name] }{2:  }{24:X}',
+            '{1:%^$}',
+          },
+        })
+        command('tabclose')
+        screen:expect({
+          any = {
+            '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
+            'this is ba%^r{1:$}',
+          },
+        })
+        feed('<2-LeftMouse><10,0>')
+        screen:expect({
+          any = {
+            '{24: %+ foo }{5:  Name] }{24: %+ bar }{2:  }{24:X}',
+            '{1:%^$}',
+          },
+        })
+      end)
+
+      describe('%@ label', function()
+        before_each(function()
+          feed_command([[
+            function Test(...)
+              let g:reply = a:000
+              return copy(a:000)  " Check for memory leaks: return should be freed
+            endfunction
+          ]])
+          feed_command([[
+            function Test2(...)
+              return call('Test', a:000 + [2])
+            endfunction
+          ]])
+          api.nvim_set_option_value('tabline', '%@Test@test%X-%5@Test2@test2', {})
+          api.nvim_set_option_value('showtabline', 2, {})
+          screen:expect({
+            any = {
+              '{2:test%-test2               }',
+              'testing',
+              'mouse',
+              'support and selectio%^n',
+            },
+          })
+          api.nvim_set_var('reply', {})
+        end)
+
+        local check_reply = function(expected)
+          eq(expected, api.nvim_get_var('reply'))
+          api.nvim_set_var('reply', {})
+        end
+
+        local test_click = function(name, click_str, click_num, mouse_button, modifiers)
+          local function doit(do_click)
+            eq(1, fn.has('tablineat'))
+            do_click(0, 3)
+            check_reply({ 0, click_num, mouse_button, modifiers })
+            do_click(0, 4)
+            check_reply({})
+            do_click(0, 6)
+            check_reply({ 5, click_num, mouse_button, modifiers, 2 })
+            do_click(0, 13)
+            check_reply({ 5, click_num, mouse_button, modifiers, 2 })
+          end
+
+          it(name .. ' works (pseudokey)', function()
+            doit(function(row, col)
+              feed(click_str .. '<' .. col .. ',' .. row .. '>')
+            end)
+          end)
+
+          it(name .. ' works (nvim_input_mouse)', function()
+            doit(function(row, col)
+              local buttons = { l = 'left', m = 'middle', r = 'right' }
+              local modstr = (click_num > 1) and tostring(click_num) or ''
+              for char in string.gmatch(modifiers, '%w') do
+                modstr = modstr .. char .. '-' -- - not needed but should be accepted
+              end
+              api.nvim_input_mouse(buttons[mouse_button], 'press', modstr, 0, row, col)
+            end)
+          end)
+        end
+
+        test_click('single left click', '<LeftMouse>', 1, 'l', '    ')
+        test_click('shifted single left click', '<S-LeftMouse>', 1, 'l', 's   ')
+        test_click('shifted single left click with alt modifier', '<S-A-LeftMouse>', 1, 'l', 's a ')
+        test_click(
+          'shifted single left click with alt and ctrl modifiers',
+          '<S-C-A-LeftMouse>',
+          1,
+          'l',
+          'sca '
+        )
+        -- <C-RightMouse> does not work
+        test_click(
+          'shifted single right click with alt modifier',
+          '<S-A-RightMouse>',
+          1,
+          'r',
+          's a '
+        )
+        -- Modifiers do not work with MiddleMouse
+        test_click(
+          'shifted single middle click with alt and ctrl modifiers',
+          '<MiddleMouse>',
+          1,
+          'm',
+          '    '
+        )
+        -- Modifiers do not work with N-*Mouse
+        test_click('double left click', '<2-LeftMouse>', 2, 'l', '    ')
+        test_click('triple left click', '<3-LeftMouse>', 3, 'l', '    ')
+        test_click('quadruple left click', '<4-LeftMouse>', 4, 'l', '    ')
+        test_click('double right click', '<2-RightMouse>', 2, 'r', '    ')
+        test_click('triple right click', '<3-RightMouse>', 3, 'r', '    ')
+        test_click('quadruple right click', '<4-RightMouse>', 4, 'r', '    ')
+        test_click('double middle click', '<2-MiddleMouse>', 2, 'm', '    ')
+        test_click('triple middle click', '<3-MiddleMouse>', 3, 'm', '    ')
+        test_click('quadruple middle click', '<4-MiddleMouse>', 4, 'm', '    ')
+      end)
+    end)
+
+    it('left drag changes visual selection', function()
+      -- drag events must be preceded by a click
+      feed('<LeftMouse><2,1>')
       screen:expect({
         any = {
-          '{5: %+ foo }{24: %+ bar }{2:          }{24:X}',
-          'this is fo%^o',
+          'testing',
+          'mo%^use',
+          'support and selection',
         },
       })
       feed('<LeftDrag><4,1>')
       screen:expect({
         any = {
-          '{5: %+ foo }{24: %+ bar }{2:          }{24:X}',
-          'this is fo%^o',
+          'testing',
+          'mo{17:us}%^e',
+          'support and selection',
+          'VISUAL',
         },
-        unchanged = true,
       })
-      feed('<LeftDrag><14,1>')
+      feed('<LeftDrag><2,2>')
       screen:expect({
         any = {
-          '{24: %+ bar }{5: %+ foo }{2:          }{24:X}',
-          'this is fo%^o',
+          'testing',
+          'mo{17:use}',
+          '{17:su}%^pport and selection',
+          'VISUAL',
+        },
+      })
+      feed('<LeftDrag><0,0>')
+      screen:expect({
+        any = {
+          '%^t{17:esting}',
+          '{17:mou}se ',
+          'support and selection',
+          'VISUAL',
         },
       })
     end)
 
-    it('out of tabline to the left moves tab left', function()
-      feed_command('%delete')
-      insert('this is foo')
+    it('left drag changes visual selection after tab click', function()
       feed_command('silent file foo | tabnew | file bar')
       insert('this is bar')
-      screen:expect({
-        any = {
-          '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-          'this is ba%^r{1:%$}',
-        },
-      })
-      feed('<LeftMouse><11,0>')
-      -- Prevent the case where screen:expect() with "unchanged" returns too early,
-      -- causing the click position to be overwritten by the next drag.
-      poke_eventloop()
-      screen:expect({
-        any = {
-          '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-          'this is ba%^r{1:%$}',
-        },
-        unchanged = true,
-      })
-      feed('<LeftDrag><11,1>')
-      screen:expect({
-        any = {
-          '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-          'this is ba%^r{1:%$}',
-        },
-        unchanged = true,
-      })
-      feed('<LeftDrag><6,1>')
-      screen:expect({
-        any = {
-          '{5: %+ bar }{24: %+ foo }{2:          }{24:X}',
-          'this is ba%^r{1:%$}',
-        },
-      })
-    end)
-
-    it('out of tabline to the right moves tab right', function()
-      feed_command('%delete')
-      insert('this is foo')
-      feed_command('silent file foo | tabnew | file bar')
-      insert('this is bar')
-      screen:expect({
-        any = {
-          '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-          'this is ba%^r{1:%$}',
-        },
-      })
-      feed('<LeftMouse><4,0>')
-      screen:expect({
-        any = {
-          '{5: %+ foo }{24: %+ bar }{2:          }{24:X}',
-          'this is fo%^o',
-        },
-      })
-      feed('<LeftDrag><4,1>')
-      screen:expect({
-        any = {
-          '{5: %+ foo }{24: %+ bar }{2:          }{24:X}',
-          'this is fo%^o',
-        },
-        unchanged = true,
-      })
-      feed('<LeftDrag><7,1>')
-      screen:expect({
-        any = {
-          '{24: %+ bar }{5: %+ foo }{2:          }{24:X}',
-          'this is fo%^o',
-        },
-      })
-    end)
-  end)
-
-  describe('tabline', function()
-    it('left click in default tabline (tabpage label) switches to tab', function()
-      feed_command('%delete')
-      insert('this is foo')
-      feed_command('silent file foo | tabnew | file bar')
-      insert('this is bar')
-      screen:expect({
-        any = {
-          '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-          'this is ba%^r{1:%$}',
-        },
-      })
-      feed('<LeftMouse><4,0>')
-      screen:expect({
-        any = {
-          '{5: %+ foo }{24: %+ bar }{2:          }{24:X}',
-          'this is fo%^o',
-        },
-      })
-      feed('<LeftMouse><6,0>')
-      screen:expect_unchanged()
-      feed('<LeftMouse><10,0>')
-      screen:expect({
-        any = {
-          '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-          'this is ba%^r{1:%$}',
-        },
-      })
-      feed('<LeftMouse><12,0>')
-      screen:expect_unchanged()
-    end)
-
-    it('left click in default tabline (blank space) switches tab', function()
-      feed_command('%delete')
-      insert('this is foo')
-      feed_command('silent file foo | tabnew | file bar')
-      insert('this is bar')
-      screen:expect({
-        any = {
-          '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-          'this is ba%^r{1:%$}',
-        },
-      })
-      feed('<LeftMouse><20,0>')
-      screen:expect({
-        any = {
-          '{5: %+ foo }{24: %+ bar }{2:          }{24:X}',
-          'this is fo%^o',
-        },
-      })
-      feed('<LeftMouse><22,0>')
-      screen:expect({
-        any = {
-          '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-          'this is ba%^r{1:%$}',
-        },
-      })
-    end)
-
-    it('left click in default tabline (close label) closes tab', function()
-      api.nvim_set_option_value('hidden', true, {})
-      feed_command('%delete')
-      insert('this is foo')
-      feed_command('silent file foo | tabnew | file bar')
-      insert('this is bar')
-      screen:expect({
-        any = {
-          '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-          'this is ba%^r{1:%$}',
-        },
-      })
-      feed('<LeftMouse><24,0>')
-      screen:expect({
-        any = {
-          'this is fo%^o',
-        },
-        none = {
-          '{24:X}',
-          '%+ foo',
-          '%+ bar',
-        },
-      })
-    end)
-
-    it('double click in default tabline opens new tab before', function()
-      feed_command('%delete')
-      insert('this is foo')
-      feed_command('silent file foo | tabnew | file bar')
-      insert('this is bar')
-      screen:expect({
-        any = {
-          '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-          'this is ba%^r{1:%$}',
-        },
-      })
-      feed('<2-LeftMouse><4,0>')
-      screen:expect({
-        any = {
-          '{5:  Name] }{24: %+ foo  %+ bar }{2:  }{24:X}|',
-          '{1:%^$}',
-        },
-      })
-      command('tabclose')
+      feed_command('tabprevious') -- go to first tab
       screen:expect({
         any = {
           '{5: %+ foo }{24: %+ bar }{2:          }{24:X}|',
-          'this is fo%^o',
+          'testing',
+          'mouse',
+          'support and selectio%^n',
+          ':tabprevious',
         },
       })
-      feed('<2-LeftMouse><20,0>')
-      screen:expect({
-        any = {
-          '{24: %+ foo  %+ bar }{5:  Name] }{2:  }{24:X}',
-          '{1:%^$}',
-        },
-      })
-      command('tabclose')
+      feed('<LeftMouse><10,0><LeftRelease>') -- go to second tab
+      n.poke_eventloop()
+      feed('<LeftMouse><0,1>')
+      -- This text is hidden when using multigrid
+      local none = {
+        'mouse',
+        'support and selection',
+      }
+      if multigrid then
+        none = nil
+      end
       screen:expect({
         any = {
           '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-          'this is ba%^r{1:$}',
+          '%^this is bar{1:%$}',
+          ':tabprevious',
         },
+        none = none,
       })
-      feed('<2-LeftMouse><10,0>')
+      feed('<LeftDrag><4,1>')
       screen:expect({
         any = {
-          '{24: %+ foo }{5:  Name] }{24: %+ bar }{2:  }{24:X}',
-          '{1:%^$}',
+          '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
+          '{17:this}%^ is bar{1:%$}',
+          'VISUAL',
         },
       })
     end)
 
-    describe('%@ label', function()
-      before_each(function()
-        feed_command([[
-          function Test(...)
-            let g:reply = a:000
-            return copy(a:000)  " Check for memory leaks: return should be freed
-          endfunction
-        ]])
-        feed_command([[
-          function Test2(...)
-            return call('Test', a:000 + [2])
-          endfunction
-        ]])
-        api.nvim_set_option_value('tabline', '%@Test@test%X-%5@Test2@test2', {})
-        api.nvim_set_option_value('showtabline', 2, {})
+    it('left drag changes visual selection in split layout', function()
+      screen:try_resize(53, 14)
+      command('set mouse=a')
+      command('vsplit')
+      command('wincmd l')
+      command('below split')
+      command('enew')
+      feed('ifoo\nbar<esc>')
+      screen:expect({
+        any = {
+          'foo{1:%$}',
+          'ba%^r{1:%$}',
+        },
+      })
+      api.nvim_input_mouse('left', 'press', '', 0, 6, 27)
+      screen:expect({
+        any = {
+          '%^foo{1:%$}',
+          'bar{1:%$}',
+        },
+      })
+      api.nvim_input_mouse('left', 'drag', '', 0, 7, 30)
+      screen:expect({
+        any = {
+          '{17:foo}{100:%$}',
+          '{17:bar}{1:%^%$}',
+          'VISUAL',
+        },
+      })
+    end)
+
+    it('two clicks will enter VISUAL and dragging selects words', function()
+      feed('<LeftMouse><2,2>')
+      feed('<LeftRelease><2,2>')
+      feed('<LeftMouse><2,2>')
+      screen:expect({
+        any = {
+          'testing',
+          'mouse',
+          '{17:suppor}%^t and selection',
+          'VISUAL',
+        },
+      })
+      feed('<LeftDrag><0,1>')
+      screen:expect({
+        any = {
+          'testing',
+          '%^m{17:ouse}',
+          '{17:support} and selection',
+          'VISUAL',
+        },
+      })
+      feed('<LeftDrag><4,0>')
+      screen:expect({
+        any = {
+          '%^t{17:esting}',
+          '{17:mouse}',
+          '{17:support} and selection',
+          'VISUAL',
+        },
+      })
+      feed('<LeftDrag><14,2>')
+      screen:expect({
+        any = {
+          'testing',
+          'mouse',
+          '{17:support and selectio}%^n',
+          'VISUAL',
+        },
+      })
+    end)
+
+    it('three clicks will enter VISUAL LINE and dragging selects lines', function()
+      feed('<LeftMouse><2,2>')
+      feed('<LeftRelease><2,2>')
+      feed('<LeftMouse><2,2>')
+      feed('<LeftRelease><2,2>')
+      feed('<LeftMouse><2,2>')
+      screen:expect({
+        any = {
+          'testing',
+          'mouse',
+          '{17:su}%^p{17:port and selection}',
+          'VISUAL LINE',
+        },
+      })
+      feed('<LeftDrag><0,1>')
+      screen:expect({
+        any = {
+          'testing',
+          '%^m{17:ouse}',
+          '{17:support and selection}',
+          'VISUAL LINE',
+        },
+      })
+      feed('<LeftDrag><4,0>')
+      screen:expect({
+        any = {
+          '{17:test}%^i{17:ng}',
+          '{17:mouse}',
+          '{17:support and selection}',
+          'VISUAL LINE',
+        },
+      })
+      feed('<LeftDrag><14,2>')
+      screen:expect({
+        any = {
+          'testing',
+          'mouse',
+          '{17:support and se}%^l{17:ection}',
+          'VISUAL LINE',
+        },
+      })
+    end)
+
+    it('four clicks will enter VISUAL BLOCK and dragging selects blockwise', function()
+      feed('<LeftMouse><2,2>')
+      feed('<LeftRelease><2,2>')
+      feed('<LeftMouse><2,2>')
+      feed('<LeftRelease><2,2>')
+      feed('<LeftMouse><2,2>')
+      feed('<LeftRelease><2,2>')
+      feed('<LeftMouse><2,2>')
+      screen:expect({
+        any = {
+          'testing',
+          'mouse',
+          'su%^pport and selection',
+          'VISUAL BLOCK',
+        },
+      })
+      feed('<LeftDrag><0,1>')
+      screen:expect({
+        any = {
+          'testing',
+          '%^m{17:ou}se',
+          '{17:sup}port and selection',
+          'VISUAL BLOCK',
+        },
+      })
+      feed('<LeftDrag><4,0>')
+      screen:expect({
+        any = {
+          'te{17:st}%^ing',
+          'mo{17:use}',
+          'su{17:ppo}rt and selection',
+          'VISUAL BLOCK',
+        },
+      })
+      feed('<LeftDrag><14,2>')
+      screen:expect({
+        any = {
+          'testing',
+          'mouse',
+          'su{17:pport and se}%^lection',
+          'VISUAL BLOCK',
+        },
+      })
+    end)
+
+    it('right click extends visual selection to the clicked location', function()
+      feed('<LeftMouse><0,0>')
+      screen:expect({
+        any = {
+          '%^testing',
+          'mouse',
+          'support and selection',
+        },
+      })
+      feed('<RightMouse><2,2>')
+      screen:expect({
+        any = {
+          '{17:testing}',
+          '{17:mouse}',
+          '{17:su}^pport and selection',
+          'VISUAL',
+        },
+      })
+    end)
+
+    it('ctrl + left click will search for a tag', function()
+      api.nvim_set_option_value('tags', './non-existent-tags-file', {})
+      feed('<C-LeftMouse><0,0>')
+      screen:expect({
+        any = {
+          '{9:E433: No tags file}',
+          '{9:E426: Tag not found: test}',
+          '{9:ing}',
+          '{6:Press ENTER or type comma}',
+          '{6:nd to continue}%^',
+        },
+      })
+      feed('<cr>')
+    end)
+
+    it('x1 and x2 can be triggered by api', function()
+      api.nvim_set_var('x1_pressed', 0)
+      api.nvim_set_var('x1_released', 0)
+      api.nvim_set_var('x2_pressed', 0)
+      api.nvim_set_var('x2_released', 0)
+      command('nnoremap <X1Mouse> <Cmd>let g:x1_pressed += 1<CR>')
+      command('nnoremap <X1Release> <Cmd>let g:x1_released += 1<CR>')
+      command('nnoremap <X2Mouse> <Cmd>let g:x2_pressed += 1<CR>')
+      command('nnoremap <X2Release> <Cmd>let g:x2_released += 1<CR>')
+      api.nvim_input_mouse('x1', 'press', '', 0, 0, 0)
+      api.nvim_input_mouse('x1', 'release', '', 0, 0, 0)
+      api.nvim_input_mouse('x2', 'press', '', 0, 0, 0)
+      api.nvim_input_mouse('x2', 'release', '', 0, 0, 0)
+      eq(1, api.nvim_get_var('x1_pressed'), 'x1 pressed once')
+      eq(1, api.nvim_get_var('x1_released'), 'x1 released once')
+      eq(1, api.nvim_get_var('x2_pressed'), 'x2 pressed once')
+      eq(1, api.nvim_get_var('x2_released'), 'x2 released once')
+    end)
+
+    it('dragging vertical separator', function()
+      screen:try_resize(45, 5)
+      command('setlocal nowrap')
+      local oldwin = api.nvim_get_current_win()
+      command('rightbelow vnew')
+      screen:expect({
+        any = {
+          'testing               ',
+          'mouse                 ',
+          'support and selection ',
+          '{1:%^%$}                     ',
+          '{2:%[No Name%] %[%+%]          }{3:%[No Name%]             }',
+        },
+      })
+      api.nvim_input_mouse('left', 'press', '', 0, 0, 22)
+      poke_eventloop()
+      api.nvim_input_mouse('left', 'drag', '', 0, 1, 12)
+      screen:expect({
+        any = {
+          'testing     ',
+          'mouse       ',
+          'support and ',
+          '{1:%^$}                               ',
+          '{2:< Name%] %[%+%]  }{3:%[No Name%]                       }',
+        },
+      })
+      api.nvim_input_mouse('left', 'drag', '', 0, 2, 2)
+      screen:expect({
+        any = {
+          'te',
+          'mo',
+          'su',
+          '{1:%^%$}                                         ',
+          '{2:<  }{3:%[No Name%]                                 }',
+        },
+      })
+      api.nvim_input_mouse('left', 'release', '', 0, 2, 2)
+      api.nvim_set_option_value('statuscolumn', 'foobar', { win = oldwin })
+      screen:expect({
+        any = {
+          '{8:fo}',
+          '{1:%^%$}                                         ',
+          '{2:<  }{3:%[No Name%]                                 }',
+        },
+      })
+      api.nvim_input_mouse('left', 'press', '', 0, 0, 2)
+      poke_eventloop()
+      api.nvim_input_mouse('left', 'drag', '', 0, 1, 12)
+      screen:expect({
+        any = {
+          '{8:foobar}testin',
+          '{8:foobar}mouse ',
+          '{8:foobar}suppor',
+          '{1:%^%$}                               ',
+          '{2:< Name%] %[%+%]  }{3:%[No Name%]                       }',
+        },
+      })
+      api.nvim_input_mouse('left', 'drag', '', 0, 2, 22)
+      screen:expect({
+        any = {
+          '{8:foobar}testing         ',
+          '{8:foobar}mouse           ',
+          '{8:foobar}support and sele',
+          '{1:%^%$}                     ',
+          '{2:%[No Name%] %[%+%]          }{3:%[No Name%]             }',
+        },
+      })
+      api.nvim_input_mouse('left', 'release', '', 0, 2, 22)
+    end)
+
+    local function wheel(use_api)
+      feed('ggdG')
+      insert([[
+      Inserting
+      text
+      with
+      many
+      lines
+      to
+      test
+      mouse scrolling
+      ]])
+      screen:try_resize(53, 14)
+      feed('k')
+      api.nvim_set_option_value('statuscolumn', 'C', { win = api.nvim_get_current_win() })
+      feed_command('sp')
+      api.nvim_set_option_value('statuscolumn', 'B', { win = api.nvim_get_current_win() })
+      feed_command('vsp')
+      api.nvim_set_option_value('statuscolumn', 'A', { win = api.nvim_get_current_win() })
+      screen:expect({
+        any = {
+          '{8:A}lines                    ',
+          '{8:A}to                       ',
+          '{8:A}test                     ',
+          '{8:A}^mouse scrolling          ',
+          '{8:B}lines                    ',
+          '{8:B}to                       ',
+          '{8:B}test                     ',
+          '{8:B}mouse scrolling          ',
+          '{3:%[No Name%] %[%+%]              }{2:%[No Name%] %[%+%]             }',
+          '{8:C}to                                                  ',
+          '{8:C}test                                                ',
+          '{8:C}mouse scrolling                                     ',
+          '{2:%[No Name%] %[%+%]                                        }',
+        },
+        none = {
+          '{8:A}Inserting',
+          '{8:A}text',
+          '{8:A}with',
+          '{8:A}many',
+          '{8:B}Inserting',
+          '{8:B}text',
+          '{8:B}with',
+          '{8:B}many',
+          '{8:C}Inserting',
+          '{8:C}text',
+          '{8:C}with',
+          '{8:C}many',
+          '{8:C}lines',
+        },
+      })
+      if use_api then
+        api.nvim_input_mouse('wheel', 'down', '', 0, 0, 0)
+      else
+        feed('<ScrollWheelDown><0,0>')
+      end
+      screen:expect({
+        any = {
+          '{8:A}^mouse scrolling          ',
+          '{8:B}lines                    ',
+          '{8:B}to                       ',
+          '{8:B}test                     ',
+          '{8:B}mouse scrolling          ',
+          '{3:%[No Name%] %[%+%]              }{2:%[No Name%] %[%+%]             }',
+          '{8:C}to                                                  ',
+          '{8:C}test                                                ',
+          '{8:C}mouse scrolling                                     ',
+          '{2:%[No Name%] %[%+%]                                        }',
+        },
+        none = {
+          '{8:A}lines',
+          '{8:A}to',
+          '{8:A}test',
+          '{8:B}Inserting',
+          '{8:B}text',
+          '{8:B}with',
+          '{8:B}many',
+          '{8:C}Inserting',
+          '{8:C}text',
+          '{8:C}with',
+          '{8:C}many',
+          '{8:C}lines',
+        },
+      })
+      if use_api then
+        api.nvim_input_mouse('wheel', 'up', '', 0, 0, 27)
+      else
+        feed('<ScrollWheelUp><27,0>')
+      end
+      screen:expect({
+        any = {
+          '{8:A}^mouse scrolling          ',
+          '{8:B}lines                    ',
+          '{8:B}to                       ',
+          '{8:B}test                     ',
+          '{3:%[No Name%] %[%+%]              }{2:%[No Name%] %[%+%]             }',
+          '{8:C}to                                                  ',
+          '{8:C}test                                                ',
+          '{8:C}mouse scrolling                                     ',
+          '{2:%[No Name%] %[%+%]                                        }',
+        },
+        none = {
+          '{8:A}Inserting',
+          '{8:A}text',
+          '{8:A}with',
+          '{8:A}many',
+          '{8:A}lines',
+          '{8:A}to',
+          '{8:A}test',
+          '{8:B}Inserting',
+          '{8:B}mouse scrolling',
+          '{8:C}Inserting',
+          '{8:C}text',
+          '{8:C}with',
+          '{8:C}many',
+          '{8:C}lines',
+        },
+      })
+      if use_api then
+        api.nvim_input_mouse('wheel', 'up', '', 0, 7, 27)
+        api.nvim_input_mouse('wheel', 'up', '', 0, 7, 27)
+      else
+        feed('<ScrollWheelUp><27,7><ScrollWheelUp>')
+      end
+      screen:expect({
+        any = {
+          '{8:A}^mouse scrolling          ',
+          '{8:B}lines                    ',
+          '{8:B}to                       ',
+          '{8:B}test                     ',
+          '{3:%[No Name%] %[%+%]              }{2:%[No Name%] %[%+%]             }',
+          '{8:C}Inserting                                           ',
+          '{8:C}text                                                ',
+          '{8:C}with                                                ',
+          '{8:C}many                                                ',
+          '{8:C}lines                                               ',
+          '{2:%[No Name%] %[%+%]                                        }',
+        },
+        none = {
+          '{8:A}Inserting',
+          '{8:A}text',
+          '{8:A}with',
+          '{8:A}many',
+          '{8:A}lines',
+          '{8:A}to',
+          '{8:A}test',
+          '{8:B}Inserting',
+          '{8:B}mouse scrolling',
+          '{8:C}to',
+          '{8:C}test',
+          '{8:C}mouse scrolling',
+        },
+      })
+    end
+
+    it('mouse wheel will target the hovered window (pseudokey)', function()
+      wheel(false)
+    end)
+
+    it('mouse wheel will target the hovered window (nvim_input_mouse)', function()
+      wheel(true)
+    end)
+
+    it('horizontal scrolling (pseudokey)', function()
+      command('set sidescroll=0')
+      feed('<esc>:set nowrap<cr>')
+
+      feed('a <esc>17Ab<esc>3Ab<esc>')
+      screen:expect({
+        any = {
+          'bbbbbbbbbbbbbbb%^b        ',
+        },
+      })
+
+      feed('<ScrollWheelLeft><0,0>')
+      screen:expect({
+        any = {
+          'n bbbbbbbbbbbbbbbbbbb%^b   ',
+        },
+      })
+
+      feed('^<ScrollWheelRight><0,0>')
+      screen:expect({
+        any = {
+          'g                        ',
+          '%^t and selection bbbbbbbbb',
+        },
+      })
+    end)
+
+    it('horizontal scrolling (nvim_input_mouse)', function()
+      command('set sidescroll=0')
+      feed('<esc>:set nowrap<cr>')
+
+      feed('a <esc>17Ab<esc>3Ab<esc>')
+      screen:expect({
+        any = {
+          'bbbbbbbbbbbbbbb%^b        ',
+        },
+      })
+
+      api.nvim_input_mouse('wheel', 'left', '', 0, 0, 27)
+      screen:expect({
+        any = {
+          'n bbbbbbbbbbbbbbbbbbb%^b   ',
+        },
+      })
+
+      feed('^')
+      api.nvim_input_mouse('wheel', 'right', '', 0, 0, 0)
+      screen:expect({
+        any = {
+          'g                        ',
+          '%^t and selection bbbbbbbbb',
+        },
+      })
+    end)
+
+    it("'sidescrolloff' applies to horizontal scrolling", function()
+      command('set nowrap')
+      command('set sidescrolloff=4')
+
+      feed('I <esc>020ib<esc>0')
+      screen:expect({
+        any = {
+          'testing                  ',
+          'mouse                    ',
+          '%^bbbbbbbbbbbbbbbbbbbb supp',
+        },
+      })
+
+      api.nvim_input_mouse('wheel', 'right', '', 0, 0, 27)
+      screen:expect({
+        any = {
+          'g                        ',
+          '                         ',
+          'bbbb%^bbbbbbbbbb support an',
+        },
+      })
+
+      -- window-local 'sidescrolloff' should override global value. #21162
+      command('setlocal sidescrolloff=2')
+      feed('0')
+      screen:expect({
+        any = {
+          'testing                  ',
+          'mouse                    ',
+          '%^bbbbbbbbbbbbbbbbbbbb supp',
+        },
+      })
+
+      api.nvim_input_mouse('wheel', 'right', '', 0, 0, 27)
+      screen:expect({
+        any = {
+          'g                        ',
+          '                         ',
+          'bb%^bbbbbbbbbbbb support an',
+        },
+      })
+    end)
+
+    local function test_mouse_click_conceal()
+      it('(level 1) click on non-wrapped lines', function()
+        feed_command('let &conceallevel=1', 'echo')
+
+        feed('<esc><LeftMouse><0,0>')
         screen:expect({
           any = {
-            '{2:test%-test2               }',
-            'testing',
-            'mouse',
-            'support and selectio%^n',
+            '%^Section{1:>>--->--->---}{14: }t1{14: } ',
+            '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
+            '{14:>} 私は猫が大好き{1:>---}{14: X } {1:>}',
           },
         })
-        api.nvim_set_var('reply', {})
+
+        feed('<esc><LeftMouse><1,0>')
+        screen:expect({
+          any = {
+            'S%^ection{1:>>--->--->---}{14: }t1{14: } ',
+            '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
+            '{14:>} 私は猫が大好き{1:>---}{14: X } {1:>}',
+          },
+        })
+
+        feed('<esc><LeftMouse><21,0>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}{14: }%^t1{14: } ',
+            '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
+            '{14:>} 私は猫が大好き{1:>---}{14: X } {1:>}',
+          },
+        })
+
+        feed('<esc><LeftMouse><21,1>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}{14: }t1{14: } ',
+            '{1:>--->--->---}  {14: }t2{14: } {14: }t%^3{14: } {14: }',
+            '{14:>} 私は猫が大好き{1:>---}{14: X } {1:>}',
+          },
+        })
+
+        feed('<esc><LeftMouse><0,2>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}{14: }t1{14: } ',
+            '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
+            '{14:%^>} 私は猫が大好き{1:>---}{14: X } {1:>}',
+          },
+        })
+
+        feed('<esc><LeftMouse><7,2>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}{14: }t1{14: } ',
+            '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
+            '{14:>} 私は%^猫が大好き{1:>---}{14: X } {1:>}',
+          },
+        })
+
+        feed('<esc><LeftMouse><21,2>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}{14: }t1{14: } ',
+            '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
+            '{14:>} 私は猫が大好き{1:>---}{14: %^X } {1:>}',
+          },
+        })
+      end) -- level 1 - non wrapped
+
+      it('(level 1) click on wrapped lines', function()
+        feed_command('let &conceallevel=1', 'let &wrap=1', 'echo')
+
+        feed('<esc><LeftMouse><24,1>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}{14: }t1{14: } ',
+            '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14:%^ }',
+            't4{14: }                      ',
+            '{14:>} 私は猫が大好き{1:>---}{14: X}   ',
+            '{14: } ✨🐈✨                 ',
+          },
+        })
+
+        feed('<esc><LeftMouse><0,2>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}{14: }t1{14: } ',
+            '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
+            '%^t4{14: }                      ',
+            '{14:>} 私は猫が大好き{1:>---}{14: X}   ',
+            '{14: } ✨🐈✨                 ',
+          },
+        })
+
+        feed('<esc><LeftMouse><8,3>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}{14: }t1{14: } ',
+            '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
+            't4{14: }                      ',
+            '{14:>} 私は猫%^が大好き{1:>---}{14: X}   ',
+            '{14: } ✨🐈✨                 ',
+          },
+        })
+
+        feed('<esc><LeftMouse><21,3>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}{14: }t1{14: } ',
+            '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
+            't4{14: }                      ',
+            '{14:>} 私は猫が大好き{1:>---}{14: %^X}   ',
+            '{14: } ✨🐈✨                 ',
+          },
+        })
+
+        feed('<esc><LeftMouse><4,4>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}{14: }t1{14: } ',
+            '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
+            't4{14: }                      ',
+            '{14:>} 私は猫が大好き{1:>---}{14: X}   ',
+            '{14: } ✨%^🐈✨                 ',
+          },
+        })
+      end) -- level 1 - wrapped
+
+      it('(level 2) click on non-wrapped lines', function()
+        feed_command('let &conceallevel=2', 'echo')
+
+        feed('<esc><LeftMouse><20,0>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}%^t1   ',
+            '{1:>--->--->---}  t2 t3 t4   ',
+            '{14:>} 私は猫が大好き{1:>---}{14:X} ✨{1:>}',
+          },
+        })
+
+        feed('<esc><LeftMouse><14,1>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  %^t2 t3 t4   ',
+            '{14:>} 私は猫が大好き{1:>---}{14:X} ✨{1:>}',
+          },
+        })
+
+        feed('<esc><LeftMouse><18,1>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t%^3 t4   ',
+            '{14:>} 私は猫が大好き{1:>---}{14:X} ✨{1:>}',
+          },
+        })
+
+        feed('<esc><LeftMouse><0,2>') -- Weirdness
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3 t4   ',
+            '{14:%^>} 私は猫が大好き{1:>---}{14:X} ✨{1:>}',
+          },
+        })
+
+        feed('<esc><LeftMouse><8,2>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3 t4   ',
+            '{14:>} 私は猫%^が大好き{1:>---}{14:X} ✨{1:>}',
+          },
+        })
+
+        feed('<esc><LeftMouse><20,2>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3 t4   ',
+            '{14:>} 私は猫が大好き{1:>---}{14:%^X} ✨{1:>}',
+          },
+        })
+      end) -- level 2 - non wrapped
+
+      it('(level 2) click on non-wrapped lines (insert mode)', function()
+        feed_command('let &conceallevel=2', 'echo')
+
+        feed('<esc>i<LeftMouse><20,0>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}%^t1   ',
+            '{1:>--->--->---}  t2 t3 t4   ',
+            '{14:>} 私は猫が大好き{1:>---}{14:X} ✨{1:>}',
+          },
+        })
+
+        feed('<LeftMouse><14,1>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  %^t2 t3 t4   ',
+            '{14:>} 私は猫が大好き{1:>---}{14:X} ✨{1:>}',
+          },
+        })
+
+        feed('<LeftMouse><18,1>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t%^3 t4   ',
+            '{14:>} 私は猫が大好き{1:>---}{14:X} ✨{1:>}',
+          },
+        })
+
+        feed('<LeftMouse><0,2>') -- Weirdness
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3 t4   ',
+            '{14:%^>} 私は猫が大好き{1:>---}{14:X} ✨{1:>}',
+          },
+        })
+
+        feed('<LeftMouse><8,2>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3 t4   ',
+            '{14:>} 私は猫%^が大好き{1:>---}{14:X} ✨{1:>}',
+          },
+        })
+
+        feed('<LeftMouse><20,2>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3 t4   ',
+            '{14:>} 私は猫が大好き{1:>---}{14:%^X} ✨{1:>}',
+          },
+        })
+      end) -- level 2 - non wrapped (insert mode)
+
+      it('(level 2) click on wrapped lines', function()
+        feed_command('let &conceallevel=2', 'let &wrap=1', 'echo')
+
+        feed('<esc><LeftMouse><20,0>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}%^t1   ',
+            '{1:>--->--->---}  t2 t3      ',
+            't4                       ',
+            '{14:>} 私は猫が大好き{1:>---}{14:X}    ',
+            ' ✨🐈✨                  ',
+          },
+        })
+
+        feed('<esc><LeftMouse><14,1>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  %^t2 t3      ',
+            't4                       ',
+            '{14:>} 私は猫が大好き{1:>---}{14:X}    ',
+            ' ✨🐈✨                  ',
+          },
+        })
+
+        feed('<esc><LeftMouse><18,1>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t%^3      ',
+            't4                       ',
+            '{14:>} 私は猫が大好き{1:>---}{14:X}    ',
+            ' ✨🐈✨                  ',
+          },
+        })
+
+        -- NOTE: The click would ideally be on the 't' in 't4', but wrapping
+        -- caused the invisible '*' right before 't4' to remain on the previous
+        -- screen line.  This is being treated as expected because fixing this is
+        -- out of scope for mouse clicks.  Should the wrapping behavior of
+        -- concealed characters change in the future, this case should be
+        -- reevaluated.
+        feed('<esc><LeftMouse><0,2>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3 %^     ',
+            't4                       ',
+            '{14:>} 私は猫が大好き{1:>---}{14:X}    ',
+            ' ✨🐈✨                  ',
+          },
+        })
+
+        feed('<esc><LeftMouse><1,2>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3      ',
+            't%^4                       ',
+            '{14:>} 私は猫が大好き{1:>---}{14:X}    ',
+            ' ✨🐈✨                  ',
+          },
+        })
+
+        feed('<esc><LeftMouse><0,3>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3      ',
+            't4                       ',
+            '{14:%^>} 私は猫が大好き{1:>---}{14:X}    ',
+            ' ✨🐈✨                  ',
+          },
+        })
+
+        feed('<esc><LeftMouse><20,3>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3      ',
+            't4                       ',
+            '{14:>} 私は猫が大好き{1:>---}{14:%^X}    ',
+            ' ✨🐈✨                  ',
+          },
+        })
+
+        feed('<esc><LeftMouse><1,4>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3      ',
+            't4                       ',
+            '{14:>} 私は猫が大好き{1:>---}{14:X}    ',
+            '%^✨🐈✨                 ',
+          },
+        })
+
+        feed('<esc><LeftMouse><5,4>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3      ',
+            't4                       ',
+            '{14:>} 私は猫が大好き{1:>---}{14:X}    ',
+            '✨🐈%^✨                  ',
+          },
+        })
+      end) -- level 2 - wrapped
+
+      it('(level 3) click on non-wrapped lines', function()
+        feed_command('let &conceallevel=3', 'echo')
+
+        feed('<esc><LeftMouse><0,2>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3 t4   ',
+            '%^ 私は猫が大好き{1:>----} ✨🐈',
+          },
+        })
+
+        feed('<esc><LeftMouse><1,2>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3 t4   ',
+            ' %^私は猫が大好き{1:>----} ✨🐈',
+          },
+        })
+
+        feed('<esc><LeftMouse><13,2>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3 t4   ',
+            ' 私は猫が大好%^き{1:>----} ✨🐈',
+          },
+        })
+
+        feed('<esc><LeftMouse><20,2>')
+        feed('zH') -- FIXME: unnecessary horizontal scrolling
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3 t4   ',
+            ' 私は猫が大好き{1:>----}%^ ✨🐈',
+          },
+        })
+      end) -- level 3 - non wrapped
+
+      it('(level 3) click on wrapped lines', function()
+        feed_command('let &conceallevel=3', 'let &wrap=1', 'echo')
+
+        feed('<esc><LeftMouse><14,1>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  %^t2 t3      ',
+            't4                       ',
+            ' 私は猫が大好き{1:>----}     ',
+            ' ✨🐈✨                  ',
+          },
+        })
+
+        feed('<esc><LeftMouse><18,1>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t%^3      ',
+            't4                       ',
+            ' 私は猫が大好き{1:>----}     ',
+            ' ✨🐈✨                  ',
+          },
+        })
+
+        feed('<esc><LeftMouse><1,2>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3      ',
+            't%^4                       ',
+            ' 私は猫が大好き{1:>----}     ',
+            ' ✨🐈✨                  ',
+          },
+        })
+
+        feed('<esc><LeftMouse><0,3>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3      ',
+            't4                       ',
+            '%^ 私は猫が大好き{1:>----}     ',
+            ' ✨🐈✨                  ',
+          },
+        })
+
+        feed('<esc><LeftMouse><20,3>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3      ',
+            't4                       ',
+            ' 私は猫が大好き{1:>----}%^     ',
+            ' ✨🐈✨                  ',
+          },
+        })
+
+        feed('<esc><LeftMouse><1,4>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3      ',
+            't4                       ',
+            ' 私は猫が大好き{1:>----}     ',
+            ' %^✨🐈✨                  ',
+          },
+        })
+
+        feed('<esc><LeftMouse><3,4>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3      ',
+            't4                       ',
+            ' 私は猫が大好き{1:>----}     ',
+            ' ✨%^🐈✨                  ',
+          },
+        })
+
+        feed('<esc><LeftMouse><5,4>')
+        screen:expect({
+          any = {
+            'Section{1:>>--->--->---}t1   ',
+            '{1:>--->--->---}  t2 t3      ',
+            't4                       ',
+            ' 私は猫が大好き{1:>----}     ',
+            ' ✨🐈%^✨                  ',
+          },
+        })
+      end) -- level 3 - wrapped
+    end
+
+    describe('on concealed text', function()
+      -- Helpful for reading the test expectations:
+      -- :match Error /\^/
+
+      before_each(function()
+        screen:try_resize(25, 7)
+        feed('ggdG')
+
+        command([[setlocal concealcursor=ni nowrap shiftwidth=2 tabstop=4 list listchars=tab:>-]])
+        command([[highlight link X0 Normal]])
+        command([[highlight link X1 NonText]])
+        command([[highlight link X2 NonText]])
+        command([[highlight link X3 NonText]])
+
+        -- First column is there to retain the tabs.
+        insert([[
+        |Section				*t1*
+        |			  *t2* *t3* *t4*
+        |x 私は猫が大好き	*cats* ✨🐈✨
+        ]])
+
+        feed('gg<c-v>Gxgg')
       end)
 
-      local check_reply = function(expected)
-        eq(expected, api.nvim_get_var('reply'))
-        api.nvim_set_var('reply', {})
-      end
-
-      local test_click = function(name, click_str, click_num, mouse_button, modifiers)
-        local function doit(do_click)
-          eq(1, fn.has('tablineat'))
-          do_click(0, 3)
-          check_reply({ 0, click_num, mouse_button, modifiers })
-          do_click(0, 4)
-          check_reply({})
-          do_click(0, 6)
-          check_reply({ 5, click_num, mouse_button, modifiers, 2 })
-          do_click(0, 13)
-          check_reply({ 5, click_num, mouse_button, modifiers, 2 })
-        end
-
-        it(name .. ' works (pseudokey)', function()
-          doit(function(row, col)
-            feed(click_str .. '<' .. col .. ',' .. row .. '>')
-          end)
+      describe('(syntax)', function()
+        before_each(function()
+          command([[syntax region X0 matchgroup=X1 start=/\*/ end=/\*/ concealends contains=X2]])
+          command([[syntax match X2 /cats/ conceal cchar=X contained]])
+          command([[syntax match X3 /\n\@<=x/ conceal cchar=>]])
         end)
+        test_mouse_click_conceal()
+      end)
 
-        it(name .. ' works (nvim_input_mouse)', function()
-          doit(function(row, col)
-            local buttons = { l = 'left', m = 'middle', r = 'right' }
-            local modstr = (click_num > 1) and tostring(click_num) or ''
-            for char in string.gmatch(modifiers, '%w') do
-              modstr = modstr .. char .. '-' -- - not needed but should be accepted
+      describe('(matchadd())', function()
+        before_each(function()
+          fn.matchadd('Conceal', [[\*]])
+          fn.matchadd('Conceal', [[cats]], 10, -1, { conceal = 'X' })
+          fn.matchadd('Conceal', [[\n\@<=x]], 10, -1, { conceal = '>' })
+        end)
+        test_mouse_click_conceal()
+      end)
+
+      describe('(extmarks)', function()
+        before_each(function()
+          local ns = api.nvim_create_namespace('conceal')
+          api.nvim_buf_set_extmark(0, ns, 0, 11, { end_col = 12, conceal = '' })
+          api.nvim_buf_set_extmark(0, ns, 0, 14, { end_col = 15, conceal = '' })
+          api.nvim_buf_set_extmark(0, ns, 1, 5, { end_col = 6, conceal = '' })
+          api.nvim_buf_set_extmark(0, ns, 1, 8, { end_col = 9, conceal = '' })
+          api.nvim_buf_set_extmark(0, ns, 1, 10, { end_col = 11, conceal = '' })
+          api.nvim_buf_set_extmark(0, ns, 1, 13, { end_col = 14, conceal = '' })
+          api.nvim_buf_set_extmark(0, ns, 1, 15, { end_col = 16, conceal = '' })
+          api.nvim_buf_set_extmark(0, ns, 1, 18, { end_col = 19, conceal = '' })
+          api.nvim_buf_set_extmark(0, ns, 2, 24, { end_col = 25, conceal = '' })
+          api.nvim_buf_set_extmark(0, ns, 2, 29, { end_col = 30, conceal = '' })
+          api.nvim_buf_set_extmark(0, ns, 2, 25, { end_col = 29, conceal = 'X' })
+          api.nvim_buf_set_extmark(0, ns, 2, 0, { end_col = 1, conceal = '>' })
+        end)
+        test_mouse_click_conceal()
+      end)
+    end)
+
+    it('virtual text does not change cursor placement on concealed line', function()
+      command('%delete')
+      insert('aaaaaaaaaa|hidden|bbbbbbbbbb|hidden|cccccccccc')
+      command('syntax match test /|hidden|/ conceal cchar=X')
+      command('set conceallevel=2 concealcursor=n virtualedit=all')
+      screen:expect({
+        any = {
+          'aaaaaaaaaa{14:X}bbbbbbb       ',
+          'bbb{14:X}ccccccccc%^c           ',
+        },
+      })
+      api.nvim_input_mouse('left', 'press', '', 0, 0, 22)
+      screen:expect({
+        any = {
+          'aaaaaaaaaa{14:X}bbbbbb%^b       ',
+          'bbb{14:X}cccccccccc           ',
+        },
+      })
+      api.nvim_input_mouse('left', 'press', '', 0, 1, 16)
+      screen:expect({
+        any = {
+          'aaaaaaaaaa{14:X}bbbbbbb       ',
+          'bbb{14:X}cccccccccc  %^         ',
+        },
+      })
+
+      api.nvim_buf_set_extmark(0, api.nvim_create_namespace(''), 0, 0, {
+        virt_text = { { '?', 'ErrorMsg' } },
+        virt_text_pos = 'right_align',
+        virt_text_repeat_linebreak = true,
+      })
+      screen:expect({
+        any = {
+          'aaaaaaaaaa{14:X}bbbbbbb      {9:%?}',
+          'bbb{14:X}cccccccccc  %^        {9:%?}',
+        },
+      })
+      api.nvim_input_mouse('left', 'press', '', 0, 0, 22)
+      screen:expect({
+        any = {
+          'aaaaaaaaaa{14:X}bbbbbb%^b      {9:%?}',
+          'bbb{14:X}cccccccccc          {9:%?}',
+        },
+      })
+      api.nvim_input_mouse('left', 'press', '', 0, 1, 16)
+      screen:expect({
+        any = {
+          'aaaaaaaaaa{14:X}bbbbbbb      {9:%?}',
+          'bbb{14:X}cccccccccc  %^        {9:%?}',
+        },
+      })
+    end)
+
+    it("mouse click on window separator in statusline doesn't crash", function()
+      api.nvim_set_option_value('winwidth', 1, {})
+      api.nvim_set_option_value('statusline', '%f', {})
+
+      command('vsplit')
+      command('redraw')
+
+      local lines = api.nvim_get_option_value('lines', {})
+      local columns = api.nvim_get_option_value('columns', {})
+
+      api.nvim_input_mouse('left', 'press', '', 0, lines - 1, math.floor(columns / 2))
+      command('redraw')
+    end)
+
+    it('getmousepos() works correctly', function()
+      local winwidth = api.nvim_get_option_value('winwidth', {})
+      -- Set winwidth=1 so that window sizes don't change.
+      api.nvim_set_option_value('winwidth', 1, {})
+      command('tabedit')
+      local tabpage = api.nvim_get_current_tabpage()
+      insert('hello')
+      command('vsplit')
+      local opts = {
+        relative = 'editor',
+        width = 12,
+        height = 1,
+        col = 8,
+        row = 1,
+        anchor = 'NW',
+        style = 'minimal',
+        border = 'single',
+        focusable = 1,
+      }
+      local float = api.nvim_open_win(api.nvim_get_current_buf(), false, opts)
+      command('redraw')
+      local lines = api.nvim_get_option_value('lines', {})
+      local columns = api.nvim_get_option_value('columns', {})
+
+      -- Test that screenrow and screencol are set properly for all positions.
+      for row = 0, lines - 1 do
+        for col = 0, columns - 1 do
+          -- Skip the X button that would close the tab.
+          if row ~= 0 or col ~= columns - 1 then
+            api.nvim_input_mouse('left', 'press', '', 0, row, col)
+            api.nvim_set_current_tabpage(tabpage)
+            local mousepos = fn.getmousepos()
+            eq(row + 1, mousepos.screenrow)
+            eq(col + 1, mousepos.screencol)
+            -- All other values should be 0 when clicking on the command line.
+            if row == lines - 1 then
+              eq(0, mousepos.winid)
+              eq(0, mousepos.winrow)
+              eq(0, mousepos.wincol)
+              eq(0, mousepos.line)
+              eq(0, mousepos.column)
+              eq(0, mousepos.coladd)
             end
-            api.nvim_input_mouse(buttons[mouse_button], 'press', modstr, 0, row, col)
-          end)
-        end)
-      end
-
-      test_click('single left click', '<LeftMouse>', 1, 'l', '    ')
-      test_click('shifted single left click', '<S-LeftMouse>', 1, 'l', 's   ')
-      test_click('shifted single left click with alt modifier', '<S-A-LeftMouse>', 1, 'l', 's a ')
-      test_click(
-        'shifted single left click with alt and ctrl modifiers',
-        '<S-C-A-LeftMouse>',
-        1,
-        'l',
-        'sca '
-      )
-      -- <C-RightMouse> does not work
-      test_click('shifted single right click with alt modifier', '<S-A-RightMouse>', 1, 'r', 's a ')
-      -- Modifiers do not work with MiddleMouse
-      test_click(
-        'shifted single middle click with alt and ctrl modifiers',
-        '<MiddleMouse>',
-        1,
-        'm',
-        '    '
-      )
-      -- Modifiers do not work with N-*Mouse
-      test_click('double left click', '<2-LeftMouse>', 2, 'l', '    ')
-      test_click('triple left click', '<3-LeftMouse>', 3, 'l', '    ')
-      test_click('quadruple left click', '<4-LeftMouse>', 4, 'l', '    ')
-      test_click('double right click', '<2-RightMouse>', 2, 'r', '    ')
-      test_click('triple right click', '<3-RightMouse>', 3, 'r', '    ')
-      test_click('quadruple right click', '<4-RightMouse>', 4, 'r', '    ')
-      test_click('double middle click', '<2-MiddleMouse>', 2, 'm', '    ')
-      test_click('triple middle click', '<3-MiddleMouse>', 3, 'm', '    ')
-      test_click('quadruple middle click', '<4-MiddleMouse>', 4, 'm', '    ')
-    end)
-  end)
-
-  it('left drag changes visual selection', function()
-    -- drag events must be preceded by a click
-    feed('<LeftMouse><2,1>')
-    screen:expect({
-      any = {
-        'testing',
-        'mo%^use',
-        'support and selection',
-      },
-    })
-    feed('<LeftDrag><4,1>')
-    screen:expect({
-      any = {
-        'testing',
-        'mo{17:us}%^e',
-        'support and selection',
-        'VISUAL',
-      },
-    })
-    feed('<LeftDrag><2,2>')
-    screen:expect({
-      any = {
-        'testing',
-        'mo{17:use}',
-        '{17:su}%^pport and selection',
-        'VISUAL',
-      },
-    })
-    feed('<LeftDrag><0,0>')
-    screen:expect({
-      any = {
-        '%^t{17:esting}',
-        '{17:mou}se ',
-        'support and selection',
-        'VISUAL',
-      },
-    })
-  end)
-
-  it('left drag changes visual selection after tab click', function()
-    feed_command('silent file foo | tabnew | file bar')
-    insert('this is bar')
-    feed_command('tabprevious') -- go to first tab
-    screen:expect({
-      any = {
-        '{5: %+ foo }{24: %+ bar }{2:          }{24:X}|',
-        'testing',
-        'mouse',
-        'support and selectio%^n',
-        ':tabprevious',
-      },
-    })
-    feed('<LeftMouse><10,0><LeftRelease>') -- go to second tab
-    n.poke_eventloop()
-    feed('<LeftMouse><0,1>')
-    screen:expect({
-      any = {
-        '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-        '%^this is bar{1:%$}',
-        ':tabprevious',
-      },
-      none = {
-        'mouse',
-        'support and selection',
-      },
-    })
-    feed('<LeftDrag><4,1>')
-    screen:expect({
-      any = {
-        '{24: %+ foo }{5: %+ bar }{2:          }{24:X}',
-        '{17:this}%^ is bar{1:%$}',
-        'VISUAL',
-      },
-    })
-  end)
-
-  it('left drag changes visual selection in split layout', function()
-    screen:try_resize(53, 14)
-    command('set mouse=a')
-    command('vsplit')
-    command('wincmd l')
-    command('below split')
-    command('enew')
-    feed('ifoo\nbar<esc>')
-    screen:expect({
-      any = {
-        'foo{1:%$}',
-        'ba%^r{1:%$}',
-      },
-    })
-    api.nvim_input_mouse('left', 'press', '', 0, 6, 27)
-    screen:expect({
-      any = {
-        '%^foo{1:%$}',
-        'bar{1:%$}',
-      },
-    })
-    api.nvim_input_mouse('left', 'drag', '', 0, 7, 30)
-    screen:expect({
-      any = {
-        '{17:foo}{100:%$}',
-        '{17:bar}{1:%^%$}',
-        'VISUAL',
-      },
-    })
-  end)
-
-  it('two clicks will enter VISUAL and dragging selects words', function()
-    feed('<LeftMouse><2,2>')
-    feed('<LeftRelease><2,2>')
-    feed('<LeftMouse><2,2>')
-    screen:expect({
-      any = {
-        'testing',
-        'mouse',
-        '{17:suppor}%^t and selection',
-        'VISUAL',
-      },
-    })
-    feed('<LeftDrag><0,1>')
-    screen:expect({
-      any = {
-        'testing',
-        '%^m{17:ouse}',
-        '{17:support} and selection',
-        'VISUAL',
-      },
-    })
-    feed('<LeftDrag><4,0>')
-    screen:expect({
-      any = {
-        '%^t{17:esting}',
-        '{17:mouse}',
-        '{17:support} and selection',
-        'VISUAL',
-      },
-    })
-    feed('<LeftDrag><14,2>')
-    screen:expect({
-      any = {
-        'testing',
-        'mouse',
-        '{17:support and selectio}%^n',
-        'VISUAL',
-      },
-    })
-  end)
-
-  it('three clicks will enter VISUAL LINE and dragging selects lines', function()
-    feed('<LeftMouse><2,2>')
-    feed('<LeftRelease><2,2>')
-    feed('<LeftMouse><2,2>')
-    feed('<LeftRelease><2,2>')
-    feed('<LeftMouse><2,2>')
-    screen:expect({
-      any = {
-        'testing',
-        'mouse',
-        '{17:su}%^p{17:port and selection}',
-        'VISUAL LINE',
-      },
-    })
-    feed('<LeftDrag><0,1>')
-    screen:expect({
-      any = {
-        'testing',
-        '%^m{17:ouse}',
-        '{17:support and selection}',
-        'VISUAL LINE',
-      },
-    })
-    feed('<LeftDrag><4,0>')
-    screen:expect({
-      any = {
-        '{17:test}%^i{17:ng}',
-        '{17:mouse}',
-        '{17:support and selection}',
-        'VISUAL LINE',
-      },
-    })
-    feed('<LeftDrag><14,2>')
-    screen:expect({
-      any = {
-        'testing',
-        'mouse',
-        '{17:support and se}%^l{17:ection}',
-        'VISUAL LINE',
-      },
-    })
-  end)
-
-  it('four clicks will enter VISUAL BLOCK and dragging selects blockwise', function()
-    feed('<LeftMouse><2,2>')
-    feed('<LeftRelease><2,2>')
-    feed('<LeftMouse><2,2>')
-    feed('<LeftRelease><2,2>')
-    feed('<LeftMouse><2,2>')
-    feed('<LeftRelease><2,2>')
-    feed('<LeftMouse><2,2>')
-    screen:expect({
-      any = {
-        'testing',
-        'mouse',
-        'su%^pport and selection',
-        'VISUAL BLOCK',
-      },
-    })
-    feed('<LeftDrag><0,1>')
-    screen:expect({
-      any = {
-        'testing',
-        '%^m{17:ou}se',
-        '{17:sup}port and selection',
-        'VISUAL BLOCK',
-      },
-    })
-    feed('<LeftDrag><4,0>')
-    screen:expect({
-      any = {
-        'te{17:st}%^ing',
-        'mo{17:use}',
-        'su{17:ppo}rt and selection',
-        'VISUAL BLOCK',
-      },
-    })
-    feed('<LeftDrag><14,2>')
-    screen:expect({
-      any = {
-        'testing',
-        'mouse',
-        'su{17:pport and se}%^lection',
-        'VISUAL BLOCK',
-      },
-    })
-  end)
-
-  it('right click extends visual selection to the clicked location', function()
-    feed('<LeftMouse><0,0>')
-    screen:expect({
-      any = {
-        '%^testing',
-        'mouse',
-        'support and selection',
-      },
-    })
-    feed('<RightMouse><2,2>')
-    screen:expect({
-      any = {
-        '{17:testing}',
-        '{17:mouse}',
-        '{17:su}^pport and selection',
-        'VISUAL',
-      },
-    })
-  end)
-
-  it('ctrl + left click will search for a tag', function()
-    api.nvim_set_option_value('tags', './non-existent-tags-file', {})
-    feed('<C-LeftMouse><0,0>')
-    screen:expect({
-      any = {
-        '{9:E433: No tags file}',
-        '{9:E426: Tag not found: test}',
-        '{9:ing}',
-        '{6:Press ENTER or type comma}',
-        '{6:nd to continue}%^',
-      },
-    })
-    feed('<cr>')
-  end)
-
-  it('x1 and x2 can be triggered by api', function()
-    api.nvim_set_var('x1_pressed', 0)
-    api.nvim_set_var('x1_released', 0)
-    api.nvim_set_var('x2_pressed', 0)
-    api.nvim_set_var('x2_released', 0)
-    command('nnoremap <X1Mouse> <Cmd>let g:x1_pressed += 1<CR>')
-    command('nnoremap <X1Release> <Cmd>let g:x1_released += 1<CR>')
-    command('nnoremap <X2Mouse> <Cmd>let g:x2_pressed += 1<CR>')
-    command('nnoremap <X2Release> <Cmd>let g:x2_released += 1<CR>')
-    api.nvim_input_mouse('x1', 'press', '', 0, 0, 0)
-    api.nvim_input_mouse('x1', 'release', '', 0, 0, 0)
-    api.nvim_input_mouse('x2', 'press', '', 0, 0, 0)
-    api.nvim_input_mouse('x2', 'release', '', 0, 0, 0)
-    eq(1, api.nvim_get_var('x1_pressed'), 'x1 pressed once')
-    eq(1, api.nvim_get_var('x1_released'), 'x1 released once')
-    eq(1, api.nvim_get_var('x2_pressed'), 'x2 pressed once')
-    eq(1, api.nvim_get_var('x2_released'), 'x2 released once')
-  end)
-
-  it('dragging vertical separator', function()
-    screen:try_resize(45, 5)
-    command('setlocal nowrap')
-    local oldwin = api.nvim_get_current_win()
-    command('rightbelow vnew')
-    screen:expect({
-      any = {
-        'testing               ',
-        'mouse                 ',
-        'support and selection ',
-        '{1:%^%$}                     ',
-        '{2:%[No Name%] %[%+%]          }{3:%[No Name%]             }',
-      },
-    })
-    api.nvim_input_mouse('left', 'press', '', 0, 0, 22)
-    poke_eventloop()
-    api.nvim_input_mouse('left', 'drag', '', 0, 1, 12)
-    screen:expect({
-      any = {
-        'testing     ',
-        'mouse       ',
-        'support and ',
-        '{1:%^$}                               ',
-        '{2:< Name%] %[%+%]  }{3:%[No Name%]                       }',
-      },
-    })
-    api.nvim_input_mouse('left', 'drag', '', 0, 2, 2)
-    screen:expect({
-      any = {
-        'te',
-        'mo',
-        'su',
-        '{1:%^%$}                                         ',
-        '{2:<  }{3:%[No Name%]                                 }',
-      },
-    })
-    api.nvim_input_mouse('left', 'release', '', 0, 2, 2)
-    api.nvim_set_option_value('statuscolumn', 'foobar', { win = oldwin })
-    screen:expect({
-      any = {
-        '{8:fo}',
-        '{1:%^%$}                                         ',
-        '{2:<  }{3:%[No Name%]                                 }',
-      },
-    })
-    api.nvim_input_mouse('left', 'press', '', 0, 0, 2)
-    poke_eventloop()
-    api.nvim_input_mouse('left', 'drag', '', 0, 1, 12)
-    screen:expect({
-      any = {
-        '{8:foobar}testin',
-        '{8:foobar}mouse ',
-        '{8:foobar}suppor',
-        '{1:%^%$}                               ',
-        '{2:< Name%] %[%+%]  }{3:%[No Name%]                       }',
-      },
-    })
-    api.nvim_input_mouse('left', 'drag', '', 0, 2, 22)
-    screen:expect({
-      any = {
-        '{8:foobar}testing         ',
-        '{8:foobar}mouse           ',
-        '{8:foobar}support and sele',
-        '{1:%^%$}                     ',
-        '{2:%[No Name%] %[%+%]          }{3:%[No Name%]             }',
-      },
-    })
-    api.nvim_input_mouse('left', 'release', '', 0, 2, 22)
-  end)
-
-  local function wheel(use_api)
-    feed('ggdG')
-    insert([[
-    Inserting
-    text
-    with
-    many
-    lines
-    to
-    test
-    mouse scrolling
-    ]])
-    screen:try_resize(53, 14)
-    feed('k')
-    api.nvim_set_option_value('statuscolumn', 'C', { win = api.nvim_get_current_win() })
-    feed_command('sp')
-    api.nvim_set_option_value('statuscolumn', 'B', { win = api.nvim_get_current_win() })
-    feed_command('vsp')
-    api.nvim_set_option_value('statuscolumn', 'A', { win = api.nvim_get_current_win() })
-    screen:expect({
-      any = {
-        '{8:A}lines                    ',
-        '{8:A}to                       ',
-        '{8:A}test                     ',
-        '{8:A}^mouse scrolling          ',
-        '{8:B}lines                    ',
-        '{8:B}to                       ',
-        '{8:B}test                     ',
-        '{8:B}mouse scrolling          ',
-        '{3:%[No Name%] %[%+%]              }{2:%[No Name%] %[%+%]             }',
-        '{8:C}to                                                  ',
-        '{8:C}test                                                ',
-        '{8:C}mouse scrolling                                     ',
-        '{2:%[No Name%] %[%+%]                                        }',
-      },
-      none = {
-        '{8:A}Inserting',
-        '{8:A}text',
-        '{8:A}with',
-        '{8:A}many',
-        '{8:B}Inserting',
-        '{8:B}text',
-        '{8:B}with',
-        '{8:B}many',
-        '{8:C}Inserting',
-        '{8:C}text',
-        '{8:C}with',
-        '{8:C}many',
-        '{8:C}lines',
-      },
-    })
-    if use_api then
-      api.nvim_input_mouse('wheel', 'down', '', 0, 0, 0)
-    else
-      feed('<ScrollWheelDown><0,0>')
-    end
-    screen:expect({
-      any = {
-        '{8:A}^mouse scrolling          ',
-        '{8:B}lines                    ',
-        '{8:B}to                       ',
-        '{8:B}test                     ',
-        '{8:B}mouse scrolling          ',
-        '{3:%[No Name%] %[%+%]              }{2:%[No Name%] %[%+%]             }',
-        '{8:C}to                                                  ',
-        '{8:C}test                                                ',
-        '{8:C}mouse scrolling                                     ',
-        '{2:%[No Name%] %[%+%]                                        }',
-      },
-      none = {
-        '{8:A}lines',
-        '{8:A}to',
-        '{8:A}test',
-        '{8:B}Inserting',
-        '{8:B}text',
-        '{8:B}with',
-        '{8:B}many',
-        '{8:C}Inserting',
-        '{8:C}text',
-        '{8:C}with',
-        '{8:C}many',
-        '{8:C}lines',
-      },
-    })
-    if use_api then
-      api.nvim_input_mouse('wheel', 'up', '', 0, 0, 27)
-    else
-      feed('<ScrollWheelUp><27,0>')
-    end
-    screen:expect({
-      any = {
-        '{8:A}^mouse scrolling          ',
-        '{8:B}lines                    ',
-        '{8:B}to                       ',
-        '{8:B}test                     ',
-        '{3:%[No Name%] %[%+%]              }{2:%[No Name%] %[%+%]             }',
-        '{8:C}to                                                  ',
-        '{8:C}test                                                ',
-        '{8:C}mouse scrolling                                     ',
-        '{2:%[No Name%] %[%+%]                                        }',
-      },
-      none = {
-        '{8:A}Inserting',
-        '{8:A}text',
-        '{8:A}with',
-        '{8:A}many',
-        '{8:A}lines',
-        '{8:A}to',
-        '{8:A}test',
-        '{8:B}Inserting',
-        '{8:B}mouse scrolling',
-        '{8:C}Inserting',
-        '{8:C}text',
-        '{8:C}with',
-        '{8:C}many',
-        '{8:C}lines',
-      },
-    })
-    if use_api then
-      api.nvim_input_mouse('wheel', 'up', '', 0, 7, 27)
-      api.nvim_input_mouse('wheel', 'up', '', 0, 7, 27)
-    else
-      feed('<ScrollWheelUp><27,7><ScrollWheelUp>')
-    end
-    screen:expect({
-      any = {
-        '{8:A}^mouse scrolling          ',
-        '{8:B}lines                    ',
-        '{8:B}to                       ',
-        '{8:B}test                     ',
-        '{3:%[No Name%] %[%+%]              }{2:%[No Name%] %[%+%]             }',
-        '{8:C}Inserting                                           ',
-        '{8:C}text                                                ',
-        '{8:C}with                                                ',
-        '{8:C}many                                                ',
-        '{8:C}lines                                               ',
-        '{2:%[No Name%] %[%+%]                                        }',
-      },
-      none = {
-        '{8:A}Inserting',
-        '{8:A}text',
-        '{8:A}with',
-        '{8:A}many',
-        '{8:A}lines',
-        '{8:A}to',
-        '{8:A}test',
-        '{8:B}Inserting',
-        '{8:B}mouse scrolling',
-        '{8:C}to',
-        '{8:C}test',
-        '{8:C}mouse scrolling',
-      },
-    })
-  end
-
-  it('mouse wheel will target the hovered window (pseudokey)', function()
-    wheel(false)
-  end)
-
-  it('mouse wheel will target the hovered window (nvim_input_mouse)', function()
-    wheel(true)
-  end)
-
-  it('horizontal scrolling (pseudokey)', function()
-    command('set sidescroll=0')
-    feed('<esc>:set nowrap<cr>')
-
-    feed('a <esc>17Ab<esc>3Ab<esc>')
-    screen:expect({
-      any = {
-        'bbbbbbbbbbbbbbb%^b        ',
-      },
-    })
-
-    feed('<ScrollWheelLeft><0,0>')
-    screen:expect({
-      any = {
-        'n bbbbbbbbbbbbbbbbbbb%^b   ',
-      },
-    })
-
-    feed('^<ScrollWheelRight><0,0>')
-    screen:expect({
-      any = {
-        'g                        ',
-        '%^t and selection bbbbbbbbb',
-      },
-    })
-  end)
-
-  it('horizontal scrolling (nvim_input_mouse)', function()
-    command('set sidescroll=0')
-    feed('<esc>:set nowrap<cr>')
-
-    feed('a <esc>17Ab<esc>3Ab<esc>')
-    screen:expect({
-      any = {
-        'bbbbbbbbbbbbbbb%^b        ',
-      },
-    })
-
-    api.nvim_input_mouse('wheel', 'left', '', 0, 0, 27)
-    screen:expect({
-      any = {
-        'n bbbbbbbbbbbbbbbbbbb%^b   ',
-      },
-    })
-
-    feed('^')
-    api.nvim_input_mouse('wheel', 'right', '', 0, 0, 0)
-    screen:expect({
-      any = {
-        'g                        ',
-        '%^t and selection bbbbbbbbb',
-      },
-    })
-  end)
-
-  it("'sidescrolloff' applies to horizontal scrolling", function()
-    command('set nowrap')
-    command('set sidescrolloff=4')
-
-    feed('I <esc>020ib<esc>0')
-    screen:expect({
-      any = {
-        'testing                  ',
-        'mouse                    ',
-        '%^bbbbbbbbbbbbbbbbbbbb supp',
-      },
-    })
-
-    api.nvim_input_mouse('wheel', 'right', '', 0, 0, 27)
-    screen:expect({
-      any = {
-        'g                        ',
-        '                         ',
-        'bbbb%^bbbbbbbbbb support an',
-      },
-    })
-
-    -- window-local 'sidescrolloff' should override global value. #21162
-    command('setlocal sidescrolloff=2')
-    feed('0')
-    screen:expect({
-      any = {
-        'testing                  ',
-        'mouse                    ',
-        '%^bbbbbbbbbbbbbbbbbbbb supp',
-      },
-    })
-
-    api.nvim_input_mouse('wheel', 'right', '', 0, 0, 27)
-    screen:expect({
-      any = {
-        'g                        ',
-        '                         ',
-        'bb%^bbbbbbbbbbbb support an',
-      },
-    })
-  end)
-
-  local function test_mouse_click_conceal()
-    it('(level 1) click on non-wrapped lines', function()
-      feed_command('let &conceallevel=1', 'echo')
-
-      feed('<esc><LeftMouse><0,0>')
-      screen:expect({
-        any = {
-          '%^Section{1:>>--->--->---}{14: }t1{14: } ',
-          '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
-          '{14:>} 私は猫が大好き{1:>---}{14: X } {1:>}',
-        },
-      })
-
-      feed('<esc><LeftMouse><1,0>')
-      screen:expect({
-        any = {
-          'S%^ection{1:>>--->--->---}{14: }t1{14: } ',
-          '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
-          '{14:>} 私は猫が大好き{1:>---}{14: X } {1:>}',
-        },
-      })
-
-      feed('<esc><LeftMouse><21,0>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}{14: }%^t1{14: } ',
-          '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
-          '{14:>} 私は猫が大好き{1:>---}{14: X } {1:>}',
-        },
-      })
-
-      feed('<esc><LeftMouse><21,1>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}{14: }t1{14: } ',
-          '{1:>--->--->---}  {14: }t2{14: } {14: }t%^3{14: } {14: }',
-          '{14:>} 私は猫が大好き{1:>---}{14: X } {1:>}',
-        },
-      })
-
-      feed('<esc><LeftMouse><0,2>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}{14: }t1{14: } ',
-          '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
-          '{14:%^>} 私は猫が大好き{1:>---}{14: X } {1:>}',
-        },
-      })
-
-      feed('<esc><LeftMouse><7,2>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}{14: }t1{14: } ',
-          '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
-          '{14:>} 私は%^猫が大好き{1:>---}{14: X } {1:>}',
-        },
-      })
-
-      feed('<esc><LeftMouse><21,2>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}{14: }t1{14: } ',
-          '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
-          '{14:>} 私は猫が大好き{1:>---}{14: %^X } {1:>}',
-        },
-      })
-    end) -- level 1 - non wrapped
-
-    it('(level 1) click on wrapped lines', function()
-      feed_command('let &conceallevel=1', 'let &wrap=1', 'echo')
-
-      feed('<esc><LeftMouse><24,1>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}{14: }t1{14: } ',
-          '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14:%^ }',
-          't4{14: }                      ',
-          '{14:>} 私は猫が大好き{1:>---}{14: X}   ',
-          '{14: } ✨🐈✨                 ',
-        },
-      })
-
-      feed('<esc><LeftMouse><0,2>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}{14: }t1{14: } ',
-          '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
-          '%^t4{14: }                      ',
-          '{14:>} 私は猫が大好き{1:>---}{14: X}   ',
-          '{14: } ✨🐈✨                 ',
-        },
-      })
-
-      feed('<esc><LeftMouse><8,3>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}{14: }t1{14: } ',
-          '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
-          't4{14: }                      ',
-          '{14:>} 私は猫%^が大好き{1:>---}{14: X}   ',
-          '{14: } ✨🐈✨                 ',
-        },
-      })
-
-      feed('<esc><LeftMouse><21,3>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}{14: }t1{14: } ',
-          '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
-          't4{14: }                      ',
-          '{14:>} 私は猫が大好き{1:>---}{14: %^X}   ',
-          '{14: } ✨🐈✨                 ',
-        },
-      })
-
-      feed('<esc><LeftMouse><4,4>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}{14: }t1{14: } ',
-          '{1:>--->--->---}  {14: }t2{14: } {14: }t3{14: } {14: }',
-          't4{14: }                      ',
-          '{14:>} 私は猫が大好き{1:>---}{14: X}   ',
-          '{14: } ✨%^🐈✨                 ',
-        },
-      })
-    end) -- level 1 - wrapped
-
-    it('(level 2) click on non-wrapped lines', function()
-      feed_command('let &conceallevel=2', 'echo')
-
-      feed('<esc><LeftMouse><20,0>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}%^t1   ',
-          '{1:>--->--->---}  t2 t3 t4   ',
-          '{14:>} 私は猫が大好き{1:>---}{14:X} ✨{1:>}',
-        },
-      })
-
-      feed('<esc><LeftMouse><14,1>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  %^t2 t3 t4   ',
-          '{14:>} 私は猫が大好き{1:>---}{14:X} ✨{1:>}',
-        },
-      })
-
-      feed('<esc><LeftMouse><18,1>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t%^3 t4   ',
-          '{14:>} 私は猫が大好き{1:>---}{14:X} ✨{1:>}',
-        },
-      })
-
-      feed('<esc><LeftMouse><0,2>') -- Weirdness
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3 t4   ',
-          '{14:%^>} 私は猫が大好き{1:>---}{14:X} ✨{1:>}',
-        },
-      })
-
-      feed('<esc><LeftMouse><8,2>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3 t4   ',
-          '{14:>} 私は猫%^が大好き{1:>---}{14:X} ✨{1:>}',
-        },
-      })
-
-      feed('<esc><LeftMouse><20,2>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3 t4   ',
-          '{14:>} 私は猫が大好き{1:>---}{14:%^X} ✨{1:>}',
-        },
-      })
-    end) -- level 2 - non wrapped
-
-    it('(level 2) click on non-wrapped lines (insert mode)', function()
-      feed_command('let &conceallevel=2', 'echo')
-
-      feed('<esc>i<LeftMouse><20,0>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}%^t1   ',
-          '{1:>--->--->---}  t2 t3 t4   ',
-          '{14:>} 私は猫が大好き{1:>---}{14:X} ✨{1:>}',
-        },
-      })
-
-      feed('<LeftMouse><14,1>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  %^t2 t3 t4   ',
-          '{14:>} 私は猫が大好き{1:>---}{14:X} ✨{1:>}',
-        },
-      })
-
-      feed('<LeftMouse><18,1>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t%^3 t4   ',
-          '{14:>} 私は猫が大好き{1:>---}{14:X} ✨{1:>}',
-        },
-      })
-
-      feed('<LeftMouse><0,2>') -- Weirdness
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3 t4   ',
-          '{14:%^>} 私は猫が大好き{1:>---}{14:X} ✨{1:>}',
-        },
-      })
-
-      feed('<LeftMouse><8,2>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3 t4   ',
-          '{14:>} 私は猫%^が大好き{1:>---}{14:X} ✨{1:>}',
-        },
-      })
-
-      feed('<LeftMouse><20,2>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3 t4   ',
-          '{14:>} 私は猫が大好き{1:>---}{14:%^X} ✨{1:>}',
-        },
-      })
-    end) -- level 2 - non wrapped (insert mode)
-
-    it('(level 2) click on wrapped lines', function()
-      feed_command('let &conceallevel=2', 'let &wrap=1', 'echo')
-
-      feed('<esc><LeftMouse><20,0>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}%^t1   ',
-          '{1:>--->--->---}  t2 t3      ',
-          't4                       ',
-          '{14:>} 私は猫が大好き{1:>---}{14:X}    ',
-          ' ✨🐈✨                  ',
-        },
-      })
-
-      feed('<esc><LeftMouse><14,1>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  %^t2 t3      ',
-          't4                       ',
-          '{14:>} 私は猫が大好き{1:>---}{14:X}    ',
-          ' ✨🐈✨                  ',
-        },
-      })
-
-      feed('<esc><LeftMouse><18,1>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t%^3      ',
-          't4                       ',
-          '{14:>} 私は猫が大好き{1:>---}{14:X}    ',
-          ' ✨🐈✨                  ',
-        },
-      })
-
-      -- NOTE: The click would ideally be on the 't' in 't4', but wrapping
-      -- caused the invisible '*' right before 't4' to remain on the previous
-      -- screen line.  This is being treated as expected because fixing this is
-      -- out of scope for mouse clicks.  Should the wrapping behavior of
-      -- concealed characters change in the future, this case should be
-      -- reevaluated.
-      feed('<esc><LeftMouse><0,2>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3 %^     ',
-          't4                       ',
-          '{14:>} 私は猫が大好き{1:>---}{14:X}    ',
-          ' ✨🐈✨                  ',
-        },
-      })
-
-      feed('<esc><LeftMouse><1,2>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3      ',
-          't%^4                       ',
-          '{14:>} 私は猫が大好き{1:>---}{14:X}    ',
-          ' ✨🐈✨                  ',
-        },
-      })
-
-      feed('<esc><LeftMouse><0,3>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3      ',
-          't4                       ',
-          '{14:%^>} 私は猫が大好き{1:>---}{14:X}    ',
-          ' ✨🐈✨                  ',
-        },
-      })
-
-      feed('<esc><LeftMouse><20,3>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3      ',
-          't4                       ',
-          '{14:>} 私は猫が大好き{1:>---}{14:%^X}    ',
-          ' ✨🐈✨                  ',
-        },
-      })
-
-      feed('<esc><LeftMouse><1,4>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3      ',
-          't4                       ',
-          '{14:>} 私は猫が大好き{1:>---}{14:X}    ',
-          '%^✨🐈✨                 ',
-        },
-      })
-
-      feed('<esc><LeftMouse><5,4>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3      ',
-          't4                       ',
-          '{14:>} 私は猫が大好き{1:>---}{14:X}    ',
-          '✨🐈%^✨                  ',
-        },
-      })
-    end) -- level 2 - wrapped
-
-    it('(level 3) click on non-wrapped lines', function()
-      feed_command('let &conceallevel=3', 'echo')
-
-      feed('<esc><LeftMouse><0,2>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3 t4   ',
-          '%^ 私は猫が大好き{1:>----} ✨🐈',
-        },
-      })
-
-      feed('<esc><LeftMouse><1,2>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3 t4   ',
-          ' %^私は猫が大好き{1:>----} ✨🐈',
-        },
-      })
-
-      feed('<esc><LeftMouse><13,2>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3 t4   ',
-          ' 私は猫が大好%^き{1:>----} ✨🐈',
-        },
-      })
-
-      feed('<esc><LeftMouse><20,2>')
-      feed('zH') -- FIXME: unnecessary horizontal scrolling
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3 t4   ',
-          ' 私は猫が大好き{1:>----}%^ ✨🐈',
-        },
-      })
-    end) -- level 3 - non wrapped
-
-    it('(level 3) click on wrapped lines', function()
-      feed_command('let &conceallevel=3', 'let &wrap=1', 'echo')
-
-      feed('<esc><LeftMouse><14,1>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  %^t2 t3      ',
-          't4                       ',
-          ' 私は猫が大好き{1:>----}     ',
-          ' ✨🐈✨                  ',
-        },
-      })
-
-      feed('<esc><LeftMouse><18,1>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t%^3      ',
-          't4                       ',
-          ' 私は猫が大好き{1:>----}     ',
-          ' ✨🐈✨                  ',
-        },
-      })
-
-      feed('<esc><LeftMouse><1,2>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3      ',
-          't%^4                       ',
-          ' 私は猫が大好き{1:>----}     ',
-          ' ✨🐈✨                  ',
-        },
-      })
-
-      feed('<esc><LeftMouse><0,3>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3      ',
-          't4                       ',
-          '%^ 私は猫が大好き{1:>----}     ',
-          ' ✨🐈✨                  ',
-        },
-      })
-
-      feed('<esc><LeftMouse><20,3>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3      ',
-          't4                       ',
-          ' 私は猫が大好き{1:>----}%^     ',
-          ' ✨🐈✨                  ',
-        },
-      })
-
-      feed('<esc><LeftMouse><1,4>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3      ',
-          't4                       ',
-          ' 私は猫が大好き{1:>----}     ',
-          ' %^✨🐈✨                  ',
-        },
-      })
-
-      feed('<esc><LeftMouse><3,4>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3      ',
-          't4                       ',
-          ' 私は猫が大好き{1:>----}     ',
-          ' ✨%^🐈✨                  ',
-        },
-      })
-
-      feed('<esc><LeftMouse><5,4>')
-      screen:expect({
-        any = {
-          'Section{1:>>--->--->---}t1   ',
-          '{1:>--->--->---}  t2 t3      ',
-          't4                       ',
-          ' 私は猫が大好き{1:>----}     ',
-          ' ✨🐈%^✨                  ',
-        },
-      })
-    end) -- level 3 - wrapped
-  end
-
-  describe('on concealed text', function()
-    -- Helpful for reading the test expectations:
-    -- :match Error /\^/
-
-    before_each(function()
-      screen:try_resize(25, 7)
-      feed('ggdG')
-
-      command([[setlocal concealcursor=ni nowrap shiftwidth=2 tabstop=4 list listchars=tab:>-]])
-      command([[highlight link X0 Normal]])
-      command([[highlight link X1 NonText]])
-      command([[highlight link X2 NonText]])
-      command([[highlight link X3 NonText]])
-
-      -- First column is there to retain the tabs.
-      insert([[
-      |Section				*t1*
-      |			  *t2* *t3* *t4*
-      |x 私は猫が大好き	*cats* ✨🐈✨
-      ]])
-
-      feed('gg<c-v>Gxgg')
-    end)
-
-    describe('(syntax)', function()
-      before_each(function()
-        command([[syntax region X0 matchgroup=X1 start=/\*/ end=/\*/ concealends contains=X2]])
-        command([[syntax match X2 /cats/ conceal cchar=X contained]])
-        command([[syntax match X3 /\n\@<=x/ conceal cchar=>]])
-      end)
-      test_mouse_click_conceal()
-    end)
-
-    describe('(matchadd())', function()
-      before_each(function()
-        fn.matchadd('Conceal', [[\*]])
-        fn.matchadd('Conceal', [[cats]], 10, -1, { conceal = 'X' })
-        fn.matchadd('Conceal', [[\n\@<=x]], 10, -1, { conceal = '>' })
-      end)
-      test_mouse_click_conceal()
-    end)
-
-    describe('(extmarks)', function()
-      before_each(function()
-        local ns = api.nvim_create_namespace('conceal')
-        api.nvim_buf_set_extmark(0, ns, 0, 11, { end_col = 12, conceal = '' })
-        api.nvim_buf_set_extmark(0, ns, 0, 14, { end_col = 15, conceal = '' })
-        api.nvim_buf_set_extmark(0, ns, 1, 5, { end_col = 6, conceal = '' })
-        api.nvim_buf_set_extmark(0, ns, 1, 8, { end_col = 9, conceal = '' })
-        api.nvim_buf_set_extmark(0, ns, 1, 10, { end_col = 11, conceal = '' })
-        api.nvim_buf_set_extmark(0, ns, 1, 13, { end_col = 14, conceal = '' })
-        api.nvim_buf_set_extmark(0, ns, 1, 15, { end_col = 16, conceal = '' })
-        api.nvim_buf_set_extmark(0, ns, 1, 18, { end_col = 19, conceal = '' })
-        api.nvim_buf_set_extmark(0, ns, 2, 24, { end_col = 25, conceal = '' })
-        api.nvim_buf_set_extmark(0, ns, 2, 29, { end_col = 30, conceal = '' })
-        api.nvim_buf_set_extmark(0, ns, 2, 25, { end_col = 29, conceal = 'X' })
-        api.nvim_buf_set_extmark(0, ns, 2, 0, { end_col = 1, conceal = '>' })
-      end)
-      test_mouse_click_conceal()
-    end)
-  end)
-
-  it('virtual text does not change cursor placement on concealed line', function()
-    command('%delete')
-    insert('aaaaaaaaaa|hidden|bbbbbbbbbb|hidden|cccccccccc')
-    command('syntax match test /|hidden|/ conceal cchar=X')
-    command('set conceallevel=2 concealcursor=n virtualedit=all')
-    screen:expect({
-      any = {
-        'aaaaaaaaaa{14:X}bbbbbbb       ',
-        'bbb{14:X}ccccccccc%^c           ',
-      },
-    })
-    api.nvim_input_mouse('left', 'press', '', 0, 0, 22)
-    screen:expect({
-      any = {
-        'aaaaaaaaaa{14:X}bbbbbb%^b       ',
-        'bbb{14:X}cccccccccc           ',
-      },
-    })
-    api.nvim_input_mouse('left', 'press', '', 0, 1, 16)
-    screen:expect({
-      any = {
-        'aaaaaaaaaa{14:X}bbbbbbb       ',
-        'bbb{14:X}cccccccccc  %^         ',
-      },
-    })
-
-    api.nvim_buf_set_extmark(0, api.nvim_create_namespace(''), 0, 0, {
-      virt_text = { { '?', 'ErrorMsg' } },
-      virt_text_pos = 'right_align',
-      virt_text_repeat_linebreak = true,
-    })
-    screen:expect({
-      any = {
-        'aaaaaaaaaa{14:X}bbbbbbb      {9:%?}',
-        'bbb{14:X}cccccccccc  %^        {9:%?}',
-      },
-    })
-    api.nvim_input_mouse('left', 'press', '', 0, 0, 22)
-    screen:expect({
-      any = {
-        'aaaaaaaaaa{14:X}bbbbbb%^b      {9:%?}',
-        'bbb{14:X}cccccccccc          {9:%?}',
-      },
-    })
-    api.nvim_input_mouse('left', 'press', '', 0, 1, 16)
-    screen:expect({
-      any = {
-        'aaaaaaaaaa{14:X}bbbbbbb      {9:%?}',
-        'bbb{14:X}cccccccccc  %^        {9:%?}',
-      },
-    })
-  end)
-
-  it("mouse click on window separator in statusline doesn't crash", function()
-    api.nvim_set_option_value('winwidth', 1, {})
-    api.nvim_set_option_value('statusline', '%f', {})
-
-    command('vsplit')
-    command('redraw')
-
-    local lines = api.nvim_get_option_value('lines', {})
-    local columns = api.nvim_get_option_value('columns', {})
-
-    api.nvim_input_mouse('left', 'press', '', 0, lines - 1, math.floor(columns / 2))
-    command('redraw')
-  end)
-
-  it('getmousepos() works correctly', function()
-    local winwidth = api.nvim_get_option_value('winwidth', {})
-    -- Set winwidth=1 so that window sizes don't change.
-    api.nvim_set_option_value('winwidth', 1, {})
-    command('tabedit')
-    local tabpage = api.nvim_get_current_tabpage()
-    insert('hello')
-    command('vsplit')
-    local opts = {
-      relative = 'editor',
-      width = 12,
-      height = 1,
-      col = 8,
-      row = 1,
-      anchor = 'NW',
-      style = 'minimal',
-      border = 'single',
-      focusable = 1,
-    }
-    local float = api.nvim_open_win(api.nvim_get_current_buf(), false, opts)
-    command('redraw')
-    local lines = api.nvim_get_option_value('lines', {})
-    local columns = api.nvim_get_option_value('columns', {})
-
-    -- Test that screenrow and screencol are set properly for all positions.
-    for row = 0, lines - 1 do
-      for col = 0, columns - 1 do
-        -- Skip the X button that would close the tab.
-        if row ~= 0 or col ~= columns - 1 then
-          api.nvim_input_mouse('left', 'press', '', 0, row, col)
-          api.nvim_set_current_tabpage(tabpage)
-          local mousepos = fn.getmousepos()
-          eq(row + 1, mousepos.screenrow)
-          eq(col + 1, mousepos.screencol)
-          -- All other values should be 0 when clicking on the command line.
-          if row == lines - 1 then
-            eq(0, mousepos.winid)
-            eq(0, mousepos.winrow)
-            eq(0, mousepos.wincol)
-            eq(0, mousepos.line)
-            eq(0, mousepos.column)
-            eq(0, mousepos.coladd)
           end
         end
       end
-    end
 
-    -- Test that mouse position values are properly set for the floating window
-    -- with a border. 1 is added to the height and width to account for the
-    -- border.
-    for win_row = 0, opts.height + 1 do
-      for win_col = 0, opts.width + 1 do
-        local row = win_row + opts.row
-        local col = win_col + opts.col
-        api.nvim_input_mouse('left', 'press', '', 0, row, col)
-        local mousepos = fn.getmousepos()
-        eq(float, mousepos.winid)
-        eq(win_row + 1, mousepos.winrow)
-        eq(win_col + 1, mousepos.wincol)
-        local line = 0
-        local column = 0
-        local coladd = 0
-        if
-          win_row > 0
-          and win_row < opts.height + 1
-          and win_col > 0
-          and win_col < opts.width + 1
-        then
-          -- Because of border, win_row and win_col don't need to be
-          -- incremented by 1.
-          line = math.min(win_row, fn.line('$'))
-          column = math.min(win_col, #fn.getline(line) + 1)
-          coladd = win_col - column
-        end
-        eq(line, mousepos.line)
-        eq(column, mousepos.column)
-        eq(coladd, mousepos.coladd)
-      end
-    end
-
-    -- Test that mouse position values are properly set for the floating
-    -- window, after removing the border.
-    opts.border = 'none'
-    api.nvim_win_set_config(float, opts)
-    command('redraw')
-    for win_row = 0, opts.height - 1 do
-      for win_col = 0, opts.width - 1 do
-        local row = win_row + opts.row
-        local col = win_col + opts.col
-        api.nvim_input_mouse('left', 'press', '', 0, row, col)
-        local mousepos = fn.getmousepos()
-        eq(float, mousepos.winid)
-        eq(win_row + 1, mousepos.winrow)
-        eq(win_col + 1, mousepos.wincol)
-        local line = math.min(win_row + 1, fn.line('$'))
-        local column = math.min(win_col + 1, #fn.getline(line) + 1)
-        local coladd = win_col + 1 - column
-        eq(line, mousepos.line)
-        eq(column, mousepos.column)
-        eq(coladd, mousepos.coladd)
-      end
-    end
-
-    -- Test that mouse position values are properly set for ordinary windows.
-    -- Set the float to be unfocusable instead of closing, to additionally test
-    -- that getmousepos() does not consider unfocusable floats. (see discussion
-    -- in PR #14937 for details).
-    opts.focusable = false
-    api.nvim_win_set_config(float, opts)
-    command('redraw')
-    for nr = 1, 2 do
-      for win_row = 0, fn.winheight(nr) - 1 do
-        for win_col = 0, fn.winwidth(nr) - 1 do
-          local row = win_row + fn.win_screenpos(nr)[1] - 1
-          local col = win_col + fn.win_screenpos(nr)[2] - 1
+      -- Test that mouse position values are properly set for the floating window
+      -- with a border. 1 is added to the height and width to account for the
+      -- border.
+      for win_row = 0, opts.height + 1 do
+        for win_col = 0, opts.width + 1 do
+          local row = win_row + opts.row
+          local col = win_col + opts.col
           api.nvim_input_mouse('left', 'press', '', 0, row, col)
           local mousepos = fn.getmousepos()
-          eq(fn.win_getid(nr), mousepos.winid)
+          eq(float, mousepos.winid)
+          eq(win_row + 1, mousepos.winrow)
+          eq(win_col + 1, mousepos.wincol)
+          local line = 0
+          local column = 0
+          local coladd = 0
+          if
+            win_row > 0
+            and win_row < opts.height + 1
+            and win_col > 0
+            and win_col < opts.width + 1
+          then
+            -- Because of border, win_row and win_col don't need to be
+            -- incremented by 1.
+            line = math.min(win_row, fn.line('$'))
+            column = math.min(win_col, #fn.getline(line) + 1)
+            coladd = win_col - column
+          end
+          eq(line, mousepos.line)
+          eq(column, mousepos.column)
+          eq(coladd, mousepos.coladd)
+        end
+      end
+
+      -- Test that mouse position values are properly set for the floating
+      -- window, after removing the border.
+      opts.border = 'none'
+      api.nvim_win_set_config(float, opts)
+      command('redraw')
+      for win_row = 0, opts.height - 1 do
+        for win_col = 0, opts.width - 1 do
+          local row = win_row + opts.row
+          local col = win_col + opts.col
+          api.nvim_input_mouse('left', 'press', '', 0, row, col)
+          local mousepos = fn.getmousepos()
+          eq(float, mousepos.winid)
           eq(win_row + 1, mousepos.winrow)
           eq(win_col + 1, mousepos.wincol)
           local line = math.min(win_row + 1, fn.line('$'))
@@ -1896,240 +1883,275 @@ describe('ui/mouse/input', function()
           eq(coladd, mousepos.coladd)
         end
       end
-    end
 
-    -- Restore state and release mouse.
-    command('tabclose!')
-    api.nvim_set_option_value('winwidth', winwidth, {})
-    api.nvim_input_mouse('left', 'release', '', 0, 0, 0)
+      -- Test that mouse position values are properly set for ordinary windows.
+      -- Set the float to be unfocusable instead of closing, to additionally test
+      -- that getmousepos() does not consider unfocusable floats. (see discussion
+      -- in PR #14937 for details).
+      opts.focusable = false
+      api.nvim_win_set_config(float, opts)
+      command('redraw')
+      for nr = 1, 2 do
+        for win_row = 0, fn.winheight(nr) - 1 do
+          for win_col = 0, fn.winwidth(nr) - 1 do
+            local row = win_row + fn.win_screenpos(nr)[1] - 1
+            local col = win_col + fn.win_screenpos(nr)[2] - 1
+            api.nvim_input_mouse('left', 'press', '', 0, row, col)
+            local mousepos = fn.getmousepos()
+            eq(fn.win_getid(nr), mousepos.winid)
+            eq(win_row + 1, mousepos.winrow)
+            eq(win_col + 1, mousepos.wincol)
+            local line = math.min(win_row + 1, fn.line('$'))
+            local column = math.min(win_col + 1, #fn.getline(line) + 1)
+            local coladd = win_col + 1 - column
+            eq(line, mousepos.line)
+            eq(column, mousepos.column)
+            eq(coladd, mousepos.coladd)
+          end
+        end
+      end
+
+      -- Restore state and release mouse.
+      command('tabclose!')
+      api.nvim_set_option_value('winwidth', winwidth, {})
+      api.nvim_input_mouse('left', 'release', '', 0, 0, 0)
+    end)
+
+    it('scroll keys are not translated into multiclicks and can be mapped #6211 #6989', function()
+      api.nvim_set_var('mouse_up', 0)
+      api.nvim_set_var('mouse_up2', 0)
+      command('nnoremap <ScrollWheelUp> <Cmd>let g:mouse_up += 1<CR>')
+      command('nnoremap <2-ScrollWheelUp> <Cmd>let g:mouse_up2 += 1<CR>')
+      feed('<ScrollWheelUp><0,0>')
+      feed('<ScrollWheelUp><0,0>')
+      api.nvim_input_mouse('wheel', 'up', '', 0, 0, 0)
+      api.nvim_input_mouse('wheel', 'up', '', 0, 0, 0)
+      eq(4, api.nvim_get_var('mouse_up'))
+      eq(0, api.nvim_get_var('mouse_up2'))
+    end)
+
+    it('<MouseMove> to different locations can be mapped', function()
+      api.nvim_set_var('mouse_move', 0)
+      api.nvim_set_var('mouse_move2', 0)
+      command('nnoremap <MouseMove> <Cmd>let g:mouse_move += 1<CR>')
+      command('nnoremap <2-MouseMove> <Cmd>let g:mouse_move2 += 1<CR>')
+      feed('<MouseMove><1,0>')
+      feed('<MouseMove><2,0>')
+      api.nvim_input_mouse('move', '', '', 0, 0, 3)
+      api.nvim_input_mouse('move', '', '', 0, 0, 4)
+      eq(4, api.nvim_get_var('mouse_move'))
+      eq(0, api.nvim_get_var('mouse_move2'))
+    end)
+
+    it('<MouseMove> to same location does not generate events #31103', function()
+      api.nvim_set_var('mouse_move', 0)
+      api.nvim_set_var('mouse_move2', 0)
+      command('nnoremap <MouseMove> <Cmd>let g:mouse_move += 1<CR>')
+      command('nnoremap <2-MouseMove> <Cmd>let g:mouse_move2 += 1<CR>')
+      api.nvim_input_mouse('move', '', '', 0, 0, 3)
+      eq(1, api.nvim_get_var('mouse_move'))
+      eq(0, api.nvim_get_var('mouse_move2'))
+      feed('<MouseMove><3,0>')
+      feed('<MouseMove><3,0>')
+      api.nvim_input_mouse('move', '', '', 0, 0, 3)
+      api.nvim_input_mouse('move', '', '', 0, 0, 3)
+      eq(1, api.nvim_get_var('mouse_move'))
+      eq(0, api.nvim_get_var('mouse_move2'))
+      eq({ mode = 'n', blocking = false }, api.nvim_get_mode())
+      feed('<MouseMove><3,0><Insert>')
+      eq(1, api.nvim_get_var('mouse_move'))
+      eq(0, api.nvim_get_var('mouse_move2'))
+      eq({ mode = 'i', blocking = false }, api.nvim_get_mode())
+    end)
+
+    it('feeding <MouseMove> in Normal mode does not use uninitialized memory #19480', function()
+      feed('<MouseMove>')
+      n.poke_eventloop()
+      n.assert_alive()
+    end)
+
+    it('mousemodel=popup_setpos', function()
+      screen:try_resize(80, 24)
+      exec([[
+        5new
+        call setline(1, ['the dish ran away with the spoon',
+              \ 'the cow jumped over the moon' ])
+
+        set mouse=a mousemodel=popup_setpos
+
+        aunmenu PopUp
+        nmenu PopUp.foo :let g:menustr = 'foo'<CR>
+        nmenu PopUp.bar :let g:menustr = 'bar'<CR>
+        nmenu PopUp.baz :let g:menustr = 'baz'<CR>
+        vmenu PopUp.foo y:<C-U>let g:menustr = 'foo'<CR>
+        vmenu PopUp.bar y:<C-U>let g:menustr = 'bar'<CR>
+        vmenu PopUp.baz y:<C-U>let g:menustr = 'baz'<CR>
+      ]])
+
+      api.nvim_win_set_cursor(0, { 1, 0 })
+      api.nvim_input_mouse('right', 'press', '', 0, 0, 4)
+      api.nvim_input_mouse('right', 'release', '', 0, 0, 4)
+      feed('<Down><Down><CR>')
+      eq('bar', api.nvim_get_var('menustr'))
+      eq({ 1, 4 }, api.nvim_win_get_cursor(0))
+
+      -- Test for right click in visual mode inside the selection
+      fn.setreg('"', '')
+      api.nvim_win_set_cursor(0, { 1, 9 })
+      feed('vee')
+      api.nvim_input_mouse('right', 'press', '', 0, 0, 11)
+      api.nvim_input_mouse('right', 'release', '', 0, 0, 11)
+      feed('<Down><CR>')
+      eq({ 1, 9 }, api.nvim_win_get_cursor(0))
+      eq('ran away', fn.getreg('"'))
+
+      -- Test for right click in visual mode right before the selection
+      fn.setreg('"', '')
+      api.nvim_win_set_cursor(0, { 1, 9 })
+      feed('vee')
+      api.nvim_input_mouse('right', 'press', '', 0, 0, 8)
+      api.nvim_input_mouse('right', 'release', '', 0, 0, 8)
+      feed('<Down><CR>')
+      eq({ 1, 8 }, api.nvim_win_get_cursor(0))
+      eq('', fn.getreg('"'))
+
+      -- Test for right click in visual mode right after the selection
+      fn.setreg('"', '')
+      api.nvim_win_set_cursor(0, { 1, 9 })
+      feed('vee')
+      api.nvim_input_mouse('right', 'press', '', 0, 0, 17)
+      api.nvim_input_mouse('right', 'release', '', 0, 0, 17)
+      feed('<Down><CR>')
+      eq({ 1, 17 }, api.nvim_win_get_cursor(0))
+      eq('', fn.getreg('"'))
+
+      -- Test for right click in block-wise visual mode inside the selection
+      fn.setreg('"', '')
+      api.nvim_win_set_cursor(0, { 1, 15 })
+      feed('<C-V>j3l')
+      api.nvim_input_mouse('right', 'press', '', 0, 1, 16)
+      api.nvim_input_mouse('right', 'release', '', 0, 1, 16)
+      feed('<Down><CR>')
+      eq({ 1, 15 }, api.nvim_win_get_cursor(0))
+      eq('\0224', fn.getregtype('"'))
+
+      -- Test for right click in block-wise visual mode outside the selection
+      fn.setreg('"', '')
+      api.nvim_win_set_cursor(0, { 1, 15 })
+      feed('<C-V>j3l')
+      api.nvim_input_mouse('right', 'press', '', 0, 1, 1)
+      api.nvim_input_mouse('right', 'release', '', 0, 1, 1)
+      feed('<Down><CR>')
+      eq({ 2, 1 }, api.nvim_win_get_cursor(0))
+      eq('v', fn.getregtype('"'))
+      eq('', fn.getreg('"'))
+
+      -- Test for right click in line-wise visual mode inside the selection
+      fn.setreg('"', '')
+      api.nvim_win_set_cursor(0, { 1, 15 })
+      feed('V')
+      api.nvim_input_mouse('right', 'press', '', 0, 0, 9)
+      api.nvim_input_mouse('right', 'release', '', 0, 0, 9)
+      feed('<Down><CR>')
+      eq({ 1, 0 }, api.nvim_win_get_cursor(0)) -- After yanking, the cursor goes to 1,1
+      eq('V', fn.getregtype('"'))
+      eq(1, #fn.getreg('"', 1, true))
+
+      -- Test for right click in multi-line line-wise visual mode inside the selection
+      fn.setreg('"', '')
+      api.nvim_win_set_cursor(0, { 1, 15 })
+      feed('Vj')
+      api.nvim_input_mouse('right', 'press', '', 0, 1, 19)
+      api.nvim_input_mouse('right', 'release', '', 0, 1, 19)
+      feed('<Down><CR>')
+      eq({ 1, 0 }, api.nvim_win_get_cursor(0)) -- After yanking, the cursor goes to 1,1
+      eq('V', fn.getregtype('"'))
+      eq(2, #fn.getreg('"', 1, true))
+
+      -- Test for right click in line-wise visual mode outside the selection
+      fn.setreg('"', '')
+      api.nvim_win_set_cursor(0, { 1, 15 })
+      feed('V')
+      api.nvim_input_mouse('right', 'press', '', 0, 1, 9)
+      api.nvim_input_mouse('right', 'release', '', 0, 1, 9)
+      feed('<Down><CR>')
+      eq({ 2, 9 }, api.nvim_win_get_cursor(0))
+      eq('', fn.getreg('"'))
+
+      -- Try clicking outside the window
+      fn.setreg('"', '')
+      api.nvim_win_set_cursor(0, { 2, 1 })
+      feed('vee')
+      api.nvim_input_mouse('right', 'press', '', 0, 6, 1)
+      api.nvim_input_mouse('right', 'release', '', 0, 6, 1)
+      feed('<Down><CR>')
+      eq(2, fn.winnr())
+      eq('', fn.getreg('"'))
+
+      -- Test for right click in visual mode inside the selection with vertical splits
+      command('wincmd t')
+      command('rightbelow vsplit')
+      fn.setreg('"', '')
+      api.nvim_win_set_cursor(0, { 1, 9 })
+      feed('vee')
+      api.nvim_input_mouse('right', 'press', '', 0, 0, 52)
+      api.nvim_input_mouse('right', 'release', '', 0, 0, 52)
+      feed('<Down><CR>')
+      eq({ 1, 9 }, api.nvim_win_get_cursor(0))
+      eq('ran away', fn.getreg('"'))
+
+      -- Test for right click inside visual selection at bottom of window with winbar
+      command('setlocal winbar=WINBAR')
+      feed('2yyP')
+      fn.setreg('"', '')
+      feed('G$vbb')
+      api.nvim_input_mouse('right', 'press', '', 0, 4, 61)
+      api.nvim_input_mouse('right', 'release', '', 0, 4, 61)
+      feed('<Down><CR>')
+      eq({ 4, 20 }, api.nvim_win_get_cursor(0))
+      eq('the moon', fn.getreg('"'))
+
+      -- Try clicking in the cmdline
+      api.nvim_input_mouse('right', 'press', '', 0, 23, 0)
+      api.nvim_input_mouse('right', 'release', '', 0, 23, 0)
+      feed('<Down><Down><Down><CR>')
+      eq('baz', api.nvim_get_var('menustr'))
+
+      -- Try clicking in horizontal separator with global statusline
+      command('set laststatus=3')
+      api.nvim_input_mouse('right', 'press', '', 0, 5, 0)
+      api.nvim_input_mouse('right', 'release', '', 0, 5, 0)
+      feed('<Down><CR>')
+      eq('foo', api.nvim_get_var('menustr'))
+
+      -- Try clicking in the cmdline with global statusline
+      api.nvim_input_mouse('right', 'press', '', 0, 23, 0)
+      api.nvim_input_mouse('right', 'release', '', 0, 23, 0)
+      feed('<Down><Down><CR>')
+      eq('bar', api.nvim_get_var('menustr'))
+    end)
+
+    it('below a concealed line #33450', function()
+      api.nvim_set_option_value('conceallevel', 2, {})
+      api.nvim_buf_set_extmark(0, api.nvim_create_namespace(''), 1, 0, { conceal_lines = '' })
+      api.nvim_input_mouse('left', 'press', '', 0, 1, 0)
+      api.nvim_input_mouse('left', 'release', '', 0, 1, 0)
+      eq(3, fn.line('.'))
+      -- No error when clicking below last line that is concealed.
+      screen:try_resize(80, 10) -- Prevent hit-enter
+      api.nvim_set_option_value('cmdheight', 3, {})
+      local count = api.nvim_buf_line_count(0)
+      api.nvim_buf_set_extmark(0, 1, count - 1, 0, { conceal_lines = '' })
+      api.nvim_input_mouse('left', 'press', '', 0, count, 0)
+      eq('', api.nvim_get_vvar('errmsg'))
+    end)
+  end
+
+  describe('with ext_multigrid', function()
+    with_ext_multigrid(true)
   end)
 
-  it('scroll keys are not translated into multiclicks and can be mapped #6211 #6989', function()
-    api.nvim_set_var('mouse_up', 0)
-    api.nvim_set_var('mouse_up2', 0)
-    command('nnoremap <ScrollWheelUp> <Cmd>let g:mouse_up += 1<CR>')
-    command('nnoremap <2-ScrollWheelUp> <Cmd>let g:mouse_up2 += 1<CR>')
-    feed('<ScrollWheelUp><0,0>')
-    feed('<ScrollWheelUp><0,0>')
-    api.nvim_input_mouse('wheel', 'up', '', 0, 0, 0)
-    api.nvim_input_mouse('wheel', 'up', '', 0, 0, 0)
-    eq(4, api.nvim_get_var('mouse_up'))
-    eq(0, api.nvim_get_var('mouse_up2'))
-  end)
-
-  it('<MouseMove> to different locations can be mapped', function()
-    api.nvim_set_var('mouse_move', 0)
-    api.nvim_set_var('mouse_move2', 0)
-    command('nnoremap <MouseMove> <Cmd>let g:mouse_move += 1<CR>')
-    command('nnoremap <2-MouseMove> <Cmd>let g:mouse_move2 += 1<CR>')
-    feed('<MouseMove><1,0>')
-    feed('<MouseMove><2,0>')
-    api.nvim_input_mouse('move', '', '', 0, 0, 3)
-    api.nvim_input_mouse('move', '', '', 0, 0, 4)
-    eq(4, api.nvim_get_var('mouse_move'))
-    eq(0, api.nvim_get_var('mouse_move2'))
-  end)
-
-  it('<MouseMove> to same location does not generate events #31103', function()
-    api.nvim_set_var('mouse_move', 0)
-    api.nvim_set_var('mouse_move2', 0)
-    command('nnoremap <MouseMove> <Cmd>let g:mouse_move += 1<CR>')
-    command('nnoremap <2-MouseMove> <Cmd>let g:mouse_move2 += 1<CR>')
-    api.nvim_input_mouse('move', '', '', 0, 0, 3)
-    eq(1, api.nvim_get_var('mouse_move'))
-    eq(0, api.nvim_get_var('mouse_move2'))
-    feed('<MouseMove><3,0>')
-    feed('<MouseMove><3,0>')
-    api.nvim_input_mouse('move', '', '', 0, 0, 3)
-    api.nvim_input_mouse('move', '', '', 0, 0, 3)
-    eq(1, api.nvim_get_var('mouse_move'))
-    eq(0, api.nvim_get_var('mouse_move2'))
-    eq({ mode = 'n', blocking = false }, api.nvim_get_mode())
-    feed('<MouseMove><3,0><Insert>')
-    eq(1, api.nvim_get_var('mouse_move'))
-    eq(0, api.nvim_get_var('mouse_move2'))
-    eq({ mode = 'i', blocking = false }, api.nvim_get_mode())
-  end)
-
-  it('feeding <MouseMove> in Normal mode does not use uninitialized memory #19480', function()
-    feed('<MouseMove>')
-    n.poke_eventloop()
-    n.assert_alive()
-  end)
-
-  it('mousemodel=popup_setpos', function()
-    screen:try_resize(80, 24)
-    exec([[
-      5new
-      call setline(1, ['the dish ran away with the spoon',
-            \ 'the cow jumped over the moon' ])
-
-      set mouse=a mousemodel=popup_setpos
-
-      aunmenu PopUp
-      nmenu PopUp.foo :let g:menustr = 'foo'<CR>
-      nmenu PopUp.bar :let g:menustr = 'bar'<CR>
-      nmenu PopUp.baz :let g:menustr = 'baz'<CR>
-      vmenu PopUp.foo y:<C-U>let g:menustr = 'foo'<CR>
-      vmenu PopUp.bar y:<C-U>let g:menustr = 'bar'<CR>
-      vmenu PopUp.baz y:<C-U>let g:menustr = 'baz'<CR>
-    ]])
-
-    api.nvim_win_set_cursor(0, { 1, 0 })
-    api.nvim_input_mouse('right', 'press', '', 0, 0, 4)
-    api.nvim_input_mouse('right', 'release', '', 0, 0, 4)
-    feed('<Down><Down><CR>')
-    eq('bar', api.nvim_get_var('menustr'))
-    eq({ 1, 4 }, api.nvim_win_get_cursor(0))
-
-    -- Test for right click in visual mode inside the selection
-    fn.setreg('"', '')
-    api.nvim_win_set_cursor(0, { 1, 9 })
-    feed('vee')
-    api.nvim_input_mouse('right', 'press', '', 0, 0, 11)
-    api.nvim_input_mouse('right', 'release', '', 0, 0, 11)
-    feed('<Down><CR>')
-    eq({ 1, 9 }, api.nvim_win_get_cursor(0))
-    eq('ran away', fn.getreg('"'))
-
-    -- Test for right click in visual mode right before the selection
-    fn.setreg('"', '')
-    api.nvim_win_set_cursor(0, { 1, 9 })
-    feed('vee')
-    api.nvim_input_mouse('right', 'press', '', 0, 0, 8)
-    api.nvim_input_mouse('right', 'release', '', 0, 0, 8)
-    feed('<Down><CR>')
-    eq({ 1, 8 }, api.nvim_win_get_cursor(0))
-    eq('', fn.getreg('"'))
-
-    -- Test for right click in visual mode right after the selection
-    fn.setreg('"', '')
-    api.nvim_win_set_cursor(0, { 1, 9 })
-    feed('vee')
-    api.nvim_input_mouse('right', 'press', '', 0, 0, 17)
-    api.nvim_input_mouse('right', 'release', '', 0, 0, 17)
-    feed('<Down><CR>')
-    eq({ 1, 17 }, api.nvim_win_get_cursor(0))
-    eq('', fn.getreg('"'))
-
-    -- Test for right click in block-wise visual mode inside the selection
-    fn.setreg('"', '')
-    api.nvim_win_set_cursor(0, { 1, 15 })
-    feed('<C-V>j3l')
-    api.nvim_input_mouse('right', 'press', '', 0, 1, 16)
-    api.nvim_input_mouse('right', 'release', '', 0, 1, 16)
-    feed('<Down><CR>')
-    eq({ 1, 15 }, api.nvim_win_get_cursor(0))
-    eq('\0224', fn.getregtype('"'))
-
-    -- Test for right click in block-wise visual mode outside the selection
-    fn.setreg('"', '')
-    api.nvim_win_set_cursor(0, { 1, 15 })
-    feed('<C-V>j3l')
-    api.nvim_input_mouse('right', 'press', '', 0, 1, 1)
-    api.nvim_input_mouse('right', 'release', '', 0, 1, 1)
-    feed('<Down><CR>')
-    eq({ 2, 1 }, api.nvim_win_get_cursor(0))
-    eq('v', fn.getregtype('"'))
-    eq('', fn.getreg('"'))
-
-    -- Test for right click in line-wise visual mode inside the selection
-    fn.setreg('"', '')
-    api.nvim_win_set_cursor(0, { 1, 15 })
-    feed('V')
-    api.nvim_input_mouse('right', 'press', '', 0, 0, 9)
-    api.nvim_input_mouse('right', 'release', '', 0, 0, 9)
-    feed('<Down><CR>')
-    eq({ 1, 0 }, api.nvim_win_get_cursor(0)) -- After yanking, the cursor goes to 1,1
-    eq('V', fn.getregtype('"'))
-    eq(1, #fn.getreg('"', 1, true))
-
-    -- Test for right click in multi-line line-wise visual mode inside the selection
-    fn.setreg('"', '')
-    api.nvim_win_set_cursor(0, { 1, 15 })
-    feed('Vj')
-    api.nvim_input_mouse('right', 'press', '', 0, 1, 19)
-    api.nvim_input_mouse('right', 'release', '', 0, 1, 19)
-    feed('<Down><CR>')
-    eq({ 1, 0 }, api.nvim_win_get_cursor(0)) -- After yanking, the cursor goes to 1,1
-    eq('V', fn.getregtype('"'))
-    eq(2, #fn.getreg('"', 1, true))
-
-    -- Test for right click in line-wise visual mode outside the selection
-    fn.setreg('"', '')
-    api.nvim_win_set_cursor(0, { 1, 15 })
-    feed('V')
-    api.nvim_input_mouse('right', 'press', '', 0, 1, 9)
-    api.nvim_input_mouse('right', 'release', '', 0, 1, 9)
-    feed('<Down><CR>')
-    eq({ 2, 9 }, api.nvim_win_get_cursor(0))
-    eq('', fn.getreg('"'))
-
-    -- Try clicking outside the window
-    fn.setreg('"', '')
-    api.nvim_win_set_cursor(0, { 2, 1 })
-    feed('vee')
-    api.nvim_input_mouse('right', 'press', '', 0, 6, 1)
-    api.nvim_input_mouse('right', 'release', '', 0, 6, 1)
-    feed('<Down><CR>')
-    eq(2, fn.winnr())
-    eq('', fn.getreg('"'))
-
-    -- Test for right click in visual mode inside the selection with vertical splits
-    command('wincmd t')
-    command('rightbelow vsplit')
-    fn.setreg('"', '')
-    api.nvim_win_set_cursor(0, { 1, 9 })
-    feed('vee')
-    api.nvim_input_mouse('right', 'press', '', 0, 0, 52)
-    api.nvim_input_mouse('right', 'release', '', 0, 0, 52)
-    feed('<Down><CR>')
-    eq({ 1, 9 }, api.nvim_win_get_cursor(0))
-    eq('ran away', fn.getreg('"'))
-
-    -- Test for right click inside visual selection at bottom of window with winbar
-    command('setlocal winbar=WINBAR')
-    feed('2yyP')
-    fn.setreg('"', '')
-    feed('G$vbb')
-    api.nvim_input_mouse('right', 'press', '', 0, 4, 61)
-    api.nvim_input_mouse('right', 'release', '', 0, 4, 61)
-    feed('<Down><CR>')
-    eq({ 4, 20 }, api.nvim_win_get_cursor(0))
-    eq('the moon', fn.getreg('"'))
-
-    -- Try clicking in the cmdline
-    api.nvim_input_mouse('right', 'press', '', 0, 23, 0)
-    api.nvim_input_mouse('right', 'release', '', 0, 23, 0)
-    feed('<Down><Down><Down><CR>')
-    eq('baz', api.nvim_get_var('menustr'))
-
-    -- Try clicking in horizontal separator with global statusline
-    command('set laststatus=3')
-    api.nvim_input_mouse('right', 'press', '', 0, 5, 0)
-    api.nvim_input_mouse('right', 'release', '', 0, 5, 0)
-    feed('<Down><CR>')
-    eq('foo', api.nvim_get_var('menustr'))
-
-    -- Try clicking in the cmdline with global statusline
-    api.nvim_input_mouse('right', 'press', '', 0, 23, 0)
-    api.nvim_input_mouse('right', 'release', '', 0, 23, 0)
-    feed('<Down><Down><CR>')
-    eq('bar', api.nvim_get_var('menustr'))
-  end)
-
-  it('below a concealed line #33450', function()
-    api.nvim_set_option_value('conceallevel', 2, {})
-    api.nvim_buf_set_extmark(0, api.nvim_create_namespace(''), 1, 0, { conceal_lines = '' })
-    api.nvim_input_mouse('left', 'press', '', 0, 1, 0)
-    api.nvim_input_mouse('left', 'release', '', 0, 1, 0)
-    eq(3, fn.line('.'))
-    -- No error when clicking below last line that is concealed.
-    screen:try_resize(80, 10) -- Prevent hit-enter
-    api.nvim_set_option_value('cmdheight', 3, {})
-    local count = api.nvim_buf_line_count(0)
-    api.nvim_buf_set_extmark(0, 1, count - 1, 0, { conceal_lines = '' })
-    api.nvim_input_mouse('left', 'press', '', 0, count, 0)
-    eq('', api.nvim_get_vvar('errmsg'))
+  describe('without ext_multigrid', function()
+    with_ext_multigrid(false)
   end)
 end)

--- a/test/functional/ui/multigrid_spec.lua
+++ b/test/functional/ui/multigrid_spec.lua
@@ -736,7 +736,7 @@ describe('ext_multigrid', function()
         {22:~    }|*4
       ]],
         float_pos = {
-          [4] = { 1001, 'SE', 2, 16, 58, true, 50, 1, 8, 48 },
+          [4] = { 1001, 'SE', 2, 16, 58, true, 50, 2, 8, 48 },
         },
       }
     end)
@@ -761,7 +761,7 @@ describe('ext_multigrid', function()
         {21: bar}|
       ]],
         float_pos = {
-          [4] = { -1, 'NW', 2, 15, 55, false, 100, 1, 15, 55 },
+          [4] = { -1, 'NW', 2, 15, 55, false, 100, 2, 15, 55 },
         },
       }
       feed('<C-E><Esc>')
@@ -786,7 +786,7 @@ describe('ext_multigrid', function()
         {21:            rab}|
       ]],
         float_pos = {
-          [4] = { -1, 'NW', 2, 16, 45, false, 100, 1, 16, 45 },
+          [4] = { -1, 'NW', 2, 16, 45, false, 100, 2, 16, 45 },
         },
       }
       feed('<C-E><Esc>')
@@ -811,7 +811,7 @@ describe('ext_multigrid', function()
         {21: unplace        }|
       ]],
         float_pos = {
-          [4] = { -1, 'SW', 1, 13, 5, false, 250, 2, 11, 5 },
+          [4] = { -1, 'SW', 1, 13, 5, false, 250, 3, 11, 5 },
         },
       }
     end)
@@ -1468,7 +1468,7 @@ describe('ext_multigrid', function()
       {21: Copy }|
     ]],
       float_pos = {
-        [6] = { -1, 'NW', 2, 2, 5, false, 250, 2, 7, 36 },
+        [6] = { -1, 'NW', 2, 2, 5, false, 250, 5, 7, 36 },
       },
     }
     feed('<Down><CR>')
@@ -1549,7 +1549,7 @@ describe('ext_multigrid', function()
       {21: Copy }|
     ]],
       float_pos = {
-        [6] = { -1, 'NW', 4, 1, 63, false, 250, 2, 1, 63 },
+        [6] = { -1, 'NW', 4, 1, 63, false, 250, 5, 1, 63 },
       },
     }
     feed('<Down><CR>')
@@ -1680,7 +1680,7 @@ describe('ext_multigrid', function()
       {21: Copy }|
     ]],
       float_pos = {
-        [6] = { -1, 'SW', 4, 9, 0, false, 250, 2, 14, 0 },
+        [6] = { -1, 'SW', 4, 9, 0, false, 250, 5, 14, 0 },
       },
     }
     feed('<Down><CR>')
@@ -1821,7 +1821,7 @@ describe('ext_multigrid', function()
       {21: Copy }|
     ]],
       float_pos = {
-        [6] = { -1, 'NW', 4, 10, 0, false, 250, 2, 16, 0 },
+        [6] = { -1, 'NW', 4, 10, 0, false, 250, 5, 16, 0 },
       },
     }
     feed('<Down><CR>')

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -1018,7 +1018,7 @@ end)
 describe('builtin popupmenu', function()
   before_each(clear)
 
-  local function with_ext_multigrid(multigrid)
+  local function with_ext_multigrid(multigrid, send_mouse_grid)
     local screen
     before_each(function()
       screen = Screen.new(32, 20, { ext_multigrid = multigrid })
@@ -2553,8 +2553,12 @@ describe('builtin popupmenu', function()
         ]])
       end
 
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('wheel', 'down', '', 2, 9, 33)
+      else
+        api.nvim_input_mouse('wheel', 'down', '', 0, 9, 40)
+      end
+      if multigrid then
         screen:expect({
           grid = [[
           ## grid 1
@@ -2595,7 +2599,6 @@ describe('builtin popupmenu', function()
           float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
         })
       else
-        api.nvim_input_mouse('wheel', 'down', '', 0, 9, 40)
         screen:expect([[
           Est ^                                                        |
             L{n: sunt           }{12: }sit amet, consectetur                   |
@@ -2672,8 +2675,12 @@ describe('builtin popupmenu', function()
         ]])
       end
 
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('wheel', 'up', '', 2, 9, 33)
+      else
+        api.nvim_input_mouse('wheel', 'up', '', 0, 9, 40)
+      end
+      if multigrid then
         screen:expect({
           grid = [[
           ## grid 1
@@ -2712,7 +2719,6 @@ describe('builtin popupmenu', function()
           float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
         })
       else
-        api.nvim_input_mouse('wheel', 'up', '', 0, 9, 40)
         screen:expect([[
           Est e^                                                       |
             L{n: elit           } sit amet, consectetur                   |
@@ -2781,8 +2787,12 @@ describe('builtin popupmenu', function()
         ]])
       end
 
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('wheel', 'down', '', 2, 9, 33)
+      else
+        api.nvim_input_mouse('wheel', 'down', '', 0, 9, 40)
+      end
+      if multigrid then
         screen:expect({
           grid = [[
           ## grid 1
@@ -2813,7 +2823,6 @@ describe('builtin popupmenu', function()
           float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
         })
       else
-        api.nvim_input_mouse('wheel', 'down', '', 0, 9, 40)
         screen:expect([[
           Est es^                                                      |
             L{n: esse           } sit amet, consectetur                   |
@@ -2948,8 +2957,12 @@ describe('builtin popupmenu', function()
         ]])
       end
 
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('wheel', 'down', '', 2, 9, 33)
+      else
+        api.nvim_input_mouse('wheel', 'down', '', 0, 9, 40)
+      end
+      if multigrid then
         screen:expect({
           grid = [[
           ## grid 1
@@ -2988,7 +3001,6 @@ describe('builtin popupmenu', function()
           float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
         })
       else
-        api.nvim_input_mouse('wheel', 'down', '', 0, 9, 40)
         screen:expect([[
           Est eu^                                                      |
             L{n: elit           } sit amet, consectetur                   |
@@ -6614,9 +6626,13 @@ describe('builtin popupmenu', function()
         return new_state
       end
 
-      local no_sel_screen ---@type string|test.functional.ui.screen.Expect
-      if multigrid then
+      local no_sel_screen ---@type string|test.function.ui.screen.Expect
+      if send_mouse_grid then
         api.nvim_input_mouse('right', 'press', '', 2, 0, 4)
+      else
+        feed('<RightMouse><4,0>')
+      end
+      if multigrid then
         no_sel_screen = {
           grid = [[
         ## grid 1
@@ -6635,7 +6651,6 @@ describe('builtin popupmenu', function()
           float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250, 2, 1, 3 } },
         }
       else
-        feed('<RightMouse><4,0>')
         no_sel_screen = [[
           ^popup menu test                 |
           {1:~  }{n: foo }{1:                        }|
@@ -6673,8 +6688,12 @@ describe('builtin popupmenu', function()
       screen:expect(no_menu_screen)
       eq('bar', api.nvim_get_var('menustr'))
 
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('right', 'press', '', 2, 2, 20)
+      else
+        feed('<RightMouse><20,2>')
+      end
+      if multigrid then
         screen:expect({
           grid = [[
         ## grid 1
@@ -6693,7 +6712,6 @@ describe('builtin popupmenu', function()
           float_pos = { [4] = { -1, 'NW', 2, 3, 19, false, 250, 2, 3, 19 } },
         })
       else
-        feed('<RightMouse><20,2>')
         screen:expect([[
           ^popup menu test                 |
           {1:~                               }|*2
@@ -6702,8 +6720,12 @@ describe('builtin popupmenu', function()
           :let g:menustr = 'b{n: baz }        |
         ]])
       end
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('right', 'press', '', 2, 0, 18)
+      else
+        feed('<RightMouse><18,0>')
+      end
+      if multigrid then
         screen:expect({
           grid = [[
         ## grid 1
@@ -6722,7 +6744,6 @@ describe('builtin popupmenu', function()
           float_pos = { [4] = { -1, 'NW', 2, 1, 17, false, 250, 2, 1, 17 } },
         })
       else
-        feed('<RightMouse><18,0>')
         screen:expect([[
           ^popup menu test                 |
           {1:~                }{n: foo }{1:          }|
@@ -6732,8 +6753,12 @@ describe('builtin popupmenu', function()
           :let g:menustr = 'bar'          |
         ]])
       end
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('right', 'press', '', 4, 1, 3)
+      else
+        feed('<RightMouse><20,2>')
+      end
+      if multigrid then
         screen:expect({
           grid = [[
         ## grid 1
@@ -6752,7 +6777,6 @@ describe('builtin popupmenu', function()
           float_pos = { [4] = { -1, 'NW', 2, 3, 19, false, 250, 2, 3, 19 } },
         })
       else
-        feed('<RightMouse><20,2>')
         screen:expect([[
           ^popup menu test                 |
           {1:~                               }|*2
@@ -6761,7 +6785,7 @@ describe('builtin popupmenu', function()
           :let g:menustr = 'b{n: baz }        |
         ]])
       end
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('left', 'press', '', 4, 2, 2)
       else
         feed('<LeftMouse><21,5>')
@@ -6770,8 +6794,12 @@ describe('builtin popupmenu', function()
       screen:expect(no_menu_screen)
       eq('baz', api.nvim_get_var('menustr'))
 
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('right', 'press', '', 2, 0, 4)
+      else
+        feed('<RightMouse><4,0>')
+      end
+      if multigrid then
         no_sel_screen = {
           grid = [[
         ## grid 1
@@ -6790,7 +6818,6 @@ describe('builtin popupmenu', function()
           float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250, 2, 1, 3 } },
         }
       else
-        feed('<RightMouse><4,0>')
         no_sel_screen = [[
           ^popup menu test                 |
           {1:~  }{n: foo }{1:                        }|
@@ -6801,13 +6828,13 @@ describe('builtin popupmenu', function()
         ]]
       end
       screen:expect(no_sel_screen)
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('right', 'drag', '', 2, 3, 6)
       else
         feed('<RightDrag><6,3>')
       end
       screen:expect(screen_replace(no_sel_screen, '{n: baz }', '{12: baz }'))
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('right', 'release', '', 2, 1, 6)
       else
         feed('<RightRelease><6,1>')
@@ -6818,35 +6845,36 @@ describe('builtin popupmenu', function()
       no_sel_screen = screen_replace(no_sel_screen, [['baz']], [['foo']])
 
       eq(false, screen.options.mousemoveevent)
-      if multigrid then
+
+      if send_mouse_grid then
         api.nvim_input_mouse('right', 'press', '', 2, 0, 4)
       else
         feed('<RightMouse><4,0>')
       end
       screen:expect(no_sel_screen)
       eq(true, screen.options.mousemoveevent)
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('wheel', 'up', '', 2, 0, 4)
       else
         feed('<ScrollWheelUp><4,0>')
       end
       screen:expect(screen_replace(no_sel_screen, '{n: foo }', '{12: foo }'))
       eq(true, screen.options.mousemoveevent)
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('move', '', '', 4, 2, 3)
       else
         feed('<MouseMove><6,3>')
       end
       screen:expect(screen_replace(no_sel_screen, '{n: baz }', '{12: baz }'))
       eq(true, screen.options.mousemoveevent)
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('wheel', 'down', '', 4, 2, 3)
       else
         feed('<ScrollWheelDown><6,3>')
       end
       screen:expect(screen_replace(no_sel_screen, '{n: bar }', '{12: bar }'))
       eq(true, screen.options.mousemoveevent)
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('left', 'press', '', 4, 1, 3)
       else
         feed('<LeftMouse><6,2>')
@@ -6857,8 +6885,12 @@ describe('builtin popupmenu', function()
       eq('bar', api.nvim_get_var('menustr'))
 
       command('set laststatus=0 | botright split')
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('right', 'press', '', 5, 1, 20)
+      else
+        feed('<RightMouse><20,4>')
+      end
+      if multigrid then
         screen:expect({
           grid = [[
         ## grid 1
@@ -6882,7 +6914,6 @@ describe('builtin popupmenu', function()
           float_pos = { [4] = { -1, 'SW', 5, 1, 19, false, 250, 2, 1, 19 } },
         })
       else
-        feed('<RightMouse><20,4>')
         screen:expect([[
           popup menu test                 |
           {1:~                  }{n: foo }{1:        }|
@@ -6892,8 +6923,12 @@ describe('builtin popupmenu', function()
           :let g:menustr = 'bar'          |
         ]])
       end
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('left', 'press', '', 4, 2, 2)
+      else
+        feed('<LeftMouse><21,3>')
+      end
+      if multigrid then
         screen:expect([[
         ## grid 1
           [2:--------------------------------]|*2
@@ -6910,7 +6945,6 @@ describe('builtin popupmenu', function()
           {1:~                               }|
         ]])
       else
-        feed('<LeftMouse><21,3>')
         screen:expect([[
           popup menu test                 |
           {1:~                               }|
@@ -6923,8 +6957,12 @@ describe('builtin popupmenu', function()
       eq('baz', api.nvim_get_var('menustr'))
 
       command('set winwidth=1 | rightbelow vsplit')
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('right', 'press', '', 6, 1, 14)
+      else
+        feed('<RightMouse><30,4>')
+      end
+      if multigrid then
         screen:expect({
           grid = [[
         ## grid 1
@@ -6951,7 +6989,6 @@ describe('builtin popupmenu', function()
           float_pos = { [4] = { -1, 'SW', 6, 1, 12, false, 250, 2, 1, 28 } },
         })
       else
-        feed('<RightMouse><30,4>')
         screen:expect([[
           popup menu test                 |
           {1:~                           }{n: foo}|
@@ -6961,8 +6998,12 @@ describe('builtin popupmenu', function()
           :let g:menustr = 'baz'          |
         ]])
       end
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('left', 'press', '', 4, 0, 2)
+      else
+        feed('<LeftMouse><31,1>')
+      end
+      if multigrid then
         screen:expect([[
         ## grid 1
           [2:--------------------------------]|*2
@@ -6982,7 +7023,6 @@ describe('builtin popupmenu', function()
           {1:~               }|
         ]])
       else
-        feed('<LeftMouse><31,1>')
         screen:expect([[
           popup menu test                 |
           {1:~                               }|
@@ -6995,8 +7035,12 @@ describe('builtin popupmenu', function()
       eq('foo', api.nvim_get_var('menustr'))
 
       command('setlocal winbar=WINBAR')
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('right', 'press', '', 6, 1, 14)
+      else
+        feed('<RightMouse><30,4>')
+      end
+      if multigrid then
         no_sel_screen = {
           grid = [[
         ## grid 1
@@ -7023,7 +7067,6 @@ describe('builtin popupmenu', function()
           float_pos = { [4] = { -1, 'SW', 6, 1, 12, false, 250, 2, 1, 28 } },
         }
       else
-        feed('<RightMouse><30,4>')
         no_sel_screen = [[
           popup menu test                 |
           {1:~                           }{n: foo}|
@@ -7034,20 +7077,24 @@ describe('builtin popupmenu', function()
         ]]
       end
       screen:expect(no_sel_screen)
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('right', 'drag', '', 6, 0, 15)
       else
         feed('<RightDrag><31,3>')
       end
       screen:expect(screen_replace(no_sel_screen, '{n: baz}', '{12: baz}'))
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('right', 'release', '', 6, 1, 15)
       else
         feed('<RightRelease><31,4>')
       end
       screen:expect(no_sel_screen)
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('left', 'press', '', 4, 1, 2)
+      else
+        feed('<LeftMouse><31,2>')
+      end
+      if multigrid then
         screen:expect([[
         ## grid 1
           [2:--------------------------------]|*2
@@ -7067,7 +7114,6 @@ describe('builtin popupmenu', function()
           ^popup menu test |
         ]])
       else
-        feed('<LeftMouse><31,2>')
         screen:expect([[
           popup menu test                 |
           {1:~                               }|
@@ -7181,7 +7227,7 @@ describe('builtin popupmenu', function()
         { 0, 5, 19 },
         { 0, 5, 18 },
       }
-      if multigrid then
+      if send_mouse_grid then
         for i = 1, 7 do
           local _, row, col = unpack(pos[i])
           pos[i] = { 2, row - 2, col - 5 }
@@ -7206,7 +7252,7 @@ describe('builtin popupmenu', function()
       screen:expect(no_menu_screen)
       eq('', api.nvim_get_var('menustr'))
 
-      if multigrid then
+      if send_mouse_grid then
         for i = 2, 6, 2 do
           local _, row, col = unpack(pos[i])
           pos[i] = { 4, row - 1, col - 14 }
@@ -7329,7 +7375,7 @@ describe('builtin popupmenu', function()
         { 0, 5, 21 },
         { 0, 5, 22 },
       }
-      if multigrid then
+      if send_mouse_grid then
         for i = 1, 7 do
           local _, row, col = unpack(pos[i])
           pos[i] = { 2, row - 2, col - 5 }
@@ -7352,7 +7398,7 @@ describe('builtin popupmenu', function()
       screen:expect(no_menu_screen)
       eq('', api.nvim_get_var('menustr'))
 
-      if multigrid then
+      if send_mouse_grid then
         for i = 2, 6, 2 do
           local _, row, col = unpack(pos[i])
           pos[i] = { 4, row - 1, col - 12 }
@@ -7551,8 +7597,12 @@ describe('builtin popupmenu', function()
         call setline(1, join(range(20)))
       ]])
 
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('right', 'press', '', 2, 0, 45 - 1)
+      else
+        api.nvim_input_mouse('right', 'press', '', 0, 0, 45 - 1)
+      end
+      if multigrid then
         screen:expect({
           grid = [[
           ## grid 1
@@ -7578,7 +7628,6 @@ describe('builtin popupmenu', function()
           float_pos = { [4] = { -1, 'NW', 2, 1, 33, false, 250, 2, 1, 33 } },
         })
       else
-        api.nvim_input_mouse('right', 'press', '', 0, 0, 45 - 1)
         screen:expect([[
           0 1 2 3 4 5 6 7 8 9 10 11 12 13 14 15 16 17 ^18 19 |
           {1:~                                }{n: Undo            }|
@@ -7598,8 +7647,12 @@ describe('builtin popupmenu', function()
       feed('<Esc>')
 
       command('set rightleft')
-      if multigrid then
+      if send_mouse_grid then
         api.nvim_input_mouse('right', 'press', '', 2, 0, 50 - 45)
+      else
+        api.nvim_input_mouse('right', 'press', '', 0, 0, 50 - 45)
+      end
+      if multigrid then
         screen:expect({
           grid = [[
           ## grid 1
@@ -7625,7 +7678,6 @@ describe('builtin popupmenu', function()
           float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 250, 2, 1, 0 } },
         })
       else
-        api.nvim_input_mouse('right', 'press', '', 0, 0, 50 - 45)
         screen:expect([[
            91 8^1 71 61 51 41 31 21 11 01 9 8 7 6 5 4 3 2 1 0|
           {n:            odnU }{1:                                ~}|
@@ -8678,11 +8730,15 @@ describe('builtin popupmenu', function()
     end
   end
 
-  describe('with ext_multigrid', function()
-    with_ext_multigrid(true)
+  describe('with ext_multigrid and actual mouse grid', function()
+    with_ext_multigrid(true, true)
+  end)
+
+  describe('with ext_multigrid and mouse grid 0', function()
+    with_ext_multigrid(true, false)
   end)
 
   describe('without ext_multigrid', function()
-    with_ext_multigrid(false)
+    with_ext_multigrid(false, false)
   end)
 end)

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -42,31 +42,43 @@ describe('ui/ext_popupmenu', function()
       foo^                                                         |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-      ]],
-      popupmenu = { items = expected, pos = 0, anchor = { 1, 1, 0 } },
+    ]],
+      popupmenu = {
+        items = expected,
+        pos = 0,
+        anchor = { 2, 1, 0 },
+      },
     }
 
     feed('<c-p>')
     screen:expect {
       grid = [[
-                                                                    |
-        ^                                                            |
-        {1:~                                                           }|*5
-        {5:-- INSERT --}                                                |
-      ]],
-      popupmenu = { items = expected, pos = -1, anchor = { 1, 1, 0 } },
+                                                                  |
+      ^                                                            |
+      {1:~                                                           }|*5
+      {5:-- INSERT --}                                                |
+    ]],
+      popupmenu = {
+        items = expected,
+        pos = -1,
+        anchor = { 2, 1, 0 },
+      },
     }
 
     -- down moves the selection in the menu, but does not insert anything
     feed('<down><down>')
     screen:expect {
       grid = [[
-                                                                    |
-        ^                                                            |
-        {1:~                                                           }|*5
-        {5:-- INSERT --}                                                |
-      ]],
-      popupmenu = { items = expected, pos = 1, anchor = { 1, 1, 0 } },
+                                                                  |
+      ^                                                            |
+      {1:~                                                           }|*5
+      {5:-- INSERT --}                                                |
+    ]],
+      popupmenu = {
+        items = expected,
+        pos = 1,
+        anchor = { 2, 1, 0 },
+      },
     }
 
     feed('<cr>')
@@ -86,8 +98,12 @@ describe('ui/ext_popupmenu', function()
       foo^                                                         |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-      ]],
-      popupmenu = { items = expected, pos = 0, anchor = { 1, 1, 0 } },
+    ]],
+      popupmenu = {
+        items = expected,
+        pos = 0,
+        anchor = { 2, 1, 0 },
+      },
     }
 
     api.nvim_select_popupmenu_item(1, false, false, {})
@@ -97,8 +113,12 @@ describe('ui/ext_popupmenu', function()
       foo^                                                         |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-      ]],
-      popupmenu = { items = expected, pos = 1, anchor = { 1, 1, 0 } },
+    ]],
+      popupmenu = {
+        items = expected,
+        pos = 1,
+        anchor = { 2, 1, 0 },
+      },
     }
 
     api.nvim_select_popupmenu_item(2, true, false, {})
@@ -108,8 +128,12 @@ describe('ui/ext_popupmenu', function()
       spam^                                                        |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-      ]],
-      popupmenu = { items = expected, pos = 2, anchor = { 1, 1, 0 } },
+    ]],
+      popupmenu = {
+        items = expected,
+        pos = 2,
+        anchor = { 2, 1, 0 },
+      },
     }
 
     api.nvim_select_popupmenu_item(0, true, true, {})
@@ -127,8 +151,12 @@ describe('ui/ext_popupmenu', function()
       foo^                                                         |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-      ]],
-      popupmenu = { items = expected, pos = 0, anchor = { 1, 1, 0 } },
+    ]],
+      popupmenu = {
+        items = expected,
+        pos = 0,
+        anchor = { 2, 1, 0 },
+      },
     }
 
     api.nvim_select_popupmenu_item(-1, false, false, {})
@@ -138,8 +166,12 @@ describe('ui/ext_popupmenu', function()
       foo^                                                         |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-      ]],
-      popupmenu = { items = expected, pos = -1, anchor = { 1, 1, 0 } },
+    ]],
+      popupmenu = {
+        items = expected,
+        pos = -1,
+        anchor = { 2, 1, 0 },
+      },
     }
 
     api.nvim_select_popupmenu_item(1, true, false, {})
@@ -149,8 +181,12 @@ describe('ui/ext_popupmenu', function()
       bar^                                                         |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-      ]],
-      popupmenu = { items = expected, pos = 1, anchor = { 1, 1, 0 } },
+    ]],
+      popupmenu = {
+        items = expected,
+        pos = 1,
+        anchor = { 2, 1, 0 },
+      },
     }
 
     api.nvim_select_popupmenu_item(-1, true, false, {})
@@ -160,8 +196,12 @@ describe('ui/ext_popupmenu', function()
       ^                                                            |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-      ]],
-      popupmenu = { items = expected, pos = -1, anchor = { 1, 1, 0 } },
+    ]],
+      popupmenu = {
+        items = expected,
+        pos = -1,
+        anchor = { 2, 1, 0 },
+      },
     }
 
     api.nvim_select_popupmenu_item(0, true, false, {})
@@ -171,8 +211,12 @@ describe('ui/ext_popupmenu', function()
       foo^                                                         |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-      ]],
-      popupmenu = { items = expected, pos = 0, anchor = { 1, 1, 0 } },
+    ]],
+      popupmenu = {
+        items = expected,
+        pos = 0,
+        anchor = { 2, 1, 0 },
+      },
     }
 
     api.nvim_select_popupmenu_item(-1, true, true, {})
@@ -259,7 +303,11 @@ describe('ui/ext_popupmenu', function()
         {1:~                                                           }|*5
         {5:-- INSERT --}                                                |
       ]],
-        popupmenu = { items = expected, pos = 0, anchor = { 1, 1, 0 } },
+        popupmenu = {
+          items = expected,
+          pos = 0,
+          anchor = { 2, 1, 0 },
+        },
       }
 
       feed('<f1>')
@@ -270,7 +318,11 @@ describe('ui/ext_popupmenu', function()
         {1:~                                                           }|*5
         {5:-- INSERT --}                                                |
       ]],
-        popupmenu = { items = expected, pos = 2, anchor = { 1, 1, 0 } },
+        popupmenu = {
+          items = expected,
+          pos = 2,
+          anchor = { 2, 1, 0 },
+        },
       }
 
       feed('<f2>')
@@ -281,7 +333,11 @@ describe('ui/ext_popupmenu', function()
         {1:~                                                           }|*5
         {5:-- INSERT --}                                                |
       ]],
-        popupmenu = { items = expected, pos = -1, anchor = { 1, 1, 0 } },
+        popupmenu = {
+          items = expected,
+          pos = -1,
+          anchor = { 2, 1, 0 },
+        },
       }
 
       feed('<f3>')
@@ -522,7 +578,11 @@ describe('ui/ext_popupmenu', function()
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
       ]],
-        popupmenu = { items = month_expected, pos = pum_height - 2, anchor = { 1, 1, 0 } },
+        popupmenu = {
+          items = month_expected,
+          pos = pum_height - 2,
+          anchor = { 2, 1, 0 },
+        },
       }
     end)
 
@@ -570,7 +630,11 @@ describe('ui/ext_popupmenu', function()
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
       ]],
-        popupmenu = { items = month_expected, pos = pum_height - 2, anchor = { 1, 1, 0 } },
+        popupmenu = {
+          items = month_expected,
+          pos = pum_height - 2,
+          anchor = { 2, 1, 0 },
+        },
       }
     end)
 
@@ -621,7 +685,11 @@ describe('ui/ext_popupmenu', function()
     {1:~                                                           }|*5
     {5:-- INSERT --}                                                |
     ]],
-      popupmenu = { items = month_expected, pos = 3, anchor = { 1, 1, 0 } },
+      popupmenu = {
+        items = month_expected,
+        pos = 3,
+        anchor = { 2, 1, 0 },
+      },
     }
     feed('<PageUp>')
     screen:expect {
@@ -631,7 +699,11 @@ describe('ui/ext_popupmenu', function()
     {1:~                                                           }|*5
     {5:-- INSERT --}                                                |
     ]],
-      popupmenu = { items = month_expected, pos = 0, anchor = { 1, 1, 0 } },
+      popupmenu = {
+        items = month_expected,
+        pos = 0,
+        anchor = { 2, 1, 0 },
+      },
     }
   end)
 
@@ -750,7 +822,11 @@ describe('ui/ext_popupmenu', function()
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
     ]],
-      popupmenu = { items = expected, pos = 0, anchor = { 1, 1, 0 } },
+      popupmenu = {
+        items = expected,
+        pos = 0,
+        anchor = { 2, 1, 0 },
+      },
     }
 
     feed('<c-p>')
@@ -761,7 +837,11 @@ describe('ui/ext_popupmenu', function()
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
     ]],
-      popupmenu = { items = expected, pos = -1, anchor = { 1, 1, 0 } },
+      popupmenu = {
+        items = expected,
+        pos = -1,
+        anchor = { 2, 1, 0 },
+      },
     }
 
     feed('<esc>')
@@ -1129,7 +1209,9 @@ describe('builtin popupmenu', function()
           {n:gg             }{12: }|
           {n:hh             }{12: }|
         ]],
-          float_pos = { [5] = { -1, 'NW', 2, 2, 0, false, 100, 1, 11, 0 } },
+          float_pos = {
+            [5] = { -1, 'NW', 2, 2, 0, false, 100, 3, 11, 0 },
+          },
         }
       else
         screen:expect([[
@@ -1185,7 +1267,9 @@ describe('builtin popupmenu', function()
           {n:gg             }{12: }|
           {n:hh             }{12: }|
         ]],
-          float_pos = { [5] = { -1, 'NW', 2, 2, 0, false, 100, 1, 2, 0 } },
+          float_pos = {
+            [5] = { -1, 'NW', 2, 2, 0, false, 100, 3, 2, 0 },
+          },
         }
       else
         screen:expect([[
@@ -1259,7 +1343,9 @@ describe('builtin popupmenu', function()
           {n:ll             }{12: }|
           {n:mm             }{12: }|
         ]],
-          float_pos = { [5] = { -1, 'SW', 2, 12, 0, false, 100, 1, 4, 0 } },
+          float_pos = {
+            [5] = { -1, 'SW', 2, 12, 0, false, 100, 3, 4, 0 },
+          },
         }
       else
         screen:expect([[
@@ -1333,7 +1419,9 @@ describe('builtin popupmenu', function()
           {n:hh             }{c: }|
           {n:ii             }{12: }|
         ]],
-          float_pos = { [5] = { -1, 'SW', 2, 8, 0, false, 100, 1, 8, 0 } },
+          float_pos = {
+            [5] = { -1, 'SW', 2, 8, 0, false, 100, 3, 8, 0 },
+          },
         }
       else
         screen:expect([[
@@ -1406,7 +1494,9 @@ describe('builtin popupmenu', function()
           {n:gg             }{12: }|
           {n:hh             }{12: }|
         ]],
-          float_pos = { [5] = { -1, 'SW', 2, 8, 0, false, 100, 1, 0, 0 } },
+          float_pos = {
+            [5] = { -1, 'SW', 2, 8, 0, false, 100, 3, 0, 0 },
+          },
         }
       else
         screen:expect([[
@@ -1489,7 +1579,9 @@ describe('builtin popupmenu', function()
               {n:ab5            }{12: }|
               {n:ab6            }{12: }|
             ]],
-            float_pos = { [5] = { -1, 'SW', 2, 6, 0, false, 100, 1, 9, 0 } },
+            float_pos = {
+              [5] = { -1, 'SW', 2, 6, 0, false, 100, 3, 9, 0 },
+            },
           })
         else
           screen:expect([[
@@ -1565,7 +1657,9 @@ describe('builtin popupmenu', function()
               {n:ab4            }{12: }|
               {n:ab5            }{12: }|
             ]],
-            float_pos = { [5] = { -1, 'SW', 2, 5, 0, false, 100, 1, 9, 0 } },
+            float_pos = {
+              [5] = { -1, 'SW', 2, 5, 0, false, 100, 3, 9, 0 },
+            },
           })
         else
           screen:expect([[
@@ -1622,7 +1716,9 @@ describe('builtin popupmenu', function()
             {n:two            }|
             {n:three          }|
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
+          },
         })
       else
         screen:expect([[
@@ -1657,7 +1753,9 @@ describe('builtin popupmenu', function()
             1info                           |
             {1:~                               }|*2
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 5, 0 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 1, 0, false, 100, 3, 5, 0 },
+          },
         })
       else
         screen:expect([[
@@ -1713,7 +1811,9 @@ describe('builtin popupmenu', function()
             {n:aa6bb          }{12: }|
             {n:aa7bb          }{12: }|
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
+          },
         })
       else
         screen:expect([[
@@ -1801,8 +1901,8 @@ describe('builtin popupmenu', function()
             ]],
             win_pos = { [2] = { height = 10, startcol = 0, startrow = 0, width = 40, win = 1000 } },
             float_pos = {
-              [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
-              [4] = { 1001, 'NW', 1, 1, 19, false, 50, 1, 1, 19 },
+              [5] = { -1, 'NW', 2, 1, 0, false, 100, 3, 1, 0 },
+              [4] = { 1001, 'NW', 1, 1, 19, false, 50, 2, 1, 19 },
             },
             win_viewport = {
               [2] = {
@@ -1861,8 +1961,8 @@ describe('builtin popupmenu', function()
             ]],
             win_pos = { [2] = { height = 10, startcol = 0, startrow = 0, width = 40, win = 1000 } },
             float_pos = {
-              [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
-              [4] = { 1001, 'NW', 1, 1, 15, false, 50, 1, 1, 15 },
+              [5] = { -1, 'NW', 2, 1, 0, false, 100, 3, 1, 0 },
+              [4] = { 1001, 'NW', 1, 1, 15, false, 50, 2, 1, 15 },
             },
             win_viewport = {
               [2] = {
@@ -1916,8 +2016,18 @@ describe('builtin popupmenu', function()
             ## grid 5
               {n:one            }|
             ]],
-            win_pos = { [2] = { height = 10, startcol = 0, startrow = 0, width = 40, win = 1000 } },
-            float_pos = { [5] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
+            win_pos = {
+              [2] = {
+                height = 10,
+                startcol = 0,
+                startrow = 0,
+                width = 40,
+                win = 1000,
+              },
+            },
+            float_pos = {
+              [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
+            },
             win_viewport = {
               [2] = {
                 win = 1000,
@@ -1976,8 +2086,8 @@ describe('builtin popupmenu', function()
             ]],
             win_pos = { [2] = { height = 10, startcol = 0, startrow = 0, width = 40, win = 1000 } },
             float_pos = {
-              [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
-              [4] = { 1001, 'NW', 1, 1, 19, false, 50, 1, 1, 19 },
+              [5] = { -1, 'NW', 2, 1, 0, false, 100, 3, 1, 0 },
+              [4] = { 1001, 'NW', 1, 1, 19, false, 50, 2, 1, 19 },
             },
             win_viewport = {
               [2] = {
@@ -2040,8 +2150,8 @@ describe('builtin popupmenu', function()
             ]],
             win_pos = { [2] = { height = 10, startcol = 0, startrow = 0, width = 40, win = 1000 } },
             float_pos = {
-              [5] = { -1, 'NW', 2, 1, 18, false, 100, 2, 1, 18 },
-              [4] = { 1001, 'NW', 1, 1, 13, false, 50, 1, 1, 13 },
+              [5] = { -1, 'NW', 2, 1, 18, false, 100, 3, 1, 18 },
+              [4] = { 1001, 'NW', 1, 1, 13, false, 50, 2, 1, 13 },
             },
             win_viewport = {
               [2] = {
@@ -2108,8 +2218,8 @@ describe('builtin popupmenu', function()
             ]],
             win_pos = { [2] = { height = 10, startcol = 0, startrow = 0, width = 40, win = 1000 } },
             float_pos = {
-              [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
-              [4] = { 1001, 'NW', 1, 1, 19, false, 50, 1, 1, 19 },
+              [5] = { -1, 'NW', 2, 1, 0, false, 100, 3, 1, 0 },
+              [4] = { 1001, 'NW', 1, 1, 19, false, 50, 2, 1, 19 },
             },
             win_viewport = {
               [2] = {
@@ -2180,8 +2290,8 @@ describe('builtin popupmenu', function()
             ]],
             win_pos = { [2] = { height = 10, startcol = 0, startrow = 0, width = 40, win = 1000 } },
             float_pos = {
-              [5] = { 1001, 'NW', 1, 1, 19, false, 50, 1, 1, 19 },
-              [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
+              [5] = { 1001, 'NW', 1, 1, 19, false, 50, 2, 1, 19 },
+              [4] = { -1, 'NW', 2, 1, 0, false, 100, 3, 1, 0 },
             },
             win_viewport = {
               [2] = {
@@ -2289,7 +2399,9 @@ describe('builtin popupmenu', function()
           {n: aab            }|
           {n: aac            }|
         ]],
-          float_pos = { [5] = { -1, 'NW', 4, 2, 3, false, 100, 1, 2, 3 } },
+          float_pos = {
+            [5] = { -1, 'NW', 4, 2, 3, false, 100, 3, 2, 3 },
+          },
         }
       else
         screen:expect([[
@@ -2329,7 +2441,9 @@ describe('builtin popupmenu', function()
           {n: aab            }|
           {n: aac            }|
         ]],
-          float_pos = { [5] = { -1, 'NW', 2, 3, 1, false, 100, 1, 3, 13 } },
+          float_pos = {
+            [5] = { -1, 'NW', 2, 3, 1, false, 100, 3, 3, 13 },
+          },
         }
       else
         screen:expect([[
@@ -2371,7 +2485,9 @@ describe('builtin popupmenu', function()
           {n: aac     }|
           {n: aaabcdef}|
         ]],
-          float_pos = { [5] = { -1, 'NW', 2, 3, 11, false, 100, 1, 3, 23 } },
+          float_pos = {
+            [5] = { -1, 'NW', 2, 3, 11, false, 100, 3, 3, 23 },
+          },
         }
       else
         screen:expect([[
@@ -2414,7 +2530,9 @@ describe('builtin popupmenu', function()
           {n: aab            }{12: }|
           {n: aac            }{12: }|
         ]],
-          float_pos = { [5] = { -1, 'NW', 2, 4, -1, false, 100, 1, 4, 11 } },
+          float_pos = {
+            [5] = { -1, 'NW', 2, 4, -1, false, 100, 3, 4, 11 },
+          },
         }
       else
         screen:expect([[
@@ -2532,7 +2650,9 @@ describe('builtin popupmenu', function()
             {n: laborum        }{c: }|
             {12: Est            }{c: }|
           ]],
-          float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
+          float_pos = {
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 3, 1, 3 },
+          },
         })
       else
         screen:expect([[
@@ -2596,7 +2716,9 @@ describe('builtin popupmenu', function()
             {n: laborum        }{c: }|
             {12: Est            }{c: }|
           ]],
-          float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
+          float_pos = {
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 3, 1, 3 },
+          },
         })
       else
         screen:expect([[
@@ -2654,7 +2776,9 @@ describe('builtin popupmenu', function()
             {n: eu             }|
             {12: est            }|
           ]],
-          float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
+          float_pos = {
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 3, 1, 3 },
+          },
         })
       else
         screen:expect([[
@@ -2716,7 +2840,9 @@ describe('builtin popupmenu', function()
             {n: eu             }|
             {12: est            }|
           ]],
-          float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
+          float_pos = {
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 3, 1, 3 },
+          },
         })
       else
         screen:expect([[
@@ -2766,7 +2892,9 @@ describe('builtin popupmenu', function()
             {n: esse           }|
             {12: est            }|
           ]],
-          float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
+          float_pos = {
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 3, 1, 3 },
+          },
         })
       else
         screen:expect([[
@@ -2820,7 +2948,9 @@ describe('builtin popupmenu', function()
             {n: esse           }|
             {12: est            }|
           ]],
-          float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
+          float_pos = {
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 3, 1, 3 },
+          },
         })
       else
         screen:expect([[
@@ -2878,7 +3008,9 @@ describe('builtin popupmenu', function()
             {n: eu             }|
             {12: est            }|
           ]],
-          float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
+          float_pos = {
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 3, 1, 3 },
+          },
         })
       else
         screen:expect([[
@@ -2936,7 +3068,9 @@ describe('builtin popupmenu', function()
             {12: eu             }|
             {n: est            }|
           ]],
-          float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
+          float_pos = {
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 3, 1, 3 },
+          },
         })
       else
         screen:expect([[
@@ -2998,7 +3132,9 @@ describe('builtin popupmenu', function()
             {12: eu             }|
             {n: est            }|
           ]],
-          float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
+          float_pos = {
+            [5] = { -1, 'NW', 4, 1, 3, false, 100, 3, 1, 3 },
+          },
         })
       else
         screen:expect([[
@@ -3055,7 +3191,9 @@ describe('builtin popupmenu', function()
             {n: eä                 }|
             {n: eö                 }|
           ]],
-          float_pos = { [5] = { -1, 'NW', 4, 1, 2, false, 100, 1, 1, 2 } },
+          float_pos = {
+            [5] = { -1, 'NW', 4, 1, 2, false, 100, 3, 1, 2 },
+          },
         })
       else
         screen:expect([[
@@ -3112,7 +3250,9 @@ describe('builtin popupmenu', function()
             {n: eä             }|
             {n: eö             }|
           ]],
-          float_pos = { [5] = { -1, 'NW', 4, 1, 2, false, 100, 1, 1, 2 } },
+          float_pos = {
+            [5] = { -1, 'NW', 4, 1, 2, false, 100, 3, 1, 2 },
+          },
         })
       else
         screen:expect([[
@@ -3169,7 +3309,9 @@ describe('builtin popupmenu', function()
             {n: eä             }|
             {n: eö             }|
           ]],
-          float_pos = { [5] = { -1, 'NW', 4, 1, 2, false, 100, 1, 1, 2 } },
+          float_pos = {
+            [5] = { -1, 'NW', 4, 1, 2, false, 100, 3, 1, 2 },
+          },
         })
       else
         screen:expect([[
@@ -3219,7 +3361,9 @@ describe('builtin popupmenu', function()
             {12: foo            }|
             {n: bar            }|
           ]],
-          float_pos = { [5] = { -1, 'NW', 4, 1, 4, false, 100, 1, 1, 4 } },
+          float_pos = {
+            [5] = { -1, 'NW', 4, 1, 4, false, 100, 3, 1, 4 },
+          },
         })
       else
         screen:expect([[
@@ -3307,7 +3451,9 @@ describe('builtin popupmenu', function()
             {n: text  }|
             {n: thing }|
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 25, false, 100, 1, 1, 25 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 1, 25, false, 100, 2, 1, 25 },
+          },
         })
       else
         screen:expect([[
@@ -3340,7 +3486,9 @@ describe('builtin popupmenu', function()
             {n:text           }|
             {12:thing          }|
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 2, 0, false, 100, 1, 2, 0 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 2, 0, false, 100, 2, 2, 0 },
+          },
         })
       else
         screen:expect([[
@@ -3374,7 +3522,9 @@ describe('builtin popupmenu', function()
             {12: text  }|
             {n: thing }|
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 25, false, 100, 1, 1, 25 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 1, 25, false, 100, 2, 1, 25 },
+          },
         })
       else
         screen:expect([[
@@ -3407,7 +3557,9 @@ describe('builtin popupmenu', function()
             {12:text           }|
             {n:thing          }|
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 2, 0, false, 100, 1, 2, 0 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 2, 0, false, 100, 2, 2, 0 },
+          },
         })
       else
         screen:expect([[
@@ -3440,7 +3592,9 @@ describe('builtin popupmenu', function()
             {12: text           }|
             {n: thing          }|
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 27, false, 100, 1, 1, 27 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 1, 27, false, 100, 2, 1, 27 },
+          },
         })
       else
         screen:expect([[
@@ -3473,7 +3627,9 @@ describe('builtin popupmenu', function()
             {12: text           }|
             {n: thing          }|
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 2, 3, false, 100, 1, 2, 3 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 2, 3, false, 100, 2, 2, 3 },
+          },
         })
       else
         screen:expect([[
@@ -3508,15 +3664,17 @@ describe('builtin popupmenu', function()
             {12: text           }|
             {n: thing          }|
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 2, 3, false, 100, 1, 2, 3 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 2, 3, false, 100, 2, 2, 3 },
+          },
         })
       else
         screen:expect([[
           some long   |
           prefix      |
-          bef{n: word  }  |
-          tex{n: }^        |
-          {5:-- INSERT --}|
+          bef{n: word    }|
+          tex{n: ^choice  }|
+          {2:-- INSERT --}|
         ]])
       end
 
@@ -3538,7 +3696,9 @@ describe('builtin popupmenu', function()
             {12: text           }|
             {n: thing          }|
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 2, 3, false, 100, 1, 2, 3 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 2, 3, false, 100, 2, 2, 3 },
+          },
         })
       else
         screen:expect([[
@@ -3567,7 +3727,9 @@ describe('builtin popupmenu', function()
             {12: text    }|
             {n: thing   }|
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 2, 10, false, 100, 1, 2, 10 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 2, 10, false, 100, 2, 2, 10 },
+          },
         })
       else
         screen:expect([[
@@ -3606,7 +3768,9 @@ describe('builtin popupmenu', function()
             {n: text  }|
             {n: thing }|
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 25, false, 100, 1, 1, 25 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 1, 25, false, 100, 2, 1, 25 },
+          },
         })
       else
         screen:expect([[
@@ -3640,7 +3804,9 @@ describe('builtin popupmenu', function()
             {n: text        }|
             {n: thing       }|
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 3, 3, false, 100, 1, 3, 3 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 3, 3, false, 100, 2, 3, 3 },
+          },
         })
       else
         screen:expect([[
@@ -3698,7 +3864,9 @@ describe('builtin popupmenu', function()
             {n:           txet }|
             {n:          gniht }|
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 2, false, 100, 1, 1, 2 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 1, 2, false, 100, 2, 1, 2 },
+          },
         })
       else
         screen:expect([[
@@ -3730,7 +3898,9 @@ describe('builtin popupmenu', function()
             {n:           txet }|
             {n:          gniht }|
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 2, false, 100, 1, 1, 2 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 1, 2, false, 100, 2, 1, 2 },
+          },
         })
       else
         screen:expect([[
@@ -3805,7 +3975,9 @@ describe('builtin popupmenu', function()
             {n: undefine       }|
             {n: unplace        }|
           ]],
-          float_pos = { [4] = { -1, 'SW', 1, 19, 5, false, 250, 2, 13, 5 } },
+          float_pos = {
+            [4] = { -1, 'SW', 1, 19, 5, false, 250, 3, 13, 5 },
+          },
         })
       else
         screen:expect([[
@@ -3858,7 +4030,9 @@ describe('builtin popupmenu', function()
           {c: }{n:           drow }|
           {12: }{n:         eciohc }|
         ]],
-          float_pos = { [5] = { -1, 'NW', 4, 1, -11, false, 100, 1, 1, 9 } },
+          float_pos = {
+            [5] = { -1, 'NW', 4, 1, -11, false, 100, 3, 1, 9 },
+          },
         }
       else
         screen:expect([[
@@ -3893,7 +4067,9 @@ describe('builtin popupmenu', function()
           {c: }{n:           drow}|
           {12: }{n:         eciohc}|
         ]],
-          float_pos = { [5] = { -1, 'NW', 4, 2, 4, false, 100, 1, 2, 24 } },
+          float_pos = {
+            [5] = { -1, 'NW', 4, 2, 4, false, 100, 3, 2, 24 },
+          },
         }
       else
         screen:expect([[
@@ -3956,7 +4132,9 @@ describe('builtin popupmenu', function()
           {12:define         }{c: }|
           {n:jump           }{12: }|
         ]],
-          float_pos = { [5] = { -1, 'SW', 1, 5, 0, false, 250, 2, 3, 0 } },
+          float_pos = {
+            [5] = { -1, 'SW', 1, 5, 0, false, 250, 4, 3, 0 },
+          },
         }
       else
         screen:expect([[
@@ -4945,7 +5123,9 @@ describe('builtin popupmenu', function()
             {n: undefine       }|
             {n: unplace        }|
           ]],
-          float_pos = { [4] = { -1, 'SW', 1, 9, 5, false, 250, 2, 3, 5 } },
+          float_pos = {
+            [4] = { -1, 'SW', 1, 9, 5, false, 250, 3, 3, 5 },
+          },
         })
       else
         screen:expect([[
@@ -5334,7 +5514,9 @@ describe('builtin popupmenu', function()
           {n: word  }{c: }|
           {n: choice}{12: }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 24, false, 100, 1, 1, 24 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 1, 24, false, 100, 2, 1, 24 },
+          },
         }
       else
         screen:expect([[
@@ -5371,7 +5553,9 @@ describe('builtin popupmenu', function()
           {n: text  }|
           {n: thing }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 25, false, 100, 1, 1, 25 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 1, 25, false, 100, 2, 1, 25 },
+          },
         }
       else
         screen:expect([[
@@ -5413,7 +5597,7 @@ describe('builtin popupmenu', function()
           {12: 123456789_123456789_123456789_a }|
           {n: 123456789_123456789_123456789_b }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100, 1, 3, 11 } },
+          float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100, 2, 3, 11 } },
         })
       else
         screen:expect([[
@@ -5447,7 +5631,7 @@ describe('builtin popupmenu', function()
           {12: 123456789>}|
           {n: 123456789>}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100, 1, 3, 11 } },
+          float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100, 2, 3, 11 } },
         })
       else
         screen:expect([[
@@ -5481,7 +5665,7 @@ describe('builtin popupmenu', function()
           {12: 123456789_123456789>}|
           {n: 123456789_123456789>}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100, 1, 3, 11 } },
+          float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100, 2, 3, 11 } },
         })
       else
         screen:expect([[
@@ -5515,7 +5699,7 @@ describe('builtin popupmenu', function()
           {12: 1234567>}|
           {n: 1234567>}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100, 1, 3, 11 } },
+          float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100, 2, 3, 11 } },
         })
       else
         screen:expect([[
@@ -5550,7 +5734,7 @@ describe('builtin popupmenu', function()
           {12: 1234567>}|
           {n: 1234567>}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 4, 11, false, 100, 1, 4, 11 } },
+          float_pos = { [4] = { -1, 'NW', 2, 4, 11, false, 100, 2, 4, 11 } },
         })
       else
         screen:expect([[
@@ -5628,7 +5812,7 @@ describe('builtin popupmenu', function()
           {n:abcdefghij                     }|
           {n:上下左右                       }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 } },
         })
       else
         screen:expect([[
@@ -5662,7 +5846,7 @@ describe('builtin popupmenu', function()
           {n:abcdefghij}|
           {n:上下左右  }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 } },
         })
       else
         screen:expect([[
@@ -5696,7 +5880,7 @@ describe('builtin popupmenu', function()
           {n:jihgfedcba}|
           {n:  右左下上}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 50, false, 100, 1, 1, 50 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 50, false, 100, 2, 1, 50 } },
         })
       else
         screen:expect([[
@@ -5731,7 +5915,7 @@ describe('builtin popupmenu', function()
           {n:a>}|
           {n: >}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 } },
         })
       else
         screen:expect([[
@@ -5766,7 +5950,7 @@ describe('builtin popupmenu', function()
           {n:bar barKind b>}|
           {n:baz bazKind b>}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 } },
         })
       else
         screen:expect([[
@@ -6088,7 +6272,7 @@ describe('builtin popupmenu', function()
           {n:<rab}|
           {n:< 一}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 28, false, 100, 1, 1, 28 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 28, false, 100, 2, 1, 28 } },
         })
       else
         screen:expect([[
@@ -6121,7 +6305,7 @@ describe('builtin popupmenu', function()
           {n:bar        一二>}|
           {n:一二三四五 multi}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 } },
         })
       else
         screen:expect([[
@@ -6153,7 +6337,7 @@ describe('builtin popupmenu', function()
           {n:<二一        rab}|
           {n:itlum 五四三二一}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 16, false, 100, 1, 1, 16 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 16, false, 100, 2, 1, 16 } },
         })
       else
         screen:expect([[
@@ -6360,7 +6544,7 @@ describe('builtin popupmenu', function()
         ## grid 4
           {n: 一二三四五六七八九>}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 12, false, 100, 1, 1, 12 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 12, false, 100, 2, 1, 12 } },
         })
       else
         screen:expect([[
@@ -6387,7 +6571,7 @@ describe('builtin popupmenu', function()
         ## grid 4
           {n: 一二三 四五六 七八>}|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 12, false, 100, 1, 1, 12 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 12, false, 100, 2, 1, 12 } },
         })
       else
         screen:expect([[
@@ -6415,7 +6599,7 @@ describe('builtin popupmenu', function()
         ## grid 4
           {n:<九八七六五四三二一 }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 } },
         })
       else
         screen:expect([[
@@ -6442,7 +6626,7 @@ describe('builtin popupmenu', function()
         ## grid 4
           {n:<八七 六五四 三二一 }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 } },
         })
       else
         screen:expect([[
@@ -6494,7 +6678,7 @@ describe('builtin popupmenu', function()
           {n: 一二三四五六七八九>}{c: }|*2
           {n: 一二三四五六七八九>}{12: }|*2
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 11, false, 100, 1, 1, 11 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 11, false, 100, 2, 1, 11 } },
         })
       else
         screen:expect([[
@@ -6523,7 +6707,7 @@ describe('builtin popupmenu', function()
           {n: abcdef ghijkl mnopq}{c: }|*2
           {n: 一二三 四五六 七八>}{12: }|*2
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 11, false, 100, 1, 1, 11 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 11, false, 100, 2, 1, 11 } },
         })
       else
         screen:expect([[
@@ -6553,7 +6737,7 @@ describe('builtin popupmenu', function()
           {c: }{n:<九八七六五四三二一 }|*2
           {12: }{n:<九八七六五四三二一 }|*2
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 } },
         })
       else
         screen:expect([[
@@ -6582,7 +6766,7 @@ describe('builtin popupmenu', function()
           {c: }{n:qponm lkjihg fedcba }|*2
           {12: }{n:<八七 六五四 三二一 }|*2
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 } },
         })
       else
         screen:expect([[
@@ -6648,7 +6832,7 @@ describe('builtin popupmenu', function()
           {n: bar }|
           {n: baz }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250, 2, 1, 3 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250, 3, 1, 3 } },
         }
       else
         no_sel_screen = [[
@@ -6709,7 +6893,7 @@ describe('builtin popupmenu', function()
           {n: bar }|
           {n: baz }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 3, 19, false, 250, 2, 3, 19 } },
+          float_pos = { [4] = { -1, 'NW', 2, 3, 19, false, 250, 3, 3, 19 } },
         })
       else
         screen:expect([[
@@ -6741,7 +6925,7 @@ describe('builtin popupmenu', function()
           {n: bar }|
           {n: baz }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 17, false, 250, 2, 1, 17 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 17, false, 250, 3, 1, 17 } },
         })
       else
         screen:expect([[
@@ -6774,7 +6958,7 @@ describe('builtin popupmenu', function()
           {n: bar }|
           {n: baz }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 3, 19, false, 250, 2, 3, 19 } },
+          float_pos = { [4] = { -1, 'NW', 2, 3, 19, false, 250, 3, 3, 19 } },
         })
       else
         screen:expect([[
@@ -6815,7 +6999,7 @@ describe('builtin popupmenu', function()
           {n: bar }|
           {n: baz }|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250, 2, 1, 3 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 3, false, 250, 3, 1, 3 } },
         }
       else
         no_sel_screen = [[
@@ -6911,7 +7095,7 @@ describe('builtin popupmenu', function()
           ^popup menu test                 |
           {1:~                               }|
         ]],
-          float_pos = { [4] = { -1, 'SW', 5, 1, 19, false, 250, 2, 1, 19 } },
+          float_pos = { [4] = { -1, 'SW', 5, 1, 19, false, 250, 4, 1, 19 } },
         })
       else
         screen:expect([[
@@ -6986,7 +7170,7 @@ describe('builtin popupmenu', function()
           ^popup menu test |
           {1:~               }|
         ]],
-          float_pos = { [4] = { -1, 'SW', 6, 1, 12, false, 250, 2, 1, 28 } },
+          float_pos = { [4] = { -1, 'SW', 6, 1, 12, false, 250, 5, 1, 28 } },
         })
       else
         screen:expect([[
@@ -7064,7 +7248,7 @@ describe('builtin popupmenu', function()
           {5:WINBAR          }|
           ^popup menu test |
         ]],
-          float_pos = { [4] = { -1, 'SW', 6, 1, 12, false, 250, 2, 1, 28 } },
+          float_pos = { [4] = { -1, 'SW', 6, 1, 12, false, 250, 3, 1, 28 } },
         }
       else
         no_sel_screen = [[
@@ -7202,7 +7386,7 @@ describe('builtin popupmenu', function()
         ## grid 8
           ^popup menu test                 |
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 14, false, 250, 2, 3, 19 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 14, false, 250, 3, 3, 19 } },
         }
       else
         no_sel_screen = [[
@@ -7350,7 +7534,7 @@ describe('builtin popupmenu', function()
         ## grid 8
                            tset unem pupo^p|
         ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 12, false, 250, 2, 3, 17 } },
+          float_pos = { [4] = { -1, 'NW', 2, 1, 12, false, 250, 5, 3, 17 } },
         }
       else
         no_sel_screen = [[
@@ -7625,7 +7809,9 @@ describe('builtin popupmenu', function()
             {n: Select Block    }|
             {n: Select All      }|
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 33, false, 250, 2, 1, 33 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 1, 33, false, 250, 3, 1, 33 },
+          },
         })
       else
         screen:expect([[
@@ -7675,7 +7861,9 @@ describe('builtin popupmenu', function()
             {n:    kcolB tceleS }|
             {n:      llA tceleS }|
           ]],
-          float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 250, 2, 1, 0 } },
+          float_pos = {
+            [4] = { -1, 'NW', 2, 1, 0, false, 250, 3, 1, 0 },
+          },
         })
       else
         screen:expect([[

--- a/test/functional/ui/screen_basic_spec.lua
+++ b/test/functional/ui/screen_basic_spec.lua
@@ -614,7 +614,8 @@ local function screen_tests(linegrid)
     it('messages from the same Ex command as resize are visible #22225', function()
       feed(':set columns=20 | call<CR>')
       screen:expect([[
-                            |*9
+                            |
+        {0:~                   }|*8
         {1:                    }|
         {8:E471: Argument requi}|
         {8:red}                 |


### PR DESCRIPTION
### Problem

The mere presence of a multigrid UI completely changes the way Neovim works internally. This prevents multigrid UIs and non-multigrid UIs to connect to the same instance, or to switch from one UI type to another.  That's the case even when no multigrid specific features, such as external windows or custom window sizes are used.

It also makes the code hard to understand and follow, when different branches work differently. The multigrid code paths are also much less testing, which often leads to bugs.

### Solution

Always use multiple grids internally and combine them during the composition stage. Non multigrid UIs still only see one grid, while multi-grid UIs receives window events and grid events for all grids. Only a couple of `ui_has(kUIMultigrid)` checks remain, to allow creation of external windows and resizing grids if a multigrid UI is connected. But I think those could perhaps always be allowed, and the non-multigrid UIs like the TUI just ignore those windows.

* fixes https://github.com/neovim/neovim/issues/30583

### Breaking change

This is a breaking change, since `popupmenu_show` now always incudes a real grid id. Therefore, it's no longer possible for non-multigrid UIs to get the absolute coordinates through the UI protocol, without also enabling multigrid. This could be fixed by including the absolute coordinates like in https://github.com/neovim/neovim/pull/31837

### Bugs
These bugs now also affects non-multigrid UIs, so they need to be fixed before this is merged. All failing tests are related to one of these
* https://github.com/neovim/neovim/issues/24802
* https://github.com/neovim/neovim/issues/31811

### Dependencies
This PR includes and depends on the following PRs, which needs to be merged before this
* https://github.com/neovim/neovim/pull/32470
* https://github.com/neovim/neovim/pull/32440
* https://github.com/neovim/neovim/pull/31837
* https://github.com/neovim/neovim/pull/32494
* https://github.com/neovim/neovim/pull/32535

Only the latest two commits are for this specific PR, where `refactor(ui): replace ui_has(kUIMultigrid) with multigrid specific events` could be split into its own PR. But not done so yet due to conflicts that will arise.

### Potential next steps
Get rid of the default grid, the split separators and the statusbar could be part of the window/grid, like winbar and borders.
