### PR TITLE
fix(provider/python)!: properly drop Python 3.7 and 3.8 support

### DIFF
--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -35,7 +35,7 @@ if you already have it (some package managers install the module with Nvim
 itself).
 
 For Python 3 plugins:
-1. Make sure Python 3.4+ is available in your $PATH.
+1. Make sure Python 3.9+ is available in your $PATH.
 2. Install the module (try "python" if "python3" is missing): >bash
    python3 -m pip install --user --upgrade pynvim
 

--- a/runtime/lua/vim/provider/python.lua
+++ b/runtime/lua/vim/provider/python.lua
@@ -1,5 +1,5 @@
 local M = {}
-local min_version = '3.7'
+local min_version = '3.9'
 local s_err ---@type string?
 local s_host ---@type string?
 


### PR DESCRIPTION
Problem: #33022 didn't update `min_version` to 3.9, therefore Python 3.7 and 3.8 are still available.

Solution: Update `min_version` to 3.9.