### PR TITLE
build(deps): bump tree-sitter-vim to v0.6.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -46,8 +46,8 @@
             .hash = "N-V-__8AALBVCABzNpJmVFujBmfpbSS_5V-I8aZS6LaTtWWi",
         },
         .treesitter_vim = .{
-            .url = "git+https://github.com/tree-sitter-grammars/tree-sitter-vim?ref=v0.5.0#0f31cb98e5c0cb3707e097bf95a04c0c2aac573d",
-            .hash = "N-V-__8AAAFtUgDN41WOv5Ch59n-6WdlCnD97F3jwboANSLU",
+            .url = "git+https://github.com/tree-sitter-grammars/tree-sitter-vim?ref=v0.6.0#2f9e2be0a3af4999f615d69a6261efc699e5985c",
+            .hash = "N-V-__8AAHIQUwAO7lkXegMUhQxMCiIltH69Kgcpo17B0K6z",
         },
         .treesitter_vimdoc = .{
             .url = "git+https://github.com/neovim/tree-sitter-vimdoc?ref=v3.0.1#2694c3d27e2ca98a0ccde72f33887394300d524e",

--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -38,8 +38,8 @@ TREESITTER_C_URL https://github.com/tree-sitter/tree-sitter-c/archive/v0.23.4.ta
 TREESITTER_C_SHA256 b66c5043e26d84e5f17a059af71b157bcf202221069ed220aa1696d7d1d28a7a
 TREESITTER_LUA_URL https://github.com/tree-sitter-grammars/tree-sitter-lua/archive/v0.3.0.tar.gz
 TREESITTER_LUA_SHA256 a34cc70abfd8d2d4b0fabf01403ea05f848e1a4bc37d8a4bfea7164657b35d31
-TREESITTER_VIM_URL https://github.com/tree-sitter-grammars/tree-sitter-vim/archive/v0.5.0.tar.gz
-TREESITTER_VIM_SHA256 90019d12d2da0751c027124f27f5335babf069a050457adaed53693b5e9cf10a
+TREESITTER_VIM_URL https://github.com/tree-sitter-grammars/tree-sitter-vim/archive/v0.6.0.tar.gz
+TREESITTER_VIM_SHA256 b36080be8f9ec53d6413447a792985b984b6f89a223ff758f1acfd380b469a74
 TREESITTER_VIMDOC_URL https://github.com/neovim/tree-sitter-vimdoc/archive/v3.0.1.tar.gz
 TREESITTER_VIMDOC_SHA256 76b65e5bee9ff78eb21256619b1995aac4d80f252c19e1c710a4839481ded09e
 TREESITTER_QUERY_URL https://github.com/tree-sitter-grammars/tree-sitter-query/archive/v0.5.1.tar.gz

--- a/runtime/queries/vim/highlights.scm
+++ b/runtime/queries/vim/highlights.scm
@@ -127,6 +127,7 @@
   "eval"
   "sign"
   "abort"
+  "substitute"
 ] @keyword
 
 (map_statement
@@ -312,6 +313,9 @@
 
 (binary_operation
   "." @operator)
+
+(lua_statement
+  "=" @keyword)
 
 ; Punctuation
 [


### PR DESCRIPTION
Will add syntax highlighting for `:=` on the extui cmdline.

@bfredl now that build.zig is merged, do we need to keep the ZON updated as well? This will make updating dependencies much harder (if not impossible) for me since the script doesn't know about that (and I don't know about Zig).