### PR TITLE
fix(vim.lsp.enable): shouldn't run LSP configs on startup

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -623,7 +623,9 @@ function lsp.enable(name, enable)
 
   -- Ensure any pre-existing buffers start/stop their LSP clients.
   if enable ~= false then
-    vim.api.nvim_command('doautoall nvim.lsp.enable FileType')
+    if vim.v.vim_did_enter == 1 then
+      vim.cmd.doautoall('nvim.lsp.enable FileType')
+    end
   else
     for _, nm in ipairs(names) do
       for _, client in ipairs(lsp.get_clients({ name = nm })) do


### PR DESCRIPTION
closes #33761

cc @MariaSolOs @mfussenegger @lewis6991 @jfly I'm not sure if https://github.com/neovim/neovim/pull/33702 is even a good idea, shouldn't starting/stopping LSP clients be the job of `vim.lsp.start/stop`? Maybe should extend them to support client name instead

If the name of `vim.lsp.enable` is confusing, maybe it's better to rename it to `activate/add/prepare/setup` instead?
