### PR TITLE
fix(tohtml): set nomodeline

### DIFF
--- a/runtime/lua/tohtml.lua
+++ b/runtime/lua/tohtml.lua
@@ -1372,6 +1372,7 @@ local function win_to_html(winid, opt)
   state_generate_style(state)
 
   local html = {}
+  table.insert(html, '<!-- vim: set nomodeline: -->')
   extend_html(html, function()
     extend_head(html, global_state)
     extend_body(html, function()

--- a/test/functional/plugin/tohtml_spec.lua
+++ b/test/functional/plugin/tohtml_spec.lua
@@ -159,6 +159,7 @@ local function test_generates_html(guifont, expect_font)
 
   local out_file = api.nvim_buf_get_name(api.nvim_get_current_buf())
   eq({
+    '<!-- vim: set nomodeline: -->',
     '<!DOCTYPE html>',
     '<html>',
     '<head>',
@@ -212,6 +213,7 @@ describe(':TOhtml', function()
     n.command('2,2TOhtml')
     local out_file = api.nvim_buf_get_name(api.nvim_get_current_buf())
     eq({
+      '<!-- vim: set nomodeline: -->',
       '<!DOCTYPE html>',
       '<html>',
       '<head>',


### PR DESCRIPTION
Problem: Running `:TOhtml` with a file containing modeline may generate an invalid modeline in the output.
Sulution: Add `<!-- vim: set nomodeline: -->` to the output.