### PR TITLE
vim-patch:9.1.1383: completion: 'isexpand' option does not handle space char correct

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3147,7 +3147,15 @@ void f_complete_match(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     char *cur_end = before_cursor + (int)strlen(before_cursor);
 
     while (*p != NUL) {
-      size_t len = copy_option_part(&p, part, MAXPATHL, ",");
+      size_t len = 0;
+      if (*p == ',' && *(p + 1) == ' ' && (*(p + 2) == ',' || *(p + 2) == NUL)) {
+        part[0] = ' ';
+        len = 1;
+        p++;
+      } else {
+        len = copy_option_part(&p, part, MAXPATHL, ",");
+      }
+
       if (len > 0 && (int)len <= col) {
         if (strncmp(cur_end - len, part, len) == 0) {
           int bytepos = col - (int)len;

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -3762,6 +3762,10 @@ func Test_complete_match()
   call feedkeys("Sabc, \<ESC>:let g:result=complete_match()\<CR>", 'tx')
   call assert_equal([[4, ',']], g:result)
 
+  set ise=\ ,=
+  call feedkeys("Sif true  \<ESC>:let g:result=complete_match()\<CR>", 'tx')
+  call assert_equal([[8, ' ']], g:result)
+
   bw!
   unlet g:result
   set isexpand&


### PR DESCRIPTION

Problem:  When a space character is used as a trigger in 'isexpand' option
          it doesn't get recognized because skip_to_option_part() skips
          spaces after a comma, treating them as option separators
          rather than option value (after v9.1.1341)
Solution: manually set the part to a space character (glepnir).

closes: vim/vim#17305

https://github.com/vim/vim/commit/8d0e42b71023144e6db17534da41ffecbd0b655f

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
