### PR TITLE
fix(marks): wrong winline info for concealed line with below virt line

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2118,13 +2118,13 @@ static void win_update(win_T *wp)
         if (wp == curwin && lnum == curwin->w_cursor.lnum) {
           conceal_cursor_used = conceal_cursor_line(curwin);
         }
-        if (idx > 0) {
-          wp->w_lines[idx - 1].wl_lastlnum = lnum + foldinfo.fi_lines - (foldinfo.fi_lines != 0);
-        }
-        if (lnum == mod_top && lnum < mod_bot) {
-          mod_top += foldinfo.fi_lines ? foldinfo.fi_lines : 1;
-        }
         if (win_get_fill(wp, lnum) == 0) {
+          if (idx > 0) {
+            wp->w_lines[idx - 1].wl_lastlnum = lnum + foldinfo.fi_lines - (foldinfo.fi_lines != 0);
+          }
+          if (lnum == mod_top && lnum < mod_bot) {
+            mod_top += foldinfo.fi_lines ? foldinfo.fi_lines : 1;
+          }
           lnum += foldinfo.fi_lines ? foldinfo.fi_lines : 1;
           spv.spv_capcol_lnum = 0;
           continue;

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2894,6 +2894,41 @@ describe('extmark decorations', function()
       {1:~                                                 }|*4
                                                         |
     ]])
+    -- Also with above virtual line #32744
+    command('set nornu')
+    api.nvim_buf_set_extmark(0, ns, 3, 0, { virt_lines = { { { "virt_below 4" } } } })
+    feed('6G')
+    screen:expect([[
+      {2:  1 }for _,item in ipairs(items) do                |
+      {2:  3 }    if hl_id_cell ~= nil then                 |
+      {2:  4 }        hl_id = hl_id_cell                    |
+      {2:    }virt_below 4                                  |
+      {2:  6 }    ^for _ = 1, (count or 1) do                |
+      {2:  7 }        local cell = line[colpos]             |
+      {2:  8 }        cell.text = text                      |
+      {2:  9 }        cell.hl_id = hl_id                    |
+      {2: 10 }        colpos = colpos+1                     |
+      {2: 11 }    end                                       |
+      {2: 12 }end                                           |
+      {1:~                                                 }|*3
+                                                        |
+    ]])
+    feed('j')
+    screen:expect([[
+      {2:  1 }for _,item in ipairs(items) do                |
+      {2:  3 }    if hl_id_cell ~= nil then                 |
+      {2:  4 }        hl_id = hl_id_cell                    |
+      {2:    }virt_below 4                                  |
+      {2:  6 }    for _ = 1, (count or 1) do                |
+      {2:  7 }    ^    local cell = line[colpos]             |
+      {2:  8 }        cell.text = text                      |
+      {2:  9 }        cell.hl_id = hl_id                    |
+      {2: 10 }        colpos = colpos+1                     |
+      {2: 11 }    end                                       |
+      {2: 12 }end                                           |
+      {1:~                                                 }|*3
+                                                        |
+    ]])
   end)
 end)
 


### PR DESCRIPTION
Problem:  Skipping over a concealed line for which `win_line()`
          _should_ be called because it has `virt_lines_above = false`
          lines associated with it.
Solution: Don't include such a line in `wl_lastlnum` from the line
          above.

Fix #32744