### PR TITLE
feat(api): 'vim.api.nvim_eval_statusline' now accepts a 'default' opt

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -667,6 +667,8 @@ nvim_eval_statusline({str}, {opts})                   *nvim_eval_statusline()*
     Parameters: ~
       • {str}   Statusline string (see 'statusline').
       • {opts}  Optional parameters.
+                • default: (boolean) Use the default statusline, winbar,
+                  tabline, or statuscol.
                 • winid: (number) |window-ID| of the window to use as context
                   for statusline.
                 • maxwidth: (number) Maximum width of statusline.

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1125,6 +1125,7 @@ function vim.api.nvim_eval(expr) end
 ---
 --- @param str string Statusline string (see 'statusline').
 --- @param opts vim.api.keyset.eval_statusline Optional parameters.
+--- - default: (boolean) Use the default statusline, winbar, tabline, or statuscol.
 --- - winid: (number) `window-ID` of the window to use as context for statusline.
 --- - maxwidth: (number) Maximum width of statusline.
 --- - fillchar: (string) Character to fill blank spaces in the statusline (see

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -95,6 +95,7 @@ error('Cannot require a meta file')
 
 --- @class vim.api.keyset.eval_statusline
 --- @field winid? integer
+--- @field default? boolean
 --- @field maxwidth? integer
 --- @field fillchar? string
 --- @field highlights? boolean

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -145,6 +145,7 @@ typedef struct {
 typedef struct {
   OptionalKeys is_set__eval_statusline_;
   Window winid;
+  Boolean default_ DictKey(default);
   Integer maxwidth;
   String fillchar;
   Boolean highlights;


### PR DESCRIPTION
Fixes: #28444

This PR implements default value options for `nvim_eval_statusline`. Passing `default = true` will look up the default option derived from `options.lua` and return either the status line, tab line, win bar, or status column. The validation of mutual exclusivity is done later in the function, but this does assert that the user passes in an empty string.

I opted to use `default = true` instead of an empty string here doing default by default in case for some reason someone wanted to actually evaluate an empty string.
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
