### PR TITLE
vim-patch:9.1.1204: MS-Windows: crash when passing long string to expand()

### DIFF
--- a/test/old/testdir/test_expand_func.vim
+++ b/test/old/testdir/test_expand_func.vim
@@ -143,4 +143,11 @@ func Test_expand_wildignore()
   set wildignore&
 endfunc
 
+" Passing a long string to expand with 'wildignorecase' should not crash Vim.
+func Test_expand_long_str()
+  set wildignorecase
+  call expand('a'->repeat(99999))
+  set wildignorecase&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1204: MS-Windows: crash when passing long string to expand()

Problem:  MS-Windows: crash when passing long string to expand() with
          'wildignorecase'.
Solution: Use the same buflen as unix_expandpath() in dos_expandpath().
          Remove an unnecessary STRLEN() while at it (zeertzjq).

closes: vim/vim#16896

https://github.com/vim/vim/commit/00a749bd90e6b84e7e5132691d73fe9aa3fdff05