### PR TITLE
vim-patch:9.1.1238: wrong cursor column with 'set splitkeep=screen'

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6431,7 +6431,7 @@ void win_fix_scroll(bool resize)
           && wp->w_botline - 1 <= wp->w_buffer->b_ml.ml_line_count) {
         int diff = (wp->w_winrow - wp->w_prev_winrow)
                    + (wp->w_height - wp->w_prev_height);
-        linenr_T lnum = wp->w_cursor.lnum;
+        pos_T cursor = wp->w_cursor;
         wp->w_cursor.lnum = wp->w_botline - 1;
 
         // Add difference in height and row to botline.
@@ -6445,7 +6445,8 @@ void win_fix_scroll(bool resize)
         // screen.
         wp->w_fraction = FRACTION_MULT;
         scroll_to_fraction(wp, wp->w_prev_height);
-        wp->w_cursor.lnum = lnum;
+        wp->w_cursor = cursor;
+        wp->w_valid &= ~VALID_WCOL;
       } else if (wp == curwin) {
         wp->w_valid &= ~VALID_CROW;
       }

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -1934,6 +1934,18 @@ func Test_splitkeep_misc()
   set splitkeep&
 endfunc
 
+func Test_splitkeep_screen_cursor_pos()
+  new
+  set splitkeep=screen
+  call setline(1, ["longer than the last", "shorter"])
+  norm! $
+  wincmd s
+  close
+  call assert_equal([0, 1, 20, 0], getpos('.'))
+  %bwipeout!
+  set splitkeep&
+endfunc
+
 func Test_splitkeep_cursor()
   CheckScreendump
   let lines =<< trim END


### PR DESCRIPTION
#### vim-patch:9.1.1238: wrong cursor column with 'set splitkeep=screen'

Problem:  With ':set splitkeep=screen', cursor did't restore column
          correctly when splitting a window on a line longer than the
          last line on the screen (after v9.1.0707)
Solution: Restore cursor column in `win_fix_scroll()` since it may be
          changed in `getvcol()` after 396fd1ec2956 (phanium).

Example:
```
echo longlonglongling\nshort | vim - -u NONE --cmd 'set
splitkeep=screen' +'norm $' +new +q
```

closes: vim/vim#16971

https://github.com/vim/vim/commit/7746348c5d0f4c4707503f856d0335d8921e8d50

Co-authored-by: phanium <91544758+phanen@users.noreply.github.com>