### PR TITLE
fix(ui): schedule UI detach

### DIFF
--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -484,6 +484,16 @@ void rpc_close(Channel *channel)
   }
 
   channel->rpc.closed = true;
+
+  // Scheduled to avoid running UILeave autocommands in a libuv handler.
+  multiqueue_put(main_loop.fast_events, rpc_close_event, channel);
+}
+
+static void rpc_close_event(void **argv)
+{
+  Channel *channel = (Channel *)argv[0];
+  assert(channel);
+
   channel_decref(channel);
 
   bool is_ui_client = ui_client_channel_id && channel->id == ui_client_channel_id;


### PR DESCRIPTION
When a UI detaches it will execute any UILeave events. Autocommands cannot run in a libuv handler because they will in turn poll the event loop, which results in recursive loop execution. So we schedule the callback to detach the UI on the main event queue.

We also have to schedule the exit when the RPC channel is closed to ensure it does not run until after `remote_ui_disconnect` has run, otherwise it will hang.

---

This appears to solve the ASAN failures in https://github.com/neovim/neovim/pull/32756.

I am not sure how to write a test for this. We already have tests that create `UILeave` autocommands, so I am not sure why those tests haven't been triggering this issue all along.