### PR TITLE
fix(snippet): use <cmd>call cursor() for visual range

### DIFF
--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -278,15 +278,6 @@ local function select_tabstop(tabstop)
     vim.api.nvim_feedkeys(keys, 'n', true)
   end
 
-  --- NOTE: We don't use `vim.api.nvim_win_set_cursor` here because it causes the cursor to end
-  --- at the end of the selection instead of the start.
-  ---
-  --- @param row integer
-  --- @param col integer
-  local function move_cursor_to(row, col)
-    feedkeys(string.format('%sG%s|', row, col))
-  end
-
   local range = tabstop:get_range()
   local mode = vim.fn.mode()
 
@@ -311,13 +302,16 @@ local function select_tabstop(tabstop)
     end
   else
     -- Else, select the tabstop's text.
-    if mode ~= 'n' then
-      feedkeys('<Esc>')
-    end
-    move_cursor_to(range[1] + 1, range[2] + 1)
-    feedkeys('v')
-    move_cursor_to(range[3] + 1, range[4])
-    feedkeys('o<c-g><c-r>_')
+    -- Need this exact order so cannot mix regular API calls with feedkeys, which
+    -- are not executed immediately. Use <Cmd> to set the cursor position.
+    local keys = {
+      mode ~= 'n' and '<Esc>' or '',
+      ('<Cmd>call cursor(%s,%s)<CR>'):format(range[1] + 1, range[2] + 1),
+      'v',
+      ('<Cmd>call cursor(%s,%s)<CR>'):format(range[3] + 1, range[4]),
+      'o<c-g><c-r>_',
+    }
+    feedkeys(table.concat(keys))
   end
 end
 

--- a/test/functional/lua/snippet_spec.lua
+++ b/test/functional/lua/snippet_spec.lua
@@ -307,4 +307,10 @@ describe('vim.snippet', function()
     ]]
     )
   end)
+
+  it('correct visual selection with multi-byte text', function()
+    test_expand_success({ 'function(${1:var})' }, { '口口function(var)' }, nil, '口口')
+    feed('foo')
+    eq({ '口口function(foo)' }, buf_lines(0))
+  end)
 end)


### PR DESCRIPTION
Problem:  Change applied in d3e495ce uses a byte-offset where a virtual
          column is expected.
Solution: Set the cursor directly through `call cursor()` while making
          sure the commands are ordered correctly by adding them to the
          type ahead buffer.

