### PR TITLE
vim-patch:2398460: runtime(doc): clarify 'includeexpr' is not used for <cfile>

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3419,7 +3419,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 <
 	Also used for the |gf| command if an unmodified file name can't be
 	found.  Allows doing "gf" on the name after an 'include' statement.
-	Also used for |<cfile>|.
+	Note: Not used for |<cfile>|.
 
 	If the expression starts with s: or |<SID>|, then it is replaced with
 	the script ID (|local-function|). Example: >vim

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -3281,7 +3281,7 @@ vim.go.inc = vim.go.include
 ---
 --- Also used for the `gf` command if an unmodified file name can't be
 --- found.  Allows doing "gf" on the name after an 'include' statement.
---- Also used for `<cfile>`.
+--- Note: Not used for `<cfile>`.
 ---
 --- If the expression starts with s: or `<SID>`, then it is replaced with
 --- the script ID (`local-function`). Example:

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -4462,7 +4462,7 @@ local options = {
         <
         Also used for the |gf| command if an unmodified file name can't be
         found.  Allows doing "gf" on the name after an 'include' statement.
-        Also used for |<cfile>|.
+        Note: Not used for |<cfile>|.
 
         If the expression starts with s: or |<SID>|, then it is replaced with
         the script ID (|local-function|). Example: >vim


### PR DESCRIPTION
#### vim-patch:2398460: runtime(doc): clarify 'includeexpr' is not used for \<cfile>

https://github.com/vim/vim/commit/23984602327600b7ef28dcedc772949d5c66b57f

Co-authored-by: Christian Brabandt <cb@256bit.org>