### PR TITLE
fix(extui): cmdline visibility, cmdheight cursor position

### DIFF
--- a/runtime/lua/vim/_extui/messages.lua
+++ b/runtime/lua/vim/_extui/messages.lua
@@ -331,7 +331,7 @@ function M.msg_clear() end
 ---
 ---@param content MsgContent
 function M.msg_showmode(content)
-  M.virt.last[M.virt.idx.mode] = content
+  M.virt.last[M.virt.idx.mode] = ext.cmd.level < 0 and content or {}
   M.virt.last[M.virt.idx.search] = {}
   set_virttext('last')
 end
@@ -386,7 +386,6 @@ function M.set_pos(type)
       height = height,
       row = win == ext.wins[ext.tab].box and 0 or 1,
       col = 10000,
-      zindex = type == 'more' and 299 or nil,
     })
     if type == 'box' then
       -- Ensure last line is visible and first line is at top of window.

--- a/runtime/lua/vim/_extui/shared.lua
+++ b/runtime/lua/vim/_extui/shared.lua
@@ -29,7 +29,6 @@ local wincfg = { -- Default cfg for nvim_open_win().
   width = 10000,
   height = 1,
   noautocmd = true,
-  zindex = 300,
 }
 
 --- Ensure the various buffers and windows have not been deleted.
@@ -63,6 +62,8 @@ function M.tab_check_wins()
         hide = type ~= 'cmd' or M.cmdheight == 0 or nil,
         title = type == 'more' and 'Messages' or nil,
         border = type == 'box' and not o.termguicolors and 'single' or border or 'none',
+        -- kZIndexMessages < zindex < kZIndexCmdlinePopupMenu (grid_defs.h), 'more' below others.
+        zindex = 200 - (type == 'more' and 1 or 0),
         _cmdline_offset = type == 'cmd' and 0 or nil,
       })
       M.wins[M.tab][type] = api.nvim_open_win(M.bufs[type], false, cfg)


### PR DESCRIPTION
Problem:  The cmdline popupmenu is hidden behind extui windows.
          'showmode' message is drawn over the cmdline.
          Changing the 'cmdheight' to accommodate space for the text in
          the cmdline may change the current cursor position.
Solution: Ensure kZIndexMessages < zindex < kZIndexCmdlinePopupMenu.
          Clear the 'showmode' message when the cmdline level is negative.
          Temporarily set 'splitkeep' = "screen" when changing the 'cmdheight'.

Fix #33773
Fix #33775
Fix #33786