### PR TITLE
doc(lsp): add example setting to make server aware of global `vim`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -50,6 +50,15 @@ Follow these steps to get LSP features:
           Lua = {
             runtime = {
               version = 'LuaJIT',
+            },
+            -- Make the server aware of Nvim runtime files. Useful if you
+            -- primarily use Lua for Nvim configuration, plugins,...
+            workspace = {
+              checkThirdParty = false,
+              library = {
+                vim.env.VIMRUNTIME,
+                -- additional paths here.
+              }
             }
           }
         }


### PR DESCRIPTION
Problem:
I think most Nvim users only use Lua for configuration and plugins, and a common question is that they are warned by the server about the `vim` global variable.

Solution:
Add a bit code to the LuaLS example in `lsp.txt`