### PR TITLE
vim-patch:9.1.1346: missing out-of-memory check in textformat.c

### DIFF
--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -355,7 +355,7 @@ void internal_format(int textwidth, int second_indent, int flags, bool format_on
     if (State & VREPLACE_FLAG) {
       // In MODE_VREPLACE state, we will backspace over the text to be
       // wrapped, so save a copy now to put on the next line.
-      saved_text = xstrdup(get_cursor_pos_ptr());
+      saved_text = xstrnsave(get_cursor_pos_ptr(), (size_t)get_cursor_pos_len());
       curwin->w_cursor.col = orig_col;
       saved_text[startcol] = NUL;
 
@@ -547,7 +547,7 @@ static bool same_leader(linenr_T lnum, int leader1_len, char *leader1_flags, int
 
   // Get current line and next line, compare the leaders.
   // The first line has to be saved, only one line can be locked at a time.
-  char *line1 = xstrdup(ml_get(lnum));
+  char *line1 = xstrnsave(ml_get(lnum), (size_t)ml_get_len(lnum));
   for (idx1 = 0; ascii_iswhite(line1[idx1]); idx1++) {}
   char *line2 = ml_get(lnum + 1);
   for (idx2 = 0; idx2 < leader2_len; idx2++) {


### PR DESCRIPTION
#### vim-patch:9.1.1346: missing out-of-memory check in textformat.c

Problem:  missing out-of-memory check in textformat.c
Solution: add out-of-memory check, add small optimizations to
          internal_format() and same_leader() (John Marriott)

closes: vim/vim#17200

https://github.com/vim/vim/commit/c25368ba14a7135b685ba3d6941f26bc630a2501

Co-authored-by: John Marriott <basilisk@internode.on.net>