### PR TITLE
refactor(lsp): deprecate vim.lsp.util._refresh()

### DIFF
--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -252,11 +252,17 @@ end
 --- @param bufnr integer
 --- @param client_id? integer
 function M._buf_refresh(bufnr, client_id)
-  util._refresh(ms.textDocument_documentColor, {
-    bufnr = bufnr,
-    handler = on_document_color,
-    client_id = client_id,
-  })
+  for _, client in
+    ipairs(lsp.get_clients({
+      bufnr = bufnr,
+      id = client_id,
+      method = ms.textDocument_documentColor,
+    }))
+  do
+    ---@type lsp.DocumentColorParams
+    local params = { textDocument = util.make_text_document_params(bufnr) }
+    client:request(ms.textDocument_documentColor, params, on_document_color)
+  end
 end
 
 --- Query whether document colors are enabled in the given buffer.


### PR DESCRIPTION
 There is an explanation in https://github.com/neovim/neovim/pull/32887#discussion_r1996413602. A quick recap:

- This function is only used by `inlay_hint.lua` and `document_color.lua`, and both have their own wrapper functions;
- This function provides unified parameters, but this layer of wrapping is almost meaningless because
  - document color does not need the range parameter;
  - inlay hint requires a range parameter, but it is not complicated

Therefore, it can basically be considered redundant. This function seems to be for internal use only, so it should be possible to remove it?