### PR TITLE
docs(lsp): update server handler example

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -364,7 +364,7 @@ Handlers can be set by (in increasing priority):
     vim.lsp.start {
       ..., -- Other configuration omitted.
       handlers = {
-        ['textDocument/publishDiagnostics'] = my_custom_server_definition
+        ['textDocument/publishDiagnostics'] = my_custom_diagnostics_handler
       },
     }
 


### PR DESCRIPTION
In 9b357e30

Handler key was changed but not the handler function name inside the `vim.lsp.start` snippet
```diff
-    vim.lsp.handlers["textDocument/definition"] = my_custom_default_definition
+   vim.lsp.handlers['textDocument/publishDiagnostics'] = my_custom_diagnostics_handler


     vim.lsp.start {
       ..., -- Other configuration omitted.
       handlers = {
-        ["textDocument/definition"] = my_custom_server_definition
+        ['textDocument/publishDiagnostics'] = my_custom_server_definition
       },
     }
```

