### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/syntax/hyprlang.vim
+++ b/runtime/syntax/hyprlang.vim
@@ -1,11 +1,14 @@
 " Vim syntax file
 " Language:     hyprlang
 " Maintainer:   Luca Saccarola <github.e41mv@aleeas.com>
-" Last Change:  2025 Jan 29
+" Last Change:  2025 Mar 26
 
 if exists("b:current_syntax")
   finish
 endif
+let s:cpo= &cpo
+set cpo&vim
+
 let b:current_syntax = "hyprlang"
 
 syn case ignore
@@ -56,4 +59,6 @@ hi def link hyprString    String
 hi def link hyprColor     Structure
 hi def link hyprCommand   Keyword
 
+let &cpo = s:cpo
+unlet s:cpo
 " vim: ts=8 sts=2 sw=2 et

--- a/runtime/syntax/solidity.vim
+++ b/runtime/syntax/solidity.vim
@@ -2,10 +2,11 @@
 " Language:		Solidity
 " Maintainer:		Cothi (jiungdev@gmail.com)
 " Original Author:	tomlion (https://github.com/tomlion/vim-solidity/blob/master/syntax/solidity.vim)
-" Last Change:		2022 Sep 27
+" Last Change:		2025 Mar 25
 "
 " Contributors:
 "       Modified by thesis (https://github.com/thesis/vim-solidity/blob/main/indent/solidity.vim)
+"       Modified by S0AndS0 (https://github.com/S0AndS0/vim/blob/syntax-solidity-updates/runtime/syntax/solidity.vim)
 
 if exists("b:current_syntax")
   finish
@@ -15,7 +16,7 @@ endif
 syn keyword solKeyword           abstract anonymous as break calldata case catch constant constructor continue default switch revert require
 syn keyword solKeyword           ecrecover addmod mulmod keccak256
 syn keyword solKeyword           delete do else emit enum external final for function if immutable import in indexed inline
-syn keyword solKeyword           interface internal is let match memory modifier new of payable pragma private public pure override virtual
+syn keyword solKeyword           interface internal is let match memory modifier new of payable pragma private public pure override virtual transient
 syn keyword solKeyword           relocatable return returns static storage struct throw try type typeof using
 syn keyword solKeyword           var view while
 
@@ -157,6 +158,15 @@ syn match   solEventArgSpecial   contained 'indexed'
 hi def link solEvent             Type
 hi def link solEventName         Function
 hi def link solEventArgSpecial   Label
+
+" Error
+syn match   solError             /\<error\>/ nextgroup=solErrorName,solErrorArgs skipwhite
+syn match   solErrorName         contained /\<[a-zA-Z_$][0-9a-zA-Z_$]*/ nextgroup=solErrorArgs skipwhite
+syn region  solErrorArgs         contained matchgroup=solFuncParens start='(' end=')' contains=solErrorArgCommas,solBuiltinType skipwhite skipempty
+syn match   solErrorArgCommas    contained ','
+
+hi def link solError             Type
+hi def link solErrorName         Function
 
 " Comment
 syn keyword solCommentTodo       TODO FIXME XXX TBD contained


### PR DESCRIPTION
#### vim-patch:052b86b: runtime(solidity): update syntax script with error definitions

closes: vim/vim#16978

References:
- https://docs.soliditylang.org/en/latest/contracts.html#transient-storage
- https://soliditylang.org/blog/2021/04/21/custom-errors/

https://github.com/vim/vim/commit/052b86ba6315e65eb034ac906128f9bd82d5f2d7

Co-authored-by: S0AndS0 <strangerthanbland@gmail.com>


#### vim-patch:f9f4e27: runtime(hyprlang): save and restore cpo setting in syntax script

closes: vim/vim#16973

https://github.com/vim/vim/commit/f9f4e27ad76ee36a5a49013a84a466800d26f360

Co-authored-by: Christian Brabandt <cb@256bit.org>