### PR TITLE
fix(extui): do not overwrite cmdline with message

### DIFF
--- a/runtime/lua/vim/_extui/cmdline.lua
+++ b/runtime/lua/vim/_extui/cmdline.lua
@@ -6,7 +6,7 @@ local M = {
   indent = 0, -- Current indent for block event.
   prompt = false, -- Whether a prompt is active; messages are placed in the 'prompt' window.
   row = 0, -- Current row in the cmdline buffer, > 0 for block events.
-  level = -1, -- Current cmdline level, < 0 when inactive (otherwise unused).
+  level = 0, -- Current cmdline level, 0 when inactive (otherwise unused).
 }
 
 --- Set the 'cmdheight' and cmdline window height. Reposition message windows.
@@ -132,7 +132,7 @@ function M.cmdline_hide(_, abort)
     end)
   end
 
-  M.prompt, M.level, curpos[1], curpos[2] = false, -1, 0, 0
+  M.prompt, M.level, curpos[1], curpos[2] = false, 0, 0, 0
   win_config(ext.wins[ext.tab].cmd, true, ext.cmdheight)
 end
 

--- a/runtime/lua/vim/_extui/messages.lua
+++ b/runtime/lua/vim/_extui/messages.lua
@@ -313,15 +313,19 @@ function M.msg_show(kind, content)
     M.set_pos('prompt')
   else
     local tar = ext.cfg.msg.pos
-    M.virt.last[M.virt.idx.search][1] = tar ~= 'cmd' and M.virt.last[M.virt.idx.search][1] or nil
+    if tar == 'cmd' then
+      if ext.cmd.level > 0 then
+        return -- Do not overwrite an active cmdline.
+      end
+      -- Store the time when an error message was emitted in order to not overwrite
+      -- it with 'last' virt_text in the cmdline to give the user a chance to read it.
+      M.cmd.last_emsg = kind == 'emsg' and os.time() or M.cmd.last_emsg
+      M.virt.last[M.virt.idx.search][1] = nil
+    end
+
     M.show_msg(tar, content, replace_bufwrite, kind == 'list_cmd')
     -- Replace message for every second bufwrite message.
     replace_bufwrite = not replace_bufwrite and kind == 'bufwrite'
-    -- Store the time when an error message was emitted in order to not overwrite
-    -- it with 'last' virt_text in the cmdline to give the user a chance to read it.
-    if tar == 'cmd' and kind == 'emsg' then
-      M.cmd.last_emsg = os.time()
-    end
   end
 end
 
@@ -331,7 +335,7 @@ function M.msg_clear() end
 ---
 ---@param content MsgContent
 function M.msg_showmode(content)
-  M.virt.last[M.virt.idx.mode] = ext.cmd.level < 0 and content or {}
+  M.virt.last[M.virt.idx.mode] = ext.cmd.level > 0 and {} or content
   M.virt.last[M.virt.idx.search] = {}
   set_virttext('last')
 end


### PR DESCRIPTION
Problem:  Active cmdline may be overwritten by a message.
Solution: Check if cmdline is active before writing message.

Fix #33841