### PR TITLE
fix(treesitter): close `:InspectTree` with `q`

### DIFF
--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -451,6 +451,8 @@ function M.inspect_tree(opts)
     end,
   })
 
+  api.nvim_buf_set_keymap(b, 'n', 'q', '<C-w>c', { desc = 'Close language tree window' })
+
   local group = api.nvim_create_augroup('nvim.treesitter.dev', {})
 
   api.nvim_create_autocmd('CursorMoved', {


### PR DESCRIPTION
Problem: `:InspectTree` window does not follow precedent for focused "info windows" (like `checkhealth`, `Man`, etc.).

Solution: Map `q` to `<C-w>c`.

(Follow-up to #33784)
