### PR TITLE
vim-patch:37045b5,9.1.1384 && fix(tutor): `l:lang` is undefined

### DIFF
--- a/runtime/autoload/tutor.vim
+++ b/runtime/autoload/tutor.vim
@@ -220,6 +220,7 @@ function! tutor#TutorCmd(tutor_name)
 
     call tutor#SetupVim()
     exe "edit ".l:to_open
+    call tutor#EnableInteractive(v:true)
     call tutor#ApplyTransform()
 endfunction
 
@@ -227,6 +228,27 @@ function! tutor#TutorCmdComplete(lead,line,pos)
     let l:tutors = s:GlobTutorials('*')
     let l:names = uniq(sort(map(l:tutors, 'fnamemodify(v:val, ":t:r")'), 's:Sort'))
     return join(l:names, "\n")
+endfunction
+
+" Enables/disables interactive mode.
+function! tutor#EnableInteractive(enable)
+    let enable = a:enable
+    if enable
+        setlocal buftype=nofile
+        setlocal concealcursor+=inv
+        setlocal conceallevel=2
+        call tutor#ApplyMarks()
+        augroup tutor_interactive
+            autocmd! TextChanged,TextChangedI <buffer> call tutor#ApplyMarksOnChanged()
+        augroup END
+    else
+        setlocal buftype<
+        setlocal concealcursor<
+        setlocal conceallevel<
+        if exists('#tutor_interactive')
+            autocmd! tutor_interactive * <buffer>
+        endif
+    endif
 endfunction
 
 function! tutor#ApplyTransform()

--- a/runtime/autoload/tutor.vim
+++ b/runtime/autoload/tutor.vim
@@ -120,6 +120,8 @@ endfunction
 " Tutor Cmd: {{{1
 
 function! s:Locale()
+    " Make sure l:lang exists before returning.
+    let l:lang = 'en_US'
     if exists('v:lang') && v:lang =~ '\a\a'
         let l:lang = v:lang
     elseif $LC_ALL =~ '\a\a'
@@ -132,8 +134,6 @@ function! s:Locale()
       endif
     elseif $LANG =~ '\a\a'
         let l:lang = $LANG
-    else
-        let l:lang = 'en_US'
     endif
     return split(l:lang, '_')
 endfunction

--- a/runtime/ftplugin/tutor.vim
+++ b/runtime/ftplugin/tutor.vim
@@ -6,21 +6,13 @@
 " Original Author: Felipe Morales <hel.sheep@gmail.com>
 " Last Change:
 " 2025 May 10 set b:undo_ftplugin
+" 2025 May 12 update b:undo_ftplugin
 
 " Base: {{{1
 call tutor#SetupVim()
 
 " Buffer Settings: {{{1
 setlocal noreadonly
-if !exists('g:tutor_debug') || g:tutor_debug == 0
-    setlocal buftype=nofile
-    setlocal concealcursor+=inv
-    setlocal conceallevel=2
-else
-    setlocal buftype=
-    setlocal concealcursor&
-    setlocal conceallevel=0
-endif
 setlocal noundofile
 
 setlocal keywordprg=:help
@@ -46,14 +38,7 @@ call tutor#SetNormalMappings()
 sign define tutorok text=✓ texthl=tutorOK
 sign define tutorbad text=✗ texthl=tutorX
 
-if !exists('g:tutor_debug') || g:tutor_debug == 0
-    call tutor#ApplyMarks()
-    autocmd! TextChanged,TextChangedI <buffer> call tutor#ApplyMarksOnChanged()
-endif
-
-let b:undo_ftplugin = 'unlet! g:tutor_debug |'
-let b:undo_ftplugin ..= 'setl concealcursor< conceallevel< |'
-let b:undo_ftplugin ..= 'setl foldmethod< foldexpr< foldlevel< |'
-let b:undo_ftplugin ..= 'setl buftype< undofile< keywordprg< iskeyword< |'
+let b:undo_ftplugin = "setl foldmethod< foldexpr< foldlevel< undofile< keywordprg< iskeyword< |"
+    \ . "call tutor#EnableInteractive(v:false) |"
 
 " vim: fdm=marker

--- a/runtime/ftplugin/tutor.vim
+++ b/runtime/ftplugin/tutor.vim
@@ -1,4 +1,11 @@
-" vim: fdm=marker
+" Tutor filetype plugin
+" Language:	Tutor (the new tutor plugin)
+" Maintainer:	This runtime file is looking for a new maintainer.
+" Last Change:	2025 May 10
+" Contributors:	Phạm Bình An <phambinhanctb2004@gmail.com>
+" Original Author: Felipe Morales <hel.sheep@gmail.com>
+" Last Change:
+" 2025 May 10 set b:undo_ftplugin
 
 " Base: {{{1
 call tutor#SetupVim()
@@ -43,3 +50,10 @@ if !exists('g:tutor_debug') || g:tutor_debug == 0
     call tutor#ApplyMarks()
     autocmd! TextChanged,TextChangedI <buffer> call tutor#ApplyMarksOnChanged()
 endif
+
+let b:undo_ftplugin = 'unlet! g:tutor_debug |'
+let b:undo_ftplugin ..= 'setl concealcursor< conceallevel< |'
+let b:undo_ftplugin ..= 'setl foldmethod< foldexpr< foldlevel< |'
+let b:undo_ftplugin ..= 'setl buftype< undofile< keywordprg< iskeyword< |'
+
+" vim: fdm=marker

--- a/runtime/plugin/tutor.vim
+++ b/runtime/plugin/tutor.vim
@@ -1,6 +1,17 @@
+" Tutor:	New Style Tutor Plugin :h vim-tutor-mode
+" Maintainer:	This runtime file is looking for a new maintainer.
+" Contributors:	Phạm Bình An <phambinhanctb2004@gmail.com>
+" Original Author: Felipe Morales <hel.sheep@gmail.com>
+" Date: 2025 May 10
+
 if exists('g:loaded_tutor_mode_plugin') || &compatible
     finish
 endif
 let g:loaded_tutor_mode_plugin = 1
+
+" Define this variable so that users get cmdline completion.
+if !exists('g:tutor_debug')
+  let g:tutor_debug = 0
+endif
 
 command! -nargs=? -complete=custom,tutor#TutorCmdComplete Tutor call tutor#TutorCmd(<q-args>)

--- a/runtime/plugin/tutor.vim
+++ b/runtime/plugin/tutor.vim
@@ -2,16 +2,11 @@
 " Maintainer:	This runtime file is looking for a new maintainer.
 " Contributors:	Phạm Bình An <phambinhanctb2004@gmail.com>
 " Original Author: Felipe Morales <hel.sheep@gmail.com>
-" Date: 2025 May 10
+" Date: 2025 May 12
 
 if exists('g:loaded_tutor_mode_plugin') || &compatible
     finish
 endif
 let g:loaded_tutor_mode_plugin = 1
-
-" Define this variable so that users get cmdline completion.
-if !exists('g:tutor_debug')
-  let g:tutor_debug = 0
-endif
 
 command! -nargs=? -complete=custom,tutor#TutorCmdComplete Tutor call tutor#TutorCmd(<q-args>)

--- a/runtime/tutor/tutor.tutor
+++ b/runtime/tutor/tutor.tutor
@@ -17,15 +17,8 @@ Table of contents:
 
 ## SETTING UP *setting-up*
 
-First, you'll need to enable "debug" mode
-~~~ cmd
-    :let g:tutor_debug = 1
-~~~
-This will allow saving changes to the tutor files and will disable conceals, so
-you can more easily check your changes.
-
-After this, create a new .tutor file (we will be practicing on this very file, so you
-don't need to do this now):
+Create a new .tutor file (we will be practicing on this very file, so you don't
+need to do this now):
 ~~~ cmd
     :e new-tutorial.tutor
 ~~~

--- a/test/old/testdir/test_plugin_tutor.vim
+++ b/test/old/testdir/test_plugin_tutor.vim
@@ -1,0 +1,16 @@
+" Test for the new-tutor plugin
+
+func SetUp()
+  set nocompatible
+  runtime plugin/tutor.vim
+endfunc
+
+func Test_auto_enable_interactive()
+  Tutor
+  call assert_equal('nofile', &buftype)
+  call assert_match('tutor#EnableInteractive', b:undo_ftplugin)
+
+  edit Xtutor/Xtest.tutor
+  call assert_true(empty(&buftype))
+  call assert_match('tutor#EnableInteractive', b:undo_ftplugin)
+endfunc


### PR DESCRIPTION
### vim-patch:9.1.1384: still some problem with the new tutors filetype plugin
Problem:  still some problem with the new tutors filetype plugin
Solution: refactor code to enable/disable tutor mode into
          tutor#EnableInteractive() function, include a test
          (Phạm Bình An)

I find it annoying that Tutor's interactive mode is always on (or debug
mode is off) even when I open a tutor file with :edit command.
I think it makes more sense to make this "interactive mode":

- Always on when it is opened with :Tutor command
- Off otherwise

For more references, see `:help` feature, it is a much better than
:Tutor, since I don't have to run `:let g:help_debug = 1` just to be able
to edit and save a help file

Therefore, I remove `g:tutor_debug`

closes: https://github.com/vim/vim/pull/17299

https://github.com/vim/vim/commit/13bea589a25707c8f9e29b2920410bdcccd79bc5

Co-authored-by: Phạm Bình An <phambinhanctb2004@gmail.com>

### fix(tutor): l:lang is undefined

Fix [failed tests](https://github.com/neovim/neovim/actions/runs/14983899155/job/42094007964?pr=33994)