### PR TITLE
vim-patch:9.1.1378: sign without text overwrites number option

### DIFF
--- a/test/functional/ui/sign_spec.lua
+++ b/test/functional/ui/sign_spec.lua
@@ -359,6 +359,7 @@ describe('Signs', function()
       ]])
     end)
 
+    -- oldtest: Test_sign_number_without_signtext()
     it('ignores signs with no icon and text when calculating the signcolumn width', function()
       feed('ia<cr>b<cr>c<cr><esc>')
       exec([[

--- a/test/old/testdir/test_signs.vim
+++ b/test/old/testdir/test_signs.vim
@@ -2073,4 +2073,23 @@ func Test_sign_null_list()
   eval v:_null_list->sign_unplacelist()
 endfunc
 
+func Test_sign_number_without_signtext()
+  CheckScreendump
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+      set number signcolumn=number
+      call setline(1, ['a', 'b', 'c'])
+      sign define SignA text=>> texthl=Search numhl=Error
+      sign define SignB numhl=Error
+      sign place 1 line=1 name=SignA buffer=1
+      sign place 2 line=2 name=SignB  buffer=1
+  END
+  call writefile(lines, 'XtestSigncolumnNumber', 'D')
+  let buf = RunVimInTerminal('-S XtestSigncolumnNumber', {'rows': 5})
+  call VerifyScreenDump(buf, 'Test_sign_number_without_signtext', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1378: sign without text overwrites number option

Problem:  When 'signcolumn' is set to `number` but a line has a sign
          without text, the line number disappears (finite-state-machine)
Solution: Verify that a sign actually contains text before rendering the
          line number (glepnir)

closes: vim/vim#17282

https://github.com/vim/vim/commit/1b186833c1cabeb4da3c855596b9161ff982bcfc

Co-authored-by: glepnir <glephunter@gmail.com>