### PR TITLE
vim-patch:9.1.1289: tests: no test for matchparen plugin with WinScrolled event

### DIFF
--- a/runtime/plugin/matchparen.vim
+++ b/runtime/plugin/matchparen.vim
@@ -1,6 +1,6 @@
 " Vim plugin for showing matching parens
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2025 Mar 14
+" Last Change:	2025 Apr 08
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Exit quickly when:

--- a/test/functional/legacy/matchparen_spec.lua
+++ b/test/functional/legacy/matchparen_spec.lua
@@ -261,4 +261,35 @@ describe('matchparen', function()
       {5:-- INSERT --}                            |
     ]])
   end)
+
+  -- oldtest: Test_scroll_winenter()
+  it('with scrolling', function()
+    local screen = Screen.new(30, 7)
+    exec([[
+      source $VIMRUNTIME/plugin/matchparen.vim
+      set scrolloff=1
+      call setline(1, ['foobar {', '', '', '', '}'])
+      call cursor(5, 1)
+    ]])
+    screen:add_extra_attr_ids({
+      [100] = { background = Screen.colors.Aqua },
+    })
+    local s1 = [[
+      foobar {100:{}                      |
+                                    |*3
+      {100:^}}                             |
+      {1:~                             }|
+                                    |
+    ]]
+    screen:expect(s1)
+    feed('<C-E>')
+    screen:expect([[
+                                    |*3
+      ^}                             |
+      {1:~                             }|*2
+                                    |
+    ]])
+    feed('<C-Y>')
+    screen:expect(s1)
+  end)
 end)

--- a/test/old/testdir/test_plugin_matchparen.vim
+++ b/test/old/testdir/test_plugin_matchparen.vim
@@ -177,4 +177,28 @@ func Test_matchparen_ignore_sh_case()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test for the WinScrolled event
+func Test_scroll_winenter()
+  CheckScreendump
+
+  let lines =<< trim END
+    source $VIMRUNTIME/plugin/matchparen.vim
+    set scrolloff=1
+    call setline(1, ['foobar {', '', '', '', '}'])
+    call cursor(5, 1)
+  END
+
+  let filename = 'Xmatchparen_winscrolled'
+  call writefile(lines, filename, 'D')
+
+  let buf = RunVimInTerminal('-S '.filename, #{rows: 7})
+  call VerifyScreenDump(buf, 'Test_matchparen_winscrolled1', {})
+  call term_sendkeys(buf, "\<C-E>")
+  call VerifyScreenDump(buf, 'Test_matchparen_winscrolled2', {})
+  call term_sendkeys(buf, "\<C-Y>")
+  call VerifyScreenDump(buf, 'Test_matchparen_winscrolled1', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1289: tests: no test for matchparen plugin with WinScrolled event

Problem:  tests: no test for matchparen plugin with WinScrolled event
Solution: add missing test

https://github.com/vim/vim/commit/96a0b2a6d5107580398435e263bd529d4ba3df49

Co-authored-by: Christian Brabandt <cb@256bit.org>