### PR TITLE
fix(vim.lsp.inlay_hint): Don't request inlay_hints if not enabled

### DIFF
--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -94,10 +94,10 @@ function M.on_refresh(err, _, ctx)
   for _, bufnr in ipairs(vim.lsp.get_buffers_by_client_id(ctx.client_id)) do
     for _, winid in ipairs(api.nvim_list_wins()) do
       if api.nvim_win_get_buf(winid) == bufnr then
-        if bufstates[bufnr] then
+        if bufstates[bufnr] and bufstates[bufnr].enabled then
           bufstates[bufnr].applied = {}
+          util._refresh(ms.textDocument_inlayHint, { bufnr = bufnr })
         end
-        util._refresh(ms.textDocument_inlayHint, { bufnr = bufnr })
       end
     end
   end

--- a/test/functional/plugin/lsp/inlay_hint_spec.lua
+++ b/test/functional/plugin/lsp/inlay_hint_spec.lua
@@ -297,6 +297,50 @@ int main() {
         end)
       )
     end)
+
+    it('does not request hints from lsp when disabled', function()
+      exec_lua(function()
+        _G.server2 = _G._create_server({
+          capabilities = {
+            inlayHintProvider = true,
+          },
+          handlers = {
+            ['textDocument/inlayHint'] = function(_, _, callback)
+              _G.got_inlay_hint_request = true
+              callback(nil, {})
+            end,
+          },
+        })
+        _G.client2 = vim.lsp.start({ name = 'dummy2', cmd = _G.server2.cmd })
+      end)
+
+      local function was_request_sent()
+        return exec_lua(function()
+          return _G.got_inlay_hint_request == true
+        end)
+      end
+
+      eq(false, was_request_sent())
+
+      exec_lua(function()
+        vim.lsp.inlay_hint.get()
+      end)
+
+      eq(false, was_request_sent())
+
+      exec_lua(function()
+        vim.lsp.inlay_hint.enable(false, { bufnr = bufnr })
+        vim.lsp.inlay_hint.get()
+      end)
+
+      eq(false, was_request_sent())
+
+      exec_lua(function()
+        vim.lsp.inlay_hint.enable(true, { bufnr = bufnr })
+      end)
+
+      eq(true, was_request_sent())
+    end)
   end)
 end)
 


### PR DESCRIPTION
Neovim needlessly requests inlay_hints even if they are disabled for a given buffer