### PR TITLE
fix(man.lua): provide better error message when failing to execute man

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -8,6 +8,12 @@ local M = {}
 --- @param env? table<string,string|number>
 --- @return string
 local function system(cmd, silent, env)
+  if vim.fn.executable(cmd[1]) == 0 then
+    error(string.format('not found: "%s"', cmd[1]), 0)
+  elseif vim.uv.fs_access(cmd[1], 'X') then
+    error(string.format('not executable : "%s"', cmd[1]), 0)
+  end
+
   local r = vim.system(cmd, { env = env, timeout = 10000 }):wait()
 
   if not silent then
@@ -577,7 +583,10 @@ function M.man_complete(arg_lead, cmd_line)
     return {}
   end
 
-  local pages = get_paths(name, sect)
+  local ok, pages = pcall(get_paths, name, sect)
+  if not ok then
+    return nil
+  end
 
   -- We check for duplicates in case the same manpage in different languages
   -- was found.

--- a/runtime/plugin/man.lua
+++ b/runtime/plugin/man.lua
@@ -8,7 +8,7 @@ vim.api.nvim_create_user_command('Man', function(params)
   if params.bang then
     man.init_pager()
   else
-    local err = man.open_page(params.count, params.smods, params.fargs)
+    local _, err = pcall(man.open_page, params.count, params.smods, params.fargs)
     if err then
       vim.notify('man.lua: ' .. err, vim.log.levels.ERROR)
     end


### PR DESCRIPTION
Problem:  `:Man` shows inacurrate error message when `man`
	  can't be executed

Solution: throw error with better message when `vim.system` fails

Fixes: #33265

Before:
![before - Copy](https://github.com/user-attachments/assets/3249bd46-95a4-4546-9b65-a13f690d5322)


After:
![afternew - Copy](https://github.com/user-attachments/assets/1e25532b-85a0-49b9-b4ab-0dd6ca93bd29)
