### PR TITLE
perf(treesitter): track injection regions in an interval tree

### DIFF
--- a/runtime/lua/vim/treesitter/_interval_tree.lua
+++ b/runtime/lua/vim/treesitter/_interval_tree.lua
@@ -1,0 +1,232 @@
+local Range = require('vim.treesitter._range')
+
+local end_point = Range.end_point
+local start_point = Range.start_point
+
+---@class ITNode
+---@field range Range6
+---Since we key nodes by the convex hull of their region, we must explicitly store the region information as well.
+---@field region Range6[]
+---@field index integer
+---@field left ITNode?
+---@field right ITNode?
+---@field height integer
+---@field max_end Point
+local ITNode = {}
+ITNode.__index = ITNode
+
+---@param range Range6
+---@param region Range6[]
+---@param index integer
+---@return ITNode
+function ITNode.new(range, region, index)
+  return setmetatable({
+    range = range,
+    left = nil,
+    index = index,
+    right = nil,
+    height = 1,
+    region = region,
+    max_end = end_point(range),
+  }, ITNode)
+end
+
+---@param node ITNode?
+---@return integer
+local function height(node)
+  return node and node.height or 0
+end
+
+---@param node ITNode
+---@return integer
+local function balance_factor(node)
+  return height(node.left) - height(node.right)
+end
+
+---@param node ITNode
+local function node_update_height(node)
+  node.height = math.max(height(node.left), height(node.right)) + 1
+end
+
+---@param node ITNode
+local function update_max_end(node)
+  local max_end = node.max_end
+  if node.left and max_end < node.left.max_end then
+    max_end = node.left.max_end
+  end
+  if node.right and max_end < node.right.max_end then
+    max_end = node.right.max_end
+  end
+  node.max_end = max_end
+end
+
+---@param y ITNode
+---@return ITNode
+local function rotate_right(y)
+  local x = assert(y.left)
+  y.left = x.right
+  x.right = y
+  node_update_height(x)
+  node_update_height(y)
+  update_max_end(x)
+  update_max_end(y)
+  return x
+end
+
+---@param x ITNode
+---@return ITNode
+local function rotate_left(x)
+  local y = assert(x.right)
+  x.right = y.left
+  y.left = x
+  node_update_height(x)
+  node_update_height(y)
+  update_max_end(x)
+  update_max_end(y)
+  return y
+end
+
+---@param node ITNode
+---@return ITNode
+local function rebalance(node)
+  node_update_height(node)
+  local balance = balance_factor(node)
+
+  -- Left Heavy
+  if balance > 1 then
+    if balance_factor(node.left) < 0 then
+      node.left = rotate_left(node.left) -- Left-Right case
+    end
+    return rotate_right(node) -- Left-Left case
+  end
+
+  -- Right Heavy
+  if balance < -1 then
+    if balance_factor(node.right) > 0 then
+      node.right = rotate_right(node.right) -- Right-Left case
+    end
+    return rotate_left(node) -- Right-Right case
+  end
+
+  return node -- Already balanced
+end
+
+---@param node ITNode
+---@param range Range6
+---@param ranges Range6[]
+---@param index integer
+local function insert(node, range, ranges, index)
+  if not node then
+    return ITNode.new(range, ranges, index)
+  end
+
+  if start_point(range) < start_point(node.range) then
+    node.left = insert(node.left, range, ranges, index)
+  elseif start_point(range) > start_point(node.range) then
+    node.right = insert(node.right, range, ranges, index)
+  else
+    return node
+  end
+
+  update_max_end(node)
+
+  return rebalance(node)
+end
+
+---@class ITree
+---@field root ITNode?
+local ITree = {}
+ITree.__index = ITree
+
+function ITree.new()
+  return setmetatable({ root = nil }, ITree)
+end
+
+---@param range Range6
+---@param region Range6[]
+---@param index integer
+function ITree:insert(range, region, index)
+  self.root = insert(self.root, range, region, index)
+end
+
+---@param regions Range6[][]
+---@param start integer
+---@param stop integer
+---@param callback function
+local function sorted_regions_to_tree(regions, start, stop, callback)
+  if start > stop then
+    return nil
+  end
+
+  local mid = math.floor((start + stop) / 2)
+  local region = regions[mid]
+  local r1 = region[1]
+  local r2 = region[#region]
+  local combined = { r1[1], r1[2], r1[3], r2[4], r2[5], r2[6] }
+  local node = ITNode.new(combined, region, mid)
+
+  callback()
+
+  node.left = sorted_regions_to_tree(regions, start, mid - 1, callback)
+  node.right = sorted_regions_to_tree(regions, mid + 1, stop, callback)
+
+  update_max_end(node)
+  node_update_height(node)
+
+  return node
+end
+
+---@param ranges Range6[][]
+---@param callback function A callback to run after each node is created.
+function ITree.from_sorted_regions(ranges, callback)
+  return setmetatable({ root = sorted_regions_to_tree(ranges, 1, #ranges, callback) }, ITree)
+end
+
+---@param node ITNode
+---@param range Range
+---@param result ITNode[]
+local function find_overlapping_intervals(node, range, result)
+  if Range.intercepts(node.range, range) then
+    table.insert(result, node)
+  end
+
+  if node.left and start_point(range) <= node.left.max_end then
+    find_overlapping_intervals(node.left, range, result)
+  end
+
+  if node.right and start_point(node.range) <= end_point(range) then
+    find_overlapping_intervals(node.right, range, result)
+  end
+end
+
+---@param range Range
+---@return ITNode[]
+function ITree:find_overlapping_intervals(range)
+  ---@type ITNode[]
+  local result = {}
+  if self.root then
+    find_overlapping_intervals(self.root, range, result)
+  end
+  return result
+end
+
+---@param node ITNode
+---@param list ITNode[]
+local function inorder_traversal(node, list)
+  if not node then
+    return
+  end
+  inorder_traversal(node.left, list)
+  table.insert(list, node)
+  inorder_traversal(node.right, list)
+end
+
+---@return ITNode[]
+function ITree:nodes()
+  ---@type ITNode[]
+  local ranges = {}
+  inorder_traversal(self.root, ranges)
+  return ranges
+end
+
+return ITree

--- a/runtime/lua/vim/treesitter/_range.lua
+++ b/runtime/lua/vim/treesitter/_range.lua
@@ -2,6 +2,47 @@ local api = vim.api
 
 local M = {}
 
+---@class Point
+---@field start integer
+---@field end_ integer
+local Point = {}
+Point.__index = Point
+
+---@param start integer
+---@param end_ integer
+function Point.new(start, end_)
+  return setmetatable({ start = start, end_ = end_ }, Point)
+end
+
+---@param point Point
+function Point:__lt(point)
+  return M.cmp_pos.lt(self.start, self.end_, point.start, point.end_)
+end
+
+---@param point Point
+function Point:__le(point)
+  return M.cmp_pos.le(self.start, self.end_, point.start, point.end_)
+end
+
+---@param point Point
+function Point:__eq(point)
+  return M.cmp_pos.eq(self.start, self.end_, point.start, point.end_)
+end
+
+---@param range Range
+---@return Point
+function M.start_point(range)
+  local start, end_ = M.unpack4(range)
+  return Point.new(start, end_)
+end
+
+---@param range Range
+---@return Point
+function M.end_point(range)
+  local _, _, start, end_ = M.unpack4(range)
+  return Point.new(start, end_)
+end
+
 ---@class Range2
 ---@inlinedoc
 ---@field [1] integer start row

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -575,22 +575,22 @@ int x = INT_MAX;
         eq(5, exec_lua('return #parser:children().c:trees()'))
         eq({
           { 0, 0, 7, 0 }, -- root tree
+          { 1, 26, 1, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
+          { 2, 29, 2, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
           { 3, 14, 3, 17 }, -- VALUE 123
           { 4, 15, 4, 18 }, -- VALUE1 123
           { 5, 15, 5, 18 }, -- VALUE2 123
-          { 1, 26, 1, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
-          { 2, 29, 2, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
         }, get_ranges())
 
         n.feed('ggo<esc>')
         eq(5, exec_lua('return #parser:children().c:trees()'))
         eq({
           { 0, 0, 8, 0 }, -- root tree
+          { 2, 26, 2, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
+          { 3, 29, 3, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
           { 4, 14, 4, 17 }, -- VALUE 123
           { 5, 15, 5, 18 }, -- VALUE1 123
           { 6, 15, 6, 18 }, -- VALUE2 123
-          { 2, 26, 2, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
-          { 3, 29, 3, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
         }, get_ranges())
       end)
     end)
@@ -613,11 +613,11 @@ int x = INT_MAX;
         eq(2, exec_lua('return #parser:children().c:trees()'))
         eq({
           { 0, 0, 7, 0 }, -- root tree
+          { 1, 26, 2, 66 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
+          -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
           { 3, 14, 5, 18 }, -- VALUE 123
           -- VALUE1 123
           -- VALUE2 123
-          { 1, 26, 2, 66 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
-          -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
         }, get_ranges())
 
         n.feed('ggo<esc>')
@@ -625,11 +625,11 @@ int x = INT_MAX;
         eq(2, exec_lua('return #parser:children().c:trees()'))
         eq({
           { 0, 0, 8, 0 }, -- root tree
-          { 4, 14, 6, 18 }, -- VALUE 123
-          -- VALUE1 123
-          -- VALUE2 123
           { 2, 26, 3, 66 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
           -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
+          -- VALUE 123
+          { 4, 14, 6, 18 }, -- VALUE1 123
+          -- VALUE2 123
         }, get_ranges())
 
         n.feed('7ggI//<esc>')
@@ -638,10 +638,10 @@ int x = INT_MAX;
         eq(2, exec_lua('return #parser:children().c:trees()'))
         eq({
           { 0, 0, 8, 0 }, -- root tree
-          { 4, 14, 5, 18 }, -- VALUE 123
-          -- VALUE1 123
           { 2, 26, 3, 66 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
           -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
+          -- VALUE 123
+          { 4, 14, 5, 18 }, -- VALUE1 123
         }, get_ranges())
       end)
 
@@ -794,22 +794,22 @@ int x = INT_MAX;
         eq(5, exec_lua('return #parser:children().c:trees()'))
         eq({
           { 0, 0, 7, 0 }, -- root tree
+          { 1, 26, 1, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
+          { 2, 29, 2, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
           { 3, 14, 3, 17 }, -- VALUE 123
           { 4, 15, 4, 18 }, -- VALUE1 123
           { 5, 15, 5, 18 }, -- VALUE2 123
-          { 1, 26, 1, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
-          { 2, 29, 2, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
         }, get_ranges())
 
         n.feed('ggo<esc>')
         eq(5, exec_lua('return #parser:children().c:trees()'))
         eq({
           { 0, 0, 8, 0 }, -- root tree
+          { 2, 26, 2, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
+          { 3, 29, 3, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
           { 4, 14, 4, 17 }, -- VALUE 123
           { 5, 15, 5, 18 }, -- VALUE1 123
           { 6, 15, 6, 18 }, -- VALUE2 123
-          { 2, 26, 2, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
-          { 3, 29, 3, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
         }, get_ranges())
       end)
     end)
@@ -831,11 +831,11 @@ int x = INT_MAX;
         eq('table', exec_lua('return type(parser:children().c)'))
         eq({
           { 0, 0, 7, 0 }, -- root tree
+          { 1, 26, 1, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
+          { 2, 29, 2, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
           { 3, 16, 3, 16 }, -- VALUE 123
           { 4, 17, 4, 17 }, -- VALUE1 123
           { 5, 17, 5, 17 }, -- VALUE2 123
-          { 1, 26, 1, 63 }, -- READ_STRING(x, y) (char *)read_string((x), (size_t)(y))
-          { 2, 29, 2, 66 }, -- READ_STRING_OK(x, y) (char *)read_string((x), (size_t)(y))
         }, get_ranges())
       end)
       it('should list all directives', function()


### PR DESCRIPTION
This greatly improves the performance of scrolling and re-parsing large buffers with combined injections (meaning lots of tracked regions). Instead of a linear search to find intersecting regions, the language tree now uses an interval tree which performs the search in logarithmic time.

Things to note:

- `LanguageTree:included_regions()` now returns regions in ascending order, sorted by region start point. It also no longer returns a table with holes. (I believe this also means `._trees` no longer has holes?)
  - It can also be run asynchronously now, as it would cause a good amount of stutter when there was a large number of regions.
- Regions in the interval tree are keyed by their convex hull, meaning one range which spans the start point of the first range and end point of the last range. This means that sometimes combined injections will match as "intersecting" even if they aren't technically in the viewport, but this doesn't affect the correctness of the code from what I can tell. The benefit is that this greatly simplifies the tree construction code, allowing it to be done in *linear time*.
  - Each tree node still also keeps track of the original region data in another field.
- Interval tree code was constructed by referencing [this Wikipedia article](https://en.wikipedia.org/wiki/Interval_tree#Augmented_tree).
- This commit removes the heuristic to keep some trees based on the amount of new injection regions, and always invalidates the injection trees upon re-parsing (since incremental tree validation was already not supported). Keeping that code added complexity, was expensive when there were many ranges, and was not always even applicable.