### PR TITLE
feat(fs): glob/wildcard patterns in `vim.fs.find()`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2622,13 +2622,16 @@ vim.fs.find({names}, {opts})                                   *vim.fs.find()*
         local files = vim.fs.find(function(name, path)
           return name:match('.*%.[ch]pp$') and path:match('[/\\]lib$')
         end, { limit = math.huge, type = 'file' })
+
+        -- Find files with globbing (filename only)
+        local files = vim.fs.find({ glob = "*.cpp" }, { limit = math.huge })
 <
 
     Attributes: ~
         Since: 0.8.0
 
     Parameters: ~
-      • {names}  (`string|string[]|fun(name: string, path: string): boolean`)
+      • {names}  (`string|string[]|table|fun(name: string, path: string): boolean`)
                  Names of the items to find. Must be base names, paths and
                  globs are not supported when {names} is a string or a table.
                  If {names} is a function, it is called for each traversed
@@ -2638,6 +2641,9 @@ vim.fs.find({names}, {opts})                                   *vim.fs.find()*
 
                  The function should return `true` if the given item is
                  considered a match.
+
+                 When {names} is a table, the glob field matches filenames
+                 using glob patterns.
       • {opts}   (`table?`) Optional keyword arguments:
                  • {path}? (`string`) Path to begin searching from, defaults
                    to |current-directory|. Not expanded.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -157,6 +157,7 @@ LUA
 • |vim.net.request()| can specify custom headers by passing `opts.headers`.
 • |vim.filetype.inspect()| returns a copy of the internal tables used for
   filetype detection.
+• |vim.fs.find()| supports glob matching on filenames.
 • Added `__eq` metamethod to |vim.VersionRange|. 2 distinct but representing
 the same range instances now compare equal.
 

--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -280,16 +280,20 @@ end
 --- local files = vim.fs.find(function(name, path)
 ---   return name:match('.*%.[ch]pp$') and path:match('[/\\]lib$')
 --- end, { limit = math.huge, type = 'file' })
---- ```
 ---
+--- -- Find files with globbing (filename only)
+--- local files = vim.fs.find({ glob = "*.cpp" }, { limit = math.huge })
+--- ```
 ---@since 10
----@param names (string|string[]|fun(name: string, path: string): boolean) Names of the items to find.
+---@param names (string|string[]|table|fun(name: string, path: string): boolean) Names of the items to find.
 ---             Must be base names, paths and globs are not supported when {names} is a string or a table.
 ---             If {names} is a function, it is called for each traversed item with args:
 ---             - name: base name of the current item
 ---             - path: full path of the current item
 ---
 ---             The function should return `true` if the given item is considered a match.
+---
+---             When {names} is a table, the glob field matches filenames using glob patterns.
 ---
 ---@param opts? vim.fs.find.Opts Optional keyword arguments:
 ---@return (string[]) # Normalized paths |vim.fs.normalize()| of all matching items
@@ -305,6 +309,13 @@ function M.find(names, opts)
 
   if type(names) == 'string' then
     names = { names }
+  end
+
+  if type(names) == 'table' and names.glob then
+    local pattern = vim.glob.to_lpeg(names.glob)
+    names = function(name, _)
+      return pattern:match(name) ~= nil
+    end
   end
 
   local path = opts.path or assert(uv.cwd())

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -254,6 +254,16 @@ describe('vim.fs', function()
 
       local parent, name = nvim_dir:match('^(.*/)([^/]+)$')
       eq({ nvim_dir }, vim.fs.find(name, { path = parent, upward = true, type = 'directory' }))
+
+      eq(
+        { test_build_dir .. '/bin' },
+        vim.fs.find({ glob = 'bi?' }, { path = nvim_dir, upward = true, type = 'directory' })
+      )
+
+      eq(
+        { test_build_dir .. '/bin' },
+        vim.fs.find({ glob = 'b*' }, { path = nvim_dir, upward = true, type = 'directory' })
+      )
     end)
 
     it('follows symlinks', function()


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

Related:
- #33444 
- https://github.com/neovim/nvim-lspconfig/issues/3768
- https://github.com/neovim/nvim-lspconfig/pull/3711#discussion_r2042332765

There are some type warning because `vim.lpeg.Pattern` is of type `userdata` and `vim.lpeg.type` cannot perform a sufficient narrowing.

I preferred not to mix up `string` and `Pattern` in something like `(string|vim.lpeg.Pattern)[]` to reduce code complexity.

CC @justinmk 