### PR TITLE
feat(on_yank): add vim.hl.enable_on_yank function

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -590,6 +590,22 @@ A subset of the `vim.*` stdlib is available in threads, including:
 ==============================================================================
 VIM.HL                                                                *vim.hl*
 
+vim.hl.enable_on_yank({opts})                        *vim.hl.enable_on_yank()*
+    Enable automatic highlighting of the yanked text during |TextYankPost|
+    events.
+
+    Equivalent to: >lua
+        vim.api.nvim_create_autocmd("TextYankPost", {
+          group = nvim.api.nvim_create_augroup("nvim.hl.enable_on_yank", {}),
+          callback = function()
+            vim.hl.on_yank(opts)
+          end,
+        })
+<
+
+    Parameters: ~
+      • {opts}  (`table?`) See |vim.hl.on_yank|
+
 vim.hl.on_yank({opts})                                      *vim.hl.on_yank()*
     Highlight the yanked text during a |TextYankPost| event.
 

--- a/runtime/lua/vim/hl.lua
+++ b/runtime/lua/vim/hl.lua
@@ -198,4 +198,27 @@ function M.on_yank(opts)
   })
 end
 
+--- Enable automatic highlighting of the yanked text during |TextYankPost| events.
+---
+--- Equivalent to:
+---
+--- ```lua
+--- vim.api.nvim_create_autocmd("TextYankPost", {
+---   group = nvim.api.nvim_create_augroup("nvim.hl.enable_on_yank", {}),
+---   callback = function()
+---     vim.hl.on_yank(opts)
+---   end,
+--- })
+--- ```
+---
+--- @param opts table|nil See |vim.hl.on_yank|
+function M.enable_on_yank(opts)
+  vim.api.nvim_create_autocmd('TextYankPost', {
+    group = vim.api.nvim_create_augroup('nvim.hl.enable_on_yank', {}),
+    callback = function()
+      M.on_yank(opts)
+    end,
+  })
+end
+
 return M


### PR DESCRIPTION
Setting up on-yank highlighting in Lua is rather verbose, and a very common config option.

The new `vim.hl.enable_on_yank` function abstracts away the autocmd setup and is the equivalent of the recommended Vimscript line in `vim.hl.on_yank`. This allows a one-line config in Lua and brings it on par to the Vimscript one-liner.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
