### PR TITLE
fix(health): correct check for inotify

### DIFF
--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -111,8 +111,8 @@ local function check_watcher()
     watchfunc_name = 'libuv-watch'
   elseif watchfunc == vim._watch.watchdirs then
     watchfunc_name = 'libuv-watchdirs'
-  elseif watchfunc == vim._watch.inotifywait then
-    watchfunc_name = 'inotifywait'
+  elseif watchfunc == vim._watch.inotify then
+    watchfunc_name = 'inotify'
   else
     local nm = debug.getinfo(watchfunc, 'S').source
     watchfunc_name = string.format('Custom (%s)', nm)


### PR DESCRIPTION
Problem:
`vim.lsp._watchfiles._watchfunc` was being compared to `nil`

Solution:
Clean up remnant code, seems the name of `vim._watch.inotify` was `inotifywait` at one point.