### PR TITLE
vim-patch:9.1.1165: diff: regression with multi-file diff blocks

### DIFF
--- a/test/old/testdir/test_diffmode.vim
+++ b/test/old/testdir/test_diffmode.vim
@@ -2045,6 +2045,30 @@ func Test_diff_overlapped_diff_blocks_will_be_merged()
   call WriteDiffFiles3(buf, ["a", "b", "c"], ["d", "e"], ["b"])
   call VerifyBoth(buf, "Test_diff_overlapped_3.39", "")
 
+  " File 3 overlaps twice, 2nd overlap completely within the existing block.
+  call WriteDiffFiles3(buf, ["foo", "a", "b", "c", "bar"], ["foo", "w", "x", "y", "z", "bar"], ["foo", "1", "a", "b", "2", "bar"])
+  call VerifyBoth(buf, "Test_diff_overlapped_3.40", "")
+
+  " File 3 overlaps twice, 2nd overlap extends beyond existing block on new
+  " side. Make sure we don't over-extend the range and hit 'bar'.
+  call WriteDiffFiles3(buf, ["foo", "a", "b", "c", "d", "bar"], ["foo", "w", "x", "y", "z", "u", "bar"], ["foo", "1", "a", "b", "2", "d", "bar"])
+  call VerifyBoth(buf, "Test_diff_overlapped_3.41", "")
+
+  " Chained overlaps. File 3's 2nd overlap spans two diff blocks and is longer
+  " than the 2nd one.
+  call WriteDiffFiles3(buf, ["foo", "a", "b", "c", "d", "e", "f", "bar"], ["foo", "w", "x", "y", "z", "e", "u", "bar"], ["foo", "1", "b", "2", "3", "d", "4", "f", "bar"])
+  call VerifyBoth(buf, "Test_diff_overlapped_3.42", "")
+
+  " File 3 has 2 overlaps. An add and a delete. First overlap's expansion hits
+  " the 2nd one. Make sure we adjust the diff block to have fewer lines.
+  call WriteDiffFiles3(buf, ["foo", "a", "b", "bar"], ["foo", "x", "y", "bar"], ["foo", "1", "a", "bar"])
+  call VerifyBoth(buf, "Test_diff_overlapped_3.43", "")
+
+  " File 3 has 2 overlaps. An add and another add. First overlap's expansion hits
+  " the 2nd one. Make sure we adjust the diff block to have more lines.
+  call WriteDiffFiles3(buf, ["foo", "a", "b", "c", "d", "bar"], ["foo", "w", "x", "y", "z", "u", "bar"], ["foo", "1", "a", "b", "3", "4", "d", "bar"])
+  call VerifyBoth(buf, "Test_diff_overlapped_3.44", "")
+
   call StopVimInTerminal(buf)
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.1165: diff: regression with multi-file diff blocks

Problem:  Vim's diff block merging algorithm when doing a multi-file diff
          is buggy when two different diff hunks overlap a single
          existing diff block (after v9.1.0743)

Solution: fix a couple bugs in this logic:

1. Fix regression from v9.1.0743 where it's not correctly expanding the
   2nd overlap correctly, where it always expands without taking into
   account that this was always taken care of when the first overlap
   happened. Instead, we should only grow the 2nd overlap if it overhangs
   outside the existing diff block, and if we encounter a new overlapping
   diff block (due to overlap chaining).
2. When we expand a diff block to match the hunk size on the orig side
   (when handling the first overlap), we expand the same amount of lines
   in the new side. This is not sound if there exists a second overlap
   hunk that we haven't processed yet, and that hunk has different
   number of lines in orig/new. Fix this by doing the corresponding
   counter adjustment when handling 2nd/3rd/etc overlap by calculating
   the difference in lines between orig and new side.
   (Yee Cheng Chin)

closes: vim/vim#16768

https://github.com/vim/vim/commit/bc08ceb75572dcac57ef5019f3d0df6e8290c0f9

Co-authored-by: Yee Cheng Chin <ychin.git@gmail.com>