### PR TITLE
fix(messages): inputlist, tselect: don't send last newline with ext_messages

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3563,16 +3563,19 @@ static void f_inputlist(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   msg_scroll = true;
   msg_clr_eos();
 
-  TV_LIST_ITER_CONST(argvars[0].vval.v_list, li, {
+  list_T *l = argvars[0].vval.v_list;
+  TV_LIST_ITER_CONST(l, li, {
     msg_puts(tv_get_string(TV_LIST_ITEM_TV(li)));
-    msg_putchar('\n');
+    if (!ui_has(kUIMessages) || TV_LIST_ITEM_NEXT(l, li) != NULL) {
+      msg_putchar('\n');
+    }
   });
 
   // Ask for choice.
   bool mouse_used = false;
   int selected = prompt_for_input(NULL, 0, false, &mouse_used);
   if (mouse_used) {
-    selected = tv_list_len(argvars[0].vval.v_list) - (cmdline_row - mouse_row);
+    selected = tv_list_len(l) - (cmdline_row - mouse_row);
   }
 
   rettv->vval.v_number = selected;

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -588,7 +588,9 @@ void spell_suggest(int count)
         msg_advance(30);
         msg_puts(IObuff);
       }
-      msg_putchar('\n');
+      if (!ui_has(kUIMessages) || i < sug.su_ga.ga_len - 1) {
+        msg_putchar('\n');
+      }
     }
 
     cmdmsg_rl = false;

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -961,7 +961,7 @@ static void print_tag_list(bool new_tag, bool use_tagstack, int num_matches, cha
         break;
       }
     }
-    if (msg_col) {
+    if (msg_col && (!ui_has(kUIMessages) || i < num_matches - 1)) {
       msg_putchar('\n');
     }
     os_breakcheck();

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -382,10 +382,6 @@ describe('ui/ext_messages', function()
     feed('<CR>')
     n.add_builddir_to_rtp()
     feed(':help<CR>:tselect<CR>')
-    local tagfile = t.paths.test_build_dir .. '/runtime/doc/help.txt'
-    if t.is_os('win') then
-      tagfile = tagfile:gsub('/', '\\')
-    end
     screen:expect({
       grid = [[
         ^*help.txt*      Nvim     |
@@ -402,22 +398,21 @@ describe('ui/ext_messages', function()
           prompt = 'Type number and <Enter> (q or empty cancels): ',
         },
       },
-      messages = {
-        {
-          content = {
-            { '  # pri kind tag', 101, 23 },
-            { '\n                        ' },
-            { 'file\n', 101, 23 },
-            { '> 1 F        ' },
-            { 'help.txt', 101, 23 },
-            { ' \n                        ' },
-            { tagfile, 18, 5 },
-            { '\n               *help.txt*\n' },
-          },
-          history = false,
-          kind = 'confirm',
-        },
-      },
+      -- Message depends on runtimepath, only test the static text...
+      condition = function()
+        for _, msg in ipairs(screen.messages) do
+          eq(false, msg.history)
+          eq('confirm', msg.kind)
+          eq({ 150, '  # pri kind tag', 23 }, msg.content[1])
+          eq({ 0, '\n                        ', 0 }, msg.content[2])
+          eq({ 150, 'file\n', 23 }, msg.content[3])
+          eq({ 0, '> 1 F        ', 0 }, msg.content[4])
+          eq({ 150, 'help.txt', 23 }, msg.content[5])
+          eq({ 0, ' \n                        ', 0 }, msg.content[6])
+          eq({ 0, '\n               *help.txt*', 0 }, msg.content[#msg.content])
+        end
+        screen.messages = {}
+      end,
     })
     feed('<CR>:bd<CR>')
 
@@ -1330,7 +1325,7 @@ stack traceback:
       },
       messages = {
         {
-          content = { { 'Change "helllo" to:\n 1 "Hello"\n 2 "Hallo"\n 3 "Hullo"\n' } },
+          content = { { 'Change "helllo" to:\n 1 "Hello"\n 2 "Hallo"\n 3 "Hullo"' } },
           history = false,
           kind = 'confirm',
         },
@@ -1353,7 +1348,7 @@ stack traceback:
       },
       messages = {
         {
-          content = { { 'Change "helllo" to:\n 1 "Hello"\n 2 "Hallo"\n 3 "Hullo"\n' } },
+          content = { { 'Change "helllo" to:\n 1 "Hello"\n 2 "Hallo"\n 3 "Hullo"' } },
           history = false,
           kind = 'confirm',
         },
@@ -1385,7 +1380,7 @@ stack traceback:
       },
       messages = {
         {
-          content = { { 'input0\ninput1\n' } },
+          content = { { 'input0\ninput1' } },
           history = false,
           kind = 'confirm',
         },


### PR DESCRIPTION
Problem:  Various list commands end in a newline to go to a new line on
          the message grid for the prompt message, which is unwanted
          with ext_messages.
Solution: Don't emit a trailing newline with ext_messages for
          inputlist(), :tselect and z=.

Fixes #32584

Co-authored-by: luukvbaal