### PR TITLE
fix(options): fix 'winborder' accepting multiple string values

### DIFF
--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -10190,7 +10190,6 @@ local options = {
     },
     {
       defaults = { if_true = '' },
-      cb = 'did_set_winborder',
       values = { '', 'double', 'single', 'shadow', 'rounded', 'solid', 'none' },
       desc = [=[
         Defines the default border style of floating windows. The default value

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -2005,15 +2005,6 @@ const char *did_set_winhighlight(optset_T *args)
   return NULL;
 }
 
-/// The 'winborder' option is changed.
-const char *did_set_winborder(optset_T *args)
-{
-  if (opt_strings_flags(p_winbd, opt_winborder_values, NULL, true) != OK) {
-    return e_invarg;
-  }
-  return NULL;
-}
-
 int expand_set_winhighlight(optexpand_T *args, int *numMatches, char ***matches)
 {
   return expand_set_opt_generic(args, get_highlight_name, numMatches, matches);

--- a/test/old/testdir/gen_opt_test.vim
+++ b/test/old/testdir/gen_opt_test.vim
@@ -75,7 +75,7 @@ let test_values = {
       \ 'shada': [['', '''50', '"30'], ['xxx']],
       \ 'termpastefilter': [['BS', 'HT', 'FF', 'ESC', 'DEL', 'C0', 'C1', 'C0,C1'],
       \		['xxx', 'C0,C1,xxx']],
-      \ 'winborder': [['rounded', 'none', 'single', 'solid'], ['xxx']],
+      \ 'winborder': [['rounded', 'none', 'single', 'solid'], ['xxx', 'none,solid']],
       \ 'winhighlight': [['', 'a:b', 'a:', 'a:b,c:d'],
       \		['a', ':', ':b', 'a:b:c', 'a:/', '/:b', ',', 'a:b,,', 'a:b,c']],
       \


### PR DESCRIPTION
Problem:  'winborder' accepting multiple string values.
Solution: Use the fallback did_set_str_generic() callback instead of
          did_set_winborder() which calls opt_strings_flags() with
          incorrect last argument.
