### PR TITLE
fix(vim.hl): nvim_buf_del_extmark on invalid buffer

### DIFF
--- a/runtime/lua/vim/hl.lua
+++ b/runtime/lua/vim/hl.lua
@@ -128,6 +128,9 @@ function M.range(bufnr, ns, higroup, start, finish, opts)
   end
 
   local range_hl_clear = function()
+    if not api.nvim_buf_is_valid(bufnr) then
+      return
+    end
     for _, mark in ipairs(extmarks) do
       api.nvim_buf_del_extmark(bufnr, ns, mark)
     end

--- a/test/functional/lua/hl_spec.lua
+++ b/test/functional/lua/hl_spec.lua
@@ -222,6 +222,7 @@ describe('vim.hl.on_yank', function()
 
   it('does not show errors even if buffer is wiped before timeout', function()
     command('new')
+    n.feed('ifoo<esc>') -- set '[, ']
     exec_lua(function()
       vim.hl.on_yank({
         timeout = 10,


### PR DESCRIPTION
Problem: nvim_buf_del_extmark error if buffer is wipeout before timer
stops

Solution: pcall nvim_buf_del_extmark

Reproduction:
source this in a buffer:
```lua
vim.hl.on_yank({ timeout = 100, on_macro = true, event = { operator = 'y', regtype = 'v' } })
vim.cmd('bwipeout!')
```

Beofre test forget to set a mark '[, '] before on_yank.