### PR TITLE
vim-patch:9.1.1175: inconsistent behaviour with exclusive selection and motion commands

### DIFF
--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -464,6 +464,8 @@ EXTERN bool VIsual_active INIT( = false);
 EXTERN bool VIsual_select INIT( = false);
 /// Register name for Select mode
 EXTERN int VIsual_select_reg INIT( = 0);
+/// Whether incremented cursor during exclusive selection
+EXTERN bool VIsual_select_exclu_adj INIT( = false);
 /// Restart Select mode when next cmd finished
 EXTERN int restart_VIsual_select INIT( = 0);
 /// Whether to restart the selection after a Select-mode mapping or menu.

--- a/src/nvim/textobject.c
+++ b/src/nvim/textobject.c
@@ -19,6 +19,7 @@
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/move.h"
+#include "nvim/normal.h"
 #include "nvim/option_vars.h"
 #include "nvim/pos_defs.h"
 #include "nvim/search.h"
@@ -427,6 +428,13 @@ int end_word(int count, bool bigword, bool stop, bool empty)
 
   curwin->w_cursor.coladd = 0;
   cls_bigword = bigword;
+
+  // If adjusted cursor position previously, unadjust it.
+  if (*p_sel == 'e' && VIsual_active && VIsual_mode == 'v'
+      && VIsual_select_exclu_adj) {
+    unadjust_for_sel();
+  }
+
   while (--count >= 0) {
     // When inside a range of folded lines, move to the last char of the
     // last line.

--- a/test/old/testdir/test_visual.vim
+++ b/test/old/testdir/test_visual.vim
@@ -1101,6 +1101,50 @@ func Test_exclusive_selection()
   bw!
 endfunc
 
+" Test for inclusive motion in visual mode with 'exclusive' selection
+func Test_inclusive_motion_selection_exclusive()
+  func s:compare_exclu_inclu(line, keys, expected_exclu)
+    let msg = "data: '" . a:line . "' operation: '" . a:keys . "'"
+    call setline(1, a:line)
+    set selection=exclusive
+    call feedkeys(a:keys, 'xt')
+    call assert_equal(a:expected_exclu, getpos('.'), msg)
+    let pos_ex = col('.')
+    set selection=inclusive
+    call feedkeys(a:keys, 'xt')
+    let pos_in = col('.')
+    call assert_equal(1, pos_ex - pos_in, msg)
+  endfunc
+
+  new
+  " Test 'e' motion
+  set selection=exclusive
+  call setline(1, 'eins zwei drei')
+  norm! ggvey
+  call assert_equal('eins', @")
+  call setline(1, 'abc(abc)abc')
+  norm! ggveeed
+  call assert_equal(')abc', getline(1))
+  call setline(1, 'abc(abc)abc')
+  norm! gg3lvey
+  call assert_equal('(abc', @")
+  call s:compare_exclu_inclu('abc(abc)abc', 'ggveee', [0, 1, 8, 0])
+  " Test 'f' motion
+  call s:compare_exclu_inclu('geschwindigkeit', 'ggvfefe', [0, 1, 14, 0])
+  call s:compare_exclu_inclu('loooooooooooong', 'ggv2fo2fo2fo', [0, 1, 8, 0])
+  " Test 't' motion
+  call s:compare_exclu_inclu('geschwindigkeit', 'ggv2te', [0, 1, 13, 0])
+  call s:compare_exclu_inclu('loooooooooooong', 'gglv2to2to2to', [0, 1, 6, 0])
+  " Test ';' motion
+  call s:compare_exclu_inclu('geschwindigkeit', 'ggvfi;;', [0, 1, 15, 0])
+  call s:compare_exclu_inclu('geschwindigkeit', 'ggvti;;', [0, 1, 14, 0])
+  call s:compare_exclu_inclu('loooooooooooong', 'ggv2fo;;', [0, 1, 6, 0])
+  call s:compare_exclu_inclu('loooooooooooong', 'ggvl2to;;', [0, 1, 6, 0])
+  " Clean up
+  set selection&
+  bw!
+endfunc
+
 " Test for starting linewise visual with a count.
 " This test needs to be run without any previous visual mode. Otherwise the
 " count will use the count from the previous visual mode.


### PR DESCRIPTION
#### vim-patch:9.1.1175: inconsistent behaviour with exclusive selection and motion commands

Problem:  inconsistent behaviour with exclusive selection and motion
          commands (aidancz)
Solution: adjust cursor position when selection is exclusive
          (Jim Zhou)

closes: vim/vim#16784

https://github.com/vim/vim/commit/c8cce711dde2d8abcf0929b3b12c4bfc5547a89d

Co-authored-by: Jim Zhou <jimzhouzzy@gmail.com>
Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>