### PR TITLE
vim-patch:{3d1a437,d89770e}

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -83,6 +83,10 @@ CTRL-Q		Same as CTRL-V.  But with some terminals it is used for
 CTRL-SHIFT-V				*c_CTRL-SHIFT-V* *c_CTRL-SHIFT-Q*
 CTRL-SHIFT-Q	Works just like CTRL-V, but do not try to include the CTRL
 		modifier into the key.
+		Note: When CTRL-SHIFT-V is intercepted by your system
+		(e.g., to paste text) you can often use CTRL-SHIFT-Q instead.
+		However, in some terminals (e.g. Gnome Terminal), CTRL-SHIFT-Q
+		quits the terminal without confirmation.
 
 							*c_<Left>* *c_Left*
 <Left>		cursor left.  See 'wildmenu' for behavior during wildmenu

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -83,9 +83,9 @@ CTRL-Q		Same as CTRL-V.  But with some terminals it is used for
 CTRL-SHIFT-V				*c_CTRL-SHIFT-V* *c_CTRL-SHIFT-Q*
 CTRL-SHIFT-Q	Works just like CTRL-V, but do not try to include the CTRL
 		modifier into the key.
-		Note: When CTRL-SHIFT-V is intercepted by your system
-		(e.g., to paste text) you can often use CTRL-SHIFT-Q instead.
-		However, in some terminals (e.g. Gnome Terminal), CTRL-SHIFT-Q
+		Note: When CTRL-SHIFT-V is intercepted by your system (e.g.,
+		to paste text) you can often use CTRL-SHIFT-Q instead.
+		However, in some terminals (e.g. GNOME Terminal), CTRL-SHIFT-Q
 		quits the terminal without confirmation.
 
 							*c_<Left>* *c_Left*

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -214,7 +214,7 @@ CTRL-SHIFT-Q	Works just like CTRL-V, but do not try to include the CTRL
 		modifier into the key.
 		Note: When CTRL-SHIFT-V is intercepted by your system (e.g.,
 		to paste text) you can often use CTRL-SHIFT-Q instead.
-		However, in some terminals (e.g. Gnome Terminal), CTRL-SHIFT-Q
+		However, in some terminals (e.g. GNOME Terminal), CTRL-SHIFT-Q
 		quits the terminal without confirmation.
 
 CTRL-X		Enter CTRL-X mode.  This is a sub-mode where commands can

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -212,6 +212,10 @@ CTRL-Q		Same as CTRL-V.
 CTRL-SHIFT-V				*i_CTRL-SHIFT-V* *i_CTRL-SHIFT-Q*
 CTRL-SHIFT-Q	Works just like CTRL-V, but do not try to include the CTRL
 		modifier into the key.
+		Note: When CTRL-SHIFT-V is intercepted by your system (e.g.,
+		to paste text) you can often use CTRL-SHIFT-Q instead.
+		However, in some terminals (e.g. Gnome Terminal), CTRL-SHIFT-Q
+		quits the terminal without confirmation.
 
 CTRL-X		Enter CTRL-X mode.  This is a sub-mode where commands can
 		be given to complete words or scroll the window.  See


### PR DESCRIPTION
#### vim-patch:3d1a437: runtime(doc): warn users about potentially risky hotkey

Also, mention that CTRL-SHIFT-V might be mapped to paste text, similar
to the note about CTRL-V.

References:
https://gitlab.gnome.org/GNOME/gnome-terminal/-/blob/2d7e9d78c9631be63b6b381f6966cb8808865ffb/src/org.gnome.Terminal.gschema.xml#L395-398
https://gitlab.gnome.org/chergert/ptyxis/-/blob/8942adde5b98c82c85238851743b371a034a1c1b/src/org.gnome.Ptyxis.gschema.xml.in#L529-L533

closes: vim/vim#16816

https://github.com/vim/vim/commit/3d1a437f1bb41933739445a8436fdc1902e4ea98

Co-authored-by: David Mandelberg <david@mandelberg.org>


#### vim-patch:d89770e: runtime(doc): use GNOME instead of Gnome

It's called "GNOME Terminal" in
https://gitlab.gnome.org/GNOME/gnome-terminal

It's also called GNOME Terminal in English Wikipedia
https://en.wikipedia.org/wiki/GNOME_Terminal and the Wikipedia pages of
8 other languages.

Also, make line wrapping the same in insert.txt and cmdline.txt.

closes: vim/vim#16832

https://github.com/vim/vim/commit/d89770eb987768aca78fef74d8d8601ce53fc435