### PR TITLE
fix: bug in stylize_markdown

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1138,10 +1138,8 @@ function M.stylize_markdown(bufnr, contents, opts)
   -- Clean up
   contents = vim.split(table.concat(contents, '\n'), '\n', { trimempty = true })
 
-  local stripped = {}
+  local stripped = {} --- @type string[]
   local highlights = {} --- @type {ft:string,start:integer,finish:integer}[]
-  -- keep track of lnums that contain markdown
-  local markdown_lines = {} --- @type table<integer,boolean>
 
   local i = 1
   while i <= #contents do
@@ -1156,7 +1154,7 @@ function M.stylize_markdown(bufnr, contents, opts)
           i = i + 1
           break
         end
-        table.insert(stripped, line)
+        stripped[#stripped + 1] = line
         i = i + 1
       end
       table.insert(highlights, {
@@ -1166,30 +1164,23 @@ function M.stylize_markdown(bufnr, contents, opts)
       })
       -- add a separator, but not on the last line
       if opts.separator and i < #contents then
-        table.insert(stripped, '---')
-        markdown_lines[#stripped] = true
+        stripped[#stripped + 1] = '---'
       end
     else
       -- strip any empty lines or separators prior to this separator in actual markdown
       if line:match('^---+$') then
         while
-          markdown_lines[#stripped]
+          stripped[#stripped]
           and (stripped[#stripped]:match('^%s*$') or stripped[#stripped]:match('^---+$'))
         do
-          markdown_lines[#stripped] = false
-          table.remove(stripped, #stripped)
+          stripped[#stripped] = nil
         end
       end
       -- add the line if its not an empty line following a separator
       if
-        not (
-          line:match('^%s*$')
-          and markdown_lines[#stripped]
-          and stripped[#stripped]:match('^---+$')
-        )
+        not (line:match('^%s*$') and stripped[#stripped] and stripped[#stripped]:match('^---+$'))
       then
-        table.insert(stripped, line)
-        markdown_lines[#stripped] = true
+        stripped[#stripped + 1] = line
       end
       i = i + 1
     end
@@ -1220,7 +1211,7 @@ function M.stylize_markdown(bufnr, contents, opts)
 
   local sep_line = string.rep('─', math.min(width, opts.wrap_at or width))
 
-  for l in pairs(markdown_lines) do
+  for l in ipairs(stripped) do
     if stripped[l]:match('^---+$') then
       stripped[l] = sep_line
     end


### PR DESCRIPTION
Discovered in https://github.com/lewis6991/hover.nvim

`stripped` and `markdown_lines` are iterated together so must have the same length.