### PR TITLE
fix(docs): Remove nested tables in root_markers for Lua LSP configuration

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -42,7 +42,7 @@ Follow these steps to get LSP features:
         -- ".luarc.jsonc" file. Files that share a root directory will reuse
         -- the connection to the same LSP server.
         -- Nested lists indicate equal priority, see |vim.lsp.Config|.
-        root_markers = { { '.luarc.json', '.luarc.jsonc' }, '.git' },
+        root_markers = { '.luarc.json', '.luarc.jsonc', '.git' },
 
         -- Specific settings to send to the server. The schema for this is
         -- defined by the server. For example the schema for lua-language-server


### PR DESCRIPTION
This PR addresses an issue in the Lua LSP configuration documentation and examples where root_markers is incorrectly defined as a nested table. Using a nested table causes the following error when running :checkhealth for the vim.lsp plugin:

```bash
Error detected while processing function <SNR>24_NetrwBrowseChgDir[163]..<SNR>24_NetrwEditFile[10]..BufReadPost Autocommands for "*":
Error executing lua callback: ...rew/Cellar/neovim/0.11.1/share/nvim/runtime/filetype.lua:36: function <SNR>24_NetrwBrowseChgDir[163]..<SNR>24_NetrwEditFile[10]..BufReadPost Autocommands for "*"..FileType Autocommands for "*": Vim(append):Error executing
lua callback: vim/fs.lua:0: invalid value (table) at index 2 in table for 'concat'
stack traceback:
        [C]: in function 'concat'
        vim/fs.lua: in function 'joinpath'
        vim/fs.lua: in function <vim/fs.lua:0>
        vim/fs.lua: in function 'find'
        vim/fs.lua: in function 'root'
        .../Cellar/neovim/0.11.1/share/nvim/runtime/lua/vim/lsp.lua:633: in function 'start_config'
        .../Cellar/neovim/0.11.1/share/nvim/runtime/lua/vim/lsp.lua:517: in function 'lsp_enable_callback'
        .../Cellar/neovim/0.11.1/share/nvim/runtime/lua/vim/lsp.lua:561: in function <.../Cellar/neovim/0.11.1/share/nvim/runtime/lua/vim/lsp.lua:560>
        [C]: in function 'nvim_cmd'
        ...rew/Cellar/neovim/0.11.1/share/nvim/runtime/filetype.lua:36: in function <...rew/Cellar/neovim/0.11.1/share/nvim/runtime/filetype.lua:35>
        [C]: in function 'pcall'
        vim/shared.lua: in function <vim/shared.lua:0>
        [C]: in function '_with'
        ...rew/Cellar/neovim/0.11.1/share/nvim/runtime/filetype.lua:35: in function <...rew/Cellar/neovim/0.11.1/share/nvim/runtime/filetype.lua:10>
stack traceback:
        [C]: in function '_with'
        ...rew/Cellar/neovim/0.11.1/share/nvim/runtime/filetype.lua:35: in function <...rew/Cellar/neovim/0.11.1/share/nvim/runtime/filetype.lua:10>
Press ENTER or type command to continue
```