### PR TITLE
docs: add lib to `apt install` for ubuntu/debian

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -294,7 +294,7 @@ Platform-specific requirements are listed below.
 ### Ubuntu / Debian
 
 ```sh
-sudo apt-get install ninja-build gettext cmake curl build-essential
+sudo apt-get install ninja-build gettext cmake curl build-essential libnsl-dev
 ```
 
 ### RHEL / Fedora


### PR DESCRIPTION
Hi!
I've updated command for Ubuntu/Debian - without this lib nvim build failed for Debian testing on my machine.
