### PR TITLE
vim-patch:9.1.1169: using global variable for get_insert()/get_lambda_name()

### DIFF
--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -155,9 +155,6 @@ static uint8_t noremapbuf_init[TYPELEN_INIT];  ///< initial typebuf.tb_noremap
 
 static size_t last_recorded_len = 0;  ///< number of last recorded chars
 
-static size_t last_get_inserted_len = 0;  ///< length of the string returned from the
-                                          ///< last call to get_inserted()
-
 enum {
   KEYLEN_PART_KEY = -1,  ///< keylen value for incomplete key-code
   KEYLEN_PART_MAP = -2,  ///< keylen value for incomplete mapping
@@ -254,15 +251,11 @@ char *get_recorded(void)
 
 /// Return the contents of the redo buffer as a single string.
 /// K_SPECIAL in the returned string is escaped.
-char *get_inserted(void)
+String get_inserted(void)
 {
-  return get_buffcont(&redobuff, false, &last_get_inserted_len);
-}
-
-/// Return the length of string returned from the last call of get_inserted().
-size_t get_inserted_len(void)
-{
-  return last_get_inserted_len;
+  size_t len = 0;
+  char *str = get_buffcont(&redobuff, false, &len);
+  return cbuf_as_string(str, len);
 }
 
 /// Add string after the current block of the given buffer

--- a/src/nvim/getchar.h
+++ b/src/nvim/getchar.h
@@ -3,6 +3,7 @@
 #include <stddef.h>  // IWYU pragma: keep
 #include <stdint.h>  // IWYU pragma: keep
 
+#include "nvim/api/private/defs.h"  // IWYU pragma: keep
 #include "nvim/eval/typval_defs.h"  // IWYU pragma: keep
 #include "nvim/getchar_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep


### PR DESCRIPTION
#### vim-patch:9.1.1169: using global variable for get_insert()/get_lambda_name()

Problem:  using global variable for get_insert()/get_lambda_name()
          (after v9.1.1151)
Solution: let the functions return a string_T object instead
          (Yee Cheng Chin)

In vim/vim#16720, `get_insert()` was modified to store a string length in a
global variable to be queried immediately by another `get_insert_len()`
function, which is somewhat fragile. Instead, just have the function
itself return a `string_T` object instead. Also do the same for
`get_lambda_name()` which has similar issues.

closes: vim/vim#16775

https://github.com/vim/vim/commit/0b5fe420715786249cd121d845dbd6a81f962d1b

Co-authored-by: Yee Cheng Chin <ychin.git@gmail.com>