### PR TITLE
vim-patch:0553f2f: runtime(doc): clarify single/multibyte support for 'fillchars'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2665,9 +2665,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Example: >vim
 	    set fillchars=stl:\ ,stlnc:\ ,vert:│,fold:·,diff:-
 <
-	For the "stl", "stlnc", "foldopen", "foldclose" and "foldsep" items
-	single-byte and multibyte characters are supported.  But double-width
-	characters are not supported. |E1512|
+	All items support single-byte and multibyte characters.  But
+	double-width characters are not supported. |E1512|
 
 	The highlighting used for these items:
 	  item		highlight group ~

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -2363,9 +2363,8 @@ vim.bo.ft = vim.bo.filetype
 ---     set fillchars=stl:\ ,stlnc:\ ,vert:│,fold:·,diff:-
 --- ```
 ---
---- For the "stl", "stlnc", "foldopen", "foldclose" and "foldsep" items
---- single-byte and multibyte characters are supported.  But double-width
---- characters are not supported. `E1512`
+--- All items support single-byte and multibyte characters.  But
+--- double-width characters are not supported. `E1512`
 ---
 --- The highlighting used for these items:
 ---   item		highlight group ~

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3085,9 +3085,8 @@ local options = {
         Example: >vim
             set fillchars=stl:\ ,stlnc:\ ,vert:│,fold:·,diff:-
         <
-        For the "stl", "stlnc", "foldopen", "foldclose" and "foldsep" items
-        single-byte and multibyte characters are supported.  But double-width
-        characters are not supported. |E1512|
+        All items support single-byte and multibyte characters.  But
+        double-width characters are not supported. |E1512|
 
         The highlighting used for these items:
           item		highlight group ~


### PR DESCRIPTION
#### vim-patch:0553f2f: runtime(doc): clarify single/multibyte support for 'fillchars'

closes: vim/vim#17287

https://github.com/vim/vim/commit/0553f2ff0d170db3f4649a7aaa74b635b1101eed

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>