### PR TITLE
fix(lua): vim.validate `message` param

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -475,7 +475,8 @@ lsp.config = setmetatable({ _configs = {} }, {
   --- @param cfg vim.lsp.Config
   __newindex = function(self, name, cfg)
     validate_config_name(name)
-    validate('cfg', cfg, 'table')
+    local msg = ('table (hint: to resolve a config, use vim.lsp.config["%s"])'):format(name)
+    validate('cfg', cfg, 'table', msg)
     invalidate_enabled_config(name)
     self._configs[name] = cfg
   end,
@@ -485,7 +486,8 @@ lsp.config = setmetatable({ _configs = {} }, {
   --- @param cfg vim.lsp.Config
   __call = function(self, name, cfg)
     validate_config_name(name)
-    validate('cfg', cfg, 'table')
+    local msg = ('table (hint: to resolve a config, use vim.lsp.config["%s"])'):format(name)
+    validate('cfg', cfg, 'table', msg)
     invalidate_enabled_config(name)
     self[name] = vim.tbl_deep_extend('force', self._configs[name] or {}, cfg)
   end,

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -865,7 +865,7 @@ do
   --- @param param_name string
   --- @param val any
   --- @param validator vim.validate.Validator
-  --- @param message? string
+  --- @param message? string "Expected" message
   --- @param allow_alias? boolean Allow short type names: 'n', 's', 't', 'b', 'f', 'c'
   --- @return string?
   local function is_valid(param_name, val, validator, message, allow_alias)
@@ -877,18 +877,18 @@ do
       end
 
       if not is_type(val, expected) then
-        return string.format('%s: expected %s, got %s', param_name, expected, type(val))
+        return ('%s: expected %s, got %s'):format(param_name, message or expected, type(val))
       end
     elseif vim.is_callable(validator) then
       -- Check user-provided validation function
       local valid, opt_msg = validator(val)
       if not valid then
-        local err_msg =
-          string.format('%s: expected %s, got %s', param_name, message or '?', tostring(val))
-
-        if opt_msg then
-          err_msg = string.format('%s. Info: %s', err_msg, opt_msg)
-        end
+        local err_msg = ('%s: expected %s, got %s'):format(
+          param_name,
+          message or '?',
+          tostring(val)
+        )
+        err_msg = opt_msg and ('%s. Info: %s'):format(err_msg, opt_msg) or err_msg
 
         return err_msg
       end

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1556,10 +1556,15 @@ describe('lua stdlib', function()
       pcall_err(exec_lua, "vim.validate('arg1', nil, {'number', 'string'})")
     )
 
-    -- Pass an additional message back.
+    -- Validator func can return an extra "Info" message.
     matches(
       'arg1: expected %?, got 3. Info: TEST_MSG',
       pcall_err(exec_lua, "vim.validate('arg1', 3, function(a) return a == 1, 'TEST_MSG' end)")
+    )
+    -- Caller can override the "expected" message.
+    eq(
+      'arg1: expected TEST_MSG, got nil',
+      pcall_err(exec_lua, "vim.validate('arg1', nil, 'table', 'TEST_MSG')")
     )
   end)
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -6313,7 +6313,7 @@ describe('LSP', function()
   end)
 
   describe('vim.lsp.config() and vim.lsp.enable()', function()
-    it('can merge settings from "*"', function()
+    it('merges settings from "*"', function()
       eq(
         {
           name = 'foo',
@@ -6325,6 +6325,15 @@ describe('LSP', function()
           vim.lsp.config('foo', { cmd = { 'foo' } })
 
           return vim.lsp.config['foo']
+        end)
+      )
+    end)
+
+    it('config("bogus") shows a hint', function()
+      matches(
+        'hint%: to resolve a config',
+        pcall_err(exec_lua, function()
+          vim.print(vim.lsp.config('non-existent-config'))
         end)
       )
     end)
@@ -6650,21 +6659,18 @@ describe('LSP', function()
           local _ = vim.lsp.config['foo*']
         end)
       )
-
       matches(
         err,
         pcall_err(exec_lua, function()
           vim.lsp.config['foo*'] = {}
         end)
       )
-
       matches(
         err,
         pcall_err(exec_lua, function()
           vim.lsp.config('foo*', {})
         end)
       )
-
       -- Exception for '*'
       pcall(exec_lua, function()
         vim.lsp.config('*', {})


### PR DESCRIPTION
Problem:
vim.validate does not handle `message` param.

Solution:
Add the missing logic.