### PR TITLE
vim-patch:9.1.1308: completion: cannot order matches by distance to cursor

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -79,6 +79,7 @@ LUA
 OPTIONS
 
 • 'chistory' and 'lhistory' set size of the |quickfix-stack|.
+• 'completeopt' flag "nearset" sorts completion results by distance to cursor.
 • 'diffopt' `inline:` configures diff highlighting for changes within a line.
 • 'pummaxwidth' sets maximum width for the completion popup menu.
 • 'shelltemp' defaults to "false".

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1590,6 +1590,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    Useful when there is additional information about the
 		    match, e.g., what file it comes from.
 
+	   nearest  Matches are presented in order of proximity to the cursor
+		    position.  This applies only to matches from the current
+		    buffer.  No effect if "fuzzy" is present.
+
 	   noinsert Do not insert any text for a match until the user selects
 		    a match from the menu.  Only works in combination with
 		    "menu" or "menuone". No effect if "longest" is present.

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1123,6 +1123,10 @@ vim.go.cia = vim.go.completeitemalign
 --- 	    Useful when there is additional information about the
 --- 	    match, e.g., what file it comes from.
 ---
+---    nearest  Matches are presented in order of proximity to the cursor
+--- 	    position.  This applies only to matches from the current
+--- 	    buffer.  No effect if "fuzzy" is present.
+---
 ---    noinsert Do not insert any text for a match until the user selects
 --- 	    a match from the menu.  Only works in combination with
 --- 	    "menu" or "menuone". No effect if "longest" is present.

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -164,7 +164,7 @@ struct compl_S {
                                  ///< cp_flags has CP_FREE_FNAME
   int cp_flags;                  ///< CP_ values
   int cp_number;                 ///< sequence number
-  int cp_score;                  ///< fuzzy match score
+  int cp_score;                  ///< fuzzy match score or proximity score
   bool cp_in_match_array;        ///< collected by compl_match_array
   int cp_user_abbr_hlattr;       ///< highlight attribute for abbr
   int cp_user_kind_hlattr;       ///< highlight attribute for kind
@@ -816,6 +816,74 @@ static inline void free_cptext(char *const *const cptext)
   }
 }
 
+/// Returns true if matches should be sorted based on proximity to the cursor.
+static bool is_nearest_active(void)
+{
+  unsigned flags = get_cot_flags();
+  return (flags & kOptCotFlagNearest) && !(flags & kOptCotFlagFuzzy);
+}
+
+/// Repositions a match in the completion list based on its proximity score.
+/// If the match is at the head and has a higher score than the next node,
+/// or if it's in the middle/tail and has a lower score than the previous node,
+/// it is moved to the correct position while maintaining ascending order.
+static void reposition_match(compl_T *match)
+{
+  compl_T *insert_before = NULL;
+  compl_T *insert_after = NULL;
+
+  if (!match->cp_prev) {  // Node is at head and score is too big
+    if (match->cp_next && match->cp_next->cp_score > 0
+        && match->cp_next->cp_score < match->cp_score) {
+      // <c-p>: compl_first_match is at head and newly inserted node
+      compl_first_match = compl_curr_match = match->cp_next;
+      // Find the correct position in ascending order
+      insert_before = match->cp_next;
+      do {
+        insert_after = insert_before;
+        insert_before = insert_before->cp_next;
+      } while (insert_before && insert_before->cp_score > 0
+               && insert_before->cp_score < match->cp_score);
+    } else {
+      return;
+    }
+  } else {  // Node is at tail or in the middle but score is too small
+    if (match->cp_prev->cp_score > 0 && match->cp_prev->cp_score > match->cp_score) {
+      // <c-n>: compl_curr_match (and newly inserted match) is at tail
+      if (!match->cp_next) {
+        compl_curr_match = compl_curr_match->cp_prev;
+      }
+      // Find the correct position in ascending order
+      insert_after = match->cp_prev;
+      do {
+        insert_before = insert_after;
+        insert_after = insert_after->cp_prev;
+      } while (insert_after && insert_after->cp_score > 0
+               && insert_after->cp_score > match->cp_score);
+    } else {
+      return;
+    }
+  }
+
+  if (insert_after) {
+    // Remove the match from its current position
+    if (match->cp_prev) {
+      match->cp_prev->cp_next = match->cp_next;
+    } else {
+      compl_first_match = match->cp_next;
+    }
+    if (match->cp_next) {
+      match->cp_next->cp_prev = match->cp_prev;
+    }
+
+    // Insert the match at the correct position
+    match->cp_next = insert_before;
+    match->cp_prev = insert_after;
+    insert_after->cp_next = match;
+    insert_before->cp_prev = match;
+  }
+}
+
 /// Add a match to the list of matches
 ///
 /// @param[in]  str     text of the match to add
@@ -872,6 +940,10 @@ static int ins_compl_add(char *const str, int len, char *const fname, char *cons
       if (!match_at_original_text(match)
           && strncmp(match->cp_str.data, str, (size_t)len) == 0
           && ((int)match->cp_str.size <= len || match->cp_str.data[len] == NUL)) {
+        if (is_nearest_active() && score > 0 && score < match->cp_score) {
+          match->cp_score = score;
+          reposition_match(match);
+        }
         if (cptext_allocated) {
           free_cptext(cptext);
         }
@@ -976,6 +1048,10 @@ static int ins_compl_add(char *const str, int len, char *const fname, char *cons
     compl_first_match = match;
   }
   compl_curr_match = match;
+
+  if (is_nearest_active() && score > 0) {
+    reposition_match(match);
+  }
 
   // Find the longest common string if still doing that.
   if (compl_get_longest && (flags & CP_ORIGINAL_TEXT) == 0 && !cfc_has_mode()) {
@@ -3746,6 +3822,7 @@ static int get_next_default_completion(ins_compl_next_state_T *st, pos_T *start_
   bool in_collect = (cfc_has_mode() && compl_length > 0);
   char *leader = ins_compl_leader();
   int score = 0;
+  const bool in_curbuf = st->ins_buf == curbuf;
 
   // If 'infercase' is set, don't use 'smartcase' here
   const int save_p_scs = p_scs;
@@ -3759,7 +3836,7 @@ static int get_next_default_completion(ins_compl_next_state_T *st, pos_T *start_
   // buffers is a good idea, on the other hand, we always set
   // wrapscan for curbuf to avoid missing matches -- Acevedo,Webb
   const int save_p_ws = p_ws;
-  if (st->ins_buf != curbuf) {
+  if (!in_curbuf) {
     p_ws = false;
   } else if (*st->e_cpt == '.') {
     p_ws = true;
@@ -3822,7 +3899,7 @@ static int get_next_default_completion(ins_compl_next_state_T *st, pos_T *start_
     }
 
     // when ADDING, the text before the cursor matches, skip it
-    if (compl_status_adding() && st->ins_buf == curbuf
+    if (compl_status_adding() && in_curbuf
         && start_pos->lnum == st->cur_match_pos->lnum
         && start_pos->col == st->cur_match_pos->col) {
       continue;
@@ -3837,8 +3914,16 @@ static int get_next_default_completion(ins_compl_next_state_T *st, pos_T *start_
       continue;
     }
 
+    if (is_nearest_active() && in_curbuf) {
+      score = st->cur_match_pos->lnum - curwin->w_cursor.lnum;
+      if (score < 0) {
+        score = -score;
+      }
+      score++;
+    }
+
     if (ins_compl_add_infercase(ptr, len, p_ic,
-                                st->ins_buf == curbuf ? NULL : st->ins_buf->b_sfname,
+                                in_curbuf ? NULL : st->ins_buf->b_sfname,
                                 0, cont_s_ipos, score) != NOTDONE) {
       if (in_collect && score == compl_first_match->cp_next->cp_score) {
         compl_num_bests++;

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1548,6 +1548,7 @@ local options = {
         'fuzzy',
         'nosort',
         'preinsert',
+        'nearest',
       },
       flags = true,
       deny_duplicates = true,
@@ -1578,6 +1579,10 @@ local options = {
            menuone  Use the popup menu also when there is only one match.
         	    Useful when there is additional information about the
         	    match, e.g., what file it comes from.
+
+           nearest  Matches are presented in order of proximity to the cursor
+        	    position.  This applies only to matches from the current
+        	    buffer.  No effect if "fuzzy" is present.
 
            noinsert Do not insert any text for a match until the user selects
         	    a match from the menu.  Only works in combination with


### PR DESCRIPTION
#### vim-patch:9.1.1308: completion: cannot order matches by distance to cursor

Problem:  During insert-mode completion, the most relevant match is often
          the one closest to the cursor—frequently just above the current line.
          However, both `<C-N>` and `<C-P>` tend to rank candidates from the
          current buffer that appear above the cursor near the bottom of the
          completion menu, rather than near the top. This ordering can feel
          unintuitive, especially when `noselect` is active, as it doesn't
          prioritize the most contextually relevant suggestions.

Solution: This change introduces a new sub-option value "nearest" for the
          'completeopt' setting. When enabled, matches from the current buffer
          are prioritized based on their proximity to the cursor position,
          improving the relevance of suggestions during completion
          (Girish Palya).

Key Details:
- Option: "nearest" added to 'completeopt'
- Applies to: Matches from the current buffer only
- Effect: Sorts completion candidates by their distance from the cursor
- Interaction with other options:
  - Has no effect if the `fuzzy` option is also present

This feature is helpful especially when working within large buffers where
multiple similar matches may exist at different locations.

You can test this feature with auto-completion using the snippet below. Try it
in a large file like `vim/src/insexpand.c`, where you'll encounter many
potential matches. You'll notice that the popup menu now typically surfaces the
most relevant matches—those closest to the cursor—at the top. Sorting by
spatial proximity (i.e., contextual relevance) often produces more useful
matches than sorting purely by lexical distance ("fuzzy").

Another way to sort matches is by recency, using an LRU (Least Recently Used)
cache—essentially ranking candidates based on how recently they were used.
However, this is often overkill in practice, as spatial proximity (as provided
by the "nearest" option) is usually sufficient to surface the most relevant
matches.

```vim
set cot=menuone,popup,noselect,nearest inf

def SkipTextChangedIEvent(): string
    # Suppress next event caused by <c-e> (or <c-n> when no matches found)
    set eventignore+=TextChangedI
    timer_start(1, (_) => {
        set eventignore-=TextChangedI
    })
    return ''
enddef

autocmd TextChangedI * InsComplete()

def InsComplete()
    if getcharstr(1) == '' && getline('.')->strpart(0, col('.') - 1) =~ '\k$'
        SkipTextChangedIEvent()
        feedkeys("\<c-n>", "n")
    endif
enddef

inoremap <silent> <c-e> <c-r>=<SID>SkipTextChangedIEvent()<cr><c-e>

inoremap <silent><expr> <tab>   pumvisible() ? "\<c-n>" : "\<tab>"
inoremap <silent><expr> <s-tab> pumvisible() ? "\<c-p>" : "\<s-tab>"
```

closes: vim/vim#17076

https://github.com/vim/vim/commit/b156588eb707a084bbff8685953a8892e1e45bca

Co-authored-by: Girish Palya <girishji@gmail.com>