### PR TITLE
vim-patch:9.0.{1653,1654},9.1.{0721,1317}

### DIFF
--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -3099,7 +3099,7 @@ static int put_folds_recurse(FILE *fd, garray_T *gap, linenr_T off)
     if (put_folds_recurse(fd, &fp->fd_nested, off + fp->fd_top) == FAIL) {
       return FAIL;
     }
-    if (fprintf(fd, "%" PRId64 ",%" PRId64 "fold",
+    if (fprintf(fd, "sil! %" PRId64 ",%" PRId64 "fold",
                 (int64_t)fp->fd_top + off,
                 (int64_t)(fp->fd_top + off + fp->fd_len - 1)) < 0
         || put_eol(fd) == FAIL) {
@@ -3121,9 +3121,10 @@ static int put_foldopen_recurse(FILE *fd, win_T *wp, garray_T *gap, linenr_T off
     if (fp->fd_flags != FD_LEVEL) {
       if (!GA_EMPTY(&fp->fd_nested)) {
         // open nested folds while this fold is open
+        // ignore errors
         if (fprintf(fd, "%" PRId64, (int64_t)fp->fd_top + off) < 0
             || put_eol(fd) == FAIL
-            || put_line(fd, "normal! zo") == FAIL) {
+            || put_line(fd, "sil! normal! zo") == FAIL) {
           return FAIL;
         }
         if (put_foldopen_recurse(fd, wp, &fp->fd_nested,
@@ -3164,7 +3165,7 @@ static int put_fold_open_close(FILE *fd, fold_T *fp, linenr_T off)
 {
   if (fprintf(fd, "%" PRIdLINENR, fp->fd_top + off) < 0
       || put_eol(fd) == FAIL
-      || fprintf(fd, "normal! z%c",
+      || fprintf(fd, "sil! normal! z%c",
                  fp->fd_flags == FD_CLOSED ? 'c' : 'o') < 0
       || put_eol(fd) == FAIL) {
     return FAIL;

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -114,6 +114,10 @@ endif
 " defaults before we get here, and test_mksession checks that.
 let $ORIGHOME = $HOME
 
+if !exists('$XDG_CONFIG_HOME')
+  let $XDG_CONFIG_HOME = $HOME .. '/.config'
+endif
+
 " Make sure $HOME does not get read or written.
 let $HOME = expand(getcwd() . '/XfakeHOME')
 if !isdirectory($HOME)

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -110,6 +110,10 @@ if executable('gem')
   let $GEM_PATH = system('gem env gempath')
 endif
 
+" Have current $HOME available as $ORIGHOME.  $HOME is used for option
+" defaults before we get here, and test_mksession checks that.
+let $ORIGHOME = $HOME
+
 " Make sure $HOME does not get read or written.
 let $HOME = expand(getcwd() . '/XfakeHOME')
 if !isdirectory($HOME)

--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -1198,6 +1198,24 @@ func Test_mkview_manual_fold()
   bw!
 endfunc
 
+" Test for handling invalid folds within views
+func Test_mkview_ignore_invalid_folds()
+  call writefile(range(1,10), 'Xmkvfile', 'D')
+  new Xmkvfile
+  " create some folds
+  5,6fold
+  4,7fold
+  mkview Xview
+  normal zE
+  " delete lines to make folds invalid
+  call deletebufline('', 6, '$')
+  source Xview
+  call assert_equal([-1, -1, -1, -1, -1, -1], [foldclosed(3), foldclosed(4),
+        \ foldclosed(5), foldclosed(6), foldclosed(7), foldclosed(8)])
+  call delete('Xview')
+  bw!
+endfunc
+
 " Test default 'viewdir' value
 func Test_mkview_default_home()
   throw 'Skipped: N/A'

--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -1170,8 +1170,8 @@ endfunc
 
 " Test for creating views with manual folds
 func Test_mkview_manual_fold()
-  call writefile(range(1,10), 'Xfile')
-  new Xfile
+  call writefile(range(1,10), 'Xmkvfile', 'D')
+  new Xmkvfile
   " create recursive folds
   5,6fold
   4,7fold
@@ -1194,9 +1194,22 @@ func Test_mkview_manual_fold()
   source Xview
   call assert_equal([-1, -1, -1, -1, -1, -1], [foldclosed(3), foldclosed(4),
         \ foldclosed(5), foldclosed(6), foldclosed(7), foldclosed(8)])
-  call delete('Xfile')
   call delete('Xview')
   bw!
+endfunc
+
+" Test default 'viewdir' value
+func Test_mkview_default_home()
+  throw 'Skipped: N/A'
+  if has('win32')
+    call assert_match('^' .. $ORIGHOME .. '/vimfiles', &viewdir)
+  elseif has('unix')
+    call assert_match('^' .. $ORIGHOME .. '/.vim', &viewdir)
+  elseif has('amiga')
+    call assert_match('^home:vimfiles', &viewdir)
+  elseif has('mac')
+    call assert_match('^' .. $VIM .. '/vimfiles', &viewdir)
+  endif
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -1205,7 +1205,10 @@ func Test_mkview_default_home()
     " use escape() to handle backslash path separators
     call assert_match('^' .. escape($ORIGHOME, '\') .. '/vimfiles', &viewdir)
   elseif has('unix')
-    call assert_match('^' .. $ORIGHOME .. '/.vim', &viewdir)
+    call assert_match(
+          \ '^' .. $ORIGHOME .. '/.vim\|' ..
+          \ '^' .. $XDG_CONFIG_HOME .. '/vim'
+          \ , &viewdir)
   elseif has('amiga')
     call assert_match('^home:vimfiles', &viewdir)
   elseif has('mac')

--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -1202,7 +1202,8 @@ endfunc
 func Test_mkview_default_home()
   throw 'Skipped: N/A'
   if has('win32')
-    call assert_match('^' .. $ORIGHOME .. '/vimfiles', &viewdir)
+    " use escape() to handle backslash path separators
+    call assert_match('^' .. escape($ORIGHOME, '\') .. '/vimfiles', &viewdir)
   elseif has('unix')
     call assert_match('^' .. $ORIGHOME .. '/.vim', &viewdir)
   elseif has('amiga')


### PR DESCRIPTION
#### vim-patch:9.0.1653: Amiga: default 'viewdir' may not work

Problem:    Amiga: default 'viewdir' may not work.
Solution:   Use "home:" instead of "$VIM". Add a test. (Christian Brabandt,
            closes vim/vim#12576)

https://github.com/vim/vim/commit/b8b1c8ebd4e62d4567aa16b57b25823b80bfc76f

Cherry-pick Test_mkview_manual_fold() changes from 9.0.{0363,0626}.

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.0.1654: MS-Windows: test for default 'viewdir' fails

Problem:    MS-Windows: test for default 'viewdir' fails.
Solution:   Escape the pattern.

https://github.com/vim/vim/commit/813b7a85f2489e9f698239a9fee17c64da68f435

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.1.0721: tests: test_mksession does not consider XDG_CONFIG_HOME

Problem:  tests: test_mksession does not consider XDG_CONFIG_HOME
Solution: allow to match $HOME/.vim/ and $HOME/.config/vim for &viewdir
          (John M Devin)

closes: vim/vim#15639

https://github.com/vim/vim/commit/5b9237c2e7613f126f95e26056f55024af759102

Co-authored-by: John M Devin <john.m.devin@gmail.com>


#### vim-patch:9.1.1317: noisy error when restoring folds from session fails

Problem:  noisy error when restoring folds from session fails
Solution: ignore errors silently when sourcing session file.
          (Igor Lacerda)

closes: vim/vim#17127

https://github.com/vim/vim/commit/cca5dea76e5bfa8369ae9d54b35fd140bb9159b4

Co-authored-by: Igor Lacerda <igorlfs@ufmg.br>