### PR TITLE
fix(treesitter): invalidate conceal_lines marks

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -387,6 +387,7 @@ local function on_line_impl(self, buf, line, on_spell, on_conceal)
               api.nvim_buf_set_extmark(buf, ns, start_row, 0, {
                 end_line = end_row,
                 conceal_lines = '',
+                invalidate = true,
               })
             end
           end


### PR DESCRIPTION
Problem:  Spliced conceal_lines marks after changing the buffer text are
          left valid, concealing lines that shouldn't be (until the next redraw).
Solution: Set the `invalidate` extmark property.

Fix #33808