### PR TITLE
vim-patch:cb3b752: runtime(doc): clarify "nearest" value for 'completeopt'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1590,8 +1590,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    Useful when there is additional information about the
 		    match, e.g., what file it comes from.
 
-	   nearest  Matches are presented in order of proximity to the cursor
-		    position.  This applies only to matches from the current
+	   nearest  Matches are listed based on their proximity to the cursor
+		    position, unlike the default behavior, which only
+		    considers proximity for matches appearing below the
+		    cursor.  This applies only to matches from the current
 		    buffer.  No effect if "fuzzy" is present.
 
 	   noinsert Do not insert any text for a match until the user selects

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1123,8 +1123,10 @@ vim.go.cia = vim.go.completeitemalign
 --- 	    Useful when there is additional information about the
 --- 	    match, e.g., what file it comes from.
 ---
----    nearest  Matches are presented in order of proximity to the cursor
---- 	    position.  This applies only to matches from the current
+---    nearest  Matches are listed based on their proximity to the cursor
+--- 	    position, unlike the default behavior, which only
+--- 	    considers proximity for matches appearing below the
+--- 	    cursor.  This applies only to matches from the current
 --- 	    buffer.  No effect if "fuzzy" is present.
 ---
 ---    noinsert Do not insert any text for a match until the user selects

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1580,8 +1580,10 @@ local options = {
         	    Useful when there is additional information about the
         	    match, e.g., what file it comes from.
 
-           nearest  Matches are presented in order of proximity to the cursor
-        	    position.  This applies only to matches from the current
+           nearest  Matches are listed based on their proximity to the cursor
+        	    position, unlike the default behavior, which only
+        	    considers proximity for matches appearing below the
+        	    cursor.  This applies only to matches from the current
         	    buffer.  No effect if "fuzzy" is present.
 
            noinsert Do not insert any text for a match until the user selects


### PR DESCRIPTION
#### vim-patch:cb3b752: runtime(doc): clarify "nearest" value for 'completeopt'

closes: vim/vim#17146

https://github.com/vim/vim/commit/cb3b752f9523060d3feaee33049d2092c288fca2

Co-authored-by: Girish Palya <girishji@gmail.com>