### PR TITLE
vim-patch:9.1.1173: filetype: ABNF files are not detected

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -198,6 +198,7 @@ local extension = {
   abap = 'abap',
   abc = 'abc',
   abl = 'abel',
+  abnf = 'abnf',
   wrm = 'acedb',
   ads = 'ada',
   ada = 'ada',

--- a/runtime/syntax/abnf.vim
+++ b/runtime/syntax/abnf.vim
@@ -1,0 +1,33 @@
+" Vim compiler file
+" Language:	abnf
+" Maintainer:	A4-Tacks <wdsjxhno1001@163.com>
+" Last Change:	2025 Mar 05
+" Upstream:	https://github.com/A4-Tacks/abnf.vim
+
+" Implementing RFC-5234, RFC-7405
+
+if exists('b:current_syntax')
+  finish
+endif
+
+syn case ignore
+
+syn match  abnfError	/[<>"]/
+syn match  abnfComment	/;.*/
+syn match  abnfOption	/[[/\]]/
+syn region abnfString	start=/\(%[si]\)\="/ end=/"/ oneline
+syn region abnfProse	start=/</ end=/>/ oneline
+syn match  abnfNumVal	/\v\%b[01]+%(%(\.[01]+)+|-[01]+)=>/
+syn match  abnfNumVal	/\v\%d\d+%(%(\.\d+)+|-\d+)=>/
+syn match  abnfNumVal	/\v\%x[0-9a-f]+%(%(\.[0-9a-f]+)+|-[0-9a-f]+)=>/
+syn match  abnfRepeat	/\v%(%(<\d+)=\*\d*|<\d+ =)\ze[^ \t\r\n0-9*/)\]]/
+
+hi def link abnfError		Error
+hi def link abnfComment		Comment
+hi def link abnfOption		PreProc
+hi def link abnfString		String
+hi def link abnfProse		String
+hi def link abnfNumVal		Number
+hi def link abnfRepeat		Repeat
+
+" vim:noet:ts=8:sts=8:nowrap

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -88,6 +88,7 @@ func s:GetFilenameChecks() abort
     \ 'abap': ['file.abap'],
     \ 'abc': ['file.abc'],
     \ 'abel': ['file.abl'],
+    \ 'abnf': ['file.abnf'],
     \ 'acedb': ['file.wrm'],
     \ 'ada': ['file.adb', 'file.ads', 'file.ada', 'file.gpr'],
     \ 'ahdl': ['file.tdf'],


### PR DESCRIPTION
#### vim-patch:9.1.1173: filetype: ABNF files are not detected

Problem:  filetype: ABNF files are not detected
Solution: detect '.abnf' file as abnf filetype and
          include an abnf syntax plugin (A4-Tacks).

References:
- RFC5234
- RFC7405

closes: vim/vim#16802

https://github.com/vim/vim/commit/9f827ec58728c4ea55a8d71d40a283ca2ce5b058

Co-authored-by: A4-Tacks <wdsjxhno1001@163.com>