### PR TITLE
feat(defaults): enable treesitter for all included parsers

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -215,6 +215,10 @@ DEFAULTS
 
 • Highlighting:
   • Improved styling of :checkhealth and :help buffers.
+  • Enabled treesitter highlighting for all builtin |treesitter-parsers|:
+    • C
+    • Vimscript
+    • Markdown
 
 • Mappings:
   • |grn| in Normal mode maps to |vim.lsp.buf.rename()|

--- a/runtime/ftplugin/c.lua
+++ b/runtime/ftplugin/c.lua
@@ -1,3 +1,6 @@
+-- Use treesitter.
+vim.treesitter.start()
+
 -- These are the default option values in Vim, but not in Nvim, so must be set explicitly.
 vim.bo.commentstring = '// %s'
 vim.bo.define = '^\\s*#\\s*define'

--- a/runtime/ftplugin/markdown.lua
+++ b/runtime/ftplugin/markdown.lua
@@ -1,3 +1,6 @@
+-- Use treesitter.
+vim.treesitter.start()
+
 vim.keymap.set('n', 'gO', function()
   require('vim.treesitter._headings').show_toc()
 end, { buffer = 0, silent = true, desc = 'Show table of contents for current buffer' })

--- a/runtime/ftplugin/vim.lua
+++ b/runtime/ftplugin/vim.lua
@@ -1,0 +1,2 @@
+-- Use treesitter.
+vim.treesitter.start()


### PR DESCRIPTION
Problem:
We ship parsers for c/vimscript but don't enable them by default. This is confusing since we enable ts for the other shipped parsers (lua/vimdoc/query).

Solution:
Enable treesitter for all shipped parsers.

Edit: markdown enabled in https://github.com/neovim/neovim/pull/37907

cc @clason 