### PR TITLE
fix(display): adjust winline info for concealed lines below last line

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2319,6 +2319,13 @@ static void win_update(win_T *wp)
           wp->w_lines[idx].wl_lastlnum = lnum + foldinfo.fi_lines;
           did_update = DID_FOLD;
         }
+
+        // Adjust "wl_lastlnum" for concealed lines below the last line in the window.
+        while (row == wp->w_grid.rows
+               && decor_conceal_line(wp, wp->w_lines[idx].wl_lastlnum, false)) {
+          wp->w_lines[idx].wl_lastlnum++;
+          hasFolding(wp, wp->w_lines[idx].wl_lastlnum, NULL, &wp->w_lines[idx].wl_lastlnum);
+        }
       }
 
       wp->w_lines[idx].wl_lnum = lnum;

--- a/test/functional/plugin/lsp/utils_spec.lua
+++ b/test/functional/plugin/lsp/utils_spec.lua
@@ -382,5 +382,23 @@ describe('vim.lsp.util', function()
       {1:~                                                    }|*9
                                                            |
     ]])
+    -- This tests the valid winline code path (why doesn't the above?).
+    exec_lua([[
+      vim.cmd.only()
+      vim.lsp.util.open_floating_preview({ 'foo', '```lua', 'local bar', '```' }, 'markdown', {
+        border = 'single',
+        focus = false,
+      })
+    ]])
+    feed('<C-W>wG')
+    screen:expect([[
+                                                           |
+      ┌─────────┐{1:                                          }|
+      │{4:foo      }│{1:                                          }|
+      │{100:^local}{101: }{102:bar}│{1:                                          }|
+      └─────────┘{1:                                          }|
+      {1:~                                                    }|*8
+                                                           |
+    ]])
   end)
 end)


### PR DESCRIPTION
Problem:  Last line in a window does not store correct `wl_lastlnum` if
          lines below it are concealed (resulting in e.g. incorrect
          cursor row).
Solution: Increment `wl_lastlnum` while it points to a line above a
          concealed line.