### PR TITLE
vim-patch:b9ffbf5: runtime(vim): Update base-syntax, fix inline Vim9 dict comments at SOL

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -337,7 +337,7 @@ Vim9 syn match 	vimAugroup	"\<aug\%[roup]\>\ze\s*\%([#|]\|$\)"	skipwhite nextgro
 
 " Operators: {{{2
 " =========
-syn cluster	vimOperGroup	contains=@vimContinue,@vimExprList,vim9Comment,vimContinueString
+syn cluster	vimOperGroup	contains=@vimContinue,@vimExprList,vim9Comment,vim9LineComment,vimContinueString
 syn match	vimOper	"\a\@<!!"			skipwhite skipnl nextgroup=@vimOperContinue,@vimExprList,vimSpecFile
 syn match	vimOper	"||\|&&\|[-+*/%.]"		skipwhite skipnl nextgroup=@vimOperContinue,@vimExprList,vimSpecFile
 syn match	vimOper	"?"			skipwhite skipnl nextgroup=@vimOperContinue,@vimExprList,vimContinueString


### PR DESCRIPTION
#### vim-patch:b9ffbf5: runtime(vim): Update base-syntax, fix inline Vim9 dict comments at SOL

Match Vim9 comments at start-of-line (no leading whitespace) in
dictionaries, lists and parenthesised expressions and argument lists.

Addresses https://github.com/vim/vim/pull/14975#issuecomment-2832643115

Report and fix by Aliaksei Budavei.

closes: vim/vim#17211

https://github.com/vim/vim/commit/b9ffbf57f86e7b78021e2c8899ee0aa06966ddf5

Co-authored-by: Doug Kearns <dougkearns@gmail.com>