### PR TITLE
fix(treesitter): proper tree `contains()` logic with combined injections

### DIFF
--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -1290,12 +1290,13 @@ end
 local function tree_contains(tree, range)
   local tree_ranges = tree:included_ranges(false)
 
-  return Range.contains({
-    tree_ranges[1][1],
-    tree_ranges[1][2],
-    tree_ranges[#tree_ranges][3],
-    tree_ranges[#tree_ranges][4],
-  }, range)
+  for _, tree_range in ipairs(tree_ranges) do
+    if Range.contains(tree_range, range) then
+      return true
+    end
+  end
+
+  return false
 end
 
 --- Determines whether {range} is contained in the |LanguageTree|.


### PR DESCRIPTION
**Problem:** `LanguageTree:contains()` considers any range within the start of the first tree and end of the last tree as "within" the language tree. In the case of combined injections, this is problematic because we only want to consider ranges within any of the combined trees as "contained" (as opposed to any range within the entire range spanned by all combined trees).

**Solution:** Use a more discriminative check in
`LanguageTree:contains()`.

Fixes #31984, #30799

Needs tests but i am about to be afk