### PR TITLE
vim-patch:9.1.1300: wrong detection of -inf

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -5323,7 +5323,7 @@ size_t string2float(const char *const text, float_T *const ret_value)
     *ret_value = (float_T)INFINITY;
     return 3;
   }
-  if (STRNICMP(text, "-inf", 3) == 0) {
+  if (STRNICMP(text, "-inf", 4) == 0) {
     *ret_value = (float_T)(-INFINITY);
     return 4;
   }


### PR DESCRIPTION
#### vim-patch:9.1.1300: wrong detection of -inf

Problem:  wrong detection of -inf
Solution: correctly compare 4 characters and not 3
          (John Marriott)

closes: vim/vim#17109

https://github.com/vim/vim/commit/10f69298b4577b3712eedeb49b4d9ad1a69111f8

Co-authored-by: John Marriott <basilisk@internode.on.net>