### PR TITLE
fix(diagnostic): clear autocmd only for valid buf for virtual_lines handler

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1952,8 +1952,8 @@ M.handlers.virtual_lines = {
       diagnostic_cache_extmarks[bufnr][ns.user_data.virt_lines_ns] = {}
       if api.nvim_buf_is_valid(bufnr) then
         api.nvim_buf_clear_namespace(bufnr, ns.user_data.virt_lines_ns, 0, -1)
+        api.nvim_clear_autocmds({ group = ns.user_data.virt_lines_augroup, buffer = bufnr })
       end
-      api.nvim_clear_autocmds({ group = ns.user_data.virt_lines_augroup, buffer = bufnr })
     end
   end,
 }


### PR DESCRIPTION
This is basically #32861 for `virtual_lines` handler.

I don't have the error message right now. But I can add it if needed.

This is my first contribution. I'm glad to change this MR if there's something missing.
Thank you!