### PR TITLE
docs(diagnostic): mention `severity` in `Opts.VirtualLines`

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -574,8 +574,8 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
 *vim.diagnostic.Opts.Signs*
 
     Fields: ~
-      • {severity}?  (`vim.diagnostic.SeverityFilter`) Only show virtual text
-                     for diagnostics matching the given severity
+      • {severity}?  (`vim.diagnostic.SeverityFilter`) Only show signs for
+                     diagnostics matching the given severity
                      |diagnostic-severity|
       • {priority}?  (`integer`, default: `10`) Base priority to use for
                      signs. When {severity_sort} is used, the priority of a
@@ -607,6 +607,9 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
 *vim.diagnostic.Opts.VirtualLines*
 
     Fields: ~
+      • {severity}?      (`vim.diagnostic.SeverityFilter`) Only show virtual
+                         lines for diagnostics matching the given severity
+                         |diagnostic-severity|
       • {current_line}?  (`boolean`, default: `false`) Only show diagnostics
                          for the current line.
       • {format}?        (`fun(diagnostic:vim.Diagnostic): string?`) A

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -241,6 +241,10 @@ end
 
 --- @class vim.diagnostic.Opts.VirtualLines
 ---
+--- Only show virtual lines for diagnostics matching the given
+--- severity |diagnostic-severity|
+--- @field severity? vim.diagnostic.SeverityFilter
+---
 --- Only show diagnostics for the current line.
 --- (default: `false`)
 --- @field current_line? boolean
@@ -252,7 +256,7 @@ end
 
 --- @class vim.diagnostic.Opts.Signs
 ---
---- Only show virtual text for diagnostics matching the given
+--- Only show signs for diagnostics matching the given
 --- severity |diagnostic-severity|
 --- @field severity? vim.diagnostic.SeverityFilter
 ---


### PR DESCRIPTION
Problem: `severity` field is recognized by
  `vim.diagnostic.Opts.VirtualLines`, but it is not explicitly
  documented.

Solution: document it.

---

Also fix `severity` description for `vim.diagnostic.Opts.Signs`.