### PR TITLE
fix(runtime): conceal paths in help and man table of contents loclist

### DIFF
--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -823,6 +823,8 @@ function M.show_toc()
   fn.setloclist(0, {}, 'a', { title = 'Table of contents' })
   vim.cmd.lopen()
   vim.w.qf_toc = bufname
+  -- reload syntax file after setting qf_toc variable
+  vim.bo.filetype = 'qf'
 end
 
 return M

--- a/runtime/lua/vim/treesitter/_headings.lua
+++ b/runtime/lua/vim/treesitter/_headings.lua
@@ -86,6 +86,7 @@ end
 --- Shows an Outline (table of contents) of the current buffer, in the loclist.
 function M.show_toc()
   local bufnr = api.nvim_get_current_buf()
+  local bufname = api.nvim_buf_get_name(bufnr)
   local headings = get_headings(bufnr)
   if #headings == 0 then
     return
@@ -102,6 +103,9 @@ function M.show_toc()
   vim.fn.setloclist(0, headings, ' ')
   vim.fn.setloclist(0, {}, 'a', { title = 'Table of contents' })
   vim.cmd.lopen()
+  vim.w.qf_toc = bufname
+  -- reload syntax file after setting qf_toc variable
+  vim.bo.filetype = 'qf'
 end
 
 --- Jump to section


### PR DESCRIPTION
Problem:

The check for concealing paths in TOCs in the qf syntax file fails because the TOC tile has changed.

Solution:

This forces the qf syntax file to be reloaded after the qf_toc variable has been set, so that the it can apply the correct settings.

Using the explicit qf_toc key, already used in the syntax file, instead of the title is less prone to breaking.

It was also already being set for man pages but it had no effect because the syntax file had already been loaded when the variable was set.

Fixes #33733

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
