### PR TITLE
test(lsp/utils): prevent CursorMoved closing float immediately

### DIFF
--- a/test/functional/plugin/lsp/utils_spec.lua
+++ b/test/functional/plugin/lsp/utils_spec.lua
@@ -368,6 +368,7 @@ describe('vim.lsp.util', function()
     ]])
     -- Correct height when float inherits 'conceallevel' >= 2 #32639
     command('close | set conceallevel=2')
+    feed('<Ignore>') -- Prevent CursorMoved closing the next float immediately
     exec_lua([[
       vim.lsp.util.open_floating_preview({ '```lua', 'local foo', '```' }, 'markdown', {
         border = 'single',


### PR DESCRIPTION
This fixes the flakiness observed in https://github.com/neovim/neovim/actions/runs/13733258040/job/38413757162?pr=32780