### PR TITLE
test(cmdline): reduce redundant screen:expect() lines

### DIFF
--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -15,6 +15,11 @@ local api = n.api
 
 local function test_cmdline(linegrid)
   local screen
+  local empty_grid = [[
+    ^                         |
+    {1:~                        }|*3
+                             |
+  ]]
 
   before_each(function()
     clear()
@@ -23,26 +28,18 @@ local function test_cmdline(linegrid)
 
   it('works', function()
     feed(':')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = { {
         firstc = ':',
         content = { { '' } },
         pos = 0,
       } },
-    }
+    })
 
     feed('sign')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -50,15 +47,11 @@ local function test_cmdline(linegrid)
           pos = 4,
         },
       },
-    }
+    })
 
     feed('<Left>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -66,15 +59,11 @@ local function test_cmdline(linegrid)
           pos = 3,
         },
       },
-    }
+    })
 
     feed('<bs>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -82,27 +71,16 @@ local function test_cmdline(linegrid)
           pos = 2,
         },
       },
-    }
+    })
 
     feed('<Esc>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
-      cmdline = { { abort = true } },
-    }
+    screen:expect({ grid = empty_grid, cmdline = { { abort = true } } })
   end)
 
   it('works with input()', function()
     feed(':call input("input", "default")<cr>')
     screen:expect({
-      grid = [[
-        ^                         |
-        {1:~                        }|*3
-                                 |
-      ]],
+      grid = empty_grid,
       cmdline = {
         {
           content = { { 'default' } },
@@ -114,24 +92,13 @@ local function test_cmdline(linegrid)
     })
 
     feed('<cr>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
-      cmdline = { { abort = false } },
-    }
+    screen:expect({ grid = empty_grid, cmdline = { { abort = false } } })
   end)
 
   it('works with special chars and nested cmdline', function()
     feed(':xx<c-r>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -140,15 +107,11 @@ local function test_cmdline(linegrid)
           special = { '"', true },
         },
       },
-    }
+    })
 
     feed('=')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -162,7 +125,7 @@ local function test_cmdline(linegrid)
           pos = 0,
         },
       },
-    }
+    })
 
     feed('1+2')
     local expectation = {
@@ -179,34 +142,15 @@ local function test_cmdline(linegrid)
       },
     }
 
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
-      cmdline = expectation,
-    }
+    screen:expect({ grid = empty_grid, cmdline = expectation })
 
     -- erase information, so we check if it is retransmitted
     command('mode')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
-      cmdline = expectation,
-      reset = true,
-    }
+    screen:expect({ grid = empty_grid, cmdline = expectation, reset = true })
 
     feed('<cr>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -215,27 +159,16 @@ local function test_cmdline(linegrid)
         },
         { abort = false },
       },
-    }
+    })
 
     feed('<esc>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
-      cmdline = { { abort = true } },
-    }
+    screen:expect({ grid = empty_grid, cmdline = { { abort = true } } })
   end)
 
   it('works with function definitions', function()
     feed(':function Foo()<cr>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           indent = 2,
@@ -247,15 +180,11 @@ local function test_cmdline(linegrid)
       cmdline_block = {
         { { 'function Foo()' } },
       },
-    }
+    })
 
     feed('line1<cr>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           indent = 2,
@@ -268,15 +197,11 @@ local function test_cmdline(linegrid)
         { { 'function Foo()' } },
         { { '  line1' } },
       },
-    }
+    })
 
     command('mode')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           indent = 2,
@@ -290,26 +215,15 @@ local function test_cmdline(linegrid)
         { { '  line1' } },
       },
       reset = true,
-    }
+    })
 
     feed('endfunction<cr>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
-      cmdline = { { abort = false } },
-    }
+    screen:expect({ grid = empty_grid, cmdline = { { abort = false } } })
 
     -- Try once more, to check buffer is reinitialized. #8007
     feed(':function Bar()<cr>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           indent = 2,
@@ -321,27 +235,16 @@ local function test_cmdline(linegrid)
       cmdline_block = {
         { { 'function Bar()' } },
       },
-    }
+    })
 
     feed('endfunction<cr>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
-      cmdline = { { abort = false } },
-    }
+    screen:expect({ grid = empty_grid, cmdline = { { abort = false } } })
   end)
 
   it('works with cmdline window', function()
     feed(':make')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -349,10 +252,10 @@ local function test_cmdline(linegrid)
           pos = 4,
         },
       },
-    }
+    })
 
     feed('<c-f>')
-    screen:expect {
+    screen:expect({
       grid = [[
                                |
       {2:[No Name]                }|
@@ -361,11 +264,11 @@ local function test_cmdline(linegrid)
                                |
     ]],
       cmdline = { { abort = false } },
-    }
+    })
 
     -- nested cmdline
     feed(':yank')
-    screen:expect {
+    screen:expect({
       grid = [[
                                |
       {2:[No Name]                }|
@@ -381,10 +284,10 @@ local function test_cmdline(linegrid)
           pos = 4,
         },
       },
-    }
+    })
 
     command('mode')
-    screen:expect {
+    screen:expect({
       grid = [[
                                |
       {2:[No Name]                }|
@@ -401,29 +304,29 @@ local function test_cmdline(linegrid)
         },
       },
       reset = true,
-    }
+    })
 
     feed('<c-c>')
-    screen:expect {
+    screen:expect({
       grid = [[
-                               |
-      {2:[No Name]                }|
-      {1::}make^                    |
-      {3:[Command Line]           }|
-                               |
-    ]],
+                                 |
+        {2:[No Name]                }|
+        {1::}make^                    |
+        {3:[Command Line]           }|
+                                 |
+      ]],
       cmdline = { [2] = { abort = true } },
-    }
+    })
 
     feed('<c-c>')
-    screen:expect {
+    screen:expect({
       grid = [[
-      ^                         |
-      {2:[No Name]                }|
-      {1::}make                    |
-      {3:[Command Line]           }|
-                               |
-    ]],
+        ^                         |
+        {2:[No Name]                }|
+        {1::}make                    |
+        {3:[Command Line]           }|
+                                 |
+      ]],
       cmdline = {
         {
           firstc = ':',
@@ -431,15 +334,11 @@ local function test_cmdline(linegrid)
           pos = 4,
         },
       },
-    }
+    })
 
     command('redraw!')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -447,17 +346,13 @@ local function test_cmdline(linegrid)
           pos = 4,
         },
       },
-    }
+    })
   end)
 
   it('works with inputsecret()', function()
     feed(":call inputsecret('secret:')<cr>abc123")
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           prompt = 'secret:',
@@ -466,7 +361,7 @@ local function test_cmdline(linegrid)
           pos = 6,
         },
       },
-    }
+    })
   end)
 
   it('works with highlighted cmdline', function()
@@ -496,12 +391,8 @@ local function test_cmdline(linegrid)
       "map <f5>  :let x = input({'prompt':'>'})<cr>
     ]])
     feed('<f5>(a(b)a)')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           prompt = '>',
@@ -518,7 +409,7 @@ local function test_cmdline(linegrid)
           pos = 7,
         },
       },
-    }
+    })
   end)
 
   it('works together with ext_wildmenu', function()
@@ -536,12 +427,8 @@ local function test_cmdline(linegrid)
     screen:set_option('ext_wildmenu', true)
     feed(':sign <tab>')
 
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -551,15 +438,11 @@ local function test_cmdline(linegrid)
       },
       wildmenu_items = expected,
       wildmenu_pos = 0,
-    }
+    })
 
     feed('<tab>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -569,15 +452,11 @@ local function test_cmdline(linegrid)
       },
       wildmenu_items = expected,
       wildmenu_pos = 1,
-    }
+    })
 
     feed('<left><left>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -587,15 +466,11 @@ local function test_cmdline(linegrid)
       },
       wildmenu_items = expected,
       wildmenu_pos = -1,
-    }
+    })
 
     feed('<right>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -605,15 +480,11 @@ local function test_cmdline(linegrid)
       },
       wildmenu_items = expected,
       wildmenu_pos = 0,
-    }
+    })
 
     feed('a')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -621,7 +492,7 @@ local function test_cmdline(linegrid)
           pos = 12,
         },
       },
-    }
+    })
   end)
 
   it('works together with ext_popupmenu', function()
@@ -639,12 +510,8 @@ local function test_cmdline(linegrid)
     screen:set_option('ext_popupmenu', true)
     feed(':sign <tab>')
 
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -653,15 +520,11 @@ local function test_cmdline(linegrid)
         },
       },
       popupmenu = { items = expected, pos = 0, anchor = { -1, 0, 5 } },
-    }
+    })
 
     feed('<tab>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -670,15 +533,11 @@ local function test_cmdline(linegrid)
         },
       },
       popupmenu = { items = expected, pos = 1, anchor = { -1, 0, 5 } },
-    }
+    })
 
     feed('<left><left>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -687,15 +546,11 @@ local function test_cmdline(linegrid)
         },
       },
       popupmenu = { items = expected, pos = -1, anchor = { -1, 0, 5 } },
-    }
+    })
 
     feed('<right>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -704,15 +559,11 @@ local function test_cmdline(linegrid)
         },
       },
       popupmenu = { items = expected, pos = 0, anchor = { -1, 0, 5 } },
-    }
+    })
 
     feed('a')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -720,14 +571,14 @@ local function test_cmdline(linegrid)
           pos = 12,
         },
       },
-    }
+    })
     feed('<esc>')
 
     -- check positioning with multibyte char in pattern
     command('e långfile1')
     command('sp långfile2')
     feed(':b lå<tab>')
-    screen:expect {
+    screen:expect({
       grid = [[
       ^                         |
       {3:långfile2                }|
@@ -747,7 +598,7 @@ local function test_cmdline(linegrid)
           pos = 12,
         },
       },
-    }
+    })
   end)
 
   it('ext_wildmenu takes precedence over ext_popupmenu', function()
@@ -766,12 +617,8 @@ local function test_cmdline(linegrid)
     screen:set_option('ext_popupmenu', true)
     feed(':sign <tab>')
 
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           firstc = ':',
@@ -781,7 +628,7 @@ local function test_cmdline(linegrid)
       },
       wildmenu_items = expected,
       wildmenu_pos = 0,
-    }
+    })
   end)
 
   it("doesn't send invalid events when aborting mapping #10000", function()
@@ -789,12 +636,8 @@ local function test_cmdline(linegrid)
     command('cnoremap ab c')
 
     feed(':xa')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]],
+    screen:expect({
+      grid = empty_grid,
       cmdline = {
         {
           content = { { 'x' } },
@@ -803,19 +646,12 @@ local function test_cmdline(linegrid)
           special = { 'a', false },
         },
       },
-    }
+    })
 
     -- This used to send an invalid event where pos where larger than the total
     -- length of content. Checked in _handle_cmdline_show.
     feed('<esc>')
-    screen:expect({
-      grid = [[
-        ^                         |
-        {1:~                        }|*3
-                                 |
-      ]],
-      cmdline = { { abort = true } },
-    })
+    screen:expect({ grid = empty_grid, cmdline = { { abort = true } } })
   end)
 
   it('does not move cursor to curwin #20309', function()
@@ -843,18 +679,10 @@ local function test_cmdline(linegrid)
   end)
 
   it('show prompt hl_id', function()
-    screen:expect([[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]])
+    screen:expect(empty_grid)
     feed(':echohl Error | call input("Prompt:")<CR>')
     screen:expect({
-      grid = [[
-        ^                         |
-        {1:~                        }|*3
-                                 |
-      ]],
+      grid = empty_grid,
       cmdline = {
         {
           content = { { '' } },
@@ -867,15 +695,10 @@ local function test_cmdline(linegrid)
   end)
 
   it('works with conditionals', function()
-    local s1 = [[
-      ^                         |
-      {1:~                        }|*3
-                               |
-    ]]
-    screen:expect(s1)
+    screen:expect(empty_grid)
     feed(':if 1<CR>')
     screen:expect({
-      grid = s1,
+      grid = empty_grid,
       cmdline = {
         {
           content = { { '' } },
@@ -888,7 +711,7 @@ local function test_cmdline(linegrid)
     })
     feed(':let x = 1<CR>')
     screen:expect({
-      grid = s1,
+      grid = empty_grid,
       cmdline = {
         {
           content = { { '' } },
@@ -901,7 +724,7 @@ local function test_cmdline(linegrid)
     })
     feed(':endif')
     screen:expect({
-      grid = s1,
+      grid = empty_grid,
       cmdline = {
         {
           content = { { ':endif' } },
@@ -913,10 +736,7 @@ local function test_cmdline(linegrid)
       cmdline_block = { { { 'if 1' } }, { { '  :let x = 1' } } },
     })
     feed('<CR>')
-    screen:expect({
-      grid = s1,
-      cmdline = { { abort = false } },
-    })
+    screen:expect({ grid = empty_grid, cmdline = { { abort = false } } })
   end)
 end
 
@@ -938,27 +758,15 @@ describe('cmdline redraw', function()
 
   it('with timer', function()
     feed(':012345678901234567890123456789')
-    screen:expect {
-      grid = [[
-                             |
-    {1:~                        }|
-    {3:                         }|
-    :012345678901234567890123|
-    456789^                   |
-    ]],
-    }
+    screen:expect([[
+                               |
+      {1:~                        }|
+      {3:                         }|
+      :012345678901234567890123|
+      456789^                   |
+    ]])
     command('call timer_start(0, {-> 1})')
-    screen:expect {
-      grid = [[
-                             |
-    {1:~                        }|
-    {3:                         }|
-    :012345678901234567890123|
-    456789^                   |
-    ]],
-      unchanged = true,
-      timeout = 100,
-    }
+    screen:expect_unchanged(false, 100)
   end)
 
   it('with <Cmd>', function()
@@ -967,26 +775,15 @@ describe('cmdline redraw', function()
     end
     command('cmap a <Cmd>call sin(0)<CR>') -- no-op
     feed(':012345678901234567890123456789')
-    screen:expect {
-      grid = [[
-                             |
-    {1:~                        }|
-    {3:                         }|
-    :012345678901234567890123|
-    456789^                   |
-    ]],
-    }
+    screen:expect([[
+                               |
+      {1:~                        }|
+      {3:                         }|
+      :012345678901234567890123|
+      456789^                   |
+    ]])
     feed('a')
-    screen:expect {
-      grid = [[
-                             |
-    {1:~                        }|
-    {3:                         }|
-    :012345678901234567890123|
-    456789^                   |
-    ]],
-      unchanged = true,
-    }
+    screen:expect_unchanged()
   end)
 
   it('after pressing Ctrl-C in cmdwin in Visual mode #18967', function()
@@ -1017,79 +814,63 @@ describe('cmdline redraw', function()
   it('with rightleftcmd', function()
     command('set rightleft rightleftcmd=search shortmess+=s')
     api.nvim_buf_set_lines(0, 0, -1, true, { "let's rock!" })
-    screen:expect {
-      grid = [[
+    screen:expect([[
                     !kcor s'te^l|
       {1:                        ~}|*3
                                |
-    ]],
-    }
+    ]])
 
     feed '/'
-    screen:expect {
-      grid = [[
+    screen:expect([[
                     !kcor s'tel|
       {1:                        ~}|*3
                              ^ /|
-    ]],
-    }
+    ]])
 
     feed "let's"
     -- note: cursor looks off but looks alright in real use
     -- when rendered as a block so it touches the end of the text
-    screen:expect {
-      grid = [[
+    screen:expect([[
                     !kcor {2:s'tel}|
       {1:                        ~}|*3
                         ^ s'tel/|
-    ]],
-    }
+    ]])
 
     -- cursor movement
     feed '<space>'
-    screen:expect {
-      grid = [[
+    screen:expect([[
                     !kcor{2: s'tel}|
       {1:                        ~}|*3
                        ^  s'tel/|
-    ]],
-    }
+    ]])
 
     feed 'rock'
-    screen:expect {
-      grid = [[
+    screen:expect([[
                     !{2:kcor s'tel}|
       {1:                        ~}|*3
                    ^ kcor s'tel/|
-    ]],
-    }
+    ]])
 
     feed '<right>'
-    screen:expect {
-      grid = [[
+    screen:expect([[
                     !{2:kcor s'tel}|
       {1:                        ~}|*3
                     ^kcor s'tel/|
-    ]],
-    }
+    ]])
 
     feed '<left>'
-    screen:expect {
-      grid = [[
+    screen:expect([[
                     !{2:kcor s'tel}|
       {1:                        ~}|*3
                    ^ kcor s'tel/|
-    ]],
-    }
+    ]])
 
     feed '<cr>'
-    screen:expect {
-      grid = [[
+    screen:expect([[
                     !{10:kcor s'te^l}|
       {1:                        ~}|*3
       kcor s'tel/              |
-    ]],
-    }
+    ]])
   end)
 
   it('silent prompt', function()
@@ -1134,48 +915,40 @@ describe('statusline is redrawn on entering cmdline', function()
 
   it('from normal mode', function()
     command('set statusline=%{mode()}')
-    screen:expect {
-      grid = [[
+    screen:expect([[
       ^                         |
       {1:~                        }|*2
       {3:n                        }|
                                |
-    ]],
-    }
+    ]])
 
     feed(':')
-    screen:expect {
-      grid = [[
+    screen:expect([[
                                |
       {1:~                        }|*2
       {3:c                        }|
       :^                        |
-    ]],
-    }
+    ]])
   end)
 
   it('from normal mode when : is mapped', function()
     command('set statusline=%{mode()}')
     command('nnoremap ; :')
 
-    screen:expect {
-      grid = [[
+    screen:expect([[
       ^                         |
       {1:~                        }|*2
       {3:n                        }|
                                |
-    ]],
-    }
+    ]])
 
     feed(';')
-    screen:expect {
-      grid = [[
+    screen:expect([[
                                |
       {1:~                        }|*2
       {3:c                        }|
       :^                        |
-    ]],
-    }
+    ]])
   end)
 
   it('with scrolled messages', function()
@@ -1189,8 +962,7 @@ describe('statusline is redrawn on entering cmdline', function()
       setlocal winbar=%{mode()}%{g:count}
     ]])
     feed(':echoerr doesnotexist<cr>')
-    screen:expect {
-      grid = [[
+    screen:expect([[
       {5:c1                                 }|
                                          |
       {3:c1                                 }|
@@ -1201,11 +973,9 @@ describe('statusline is redrawn on entering cmdline', function()
       {9:ist}                                |
       {6:Press ENTER or type command to cont}|
       {6:inue}^                               |
-    ]],
-    }
+    ]])
     feed(':echoerr doesnotexist<cr>')
-    screen:expect {
-      grid = [[
+    screen:expect([[
       {5:c2                                 }|
                                          |
       {3:c2                                 }|
@@ -1219,12 +989,10 @@ describe('statusline is redrawn on entering cmdline', function()
       {9:ist}                                |
       {6:Press ENTER or type command to cont}|
       {6:inue}^                               |
-    ]],
-    }
+    ]])
 
     feed(':echoerr doesnotexist<cr>')
-    screen:expect {
-      grid = [[
+    screen:expect([[
       {5:c3                                 }|
                                          |
       {3:c3                                 }|
@@ -1239,12 +1007,10 @@ describe('statusline is redrawn on entering cmdline', function()
       {9:ist}                                |
       {6:Press ENTER or type command to cont}|
       {6:inue}^                               |
-    ]],
-    }
+    ]])
 
     feed('<cr>')
-    screen:expect {
-      grid = [[
+    screen:expect([[
       {5:n3                                 }|
       ^                                   |
       {3:n3                                 }|
@@ -1252,47 +1018,40 @@ describe('statusline is redrawn on entering cmdline', function()
       {1:~                                  }|*8
       {2:[No Name]                          }|
                                          |
-    ]],
-    }
+    ]])
   end)
 
   describe('if custom statusline is set by', function()
     before_each(function()
       command('set statusline=')
-      screen:expect {
-        grid = [[
+      screen:expect([[
         ^                         |
         {1:~                        }|*2
         {3:[No Name]                }|
                                  |
-      ]],
-      }
+      ]])
     end)
 
     it('CmdlineEnter autocommand', function()
       command('autocmd CmdlineEnter * set statusline=command')
       feed(':')
-      screen:expect {
-        grid = [[
+      screen:expect([[
                                  |
         {1:~                        }|*2
         {3:command                  }|
         :^                        |
-      ]],
-      }
+      ]])
     end)
 
     it('ModeChanged autocommand', function()
       command('autocmd ModeChanged *:c set statusline=command')
       feed(':')
-      screen:expect {
-        grid = [[
+      screen:expect([[
                                  |
         {1:~                        }|*2
         {3:command                  }|
         :^                        |
-      ]],
-      }
+      ]])
     end)
   end)
 end)
@@ -1312,26 +1071,22 @@ it('tabline is not redrawn in Ex mode #24122', function()
   ]])
 
   feed('gQ')
-  screen:expect {
-    grid = [[
+  screen:expect([[
     {2:foo                                                         }|
                                                                 |
     {3:                                                            }|
     Entering Ex mode.  Type "visual" to go to Normal mode.      |
     :^                                                           |
-  ]],
-  }
+  ]])
 
   feed('echo 1<CR>')
-  screen:expect {
-    grid = [[
+  screen:expect([[
     {3:                                                            }|
     Entering Ex mode.  Type "visual" to go to Normal mode.      |
     :echo 1                                                     |
     1                                                           |
     :^                                                           |
-  ]],
-  }
+  ]])
 end)
 
 describe('cmdline height', function()
@@ -1356,6 +1111,10 @@ end)
 
 describe('cmdheight=0', function()
   local screen
+  local empty_grid = [[
+    ^                         |
+    {1:~                        }|*4
+  ]]
   before_each(function()
     clear()
     screen = Screen.new(25, 5)
@@ -1363,66 +1122,44 @@ describe('cmdheight=0', function()
 
   it('with redrawdebug=invalid resize -1', function()
     command('set redrawdebug=invalid cmdheight=0 noruler laststatus=0')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*4
-    ]],
-    }
+    screen:expect(empty_grid)
     feed(':resize -1<CR>')
-    screen:expect {
-      grid = [[
+    screen:expect([[
       ^                         |
       {1:~                        }|*3
                                |
-    ]],
-    }
+    ]])
     assert_alive()
   end)
 
   it('with cmdheight=1 noruler laststatus=2', function()
     command('set cmdheight=1 noruler laststatus=2')
-    screen:expect {
-      grid = [[
+    screen:expect([[
       ^                         |
       {1:~                        }|*2
       {3:[No Name]                }|
                                |
-    ]],
-    }
+    ]])
   end)
 
   it('with cmdheight=0 noruler laststatus=2', function()
     command('set cmdheight=0 noruler laststatus=2')
-    screen:expect {
-      grid = [[
+    screen:expect([[
       ^                         |
       {1:~                        }|*3
       {3:[No Name]                }|
-    ]],
-    }
+    ]])
   end)
 
   it('with cmdheight=0 ruler laststatus=0', function()
     command('set cmdheight=0 ruler laststatus=0')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*4
-    ]],
-    }
+    screen:expect(empty_grid)
   end)
 
   it('with cmdheight=0 ruler laststatus=0', function()
     command('set cmdheight=0 noruler laststatus=0 showmode')
     feed('i')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*4
-    ]],
-      showmode = {},
-    }
+    screen:expect({ grid = empty_grid, showmode = {} })
     feed('<Esc>')
     eq(0, eval('&cmdheight'))
   end)
@@ -1430,13 +1167,7 @@ describe('cmdheight=0', function()
   it('with cmdheight=0 ruler rulerformat laststatus=0', function()
     command('set cmdheight=0 noruler laststatus=0 rulerformat=%l,%c%= showmode')
     feed('i')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*4
-    ]],
-      showmode = {},
-    }
+    screen:expect({ grid = empty_grid, showmode = {} })
     feed('<Esc>')
     eq(0, eval('&cmdheight'))
   end)
@@ -1444,13 +1175,11 @@ describe('cmdheight=0', function()
   it('with showmode', function()
     command('set cmdheight=1 noruler laststatus=0 showmode')
     feed('i')
-    screen:expect {
-      grid = [[
+    screen:expect([[
       ^                         |
       {1:~                        }|*3
       {5:-- INSERT --}             |
-    ]],
-    }
+    ]])
     feed('<Esc>')
     eq(1, eval('&cmdheight'))
   end)
@@ -1458,81 +1187,59 @@ describe('cmdheight=0', function()
   it('when using command line', function()
     command('set cmdheight=0 noruler laststatus=0')
     feed(':')
-    screen:expect {
-      grid = [[
+    screen:expect([[
                                |
       {1:~                        }|*3
       :^                        |
-    ]],
-    }
+    ]])
     eq(0, eval('&cmdheight'))
     feed('<cr>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*4
-    ]],
-      showmode = {},
-    }
+    screen:expect({ grid = empty_grid, showmode = {} })
     eq(0, eval('&cmdheight'))
   end)
 
   it('when using input()', function()
     command('set cmdheight=0 noruler laststatus=0')
     feed(':call input("foo >")<cr>')
-    screen:expect {
-      grid = [[
+    screen:expect([[
                                |
       {1:~                        }|
       {3:                         }|
       :call input("foo >")     |
       foo >^                    |
-    ]],
-    }
+    ]])
     eq(0, eval('&cmdheight'))
     feed('<cr>')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*4
-    ]],
-      showmode = {},
-    }
+    screen:expect({ grid = empty_grid, showmode = {} })
     eq(0, eval('&cmdheight'))
   end)
 
   it('with winbar and splits', function()
     command('set cmdheight=0 noruler laststatus=3 winbar=foo')
     feed(':split<CR>')
-    screen:expect {
-      grid = [[
+    screen:expect([[
       {3:                         }|
       :split                   |
       {9:E36: Not enough room}     |
       {6:Press ENTER or type comma}|
       {6:nd to continue}^           |
-    ]],
-    }
+    ]])
     feed('<CR>')
-    screen:expect {
-      grid = [[
+    screen:expect([[
       {5:foo                      }|
       ^                         |
       {1:~                        }|*2
       {3:[No Name]                }|
-    ]],
-    }
+    ]])
     feed(':')
-    screen:expect {
-      grid = [[
+    screen:expect([[
       {5:foo                      }|
                                |
       {1:~                        }|*2
       :^                        |
-    ]],
-    }
+    ]])
     feed('<Esc>')
-    screen:expect {
+    screen:expect({
       grid = [[
       {5:foo                      }|
       ^                         |
@@ -1540,7 +1247,7 @@ describe('cmdheight=0', function()
       {3:[No Name]                }|
     ]],
       showmode = {},
-    }
+    })
     eq(0, eval('&cmdheight'))
 
     assert_alive()
@@ -1549,20 +1256,9 @@ describe('cmdheight=0', function()
   it('when macro with lastline', function()
     command('set cmdheight=0 display=lastline')
     feed('qq')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*4
-    ]],
-    }
+    screen:expect(empty_grid)
     feed('q')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*4
-    ]],
-      unchanged = true,
-    }
+    screen:expect_unchanged()
   end)
 
   it('when substitute text', function()
@@ -1605,47 +1301,38 @@ describe('cmdheight=0', function()
     command('set cmdheight=0')
     command('map <f3> :nohlsearch<cr>')
     feed('iaabbaa<esc>/aa<cr>')
-    screen:expect {
-      grid = [[
+    screen:expect([[
       {10:^aa}bb{10:aa}                   |
       {1:~                        }|*4
-    ]],
-    }
+    ]])
 
     feed('<f3>')
-    screen:expect {
-      grid = [[
+    screen:expect([[
       ^aabbaa                   |
       {1:~                        }|*4
-    ]],
-    }
+    ]])
   end)
 
   it('with silent! at startup', function()
     clear { args = { '-c', 'set cmdheight=0', '-c', 'autocmd VimEnter * silent! call Foo()' } }
     screen = Screen.new(25, 5)
     -- doesn't crash while not displaying silent! error message
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*4
-    ]],
-    }
+    screen:expect(empty_grid)
   end)
 
   it('with multigrid', function()
     clear { args = { '--cmd', 'set cmdheight=0' } }
     screen = Screen.new(25, 5, { ext_multigrid = true })
     api.nvim_buf_set_lines(0, 0, -1, true, { 'p' })
-    screen:expect {
+    screen:expect({
       grid = [[
-    ## grid 1
-      [2:-------------------------]|*5
-    ## grid 2
-      ^p                        |
-      {1:~                        }|*4
-    ## grid 3
-    ]],
+        ## grid 1
+          [2:-------------------------]|*5
+        ## grid 2
+          ^p                        |
+          {1:~                        }|*4
+        ## grid 3
+      ]],
       win_viewport = {
         [2] = {
           win = 1000,
@@ -1657,20 +1344,20 @@ describe('cmdheight=0', function()
           sum_scroll_delta = 0,
         },
       },
-    }
+    })
 
     feed '/p'
-    screen:expect {
+    screen:expect({
       grid = [[
-    ## grid 1
-      [2:-------------------------]|*4
-      [3:-------------------------]|
-    ## grid 2
-      {2:p}                        |
-      {1:~                        }|*4
-    ## grid 3
-      /p^                       |
-    ]],
+        ## grid 1
+          [2:-------------------------]|*4
+          [3:-------------------------]|
+        ## grid 2
+          {2:p}                        |
+          {1:~                        }|*4
+        ## grid 3
+          /p^                       |
+      ]],
       win_viewport = {
         [2] = {
           win = 1000,
@@ -1682,7 +1369,7 @@ describe('cmdheight=0', function()
           sum_scroll_delta = 0,
         },
       },
-    }
+    })
   end)
 
   it('winbar is redrawn on entering cmdline and :redrawstatus #20336', function()
@@ -1755,10 +1442,7 @@ describe('cmdheight=0', function()
   it('no assert failure with showcmd', function()
     command('set showcmd cmdheight=0')
     feed('d')
-    screen:expect([[
-      ^                         |
-      {1:~                        }|*4
-    ]])
+    screen:expect(empty_grid)
     assert_alive()
   end)
 
@@ -1766,28 +1450,24 @@ describe('cmdheight=0', function()
     command('set laststatus=2')
     command('resize +1')
     screen:expect([[
-      ^                         |
-      {1:~                        }|*2
-      {3:[No Name]                }|
-                               |
-    ]])
+    ^                         |
+    {1:~                        }|*2
+    {3:[No Name]                }|
+                             |
+  ]])
     command('set cmdheight=0')
-    screen:expect {
-      grid = [[
+    screen:expect([[
       ^                         |
       {1:~                        }|*3
       {3:[No Name]                }|
-    ]],
-    }
+    ]])
     command('resize -1')
-    screen:expect {
-      grid = [[
-      ^                         |
-      {1:~                        }|*2
-      {3:[No Name]                }|
-                               |
-    ]],
-    }
+    screen:expect([[
+    ^                         |
+    {1:~                        }|*2
+    {3:[No Name]                }|
+                             |
+  ]])
     command('resize +1')
     screen:expect([[
       ^                         |


### PR DESCRIPTION
Use more compact formatting and re-use repeated screen states.
