### PR TITLE
 test(lsp): add a test to verify custom LSP servers aren't auto-detached

### DIFF
--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -6568,20 +6568,35 @@ describe('LSP', function()
         return exec_lua(function()
           local foos = vim.lsp.get_clients({ name = 'foo', bufnr = 0 })
           local bars = vim.lsp.get_clients({ name = 'bar', bufnr = 0 })
-          return { #foos, 'foo', #bars, 'bar' }
+          local bazs = vim.lsp.get_clients({ name = 'baz', bufnr = 0 })
+          return { #foos, 'foo', #bars, 'bar', #bazs, 'baz' }
         end)
       end
 
       -- No filetype on the buffer yet, so no LSPs.
-      eq({ 0, 'foo', 0, 'bar' }, count_clients())
+      eq({ 0, 'foo', 0, 'bar', 0, 'baz' }, count_clients())
 
-      -- Set the filetype to 'foo', confirm a LSP starts.
+      -- Start a LSP manually. This does not have a corresponding `lsp.config`, and should *not* get
+      -- cleaned up when the filetype changes.
+      exec_lua(function()
+        local server = _G._create_server({
+          handlers = {
+            initialize = function(_, _, callback)
+              callback(nil, { capabilities = {} })
+            end,
+          },
+        })
+
+        vim.lsp.start({ name = 'baz', cmd = server.cmd }, { bufnr = 0 })
+      end)
+
+      -- Set the filetype to 'foo', confirm an LSP starts.
       exec_lua([[vim.bo.filetype = 'foo']])
-      eq({ 1, 'foo', 0, 'bar' }, count_clients())
+      eq({ 1, 'foo', 0, 'bar', 1, 'baz' }, count_clients())
 
       -- Set the filetype to 'bar', confirm a new LSP starts, and the old one goes away.
       exec_lua([[vim.bo.filetype = 'bar']])
-      eq({ 0, 'foo', 1, 'bar' }, count_clients())
+      eq({ 0, 'foo', 1, 'bar', 1, 'baz' }, count_clients())
     end)
 
     it('validates config on attach', function()


### PR DESCRIPTION
@glepnir already fixed the original bug in
https://github.com/neovim/neovim/commit/91e116f3a6719e9dc7652f4e0a4b1760dfbf1af0, I just wanted to add a test to make sure we don't regress in the future.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
