### PR TITLE
docs: default mappings

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -714,10 +714,13 @@ list of the current window.
 			omitted the current entry is used.
 			Also see |++opt| and |+cmd|.
 
-:[count]n[ext] [++opt] [+cmd]			*:n* *:ne* *:next* *]a* *E165* *E163*
+:[count]n[ext] [++opt] [+cmd]			*:n* *:ne* *:next* *E165* *E163*
 			Edit [count] next file.  This fails when changes have
 			been made and Vim does not want to |abandon| the
 			current buffer.  Also see |++opt| and |+cmd|.
+
+								*]a*
+]a			Mapped to |:next|. |default-mappings|
 
 :[count]n[ext]! [++opt] [+cmd]
 			Edit [count] next file, discard any changes to the
@@ -740,15 +743,21 @@ list of the current window.
 			any changes to the buffer.  Also see |++opt| and
 			|+cmd|.
 
-:[count]prev[ious] [count] [++opt] [+cmd]		*:prev* *:previous* *[a*
+:[count]prev[ious] [count] [++opt] [+cmd]		*:prev* *:previous*
 			Same as :Next.  Also see |++opt| and |+cmd|.
 
-							*:rew* *:rewind* *[A*
+							*[a*
+[a			Mapped to |:previous|. |default-mappings|
+
+							*:rew* *:rewind*
 :rew[ind] [++opt] [+cmd]
 			Start editing the first file in the argument list.
 			This fails when changes have been made and Vim does
 			not want to |abandon| the current buffer.
 			Also see |++opt| and |+cmd|.
+
+								*[A*
+[A			Mapped to |:rewind|. |default-mappings|
 
 :rew[ind]! [++opt] [+cmd]
 			Start editing the first file in the argument list.
@@ -759,12 +768,15 @@ list of the current window.
 :fir[st][!] [++opt] [+cmd]
 			Other name for ":rewind".
 
-							*:la* *:last* *]A*
+							*:la* *:last*
 :la[st] [++opt] [+cmd]
 			Start editing the last file in the argument list.
 			This fails when changes have been made and Vim does
 			not want to |abandon| the current buffer.
 			Also see |++opt| and |+cmd|.
+
+								*]A*
+]A			Mapped to |:last|. |default-mappings|
 
 :la[st]! [++opt] [+cmd]
 			Start editing the last file in the argument list.

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1924,7 +1924,7 @@ These commands are used to start inserting text.  You can end insert mode with
 <Esc>.  See |mode-ins-repl| for the other special characters in Insert mode.
 The effect of [count] takes place after Insert mode is exited.
 
-The following commands insert text, but stay in normal mode:
+The following |default-mappings| insert text, but stay in normal mode:
 
 							*]<Space>*
 ]<Space>		Insert an empty line below the cursor without leaving

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -91,27 +91,39 @@ processing a quickfix or location list command, it will be aborted.
 :ll[!] [nr]		Same as ":cc", except the location list for the
 :[nr]ll[!]		current window is used instead of the quickfix list.
 
-						*:cn* *:cne* *:cnext* *E553* *]q*
+						*:cn* *:cne* *:cnext* *E553*
 :[count]cn[ext][!]	Display the [count] next error in the list that
 			includes a file name.  If there are no file names at
 			all, go to the [count] next error.  See |:cc| for
 			[!] and 'switchbuf'.
 
-							*:lne* *:lnext* *]l*
+								*]q*
+]q			Mapped to |:cnext|. |default-mappings|
+
+							*:lne* *:lnext*
 :[count]lne[xt][!]	Same as ":cnext", except the location list for the
 			current window is used instead of the quickfix list.
 
-:[count]cN[ext][!]		*:cp* *:cprevious*  *:cprev* *:cN* *:cNext* *[q*
+								*]l*
+]l			Mapped to |:lnext|. |default-mappings|
+
+:[count]cN[ext][!]		*:cp* *:cprevious*  *:cprev* *:cN* *:cNext*
 :[count]cp[revious][!]	Display the [count] previous error in the list that
 			includes a file name.  If there are no file names at
 			all, go to the [count] previous error.  See |:cc| for
 			[!] and 'switchbuf'.
 
+								*[q*
+[q			Mapped to |:cprevious|. |default-mappings|
 
-:[count]lN[ext][!]		*:lp* *:lprevious* *:lprev* *:lN* *:lNext* *[l*
+
+:[count]lN[ext][!]		*:lp* *:lprevious* *:lprev* *:lN* *:lNext*
 :[count]lp[revious][!]	Same as ":cNext" and ":cprevious", except the location
 			list for the current window is used instead of the
 			quickfix list.
+
+								*[l*
+[l			Mapped to |:lprevious|. |default-mappings|
 
 							*:cabo* *:cabove*
 :[count]cabo[ve]	Go to the [count] error above the current line in the
@@ -171,37 +183,55 @@ processing a quickfix or location list command, it will be aborted.
 :[count]laf[ter]	Same as ":cafter", except the location list for the
 			current window is used instead of the quickfix list.
 
-							*:cnf* *:cnfile* *]CTRL-Q*
+							*:cnf* *:cnfile*
 :[count]cnf[ile][!]	Display the first error in the [count] next file in
 			the list that includes a file name.  If there are no
 			file names at all or if there is no next file, go to
 			the [count] next error.  See |:cc| for [!] and
 			'switchbuf'.
 
-							*:lnf* *:lnfile* *]CTRL-L*
+							*]CTRL-Q*
+]CTRL-Q			Mapped to |:cnfile|. |default-mappings|
+
+							*:lnf* *:lnfile*
 :[count]lnf[ile][!]	Same as ":cnfile", except the location list for the
 			current window is used instead of the quickfix list.
 
-:[count]cNf[ile][!]			*:cpf* *:cpfile* *:cNf* *:cNfile* *[CTRL-Q*
+							*]CTRL-L*
+]CTRL-L			Mapped to |:lnfile|. |default-mappings|
+
+:[count]cNf[ile][!]			*:cpf* *:cpfile* *:cNf* *:cNfile*
 :[count]cpf[ile][!]	Display the last error in the [count] previous file in
 			the list that includes a file name.  If there are no
 			file names at all or if there is no next file, go to
 			the [count] previous error.  See |:cc| for [!] and
 			'switchbuf'.
 
+								*[CTRL-Q*
+[CTRL-Q			Mapped to |:cpfile|. |default-mappings|
 
-:[count]lNf[ile][!]			*:lpf* *:lpfile* *:lNf* *:lNfile* *[CTRL-L*
+
+:[count]lNf[ile][!]			*:lpf* *:lpfile* *:lNf* *:lNfile*
 :[count]lpf[ile][!]	Same as ":cNfile" and ":cpfile", except the location
 			list for the current window is used instead of the
 			quickfix list.
 
-							*:crewind* *:cr* *[Q*
+							*[CTRL-L*
+[CTRL-L			Mapped to |:lpfile|. |default-mappings|
+
+							*:crewind* *:cr*
 :cr[ewind][!] [nr]	Display error [nr].  If [nr] is omitted, the FIRST
 			error is displayed.  See |:cc|.
 
-							*:lrewind* *:lr* *[L*
+							*[Q*
+[Q			Mapped to |:crewind|. |default-mappings|
+
+							*:lrewind* *:lr*
 :lr[ewind][!] [nr]	Same as ":crewind", except the location list for the
 			current window is used instead of the quickfix list.
+
+							*[L*
+[L			Mapped to |:lrewind|. |default-mappings|
 
 							*:cfirst* *:cfir*
 :cfir[st][!] [nr]	Same as ":crewind".
@@ -209,13 +239,19 @@ processing a quickfix or location list command, it will be aborted.
 							*:lfirst* *:lfir*
 :lfir[st][!] [nr]	Same as ":lrewind".
 
-							*:clast* *:cla* *]Q*
+							*:clast* *:cla*
 :cla[st][!] [nr]	Display error [nr].  If [nr] is omitted, the LAST
 			error is displayed.  See |:cc|.
 
-							*:llast* *:lla* *]L*
+							*]Q*
+]Q			Mapped to |:clast|.
+
+							*:llast* *:lla*
 :lla[st][!] [nr]	Same as ":clast", except the location list for the
 			current window is used instead of the quickfix list.
+
+							*]L*
+]L			Mapped to |:llast|.
 
 							*:cq* *:cquit*
 :cq[uit][!]

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -274,26 +274,38 @@ g CTRL-]		Like CTRL-], but use ":tjump" instead of ":tag".
 {Visual}g CTRL-]	Same as "g CTRL-]", but use the highlighted text as
 			the identifier.
 
-							*:tn* *:tnext* *]t*
+							*:tn* *:tnext*
 :[count]tn[ext][!]	Jump to [count] next matching tag (default 1).  See
 			|tag-!| for [!].
 
-							*:tp* *:tprevious* *[t*
+								*]t*
+]t			Mapped to |:tnext|. |default-mappings|
+
+							*:tp* *:tprevious*
 :[count]tp[revious][!]	Jump to [count] previous matching tag (default 1).
 			See |tag-!| for [!].
+
+								*[t*
+[t			Mapped to |:tprevious|. |default-mappings|
 
 							*:tN* *:tNext*
 :[count]tN[ext][!]	Same as ":tprevious".
 
-							*:tr* *:trewind* *[T*
+							*:tr* *:trewind*
 :[count]tr[ewind][!]	Jump to first matching tag.  If [count] is given, jump
 			to [count]th matching tag.  See |tag-!| for [!].
+
+								*[T*
+[T			Mapped to |:trewind|. |default-mappings|
 
 							*:tf* *:tfirst*
 :[count]tf[irst][!]	Same as ":trewind".
 
-							*:tl* *:tlast* *]T*
+							*:tl* *:tlast*
 :tl[ast][!]		Jump to last matching tag.  See |tag-!| for [!].
+
+								*]T*
+]T			Mapped to |:tlast|. |default-mappings|
 
 							*:lt* *:ltag*
 :lt[ag][!] [name]	Jump to tag [name] and add the matching tags to a new
@@ -335,11 +347,17 @@ the same as above, with a "p" prepended.
 :ptj[ump][!] [name]	Does ":tjump[!] [name]" and shows the new tag in a
 			"Preview" window.  See |:ptag| for more info.
 
-							*:ptn* *:ptnext* *]CTRL-T*
+							*:ptn* *:ptnext*
 :[count]ptn[ext][!]	":tnext" in the preview window.  See |:ptag|.
 
-							*:ptp* *:ptprevious* *[CTRL-T*
+								*]CTRL-T*
+]CTRL-T			Mapped to |:ptnext|. |default-mappings|
+
+							*:ptp* *:ptprevious*
 :[count]ptp[revious][!]	":tprevious" in the preview window.  See |:ptag|.
+
+								*[CTRL-T*
+[CTRL-T			Mapped to |:ptprevious|. |default-mappings|
 
 							*:ptN* *:ptNext*
 :[count]ptN[ext][!]	Same as ":ptprevious".

--- a/runtime/doc/various.txt
+++ b/runtime/doc/various.txt
@@ -103,11 +103,11 @@ g8			Print the hex values of the bytes used in the
 							*gx*
 gx			Opens the current filepath or URL (decided by
 			|<cfile>|, 'isfname') at cursor using the system
-			default handler, by calling |vim.ui.open()|.
+			default handler. Mapped to |vim.ui.open()|.
 
 							*v_gx*
 {Visual}gx		Opens the selected text using the system default
-			handler, by calling |vim.ui.open()|.
+			handler. Mapped to |vim.ui.open()|.
 
 						*:p* *:pr* *:print* *E749*
 :[range]p[rint] [flags]
@@ -612,6 +612,8 @@ If the filetype of the buffer is associated with a language for which a
 to look up the value of 'commentstring' corresponding to the cursor position.
 (This can be different from the buffer's 'commentstring' in case of
 |treesitter-language-injections|.)
+
+The following |default-mappings| are defined:
 
 							*gc* *gc-default*
 gc{motion}		Comment or uncomment lines covered by {motion}.

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1273,7 +1273,7 @@ list of buffers. |unlisted-buffer|
 			:w foobar | sp #
 <		Also see |+cmd|.
 
-:[N]bn[ext][!] [+cmd] [N]				*:bn* *:bnext* *]b* *E87*
+:[N]bn[ext][!] [+cmd] [N]				*:bn* *:bnext* *E87*
 		Go to [N]th next buffer in buffer list.  [N] defaults to one.
 		Wraps around the end of the buffer list.
 		See |:buffer-!| for [!].
@@ -1285,13 +1285,20 @@ list of buffers. |unlisted-buffer|
 		the way when you're browsing code/text buffers.  The next three
 		commands also work like this.
 
+								*]b*
+]b		Mapped to |:bnext|. |default-mappings|
+
 							*:sbn* *:sbnext*
 :[N]sbn[ext] [+cmd] [N]
 		Split window and go to [N]th next buffer in buffer list.
 		Wraps around the end of the buffer list.  Uses 'switchbuf'
 		Also see |+cmd|.
 
-:[N]bN[ext][!] [+cmd] [N]		*:bN* *:bNext* *:bp* *:bprevious* *[b* *E88*
+:[N]bN[ext][!] [+cmd] [N]		*:bN* *:bNext* *:bp* *:bprevious* *E88*
+
+								*[b*
+[b		Mapped to |:bprevious|. |default-mappings|
+
 :[N]bp[revious][!] [+cmd] [N]
 		Go to [N]th previous buffer in buffer list.  [N] defaults to
 		one.  Wraps around the start of the buffer list.
@@ -1305,10 +1312,13 @@ list of buffers. |unlisted-buffer|
 		Uses 'switchbuf'.
 		Also see |+cmd|.
 
-:br[ewind][!] [+cmd]					*:br* *:bre* *:brewind* *[B*
+:br[ewind][!] [+cmd]					*:br* *:bre* *:brewind*
 		Go to first buffer in buffer list.  If the buffer list is
 		empty, go to the first unlisted buffer.
 		See |:buffer-!| for [!].
+
+								*[B*
+[B		Mapped to |:brewind|. |default-mappings|
 
 :bf[irst] [+cmd]					*:bf* *:bfirst*
 		Same as |:brewind|.
@@ -1323,10 +1333,13 @@ list of buffers. |unlisted-buffer|
 :sbf[irst] [+cmd]					*:sbf* *:sbfirst*
 		Same as ":sbrewind".
 
-:bl[ast][!] [+cmd]					*:bl* *:blast* *]B*
+:bl[ast][!] [+cmd]					*:bl* *:blast*
 		Go to last buffer in buffer list.  If the buffer list is
 		empty, go to the last unlisted buffer.
 		See |:buffer-!| for [!].
+
+								*]B*
+]B		Mapped to |:blast|. |default-mappings|
 
 :sbl[ast] [+cmd]					*:sbl* *:sblast*
 		Split window and go to last buffer in buffer list.  If the


### PR DESCRIPTION
Problem:
Default mappings are not really "default" as `d`, `y`,...

This creates a confusion when users read, said `:h gc`, because its document doesn't event mention that `gc` is just a mapping, not a normal mode command defined in C that users can use in `:noremap`. https://github.com/neovim/neovim/issues/32453

(Btw, I really hate how Vim term "command" is so confusing, in help docs it often refers to operators like `d`, `y`, etc instead of Ex commands. Meanwhile `:command` can only create Ex commands!)

Solution:

- Explicitly mention in each `:h {default-maping}` that it is a mapping.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
