### PR TITLE
vim-patch:0a336cc: runtime(doc): clarify that a umask is applied to mkdir()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6796,10 +6796,9 @@ mkdir({name} [, {flags} [, {prot}]])                              *mkdir()* *E73
 		If {prot} is given it is used to set the protection bits of
 		the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
 		the user, readable for others).  Use 0o700 to make it
-		unreadable for others.
-
-		{prot} is applied for all parts of {name}.  Thus if you create
-		/tmp/foo/bar then /tmp/foo will be created with 0o700. Example: >vim
+		unreadable for others.  This is used for the newly created
+		directories.  Note an umask is applied to {prot} (on Unix).
+		Example: >vim
 			call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
 
 <		This function is not available in the |sandbox|.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -6173,10 +6173,9 @@ function vim.fn.min(expr) end
 --- If {prot} is given it is used to set the protection bits of
 --- the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
 --- the user, readable for others).  Use 0o700 to make it
---- unreadable for others.
----
---- {prot} is applied for all parts of {name}.  Thus if you create
---- /tmp/foo/bar then /tmp/foo will be created with 0o700. Example: >vim
+--- unreadable for others.  This is used for the newly created
+--- directories.  Note an umask is applied to {prot} (on Unix).
+--- Example: >vim
 ---   call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
 ---
 --- <This function is not available in the |sandbox|.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -7550,10 +7550,9 @@ M.funcs = {
       If {prot} is given it is used to set the protection bits of
       the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
       the user, readable for others).  Use 0o700 to make it
-      unreadable for others.
-
-      {prot} is applied for all parts of {name}.  Thus if you create
-      /tmp/foo/bar then /tmp/foo will be created with 0o700. Example: >vim
+      unreadable for others.  This is used for the newly created
+      directories.  Note an umask is applied to {prot} (on Unix).
+      Example: >vim
       	call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
 
       <This function is not available in the |sandbox|.


### PR DESCRIPTION
#### vim-patch:0a336cc: runtime(doc): clarify that a umask is applied to mkdir()

https://github.com/vim/vim/commit/0a336ccb57003c44ba303ccc50cf50cb640c2309

Co-authored-by: Christian Brabandt <cb@256bit.org>