### PR TITLE
vim-patch:7517a8c: runtime(lf): improve syntax script, add filetype plugin

### DIFF
--- a/runtime/ftplugin/lf.vim
+++ b/runtime/ftplugin/lf.vim
@@ -1,0 +1,22 @@
+" Vim filetype plugin file
+" Language: lf file manager configuration file (lfrc)
+" Maintainer: Andis Sprinkis <andis@sprinkis.com>
+" URL: https://github.com/andis-sprinkis/lf-vim
+" Last Change: 6 Apr 2025
+
+if exists("b:did_ftplugin") | finish | endif
+
+let b:did_ftplugin = 1
+
+let s:cpo = &cpo
+set cpo&vim
+
+let b:undo_ftplugin = "setlocal comments< commentstring< formatoptions<"
+
+setlocal comments=:#
+setlocal commentstring=#\ %s
+
+setlocal formatoptions-=t formatoptions+=rol
+
+let &cpo = s:cpo
+unlet s:cpo

--- a/runtime/syntax/lf.vim
+++ b/runtime/syntax/lf.vim
@@ -3,242 +3,235 @@
 " Maintainer: Andis Sprinkis <andis@sprinkis.com>
 " Former Maintainer: Cameron Wright
 " URL: https://github.com/andis-sprinkis/lf-vim
-" Last Change: 28 March 2025
-" 29 Mar 2025 by Vim Project (save and restore 'cpo' setting)
+" Last Change: 5 Apr 2025
 "
 " The shell syntax highlighting is configurable. See $VIMRUNTIME/doc/syntax.txt
 " lf version: 34
 
-if exists("b:current_syntax")
-    finish
-endif
+if exists("b:current_syntax") | finish | endif
+
 let s:cpo = &cpo
 set cpo&vim
 
 let b:current_syntax = "lf"
 
 "{{{ Comment Matching
-syn match    lfComment        '#.*$'
+syn match lfComment '#.*$'
 "}}}
 
 "{{{ String Matching
-syn match    lfString         "'.*'"
-syn match    lfString         '".*"' contains=lfVar,lfSpecial
-"}}}
-
-"{{{ Match lf Variables
-syn match    lfVar            '\$f\|\$fx\|\$fs\|\$id'
+syn match lfString "'.*'"
+syn match lfString '".*"' contains=lfSpecial
 "}}}
 
 "{{{ Keywords
-syn keyword  lfKeyword        set setlocal cmd map cmap skipwhite
+syn keyword lfKeyword set setlocal cmd map cmap skipwhite
 "}}}
 
 "{{{ Options Keywords
-syn keyword  lfOptions
-    \ anchorfind
-    \ autoquit
-    \ borderfmt
-    \ bottom
-    \ calcdirsize
-    \ cd
-    \ cleaner
-    \ clear
-    \ clearmaps
-    \ cmd-capitalize-word
-    \ cmd-complete
-    \ cmd-delete
-    \ cmd-delete-back
-    \ cmd-delete-end
-    \ cmd-delete-home
-    \ cmd-delete-unix-word
-    \ cmd-delete-word
-    \ cmd-delete-word-back
-    \ cmd-end
-    \ cmd-enter
-    \ cmd-escape
-    \ cmd-history-next
-    \ cmd-history-prev
-    \ cmd-home
-    \ cmd-interrupt
-    \ cmd-left
-    \ cmd-lowercase-word
-    \ cmd-menu-accept
-    \ cmd-menu-complete
-    \ cmd-menu-complete-back
-    \ cmd-right
-    \ cmd-transpose
-    \ cmd-transpose-word
-    \ cmd-uppercase-word
-    \ cmd-word
-    \ cmd-word-back
-    \ cmd-yank
-    \ copy
-    \ copyfmt
-    \ cursoractivefmt
-    \ cursorparentfmt
-    \ cursorpreviewfmt
-    \ cut
-    \ cutfmt
-    \ delete
-    \ dircache
-    \ dircounts
-    \ dirfirst
-    \ dironly
-    \ dirpreviews
-    \ down
-    \ draw
-    \ drawbox
-    \ dupfilefmt
-    \ echo
-    \ echoerr
-    \ echomsg
-    \ errorfmt
-    \ filesep
-    \ filter
-    \ find
-    \ find-back
-    \ find-next
-    \ find-prev
-    \ findlen
-    \ glob-select
-    \ glob-unselect
-    \ globfilter
-    \ globsearch
-    \ half-down
-    \ half-up
-    \ hidden
-    \ hiddenfiles
-    \ high
-    \ history
-    \ icons
-    \ ifs
-    \ ignorecase
-    \ ignoredia
-    \ incfilter
-    \ incsearch
-    \ info
-    \ infotimefmtnew
-    \ infotimefmtold
-    \ invert
-    \ invert-below
-    \ jump-next
-    \ jump-prev
-    \ load
-    \ locale
-    \ low
-    \ mark-load
-    \ mark-remove
-    \ mark-save
-    \ middle
-    \ mouse
-    \ number
-    \ numberfmt
-    \ on-cd
-    \ on-focus-gained
-    \ on-focus-lost
-    \ on-init
-    \ on-quit
-    \ on-redraw
-    \ on-select
-    \ open
-    \ page-down
-    \ page-up
-    \ paste
-    \ period
-    \ pre-cd
-    \ preserve
-    \ preview
-    \ previewer
-    \ promptfmt
-    \ push
-    \ quit
-    \ ratios
-    \ read
-    \ redraw
-    \ relativenumber
-    \ reload
-    \ rename
-    \ reverse
-    \ roundbox
-    \ rulerfmt
-    \ scroll-down
-    \ scroll-up
-    \ scrolloff
-    \ search
-    \ search-back
-    \ search-next
-    \ search-prev
-    \ select
-    \ selectfmt
-    \ selmode
-    \ setfilter
-    \ shell
-    \ shell-async
-    \ shell-pipe
-    \ shell-wait
-    \ shellflag
-    \ shellopts
-    \ showbinds
-    \ sixel
-    \ smartcase
-    \ smartdia
-    \ sortby
-    \ source
-    \ statfmt
-    \ sync
-    \ tabstop
-    \ tag
-    \ tag-toggle
-    \ tagfmt
-    \ tempmarks
-    \ timefmt
-    \ toggle
-    \ top
-    \ truncatechar
-    \ truncatepct
-    \ unselect
-    \ up
-    \ updir
-    \ waitmsg
-    \ watch
-    \ wrapscan
-    \ wrapscroll
+syn keyword lfOptions
+  \ anchorfind
+  \ autoquit
+  \ borderfmt
+  \ bottom
+  \ calcdirsize
+  \ cd
+  \ cleaner
+  \ clear
+  \ clearmaps
+  \ cmaps
+  \ cmd-capitalize-word
+  \ cmd-complete
+  \ cmd-delete
+  \ cmd-delete-back
+  \ cmd-delete-end
+  \ cmd-delete-home
+  \ cmd-delete-unix-word
+  \ cmd-delete-word
+  \ cmd-delete-word-back
+  \ cmd-end
+  \ cmd-enter
+  \ cmd-escape
+  \ cmd-history-next
+  \ cmd-history-prev
+  \ cmd-home
+  \ cmd-interrupt
+  \ cmd-left
+  \ cmd-lowercase-word
+  \ cmd-menu-accept
+  \ cmd-menu-complete
+  \ cmd-menu-complete-back
+  \ cmd-right
+  \ cmd-transpose
+  \ cmd-transpose-word
+  \ cmd-uppercase-word
+  \ cmd-word
+  \ cmd-word-back
+  \ cmd-yank
+  \ cmds
+  \ copy
+  \ copyfmt
+  \ cursoractivefmt
+  \ cursorparentfmt
+  \ cursorpreviewfmt
+  \ cut
+  \ cutfmt
+  \ delete
+  \ dircache
+  \ dircounts
+  \ dirfirst
+  \ dironly
+  \ dirpreviews
+  \ doc
+  \ down
+  \ draw
+  \ drawbox
+  \ dupfilefmt
+  \ echo
+  \ echoerr
+  \ echomsg
+  \ errorfmt
+  \ filesep
+  \ filter
+  \ find
+  \ find-back
+  \ find-next
+  \ find-prev
+  \ findlen
+  \ glob-select
+  \ glob-unselect
+  \ globfilter
+  \ globsearch
+  \ half-down
+  \ half-up
+  \ hidden
+  \ hiddenfiles
+  \ high
+  \ history
+  \ icons
+  \ ifs
+  \ ignorecase
+  \ ignoredia
+  \ incfilter
+  \ incsearch
+  \ info
+  \ infotimefmtnew
+  \ infotimefmtold
+  \ invert
+  \ invert-below
+  \ jump-next
+  \ jump-prev
+  \ load
+  \ locale
+  \ low
+  \ maps
+  \ mark-load
+  \ mark-remove
+  \ mark-save
+  \ middle
+  \ mouse
+  \ number
+  \ numberfmt
+  \ on-cd
+  \ on-focus-gained
+  \ on-focus-lost
+  \ on-init
+  \ on-quit
+  \ on-redraw
+  \ on-select
+  \ open
+  \ page-down
+  \ page-up
+  \ paste
+  \ period
+  \ pre-cd
+  \ preserve
+  \ preview
+  \ previewer
+  \ promptfmt
+  \ push
+  \ quit
+  \ ratios
+  \ read
+  \ redraw
+  \ relativenumber
+  \ reload
+  \ rename
+  \ reverse
+  \ roundbox
+  \ rulerfmt
+  \ scroll-down
+  \ scroll-up
+  \ scrolloff
+  \ search
+  \ search-back
+  \ search-next
+  \ search-prev
+  \ select
+  \ selectfmt
+  \ selmode
+  \ setfilter
+  \ shell
+  \ shell-async
+  \ shell-pipe
+  \ shell-wait
+  \ shellflag
+  \ shellopts
+  \ showbinds
+  \ sixel
+  \ smartcase
+  \ smartdia
+  \ sortby
+  \ source
+  \ statfmt
+  \ sync
+  \ tabstop
+  \ tag
+  \ tag-toggle
+  \ tagfmt
+  \ tempmarks
+  \ timefmt
+  \ toggle
+  \ top
+  \ truncatechar
+  \ truncatepct
+  \ unselect
+  \ up
+  \ updir
+  \ waitmsg
+  \ watch
+  \ wrapscan
+  \ wrapscroll
 "}}}
 
 "{{{ Special Matching
-syn match    lfSpecial        '<.*>\|\\.'
+syn match lfSpecial '\v\<[^>]+\>'
+syn match lfSpecial '\v\\(["\\abfnrtv]|\o+)'
 "}}}
 
 "{{{ Shell Script Matching for cmd
 let s:shell_syntax = get(g:, 'lf_shell_syntax', "syntax/sh.vim")
 let s:shell_syntax = get(b:, 'lf_shell_syntax', s:shell_syntax)
+
 unlet b:current_syntax
 exe 'syn include @Shell '.s:shell_syntax
 let b:current_syntax = "lf"
-syn region   lfIgnore         start=".{{\n" end="^}}"
-    \ keepend contains=lfExternalShell,lfExternalPatch
-syn match    lfShell          '\$[a-zA-Z].*$
-    \\|:[a-zA-Z].*$
-    \\|%[a-zA-Z].*$
-    \\|![a-zA-Z].*$
-    \\|&[a-zA-Z].*$'
-    \ transparent contains=@Shell,lfExternalPatch
-syn match    lfExternalShell  "^.*$" transparent contained contains=@Shell
-syn match    lfExternalPatch  "^\s*cmd\ .*\ .{{$\|^}}$" contained
+
+syn region lfCommand matchgroup=lfCommandMarker start=' \zs:\ze' end='$' keepend transparent
+syn region lfCommand matchgroup=lfCommandMarker start=' \zs:{{\ze' end='}}' keepend transparent
+syn region lfShell matchgroup=lfShellMarker start=' \zs[$!%&]\ze' end='$' keepend contains=@Shell
+syn region lfShell matchgroup=lfShellMarker start=' \zs[$!%&]{{\ze' end='}}' keepend contains=@Shell
 "}}}
 
 "{{{ Link Highlighting
-hi def link  lfComment        Comment
-hi def link  lfVar            Type
-hi def link  lfSpecial        Special
-hi def link  lfString         String
-hi def link  lfKeyword        Statement
-hi def link  lfOptions        Constant
-hi def link  lfConstant       Constant
-hi def link  lfExternalShell  Normal
-hi def link  lfExternalPatch  Special
-hi def link  lfIgnore         Special
+hi def link lfComment       Comment
+hi def link lfSpecial       SpecialChar
+hi def link lfString        String
+hi def link lfKeyword       Statement
+hi def link lfOptions       Constant
+hi def link lfCommandMarker Special
+hi def link lfShellMarker   Special
 "}}}
+
 let &cpo = s:cpo
 unlet s:cpo


### PR DESCRIPTION
- Greatly improve detection and highlighting of command/shell regions,
  input-device key labels, escape sequences (@joelim-work)
- Add ftplugin for formatoptions, toggling comment areas
  (@andis-sprinkis)
- Add a few missing lf option keywords, rm. old non-working code, misc.
  formatting (@andis-sprinkis)

closes: vim/vim#17078

https://github.com/vim/vim/commit/7517a8cadfd0e70d0422955cbad4767f6a40f29d

Co-authored-by: Andis Spriņķis <andis@sprinkis.com>

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
