### PR TITLE
feat(build): ignore out-of-source build folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,7 +10,6 @@ compile_commands.json
 /.idea/
 
 # Build/deps dir
-/build/
 /.deps/
 /tmp/
 /.clangd/

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -35,6 +35,11 @@ include(InstallHelpers)
 include(PreventInTreeBuilds)
 include(Util)
 
+if(NOT PROJECT_SOURCE_DIR STREQUAL PROJECT_BINARY_DIR)
+  # Auto-create a .gitignore in the specified "build" directory.
+  file(GENERATE OUTPUT .gitignore CONTENT "*")
+endif()
+
 #-------------------------------------------------------------------------------
 # User settings
 #-------------------------------------------------------------------------------


### PR DESCRIPTION
Create a `.gitignore` file inside a build folder. This way this folder
will be ignored by git and hence, no entry in the root `.gitignore` is
required.

This PR mimics meson build system's default behaviour.

For more information see this post:
https://www.scivision.dev/cmake-auto-gitignore-build-dir/