### PR TITLE
fix(marks): issues with invalid marks and marks beyond eob

### DIFF
--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -182,8 +182,9 @@ DecorSignHighlight decor_sh_from_inline(DecorHighlightInline item)
 
 void buf_put_decor(buf_T *buf, DecorInline decor, int row, int row2)
 {
-  if (decor.ext) {
+  if (decor.ext && row < buf->b_ml.ml_line_count) {
     uint32_t idx = decor.data.ext.sh_idx;
+    row2 = MIN(buf->b_ml.ml_line_count - 1, row2);
     while (idx != DECOR_ID_INVALID) {
       DecorSignHighlight *sh = &kv_A(decor_items, idx);
       buf_put_decor_sh(buf, sh, row, row2);
@@ -222,16 +223,17 @@ void buf_put_decor_sh(buf_T *buf, DecorSignHighlight *sh, int row1, int row2)
 void buf_decor_remove(buf_T *buf, int row1, int row2, int col1, DecorInline decor, bool free)
 {
   decor_redraw(buf, row1, row2, col1, decor);
-  if (decor.ext) {
+  if (decor.ext && row1 < buf->b_ml.ml_line_count) {
     uint32_t idx = decor.data.ext.sh_idx;
+    row2 = MIN(buf->b_ml.ml_line_count - 1, row2);
     while (idx != DECOR_ID_INVALID) {
       DecorSignHighlight *sh = &kv_A(decor_items, idx);
       buf_remove_decor_sh(buf, row1, row2, sh);
       idx = sh->next;
     }
-    if (free) {
-      decor_free(decor);
-    }
+  }
+  if (free) {
+    decor_free(decor);
   }
 }
 

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -1238,7 +1238,7 @@ static bool win_redraw_signcols(win_T *wp)
   if (!buf->b_signcols.autom
       && (*wp->w_p_stc != NUL || (wp->w_maxscwidth > 1 && wp->w_minscwidth != wp->w_maxscwidth))) {
     buf->b_signcols.autom = true;
-    buf_signcols_count_range(buf, 0, buf->b_ml.ml_line_count, MAXLNUM, kFalse);
+    buf_signcols_count_range(buf, 0, buf->b_ml.ml_line_count - 1, MAXLNUM, kFalse);
   }
 
   while (buf->b_signcols.max > 0 && buf->b_signcols.count[buf->b_signcols.max - 1] == 0) {

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -6366,6 +6366,30 @@ l5
       ]]
     })
   end)
+
+  it('signcolumn correctly tracked with signs beyond eob and pair end before start', function()
+    api.nvim_set_option_value('signcolumn', 'auto:2', {})
+    api.nvim_set_option_value('filetype', 'lua', {})
+    api.nvim_buf_set_lines(0, 0, -1, false, {'foo', 'bar'})
+    api.nvim_buf_set_extmark(0, ns, 2, 0, {sign_text='S1'})
+    api.nvim_set_hl(0, 'SignColumn', { link = 'Error' })
+    screen:expect([[
+      ^foo                                               |
+      bar                                               |
+      {1:~                                                 }|*7
+                                                        |
+    ]])
+    api.nvim_buf_set_extmark(0, ns, 0, 0, {sign_text='S2', end_row = 1})
+    api.nvim_buf_set_lines(0, 0, -1, false, {'-- foo', '-- bar'})
+    api.nvim_buf_clear_namespace(0, ns, 0, -1)
+    screen:expect([[
+      ^-- foo                                            |
+      -- bar                                            |
+      {1:~                                                 }|*7
+                                                        |
+    ]])
+    assert_alive()
+  end)
 end)
 
 describe('decorations: virt_text', function()


### PR DESCRIPTION
Problem:  Marks that go beyond the end of the buffer, and paired marks
          whose end is in front of its start mark are added to and
          removed from the decor. This results in incorrect tracking
          of the signcolumn.
Solution: Ensure such marks are not added to and removed from the decor.

Fix #32849