### PR TITLE
feat(lsp): `root_markers` can control priority

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -41,6 +41,7 @@ Follow these steps to get LSP features:
         -- current buffer that contains either a ".luarc.json" or a
         -- ".luarc.jsonc" file. Files that share a root directory will reuse
         -- the connection to the same LSP server.
+        -- It also supports priorities see |vim.lsp.Config|
         root_markers = { '.luarc.json', '.luarc.jsonc' },
 
         -- Specific settings to send to the server. The schema for this is
@@ -722,9 +723,30 @@ Lua module: vim.lsp                                                 *lsp-core*
                          the buffer. Thus a `root_dir()` function can
                          dynamically decide per-buffer whether to activate (or
                          skip) LSP. See example at |vim.lsp.enable()|.
-      • {root_markers}?  (`string[]`) Directory markers (e.g. ".git/",
-                         "package.json") used to decide `root_dir`. Unused if
-                         `root_dir` is provided.
+      • {root_markers}?  (`(string|string[])[]`) Directory markers (.e.g.
+                         '.git/') where the LSP server will base its
+                         workspaceFolders, rootUri, and rootPath on
+                         initialization. Unused if `root_dir` is provided.
+
+                         It's possibile to specify marker's priority. The
+                         default behaviour performs a folder-up first search,
+                         but it can be configured to look for multple markers
+                         in each directory before going up.
+
+                         Example (default, folder-up first): >lua
+                               root_markers = { 'stylua.toml', '.git' }
+<
+
+                         Looks for `stylua.toml` in every folder going up, if
+                         it isn't found it does the same for `.git`.
+
+                         Example (mixed priorities): >lua
+                               root_markers = { { 'stylua.toml', '.luarc.json' }, '.git' }
+<
+
+                         Looks for both `.stylua.toml` and `.luarc.json` (in
+                         this order) in every folder going up, if none of them
+                         is found it does the same for `.git`.
 
 
 buf_attach_client({bufnr}, {client_id})          *vim.lsp.buf_attach_client()*

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -41,8 +41,8 @@ Follow these steps to get LSP features:
         -- current buffer that contains either a ".luarc.json" or a
         -- ".luarc.jsonc" file. Files that share a root directory will reuse
         -- the connection to the same LSP server.
-        -- It also supports priorities see |vim.lsp.Config|
-        root_markers = { '.luarc.json', '.luarc.jsonc' },
+        -- Nested lists indicate equal priority, see |vim.lsp.Config|.
+        root_markers = { { '.luarc.json', '.luarc.jsonc' }, '.git' },
 
         -- Specific settings to send to the server. The schema for this is
         -- defined by the server. For example the schema for lua-language-server
@@ -728,25 +728,32 @@ Lua module: vim.lsp                                                 *lsp-core*
                          workspaceFolders, rootUri, and rootPath on
                          initialization. Unused if `root_dir` is provided.
 
-                         It's possibile to specify marker's priority. The
-                         default behaviour performs a folder-up first search,
-                         but it can be configured to look for multple markers
-                         in each directory before going up.
+                         The list order decides the priority. To indicate
+                         "equal priority", specify names in a nested list
+                         (`{ { 'a', 'b' }, ... }`) Each entry in this list is
+                         a set of one or more markers. For each set, Nvim will
+                         search upwards for each marker contained in the set.
+                         If a marker is found, the directory which contains
+                         that marker is used as the root directory. If no
+                         markers from the set are found, the process is
+                         repeated with the next set in the list.
 
-                         Example (default, folder-up first): >lua
+                         Example: >lua
                                root_markers = { 'stylua.toml', '.git' }
 <
 
-                         Looks for `stylua.toml` in every folder going up, if
-                         it isn't found it does the same for `.git`.
+                         Find the first parent directory containing the file
+                         `stylua.toml`. If not found, find the first parent
+                         directory containing the file or directory `.git`.
 
-                         Example (mixed priorities): >lua
+                         Example: >lua
                                root_markers = { { 'stylua.toml', '.luarc.json' }, '.git' }
 <
 
-                         Looks for both `.stylua.toml` and `.luarc.json` (in
-                         this order) in every folder going up, if none of them
-                         is found it does the same for `.git`.
+                         Find the first parent directory containing EITHER
+                         `stylua.toml` or `.luarc.json`. If not found, find
+                         the first parent directory containing the file or
+                         directory `.git`.
 
 
 buf_attach_client({bufnr}, {client_id})          *vim.lsp.buf_attach_client()*

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -70,7 +70,7 @@ HIGHLIGHTS
 
 LSP
 
-• todo
+• `root_markers` in |vim.lsp.Config| can now be ordered by priority.
 
 LUA
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -613,7 +613,7 @@ end
 --- Suppress error reporting if the LSP server fails to start (default false).
 --- @field silent? boolean
 ---
---- @field package _root_markers? string[]
+--- @field package _root_markers? (string|string[])[]
 
 --- Create a new LSP client and start a language server or reuses an already
 --- running client if one is found matching `name` and `root_dir`.
@@ -662,8 +662,16 @@ function lsp.start(config, opts)
   local bufnr = vim._resolve_bufnr(opts.bufnr)
 
   if not config.root_dir and opts._root_markers then
+    validate('root_markers', opts._root_markers, 'table')
     config = vim.deepcopy(config)
-    config.root_dir = vim.fs.root(bufnr, opts._root_markers)
+
+    for _, marker in ipairs(opts._root_markers) do
+      local root = vim.fs.root(bufnr, marker)
+      if root ~= nil then
+        config.root_dir = root
+        break
+      end
+    end
   end
 
   if

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -293,9 +293,31 @@ end
 --- example at |vim.lsp.enable()|.
 --- @field root_dir? string|fun(bufnr: integer, on_dir:fun(root_dir?:string))
 ---
---- Directory markers (e.g. ".git/", "package.json") used to decide `root_dir`. Unused if `root_dir`
---- is provided.
---- @field root_markers? string[]
+--- Directory markers (.e.g. '.git/') where the LSP server will base its workspaceFolders,
+--- rootUri, and rootPath on initialization. Unused if `root_dir` is provided.
+---
+--- It's possibile to specify marker's priority. The default behaviour performs a
+--- folder-up first search, but it can be configured to look for multple markers in each
+--- directory before going up.
+---
+--- Example (default, folder-up first):
+---
+--- ```lua
+---   root_markers = { 'stylua.toml', '.git' }
+--- ```
+---
+--- Looks for `stylua.toml` in every folder going up, if it isn't found it does
+--- the same for `.git`.
+---
+--- Example (mixed priorities):
+---
+--- ```lua
+---   root_markers = { { 'stylua.toml', '.luarc.json' }, '.git' }
+--- ```
+---
+--- Looks for both `.stylua.toml` and `.luarc.json` (in this order) in every
+--- folder going up, if none of them is found it does the same for `.git`.
+--- @field root_markers? (string|string[])[]
 
 --- Sets the default configuration for an LSP client (or _all_ clients if the special name "*" is
 --- used).

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -296,27 +296,33 @@ end
 --- Directory markers (.e.g. '.git/') where the LSP server will base its workspaceFolders,
 --- rootUri, and rootPath on initialization. Unused if `root_dir` is provided.
 ---
---- It's possibile to specify marker's priority. The default behaviour performs a
---- folder-up first search, but it can be configured to look for multple markers in each
---- directory before going up.
+--- The list order decides the priority. To indicate "equal priority", specify names in a nested list (`{ { 'a', 'b' }, ... }`)
+--- Each entry in this list is a set of one or more markers. For each set, Nvim
+--- will search upwards for each marker contained in the set. If a marker is
+--- found, the directory which contains that marker is used as the root
+--- directory. If no markers from the set are found, the process is repeated
+--- with the next set in the list.
 ---
---- Example (default, folder-up first):
+--- Example:
 ---
 --- ```lua
 ---   root_markers = { 'stylua.toml', '.git' }
 --- ```
 ---
---- Looks for `stylua.toml` in every folder going up, if it isn't found it does
---- the same for `.git`.
+--- Find the first parent directory containing the file `stylua.toml`. If not
+--- found, find the first parent directory containing the file or directory
+--- `.git`.
 ---
---- Example (mixed priorities):
+--- Example:
 ---
 --- ```lua
 ---   root_markers = { { 'stylua.toml', '.luarc.json' }, '.git' }
 --- ```
 ---
---- Looks for both `.stylua.toml` and `.luarc.json` (in this order) in every
---- folder going up, if none of them is found it does the same for `.git`.
+--- Find the first parent directory containing EITHER `stylua.toml` or
+--- `.luarc.json`. If not found, find the first parent directory containing the
+--- file or directory `.git`.
+---
 --- @field root_markers? (string|string[])[]
 
 --- Sets the default configuration for an LSP client (or _all_ clients if the special name "*" is


### PR DESCRIPTION
Hello everyone! This PR is mostly intended to gather opinion on the topic.

While deprecating [`lspconfig`](https://github.com/neovim/nvim-lspconfig)`.util` module I came across an incoherent behaviour:

- `lspconfig.util.root_pattern` prioritises folder-up search
- `root_markers` of `vim.lsp.config` matches every pattern in every folder before going up (see `vim.fs.root()`.

With this modification now `root_markers` accepts `string[]` and `string[][]` (it actually also supports `string` and `function(name: string, path: string)`, but they're not documented), where each entry of the outer table is feed into `vim.fs.root()`. So:

```lua
{
  ...
  root_markers = { ".stylua.toml", ".git" }
  ...
}
```

Will look for `.stylua.toml` in every folder going up, if it isn't found it would do the same for `.git`. (Same behaviour as `util.root_pattern`, would make the change not affecting ported configs)

Instead:

```lua
{
  ...
  root_markers = { { ".stylua.toml", ".luarc.json" }, { ".git "} }
  ...
}
```

Would create two groups of "different priorites", where the it would look for `.stylua.toml` and `.luarc.json` (in this order) in every folder going up, if they aren't found it would do the same for `.git`.


This modification is not only "backward-compatible" with [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig), but it offers the possibility to have different precedences in matching, as the "right way" is currently debated, it depends on how some languages are implemented and how some users work.

Reference:

> > I'm not entirely sure if this migration is ok. It seems like `util.root_pattern` and `vim.fs.root` behave differently
>
> See also https://github.com/neovim/nvim-lspconfig/pull/3651 . Deciding on well-defined behavior will require some thought.
>
> _Originally posted by @justinmk in https://github.com/neovim/nvim-lspconfig/issues/3711#issuecomment-2802304532_

See also:
https://github.com/neovim/nvim-lspconfig/pull/3651 
https://github.com/neovim/nvim-lspconfig/pull/2885