### PR TITLE
vim-patch:9.1.1224: cannot :put while keeping indent

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -1105,6 +1105,11 @@ inside of strings can change!  Also see 'softtabstop' option. >
 :[line]pu[t]! [x]	Put the text [from register x] before [line] (default
 			current line).
 
+							*:ip* *:iput*
+:[line]ip[ut] [x]	like |:put|, but adjust indent to the current line
+
+:[line]ip[ut]! [x]	like |:put|!, but adjust indent to the current line
+
 ["x]]p		    or					*]p* *]<MiddleMouse>*
 ["x]]<MiddleMouse>	Like "p", but adjust the indent to the current line.
 			Using the mouse only works when 'mouse' contains 'n'

--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1348,6 +1348,8 @@ tag		command		action ~
 |:inoreabbrev|	:inorea[bbrev]	like ":noreabbrev" but for Insert mode
 |:inoremenu|	:inoreme[nu]	like ":noremenu" but for Insert mode
 |:intro|	:int[ro]	print the introductory message
+|:iput|		:ip[ut]		like |:put|, but adjust the indent to the
+				current line
 |:isearch|	:is[earch]	list one line where identifier matches
 |:isplit|	:isp[lit]	split window and jump to definition of
 				identifier

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -115,7 +115,7 @@ DIAGNOSTICS
 
 EDITOR
 
-• todo
+• |:iput| works like |:put| but adjusts indent.
 
 EVENTS
 

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -504,7 +504,9 @@ String nvim_cmd(uint64_t channel_id, Dict(cmd) *cmd, Dict(cmd_opts) *opts, Arena
     VALIDATE((regname != '='), "%s", "Cannot use register \"=", {
       goto end;
     });
-    VALIDATE(valid_yank_reg(regname, ea.cmdidx != CMD_put && !IS_USER_CMDIDX(ea.cmdidx)),
+    VALIDATE(valid_yank_reg(regname,
+                            (!IS_USER_CMDIDX(ea.cmdidx)
+                             && ea.cmdidx != CMD_put && ea.cmdidx != CMD_iput)),
              "Invalid register: \"%c", regname, {
       goto end;
     });

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1219,6 +1219,12 @@ M.cmds = {
     func = 'ex_intro',
   },
   {
+    command = 'iput',
+    flags = bit.bor(RANGE, WHOLEFOLD, BANG, REGSTR, TRLBAR, ZEROR, CMDWIN, LOCK_OK, MODIFY),
+    addr_type = 'ADDR_LINES',
+    func = 'ex_iput',
+  },
+  {
     command = 'isearch',
     flags = bit.bor(BANG, RANGE, DFLALL, WHOLEFOLD, EXTRA, CMDWIN, LOCK_OK),
     addr_type = 'ADDR_LINES',


### PR DESCRIPTION
#### vim-patch:9.1.1224: cannot :put while keeping indent

Problem:  cannot :put while keeping indent (Peter Aronoff)
Solution: add the :iput ex command (64-bitman)

closes: vim/vim#16886

https://github.com/vim/vim/commit/e08f10a55c3f15b0b4af631908551d88ec4fe502

Cherry-pick test_put.vim changes from patch 8.2.1593.

N/A patches:
vim-patch:9.1.1213: cannot :put while keeping indent
vim-patch:9.1.1215: Patch 9.1.1213 has some issues

Co-authored-by: 64-bitman <60551350+64-bitman@users.noreply.github.com>
Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>