### PR TITLE
vim-patch:9.1.{1245,1249}

### DIFF
--- a/test/old/testdir/test_let.vim
+++ b/test/old/testdir/test_let.vim
@@ -93,6 +93,26 @@ func Test_let()
   let [l[0], l[1]] = [10, 20]
   call assert_equal([10, 20, 3], l)
 
+  " Test for using curly brace name in the LHS of an assignment
+  let listvar = [1, 2]
+  let s = 'listvar'
+  let {s} = [3, 4]
+  call assert_equal([3, 4], listvar)
+
+  " Test for using curly brace name as a list and as list index in the LHS of
+  " an assignment
+  let listvar = [1, 2]
+  let idx = 1
+  let s = 'listvar'
+  let {s}[0] = 10
+  let s = 'idx'
+  let listvar[{s}] = 20
+  call assert_equal([10, 20], listvar)
+  let s1 = 'listvar'
+  let s2 = 'idx'
+  let {s1}[{s2}] = 30
+  call assert_equal([10, 30], listvar)
+
   " Test for errors in conditional expression
   call assert_fails('let val = [] ? 1 : 2', 'E745:')
   call assert_fails('let val = 1 ? 5+ : 6', 'E121:')

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -2705,6 +2705,22 @@ func Test_normal33_g_cmd2()
   call assert_equal(87, col('.'))
   call assert_equal('E', getreg(0))
 
+  " Have an odd number of chars in the line
+  norm! A.
+  call assert_equal(145, col('.'))
+  norm! gMyl
+  call assert_equal(73, col('.'))
+  call assert_equal('0', getreg(0))
+
+  " 'listchars' "eol" should not affect gM behavior
+  setlocal list listchars=eol:$
+  norm! $
+  call assert_equal(145, col('.'))
+  norm! gMyl
+  call assert_equal(73, col('.'))
+  call assert_equal('0', getreg(0))
+  setlocal nolist
+
   " Test for gM with Tab characters
   call setline('.', "\ta\tb\tc\td\te\tf")
   norm! gMyl


### PR DESCRIPTION
#### vim-patch:9.1.1245: need some more tests for curly braces evaluation

Problem:  need some more tests for curly braces evaluation
Solution: Add a test for the regression introduced by patch v9.1.1242
          (Yegappan Lakshmanan)

closes: vim/vim#16986

https://github.com/vim/vim/commit/d9b82cfe846e988772f2eec40643d7009d61ffdf

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.1.1249: tests: no test that 'listchars' "eol" doesn't affect "gM"

Problem:  No test that 'listchars' "eol" doesn't affect "gM".
Solution: Add a test (zeertzjq).

closes: vim/vim#16990

https://github.com/vim/vim/commit/757c37da6dd99d23fed90c00e44dd65e351e19ac