### PR TITLE
vim-patch:9.1.{1314,1318}: max allowed string width too small

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -7395,7 +7395,8 @@ printf({fmt}, {expr1} ...)                                            *printf()*
 <		      1.41
 
 		You will get an overflow error |E1510|, when the field-width
-		or precision will result in a string longer than 6400 chars.
+		or precision will result in a string longer than 1 MB
+		(1024*1024 = 1048576) chars.
 
 							*E1500*
 		You cannot mix positional and non-positional arguments: >vim

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -6720,7 +6720,8 @@ function vim.fn.prevnonblank(lnum) end
 --- <      1.41
 ---
 --- You will get an overflow error |E1510|, when the field-width
---- or precision will result in a string longer than 6400 chars.
+--- or precision will result in a string longer than 1 MB
+--- (1024*1024 = 1048576) chars.
 ---
 ---           *E1500*
 --- You cannot mix positional and non-positional arguments: >vim

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -8169,7 +8169,8 @@ M.funcs = {
       <      1.41
 
       You will get an overflow error |E1510|, when the field-width
-      or precision will result in a string longer than 6400 chars.
+      or precision will result in a string longer than 1 MB
+      (1024*1024 = 1048576) chars.
 
       					*E1500*
       You cannot mix positional and non-positional arguments: >vim

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -1027,7 +1027,7 @@ static void format_overflow_error(const char *pstart)
   xfree(argcopy);
 }
 
-enum { MAX_ALLOWED_STRING_WIDTH = 6400, };
+enum { MAX_ALLOWED_STRING_WIDTH = 1048576, };  // 1MiB
 
 static int get_unsigned_int(const char *pstart, const char **p, unsigned *uj, bool overflow_err)
 {

--- a/test/old/testdir/test_format.vim
+++ b/test/old/testdir/test_format.vim
@@ -334,13 +334,13 @@ func Test_printf_pos_errors()
   call CheckLegacyAndVim9Failure(["call printf('%1$*123456789$.*987654321$d', 5)"], "E1510:")
   call CheckLegacyAndVim9Failure(["call printf('%123456789$*1$.*987654321$d', 5)"], "E1510:")
 
-  call CheckLegacyAndVim9Failure(["call printf('%1$*2$.*1$d', 5, 9999)"], "E1510:")
-  call CheckLegacyAndVim9Failure(["call printf('%1$*1$.*2$d', 5, 9999)"], "E1510:")
-  call CheckLegacyAndVim9Failure(["call printf('%2$*3$.*1$d', 5, 9123, 9321)"], "E1510:")
-  call CheckLegacyAndVim9Failure(["call printf('%1$*2$.*3$d', 5, 9123, 9321)"], "E1510:")
-  call CheckLegacyAndVim9Failure(["call printf('%2$*1$.*3$d', 5, 9123, 9312)"], "E1510:")
+  call CheckLegacyAndVim9Failure(["call printf('%1$*2$.*1$d', 5, 9999999)"], "E1510:")
+  call CheckLegacyAndVim9Failure(["call printf('%1$*1$.*2$d', 5, 9999999)"], "E1510:")
+  call CheckLegacyAndVim9Failure(["call printf('%2$*3$.*1$d', 5, 9999123, 9999321)"], "E1510:")
+  call CheckLegacyAndVim9Failure(["call printf('%1$*2$.*3$d', 5, 9999123, 9999321)"], "E1510:")
+  call CheckLegacyAndVim9Failure(["call printf('%2$*1$.*3$d', 5, 9999123, 9999312)"], "E1510:")
 
-  call CheckLegacyAndVim9Failure(["call printf('%1$*2$d', 5, 9999)"], "E1510:")
+  call CheckLegacyAndVim9Failure(["call printf('%1$*2$d', 5, 9999999)"], "E1510:")
 endfunc
 
 func Test_printf_pos_64bit()


### PR DESCRIPTION
#### vim-patch:9.1.1314: max allowed string width too small

Problem:  max allowed string width too small
Solution: increased MAX_ALLOWED_STRING_WIDTH from 6400 to 1MiB
          (Hirohito Higashi)

closes: vim/vim#17138

https://github.com/vim/vim/commit/06fdfa11c565599ac13ad5c077d1dabbbfde03ac

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
Co-authored-by: John Marriott <basilisk@internode.on.net>


#### vim-patch:9.1.1318: tests: test_format fails

Problem:  tests: test_format fails (after 9.1.1314).
Solution: Increase the string size.  Add missing test_format.res in
          NEW_TESTS_RES (zeertzjq).

closes: vim/vim#17144

https://github.com/vim/vim/commit/e9a27ef37395a0130f99e21b288b7765f0e38236
