### PR TITLE
vim-patch:partial:fbe4a8f: runtime(doc): Fix notation of "Vim script" and "Vim9 script"

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -264,7 +264,7 @@ D. If your filetype can only be detected by inspecting the contents of the
       item of the 'runtimepath' option.  Example for Unix: >
 	:!mkdir -p ~/.config/nvim
 <
-   2. Create a vim script file for doing this.  Example: >
+   2. Create a Vim script file for doing this.  Example: >
 	if did_filetype()	" filetype already set..
 	  finish		" ..don't do these checks
 	endif

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -2663,7 +2663,7 @@ fun! netrw#NetWrite(...) range
 endfun
 
 " ---------------------------------------------------------------------
-" netrw#NetSource: source a remotely hosted vim script {{{2
+" netrw#NetSource: source a remotely hosted Vim script {{{2
 " uses NetRead to get a copy of the file into a temporarily file,
 "              then sources that file,
 "              then removes that file.

--- a/runtime/pack/dist/opt/netrw/doc/netrw.txt
+++ b/runtime/pack/dist/opt/netrw/doc/netrw.txt
@@ -467,7 +467,7 @@ file using root-relative paths, use the full path:
 ==============================================================================
 4. Network-Oriented File Transfer			*netrw-xfer* {{{1
 
-Network-oriented file transfer under Vim is implemented by a vim script
+Network-oriented file transfer under Vim is implemented by a Vim script
 (<netrw.vim>) using plugin techniques.  It currently supports both reading and
 writing across networks using rcp, scp, ftp or ftp+<.netrc>, scp, fetch,
 dav/cadaver, rsync, or sftp.

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -1481,7 +1481,7 @@ syn match	vim9SearchDelim	'^\s*\zs:[/?]\|[/?]$'	contained contains=vimCmdSep
 syn region	vimGlobal	matchgroup=Statement start='\<g\%[lobal]!\=/'  skip='\\.' end='/'	skipwhite nextgroup=vimSubst1
 syn region	vimGlobal	matchgroup=Statement start='\<v\%[global]!\=/' skip='\\.' end='/'	skipwhite nextgroup=vimSubst1
 
-" Vim9 Script Regions: {{{2
+" Vim9 script Regions: {{{2
 " ==================
 
 if s:vim9script

--- a/test/old/testdir/test_source.vim
+++ b/test/old/testdir/test_source.vim
@@ -59,12 +59,11 @@ func Test_different_script()
   call assert_fails('source XtwoScript', 'E121:')
 endfunc
 
-" When sourcing a vim script, shebang should be ignored.
+" When sourcing a Vim script, shebang should be ignored.
 func Test_source_ignore_shebang()
-  call writefile(['#!./xyzabc', 'let g:val=369'], 'Xfile.vim')
-  source Xfile.vim
+  call writefile(['#!./xyzabc', 'let g:val=369'], 'Xsisfile.vim', 'D')
+  source Xsisfile.vim
   call assert_equal(g:val, 369)
-  call delete('Xfile.vim')
 endfunc
 
 " Test for expanding <sfile> in a autocmd and for <slnum> and <sflnum>
@@ -415,7 +414,7 @@ func Test_source_buffer_vim9()
   source
   call assert_equal(10, Xtestfunc())
 
-  " test for sourcing a vim9 script with line continuation
+  " test for sourcing a Vim9 script with line continuation
   %d _
   let lines =<< trim END
      vim9script


### PR DESCRIPTION
#### vim-patch:partial:fbe4a8f: runtime(doc): Fix notation of "Vim script" and "Vim9 script"

closes: vim/vim#17213

https://github.com/vim/vim/commit/fbe4a8f5c0fbaa99ffa5b67081c10c85bc88a91a

Cherry-pick Test_source_ignore_shebang() change from patch 9.0.0363.

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>