### PR TITLE
Revert "feat(lsp): return resolved config for vim.lsp.config[name]"

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -371,33 +371,9 @@ lsp.config = setmetatable({ _configs = {} }, {
   --- @return vim.lsp.Config
   __index = function(self, name)
     validate('name', name, 'string')
-
-    local rconfig = lsp._enabled_configs[name] or {}
+    invalidate_enabled_config(name)
     self._configs[name] = self._configs[name] or {}
-
-    if not rconfig.resolved_config then
-      -- Resolve configs from lsp/*.lua
-      -- Calls to vim.lsp.config in lsp/* have a lower precedence than calls from other sites.
-      local rtp_config = {} ---@type vim.lsp.Config
-      for _, v in ipairs(api.nvim_get_runtime_file(('lsp/%s.lua'):format(name), true)) do
-        local config = assert(loadfile(v))() ---@type any?
-        if type(config) == 'table' then
-          rtp_config = vim.tbl_deep_extend('force', rtp_config, config)
-        else
-          log.warn(string.format('%s does not return a table, ignoring', v))
-        end
-      end
-
-      rconfig.resolved_config = vim.tbl_deep_extend(
-        'force',
-        lsp.config._configs['*'] or {},
-        rtp_config,
-        lsp.config._configs[name] or {}
-      )
-      rconfig.resolved_config.name = name
-    end
-
-    return rconfig.resolved_config
+    return self._configs[name]
   end,
 
   --- @param self vim.lsp.config
@@ -420,6 +396,44 @@ lsp.config = setmetatable({ _configs = {} }, {
     self[name] = vim.tbl_deep_extend('force', self._configs[name] or {}, cfg)
   end,
 })
+
+--- @private
+--- @param name string
+--- @return vim.lsp.Config
+function lsp._resolve_config(name)
+  local econfig = lsp._enabled_configs[name] or {}
+
+  if not econfig.resolved_config then
+    -- Resolve configs from lsp/*.lua
+    -- Calls to vim.lsp.config in lsp/* have a lower precedence than calls from other sites.
+    local rtp_config = {} ---@type vim.lsp.Config
+    for _, v in ipairs(api.nvim_get_runtime_file(('lsp/%s.lua'):format(name), true)) do
+      local config = assert(loadfile(v))() ---@type any?
+      if type(config) == 'table' then
+        rtp_config = vim.tbl_deep_extend('force', rtp_config, config)
+      else
+        log.warn(string.format('%s does not return a table, ignoring', v))
+      end
+    end
+
+    local config = vim.tbl_deep_extend(
+      'force',
+      lsp.config._configs['*'] or {},
+      rtp_config,
+      lsp.config._configs[name] or {}
+    )
+
+    config.name = name
+
+    validate('cmd', config.cmd, { 'function', 'table' })
+    validate('cmd', config.reuse_client, 'function', true)
+    -- All other fields are validated in client.create
+
+    econfig.resolved_config = config
+  end
+
+  return assert(econfig.resolved_config)
+end
 
 local lsp_enable_autocmd_id --- @type integer?
 
@@ -451,9 +465,7 @@ local function lsp_enable_callback(bufnr)
   end
 
   for name in vim.spairs(lsp._enabled_configs) do
-    local config = lsp.config[name]
-    validate('cmd', config.cmd, { 'function', 'table' })
-    validate('cmd', config.reuse_client, 'function', true)
+    local config = lsp._resolve_config(name)
 
     if can_start(config) then
       -- Deepcopy config so changes done in the client
@@ -461,7 +473,6 @@ local function lsp_enable_callback(bufnr)
       config = vim.deepcopy(config)
 
       if type(config.root_dir) == 'function' then
-        ---@param root_dir string
         config.root_dir(function(root_dir)
           config.root_dir = root_dir
           vim.schedule(function()

--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -184,7 +184,7 @@ local function check_enabled_configs()
   vim.health.start('vim.lsp: Enabled Configurations')
 
   for name in vim.spairs(vim.lsp._enabled_configs) do
-    local config = vim.lsp.config[name]
+    local config = vim.lsp._resolve_config(name)
     local text = {} --- @type string[]
     text[#text + 1] = ('%s:'):format(name)
     for k, v in

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -6233,7 +6233,7 @@ describe('LSP', function()
           vim.lsp.config('*', { root_markers = { '.git' } })
           vim.lsp.config('foo', { cmd = { 'foo' } })
 
-          return vim.lsp.config['foo']
+          return vim.lsp._resolve_config('foo')
         end)
       )
     end)


### PR DESCRIPTION
This reverts commit e00cd1ab4060915d86b8536b082e663818268b69. (#31771)

It causes `lsp/` to be sourced on every trigger to the filetype autocommand. This will be detrimental when nvim-lspconfig migrates to `lsp.config` which contains > 350 configs.
