### PR TITLE
fix(lsp): handle `nil` buffer state in `documentColor` clear

### DIFF
--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -157,7 +157,11 @@ end
 
 --- @param bufnr integer
 local function buf_clear(bufnr)
-  local bufstate = assert(bufstates[bufnr])
+  local bufstate = bufstates[bufnr]
+  if not bufstate then
+    return
+  end
+
   local client_ids = vim.tbl_keys(bufstate.hl_info) --- @type integer[]
 
   for _, client_id in ipairs(client_ids) do


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Fixes https://github.com/neovim/neovim/issues/33699