### PR TITLE
vim-patch:9.1.1177: filetype: tera files not detected

### DIFF
--- a/runtime/ftplugin/tera.vim
+++ b/runtime/ftplugin/tera.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin file
+" Language:             Tera
+" Maintainer:           Muntasir Mahmud <muntasir.joypurhat@gmail.com>
+" Last Change:          2025 Mar 06
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal commentstring={#\ %s\ #}
+
+let b:undo_ftplugin = "setlocal commentstring<"

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1207,6 +1207,7 @@ local extension = {
   tl = 'teal',
   templ = 'templ',
   tmpl = 'template',
+  tera = 'tera',
   ti = 'terminfo',
   dtx = 'tex',
   ltx = 'tex',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -801,6 +801,7 @@ func s:GetFilenameChecks() abort
     \ 'teal': ['file.tl'],
     \ 'templ': ['file.templ'],
     \ 'template': ['file.tmpl'],
+    \ 'tera': ['file.tera'],
     \ 'teraterm': ['file.ttl'],
     \ 'terminfo': ['file.ti'],
     \ 'terraform-vars': ['file.tfvars'],


### PR DESCRIPTION
Problem:  filetype: tera files not detected
Solution: detect '*.tera' files as tera filetype,
          include a simple filetype plugin
          (MuntasirSZN)

closes: vim/vim#16806

https://github.com/vim/vim/commit/5daaf2326800ff0683a5be9a7f475667a4fc09db

Co-authored-by: MuntasirSZN <muntasir.joypurhat@gmail.com>
