### PR TITLE
fix(vim.version): check nvim version but fast

### DIFF
--- a/runtime/lua/vim/version.lua
+++ b/runtime/lua/vim/version.lua
@@ -459,14 +459,31 @@ function M.parse(version, opts)
   return M._version(version, opts.strict)
 end
 
+M.nvim_version = setmetatable({}, Version)
+for _, p in ipairs(require('vim._nvim_version')) do
+  M.nvim_version[p[1]] = p[2]
+end
+M.nvim_version.prerelease = M.nvim_version.prerelease and 'dev' or nil
+
+  --- Check whether current Nvim version includes version
+  --- behaves similar to has("nvim-{major}.{minor}.{patch}")
+  ---@return true if actual version is less than or equal to major.minor.patch
+function M.has(major, minor, patch)
+  local v = M.nvim_version
+  if major ~= v.major then
+    return major < v.major
+  end
+  if minor ~= v.minor then
+    return minor < v.minor
+  end
+  return (patch or 0) <= v.patch
+end
+
 setmetatable(M, {
   --- Returns the current Nvim version.
   ---@return vim.Version
   __call = function()
-    local version = vim.fn.api_info().version ---@type vim.Version
-    -- Workaround: vim.fn.api_info().version reports "prerelease" as a boolean.
-    version.prerelease = version.prerelease and 'dev' or nil
-    return setmetatable(version, Version)
+    return M.nvim_version
   end,
 })
 

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -615,9 +615,10 @@ add_custom_command(
   COMMAND ${CMAKE_COMMAND} -E env
       "LUAC_PRG=${LUAC_PRG}"
       ${LUA_PRG} ${CHAR_BLOB_GENERATOR} -c ${VIM_MODULE_FILE}
-      # NB: vim._init_packages and vim.inspect must be be first and second ones
-      # respectively, otherwise --luamod-dev won't work properly.
+      # NB: vim._init_packages, _nvim_version and vim.inspect must be first in that order
+      # otherwise --luamod-dev won't work properly.
       ${LUA_INIT_PACKAGES_MODULE_SOURCE} "vim._init_packages"
+      ${NVIM_VERSION_LUA} "vim._nvim_version"
       ${LUA_INSPECT_MODULE_SOURCE} "vim.inspect"
       ${LUA_EDITOR_MODULE_SOURCE} "vim._editor"
       ${LUA_FILETYPE_MODULE_SOURCE} "vim.filetype"
@@ -643,6 +644,7 @@ add_custom_command(
     ${LUA_OPTIONS_MODULE_SOURCE}
     ${LUA_SHARED_MODULE_SOURCE}
     ${LUA_TEXT_MODULE_SOURCE}
+    ${NVIM_VERSION_LUA}
   VERBATIM
 )
 


### PR DESCRIPTION
problem: using vim.version() as a replacement of vim.has("nvim-0.11") is too slow
solution: add vim.version.has(major,minor,patch) which is fast