### PR TITLE
build(deps): check for `pthread_getname_np` symbol before bundling libuv

### DIFF
--- a/cmake.deps/CMakeLists.txt
+++ b/cmake.deps/CMakeLists.txt
@@ -110,7 +110,14 @@ if(USE_BUNDLED_UNIBILIUM)
 endif()
 
 if(USE_BUNDLED_LIBUV)
-  include(BuildLibuv)
+  include(CheckSymbolExists)
+  check_symbol_exists(pthread_getname_np "pthread.h" HAVE_PTHREAD_GETNAME_NP)
+
+  if(HAVE_PTHREAD_GETNAME_NP)
+    include(BuildLibuv)
+  else()
+    set(USE_BUNDLED_LIBUV OFF)
+  endif()
 endif()
 
 if(USE_BUNDLED_LUAJIT)


### PR DESCRIPTION
On systems that use a musl version prior to 1.2.3 neovim fails to link because the bundled libuv uses `pthread_getname_np`, which was implemented in musl 1.2.3.

Our solution is to check for the `pthread_getname_np` symbol before bundling libuv. If not found, require to use the system libuv library, which may not need `pthread_getname_np`.

Fixes #32613 