### PR TITLE
refactor(eval): move diff functions to diff.c

### DIFF
--- a/src/gen/gen_eval.lua
+++ b/src/gen/gen_eval.lua
@@ -16,6 +16,7 @@ hashpipe:write([[
 #include "nvim/arglist.h"
 #include "nvim/cmdexpand.h"
 #include "nvim/cmdhist.h"
+#include "nvim/diff.h"
 #include "nvim/digraph.h"
 #include "nvim/eval.h"
 #include "nvim/eval/buffer.h"

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -34,7 +34,6 @@
 #include "nvim/cmdexpand_defs.h"
 #include "nvim/context.h"
 #include "nvim/cursor.h"
-#include "nvim/diff.h"
 #include "nvim/edit.h"
 #include "nvim/errors.h"
 #include "nvim/eval.h"
@@ -1298,63 +1297,6 @@ static void f_dictwatcherdel(typval_T *argvars, typval_T *rettv, EvalFuncData fp
 static void f_did_filetype(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
   rettv->vval.v_number = curbuf->b_did_filetype;
-}
-
-/// "diff_filler()" function
-static void f_diff_filler(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
-{
-  rettv->vval.v_number = MAX(0, diff_check(curwin, tv_get_lnum(argvars)));
-}
-
-/// "diff_hlID()" function
-static void f_diff_hlID(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
-{
-  linenr_T lnum = tv_get_lnum(argvars);
-  static linenr_T prev_lnum = 0;
-  static varnumber_T changedtick = 0;
-  static int fnum = 0;
-  static int change_start = 0;
-  static int change_end = 0;
-  static hlf_T hlID = (hlf_T)0;
-
-  if (lnum < 0) {       // ignore type error in {lnum} arg
-    lnum = 0;
-  }
-  if (lnum != prev_lnum
-      || changedtick != buf_get_changedtick(curbuf)
-      || fnum != curbuf->b_fnum) {
-    // New line, buffer, change: need to get the values.
-    int linestatus = 0;
-    int filler_lines = diff_check_with_linestatus(curwin, lnum, &linestatus);
-    if (filler_lines < 0 || linestatus < 0) {
-      if (filler_lines == -1 || linestatus == -1) {
-        change_start = MAXCOL;
-        change_end = -1;
-        if (diff_find_change(curwin, lnum, &change_start, &change_end)) {
-          hlID = HLF_ADD;               // added line
-        } else {
-          hlID = HLF_CHD;               // changed line
-        }
-      } else {
-        hlID = HLF_ADD;         // added line
-      }
-    } else {
-      hlID = (hlf_T)0;
-    }
-    prev_lnum = lnum;
-    changedtick = buf_get_changedtick(curbuf);
-    fnum = curbuf->b_fnum;
-  }
-
-  if (hlID == HLF_CHD || hlID == HLF_TXD) {
-    int col = (int)tv_get_number(&argvars[1]) - 1;  // Ignore type error in {col}.
-    if (col >= change_start && col <= change_end) {
-      hlID = HLF_TXD;  // Changed text.
-    } else {
-      hlID = HLF_CHD;  // Changed line.
-    }
-  }
-  rettv->vval.v_number = hlID;
 }
 
 /// "empty({expr})" function


### PR DESCRIPTION
They were moved in Vim in patch 8.1.1989.
This change is required to port patch 9.1.1243.
