### PR TITLE
fix(treesitter): one-off error in range redraw

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -237,7 +237,7 @@ end
 ---@param changes Range6[]
 function TSHighlighter:on_changedtree(changes)
   for _, ch in ipairs(changes) do
-    api.nvim__redraw({ buf = self.bufnr, range = { ch[1], ch[4] }, flush = false })
+    api.nvim__redraw({ buf = self.bufnr, range = { ch[1], ch[4] + 1 }, flush = false })
     -- Only invalidate the _conceal_checked range if _conceal_line is set and
     -- ch[4] is not UINT32_MAX (empty range on first changedtree).
     if ch[4] == 2 ^ 32 - 1 then


### PR DESCRIPTION
It looks like https://github.com/neovim/neovim/pull/31324 introduced a regression:

When a line is deleted and there are virtual text lines above it, the virtualtext might not always be refreshed correctly, as seen in https://github.com/neovim/neovim/issues/33358.

This fix worked for me, but I don't really know what I'm doing here (besides reverting a part of a commit).