### PR TITLE
vim-patch:9.1.1200: cmdline pum not cleared for input() completion

### DIFF
--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -115,6 +115,77 @@ describe('cmdline', function()
     ]])
   end)
 
+  -- oldtest: Test_wildmenu_with_input_func()
+  it('wildmenu works with input() function', function()
+    local screen = Screen.new(60, 8)
+    screen:add_extra_attr_ids({
+      [100] = { background = Screen.colors.Yellow, foreground = Screen.colors.Black },
+    })
+
+    feed(":call input('Command? ', '', 'command')<CR>")
+    screen:expect([[
+                                                                  |
+      {1:~                                                           }|*6
+      Command? ^                                                   |
+    ]])
+    feed('ech<Tab>')
+    screen:expect([[
+                                                                  |
+      {1:~                                                           }|*5
+      {100:echo}{3:  echoerr  echohl  echomsg  echon                       }|
+      Command? echo^                                               |
+    ]])
+    feed('<Space>')
+    screen:expect([[
+                                                                  |
+      {1:~                                                           }|*6
+      Command? echo ^                                              |
+    ]])
+    feed('bufn<Tab>')
+    screen:expect([[
+                                                                  |
+      {1:~                                                           }|*5
+      {100:bufname(}{3:  bufnr(                                            }|
+      Command? echo bufname(^                                      |
+    ]])
+    feed('<CR>')
+
+    command('set wildoptions+=pum')
+
+    feed(":call input('Command? ', '', 'command')<CR>")
+    screen:expect([[
+                                                                  |
+      {1:~                                                           }|*6
+      Command? ^                                                   |
+    ]])
+    feed('ech<Tab>')
+    screen:expect([[
+                                                                  |
+      {1:~                                                           }|
+      {1:~       }{12: echo           }{1:                                    }|
+      {1:~       }{4: echoerr        }{1:                                    }|
+      {1:~       }{4: echohl         }{1:                                    }|
+      {1:~       }{4: echomsg        }{1:                                    }|
+      {1:~       }{4: echon          }{1:                                    }|
+      Command? echo^                                               |
+    ]])
+    feed('<Space>')
+    screen:expect([[
+                                                                  |
+      {1:~                                                           }|*6
+      Command? echo ^                                              |
+    ]])
+    feed('bufn<Tab>')
+    screen:expect([[
+                                                                  |
+      {1:~                                                           }|*4
+      {1:~            }{12: bufname(       }{1:                               }|
+      {1:~            }{4: bufnr(         }{1:                               }|
+      Command? echo bufname(^                                      |
+    ]])
+    feed('<CR>')
+  end)
+
   -- oldtest: Test_redraw_in_autocmd()
   it('cmdline cursor position is correct after :redraw with cmdheight=2', function()
     local screen = Screen.new(30, 6)

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -212,6 +212,37 @@ func Test_wildmenu_screendump()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_wildmenu_with_input_func()
+  CheckScreendump
+
+  let buf = RunVimInTerminal('-c "set wildmenu"', {'rows': 8})
+
+  call term_sendkeys(buf, ":call input('Command? ', '', 'command')\<CR>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_input_func_1', {})
+  call term_sendkeys(buf, "ech\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_input_func_2', {})
+  call term_sendkeys(buf, "\<Space>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_input_func_3', {})
+  call term_sendkeys(buf, "bufn\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_input_func_4', {})
+  call term_sendkeys(buf, "\<CR>")
+
+  call term_sendkeys(buf, ":set wildoptions+=pum\<CR>")
+
+  call term_sendkeys(buf, ":call input('Command? ', '', 'command')\<CR>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_input_func_5', {})
+  call term_sendkeys(buf, "ech\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_input_func_6', {})
+  call term_sendkeys(buf, "\<Space>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_input_func_7', {})
+  call term_sendkeys(buf, "bufn\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_input_func_8', {})
+  call term_sendkeys(buf, "\<CR>")
+
+  " clean up
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_redraw_in_autocmd()
   CheckScreendump
 


### PR DESCRIPTION
#### vim-patch:9.1.1200: cmdline pum not cleared for input() completion

Problem:  Cmdline pum not cleared for input() completion.
Solution: Temporary reset RedrawingDisabled in cmdline_pum_cleanup(),
          like what is done in wildmenu_cleanup() (zeertzjq).

closes: vim/vim#16876

https://github.com/vim/vim/commit/1830e787f6ee9828151284c44b494b801c677ee9

No code change is needed in Nvim, as RedrawingDisabled does not prevent
the compositor from removing a grid.