### PR TITLE
refactor(treesitter): remove empty parse callback

### DIFF
--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -545,8 +545,7 @@ static int parser_parse(lua_State *L)
                                        .progress_callback = on_parser_progress };
       new_tree = ts_parser_parse_with_options(p, old_tree, input, parse_options);
     } else {
-      // Tree-sitter retains parse options after use, so we must explicitly reset them here.
-      new_tree = ts_parser_parse_with_options(p, old_tree, input, (TSParseOptions) { 0 });
+      new_tree = ts_parser_parse(p, old_tree, input);
     }
 
     break;


### PR DESCRIPTION
Now that we have bumped to tree-sitter 0.25.4, we no longer need to do this since upstream does it for us when calling the regular parse method.

See https://github.com/tree-sitter/tree-sitter/pull/4355
