### PR TITLE
vim-patch:9.1.1385: inefficient loop for 'nosmoothscroll' scrolling

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2428,11 +2428,16 @@ static bool scroll_with_sms(Direction dir, int count, int *curscount)
     if (labs(curwin->w_topline - prev_topline) > (dir == BACKWARD)) {
       fixdir = dir * -1;
     }
-    while (curwin->w_skipcol > 0
-           && curwin->w_topline < curbuf->b_ml.ml_line_count) {
-      scroll_redraw(fixdir == FORWARD, 1);
-      *curscount += (fixdir == dir ? 1 : -1);
+
+    int width1 = curwin->w_view_width - win_col_off(curwin);
+    int width2 = width1 + win_col_off2(curwin);
+    count = 1 + (curwin->w_skipcol - width1) / width2;
+    if (fixdir == FORWARD) {
+      count = 2 + (linetabsize_eol(curwin, curwin->w_topline)
+                   - curwin->w_skipcol - width1) / width2;
     }
+    scroll_redraw(fixdir == FORWARD, count);
+    *curscount += count * (fixdir == dir ? 1 : -1);
   }
   curwin->w_p_sms = prev_sms;
 

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4355,4 +4355,13 @@ func Test_scroll_longline_scrolloff()
   bwipe!
 endfunc
 
+" Benchmark test for Ctrl-F with 'nosmoothscroll'
+func Test_scroll_longline_benchmark()
+  call setline(1, ['foo'->repeat(20000)] + [''])
+  let start = reltime()
+  exe "normal! \<C-F>"
+  call assert_inrange(0, 0.1, reltimefloat(reltime(start)))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  Loop that ensures "w_skipcol" is zero with 'nosmoothscroll'
	  for (half)-page scrolling is inefficient.
Solution: Calculate the required "count" instead of looping until
	  "w_skipcol" is zero (Luuk van Baal).

https://github.com/vim/vim/commit/acf0ebe8a8f4dd389a8fe8cea52ff43bc8bfe1be
