### PR TITLE
fix(help): remove runnable code virtual text

### DIFF
--- a/runtime/ftplugin/help.lua
+++ b/runtime/ftplugin/help.lua
@@ -82,9 +82,7 @@ local query = vim.treesitter.query.parse(
 ]]
 )
 local root = parser:parse()[1]:root()
-local run_message_ns = vim.api.nvim_create_namespace('nvim.vimdoc.run_message')
 
-vim.api.nvim_buf_clear_namespace(0, run_message_ns, 0, -1)
 for _, match, metadata in query:iter_matches(root, 0, 0, -1) do
   for id, nodes in pairs(match) do
     local name = query.captures[id]
@@ -92,9 +90,6 @@ for _, match, metadata in query:iter_matches(root, 0, 0, -1) do
     local start, _, end_ = node:parent():range()
 
     if name == 'code' then
-      vim.api.nvim_buf_set_extmark(0, run_message_ns, start, 0, {
-        virt_text = { { 'Run with `g==`', 'LspCodeLens' } },
-      })
       local code = vim.treesitter.get_node_text(node, 0)
       local lang_node = match[metadata[id].lang][1] --[[@as TSNode]]
       local lang = vim.treesitter.get_node_text(lang_node, 0)


### PR DESCRIPTION
Problem: Virtual text indicating runnable code examples in help files is
intrusive and non-configurable (and often denotes actually non-working
examples).

Solution: Remove virtual text.

Can be reverted and iterated on after release, but in its current form it's too raw for public consumption.

(Note that the feature itself remains; this is just about the annotation.)