### PR TITLE
fix(messages): incorrect error message splitting and kind

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -368,7 +368,7 @@ static void api_wrapper(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   Object result = handler.fn(VIML_INTERNAL_CALL, args, &arena, &err);
 
   if (ERROR_SET(&err)) {
-    semsg_multiline(e_api_error, err.msg);
+    semsg_multiline("emsg", e_api_error, err.msg);
     goto end;
   }
 
@@ -6414,12 +6414,11 @@ static void f_rpcrequest(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     if (chan) {
       name = get_client_info(chan, "name");
     }
-    msg_ext_set_kind("rpc_error");
     if (name) {
-      semsg_multiline("Error invoking '%s' on channel %" PRIu64 " (%s):\n%s",
+      semsg_multiline("rpc_error", "Error invoking '%s' on channel %" PRIu64 " (%s):\n%s",
                       method, chan_id, name, err.msg);
     } else {
-      semsg_multiline("Error invoking '%s' on channel %" PRIu64 ":\n%s",
+      semsg_multiline("rpc_error", "Error invoking '%s' on channel %" PRIu64 ":\n%s",
                       method, chan_id, err.msg);
     }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7804,7 +7804,7 @@ static void ex_checkhealth(exarg_T *eap)
       emsg(_("E5009: Invalid 'runtimepath'"));
     }
   }
-  semsg_multiline(err.msg);
+  semsg_multiline("emsg", err.msg);
   api_clear_error(&err);
 }
 

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -3254,7 +3254,7 @@ bool map_execute_lua(bool may_repeat)
   Array args = ARRAY_DICT_INIT;
   nlua_call_ref(ref, NULL, args, kRetNilBool, NULL, &err);
   if (ERROR_SET(&err)) {
-    semsg_multiline("E5108: %s", err.msg);
+    semsg_multiline("emsg", "E5108: %s", err.msg);
     api_clear_error(&err);
   }
 

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -160,8 +160,7 @@ void nlua_error(lua_State *const lstate, const char *const msg)
     fprintf(stderr, msg, (int)len, str);
     fprintf(stderr, "\n");
   } else {
-    msg_ext_set_kind("lua_error");
-    semsg_multiline(msg, (int)len, str);
+    semsg_multiline("lua_error", msg, (int)len, str);
   }
 
   lua_pop(lstate, 1);
@@ -191,16 +190,15 @@ static void nlua_luv_error_event(void **argv)
 {
   char *error = (char *)argv[0];
   luv_err_t type = (luv_err_t)(intptr_t)argv[1];
-  msg_ext_set_kind("lua_error");
   switch (type) {
   case kCallback:
-    semsg_multiline("Error executing callback:\n%s", error);
+    semsg_multiline("lua_error", "Error executing callback:\n%s", error);
     break;
   case kThread:
-    semsg_multiline("Error in luv thread:\n%s", error);
+    semsg_multiline("lua_error", "Error in luv thread:\n%s", error);
     break;
   case kThreadCallback:
-    semsg_multiline("Error in luv callback, thread:\n%s", error);
+    semsg_multiline("lua_error", "Error in luv callback, thread:\n%s", error);
     break;
   default:
     break;

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -2064,7 +2064,7 @@ static void do_exrc_initialization(void)
       xfree(str);
       if (ERROR_SET(&err)) {
         semsg("Error detected while processing %s:", VIMRC_LUA_FILE);
-        semsg_multiline(err.msg);
+        semsg_multiline("emsg", err.msg);
         api_clear_error(&err);
       }
     }

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -1664,7 +1664,7 @@ char *eval_map_expr(mapblock_T *mp, int c)
     }
     api_free_object(ret);
     if (ERROR_SET(&err)) {
-      semsg_multiline("E5108: %s", err.msg);
+      semsg_multiline("emsg", "E5108: %s", err.msg);
       api_clear_error(&err);
     }
   } else {

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -362,7 +362,7 @@ describe('vim.ui_attach', function()
       messages = {
         {
           content = { { 'Press ENTER or type command to continue', 100, 18 } },
-          history = true,
+          history = false,
           kind = 'return_prompt',
         },
       },

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -181,19 +181,11 @@ describe('ui/ext_messages', function()
       cmdline = { { abort = false } },
       messages = {
         {
-          content = { { 'Error detected while processing :', 9, 6 } },
+          content = {
+            { 'Error detected while processing :\nE605: Exception not caught: foo', 9, 6 },
+          },
           history = true,
           kind = 'emsg',
-        },
-        {
-          content = { { 'E605: Exception not caught: foo', 9, 6 } },
-          history = true,
-          kind = 'emsg',
-        },
-        {
-          content = { { 'Press ENTER or type command to continue', 6, 18 } },
-          history = false,
-          kind = 'return_prompt',
         },
       },
     }


### PR DESCRIPTION
Problem:  Message kind logic for emitting an error message is convoluted
          and still results in emitting an unfinished message earlier than
          wanted.
Solution: Ensure emsg_multiline() always sets the kind wanted by the caller
          and doesn't isn't unset to logic for emitting the source message.
          Caller is responsible for making sure multiple message chunks are
          not emitted as multiple events by setting `msg_ext_skip_flush`...

Fix #32933