### PR TITLE
vim-patch:54081f0: runtime(nix): set iskeyword and b:match_words in ftplugin

### DIFF
--- a/runtime/ftplugin/nix.vim
+++ b/runtime/ftplugin/nix.vim
@@ -2,6 +2,7 @@
 " Language:    nix
 " Maintainer:  Keith Smiley <keithbsmiley@gmail.com>
 " Last Change: 2023 Jul 22
+" 2025 Apr 18 by Vim Project (set 'iskeyword' and b:match_words #17154)
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -11,7 +12,10 @@ endif
 " Don't load another plugin for this buffer
 let b:did_ftplugin = 1
 
-let b:undo_ftplugin = "setl commentstring< comments<"
+let b:undo_ftplugin = "setl commentstring< comments< iskeyword< | unlet! b:match_words"
+
+let b:match_words = "\<if\>:\<then\>:\<else\>,\<let\>:\<in\>"
 
 setlocal comments=:#
 setlocal commentstring=#\ %s
+setlocal iskeyword+=-


### PR DESCRIPTION
#### vim-patch:54081f0: runtime(nix): set iskeyword and b:match_words in ftplugin

closes: vim/vim#17154

https://github.com/vim/vim/commit/54081f0ce087bb3efd2f62fdbbbd5ac812da69f8

Co-authored-by: Arnie97 <arnie97@gmail.com>