### PR TITLE
fix(tui): clear primary device callback before invoking it

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -658,8 +658,10 @@ static void handle_unknown_csi(TermInput *input, const TermKeyKey *key)
     case '?':
       // Primary Device Attributes (DA1) response
       if (input->callbacks.primary_device_attr) {
-        input->callbacks.primary_device_attr(input->tui_data);
+        void (*cb_save)(TUIData *) = input->callbacks.primary_device_attr;
+        // Clear the callback before invoking it, as it may set a new callback. #34031
         input->callbacks.primary_device_attr = NULL;
+        cb_save(input->tui_data);
       }
 
       break;

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -358,6 +358,7 @@ static void terminfo_start(TUIData *tui)
   tui->overflow = false;
   tui->set_cursor_color_as_str = false;
   tui->cursor_has_color = false;
+  tui->did_set_grapheme_cluster_mode = false;
   tui->showing_mode = SHAPE_IDX_N;
   tui->unibi_ext.enable_mouse = -1;
   tui->unibi_ext.disable_mouse = -1;


### PR DESCRIPTION
A primary device callback may set a new callback (e.g. when suspending),
so clearing it after invoking it is too late.

While at it, add missing reset of did_set_grapheme_cluster_mode in
terminfo_start().

Fix #34031
