### PR TITLE
fix(lsp): ensure initializeOptions is serialized as an object

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -509,6 +509,13 @@ function Client:initialize()
     root_path = vim.uri_to_fname(root_uri)
   end
 
+  -- Ensure empty tables for initializationOptions are serialized as objects, not arrays
+  local init_options = config.init_options
+  if type(init_options) == 'table' and vim.tbl_isempty(init_options) then
+    -- For empty tables, ensure they're serialized as objects
+    init_options = vim.empty_dict()
+  end
+
   local init_params = {
     -- The process Id of the parent process that started the server. Is null if
     -- the process has not been started by another process.  If the parent
@@ -530,7 +537,7 @@ function Client:initialize()
     rootUri = root_uri or vim.NIL,
     workspaceFolders = self.workspace_folders or vim.NIL,
     -- User provided initialization options.
-    initializationOptions = config.init_options,
+    initializationOptions = init_options,
     capabilities = self.capabilities,
     trace = self._trace,
     workDoneToken = '1',

--- a/test/functional/plugin/lsp/initialization_spec.lua
+++ b/test/functional/plugin/lsp/initialization_spec.lua
@@ -1,0 +1,95 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+local t_lsp = require('test.functional.plugin.lsp.testutil')
+
+local eq = t.eq
+local create_server_definition = t_lsp.create_server_definition
+local exec_lua = n.exec_lua
+
+describe('LSP initialization', function()
+  before_each(function()
+    n.clear()
+    exec_lua(create_server_definition)
+  end)
+
+  it('serializes empty initializationOptions as an object, not an array', function()
+    local result = exec_lua(function()
+      local captured_init_options_raw
+      local server = _G._create_server({
+        handlers = {
+          initialize = function(_, params, _)
+            -- Store the raw JSON to examine serialization
+            captured_init_options_raw = vim.fn.json_encode(params.initializationOptions)
+            return {
+              capabilities = {},
+            }
+          end,
+        },
+      })
+
+      -- Start an LSP client with empty init_options
+      local client_id = vim.lsp.start({
+        name = 'test-empty-init-options',
+        cmd = server.cmd,
+        -- This should be serialized as an object {}, not an array []
+        init_options = {},
+      })
+
+      -- Wait for initialization to complete
+      vim.wait(1000, function()
+        return captured_init_options_raw ~= nil
+      end)
+
+      -- Stop the client
+      vim.lsp.stop_client(client_id)
+
+      return captured_init_options_raw
+    end)
+
+    -- Verify that empty initializationOptions are serialized as '{}' (object)
+    -- and not '[]' (array)
+    eq('{}', result)
+  end)
+
+  it('preserves non-empty initializationOptions correctly', function()
+    local result = exec_lua(function()
+      local captured_init_options
+      local server = _G._create_server({
+        handlers = {
+          initialize = function(_, params, _)
+            captured_init_options = params.initializationOptions
+            return {
+              capabilities = {},
+            }
+          end,
+        },
+      })
+
+      -- Start an LSP client with non-empty init_options
+      local client_id = vim.lsp.start({
+        name = 'test-non-empty-init-options',
+        cmd = server.cmd,
+        init_options = {
+          setting1 = 'value1',
+          setting2 = 42,
+        },
+      })
+
+      -- Wait for initialization to complete
+      vim.wait(1000, function()
+        return captured_init_options ~= nil
+      end)
+
+      -- Stop the client
+      vim.lsp.stop_client(client_id)
+
+      return captured_init_options
+    end)
+
+    -- Verify that non-empty initializationOptions are preserved correctly
+    eq({
+      setting1 = 'value1',
+      setting2 = 42,
+    }, result)
+  end)
+end)


### PR DESCRIPTION
This fixes an issue with lua empty tables being serialized as arrays.

This caused an issue with ALE -> Sorbet LSP server.

```
Error executing vim.schedule lua callback: ...nvimEllFDd/usr/share/nvim/runtime/lua/vim/lsp/client.lua:548: RPC[Error] code_name = InvalidParams, message = "Unable to deserialize LSP request: Error deserializing JSON message: Expected field `InitializeParams.initializationOptions` to have value of type `object`, but had value `[]`."
stack traceback:
        [C]: in function 'assert'
        ...nvimEllFDd/usr/share/nvim/runtime/lua/vim/lsp/cl…
```

This change ensures that we always serialize it as an object

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
