### PR TITLE
vim-patch:9.1.1222: using wrong length for last inserted string

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -3849,7 +3849,8 @@ void ex_display(exarg_T *eap)
   }
 
   // display last inserted text
-  if ((p = get_last_insert()->data) != NULL
+  String insert = get_last_insert();
+  if ((p = insert.data) != NULL
       && (arg == NULL || vim_strchr(arg, '.') != NULL) && !got_int
       && !message_filtered(p)) {
     msg_puts("\n  c  \".   ");


### PR DESCRIPTION
#### vim-patch:9.1.1222: using wrong length for last inserted string

Problem:  using wrong length for last inserted string
          (Christ van Willegen, after v9.1.1212)
Solution: use the correct length in get_last_insert_save(), make
          get_last_insert() return a string_T (John Marriott)

closes: vim/vim#16921

https://github.com/vim/vim/commit/8ac0f73eb1e0e6128dd21eb294d12b83b615f05a

N/A patches:
vim-patch:9.1.1129: missing out-of-memory test in buf_write()
vim-patch:9.1.1218: missing out-of-memory check in filepath.c

Co-authored-by: John Marriott <basilisk@internode.on.net>