### PR TITLE
fix(tui): remove DCS escaping in tmux

### DIFF
--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -264,7 +264,8 @@ causes the terminal emulator to write to or read from the system clipboard.
 When Nvim is running in the |TUI|, it will automatically attempt to determine if
 the host terminal emulator supports OSC 52. If it does, then Nvim will use OSC
 52 for copying and pasting if no other |clipboard-tool| is found and when
-'clipboard' is unset.
+'clipboard' is unset. NOTE: Using a terminal multiplexer (e.g. tmux) may
+inhibit automatic OSC 52 support detection.
 
 							*g:termfeatures*
 To disable the automatic detection, set the "osc52" key of |g:termfeatures| to

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -834,9 +834,7 @@ do
         -- terminal responds to the DECRQSS with the same SGR sequence that we
         -- sent then the terminal supports truecolor.
         local decrqss = '\027P$qm\027\\'
-        if os.getenv('TMUX') then
-          decrqss = string.format('\027Ptmux;%s\027\\', decrqss:gsub('\027', '\027\027'))
-        end
+
         -- Reset attributes first, as other code may have set attributes.
         io.stdout:write(string.format('\027[0m\027[48;2;%d;%d;%dm%s', r, g, b, decrqss))
 

--- a/runtime/lua/vim/termcap.lua
+++ b/runtime/lua/vim/termcap.lua
@@ -71,11 +71,6 @@ function M.query(caps, cb)
 
   local query = string.format('\027P+q%s\027\\', table.concat(encoded, ';'))
 
-  -- If running in tmux, wrap with the passthrough sequence
-  if os.getenv('TMUX') then
-    query = string.format('\027Ptmux;%s\027\\', query:gsub('\027', '\027\027'))
-  end
-
   io.stdout:write(query)
 
   timer:start(1000, 0, function()


### PR DESCRIPTION
Per https://github.com/tmux/tmux/issues/4386, tmux does not support DCS responses, even if the initial request was escaped.

Closes: https://github.com/neovim/neovim/issues/32609