### PR TITLE
fix(messages): single msg_show event for multiple :set options

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1282,10 +1282,10 @@ static void do_one_set_option(int opt_flags, char **argp, bool *did_show, char *
     if (*did_show) {
       msg_putchar('\n');                // cursor below last one
     } else {
+      msg_ext_set_kind("list_cmd");
       gotocmdline(true);                // cursor at status line
       *did_show = true;                 // remember that we did a line
     }
-    msg_ext_set_kind("list_cmd");
     showoneopt(&options[opt_idx], opt_flags);
 
     if (p_verbose > 0) {

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1605,12 +1605,11 @@ stack traceback:
 
   it('g< mapping shows recent messages', function()
     command('echo "foo" | echo "bar"')
-    local s1 = [[
-      ^                         |
-      {1:~                        }|*4
-    ]]
     screen:expect({
-      grid = s1,
+      grid = [[
+        ^                         |
+        {1:~                        }|*4
+      ]],
       messages = {
         {
           content = { { 'bar' } },
@@ -1640,6 +1639,23 @@ stack traceback:
         {
           content = { { 'bar' } },
           kind = 'echo',
+        },
+      },
+    })
+  end)
+
+  it('single event for multiple :set options', function()
+    command('set sw ts sts')
+    screen:expect({
+      grid = [[
+        ^                         |
+        {1:~                        }|*4
+      ]],
+      messages = {
+        {
+          content = { { '  shiftwidth=8\n  tabstop=8\n  softtabstop=0' } },
+          history = false,
+          kind = 'list_cmd',
         },
       },
     })


### PR DESCRIPTION
Problem:  :set opt1 opt2... emits a separate event for each option.
Solution: Only set the kind for the first printed option value.

Fix #32583
