### PR TITLE
fix(netrw): use vim.ui.open when pressing x

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -5145,8 +5145,7 @@ fun! netrw#BrowseX(fname,remote)
     endif
   endif
 
-  " although shellescape(..., 1) is used in netrw#Open(), it's insufficient
-  call netrw#Open(escape(fname, '#%'))
+  call luaeval('vim.ui.open(_A) and nil', fname)
 
   " cleanup: remove temporary file,
   "          delete current buffer if success with handler,


### PR DESCRIPTION
closes: #33713 

In upstream netrw I've pulled this out into a separate module but since you guys don't want to keep using netrw in the future I think is safe to just fix the bugs if they are brought up and then it will tell the users to use upstream if they wish to still use netrw.
