### PR TITLE
vim-patch:9.1.1343: filetype: IPython files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1003,6 +1003,7 @@ local extension = {
   py = 'python',
   pyi = 'python',
   ptl = 'python',
+  ipy = 'python',
   ql = 'ql',
   qll = 'ql',
   qml = 'qml',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -629,7 +629,7 @@ func s:GetFilenameChecks() abort
     \ 'pymanifest': ['MANIFEST.in'],
     \ 'pyret': ['file.arr'],
     \ 'pyrex': ['file.pyx', 'file.pxd', 'file.pxi', 'file.pyx+'],
-    \ 'python': ['file.py', 'file.pyw', '.pythonstartup', '.pythonrc', '.python_history', '.jline-jython.history', 'file.ptl', 'file.pyi', 'SConstruct'],
+    \ 'python': ['file.py', 'file.pyw', '.pythonstartup', '.pythonrc', '.python_history', '.jline-jython.history', 'file.ptl', 'file.pyi', 'SConstruct', 'file.ipy'],
     \ 'ql': ['file.ql', 'file.qll'],
     \ 'qml': ['file.qml', 'file.qbs'],
     \ 'qmldir': ['qmldir'],


### PR DESCRIPTION
Problem:  filetype: IPython files are not recognized
          (user202729)
Solution: detect *.ipy files as python filetype

fixes: vim/vim#17163

https://github.com/vim/vim/commit/e380b5cbba23869b07e17cfc7f4602e2fe681945

Co-authored-by: Christian Brabandt <cb@256bit.org>
