### PR TITLE
feat(ftplugin): Lua keywordprg [skip ci]

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -127,7 +127,8 @@ LSP
 
 LUA
 
-• todo
+• |K| in Lua buffers and Lua code block in |help| buffers can open |help|
+documentation for the symbol under the cursor.
 
 OPTIONS
 

--- a/runtime/ftplugin/help.lua
+++ b/runtime/ftplugin/help.lua
@@ -112,7 +112,15 @@ vim.keymap.set('n', 'g==', function()
   end
 end, { buffer = true })
 
+vim.bo.keywordprg = ':HelpKeywordPrg'
+
+vim.api.nvim_buf_create_user_command(0, 'HelpKeywordPrg', function()
+  require('vim._ftplugin.help').keywordprg()
+end, { nargs = '*' })
+
 vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '')
   .. '\n sil! exe "nunmap <buffer> gO" | sil! exe "nunmap <buffer> g=="'
   .. '\n sil! exe "nunmap <buffer> ]]" | sil! exe "nunmap <buffer> [["'
+  .. '\n sil! setl keywordprg<'
+  .. '\n delcommand -buffer HelpKeywordPrg'
 vim.b.undo_ftplugin = vim.b.undo_ftplugin .. ' | call v:lua.vim.treesitter.stop()'

--- a/runtime/ftplugin/lua.lua
+++ b/runtime/ftplugin/lua.lua
@@ -4,6 +4,11 @@ vim.treesitter.start()
 vim.bo.includeexpr = [[v:lua.require'vim._ftplugin.lua'.includeexpr(v:fname)]]
 vim.bo.omnifunc = 'v:lua.vim.lua_omnifunc'
 vim.wo[0][0].foldexpr = 'v:lua.vim.treesitter.foldexpr()'
+vim.bo.keywordprg = ':LuaKeywordPrg'
+
+vim.api.nvim_buf_create_user_command(0, 'LuaKeywordPrg', function()
+  require('vim._ftplugin.lua').keywordprg()
+end, { nargs = '*' })
 
 vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '')
   .. '\n call v:lua.vim.treesitter.stop()'

--- a/runtime/lua/vim/_ftplugin/help.lua
+++ b/runtime/lua/vim/_ftplugin/help.lua
@@ -1,0 +1,17 @@
+local M = {}
+
+function M.keywordprg()
+  local captures = vim.treesitter.get_captures_at_pos(0, vim.fn.line('.') - 1, vim.fn.col('.'))
+  if #captures == 0 then return end
+  local lang = captures[#captures].lang
+  if lang == 'lua' then
+    local temp_isk = vim.bo.iskeyword
+    vim.cmd('setl isk<')
+    require('vim._ftplugin.lua').keywordprg()
+    vim.bo.iskeyword = temp_isk
+  else
+    vim.cmd.help(vim.fn.expand('<cword>'))
+  end
+end
+
+return M

--- a/runtime/lua/vim/_ftplugin/lua.lua
+++ b/runtime/lua/vim/_ftplugin/lua.lua
@@ -17,4 +17,82 @@ function M.includeexpr(module)
   return modInfo and modInfo.modpath or module
 end
 
+---@param keyword string
+---@param opts {prefix: string?, suffix: string?, regex: string?, pattern: string?, on_keyword: function?}
+---@return boolean
+local function lookup_help(keyword, opts)
+  if opts.regex and opts.pattern then
+    error("Cannot use both regex and pattern options", vim.log.levels.ERROR)
+    return false
+  end
+  if opts.regex then
+    local match_start, match_end = vim.regex(opts.regex):match_str(keyword)
+    if not match_start then
+      return false
+    end
+    keyword = keyword:sub(match_start + 1, match_end)
+  elseif opts.pattern then
+    keyword = keyword:match(opts.pattern)
+  elseif opts.on_keyword then
+    keyword = opts.on_keyword(keyword)
+  end
+  if keyword and keyword ~= "" then
+    if opts.prefix then
+      keyword = opts.prefix .. keyword
+    end
+    if opts.suffix then
+      keyword = keyword .. opts.suffix
+    end
+    return pcall(vim.cmd.help, vim.fn.escape(keyword, " []*?"))
+  end
+  return false
+end
+
+function M.keywordprg()
+  local temp_isk = vim.o.iskeyword
+  vim.cmd("set iskeyword+=.,#")
+  ---@diagnostic disable-next-line: assign-type-mismatch
+  local _, cword = pcall(vim.fn.expand, "<cword>") ---@type boolean, string
+  vim.o.iskeyword = temp_isk
+  if not cword or #cword == 0 then return end
+  local list_of_opts = {
+    -- Nvim API
+    { regex = [[nvim_.\+]], suffix = '()' },
+    -- Vimscript functions
+    { regex = [[\(vim\.fn\.\)\@<=\w\+]], suffix = '()' },
+    -- Options
+    { regex = [[\(vim\.\(o\|go\|bo\|wo\|opt\|opt_local\|opt_global\)\.\)\@<=\w\+]], prefix = "'", suffix = "'" },
+    -- Vimscript variables
+    {
+      ---@param keyword string
+      ---@return string?
+      on_keyword = function(keyword)
+        local match_start, match_end = vim.regex([[\(vim\.\(g\|b\|w\|v\|t\)\.\)\@<=\w\+]]):match_str(keyword)
+        if not match_start then return end
+        return keyword:sub(match_start - 1, match_start - 1) .. ':' .. keyword:sub(match_start + 1, match_end)
+      end
+    },
+    -- Ex commands
+    { regex = [[\(vim\.cmd\.\)\@<=\w\+]], prefix = ":" },
+    -- Luv
+    { regex = [[\(vim\.uv\.\)\@<=\w\+]],  suffix = '()' },
+    -- Luaref
+    { prefix = 'lua-' },
+    -- environment variable
+    { regex = [[\(vim\.env\.\)\@<=\w\+]], prefix = "$" },
+    -- Other
+    {}
+  }
+  local success ---@type boolean
+  for _, opts in ipairs(list_of_opts) do
+    success = lookup_help(cword, opts)
+    if success then
+      break
+    end
+  end
+  if not success then
+    vim.notify("Sorry, can't find relevant help for " .. cword, vim.log.levels.ERROR)
+  end
+end
+
 return M


### PR DESCRIPTION
Problem:
- Neovim has built-in documentation for Lua, but it's not used by keywordprg.
- `K` in Lua code block in `help` buffer doesn't work.

Solution:
- Add a Lua keywordprg function
- Use it for Lua buffer and help buffer's keywordprg function

TODO
- [ ] Add tests ([comment](https://github.com/neovim/neovim/pull/32995#issuecomment-2761166368))

Closes https://github.com/neovim/neovim/issues/22368