### PR TITLE
fix(mouse): do not fetch clipboard twice when pasting with middle button

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3250,7 +3250,7 @@ static void ins_reg(void)
 
       do_put(regname, NULL, BACKWARD, 1,
              (literally == Ctrl_P ? PUT_FIXINDENT : 0) | PUT_CURSEND);
-    } else if (insert_reg(regname, literally) == FAIL) {
+    } else if (insert_reg(regname, NULL, literally) == FAIL) {
       vim_beep(kOptBoFlagRegister);
       need_redraw = true;  // remove the '"'
     } else if (stop_insert_mode) {

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -503,15 +503,16 @@ bool do_mouse(oparg_T *oap, int c, int dir, int count, bool fixindent)
     // happens for the GUI).
     if ((State & MODE_INSERT)) {
       if (regname == '.') {
-        insert_reg(regname, true);
+        insert_reg(regname, NULL, true);
       } else {
         if (regname == 0 && eval_has_provider("clipboard", false)) {
           regname = '*';
         }
-        if ((State & REPLACE_FLAG) && !yank_register_mline(regname)) {
-          insert_reg(regname, true);
+        yankreg_T *reg = NULL;
+        if ((State & REPLACE_FLAG) && !yank_register_mline(regname, &reg)) {
+          insert_reg(regname, reg, true);
         } else {
-          do_put(regname, NULL, BACKWARD, 1,
+          do_put(regname, reg, BACKWARD, 1,
                  (fixindent ? PUT_FIXINDENT : 0) | PUT_CURSEND);
 
           // Repeat it with CTRL-R CTRL-O r or CTRL-R CTRL-P r
@@ -833,7 +834,8 @@ bool do_mouse(oparg_T *oap, int c, int dir, int count, bool fixindent)
     if (regname == 0 && eval_has_provider("clipboard", false)) {
       regname = '*';
     }
-    if (yank_register_mline(regname)) {
+    yankreg_T *reg = NULL;
+    if (yank_register_mline(regname, &reg)) {
       if (mouse_past_bottom) {
         dir = FORWARD;
       }
@@ -855,7 +857,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, int count, bool fixindent)
     if (restart_edit != 0) {
       where_paste_started = curwin->w_cursor;
     }
-    do_put(regname, NULL, dir, count,
+    do_put(regname, reg, dir, count,
            (fixindent ? PUT_FIXINDENT : 0)| PUT_CURSEND);
   } else if (((mod_mask & MOD_MASK_CTRL) || (mod_mask & MOD_MASK_MULTI_CLICK) == MOD_MASK_2CLICK)
              && bt_quickfix(curbuf)) {


### PR DESCRIPTION
When doing paste operation mouse code tries to figure out it it is dealing with a multi-line register by calling yank_register_mline(), which fetches register data and checks its type. Later the code calls either do_put() or insert_reg() which fetch register data again. This is unnoticeable when working with internal neovim registers, but starts hurting when dealing with clipboards, especially remote one (forwarded X or socket tunnel or similar).

Fix this by making yank_register_mline() to also return pointer to the register structure prepared for pasting, and insert_reg() to accept such register pointer and use it if it is supplied. do_put() already has support for accepting a register structure to be used for pasting.

Fixes #33493

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
