### PR TITLE
docs(lua doc): fix typing for vim.fn.winlayout

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -12106,7 +12106,7 @@ winlayout([{tabnr}])                                               *winlayout()*
                   • {tabnr} (`integer?`)
 
                 Return: ~
-                  (`any[]`)
+                  (`vim.fn.winlayout.ret`)
 
 winline()                                                            *winline()*
 		The result is a Number, which is the screen line of the cursor

--- a/runtime/lua/vim/_meta/builtin_types.lua
+++ b/runtime/lua/vim/_meta/builtin_types.lua
@@ -304,10 +304,11 @@
 
 --- @class vim.fn.winlayout.branch
 --- @field [1] "row" | "col" Node type
---- @field [2] vim.fn.winlayout.ret[] children
+--- @field [2] (vim.fn.winlayout.leaf|vim.fn.winlayout.branch)[] children
 
 --- @class vim.fn.winlayout.empty
 
 --- @alias vim.fn.winlayout.ret
 --- | vim.fn.winlayout.leaf
 --- | vim.fn.winlayout.branch
+--- | vim.fn.winlayout.empty

--- a/runtime/lua/vim/_meta/builtin_types.lua
+++ b/runtime/lua/vim/_meta/builtin_types.lua
@@ -297,3 +297,17 @@
 --- A list of dictionaries with information about
 --- undo blocks.
 --- @field entries vim.fn.undotree.entry[]
+
+--- @class vim.fn.winlayout.leaf
+--- @field [1] "leaf" Node type
+--- @field [2] integer winid
+
+--- @class vim.fn.winlayout.branch
+--- @field [1] "row" | "col" Node type
+--- @field [2] vim.fn.winlayout.ret[] children
+
+--- @class vim.fn.winlayout.empty
+
+--- @alias vim.fn.winlayout.ret
+--- | vim.fn.winlayout.leaf
+--- | vim.fn.winlayout.branch

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -11002,7 +11002,7 @@ function vim.fn.winheight(nr) end
 --- <
 ---
 --- @param tabnr? integer
---- @return vim.fn.winlayout.ret | vim.fn.winlayout.empty
+--- @return vim.fn.winlayout.ret
 function vim.fn.winlayout(tabnr) end
 
 --- The result is a Number, which is the screen line of the cursor

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -11002,7 +11002,7 @@ function vim.fn.winheight(nr) end
 --- <
 ---
 --- @param tabnr? integer
---- @return any[]
+--- @return vim.fn.winlayout.ret | vim.fn.winlayout.empty
 function vim.fn.winlayout(tabnr) end
 
 --- The result is a Number, which is the screen line of the cursor

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -13321,7 +13321,7 @@ M.funcs = {
     ]=],
     name = 'winlayout',
     params = { { 'tabnr', 'integer' } },
-    returns = 'any[]',
+    returns = 'vim.fn.winlayout.ret',
     signature = 'winlayout([{tabnr}])',
   },
   winline = {


### PR DESCRIPTION
**Problem:**
`any[]` means nothing, and the return value is not the same as what's documented in the comment:
- Lua returns:
`{ "row", { { "leaf", 1000 }, { "leaf", 1001 } } }`
- Docs say:
`{ "row", { "leaf", 1000, "leaf", 1001 } }`

<img src="https://github.com/user-attachments/assets/2bf79f99-41ff-4268-aa3c-7bd29657ef1f" width="364"/>

<br>
<br>

**Solution:**
Add some stuff to luadoc

![image](https://github.com/user-attachments/assets/5660bdb9-a20b-4410-90bd-cd9bf384166a)

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
