### PR TITLE
vim-patch:42e498d: runtime(plsql): move fold option from syntax to filetype plugin

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -821,6 +821,12 @@ the PDF.  The following are treated as tags:
 
 These maps can be disabled with >
 	:let g:no_pdf_maps = 1
+
+PLSQL							*ft-plsql-plugin*
+
+To enable syntax folding in PL/SQL filetypes, set the following variable: >
+
+	:let g:plsql_fold = 1
 <
 
 PYTHON						*ft-python-plugin* *PEP8*

--- a/runtime/ftplugin/plsql.vim
+++ b/runtime/ftplugin/plsql.vim
@@ -1,0 +1,17 @@
+" Vim ftplugin file
+" Language: Oracle Procedural SQL (PL/SQL)
+" Maintainer: Lee Lindley (lee dot lindley at gmail dot com)
+" Previous Maintainer: Jeff Lanzarotta (jefflanzarotta at yahoo dot com)
+" Previous Maintainer: C. Laurence Gonsalves (clgonsal@kami.com)
+" URL: https://github.com/lee-lindley/vim_plsql_syntax
+" Last Change: Feb 19, 2025
+" History:  Enno Konfekt move handling of optional syntax folding from syntax
+"               file to ftplugin
+
+if exists("b:did_ftplugin") | finish | endif
+let b:did_ftplugin = 1
+
+if get(g:,"plsql_fold",0) == 1
+    setlocal foldmethod=syntax
+    let b:undo_ftplugin = "setl fdm< "
+endif

--- a/runtime/syntax/plsql.vim
+++ b/runtime/syntax/plsql.vim
@@ -4,7 +4,7 @@
 " Previous Maintainer: Jeff Lanzarotta (jefflanzarotta at yahoo dot com)
 " Previous Maintainer: C. Laurence Gonsalves (clgonsal@kami.com)
 " URL: https://github.com/lee-lindley/vim_plsql_syntax
-" Last Change: Sep 19, 2022   
+" Last Change: Mar 09, 2025   
 " History  Carsten Czarski (carsten dot czarski at oracle com)
 "               add handling for typical SQL*Plus commands (rem, start, host, set, etc)
 "               add error highlight for non-breaking space
@@ -694,7 +694,6 @@ syn region plsqlSqlPlusCommand  start="^\(SET\|DEFINE\|PROMPT\|ACCEPT\|EXEC\|HOS
 syn region plsqlSqlPlusRunFile  start="^\(@\|@@\)" skip="\\$" end="$" keepend extend
 
 if get(g:,"plsql_fold",0) == 1
-    setlocal foldmethod=syntax
     syn sync fromstart
 
     syn cluster plsqlProcedureGroup contains=plsqlProcedure


### PR DESCRIPTION
closes: vim/vim#16838

https://github.com/vim/vim/commit/42e498d9c41a0260ccddceeb2927c18b508eff54

Co-authored-by: Lee Lindley <lee.lindley@gmail.com>
Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>
