### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2650,7 +2650,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  lastline	'@'		'display' contains lastline/truncate
 	  trunc		'>'		truncated text in the
 					|ins-completion-menu|.
-	  truncrl	'<'		same as "trunc' in 'rightleft' mode
+	  truncrl	'<'		same as "trunc" in 'rightleft' mode
 
 	Any one that is omitted will fall back to the default.
 
@@ -3546,10 +3546,10 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'isexpand'* *'ise'*
 'isexpand' 'ise'	string	(default "")
 			global or local to buffer |global-local|
-	Defines characters and patterns for completion in insert mode. Used by
-	the |complete_match()| function to determine the starting position for
-	completion. This is a comma-separated list of triggers. Each trigger
-	can be:
+	Defines characters and patterns for completion in insert mode.  Used
+	by the |complete_match()| function to determine the starting position
+	for completion.  This is a comma-separated list of triggers.  Each
+	trigger can be:
 	- A single character like "." or "/"
 	- A sequence of characters like "->", "/*", or "/**"
 
@@ -7197,8 +7197,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	First press: longest common substring
 	Second press: list all matches >vim
 		set wildmode=noselect:full
-<	Show 'wildmenu' without completing or selecting on first press
-	Cycle full matches on second press >vim
+<	First press: show 'wildmenu' without completing or selecting
+	Second press: cycle full matches >vim
 		set wildmode=noselect:lastused,full
 <	Same as above, but buffer matches are sorted by time last used
 	More info here: |cmdline-completion|.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6531,7 +6531,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'tagfunc'* *'tfu'*
 'tagfunc' 'tfu'		string	(default "")
 			local to buffer
-	This option specifies a function to be used to perform tag searches.
+	This option specifies a function to be used to perform tag searches
+	(including |taglist()|).
 	The function gets the tag pattern and should return a List of matching
 	tags.  See |tag-function| for an explanation of how to write the
 	function and an example.  The value can be the name of a function, a

--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -888,8 +888,8 @@ Common arguments for the commands above:
 7. Using 'tagfunc'						*tag-function*
 
 It is possible to provide Vim with a function which will generate a list of
-tags used for commands like |:tag|, |:tselect| and Normal mode tag commands
-like |CTRL-]|.
+tags used for commands like |:tag|, |:tselect|, Normal mode tag commands like
+|CTRL-]| and for the |taglist()| function.
 
 The function used for generating the taglist is specified by setting the
 'tagfunc' option.  The function will be called with three arguments:
@@ -943,15 +943,14 @@ It is not allowed to close a window or change window from inside 'tagfunc'.
 The following is a hypothetical example of a function used for 'tagfunc'.  It
 uses the output of |taglist()| to generate the result: a list of tags in the
 inverse order of file names.
->
-	function TagFunc(pattern, flags, info)
-	  function CompareFilenames(item1, item2)
-	    let f1 = a:item1['filename']
-	    let f2 = a:item2['filename']
-	    return f1 >=# f2 ?
-			\ -1 : f1 <=# f2 ? 1 : 0
-	  endfunction
+>vim
+	function CompareFilenames(item1, item2)
+	  let f1 = a:item1['filename']
+	  let f2 = a:item2['filename']
+	  return f1 >=# f2 ? -1 : f1 <=# f2 ? 1 : 0
+	endfunction
 
+	function TagFunc(pattern, flags, info)
 	  let result = taglist(a:pattern)
 	  call sort(result, "CompareFilenames")
 
@@ -959,5 +958,7 @@ inverse order of file names.
 	endfunc
 	set tagfunc=TagFunc
 <
+Note: When executing |taglist()| the 'tagfunc' function won't be called
+recursively.
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1249,7 +1249,9 @@ list of buffers. |unlisted-buffer|
 		name also works, so long as it is unique in the list of
 		buffers.
 		Note that a buffer whose name is a number cannot be referenced
-		by that name; use the buffer number instead.
+		by that name; use the buffer number instead.  Same is true if
+		the buffer name starts with a `+`, it will be interpreted as
+		the start of a |+cmd|.
 		Insert a backslash before a space in a buffer name.
 		See |:buffer-!| for [!].
 		This will also edit a buffer that is not in the buffer list,

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -7037,7 +7037,8 @@ vim.bo.tc = vim.bo.tagcase
 vim.go.tagcase = vim.o.tagcase
 vim.go.tc = vim.go.tagcase
 
---- This option specifies a function to be used to perform tag searches.
+--- This option specifies a function to be used to perform tag searches
+--- (including `taglist()`).
 --- The function gets the tag pattern and should return a List of matching
 --- tags.  See `tag-function` for an explanation of how to write the
 --- function and an example.  The value can be the name of a function, a

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -2345,7 +2345,7 @@ vim.bo.ft = vim.bo.filetype
 ---   lastline	'@'		'display' contains lastline/truncate
 ---   trunc		'>'		truncated text in the
 --- 				`ins-completion-menu`.
----   truncrl	'<'		same as "trunc' in 'rightleft' mode
+---   truncrl	'<'		same as "trunc" in 'rightleft' mode
 ---
 --- Any one that is omitted will fall back to the default.
 ---
@@ -3438,10 +3438,10 @@ vim.o.inf = vim.o.infercase
 vim.bo.infercase = vim.o.infercase
 vim.bo.inf = vim.bo.infercase
 
---- Defines characters and patterns for completion in insert mode. Used by
---- the `complete_match()` function to determine the starting position for
---- completion. This is a comma-separated list of triggers. Each trigger
---- can be:
+--- Defines characters and patterns for completion in insert mode.  Used
+--- by the `complete_match()` function to determine the starting position
+--- for completion.  This is a comma-separated list of triggers.  Each
+--- trigger can be:
 --- - A single character like "." or "/"
 --- - A sequence of characters like "->", "/*", or "/**"
 ---
@@ -7879,8 +7879,8 @@ vim.go.wmnu = vim.go.wildmenu
 --- ```vim
 --- 	set wildmode=noselect:full
 --- ```
---- Show 'wildmenu' without completing or selecting on first press
---- Cycle full matches on second press
+--- First press: show 'wildmenu' without completing or selecting
+--- Second press: cycle full matches
 ---
 --- ```vim
 --- 	set wildmode=noselect:lastused,full

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3070,7 +3070,7 @@ local options = {
           lastline	'@'		'display' contains lastline/truncate
           trunc		'>'		truncated text in the
         				|ins-completion-menu|.
-          truncrl	'<'		same as "trunc' in 'rightleft' mode
+          truncrl	'<'		same as "trunc" in 'rightleft' mode
 
         Any one that is omitted will fall back to the default.
 
@@ -4640,10 +4640,10 @@ local options = {
       defaults = '',
       deny_duplicates = true,
       desc = [=[
-        Defines characters and patterns for completion in insert mode. Used by
-        the |complete_match()| function to determine the starting position for
-        completion. This is a comma-separated list of triggers. Each trigger
-        can be:
+        Defines characters and patterns for completion in insert mode.  Used
+        by the |complete_match()| function to determine the starting position
+        for completion.  This is a comma-separated list of triggers.  Each
+        trigger can be:
         - A single character like "." or "/"
         - A sequence of characters like "->", "/*", or "/**"
 
@@ -10245,8 +10245,8 @@ local options = {
         <	First press: longest common substring
         Second press: list all matches >vim
         	set wildmode=noselect:full
-        <	Show 'wildmenu' without completing or selecting on first press
-        Cycle full matches on second press >vim
+        <	First press: show 'wildmenu' without completing or selecting
+        Second press: cycle full matches >vim
         	set wildmode=noselect:lastused,full
         <	Same as above, but buffer matches are sorted by time last used
         More info here: |cmdline-completion|.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9182,7 +9182,8 @@ local options = {
       cb = 'did_set_tagfunc',
       defaults = '',
       desc = [=[
-        This option specifies a function to be used to perform tag searches.
+        This option specifies a function to be used to perform tag searches
+        (including |taglist()|).
         The function gets the tag pattern and should return a List of matching
         tags.  See |tag-function| for an explanation of how to write the
         function and an example.  The value can be the name of a function, a

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -1502,7 +1502,8 @@ static bool findtags_in_help_init(findtags_state_T *st)
 /// Use the function set in 'tagfunc' (if configured and enabled) to get the
 /// tags.
 /// Return OK if at least 1 tag has been successfully found, NOTDONE if the
-/// 'tagfunc' is not used or the 'tagfunc' returns v:null and FAIL otherwise.
+/// 'tagfunc' is not used, still executing or the 'tagfunc' returned v:null and
+/// FAIL otherwise.
 static int findtags_apply_tfu(findtags_state_T *st, char *pat, char *buf_ffname)
 {
   const bool use_tfu = ((st->flags & TAG_NO_TAGFUNC) == 0);


### PR DESCRIPTION
#### vim-patch:partial:fa8b7db: runtime(doc): tweak documentation style in options.txt

closes: vim/vim#17229

https://github.com/vim/vim/commit/fa8b7db99afad9074e4e1f89b49046836ac61d5b

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>


#### vim-patch:fb08192: runtime(doc): clarify the use of 'tagfunc', update a comment in tags.c

related: vim/vim#17228

https://github.com/vim/vim/commit/fb08192ca75344d6467f9e7f9b9e6d4509df308a

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:ff3d4b2: runtime(doc): document that :b cannot handle buffer names starting with "+"

closes: vim/vim#17229

https://github.com/vim/vim/commit/ff3d4b2d49c4b8b7d97cfaeffe57321a1852f7e8

Co-authored-by: Christian Brabandt <cb@256bit.org>