### PR TITLE
vim-patch:9.1.1176: wrong indent when expanding multiple lines

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1315,7 +1315,8 @@ bool open_line(int dir, int flags, int second_line_indent, bool *did_do_comment)
   // May do indenting after opening a new line.
   bool do_cindent = !p_paste && (curbuf->b_p_cin || *curbuf->b_p_inde != NUL)
                     && in_cinkeys(dir == FORWARD ? KEY_OPEN_FORW : KEY_OPEN_BACK,
-                                  ' ', linewhite(curwin->w_cursor.lnum));
+                                  ' ', linewhite(curwin->w_cursor.lnum))
+                    && !(flags & OPENLINE_FORCE_INDENT);
 
   // Find out if the current line starts with a comment leader.
   // This may then be inserted in front of the new line.

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -7310,6 +7310,7 @@ describe('builtin popupmenu', function()
             return [#{word: "func ()\n\t\nend", abbr: "function ()",}, #{word: "foobar"}, #{word: "你好\n\t\n我好"}]
           endfunc
           set omnifunc=Omni_test
+          inoremap <F5> <Cmd>call complete(col('.'), [ "my\n\tmulti\nline", "my\n\t\tmulti\nline" ])<CR>
         ]])
 
         feed('S<C-X><C-O>')
@@ -7449,6 +7450,21 @@ describe('builtin popupmenu', function()
           {8:    }                            |
             end^                           |
           end                             |
+          {1:~                               }|*14
+          {2:-- INSERT --}                    |
+        ]])
+
+        feed('<Esc>ggVGd')
+        command('filetype indent on')
+        command('setlocal noautoindent shiftwidth& tabstop&')
+        command('setlocal ft=lua')
+        feed('S<F5>')
+        screen:expect([[
+          {8:my}                              |
+          {8:        multi}                   |
+          {8:line}^                            |
+          {s:my^@  multi^@line   }{1:            }|
+          {n:my^@    multi^@line }{1:            }|
           {1:~                               }|*14
           {2:-- INSERT --}                    |
         ]])

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1896,6 +1896,7 @@ func Test_pum_complete_with_special_characters()
       return [#{word: "func ()\n\t\nend", abbr: "function ()",}, #{word: "foobar"}, #{word: "你好\n\t\n我好"}]
     endfunc
     set omnifunc=Omni_test
+    inoremap <F5> <Cmd>call complete(col('.'), [ "my\n\tmulti\nline", "my\n\t\tmulti\nline" ])<CR>
   END
 
   call writefile(lines, 'Xpreviewscript', 'D')
@@ -1953,6 +1954,14 @@ func Test_pum_complete_with_special_characters()
   call term_sendkeys(buf, "\<C-Y>")
   call TermWait(buf, 50)
   call VerifyScreenDump(buf, 'Test_pum_with_special_characters_12', {})
+
+  call term_sendkeys(buf, "\<ESC>ggVGd")
+  call term_sendkeys(buf, ":filetype indent on\<CR>")
+  call term_sendkeys(buf, ":set nocompatible autoindent& shiftwidth& tabstop&\<CR>")
+  call term_sendkeys(buf, ":setlocal ft=lua\<CR>")
+  call term_sendkeys(buf, "S\<F5>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_pum_with_special_characters_13', {})
 
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.1176: wrong indent when expanding multiple lines

Problem:  wrong indentation of lastline when expanding multiple lines
Solution: Check OPENLINE_FORCE_INDENT flag in open_line() (glepnir)

closes: vim/vim#16786

https://github.com/vim/vim/commit/34a7d82aaed9836174f4ea84af047db3fdf6c8b3

Co-authored-by: glepnir <glephunter@gmail.com>