### PR TITLE
Start and stop LSPs as necessary during `vim.lsp.enable`

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -577,21 +577,32 @@ function lsp.enable(name, enable)
   end
 
   if not next(lsp._enabled_configs) then
+    -- If there are no remaining LSPs enabled, remove the enable autocmd.
     if lsp_enable_autocmd_id then
       api.nvim_del_autocmd(lsp_enable_autocmd_id)
       lsp_enable_autocmd_id = nil
     end
-    return
+  else
+    -- Only ever create autocmd once to reuse computation of config merging.
+    lsp_enable_autocmd_id = lsp_enable_autocmd_id
+      or api.nvim_create_autocmd('FileType', {
+        group = api.nvim_create_augroup('nvim.lsp.enable', {}),
+        callback = function(args)
+          lsp_enable_callback(args.buf)
+        end,
+      })
   end
 
-  -- Only ever create autocmd once to reuse computation of config merging.
-  lsp_enable_autocmd_id = lsp_enable_autocmd_id
-    or api.nvim_create_autocmd('FileType', {
-      group = api.nvim_create_augroup('nvim.lsp.enable', {}),
-      callback = function(args)
-        lsp_enable_callback(args.buf)
-      end,
-    })
+  -- Ensure any pre-existing buffers start/stop their LSP clients.
+  if enable ~= false then
+    vim.api.nvim_command('doautoall nvim.lsp.enable FileType')
+  else
+    for _, nm in ipairs(names) do
+      for _, client in ipairs(lsp.get_clients({ name = nm })) do
+        client:stop()
+      end
+    end
+  end
 end
 
 --- @class vim.lsp.start.Opts


### PR DESCRIPTION
IIUC, the intent `vim.lsp.enable` is for it to be called once early during startup. However, I have a noisy LSP that I'd like to be able to turn off when it's distracting and on when it's useful. I want this enable/disabling to affect all current and future buffers, and `vim.lsp.enable` seems like a reasonable place to put that logic.

fixes https://github.com/neovim/neovim/issues/33701
fixes https://github.com/neovim/neovim/issues/33116

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
