### PR TITLE
fix(man.lua): E95 when raw manpage content is piped into :Man

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -639,8 +639,21 @@ function M.init_pager()
   local _, sect, err = pcall(parse_ref, ref)
   vim.b.man_sect = err ~= nil and sect or ''
 
-  if not fn.bufname('%'):match('man://') then -- Avoid duplicate buffers, E95.
-    vim.cmd.file({ 'man://' .. fn.fnameescape(ref):lower(), mods = { silent = true } })
+  local man_bufname = 'man://' .. fn.fnameescape(ref):lower()
+
+  -- Raw manpage into (:Man!) overlooks `match('man://')` condition,
+  -- so if the buffer already exists, create new with a non existing name.
+  if vim.fn.bufexists(man_bufname) == 1 then
+    local new_bufname = man_bufname
+    for i = 1, 100 do
+      if vim.fn.bufexists(new_bufname) == 0 then
+        break
+      end
+      new_bufname = ('%s?new=%s'):format(man_bufname, i)
+    end
+    vim.cmd.file({ new_bufname, mods = { silent = true } })
+  elseif not fn.bufname('%'):match('man://') then -- Avoid duplicate buffers, E95.
+    vim.cmd.file({ man_bufname, mods = { silent = true } })
   end
 
   set_options()

--- a/test/functional/plugin/man_spec.lua
+++ b/test/functional/plugin/man_spec.lua
@@ -228,6 +228,24 @@ describe(':Man', function()
     matches('quit works!!', fn.system(args, { 'manpage contents' }))
   end)
 
+  it('raw manpage into (:Man!) creates a new buffer #30132', function()
+    local args = {
+      nvim_prog,
+      '--headless',
+      '+Man! foo',
+      '+echo bufname()',
+      '+enew',
+      '+Man! foo',
+      '+echo bufname()',
+      '+enew',
+      '+Man! foo',
+      '+echo bufname()',
+      '+q',
+    }
+    local out = fn.system(args, { 'manpage contents' })
+    assert(out and out:match('man://%?new=%d'))
+  end)
+
   it('reports non-existent man pages for absolute paths', function()
     skip(is_ci('cirrus'))
     local actual_file = tmpname()


### PR DESCRIPTION
Problem: 
    When piping raw manpage content into :Man!, the buffer name is set to 'man://.. ref'. However, the existing check  only verifies whether the buffer name starts with 'man://', rather than checking for an exact match.
    `if not fn.bufname('%'):match('man://') then -- Avoid duplicate buffers, E95.`
    This allows :Man! to attempt creating a buffer with a already in use name, triggering E95: Buffer with this name already exists.

Solution:
    Instead of matching just the 'man://' prefix, the new logic checks for an exact match of the buffer name. If the buffer already exists, a unique name is assigned using the format:  `man://<ref>_copy` and `man://<ref>_copy_copy...`, for continuous calls.
    The solution preserves the previous behavior while supporting the creation of multiple buffers with the same man page contents.

Testing:

- Verified that opening a new manpage works as expected.
- Tested piping raw content into :Man!, ensuring no duplicate buffer errors occur.
- Ensured that multiple calls to :Man! create uniquely named buffers (_copy suffix).
- Added test coverage for the newly implemented behavior.

Fix #30132


