### PR TITLE
vim-patch:9.1.{1186,1191,1194}: filetype: help files in git repos are not detected

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -643,7 +643,7 @@ Also see the 'infercase' option if you want to adjust the case of the match.
 
 When inserting a selected candidate word from the |popup-menu|, the part of
 the candidate word that does not match the query is highlighted using
-|hl-ComplMatchIns|. If fuzzy is enabled in 'completeopt', highlighting will
+|hl-ComplMatchIns|.  If fuzzy is enabled in 'completeopt', highlighting will
 not be applied.
 
 							*complete_CTRL-E*

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2417,7 +2417,7 @@ local pattern = {
     ['^%.?gtkrc'] = starsetf('gtkrc'),
     ['/doc/.*%.txt$'] = function(_, bufnr)
       local line = M._getline(bufnr, -1)
-      local ml = line:find('vim:')
+      local ml = line:find('^vim:') or line:find('%svim:')
       if ml and M._matchregex(line:sub(ml), [[\<\(ft\|filetype\)=help\>]]) then
         return 'help'
       end

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2415,7 +2415,13 @@ local pattern = {
     ['/boot/grub/menu%.lst$'] = 'grub',
     -- gtkrc* and .gtkrc*
     ['^%.?gtkrc'] = starsetf('gtkrc'),
-    ['^${VIMRUNTIME}/doc/.*%.txt$'] = 'help',
+    ['/doc/.*%.txt$'] = function(_, bufnr)
+      local line = M._getline(bufnr, -1)
+      local ml = line:find('vim:')
+      if ml and M._matchregex(line:sub(ml), [[\<\(ft\|filetype\)=help\>]]) then
+        return 'help'
+      end
+    end,
     ['^hg%-editor%-.*%.txt$'] = 'hgcommit',
     ['%.html%.m4$'] = 'htmlm4',
     ['^JAM.*%.'] = starsetf('jam'),

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -1619,6 +1619,7 @@ func Test_haredoc_file()
 endfunc
 
 func Test_help_file()
+  set nomodeline
   filetype on
   call assert_true(mkdir('doc', 'pR'))
 
@@ -1633,6 +1634,7 @@ func Test_help_file()
   bwipe!
 
   filetype off
+  set modeline&
 endfunc
 
 func Test_hook_file()

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -1628,8 +1628,19 @@ func Test_help_file()
   call assert_equal('help', &filetype)
   bwipe!
 
+  call writefile(['some text', 'Copyright: |manual-copyright| vim:ft=help:'],
+        \ 'doc/help1.txt', 'D')
+  split doc/help1.txt
+  call assert_equal('help', &filetype)
+  bwipe!
+
   call writefile(['some text'], 'doc/nothelp.txt', 'D')
   split doc/nothelp.txt
+  call assert_notequal('help', &filetype)
+  bwipe!
+
+  call writefile(['some text', '`vim:ft=help`'], 'doc/nothelp1.txt', 'D')
+  split doc/nothelp1.txt
   call assert_notequal('help', &filetype)
   bwipe!
 

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -916,8 +916,6 @@ func s:GetFilenameChecks() abort
     \         '.zcompdump', '.zlogin', '.zlogout', '.zshenv', '.zshrc', '.zsh_history',
     \         '.zcompdump-file', '.zlog', '.zlog-file', '.zsh', '.zsh-file',
     \         'any/etc/zprofile', 'zlog', 'zlog-file', 'zsh', 'zsh-file'],
-    \
-    \ 'help': [$VIMRUNTIME .. '/doc/help.txt'],
     \ }
 endfunc
 
@@ -1616,6 +1614,23 @@ func Test_haredoc_file()
   bwipe!
   unlet g:filetype_haredoc
   unlet g:haredoc_search_depth
+
+  filetype off
+endfunc
+
+func Test_help_file()
+  filetype on
+  call assert_true(mkdir('doc', 'pR'))
+
+  call writefile(['some text', 'vim:ft=help:'], 'doc/help.txt', 'D')
+  split doc/help.txt
+  call assert_equal('help', &filetype)
+  bwipe!
+
+  call writefile(['some text'], 'doc/nothelp.txt', 'D')
+  split doc/nothelp.txt
+  call assert_notequal('help', &filetype)
+  bwipe!
 
   filetype off
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.1186: filetype: help files in git repos are not detected

Problem:  filetype: help files in git repos are not detected
Solution: detect */doc/*.txt files as help if they end with a help
          modeline, even if 'modeline' is off

Here's how I checked that this would still detect vim's own help files
correctly:

$ find . -type f -path '*/doc/*.txt' \
> -exec awk '{ } ENDFILE { print FILENAME ":" $0; }' '{}' + |
> grep -v 'vim:.*\<\(ft\|filetype\)=help\>'
./src/libvterm/doc/seqs.txt: 23    DECSM 42         = DECNRCM, national/multinational character

closes: vim/vim#16817

https://github.com/vim/vim/commit/16d6fff98ed3a9dfd34a41696b005b0c4c7800f8

Split the pattern into a Lua pattern for the first part and a Vim regex
pattern for the second part, so that if the first part doesn't match
there is no need to use the Vim regex.

Co-authored-by: David Mandelberg <david@mandelberg.org>


#### vim-patch:9.1.1191: tests: test for patch 9.1.1186 doesn't fail without the patch

Problem:  Test for patch 9.1.1186 doesn't fail without the patch.
Solution: Set 'nomodeline' in the test (zeertzjq).

closes: vim/vim#16835

https://github.com/vim/vim/commit/d6c7913e24e07c1d0ea099cda85e0014e8627c5c


#### vim-patch:9.1.1194: filetype: false positive help filetype detection

Problem:  filetype: false positive help filetype detection
Solution: Only detect a file as help if modeline appears either at start
          of line or is preceded by whitespace (zeertzjq).

closes: vim/vim#16845

https://github.com/vim/vim/commit/6763b0ee95e7e66ab7992653fbba48691e803e70