### PR TITLE
feat(ui): no delay for errors with ext_messages

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1954,7 +1954,7 @@ buf_T *buflist_new(char *ffname_arg, char *sfname_arg, linenr_T lnum, int flags)
     pmap_put(int)(&buffer_handles, buf->b_fnum, buf);
     if (top_file_num < 0) {  // wrap around (may cause duplicates)
       emsg(_("W14: Warning: List of file names overflow"));
-      if (emsg_silent == 0 && !in_assert_fails) {
+      if (emsg_silent == 0 && !in_assert_fails && !ui_has(kUIMessages)) {
         ui_flush();
         os_delay(3001, true);  // make sure it is noticed
       }

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -94,7 +94,7 @@ void change_warning(buf_T *buf, int col)
     set_vim_var_string(VV_WARNINGMSG, _(w_readonly), -1);
     msg_clr_eos();
     msg_end();
-    if (msg_silent == 0 && !silent_mode && ui_active()) {
+    if (msg_silent == 0 && !silent_mode && ui_active() && !ui_has(kUIMessages)) {
       ui_flush();
       os_delay(1002, true);  // give the user time to think about it
     }
@@ -133,7 +133,7 @@ void changed(buf_T *buf)
       // Wait two seconds, to make sure the user reads this unexpected
       // message.  Since we could be anywhere, call wait_return() now,
       // and don't let the emsg() set msg_scroll.
-      if (need_wait_return && emsg_silent == 0 && !in_assert_fails) {
+      if (need_wait_return && emsg_silent == 0 && !in_assert_fails && !ui_has(kUIMessages)) {
         ui_flush();
         os_delay(2002, true);
         wait_return(true);

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -3041,7 +3041,7 @@ int buf_check_timestamp(buf_T *buf)
         }
         msg_clr_eos();
         msg_end();
-        if (emsg_silent == 0 && !in_assert_fails) {
+        if (emsg_silent == 0 && !in_assert_fails && !ui_has(kUIMessages)) {
           ui_flush();
           // give the user some time to think about it
           os_delay(1004, true);

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -492,13 +492,14 @@ bool check_compl_option(bool dict_opt)
          && *curbuf->b_p_tsrfu == NUL && *p_tsrfu == NUL)) {
     ctrl_x_mode = CTRL_X_NORMAL;
     edit_submode = NULL;
-    msg((dict_opt ? _("'dictionary' option is empty") : _("'thesaurus' option is empty")),
-        HLF_E);
+    emsg(dict_opt ? _("'dictionary' option is empty") : _("'thesaurus' option is empty"));
     if (emsg_silent == 0 && !in_assert_fails) {
       vim_beep(kOptBoFlagComplete);
       setcursor();
-      ui_flush();
-      os_delay(2004, false);
+      if (!ui_has(kUIMessages)) {
+        ui_flush();
+        os_delay(2004, false);
+      }
     }
     return false;
   }

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -3838,9 +3838,7 @@ int vim_dialog_yesnoallcancel(int type, char *title, char *message, int dflt)
 void msg_check_for_delay(bool check_msg_scroll)
 {
   if ((emsg_on_display || (check_msg_scroll && msg_scroll))
-      && !did_wait_return
-      && emsg_silent == 0
-      && !in_assert_fails) {
+      && !did_wait_return && emsg_silent == 0 && !in_assert_fails && !ui_has(kUIMessages)) {
     ui_flush();
     os_delay(1006, true);
     emsg_on_display = false;

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -700,10 +700,12 @@ static void normal_redraw_mode_message(NormalState *s)
   setcursor();
   ui_cursor_shape();                  // show different cursor shape
   ui_flush();
-  if (msg_scroll || emsg_on_display) {
+  if (!ui_has(kUIMessages) && (msg_scroll || emsg_on_display)) {
     os_delay(1003, true);            // wait at least one second
   }
-  os_delay(3003, false);             // wait up to three seconds
+  if (ui_has(kUIMessages)) {
+    os_delay(3003, false);           // wait up to three seconds
+  }
   State = save_State;
 
   msg_scroll = false;

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -740,7 +740,7 @@ void do_tag(char *tag, int type, int count, int forceit, bool verbose)
         } else {
           give_warning(IObuff, ic);
         }
-        if (ic && !msg_scrolled && msg_silent == 0) {
+        if (ic && !msg_scrolled && msg_silent == 0 && !ui_has(kUIMessages)) {
           ui_flush();
           os_delay(1007, true);
         }
@@ -2965,7 +2965,7 @@ static int jumpto_tag(const char *lbuf_arg, int forceit, bool keep_help)
           // is set and match found while ignoring case.
           if (found == 2 || !save_p_ic) {
             msg(_("E435: Couldn't find tag, just guessing!"), 0);
-            if (!msg_scrolled && msg_silent == 0) {
+            if (!msg_scrolled && msg_silent == 0 && !ui_has(kUIMessages)) {
               ui_flush();
               os_delay(1010, true);
             }

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -2334,7 +2334,8 @@ func Test_thesaurusfunc_callback()
     new
     call setline(1, 'sun')
     LET g:TsrFunc1Args = []
-    call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")
+    " Nvim: message is an actual error rather than message with error highlight
+    silent! call feedkeys("A\<C-X>\<C-T>\<Esc>", "x")
     call assert_equal('sun', getline(1))
     call assert_equal([], g:TsrFunc1Args)
     set thesaurusfunc=function('g:TsrFunc1',\ [23])


### PR DESCRIPTION
Problem:  Delay for reading a message may be unwanted for ext_messages,
          and can be done by the implementation. Empty completion source
          error message is not distinguishable as such.
Solution: Only delay without ext_messages enabled. Emit empty completion
          source message as an error.