### PR TITLE
feat(extui): assign 'filetype' to extui windows

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2691,6 +2691,19 @@ To enable the experimental UI (default opts shown): >lua
     })
 <
 
+There are four separate window types used by this interface:
+• "cmd": The cmdline window; also used for 'showcmd', 'showmode', 'ruler', and
+  messages if 'cmdheight' > 0.
+• "box": The message box window; used for messages when 'cmdheight' == 0.
+• "more": The more-prompt window; used for |:messages| and certain messages
+  that should be shown in full.
+• "prompt": The cmdline prompt window; used for prompt messages that expect
+  user input.
+
+These four windows are assigned the "cmdline", "msgbox", "msgmore" and
+"msgprompt" 'filetype' respectively. Use a |FileType| autocommand to configure
+any local options for these windows and their respective buffers.
+
 
 
 ==============================================================================

--- a/runtime/lua/vim/_extui.lua
+++ b/runtime/lua/vim/_extui.lua
@@ -17,6 +17,19 @@
 ---  },
 ---})
 ---```
+---
+---There are four separate window types used by this interface:
+---- "cmd": The cmdline window; also used for 'showcmd', 'showmode', 'ruler', and
+---  messages if 'cmdheight' > 0.
+---- "box": The message box window; used for messages when 'cmdheight' == 0.
+---- "more": The more-prompt window; used for |:messages| and certain messages
+---   that should be shown in full.
+---- "prompt": The cmdline prompt window; used for prompt messages that expect
+---   user input.
+---
+---These four windows are assigned the "cmdline", "msgbox", "msgmore" and
+---"msgprompt" 'filetype' respectively. Use a |FileType| autocommand to configure
+---any local options for these windows and their respective buffers.
 
 local api = vim.api
 local ext = require('vim._extui.shared')
@@ -90,24 +103,17 @@ function M.enable(opts)
         ext.msg.prev_msg = ''
       end
       ext.cmdheight = value
-    elseif name == 'termguicolors' then
-      -- 'termguicolors' toggled; add or remove border and set 'winblend' for box windows.
-      for _, tab in ipairs(api.nvim_list_tabpages()) do
-        api.nvim_win_set_config(ext.wins[tab].box, { border = value and 'none' or 'single' })
-        vim.wo[ext.wins[tab].box].winblend = value and 30 or 0
-      end
     end
   end
 
   if vim.v.vim_did_enter == 1 then
     ext.tab_check_wins()
     check_opt('cmdheight', vim.o.cmdheight)
-    check_opt('termguicolors', vim.o.termguicolors)
   end
 
   api.nvim_create_autocmd('OptionSet', {
     group = ext.augroup,
-    pattern = { 'cmdheight', 'termguicolors' },
+    pattern = { 'cmdheight' },
     callback = function(ev)
       ext.tab_check_wins()
       check_opt(ev.match, vim.v.option_new)
@@ -122,7 +128,6 @@ function M.enable(opts)
       ext.tab_check_wins()
       if ev.event == 'VimEnter' then
         check_opt('cmdheight', vim.o.cmdheight)
-        check_opt('termguicolors', vim.o.termguicolors)
       end
       ext.msg.set_pos()
     end,

--- a/runtime/lua/vim/_extui/shared.lua
+++ b/runtime/lua/vim/_extui/shared.lua
@@ -47,7 +47,7 @@ function M.tab_check_wins()
         M.cmd.highlighter = vim.treesitter.highlighter.new(parser)
       elseif type == 'more' then
         -- Close more window with `q`, same as `checkhealth`
-        vim.keymap.set('n', 'q', '<C-w>c', { buffer = M.bufs.more })
+        api.nvim_buf_set_keymap(M.bufs.more, 'n', 'q', '<C-w>c', {})
       end
     end
 
@@ -80,12 +80,15 @@ function M.tab_check_wins()
     end
 
     if setopt then
-      if type == 'box' and o.termguicolors then
-        vim.wo[M.wins[M.tab][type]].winblend = 30
-      end
-      vim.wo[M.wins[M.tab][type]].linebreak = false
-      vim.wo[M.wins[M.tab][type]].smoothscroll = true
-      vim.wo[M.wins[M.tab][type]].eventignorewin = 'all'
+      -- Fire a FileType autocommand with window context to let the user reconfigure local options.
+      api.nvim_win_call(M.wins[M.tab][type], function()
+        api.nvim_set_option_value('wrap', true, { scope = 'local' })
+        api.nvim_set_option_value('linebreak', false, { scope = 'local' })
+        api.nvim_set_option_value('smoothscroll', true, { scope = 'local' })
+        local ft = type == 'cmd' and 'cmdline' or ('msg' .. type)
+        api.nvim_set_option_value('filetype', ft, { scope = 'local' })
+        api.nvim_set_option_value('eventignorewin', 'all', { scope = 'local' })
+      end)
     end
   end
 end


### PR DESCRIPTION
Problem:  Unable to discern windows used by the extui interface
          to configure their local options.
          'winblend' may be detrimental to legibility depending on the
          colorscheme and 'background'.
Solution: Assign the "cmdline", "msgmore", "msgprompt" and "msgbox" 
          'filetype' to the respective windows.
          Don't set 'winblend' for the message "box" window.

Fix #33871
Fix #33891