### PR TITLE
vim-patch:3cbd7f1: runtime(gleam): update Maintainer and filetype options

### DIFF
--- a/runtime/ftplugin/gleam.vim
+++ b/runtime/ftplugin/gleam.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
-" Language:    Gleam
-" Maintainer:  Trilowy (https://github.com/trilowy)
-" Last Change: 2024 Oct 13
+" Language:            Gleam
+" Maintainer:          Kirill Morozov <kirill@robotix.pro>
+" Previous Maintainer: Trilowy (https://github.com/trilowy)
+" Last Change:         2025-04-12
 
 if exists('b:did_ftplugin')
   finish
@@ -10,7 +11,11 @@ let b:did_ftplugin = 1
 
 setlocal comments=://,:///,:////
 setlocal commentstring=//\ %s
+setlocal expandtab
+setlocal formatprg=gleam\ format\ --stdin
+setlocal shiftwidth=2
+setlocal softtabstop=2
 
-let b:undo_ftplugin = "setlocal comments< commentstring<"
+let b:undo_ftplugin = "setlocal com< cms< fp< et< sw< sts<"
 
 " vim: sw=2 sts=2 et


### PR DESCRIPTION
#### vim-patch:3cbd7f1: runtime(gleam): update Maintainer and filetype options

closes: vim/vim#17086

https://github.com/vim/vim/commit/3cbd7f18e320aa1df652c9a16bed4b284c4538b8

Co-authored-by: Kirill Morozov <kirill@robotix.pro>