### PR TITLE
refactor(treesitter)!: remove "all" option of Query:iter_matches

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -127,6 +127,8 @@ TREESITTER
   `metadata[capture_id].offset`. The offset will be applied in
   |vim.treesitter.get_range()|, which should be preferred over reading
   metadata directly for retrieving node ranges.
+• The "all" option to |Query:iter_matches()|, which was introduced in Nvim
+  0.11 to aid in transitioning to the new behavior, has been removed.
 
 TUI
 

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1553,10 +1553,6 @@ add_directive({name}, {handler}, {opts})
       • {opts}     (`table`) A table with the following fields:
                    • {force}? (`boolean`) Override an existing predicate of
                      the same name
-                   • {all}? (`boolean`) Use the correct implementation of the
-                     match table where capture IDs map to a list of nodes
-                     instead of a single node. Defaults to true. This option
-                     will be removed in a future release.
 
                                         *vim.treesitter.query.add_predicate()*
 add_predicate({name}, {handler}, {opts})
@@ -1570,10 +1566,6 @@ add_predicate({name}, {handler}, {opts})
       • {opts}     (`table?`) A table with the following fields:
                    • {force}? (`boolean`) Override an existing predicate of
                      the same name
-                   • {all}? (`boolean`) Use the correct implementation of the
-                     match table where capture IDs map to a list of nodes
-                     instead of a single node. Defaults to true. This option
-                     will be removed in a future release.
 
 edit({lang})                                     *vim.treesitter.query.edit()*
     Opens a live editor to query the buffer you started from.
@@ -1790,11 +1782,6 @@ Query:iter_matches({node}, {source}, {start}, {stop}, {opts})
                     traversing too deep into a tree.
                   • match_limit (integer) Set the maximum number of
                     in-progress matches (Default: 256).
-                  • all (boolean) When `false` (default `true`), the returned
-                    table maps capture IDs to a single (last) node instead of
-                    the full list of matching nodes. This option is only for
-                    backward compatibility and will be removed in a future
-                    release.
 
     Return: ~
         (`fun(): integer, table<integer, TSNode[]>, vim.treesitter.query.TSMetadata, TSTree`)

--- a/test/functional/treesitter/query_spec.lua
+++ b/test/functional/treesitter/query_spec.lua
@@ -523,36 +523,6 @@ void ui_refresh(void)
       eq({ { 0, 4, 0, 8 } }, res)
     end
 
-    -- Once with the old API. Remove this whole 'do' block in 0.12
-    do
-      local res = exec_lua(function()
-        local query = vim.treesitter.query
-
-        local function is_main(match, _pattern, bufnr, predicate)
-          local node = match[predicate[2]]
-
-          return vim.treesitter.get_node_text(node, bufnr) == 'main'
-        end
-
-        local parser = vim.treesitter.get_parser(0, 'c')
-
-        query.add_predicate('is-main?', is_main, { all = false, force = true })
-
-        local query0 = query.parse('c', custom_query)
-
-        local nodes = {}
-        for _, node in query0:iter_captures(parser:parse()[1]:root(), 0) do
-          table.insert(nodes, { node:range() })
-        end
-
-        return nodes
-      end)
-
-      -- Remove this 'do' block in 0.12
-      -- eq(0, n.fn.has('nvim-0.12'))
-      eq({ { 0, 4, 0, 8 } }, res)
-    end
-
     do
       local res = exec_lua(function()
         local query = vim.treesitter.query
@@ -678,50 +648,6 @@ void ui_refresh(void)
       { 1, 0, 1, 10 },
       { 2, 0, 2, 10 },
     }, result)
-  end)
-
-  it('supports the old broken version of iter_matches #24738', function()
-    -- Delete this test in 0.12 when iter_matches is removed
-    -- eq(0, n.fn.has('nvim-0.12'))
-
-    insert(test_text)
-    local res = exec_lua(function()
-      local cquery = vim.treesitter.query.parse('c', test_query)
-      local parser = vim.treesitter.get_parser(0, 'c')
-      local tree = parser:parse()[1]
-      local res = {}
-      for pattern, match in cquery:iter_matches(tree:root(), 0, 7, 14, { all = false }) do
-        local mrepr = {}
-        for cid, node in pairs(match) do
-          table.insert(mrepr, { '@' .. cquery.captures[cid], node:type(), node:range() })
-        end
-        table.insert(res, { pattern, mrepr })
-      end
-      return res
-    end)
-
-    eq({
-      { 3, { { '@type', 'primitive_type', 8, 2, 8, 6 } } },
-      { 2, { { '@keyword', 'for', 9, 2, 9, 5 } } },
-      { 3, { { '@type', 'primitive_type', 9, 7, 9, 13 } } },
-      { 4, { { '@fieldarg', 'identifier', 11, 16, 11, 18 } } },
-      {
-        1,
-        {
-          { '@minfunc', 'identifier', 11, 12, 11, 15 },
-          { '@min_id', 'identifier', 11, 27, 11, 32 },
-        },
-      },
-      { 4, { { '@fieldarg', 'identifier', 12, 17, 12, 19 } } },
-      {
-        1,
-        {
-          { '@minfunc', 'identifier', 12, 13, 12, 16 },
-          { '@min_id', 'identifier', 12, 29, 12, 35 },
-        },
-      },
-      { 4, { { '@fieldarg', 'identifier', 13, 14, 13, 16 } } },
-    }, res)
   end)
 
   it('should use node range when omitted', function()


### PR DESCRIPTION
This option was introduced to help with transitioning to the new behavior during the 0.11 release cycle with the intention of removing in 0.12.