### PR TITLE
feat(vim.hl): allow multiple timed highlights simultaneously

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -640,6 +640,12 @@ vim.hl.range({bufnr}, {ns}, {higroup}, {start}, {finish}, {opts})
                    • {timeout}? (`integer`, default: -1 no timeout) Time in ms
                      before highlight is cleared
 
+    Return (multiple): ~
+        (`uv.uv_timer_t?`) range_timer A timer which manages how much time the
+        highlight has left
+        (`fun()?`) range_clear A function which allows clearing the highlight
+        manually. nil is returned if timeout is not specified
+
 
 ==============================================================================
 VIM.DIFF                                                            *vim.diff*

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -104,7 +104,7 @@ The following new features were added.
 
 API
 
-• todo
+• |vim.hl.range()| now allows multiple timed highlights
 
 DEFAULTS
 

--- a/test/functional/lua/hl_spec.lua
+++ b/test/functional/lua/hl_spec.lua
@@ -139,6 +139,80 @@ describe('vim.hl.range', function()
                                                                   |
     ]])
   end)
+
+  it('shows multiple highlights with different timeouts simultaneously', function()
+    local timeout1 = 300
+    local timeout2 = 600
+    exec_lua(function()
+      local ns = vim.api.nvim_create_namespace('')
+      vim.hl.range(0, ns, 'Search', { 0, 0 }, { 4, 0 }, { timeout = timeout1 })
+      vim.hl.range(0, ns, 'Search', { 2, 6 }, { 3, 5 }, { timeout = timeout2 })
+    end)
+    screen:expect({
+      grid = [[
+        {10:^asdfghjkl}{100:$}                                                  |
+        {10:«口=口»}{100:$}                                                    |
+        {10:qwertyuiop}{100:$}                                                 |
+        {10:口口=口口}{1:$}                                                  |
+        zxcvbnm{1:$}                                                    |
+                                                                    |
+      ]],
+      timeout = timeout1 / 3,
+    })
+    screen:expect({
+      grid = [[
+        ^asdfghjkl{1:$}                                                  |
+        «口=口»{1:$}                                                    |
+        qwerty{10:uiop}{100:$}                                                 |
+        {10:口口}=口口{1:$}                                                  |
+        zxcvbnm{1:$}                                                    |
+                                                                    |
+      ]],
+      timeout = timeout1 + ((timeout2 - timeout1) / 3),
+    })
+    screen:expect([[
+      ^asdfghjkl{1:$}                                                  |
+      «口=口»{1:$}                                                    |
+      qwertyuiop{1:$}                                                 |
+      口口=口口{1:$}                                                  |
+      zxcvbnm{1:$}                                                    |
+                                                                  |
+    ]])
+  end)
+
+  it('allows cancelling a highlight that has not timed out', function()
+    exec_lua(function()
+      local timeout = 3000
+      local range_timer
+      local range_hl_clear
+      local ns = vim.api.nvim_create_namespace('')
+      range_timer, range_hl_clear = vim.hl.range(
+        0,
+        ns,
+        'Search',
+        { 0, 0 },
+        { 4, 0 },
+        { timeout = timeout }
+      )
+      if range_timer and not range_timer:is_closing() then
+        range_timer:close()
+        assert(range_hl_clear)
+        range_hl_clear()
+        range_hl_clear() -- Exercise redundant call
+      end
+    end)
+    screen:expect({
+      grid = [[
+        ^asdfghjkl{1:$}                                                  |
+        «口=口»{1:$}                                                    |
+        qwertyuiop{1:$}                                                 |
+        口口=口口{1:$}                                                  |
+        zxcvbnm{1:$}                                                    |
+                                                                    |
+      ]],
+      unchanged = true,
+    })
+  end)
 end)
 
 describe('vim.hl.on_yank', function()


### PR DESCRIPTION
Problem: Currently vim.hl.range only allows one timed highlight. Creating another one, removes the old one.
Solution: vim.hl.range now returns a timer and a function. The timer keeps track of how much time is left in the highlight and the function allows you to clear it, letting the user decide what to do with old highlights.

Ref: https://github.com/neovim/neovim/pull/32012#discussion_r1923881208