### PR TITLE
vim-patch:4ac995b: runtime(rust): set formatprg to rustfmt

### DIFF
--- a/runtime/autoload/rustfmt.vim
+++ b/runtime/autoload/rustfmt.vim
@@ -1,5 +1,6 @@
 " Author: Stephen Sugden <stephen@stephensugden.com>
 " Last Modified: 2023-09-11
+" Last Change:   2025 Mar 31 by Vim project (rename s:RustfmtConfigOptions())
 "
 " Adapted from https://github.com/fatih/vim-go
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
@@ -61,7 +62,7 @@ function! s:RustfmtWriteMode()
     endif
 endfunction
 
-function! s:RustfmtConfigOptions()
+function! rustfmt#RustfmtConfigOptions()
     let l:rustfmt_toml = findfile('rustfmt.toml', expand('%:p:h') . ';')
     if l:rustfmt_toml !=# ''
         return '--config-path '.shellescape(fnamemodify(l:rustfmt_toml, ":p"))
@@ -84,7 +85,7 @@ function! s:RustfmtCommandRange(filename, line1, line2)
 
     let l:arg = {"file": shellescape(a:filename), "range": [a:line1, a:line2]}
     let l:write_mode = s:RustfmtWriteMode()
-    let l:rustfmt_config = s:RustfmtConfigOptions()
+    let l:rustfmt_config = rustfmt#RustfmtConfigOptions()
 
     " FIXME: When --file-lines gets to be stable, add version range checking
     " accordingly.
@@ -99,7 +100,7 @@ endfunction
 
 function! s:RustfmtCommand()
     let write_mode = g:rustfmt_emit_files ? '--emit=stdout' : '--write-mode=display'
-    let config = s:RustfmtConfigOptions()
+    let config = rustfmt#RustfmtConfigOptions()
     return join([g:rustfmt_command, write_mode, config, g:rustfmt_options])
 endfunction
 

--- a/runtime/ftplugin/rust.vim
+++ b/runtime/ftplugin/rust.vim
@@ -3,6 +3,7 @@
 " Maintainer:	Chris Morgan <me@chrismorgan.info>
 " Last Change:	2024 Mar 17
 "		2024 May 23 by Riley Bruins <ribru17@gmail.com ('commentstring')
+"		2025 Mar 31 by Vim project (set 'formatprg' option)
 " For bugs, patches and license go to https://github.com/rust-lang/rust.vim
 
 if exists("b:did_ftplugin")
@@ -56,6 +57,19 @@ setlocal include=\\v^\\s*(pub\\s+)?use\\s+\\zs(\\f\|:)+
 setlocal includeexpr=rust#IncludeExpr(v:fname)
 
 setlocal suffixesadd=.rs
+
+if executable(get(g:, 'rustfmt_command', 'rustfmt'))
+    if get(g:, "rustfmt_fail_silently", 0)
+        augroup rust.vim.FailSilently
+            autocmd! * <buffer>
+            autocmd ShellFilterPost <buffer> if v:shell_error | execute 'echom "shell filter returned error " . v:shell_error . ", undoing changes"' | undo | endif
+        augroup END
+    endif
+
+    let &l:formatprg = get(g:, 'rustfmt_command', 'rustfmt') . ' ' .
+                \ get(g:, 'rustfmt_options', '') . ' ' .
+                \ rustfmt#RustfmtConfigOptions()
+endif
 
 if exists("g:ftplugin_rust_source_path")
     let &l:path=g:ftplugin_rust_source_path . ',' . &l:path
@@ -149,7 +163,7 @@ endif
 
 let b:undo_ftplugin = "
             \ compiler make |
-            \ setlocal formatoptions< comments< commentstring< include< includeexpr< suffixesadd<
+            \ setlocal formatoptions< comments< commentstring< include< includeexpr< suffixesadd< formatprg<
             \|if exists('b:rust_set_style')
                 \|setlocal tabstop< shiftwidth< softtabstop< expandtab< textwidth<
                 \|endif


### PR DESCRIPTION
#### vim-patch:4ac995b: runtime(rust): set formatprg to rustfmt

closes: vim/vim#16967

https://github.com/vim/vim/commit/4ac995bf9366c6624a0724d19b2226f4c95694b3

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>