### PR TITLE
fix(lsp): improve validation of lsp configs

### DIFF
--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -45,6 +45,11 @@ function log.get_filename()
   return logfilename
 end
 
+--- @param s string
+function log._set_filename(s)
+  logfilename = s
+end
+
 --- @type file*?, string?
 local logfile, openerr
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -6370,5 +6370,35 @@ describe('LSP', function()
         )
       end)
     end)
+
+    it('validates config on attach', function()
+      local tmp1 = t.tmpname(true)
+      exec_lua(function()
+        vim.lsp.log._set_filename(fake_lsp_logfile)
+      end)
+
+      local function test_cfg(cfg, err)
+        exec_lua(function()
+          vim.lsp.config['foo'] = {}
+          vim.lsp.config('foo', cfg)
+          vim.lsp.enable('foo')
+          vim.cmd.edit(assert(tmp1))
+          vim.bo.filetype = 'foo'
+        end)
+
+        retry(nil, 1000, function()
+          assert_log(err, fake_lsp_logfile)
+        end)
+      end
+
+      test_cfg({
+        cmd = { 'lolling' },
+      }, 'cannot start foo due to config error: .* lolling is not executable')
+
+      test_cfg({
+        cmd = { 'cat' },
+        filetypes = true,
+      }, 'cannot start foo due to config error: .* filetypes: expected table, got boolean')
+    end)
   end)
 end)


### PR DESCRIPTION
`lsp.config['name']` can not return `nil` if the `name` does not have an entry `lsp/name.lua` or a config set by `lsp.config('name', { ... })`.

This avoids hard to understand errors caused by types to `lsp.enable`.

E.g. I had `lsp.enable('rust_analyzer')` when it should have been `lsp.enable('rust-analyzer')`.

This caused the error when opening any file:

```
Error detected while processing BufNewFile Autocommands for "*":
Error executing lua callback: /usr/local/share/nvim/runtime/filetype.lua:36: BufNewFile Autocommands for "*"..FileType Autocommands for "*": Vim(ap
pend):Error executing lua callback: /usr/local/share/nvim/runtime/lua/vim/lsp.lua:455: cmd: expected function|table, got nil
stack traceback:
        [C]: in function 'error'
        vim/shared.lua: in function 'validate'
        /usr/local/share/nvim/runtime/lua/vim/lsp.lua:455: in function 'lsp_enable_callback'
        /usr/local/share/nvim/runtime/lua/vim/lsp.lua:516: in function </usr/local/share/nvim/runtime/lua/vim/lsp.lua:515>
        [C]: in function 'nvim_cmd'
        /usr/local/share/nvim/runtime/filetype.lua:36: in function </usr/local/share/nvim/runtime/filetype.lua:35>
        [C]: in function 'pcall'
        vim/shared.lua: in function <vim/shared.lua:0>
        [C]: in function '_with'
        /usr/local/share/nvim/runtime/filetype.lua:35: in function </usr/local/share/nvim/runtime/filetype.lua:10>
stack traceback:
        [C]: in function '_with'
        /usr/local/share/nvim/runtime/filetype.lua:35: in function </usr/local/share/nvim/runtime/filetype.lua:10>
```

Now we continue silently and ignore the entry but log a warning.