### PR TITLE
docs: fix some treesitter parse issues

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -487,7 +487,7 @@ CompleteDone			After Insert mode completion is done.  Either
 						- "accept": completion was
 						  accepted by |complete_CTRL-Y|.
 						- "cancel": completion was
-						  stopped by |complete_CTRL-E.
+						  stopped by |complete_CTRL-E|.
 						- "discard": completion was
 						  abandoned for other reason.
 

--- a/runtime/doc/debug.txt
+++ b/runtime/doc/debug.txt
@@ -160,5 +160,4 @@ In WinDbg: choose Open Crash Dump on the File menu. Follow the instructions in
 Visual Studio 2017 Community Edition can be downloaded for free from:
     https://visualstudio.microsoft.com/downloads/
 
-=========================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -95,7 +95,7 @@ LUA
 • vim.validate(opts: table) Use form 1. See |vim.validate()|.
 
 VIMSCRIPT
-• *termopen()* Use |jobstart() with `{term: v:true}`.
+• *termopen()* Use |jobstart()| with `{term: v:true}`.
 
 ------------------------------------------------------------------------------
 DEPRECATED IN 0.10					*deprecated-0.10*

--- a/runtime/doc/dev_style.txt
+++ b/runtime/doc/dev_style.txt
@@ -901,8 +901,8 @@ Return Values ~
 
 Do not needlessly surround the `return` expression with parentheses.
 
-Use parentheses in `return expr`; only where you would use them in `x =
-expr;`. >c
+Use parentheses in `return expr;` only where you would also use them in
+`x = expr;`. >c
 
     return result;
     return (some_long_condition && another_condition);

--- a/runtime/doc/dev_tools.txt
+++ b/runtime/doc/dev_tools.txt
@@ -171,8 +171,8 @@ USING GDBSERVER IN TMUX
 Consider using a custom makefile
 https://github.com/neovim/neovim/blob/master/BUILD.md#custom-makefile to
 quickly start debugging sessions using the `gdbserver` method mentioned above.
-This example `local.mk` will create the debugging session when you type `make
-debug`.
+This example `local.mk` will create the debugging session when you type
+`make debug`.
 >make
     .PHONY: dbg-start dbg-attach debug build
 

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -201,7 +201,7 @@ Docstring format:
 - Markdown is supported.
 - Tags are written as `[tag]()`.
 - References are written as `[tag]`
-- Use ``` for code samples.
+- Use "```" for code samples.
   Code samples can be annotated as `vim` or `lua`
 
 Example: the help for |nvim_open_win()| is generated from a docstring defined
@@ -245,7 +245,7 @@ Docstring format:
 - Markdown is supported.
 - Tags are written as `[tag]()`.
 - References are written as `[tag]`
-- Use ``` for code samples.
+- Use "```" for code samples.
   Code samples can be annotated as `vim` or `lua`
 - Use `@since <api-level>` to note the |api-level| when the function became
   "stable". If `<api-level>` is greater than the current stable release (or

--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -647,5 +647,4 @@ If this buffer has been edited in this window, the values from back then are
 used.  Otherwise the values from the window where the buffer was edited last
 are used.
 
-==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/ft_ada.txt
+++ b/runtime/doc/ft_ada.txt
@@ -507,6 +507,4 @@ taglist.vim
 The GNU Ada Project distribution (http://gnuada.sourceforge.net) of Vim
 contains all of the above.
 
-==============================================================================
-vim: textwidth=78 nowrap tabstop=8 shiftwidth=4 softtabstop=4 noexpandtab
-vim: filetype=help
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/ft_hare.txt
+++ b/runtime/doc/ft_hare.txt
@@ -73,5 +73,4 @@ The maximum search depth can be set to any integer, but using values higher
 than 2 is not recommended, and will likely provide no tangible benefit in most
 situations.
 
-==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/ft_ps1.txt
+++ b/runtime/doc/ft_ps1.txt
@@ -60,5 +60,4 @@ Many other distributions are available for Windows like
 https://chocolatey.org/packages/less/. Make sure `less` is in a directory
 listed in the `PATH` environment variable, which chocolatey above does.
 
-------------------------------------------------------------------------------
  vim:ft=help:

--- a/runtime/doc/ft_rust.txt
+++ b/runtime/doc/ft_rust.txt
@@ -475,4 +475,4 @@ MAPPINGS                                                       *rust-mappings*
 This plugin defines mappings for |[[| and |]]| to support hanging indents.
 
 
-vim:tw=78:sw=4:noet:ts=8:ft=help:norl:
+ vim:tw=78:sw=4:noet:ts=8:ft=help:norl:

--- a/runtime/doc/if_perl.txt
+++ b/runtime/doc/if_perl.txt
@@ -268,5 +268,4 @@ These are also available via the "main" package:
 $main::curwin		The current Window object.
 $main::curbuf		The current Buffer object.
 
-==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/if_pyth.txt
+++ b/runtime/doc/if_pyth.txt
@@ -645,6 +645,6 @@ To check if `pyx*` functions and commands are available: >vim
 	if has('pythonx')
 	  echo 'pyx* commands are available. (Python ' .. &pyx .. ')'
 	endif
+<
 
-==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/if_ruby.txt
+++ b/runtime/doc/if_ruby.txt
@@ -189,5 +189,4 @@ evaluate Ruby expressions and pass their values to Vim script.
 The Ruby value "true", "false" and "nil" are converted to v:true, v:false and
 v:null, respectively.
 
-==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -711,5 +711,4 @@ Arbitrary code registered via |:UpdateRemotePlugins|, that runs in a separate
 process and communicates with Nvim via the |api|.
 
 
-==============================================================================
  vim:tw=78:ts=8:et:sw=4:ft=help:norl:

--- a/runtime/doc/job_control.txt
+++ b/runtime/doc/job_control.txt
@@ -140,5 +140,4 @@ A job may be killed at any time with the |jobstop()| function:
 <
 Individual streams can be closed without killing the job, see |chanclose()|.
 
-==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/lua-bit.txt
+++ b/runtime/doc/lua-bit.txt
@@ -379,5 +379,4 @@ COPYRIGHT
 Lua BitOp is Copyright (C) 2008-2012 Mike Pall.
 Lua BitOp is free software, released under the MIT license.
 
-==============================================================================
  vim:tw=78:ts=4:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/doc/luaref.txt
+++ b/runtime/doc/luaref.txt
@@ -1654,8 +1654,8 @@ lua_Alloc                                                            *lua_Alloc*
         `NULL` if and only if it cannot fill the request. When `nsize` is not
         zero and `osize` is zero, the allocator should behave like `malloc`.
         When `nsize` and `osize` are not zero, the allocator behaves like
-        `realloc`. Lua assumes that the allocator never fails when `osize >=
-        nsize`.
+        `realloc`. Lua assumes that the allocator never fails when
+        `osize >= nsize`.
 
         Here is a simple implementation for the allocator function. It is used
         in the auxiliary library by `luaL_newstate` (see
@@ -3567,8 +3567,8 @@ collectgarbage({opt} [, {arg}])                         *collectgarbage()*
                      `true` if the step finished a collection cycle.
         `"setpause"`   sets {arg} /100 as the new value for the `pause` of
                      the collector (see |lua-gc|).
-        `"setstepmul"` sets {arg} /100 as the new value for the `step
-                     multiplier` of the collector (see |lua-gc|).
+        `"setstepmul"` sets {arg} /100 as the new value for the
+                     `step multiplier` of the collector (see |lua-gc|).
 
 dofile({filename})                                      *dofile()*
         Opens the named file and executes its contents as a Lua chunk. When
@@ -4785,8 +4785,8 @@ debug.sethook([{thread},] {hook}, {mask} [, {count}])          *debug.sethook()*
         When called without arguments, the `debug.sethook` turns off the hook.
 
         When the hook is called, its first parameter is a string describing
-        the event that triggered its call: `"call"`, `"return"` (or `"tail
-        return"`), `"line"`, and `"count"`. For line events, the hook also
+        the event that triggered its call: `"call"`, `"return"` (or
+        `"tail return"`), `"line"`, and `"count"`. For line events, the hook also
         gets the new line number as its second parameter. Inside a hook, you
         can call `getinfo` with level 2 to get more information about the
         running function (level 0 is the `getinfo` function, and level 1 is
@@ -4885,5 +4885,4 @@ Christian Habermann's CRefVim project
 Adapted for bundled Nvim documentation; the original plugin can be found at
 https://www.vim.org/scripts/script.php?script_id=1291
 
-------------------------------------------------------------------------------
- vi:tw=78:ts=4:ft=help:norl:et
+ vim:tw=78:ts=4:ft=help:norl:et

--- a/runtime/doc/mbyte.txt
+++ b/runtime/doc/mbyte.txt
@@ -476,7 +476,7 @@ and what the keymaps are to get those characters:
 
 glyph   encoding	   keymap ~
 Char UTF-8 cp1255  hebrew  hebrewp  name ~
-א    0x5d0  0xe0     t	      a     ´alef
+א    0x5d0  0xe0     t	      a     alef
 ב    0x5d1  0xe1     c	      b     bet
 ג    0x5d2  0xe2     d	      g     gimel
 ד    0x5d3  0xe3     s	      d     dalet
@@ -494,7 +494,7 @@ Char UTF-8 cp1255  hebrew  hebrewp  name ~
 ן    0x5df  0xef     i	      N     nun sofit
 נ    0x5e0  0xf0     b	      n     nun
 ס    0x5e1  0xf1     x	      s     samech
-ע    0x5e2  0xf2     g	      u     `ayin
+ע    0x5e2  0xf2     g	      u     ayin
 ף    0x5e3  0xf3     ;	      P     pe sofit
 פ    0x5e4  0xf4     p	      p     pe
 ץ    0x5e5  0xf5     .	      X     tsadi sofit
@@ -556,8 +556,8 @@ Char UTF-8 hebrew name
 ב֯    0x5af   CC   masora circle
 
 Combining forms:
-ﬠ    0xfb20  X`   Alternative `ayin
-ﬡ    0xfb21  X'   Alternative ´alef
+ﬠ    0xfb20  X`   Alternative ayin
+ﬡ    0xfb21  X'   Alternative alef
 ﬢ    0xfb22  X-d  Alternative dalet
 ﬣ    0xfb23  X-h  Alternative he
 ﬤ    0xfb24  X-k  Alternative kaf

--- a/runtime/doc/nvim.txt
+++ b/runtime/doc/nvim.txt
@@ -98,5 +98,4 @@ However, in general, we recommend (eventually) taking time to learn Nvim from
 its stock configuration, and incrementally setting options and adding plugins
 to your |config| as you find an explicit need to do so.
 
-==============================================================================
  vim:tw=78:ts=8:et:ft=help:norl:

--- a/runtime/doc/pi_msgpack.txt
+++ b/runtime/doc/pi_msgpack.txt
@@ -140,5 +140,4 @@ msgpack#equal({msgpack-value}, {msgpack-value})		*msgpack#equal()*
 	|msgpack-special-dict| with equivalent non-special-dict value
 	evaluates to 1.
 
-==============================================================================
-vim:tw=78:ts=8:ft=help:fdm=marker
+ vim:tw=78:ts=8:ft=help:fdm=marker

--- a/runtime/doc/provider.txt
+++ b/runtime/doc/provider.txt
@@ -366,5 +366,4 @@ generally inserted with the middle mouse button.
 Nvim's X11 clipboard providers only use the PRIMARY and CLIPBOARD selections,
 for the "*" and "+" registers, respectively.
 
-==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/remote_plugin.txt
+++ b/runtime/doc/remote_plugin.txt
@@ -137,5 +137,4 @@ named `rplugin.vim` at:
 	Windows ~
 	  $LOCALAPPDATA/nvim/ or ~/AppData/Local/nvim/
 
-==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/russian.txt
+++ b/runtime/doc/russian.txt
@@ -61,5 +61,4 @@ In order to use the Russian documentation, make sure you have set the
    is related to a bug in GNU gettext library and may be fixed in the future
    releases of gettext.
 
-===============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1652,7 +1652,7 @@ diverge as follows:
   1. The first sentence (all characters up to the first period `.`, which is
      followed by a whitespace character or a line terminator, or up to the
      first block tag, e.g. `@param`, `@return`) is colored as
-	*SpecialComment	special comments.
+	`*SpecialComment`	special comments.
   2. The text is colored as
 	`*Comment`	comments.
   3. HTML comments are colored as
@@ -1898,9 +1898,9 @@ quoted text and URLs / email addresses).  In keeping with standard conventions,
 signatures begin in a line containing only "--" followed optionally by
 whitespaces and end with a newline.
 
-Vim treats lines beginning with ']', '}', '|', '>' or a word followed by '>'
+Vim treats lines beginning with "]", "}", "|", ">" or a word followed by ">"
 as quoted text.  However Vim highlights headers and signatures in quoted text
-only if the text is quoted with '>' (optionally followed by one space).
+only if the text is quoted with ">" (optionally followed by one space).
 
 By default mail.vim synchronises syntax to 100 lines before the first
 displayed line.  If you have a slow machine, and generally deal with emails
@@ -2064,8 +2064,8 @@ To disable highlighting of pronoun substitution patterns inside strings: >
 
 	:let moo_no_pronoun_sub = 1
 
-To disable highlighting of the regular expression operator '%|', and matching
-'%(' and '%)' inside strings: >
+To disable highlighting of the regular expression operator "%|", and matching
+"%(" and "%)" inside strings: >
 
 	:let moo_no_regexp = 1
 
@@ -2894,7 +2894,7 @@ The value is a space-separated list of keywords:
     [	       Array literal
     %	       Literal with "%" notation, e.g.: %w(STRING), %!STRING!
     /	       Regexp
-    string     String and shell command output (surrounded by ', ", `)
+    string     String and shell command output (surrounded by ', ", "`")
     :	       Symbol
     #	       Multiline comment
     <<	       Here documents

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -884,5 +884,4 @@ must handle.
 ["msg_history_clear"] ~
 	Clear the |:messages| history.
 
-==============================================================================
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/userfunc.txt
+++ b/runtime/doc/userfunc.txt
@@ -407,8 +407,8 @@ Now `:messages` shows:
 	number 0
 
 Any return value of the deferred function is discarded.  The function cannot
-be followed by anything, such as "->func" or ".member".  Currently `:defer
-GetArg()->TheFunc()` does not work, it may work in a later version.
+be followed by anything, such as "->func" or ".member".  Currently
+`:defer GetArg()->TheFunc()` does not work, it may work in a later version.
 
 Errors are reported but do not cause aborting execution of deferred functions
 or altering execution outside of deferred functions.

--- a/runtime/doc/vietnamese.txt
+++ b/runtime/doc/vietnamese.txt
@@ -69,5 +69,4 @@ name of the Vietnamese locale.  For example, >
 Note that the name of the Vietnamese locale may vary depending on your system.
 See |mbyte-first| for details.
 
-===============================================================================
-vim:tw=78:ts=8:noet:ft=help:norl:
+ vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -894,5 +894,4 @@ TUI:
   at how the terminal is sending CSI.  Nvim does not issue such a sequence and
   always uses 7-bit control sequences.
 
-==============================================================================
  vim:tw=78:ts=8:sw=2:et:ft=help:norl:


### PR DESCRIPTION
Minor cleanup; there's about ~65 more issues that are harder to resolve (mostly around literal backticks in the text) or more opinionated (no heading line before modelines).