### PR TITLE
vim-patch:9.1.1312: tests: Test_backupskip() fails when HOME is defined

### DIFF
--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -1137,11 +1137,14 @@ func Test_backupskip()
     call setenv(var, '/duplicate/path')
   endfor
 
+  " unset $HOME, so that it won't try to read init files
+  let saveenv['HOME'] = getenv("HOME")
+  call setenv('HOME', v:null)
   exe 'silent !' . cmd
   call assert_equal(['errors:'], readfile('Xtestout'))
 
   " restore environment variables
-  for var in ['TMPDIR', 'TMP', 'TEMP']
+  for var in ['TMPDIR', 'TMP', 'TEMP', 'HOME']
     call setenv(var, saveenv[var])
   endfor
 


### PR DESCRIPTION
#### vim-patch:9.1.1312: tests: Test_backupskip() fails when HOME is defined

Problem:  tests: Test_backupskip() fails when HOME is defined
Solution: unset $HOME temporarily

https://github.com/vim/vim/commit/ad503fe92772cb37d6f8601f48ff2bdb34cdbe96

Co-authored-by: Christian Brabandt <cb@256bit.org>