### PR TITLE
fix: `jobstart(…,{term=true})` accepts `width`/`height`

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3595,8 +3595,8 @@ void f_jobstart(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     }
   }
 
-  uint16_t width = 0;
-  uint16_t height = 0;
+  uint16_t width = (uint16_t)tv_dict_get_number(job_opts, "width");
+  uint16_t height = (uint16_t)tv_dict_get_number(job_opts, "height");
   char *term_name = NULL;
 
   if (term) {
@@ -3616,13 +3616,11 @@ void f_jobstart(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     overlapped = false;
     detach = false;
     stdin_mode = kChannelStdinPipe;
-    width = (uint16_t)MAX(0, curwin->w_view_width - win_col_off(curwin));
-    height = (uint16_t)curwin->w_view_height;
+    width = width ? width : (uint16_t)MAX(0, curwin->w_view_width - win_col_off(curwin));
+    height = height ? height : (uint16_t)curwin->w_view_height;
   }
 
   if (pty) {
-    width = width ? width : (uint16_t)tv_dict_get_number(job_opts, "width");
-    height = height ? height : (uint16_t)tv_dict_get_number(job_opts, "height");
     // Deprecated TERM field is from before `env` option existed.
     term_name = term_name ? term_name : tv_dict_get_string(job_opts, "TERM", false);
     term_name = term_name ? term_name : "ansi";

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -97,6 +97,28 @@ describe('jobs', function()
     command("call jobstart(['cat', '-'], { 'term': v:false })")
   end)
 
+  it('jobstart(term=true) accepts width/height (#33904)', function()
+    local buf = api.nvim_create_buf(false, true)
+    exec_lua(function()
+      vim.api.nvim_buf_call(buf, function()
+        vim.fn.jobstart({
+          vim.v.progpath,
+          '--clean',
+          '--headless',
+          '+lua print(vim.uv.new_tty(0, true):get_winsize())',
+        }, {
+          term = true,
+          width = 11,
+          height = 12,
+          env = { VIMRUNTIME = os.getenv('VIMRUNTIME') },
+        })
+      end)
+    end)
+    retry(nil, nil, function()
+      eq({ '11 12' }, api.nvim_buf_get_lines(buf, 0, 1, false))
+    end)
+  end)
+
   it('must specify env option as a dict', function()
     command('let g:job_opts.env = v:true')
     local _, err = pcall(function()

--- a/test/functional/core/job_spec.lua
+++ b/test/functional/core/job_spec.lua
@@ -105,7 +105,7 @@ describe('jobs', function()
           vim.v.progpath,
           '--clean',
           '--headless',
-          '+lua print(vim.uv.new_tty(0, true):get_winsize())',
+          '+lua print(vim.uv.new_tty(1, false):get_winsize())',
         }, {
           term = true,
           width = 11,


### PR DESCRIPTION
## Problem
To create a hidden terminal job I use `nvim_buf_call`+
`jobstart(…,{term=true})`. Then I found `lazygit` cannot figure out the
correct width and height:

![Image](https://github.com/user-attachments/assets/5b81d852-3daf-4888-9a8c-7aa13c982ae6)

Then I try to use `jobstart(…,{term=true,width=xx,height=xx})`, but it
also doesn't work now.
https://github.com/neovim/neovim/blob/fc2dee17368d76e7e845872990bb6fdef1c6bf54/src/nvim/eval/funcs.c#L4022-L4023

Here's a workaournd, but looks ugly I wonder if we could just support
`width`/`height` for `term=true`?
```lua
local api, fn = vim.api, vim.fn

local create_job = function()
  local buf = api.nvim_create_buf(false, true)
  local tmpwin = api.nvim_open_win(buf, false, {
    relative = 'editor',
    row = 0,
    col = 0,
    hide = true,
    focusable = false,
    style = 'minimal',
    height = vim.o.lines,
    width = vim.o.columns,
  })
  local job = api.nvim_win_call(tmpwin, function()
    return api.nvim_buf_call(buf, function()
      return fn.jobstart({ 'lazygit' }, {
        term = true,
        -- useless since we're using `term=true`
        -- height = vim.o.lines,
        -- width = vim.o.columns,
      })
    end)
  end)
  api.nvim_win_close(tmpwin, true)
  return job
end

local job = create_job()

local open = function()
  local buf = api.nvim_get_chan_info(job).buffer
  api.nvim_open_win(buf, true, {
    relative = 'editor',
    row = 0,
    col = 0,
    style = 'minimal',
    width = vim.o.columns,
    height = vim.o.lines,
  })
end

open()
```

## Solution
`jobstart(…,{term=true})` accepts `width`/`height`

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
