### PR TITLE
fix(messages): verbose message emitted without kind

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -3363,8 +3363,8 @@ void verbose_enter(void)
   }
   if (msg_ext_kind != verbose_kind) {
     pre_verbose_kind = msg_ext_kind;
-    msg_ext_set_kind("verbose");
   }
+  msg_ext_set_kind("verbose");
 }
 
 /// After giving verbose message.

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -372,6 +372,50 @@ describe('ui/ext_messages', function()
     })
 
     feed('<CR>')
+    exec([[
+      set verbose=9
+      augroup verbose
+        autocmd BufEnter * echoh "BufEnter"
+        autocmd BufWinEnter * bdelete
+      augroup END
+    ]])
+    feed(':edit! foo<CR>')
+    screen:expect({
+      grid = s2,
+      cmdline = { { abort = false } },
+      messages = {
+        {
+          content = { { 'Executing BufEnter Autocommands for "*"' } },
+          history = true,
+          kind = 'verbose',
+        },
+        {
+          content = { { 'autocommand echoh "BufEnter"\n' } },
+          history = true,
+          kind = 'verbose',
+        },
+        {
+          content = { { 'Executing BufWinEnter Autocommands for "*"' } },
+          history = true,
+          kind = 'verbose',
+        },
+        {
+          content = { { 'autocommand bdelete\n' } },
+          history = true,
+          kind = 'verbose',
+        },
+        {
+          content = { { 'Press ENTER or type command to continue', 6, 18 } },
+          history = false,
+          kind = 'return_prompt',
+        },
+      },
+    })
+    feed('<CR>')
+    command('autocmd! verbose')
+    command('augroup! verbose')
+    command('set verbose=0')
+
     n.add_builddir_to_rtp()
     feed(':help<CR>:tselect<CR>')
     screen:expect({
@@ -406,7 +450,7 @@ describe('ui/ext_messages', function()
         screen.messages = {}
       end,
     })
-    feed('<CR>:bd<CR>')
+    feed('<CR>:bdelete<CR>$')
 
     -- kind=shell for :!cmd messages
     local cmd = t.is_os('win') and 'echo stdout& echo stderr>&2& exit 3'


### PR DESCRIPTION
Problem:  Successive autocmd verbose messages may be emitted without a kind.
Solution: Always set the kind when preparing to emit a verbose message.