### PR TITLE
feat(defaults): completeopt+=menuone,noselect

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -242,6 +242,7 @@ DEFAULTS
     OSC 133 sequences ("shell integration" or "semantic prompts").
 
 • Options:
+  • 'completeopt' defaults to "menu,noselect,popup".
   • 'diffopt' default includes "linematch:40".
   • 'number', 'relativenumber', 'signcolumn', and 'foldcolumn' are disabled in
     |terminal| buffers. |terminal-config| shows how to change these defaults.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1528,7 +1528,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	order.
 
 						*'completeopt'* *'cot'*
-'completeopt' 'cot'	string	(default "menu,popup")
+'completeopt' 'cot'	string	(default "menu,noselect,popup")
 			global or local to buffer |global-local|
 	A comma-separated list of options for Insert mode completion
 	|ins-completion|.  The supported values are:

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -46,7 +46,7 @@ Defaults                                            *defaults* *nvim-defaults*
 - 'commentstring' defaults to ""
 - 'compatible' is always disabled
 - 'complete' excludes "i"
-- 'completeopt' defaults to "menu,popup"
+- 'completeopt' defaults to "menu,noselect,popup"
 - 'define' defaults to "". The C ftplugin sets it to "^\\s*#\\s*define"
 - 'diffopt' defaults to "internal,filler,closeoff,linematch:40"
 - 'directory' defaults to ~/.local/state/nvim/swap// (|xdg|), auto-created

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1109,7 +1109,7 @@ vim.go.cia = vim.go.completeitemalign
 --- 	    combination with "menu" or "menuone".
 ---
 --- @type string
-vim.o.completeopt = "menu,popup"
+vim.o.completeopt = "menu,noselect,popup"
 vim.o.cot = vim.o.completeopt
 vim.bo.completeopt = vim.o.completeopt
 vim.bo.cot = vim.bo.completeopt

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1483,7 +1483,7 @@ local options = {
     {
       abbreviation = 'cot',
       cb = 'did_set_completeopt',
-      defaults = 'menu,popup',
+      defaults = 'menu,noselect,popup',
       values = {
         'menu',
         'menuone',

--- a/test/functional/ex_cmds/cmd_map_spec.lua
+++ b/test/functional/ex_cmds/cmd_map_spec.lua
@@ -593,6 +593,7 @@ describe('mappings with <Cmd>', function()
   end)
 
   it('works in insert completion (Ctrl-X) mode', function()
+    command('set completeopt-=noselect')
     feed('os<c-x><c-n>')
     screen:expect([[
       some short lines                                                 |

--- a/test/functional/lua/luaeval_spec.lua
+++ b/test/functional/lua/luaeval_spec.lua
@@ -510,6 +510,7 @@ describe('v:lua', function()
 
   it('works in func options', function()
     local screen = Screen.new(60, 8)
+    command('set completeopt-=noselect')
     api.nvim_set_option_value('omnifunc', 'v:lua.mymod.omni', {})
     feed('isome st<c-x><c-o>')
     screen:expect{grid=[[

--- a/test/functional/lua/snippet_spec.lua
+++ b/test/functional/lua/snippet_spec.lua
@@ -18,6 +18,7 @@ local retry = t.retry
 describe('vim.snippet', function()
   before_each(function()
     clear()
+    n.command('set completeopt-=noselect')
     exec_lua(function()
       local function set_snippet_jump(direction, key)
         vim.keymap.set({ 'i', 's' }, key, function()

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -40,6 +40,7 @@ describe('vim.ui_attach', function()
   end
 
   it('can receive popupmenu events', function()
+    n.command('set completeopt-=noselect')
     exec_lua [[ vim.ui_attach(ns, {ext_popupmenu=true}, on_event) ]]
     feed('ifo')
     screen:expect {

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -4140,7 +4140,7 @@ stack traceback:
 
   it('vim.lua_omnifunc', function()
     local screen = Screen.new(60, 5)
-    command [[ set omnifunc=v:lua.vim.lua_omnifunc ]]
+    command [[ set omnifunc=v:lua.vim.lua_omnifunc completeopt-=noselect ]]
 
     -- Note: the implementation is shared with lua command line completion.
     -- More tests for completion in lua/command_line_completion_spec.lua

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -27,6 +27,7 @@ describe('float window', function()
   before_each(function()
     clear()
     command('hi VertSplit gui=reverse')
+    command('set completeopt-=noselect')
   end)
 
   it('behavior', function()

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -25,6 +25,7 @@ describe('ui/ext_popupmenu', function()
         call complete(1, [{'word':'foo', 'abbr':'fo', 'menu':'the foo', 'info':'foo-y', 'kind':'x'}, 'bar', 'spam'])
         return ''
       endfunction
+      set completeopt-=noselect
     ]])
   end)
 
@@ -905,7 +906,12 @@ describe('ui/ext_popupmenu', function()
 end)
 
 describe("builtin popupmenu 'pumblend'", function()
-  before_each(clear)
+  before_each(function()
+    clear()
+    source([[
+      set completeopt-=noselect
+    ]])
+  end)
 
   it('RGB-color', function()
     local screen = Screen.new(60, 14)
@@ -1141,7 +1147,12 @@ describe("builtin popupmenu 'pumblend'", function()
 end)
 
 describe('builtin popupmenu', function()
-  before_each(clear)
+  before_each(function()
+    clear()
+    source([[
+      set completeopt-=noselect
+    ]])
+  end)
 
   local function with_ext_multigrid(multigrid)
     local screen

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -1,6 +1,7 @@
 if exists('s:did_load')
   " Align Nvim defaults to Vim.
   set commentstring=/*\ %s\ */
+  set completeopt-=noselect,popup
   set complete=.,w,b,u,t,i
   set define=^\\s*#\\s*define
   set diffopt=internal,filler,closeoff

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -955,7 +955,7 @@ func Test_complete_with_longest()
   inoremap <buffer> <f3> <cmd>call complete(1, ["iaax", "iaay", "iaaz"])<cr>
 
   " default: insert first match
-  set completeopt&
+  set completeopt& completeopt-=noselect,popup
   call setline(1, ['i'])
   exe "normal Aa\<f3>\<esc>"
   call assert_equal('iaax', getline(1))
@@ -1223,6 +1223,7 @@ endfunc
 " Test for <CTRL-X> <CTRL-Z> stopping completion without changing the match
 func Test_complete_stop()
   new
+  setlocal completeopt-=noselect,popup
   func Save_mode1()
     let g:mode1 = mode(1)
     return ''
@@ -1247,7 +1248,7 @@ func Test_complete_stop()
   call assert_equal('ic', g:mode1)
   call assert_equal('i', g:mode2)
   call assert_equal('aaa bbb ccc aaa bb', getline(1))
-  set completeopt&
+  set completeopt& completeopt-=noselect,popup
   exe "normal A d\<C-N>\<F1>\<C-X>\<C-Z>\<F2>\<Esc>"
   call assert_equal('ic', g:mode1)
   call assert_equal('i', g:mode2)
@@ -1433,6 +1434,7 @@ endfunc
 " <C-X> to cancel the current completion mode.
 func Test_complete_local_expansion()
   new
+  setlocal completeopt-=noselect,popup
   set complete=t
   call setline(1, ['abc', 'def'])
   exe "normal! Go\<C-X>\<C-P>"
@@ -1460,7 +1462,7 @@ func Test_complete_local_expansion()
   " when only one <C-X> is used to interrupt, do normal expansion
   exe "normal! Go\<C-X>\<C-F>\<C-X>\<C-P>"
   call assert_equal("", getline(11))
-  set completeopt&
+  set completeopt& completeopt-=noselect,popup
 
   " using two <C-X> in non-completion mode and restarting the same mode
   exe "normal! God\<C-X>\<C-X>\<C-P>\<C-X>\<C-X>\<C-P>\<C-Y>"
@@ -1497,7 +1499,7 @@ func Test_complete_undo()
   call assert_equal("abo", getline(3))
   undo
   call assert_equal("a", getline(3))
-  set completeopt&
+  set completeopt& completeopt-=noselect,popup
   %d
   " undo for line completion
   call setline(1, ['above that change', 'below that change'])
@@ -1555,7 +1557,7 @@ func Test_complete_items()
   exe "normal! o\<C-R>=CompleteItems(2)\<CR>one\<C-N>\<C-Y>"
   call assert_equal('oNE', getline(4))
   call assert_equal('u8', v:completed_item.user_data)
-  set completeopt&
+  set completeopt& completeopt-=noselect,popup
   exe "normal! o\<C-R>=CompleteItems(3)\<CR>"
   call assert_equal('', getline(5))
   exe "normal! o\<C-R>=CompleteItems(4)\<CR>"

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -512,7 +512,7 @@ func Test_set_completion_string_values()
     call assert_match('unnamed', getcompletion('set clipboard=', 'cmdline')[0])
   endif
   call assert_equal('.', getcompletion('set complete=', 'cmdline')[1])
-  call assert_equal('menu', getcompletion('set completeopt=', 'cmdline')[1])
+  call assert_equal('menuone', getcompletion('set completeopt=', 'cmdline')[1])
   if exists('+completeslash')
     call assert_equal('backslash', getcompletion('set completeslash=', 'cmdline')[1])
   endif


### PR DESCRIPTION
Problem:
`vim.lsp.completion` behaves poorly with the default 'completeopt'.

Solution:
Set `completeopt+=menuone,noselect` by default. This has a small cost for the builtin CTRL-N completion, which is offset by a big cost-reduction for `vim.lsp.completion`.

Fix #30644

Todo:

- [ ] add `menuone`