### PR TITLE
fix(lsp): avoid `foldclose()` after the buffer in the window has changed

### DIFF
--- a/runtime/lua/vim/lsp/_folding_range.lua
+++ b/runtime/lua/vim/lsp/_folding_range.lua
@@ -345,7 +345,10 @@ function M.foldclose(kind, winid)
   local params = { textDocument = util.make_text_document_params(bufnr) }
   vim.lsp.buf_request_all(bufnr, ms.textDocument_foldingRange, params, function(...)
     multi_handler(...)
-    foldclose(kind, winid)
+    -- Ensure this buffer stays as the current buffer after the async request
+    if api.nvim_win_get_buf(winid) == bufnr then
+      foldclose(kind, winid)
+    end
   end)
 end
 


### PR DESCRIPTION
Problem:

Because the buffer in the window may change before the request is completed, `foldclose()` might be executed on the wrong buffer.

Solution:

Avoid that.