### PR TITLE
ci(tests): add windows-11-arm

### DIFF
--- a/.github/workflows/test_windows.yml
+++ b/.github/workflows/test_windows.yml
@@ -11,12 +11,13 @@ on:
 
 jobs:
   windows:
-    runs-on: windows-2022
     timeout-minutes: 45
     strategy:
       fail-fast: false
       matrix:
+        runner: [windows-2022, windows-11-arm]
         test: [functional, old]
+    runs-on: ${{ matrix.runner }}
     steps:
       - uses: actions/checkout@v4
       - uses: ./.github/actions/setup


### PR DESCRIPTION
Just a test to see how badly this breaks.

Note: Like `ubuntu-arm`, these are custom images hosted at https://github.com/actions/partner-runner-images/blob/main/images/arm-windows-11-image.md

In particular, this image comes without `msys2` (which is why the `oldtest` fails).