### PR TITLE
refactor(lsp)!: rename lsp.completion.trigger() to get()

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -42,7 +42,7 @@ LSP
 • *vim.lsp.util.jump_to_location*	Use |vim.lsp.util.show_document()| with
 					`{focus=true}` instead.
 • *vim.lsp.buf.execute_command*		Use |Client:exec_cmd()| instead.
-• *vim.lsp.buf.completion*		Use |vim.lsp.completion.trigger()| instead.
+• *vim.lsp.buf.completion*		Use |vim.lsp.completion.get()| instead.
 • vim.lsp.buf_request_all		The `error` key has been renamed to `err` inside
 					the result parameter of the handler.
 • *vim.lsp.with()*			Pass configuration to equivalent

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1870,7 +1870,7 @@ enable({enable}, {client_id}, {bufnr}, {opts})
       • {opts}       (`vim.lsp.completion.BufferOpts?`) See
                      |vim.lsp.completion.BufferOpts|.
 
-show({opts})                                       *vim.lsp.completion.show()*
+get({opts})                                         *vim.lsp.completion.get()*
     Triggers LSP completion once in the current buffer.
 
     Parameters: ~

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1870,7 +1870,7 @@ enable({enable}, {client_id}, {bufnr}, {opts})
       • {opts}       (`vim.lsp.completion.BufferOpts?`) See
                      |vim.lsp.completion.BufferOpts|.
 
-trigger({opts})                                 *vim.lsp.completion.trigger()*
+show({opts})                                       *vim.lsp.completion.show()*
     Triggers LSP completion once in the current buffer.
 
     Parameters: ~

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -29,7 +29,8 @@ LSP
 • `vim.lsp.buf.document_symbol()` uses the |location-list| by default. Use
   `vim.lsp.buf.document_symbol({ loclist = false })` to use the |quickfix|
   list.
-
+• `vim.lsp.completion.trigger()` has been renamed to
+  |vim.lsp.completion.get()|.
 
 OPTIONS
 

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -536,7 +536,7 @@ local function on_insert_char_pre(handle)
       local ctx = { triggerKind = protocol.CompletionTriggerKind.TriggerForIncompleteCompletions }
       if debounce_ms == 0 then
         vim.schedule(function()
-          M.trigger({ ctx = ctx })
+          M.show({ ctx = ctx })
         end)
       else
         completion_timer = new_timer()
@@ -544,7 +544,7 @@ local function on_insert_char_pre(handle)
           debounce_ms,
           0,
           vim.schedule_wrap(function()
-            M.trigger({ ctx = ctx })
+            M.show({ ctx = ctx })
           end)
         )
       end
@@ -791,13 +791,13 @@ function M.enable(enable, client_id, bufnr, opts)
 end
 
 --- @inlinedoc
---- @class vim.lsp.completion.trigger.Opts
+--- @class vim.lsp.completion.show.Opts
 --- @field ctx? lsp.CompletionContext Completion context. Defaults to a trigger kind of `invoked`.
 
 --- Triggers LSP completion once in the current buffer.
 ---
---- @param opts? vim.lsp.completion.trigger.Opts
-function M.trigger(opts)
+--- @param opts? vim.lsp.completion.show.Opts
+function M.show(opts)
   opts = opts or {}
   local ctx = opts.ctx or { triggerKind = protocol.CompletionTriggerKind.Invoked }
   local bufnr = api.nvim_get_current_buf()

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -536,7 +536,7 @@ local function on_insert_char_pre(handle)
       local ctx = { triggerKind = protocol.CompletionTriggerKind.TriggerForIncompleteCompletions }
       if debounce_ms == 0 then
         vim.schedule(function()
-          M.show({ ctx = ctx })
+          M.get({ ctx = ctx })
         end)
       else
         completion_timer = new_timer()
@@ -544,7 +544,7 @@ local function on_insert_char_pre(handle)
           debounce_ms,
           0,
           vim.schedule_wrap(function()
-            M.show({ ctx = ctx })
+            M.get({ ctx = ctx })
           end)
         )
       end
@@ -791,13 +791,13 @@ function M.enable(enable, client_id, bufnr, opts)
 end
 
 --- @inlinedoc
---- @class vim.lsp.completion.show.Opts
+--- @class vim.lsp.completion.get.Opts
 --- @field ctx? lsp.CompletionContext Completion context. Defaults to a trigger kind of `invoked`.
 
 --- Triggers LSP completion once in the current buffer.
 ---
---- @param opts? vim.lsp.completion.show.Opts
-function M.show(opts)
+--- @param opts? vim.lsp.completion.get.Opts
+function M.get(opts)
   opts = opts or {}
   local ctx = opts.ctx or { triggerKind = protocol.CompletionTriggerKind.Invoked }
   local bufnr = api.nvim_get_current_buf()

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -847,7 +847,7 @@ describe('vim.lsp.completion: protocol', function()
     exec_lua(function()
       local win = vim.api.nvim_get_current_win()
       vim.api.nvim_win_set_cursor(win, pos)
-      vim.lsp.completion.show()
+      vim.lsp.completion.get()
     end)
 
     retry(nil, nil, function()
@@ -1153,7 +1153,7 @@ describe('vim.lsp.completion: protocol', function()
         end,
       })
 
-      vim.lsp.completion.show()
+      vim.lsp.completion.get()
 
       return params
     end)

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -847,7 +847,7 @@ describe('vim.lsp.completion: protocol', function()
     exec_lua(function()
       local win = vim.api.nvim_get_current_win()
       vim.api.nvim_win_set_cursor(win, pos)
-      vim.lsp.completion.trigger()
+      vim.lsp.completion.show()
     end)
 
     retry(nil, nil, function()
@@ -1153,7 +1153,7 @@ describe('vim.lsp.completion: protocol', function()
         end,
       })
 
-      vim.lsp.completion.trigger()
+      vim.lsp.completion.show()
 
       return params
     end)


### PR DESCRIPTION
`trigger` is a custom verb not yet used in APIs. Use `show` instead
because the effect is that the completion candidates will be shown.


Other option would be `get` - in light of https://github.com/neovim/neovim/pull/30936 which would add a `on_result` option to `opts` while still defaulting to `vim.fn.complete` to show the candidates