### PR TITLE
vim-patch:51a06ec: runtime(sh): consider sh as POSIX shell by default

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -3032,24 +3032,24 @@ cases pertain, then the first line of the file is examined (ex. looking for
 /bin/sh  /bin/ksh  /bin/bash).  If the first line specifies a shelltype, then
 that shelltype is used.  However some files (ex. .profile) are known to be
 shell files but the type is not apparent.  Furthermore, on many systems sh is
-symbolically linked to "bash" (Linux, Windows+cygwin) or "ksh" (Posix).
+symbolically linked to "bash" (Linux, Windows+cygwin) or "ksh" (POSIX).
 
 One may specify a global default by instantiating one of the following
 variables in your vimrc:
 
    ksh: >
 	let g:is_kornshell = 1
-<   posix:  (using this is nearly the same as setting g:is_kornshell to 1) >
+<   posix: (default) >
 	let g:is_posix     = 1
 <   bash: >
 	let g:is_bash	   = 1
-<   sh: (default) Bourne shell >
+<   dash: >
+	let g:is_dash	   = 1
+<   sh: Bourne shell >
 	let g:is_sh	   = 1
 
-<   (dash users should use posix)
-
 If there's no "#! ..." line, and the user hasn't availed themself of a default
-sh.vim syntax setting as just shown, then syntax/sh.vim will assume the Bourne
+sh.vim syntax setting as just shown, then syntax/sh.vim will assume the POSIX
 shell syntax.  No need to quote RFCs or market penetration statistics in error
 reports, please -- just select the default version of the sh your system uses
 and install the associated "let..." in your <.vimrc>.


### PR DESCRIPTION
#### vim-patch:51a06ec: runtime(sh): consider sh as POSIX shell by default

Also, do not set g:is_kornshell when g:is_posix is set. BSD shells are
POSIX but many are derived from the ash shell.

closes: vim/vim#16939

https://github.com/vim/vim/commit/51a06ecee06096672b2f10fc6cd76bd8f6dfe8c9

Co-authored-by: Mohamed Akram <mohd.akram@outlook.com>