### PR TITLE
test(swapfile): don't check for line with full file path

### DIFF
--- a/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
+++ b/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
@@ -451,8 +451,8 @@ pcall(vim.cmd.edit, 'Xtest_swapredraw.lua')
       screen:expect({
         any = table.concat({
           pesc('{2:E325: ATTENTION}'),
-          'file name: .*Xswaptest',
-          'process ID: %d* %(STILL RUNNING%)',
+          '\n        process ID: %d* %(STILL RUNNING%)',
+          '\nWhile opening file "Xswaptest"',
           pesc('{1:[O]pen Read-Only, (E)dit anyway, (R)ecover, (Q)uit, (A)bort: }^'),
         }, '.*'),
       })


### PR DESCRIPTION
Wrapping can happen anywhere where in the full file path, breaking the
matching. Match a line with the "Xswaptest" line instead.

Fix #33892
