### PR TITLE
vim-patch:9.1.1319: Various typos in the code, issue with test_inst_complete.vim

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -2916,7 +2916,7 @@ static void diff_refine_inline_char_highlight(diff_T *dp_orig, garray_T *linemap
   } while (pass++ < 4);  // use limited number of passes to avoid excessive looping
 }
 
-/// Find the inline difference within a diff block among differnt buffers.  Do
+/// Find the inline difference within a diff block among different buffers.  Do
 /// this by splitting each block's content into characters or words, and then
 /// use internal xdiff to calculate the per-character/word diff.  The result is
 /// stored in dp instead of returned by the function.
@@ -4076,7 +4076,7 @@ void f_diff_hlID(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   diffline_T diffline = { 0 };
   // Remember the results if using simple since it's recalculated per
   // call. Otherwise just call diff_find_change() every time since
-  // internally the result is cached interally.
+  // internally the result is cached internally.
   const bool cache_results = !(diff_flags & ALL_INLINE_DIFF);
 
   linenr_T lnum = tv_get_lnum(argvars);

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2909,7 +2909,7 @@ static void nv_zet(cmdarg_T *cap)
     }
     break;
 
-  // "zp", "zP" in block mode put without addind trailing spaces
+  // "zp", "zP" in block mode put without adding trailing spaces
   case 'P':
   case 'p':
     nv_put(cap);

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -297,12 +297,12 @@ static int get_vts_sum(const int *vts_array, int index)
   int sum = 0;
   int i;
 
-  // Perform the summation for indeces within the actual array.
+  // Perform the summation for indices within the actual array.
   for (i = 1; i <= index && i <= vts_array[0]; i++) {
     sum += vts_array[i];
   }
 
-  // Add topstops whose indeces exceed the actual array.
+  // Add tabstops whose indices exceed the actual array.
   if (i <= index) {
     sum += vts_array[vts_array[0]] * (index - vts_array[0]);
   }

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2988,7 +2988,7 @@ func Test_complete_fuzzy_collect()
   call feedkeys("Gofuzzy\<C-X>\<C-N>\<C-N>\<C-N>\<C-Y>\<Esc>0", 'tx!')
   call assert_equal('completefuzzycollect', getline('.'))
 
-  execute('%d _')
+  %d _
   call setline(1, ['fuzzy', 'fuzzy foo', "fuzzy bar", 'fuzzycollect'])
   call feedkeys("Gofuzzy\<C-X>\<C-N>\<C-N>\<C-N>\<C-Y>\<Esc>0", 'tx!')
   call assert_equal('fuzzycollect', getline('.'))


### PR DESCRIPTION
#### vim-patch:9.1.1319: Various typos in the code, issue with test_inst_complete.vim

Problem:  Various typos in the code, redundant and strange use of
          :execute in test_ins_complete.vim (after 9.1.1315).
Solution: Fix typos in the code and in the documentation, use the
          executed command directly (zeertzjq).

closes: vim/vim#17143

https://github.com/vim/vim/commit/98800979dc109e03f390a0472b14ed89189e02fe

Co-authored-by: Christ van Willegen <cvwillegen@gmail.com>