### PR TITLE
fix(events): don't exit on SIGTSTP

### DIFF
--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -212,10 +212,14 @@ static void on_signal(SignalWatcher *handle, int signum, void *data)
     // Ignore
     break;
 #endif
-  case SIGTERM:
 #ifdef SIGTSTP
   case SIGTSTP:
+    if (p_awa) {
+      autowrite_all();
+    }
+    break;
 #endif
+  case SIGTERM:
 #ifdef SIGQUIT
   case SIGQUIT:
 #endif

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1576,7 +1576,8 @@ void tui_suspend(TUIData *tui)
   tui_terminal_stop(tui);
   stream_set_blocking(tui->input.in_fd, true);   // normalize stream (#2598)
 
-  kill(0, SIGTSTP);
+  // Avoid os/signal.c SIGTSTP handler. ex_stop calls auto_writeall. #33258
+  kill(0, SIGSTOP);
 
   tui_terminal_start(tui);
   tui_terminal_after_startup(tui);


### PR DESCRIPTION
Problem: after
https://github.com/neovim/neovim/commit/4dabeff308222307ede8e74a2bd341713a7f7d81,
neovim quit and crash on receive SIGTSTP (Ctrl-Z).

Solution: Don't exit on SIGTSTP (not a deadly signal).

Fix https://github.com/neovim/neovim/issues/33254.
