### PR TITLE
vim-patch:c5cb6b2: runtime(doc): tagfunc should refer to 'complete' option

### DIFF
--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -907,7 +907,7 @@ Currently up to three flags may be passed to the tag function:
 	        (mnemonic: the tag function may use the context around the
 		cursor to perform a better job of generating the tag list.)
   'i'		In Insert mode, the user was completing a tag (with
-		|i_CTRL-X_CTRL-]| or 'completeopt' contains `t`).
+		|i_CTRL-X_CTRL-]| or 'complete' contains "`t`" or "`]`").
   'r'		The first argument to tagfunc should be interpreted as a
 		|pattern| (see |tag-regexp|), such as when using: >
 		  :tag /pat


### PR DESCRIPTION
#### vim-patch:c5cb6b2: runtime(doc): tagfunc should refer to 'complete' option

https://github.com/vim/vim/commit/c5cb6b2ee4af5d8199123015e1519e3c8769a11f

Co-authored-by: Christian Brabandt <cb@256bit.org>