### PR TITLE
Fix inefficient fixstr messagepack packing

### DIFF
--- a/src/nvim/msgpack_rpc/packer.c
+++ b/src/nvim/msgpack_rpc/packer.c
@@ -78,7 +78,7 @@ void mpack_float8(char **ptr, double i)
 void mpack_str(String str, PackerBuffer *packer)
 {
   const size_t len = str.size;
-  if (len < 20) {
+  if (len < 32) {
     mpack_w(&packer->ptr, 0xa0 | len);
   } else if (len < 0xff) {
     mpack_w(&packer->ptr, 0xd9);

--- a/test/unit/msgpack_spec.lua
+++ b/test/unit/msgpack_spec.lua
@@ -1,7 +1,7 @@
 local t = require('test.unit.testutil')
 local cimport = t.cimport
 local itp = t.gen_itp(it)
-local lib = cimport('./src/nvim/msgpack_rpc/unpacker.h', './src/nvim/memory.h')
+local lib = cimport('./src/nvim/msgpack_rpc/packer.h', './src/nvim/msgpack_rpc/unpacker.h', './src/nvim/memory.h')
 local ffi = t.ffi
 local eq = t.eq
 local to_cstr = t.to_cstr
@@ -77,13 +77,13 @@ describe('msgpack', function()
     end)
 
     itp('packs strings with lengths between 20 and 31 bytes as fixstr', function()
-      local packer = ffi.new('PackerBuffer')
-      lib.packer_buffer_init(packer)
+      -- PackerBuffer sbuf = packer_string_buffer();
+      local packer = lib.packer_string_buffer()
 
       for len = 20, 31 do
         local str = string.rep('a', len)
-        lib.mpack_str({ data = str, size = len }, packer)
-        eq(0xa0 + len, string.byte(packer.startptr))
+        lib.mpack_str({ data = to_cstr(str), size = len }, packer)
+        eq(0xa0 + len, string.byte(ffi.string(packer.startptr)))
       end
     end)
   end)

--- a/test/unit/msgpack_spec.lua
+++ b/test/unit/msgpack_spec.lua
@@ -75,5 +75,16 @@ describe('msgpack', function()
       local finished = unpacker_advance(unpacker)
       eq(true, finished)
     end)
+
+    itp('packs strings with lengths between 20 and 31 bytes as fixstr', function()
+      local packer = ffi.new('PackerBuffer')
+      lib.packer_buffer_init(packer)
+
+      for len = 20, 31 do
+        local str = string.rep('a', len)
+        lib.mpack_str({ data = str, size = len }, packer)
+        eq(0xa0 + len, string.byte(packer.startptr))
+      end
+    end)
   end)
 end)


### PR DESCRIPTION
Fixes #32784

Fix the MessagePack packer to correctly pack `fixstr` for strings with lengths between 20 and 31 bytes.

* Update the condition in `mpack_str` function in `src/nvim/msgpack_rpc/packer.c` to check if the length is less than 32 to pack as `fixstr`.
* Adjust the condition to pack as `str8` if the length is less than 0xff.
* Add a new test case in `test/unit/msgpack_spec.lua` to verify that strings with lengths between 20 and 31 bytes are packed as `fixstr`.
* Ensure the test case covers the range of lengths from 20 to 31 bytes.

