### PR TITLE
feat(lsp): filetypes table containing "*" enables server for all

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -709,8 +709,9 @@ Lua module: vim.lsp                                                 *lsp-core*
       • {cmd}?           (`string[]|fun(dispatchers: vim.lsp.rpc.Dispatchers): vim.lsp.rpc.PublicClient`)
                          See `cmd` in |vim.lsp.ClientConfig|.
       • {filetypes}?     (`string[]`) Filetypes the client will attach to, if
-                         activated by `vim.lsp.enable()`. If not provided, the
-                         client will attach to all filetypes.
+                         activated by `vim.lsp.enable()`. If not provided, or
+                         contains at any position "*", the client will attach
+                         to all filetypes.
       • {reuse_client}?  (`fun(client: vim.lsp.Client, config: vim.lsp.ClientConfig): boolean`)
                          Predicate which decides if a client should be
                          re-used. Used on all running clients. The default

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -709,9 +709,9 @@ Lua module: vim.lsp                                                 *lsp-core*
       • {cmd}?           (`string[]|fun(dispatchers: vim.lsp.rpc.Dispatchers): vim.lsp.rpc.PublicClient`)
                          See `cmd` in |vim.lsp.ClientConfig|.
       • {filetypes}?     (`string[]`) Filetypes the client will attach to, if
-                         activated by `vim.lsp.enable()`. If not provided, or
-                         contains at any position "*", the client will attach
-                         to all filetypes.
+                         activated by `vim.lsp.enable()`. If contains "*", the
+                         client will attach to all filetypes. If not provided,
+                         falls back to attaching to all.
       • {reuse_client}?  (`fun(client: vim.lsp.Client, config: vim.lsp.ClientConfig): boolean`)
                          Predicate which decides if a client should be
                          re-used. Used on all running clients. The default

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -147,6 +147,8 @@ LSP
   https://microsoft.github.io/language-server-protocol/specification/#textDocument_documentColor
 • The `textDocument/diagnostic` request now includes the previous id in its
   parameters.
+• Adding "*" to {filetypes} table in |vim.lsp.Config| causes client to attach
+  to all filetypes.
 
 LUA
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -278,8 +278,8 @@ end
 --- See `cmd` in [vim.lsp.ClientConfig].
 --- @field cmd? string[]|fun(dispatchers: vim.lsp.rpc.Dispatchers): vim.lsp.rpc.PublicClient
 ---
---- Filetypes the client will attach to, if activated by `vim.lsp.enable()`. If not provided, the
---- client will attach to all filetypes.
+--- Filetypes the client will attach to, if activated by `vim.lsp.enable()`. If not provided,
+--- or contains at any position "*", the client will attach to all filetypes.
 --- @field filetypes? string[]
 ---
 --- Predicate which decides if a client should be re-used. Used on all running clients. The default
@@ -522,8 +522,14 @@ local function can_start(bufnr, name, config)
     return false
   end
 
-  if config.filetypes and not vim.tbl_contains(config.filetypes, vim.bo[bufnr].filetype) then
-    return false
+  if config.filetypes then
+    if vim.tbl_contains(config.filetypes, '*') then
+      return true
+    elseif vim.tbl_contains(config.filetypes, vim.bo[bufnr].filetype) then
+      return true
+    else
+      return false
+    end
   end
 
   return true

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -278,8 +278,8 @@ end
 --- See `cmd` in [vim.lsp.ClientConfig].
 --- @field cmd? string[]|fun(dispatchers: vim.lsp.rpc.Dispatchers): vim.lsp.rpc.PublicClient
 ---
---- Filetypes the client will attach to, if activated by `vim.lsp.enable()`. If not provided,
---- or contains at any position "*", the client will attach to all filetypes.
+--- Filetypes the client will attach to, if activated by `vim.lsp.enable()`. If contains "*",
+--- the client will attach to all filetypes. If not provided, falls back to attaching to all.
 --- @field filetypes? string[]
 ---
 --- Predicate which decides if a client should be re-used. Used on all running clients. The default
@@ -522,14 +522,11 @@ local function can_start(bufnr, name, config)
     return false
   end
 
-  if config.filetypes then
-    if vim.tbl_contains(config.filetypes, '*') then
-      return true
-    elseif vim.tbl_contains(config.filetypes, vim.bo[bufnr].filetype) then
-      return true
-    else
-      return false
-    end
+  if vim.tbl_contains(config.filetypes or { '*' }, '*') then
+    return true
+  end
+  if not vim.tbl_contains(config.filetypes, vim.bo[bufnr].filetype) then
+    return false
   end
 
   return true


### PR DESCRIPTION
Fixes neovim/nvim-lspconfig#3788  
Simpler version of previous PR (#33949)

The most common use-case would be enabling server from [nvim-lspconifg](https://github.com/neovim/nvim-lspconfig) for all filetypes by just setting:
```lua
    filetypes = { '*' },
```
as a simpler way in contrast to defining `merge_behavior` function (#33833) or other alternative discussed in #33577.