### PR TITLE
fix(marks): wrong display after inserting/deleting lines

### DIFF
--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -3033,6 +3033,21 @@ describe('extmark decorations', function()
     feed('<C-E><C-Y>')
     eq(5, n.fn.line('w0'))
   end)
+
+  it('redraws the line from which a left gravity mark has moved #27369', function()
+    fn.setline(1, {'aaa', 'bbb', 'ccc', 'ddd' })
+    api.nvim_buf_set_extmark(0, ns, 1, 0, { virt_text = {{'foo'}}, right_gravity = false })
+    feed('yyp')
+    screen:expect([[
+      aaa                                               |
+      ^aaa foo                                           |
+      bbb                                               |
+      ccc                                               |
+      ddd                                               |
+      {1:~                                                 }|*9
+                                                        |
+    ]])
+  end)
 end)
 
 describe('decorations: inline virtual text', function()
@@ -4756,6 +4771,67 @@ describe('decorations: inline virtual text', function()
       {1:~                                                 }|*3
                                                         |
     ]])
+  end)
+
+  it('is redrawn correctly after delete or redo #27370', function()
+    screen:try_resize(50, 12)
+    exec([[
+      call setline(1, ['aaa', 'bbb', 'ccc', 'ddd', 'eee', 'fff'])
+      call setline(3, repeat('c', winwidth(0) - 1))
+    ]])
+    api.nvim_buf_set_extmark(0, ns, 1, 0, { virt_text = { { '!!!' } }, virt_text_pos = 'inline' })
+    feed('j')
+    local before_delete = [[
+      aaa                                               |
+      !!!^bbb                                            |
+      ccccccccccccccccccccccccccccccccccccccccccccccccc |
+      ddd                                               |
+      eee                                               |
+      fff                                               |
+      {1:~                                                 }|*5
+                                                        |
+    ]]
+    screen:expect(before_delete)
+    feed('dd')
+    local after_delete = [[
+      aaa                                               |
+      !!!^ccccccccccccccccccccccccccccccccccccccccccccccc|
+      cc                                                |
+      ddd                                               |
+      eee                                               |
+      fff                                               |
+      {1:~                                                 }|*5
+                                                        |
+    ]]
+    screen:expect(after_delete)
+    command('silent undo')
+    screen:expect(before_delete)
+    command('silent redo')
+    screen:expect(after_delete)
+    command('silent undo')
+    screen:expect(before_delete)
+    command('set report=100')
+    feed('yypk2P')
+    before_delete = [[
+      aaa                                               |
+      ^bbb                                               |
+      bbb                                               |
+      !!!bbb                                            |
+      bbb                                               |
+      ccccccccccccccccccccccccccccccccccccccccccccccccc |
+      ddd                                               |
+      eee                                               |
+      fff                                               |
+      {1:~                                                 }|*2
+                                                        |
+    ]]
+    screen:expect(before_delete)
+    feed('4dd')
+    screen:expect(after_delete)
+    command('silent undo')
+    screen:expect(before_delete)
+    command('silent redo')
+    screen:expect(after_delete)
   end)
 
   it('cursor position is correct with invalidated inline virt text', function()


### PR DESCRIPTION
Problem:  Lines to/from which virt_lines or inline virt_text may have
          moved are left valid. Similarly the modified region may be
          too small to account for moved decorations after inserting
          or deleting lines. `redrawOneLine()` can be replaced with
          a call to `changed_lines_redraw_buf()`.
Solution: Invalidate the line after a change if there is virt_lines, or
          inline virt_text in the buffer with 'wrap' enabled. Extend the
          modified region for inserted or deleted lines if there may be
          decorations in the buffer. Remove `redrawOneLine()`.
          Simplify the logic for `changed_lines_invalidate_win()`.

Fix #27369
Fix #27370