### PR TITLE
vim-patch:910bfd5: runtime(java): Consent to HTML tags folding in Javadoc comments

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1689,6 +1689,13 @@ line for any comments written in this way, and showing the contents of a first
 line otherwise, with >
 	:let g:java_foldtext_show_first_or_second_line = 1
 
+HTML tags in Javadoc comments can additionally be folded by following the
+instructions listed under |html-folding| and giving explicit consent with >
+	:let g:java_consent_to_html_syntax_folding = 1
+Do not default to this kind of folding unless ALL start tags and optional end
+tags are balanced in Javadoc comments; otherwise, put up with creating runaway
+folds that break syntax highlighting.
+
 Trailing whitespace characters or a run of space characters before a tab
 character can be marked as an error with >
 	:let g:java_space_errors = 1

--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Aliaksei Budavei <0x000c70 AT gmail DOT com>
 " Former Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
-" Last Change:		2025 Mar 26
+" Last Change:		2025 Apr 28
 
 " Please check ":help java.vim" for comments on some of the options
 " available.
@@ -387,15 +387,30 @@ if !exists("g:java_ignore_javadoc") && (s:with_html || s:with_markdown) && g:mai
   " Include HTML syntax coloring for Javadoc comments.
   if s:with_html
     try
+      if exists("g:html_syntax_folding") && !exists("g:java_consent_to_html_syntax_folding")
+	let s:html_syntax_folding_copy = g:html_syntax_folding
+	unlet g:html_syntax_folding
+      endif
+
       syntax include @javaHtml syntax/html.vim
     finally
       unlet! b:current_syntax
+
+      if exists("s:html_syntax_folding_copy")
+	let g:html_syntax_folding = s:html_syntax_folding_copy
+	unlet s:html_syntax_folding_copy
+      endif
     endtry
   endif
 
   " Include Markdown syntax coloring (v7.2.437) for Javadoc comments.
   if s:with_markdown
     try
+      if exists("g:html_syntax_folding") && !exists("g:java_consent_to_html_syntax_folding")
+	let s:html_syntax_folding_copy = g:html_syntax_folding
+	unlet g:html_syntax_folding
+      endif
+
       syntax include @javaMarkdown syntax/markdown.vim
 
       try
@@ -412,6 +427,11 @@ if !exists("g:java_ignore_javadoc") && (s:with_html || s:with_markdown) && g:mai
       let s:no_support = 1
     finally
       unlet! b:current_syntax
+
+      if exists("s:html_syntax_folding_copy")
+	let g:html_syntax_folding = s:html_syntax_folding_copy
+	unlet s:html_syntax_folding_copy
+      endif
 
       if exists("s:no_support")
 	unlet s:no_support


### PR DESCRIPTION
#### vim-patch:910bfd5: runtime(java): Consent to HTML tags folding in Javadoc comments

HTML tags in Javadoc comments can additionally be folded
after applying
------------------------------------------------------------
	let g:html_syntax_folding = 1
	set foldmethod=syntax
------------------------------------------------------------

and giving explicit consent with
------------------------------------------------------------
	let g:java_consent_to_html_syntax_folding = 1
------------------------------------------------------------

Do not default to this kind of folding unless ALL start tags
and optional end tags are balanced in Javadoc comments;
otherwise, put up with creating runaway folds that break
syntax highlighting.

closes: vim/vim#17216

https://github.com/vim/vim/commit/910bfd5d38812079bf31cc91eb6978415f29b725

Co-authored-by: Aliaksei Budavei <0x000c70@gmail.com>