### PR TITLE
fix(checkhealth): when plugin has nested lua directory

### DIFF
--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -118,7 +118,13 @@ local function filepath_to_healthcheck(path)
     func = 'health#' .. name .. '#check'
     filetype = 'v'
   else
-    local subpath = path:gsub('.*/lua/', '')
+    local rtp = vim
+      .iter(vim.api.nvim_list_runtime_paths())
+      :map(vim.fs.normalize)
+      :find(function(rtp0)
+        return vim.fs.relpath(rtp0, path)
+      end)
+    local subpath = path:gsub('^' .. vim.pesc(rtp .. '/lua/'), '')
     if vim.fs.basename(subpath) == 'health.lua' then
       -- */health.lua
       name = vim.fs.dirname(subpath)

--- a/test/functional/fixtures/lua/test_plug/lua/health.lua
+++ b/test/functional/fixtures/lua/test_plug/lua/health.lua
@@ -1,0 +1,8 @@
+local M = {}
+
+M.check = function()
+  vim.health.start('nested lua/ directory')
+  vim.health.ok('everything is ok')
+end
+
+return M

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -212,6 +212,18 @@ describe('vim.health', function()
       n.expect([[
       ERROR: No healthchecks found.]])
     end)
+
+    it('nested lua/ directory', function()
+      command('checkhealth lua')
+      n.expect([[
+
+      ==============================================================================
+      test_plug.lua:                         require("test_plug.lua.health").check()
+
+      nested lua/ directory ~
+      - OK everything is ok
+      ]])
+    end)
   end)
 end)
 


### PR DESCRIPTION
Problem: `:checkhealth` fails if plugin has nested "lua" directory

Solution: trim `{runtimepath}/lua` from fullpath to get subpath (`./**/{health, health/init.lua}`)

Fix https://github.com/neovim/neovim/issues/32913.
