### PR TITLE
test(treesitter): disable flaky test when TEST_SKIP_FRAGILE is set

### DIFF
--- a/test/functional/treesitter/fold_spec.lua
+++ b/test/functional/treesitter/fold_spec.lua
@@ -718,6 +718,12 @@ t3]])
   end)
 
   it("doesn't open folds that are not touched", function()
+    -- test is known to be flaky
+    -- https://github.com/neovim/neovim/issues/33910
+    if t.skip_fragile(pending) then
+      return
+    end
+
     local screen = Screen.new(40, 8)
     screen:set_default_attr_ids({
       [1] = { foreground = Screen.colors.DarkBlue, background = Screen.colors.Gray },


### PR DESCRIPTION
ref: https://github.com/neovim/neovim/issues/33910#issuecomment-2863276239

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
