### PR TITLE
fix(diagnostics): fixed virtual_text cursormoved autocmd error

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1588,7 +1588,6 @@ M.handlers.underline = {
   end,
 }
 
-
 --- @param namespace integer
 --- @param bufnr integer
 --- @param diagnostics table<integer, vim.Diagnostic[]>

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1588,27 +1588,40 @@ M.handlers.underline = {
   end,
 }
 
+
 --- @param namespace integer
 --- @param bufnr integer
 --- @param diagnostics table<integer, vim.Diagnostic[]>
 --- @param opts vim.diagnostic.Opts.VirtualText
 local function render_virtual_text(namespace, bufnr, diagnostics, opts)
   local lnum = api.nvim_win_get_cursor(0)[1] - 1
+  local buf_len = api.nvim_buf_line_count(bufnr)
   api.nvim_buf_clear_namespace(bufnr, namespace, 0, -1)
 
-  for line, line_diagnostics in pairs(diagnostics) do
-    local virt_texts = M._get_virt_text_chunks(line_diagnostics, opts)
-    local skip = (opts.current_line == true and line ~= lnum)
+  local function should_render(line)
+    if
+      (line >= buf_len)
+      or (opts.current_line == true and line ~= lnum)
       or (opts.current_line == false and line == lnum)
+    then
+      return false
+    else
+      return true
+    end
+  end
 
-    if virt_texts and not skip then
-      api.nvim_buf_set_extmark(bufnr, namespace, line, 0, {
-        hl_mode = opts.hl_mode or 'combine',
-        virt_text = virt_texts,
-        virt_text_pos = opts.virt_text_pos,
-        virt_text_hide = opts.virt_text_hide,
-        virt_text_win_col = opts.virt_text_win_col,
-      })
+  for line, line_diagnostics in pairs(diagnostics) do
+    if should_render(line) then
+      local virt_texts = M._get_virt_text_chunks(line_diagnostics, opts)
+      if virt_texts then
+        api.nvim_buf_set_extmark(bufnr, namespace, line, 0, {
+          hl_mode = opts.hl_mode or 'combine',
+          virt_text = virt_texts,
+          virt_text_pos = opts.virt_text_pos,
+          virt_text_hide = opts.virt_text_hide,
+          virt_text_win_col = opts.virt_text_win_col,
+        })
+      end
     end
   end
 end

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1604,9 +1604,9 @@ local function render_virtual_text(namespace, bufnr, diagnostics, opts)
       or (opts.current_line == false and line == lnum)
     then
       return false
-    else
-      return true
     end
+
+    return true
   end
 
   for line, line_diagnostics in pairs(diagnostics) do

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -3412,7 +3412,7 @@ describe('extmark decorations', function()
         {4:^1}                                                 |
         {4:1}                                                 |*13
                                                           |
-      ]]
+      ]],
     })
     feed('<C-e>')
     -- Newly visible line should also have the highlight.
@@ -3421,7 +3421,7 @@ describe('extmark decorations', function()
         {4:^1}                                                 |
         {4:1}                                                 |*13
                                                           |
-      ]]
+      ]],
     })
   end)
 end)


### PR DESCRIPTION
Problem:
Selecting and deleting all lines in a file with multiple diagnostics leads to the following error:
```
Error in CursorMoved Autocommands for "<buffer=9>":
Lua callback: ...nvimdcgMep/usr/share/nvim/runtime/lua/vim/diagnostic.lua:1587: Invalid 'line': out of range
stack traceback:
        [C]: in function 'nvim_buf_set_extmark'
        ...nvimdcgMep/usr/share/nvim/runtime/lua/vim/diagnostic.lua:1587: in function 'render_virtual_text'
        ...nvimdcgMep/usr/share/nvim/runtime/lua/vim/diagnostic.lua:1645: in function <...nvimdcgMep/usr/share/nvim/runtime/lua/vim/diagnostic.lua:1644>
```
This seems to have been introduced along with the changes made in the following PR [#33517](https://github.com/neovim/neovim/pull/33517)

How to Reproduce:
 - Use a minimal lsp diagnostic config:   ` vim.diagnostic.config({virtual_lines  = {current_line = true}, virtual_text = {current_line = false}})`
- Create a test file named test.lua
- Ensure you have a lua lsp active 
- Write 3-4 lines of errors (I used the following): 
```
asd
asd
asd
asd
```
- Select and delete all lines in the file (for example using the vim motion VggD from the bottom of the file)

Solution:
This PR introduces a check to verify that the line number does not exceed the number of lines within the buffer. This allows the CursorMoved auto-command to run as intended.

Fixes https://github.com/neovim/neovim/issues/34081