### PR TITLE
vim-patch:8f09684: runtime(jjdescription): Don't require a space to start comments

### DIFF
--- a/runtime/syntax/jjdescription.vim
+++ b/runtime/syntax/jjdescription.vim
@@ -2,6 +2,7 @@
 " Language:	jj description
 " Maintainer:	Gregory Anders <greg@gpanders.com>
 " Last Change:	2024 May 8
+" 2025 Apr 17 by Vim Project (don't require space to start comments, #17130)
 
 if exists('b:current_syntax')
   finish
@@ -11,7 +12,7 @@ syn match jjAdded "A .*" contained
 syn match jjRemoved "D .*" contained
 syn match jjChanged "M .*" contained
 
-syn region jjComment start="^JJ: " end="$" contains=jjAdded,jjRemoved,jjChanged
+syn region jjComment start="^JJ:" end="$" contains=jjAdded,jjRemoved,jjChanged
 
 syn include @jjCommitDiff syntax/diff.vim
 syn region jjCommitDiff start=/\%(^diff --\%(git\|cc\|combined\) \)\@=/ end=/^\%(diff --\|$\|@@\@!\|[^[:alnum:]\ +-]\S\@!\)\@=/ fold contains=@jjCommitDiff


### PR DESCRIPTION
#### vim-patch:8f09684: runtime(jjdescription): Don't require a space to start comments

Since jj v0.24.0 (December 2024), `JJ:` comments are recognised even
when not followed by a space.

closes: vim/vim#17130

https://github.com/vim/vim/commit/8f096845693fc7a170283ca5dcf8e13aea3ec273

Co-authored-by: ash <ash@sorrel.sh>