### PR TITLE
vim-patch:9.1.{1269,1272}

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -4243,7 +4243,7 @@ static compl_T *find_comp_when_fuzzy(void)
   if ((is_forward && compl_selected_item == compl_match_arraysize - 1)
       || (is_backward && compl_selected_item == 0)) {
     return compl_first_match != compl_shown_match
-           ? compl_first_match
+           ? (is_forward ? compl_shown_match->cp_next : compl_first_match)
            : (compl_first_match->cp_prev ? compl_first_match->cp_prev : NULL);
   }
 

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1291,6 +1291,12 @@ static int ins_compl_build_pum(void)
   // match after it, don't highlight anything.
   bool shown_match_ok = match_at_original_text(compl_shown_match);
 
+  bool update_shown_match = fuzzy_filter;
+  if (fuzzy_filter && ctrl_x_mode_normal()
+      && compl_leader.data == NULL && compl_shown_match->cp_score > 0) {
+    update_shown_match = false;
+  }
+
   if (strequal(compl_leader.data, compl_orig_text.data) && !shown_match_ok) {
     compl_shown_match = compl_no_select ? compl_first_match : compl_first_match->cp_next;
   }
@@ -1339,7 +1345,7 @@ static int ins_compl_build_pum(void)
         }
         // Update the maximum fuzzy score and the shown match
         // if the current item's score is higher
-        if (fuzzy_sort && comp->cp_score > max_fuzzy_score) {
+        if (fuzzy_sort && comp->cp_score > max_fuzzy_score && update_shown_match) {
           did_find_shown_match = true;
           max_fuzzy_score = comp->cp_score;
           if (!compl_no_select) {

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2866,6 +2866,8 @@ func Test_complete_opt_fuzzy()
   call assert_equal('bar', getline('.'))
   call feedkeys("Sb\<C-X>\<C-N>\<C-Y>\<ESC>", 'tx')
   call assert_equal('blue', getline('.'))
+  call feedkeys("Sb\<C-X>\<C-P>\<C-N>\<C-Y>\<ESC>", 'tx')
+  call assert_equal('b', getline('.'))
 
   " clean up
   set omnifunc=

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2861,6 +2861,12 @@ func Test_complete_opt_fuzzy()
   call feedkeys("i\<C-R>=CompAnother()\<CR>\<C-P>\<C-P>", 'tx')
   call assert_equal("for", g:abbr)
 
+  set cot=menu,fuzzy
+  call feedkeys("Sblue\<CR>bar\<CR>b\<C-X>\<C-P>\<C-Y>\<ESC>", 'tx')
+  call assert_equal('bar', getline('.'))
+  call feedkeys("Sb\<C-X>\<C-N>\<C-Y>\<ESC>", 'tx')
+  call assert_equal('blue', getline('.'))
+
   " clean up
   set omnifunc=
   bw!


### PR DESCRIPTION
Problem:  compl_shown_match is updated when starting keyword completion
          and does not include fuzzy matching.
Solution: Do not update compl_shown_match when starting keyword
          completion, since it is the one already selected by the
          keyword completion direction. (glepnir)

closes: vim/vim#17033

https://github.com/vim/vim/commit/e4e4d1c381e9d0af55f6111e9bcaf98ad60461fc


vim-patch:9.1.1272: completion: in keyword completion Ctrl_P cannot go back after Ctrl_N

Problem:  completion: in keyword completion Ctrl_P cannot go back after
          Ctrl_N
Solution: in find_compl_when_fuzzy() always return first match of array, after Ctrl_P
          use compl_shown_match->cp_next instead of compl_first_match.
          (glepnir)

closes: vim/vim#17043

https://github.com/vim/vim/commit/3e50a28a03d136c1e0c1f4fabe50d97faaf08c5c

Fix #33261
