### PR TITLE
feat(lsp): add support for ListOpts opts to call hierarchy

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1663,18 +1663,24 @@ implementation({opts})                          *vim.lsp.buf.implementation()*
     Parameters: ~
       • {opts}  (`vim.lsp.LocationOpts?`) See |vim.lsp.LocationOpts|.
 
-incoming_calls()                                *vim.lsp.buf.incoming_calls()*
+incoming_calls({opts})                          *vim.lsp.buf.incoming_calls()*
     Lists all the call sites of the symbol under the cursor in the |quickfix|
     window. If the symbol can resolve to multiple items, the user can pick one
     in the |inputlist()|.
 
+    Parameters: ~
+      • {opts}  (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.
+
 list_workspace_folders()                *vim.lsp.buf.list_workspace_folders()*
     List workspace folders.
 
-outgoing_calls()                                *vim.lsp.buf.outgoing_calls()*
+outgoing_calls({opts})                          *vim.lsp.buf.outgoing_calls()*
     Lists all the items that are called by the symbol under the cursor in the
     |quickfix| window. If the symbol can resolve to multiple items, the user
     can pick one in the |inputlist()|.
+
+    Parameters: ~
+      • {opts}  (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.
 
 references({context}, {opts})                       *vim.lsp.buf.references()*
     Lists all the references to the symbol under the cursor in the quickfix
@@ -1724,13 +1730,14 @@ type_definition({opts})                        *vim.lsp.buf.type_definition()*
     Parameters: ~
       • {opts}  (`vim.lsp.LocationOpts?`) See |vim.lsp.LocationOpts|.
 
-typehierarchy({kind})                            *vim.lsp.buf.typehierarchy()*
+typehierarchy({kind}, {opts})                    *vim.lsp.buf.typehierarchy()*
     Lists all the subtypes or supertypes of the symbol under the cursor in the
     |quickfix| window. If the symbol can resolve to multiple items, the user
     can pick one using |vim.ui.select()|.
 
     Parameters: ~
       • {kind}  (`"subtypes"|"supertypes"`)
+      • {opts}  (`vim.lsp.ListOpts?`) See |vim.lsp.ListOpts|.
 
 workspace_symbol({query}, {opts})             *vim.lsp.buf.workspace_symbol()*
     Lists all symbols in the current workspace in the quickfix window.


### PR DESCRIPTION
Adds support for `vim.lsp.ListOpts` options (`on_list` and `loclist`) to
`vim.lsp.buf.incoming_calls`, `vim.lsp.buf.outgoing_calls` and `vim.lsp.buf.typehierarchy`.
