### PR TITLE
refactor(shell)!: shell_build_argv no longer tokenizes p_sh

### DIFF
--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -576,11 +576,12 @@ notfound:
 char **shell_build_argv(const char *cmd, const char *extra_args)
   FUNC_ATTR_NONNULL_RET
 {
-  size_t argc = tokenize(p_sh, NULL) + (cmd ? tokenize(p_shcf, NULL) : 0);
+  size_t argc = 1 + (cmd ? tokenize(p_shcf, NULL) : 0);
   char **rv = xmalloc((argc + 4) * sizeof(*rv));
 
-  // Split 'shell'
-  size_t i = tokenize(p_sh, rv);
+  size_t i = 0;
+  // Unquote 'shell'
+  rv[i++] = vim_strnsave_unquoted((const char *)p_sh, strlen((const char *)p_sh));
 
   if (extra_args) {
     rv[i++] = xstrdup(extra_args);        // Push a copy of `extra_args`


### PR DESCRIPTION
fixes #7810  
- Previous attempts: #7846, #11281  
- Related: vim/vim#459  

NOTE: No real change from #7846. This aims to be a breaking change by disallowing flags in the `shell` option, resulting in simpler option setting and test case modifications.