### PR TITLE
fix(api): nvim_parse_cmd don't put key 'range' when ea.addr_count == 0

### DIFF
--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -154,14 +154,12 @@ Dict(cmd) nvim_parse_cmd(String str, Dict(empty) *opts, Arena *arena, Error *err
   char *name = (cmd != NULL ? cmd->uc_name : get_command_name(NULL, ea.cmdidx));
   PUT_KEY(result, cmd, cmd, cstr_as_string(name));
 
-  if (ea.argt & EX_RANGE) {
+  if ((ea.argt & EX_RANGE) && ea.addr_count > 0) {
     Array range = arena_array(arena, 2);
-    if (ea.addr_count > 0) {
-      if (ea.addr_count > 1) {
-        ADD_C(range, INTEGER_OBJ(ea.line1));
-      }
-      ADD_C(range, INTEGER_OBJ(ea.line2));
+    if (ea.addr_count > 1) {
+      ADD_C(range, INTEGER_OBJ(ea.line1));
     }
+    ADD_C(range, INTEGER_OBJ(ea.line2));
     PUT_KEY(result, cmd, range, range);
   }
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -4307,7 +4307,6 @@ describe('API', function()
         cmd = 'put',
         args = {},
         bang = false,
-        range = {},
         reg = '+',
         addr = 'line',
         magic = {
@@ -4346,7 +4345,6 @@ describe('API', function()
         cmd = 'put',
         args = {},
         bang = false,
-        range = {},
         reg = '',
         addr = 'line',
         magic = {
@@ -4429,7 +4427,6 @@ describe('API', function()
         cmd = 'write',
         args = {},
         bang = true,
-        range = {},
         addr = 'line',
         magic = {
           file = true,
@@ -4470,7 +4467,6 @@ describe('API', function()
           cmd = 'split',
           args = { 'foo.txt' },
           bang = false,
-          range = {},
           addr = '?',
           magic = {
             file = true,
@@ -4514,7 +4510,6 @@ describe('API', function()
           cmd = 'split',
           args = { 'foo.txt' },
           bang = false,
-          range = {},
           addr = '?',
           magic = {
             file = true,
@@ -4600,7 +4595,6 @@ describe('API', function()
         cmd = 'argadd',
         args = { 'a.txt' },
         bang = false,
-        range = {},
         addr = 'arg',
         magic = {
           file = true,
@@ -4775,6 +4769,8 @@ describe('API', function()
       eq('foo', api.nvim_cmd(api.nvim_parse_cmd('echo "foo"', {}), { output = true }))
       api.nvim_cmd(api.nvim_parse_cmd('set cursorline', {}), {})
       eq(true, api.nvim_get_option_value('cursorline', {}))
+      -- Roundtrip on :bdelete which does not accept "range". #33394
+      api.nvim_cmd(api.nvim_parse_cmd('bdelete', {}), {})
     end)
     it('no side-effects (error messages) in pcall() #20339', function()
       eq(


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

Fixes: #33394.

Why change the tests?
Adding a condition of `ea.addr_count > 0` would change the behavior,
- We won't add the `range` field to the `result` if the conditions are not matched.
- But the result used to contain a `range` field, which is `{}`.