### PR TITLE
fix(extui): only use custom highlight namespace in cmdline window

### DIFF
--- a/runtime/lua/vim/_extui.lua
+++ b/runtime/lua/vim/_extui.lua
@@ -67,6 +67,9 @@ function M.enable(opts)
     end
   end)
 
+  -- Use MsgArea and hide search highlighting in the cmdline window.
+  -- TODO: Add new highlight group/namespaces for other windows? It is
+  -- clear MsgArea would be wanted in the box, more and prompt windows.
   api.nvim_set_hl(ext.ns, 'Normal', { link = 'MsgArea' })
   api.nvim_set_hl(ext.ns, 'Search', { link = 'MsgArea' })
   api.nvim_set_hl(ext.ns, 'CurSearch', { link = 'MsgArea' })

--- a/runtime/lua/vim/_extui/shared.lua
+++ b/runtime/lua/vim/_extui/shared.lua
@@ -67,7 +67,9 @@ function M.tab_check_wins()
         _cmdline_offset = type == 'cmd' and 0 or nil,
       })
       M.wins[M.tab][type] = api.nvim_open_win(M.bufs[type], false, cfg)
-      api.nvim_win_set_hl_ns(M.wins[M.tab][type], M.ns)
+      if type == 'cmd' then
+        api.nvim_win_set_hl_ns(M.wins[M.tab][type], M.ns)
+      end
       setopt = true
     elseif api.nvim_win_get_buf(M.wins[M.tab][type]) ~= M.bufs[type] then
       api.nvim_win_set_buf(M.wins[M.tab][type], M.bufs[type])


### PR DESCRIPTION
Problem:  No search highlighting in extui more window.
Solution: Only use custom highlight namespace in cmdline window.