### PR TITLE
fix(lsp): fallback to empty `capability_path` in `supports_registration`

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -840,7 +840,7 @@ end
 --- Get options for a method that is registered dynamically.
 --- @param method vim.lsp.protocol.Method
 function Client:_supports_registration(method)
-  local capability_path = lsp.protocol._request_name_to_client_capability[method]
+  local capability_path = lsp.protocol._request_name_to_client_capability[method] or {}
   local capability = vim.tbl_get(self.capabilities, unpack(capability_path))
   return type(capability) == 'table' and capability.dynamicRegistration
 end

--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -99,7 +99,6 @@ local function reset_bufstate(bufnr, enabled)
     processed_version = {},
     applied_version = {},
     hl_info = {},
-    ns = {},
   }
 end
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

First commit is a nit from https://github.com/neovim/neovim/pull/33656, and the second one is the true fix (follow-up from https://github.com/neovim/neovim/pull/33660) as I'm now seeing this appear in my LSP log:
```
[ERROR][2025-04-27 10:11:45] ...m/lsp/client.lua:1057	"LSP[css_variables]"	"on_error"	{ code = "SERVER_REQUEST_HANDLER_ERROR", err = "...josolano/.nvim/share/nvim/runtime/lua/vim/lsp/client.lua:844: bad argument #1 to 'unpack' (table expected, got nil)" }
```