### PR TITLE
fix(vim.system): clear_env = true gives an invalid env to uv.spawn

### DIFF
--- a/runtime/lua/vim/_system.lua
+++ b/runtime/lua/vim/_system.lua
@@ -211,15 +211,13 @@ end
 --- @param clear_env? boolean
 --- @return string[]?
 local function setup_env(env, clear_env)
-  if clear_env then
-    return env
+  if not clear_env then
+    --- @type table<string,string|number>
+    env = vim.tbl_extend('force', base_env(), env or {})
   end
 
-  --- @type table<string,string|number>
-  env = vim.tbl_extend('force', base_env(), env or {})
-
   local renv = {} --- @type string[]
-  for k, v in pairs(env) do
+  for k, v in pairs(env or {}) do
     renv[#renv + 1] = string.format('%s=%s', k, tostring(v))
   end
 

--- a/test/functional/lua/system_spec.lua
+++ b/test/functional/lua/system_spec.lua
@@ -68,6 +68,26 @@ describe('vim.system', function()
         eq('hellocat', system({ 'cat' }, { stdin = 'hellocat', text = true }).stdout)
       end)
 
+      it('can set environment', function()
+        eq(
+          'TESTVAL',
+          system(
+            { n.testprg('printenv-test'), 'TEST' },
+            { env = { TEST = 'TESTVAL' }, text = true }
+          ).stdout
+        )
+      end)
+
+      it('can set environment with clear_env = true', function()
+        eq(
+          'TESTVAL',
+          system(
+            { n.testprg('printenv-test'), 'TEST' },
+            { clear_env = true, env = { TEST = 'TESTVAL' }, text = true }
+          ).stdout
+        )
+      end)
+
       it('supports timeout', function()
         eq({
           code = 124,


### PR DESCRIPTION
I was going through the code of vim.system so that I could adapt it to be used outside of nvim in something else, and I noticed something.

In setup_env, some needed logic was being bypassed only when clear_env == true

While one COULD technically use the env argument anyway if they did the logic themselves before passing it, it behaves VERY differently than with clear_env == false (the default) and doesnt fit the type annotations either, thus this is clearly unintentional and should be fixed.