### PR TITLE
vim-patch:9.1.1315: completion: issue with fuzzy completion and 'completefuzzycollect'

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -5102,7 +5102,6 @@ static int ins_compl_start(void)
     line = ml_get(curwin->w_cursor.lnum);
   }
 
-  bool in_fuzzy = get_cot_flags() & kOptCotFlagFuzzy;
   if (compl_status_adding()) {
     edit_submode_pre = _(" Adding");
     if (ctrl_x_mode_line_or_eval()) {
@@ -5117,7 +5116,7 @@ static int ins_compl_start(void)
       compl_length = 0;
       compl_col = curwin->w_cursor.col;
       compl_lnum = curwin->w_cursor.lnum;
-    } else if (ctrl_x_mode_normal() && in_fuzzy) {
+    } else if (ctrl_x_mode_normal() && cfc_has_mode()) {
       compl_startpos = curwin->w_cursor;
       compl_cont_status &= CONT_S_IPOS;
     }

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3745,22 +3745,6 @@ bool search_for_fuzzy_match(buf_T *buf, pos_T *pos, char *pattern, int dir, pos_
           found_new_match = fuzzy_match_str_in_line(ptr, pattern,
                                                     len, &current_pos, score);
           if (found_new_match) {
-            if (ctrl_x_mode_normal()) {
-              if (strncmp(*ptr, pattern, (size_t)(*len)) == 0 && pattern[*len] == NUL) {
-                char *next_word_end = find_word_start(*ptr + *len);
-                if (*next_word_end != NUL && *next_word_end != NL) {
-                  // Find end of the word.
-                  while (*next_word_end != NUL) {
-                    int l = utfc_ptr2len(next_word_end);
-                    if (l < 2 && !vim_iswordc(*next_word_end)) {
-                      break;
-                    }
-                    next_word_end += l;
-                  }
-                }
-                *len = (int)(next_word_end - *ptr);
-              }
-            }
             *pos = current_pos;
             break;
           } else if (looped_around && current_pos.lnum == circly_end.lnum) {

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2869,6 +2869,14 @@ func Test_complete_opt_fuzzy()
   call feedkeys("Sb\<C-X>\<C-P>\<C-N>\<C-Y>\<ESC>", 'tx')
   call assert_equal('b', getline('.'))
 
+  " chain completion
+  call feedkeys("Slore spum\<CR>lor\<C-X>\<C-P>\<C-X>\<C-P>\<ESC>", 'tx')
+  call assert_equal('lore spum', getline('.'))
+
+  " issue #15412
+  call feedkeys("Salpha bravio charlie\<CR>alpha\<C-X>\<C-N>\<C-X>\<C-N>\<C-X>\<C-N>\<ESC>", 'tx')
+  call assert_equal('alpha bravio charlie', getline('.'))
+
   " clean up
   set omnifunc=
   bw!
@@ -2955,34 +2963,6 @@ func Test_complete_fuzzy_collect()
   call feedkeys("Su\<C-X>\<C-L>\<C-P>\<Esc>0", 'tx!')
   call assert_equal('no one can save me but you', getline('.'))
 
-  " issue #15412
-  call setline(1, ['alpha bravio charlie'])
-  call feedkeys("Salpha\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('alpha bravio', getline('.'))
-  call feedkeys("Salp\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('alpha', getline('.'))
-  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('alpha bravio', getline('.'))
-  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('alpha bravio charlie', getline('.'))
-
-  set complete-=i
-  call feedkeys("Salp\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('alpha', getline('.'))
-  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('alpha bravio', getline('.'))
-  call feedkeys("A\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('alpha bravio charlie', getline('.'))
-
-  call setline(1, ['alpha bravio charlie', 'alpha another'])
-  call feedkeys("Salpha\<C-X>\<C-N>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('alpha another', getline('.'))
-  call setline(1, ['你好 我好', '你好 他好'])
-  call feedkeys("S你好\<C-X>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('你好 我好', getline('.'))
-  call feedkeys("S你好\<C-X>\<C-N>\<C-N>\<Esc>0", 'tx!')
-  call assert_equal('你好 他好', getline('.'))
-
   " issue #15526
   set completeopt=menuone,menu,noselect
   call setline(1, ['Text', 'ToText', ''])
@@ -3007,6 +2987,11 @@ func Test_complete_fuzzy_collect()
   call setline(1, ['foo bar fuzzy', 'completefuzzycollect'])
   call feedkeys("Gofuzzy\<C-X>\<C-N>\<C-N>\<C-N>\<C-Y>\<Esc>0", 'tx!')
   call assert_equal('completefuzzycollect', getline('.'))
+
+  execute('%d _')
+  call setline(1, ['fuzzy', 'fuzzy foo', "fuzzy bar", 'fuzzycollect'])
+  call feedkeys("Gofuzzy\<C-X>\<C-N>\<C-N>\<C-N>\<C-Y>\<Esc>0", 'tx!')
+  call assert_equal('fuzzycollect', getline('.'))
 
   bw!
   bw!


### PR DESCRIPTION
#### vim-patch:9.1.1315: completion: issue with fuzzy completion and 'completefuzzycollect'

Problem:  chain complete does not work when 'cot' includes fuzzy
          and 'completefuzzycollect' collects wrong next word.
          (Konfekt)
Solution: compl_startpos is not set correctly, remove next word check
          in search_for_fuzzy_match (glepnir).

closes: vim/vim#17136

https://github.com/vim/vim/commit/cfe502c5753cce2080ddabdfdcacb8e4b3092721

Co-authored-by: glepnir <glephunter@gmail.com>