### PR TITLE
vim-patch:9.1.1307: make syntax does not reliably detect different flavors

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -156,6 +156,8 @@ variables can be used to overrule the filetype used for certain extensions:
 	`*.inc`		g:filetype_inc
 	`*.lsl`		g:filetype_lsl
 	`*.m`		g:filetype_m		|ft-mathematica-syntax|
+	`*[mM]makefile,*.mk,*.mak,[mM]akefile*`
+			g:make_flavor		|ft-make-syntax|
 	`*.markdown,*.mdown,*.mkd,*.mkdn,*.mdwn,*.md`
 			g:filetype_md		|ft-pandoc-syntax|
 	`*.mod`		g:filetype_mod

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1914,11 +1914,16 @@ Comments are also highlighted by default.  You can turn this off by using: >
 
 	:let make_no_comments = 1
 
-Microsoft Makefile handles variable expansion and comments differently
-(backslashes are not used for escape).  If you see any wrong highlights
-because of this, you can try this: >
+There are various Make implementations, which add extensions other than the
+POSIX specification and thus are mutually incompatible.  If the filename is
+BSDmakefile or GNUmakefile, the corresponding implementation is automatically
+determined; otherwise vim tries to detect it by the file contents.  If you see
+any wrong highlights because of this, you can enforce a flavor by setting one
+of the following: >
 
-	:let make_microsoft = 1
+	:let g:make_flavor = 'bsd'  " or
+	:let g:make_flavor = 'gnu'  " or
+	:let g:make_flavor = 'microsoft'
 
 
 MAPLE						*maple.vim* *ft-maple-syntax*

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2290,7 +2290,7 @@ local pattern = {
     ['^Containerfile%.'] = starsetf('dockerfile'),
     ['^Dockerfile%.'] = starsetf('dockerfile'),
     ['[mM]akefile$'] = detect.make,
-    ['^[mM]akefile'] = starsetf('make'),
+    ['^[mM]akefile'] = starsetf(detect.make),
     ['^[rR]akefile'] = starsetf('ruby'),
     ['^%.profile'] = detect.sh,
   },

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -2851,15 +2851,48 @@ endfunc
 func Test_make_file()
   filetype on
 
+  " BSD Makefile
+  call writefile([''], 'BSDmakefile', 'D')
+  split BSDmakefile
+  call assert_equal('bsd', get(b:, 'make_flavor', ''))
+  bwipe!
+
+  call writefile(['.ifmake all', '.endif'], 'XMakefile.mak', 'D')
+  split XMakefile.mak
+  call assert_equal('bsd', get(b:, 'make_flavor', ''))
+  bwipe!
+
+  " GNU Makefile
+  call writefile([''], 'GNUmakefile', 'D')
+  split GNUmakefile
+  call assert_equal('gnu', get(b:, 'make_flavor', ''))
+  bwipe!
+
+  call writefile(['ifeq ($(foo),foo)', 'endif'], 'XMakefile.mak', 'D')
+  split XMakefile.mak
+  call assert_equal('gnu', get(b:, 'make_flavor', ''))
+  bwipe!
+
+  call writefile(['define foo', 'endef'], 'XMakefile.mak', 'D')
+  split XMakefile.mak
+  call assert_equal('gnu', get(b:, 'make_flavor', ''))
+  bwipe!
+
+  call writefile(['vim := $(wildcard *.vim)'], 'XMakefile.mak', 'D')
+  split XMakefile.mak
+  call assert_equal('gnu', get(b:, 'make_flavor', ''))
+  bwipe!
+
   " Microsoft Makefile
   call writefile(['# Makefile for Windows', '!if "$(VIMDLL)" == "yes"'], 'XMakefile.mak', 'D')
   split XMakefile.mak
-  call assert_equal(1, get(b:, 'make_microsoft', 0))
+  call assert_equal('microsoft', get(b:, 'make_flavor', ''))
   bwipe!
 
+  " BSD or GNU
   call writefile(['# get the list of tests', 'include testdir/Make_all.mak'], 'XMakefile.mak', 'D')
   split XMakefile.mak
-  call assert_equal(0, get(b:, 'make_microsoft', 0))
+  call assert_notequal('microsoft', get(b:, 'make_flavor', ''))
   bwipe!
 
   filetype off


### PR DESCRIPTION
#### vim-patch:9.1.1307: make syntax does not reliably detect different flavors

Problem:  GNU extensions, such as `ifeq` and `wildcard` function, are
          highlighted in BSDmakefile
Solution: detect BSD, GNU, or Microsoft implementation according to
	  filename, user-defined global variables, or file contents

closes: vim/vim#17089

https://github.com/vim/vim/commit/f35bd76b31e6cd62bcc47e401887059b8503c5cc

Co-authored-by: Eisuke Kawashima <e-kwsm@users.noreply.github.com>
Co-authored-by: Roland Hieber <rohieb@users.noreply.github.com>