### PR TITLE
fix: use nvim namespace convention

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -746,7 +746,7 @@ local registered_autocmds = {}
 
 local function make_augroup_key(namespace, bufnr)
   local ns = M.get_namespace(namespace)
-  return string.format('DiagnosticInsertLeave:%s:%s', bufnr, ns.name)
+  return string.format('nvim.diagnostic.insertleave.%s.%s', bufnr, ns.name)
 end
 
 --- @param namespace integer

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -189,7 +189,7 @@ function M.get_namespace(client_id, is_pull)
       vim.tbl_get((client or {}).server_capabilities, 'diagnosticProvider', 'identifier')
     local key = string.format('%d:%s', client_id, server_id or 'nil')
     local name = string.format(
-      'vim.lsp.%s.%d.%s',
+      'nvim.lsp.%s.%d.%s',
       client and client.name or 'unknown',
       client_id,
       server_id or 'nil'
@@ -201,7 +201,7 @@ function M.get_namespace(client_id, is_pull)
     end
     return ns
   else
-    local name = string.format('vim.lsp.%s.%d', client and client.name or 'unknown', client_id)
+    local name = string.format('nvim.lsp.%s.%d', client and client.name or 'unknown', client_id)
     local ns = _client_push_namespaces[client_id]
     if not ns then
       ns = api.nvim_create_namespace(name)

--- a/runtime/plugin/shada.vim
+++ b/runtime/plugin/shada.vim
@@ -3,7 +3,7 @@ if exists('g:loaded_shada_plugin')
 endif
 let g:loaded_shada_plugin = 1
 
-augroup ShaDaCommands
+augroup nvim.shada
   autocmd!
   autocmd BufReadCmd *.shada,*.shada.tmp.[a-z]
         \ :if !empty(v:cmdarg)|throw '++opt not supported'|endif

--- a/test/functional/plugin/shada_spec.lua
+++ b/test/functional/plugin/shada_spec.lua
@@ -2636,8 +2636,7 @@ describe('plugin/shada.vim', function()
     wshada('\004\000\009\147\000\196\002ab\196\001a')
     wshada_tmp('\004\000\009\147\000\196\002ab\196\001b')
 
-    local bufread_commands =
-      api.nvim_get_autocmds({ group = 'ShaDaCommands', event = 'BufReadCmd' })
+    local bufread_commands = api.nvim_get_autocmds({ group = 'nvim.shada', event = 'BufReadCmd' })
     eq(2, #bufread_commands--[[, vim.inspect(bufread_commands) ]])
 
     -- Need to set nohidden so that the buffer containing 'fname' is not unloaded


### PR DESCRIPTION
Switches the lsp diagnostic namespaces to the `nvim.`-prefixed convention.
