### PR TITLE
fix(lsp): autocmds to close lsp preview windows not cleared

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1345,7 +1345,7 @@ local function close_preview_window(winnr, bufnrs)
       return
     end
 
-    local augroup = 'preview_window_' .. winnr
+    local augroup = 'nvim.preview_window_' .. winnr
     pcall(api.nvim_del_augroup_by_name, augroup)
     pcall(api.nvim_win_close, winnr, true)
   end)


### PR DESCRIPTION
Problem: Augroup to close lsp preview hover window is not cleared after the window is closed because of unmatched group name.

Solution: Delete the augroup before closing the preview window with correct group name.