### PR TITLE
feat(lsp): incremental selection via `textDocument/selectionRange`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -81,7 +81,7 @@ the options are empty or were set by the builtin runtime (ftplugin) files. The
 options are not restored when the LSP client is stopped or detached.
 
 GLOBAL DEFAULTS
-                                          *grr* *gra* *grn* *gri* *i_CTRL-S*
+                                *grr* *gra* *grn* *gri* *i_CTRL-S* *an* *in*
 These GLOBAL keymaps are created unconditionally when Nvim starts:
 - "grn" is mapped in Normal mode to |vim.lsp.buf.rename()|
 - "gra" is mapped in Normal and Visual mode to |vim.lsp.buf.code_action()|
@@ -89,6 +89,8 @@ These GLOBAL keymaps are created unconditionally when Nvim starts:
 - "gri" is mapped in Normal mode to |vim.lsp.buf.implementation()|
 - "gO" is mapped in Normal mode to |vim.lsp.buf.document_symbol()|
 - CTRL-S is mapped in Insert mode to |vim.lsp.buf.signature_help()|
+- "an" and "in" are mapped in Visual mode to outer and inner incremental
+  selections, respectively, using |vim.lsp.buf.selection_range()|
 
 BUFFER-LOCAL DEFAULTS
 - 'omnifunc' is set to |vim.lsp.omnifunc()|, use |i_CTRL-X_CTRL-O| to trigger
@@ -1832,6 +1834,14 @@ rename({new_name}, {opts})                              *vim.lsp.buf.rename()*
                     • {name}? (`string`) Restrict clients used for rename to
                       ones where client.name matches this field.
                     • {bufnr}? (`integer`) (default: current buffer)
+
+selection_range({direction})                   *vim.lsp.buf.selection_range()*
+    Perform an incremental selection at the cursor position based on ranges
+    given by the LSP. The `direction` parameter specifies whether the
+    selection should head inward or outward.
+
+    Parameters: ~
+      • {direction}  (`'inner'|'outer'`)
 
 signature_help({config})                        *vim.lsp.buf.signature_help()*
     Displays signature information about the symbol under the cursor in a

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -167,6 +167,8 @@ LSP
   "resolving" it).
 • Support for `workspace/diagnostic`: |vim.lsp.buf.workspace_diagnostics()|
   https://microsoft.github.io/language-server-protocol/specifications/specification-current/#workspace_dagnostics
+• Incremental selection is now supported via `textDocument/selectionRange`.
+  `an` selects outwards and `in` selects inwards.
 
 LUA
 

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -209,6 +209,14 @@ do
       vim.lsp.buf.implementation()
     end, { desc = 'vim.lsp.buf.implementation()' })
 
+    vim.keymap.set('x', 'an', function()
+      vim.lsp.buf.selection_range('outer')
+    end, { desc = "vim.lsp.buf.selection_range('outer')" })
+
+    vim.keymap.set('x', 'in', function()
+      vim.lsp.buf.selection_range('inner')
+    end, { desc = "vim.lsp.buf.selection_range('inner')" })
+
     vim.keymap.set('n', 'gO', function()
       vim.lsp.buf.document_symbol()
     end, { desc = 'vim.lsp.buf.document_symbol()' })

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -535,6 +535,9 @@ function protocol.make_client_capabilities()
       colorProvider = {
         dynamicRegistration = true,
       },
+      selectionRange = {
+        dynamicRegistration = false,
+      },
     },
     workspace = {
       symbol = {


### PR DESCRIPTION
Select outwards with `an` and inwards with `in` in Visual mode. Ranges are reset when leaving Visual mode.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
