### PR TITLE
feat(lsp): add support for completion context

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1869,8 +1869,13 @@ enable({enable}, {client_id}, {bufnr}, {opts})
       • {opts}       (`vim.lsp.completion.BufferOpts?`) See
                      |vim.lsp.completion.BufferOpts|.
 
-trigger()                                       *vim.lsp.completion.trigger()*
+trigger({opts})                                 *vim.lsp.completion.trigger()*
     Triggers LSP completion once in the current buffer.
+
+    Parameters: ~
+      • {opts}  (`table?`) A table with the following fields:
+                • {ctx}? (`lsp.CompletionContext`) Completion context.
+                  Defaults to a trigger kind of `invoked`.
 
 
 ==============================================================================

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -313,6 +313,8 @@ LSP
 • |vim.lsp.enable()| has been added to enable servers.
 • |vim.lsp.buf.code_action()| resolves the `command` property during the
   `codeAction/resolve` request.
+• The `textDocument/completion` request now includes the completion context in
+  its parameters.
 
 LUA
 

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -476,9 +476,7 @@ function protocol.make_client_capabilities()
             'data',
           },
         },
-
-        -- TODO(tjdevries): Implement this
-        contextSupport = false,
+        contextSupport = true,
       },
       declaration = {
         linkSupport = true,


### PR DESCRIPTION
`vim.lsp.completion` has all the necessary information to include the completion context when sending the request to language servers.