### PR TITLE
fix(vim.system): unclear non-executable message

### DIFF
--- a/runtime/lua/vim/_system.lua
+++ b/runtime/lua/vim/_system.lua
@@ -245,7 +245,7 @@ local function spawn(cmd, opts, on_exit, on_error)
   local handle, pid_or_err = uv.spawn(cmd, opts, on_exit)
   if not handle then
     on_error()
-    error(pid_or_err)
+    error(('%s: "%s"'):format(pid_or_err, cmd))
   end
   return handle, pid_or_err --[[@as integer]]
 end

--- a/test/functional/lua/system_spec.lua
+++ b/test/functional/lua/system_spec.lua
@@ -53,6 +53,13 @@ describe('vim.system', function()
 
   for name, system in pairs { sync = system_sync, async = system_async } do
     describe('(' .. name .. ')', function()
+      it('failure modes', function()
+        t.matches(
+          'ENOENT%: no such file .*: "non%-existent%-cmd"',
+          t.pcall_err(system, { 'non-existent-cmd', 'arg1', 'arg2' }, { text = true })
+        )
+      end)
+
       it('can run simple commands', function()
         eq('hello\n', system({ 'echo', 'hello' }, { text = true }).stdout)
       end)


### PR DESCRIPTION
Problem:
When a command is not found or not executable, the error message gives no indication about what command was actually tried.

Solution:
Append the command name to ENOENT and EACCES messages.

TODO:
- maybe we can do this for all errors?
- can we check the error code instead of using `pid_or_err:match()`?

BEFORE:

    E5108: Error executing lua …/_system.lua:248: ENOENT: no such file or directory

AFTER:

    E5108: Error executing lua …/_system.lua:249: ENOENT: no such file or directory: "foo"

fix #33445

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
