### PR TITLE
refactor(gen_keycodes): put TAB and K_TAB together

### DIFF
--- a/src/gen/preload_nlua.lua
+++ b/src/gen/preload_nlua.lua
@@ -9,6 +9,7 @@ package.path = (srcdir .. '/src/?.lua;')
 
 _G.vim = require 'vim.shared'
 _G.vim.inspect = require 'vim.inspect'
+_G.vim.iter = require 'vim.iter'
 package.cpath = package.cpath .. ';' .. nlualib
 require 'nlua0'
 vim.NIL = vim.mpack.NIL -- WOW BOB WOW


### PR DESCRIPTION
Keep track of the original indexes of both TAB and K_TAB, so that there
doesn't have to be an extra table and loop for K_TAB.
