### PR TITLE
vim-patch:9.1.1322: small delete register cannot paste multi-line correctly

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1367,7 +1367,7 @@ int insert_reg(int regname, yankreg_T *reg, bool literally_arg)
       retval = FAIL;
     } else {
       for (size_t i = 0; i < reg->y_size; i++) {
-        if (regname == '-') {
+        if (regname == '-' && reg->y_type == kMTCharWise) {
           Direction dir = BACKWARD;
           if ((State & REPLACE_FLAG) != 0) {
             pos_T curpos;
@@ -1388,11 +1388,11 @@ int insert_reg(int regname, yankreg_T *reg, bool literally_arg)
           do_put(regname, NULL, dir, 1, PUT_CURSEND);
         } else {
           stuffescaped(reg->y_array[i].data, literally);
-        }
-        // Insert a newline between lines and after last line if
-        // y_type is kMTLineWise.
-        if (reg->y_type == kMTLineWise || i < reg->y_size - 1) {
-          stuffcharReadbuff('\n');
+          // Insert a newline between lines and after last line if
+          // y_type is kMTLineWise.
+          if (reg->y_type == kMTLineWise || i < reg->y_size - 1) {
+            stuffcharReadbuff('\n');
+          }
         }
       }
     }

--- a/test/old/testdir/test_registers.vim
+++ b/test/old/testdir/test_registers.vim
@@ -1087,4 +1087,13 @@ func Test_mark_from_yank()
   bw!
 endfunc
 
+func Test_insert_small_delete_linewise()
+  new
+  call setline(1, ['foo'])
+  call cursor(1, 1)
+  exe ":norm! \"-cc\<C-R>-"
+  call assert_equal(['foo', ''], getline(1, '$'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  small delete register cannot paste multi-line correctly
          (after v8.2.2189)
Solution: caused by 032a2d050b82b146d70d6ff714838ee62c07d8ad, so make
          this logic handle charwise only (phanium)

closes: vim/vim#17151

https://github.com/vim/vim/commit/7e93d4c617784e03f539d139f3475bd72c04a6e5

Co-authored-by: phanium <91544758+phanen@users.noreply.github.com>
