### PR TITLE
fix(lsp): warn on missing configurations in `:checkhealth`

### DIFF
--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -187,26 +187,32 @@ local function check_enabled_configs()
     local config = vim.lsp.config[name]
     local text = {} --- @type string[]
     text[#text + 1] = ('%s:'):format(name)
-    for k, v in
-      vim.spairs(config --[[@as table<string,any>]])
-    do
-      local v_str --- @type string?
-      if k == 'name' then
-        v_str = nil
-      elseif k == 'filetypes' or k == 'root_markers' then
-        v_str = table.concat(v, ', ')
-      elseif type(v) == 'function' then
-        v_str = func_tostring(v)
-      else
-        v_str = vim.inspect(v, { newline = '\n  ' })
-      end
+    if not config then
+      report_warn(
+        ("'%s' config not found. Ensure that vim.lsp.config('%s') was called."):format(name, name)
+      )
+    else
+      for k, v in
+        vim.spairs(config --[[@as table<string,any>]])
+      do
+        local v_str --- @type string?
+        if k == 'name' then
+          v_str = nil
+        elseif k == 'filetypes' or k == 'root_markers' then
+          v_str = table.concat(v, ', ')
+        elseif type(v) == 'function' then
+          v_str = func_tostring(v)
+        else
+          v_str = vim.inspect(v, { newline = '\n  ' })
+        end
 
-      if k == 'cmd' and type(v) == 'table' and vim.fn.executable(v[1]) == 0 then
-        report_warn(("'%s' is not executable. Configuration will not be used."):format(v[1]))
-      end
+        if k == 'cmd' and type(v) == 'table' and vim.fn.executable(v[1]) == 0 then
+          report_warn(("'%s' is not executable. Configuration will not be used."):format(v[1]))
+        end
 
-      if v_str then
-        text[#text + 1] = ('- %s: %s'):format(k, v_str)
+        if v_str then
+          text[#text + 1] = ('- %s: %s'):format(k, v_str)
+        end
       end
     end
     text[#text + 1] = ''


### PR DESCRIPTION
Currently if a language server is enabled with `vim.lsp.enable` and is not configured previously with `vim.lsp.config` it just gives an error in the `:checkhealth vim.lsp`:

```
- ERROR Failed to run healthcheck for "vim.lsp" plugin. Exception:
  vim/shared.lua:0: t: expected table, got nil
```

This resolves the failure and instead gives the user a warning that an enabled language server could not be resolved to a configuration

Resolves #33089