### PR TITLE
vim-patch:9.1.1231: filetype: SPA JSON files are not recognized

### DIFF
--- a/runtime/ftplugin/spajson.vim
+++ b/runtime/ftplugin/spajson.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin
+" Language:	SPA JSON
+" Maintainer:	David Mandelberg <david@mandelberg.org>
+" Last Change:	2025 Mar 22
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=:###,:##,:#
+setlocal commentstring=#\ %s
+
+let b:undo_ftplugin = "setlocal comments< commentstring<"

--- a/runtime/indent/spajson.vim
+++ b/runtime/indent/spajson.vim
@@ -1,0 +1,6 @@
+" Vim indent file
+" Language:	SPA JSON
+" Maintainer:	David Mandelberg <david@mandelberg.org>
+" Last Change:	2025 Mar 22
+
+runtime! indent/json.vim

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2263,6 +2263,8 @@ local pattern = {
     ['^named.*%.conf$'] = 'named',
     ['^rndc.*%.conf$'] = 'named',
     ['/openvpn/.*/.*%.conf$'] = 'openvpn',
+    ['/pipewire/.*%.conf$'] = 'spajson',
+    ['/wireplumber/.*%.conf$'] = 'spajson',
     ['/%.ssh/.*%.conf$'] = 'sshconfig',
     ['^%.?tmux.*%.conf$'] = 'tmux',
     ['^%.?tmux.*%.conf'] = { 'tmux', { priority = -1 } },

--- a/runtime/syntax/spajson.vim
+++ b/runtime/syntax/spajson.vim
@@ -1,0 +1,50 @@
+" Vim syntax file
+" Language:	SPA JSON
+" Maintainer:	David Mandelberg <david@mandelberg.org>
+" Last Change:	2025 Mar 22
+"
+" Based on parser code:
+" https://gitlab.freedesktop.org/pipewire/pipewire/-/blob/master/spa/include/spa/utils/json-core.h
+
+if exists("b:current_syntax")
+ finish
+endif
+let b:current_syntax = "spajson"
+
+syn sync minlines=500
+
+" Treat the __BARE parser state as a keyword, to make it easier to match
+" keywords and numbers only when they're not part of a larger __BARE section.
+" E.g., v4l2 and pipewire-0 probably shouldn't highlight anything as
+" spajsonInt.
+syn iskeyword 32-126,^ ,^",^#,^:,^,,^=,^],^},^\
+
+syn match spajsonEscape "\\["\\/bfnrt]" contained
+syn match spajsonEscape "\\u[0-9A-Fa-f]\{4}" contained
+
+syn match spajsonError "."
+syn match spajsonBare "\k\+"
+syn match spajsonComment "#.*$" contains=@Spell
+syn region spajsonString start=/"/ skip=/\\\\\|\\"/ end=/"/ contains=spajsonEscape
+syn match spajsonKeyDelimiter "[:=]"
+syn region spajsonArray matchgroup=spajsonBracket start="\[" end="]" contains=ALLBUT,spajsonKeyDelimiter fold
+syn region spajsonObject matchgroup=spajsonBrace start="{" end="}" contains=ALL fold
+syn match spajsonFloat "\<[+-]\?[0-9]\+\(\.[0-9]*\)\?\([Ee][+-]\?[0-9]\+\)\?\>"
+syn match spajsonFloat "\<[+-]\?\.[0-9]\+\([Ee][+-]\?[0-9]\+\)\?\>"
+syn match spajsonInt "\<[+-]\?0[Xx][0-9A-Fa-f]\+\>"
+syn match spajsonInt "\<[+-]\?[1-9][0-9]*\>"
+syn match spajsonInt "\<[+-]\?0[0-7]*\>"
+syn keyword spajsonBoolean true false
+syn keyword spajsonNull null
+syn match spajsonWhitespace "[\x00\t \r\n,]"
+
+hi def link spajsonBoolean Boolean
+hi def link spajsonBrace Delimiter
+hi def link spajsonBracket Delimiter
+hi def link spajsonComment Comment
+hi def link spajsonError Error
+hi def link spajsonEscape SpecialChar
+hi def link spajsonFloat Float
+hi def link spajsonInt Number
+hi def link spajsonNull Constant
+hi def link spajsonString String

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -719,6 +719,8 @@ func s:GetFilenameChecks() abort
     \ 'snobol4': ['file.sno', 'file.spt'],
     \ 'solidity': ['file.sol'],
     \ 'solution': ['file.sln'],
+    \ 'spajson': ['any/pipewire/file.conf', 'any/pipewire/file.conf.d/other.conf',
+    \             'any/wireplumber/file.conf', 'any/wireplumber/file.conf.d/other.conf'],
     \ 'sparql': ['file.rq', 'file.sparql'],
     \ 'spec': ['file.spec'],
     \ 'spice': ['file.sp', 'file.spice'],


### PR DESCRIPTION
Problem:  filetype: SPA (single page application) JSON files are not
          recognized (used by pipewire and wireplumber)
Solution: detect pipewire and wireplumber configuration files as spajson
          filetype, include filetype, indent and syntax scripts for this
          new filetype (David Mandelberg).

I looked at all the files found by this command to see if the syntax
highlighting looked reasonable:

```
find {~/.config,/etc,/usr/share}/{pipewire,wireplumber} -type f -name \*.conf
```

References:
*   pipewire config files: https://docs.pipewire.org/page_config.html
*   wireplumber config files:
    https://pipewire.pages.freedesktop.org/wireplumber/daemon/configuration/conf_file.html
    and
*   https://pipewire.pages.freedesktop.org/wireplumber/daemon/locations.html

closes: vim/vim#16950

https://github.com/vim/vim/commit/4e7b4308fb92628434bd7e07ab92910c33051431

Co-authored-by: David Mandelberg <david@mandelberg.org>
