### PR TITLE
fix: E29 error when `<C-R>.` in RelWithDebInfo build

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2753,13 +2753,12 @@ int stuff_inserted(int c, int count, int no_esc)
 }
 
 String *get_last_insert(void)
-  FUNC_ATTR_PURE
 {
   static String insert = STRING_INIT;
 
   insert = last_insert.data == NULL ? NULL_STRING : (String){
-    insert.data = last_insert.data + last_insert_skip,
-    insert.size = last_insert.size - (size_t)last_insert_skip,
+    .data = last_insert.data + last_insert_skip,
+    .size = last_insert.size - (size_t)last_insert_skip,
   };
 
   return &insert;


### PR DESCRIPTION
Problem: `<C-R>.` show `E29: No inserted text yet` when build as
`RelWithDebInfo`. since https://github.com/neovim/neovim/commit/59d8d50c5bbcfb9215eddc0f4314fdd1cce55422.
But interesting this works well in `Debug` build.

Solution: remove `FUNC_ATTR_PURE`.

Reproduction: `nvim -u NONE -i NONE`, then type `iabc<Esc>a<C-R>.`
