### PR TITLE
feat: smaller indentation for outline

### DIFF
--- a/runtime/lua/vim/treesitter/_headings.lua
+++ b/runtime/lua/vim/treesitter/_headings.lua
@@ -93,12 +93,7 @@ function M.show_toc()
   end
   -- add indentation for nicer list formatting
   for _, heading in pairs(headings) do
-    if heading.level > 2 then
-      heading.text = '  ' .. heading.text
-    end
-    if heading.level > 4 then
-      heading.text = '  ' .. heading.text
-    end
+    heading.text = (' '):rep(heading.level - 1) .. heading.text
   end
   vim.fn.setloclist(0, headings, ' ')
   vim.fn.setloclist(0, {}, 'a', { title = 'Table of contents' })


### PR DESCRIPTION
In the generated TOC for markdown (using gO), an indentation of 2 no-break-spaces for every 2 levels feels weird. So, instead, have one no-break-space indentation per level.

Also, I'm open to replacing no-break-space with some other character for better readability.