### PR TITLE
fix(lsp): only auto-detach lsp.config clients

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -547,7 +547,7 @@ local function lsp_enable_callback(bufnr)
   -- Stop any clients that no longer apply to this buffer.
   local clients = lsp.get_clients({ bufnr = bufnr, _uninitialized = true })
   for _, client in ipairs(clients) do
-    if not can_start(bufnr, client.name, lsp.config[client.name]) then
+    if lsp.config[client.name] and not can_start(bufnr, client.name, lsp.config[client.name]) then
       lsp.buf_detach_client(bufnr, client.id)
     end
   end


### PR DESCRIPTION
Problem: custom server unexpectedly detached which does not use vim.lsp.config

Solution: Ensure the client is checked in `lsp.config` before initiating the detached server to avoid unexpected behavior.

Followup to https://github.com/neovim/neovim/pull/33707