### PR TITLE
test(lua/secure_spec): avoid magic number

### DIFF
--- a/test/functional/lua/secure_spec.lua
+++ b/test/functional/lua/secure_spec.lua
@@ -47,7 +47,8 @@ describe('vim.secure', function()
       })
 
       local cwd = fn.getcwd()
-      if #cwd + 23 > 500 then
+      local msg = cwd .. pathsep .. 'Xfile is not trusted.'
+      if #msg >= screen._width then
         pending('path too long')
         return
       end
@@ -59,7 +60,7 @@ describe('vim.secure', function()
         {1:~{MATCH: +}}|*3
         {2:{MATCH: +}}|
         :lua vim.secure.read('Xfile'){MATCH: +}|
-        {3:]] .. cwd .. pathsep .. [[Xfile is not trusted.}{MATCH: +}|
+        {3:]] .. msg .. [[}{MATCH: +}|
         {3:[i]gnore, (v)iew, (d)eny, (a)llow: }^{MATCH: +}|
       ]])
       feed('d')
@@ -81,7 +82,7 @@ describe('vim.secure', function()
         {1:~{MATCH: +}}|*3
         {2:{MATCH: +}}|
         :lua vim.secure.read('Xfile'){MATCH: +}|
-        {3:]] .. cwd .. pathsep .. [[Xfile is not trusted.}{MATCH: +}|
+        {3:]] .. msg .. [[}{MATCH: +}|
         {3:[i]gnore, (v)iew, (d)eny, (a)llow: }^{MATCH: +}|
       ]])
       feed('a')
@@ -104,7 +105,7 @@ describe('vim.secure', function()
         {1:~{MATCH: +}}|*3
         {2:{MATCH: +}}|
         :lua vim.secure.read('Xfile'){MATCH: +}|
-        {3:]] .. cwd .. pathsep .. [[Xfile is not trusted.}{MATCH: +}|
+        {3:]] .. msg .. [[}{MATCH: +}|
         {3:[i]gnore, (v)iew, (d)eny, (a)llow: }^{MATCH: +}|
       ]])
       feed('i')
@@ -123,7 +124,7 @@ describe('vim.secure', function()
         {1:~{MATCH: +}}|*3
         {2:{MATCH: +}}|
         :lua vim.secure.read('Xfile'){MATCH: +}|
-        {3:]] .. cwd .. pathsep .. [[Xfile is not trusted.}{MATCH: +}|
+        {3:]] .. msg .. [[}{MATCH: +}|
         {3:[i]gnore, (v)iew, (d)eny, (a)llow: }^{MATCH: +}|
       ]])
       feed('v')


### PR DESCRIPTION
Avoid magic number in skipping condition by moving the expected message
to a variable.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
