### PR TITLE
fix(defaults): keywordprg=':help' on windows

### DIFF
--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -4844,7 +4844,9 @@ local options = {
     {
       abbreviation = 'kp',
       defaults = {
-        if_true = ':Man',
+        condition = 'MSWIN',
+        if_true = ':help',
+        if_false = ':Man',
         doc = '":Man", Windows: ":help"',
       },
       desc = [=[


### PR DESCRIPTION
**Problem:**
As `:h kp` says, the default value for keywordprg
should be ':help' on Windows. It is currently
always ':Man'.

**Solution:**
Add condition to options.lua which sets keywordprg to ':help' if running on windows.

Resolves getting noisy error message when using `<S-k>` on windows described in: #33265 since nvim no longer tries to find `man` by default