### PR TITLE
fix(terminal): check size when switching buffers

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1773,6 +1773,10 @@ void enter_buffer(buf_T *buf)
   }
   curbuf->b_last_used = time(NULL);
 
+  if (curbuf->terminal != NULL) {
+    terminal_check_size(curbuf->terminal);
+  }
+
   redraw_later(curwin, UPD_NOT_VALID);
 }
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2742,6 +2742,9 @@ theend:
   if (bufref_valid(&old_curbuf) && old_curbuf.br_buf->terminal != NULL) {
     terminal_check_size(old_curbuf.br_buf->terminal);
   }
+  if ((!bufref_valid(&old_curbuf) || curbuf != old_curbuf.br_buf) && curbuf->terminal != NULL) {
+    terminal_check_size(curbuf->terminal);
+  }
 
   if (did_inc_redrawing_disabled) {
     RedrawingDisabled--;

--- a/test/functional/terminal/buffer_spec.lua
+++ b/test/functional/terminal/buffer_spec.lua
@@ -322,6 +322,27 @@ describe(':terminal buffer', function()
     eq({ mode = 'nt', blocking = false }, api.nvim_get_mode())
     command('bd!')
   end)
+
+  it('correct size when switching buffers', function()
+    local term_buf = api.nvim_get_current_buf()
+    command('file foo | enew | vsplit')
+    api.nvim_set_current_buf(term_buf)
+    screen:expect([[
+      tty ready                │                        |
+      ^rows: 5, cols: 25        │{4:~                       }|
+                               │{4:~                       }|*3
+      {17:foo [-]                   }{1:[No Name]               }|
+                                                        |
+    ]])
+
+    feed('<C-^><C-W><C-O><C-^>')
+    screen:expect([[
+      tty ready                                         |
+      ^rows: 5, cols: 25                                 |
+      rows: 6, cols: 50                                 |
+                                                        |*4
+    ]])
+  end)
 end)
 
 describe(':terminal buffer', function()


### PR DESCRIPTION
Problem: terminal not always resized when switching to its buffer.
Solution: add missing calls to terminal_check_size.

Ref: https://github.com/neovim/neovim/pull/33904#issuecomment-2862646996
