### PR TITLE
fix(extui): close message window with `q`

### DIFF
--- a/runtime/lua/vim/_extui/shared.lua
+++ b/runtime/lua/vim/_extui/shared.lua
@@ -47,8 +47,8 @@ function M.tab_check_wins()
         local parser = assert(vim.treesitter.get_parser(M.bufs.cmd, 'vim', {}))
         M.cmd.highlighter = vim.treesitter.highlighter.new(parser)
       elseif type == 'more' then
-        -- Close more window with Ctrl-C.
-        vim.keymap.set('n', '<C-c>', '<C-w>c', { buffer = M.bufs.more })
+        -- Close more window with `q`, same as `checkhealth`
+        vim.keymap.set('n', 'q', '<C-w>c', { buffer = M.bufs.more })
       end
     end
 


### PR DESCRIPTION
Problem: Using `<c-c>` does not follow precedent (from `checkhealth`, `Man`, etc.) for closing "information windows".

Solution: Use `q` for close mapping.