### PR TITLE
vim-patch:9.1.1206: tests: test_filetype fails when a file is a directory

### DIFF
--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -934,6 +934,9 @@ func CheckItems(checks)
   set noswapfile
   for [ft, names] in items(a:checks)
     for i in range(0, len(names) - 1)
+      if isdirectory(fnameescape(names[i]))
+        continue
+      endif
       new
       try
         exe 'edit ' .. fnameescape(names[i])


### PR DESCRIPTION
#### vim-patch:9.1.1206: tests: test_filetype fails when a file is a directory

Problem:  tests: test_filetype fails when a file is a directory
          (Eisuke Kawashima)
Solution: When encountering a directory instead of a file, skip that
          particular filetype test

https://github.com/vim/vim/commit/63a885b6506ce90050c1e3515836db06853cd0d7

Co-authored-by: Christian Brabandt <cb@256bit.org>