### PR TITLE
vim-patch:2347330: runtime(compiler): allow customizing exe and args for tsc

### DIFF
--- a/runtime/compiler/tsc.vim
+++ b/runtime/compiler/tsc.vim
@@ -2,6 +2,7 @@
 " Compiler:	TypeScript Compiler
 " Maintainer:	Doug Kearns <dougkearns@gmail.com>
 " Last Change:	2024 Apr 03
+"		2025 Mar 11 by The Vim Project (add comment for Dispatch, add tsc_makeprg variable)
 
 if exists("current_compiler")
   finish
@@ -11,9 +12,9 @@ let current_compiler = "tsc"
 let s:cpo_save = &cpo
 set cpo&vim
 
+" CompilerSet makeprg=tsc
 " CompilerSet makeprg=npx\ tsc
-
-CompilerSet makeprg=tsc
+execute $'CompilerSet makeprg={escape(get(b:, 'tsc_makeprg', get(g:, 'tsc_makeprg', 'tsc')), ' \|"')}'
 CompilerSet errorformat=%f\ %#(%l\\,%c):\ %trror\ TS%n:\ %m,
 		       \%trror\ TS%n:\ %m,
 		       \%-G%.%#

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -1681,6 +1681,13 @@ shells and OSes and also does not allow to use other available TeX options,
 if any.  If your TeX doesn't support "-interaction=nonstopmode", please
 report it with different means to express \nonstopmode from the command line.
 
+TSC COMPILER						*compiler-tsc*
+
+The executable and compiler options can be added to 'makeprg' by setting the
+b/g:tsc_makeprg variable.  For example: >
+
+	let b:tsc_makeprg = "npx tsc --noEmit"
+
 TYPST COMPILER						*compiler-typst*
 
 Vim includes a compiler plugin for Typst files. This compiler is enabled


### PR DESCRIPTION
vim-patch:2347330: runtime(compiler): allow customizing exe and args for tsc

closes: vim/vim#16853

https://github.com/vim/vim/commit/23473303b78d598a0f3c2f9370e011045093d3bd

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>
