### PR TITLE
Add ftplugin for commentstrings for `remind`

### DIFF
--- a/runtime/ftplugin/remind.vim
+++ b/runtime/ftplugin/remind.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin file
+" Language:             Remind - a sophisticated calendar and alarm
+" Maintainer:           Joe Reynolds <joereynolds952@gmail.com>
+" Previous Maintainer:  None
+" Latest Revision:      2025 April 08
+" License:              Vim (see :h license)
+
+if exists("b:did_ftplugin")
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=:# commentstring=#\ %s


### PR DESCRIPTION
Adds in an ftplugin for [remind](https://dianne.skoll.ca/projects/remind/).

It was bugging me that I couldn't `gc` my remind file.


