### PR TITLE
fix(terminal): emit Termrequest for all recognized osc sequence

### DIFF
--- a/src/nvim/vterm/state.c
+++ b/src/nvim/vterm/state.c
@@ -1948,28 +1948,26 @@ static int on_osc(int command, VTermStringFragment frag, void *user)
   case 0:
     settermprop_string(state, VTERM_PROP_ICONNAME, frag);
     settermprop_string(state, VTERM_PROP_TITLE, frag);
-    return 1;
+    break;
 
   case 1:
     settermprop_string(state, VTERM_PROP_ICONNAME, frag);
-    return 1;
+    break;
 
   case 2:
     settermprop_string(state, VTERM_PROP_TITLE, frag);
-    return 1;
+    break;
 
   case 52:
     if (state->selection.callbacks) {
       osc_selection(state, frag);
     }
+    break;
+  }
 
-    return 1;
-
-  default:
-    if (state->fallbacks && state->fallbacks->osc) {
-      if ((*state->fallbacks->osc)(command, frag, state->fbdata)) {
-        return 1;
-      }
+  if (state->fallbacks && state->fallbacks->osc) {
+    if ((*state->fallbacks->osc)(command, frag, state->fbdata)) {
+      return 1;
     }
   }
 


### PR DESCRIPTION
Problem: osc 0/1/2/52 didn't emit TermRequest.

Solution: emit `TermRequest` for all recognized osc.

Related: https://github.com/neovim/neovim/discussions/33165#discussioncomment-12666099.
