### PR TITLE
fix(highlight): match highlight gone after redraw during substitute prompt

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -3788,7 +3788,6 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
               redraw_later(curwin, UPD_SOME_VALID);
               show_cursor_info_later(true);
               update_screen();
-              highlight_match = false;
               redraw_later(curwin, UPD_SOME_VALID);
 
               curwin->w_p_fen = save_p_fen;
@@ -3797,6 +3796,7 @@ static int do_sub(exarg_T *eap, const proftime_T timeout, const int cmdpreview_n
               snprintf(IObuff, IOSIZE, p, sub);
               p = xstrdup(IObuff);
               typed = prompt_for_input(p, HLF_R, true, NULL);
+              highlight_match = false;
               xfree(p);
 
               msg_didout = false;                 // don't scroll up


### PR DESCRIPTION
Problem:  Redrawing during a substitute confirm prompt causes the match
          highlight to disappear.
Solution: Unset `highlight_match` after the prompt has returned.
          Use global highlight definitions in searchhl_spec.lua.

Fix #33200