### PR TITLE
feat(clipboard): wayclip primary clipboard and correct mimetype

### DIFF
--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -87,8 +87,8 @@ endfunction
 function! s:set_wayclip() abort
   let s:copy['+'] = ['waycopy']
   let s:paste['+'] = ['waypaste']
-  let s:copy['*'] = s:copy['+']
-  let s:paste['*'] = s:paste['+']
+  let s:copy['*'] = ['waycopy', '-p']
+  let s:paste['*'] = ['waypaste', '-p']
   return 'wayclip'
 endfunction
 

--- a/runtime/autoload/provider/clipboard.vim
+++ b/runtime/autoload/provider/clipboard.vim
@@ -85,8 +85,8 @@ function! s:set_wayland() abort
 endfunction
 
 function! s:set_wayclip() abort
-  let s:copy['+'] = ['waycopy', '-t', 'text/plain']
-  let s:paste['+'] = ['waypaste', '-t', 'text/plain']
+  let s:copy['+'] = ['waycopy']
+  let s:paste['+'] = ['waypaste']
   let s:copy['*'] = s:copy['+']
   let s:paste['*'] = s:paste['+']
   return 'wayclip'


### PR DESCRIPTION
* feat(clipboard): don't specify wayclip mimetype
 
  Problem:  Since wayclip 0.2, wayclip assumes UTF-8
            (text/plain;charset=utf-8) in absence of an explicit mimetype.
	    Since Neovim sets the mimetype to "text/plain" without
	    specifying UTF-8, you will also have to use `-t text/plain`
	    when using waypaste or wayclip outside of Neovim.

  Solution: Don't specify mimetype when using wayclip, thereby using the
            default "text/plain:charset=utf-8".

* feat(clipboard): add primary clipboard support to wayclip
 
  wayclip have had support for primary clipboard for some time now.

---

Let me know if there is anything else I need to do. I also assumed this was too small a change to go into news.txt, but do correct me.