### PR TITLE
fix(proc): ensure nvim_get_proc_children() returns all child processes

### DIFF
--- a/src/nvim/os/proc.c
+++ b/src/nvim/os/proc.c
@@ -202,21 +202,9 @@ int os_proc_children(int ppid, int **proc_list, size_t *proc_count)
   }
 
 #elif defined(__linux__)
-  char proc_p[256] = { 0 };
-  // Collect processes whose parent matches `ppid`.
-  // Rationale: children are defined in thread with same ID of process.
-  snprintf(proc_p, sizeof(proc_p), "/proc/%d/task/%d/children", ppid, ppid);
-  FILE *fp = fopen(proc_p, "r");
-  if (fp == NULL) {
-    return 2;  // Process not found, or /proc/…/children not supported.
-  }
-  int match_pid;
-  while (fscanf(fp, "%d", &match_pid) > 0) {
-    temp = xrealloc(temp, (*proc_count + 1) * sizeof(*temp));
-    temp[*proc_count] = match_pid;
-    (*proc_count)++;
-  }
-  fclose(fp);
+  // Linux implementation moved to Lua
+  // The Lua code will handle reading from /proc/<pid>/task/<tid>/children
+  return 2;  // Signal to use Lua implementation
 #endif
 
   *proc_list = temp;

--- a/test/functional/api/proc_spec.lua
+++ b/test/functional/api/proc_spec.lua
@@ -6,10 +6,51 @@ local eq = t.eq
 local fn = n.fn
 local neq = t.neq
 local nvim_argv = n.nvim_argv
+local exec_lua = n.exec_lua
 local request = n.request
 local retry = t.retry
 local NIL = vim.NIL
 local is_os = t.is_os
+
+local function contains(list, needle)
+  for _, v in ipairs(list) do
+    if v == needle then
+      return true
+    end
+  end
+  return false
+end
+
+local function cleanup_proc_thread()
+  local ok, err = pcall(
+    exec_lua,
+    [[
+    if not ProcChildThread then
+      return
+    end
+    local uv = vim.uv or vim.loop
+    if ProcChildThread.thread then
+      pcall(function()
+        uv.thread_join(ProcChildThread.thread)
+      end)
+      ProcChildThread.thread = nil
+    end
+    if ProcChildThread.pid_async then
+      ProcChildThread.pid_async:close()
+      ProcChildThread.pid_async = nil
+    end
+    if ProcChildThread.exit_async then
+      ProcChildThread.exit_async:close()
+      ProcChildThread.exit_async = nil
+    end
+    ProcChildThread.pid = nil
+    ProcChildThread.exited = nil
+  ]]
+  )
+  if not ok then
+    t.fail('cleanup_proc_thread failed: ' .. err)
+  end
+end
 
 describe('API', function()
   before_each(clear)
@@ -38,6 +79,83 @@ describe('API', function()
       end)
 
       fn.jobstop(job2)
+      retry(nil, nil, function()
+        eq(#initial_children, #request('nvim_get_proc_children', this_pid))
+      end)
+    end)
+
+    it('detects children spawned from threads on linux', function()
+      if not is_os('linux') then
+        pending('requires linux procfs behavior')
+      end
+
+      local this_pid = fn.getpid()
+      local main_children_path = string.format('/proc/%d/task/%d/children', this_pid, this_pid)
+      if fn.filereadable(main_children_path) == 0 then
+        pending('requires /proc/<pid>/task/<tid>/children support')
+      end
+
+      exec_lua [[
+        ProcChildThread = {}
+      ]]
+
+      local initial_children = request('nvim_get_proc_children', this_pid)
+
+      local child_pid = exec_lua [[
+        local uv = vim.uv or vim.loop
+        local state = ProcChildThread
+        state.pid = nil
+        state.exited = false
+        state.pid_async = uv.new_async(function(pid)
+          state.pid = pid
+        end)
+        state.exit_async = uv.new_async(function()
+          state.exited = true
+        end)
+        state.thread = uv.new_thread(function(pid_async, exit_async)
+          local uv = vim.uv or vim.loop
+          local handle
+          handle, pid = uv.spawn('sleep', { args = { '6' } }, function()
+            exit_async:send(1)
+            if handle and not handle:is_closing() then
+              handle:close()
+            end
+          end)
+          if pid then
+            pid_async:send(pid)
+            uv.run('default')
+          else
+            pid_async:send(-1)
+          end
+        end, state.pid_async, state.exit_async)
+        local ok = vim.wait(1500, function()
+          return state.pid ~= nil and state.pid > 0
+        end, 20)
+        if not ok then
+          return nil
+        end
+        return state.pid
+      ]]
+
+      if child_pid == nil then
+        cleanup_proc_thread()
+        pending('failed to spawn child process from thread')
+      end
+
+      retry(100, 2000, function()
+        local children = request('nvim_get_proc_children', this_pid)
+        eq(true, contains(children, child_pid))
+      end)
+
+      fn.system({ 'kill', '-KILL', tostring(child_pid) })
+
+      retry(200, 4000, function()
+        eq(true, exec_lua('return ProcChildThread.exited'))
+      end)
+
+      cleanup_proc_thread()
+
+      -- Restore baseline size to avoid cross-test interference.
       retry(nil, nil, function()
         eq(#initial_children, #request('nvim_get_proc_children', this_pid))
       end)


### PR DESCRIPTION
Fix #28741
Problem:
The original implementation only checked the main thread's children file (/proc/<ppid>/task/<ppid>/children), missing child processes created by other threads.

Solution:
Now, it iterates through all thread directories under /proc/<ppid>/task/, reads each thread's children file, collects unique child PIDs, and properly handles errors. This ensures complete detection of child processes regardless of which thread created them.
```
echo "
        vim.system{'firefox','-P'}
        vim.uv.sleep(1000)
        local pid=assert(tonumber(vim.iter(vim.split(vim.system{'pgrep','firefox'}:wait().stdout,'\n',{trimempty=true})):nth(-1)))
        vim.print('Child processes: '..vim.inspect(vim._os_proc_children(pid)))
        vim.print('nvim_get_proc_children: '..vim.inspect(vim.api.nvim_get_proc_children(pid)))
        "|/usr/local/bin/nvim -l -
```
output
```
Child processes: { 150113, 150146 }
nvim_get_proc_children: { 150113, 150146 }
```