### PR TITLE
feat(extui): show "g<" hint when message spills 'cmdheight'

### DIFF
--- a/runtime/lua/vim/_extui/messages.lua
+++ b/runtime/lua/vim/_extui/messages.lua
@@ -265,13 +265,16 @@ function M.show_msg(tar, content, replace_last, more)
       ext.cmd.cmdline_show({}, 0, ':', '', ext.cmd.indent, 0, 0)
       api.nvim__redraw({ flush = true, cursor = true, win = ext.wins[ext.tab].cmd })
     else
-      -- Place [+x] indicator for lines that spill over 'cmdheight'.
-      local h = api.nvim_win_text_height(ext.wins[ext.tab].cmd, {})
-      M.cmd.lines, M.cmd.msg_row = h.all, h.end_row
-      local spill = M.cmd.lines > ext.cmdheight and ('[+%d]'):format(M.cmd.lines - ext.cmdheight)
-      M.virt.msg[M.virt.idx.spill][1] = spill and { 0, spill } or nil
       api.nvim_win_set_cursor(ext.wins[ext.tab][tar], { 1, 0 })
       ext.cmd.highlighter.active[ext.bufs.cmd] = nil
+      -- Show hint in box and place [+x] indicator for lines that spill over 'cmdheight'.
+      local h = api.nvim_win_text_height(ext.wins[ext.tab].cmd, {})
+      M.cmd.lines, M.cmd.msg_row = h.all, h.end_row
+      local spill = M.cmd.lines - ext.cmdheight
+      M.virt.msg[M.virt.idx.spill][1] = spill > 0 and { 0, ('[+%d]'):format(spill) } or nil
+      if spill > 0 then
+        M.msg_show('verbose', { { 0, ('Press g< to see %d more lines'):format(spill), 0 } })
+      end
     end
   end
 


### PR DESCRIPTION
**feat(extui): show "g<" hint when message spills 'cmdheight'**

Problem:  Extui shows a spill indicator to hint to the user to press "g<"
          to show the output of the last command. The user may be
          unaware of this mapping.
Solution: Route a hint message to the message "box" window.

**fix(extui): adjust which messages are sent to "more" window**

Problem:  Decision whether message is sent to "more" window is based on
          the number of newlines present in a message, rather than the
          actual text height.
          With the "box" target, messages that come from a cmdline
          entered command are not always routed to the more window.
Solution: Still write the message to the target buffer, and calculate
          the actual text height. Postpone updating several state
          variables until after the decision to re-route is made.
          With the "box" target, only consider the text height of the
          message if it is not a message from a cmdline entered command.

Fix #33956