### PR TITLE
vim-patch:9.1.1337: Undo corrupted with 'completeopt' "preinsert" when switching buffer

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2334,9 +2334,10 @@ static bool set_ctrl_x_mode(const int c)
 static bool ins_compl_stop(const int c, const int prev_mode, bool retval)
 {
   // Remove pre-inserted text when present.
-  if (ins_compl_preinsert_effect()) {
+  if (ins_compl_preinsert_effect() && ins_compl_win_active(curwin)) {
     ins_compl_delete(false);
   }
+
   // Get here when we have finished typing a sequence of ^N and
   // ^P or other completion characters in CTRL-X mode.  Free up
   // memory that was used, and make sure we can redo the insert.


### PR DESCRIPTION
Fix #33581

#### vim-patch:9.1.1337: Undo corrupted with 'completeopt' "preinsert" when switching buffer

Problem:  Undo corrupted with 'completeopt' "preinsert" when switching
          buffer or window.
Solution: Do not delete preinsert text when switching buffer or window.
          (zeertzjq)

closes: vim/vim#17193

https://github.com/vim/vim/commit/1343681aba56d49c16d3070615b8ece7f8b0d1bd