### PR TITLE
fix(docs): fix syntax error in Lua snippet for `vim.lsp.document_color`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2167,7 +2167,7 @@ enable({enable}, {bufnr}, {opts})            *vim.lsp.document_color.enable()*
           callback = function(args)
             local client = vim.lsp.get_client_by_id(args.data.client_id)
 
-            if client:supports_method('textDocument/documentColor')
+            if client:supports_method('textDocument/documentColor') then
               vim.lsp.document_color.enable(true, args.buf)
             end
           end

--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -249,7 +249,7 @@ end
 ---   callback = function(args)
 ---     local client = vim.lsp.get_client_by_id(args.data.client_id)
 ---
----     if client:supports_method('textDocument/documentColor')
+---     if client:supports_method('textDocument/documentColor') then
 ---       vim.lsp.document_color.enable(true, args.buf)
 ---     end
 ---   end


### PR DESCRIPTION
9ff1239634 added support for 'textDocument/documentColor' but the text snippet in the Lua docs seem to contain a syntax error.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
