### PR TITLE
fix(marks): mark winline as invalid if change is in a concealed line

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -810,8 +810,8 @@ struct tabpage_S {
 typedef struct {
   linenr_T wl_lnum;             // buffer line number for logical line
   uint16_t wl_size;             // height in screen lines
-  char wl_valid;                // true values are valid for text in buffer
-  char wl_folded;               // true when this is a range of folded lines
+  bool wl_valid;                // true values are valid for text in buffer
+  bool wl_folded;               // true when this is a range of folded lines
   linenr_T wl_foldend;          // last buffer line number for folded line
   linenr_T wl_lastlnum;         // last buffer line number for logical line
 } wline_T;

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -208,8 +208,9 @@ static void changed_lines_invalidate_win(win_T *wp, linenr_T lnum, colnr_T col, 
           wp->w_lines[i].wl_foldend += xtra;
           wp->w_lines[i].wl_lastlnum += xtra;
         }
-      } else if (wp->w_lines[i].wl_foldend >= lnum) {
-        // change somewhere inside this range of folded lines,
+      } else if (wp->w_lines[i].wl_foldend >= lnum
+                 || wp->w_lines[i].wl_lastlnum >= lnum) {
+        // change somewhere inside this range of folded or concealed lines,
         // may need to be redrawn
         wp->w_lines[i].wl_valid = false;
       }

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2929,6 +2929,26 @@ describe('extmark decorations', function()
       {1:~                                                 }|*3
                                                         |
     ]])
+    -- Even when virtual line is added as line is concealed #32762
+    feed('5G')
+    api.nvim_buf_clear_namespace(0, ns, 3, 4)
+    feed('j')
+    api.nvim_buf_set_extmark(0, ns, 3, 0, { virt_lines = { { { "virt_below 4" } } } })
+    screen:expect([[
+      {2:  1 }for _,item in ipairs(items) do                |
+      {2:  3 }    if hl_id_cell ~= nil then                 |
+      {2:  4 }        hl_id = hl_id_cell                    |
+      {2:    }virt_below 4                                  |
+      {2:  6 }^    for _ = 1, (count or 1) do                |
+      {2:  7 }        local cell = line[colpos]             |
+      {2:  8 }        cell.text = text                      |
+      {2:  9 }        cell.hl_id = hl_id                    |
+      {2: 10 }        colpos = colpos+1                     |
+      {2: 11 }    end                                       |
+      {2: 12 }end                                           |
+      {1:~                                                 }|*3
+                                                        |
+    ]])
   end)
 end)
 


### PR DESCRIPTION
Code that checks whether a `w_lines` entry has become invalid due to a change in a folded line should now also check for concealed lines.

Fix #32762