### PR TITLE
Virtual lines in TS query editor

### DIFF
--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -685,15 +685,16 @@ function M.edit_query(lang)
     end,
   })
 
-  api.nvim_buf_set_lines(query_buf, 0, -1, false, {
-    ';; Write queries here (see $VIMRUNTIME/queries/ for examples).',
-    ';; Move cursor to a capture ("@foo") to highlight matches in the source buffer.',
-    ';; Completion for grammar nodes is available (:help compl-omni)',
-    '',
-    '',
+  local ns = vim.api.nvim_create_namespace('nvim.treesitter.queryhint')
+  api.nvim_buf_set_extmark(query_buf, ns, 0, 0, {
+    virt_lines = {
+      { { 'Write queries here (see $VIMRUNTIME/queries/ for examples).', 'Conceal' } },
+      { { 'Move cursor to a capture ("@foo") to highlight matches in the source buffer.', 'Conceal' } },
+      { { 'Completion for grammar nodes is available (:help compl-omni)', 'Conceal' } },
+    },
+    virt_lines_above = true,
   })
-  vim.cmd('normal! G')
-  vim.cmd.startinsert()
+  vim.cmd('normal! zt')
 
   return true
 end


### PR DESCRIPTION
This is just a suggestion, feel free to close this if it's not desired.

Using comments in the query editor feels old school, and we currently have a
better solution for showing hints to a user: extmarks, in the form of virtual
lines. This PR replaces the comment on top of the query editor with virtual
lines.


| Before | After |
|--------|--------|
| <img width="732" alt="image" src="https://github.com/user-attachments/assets/972265ae-66ab-4fed-aa08-394170724e75" /> | <img width="729" alt="image" src="https://github.com/user-attachments/assets/e0371d97-d72f-4cc9-92ea-e87d81e654ec" /> |

Downside: virtual lines are truncated when they do not fit the screen. I tried `virt_lines_overflow = 'scroll'`, but couldn't figure out how to actually scroll.