### PR TITLE
vim-patch:9.1.1388: Scrolling one line too far with 'nosmoothscroll' page scrolling

### DIFF
--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -2431,10 +2431,10 @@ static bool scroll_with_sms(Direction dir, int count, int *curscount)
 
     int width1 = curwin->w_view_width - win_col_off(curwin);
     int width2 = width1 + win_col_off2(curwin);
-    count = 1 + (curwin->w_skipcol - width1) / width2;
+    count = 1 + (curwin->w_skipcol - width1 - 1) / width2;
     if (fixdir == FORWARD) {
-      count = 2 + (linetabsize_eol(curwin, curwin->w_topline)
-                   - curwin->w_skipcol - width1) / width2;
+      count = 1 + (linetabsize_eol(curwin, curwin->w_topline)
+                   - curwin->w_skipcol - width1 + width2 - 1) / width2;
     }
     scroll_redraw(fixdir == FORWARD, count);
     *curscount += count * (fixdir == dir ? 1 : -1);

--- a/test/old/testdir/test_normal.vim
+++ b/test/old/testdir/test_normal.vim
@@ -4364,4 +4364,21 @@ func Test_scroll_longline_benchmark()
   bwipe!
 endfunc
 
+" Test Ctrl-B with 'nosmoothscroll' not stuck with line exactly window width.
+func Test_scroll_longline_winwidth()
+  10new
+  call setline(1, ['']->repeat(20) + ['A'->repeat(20 * winwidth(0))] + ['']->repeat(20))
+  exe "normal! G3\<C-B>"
+  call assert_equal(22, line('w0'))
+  exe "normal! \<C-B>"
+  call assert_equal(21, line('w0'))
+  exe "normal! \<C-B>"
+  call assert_equal(11, line('w0'))
+  exe "normal! \<C-B>"
+  call assert_equal(3, line('w0'))
+  exe "normal! \<C-B>"
+  call assert_equal(1, line('w0'))
+  bwipe!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
Problem:  One-off error in "count" to make "w_skipcol" zero with
          'nosmoothscroll' page scrolling when last virtual line
          in a buffer line is exactly the entire window width.
          (Hirohito Higashi)
Solution: Properly compute the smallest integer value necessary
          to make "w_skipcol" zero (Luuk van Baal)

https://github.com/vim/vim/commit/c6c72d165c90e94eee1d9107d82fb180ed138190
