### PR TITLE
refactor(lua): switch value arguments in `tbl_extend` behavior function

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2259,15 +2259,15 @@ vim.tbl_deep_extend({behavior}, {...})                 *vim.tbl_deep_extend()*
     overwritten instead of merged).
 
     Parameters: ~
-      • {behavior}  (`'error'|'keep'|'force'|fun(key:any, v:any, prev_value:any?): any`)
+      • {behavior}  (`'error'|'keep'|'force'|fun(key:any, prev_value:any?, value:any): any`)
                     Decides what to do if a key is found in more than one map:
                     • "error": raise an error
                     • "keep": use value from the leftmost map
                     • "force": use value from the rightmost map
-                    • If a function, it receives the current key, value, and
-                      the previous value in the currently merged table (if
-                      present) and should return the value for the given key
-                      in the merged table.
+                    • If a function, it receives the current key, the previous
+                      value in the currently merged table (if present), the
+                      current value and should return the value for the given
+                      key in the merged table.
       • {...}       (`table`) Two or more tables
 
     Return: ~
@@ -2280,15 +2280,15 @@ vim.tbl_extend({behavior}, {...})                           *vim.tbl_extend()*
     Merges two or more tables.
 
     Parameters: ~
-      • {behavior}  (`'error'|'keep'|'force'|fun(key:any, v:any, prev_value:any?): any`)
+      • {behavior}  (`'error'|'keep'|'force'|fun(key:any, prev_value:any?, value:any): any`)
                     Decides what to do if a key is found in more than one map:
                     • "error": raise an error
                     • "keep": use value from the leftmost map
                     • "force": use value from the rightmost map
-                    • If a function, it receives the current key, value, and
-                      the previous value in the currently merged table (if
-                      present) and should return the value for the given key
-                      in the merged table.
+                    • If a function, it receives the current key, the previous
+                      value in the currently merged table (if present), the
+                      current value and should return the value for the given
+                      key in the merged table.
       • {...}       (`table`) Two or more tables
 
     Return: ~

--- a/runtime/lua/vim/shared.lua
+++ b/runtime/lua/vim/shared.lua
@@ -366,7 +366,7 @@ local function can_merge(v)
 end
 
 --- Recursive worker for tbl_extend
---- @param behavior 'error'|'keep'|'force'|fun(key:any, v:any, prev_value:any): any
+--- @param behavior 'error'|'keep'|'force'|fun(key:any, prev_value:any?, value:any): any
 --- @param deep_extend boolean
 --- @param ... table<any,any>
 local function tbl_extend_rec(behavior, deep_extend, ...)
@@ -382,7 +382,7 @@ local function tbl_extend_rec(behavior, deep_extend, ...)
         if deep_extend and can_merge(v) and can_merge(ret[k]) then
           ret[k] = tbl_extend_rec(behavior, true, ret[k], v)
         elseif type(behavior) == 'function' then
-          ret[k] = behavior(k, v, ret[k])
+          ret[k] = behavior(k, ret[k], v)
         elseif behavior ~= 'force' and ret[k] ~= nil then
           if behavior == 'error' then
             error('key found in more than one map: ' .. k)
@@ -397,7 +397,7 @@ local function tbl_extend_rec(behavior, deep_extend, ...)
   return ret
 end
 
---- @param behavior 'error'|'keep'|'force'|fun(key:any, v:any, prev_value:any): any
+--- @param behavior 'error'|'keep'|'force'|fun(key:any, prev_value:any?, value:any): any
 --- @param deep_extend boolean
 --- @param ... table<any,any>
 local function tbl_extend(behavior, deep_extend, ...)
@@ -427,11 +427,11 @@ end
 ---
 ---@see |extend()|
 ---
----@param behavior 'error'|'keep'|'force'|fun(key:any, v:any, prev_value:any?): any Decides what to do if a key is found in more than one map:
+---@param behavior 'error'|'keep'|'force'|fun(key:any, prev_value:any?, value:any): any Decides what to do if a key is found in more than one map:
 ---      - "error": raise an error
 ---      - "keep":  use value from the leftmost map
 ---      - "force": use value from the rightmost map
----      - If a function, it receives the current key, value, and the previous value in the currently merged table (if present) and should
+---      - If a function, it receives the current key, the previous value in the currently merged table (if present), the current value and should
 ---        return the value for the given key in the merged table.
 ---@param ... table Two or more tables
 ---@return table : Merged table
@@ -450,11 +450,11 @@ end
 ---
 ---@generic T1: table
 ---@generic T2: table
----@param behavior 'error'|'keep'|'force'|fun(key:any, v:any, prev_value:any?): any Decides what to do if a key is found in more than one map:
+---@param behavior 'error'|'keep'|'force'|fun(key:any, prev_value:any?, value:any): any Decides what to do if a key is found in more than one map:
 ---      - "error": raise an error
 ---      - "keep":  use value from the leftmost map
 ---      - "force": use value from the rightmost map
----      - If a function, it receives the current key, value, and the previous value in the currently merged table (if present) and should
+---      - If a function, it receives the current key, the previous value in the currently merged table (if present), the current value and should
 ---        return the value for the given key in the merged table.
 ---@param ... T2 Two or more tables
 ---@return T1|T2 (table) Merged table

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -1040,7 +1040,7 @@ describe('lua stdlib', function()
       local a = { a = 1, b = 2, c = 1 }
       local b = { a = -1, b = 5, c = 3, d = 4 }
       -- Return the maximum value for each key.
-      local c = vim.tbl_extend(function(k, v, prev_v)
+      local c = vim.tbl_extend(function(k, prev_v, v)
         if prev_v then
           return v > prev_v and v or prev_v
         else
@@ -1195,7 +1195,7 @@ describe('lua stdlib', function()
       local a = { a = 1, b = 2, c = { d = 1, e = -2} }
       local b = { a = -1, b = 5, c = { d = 6 } }
       -- Return the maximum value for each key.
-      local c = vim.tbl_deep_extend(function(k, v, prev_v)
+      local c = vim.tbl_deep_extend(function(k, prev_v, v)
         if prev_v then
           return v > prev_v and v or prev_v
         else


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

Following up on https://github.com/neovim/neovim/pull/33819#discussion_r2072575681.

Initially I wasn't a fan of switching the order but I think it fits better with `vim.iter(...):fold`, where the parameters to the folding function are the "accumulated" value and the current value.