### PR TITLE
fix(lsp): trigger `autochdir` before resolving `root_markers`

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -571,6 +571,11 @@ local function lsp_enable_callback(bufnr)
           end)
         end)
       else
+        if vim.go.autochdir == true then
+          -- update directory before resolving root markers
+          -- setting value triggers autochdir callback
+          vim.go.autochdir = true
+        end
         start_config(bufnr, config)
       end
     end


### PR DESCRIPTION
If `autochdir` is enabled, ensure that the directory has been updated before resolving `root_markers`.