### PR TITLE
filetype: uv.lock file is not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1848,6 +1848,7 @@ local filename = {
   ['pending.data'] = 'taskdata',
   ['completed.data'] = 'taskdata',
   ['undo.data'] = 'taskdata',
+  ['uv.lock'] = 'toml',
   ['.tclshrc'] = 'tcl',
   ['.wishrc'] = 'tcl',
   ['.tclsh-history'] = 'tcl',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -816,7 +816,7 @@ func s:GetFilenameChecks() abort
     \ 'tla': ['file.tla'],
     \ 'tli': ['file.tli'],
     \ 'tmux': ['tmuxfile.conf', '.tmuxfile.conf', '.tmux-file.conf', '.tmux.conf', 'tmux-file.conf', 'tmux.conf', 'tmux.conf.local'],
-    \ 'toml': ['file.toml', 'Gopkg.lock', 'Pipfile', '/home/user/.cargo/config', '.black',
+    \ 'toml': ['file.toml', 'Gopkg.lock', 'uv.lock', 'Pipfile', '/home/user/.cargo/config', '.black',
     \          'any/containers/containers.conf', 'any/containers/containers.conf.d/file.conf',
     \          'any/containers/containers.conf.modules/file.conf', 'any/containers/containers.conf.modules/any/file.conf',
     \          'any/containers/registries.conf', 'any/containers/registries.conf.d/file.conf',


### PR DESCRIPTION
[nv](https://docs.astral.sh/uv/): A single tool to replace pip, pip-tools, pipx, poetry, pyenv, twine, virtualenv, and more.
