### PR TITLE
feat(checkhealth): use emoji for OK/WARN/ERROR

### DIFF
--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -275,7 +275,7 @@ end
 ---
 --- @param msg string
 function M.ok(msg)
-  local input = format_report_message('OK', msg)
+  local input = format_report_message('✅ OK', msg)
   collect_output(input)
 end
 
@@ -284,7 +284,7 @@ end
 --- @param msg string
 --- @param ... string|string[] Optional advice
 function M.warn(msg, ...)
-  local input = format_report_message('WARNING', msg, ...)
+  local input = format_report_message('🤔 WARNING', msg, ...)
   collect_output(input)
 end
 
@@ -293,7 +293,7 @@ end
 --- @param msg string
 --- @param ... string|string[] Optional advice
 function M.error(msg, ...)
-  local input = format_report_message('ERROR', msg, ...)
+  local input = format_report_message('❌ ERROR', msg, ...)
   collect_output(input)
 end
 

--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -284,7 +284,7 @@ end
 --- @param msg string
 --- @param ... string|string[] Optional advice
 function M.warn(msg, ...)
-  local input = format_report_message('🤔 WARNING', msg, ...)
+  local input = format_report_message('⚠️ WARNING', msg, ...)
   collect_output(input)
 end
 

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -86,7 +86,7 @@ describe('vim.health', function()
   end)
 
   describe(':checkhealth', function()
-    it('functions report_*() render correctly', function()
+    it('report_xx() renders correctly', function()
       command('checkhealth full_render')
       n.expect([[
 
@@ -94,15 +94,15 @@ describe('vim.health', function()
       test_plug.full_render:         require("test_plug.full_render.health").check()
 
       report 1 ~
-      - OK life is fine
-      - WARNING no what installed
+      - ✅ OK life is fine
+      - ⚠️ WARNING no what installed
         - ADVICE:
           - pip what
           - make what
 
       report 2 ~
       - stuff is stable
-      - ERROR why no hardcopy
+      - ❌ ERROR why no hardcopy
         - ADVICE:
           - :help |:hardcopy|
           - :help |:TOhtml|
@@ -117,25 +117,25 @@ describe('vim.health', function()
         test_plug:                                 require("test_plug.health").check()
 
         report 1 ~
-        - OK everything is fine
+        - ✅ OK everything is fine
 
         report 2 ~
-        - OK nothing to see here
+        - ✅ OK nothing to see here
 
         ==============================================================================
         test_plug.success1:               require("test_plug.success1.health").check()
 
         report 1 ~
-        - OK everything is fine
+        - ✅ OK everything is fine
 
         report 2 ~
-        - OK nothing to see here
+        - ✅ OK nothing to see here
 
         ==============================================================================
         test_plug.success2:               require("test_plug.success2.health").check()
 
         another 1 ~
-        - OK ok
+        - ✅ OK ok
         ]])
     end)
 
@@ -147,10 +147,10 @@ describe('vim.health', function()
         test_plug.submodule:             require("test_plug.submodule.health").check()
 
         report 1 ~
-        - OK everything is fine
+        - ✅ OK everything is fine
 
         report 2 ~
-        - OK nothing to see here
+        - ✅ OK nothing to see here
         ]])
     end)
 
@@ -161,7 +161,7 @@ describe('vim.health', function()
       ==============================================================================
       test_plug.submodule_empty: require("test_plug.submodule_empty.health").check()
 
-      - ERROR The healthcheck report for "test_plug.submodule_empty" plugin is empty.
+      - ❌ ERROR The healthcheck report for "test_plug.submodule_empty" plugin is empty.
       ]])
     end)
 
@@ -182,13 +182,13 @@ describe('vim.health', function()
         {Bar:                                                  }|
         {h1:foo:                                              }|
                                                           |
-        - {Error:ERROR} No healthcheck found for "foo" plugin.    |
+        - ❌ {Error:ERROR} No healthcheck found for "foo" plugin. |
                                                           |
         {Bar:                                                  }|
         {h1:test_plug.success1:               require("test_pl}|
                                                           |
         {h2:report 1}                                          |
-        - {Ok:OK} everything is fine                           |
+        - ✅ {Ok:OK} everything is fine                        |
                                                           |
       ]],
       }
@@ -202,11 +202,11 @@ describe('vim.health', function()
         ==============================================================================
         non_existent_healthcheck:                                                     
 
-        - ERROR No healthcheck found for "non_existent_healthcheck" plugin.
+        - ❌ ERROR No healthcheck found for "non_existent_healthcheck" plugin.
         ]])
     end)
 
-    it('does not use vim.health as a healtcheck', function()
+    it('does not use vim.health as a healthcheck', function()
       -- vim.health is not a healthcheck
       command('checkhealth vim')
       n.expect([[
@@ -221,7 +221,7 @@ describe('vim.health', function()
       test_plug.lua:                         require("test_plug.lua.health").check()
 
       nested lua/ directory ~
-      - OK everything is ok
+      - ✅ OK everything is ok
       ]])
     end)
 
@@ -239,7 +239,7 @@ describe('vim.health', function()
       nest:                                           require("nest.health").check()
 
       healthy pack ~
-      - OK healthy ok
+      - ✅ OK healthy ok
       ]])
     end)
   end)
@@ -285,10 +285,10 @@ describe(':checkhealth window', function()
       {h1:require("test_plug.success1.health").check()}      |
                                                         |
       {h2:report 1}                                          |
-      - {32:OK} everything is fine                           |
+      - ✅ {32:OK} everything is fine                        |
                                                         |
       {h2:report 2}                                          |
-      - {32:OK} nothing to see here                          |
+      - ✅ {32:OK} nothing to see here                       |
     ## grid 3
                                                         |
     ]],
@@ -328,12 +328,14 @@ describe(':checkhealth window', function()
       {h1:success1.health").check()}|
                                |
       {h2:report 1}                 |
-      - {32:OK} everything is fine  |
+      - ✅ {32:OK} everything is    |
+      fine                     |
                                |
       {h2:report 2}                 |
-      - {32:OK} nothing to see here |
+      - ✅ {32:OK} nothing to see   |
+      here                     |
                                |
-      {1:~                        }|*3
+      {1:~                        }|
     ]]):format(
         left and '[4:-------------------------]│[2:------------------------]|*19'
           or '[2:------------------------]│[4:-------------------------]|*19',
@@ -385,10 +387,10 @@ describe(':checkhealth window', function()
       require("test_plug.success1.health").check()      |
                                                         |
       report 1                                          |
-      - OK everything is fine                           |
+      - ✅ OK everything is fine                        |
                                                         |
       report 2                                          |
-      - OK nothing to see here                          |
+      - ✅ OK nothing to see here                       |
                                                         |
     ]]):format(
         top


### PR DESCRIPTION
## Problem:
Health status can be much more visually distinct.

## Solution:
- Use emoji next to each status.
    - <img width="675" alt="image" src="https://github.com/user-attachments/assets/f20766dd-ada9-4ef4-b2a7-b01a4b055fca" />


## Future:
- `OK` etc should also be highlighted with `DiagnosticOk`, etc. https://github.com/neovim/neovim/issues/32646