### PR TITLE
refactor(lsp): use `opts.handler` from `_refresh` instead of public `inlay_hint` handler

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -223,11 +223,6 @@ RCS[ms.textDocument_codeLens] = function(...)
   return vim.lsp.codelens.on_codelens(...)
 end
 
---- @private
-RCS[ms.textDocument_inlayHint] = function(...)
-  return vim.lsp.inlay_hint.on_inlayhint(...)
-end
-
 --- Return a function that converts LSP responses to list items and opens the list
 ---
 --- The returned function has an optional {config} parameter that accepts |vim.lsp.ListOpts|

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -85,7 +85,7 @@ end
 
 --- |lsp-handler| for the method `workspace/inlayHint/refresh`
 ---@param ctx lsp.HandlerContext
----@private
+---@nodoc
 function M.on_refresh(err, _, ctx)
   if err then
     return vim.NIL
@@ -229,13 +229,13 @@ end
 
 --- Refresh inlay hints, only if we have attached clients that support it
 ---@param bufnr (integer) Buffer handle, or 0 for current
----@param opts? vim.lsp.util._refresh.Opts Additional options to pass to util._refresh
----@private
-local function _refresh(bufnr, opts)
-  opts = opts or {}
-  opts['bufnr'] = bufnr
-  opts.handler = on_inlayhint
-  util._refresh(ms.textDocument_inlayHint, opts)
+---@param client_id? (integer) Client ID
+local function _refresh(bufnr, client_id)
+  util._refresh(ms.textDocument_inlayHint, {
+    bufnr = bufnr,
+    handler = on_inlayhint,
+    client_id = client_id,
+  })
 end
 
 --- Enable inlay hints for a buffer
@@ -259,7 +259,7 @@ api.nvim_create_autocmd('LspNotify', {
       return
     end
     if bufstates[bufnr].enabled then
-      _refresh(bufnr, { client_id = args.data.client_id })
+      _refresh(bufnr, args.data.client_id)
     end
   end,
   group = augroup,

--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -36,8 +36,7 @@ local augroup = api.nvim_create_augroup('nvim.lsp.inlayhint', {})
 --- Store hints for a specific buffer and client
 ---@param result lsp.InlayHint[]?
 ---@param ctx lsp.HandlerContext
----@private
-function M.on_inlayhint(err, result, ctx)
+local function on_inlayhint(err, result, ctx)
   if err then
     log.error('inlayhint', err)
     return
@@ -96,7 +95,7 @@ function M.on_refresh(err, _, ctx)
       if api.nvim_win_get_buf(winid) == bufnr then
         if bufstates[bufnr] and bufstates[bufnr].enabled then
           bufstates[bufnr].applied = {}
-          util._refresh(ms.textDocument_inlayHint, { bufnr = bufnr })
+          util._refresh(ms.textDocument_inlayHint, { bufnr = bufnr, handler = on_inlayhint })
         end
       end
     end
@@ -235,6 +234,7 @@ end
 local function _refresh(bufnr, opts)
   opts = opts or {}
   opts['bufnr'] = bufnr
+  opts.handler = on_inlayhint
   util._refresh(ms.textDocument_inlayHint, opts)
 end
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

Bringing a couple of improvements that @lewis6991 suggested in #33440.