### PR TITLE
vim-patch:9.1.1328: too many strlen() calls in indent.c

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1638,7 +1638,7 @@ void change_indent(int type, int amount, int round, bool call_changed_bytes)
 
   // MODE_VREPLACE state needs to know what the line was like before changing
   if (State & VREPLACE_FLAG) {
-    orig_line = xstrdup(get_cursor_line_ptr());   // Deal with NULL below
+    orig_line = xstrnsave(get_cursor_line_ptr(), (size_t)get_cursor_line_len());
     orig_col = curwin->w_cursor.col;
   }
 
@@ -1788,7 +1788,7 @@ void change_indent(int type, int amount, int round, bool call_changed_bytes)
   // then put it back again the way we wanted it.
   if (State & VREPLACE_FLAG) {
     // Save new line
-    char *new_line = xstrdup(get_cursor_line_ptr());
+    char *new_line = xstrnsave(get_cursor_line_ptr(), (size_t)get_cursor_line_len());
 
     // We only put back the new line up to the cursor
     new_line[curwin->w_cursor.col] = NUL;


### PR DESCRIPTION
#### vim-patch:9.1.1328: too many strlen() calls in indent.c

Problem:  too many strlen() calls in indent.c
Solution: refactor indent.c slightly and remove strlen() calls
          (John Marriott)

closes: vim/vim#17156

https://github.com/vim/vim/commit/eac45c558e3585ada79bb24a86e8cd343e2807cf

Co-authored-by: John Marriott <basilisk@internode.on.net>