### PR TITLE
perf(lsp): don't construct potentially expensive strings

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -366,6 +366,7 @@ PERFORMANCE
   significantly improving |treesitter-highlight| performance.
 • Treesitter injection query iteration is now asynchronous, making edits in
   large buffers with combined injections much quicker.
+• 10x reduction in blocking time when attaching an LSP to a large buffer.
 
 PLUGINS
 

--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -278,10 +278,8 @@ function Client:encode_and_send(payload)
   if self.transport:is_closing() then
     return false
   end
-  local jsonstr = assert(
-    vim.json.encode(payload),
-    string.format("Couldn't encode payload '%s'", vim.inspect(payload))
-  )
+  local jsonstr = vim.json.encode(payload)
+
   self.transport:write(format_message_with_content_length(jsonstr))
   return true
 end


### PR DESCRIPTION
## Problem

https://github.com/neovim/neovim/commit/3f788e73 introduced a performance regression which constructed a very large string if opening a very large buffer with LSP attached. This string is expensive and actually not even necessary, since `vim.json.encode()` never returns a falsy value. The string's creation led to 1-2 seconds of blocking time upon attaching an LSP to a large buffer.

## Solution

Remove the `assert()` and string construction.

Closes #32740 (which was misdiagnosed)

## Benchmark

With the following simple test measuring execution time, in ms:

```diff
diff --git a/runtime/lua/vim/lsp/rpc.lua b/runtime/lua/vim/lsp/rpc.lua
index a0d1fe776b..e4cea96e68 100644
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -278,10 +278,15 @@ function Client:encode_and_send(payload)
   if self.transport:is_closing() then
     return false
   end
+  local time = vim.uv.hrtime()
   local jsonstr = assert(
     vim.json.encode(payload),
     string.format("Couldn't encode payload '%s'", vim.inspect(payload))
   )
+  if payload.method == protocol.Methods.textDocument_didOpen then
+    vim.print((vim.uv.hrtime() - time) / 1000000, '\n')
+  end
+
   self.transport:write(format_message_with_content_length(jsonstr))
   return true
 end
```

Before: `1115.092449`

---

```diff
diff --git a/runtime/lua/vim/lsp/rpc.lua b/runtime/lua/vim/lsp/rpc.lua
index d31d94cab7..1f41100dc9 100644
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -278,7 +278,11 @@ function Client:encode_and_send(payload)
   if self.transport:is_closing() then
     return false
   end
+  local time = vim.uv.hrtime()
   local jsonstr = vim.json.encode(payload)
+  if payload.method == protocol.Methods.textDocument_didOpen then
+    vim.print((vim.uv.hrtime() - time) / 1000000, '\n')
+  end
 
   self.transport:write(format_message_with_content_length(jsonstr))
   return true
```

After: `94.136693`