### PR TITLE
vim-patch:2ffb4d0: runtime(lua): fix whitespace style issues in lua ftplugin

### DIFF
--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -1,12 +1,14 @@
-" Language:             Lua
-" Maintainer:           Doug Kearns <dougkearns@gmail.com>
-" Previous Maintainer:  Max Ischenko <mfi@ukr.net>
-" Contributor:          Dorai Sitaram <ds26@gte.com>
-"                       C.D. MacEachern <craig.daniel.maceachern@gmail.com>
-"                       Tyler Miller <tmillr@proton.me>
-"                       Phạm Bình An <phambinhanctb2004@gmail.com>
-"                       @konfekt
-" Last Change:          2025 Apr 04
+" Vim filetype plugin file.
+
+" Language:		Lua
+" Maintainer:		Doug Kearns <dougkearns@gmail.com>
+" Previous Maintainer:	Max Ischenko <mfi@ukr.net>
+" Contributor:		Dorai Sitaram <ds26@gte.com>
+"			C.D. MacEachern <craig.daniel.maceachern@gmail.com>
+"			Tyler Miller <tmillr@proton.me>
+"			Phạm Bình An <phambinhanctb2004@gmail.com>
+"			@konfekt
+" Last Change:		2025 Apr 04
 
 if exists("b:did_ftplugin")
   finish
@@ -41,11 +43,11 @@ let b:undo_ftplugin = "setl cms< com< def< fo< inc< inex< sua<"
 if exists("loaded_matchit") && !exists("b:match_words")
   let b:match_ignorecase = 0
   let b:match_words =
-        \ '\<\%(do\|function\|if\)\>:' ..
-        \ '\<\%(return\|else\|elseif\)\>:' ..
-        \ '\<end\>,' ..
-        \ '\<repeat\>:\<until\>,' ..
-        \ '\%(--\)\=\[\(=*\)\[:]\1]'
+	\ '\<\%(do\|function\|if\)\>:' ..
+	\ '\<\%(return\|else\|elseif\)\>:' ..
+	\ '\<end\>,' ..
+	\ '\<repeat\>:\<until\>,' ..
+	\ '\%(--\)\=\[\(=*\)\[:]\1]'
   let b:undo_ftplugin ..= " | unlet! b:match_words b:match_ignorecase"
 endif
 


### PR DESCRIPTION
#### vim-patch:2ffb4d0: runtime(lua): fix whitespace style issues in lua ftplugin

related: vim/vim#17049

https://github.com/vim/vim/commit/2ffb4d0298426f6c57f3ec3caae4480024e4372d

Co-authored-by: Christian Brabandt <cb@256bit.org>