### PR TITLE
fix(lsp): nil error in ColorScheme autocmd

### DIFF
--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -303,7 +303,7 @@ api.nvim_create_autocmd('ColorScheme', {
 
     for _, bufnr in ipairs(api.nvim_list_bufs()) do
       buf_clear(bufnr)
-      if api.nvim_buf_is_loaded(bufnr) and bufstates[bufnr].enabled then
+      if api.nvim_buf_is_loaded(bufnr) and vim.tbl_get(bufstates, bufnr, 'enabled') then
         M._buf_refresh(bufnr)
       else
         reset_bufstate(bufnr, false)


### PR DESCRIPTION
Problem: nil error possible if a loaded buffer hasn't been drawn in a window:

```vim
lua vim.lsp.document_color.is_enabled() -- Load module
badd foo
call bufload('foo')
colo default
```

Solution: Skip _buf_refresh branch also if bufstates[bufnr] is nil.

I won't merge this one as to give @MariaSolOs a chance to try out the shiny new button! :partying_face: :sparkles: 