### PR TITLE
fix(api): don't use 'winborder' when reconfiguring float

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -1280,7 +1280,7 @@ static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fco
       goto fail;
     }
     border_style = config->border;
-  } else if (*p_winborder != NUL) {
+  } else if (*p_winborder != NUL && (wp == NULL || !wp->w_floating)) {
     border_style = CSTR_AS_OBJ(p_winborder);
   }
   if (border_style.type != kObjectTypeNil) {

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -1907,6 +1907,38 @@ describe('API/win', function()
   end)
 
   describe('set_config', function()
+    it("uses 'winborder' when converting a split to a floating window", function()
+      api.nvim_set_option_value('winborder', 'single', {})
+      command('split')
+      local winid = api.nvim_get_current_win()
+      -- Convert split to float without specifying border
+      api.nvim_win_set_config(winid, {
+        relative = 'editor',
+        row = 2,
+        col = 2,
+        width = 10,
+        height = 5,
+      })
+      local config = api.nvim_win_get_config(winid)
+      eq('┌', config.border[1])
+    end)
+
+    it('erases border of a floating window when converting to split window', function()
+      api.nvim_set_option_value('winborder', 'single', {})
+      local winid = api.nvim_open_win(api.nvim_create_buf(false, false), false, {
+        relative = 'editor',
+        row = 2,
+        col = 2,
+        width = 10,
+        height = 5,
+      })
+      local config = api.nvim_win_get_config(winid)
+      eq('┌', config.border[1])
+      api.nvim_win_set_config(winid, { split = 'right', win = 0 })
+      config = api.nvim_win_get_config(winid)
+      eq(nil, config.border)
+    end)
+
     it('moves a split into a float', function()
       local win = api.nvim_open_win(0, true, {
         vertical = false,

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -10088,7 +10088,7 @@ describe('float window', function()
       -- respect config.border
       command('set winborder=rounded')
       config.border = 'single'
-      api.nvim_open_win(buf, false, config)
+      local winid = api.nvim_open_win(buf, false, config)
       if multigrid then
         screen:expect({
           grid = [[
@@ -10153,6 +10153,11 @@ describe('float window', function()
         ]])
       end
 
+      -- don't use winborder when reconfig a floating window
+      config.border = nil
+      api.nvim_win_set_config(winid, config)
+      screen:expect_unchanged()
+      command('fclose!')
       -- it is currently not supported.
       eq('Vim(set):E474: Invalid argument: winborder=custom', pcall_err(command, 'set winborder=custom'))
     end)


### PR DESCRIPTION
Problem: reconfig-ing a floatwin applies the global 'winborder'.

Solution:
- ignore 'winborder' when reconfig-ing a floatwin.
- apply 'winborder' when converting a "split" win to a "float" win.

Fix #32974