### PR TITLE
vim-patch:4783a2c: runtime(doc): mention bzip3 in gzip plugin documentation

### DIFF
--- a/runtime/doc/pi_gzip.txt
+++ b/runtime/doc/pi_gzip.txt
@@ -29,6 +29,7 @@ with these extensions:
 
 	extension	compression >
 	*.bz2		bzip2
+	*.bz3		bzip3
 	*.gz		gzip
 	*.lz		lzip
 	*.lz4		lz4


### PR DESCRIPTION
#### vim-patch:4783a2c: runtime(doc): mention bzip3 in gzip plugin documentation

closes: vim/vim#16800

https://github.com/vim/vim/commit/4783a2c073ecc075a6d1b23414901e78e1f18383

Co-authored-by: Jim Zhou <jimzhouzzy@gmail.com>