### PR TITLE
vim-patch:9.1.1260: Hang when filtering buffer with NUL bytes

### DIFF
--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -1211,7 +1211,6 @@ static void read_input(StringBuilder *buf)
   size_t lplen = (size_t)ml_get_len(lnum);
 
   while (true) {
-    lplen -= written;
     if (lplen == 0) {
       len = 0;
     } else if (lp[written] == NL) {
@@ -1220,11 +1219,11 @@ static void read_input(StringBuilder *buf)
       kv_push(*buf, NUL);
     } else {
       char *s = vim_strchr(lp + written, NL);
-      len = s == NULL ? lplen : (size_t)(s - (lp + written));
+      len = s == NULL ? lplen - written : (size_t)(s - (lp + written));
       kv_concat_len(*buf, lp + written, len);
     }
 
-    if (len == lplen) {
+    if (len == lplen - written) {
       // Finished a line, add a NL, unless this line should not have one.
       if (lnum != curbuf->b_op_end.lnum
           || (!curbuf->b_p_bin && curbuf->b_p_fixeol)

--- a/test/old/testdir/test_shell.vim
+++ b/test/old/testdir/test_shell.vim
@@ -281,4 +281,18 @@ func Test_shell_no_prevcmd()
   call delete('Xtestdone')
 endfunc
 
+func Test_shell_filter_buffer_with_nul_bytes()
+  CheckUnix
+  new
+  set noshelltemp
+  " \n is a NUL byte
+  let lines = ["aaa\nbbb\nccc\nddd\neee", "fff\nggg\nhhh\niii\njjj"]
+  call setline(1, lines)
+  %!cat
+  call assert_equal(lines, getline(1, '$'))
+
+  set shelltemp&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Fix #33173

#### vim-patch:9.1.1260: Hang when filtering buffer with NUL bytes

Problem:  Hang when filtering buffer with NUL bytes (after 9.1.1050).
Solution: Don't subtract "written" from "lplen" repeatedly (zeertzjq).

closes: vim/vim#17011

https://github.com/vim/vim/commit/53fed23cb7bd59d9400961b44c6c8dca0029c929