### PR TITLE
vim-patch:9.1.1226: "shellcmdline" completion doesn't work with input()

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -2407,6 +2407,10 @@ void set_cmd_context(expand_T *xp, char *str, int len, int col, int use_ccline)
     xp->xp_context = ccline->xp_context;
     xp->xp_pattern = ccline->cmdbuff;
     xp->xp_arg = ccline->xp_arg;
+    if (xp->xp_context == EXPAND_SHELLCMDLINE) {
+      int context = xp->xp_context;
+      set_context_for_wildcard_arg(NULL, xp->xp_pattern, false, xp, &context);
+    }
   } else {
     while (nextcomm != NULL) {
       nextcomm = set_one_cmd_context(xp, nextcomm);

--- a/test/old/testdir/test_functions.vim
+++ b/test/old/testdir/test_functions.vim
@@ -2072,10 +2072,20 @@ func Test_input_func()
   call assert_fails("call input('F:', '', 'invalid')", 'E180:')
   call assert_fails("call input('F:', '', [])", 'E730:')
 
-  " Test for using 'command' as the completion function
+  " Test for using "command" as the completion function
   call feedkeys(":let c = input('Command? ', '', 'command')\<CR>"
         \ .. "echo bufnam\<C-A>\<CR>", 'xt')
   call assert_equal('echo bufname(', c)
+
+  " Test for using "shellcmdline" as the completion function
+  call feedkeys(":let c = input('Shell? ', '', 'shellcmdline')\<CR>"
+        \ .. "vim test_functions.\<C-A>\<CR>", 'xt')
+  call assert_equal('vim test_functions.vim', c)
+  if executable('whoami')
+    call feedkeys(":let c = input('Shell? ', '', 'shellcmdline')\<CR>"
+          \ .. "whoam\<C-A>\<CR>", 'xt')
+    call assert_match('\<whoami\>', c)
+  endif
 endfunc
 
 " Test for the inputdialog() function


### PR DESCRIPTION
Fix #32987

#### vim-patch:9.1.1226: "shellcmdline" completion doesn't work with input()

Problem:  "shellcmdline" completion doesn't work with input().
Solution: Use set_context_for_wildcard_arg().  Fix indent in nextwild()
          (zeertzjq).

There are some other inconsistencies for input() completion (ref vim/vim#948),
but since "shellcmdline" currently doesn't work at all, it makse sense
to at least make it work.

closes: vim/vim#16934

https://github.com/vim/vim/commit/7a5115ce50c622caf91503f9d7fe09c3749b928b