### PR TITLE
vim-patch:9.1.1193: Unnecessary use of STRCAT() in au_event_disable()

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -700,12 +700,13 @@ int check_ei(char *ei)
 // Returns the old value of 'eventignore' in allocated memory.
 char *au_event_disable(char *what)
 {
-  char *save_ei = xstrdup(p_ei);
-  char *new_ei = xstrnsave(p_ei, strlen(p_ei) + strlen(what));
+  size_t p_ei_len = strlen(p_ei);
+  char *save_ei = xmemdupz(p_ei, p_ei_len);
+  char *new_ei = xstrnsave(p_ei, p_ei_len + strlen(what));
   if (*what == ',' && *p_ei == NUL) {
     STRCPY(new_ei, what + 1);
   } else {
-    strcat(new_ei, what);
+    STRCPY(new_ei + p_ei_len, what);
   }
   set_option_direct(kOptEventignore, CSTR_AS_OPTVAL(new_ei), 0, SID_NONE);
   xfree(new_ei);

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4528,7 +4528,7 @@ static int open_cmdwin(void)
   State = MODE_NORMAL;
   setmouse();
 
-  // Reset here so it can be set by a CmdWinEnter autocommand.
+  // Reset here so it can be set by a CmdwinEnter autocommand.
   cmdwin_result = 0;
 
   // Trigger CmdwinEnter autocommands.

--- a/test/old/testdir/test_arglist.vim
+++ b/test/old/testdir/test_arglist.vim
@@ -555,9 +555,34 @@ endfunc
 func Test_argdo()
   next! Xa.c Xb.c Xc.c
   new
+
+  let g:bufenter = 0
+  let g:bufleave = 0
+  autocmd BufEnter * let g:bufenter += 1
+  autocmd BufLeave * let g:bufleave += 1
+
   let l = []
   argdo call add(l, expand('%'))
   call assert_equal(['Xa.c', 'Xb.c', 'Xc.c'], l)
+  call assert_equal(3, g:bufenter)
+  call assert_equal(3, g:bufleave)
+
+  let g:bufenter = 0
+  let g:bufleave = 0
+
+  set eventignore=BufEnter,BufLeave
+  let l = []
+  argdo call add(l, expand('%'))
+  call assert_equal(['Xa.c', 'Xb.c', 'Xc.c'], l)
+  call assert_equal(0, g:bufenter)
+  call assert_equal(0, g:bufleave)
+  call assert_equal('BufEnter,BufLeave', &eventignore)
+  set eventignore&
+
+  autocmd! BufEnter
+  autocmd! BufLeave
+  unlet g:bufenter
+  unlet g:bufleave
   bwipe Xa.c Xb.c Xc.c
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.1193: Unnecessary use of STRCAT() in au_event_disable()

Problem:  Unnecessary use of STRCAT() in au_event_disable().  STRCAT()
          seeks to the end of new_ei, but here the end is already known.
Solution: Use STRCPY() and add p_ei_len to new_ei.  Also fix a typo in a
          comment.  Add a test that 'eventignore' works in :argdo
          (zeertzjq).

closes: vim/vim#16844

https://github.com/vim/vim/commit/969e11a18b145241dc0ab39fc1be7ed814655dfc

Cherry-pick p_ei_len from patch 9.1.0256.