### PR TITLE
fix(coverity/530026,530028): free resources on early exit in nlua_exec_file

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1813,10 +1813,14 @@ bool nlua_exec_file(const char *path)
     // Read all input from stdin, unless interrupted (ctrl-c).
     while (true) {
       if (got_int) {  // User canceled.
+        file_close(&stdin_dup, false);
+        kv_destroy(sb);
         return false;
       }
       ptrdiff_t read_size = file_read(&stdin_dup, IObuff, 64);
       if (read_size < 0) {  // Error.
+        file_close(&stdin_dup, false);
+        kv_destroy(sb);
         return false;
       }
       if (read_size > 0) {


### PR DESCRIPTION
Problem: The stdin reading path does not close `stdin_dup` or free `sb` upon early exit.

Solution: Free the resources before returning false.