### PR TITLE
build: bump NVIM_API_LEVEL

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,9 +150,9 @@ set(NVIM_VERSION_PATCH 0)
 set(NVIM_VERSION_PRERELEASE "-dev") # for package maintainers
 
 # API level
-set(NVIM_API_LEVEL 13)        # Bump this after any API/stdlib change.
+set(NVIM_API_LEVEL 14)        # Bump this after any API/stdlib change.
 set(NVIM_API_LEVEL_COMPAT 0)  # Adjust this after a _breaking_ API change.
-set(NVIM_API_PRERELEASE false)
+set(NVIM_API_PRERELEASE true)
 
 # We _want_ assertions in RelWithDebInfo build-type.
 if(CMAKE_C_FLAGS_RELWITHDEBINFO MATCHES DNDEBUG)

--- a/src/gen/util.lua
+++ b/src/gen/util.lua
@@ -20,6 +20,7 @@ end
 -- Map of api_level:version, by inspection of:
 --    :lua= vim.mpack.decode(vim.fn.readfile('test/functional/fixtures/api_level_9.mpack','B')).version
 M.version_level = {
+  [14] = '0.12.0',
   [13] = '0.11.0',
   [12] = '0.10.0',
   [11] = '0.9.0',


### PR DESCRIPTION
Bumping NVIM_API_LEVEL is pretty much required after every major release, because it's also used to correlated Lua stdlib changes to a Nvim version.