### PR TITLE
vim-patch:9.1.1357,83cb817

### DIFF
--- a/runtime/doc/tagsrch.txt
+++ b/runtime/doc/tagsrch.txt
@@ -510,7 +510,7 @@ directory where the tag file is.
 ==============================================================================
 5. Tags file format				*tags-file-format* *E431*
 
-						*ctags* *jtags*
+						*ctags*
 A tags file can be created with an external command, for example "ctags".  It
 will contain a tag for each function.  Some versions of "ctags" will also make
 a tag for each "#defined" macro, typedefs, enums, etc.
@@ -524,10 +524,11 @@ universal ctags		A maintained version of ctags based on exuberant
 exuberant ctags		Works for C, C++, Java, Fortran, Eiffel and others.
 			See https://ctags.sourceforge.net. No new version
 			since 2009.
-JTags			For Java, in Java.  It can be found at
-			https://www.fleiner.com/jtags/.
+|:helptags|		For Vim's |help| files
 ptags.py		For Python, in Python.  Found in your Python source
 			directory at Tools/scripts/ptags.py.
+ptags			For Perl, in Perl.  It can be found at
+			https://metacpan.org/pod/Vim::Tag
 
 
 The lines in the tags file must have one of these two formats:

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3500,7 +3500,7 @@ static void nv_ident(cmdarg_T *cap)
     } else if (cmdchar == '#') {
       aux_ptr = (magic_isset() ? "/?.*~[^$\\" : "/?^$\\");
     } else if (tag_cmd) {
-      if (curbuf->b_help) {
+      if (strcmp(curbuf->b_p_ft, "help") == 0) {
         // ":help" handles unescaped argument
         aux_ptr = "";
       } else {

--- a/test/old/testdir/test_help.vim
+++ b/test/old/testdir/test_help.vim
@@ -225,5 +225,22 @@ func Test_help_using_visual_match()
   call CheckScriptFailure(lines, 'E149:')
 endfunc
 
+func Test_helptag_navigation()
+  let helpdir = tempname()
+  let tempfile = helpdir . '/test.txt'
+  call mkdir(helpdir, 'pR')
+  call writefile(['', '*[tag*', '', '|[tag|'], tempfile)
+  exe 'helptags' helpdir
+  exe 'sp' tempfile
+  exe 'lcd' helpdir
+  setl ft=help
+  let &l:iskeyword='!-~,^*,^|,^",192-255'
+  call cursor(4, 2)
+  " Vim must not escape `[` when expanding the tag
+  exe "normal! \<C-]>"
+  call assert_equal(2, line('.'))
+  bw
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
vim-patch:9.1.1357: Vim incorrectly escapes tags with "[" in a help buffer
Problem:  Vim incorrectly escapes tags containing "[" in a help buffer
Solution: check if the buffer has the "help" filetype set, instead of
          already being a help buffer (Phạm Bình An)

fixes: https://github.com/vim/vim/issues/17224
closes: https://github.com/vim/vim/pull/17232

https://github.com/vim/vim/commit/6af20a9be3312045c38ca24b93f2d5d0d70da0b1

Co-authored-by: Phạm Bình An <phambinhanctb2004@gmail.com>
Co-authored-by: Christian Brabandt <cb@256bit.org>
Co-authored-by: zeertzjq <zeertzjq@outlook.com>


vim-patch:83cb817: runtime(doc): update example ctags program and links
- :helptags is also a tags generating program, it deserves mentioning
- JTags seems too dead: its website has been sold, the source, binary
  can't be found anywhere.
- update link of ptags

closes: https://github.com/vim/vim/pull/17233

https://github.com/vim/vim/commit/83cb8174c8fef6e27b2c9e810296edfba37a4b4d

Co-authored-by: Phạm Bình An <phambinhanctb2004@gmail.com>