### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1528,8 +1528,6 @@ cursor({list})
 		position within a <Tab> or after the last character.
 		Returns 0 when the position could be set, -1 otherwise.
 
-		Returns 0 when the position could be set, -1 otherwise.
-
                 Parameters: ~
                   • {list} (`integer[]`)
 

--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1528,6 +1528,8 @@ cursor({list})
 		position within a <Tab> or after the last character.
 		Returns 0 when the position could be set, -1 otherwise.
 
+		Returns 0 when the position could be set, -1 otherwise.
+
                 Parameters: ~
                   • {list} (`integer[]`)
 
@@ -2457,7 +2459,7 @@ finddir({name} [, {path} [, {count}]])                               *finddir()*
                   • {count} (`integer?`)
 
                 Return: ~
-                  (`any`)
+                  (`string|string[]`)
 
 findfile({name} [, {path} [, {count}]])                             *findfile()*
 		Just like |finddir()|, but find a file instead of a directory.
@@ -2470,10 +2472,10 @@ findfile({name} [, {path} [, {count}]])                             *findfile()*
                 Parameters: ~
                   • {name} (`string`)
                   • {path} (`string?`)
-                  • {count} (`any?`)
+                  • {count} (`integer?`)
 
                 Return: ~
-                  (`any`)
+                  (`string|string[]`)
 
 flatten({list} [, {maxdepth}])                                       *flatten()*
 		Flatten {list} up to {maxdepth} levels.  Without {maxdepth}
@@ -8941,6 +8943,8 @@ setcursorcharpos({list})
 <		positions the cursor on the third character '세'. >vim
 			call cursor(4, 3)
 <		positions the cursor on the first character '여'.
+
+		Returns 0 when the position could be set, -1 otherwise.
 
                 Parameters: ~
                   • {list} (`integer[]`)

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -1350,6 +1350,8 @@ function vim.fn.cursor(lnum, col, off) end
 --- position within a <Tab> or after the last character.
 --- Returns 0 when the position could be set, -1 otherwise.
 ---
+--- Returns 0 when the position could be set, -1 otherwise.
+---
 --- @param list integer[]
 --- @return any
 function vim.fn.cursor(list) end
@@ -2197,7 +2199,7 @@ function vim.fn.filter(expr1, expr2) end
 --- @param name string
 --- @param path? string
 --- @param count? integer
---- @return any
+--- @return string|string[]
 function vim.fn.finddir(name, path, count) end
 
 --- Just like |finddir()|, but find a file instead of a directory.
@@ -2209,8 +2211,8 @@ function vim.fn.finddir(name, path, count) end
 ---
 --- @param name string
 --- @param path? string
---- @param count? any
---- @return any
+--- @param count? integer
+--- @return string|string[]
 function vim.fn.findfile(name, path, count) end
 
 --- Flatten {list} up to {maxdepth} levels.  Without {maxdepth}
@@ -8149,6 +8151,8 @@ function vim.fn.setcursorcharpos(lnum, col, off) end
 --- <positions the cursor on the third character '세'. >vim
 ---   call cursor(4, 3)
 --- <positions the cursor on the first character '여'.
+---
+--- Returns 0 when the position could be set, -1 otherwise.
 ---
 --- @param list integer[]
 --- @return any

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -1350,8 +1350,6 @@ function vim.fn.cursor(lnum, col, off) end
 --- position within a <Tab> or after the last character.
 --- Returns 0 when the position could be set, -1 otherwise.
 ---
---- Returns 0 when the position could be set, -1 otherwise.
----
 --- @param list integer[]
 --- @return any
 function vim.fn.cursor(list) end

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -1779,7 +1779,6 @@ M.funcs = {
       position within a <Tab> or after the last character.
       Returns 0 when the position could be set, -1 otherwise.
 
-      Returns 0 when the position could be set, -1 otherwise.
     ]=],
     name = 'cursor',
     params = { { 'list', 'integer[]' } },

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -1779,6 +1779,7 @@ M.funcs = {
       position within a <Tab> or after the last character.
       Returns 0 when the position could be set, -1 otherwise.
 
+      Returns 0 when the position could be set, -1 otherwise.
     ]=],
     name = 'cursor',
     params = { { 'list', 'integer[]' } },
@@ -2795,6 +2796,7 @@ M.funcs = {
     ]=],
     name = 'finddir',
     params = { { 'name', 'string' }, { 'path', 'string' }, { 'count', 'integer' } },
+    returns = 'string|string[]',
     signature = 'finddir({name} [, {path} [, {count}]])',
   },
   findfile = {
@@ -2810,7 +2812,8 @@ M.funcs = {
 
     ]=],
     name = 'findfile',
-    params = { { 'name', 'string' }, { 'path', 'string' }, { 'count', 'any' } },
+    params = { { 'name', 'string' }, { 'path', 'string' }, { 'count', 'integer' } },
+    returns = 'string|string[]',
     signature = 'findfile({name} [, {path} [, {count}]])',
   },
   flatten = {
@@ -9872,6 +9875,7 @@ M.funcs = {
       	call cursor(4, 3)
       <positions the cursor on the first character '여'.
 
+      Returns 0 when the position could be set, -1 otherwise.
     ]=],
     name = 'setcursorcharpos',
     params = { { 'list', 'integer[]' } },


### PR DESCRIPTION
#### vim-patch:17ad852: runtime(doc): update return types for builtin functions

credit: Github user @msoyka2024

https://github.com/vim/vim/commit/17ad852a62b6e2cf25207292ebca7a748e529d59

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9973b39: runtime(doc): remove duplicate sentence in builtin.txt

https://github.com/vim/vim/commit/9973b39a17095e6d77b25aafb73a317cebcf586e

Co-authored-by: Christian Brabandt <cb@256bit.org>