### PR TITLE
vim-patch:b8d5c85: runtime(doc): update WinScrolled documentation

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1186,6 +1186,13 @@ WinScrolled			After any window in the current tab page
 				or changed width or height.  See
 				|win-scrolled-resized|.
 
+				Note: This can not be skipped with
+				`:noautocmd`, because it triggers after
+				processing normal commands when Vim is back in
+				the main loop.  If you want to disable this,
+				consider setting the 'eventignore' option
+				instead.
+
 				The pattern is matched against the |window-ID|
 				of the first window that scrolled or resized.
 				Both <amatch> and <afile> are set to the


### PR DESCRIPTION
#### vim-patch:b8d5c85: runtime(doc): update WinScrolled documentation

https://github.com/vim/vim/commit/b8d5c8509998f3a97ffe42f674352b07749cd119

Co-authored-by: Christian Brabandt <cb@256bit.org>