### PR TITLE
fix(man.lua): useless executability check in `system`

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -9,9 +9,7 @@ local M = {}
 --- @return string
 local function system(cmd, silent, env)
   if vim.fn.executable(cmd[1]) == 0 then
-    error(string.format('not found: "%s"', cmd[1]), 0)
-  elseif vim.uv.fs_access(cmd[1], 'X') then
-    error(string.format('not executable : "%s"', cmd[1]), 0)
+    error(string.format('executable not found: "%s"', cmd[1]), 0)
   end
 
   local r = vim.system(cmd, { env = env, timeout = 10000 }):wait()


### PR DESCRIPTION
Problem:
executability check using `uv.fs_access` added in #33409 doesn't work at all currently 
and can't work on windows since `uv.fs_access(..., 'X')` always returns true if the file exists
(even if its a text file which is read only, and every user is denied read & write & execute access)

Solution:
Since this check is never reached on other platforms anyway, (due to `vim.fn.executable` also checking for
execute access if not on windows) remove `uv.fs_access` check