### PR TITLE
fix(:print): don't use schar_from_ascii() for illegal byte

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2019,6 +2019,11 @@ void msg_prt_line(const char *s, bool list)
     } else {
       hl_id = 0;
       int c = (uint8_t)(*s++);
+      if (c >= 0x80) {  // Illegal byte
+        col += utf_char2cells(c);
+        msg_putchar(c);
+        continue;
+      }
       sc_extra = NUL;
       sc_final = NUL;
       if (list) {

--- a/test/functional/ex_cmds/print_commands_spec.lua
+++ b/test/functional/ex_cmds/print_commands_spec.lua
@@ -1,7 +1,9 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
 
 local clear, eq, command, fn = n.clear, t.eq, n.command, n.fn
+local assert_alive = n.assert_alive
 
 describe(':z^', function()
   before_each(clear)
@@ -9,5 +11,22 @@ describe(':z^', function()
   it('correctly sets the cursor after :z^', function()
     command('z^')
     eq(1, fn.line('.'))
+  end)
+end)
+
+describe(':print', function()
+  before_each(clear)
+
+  it('does not crash when printing 0xFF byte #34044', function()
+    local screen = Screen.new()
+    -- Needs raw 0xFF byte, not 0xFF char
+    command('call setline(1, "foo\\xFFbar")')
+    command('%print')
+    screen:expect([[
+      ^foo{18:<ff>}bar                                           |
+      {1:~                                                    }|*12
+      fooÿbar                                              |
+    ]])
+    assert_alive()
   end)
 end)


### PR DESCRIPTION
Fix #34044
