### PR TITLE
vim-patch:9.1.1250: cannot set the maximum popup menu width

### DIFF
--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -305,6 +305,7 @@ EXTERN char *p_csl;             ///< 'completeslash'
 #endif
 EXTERN OptInt p_pb;             ///< 'pumblend'
 EXTERN OptInt p_ph;             ///< 'pumheight'
+EXTERN OptInt p_pmw;            ///< 'pummaxwidth'
 EXTERN OptInt p_pw;             ///< 'pumwidth'
 EXTERN char *p_com;             ///< 'comments'
 EXTERN char *p_cpo;             ///< 'cpoptions'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -6410,6 +6410,22 @@ local options = {
       varname = 'p_ph',
     },
     {
+      abbreviation = 'pmw',
+      defaults = 0,
+      desc = [=[
+        Determines the maximum width to use for the popup menu
+        (|ins-completion-menu|) for completion. When zero, there is no maximum
+        width limit, otherwise the popup menu will never be wider than this
+        value.  Truncated text will be indicated by "..." at the end.  Takes
+        precedence over 'pumwidth'.
+      ]=],
+      full_name = 'pummaxwidth',
+      scope = { 'global' },
+      short_desc = N_('maximum width of the popup menu'),
+      type = 'number',
+      varname = 'p_pmw',
+    },
+    {
       abbreviation = 'pw',
       defaults = 15,
       desc = [=[

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -7681,6 +7681,115 @@ describe('builtin popupmenu', function()
           {2:-- INSERT --}                    |
         ]])
       end)
+
+      -- old test Test_pum_maxwidth
+      it('pummaxwidth #test', function()
+        feed('S123456789_123456789_123456789_a<CR>123456789_123456789_123456789_b<CR>            123<ESC>gg')
+        feed('G"zyy')
+        feed('A<C-N>')
+        screen:expect([[
+          123456789_123456789_123456789_a |
+          123456789_123456789_123456789_b |
+                      123456789_123456789_|
+          123456789_a^                     |
+          {1:~          }{s: 123456789_123456789_}|
+          {1:~          }{n: 123456789_123456789_}|
+          {1:~                               }|*13
+          {2:-- }{5:match 1 of 2}                 |
+        ]])
+        feed('<Esc>3Gdd"zp')
+
+        command('set pummaxwidth=10')
+        feed('GA<C-N>')
+        screen:expect([[
+          123456789_123456789_123456789_a |
+          123456789_123456789_123456789_b |
+                      123456789_123456789_|
+          123456789_a^                     |
+          {1:~          }{s: 1234567...}{1:          }|
+          {1:~          }{n: 1234567...}{1:          }|
+          {1:~                               }|*13
+          {2:-- }{5:match 1 of 2}                 |
+        ]])
+        feed('<Esc>3Gdd"zp')
+
+        command('set pummaxwidth=20')
+        feed('GA<C-N>')
+        screen:expect([[
+          123456789_123456789_123456789_a |
+          123456789_123456789_123456789_b |
+                      123456789_123456789_|
+          123456789_a^                     |
+          {1:~          }{s: 123456789_123456789_}|
+          {1:~          }{n: 123456789_123456789_}|
+          {1:~                               }|*13
+          {2:-- }{5:match 1 of 2}                 |
+        ]])
+        feed('<Esc>3Gdd"zp')
+
+        -- failed
+        command('set pummaxwidth=8 pumwidth=20')
+        feed('GA<C-N>')
+      end)
+
+      -- old test Test_pum_maxwidth_multibyte
+      it('pummaxwidth multibyte', function()
+        exec([[
+          func Omni_test(findstart, base)
+             if a:findstart
+               return col(".")
+             endif
+             return [
+               \ #{word: "123456789_123456789_123456789_"},
+               \ #{word: "一二三四五六七八九十"},
+               \ ]
+           endfunc
+           set omnifunc=Omni_test
+        ]])
+
+        feed('S<C-X><C-O>')
+        screen:expect([[
+          123456789_123456789_123456789_^  |
+          {s:123456789_123456789_123456789_ }{1: }|
+          {n:一二三四五六七八九十           }{1: }|
+          {1:~                               }|*16
+          {2:-- }{5:match 1 of 2}                 |
+        ]])
+        feed('<ESC>')
+
+        command('set pummaxwidth=10')
+        feed('S<C-X><C-O>')
+        screen:expect([[
+          123456789_123456789_123456789_^  |
+          {s:1234567...}{1:                      }|
+          {n:一二三 ...}{1:                      }|
+          {1:~                               }|*16
+          {2:-- }{5:match 1 of 2}                 |
+        ]])
+        feed('<ESC>')
+
+        command('set rightleft')
+        feed('S<C-X><C-O>')
+        screen:expect([[
+           ^ _987654321_987654321_987654321|
+          {1:                      }{s:...7654321}|
+          {1:                      }{n:... 三二一}|
+          {1:                               ~}|*16
+          {2:-- }{5:match 1 of 2}                 |
+        ]])
+        feed('<ESC>')
+        command('set rl&')
+
+        command('set pummaxwidth=2')
+        feed('S<C-X><C-O>')
+        screen:expect([[
+          123456789_123456789_123456789_^  |
+          {s:12}{1:                              }|
+          {n:一}{1:                              }|
+          {1:~                               }|*16
+          {2:-- }{5:match 1 of 2}                 |
+        ]])
+      end)
     end
   end
 

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1992,4 +1992,81 @@ func Test_pum_complete_with_special_characters()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_pum_maxwidth()
+  CheckScreendump
+
+  let lines =<< trim END
+    123456789_123456789_123456789_a
+    123456789_123456789_123456789_b
+                123
+  END
+  call writefile(lines, 'Xtest', 'D')
+  let buf = RunVimInTerminal('Xtest', {})
+
+  call term_sendkeys(buf, "G\"zyy")
+  call term_sendkeys(buf, "A\<C-N>")
+  call VerifyScreenDump(buf, 'Test_pum_maxwidth_01', {'rows': 8})
+  call term_sendkeys(buf, "\<Esc>3Gdd\"zp")
+
+  call term_sendkeys(buf, ":set pummaxwidth=10\<CR>")
+  call term_sendkeys(buf, "GA\<C-N>")
+  call VerifyScreenDump(buf, 'Test_pum_maxwidth_02', {'rows': 8})
+  call term_sendkeys(buf, "\<Esc>3Gdd\"zp")
+
+  call term_sendkeys(buf, ":set pummaxwidth=20\<CR>")
+  call term_sendkeys(buf, "GA\<C-N>")
+  call VerifyScreenDump(buf, 'Test_pum_maxwidth_03', {'rows': 8})
+  call term_sendkeys(buf, "\<Esc>3Gdd\"zp")
+
+  call term_sendkeys(buf, ":set pumwidth=20 pummaxwidth=8\<CR>")
+  call term_sendkeys(buf, "GA\<C-N>")
+  call VerifyScreenDump(buf, 'Test_pum_maxwidth_04', {'rows': 8})
+  call term_sendkeys(buf, "\<Esc>3Gdd\"zp")
+
+  call StopVimInTerminal(buf)
+endfunc
+
+func Test_pum_maxwidth_multibyte()
+  CheckScreendump
+
+  let lines =<< trim END
+    func Omni_test(findstart, base)
+      if a:findstart
+        return col(".")
+      endif
+      return [
+        \ #{word: "123456789_123456789_123456789_"},
+        \ #{word: "一二三四五六七八九十"},
+        \ ]
+    endfunc
+    set omnifunc=Omni_test
+  END
+  call writefile(lines, 'Xtest', 'D')
+  let  buf = RunVimInTerminal('-S Xtest', {})
+  call TermWait(buf)
+
+  call term_sendkeys(buf, "S\<C-X>\<C-O>")
+  call VerifyScreenDump(buf, 'Test_pum_maxwidth_05', {'rows': 8})
+  call term_sendkeys(buf, "\<ESC>")
+
+  call term_sendkeys(buf, ":set pummaxwidth=10\<CR>")
+  call term_sendkeys(buf, "S\<C-X>\<C-O>")
+  call VerifyScreenDump(buf, 'Test_pum_maxwidth_06', {'rows': 8})
+  call term_sendkeys(buf, "\<ESC>")
+
+  if has('rightleft')
+    call term_sendkeys(buf, ":set rightleft\<CR>")
+    call term_sendkeys(buf, "S\<C-X>\<C-O>")
+    call VerifyScreenDump(buf, 'Test_pum_maxwidth_07', {'rows': 8})
+    call term_sendkeys(buf, "\<Esc>:set norightleft\<CR>")
+  endif
+
+  call term_sendkeys(buf, ":set pummaxwidth=2\<CR>")
+  call term_sendkeys(buf, "S\<C-X>\<C-O>")
+  call VerifyScreenDump(buf, 'Test_pum_maxwidth_08', {'rows': 8})
+  call term_sendkeys(buf, "\<ESC>")
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  cannot set the maximum popup menu width
          (Lucas Mior)
Solution: add the new global option value 'pummaxwidth'
          (glepnir)

fixes: vim/vim#10901
closes: vim/vim#16943

https://github.com/vim/vim/commit/88d75934c3d5bc4c406343f106e1a61638abd3a7