### PR TITLE
fix(runtime): E15: Invalid expression in lua file when `gf`

### DIFF
--- a/runtime/ftplugin/lua.lua
+++ b/runtime/ftplugin/lua.lua
@@ -1,7 +1,7 @@
 -- use treesitter over syntax
 vim.treesitter.start()
 
-vim.bo.includeexpr = 'v:lua.require"vim._ftplugin.lua".includeexpr()'
+vim.bo.includeexpr = [[v:lua.require'vim._ftplugin.lua'.includeexpr(v:fname)]]
 vim.bo.omnifunc = 'v:lua.vim.lua_omnifunc'
 vim.wo[0][0].foldexpr = 'v:lua.vim.treesitter.foldexpr()'
 


### PR DESCRIPTION
Problem:
after https://github.com/neovim/neovim/pull/32719, `gf` error in lua:
```
E15: Invalid expression: "v:lua.require"vim._ftplugin.lua".includeexpr()"
E447: Can't find file "vim._ftplugin.lua" in path
```

Solution:
* use single quote (no idea why there's two pair double quote in expression).
* add missing `v:fname`.

To quickly reproduce:
Type `gf` after:
```
VIMRUNTIME=runtime nvim --clean runtime/ftplugin/lua.lua +'/vim._ftplugin.lua' +'norm! n'
```