### PR TITLE
fix(cmdline): do not move UI cursor when entering cmdline

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -795,7 +795,6 @@ static uint8_t *command_line_enter(int firstc, int count, int indent, bool clear
   }
 
   setmouse();
-  setcursor();
 
   s->cmdline_type = firstc > 0 ? firstc : '-';
   Error err = ERROR_INIT;

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -125,8 +125,8 @@ describe('ui/ext_messages', function()
     feed(':%s/i/X/gc<cr>')
     screen:expect({
       grid = [[
-        l{2:^i}ne 1                   |
-        l{10:i}ne 2                   |
+        l{2:i}ne 1                   |
+        l{10:i}ne ^2                   |
         {1:~                        }|*3
       ]],
       cmdline = {
@@ -1351,7 +1351,7 @@ stack traceback:
     feed('z=')
     screen:expect({
       grid = [[
-        {100:^helllo}                   |
+        {100:helll^o}                   |
         {1:~                        }|*4
       ]],
       cmdline = {
@@ -1374,7 +1374,7 @@ stack traceback:
     feed('1')
     screen:expect({
       grid = [[
-        {100:^helllo}                   |
+        {100:helll^o}                   |
         {1:~                        }|*4
       ]],
       cmdline = {


### PR DESCRIPTION
Problem:  Cursor is still moved to curwin when entering cmdline (after d41b8d47).
Solution: Remove call to `setcursor()`.
