### PR TITLE
fix(lsp): correctly check for "codeAction/resolve" support

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -1152,7 +1152,7 @@ local function on_code_action_results(results, opts)
       return
     end
 
-    if not action.edit or not action.command and client:supports_method(ms.codeAction_resolve) then
+    if not (action.edit and action.command) and client:supports_method(ms.codeAction_resolve) then
       client:request(ms.codeAction_resolve, action, function(err, resolved_action)
         if err then
           -- If resolve fails, try to apply the edit/command from the original code action.


### PR DESCRIPTION
I believe this PR: https://github.com/neovim/neovim/pull/32704 forgot some parentheses around the condition, so the resolve request for missing `edit`s is always made, even if there is no "codeAction/resolve" support.

This was brought to my attention, because the code actions of crates.nvim stopped working in nightly (https://github.com/saecki/crates.nvim/issues/157).