### PR TITLE
docs: fixups

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -269,6 +269,26 @@ DiagnosticVirtualTextHint
 DiagnosticVirtualTextOk
     Used for "Ok" diagnostic virtual text.
 
+                                            *hl-DiagnosticVirtualLinesError*
+DiagnosticVirtualLinesError
+    Used for "Error" diagnostic virtual lines.
+
+                                            *hl-DiagnosticVirtualLinesWarn*
+DiagnosticVirtualLinesWarn
+    Used for "Warn" diagnostic virtual lines.
+
+                                            *hl-DiagnosticVirtualLinesInfo*
+DiagnosticVirtualLinesInfo
+    Used for "Info" diagnostic virtual lines.
+
+                                            *hl-DiagnosticVirtualLinesHint*
+DiagnosticVirtualLinesHint
+    Used for "Hint" diagnostic virtual lines.
+
+                                                *hl-DiagnosticVirtualLinesOk*
+DiagnosticVirtualLinesOk
+    Used for "Ok" diagnostic virtual lines.
+
                                                 *hl-DiagnosticUnderlineError*
 DiagnosticUnderlineError
     Used to underline "Error" diagnostics.

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -569,8 +569,10 @@ LspAttach                                                          *LspAttach*
         if not client then
           return
         end
-        -- Call your custom on_attach logic...
-        -- my_on_attach(client, vim.api.nvim_get_current_buf())
+        for bufnr, _ in pairs(client.attached_buffers) do
+          -- Call your custom on_attach logic...
+          -- my_on_attach(client, bufnr)
+        end
         return result
       end
     end)(vim.lsp.handlers['client/registerCapability'])


### PR DESCRIPTION
- Add missing diagnostics virtual lines hl groups.
- Fix LSP dynamic registration example; curbuf may not actually be attached to the client, and it may be attached to many such buffers.

Closes #33814 
