### PR TITLE
refactor: move StringBuilder to types_defs.h

### DIFF
--- a/src/clint.py
+++ b/src/clint.py
@@ -879,7 +879,6 @@ def CheckIncludes(filename, lines, error):
             "mpack/mpack_core.h",
             "mpack/object.h",
             "nvim/func_attr.h",
-            "nvim/strings.h",
             "termkey/termkey.h",
             "vterm/vterm.h",
             "xdiff/xdiff.h",

--- a/src/klib/kvec.h
+++ b/src/klib/kvec.h
@@ -139,8 +139,6 @@
                            && memmove(&kv_A(v, (i)), &kv_A(v, (i)+(n)), \
                                       ((v).size-(i))*sizeof(kv_A(v, i))))
 
-#define kv_printf(v, ...) kv_do_printf(&(v), __VA_ARGS__)
-
 /// Type of a vector with a few first members allocated on stack
 ///
 /// Is compatible with #kv_A, #kv_pop, #kv_size, #kv_max, #kv_last.

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -80,7 +80,6 @@
 #include "nvim/state.h"
 #include "nvim/statusline.h"
 #include "nvim/statusline_defs.h"
-#include "nvim/strings.h"
 #include "nvim/terminal.h"
 #include "nvim/types_defs.h"
 #include "nvim/ui.h"

--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -8,7 +8,6 @@
 #include "nvim/gettext_defs.h"  // IWYU pragma: keep
 #include "nvim/macros_defs.h"
 #include "nvim/marktree_defs.h"
-#include "nvim/strings.h"
 #include "nvim/types_defs.h"
 
 /// Values for buflist_getfile()

--- a/src/nvim/linematch.c
+++ b/src/nvim/linematch.c
@@ -8,7 +8,6 @@
 #include "nvim/macros_defs.h"
 #include "nvim/memory.h"
 #include "nvim/pos_defs.h"
-#include "nvim/strings.h"
 #include "xdiff/xdiff.h"
 
 #define LN_MAX_BUFS 8

--- a/src/nvim/strings.h
+++ b/src/nvim/strings.h
@@ -4,13 +4,10 @@
 #include <string.h>
 
 #include "auto/config.h"
-#include "klib/kvec.h"
 #include "nvim/api/private/defs.h"  // IWYU pragma: keep
 #include "nvim/eval/typval_defs.h"  // IWYU pragma: keep
 #include "nvim/os/os_defs.h"
 #include "nvim/types_defs.h"  // IWYU pragma: keep
-
-typedef kvec_t(char) StringBuilder;
 
 // Return the length of a string literal
 #define STRLEN_LITERAL(s) (sizeof(s) - 1)
@@ -65,3 +62,5 @@ static inline char *strappend(char *const dst, const char *const src)
 #  define STRNICMP(d, s, n) vim_strnicmp((char *)(d), (char *)(s), (size_t)(n))
 # endif
 #endif
+
+#define kv_printf(v, ...) kv_do_printf(&(v), __VA_ARGS__)

--- a/src/nvim/tui/terminfo.c
+++ b/src/nvim/tui/terminfo.c
@@ -10,7 +10,6 @@
 #include "nvim/ascii_defs.h"
 #include "nvim/charset.h"
 #include "nvim/memory.h"
-#include "nvim/strings.h"
 #include "nvim/tui/terminfo.h"
 #include "nvim/tui/terminfo_defs.h"
 

--- a/src/nvim/types_defs.h
+++ b/src/nvim/types_defs.h
@@ -2,6 +2,8 @@
 
 #include <stdint.h>
 
+#include "klib/kvec.h"
+
 // dummy to pass an ACL to a function
 typedef void *vim_acl_T;
 
@@ -66,3 +68,5 @@ typedef struct {
   uint32_t nbytes;
   char data[];
 } AdditionalData;
+
+typedef kvec_t(char) StringBuilder;


### PR DESCRIPTION
Follow up to https://github.com/neovim/neovim/pull/33720 after discussion with the team.