### PR TITLE
vim-patch:ab2fe65: runtime(doc): correct backslash escaping comma example

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -156,7 +156,7 @@ A few examples: >
    :set makeprg=make,file	    results in "make,file"
    :set makeprg=make\\,file	    results in "make\,file"
    :set tags=tags,file		    results in "tags" and "file"
-   :set tags=tags\\,file	    results in "tags,file"
+   :set tags=tags\\,file	    results in "tags\,file"
    :let &tags='tags\,file'	    (same as above)
 
 The "|" character separates a ":set" command from a following command.  To


### PR DESCRIPTION
#### vim-patch:ab2fe65: runtime(doc): correct backslash escaping comma example

closes: vim/vim#17096

https://github.com/vim/vim/commit/ab2fe65fbf2680af5f23112da9f8a83167e234bb

Co-authored-by: Qiming zhao <chemzqm@gmail.com>