### PR TITLE
vim-patch: update runtime files

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -1129,6 +1129,13 @@ functions with [[ and ]].  Move around comments with ]" and [".
 The mappings can be disabled with: >
 	let g:no_vim_maps = 1
 
+YAML							*ft-yaml-plugin*
+By default, the YAML filetype plugin enables the following options: >
+	setlocal shiftwidth=2 softtabstop=2
+
+To disable this, set the following variable: >
+	let g:yaml_recommended_style = 0
+
 
 ZIG							*ft-zig-plugin*
 

--- a/runtime/ftplugin/yaml.vim
+++ b/runtime/ftplugin/yaml.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
 " Language:             YAML (YAML Ain't Markup Language)
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se> (inactive)
-" Last Change:  2024 Oct 04
+" Last Change:          2024 Oct 04
+" 2025 Apr 22 by Vim project re-order b:undo_ftplugin (#17179)
 
 if exists("b:did_ftplugin")
   finish
@@ -16,20 +17,25 @@ let b:undo_ftplugin = "setl com< cms< et< fo<"
 setlocal comments=:# commentstring=#\ %s expandtab
 setlocal formatoptions-=t formatoptions+=croql
 
-" rime input method engine uses `*.custom.yaml` as its config files
-if expand('%:r:e') ==# 'custom'
-  if !exists('current_compiler')
-    compiler rime_deployer
-    let b:undo_ftplugin ..= "| compiler make"
-  endif
-  setlocal include=__include:\\s*
-  let b:undo_ftplugin ..= " inc<"
-endif
-
-if !exists("g:yaml_recommended_style") || g:yaml_recommended_style != 0
+if get(g:, "yaml_recommended_style",1)
   let b:undo_ftplugin ..= " sw< sts<"
   setlocal shiftwidth=2 softtabstop=2
 endif
+
+" rime input method engine(https://rime.im/)
+" uses `*.custom.yaml` as its config files
+if expand('%:r:e') ==# 'custom'
+  " `__include` command in `*.custom.yaml`
+  " see: https://github.com/rime/home/wiki/Configuration#%E5%8C%85%E5%90%AB
+  setlocal include=__include:\\s*
+  let b:undo_ftplugin ..= " inc<"
+
+  if !exists('current_compiler')
+    compiler rime_deployer
+    let b:undo_ftplugin ..= " | compiler make"
+  endif
+endif
+
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/indent/make.vim
+++ b/runtime/indent/make.vim
@@ -3,6 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
 " Last Change:		2022 Apr 06
+" 2025 Apr 22 by Vim Project: do not indent after special targets #17183
 
 if exists("b:did_indent")
   finish
@@ -21,6 +22,8 @@ endif
 
 let s:comment_rx = '^\s*#'
 let s:rule_rx = '^[^ \t#:][^#:]*:\{1,2}\%([^=:]\|$\)'
+" .PHONY, .DELETE_ON_ERROR, etc
+let s:rule_special = '^\.[A-Z_]\+\s*:'
 let s:continued_rule_rx = '^[^#:]*:\{1,2}\%([^=:]\|$\)'
 let s:continuation_rx = '\\$'
 let s:assignment_rx = '^\s*\h\w*\s*[+:?]\==\s*\zs.*\\$'
@@ -50,7 +53,7 @@ function GetMakeIndent()
   if prev_line =~ s:continuation_rx
     if prev_prev_line =~ s:continuation_rx
       return indent(prev_lnum)
-    elseif prev_line =~ s:rule_rx
+    elseif prev_line =~ s:rule_rx && prev_line !~ s:rule_special
       return shiftwidth()
     elseif prev_line =~ s:assignment_rx
       call cursor(prev_lnum, 1)
@@ -81,15 +84,15 @@ function GetMakeIndent()
       let line = getline(lnum)
     endwhile
     let folded_lnum = lnum + 1
-    if folded_line =~ s:rule_rx
-      if getline(v:lnum) =~ s:rule_rx
+    if folded_line =~ s:rule_rx && prev_line !~ s:rule_special
+      if getline(v:lnum) =~ s:rule_rx && prev_line !~ s:rule_special
         return 0
       else
         return &ts
       endif
     else
 "    elseif folded_line =~ s:folded_assignment_rx
-      if getline(v:lnum) =~ s:rule_rx
+      if getline(v:lnum) =~ s:rule_rx && prev_line !~ s:rule_special
         return 0
       else
         return indent(folded_lnum)
@@ -98,8 +101,8 @@ function GetMakeIndent()
 "      " TODO: ?
 "      return indent(prev_lnum)
     endif
-  elseif prev_line =~ s:rule_rx
-    if getline(v:lnum) =~ s:rule_rx
+  elseif prev_line =~ s:rule_rx && prev_line !~ s:rule_special
+    if getline(v:lnum) =~ s:rule_rx && prev_line !~ s:rule_special
       return 0
     else
       return &ts

--- a/runtime/indent/testdir/make.in
+++ b/runtime/indent/testdir/make.in
@@ -1,0 +1,20 @@
+# vim:ft=make
+# START_INDENT
+.POSIX :
+MAKEFLAGS += -rR
+
+.SUFFIXES: .F .f
+FC = f95
+FFLAGS =
+CPPFLAGS =
+
+.PHONY: help
+help:
+@echo indentation test
+
+.F.f:
+$(FC) $(CPPFLAGS) -E $< > $@
+
+.f.o:
+$(FC) $(FFLAGS) -c -o $@ $<
+# END_INDENT

--- a/runtime/indent/testdir/make.ok
+++ b/runtime/indent/testdir/make.ok
@@ -1,0 +1,20 @@
+# vim:ft=make
+# START_INDENT
+.POSIX :
+MAKEFLAGS += -rR
+
+.SUFFIXES: .F .f
+FC = f95
+FFLAGS =
+CPPFLAGS =
+
+.PHONY: help
+help:
+	@echo indentation test
+
+.F.f:
+	$(FC) $(CPPFLAGS) -E $< > $@
+
+.f.o:
+	$(FC) $(FFLAGS) -c -o $@ $<
+# END_INDENT


### PR DESCRIPTION
- **vim-patch:7bc9880: runtime(make): do not automatically indent after a special target**
- **vim-patch:229f79c: runtime(yaml): fix wrong order of undo_ftplugin suboptions**
