### PR TITLE
docs(editorconfig): add trim_trailing_whitespace option

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -6,6 +6,7 @@ indent_size = 2
 tab_width = 8
 end_of_line = lf
 insert_final_newline = true
+trim_trailing_whitespace = true
 
 [*.{c,h,in,lua}]
 max_line_length = 100


### PR DESCRIPTION
Problem: I often have [tests fail because of trailing whitespace](https://github.com/neovim/neovim/actions/runs/14803083098/job/41566109453?pr=29073).

Solution: Add `trim_trailing_whitespace = true` to `.editorconfig`.

Note: I don't know if `[*]` is the best place to put this. Does this rule apply to all files?
If not, perhaps it should be added to the `[{Makefile,**/Makefile,*.mk,runtime/doc/*.txt}]` section instead?