### PR TITLE
fix(cmdline): empty ext_cmdline block events for :<CR>

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -577,7 +577,8 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
       int indent = cstack.cs_idx < 0 ? 0 : (cstack.cs_idx + 1) * 2;
       if (count >= 1 && getline_equal(fgetline, cookie, getexline)) {
         if (ui_has(kUICmdline)) {
-          ui_ext_cmdline_block_append((size_t)MAX(0, block_indent), last_cmdline);
+          char *line = last_cmdline ? last_cmdline : "";
+          ui_ext_cmdline_block_append((size_t)MAX(0, block_indent), line);
           block_indent = indent;
         } else if (count == 1) {
           // Need to set msg_didout for the first line after an ":if",
@@ -683,8 +684,7 @@ int do_cmdline(char *cmdline, LineGetter fgetline, void *cookie, int flags)
 
       // If the command was typed, remember it for the ':' register.
       // Do this AFTER executing the command to make :@: work.
-      if (getline_equal(fgetline, cookie, getexline)
-          && new_last_cmdline != NULL) {
+      if (getline_equal(fgetline, cookie, getexline)) {
         xfree(last_cmdline);
         last_cmdline = new_last_cmdline;
         new_last_cmdline = NULL;

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -886,7 +886,7 @@ local function test_cmdline(linegrid)
       },
       cmdline_block = { { { 'if 1' } } },
     })
-    feed(':let x = 1<CR>')
+    feed('let x = 1<CR>')
     screen:expect({
       grid = s1,
       cmdline = {
@@ -897,20 +897,33 @@ local function test_cmdline(linegrid)
           pos = 0,
         },
       },
-      cmdline_block = { { { 'if 1' } }, { { '  :let x = 1' } } },
+      cmdline_block = { { { 'if 1' } }, { { '  let x = 1' } } },
     })
-    feed(':endif')
+    feed('<CR>')
     screen:expect({
       grid = s1,
       cmdline = {
         {
-          content = { { ':endif' } },
+          content = { { '' } },
           firstc = ':',
           indent = 2,
-          pos = 6,
+          pos = 0,
         },
       },
-      cmdline_block = { { { 'if 1' } }, { { '  :let x = 1' } } },
+      cmdline_block = { { { 'if 1' } }, { { '  let x = 1' } }, { { '  ' } } },
+    })
+    feed('endif')
+    screen:expect({
+      grid = s1,
+      cmdline = {
+        {
+          content = { { 'endif' } },
+          firstc = ':',
+          indent = 2,
+          pos = 5,
+        },
+      },
+      cmdline_block = { { { 'if 1' } }, { { '  let x = 1' } }, { { '  ' } } },
     })
     feed('<CR>')
     screen:expect({


### PR DESCRIPTION
Problem:  An ext_cmdline block event that should be empty after :\<CR>
          re-emits the previous cmdline.
Solution: Clear `last_cmdline` even when `new_last_cmdline == NULL`.