### PR TITLE
refactor(tests): lint float_spec, etc.

### DIFF
--- a/.stylua2.toml
+++ b/.stylua2.toml
@@ -1,0 +1,8 @@
+# Alternative settings for special snowflakes like: decorations_spec.lua, multigrid_spec.lua, etc.
+
+column_width = 140
+line_endings = "Unix"
+indent_type = "Spaces"
+indent_width = 2
+quote_style = "AutoPreferSingle"
+call_parentheses = "Input"

--- a/.styluaignore
+++ b/.styluaignore
@@ -1,15 +1,15 @@
-/build/
-/.deps/
-/runtime/lua/coxpcall.lua
-/runtime/lua/uv/_meta.lua
-/runtime/lua/vim/_meta
-/runtime/lua/vim/re.lua
+build/
+.deps/
+runtime/lua/coxpcall.lua
+runtime/lua/uv/_meta.lua
+runtime/lua/vim/_meta
+runtime/lua/vim/re.lua
 
+# These are formatted explicitly by the "formatlua2" build task.
 test/functional/ui/decorations_spec.lua
 test/functional/ui/float_spec.lua
 test/functional/ui/multigrid_spec.lua
-/test/functional/fixtures/lua/syntax_error.lua
-/test/functional/legacy/030_fileformats_spec.lua
-/test/functional/legacy/044_099_regexp_multibyte_magic_spec.lua
-/test/functional/legacy/093_mksession_cursor_cols_latin1_spec.lua
-/test/functional/lua/luaeval_spec.lua
+test/functional/fixtures/lua/syntax_error.lua
+test/functional/legacy/030_fileformats_spec.lua
+test/functional/legacy/044_099_regexp_multibyte_magic_spec.lua
+test/functional/legacy/093_mksession_cursor_cols_latin1_spec.lua

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -281,7 +281,15 @@ add_glob_target(
   GLOB_DIRS ${STYLUA_DIRS}
   GLOB_PAT *.lua
   TOUCH_STRATEGY PER_DIR)
-
+# Special handling of some files (which are ignored in .styluaignore).
+# Workaround because stylua doesn't(?) support file-specific settings.
+add_custom_target(formatlua2
+  COMMAND ${STYLUA_PRG} --config-path "${PROJECT_SOURCE_DIR}/.stylua2.toml"
+    "${PROJECT_SOURCE_DIR}/test/functional/ui/decorations_spec.lua"
+    "${PROJECT_SOURCE_DIR}/test/functional/ui/float_spec.lua"
+    "${PROJECT_SOURCE_DIR}/test/functional/ui/multigrid_spec.lua"
+)
+add_dependencies(formatlua formatlua2)
 add_custom_target(format)
 add_dependencies(format formatc formatlua)
 

--- a/src/gen/luacats_grammar.lua
+++ b/src/gen/luacats_grammar.lua
@@ -170,6 +170,7 @@ local ty_name = Cg(ty_ident, 'name')
 local opt_parent = opt(colon * Cg(ty_ident, 'parent'))
 local lname = (ident + ellipsis) * opt(P('?'))
 
+-- stylua: ignore
 local grammar = P {
   rep1(P('@') * (v.ats + v.ext_ats)),
 

--- a/test/functional/lua/luaeval_spec.lua
+++ b/test/functional/lua/luaeval_spec.lua
@@ -27,39 +27,45 @@ describe('luaeval()', function()
   local nested_by_level = {}
   local nested = {}
   local nested_s = '{}'
-  for i=1,100 do
+  for i = 1, 100 do
     if i % 2 == 0 then
-      nested = {nested}
+      nested = { nested }
       nested_s = '{' .. nested_s .. '}'
     else
-      nested = {nested=nested}
+      nested = { nested = nested }
       nested_s = '{nested=' .. nested_s .. '}'
     end
-    nested_by_level[i] = {o=nested, s=nested_s}
+    nested_by_level[i] = { o = nested, s = nested_s }
   end
 
   describe('second argument', function()
     it('is successfully received', function()
-      local q = {t=true, f=false, --[[n=NIL,]] d={l={'string', 42, 0.42}}}
-      eq(q, fn.luaeval("_A", q))
+      local q = {
+        t = true,
+        f = false, --[[n=NIL,]]
+        d = { l = { 'string', 42, 0.42 } },
+      }
+      eq(q, fn.luaeval('_A', q))
       -- Not tested: nil, funcrefs, returned object identity: behaviour will
       -- most likely change.
     end)
   end)
   describe('lua values', function()
     it('are successfully transformed', function()
-      eq({n=1, f=1.5, s='string', l={4, 2}},
-         fn.luaeval('{n=1, f=1.5, s="string", l={4, 2}}'))
+      eq(
+        { n = 1, f = 1.5, s = 'string', l = { 4, 2 } },
+        fn.luaeval('{n=1, f=1.5, s="string", l={4, 2}}')
+      )
       -- Not tested: nil inside containers: behaviour will most likely change.
       eq(NIL, fn.luaeval('nil'))
-      eq({['']=1}, fn.luaeval('{[""]=1}'))
+      eq({ [''] = 1 }, fn.luaeval('{[""]=1}'))
     end)
   end)
   describe('recursive lua values', function()
     it('are successfully transformed', function()
       command('lua rawset(_G, "d", {})')
       command('lua rawset(d, "d", d)')
-      eq('\n{\'d\': {...@0}}', fn.execute('echo luaeval("d")'))
+      eq("\n{'d': {...@0}}", fn.execute('echo luaeval("d")'))
 
       command('lua rawset(_G, "l", {})')
       command('lua table.insert(l, l)')
@@ -73,13 +79,13 @@ describe('luaeval()', function()
     end)
     it('are successfully converted to special dictionaries in table keys', function()
       command([[let d = luaeval('{["\0"]=1}')]])
-      eq({_TYPE={}, _VAL={{'\000', 1}}}, api.nvim_get_var('d'))
+      eq({ _TYPE = {}, _VAL = { { '\000', 1 } } }, api.nvim_get_var('d'))
       eq(1, fn.eval('d._TYPE is v:msgpack_types.map'))
       eq(eval('v:t_blob'), fn.eval('type(d._VAL[0][0])'))
     end)
     it('are successfully converted to blobs from a list', function()
       command([[let l = luaeval('{"abc", "a\0b", "c\0d", "def"}')]])
-      eq({'abc', 'a\000b', 'c\000d', 'def'}, api.nvim_get_var('l'))
+      eq({ 'abc', 'a\000b', 'c\000d', 'def' }, api.nvim_get_var('l'))
     end)
   end)
 
@@ -94,7 +100,7 @@ describe('luaeval()', function()
     eq(1.5, fn.luaeval('1.5'))
     eq(5, eval('"1.5"->luaeval()->type()'))
 
-    eq("test", fn.luaeval('"test"'))
+    eq('test', fn.luaeval('"test"'))
     eq(1, eval('"\'test\'"->luaeval()->type()'))
 
     eq('', fn.luaeval('""'))
@@ -111,27 +117,31 @@ describe('luaeval()', function()
     eq({}, fn.luaeval('{}'))
     eq(3, eval('type(luaeval("{}"))'))
 
-    eq({test=1, foo=2}, fn.luaeval('{test=1, foo=2}'))
+    eq({ test = 1, foo = 2 }, fn.luaeval('{test=1, foo=2}'))
     eq(4, eval('type(luaeval("{test=1, foo=2}"))'))
 
-    eq({4, 2}, fn.luaeval('{4, 2}'))
+    eq({ 4, 2 }, fn.luaeval('{4, 2}'))
     eq(3, eval('type(luaeval("{4, 2}"))'))
 
-    eq({NIL, 20}, fn.luaeval('{[2] = 20}'))
+    eq({ NIL, 20 }, fn.luaeval('{[2] = 20}'))
     eq(3, eval('type(luaeval("{[2] = 20}"))'))
 
-    eq({10, NIL, 30}, fn.luaeval('{[1] = 10, [3] = 30}'))
+    eq({ 10, NIL, 30 }, fn.luaeval('{[1] = 10, [3] = 30}'))
     eq(3, eval('type(luaeval("{[1] = 10, [3] = 30}"))'))
 
     local level = 30
     eq(nested_by_level[level].o, fn.luaeval(nested_by_level[level].s))
 
-    eq({_TYPE={}, _VAL={{'\000\n\000', '\000\n\000\000'}}},
-       fn.luaeval([[{['\0\n\0']='\0\n\0\0'}]]))
+    eq(
+      { _TYPE = {}, _VAL = { { '\000\n\000', '\000\n\000\000' } } },
+      fn.luaeval([[{['\0\n\0']='\0\n\0\0'}]])
+    )
     eq(1, eval([[luaeval('{["\0\n\0"]="\0\n\0\0"}')._TYPE is v:msgpack_types.map]]))
-    eq(eval("v:t_blob"), eval([[type(luaeval('{["\0\n\0"]="\0\n\0\0"}')._VAL[0][0])]]))
-    eq({nested={{_TYPE={}, _VAL={{'\000\n\000', '\000\n\000\000'}}}}},
-       fn.luaeval([[{nested={{['\0\n\0']='\0\n\0\0'}}}]]))
+    eq(eval('v:t_blob'), eval([[type(luaeval('{["\0\n\0"]="\0\n\0\0"}')._VAL[0][0])]]))
+    eq(
+      { nested = { { _TYPE = {}, _VAL = { { '\000\n\000', '\000\n\000\000' } } } } },
+      fn.luaeval([[{nested={{['\0\n\0']='\0\n\0\0'}}}]])
+    )
   end)
 
   it('correctly passes scalars as argument', function()
@@ -146,8 +156,8 @@ describe('luaeval()', function()
 
   it('correctly passes containers as argument', function()
     eq({}, fn.luaeval('_A', {}))
-    eq({test=1}, fn.luaeval('_A', {test=1}))
-    eq({4, 2}, fn.luaeval('_A', {4, 2}))
+    eq({ test = 1 }, fn.luaeval('_A', { test = 1 }))
+    eq({ 4, 2 }, fn.luaeval('_A', { 4, 2 }))
     local level = 28
     eq(nested_by_level[level].o, fn.luaeval('_A', nested_by_level[level].o))
   end)
@@ -157,9 +167,8 @@ describe('luaeval()', function()
   end
   local function mapsp(...)
     local val = ''
-    for i=1,(select('#', ...)/2) do
-      val = ('%s[%s,%s],'):format(val, select(i * 2 - 1, ...),
-                                  select(i * 2, ...))
+    for i = 1, (select('#', ...) / 2) do
+      val = ('%s[%s,%s],'):format(val, select(i * 2 - 1, ...), select(i * 2, ...))
     end
     return sp('map', '[' .. val .. ']')
   end
@@ -178,26 +187,27 @@ describe('luaeval()', function()
   end
 
   it('correctly passes special dictionaries', function()
-    eq({0, '\000\n\000'}, luaevalarg(sp('string', '["\\n", "\\n"]')))
-    eq({0, true}, luaevalarg(sp('boolean', 1)))
-    eq({0, false}, luaevalarg(sp('boolean', 0)))
-    eq({0, NIL}, luaevalarg(sp('nil', 0)))
-    eq({0, {[""]=""}}, luaevalarg(mapsp(sp('string', '[""]'), '""')))
+    eq({ 0, '\000\n\000' }, luaevalarg(sp('string', '["\\n", "\\n"]')))
+    eq({ 0, true }, luaevalarg(sp('boolean', 1)))
+    eq({ 0, false }, luaevalarg(sp('boolean', 0)))
+    eq({ 0, NIL }, luaevalarg(sp('nil', 0)))
+    eq({ 0, { [''] = '' } }, luaevalarg(mapsp(sp('string', '[""]'), '""')))
   end)
 
   it('issues an error in some cases', function()
-    eq("Vim(call):E5100: Cannot convert given Lua table: table should contain either only integer keys or only string keys",
-       exc_exec('call luaeval("{1, foo=2}")'))
+    eq(
+      'Vim(call):E5100: Cannot convert given Lua table: table should contain either only integer keys or only string keys',
+      exc_exec('call luaeval("{1, foo=2}")')
+    )
 
-    startswith("Vim(call):E5107: Lua: [string \"luaeval()\"]:",
-               exc_exec('call luaeval("1, 2, 3")'))
-    startswith("Vim(call):E5108: Lua: [string \"luaeval()\"]:",
-               exc_exec('call luaeval("(nil)()")'))
-
+    startswith('Vim(call):E5107: Lua: [string "luaeval()"]:', exc_exec('call luaeval("1, 2, 3")'))
+    startswith('Vim(call):E5108: Lua: [string "luaeval()"]:', exc_exec('call luaeval("(nil)()")'))
   end)
 
   it('should handle sending lua functions to viml', function()
-    eq(true, exec_lua [[
+    eq(
+      true,
+      exec_lua [[
       can_pass_lua_callback_to_vim_from_lua_result = nil
 
       vim.fn.call(function()
@@ -205,11 +215,14 @@ describe('luaeval()', function()
       end, {})
 
       return can_pass_lua_callback_to_vim_from_lua_result
-    ]])
+    ]]
+    )
   end)
 
   it('run functions even in timers', function()
-    eq(true, exec_lua [[
+    eq(
+      true,
+      exec_lua [[
       can_pass_lua_callback_to_vim_from_lua_result = nil
 
       vim.fn.timer_start(50, function()
@@ -221,11 +234,14 @@ describe('luaeval()', function()
       end)
 
       return can_pass_lua_callback_to_vim_from_lua_result
-    ]])
+    ]]
+    )
   end)
 
   it('can run named functions more than once', function()
-    eq(5, exec_lua [[
+    eq(
+      5,
+      exec_lua [[
       count_of_vals = 0
 
       vim.fn.timer_start(5, function()
@@ -237,11 +253,14 @@ describe('luaeval()', function()
       end)
 
       return count_of_vals
-    ]])
+    ]]
+    )
   end)
 
   it('can handle clashing names', function()
-    eq(1, exec_lua [[
+    eq(
+      1,
+      exec_lua [[
       local f_loc = function() return 1 end
 
       local result = nil
@@ -253,11 +272,14 @@ describe('luaeval()', function()
       vim.wait(1000, function() return result ~= nil end)
 
       return result
-    ]])
+    ]]
+    )
   end)
 
   it('can handle functions with errors', function()
-    eq(true, exec_lua [[
+    eq(
+      true,
+      exec_lua [[
       vim.fn.timer_start(10, function()
         error("dead function")
       end)
@@ -265,7 +287,8 @@ describe('luaeval()', function()
       vim.wait(1000, function() return false end)
 
       return true
-    ]])
+    ]]
+    )
   end)
 
   it('should handle passing functions around', function()
@@ -276,7 +299,9 @@ describe('luaeval()', function()
       endfunction
     ]]
 
-    eq("Hello Vim I'm Lua", exec_lua [[
+    eq(
+      "Hello Vim I'm Lua",
+      exec_lua [[
       can_pass_lua_callback_to_vim_from_lua_result = ""
 
       vim.fn.VimCanCallLuaCallbacks(
@@ -285,7 +310,8 @@ describe('luaeval()', function()
       )
 
       return can_pass_lua_callback_to_vim_from_lua_result
-    ]])
+    ]]
+    )
   end)
 
   it('should handle funcrefs', function()
@@ -296,7 +322,9 @@ describe('luaeval()', function()
       endfunction
     ]]
 
-    eq("Hello Vim I'm Lua", exec_lua [[
+    eq(
+      "Hello Vim I'm Lua",
+      exec_lua [[
       can_pass_lua_callback_to_vim_from_lua_result = ""
 
       vim.funcref('VimCanCallLuaCallbacks')(
@@ -305,11 +333,14 @@ describe('luaeval()', function()
       )
 
       return can_pass_lua_callback_to_vim_from_lua_result
-    ]])
+    ]]
+    )
   end)
 
   it('should work with metatables using __call', function()
-    eq(1, exec_lua [[
+    eq(
+      1,
+      exec_lua [[
       local this_is_local_variable = false
       local callable_table = setmetatable({x = 1}, {
         __call = function(t, ...)
@@ -324,11 +355,14 @@ describe('luaeval()', function()
       end)
 
       return this_is_local_variable
-    ]])
+    ]]
+    )
   end)
 
   it('should handle being called from a timer once.', function()
-    eq(3, exec_lua [[
+    eq(
+      3,
+      exec_lua [[
       local this_is_local_variable = false
       local callable_table = setmetatable({5, 4, 3, 2, 1}, {
         __call = function(t, ...) this_is_local_variable = t[3] end
@@ -340,11 +374,14 @@ describe('luaeval()', function()
       end)
 
       return this_is_local_variable
-    ]])
+    ]]
+    )
   end)
 
   it('should call functions once with __call metamethod', function()
-    eq(true, exec_lua [[
+    eq(
+      true,
+      exec_lua [[
       local this_is_local_variable = false
       local callable_table = setmetatable({a = true, b = false}, {
         __call = function(t, ...) this_is_local_variable = t.a end
@@ -354,11 +391,14 @@ describe('luaeval()', function()
       vim.fn.call(callable_table, {})
 
       return this_is_local_variable
-    ]])
+    ]]
+    )
   end)
 
   it('should work with lists using __call', function()
-    eq(3, exec_lua [[
+    eq(
+      3,
+      exec_lua [[
       local this_is_local_variable = false
       local mt = {
         __call = function(t, ...)
@@ -382,16 +422,20 @@ describe('luaeval()', function()
       end)
 
       return this_is_local_variable
-    ]])
+    ]]
+    )
   end)
 
   it('should not work with tables not using __call', function()
-    eq({false, 'Vim:E921: Invalid callback argument'}, exec_lua [[
+    eq(
+      { false, 'Vim:E921: Invalid callback argument' },
+      exec_lua [[
       local this_is_local_variable = false
       local callable_table = setmetatable({x = 1}, {})
 
       return {pcall(function() vim.fn.timer_start(5, callable_table) end)}
-    ]])
+    ]]
+    )
   end)
 
   it('correctly converts containers with type_idx', function()
@@ -402,8 +446,14 @@ describe('luaeval()', function()
     eq({}, fn.luaeval('{[vim.type_idx]=vim.types.array}'))
 
     -- Presence of type_idx makes Vim ignore some keys
-    eq({42}, fn.luaeval('{[vim.type_idx]=vim.types.array, [vim.val_idx]=10, [5]=1, foo=2, [1]=42}'))
-    eq({foo=2}, fn.luaeval('{[vim.type_idx]=vim.types.dictionary, [vim.val_idx]=10, [5]=1, foo=2, [1]=42}'))
+    eq(
+      { 42 },
+      fn.luaeval('{[vim.type_idx]=vim.types.array, [vim.val_idx]=10, [5]=1, foo=2, [1]=42}')
+    )
+    eq(
+      { foo = 2 },
+      fn.luaeval('{[vim.type_idx]=vim.types.dictionary, [vim.val_idx]=10, [5]=1, foo=2, [1]=42}')
+    )
     eq(10, fn.luaeval('{[vim.type_idx]=vim.types.float, [vim.val_idx]=10, [5]=1, foo=2, [1]=42}'))
 
     -- The following should not crash
@@ -418,7 +468,7 @@ describe('luaeval()', function()
     eq(true, eval('luaeval("_A.d == _A.d[1]", {"d": l})'))
     eq(true, eval('luaeval("_A ~= _A[1]", [l])'))
 
-    api.nvim_set_var('d', {foo=42})
+    api.nvim_set_var('d', { foo = 42 })
     eval('extend(d, {"d": d})')
     eq(true, eval('luaeval("_A == _A.d", d)'))
     eq(true, eval('luaeval("_A[1] == _A[1].d", [d])'))
@@ -428,19 +478,23 @@ describe('luaeval()', function()
 
   it('errors out correctly when doing incorrect things in lua', function()
     -- Conversion errors
-    eq('Vim(call):E5108: Lua: [string "luaeval()"]:1: attempt to call field \'xxx_nonexistent_key_xxx\' (a nil value)',
-       remove_trace(exc_exec([[call luaeval("vim.xxx_nonexistent_key_xxx()")]])))
-    eq('Vim(call):E5108: Lua: [string "luaeval()"]:1: ERROR',
-       remove_trace(exc_exec([[call luaeval("error('ERROR')")]])))
-    eq('Vim(call):E5108: Lua: [NULL]',
-       remove_trace(exc_exec([[call luaeval("error(nil)")]])))
+    eq(
+      'Vim(call):E5108: Lua: [string "luaeval()"]:1: attempt to call field \'xxx_nonexistent_key_xxx\' (a nil value)',
+      remove_trace(exc_exec([[call luaeval("vim.xxx_nonexistent_key_xxx()")]]))
+    )
+    eq(
+      'Vim(call):E5108: Lua: [string "luaeval()"]:1: ERROR',
+      remove_trace(exc_exec([[call luaeval("error('ERROR')")]]))
+    )
+    eq('Vim(call):E5108: Lua: [NULL]', remove_trace(exc_exec([[call luaeval("error(nil)")]])))
   end)
 
-  it('does not leak memory when called with too long line',
-  function()
+  it('does not leak memory when called with too long line', function()
     local s = ('x'):rep(65536)
-    eq('Vim(call):E5107: Lua: [string "luaeval()"]:1: unexpected symbol near \')\'',
-       exc_exec([[call luaeval("(']] .. s ..[[' + )")]]))
+    eq(
+      'Vim(call):E5107: Lua: [string "luaeval()"]:1: unexpected symbol near \')\'',
+      exc_exec([[call luaeval("(']] .. s .. [[' + )")]])
+    )
     eq(s, fn.luaeval('"' .. s .. '"'))
   end)
 end)
@@ -478,12 +532,14 @@ describe('v:lua', function()
     eq(7, eval('v:lua.foo(3,4,v:null)'))
     eq(true, exec_lua([[return _G.val == vim.NIL]]))
     eq(NIL, eval('v:lua.mymod.noisy("eval")'))
-    eq("hey eval", api.nvim_get_current_line())
-    eq("string: abc", eval('v:lua.mymod.whatis(0z616263)'))
-    eq("string: ", eval('v:lua.mymod.whatis(v:_null_blob)'))
+    eq('hey eval', api.nvim_get_current_line())
+    eq('string: abc', eval('v:lua.mymod.whatis(0z616263)'))
+    eq('string: ', eval('v:lua.mymod.whatis(v:_null_blob)'))
 
-    eq("Vim:E5108: Lua: [string \"<nvim>\"]:0: attempt to call global 'nonexistent' (a nil value)",
-       pcall_err(eval, 'v:lua.mymod.crashy()'))
+    eq(
+      'Vim:E5108: Lua: [string "<nvim>"]:0: attempt to call global \'nonexistent\' (a nil value)',
+      pcall_err(eval, 'v:lua.mymod.crashy()')
+    )
   end)
 
   it('works when called as a method', function()
@@ -491,38 +547,44 @@ describe('v:lua', function()
     eq(true, exec_lua([[return _G.val == nil]]))
 
     eq(321, eval('300->v:lua.foo(21, "boop")'))
-    eq("boop", exec_lua([[return _G.val]]))
+    eq('boop', exec_lua([[return _G.val]]))
 
     eq(NIL, eval('"there"->v:lua.mymod.noisy()'))
-    eq("hey there", api.nvim_get_current_line())
-    eq({5, 10, 15, 20}, eval('[[1], [2, 3], [4]]->v:lua.vim.tbl_flatten()->map({_, v -> v * 5})'))
+    eq('hey there', api.nvim_get_current_line())
+    eq({ 5, 10, 15, 20 }, eval('[[1], [2, 3], [4]]->v:lua.vim.tbl_flatten()->map({_, v -> v * 5})'))
 
-    eq("Vim:E5108: Lua: [string \"<nvim>\"]:0: attempt to call global 'nonexistent' (a nil value)",
-       pcall_err(eval, '"huh?"->v:lua.mymod.crashy()'))
+    eq(
+      'Vim:E5108: Lua: [string "<nvim>"]:0: attempt to call global \'nonexistent\' (a nil value)',
+      pcall_err(eval, '"huh?"->v:lua.mymod.crashy()')
+    )
   end)
 
   it('works in :call', function()
     command(":call v:lua.mymod.noisy('command')")
-    eq("hey command", api.nvim_get_current_line())
-    eq("Vim(call):E5108: Lua: [string \"<nvim>\"]:0: attempt to call global 'nonexistent' (a nil value)",
-       pcall_err(command, 'call v:lua.mymod.crashy()'))
+    eq('hey command', api.nvim_get_current_line())
+    eq(
+      'Vim(call):E5108: Lua: [string "<nvim>"]:0: attempt to call global \'nonexistent\' (a nil value)',
+      pcall_err(command, 'call v:lua.mymod.crashy()')
+    )
   end)
 
   it('works in func options', function()
     local screen = Screen.new(60, 8)
     api.nvim_set_option_value('omnifunc', 'v:lua.mymod.omni', {})
     feed('isome st<c-x><c-o>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       some stuff^                                                  |
       {1:~   }{12: stuff          }{1:                                        }|
       {1:~   }{4: steam          }{1:                                        }|
       {1:~   }{4: strange things }{1:                                        }|
       {1:~                                                           }|*3
       {5:-- Omni completion (^O^N^P) }{6:match 1 of 3}                    |
-    ]]}
+    ]],
+    }
     api.nvim_set_option_value('operatorfunc', 'v:lua.mymod.noisy', {})
     feed('<Esc>g@g@')
-    eq("hey line", api.nvim_get_current_line())
+    eq('hey line', api.nvim_get_current_line())
   end)
 
   it('supports packages', function()
@@ -535,25 +597,43 @@ describe('v:lua', function()
   end)
 
   it('throw errors for invalid use', function()
-    eq([[Vim(let):E15: Invalid expression: "v:lua.func"]], pcall_err(command, "let g:Func = v:lua.func"))
-    eq([[Vim(let):E15: Invalid expression: "v:lua"]], pcall_err(command, "let g:Func = v:lua"))
-    eq([[Vim(let):E15: Invalid expression: "v:['lua']"]], pcall_err(command, "let g:Func = v:['lua']"))
+    eq(
+      [[Vim(let):E15: Invalid expression: "v:lua.func"]],
+      pcall_err(command, 'let g:Func = v:lua.func')
+    )
+    eq([[Vim(let):E15: Invalid expression: "v:lua"]], pcall_err(command, 'let g:Func = v:lua'))
+    eq(
+      [[Vim(let):E15: Invalid expression: "v:['lua']"]],
+      pcall_err(command, "let g:Func = v:['lua']")
+    )
 
     eq([[Vim:E15: Invalid expression: "v:['lua'].foo()"]], pcall_err(eval, "v:['lua'].foo()"))
-    eq("Vim(call):E461: Illegal variable name: v:['lua']", pcall_err(command, "call v:['lua'].baar()"))
-    eq("Vim:E1085: Not a callable type: v:lua", pcall_err(eval, "v:lua()"))
+    eq(
+      "Vim(call):E461: Illegal variable name: v:['lua']",
+      pcall_err(command, "call v:['lua'].baar()")
+    )
+    eq('Vim:E1085: Not a callable type: v:lua', pcall_err(eval, 'v:lua()'))
 
-    eq("Vim(let):E46: Cannot change read-only variable \"v:['lua']\"", pcall_err(command, "let v:['lua'] = 'xx'"))
-    eq("Vim(let):E46: Cannot change read-only variable \"v:lua\"", pcall_err(command, "let v:lua = 'xx'"))
+    eq(
+      'Vim(let):E46: Cannot change read-only variable "v:[\'lua\']"',
+      pcall_err(command, "let v:['lua'] = 'xx'")
+    )
+    eq(
+      'Vim(let):E46: Cannot change read-only variable "v:lua"',
+      pcall_err(command, "let v:lua = 'xx'")
+    )
 
-    eq("Vim:E107: Missing parentheses: v:lua.func", pcall_err(eval, "'bad'->v:lua.func"))
-    eq("Vim:E274: No white space allowed before parenthesis", pcall_err(eval, "'bad'->v:lua.func ()"))
-    eq("Vim:E107: Missing parentheses: v:lua", pcall_err(eval, "'bad'->v:lua"))
-    eq("Vim:E1085: Not a callable type: v:lua", pcall_err(eval, "'bad'->v:lua()"))
+    eq('Vim:E107: Missing parentheses: v:lua.func', pcall_err(eval, "'bad'->v:lua.func"))
+    eq(
+      'Vim:E274: No white space allowed before parenthesis',
+      pcall_err(eval, "'bad'->v:lua.func ()")
+    )
+    eq('Vim:E107: Missing parentheses: v:lua', pcall_err(eval, "'bad'->v:lua"))
+    eq('Vim:E1085: Not a callable type: v:lua', pcall_err(eval, "'bad'->v:lua()"))
     eq([[Vim:E15: Invalid expression: "v:lua.()"]], pcall_err(eval, "'bad'->v:lua.()"))
 
-    eq("Vim:E1085: Not a callable type: v:lua", pcall_err(eval, "v:lua()"))
-    eq([[Vim:E15: Invalid expression: "v:lua.()"]], pcall_err(eval, "v:lua.()"))
+    eq('Vim:E1085: Not a callable type: v:lua', pcall_err(eval, 'v:lua()'))
+    eq([[Vim:E15: Invalid expression: "v:lua.()"]], pcall_err(eval, 'v:lua.()'))
   end)
 
   describe('invalid use in fold text', function()

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -17,7 +17,7 @@ local pcall_err = t.pcall_err
 
 --- @return integer
 local function setup_provider(code)
-  return exec_lua ([[
+  return exec_lua([[
     local api = vim.api
     _G.ns1 = api.nvim_create_namespace "ns1"
   ]] .. (code or [[
@@ -41,25 +41,25 @@ describe('decorations providers', function()
     clear()
     screen = Screen.new(40, 8)
     screen:set_default_attr_ids {
-      [1] = {bold=true, foreground=Screen.colors.Blue};
-      [2] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red};
-      [3] = {foreground = Screen.colors.Brown};
-      [4] = {foreground = Screen.colors.Blue1};
-      [5] = {foreground = Screen.colors.Magenta};
-      [6] = {bold = true, foreground = Screen.colors.Brown};
-      [7] = {background = Screen.colors.Gray90};
-      [8] = {bold = true, reverse = true};
-      [9] = {reverse = true};
-      [10] = {italic = true, background = Screen.colors.Magenta};
-      [11] = {foreground = Screen.colors.Red, background = tonumber('0x005028')};
-      [12] = {foreground = tonumber('0x990000')};
-      [13] = {background = Screen.colors.LightBlue};
-      [14] = {background = Screen.colors.WebGray, foreground = Screen.colors.DarkBlue};
-      [15] = {special = Screen.colors.Blue, undercurl = true},
-      [16] = {special = Screen.colors.Red, undercurl = true},
-      [17] = {foreground = Screen.colors.Red},
-      [18] = {bold = true, foreground = Screen.colors.SeaGreen};
-      [19] = {bold = true};
+      [1] = { bold = true, foreground = Screen.colors.Blue },
+      [2] = { foreground = Screen.colors.Grey100, background = Screen.colors.Red },
+      [3] = { foreground = Screen.colors.Brown },
+      [4] = { foreground = Screen.colors.Blue1 },
+      [5] = { foreground = Screen.colors.Magenta },
+      [6] = { bold = true, foreground = Screen.colors.Brown },
+      [7] = { background = Screen.colors.Gray90 },
+      [8] = { bold = true, reverse = true },
+      [9] = { reverse = true },
+      [10] = { italic = true, background = Screen.colors.Magenta },
+      [11] = { foreground = Screen.colors.Red, background = tonumber('0x005028') },
+      [12] = { foreground = tonumber('0x990000') },
+      [13] = { background = Screen.colors.LightBlue },
+      [14] = { background = Screen.colors.WebGray, foreground = Screen.colors.DarkBlue },
+      [15] = { special = Screen.colors.Blue, undercurl = true },
+      [16] = { special = Screen.colors.Red, undercurl = true },
+      [17] = { foreground = Screen.colors.Red },
+      [18] = { bold = true, foreground = Screen.colors.SeaGreen },
+      [19] = { bold = true },
     }
   end)
 
@@ -74,7 +74,7 @@ describe('decorations providers', function()
 
   local function check_trace(expected)
     local actual = exec_lua [[ local b = beamtrace beamtrace = {} return b ]]
-    expect_events(expected, actual, "beam trace")
+    expect_events(expected, actual, 'beam trace')
   end
 
   it('does not OOM when inserting, rather than appending, to the decoration provider vector', function()
@@ -94,7 +94,8 @@ describe('decorations providers', function()
 
     setup_provider()
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       // just to see if there was an accident |
       // on Mulholland Drive                  |
       try_start();                            |
@@ -103,22 +104,24 @@ describe('decorations providers', function()
       posp = getmark(mark, false);            |
       restore_buffer(&save_buf);^              |
                                               |
-    ]]}
+    ]],
+    }
     check_trace {
-      { "start", 4 };
-      { "win", 1000, 1, 0, 6 };
-      { "line", 1000, 1, 0 };
-      { "line", 1000, 1, 1 };
-      { "line", 1000, 1, 2 };
-      { "line", 1000, 1, 3 };
-      { "line", 1000, 1, 4 };
-      { "line", 1000, 1, 5 };
-      { "line", 1000, 1, 6 };
-      { "end", 4 };
+      { 'start', 4 },
+      { 'win', 1000, 1, 0, 6 },
+      { 'line', 1000, 1, 0 },
+      { 'line', 1000, 1, 1 },
+      { 'line', 1000, 1, 2 },
+      { 'line', 1000, 1, 3 },
+      { 'line', 1000, 1, 4 },
+      { 'line', 1000, 1, 5 },
+      { 'line', 1000, 1, 6 },
+      { 'end', 4 },
     }
 
-    feed "iü<esc>"
-    screen:expect{grid=[[
+    feed 'iü<esc>'
+    screen:expect {
+      grid = [[
       // just to see if there was an accident |
       // on Mulholland Drive                  |
       try_start();                            |
@@ -127,13 +130,14 @@ describe('decorations providers', function()
       posp = getmark(mark, false);            |
       restore_buffer(&save_buf);^ü             |
                                               |
-    ]]}
+    ]],
+    }
     check_trace {
-      { "start", 5 };
-      { "buf", 1, 5 };
-      { "win", 1000, 1, 0, 6 };
-      { "line", 1000, 1, 6 };
-      { "end", 5 };
+      { 'start', 5 },
+      { 'buf', 1, 5 },
+      { 'win', 1000, 1, 0, 6 },
+      { 'line', 1000, 1, 6 },
+      { 'end', 5 },
     }
   end)
 
@@ -154,7 +158,8 @@ describe('decorations providers', function()
       end
     ]]
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {2:/}/ just to see if there was an accident |
       /{2:/} on Mulholland Drive                  |
       tr{2:y}_start();                            |
@@ -163,7 +168,8 @@ describe('decorations providers', function()
       posp {2:=} getmark(mark, false);            |
       restor{2:e}_buffer(&save_buf);^              |
                                               |
-    ]]}
+    ]],
+    }
   end)
 
   it('can indicate spellchecked points', function()
@@ -197,98 +203,111 @@ describe('decorations providers', function()
     ]]
 
     check_trace {
-      { "start", 5 };
-      { "win", 1000, 1, 0, 3 };
-      { "line", 1000, 1, 0 };
-      { "line", 1000, 1, 1 };
-      { "line", 1000, 1, 2 };
-      { "line", 1000, 1, 3 };
-      { "end", 5 };
+      { 'start', 5 },
+      { 'win', 1000, 1, 0, 3 },
+      { 'line', 1000, 1, 0 },
+      { 'line', 1000, 1, 1 },
+      { 'line', 1000, 1, 2 },
+      { 'line', 1000, 1, 3 },
+      { 'end', 5 },
     }
 
-    feed "gg0"
+    feed 'gg0'
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^I am well written text.                 |
       {15:i} am not capitalized.                   |
       I am a {16:speling} {16:mistakke}.                |
                                               |
       {1:~                                       }|*3
                                               |
-    ]]}
-
-    feed "]s"
-    check_trace {
-      { "spell", 1000, 1, 1, 0, 1, -1 };
+    ]],
     }
-    screen:expect{grid=[[
+
+    feed ']s'
+    check_trace {
+      { 'spell', 1000, 1, 1, 0, 1, -1 },
+    }
+    screen:expect {
+      grid = [[
       I am well written text.                 |
       {15:^i} am not capitalized.                   |
       I am a {16:speling} {16:mistakke}.                |
                                               |
       {1:~                                       }|*3
                                               |
-    ]]}
-
-    feed "]s"
-    check_trace {
-      { "spell", 1000, 1, 2, 7, 2, -1 };
+    ]],
     }
-    screen:expect{grid=[[
+
+    feed ']s'
+    check_trace {
+      { 'spell', 1000, 1, 2, 7, 2, -1 },
+    }
+    screen:expect {
+      grid = [[
       I am well written text.                 |
       {15:i} am not capitalized.                   |
       I am a {16:^speling} {16:mistakke}.                |
                                               |
       {1:~                                       }|*3
                                               |
-    ]]}
+    ]],
+    }
 
     -- spell=false with higher priority does disable spell
-    local ns = api.nvim_create_namespace "spell"
+    local ns = api.nvim_create_namespace 'spell'
     local id = api.nvim_buf_set_extmark(0, ns, 0, 0, { priority = 30, end_row = 2, end_col = 23, spell = false })
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       I am well written text.                 |
       i am not capitalized.                   |
       I am a ^speling mistakke.                |
                                               |
       {1:~                                       }|*3
                                               |
-    ]]}
+    ]],
+    }
 
-    feed "]s"
-    screen:expect{grid=[[
+    feed ']s'
+    screen:expect {
+      grid = [[
       I am well written text.                 |
       i am not capitalized.                   |
       I am a ^speling mistakke.                |
                                               |
       {1:~                                       }|*3
       {17:search hit BOTTOM, continuing at TOP}    |
-    ]]}
+    ]],
+    }
     command('echo ""')
 
     -- spell=false with lower priority doesn't disable spell
     api.nvim_buf_set_extmark(0, ns, 0, 0, { id = id, priority = 10, end_row = 2, end_col = 23, spell = false })
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       I am well written text.                 |
       {15:i} am not capitalized.                   |
       I am a {16:^speling} {16:mistakke}.                |
                                               |
       {1:~                                       }|*3
                                               |
-    ]]}
+    ]],
+    }
 
-    feed "]s"
-    screen:expect{grid=[[
+    feed ']s'
+    screen:expect {
+      grid = [[
       I am well written text.                 |
       {15:i} am not capitalized.                   |
       I am a {16:speling} {16:^mistakke}.                |
                                               |
       {1:~                                       }|*3
                                               |
-    ]]}
-
+    ]],
+    }
   end)
 
   it('can predefine highlights', function()
@@ -303,13 +322,16 @@ describe('decorations providers', function()
     ]]
     local ns1 = setup_provider()
 
-    for k,v in pairs {
-      LineNr = {italic=true, bg="Magenta"};
-      Comment = {fg="#FF0000", bg = 80*256+40};
-      CursorLine = {link="ErrorMsg"};
-    } do api.nvim_set_hl(ns1, k, v) end
+    for k, v in pairs {
+      LineNr = { italic = true, bg = 'Magenta' },
+      Comment = { fg = '#FF0000', bg = 80 * 256 + 40 },
+      CursorLine = { link = 'ErrorMsg' },
+    } do
+      api.nvim_set_hl(ns1, k, v)
+    end
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {3:  1 }{4:// just to see if there was an accid}|
       {3:    }{4:ent}                                 |
       {3:  2 }{4:// on Mulholland Drive}              |
@@ -326,10 +348,12 @@ describe('decorations providers', function()
       {3:  7 }restore_buffer(&save_buf);          |
       {9:[No Name] [+]                           }|
                                               |
-    ]]}
+    ]],
+    }
 
     api.nvim_set_hl_ns(ns1)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:  1 }{11:// just to see if there was an accid}|
       {10:    }{11:ent}                                 |
       {10:  2 }{11:// on Mulholland Drive}              |
@@ -346,7 +370,8 @@ describe('decorations providers', function()
       {10:  7 }restore_buffer(&save_buf);          |
       {9:[No Name] [+]                           }|
                                               |
-    ]]}
+    ]],
+    }
 
     exec_lua [[
       local api = vim.api
@@ -358,7 +383,8 @@ describe('decorations providers', function()
         end;
       })
     ]]
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:  1 }{11:// just to see if there was an accid}|
       {10:    }{11:ent}                                 |
       {10:  2 }{11:// on Mulholland Drive}              |
@@ -375,8 +401,8 @@ describe('decorations providers', function()
       {3:  7 }restore_buffer(&save_buf);          |
       {9:[No Name] [+]                           }|
                                               |
-    ]]}
-
+    ]],
+    }
   end)
 
   it('can break an existing link', function()
@@ -388,8 +414,9 @@ describe('decorations providers', function()
       highlight link LinkGroup OriginalGroup
     ]]
 
-    api.nvim_buf_set_virtual_text(0, 0, 2, {{'- not red', 'LinkGroup'}}, {})
-    screen:expect{grid=[[
+    api.nvim_buf_set_virtual_text(0, 0, 2, { { '- not red', 'LinkGroup' } }, {})
+    screen:expect {
+      grid = [[
       // just to see if there was an accident |
       // on Mulholland Drive                  |
       try_start(); {12:- not red}                  |
@@ -398,12 +425,14 @@ describe('decorations providers', function()
       posp = getmark(mark, false);            |
       restore_buffer(&save_buf);^              |
                                               |
-    ]]}
+    ]],
+    }
 
-    api.nvim_set_hl(ns1, 'LinkGroup', {fg = 'Blue'})
+    api.nvim_set_hl(ns1, 'LinkGroup', { fg = 'Blue' })
     api.nvim_set_hl_ns(ns1)
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       // just to see if there was an accident |
       // on Mulholland Drive                  |
       try_start(); {4:- not red}                  |
@@ -412,7 +441,8 @@ describe('decorations providers', function()
       posp = getmark(mark, false);            |
       restore_buffer(&save_buf);^              |
                                               |
-    ]]}
+    ]],
+    }
   end)
 
   it("with 'default': do not break an existing link", function()
@@ -424,8 +454,9 @@ describe('decorations providers', function()
       highlight link LinkGroup OriginalGroup
     ]]
 
-    api.nvim_buf_set_virtual_text(0, 0, 2, {{'- not red', 'LinkGroup'}}, {})
-    screen:expect{grid=[[
+    api.nvim_buf_set_virtual_text(0, 0, 2, { { '- not red', 'LinkGroup' } }, {})
+    screen:expect {
+      grid = [[
       // just to see if there was an accident |
       // on Mulholland Drive                  |
       try_start(); {12:- not red}                  |
@@ -434,13 +465,15 @@ describe('decorations providers', function()
       posp = getmark(mark, false);            |
       restore_buffer(&save_buf);^              |
                                               |
-    ]]}
+    ]],
+    }
 
-    api.nvim_set_hl(ns1, 'LinkGroup', {fg = 'Blue', default=true})
+    api.nvim_set_hl(ns1, 'LinkGroup', { fg = 'Blue', default = true })
     api.nvim_set_hl_ns(ns1)
     feed 'k'
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       // just to see if there was an accident |
       // on Mulholland Drive                  |
       try_start(); {12:- not red}                  |
@@ -449,7 +482,8 @@ describe('decorations providers', function()
       posp = getmark(mark, false^);            |
       restore_buffer(&save_buf);              |
                                               |
-    ]]}
+    ]],
+    }
   end)
 
   it('can have virtual text', function()
@@ -469,7 +503,8 @@ describe('decorations providers', function()
       end
     ]]
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {2:+}/ just to see if there was an accident |
       {2:+}/ on Mulholland Drive                  |
       {2:+}ry_start();                            |
@@ -478,7 +513,8 @@ describe('decorations providers', function()
       {2:+}osp = getmark(mark, false);            |
       {2:+}estore_buffer(&save_buf);^              |
                                               |
-    ]]}
+    ]],
+    }
   end)
 
   it('can have virtual text of the style: right_align', function()
@@ -498,7 +534,8 @@ describe('decorations providers', function()
       end
     ]]
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       // just to see if there was an acciden+{2: }|
       // on Mulholland Drive               +{2:  }|
       try_start();                        +{2:   }|
@@ -507,7 +544,8 @@ describe('decorations providers', function()
       posp = getmark(mark, false);     +{2:      }|
       restore_buffer(&save_buf);^      +{2:       }|
                                               |
-    ]]}
+    ]],
+    }
   end)
 
   it('can have virtual text of the style: eol_right_align', function()
@@ -527,7 +565,8 @@ describe('decorations providers', function()
       end
     ]]
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       // just to see if there was an accident |
       // on Mulholland Drive       +{2:1234567890}|
       try_start();                 +{2:1234567890}|
@@ -536,7 +575,8 @@ describe('decorations providers', function()
       posp = getmark(mark, false); +{2:1234567890}|
       restore_buffer(&save_buf);^   +{2:1234567890}|
                                               |
-    ]]}
+    ]],
+    }
   end)
 
   it('multiple eol_right_align', function()
@@ -561,7 +601,8 @@ describe('decorations providers', function()
       end
     ]]
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       // just to see if there was an accident |
       // on Mulholland Drive       11111 22222|
       try_start();                 11111 22222|
@@ -570,7 +611,8 @@ describe('decorations providers', function()
       posp = getmark(mark, false); 11111 22222|
       restore_buffer(&save_buf);^   11111 22222|
                                               |
-    ]]}
+    ]],
+    }
   end)
 
   it('virtual text works with wrapped lines', function()
@@ -616,7 +658,8 @@ describe('decorations providers', function()
       end
     ]]
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       // jus{2:*} to see if th{2:!}re was an accident |
       {2:;}n Mulholl{2:?}nd Drive {2:/}                 +{2: }|
       try_st{2:**}t(); bufref_{2:!!}save_buf; switch_b|
@@ -625,9 +668,11 @@ describe('decorations providers', function()
       {2:;;;}(&save_{2:???});  {2:///}                +{2:   }|
       {1:~                                       }|
                                               |
-    ]]}
+    ]],
+    }
     command('setlocal breakindent breakindentopt=shift:2')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       // jus{2:*} to see if th{2:!}re was an accident |
         {2:;}n Mulho{2:?}land Drive {2:/}               +{2: }|
       try_st{2:**}t(); bufref_{2:!!}save_buf; switch_b|
@@ -636,7 +681,8 @@ describe('decorations providers', function()
         {2:;;;}(&sav{2:???}uf);  {2:///}              +{2:   }|
       {1:~                                       }|
                                               |
-    ]]}
+    ]],
+    }
   end)
 
   it('can highlight beyond EOL', function()
@@ -658,7 +704,8 @@ describe('decorations providers', function()
       end
     ]]
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       // just to see if there was an accident |
       // on Mulholland Drive                  |
       try_start();                            |
@@ -667,7 +714,8 @@ describe('decorations providers', function()
       posp = getmark(mark, false);            |
       {13:restore_buffer(&save_buf);^              }|
                                               |
-    ]]}
+    ]],
+    }
   end)
 
   it('can create and remove signs when CursorMoved autocommand validates botline #18661', function()
@@ -690,7 +738,7 @@ describe('decorations providers', function()
       end
     ]])
     command([[autocmd CursorMoved * call line('w$')]])
-    api.nvim_win_set_cursor(0, {100, 0})
+    api.nvim_win_set_cursor(0, { 100, 0 })
     screen:expect([[
       {14:  }hello97                               |
       {14:  }hello98                               |
@@ -701,7 +749,7 @@ describe('decorations providers', function()
       {14:  }hello103                              |
                                               |
     ]])
-    api.nvim_win_set_cursor(0, {1, 0})
+    api.nvim_win_set_cursor(0, { 1, 0 })
     screen:expect([[
       ^hello1                                  |
       hello2                                  |
@@ -789,7 +837,7 @@ describe('decorations providers', function()
   end)
 
   it('can do large changes to the marktree', function()
-    insert("line1 with a lot of text\nline2 with a lot of text")
+    insert('line1 with a lot of text\nline2 with a lot of text')
     setup_provider([[
       function on_do(event, _, _, row)
         if event == 'win' or (event == 'line' and row == 1) then
@@ -813,7 +861,7 @@ describe('decorations providers', function()
   end)
 
   it('inline virt_text does not result in wrong cursor column #33153', function()
-    insert("line1 with a lot of text\nline2 with a lot of text")
+    insert('line1 with a lot of text\nline2 with a lot of text')
     setup_provider([[
       _G.do_win = false
       vim.keymap.set('n', 'f', function()
@@ -903,57 +951,57 @@ end]]
 describe('extmark decorations', function()
   local screen ---@type test.functional.ui.screen
   local ns ---@type integer
-  before_each( function()
+  before_each(function()
     clear()
     screen = Screen.new(50, 15)
     screen:set_default_attr_ids {
-      [1] = {bold=true, foreground=Screen.colors.Blue};
-      [2] = {foreground = Screen.colors.Brown};
-      [3] = {bold = true, foreground = Screen.colors.SeaGreen};
-      [4] = {background = Screen.colors.Red1, foreground = Screen.colors.Gray100};
-      [5] = {foreground = Screen.colors.Brown, bold = true};
-      [6] = {foreground = Screen.colors.DarkCyan};
-      [7] = {foreground = Screen.colors.Grey0, background = tonumber('0xff4c4c')};
-      [8] = {foreground = tonumber('0x180606'), background = tonumber('0xff4c4c')};
-      [9] = {foreground = tonumber('0xe40c0c'), background = tonumber('0xff4c4c'), bold = true};
-      [10] = {foreground = tonumber('0xb20000'), background = tonumber('0xff4c4c')};
-      [11] = {blend = 30, background = Screen.colors.Red1};
-      [12] = {foreground = Screen.colors.Brown, blend = 30, background = Screen.colors.Red1, bold = true};
-      [13] = {foreground = Screen.colors.Fuchsia};
-      [14] = {background = Screen.colors.Red1, foreground = Screen.colors.Black};
-      [15] = {background = Screen.colors.Red1, foreground = tonumber('0xb20000')};
-      [16] = {blend = 30, background = Screen.colors.Red1, foreground = Screen.colors.Magenta1};
-      [17] = {bold = true, foreground = Screen.colors.Brown, background = Screen.colors.LightGrey};
-      [18] = {background = Screen.colors.LightGrey};
-      [19] = {foreground = Screen.colors.DarkCyan, background = Screen.colors.LightGrey};
-      [20] = {foreground = tonumber('0x180606'), background = tonumber('0xf13f3f')};
-      [21] = {foreground = Screen.colors.Gray0, background = tonumber('0xf13f3f')};
-      [22] = {foreground = tonumber('0xb20000'), background = tonumber('0xf13f3f')};
-      [23] = {foreground = Screen.colors.Magenta1, background = Screen.colors.LightGrey};
-      [24] = {bold = true};
-      [25] = {background = Screen.colors.LightRed};
-      [26] = {background = Screen.colors.DarkGrey, foreground = Screen.colors.LightGrey};
-      [27] = {background = Screen.colors.LightGrey, foreground = Screen.colors.Black};
-      [28] = {underline = true, foreground = Screen.colors.SlateBlue};
-      [29] = {foreground = Screen.colors.SlateBlue, background = Screen.colors.LightGrey, underline = true};
-      [30] = {foreground = Screen.colors.DarkCyan, background = Screen.colors.LightGrey, underline = true};
-      [31] = {underline = true, foreground = Screen.colors.DarkCyan};
-      [32] = {underline = true};
-      [33] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.LightGrey};
-      [34] = {background = Screen.colors.Yellow};
-      [35] = {background = Screen.colors.Yellow, bold = true, foreground = Screen.colors.Blue};
-      [36] = {foreground = Screen.colors.Blue1, bold = true, background = Screen.colors.Red};
-      [37] = {background = Screen.colors.WebGray, foreground = Screen.colors.DarkBlue};
-      [38] = {background = Screen.colors.LightBlue};
-      [39] = {foreground = Screen.colors.Blue1, background = Screen.colors.LightCyan1, bold = true};
-      [40] = {reverse = true};
-      [41] = {bold = true, reverse = true};
-      [42] = {undercurl = true, special = Screen.colors.Red};
-      [43] = {background = Screen.colors.Yellow, undercurl = true, special = Screen.colors.Red};
-      [44] = {background = Screen.colors.LightMagenta};
-      [45] = { background = Screen.colors.Red, special = Screen.colors.Red, foreground = Screen.colors.Red };
-      [46] = { background = Screen.colors.Blue, foreground = Screen.colors.Blue, special = Screen.colors.Red };
-      [47] = { background = Screen.colors.Green, foreground = Screen.colors.Blue, special = Screen.colors.Red };
+      [1] = { bold = true, foreground = Screen.colors.Blue },
+      [2] = { foreground = Screen.colors.Brown },
+      [3] = { bold = true, foreground = Screen.colors.SeaGreen },
+      [4] = { background = Screen.colors.Red1, foreground = Screen.colors.Gray100 },
+      [5] = { foreground = Screen.colors.Brown, bold = true },
+      [6] = { foreground = Screen.colors.DarkCyan },
+      [7] = { foreground = Screen.colors.Grey0, background = tonumber('0xff4c4c') },
+      [8] = { foreground = tonumber('0x180606'), background = tonumber('0xff4c4c') },
+      [9] = { foreground = tonumber('0xe40c0c'), background = tonumber('0xff4c4c'), bold = true },
+      [10] = { foreground = tonumber('0xb20000'), background = tonumber('0xff4c4c') },
+      [11] = { blend = 30, background = Screen.colors.Red1 },
+      [12] = { foreground = Screen.colors.Brown, blend = 30, background = Screen.colors.Red1, bold = true },
+      [13] = { foreground = Screen.colors.Fuchsia },
+      [14] = { background = Screen.colors.Red1, foreground = Screen.colors.Black },
+      [15] = { background = Screen.colors.Red1, foreground = tonumber('0xb20000') },
+      [16] = { blend = 30, background = Screen.colors.Red1, foreground = Screen.colors.Magenta1 },
+      [17] = { bold = true, foreground = Screen.colors.Brown, background = Screen.colors.LightGrey },
+      [18] = { background = Screen.colors.LightGrey },
+      [19] = { foreground = Screen.colors.DarkCyan, background = Screen.colors.LightGrey },
+      [20] = { foreground = tonumber('0x180606'), background = tonumber('0xf13f3f') },
+      [21] = { foreground = Screen.colors.Gray0, background = tonumber('0xf13f3f') },
+      [22] = { foreground = tonumber('0xb20000'), background = tonumber('0xf13f3f') },
+      [23] = { foreground = Screen.colors.Magenta1, background = Screen.colors.LightGrey },
+      [24] = { bold = true },
+      [25] = { background = Screen.colors.LightRed },
+      [26] = { background = Screen.colors.DarkGrey, foreground = Screen.colors.LightGrey },
+      [27] = { background = Screen.colors.LightGrey, foreground = Screen.colors.Black },
+      [28] = { underline = true, foreground = Screen.colors.SlateBlue },
+      [29] = { foreground = Screen.colors.SlateBlue, background = Screen.colors.LightGrey, underline = true },
+      [30] = { foreground = Screen.colors.DarkCyan, background = Screen.colors.LightGrey, underline = true },
+      [31] = { underline = true, foreground = Screen.colors.DarkCyan },
+      [32] = { underline = true },
+      [33] = { foreground = Screen.colors.DarkBlue, background = Screen.colors.LightGrey },
+      [34] = { background = Screen.colors.Yellow },
+      [35] = { background = Screen.colors.Yellow, bold = true, foreground = Screen.colors.Blue },
+      [36] = { foreground = Screen.colors.Blue1, bold = true, background = Screen.colors.Red },
+      [37] = { background = Screen.colors.WebGray, foreground = Screen.colors.DarkBlue },
+      [38] = { background = Screen.colors.LightBlue },
+      [39] = { foreground = Screen.colors.Blue1, background = Screen.colors.LightCyan1, bold = true },
+      [40] = { reverse = true },
+      [41] = { bold = true, reverse = true },
+      [42] = { undercurl = true, special = Screen.colors.Red },
+      [43] = { background = Screen.colors.Yellow, undercurl = true, special = Screen.colors.Red },
+      [44] = { background = Screen.colors.LightMagenta },
+      [45] = { background = Screen.colors.Red, special = Screen.colors.Red, foreground = Screen.colors.Red },
+      [46] = { background = Screen.colors.Blue, foreground = Screen.colors.Blue, special = Screen.colors.Red },
+      [47] = { background = Screen.colors.Green, foreground = Screen.colors.Blue, special = Screen.colors.Red },
     }
 
     ns = api.nvim_create_namespace 'test'
@@ -979,7 +1027,7 @@ describe('extmark decorations', function()
       {1:~                                                 }|*2
                                                         |
     ]])
-    api.nvim_buf_set_extmark(0, ns, 4, 0, { virt_text={{''}}, virt_text_pos='eol'})
+    api.nvim_buf_set_extmark(0, ns, 4, 0, { virt_text = { { '' } }, virt_text_pos = 'eol' })
     screen:expect_unchanged()
   end)
 
@@ -987,22 +1035,35 @@ describe('extmark decorations', function()
     insert(example_text)
     feed 'gg'
 
-    for i = 1,9 do
-      api.nvim_buf_set_extmark(0, ns, i, 0, { virt_text={{'|', 'LineNr'}}, virt_text_pos='overlay'})
+    for i = 1, 9 do
+      api.nvim_buf_set_extmark(0, ns, i, 0, { virt_text = { { '|', 'LineNr' } }, virt_text_pos = 'overlay' })
       if i == 3 or (i >= 6 and i <= 9) then
-        api.nvim_buf_set_extmark(0, ns, i, 4, { virt_text={{'|', 'NonText'}}, virt_text_pos='overlay'})
+        api.nvim_buf_set_extmark(0, ns, i, 4, { virt_text = { { '|', 'NonText' } }, virt_text_pos = 'overlay' })
       end
     end
-    api.nvim_buf_set_extmark(0, ns, 9, 10, { virt_text={{'foo'}, {'bar', 'MoreMsg'}, {'!!', 'ErrorMsg'}}, virt_text_pos='overlay'})
+    api.nvim_buf_set_extmark(
+      0,
+      ns,
+      9,
+      10,
+      { virt_text = { { 'foo' }, { 'bar', 'MoreMsg' }, { '!!', 'ErrorMsg' } }, virt_text_pos = 'overlay' }
+    )
 
     -- can "float" beyond end of line
-    api.nvim_buf_set_extmark(0, ns, 5, 28, { virt_text={{'loopy', 'ErrorMsg'}}, virt_text_pos='overlay'})
+    api.nvim_buf_set_extmark(0, ns, 5, 28, { virt_text = { { 'loopy', 'ErrorMsg' } }, virt_text_pos = 'overlay' })
     -- bound check: right edge of window
-    api.nvim_buf_set_extmark(0, ns, 2, 26, { virt_text={{'bork bork bork'}, {(' bork'):rep(10), 'ErrorMsg'}}, virt_text_pos='overlay'})
+    api.nvim_buf_set_extmark(
+      0,
+      ns,
+      2,
+      26,
+      { virt_text = { { 'bork bork bork' }, { (' bork'):rep(10), 'ErrorMsg' } }, virt_text_pos = 'overlay' }
+    )
     -- empty virt_text should not change anything
-    api.nvim_buf_set_extmark(0, ns, 6, 16, { virt_text={{''}}, virt_text_pos='overlay'})
+    api.nvim_buf_set_extmark(0, ns, 6, 16, { virt_text = { { '' } }, virt_text_pos = 'overlay' })
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^for _,item in ipairs(items) do                    |
       {2:|}   local text, hl_id_cell, count = unpack(item)  |
       {2:|}   if hl_id_cell ~= nil tbork bork bork{4: bork bork}|
@@ -1017,11 +1078,13 @@ describe('extmark decorations', function()
       end                                               |
       {1:~                                                 }|*2
                                                         |
-    ]]}
+    ]],
+    }
 
     -- handles broken lines
     screen:try_resize(22, 25)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^for _,item in ipairs(i|
       tems) do              |
       {2:|}   local text, hl_id_|
@@ -1046,16 +1109,18 @@ describe('extmark decorations', function()
       end                   |
       {1:~                     }|*2
                             |
-    ]]}
+    ]],
+    }
 
     -- truncating in the middle of a char leaves a space
-    api.nvim_buf_set_lines(0, 0, 1, true, {'for _,item in ipairs(items) do  -- 古古古'})
-    api.nvim_buf_set_lines(0, 10, 12, true, {'    end  -- ??????????', 'end  -- ?古古古古?古古'})
-    api.nvim_buf_set_extmark(0, ns, 0, 35, { virt_text={{'A', 'ErrorMsg'}, {'AA'}}, virt_text_pos='overlay'})
-    api.nvim_buf_set_extmark(0, ns, 10, 19, { virt_text={{'口口口', 'ErrorMsg'}}, virt_text_pos='overlay'})
-    api.nvim_buf_set_extmark(0, ns, 11, 21, { virt_text={{'口口口', 'ErrorMsg'}}, virt_text_pos='overlay'})
-    api.nvim_buf_set_extmark(0, ns, 11, 8, { virt_text={{'口口', 'ErrorMsg'}}, virt_text_pos='overlay'})
-    screen:expect{grid=[[
+    api.nvim_buf_set_lines(0, 0, 1, true, { 'for _,item in ipairs(items) do  -- 古古古' })
+    api.nvim_buf_set_lines(0, 10, 12, true, { '    end  -- ??????????', 'end  -- ?古古古古?古古' })
+    api.nvim_buf_set_extmark(0, ns, 0, 35, { virt_text = { { 'A', 'ErrorMsg' }, { 'AA' } }, virt_text_pos = 'overlay' })
+    api.nvim_buf_set_extmark(0, ns, 10, 19, { virt_text = { { '口口口', 'ErrorMsg' } }, virt_text_pos = 'overlay' })
+    api.nvim_buf_set_extmark(0, ns, 11, 21, { virt_text = { { '口口口', 'ErrorMsg' } }, virt_text_pos = 'overlay' })
+    api.nvim_buf_set_extmark(0, ns, 11, 8, { virt_text = { { '口口', 'ErrorMsg' } }, virt_text_pos = 'overlay' })
+    screen:expect {
+      grid = [[
       ^for _,item in ipairs(i|
       tems) do  -- {4:A}AA 古   |
       {2:|}   local text, hl_id_|
@@ -1080,10 +1145,12 @@ describe('extmark decorations', function()
       end  -- {4:口口} 古古{4:口口 }|
       {1:~                     }|*2
                             |
-    ]]}
+    ]],
+    }
 
     screen:try_resize(82, 13)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^for _,item in ipairs(items) do  -- {4:A}AA 古                                         |
       {2:|}   local text, hl_id_cell, count = unpack(item)                                  |
       {2:|}   if hl_id_cell ~= nil tbork bork bork{4: bork bork bork bork bork bork bork bork b}|
@@ -1097,10 +1164,12 @@ describe('extmark decorations', function()
           end  -- ???????{4:口口口}                                                         |
       end  -- {4:口口} 古古{4:口口口}                                                           |
                                                                                         |
-    ]]}
+    ]],
+    }
 
     api.nvim_buf_clear_namespace(0, ns, 0, -1)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^for _,item in ipairs(items) do  -- 古古古                                         |
           local text, hl_id_cell, count = unpack(item)                                  |
           if hl_id_cell ~= nil then                                                     |
@@ -1114,180 +1183,225 @@ describe('extmark decorations', function()
           end  -- ??????????                                                            |
       end  -- ?古古古古?古古                                                            |
                                                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('overlay virtual text works with wrapped lines #25158', function()
     screen:try_resize(50, 6)
     insert(('ab'):rep(100))
     for i = 0, 9 do
-      api.nvim_buf_set_extmark(0, ns, 0, 42 + i, { virt_text={{tostring(i), 'ErrorMsg'}}, virt_text_pos='overlay'})
-      api.nvim_buf_set_extmark(0, ns, 0, 91 + i, { virt_text={{tostring(i), 'ErrorMsg'}}, virt_text_pos='overlay', virt_text_hide=true})
+      api.nvim_buf_set_extmark(0, ns, 0, 42 + i, { virt_text = { { tostring(i), 'ErrorMsg' } }, virt_text_pos = 'overlay' })
+      api.nvim_buf_set_extmark(
+        0,
+        ns,
+        0,
+        91 + i,
+        { virt_text = { { tostring(i), 'ErrorMsg' } }, virt_text_pos = 'overlay', virt_text_hide = true }
+      )
     end
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ababababababababababababababababababababab{4:01234567}|
       {4:89}abababababababababababababababababababa{4:012345678}|
       {4:9}babababababababababababababababababababababababab|
       ababababababababababababababababababababababababa^b|
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
 
     command('set showbreak=++')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ababababababababababababababababababababab{4:01234567}|
       {1:++}{4:89}abababababababababababababababababababa{4:0123456}|
       {1:++}{4:789}babababababababababababababababababababababab|
       {1:++}abababababababababababababababababababababababab|
       {1:++}ababa^b                                          |
                                                         |
-    ]]}
+    ]],
+    }
 
     feed('2gkvg0')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ababababababababababababababababababababab{4:01234567}|
       {1:++}{4:89}abababababababababababababababababababa{4:0123456}|
       {1:++}^a{27:babab}ababababababababababababababababababababab|
       {1:++}abababababababababababababababababababababababab|
       {1:++}ababab                                          |
       {24:-- VISUAL --}                                      |
-    ]]}
+    ]],
+    }
 
     feed('o')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ababababababababababababababababababababab{4:01234567}|
       {1:++}{4:89}abababababababababababababababababababa{4:0123456}|
       {1:++}{27:ababa}^bababababababababababababababababababababab|
       {1:++}abababababababababababababababababababababababab|
       {1:++}ababab                                          |
       {24:-- VISUAL --}                                      |
-    ]]}
+    ]],
+    }
 
     feed('gk')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ababababababababababababababababababababab{4:01234567}|
       {1:++}{4:89}aba^b{27:ababababababababababababababababababababab}|
       {1:++}{27:a}{4:89}babababababababababababababababababababababab|
       {1:++}abababababababababababababababababababababababab|
       {1:++}ababab                                          |
       {24:-- VISUAL --}                                      |
-    ]]}
+    ]],
+    }
 
     feed('o')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ababababababababababababababababababababab{4:01234567}|
       {1:++}{4:89}aba{27:bababababababababababababababababababababab}|
       {1:++}^a{4:89}babababababababababababababababababababababab|
       {1:++}abababababababababababababababababababababababab|
       {1:++}ababab                                          |
       {24:-- VISUAL --}                                      |
-    ]]}
+    ]],
+    }
 
     feed('<Esc>$')
     command('set number showbreak=')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {2:  1 }ababababababababababababababababababababab{4:0123}|
       {2:    }{4:456789}abababababababababababababababababababa{4:0}|
       {2:    }{4:123456789}babababababababababababababababababab|
       {2:    }ababababababababababababababababababababababab|
       {2:    }abababababababa^b                              |
                                                         |
-    ]]}
+    ]],
+    }
 
     command('set cpoptions+=n')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {2:  1 }ababababababababababababababababababababab{4:0123}|
       {4:456789}abababababababababababababababababababa{4:01234}|
       {4:56789}babababababababababababababababababababababab|
       ababababababababababababababababababababababababab|
       aba^b                                              |
                                                         |
-    ]]}
+    ]],
+    }
 
     feed('0g$hi<Tab>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {2:  1 }ababababababababababababababababababababab{4:01}  |
         {4:^23456789}abababababababababababababababababababa{4:0}|
       {4:123456789}babababababababababababababababababababab|
       ababababababababababababababababababababababababab|
       abababab                                          |
       {24:-- INSERT --}                                      |
-    ]]}
+    ]],
+    }
   end)
 
   it('virt_text_hide hides overlay virtual text when extmark is off-screen', function()
     screen:try_resize(50, 3)
     command('set nowrap')
-    api.nvim_buf_set_lines(0, 0, -1, true, {'-- ' .. ('…'):rep(57)})
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text={{'?????', 'ErrorMsg'}}, virt_text_pos='overlay', virt_text_hide=true})
-    api.nvim_buf_set_extmark(0, ns, 0, 123, { virt_text={{'!!!!!', 'ErrorMsg'}}, virt_text_pos='overlay', virt_text_hide=true})
-    screen:expect{grid=[[
+    api.nvim_buf_set_lines(0, 0, -1, true, { '-- ' .. ('…'):rep(57) })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { '?????', 'ErrorMsg' } }, virt_text_pos = 'overlay', virt_text_hide = true })
+    api.nvim_buf_set_extmark(0, ns, 0, 123, { virt_text = { { '!!!!!', 'ErrorMsg' } }, virt_text_pos = 'overlay', virt_text_hide = true })
+    screen:expect {
+      grid = [[
       {4:^?????}……………………………………………………………………………………………………{4:!!!!!}……|
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('40zl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^………{4:!!!!!}………………………………                              |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('3zl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {4:^!!!!!}………………………………                                 |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('7zl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^…………………………                                        |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
 
     command('set wrap smoothscroll')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {4:?????}……………………………………………………………………………………………………{4:!!!!!}……|
       ^…………………………                                        |
                                                         |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {1:<<<}………………^…                                        |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     screen:try_resize(40, 3)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {1:<<<}{4:!!!!!}……………………………^…                    |
       {1:~                                       }|
                                               |
-    ]]}
+    ]],
+    }
     feed('<C-Y>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {4:?????}……………………………………………………………………………………………|
       ………{4:!!!!!}……………………………^…                    |
                                               |
-    ]]}
+    ]],
+    }
   end)
 
   it('overlay virtual text works on and after a TAB #24022', function()
     screen:try_resize(40, 3)
-    api.nvim_buf_set_lines(0, 0, -1, true, {'\t\tline 1'})
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = {{'AA', 'Search'}}, virt_text_pos = 'overlay', hl_mode = 'combine' })
-    api.nvim_buf_set_extmark(0, ns, 0, 1, { virt_text = {{'BB', 'Search'}}, virt_text_pos = 'overlay', hl_mode = 'combine' })
-    api.nvim_buf_set_extmark(0, ns, 0, 2, { virt_text = {{'CC', 'Search'}}, virt_text_pos = 'overlay', hl_mode = 'combine' })
-    screen:expect{grid=[[
+    api.nvim_buf_set_lines(0, 0, -1, true, { '\t\tline 1' })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'AA', 'Search' } }, virt_text_pos = 'overlay', hl_mode = 'combine' })
+    api.nvim_buf_set_extmark(0, ns, 0, 1, { virt_text = { { 'BB', 'Search' } }, virt_text_pos = 'overlay', hl_mode = 'combine' })
+    api.nvim_buf_set_extmark(0, ns, 0, 2, { virt_text = { { 'CC', 'Search' } }, virt_text_pos = 'overlay', hl_mode = 'combine' })
+    screen:expect {
+      grid = [[
       {34:AA}     ^ {34:BB}      {34:CC}ne 1                  |
       {1:~                                       }|
                                               |
-    ]]}
+    ]],
+    }
     command('setlocal list listchars=tab:<->')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {35:^AA}{1:----->}{35:BB}{1:----->}{34:CC}ne 1                  |
       {1:~                                       }|
                                               |
-    ]]}
+    ]],
+    }
   end)
 
   it('can have virtual text of overlay position and styling', function()
@@ -1297,7 +1411,8 @@ describe('extmark decorations', function()
     command 'set ft=lua'
     command 'syntax on'
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {5:^for} _,item {5:in} {6:ipairs}(items) {5:do}                    |
           {5:local} text, hl_id_cell, count {5:=} unpack(item)  |
           {5:if} hl_id_cell {5:~=} {13:nil} {5:then}                     |
@@ -1312,19 +1427,57 @@ describe('extmark decorations', function()
       {5:end}                                               |
       {1:~                                                 }|*2
                                                         |
-    ]]}
+    ]],
+    }
 
     command 'hi Blendy guibg=Red blend=30'
     command 'hi! Visual guifg=NONE guibg=LightGrey'
-    api.nvim_buf_set_extmark(0, ns, 1, 5, { virt_text={{'blendy text - here', 'Blendy'}}, virt_text_pos='overlay', hl_mode='blend'})
-    api.nvim_buf_set_extmark(0, ns, 2, 5, { virt_text={{'combining color', 'Blendy'}}, virt_text_pos='overlay', hl_mode='combine'})
-    api.nvim_buf_set_extmark(0, ns, 3, 5, { virt_text={{'replacing color', 'Blendy'}}, virt_text_pos='overlay', hl_mode='replace'})
+    api.nvim_buf_set_extmark(
+      0,
+      ns,
+      1,
+      5,
+      { virt_text = { { 'blendy text - here', 'Blendy' } }, virt_text_pos = 'overlay', hl_mode = 'blend' }
+    )
+    api.nvim_buf_set_extmark(
+      0,
+      ns,
+      2,
+      5,
+      { virt_text = { { 'combining color', 'Blendy' } }, virt_text_pos = 'overlay', hl_mode = 'combine' }
+    )
+    api.nvim_buf_set_extmark(
+      0,
+      ns,
+      3,
+      5,
+      { virt_text = { { 'replacing color', 'Blendy' } }, virt_text_pos = 'overlay', hl_mode = 'replace' }
+    )
 
-    api.nvim_buf_set_extmark(0, ns, 4, 5, { virt_text={{'blendy text - here', 'Blendy'}}, virt_text_pos='overlay', hl_mode='blend', virt_text_hide=true})
-    api.nvim_buf_set_extmark(0, ns, 5, 5, { virt_text={{'combining color', 'Blendy'}}, virt_text_pos='overlay', hl_mode='combine', virt_text_hide=true})
-    api.nvim_buf_set_extmark(0, ns, 6, 5, { virt_text={{'replacing color', 'Blendy'}}, virt_text_pos='overlay', hl_mode='replace', virt_text_hide=true})
+    api.nvim_buf_set_extmark(
+      0,
+      ns,
+      4,
+      5,
+      { virt_text = { { 'blendy text - here', 'Blendy' } }, virt_text_pos = 'overlay', hl_mode = 'blend', virt_text_hide = true }
+    )
+    api.nvim_buf_set_extmark(
+      0,
+      ns,
+      5,
+      5,
+      { virt_text = { { 'combining color', 'Blendy' } }, virt_text_pos = 'overlay', hl_mode = 'combine', virt_text_hide = true }
+    )
+    api.nvim_buf_set_extmark(
+      0,
+      ns,
+      6,
+      5,
+      { virt_text = { { 'replacing color', 'Blendy' } }, virt_text_pos = 'overlay', hl_mode = 'replace', virt_text_hide = true }
+    )
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {5:^for} _,item {5:in} {6:ipairs}(items) {5:do}                    |
           {5:l}{8:blen}{7:dy}{10:e}{7:text}{10:h}{7:-}{10:_}{7:here}ell, count {5:=} unpack(item)  |
           {5:i}{12:c}{11:ombining col}{12:or} {13:nil} {5:then}                     |
@@ -1339,10 +1492,12 @@ describe('extmark decorations', function()
       {5:end}                                               |
       {1:~                                                 }|*2
                                                         |
-    ]]}
+    ]],
+    }
 
     feed 'V5G'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {17:for}{18: _,item }{17:in}{18: }{19:ipairs}{18:(items) }{17:do}                    |
       {18:    }{17:l}{20:blen}{21:dy}{22:e}{21:text}{22:h}{21:-}{22:_}{21:here}{18:ell, count }{17:=}{18: unpack(item)}  |
       {18:    }{17:i}{12:c}{11:ombining col}{12:or}{18: }{23:nil}{18: }{17:then}                     |
@@ -1357,10 +1512,12 @@ describe('extmark decorations', function()
       {5:end}                                               |
       {1:~                                                 }|*2
       {24:-- VISUAL LINE --}                                 |
-    ]]}
+    ]],
+    }
 
     feed 'jj'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {17:for}{18: _,item }{17:in}{18: }{19:ipairs}{18:(items) }{17:do}                    |
       {18:    }{17:l}{20:blen}{21:dy}{22:e}{21:text}{22:h}{21:-}{22:_}{21:here}{18:ell, count }{17:=}{18: unpack(item)}  |
       {18:    }{17:i}{12:c}{11:ombining col}{12:or}{18: }{23:nil}{18: }{17:then}                     |
@@ -1375,25 +1532,27 @@ describe('extmark decorations', function()
       {5:end}                                               |
       {1:~                                                 }|*2
       {24:-- VISUAL LINE --}                                 |
-    ]]}
+    ]],
+    }
   end)
 
   it('can have virtual text of right_align and fixed win_col position', function()
     insert(example_text)
     feed 'gg'
-    api.nvim_buf_set_extmark(0, ns, 1, 0, { virt_text={{'Very', 'ErrorMsg'}}, virt_text_win_col=31, hl_mode='blend'})
-    api.nvim_buf_set_extmark(0, ns, 1, 0, { virt_text={{'VERY', 'ErrorMsg'}}, virt_text_pos='right_align', hl_mode='blend'})
-    api.nvim_buf_set_extmark(0, ns, 2, 10, { virt_text={{'Much', 'ErrorMsg'}}, virt_text_win_col=31, hl_mode='blend'})
-    api.nvim_buf_set_extmark(0, ns, 2, 10, { virt_text={{'MUCH', 'ErrorMsg'}}, virt_text_pos='right_align', hl_mode='blend'})
-    api.nvim_buf_set_extmark(0, ns, 3, 14, { virt_text={{'Error', 'ErrorMsg'}}, virt_text_win_col=31, hl_mode='blend'})
-    api.nvim_buf_set_extmark(0, ns, 3, 14, { virt_text={{'ERROR', 'ErrorMsg'}}, virt_text_pos='right_align', hl_mode='blend'})
-    api.nvim_buf_set_extmark(0, ns, 7, 21, { virt_text={{'-', 'NonText'}}, virt_text_win_col=4, hl_mode='blend'})
-    api.nvim_buf_set_extmark(0, ns, 7, 21, { virt_text={{'-', 'NonText'}}, virt_text_pos='right_align', hl_mode='blend'})
+    api.nvim_buf_set_extmark(0, ns, 1, 0, { virt_text = { { 'Very', 'ErrorMsg' } }, virt_text_win_col = 31, hl_mode = 'blend' })
+    api.nvim_buf_set_extmark(0, ns, 1, 0, { virt_text = { { 'VERY', 'ErrorMsg' } }, virt_text_pos = 'right_align', hl_mode = 'blend' })
+    api.nvim_buf_set_extmark(0, ns, 2, 10, { virt_text = { { 'Much', 'ErrorMsg' } }, virt_text_win_col = 31, hl_mode = 'blend' })
+    api.nvim_buf_set_extmark(0, ns, 2, 10, { virt_text = { { 'MUCH', 'ErrorMsg' } }, virt_text_pos = 'right_align', hl_mode = 'blend' })
+    api.nvim_buf_set_extmark(0, ns, 3, 14, { virt_text = { { 'Error', 'ErrorMsg' } }, virt_text_win_col = 31, hl_mode = 'blend' })
+    api.nvim_buf_set_extmark(0, ns, 3, 14, { virt_text = { { 'ERROR', 'ErrorMsg' } }, virt_text_pos = 'right_align', hl_mode = 'blend' })
+    api.nvim_buf_set_extmark(0, ns, 7, 21, { virt_text = { { '-', 'NonText' } }, virt_text_win_col = 4, hl_mode = 'blend' })
+    api.nvim_buf_set_extmark(0, ns, 7, 21, { virt_text = { { '-', 'NonText' } }, virt_text_pos = 'right_align', hl_mode = 'blend' })
     -- empty virt_text should not change anything
-    api.nvim_buf_set_extmark(0, ns, 8, 0, { virt_text={{''}}, virt_text_win_col=14, hl_mode='blend'})
-    api.nvim_buf_set_extmark(0, ns, 8, 0, { virt_text={{''}}, virt_text_pos='right_align', hl_mode='blend'})
+    api.nvim_buf_set_extmark(0, ns, 8, 0, { virt_text = { { '' } }, virt_text_win_col = 14, hl_mode = 'blend' })
+    api.nvim_buf_set_extmark(0, ns, 8, 0, { virt_text = { { '' } }, virt_text_pos = 'right_align', hl_mode = 'blend' })
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^for _,item in ipairs(items) do                    |
           local text, hl_id_cell, cou{4:Very} unpack(ite{4:VERY}|
           if hl_id_cell ~= nil then  {4:Much}           {4:MUCH}|
@@ -1408,10 +1567,12 @@ describe('extmark decorations', function()
       end                                               |
       {1:~                                                 }|*2
                                                         |
-    ]]}
+    ]],
+    }
 
     feed '3G12|i<cr><esc>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       for _,item in ipairs(items) do                    |
           local text, hl_id_cell, cou{4:Very} unpack(ite{4:VERY}|
           if hl_i                    {4:Much}           {4:MUCH}|
@@ -1427,10 +1588,12 @@ describe('extmark decorations', function()
       end                                               |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
 
     feed 'u:<cr>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       for _,item in ipairs(items) do                    |
           local text, hl_id_cell, cou{4:Very} unpack(ite{4:VERY}|
           if hl_i^d_cell ~= nil then  {4:Much}           {4:MUCH}|
@@ -1445,10 +1608,12 @@ describe('extmark decorations', function()
       end                                               |
       {1:~                                                 }|*2
       :                                                 |
-    ]]}
+    ]],
+    }
 
     feed '8|i<cr><esc>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       for _,item in ipairs(items) do                    |
           local text, hl_id_cell, cou{4:Very} unpack(ite{4:VERY}|
           if                                            |
@@ -1464,10 +1629,12 @@ describe('extmark decorations', function()
       end                                               |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
 
     feed 'jI-- <esc>..........'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       for _,item in ipairs(items) do                    |
           local text, hl_id_cell, cou{4:Very} unpack(ite{4:VERY}|
           if                                            |
@@ -1483,10 +1650,12 @@ describe('extmark decorations', function()
           end                                           |
       end                                               |
                                                         |
-    ]]}
+    ]],
+    }
 
-    api.nvim_buf_set_extmark(0, ns, 4, 50, { virt_text={{'EOL', 'NonText'}} })
-    screen:expect{grid=[[
+    api.nvim_buf_set_extmark(0, ns, 4, 50, { virt_text = { { 'EOL', 'NonText' } } })
+    screen:expect {
+      grid = [[
       for _,item in ipairs(items) do                    |
           local text, hl_id_cell, cou{4:Very} unpack(ite{4:VERY}|
           if                                            |
@@ -1502,10 +1671,12 @@ describe('extmark decorations', function()
           end                                           |
       end                                               |
                                                         |
-    ]]}
+    ]],
+    }
 
     feed '.'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       for _,item in ipairs(items) do                    |
           local text, hl_id_cell, cou{4:Very} unpack(ite{4:VERY}|
           if                                            |
@@ -1521,10 +1692,12 @@ describe('extmark decorations', function()
           end                                           |
       end                                               |
                                                         |
-    ]]}
+    ]],
+    }
 
     command 'set number'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {2:  1 }for _,item in ipairs(items) do                |
       {2:  2 }    local text, hl_id_cell, cou{4:Very} unpack{4:VERY}|
       {2:    }m)                                            |
@@ -1540,10 +1713,12 @@ describe('extmark decorations', function()
       {2: 11 }        colpos = colpos+1                     |
       {2: 12 }    end                                       |
                                                         |
-    ]]}
+    ]],
+    }
 
     command 'set cpoptions+=n'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {2:  1 }for _,item in ipairs(items) do                |
       {2:  2 }    local text, hl_id_cell, cou{4:Very} unpack{4:VERY}|
       m)                                                |
@@ -1559,10 +1734,12 @@ describe('extmark decorations', function()
       {2: 11 }        colpos = colpos+1                     |
       {2: 12 }    end                                       |
                                                         |
-    ]]}
+    ]],
+    }
 
     command 'set cpoptions-=n nowrap'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {2:  1 }for _,item in ipairs(items) do                |
       {2:  2 }    local text, hl_id_cell, cou{4:Very} unpack{4:VERY}|
       {2:  3 }    if                                        |
@@ -1578,10 +1755,12 @@ describe('extmark decorations', function()
       {2: 13 }end                                           |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
 
     feed '12zl'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {2:  1 }n ipairs(items) do                            |
       {2:  2 }xt, hl_id_cell, count = unpack({4:Very})      {4:VERY}|
       {2:  3 }                                              |
@@ -1597,10 +1776,12 @@ describe('extmark decorations', function()
       {2: 13 }                                              |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
 
     feed('fhi<Tab>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {2:  1 }n ipairs(items) do                            |
       {2:  2 }xt, hl_id_cell, count = unpack({4:Very})      {4:VERY}|
       {2:  3 }                                              |
@@ -1616,10 +1797,12 @@ describe('extmark decorations', function()
       {2: 13 }                                              |
       {1:~                                                 }|
       {24:-- INSERT --}                                      |
-    ]]}
+    ]],
+    }
 
     feed('<Esc>0')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {2:  1 }for _,item in ipairs(items) do                |
       {2:  2 }    local text, hl_id_cell, cou{4:Very} unpack{4:VERY}|
       {2:  3 }    if                                        |
@@ -1635,20 +1818,23 @@ describe('extmark decorations', function()
       {2: 13 }end                                           |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('virtual text win_col out of window does not break display #25645', function()
     screen:try_resize(51, 6)
     command('vnew')
     api.nvim_buf_set_lines(0, 0, -1, false, { string.rep('a', 50) })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^aaaaaaaaaaaaaaaaaaaaaaaaa│                         |
       aaaaaaaaaaaaaaaaaaaaaaaaa│{1:~                        }|
       {1:~                        }│{1:~                        }|*2
       {41:[No Name] [+]             }{40:[No Name]                }|
                                                          |
-    ]]}
+    ]],
+    }
     local extmark_opts = { virt_text_win_col = 35, virt_text = { { ' ', 'Comment' } } }
     api.nvim_buf_set_extmark(0, ns, 0, 0, extmark_opts)
     screen:expect_unchanged()
@@ -1666,34 +1852,42 @@ describe('extmark decorations', function()
     -- XXX: the behavior of overlay virtual text at non-zero column is strange:
     -- 1. With 'wrap' it is never shown.
     -- 2. With 'nowrap' it is shown only if the extmark is hidden before leftcol.
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = {{'AA', 'Underlined'}}, hl_mode = 'combine', virt_text_pos = 'overlay' })
-    api.nvim_buf_set_extmark(0, ns, 0, 5, { virt_text = {{'BB', 'Underlined'}}, hl_mode = 'combine', virt_text_win_col = 10 })
-    api.nvim_buf_set_extmark(0, ns, 0, 2, { virt_text = {{'CC', 'Underlined'}}, hl_mode = 'combine', virt_text_pos = 'right_align' })
-    screen:expect{grid=[[
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'AA', 'Underlined' } }, hl_mode = 'combine', virt_text_pos = 'overlay' })
+    api.nvim_buf_set_extmark(0, ns, 0, 5, { virt_text = { { 'BB', 'Underlined' } }, hl_mode = 'combine', virt_text_win_col = 10 })
+    api.nvim_buf_set_extmark(0, ns, 0, 2, { virt_text = { { 'CC', 'Underlined' } }, hl_mode = 'combine', virt_text_pos = 'right_align' })
+    screen:expect {
+      grid = [[
       {29:AA}{33:-  2 lin}{29:BB}{33:: 11111·····························}{29:CC}|
       3333^3                                             |
                                                         |
-    ]]}
+    ]],
+    }
     command('set nowrap')
     screen:expect_unchanged()
     feed('zl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {29:AA}{33:-  2 lin}{29:BB}{33:: 11111·····························}{29:CC}|
       333^3                                              |
                                                         |
-    ]]}
+    ]],
+    }
     feed('zl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {29:AA}{33:-  2 lin}{29:BB}{33:: 11111·····························}{29:CC}|
       33^3                                               |
                                                         |
-    ]]}
+    ]],
+    }
     feed('zl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {29:AA}{33:-  2 lin}{29:BB}{33:: 11111·····························}{29:CC}|
       3^3                                                |
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('virtual text works below diff filler lines', function()
@@ -1711,10 +1905,11 @@ describe('extmark decorations', function()
       ddddd
       eeeee]])
     command('windo diffthis')
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = {{'AA', 'Underlined'}}, virt_text_pos = 'overlay' })
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = {{'BB', 'Underlined'}}, virt_text_win_col = 10 })
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = {{'CC', 'Underlined'}}, virt_text_pos = 'right_align' })
-    screen:expect{grid=[[
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'AA', 'Underlined' } }, virt_text_pos = 'overlay' })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'BB', 'Underlined' } }, virt_text_win_col = 10 })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'CC', 'Underlined' } }, virt_text_pos = 'right_align' })
+    screen:expect {
+      grid = [[
       {37:  }{38:aaaaa                   }│{37:  }{39:------------------------}|
       {37:  }bbbbb                   │{37:  }{28:AA}bbb     {28:BB}          {28:CC}|
       {37:  }ccccc                   │{37:  }ccccc                   |
@@ -1723,7 +1918,8 @@ describe('extmark decorations', function()
       {1:~                         }│{1:~                         }|
       {40:[No Name] [+]              }{41:[No Name] [+]             }|
                                                            |
-    ]]}
+    ]],
+    }
     command('windo set wrap')
     screen:expect_unchanged()
   end)
@@ -1732,12 +1928,12 @@ describe('extmark decorations', function()
     screen:try_resize(20, 5)
 
     screen:set_default_attr_ids {
-      [1] = {bold=true, foreground=Screen.colors.Blue};
-      [2] = {background = tonumber('0x123456'), foreground = tonumber('0xbbbbbb')};
-      [3] = {background = tonumber('0x123456'), foreground = tonumber('0xcccccc')};
-      [4] = {background = tonumber('0x234567'), foreground = tonumber('0xbbbbbb')};
-      [5] = {background = tonumber('0x234567'), foreground = tonumber('0xcccccc')};
-      [6] = {bold = true, foreground = tonumber('0xcccccc'), background = tonumber('0x234567')};
+      [1] = { bold = true, foreground = Screen.colors.Blue },
+      [2] = { background = tonumber('0x123456'), foreground = tonumber('0xbbbbbb') },
+      [3] = { background = tonumber('0x123456'), foreground = tonumber('0xcccccc') },
+      [4] = { background = tonumber('0x234567'), foreground = tonumber('0xbbbbbb') },
+      [5] = { background = tonumber('0x234567'), foreground = tonumber('0xcccccc') },
+      [6] = { bold = true, foreground = tonumber('0xcccccc'), background = tonumber('0x234567') },
     }
 
     exec [[
@@ -1750,22 +1946,24 @@ describe('extmark decorations', function()
 
     insert('##')
     local vt = {
-      {'a', {'BgOne', 'FgEin'}};
-      {'b', {'BgOne', 'FgZwei'}};
-      {'c', {'BgTwo', 'FgEin'}};
-      {'d', {'BgTwo', 'FgZwei'}};
-      {'X', {'BgTwo', 'FgZwei', 'VeryBold'}};
+      { 'a', { 'BgOne', 'FgEin' } },
+      { 'b', { 'BgOne', 'FgZwei' } },
+      { 'c', { 'BgTwo', 'FgEin' } },
+      { 'd', { 'BgTwo', 'FgZwei' } },
+      { 'X', { 'BgTwo', 'FgZwei', 'VeryBold' } },
     }
     api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = vt, virt_text_pos = 'eol' })
     api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = vt, virt_text_pos = 'right_align' })
     api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = vt, virt_text_pos = 'inline' })
     api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_lines = { vt, vt } })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {2:a}{3:b}{4:c}{5:d}{6:X}#^# {2:a}{3:b}{4:c}{5:d}{6:X}  {2:a}{3:b}{4:c}{5:d}{6:X}|
       {2:a}{3:b}{4:c}{5:d}{6:X}               |*2
       {1:~                   }|
                           |
-    ]]}
+    ]],
+    }
   end)
 
   it('does not crash when deleting a cleared buffer #15212', function()
@@ -1773,28 +1971,32 @@ describe('extmark decorations', function()
       ns = vim.api.nvim_create_namespace("myplugin")
       vim.api.nvim_buf_set_extmark(0, ns, 0, 0, {virt_text = {{"a"}}, end_col = 0})
     ]]
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^ a                                                |
       {1:~                                                 }|*13
                                                         |
-    ]]}
+    ]],
+    }
 
     exec_lua [[
       vim.api.nvim_buf_clear_namespace(0, ns, 0, -1)
       vim.cmd("bdelete")
     ]]
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^                                                  |
       {1:~                                                 }|*13
                                                         |
-    ]]}
+    ]],
+    }
     assert_alive()
   end)
 
   it('conceal with conceal char #19007', function()
     screen:try_resize(50, 5)
     insert('foo\n')
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {end_col=0, end_row=2, conceal='X'})
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_col = 0, end_row = 2, conceal = 'X' })
     command('set conceallevel=2')
     screen:expect([[
       {26:X}                                                 |
@@ -1805,13 +2007,13 @@ describe('extmark decorations', function()
     command('set conceallevel=1')
     screen:expect_unchanged()
 
-    eq("conceal char has to be printable", pcall_err(api.nvim_buf_set_extmark, 0, ns, 0, 0, {end_col=0, end_row=2, conceal='\255'}))
+    eq('conceal char has to be printable', pcall_err(api.nvim_buf_set_extmark, 0, ns, 0, 0, { end_col = 0, end_row = 2, conceal = '\255' }))
   end)
 
   it('conceal with composed conceal char', function()
     screen:try_resize(50, 5)
     insert('foo\n')
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {end_col=0, end_row=2, conceal='ẍ̲'})
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_col = 0, end_row = 2, conceal = 'ẍ̲' })
     command('set conceallevel=2')
     screen:expect([[
       {26:ẍ̲}                                                 |
@@ -1824,18 +2026,20 @@ describe('extmark decorations', function()
 
     -- this is rare, but could happen. Save at least the first codepoint
     api.nvim__invalidate_glyph_cache()
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {26:x}                                                 |
       ^                                                  |
       {1:~                                                 }|*2
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('conceal without conceal char #24782', function()
     screen:try_resize(50, 5)
     insert('foobar\n')
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {end_col=3, conceal=''})
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_col = 3, conceal = '' })
     command('set listchars=conceal:?')
     command('let &conceallevel=1')
     screen:expect([[
@@ -1855,55 +2059,65 @@ describe('extmark decorations', function()
 
   it('conceal works just before truncated double-width char #21486', function()
     screen:try_resize(40, 4)
-    api.nvim_buf_set_lines(0, 0, -1, true, {'', ('a'):rep(37) .. '<>古'})
-    api.nvim_buf_set_extmark(0, ns, 1, 37, {end_col=39, conceal=''})
+    api.nvim_buf_set_lines(0, 0, -1, true, { '', ('a'):rep(37) .. '<>古' })
+    api.nvim_buf_set_extmark(0, ns, 1, 37, { end_col = 39, conceal = '' })
     command('setlocal conceallevel=2')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^                                        |
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{1:>}  |
       古                                      |
                                               |
-    ]]}
+    ]],
+    }
     feed('j')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
                                               |
       ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa<>{1:>}|
       古                                      |
                                               |
-    ]]}
+    ]],
+    }
   end)
 
   it('redraws properly when adding/removing conceal on non-current line', function()
     screen:try_resize(50, 5)
-    api.nvim_buf_set_lines(0, 0, -1, true, {'abcd', 'efgh','ijkl', 'mnop'})
+    api.nvim_buf_set_lines(0, 0, -1, true, { 'abcd', 'efgh', 'ijkl', 'mnop' })
     command('setlocal conceallevel=2')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^abcd                                              |
       efgh                                              |
       ijkl                                              |
       mnop                                              |
                                                         |
-    ]]}
-    api.nvim_buf_set_extmark(0, ns, 2, 1, {end_col=3, conceal=''})
-    screen:expect{grid=[[
+    ]],
+    }
+    api.nvim_buf_set_extmark(0, ns, 2, 1, { end_col = 3, conceal = '' })
+    screen:expect {
+      grid = [[
       ^abcd                                              |
       efgh                                              |
       il                                                |
       mnop                                              |
                                                         |
-    ]]}
+    ]],
+    }
     api.nvim_buf_clear_namespace(0, ns, 0, -1)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^abcd                                              |
       efgh                                              |
       ijkl                                              |
       mnop                                              |
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('avoids redraw issue #20651', function()
-    exec_lua[[
+    exec_lua [[
       vim.cmd.normal'10oXXX'
       vim.cmd.normal'gg'
       local ns = vim.api.nvim_create_namespace('ns')
@@ -1930,15 +2144,16 @@ describe('extmark decorations', function()
       feed 'j'
     end
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {44: }                                                 |
       XXX                                               |*2
       ^XXX HELLO                                         |
       XXX                                               |*7
       {1:~                                                 }|*3
                                                         |
-    ]]}
-
+    ]],
+    }
   end)
 
   it('underline attribute with higher priority takes effect #22371', function()
@@ -1950,13 +2165,13 @@ describe('extmark decorations', function()
       hi TestBold gui=bold
     ]])
     screen:set_default_attr_ids({
-      [0] = {bold = true, foreground = Screen.colors.Blue};
-      [1] = {underline = true, foreground = Screen.colors.Blue};
-      [2] = {undercurl = true, special = Screen.colors.Red};
-      [3] = {underline = true, foreground = Screen.colors.Blue, special = Screen.colors.Red};
-      [4] = {undercurl = true, foreground = Screen.colors.Blue, special = Screen.colors.Red};
-      [5] = {bold = true, underline = true, foreground = Screen.colors.Blue};
-      [6] = {bold = true, undercurl = true, special = Screen.colors.Red};
+      [0] = { bold = true, foreground = Screen.colors.Blue },
+      [1] = { underline = true, foreground = Screen.colors.Blue },
+      [2] = { undercurl = true, special = Screen.colors.Red },
+      [3] = { underline = true, foreground = Screen.colors.Blue, special = Screen.colors.Red },
+      [4] = { undercurl = true, foreground = Screen.colors.Blue, special = Screen.colors.Red },
+      [5] = { bold = true, underline = true, foreground = Screen.colors.Blue },
+      [6] = { bold = true, undercurl = true, special = Screen.colors.Red },
     })
 
     api.nvim_buf_set_extmark(0, ns, 0, 0, { end_col = 9, hl_group = 'TestUL', priority = 20 })
@@ -1992,7 +2207,7 @@ describe('extmark decorations', function()
     ]])
 
     -- When only one highlight group has an underline attribute, it should always take effect.
-    for _, d in ipairs({-5, 5}) do
+    for _, d in ipairs({ -5, 5 }) do
       api.nvim_buf_clear_namespace(0, ns, 0, -1)
       screen:expect([[
         aaabbbaa^a                                         |
@@ -2007,7 +2222,7 @@ describe('extmark decorations', function()
                                                           |
       ]])
     end
-    for _, d in ipairs({-5, 5}) do
+    for _, d in ipairs({ -5, 5 }) do
       api.nvim_buf_clear_namespace(0, ns, 0, -1)
       screen:expect([[
         aaabbbaa^a                                         |
@@ -2037,11 +2252,13 @@ describe('extmark decorations', function()
     command('hi default MyLine gui=underline')
     command('sign define CurrentLine linehl=MyLine')
     fn.sign_place(6, 'Test', 'CurrentLine', '', { lnum = 1 })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {30:^fun}{31:ction}{32: Func()                                   }|
       {6:end}                                               |
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('highlight can combine multiple groups', function()
@@ -2050,7 +2267,7 @@ describe('extmark decorations', function()
     command('hi Group2 guibg=Blue guifg=Blue')
     command('hi Group3 guibg=Green')
     insert([[example text]])
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_row=1, hl_group = {} })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_row = 1, hl_group = {} })
     screen:expect([[
       example tex^t                                      |
       {1:~                                                 }|
@@ -2058,99 +2275,114 @@ describe('extmark decorations', function()
     ]])
 
     api.nvim_buf_clear_namespace(0, ns, 0, -1)
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_row=1, hl_group = {'Group1'} })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_row = 1, hl_group = { 'Group1' } })
     screen:expect([[
       {45:example tex^t}                                      |
       {1:~                                                 }|
                                                         |
     ]])
     api.nvim_buf_clear_namespace(0, ns, 0, -1)
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_row = 1, hl_group = {'Group1', 'Group2'} })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_row = 1, hl_group = { 'Group1', 'Group2' } })
     screen:expect([[
       {46:example tex^t}                                      |
       {1:~                                                 }|
                                                         |
     ]])
     api.nvim_buf_clear_namespace(0, ns, 0, -1)
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_row = 1, hl_group = {'Group1', 'Group2', 'Group3'}, hl_eol=true })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_row = 1, hl_group = { 'Group1', 'Group2', 'Group3' }, hl_eol = true })
     screen:expect([[
       {47:example tex^t                                      }|
       {1:~                                                 }|
                                                         |
     ]])
 
-    eq('Invalid hl_group: hl_group item',
-       pcall_err(api.nvim_buf_set_extmark, 0, ns, 0, 0, { end_row = 1, hl_group = {'Group1', 'Group2', {'fail'}}, hl_eol=true }))
+    eq(
+      'Invalid hl_group: hl_group item',
+      pcall_err(api.nvim_buf_set_extmark, 0, ns, 0, 0, { end_row = 1, hl_group = { 'Group1', 'Group2', { 'fail' } }, hl_eol = true })
+    )
   end)
-
 
   it('highlight works after TAB with sidescroll #14201', function()
     screen:try_resize(50, 3)
     command('set nowrap')
-    api.nvim_buf_set_lines(0, 0, -1, true, {'\tword word word word'})
+    api.nvim_buf_set_lines(0, 0, -1, true, { '\tword word word word' })
     api.nvim_buf_set_extmark(0, ns, 0, 1, { end_col = 3, hl_group = 'ErrorMsg' })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
              ^ {4:wo}rd word word word                       |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('7zl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
        {4:^wo}rd word word word                              |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('zl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {4:^wo}rd word word word                               |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('zl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {4:^o}rd word word word                                |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('highlights the beginning of a TAB char correctly #23734', function()
     screen:try_resize(50, 3)
-    api.nvim_buf_set_lines(0, 0, -1, true, {'this is the\ttab'})
+    api.nvim_buf_set_lines(0, 0, -1, true, { 'this is the\ttab' })
     api.nvim_buf_set_extmark(0, ns, 0, 11, { end_col = 15, hl_group = 'ErrorMsg' })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^this is the{4:     tab}                               |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
 
     api.nvim_buf_clear_namespace(0, ns, 0, -1)
     api.nvim_buf_set_extmark(0, ns, 0, 12, { end_col = 15, hl_group = 'ErrorMsg' })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^this is the     {4:tab}                               |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('highlight applies to a full TAB on line with matches #20885', function()
     screen:try_resize(50, 3)
-    api.nvim_buf_set_lines(0, 0, -1, true, {'\t-- match1', '        -- match2'})
+    api.nvim_buf_set_lines(0, 0, -1, true, { '\t-- match1', '        -- match2' })
     fn.matchadd('NonText', 'match')
     api.nvim_buf_set_extmark(0, ns, 0, 0, { end_row = 1, end_col = 0, hl_group = 'Search' })
     api.nvim_buf_set_extmark(0, ns, 1, 0, { end_row = 2, end_col = 0, hl_group = 'Search' })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {34:       ^ -- }{35:match}{34:1}                                 |
       {34:        -- }{35:match}{34:2}                                 |
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('highlight applies to a full TAB in visual block mode', function()
     screen:try_resize(50, 8)
     command('hi! Visual guifg=NONE guibg=LightGrey')
-    api.nvim_buf_set_lines(0, 0, -1, true, {'asdf', '\tasdf', '\tasdf', '\tasdf', 'asdf'})
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {end_row = 5, end_col = 0, hl_group = 'Underlined'})
+    api.nvim_buf_set_lines(0, 0, -1, true, { 'asdf', '\tasdf', '\tasdf', '\tasdf', 'asdf' })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_row = 5, end_col = 0, hl_group = 'Underlined' })
     screen:expect([[
       {28:^asdf}                                              |
       {28:        asdf}                                      |*3
@@ -2188,12 +2420,13 @@ describe('extmark decorations', function()
   it('supports multiline highlights', function()
     insert(example_text)
     feed 'gg'
-    for _,i in ipairs {1,2,3,5,6,7} do
-      for _,j in ipairs {2,5,10,15} do
-        api.nvim_buf_set_extmark(0, ns, i, j, { end_col=j+2, hl_group = 'NonText'})
+    for _, i in ipairs { 1, 2, 3, 5, 6, 7 } do
+      for _, j in ipairs { 2, 5, 10, 15 } do
+        api.nvim_buf_set_extmark(0, ns, i, j, { end_col = j + 2, hl_group = 'NonText' })
       end
     end
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^for _,item in ipairs(items) do                    |
         {1:  }l{1:oc}al {1:te}xt,{1: h}l_id_cell, count = unpack(item)  |
         {1:  }i{1:f }hl_{1:id}_ce{1:ll} ~= nil then                     |
@@ -2208,9 +2441,11 @@ describe('extmark decorations', function()
       end                                               |
       {1:~                                                 }|*2
                                                         |
-    ]]}
-    feed'5<c-e>'
-    screen:expect{grid=[[
+    ]],
+    }
+    feed '5<c-e>'
+    screen:expect {
+      grid = [[
       ^  {1:  }f{1:or} _ {1:= }1, {1:(c}ount or 1) do                    |
         {1:  } {1:  } lo{1:ca}l c{1:el}l = line[colpos]                 |
         {1:  } {1:  } ce{1:ll}.te{1:xt} = text                          |
@@ -2220,10 +2455,12 @@ describe('extmark decorations', function()
       end                                               |
       {1:~                                                 }|*7
                                                         |
-    ]]}
+    ]],
+    }
 
-    api.nvim_buf_set_extmark(0, ns, 1, 0, { end_line=8, end_col=10, hl_group = 'ErrorMsg'})
-    screen:expect{grid=[[
+    api.nvim_buf_set_extmark(0, ns, 1, 0, { end_line = 8, end_col = 10, hl_group = 'ErrorMsg' })
+    screen:expect {
+      grid = [[
       {4:^  }{36:  }{4:f}{36:or}{4: _ }{36:= }{4:1, }{36:(c}{4:ount or 1) do}                    |
       {4:  }{36:  }{4: }{36:  }{4: lo}{36:ca}{4:l c}{36:el}{4:l = line[colpos]}                 |
       {4:  }{36:  }{4: }{36:  }{4: ce}{36:ll}{4:.te}{36:xt}{4: = text}                          |
@@ -2233,61 +2470,84 @@ describe('extmark decorations', function()
       end                                               |
       {1:~                                                 }|*7
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   local function with_undo_restore(val)
     screen:try_resize(50, 5)
     insert(example_text)
-    feed'gg'
-    api.nvim_buf_set_extmark(0, ns, 0, 6, { end_col=13, hl_group = 'NonText', undo_restore=val})
-    screen:expect{grid=[[
+    feed 'gg'
+    api.nvim_buf_set_extmark(0, ns, 0, 6, { end_col = 13, hl_group = 'NonText', undo_restore = val })
+    screen:expect {
+      grid = [[
       ^for _,{1:item in} ipairs(items) do                    |
           local text, hl_id_cell, count = unpack(item)  |
           if hl_id_cell ~= nil then                     |
               hl_id = hl_id_cell                        |
                                                         |
-    ]]}
+    ]],
+    }
 
-    api.nvim_buf_set_text(0, 0, 4, 0, 8, {''})
-    screen:expect{grid=[[
+    api.nvim_buf_set_text(0, 0, 4, 0, 8, { '' })
+    screen:expect {
+      grid = [[
       ^for {1:em in} ipairs(items) do                        |
           local text, hl_id_cell, count = unpack(item)  |
           if hl_id_cell ~= nil then                     |
               hl_id = hl_id_cell                        |
                                                         |
-    ]]}
+    ]],
+    }
   end
 
-  it("highlights do reapply to restored text after delete", function()
+  it('highlights do reapply to restored text after delete', function()
     with_undo_restore(true) -- also default behavior
 
     command('silent undo')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^for _,{1:item in} ipairs(items) do                    |
           local text, hl_id_cell, count = unpack(item)  |
           if hl_id_cell ~= nil then                     |
               hl_id = hl_id_cell                        |
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it("highlights don't reapply to restored text after delete with undo_restore=false", function()
     with_undo_restore(false)
 
     command('silent undo')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^for _,it{1:em in} ipairs(items) do                    |
           local text, hl_id_cell, count = unpack(item)  |
           if hl_id_cell ~= nil then                     |
               hl_id = hl_id_cell                        |
                                                         |
-    ]]}
+    ]],
+    }
 
-    eq({ { 1, 0, 8, { end_col = 13, end_right_gravity = false, end_row = 0,
-                       hl_eol = false, hl_group = "NonText", undo_restore = false,
-                       ns_id = ns, priority = 4096, right_gravity = true } } },
-       api.nvim_buf_get_extmarks(0, ns, {0,0}, {0, -1}, {details=true}))
+    eq({
+      {
+        1,
+        0,
+        8,
+        {
+          end_col = 13,
+          end_right_gravity = false,
+          end_row = 0,
+          hl_eol = false,
+          hl_group = 'NonText',
+          undo_restore = false,
+          ns_id = ns,
+          priority = 4096,
+          right_gravity = true,
+        },
+      },
+    }, api.nvim_buf_get_extmarks(0, ns, { 0, 0 }, { 0, -1 }, { details = true }))
   end)
 
   it('virtual text works with rightleft', function()
@@ -2295,83 +2555,103 @@ describe('extmark decorations', function()
     insert('abcdefghijklmn')
     feed('0')
     command('set rightleft')
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = {{'EOL', 'Underlined'}}})
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = {{'right_align', 'Underlined'}}, virt_text_pos = 'right_align' })
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = {{'win_col', 'Underlined'}}, virt_text_win_col = 20 })
-    api.nvim_buf_set_extmark(0, ns, 0, 2, { virt_text = {{'overlayed', 'Underlined'}}, virt_text_pos = 'overlay' })
-    screen:expect{grid=[[
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'EOL', 'Underlined' } } })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'right_align', 'Underlined' } }, virt_text_pos = 'right_align' })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'win_col', 'Underlined' } }, virt_text_win_col = 20 })
+    api.nvim_buf_set_extmark(0, ns, 0, 2, { virt_text = { { 'overlayed', 'Underlined' } }, virt_text_pos = 'overlay' })
+    screen:expect {
+      grid = [[
       {28:ngila_thgir}            {28:loc_niw}  {28:LOE} nml{28:deyalrevo}b^a|
       {1:                                                 ~}|
                                                         |
-    ]]}
+    ]],
+    }
 
     insert(('#'):rep(32))
     feed('0')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {28:ngila_tdeyalrevo}ba#####{28:loc_niw}###################^#|
       {1:                                                 ~}|
                                                         |
-    ]]}
+    ]],
+    }
 
     insert(('#'):rep(16))
     feed('0')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {28:ngila_thgir}############{28:loc_niw}###################^#|
                                         {28:LOE} nml{28:deyalrevo}|
                                                         |
-    ]]}
+    ]],
+    }
 
     insert('###')
     feed('0')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       #################################################^#|
       {28:ngila_thgir}            {28:loc_niw} {28:LOE} nml{28:deyalrevo}ba#|
                                                         |
-    ]]}
+    ]],
+    }
 
     command('set number')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       #############################################^#{2: 1  }|
       {28:ngila_thgir}        {28:loc_niw} nml{28:deyalrevo}ba#####{2:    }|
                                                         |
-    ]]}
+    ]],
+    }
 
     command('set cpoptions+=n')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       #############################################^#{2: 1  }|
       {28:ngila_thgir}            {28:loc_niw} nml{28:deyalrevo}ba#####|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('virtual text overwrites double-width char properly', function()
     screen:try_resize(50, 3)
     insert('abcdefghij口klmnopqrstu口vwx口yz')
     feed('0')
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = {{'!!!!!', 'Underlined'}}, virt_text_win_col = 11 })
-    screen:expect{grid=[[
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { '!!!!!', 'Underlined' } }, virt_text_win_col = 11 })
+    screen:expect {
+      grid = [[
       ^abcdefghij {28:!!!!!}opqrstu口vwx口yz                  |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('8x')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^ij口klmnopq{28:!!!!!} vwx口yz                          |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('3l5x')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ij口^pqrstu {28:!!!!!} yz                               |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('5x')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ij口^u口vwx {28:!!!!!}                                  |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('virtual text blending space does not overwrite double-width char', function()
@@ -2379,36 +2659,46 @@ describe('extmark decorations', function()
     insert('abcdefghij口klmnopqrstu口vwx口yz')
     feed('0')
     command('hi Blendy guibg=Red blend=30')
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = {{' !  ! ', 'Blendy'}}, virt_text_win_col = 8, hl_mode = 'blend' })
-    screen:expect{grid=[[
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { ' !  ! ', 'Blendy' } }, virt_text_win_col = 8, hl_mode = 'blend' })
+    screen:expect {
+      grid = [[
       ^abcdefgh{10:i}{7:!}{10:口}{7:!}{10:l}mnopqrstu口vwx口yz                  |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('x')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^bcdefghi{10:j}{7:!}{10: k}{7:!}{10:m}nopqrstu口vwx口yz                   |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('x')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^cdefghij{10: }{7:!}{10:kl}{7:!}{10:n}opqrstu口vwx口yz                    |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('x')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^defghij口{7:!}{10:lm}{7:!}{10:o}pqrstu口vwx口yz                     |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('7x')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^口klmnop{10:q}{7:!}{10:st}{7:!}{10:口}vwx口yz                            |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('virtual text works with double-width char and rightleft', function()
@@ -2416,28 +2706,33 @@ describe('extmark decorations', function()
     insert('abcdefghij口klmnopqrstu口vwx口yz')
     feed('0')
     command('set rightleft')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
                         zy口xwv口utsrqponmlk口jihgfedcb^a|
       {1:                                                 ~}|
                                                         |
-    ]]}
-    api.nvim_buf_set_extmark(0, ns, 0, 2, { virt_text = {{'overlayed', 'Underlined'}}, virt_text_pos = 'overlay' })
-    api.nvim_buf_set_extmark(0, ns, 0, 14, { virt_text = {{'古', 'Underlined'}}, virt_text_pos = 'overlay' })
-    api.nvim_buf_set_extmark(0, ns, 0, 20, { virt_text = {{'\t', 'Underlined'}}, virt_text_pos = 'overlay' })
-    api.nvim_buf_set_extmark(0, ns, 0, 29, { virt_text = {{'古', 'Underlined'}}, virt_text_pos = 'overlay' })
-    screen:expect{grid=[[
+    ]],
+    }
+    api.nvim_buf_set_extmark(0, ns, 0, 2, { virt_text = { { 'overlayed', 'Underlined' } }, virt_text_pos = 'overlay' })
+    api.nvim_buf_set_extmark(0, ns, 0, 14, { virt_text = { { '古', 'Underlined' } }, virt_text_pos = 'overlay' })
+    api.nvim_buf_set_extmark(0, ns, 0, 20, { virt_text = { { '\t', 'Underlined' } }, virt_text_pos = 'overlay' })
+    api.nvim_buf_set_extmark(0, ns, 0, 29, { virt_text = { { '古', 'Underlined' } }, virt_text_pos = 'overlay' })
+    screen:expect {
+      grid = [[
                         zy {28:古}wv {28:     }qpon{28:古}k {28:deyalrevo}b^a|
       {1:                                                 ~}|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('virtual text is drawn correctly after delete and undo #27368', function()
     insert('aaa\nbbb\nccc\nddd\neee')
     command('vsplit')
-    api.nvim_buf_set_extmark(0, ns, 2, 0, { virt_text = {{'EOL'}} })
+    api.nvim_buf_set_extmark(0, ns, 2, 0, { virt_text = { { 'EOL' } } })
     feed('3gg')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaa                      │aaa                     |
       bbb                      │bbb                     |
       ^ccc EOL                  │ccc EOL                 |
@@ -2446,9 +2741,11 @@ describe('extmark decorations', function()
       {1:~                        }│{1:~                       }|*8
       {41:[No Name] [+]             }{40:[No Name] [+]           }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('dd')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaa                      │aaa                     |
       bbb                      │bbb                     |
       ^ddd EOL                  │ddd EOL                 |
@@ -2456,9 +2753,11 @@ describe('extmark decorations', function()
       {1:~                        }│{1:~                       }|*9
       {41:[No Name] [+]             }{40:[No Name] [+]           }|
                                                         |
-    ]]}
+    ]],
+    }
     command('silent undo')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaa                      │aaa                     |
       bbb                      │bbb                     |
       ^ccc EOL                  │ccc EOL                 |
@@ -2467,7 +2766,8 @@ describe('extmark decorations', function()
       {1:~                        }│{1:~                       }|*8
       {41:[No Name] [+]             }{40:[No Name] [+]           }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('virtual text does not crash with blend, conceal and wrap #27836', function()
@@ -2475,12 +2775,14 @@ describe('extmark decorations', function()
     insert(('a'):rep(45) .. '|hidden|' .. ('b'):rep(45))
     command('syntax match test /|hidden|/ conceal')
     command('set conceallevel=2 concealcursor=n')
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {virt_text = {{'FOO'}}, virt_text_pos='right_align', hl_mode='blend'})
-    screen:expect{grid=[[
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'FOO' } }, virt_text_pos = 'right_align', hl_mode = 'blend' })
+    screen:expect {
+      grid = [[
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa  FOO|
       bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb^b     |
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('works with both hl_group and sign_hl_group', function()
@@ -2489,7 +2791,7 @@ describe('extmark decorations', function()
       [100] = { background = Screen.colors.WebGray, foreground = Screen.colors.Blue, bold = true },
     })
     insert('abcdefghijklmn')
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {sign_text='S', sign_hl_group='NonText', hl_group='Error', end_col=14})
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { sign_text = 'S', sign_hl_group = 'NonText', hl_group = 'Error', end_col = 14 })
     screen:expect([[
       {100:S }{9:abcdefghijklm^n}                                  |
       {1:~                                                 }|
@@ -2501,26 +2803,54 @@ describe('extmark decorations', function()
     screen:try_resize(40, 5)
     api.nvim_set_option_value('breakindent', true, {})
     insert(example_text)
-    api.nvim_buf_set_extmark(0, ns, 1, 0, { virt_text = {{'│', 'NonText'}}, virt_text_pos = 'overlay', virt_text_repeat_linebreak = true })
-    api.nvim_buf_set_extmark(0, ns, 1, 3, { virt_text = {{'│', 'NonText'}}, virt_text_pos = 'overlay', virt_text_repeat_linebreak = true })
+    api.nvim_buf_set_extmark(
+      0,
+      ns,
+      1,
+      0,
+      { virt_text = { { '│', 'NonText' } }, virt_text_pos = 'overlay', virt_text_repeat_linebreak = true }
+    )
+    api.nvim_buf_set_extmark(
+      0,
+      ns,
+      1,
+      3,
+      { virt_text = { { '│', 'NonText' } }, virt_text_pos = 'overlay', virt_text_repeat_linebreak = true }
+    )
     command('norm gg')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^for _,item in ipairs(items) do          |
       {1:│}  {1:│}local text, hl_id_cell, count = unpa|
       {1:│}  {1:│}ck(item)                            |
           if hl_id_cell ~= nil then           |
                                               |
-    ]]}
+    ]],
+    }
     api.nvim_buf_clear_namespace(0, ns, 0, -1)
-    api.nvim_buf_set_extmark(0, ns, 1, 0, { virt_text = {{'│', 'NonText'}}, virt_text_repeat_linebreak = true, virt_text_win_col = 0 })
-    api.nvim_buf_set_extmark(0, ns, 1, 0, { virt_text = {{'│', 'NonText'}}, virt_text_repeat_linebreak = true, virt_text_win_col = 2 })
-    screen:expect{grid=[[
+    api.nvim_buf_set_extmark(
+      0,
+      ns,
+      1,
+      0,
+      { virt_text = { { '│', 'NonText' } }, virt_text_repeat_linebreak = true, virt_text_win_col = 0 }
+    )
+    api.nvim_buf_set_extmark(
+      0,
+      ns,
+      1,
+      0,
+      { virt_text = { { '│', 'NonText' } }, virt_text_repeat_linebreak = true, virt_text_win_col = 2 }
+    )
+    screen:expect {
+      grid = [[
       ^for _,item in ipairs(items) do          |
       {1:│} {1:│} local text, hl_id_cell, count = unpa|
       {1:│} {1:│} ck(item)                            |
           if hl_id_cell ~= nil then           |
                                               |
-    ]]}
+    ]],
+    }
   end)
 
   it('supports URLs', function()
@@ -2564,42 +2894,48 @@ describe('extmark decorations', function()
   end)
 
   it('can replace marks in place with different decorations #27211', function()
-    local mark = api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_lines = {{{"foo", "ErrorMsg"}}}, })
-    screen:expect{grid=[[
+    local mark = api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_lines = { { { 'foo', 'ErrorMsg' } } } })
+    screen:expect {
+      grid = [[
       ^                                                  |
       {4:foo}                                               |
       {1:~                                                 }|*12
                                                         |
-    ]]}
+    ]],
+    }
 
     api.nvim_buf_set_extmark(0, ns, 0, 0, {
       id = mark,
-      virt_text = { { "testing", "NonText" } },
-      virt_text_pos = "inline",
+      virt_text = { { 'testing', 'NonText' } },
+      virt_text_pos = 'inline',
     })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {1:^testing}                                           |
       {1:~                                                 }|*13
                                                         |
-    ]]}
+    ]],
+    }
 
     api.nvim_buf_del_extmark(0, ns, mark)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^                                                  |
       {1:~                                                 }|*13
                                                         |
-    ]]}
+    ]],
+    }
 
     n.assert_alive()
   end)
 
   it('priority ordering of overlay or win_col virtual text at same position', function()
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = {{'A'}}, virt_text_pos = 'overlay', priority = 100 })
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = {{'A'}}, virt_text_win_col = 30, priority = 100 })
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = {{'BB'}}, virt_text_pos = 'overlay', priority = 90 })
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = {{'BB'}}, virt_text_win_col = 30, priority = 90 })
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = {{'CCC'}}, virt_text_pos = 'overlay', priority = 80 })
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = {{'CCC'}}, virt_text_win_col = 30, priority = 80 })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'A' } }, virt_text_pos = 'overlay', priority = 100 })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'A' } }, virt_text_win_col = 30, priority = 100 })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'BB' } }, virt_text_pos = 'overlay', priority = 90 })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'BB' } }, virt_text_win_col = 30, priority = 90 })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'CCC' } }, virt_text_pos = 'overlay', priority = 80 })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'CCC' } }, virt_text_win_col = 30, priority = 80 })
     screen:expect([[
       ^ABC                           ABC                 |
       {1:~                                                 }|*13
@@ -2609,23 +2945,23 @@ describe('extmark decorations', function()
 
   it('priority ordering of inline and non-inline virtual text at same char', function()
     insert(('?'):rep(40) .. ('!'):rep(30))
-    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = {{'A'}}, virt_text_pos = 'overlay', priority = 10 })
-    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = {{'a'}}, virt_text_win_col = 15, priority = 10 })
-    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = {{'BBBB'}}, virt_text_pos = 'inline', priority = 15 })
-    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = {{'C'}}, virt_text_pos = 'overlay', priority = 20 })
-    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = {{'c'}}, virt_text_win_col = 17, priority = 20 })
-    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = {{'DDDD'}}, virt_text_pos = 'inline', priority = 25 })
-    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = {{'E'}}, virt_text_pos = 'overlay', priority = 30 })
-    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = {{'e'}}, virt_text_win_col = 19, priority = 30 })
-    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = {{'FFFF'}}, virt_text_pos = 'inline', priority = 35 })
-    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = {{'G'}}, virt_text_pos = 'overlay', priority = 40 })
-    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = {{'g'}}, virt_text_win_col = 21, priority = 40 })
-    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = {{'HHHH'}}, virt_text_pos = 'inline', priority = 45 })
-    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = {{'I'}}, virt_text_pos = 'overlay', priority = 50 })
-    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = {{'i'}}, virt_text_win_col = 23, priority = 50 })
-    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = {{'JJJJ'}}, virt_text_pos = 'inline', priority = 55 })
-    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = {{'K'}}, virt_text_pos = 'overlay', priority = 60 })
-    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = {{'k'}}, virt_text_win_col = 25, priority = 60 })
+    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { 'A' } }, virt_text_pos = 'overlay', priority = 10 })
+    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { 'a' } }, virt_text_win_col = 15, priority = 10 })
+    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { 'BBBB' } }, virt_text_pos = 'inline', priority = 15 })
+    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { 'C' } }, virt_text_pos = 'overlay', priority = 20 })
+    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { 'c' } }, virt_text_win_col = 17, priority = 20 })
+    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { 'DDDD' } }, virt_text_pos = 'inline', priority = 25 })
+    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { 'E' } }, virt_text_pos = 'overlay', priority = 30 })
+    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { 'e' } }, virt_text_win_col = 19, priority = 30 })
+    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { 'FFFF' } }, virt_text_pos = 'inline', priority = 35 })
+    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { 'G' } }, virt_text_pos = 'overlay', priority = 40 })
+    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { 'g' } }, virt_text_win_col = 21, priority = 40 })
+    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { 'HHHH' } }, virt_text_pos = 'inline', priority = 45 })
+    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { 'I' } }, virt_text_pos = 'overlay', priority = 50 })
+    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { 'i' } }, virt_text_win_col = 23, priority = 50 })
+    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { 'JJJJ' } }, virt_text_pos = 'inline', priority = 55 })
+    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { 'K' } }, virt_text_pos = 'overlay', priority = 60 })
+    api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { 'k' } }, virt_text_win_col = 25, priority = 60 })
     screen:expect([[
       ???????????????a?c?e????????????????????ABBBCDDDEF|
       FFGHHHIJJJK!!!!!!!!!!g!i!k!!!!!!!!!!!!!^!          |
@@ -2680,7 +3016,7 @@ describe('extmark decorations', function()
     ]])
   end)
 
-  it ('conceal_lines', function()
+  it('conceal_lines', function()
     insert(example_text)
     exec('set number conceallevel=3')
     feed('ggj')
@@ -2701,10 +3037,10 @@ describe('extmark decorations', function()
         {2: 12 }end                                           |
         {1:~                                                 }|
                                                           |
-      ]]
+      ]],
     }
     screen:expect(not_concealed)
-    api.nvim_buf_set_extmark(0, ns, 1, 0, { conceal_lines = "" })
+    api.nvim_buf_set_extmark(0, ns, 1, 0, { conceal_lines = '' })
     screen:expect_unchanged()
     feed('j')
     local concealed = {
@@ -2722,14 +3058,14 @@ describe('extmark decorations', function()
         {2: 12 }end                                           |
         {1:~                                                 }|*3
                                                           |
-      ]]
+      ]],
     }
     screen:expect(concealed)
     feed('k')
     screen:expect(not_concealed)
     exec('set concealcursor=n')
     screen:expect(concealed)
-    api.nvim_buf_set_extmark(0, ns, 3, 0, { conceal_lines = "" })
+    api.nvim_buf_set_extmark(0, ns, 3, 0, { conceal_lines = '' })
     screen:expect({
       grid = [[
         {2:  1 }for _,item in ipairs(items) do                |
@@ -2744,11 +3080,11 @@ describe('extmark decorations', function()
         {2: 12 }end                                           |
         {1:~                                                 }|*4
                                                           |
-      ]]
+      ]],
     })
     feed('kjj')
     screen:expect_unchanged()
-    api.nvim_buf_set_extmark(0, ns, 4, 0, { conceal_lines = "" })
+    api.nvim_buf_set_extmark(0, ns, 4, 0, { conceal_lines = '' })
     feed('kjjjC')
     screen:expect({
       grid = [[
@@ -2764,7 +3100,7 @@ describe('extmark decorations', function()
         {2: 12 }end                                           |
         {1:~                                                 }|*4
         {24:-- INSERT --}                                      |
-      ]]
+      ]],
     })
     feed('<esc>')
     screen:expect({
@@ -2780,7 +3116,7 @@ describe('extmark decorations', function()
         {2: 12 }end                                           |
         {1:~                                                 }|*5
                                                           |
-      ]]
+      ]],
     })
     feed('kji')
     screen:expect({
@@ -2797,7 +3133,7 @@ describe('extmark decorations', function()
         {2: 12 }end                                           |
         {1:~                                                 }|*4
         {24:-- INSERT --}                                      |
-      ]]
+      ]],
     })
     feed('conceal text')
     screen:expect({
@@ -2814,7 +3150,7 @@ describe('extmark decorations', function()
         {2: 12 }end                                           |
         {1:~                                                 }|*4
         {24:-- INSERT --}                                      |
-      ]]
+      ]],
     })
     feed('<esc>')
     screen:expect({
@@ -2830,7 +3166,7 @@ describe('extmark decorations', function()
         {2: 12 }end                                           |
         {1:~                                                 }|*5
                                                           |
-      ]]
+      ]],
     })
     feed('ggzfj')
     screen:expect({
@@ -2846,7 +3182,7 @@ describe('extmark decorations', function()
         {2: 12 }end                                           |
         {1:~                                                 }|*5
                                                           |
-      ]]
+      ]],
     })
     feed('j')
     screen:expect({
@@ -2862,7 +3198,7 @@ describe('extmark decorations', function()
         {2: 12 }end                                           |
         {1:~                                                 }|*5
                                                           |
-      ]]
+      ]],
     })
     feed('ggzdjzfj')
     screen:expect({
@@ -2877,7 +3213,7 @@ describe('extmark decorations', function()
         {2: 12 }end                                           |
         {1:~                                                 }|*6
                                                           |
-      ]]
+      ]],
     })
     feed('jj')
     screen:expect({
@@ -2892,14 +3228,14 @@ describe('extmark decorations', function()
         {2: 12 }end                                           |
         {1:~                                                 }|*6
                                                           |
-      ]]
+      ]],
     })
     -- Below virtual line belonging to line above concealed line is drawn.
     api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_lines = { { { 'line 1 below' } } } })
     -- Above virtual line belonging to concealed line isn't.
     api.nvim_buf_set_extmark(0, ns, 1, 0, {
       virt_lines = { { { 'line 2 above' } } },
-      virt_lines_above = true
+      virt_lines_above = true,
     })
     screen:expect([[
       {2:  1 }for _,item in ipairs(items) do                |
@@ -2917,8 +3253,8 @@ describe('extmark decorations', function()
     -- w_lines.wl_lastlnum values are valid
     command('set relativenumber concealcursor=')
     api.nvim_buf_clear_namespace(0, ns, 0, -1)
-    api.nvim_buf_set_extmark(0, ns, 1, 0, { conceal_lines = "" })
-    api.nvim_buf_set_extmark(0, ns, 4, 0, { conceal_lines = "" })
+    api.nvim_buf_set_extmark(0, ns, 1, 0, { conceal_lines = '' })
+    api.nvim_buf_set_extmark(0, ns, 4, 0, { conceal_lines = '' })
     feed('zE')
     screen:expect([[
       {2:  4 }for _,item in ipairs(items) do                |
@@ -2968,7 +3304,7 @@ describe('extmark decorations', function()
     ]])
     -- Also with above virtual line #32744
     command('set nornu')
-    api.nvim_buf_set_extmark(0, ns, 3, 0, { virt_lines = { { { "virt_below 4" } } } })
+    api.nvim_buf_set_extmark(0, ns, 3, 0, { virt_lines = { { { 'virt_below 4' } } } })
     feed('6G')
     screen:expect([[
       {2:  1 }for _,item in ipairs(items) do                |
@@ -3005,7 +3341,7 @@ describe('extmark decorations', function()
     feed('5G')
     api.nvim_buf_clear_namespace(0, ns, 3, 4)
     feed('j')
-    api.nvim_buf_set_extmark(0, ns, 3, 0, { virt_lines = { { { "virt_below 4" } } } })
+    api.nvim_buf_set_extmark(0, ns, 3, 0, { virt_lines = { { { 'virt_below 4' } } } })
     screen:expect([[
       {2:  1 }for _,item in ipairs(items) do                |
       {2:  3 }    if hl_id_cell ~= nil then                 |
@@ -3023,8 +3359,8 @@ describe('extmark decorations', function()
     ]])
     -- No scrolling for concealed topline #33033
     api.nvim_buf_clear_namespace(0, ns, 0, -1)
-    api.nvim_buf_set_extmark(0, ns, 1, 0, { virt_lines_above = true, virt_lines = { { { "virt_above 2" } } } })
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { conceal_lines = "" })
+    api.nvim_buf_set_extmark(0, ns, 1, 0, { virt_lines_above = true, virt_lines = { { { 'virt_above 2' } } } })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { conceal_lines = '' })
     feed('ggjj')
     screen:expect([[
       {2:    }virt_above 2                                  |
@@ -3046,15 +3382,15 @@ describe('extmark decorations', function()
     -- No asymmetric topline for <C-E><C-Y> #33182
     feed('4<C-E>')
     exec('set concealcursor=n')
-    api.nvim_buf_set_extmark(0, ns, 4, 0, { conceal_lines = "" })
+    api.nvim_buf_set_extmark(0, ns, 4, 0, { conceal_lines = '' })
     eq(5, n.fn.line('w0'))
     feed('<C-E><C-Y>')
     eq(5, n.fn.line('w0'))
   end)
 
   it('redraws the line from which a left gravity mark has moved #27369', function()
-    fn.setline(1, {'aaa', 'bbb', 'ccc', 'ddd' })
-    api.nvim_buf_set_extmark(0, ns, 1, 0, { virt_text = {{'foo'}}, right_gravity = false })
+    fn.setline(1, { 'aaa', 'bbb', 'ccc', 'ddd' })
+    api.nvim_buf_set_extmark(0, ns, 1, 0, { virt_text = { { 'foo' } }, right_gravity = false })
     feed('yyp')
     screen:expect([[
       aaa                                               |
@@ -3071,42 +3407,42 @@ end)
 describe('decorations: inline virtual text', function()
   local screen ---@type test.functional.ui.screen
   local ns ---@type integer
-  before_each( function()
+  before_each(function()
     clear()
     screen = Screen.new(50, 3)
     screen:set_default_attr_ids {
-      [1] = {bold=true, foreground=Screen.colors.Blue};
-      [2] = {foreground = Screen.colors.Brown};
-      [3] = {bold = true, foreground = Screen.colors.SeaGreen};
-      [4] = {background = Screen.colors.Red1, foreground = Screen.colors.Gray100};
-      [5] = {background = Screen.colors.Red1, bold = true};
-      [6] = {foreground = Screen.colors.DarkCyan};
-      [7] = {background = Screen.colors.LightGrey, foreground = Screen.colors.Black};
-      [8] = {bold = true};
-      [9] = {background = Screen.colors.Plum1};
-      [10] = {foreground = Screen.colors.SlateBlue};
-      [11] = {blend = 30, background = Screen.colors.Red1};
-      [12] = {background = Screen.colors.Yellow};
-      [13] = {reverse = true};
-      [14] = {foreground = Screen.colors.SlateBlue, background = Screen.colors.LightMagenta};
-      [15] = {bold = true, reverse = true};
-      [16] = {foreground = Screen.colors.Red};
-      [17] = {background = Screen.colors.LightGrey, foreground = Screen.colors.DarkBlue};
-      [18] = {background = Screen.colors.LightGrey, foreground = Screen.colors.Red};
-      [19] = {background = Screen.colors.Yellow, foreground = Screen.colors.SlateBlue};
-      [20] = {background = Screen.colors.LightGrey, foreground = Screen.colors.SlateBlue};
-      [21] = {reverse = true, foreground = Screen.colors.SlateBlue}
+      [1] = { bold = true, foreground = Screen.colors.Blue },
+      [2] = { foreground = Screen.colors.Brown },
+      [3] = { bold = true, foreground = Screen.colors.SeaGreen },
+      [4] = { background = Screen.colors.Red1, foreground = Screen.colors.Gray100 },
+      [5] = { background = Screen.colors.Red1, bold = true },
+      [6] = { foreground = Screen.colors.DarkCyan },
+      [7] = { background = Screen.colors.LightGrey, foreground = Screen.colors.Black },
+      [8] = { bold = true },
+      [9] = { background = Screen.colors.Plum1 },
+      [10] = { foreground = Screen.colors.SlateBlue },
+      [11] = { blend = 30, background = Screen.colors.Red1 },
+      [12] = { background = Screen.colors.Yellow },
+      [13] = { reverse = true },
+      [14] = { foreground = Screen.colors.SlateBlue, background = Screen.colors.LightMagenta },
+      [15] = { bold = true, reverse = true },
+      [16] = { foreground = Screen.colors.Red },
+      [17] = { background = Screen.colors.LightGrey, foreground = Screen.colors.DarkBlue },
+      [18] = { background = Screen.colors.LightGrey, foreground = Screen.colors.Red },
+      [19] = { background = Screen.colors.Yellow, foreground = Screen.colors.SlateBlue },
+      [20] = { background = Screen.colors.LightGrey, foreground = Screen.colors.SlateBlue },
+      [21] = { reverse = true, foreground = Screen.colors.SlateBlue },
     }
 
     ns = api.nvim_create_namespace 'test'
   end)
 
-
   it('works', function()
     screen:try_resize(50, 10)
     insert(example_text)
     feed 'gg'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^for _,item in ipairs(items) do                    |
           local text, hl_id_cell, count = unpack(item)  |
           if hl_id_cell ~= nil then                     |
@@ -3117,10 +3453,12 @@ describe('decorations: inline virtual text', function()
               cell.text = text                          |
               cell.hl_id = hl_id                        |
                                                         |
-    ]]}
+    ]],
+    }
 
-    api.nvim_buf_set_extmark(0, ns, 1, 14, {virt_text={{': ', 'Special'}, {'string', 'Type'}}, virt_text_pos='inline'})
-    screen:expect{grid=[[
+    api.nvim_buf_set_extmark(0, ns, 1, 14, { virt_text = { { ': ', 'Special' }, { 'string', 'Type' } }, virt_text_pos = 'inline' })
+    screen:expect {
+      grid = [[
       ^for _,item in ipairs(items) do                    |
           local text{10:: }{3:string}, hl_id_cell, count = unpack|
       (item)                                            |
@@ -3131,10 +3469,12 @@ describe('decorations: inline virtual text', function()
               local cell = line[colpos]                 |
               cell.text = text                          |
                                                         |
-    ]]}
+    ]],
+    }
 
     screen:try_resize(55, 10)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^for _,item in ipairs(items) do                         |
           local text{10:: }{3:string}, hl_id_cell, count = unpack(item|
       )                                                      |
@@ -3145,10 +3485,12 @@ describe('decorations: inline virtual text', function()
               local cell = line[colpos]                      |
               cell.text = text                               |
                                                              |
-    ]]}
+    ]],
+    }
 
     screen:try_resize(56, 10)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^for _,item in ipairs(items) do                          |
           local text{10:: }{3:string}, hl_id_cell, count = unpack(item)|
           if hl_id_cell ~= nil then                           |
@@ -3159,14 +3501,16 @@ describe('decorations: inline virtual text', function()
               cell.text = text                                |
               cell.hl_id = hl_id                              |
                                                               |
-    ]]}
+    ]],
+    }
   end)
 
   it('works with 0-width chunk', function()
     screen:try_resize(50, 10)
     insert(example_text)
     feed 'gg'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^for _,item in ipairs(items) do                    |
           local text, hl_id_cell, count = unpack(item)  |
           if hl_id_cell ~= nil then                     |
@@ -3177,12 +3521,14 @@ describe('decorations: inline virtual text', function()
               cell.text = text                          |
               cell.hl_id = hl_id                        |
                                                         |
-    ]]}
+    ]],
+    }
 
-    api.nvim_buf_set_extmark(0, ns, 0, 5, {virt_text={{''}, {''}}, virt_text_pos='inline'})
-    api.nvim_buf_set_extmark(0, ns, 1, 14, {virt_text={{''}, {': ', 'Special'}}, virt_text_pos='inline'})
-    api.nvim_buf_set_extmark(0, ns, 1, 48, {virt_text={{''}, {''}}, virt_text_pos='inline'})
-    screen:expect{grid=[[
+    api.nvim_buf_set_extmark(0, ns, 0, 5, { virt_text = { { '' }, { '' } }, virt_text_pos = 'inline' })
+    api.nvim_buf_set_extmark(0, ns, 1, 14, { virt_text = { { '' }, { ': ', 'Special' } }, virt_text_pos = 'inline' })
+    api.nvim_buf_set_extmark(0, ns, 1, 48, { virt_text = { { '' }, { '' } }, virt_text_pos = 'inline' })
+    screen:expect {
+      grid = [[
       ^for _,item in ipairs(items) do                    |
           local text{10:: }, hl_id_cell, count = unpack(item)|
           if hl_id_cell ~= nil then                     |
@@ -3193,11 +3539,13 @@ describe('decorations: inline virtual text', function()
               cell.text = text                          |
               cell.hl_id = hl_id                        |
                                                         |
-    ]]}
+    ]],
+    }
 
-    api.nvim_buf_set_extmark(0, ns, 1, 14, {virt_text={{''}, {'string', 'Type'}}, virt_text_pos='inline'})
+    api.nvim_buf_set_extmark(0, ns, 1, 14, { virt_text = { { '' }, { 'string', 'Type' } }, virt_text_pos = 'inline' })
     feed('V')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^f{7:or _,item in ipairs(items) do}                    |
           local text{10:: }{3:string}, hl_id_cell, count = unpack|
       (item)                                            |
@@ -3208,10 +3556,12 @@ describe('decorations: inline virtual text', function()
               local cell = line[colpos]                 |
               cell.text = text                          |
       {8:-- VISUAL LINE --}                                 |
-    ]]}
+    ]],
+    }
 
     feed('<Esc>jf,')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       for _,item in ipairs(items) do                    |
           local text{10:: }{3:string}^, hl_id_cell, count = unpack|
       (item)                                            |
@@ -3222,7 +3572,8 @@ describe('decorations: inline virtual text', function()
               local cell = line[colpos]                 |
               cell.text = text                          |
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('Normal mode "gM" command works properly', function()
@@ -3230,11 +3581,13 @@ describe('decorations: inline virtual text', function()
     api.nvim_buf_set_extmark(0, ns, 0, 2, { virt_text = { { 'bbb', 'Special' } }, virt_text_pos = 'inline' })
     api.nvim_buf_set_extmark(0, ns, 0, 7, { virt_text = { { 'bbb', 'Special' } }, virt_text_pos = 'inline' })
     feed('gM')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       12{10:bbb}34^567{10:bbb}89                                   |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   local function test_normal_gj_gk()
@@ -3242,68 +3595,82 @@ describe('decorations: inline virtual text', function()
     command([[call setline(1, repeat([repeat('a', 55)], 2))]])
     api.nvim_buf_set_extmark(0, ns, 0, 40, { virt_text = { { ('b'):rep(10), 'Special' } }, virt_text_pos = 'inline' })
     api.nvim_buf_set_extmark(0, ns, 1, 40, { virt_text = { { ('b'):rep(10), 'Special' } }, virt_text_pos = 'inline' })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
       aaaaa                                                       |
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
       aaaaa                                                       |
       {1:~                                                           }|
                                                                   |
-    ]]}
+    ]],
+    }
     feed('gj')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
       ^aaaaa                                                       |
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
       aaaaa                                                       |
       {1:~                                                           }|
                                                                   |
-    ]]}
+    ]],
+    }
     feed('gj')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
       aaaaa                                                       |
       ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
       aaaaa                                                       |
       {1:~                                                           }|
                                                                   |
-    ]]}
+    ]],
+    }
     feed('gj')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
       aaaaa                                                       |
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
       ^aaaaa                                                       |
       {1:~                                                           }|
                                                                   |
-    ]]}
+    ]],
+    }
     feed('gk')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
       aaaaa                                                       |
       ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
       aaaaa                                                       |
       {1:~                                                           }|
                                                                   |
-    ]]}
+    ]],
+    }
     feed('gk')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
       ^aaaaa                                                       |
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
       aaaaa                                                       |
       {1:~                                                           }|
                                                                   |
-    ]]}
+    ]],
+    }
     feed('gk')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
       aaaaa                                                       |
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbbbbbbbbb}aaaaaaaaaa|
       aaaaa                                                       |
       {1:~                                                           }|
                                                                   |
-    ]]}
+    ]],
+    }
   end
 
   describe('Normal mode "gj" "gk" commands work properly', function()
@@ -3323,11 +3690,13 @@ describe('decorations: inline virtual text', function()
     api.nvim_buf_set_extmark(0, ns, 0, 4, { virt_text = { { ' virtual text ', 'Special' } }, virt_text_pos = 'inline' })
     feed '^'
     feed '4l'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       1234{10: virtual text  virtual text }^5678              |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('adjusts cursor location correctly when inserting around inline virtual text', function()
@@ -3335,22 +3704,26 @@ describe('decorations: inline virtual text', function()
     feed '$'
     api.nvim_buf_set_extmark(0, ns, 0, 4, { virt_text = { { ' virtual text ', 'Special' } }, virt_text_pos = 'inline' })
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       1234{10: virtual text }567^8                            |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('has correct highlighting with multi-byte characters', function()
     insert('12345678')
     api.nvim_buf_set_extmark(0, ns, 0, 4, { virt_text = { { 'múlti-byté chñröcters 修补', 'Special' } }, virt_text_pos = 'inline' })
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       1234{10:múlti-byté chñröcters 修补}567^8                |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('has correct cursor position when inserting around virtual text', function()
@@ -3359,34 +3732,42 @@ describe('decorations: inline virtual text', function()
     feed '^'
     feed '3l'
     feed 'a'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       1234{10:^virtual text}5678                              |
       {1:~                                                 }|
       {8:-- INSERT --}                                      |
-    ]]}
+    ]],
+    }
     feed '<ESC>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       123^4{10:virtual text}5678                              |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed '^'
     feed '4l'
     feed 'i'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       1234{10:^virtual text}5678                              |
       {1:~                                                 }|
       {8:-- INSERT --}                                      |
-    ]]}
+    ]],
+    }
   end)
 
   it('has correct cursor position with virtual text on an empty line', function()
     api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline' })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:^virtual text}                                      |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('text is drawn correctly with a wrapping virtual text', function()
@@ -3398,7 +3779,8 @@ describe('decorations: inline virtual text', function()
     api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { string.rep('X', 60), 'Special' } }, virt_text_pos = 'inline' })
     api.nvim_buf_set_extmark(0, ns, 2, 0, { virt_text = { { string.rep('X', 61), 'Special' } }, virt_text_pos = 'inline' })
     feed('$')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:^XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
       aaa                                                         |
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
@@ -3406,9 +3788,11 @@ describe('decorations: inline virtual text', function()
       bbbbbb                                                      |
       {1:~                                                           }|*2
                                                                   |
-    ]]}
+    ]],
+    }
     feed('j')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
       aa^a                                                         |
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
@@ -3416,9 +3800,11 @@ describe('decorations: inline virtual text', function()
       bbbbbb                                                      |
       {1:~                                                           }|*2
                                                                   |
-    ]]}
+    ]],
+    }
     feed('j')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
       aaa                                                         |
       {10:^XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
@@ -3426,9 +3812,11 @@ describe('decorations: inline virtual text', function()
       bbbbbb                                                      |
       {1:~                                                           }|*2
                                                                   |
-    ]]}
+    ]],
+    }
     feed('j')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
       aaa                                                         |
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
@@ -3436,9 +3824,11 @@ describe('decorations: inline virtual text', function()
       bbbbb^b                                                      |
       {1:~                                                           }|*2
                                                                   |
-    ]]}
+    ]],
+    }
     feed('0<C-V>2l2k')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
       {7:aa}^a                                                         |
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
@@ -3446,9 +3836,11 @@ describe('decorations: inline virtual text', function()
       {7:bbb}bbb                                                      |
       {1:~                                                           }|*2
       {8:-- VISUAL BLOCK --}                                          |
-    ]]}
+    ]],
+    }
     feed([[<Esc>/aaa\n\%V<CR>]])
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
       {12:^aaa }                                                        |
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
@@ -3456,9 +3848,11 @@ describe('decorations: inline virtual text', function()
       bbbbbb                                                      |
       {1:~                                                           }|*2
       {16:search hit BOTTOM, continuing at TOP}                        |
-    ]]}
+    ]],
+    }
     feed('3ggic')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
       {12:aaa }                                                        |
       c{10:^XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
@@ -3466,9 +3860,11 @@ describe('decorations: inline virtual text', function()
       bbbbbb                                                      |
       {1:~                                                           }|*2
       {8:-- INSERT --}                                                |
-    ]]}
+    ]],
+    }
     feed([[<Esc>/aaa\nc\%V<CR>]])
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
       {12:^aaa }                                                        |
       {12:c}{10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
@@ -3476,7 +3872,8 @@ describe('decorations: inline virtual text', function()
       bbbbbb                                                      |
       {1:~                                                           }|*2
       {16:search hit BOTTOM, continuing at TOP}                        |
-    ]]}
+    ]],
+    }
   end)
 
   it('cursor position is correct with virtual text attached to hard TABs', function()
@@ -3488,39 +3885,49 @@ describe('decorations: inline virtual text', function()
     feed('<ESC>')
     api.nvim_buf_set_extmark(0, ns, 0, 1, { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline' })
     feed('0')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
              ^ {10:virtual text}    test                      |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
 
     feed('l')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
               {10:virtual text}   ^ test                      |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
 
     feed('l')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
               {10:virtual text}    ^test                      |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
 
     feed('l')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
               {10:virtual text}    t^est                      |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
 
     feed('l')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
               {10:virtual text}    te^st                      |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('cursor position is correct with virtual text on an empty line', function()
@@ -3528,11 +3935,13 @@ describe('decorations: inline virtual text', function()
     insert('one twoword')
     feed('0')
     api.nvim_buf_set_extmark(0, ns, 0, 3, { virt_text = { { ': virtual text', 'Special' } }, virt_text_pos = 'inline' })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^one{10:: virtual text} twoword                         |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('search highlight is correct', function()
@@ -3542,26 +3951,32 @@ describe('decorations: inline virtual text', function()
     api.nvim_buf_set_extmark(0, ns, 0, 9, { virt_text = { { 'BBB', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     api.nvim_buf_set_extmark(0, ns, 1, 9, { virt_text = { { 'CCC', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     api.nvim_buf_set_extmark(0, ns, 1, 9, { virt_text = { { 'DDD', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'replace' })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^foo foo f{10:AAABBB}oo bar                             |
       foo foo f{10:CCCDDD}oo bar                             |
                                                         |
-    ]]}
+    ]],
+    }
 
     feed('/foo')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {12:foo} {13:foo} {12:f}{10:AAA}{19:BBB}{12:oo} bar                             |
       {12:foo} {12:foo} {12:f}{19:CCC}{10:DDD}{12:oo} bar                             |
       /foo^                                              |
-    ]]}
+    ]],
+    }
 
     api.nvim_buf_set_extmark(0, ns, 0, 13, { virt_text = { { 'EEE', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     feed('<C-G>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {12:foo} {12:foo} {13:f}{10:AAA}{21:BBB}{13:oo} b{10:EEE}ar                          |
       {12:foo} {12:foo} {12:f}{19:CCC}{10:DDD}{12:oo} bar                             |
       /foo^                                              |
-    ]]}
+    ]],
+    }
   end)
 
   it('Visual select highlight is correct', function()
@@ -3572,26 +3987,32 @@ describe('decorations: inline virtual text', function()
     api.nvim_buf_set_extmark(0, ns, 1, 8, { virt_text = { { 'CCC', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     api.nvim_buf_set_extmark(0, ns, 1, 8, { virt_text = { { 'DDD', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'replace' })
     feed('8l')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       foo foo {10:AAABBB}^foo bar                             |
       foo foo {10:CCCDDD}foo bar                             |
                                                         |
-    ]]}
+    ]],
+    }
 
     feed('<C-V>')
     feed('2hj')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       foo fo{7:o }{10:AAA}{20:BBB}{7:f}oo bar                             |
       foo fo^o{7: }{20:CCC}{10:DDD}{7:f}oo bar                             |
       {8:-- VISUAL BLOCK --}                                |
-    ]]}
+    ]],
+    }
 
     api.nvim_buf_set_extmark(0, ns, 0, 10, { virt_text = { { 'EEE', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       foo fo{7:o }{10:AAA}{20:BBB}{7:f}o{10:EEE}o bar                          |
       foo fo^o{7: }{20:CCC}{10:DDD}{7:f}oo bar                             |
       {8:-- VISUAL BLOCK --}                                |
-    ]]}
+    ]],
+    }
   end)
 
   it('inside highlight range of another extmark', function()
@@ -3602,11 +4023,13 @@ describe('decorations: inline virtual text', function()
     api.nvim_buf_set_extmark(0, ns, 1, 8, { virt_text = { { 'DDD', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'replace' })
     api.nvim_buf_set_extmark(0, ns, 0, 4, { end_col = 11, hl_group = 'Search' })
     api.nvim_buf_set_extmark(0, ns, 1, 4, { end_col = 11, hl_group = 'Search' })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       foo {12:foo }{10:AAA}{19:BBB}{12:foo} bar                             |
       foo {12:foo }{19:CCC}{10:DDD}{12:foo} ba^r                             |
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('inside highlight range of syntax', function()
@@ -3616,11 +4039,13 @@ describe('decorations: inline virtual text', function()
     api.nvim_buf_set_extmark(0, ns, 1, 8, { virt_text = { { 'CCC', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     api.nvim_buf_set_extmark(0, ns, 1, 8, { virt_text = { { 'DDD', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'replace' })
     command([[syntax match Search 'foo \zsfoo foo\ze bar']])
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       foo {12:foo }{10:AAA}{19:BBB}{12:foo} bar                             |
       foo {12:foo }{19:CCC}{10:DDD}{12:foo} ba^r                             |
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('cursor position is correct when inserting around a virtual text with left gravity', function()
@@ -3629,185 +4054,231 @@ describe('decorations: inline virtual text', function()
     api.nvim_buf_set_extmark(0, ns, 0, 8, { virt_text = { { ('>'):rep(43), 'Special' } }, virt_text_pos = 'inline', right_gravity = false })
     command('setlocal showbreak=+ breakindent breakindentopt=shift:2')
     feed('08l')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaa{10:>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}^aaaaaaa                 |
                                  |
-    ]]}
+    ]],
+    }
     feed('i')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaa{10:>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}^aaaaaaa                 |
       {8:-- INSERT --}               |
-    ]]}
+    ]],
+    }
     feed([[<C-\><C-O>]])
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaa{10:>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}^aaaaaaa                 |
       {8:-- (insert) --}             |
-    ]]}
+    ]],
+    }
     feed('D')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaa{10:>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>>>>>>>>>>>>>>>>>>>>>>>}|
       {1:^~                          }|
       {8:-- INSERT --}               |
-    ]]}
+    ]],
+    }
     command('setlocal list listchars=eol:$')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaa{10:>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+^$}                       |
       {8:-- INSERT --}               |
-    ]]}
+    ]],
+    }
     feed('<C-U>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:>>>>>>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>>>>>>>>>>>>>>>}{1:^$}       |
       {1:~                          }|
       {8:-- INSERT --}               |
-    ]]}
+    ]],
+    }
     feed('a')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:>>>>>>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>>>>>>>>>>>>>>>}a{1:^$}      |
       {1:~                          }|
       {8:-- INSERT --}               |
-    ]]}
+    ]],
+    }
     feed('<Esc>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:>>>>>>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>>>>>>>>>>>>>>>}^a{1:$}      |
       {1:~                          }|
                                  |
-    ]]}
+    ]],
+    }
     feed('x')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:^>>>>>>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>>>>>>>>>>>>>>>}{1:$}       |
       {1:~                          }|
                                  |
-    ]]}
+    ]],
+    }
   end)
 
   it('cursor position is correct when inserting around virtual texts with both left and right gravity', function()
     screen:try_resize(30, 4)
     command('setlocal showbreak=+ breakindent breakindentopt=shift:2')
     insert(('a'):rep(15))
-    api.nvim_buf_set_extmark(0, ns, 0, 8, { virt_text = {{ ('>'):rep(32), 'Special' }}, virt_text_pos = 'inline', right_gravity = false })
-    api.nvim_buf_set_extmark(0, ns, 0, 8, { virt_text = {{ ('<'):rep(32), 'Special' }}, virt_text_pos = 'inline', right_gravity = true })
+    api.nvim_buf_set_extmark(0, ns, 0, 8, { virt_text = { { ('>'):rep(32), 'Special' } }, virt_text_pos = 'inline', right_gravity = false })
+    api.nvim_buf_set_extmark(0, ns, 0, 8, { virt_text = { { ('<'):rep(32), 'Special' } }, virt_text_pos = 'inline', right_gravity = true })
     feed('08l')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaa{10:>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>>>>>>>>><<<<<<<<<<<<<<<<<}|
         {1:+}{10:<<<<<<<<<<<<<<<}^aaaaaaa     |
                                     |
-    ]]}
+    ]],
+    }
     feed('i')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaa{10:>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>>>>>>>>>^<<<<<<<<<<<<<<<<<}|
         {1:+}{10:<<<<<<<<<<<<<<<}aaaaaaa     |
       {8:-- INSERT --}                  |
-    ]]}
+    ]],
+    }
     feed('a')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaa{10:>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>>>>>>>>>}a{10:^<<<<<<<<<<<<<<<<}|
         {1:+}{10:<<<<<<<<<<<<<<<<}aaaaaaa    |
       {8:-- INSERT --}                  |
-    ]]}
+    ]],
+    }
     feed([[<C-\><C-O>]])
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaa{10:>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>>>>>>>>>}a{10:<<<<<<<<<<<<<<<<}|
         {1:+}{10:<<<<<<<<<<<<<<<<}^aaaaaaa    |
       {8:-- (insert) --}                |
-    ]]}
+    ]],
+    }
     feed('D')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaa{10:>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>>>>>>>>>}a{10:^<<<<<<<<<<<<<<<<}|
         {1:+}{10:<<<<<<<<<<<<<<<<}           |
       {8:-- INSERT --}                  |
-    ]]}
+    ]],
+    }
     feed('<BS>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaa{10:>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>>>>>>>>>^<<<<<<<<<<<<<<<<<}|
         {1:+}{10:<<<<<<<<<<<<<<<}            |
       {8:-- INSERT --}                  |
-    ]]}
+    ]],
+    }
     feed('<C-U>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>^<<<<<<<<<<<<<<<<<<<<<<<<<}|
         {1:+}{10:<<<<<<<}                    |
       {8:-- INSERT --}                  |
-    ]]}
+    ]],
+    }
     feed('a')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>}a{10:^<<<<<<<<<<<<<<<<<<<<<<<<}|
         {1:+}{10:<<<<<<<<}                   |
       {8:-- INSERT --}                  |
-    ]]}
+    ]],
+    }
     feed('<Esc>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>}^a{10:<<<<<<<<<<<<<<<<<<<<<<<<}|
         {1:+}{10:<<<<<<<<}                   |
                                     |
-    ]]}
+    ]],
+    }
     feed('x')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:^>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>><<<<<<<<<<<<<<<<<<<<<<<<<}|
         {1:+}{10:<<<<<<<}                    |
                                     |
-    ]]}
+    ]],
+    }
     feed('i')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:>>^<<<<<<<<<<<<<<<<<<<<<<<<<}|
         {1:+}{10:<<<<<<<}                    |
       {8:-- INSERT --}                  |
-    ]]}
+    ]],
+    }
     screen:try_resize(32, 4)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>}|
         {1:+}{10:^<<<<<<<<<<<<<<<<<<<<<<<<<<<<<}|
         {1:+}{10:<<<}                          |
       {8:-- INSERT --}                    |
-    ]]}
+    ]],
+    }
     command('setlocal nobreakindent')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>}|
       {1:+}{10:^<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<}|
       {1:+}{10:<}                              |
       {8:-- INSERT --}                    |
-    ]]}
+    ]],
+    }
   end)
 
   it('draws correctly with no wrap multiple virtual text, where one is hidden', function()
     insert('abcdefghijklmnopqrstuvwxyzabcdefghijklmnopqrstuvwxyz')
-    command("set nowrap")
+    command('set nowrap')
     api.nvim_buf_set_extmark(0, ns, 0, 50, { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline' })
     api.nvim_buf_set_extmark(0, ns, 0, 2, { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline' })
     feed('$')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       opqrstuvwxyzabcdefghijklmnopqrstuvwx{10:virtual text}y^z|
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('draws correctly with no wrap and a long virtual text', function()
     insert('abcdefghi')
-    command("set nowrap")
+    command('set nowrap')
     api.nvim_buf_set_extmark(0, ns, 0, 2, { virt_text = { { string.rep('X', 55), 'Special' } }, virt_text_pos = 'inline' })
     feed('$')
     screen:expect([[
@@ -3945,23 +4416,27 @@ describe('decorations: inline virtual text', function()
     feed('itest<TAB>a<ESC>')
     api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { string.rep('a', 55), 'Special' } }, virt_text_pos = 'inline' })
     feed('gg$')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:aaaaaaaaaaaaaaaaaaaaaaaaa}test     ^a               |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('highlighting does not extend with no wrap and a long virtual text', function()
     insert('abcdef')
-    command("set nowrap")
+    command('set nowrap')
     api.nvim_buf_set_extmark(0, ns, 0, 3, { virt_text = { { string.rep('X', 50), 'Special' } }, virt_text_pos = 'inline' })
     feed('$')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}de^f|
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('hidden virtual text does not interfere with Visual highlight', function()
@@ -3969,23 +4444,29 @@ describe('decorations: inline virtual text', function()
     command('set nowrap')
     api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'XXX', 'Special' } }, virt_text_pos = 'inline' })
     feed('V2zl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:X}{7:abcde}^f                                           |
       {1:~                                                 }|
       {8:-- VISUAL LINE --}                                 |
-    ]]}
+    ]],
+    }
     feed('zl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {7:abcde}^f                                            |
       {1:~                                                 }|
       {8:-- VISUAL LINE --}                                 |
-    ]]}
+    ]],
+    }
     feed('zl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {7:bcde}^f                                             |
       {1:~                                                 }|
       {8:-- VISUAL LINE --}                                 |
-    ]]}
+    ]],
+    }
   end)
 
   it('highlighting is correct when virtual text wraps with number', function()
@@ -3996,13 +4477,15 @@ describe('decorations: inline virtual text', function()
     command('set number')
     api.nvim_buf_set_extmark(0, ns, 0, 1, { virt_text = { { string.rep('X', 55), 'Special' } }, virt_text_pos = 'inline' })
     feed('gg0')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {2:  1 }^t{10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
       {2:    }{10:XXXXXXXXXX}est                                 |
       {2:  2 }test                                          |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('highlighting is correct when virtual text is proceeded with a match', function()
@@ -4010,34 +4493,42 @@ describe('decorations: inline virtual text', function()
     api.nvim_buf_set_extmark(0, ns, 0, 2, { virt_text = { { 'virtual text', 'Special' } }, virt_text_pos = 'inline' })
     feed('gg0')
     command('match ErrorMsg /e/')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^t{4:e}{10:virtual text}st                                  |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     command('match ErrorMsg /s/')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^te{10:virtual text}{4:s}t                                  |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('smoothscroll works correctly when virtual text wraps', function()
     insert('foobar')
     api.nvim_buf_set_extmark(0, ns, 0, 3, { virt_text = { { string.rep('X', 55), 'Special' } }, virt_text_pos = 'inline' })
     command('setlocal smoothscroll')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       foo{10:XXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX}|
       {10:XXXXXXXX}ba^r                                       |
                                                         |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {1:<<<}{10:XXXXX}ba^r                                       |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('in diff mode is highlighted correct', function()
@@ -4050,11 +4541,11 @@ describe('decorations: inline virtual text', function()
     0009
     ]])
     insert('aaa\tbbb')
-    command("set diff")
+    command('set diff')
     api.nvim_buf_set_extmark(0, ns, 0, 1, { virt_text = { { 'test', 'Special' } }, virt_text_pos = 'inline', right_gravity = false })
     api.nvim_buf_set_extmark(0, ns, 5, 0, { virt_text = { { '!', 'Special' } }, virt_text_pos = 'inline' })
     api.nvim_buf_set_extmark(0, ns, 5, 3, { virt_text = { { '' } }, virt_text_pos = 'inline' })
-    command("vnew")
+    command('vnew')
     insert([[
     000
     000
@@ -4063,9 +4554,10 @@ describe('decorations: inline virtual text', function()
     000
     ]])
     insert('aaabbb')
-    command("set diff")
+    command('set diff')
     feed('gg0')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {9:^000                      }│{5:9}{14:test}{9:000                }|
       {9:000                      }│{9:000}{5:9}{9:                    }|*2
       {9:000                      }│{5:9}{9:000                    }|
@@ -4074,10 +4566,12 @@ describe('decorations: inline virtual text', function()
       {1:~                        }│{1:~                       }|*2
       {15:[No Name] [+]             }{13:[No Name] [+]           }|
                                                         |
-    ]]}
+    ]],
+    }
     command('wincmd w | set nowrap')
     feed('zl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {9:000                      }│{14:test}{9:000                 }|
       {9:000                      }│{9:00}{5:9}{9:                     }|*2
       {9:000                      }│{9:000                     }|
@@ -4086,7 +4580,8 @@ describe('decorations: inline virtual text', function()
       {1:~                        }│{1:~                       }|*2
       {13:[No Name] [+]             }{15:[No Name] [+]           }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('correctly draws when there are multiple overlapping virtual texts on the same line with nowrap', function()
@@ -4095,23 +4590,27 @@ describe('decorations: inline virtual text', function()
     api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { string.rep('a', 55), 'Special' } }, virt_text_pos = 'inline' })
     api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { string.rep('b', 55), 'Special' } }, virt_text_pos = 'inline' })
     feed('$')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {10:bbbbbbbbbbbbbbbbbbbbbbbbb}^a                        |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('correctly draws when overflowing virtual text is followed by TAB with no wrap', function()
     command('set nowrap')
     feed('i<TAB>test<ESC>')
-    api.nvim_buf_set_extmark( 0, ns, 0, 0, { virt_text = { { string.rep('a', 60), 'Special' } }, virt_text_pos = 'inline' })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { string.rep('a', 60), 'Special' } }, virt_text_pos = 'inline' })
     feed('0')
-    screen:expect({grid=[[
+    screen:expect({
+      grid = [[
       {10:aaaaaaaaaaaaaaaaaaaaaa}   ^ test                    |
       {1:~                                                 }|
                                                         |
-    ]]})
+    ]],
+    })
   end)
 
   it('does not crash at column 0 when folded in a wide window', function()
@@ -4123,76 +4622,94 @@ describe('decorations: inline virtual text', function()
       bbbbb
 
       ccccc]])
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = {{'foo'}}, virt_text_pos = 'inline' })
-    api.nvim_buf_set_extmark(0, ns, 2, 0, { virt_text = {{'bar'}}, virt_text_pos = 'inline' })
-    screen:expect{grid=[[
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'foo' } }, virt_text_pos = 'inline' })
+    api.nvim_buf_set_extmark(0, ns, 2, 0, { virt_text = { { 'bar' } }, virt_text_pos = 'inline' })
+    screen:expect {
+      grid = [[
       fooaaaaa                                                                          |
       bbbbb                                                                             |
       bar                                                                               |
       {16:cccc^c                                                                             }|
                                                                                         |
-    ]]}
+    ]],
+    }
     command('1,2fold')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {17:+--  2 lines: aaaaa·······························································}|
       bar                                                                               |
       {16:cccc^c                                                                             }|
       {1:~                                                                                 }|
                                                                                         |
-    ]]}
+    ]],
+    }
     feed('2k')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {18:^+--  2 lines: aaaaa·······························································}|
       bar                                                                               |
       ccccc                                                                             |
       {1:~                                                                                 }|
                                                                                         |
-    ]]}
+    ]],
+    }
     command('3,4fold')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {18:^+--  2 lines: aaaaa·······························································}|
       {17:+--  2 lines: ccccc·······························································}|
       {1:~                                                                                 }|*2
                                                                                         |
-    ]]}
+    ]],
+    }
     feed('j')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {17:+--  2 lines: aaaaa·······························································}|
       {18:^+--  2 lines: ccccc·······························································}|
       {1:~                                                                                 }|*2
                                                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('does not crash at right edge of wide window #23848', function()
     screen:try_resize(82, 5)
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {virt_text = {{('a'):rep(82)}, {'b'}}, virt_text_pos = 'inline'})
-    screen:expect{grid=[[
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { ('a'):rep(82) }, { 'b' } }, virt_text_pos = 'inline' })
+    screen:expect {
+      grid = [[
       ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       b                                                                                 |
       {1:~                                                                                 }|*2
                                                                                         |
-    ]]}
+    ]],
+    }
     command('set nowrap')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       {1:~                                                                                 }|*3
                                                                                         |
-    ]]}
+    ]],
+    }
     feed('82i0<Esc>0')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^0000000000000000000000000000000000000000000000000000000000000000000000000000000000|
       {1:~                                                                                 }|*3
                                                                                         |
-    ]]}
+    ]],
+    }
     command('set wrap')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^0000000000000000000000000000000000000000000000000000000000000000000000000000000000|
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       b                                                                                 |
       {1:~                                                                                 }|
                                                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('lcs-extends is drawn with inline virtual text at end of screen line', function()
@@ -4202,35 +4719,45 @@ describe('decorations: inline virtual text', function()
     ]])
     api.nvim_buf_set_extmark(0, ns, 0, 50, { virt_text = { { 'bbb', 'Special' } }, virt_text_pos = 'inline' })
     feed('20l')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaaaaaaaaaaaaaa^aaaaaaaaaaaaaaaaaaaaaaaaaaaaa{1:!}|
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('zl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaaaaaaaaaaaaa^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{1:!}|
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('zl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaaaaaaaaaaaa^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:b}{1:!}|
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('zl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaaaaaaaaaaa^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bb}{1:!}|
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
     feed('zl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaaaaaaaaaa^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{10:bbb}a|
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('lcs-extends is drawn with only inline virtual text offscreen', function()
@@ -4240,11 +4767,13 @@ describe('decorations: inline virtual text', function()
     api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text = { { 'test', 'Special' } }, virt_text_pos = 'inline' })
     insert(string.rep('a', 50))
     feed('gg0')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa{1:c}|
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('blockwise Visual highlight with double-width virtual text (replace)', function()
@@ -4253,68 +4782,82 @@ describe('decorations: inline virtual text', function()
     api.nvim_buf_set_extmark(0, ns, 1, 1, { virt_text = { { '-口-', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'replace' })
     api.nvim_buf_set_extmark(0, ns, 2, 2, { virt_text = { { '口', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'replace' })
     feed('gg0')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^123456789                                                   |
       1{10:-口-}23456789                                               |
       12{10:口}3456789                                                 |
       123456789                                                   |
       {1:~                                                           }|
                                                                   |
-    ]]}
+    ]],
+    }
     feed('<C-V>3jl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {7:12}3456789                                                   |
       {7:1}{10:-口-}23456789                                               |
       {7:12}{10:口}3456789                                                 |
       {7:1}^23456789                                                   |
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
-    ]]}
+    ]],
+    }
     feed('l')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {7:123}456789                                                   |
       {7:1}{10:-口-}23456789                                               |
       {7:12}{10:口}3456789                                                 |
       {7:12}^3456789                                                   |
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
-    ]]}
+    ]],
+    }
     feed('4l')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {7:1234567}89                                                   |
       {7:1}{10:-口-}{7:23}456789                                               |
       {7:12}{10:口}{7:345}6789                                                 |
       {7:123456}^789                                                   |
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
-    ]]}
+    ]],
+    }
     feed('Ol')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       1{7:234567}89                                                   |
       1{10:-口-}{7:23}456789                                               |
       1{7:2}{10:口}{7:345}6789                                                 |
       1^2{7:34567}89                                                   |
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
-    ]]}
+    ]],
+    }
     feed('l')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       12{7:34567}89                                                   |
       1{10:-口-}{7:23}456789                                               |
       12{10:口}{7:345}6789                                                 |
       12^3{7:4567}89                                                   |
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
-    ]]}
+    ]],
+    }
     feed('l')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       123{7:4567}89                                                   |
       1{10:-口-}{7:23}456789                                               |
       12{10:口}{7:345}6789                                                 |
       123^4{7:567}89                                                   |
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
-    ]]}
+    ]],
+    }
   end)
 
   it('blockwise Visual highlight with double-width virtual text (combine)', function()
@@ -4323,68 +4866,82 @@ describe('decorations: inline virtual text', function()
     api.nvim_buf_set_extmark(0, ns, 1, 1, { virt_text = { { '-口-', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     api.nvim_buf_set_extmark(0, ns, 2, 2, { virt_text = { { '口', 'Special' } }, virt_text_pos = 'inline', hl_mode = 'combine' })
     feed('gg0')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^123456789                                                   |
       1{10:-口-}23456789                                               |
       12{10:口}3456789                                                 |
       123456789                                                   |
       {1:~                                                           }|
                                                                   |
-    ]]}
+    ]],
+    }
     feed('<C-V>3jl')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {7:12}3456789                                                   |
       {7:1}{20:-}{10:口-}23456789                                               |
       {7:12}{10:口}3456789                                                 |
       {7:1}^23456789                                                   |
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
-    ]]}
+    ]],
+    }
     feed('l')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {7:123}456789                                                   |
       {7:1}{20:-口}{10:-}23456789                                               |
       {7:12}{20:口}3456789                                                 |
       {7:12}^3456789                                                   |
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
-    ]]}
+    ]],
+    }
     feed('4l')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {7:1234567}89                                                   |
       {7:1}{20:-口-}{7:23}456789                                               |
       {7:12}{20:口}{7:345}6789                                                 |
       {7:123456}^789                                                   |
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
-    ]]}
+    ]],
+    }
     feed('Ol')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       1{7:234567}89                                                   |
       1{20:-口-}{7:23}456789                                               |
       1{7:2}{20:口}{7:345}6789                                                 |
       1^2{7:34567}89                                                   |
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
-    ]]}
+    ]],
+    }
     feed('l')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       12{7:34567}89                                                   |
       1{10:-}{20:口-}{7:23}456789                                               |
       12{20:口}{7:345}6789                                                 |
       12^3{7:4567}89                                                   |
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
-    ]]}
+    ]],
+    }
     feed('l')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       123{7:4567}89                                                   |
       1{10:-}{20:口-}{7:23}456789                                               |
       12{20:口}{7:345}6789                                                 |
       123^4{7:567}89                                                   |
       {1:~                                                           }|
       {8:-- VISUAL BLOCK --}                                          |
-    ]]}
+    ]],
+    }
   end)
 
   local function test_virt_inline_showbreak_smoothscroll()
@@ -4397,197 +4954,245 @@ describe('decorations: inline virtual text', function()
       normal! $
     ]])
     api.nvim_buf_set_extmark(0, ns, 0, 27, { virt_text = { { ('123'):rep(23) } }, virt_text_pos = 'inline' })
-    feed(':<CR>')  -- Have a screen line that doesn't start with spaces
-    screen:expect{grid=[[
+    feed(':<CR>') -- Have a screen line that doesn't start with spaces
+    screen:expect {
+      grid = [[
         1 aaaaaaaaaaaaaaaaaaaaaaaaaa|
             {1:+}a1231231231231231231231|
             {1:+}23123123123123123123123|
             {1:+}12312312312312312312312|
             {1:+}3^a                     |
       :                             |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
             {1:+}a1231231231231231231231|
             {1:+}23123123123123123123123|
             {1:+}12312312312312312312312|
             {1:+}3^a                     |
       {1:~                             }|
       :                             |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
             {1:+}23123123123123123123123|
             {1:+}12312312312312312312312|
             {1:+}3^a                     |
       {1:~                             }|*2
       :                             |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
             {1:+}12312312312312312312312|
             {1:+}3^a                     |
       {1:~                             }|*3
       :                             |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
             {1:+}3^a                     |
       {1:~                             }|*4
       :                             |
-    ]]}
+    ]],
+    }
     feed('zbi')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
         1 aaaaaaaaaaaaaaaaaaaaaaaaaa|
             {1:+}a^1231231231231231231231|
             {1:+}23123123123123123123123|
             {1:+}12312312312312312312312|
             {1:+}3a                     |
       {8:-- INSERT --}                  |
-    ]]}
+    ]],
+    }
     feed('<BS>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
         1 aaaaaaaaaaaaaaaaaaaaaaaaaa|
             {1:+}^12312312312312312312312|
             {1:+}31231231231231231231231|
             {1:+}23123123123123123123123|
             {1:+}a                      |
       {8:-- INSERT --}                  |
-    ]]}
+    ]],
+    }
     feed('<Esc>l')
-    feed(':<CR>')  -- Have a screen line that doesn't start with spaces
-    screen:expect{grid=[[
+    feed(':<CR>') -- Have a screen line that doesn't start with spaces
+    screen:expect {
+      grid = [[
         1 aaaaaaaaaaaaaaaaaaaaaaaaaa|
             {1:+}12312312312312312312312|
             {1:+}31231231231231231231231|
             {1:+}23123123123123123123123|
             {1:+}^a                      |
       :                             |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
             {1:+}12312312312312312312312|
             {1:+}31231231231231231231231|
             {1:+}23123123123123123123123|
             {1:+}^a                      |
       {1:~                             }|
       :                             |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
             {1:+}31231231231231231231231|
             {1:+}23123123123123123123123|
             {1:+}^a                      |
       {1:~                             }|*2
       :                             |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
             {1:+}23123123123123123123123|
             {1:+}^a                      |
       {1:~                             }|*3
       :                             |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
             {1:+}^a                      |
       {1:~                             }|*4
       :                             |
-    ]]}
+    ]],
+    }
     feed('023x$')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
         1 aaa12312312312312312312312|
             {1:+}31231231231231231231231|
             {1:+}23123123123123123123123|
             {1:+}^a                      |
       {1:~                             }|
       :                             |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
             {1:+}31231231231231231231231|
             {1:+}23123123123123123123123|
             {1:+}^a                      |
       {1:~                             }|*2
       :                             |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
             {1:+}23123123123123123123123|
             {1:+}^a                      |
       {1:~                             }|*3
       :                             |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
             {1:+}^a                      |
       {1:~                             }|*4
       :                             |
-    ]]}
+    ]],
+    }
     feed('zbi')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
         1 aaa^12312312312312312312312|
             {1:+}31231231231231231231231|
             {1:+}23123123123123123123123|
             {1:+}a                      |
       {1:~                             }|
       {8:-- INSERT --}                  |
-    ]]}
+    ]],
+    }
     feed('<C-U>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
         1 ^12312312312312312312312312|
             {1:+}31231231231231231231231|
             {1:+}23123123123123123123a  |
       {1:~                             }|*2
       {8:-- INSERT --}                  |
-    ]]}
+    ]],
+    }
     feed('<Esc>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
         1 12312312312312312312312312|
             {1:+}31231231231231231231231|
             {1:+}23123123123123123123^a  |
       {1:~                             }|*2
                                     |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
             {1:+}31231231231231231231231|
             {1:+}23123123123123123123^a  |
       {1:~                             }|*3
                                     |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
             {1:+}23123123123123123123^a  |
       {1:~                             }|*4
                                     |
-    ]]}
+    ]],
+    }
     feed('zbx')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
         1 ^12312312312312312312312312|
             {1:+}31231231231231231231231|
             {1:+}23123123123123123123   |
       {1:~                             }|*2
                                     |
-    ]]}
+    ]],
+    }
     feed('26ia<Esc>a')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
         1 aaaaaaaaaaaaaaaaaaaaaaaaaa|
             {1:+}^12312312312312312312312|
             {1:+}31231231231231231231231|
             {1:+}23123123123123123123123|
       {1:~                             }|
       {8:-- INSERT --}                  |
-    ]]}
+    ]],
+    }
     feed([[<C-\><C-O>:setlocal breakindentopt=<CR>]])
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
         1 aaaaaaaaaaaaaaaaaaaaaaaaaa|
           {1:+}^1231231231231231231231231|
           {1:+}2312312312312312312312312|
           {1:+}3123123123123123123      |
       {1:~                             }|
       {8:-- INSERT --}                  |
-    ]]}
+    ]],
+    }
   end
 
   describe('with showbreak, smoothscroll', function()
@@ -4610,92 +5215,114 @@ describe('decorations: inline virtual text', function()
       normal! $
     ]])
     api.nvim_buf_set_extmark(0, ns, 0, 3, { virt_text = { { ('12'):rep(32) } }, virt_text_pos = 'inline' })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {1:<------><------><------>}121212|
       121212121212121212121212121212|
       1212121212121212121212121212{1:<-}|
       {1:----->}^a                       |
       {1:~                             }|
                                     |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {1:<<<}212121212121212121212121212|
       1212121212121212121212121212{1:<-}|
       {1:----->}^a                       |
       {1:~                             }|*2
                                     |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {1:<<<}2121212121212121212121212{1:<-}|
       {1:----->}^a                       |
       {1:~                             }|*3
                                     |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {1:<<<-->}^a                       |
       {1:~                             }|*4
                                     |
-    ]]}
+    ]],
+    }
     feed('zbh')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {1:<------><------><------>}121212|
       121212121212121212121212121212|
       1212121212121212121212121212{1:^<-}|
       {1:----->}a                       |
       {1:~                             }|
                                     |
-    ]]}
+    ]],
+    }
     feed('i')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {1:<------><------><------>}^121212|
       121212121212121212121212121212|
       1212121212121212121212121212{1:<-}|
       {1:----->}a                       |
       {1:~                             }|
       {8:-- INSERT --}                  |
-    ]]}
+    ]],
+    }
     feed('<C-O>:setlocal nolist<CR>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
                               ^121212|
       121212121212121212121212121212|
       1212121212121212121212121212  |
             a                       |
       {1:~                             }|
       {8:-- INSERT --}                  |
-    ]]}
+    ]],
+    }
     feed('<Esc>l')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
                               121212|
       121212121212121212121212121212|
       1212121212121212121212121212  |
            ^ a                       |
       {1:~                             }|
                                     |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {1:<<<}212121212121212121212121212|
       1212121212121212121212121212  |
            ^ a                       |
       {1:~                             }|*2
                                     |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {1:<<<}2121212121212121212121212  |
            ^ a                       |
       {1:~                             }|*3
                                     |
-    ]]}
+    ]],
+    }
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {1:<<<}  ^ a                       |
       {1:~                             }|*4
                                     |
-    ]]}
+    ]],
+    }
   end)
 
   it('before a space with linebreak', function()
@@ -4706,21 +5333,25 @@ describe('decorations: inline virtual text', function()
       normal! $
     ]])
     api.nvim_buf_set_extmark(0, ns, 0, 50, { virt_text = { { ('b'):rep(10) } }, virt_text_pos = 'inline' })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
         {1:+}bbbbbbbbbb                                     |
         {1:+}cccccccccccccccccccccccccccccccccccccccccccc^c  |
       {1:~                                                 }|*2
                                                         |
-    ]]}
+    ]],
+    }
     feed('05x$')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaabbbbb|
         {1:+}bbbbb                                          |
         {1:+}cccccccccccccccccccccccccccccccccccccccccccc^c  |
       {1:~                                                 }|*2
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('before double-width char that wraps', function()
@@ -4751,8 +5382,8 @@ describe('decorations: inline virtual text', function()
   it('cursor position is correct if end_row or end_col is specified', function()
     screen:try_resize(50, 8)
     api.nvim_buf_set_lines(0, 0, -1, false, { ('a'):rep(48), ('b'):rep(48), ('c'):rep(48), ('d'):rep(48) })
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {end_row = 2, virt_text_pos = 'inline', virt_text = {{'I1', 'NonText'}}})
-    api.nvim_buf_set_extmark(0, ns, 3, 0, {end_col = 2, virt_text_pos = 'inline', virt_text = {{'I2', 'NonText'}}})
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_row = 2, virt_text_pos = 'inline', virt_text = { { 'I1', 'NonText' } } })
+    api.nvim_buf_set_extmark(0, ns, 3, 0, { end_col = 2, virt_text_pos = 'inline', virt_text = { { 'I2', 'NonText' } } })
     feed('$')
     screen:expect([[
       {1:I1}aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa^a|
@@ -4855,7 +5486,7 @@ describe('decorations: inline virtual text', function()
   it('cursor position is correct with invalidated inline virt text', function()
     screen:try_resize(50, 8)
     api.nvim_buf_set_lines(0, 0, -1, false, { ('a'):rep(48), ('b'):rep(48) })
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text_pos = 'inline', virt_text = {{'INLINE', 'NonText'}}, invalidate = true })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_text_pos = 'inline', virt_text = { { 'INLINE', 'NonText' } }, invalidate = true })
     screen:expect([[
       {1:INLINE}^aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|
       aaaa                                              |
@@ -4880,7 +5511,7 @@ describe('decorations: virtual lines', function()
     clear()
     screen = Screen.new(50, 12)
     screen:add_extra_attr_ids {
-        [100] = { foreground = Screen.colors.Blue, background = Screen.colors.Yellow },
+      [100] = { foreground = Screen.colors.Blue, background = Screen.colors.Yellow },
     }
 
     ns = api.nvim_create_namespace 'test'
@@ -4899,7 +5530,8 @@ if (h->n_buckets < new_n_buckets) { // expand
   it('works with one line', function()
     insert(example_text2)
     feed '2gg'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       if (h->n_buckets < new_n_buckets) { // expand     |
         ^khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
@@ -4912,14 +5544,16 @@ if (h->n_buckets < new_n_buckets) { // expand
       }                                                 |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
 
     api.nvim_buf_set_extmark(0, ns, 1, 33, {
-      virt_lines={ {{">> ", "NonText"}, {"krealloc", "Identifier"}, {": change the size of an allocation"}}};
-      virt_lines_above=true;
+      virt_lines = { { { '>> ', 'NonText' }, { 'krealloc', 'Identifier' }, { ': change the size of an allocation' } } },
+      virt_lines_above = true,
     })
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       if (h->n_buckets < new_n_buckets) { // expand     |
       {1:>> }{25:krealloc}: change the size of an allocation     |
         ^khkey_t *new_keys = (khkey_t *)krealloc((void *)|
@@ -4932,10 +5566,12 @@ if (h->n_buckets < new_n_buckets) { // expand
         }                                               |
       }                                                 |
                                                         |
-    ]]}
+    ]],
+    }
 
     feed '/krealloc<cr>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       if (h->n_buckets < new_n_buckets) { // expand     |
       {1:>> }{25:krealloc}: change the size of an allocation     |
         khkey_t *new_keys = (khkey_t *){10:^krealloc}((void *)|
@@ -4948,11 +5584,13 @@ if (h->n_buckets < new_n_buckets) { // expand
         }                                               |
       }                                                 |
       /krealloc                                         |
-    ]]}
+    ]],
+    }
 
     -- virtual line remains anchored to the extmark
     feed 'i<cr>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)                 |
       {1:>> }{25:krealloc}: change the size of an allocation     |
@@ -4965,10 +5603,12 @@ if (h->n_buckets < new_n_buckets) { // expand
           h->vals_buf = new_vals;                       |
         }                                               |
       {5:-- INSERT --}                                      |
-    ]]}
+    ]],
+    }
 
     feed '<esc>3+'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)                 |
       {1:>> }{25:krealloc}: change the size of an allocation     |
@@ -4981,12 +5621,14 @@ if (h->n_buckets < new_n_buckets) { // expand
           h->vals_buf = new_vals;                       |
         }                                               |
                                                         |
-    ]]}
+    ]],
+    }
 
     api.nvim_buf_set_extmark(0, ns, 5, 0, {
-      virt_lines = { {{"^^ REVIEW:", "Todo"}, {" new_vals variable seems unnecessary?", "Comment"}} };
+      virt_lines = { { { '^^ REVIEW:', 'Todo' }, { ' new_vals variable seems unnecessary?', 'Comment' } } },
     })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)                 |
       {1:>> }{25:krealloc}: change the size of an allocation     |
@@ -4999,10 +5641,12 @@ if (h->n_buckets < new_n_buckets) { // expand
       {100:^^ REVIEW:}{18: new_vals variable seems unnecessary?}   |
           h->vals_buf = new_vals;                       |
                                                         |
-    ]]}
+    ]],
+    }
 
     api.nvim_buf_clear_namespace(0, ns, 0, -1)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)                 |
       {10:krealloc}((void *)h->keys, new_n_buckets * sizeof(k|
@@ -5015,14 +5659,16 @@ if (h->n_buckets < new_n_buckets) { // expand
         }                                               |
       }                                                 |
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('works with text at the beginning of the buffer', function()
     insert(example_text2)
     feed 'gg'
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
@@ -5035,19 +5681,21 @@ if (h->n_buckets < new_n_buckets) { // expand
       }                                                 |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
 
     api.nvim_buf_set_extmark(0, ns, 0, 0, {
-      virt_lines={
-        {{"refactor(khash): ", "Special"}, {"take size of values as parameter"}};
-        {{"Author: Dev Devsson, "}, {"Tue Aug 31 10:13:37 2021", "Comment"}};
-      };
-      virt_lines_above=true;
-      right_gravity=false;
+      virt_lines = {
+        { { 'refactor(khash): ', 'Special' }, { 'take size of values as parameter' } },
+        { { 'Author: Dev Devsson, ' }, { 'Tue Aug 31 10:13:37 2021', 'Comment' } },
+      },
+      virt_lines_above = true,
+      right_gravity = false,
     })
 
     -- placing virt_text on topline does not automatically cause a scroll
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
@@ -5060,10 +5708,13 @@ if (h->n_buckets < new_n_buckets) { // expand
       }                                                 |
       {1:~                                                 }|
                                                         |
-    ]], unchanged=true}
+    ]],
+      unchanged = true,
+    }
 
     feed '<c-b>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {16:refactor(khash): }take size of values as parameter |
       Author: Dev Devsson, {18:Tue Aug 31 10:13:37 2021}     |
       if (h->n_buckets < new_n_buckets) { // expand     |
@@ -5076,14 +5727,16 @@ if (h->n_buckets < new_n_buckets) { // expand
           h->vals_buf = new_vals;                       |
         ^}                                               |
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('works with text at the end of the buffer', function()
     insert(example_text2)
     feed 'G'
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
@@ -5096,14 +5749,16 @@ if (h->n_buckets < new_n_buckets) { // expand
       ^}                                                 |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
 
     local id = api.nvim_buf_set_extmark(0, ns, 7, 0, {
-      virt_lines={{{"Grugg"}}};
-      right_gravity=false;
+      virt_lines = { { { 'Grugg' } } },
+      right_gravity = false,
     })
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
@@ -5116,11 +5771,13 @@ if (h->n_buckets < new_n_buckets) { // expand
       ^}                                                 |
       Grugg                                             |
                                                         |
-    ]]}
+    ]],
+    }
 
     screen:try_resize(50, 11)
     feed('gg')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
@@ -5132,10 +5789,12 @@ if (h->n_buckets < new_n_buckets) { // expand
         }                                               |
       }                                                 |
                                                         |
-    ]]}
+    ]],
+    }
 
     feed('G<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
         khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
         h->keys = new_keys;                             |
@@ -5147,10 +5806,12 @@ if (h->n_buckets < new_n_buckets) { // expand
       ^}                                                 |
       Grugg                                             |
                                                         |
-    ]]}
+    ]],
+    }
 
     feed('gg')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
@@ -5162,11 +5823,13 @@ if (h->n_buckets < new_n_buckets) { // expand
         }                                               |
       }                                                 |
                                                         |
-    ]]}
+    ]],
+    }
 
     screen:try_resize(50, 12)
     feed('G')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
@@ -5179,10 +5842,12 @@ if (h->n_buckets < new_n_buckets) { // expand
       ^}                                                 |
       Grugg                                             |
                                                         |
-    ]]}
+    ]],
+    }
 
     api.nvim_buf_del_extmark(0, ns, id)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
@@ -5195,14 +5860,16 @@ if (h->n_buckets < new_n_buckets) { // expand
       ^}                                                 |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('works beyond end of the buffer with virt_lines_above', function()
     insert(example_text2)
     feed 'G'
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
@@ -5215,14 +5882,16 @@ if (h->n_buckets < new_n_buckets) { // expand
       ^}                                                 |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
 
     local id = api.nvim_buf_set_extmark(0, ns, 8, 0, {
-      virt_lines={{{"Grugg"}}};
+      virt_lines = { { { 'Grugg' } } },
       virt_lines_above = true,
     })
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
@@ -5235,10 +5904,12 @@ if (h->n_buckets < new_n_buckets) { // expand
       ^}                                                 |
       Grugg                                             |
                                                         |
-    ]]}
+    ]],
+    }
 
     feed('dd')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
@@ -5251,10 +5922,12 @@ if (h->n_buckets < new_n_buckets) { // expand
       Grugg                                             |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
 
     feed('dk')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
@@ -5265,29 +5938,34 @@ if (h->n_buckets < new_n_buckets) { // expand
       Grugg                                             |
       {1:~                                                 }|*3
                                                         |
-    ]]}
+    ]],
+    }
 
     feed('dgg')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^                                                  |
       Grugg                                             |
       {1:~                                                 }|*9
       --No lines in buffer--                            |
-    ]]}
+    ]],
+    }
 
     api.nvim_buf_del_extmark(0, ns, id)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^                                                  |
       {1:~                                                 }|*10
       --No lines in buffer--                            |
-    ]]}
+    ]],
+    }
   end)
 
   it('does not cause syntax ml_get error at the end of a buffer #17816', function()
     command([[syntax region foo keepend start='^foo' end='^$']])
     command('syntax sync minlines=100')
     insert('foo')
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {virt_lines = {{{'bar', 'Comment'}}}})
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_lines = { { { 'bar', 'Comment' } } } })
     screen:expect([[
       fo^o                                               |
       {18:bar}                                               |
@@ -5298,19 +5976,20 @@ if (h->n_buckets < new_n_buckets) { // expand
 
   it('works with a block scrolling up', function()
     screen:try_resize(30, 7)
-    insert("aa\nbb\ncc\ndd\nee\nff\ngg\nhh")
+    insert('aa\nbb\ncc\ndd\nee\nff\ngg\nhh')
     feed 'gg'
 
     api.nvim_buf_set_extmark(0, ns, 6, 0, {
-      virt_lines={
-        {{"they see me"}};
-        {{"scrolling", "Special"}};
-        {{"they"}};
-        {{"hatin'", "Special"}};
-      };
+      virt_lines = {
+        { { 'they see me' } },
+        { { 'scrolling', 'Special' } },
+        { { 'they' } },
+        { { "hatin'", 'Special' } },
+      },
     })
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^aa                            |
       bb                            |
       cc                            |
@@ -5318,10 +5997,12 @@ if (h->n_buckets < new_n_buckets) { // expand
       ee                            |
       ff                            |
                                     |
-    ]]}
+    ]],
+    }
 
     feed '<c-e>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^bb                            |
       cc                            |
       dd                            |
@@ -5329,10 +6010,12 @@ if (h->n_buckets < new_n_buckets) { // expand
       ff                            |
       gg                            |
                                     |
-    ]]}
+    ]],
+    }
 
     feed '<c-e>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^cc                            |
       dd                            |
       ee                            |
@@ -5340,10 +6023,12 @@ if (h->n_buckets < new_n_buckets) { // expand
       gg                            |
       they see me                   |
                                     |
-    ]]}
+    ]],
+    }
 
     feed '<c-e>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^dd                            |
       ee                            |
       ff                            |
@@ -5351,10 +6036,12 @@ if (h->n_buckets < new_n_buckets) { // expand
       they see me                   |
       {16:scrolling}                     |
                                     |
-    ]]}
+    ]],
+    }
 
     feed '<c-e>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^ee                            |
       ff                            |
       gg                            |
@@ -5362,10 +6049,12 @@ if (h->n_buckets < new_n_buckets) { // expand
       {16:scrolling}                     |
       they                          |
                                     |
-    ]]}
+    ]],
+    }
 
     feed '<c-e>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^ff                            |
       gg                            |
       they see me                   |
@@ -5373,10 +6062,12 @@ if (h->n_buckets < new_n_buckets) { // expand
       they                          |
       {16:hatin'}                        |
                                     |
-    ]]}
+    ]],
+    }
 
     feed '<c-e>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^gg                            |
       they see me                   |
       {16:scrolling}                     |
@@ -5384,10 +6075,12 @@ if (h->n_buckets < new_n_buckets) { // expand
       {16:hatin'}                        |
       hh                            |
                                     |
-    ]]}
+    ]],
+    }
 
     feed '<c-e>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       they see me                   |
       {16:scrolling}                     |
       they                          |
@@ -5395,48 +6088,58 @@ if (h->n_buckets < new_n_buckets) { // expand
       ^hh                            |
       {1:~                             }|
                                     |
-    ]]}
+    ]],
+    }
 
     feed '<c-e>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {16:scrolling}                     |
       they                          |
       {16:hatin'}                        |
       ^hh                            |
       {1:~                             }|*2
                                     |
-    ]]}
+    ]],
+    }
 
     feed '<c-e>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       they                          |
       {16:hatin'}                        |
       ^hh                            |
       {1:~                             }|*3
                                     |
-    ]]}
+    ]],
+    }
 
     feed '<c-e>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {16:hatin'}                        |
       ^hh                            |
       {1:~                             }|*4
                                     |
-    ]]}
+    ]],
+    }
 
     feed '<c-e>'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^hh                            |
       {1:~                             }|*5
                                     |
-    ]]}
+    ]],
+    }
   end)
 
   it('works with sign and numbercolumns', function()
     insert(example_text2)
     feed 'gg'
     command 'set number signcolumn=yes'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {7:  }{8:  1 }^if (h->n_buckets < new_n_buckets) { // expan|
       {7:  }{8:    }d                                           |
       {7:  }{8:  2 }  khkey_t *new_keys = (khkey_t *)krealloc((v|
@@ -5449,16 +6152,18 @@ if (h->n_buckets < new_n_buckets) { // expand
       {7:  }{8:  6 }    h->vals_buf = new_vals;                 |
       {7:  }{8:  7 }  }                                         |
                                                         |
-    ]]}
+    ]],
+    }
 
     local markid = api.nvim_buf_set_extmark(0, ns, 2, 0, {
-      virt_lines={
-        {{"Some special", "Special"}};
-        {{"remark about codes", "Comment"}};
-      };
+      virt_lines = {
+        { { 'Some special', 'Special' } },
+        { { 'remark about codes', 'Comment' } },
+      },
     })
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {7:  }{8:  1 }^if (h->n_buckets < new_n_buckets) { // expan|
       {7:  }{8:    }d                                           |
       {7:  }{8:  2 }  khkey_t *new_keys = (khkey_t *)krealloc((v|
@@ -5471,17 +6176,19 @@ if (h->n_buckets < new_n_buckets) { // expand
       {7:  }{8:  5 }    char *new_vals = krealloc( h->vals_buf, |
       {7:  }{8:    }new_n_buckets * val_size);                  |
                                                         |
-    ]]}
+    ]],
+    }
 
     api.nvim_buf_set_extmark(0, ns, 2, 0, {
-      virt_lines={
-        {{"Some special", "Special"}};
-        {{"remark about codes", "Comment"}};
-      };
-      virt_lines_leftcol=true;
-      id=markid;
+      virt_lines = {
+        { { 'Some special', 'Special' } },
+        { { 'remark about codes', 'Comment' } },
+      },
+      virt_lines_leftcol = true,
+      id = markid,
     })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {7:  }{8:  1 }^if (h->n_buckets < new_n_buckets) { // expan|
       {7:  }{8:    }d                                           |
       {7:  }{8:  2 }  khkey_t *new_keys = (khkey_t *)krealloc((v|
@@ -5494,16 +6201,18 @@ if (h->n_buckets < new_n_buckets) { // expand
       {7:  }{8:  5 }    char *new_vals = krealloc( h->vals_buf, |
       {7:  }{8:    }new_n_buckets * val_size);                  |
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('works with hard TABs', function()
     insert(example_text2)
     feed 'gg'
     api.nvim_buf_set_extmark(0, ns, 1, 0, {
-      virt_lines={ {{">>", "NonText"}, {"\tvery\ttabby", "Identifier"}, {"text\twith\ttabs"}}};
+      virt_lines = { { { '>>', 'NonText' }, { '\tvery\ttabby', 'Identifier' }, { 'text\twith\ttabs' } } },
     })
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
@@ -5516,10 +6225,12 @@ if (h->n_buckets < new_n_buckets) { // expand
         }                                               |
       }                                                 |
                                                         |
-    ]]}
+    ]],
+    }
 
     command 'set tabstop=4'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       ^if (h->n_buckets < new_n_buckets) { // expand     |
         khkey_t *new_keys = (khkey_t *)krealloc((void *)|
       h->keys, new_n_buckets * sizeof(khkey_t));        |
@@ -5532,10 +6243,12 @@ if (h->n_buckets < new_n_buckets) { // expand
         }                                               |
       }                                                 |
                                                         |
-    ]]}
+    ]],
+    }
 
     command 'set number'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {8:  1 }^if (h->n_buckets < new_n_buckets) { // expand |
       {8:  2 }  khkey_t *new_keys = (khkey_t *)krealloc((voi|
       {8:    }d *)h->keys, new_n_buckets * sizeof(khkey_t));|
@@ -5548,10 +6261,12 @@ if (h->n_buckets < new_n_buckets) { // expand
       {8:  7 }  }                                           |
       {8:  8 }}                                             |
                                                         |
-    ]]}
+    ]],
+    }
 
     command 'set tabstop&'
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {8:  1 }^if (h->n_buckets < new_n_buckets) { // expand |
       {8:  2 }  khkey_t *new_keys = (khkey_t *)krealloc((voi|
       {8:    }d *)h->keys, new_n_buckets * sizeof(khkey_t));|
@@ -5564,7 +6279,8 @@ if (h->n_buckets < new_n_buckets) { // expand
       {8:  7 }  }                                           |
       {8:  8 }}                                             |
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('scrolls horizontally with virt_lines_overflow = "scroll" #31000', function()
@@ -5708,9 +6424,10 @@ if (h->n_buckets < new_n_buckets) { // expand
       bbb
       ccc
       ddd]])
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {end_row = 2, virt_lines = {{{'VIRT LINE 1', 'NonText'}}}})
-    api.nvim_buf_set_extmark(0, ns, 3, 0, {end_col = 2, virt_lines = {{{'VIRT LINE 2', 'NonText'}}}})
-    screen:expect{grid=[[
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_row = 2, virt_lines = { { { 'VIRT LINE 1', 'NonText' } } } })
+    api.nvim_buf_set_extmark(0, ns, 3, 0, { end_col = 2, virt_lines = { { { 'VIRT LINE 2', 'NonText' } } } })
+    screen:expect {
+      grid = [[
       aaa                                               |
       {1:VIRT LINE 1}                                       |
       bbb                                               |
@@ -5719,7 +6436,8 @@ if (h->n_buckets < new_n_buckets) { // expand
       {1:VIRT LINE 2}                                       |
       {1:~                                                 }|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('works with rightleft', function()
@@ -5730,9 +6448,10 @@ if (h->n_buckets < new_n_buckets) { // expand
       ccc
       ddd]])
     command('set number rightleft')
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {virt_lines = {{{'VIRT LINE 1', 'NonText'}}}, virt_lines_leftcol = true})
-    api.nvim_buf_set_extmark(0, ns, 3, 0, {virt_lines = {{{'VIRT LINE 2', 'NonText'}}}})
-    screen:expect{grid=[[
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_lines = { { { 'VIRT LINE 1', 'NonText' } } }, virt_lines_leftcol = true })
+    api.nvim_buf_set_extmark(0, ns, 3, 0, { virt_lines = { { { 'VIRT LINE 2', 'NonText' } } } })
+    screen:expect {
+      grid = [[
                                                  aaa{8: 1  }|
                                              {1:1 ENIL TRIV}|
                                                  bbb{8: 2  }|
@@ -5741,7 +6460,8 @@ if (h->n_buckets < new_n_buckets) { // expand
                                          {1:2 ENIL TRIV}{8:    }|
       {1:                                                 ~}|
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('works when using dd or yyp #23915 #23916', function()
@@ -5751,8 +6471,9 @@ if (h->n_buckets < new_n_buckets) { // expand
       line3
       line4
       line5]])
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {virt_lines={{{"foo"}}, {{"bar"}}, {{"baz"}}}})
-    screen:expect{grid=[[
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_lines = { { { 'foo' } }, { { 'bar' } }, { { 'baz' } } } })
+    screen:expect {
+      grid = [[
       line1                                             |
       foo                                               |
       bar                                               |
@@ -5763,11 +6484,13 @@ if (h->n_buckets < new_n_buckets) { // expand
       line^5                                             |
       {1:~                                                 }|*3
                                                         |
-    ]]}
+    ]],
+    }
 
     feed('gg')
     feed('yyp')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       line1                                             |
       foo                                               |
       bar                                               |
@@ -5779,10 +6502,12 @@ if (h->n_buckets < new_n_buckets) { // expand
       line5                                             |
       {1:~                                                 }|*2
                                                         |
-    ]]}
+    ]],
+    }
 
     feed('dd')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       line1                                             |
       foo                                               |
       bar                                               |
@@ -5793,7 +6518,8 @@ if (h->n_buckets < new_n_buckets) { // expand
       line5                                             |
       {1:~                                                 }|*3
                                                         |
-    ]]}
+    ]],
+    }
 
     feed('kdd')
     screen:expect([[
@@ -5814,7 +6540,7 @@ if (h->n_buckets < new_n_buckets) { // expand
     insert('\n')
     api.nvim_set_option_value('conceallevel', 2, {})
     api.nvim_set_option_value('concealcursor', 'niv', {})
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_lines = {{{'VIRT1'}}, {{'VIRT2'}}} })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_lines = { { { 'VIRT1' } }, { { 'VIRT2' } } } })
     screen:expect([[
                                │                        |
       VIRT1                    │VIRT1                   |
@@ -5829,7 +6555,7 @@ if (h->n_buckets < new_n_buckets) { // expand
   it('works with full page scrolling #28290', function()
     screen:try_resize(20, 8)
     command('call setline(1, range(20))')
-    api.nvim_buf_set_extmark(0, ns, 10, 0, { virt_lines = {{{'VIRT1'}}, {{'VIRT2'}}} })
+    api.nvim_buf_set_extmark(0, ns, 10, 0, { virt_lines = { { { 'VIRT1' } }, { { 'VIRT2' } } } })
     screen:expect([[
       ^0                   |
       1                   |
@@ -5910,7 +6636,7 @@ if (h->n_buckets < new_n_buckets) { // expand
 
   it('not drawn when invalid', function()
     api.nvim_buf_set_lines(0, 0, -1, false, { 'foo', 'bar' })
-    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_lines = {{{'VIRT1'}}}, invalidate = true })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { virt_lines = { { { 'VIRT1' } } }, invalidate = true })
     screen:expect({
       grid = [[
         ^foo                                               |
@@ -5918,7 +6644,7 @@ if (h->n_buckets < new_n_buckets) { // expand
         bar                                               |
         {1:~                                                 }|*8
                                                           |
-      ]]
+      ]],
     })
     feed('dd')
     screen:expect({
@@ -5926,7 +6652,7 @@ if (h->n_buckets < new_n_buckets) { // expand
         ^bar                                               |
         {1:~                                                 }|*10
                                                           |
-      ]]
+      ]],
     })
   end)
 end)
@@ -5939,7 +6665,7 @@ describe('decorations: signs', function()
     clear()
     screen = Screen.new(50, 10)
     screen:add_extra_attr_ids {
-        [100] = { foreground = Screen.colors.Blue, background = Screen.colors.Yellow },
+      [100] = { foreground = Screen.colors.Blue, background = Screen.colors.Yellow },
     }
 
     ns = api.nvim_create_namespace 'test'
@@ -5958,7 +6684,7 @@ l5
     insert(example_test3)
     feed 'gg'
 
-    api.nvim_buf_set_extmark(0, ns, 1, -1, {sign_text='S'})
+    api.nvim_buf_set_extmark(0, ns, 1, -1, { sign_text = 'S' })
 
     screen:expect([[
       {7:  }^l1                                              |
@@ -5976,7 +6702,7 @@ l5
     insert(example_test3)
     feed 'gg'
 
-    api.nvim_buf_set_extmark(0, ns, 1, -1, {sign_text='S', end_row=1})
+    api.nvim_buf_set_extmark(0, ns, 1, -1, { sign_text = 'S', end_row = 1 })
 
     screen:expect([[
       {7:  }^l1                                              |
@@ -5994,7 +6720,7 @@ l5
     insert(example_test3)
     feed 'gg'
 
-    api.nvim_buf_set_extmark(0, ns, 1, 0, {sign_text='S', hl_group='Todo', end_col=1})
+    api.nvim_buf_set_extmark(0, ns, 1, 0, { sign_text = 'S', hl_group = 'Todo', end_col = 1 })
     screen:expect([[
       {7:  }^l1                                              |
       {7:S }{100:l}2                                              |
@@ -6013,7 +6739,7 @@ l5
     insert(example_test3)
     feed 'gg'
 
-    api.nvim_buf_set_extmark(0, ns, 1, -1, {sign_text='S', end_row = 2})
+    api.nvim_buf_set_extmark(0, ns, 1, -1, { sign_text = 'S', end_row = 2 })
 
     screen:expect([[
       {7:  }^l1                                              |
@@ -6029,10 +6755,10 @@ l5
 
   it('can add multiple signs (multiple extmarks)', function()
     insert(example_test3)
-    feed'gg'
+    feed 'gg'
 
-    api.nvim_buf_set_extmark(0, ns, 1, -1, {sign_text='S1'})
-    api.nvim_buf_set_extmark(0, ns, 3, -1, {sign_text='S2', end_row = 4})
+    api.nvim_buf_set_extmark(0, ns, 1, -1, { sign_text = 'S1' })
+    api.nvim_buf_set_extmark(0, ns, 3, -1, { sign_text = 'S2', end_row = 4 })
 
     screen:expect([[
       {7:  }^l1                                              |
@@ -6050,8 +6776,8 @@ l5
     insert(example_test3)
     feed 'gg'
 
-    api.nvim_buf_set_extmark(0, ns, 3, -1, {sign_text='S1'})
-    api.nvim_buf_set_extmark(0, ns, 1, -1, {sign_text='S2', end_row = 3})
+    api.nvim_buf_set_extmark(0, ns, 3, -1, { sign_text = 'S1' })
+    api.nvim_buf_set_extmark(0, ns, 1, -1, { sign_text = 'S2', end_row = 3 })
     screen:expect([[
       {7:    }^l1                                            |
       {7:S2  }l2                                            |
@@ -6065,12 +6791,11 @@ l5
   end)
 
   it('can add multiple signs (multiple extmarks) 3', function()
-
     insert(example_test3)
     feed 'gg'
 
-    api.nvim_buf_set_extmark(0, ns, 1, -1, {sign_text='S1', end_row=2})
-    api.nvim_buf_set_extmark(0, ns, 2, -1, {sign_text='S2', end_row=3})
+    api.nvim_buf_set_extmark(0, ns, 1, -1, { sign_text = 'S1', end_row = 2 })
+    api.nvim_buf_set_extmark(0, ns, 2, -1, { sign_text = 'S2', end_row = 3 })
 
     screen:expect([[
       {7:    }^l1                                            |
@@ -6088,8 +6813,8 @@ l5
     insert(example_test3)
     feed 'gg'
 
-    api.nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='S1', end_row=0})
-    api.nvim_buf_set_extmark(0, ns, 1, -1, {sign_text='S2', end_row=1})
+    api.nvim_buf_set_extmark(0, ns, 0, -1, { sign_text = 'S1', end_row = 0 })
+    api.nvim_buf_set_extmark(0, ns, 1, -1, { sign_text = 'S2', end_row = 1 })
 
     screen:expect([[
       {7:S1}^l1                                              |
@@ -6110,10 +6835,10 @@ l5
     n.command('sign define Oldsign text=x')
     n.command([[exe 'sign place 42 line=2 name=Oldsign buffer=' . bufnr('')]])
 
-    api.nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='S1'})
-    api.nvim_buf_set_extmark(0, ns, 1, -1, {sign_text='S2'})
-    api.nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='S4'})
-    api.nvim_buf_set_extmark(0, ns, 2, -1, {sign_text='S5'})
+    api.nvim_buf_set_extmark(0, ns, 0, -1, { sign_text = 'S1' })
+    api.nvim_buf_set_extmark(0, ns, 1, -1, { sign_text = 'S2' })
+    api.nvim_buf_set_extmark(0, ns, 0, -1, { sign_text = 'S4' })
+    api.nvim_buf_set_extmark(0, ns, 2, -1, { sign_text = 'S5' })
 
     screen:expect([[
       {7:S4S1}^l1                                            |
@@ -6134,11 +6859,11 @@ l5
     n.command('sign define Oldsign text=x')
     n.command([[exe 'sign place 42 line=2 name=Oldsign buffer=' . bufnr('')]])
 
-    api.nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='S1'})
-    api.nvim_buf_set_extmark(0, ns, 1, -1, {sign_text='S2'})
-    api.nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='S3', end_row = 4})
-    api.nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='S4'})
-    api.nvim_buf_set_extmark(0, ns, 2, -1, {sign_text='S5'})
+    api.nvim_buf_set_extmark(0, ns, 0, -1, { sign_text = 'S1' })
+    api.nvim_buf_set_extmark(0, ns, 1, -1, { sign_text = 'S2' })
+    api.nvim_buf_set_extmark(0, ns, 0, -1, { sign_text = 'S3', end_row = 4 })
+    api.nvim_buf_set_extmark(0, ns, 0, -1, { sign_text = 'S4' })
+    api.nvim_buf_set_extmark(0, ns, 2, -1, { sign_text = 'S5' })
 
     screen:expect([[
       {7:S4S3S1}^l1                                          |
@@ -6158,7 +6883,7 @@ l5
     feed 'gg'
     feed '2<C-e>'
 
-    api.nvim_buf_set_extmark(0, ns, 1, -1, {sign_text='X', end_row=3})
+    api.nvim_buf_set_extmark(0, ns, 1, -1, { sign_text = 'X', end_row = 3 })
 
     screen:expect([[
       {7:X   }^l3                                            |
@@ -6175,18 +6900,18 @@ l5
     command 'normal 10oa b c d e f g h'
 
     for i = 1, 10 do
-      api.nvim_buf_set_extmark(0, ns, i,  0, { end_col =  1, hl_group='Todo' })
-      api.nvim_buf_set_extmark(0, ns, i,  2, { end_col =  3, hl_group='Todo' })
-      api.nvim_buf_set_extmark(0, ns, i,  4, { end_col =  5, hl_group='Todo' })
-      api.nvim_buf_set_extmark(0, ns, i,  6, { end_col =  7, hl_group='Todo' })
-      api.nvim_buf_set_extmark(0, ns, i,  8, { end_col =  9, hl_group='Todo' })
-      api.nvim_buf_set_extmark(0, ns, i, 10, { end_col = 11, hl_group='Todo' })
-      api.nvim_buf_set_extmark(0, ns, i, 12, { end_col = 13, hl_group='Todo' })
-      api.nvim_buf_set_extmark(0, ns, i, 14, { end_col = 15, hl_group='Todo' })
-      api.nvim_buf_set_extmark(0, ns, i, -1, { sign_text='W' })
-      api.nvim_buf_set_extmark(0, ns, i, -1, { sign_text='X' })
-      api.nvim_buf_set_extmark(0, ns, i, -1, { sign_text='Y' })
-      api.nvim_buf_set_extmark(0, ns, i, -1, { sign_text='Z' })
+      api.nvim_buf_set_extmark(0, ns, i, 0, { end_col = 1, hl_group = 'Todo' })
+      api.nvim_buf_set_extmark(0, ns, i, 2, { end_col = 3, hl_group = 'Todo' })
+      api.nvim_buf_set_extmark(0, ns, i, 4, { end_col = 5, hl_group = 'Todo' })
+      api.nvim_buf_set_extmark(0, ns, i, 6, { end_col = 7, hl_group = 'Todo' })
+      api.nvim_buf_set_extmark(0, ns, i, 8, { end_col = 9, hl_group = 'Todo' })
+      api.nvim_buf_set_extmark(0, ns, i, 10, { end_col = 11, hl_group = 'Todo' })
+      api.nvim_buf_set_extmark(0, ns, i, 12, { end_col = 13, hl_group = 'Todo' })
+      api.nvim_buf_set_extmark(0, ns, i, 14, { end_col = 15, hl_group = 'Todo' })
+      api.nvim_buf_set_extmark(0, ns, i, -1, { sign_text = 'W' })
+      api.nvim_buf_set_extmark(0, ns, i, -1, { sign_text = 'X' })
+      api.nvim_buf_set_extmark(0, ns, i, -1, { sign_text = 'Y' })
+      api.nvim_buf_set_extmark(0, ns, i, -1, { sign_text = 'Z' })
     end
 
     screen:expect([[
@@ -6204,10 +6929,10 @@ l5
     command('sign define Oldsign text=O3')
     command([[exe 'sign place 42 line=1 name=Oldsign priority=10 buffer=' . bufnr('')]])
 
-    api.nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='S4', priority=100})
-    api.nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='S2', priority=5})
-    api.nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='S5', priority=200})
-    api.nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='S1', priority=1})
+    api.nvim_buf_set_extmark(0, ns, 0, -1, { sign_text = 'S4', priority = 100 })
+    api.nvim_buf_set_extmark(0, ns, 0, -1, { sign_text = 'S2', priority = 5 })
+    api.nvim_buf_set_extmark(0, ns, 0, -1, { sign_text = 'S5', priority = 200 })
+    api.nvim_buf_set_extmark(0, ns, 0, -1, { sign_text = 'S1', priority = 1 })
 
     screen:expect([[
       {7:S5S4O3S2S1}^l1        |
@@ -6245,10 +6970,10 @@ l5
                           |
     ]])
 
-    api.nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='S1', priority=1})
+    api.nvim_buf_set_extmark(0, ns, 0, -1, { sign_text = 'S1', priority = 1 })
     screen:expect_unchanged()
 
-    api.nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='S5', priority=200})
+    api.nvim_buf_set_extmark(0, ns, 0, -1, { sign_text = 'S5', priority = 200 })
     screen:expect([[
       {7:S5O3O3O3O3O3O3O3O3}^  |
       {1:~                   }|
@@ -6263,20 +6988,20 @@ l5
     api.nvim_set_option_value('signcolumn', 'auto', {})
     insert(example_test3)
     feed 'gg'
-    api.nvim_buf_set_extmark(0, ns, 0, -1, {number_hl_group='Error'})
-    screen:expect{grid=[[
+    api.nvim_buf_set_extmark(0, ns, 0, -1, { number_hl_group = 'Error' })
+    screen:expect { grid = [[
       ^l1                  |
       l2                  |
                           |
-    ]]}
+    ]] }
   end)
 
   it('correct width when removing multiple signs from sentinel line', function()
     screen:try_resize(20, 4)
     insert(example_test3)
-    api.nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='S1', end_row=3})
-    api.nvim_buf_set_extmark(0, ns, 1, -1, {invalidate = true, sign_text='S2'})
-    api.nvim_buf_set_extmark(0, ns, 1, -1, {invalidate = true, sign_text='S3'})
+    api.nvim_buf_set_extmark(0, ns, 0, -1, { sign_text = 'S1', end_row = 3 })
+    api.nvim_buf_set_extmark(0, ns, 1, -1, { invalidate = true, sign_text = 'S2' })
+    api.nvim_buf_set_extmark(0, ns, 1, -1, { invalidate = true, sign_text = 'S3' })
     feed('2Gdd')
 
     screen:expect([[
@@ -6290,9 +7015,9 @@ l5
   it('correct width with multiple overlapping signs', function()
     screen:try_resize(20, 4)
     insert(example_test3)
-    api.nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='S1'})
-    api.nvim_buf_set_extmark(0, ns, 0, -1, {sign_text='S2', end_row=2})
-    api.nvim_buf_set_extmark(0, ns, 1, -1, {sign_text='S3', end_row=2})
+    api.nvim_buf_set_extmark(0, ns, 0, -1, { sign_text = 'S1' })
+    api.nvim_buf_set_extmark(0, ns, 0, -1, { sign_text = 'S2', end_row = 2 })
+    api.nvim_buf_set_extmark(0, ns, 1, -1, { sign_text = 'S3', end_row = 2 })
     feed('gg')
 
     local s1 = [[
@@ -6311,7 +7036,7 @@ l5
                           |
     ]])
     command('silent undo')
-    screen:expect{grid=s1}
+    screen:expect { grid = s1 }
     command('d')
     screen:expect([[
       {7:S3S2S1}^l2            |
@@ -6380,8 +7105,8 @@ l5
     screen:try_resize(20, 4)
     insert(example_test3)
     feed('gg')
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {sign_text='S1'})
-    api.nvim_buf_set_extmark(0, ns, 0, 1, {sign_text='S2'})
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { sign_text = 'S1' })
+    api.nvim_buf_set_extmark(0, ns, 0, 1, { sign_text = 'S2' })
     feed('a<cr><esc>')
     screen:expect([[
       {7:S1}l                 |
@@ -6404,14 +7129,14 @@ l5
                           |
     ]])
     api.nvim_win_set_buf(0, api.nvim_create_buf(false, true))
-    api.nvim_buf_delete(buf, {unload=true, force=true})
-    api.nvim_buf_set_lines(buf, 0, -1, false, {''})
+    api.nvim_buf_delete(buf, { unload = true, force = true })
+    api.nvim_buf_set_lines(buf, 0, -1, false, { '' })
     api.nvim_win_set_buf(0, buf)
-    screen:expect{grid=[[
+    screen:expect { grid = [[
       ^                    |
       {1:~                   }|*2
                           |
-    ]]}
+    ]] }
   end)
 
   it('correct width with moved marks before undo savepos', function()
@@ -6445,9 +7170,9 @@ l5
     screen:try_resize(20, 4)
     insert('a')
     for _ = 0, 104 do
-      api.nvim_buf_set_extmark(0, ns, 0, 0, {hl_group = 'Error', end_col = 1})
+      api.nvim_buf_set_extmark(0, ns, 0, 0, { hl_group = 'Error', end_col = 1 })
     end
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {sign_text = 'S1'})
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { sign_text = 'S1' })
 
     screen:expect([[
       {7:S1}{9:^a}                 |
@@ -6458,8 +7183,8 @@ l5
 
   it('correct sort order with multiple namespaces and same id', function()
     local ns2 = api.nvim_create_namespace('')
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {sign_text = 'S1', id = 1})
-    api.nvim_buf_set_extmark(0, ns2, 0, 0, {sign_text = 'S2', id = 1})
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { sign_text = 'S1', id = 1 })
+    api.nvim_buf_set_extmark(0, ns2, 0, 0, { sign_text = 'S2', id = 1 })
 
     screen:expect([[
       {7:S2S1}^                                              |
@@ -6470,16 +7195,16 @@ l5
 
   it('correct number of signs after deleting text (#27046)', function()
     command('call setline(1, ["foo"]->repeat(31))')
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {end_row = 0, sign_text = 'S1'})
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {end_row = 0, end_col = 3, hl_group = 'Error'})
-    api.nvim_buf_set_extmark(0, ns, 9, 0, {end_row = 9,  sign_text = 'S2'})
-    api.nvim_buf_set_extmark(0, ns, 9, 0, {end_row = 9, end_col = 3, hl_group = 'Error'})
-    api.nvim_buf_set_extmark(0, ns, 19, 0, {end_row = 19, sign_text = 'S3'})
-    api.nvim_buf_set_extmark(0, ns, 19, 0, {end_row = 19, end_col = 3, hl_group = 'Error'})
-    api.nvim_buf_set_extmark(0, ns, 29, 0, {end_row = 29, sign_text = 'S4'})
-    api.nvim_buf_set_extmark(0, ns, 29, 0, {end_row = 29, end_col = 3, hl_group = 'Error'})
-    api.nvim_buf_set_extmark(0, ns, 30, 0, {end_row = 30, sign_text = 'S5'})
-    api.nvim_buf_set_extmark(0, ns, 30, 0, {end_row = 30, end_col = 3, hl_group = 'Error'})
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_row = 0, sign_text = 'S1' })
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { end_row = 0, end_col = 3, hl_group = 'Error' })
+    api.nvim_buf_set_extmark(0, ns, 9, 0, { end_row = 9, sign_text = 'S2' })
+    api.nvim_buf_set_extmark(0, ns, 9, 0, { end_row = 9, end_col = 3, hl_group = 'Error' })
+    api.nvim_buf_set_extmark(0, ns, 19, 0, { end_row = 19, sign_text = 'S3' })
+    api.nvim_buf_set_extmark(0, ns, 19, 0, { end_row = 19, end_col = 3, hl_group = 'Error' })
+    api.nvim_buf_set_extmark(0, ns, 29, 0, { end_row = 29, sign_text = 'S4' })
+    api.nvim_buf_set_extmark(0, ns, 29, 0, { end_row = 29, end_col = 3, hl_group = 'Error' })
+    api.nvim_buf_set_extmark(0, ns, 30, 0, { end_row = 30, sign_text = 'S5' })
+    api.nvim_buf_set_extmark(0, ns, 30, 0, { end_row = 30, end_col = 3, hl_group = 'Error' })
     command('0d29')
 
     screen:expect([[
@@ -6511,11 +7236,11 @@ l5
   it('supports emoji as signs', function()
     insert(example_test3)
     feed 'gg'
-    api.nvim_buf_set_extmark(0, ns, 1, 0, {sign_text='🧑‍🌾'})
+    api.nvim_buf_set_extmark(0, ns, 1, 0, { sign_text = '🧑‍🌾' })
     -- VS16 can change width of character
-    api.nvim_buf_set_extmark(0, ns, 2, 0, {sign_text='❤️'})
-    api.nvim_buf_set_extmark(0, ns, 3, 0, {sign_text='❤'})
-    api.nvim_buf_set_extmark(0, ns, 4, 0, {sign_text='❤x'})
+    api.nvim_buf_set_extmark(0, ns, 2, 0, { sign_text = '❤️' })
+    api.nvim_buf_set_extmark(0, ns, 3, 0, { sign_text = '❤' })
+    api.nvim_buf_set_extmark(0, ns, 4, 0, { sign_text = '❤x' })
     screen:expect([[
       {7:  }^l1                                              |
       {7:🧑‍🌾}l2                                              |
@@ -6526,27 +7251,27 @@ l5
       {1:~                                                 }|*3
                                                         |
     ]])
-    eq("Invalid 'sign_text'", pcall_err(api.nvim_buf_set_extmark, 0, ns, 5, 0, {sign_text='❤️x'}))
+    eq("Invalid 'sign_text'", pcall_err(api.nvim_buf_set_extmark, 0, ns, 5, 0, { sign_text = '❤️x' }))
   end)
 
   it('auto signcolumn hides with invalidated sign', function()
     api.nvim_set_option_value('signcolumn', 'auto', {})
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {sign_text='S1', invalidate=true})
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { sign_text = 'S1', invalidate = true })
     feed('ia<cr>b<esc>dd')
     screen:expect({
       grid = [[
         ^a                                                 |
         {1:~                                                 }|*8
                                                           |
-      ]]
+      ]],
     })
   end)
 
   it('signcolumn correctly tracked with signs beyond eob and pair end before start', function()
     api.nvim_set_option_value('signcolumn', 'auto:2', {})
     api.nvim_set_option_value('filetype', 'lua', {})
-    api.nvim_buf_set_lines(0, 0, -1, false, {'foo', 'bar'})
-    api.nvim_buf_set_extmark(0, ns, 2, 0, {sign_text='S1'})
+    api.nvim_buf_set_lines(0, 0, -1, false, { 'foo', 'bar' })
+    api.nvim_buf_set_extmark(0, ns, 2, 0, { sign_text = 'S1' })
     api.nvim_set_hl(0, 'SignColumn', { link = 'Error' })
     screen:expect([[
       ^foo                                               |
@@ -6554,8 +7279,8 @@ l5
       {1:~                                                 }|*7
                                                         |
     ]])
-    api.nvim_buf_set_extmark(0, ns, 0, 0, {sign_text='S2', end_row = 1})
-    api.nvim_buf_set_lines(0, 0, -1, false, {'-- foo', '-- bar'})
+    api.nvim_buf_set_extmark(0, ns, 0, 0, { sign_text = 'S2', end_row = 1 })
+    api.nvim_buf_set_lines(0, 0, -1, false, { '-- foo', '-- bar' })
     api.nvim_buf_clear_namespace(0, ns, 0, -1)
     screen:expect([[
       ^-- foo                                            |
@@ -6582,11 +7307,12 @@ describe('decorations: virt_text', function()
     command 'normal aVIRTUAL'
 
     api.nvim_buf_set_extmark(0, ns, 2, 0, {
-      virt_text = {{"hello", "String"}},
+      virt_text = { { 'hello', 'String' } },
       virt_text_win_col = 20,
     })
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {8:  4 }                                              |
       {8:  3 }hello                                         |
       {8:  2 }hello               {26:hello}                     |
@@ -6594,12 +7320,14 @@ describe('decorations: virt_text', function()
       {8:5   }helloVIRTUA^L                                  |
       {1:~                                                 }|*4
                                                         |
-    ]]}
+    ]],
+    }
 
     -- Trigger a screen update
     feed('k')
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
       {8:  3 }                                              |
       {8:  2 }hello                                         |
       {8:  1 }hello               {26:hello}                     |
@@ -6607,36 +7335,41 @@ describe('decorations: virt_text', function()
       {8:  1 }helloVIRTUAL                                  |
       {1:~                                                 }|*4
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('redraws correctly when re-using extmark ids', function()
     command 'normal 5ohello'
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
                                                         |
       hello                                             |*4
       hell^o                                             |
       {1:~                                                 }|*3
                                                         |
-    ]]}
+    ]],
+    }
 
     for row = 1, 5 do
-      api.nvim_buf_set_extmark(0, ns, row, 0, { id = 1, virt_text = {{'world', 'Normal'}} })
+      api.nvim_buf_set_extmark(0, ns, row, 0, { id = 1, virt_text = { { 'world', 'Normal' } } })
     end
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
                                                         |
       hello                                             |*4
       hell^o world                                       |
       {1:~                                                 }|*3
                                                         |
-    ]]}
+    ]],
+    }
   end)
 
   it('redraws correctly when removing mark whose end ends up in front of start', function()
     command('normal 5ohello')
-    api.nvim_buf_set_extmark(0, ns, 2, 0, { end_col = 1, virt_text = {{'world', 'Normal'}} })
+    api.nvim_buf_set_extmark(0, ns, 2, 0, { end_col = 1, virt_text = { { 'world', 'Normal' } } })
     screen:expect([[
                                                         |
       hello                                             |
@@ -6678,9 +7411,13 @@ describe('decorations: window scoped', function()
     insert('12345')
 
     win_other = api.nvim_open_win(0, false, {
-      col=0,row=0,width=20,height=10,
-      relative = 'win',style = 'minimal',
-      hide = true
+      col = 0,
+      row = 0,
+      width = 20,
+      height = 10,
+      relative = 'win',
+      style = 'minimal',
+      hide = true,
     })
   end)
 
@@ -6947,7 +7684,7 @@ describe('decorations: window scoped', function()
     })
 
     api.nvim__ns_set(ns, { wins = { 0 } })
-    eq({ wins={ api.nvim_get_current_win() } }, api.nvim__ns_get(ns))
+    eq({ wins = { api.nvim_get_current_win() } }, api.nvim__ns_get(ns))
 
     screen:expect {
       grid = [[
@@ -6963,7 +7700,7 @@ describe('decorations: window scoped', function()
     screen:expect(noextmarks)
 
     api.nvim__ns_set(ns, { wins = { 0 } })
-    eq({ wins={ api.nvim_get_current_win() } }, api.nvim__ns_get(ns))
+    eq({ wins = { api.nvim_get_current_win() } }, api.nvim__ns_get(ns))
 
     screen:expect {
       grid = [[
@@ -6974,13 +7711,17 @@ describe('decorations: window scoped', function()
     }
 
     local win_new = api.nvim_open_win(0, false, {
-      col=0,row=0,width=20,height=10,
-      relative = 'win',style = 'minimal',
-      hide = true
+      col = 0,
+      row = 0,
+      width = 20,
+      height = 10,
+      relative = 'win',
+      style = 'minimal',
+      hide = true,
     })
 
     api.nvim__ns_set(ns, { wins = { win_new } })
-    eq({ wins={ win_new } }, api.nvim__ns_get(ns))
+    eq({ wins = { win_new } }, api.nvim__ns_get(ns))
 
     screen:expect(noextmarks)
   end)
@@ -6997,7 +7738,7 @@ describe('decorations: window scoped', function()
     eq({ wins = {} }, api.nvim__ns_get(ns))
   end)
 
-  it('remove window from namespace scope when deleted', function ()
+  it('remove window from namespace scope when deleted', function()
     api.nvim__ns_set(ns, { wins = { 0 } })
 
     eq({ wins = { api.nvim_get_current_win() } }, api.nvim__ns_get(ns))

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -33,7 +33,7 @@ describe('float window', function()
     -- Create three windows and test that ":wincmd <direction>" changes to the
     -- first window, if the previous window is invalid.
     command('split')
-    api.nvim_open_win(0, true, {width=10, height=10, relative='editor', row=0, col=0})
+    api.nvim_open_win(0, true, { width = 10, height = 10, relative = 'editor', row = 0, col = 0 })
     eq(1002, fn.win_getid())
     eq('editor', api.nvim_win_get_config(1002).relative)
     command([[
@@ -43,31 +43,34 @@ describe('float window', function()
     eq(1000, fn.win_getid())
   end)
 
-  it('win_execute() should work' , function()
+  it('win_execute() should work', function()
     local buf = api.nvim_create_buf(false, false)
-    api.nvim_buf_set_lines(buf, 0, -1, true, {'the floatwin', 'abc', 'def'})
-    local win = api.nvim_open_win(buf, false, {relative='win', width=16, height=1, row=0, col=10})
+    api.nvim_buf_set_lines(buf, 0, -1, true, { 'the floatwin', 'abc', 'def' })
+    local win = api.nvim_open_win(buf, false, { relative = 'win', width = 16, height = 1, row = 0, col = 10 })
     local line = fn.win_execute(win, 'echo getline(1)')
     eq('\nthe floatwin', line)
-    eq('\n1', fn.win_execute(win, 'echo line(".",'..win..')'))
-    eq('\n3', fn.win_execute(win, 'echo line("$",'..win..')'))
+    eq('\n1', fn.win_execute(win, 'echo line(".",' .. win .. ')'))
+    eq('\n3', fn.win_execute(win, 'echo line("$",' .. win .. ')'))
     eq('\n0', fn.win_execute(win, 'echo line("$", 123456)'))
     fn.win_execute(win, 'bwipe!')
   end)
 
-  it("win_execute() call commands that are not allowed when 'hidden' is not set" , function()
+  it("win_execute() call commands that are not allowed when 'hidden' is not set", function()
     command('set nohidden')
     local buf = api.nvim_create_buf(false, false)
-    api.nvim_buf_set_lines(buf, 0, -1, true, {'the floatwin'})
-    local win = api.nvim_open_win(buf, true, {relative='win', width=16, height=1, row=0, col=10})
+    api.nvim_buf_set_lines(buf, 0, -1, true, { 'the floatwin' })
+    local win = api.nvim_open_win(buf, true, { relative = 'win', width = 16, height = 1, row = 0, col = 10 })
     eq('Vim(close):E37: No write since last change (add ! to override)', pcall_err(fn.win_execute, win, 'close'))
     eq('Vim(bdelete):E89: No write since last change for buffer 2 (add ! to override)', pcall_err(fn.win_execute, win, 'bdelete'))
     fn.win_execute(win, 'bwipe!')
   end)
 
   it('closed immediately by autocmd #11383', function()
-    eq('Window was closed immediately',
-      pcall_err(exec_lua, [[
+    eq(
+      'Window was closed immediately',
+      pcall_err(
+        exec_lua,
+        [[
         local api = vim.api
         local function crashes(contents)
           local buf = api.nvim_create_buf(false, true)
@@ -86,13 +89,18 @@ describe('float window', function()
         end
         crashes{'foo'}
         crashes{'bar'}
-    ]]))
+    ]]
+      )
+    )
     assert_alive()
   end)
 
   it('closed immediately by autocmd after win_enter #15548', function()
-    eq('Window was closed immediately',
-      pcall_err(exec_lua, [[
+    eq(
+      'Window was closed immediately',
+      pcall_err(
+        exec_lua,
+        [[
         vim.cmd "autocmd BufLeave * ++once quit!"
         local buf = vim.api.nvim_create_buf(true, true)
         vim.api.nvim_open_win(buf, true, {
@@ -101,7 +109,9 @@ describe('float window', function()
           width = 1, height = 1,
           noautocmd = false,
         })
-    ]]))
+    ]]
+      )
+    )
     assert_alive()
   end)
 
@@ -280,7 +290,6 @@ describe('float window', function()
     eq(14, pos[2])
   end)
 
-
   it('opened with correct position relative to another relative window', function()
     local pos = exec_lua([[
       local bufnr = vim.api.nvim_create_buf(false, true)
@@ -329,31 +338,13 @@ describe('float window', function()
 
   it('error message when invalid field specified for split', function()
     local bufnr = api.nvim_create_buf(false, true)
-    eq(
-      "non-float cannot have 'row'",
-      pcall_err(api.nvim_open_win, bufnr, true, { split = 'right', row = 10 })
-    )
-    eq(
-      "non-float cannot have 'col'",
-      pcall_err(api.nvim_open_win, bufnr, true, { split = 'right', col = 10 })
-    )
-    eq(
-      "non-float cannot have 'bufpos'",
-      pcall_err(api.nvim_open_win, bufnr, true, { split = 'right', bufpos = { 0, 0 } })
-    )
+    eq("non-float cannot have 'row'", pcall_err(api.nvim_open_win, bufnr, true, { split = 'right', row = 10 }))
+    eq("non-float cannot have 'col'", pcall_err(api.nvim_open_win, bufnr, true, { split = 'right', col = 10 }))
+    eq("non-float cannot have 'bufpos'", pcall_err(api.nvim_open_win, bufnr, true, { split = 'right', bufpos = { 0, 0 } }))
     local winid = api.nvim_open_win(bufnr, true, { split = 'right' })
-    eq(
-      "non-float cannot have 'row'",
-      pcall_err(api.nvim_win_set_config, winid, { split = 'right', row = 10 })
-    )
-    eq(
-      "non-float cannot have 'col'",
-      pcall_err(api.nvim_win_set_config, winid, { split = 'right', col = 10 })
-    )
-    eq(
-      "non-float cannot have 'bufpos'",
-      pcall_err(api.nvim_win_set_config, winid, { split = 'right', bufpos = { 0, 0 } })
-    )
+    eq("non-float cannot have 'row'", pcall_err(api.nvim_win_set_config, winid, { split = 'right', row = 10 }))
+    eq("non-float cannot have 'col'", pcall_err(api.nvim_win_set_config, winid, { split = 'right', col = 10 }))
+    eq("non-float cannot have 'bufpos'", pcall_err(api.nvim_win_set_config, winid, { split = 'right', bufpos = { 0, 0 } }))
   end)
 
   it('error message when reconfig missing relative field', function()
@@ -517,8 +508,8 @@ describe('float window', function()
     eq(winids, eval('winids'))
   end)
 
-  it("open does not trigger BufEnter #15300", function()
-    local res = exec_lua[[
+  it('open does not trigger BufEnter #15300', function()
+    local res = exec_lua [[
       local times = {}
       local buf = vim.api.nvim_create_buf(fasle, true)
       vim.api.nvim_create_autocmd('BufEnter', {
@@ -554,32 +545,32 @@ describe('float window', function()
 
       return times
     ]]
-    eq({true, 1, true}, res)
+    eq({ true, 1, true }, res)
   end)
 
   it('no crash with bufpos and non-existent window', function()
     command('new')
     local closed_win = api.nvim_get_current_win()
     command('close')
-    local buf = api.nvim_create_buf(false,false)
+    local buf = api.nvim_create_buf(false, false)
     eq(
       'Invalid window id: ' .. closed_win,
-      pcall_err(api.nvim_open_win, buf, true, {relative='win', win=closed_win, width=1, height=1, bufpos={0,0}})
+      pcall_err(api.nvim_open_win, buf, true, { relative = 'win', win = closed_win, width = 1, height = 1, bufpos = { 0, 0 } })
     )
     assert_alive()
   end)
 
   it("no segfault when setting minimal style after clearing local 'fillchars' #19510", function()
-    local float_opts = {relative = 'editor', row = 1, col = 1, width = 1, height = 1}
+    local float_opts = { relative = 'editor', row = 1, col = 1, width = 1, height = 1 }
     local float_win = api.nvim_open_win(0, true, float_opts)
-    api.nvim_set_option_value('fillchars', NIL, {win=float_win})
+    api.nvim_set_option_value('fillchars', NIL, { win = float_win })
     float_opts.style = 'minimal'
     api.nvim_win_set_config(float_win, float_opts)
     assert_alive()
-    end)
+  end)
 
-    it("should re-apply 'style' when present", function()
-    local float_opts = {style = 'minimal', relative = 'editor', row = 1, col = 1, width = 1, height = 1}
+  it("should re-apply 'style' when present", function()
+    local float_opts = { style = 'minimal', relative = 'editor', row = 1, col = 1, width = 1, height = 1 }
     local float_win = api.nvim_open_win(0, true, float_opts)
     api.nvim_set_option_value('number', true, { win = float_win })
     float_opts.row = 2
@@ -588,7 +579,7 @@ describe('float window', function()
   end)
 
   it("should not re-apply 'style' when missing", function()
-    local float_opts = {style = 'minimal', relative = 'editor', row = 1, col = 1, width = 1, height = 1}
+    local float_opts = { style = 'minimal', relative = 'editor', row = 1, col = 1, width = 1, height = 1 }
     local float_win = api.nvim_open_win(0, true, float_opts)
     api.nvim_set_option_value('number', true, { win = float_win })
     float_opts.row = 2
@@ -599,13 +590,13 @@ describe('float window', function()
 
   it("'scroll' is computed correctly when opening float with splitkeep=screen #20684", function()
     api.nvim_set_option_value('splitkeep', 'screen', {})
-    local float_opts = {relative = 'editor', row = 1, col = 1, width = 10, height = 10}
+    local float_opts = { relative = 'editor', row = 1, col = 1, width = 10, height = 10 }
     local float_win = api.nvim_open_win(0, true, float_opts)
-    eq(5, api.nvim_get_option_value('scroll', {win=float_win}))
+    eq(5, api.nvim_get_option_value('scroll', { win = float_win }))
   end)
 
   it(':unhide works when there are floating windows', function()
-    local float_opts = {relative = 'editor', row = 1, col = 1, width = 5, height = 5}
+    local float_opts = { relative = 'editor', row = 1, col = 1, width = 5, height = 5 }
     local w0 = curwin()
     api.nvim_open_win(0, false, float_opts)
     api.nvim_open_win(0, false, float_opts)
@@ -616,7 +607,7 @@ describe('float window', function()
 
   it(':all works when there are floating windows', function()
     command('args Xa.txt')
-    local float_opts = {relative = 'editor', row = 1, col = 1, width = 5, height = 5}
+    local float_opts = { relative = 'editor', row = 1, col = 1, width = 5, height = 5 }
     local w0 = curwin()
     api.nvim_open_win(0, false, float_opts)
     api.nvim_open_win(0, false, float_opts)
@@ -627,23 +618,23 @@ describe('float window', function()
 
   it('win_splitmove() can move float into a split', function()
     command('split')
-    eq({'col', {{'leaf', 1001}, {'leaf', 1000}}}, fn.winlayout())
+    eq({ 'col', { { 'leaf', 1001 }, { 'leaf', 1000 } } }, fn.winlayout())
 
-    local win1 = api.nvim_open_win(0, true, {relative = 'editor', row = 1, col = 1, width = 5, height = 5})
-    fn.win_splitmove(win1, 1001, {vertical = true})
-    eq({'col', {{'row', {{'leaf', win1}, {'leaf', 1001}}}, {'leaf', 1000}}}, fn.winlayout())
+    local win1 = api.nvim_open_win(0, true, { relative = 'editor', row = 1, col = 1, width = 5, height = 5 })
+    fn.win_splitmove(win1, 1001, { vertical = true })
+    eq({ 'col', { { 'row', { { 'leaf', win1 }, { 'leaf', 1001 } } }, { 'leaf', 1000 } } }, fn.winlayout())
     eq('', api.nvim_win_get_config(win1).relative)
 
     -- Should be unable to create a split relative to a float, though.
-    local win2 = api.nvim_open_win(0, true, {relative = 'editor', row = 1, col = 1, width = 5, height = 5})
-    eq('Vim:E957: Invalid window number', pcall_err(fn.win_splitmove, win1, win2, {vertical = true}))
+    local win2 = api.nvim_open_win(0, true, { relative = 'editor', row = 1, col = 1, width = 5, height = 5 })
+    eq('Vim:E957: Invalid window number', pcall_err(fn.win_splitmove, win1, win2, { vertical = true }))
   end)
 
   it('tp_curwin updated if external window is moved into split', function()
     local _ = Screen.new(20, 7, { ext_multigrid = true })
 
     command('tabnew')
-    local external_win = api.nvim_open_win(0, true, {external = true, width = 5, height = 5})
+    local external_win = api.nvim_open_win(0, true, { external = true, width = 5, height = 5 })
     eq(external_win, api.nvim_get_current_win())
     eq(2, fn.tabpagenr())
     command('tabfirst')
@@ -676,7 +667,7 @@ describe('float window', function()
   end)
 
   describe('with only one tabpage,', function()
-    local float_opts = {relative = 'editor', row = 1, col = 1, width = 1, height = 1}
+    local float_opts = { relative = 'editor', row = 1, col = 1, width = 1, height = 1 }
     local old_buf, old_win
     before_each(function()
       insert('foo')
@@ -689,12 +680,10 @@ describe('float window', function()
       end)
       it('if called from non-floating window', function()
         api.nvim_set_current_win(old_win)
-        eq('Vim:E444: Cannot close last window',
-           pcall_err(api.nvim_win_close, old_win, false))
+        eq('Vim:E444: Cannot close last window', pcall_err(api.nvim_win_close, old_win, false))
       end)
       it('if called from floating window', function()
-        eq('Vim:E444: Cannot close last window',
-           pcall_err(api.nvim_win_close, old_win, false))
+        eq('Vim:E444: Cannot close last window', pcall_err(api.nvim_win_close, old_win, false))
       end)
     end)
     describe("deleting the last non-floating window's buffer", function()
@@ -709,13 +698,13 @@ describe('float window', function()
           eq(1, #api.nvim_list_wins())
         end)
         it('if called from non-floating window', function()
-          api.nvim_buf_delete(old_buf, {force = true})
+          api.nvim_buf_delete(old_buf, { force = true })
         end)
         it('if called from floating window', function()
           api.nvim_set_current_win(same_buf_float)
           command('autocmd WinLeave * let g:win_leave = nvim_get_current_win()')
           command('autocmd WinEnter * let g:win_enter = nvim_get_current_win()')
-          api.nvim_buf_delete(old_buf, {force = true})
+          api.nvim_buf_delete(old_buf, { force = true })
           eq(same_buf_float, eval('g:win_leave'))
           eq(old_win, eval('g:win_enter'))
         end)
@@ -735,14 +724,14 @@ describe('float window', function()
           eq(2, #api.nvim_list_wins())
         end)
         it('if called from non-floating window', function()
-          api.nvim_buf_delete(old_buf, {force = true})
+          api.nvim_buf_delete(old_buf, { force = true })
           eq(old_win, curwin())
         end)
         it('if called from floating window with the same buffer', function()
           api.nvim_set_current_win(same_buf_float)
           command('autocmd WinLeave * let g:win_leave = nvim_get_current_win()')
           command('autocmd WinEnter * let g:win_enter = nvim_get_current_win()')
-          api.nvim_buf_delete(old_buf, {force = true})
+          api.nvim_buf_delete(old_buf, { force = true })
           eq(same_buf_float, eval('g:win_leave'))
           eq(old_win, eval('g:win_enter'))
           eq(old_win, curwin())
@@ -750,7 +739,7 @@ describe('float window', function()
         -- TODO: this case is too hard to deal with
         pending('if called from floating window with another buffer', function()
           api.nvim_set_current_win(other_buf_float)
-          api.nvim_buf_delete(old_buf, {force = true})
+          api.nvim_buf_delete(old_buf, { force = true })
         end)
       end)
       describe('creates an empty buffer when there is only one listed buffer', function()
@@ -768,14 +757,14 @@ describe('float window', function()
           eq(2, #api.nvim_list_wins())
         end)
         it('if called from non-floating window', function()
-          api.nvim_buf_delete(old_buf, {force = true})
+          api.nvim_buf_delete(old_buf, { force = true })
           eq(old_win, curwin())
         end)
         it('if called from floating window with the same buffer', function()
           api.nvim_set_current_win(same_buf_float)
           command('autocmd WinLeave * let g:win_leave = nvim_get_current_win()')
           command('autocmd WinEnter * let g:win_enter = nvim_get_current_win()')
-          api.nvim_buf_delete(old_buf, {force = true})
+          api.nvim_buf_delete(old_buf, { force = true })
           eq(same_buf_float, eval('g:win_leave'))
           eq(old_win, eval('g:win_enter'))
           eq(old_win, curwin())
@@ -783,7 +772,7 @@ describe('float window', function()
         -- TODO: this case is too hard to deal with
         pending('if called from floating window with an unlisted buffer', function()
           api.nvim_set_current_win(unlisted_buf_float)
-          api.nvim_buf_delete(old_buf, {force = true})
+          api.nvim_buf_delete(old_buf, { force = true })
         end)
       end)
     end)
@@ -802,12 +791,12 @@ describe('float window', function()
           eq(2, #api.nvim_list_wins())
         end)
         it('if called from non-floating window with the deleted buffer', function()
-          api.nvim_buf_delete(old_buf, {force = true})
+          api.nvim_buf_delete(old_buf, { force = true })
           eq(old_win, curwin())
         end)
         it('if called from floating window with the deleted buffer', function()
           api.nvim_set_current_win(same_buf_float)
-          api.nvim_buf_delete(old_buf, {force = true})
+          api.nvim_buf_delete(old_buf, { force = true })
           eq(same_buf_float, curwin())
         end)
       end)
@@ -815,7 +804,7 @@ describe('float window', function()
   end)
 
   describe('with multiple tabpages but only one listed buffer,', function()
-    local float_opts = {relative = 'editor', row = 1, col = 1, width = 1, height = 1}
+    local float_opts = { relative = 'editor', row = 1, col = 1, width = 1, height = 1 }
     local unlisted_buf, old_buf, old_win
     before_each(function()
       insert('unlisted')
@@ -838,19 +827,19 @@ describe('float window', function()
         eq(2, #api.nvim_list_tabpages())
       end)
       it('if called from non-floating window', function()
-        api.nvim_buf_delete(old_buf, {force = true})
+        api.nvim_buf_delete(old_buf, { force = true })
         eq(old_win, curwin())
       end)
       it('if called from non-floating window in another tabpage', function()
         command('tab split')
         eq(3, #api.nvim_list_tabpages())
-        api.nvim_buf_delete(old_buf, {force = true})
+        api.nvim_buf_delete(old_buf, { force = true })
       end)
       it('if called from floating window with the same buffer', function()
         api.nvim_set_current_win(same_buf_float)
         command('autocmd WinLeave * let g:win_leave = nvim_get_current_win()')
         command('autocmd WinEnter * let g:win_enter = nvim_get_current_win()')
-        api.nvim_buf_delete(old_buf, {force = true})
+        api.nvim_buf_delete(old_buf, { force = true })
         eq(same_buf_float, eval('g:win_leave'))
         eq(old_win, eval('g:win_enter'))
         eq(old_win, curwin())
@@ -870,19 +859,19 @@ describe('float window', function()
         eq(2, #api.nvim_list_tabpages())
       end)
       it('if called from non-floating window with the deleted buffer', function()
-        api.nvim_buf_delete(old_buf, {force = true})
+        api.nvim_buf_delete(old_buf, { force = true })
         eq(old_win, curwin())
       end)
       it('if called from floating window with the deleted buffer', function()
         api.nvim_set_current_win(same_buf_float)
-        api.nvim_buf_delete(old_buf, {force = true})
+        api.nvim_buf_delete(old_buf, { force = true })
         eq(same_buf_float, curwin())
       end)
     end)
   end)
 
   describe('with multiple tabpages and multiple listed buffers,', function()
-    local float_opts = {relative = 'editor', row = 1, col = 1, width = 1, height = 1}
+    local float_opts = { relative = 'editor', row = 1, col = 1, width = 1, height = 1 }
     local old_tabpage, old_buf, old_win
     before_each(function()
       old_tabpage = curtab()
@@ -920,13 +909,11 @@ describe('float window', function()
           api.nvim_set_current_win(old_win)
         end)
         it('if called from non-floating window', function()
-          eq('Vim:E5601: Cannot close window, only floating window would remain',
-             pcall_err(api.nvim_win_close, old_win, false))
+          eq('Vim:E5601: Cannot close window, only floating window would remain', pcall_err(api.nvim_win_close, old_win, false))
         end)
         it('if called from floating window', function()
           api.nvim_set_current_win(other_buf_float)
-          eq('Vim:E5601: Cannot close window, only floating window would remain',
-             pcall_err(api.nvim_win_close, old_win, false))
+          eq('Vim:E5601: Cannot close window, only floating window would remain', pcall_err(api.nvim_win_close, old_win, false))
         end)
       end)
     end)
@@ -945,16 +932,16 @@ describe('float window', function()
           eq(1, #api.nvim_list_tabpages())
         end)
         it('if called from non-floating window', function()
-          api.nvim_buf_delete(old_buf, {force = false})
+          api.nvim_buf_delete(old_buf, { force = false })
         end)
         it('if called from floating window with the same buffer', function()
           api.nvim_set_current_win(same_buf_float)
-          api.nvim_buf_delete(old_buf, {force = false})
+          api.nvim_buf_delete(old_buf, { force = false })
         end)
         -- TODO: this case is too hard to deal with
         pending('if called from floating window with another buffer', function()
           api.nvim_set_current_win(other_buf_float)
-          api.nvim_buf_delete(old_buf, {force = false})
+          api.nvim_buf_delete(old_buf, { force = false })
         end)
       end)
       -- TODO: what to do when there are non-closeable floating windows?
@@ -1106,52 +1093,58 @@ describe('float window', function()
   local function with_ext_multigrid(multigrid)
     local screen, attrs
     before_each(function()
-      screen = Screen.new(40,7, {ext_multigrid=multigrid})
+      screen = Screen.new(40, 7, { ext_multigrid = multigrid })
       attrs = {
-        [0] = {bold=true, foreground=Screen.colors.Blue},
-        [1] = {background = Screen.colors.LightMagenta},
-        [2] = {background = Screen.colors.LightMagenta, bold = true, foreground = Screen.colors.Blue1},
-        [3] = {bold = true},
-        [4] = {bold = true, reverse = true},
-        [5] = {reverse = true},
-        [6] = {background = Screen.colors.LightMagenta, bold = true, reverse = true},
-        [7] = {foreground = Screen.colors.White, background = Screen.colors.Red},
-        [8] = {bold = true, foreground = Screen.colors.SeaGreen4},
-        [9] = {background = Screen.colors.LightGrey, underline = true},
-        [10] = {background = Screen.colors.LightGrey, underline = true, bold = true, foreground = Screen.colors.Magenta},
-        [11] = {bold = true, foreground = Screen.colors.Magenta},
-        [12] = {background = Screen.colors.Red, bold = true, foreground = Screen.colors.Blue1},
-        [13] = {background = Screen.colors.WebGray},
-        [14] = {foreground = Screen.colors.Brown},
-        [15] = {background = Screen.colors.Grey20},
-        [16] = {background = Screen.colors.Grey20, bold = true, foreground = Screen.colors.Blue1},
-        [17] = {background = Screen.colors.Yellow},
-        [18] = {foreground = Screen.colors.Brown, background = Screen.colors.Grey20},
-        [19] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.WebGray},
-        [20] = {bold = true, foreground = Screen.colors.Brown},
-        [21] = {background = Screen.colors.Gray90},
-        [22] = {background = Screen.colors.LightRed},
-        [23] = {foreground = Screen.colors.Black, background = Screen.colors.White};
-        [24] = {foreground = Screen.colors.Black, background = Screen.colors.Grey80};
-        [25] = {blend = 100, background = Screen.colors.Gray0};
-        [26] = {blend = 80, background = Screen.colors.Gray0};
-        [27] = {foreground = Screen.colors.Black, background = Screen.colors.LightGrey};
-        [28] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.LightGrey};
-        [29] = {background = Screen.colors.Yellow1, foreground = Screen.colors.Blue4};
-        [30] = {background = Screen.colors.Grey, foreground = Screen.colors.Blue4, bold = true};
+        [0] = { bold = true, foreground = Screen.colors.Blue },
+        [1] = { background = Screen.colors.LightMagenta },
+        [2] = { background = Screen.colors.LightMagenta, bold = true, foreground = Screen.colors.Blue1 },
+        [3] = { bold = true },
+        [4] = { bold = true, reverse = true },
+        [5] = { reverse = true },
+        [6] = { background = Screen.colors.LightMagenta, bold = true, reverse = true },
+        [7] = { foreground = Screen.colors.White, background = Screen.colors.Red },
+        [8] = { bold = true, foreground = Screen.colors.SeaGreen4 },
+        [9] = { background = Screen.colors.LightGrey, underline = true },
+        [10] = {
+          background = Screen.colors.LightGrey,
+          underline = true,
+          bold = true,
+          foreground = Screen.colors.Magenta,
+        },
+        [11] = { bold = true, foreground = Screen.colors.Magenta },
+        [12] = { background = Screen.colors.Red, bold = true, foreground = Screen.colors.Blue1 },
+        [13] = { background = Screen.colors.WebGray },
+        [14] = { foreground = Screen.colors.Brown },
+        [15] = { background = Screen.colors.Grey20 },
+        [16] = { background = Screen.colors.Grey20, bold = true, foreground = Screen.colors.Blue1 },
+        [17] = { background = Screen.colors.Yellow },
+        [18] = { foreground = Screen.colors.Brown, background = Screen.colors.Grey20 },
+        [19] = { foreground = Screen.colors.DarkBlue, background = Screen.colors.WebGray },
+        [20] = { bold = true, foreground = Screen.colors.Brown },
+        [21] = { background = Screen.colors.Gray90 },
+        [22] = { background = Screen.colors.LightRed },
+        [23] = { foreground = Screen.colors.Black, background = Screen.colors.White },
+        [24] = { foreground = Screen.colors.Black, background = Screen.colors.Grey80 },
+        [25] = { blend = 100, background = Screen.colors.Gray0 },
+        [26] = { blend = 80, background = Screen.colors.Gray0 },
+        [27] = { foreground = Screen.colors.Black, background = Screen.colors.LightGrey },
+        [28] = { foreground = Screen.colors.DarkBlue, background = Screen.colors.LightGrey },
+        [29] = { background = Screen.colors.Yellow1, foreground = Screen.colors.Blue4 },
+        [30] = { background = Screen.colors.Grey, foreground = Screen.colors.Blue4, bold = true },
       }
       screen:set_default_attr_ids(attrs)
     end)
 
     it('can be created and reconfigured', function()
-      local buf = api.nvim_create_buf(false,false)
-      local win = api.nvim_open_win(buf, false, {relative='editor', width=20, height=2, row=2, col=5})
+      local buf = api.nvim_create_buf(false, false)
+      local win = api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 2, row = 2, col = 5 })
       local expected_pos = {
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 },
+        [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
       }
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -1163,7 +1156,9 @@ describe('float window', function()
         ## grid 4
           {1:                    }|
           {2:~                   }|
-        ]], float_pos=expected_pos}
+        ]],
+          float_pos = expected_pos,
+        }
       else
         screen:expect([[
           ^                                        |
@@ -1175,14 +1170,14 @@ describe('float window', function()
           ]])
       end
 
-
-      api.nvim_win_set_config(win, {relative='editor', row=0, col=10})
+      api.nvim_win_set_config(win, { relative = 'editor', row = 0, col = 10 })
       expected_pos[4][4] = 0
       expected_pos[4][5] = 10
       expected_pos[4][9] = 0
       expected_pos[4][10] = 10
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -1194,7 +1189,9 @@ describe('float window', function()
         ## grid 4
           {1:                    }|
           {2:~                   }|
-        ]], float_pos=expected_pos}
+        ]],
+          float_pos = expected_pos,
+        }
       else
         screen:expect([[
           ^          {1:                    }          |
@@ -1227,12 +1224,20 @@ describe('float window', function()
 
     it('window position fixed', function()
       command('rightbelow 20vsplit')
-      local buf = api.nvim_create_buf(false,false)
+      local buf = api.nvim_create_buf(false, false)
       local win = api.nvim_open_win(buf, false, {
-        relative='win', width=15, height=2, row=2, col=10, anchor='NW', fixed=true})
+        relative = 'win',
+        width = 15,
+        height = 2,
+        row = 2,
+        col = 10,
+        anchor = 'NW',
+        fixed = true,
+      })
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:-------------------]{5:│}[4:--------------------]|*5
           {5:[No Name]           }{4:[No Name]           }|
@@ -1248,9 +1253,11 @@ describe('float window', function()
         ## grid 5
           {1:               }|
           {2:~              }|
-        ]], float_pos={
-          [5] = { 1002, "NW", 4, 2, 10, true, 50, 1, 2, 30 };
-        }}
+        ]],
+          float_pos = {
+            [5] = { 1002, 'NW', 4, 2, 10, true, 50, 1, 2, 30 },
+          },
+        }
       else
         screen:expect([[
                              {5:│}^                    |
@@ -1263,10 +1270,11 @@ describe('float window', function()
         ]])
       end
 
-      api.nvim_win_set_config(win, {fixed=false})
+      api.nvim_win_set_config(win, { fixed = false })
 
       if multigrid then
-        screen:expect{grid = [[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:-------------------]{5:│}[4:--------------------]|*5
           {5:[No Name]           }{4:[No Name]           }|
@@ -1282,9 +1290,11 @@ describe('float window', function()
         ## grid 5
           {1:               }|
           {2:~              }|
-        ]], float_pos={
-          [5] = {1002, "NW", 4, 2, 10, true, 50, 1, 2, 25};
-        }}
+        ]],
+          float_pos = {
+            [5] = { 1002, 'NW', 4, 2, 10, true, 50, 1, 2, 25 },
+          },
+        }
       else
         screen:expect([[
                              {5:│}^                    |
@@ -1303,16 +1313,17 @@ describe('float window', function()
       -- (as it is intermediate only, and is allowed to change by internal
       -- refactors). Only check that it doesn't cause permanent glitches,
       -- or something.
-      command("set redrawdebug=compositor")
-      command("set wd=1")
-      local buf = api.nvim_create_buf(false,false)
-      local win = api.nvim_open_win(buf, false, {relative='editor', width=20, height=2, row=2, col=5})
+      command('set redrawdebug=compositor')
+      command('set wd=1')
+      local buf = api.nvim_create_buf(false, false)
+      local win = api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 2, row = 2, col = 5 })
       local expected_pos = {
-        [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 },
+        [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
       }
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -1324,7 +1335,9 @@ describe('float window', function()
         ## grid 4
           {1:                    }|
           {2:~                   }|
-        ]], float_pos=expected_pos}
+        ]],
+          float_pos = expected_pos,
+        }
       else
         screen:expect([[
           ^                                        |
@@ -1336,14 +1349,14 @@ describe('float window', function()
           ]])
       end
 
-
-      api.nvim_win_set_config(win, {relative='editor', row=0, col=10})
+      api.nvim_win_set_config(win, { relative = 'editor', row = 0, col = 10 })
       expected_pos[4][4] = 0
       expected_pos[4][5] = 10
       expected_pos[4][9] = 0
       expected_pos[4][10] = 10
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -1355,7 +1368,9 @@ describe('float window', function()
         ## grid 4
           {1:                    }|
           {2:~                   }|
-        ]], float_pos=expected_pos}
+        ]],
+          float_pos = expected_pos,
+        }
       else
         screen:expect([[
           ^          {1:                    }          |
@@ -1388,10 +1403,25 @@ describe('float window', function()
 
     it('return their configuration', function()
       local buf = api.nvim_create_buf(false, false)
-      local win = api.nvim_open_win(buf, false, {relative='editor', width=20, height=2, row=3, col=5, zindex=60})
-      local expected = {anchor='NW', col=5, external=false, focusable=true, mouse=true, height=2, relative='editor', row=3, width=20, zindex=60, hide=false}
+      local win = api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 2, row = 3, col = 5, zindex = 60 })
+      local expected = {
+        anchor = 'NW',
+        col = 5,
+        external = false,
+        focusable = true,
+        mouse = true,
+        height = 2,
+        relative = 'editor',
+        row = 3,
+        width = 20,
+        zindex = 60,
+        hide = false,
+      }
       eq(expected, api.nvim_win_get_config(win))
-      eq(true, exec_lua([[
+      eq(
+        true,
+        exec_lua(
+          [[
         local expected, win = ...
         local actual = vim.api.nvim_win_get_config(win)
         for k,v in pairs(expected) do
@@ -1399,13 +1429,23 @@ describe('float window', function()
             error(k)
           end
         end
-        return true]], expected, win))
+        return true]],
+          expected,
+          win
+        )
+      )
 
-      eq({external=false, focusable=true, mouse=true, hide=false, relative='',split="left",width=40,height=6}, api.nvim_win_get_config(0))
+      eq(
+        { external = false, focusable = true, mouse = true, hide = false, relative = '', split = 'left', width = 40, height = 6 },
+        api.nvim_win_get_config(0)
+      )
 
       if multigrid then
-        api.nvim_win_set_config(win, {external=true, width=10, height=1})
-        eq({external=true,focusable=true,mouse=true,width=10,height=1,relative='',hide=false}, api.nvim_win_get_config(win))
+        api.nvim_win_set_config(win, { external = true, width = 10, height = 1 })
+        eq(
+          { external = true, focusable = true, mouse = true, width = 10, height = 1, relative = '', hide = false },
+          api.nvim_win_get_config(win)
+        )
       end
     end)
 
@@ -1413,9 +1453,10 @@ describe('float window', function()
       command('set number')
       command('hi NormalFloat guibg=#333333 guifg=NONE')
       feed('ix<cr>y<cr><esc>gg')
-      local win = api.nvim_open_win(0, false, {relative='editor', width=20, height=4, row=4, col=10})
+      local win = api.nvim_open_win(0, false, { relative = 'editor', width = 20, height = 4, row = 4, col = 10 })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -1431,7 +1472,9 @@ describe('float window', function()
           {18:  2 }{15:y               }|
           {18:  3 }{15:                }|
           {16:~                   }|
-        ]], float_pos = {[4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10}}}
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
+        }
       else
         screen:expect([[
           {14:  1 }^x                                   |
@@ -1447,7 +1490,8 @@ describe('float window', function()
       local buf = api.nvim_create_buf(false, true)
       api.nvim_win_set_buf(win, buf)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -1461,7 +1505,9 @@ describe('float window', function()
         ## grid 4
           {18:  1 }{15:                }|
           {16:~                   }|*3
-        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10}}}
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
+        }
       else
         screen:expect([[
           {14:  1 }^x                                   |
@@ -1496,15 +1542,19 @@ describe('float window', function()
             {22:x           }|
             {22:y           }|
             {22:            }|
-          ]], float_pos={
-          [5] = {1002, "NW", 2, 3, 3, true, 50, 1, 3, 3};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 4, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
-          [5] = {win = 1002, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
-        }, win_viewport_margins={
-          [2] = { bottom = 0, left = 0, right = 0, top = 0, win = 1000 },
-          [5] = { bottom = 0, left = 0, right = 0, top = 0, win = 1002 }
-        }})
+          ]],
+          float_pos = {
+            [5] = { 1002, 'NW', 2, 3, 3, true, 50, 1, 3, 3 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 4, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
+            [5] = { win = 1002, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
+          },
+          win_viewport_margins = {
+            [2] = { bottom = 0, left = 0, right = 0, top = 0, win = 1000 },
+            [5] = { bottom = 0, left = 0, right = 0, top = 0, win = 1002 },
+          },
+        })
       else
         screen:expect({
           grid = [[
@@ -1515,7 +1565,7 @@ describe('float window', function()
             {0:~  }{22:y           }{0:                         }|
             {0:~  }{22:            }{0:                         }|
                                                     |
-          ]]
+          ]],
         })
       end
     end)
@@ -1528,9 +1578,10 @@ describe('float window', function()
       command('set foldcolumn=1')
       command('hi NormalFloat guibg=#333333 guifg=NONE')
       feed('ix<cr>y<cr><esc>gg')
-      local win = api.nvim_open_win(0, false, {relative='editor', width=20, height=4, row=4, col=10, style='minimal'})
+      local win = api.nvim_open_win(0, false, { relative = 'editor', width = 20, height = 4, row = 4, col = 10, style = 'minimal' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -1545,23 +1596,28 @@ describe('float window', function()
           {15:x                   }|
           {15:y                   }|
           {15:                    }|*2
-        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10}}}
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           {19:   }{20:  1 }{22:^x}{21:                                }|
           {19:   }{14:  2 }{22:y}                                |
           {19:   }{14:  3 }{22: }  {15:x                   }          |
           {0:~         }{15:y                   }{0:          }|
           {0:~         }{15:                    }{0:          }|*2
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       --  signcolumn=yes still works if there actually are signs
       command('sign define piet1 text=𐌢̀́̂̃̅̄𐌢̀́̂̃̅̄ texthl=Search')
       command('sign place 1 line=1 name=piet1 buffer=1')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -1577,8 +1633,9 @@ describe('float window', function()
           {19:  }{15:y                 }|
           {19:  }{15:                  }|
           {15:                    }|
-        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10}}}
-
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
+        }
       else
         screen:expect([[
           {19: }{29:𐌢̀́̂̃̅̄𐌢̀́̂̃̅̄}{20:  1 }{22:^x}{21:                                }|
@@ -1595,7 +1652,8 @@ describe('float window', function()
       local buf = api.nvim_create_buf(false, true)
       api.nvim_win_set_buf(win, buf)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -1608,7 +1666,9 @@ describe('float window', function()
                                                   |
         ## grid 4
           {15:                    }|*4
-        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10}}}
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
+        }
       else
         screen:expect([[
           {19:   }{20:  1 }{22:^x}{21:                                }|
@@ -1628,9 +1688,10 @@ describe('float window', function()
       command('set foldcolumn=1')
       command('hi NormalFloat guibg=#333333 guifg=NONE')
       feed('ix<cr>y<cr><esc>gg')
-      local win = api.nvim_open_win(0, false, {relative='editor', width=20, height=4, row=4, col=10, style='minimal'})
+      local win = api.nvim_open_win(0, false, { relative = 'editor', width = 20, height = 4, row = 4, col = 10, style = 'minimal' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -1645,23 +1706,28 @@ describe('float window', function()
           {15:x                   }|
           {15:y                   }|
           {15:                    }|*2
-        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10}}}
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           {19:   }{20:  1 }{22:^x}{21:                                }|
           {19:   }{14:  2 }{22:y}                                |
           {19:   }{14:  3 }{22: }  {15:x                   }          |
           {0:~         }{15:y                   }{0:          }|
           {0:~         }{15:                    }{0:          }|*2
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       command('sign define piet1 text=𐌢̀́̂̃̅̄𐌢̀́̂̃̅̄ texthl=Search')
       command('sign place 1 line=1 name=piet1 buffer=1')
       --  signcolumn=auto:1-3 still works if there actually are signs
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -1677,8 +1743,9 @@ describe('float window', function()
           {19:  }{15:y                 }|
           {19:  }{15:                  }|
           {15:                    }|
-        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10}}}
-
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
+        }
       else
         screen:expect([[
           {19: }{29:𐌢̀́̂̃̅̄𐌢̀́̂̃̅̄}{20:  1 }{22:^x}{21:                                }|
@@ -1695,7 +1762,8 @@ describe('float window', function()
       local buf = api.nvim_create_buf(false, true)
       api.nvim_win_set_buf(win, buf)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -1708,7 +1776,9 @@ describe('float window', function()
                                                   |
         ## grid 4
           {15:                    }|*4
-        ]], float_pos={[4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10}}}
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
+        }
       else
         screen:expect([[
           {19:   }{20:  1 }{22:^x}{21:                                }|
@@ -1729,7 +1799,7 @@ describe('float window', function()
       command('set statuscolumn=%l%s%C')
       command('hi NormalFloat guibg=#333333 guifg=NONE')
       feed('ix<cr>y<cr><esc>gg')
-      api.nvim_open_win(0, false, {relative='editor', width=20, height=4, row=4, col=10, style='minimal'})
+      api.nvim_open_win(0, false, { relative = 'editor', width = 20, height = 4, row = 4, col = 10, style = 'minimal' })
       if multigrid then
         screen:expect({
           grid = [[
@@ -1748,7 +1818,7 @@ describe('float window', function()
             {15:y                   }|
             {15:                    }|*2
           ]],
-          float_pos = { [4] = {1001, "NW", 1, 4, 10, true, 50, 1, 2, 10} },
+          float_pos = { [4] = { 1001, 'NW', 1, 4, 10, true, 50, 1, 2, 10 } },
         })
       else
         screen:expect([[
@@ -1764,25 +1834,28 @@ describe('float window', function()
 
     it('can have border', function()
       local buf = api.nvim_create_buf(false, false)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {' halloj! ',
-                                             ' BORDAA  '})
-      local win = api.nvim_open_win(buf, false, {relative='editor', width=9, height=2, row=2, col=5, border="double"})
+      api.nvim_buf_set_lines(buf, 0, -1, true, { ' halloj! ', ' BORDAA  ' })
+      local win = api.nvim_open_win(buf, false, { relative = 'editor', width = 9, height = 2, row = 2, col = 5, border = 'double' })
       eq('╔', api.nvim_win_get_config(win).border[1])
 
-      api.nvim_win_set_config(win, {border="single"})
+      api.nvim_win_set_config(win, { border = 'single' })
       eq('┌', api.nvim_win_get_config(win).border[1])
 
-      api.nvim_win_set_config(win, {border="rounded"})
+      api.nvim_win_set_config(win, { border = 'rounded' })
       eq('╭', api.nvim_win_get_config(win).border[1])
 
-      api.nvim_win_set_config(win, {border="solid"})
+      api.nvim_win_set_config(win, { border = 'solid' })
       eq(' ', api.nvim_win_get_config(win).border[1])
 
       -- support: ascii char, UTF-8 char, composed char, highlight per char
-      api.nvim_win_set_config(win, {border={"x", {"å", "ErrorMsg"}, {"\\"}, {"n̈̊", "Search"}}})
-      eq({"x", {"å", "ErrorMsg"}, "\\", {"n̈̊", "Search"}, "x", {"å", "ErrorMsg"}, "\\", {"n̈̊", "Search"}}, api.nvim_win_get_config(win).border)
+      api.nvim_win_set_config(win, { border = { 'x', { 'å', 'ErrorMsg' }, { '\\' }, { 'n̈̊', 'Search' } } })
+      eq(
+        { 'x', { 'å', 'ErrorMsg' }, '\\', { 'n̈̊', 'Search' }, 'x', { 'å', 'ErrorMsg' }, '\\', { 'n̈̊', 'Search' } },
+        api.nvim_win_get_config(win).border
+      )
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -1796,14 +1869,18 @@ describe('float window', function()
           {17:n̈̊}{1: halloj! }{17:n̈̊}|
           {17:n̈̊}{1: BORDAA  }{17:n̈̊}|
           {5:\}{7:ååååååååå}{5:x}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{5:x}{7:ååååååååå}{5:\}{0:                        }|
@@ -1811,16 +1888,18 @@ describe('float window', function()
           {0:~    }{17:n̈̊}{1: BORDAA  }{17:n̈̊}{0:                        }|
           {0:~    }{5:\}{7:ååååååååå}{5:x}{0:                        }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
-      api.nvim_win_set_config(win, {border="none"})
+      api.nvim_win_set_config(win, { border = 'none' })
       eq(nil, api.nvim_win_get_config(win).border)
 
-      api.nvim_win_set_config(win, {border={"", "", "", ">", "", "", "", "<"}})
-      eq({"", "", "", ">", "", "", "", "<"}, api.nvim_win_get_config(win).border)
+      api.nvim_win_set_config(win, { border = { '', '', '', '>', '', '', '', '<' } })
+      eq({ '', '', '', '>', '', '', '', '<' }, api.nvim_win_get_config(win).border)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -1832,32 +1911,37 @@ describe('float window', function()
         ## grid 4
           {5:<}{1: halloj! }{5:>}|
           {5:<}{1: BORDAA  }{5:>}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        },
-        win_viewport_margins={
-          [2] = {win = 1000, top = 0, bottom = 0, left = 0, right = 0};
-          [4] = {win = 1001, top = 0, bottom = 0, left = 1, right = 1};
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+          win_viewport_margins = {
+            [2] = { win = 1000, top = 0, bottom = 0, left = 0, right = 0 },
+            [4] = { win = 1001, top = 0, bottom = 0, left = 1, right = 1 },
+          },
         }
-      }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{5:<}{1: halloj! }{5:>}{0:                        }|
           {0:~    }{5:<}{1: BORDAA  }{5:>}{0:                        }|
           {0:~                                       }|*2
                                                   |
-        ]]}
+        ]],
+        }
       end
 
-      api.nvim_win_set_config(win, {border={"", "_", "", "", "", "-", "", ""}})
-      eq({"", "_", "", "", "", "-", "", ""}, api.nvim_win_get_config(win).border)
+      api.nvim_win_set_config(win, { border = { '', '_', '', '', '', '-', '', '' } })
+      eq({ '', '_', '', '', '', '-', '', '' }, api.nvim_win_get_config(win).border)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -1871,18 +1955,22 @@ describe('float window', function()
           {1: halloj! }|
           {1: BORDAA  }|
           {5:---------}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        },
-        win_viewport_margins={
-          [2] = {win = 1000, top = 0, bottom = 0, left = 0, right = 0};
-          [4] = {win = 1001, top = 1, bottom = 1, left = 0, right = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+          win_viewport_margins = {
+            [2] = { win = 1000, top = 0, bottom = 0, left = 0, right = 0 },
+            [4] = { win = 1001, top = 1, bottom = 1, left = 0, right = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{5:_________}{0:                          }|
@@ -1890,7 +1978,8 @@ describe('float window', function()
           {0:~    }{1: BORDAA  }{0:                          }|
           {0:~    }{5:---------}{0:                          }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       insert [[
@@ -1901,9 +1990,10 @@ describe('float window', function()
         of border shadow
       ]]
 
-      api.nvim_win_set_config(win, {border="shadow"})
+      api.nvim_win_set_config(win, { border = 'shadow' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -1920,18 +2010,22 @@ describe('float window', function()
           {1: halloj! }{25: }|
           {1: BORDAA  }{26: }|
           {25: }{26:         }|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 6, curline = 5, curcol = 0, linecount = 6, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        },
-        win_viewport_margins={
-          [2] = {win = 1000, top = 0, bottom = 0, left = 0, right = 0};
-          [4] = {win = 1001, top = 0, bottom = 1, left = 0, right = 1};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 6, curline = 5, curcol = 0, linecount = 6, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+          win_viewport_margins = {
+            [2] = { win = 1000, top = 0, bottom = 0, left = 0, right = 0 },
+            [4] = { win = 1001, top = 0, bottom = 1, left = 0, right = 1 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           neeed some dummy                        |
           background text                         |
           to sh{1: halloj! }{23:f}ect                      |
@@ -1939,17 +2033,25 @@ describe('float window', function()
           of bo{23:r}{24:der shado}w                        |
           ^                                        |
                                                   |
-        ]]}
+        ]],
+        }
       end
     end)
 
     it('validates title title_pos', function()
-      local buf = api.nvim_create_buf(false,false)
-      eq("title_pos requires title to be set",
-         pcall_err(api.nvim_open_win,buf, false, {
-          relative='editor', width=9, height=2, row=2, col=5,
-          border='single', title_pos='left',
-         }))
+      local buf = api.nvim_create_buf(false, false)
+      eq(
+        'title_pos requires title to be set',
+        pcall_err(api.nvim_open_win, buf, false, {
+          relative = 'editor',
+          width = 9,
+          height = 2,
+          row = 2,
+          col = 5,
+          border = 'single',
+          title_pos = 'left',
+        })
+      )
     end)
 
     it('validate title_pos in nvim_win_get_config', function()
@@ -1974,12 +2076,19 @@ describe('float window', function()
     end)
 
     it('validates footer footer_pos', function()
-      local buf = api.nvim_create_buf(false,false)
-      eq("footer_pos requires footer to be set",
-         pcall_err(api.nvim_open_win,buf, false, {
-          relative='editor', width=9, height=2, row=2, col=5,
-          border='single', footer_pos='left',
-         }))
+      local buf = api.nvim_create_buf(false, false)
+      eq(
+        'footer_pos requires footer to be set',
+        pcall_err(api.nvim_open_win, buf, false, {
+          relative = 'editor',
+          width = 9,
+          height = 2,
+          row = 2,
+          col = 5,
+          border = 'single',
+          footer_pos = 'left',
+        })
+      )
     end)
 
     it('validate footer_pos in nvim_win_get_config', function()
@@ -2005,15 +2114,21 @@ describe('float window', function()
 
     it('center aligned title longer than window width #25746', function()
       local buf = api.nvim_create_buf(false, false)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {' halloj! ',
-                                             ' BORDAA  '})
+      api.nvim_buf_set_lines(buf, 0, -1, true, { ' halloj! ', ' BORDAA  ' })
       local win = api.nvim_open_win(buf, false, {
-        relative='editor', width=9, height=2, row=2, col=5, border="double",
-        title = "abcdefghijklmnopqrstuvwxyz",title_pos = "center",
+        relative = 'editor',
+        width = 9,
+        height = 2,
+        row = 2,
+        col = 5,
+        border = 'double',
+        title = 'abcdefghijklmnopqrstuvwxyz',
+        title_pos = 'center',
       })
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -2027,14 +2142,18 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{5:╔}{11:abcdefghi}{5:╗}{0:                        }|
@@ -2042,7 +2161,8 @@ describe('float window', function()
           {0:~    }{5:║}{1: BORDAA  }{5:║}{0:                        }|
           {0:~    }{5:╚═════════╝}{0:                        }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       api.nvim_win_close(win, false)
@@ -2053,8 +2173,13 @@ describe('float window', function()
       local buf = api.nvim_create_buf(false, false)
       api.nvim_buf_set_lines(buf, 0, -1, true, { 'Hello' })
       api.nvim_open_win(buf, false, {
-        relative='editor', width=9, height=2, row=2, col=5,
-        title = 'Title', footer = 'Footer'
+        relative = 'editor',
+        width = 9,
+        height = 2,
+        row = 2,
+        col = 5,
+        title = 'Title',
+        footer = 'Footer',
       })
 
       if multigrid then
@@ -2073,7 +2198,7 @@ describe('float window', function()
             {2:~        }|
           ]],
           float_pos = {
-            [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 },
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
           },
           win_viewport = {
             [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
@@ -2094,15 +2219,21 @@ describe('float window', function()
 
     it('border with title', function()
       local buf = api.nvim_create_buf(false, false)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {' halloj! ',
-                                             ' BORDAA  '})
+      api.nvim_buf_set_lines(buf, 0, -1, true, { ' halloj! ', ' BORDAA  ' })
       local win = api.nvim_open_win(buf, false, {
-        relative='editor', width=9, height=2, row=2, col=5, border="double",
-        title = "Left",title_pos = "left",
+        relative = 'editor',
+        width = 9,
+        height = 2,
+        row = 2,
+        col = 5,
+        border = 'double',
+        title = 'Left',
+        title_pos = 'left',
       })
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -2116,14 +2247,18 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{5:╔}{11:Left}{5:═════╗}{0:                        }|
@@ -2131,12 +2266,14 @@ describe('float window', function()
           {0:~    }{5:║}{1: BORDAA  }{5:║}{0:                        }|
           {0:~    }{5:╚═════════╝}{0:                        }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
-      api.nvim_win_set_config(win, {title= "Center",title_pos="center"})
+      api.nvim_win_set_config(win, { title = 'Center', title_pos = 'center' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -2150,14 +2287,18 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{5:╔═}{11:Center}{5:══╗}{0:                        }|
@@ -2165,12 +2306,14 @@ describe('float window', function()
           {0:~    }{5:║}{1: BORDAA  }{5:║}{0:                        }|
           {0:~    }{5:╚═════════╝}{0:                        }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
-      api.nvim_win_set_config(win, {title= "Right",title_pos="right"})
+      api.nvim_win_set_config(win, { title = 'Right', title_pos = 'right' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -2184,14 +2327,18 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{5:╔════}{11:Right}{5:╗}{0:                        }|
@@ -2199,12 +2346,14 @@ describe('float window', function()
           {0:~    }{5:║}{1: BORDAA  }{5:║}{0:                        }|
           {0:~    }{5:╚═════════╝}{0:                        }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
-      api.nvim_win_set_config(win, {title= { {"🦄"},{"BB"}},title_pos="right"})
+      api.nvim_win_set_config(win, { title = { { '🦄' }, { 'BB' } }, title_pos = 'right' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -2218,14 +2367,18 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{5:╔═════}{11:🦄BB}{5:╗}{0:                        }|
@@ -2233,11 +2386,12 @@ describe('float window', function()
           {0:~    }{5:║}{1: BORDAA  }{5:║}{0:                        }|
           {0:~    }{5:╚═════════╝}{0:                        }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       -- reuse before title pos
-      api.nvim_win_set_config(win, {title= 'new'})
+      api.nvim_win_set_config(win, { title = 'new' })
       if multigrid then
         screen:expect({
           grid = [[
@@ -2256,28 +2410,28 @@ describe('float window', function()
             {5:╚═════════╝}|
           ]],
           float_pos = {
-          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
-        },
-          win_viewport = {
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        },
-          win_viewport_margins = {
-          [2] = {
-            bottom = 0,
-            left = 0,
-            right = 0,
-            top = 0,
-            win = 1000
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
           },
-          [4] = {
-            bottom = 1,
-            left = 1,
-            right = 1,
-            top = 1,
-            win = 1001
-          }
-        },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+          win_viewport_margins = {
+            [2] = {
+              bottom = 0,
+              left = 0,
+              right = 0,
+              top = 0,
+              win = 1000,
+            },
+            [4] = {
+              bottom = 1,
+              left = 1,
+              right = 1,
+              top = 1,
+              win = 1001,
+            },
+          },
         })
       else
         screen:expect([[
@@ -2294,15 +2448,21 @@ describe('float window', function()
 
     it('border with footer', function()
       local buf = api.nvim_create_buf(false, false)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {' halloj! ',
-                                             ' BORDAA  '})
+      api.nvim_buf_set_lines(buf, 0, -1, true, { ' halloj! ', ' BORDAA  ' })
       local win = api.nvim_open_win(buf, false, {
-        relative='editor', width=9, height=2, row=2, col=5, border="double",
-        footer = "Left",footer_pos = "left",
+        relative = 'editor',
+        width = 9,
+        height = 2,
+        row = 2,
+        col = 5,
+        border = 'double',
+        footer = 'Left',
+        footer_pos = 'left',
       })
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -2316,14 +2476,18 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚}{11:Left}{5:═════╝}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{5:╔═════════╗}{0:                        }|
@@ -2331,12 +2495,14 @@ describe('float window', function()
           {0:~    }{5:║}{1: BORDAA  }{5:║}{0:                        }|
           {0:~    }{5:╚}{11:Left}{5:═════╝}{0:                        }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
-      api.nvim_win_set_config(win, {footer= "Center",footer_pos="center"})
+      api.nvim_win_set_config(win, { footer = 'Center', footer_pos = 'center' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -2350,14 +2516,18 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═}{11:Center}{5:══╝}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{5:╔═════════╗}{0:                        }|
@@ -2365,12 +2535,14 @@ describe('float window', function()
           {0:~    }{5:║}{1: BORDAA  }{5:║}{0:                        }|
           {0:~    }{5:╚═}{11:Center}{5:══╝}{0:                        }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
-      api.nvim_win_set_config(win, {footer= "Right",footer_pos="right"})
+      api.nvim_win_set_config(win, { footer = 'Right', footer_pos = 'right' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -2384,14 +2556,18 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚════}{11:Right}{5:╝}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{5:╔═════════╗}{0:                        }|
@@ -2399,12 +2575,14 @@ describe('float window', function()
           {0:~    }{5:║}{1: BORDAA  }{5:║}{0:                        }|
           {0:~    }{5:╚════}{11:Right}{5:╝}{0:                        }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
-      api.nvim_win_set_config(win, {footer= { {"🦄"},{"BB"}},footer_pos="right"})
+      api.nvim_win_set_config(win, { footer = { { '🦄' }, { 'BB' } }, footer_pos = 'right' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -2418,14 +2596,18 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════}{11:🦄BB}{5:╝}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{5:╔═════════╗}{0:                        }|
@@ -2433,7 +2615,8 @@ describe('float window', function()
           {0:~    }{5:║}{1: BORDAA  }{5:║}{0:                        }|
           {0:~    }{5:╚═════}{11:🦄BB}{5:╝}{0:                        }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       -- reuse before footer pos
@@ -2456,28 +2639,28 @@ describe('float window', function()
             {5:╚══════}{11:new}{5:╝}|
           ]],
           float_pos = {
-          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
-        },
-          win_viewport = {
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        },
-          win_viewport_margins = {
-          [2] = {
-            bottom = 0,
-            left = 0,
-            right = 0,
-            top = 0,
-            win = 1000
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
           },
-          [4] = {
-            bottom = 1,
-            left = 1,
-            right = 1,
-            top = 1,
-            win = 1001
-          }
-        },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+          win_viewport_margins = {
+            [2] = {
+              bottom = 0,
+              left = 0,
+              right = 0,
+              top = 0,
+              win = 1000,
+            },
+            [4] = {
+              bottom = 1,
+              left = 1,
+              right = 1,
+              top = 1,
+              win = 1001,
+            },
+          },
         })
       else
         screen:expect([[
@@ -2494,15 +2677,23 @@ describe('float window', function()
 
     it('border with title and footer', function()
       local buf = api.nvim_create_buf(false, false)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {' halloj! ',
-                                             ' BORDAA  '})
+      api.nvim_buf_set_lines(buf, 0, -1, true, { ' halloj! ', ' BORDAA  ' })
       local win = api.nvim_open_win(buf, false, {
-        relative='editor', width=9, height=2, row=2, col=5, border="double",
-        title = "Left", title_pos = "left", footer = "Right", footer_pos = "right",
+        relative = 'editor',
+        width = 9,
+        height = 2,
+        row = 2,
+        col = 5,
+        border = 'double',
+        title = 'Left',
+        title_pos = 'left',
+        footer = 'Right',
+        footer_pos = 'right',
       })
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -2516,14 +2707,18 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚════}{11:Right}{5:╝}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{5:╔}{11:Left}{5:═════╗}{0:                        }|
@@ -2531,12 +2726,14 @@ describe('float window', function()
           {0:~    }{5:║}{1: BORDAA  }{5:║}{0:                        }|
           {0:~    }{5:╚════}{11:Right}{5:╝}{0:                        }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
-      api.nvim_win_set_config(win, {title= "Center",title_pos="center",footer= "Center",footer_pos="center"})
+      api.nvim_win_set_config(win, { title = 'Center', title_pos = 'center', footer = 'Center', footer_pos = 'center' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -2550,14 +2747,18 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═}{11:Center}{5:══╝}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{5:╔═}{11:Center}{5:══╗}{0:                        }|
@@ -2565,12 +2766,14 @@ describe('float window', function()
           {0:~    }{5:║}{1: BORDAA  }{5:║}{0:                        }|
           {0:~    }{5:╚═}{11:Center}{5:══╝}{0:                        }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
-      api.nvim_win_set_config(win, {title= "Right",title_pos="right",footer= "Left",footer_pos="left"})
+      api.nvim_win_set_config(win, { title = 'Right', title_pos = 'right', footer = 'Left', footer_pos = 'left' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -2584,14 +2787,18 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚}{11:Left}{5:═════╝}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{5:╔════}{11:Right}{5:╗}{0:                        }|
@@ -2599,18 +2806,22 @@ describe('float window', function()
           {0:~    }{5:║}{1: BORDAA  }{5:║}{0:                        }|
           {0:~    }{5:╚}{11:Left}{5:═════╝}{0:                        }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       command('hi B0 guibg=Red guifg=Black')
       command('hi B1 guifg=White')
 
       api.nvim_win_set_config(win, {
-        title = {{"🦄"}, {"BB", {"B0", "B1"}}}, title_pos = "right",
-        footer= {{"🦄"}, {"BB", {"B0", "B1"}}}, footer_pos = "right",
+        title = { { '🦄' }, { 'BB', { 'B0', 'B1' } } },
+        title_pos = 'right',
+        footer = { { '🦄' }, { 'BB', { 'B0', 'B1' } } },
+        footer_pos = 'right',
       })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -2624,14 +2835,18 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════}{11:🦄}{7:BB}{5:╝}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{5:╔═════}{11:🦄}{7:BB}{5:╗}{0:                        }|
@@ -2639,17 +2854,21 @@ describe('float window', function()
           {0:~    }{5:║}{1: BORDAA  }{5:║}{0:                        }|
           {0:~    }{5:╚═════}{11:🦄}{7:BB}{5:╝}{0:                        }|
                                                   |
-        ]]}
+        ]],
+        }
       end
-      eq({{"🦄"}, {"BB", {"B0", "B1"}}}, api.nvim_win_get_config(win).title)
-      eq({{"🦄"}, {"BB", {"B0", "B1"}}}, api.nvim_win_get_config(win).footer)
+      eq({ { '🦄' }, { 'BB', { 'B0', 'B1' } } }, api.nvim_win_get_config(win).title)
+      eq({ { '🦄' }, { 'BB', { 'B0', 'B1' } } }, api.nvim_win_get_config(win).footer)
 
       api.nvim_win_set_config(win, {
-        title = {{"🦄", ""}, {"BB", {"B0", "B1", ""}}}, title_pos = "left",
-        footer= {{"🦄", ""}, {"BB", {"B0", "B1", ""}}}, footer_pos = "left",
+        title = { { '🦄', '' }, { 'BB', { 'B0', 'B1', '' } } },
+        title_pos = 'left',
+        footer = { { '🦄', '' }, { 'BB', { 'B0', 'B1', '' } } },
+        footer_pos = 'left',
       })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -2663,14 +2882,18 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚}🦄{7:BB}{5:═════╝}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{5:╔}🦄{7:BB}{5:═════╗}{0:                        }|
@@ -2678,15 +2901,17 @@ describe('float window', function()
           {0:~    }{5:║}{1: BORDAA  }{5:║}{0:                        }|
           {0:~    }{5:╚}🦄{7:BB}{5:═════╝}{0:                        }|
                                                   |
-        ]]}
+        ]],
+        }
       end
-      eq({{"🦄", ""}, {"BB", {"B0", "B1", ""}}}, api.nvim_win_get_config(win).title)
-      eq({{"🦄", ""}, {"BB", {"B0", "B1", ""}}}, api.nvim_win_get_config(win).footer)
+      eq({ { '🦄', '' }, { 'BB', { 'B0', 'B1', '' } } }, api.nvim_win_get_config(win).title)
+      eq({ { '🦄', '' }, { 'BB', { 'B0', 'B1', '' } } }, api.nvim_win_get_config(win).footer)
 
       -- making it a split should not leak memory
       api.nvim_win_set_config(win, { vertical = true })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [4:--------------------]{5:│}[2:-------------------]|*5
           {5:[No Name] [+]        }{4:[No Name]          }|
@@ -2700,26 +2925,31 @@ describe('float window', function()
            halloj!            |
            BORDAA             |
           {0:~                   }|*3
-        ]], win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
            halloj!            {5:│}^                   |
            BORDAA             {5:│}{0:~                  }|
           {0:~                   }{5:│}{0:~                  }|*3
           {5:[No Name] [+]        }{4:[No Name]          }|
                                                   |
-        ]]}
+        ]],
+        }
       end
     end)
 
     it('terminates border on edge of viewport when window extends past viewport', function()
       local buf = api.nvim_create_buf(false, false)
-      api.nvim_open_win(buf, false, {relative='editor', width=40, height=7, row=0, col=0, border="single", zindex=201})
+      api.nvim_open_win(buf, false, { relative = 'editor', width = 40, height = 7, row = 0, col = 0, border = 'single', zindex = 201 })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -2733,32 +2963,41 @@ describe('float window', function()
           {5:│}{1:                                        }{5:│}|
           {5:│}{2:~                                       }{5:│}|*6
           {5:└────────────────────────────────────────┘}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 0, 0, true, 201, 2, 0, 0 }
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 0, true, 201, 2, 0, 0 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           {5:^┌──────────────────────────────────────┐}|
           {5:│}{1:                                      }{5:│}|
           {5:│}{2:~                                     }{5:│}|*4
           {5:└──────────────────────────────────────┘}|
-        ]]}
+        ]],
+        }
       end
     end)
 
     it('with border show popupmenu', function()
-      screen:try_resize(40,10)
+      screen:try_resize(40, 10)
       local buf = api.nvim_create_buf(false, false)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {'aaa aab ',
-                                             'abb acc ', ''})
-      api.nvim_open_win(buf, true, {relative='editor', width=9, height=3, row=0, col=5, border="double"})
+      api.nvim_buf_set_lines(buf, 0, -1, true, {
+        'aaa aab ',
+        'abb acc ',
+        '',
+      })
+      api.nvim_open_win(buf, true, { relative = 'editor', width = 9, height = 3, row = 0, col = 5, border = 'double' })
       feed 'G'
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*9
           [3:----------------------------------------]|
@@ -2773,14 +3012,18 @@ describe('float window', function()
           {5:║}{1:abb acc  }{5:║}|
           {5:║}{1:^         }{5:║}|
           {5:╚═════════╝}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 0, 5, true, 50, 1, 0, 5 };
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 2, curcol = 0, linecount = 3, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 2, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                {5:╔═════════╗}                        |
           {0:~    }{5:║}{1:aaa aab  }{5:║}{0:                        }|
           {0:~    }{5:║}{1:abb acc  }{5:║}{0:                        }|
@@ -2788,12 +3031,14 @@ describe('float window', function()
           {0:~    }{5:╚═════════╝}{0:                        }|
           {0:~                                       }|*4
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       feed 'i<c-x><c-p>'
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*9
           [3:----------------------------------------]|
@@ -2813,15 +3058,19 @@ describe('float window', function()
           {1: aab            }|
           {1: abb            }|
           {13: acc            }|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 0, 5, true, 50, 1, 0, 5 };
-          [5] = { -1, "NW", 4, 4, 0, false, 100, 2, 4, 5 };
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount=1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 2, curcol = 3, linecount=3, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
+            [5] = { -1, 'NW', 4, 4, 0, false, 100, 2, 4, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 2, curcol = 3, linecount = 3, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                {5:╔═════════╗}                        |
           {0:~    }{5:║}{1:aaa aab  }{5:║}{0:                        }|
           {0:~    }{5:║}{1:abb acc  }{5:║}{0:                        }|
@@ -2832,12 +3081,14 @@ describe('float window', function()
           {0:~    }{13: acc            }{0:                   }|
           {0:~                                       }|
           {3:-- }{8:match 1 of 4}                         |
-        ]]}
+        ]],
+        }
       end
 
       feed '<esc>'
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*9
           [3:----------------------------------------]|
@@ -2852,14 +3103,18 @@ describe('float window', function()
           {5:║}{1:abb acc  }{5:║}|
           {5:║}{1:ac^c      }{5:║}|
           {5:╚═════════╝}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 0, 5, true, 50, 1, 0, 5 };
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 2, curcol = 2, linecount = 3, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 2, curcol = 2, linecount = 3, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                {5:╔═════════╗}                        |
           {0:~    }{5:║}{1:aaa aab  }{5:║}{0:                        }|
           {0:~    }{5:║}{1:abb acc  }{5:║}{0:                        }|
@@ -2867,7 +3122,8 @@ describe('float window', function()
           {0:~    }{5:╚═════════╝}{0:                        }|
           {0:~                                       }|*4
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       exec([[
@@ -2877,7 +3133,8 @@ describe('float window', function()
       ]])
       feed ':popup Test<CR>'
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*9
           [3:----------------------------------------]|
@@ -2896,15 +3153,19 @@ describe('float window', function()
           {1: foo }|
           {1: bar }|
           {1: baz }|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 0, 5, true, 50, 1, 0, 5 };
-          [5] = { -1, "NW", 4, 4, 2, false, 250, 3, 4, 7 };
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 2, curcol = 2, linecount = 3, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
+            [5] = { -1, 'NW', 4, 4, 2, false, 250, 3, 4, 7 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 2, curcol = 2, linecount = 3, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                {5:╔═════════╗}                        |
           {0:~    }{5:║}{1:aaa aab  }{5:║}{0:                        }|
           {0:~    }{5:║}{1:abb acc  }{5:║}{0:                        }|
@@ -2914,17 +3175,19 @@ describe('float window', function()
           {0:~      }{1: baz }{0:                            }|
           {0:~                                       }|*2
           :popup Test                             |
-        ]]}
+        ]],
+        }
       end
     end)
 
     it("doesn't wrap with vertical border", function()
-      screen:try_resize(40,10)
+      screen:try_resize(40, 10)
       local buf = api.nvim_create_buf(false, false)
-      api.nvim_open_win(buf, false, {relative='editor', width=9, height=3, row=0, col=5, border="double"})
+      api.nvim_open_win(buf, false, { relative = 'editor', width = 9, height = 3, row = 0, col = 5, border = 'double' })
       -- make sure text is drawn after border
       if multigrid then
-        screen:expect {grid = [[
+        screen:expect {
+          grid = [[
           ## grid 1
             [2:----------------------------------------]|*9
             [3:----------------------------------------]|
@@ -2945,19 +3208,19 @@ describe('float window', function()
               startcol = 0,
               startrow = 0,
               width = 40,
-              win = 1000
-            }
+              win = 1000,
+            },
           },
           float_pos = {
-            [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0, 5};
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
           },
           win_viewport = {
-            [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-            [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
           },
           win_viewport_margins = {
-            [2] = { bottom = 0, left = 0, right = 0, top = 0, win = 1000 };
-            [4] = { bottom = 1, left = 1, right = 1, top = 1, win = 1001 };
+            [2] = { bottom = 0, left = 0, right = 0, top = 0, win = 1000 },
+            [4] = { bottom = 1, left = 1, right = 1, top = 1, win = 1001 },
           },
         }
       else
@@ -2970,7 +3233,7 @@ describe('float window', function()
                                                   |
         ]])
       end
-      api.nvim_buf_set_lines(buf, 0, -1, true, {'aaa long line', 'abb acc '})
+      api.nvim_buf_set_lines(buf, 0, -1, true, { 'aaa long line', 'abb acc ' })
       if multigrid then
         screen:expect {
           grid = [[
@@ -2995,25 +3258,25 @@ describe('float window', function()
               startcol = 0,
               startrow = 0,
               width = 40,
-              win = 1000
-            }
+              win = 1000,
+            },
           },
-            float_pos = {
-            [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0, 5};
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
           },
-            win_viewport = {
-            [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-            [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
           },
-            win_viewport_margins = {
+          win_viewport_margins = {
             [2] = { bottom = 0, left = 0, right = 0, top = 0, win = 1000 },
-            [4] = { bottom = 1, left = 1, right = 1, top = 1, win = 1001 }
+            [4] = { bottom = 1, left = 1, right = 1, top = 1, win = 1001 },
           },
           condition = function()
-            for i = 1,5 do
+            for i = 1, 5 do
               eq(false, screen._grids[4].rows[i].wrap, i)
             end
-          end
+          end,
         }
       else
         screen:expect([[
@@ -3028,11 +3291,11 @@ describe('float window', function()
       end
     end)
 
-    it("does wrap without vertical border", function()
-      screen:try_resize(40,10)
+    it('does wrap without vertical border', function()
+      screen:try_resize(40, 10)
       local buf = api.nvim_create_buf(false, false)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {'aaa long line', 'abb acc '})
-      api.nvim_open_win(buf, false, {relative='editor', width=9, height=3, row=0, col=5})
+      api.nvim_buf_set_lines(buf, 0, -1, true, { 'aaa long line', 'abb acc ' })
+      api.nvim_open_win(buf, false, { relative = 'editor', width = 9, height = 3, row = 0, col = 5 })
       if multigrid then
         screen:expect {
           grid = [[
@@ -3050,22 +3313,21 @@ describe('float window', function()
             {1:abb acc  }|
           ]],
           win_pos = {
-            [2] = { height = 9, startcol = 0, startrow = 0, width = 40, win = 1000
-            }
+            [2] = { height = 9, startcol = 0, startrow = 0, width = 40, win = 1000 },
           },
           float_pos = {
-            [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0, 5};
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
           },
           win_viewport = {
-            [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-            [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
           },
           win_viewport_margins = {
             [2] = { bottom = 0, left = 0, right = 0, top = 0, win = 1000 },
-            [4] = { bottom = 0, left = 0, right = 0, top = 0, win = 1001 }
+            [4] = { bottom = 0, left = 0, right = 0, top = 0, win = 1001 },
           },
           condition = function()
-            for i = 1,3 do
+            for i = 1, 3 do
               eq(i == 1, screen._grids[4].rows[i].wrap, i)
             end
           end,
@@ -3084,13 +3346,13 @@ describe('float window', function()
     it('show ruler of current floating window', function()
       command 'set ruler'
       local buf = api.nvim_create_buf(false, false)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {'aaa aab ',
-                                             'abb acc '})
-      api.nvim_open_win(buf, true, {relative='editor', width=9, height=3, row=0, col=5})
+      api.nvim_buf_set_lines(buf, 0, -1, true, { 'aaa aab ', 'abb acc ' })
+      api.nvim_open_win(buf, true, { relative = 'editor', width = 9, height = 3, row = 0, col = 5 })
       feed 'gg'
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -3103,25 +3365,31 @@ describe('float window', function()
           {1:^aaa aab  }|
           {1:abb acc  }|
           {2:~        }|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                {1:^aaa aab  }                          |
           {0:~    }{1:abb acc  }{0:                          }|
           {0:~    }{2:~        }{0:                          }|
           {0:~                                       }|*3
                                 1,1           All |
-        ]]}
+        ]],
+        }
       end
 
       feed 'w'
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -3134,28 +3402,34 @@ describe('float window', function()
           {1:aaa ^aab  }|
           {1:abb acc  }|
           {2:~        }|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0,  5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 4, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 4, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                {1:aaa ^aab  }                          |
           {0:~    }{1:abb acc  }{0:                          }|
           {0:~    }{2:~        }{0:                          }|
           {0:~                                       }|*3
                                 1,5           All |
-        ]]}
+        ]],
+        }
       end
     end)
 
     it("correct ruler position in current float with 'rulerformat' set", function()
       command 'set ruler rulerformat=fish:<><'
-      api.nvim_open_win(0, true, {relative='editor', width=9, height=3, row=0, col=5})
+      api.nvim_open_win(0, true, { relative = 'editor', width = 9, height = 3, row = 0, col = 5 })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -3167,32 +3441,38 @@ describe('float window', function()
         ## grid 4
           {1:^         }|
           {2:~        }|*2
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                {1:^         }                          |
           {0:~    }{2:~        }{0:                          }|*2
           {0:~                                       }|*3
                                 fish:<><          |
-        ]]}
+        ]],
+        }
       end
     end)
 
     it('does not show ruler of not-last current float during ins-completion', function()
-      screen:try_resize(50,9)
+      screen:try_resize(50, 9)
       command 'set ruler showmode'
-      api.nvim_open_win(0, false, {relative='editor', width=3, height=3, row=0, col=0})
-      api.nvim_open_win(0, false, {relative='editor', width=3, height=3, row=0, col=5})
+      api.nvim_open_win(0, false, { relative = 'editor', width = 3, height = 3, row = 0, col = 0 })
+      api.nvim_open_win(0, false, { relative = 'editor', width = 3, height = 3, row = 0, col = 5 })
       feed '<c-w>w'
       neq('', api.nvim_win_get_config(0).relative)
       neq(fn.winnr '$', fn.winnr())
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:--------------------------------------------------]|*8
           [3:--------------------------------------------------]|
@@ -3207,25 +3487,31 @@ describe('float window', function()
         ## grid 5
           {1:^   }|
           {2:~  }|*2
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 0, true, 50, 1, 0, 0};
-          [5] = {1002, "NW", 1, 0, 5, true, 50, 2, 0, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [5] = {win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 0, true, 50, 1, 0, 0 },
+            [5] = { 1002, 'NW', 1, 0, 5, true, 50, 2, 0, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [5] = { win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           {1:   }  {1:^   }                                          |
           {2:~  }{0:  }{2:~  }{0:                                          }|*2
           {0:~                                                 }|*5
                                           0,0-1         All |
-        ]]}
+        ]],
+        }
       end
       feed 'i<c-x>'
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:--------------------------------------------------]|*8
           [3:--------------------------------------------------]|
@@ -3240,31 +3526,37 @@ describe('float window', function()
         ## grid 5
           {1:^   }|
           {2:~  }|*2
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 0, true, 50, 1, 0, 0};
-          [5] = {1002, "NW", 1, 0, 5, true, 50, 2, 0, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [5] = {win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 0, true, 50, 1, 0, 0 },
+            [5] = { 1002, 'NW', 1, 0, 5, true, 50, 2, 0, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [5] = { win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           {1:   }  {1:^   }                                          |
           {2:~  }{0:  }{2:~  }{0:                                          }|*2
           {0:~                                                 }|*5
           {3:-- ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)}          |
-        ]]}
+        ]],
+        }
       end
     end)
 
     it('can have minimum size', function()
-      insert("the background text")
+      insert('the background text')
       local buf = api.nvim_create_buf(false, true)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {'x'})
-      local win = api.nvim_open_win(buf, false, {relative='win', width=1, height=1, row=0, col=4, focusable=false})
+      api.nvim_buf_set_lines(buf, 0, -1, true, { 'x' })
+      local win = api.nvim_open_win(buf, false, { relative = 'win', width = 1, height = 1, row = 0, col = 4, focusable = false })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -3275,9 +3567,11 @@ describe('float window', function()
                                                   |
         ## grid 4
           {1:x}|
-        ]], float_pos={
-          [4] = {1001, "NW", 2, 0, 4, false, 50, 1, 0, 4}
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 2, 0, 4, false, 50, 1, 0, 4 },
+          },
+        }
       else
         screen:expect([[
           the {1:x}ackground tex^t                     |
@@ -3286,9 +3580,10 @@ describe('float window', function()
         ]])
       end
 
-      api.nvim_win_set_config(win, {relative='win', row=0, col=15})
+      api.nvim_win_set_config(win, { relative = 'win', row = 0, col = 15 })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -3299,9 +3594,11 @@ describe('float window', function()
                                                   |
         ## grid 4
           {1:x}|
-        ]], float_pos={
-          [4] = {1001, "NW", 2, 0, 15, false, 50, 1, 0, 15}
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 2, 0, 15, false, 50, 1, 0, 15 },
+          },
+        }
       else
         screen:expect([[
           the background {1:x}ex^t                     |
@@ -3310,7 +3607,7 @@ describe('float window', function()
         ]])
       end
 
-      api.nvim_win_close(win,false)
+      api.nvim_win_close(win, false)
       if multigrid then
         screen:expect([[
         ## grid 1
@@ -3350,7 +3647,8 @@ describe('float window', function()
         api.nvim_win_set_config(w4, float_opts)
         command('wincmd =')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [8:----------------------------------------]|*2
             {4:X6                                      }|
@@ -3379,19 +3677,23 @@ describe('float window', function()
           ## grid 8
             ^                                        |
             {0:~                                       }|
-          ]], float_pos={
-            [5] = {1002, "NW", 1, 6, 0, true, 50, 1, 6, 0};
-            [6] = {1003, "NW", 1, 6, 0, true, 50, 2, 6, 0};
-          }, win_viewport={
-            [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-            [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-            [5] = {win = 1002, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-            [6] = {win = 1003, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-            [7] = {win = 1004, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-            [8] = {win = 1005, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          }}
+          ]],
+            float_pos = {
+              [5] = { 1002, 'NW', 1, 6, 0, true, 50, 1, 6, 0 },
+              [6] = { 1003, 'NW', 1, 6, 0, true, 50, 2, 6, 0 },
+            },
+            win_viewport = {
+              [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+              [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+              [5] = { win = 1002, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+              [6] = { win = 1003, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+              [7] = { win = 1004, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+              [8] = { win = 1005, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            },
+          }
         else
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
             ^                                        |
             {0:~                                       }|
             {4:X6                                      }|
@@ -3405,12 +3707,14 @@ describe('float window', function()
             {0:~                                       }|
             {5:X1                                      }|
                                                     |
-          ]]}
+          ]],
+          }
         end
 
         command(cmd)
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|
             {4:X1                                      }|
@@ -3439,16 +3743,19 @@ describe('float window', function()
                                                     |
           ## grid 10
                                                     |
-          ]], win_viewport={
-            [2] = {win = 1000, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-            [4] = {win = 1001, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-            [7] = {win = 1004, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-            [8] = {win = 1005, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-            [9] = {win = 1006, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-            [10] = {win = 1007, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          }}
+          ]],
+            win_viewport = {
+              [2] = { win = 1000, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+              [4] = { win = 1001, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+              [7] = { win = 1004, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+              [8] = { win = 1005, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+              [9] = { win = 1006, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+              [10] = { win = 1007, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            },
+          }
         else
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
             ^                                        |
             {4:X1                                      }|
                                                     |
@@ -3462,7 +3769,8 @@ describe('float window', function()
                                                     |
             {5:X6                                      }|
                                                     |
-          ]]}
+          ]],
+          }
         end
       end
 
@@ -3476,38 +3784,55 @@ describe('float window', function()
     end)
 
     it('API has proper error messages', function()
-      local buf = api.nvim_create_buf(false,false)
-      eq("Invalid key: 'bork'",
-         pcall_err(api.nvim_open_win, buf, false, {width=20,height=2,bork=true}))
-      eq("'win' key is only valid with relative='win' and relative=''",
-         pcall_err(api.nvim_open_win, buf, false, {width=20,height=2,relative='editor',row=0,col=0,win=0}))
-      eq("floating windows cannot have 'vertical'",
-         pcall_err(api.nvim_open_win, buf, false, {width=20,height=2,relative='editor',row=0,col=0,vertical=true}))
-      eq("floating windows cannot have 'split'",
-         pcall_err(api.nvim_open_win, buf, false, {width=20,height=2,relative='editor',row=0,col=0,split="left"}))
-      eq("Only one of 'relative' and 'external' must be used",
-         pcall_err(api.nvim_open_win, buf, false, {width=20,height=2,relative='editor',row=0,col=0,external=true}))
-      eq("Invalid value of 'relative' key",
-         pcall_err(api.nvim_open_win, buf, false, {width=20,height=2,relative='shell',row=0,col=0}))
-      eq("Invalid value of 'anchor' key",
-         pcall_err(api.nvim_open_win, buf, false, {width=20,height=2,relative='editor',row=0,col=0,anchor='bottom'}))
-      eq("'relative' requires 'row'/'col' or 'bufpos'",
-         pcall_err(api.nvim_open_win, buf, false, {width=20,height=2,relative='editor'}))
-      eq("'width' key must be a positive Integer",
-         pcall_err(api.nvim_open_win, buf, false, {width=-1,height=2,relative='editor', row=0, col=0}))
-      eq("'height' key must be a positive Integer",
-         pcall_err(api.nvim_open_win, buf, false, {width=20,height=-1,relative='editor', row=0, col=0}))
-      eq("'height' key must be a positive Integer",
-         pcall_err(api.nvim_open_win, buf, false, {width=20,height=0,relative='editor', row=0, col=0}))
-      eq("Must specify 'width'",
-         pcall_err(api.nvim_open_win, buf, false, {relative='editor', row=0, col=0}))
-      eq("Must specify 'height'",
-         pcall_err(api.nvim_open_win, buf, false, {relative='editor', row=0, col=0, width=2}))
+      local buf = api.nvim_create_buf(false, false)
+      eq("Invalid key: 'bork'", pcall_err(api.nvim_open_win, buf, false, { width = 20, height = 2, bork = true }))
+      eq(
+        "'win' key is only valid with relative='win' and relative=''",
+        pcall_err(api.nvim_open_win, buf, false, { width = 20, height = 2, relative = 'editor', row = 0, col = 0, win = 0 })
+      )
+      eq(
+        "floating windows cannot have 'vertical'",
+        pcall_err(api.nvim_open_win, buf, false, { width = 20, height = 2, relative = 'editor', row = 0, col = 0, vertical = true })
+      )
+      eq(
+        "floating windows cannot have 'split'",
+        pcall_err(api.nvim_open_win, buf, false, { width = 20, height = 2, relative = 'editor', row = 0, col = 0, split = 'left' })
+      )
+      eq(
+        "Only one of 'relative' and 'external' must be used",
+        pcall_err(api.nvim_open_win, buf, false, { width = 20, height = 2, relative = 'editor', row = 0, col = 0, external = true })
+      )
+      eq(
+        "Invalid value of 'relative' key",
+        pcall_err(api.nvim_open_win, buf, false, { width = 20, height = 2, relative = 'shell', row = 0, col = 0 })
+      )
+      eq(
+        "Invalid value of 'anchor' key",
+        pcall_err(api.nvim_open_win, buf, false, { width = 20, height = 2, relative = 'editor', row = 0, col = 0, anchor = 'bottom' })
+      )
+      eq(
+        "'relative' requires 'row'/'col' or 'bufpos'",
+        pcall_err(api.nvim_open_win, buf, false, { width = 20, height = 2, relative = 'editor' })
+      )
+      eq(
+        "'width' key must be a positive Integer",
+        pcall_err(api.nvim_open_win, buf, false, { width = -1, height = 2, relative = 'editor', row = 0, col = 0 })
+      )
+      eq(
+        "'height' key must be a positive Integer",
+        pcall_err(api.nvim_open_win, buf, false, { width = 20, height = -1, relative = 'editor', row = 0, col = 0 })
+      )
+      eq(
+        "'height' key must be a positive Integer",
+        pcall_err(api.nvim_open_win, buf, false, { width = 20, height = 0, relative = 'editor', row = 0, col = 0 })
+      )
+      eq("Must specify 'width'", pcall_err(api.nvim_open_win, buf, false, { relative = 'editor', row = 0, col = 0 }))
+      eq("Must specify 'height'", pcall_err(api.nvim_open_win, buf, false, { relative = 'editor', row = 0, col = 0, width = 2 }))
     end)
 
     it('can be placed relative window or cursor', function()
-      screen:try_resize(40,9)
-      api.nvim_buf_set_lines(0, 0, -1, true, {'just some', 'example text'})
+      screen:try_resize(40, 9)
+      api.nvim_buf_set_lines(0, 0, -1, true, { 'just some', 'example text' })
       feed('gge')
       local oldwin = api.nvim_get_current_win()
       command('below split')
@@ -3544,11 +3869,12 @@ describe('float window', function()
         ]])
       end
 
-      local buf = api.nvim_create_buf(false,false)
+      local buf = api.nvim_create_buf(false, false)
       -- no 'win' arg, relative default window
-      local win = api.nvim_open_win(buf, false, {relative='win', width=20, height=2, row=0, col=10})
+      local win = api.nvim_open_win(buf, false, { relative = 'win', width = 20, height = 2, row = 0, col = 10 })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*3
           {5:[No Name] [+]                           }|
@@ -3568,9 +3894,11 @@ describe('float window', function()
         ## grid 5
           {1:                    }|
           {2:~                   }|
-        ]], float_pos={
-          [5] = {1002, "NW", 4, 0, 10, true, 50, 1, 4, 10}
-        }}
+        ]],
+          float_pos = {
+            [5] = { 1002, 'NW', 4, 0, 10, true, 50, 1, 4, 10 },
+          },
+        }
       else
         screen:expect([[
           just some                               |
@@ -3585,9 +3913,10 @@ describe('float window', function()
         ]])
       end
 
-      api.nvim_win_set_config(win, {relative='cursor', row=1, col=-2})
+      api.nvim_win_set_config(win, { relative = 'cursor', row = 1, col = -2 })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*3
           {5:[No Name] [+]                           }|
@@ -3607,9 +3936,11 @@ describe('float window', function()
         ## grid 5
           {1:                    }|
           {2:~                   }|
-        ]], float_pos={
-          [5] = {1002, "NW", 4, 1, 1, true, 50, 1, 5, 1}
-        }}
+        ]],
+          float_pos = {
+            [5] = { 1002, 'NW', 4, 1, 1, true, 50, 1, 5, 1 },
+          },
+        }
       else
         screen:expect([[
           just some                               |
@@ -3624,9 +3955,10 @@ describe('float window', function()
         ]])
       end
 
-      api.nvim_win_set_config(win, {relative='cursor', row=0, col=0, anchor='SW'})
+      api.nvim_win_set_config(win, { relative = 'cursor', row = 0, col = 0, anchor = 'SW' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*3
           {5:[No Name] [+]                           }|
@@ -3646,9 +3978,11 @@ describe('float window', function()
         ## grid 5
           {1:                    }|
           {2:~                   }|
-        ]], float_pos={
-          [5] = {1002, "SW", 4, 0, 3, true, 50, 1, 2, 3}
-        }}
+        ]],
+          float_pos = {
+            [5] = { 1002, 'SW', 4, 0, 3, true, 50, 1, 2, 3 },
+          },
+        }
       else
         screen:expect([[
           just some                               |
@@ -3663,9 +3997,10 @@ describe('float window', function()
         ]])
       end
 
-      api.nvim_win_set_config(win, {relative='win', win=oldwin, row=1, col=10, anchor='NW'})
+      api.nvim_win_set_config(win, { relative = 'win', win = oldwin, row = 1, col = 10, anchor = 'NW' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*3
           {5:[No Name] [+]                           }|
@@ -3685,9 +4020,11 @@ describe('float window', function()
         ## grid 5
           {1:                    }|
           {2:~                   }|
-        ]], float_pos={
-          [5] = {1002, "NW", 2, 1, 10, true, 50, 1, 1, 10}
-        }}
+        ]],
+          float_pos = {
+            [5] = { 1002, 'NW', 2, 1, 10, true, 50, 1, 1, 10 },
+          },
+        }
       else
         screen:expect([[
           just some                               |
@@ -3702,9 +4039,10 @@ describe('float window', function()
         ]])
       end
 
-      api.nvim_win_set_config(win, {relative='win', win=oldwin, row=3, col=39, anchor='SE'})
+      api.nvim_win_set_config(win, { relative = 'win', win = oldwin, row = 3, col = 39, anchor = 'SE' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*3
           {5:[No Name] [+]                           }|
@@ -3724,9 +4062,11 @@ describe('float window', function()
         ## grid 5
           {1:                    }|
           {2:~                   }|
-        ]], float_pos={
-          [5] = {1002, "SE", 2, 3, 39, true, 50, 1, 1, 19}
-        }}
+        ]],
+          float_pos = {
+            [5] = { 1002, 'SE', 2, 3, 39, true, 50, 1, 1, 19 },
+          },
+        }
       else
         screen:expect([[
           just some                               |
@@ -3741,9 +4081,10 @@ describe('float window', function()
         ]])
       end
 
-      api.nvim_win_set_config(win, {relative='win', win=0, row=0, col=50, anchor='NE'})
+      api.nvim_win_set_config(win, { relative = 'win', win = 0, row = 0, col = 50, anchor = 'NE' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*3
           {5:[No Name] [+]                           }|
@@ -3763,10 +4104,12 @@ describe('float window', function()
         ## grid 5
           {1:                    }|
           {2:~                   }|
-        ]], float_pos={
-          [5] = {1002, "NE", 4, 0, 50, true, 50, 1, 4, 20}
-        }, win_viewport = {
-          [2] = {
+        ]],
+          float_pos = {
+            [5] = { 1002, 'NE', 4, 0, 50, true, 50, 1, 4, 20 },
+          },
+          win_viewport = {
+            [2] = {
               topline = 0,
               botline = 3,
               curline = 0,
@@ -3774,26 +4117,27 @@ describe('float window', function()
               linecount = 2,
               sum_scroll_delta = 0,
               win = 1000,
-          },
-          [4] = {
+            },
+            [4] = {
               topline = 0,
               botline = 3,
               curline = 0,
               curcol = 3,
               linecount = 2,
               sum_scroll_delta = 0,
-              win = 1001
+              win = 1001,
+            },
+            [5] = {
+              topline = 0,
+              botline = 2,
+              curline = 0,
+              curcol = 0,
+              linecount = 1,
+              sum_scroll_delta = 0,
+              win = 1002,
+            },
           },
-          [5] = {
-            topline = 0,
-            botline = 2,
-            curline = 0,
-            curcol = 0,
-            linecount = 1,
-            sum_scroll_delta = 0,
-            win = 1002
-          }
-        }}
+        }
       else
         screen:expect([[
           just some                               |
@@ -3810,8 +4154,8 @@ describe('float window', function()
     end)
 
     it('always anchor to corner including border', function()
-      screen:try_resize(40,13)
-      api.nvim_buf_set_lines(0, 0, -1, true, {'just some example text', 'some more example text'})
+      screen:try_resize(40, 13)
+      api.nvim_buf_set_lines(0, 0, -1, true, { 'just some example text', 'some more example text' })
       feed('ggeee')
       command('below split')
       if multigrid then
@@ -3848,12 +4192,12 @@ describe('float window', function()
       end
 
       local buf = api.nvim_create_buf(false, false)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {' halloj! ',
-                                             ' BORDAA  '})
-      local win = api.nvim_open_win(buf, false, {relative='cursor', width=9, height=2, row=1, col=-2, border="double"})
+      api.nvim_buf_set_lines(buf, 0, -1, true, { ' halloj! ', ' BORDAA  ' })
+      local win = api.nvim_open_win(buf, false, { relative = 'cursor', width = 9, height = 2, row = 1, col = -2, border = 'double' })
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*5
           {5:[No Name] [+]                           }|
@@ -3875,9 +4219,11 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
-        ]], float_pos={
-          [5] = {1002, "NW", 4, 1, 14, true, 50, 1, 7, 14 }
-        }}
+        ]],
+          float_pos = {
+            [5] = { 1002, 'NW', 4, 1, 14, true, 50, 1, 7, 14 },
+          },
+        }
       else
         screen:expect([[
           just some example text                  |
@@ -3894,9 +4240,10 @@ describe('float window', function()
         ]])
       end
 
-      api.nvim_win_set_config(win, {relative='cursor', row=0, col=-2, anchor='NE'})
+      api.nvim_win_set_config(win, { relative = 'cursor', row = 0, col = -2, anchor = 'NE' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*5
           {5:[No Name] [+]                           }|
@@ -3918,9 +4265,11 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
-        ]], float_pos={
-          [5] = {1002, "NE", 4, 0, 14, true, 50, 1, 6, 3}
-        }}
+        ]],
+          float_pos = {
+            [5] = { 1002, 'NE', 4, 0, 14, true, 50, 1, 6, 3 },
+          },
+        }
       else
         screen:expect([[
           just some example text                  |
@@ -3937,9 +4286,10 @@ describe('float window', function()
         ]])
       end
 
-      api.nvim_win_set_config(win, {relative='cursor', row=1, col=-2, anchor='SE'})
+      api.nvim_win_set_config(win, { relative = 'cursor', row = 1, col = -2, anchor = 'SE' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*5
           {5:[No Name] [+]                           }|
@@ -3961,9 +4311,11 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
-        ]], float_pos={
-          [5] = {1002, "SE", 4, 1, 14, true, 50, 1, 3, 3}
-        }}
+        ]],
+          float_pos = {
+            [5] = { 1002, 'SE', 4, 1, 14, true, 50, 1, 3, 3 },
+          },
+        }
       else
         screen:expect([[
           just some example text                  |
@@ -3980,9 +4332,10 @@ describe('float window', function()
         ]])
       end
 
-      api.nvim_win_set_config(win, {relative='cursor', row=0, col=-2, anchor='SW'})
+      api.nvim_win_set_config(win, { relative = 'cursor', row = 0, col = -2, anchor = 'SW' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*5
           {5:[No Name] [+]                           }|
@@ -4004,9 +4357,11 @@ describe('float window', function()
           {5:║}{1: halloj! }{5:║}|
           {5:║}{1: BORDAA  }{5:║}|
           {5:╚═════════╝}|
-        ]], float_pos={
-          [5] = {1002, "SW", 4, 0, 14, true, 50, 1, 2, 14}
-        }}
+        ]],
+          float_pos = {
+            [5] = { 1002, 'SW', 4, 0, 14, true, 50, 1, 2, 14 },
+          },
+        }
       else
         screen:expect([[
           just some example text                  |
@@ -4062,7 +4417,8 @@ describe('float window', function()
         let w8 = nvim_open_win(b8, v:false, o8)
       ]])
       if multigrid then
-      screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -4088,16 +4444,18 @@ describe('float window', function()
           {1:7    }|
         ## grid 12
           {1:8    }|
-        ]], float_pos={
-          [5] = {1002, "NW", 1, 1, 10, true, 50, 5, 1, 10};
-          [6] = {1003, "NW", 1, 1, 30, true, 50, 1, 1, 30};
-          [7] = {1004, "NE", 5, 1, 0, true, 50, 6, 2, 5};
-          [8] = {1005, "NE", 6, 1, 0, true, 50, 2, 2, 25};
-          [9] = {1006, "SE", 7, 0, 0, true, 50, 7, 1, 0};
-          [10] = {1007, "SE", 8, 0, 0, true, 50, 3, 1, 20};
-          [11] = {1008, "SW", 9, 0, 5, true, 50, 8, 0, 5};
-          [12] = {1009, "SW", 10, 0, 5, true, 50, 4, 0, 25};
-        }}
+        ]],
+          float_pos = {
+            [5] = { 1002, 'NW', 1, 1, 10, true, 50, 5, 1, 10 },
+            [6] = { 1003, 'NW', 1, 1, 30, true, 50, 1, 1, 30 },
+            [7] = { 1004, 'NE', 5, 1, 0, true, 50, 6, 2, 5 },
+            [8] = { 1005, 'NE', 6, 1, 0, true, 50, 2, 2, 25 },
+            [9] = { 1006, 'SE', 7, 0, 0, true, 50, 7, 1, 0 },
+            [10] = { 1007, 'SE', 8, 0, 0, true, 50, 3, 1, 20 },
+            [11] = { 1008, 'SW', 9, 0, 5, true, 50, 8, 0, 5 },
+            [12] = { 1009, 'SW', 10, 0, 5, true, 50, 4, 0, 25 },
+          },
+        }
       else
         screen:expect([[
                {1:7    }               {1:8    }          |
@@ -4129,7 +4487,8 @@ describe('float window', function()
         call nvim_win_set_config(w7, o8)
       ]])
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -4155,16 +4514,18 @@ describe('float window', function()
           {1:7    }|
         ## grid 12
           {1:8    }|
-        ]], float_pos={
-          [5] = {1002, "NE", 8, 1, 0, true, 50, 5, 2, 25};
-          [6] = {1003, "NE", 12, 1, 0, true, 50, 1, 2, 5};
-          [7] = {1004, "SE", 5, 0, 0, true, 50, 6, 1, 20};
-          [8] = {1005, "NW", 1, 1, 30, true, 50, 2, 1, 30};
-          [9] = {1006, "SW", 10, 0, 5, true, 50, 7, 0, 5};
-          [10] = {1007, "SE", 6, 0, 0, true, 50, 3, 1, 0};
-          [11] = {1008, "SW", 7, 0, 5, true, 50, 8, 0, 25};
-          [12] = {1009, "NW", 1, 1, 10, true, 50, 4, 1, 10};
-        }}
+        ]],
+          float_pos = {
+            [5] = { 1002, 'NE', 8, 1, 0, true, 50, 5, 2, 25 },
+            [6] = { 1003, 'NE', 12, 1, 0, true, 50, 1, 2, 5 },
+            [7] = { 1004, 'SE', 5, 0, 0, true, 50, 6, 1, 20 },
+            [8] = { 1005, 'NW', 1, 1, 30, true, 50, 2, 1, 30 },
+            [9] = { 1006, 'SW', 10, 0, 5, true, 50, 7, 0, 5 },
+            [10] = { 1007, 'SE', 6, 0, 0, true, 50, 3, 1, 0 },
+            [11] = { 1008, 'SW', 7, 0, 5, true, 50, 8, 0, 25 },
+            [12] = { 1009, 'NW', 1, 1, 10, true, 50, 4, 1, 10 },
+          },
+        }
       else
         screen:expect([[
                {1:5    }               {1:7    }          |
@@ -4199,11 +4560,12 @@ describe('float window', function()
     end)
 
     it('can be placed relative text in a window', function()
-      screen:try_resize(30,5)
+      screen:try_resize(30, 5)
       local firstwin = api.nvim_get_current_win()
-      api.nvim_buf_set_lines(0, 0, -1, true, {'just some', 'example text that is wider than the window', '', '', 'more text'})
+      api.nvim_buf_set_lines(0, 0, -1, true, { 'just some', 'example text that is wider than the window', '', '', 'more text' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:------------------------------]|*4
           [3:------------------------------]|
@@ -4214,22 +4576,26 @@ describe('float window', function()
                                         |
         ## grid 3
                                         |
-        ]]}
+        ]],
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^just some                     |
           example text that is wider tha|
           n the window                  |
                                         |*2
-        ]]}
+        ]],
+        }
       end
 
-      local buf = api.nvim_create_buf(false,false)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {'some info!'})
+      local buf = api.nvim_create_buf(false, false)
+      api.nvim_buf_set_lines(buf, 0, -1, true, { 'some info!' })
 
-      local win = api.nvim_open_win(buf, false, {relative='win', width=12, height=1, bufpos={1,32}})
+      local win = api.nvim_open_win(buf, false, { relative = 'win', width = 12, height = 1, bufpos = { 1, 32 } })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:------------------------------]|*4
           [3:------------------------------]|
@@ -4242,24 +4608,42 @@ describe('float window', function()
                                         |
         ## grid 4
           {1:some info!  }|
-        ]], float_pos={
-          [4] = { 1001, "NW", 2, 3, 2, true, 50, 1, 3, 2 }
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 2, 3, 2, true, 50, 1, 3, 2 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^just some                     |
           example text that is wider tha|
           n the window                  |
             {1:some info!  }                |
                                         |
-        ]]}
+        ]],
+        }
       end
-      eq({relative='win', width=12, height=1, bufpos={1,32}, anchor='NW', hide=false,
-          external=false, col=0, row=1, win=firstwin, focusable=true, mouse=true, zindex=50}, api.nvim_win_get_config(win))
+      eq({
+        relative = 'win',
+        width = 12,
+        height = 1,
+        bufpos = { 1, 32 },
+        anchor = 'NW',
+        hide = false,
+        external = false,
+        col = 0,
+        row = 1,
+        win = firstwin,
+        focusable = true,
+        mouse = true,
+        zindex = 50,
+      }, api.nvim_win_get_config(win))
 
       feed('<c-e>')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:------------------------------]|*4
           [3:------------------------------]|
@@ -4271,22 +4655,26 @@ describe('float window', function()
                                         |
         ## grid 4
           {1:some info!  }|
-        ]], float_pos={
-          [4] = { 1001, "NW", 2, 2, 2, true, 50, 1, 2, 2 },
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 2, 2, 2, true, 50, 1, 2, 2 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^example text that is wider tha|
           n the window                  |
             {1:some info!  }                |
                                         |*2
-        ]]}
+        ]],
+        }
       end
 
-
-      screen:try_resize(45,5)
+      screen:try_resize(45, 5)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:---------------------------------------------]|*4
           [3:---------------------------------------------]|
@@ -4298,23 +4686,28 @@ describe('float window', function()
                                                        |
         ## grid 4
           {1:some info!  }|
-        ]], float_pos={
-          [4] = { 1001, "NW", 2, 1, 32, true, 50, 1, 1, 32 }
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 2, 1, 32, true, 50, 1, 1, 32 },
+          },
+        }
       else
         -- note: appears misaligned due to cursor
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^example text that is wider than the window   |
                                           {1:some info!  } |
                                                        |
           more text                                    |
                                                        |
-        ]]}
+        ]],
+        }
       end
 
-      screen:try_resize(25,10)
+      screen:try_resize(25, 10)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:-------------------------]|*9
           [3:-------------------------]|
@@ -4328,11 +4721,14 @@ describe('float window', function()
                                    |
         ## grid 4
           {1:some info!  }|
-        ]], float_pos={
-          [4] = { 1001, "NW", 2, 2, 7, true, 50, 1, 2, 7 }
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 2, 2, 7, true, 50, 1, 2, 7 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^example text that is wide|
           r than the window        |
                  {1:some info!  }      |
@@ -4340,12 +4736,14 @@ describe('float window', function()
           more text                |
           {0:~                        }|*4
                                    |
-        ]]}
+        ]],
+        }
       end
 
-      api.nvim_win_set_config(win, {relative='win', bufpos={1,32}, anchor='SW'})
+      api.nvim_win_set_config(win, { relative = 'win', bufpos = { 1, 32 }, anchor = 'SW' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:-------------------------]|*9
           [3:-------------------------]|
@@ -4359,24 +4757,29 @@ describe('float window', function()
                                    |
         ## grid 4
           {1:some info!  }|
-        ]], float_pos={
-          [4] = { 1001, "SW", 2, 1, 7, true, 50, 1, 0, 7 }
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'SW', 2, 1, 7, true, 50, 1, 0, 7 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^example{1:some info!  }s wide|
           r than the window        |
                                    |*2
           more text                |
           {0:~                        }|*4
                                    |
-        ]]}
+        ]],
+        }
       end
 
       command('set laststatus=0')
       command('botright vnew')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----]{5:│}[5:--------------------]|*9
           [3:-------------------------]|
@@ -4397,11 +4800,14 @@ describe('float window', function()
         ## grid 5
           ^                    |
           {0:~                   }|*8
-        ]], float_pos={
-          [4] = { 1001, "SW", 2, 8, 0, true, 50, 1, 7, 0 }
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'SW', 2, 8, 0, true, 50, 1, 7, 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           exam{5:│}^                    |
           ple {5:│}{0:~                   }|
           text{5:│}{0:~                   }|
@@ -4412,13 +4818,15 @@ describe('float window', function()
           {1:some info!  }{0:             }|
           the {5:│}{0:~                   }|
                                    |
-        ]]}
+        ]],
+        }
       end
       command('close')
 
-      api.nvim_win_set_config(win, {relative='win', bufpos={1,32}, anchor='NW', col=-2})
+      api.nvim_win_set_config(win, { relative = 'win', bufpos = { 1, 32 }, anchor = 'NW', col = -2 })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:-------------------------]|*9
           [3:-------------------------]|
@@ -4432,11 +4840,14 @@ describe('float window', function()
                                    |
         ## grid 4
           {1:some info!  }|
-        ]], float_pos={
-          [4] = { 1001, "NW", 2, 2, 5, true, 50, 1, 2, 5 }
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 2, 2, 5, true, 50, 1, 2, 5 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^example text that is wide|
           r than the window        |
                {1:some info!  }        |
@@ -4444,12 +4855,14 @@ describe('float window', function()
           more text                |
           {0:~                        }|*4
                                    |
-        ]]}
+        ]],
+        }
       end
 
-      api.nvim_win_set_config(win, {relative='win', bufpos={1,32}, row=2})
+      api.nvim_win_set_config(win, { relative = 'win', bufpos = { 1, 32 }, row = 2 })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:-------------------------]|*9
           [3:-------------------------]|
@@ -4463,11 +4876,14 @@ describe('float window', function()
                                    |
         ## grid 4
           {1:some info!  }|
-        ]], float_pos={
-          [4] = { 1001, "NW", 2, 3, 7, true, 50, 1, 3, 7 }
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 2, 3, 7, true, 50, 1, 3, 7 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^example text that is wide|
           r than the window        |
                                    |
@@ -4475,12 +4891,14 @@ describe('float window', function()
           more text                |
           {0:~                        }|*4
                                    |
-        ]]}
+        ]],
+        }
       end
 
       command('%fold')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:-------------------------]|*9
           [3:-------------------------]|
@@ -4491,23 +4909,27 @@ describe('float window', function()
                                    |
         ## grid 4
           {1:some info!  }|
-        ]], float_pos={
-          [4] = { 1001, "NW", 2, 2, 0, true, 50, 1, 2, 0 }
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 2, 2, 0, true, 50, 1, 2, 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           {28:^+--  5 lines: just some··}|
           {0:~                        }|
           {1:some info!  }{0:             }|
           {0:~                        }|*6
                                    |
-        ]]}
+        ]],
+        }
       end
     end)
 
     it('validates cursor even when window is not entered', function()
-      screen:try_resize(30,5)
-      command("set nowrap")
+      screen:try_resize(30, 5)
+      command('set nowrap')
       insert([[some text that is wider than the window]])
       if multigrid then
         screen:expect([[
@@ -4528,11 +4950,12 @@ describe('float window', function()
         ]])
       end
 
-      local buf = api.nvim_create_buf(false,true)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {'some floaty text'})
-      api.nvim_open_win(buf, false, {relative='editor', width=20, height=1, row=3, col=1})
+      local buf = api.nvim_create_buf(false, true)
+      api.nvim_buf_set_lines(buf, 0, -1, true, { 'some floaty text' })
+      api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 1, row = 3, col = 1 })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:------------------------------]|*4
           [3:------------------------------]|
@@ -4543,9 +4966,11 @@ describe('float window', function()
                                         |
         ## grid 4
           {1:some floaty text    }|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 3, 1, true, 50, 1, 3, 1}
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 3, 1, true, 50, 1, 3, 1 },
+          },
+        }
       else
         screen:expect([[
           that is wider than the windo^w |
@@ -4557,18 +4982,19 @@ describe('float window', function()
     end)
 
     if multigrid then
-      pending("supports second UI without multigrid", function()
+      pending('supports second UI without multigrid', function()
         local session2 = n.connect(eval('v:servername'))
-        print(session2:request("nvim_eval", "2+2"))
-        local screen2 = Screen.new(40,7)
+        print(session2:request('nvim_eval', '2+2'))
+        local screen2 = Screen.new(40, 7)
         screen2:attach(nil, session2)
         screen2:set_default_attr_ids(attrs)
-        local buf = api.nvim_create_buf(false,false)
-        api.nvim_open_win(buf, true, {relative='editor', width=20, height=2, row=2, col=5})
+        local buf = api.nvim_create_buf(false, false)
+        api.nvim_open_win(buf, true, { relative = 'editor', width = 20, height = 2, row = 2, col = 5 })
         local expected_pos = {
-          [2]={1001, 'NW', 1, 2, 5}
+          [2] = { 1001, 'NW', 1, 2, 5 },
         }
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
                                                   |
           {0:~                                       }|*5
@@ -4576,7 +5002,9 @@ describe('float window', function()
         ## grid 2
           {1:^                    }|
           {2:~                   }|
-        ]], float_pos=expected_pos}
+        ]],
+          float_pos = expected_pos,
+        }
         screen2:expect([[
                                                   |
           {0:~                                       }|
@@ -4588,13 +5016,13 @@ describe('float window', function()
       end)
     end
 
-
     it('handles resized screen', function()
-      local buf = api.nvim_create_buf(false,false)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {'such', 'very', 'float'})
-      local win = api.nvim_open_win(buf, false, {relative='editor', width=15, height=4, row=2, col=10})
+      local buf = api.nvim_create_buf(false, false)
+      api.nvim_buf_set_lines(buf, 0, -1, true, { 'such', 'very', 'float' })
+      local win = api.nvim_open_win(buf, false, { relative = 'editor', width = 15, height = 4, row = 2, col = 10 })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -4608,9 +5036,11 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
           {2:~              }|
-        ]], float_pos={
-          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
+          },
+        }
       else
         screen:expect([[
           ^                                        |
@@ -4623,9 +5053,10 @@ describe('float window', function()
         ]])
       end
 
-      screen:try_resize(40,5)
+      screen:try_resize(40, 5)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*4
           [3:----------------------------------------]|
@@ -4639,9 +5070,11 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
           {2:~              }|
-        ]], float_pos={
-          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 10 },
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 10 },
+          },
+        }
       else
         screen:expect([[
           ^          {1:such           }               |
@@ -4652,9 +5085,10 @@ describe('float window', function()
         ]])
       end
 
-      screen:try_resize(40,4)
+      screen:try_resize(40, 4)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*3
           [3:----------------------------------------]|
@@ -4668,9 +5102,11 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
           {2:~              }|
-        ]], float_pos={
-          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 10 },
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 10 },
+          },
+        }
       else
         screen:expect([[
           ^          {1:such           }               |
@@ -4680,9 +5116,10 @@ describe('float window', function()
         ]])
       end
 
-      screen:try_resize(40,3)
+      screen:try_resize(40, 3)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*2
           [3:----------------------------------------]|
@@ -4696,9 +5133,11 @@ describe('float window', function()
           {1:very           }|
           {1:float          }|
           {2:~              }|
-        ]], float_pos={
-          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 10 },
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 10 },
+          },
+        }
       else
         screen:expect([[
           ^          {1:such           }               |
@@ -4708,7 +5147,8 @@ describe('float window', function()
       end
       feed('<c-w>wjj')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*2
           [3:----------------------------------------]|
@@ -4722,9 +5162,11 @@ describe('float window', function()
           {1:very           }|
           {1:^float          }|
           {2:~              }|
-        ]], float_pos={
-          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 10 },
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 10 },
+          },
+        }
       else
         screen:expect([[
                     {1:such           }               |
@@ -4733,9 +5175,10 @@ describe('float window', function()
         ]])
       end
 
-      screen:try_resize(40,7)
+      screen:try_resize(40, 7)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -4749,9 +5192,11 @@ describe('float window', function()
           {1:very           }|
           {1:^float          }|
           {2:~              }|
-        ]], float_pos={
-          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
+          },
+        }
       else
         screen:expect([[
                                                   |
@@ -4764,10 +5209,11 @@ describe('float window', function()
         ]])
       end
 
-      api.nvim_win_set_config(win, {height=3})
+      api.nvim_win_set_config(win, { height = 3 })
       feed('gg')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -4780,9 +5226,11 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos={
-          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
+          },
+        }
       else
         screen:expect([[
                                                   |
@@ -4795,9 +5243,10 @@ describe('float window', function()
         ]])
       end
 
-      screen:try_resize(26,7)
+      screen:try_resize(26, 7)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:--------------------------]|*6
           [3:--------------------------]|
@@ -4810,9 +5259,11 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos={
-          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
+          },
+        }
       else
         screen:expect([[
                                     |
@@ -4825,9 +5276,10 @@ describe('float window', function()
         ]])
       end
 
-      screen:try_resize(25,7)
+      screen:try_resize(25, 7)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:-------------------------]|*6
           [3:-------------------------]|
@@ -4840,9 +5292,11 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos={
-          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
+          },
+        }
       else
         screen:expect([[
                                    |
@@ -4855,9 +5309,10 @@ describe('float window', function()
         ]])
       end
 
-      screen:try_resize(24,7)
+      screen:try_resize(24, 7)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:------------------------]|*6
           [3:------------------------]|
@@ -4870,9 +5325,11 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos={
-          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 9 },
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 9 },
+          },
+        }
       else
         screen:expect([[
                                   |
@@ -4885,9 +5342,10 @@ describe('float window', function()
         ]])
       end
 
-      screen:try_resize(16,7)
+      screen:try_resize(16, 7)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------]|*6
           [3:----------------]|
@@ -4900,9 +5358,11 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos={
-          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 1 },
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 1 },
+          },
+        }
       else
         screen:expect([[
                           |
@@ -4915,9 +5375,10 @@ describe('float window', function()
         ]])
       end
 
-      screen:try_resize(15,7)
+      screen:try_resize(15, 7)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:---------------]|*6
           [3:---------------]|
@@ -4930,9 +5391,11 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos={
-          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 0 },
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 0 },
+          },
+        }
       else
         screen:expect([[
                          |
@@ -4945,9 +5408,10 @@ describe('float window', function()
         ]])
       end
 
-      screen:try_resize(14,7)
+      screen:try_resize(14, 7)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:--------------]|*6
           [3:--------------]|
@@ -4960,9 +5424,11 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos={
-          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 0 },
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 0 },
+          },
+        }
       else
         screen:expect([[
                         |
@@ -4975,9 +5441,10 @@ describe('float window', function()
         ]])
       end
 
-      screen:try_resize(12,7)
+      screen:try_resize(12, 7)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:------------]|*6
           [3:------------]|
@@ -4990,9 +5457,11 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos={
-          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 0 },
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 0 },
+          },
+        }
       else
         screen:expect([[
                       |
@@ -5006,9 +5475,10 @@ describe('float window', function()
       end
 
       -- Doesn't make much sense, but check nvim doesn't crash
-      screen:try_resize(1,1)
+      screen:try_resize(1, 1)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:------------]|
           [3:------------]|
@@ -5020,9 +5490,11 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos={
-          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 0 },
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 0, 0 },
+          },
+        }
       else
         screen:expect([[
           {1:^such        }|
@@ -5030,9 +5502,10 @@ describe('float window', function()
         ]])
       end
 
-      screen:try_resize(40,7)
+      screen:try_resize(40, 7)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -5045,9 +5518,11 @@ describe('float window', function()
           {1:^such           }|
           {1:very           }|
           {1:float          }|
-        ]], float_pos={
-          [4]={ 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 10, true, 50, 1, 2, 10 },
+          },
+        }
       else
         screen:expect([[
                                                   |
@@ -5063,14 +5538,14 @@ describe('float window', function()
 
     it('does not crash with inccommand #9379', function()
       local expected_pos = {
-        [4]={ 1001, 'NW', 1, 2, 0, true, 50, 1, 2, 0},
+        [4] = { 1001, 'NW', 1, 2, 0, true, 50, 1, 2, 0 },
       }
 
-      command("set inccommand=split")
-      command("set laststatus=2")
+      command('set inccommand=split')
+      command('set laststatus=2')
 
-      local buf = api.nvim_create_buf(false,false)
-      api.nvim_open_win(buf, true, {relative='editor', width=30, height=3, row=2, col=0})
+      local buf = api.nvim_create_buf(false, false)
+      api.nvim_open_win(buf, true, { relative = 'editor', width = 30, height = 3, row = 2, col = 0 })
 
       insert([[
       foo
@@ -5078,7 +5553,8 @@ describe('float window', function()
       ]])
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ## grid 1
             [2:----------------------------------------]|*5
             {5:[No Name]                               }|
@@ -5092,7 +5568,9 @@ describe('float window', function()
             {1:foo                           }|
             {1:bar                           }|
             {1:^                              }|
-        ]], float_pos=expected_pos}
+        ]],
+          float_pos = expected_pos,
+        }
       else
         screen:expect([[
                                                   |
@@ -5108,7 +5586,8 @@ describe('float window', function()
       feed(':%s/.')
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ## grid 1
             [2:----------------------------------------]|*5
             {5:[Preview]                               }|
@@ -5121,7 +5600,9 @@ describe('float window', function()
             {17:f}{1:oo                           }|
             {17:b}{1:ar                           }|
             {1:                              }|
-        ]], float_pos=expected_pos}
+        ]],
+          float_pos = expected_pos,
+        }
       else
         screen:expect([[
                                                   |
@@ -5137,7 +5618,8 @@ describe('float window', function()
       feed('<Esc>')
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ## grid 1
             [2:----------------------------------------]|*5
             {5:[No Name]                               }|
@@ -5151,7 +5633,9 @@ describe('float window', function()
             {1:foo                           }|
             {1:bar                           }|
             {1:^                              }|
-        ]], float_pos=expected_pos}
+        ]],
+          float_pos = expected_pos,
+        }
       else
         screen:expect([[
                                                   |
@@ -5166,19 +5650,20 @@ describe('float window', function()
     end)
 
     it('does not crash when set cmdheight #9680', function()
-      local buf = api.nvim_create_buf(false,false)
-      api.nvim_open_win(buf, false, {relative='editor', width=20, height=2, row=2, col=5})
-      command("set cmdheight=2")
+      local buf = api.nvim_create_buf(false, false)
+      api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 2, row = 2, col = 5 })
+      command('set cmdheight=2')
       eq(1, api.nvim_eval('1'))
     end)
 
     describe('and completion', function()
       before_each(function()
-        local buf = api.nvim_create_buf(false,false)
-        local win = api.nvim_open_win(buf, true, {relative='editor', width=12, height=4, row=2, col=5})
-        api.nvim_set_option_value('winhl', 'Normal:ErrorMsg', {win=win})
+        local buf = api.nvim_create_buf(false, false)
+        local win = api.nvim_open_win(buf, true, { relative = 'editor', width = 12, height = 4, row = 2, col = 5 })
+        api.nvim_set_option_value('winhl', 'Normal:ErrorMsg', { win = win })
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5190,9 +5675,11 @@ describe('float window', function()
           ## grid 4
             {7:^            }|
             {12:~           }|*3
-          ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5},
-          }}
+          ]],
+            float_pos = {
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+            },
+          }
         else
           screen:expect([[
                                                     |
@@ -5206,9 +5693,10 @@ describe('float window', function()
 
       it('with builtin popupmenu', function()
         feed('ix ')
-        fn.complete(3, {'aa', 'word', 'longtext'})
+        fn.complete(3, { 'aa', 'word', 'longtext' })
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5224,10 +5712,12 @@ describe('float window', function()
             {13: aa             }|
             {1: word           }|
             {1: longtext       }|
-          ]], float_pos={
-            [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 },
-            [5] = { -1, "NW", 4, 1, 1, false, 100, 2, 3, 6 }
-          }}
+          ]],
+            float_pos = {
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+              [5] = { -1, 'NW', 4, 1, 1, false, 100, 2, 3, 6 },
+            },
+          }
         else
           screen:expect([[
                                                     |
@@ -5242,7 +5732,8 @@ describe('float window', function()
 
         feed('<esc>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5254,10 +5745,11 @@ describe('float window', function()
           ## grid 4
             {7:x a^a        }|
             {12:~           }|*3
-          ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5},
-          }}
-
+          ]],
+            float_pos = {
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+            },
+          }
         else
           screen:expect([[
                                                     |
@@ -5269,9 +5761,10 @@ describe('float window', function()
         end
 
         feed('<c-w>wi')
-        fn.complete(1, {'xx', 'yy', 'zz'})
+        fn.complete(1, { 'xx', 'yy', 'zz' })
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5287,10 +5780,12 @@ describe('float window', function()
             {13:xx             }|
             {1:yy             }|
             {1:zz             }|
-          ]], float_pos={
-            [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 },
-            [5] = { -1, "NW", 2, 1, 0, false, 100, 2, 1, 0 }
-          }}
+          ]],
+            float_pos = {
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+              [5] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
+            },
+          }
         else
           screen:expect([[
             xx^                                      |
@@ -5304,7 +5799,8 @@ describe('float window', function()
 
         feed('<c-y>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5316,9 +5812,11 @@ describe('float window', function()
           ## grid 4
             {7:x aa        }|
             {12:~           }|*3
-          ]], float_pos={
-            [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 },
-          }}
+          ]],
+            float_pos = {
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+            },
+          }
         else
           screen:expect([[
             xx^                                      |
@@ -5334,7 +5832,8 @@ describe('float window', function()
         command('set wildmenu wildmode=longest:full wildoptions=pum')
         feed(':sign u<tab>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5349,12 +5848,15 @@ describe('float window', function()
           ## grid 5
             {1: undefine       }|
             {1: unplace        }|
-          ]], float_pos={
-            [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 };
-            [5] = { -1, "SW", 1, 6, 5, false, 250, 3, 4, 5 };
-          }}
+          ]],
+            float_pos = {
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+              [5] = { -1, 'SW', 1, 6, 5, false, 250, 3, 4, 5 },
+            },
+          }
         else
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
                                                     |
             {0:~                                       }|
             {0:~    }{7:            }{0:                       }|
@@ -5362,17 +5864,19 @@ describe('float window', function()
             {0:~    }{1: undefine       }{0:                   }|
             {0:~    }{1: unplace        }{0:                   }|
             :sign un^                                |
-          ]]}
+          ]],
+          }
         end
       end)
 
       it('with ext_popupmenu', function()
         screen:set_option('ext_popupmenu', true)
         feed('ix ')
-        fn.complete(3, {'aa', 'word', 'longtext'})
-        local items = {{"aa", "", "", ""}, {"word", "", "", ""}, {"longtext", "", "", ""}}
+        fn.complete(3, { 'aa', 'word', 'longtext' })
+        local items = { { 'aa', '', '', '' }, { 'word', '', '', '' }, { 'longtext', '', '', '' } }
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5384,26 +5888,37 @@ describe('float window', function()
           ## grid 4
             {7:x aa^        }|
             {12:~           }|*3
-          ]], float_pos={
-            [4] = { 1001, "NW", 1, 2, 5, true, 50, 1, 2, 5 },
-          }, popupmenu={
-            anchor = {4, 0, 2}, items = items, pos = 0
-          }}
+          ]],
+            float_pos = {
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+            },
+            popupmenu = {
+              anchor = { 4, 0, 2 },
+              items = items,
+              pos = 0,
+            },
+          }
         else
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
                                                     |
             {0:~                                       }|
             {0:~    }{7:x aa^        }{0:                       }|
             {0:~    }{12:~           }{0:                       }|*3
             {3:-- INSERT --}                            |
-          ]], popupmenu={
-            anchor = {1, 2, 7}, items = items, pos = 0
-          }}
+          ]],
+            popupmenu = {
+              anchor = { 1, 2, 7 },
+              items = items,
+              pos = 0,
+            },
+          }
         end
 
         feed('<esc>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5415,9 +5930,11 @@ describe('float window', function()
           ## grid 4
             {7:x a^a        }|
             {12:~           }|*3
-          ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5},
-          }}
+          ]],
+            float_pos = {
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+            },
+          }
         else
           screen:expect([[
                                                     |
@@ -5429,10 +5946,11 @@ describe('float window', function()
         end
 
         feed('<c-w>wi')
-        fn.complete(1, {'xx', 'yy', 'zz'})
-        items = {{"xx", "", "", ""}, {"yy", "", "", ""}, {"zz", "", "", ""}}
+        fn.complete(1, { 'xx', 'yy', 'zz' })
+        items = { { 'xx', '', '', '' }, { 'yy', '', '', '' }, { 'zz', '', '', '' } }
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5444,26 +5962,37 @@ describe('float window', function()
           ## grid 4
             {7:x aa        }|
             {12:~           }|*3
-          ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5},
-          }, popupmenu={
-            anchor = {2, 0, 0}, items = items, pos = 0
-          }}
+          ]],
+            float_pos = {
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+            },
+            popupmenu = {
+              anchor = { 2, 0, 0 },
+              items = items,
+              pos = 0,
+            },
+          }
         else
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
             xx^                                      |
             {0:~                                       }|
             {0:~    }{7:x aa        }{0:                       }|
             {0:~    }{12:~           }{0:                       }|*3
             {3:-- INSERT --}                            |
-          ]], popupmenu={
-            anchor = {1, 0, 0}, items = items, pos = 0
-          }}
+          ]],
+            popupmenu = {
+              anchor = { 1, 0, 0 },
+              items = items,
+              pos = 0,
+            },
+          }
         end
 
         feed('<c-y>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5475,9 +6004,11 @@ describe('float window', function()
           ## grid 4
             {7:x aa        }|
             {12:~           }|*3
-          ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5},
-          }}
+          ]],
+            float_pos = {
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+            },
+          }
         else
           screen:expect([[
             xx^                                      |
@@ -5495,9 +6026,10 @@ describe('float window', function()
       before_each(function()
         command('hi NormalFloat guibg=#333333 guifg=NONE')
         feed('i')
-        fn.complete(1, {'aa', 'word', 'longtext'})
+        fn.complete(1, { 'aa', 'word', 'longtext' })
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5510,8 +6042,10 @@ describe('float window', function()
             {13:aa             }|
             {1:word           }|
             {1:longtext       }|
-          ]], float_pos={
-            [4] = {-1, "NW", 2, 1, 0, false, 100, 1, 1, 0}}
+          ]],
+            float_pos = {
+              [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 },
+            },
           }
         else
           screen:expect([[
@@ -5524,11 +6058,12 @@ describe('float window', function()
           ]])
         end
 
-        local buf = api.nvim_create_buf(false,true)
-        api.nvim_buf_set_lines(buf,0,-1,true,{"some info", "about item"})
-        win = api.nvim_open_win(buf, false, {relative='cursor', width=12, height=2, row=1, col=10})
+        local buf = api.nvim_create_buf(false, true)
+        api.nvim_buf_set_lines(buf, 0, -1, true, { 'some info', 'about item' })
+        win = api.nvim_open_win(buf, false, { relative = 'cursor', width = 12, height = 2, row = 1, col = 10 })
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5544,10 +6079,12 @@ describe('float window', function()
           ## grid 5
             {15:some info   }|
             {15:about item  }|
-          ]], float_pos={
-            [5] = {1001, "NW", 2, 1, 12, true, 50, 1, 1, 12},
-            [4] = {-1, "NW", 2, 1, 0, false, 100, 2, 1, 0},
-          }}
+          ]],
+            float_pos = {
+              [5] = { 1001, 'NW', 2, 1, 12, true, 50, 1, 1, 12 },
+              [4] = { -1, 'NW', 2, 1, 0, false, 100, 2, 1, 0 },
+            },
+          }
         else
           screen:expect([[
             aa^                                      |
@@ -5563,7 +6100,8 @@ describe('float window', function()
       it('and close pum first', function()
         feed('<c-y>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5575,9 +6113,11 @@ describe('float window', function()
           ## grid 5
             {15:some info   }|
             {15:about item  }|
-          ]], float_pos={
-            [5] = {1001, "NW", 2, 1, 12, true, 50, 1, 1, 12},
-          }}
+          ]],
+            float_pos = {
+              [5] = { 1001, 'NW', 2, 1, 12, true, 50, 1, 1, 12 },
+            },
+          }
         else
           screen:expect([[
             aa^                                      |
@@ -5612,7 +6152,8 @@ describe('float window', function()
       it('and close float first', function()
         api.nvim_win_close(win, false)
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5625,9 +6166,11 @@ describe('float window', function()
             {13:aa             }|
             {1:word           }|
             {1:longtext       }|
-          ]], float_pos={
-            [4] = {-1, "NW", 2, 1, 0, false, 100, 1, 1, 0},
-          }}
+          ]],
+            float_pos = {
+              [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 },
+            },
+          }
         else
           screen:expect([[
             aa^                                      |
@@ -5661,14 +6204,15 @@ describe('float window', function()
       end)
     end)
 
-    it("can use Normal as background", function()
-      local buf = api.nvim_create_buf(false,false)
-      api.nvim_buf_set_lines(buf,0,-1,true,{"here", "float"})
-      local win = api.nvim_open_win(buf, false, {relative='editor', width=20, height=2, row=2, col=5})
-      api.nvim_set_option_value('winhl', 'Normal:Normal', {win=win})
+    it('can use Normal as background', function()
+      local buf = api.nvim_create_buf(false, false)
+      api.nvim_buf_set_lines(buf, 0, -1, true, { 'here', 'float' })
+      local win = api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 2, row = 2, col = 5 })
+      api.nvim_set_option_value('winhl', 'Normal:Normal', { win = win })
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -5680,40 +6224,46 @@ describe('float window', function()
         ## grid 4
           here                |
           float               |
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }here                {0:               }|
           {0:~    }float               {0:               }|
           {0:~                                       }|*2
                                                   |
-        ]]}
+        ]],
+        }
       end
     end)
 
-    describe("handles :wincmd", function()
+    describe('handles :wincmd', function()
       local win
       local expected_pos
       before_each(function()
         -- the default, but be explicit:
-        command("set laststatus=1")
-        command("set hidden")
-        api.nvim_buf_set_lines(0,0,-1,true,{"x"})
-        local buf = api.nvim_create_buf(false,false)
-        win = api.nvim_open_win(buf, false, {relative='editor', width=20, height=2, row=2, col=5})
-        api.nvim_buf_set_lines(buf,0,-1,true,{"y"})
+        command('set laststatus=1')
+        command('set hidden')
+        api.nvim_buf_set_lines(0, 0, -1, true, { 'x' })
+        local buf = api.nvim_create_buf(false, false)
+        win = api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 2, row = 2, col = 5 })
+        api.nvim_buf_set_lines(buf, 0, -1, true, { 'y' })
         expected_pos = {
-          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}
+          [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
         }
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5725,7 +6275,9 @@ describe('float window', function()
           ## grid 4
             {1:y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             ^x                                       |
@@ -5738,10 +6290,11 @@ describe('float window', function()
         end
       end)
 
-      it("w", function()
-        feed("<c-w>w")
+      it('w', function()
+        feed('<c-w>w')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5753,7 +6306,9 @@ describe('float window', function()
           ## grid 4
             {1:^y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                                       |
@@ -5765,9 +6320,10 @@ describe('float window', function()
           ]])
         end
 
-        feed("<c-w>w")
+        feed('<c-w>w')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5779,7 +6335,9 @@ describe('float window', function()
           ## grid 4
             {1:y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             ^x                                       |
@@ -5792,12 +6350,13 @@ describe('float window', function()
         end
       end)
 
-      it("w with focusable=false", function()
-        api.nvim_win_set_config(win, {focusable=false})
+      it('w with focusable=false', function()
+        api.nvim_win_set_config(win, { focusable = false })
         expected_pos[4][6] = false
-        feed("<c-w>wi") -- i to provoke redraw
+        feed('<c-w>wi') -- i to provoke redraw
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5809,7 +6368,9 @@ describe('float window', function()
           ## grid 4
             {1:y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             ^x                                       |
@@ -5821,9 +6382,10 @@ describe('float window', function()
           ]])
         end
 
-        feed("<esc><c-w>w")
+        feed('<esc><c-w>w')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5835,7 +6397,9 @@ describe('float window', function()
           ## grid 4
             {1:y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             ^x                                       |
@@ -5847,64 +6411,45 @@ describe('float window', function()
           ]])
         end
 
-        api.nvim_open_win(
-          0,
-          false,
-          { relative = "editor", width = 1, height = 1, row = 0, col = 0 }
-        )
-        api.nvim_open_win(
-          0,
-          false,
-          { relative = "editor", width = 1, height = 1, row = 0, col = 0, focusable = false }
-        )
-        api.nvim_open_win(
-          0,
-          false,
-          { relative = "editor", width = 1, height = 1, row = 0, col = 0, focusable = false }
-        )
-        api.nvim_open_win(
-          0,
-          false,
-          { relative = "editor", width = 1, height = 1, row = 0, col = 0, focusable = true }
-        )
-        api.nvim_open_win(
-          0,
-          false,
-          { relative = "editor", width = 1, height = 1, row = 0, col = 0, focusable = false }
-        )
+        api.nvim_open_win(0, false, { relative = 'editor', width = 1, height = 1, row = 0, col = 0 })
+        api.nvim_open_win(0, false, { relative = 'editor', width = 1, height = 1, row = 0, col = 0, focusable = false })
+        api.nvim_open_win(0, false, { relative = 'editor', width = 1, height = 1, row = 0, col = 0, focusable = false })
+        api.nvim_open_win(0, false, { relative = 'editor', width = 1, height = 1, row = 0, col = 0, focusable = true })
+        api.nvim_open_win(0, false, { relative = 'editor', width = 1, height = 1, row = 0, col = 0, focusable = false })
         local nr_focusable = {}
-        for nr = 1, fn.winnr("$") do
+        for nr = 1, fn.winnr('$') do
           table.insert(nr_focusable, api.nvim_win_get_config(fn.win_getid(nr)).focusable)
         end
-        eq({true, false, true, false, false, true, false}, nr_focusable)
+        eq({ true, false, true, false, false, true, false }, nr_focusable)
 
-        command("1wincmd w")
+        command('1wincmd w')
         eq(1, fn.winnr())
-        command("2wincmd w")
+        command('2wincmd w')
         eq(3, fn.winnr())
-        command("3wincmd w")
+        command('3wincmd w')
         eq(3, fn.winnr())
-        command("4wincmd w")
+        command('4wincmd w')
         eq(6, fn.winnr())
-        command("5wincmd w")
+        command('5wincmd w')
         eq(6, fn.winnr())
-        command("6wincmd w")
+        command('6wincmd w')
         eq(6, fn.winnr())
-        command("7wincmd w")
+        command('7wincmd w')
         eq(6, fn.winnr())
 
-        feed("1<c-w>w")
+        feed('1<c-w>w')
         eq(1, fn.winnr())
-        feed("2<c-w>w")
+        feed('2<c-w>w')
         eq(3, fn.winnr())
-        feed("999<c-w>w")
+        feed('999<c-w>w')
         eq(6, fn.winnr())
       end)
 
-      it("W", function()
-        feed("<c-w>W")
+      it('W', function()
+        feed('<c-w>W')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5916,7 +6461,9 @@ describe('float window', function()
           ## grid 4
             {1:^y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                                       |
@@ -5928,9 +6475,10 @@ describe('float window', function()
           ]])
         end
 
-        feed("<c-w>W")
+        feed('<c-w>W')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5942,7 +6490,9 @@ describe('float window', function()
           ## grid 4
             {1:y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             ^x                                       |
@@ -5958,7 +6508,8 @@ describe('float window', function()
       local function test_float_mouse_focus()
         if multigrid then
           api.nvim_input_mouse('left', 'press', '', 4, 0, 0)
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5970,7 +6521,9 @@ describe('float window', function()
           ## grid 4
             {1:^y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           api.nvim_input_mouse('left', 'press', '', 0, 2, 5)
           screen:expect([[
@@ -5985,7 +6538,8 @@ describe('float window', function()
 
         if multigrid then
           api.nvim_input_mouse('left', 'press', '', 2, 0, 0)
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -5997,7 +6551,9 @@ describe('float window', function()
           ## grid 4
             {1:y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           api.nvim_input_mouse('left', 'press', '', 0, 0, 0)
           screen:expect([[
@@ -6011,21 +6567,22 @@ describe('float window', function()
         end
       end
 
-      it("focus by mouse (focusable=true)", function()
+      it('focus by mouse (focusable=true)', function()
         test_float_mouse_focus()
       end)
 
-      it("focus by mouse (focusable=false, mouse=true)", function()
-        api.nvim_win_set_config(win, {focusable=false, mouse=true})
+      it('focus by mouse (focusable=false, mouse=true)', function()
+        api.nvim_win_set_config(win, { focusable = false, mouse = true })
         test_float_mouse_focus()
       end)
 
       local function test_float_mouse_no_focus()
-        api.nvim_buf_set_lines(0, -1, -1, true, {"a"})
+        api.nvim_buf_set_lines(0, -1, -1, true, { 'a' })
         expected_pos[4][6] = false
         if multigrid then
           api.nvim_input_mouse('left', 'press', '', 4, 0, 0)
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6038,7 +6595,9 @@ describe('float window', function()
           ## grid 4
             {1:y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           api.nvim_input_mouse('left', 'press', '', 0, 2, 5)
           screen:expect([[
@@ -6053,7 +6612,8 @@ describe('float window', function()
 
         if multigrid then
           api.nvim_input_mouse('left', 'press', '', 2, 0, 0)
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6066,7 +6626,10 @@ describe('float window', function()
           ## grid 4
             {1:y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos, unchanged=true}
+          ]],
+            float_pos = expected_pos,
+            unchanged = true,
+          }
         else
           api.nvim_input_mouse('left', 'press', '', 0, 0, 0)
           screen:expect([[
@@ -6080,20 +6643,21 @@ describe('float window', function()
         end
       end
 
-      it("focus by mouse (focusable=false)", function()
-        api.nvim_win_set_config(win, {focusable=false})
+      it('focus by mouse (focusable=false)', function()
+        api.nvim_win_set_config(win, { focusable = false })
         test_float_mouse_no_focus()
       end)
 
-      it("focus by mouse (focusable=true, mouse=false)", function()
-        api.nvim_win_set_config(win, {mouse=false})
+      it('focus by mouse (focusable=true, mouse=false)', function()
+        api.nvim_win_set_config(win, { mouse = false })
         test_float_mouse_no_focus()
       end)
 
-      it("j", function()
-        feed("<c-w>ji") -- INSERT to trigger screen change
+      it('j', function()
+        feed('<c-w>ji') -- INSERT to trigger screen change
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6105,7 +6669,9 @@ describe('float window', function()
           ## grid 4
             {1:y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             ^x                                       |
@@ -6117,9 +6683,10 @@ describe('float window', function()
           ]])
         end
 
-        feed("<esc><c-w>w")
+        feed('<esc><c-w>w')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6131,7 +6698,9 @@ describe('float window', function()
           ## grid 4
             {1:^y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                                       |
@@ -6143,9 +6712,10 @@ describe('float window', function()
           ]])
         end
 
-        feed("<c-w>j")
+        feed('<c-w>j')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6157,7 +6727,9 @@ describe('float window', function()
           ## grid 4
             {1:y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             ^x                                       |
@@ -6168,13 +6740,13 @@ describe('float window', function()
                                                     |
           ]])
         end
-
       end)
 
-      it("vertical resize + - _", function()
+      it('vertical resize + - _', function()
         feed('<c-w>w')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6186,7 +6758,9 @@ describe('float window', function()
           ## grid 4
             {1:^y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                                       |
@@ -6200,7 +6774,8 @@ describe('float window', function()
 
         feed('<c-w>+')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6212,7 +6787,9 @@ describe('float window', function()
           ## grid 4
             {1:^y                   }|
             {2:~                   }|*2
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                                       |
@@ -6226,7 +6803,8 @@ describe('float window', function()
 
         feed('<c-w>2-')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6237,7 +6815,9 @@ describe('float window', function()
                                                     |
           ## grid 4
             {1:^y                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                                       |
@@ -6250,7 +6830,8 @@ describe('float window', function()
 
         feed('<c-w>4_')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6262,7 +6843,9 @@ describe('float window', function()
           ## grid 4
             {1:^y                   }|
             {2:~                   }|*3
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                                       |
@@ -6275,7 +6858,8 @@ describe('float window', function()
 
         feed('<c-w>_')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6287,9 +6871,11 @@ describe('float window', function()
           ## grid 4
             {1:^y                   }|
             {2:~                   }|*5
-          ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 0, 5}
-          }}
+          ]],
+            float_pos = {
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 0, 5 },
+            },
+          }
         else
           screen:expect([[
             x    {1:^y                   }               |
@@ -6299,10 +6885,11 @@ describe('float window', function()
         end
       end)
 
-      it("horizontal resize > < |", function()
+      it('horizontal resize > < |', function()
         feed('<c-w>w')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6314,7 +6901,9 @@ describe('float window', function()
           ## grid 4
             {1:^y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                                       |
@@ -6328,7 +6917,8 @@ describe('float window', function()
 
         feed('<c-w>>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6340,7 +6930,9 @@ describe('float window', function()
           ## grid 4
             {1:^y                    }|
             {2:~                    }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                                       |
@@ -6354,7 +6946,8 @@ describe('float window', function()
 
         feed('<c-w>10<lt>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6366,7 +6959,9 @@ describe('float window', function()
           ## grid 4
             {1:^y          }|
             {2:~          }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                                       |
@@ -6380,7 +6975,8 @@ describe('float window', function()
 
         feed('<c-w>15|')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6392,7 +6988,9 @@ describe('float window', function()
           ## grid 4
             {1:^y              }|
             {2:~              }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                                       |
@@ -6406,7 +7004,8 @@ describe('float window', function()
 
         feed('<c-w>|')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6418,9 +7017,11 @@ describe('float window', function()
           ## grid 4
             {1:^y                                       }|
             {2:~                                       }|
-          ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 0}
-          }}
+          ]],
+            float_pos = {
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 0 },
+            },
+          }
         else
           screen:expect([[
             x                                       |
@@ -6433,10 +7034,11 @@ describe('float window', function()
         end
       end)
 
-      it("s :split (non-float)", function()
-        feed("<c-w>s")
+      it('s :split (non-float)', function()
+        feed('<c-w>s')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [5:----------------------------------------]|*2
             {4:[No Name] [+]                           }|
@@ -6454,7 +7056,9 @@ describe('float window', function()
           ## grid 5
             ^x                                       |
             {0:~                                       }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             ^x                                       |
@@ -6467,9 +7071,10 @@ describe('float window', function()
           ]])
         end
 
-        feed("<c-w>w")
+        feed('<c-w>w')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [5:----------------------------------------]|*2
             {5:[No Name] [+]                           }|
@@ -6487,7 +7092,9 @@ describe('float window', function()
           ## grid 5
             x                                       |
             {0:~                                       }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                                       |
@@ -6500,9 +7107,10 @@ describe('float window', function()
           ]])
         end
 
-        feed("<c-w>w")
+        feed('<c-w>w')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [5:----------------------------------------]|*2
             {5:[No Name] [+]                           }|
@@ -6520,7 +7128,9 @@ describe('float window', function()
           ## grid 5
             x                                       |
             {0:~                                       }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                                       |
@@ -6533,10 +7143,10 @@ describe('float window', function()
           ]])
         end
 
-
-        feed("<c-w>w")
+        feed('<c-w>w')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [5:----------------------------------------]|*2
             {4:[No Name] [+]                           }|
@@ -6554,7 +7164,9 @@ describe('float window', function()
           ## grid 5
             ^x                                       |
             {0:~                                       }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             ^x                                       |
@@ -6568,10 +7180,11 @@ describe('float window', function()
         end
       end)
 
-      it("s :split (float)", function()
-        feed("<c-w>w<c-w>s")
+      it('s :split (float)', function()
+        feed('<c-w>w<c-w>s')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [5:----------------------------------------]|*2
             {4:[No Name] [+]                           }|
@@ -6589,7 +7202,9 @@ describe('float window', function()
           ## grid 5
             ^y                                       |
             {0:~                                       }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             ^y                                       |
@@ -6602,9 +7217,10 @@ describe('float window', function()
           ]])
         end
 
-        feed("<c-w>j")
+        feed('<c-w>j')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [5:----------------------------------------]|*2
             {5:[No Name] [+]                           }|
@@ -6622,7 +7238,9 @@ describe('float window', function()
           ## grid 5
             y                                       |
             {0:~                                       }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             y                                       |
@@ -6635,9 +7253,10 @@ describe('float window', function()
           ]])
         end
 
-        feed("<c-w>ji")
+        feed('<c-w>ji')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [5:----------------------------------------]|*2
             {5:[No Name] [+]                           }|
@@ -6655,7 +7274,9 @@ describe('float window', function()
           ## grid 5
             y                                       |
             {0:~                                       }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             y                                       |
@@ -6669,10 +7290,11 @@ describe('float window', function()
         end
       end)
 
-      it(":new (non-float)", function()
-        feed(":new<cr>")
+      it(':new (non-float)', function()
+        feed(':new<cr>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [5:----------------------------------------]|*2
             {4:[No Name]                               }|
@@ -6690,7 +7312,9 @@ describe('float window', function()
           ## grid 5
             ^                                        |
             {0:~                                       }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             ^                                        |
@@ -6704,10 +7328,11 @@ describe('float window', function()
         end
       end)
 
-      it(":new (float)", function()
-        feed("<c-w>w:new<cr>")
+      it(':new (float)', function()
+        feed('<c-w>w:new<cr>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [5:----------------------------------------]|*2
             {4:[No Name]                               }|
@@ -6725,7 +7350,9 @@ describe('float window', function()
           ## grid 5
             ^                                        |
             {0:~                                       }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             ^                                        |
@@ -6739,10 +7366,11 @@ describe('float window', function()
         end
       end)
 
-      it("v :vsplit (non-float)", function()
-        feed("<c-w>v")
+      it('v :vsplit (non-float)', function()
+        feed('<c-w>v')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [5:--------------------]{5:│}[2:-------------------]|*5
             {4:[No Name] [+]        }{5:[No Name] [+]      }|
@@ -6758,7 +7386,9 @@ describe('float window', function()
           ## grid 5
             ^x                   |
             {0:~                   }|*4
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             ^x                   {5:│}x                  |
@@ -6772,10 +7402,11 @@ describe('float window', function()
         end
       end)
 
-      it(":vnew (non-float)", function()
-        feed(":vnew<cr>")
+      it(':vnew (non-float)', function()
+        feed(':vnew<cr>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [5:--------------------]{5:│}[2:-------------------]|*5
             {4:[No Name]            }{5:[No Name] [+]      }|
@@ -6791,7 +7422,9 @@ describe('float window', function()
           ## grid 5
             ^                    |
             {0:~                   }|*4
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             ^                    {5:│}x                  |
@@ -6805,10 +7438,11 @@ describe('float window', function()
         end
       end)
 
-      it(":vnew (float)", function()
-        feed("<c-w>w:vnew<cr>")
+      it(':vnew (float)', function()
+        feed('<c-w>w:vnew<cr>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [5:--------------------]{5:│}[2:-------------------]|*5
             {4:[No Name]            }{5:[No Name] [+]      }|
@@ -6824,7 +7458,9 @@ describe('float window', function()
           ## grid 5
             ^                    |
             {0:~                   }|*4
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             ^                    {5:│}x                  |
@@ -6838,21 +7474,21 @@ describe('float window', function()
         end
       end)
 
-      it("q (:quit) last non-float exits nvim", function()
+      it('q (:quit) last non-float exits nvim', function()
         command('autocmd VimLeave    * call rpcrequest(1, "exit")')
         -- avoid unsaved change in other buffer
-        feed("<c-w><c-w>:w Xtest_written2<cr><c-w><c-w>")
+        feed('<c-w><c-w>:w Xtest_written2<cr><c-w><c-w>')
         -- quit in last non-float
-        feed(":wq Xtest_written<cr>")
+        feed(':wq Xtest_written<cr>')
         local exited = false
         local function on_request(name, args)
-          eq("exit", name)
+          eq('exit', name)
           eq({}, args)
           exited = true
           return 0
         end
         local function on_setup()
-          feed(":wq Xtest_written<cr>")
+          feed(':wq Xtest_written<cr>')
         end
         run(on_request, nil, on_setup)
         os.remove('Xtest_written')
@@ -6864,9 +7500,10 @@ describe('float window', function()
         -- enter first float
         feed('<c-w><c-w>')
         -- enter second float
-        api.nvim_open_win(0, true, {relative='editor', width=20, height=2, row=4, col=8})
+        api.nvim_open_win(0, true, { relative = 'editor', width = 20, height = 2, row = 4, col = 8 })
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6881,10 +7518,12 @@ describe('float window', function()
           ## grid 5
             {1:^y                   }|
             {2:~                   }|
-          ]], float_pos={
-            [5] = {1002, "NW", 1, 4, 8, true, 50, 2, 4, 8},
-            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}
-          }}
+          ]],
+            float_pos = {
+              [5] = { 1002, 'NW', 1, 4, 8, true, 50, 2, 4, 8 },
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+            },
+          }
         else
           screen:expect([[
             x                                       |
@@ -6899,7 +7538,8 @@ describe('float window', function()
 
         feed(':quit<cr>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6911,9 +7551,11 @@ describe('float window', function()
           ## grid 4
             {1:^y                   }|
             {2:~                   }|
-          ]], float_pos={
-            [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5},
-          }}
+          ]],
+            float_pos = {
+              [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+            },
+          }
         else
           screen:expect([[
             x                                       |
@@ -6937,7 +7579,7 @@ describe('float window', function()
           ## grid 3
             :quit                                   |
           ]])
-         else
+        else
           screen:expect([[
             ^x                                       |
             {0:~                                       }|*5
@@ -6948,10 +7590,11 @@ describe('float window', function()
         assert_alive()
       end)
 
-      it("o (:only) non-float", function()
-        feed("<c-w>o")
+      it('o (:only) non-float', function()
+        feed('<c-w>o')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -6960,7 +7603,8 @@ describe('float window', function()
             {0:~                                       }|*5
           ## grid 3
                                                     |
-          ]]}
+          ]],
+          }
         else
           screen:expect([[
             ^x                                       |
@@ -6970,10 +7614,11 @@ describe('float window', function()
         end
       end)
 
-      it("o (:only) float fails", function()
-        feed("<c-w>w<c-w>o")
+      it('o (:only) float fails', function()
+        feed('<c-w>w<c-w>o')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*4
             [3:----------------------------------------]|*3
@@ -6987,7 +7632,9 @@ describe('float window', function()
           ## grid 4
             {1:y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                                       |
@@ -7003,7 +7650,8 @@ describe('float window', function()
         -- test message clear
         feed('<cr>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -7015,7 +7663,9 @@ describe('float window', function()
           ## grid 4
             {1:^y                   }|
             {2:~                   }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                                       |
@@ -7028,10 +7678,11 @@ describe('float window', function()
         end
       end)
 
-      it("o (:only) non-float with split", function()
-        feed("<c-w>s")
+      it('o (:only) non-float with split', function()
+        feed('<c-w>s')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [5:----------------------------------------]|*2
             {4:[No Name] [+]                           }|
@@ -7049,7 +7700,9 @@ describe('float window', function()
           ## grid 5
             ^x                                       |
             {0:~                                       }|
-        ]], float_pos=expected_pos}
+        ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             ^x                                       |
@@ -7062,9 +7715,10 @@ describe('float window', function()
           ]])
         end
 
-        feed("<c-w>o")
+        feed('<c-w>o')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [5:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -7073,7 +7727,8 @@ describe('float window', function()
           ## grid 5
             ^x                                       |
             {0:~                                       }|*5
-          ]]}
+          ]],
+          }
         else
           screen:expect([[
             ^x                                       |
@@ -7083,10 +7738,11 @@ describe('float window', function()
         end
       end)
 
-      it("o (:only) float with split", function()
-        feed("<c-w>s<c-w>W")
+      it('o (:only) float with split', function()
+        feed('<c-w>s<c-w>W')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [5:----------------------------------------]|*2
             {5:[No Name] [+]                           }|
@@ -7104,7 +7760,9 @@ describe('float window', function()
           ## grid 5
             x                                       |
             {0:~                                       }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                                       |
@@ -7117,9 +7775,10 @@ describe('float window', function()
           ]])
         end
 
-        feed("<c-w>o")
+        feed('<c-w>o')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [5:----------------------------------------]|*2
             {5:[No Name] [+]                           }|
@@ -7138,7 +7797,9 @@ describe('float window', function()
           ## grid 5
             x                                       |
             {0:~                                       }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                                       |
@@ -7152,10 +7813,11 @@ describe('float window', function()
         end
       end)
 
-      it("J (float)", function()
-        feed("<c-w>w<c-w>J")
+      it('J (float)', function()
+        feed('<c-w>w<c-w>J')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*2
             {5:[No Name] [+]                           }|
@@ -7170,7 +7832,8 @@ describe('float window', function()
           ## grid 4
             ^y                                       |
             {0:~                                       }|
-          ]]}
+          ]],
+          }
         else
           screen:expect([[
             x                                       |
@@ -7184,9 +7847,10 @@ describe('float window', function()
         end
 
         if multigrid then
-          api.nvim_win_set_config(0, {external=true, width=30, height=2})
-          expected_pos = {[4]={external=true}}
-          screen:expect{grid=[[
+          api.nvim_win_set_config(0, { external = true, width = 30, height = 2 })
+          expected_pos = { [4] = { external = true } }
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*5
             {5:[No Name] [+]                           }|
@@ -7199,14 +7863,15 @@ describe('float window', function()
           ## grid 4
             ^y                             |
             {0:~                             }|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
-          eq("UI doesn't support external windows",
-             pcall_err(api.nvim_win_set_config, 0, {external=true, width=30, height=2}))
+          eq("UI doesn't support external windows", pcall_err(api.nvim_win_set_config, 0, { external = true, width = 30, height = 2 }))
           return
         end
 
-        feed("<c-w>J")
+        feed('<c-w>J')
         if multigrid then
           screen:expect([[
           ## grid 1
@@ -7228,9 +7893,10 @@ describe('float window', function()
       end)
 
       it('J (float with border)', function()
-        api.nvim_win_set_config(win, {relative='editor', width=20, height=2, row=2, col=5, border='single'})
+        api.nvim_win_set_config(win, { relative = 'editor', width = 20, height = 2, row = 2, col = 5, border = 'single' })
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*6
             [3:----------------------------------------]|
@@ -7244,7 +7910,9 @@ describe('float window', function()
             {5:│}{1:y                   }{5:│}|
             {5:│}{2:~                   }{5:│}|
             {5:└────────────────────┘}|
-          ]], float_pos=expected_pos}
+          ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             ^x                                       |
@@ -7257,9 +7925,10 @@ describe('float window', function()
           ]])
         end
 
-        feed("<c-w>w<c-w>J")
+        feed('<c-w>w<c-w>J')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [2:----------------------------------------]|*2
             {5:[No Name] [+]                           }|
@@ -7274,7 +7943,8 @@ describe('float window', function()
           ## grid 4
             ^y                                       |
             {0:~                                       }|
-          ]]}
+          ]],
+          }
         else
           screen:expect([[
             x                                       |
@@ -7289,10 +7959,11 @@ describe('float window', function()
       end)
 
       it('movements with nested split layout', function()
-        command("set hidden")
-        feed("<c-w>s<c-w>v<c-w>b<c-w>v")
+        command('set hidden')
+        feed('<c-w>s<c-w>v<c-w>b<c-w>v')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [6:--------------------]{5:│}[5:-------------------]|*2
             {5:[No Name] [+]        [No Name] [+]      }|
@@ -7316,7 +7987,9 @@ describe('float window', function()
           ## grid 7
             ^x                   |
             {0:~                   }|
-        ]], float_pos=expected_pos}
+        ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             x                   {5:│}x                  |
@@ -7330,14 +8003,15 @@ describe('float window', function()
         end
 
         -- verify that N<c-w>w works
-        for i = 1,5 do
-          feed(i.."<c-w>w")
-          feed_command("enew")
-          api.nvim_buf_set_lines(0, 0,-1,true,{tostring(i)})
+        for i = 1, 5 do
+          feed(i .. '<c-w>w')
+          feed_command('enew')
+          api.nvim_buf_set_lines(0, 0, -1, true, { tostring(i) })
         end
 
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             [6:-------------------]{5:│}[5:--------------------]|*2
             {5:[No Name] [+]       [No Name] [+]       }|
@@ -7361,7 +8035,9 @@ describe('float window', function()
           ## grid 7
             3                  |
             {0:~                  }|
-        ]], float_pos=expected_pos}
+        ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             1                  {5:│}2                   |
@@ -7375,44 +8051,44 @@ describe('float window', function()
         end
 
         local movements = {
-          w={2,3,4,5,1},
-          W={5,1,2,3,4},
-          h={1,1,3,3,3},
-          j={3,3,3,4,4},
-          k={1,2,1,1,1},
-          l={2,2,4,4,4},
-          t={1,1,1,1,1},
-          b={4,4,4,4,4},
+          w = { 2, 3, 4, 5, 1 },
+          W = { 5, 1, 2, 3, 4 },
+          h = { 1, 1, 3, 3, 3 },
+          j = { 3, 3, 3, 4, 4 },
+          k = { 1, 2, 1, 1, 1 },
+          l = { 2, 2, 4, 4, 4 },
+          t = { 1, 1, 1, 1, 1 },
+          b = { 4, 4, 4, 4, 4 },
         }
 
-        for k,v in pairs(movements) do
-          for i = 1,5 do
-            feed(i.."<c-w>w")
-            feed('<c-w>'..k)
+        for k, v in pairs(movements) do
+          for i = 1, 5 do
+            feed(i .. '<c-w>w')
+            feed('<c-w>' .. k)
             local nr = fn.winnr()
-            eq(v[i],nr, "when using <c-w>"..k.." from window "..i)
+            eq(v[i], nr, 'when using <c-w>' .. k .. ' from window ' .. i)
           end
         end
 
-        for i = 1,5 do
-          feed(i.."<c-w>w")
-          for j = 1,5 do
+        for i = 1, 5 do
+          feed(i .. '<c-w>w')
+          for j = 1, 5 do
             if j ~= i then
-              feed(j.."<c-w>w")
+              feed(j .. '<c-w>w')
               feed('<c-w>p')
               local nr = fn.winnr()
-              eq(i,nr, "when using <c-w>p to window "..i.." from window "..j)
+              eq(i, nr, 'when using <c-w>p to window ' .. i .. ' from window ' .. j)
             end
           end
         end
-
       end)
 
-      it(":tabnew and :tabnext", function()
-        feed(":tabnew<cr>")
+      it(':tabnew and :tabnext', function()
+        feed(':tabnew<cr>')
         if multigrid then
           -- grid is not freed, but float is marked as closed (should it rather be "invisible"?)
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             {9: }{10:2}{9:+ [No Name] }{3: [No Name] }{5:              }{9:X}|
             [5:----------------------------------------]|*5
@@ -7428,7 +8104,8 @@ describe('float window', function()
           ## grid 5
             ^                                        |
             {0:~                                       }|*4
-          ]]}
+          ]],
+          }
         else
           screen:expect([[
             {9: }{10:2}{9:+ [No Name] }{3: [No Name] }{5:              }{9:X}|
@@ -7438,9 +8115,10 @@ describe('float window', function()
           ]])
         end
 
-        feed(":tabnext<cr>")
+        feed(':tabnext<cr>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             {3: }{11:2}{3:+ [No Name] }{9: [No Name] }{5:              }{9:X}|
             [2:----------------------------------------]|*5
@@ -7456,7 +8134,9 @@ describe('float window', function()
           ## grid 5 (hidden)
                                                     |
             {0:~                                       }|*4
-        ]], float_pos=expected_pos}
+        ]],
+            float_pos = expected_pos,
+          }
         else
           screen:expect([[
             {3: }{11:2}{3:+ [No Name] }{9: [No Name] }{5:              }{9:X}|
@@ -7468,9 +8148,10 @@ describe('float window', function()
           ]])
         end
 
-        feed(":tabnext<cr>")
+        feed(':tabnext<cr>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             {9: }{10:2}{9:+ [No Name] }{3: [No Name] }{5:              }{9:X}|
             [5:----------------------------------------]|*5
@@ -7486,7 +8167,8 @@ describe('float window', function()
           ## grid 5
             ^                                        |
             {0:~                                       }|*4
-        ]]}
+        ]],
+          }
         else
           screen:expect([[
             {9: }{10:2}{9:+ [No Name] }{3: [No Name] }{5:              }{9:X}|
@@ -7497,13 +8179,14 @@ describe('float window', function()
         end
       end)
 
-      it(":tabnew and :tabnext (external)", function()
+      it(':tabnew and :tabnext (external)', function()
         if multigrid then
           -- also test external window wider than main screen
-          api.nvim_win_set_config(win, {external=true, width=65, height=4})
-          expected_pos = {[4]={external=true}}
-          feed(":tabnew<cr>")
-          screen:expect{grid=[[
+          api.nvim_win_set_config(win, { external = true, width = 65, height = 4 })
+          expected_pos = { [4] = { external = true } }
+          feed(':tabnew<cr>')
+          screen:expect {
+            grid = [[
           ## grid 1
             {9: + [No Name] }{3: }{11:2}{3:+ [No Name] }{5:            }{9:X}|
             [5:----------------------------------------]|*5
@@ -7519,15 +8202,17 @@ describe('float window', function()
           ## grid 5
             ^                                        |
             {0:~                                       }|*4
-        ]], float_pos=expected_pos}
+        ]],
+            float_pos = expected_pos,
+          }
         else
-          eq("UI doesn't support external windows",
-             pcall_err(api.nvim_win_set_config, 0, {external=true, width=65, height=4}))
+          eq("UI doesn't support external windows", pcall_err(api.nvim_win_set_config, 0, { external = true, width = 65, height = 4 }))
         end
 
-        feed(":tabnext<cr>")
+        feed(':tabnext<cr>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             {3: }{11:2}{3:+ [No Name] }{9: [No Name] }{5:              }{9:X}|
             [2:----------------------------------------]|*5
@@ -7543,12 +8228,15 @@ describe('float window', function()
           ## grid 5 (hidden)
                                                     |
             {0:~                                       }|*4
-        ]], float_pos=expected_pos}
+        ]],
+            float_pos = expected_pos,
+          }
         end
 
-        feed(":tabnext<cr>")
+        feed(':tabnext<cr>')
         if multigrid then
-          screen:expect{grid=[[
+          screen:expect {
+            grid = [[
           ## grid 1
             {9: + [No Name] }{3: }{11:2}{3:+ [No Name] }{5:            }{9:X}|
             [5:----------------------------------------]|*5
@@ -7564,17 +8252,20 @@ describe('float window', function()
           ## grid 5
             ^                                        |
             {0:~                                       }|*4
-        ]], float_pos=expected_pos}
+        ]],
+            float_pos = expected_pos,
+          }
         end
       end)
     end)
 
-    it("left drag changes visual selection in float window", function()
-      local buf = api.nvim_create_buf(false,false)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {'foo', 'bar', 'baz'})
-      api.nvim_open_win(buf, false, {relative='editor', width=20, height=3, row=2, col=5})
+    it('left drag changes visual selection in float window', function()
+      local buf = api.nvim_create_buf(false, false)
+      api.nvim_buf_set_lines(buf, 0, -1, true, { 'foo', 'bar', 'baz' })
+      api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 3, row = 2, col = 5 })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -7587,15 +8278,19 @@ describe('float window', function()
           {1:foo                 }|
           {1:bar                 }|
           {1:baz                 }|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
+          },
+        }
 
         api.nvim_input_mouse('left', 'press', '', 4, 0, 0)
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -7608,15 +8303,19 @@ describe('float window', function()
           {1:^foo                 }|
           {1:bar                 }|
           {1:baz                 }|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
+          },
+        }
 
         api.nvim_input_mouse('left', 'drag', '', 4, 1, 2)
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -7629,14 +8328,18 @@ describe('float window', function()
           {27:foo}{1:                 }|
           {27:ba}{1:^r                 }|
           {1:baz                 }|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 1, curcol = 2, linecount = 3, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 1, curcol = 2, linecount = 3, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{1:foo                 }{0:               }|
@@ -7644,10 +8347,12 @@ describe('float window', function()
           {0:~    }{1:baz                 }{0:               }|
           {0:~                                       }|
                                                   |
-        ]]}
+        ]],
+        }
 
         api.nvim_input_mouse('left', 'press', '', 0, 2, 5)
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                                                   |
           {0:~                                       }|
           {0:~    }{1:^foo                 }{0:               }|
@@ -7655,10 +8360,12 @@ describe('float window', function()
           {0:~    }{1:baz                 }{0:               }|
           {0:~                                       }|
                                                   |
-        ]]}
+        ]],
+        }
 
         api.nvim_input_mouse('left', 'drag', '', 0, 3, 7)
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                                                   |
           {0:~                                       }|
           {0:~    }{27:foo}{1:                 }{0:               }|
@@ -7666,16 +8373,18 @@ describe('float window', function()
           {0:~    }{1:baz                 }{0:               }|
           {0:~                                       }|
           {3:-- VISUAL --}                            |
-        ]]}
+        ]],
+        }
       end
     end)
 
-    it("left drag changes visual selection in float window with border", function()
-      local buf = api.nvim_create_buf(false,false)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {'foo', 'bar', 'baz'})
-      api.nvim_open_win(buf, false, {relative='editor', width=20, height=3, row=0, col=5, border='single'})
+    it('left drag changes visual selection in float window with border', function()
+      local buf = api.nvim_create_buf(false, false)
+      api.nvim_buf_set_lines(buf, 0, -1, true, { 'foo', 'bar', 'baz' })
+      api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 3, row = 0, col = 5, border = 'single' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -7690,15 +8399,19 @@ describe('float window', function()
           {5:│}{1:bar                 }{5:│}|
           {5:│}{1:baz                 }{5:│}|
           {5:└────────────────────┘}|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
+          },
+        }
 
         api.nvim_input_mouse('left', 'press', '', 4, 1, 1)
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -7713,15 +8426,19 @@ describe('float window', function()
           {5:│}{1:bar                 }{5:│}|
           {5:│}{1:baz                 }{5:│}|
           {5:└────────────────────┘}|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
+          },
+        }
 
         api.nvim_input_mouse('left', 'drag', '', 4, 2, 3)
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -7736,14 +8453,18 @@ describe('float window', function()
           {5:│}{27:ba}{1:^r                 }{5:│}|
           {5:│}{1:baz                 }{5:│}|
           {5:└────────────────────┘}|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 1, curcol = 2, linecount = 3, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 1, curcol = 2, linecount = 3, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^     {5:┌────────────────────┐}             |
           {0:~    }{5:│}{1:foo                 }{5:│}{0:             }|
           {0:~    }{5:│}{1:bar                 }{5:│}{0:             }|
@@ -7751,10 +8472,12 @@ describe('float window', function()
           {0:~    }{5:└────────────────────┘}{0:             }|
           {0:~                                       }|
                                                   |
-        ]]}
+        ]],
+        }
 
         api.nvim_input_mouse('left', 'press', '', 0, 1, 6)
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                {5:┌────────────────────┐}             |
           {0:~    }{5:│}{1:^foo                 }{5:│}{0:             }|
           {0:~    }{5:│}{1:bar                 }{5:│}{0:             }|
@@ -7762,10 +8485,12 @@ describe('float window', function()
           {0:~    }{5:└────────────────────┘}{0:             }|
           {0:~                                       }|
                                                   |
-        ]]}
+        ]],
+        }
 
         api.nvim_input_mouse('left', 'drag', '', 0, 2, 8)
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                {5:┌────────────────────┐}             |
           {0:~    }{5:│}{27:foo}{1:                 }{5:│}{0:             }|
           {0:~    }{5:│}{27:ba}{1:^r                 }{5:│}{0:             }|
@@ -7773,17 +8498,19 @@ describe('float window', function()
           {0:~    }{5:└────────────────────┘}{0:             }|
           {0:~                                       }|
           {3:-- VISUAL --}                            |
-        ]]}
+        ]],
+        }
       end
     end)
 
-    it("left drag changes visual selection in float window with winbar", function()
-      local buf = api.nvim_create_buf(false,false)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {'foo', 'bar', 'baz'})
-      local float_win = api.nvim_open_win(buf, false, {relative='editor', width=20, height=4, row=1, col=5})
-      api.nvim_set_option_value('winbar', 'floaty bar', {win=float_win})
+    it('left drag changes visual selection in float window with winbar', function()
+      local buf = api.nvim_create_buf(false, false)
+      api.nvim_buf_set_lines(buf, 0, -1, true, { 'foo', 'bar', 'baz' })
+      local float_win = api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 4, row = 1, col = 5 })
+      api.nvim_set_option_value('winbar', 'floaty bar', { win = float_win })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -7797,15 +8524,19 @@ describe('float window', function()
           {1:foo                 }|
           {1:bar                 }|
           {1:baz                 }|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 5, true, 50, 1, 1, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 5, true, 50, 1, 1, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
+          },
+        }
 
         api.nvim_input_mouse('left', 'press', '', 4, 1, 0)
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -7819,15 +8550,19 @@ describe('float window', function()
           {1:^foo                 }|
           {1:bar                 }|
           {1:baz                 }|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 5, true, 50, 1, 1, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 5, true, 50, 1, 1, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
+          },
+        }
 
         api.nvim_input_mouse('left', 'drag', '', 4, 2, 2)
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -7841,14 +8576,18 @@ describe('float window', function()
           {27:foo}{1:                 }|
           {27:ba}{1:^r                 }|
           {1:baz                 }|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 5, true, 50, 1, 1, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 1, curcol = 2, linecount = 3, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 5, true, 50, 1, 1, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 1, curcol = 2, linecount = 3, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~    }{3:floaty bar          }{0:               }|
           {0:~    }{1:foo                 }{0:               }|
@@ -7856,10 +8595,12 @@ describe('float window', function()
           {0:~    }{1:baz                 }{0:               }|
           {0:~                                       }|
                                                   |
-        ]]}
+        ]],
+        }
 
         api.nvim_input_mouse('left', 'press', '', 0, 2, 5)
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                                                   |
           {0:~    }{3:floaty bar          }{0:               }|
           {0:~    }{1:^foo                 }{0:               }|
@@ -7867,10 +8608,12 @@ describe('float window', function()
           {0:~    }{1:baz                 }{0:               }|
           {0:~                                       }|
                                                   |
-        ]]}
+        ]],
+        }
 
         api.nvim_input_mouse('left', 'drag', '', 0, 3, 7)
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                                                   |
           {0:~    }{3:floaty bar          }{0:               }|
           {0:~    }{27:foo}{1:                 }{0:               }|
@@ -7878,14 +8621,15 @@ describe('float window', function()
           {0:~    }{1:baz                 }{0:               }|
           {0:~                                       }|
           {3:-- VISUAL --}                            |
-        ]]}
+        ]],
+        }
       end
     end)
 
     it('left drag changes visual selection if float window is turned into a split', function()
-      local buf = api.nvim_create_buf(false,false)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {'foo', 'bar', 'baz'})
-      api.nvim_open_win(buf, true, {relative='editor', width=20, height=3, row=2, col=5})
+      local buf = api.nvim_create_buf(false, false)
+      api.nvim_buf_set_lines(buf, 0, -1, true, { 'foo', 'bar', 'baz' })
+      api.nvim_open_win(buf, true, { relative = 'editor', width = 20, height = 3, row = 2, col = 5 })
       command('wincmd L')
       if multigrid then
         screen:expect([[
@@ -7973,11 +8717,12 @@ describe('float window', function()
     end)
 
     it('left click sets correct curswant in float window with border', function()
-      local buf = api.nvim_create_buf(false,false)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {'', '', ''})
-      api.nvim_open_win(buf, false, {relative='editor', width=20, height=3, row=0, col=5, border='single'})
+      local buf = api.nvim_create_buf(false, false)
+      api.nvim_buf_set_lines(buf, 0, -1, true, { '', '', '' })
+      api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 3, row = 0, col = 5, border = 'single' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -7990,20 +8735,25 @@ describe('float window', function()
           {5:┌────────────────────┐}|
           {5:│}{1:                    }{5:│}|*3
           {5:└────────────────────┘}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 0, 5, true, 50, 1, 0, 5 };
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^     {5:┌────────────────────┐}             |
           {0:~    }{5:│}{1:                    }{5:│}{0:             }|*3
           {0:~    }{5:└────────────────────┘}{0:             }|
           {0:~                                       }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       if multigrid then
@@ -8011,26 +8761,27 @@ describe('float window', function()
       else
         api.nvim_input_mouse('left', 'press', '', 0, 3, 6)
       end
-      eq({0, 3, 1, 0, 1}, fn.getcurpos())
+      eq({ 0, 3, 1, 0, 1 }, fn.getcurpos())
 
       if multigrid then
         api.nvim_input_mouse('left', 'press', '', 4, 3, 2)
       else
         api.nvim_input_mouse('left', 'press', '', 0, 3, 7)
       end
-      eq({0, 3, 1, 0, 2}, fn.getcurpos())
+      eq({ 0, 3, 1, 0, 2 }, fn.getcurpos())
 
       if multigrid then
         api.nvim_input_mouse('left', 'press', '', 4, 3, 10)
       else
         api.nvim_input_mouse('left', 'press', '', 0, 3, 15)
       end
-      eq({0, 3, 1, 0, 10}, fn.getcurpos())
+      eq({ 0, 3, 1, 0, 10 }, fn.getcurpos())
 
       command('setlocal foldcolumn=1')
       feed('zfkgg')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -8045,14 +8796,18 @@ describe('float window', function()
           {5:│}{19:+}{28:+--  2 lines: ·····}{5:│}|
           {5:│}{2:~                   }{5:│}|
           {5:└────────────────────┘}|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 4, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 4, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                {5:┌────────────────────┐}             |
           {0:~    }{5:│}{19: }{1:^                   }{5:│}{0:             }|
           {0:~    }{5:│}{19:+}{28:+--  2 lines: ·····}{5:│}{0:             }|
@@ -8060,12 +8815,14 @@ describe('float window', function()
           {0:~    }{5:└────────────────────┘}{0:             }|
           {0:~                                       }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       if multigrid then
         api.nvim_input_mouse('left', 'press', '', 4, 2, 1)
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -8080,15 +8837,19 @@ describe('float window', function()
           {5:│}{19:-}{1:                   }{5:│}|
           {5:│}{19:│}{1:                   }{5:│}|
           {5:└────────────────────┘}|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 5, true, 50, 1, 0, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 5, true, 50, 1, 0, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 0, curcol = 0, linecount = 3, sum_scroll_delta = 0 },
+          },
+        }
       else
         api.nvim_input_mouse('left', 'press', '', 0, 2, 6)
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                {5:┌────────────────────┐}             |
           {0:~    }{5:│}{19: }{1:^                   }{5:│}{0:             }|
           {0:~    }{5:│}{19:-}{1:                   }{5:│}{0:             }|
@@ -8096,7 +8857,8 @@ describe('float window', function()
           {0:~    }{5:└────────────────────┘}{0:             }|
           {0:~                                       }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       if multigrid then
@@ -8104,51 +8866,51 @@ describe('float window', function()
       else
         api.nvim_input_mouse('left', 'press', '', 0, 2, 7)
       end
-      eq({0, 2, 1, 0, 1}, fn.getcurpos())
+      eq({ 0, 2, 1, 0, 1 }, fn.getcurpos())
 
       if multigrid then
         api.nvim_input_mouse('left', 'press', '', 4, 2, 3)
       else
         api.nvim_input_mouse('left', 'press', '', 0, 2, 8)
       end
-      eq({0, 2, 1, 0, 2}, fn.getcurpos())
+      eq({ 0, 2, 1, 0, 2 }, fn.getcurpos())
 
       if multigrid then
         api.nvim_input_mouse('left', 'press', '', 4, 2, 11)
       else
         api.nvim_input_mouse('left', 'press', '', 0, 2, 16)
       end
-      eq({0, 2, 1, 0, 10}, fn.getcurpos())
+      eq({ 0, 2, 1, 0, 10 }, fn.getcurpos())
     end)
 
     it("'winblend' option", function()
-      screen:try_resize(50,9)
+      screen:try_resize(50, 9)
       screen:set_default_attr_ids({
-        [1] = {background = Screen.colors.LightMagenta},
-        [2] = {foreground = Screen.colors.Grey0, background = tonumber('0xffcfff')},
-        [3] = {foreground = tonumber('0xb282b2'), background = tonumber('0xffcfff')},
-        [4] = {foreground = Screen.colors.Red, background = Screen.colors.LightMagenta},
-        [5] = {foreground = tonumber('0x990000'), background = tonumber('0xfff1ff')},
-        [6] = {foreground = tonumber('0x332533'), background = tonumber('0xfff1ff')},
-        [7] = {background = tonumber('0xffcfff'), bold = true, foreground = tonumber('0x0000d8')},
-        [8] = {background = Screen.colors.LightMagenta, bold = true, foreground = Screen.colors.Blue1},
-        [9] = {background = Screen.colors.LightMagenta, blend = 30},
-        [10] = {foreground = Screen.colors.Red, background = Screen.colors.LightMagenta, blend = 0},
-        [11] = {foreground = Screen.colors.Red, background = Screen.colors.LightMagenta, blend = 80},
-        [12] = {background = Screen.colors.LightMagenta, bold = true, foreground = Screen.colors.Blue1, blend = 30},
-        [13] = {foreground = Screen.colors.Black, background = Screen.colors.LightGray, blend = 30},
-        [14] = {foreground = Screen.colors.Black, background = Screen.colors.Grey88},
-        [15] = {foreground = tonumber('0x939393'), background = Screen.colors.Grey88},
-        [16] = {background = Screen.colors.Grey90};
-        [17] = {blend = 100};
-        [18] = {background = Screen.colors.LightMagenta, blend = 100};
-        [19] = {background = Screen.colors.LightMagenta, bold = true, blend = 100, foreground = Screen.colors.Blue1};
-        [20] = {background = Screen.colors.White, foreground = Screen.colors.Gray0};
-        [21] = {background = Screen.colors.White, bold = true, foreground = tonumber('0x00007f')};
-        [22] = {background = Screen.colors.Gray90, foreground = Screen.colors.Gray0};
-        [23] = {blend = 100, bold = true, foreground = Screen.colors.Magenta};
-        [24] = {foreground = tonumber('0x7f007f'), bold = true, background = Screen.colors.White};
-        [25] = {foreground = tonumber('0x7f007f'), bold = true, background = Screen.colors.Grey90};
+        [1] = { background = Screen.colors.LightMagenta },
+        [2] = { foreground = Screen.colors.Grey0, background = tonumber('0xffcfff') },
+        [3] = { foreground = tonumber('0xb282b2'), background = tonumber('0xffcfff') },
+        [4] = { foreground = Screen.colors.Red, background = Screen.colors.LightMagenta },
+        [5] = { foreground = tonumber('0x990000'), background = tonumber('0xfff1ff') },
+        [6] = { foreground = tonumber('0x332533'), background = tonumber('0xfff1ff') },
+        [7] = { background = tonumber('0xffcfff'), bold = true, foreground = tonumber('0x0000d8') },
+        [8] = { background = Screen.colors.LightMagenta, bold = true, foreground = Screen.colors.Blue1 },
+        [9] = { background = Screen.colors.LightMagenta, blend = 30 },
+        [10] = { foreground = Screen.colors.Red, background = Screen.colors.LightMagenta, blend = 0 },
+        [11] = { foreground = Screen.colors.Red, background = Screen.colors.LightMagenta, blend = 80 },
+        [12] = { background = Screen.colors.LightMagenta, bold = true, foreground = Screen.colors.Blue1, blend = 30 },
+        [13] = { foreground = Screen.colors.Black, background = Screen.colors.LightGray, blend = 30 },
+        [14] = { foreground = Screen.colors.Black, background = Screen.colors.Grey88 },
+        [15] = { foreground = tonumber('0x939393'), background = Screen.colors.Grey88 },
+        [16] = { background = Screen.colors.Grey90 },
+        [17] = { blend = 100 },
+        [18] = { background = Screen.colors.LightMagenta, blend = 100 },
+        [19] = { background = Screen.colors.LightMagenta, bold = true, blend = 100, foreground = Screen.colors.Blue1 },
+        [20] = { background = Screen.colors.White, foreground = Screen.colors.Gray0 },
+        [21] = { background = Screen.colors.White, bold = true, foreground = tonumber('0x00007f') },
+        [22] = { background = Screen.colors.Gray90, foreground = Screen.colors.Gray0 },
+        [23] = { blend = 100, bold = true, foreground = Screen.colors.Magenta },
+        [24] = { foreground = tonumber('0x7f007f'), bold = true, background = Screen.colors.White },
+        [25] = { foreground = tonumber('0x7f007f'), bold = true, background = Screen.colors.Grey90 },
       })
       insert([[
         Lorem ipsum dolor sit amet, consectetur
@@ -8162,12 +8924,13 @@ describe('float window', function()
         occaecat cupidatat non proident, sunt in culpa
         qui officia deserunt mollit anim id est
         laborum.]])
-      local buf = api.nvim_create_buf(false,false)
-      local test_data = {"test", "", "popup    text"}
+      local buf = api.nvim_create_buf(false, false)
+      local test_data = { 'test', '', 'popup    text' }
       api.nvim_buf_set_lines(buf, 0, -1, true, test_data)
-      local win = api.nvim_open_win(buf, false, {relative='editor', width=15, height=3, row=2, col=5})
+      local win = api.nvim_open_win(buf, false, { relative = 'editor', width = 15, height = 3, row = 2, col = 5 })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:--------------------------------------------------]|*8
           [3:--------------------------------------------------]|
@@ -8186,7 +8949,9 @@ describe('float window', function()
           {1:test           }|
           {1:               }|
           {1:popup    text  }|
-        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}}}
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+        }
       else
         screen:expect([[
           Ut enim ad minim veniam, quis nostrud             |
@@ -8201,9 +8966,10 @@ describe('float window', function()
         ]])
       end
 
-      api.nvim_set_option_value("winblend", 30, {win=win})
+      api.nvim_set_option_value('winblend', 30, { win = win })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:--------------------------------------------------]|*8
           [3:--------------------------------------------------]|
@@ -8222,7 +8988,10 @@ describe('float window', function()
           {9:test           }|
           {9:               }|
           {9:popup    text  }|
-        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}}, unchanged=true}
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          unchanged = true,
+        }
       else
         screen:expect([[
           Ut enim ad minim veniam, quis nostrud             |
@@ -8238,10 +9007,11 @@ describe('float window', function()
       end
 
       -- Treat for \u2800 (braille blank) as whitespace.
-      local braille_blank = "\226\160\128"
-      api.nvim_buf_set_lines(buf, 0, -1, true, {"test" .. braille_blank, "", "popup"..braille_blank.."   text"})
+      local braille_blank = '\226\160\128'
+      api.nvim_buf_set_lines(buf, 0, -1, true, { 'test' .. braille_blank, '', 'popup' .. braille_blank .. '   text' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:--------------------------------------------------]|*8
           [3:--------------------------------------------------]|
@@ -8260,7 +9030,10 @@ describe('float window', function()
           {9:test]] .. braille_blank .. [[          }|
           {9:               }|
           {9:popup]] .. braille_blank .. [[   text  }|
-        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}}, unchanged=true}
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          unchanged = true,
+        }
       else
         screen:expect([[
           Ut enim ad minim veniam, quis nostrud             |
@@ -8277,9 +9050,10 @@ describe('float window', function()
       api.nvim_buf_set_lines(buf, 0, -1, true, test_data)
 
       -- Check that 'winblend' works with NormalNC highlight
-      api.nvim_set_option_value('winhighlight', 'NormalNC:Visual', {win = win})
+      api.nvim_set_option_value('winhighlight', 'NormalNC:Visual', { win = win })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:--------------------------------------------------]|*8
           [3:--------------------------------------------------]|
@@ -8298,7 +9072,9 @@ describe('float window', function()
           {13:test           }|
           {13:               }|
           {13:popup    text  }|
-        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}}}
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+        }
       else
         screen:expect([[
           Ut enim ad minim veniam, quis nostrud             |
@@ -8314,17 +9090,21 @@ describe('float window', function()
       end
 
       -- Also test with global NormalNC highlight
-      exec_lua([[
+      exec_lua(
+        [[
         vim.api.nvim_set_option_value('winhighlight', '', {win = ...})
         vim.api.nvim_set_hl(0, 'NormalNC', {link = 'Visual'})
-      ]], win)
+      ]],
+        win
+      )
       screen:expect_unchanged()
       command('hi clear NormalNC')
 
       command('hi SpecialRegion guifg=Red blend=0')
-      api.nvim_buf_add_highlight(buf, -1, "SpecialRegion", 2, 0, -1)
+      api.nvim_buf_add_highlight(buf, -1, 'SpecialRegion', 2, 0, -1)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:--------------------------------------------------]|*8
           [3:--------------------------------------------------]|
@@ -8343,7 +9123,9 @@ describe('float window', function()
           {9:test           }|
           {9:               }|
           {10:popup    text}{9:  }|
-        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}}}
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+        }
       else
         screen:expect([[
           Ut enim ad minim veniam, quis nostrud             |
@@ -8360,7 +9142,8 @@ describe('float window', function()
 
       command('hi SpecialRegion guifg=Red blend=80')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:--------------------------------------------------]|*8
           [3:--------------------------------------------------]|
@@ -8379,7 +9162,10 @@ describe('float window', function()
           {9:test           }|
           {9:               }|
           {11:popup    text}{9:  }|
-        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}}, unchanged=true}
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+          unchanged = true,
+        }
       else
         screen:expect([[
           Ut enim ad minim veniam, quis nostrud             |
@@ -8397,7 +9183,8 @@ describe('float window', function()
       -- Test scrolling by mouse
       if multigrid then
         api.nvim_input_mouse('wheel', 'down', '', 4, 2, 2)
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:--------------------------------------------------]|*8
           [3:--------------------------------------------------]|
@@ -8415,7 +9202,9 @@ describe('float window', function()
         ## grid 4
           {11:popup    text}{9:  }|
           {12:~              }|*2
-        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}}}
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+        }
       else
         api.nvim_input_mouse('wheel', 'down', '', 0, 4, 7)
         screen:expect([[
@@ -8432,13 +9221,14 @@ describe('float window', function()
       end
 
       -- Check that 'winblend' applies to border/title/footer
-      api.nvim_win_set_config(win, {border='single', title='Title', footer='Footer'})
-      api.nvim_set_option_value('winblend', 100, {win=win})
-      api.nvim_set_option_value("cursorline", true, {win=0})
+      api.nvim_win_set_config(win, { border = 'single', title = 'Title', footer = 'Footer' })
+      api.nvim_set_option_value('winblend', 100, { win = win })
+      api.nvim_set_option_value('cursorline', true, { win = 0 })
       command('hi clear VertSplit')
       feed('k0')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:--------------------------------------------------]|*8
           [3:--------------------------------------------------]|
@@ -8458,7 +9248,9 @@ describe('float window', function()
           {17:│}{11:popup    text}{18:  }{17:│}|
           {17:│}{19:~              }{17:│}|*2
           {17:└}{23:Footer}{17:─────────┘}|
-        ]], float_pos={[4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5}}}
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 } },
+        }
       else
         screen:expect([[
           Ut enim ad minim veniam, quis nostrud             |
@@ -8478,11 +9270,12 @@ describe('float window', function()
       insert([[
         # TODO: 测试字典信息的准确性
         # FIXME: 测试字典信息的准确性]])
-      local buf = api.nvim_create_buf(false,false)
-      api.nvim_buf_set_lines(buf, 0, -1, true, {'口', '口'})
-      local win = api.nvim_open_win(buf, false, {relative='editor', width=5, height=3, row=0, col=11, style='minimal'})
+      local buf = api.nvim_create_buf(false, false)
+      api.nvim_buf_set_lines(buf, 0, -1, true, { '口', '口' })
+      local win = api.nvim_open_win(buf, false, { relative = 'editor', width = 5, height = 3, row = 0, col = 11, style = 'minimal' })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -8495,7 +9288,9 @@ describe('float window', function()
         ## grid 4
           {1:口   }|*2
           {1:     }|
-        ]], float_pos={ [4] = { 1001, "NW", 1, 0, 11, true, 50, 1, 0, 11 } }}
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 0, 11, true, 50, 1, 0, 11 } },
+        }
       else
         screen:expect([[
           # TODO: 测 {1:口   }信息的准确性            |
@@ -8531,18 +9326,19 @@ describe('float window', function()
       -- The interaction between 'winblend' and doublewidth chars in the background
       -- does not look very good. But check no chars get incorrectly placed
       -- at least. Also check invisible EndOfBuffer region blends correctly.
-      api.nvim_buf_set_lines(buf, 0, -1, true, {" x x  x   xx", "  x x  x   x"})
-      win = api.nvim_open_win(buf, false, {relative='editor', width=12, height=3, row=0, col=11, style='minimal'})
-      api.nvim_set_option_value('winblend', 30, {win=win})
+      api.nvim_buf_set_lines(buf, 0, -1, true, { ' x x  x   xx', '  x x  x   x' })
+      win = api.nvim_open_win(buf, false, { relative = 'editor', width = 12, height = 3, row = 0, col = 11, style = 'minimal' })
+      api.nvim_set_option_value('winblend', 30, { win = win })
       screen:set_default_attr_ids({
-        [1] = {foreground = tonumber('0xb282b2'), background = tonumber('0xffcfff')},
-        [2] = {foreground = Screen.colors.Grey0, background = tonumber('0xffcfff')},
-        [3] = {bold = true, foreground = Screen.colors.Blue1},
-        [4] = {background = tonumber('0xffcfff'), bold = true, foreground = tonumber('0xb282ff')},
-        [5] = {background = Screen.colors.LightMagenta, blend=30},
+        [1] = { foreground = tonumber('0xb282b2'), background = tonumber('0xffcfff') },
+        [2] = { foreground = Screen.colors.Grey0, background = tonumber('0xffcfff') },
+        [3] = { bold = true, foreground = Screen.colors.Blue1 },
+        [4] = { background = tonumber('0xffcfff'), bold = true, foreground = tonumber('0xb282ff') },
+        [5] = { background = Screen.colors.LightMagenta, blend = 30 },
       })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -8556,9 +9352,11 @@ describe('float window', function()
           {5: x x  x   xx}|
           {5:  x x  x   x}|
           {5:            }|
-        ]], float_pos={
-          [5] = { 1002, "NW", 1, 0, 11, true, 50, 1, 0, 11 }
-        }}
+        ]],
+          float_pos = {
+            [5] = { 1002, 'NW', 1, 0, 11, true, 50, 1, 0, 11 },
+          },
+        }
       else
         screen:expect([[
           # TODO: 测 {2: x x  x}{1:息}{2: xx} 确性            |
@@ -8569,9 +9367,10 @@ describe('float window', function()
         ]])
       end
 
-      api.nvim_win_set_config(win, {relative='editor', row=0, col=12})
+      api.nvim_win_set_config(win, { relative = 'editor', row = 0, col = 12 })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -8585,9 +9384,11 @@ describe('float window', function()
           {5: x x  x   xx}|
           {5:  x x  x   x}|
           {5:            }|
-        ]], float_pos={
-          [5] = { 1002, "NW", 1, 0, 12, true, 50, 1, 0, 12 }
-        }}
+        ]],
+          float_pos = {
+            [5] = { 1002, 'NW', 1, 0, 12, true, 50, 1, 0, 12 },
+          },
+        }
       else
         screen:expect([[
           # TODO: 测试{2: x x}{1:信}{2:x }{1:的}{2:xx}确性            |
@@ -8599,8 +9400,8 @@ describe('float window', function()
       end
     end)
 
-    it("correctly redraws when overlaid windows are resized #13991", function()
-	  n.source([[
+    it('correctly redraws when overlaid windows are resized #13991', function()
+      n.source([[
         let popup_config = {"relative" : "editor",
                     \ "width" : 7,
                     \ "height" : 3,
@@ -8628,7 +9429,8 @@ describe('float window', function()
       ]])
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
 		## grid 1
 		  [2:----------------------------------------]|*6
 		  [3:----------------------------------------]|
@@ -8645,13 +9447,16 @@ describe('float window', function()
 		  {2:---------}|
 		  {2:-       -}|*2
 		  {2:         }|*2
-		]], attr_ids={
-          [1] = {foreground = Screen.colors.Blue1, bold = true};
-          [2] = {background = Screen.colors.LightMagenta};
-        }, float_pos={
-            [4] = {1001, "NW", 1, 1, 1, true, 50, 2, 1, 1},
-            [5] = {1002, "NW", 1, 0, 0, true, 50, 1, 0, 0}
-        }}
+		]],
+          attr_ids = {
+            [1] = { foreground = Screen.colors.Blue1, bold = true },
+            [2] = { background = Screen.colors.LightMagenta },
+          },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 2, 1, 1 },
+            [5] = { 1002, 'NW', 1, 0, 0, true, 50, 1, 0, 0 },
+          },
+        }
       else
         screen:expect([[
         {1:---------}                               |
@@ -8679,9 +9484,10 @@ describe('float window', function()
         nnoremap zz <cmd>call Resize()<cr>
       ]])
 
-      n.feed("zz")
+      n.feed('zz')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -8698,13 +9504,16 @@ describe('float window', function()
           {2:---}|
           {2:- -}|*2
           {2:   }|*2
-        ]], attr_ids={
-          [1] = {foreground = Screen.colors.Blue1, bold = true};
-          [2] = {background = Screen.colors.LightMagenta};
-        }, float_pos={
-          [4] = { 1001, "NW", 1, 1, 1, true, 50, 2, 1, 1 },
-          [5] = { 1002, "NW", 1, 0, 0, true, 50, 1, 0, 0 }
-        }}
+        ]],
+          attr_ids = {
+            [1] = { foreground = Screen.colors.Blue1, bold = true },
+            [2] = { background = Screen.colors.LightMagenta },
+          },
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 2, 1, 1 },
+            [5] = { 1002, 'NW', 1, 0, 0, true, 50, 1, 0, 0 },
+          },
+        }
       else
         screen:expect([[
         {1:---}                                     |
@@ -8718,13 +9527,14 @@ describe('float window', function()
       end
     end)
 
-    it("correctly orders multiple opened floats (current last)", function()
-      local buf = api.nvim_create_buf(false,false)
-      local win = api.nvim_open_win(buf, false, {relative='editor', width=20, height=2, row=2, col=5})
-      api.nvim_set_option_value("winhl", "Normal:ErrorMsg,EndOfBuffer:ErrorMsg", {win=win})
+    it('correctly orders multiple opened floats (current last)', function()
+      local buf = api.nvim_create_buf(false, false)
+      local win = api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 2, row = 2, col = 5 })
+      api.nvim_set_option_value('winhl', 'Normal:ErrorMsg,EndOfBuffer:ErrorMsg', { win = win })
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -8736,21 +9546,26 @@ describe('float window', function()
         ## grid 4
           {7:                    }|
           {7:~                   }|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{7:                    }{0:               }|
           {0:~    }{7:~                   }{0:               }|
           {0:~                                       }|*2
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       exec_lua [[
@@ -8763,7 +9578,8 @@ describe('float window', function()
       ]]
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -8781,18 +9597,22 @@ describe('float window', function()
         ## grid 6
           {17:^            }|
           {17:~           }|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
-          [5] = {1002, "NW", 1, 3, 8, true, 50, 2, 3, 8};
-          [6] = {1003, "NW", 1, 4, 10, true, 50, 3, 4, 10};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount=1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount=1, sum_scroll_delta = 0};
-          [5] = {win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount=1, sum_scroll_delta = 0};
-          [6] = {win = 1003, topline = 0, botline = 2, curline = 0, curcol = 0, linecount=1, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+            [5] = { 1002, 'NW', 1, 3, 8, true, 50, 2, 3, 8 },
+            [6] = { 1003, 'NW', 1, 4, 10, true, 50, 3, 4, 10 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [5] = { win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [6] = { win = 1003, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                                                   |
           {0:~                                       }|
           {0:~    }{7:                    }{0:               }|
@@ -8800,7 +9620,8 @@ describe('float window', function()
           {0:~       }{1:~ }{17:^            }{1:  }{0:                }|
           {0:~         }{17:~           }{0:                  }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       -- This should bring win into focus on top
@@ -8827,25 +9648,26 @@ describe('float window', function()
             {17:~           }|
           ]],
           win_pos = {
-          [2] = {
-            height = 6,
-            startcol = 0,
-            startrow = 0,
-            width = 40,
-            win = 1000
-          }
-        },
+            [2] = {
+              height = 6,
+              startcol = 0,
+              startrow = 0,
+              width = 40,
+              win = 1000,
+            },
+          },
           float_pos = {
-          [4] = {1001, "NW", 1, 2, 5, true, 50, 3, 2, 5};
-          [5] = {1002, "NW", 1, 3, 8, true, 50, 1, 3, 8};
-          [6] = {1003, "NW", 1, 4, 10, true, 50, 2, 4, 10};
-        },
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 3, 2, 5 },
+            [5] = { 1002, 'NW', 1, 3, 8, true, 50, 1, 3, 8 },
+            [6] = { 1003, 'NW', 1, 4, 10, true, 50, 2, 4, 10 },
+          },
           win_viewport = {
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [5] = {win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [6] = {win = 1003, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }})
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [5] = { win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [6] = { win = 1003, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        })
       else
         screen:expect([[
                                                   |
@@ -8859,13 +9681,14 @@ describe('float window', function()
       end
     end)
 
-    it("correctly orders multiple opened floats (non-current last)", function()
-      local buf = api.nvim_create_buf(false,false)
-      local win = api.nvim_open_win(buf, false, {relative='editor', width=20, height=2, row=2, col=5})
-      api.nvim_set_option_value("winhl", "Normal:ErrorMsg,EndOfBuffer:ErrorMsg", {win=win})
+    it('correctly orders multiple opened floats (non-current last)', function()
+      local buf = api.nvim_create_buf(false, false)
+      local win = api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 2, row = 2, col = 5 })
+      api.nvim_set_option_value('winhl', 'Normal:ErrorMsg,EndOfBuffer:ErrorMsg', { win = win })
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -8877,21 +9700,26 @@ describe('float window', function()
         ## grid 4
           {7:                    }|
           {7:~                   }|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {0:~    }{7:                    }{0:               }|
           {0:~    }{7:~                   }{0:               }|
           {0:~                                       }|*2
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       exec_lua [[
@@ -8904,7 +9732,8 @@ describe('float window', function()
       ]]
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -8922,18 +9751,22 @@ describe('float window', function()
         ## grid 6
           {1:                }|
           {1:~               }|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5};
-          [5] = {1002, "NW", 1, 4, 10, true, 50, 3, 4, 10};
-          [6] = {1003, "NW", 1, 3, 8, true, 50, 2, 3, 8};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [5] = {win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [6] = {win = 1003, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
+            [5] = { 1002, 'NW', 1, 4, 10, true, 50, 3, 4, 10 },
+            [6] = { 1003, 'NW', 1, 3, 8, true, 50, 2, 3, 8 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [5] = { win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [6] = { win = 1003, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                                                   |
           {0:~                                       }|
           {0:~    }{7:                    }{0:               }|
@@ -8941,7 +9774,8 @@ describe('float window', function()
           {0:~       }{1:~ }{17:^            }{1:  }{0:                }|
           {0:~         }{17:~           }{0:                  }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       -- This should bring win into focus on top
@@ -8968,25 +9802,26 @@ describe('float window', function()
             {1:~               }|
           ]],
           win_pos = {
-          [2] = {
-            height = 6,
-            startcol = 0,
-            startrow = 0,
-            width = 40,
-            win = 1000
-          }
-        },
+            [2] = {
+              height = 6,
+              startcol = 0,
+              startrow = 0,
+              width = 40,
+              win = 1000,
+            },
+          },
           float_pos = {
-          [4] = {1001, "NW", 1, 2, 5, true, 50, 3, 2, 5};
-          [5] = {1002, "NW", 1, 4, 10, true, 50, 2, 4, 10};
-          [6] = {1003, "NW", 1, 3, 8, true, 50, 1, 3, 8};
-        },
+            [4] = { 1001, 'NW', 1, 2, 5, true, 50, 3, 2, 5 },
+            [5] = { 1002, 'NW', 1, 4, 10, true, 50, 2, 4, 10 },
+            [6] = { 1003, 'NW', 1, 3, 8, true, 50, 1, 3, 8 },
+          },
           win_viewport = {
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [5] = {win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [6] = {win = 1003, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }})
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [5] = { win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [6] = { win = 1003, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        })
       else
         screen:expect([[
                                                   |
@@ -9001,16 +9836,17 @@ describe('float window', function()
     end)
 
     it('can use z-index', function()
-      local buf = api.nvim_create_buf(false,false)
-      local win1 = api.nvim_open_win(buf, false, {relative='editor', width=20, height=3, row=1, col=5, zindex=30})
-      api.nvim_set_option_value("winhl", "Normal:ErrorMsg,EndOfBuffer:ErrorMsg", {win=win1})
-      local win2 = api.nvim_open_win(buf, false, {relative='editor', width=20, height=3, row=2, col=6, zindex=50})
-      api.nvim_set_option_value("winhl", "Normal:Search,EndOfBuffer:Search", {win=win2})
-      local win3 = api.nvim_open_win(buf, false, {relative='editor', width=20, height=3, row=3, col=7, zindex=40})
-      api.nvim_set_option_value("winhl", "Normal:Question,EndOfBuffer:Question", {win=win3})
+      local buf = api.nvim_create_buf(false, false)
+      local win1 = api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 3, row = 1, col = 5, zindex = 30 })
+      api.nvim_set_option_value('winhl', 'Normal:ErrorMsg,EndOfBuffer:ErrorMsg', { win = win1 })
+      local win2 = api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 3, row = 2, col = 6, zindex = 50 })
+      api.nvim_set_option_value('winhl', 'Normal:Search,EndOfBuffer:Search', { win = win2 })
+      local win3 = api.nvim_open_win(buf, false, { relative = 'editor', width = 20, height = 3, row = 3, col = 7, zindex = 40 })
+      api.nvim_set_option_value('winhl', 'Normal:Question,EndOfBuffer:Question', { win = win3 })
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -9028,18 +9864,22 @@ describe('float window', function()
         ## grid 6
           {8:                    }|
           {8:~                   }|*2
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 5, true, 30, 1, 1, 5};
-          [5] = {1002, "NW", 1, 2, 6, true, 50, 3, 2, 6};
-          [6] = {1003, "NW", 1, 3, 7, true, 40, 2, 3, 7};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [5] = {win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [6] = {win = 1003, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 5, true, 30, 1, 1, 5 },
+            [5] = { 1002, 'NW', 1, 2, 6, true, 50, 3, 2, 6 },
+            [6] = { 1003, 'NW', 1, 3, 7, true, 40, 2, 3, 7 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [5] = { win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [6] = { win = 1003, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~    }{7:                    }{0:               }|
           {0:~    }{7:~}{17:                    }{0:              }|
@@ -9047,18 +9887,23 @@ describe('float window', function()
           {0:~     }{17:~                   }{8: }{0:             }|
           {0:~      }{8:~                   }{0:             }|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       --
       -- Check that floats are positioned correctly after changing the zindexes.
       --
       command('fclose')
-      exec_lua([[
+      exec_lua(
+        [[
         local win1, win3 = ...
         vim.api.nvim_win_set_config(win1, { zindex = 400, title = 'win_400', title_pos = 'center', border = 'double' })
         vim.api.nvim_win_set_config(win3, { zindex = 300, title = 'win_300', title_pos = 'center', border = 'single' })
-      ]], win1, win3)
+      ]],
+        win1,
+        win3
+      )
       if multigrid then
         screen:expect({
           grid = [[
@@ -9080,18 +9925,22 @@ describe('float window', function()
             {5:│}{8:                    }{5:│}|
             {5:│}{8:~                   }{5:│}|*2
             {5:└────────────────────┘}|
-          ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 5, true, 400, 3, 1, 5};
-          [6] = {1003, "NW", 1, 3, 7, true, 300, 2, 2, 7};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [6] = {win = 1003, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }, win_viewport_margins={
-          [2] = { bottom = 0, left = 0, right = 0, top = 0, win = 1000 },
-          [4] = { bottom = 1, left = 1, right = 1, top = 1, win = 1001 },
-          [6] = { bottom = 1, left = 1, right = 1, top = 1, win = 1003 }
-        }})
+          ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 5, true, 400, 3, 1, 5 },
+            [6] = { 1003, 'NW', 1, 3, 7, true, 300, 2, 2, 7 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [6] = { win = 1003, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+          win_viewport_margins = {
+            [2] = { bottom = 0, left = 0, right = 0, top = 0, win = 1000 },
+            [4] = { bottom = 1, left = 1, right = 1, top = 1, win = 1001 },
+            [6] = { bottom = 1, left = 1, right = 1, top = 1, win = 1003 },
+          },
+        })
       else
         screen:expect({
           grid = [[
@@ -9101,14 +9950,18 @@ describe('float window', function()
             {0:~    }{5:║}{7:~                   }{5:║}{8: }{5:│}{0:           }|*2
             {0:~    }{5:╚════════════════════╝}{8: }{5:│}{0:           }|
                    {5:└────────────────────┘}           |
-          ]]
+          ]],
         })
       end
-      exec_lua([[
+      exec_lua(
+        [[
         local win1, win3 = ...
         vim.api.nvim_win_set_config(win1, { zindex = 100, title='win_100' })
         vim.api.nvim_win_set_config(win3, { zindex = 150, title='win_150' })
-      ]], win1, win3)
+      ]],
+        win1,
+        win3
+      )
       if multigrid then
         screen:expect({
           grid = [[
@@ -9132,37 +9985,37 @@ describe('float window', function()
             {5:└────────────────────┘}|
           ]],
           float_pos = {
-          [4] = {1001, "NW", 1, 1, 5, true, 100, 1, 1, 5 };
-          [6] = {1003, "NW", 1, 3, 7, true, 150, 2, 1, 7 };
-        },
+            [4] = { 1001, 'NW', 1, 1, 5, true, 100, 1, 1, 5 },
+            [6] = { 1003, 'NW', 1, 3, 7, true, 150, 2, 1, 7 },
+          },
           win_viewport = {
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [6] = {win = 1003, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        },
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [6] = { win = 1003, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
           win_viewport_margins = {
-          [2] = {
-            bottom = 0,
-            left = 0,
-            right = 0,
-            top = 0,
-            win = 1000
+            [2] = {
+              bottom = 0,
+              left = 0,
+              right = 0,
+              top = 0,
+              win = 1000,
+            },
+            [4] = {
+              bottom = 1,
+              left = 1,
+              right = 1,
+              top = 1,
+              win = 1001,
+            },
+            [6] = {
+              bottom = 1,
+              left = 1,
+              right = 1,
+              top = 1,
+              win = 1003,
+            },
           },
-          [4] = {
-            bottom = 1,
-            left = 1,
-            right = 1,
-            top = 1,
-            win = 1001
-          },
-          [6] = {
-            bottom = 1,
-            left = 1,
-            right = 1,
-            top = 1,
-            win = 1003
-          }
-        },
         })
       else
         screen:expect([[
@@ -9177,12 +10030,13 @@ describe('float window', function()
     end)
 
     it('can use winbar', function()
-      local buf = api.nvim_create_buf(false,false)
-      local win1 = api.nvim_open_win(buf, false, {relative='editor', width=15, height=3, row=1, col=5})
-      api.nvim_set_option_value('winbar', 'floaty bar', {win=win1})
+      local buf = api.nvim_create_buf(false, false)
+      local win1 = api.nvim_open_win(buf, false, { relative = 'editor', width = 15, height = 3, row = 1, col = 5 })
+      api.nvim_set_option_value('winbar', 'floaty bar', { win = win1 })
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -9195,28 +10049,34 @@ describe('float window', function()
           {3:floaty bar     }|
           {1:               }|
           {2:~              }|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 5, true, 50, 1, 1, 5};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 5, true, 50, 1, 1, 5 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~    }{3:floaty bar     }{0:                    }|
           {0:~    }{1:               }{0:                    }|
           {0:~    }{2:~              }{0:                    }|
           {0:~                                       }|*2
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       -- resize and add a border
-      api.nvim_win_set_config(win1, {relative='editor', width=15, height=4, row=0, col=4, border = 'single'})
+      api.nvim_win_set_config(win1, { relative = 'editor', width = 15, height = 4, row = 0, col = 4, border = 'single' })
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -9231,36 +10091,52 @@ describe('float window', function()
           {5:│}{1:               }{5:│}|
           {5:│}{2:~              }{5:│}|*2
           {5:└───────────────┘}|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 0, 4, true, 50, 1, 0, 4};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        },
-        win_viewport_margins={
-          [2] = {win = 1000, top = 0, bottom = 0, left = 0, right = 0};
-          [4] = {win = 1001, top = 2, bottom = 1, left = 1, right = 1};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 0, 4, true, 50, 1, 0, 4 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+          win_viewport_margins = {
+            [2] = { win = 1000, top = 0, bottom = 0, left = 0, right = 0 },
+            [4] = { win = 1001, top = 2, bottom = 1, left = 1, right = 1 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^    {5:┌───────────────┐}                   |
           {0:~   }{5:│}{3:floaty bar     }{5:│}{0:                   }|
           {0:~   }{5:│}{1:               }{5:│}{0:                   }|
           {0:~   }{5:│}{2:~              }{5:│}{0:                   }|*2
           {0:~   }{5:└───────────────┘}{0:                   }|
                                                   |
-        ]]}
+        ]],
+        }
       end
     end)
 
     it('it can be resized with messages and cmdheight=0 #20106', function()
-      screen:try_resize(40,9)
+      screen:try_resize(40, 9)
       command 'set cmdheight=0'
-      local buf = api.nvim_create_buf(false,true)
-      local win = api.nvim_open_win(buf, false, {relative='editor', width=40, height=4, anchor='SW', row=9, col=0, style='minimal', border="single", noautocmd=true})
+      local buf = api.nvim_create_buf(false, true)
+      local win = api.nvim_open_win(buf, false, {
+        relative = 'editor',
+        width = 40,
+        height = 4,
+        anchor = 'SW',
+        row = 9,
+        col = 0,
+        style = 'minimal',
+        border = 'single',
+        noautocmd = true,
+      })
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*9
         ## grid 2
@@ -9271,30 +10147,39 @@ describe('float window', function()
           {5:┌────────────────────────────────────────┐}|
           {5:│}{1:                                        }{5:│}|*4
           {5:└────────────────────────────────────────┘}|
-        ]], float_pos={
-          [4] = {1001, "SW", 1, 9, 0, true, 50, 1, 3, 0};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'SW', 1, 9, 0, true, 50, 1, 3, 0 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|*2
           {5:┌──────────────────────────────────────┐}|
           {5:│}{1:                                      }{5:│}|*4
           {5:└──────────────────────────────────────┘}|
-        ]]}
+        ]],
+        }
       end
 
-      exec_lua([[
+      exec_lua(
+        [[
         local win = ...
         vim.api.nvim_win_set_height(win, 2)
         vim.api.nvim_echo({ { "" } }, false, {})
-      ]], win)
+      ]],
+        win
+      )
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*9
         ## grid 2
@@ -9305,50 +10190,70 @@ describe('float window', function()
           {5:┌────────────────────────────────────────┐}|
           {5:│}{1:                                        }{5:│}|*2
           {5:└────────────────────────────────────────┘}|
-        ]], float_pos={
-          [4] = {1001, "SW", 1, 9, 0, true, 50, 1, 5, 0};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'SW', 1, 9, 0, true, 50, 1, 5, 0 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|*4
           {5:┌──────────────────────────────────────┐}|
           {5:│}{1:                                      }{5:│}|*2
           {5:└──────────────────────────────────────┘}|
-        ]]}
-
+        ]],
+        }
       end
 
       api.nvim_win_close(win, true)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*9
         ## grid 2
           ^                                        |
           {0:~                                       }|*8
         ## grid 3
-        ]], win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+        ]],
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|*8
-        ]]}
+        ]],
+        }
       end
     end)
 
     it('it can be resized with messages and cmdheight=1', function()
-      screen:try_resize(40,9)
-      local buf = api.nvim_create_buf(false,true)
-      local win = api.nvim_open_win(buf, false, {relative='editor', width=40, height=4, anchor='SW', row=8, col=0, style='minimal', border="single", noautocmd=true})
+      screen:try_resize(40, 9)
+      local buf = api.nvim_create_buf(false, true)
+      local win = api.nvim_open_win(buf, false, {
+        relative = 'editor',
+        width = 40,
+        height = 4,
+        anchor = 'SW',
+        row = 8,
+        col = 0,
+        style = 'minimal',
+        border = 'single',
+        noautocmd = true,
+      })
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*8
           [3:----------------------------------------]|
@@ -9361,34 +10266,43 @@ describe('float window', function()
           {5:┌────────────────────────────────────────┐}|
           {5:│}{1:                                        }{5:│}|*4
           {5:└────────────────────────────────────────┘}|
-        ]], float_pos={
-          [4] = {1001, "SW", 1, 8, 0, true, 50, 1, 2, 0};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'SW', 1, 8, 0, true, 50, 1, 2, 0 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|
           {5:┌──────────────────────────────────────┐}|
           {5:│}{1:                                      }{5:│}|*4
           {5:└──────────────────────────────────────┘}|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
-      exec_lua([[
+      exec_lua(
+        [[
         -- echo prompt is blocking, so schedule
         local win = ...
         vim.schedule(function()
           vim.api.nvim_win_set_height(win, 2)
           vim.api.nvim_echo({ { "\n" } }, false, {})
         end)
-      ]], win)
+      ]],
+        win
+      )
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*7
           [3:----------------------------------------]|*2
@@ -9402,14 +10316,18 @@ describe('float window', function()
           {5:┌────────────────────────────────────────┐}|
           {5:│}{1:                                        }{5:│}|*4
           {5:└────────────────────────────────────────┘}|
-        ]], float_pos={
-          [4] = { 1001, "SW", 1, 8, 0, true, 50, 1, 4, 0 };
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'SW', 1, 8, 0, true, 50, 1, 4, 0 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                                                   |
           {0:~                                       }|
           {5:┌──────────────────────────────────────┐}|
@@ -9417,12 +10335,14 @@ describe('float window', function()
           {4:                                        }|
                                                   |
           {8:Press ENTER or type command to continue}^ |
-        ]]}
+        ]],
+        }
       end
 
       feed('<cr>')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*8
           [3:----------------------------------------]|
@@ -9435,26 +10355,32 @@ describe('float window', function()
           {5:┌────────────────────────────────────────┐}|
           {5:│}{1:                                        }{5:│}|*2
           {5:└────────────────────────────────────────┘}|
-        ]], float_pos={
-          [4] = {1001, "SW", 1, 8, 0, true, 50, 1, 4, 0};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'SW', 1, 8, 0, true, 50, 1, 4, 0 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|*3
           {5:┌──────────────────────────────────────┐}|
           {5:│}{1:                                      }{5:│}|*2
           {5:└──────────────────────────────────────┘}|
                                                   |
-        ]]}
+        ]],
+        }
       end
 
       api.nvim_win_close(win, true)
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*8
           [3:----------------------------------------]|
@@ -9463,24 +10389,28 @@ describe('float window', function()
           {0:~                                       }|*7
         ## grid 3
                                                   |
-        ]], win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+        ]],
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ^                                        |
           {0:~                                       }|*7
                                                   |
-        ]]}
+        ]],
+        }
       end
     end)
 
     describe('no crash after moving and closing float window #21547', function()
       local function test_float_move_close(cmd)
-        local float_opts = {relative = 'editor', row = 1, col = 1, width = 10, height = 10}
+        local float_opts = { relative = 'editor', row = 1, col = 1, width = 10, height = 10 }
         api.nvim_open_win(api.nvim_create_buf(false, false), true, float_opts)
         if multigrid then
-          screen:expect({float_pos = {[4] = {1001, 'NW', 1, 1, 1, true, 50, 1, 0, 1}}})
+          screen:expect({ float_pos = { [4] = { 1001, 'NW', 1, 1, 1, true, 50, 1, 0, 1 } } })
         end
         command(cmd)
         exec_lua([[
@@ -9489,7 +10419,7 @@ describe('float window', function()
           vim.api.nvim_echo({{''}}, false, {})
         ]])
         if multigrid then
-          screen:expect({float_pos = {}})
+          screen:expect({ float_pos = {} })
         end
         assert_alive()
       end
@@ -9504,12 +10434,13 @@ describe('float window', function()
     end)
 
     it(':sleep cursor placement #22639', function()
-      local float_opts = {relative = 'editor', row = 1, col = 1, width = 4, height = 3}
+      local float_opts = { relative = 'editor', row = 1, col = 1, width = 4, height = 3 }
       local win = api.nvim_open_win(api.nvim_create_buf(false, false), true, float_opts)
       feed('iab<CR>cd<Esc>')
       feed(':sleep 100')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -9522,26 +10453,32 @@ describe('float window', function()
           {1:ab  }|
           {1:cd  }|
           {2:~   }|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 1, true, 50, 1, 1, 1};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 1, 1, 1 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                                                   |
           {0:~}{1:ab  }{0:                                   }|
           {0:~}{1:cd  }{0:                                   }|
           {0:~}{2:~   }{0:                                   }|
           {0:~                                       }|*2
           :sleep 100^                              |
-        ]]}
+        ]],
+        }
       end
 
       feed('<CR>')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -9554,29 +10491,35 @@ describe('float window', function()
           {1:ab  }|
           {1:c^d  }|
           {2:~   }|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 1, true, 50, 1, 1, 1};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 1, 1, 1 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                                                   |
           {0:~}{1:ab  }{0:                                   }|
           {0:~}{1:c^d  }{0:                                   }|
           {0:~}{2:~   }{0:                                   }|
           {0:~                                       }|*2
           :sleep 100                              |
-        ]]}
+        ]],
+        }
       end
       feed('<C-C>')
       screen:expect_unchanged()
 
-      api.nvim_win_set_config(win, {border = 'single'})
+      api.nvim_win_set_config(win, { border = 'single' })
       feed(':sleep 100')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -9591,14 +10534,18 @@ describe('float window', function()
           {5:│}{1:cd  }{5:│}|
           {5:│}{2:~   }{5:│}|
           {5:└────┘}|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 1, true, 50, 1, 1, 1};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 1, 1, 1 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                                                   |
           {0:~}{5:┌────┐}{0:                                 }|
           {0:~}{5:│}{1:ab  }{5:│}{0:                                 }|
@@ -9606,12 +10553,14 @@ describe('float window', function()
           {0:~}{5:│}{2:~   }{5:│}{0:                                 }|
           {0:~}{5:└────┘}{0:                                 }|
           :sleep 100^                              |
-        ]]}
+        ]],
+        }
       end
 
       feed('<CR>')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -9626,14 +10575,18 @@ describe('float window', function()
           {5:│}{1:c^d  }{5:│}|
           {5:│}{2:~   }{5:│}|
           {5:└────┘}|
-        ]], float_pos={
-          [4] = { 1001, "NW", 1, 1, 1, true, 50, 1, 1, 1 };
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 1, 1, 1 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                                                   |
           {0:~}{5:┌────┐}{0:                                 }|
           {0:~}{5:│}{1:ab  }{5:│}{0:                                 }|
@@ -9641,7 +10594,8 @@ describe('float window', function()
           {0:~}{5:│}{2:~   }{5:│}{0:                                 }|
           {0:~}{5:└────┘}{0:                                 }|
           :sleep 100                              |
-        ]]}
+        ]],
+        }
       end
       feed('<C-C>')
       screen:expect_unchanged()
@@ -9649,7 +10603,8 @@ describe('float window', function()
       command('setlocal winbar=foo')
       feed(':sleep 100')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -9664,14 +10619,18 @@ describe('float window', function()
           {5:│}{1:ab  }{5:│}|
           {5:│}{1:cd  }{5:│}|
           {5:└────┘}|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 1, true, 50, 1, 1, 1};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 1, 1, 1 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                                                   |
           {0:~}{5:┌────┐}{0:                                 }|
           {0:~}{5:│}{3:foo }{5:│}{0:                                 }|
@@ -9679,12 +10638,14 @@ describe('float window', function()
           {0:~}{5:│}{1:cd  }{5:│}{0:                                 }|
           {0:~}{5:└────┘}{0:                                 }|
           :sleep 100^                              |
-        ]]}
+        ]],
+        }
       end
 
       feed('<CR>')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -9699,14 +10660,18 @@ describe('float window', function()
           {5:│}{1:ab  }{5:│}|
           {5:│}{1:c^d  }{5:│}|
           {5:└────┘}|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 1, true, 50, 1, 1, 1};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 1, 1, 1 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 1, curcol = 1, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                                                   |
           {0:~}{5:┌────┐}{0:                                 }|
           {0:~}{5:│}{3:foo }{5:│}{0:                                 }|
@@ -9714,19 +10679,21 @@ describe('float window', function()
           {0:~}{5:│}{1:c^d  }{5:│}{0:                                 }|
           {0:~}{5:└────┘}{0:                                 }|
           :sleep 100                              |
-        ]]}
+        ]],
+        }
       end
       feed('<C-C>')
       screen:expect_unchanged()
     end)
 
     it('with rightleft and border #22640', function()
-      local float_opts = {relative='editor', width=5, height=3, row=1, col=1, border='single'}
+      local float_opts = { relative = 'editor', width = 5, height = 3, row = 1, col = 1, border = 'single' }
       api.nvim_open_win(api.nvim_create_buf(false, false), true, float_opts)
       command('setlocal rightleft')
       feed('iabc<CR>def<Esc>')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -9741,14 +10708,18 @@ describe('float window', function()
           {5:│}{1:  ^fed}{5:│}|
           {5:│}{2:    ~}{5:│}|
           {5:└─────┘}|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 1, 1, true, 50, 1, 1, 1};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 3, curline = 1, curcol = 2, linecount = 2, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 1, 1, true, 50, 1, 1, 1 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 3, curline = 1, curcol = 2, linecount = 2, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                                                   |
           {0:~}{5:┌─────┐}{0:                                }|
           {0:~}{5:│}{1:  cba}{5:│}{0:                                }|
@@ -9756,20 +10727,22 @@ describe('float window', function()
           {0:~}{5:│}{2:    ~}{5:│}{0:                                }|
           {0:~}{5:└─────┘}{0:                                }|
                                                   |
-        ]]}
+        ]],
+        }
       end
     end)
 
     it('float window with hide option', function()
       local cwin = api.nvim_get_current_win()
-      local buf = api.nvim_create_buf(false,false)
-      local win = api.nvim_open_win(buf, false, {relative='editor', width=10, height=2, row=2, col=5, hide = true})
+      local buf = api.nvim_create_buf(false, false)
+      local win = api.nvim_open_win(buf, false, { relative = 'editor', width = 10, height = 2, row = 2, col = 5, hide = true })
       local expected_pos = {
-          [4] = {1001, "NW", 1, 2, 5, true, 50, 1, 2, 5},
+        [4] = { 1001, 'NW', 1, 2, 5, true, 50, 1, 2, 5 },
       }
 
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -9782,7 +10755,9 @@ describe('float window', function()
         ## grid 4 (hidden)
           {1:          }|
           {2:~         }|
-        ]], float_pos = {}}
+        ]],
+          float_pos = {},
+        }
       else
         screen:expect([[
           ^                                        |
@@ -9791,9 +10766,10 @@ describe('float window', function()
         ]])
       end
 
-      api.nvim_win_set_config(win, {hide = false})
+      api.nvim_win_set_config(win, { hide = false })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -9806,7 +10782,9 @@ describe('float window', function()
         ## grid 4
           {1:          }|
           {2:~         }|
-        ]], float_pos = expected_pos}
+        ]],
+          float_pos = expected_pos,
+        }
       else
         screen:expect([[
           ^                                        |
@@ -9818,9 +10796,10 @@ describe('float window', function()
         ]])
       end
 
-      api.nvim_win_set_config(win, {hide=true})
+      api.nvim_win_set_config(win, { hide = true })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -9833,7 +10812,9 @@ describe('float window', function()
         ## grid 4 (hidden)
           {1:          }|
           {2:~         }|
-        ]], float_pos = {}}
+        ]],
+          float_pos = {},
+        }
       else
         screen:expect([[
           ^                                        |
@@ -9861,25 +10842,27 @@ describe('float window', function()
           ## grid 4 (hidden)
             {1:          }|
             {2:~         }|
-          ]], win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }, win_viewport_margins={
-          [2] = {
-            bottom = 0,
-            left = 0,
-            right = 0,
-            top = 0,
-            win = 1000
+          ]],
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
           },
-          [4] = {
-            bottom = 0,
-            left = 0,
-            right = 0,
-            top = 0,
-            win = 1001
-          }
-        }
+          win_viewport_margins = {
+            [2] = {
+              bottom = 0,
+              left = 0,
+              right = 0,
+              top = 0,
+              win = 1000,
+            },
+            [4] = {
+              bottom = 0,
+              left = 0,
+              right = 0,
+              top = 0,
+              win = 1001,
+            },
+          },
         })
       else
         screen:expect({
@@ -9887,7 +10870,7 @@ describe('float window', function()
                                                     |
             {0:~                                       }|*5
                                                     |
-          ]]
+          ]],
         })
       end
 
@@ -9907,25 +10890,27 @@ describe('float window', function()
           ## grid 4 (hidden)
             {1:          }|
             {2:~         }|
-          ]], win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }, win_viewport_margins={
-          [2] = {
-            bottom = 0,
-            left = 0,
-            right = 0,
-            top = 0,
-            win = 1000
+          ]],
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
           },
-          [4] = {
-            bottom = 0,
-            left = 0,
-            right = 0,
-            top = 0,
-            win = 1001
-          }
-        }
+          win_viewport_margins = {
+            [2] = {
+              bottom = 0,
+              left = 0,
+              right = 0,
+              top = 0,
+              win = 1000,
+            },
+            [4] = {
+              bottom = 0,
+              left = 0,
+              right = 0,
+              top = 0,
+              win = 1001,
+            },
+          },
         })
       else
         screen:expect({
@@ -9933,7 +10918,7 @@ describe('float window', function()
                                                     |
             {0:~                                       }|*5
             :^                                       |
-          ]]
+          ]],
         })
       end
       feed('<ESC>')
@@ -9954,25 +10939,27 @@ describe('float window', function()
           ## grid 4 (hidden)
             {1:          }|
             {2:~         }|
-          ]], win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }, win_viewport_margins={
-          [2] = {
-            bottom = 0,
-            left = 0,
-            right = 0,
-            top = 0,
-            win = 1000
+          ]],
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
           },
-          [4] = {
-            bottom = 0,
-            left = 0,
-            right = 0,
-            top = 0,
-            win = 1001
-          }
-        }
+          win_viewport_margins = {
+            [2] = {
+              bottom = 0,
+              left = 0,
+              right = 0,
+              top = 0,
+              win = 1000,
+            },
+            [4] = {
+              bottom = 0,
+              left = 0,
+              right = 0,
+              top = 0,
+              win = 1001,
+            },
+          },
         })
       else
         screen:expect({
@@ -9980,15 +10967,15 @@ describe('float window', function()
             ^                                        |
             {0:~                                       }|*5
                                                     |
-          ]]
+          ]],
         })
       end
       api.nvim_set_current_win(win)
-      local win1 = api.nvim_open_win(buf, false, {relative='editor', width=4, height=4, row=1, col=2})
+      local win1 = api.nvim_open_win(buf, false, { relative = 'editor', width = 4, height = 4, row = 1, col = 2 })
       api.nvim_set_current_win(win1)
       if multigrid then
-      screen:expect({
-        grid = [[
+        screen:expect({
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -10003,36 +10990,39 @@ describe('float window', function()
         ## grid 5
           {1:^    }|
           {2:~   }|*3
-        ]], float_pos={
-        [5] = {1002, "NW", 1, 1, 2, true, 50, 1, 1, 2};
-      }, win_viewport={
-        [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        [5] = {win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-      }, win_viewport_margins={
-        [2] = {
-          bottom = 0,
-          left = 0,
-          right = 0,
-          top = 0,
-          win = 1000
-        },
-        [4] = {
-          bottom = 0,
-          left = 0,
-          right = 0,
-          top = 0,
-          win = 1001
-        },
-        [5] = {
-          bottom = 0,
-          left = 0,
-          right = 0,
-          top = 0,
-          win = 1002
-        }
-      }
-      })
+        ]],
+          float_pos = {
+            [5] = { 1002, 'NW', 1, 1, 2, true, 50, 1, 1, 2 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [5] = { win = 1002, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+          win_viewport_margins = {
+            [2] = {
+              bottom = 0,
+              left = 0,
+              right = 0,
+              top = 0,
+              win = 1000,
+            },
+            [4] = {
+              bottom = 0,
+              left = 0,
+              right = 0,
+              top = 0,
+              win = 1001,
+            },
+            [5] = {
+              bottom = 0,
+              left = 0,
+              right = 0,
+              top = 0,
+              win = 1002,
+            },
+          },
+        })
       else
         screen:expect({
           grid = [[
@@ -10041,7 +11031,7 @@ describe('float window', function()
             {0:~ }{2:~   }{0:                                  }|*3
             {0:~                                       }|
                                                     |
-          ]]
+          ]],
         })
       end
       api.nvim_win_close(win1, true)
@@ -10050,10 +11040,10 @@ describe('float window', function()
       feed('<C-W><C-W>')
       -- should keep on current window
       eq(cwin, api.nvim_get_current_win())
-      api.nvim_win_set_config(win, {hide=false})
+      api.nvim_win_set_config(win, { hide = false })
       api.nvim_set_current_win(win)
-      local win3 = api.nvim_open_win(buf, true, {relative='editor', width=4, height=4, row=2, col=5, hide = false})
-      api.nvim_win_set_config(win, {hide=true})
+      local win3 = api.nvim_open_win(buf, true, { relative = 'editor', width = 4, height = 4, row = 2, col = 5, hide = false })
+      api.nvim_win_set_config(win, { hide = true })
       feed('<C-W>w')
       -- should goto the first window with prev
       eq(cwin, api.nvim_get_current_win())
@@ -10065,26 +11055,27 @@ describe('float window', function()
     end)
 
     it(':fclose command #9663', function()
-      local buf_a = api.nvim_create_buf(false,false)
-      local buf_b = api.nvim_create_buf(false,false)
-      local buf_c = api.nvim_create_buf(false,false)
-      local buf_d = api.nvim_create_buf(false,false)
-      local config_a = {relative='editor', width=11, height=11, row=5, col=5, border ='single', zindex=50}
-      local config_b = {relative='editor', width=8, height=8, row=7, col=7, border ='single', zindex=70}
-      local config_c = {relative='editor', width=4, height=4, row=9, col=9, border ='single',zindex=90}
-      local config_d = {relative='editor', width=2, height=2, row=10, col=10, border ='single',zindex=100}
+      local buf_a = api.nvim_create_buf(false, false)
+      local buf_b = api.nvim_create_buf(false, false)
+      local buf_c = api.nvim_create_buf(false, false)
+      local buf_d = api.nvim_create_buf(false, false)
+      local config_a = { relative = 'editor', width = 11, height = 11, row = 5, col = 5, border = 'single', zindex = 50 }
+      local config_b = { relative = 'editor', width = 8, height = 8, row = 7, col = 7, border = 'single', zindex = 70 }
+      local config_c = { relative = 'editor', width = 4, height = 4, row = 9, col = 9, border = 'single', zindex = 90 }
+      local config_d = { relative = 'editor', width = 2, height = 2, row = 10, col = 10, border = 'single', zindex = 100 }
       api.nvim_open_win(buf_a, false, config_a)
       api.nvim_open_win(buf_b, false, config_b)
       api.nvim_open_win(buf_c, false, config_c)
       api.nvim_open_win(buf_d, false, config_d)
       local expected_pos = {
-        [4] = {1001, "NW", 1, 5, 5, true, 50, 1, 0, 5},
-        [5] = {1002, "NW", 1, 7, 7, true, 70, 2, 0, 7},
-        [6] = {1003, "NW", 1, 9, 9, true, 90, 3, 0, 9},
-        [7] = {1004, "NW", 1, 10, 10, true, 100, 4, 2, 10},
+        [4] = { 1001, 'NW', 1, 5, 5, true, 50, 1, 0, 5 },
+        [5] = { 1002, 'NW', 1, 7, 7, true, 70, 2, 0, 7 },
+        [6] = { 1003, 'NW', 1, 9, 9, true, 90, 3, 0, 9 },
+        [7] = { 1004, 'NW', 1, 10, 10, true, 100, 4, 2, 10 },
       }
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -10113,7 +11104,9 @@ describe('float window', function()
           {5:│}{1:  }{5:│}|
           {5:│}{2:~ }{5:│}|
           {5:└──┘}|
-        ]], float_pos=expected_pos}
+        ]],
+          float_pos = expected_pos,
+        }
       else
         screen:expect([[
           ^     {5:┌─┌─┌────┐─┐┐}                      |
@@ -10129,7 +11122,8 @@ describe('float window', function()
       command('fclose')
       expected_pos[7] = nil
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -10154,7 +11148,9 @@ describe('float window', function()
           {5:│}{1:    }{5:│}|
           {5:│}{2:~   }{5:│}|*3
           {5:└────┘}|
-        ]], float_pos=expected_pos}
+        ]],
+          float_pos = expected_pos,
+        }
       else
         screen:expect([[
           ^     {5:┌─┌─┌────┐─┐┐}                      |
@@ -10168,7 +11164,8 @@ describe('float window', function()
       command('1fclose')
       expected_pos[6] = nil
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -10188,7 +11185,9 @@ describe('float window', function()
           {5:│}{1:        }{5:│}|
           {5:│}{2:~       }{5:│}|*7
           {5:└────────┘}|
-        ]], float_pos=expected_pos}
+        ]],
+          float_pos = expected_pos,
+        }
       else
         screen:expect([[
           ^     {5:┌─┌────────┐┐}                      |
@@ -10200,7 +11199,8 @@ describe('float window', function()
       -- with bang
       command('fclose!')
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*6
           [3:----------------------------------------]|
@@ -10210,7 +11210,9 @@ describe('float window', function()
         ## grid 3
                                                   |
 
-        ]], float_pos={}}
+        ]],
+          float_pos = {},
+        }
       else
         screen:expect([[
           ^                                        |
@@ -10221,13 +11223,14 @@ describe('float window', function()
     end)
 
     it('correctly placed in or above message area', function()
-      local float_opts = {relative='editor', width=5, height=1, row=100, col=1, border = 'single'}
+      local float_opts = { relative = 'editor', width = 5, height = 1, row = 100, col = 1, border = 'single' }
       api.nvim_set_option_value('cmdheight', 3, {})
       command("echo 'cmdline'")
       local win = api.nvim_open_win(api.nvim_create_buf(false, false), true, float_opts)
       -- Not hidden behind message area but placed above it.
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
           ## grid 1
             [2:----------------------------------------]|*4
             [3:----------------------------------------]|*3
@@ -10241,26 +11244,32 @@ describe('float window', function()
             {5:┌─────┐}|
             {5:│}{1:^     }{5:│}|
             {5:└─────┘}|
-          ]], float_pos={
-            [4] = {1001, "NW", 1, 100, 1, true, 50, 1, 1, 1};
-          }, win_viewport={
-            [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-            [4] = {win = 1001, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+          ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 100, 1, true, 50, 1, 1, 1 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                                                   |
           {0:~}{5:┌─────┐}{0:                                }|
           {0:~}{5:│}{1:^     }{5:│}{0:                                }|
           {0:~}{5:└─────┘}{0:                                }|
           cmdline                                 |
                                                   |*2
-        ]]}
+        ]],
+        }
       end
       -- Not placed above message area and visible on top of it.
-      api.nvim_win_set_config(win, {zindex = 300})
+      api.nvim_win_set_config(win, { zindex = 300 })
       if multigrid then
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:----------------------------------------]|*4
           [3:----------------------------------------]|*3
@@ -10274,27 +11283,32 @@ describe('float window', function()
           {5:┌─────┐}|
           {5:│}{1:^     }{5:│}|
           {5:└─────┘}|
-        ]], float_pos={
-          [4] = {1001, "NW", 1, 100, 1, true, 300, 2, 4, 1};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }}
+        ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 1, 100, 1, true, 300, 2, 4, 1 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 1, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        }
       else
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
                                                   |
           {0:~                                       }|*3
           c{5:┌─────┐}                                |
            {5:│}{1:^     }{5:│}                                |
            {5:└─────┘}                                |
-        ]]}
+        ]],
+        }
       end
     end)
 
     it('attempt to turn into split with no room', function()
       eq('Vim(split):E36: Not enough room', pcall_err(command, 'execute "split |"->repeat(&lines)'))
       command('vsplit | wincmd | | wincmd p')
-      api.nvim_open_win(0, true, {relative = "editor", row = 0, col = 0, width = 5, height = 5})
+      api.nvim_open_win(0, true, { relative = 'editor', row = 0, col = 0, width = 5, height = 5 })
       local config = api.nvim_win_get_config(0)
       eq('editor', config.relative)
 
@@ -10307,18 +11321,18 @@ describe('float window', function()
       eq(config, api.nvim_win_get_config(0))
     end)
 
-    it("error when relative to itself", function()
+    it('error when relative to itself', function()
       local buf = api.nvim_create_buf(false, true)
-      local config = { relative='win', width=5, height=2, row=3, col=3 }
+      local config = { relative = 'win', width = 5, height = 2, row = 3, col = 3 }
       local winid = api.nvim_open_win(buf, false, config)
       api.nvim_set_current_win(winid)
-      eq("floating window cannot be relative to itself", pcall_err(api.nvim_win_set_config, winid, config))
+      eq('floating window cannot be relative to itself', pcall_err(api.nvim_win_set_config, winid, config))
     end)
 
-    it("bufpos out of range", function()
+    it('bufpos out of range', function()
       local buf = api.nvim_create_buf(false, true)
       api.nvim_buf_set_lines(0, 0, -1, false, {})
-      local config = { relative='win', width=5, height=2, row=0, col=0, bufpos = { 3, 3 } }
+      local config = { relative = 'win', width = 5, height = 2, row = 0, col = 0, bufpos = { 3, 3 } }
       api.nvim_open_win(buf, false, config)
       if multigrid then
         screen:expect({
@@ -10334,12 +11348,15 @@ describe('float window', function()
           ## grid 4
             {1:     }|
             {2:~    }|
-          ]], float_pos={
-            [4] = {1001, "NW", 2, 0, 0, true, 50, 1, 0, 0};
-        }, win_viewport={
-          [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-          [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-        }})
+          ]],
+          float_pos = {
+            [4] = { 1001, 'NW', 2, 0, 0, true, 50, 1, 0, 0 },
+          },
+          win_viewport = {
+            [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+            [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+          },
+        })
       else
         screen:expect({
           grid = [[
@@ -10347,7 +11364,7 @@ describe('float window', function()
             {2:~    }{0:                                   }|
             {0:~                                       }|*4
                                                     |
-          ]]
+          ]],
         })
       end
     end)
@@ -10378,12 +11395,12 @@ describe('float window', function()
         })
         return {vim.wo[win].winbar, vim.wo[float_winid].winbar}
       ]])
-      eq({"%f", ""}, res)
+      eq({ '%f', '' }, res)
     end)
 
     it('winborder option', function()
-      local buf = api.nvim_create_buf(false,false)
-      local config = {relative='editor', width=4, height=4, row=2, col=2}
+      local buf = api.nvim_create_buf(false, false)
+      local config = { relative = 'editor', width = 4, height = 4, row = 2, col = 2 }
       command('set winborder=single')
       local winid = api.nvim_open_win(buf, true, config)
       eq('┌', api.nvim_win_get_config(winid).border[1])

--- a/test/functional/ui/multigrid_spec.lua
+++ b/test/functional/ui/multigrid_spec.lua
@@ -10,43 +10,43 @@ local api = n.api
 local curwin = n.api.nvim_get_current_win
 local poke_eventloop = n.poke_eventloop
 
-
 describe('ext_multigrid', function()
   local screen
 
   before_each(function()
-    clear{args_rm={'--headless'}, args={'--cmd', 'set laststatus=2'}}
-    screen = Screen.new(53,14, {ext_multigrid=true})
+    clear { args_rm = { '--headless' }, args = { '--cmd', 'set laststatus=2' } }
+    screen = Screen.new(53, 14, { ext_multigrid = true })
     screen:set_default_attr_ids({
-      [1] = {bold = true, foreground = Screen.colors.Blue1},
-      [2] = {foreground = Screen.colors.Magenta},
-      [3] = {foreground = Screen.colors.Brown, bold = true},
-      [4] = {foreground = Screen.colors.SlateBlue},
-      [5] = {bold = true, foreground = Screen.colors.SlateBlue},
-      [6] = {foreground = Screen.colors.Cyan4},
-      [7] = {bold = true},
-      [8] = {underline = true, bold = true, foreground = Screen.colors.SlateBlue},
-      [9] = {foreground = Screen.colors.SlateBlue, underline = true},
-      [10] = {foreground = Screen.colors.Red},
-      [11] = {bold = true, reverse = true},
-      [12] = {reverse = true},
-      [13] = {foreground = Screen.colors.DarkBlue, background = Screen.colors.LightGrey},
-      [14] = {foreground = Screen.colors.Grey100, background = Screen.colors.Red},
-      [15] = {bold = true, foreground = Screen.colors.SeaGreen4},
-      [16] = {background = Screen.colors.LightGrey, underline = true},
-      [17] = {background = Screen.colors.LightGrey, underline = true, bold = true, foreground = Screen.colors.Magenta},
-      [18] = {bold = true, foreground = Screen.colors.Magenta},
-      [19] = {foreground = Screen.colors.Brown},
-      [20] = {background = Screen.colors.LightGrey, foreground = Screen.colors.Black},
-      [21] = {background = Screen.colors.LightMagenta},
-      [22] = {background = Screen.colors.LightMagenta, bold = true, foreground = Screen.colors.Blue},
-      [23] = {background = Screen.colors.Grey90},
-      [24] = {background = Screen.colors.Grey},
+      [1] = { bold = true, foreground = Screen.colors.Blue1 },
+      [2] = { foreground = Screen.colors.Magenta },
+      [3] = { foreground = Screen.colors.Brown, bold = true },
+      [4] = { foreground = Screen.colors.SlateBlue },
+      [5] = { bold = true, foreground = Screen.colors.SlateBlue },
+      [6] = { foreground = Screen.colors.Cyan4 },
+      [7] = { bold = true },
+      [8] = { underline = true, bold = true, foreground = Screen.colors.SlateBlue },
+      [9] = { foreground = Screen.colors.SlateBlue, underline = true },
+      [10] = { foreground = Screen.colors.Red },
+      [11] = { bold = true, reverse = true },
+      [12] = { reverse = true },
+      [13] = { foreground = Screen.colors.DarkBlue, background = Screen.colors.LightGrey },
+      [14] = { foreground = Screen.colors.Grey100, background = Screen.colors.Red },
+      [15] = { bold = true, foreground = Screen.colors.SeaGreen4 },
+      [16] = { background = Screen.colors.LightGrey, underline = true },
+      [17] = { background = Screen.colors.LightGrey, underline = true, bold = true, foreground = Screen.colors.Magenta },
+      [18] = { bold = true, foreground = Screen.colors.Magenta },
+      [19] = { foreground = Screen.colors.Brown },
+      [20] = { background = Screen.colors.LightGrey, foreground = Screen.colors.Black },
+      [21] = { background = Screen.colors.LightMagenta },
+      [22] = { background = Screen.colors.LightMagenta, bold = true, foreground = Screen.colors.Blue },
+      [23] = { background = Screen.colors.Grey90 },
+      [24] = { background = Screen.colors.Grey },
     })
   end)
 
   it('default initial screen', function()
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [2:-----------------------------------------------------]|*12
       {11:[No Name]                                            }|
@@ -56,12 +56,14 @@ describe('ext_multigrid', function()
       {1:~                                                    }|*11
     ## grid 3
                                                            |
-    ]]}
+    ]],
+    }
   end)
 
   it('positions windows correctly', function()
     command('vsplit')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:--------------------------]│[2:--------------------------]|*12
       {11:[No Name]                  }{12:[No Name]                 }|
@@ -74,15 +76,18 @@ describe('ext_multigrid', function()
     ## grid 4
       ^                          |
       {1:~                         }|*11
-    ]], condition=function()
-      eq({
-        [2] = { win = 1000, startrow = 0, startcol = 27, width = 26, height = 12 },
-        [4] = { win = 1001, startrow = 0, startcol =  0, width = 26, height = 12 }
-      }, screen.win_position)
-    end}
+    ]],
+      condition = function()
+        eq({
+          [2] = { win = 1000, startrow = 0, startcol = 27, width = 26, height = 12 },
+          [4] = { win = 1001, startrow = 0, startcol = 0, width = 26, height = 12 },
+        }, screen.win_position)
+      end,
+    }
     command('wincmd l')
     command('split')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:--------------------------]│[5:--------------------------]|*6
       [4:--------------------------]│{11:[No Name]                 }|
@@ -100,16 +105,19 @@ describe('ext_multigrid', function()
     ## grid 5
       ^                          |
       {1:~                         }|*5
-    ]], condition=function()
-      eq({
-        [2] = { win = 1000, startrow = 7, startcol = 27, width = 26, height =  5 },
-        [4] = { win = 1001, startrow = 0, startcol =  0, width = 26, height = 12 },
-        [5] = { win = 1002, startrow = 0, startcol = 27, width = 26, height =  6 }
-      }, screen.win_position)
-    end}
+    ]],
+      condition = function()
+        eq({
+          [2] = { win = 1000, startrow = 7, startcol = 27, width = 26, height = 5 },
+          [4] = { win = 1001, startrow = 0, startcol = 0, width = 26, height = 12 },
+          [5] = { win = 1002, startrow = 0, startcol = 27, width = 26, height = 6 },
+        }, screen.win_position)
+      end,
+    }
     command('wincmd h')
     command('q')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:-----------------------------------------------------]|*6
       {11:[No Name]                                            }|
@@ -124,17 +132,19 @@ describe('ext_multigrid', function()
     ## grid 5
       ^                                                     |
       {1:~                                                    }|*5
-    ]], condition=function()
-      eq({
-        [2] = { win = 1000, startrow = 7, startcol = 0, width = 53, height =  5 },
-        [5] = { win = 1002, startrow = 0, startcol = 0, width = 53, height =  6 }
-      }, screen.win_position)
-    end}
+    ]],
+      condition = function()
+        eq({
+          [2] = { win = 1000, startrow = 7, startcol = 0, width = 53, height = 5 },
+          [5] = { win = 1002, startrow = 0, startcol = 0, width = 53, height = 6 },
+        }, screen.win_position)
+      end,
+    }
   end)
 
-  describe('split', function ()
-    describe('horizontally', function ()
-      it('allocates grids', function ()
+  describe('split', function()
+    describe('horizontally', function()
+      it('allocates grids', function()
         command('sp')
         screen:expect([[
         ## grid 1
@@ -154,7 +164,7 @@ describe('ext_multigrid', function()
         ]])
       end)
 
-      it('resizes grids', function ()
+      it('resizes grids', function()
         command('sp')
         command('resize 8')
         screen:expect([[
@@ -179,7 +189,8 @@ describe('ext_multigrid', function()
         command('sp')
         command('vsp')
         command('vsp')
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [6:--------------------]│[5:----------------]│[4:---------------]|*6
           {11:[No Name]            }{12:[No Name]        [No Name]      }|
@@ -200,9 +211,11 @@ describe('ext_multigrid', function()
         ## grid 6
           ^                    |
           {1:~                   }|*5
-        ]]}
+        ]],
+        }
         insert('hello')
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [6:--------------------]│[5:----------------]│[4:---------------]|*6
           {11:[No Name] [+]        }{12:[No Name] [+]    [No Name] [+]  }|
@@ -223,11 +236,13 @@ describe('ext_multigrid', function()
         ## grid 6
           hell^o               |
           {1:~                   }|*5
-        ]]}
+        ]],
+        }
       end)
-      it('closes splits', function ()
+      it('closes splits', function()
         command('sp')
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [4:-----------------------------------------------------]|*6
           {11:[No Name]                                            }|
@@ -242,9 +257,11 @@ describe('ext_multigrid', function()
         ## grid 4
           ^                                                     |
           {1:~                                                    }|*5
-        ]]}
+        ]],
+        }
         command('q')
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:-----------------------------------------------------]|*12
           {11:[No Name]                                            }|
@@ -254,14 +271,16 @@ describe('ext_multigrid', function()
           {1:~                                                    }|*11
         ## grid 3
                                                                |
-        ]]}
+        ]],
+        }
       end)
     end)
 
-    describe('vertically', function ()
-      it('allocates grids', function ()
+    describe('vertically', function()
+      it('allocates grids', function()
         command('vsp')
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [4:--------------------------]│[2:--------------------------]|*12
           {11:[No Name]                  }{12:[No Name]                 }|
@@ -274,12 +293,14 @@ describe('ext_multigrid', function()
         ## grid 4
           ^                          |
           {1:~                         }|*11
-        ]]}
+        ]],
+        }
       end)
-      it('resizes grids', function ()
+      it('resizes grids', function()
         command('vsp')
         command('vertical resize 10')
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [4:----------]│[2:------------------------------------------]|*12
           {11:[No Name]  }{12:[No Name]                                 }|
@@ -292,12 +313,14 @@ describe('ext_multigrid', function()
         ## grid 4
           ^          |
           {1:~         }|*11
-        ]]}
+        ]],
+        }
       end)
-      it('splits horizontally', function ()
+      it('splits horizontally', function()
         command('vsp')
         command('sp')
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [5:--------------------------]│[2:--------------------------]|*6
           {11:[No Name]                 }│[2:--------------------------]|
@@ -315,9 +338,11 @@ describe('ext_multigrid', function()
         ## grid 5
           ^                          |
           {1:~                         }|*5
-        ]]}
+        ]],
+        }
         insert('hello')
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [5:--------------------------]│[2:--------------------------]|*6
           {11:[No Name] [+]             }│[2:--------------------------]|
@@ -335,11 +360,13 @@ describe('ext_multigrid', function()
         ## grid 5
           hell^o                     |
           {1:~                         }|*5
-        ]]}
+        ]],
+        }
       end)
-      it('closes splits', function ()
+      it('closes splits', function()
         command('vsp')
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [4:--------------------------]│[2:--------------------------]|*12
           {11:[No Name]                  }{12:[No Name]                 }|
@@ -352,9 +379,11 @@ describe('ext_multigrid', function()
         ## grid 4
           ^                          |
           {1:~                         }|*11
-        ]]}
+        ]],
+        }
         command('q')
-        screen:expect{grid=[[
+        screen:expect {
+          grid = [[
         ## grid 1
           [2:-----------------------------------------------------]|*12
           {11:[No Name]                                            }|
@@ -364,15 +393,17 @@ describe('ext_multigrid', function()
           {1:~                                                    }|*11
         ## grid 3
                                                                |
-        ]]}
+        ]],
+        }
       end)
     end)
   end)
 
-  describe('on resize', function ()
-    it('rebuilds all grids', function ()
+  describe('on resize', function()
+    it('rebuilds all grids', function()
       screen:try_resize(25, 6)
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-------------------------]|*4
         {11:[No Name]                }|
@@ -382,12 +413,14 @@ describe('ext_multigrid', function()
         {1:~                        }|*3
       ## grid 3
                                  |
-      ]]}
+      ]],
+      }
     end)
 
     it('has minimum width/height values', function()
       screen:try_resize(1, 1)
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:------------]|
         {11:[No Name]   }|
@@ -396,10 +429,12 @@ describe('ext_multigrid', function()
         ^            |
       ## grid 3
                     |
-      ]]}
+      ]],
+      }
 
       feed('<esc>:ls')
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:------------]|
         {11:[No Name]   }|
@@ -408,7 +443,8 @@ describe('ext_multigrid', function()
                     |
       ## grid 3
         :ls^         |
-      ]]}
+      ]],
+      }
     end)
   end)
 
@@ -418,7 +454,8 @@ describe('ext_multigrid', function()
     end)
 
     it('is rendered correctly', function()
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name]                                            }|
@@ -428,9 +465,11 @@ describe('ext_multigrid', function()
         {1:~                   }|*4
       ## grid 3
                                                              |
-      ]]}
+      ]],
+      }
       screen:try_resize_grid(2, 8, 5)
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name]                                            }|
@@ -440,13 +479,15 @@ describe('ext_multigrid', function()
         {1:~       }|*4
       ## grid 3
                                                              |
-      ]]}
+      ]],
+      }
     end)
 
     it("cursor draws correctly with double-width char and 'showbreak'", function()
       insert(('a'):rep(19) .. '哦bbbb')
       command('setlocal showbreak=++')
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name] [+]                                        }|
@@ -457,7 +498,8 @@ describe('ext_multigrid', function()
         {1:~                   }|*3
       ## grid 3
                                                              |
-      ]]}
+      ]],
+      }
     end)
   end)
 
@@ -467,7 +509,8 @@ describe('ext_multigrid', function()
     end)
 
     it('is rendered correctly', function()
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name]                                            }|
@@ -477,9 +520,11 @@ describe('ext_multigrid', function()
         {1:~                                                           }|*19
       ## grid 3
                                                              |
-      ]]}
+      ]],
+      }
       screen:try_resize_grid(2, 80, 20)
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name]                                            }|
@@ -489,7 +534,8 @@ describe('ext_multigrid', function()
         {1:~                                                                               }|*19
       ## grid 3
                                                              |
-      ]]}
+      ]],
+      }
     end)
 
     it('winwidth() winheight() getwininfo() return inner width and height #19743', function()
@@ -507,8 +553,9 @@ describe('ext_multigrid', function()
     end)
 
     it('gets written till grid width', function()
-      insert(('a'):rep(60).."\n")
-      screen:expect{grid=[[
+      insert(('a'):rep(60) .. '\n')
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name] [+]                                        }|
@@ -519,14 +566,16 @@ describe('ext_multigrid', function()
         {1:~                                                           }|*18
       ## grid 3
                                                              |
-      ]]}
+      ]],
+      }
     end)
 
     it('g$ works correctly with double-width chars and no wrapping', function()
       command('set nowrap')
       insert(('a'):rep(58) .. ('哦'):rep(3))
       feed('0')
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name] [+]                                        }|
@@ -536,9 +585,11 @@ describe('ext_multigrid', function()
         {1:~                                                           }|*19
       ## grid 3
                                                              |
-      ]]}
+      ]],
+      }
       feed('g$')
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name] [+]                                        }|
@@ -548,12 +599,14 @@ describe('ext_multigrid', function()
         {1:~                                                           }|*19
       ## grid 3
                                                              |
-      ]]}
+      ]],
+      }
     end)
 
     it('wraps with grid width', function()
-      insert(('b'):rep(160).."\n")
-      screen:expect{grid=[[
+      insert(('b'):rep(160) .. '\n')
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name] [+]                                        }|
@@ -565,10 +618,12 @@ describe('ext_multigrid', function()
         {1:~                                                           }|*16
       ## grid 3
                                                              |
-      ]]}
+      ]],
+      }
       feed('2gk')
       command('setlocal cursorline cursorlineopt=screenline')
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name] [+]                                        }|
@@ -581,10 +636,12 @@ describe('ext_multigrid', function()
         {1:~                                                           }|*16
       ## grid 3
                                                              |
-      ]]}
+      ]],
+      }
       command('setlocal breakindent breakindentopt=shift:8')
       feed('g$')
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name] [+]                                        }|
@@ -597,13 +654,14 @@ describe('ext_multigrid', function()
         {1:~                                                           }|*16
       ## grid 3
                                                              |
-      ]]}
+      ]],
+      }
     end)
 
     it('displays messages with default grid width', function()
-      command('echomsg "this is a very very very very very very very very'..
-        ' long message"')
-      screen:expect{grid=[[
+      command('echomsg "this is a very very very very very very very very' .. ' long message"')
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name]                                            }|
@@ -613,13 +671,15 @@ describe('ext_multigrid', function()
         {1:~                                                           }|*19
       ## grid 3
         this is a very very very...ry very very long message |
-      ]]}
+      ]],
+      }
     end)
 
     it('creates folds with grid width', function()
       insert('this is a fold\nthis is inside fold\nthis is outside fold')
       feed('kzfgg')
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name] [+]                                        }|
@@ -630,12 +690,14 @@ describe('ext_multigrid', function()
         {1:~                                                           }|*18
       ## grid 3
                                                              |
-      ]]}
+      ]],
+      }
     end)
 
     it('anchored float window "bufpos"', function()
       insert(('c'):rep(1111))
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name] [+]                                        }|
@@ -646,17 +708,19 @@ describe('ext_multigrid', function()
         {1:~                                                           }|
       ## grid 3
                                                              |
-      ]]}
+      ]],
+      }
       local float_buf = api.nvim_create_buf(false, false)
       api.nvim_open_win(float_buf, false, {
         relative = 'win',
         win = curwin(),
-        bufpos = {0, 1018},
+        bufpos = { 0, 1018 },
         anchor = 'SE',
         width = 5,
         height = 5,
       })
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name] [+]                                        }|
@@ -670,15 +734,18 @@ describe('ext_multigrid', function()
       ## grid 4
         {21:     }|
         {22:~    }|*4
-      ]], float_pos={
-        [4] = {1001, "SE", 2, 16, 58, true, 50, 1, 8, 48};
-      }}
+      ]],
+        float_pos = {
+          [4] = { 1001, 'SE', 2, 16, 58, true, 50, 1, 8, 48 },
+        },
+      }
     end)
 
     it('completion popup position', function()
       insert(('\n'):rep(14) .. ('foo bar '):rep(7))
       feed('A<C-X><C-N>')
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name] [+]                                        }|
@@ -692,14 +759,17 @@ describe('ext_multigrid', function()
       ## grid 4
         {24: foo}|
         {21: bar}|
-      ]], float_pos={
-        [4] = {-1, "NW", 2, 15, 55, false, 100, 1, 15, 55};
-      }}
+      ]],
+        float_pos = {
+          [4] = { -1, 'NW', 2, 15, 55, false, 100, 1, 15, 55 },
+        },
+      }
       feed('<C-E><Esc>')
 
       command('setlocal rightleft')
       feed('o<C-X><C-N>')
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name] [+]                                        }|
@@ -714,14 +784,17 @@ describe('ext_multigrid', function()
       ## grid 4
         {24:            oof}|
         {21:            rab}|
-      ]], float_pos={
-        [4] = {-1, "NW", 2, 16, 45, false, 100, 1, 16, 45};
-      }}
+      ]],
+        float_pos = {
+          [4] = { -1, 'NW', 2, 16, 45, false, 100, 1, 16, 45 },
+        },
+      }
       feed('<C-E><Esc>')
 
       command('set wildoptions+=pum')
       feed(':sign un<Tab>')
-      screen:expect{grid=[[
+      screen:expect {
+        grid = [[
       ## grid 1
         [2:-----------------------------------------------------]|*12
         {11:[No Name] [+]                                        }|
@@ -736,9 +809,11 @@ describe('ext_multigrid', function()
       ## grid 4
         {24: undefine       }|
         {21: unplace        }|
-      ]], float_pos={
-        [4] = {-1, "SW", 1, 13, 5, false, 250, 2, 11, 5};
-      }}
+      ]],
+        float_pos = {
+          [4] = { -1, 'SW', 1, 13, 5, false, 250, 2, 11, 5 },
+        },
+      }
     end)
 
     it('half-page scrolling stops at end of buffer', function()
@@ -814,7 +889,8 @@ describe('ext_multigrid', function()
   it('multiline messages scroll over windows', function()
     command('sp')
     command('vsp')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:--------------------------]│[4:--------------------------]|*6
       {11:[No Name]                  }{12:[No Name]                 }|
@@ -832,10 +908,12 @@ describe('ext_multigrid', function()
     ## grid 5
       ^                          |
       {1:~                         }|*5
-    ]]}
+    ]],
+    }
 
     feed(":echoerr 'very' | echoerr 'much' | echoerr 'fail'<cr>")
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:--------------------------]│[4:--------------------------]|*6
       {11:[No Name]                  }{12:[No Name]                 }|
@@ -855,10 +933,12 @@ describe('ext_multigrid', function()
     ## grid 5
                                 |
       {1:~                         }|*5
-    ]]}
+    ]],
+    }
 
     feed('<cr>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:--------------------------]│[4:--------------------------]|*6
       {11:[No Name]                  }{12:[No Name]                 }|
@@ -876,7 +956,8 @@ describe('ext_multigrid', function()
     ## grid 5
       ^                          |
       {1:~                         }|*5
-    ]]}
+    ]],
+    }
 
     command([[
       func! ErrMsg()
@@ -884,8 +965,9 @@ describe('ext_multigrid', function()
           echoerr "error ".i
         endfor
       endfunc]])
-    feed(":call ErrMsg()<cr>")
-    screen:expect{grid=[[
+    feed(':call ErrMsg()<cr>')
+    screen:expect {
+      grid = [[
     ## grid 1
       [3:-----------------------------------------------------]|*14
     ## grid 2
@@ -912,10 +994,12 @@ describe('ext_multigrid', function()
     ## grid 5
                                 |
       {1:~                         }|*5
-    ]]}
+    ]],
+    }
 
-    feed("<c-c>")
-    screen:expect{grid=[[
+    feed('<c-c>')
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:--------------------------]│[4:--------------------------]|*6
       {11:[No Name]                  }{12:[No Name]                 }|
@@ -933,12 +1017,14 @@ describe('ext_multigrid', function()
     ## grid 5
       ^                          |
       {1:~                         }|*5
-    ]]}
+    ]],
+    }
   end)
 
   it('handles switch tabs', function()
     command('vsp')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:--------------------------]│[2:--------------------------]|*12
       {11:[No Name]                  }{12:[No Name]                 }|
@@ -951,12 +1037,13 @@ describe('ext_multigrid', function()
     ## grid 4
       ^                          |
       {1:~                         }|*11
-    ]]}
-
+    ]],
+    }
 
     command('tabnew')
     -- note the old grids aren't resized yet
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       {16: }{17:2}{16: [No Name] }{7: [No Name] }{12:                            }{16:X}|
       [5:-----------------------------------------------------]|*11
@@ -973,10 +1060,12 @@ describe('ext_multigrid', function()
     ## grid 5
       ^                                                     |
       {1:~                                                    }|*10
-    ]]}
+    ]],
+    }
 
     command('sp')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       {16: }{17:2}{16: [No Name] }{7: }{18:2}{7: [No Name] }{12:                          }{16:X}|
       [6:-----------------------------------------------------]|*5
@@ -998,10 +1087,12 @@ describe('ext_multigrid', function()
     ## grid 6
       ^                                                     |
       {1:~                                                    }|*4
-    ]]}
+    ]],
+    }
 
     command('tabnext')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       {7: }{18:2}{7: [No Name] }{16: }{17:2}{16: [No Name] }{12:                          }{16:X}|
       [4:--------------------------]│[2:--------------------------]|*11
@@ -1021,10 +1112,12 @@ describe('ext_multigrid', function()
     ## grid 6 (hidden)
                                                            |
       {1:~                                                    }|*4
-    ]]}
+    ]],
+    }
 
     command('tabnext')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       {16: }{17:2}{16: [No Name] }{7: }{18:2}{7: [No Name] }{12:                          }{16:X}|
       [6:-----------------------------------------------------]|*5
@@ -1046,11 +1139,13 @@ describe('ext_multigrid', function()
     ## grid 6
       ^                                                     |
       {1:~                                                    }|*4
-    ]]}
+    ]],
+    }
 
     command('tabnext')
     command('$tabnew')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       {16: }{17:2}{16: [No Name]  }{17:2}{16: [No Name] }{7: [No Name] }{12:               }{16:X}|
       [7:-----------------------------------------------------]|*11
@@ -1073,11 +1168,13 @@ describe('ext_multigrid', function()
     ## grid 7
       ^                                                     |
       {1:~                                                    }|*10
-    ]]}
+    ]],
+    }
 
     command('tabclose')
     command('tabclose')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:--------------------------]│[2:--------------------------]|*12
       {11:[No Name]                  }{12:[No Name]                 }|
@@ -1090,13 +1187,15 @@ describe('ext_multigrid', function()
     ## grid 4
       ^                          |
       {1:~                         }|*11
-    ]]}
+    ]],
+    }
   end)
 
   it('supports mouse', function()
     command('autocmd! nvim.popupmenu') -- Delete the default MenuPopup event handler.
     insert('some text\nto be clicked')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [2:-----------------------------------------------------]|*12
       {11:[No Name] [+]                                        }|
@@ -1107,10 +1206,12 @@ describe('ext_multigrid', function()
       {1:~                                                    }|*10
     ## grid 3
                                                            |
-    ]]}
+    ]],
+    }
 
     api.nvim_input_mouse('left', 'press', '', 2, 0, 5)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [2:-----------------------------------------------------]|*12
       {11:[No Name] [+]                                        }|
@@ -1121,12 +1222,14 @@ describe('ext_multigrid', function()
       {1:~                                                    }|*10
     ## grid 3
                                                            |
-    ]]}
+    ]],
+    }
 
     feed(':new<cr>')
     insert('Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmo')
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:-----------------------------------------------------]|*6
       {11:[No Name] [+]                                        }|
@@ -1143,10 +1246,12 @@ describe('ext_multigrid', function()
       Lorem ipsum dolor sit amet, consectetur adipiscing el|
       it, sed do eiusm^o                                    |
       {1:~                                                    }|*4
-    ]]}
+    ]],
+    }
 
     api.nvim_input_mouse('left', 'press', '', 2, 1, 6)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:-----------------------------------------------------]|*6
       {12:[No Name] [+]                                        }|
@@ -1163,10 +1268,12 @@ describe('ext_multigrid', function()
       Lorem ipsum dolor sit amet, consectetur adipiscing el|
       it, sed do eiusmo                                    |
       {1:~                                                    }|*4
-    ]]}
+    ]],
+    }
 
     api.nvim_input_mouse('left', 'press', '', 4, 1, 4)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:-----------------------------------------------------]|*6
       {11:[No Name] [+]                                        }|
@@ -1183,10 +1290,12 @@ describe('ext_multigrid', function()
       Lorem ipsum dolor sit amet, consectetur adipiscing el|
       it, ^sed do eiusmo                                    |
       {1:~                                                    }|*4
-    ]]}
+    ]],
+    }
 
     screen:try_resize_grid(4, 80, 2)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:-----------------------------------------------------]|*6
       {11:[No Name] [+]                                        }|
@@ -1202,10 +1311,12 @@ describe('ext_multigrid', function()
     ## grid 4
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, ^sed do eiusmo          |
       {1:~                                                                               }|
-    ]]}
+    ]],
+    }
 
     api.nvim_input_mouse('left', 'press', '', 4, 0, 64)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:-----------------------------------------------------]|*6
       {11:[No Name] [+]                                        }|
@@ -1221,7 +1332,8 @@ describe('ext_multigrid', function()
     ## grid 4
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do ^eiusmo          |
       {1:~                                                                               }|
-    ]]}
+    ]],
+    }
 
     -- XXX: mouse_check_grid() doesn't work properly when clicking on grid 1
     api.nvim_input_mouse('left', 'press', '', 1, 6, 20)
@@ -1230,7 +1342,8 @@ describe('ext_multigrid', function()
     -- but add a poke_eventloop be sure.
     poke_eventloop()
     api.nvim_input_mouse('left', 'drag', '', 1, 4, 20)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:-----------------------------------------------------]|*4
       {11:[No Name] [+]                                        }|
@@ -1246,10 +1359,12 @@ describe('ext_multigrid', function()
     ## grid 4
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do ^eiusmo          |
       {1:~                                                                               }|
-    ]]}
+    ]],
+    }
 
     feed('<c-w><c-w><c-w>v')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:-----------------------------------------------------]|*4
       {12:[No Name] [+]                                        }|
@@ -1269,12 +1384,14 @@ describe('ext_multigrid', function()
       some text                 |
       to be ^clicked             |
       {1:~                         }|*5
-    ]]}
+    ]],
+    }
 
     api.nvim_input_mouse('left', 'press', '', 1, 8, 26)
     poke_eventloop()
     api.nvim_input_mouse('left', 'drag', '', 1, 6, 30)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:-----------------------------------------------------]|*4
       {12:[No Name] [+]                                        }|
@@ -1294,13 +1411,15 @@ describe('ext_multigrid', function()
       some text                     |
       to be ^clicked                 |
       {1:~                             }|*5
-    ]]}
+    ]],
+    }
 
     command('aunmenu PopUp | vmenu PopUp.Copy y')
 
     fn.setreg('"', '')
     api.nvim_input_mouse('left', 'press', '2', 2, 1, 6)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:-----------------------------------------------------]|*4
       {12:[No Name] [+]                                        }|
@@ -1320,10 +1439,12 @@ describe('ext_multigrid', function()
       some text                     |
       to be {20:clicked}                 |
       {1:~                             }|*5
-    ]]}
+    ]],
+    }
     api.nvim_input_mouse('right', 'press', '', 2, 1, 6)
     api.nvim_input_mouse('right', 'release', '', 2, 1, 6)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:-----------------------------------------------------]|*4
       {12:[No Name] [+]                                        }|
@@ -1345,11 +1466,14 @@ describe('ext_multigrid', function()
       {1:~                             }|*5
     ## grid 6
       {21: Copy }|
-    ]], float_pos={
-      [6] = {-1, "NW", 2, 2, 5, false, 250, 2, 7, 36};
-    }}
+    ]],
+      float_pos = {
+        [6] = { -1, 'NW', 2, 2, 5, false, 250, 2, 7, 36 },
+      },
+    }
     feed('<Down><CR>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:-----------------------------------------------------]|*4
       {12:[No Name] [+]                                        }|
@@ -1369,12 +1493,14 @@ describe('ext_multigrid', function()
       some text                     |
       to be clicked                 |
       {1:~                             }|*5
-    ]]}
+    ]],
+    }
     eq('clicked', fn.getreg('"'))
 
     fn.setreg('"', '')
     api.nvim_input_mouse('left', 'press', '2', 4, 0, 64)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:-----------------------------------------------------]|*4
       {11:[No Name] [+]                                        }|
@@ -1394,10 +1520,12 @@ describe('ext_multigrid', function()
       some text                     |
       to be clicked                 |
       {1:~                             }|*5
-    ]]}
+    ]],
+    }
     api.nvim_input_mouse('right', 'press', '', 4, 0, 64)
     api.nvim_input_mouse('right', 'release', '', 4, 0, 64)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:-----------------------------------------------------]|*4
       {11:[No Name] [+]                                        }|
@@ -1419,11 +1547,14 @@ describe('ext_multigrid', function()
       {1:~                             }|*5
     ## grid 6
       {21: Copy }|
-    ]], float_pos={
-      [6] = {-1, "NW", 4, 1, 63, false, 250, 2, 1, 63};
-    }}
+    ]],
+      float_pos = {
+        [6] = { -1, 'NW', 4, 1, 63, false, 250, 2, 1, 63 },
+      },
+    }
     feed('<Down><CR>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:-----------------------------------------------------]|*4
       {11:[No Name] [+]                                        }|
@@ -1443,12 +1574,14 @@ describe('ext_multigrid', function()
       some text                     |
       to be clicked                 |
       {1:~                             }|*5
-    ]]}
+    ]],
+    }
     eq('eiusmo', fn.getreg('"'))
 
     command('wincmd J')
     screen:try_resize_grid(4, 7, 10)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:------------------------------]│[2:----------------------]|*5
       {12:[No Name] [+]                  [No Name] [+]         }|
@@ -1476,11 +1609,13 @@ describe('ext_multigrid', function()
       some text                     |
       to be clicked                 |
       {1:~                             }|*3
-    ]]}
+    ]],
+    }
 
     fn.setreg('"', '')
     api.nvim_input_mouse('left', 'press', '2', 4, 9, 1)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:------------------------------]│[2:----------------------]|*5
       {12:[No Name] [+]                  [No Name] [+]         }|
@@ -1508,10 +1643,12 @@ describe('ext_multigrid', function()
       some text                     |
       to be clicked                 |
       {1:~                             }|*3
-    ]]}
+    ]],
+    }
     api.nvim_input_mouse('right', 'press', '', 4, 9, 1)
     api.nvim_input_mouse('right', 'release', '', 4, 9, 1)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:------------------------------]│[2:----------------------]|*5
       {12:[No Name] [+]                  [No Name] [+]         }|
@@ -1541,11 +1678,14 @@ describe('ext_multigrid', function()
       {1:~                             }|*3
     ## grid 6
       {21: Copy }|
-    ]], float_pos={
-      [6] = {-1, "SW", 4, 9, 0, false, 250, 2, 14, 0};
-    }}
+    ]],
+      float_pos = {
+        [6] = { -1, 'SW', 4, 9, 0, false, 250, 2, 14, 0 },
+      },
+    }
     feed('<Down><CR>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:------------------------------]│[2:----------------------]|*5
       {12:[No Name] [+]                  [No Name] [+]         }|
@@ -1573,11 +1713,13 @@ describe('ext_multigrid', function()
       some text                     |
       to be clicked                 |
       {1:~                             }|*3
-    ]]}
+    ]],
+    }
     eq('eiusmo', fn.getreg('"'))
 
     screen:try_resize_grid(4, 7, 11)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:------------------------------]│[2:----------------------]|*5
       {12:[No Name] [+]                  [No Name] [+]         }|
@@ -1606,11 +1748,13 @@ describe('ext_multigrid', function()
       some text                     |
       to be clicked                 |
       {1:~                             }|*3
-    ]]}
+    ]],
+    }
 
     fn.setreg('"', '')
     api.nvim_input_mouse('left', 'press', '2', 4, 9, 1)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:------------------------------]│[2:----------------------]|*5
       {12:[No Name] [+]                  [No Name] [+]         }|
@@ -1639,10 +1783,12 @@ describe('ext_multigrid', function()
       some text                     |
       to be clicked                 |
       {1:~                             }|*3
-    ]]}
+    ]],
+    }
     api.nvim_input_mouse('right', 'press', '', 4, 9, 1)
     api.nvim_input_mouse('right', 'release', '', 4, 9, 1)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:------------------------------]│[2:----------------------]|*5
       {12:[No Name] [+]                  [No Name] [+]         }|
@@ -1673,11 +1819,14 @@ describe('ext_multigrid', function()
       {1:~                             }|*3
     ## grid 6
       {21: Copy }|
-    ]], float_pos={
-      [6] = {-1, "NW", 4, 10, 0, false, 250, 2, 16, 0};
-    }}
+    ]],
+      float_pos = {
+        [6] = { -1, 'NW', 4, 10, 0, false, 250, 2, 16, 0 },
+      },
+    }
     feed('<Down><CR>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:------------------------------]│[2:----------------------]|*5
       {12:[No Name] [+]                  [No Name] [+]         }|
@@ -1706,7 +1855,8 @@ describe('ext_multigrid', function()
       some text                     |
       to be clicked                 |
       {1:~                             }|*3
-    ]]}
+    ]],
+    }
     eq('eiusmo', fn.getreg('"'))
   end)
 
@@ -1722,7 +1872,8 @@ describe('ext_multigrid', function()
     poke_eventloop()
     api.nvim_input_mouse('left', 'drag', '', 5, 1, 2)
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:--------------------------]│[5:--------------------------]|*6
       [4:--------------------------]│{11:[No Name] [+]             }|
@@ -1741,12 +1892,14 @@ describe('ext_multigrid', function()
       {20:foo}                       |
       {20:ba}^r                       |
       {1:~                         }|*4
-    ]]}
+    ]],
+    }
   end)
 
   it('has viewport information', function()
     screen:try_resize(48, 8)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [2:------------------------------------------------]|*6
       {11:[No Name]                                       }|
@@ -1756,9 +1909,11 @@ describe('ext_multigrid', function()
       {1:~                                               }|*5
     ## grid 3
                                                       |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0}
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+      },
+    }
     insert([[
       Lorem ipsum dolor sit amet, consectetur
       adipisicing elit, sed do eiusmod tempor
@@ -1772,7 +1927,8 @@ describe('ext_multigrid', function()
       qui officia deserunt mollit anim id est
       laborum.]])
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [2:------------------------------------------------]|*6
       {11:[No Name] [+]                                   }|
@@ -1786,13 +1942,15 @@ describe('ext_multigrid', function()
       laborum^.                                        |
     ## grid 3
                                                       |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 5, botline = 11, curline = 10, curcol = 7, linecount = 11, sum_scroll_delta = 5},
-    }}
-
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 5, botline = 11, curline = 10, curcol = 7, linecount = 11, sum_scroll_delta = 5 },
+      },
+    }
 
     feed('<c-u>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [2:------------------------------------------------]|*6
       {11:[No Name] [+]                                   }|
@@ -1806,12 +1964,15 @@ describe('ext_multigrid', function()
       ^dolore eu fugiat nulla pariatur. Excepteur sint |
     ## grid 3
                                                       |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 2, botline = 9, curline = 7, curcol = 0, linecount = 11, sum_scroll_delta = 2},
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 2, botline = 9, curline = 7, curcol = 0, linecount = 11, sum_scroll_delta = 2 },
+      },
+    }
 
-    command("split")
-    screen:expect{grid=[[
+    command('split')
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:------------------------------------------------]|*3
       {11:[No Name] [+]                                   }|
@@ -1827,13 +1988,16 @@ describe('ext_multigrid', function()
       ea commodo consequat. Duis aute irure dolor in  |
       reprehenderit in voluptate velit esse cillum    |
       ^dolore eu fugiat nulla pariatur. Excepteur sint |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 6, botline = 9, curline = 7, curcol = 0, linecount = 11, sum_scroll_delta = 6},
-      [4] = {win = 1001, topline = 5, botline = 9, curline = 7, curcol = 0, linecount = 11, sum_scroll_delta = 5},
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 6, botline = 9, curline = 7, curcol = 0, linecount = 11, sum_scroll_delta = 6 },
+        [4] = { win = 1001, topline = 5, botline = 9, curline = 7, curcol = 0, linecount = 11, sum_scroll_delta = 5 },
+      },
+    }
 
-    feed("b")
-    screen:expect{grid=[[
+    feed('b')
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:------------------------------------------------]|*3
       {11:[No Name] [+]                                   }|
@@ -1849,13 +2013,16 @@ describe('ext_multigrid', function()
       ea commodo consequat. Duis aute irure dolor in  |
       reprehenderit in voluptate velit esse ^cillum    |
       dolore eu fugiat nulla pariatur. Excepteur sint |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 6, botline = 9, curline = 7, curcol = 0, linecount = 11, sum_scroll_delta = 6},
-      [4] = {win = 1001, topline = 5, botline = 9, curline = 6, curcol = 38, linecount = 11, sum_scroll_delta = 5},
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 6, botline = 9, curline = 7, curcol = 0, linecount = 11, sum_scroll_delta = 6 },
+        [4] = { win = 1001, topline = 5, botline = 9, curline = 6, curcol = 38, linecount = 11, sum_scroll_delta = 5 },
+      },
+    }
 
-    feed("2k")
-    screen:expect{grid=[[
+    feed('2k')
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:------------------------------------------------]|*3
       {11:[No Name] [+]                                   }|
@@ -1871,14 +2038,17 @@ describe('ext_multigrid', function()
       exercitation ullamco laboris nisi ut a^liquip ex |
       ea commodo consequat. Duis aute irure dolor in  |
       reprehenderit in voluptate velit esse cillum    |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 6, botline = 9, curline = 7, curcol = 0, linecount = 11, sum_scroll_delta = 6},
-      [4] = {win = 1001, topline = 4, botline = 8, curline = 4, curcol = 38, linecount = 11, sum_scroll_delta = 4},
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 6, botline = 9, curline = 7, curcol = 0, linecount = 11, sum_scroll_delta = 6 },
+        [4] = { win = 1001, topline = 4, botline = 8, curline = 4, curcol = 38, linecount = 11, sum_scroll_delta = 4 },
+      },
+    }
 
     -- handles non-current window
-    api.nvim_win_set_cursor(1000, {1, 10})
-    screen:expect{grid=[[
+    api.nvim_win_set_cursor(1000, { 1, 10 })
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:------------------------------------------------]|*3
       {11:[No Name] [+]                                   }|
@@ -1894,14 +2064,17 @@ describe('ext_multigrid', function()
       exercitation ullamco laboris nisi ut a^liquip ex |
       ea commodo consequat. Duis aute irure dolor in  |
       reprehenderit in voluptate velit esse cillum    |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 3, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0},
-      [4] = {win = 1001, topline = 4, botline = 8, curline = 4, curcol = 38, linecount = 11, sum_scroll_delta = 4},
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 3, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0 },
+        [4] = { win = 1001, topline = 4, botline = 8, curline = 4, curcol = 38, linecount = 11, sum_scroll_delta = 4 },
+      },
+    }
 
     -- sum_scroll_delta works with folds
     feed('zfj')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:------------------------------------------------]|*3
       {11:[No Name] [+]                                   }|
@@ -1917,13 +2090,16 @@ describe('ext_multigrid', function()
       {13:^+--  2 lines: exercitation ullamco laboris nisi }|
       reprehenderit in voluptate velit esse cillum    |
       dolore eu fugiat nulla pariatur. Excepteur sint |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 3, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0},
-      [4] = {win = 1001, topline = 4, botline = 9, curline = 4, curcol = 38, linecount = 11, sum_scroll_delta = 4},
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 3, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0 },
+        [4] = { win = 1001, topline = 4, botline = 9, curline = 4, curcol = 38, linecount = 11, sum_scroll_delta = 4 },
+      },
+    }
 
     feed('<c-e>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:------------------------------------------------]|*3
       {11:[No Name] [+]                                   }|
@@ -1939,13 +2115,16 @@ describe('ext_multigrid', function()
       ^reprehenderit in voluptate velit esse cillum    |
       dolore eu fugiat nulla pariatur. Excepteur sint |
       occaecat cupidatat non proident, sunt in culpa  |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 3, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0},
-      [4] = {win = 1001, topline = 6, botline = 10, curline = 6, curcol = 0, linecount = 11, sum_scroll_delta = 5},
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 3, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0 },
+        [4] = { win = 1001, topline = 6, botline = 10, curline = 6, curcol = 0, linecount = 11, sum_scroll_delta = 5 },
+      },
+    }
 
     command('close | 21vsplit | setlocal number smoothscroll')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:---------------------]│[2:--------------------------]|*6
       {11:[No Name] [+]         }{12:[No Name] [+]             }|
@@ -1966,13 +2145,16 @@ describe('ext_multigrid', function()
       {19:  2 }adipisicing elit,|
       {19:    } sed do eiusmod t|
       {19:    }empor            |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0};
-      [5] = {win = 1002, topline = 0, botline = 3, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0};
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0 },
+        [5] = { win = 1002, topline = 0, botline = 3, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0 },
+      },
+    }
 
     feed('5<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:---------------------]│[2:--------------------------]|*6
       {11:[No Name] [+]         }{12:[No Name] [+]             }|
@@ -1993,13 +2175,16 @@ describe('ext_multigrid', function()
       {19:    }na aliqua.       |
       {19:  4 }Ut enim ad minim |
       {19:    }veniam, quis n{1:@@@}|
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0};
-      [5] = {win = 1002, topline = 1, botline = 4, curline = 1, curcol = 38, linecount = 11, sum_scroll_delta = 5};
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0 },
+        [5] = { win = 1002, topline = 1, botline = 4, curline = 1, curcol = 38, linecount = 11, sum_scroll_delta = 5 },
+      },
+    }
 
     feed('<C-Y>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:---------------------]│[2:--------------------------]|*6
       {11:[No Name] [+]         }{12:[No Name] [+]             }|
@@ -2020,13 +2205,16 @@ describe('ext_multigrid', function()
       {19:    }ore et dolore mag|
       {19:    }na aliqua.       |
       {19:  4 }Ut enim ad min{1:@@@}|
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0};
-      [5] = {win = 1002, topline = 1, botline = 4, curline = 1, curcol = 38, linecount = 11, sum_scroll_delta = 4};
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0 },
+        [5] = { win = 1002, topline = 1, botline = 4, curline = 1, curcol = 38, linecount = 11, sum_scroll_delta = 4 },
+      },
+    }
 
     command('set cpoptions+=n')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:---------------------]│[2:--------------------------]|*6
       {11:[No Name] [+]         }{12:[No Name] [+]             }|
@@ -2047,13 +2235,16 @@ describe('ext_multigrid', function()
       ore et dolore magna a|
       liqua.               |
       {19:  4 }Ut enim ad min{1:@@@}|
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0};
-      [5] = {win = 1002, topline = 1, botline = 4, curline = 1, curcol = 38, linecount = 11, sum_scroll_delta = 4};
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0 },
+        [5] = { win = 1002, topline = 1, botline = 4, curline = 1, curcol = 38, linecount = 11, sum_scroll_delta = 4 },
+      },
+    }
 
     feed('4<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:---------------------]│[2:--------------------------]|*6
       {11:[No Name] [+]         }{12:[No Name] [+]             }|
@@ -2074,13 +2265,16 @@ describe('ext_multigrid', function()
       {19:  5 }exercitation ulla|
       mco laboris nisi ut a|
       liquip ex            |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0};
-      [5] = {win = 1002, topline = 2, botline = 6, curline = 2, curcol = 43, linecount = 11, sum_scroll_delta = 8};
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0 },
+        [5] = { win = 1002, topline = 2, botline = 6, curline = 2, curcol = 43, linecount = 11, sum_scroll_delta = 8 },
+      },
+    }
 
     feed('2<C-Y>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:---------------------]│[2:--------------------------]|*6
       {11:[No Name] [+]         }{12:[No Name] [+]             }|
@@ -2101,13 +2295,16 @@ describe('ext_multigrid', function()
       {19:  4 }Ut enim ad minim |
       veniam, quis nostrud |
       {19:  5 }exercitation u{1:@@@}|
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0};
-      [5] = {win = 1002, topline = 2, botline = 5, curline = 2, curcol = 43, linecount = 11, sum_scroll_delta = 6};
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0 },
+        [5] = { win = 1002, topline = 2, botline = 5, curline = 2, curcol = 43, linecount = 11, sum_scroll_delta = 6 },
+      },
+    }
 
     command('setlocal numberwidth=12')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:---------------------]│[2:--------------------------]|*6
       {11:[No Name] [+]         }{12:[No Name] [+]             }|
@@ -2128,13 +2325,16 @@ describe('ext_multigrid', function()
       {19:          4 }Ut enim a|
       d minim veniam, quis |
       nostrud              |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0};
-      [5] = {win = 1002, topline = 2, botline = 5, curline = 2, curcol = 43, linecount = 11, sum_scroll_delta = 6};
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0 },
+        [5] = { win = 1002, topline = 2, botline = 5, curline = 2, curcol = 43, linecount = 11, sum_scroll_delta = 6 },
+      },
+    }
 
     feed('2<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:---------------------]│[2:--------------------------]|*6
       {11:[No Name] [+]         }{12:[No Name] [+]             }|
@@ -2155,13 +2355,16 @@ describe('ext_multigrid', function()
       nostrud              |
       {19:          5 }exercitat|
       ion ullamco labori{1:@@@}|
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0};
-      [5] = {win = 1002, topline = 2, botline = 5, curline = 2, curcol = 43, linecount = 11, sum_scroll_delta = 8};
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0 },
+        [5] = { win = 1002, topline = 2, botline = 5, curline = 2, curcol = 43, linecount = 11, sum_scroll_delta = 8 },
+      },
+    }
 
     feed('<C-E>')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [5:---------------------]│[2:--------------------------]|*6
       {11:[No Name] [+]         }{12:[No Name] [+]             }|
@@ -2182,16 +2385,19 @@ describe('ext_multigrid', function()
       {19:          5 }exercitat|
       ion ullamco laboris n|
       isi ut aliquip ex    |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0};
-      [5] = {win = 1002, topline = 3, botline = 6, curline = 3, curcol = 36, linecount = 11, sum_scroll_delta = 9};
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 4, curline = 0, curcol = 10, linecount = 11, sum_scroll_delta = 0 },
+        [5] = { win = 1002, topline = 3, botline = 6, curline = 3, curcol = 36, linecount = 11, sum_scroll_delta = 9 },
+      },
+    }
   end)
 
   it('scroll_delta is approximated reasonably when scrolling many lines #24234', function()
     command('setlocal number nowrap')
     command('edit test/functional/fixtures/bigfile.txt')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [2:-----------------------------------------------------]|*12
       {11:test/functional/fixtures/bigfile.txt                 }|
@@ -2211,11 +2417,22 @@ describe('ext_multigrid', function()
       {19:   12 }000B;<control>;Cc;0;S;;;;;N;LINE TABULATION;;;;|
     ## grid 3
                                                            |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 13, curline = 0, curcol = 0, linecount = 30592, sum_scroll_delta = 0};
-    }}
+    ]],
+      win_viewport = {
+        [2] = {
+          win = 1000,
+          topline = 0,
+          botline = 13,
+          curline = 0,
+          curcol = 0,
+          linecount = 30592,
+          sum_scroll_delta = 0,
+        },
+      },
+    }
     feed('G')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [2:-----------------------------------------------------]|*12
       {11:test/functional/fixtures/bigfile.txt                 }|
@@ -2235,11 +2452,22 @@ describe('ext_multigrid', function()
       {19:30592 }^10FFFD;<Plane 16 Private Use, Last>;Co;0;L;;;;;|
     ## grid 3
                                                            |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 30580, botline = 30592, curline = 30591, curcol = 0, linecount = 30592, sum_scroll_delta = 30580};
-    }}
+    ]],
+      win_viewport = {
+        [2] = {
+          win = 1000,
+          topline = 30580,
+          botline = 30592,
+          curline = 30591,
+          curcol = 0,
+          linecount = 30592,
+          sum_scroll_delta = 30580,
+        },
+      },
+    }
     feed('gg')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [2:-----------------------------------------------------]|*12
       {11:test/functional/fixtures/bigfile.txt                 }|
@@ -2259,11 +2487,22 @@ describe('ext_multigrid', function()
       {19:   12 }000B;<control>;Cc;0;S;;;;;N;LINE TABULATION;;;;|
     ## grid 3
                                                            |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 13, curline = 0, curcol = 0, linecount = 30592, sum_scroll_delta = 0};
-    }}
+    ]],
+      win_viewport = {
+        [2] = {
+          win = 1000,
+          topline = 0,
+          botline = 13,
+          curline = 0,
+          curcol = 0,
+          linecount = 30592,
+          sum_scroll_delta = 0,
+        },
+      },
+    }
     command('setlocal wrap')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [2:-----------------------------------------------------]|*12
       {11:test/functional/fixtures/bigfile.txt                 }|
@@ -2283,11 +2522,22 @@ describe('ext_multigrid', function()
       {19:   10 }0009;<control>;Cc;0;S;;;;;N;CHARACTER TABULA{1:@@@}|
     ## grid 3
                                                            |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 10, curline = 0, curcol = 0, linecount = 30592, sum_scroll_delta = 0};
-    }}
+    ]],
+      win_viewport = {
+        [2] = {
+          win = 1000,
+          topline = 0,
+          botline = 10,
+          curline = 0,
+          curcol = 0,
+          linecount = 30592,
+          sum_scroll_delta = 0,
+        },
+      },
+    }
     feed('G')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [2:-----------------------------------------------------]|*12
       {11:test/functional/fixtures/bigfile.txt                 }|
@@ -2307,11 +2557,22 @@ describe('ext_multigrid', function()
       {19:      }N;;;;;                                         |
     ## grid 3
                                                            |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 30586, botline = 30592, curline = 30591, curcol = 0, linecount = 30592, sum_scroll_delta = 30588};
-    }}
+    ]],
+      win_viewport = {
+        [2] = {
+          win = 1000,
+          topline = 30586,
+          botline = 30592,
+          curline = 30591,
+          curcol = 0,
+          linecount = 30592,
+          sum_scroll_delta = 30588,
+        },
+      },
+    }
     feed('gg')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [2:-----------------------------------------------------]|*12
       {11:test/functional/fixtures/bigfile.txt                 }|
@@ -2331,14 +2592,25 @@ describe('ext_multigrid', function()
       {19:   10 }0009;<control>;Cc;0;S;;;;;N;CHARACTER TABULA{1:@@@}|
     ## grid 3
                                                            |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 10, curline = 0, curcol = 0, linecount = 30592, sum_scroll_delta = 0};
-    }}
+    ]],
+      win_viewport = {
+        [2] = {
+          win = 1000,
+          topline = 0,
+          botline = 10,
+          curline = 0,
+          curcol = 0,
+          linecount = 30592,
+          sum_scroll_delta = 0,
+        },
+      },
+    }
   end)
 
   it('does not crash when dragging mouse across grid boundary', function()
     screen:try_resize(48, 8)
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [2:------------------------------------------------]|*6
       {11:[No Name]                                       }|
@@ -2348,9 +2620,11 @@ describe('ext_multigrid', function()
       {1:~                                               }|*5
     ## grid 3
                                                       |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0}
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+      },
+    }
     insert([[
       Lorem ipsum dolor sit amet, consectetur
       adipisicing elit, sed do eiusmod tempor
@@ -2364,7 +2638,8 @@ describe('ext_multigrid', function()
       qui officia deserunt mollit anim id est
       laborum.]])
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [2:------------------------------------------------]|*6
       {11:[No Name] [+]                                   }|
@@ -2378,15 +2653,18 @@ describe('ext_multigrid', function()
       laborum^.                                        |
     ## grid 3
                                                       |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 5, botline = 11, curline = 10, curcol = 7, linecount = 11, sum_scroll_delta = 5},
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 5, botline = 11, curline = 10, curcol = 7, linecount = 11, sum_scroll_delta = 5 },
+      },
+    }
 
-    api.nvim_input_mouse('left', 'press', '', 1,5, 1)
+    api.nvim_input_mouse('left', 'press', '', 1, 5, 1)
     poke_eventloop()
     api.nvim_input_mouse('left', 'drag', '', 1, 6, 1)
 
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [2:------------------------------------------------]|*6
       {11:[No Name] [+]                                   }|
@@ -2400,30 +2678,33 @@ describe('ext_multigrid', function()
       {1:~                                               }|
     ## grid 3
       {7:-- VISUAL --}                                    |
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 6, botline = 12, curline = 10, curcol = 1, linecount = 11, sum_scroll_delta = 6},
-    }}
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 6, botline = 12, curline = 10, curcol = 1, linecount = 11, sum_scroll_delta = 6 },
+      },
+    }
   end)
 
   it('with winbar', function()
     command('split')
-    local win_pos ={
+    local win_pos = {
       [2] = {
         height = 5,
         startcol = 0,
         startrow = 7,
         width = 53,
-        win = 1000
+        win = 1000,
       },
       [4] = {
         height = 6,
         startcol = 0,
         startrow = 0,
         width = 53,
-        win = 1001
-      }
+        win = 1001,
+      },
     }
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:-----------------------------------------------------]|*6
       {11:[No Name]                                            }|
@@ -2438,16 +2719,21 @@ describe('ext_multigrid', function()
     ## grid 4
       ^                                                     |
       {1:~                                                    }|*5
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-      [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-    }, win_viewport_margins={
-      [2] = {win = 1000, top = 0, bottom = 0, left = 0, right = 0};
-      [4] = {win = 1001, top = 0, bottom = 0, left = 0, right = 0};
-    }, win_pos = win_pos }
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+        [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+      },
+      win_viewport_margins = {
+        [2] = { win = 1000, top = 0, bottom = 0, left = 0, right = 0 },
+        [4] = { win = 1001, top = 0, bottom = 0, left = 0, right = 0 },
+      },
+      win_pos = win_pos,
+    }
 
     command('setlocal winbar=very%=bar')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:-----------------------------------------------------]|*6
       {11:[No Name]                                            }|
@@ -2463,16 +2749,21 @@ describe('ext_multigrid', function()
       {7:very                                              bar}|
       ^                                                     |
       {1:~                                                    }|*4
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-      [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-    }, win_viewport_margins={
-      [2] = {win = 1000, top = 0, bottom = 0, left = 0, right = 0};
-      [4] = {win = 1001, top = 1, bottom = 0, left = 0, right = 0};
-    }, win_pos = win_pos }
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+        [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+      },
+      win_viewport_margins = {
+        [2] = { win = 1000, top = 0, bottom = 0, left = 0, right = 0 },
+        [4] = { win = 1001, top = 1, bottom = 0, left = 0, right = 0 },
+      },
+      win_pos = win_pos,
+    }
 
     command('setlocal winbar=')
-    screen:expect{grid=[[
+    screen:expect {
+      grid = [[
     ## grid 1
       [4:-----------------------------------------------------]|*6
       {11:[No Name]                                            }|
@@ -2487,13 +2778,17 @@ describe('ext_multigrid', function()
     ## grid 4
       ^                                                     |
       {1:~                                                    }|*5
-    ]], win_viewport={
-      [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-      [4] = {win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
-    }, win_viewport_margins={
-      [2] = {win = 1000, top = 0, bottom = 0, left = 0, right = 0};
-      [4] = {win = 1001, top = 0, bottom = 0, left = 0, right = 0};
-    }, win_pos = win_pos }
+    ]],
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+        [4] = { win = 1001, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
+      },
+      win_viewport_margins = {
+        [2] = { win = 1000, top = 0, bottom = 0, left = 0, right = 0 },
+        [4] = { win = 1001, top = 0, bottom = 0, left = 0, right = 0 },
+      },
+      win_pos = win_pos,
+    }
   end)
 
   it('with winbar dragging statusline with mouse works correctly', function()
@@ -2636,17 +2931,28 @@ describe('ext_multigrid', function()
           {23:^                                                     }|
         ## grid 3
                                                                |
-        ]], win_viewport={
-        [2] = {win = 1000, topline = 0, botline = 12, curline = 11, curcol = 0, linecount = 12, sum_scroll_delta = 0};
-      }, win_viewport_margins={
-        [2] = {
-          bottom = 0,
-          left = 0,
-          right = 0,
-          top = 0,
-          win = 1000
-        }
-      }})
+        ]],
+        win_viewport = {
+          [2] = {
+            win = 1000,
+            topline = 0,
+            botline = 12,
+            curline = 11,
+            curcol = 0,
+            linecount = 12,
+            sum_scroll_delta = 0,
+          },
+        },
+        win_viewport_margins = {
+          [2] = {
+            bottom = 0,
+            left = 0,
+            right = 0,
+            top = 0,
+            win = 1000,
+          },
+        },
+      })
       insert('line12\n')
       screen:expect({
         grid = [[
@@ -2669,17 +2975,28 @@ describe('ext_multigrid', function()
           {23:^                                                     }|
         ## grid 3
                                                                |
-        ]], win_viewport={
-        [2] = {win = 1000, topline = 1, botline = 13, curline = 12, curcol = 0, linecount = 13, sum_scroll_delta = 1};
-      }, win_viewport_margins={
-        [2] = {
-          bottom = 0,
-          left = 0,
-          right = 0,
-          top = 0,
-          win = 1000
-        }
-      }})
+        ]],
+        win_viewport = {
+          [2] = {
+            win = 1000,
+            topline = 1,
+            botline = 13,
+            curline = 12,
+            curcol = 0,
+            linecount = 13,
+            sum_scroll_delta = 1,
+          },
+        },
+        win_viewport_margins = {
+          [2] = {
+            bottom = 0,
+            left = 0,
+            right = 0,
+            top = 0,
+            win = 1000,
+          },
+        },
+      })
     end)
 
     it('got to top scrolls correctly', function()
@@ -2707,17 +3024,28 @@ describe('ext_multigrid', function()
           {23:^                                                     }|
         ## grid 3
                                                                |
-        ]], win_viewport={
-        [2] = {win = 1000, topline = 9, botline = 21, curline = 20, curcol = 0, linecount = 21, sum_scroll_delta = 9};
-      }, win_viewport_margins={
-        [2] = {
-          bottom = 0,
-          left = 0,
-          right = 0,
-          top = 0,
-          win = 1000
-        }
-      }})
+        ]],
+        win_viewport = {
+          [2] = {
+            win = 1000,
+            topline = 9,
+            botline = 21,
+            curline = 20,
+            curcol = 0,
+            linecount = 21,
+            sum_scroll_delta = 9,
+          },
+        },
+        win_viewport_margins = {
+          [2] = {
+            bottom = 0,
+            left = 0,
+            right = 0,
+            top = 0,
+            win = 1000,
+          },
+        },
+      })
       feed('gg')
       screen:expect({
         grid = [[
@@ -2740,17 +3068,20 @@ describe('ext_multigrid', function()
           line12                                               |
         ## grid 3
                                                                |
-        ]], win_viewport={
-        [2] = {win = 1000, topline = 0, botline = 13, curline = 0, curcol = 0, linecount = 21, sum_scroll_delta = 0};
-      }, win_viewport_margins={
-        [2] = {
-          bottom = 0,
-          left = 0,
-          right = 0,
-          top = 0,
-          win = 1000
-        }
-      }})
+        ]],
+        win_viewport = {
+          [2] = { win = 1000, topline = 0, botline = 13, curline = 0, curcol = 0, linecount = 21, sum_scroll_delta = 0 },
+        },
+        win_viewport_margins = {
+          [2] = {
+            bottom = 0,
+            left = 0,
+            right = 0,
+            top = 0,
+            win = 1000,
+          },
+        },
+      })
     end)
 
     it('scrolls in the middle', function()
@@ -2778,17 +3109,28 @@ describe('ext_multigrid', function()
           {23:^                                                     }|
         ## grid 3
                                                                |
-        ]], win_viewport={
-        [2] = {win = 1000, topline = 9, botline = 21, curline = 20, curcol = 0, linecount = 21, sum_scroll_delta = 9};
-      }, win_viewport_margins={
-        [2] = {
-          bottom = 0,
-          left = 0,
-          right = 0,
-          top = 0,
-          win = 1000
-        }
-      }})
+        ]],
+        win_viewport = {
+          [2] = {
+            win = 1000,
+            topline = 9,
+            botline = 21,
+            curline = 20,
+            curcol = 0,
+            linecount = 21,
+            sum_scroll_delta = 9,
+          },
+        },
+        win_viewport_margins = {
+          [2] = {
+            bottom = 0,
+            left = 0,
+            right = 0,
+            top = 0,
+            win = 1000,
+          },
+        },
+      })
       feed('M')
       screen:expect({
         grid = [[
@@ -2811,17 +3153,28 @@ describe('ext_multigrid', function()
                                                                |
         ## grid 3
                                                                |
-        ]], win_viewport={
-        [2] = {win = 1000, topline = 9, botline = 21, curline = 14, curcol = 0, linecount = 21, sum_scroll_delta = 9};
-      }, win_viewport_margins={
-        [2] = {
-          bottom = 0,
-          left = 0,
-          right = 0,
-          top = 0,
-          win = 1000
-        }
-      }})
+        ]],
+        win_viewport = {
+          [2] = {
+            win = 1000,
+            topline = 9,
+            botline = 21,
+            curline = 14,
+            curcol = 0,
+            linecount = 21,
+            sum_scroll_delta = 9,
+          },
+        },
+        win_viewport_margins = {
+          [2] = {
+            bottom = 0,
+            left = 0,
+            right = 0,
+            top = 0,
+            win = 1000,
+          },
+        },
+      })
       feed('k')
       screen:expect({
         grid = [[
@@ -2844,24 +3197,35 @@ describe('ext_multigrid', function()
           line20                                               |
         ## grid 3
                                                                |
-        ]], win_viewport={
-        [2] = {win = 1000, topline = 8, botline = 21, curline = 13, curcol = 0, linecount = 21, sum_scroll_delta = 8};
-      }, win_viewport_margins={
-        [2] = {
-          bottom = 0,
-          left = 0,
-          right = 0,
-          top = 0,
-          win = 1000
-        }
-      }})
+        ]],
+        win_viewport = {
+          [2] = {
+            win = 1000,
+            topline = 8,
+            botline = 21,
+            curline = 13,
+            curcol = 0,
+            linecount = 21,
+            sum_scroll_delta = 8,
+          },
+        },
+        win_viewport_margins = {
+          [2] = {
+            bottom = 0,
+            left = 0,
+            right = 0,
+            top = 0,
+            win = 1000,
+          },
+        },
+      })
     end)
   end)
 
   it('message grid is shown at the correct position remote re-attach', function()
     feed(':test')
     local expected = {
-        grid = [[
+      grid = [[
         ## grid 1
           [2:-----------------------------------------------------]|*12
           {11:[No Name]                                            }|
@@ -2872,28 +3236,28 @@ describe('ext_multigrid', function()
         ## grid 3
           :test^                                                |
         ]],
-        win_pos = {
+      win_pos = {
         [2] = {
           height = 12,
           startcol = 0,
           startrow = 0,
           width = 53,
-          win = 1000
-        }
+          win = 1000,
+        },
       },
-        win_viewport = {
-        [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+      win_viewport = {
+        [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
       },
-        win_viewport_margins = {
+      win_viewport_margins = {
         [2] = {
           bottom = 0,
           left = 0,
           right = 0,
           top = 0,
-          win = 1000
-        }
+          win = 1000,
+        },
       },
-      reset = true
+      reset = true,
     }
     screen:expect(expected)
     feed('<cr>')
@@ -2905,8 +3269,8 @@ describe('ext_multigrid', function()
 end)
 
 it('headless attach with showcmd', function()
-  clear{args={'--headless'}}
-  local screen = Screen.new(80, 24, {ext_multigrid=true})
+  clear { args = { '--headless' } }
+  local screen = Screen.new(80, 24, { ext_multigrid = true })
   command('set showcmd')
   feed('1234')
   screen:expect({
@@ -2921,7 +3285,7 @@ it('headless attach with showcmd', function()
                                                                            1234       |
     ]],
     win_viewport = {
-      [2] = {win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0};
+      [2] = { win = 1000, topline = 0, botline = 2, curline = 0, curcol = 0, linecount = 1, sum_scroll_delta = 0 },
     },
   })
 end)


### PR DESCRIPTION
## Problem:
decorations_spec.lua, float_spec.lua, multigrid_spec.lua are not auto-formatted.

## Solution:
Add a special `formatlua2` cmake target, which invokes `stylua` with an alternative `.stylua2.toml` config.


cc @bfredl  for blessing