### PR TITLE
feat(logs): show full paths in lsp logs

### DIFF
--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -132,10 +132,10 @@ local function create_logger(level, levelnr)
     end
     local info = debug.getinfo(2, 'Sl')
     local header = string.format(
-      '[%s][%s] ...%s:%s',
+      '[%s][%s] %s:%s',
       level,
       os.date(log_date_format),
-      info.short_src:sub(-16),
+      info.short_src,
       info.currentline
     )
     local parts = { header }


### PR DESCRIPTION
Remove 16 character limit on path lengths in lsp log messages to allow using `gf`.

From this:
```
[DEBUG][2025-05-07 08:10:35] ...m/lsp/client.lua:677  .............
```
To this:
```
[DEBUG][2025-05-07 23:03:08] /usr/local/share/nvim/runtime/lua/vim/lsp/rpc.lua:393 ............
```

I originally also proposed logging to print lua tables as markdown to get syntax highlighting and formatted lua tables but that can instead be done via `vim.lsp.log.set_format_func()`

```lua
vim.lsp.log.set_format_func(function(args)
    return '\n```lua\n' .. vim.inspect(args) .. '\n```\n'
end)

vim.api.nvim_create_autocmd("BufRead", {
    pattern = vim.lsp.log.get_filename(),
    callback = function()
        vim.bo.filetype = "markdown"
    end,
})
```
Prints the logs like so:

![image](https://github.com/user-attachments/assets/54549c10-ac3b-44b7-9e99-3ee32a795f66)

-------------------------------------------
ORIGINAL MESSAGE

# Pretty LSP Logs
LSP logs are impossible to read. These commits print it as markdown to take advantage of markdown highlighting of lua tables.


## What logs looked like before:

![BEFORE](https://github.com/user-attachments/assets/b5fc24f8-6f4c-46ba-b542-f8dbee2c4b34)

## What logs look like after:

![AFTER](https://github.com/user-attachments/assets/ce2ab715-b3d5-43c8-a2ad-d6ce78fbf7db)
