### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -11,6 +11,7 @@
 "		2025 Apr 03 command substitution opening paren at EOL (#17026)
 "		2025 Apr 10 improve shell detection (#17084)
 "		2025 Apr 29 match escaped chars in test operands (#17221)
+"		2025 May 06 improve single-quote string matching in parameter expansions
 " Version:		208
 " Former URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
 " For options and settings, please use:      :help ft-sh-syntax
@@ -649,7 +650,7 @@ if exists("b:is_bash")
  syn match  shDerefOp	contained	"[,^]\{1,2}"	nextgroup=@shDerefPatternList
  syn match  shDerefOp	contained	"@[uULQEPAKa]"
 endif
-syn region shDerefString	contained	matchgroup=shDerefDelim start=+\%(\\\)\@<!'+ end=+'+	contains=shStringSpecial
+syn region shDerefString	contained	matchgroup=shDerefDelim start=+\%(\\\)\@<!'+ end=+'+
 syn region shDerefString	contained	matchgroup=shDerefDelim start=+\%(\\\)\@<!"+ skip=+\\"+ end=+"+	contains=@shDblQuoteList,shStringSpecial
 syn match  shDerefString	contained	"\\["']"	nextgroup=shDerefPattern
 

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -12,6 +12,7 @@
 "		2025 Apr 10 improve shell detection (#17084)
 "		2025 Apr 29 match escaped chars in test operands (#17221)
 "		2025 May 06 improve single-quote string matching in parameter expansions
+"		2025 May 06 match KornShell compound arrays
 " Version:		208
 " Former URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
 " For options and settings, please use:      :help ft-sh-syntax
@@ -511,13 +512,18 @@ syn match  shSetOption	"\s\zs[-+][a-zA-Z0-9]\+\>"	contained
 syn match  shVariable	"\<\h\w*\ze="			nextgroup=shVarAssign
 if exists("b:is_bash")
  " The subscript form for array values, e.g. "foo=([2]=10 [4]=100)".
- syn region shArrayValue	contained	start="\[\%(..\{-}\]=\)\@=" end="\]=\@="	contains=@shArrayValueList nextgroup=shVarAssign
+ syn region  shArrayValue	contained	start="\[\%(..\{-}\]=\)\@=" end="\]=\@="	contains=@shArrayValueList nextgroup=shVarAssign
  syn cluster shArrayValueList	contains=shArithmetic,shArithParen,shCommandSub,shDeref,shDerefSimple,shExpr,shNumber,shExSingleQuote,shExDoubleQuote,shSingleQuote,shDoubleQuote,shSpecial,shParen,bashSpecialVariables,shParenError
+ syn region  shArrayRegion	contained matchgroup=shShellVariables start="(" skip='\\\\\|\\.' end=")" contains=@shArrayValueList,shArrayValue,shComment
+elseif exists("b:is_kornshell")
+ " The subscript form for array values, e.g. "foo=([2]=10 [4]=100)".
+ syn region  shArrayValue	contained	start="\[\%(..\{-}\]=\)\@=" end="\]=\@="	contains=@shArrayValueList nextgroup=shVarAssign
+ syn cluster shArrayValueList	contains=shArithmetic,shArithParen,shCommandSub,shDeref,shDerefSimple,shExpr,shNumber,shExSingleQuote,shExDoubleQuote,shSingleQuote,shDoubleQuote,shSpecial,shParen,kshSpecialVariables,shParenError
+ syn region  shArrayRegion	contained matchgroup=shShellVariables start="(" skip='\\\\\|\\.' end=")" contains=@shArrayValueList,shArrayValue,shComment,shArrayRegion
 endif
 if exists("b:is_bash") || exists("b:is_kornshell")
  syn match shVariable	"\<\h\w*\%(\[..\{-}\]\)\=\ze\%([|^&*/%+-]\|[<^]<\|[>^]>\)\=="	contains=shDerefVarArray nextgroup=shVarAssign
  syn match shVarAssign	contained	"\%([|^&*/%+-]\|[<^]<\|[>^]>\)\=="	nextgroup=shArrayRegion,shPattern,shDeref,shDerefSimple,shDoubleQuote,shExDoubleQuote,shSingleQuote,shExSingleQuote,shVar
- syn region shArrayRegion	contained matchgroup=shShellVariables start="(" skip='\\\\\|\\.' end=")" contains=@shArrayValueList,shArrayValue,shComment
 else
  syn match  shVarAssign	contained	"="	nextgroup=shPattern,shDeref,shDerefSimple,shDoubleQuote,shExDoubleQuote,shSingleQuote,shExSingleQuote,shVar
 endif

--- a/runtime/syntax/spec.vim
+++ b/runtime/syntax/spec.vim
@@ -5,6 +5,7 @@
 " Former Maintainer:  Donovan Rebbechi elflord@panix.com (until March 2014)
 " Last Change: 2020 May 25
 "  2024 Sep 10 by Vim Project: add file triggers support, #15569
+"  2025 May 05 by Vim Project: update for rpm 4.2 #17258
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -72,7 +73,7 @@ syn keyword specMacroNameOther contained buildroot buildsubdir distribution dist
 syn match   specMacroNameOther contained '\<\(PATCH\|SOURCE\)\d*\>'
 
 "valid _macro names from /usr/lib/rpm/macros
-syn keyword specMacroNameLocal contained _arch _binary_payload _bindir _build _build_alias _build_cpu _builddir _build_os _buildshell _buildsubdir _build_vendor _bzip2bin _datadir _dbpath _dbpath_rebuild _defaultdocdir _docdir _excludedocs _exec_prefix _fixgroup _fixowner _fixperms _ftpport _ftpproxy _gpg_path _gzipbin _host _host_alias _host_cpu _host_os _host_vendor _httpport _httpproxy _includedir _infodir _install_langs _install_script_path _instchangelog _langpatt _lib _libdir _libexecdir _localstatedir _mandir _netsharedpath _oldincludedir _os _pgpbin _pgp_path _prefix _preScriptEnvironment _provides _rpmdir _rpmfilename _sbindir _sharedstatedir _signature _sourcedir _source_payload _specdir _srcrpmdir _sysconfdir _target _target_alias _target_cpu _target_os _target_platform _target_vendor _timecheck _tmppath _topdir _usr _unitdir _usrsrc _var _vendor
+syn keyword specMacroNameLocal contained _arch _binary_payload _bindir _build _build_alias _build_cpu _build_os _build_vendor _builddir _buildshell _buildsubdir _bzip2bin _datadir _dbpath _dbpath_rebuild _defaultdocdir _defaultlicensedir _docdir _excludedocs _exec_prefix _fixgroup _fixowner _fixperms _ftpport _ftpproxy _gpg_path _group_path _gzipbin _host _host_alias _host_cpu _host_os _host_vendor _httpport _httpproxy _iconsdir _includedir _infodir _install_langs _install_script_path _instchangelog _keyring _keyringpath _langpatt _lib _libdir _libexecdir _localstatedir _mandir _netsharedpath _oldincludedir _os _passwd_path _pgp_path _pgpbin _preScriptEnvironment _prefix _provides _rpmconfigdir _rpmdir _rpmfilename _rpmformat _rpmluadir _rpmmacrodir _sbindir _sharedstatedir _signature _source_payload _sourcedir _specdir _srcrpmdir _sysconfdir _sysusersdir _target _target_alias _target_cpu _target_os _target_platform _target_vendor _timecheck _tmppath _topdir _unitdir _usr _usrsrc _var _vendor
 
 
 "------------------------------------------------------------------------------


### PR DESCRIPTION
#### vim-patch:fe22867: runtime(sh): Update syntax, fix single-quoted strings in parameter expansions

Ignore single-quoted backslash escape sequences in parameter expansions.

\' is not an escaped single quote in ${foo:-'word\'}.

closes: vim/vim#17261

https://github.com/vim/vim/commit/fe22867ef564ea78cafaabe0c784222638399cb9

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:adfeb4a: runtime(spec): add more local macro names according to rpm 4.20

closes: vim/vim#17258

https://github.com/vim/vim/commit/adfeb4ad95ca2522b966fde1bb0d8ccc8c1dc8a8

Co-authored-by: fundawang <fundawang@yeah.net>


#### vim-patch:87947a9: runtime(sh): Update syntax, match KornShell compound arrays

closes: vim/vim#17268

https://github.com/vim/vim/commit/87947a9a769ad43216beae7946c8b0bda9f8024a

Co-authored-by: Doug Kearns <dougkearns@gmail.com>