### PR TITLE
vim-patch:9.1.1252: typos in code and docs related to 'diffopt' "inline:"

### DIFF
--- a/runtime/doc/diff.txt
+++ b/runtime/doc/diff.txt
@@ -231,12 +231,11 @@ The diffs are highlighted with these groups:
 				highlight the exact difference between the
 				two.  Will respect any 'diffopt' flag that
 				affects internal diff.
-				Not used when `inline:` set to "none".
-|hl-DiffTextAdd|  DiffTextAdd	Added text inside a Changed line. Similar to
+				Not used when `inline:` is set to "none".
+|hl-DiffTextAdd|  DiffTextAdd	Added text inside a Changed line.  Similar to
 				DiffText, but used when there is no
-				corresponding text in other buffers.  Will not
-				be used when `inline:` is set to "simple" or
-				"none".
+				corresponding text in other buffers.  Not used
+				when `inline:` is set to "simple" or "none".
 |hl-DiffDelete|	DiffDelete	Deleted lines.  Also called filler lines,
 				because they don't really exist in this
 				buffer.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2125,8 +2125,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 				none    Do not perform inline highlighting.
 				simple  Highlight from first different
 					character to the last one in each
-					line. This is the default if nothing
-					is set.
+					line.  This is the default if no
+					`inline:` value is set.
 				char    Use internal diff to perform a
 					character-wise diff and highlight the
 					difference.

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1722,8 +1722,8 @@ vim.go.dex = vim.go.diffexpr
 --- 			none    Do not perform inline highlighting.
 --- 			simple  Highlight from first different
 --- 				character to the last one in each
---- 				line. This is the default if nothing
---- 				is set.
+--- 				line.  This is the default if no
+--- 				`inline:` value is set.
 --- 			char    Use internal diff to perform a
 --- 				character-wise diff and highlight the
 --- 				difference.

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -777,7 +777,7 @@ struct diffblock_S {
 typedef struct diffline_change_S diffline_change_T;
 struct diffline_change_S {
   colnr_T dc_start[DB_COUNT];       ///< byte offset of start of range in the line
-  colnr_T dc_end[DB_COUNT];         ///< 1 paste byte offset of end of range in line
+  colnr_T dc_end[DB_COUNT];         ///< 1 past byte offset of end of range in line
   int dc_start_lnum_off[DB_COUNT];  ///< starting line offset
   int dc_end_lnum_off[DB_COUNT];    ///< end line offset
 };

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2279,8 +2279,8 @@ local options = {
         			none    Do not perform inline highlighting.
         			simple  Highlight from first different
         				character to the last one in each
-        				line. This is the default if nothing
-        				is set.
+        				line.  This is the default if no
+        				`inline:` value is set.
         			char    Use internal diff to perform a
         				character-wise diff and highlight the
         				difference.

--- a/test/old/testdir/test_diffmode.vim
+++ b/test/old/testdir/test_diffmode.vim
@@ -2212,8 +2212,8 @@ func Test_diff_inline()
         \  "abcdefghijklmno", "anchor2",
         \  "abcdefghijklmno", "anchor3",
         \  "test", "multiline"],
-        \ ["a?c?e?g?i?k???o",  "anchor1",
-        \  "a??de?????klmno",  "anchor2",
+        \ ["a?c?e?g?i?k???o", "anchor1",
+        \  "a??de?????klmno", "anchor2",
         \  "a??de??????lmno", "anchor3",
         \  "t?s?", "??????i?e"])
   call VerifyInternal(buf, "Test_diff_inline_char_02", " diffopt+=inline:char")
@@ -2254,7 +2254,7 @@ func Test_diff_inline_multibuffer()
         \ ["This is buffer3. Last.", "anchor", "Some more", "text here.", "anchor", "only in buffer2/3", "not in buffer1"])
   call VerifyInternal(buf, "Test_diff_inline_multibuffer_01", " diffopt+=inline:char")
 
-  " Close one of the buffer and make sure it updates correctly
+  " Close one of the buffers and make sure it updates correctly
   call term_sendkeys(buf, ":diffoff\<CR>")
   call VerifyInternal(buf, "Test_diff_inline_multibuffer_02", " diffopt+=inline:char")
 


### PR DESCRIPTION
#### vim-patch:9.1.1252: typos in code and docs related to 'diffopt' "inline:"

Problem:  Typos in code and docs related to 'diffopt' "inline:".
          (after v9.1.1243)
Solution: Fix typos and slightly improve the docs.
          (zeertzjq)

closes: vim/vim#16997

https://github.com/vim/vim/commit/5a307c361cbe9f7ac438a917b905378d87f8f2de