### PR TITLE
fix(extui): hide inactive "more" window

### DIFF
--- a/runtime/lua/vim/_extui.lua
+++ b/runtime/lua/vim/_extui.lua
@@ -69,7 +69,7 @@ function M.enable(opts)
 
   -- Use MsgArea and hide search highlighting in the cmdline window.
   -- TODO: Add new highlight group/namespaces for other windows? It is
-  -- clear MsgArea would be wanted in the box, more and prompt windows.
+  -- not clear if MsgArea is wanted in the box, more and prompt windows.
   api.nvim_set_hl(ext.ns, 'Normal', { link = 'MsgArea' })
   api.nvim_set_hl(ext.ns, 'Search', { link = 'MsgArea' })
   api.nvim_set_hl(ext.ns, 'CurSearch', { link = 'MsgArea' })

--- a/runtime/lua/vim/_extui/messages.lua
+++ b/runtime/lua/vim/_extui/messages.lua
@@ -112,12 +112,11 @@ local function set_virttext(type)
       end
 
       -- Give virt_text the same highlight as the message tail.
-      local hl = api.nvim_buf_get_extmarks(ext.bufs[tar], ext.ns, { row, col }, { row, col }, {
-        details = true,
-        overlap = true,
-        type = 'highlight',
-      })
-      chunks[1][2] = hl[1] and hl[1][4].hl_group
+      local pos, opts = { row, col }, { details = true, overlap = true, type = 'highlight' }
+      local hl = api.nvim_buf_get_extmarks(ext.bufs[tar], ext.ns, pos, pos, opts)
+      for _, chunk in ipairs(hl[1] and chunks or {}) do
+        chunk[2] = hl[1][4].hl_group
+      end
     else
       local mode = #M.virt.last[M.virt.idx.mode]
       local pad = o.columns - width ---@type integer
@@ -392,6 +391,15 @@ function M.set_pos(type)
       local row = (texth.all > height and texth.end_row or 0) + 1
       api.nvim_win_set_cursor(ext.wins[ext.tab].box, { row, 0 })
     elseif type == 'more' and api.nvim_get_current_win() ~= win then
+      api.nvim_create_autocmd('WinEnter', {
+        once = true,
+        callback = function()
+          if api.nvim_win_is_valid(win) then
+            api.nvim_win_set_config(win, { hide = true })
+          end
+        end,
+        desc = 'Hide inactive more window.',
+      })
       api.nvim_set_current_win(win)
     end
   end


### PR DESCRIPTION
Problem:  More-window is left visible after leaving it. Cursor may be
          hidden behind it and it is hard to re-enter afterwards.
Solution: Close the more-window when another window is entered.

Fix #33801