### PR TITLE
docs(lsp): simplify example of enabling LSP folding

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -882,14 +882,23 @@ foldexpr({lnum})                                          *vim.lsp.foldexpr()*
     Provides an interface between the built-in client and a `foldexpr`
     function.
 
-    To use, check for the "textDocument/foldingRange" capability in an
-    |LspAttach| autocommand. Example: >lua
+    To use, set 'foldmethod' to "expr" and set the value of 'foldexpr': >lua
+        vim.o.foldmethod = 'expr'
+        vim.o.foldexpr = 'v:lua.vim.lsp.foldexpr()'
+<
+
+    Or use it only when supported by checking for the
+    "textDocument/foldingRange" capability in an |LspAttach| autocommand.
+    Example: >lua
+        vim.o.foldmethod = 'expr'
+        -- Default to treesitter folding
+        vim.o.foldexpr = 'v:lua.vim.treesitter.foldexpr()'
+        -- Prefer LSP folding if client supports it
         vim.api.nvim_create_autocmd('LspAttach', {
           callback = function(args)
             local client = vim.lsp.get_client_by_id(args.data.client_id)
             if client:supports_method('textDocument/foldingRange') then
               local win = vim.api.nvim_get_current_win()
-              vim.wo[win][0].foldmethod = 'expr'
               vim.wo[win][0].foldexpr = 'v:lua.vim.lsp.foldexpr()'
             end
           end,

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1365,16 +1365,26 @@ end
 
 --- Provides an interface between the built-in client and a `foldexpr` function.
 ---
---- To use, check for the "textDocument/foldingRange" capability in an
---- |LspAttach| autocommand. Example:
+--- To use, set 'foldmethod' to "expr" and set the value of 'foldexpr':
 ---
 --- ```lua
+--- vim.o.foldmethod = 'expr'
+--- vim.o.foldexpr = 'v:lua.vim.lsp.foldexpr()'
+--- ```
+---
+--- Or use it only when supported by checking for the "textDocument/foldingRange"
+--- capability in an |LspAttach| autocommand. Example:
+---
+--- ```lua
+--- vim.o.foldmethod = 'expr'
+--- -- Default to treesitter folding
+--- vim.o.foldexpr = 'v:lua.vim.treesitter.foldexpr()'
+--- -- Prefer LSP folding if client supports it
 --- vim.api.nvim_create_autocmd('LspAttach', {
 ---   callback = function(args)
 ---     local client = vim.lsp.get_client_by_id(args.data.client_id)
 ---     if client:supports_method('textDocument/foldingRange') then
 ---       local win = vim.api.nvim_get_current_win()
----       vim.wo[win][0].foldmethod = 'expr'
 ---       vim.wo[win][0].foldexpr = 'v:lua.vim.lsp.foldexpr()'
 ---     end
 ---   end,


### PR DESCRIPTION
I initially aimed to design `vim.lsp.foldexpr` to be enabled with a single line of code, but there was an bug that led to the documentation added in #31411 thinking it was designed another way. This bug should now have been fixed by #31463. `vim.o.foldexpr = 'v:lua.vim.lsp.foldexpr()'` should be sufficient now.