### PR TITLE
feat(lsp): support `documentColor` dynamic registration

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2201,14 +2201,11 @@ enable({enable}, {bufnr}, {opts})            *vim.lsp.document_color.enable()*
     Enables document highlighting from the given language client in the given
     buffer.
 
-    You can enable document highlighting from a supporting client as follows: >lua
+    You can enable document highlighting when a client attaches to a buffer as
+    follows: >lua
         vim.api.nvim_create_autocmd('LspAttach', {
           callback = function(args)
-            local client = vim.lsp.get_client_by_id(args.data.client_id)
-
-            if client:supports_method('textDocument/documentColor') then
-              vim.lsp.document_color.enable(true, args.buf)
-            end
+            vim.lsp.document_color.enable(true, args.buf)
           end
         })
 <

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -128,6 +128,15 @@ RSC[ms.client_registerCapability] = function(_, params, ctx)
   for bufnr in pairs(client.attached_buffers) do
     vim.lsp._set_defaults(client, bufnr)
   end
+  for _, reg in ipairs(params.registrations) do
+    if reg.method == ms.textDocument_documentColor then
+      for bufnr in pairs(client.attached_buffers) do
+        if vim.lsp.document_color.is_enabled(bufnr) then
+          vim.lsp.document_color._buf_refresh(bufnr, client.id)
+        end
+      end
+    end
+  end
   return vim.NIL
 end
 

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -533,7 +533,7 @@ function protocol.make_client_capabilities()
         dynamicRegistration = false,
       },
       colorProvider = {
-        dynamicRegistration = false,
+        dynamicRegistration = true,
       },
     },
     workspace = {


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Adding support for dynamic registration of `documentColor` requests.

Since there's currently no public concrete API for hooking up to dynamic registration events (see https://github.com/neovim/neovim/issues/24229), I'm adding the refresh logic to the registration handler.