### PR TITLE
fix(lsp): rename `on_publish_diagnostics` parameter: result->params

### DIFF
--- a/runtime/colors/vim.lua
+++ b/runtime/colors/vim.lua
@@ -17,7 +17,7 @@ local hi = function(name, val)
   val.force = true
 
   -- Make sure that `cterm` attribute is not populated from `gui`
-  val.cterm = val.cterm or {}
+  val.cterm = val.cterm or {} ---@type vim.api.keyset.highlight
 
   -- Define global highlight
   vim.api.nvim_set_hl(0, name, val)

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1750,13 +1750,13 @@ on_diagnostic({error}, {result}, {ctx})
       • {ctx}     (`lsp.HandlerContext`)
 
                                  *vim.lsp.diagnostic.on_publish_diagnostics()*
-on_publish_diagnostics({_}, {result}, {ctx})
+on_publish_diagnostics({_}, {params}, {ctx})
     |lsp-handler| for the method "textDocument/publishDiagnostics"
 
     See |vim.diagnostic.config()| for configuration options.
 
     Parameters: ~
-      • {result}  (`lsp.PublishDiagnosticsParams`)
+      • {params}  (`lsp.PublishDiagnosticsParams`)
       • {ctx}     (`lsp.HandlerContext`)
 
 

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -237,10 +237,10 @@ end
 --- See |vim.diagnostic.config()| for configuration options.
 ---
 ---@param _ lsp.ResponseError?
----@param result lsp.PublishDiagnosticsParams
+---@param params lsp.PublishDiagnosticsParams
 ---@param ctx lsp.HandlerContext
-function M.on_publish_diagnostics(_, result, ctx)
-  handle_diagnostics(result.uri, ctx.client_id, result.diagnostics, false)
+function M.on_publish_diagnostics(_, params, ctx)
+  handle_diagnostics(params.uri, ctx.client_id, params.diagnostics, false)
 end
 
 --- |lsp-handler| for the method "textDocument/diagnostic"


### PR DESCRIPTION
I ran into this while working on a rust-based LSP testing library. If I send a `textDocument/publishDiagnostics` notification with `None` as the params like so:

```rust
let publish_params: Option<PublishDiagnosticsParams> = None;
let params = serde_json::to_value(&publish_params).unwrap();

let notif = Notification {
    method: PublishDiagnostics::METHOD.to_string(),
    params,
};

connection.sender.send(Message::Notification(notif)).unwrap();
```

Neovim hits the following error:

```
Error executing vim.schedule lua callback: /usr/local/share/nvim/runtime/lua/vim/lsp/diagnostic.lua:243: attempt to index local 'result' (a nil value)
stack traceback:
        /usr/local/share/nvim/runtime/lua/vim/lsp/diagnostic.lua:243: in function 'handler'
        /usr/local/share/nvim/runtime/lua/vim/lsp/client.lua:1109: in function ''
        vim/_editor.lua: in function <vim/_editor.lua:0>
```

I added a test based on similar looking cases, and also tried this patch out locally. Please let me know if I've made a mistake or if there's anything else I can do for this fix :).