### PR TITLE
fix(lsp): enable globbing in filetypes table

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -522,7 +522,13 @@ local function can_start(bufnr, name, config)
     return false
   end
 
-  if config.filetypes and not vim.tbl_contains(config.filetypes, vim.bo[bufnr].filetype) then
+  if config.filetypes then
+    for _, ft in ipairs(config.filetypes) do
+      local pat = vim.fn.glob2regpat(ft)
+      if vim.regex(pat):match_str(vim.bo[bufnr].filetype) then
+        return true
+      end
+    end
     return false
   end
 


### PR DESCRIPTION
Fixes neovim/nvim-lspconfig#3838
Fixes neovim/nvim-lspconfig#3788

This change aligns `filetypes` tables in `vim.lsp.config` with behaviour of e.g. autocommands and legacy [nvim-lspconfig](https://github.com/neovim/nvim-lspconfig) API.