### PR TITLE
vim-patch:9.1.1187: matchparen plugin wrong highlights shell case statement

### DIFF
--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -1,6 +1,6 @@
 " Vim plugin for showing matching parens
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2024 May 18
+" Last Change:	2025 Mar 08
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Exit quickly when:
@@ -114,6 +114,17 @@ func s:Highlight_Matching_Pair()
           \ .. 'string\|character\|singlequote\|escape\|symbol\|comment'
           \ .. "') != -1"
   else
+    " do not attempt to match when the syntax item where the cursor is
+    " indicates there does not exist a matching parenthesis, e.g. for shells
+    " case statement: "case $var in foobar)"
+    "
+    " add the check behind a filetype check, so it only needs to be
+    " evaluated for certain filetypes
+    if ['sh']->index(&filetype) >= 0 &&
+        \ synstack(".", col("."))->indexof({_, id -> synIDattr(id, "name")
+        \ =~? "shSnglCase"}) >= 0
+      return
+    endif
     " Build an expression that detects whether the current cursor position is
     " in certain syntax types (string, comment, etc.), for use as
     " searchpairpos()'s skip argument.

--- a/test/old/testdir/test_plugin_matchparen.vim
+++ b/test/old/testdir/test_plugin_matchparen.vim
@@ -139,4 +139,36 @@ func Test_matchparen_mbyte()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test for ignoring certain parenthesis
+func Test_matchparen_ignore_sh_case()
+  CheckScreendump
+
+  let lines =<< trim END
+    source $VIMRUNTIME/plugin/matchparen.vim
+    set ft=sh
+    call setline(1, [
+          \ '#!/bin/sh',
+          \ 'SUSUWU_PRINT() (',
+          \ '  case "${LEVEL}" in',
+          \ '    "$SUSUWU_SH_NOTICE")',
+          \ '    ${SUSUWU_S} && return 1',
+          \ '  ;;',
+          \ '    "$SUSUWU_SH_DEBUG")',
+          \ '    (! ${SUSUWU_VERBOSE}) && return 1',
+          \ '  ;;',
+          \ '  esac',
+          \ '  # snip',
+          \ ')'
+          \ ])
+    call cursor(4, 26)
+  END
+
+  let filename = 'Xmatchparen_sh'
+  call writefile(lines, filename, 'D')
+
+  let buf = RunVimInTerminal('-S '.filename, #{rows: 10})
+  call VerifyScreenDump(buf, 'Test_matchparen_sh_case_1', {})
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1187: matchparen plugin wrong highlights shell case statement

Problem:  matchparen plugin wrong highlights shell case statement
          (Swudu Susuwu)
Solution: return early, if we are in a shSnglCase syntax element

The shell syntax element "case $var in foobar)" uses closing parenthesis
but there is no corresponding opening parenthesis for that syntax
element. However matchparen is not aware of such things and will happily
try to match just the next opening parenthesis.

So let's just add a way to opt out for such cases. In this case, use the
syntax state to check if the closing parenthesis belongs to the syntax
item "shSnglCase" and if it is, do not try to find a corresponding
opening parenthesis.

Since inspecting the syntax state might be expensive, put the whole
check behind a filetype test, so that matchparen will only perform this
particular check, when it knows the current buffer is a "sh" filetype.

closes: vim/vim#16831

https://github.com/vim/vim/commit/9102ac11ab3938ec8c15bfebd00d2f91d3f1cd6c

Co-authored-by: Christian Brabandt <cb@256bit.org>