### PR TITLE
fix(runtime): gO always says "Help TOC"

### DIFF
--- a/runtime/ftplugin/checkhealth.lua
+++ b/runtime/ftplugin/checkhealth.lua
@@ -1,6 +1,6 @@
 vim.keymap.set('n', 'gO', function()
   require('vim.treesitter._headings').show_toc()
-end, { buffer = 0, silent = true, desc = 'Show table of contents for current buffer' })
+end, { buffer = 0, silent = true, desc = 'Show an Outline of the current buffer' })
 
 vim.keymap.set('n', ']]', function()
   require('vim.treesitter._headings').jump({ count = 1, level = 1 })

--- a/runtime/ftplugin/help.lua
+++ b/runtime/ftplugin/help.lua
@@ -57,7 +57,7 @@ end
 
 vim.keymap.set('n', 'gO', function()
   require('vim.treesitter._headings').show_toc()
-end, { buffer = 0, silent = true, desc = 'Show table of contents for current buffer' })
+end, { buffer = 0, silent = true, desc = 'Show an Outline of the current buffer' })
 
 vim.keymap.set('n', ']]', function()
   require('vim.treesitter._headings').jump({ count = 1 })

--- a/runtime/ftplugin/markdown.lua
+++ b/runtime/ftplugin/markdown.lua
@@ -1,6 +1,6 @@
 vim.keymap.set('n', 'gO', function()
   require('vim.treesitter._headings').show_toc()
-end, { buffer = 0, silent = true, desc = 'Show table of contents for current buffer' })
+end, { buffer = 0, silent = true, desc = 'Show an Outline of the current buffer' })
 
 vim.keymap.set('n', ']]', function()
   require('vim.treesitter._headings').jump({ count = 1 })

--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -800,7 +800,7 @@ function M.show_toc()
   end
 
   fn.setloclist(0, toc, ' ')
-  fn.setloclist(0, {}, 'a', { title = 'Man TOC' })
+  fn.setloclist(0, {}, 'a', { title = 'Table of contents' })
   vim.cmd.lopen()
   vim.w.qf_toc = bufname
 end

--- a/runtime/lua/vim/treesitter/_headings.lua
+++ b/runtime/lua/vim/treesitter/_headings.lua
@@ -87,7 +87,7 @@ local get_headings = vim.func._memoize(hash_tick, function(bufnr)
   return headings
 end)
 
---- Show a table of contents for the help buffer in a loclist
+--- Shows an Outline (table of contents) of the current buffer, in the loclist.
 function M.show_toc()
   local bufnr = api.nvim_get_current_buf()
   local headings = get_headings(bufnr)
@@ -104,7 +104,7 @@ function M.show_toc()
     end
   end
   vim.fn.setloclist(0, headings, ' ')
-  vim.fn.setloclist(0, {}, 'a', { title = 'Help TOC' })
+  vim.fn.setloclist(0, {}, 'a', { title = 'Table of contents' })
   vim.cmd.lopen()
 end
 


### PR DESCRIPTION
Problem:
gO always says "Help TOC".

Solution:
Use a generic title.