### PR TITLE
vim-patch:9.1.1395: search_stat not reset when pattern differs in case

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -2724,12 +2724,9 @@ static void update_search_stat(int dirc, pos_T *pos, pos_T *cursor_pos, searchst
                 || (dirc == '/' && lt(p, lastpos)));
 
   // If anything relevant changed the count has to be recomputed.
-  // STRNICMP ignores case, but we should not ignore case.
-  // Unfortunately, there is no STRNICMP function.
-  // XXX: above comment should be "no MB_STRCMP function" ?
   if (!(chgtick == buf_get_changedtick(curbuf)
         && (lastpat != NULL  // suppress clang/NULL passed as nonnull parameter
-            && mb_strnicmp(lastpat, spats[last_idx].pat, lastpatlen) == 0
+            && strncmp(lastpat, spats[last_idx].pat, lastpatlen) == 0
             && lastpatlen == spats[last_idx].patlen)
         && equalpos(lastpos, *cursor_pos)
         && lbuf == curbuf)

--- a/test/functional/legacy/search_stat_spec.lua
+++ b/test/functional/legacy/search_stat_spec.lua
@@ -184,4 +184,28 @@ describe('search stat', function()
       {19:search hit TOP, continuing at BOTTOM}                        |
     ]])
   end)
+
+  -- oldtest: Test_search_stat_smartcase_ignorecase()
+  it('when changing case of pattern', function()
+    exec([[
+      set shm-=S ignorecase smartcase
+      call setline(1, [' MainmainmainmmmainmAin', ''])
+    ]])
+
+    feed('/main<cr>nnnn')
+    screen:expect([[
+       {10:Mainmainmain}mm{10:main^mAin}       |
+                                    |
+      {1:~                             }|*7
+      /main                  [5/5]  |
+    ]])
+
+    feed('/mAin<cr>')
+    screen:expect([[
+       Mainmainmainmmmain{10:^mAin}       |
+                                    |
+      {1:~                             }|*7
+      /mAin                  [1/1]  |
+    ]])
+  end)
 end)

--- a/test/old/testdir/test_search_stat.vim
+++ b/test/old/testdir/test_search_stat.vim
@@ -459,4 +459,23 @@ func Test_search_stat_backwards()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_search_stat_smartcase_ignorecase()
+  CheckRunVimInTerminal
+
+  let lines =<< trim END
+    set shm-=S ignorecase smartcase
+    call setline(1, [' MainmainmainmmmainmAin', ''])
+  END
+  call writefile(lines, 'Xsearchstat_ignorecase', '5')
+
+  let buf = RunVimInTerminal('-S Xsearchstat_ignorecase', #{rows: 10})
+  call term_sendkeys(buf, "/main\<cr>nnnn")
+  call WaitForAssert({-> assert_match('\[5\/5\]', term_getline(buf, 10))}, 1000)
+
+  call term_sendkeys(buf, "/mAin\<cr>")
+  call WaitForAssert({-> assert_match('\[1\/1\]', term_getline(buf, 10))}, 1000)
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1395: search_stat not reset when pattern differs in case

Problem:  search_stat not reset when pattern differs in case
          (tahzibijafar)
Solution: use STRNCMP instead of MB_STRNICMP macro

There was a long standing todo comment, that using MB_STRNICMP is wrong.
So let's change it to STRNCMP() instead. Even if it not handle
multi-byte characters correctly, then Vim will rather recompute the
search stat, instead of re-using the old (and possibly wrong) value.

closes: vim/vim#17314

https://github.com/vim/vim/commit/670d0c1468b7ece958acf3b03de9e202e612804a

Co-authored-by: Christian Brabandt <cb@256bit.org>