### PR TITLE
vim-patch:9.1.1266: MS-Windows: type conversion warnings

### DIFF
--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -799,7 +799,7 @@ void ins_char_bytes(char *buf, size_t charlen)
 
   if (!p_ri || (State & REPLACE_FLAG)) {
     // Normal insert: move cursor right
-    curwin->w_cursor.col += (int)charlen;
+    curwin->w_cursor.col += (colnr_T)charlen;
   }
   // TODO(Bram): should try to update w_row here, to avoid recomputing it later.
 }
@@ -829,7 +829,7 @@ void ins_str(char *s, size_t slen)
   memmove(newp + col + slen, oldp + col, (size_t)bytes);
   ml_replace(lnum, newp, false);
   inserted_bytes(lnum, col, 0, (int)slen);
-  curwin->w_cursor.col += (int)slen;
+  curwin->w_cursor.col += (colnr_T)slen;
 }
 
 // Delete one character under the cursor.


### PR DESCRIPTION
#### vim-patch:9.1.1266: MS-Windows: type conversion warnings

Problem:  MS-Windows: type conversion warnings
Solution: cast the variables (Yegappan Lakshmanan)

closes: vim/vim#17027

https://github.com/vim/vim/commit/7b6add0b4a694d421a1eb9c9017698ccbedde41c

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>