### PR TITLE
docs: lua-module-load

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -218,17 +218,6 @@ and loads the first module found ("first wins"): >
     bar/lua/mod.so
     bar/lua/mod.dll
 <
-Note:
-
-- Although 'runtimepath' is tracked, Nvim does not track current
-  values of |package.path| or |package.cpath|. If you happen to delete some
-  paths from there you can set 'runtimepath' to trigger an update: >vim
-      let &runtimepath = &runtimepath
-
-- Skipping paths from 'runtimepath' which contain semicolons applies both to
-  |package.path| and |package.cpath|. Given that there are some badly written
-  plugins using shell, which will not work with paths containing semicolons,
-  it is better to not have them in 'runtimepath' at all.
 
 ==============================================================================
 COMMANDS                                                        *lua-commands*


### PR DESCRIPTION
Problem:
I just realize that no text in *Note* section there applies to current Nvim. For example:
```vim
:lua package.path = ''
:let &rtp = &rtp
:=package.path " Still '' instead of the "updated value"
```
I have also tested with a runtimepath including semicolon (I move my plugins path from `~/.local/share/nvim/plug` to `~/.local/share/nvim/plug;pack` and it is clear that Nvim can still load modules from there after I add it to runtimepath Nvim can load modules 

Solution:
Remove the whole `Note` section