### PR TITLE
fix(runtime): set the local value only when the global value is not set

### DIFF
--- a/runtime/ftplugin/lua.lua
+++ b/runtime/ftplugin/lua.lua
@@ -1,9 +1,20 @@
+---@param name string
+---@param value any
+local function set_local_default(name, value)
+  if
+    vim.api.nvim_get_option_value(name, { scope = 'global' })
+    == vim.api.nvim_get_option_info2(name, { scope = 'global' }).default
+  then
+    vim.api.nvim_set_option_value(name, value, { scope = 'local' })
+  end
+end
+
 -- use treesitter over syntax
 vim.treesitter.start()
 
 vim.bo.includeexpr = [[v:lua.require'vim._ftplugin.lua'.includeexpr(v:fname)]]
 vim.bo.omnifunc = 'v:lua.vim.lua_omnifunc'
-vim.wo[0][0].foldexpr = 'v:lua.vim.treesitter.foldexpr()'
+set_local_default('foldexpr', 'v:lua.vim.treesitter.foldexpr()')
 
 vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '')
   .. '\n call v:lua.vim.treesitter.stop()'


### PR DESCRIPTION
Problem:

When the user sets a global value for `foldexpr` like `vim.lsp.foldexpr`, the intention may be to apply this setting for every filetype. The ftplugin still sets `foldexpr` to `vim.treesitter.foldexpr`, and it will override the global value when editing Lua files.


Solution:

Check if the global value is still the default before setting the local value.