### PR TITLE
fix: remove unnecessary `nvim -l` from `gen` command

### DIFF
--- a/src/gen/gen_lsp.lua
+++ b/src/gen/gen_lsp.lua
@@ -7,7 +7,7 @@ Generates lua-ls annotations for lsp.
 Also updates types in runtime/lua/vim/lsp/protocol.lua
 
 Usage:
-  nvim -l src/gen/gen_lsp.lua [options]
+  src/gen/gen_lsp.lua [options]
 
 Options:
   --version <version>  LSP version to use (default: 3.18)


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

Followup from https://github.com/neovim/neovim/pull/33660#discussion_r2062497822