### PR TITLE
fix(extui): handle carriage return in messages

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2704,6 +2704,10 @@ These four windows are assigned the "cmdline", "msgbox", "msgmore" and
 "msgprompt" 'filetype' respectively. Use a |FileType| autocommand to configure
 any local options for these windows and their respective buffers.
 
+Rather than a |hit-enter-prompt|, messages shown in the cmdline area that do
+not fit are appended with a `[+x]` "spill" indicator, where `x` indicates the
+spilled lines. To see the full message, the |g<| command can be used.
+
 
 
 ==============================================================================

--- a/runtime/lua/vim/_extui.lua
+++ b/runtime/lua/vim/_extui.lua
@@ -30,6 +30,10 @@
 ---These four windows are assigned the "cmdline", "msgbox", "msgmore" and
 ---"msgprompt" 'filetype' respectively. Use a |FileType| autocommand to configure
 ---any local options for these windows and their respective buffers.
+---
+---Rather than a |hit-enter-prompt|, messages shown in the cmdline area that do
+---not fit are appended with a `[+x]` "spill" indicator, where `x` indicates the
+---spilled lines. To see the full message, the |g<| command can be used.
 
 local api = vim.api
 local ext = require('vim._extui.shared')

--- a/runtime/lua/vim/_extui/messages.lua
+++ b/runtime/lua/vim/_extui/messages.lua
@@ -290,13 +290,10 @@ function M.show_msg(tar, content, replace_last, more)
     else
       api.nvim_win_set_cursor(ext.wins[ext.tab][tar], { 1, 0 })
       ext.cmd.highlighter.active[ext.bufs.cmd] = nil
-      -- Show hint in box and place [+x] indicator for lines that spill over 'cmdheight'.
+      -- Place [+x] indicator for lines that spill over 'cmdheight'.
       M.cmd.lines, M.cmd.msg_row = h.all, h.end_row
-      local spill = M.cmd.lines - ext.cmdheight
-      M.virt.msg[M.virt.idx.spill][1] = spill > 0 and { 0, ('[+%d]'):format(spill) } or nil
-      if spill > 0 then
-        M.msg_show('verbose', { { 0, ('Press g< to see %d more lines'):format(spill), 0 } })
-      end
+      local spill = M.cmd.lines > ext.cmdheight and ('[+%d]'):format(M.cmd.lines - ext.cmdheight)
+      M.virt.msg[M.virt.idx.spill][1] = spill and { 0, spill } or nil
     end
   end
 


### PR DESCRIPTION
**fix(extui): handle carriage return in messages**

Problem:  Carriage return should place the "write cursor" at the start of a line.
Solution: Construct the to be printed line by iterating over carriage returns.

**revert: show "g<" hint when message spills 'cmdheight'**

Problem:  Hint message to press "g<" for message that spills
          'cmdheight' is too intrusive.
Solution: Remove the hint message. Document the meaning of the spill
          indicator instead.

