### PR TITLE
fix(trust): support for trusting directories

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3740,19 +3740,25 @@ vim.regex({re})                                                  *vim.regex()*
 Lua module: vim.secure                                            *vim.secure*
 
 vim.secure.read({path})                                    *vim.secure.read()*
-    Attempt to read the file at {path} prompting the user if the file should
-    be trusted. The user's choice is persisted in a trust database at
+    If {path} is a file: attempt to read the file, prompting the user if the
+    file should be trusted.
+
+    If {path} is a directory: return true if the directory is trusted
+    (non-recursive), prompting the user as necessary.
+
+    The user's choice is persisted in a trust database at
     $XDG_STATE_HOME/nvim/trust.
 
     Attributes: ~
         Since: 0.9.0
 
     Parameters: ~
-      • {path}  (`string`) Path to a file to read.
+      • {path}  (`string`) Path to a file or directory to read.
 
     Return: ~
-        (`string?`) The contents of the given file if it exists and is
-        trusted, or nil otherwise.
+        (`boolean|string?`) If {path} is not trusted or does not exist,
+        returns `nil`. Otherwise, returns the contents of {path} if it is a
+        file, or true if {path} is a directory.
 
     See also: ~
       • |:trust|

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -171,6 +171,9 @@ API
     aligned text that truncates before covering up buffer text.
   • `virt_lines_overflow` field accepts value `scroll` to enable horizontal
     scrolling for virtual lines with 'nowrap'.
+• |vim.secure.read()| now returns `true` for trusted directories. Previously
+  it would return `nil`, which made it impossible to tell if the directory was
+  actually trusted.
 
 DEFAULTS
 

--- a/test/functional/lua/secure_spec.lua
+++ b/test/functional/lua/secure_spec.lua
@@ -20,25 +20,33 @@ local read_file = t.read_file
 describe('vim.secure', function()
   describe('read()', function()
     local xstate = 'Xstate'
+    local screen ---@type test.functional.ui.screen
 
-    setup(function()
+    before_each(function()
       clear { env = { XDG_STATE_HOME = xstate } }
       n.mkdir_p(xstate .. pathsep .. (is_os('win') and 'nvim-data' or 'nvim'))
+
+      t.mkdir('Xdir')
+      t.mkdir('Xdir/Xsubdir')
+      t.write_file('Xdir/Xfile.txt', [[hello, world]])
+
       t.write_file(
         'Xfile',
         [[
         let g:foobar = 42
       ]]
       )
+      screen = Screen.new(500, 8)
     end)
 
-    teardown(function()
+    after_each(function()
+      screen:detach()
       os.remove('Xfile')
+      n.rmdir('Xdir')
       n.rmdir(xstate)
     end)
 
-    it('works', function()
-      local screen = Screen.new(500, 8)
+    it('regular file', function()
       screen:set_default_attr_ids({
         [1] = { bold = true, foreground = Screen.colors.Blue1 },
         [2] = { bold = true, reverse = true },
@@ -94,7 +102,7 @@ describe('vim.secure', function()
       local hash = fn.sha256(assert(read_file('Xfile')))
       trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
       eq(string.format('%s %s', hash, cwd .. pathsep .. 'Xfile'), vim.trim(trust))
-      eq(vim.NIL, exec_lua([[vim.secure.read('Xfile')]]))
+      eq('let g:foobar = 42\n', exec_lua([[return vim.secure.read('Xfile')]]))
 
       os.remove(stdpath('state') .. pathsep .. 'trust')
 
@@ -144,6 +152,114 @@ describe('vim.secure', function()
       pcall_err(command, 'write')
       eq(true, api.nvim_get_option_value('readonly', {}))
     end)
+
+    it('directory', function()
+      screen:set_default_attr_ids({
+        [1] = { bold = true, foreground = Screen.colors.Blue1 },
+        [2] = { bold = true, reverse = true },
+        [3] = { bold = true, foreground = Screen.colors.SeaGreen },
+        [4] = { reverse = true },
+      })
+
+      local cwd = fn.getcwd()
+      local msg = cwd
+        .. pathsep
+        .. 'Xdir is not trusted. DIRECTORY trust is decided only by its name, not its contents.'
+      if #msg >= screen._width then
+        pending('path too long')
+        return
+      end
+
+      -- Need to use feed_command instead of exec_lua because of the confirmation prompt
+      feed_command([[lua vim.secure.read('Xdir')]])
+      screen:expect([[
+        {MATCH: +}|
+        {1:~{MATCH: +}}|*3
+        {2:{MATCH: +}}|
+        :lua vim.secure.read('Xdir'){MATCH: +}|
+        {3:]] .. msg .. [[}{MATCH: +}|
+        {3:[i]gnore, (v)iew, (d)eny, (a)llow: }^{MATCH: +}|
+      ]])
+      feed('d')
+      screen:expect([[
+        ^{MATCH: +}|
+        {1:~{MATCH: +}}|*6
+        {MATCH: +}|
+      ]])
+
+      local trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
+      eq(string.format('! %s', cwd .. pathsep .. 'Xdir'), vim.trim(trust))
+      eq(vim.NIL, exec_lua([[return vim.secure.read('Xdir')]]))
+
+      os.remove(stdpath('state') .. pathsep .. 'trust')
+
+      feed_command([[lua vim.secure.read('Xdir')]])
+      screen:expect([[
+        {MATCH: +}|
+        {1:~{MATCH: +}}|*3
+        {2:{MATCH: +}}|
+        :lua vim.secure.read('Xdir'){MATCH: +}|
+        {3:]] .. msg .. [[}{MATCH: +}|
+        {3:[i]gnore, (v)iew, (d)eny, (a)llow: }^{MATCH: +}|
+      ]])
+      feed('a')
+      screen:expect([[
+        ^{MATCH: +}|
+        {1:~{MATCH: +}}|*6
+        {MATCH: +}|
+      ]])
+
+      -- Directories aren't hashed in the trust database, instead a slug ("directory") is stored
+      -- instead.
+      local expected_hash = 'directory'
+      trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
+      eq(string.format('%s %s', expected_hash, cwd .. pathsep .. 'Xdir'), vim.trim(trust))
+      eq(true, exec_lua([[return vim.secure.read('Xdir')]]))
+
+      os.remove(stdpath('state') .. pathsep .. 'trust')
+
+      feed_command([[lua vim.secure.read('Xdir')]])
+      screen:expect([[
+        {MATCH: +}|
+        {1:~{MATCH: +}}|*3
+        {2:{MATCH: +}}|
+        :lua vim.secure.read('Xdir'){MATCH: +}|
+        {3:]] .. msg .. [[}{MATCH: +}|
+        {3:[i]gnore, (v)iew, (d)eny, (a)llow: }^{MATCH: +}|
+      ]])
+      feed('i')
+      screen:expect([[
+        ^{MATCH: +}|
+        {1:~{MATCH: +}}|*6
+        {MATCH: +}|
+      ]])
+
+      -- Trust database is not updated
+      eq(nil, read_file(stdpath('state') .. pathsep .. 'trust'))
+
+      feed_command([[lua vim.secure.read('Xdir')]])
+      screen:expect([[
+        {MATCH: +}|
+        {1:~{MATCH: +}}|*3
+        {2:{MATCH: +}}|
+        :lua vim.secure.read('Xdir'){MATCH: +}|
+        {3:]] .. msg .. [[}{MATCH: +}|
+        {3:[i]gnore, (v)iew, (d)eny, (a)llow: }^{MATCH: +}|
+      ]])
+      feed('v')
+      screen:expect([[
+        ^{MATCH: +}|
+        {1:~{MATCH: +}}|*2
+        {2:]] .. fn.fnamemodify(cwd, ':~') .. pathsep .. [[Xdir [RO]{MATCH: +}}|
+        {MATCH: +}|
+        {1:~{MATCH: +}}|
+        {4:[No Name]{MATCH: +}}|
+        {MATCH: +}|
+      ]])
+
+      -- Trust database is not updated
+      eq(nil, read_file(stdpath('state') .. pathsep .. 'trust'))
+    end)
   end)
 
   describe('trust()', function()
@@ -160,10 +276,12 @@ describe('vim.secure', function()
 
     before_each(function()
       t.write_file('test_file', 'test')
+      t.mkdir('test_dir')
     end)
 
     after_each(function()
       os.remove('test_file')
+      n.rmdir('test_dir')
     end)
 
     it('returns error when passing both path and bufnr', function()
@@ -274,6 +392,16 @@ describe('vim.secure', function()
         { false, 'buffer is not associated with a file' },
         exec_lua([[return {vim.secure.trust({action='allow', bufnr=0})}]])
       )
+    end)
+
+    it('trust directory bufnr', function()
+      local cwd = fn.getcwd()
+      local full_path = cwd .. pathsep .. 'test_dir'
+      command('edit test_dir')
+
+      eq({ true, full_path }, exec_lua([[return {vim.secure.trust({action='allow', bufnr=0})}]]))
+      local trust = read_file(stdpath('state') .. pathsep .. 'trust')
+      eq(string.format('directory %s', full_path), vim.trim(trust))
     end)
   end)
 end)


### PR DESCRIPTION
Note: this is a backport of https://github.com/neovim/neovim/pull/33617

Problem:
Directories that are "trusted" by `vim.secure.read()`, are not detectable later (they will prompt again). https://github.com/neovim/neovim/discussions/33587#discussioncomment-12925887

Solution:
`vim.secure.read()` returns `true` if the user trusts a directory.

Also fix other bugs:

- If `f:read('*a')` returns `nil`, we treat that as a successful read of the file, and hash it. `f:read` returns `nil` for directories, but it's also documented as returning `nil` "if it cannot read data with the specified format". I reworked the implementation so we explicitly treat directories differently. Rather than hashing `nil` to put in the trust database, we now put "directory" in there explicitly*.
- `vim.secure.trust` (used by `:trust`) didn't actually work for directories, as it would blindly read the contents of a netrw buffer and hash it. Now it uses the same codepath as `vim.secure.read`, and as a result, works correctly for directories.

(cherry picked from commit 272dba7f07f82f260567a792ae824e98c52e3709)

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
