### PR TITLE
fix(lsp): completely clear all hints after being requested

### DIFF
--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -94,8 +94,12 @@ function M.on_refresh(err, _, ctx)
   for _, bufnr in ipairs(vim.lsp.get_buffers_by_client_id(ctx.client_id)) do
     for _, winid in ipairs(api.nvim_list_wins()) do
       if api.nvim_win_get_buf(winid) == bufnr then
-        if bufstates[bufnr] and bufstates[bufnr].enabled then
-          bufstates[bufnr].applied = {}
+        local bufstate = bufstates[bufnr]
+        if bufstate and bufstate.enabled then
+          bufstate.applied = {}
+          if bufstate.client_hints then
+            bufstate.client_hints[ctx.client_id] = {}
+          end
           util._refresh(ms.textDocument_inlayHint, { bufnr = bufnr })
         end
       end


### PR DESCRIPTION
This PR does not address known bugs but attempts to cover potential edge cases. Can be seen as a follow-up to https://github.com/neovim/neovim/pull/32446, with relevant discussions in https://github.com/neovim/neovim/issues/33391#issuecomment-2796411525.

The LSP says this request:

```
This is useful if a server detects a configuration change which requires a re-calculation of all inlay hints.
```

However, it seems to be used in more scenarios than expected, so here we choose to clear all previous hints of the client having been requested, as this data should be outdated for the server, allowing the server to fully control the data.