### PR TITLE
fix(move): adjust for concealed lines above topline after scrolling up

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -1363,8 +1363,9 @@ bool scrolldown(win_T *wp, linenr_T line_count, int byfold)
           }
           wp->w_botline -= wp->w_topline - first;
           wp->w_topline = first;
+        } else if (decor_conceal_line(wp, wp->w_topline - 1, false)) {
+          todo++;
         } else {
-          todo += decor_conceal_line(wp, wp->w_topline - 1, false);
           if (do_sms) {
             int size = linetabsize_eol(wp, wp->w_topline);
             if (size > width1) {
@@ -1386,6 +1387,13 @@ bool scrolldown(win_T *wp, linenr_T line_count, int byfold)
     wp->w_botline--;                // approximate w_botline
     invalidate_botline(wp);
   }
+
+  // Adjust for concealed lines above w_topline
+  while (wp->w_topline > 1 && decor_conceal_line(wp, wp->w_topline - 2, false)) {
+    wp->w_topline--;
+    hasFolding(wp, wp->w_topline, &wp->w_topline, NULL);
+  }
+
   wp->w_wrow += done;               // keep w_wrow updated
   wp->w_cline_row += done;          // keep w_cline_row updated
 

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2978,6 +2978,13 @@ describe('extmark decorations', function()
       {1:~                                                 }|
                                                         |
     ]])
+    -- No asymmetric topline for <C-E><C-Y> #33182
+    feed('4<C-E>')
+    exec('set concealcursor=n')
+    api.nvim_buf_set_extmark(0, ns, 4, 0, { conceal_lines = "" })
+    eq(5, n.fn.line('w0'))
+    feed('<C-E><C-Y>')
+    eq(5, n.fn.line('w0'))
   end)
 end)
 


### PR DESCRIPTION
Problem:  Scrolling up does not adjust `w_topline` for concealed lines
          directly above it, resulting in (non-visual) asymmetry when
          scrolling up/down.
Solution: Adjust `w_topline` for concealed lines after scrolling up.

Fix #33182