### PR TITLE
feat(terminal): parse current buffer contents in nvim_open_term()

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1170,7 +1170,7 @@ nvim_open_term({buffer}, {opts})                            *nvim_open_term()*
     By default (and currently the only option) the terminal will not be
     connected to an external process. Instead, input sent on the channel will
     be echoed directly by the terminal. This is useful to display ANSI
-    terminal sequences returned as part of a rpc message, or similar.
+    terminal sequences returned as part of an RPC message, or similar.
 
     Note: to directly initiate the terminal using the right size, display the
     buffer in a configured window before calling this. For instance, for a
@@ -1195,7 +1195,8 @@ nvim_open_term({buffer}, {opts})                            *nvim_open_term()*
         Since: 0.5.0
 
     Parameters: ~
-      • {buffer}  the buffer to use (expected to be empty)
+      • {buffer}  Buffer to use. Buffer contents (if any) will be written to
+                  the PTY.
       • {opts}    Optional parameters.
                   • on_input: Lua callback for input sent, i e keypresses in
                     terminal mode. Note: keypresses are sent raw as they would

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -169,7 +169,8 @@ STARTUP
 
 TERMINAL
 
-• todo
+• |nvim_open_term()| can be called with a non-empty buffer. The buffer
+  contents are piped to the PTY and displayed as terminal output.
 
 TREESITTER
 

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1653,7 +1653,7 @@ function vim.api.nvim_notify(msg, log_level, opts) end
 --- By default (and currently the only option) the terminal will not be
 --- connected to an external process. Instead, input sent on the channel
 --- will be echoed directly by the terminal. This is useful to display
---- ANSI terminal sequences returned as part of a rpc message, or similar.
+--- ANSI terminal sequences returned as part of an RPC message, or similar.
 ---
 --- Note: to directly initiate the terminal using the right size, display the
 --- buffer in a configured window before calling this. For instance, for a
@@ -1675,7 +1675,8 @@ function vim.api.nvim_notify(msg, log_level, opts) end
 --- end, { desc = 'Highlights ANSI termcodes in curbuf' })
 --- ```
 ---
---- @param buffer integer the buffer to use (expected to be empty)
+--- @param buffer integer Buffer to use. Buffer contents (if any) will be written
+--- to the PTY.
 --- @param opts vim.api.keyset.open_term Optional parameters.
 --- - on_input: Lua callback for input sent, i e keypresses in terminal
 ---   mode. Note: keypresses are sent raw as they would be to the pty

--- a/src/clint.py
+++ b/src/clint.py
@@ -879,6 +879,7 @@ def CheckIncludes(filename, lines, error):
             "mpack/mpack_core.h",
             "mpack/object.h",
             "nvim/func_attr.h",
+            "nvim/strings.h",
             "termkey/termkey.h",
             "vterm/vterm.h",
             "xdiff/xdiff.h",

--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -8,6 +8,7 @@
 #include "nvim/gettext_defs.h"  // IWYU pragma: keep
 #include "nvim/macros_defs.h"
 #include "nvim/marktree_defs.h"
+#include "nvim/strings.h"
 #include "nvim/types_defs.h"
 
 /// Values for buflist_getfile()

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -3773,6 +3773,8 @@ describe('API', function()
         },
         [102] = { background = Screen.colors.LightMagenta, reverse = true },
         [103] = { background = Screen.colors.LightMagenta, bold = true, reverse = true },
+        [104] = { fg_indexed = true, foreground = tonumber('0xe00000') },
+        [105] = { fg_indexed = true, foreground = tonumber('0xe0e000') },
       }
     end)
 
@@ -3886,6 +3888,24 @@ describe('API', function()
       ]],
       }
       eq('ba\024blaherrejösses!', exec_lua [[ return stream ]])
+    end)
+
+    it('parses text from the current buffer', function()
+      local b = api.nvim_create_buf(true, true)
+      api.nvim_buf_set_lines(b, 0, -1, true, { '\027[31mHello\000\027[0m', '\027[33mworld\027[0m' })
+      api.nvim_set_current_buf(b)
+      screen:expect([[
+        {18:^^[}[31mHello{18:^@^[}[0m                                                                                  |
+        {18:^[}[33mworld{18:^[}[0m                                                                                    |
+        {1:~                                                                                                   }|*32
+                                                                                                            |
+      ]])
+      api.nvim_open_term(b, {})
+      screen:expect([[
+        {104:^Hello}                                                                                               |
+        {105:world}                                                                                               |
+                                                                                                            |*33
+      ]])
     end)
   end)
 


### PR DESCRIPTION
When nvim_open_term() is called with a non-empty buffer, the buffer contents are piped into the PTY.