### PR TITLE
fix(spell): save spell files to stdpath('data')/site/spell

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -186,7 +186,7 @@ CHANGED FEATURES                                                 *news-changed*
 
 These existing features changed their behavior.
 
-• 'spellfile' location defaults to `stdpath("data").."/spell/"` instead of the
+• 'spellfile' location defaults to `stdpath("data").."/site/spell/"` instead of the
   first writable directoy in 'runtimepath'.
 • |vim.version.range()| doesn't exclude `to` if it is equal to `from`.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5795,7 +5795,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	|zg| and |zw| commands can be used to access each.  This allows using
 	a personal word list file and a project word list file.
 	When a word is added while this option is empty Nvim will use
-	(and auto-create) `stdpath('data')/spell/`. For the file name the
+	(and auto-create) `stdpath('data')/site/spell/`. For the file name the
 	first language name that appears in 'spelllang' is used, ignoring the
 	region.
 	The resulting ".spl" file will be used for spell checking, it does not

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -79,7 +79,7 @@ Defaults                                            *defaults* *nvim-defaults*
 - 'showcmd' is enabled
 - 'sidescroll' defaults to 1
 - 'smarttab' is enabled
-- 'spellfile' defaults to `stdpath("data").."/spell/"`
+- 'spellfile' defaults to `stdpath("data").."/site/spell/"`
 - 'startofline' is disabled
 - 'switchbuf' defaults to "uselast"
 - 'tabpagemax' defaults to 50

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -6169,7 +6169,7 @@ vim.bo.spc = vim.bo.spellcapcheck
 --- `zg` and `zw` commands can be used to access each.  This allows using
 --- a personal word list file and a project word list file.
 --- When a word is added while this option is empty Nvim will use
---- (and auto-create) `stdpath('data')/spell/`. For the file name the
+--- (and auto-create) `stdpath('data')/site/spell/`. For the file name the
 --- first language name that appears in 'spelllang' is used, ignoring the
 --- region.
 --- The resulting ".spl" file will be used for spell checking, it does not

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -8216,7 +8216,7 @@ local options = {
         |zg| and |zw| commands can be used to access each.  This allows using
         a personal word list file and a project word list file.
         When a word is added while this option is empty Nvim will use
-        (and auto-create) `stdpath('data')/spell/`. For the file name the
+        (and auto-create) `stdpath('data')/site/spell/`. For the file name the
         first language name that appears in 'spelllang' is used, ignoring the
         region.
         The resulting ".spl" file will be used for spell checking, it does not

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -5550,7 +5550,7 @@ void spell_add_word(char *word, int len, SpellAddType what, int idx, bool undo)
 // Initialize 'spellfile' for the current buffer.
 //
 // If the location does not exist, create it. Defaults to
-// stdpath("data") + "/spell/{spelllang}.{encoding}.add".
+// stdpath("data") + "/site/spell/{spelllang}.{encoding}.add".
 static void init_spellfile(void)
 {
   char *lend;

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -5579,7 +5579,7 @@ static void init_spellfile(void)
     xstrlcpy(buf, xdg_path, buf_len);
     xfree(xdg_path);
 
-    xstrlcat(buf, "/spell", buf_len);
+    xstrlcat(buf, "/site/spell", buf_len);
 
     char *failed_dir;
     if (os_mkdir_recurse(buf, 0755, &failed_dir, NULL) != 0) {

--- a/test/functional/core/spellfile_spec.lua
+++ b/test/functional/core/spellfile_spec.lua
@@ -119,12 +119,12 @@ describe('spellfile', function()
   end)
 
   describe('default location', function()
-    it("is stdpath('data')/spell/en.utf-8.add", function()
+    it("is stdpath('data')/site/spell/en.utf-8.add", function()
       n.command('set spell')
       n.insert('abc')
       n.feed('zg')
       eq(
-        t.fix_slashes(fn.stdpath('data') .. '/spell/en.utf-8.add'),
+        t.fix_slashes(fn.stdpath('data') .. '/site/spell/en.utf-8.add'),
         t.fix_slashes(api.nvim_get_option_value('spellfile', {}))
       )
     end)


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Fixes: #33483