### PR TITLE
fix(titlestring): add ':p' to default titlestring option

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6719,7 +6719,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	will be given when the value is set.
 
 	The default behaviour is equivalent to: >vim
-	    set titlestring=%t%(\ %M%)%(\ \(%{expand(\"%:~:h\")}\)%)%a\ -\ Nvim
+	    set titlestring=%t%(\ %M%)%(\ \(%{expand(\"%:p:~:h\")}\)%)%a\ -\ Nvim
 <
 	This option cannot be set in a modeline when 'modelineexpr' is off.
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -639,7 +639,7 @@ Working directory (Vim implemented some of these after Nvim):
 Options:
 - 'titlestring' uses printf-style '%' items (see: 'statusline') to implement
   the default behaviour. The implementation is equivalent to setting
-  'titlestring' to `%t%(\ %M%)%(\ \(%{expand(\"%:~:h\")}\)%)%a\ -\ Nvim`.
+  'titlestring' to `%t%(\ %M%)%(\ \(%{expand(\"%:p:~:h\")}\)%)%a\ -\ Nvim`.
 
 ==============================================================================
 Missing features                                         *nvim-missing*

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -7268,7 +7268,7 @@ vim.go.titleold = vim.o.titleold
 --- The default behaviour is equivalent to:
 ---
 --- ```vim
----     set titlestring=%t%(\ %M%)%(\ \(%{expand(\"%:~:h\")}\)%)%a\ -\ Nvim
+---     set titlestring=%t%(\ %M%)%(\ \(%{expand(\"%:p:~:h\")}\)%)%a\ -\ Nvim
 --- ```
 ---
 --- This option cannot be set in a modeline when 'modelineexpr' is off.

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -3334,7 +3334,7 @@ void maketitle(void)
       }
     } else {
       // Format: "fname + (path) (1 of 2) - Nvim".
-      char *default_titlestring = "%t%( %M%)%( (%{expand(\"%:~:h\")})%)%a - Nvim";
+      char *default_titlestring = "%t%( %M%)%( (%{expand(\"%:p:~:h\")})%)%a - Nvim";
       build_stl_str_hl(curwin, buf, sizeof(buf), default_titlestring,
                        kOptTitlestring, 0, 0, maxlen, NULL, NULL, NULL, NULL);
       title_str = buf;

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9517,7 +9517,7 @@ local options = {
         will be given when the value is set.
 
         The default behaviour is equivalent to: >vim
-            set titlestring=%t%(\ %M%)%(\ \(%{expand(\"%:~:h\")}\)%)%a\ -\ Nvim
+            set titlestring=%t%(\ %M%)%(\ \(%{expand(\"%:p:~:h\")}\)%)%a\ -\ Nvim
         <
         This option cannot be set in a modeline when 'modelineexpr' is off.
 


### PR DESCRIPTION
Problem: incorrect default 'titlestring' format
Solution: add ':p' to arg of expand which would get current path first

closes: neovim/neovim#32411

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
