### PR TITLE
fix(api): allow split windows when 'winborder' is set

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -1273,12 +1273,19 @@ static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fco
     }
   }
 
-  if (HAS_KEY_X(config, border) || *p_winbd != NUL) {
+  if (HAS_KEY_X(config, border)) {
     if (is_split) {
       api_set_error(err, kErrorTypeValidation, "non-float cannot have 'border'");
       goto fail;
     }
     Object style = config->border.type != kObjectTypeNil ? config->border : CSTR_AS_OBJ(p_winbd);
+    parse_border_style(style, fconfig, err);
+    if (ERROR_SET(err)) {
+      goto fail;
+    }
+  } else if (!is_split && *p_winbd != NUL) {
+    // Only apply global winborder to floating windows
+    Object style = CSTR_AS_OBJ(p_winbd);
     parse_border_style(style, fconfig, err);
     if (ERROR_SET(err)) {
       goto fail;

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -10155,6 +10155,23 @@ describe('float window', function()
 
       -- it is currently not supported.
       eq('Vim(set):E474: Invalid argument: winborder=custom', pcall_err(command, 'set winborder=custom'))
+
+      -- Try to create a split window with winborder set
+      local result = exec_lua([[
+        local win_id = vim.api.nvim_open_win(0, false, {
+           split = 'right',
+           win = 0
+         })
+         return {
+           success = win_id > 0,
+           is_floating = vim.api.nvim_win_get_config(win_id).relative ~= ''
+         }
+       ]])
+
+      -- Should succeed
+      eq(true, result.success)
+      -- Should NOT be a floating window
+      eq(false, result.is_floating)
     end)
   end
 


### PR DESCRIPTION
Problem: nvim_open_win() fails to create split windows when global 'winborder'
         is non-empty, generating "non-float cannot have 'border'" error.

Solution: Only apply global winborder to floating windows, not split windows.