### PR TITLE
vim-patch:9.1.1297: Ctrl-D scrolling can get stuck

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2333,6 +2333,7 @@ void cursor_correct(win_T *wp)
         ~(VALID_WROW|VALID_WCOL|VALID_CHEIGHT|VALID_CROW);
     }
   }
+  check_cursor_moved(wp);
   wp->w_valid |= VALID_TOPLINE;
   wp->w_viewport_invalid = true;
 }

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4336,4 +4336,23 @@ func Test_normal_go()
   bwipe!
 endfunc
 
+" Test for Ctrl-D with 'scrolloff' and narrow window does not get stuck.
+func Test_scroll_longline_scrolloff()
+  11new
+  36vsplit
+  set scrolloff=5
+
+  call setline(1, ['']->repeat(5))
+  call setline(6, ['foo'->repeat(20)]->repeat(2))
+  call setline(8, ['bar'->repeat(30)])
+  call setline(9, ['']->repeat(5))
+  exe "normal! \<C-D>"
+  call assert_equal(6, line('w0'))
+  exe "normal! \<C-D>"
+  call assert_equal(7, line('w0'))
+
+  set scrolloff&
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  cursor_correct() calculates a valid cursor position which
	  is later changed by update_topline() and causes Ctrl-D
          scrolling to be stuck (Daniel Steinberg, after v9.1.0258).
Solution: Update the valid cursor position before validating topline
          (Luuk van Baal).

https://github.com/vim/vim/commit/c98250377d32007490da46b3334771ba3b2667fe
