### PR TITLE
fix(ui): prevent message box from shrinking on virt-text updates

### DIFF
--- a/runtime/lua/vim/_extui/messages.lua
+++ b/runtime/lua/vim/_extui/messages.lua
@@ -101,7 +101,10 @@ local function set_virttext(type)
       local offset = tar ~= 'box' and 0
         or api.nvim_win_get_position(win)[2] + (api.nvim_win_get_config(win).border and 1 or 0)
 
-      M.box.width = math.min(o.columns, scol - offset + width)
+      if vim.api.nvim_buf_line_count(ext.bufs.box) == 1 then
+        M.box.width = math.min(o.columns, scol - offset + width)
+      end
+
       if tar == 'box' and api.nvim_win_get_width(win) < M.box.width then
         api.nvim_win_set_width(win, M.box.width)
       end


### PR DESCRIPTION
Problem:
  set_virttext() recalculates M.box.width from lenght of the last
  message line, causing the box to shrink to that line's width.

Solution:
  Guard the width update so it only runs when the message buffer has exactly one line.

fixes #33856