### PR TITLE
vim-patch:35cfc3d: runtime(debversions): Add questing (25.10) as Ubuntu release name

### DIFF
--- a/runtime/syntax/shared/debversions.vim
+++ b/runtime/syntax/shared/debversions.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:     Debian version information
 " Maintainer:   Debian Vim Maintainers
-" Last Change:  2025 Mar 29
+" Last Change:  2025 Apr 24
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/shared/debversions.vim
 
 let s:cpo = &cpo
@@ -11,7 +11,7 @@ let g:debSharedSupportedVersions = [
       \ 'oldstable', 'stable', 'testing', 'unstable', 'experimental', 'sid', 'rc-buggy',
       \ 'bullseye', 'bookworm', 'trixie', 'forky', 'duke',
       \
-      \ 'focal', 'jammy', 'noble', 'oracular', 'plucky',
+      \ 'focal', 'jammy', 'noble', 'oracular', 'plucky', 'questing',
       \ 'devel'
       \ ]
 let g:debSharedUnsupportedVersions = [


### PR DESCRIPTION
closes: vim/vim#17201

https://github.com/vim/vim/commit/35cfc3d3c449eaee97ba2c32cca76134136de5ec

Co-authored-by: James McCoy <jamessan@jamessan.com>
