### PR TITLE
feat(osc52): provide default OSC52 tool for vim.g.clipboard

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -59,6 +59,14 @@ function! s:split_cmd(cmd) abort
   return (type(a:cmd) == v:t_string) ? split(a:cmd, " ") : a:cmd
 endfunction
 
+function! s:set_osc52() abort
+  let s:copy['+'] = v:lua.require'vim.ui.clipboard.osc52'.copy('+')
+  let s:copy['*'] = v:lua.require'vim.ui.clipboard.osc52'.copy('*')
+  let s:paste['+'] = v:lua.require'vim.ui.clipboard.osc52'.paste('+')
+  let s:paste['*'] = v:lua.require'vim.ui.clipboard.osc52'.paste('*')
+  return 'OSC 52'
+endfunction
+
 let s:cache_enabled = 1
 let s:err = ''
 
@@ -69,6 +77,13 @@ endfunction
 function! provider#clipboard#Executable() abort
   " Setting g:clipboard to v:false explicitly opts-in to using the "builtin" clipboard providers below
   if exists('g:clipboard') && g:clipboard isnot# v:false
+    if v:t_string ==# type(g:clipboard)
+      if 'osc52' == g:clipboard
+        " User opted-in to OSC 52 by manually setting g:clipboard.
+        return s:set_osc52()
+      endif
+    endif
+
     if type({}) isnot# type(g:clipboard)
           \ || type({}) isnot# type(get(g:clipboard, 'copy', v:null))
           \ || type({}) isnot# type(get(g:clipboard, 'paste', v:null))
@@ -172,11 +187,7 @@ function! provider#clipboard#Executable() abort
   elseif get(get(g:, 'termfeatures', {}), 'osc52') && &clipboard ==# ''
     " Don't use OSC 52 when 'clipboard' is set. It can be slow and cause a lot
     " of user prompts. Users can opt-in to it by setting g:clipboard manually.
-    let s:copy['+'] = v:lua.require'vim.ui.clipboard.osc52'.copy('+')
-    let s:copy['*'] = v:lua.require'vim.ui.clipboard.osc52'.copy('*')
-    let s:paste['+'] = v:lua.require'vim.ui.clipboard.osc52'.paste('+')
-    let s:paste['*'] = v:lua.require'vim.ui.clipboard.osc52'.paste('*')
-    return 'OSC 52'
+    return s:set_osc52()
   endif
 
   let s:err = 'clipboard: No clipboard tool. :help clipboard'

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -277,7 +277,20 @@ To disable the automatic detection, set the "osc52" key of |g:termfeatures| to
 To force Nvim to always use the OSC 52 provider you can use the following
 |g:clipboard| definition: >lua
 
-    vim.g.clipboard = require('vim.ui.clipboard.osc52').tool
+    vim.g.clipboard = 'osc52'
+
+Which is equivalent to: >lua
+    vim.g.clipboard = {
+      name = 'OSC 52',
+      copy = {
+        ['+'] = require('vim.ui.clipboard.osc52').copy('+'),
+        ['*'] = require('vim.ui.clipboard.osc52').copy('*'),
+      },
+      paste = {
+        ['+'] = require('vim.ui.clipboard.osc52').paste('+'),
+        ['*'] = require('vim.ui.clipboard.osc52').paste('*'),
+      },
+    }
 <
 Note that not all terminal emulators support reading from the system clipboard
 (and even for those that do, users should be aware of the security

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -277,17 +277,7 @@ To disable the automatic detection, set the "osc52" key of |g:termfeatures| to
 To force Nvim to always use the OSC 52 provider you can use the following
 |g:clipboard| definition: >lua
 
-    vim.g.clipboard = {
-      name = 'OSC 52',
-      copy = {
-        ['+'] = require('vim.ui.clipboard.osc52').copy('+'),
-        ['*'] = require('vim.ui.clipboard.osc52').copy('*'),
-      },
-      paste = {
-        ['+'] = require('vim.ui.clipboard.osc52').paste('+'),
-        ['*'] = require('vim.ui.clipboard.osc52').paste('*'),
-      },
-    }
+    vim.g.clipboard = require('vim.ui.clipboard.osc52').tool
 <
 Note that not all terminal emulators support reading from the system clipboard
 (and even for those that do, users should be aware of the security

--- a/runtime/lua/vim/ui/clipboard/osc52.lua
+++ b/runtime/lua/vim/ui/clipboard/osc52.lua
@@ -74,10 +74,4 @@ function M.paste(reg)
   end
 end
 
-M.tool = {
-  name = 'OSC 52',
-  copy = { ['+'] = M.copy('+'), ['*'] = M.copy('*') },
-  paste = { ['+'] = M.paste('+'), ['*'] = M.paste('*') },
-}
-
 return M

--- a/runtime/lua/vim/ui/clipboard/osc52.lua
+++ b/runtime/lua/vim/ui/clipboard/osc52.lua
@@ -74,4 +74,10 @@ function M.paste(reg)
   end
 end
 
+M.tool = {
+  name = 'OSC 52',
+  copy = { ['+'] = M.copy('+'), ['*'] = M.copy('*') },
+  paste = { ['+'] = M.paste('+'), ['*'] = M.paste('*') },
+}
+
 return M


### PR DESCRIPTION
Forcing Neovim to use OSC52 for the system clipboard should be simple and concise, since OSC52 is widely supported (Alacritty, Ghostty, iTerm2, WezTerm, Kitty, xterm, tmux, etc.) and is the most portable approach for syncing clipboards across SSH.

The `osc52` module should provide a default tool that can be assigned to `vim.g.clipboard` directly to reduce config boilerplate.