### PR TITLE
fix(lsp): improper diagnostic end_col computation

### DIFF
--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -100,12 +100,16 @@ local function diagnostic_lsp_to_vim(diagnostics, bufnr, client_id)
       message = diagnostic.message.value
     end
     local line = buf_lines and buf_lines[start.line + 1] or ''
+    local end_line = line
+    if _end.line > start.line then
+      end_line = buf_lines and buf_lines[_end.line + 1] or ''
+    end
     --- @type vim.Diagnostic
     return {
       lnum = start.line,
       col = vim.str_byteindex(line, position_encoding, start.character, false),
       end_lnum = _end.line,
-      end_col = vim.str_byteindex(line, position_encoding, _end.character, false),
+      end_col = vim.str_byteindex(end_line, position_encoding, _end.character, false),
       severity = severity_lsp_to_vim(diagnostic.severity),
       message = message,
       source = diagnostic.source,


### PR DESCRIPTION
**Problem:** For multiline diagnostics, the end column was improperly calculated by checking the byte index of the character position on the *start* line.

**Solution:** Calculate the byte index for end_col using the *end* line.

Before:

![image](https://github.com/user-attachments/assets/56f0f9d6-7ee3-4aca-8e25-6e55f2b91d2d)

After:

![image](https://github.com/user-attachments/assets/9a656518-6d93-4883-8ce1-786c86626383)
