### PR TITLE
docs: fix directory path for spell files on Windows

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -62,7 +62,7 @@ Several Neovim GUIs are available from scoop (extras): [scoop.sh/#/apps?q=neovim
 
 - Add the `bin` folder (e.g. `C:\Program Files\nvim\bin`) to your PATH.
     - This makes it easy to run `nvim` from anywhere.
-- If `:set spell` does not work, create the `C:/Users/foo/AppData/Local/nvim/site/spell` folder.
+- If `:set spell` does not work, create the `%LOCALAPPDATA%/nvim-data/site/spell` folder.
   You can then copy your spell files over (for English, located
   [here](https://github.com/vim/vim/blob/master/runtime/spell/en.utf-8.spl) and
   [here](https://github.com/vim/vim/blob/master/runtime/spell/en.utf-8.sug));


### PR DESCRIPTION
According to [`spellfile.vim`](https://github.com/neovim/neovim/blob/53efdedca97072f7463830d49f5d755801471c09/runtime/autoload/spellfile.vim#L202)
```vim
function! spellfile#WritableSpellDir()
  " Always use the $XDG_DATA_HOME/…/site directory
  return stdpath('data').'/site/spell'
endfunction
```

Where `stdpath('data')` on Windows points to `~/AppData/Local/nvim-data`, see `:help standard-path`