### PR TITLE
fix(terminal): stack overflow when too many csi args

### DIFF
--- a/src/nvim/vterm/vterm_internal_defs.h
+++ b/src/nvim/vterm/vterm_internal_defs.h
@@ -15,7 +15,7 @@
 
 #define INTERMED_MAX 16
 
-#define CSI_ARGS_MAX 16
+#define CSI_ARGS_MAX 32
 #define CSI_LEADER_MAX 16
 
 #define BUFIDX_PRIMARY   0


### PR DESCRIPTION
Problem:
Crash when csi contains > 16 args. It's easy to trigger
when you attempt to pipe external terminal scrollback buffer.
```sh
nvim --clean --cmd "term printf '\e[38:2:59:66:97;48:2:36:40:59;58:2:224:175:104;4:3m'"
```
<details/><summary>backtrace</summary>

```
(gdb) bt
#0  0x00005e112010efa2 in do_csi (vt=0x5e113dcd91a0, command=109 'm') at **/src/nvim/vterm/parser.c:45
#1  0x00005e112010f94f in vterm_input_write (vt=0x5e113dcd91a0, bytes=0x5e113dc8a2f0 "\033[38:2:59:66:97;48:2:36:40:59;58:2:224:175:104;4:3m", len=51) at **/src/nvim/vterm/parser.c:274
#2  0x00005e11200b7775 in terminal_receive (term=0x5e113dcd5b50, data=0x5e113dc8a2f0 "\033[38:2:59:66:97;48:2:36:40:59;58:2:224:175:104;4:3m", len=51) at **/src/nvim/terminal.c:1114
#3  0x00005e111fde8a11 in on_channel_output (stream=0x5e113dcd7f38, chan=0x5e113dcd7d50, buf=0x5e113dc8a2f0 "\033[38:2:59:66:97;48:2:36:40:59;58:2:224:175:104;4:3m", count=51, eof=false,
    reader=0x5e113dcd8438) at **/src/nvim/channel.c:681
#4  0x00005e111fde88f6 in on_channel_data (stream=0x5e113dcd7f38, buf=0x5e113dc8a2f0 "\033[38:2:59:66:97;48:2:36:40:59;58:2:224:175:104;4:3m", count=51, data=0x5e113dcd7d50, eof=false)
    at **/src/nvim/channel.c:653
#5  0x00005e111fe8fc01 in read_event (argv=0x7ffcbbf73770) at **/src/nvim/event/rstream.c:180
#6  0x00005e111fe8ff92 in invoke_read_cb (stream=0x5e113dcd7f38, eof=false) at **/src/nvim/event/rstream.c:233
#7  0x00005e111fe8f9ca in read_cb (uvstream=0x5e113dcd7f40, cnt=51, buf=0x7ffcbbf73870) at **/src/nvim/event/rstream.c:135
#8  0x00005e112022b3ff in uv__read (stream=0x5e113dcd7f40) at **/.deps/build/src/libuv/src/unix/stream.c:1148
#9  0x00005e112022b6fd in uv__stream_io (loop=0x5e11203e08e0 <main_loop>, w=0x5e113dcd7fc8, events=17) at **/.deps/build/src/libuv/src/unix/stream.c:1208
#10 0x00005e1120235f6e in uv__io_poll (loop=0x5e11203e08e0 <main_loop>, timeout=0) at **/.deps/build/src/libuv/src/unix/linux.c:1565
#11 0x00005e11202186e7 in uv_run (loop=0x5e11203e08e0 <main_loop>, mode=UV_RUN_NOWAIT) at **/.deps/build/src/libuv/src/unix/core.c:460
#12 0x00005e111fe8ca0a in loop_uv_run (loop=0x5e11203e08e0 <main_loop>, ms=0) at **/src/nvim/event/loop.c:61
#13 0x00005e111fe8ca66 in loop_poll_events (loop=0x5e11203e08e0 <main_loop>, ms=0) at **/src/nvim/event/loop.c:82
#14 0x00005e111ffe629b in os_breakcheck () at **/src/nvim/os/input.c:207
#15 0x00005e111ffed6f0 in do_path_expand (gap=0x7ffcbbf78050, path=0x5e113dd34a20 "/etc/xdg/nvim/plugin/*", wildoff=21, flags=2, didstar=true) at **/src/nvim/path.c:621
#16 0x00005e111ffedc09 in do_path_expand (gap=0x7ffcbbf78050, path=0x5e113dd2f760 "/etc/xdg/nvim/plugin/**/*", wildoff=0, flags=2, didstar=false) at **/src/nvim/path.c:722
#17 0x00005e111ffed608 in path_expand (gap=0x7ffcbbf78050, path=0x5e113dd2f760 "/etc/xdg/nvim/plugin/**/*", flags=2) at **/src/nvim/path.c:590
#18 0x00005e111ffef579 in gen_expand_wildcards (num_pat=1, pat=0x7ffcbbf78120, num_file=0x7ffcbbf780bc, file=0x7ffcbbf780c0, flags=2) at **/src/nvim/path.c:1331
#19 0x00005e112004613c in gen_expand_wildcards_and_cb (num_pat=1, pats=0x7ffcbbf78120, flags=2, all=true, callback=0x5e1120043dd8 <source_callback_vim_lua>, cookie=0x0)
    at **/src/nvim/runtime.c:977
#20 0x00005e112004435b in do_in_path (
im/after", prefix=0x5e11202a3a00 "", name=0x5e11202a3c5e "plugin/**/*", flags=65, callback=0x5e1120043dd8 <source_callback_vim_lua>, cookie=0x0) at **/src/nvim/runtime.c:488,/etc/xdg/nv
#21 0x00005e1120045209 in do_in_path_and_pp (
im/after", name=0x5e11202a3c5e "plugin/**/*", flags=65, callback=0x5e1120043dd8 <source_callback_vim_lua>, cookie=0x0) at **/src/nvim/runtime.c:725ocal/share/nvim/site/after,/etc/xdg/nv
#22 0x00005e11200460f0 in source_in_path_vim_lua (
im/after", name=0x5e11202a3c5e "plugin/**/*", flags=65) at **/src/nvim/runtime.c:957/phan/b/neovim/build/lib/nvim,/usr/share/nvim/site/after,/usr/local/share/nvim/site/after,/etc/xdg/nv
#23 0x00005e112004707b in load_plugins () at **/src/nvim/runtime.c:1308
#24 0x00005e111ff48644 in main (argc=5, argv=0x7ffcbbf78528) at **/src/nvim/main.c:468
```
</details>

Solution:
Increase buffer size.
