### PR TITLE
vim-patch:9.1.1171: tests: wrong arguments passed to assert_equal()

### DIFF
--- a/test/old/testdir/test_registers.vim
+++ b/test/old/testdir/test_registers.vim
@@ -1045,7 +1045,7 @@ func Test_mark_from_yank()
   normal! yi"
   call assert_equal([0, 1, 10, 0], getpos("']"))
   normal! ya"
-  call assert_equal(getpos("']"), [0, 1, 13, 0], getpos("']"))
+  call assert_equal([0, 1, 13, 0], getpos("']"))
   " single quote object
   call setline(1, 'test ''yank''  mark')
   normal! yi'


### PR DESCRIPTION
#### vim-patch:9.1.1171: tests: wrong arguments passed to assert_equal()

Problem:  tests: wrong arguments passed to assert_equal()
          (after v9.1.1167).
Solution: Swap arguments in the assert_equal() call (zeertzjq).

closes: vim/vim#16782

https://github.com/vim/vim/commit/a95085e0fc2e46c7136982e8ba1ae91375991bfd