### PR TITLE
fix(termkey): fix out-of-bounds write in array

### DIFF
--- a/src/nvim/tui/termkey/driver-csi.c
+++ b/src/nvim/tui/termkey/driver-csi.c
@@ -507,7 +507,7 @@ static TermKeyResult parse_csi(TermKey *tk, size_t introlen, size_t *csi_len,
       present = 0;
       argi++;
 
-      if (argi > 16) {
+      if (argi >= 16) {
         break;
       }
     } else if (c >= 0x20 && c <= 0x2f) {


### PR DESCRIPTION
Fixes #24356

termkey was crashing Neovim due to an out-of-bounds write in an array when it received a CSI sequence with 17 or more arguments. This could be observed on startup with certain terminal emulators like [RLogin], which send a response to the `CSI c` query containing 17 parameters.

The termkey code originally included a boundary check, but its comparison operator was incorrect. This PR corrects this comparison operator to ensure proper boundary checking.

With this change, I have confirmed that the crash no longer occurs on RLogin.

[RLogin]: https://github.com/kmiya-culti/RLogin