### PR TITLE
feat: deprecate vim.lsp.util.stylize_markdown

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -29,7 +29,8 @@ HIGHLIGHTS
 
 LSP
 
-• todo
+• *vim.lsp.util.stylize_markdown()"	Use |vim.treesitter.start()| with
+					`vim.wo.conceallevel = 2`.
 
 LUA
 

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2495,32 +2495,6 @@ show_document({location}, {position_encoding}, {opts})
     Return: ~
         (`boolean`) `true` if succeeded
 
-                                             *vim.lsp.util.stylize_markdown()*
-stylize_markdown({bufnr}, {contents}, {opts})
-    Converts markdown into syntax highlighted regions by stripping the code
-    blocks and converting them into highlighted code. This will by default
-    insert a blank line separator after those code block regions to improve
-    readability.
-
-    This method configures the given buffer and returns the lines to set.
-
-    If you want to open a popup with fancy markdown, use
-    `open_floating_preview` instead
-
-    Parameters: ~
-      • {bufnr}     (`integer`)
-      • {contents}  (`string[]`) of lines to show in window
-      • {opts}      (`table?`) with optional fields
-                    • height of floating window
-                    • width of floating window
-                    • wrap_at character to wrap at for computing height
-                    • max_width maximal width of floating window
-                    • max_height maximal height of floating window
-                    • separator insert separator after code block
-
-    Return: ~
-        (`table`) stripped content
-
                                              *vim.lsp.util.symbols_to_items()*
 symbols_to_items({symbols}, {bufnr}, {position_encoding})
     Converts symbols to quickfix list items.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -187,6 +187,6 @@ These deprecated features were removed.
 ==============================================================================
 DEPRECATIONS                                                *news-deprecations*
 
-See |deprecated-0.11|.
+See |deprecated-0.12|.
 
  vim:tw=78:ts=8:sw=2:et:ft=help:norl:

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1079,6 +1079,7 @@ local function get_markdown_fences()
   return fences
 end
 
+--- @deprecated
 --- Converts markdown into syntax highlighted regions by stripping the code
 --- blocks and converting them into highlighted code.
 --- This will by default insert a blank line separator after those code block
@@ -1099,6 +1100,7 @@ end
 ---  - separator insert separator after code block
 ---@return table stripped content
 function M.stylize_markdown(bufnr, contents, opts)
+  vim.deprecate('vim.lsp.util.stylize_markdown', nil, '0.14')
   validate('contents', contents, 'table')
   validate('opts', opts, 'table', true)
   opts = opts or {}


### PR DESCRIPTION
It's not used anywhere.
