### PR TITLE
fix(diagnostics): extend conversion support from/to quickfix format

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -2692,7 +2692,9 @@ function M.toqflist(diagnostics)
       end_lnum = v.end_lnum and (v.end_lnum + 1) or nil,
       end_col = v.end_col and (v.end_col + 1) or nil,
       text = v.message,
+      nr = tonumber(v.code),
       type = errlist_type_map[v.severity] or 'E',
+      valid = 1,
     }
     table.insert(list, item)
   end
@@ -2724,7 +2726,8 @@ function M.fromqflist(list)
       local col = math.max(0, item.col - 1)
       local end_lnum = item.end_lnum > 0 and (item.end_lnum - 1) or lnum
       local end_col = item.end_col > 0 and (item.end_col - 1) or col
-      local severity = item.type ~= '' and M.severity[item.type] or M.severity.ERROR
+      local code = item.nr > 0 and item.nr or nil
+      local severity = item.type ~= '' and M.severity[item.type:upper()] or M.severity.ERROR
       diagnostics[#diagnostics + 1] = {
         bufnr = item.bufnr,
         lnum = lnum,
@@ -2733,6 +2736,7 @@ function M.fromqflist(list)
         end_col = end_col,
         severity = severity,
         message = item.text,
+        code = code,
       }
     end
   end


### PR DESCRIPTION
### Problem:

- Some cmdline tools like `shellcheck` output its diagnostics in lowercase

  Ex.
  ```
  foo.sh:715:15: warning: Declare and assign separately to avoid masking return values. [SC2155]
  ```
  
  This prevents `fromqflist` method to properly assign the severity since the quickfix will store the value as `type = 'w'`

- `toqflist` does not mark its items as `valid` which prevents converting back and fort items to/from the quickfix 
  ```lua
  :lua =#vim.diagnostic.toqflist(vim.diagnostic.get(0)) == 0 -- false
  :lua =#vim.diagnostic.fromqflist(vim.diagnostic.toqflist(vim.diagnostic.get(0))) == 0 -- true
  ```
- diagnostics `code` and quickfix `nr` attributes are not included in the conversion between and from quickfix format 

### Solution:
- Use uppercase chars to find map the severity.
- Mark quickfix items as valid when converting from diagnostics 
- Set `code` to `nr` when it has a greater than 0 value and set `nr` when `code` can be parsed to an integer

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
