### PR TITLE
refactor(tui): don't use pseudo-terminfo for custom modes

### DIFF
--- a/src/nvim/tui/tui_defs.h
+++ b/src/nvim/tui/tui_defs.h
@@ -4,6 +4,10 @@ typedef struct TUIData TUIData;
 
 typedef enum {
   kTermModeLeftAndRightMargins = 69,
+  kTermModeMouseButtonEvent = 1002,
+  kTermModeMouseAnyEvent = 1003,
+  kTermModeMouseSGRExt = 1006,
+  kTermModeBracketedPaste = 2004,
   kTermModeSynchronizedOutput = 2026,
   kTermModeGraphemeClusters = 2027,
   kTermModeThemeUpdates = 2031,


### PR DESCRIPTION
This just cleans up some old definitions from before `tui_set_term_mode` existed. There is no need to represent custom modes in a different format just because they are safe without feature detection.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
