### PR TITLE
vim-patch:9.1.1263: string length wrong in get_last_inserted_save()

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2774,7 +2774,7 @@ char *get_last_insert_save(void)
 
   char *s = xmemdupz(insert.data, insert.size);
   if (insert.size > 0 && s[insert.size - 1] == ESC) {  // remain trailing ESC
-    s[insert.size - 1] = NUL;
+    s[--insert.size] = NUL;
   }
   return s;
 }


### PR DESCRIPTION
#### vim-patch:9.1.1263: string length wrong in get_last_inserted_save()

Problem:  string length wrong in get_last_inserted_save()
          (after v9.1.1222)
Solution: when removing trailing ESC, also decrease the string length
          (Christ van Willegen)

closes: vim/vim#16961

https://github.com/vim/vim/commit/583f5aee96940c29ba17ffb87f1ddf56741b72ba

Co-authored-by: Christ van Willegen <cvwillegen@gmail.com>