### PR TITLE
vim-patch:9.1.1380: 'eventignorewin' only checked for current buffer

### DIFF
--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -1635,11 +1635,12 @@ bool apply_autocmds_group(event_T event, char *fname, char *fname_io, bool force
   // into "buf" are ignoring the event.
   if (buf == curbuf && event_names[event].event <= 0) {
     win_ignore = event_ignored(event, curwin->w_p_eiw);
-  } else if (buf != NULL && event_names[event].event <= 0) {
-    for (size_t i = 0; i < kv_size(buf->b_wininfo); i++) {
-      WinInfo *wip = kv_A(buf->b_wininfo, i);
-      if (wip->wi_win != NULL && wip->wi_win->w_buffer == buf) {
-        win_ignore = event_ignored(event, wip->wi_win->w_p_eiw);
+  } else if (buf != NULL && event_names[event].event <= 0 && buf->b_nwindows > 0) {
+    win_ignore = true;
+    FOR_ALL_TAB_WINDOWS(tp, wp) {
+      if (wp->w_buffer == buf && !event_ignored(event, wp->w_p_eiw)) {
+        win_ignore = false;
+        break;
       }
     }
   }


### PR DESCRIPTION
Problem:  When an autocommand executes for a non-current buffer,
          'eventignorewin' is only checked from the buffer's last
          wininfo (overwrites win_ignore in the loop), not from the
          value of 'eventignorewin' in all windows showing the buffer as
          described (after v9.1.1084)

Solution: Fix the check and don't use wininfo, as that may only contain
          windows that recently showed the buffer. Consider all the
          buffer's windows in all tabpages (Sean Dewar).

closes: vim/vim#17294

https://github.com/vim/vim/commit/d4110e06952be7d06ba39cf0434626bbd7301a9d
