### PR TITLE
vim-patch:9.1.1393: missing test for switching buffers and reusing curbuf

### DIFF
--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -4507,4 +4507,31 @@ func Test_reuse_curbuf_leak()
   %bw!
 endfunc
 
+func Test_reuse_curbuf_switch()
+  edit asdf
+  let s:asdf_win = win_getid()
+  new
+  let other_buf = bufnr()
+  let other_win = win_getid()
+  augroup testing
+    autocmd!
+    autocmd BufUnload * ++once let s:triggered = 1
+          \| call assert_fails('split', 'E1159:')
+          \| call win_gotoid(s:asdf_win)
+  augroup END
+
+  " Check BufUnload changing curbuf does not cause buflist_new to create a new
+  " buffer while leaving "other_buf" unloaded in a window.
+  enew
+  call assert_equal(1, s:triggered)
+  call assert_equal(other_buf, bufnr())
+  call assert_equal(other_win, win_getid())
+  call assert_equal(1, win_findbuf(other_buf)->len())
+  call assert_equal(1, bufloaded(other_buf))
+
+  unlet! s:asdf_win s:triggered
+  call CleanUpTestAuGroup()
+  %bw!
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
Problem:  The check in buf_freeall that restores curwin subtly prevents
          leaving an unloaded buffer in a window when reusing curbuf, if
          autocommands switch to a different buffer.
Solution: Add a test case that covers this. Also ensure splitting isn't
          possible, as that could do the same (Sean Dewar)

closes: vim/vim#17325

https://github.com/vim/vim/commit/31be82e66d412000f1d964a36bb8a03d40eaaeac

I'll auto-merge this one as it just adds test coverage.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
