### PR TITLE
vim-patch:9.1.1326: invalid cursor position after 'tagfunc'

### DIFF
--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -1250,6 +1250,7 @@ static int find_tagfunc_tags(char *pat, garray_T *ga, int *match_count, int flag
   pos_T save_pos = curwin->w_cursor;
   int result = callback_call(&curbuf->b_tfu_cb, 3, args, &rettv);
   curwin->w_cursor = save_pos;  // restore the cursor position
+  check_cursor(curwin);         // make sure cursor position is valid
   d->dv_refcount--;
 
   if (result == FAIL) {

--- a/test/old/testdir/test_tagfunc.vim
+++ b/test/old/testdir/test_tagfunc.vim
@@ -413,5 +413,24 @@ func Test_tagfunc_closes_window()
   set tagfunc=
 endfunc
 
+func Test_tagfunc_deletes_lines()
+  defer delete('Xany')
+  split Xany
+  call writefile([''], 'Xtest', 'D')
+  call setline(1, range(10))
+  call cursor(10, 1)
+  func MytagfuncDel(pat, flags, info)
+    9,10d
+    return [{'name' : 'mytag', 'filename' : 'Xtest', 'cmd' : '1'}]
+  endfunc
+  set tagfunc=MytagfuncDel
+  call taglist('.')
+  call assert_equal([0, 8, 1, 0], getpos('.'))
+  norm! ofoobar
+  call assert_equal(['0', '1', '2', '3', '4', '5', '6', '7', 'foobar'], getline(1, '$'))
+
+  bw!
+  set tagfunc=
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1326: invalid cursor position after 'tagfunc'

Problem:  invalid cursor position after 'tagfunc'
          (gandalf4a)
Solution: call check_cursor() after executing the 'tagfunc'

https://github.com/vim/vim/commit/9919085491c5ce47091710fce5af13e3379f17fc

Co-authored-by: Christian Brabandt <cb@256bit.org>