### PR TITLE
fix(messages): clear 'showmode' message after insert_expand

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3458,7 +3458,7 @@ static bool ins_esc(int *count, int cmdchar, bool nomove)
     showmode();
   } else if (p_smd && (got_int || !skip_showmode())
              && !(p_ch == 0 && !ui_has(kUIMessages))) {
-    msg("", 0);
+    unshowmode(false);
   }
   // Exit Insert mode
   return true;

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -82,7 +82,7 @@ local hl_grid_legacy_c = [[
     {15:return} {26:0};                                                      |
   }                                                                |
   {1:~                                                                }|*2
-                                                                   |
+  14 more lines                                                    |
 ]]
 
 local hl_grid_ts_c = [[
@@ -102,7 +102,7 @@ local hl_grid_ts_c = [[
     {15:return} {26:0};                                                      |
   }                                                                |
   {1:~                                                                }|*2
-                                                                   |
+  {MATCH:1?4? m?o?r?e? l?i?n?e?s?.*}|
 ]]
 
 local test_text_c = [[

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1663,6 +1663,22 @@ stack traceback:
       },
     })
   end)
+
+  it('clears showmode after insert_expand mode', function()
+    feed('i<C-N>')
+    screen:expect({
+      grid = [[
+        ^                         |
+        {1:~                        }|*4
+      ]],
+      showmode = { { '-- Keyword completion (^N^P) ', 5, 11 }, { 'Pattern not found', 9, 6 } },
+    })
+    feed('<Esc>')
+    screen:expect([[
+      ^                         |
+      {1:~                        }|*4
+    ]])
+  end)
 end)
 
 describe('ui/builtin messages', function()


### PR DESCRIPTION
Problem:  'showmode' ext_messages state is not cleared after insert_expand mode.
Solution: Replace empty message with more idiomatic way to clear the showmode.