### PR TITLE
vim-patch:9.1.1290: tests: missing cleanup in test_filetype.vim

### DIFF
--- a/test/functional/legacy/matchparen_spec.lua
+++ b/test/functional/legacy/matchparen_spec.lua
@@ -262,7 +262,7 @@ describe('matchparen', function()
     ]])
   end)
 
-  -- oldtest: Test_scroll_winenter()
+  -- oldtest: Test_scroll_winscrolled()
   it('with scrolling', function()
     local screen = Screen.new(30, 7)
     exec([[

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -2808,6 +2808,7 @@ func Test_pro_file()
   call writefile(['x = findgen(100)/10'], 'Xfile.pro', 'D')
   split Xfile.pro
   call assert_equal('idlang', &filetype)
+  bwipe!
 
   filetype off
 endfunc
@@ -2841,6 +2842,7 @@ func Test_pl_file()
   call writefile(['%data = (1, 2, 3);'], 'Xfile.pl', 'D')
   split Xfile.pl
   call assert_equal('perl', &filetype)
+  bwipe!
 
   filetype off
 endfunc

--- a/test/old/testdir/test_plugin_matchparen.vim
+++ b/test/old/testdir/test_plugin_matchparen.vim
@@ -178,7 +178,7 @@ func Test_matchparen_ignore_sh_case()
 endfunc
 
 " Test for the WinScrolled event
-func Test_scroll_winenter()
+func Test_scroll_winscrolled()
   CheckScreendump
 
   let lines =<< trim END


### PR DESCRIPTION
#### vim-patch:9.1.1290: tests: missing cleanup in test_filetype.vim

Problem:  tests: missing cleanup in test_filetype.vim, wrong name in
          test_plugin_matchparen
Solution: Add :bwipe corresponding to :split, rename test case

closes: vim/vim#17088

https://github.com/vim/vim/commit/b0e19f9e1b43328158784ad2429880e0370b5e7b