### PR TITLE
vim-patch:2329bd4: runtime(doc): fix a typo in gitrebase filetype

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -615,7 +615,7 @@ with interactive `git rebase`: >
 	:Reword " to pick this commit, but change the commit message
 	:Squash " to squash this commit into the previous one
 
-In addition, the following comamnd can be used to cycle between the different
+In addition, the following command can be used to cycle between the different
 possibilities: >
 
 	:Cycle  " to cycle between the previous commands


### PR DESCRIPTION
#### vim-patch:2329bd4: runtime(doc): fix a typo in gitrebase filetype

Introduced in 4d2c4b90f.

closes: vim/vim#16892

https://github.com/vim/vim/commit/2329bd427a046d1e76ba29100a2e79790fd96011

Co-authored-by: skshetry <18718008+skshetry@users.noreply.github.com>