### PR TITLE
fix(lua): vim.hl.on_yank highlights wrong region with yi'

### DIFF
--- a/runtime/lua/vim/hl.lua
+++ b/runtime/lua/vim/hl.lua
@@ -182,7 +182,7 @@ function M.on_yank(opts)
   vim.api.nvim__ns_set(yank_ns, { wins = { winid } })
   M.range(bufnr, yank_ns, higroup, "'[", "']", {
     regtype = event.regtype,
-    inclusive = event.inclusive,
+    inclusive = true,
     priority = opts.priority or M.priorities.user,
     timeout = opts.timeout or 150,
   })

--- a/test/functional/lua/hl_spec.lua
+++ b/test/functional/lua/hl_spec.lua
@@ -214,4 +214,38 @@ describe('vim.hl.on_yank', function()
       vim.hl.range(0, ns, 'Search', { 0, 0 }, { 0, 0 }, { timeout = 0 })
     end)
   end)
+
+  it("highlight last character when do 'exclusive' motion", function()
+    clear()
+    local screen = Screen.new(60, 4)
+    screen:add_extra_attr_ids({
+      [100] = { foreground = Screen.colors.Blue, background = Screen.colors.Yellow, bold = true },
+    })
+    command('autocmd TextYankPost * lua vim.hl.on_yank{timeout=100000}')
+    api.nvim_buf_set_lines(0, 0, -1, true, {
+      [[foo(bar) 'baz']],
+      [[foo(bar) 'baz']],
+    })
+    n.feed('yw')
+    screen:expect([[
+      {2:^foo}(bar) 'baz'                                              |
+      foo(bar) 'baz'                                              |
+      {1:~                                                           }|
+                                                                  |
+    ]])
+    n.feed("yi'")
+    screen:expect([[
+      foo(bar) '{2:^baz}'                                              |
+      foo(bar) 'baz'                                              |
+      {1:~                                                           }|
+                                                                  |
+    ]])
+    n.feed('yvj')
+    screen:expect([[
+      foo(bar) '{2:^baz'}                                              |
+      {2:foo(bar) '}baz'                                              |
+      {1:~                                                           }|
+                                                                  |
+    ]])
+  end)
 end)

--- a/test/functional/lua/hl_spec.lua
+++ b/test/functional/lua/hl_spec.lua
@@ -215,8 +215,7 @@ describe('vim.hl.on_yank', function()
     end)
   end)
 
-  it("highlight last character when do 'exclusive' motion", function()
-    clear()
+  it('highlight last character with exclusive motion', function()
     local screen = Screen.new(60, 4)
     screen:add_extra_attr_ids({
       [100] = { foreground = Screen.colors.Blue, background = Screen.colors.Yellow, bold = true },

--- a/test/functional/lua/hl_spec.lua
+++ b/test/functional/lua/hl_spec.lua
@@ -215,7 +215,7 @@ describe('vim.hl.on_yank', function()
     end)
   end)
 
-  it('highlight last character with exclusive motion', function()
+  it('highlights last character with exclusive motion', function()
     local screen = Screen.new(60, 4)
     screen:add_extra_attr_ids({
       [100] = { foreground = Screen.colors.Blue, background = Screen.colors.Yellow, bold = true },


### PR DESCRIPTION
Problem: yi' don't highlight last character since
https://github.com/neovim/neovim/commit/8ce504820af04194a41acbe1f4c61cf12bd5feb5.

Solution: Always use `opts.inclusive=true`, since calculation of `"]` (`curbuf->b_op_end`)
have taken `inclusive` into account.

Reproduction: launch nvim, then `yi'`
```sh
echo "'abc'" | nvim -u NONE --cmd 'au TextYankPost * echomsg v:event | lua (vim.hl or vim.highlight).on_yank{timeout=100000}'
```

Actually all `exclusive` motions (e.g. `yw`,`yvj`) have an incorrect highlight region now. (I just happened to spot this issue by `yi'`)