### PR TITLE
fix(gen_vimdoc): unnecessary assert for non-source files

### DIFF
--- a/src/gen/gen_vimdoc.lua
+++ b/src/gen/gen_vimdoc.lua
@@ -983,11 +983,13 @@ local function gen_target(cfg)
 
   --- First pass so we can collect all classes
   for _, f in vim.spairs(cfg.files) do
-    local ext = assert(f:match('%.([^.]+)$')) --[[@as 'h'|'c'|'lua']]
-    local parser = assert(parsers[ext])
-    local classes, funs, briefs = parser(f)
-    file_results[f] = { classes, funs, briefs }
-    all_classes = vim.tbl_extend('error', all_classes, classes)
+    local ext = f:match('%.([^.]+)$')
+    local parser = parsers[ext]
+    if parser then
+      local classes, funs, briefs = parser(f)
+      file_results[f] = { classes, funs, briefs }
+      all_classes = vim.tbl_extend('error', all_classes, classes)
+    end
   end
 
   for f, r in vim.spairs(file_results) do


### PR DESCRIPTION
Problem:  The presence of non-source files breaks `make doc`.
Solution: Replace assert with if statement to skip non-matching files.