### PR TITLE
fix: Issue #30263 with :checkhealth.

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -5,11 +5,11 @@
 if exists('g:loaded_clipboard_provider')
   finish
 endif
-" Default to 1.  provider#clipboard#Executable() may set 2.
+" Default to 0.  provider#clipboard#Executable() may set 2.
 " To force a reload:
 "   :unlet g:loaded_clipboard_provider
 "   :runtime autoload/provider/clipboard.vim
-let g:loaded_clipboard_provider = 1
+let g:loaded_clipboard_provider = 0
 
 let s:copy = {}
 let s:paste = {}
@@ -284,4 +284,4 @@ function! provider#clipboard#Call(method, args) abort
 endfunction
 
 " eval_has_provider() decides based on this variable.
-let g:loaded_clipboard_provider = empty(provider#clipboard#Executable()) ? 1 : 2
+let g:loaded_clipboard_provider = empty(provider#clipboard#Executable()) ? 0 : 2

--- a/runtime/autoload/provider/node.vim
+++ b/runtime/autoload/provider/node.vim
@@ -1,7 +1,7 @@
 if exists('g:loaded_node_provider')
   finish
 endif
-let g:loaded_node_provider = 1
+let g:loaded_node_provider = 0
 
 function! s:is_minimum_version(version, min_version) abort
   if empty(a:version)
@@ -152,7 +152,7 @@ endfunction
 
 let s:err = ''
 let [s:prog, s:_] = provider#node#Detect()
-let g:loaded_node_provider = empty(s:prog) ? 1 : 2
+let g:loaded_node_provider = empty(s:prog) ? 0 : 2
 
 if g:loaded_node_provider != 2
   let s:err = 'Cannot find the "neovim" node package. Try :checkhealth'

--- a/runtime/autoload/provider/perl.vim
+++ b/runtime/autoload/provider/perl.vim
@@ -11,5 +11,5 @@ function! provider#perl#Require(host) abort
 endfunction
 
 let s:prog = v:lua.vim.provider.perl.detect()
-let g:loaded_perl_provider = empty(s:prog) ? 1 : 2
+let g:loaded_perl_provider = empty(s:prog) ? 0 : 2
 call v:lua.require'vim.provider.perl'.start()

--- a/runtime/autoload/provider/python3.vim
+++ b/runtime/autoload/provider/python3.vim
@@ -11,5 +11,5 @@ function! provider#python3#Require(host) abort
 endfunction
 
 let s:prog = v:lua.vim.provider.python.detect_by_module('neovim')
-let g:loaded_python3_provider = empty(s:prog) ? 1 : 2
+let g:loaded_python3_provider = empty(s:prog) ? 0 : 2
 call v:lua.require'vim.provider.python'.start()

--- a/runtime/autoload/provider/ruby.vim
+++ b/runtime/autoload/provider/ruby.vim
@@ -11,6 +11,6 @@ function! provider#ruby#Call(method, args) abort
 endfunction
 
 let s:prog = v:lua.vim.provider.ruby.detect()
-let g:loaded_ruby_provider = empty(s:prog) ? 1 : 2
+let g:loaded_ruby_provider = empty(s:prog) ? 0 : 2
 let s:plugin_path = expand('<sfile>:p:h') . '/script_host.rb'
 call v:lua.require'vim.provider.ruby'.start(s:plugin_path)

--- a/runtime/lua/vim/health/health.lua
+++ b/runtime/lua/vim/health/health.lua
@@ -110,6 +110,16 @@ local function check_config()
     )
   end
 
+  if vim.g.loaded_python3_provider == 1 then
+    ok = false
+    health.error(
+      '`g:loaded_python3_provider=1` may have been set by mistake. This option should not be used to load python provider in your config.',
+      {
+        'Remove `vim.g.loaded_python3_provider=1` from your config.',
+      }
+    )
+  end
+
   local writeable = true
   local shadaopt = vim.fn.split(vim.o.shada, ',')
   local shadafile = (


### PR DESCRIPTION
# Description
This PR fixes the issue with `:checkhealth` not recognizing `g:loaded_python3_provider=1` being set in the config (which leads to erroneous behavior as stated in #30263 ).

P.S: This is my first PR in neovim :confetti_ball: so excuse my silliness (if any) :D 