### PR TITLE
fix(extui): drop "more" window that is no longer floating

### DIFF
--- a/runtime/lua/vim/_extui/shared.lua
+++ b/runtime/lua/vim/_extui/shared.lua
@@ -52,7 +52,10 @@ function M.tab_check_wins()
     end
 
     local setopt = false
-    if not api.nvim_win_is_valid(M.wins[M.tab][type]) then
+    if
+      not api.nvim_win_is_valid(M.wins[M.tab][type])
+      or not api.nvim_win_get_config(M.wins[M.tab][type]).zindex -- no longer floating
+    then
       local top = { vim.opt.fcs:get().horiz or o.ambw == 'single' and '─' or '-', 'WinSeparator' }
       local border = (type == 'more' or type == 'prompt') and { '', top, '', '', '', '', '', '' }
       local cfg = vim.tbl_deep_extend('force', wincfg, {


### PR DESCRIPTION
Problem:  Moving the "more" (or any extui)-window to a split with
          `wincmd L` does not invalidate it as a tracked window.
Solution: Drop an extui window that is no longer floating.

Fix #33852
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
