### PR TITLE
vim-patch:9.1.1195: inside try-block: fn body executed with default arg undefined

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -1246,7 +1246,7 @@ void call_user_func(ufunc_T *fp, int argcount, typval_T *argvars, typval_T *rett
   int save_did_emsg = did_emsg;
   did_emsg = false;
 
-  if (default_arg_err && (fp->uf_flags & FC_ABORT)) {
+  if (default_arg_err && (fp->uf_flags & FC_ABORT || trylevel > 0)) {
     did_emsg = true;
   } else if (islambda) {
     char *p = *(char **)fp->uf_lines.ga_data + 7;


### PR DESCRIPTION
#### vim-patch:9.1.1195: inside try-block: fn body executed with default arg undefined

Problem:  inside try-block: fn body executed when default arg is
          undefined
Solution: When inside a try-block do not execute function body after an
          error in evaluating a default argument expression
          (Shane Harper).

closes: vim/vim#16865

https://github.com/vim/vim/commit/2d18789aa67cc60072ea0cf21811c403fa0b2c7b

Co-authored-by: Shane Harper <shane@shaneharper.net>