### PR TITLE
fix(lsp): Don't show clients with empty content in hover

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -61,11 +61,16 @@ function M.hover(config)
     local results1 = {} --- @type table<integer,lsp.Hover>
 
     for client_id, resp in pairs(results) do
+      --- @type lsp.ResponseError, lsp.Hover
       local err, result = resp.err, resp.result
       if err then
         lsp.log.error(err.code, err.message)
       elseif result then
-        results1[client_id] = result
+        -- Ensure that there is some non-empty content to display
+        local contents = result.contents
+        if type(contents) == 'string' or #vim.tbl_keys(contents) > 0 then
+          results1[client_id] = result
+        end
       end
     end
 


### PR DESCRIPTION
*Problem*:
LSP clients that produced no content are being shown in the hover summary (e.g. the client name is shown with no results).

Example of the problem - Typescript with multiple clients (`vtsls` and `graphql`) with empty section for `graphql`:

<img width="589" alt="image" src="https://github.com/user-attachments/assets/3d5b9ecf-13cf-47da-ab9f-a1ca8b45e981" />

Another example where both servers have empty results:

<img width="171" alt="image" src="https://github.com/user-attachments/assets/d1ff3b24-5c76-4935-af51-5816733f9377" />

*Solution*:
This PR hides clients with no content in the hover summary.


<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
