### PR TITLE
fix(lsp): ensure `bufstate` exists when invoking `vim.lsp.document_color.is_enabled`

### DIFF
--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -175,6 +175,18 @@ end
 local function buf_enable(bufnr)
   reset_bufstate(bufnr, true)
 
+  api.nvim_buf_attach(bufnr, false, {
+    on_reload = function(_, buf)
+      buf_clear(buf)
+      if bufstates[buf].enabled then
+        buf_refresh(buf)
+      end
+    end,
+    on_detach = function(_, buf)
+      buf_disable(buf)
+    end,
+  })
+
   api.nvim_create_autocmd('LspNotify', {
     buffer = bufnr,
     group = document_color_augroup,
@@ -188,25 +200,6 @@ local function buf_enable(bufnr)
       then
         buf_refresh(args.buf, args.data.client_id)
       end
-    end,
-  })
-
-  api.nvim_create_autocmd('LspAttach', {
-    buffer = bufnr,
-    group = document_color_augroup,
-    desc = 'Enable document_color when LSP client attaches',
-    callback = function(args)
-      api.nvim_buf_attach(args.buf, false, {
-        on_reload = function(_, buf)
-          buf_clear(buf)
-          if bufstates[buf].enabled then
-            buf_refresh(buf)
-          end
-        end,
-        on_detach = function(_, buf)
-          buf_disable(buf)
-        end,
-      })
     end,
   })
 

--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -238,7 +238,13 @@ end
 function M.is_enabled(bufnr)
   vim.validate('bufnr', bufnr, 'number', true)
 
-  return bufstates[vim._resolve_bufnr(bufnr)].enabled
+  bufnr = vim._resolve_bufnr(bufnr)
+
+  if not bufstates[bufnr] then
+    reset_bufstate(bufnr, false)
+  end
+
+  return bufstates[bufnr].enabled
 end
 
 --- Enables document highlighting from the given language client in the given buffer.

--- a/test/functional/plugin/lsp/document_color_spec.lua
+++ b/test/functional/plugin/lsp/document_color_spec.lua
@@ -159,6 +159,15 @@ body {
         end)
       )
     end)
+
+    it('does not error when called on a new unattached buffer', function()
+      eq(
+        false,
+        exec_lua(function()
+          return vim.lsp.document_color.is_enabled(vim.api.nvim_create_buf(false, true))
+        end)
+      )
+    end)
   end)
 
   describe('enable()', function()


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

@clason noticed that this could error with a `nil` access error.