### PR TITLE
vim-patch:9.1.1288: Using wrong window in ll_resize_stack()

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3794,13 +3794,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'lhistory'* *'lhi'*
 'lhistory' 'lhi'	number	(default 10)
 			local to window
-	Like 'chistory', but for the location list stack associated with the
-	current window.  If the option is changed in either the location list
-	window itself or the the window that is associated with the location
-	list stack, the new value will also be applied to the other one.  This
-	means this value will always be the same for a given location list
-	window and its corresponding window.  See |quickfix-stack| for
-	additional info.
+	Like 'chistory', but for the location list stack associated with a
+	window.  If the option is changed in either the location list window
+	itself or the window that is associated with the location list stack,
+	the new value will also be applied to the other one.  This means this
+	value will always be the same for a given location list window and its
+	corresponding window.  See |quickfix-stack| for additional info.
 
 			*'linebreak'* *'lbr'* *'nolinebreak'* *'nolbr'*
 'linebreak' 'lbr'	boolean	(default off)

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -3744,13 +3744,12 @@ vim.o.lz = vim.o.lazyredraw
 vim.go.lazyredraw = vim.o.lazyredraw
 vim.go.lz = vim.go.lazyredraw
 
---- Like 'chistory', but for the location list stack associated with the
---- current window.  If the option is changed in either the location list
---- window itself or the the window that is associated with the location
---- list stack, the new value will also be applied to the other one.  This
---- means this value will always be the same for a given location list
---- window and its corresponding window.  See `quickfix-stack` for
---- additional info.
+--- Like 'chistory', but for the location list stack associated with a
+--- window.  If the option is changed in either the location list window
+--- itself or the window that is associated with the location list stack,
+--- the new value will also be applied to the other one.  This means this
+--- value will always be the same for a given location list window and its
+--- corresponding window.  See `quickfix-stack` for additional info.
 ---
 --- @type integer
 vim.o.lhistory = 10

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -5046,13 +5046,12 @@ local options = {
       cb = 'did_set_xhistory',
       defaults = 10,
       desc = [=[
-        Like 'chistory', but for the location list stack associated with the
-        current window.  If the option is changed in either the location list
-        window itself or the the window that is associated with the location
-        list stack, the new value will also be applied to the other one.  This
-        means this value will always be the same for a given location list
-        window and its corresponding window.  See |quickfix-stack| for
-        additional info.
+        Like 'chistory', but for the location list stack associated with a
+        window.  If the option is changed in either the location list window
+        itself or the window that is associated with the location list stack,
+        the new value will also be applied to the other one.  This means this
+        value will always be the same for a given location list window and its
+        corresponding window.  See |quickfix-stack| for additional info.
       ]=],
       full_name = 'lhistory',
       scope = { 'win' },

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2011,9 +2011,9 @@ void qf_resize_stack(int n)
 /// Resize location list stack for window 'wp' to be able to hold n amount of lists.
 void ll_resize_stack(win_T *wp, int n)
 {
-  // check if current window is a location list window;
+  // check if given window is a location list window;
   // if so then sync its 'lhistory' to the parent window or vice versa
-  if (IS_LL_WINDOW(curwin)) {
+  if (IS_LL_WINDOW(wp)) {
     qf_sync_llw_to_win(wp);
   } else {
     qf_sync_win_to_llw(wp);
@@ -2107,7 +2107,6 @@ static qf_info_T *qf_alloc_stack(qfltype_T qfltype, int n)
 }
 
 /// Allocate memory for qf_lists member of qf_info_T struct.
-/// 'actual' is the actual amount of lists that have been allocated for
 static qf_list_T *qf_alloc_list_stack(int n)
   FUNC_ATTR_NONNULL_RET
 {


### PR DESCRIPTION
#### vim-patch:9.1.1288: Using wrong window in ll_resize_stack()

Problem:  Using wrong window in ll_resize_stack()
          (after v9.1.1287)
Solution: Use "wp" instead of "curwin", even though they are always the
          same value.  Fix typos in documentation (zeertzjq).

closes: vim/vim#17080

https://github.com/vim/vim/commit/b71f1309a210bf8f61a24f4eda336de64c6f0a07