### PR TITLE
feat(lsp.completion): user can control match behavior

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1886,6 +1886,7 @@ Example: activate LSP-driven auto-completion: >lua
                         `triggerCharacters`.
       • {convert}?      (`fun(item: lsp.CompletionItem): table`) Transforms an
                         LSP CompletionItem to |complete-items|.
+      • {fuzzyopts}?    (`table`) vim.fn.matchfuzzy.dict
 
 
                                                  *vim.lsp.completion.enable()*

--- a/runtime/lua/vim/_meta/builtin_types.lua
+++ b/runtime/lua/vim/_meta/builtin_types.lua
@@ -297,3 +297,8 @@
 --- A list of dictionaries with information about
 --- undo blocks.
 --- @field entries vim.fn.undotree.entry[]
+
+--- @class vim.fn.matchfuzzy.dict
+--- @field matchseq? any
+--- @field limit? integer
+--- @field camelcase? boolean


### PR DESCRIPTION
Problem: missing opts of matchfuzzy when fuzzy exists in cot.
Solution: add fuzzyopts in vim.lps.completion.BufferOpts

Fix https://github.com/neovim/neovim/issues/32968