### PR TITLE
fix(api): restore non-brutal behavior of nvim_buf_delete

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -509,8 +509,9 @@ bool buf_locked(buf_T *buf)
 bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last, bool ignore_abort)
 {
   bool unload_buf = (action != 0);
-  bool del_buf = (action == DOBUF_DEL || action == DOBUF_WIPE);
-  bool wipe_buf = (action == DOBUF_WIPE);
+  bool wipe_brutal = (action == DOBUF_WIPE_BRUTAL);
+  bool wipe_buf = (action == DOBUF_WIPE) || wipe_brutal;
+  bool del_buf = (action == DOBUF_DEL) || wipe_buf;
 
   bool is_curwin = (curwin != NULL && curwin->w_buffer == buf);
   win_T *the_curwin = curwin;
@@ -706,8 +707,10 @@ bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last, bool i
     if (buf->b_nwindows > 0) {
       return false;
     }
-    FOR_ALL_TAB_WINDOWS(tp, wp) {
-      mark_forget_file(wp, buf->b_fnum);
+    if (wipe_brutal) {
+      FOR_ALL_TAB_WINDOWS(tp, wp) {
+        mark_forget_file(wp, buf->b_fnum);
+      }
     }
     if (buf->b_sfname != buf->b_ffname) {
       XFREE_CLEAR(buf->b_sfname);
@@ -1114,7 +1117,7 @@ char *do_bufdel(int command, char *arg, int addr_count, int start_bnr, int end_b
         }
         if (!ascii_isdigit(*arg)) {
           char *p = skiptowhite_esc(arg);
-          bnr = buflist_findpat(arg, p, command == DOBUF_WIPE, false, false);
+          bnr = buflist_findpat(arg, p, command == DOBUF_WIPE_BRUTAL, false, false);
           if (bnr < 0) {                    // failed
             break;
           }
@@ -1232,7 +1235,7 @@ static int do_buffer_ext(int action, int start, int dir, int count, int flags)
   buf_T *bp;
   bool update_jumplist = true;
   bool unload = (action == DOBUF_UNLOAD || action == DOBUF_DEL
-                 || action == DOBUF_WIPE);
+                 || action == DOBUF_WIPE || action == DOBUF_WIPE_BRUTAL);
 
   switch (start) {
   case DOBUF_FIRST:
@@ -1324,7 +1327,7 @@ static int do_buffer_ext(int action, int start, int dir, int count, int flags)
 
     // When unloading or deleting a buffer that's already unloaded and
     // unlisted: fail silently.
-    if (action != DOBUF_WIPE && buf->b_ml.ml_mfp == NULL && !buf->b_p_bl) {
+    if (action != DOBUF_WIPE_BRUTAL && buf->b_ml.ml_mfp == NULL && !buf->b_p_bl) {
       return FAIL;
     }
 
@@ -1595,7 +1598,7 @@ void set_curbuf(buf_T *buf, int action, bool update_jumplist)
 {
   buf_T *prevbuf;
   int unload = (action == DOBUF_UNLOAD || action == DOBUF_DEL
-                || action == DOBUF_WIPE);
+                || action == DOBUF_WIPE || action == DOBUF_WIPE_BRUTAL);
   OptInt old_tw = curbuf->b_p_tw;
   const int last_winid = get_last_winid();
 

--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -45,6 +45,7 @@ enum dobuf_action_values {
   DOBUF_UNLOAD = 2,  ///< unload specified buffer(s)
   DOBUF_DEL    = 3,  ///< delete specified buffer(s) from buflist
   DOBUF_WIPE   = 4,  ///< delete specified buffer(s) really
+  DOBUF_WIPE_BRUTAL   = 5,///< delete specified buffer(s) brutally
 };
 
 /// Values for start argument for do_buffer_ext()

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4504,7 +4504,7 @@ static void ex_bunload(exarg_T *eap)
   eap->errmsg = do_bufdel(eap->cmdidx == CMD_bdelete
                           ? DOBUF_DEL
                           : eap->cmdidx == CMD_bwipeout
-                          ? DOBUF_WIPE
+                          ? DOBUF_WIPE_BRUTAL
                           : DOBUF_UNLOAD,
                           eap->arg, eap->addr_count, (int)eap->line1, (int)eap->line2,
                           eap->forceit);


### PR DESCRIPTION
in #13077 78556ab nvim_buf_delete was introduced by reusing the implementation of :bwipeout which at the time was the ex command to (for real) delete a buffer.

Later on, in vim-patch:9.1.0554 #29639 the implementation of :bwipeout was changed to not just delete the buffer, but also be _brutal_ about it. This inadvertently caused the API function nvim_buf_delete to also delete permanent shada state, which was never intended and never documented.

Restore the previous non-brutal behavior of nvim_buf_delete, while still deleting the buffer.

fixes #33314