### PR TITLE
build(deps): bump luajit to f14556234

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -1,8 +1,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.50.0.tar.gz
 LIBUV_SHA256 b1ec56444ee3f1e10c8bd3eed16ba47016ed0b94fe42137435aaf2e0bd574579
 
-LUAJIT_URL https://github.com/luajit/luajit/archive/f14556234cf67ea8639f0efe81f118664cc8dd49.tar.gz
-LUAJIT_SHA256 f1d13f58e4b09c8a45148ec64db9876e37a94f093540a1a76b85506106c4569e
+LUAJIT_URL https://github.com/luajit/luajit/archive/7db2d1b12a5416eed405f8112e1f45babfe60300.tar.gz
+LUAJIT_SHA256 3a362416ea8162975fb1e45ada8c949eebd443ab5007e9b05a00b61973ef7ebf
 
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -1,8 +1,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.50.0.tar.gz
 LIBUV_SHA256 b1ec56444ee3f1e10c8bd3eed16ba47016ed0b94fe42137435aaf2e0bd574579
 
-LUAJIT_URL https://github.com/luajit/luajit/archive/7db2d1b12a5416eed405f8112e1f45babfe60300.tar.gz
-LUAJIT_SHA256 3a362416ea8162975fb1e45ada8c949eebd443ab5007e9b05a00b61973ef7ebf
+LUAJIT_URL https://github.com/luajit/luajit/archive/84cb21ffaf648b472ff3884556e2c413e8abe179.tar.gz
+LUAJIT_SHA256 30c1118b8eced22a6f5be5630458e4cf10a0f429adcaa019e356ddd05456bb81
 
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -1,8 +1,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.50.0.tar.gz
 LIBUV_SHA256 b1ec56444ee3f1e10c8bd3eed16ba47016ed0b94fe42137435aaf2e0bd574579
 
-LUAJIT_URL https://github.com/LuaJIT/LuaJIT/archive/a4f56a459a588ae768801074b46ba0adcfb49eb1.tar.gz
-LUAJIT_SHA256 b4120332a4191db9c9da2d81f9f11f0d4504fc4cff2dea0f642d3d8f1fcebd0e
+LUAJIT_URL https://github.com/luajit/luajit/archive/f14556234cf67ea8639f0efe81f118664cc8dd49.tar.gz
+LUAJIT_SHA256 f1d13f58e4b09c8a45148ec64db9876e37a94f093540a1a76b85506106c4569e
 
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333


### PR DESCRIPTION
* Add compatibility string coercion for fp:seek() argument.
* Windows: Clarify installation directory layout.
* Remove Cygwin from docs, since it's not a supported target.
* Improve CLI signal handling on POSIX.
* FFI: Add pre-declared int128_t, uint128_t, __int128 types.
* Use dylib extension for iOS installs, too.
* Change handling of nil value markers in template tables.
