### PR TITLE
Work on preventing flickering

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,9 +145,9 @@ set(NVIM_VERSION_PATCH 0)
 set(NVIM_VERSION_PRERELEASE "-dev") # for package maintainers
 
 # API level
-set(NVIM_API_LEVEL 13)        # Bump this after any API/stdlib change.
+set(NVIM_API_LEVEL 14)        # Bump this after any API/stdlib change.
 set(NVIM_API_LEVEL_COMPAT 0)  # Adjust this after a _breaking_ API change.
-set(NVIM_API_PRERELEASE false)
+set(NVIM_API_PRERELEASE true)
 
 # We _want_ assertions in RelWithDebInfo build-type.
 if(CMAKE_C_FLAGS_RELWITHDEBINFO MATCHES DNDEBUG)

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -4041,4 +4041,22 @@ nvim_ui_try_resize_grid({grid}, {width}, {height})
       • {height}  The new requested height.
 
 
+==============================================================================
+Fold Functions                                                      *api-fold*
+
+nvim__fold_info({window}, {lnum})                          *nvim__fold_info()*
+    WARNING: This feature is experimental/unstable.
+
+    Gets the start and end lines for the closed fold on the given line
+
+    Parameters: ~
+      • {window}  |window-ID|, or 0 for current window
+      • {lnum}    The line number to check (0-indexed)
+
+    Return: ~
+        Dict containing fold information, with these keys:
+        • first: The start line of the current closed fold, or `nil` if none
+        • last: The end line of the current closed fold, or `nil` if none
+
+
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -32,6 +32,15 @@ function vim.api.nvim__buf_stats(buffer) end
 --- - bufnr: (number) buffer id in floating window
 function vim.api.nvim__complete_set(index, opts) end
 
+--- Gets the start and end lines for the closed fold on the given line
+---
+--- @param window integer `window-ID`, or 0 for current window
+--- @param lnum integer The line number to check (0-indexed)
+--- @return vim.api.keyset.fold_info # Dict containing fold information, with these keys:
+--- - first: The start line of the current closed fold, or `nil` if none
+--- - last: The end line of the current closed fold, or `nil` if none
+function vim.api.nvim__fold_info(window, lnum) end
+
 --- @return string
 function vim.api.nvim__get_lib_dir() end
 

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -112,6 +112,10 @@ error('Cannot require a meta file')
 --- @class vim.api.keyset.exec_opts
 --- @field output? boolean
 
+--- @class vim.api.keyset.fold_info
+--- @field first? integer
+--- @field last? integer
+
 --- @class vim.api.keyset.get_autocmds
 --- @field event? string|string[]
 --- @field group? integer|string

--- a/src/gen/gen_api_dispatch.lua
+++ b/src/gen/gen_api_dispatch.lua
@@ -5,7 +5,7 @@
 --    make
 --    cp build/nvim_version.lua src/nvim/
 --    cd src/nvim
---    nvim -l generators/gen_api_dispatch.lua "../../build/src/nvim/auto/api/private/dispatch_wrappers.generated.h" "../../build/src/nvim/auto/api/private/api_metadata.generated.h" "../../build/funcs_metadata.mpack" "../../build/src/nvim/auto/lua_api_c_bindings.generated.h" "../../build/src/nvim/auto/keysets_defs.generated.h" "../../build/ui_metadata.mpack" "../../build/cmake.config/auto/versiondef_git.h" "./api/autocmd.h" "./api/buffer.h" "./api/command.h" "./api/deprecated.h" "./api/extmark.h" "./api/keysets_defs.h" "./api/options.h" "./api/tabpage.h" "./api/ui.h" "./api/vim.h" "./api/vimscript.h" "./api/win_config.h" "./api/window.h" "../../build/include/api/autocmd.h.generated.h" "../../build/include/api/buffer.h.generated.h" "../../build/include/api/command.h.generated.h" "../../build/include/api/deprecated.h.generated.h" "../../build/include/api/extmark.h.generated.h" "../../build/include/api/options.h.generated.h" "../../build/include/api/tabpage.h.generated.h" "../../build/include/api/ui.h.generated.h" "../../build/include/api/vim.h.generated.h" "../../build/include/api/vimscript.h.generated.h" "../../build/include/api/win_config.h.generated.h" "../../build/include/api/window.h.generated.h"
+--    nvim -l generators/gen_api_dispatch.lua "../../build/src/nvim/auto/api/private/dispatch_wrappers.generated.h" "../../build/src/nvim/auto/api/private/api_metadata.generated.h" "../../build/funcs_metadata.mpack" "../../build/src/nvim/auto/lua_api_c_bindings.generated.h" "../../build/src/nvim/auto/keysets_defs.generated.h" "../../build/ui_metadata.mpack" "../../build/cmake.config/auto/versiondef_git.h" "./api/fold.h" "./api/autocmd.h" "./api/buffer.h" "./api/command.h" "./api/deprecated.h" "./api/extmark.h" "./api/keysets_defs.h" "./api/options.h" "./api/tabpage.h" "./api/ui.h" "./api/vim.h" "./api/vimscript.h" "./api/win_config.h" "./api/window.h" "../../build/include/api/fold.h.generated.h" "../../build/include/api/autocmd.h.generated.h" "../../build/include/api/buffer.h.generated.h" "../../build/include/api/command.h.generated.h" "../../build/include/api/deprecated.h.generated.h" "../../build/include/api/extmark.h.generated.h" "../../build/include/api/options.h.generated.h" "../../build/include/api/tabpage.h.generated.h" "../../build/include/api/ui.h.generated.h" "../../build/include/api/vim.h.generated.h" "../../build/include/api/vimscript.h.generated.h" "../../build/include/api/win_config.h.generated.h" "../../build/include/api/window.h.generated.h"
 
 local mpack = vim.mpack
 
@@ -337,6 +337,7 @@ output:write([[
 #include "nvim/api/vimscript.h"
 #include "nvim/api/win_config.h"
 #include "nvim/api/window.h"
+#include "nvim/api/fold.h"
 #include "nvim/ui_client.h"
 
 ]])

--- a/src/gen/gen_vimdoc.lua
+++ b/src/gen/gen_vimdoc.lua
@@ -118,6 +118,7 @@ local config = {
       'tabpage.c',
       'autocmd.c',
       'ui.c',
+      'fold.c',
     },
     exclude_types = true,
     fn_name_pat = 'nvim_.*',

--- a/src/nvim/api/fold.c
+++ b/src/nvim/api/fold.c
@@ -1,0 +1,43 @@
+#include <stdbool.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "nvim/api/fold.h"
+#include "nvim/api/private/dispatch.h"
+#include "nvim/api/private/validate.h"
+#include "nvim/fold.h"
+#include "nvim/pos_defs.h"
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "api/fold.c.generated.h"  // IWYU pragma: keep
+#endif
+
+/// Gets the start and end lines for the closed fold on the given line
+///
+/// @param window   |window-ID|, or 0 for current window
+/// @param lnum   The line number to check (0-indexed)
+/// @param[out] err Error details, if any
+/// @return  Dict containing fold information, with these keys:
+///          - first: The start line of the current closed fold, or `nil` if none
+///          - last: The end line of the current closed fold, or `nil` if none
+Dict(fold_info) nvim__fold_info(Window window, Integer lnum, Arena *arena, Error *err)
+  FUNC_API_SINCE(14)
+{
+  Dict(fold_info) rv = KEYDICT_INIT;
+  win_T *win = find_window_by_handle(window, err);
+
+  if (win) {
+    if (lnum >= 0 && lnum <= win->w_buffer->b_ml.ml_line_count - 1) {
+      linenr_T first;
+      linenr_T last;
+      if (hasFoldingWin(win, (linenr_T)(lnum + 1), &first, &last, false, NULL)) {
+        PUT_KEY(rv, fold_info, first, first);
+        PUT_KEY(rv, fold_info, last, last);
+      }
+    } else {
+      api_set_error(err, kErrorTypeValidation, "Line number outside range");
+    }
+  }
+
+  return rv;
+}

--- a/src/nvim/api/fold.h
+++ b/src/nvim/api/fold.h
@@ -1,0 +1,8 @@
+#pragma once
+
+#include "nvim/api/keysets_defs.h"  // IWYU pragma: keep
+#include "nvim/api/private/defs.h"  // IWYU pragma: keep
+
+#ifdef INCLUDE_GENERATED_DECLARATIONS
+# include "api/fold.h.generated.h"
+#endif

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -458,3 +458,9 @@ typedef struct {
   Integer c;
   String f;
 } Dict(_shada_buflist_item);
+
+typedef struct {
+  OptionalKeys is_set__fold_info_;
+  Integer first;
+  Integer last;
+} Dict(fold_info);

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -15,6 +15,7 @@
 #include "nvim/errors.h"
 #include "nvim/eval/window.h"
 #include "nvim/ex_docmd.h"
+#include "nvim/fold.h"
 #include "nvim/gettext_defs.h"
 #include "nvim/globals.h"
 #include "nvim/lua/executor.h"


### PR DESCRIPTION
Work on #32660. This PR has two commits:

---

### feat(api): tiny, experimental API function for getting fold info

This commit introduces a simple API function to get the start and end
lines of the closed fold on a given line in a given window.

---

### fix(treesitter): use double buffering in highlighter to reduce flickering

**Problem:** Ever since treesitter highlighting made use of async
parsing, highlights have started flickering since redraw attempts might
be made when the parser is still parsing. This is especially bad while
editing.

**Solution:** Apply a double buffering approach to the highlighter,
meaning that when redraw attempts are made when a parse has not yet
completed, the highlighter will re-apply the highlights from the
previous cycle to reduce flickering.

**Notes:**

- This mostly fixes flicker while editing; flickering for two
  windows open at the same time needs a parser-level change. Also note
  that
- The cons of this approach are that all extmarks applied by the
  highlighter must now be stored in a table which will be overwritten at
  every redraw attempt. This presumably means there will be more memory
  usage and GC overhead, but the effect seems minimal in my testing.
- This commit removes the `on_line` callback, and applies all extmarks
  in `on_win` (while still making sure to skip over folds). Treesitter
  query iteration was never really designed to be linewise, and
  eliminating flicker was nearly impossible with the previous, somewhat
  convoluted line-wise iteration logic.
- This changes highlighter extmarks to apply with `strict = true` (since the previous buffer of marks my fall outside the new buffer range)

## Before

[flicker_bad.webm](https://github.com/user-attachments/assets/670fa111-3060-4328-be4b-d6bc840be69f)

## After

[flicker_good.webm](https://github.com/user-attachments/assets/5833ba81-ca2a-4fd6-8998-ccc3afa5eb2c)