### PR TITLE
fix(defaults): enable term-buffer ]] motion for operator-pending mode 

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -622,10 +622,10 @@ do
       end
       vim.wo[0][0].winhighlight = winhl .. 'StatusLine:StatusLineTerm,StatusLineNC:StatusLineTermNC'
 
-      vim.keymap.set({ 'n', 'x' }, '[[', function()
+      vim.keymap.set({ 'n', 'x', 'o' }, '[[', function()
         jump_to_prompt(nvim_terminal_prompt_ns, 0, args.buf, -vim.v.count1)
       end, { buffer = args.buf, desc = 'Jump [count] shell prompts backward' })
-      vim.keymap.set({ 'n', 'x' }, ']]', function()
+      vim.keymap.set({ 'n', 'x', 'o' }, ']]', function()
         jump_to_prompt(nvim_terminal_prompt_ns, 0, args.buf, vim.v.count1)
       end, { buffer = args.buf, desc = 'Jump [count] shell prompts forward' })
     end,


### PR DESCRIPTION
This enables y]] to copy a command and its output.