### PR TITLE
fix(diagnostic): allow virtual_{lines,text} cursor exclusivity

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -624,8 +624,12 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
       • {severity}?           (`vim.diagnostic.SeverityFilter`) Only show
                               virtual text for diagnostics matching the given
                               severity |diagnostic-severity|
-      • {current_line}?       (`boolean`) Only show diagnostics for the
-                              current line. (default `false`)
+      • {current_line}?       (`boolean`) Show or hide diagnostics based on
+                              the current cursor line. If `true`, only
+                              diagnostics on the current cursor line are
+                              shown. If `false`, all diagnostics are shown
+                              except on the current cursor line. If `nil`, all
+                              diagnostics are shown. (default `nil`)
       • {source}?             (`boolean|"if_many"`) Include the diagnostic
                               source in virtual text. Use `'if_many'` to only
                               show sources if there is more than one

--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -2144,6 +2144,25 @@ describe('vim.diagnostic', function()
       eq(1, #result)
       eq(' Error here!', result[1][4].virt_text[3][1])
     end)
+
+    it('can hide virtual_text for the current line', function()
+      local result = exec_lua(function()
+        vim.api.nvim_win_set_cursor(0, { 1, 0 })
+
+        vim.diagnostic.config({ virtual_text = { current_line = false } })
+
+        vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
+          _G.make_error('Error here!', 0, 0, 0, 0, 'foo_server'),
+          _G.make_error('Another error there!', 1, 0, 1, 0, 'foo_server'),
+        })
+
+        local extmarks = _G.get_virt_text_extmarks(_G.diagnostic_ns)
+        return extmarks
+      end)
+
+      eq(1, #result)
+      eq(' Another error there!', result[1][4].virt_text[3][1])
+    end)
   end)
 
   describe('handlers.virtual_lines', function()


### PR DESCRIPTION
**Problem:**

virtual_text diagnostics are great when skimming a file, and virtual_lines are great when "zooming in" on a particular problem. Having both enabled results in duplicate diagnostics on-screen.

First reported in #33092, with this image as an example:
![image](https://github.com/user-attachments/assets/0c0b87b4-ae09-4b9b-8c15-7529958103b5)

**Solution:**

This PR expands the behavior of `current_line` for virtual_text and virtual_lines by making `virtual_text.current_line = false` distinct from `nil`.  If you set:

```lua
vim.diagnostic.config({
  virtual_text = { current_line = false },
  virtual_lines = { current_line = true },
})
```

With this configuration, virtual_text will be used to display diagnostics until the cursor reaches the same line, at which point they will be hidden and virtual_lines will take its place.

The situation in the image above now behaves like this:

![image](https://github.com/user-attachments/assets/5d5db34c-a1c8-4fb4-8259-214fca1f9d6b)

![image](https://github.com/user-attachments/assets/4c57d82f-06e6-4b03-b294-48716c3e4382)

Note to maintainers: this is my first PR to neovim and I haven't looked into writing tests for this yet but I will look into it if desired.
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
