### PR TITLE
fix(lsp): considering '\n' when get_content_length

### DIFF
--- a/runtime/lua/vim/lsp/rpc.lua
+++ b/runtime/lua/vim/lsp/rpc.lua
@@ -21,7 +21,7 @@ end
 --- @param header string The header to parse
 --- @return integer
 local function get_content_length(header)
-  for line in header:gmatch('(.-)\r\n') do
+  for line in header:gmatch('(.-)\r?\n') do
     if line == '' then
       break
     end


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

Fixes #33408

As the issue shows, this bug is started from https://github.com/neovim/neovim/commit/42657e70b8a8ddf8edbe261f410aeb6169e5f6dc which changed the impl of getting content length.

The commit used `string:gmatch` instead of `vim.gsplit` when parsing headers which differs in processing line breaks.

For `vim.gsplit(s, "\r\n")` which could split correct result for string with `"\r\n"` and `"\n"`,
```lua
local sn = "line1\nline2\nline3\n"
local srn = "line1\r\nline2\r\nline3\r\n"

---@param s string
function parse(s)
	for line in vim.gsplit(s, "\r\n") do
		if line == "" then
			break
		end

		print(line)
	end
end

parse(sn)
print("--------------------")
parse(srn)
```
This script output is,
```
line1
line2
line3
--------------------
line1
line2
line3
```

But for `string:gmatch(s, "(.-)\r\n")` which differs, (by changing the `vim.gsplit(s, "\r\n")` into `s:gmatch("(.-)\r\n")`)
```
--------------------
line1
line2
line3
```
That's because it's matching but not using find.

So we should change the patterns to make it matches the "\n" without "\r".
