### PR TITLE
fix(tui): don't process UI events when suspending or stopping

### DIFF
--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -247,8 +247,7 @@ static void parse_msgpack(Channel *channel)
   Unpacker *p = channel->rpc.unpacker;
   while (unpacker_advance(p)) {
     if (p->type == kMessageTypeRedrawEvent) {
-      // When exiting, ui_client_stop() has already been called, so don't handle UI events.
-      if (ui_client_channel_id && !exiting) {
+      if (ui_client_attached) {
         if (p->has_grid_line_event) {
           ui_client_event_raw_line(&p->grid_line_event);
           p->has_grid_line_event = false;

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -186,6 +186,7 @@ void ui_client_run(bool remote_ui)
 
 void ui_client_stop(void)
 {
+  ui_client_attached = false;
   if (!tui_is_stopped(tui)) {
     tui_stop(tui);
   }


### PR DESCRIPTION
When the TUI is suspending or stopping, redraw events should not be
processed, as when it next processes redraw events it's already waiting
for a DA1 response after having disabled some terminal modes.

Fix #33708