### PR TITLE
refactor(tui): redundant input->in_fd assignment

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -137,8 +137,6 @@ void tinput_init(TermInput *input, Loop *loop)
     pmap_put(int)(&kitty_key_map, kitty_key_map_entry[i].key, (ptr_t)kitty_key_map_entry[i].name);
   }
 
-  input->in_fd = STDIN_FILENO;
-
   const char *term = os_getenv_noalloc("TERM");
 
   if (!term) {


### PR DESCRIPTION
### Problem

During TUI initialization, `input->in_fd = STDIN_FILENO` is assigned twice.

### Solution

Remove the duplicate assignment and retain only the necessary one.

This change is functionally neutral but improves clarity and removes unnecessary code.