### PR TITLE
fix(treesitter): clear parse options state

### DIFF
--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -545,7 +545,8 @@ static int parser_parse(lua_State *L)
                                        .progress_callback = on_parser_progress };
       new_tree = ts_parser_parse_with_options(p, old_tree, input, parse_options);
     } else {
-      new_tree = ts_parser_parse(p, old_tree, input);
+      // Tree-sitter retains parse options after use, so we must explicitly reset them here.
+      new_tree = ts_parser_parse_with_options(p, old_tree, input, (TSParseOptions) { 0 });
     }
 
     break;


### PR DESCRIPTION
Apparently after parsing with options in tree-sitter, the options data persists in the parser object, and thus successive calls to `ts_parser_parse()` will act like `ts_parser_parse_with_options()`. This is problematic because `languagetree.lua` makes coroutine-environment assumptions based on if a nullptr has been returned by the parser function. This commit makes it so that the parse options state is reset upon a regular parse (would be nice if this was done upstream).

Fixes #33277
