### PR TITLE
fix: update osc52 termfeatures flag on UIEnter/UILeave

### DIFF
--- a/runtime/plugin/osc52.lua
+++ b/runtime/plugin/osc52.lua
@@ -1,37 +1,72 @@
-local tty = false
-for _, ui in ipairs(vim.api.nvim_list_uis()) do
-  if ui.chan == 1 and ui.stdout_tty then
-    tty = true
-    break
-  end
-end
+--- @class (private) TermFeatures
+--- @field osc52 boolean?
 
--- Do not query when any of the following is true:
---   * TUI is not attached
---   * OSC 52 support is explicitly disabled via g:termfeatures
---   * Using a badly behaved terminal
-if
-  not tty
-  or (vim.g.termfeatures ~= nil and vim.g.termfeatures.osc52 == false)
-  or vim.env.TERM_PROGRAM == 'Apple_Terminal'
-then
-  return
-end
+local id = vim.api.nvim_create_augroup('nvim.osc52', { clear = true })
+vim.api.nvim_create_autocmd('UIEnter', {
+  group = id,
+  desc = 'Enable OSC 52 feature flag if a supporting TUI is attached',
+  callback = function()
+    -- If OSC 52 is explicitly disabled by the user then don't do anything
+    if vim.g.termfeatures ~= nil and vim.g.termfeatures.osc52 == false then
+      return
+    end
 
-require('vim.termcap').query('Ms', function(cap, found, seq)
-  if not found then
-    return
-  end
+    local tty = false
+    for _, ui in ipairs(vim.api.nvim_list_uis()) do
+      if ui.stdout_tty then
+        tty = true
+        break
+      end
+    end
 
-  assert(cap == 'Ms')
+    -- Do not query when any of the following is true:
+    --   * No TUI is attached
+    --   * Using a badly behaved terminal
+    if not tty or vim.env.TERM_PROGRAM == 'Apple_Terminal' then
+      local termfeatures = vim.g.termfeatures or {} ---@type TermFeatures
+      termfeatures.osc52 = nil
+      vim.g.termfeatures = termfeatures
+      return
+    end
 
-  -- If the terminal reports a sequence other than OSC 52 for the Ms capability
-  -- then ignore it. We only support OSC 52 (for now)
-  if not seq or not seq:match('^\027%]52') then
-    return
-  end
+    require('vim.termcap').query('Ms', function(cap, found, seq)
+      if not found then
+        return
+      end
 
-  local termfeatures = vim.g.termfeatures or {}
-  termfeatures.osc52 = true
-  vim.g.termfeatures = termfeatures
-end)
+      assert(cap == 'Ms')
+
+      -- If the terminal reports a sequence other than OSC 52 for the Ms capability
+      -- then ignore it. We only support OSC 52 (for now)
+      if not seq or not seq:match('^\027%]52') then
+        return
+      end
+
+      local termfeatures = vim.g.termfeatures or {} ---@type TermFeatures
+      termfeatures.osc52 = true
+      vim.g.termfeatures = termfeatures
+    end)
+  end,
+})
+
+vim.api.nvim_create_autocmd('UILeave', {
+  group = id,
+  desc = 'Reset OSC 52 feature flag if no TUIs are attached',
+  callback = function()
+    -- If OSC 52 is explicitly disabled by the user then don't do anything
+    if vim.g.termfeatures ~= nil and vim.g.termfeatures.osc52 == false then
+      return
+    end
+
+    -- If no TUI is connected to Nvim's stdout then reset the OSC 52 term features flag
+    for _, ui in ipairs(vim.api.nvim_list_uis()) do
+      if ui.stdout_tty then
+        return
+      end
+    end
+
+    local termfeatures = vim.g.termfeatures or {} ---@type TermFeatures
+    termfeatures.osc52 = nil
+    vim.g.termfeatures = termfeatures
+  end,
+})


### PR DESCRIPTION
On each UIEnter/UILeave event, check to make sure there is at is a TUI client connected to Nvim's stdout. If none are, then the osc52 flag is cleared so that Nvim does not attempt to use the OSC 52 clipboard provider.

There are still some edge cases possible here. For example, if the original TUI (the one that started the embedded Nvim process) detaches after a second TUI client connects, Nvim will _not_ use the second TUI. The Nvim core process depends on its stdout being connected to the tty of the TUI, which is not the case when a TUI client connects remotely. This has the potential to cause some confusion when users wonder why some terminal features aren't working.

Solving this use case is much more involved as it will require changes to the UI protocol. That is out of scope for this change, which simply attempts to address the issue of Nvim trying to use OSC 52 when no TUIs are attached at all.

Ref: #28792