### PR TITLE
fix(ui): correct condition for "wrap" flag in a floating grid

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -3026,12 +3026,12 @@ end_check:
             || (wp->w_p_list && wp->w_p_lcs_chars.eol != NUL && lcs_eol_todo)
             || (wlv.n_extra != 0 && (wlv.sc_extra != NUL || *wlv.p_extra != NUL))
             || (may_have_inline_virt && has_more_inline_virt(&wlv, ptr - line)))) {
+      int grid_width = wp->w_grid.target->cols;
       const bool wrap = is_wrapped                      // Wrapping enabled (not a folded line).
                         && wlv.filler_todo <= 0         // Not drawing diff filler lines.
                         && lcs_eol_todo                 // Haven't printed the lcs_eol character.
                         && wlv.row != endrow - 1        // Not the last line being displayed.
-                        && (view_width == Columns       // Window spans the width of the screen,
-                            || wp->w_grid_alloc.chars)  // or has dedicated grid.
+                        && view_width == grid_width     // Window spans the width of its grid.
                         && !wp->w_p_rl;                 // Not right-to-left.
 
       int draw_col = wlv.col - wlv.boguscols;

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1230,12 +1230,13 @@ end
 --- @param row integer
 --- @param col integer
 --- @param items integer[][]
-function Screen:_handle_grid_line(grid, row, col, items)
+function Screen:_handle_grid_line(grid, row, col, items, wrap)
   assert(self._options.ext_linegrid)
   assert(#items > 0)
   local line = self._grids[grid].rows[row + 1]
   local colpos = col + 1
   local hl_id = 0
+  line.wrap = wrap
   for _, item in ipairs(items) do
     local text, hl_id_cell, count = item[1], item[2], item[3]
     if hl_id_cell ~= nil then


### PR DESCRIPTION
In a floating window grid, "wrap" flag should not be set when vertical borders are used, as the the wrapped text will be broken up by border chars.

fixes #33719

