### PR TITLE
feat(lsp): add `vim.lsp.resolve_config`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1055,6 +1055,25 @@ omnifunc({findstart}, {base})                             *vim.lsp.omnifunc()*
       • |complete-items|
       • |CompleteDone|
 
+                                                    *vim.lsp.resolve_config()*
+resolve_config({bufnr}, {config}, {on_resolve})
+    Resolves an LSP configuration into a fully usable client configuration.
+
+    This function is typically used to prepare a |vim.lsp.ClientConfig| from a
+    user-defined |vim.lsp.Config|. If the configuration requires a workspace
+    and none is found, the resolution is aborted.
+
+    Parameters: ~
+      • {bufnr}       (`integer`) Buffer number for which the config is being
+                      resolved.
+      • {config}      (`vim.lsp.Config`) The base LSP configuration to
+                      resolve. See |vim.lsp.Config|.
+      • {on_resolve}  (`fun(config: vim.lsp.ClientConfig, opts: vim.lsp.start.Opts)`)
+                      Callback invoked once the config is resolved.
+
+    Return: ~
+        (`vim.lsp.ClientConfig?`) See |vim.lsp.ClientConfig|.
+
 set_log_level({level})                               *vim.lsp.set_log_level()*
     Sets the global log level for LSP logging.
 


### PR DESCRIPTION
Adding a separate method to resolve config from `vim.lsp.Config` to `vim.lsp.ClientConfig`.

Can be useful when manually starting LSPs and it also highlights the separation between the two types.

Examples:

```lua
vim.lsp.resolve_confg(vim.lsp.config["lua_ls"], function(config, opts)
  vim.lsp.start(config, { bufnr = 0, reuse_client = opts.reuse_client }
end
```

Should I add the examples to the luadoc?

Needed to make https://github.com/neovim/nvim-lspconfig/pull/3734 less ugly.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
