### PR TITLE
feat(diagnostic): expose render functions

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -899,6 +899,19 @@ render_virtual_lines({namespace}, {bufnr}, {diagnostics})
       • {diagnostics}  (`vim.Diagnostic[]`) Diagnostics to display. See
                        |vim.Diagnostic|.
 
+                                        *vim.diagnostic.render_virtual_text()*
+render_virtual_text({namespace}, {bufnr}, {diagnostics}, {opts})
+    Displays the given diagnostics as virtual text.
+
+    Parameters: ~
+      • {namespace}    (`integer`) Diagnostic namespace ID
+      • {bufnr}        (`integer?`) Buffer handle, or 0 for current (default:
+                       0)
+      • {diagnostics}  (`vim.Diagnostic[]`) Diagnostics to display. See
+                       |vim.Diagnostic|.
+      • {opts}         (`vim.diagnostic.Opts.VirtualText?`) See
+                       |vim.diagnostic.Opts.VirtualText|.
+
 reset({namespace}, {bufnr})                           *vim.diagnostic.reset()*
     Remove all diagnostics from the given namespace.
 

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -888,6 +888,17 @@ open_float({opts})                               *vim.diagnostic.open_float()*
         (`integer?`) float_bufnr
         (`integer?`) winid
 
+                                       *vim.diagnostic.render_virtual_lines()*
+render_virtual_lines({namespace}, {bufnr}, {diagnostics})
+    Displays the given diagnostics as virtual lines.
+
+    Parameters: ~
+      • {namespace}    (`integer`) Diagnostic namespace ID
+      • {bufnr}        (`integer?`) Buffer handle, or 0 for current (default:
+                       0)
+      • {diagnostics}  (`vim.Diagnostic[]`) Diagnostics to display. See
+                       |vim.Diagnostic|.
+
 reset({namespace}, {bufnr})                           *vim.diagnostic.reset()*
     Remove all diagnostics from the given namespace.
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Part of https://github.com/neovim/neovim/issues/33154

Together with https://github.com/neovim/neovim/pull/33850, these allow folks to display virtual lines/text when jumping to a diagnostic (similar to what we do today with `open_float`).