### PR TITLE
fix(diagnostic): deprecate `float` in `vim.diagnostic.Opts.Jump`

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -21,7 +21,8 @@ API
 
 DIAGNOSTICS
 
-• "float" in |vim.diagnostic.JumpOpts|.	Use "on_jump" instead.
+• "float" in |vim.diagnostic.JumpOpts|.		Use "on_jump" instead.
+• "float" in |vim.diagnostic.Opts.Jump|.	Use "on_jump" instead.
 
 HIGHLIGHTS
 

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -604,8 +604,8 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
 *vim.diagnostic.Opts.Jump*
 
     Fields: ~
-      • {float}?     (`boolean|vim.diagnostic.Opts.Float`, default: false)
-                     Default value of the {float} parameter of
+      • {on_jump}?   (`fun(diagnostic:vim.Diagnostic?, bufnr:integer)`)
+                     Default value of the {on_jump} parameter of
                      |vim.diagnostic.jump()|.
       • {wrap}?      (`boolean`, default: true) Default value of the {wrap}
                      parameter of |vim.diagnostic.jump()|.


### PR DESCRIPTION
Problem: `float` in `vim.diagnostic.JumpOpts` has been deprecated since #33850. However, there is a `float` field in `vim.diagnostic.Opts.Jump` too, which is used to feed `vim.diagnostic.jump()`.
Solution: Deprecate it too.

(Out-of-topic question here: I wonder why [my comment](https://github.com/neovim/neovim/pull/33933#issuecomment-2868393113) seems to be totally ignored. If this is not planned or out of the scope of that PR, I couldn’t find any mention of it elsewhere. Just to be clear, I don't mean to blame anyone, developers are great, I just want to make sure I won't make the same mistake next time. I'm sorry if I missed any community guidelines, for example, commenting directly on a PR isn't encouraged.)