### PR TITLE
docs(lsp): `vim.api.buf_request_sync` can also take function as `params`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -789,7 +789,10 @@ buf_request_sync({bufnr}, {method}, {params}, {timeout_ms})
     Parameters: ~
       • {bufnr}       (`integer`) Buffer handle, or 0 for current.
       • {method}      (`string`) LSP method name
-      • {params}      (`table?`) Parameters to send to the server
+      • {params}      (`table|(fun(client: vim.lsp.Client, bufnr: integer): table?)?`)
+                      Parameters to send to the server. Can also be passed as
+                      a function that returns the params table for cases where
+                      parameters are specific to the client.
       • {timeout_ms}  (`integer?`, default: `1000`) Maximum time in
                       milliseconds to wait for a result.
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1230,7 +1230,9 @@ end
 ---
 ---@param bufnr integer Buffer handle, or 0 for current.
 ---@param method string LSP method name
----@param params table? Parameters to send to the server
+---@param params? table|(fun(client: vim.lsp.Client, bufnr: integer): table?) Parameters to send to the server.
+---               Can also be passed as a function that returns the params table for cases where
+---               parameters are specific to the client.
 ---@param timeout_ms integer? Maximum time in milliseconds to wait for a result.
 ---                           (default: `1000`)
 ---@return table<integer, {error: lsp.ResponseError?, result: any}>? result Map of client_id:request_result.


### PR DESCRIPTION
Currently in my own config, I pass the new function handler into `buf_request_sync`, however the linter complains so I've to silence it with `---@diagnostic disable-next-line: param-type-mismatch`.

While this isn't a big deal, `buf_request_sync` can accept the function, so the docs/linter may as well know about it.