### PR TITLE
test: do not dedent() in feed()

### DIFF
--- a/test/functional/ex_cmds/cmd_map_spec.lua
+++ b/test/functional/ex_cmds/cmd_map_spec.lua
@@ -574,7 +574,7 @@ describe('mappings with <Cmd>', function()
     eq('i', eval('mode(1)'))
 
     -- also works as part of abbreviation
-    feed('<space>foo ')
+    feed(' foo ')
     screen:expect([[
       in bar ^deed some short little lines                              |
       of stuff test text                                               |

--- a/test/functional/legacy/034_user_function_spec.lua
+++ b/test/functional/legacy/034_user_function_spec.lua
@@ -63,12 +63,11 @@ describe(
       /^here
     ]])
       feed('C<C-R>=Table("xxx", 4, "asdf")<cr>')
-      -- Using a actual space will not work as feed() calls dedent on the input.
-      feed('<space><C-R>=Compute(45, 0, "retval")<cr>')
-      feed('<space><C-R>=retval<cr>')
-      feed('<space><C-R>=Compute(45, 5, "retval")<cr>')
-      feed('<space><C-R>=retval<cr>')
-      feed('<space><C-R>=g:FuncRef(333)<cr>')
+      feed(' <C-R>=Compute(45, 0, "retval")<cr>')
+      feed(' <C-R>=retval<cr>')
+      feed(' <C-R>=Compute(45, 5, "retval")<cr>')
+      feed(' <C-R>=retval<cr>')
+      feed(' <C-R>=g:FuncRef(333)<cr>')
       feed('<cr>')
       feed('XX+-XX<cr>')
       feed('---*---<cr>')

--- a/test/functional/legacy/069_multibyte_formatting_spec.lua
+++ b/test/functional/legacy/069_multibyte_formatting_spec.lua
@@ -183,9 +183,8 @@ describe('multibyte text', function()
     feed_command('/^{/+1')
     feed_command('set noai tw=2 fo=tm')
     feed('gqgqjgqgqo<cr>')
-    -- Literal spaces will be trimmed from the by feed().
-    feed('<space><space>Ｘ<cr>')
-    feed('<space><space>Ｘa<esc>')
+    feed('  Ｘ<cr>')
+    feed('  Ｘa<esc>')
     expect([[
       {
         Ｘ

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -3,6 +3,7 @@ local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
 
 local command, feed = n.command, n.feed
+local dedent = t.dedent
 local clear = n.clear
 local exec_lua = n.exec_lua
 local fn = n.fn
@@ -63,9 +64,11 @@ describe(':Man', function()
 
     it('clears backspaces from text and adds highlights', function()
       feed(
-        [[
+        dedent(
+          [[
         ithis i<C-v><C-h>is<C-v><C-h>s a<C-v><C-h>a test
         with _<C-v><C-h>o_<C-v><C-h>v_<C-v><C-h>e_<C-v><C-h>r_<C-v><C-h>s_<C-v><C-h>t_<C-v><C-h>r_<C-v><C-h>u_<C-v><C-h>c_<C-v><C-h>k text<ESC>]]
+        )
       )
 
       screen:expect {
@@ -89,9 +92,11 @@ describe(':Man', function()
 
     it('clears escape sequences from text and adds highlights', function()
       feed(
-        [[
+        dedent(
+          [[
         ithis <C-v><ESC>[1mis <C-v><ESC>[3ma <C-v><ESC>[4mtest<C-v><ESC>[0m
         <C-v><ESC>[4mwith<C-v><ESC>[24m <C-v><ESC>[4mescaped<C-v><ESC>[24m <C-v><ESC>[4mtext<C-v><ESC>[24m<ESC>]]
+        )
       )
 
       screen:expect {
@@ -115,8 +120,10 @@ describe(':Man', function()
 
     it('clears OSC 8 hyperlink markup from text', function()
       feed(
-        [[
+        dedent(
+          [[
         ithis <C-v><ESC>]8;;http://example.com<C-v><ESC>\Link Title<C-v><ESC>]8;;<C-v><ESC>\<ESC>]]
+        )
       )
 
       screen:expect {
@@ -138,9 +145,11 @@ describe(':Man', function()
 
     it('highlights multibyte text', function()
       feed(
-        [[
+        dedent(
+          [[
         ithis i<C-v><C-h>is<C-v><C-h>s あ<C-v><C-h>あ test
         with _<C-v><C-h>ö_<C-v><C-h>v_<C-v><C-h>e_<C-v><C-h>r_<C-v><C-h>s_<C-v><C-h>t_<C-v><C-h>r_<C-v><C-h>u_<C-v><C-h>̃_<C-v><C-h>c_<C-v><C-h>k te<C-v><ESC>[3mxt¶<C-v><ESC>[0m<ESC>]]
+        )
       )
       exec_lua [[require'man'.init_pager()]]
 
@@ -154,10 +163,12 @@ describe(':Man', function()
 
     it('highlights underscores based on context', function()
       feed(
-        [[
+        dedent(
+          [[
         i_<C-v><C-h>_b<C-v><C-h>be<C-v><C-h>eg<C-v><C-h>gi<C-v><C-h>in<C-v><C-h>ns<C-v><C-h>s
         m<C-v><C-h>mi<C-v><C-h>id<C-v><C-h>d_<C-v><C-h>_d<C-v><C-h>dl<C-v><C-h>le<C-v><C-h>e
         _<C-v><C-h>m_<C-v><C-h>i_<C-v><C-h>d_<C-v><C-h>__<C-v><C-h>d_<C-v><C-h>l_<C-v><C-h>e<ESC>]]
+        )
       )
       exec_lua [[require'man'.init_pager()]]
 
@@ -171,10 +182,10 @@ describe(':Man', function()
     end)
 
     it('highlights various bullet formats', function()
-      feed([[
+      feed(dedent([[
         i· ·<C-v><C-h>·
         +<C-v><C-h>o
-        +<C-v><C-h>+<C-v><C-h>o<C-v><C-h>o double<ESC>]])
+        +<C-v><C-h>+<C-v><C-h>o<C-v><C-h>o double<ESC>]]))
       exec_lua [[require'man'.init_pager()]]
 
       screen:expect([[
@@ -187,11 +198,11 @@ describe(':Man', function()
     end)
 
     it('handles : characters in input', function()
-      feed([[
+      feed(dedent([[
         i<C-v><C-[>[40m    0  <C-v><C-[>[41m    1  <C-v><C-[>[42m    2  <C-v><C-[>[43m    3
         <C-v><C-[>[44m    4  <C-v><C-[>[45m    5  <C-v><C-[>[46m    6  <C-v><C-[>[47m    7  <C-v><C-[>[100m    8  <C-v><C-[>[101m    9
         <C-v><C-[>[102m   10  <C-v><C-[>[103m   11  <C-v><C-[>[104m   12  <C-v><C-[>[105m   13  <C-v><C-[>[106m   14  <C-v><C-[>[107m   15
-        <C-v><C-[>[48:5:16m   16  <ESC>]])
+        <C-v><C-[>[48:5:16m   16  <ESC>]]))
       exec_lua [[require'man'.init_pager()]]
 
       screen:expect([[

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -366,7 +366,7 @@ end
 --- @param ... string
 function M.feed(...)
   for _, v in ipairs({ ... }) do
-    nvim_feed(dedent(v))
+    nvim_feed(v)
   end
 end
 
@@ -615,7 +615,7 @@ function M.insert(...)
   nvim_feed('i')
   for _, v in ipairs({ ... }) do
     local escaped = v:gsub('<', '<lt>')
-    M.feed(escaped) -- This also dedents :P
+    nvim_feed(dedent(escaped))
   end
   nvim_feed('<ESC>')
 end


### PR DESCRIPTION
Most callers of feed() do not expect feed() to dedent.
Now use a literal space in tests where it looks better.
