### PR TITLE
test: flaky loop_spec.lua

### DIFF
--- a/test/functional/lua/loop_spec.lua
+++ b/test/functional/lua/loop_spec.lua
@@ -233,7 +233,7 @@ describe('vim.uv', function()
     screen:expect([[
       {3:                                                  }|
       {9:Error executing callback:}                         |
-      {9:uv_idle_t: 0x{MATCH:%w+}}                         |
+      {9:uv_idle_t: 0x{MATCH:%w+}}{MATCH: +}|
       {6:Press ENTER or type command to continue}^           |
     ]])
     feed('<cr>')


### PR DESCRIPTION
Problem:
Test may fail because it matches a Lua table address, and the following whitespace may differ depending on the stringified address length:

    test/functional/lua/loop_spec.lua:233: Row 3 did not match.
    Expected:
      |{3:                                                  }|
      |{9:Error executing callback:}                         |
      |*{9:uv_idle_t: 0x{MATCH:%w+}}                         |
      |{6:Press ENTER or type command to continue}^           |
    Actual:
      |{3:                                                  }|
      |{9:Error executing callback:}                         |
      |*{9:uv_idle_t: 0xd4c2820a00}                           |
      |{6:Press ENTER or type command to continue}^           |

Solution:
Match a variable amount of whitespace.