### PR TITLE
vim-patch:9.1.1174: tests: Test_complete_cmdline() may fail

### DIFF
--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -1208,8 +1208,8 @@ func Test_complete_cmdline()
   call assert_equal('abcxyz(', getline(3))
   com! -buffer TestCommand1 echo 'TestCommand1'
   com! -buffer TestCommand2 echo 'TestCommand2'
-  write TestCommand1Test
-  write TestCommand2Test
+  write! TestCommand1Test
+  write! TestCommand2Test
   " Test repeating <CTRL-X> <CTRL-V> and switching to another CTRL-X mode
   exe "normal oT\<C-X>\<C-V>\<C-X>\<C-V>\<C-X>\<C-F>\<Esc>"
   call assert_equal('TestCommand2Test', getline(4))


### PR DESCRIPTION
#### vim-patch:9.1.1174: tests: Test_complete_cmdline() may fail

Problem:  tests: when the file 'TestCommand?Test' exists,
          'Test_complete_cmdline()' will fail when writing the file. And
          there's no related cleaning operation for this kind of file
          before the test run.
Solution: modify `write` to `write!` to override (Jim Zhou).

closes: vim/vim#16799

https://github.com/vim/vim/commit/f7087cbec7ec1d32465c2460f2665725c8d3a06a

Co-authored-by: Jim Zhou <jimzhouzzy@gmail.com>