### PR TITLE
fix(decor): enable decoration provider in on_start

### DIFF
--- a/src/nvim/decoration_provider.c
+++ b/src/nvim/decoration_provider.c
@@ -118,6 +118,8 @@ void decor_providers_start(void)
       ADD_C(args, INTEGER_OBJ((int)display_tick));
       bool active = decor_provider_invoke((int)i, "start", p->redraw_start, args, true);
       kv_A(decor_providers, i).state = active ? kDecorProviderActive : kDecorProviderRedrawDisabled;
+    } else if (p->state != kDecorProviderDisabled) {
+      kv_A(decor_providers, i).state = kDecorProviderActive;
     }
   }
 }
@@ -220,7 +222,6 @@ void decor_providers_invoke_end(void)
       MAXSIZE_TEMP_ARRAY(args, 1);
       ADD_C(args, INTEGER_OBJ((int)display_tick));
       decor_provider_invoke((int)i, "end", p->redraw_end, args, true);
-      kv_A(decor_providers, i).state = kDecorProviderActive;
     }
   }
   decor_check_to_be_deleted();

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -838,6 +838,26 @@ describe('decorations providers', function()
                                               |
     ]])
   end)
+
+  it('decor provider is enabled again for next redraw after on_win disabled it', function()
+    exec_lua(function()
+      vim.api.nvim_set_decoration_provider(vim.api.nvim_create_namespace(''), {
+        on_win = function()
+          return false
+        end,
+        on_buf = function()
+          _G.did_buf = (_G.did_buf or 0) + 1
+        end,
+      })
+    end)
+    api.nvim_buf_set_lines(0, 0, -1, false, { 'foo' })
+    screen:expect([[
+      ^foo                                     |
+      {1:~                                       }|*6
+                                              |
+    ]])
+    eq(1, exec_lua('return _G.did_buf'))
+  end)
 end)
 
 describe('decoration_providers', function()


### PR DESCRIPTION
Problem:  An on_win-disabled decoration provider is left disabled for
          the on_buf callback during the next redraw (if the provider
          does not subscribe to on_end).
Solution: Move re-activation of the provider from after the on_end
          callback to before the on_start callback.

Fix #33333