### PR TITLE
feat(defaults): window navigation key maps

### DIFF
--- a/runtime/example_init.lua
+++ b/runtime/example_init.lua
@@ -47,16 +47,6 @@ vim.o.confirm = true
 -- Use <Esc> to exit terminal mode
 vim.keymap.set('t', '<Esc>', '<C-\\><C-n>')
 
--- Map <A-j>, <A-k>, <A-h>, <A-l> to navigate between windows in any modes
-vim.keymap.set({ 't', 'i' }, '<A-h>', '<C-\\><C-n><C-w>h')
-vim.keymap.set({ 't', 'i' }, '<A-j>', '<C-\\><C-n><C-w>j')
-vim.keymap.set({ 't', 'i' }, '<A-k>', '<C-\\><C-n><C-w>k')
-vim.keymap.set({ 't', 'i' }, '<A-l>', '<C-\\><C-n><C-w>l')
-vim.keymap.set({ 'n' }, '<A-h>', '<C-w>h')
-vim.keymap.set({ 'n' }, '<A-j>', '<C-w>j')
-vim.keymap.set({ 'n' }, '<A-k>', '<C-w>k')
-vim.keymap.set({ 'n' }, '<A-l>', '<C-w>l')
-
 -- [[ Basic Autocommands ]].
 -- See `:h lua-guide-autocommands`, `:h autocmd`, `:h nvim_create_autocmd()`
 

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -432,6 +432,18 @@ do
       return 'g@l'
     end, { expr = true, desc = 'Add empty line below cursor' })
   end
+
+  --- Window navigation
+  do
+    vim.keymap.set({ 't', 'i' }, '<A-h>', '<C-\\><C-n><C-w>h', { desc = 'Move to left window' })
+    vim.keymap.set({ 't', 'i' }, '<A-j>', '<C-\\><C-n><C-w>j', { desc = 'Move to down window' })
+    vim.keymap.set({ 't', 'i' }, '<A-k>', '<C-\\><C-n><C-w>k', { desc = 'Move to up window' })
+    vim.keymap.set({ 't', 'i' }, '<A-l>', '<C-\\><C-n><C-w>l', { desc = 'Move to right window' })
+    vim.keymap.set({ 'n' }, '<A-h>', '<C-w>h', { desc = 'Move to left window' })
+    vim.keymap.set({ 'n' }, '<A-j>', '<C-w>j', { desc = 'Move to down window' })
+    vim.keymap.set({ 'n' }, '<A-k>', '<C-w>k', { desc = 'Move to up window' })
+    vim.keymap.set({ 'n' }, '<A-l>', '<C-w>l', { desc = 'Move to right window' })
+  end
 end
 
 --- Default menus


### PR DESCRIPTION
**Problem**: default <C-w> + HJKL is not an ergonomic way to navigate split windows

**Solution**: set default mappings to navigate with <kbd>alt/option</kbd> + HJKL

**Context**: Following this [comment](https://github.com/neovim/neovim/pull/33524#discussion_r2062650613)