### PR TITLE
vim-patch:9.1.1190: C indentation does not detect multibyte labels

### DIFF
--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -15,6 +15,7 @@
 #include "nvim/macros_defs.h"
 #include "nvim/mark_defs.h"
 #include "nvim/math.h"
+#include "nvim/mbyte.h"
 #include "nvim/memline.h"
 #include "nvim/memory.h"
 #include "nvim/option.h"
@@ -334,7 +335,7 @@ static bool cin_islabel_skip(const char **s)
   }
 
   while (vim_isIDc((uint8_t)(**s))) {
-    (*s)++;
+    (*s) += utfc_ptr2len(*s);
   }
 
   *s = cin_skipcomment(*s);

--- a/test/old/testdir/test_indent.vim
+++ b/test/old/testdir/test_indent.vim
@@ -109,6 +109,19 @@ func Test_preproc_indent()
   close!
 endfunc
 
+func Test_userlabel_indent()
+  new
+  call setline(1, ['{', 'label:'])
+  normal GV=
+  call assert_equal('label:', getline(2))
+
+  call setline(2, 'läbél:')
+  normal GV=
+  call assert_equal('läbél:', getline(2))
+
+  close!
+endfunc
+
 " Test for 'copyindent'
 func Test_copyindent()
   new


### PR DESCRIPTION
#### vim-patch:9.1.1190: C indentation does not detect multibyte labels

Problem:  C indentation does not detect multibyte labels
Solution: Correctly skip over multibyte characters
          (Anttoni Erkkilä)

closes: vim/vim#16770

https://github.com/vim/vim/commit/f4d87ff8883e5076633ef0ab0cf4d6e4beaddc5c

Co-authored-by: Anttoni Erkkilä <anttoni.erkkila@protonmail.com>