### PR TITLE
vim-patch:9.1.1172: [security]: overflow with 'nostartofline' and Ex command in tag file

### DIFF
--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -2986,6 +2986,8 @@ static int jumpto_tag(const char *lbuf_arg, int forceit, bool keep_help)
       secure = 1;
       sandbox++;
       curwin->w_cursor.lnum = 1;  // start command in line 1
+      curwin->w_cursor.col = 0;
+      curwin->w_cursor.coladd = 0;
       do_cmdline_cmd(pbuf);
       retval = OK;
 

--- a/test/old/testdir/test_tagjump.vim
+++ b/test/old/testdir/test_tagjump.vim
@@ -1696,4 +1696,21 @@ func Test_tag_guess_short()
   set tags& cpoptions-=t
 endfunc
 
+func Test_tag_excmd_with_nostartofline()
+  call writefile(["!_TAG_FILE_ENCODING\tutf-8\t//",
+        \ "f\tXfile\tascii"],
+        \ 'Xtags', 'D')
+  call writefile(['f', 'foobar'], 'Xfile', 'D')
+
+  set nostartofline
+  new Xfile
+  setlocal tags=Xtags
+  normal! G$
+  " This used to cause heap-buffer-overflow
+  tag f
+
+  bwipe!
+  set startofline&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1172: [security]: overflow with 'nostartofline' and Ex command in tag file

Problem:  heap-buffer-overflow with 'nostartofline' and Ex command in
          tag file.
Solution: Set cursor column when moving cursor to line 1 (zeertzjq).

closes: vim/vim#16796

https://github.com/vim/vim/commit/3ed6659549e447ff00def8edc841321e497f70a8