### PR TITLE
feat(prompt): add multiline support for prompt buffer (WIP) [skip ci]

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -432,6 +432,17 @@ do
       return 'g@l'
     end, { expr = true, desc = 'Add empty line below cursor' })
   end
+
+  -- Prompt buffer mappings
+  vim.api.nvim_create_autocmd({ "BufEnter", "BufModifiedSet" }, {
+    pattern = "*",
+    callback = function ()
+      vim.keymap.set("i", "<CR>", require("vim.prompt").prompt_send, { buffer = true })
+      vim.keymap.set("i", "<S-CR>", function ()
+        require("vim.prompt").add_line(true)
+      end, { buffer = true })
+    end
+  })
 end
 
 --- Default menus

--- a/runtime/lua/vim/prompt.lua
+++ b/runtime/lua/vim/prompt.lua
@@ -1,0 +1,28 @@
+M = {}
+
+local original_prompt = ""
+---@param multiline boolean Indicates whether the buffer is in multiline mode or not
+function M.add_line(multiline)
+  if original_prompt == "" then
+    original_prompt = vim.fn.prompt_getprompt(vim.fn.bufnr(''))
+  end
+  local num_lines = vim.api.nvim_buf_line_count(0)
+  if multiline then
+    vim.fn.prompt_setprompt(vim.fn.bufnr(''), '...')
+  else
+    vim.fn.prompt_setprompt(vim.fn.bufnr(''), original_prompt)
+  end
+
+  vim.api.nvim_buf_set_lines(0, num_lines + 1, num_lines + 1, false, { "" })
+end
+
+local last_line = 0 --- @type integer
+function M.prompt_send()
+  local lnum = vim.fn.getcurpos()[2] - 1 ---@type integer
+  vim.print(vim.api.nvim_buf_get_lines(0, last_line, lnum + 1, false))
+  M.add_line(false)
+  last_line = lnum + 1
+end
+
+return M
+


### PR DESCRIPTION
Adds multiline support for prompt buffers. The PR is mostly to track progress and get some early advice.

This is still very much in WIP.

Current progress:
 - can add new lines without executing with `Shift + Enter`
 - Visual indicator for when multiline mode is active

Todo:
 - calling the actual callback of the buffer when `Enter` is pressed. Currently, it just prints what would be passed as an argument to the callback. To actually call it, I think C code will need to be interacted with, which I'm not sure how to do

Additionally, I'm not sure if I've added the code to the right place. If it should go somewhere else, please tell me where to put it. Also, setting keymaps for only the `prompt` buffer type feels very hacky in the way I've done it.

ref #32420