### PR TITLE
vim-patch:9.1.1310: completion: redundant check for preinsert effect

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2419,10 +2419,6 @@ static bool ins_compl_stop(const int c, const int prev_mode, bool retval)
     retval = true;
   }
 
-  if ((c == Ctrl_W || c == Ctrl_U) && ins_compl_preinsert_effect()) {
-    ins_compl_delete(false);
-  }
-
   auto_format(false, true);
 
   // Trigger the CompleteDonePre event to give scripts a chance to


### PR DESCRIPTION
#### vim-patch:9.1.1310: completion: redundant check for preinsert effect

Problem:  Duplicate check for preinsert effect, particularly for Ctrl_w
          and Ctrl_U.
Solution: Remove the specific check for Ctrl_w and Ctrl_U to eliminate
          redundancy (glepnir).

closes: vim/vim#17129

https://github.com/vim/vim/commit/1c2b25825037bf83862f7af71ce9177cf949daca

Co-authored-by: glepnir <glephunter@gmail.com>