### PR TITLE
feat(exrc): search in parent directories

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -122,6 +122,7 @@ DEFAULTS
 
 • 'statusline' default is exposed as a statusline expression (previously it
   was implemented as an internal C routine).
+• Project-local configuration ('exrc') is also loaded from parent directories.
 
 DIAGNOSTICS
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2412,9 +2412,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 'exrc' 'ex'		boolean	(default off)
 			global
 	Enables project-local configuration. Nvim will execute any .nvim.lua,
-	.nvimrc, or .exrc file found in the |current-directory|, if the file is
-	in the |trust| list. Use |:trust| to manage trusted files. See also
-	|vim.secure.read()|.
+	.nvimrc, or .exrc file found in the |current-directory| and all parent
+	directories (ordered upwards), if the files are in the |trust| list.
+	Use |:trust| to manage trusted files. See also |vim.secure.read()|.
 
 	Compare 'exrc' to |editorconfig|:
 	- 'exrc' can execute any code; editorconfig only specifies settings.

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -209,6 +209,10 @@ nvim.swapfile:
   swapfile is owned by a running Nvim process. Shows |W325| "Ignoring
   swapfile…" message.
 
+nvim.find_exrc:
+- VimEnter: Extend 'exrc' to also search for project-local configuration files
+  in all parent directories.
+
 ==============================================================================
 New Features                                                   *nvim-features*
 

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -925,6 +925,29 @@ do
       end
     end
   end
+
+  vim.api.nvim_create_autocmd('VimEnter', {
+    group = vim.api.nvim_create_augroup('nvim.find_exrc', {}),
+    desc = 'Find project-local configuration',
+    callback = function()
+      if vim.o.exrc then
+        local files = vim.fs.find(
+          { '.nvim.lua', '.nvimrc', '.exrc' },
+          { type = 'file', upward = true, limit = math.huge }
+        )
+        for _, file in ipairs(files) do
+          local trusted = vim.secure.read(file) --[[@as string|nil]]
+          if trusted then
+            if vim.endswith(file, '.lua') then
+              loadstring(trusted)()
+            else
+              vim.api.nvim_exec2(trusted, {})
+            end
+          end
+        end
+      end
+    end,
+  })
 end
 
 --- Default options

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -2076,9 +2076,9 @@ vim.bo.expandtab = vim.o.expandtab
 vim.bo.et = vim.bo.expandtab
 
 --- Enables project-local configuration. Nvim will execute any .nvim.lua,
---- .nvimrc, or .exrc file found in the `current-directory`, if the file is
---- in the `trust` list. Use `:trust` to manage trusted files. See also
---- `vim.secure.read()`.
+--- .nvimrc, or .exrc file found in the `current-directory` and all parent
+--- directories (ordered upwards), if the files are in the `trust` list.
+--- Use `:trust` to manage trusted files. See also `vim.secure.read()`.
 ---
 --- Compare 'exrc' to `editorconfig`:
 --- - 'exrc' can execute any code; editorconfig only specifies settings.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2745,9 +2745,9 @@ local options = {
       defaults = false,
       desc = [=[
         Enables project-local configuration. Nvim will execute any .nvim.lua,
-        .nvimrc, or .exrc file found in the |current-directory|, if the file is
-        in the |trust| list. Use |:trust| to manage trusted files. See also
-        |vim.secure.read()|.
+        .nvimrc, or .exrc file found in the |current-directory| and all parent
+        directories (ordered upwards), if the files are in the |trust| list.
+        Use |:trust| to manage trusted files. See also |vim.secure.read()|.
 
         Compare 'exrc' to |editorconfig|:
         - 'exrc' can execute any code; editorconfig only specifies settings.
@@ -2765,7 +2765,7 @@ local options = {
       full_name = 'exrc',
       scope = { 'global' },
       secure = true,
-      short_desc = N_('read .nvimrc and .exrc in the current directory'),
+      short_desc = N_('read project-local configuration in parent directories'),
       tags = { 'project-config', 'workspace-config' },
       type = 'boolean',
       varname = 'p_exrc',


### PR DESCRIPTION
Problem:
`.nvim.lua` is only loaded from current directory, which is not flexible when starting Nvim from a project subfolder.

Solution:
Also search parent directories for configuration file, executing them consecutively.

Fixes #33869, with the caveat that that issue describes to stop at the first encounter, while this PR executes all exrc files (after trusting). 

Future considerations:
- also do it on `DirChanged`?