### PR TITLE
fix(lsp): open_floating_preview() ignores max_height

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1656,7 +1656,9 @@ function M.open_floating_preview(contents, syntax, opts)
     if not opts.height then
       -- Reduce window height if TS highlighter conceals code block backticks.
       local conceal_height = api.nvim_win_text_height(floating_winnr, {}).all
-      api.nvim_win_set_height(floating_winnr, conceal_height)
+      if conceal_height < api.nvim_win_get_height(floating_winnr) then
+        api.nvim_win_set_height(floating_winnr, conceal_height)
+      end
     end
   end
 

--- a/test/functional/plugin/lsp/utils_spec.lua
+++ b/test/functional/plugin/lsp/utils_spec.lua
@@ -383,4 +383,28 @@ describe('vim.lsp.util', function()
                                                            |
     ]])
   end)
+
+  it('open_floating_preview height does not exceed max_height', function()
+    local screen = Screen.new()
+    exec_lua([[
+      vim.lsp.util.open_floating_preview(vim.fn.range(1, 10), 'markdown', {
+        border = 'single',
+        width = 5,
+        max_height = 5,
+        focus = false,
+      })
+    ]])
+    screen:expect([[
+      ^                                                     |
+      ┌─────┐{1:                                              }|
+      │{4:1    }│{1:                                              }|
+      │{4:2    }│{1:                                              }|
+      │{4:3    }│{1:                                              }|
+      │{4:4    }│{1:                                              }|
+      │{4:5    }│{1:                                              }|
+      └─────┘{1:                                              }|
+      {1:~                                                    }|*5
+                                                           |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:  After 47aaddfa the max_height option is no longer respected.
          Hover documentation and Signature help windows take up the
          entire text height.
Solution: Compare to window's current height and only modify the height
          if it would reduce the height, not enlarge it.