### PR TITLE
vim-patch:f22580e: runtime(doc): update a few minor omissions from 5876016 and 4d2c4b9

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -620,6 +620,7 @@ possibilities: >
 
 	:Cycle  " to cycle between the previous commands
 <
+The `:Cycle` command is also mapped to the CTRL-A and CTRL-X keys.
 For details, see `git-rebase --help`.
 
 GO							*ft-go-plugin*


### PR DESCRIPTION
#### vim-patch:f22580e: runtime(doc): update a few minor omissions from 5876016 and 4d2c4b9

https://github.com/vim/vim/commit/f22580e57c09ef8584fc62140028adf2d043c306

Skip options.txt: included in #30189

Co-authored-by: Christian Brabandt <cb@256bit.org>