### PR TITLE
vim-patch:9.1.1203: matchparen keeps cursor on case label in sh filetype

### DIFF
--- a/test/functional/legacy/matchparen_spec.lua
+++ b/test/functional/legacy/matchparen_spec.lua
@@ -4,6 +4,7 @@ local Screen = require('test.functional.ui.screen')
 local clear = n.clear
 local exec = n.exec
 local feed = n.feed
+local poke_eventloop = n.poke_eventloop
 
 describe('matchparen', function()
   before_each(clear)
@@ -237,6 +238,27 @@ describe('matchparen', function()
       {25:)}                                       |
       {1:~                                       }|*2
                                               |
+    ]])
+    -- Send keys one by one so that CursorMoved is triggered.
+    for _, c in ipairs({ 'A', ' ', 'f', 'o', 'o', 'b', 'a', 'r' }) do
+      feed(c)
+      poke_eventloop()
+    end
+    screen:expect([[
+      {18:#!/bin/sh}                               |
+      {25:SUSUWU_PRINT() (}                        |
+        {15:case} {15:"}{100:${LEVEL}}{15:"} {15:in}                    |
+          {15:"}{100:$SUSUWU_SH_NOTICE}{15:")} foobar^         |
+          {100:${SUSUWU_S}} {15:&&} {15:return} {26:1}             |
+        {15:;;}                                    |
+          {15:"}{100:$SUSUWU_SH_DEBUG}{15:")}                 |
+          {100:(}{15:!} {100:${SUSUWU_VERBOSE})} {15:&&} {15:return} {26:1}   |
+        {15:;;}                                    |
+        {15:esac}                                  |
+        {18:# snip}                                |
+      {25:)}                                       |
+      {1:~                                       }|*2
+      {5:-- INSERT --}                            |
     ]])
   end)
 end)

--- a/test/old/testdir/test_plugin_matchparen.vim
+++ b/test/old/testdir/test_plugin_matchparen.vim
@@ -168,6 +168,12 @@ func Test_matchparen_ignore_sh_case()
 
   let buf = RunVimInTerminal('-S '.filename, #{rows: 10})
   call VerifyScreenDump(buf, 'Test_matchparen_sh_case_1', {})
+  " Send keys one by one so that CursorMoved is triggered.
+  for c in 'A foobar'
+    call term_sendkeys(buf, c)
+    call term_wait(buf)
+  endfor
+  call VerifyScreenDump(buf, 'Test_matchparen_sh_case_2', {})
   call StopVimInTerminal(buf)
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.1203: matchparen keeps cursor on case label in sh filetype

Problem:  matchparen keeps cursor on case label in sh filetype
          (@categorical, after 9.1.1187).
Solution: Use :defer so that cursor is always restored, remove checks
          for older Vims, finish early if Vim does not support :defer

closes: vim/vim#16888

https://github.com/vim/vim/commit/47071c6076018cace96f6e567054a21c123d0c10