### PR TITLE
vim-patch:9.1.1303: missing out-of-memory check in linematch.c

### DIFF
--- a/src/nvim/linematch.c
+++ b/src/nvim/linematch.c
@@ -345,10 +345,11 @@ size_t linematch_nbuffers(const mmfile_t **diff_blk, const int *diff_len, const 
   // create the flattened path matrix
   diffcmppath_T *diffcmppath = xmalloc(sizeof(diffcmppath_T) * memsize);
   // allocate memory here
+  size_t n = (size_t)pow(2.0, (double)ndiffs);
   for (size_t i = 0; i < memsize; i++) {
     diffcmppath[i].df_lev_score = 0;
     diffcmppath[i].df_path_n = 0;
-    for (size_t j = 0; j < (size_t)pow(2, (double)ndiffs); j++) {
+    for (size_t j = 0; j < n; j++) {
       diffcmppath[i].df_choice_mem[j] = -1;
     }
   }


### PR DESCRIPTION
#### vim-patch:9.1.1303: missing out-of-memory check in linematch.c

Problem:  missing out-of-memory check in linematch.c
Solution: return early in case of memory allocation failure, move the
          pow() calculation ouside of the for() loop
          (John Marriott)

closes: vim/vim#17118

https://github.com/vim/vim/commit/2137710b436e481168382c50aa4838a4b9730163

Co-authored-by: John Marriott <basilisk@internode.on.net>