### PR TITLE
refactor(lsp): deprecate client_is_stopped

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -29,7 +29,8 @@ HIGHLIGHTS
 
 LSP
 
-• *vim.lsp.util.stylize_markdown()"	Use |vim.treesitter.start()| with
+• *vim.lsp.client_is_stopped()*		Use |vim.lsp.get_client_by_id()| instead.
+• *vim.lsp.util.stylize_markdown()*	Use |vim.treesitter.start()| with
 					`vim.wo.conceallevel = 2`.
 
 LUA

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -803,15 +803,6 @@ buf_request_sync({bufnr}, {method}, {params}, {timeout_ms})
         (`string?`) err On timeout, cancel, or error, `err` is a string
         describing the failure reason, and `result` is nil.
 
-client_is_stopped({client_id})                   *vim.lsp.client_is_stopped()*
-    Checks whether a client is stopped.
-
-    Parameters: ~
-      • {client_id}  (`integer`)
-
-    Return: ~
-        (`boolean`) stopped true if client is stopped, false otherwise.
-
 commands                                                    *vim.lsp.commands*
     Registry (a table) for client-side handlers, for custom server-commands
     that are not in the LSP specification.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1468,11 +1468,13 @@ function lsp.foldtext()
   return vim.lsp._folding_range.foldtext()
 end
 
+---@deprecated Use |vim.lsp.get_client_by_id()| instead.
 ---Checks whether a client is stopped.
 ---
 ---@param client_id (integer)
 ---@return boolean stopped true if client is stopped, false otherwise.
 function lsp.client_is_stopped(client_id)
+  vim.deprecate('vim.lsp.client_is_stopped()', 'vim.lsp.get_client_by_id()', '0.14')
   assert(client_id, 'missing client_id param')
   return not all_clients[client_id]
 end


### PR DESCRIPTION
Problem:
`client_is_stopped(…)` is an (very old...) alias for `not get_client_by_id(…)`. And it's not used anywhere in our codebase.

Solution:
Deprecate it.