### PR TITLE
fix(completion): cmdline completion does not complete items for `_defer_require` module

### DIFF
--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -917,6 +917,39 @@ function vim._expand_pat(pat, env)
 
   local final_env = env
 
+  --- @private
+  ---
+  --- Allows submodules to be defined on a `vim.<module>` table without eager-loading the module.
+  ---
+  --- Cmdline completion (`:lua vim.lsp.c<tab>`) accesses `vim.lsp._submodules` when no other candidates.
+  --- Cmdline completion (`:lua vim.lsp.completion.g<tab>`) will eager-load the module anyway. #33007
+  ---
+  --- @param m table
+  --- @param k string
+  --- @return any
+  local function safe_tbl_get(m, k)
+    local val = rawget(m, k)
+    if val ~= nil then
+      return val
+    end
+
+    local mt = getmetatable(m)
+    if not mt then
+      return m == vim and vim._extra[k] or nil
+    end
+
+    -- use mt.__index, _submodules as fallback
+    if type(mt.__index) == 'table' then
+      return rawget(mt.__index, k)
+    end
+
+    local sub = rawget(m, '_submodules')
+    if sub and type(sub) == 'table' and rawget(sub, k) then
+      -- Access the module to force _defer_require() to load the module.
+      return m[k]
+    end
+  end
+
   for _, part in ipairs(parts) do
     if type(final_env) ~= 'table' then
       return {}, 0
@@ -947,16 +980,7 @@ function vim._expand_pat(pat, env)
 
       key = result
     end
-    local field = rawget(final_env, key)
-    if field == nil then
-      local mt = getmetatable(final_env)
-      if mt and type(mt.__index) == 'table' then
-        field = rawget(mt.__index, key)
-      elseif final_env == vim and (vim._submodules[key] or vim._extra[key]) then
-        field = vim[key] --- @type any
-      end
-    end
-    final_env = field
+    final_env = safe_tbl_get(final_env, key)
 
     if not final_env then
       return {}, 0
@@ -986,15 +1010,18 @@ function vim._expand_pat(pat, env)
 
   if type(final_env) == 'table' then
     insert_keys(final_env)
+    local sub = rawget(final_env, '_submodules')
+    if type(sub) == 'table' then
+      insert_keys(sub)
+    end
+    if final_env == vim then
+      insert_keys(vim._extra)
+    end
   end
+
   local mt = getmetatable(final_env)
   if mt and type(mt.__index) == 'table' then
     insert_keys(mt.__index)
-  end
-
-  if final_env == vim then
-    insert_keys(vim._submodules)
-    insert_keys(vim._extra)
   end
 
   -- Completion for dict accessors (special vim variables and vim.fn)

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -928,6 +928,13 @@ describe('completion', function()
       command('set wildoptions+=fuzzy')
       eq({ 'vim' }, fn.getcompletion('vi', 'lua'))
     end)
+
+    it('completes _defer_require() modules', function()
+      -- vim.lsp.c<tab> -> vim.lsp.completion
+      ok(vim.tbl_contains(fn.getcompletion('lua vim.lsp.c', 'cmdline'), 'completion'))
+      -- vim.lsp.completion.g<tab> -> vim.lsp.completion.get
+      ok(vim.tbl_contains(fn.getcompletion('lua vim.lsp.completion.g', 'cmdline'), 'get'))
+    end)
   end)
 
   it('cmdline completion supports various string options', function()


### PR DESCRIPTION
Fix https://github.com/neovim/neovim/issues/33003.

Problem:
`:lua vim.lsp.c<tab>` does not list vim.lsp.completion in the completion list after [`24cea4c` (#27216)](https://github.com/neovim/neovim/pull/27216/commits/24cea4c7f7417c7fe99a98a0487f51dd68c4f409).
This happened on all defer_require() modules.

Solution:
Include keys in `vim.lsp._submodule` into candidates.
Fix `vim.lsp.c<tab>` -> `vim.lsp.completion`.

~~Call `mt.__index` function to ensure module loaded to get its key.~~
Eager-load `vim.lsp.completion` to get its completion.
Fix `vim.lsp.completion.g<tab>` -> `vim.lsp.completion.get`.
