### PR TITLE
fix(lsp): use unresolved code action when `codeAction/resolve` fails

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -1155,7 +1155,8 @@ local function on_code_action_results(results, opts)
     if not action.edit or not action.command and client:supports_method(ms.codeAction_resolve) then
       client:request(ms.codeAction_resolve, action, function(err, resolved_action)
         if err then
-          if action.command then
+          -- If resolve fails, try to apply the edit/command from the original code action.
+          if action.edit or action.command then
             apply_action(action, client, choice.ctx)
           else
             vim.notify(err.code .. ': ' .. err.message, vim.log.levels.ERROR)


### PR DESCRIPTION
Fixes https://github.com/neovim/neovim/issues/32757

This isn't indicated by the spec, but both [Helix](https://github.com/helix-editor/helix/blob/19558839b72717a5fc1d1620f73e7a9dfc5dfd6a/helix-term/src/commands/lsp.rs#L794-L795) and [VS Code](https://github.com/microsoft/vscode/blob/2b3cb533550639a43a144968b07576998a880718/src/vs/workbench/api/common/extHostLanguageFeatures.ts#L559) fallback to the original code action when resolve fails.

I'll make a PR to the LSP repo to make this clear in the spec because I don't like this guessing what the right thing should be.