### PR TITLE
vim-patch:08a410f: runtime(vim): recognize <...> strings (and keys) for 'keywordprg'

### DIFF
--- a/runtime/ftplugin/vim.vim
+++ b/runtime/ftplugin/vim.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin
 " Language:          Vim
 " Maintainer:        Doug Kearns <dougkearns@gmail.com>
-" Last Change:       2025 Feb 25
+" Last Change:       2025 Mar 05
 " Former Maintainer: Bram Moolenaar <Bram@vim.org>
 " Contributors:      Riley Bruins <ribru17@gmail.com> ('commentstring'),
 "                    @Konfekt
@@ -85,6 +85,8 @@ if !exists("*" .. expand("<SID>") .. "Help")
       return ':'.topic
     elseif pre =~# '\<v:$'
       return 'v:'.topic
+    elseif pre =~# '<$'
+      return '<'.topic.'>'
     elseif pre =~# '\\$'
       return '/\'.topic
     elseif topic ==# 'v' && post =~# ':\w\+'


### PR DESCRIPTION
#### vim-patch:08a410f: runtime(vim): recognize <...> strings (and keys) for 'keywordprg'

see :help E499 and :h key-notation

closes: vim/vim#16795

https://github.com/vim/vim/commit/08a410f674a340f137623526bf8159d5a476f729

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>