### PR TITLE
fix(display): adjust setting winline info for concealed lines

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -2826,7 +2826,6 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
         curwin->w_cline_height = wlv.row - startrow;
         curwin->w_cline_folded = has_fold;
         curwin->w_valid |= (VALID_CHEIGHT|VALID_CROW);
-        conceal_cursor_used = conceal_cursor_line(curwin);
       }
 
       break;

--- a/src/nvim/drawline.h
+++ b/src/nvim/drawline.h
@@ -19,8 +19,6 @@ typedef struct {
 } WinExtmark;
 EXTERN kvec_t(WinExtmark) win_extmark_arr INIT( = KV_INITIAL_VALUE);
 
-EXTERN bool conceal_cursor_used INIT( = false);
-
 /// Spell checking variables passed from win_update() to win_line().
 typedef struct {
   bool spv_has_spell;         ///< drawn window has spell checking

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -2950,6 +2950,22 @@ describe('extmark decorations', function()
       {1:~                                                 }|*4
                                                         |
     ]])
+    -- Correct relativenumber for line below concealed line #33694
+    feed('4Gk')
+    screen:expect([[
+      {2:  2 }for _,item in ipairs(items) do                |
+      {2:3   }    if h^l_id_cell ~= nil then                 |
+      {2:  1 }        hl_id = hl_id_cell                    |
+      {2:  3 }    for _ = 1, (count or 1) do                |
+      {2:  4 }        local cell = line[colpos]             |
+      {2:  5 }        cell.text = text                      |
+      {2:  6 }        cell.hl_id = hl_id                    |
+      {2:  7 }        colpos = colpos+1                     |
+      {2:  8 }    end                                       |
+      {2:  9 }end                                           |
+      {1:~                                                 }|*4
+                                                        |
+    ]])
     -- Also with above virtual line #32744
     command('set nornu')
     api.nvim_buf_set_extmark(0, ns, 3, 0, { virt_lines = { { { "virt_below 4" } } } })


### PR DESCRIPTION
Problem:  Wrong winline info after partial redraw. Setting
          `conceal_cursor_used` is unnecessarily spread out.
Solution: Rather than adjusting `wl_lastlnum` for the previous
          winline, adjust it when setting the current winline.
          Set `conceal_cursor_used` when the current window is redrawn.

Fix #33694
