### PR TITLE
test(plugin/shada_spec): failure if timezone isn't a whole hour ahead of UTC

### DIFF
--- a/test/functional/plugin/shada_spec.lua
+++ b/test/functional/plugin/shada_spec.lua
@@ -3170,8 +3170,8 @@ describe('syntax/shada.vim', function()
       month = htsnum(os.date('%m', 0)),
       day = htsnum(os.date('%d', 0)),
       hour = htsnum(os.date('!%H', 0)),
-      minute = htsnum(os.date('%M', 0)),
-      second = htsnum(os.date('%S', 0)),
+      minute = htsnum(os.date('!%M', 0)),
+      second = htsnum(os.date('!%S', 0)),
     }
     local msh = function(s)
       return {


### PR DESCRIPTION
Problem: When running functional tests locally, test `syntax/shada.vim works` fails if the local timezone is not a whole number of hours ahead of UTC.

Solution: Use '!%M' for minute format so that UTC is used in the expected timestamp instead of the local timezone, just like '%H' for hours.