### PR TITLE
fix(docs): remove TODO item from news-0.11.txt

### DIFF
--- a/runtime/doc/news-0.11.txt
+++ b/runtime/doc/news-0.11.txt
@@ -124,8 +124,6 @@ OPTIONS
 
 PLUGINS
 
-• TODO
-
 TREESITTER
 
 • |Query:iter_matches()| correctly returns all matching nodes in a match


### PR DESCRIPTION
Problem:
The news-0.11.txt file under the Breaking Changes → Plugins section contained a TODO item, which should not be present in the final release.

Solution:
Removed the TODO bullet point under the PLUGINS section to ensure the documentation is finalized.

Fix #33208