### PR TITLE
fix(diagnostic): clear autocmd only for valid buf

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1692,8 +1692,8 @@ M.handlers.virtual_text = {
       diagnostic_cache_extmarks[bufnr][ns.user_data.virt_text_ns] = {}
       if api.nvim_buf_is_valid(bufnr) then
         api.nvim_buf_clear_namespace(bufnr, ns.user_data.virt_text_ns, 0, -1)
+        api.nvim_clear_autocmds({ group = ns.user_data.virt_text_augroup, buffer = bufnr })
       end
-      api.nvim_clear_autocmds({ group = ns.user_data.virt_text_augroup, buffer = bufnr })
     end
   end,
 }


### PR DESCRIPTION
Otherwise, nvim may run into errors like this
```
Error executing vim.schedule lua callback:
runtime/lua/vim/diagnostic.lua:1696: Invalid buffer id: 27
stack traceback:
    [C]: in function 'nvim_clear_autocmds'
    runtime/lua/vim/diagnostic.lua:1696: in function 'hide'
    runtime/lua/vim/diagnostic.lua:2029: in function 'hide'
    runtime/lua/vim/diagnostic.lua:2373: in function 'reset'
    runtime/lua/vim/lsp.lua:223: in function <runtime/lua/vim/lsp.lua:205>
```