### PR TITLE
fix: add bold border size to vim.lsp.buf.hover

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -24,6 +24,7 @@ local border_size = {
   rounded = { 2, 2 },
   solid = { 2, 2 },
   shadow = { 1, 1 },
+  bold = { 2, 2 },
 }
 
 --- Check the border given by opts or the default border for the additional


### PR DESCRIPTION
Problem: vim.lsp.buf.hover allows a bold border size which hasn't been defined

Solution: Define the bold border size for vim.lsp.buf.hover

Fixes: https://github.com/neovim/neovim/issues/33382