### PR TITLE
vim-patch:649a237: runtime(debversions): Add release name for Debian 15 - duke

### DIFF
--- a/runtime/syntax/shared/debversions.vim
+++ b/runtime/syntax/shared/debversions.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:     Debian version information
 " Maintainer:   Debian Vim Maintainers
-" Last Change:  2024 Nov 04
+" Last Change:  2025 Mar 29
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/shared/debversions.vim
 
 let s:cpo = &cpo
@@ -9,7 +9,7 @@ set cpo-=C
 
 let g:debSharedSupportedVersions = [
       \ 'oldstable', 'stable', 'testing', 'unstable', 'experimental', 'sid', 'rc-buggy',
-      \ 'bullseye', 'bookworm', 'trixie', 'forky',
+      \ 'bullseye', 'bookworm', 'trixie', 'forky', 'duke',
       \
       \ 'focal', 'jammy', 'noble', 'oracular', 'plucky',
       \ 'devel'


### PR DESCRIPTION
#### vim-patch:649a237: runtime(debversions): Add release name for Debian 15 - duke

https://lists.debian.org/debian-devel-announce/2025/01/msg00004.html

closes: vim/vim#17010

https://github.com/vim/vim/commit/649a237bc886a2b702e95d5d45f661d8db6025f8

Co-authored-by: James McCoy <jamessan@jamessan.com>