### PR TITLE
fix(vim.system): improve error message when cwd does not exist

### DIFF
--- a/runtime/lua/vim/_system.lua
+++ b/runtime/lua/vim/_system.lua
@@ -246,7 +246,13 @@ local function spawn(cmd, opts, on_exit, on_error)
   local handle, pid_or_err = uv.spawn(cmd, opts, on_exit)
   if not handle then
     on_error()
-    error(('%s: "%s"'):format(pid_or_err, cmd))
+    if opts.cwd and not uv.fs_stat(opts.cwd) then
+      error(("%s (cwd): '%s'"):format(pid_or_err, opts.cwd))
+    elseif vim.fn.executable(cmd) == 0 then
+      error(("%s (cmd): '%s'"):format(pid_or_err, cmd))
+    else
+      error(pid_or_err)
+    end
   end
   return handle, pid_or_err --[[@as integer]]
 end

--- a/test/functional/lua/system_spec.lua
+++ b/test/functional/lua/system_spec.lua
@@ -55,8 +55,13 @@ describe('vim.system', function()
     describe('(' .. name .. ')', function()
       it('failure modes', function()
         t.matches(
-          'ENOENT%: no such file .*: "non%-existent%-cmd"',
+          "ENOENT%: no such file .* %(cmd%): 'non%-existent%-cmd'",
           t.pcall_err(system, { 'non-existent-cmd', 'arg1', 'arg2' }, { text = true })
+        )
+
+        t.matches(
+          "ENOENT%: no such file .* %(cwd%): 'non%-existent%-cwd'",
+          t.pcall_err(system, { 'echo', 'hello' }, { cwd = 'non-existent-cwd', text = true })
         )
       end)
 


### PR DESCRIPTION
Problem:
vim.uv.spawn will emit ENOENT for either when the cmd or cwd do not
exist and does not tell you which.

Solution:
If an error occurs, check if cwd was supplied and included in the error
message if it does not exist.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
