### PR TITLE
feat(lsp): vim.lsp.is_enabled()

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1085,6 +1085,15 @@ get_log_path()                                        *vim.lsp.get_log_path()*
     Return: ~
         (`string`) path to log file
 
+is_enabled({name})                                      *vim.lsp.is_enabled()*
+    Checks if the given LSP config is enabled (globally, not per-buffer).
+
+    Parameters: ~
+      • {name}  (`string`) Config name
+
+    Return: ~
+        (`boolean`)
+
 omnifunc({findstart}, {base})                             *vim.lsp.omnifunc()*
     Implements 'omnifunc' compatible LSP completion.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -109,6 +109,8 @@ API
 • |vim.secure.read()| now returns `true` for trusted directories. Previously
   it would return `nil`, which made it impossible to tell if the directory was
   actually trusted.
+• Added |vim.lsp.is_enabled()| to check if a given LSP config has been enabled
+  by |vim.lsp.enable()|.
 
 BUILD
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -635,6 +635,14 @@ function lsp.enable(name, enable)
   end
 end
 
+--- Checks if the given LSP config is enabled (globally, not per-buffer).
+---
+--- @param name string Config name
+--- @return boolean
+function lsp.is_enabled(name)
+  return lsp._enabled_configs[name] ~= nil
+end
+
 --- @class vim.lsp.start.Opts
 --- @inlinedoc
 ---

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -6680,4 +6680,26 @@ describe('LSP', function()
       markers_resolve_to({ 'foo', { 'bar', 'baz' }, 'marker_d' }, dir_b)
     end)
   end)
+
+  describe('vim.lsp.is_enabled()', function()
+    it('works', function()
+      exec_lua(function()
+        vim.lsp.config('foo', {
+          cmd = { 'foo' },
+          root_markers = { '.foorc' },
+        })
+      end)
+
+      -- LSP config defaults to disabled.
+      eq(false, exec_lua([[return vim.lsp.is_enabled('foo')]]))
+
+      -- Confirm we can enable it.
+      exec_lua([[vim.lsp.enable('foo')]])
+      eq(true, exec_lua([[return vim.lsp.is_enabled('foo')]]))
+
+      -- And finally, disable it again.
+      exec_lua([[vim.lsp.enable('foo', false)]])
+      eq(false, exec_lua([[return vim.lsp.is_enabled('foo')]]))
+    end)
+  end)
 end)


### PR DESCRIPTION
Justification: I want to be able to toggle some LSPs on/off (see https://github.com/neovim/neovim/pull/33702), and I'd like to be able to do that without having to reach into `lsp.lua` internals like `lsp._enabled_configs`.