### PR TITLE
feat(terminal): support `set scbk=0`

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -4903,7 +4903,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			local to buffer
 	Maximum number of lines kept beyond the visible screen. Lines at the
 	top are deleted if new lines exceed this limit.
-	Minimum is 1, maximum is 100000.
+	Minimum is 0, maximum is 100000.
 	Only in |terminal| buffers.
 
 	Note: Lines that are not visible and kept in scrollback are not

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -606,7 +606,7 @@ do
     callback = function(args)
       vim.bo[args.buf].modifiable = false
       vim.bo[args.buf].undolevels = -1
-      vim.bo[args.buf].scrollback = vim.o.scrollback < 0 and 10000 or math.max(1, vim.o.scrollback)
+      vim.bo[args.buf].scrollback = vim.o.scrollback < 0 and 10000 or math.max(0, vim.o.scrollback)
       vim.bo[args.buf].textwidth = 0
       vim.wo[0][0].wrap = false
       vim.wo[0][0].list = false

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5115,7 +5115,7 @@ vim.wo.scr = vim.wo.scroll
 
 --- Maximum number of lines kept beyond the visible screen. Lines at the
 --- top are deleted if new lines exceed this limit.
---- Minimum is 1, maximum is 100000.
+--- Minimum is 0, maximum is 100000.
 --- Only in `terminal` buffers.
 ---
 --- Note: Lines that are not visible and kept in scrollback are not

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -6860,7 +6860,7 @@ local options = {
       desc = [=[
         Maximum number of lines kept beyond the visible screen. Lines at the
         top are deleted if new lines exceed this limit.
-        Minimum is 1, maximum is 100000.
+        Minimum is 0, maximum is 100000.
         Only in |terminal| buffers.
 
         Note: Lines that are not visible and kept in scrollback are not

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -525,12 +525,14 @@ void terminal_open(Terminal **termpp, buf_T *buf, TerminalOptions opts)
 
   if (term->sb_buffer == NULL) {
     // Local 'scrollback' _after_ autocmds.
-    if (buf->b_p_scbk < 1) {
+    if (buf->b_p_scbk < 0) {
       buf->b_p_scbk = SB_MAX;
     }
     // Configure the scrollback buffer.
     term->sb_size = (size_t)buf->b_p_scbk;
-    term->sb_buffer = xmalloc(sizeof(ScrollbackLine *) * term->sb_size);
+    if (term->sb_size) {
+      term->sb_buffer = xmalloc(sizeof(ScrollbackLine *) * term->sb_size);
+    }
   }
 
   // Configure the color palette. Try to get the color from:
@@ -2136,7 +2138,7 @@ void on_scrollback_option_changed(Terminal *term)
 /// Adjusts scrollback storage and the terminal buffer scrollback lines
 static void adjust_scrollback(Terminal *term, buf_T *buf)
 {
-  if (buf->b_p_scbk < 1) {  // Local 'scrollback' was set to -1.
+  if (buf->b_p_scbk < 0) {  // Local 'scrollback' was set to -1.
     buf->b_p_scbk = SB_MAX;
   }
   const size_t scbk = (size_t)buf->b_p_scbk;
@@ -2159,10 +2161,9 @@ static void adjust_scrollback(Terminal *term, buf_T *buf)
   // Resize the scrollback storage.
   size_t sb_region = sizeof(ScrollbackLine *) * scbk;
   if (scbk != term->sb_size) {
-    term->sb_buffer = xrealloc(term->sb_buffer, sb_region);
+    term->sb_buffer = scbk ? xrealloc(term->sb_buffer, sb_region) : NULL;
+    term->sb_size = scbk;
   }
-
-  term->sb_size = scbk;
 }
 
 // Refresh the scrollback of an invalidated terminal.


### PR DESCRIPTION
Problem: no way to clean all scrollback buffer. Which is a useful
feature in shell, current workaround (temporally `:set scbk=1`) there
still remain one line in scrollback buffer.

Solution: support `set scbk=0`. Now user can clean all scrollback buffer
from shell by:
```sh
nvim -u NONE --headless --server $NVIM \
       --remote-send "<cmd>let scbk=&scbk|let &scbk=0|let
&scbk=scbk|unlet scbk<cr>" 2>/dev/null
```
