### PR TITLE
vim-patch:c1c3b5d: runtime(doc): remove unnecessary "an"

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -6797,7 +6797,7 @@ mkdir({name} [, {flags} [, {prot}]])                              *mkdir()* *E73
 		the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
 		the user, readable for others).  Use 0o700 to make it
 		unreadable for others.  This is used for the newly created
-		directories.  Note an umask is applied to {prot} (on Unix).
+		directories.  Note: umask is applied to {prot} (on Unix).
 		Example: >vim
 			call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
 

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -6174,7 +6174,7 @@ function vim.fn.min(expr) end
 --- the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
 --- the user, readable for others).  Use 0o700 to make it
 --- unreadable for others.  This is used for the newly created
---- directories.  Note an umask is applied to {prot} (on Unix).
+--- directories.  Note: umask is applied to {prot} (on Unix).
 --- Example: >vim
 ---   call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
 ---

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -7551,7 +7551,7 @@ M.funcs = {
       the new directory.  The default is 0o755 (rwxr-xr-x: r/w for
       the user, readable for others).  Use 0o700 to make it
       unreadable for others.  This is used for the newly created
-      directories.  Note an umask is applied to {prot} (on Unix).
+      directories.  Note: umask is applied to {prot} (on Unix).
       Example: >vim
       	call mkdir($HOME .. "/tmp/foo/bar", "p", 0o700)
 


### PR DESCRIPTION
#### vim-patch:c1c3b5d: runtime(doc): remove unnecessary "an"

"umask" is pronounce like "youmask", so having an "an" before it is a
bit strange.  In other places in the help, "umask" is not preceded by
either "a" or "an", and sometimes preceded by "the".

Also, "Note" is usually followed either by ":" or "that" in builtin.txt,
so add a ":" after "Note".

closes: 16860

https://github.com/vim/vim/commit/c1c3b5d6a0a3032057bf6de8672cc79100bb73c9