### PR TITLE
fix(lsp)!: pass buffer number to root_dir function

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -678,10 +678,11 @@ Lua module: vim.lsp                                                 *lsp-core*
                          the LSP server will base its workspaceFolders,
                          rootUri, and rootPath on initialization. Unused if
                          `root_dir` is provided.
-      • {root_dir}?      (`string|fun(cb:fun(string))`) Directory where the
-                         LSP server will base its workspaceFolders, rootUri,
-                         and rootPath on initialization. If a function, it
-                         accepts a single callback argument which must be
+      • {root_dir}?      (`string|fun(bufnr: integer, cb:fun(root_dir?:string))`)
+                         Directory where the LSP server will base its
+                         workspaceFolders, rootUri, and rootPath on
+                         initialization. If a function, it is passed the
+                         buffer number and a callback argument which must be
                          called with the value of root_dir to use. The LSP
                          server will not be started until the callback is
                          called.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -285,10 +285,11 @@ end
 --- rootUri, and rootPath on initialization. Unused if `root_dir` is provided.
 --- @field root_markers? string[]
 ---
---- Directory where the LSP server will base its workspaceFolders, rootUri, and rootPath on
---- initialization. If a function, it accepts a single callback argument which must be called with
---- the value of root_dir to use. The LSP server will not be started until the callback is called.
---- @field root_dir? string|fun(cb:fun(string))
+--- Directory where the LSP server will base its workspaceFolders, rootUri, and
+--- rootPath on initialization. If a function, it is passed the buffer number
+--- and a callback argument which must be called with the value of root_dir to
+--- use. The LSP server will not be started until the callback is called.
+--- @field root_dir? string|fun(bufnr: integer, cb:fun(root_dir?:string))
 ---
 --- Predicate used to decide if a client should be re-used. Used on all
 --- running clients. The default implementation re-uses a client if name and
@@ -462,7 +463,7 @@ local function lsp_enable_callback(bufnr)
 
       if type(config.root_dir) == 'function' then
         ---@param root_dir string
-        config.root_dir(function(root_dir)
+        config.root_dir(bufnr, function(root_dir)
           config.root_dir = root_dir
           vim.schedule(function()
             start(config)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -6348,7 +6348,8 @@ describe('LSP', function()
         vim.lsp.config('foo', {
           cmd = server.cmd,
           filetypes = { 'foo' },
-          root_dir = function(cb)
+          root_dir = function(bufnr, cb)
+            assert(tmp1 == vim.api.nvim_buf_get_name(bufnr))
             vim.system({ 'sleep', '0' }, {}, function()
               cb('some_dir')
             end)


### PR DESCRIPTION
Problem:

The root dir function is not passed any context and can only assume the
current buffer is the one being attached.

The main use case is for getting the path of the buffer using
`nvim_buf_get_name`.

Solution:

Pass the buffer number as the first argument.
