### PR TITLE
vim-patch:659cb28: runtime(doc): fix typo "bet" in :h 'completeopt'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1556,15 +1556,15 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    match, e.g., what file it comes from.
 
 	   noinsert Do not insert any text for a match until the user selects
-		    a match from the menu. Only works in combination with
+		    a match from the menu.  Only works in combination with
 		    "menu" or "menuone". No effect if "longest" is present.
 
 	   noselect Same as "noinsert", except that no menu item is
-		    pre-selected. If both "noinsert" and "noselect" are
+		    pre-selected.  If both "noinsert" and "noselect" are
 		    present, "noselect" has precedence.
 
 	   nosort   Disable sorting of completion candidates based on fuzzy
-		    scores when "fuzzy" is enabled. Candidates will appear
+		    scores when "fuzzy" is enabled.  Candidates will appear
 		    in their original order.
 
 	   popup    Show extra information about the currently selected
@@ -1575,7 +1575,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    Preinsert the portion of the first candidate word that is
 		    not part of the current completion leader and using the
 		    |hl-ComplMatchIns| highlight group.  In order for it to
-		    work, "fuzzy" must not bet set and "menuone" must be set.
+		    work, "fuzzy" must not be set and "menuone" must be set.
 
 	   preview  Show extra information about the currently selected
 		    completion in the preview window.  Only works in

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1083,15 +1083,15 @@ vim.go.cia = vim.go.completeitemalign
 --- 	    match, e.g., what file it comes from.
 ---
 ---    noinsert Do not insert any text for a match until the user selects
---- 	    a match from the menu. Only works in combination with
+--- 	    a match from the menu.  Only works in combination with
 --- 	    "menu" or "menuone". No effect if "longest" is present.
 ---
 ---    noselect Same as "noinsert", except that no menu item is
---- 	    pre-selected. If both "noinsert" and "noselect" are
+--- 	    pre-selected.  If both "noinsert" and "noselect" are
 --- 	    present, "noselect" has precedence.
 ---
 ---    nosort   Disable sorting of completion candidates based on fuzzy
---- 	    scores when "fuzzy" is enabled. Candidates will appear
+--- 	    scores when "fuzzy" is enabled.  Candidates will appear
 --- 	    in their original order.
 ---
 ---    popup    Show extra information about the currently selected
@@ -1102,7 +1102,7 @@ vim.go.cia = vim.go.completeitemalign
 --- 	    Preinsert the portion of the first candidate word that is
 --- 	    not part of the current completion leader and using the
 --- 	    `hl-ComplMatchIns` highlight group.  In order for it to
---- 	    work, "fuzzy" must not bet set and "menuone" must be set.
+--- 	    work, "fuzzy" must not be set and "menuone" must be set.
 ---
 ---    preview  Show extra information about the currently selected
 --- 	    completion in the preview window.  Only works in

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1525,15 +1525,15 @@ local options = {
         	    match, e.g., what file it comes from.
 
            noinsert Do not insert any text for a match until the user selects
-        	    a match from the menu. Only works in combination with
+        	    a match from the menu.  Only works in combination with
         	    "menu" or "menuone". No effect if "longest" is present.
 
            noselect Same as "noinsert", except that no menu item is
-        	    pre-selected. If both "noinsert" and "noselect" are
+        	    pre-selected.  If both "noinsert" and "noselect" are
         	    present, "noselect" has precedence.
 
            nosort   Disable sorting of completion candidates based on fuzzy
-        	    scores when "fuzzy" is enabled. Candidates will appear
+        	    scores when "fuzzy" is enabled.  Candidates will appear
         	    in their original order.
 
            popup    Show extra information about the currently selected
@@ -1544,7 +1544,7 @@ local options = {
         	    Preinsert the portion of the first candidate word that is
         	    not part of the current completion leader and using the
         	    |hl-ComplMatchIns| highlight group.  In order for it to
-        	    work, "fuzzy" must not bet set and "menuone" must be set.
+        	    work, "fuzzy" must not be set and "menuone" must be set.
 
            preview  Show extra information about the currently selected
         	    completion in the preview window.  Only works in


### PR DESCRIPTION
#### vim-patch:659cb28: runtime(doc): fix typo "bet" in :h 'completeopt'

closes: vim/vim#16773

https://github.com/vim/vim/commit/659cb28c25b756e59c712c337f8b4650e85f8bcd