### PR TITLE
docs(options): mark options.txt as generated

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -4,6 +4,7 @@
 
 runtime/doc/*   linguist-documentation
 runtime/doc/builtin.txt linguist-generated
+runtime/doc/options.txt linguist-generated
 
 runtime/lua/vim/_meta/vimfn.lua linguist-generated
 runtime/lua/vim/_meta/vvars.lua linguist-generated


### PR DESCRIPTION
6fa17da marks runtime/lua/vim/_meta/options.lua as generated. If I'm not
mistaken, runtime/doc/options.txt is also generated.

If there are more generated doc files, I can include them in this PR.
