### PR TITLE
fix(api): use original lhs in keymap error message

### DIFF
--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -2804,8 +2804,7 @@ void modify_keymap(uint64_t channel_id, Buffer buffer, bool is_unmap, String mod
     api_set_error(err, kErrorTypeException, e_nomap, 0);
     goto fail_and_free;
   case 5:
-    api_set_error(err, kErrorTypeException,
-                  "E227: mapping already exists for %s", parsed_args.lhs);
+    api_set_error(err, kErrorTypeException, e_mapping_already_exists_for_str, lhs.data);
     goto fail_and_free;
   default:
     assert(false && "Unrecognized return code!");

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -803,11 +803,17 @@ describe('nvim_set_keymap, nvim_del_keymap', function()
   it('throws appropriate error messages when setting <unique> maps', function()
     api.nvim_set_keymap('l', 'lhs', 'rhs', {})
     eq(
-      'E227: mapping already exists for lhs',
+      'E227: Mapping already exists for lhs',
       pcall_err(api.nvim_set_keymap, 'l', 'lhs', 'rhs', { unique = true })
     )
     -- different mapmode, no error should be thrown
     api.nvim_set_keymap('t', 'lhs', 'rhs', { unique = true })
+
+    api.nvim_set_keymap('n', '<tab>', 'rhs', {})
+    eq(
+      'E227: Mapping already exists for <tab>',
+      pcall_err(api.nvim_set_keymap, 'n', '<tab>', 'rhs', { unique = true })
+    )
   end)
 
   it('can set <expr> mappings whose RHS change dynamically', function()


### PR DESCRIPTION
When setting a keymap with "unique" that already exists the error message contains the LHS of the keymap with termcodes replaced. In particular this means that keys like <Tab> show as an actual tab character, meaning the error message displays as "Mapping already exists for ", which is hard to debug for users.

Instead, display the original LHS (without any simplification or parsed termcodes). This rperesents exactly what the user passed to the `lhs` argument of `nvim_set_keymap`, which makes it easier to find where the offending keymap is.