### PR TITLE
feat(health): summary report in section header

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -165,7 +165,7 @@ TUI
 
 UI
 
-• todo
+• |:checkhealth| shows a summary in the header for every healthcheck.
 
 VIMSCRIPT
 

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -91,7 +91,7 @@ describe('vim.health', function()
       n.expect([[
 
       ==============================================================================
-      test_plug.full_render:         require("test_plug.full_render.health").check()
+      test_plug.full_render:                                              1 ⚠️  1 ❌
 
       report 1 ~
       - ✅ OK life is fine
@@ -114,7 +114,7 @@ describe('vim.health', function()
       n.expect([[
 
         ==============================================================================
-        test_plug:                                 require("test_plug.health").check()
+        test_plug:                                                                  ✅
 
         report 1 ~
         - ✅ OK everything is fine
@@ -123,7 +123,7 @@ describe('vim.health', function()
         - ✅ OK nothing to see here
 
         ==============================================================================
-        test_plug.success1:               require("test_plug.success1.health").check()
+        test_plug.success1:                                                         ✅
 
         report 1 ~
         - ✅ OK everything is fine
@@ -132,7 +132,7 @@ describe('vim.health', function()
         - ✅ OK nothing to see here
 
         ==============================================================================
-        test_plug.success2:               require("test_plug.success2.health").check()
+        test_plug.success2:                                                         ✅
 
         another 1 ~
         - ✅ OK ok
@@ -144,7 +144,7 @@ describe('vim.health', function()
       n.expect([[
 
         ==============================================================================
-        test_plug.submodule:             require("test_plug.submodule.health").check()
+        test_plug.submodule:                                                        ✅
 
         report 1 ~
         - ✅ OK everything is fine
@@ -159,7 +159,7 @@ describe('vim.health', function()
       n.expect([[
 
       ==============================================================================
-      test_plug.submodule_empty: require("test_plug.submodule_empty.health").check()
+      test_plug.submodule_empty:                                                1 ❌
 
       - ❌ ERROR The healthcheck report for "test_plug.submodule_empty" plugin is empty.
       ]])
@@ -185,7 +185,7 @@ describe('vim.health', function()
         - ❌ {Error:ERROR} No healthcheck found for "foo" plugin. |
                                                           |
         {Bar:                                                  }|
-        {h1:test_plug.success1:               require("test_pl}|
+        {h1:test_plug.success1:                               }|
                                                           |
         {h2:report 1}                                          |
         - ✅ {Ok:OK} everything is fine                        |
@@ -200,7 +200,7 @@ describe('vim.health', function()
       n.expect([[
 
         ==============================================================================
-        non_existent_healthcheck:                                                     
+        non_existent_healthcheck:                                                 1 ❌
 
         - ❌ ERROR No healthcheck found for "non_existent_healthcheck" plugin.
         ]])
@@ -218,7 +218,7 @@ describe('vim.health', function()
       n.expect([[
 
       ==============================================================================
-      test_plug.lua:                         require("test_plug.lua.health").check()
+      test_plug.lua:                                                              ✅
 
       nested lua/ directory ~
       - ✅ OK everything is ok
@@ -236,7 +236,7 @@ describe('vim.health', function()
       n.expect([[
 
       ==============================================================================
-      nest:                                           require("nest.health").check()
+      nest:                                                                       ✅
 
       healthy pack ~
       - ✅ OK healthy ok
@@ -281,14 +281,14 @@ describe(':checkhealth window', function()
       ^                                                  |
       {14:                                                  }|
       {14:                            }                      |
-      {h1:test_plug.success1:                               }|
-      {h1:require("test_plug.success1.health").check()}      |
+      {h1:test_plug.                                        }|
+      {h1:success1:                                         }|
+      {h1:                ✅}                                |
                                                         |
       {h2:report 1}                                          |
       - ✅ {32:OK} everything is fine                        |
                                                         |
       {h2:report 2}                                          |
-      - ✅ {32:OK} nothing to see here                       |
     ## grid 3
                                                         |
     ]],
@@ -324,8 +324,8 @@ describe(':checkhealth window', function()
       {14:   }                      |
       {h1:test_plug.               }|
       {h1:success1:                }|
-      {h1:require("test_plug.      }|
-      {h1:success1.health").check()}|
+      {h1:                         }|
+      {h1:                ✅}       |
                                |
       {h2:report 1}                 |
       - ✅ {32:OK} everything is    |
@@ -383,15 +383,15 @@ describe(':checkhealth window', function()
       ^                                                  |
                                                         |
                                                         |
-      test_plug.success1:                               |
-      require("test_plug.success1.health").check()      |
+      test_plug.                                        |
+      success1:                                         |
+                      ✅                                |
                                                         |
       report 1                                          |
       - ✅ OK everything is fine                        |
                                                         |
       report 2                                          |
       - ✅ OK nothing to see here                       |
-                                                        |
     ]]):format(
         top
             and [[


### PR DESCRIPTION
As suggested in my comment (https://github.com/neovim/neovim/issues/32162#issuecomment-2767527469) on #32162, this PR implements a ok/warn/error summary in the section header of
health checks.

The format needs discussion.

## Example Formats

![](https://github.com/user-attachments/assets/9d3fb216-9f31-41b2-a730-802fef6cf60a)

| Description | Screenshot |
|--------|--------|
| | ![](https://github.com/user-attachments/assets/26d59f31-1010-4d62-8924-7b7413f9341b) |
| Without alignment | ![](https://github.com/user-attachments/assets/5457d9d9-6ed2-438c-998a-2a842fc14f9c) |
| With alignment | ![](https://github.com/user-attachments/assets/be958168-276d-4ea4-80cd-b7a3a45769ca) |
| `❌:1` | ![](https://github.com/user-attachments/assets/d2f08e82-cbc4-4ae7-947c-d1e3655da9f9) |
| w/o emojis (can ofc be colored) | ![](https://github.com/user-attachments/assets/2968f7f4-abb5-4c49-8dd3-377548676b80) |
| w/o emojis and space | ![](https://github.com/user-attachments/assets/3159eb19-45f5-4f1e-82a1-aa2964f485e5) |
| `E:1` | ![](https://github.com/user-attachments/assets/abcbec54-f43c-4c29-bc07-b7534a874b77) |

## Statusline default formats

Here are some defaults formats that different statusline plugins use. They mostly use (nerdfont) symbols instead of the diagnostic letters:

- Lualine: `E 3 W 2 I 1`
- Galaxyline: `I 1 W 2 E 3`
- Neoline: `E 3 W 2 I 1`
- Mini-statusline: `E3 W2 I1`
- Bufferline: `3E 2W 1I`
- sttusline: `E 3 W 2 I 1`
- hardline: `E:3 W:2 I:1`
- statusline.lua: `I 1 W 2 E 3`

---

Problem:
As checkhealth grows, it is increasingly hard to quickly glance through the information.

Solution:
A summary listing the number of ok, warn, and error outputs per section can aid the user in finding warnings or errors.
