### PR TITLE
vim-patch:9.1.1247: fragile setup to get (preferred) keys from key_name_entry

### DIFF
--- a/src/nvim/keycodes.c
+++ b/src/nvim/keycodes.c
@@ -338,10 +338,7 @@ char *get_special_key_name(int c, int modifiers)
       }
     }
   } else {            // use name of special key
-    const String *s = key_names_table[table_idx].pref_name != NULL
-                      ? key_names_table[table_idx].pref_name
-                      : &key_names_table[table_idx].name;
-
+    const String *s = &key_names_table[table_idx].name;
     if ((int)s->size + idx + 2 <= MAX_KEY_NAME_LEN) {
       STRCPY(string + idx, s->data);
       idx += (int)s->size;
@@ -593,7 +590,7 @@ static int extract_modifiers(int key, int *modp, const bool simplify, bool *cons
 int find_special_key_in_table(int c)
 {
   for (int i = 0; i < (int)ARRAY_SIZE(key_names_table); i++) {
-    if (c == key_names_table[i].key) {
+    if (c == key_names_table[i].key && !key_names_table[i].is_alt) {
       return i;
     }
   }

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -313,11 +313,18 @@ func Test_set_completion()
   call feedkeys(":set suffixes:\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_equal('"set suffixes:.bak,~,.o,.h,.info,.swp,.obj', @:)
 
-  " Expand key codes.
+  " " Expand key codes.
   " call feedkeys(":set <H\<C-A>\<C-B>\"\<CR>", 'tx')
   " call assert_equal('"set <Help> <Home>', @:)
-
-  " Expand terminal options.
+  " " <BackSpace> (alt name) and <BS> should both show up in auto-complete
+  " call feedkeys(":set <B\<C-A>\<C-B>\"\<CR>", 'tx')
+  " call assert_equal('"set <BackSpace> <Bar> <BS> <Bslash>', @:)
+  " " <ScrollWheelDown> has alt name <MouseUp> but it should not show up here
+  " " nor show up as duplicates
+  " call feedkeys(":set <ScrollWheel\<C-A>\<C-B>\"\<CR>", 'tx')
+  " call assert_equal('"set <ScrollWheelDown> <ScrollWheelLeft> <ScrollWheelRight> <ScrollWheelUp>', @:)
+  "
+  " " Expand terminal options.
   " call feedkeys(":set t_A\<C-A>\<C-B>\"\<CR>", 'tx')
   " call assert_equal('"set t_AB t_AF t_AU t_AL', @:)
   " call assert_fails('call feedkeys(":set <t_afoo>=\<C-A>\<CR>", "xt")', 'E474:')


### PR DESCRIPTION
#### vim-patch:9.1.1247: fragile setup to get (preferred) keys from key_name_entry

Problem:  fragile setup to get (preferred) keys from key_name_entry
          (after v9.1.1179)
Solution: refactor the code further, fix a bug with "pref_name" key
          entry introduced in v9.1.1180 (Yee Cheng Chin)

The optimization introduced for using bsearch() with key_name_entry
in vim/vim#16788 was fragile as it required synchronizing a non-obvious index
(e.g. IDX_KEYNAME_SWU) with the array that could be accidentally changed
by any one adding a key to it. Furthermore, the "pref_name" that was
introduced in that change was unnecessary, and in fact introduced a bug,
as we don't always want to use the canonical name.

The bug is triggered when the user triggers auto-complete using a
keycode, such as `:set <Scroll<Tab>`. The bug would end up showing two
copies of `<ScrollWheelUp>` because both entries end up using the
canonical name.

In this change, remove `pref_name`, and simply use a boolean to track
whether an entry is an alt name or not and modify logic to respect that.

Add test to make sure auto-complete works with alt names

closes: vim/vim#16987

https://github.com/vim/vim/commit/7d8e7df55190e8e4e5a66f443e4440b52edf2fdb

In Nvim there is no `enabled` field, so put `is_alt` before `name` to
reduce the size of the struct.

Co-authored-by: Yee Cheng Chin <ychin.git@gmail.com>