### PR TITLE
feat(lua): add minimal vim.net.download wrapper using curl

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4656,4 +4656,30 @@ tohtml.tohtml({winid}, {opt})                         *tohtml.tohtml.tohtml()*
         (`string[]`)
 
 
+==============================================================================
+Lua module: vim.net                                                  *vim.net*
+
+                                                          *vim.net.download()*
+vim.net.download({url}, {download_location}, {opts}, {on_exit})
+    Downloads a file from the given URL to a specified location.
+
+    Parameters: ~
+      • {url}                (`string`) The URL to download from.
+      • {download_location}  (`string`) The file path where the content should
+                             be saved.
+      • {opts}               (`table?`) Optional parameters:
+                             • verbose (boolean|nil): Enables verbose curl
+                               output.
+                             • retry (integer|nil): Number of times to retry
+                               on transient failures (default: 3).
+      • {on_exit}            (`fun(err?: string)?`) Optional callback. If
+                             omitted, runs synchronously.
+
+    Return (multiple): ~
+        (`boolean?`) on success (sync); false/nil and error message on
+        failure.
+        (`string?`) True on success (sync); false/nil and error message on
+        failure.
+
+
  vim:tw=78:ts=8:sw=4:sts=4:et:ft=help:norl:

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -74,6 +74,7 @@ LSP
 
 LUA
 
+• |vim.net.download()| allows downloading files.
 • todo
 
 OPTIONS

--- a/runtime/lua/vim/net.lua
+++ b/runtime/lua/vim/net.lua
@@ -1,0 +1,67 @@
+local M = {}
+
+--- Downloads a file from the given URL to a specified location.
+---
+--- @param url string The URL to download from.
+--- @param download_location string The file path where the content should be saved.
+--- @param opts? table Optional parameters:
+---   - verbose (boolean|nil): Enables verbose curl output.
+---   - retry (integer|nil): Number of times to retry on transient failures (default: 3).
+--- @param on_exit? fun(err?: string) Optional callback. If omitted, runs synchronously.
+---
+--- @return boolean|nil, string? True on success (sync); false/nil and error message on failure.
+function M.download(url, download_location, opts, on_exit)
+  vim.validate({
+    url = { url, 'string' },
+    download_location = { download_location, 'string' },
+    opts = { opts, 'table', true },
+    on_exit = { on_exit, 'function', true },
+  })
+
+  opts = opts or {}
+  local retry = opts.retry or 3
+
+  local args = { 'curl' }
+
+  if opts.verbose then
+    table.insert(args, '--verbose')
+  else
+    vim.list_extend(args, { '--silent', '--show-error', '--fail' })
+  end
+
+  vim.list_extend(args, {
+    '--retry',
+    tostring(retry),
+    '--location',
+    '--output',
+    download_location,
+    url,
+  })
+
+  if on_exit then
+    vim.system(args, { text = true }, function(res)
+      if res.code ~= 0 or res.stderr ~= '' then
+        on_exit(res.stderr ~= '' and res.stderr or 'Download failed')
+      else
+        on_exit(nil)
+      end
+    end)
+  else
+    local job = vim.system(args, { text = true })
+    local result = job:wait()
+
+    if result.code ~= 0 then
+      local err = result.stderr
+      if err == '' then
+        err = string.format('Download failed (exit code %d)', result.code)
+      else
+        err = string.format('%s (exit code %d)', err, result.code)
+      end
+      return false, err
+    end
+
+    return true
+  end
+end
+
+return M

--- a/src/gen/gen_vimdoc.lua
+++ b/src/gen/gen_vimdoc.lua
@@ -162,6 +162,7 @@ local config = {
       'snippet.lua',
       'text.lua',
       'tohtml.lua',
+      'net.lua',
     },
     files = {
       'runtime/lua/vim/iter.lua',
@@ -191,6 +192,7 @@ local config = {
       'runtime/lua/vim/_meta/re.lua',
       'runtime/lua/vim/_meta/spell.lua',
       'runtime/lua/tohtml.lua',
+      'runtime/lua/vim/net.lua',
     },
     fn_xform = function(fun)
       if contains(fun.module, { 'vim.uri', 'vim.shared', 'vim._editor' }) then

--- a/test/functional/lua/net_spec.lua
+++ b/test/functional/lua/net_spec.lua
@@ -1,0 +1,99 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local exec_lua = n.exec_lua
+local read_file = t.read_file
+
+local path = './downloaded.txt'
+
+local function assert_404_error(err)
+  assert(
+    err:lower():find('404') or err:find('22'),
+    'Expected HTTP 404 or exit code 22, got: ' .. tostring(err)
+  )
+end
+
+describe('vim.net.download', function()
+  before_each(function()
+    n:clear()
+    os.remove(path)
+  end)
+
+  it('downloads a file from a URL (async success)', function()
+    exec_lua(
+      [[
+      local done = false
+      local M = require('vim.net')
+
+      M.download("https://httpbingo.org/anything", ..., {
+        retry = 3,
+      }, function(err)
+          assert(not err, err)
+          done = true
+        end)
+
+      vim.wait(2000, function() return done end)
+      ]],
+      path
+    )
+
+    local content = read_file(path)
+    assert(
+      content and content:find('"url"%s*:%s*"https://httpbingo.org/anything"'),
+      'Expected downloaded file to contain the correct URL'
+    )
+  end)
+
+  it('calls on_exit with error on 404 (async failure)', function()
+    local err = exec_lua([[
+      local done = false
+      local result
+      local M = require('vim.net')
+
+      M.download("https://httpbingo.org/status/404", "ignored.txt", {
+      }, function(e)
+          result = e
+          done = true
+        end)
+
+      vim.wait(2000, function() return done end)
+      return result
+      ]])
+    assert_404_error(err)
+  end)
+
+  it('downloads a file from a URL (sync success)', function()
+    local success, err = exec_lua(
+      [[
+      local M = require('vim.net')
+      return M.download(...)
+      ]],
+      'https://httpbingo.org/anything',
+      path,
+      {},
+      nil
+    )
+
+    assert(success, 'Expected synchronous download to succeed, got error: ' .. (err or 'nil'))
+
+    local content = read_file(path)
+    assert(
+      content and content:find('"url"%s*:%s*"https://httpbingo.org/anything"'),
+      'Expected downloaded file to contain the correct URL'
+    )
+  end)
+
+  it('returns error on 404 (sync failure)', function()
+    exec_lua(
+      [[
+      local M = require('vim.net')
+      local success, err =  M.download(...)
+      assert(success == false, 'Expected synchronous download to fail')
+      assert(err:lower():find('404'),
+        'Expected HTTP 404 or exit code 22, got: ' .. tostring(err))
+      ]],
+      'https://httpbingo.org/status/404',
+      'ignored.txt'
+    )
+  end)
+end)


### PR DESCRIPTION
This PR introduces a minimal `vim.net.download()` implementation as a simple wrapper around `curl`, following the approach suggested in [this comment](https://github.com/neovim/neovim/pull/29104#issuecomment-2165443624).

The goal is to start small and provide the foundational download functionality first and then add more advanced features (e.g. authentication, headers, proxy support) in future PRs.

This PR is related to issue #23232 

### Implementation

- Uses `vim.system()` with `curl` to perform the download.
- Automatically adds --retry <n>, --location (follow redirects) and --output <file> plus the URL.
- Accepts an `opts` table and an optional `on_exit` callback.
- If you pass an `on_exit` callback, it runs in the background and invokes `on_exit(err or nil)` when done.
- If no callback is given, it blocks until completion and returns `true` on success or `false, errmsg` on failure.

### Proposed API Usage

1. **Basic synchronous download**:
   ```lua
    local ok, err = vim.net.download("https://httpbingo.org/anything", "./anything.txt")
    if not ok then
      print("Download failed:", err)
    end
    ```
    
2. **Synchronous with custom options**:
    ```lua
   local ok, err = vim.net.download("https://httpbingo.org/anything", "./anything.txt", {
       verbose = true,
       retry = 5,
       }
   )
   if ok then
      print("Done")
    else
      print("Error:", err)
    end
    ```
   
3. **Asynchronous with callback**
    ```lua
    vim.net.download("https://httpbingo.org/anything", "./anything.txt", { retry = 2 }, function(err)
        if err then
            print("Download failed:", err)
        else
            print("Download successful!")
        end
    end)
    ```
    
### Next Steps

After initial feedback, the implementation can be extended incrementally, adding `vim.net.request()` or broader `curl` options support in follow-up PRs.