### PR TITLE
vim-patch:9.1.1389: completion: still some issue when 'isexpand' contains a space

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3144,15 +3144,20 @@ void f_complete_match(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     }
   } else {
     char *p = ise;
+    char *p_space = NULL;
     char *cur_end = before_cursor + (int)strlen(before_cursor);
 
     while (*p != NUL) {
       size_t len = 0;
-      if (*p == ',' && *(p + 1) == ' ' && (*(p + 2) == ',' || *(p + 2) == NUL)) {
-        part[0] = ' ';
-        len = 1;
-        p++;
+      if (p_space) {
+        len = (size_t)(p - p_space - 1);
+        memcpy(part, p_space + 1, len);
+        p_space = NULL;
       } else {
+        char *next_comma = strchr((*p == ',') ? p + 1 : p, ',');
+        if (next_comma && *(next_comma + 1) == ' ') {
+          p_space = next_comma;
+        }
         len = copy_option_part(&p, part, MAXPATHL, ",");
       }
 

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -3778,6 +3778,13 @@ func Test_complete_match()
   set ise=\ ,=
   call feedkeys("Sif true  \<ESC>:let g:result=complete_match()\<CR>", 'tx')
   call assert_equal([[8, ' ']], g:result)
+  call feedkeys("Slet a = \<ESC>:let g:result=complete_match()\<CR>", 'tx')
+  call assert_equal([[7, '=']], g:result)
+  set ise={,\ ,=
+  call feedkeys("Sif true  \<ESC>:let g:result=complete_match()\<CR>", 'tx')
+  call assert_equal([[8, ' ']], g:result)
+  call feedkeys("S{ \<ESC>:let g:result=complete_match()\<CR>", 'tx')
+  call assert_equal([[1, '{']], g:result)
 
   bw!
   unlet g:result


### PR DESCRIPTION

Problem:  Cannot get completion startcol when space is not the first
          trigger character (after v9.1.1383)
Solution: Detect the next comma followed by a space in the option string
          and use in next compare loop (glepnir)

closes: vim/vim#17311

https://github.com/vim/vim/commit/08db2f4f287722d8fcdc00ab6ca9a1b07ec5faaa

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
