### PR TITLE
vim-patch: Vim syntax updates

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -3507,6 +3507,7 @@ names whose syntax definitions will be included in Typst files. Example: >
 
 VIM			*vim.vim*		*ft-vim-syntax*
 			*g:vimsyn_minlines*	*g:vimsyn_maxlines*
+
 There is a trade-off between more accurate syntax highlighting versus screen
 updating speed.  To improve accuracy, you may wish to increase the
 g:vimsyn_minlines variable.  The g:vimsyn_maxlines variable may be used to
@@ -3525,18 +3526,19 @@ embedded script highlighting they wish to have. >
    g:vimsyn_embed == 0      : disable (don't embed any scripts)
    g:vimsyn_embed == 'lpPr' : support embedded Lua, Perl, Python and Ruby
 <
-This option is disabled by default.
+By default, g:vimsyn_embed is unset, and embedded Lua scripts are supported.
+
 						*g:vimsyn_folding*
 Some folding is now supported with when 'foldmethod' is set to "syntax": >
 
    g:vimsyn_folding == 0 or doesn't exist: no syntax-based folding
    g:vimsyn_folding =~ 'a' : fold augroups
    g:vimsyn_folding =~ 'f' : fold functions
-   g:vimsyn_folding =~ 'h' : fold heredocs
-   g:vimsyn_folding =~ 'l' : fold Lua      script
-   g:vimsyn_folding =~ 'p' : fold Perl     script
-   g:vimsyn_folding =~ 'P' : fold Python   script
-   g:vimsyn_folding =~ 'r' : fold Ruby     script
+   g:vimsyn_folding =~ 'h' : fold let heredocs
+   g:vimsyn_folding =~ 'l' : fold Lua      heredocs
+   g:vimsyn_folding =~ 'p' : fold Perl     heredocs
+   g:vimsyn_folding =~ 'P' : fold Python   heredocs
+   g:vimsyn_folding =~ 'r' : fold Ruby     heredocs
 <
 
 By default, g:vimsyn_folding is unset.  Concatenate the indicated characters

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -209,13 +209,13 @@ Vim9 syn keyword vim9Boolean	true false
 " Numbers {{{2
 " =======
 syn case ignore
-syn match	vimNumber	'\<\d\+'			skipwhite nextgroup=vimGlobal,vimSubst1,@vimComment,vimSubscript
-syn match	vimNumber	'\<\d\+\.\d\+\%(e[+-]\=\d\+\)\='		skipwhite nextgroup=vimGlobal,vimSubst1,@vimComment
-syn match	vimNumber	'\<0b[01]\+'			skipwhite nextgroup=vimGlobal,vimSubst1,@vimComment,vimSubscript
-syn match	vimNumber	'\<0o\=\o\+'			skipwhite nextgroup=vimGlobal,vimSubst1,@vimComment,vimSubscript
-syn match	vimNumber	'\<0x\x\+'			skipwhite nextgroup=vimGlobal,vimSubst1,@vimComment,vimSubscript
-syn match	vimNumber	'\<0z\>'			skipwhite nextgroup=vimGlobal,vimSubst1,@vimComment
-syn match	vimNumber	'\<0z\%(\x\x\)\+\%(\.\%(\x\x\)\+\)*'	skipwhite nextgroup=vimGlobal,vimSubst1,@vimComment,vimSubscript
+syn match	vimNumber	"\<\d\+\%('\d\+\)*"		skipwhite nextgroup=@vimComment,vimSubscript,vimGlobal,vimSubst1
+syn match	vimNumber	"\<\d\+\%('\d\+\)*\.\d\+\%(e[+-]\=\d\+\)\="	skipwhite nextgroup=@vimComment
+syn match	vimNumber	"\<0b[01]\+\%('[01]\+\)*"		skipwhite nextgroup=@vimComment,vimSubscript
+syn match	vimNumber	"\<0o\=\o\+\%('\o\+\)*"		skipwhite nextgroup=@vimComment,vimSubscript
+syn match	vimNumber	"\<0x\x\+\%('\x\+\)*"		skipwhite nextgroup=@vimComment,vimSubscript
+syn match	vimNumber	'\<0z\>'			skipwhite nextgroup=@vimComment
+syn match	vimNumber	'\<0z\%(\x\x\)\+\%(\.\%(\x\x\)\+\)*'	skipwhite nextgroup=@vimComment,vimSubscript
 syn case match
 
 " All vimCommands are contained by vimIsCommand. {{{2

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -219,7 +219,7 @@ syn match	vimNumber	'\<0z\%(\x\x\)\+\%(\.\%(\x\x\)\+\)*'	skipwhite nextgroup=@vi
 syn case match
 
 " All vimCommands are contained by vimIsCommand. {{{2
-syn cluster vimCmdList	contains=vimAbb,vimAddress,vimAutocmd,vimAugroup,vimBehave,vimCall,vimCatch,vimConst,vimDoautocmd,vimDebuggreedy,vimDef,vimDefFold,vimDelcommand,@vimEcho,vimElse,vimEnddef,vimEndfunction,vimEndif,vimExecute,vimIsCommand,vimExtCmd,vimExFilter,vimFor,vimFunction,vimFuncFold,vimGrep,vimGrepAdd,vimGlobal,vimHelpgrep,vimHighlight,vimLet,vimLoadkeymap,vimLockvar,vimMake,vimMap,vimMark,vimMatch,vimNotFunc,vimNormal,vimRedir,vimSet,vimSleep,vimSort,vimSyntax,vimThrow,vimUnlet,vimUnlockvar,vimUnmap,vimUserCmd,vimVimgrep,vimVimgrepadd,vimMenu,vimMenutranslate,@vim9CmdList,@vimExUserCmdList
+syn cluster vimCmdList	contains=vimAbb,vimAddress,vimAutocmd,vimAugroup,vimBehave,vimCall,vimCatch,vimConst,vimDoautocmd,vimDebuggreedy,vimDef,vimDefFold,vimDelcommand,@vimEcho,vimElse,vimEnddef,vimEndfunction,vimEndif,vimExecute,vimIsCommand,vimExtCmd,vimExFilter,vimFor,vimFunction,vimFuncFold,vimGrep,vimGrepAdd,vimGlobal,vimHelpgrep,vimHighlight,vimLet,vimLoadkeymap,vimLockvar,vimMake,vimMap,vimMark,vimMatch,vimNotFunc,vimNormal,vimRedir,vimSet,vimSleep,vimSort,vimSyntax,vimThrow,vimUnlet,vimUnlockvar,vimUnmap,vimUserCmd,vimVimgrep,vimVimgrepadd,vimMenu,vimMenutranslate,@vim9CmdList,@vimExUserCmdList,vimLua,vimMzScheme,vimPerl,vimPython,vimPython3,vimPythonX,vimRuby,vimTcl
 syn cluster vim9CmdList	contains=vim9Abstract,vim9Class,vim9Const,vim9Enum,vim9Export,vim9Final,vim9For,vim9Interface,vim9Type,vim9Var
 syn match vimCmdSep	"\\\@1<!|"	skipwhite nextgroup=@vimCmdList,vimSubst1,vimFunc
 syn match vimCmdSep	":\+"	skipwhite nextgroup=@vimCmdList,vimSubst1
@@ -386,7 +386,7 @@ syn match	vim9LambdaOperatorComment contained "#.*" skipwhite skipempty nextgrou
 syn cluster	vimFuncList	contains=vimFuncBang,vimFunctionError,vimFuncKey,vimFuncScope,vimFuncSID,Tag
 syn cluster	vimDefList	contains=vimFuncBang,vimFunctionError,vimDefKey,vimFuncScope,vimFuncSID,Tag
 
-syn cluster	vimFuncBodyCommon	contains=@vimCmdList,vimCmplxRepeat,vimContinue,vimCtrlChar,vimDef,vimFBVar,vimFunc,vimFunction,vimLetHereDoc,vimNotFunc,vimNumber,vimOper,vimOperParen,vimRegister,vimSpecFile,vimString,vimSubst,vimFuncFold,vimDefFold
+syn cluster	vimFuncBodyCommon	contains=@vimCmdList,vimCmplxRepeat,vimContinue,vimCtrlChar,vimDef,vimFBVar,vimFunc,vimFunction,vimLetHeredoc,vimNotFunc,vimNumber,vimOper,vimOperParen,vimRegister,vimSpecFile,vimString,vimSubst,vimFuncFold,vimDefFold
 syn cluster	vimFuncBodyList	contains=@vimFuncBodyCommon,vimComment,vimLineComment,vimInsert,vimConst,vimLet,vimSearch
 syn cluster	vimDefBodyList	contains=@vimFuncBodyCommon,vim9Comment,vim9LineComment,vim9Block,vim9Const,vim9Final,vim9Var,vim9Null,vim9Boolean,vim9For,vim9LhsVariable,vim9LhsVariableList,vim9LhsRegister,vim9Search,@vimSpecialVar
 
@@ -887,16 +887,16 @@ syn region	vimUnletVars	contained
       \ nextgroup=vimCmdSep,vimComment
       \ contains=@vimContinue,vimEnvvar,vimVar,vimVimVar
 
-VimFoldh syn region vimLetHereDoc	matchgroup=vimLetHereDocStart start='\%(^\z(\s*\)\S.*\)\@<==<<\s*trim\%(\s\+\)\@>\z(\L\S*\)'	matchgroup=vimLetHereDocStop end='^\z1\=\z2$' extend
-VimFoldh syn region vimLetHereDoc	matchgroup=vimLetHereDocStart start='=<<\%(\s*\)\@>\z(\L\S*\)'			matchgroup=vimLetHereDocStop end='^\z1$' extend
-VimFoldh syn region vimLetHereDoc	matchgroup=vimLetHereDocStart start='\%(^\z(\s*\)\S.*\)\@<==<<\s*\%(trim\s\+eval\|eval\s\+trim\)\%(\s\+\)\@>\z(\L\S*\)'	matchgroup=vimLetHereDocStop end='^\z1\=\z2$' contains=@vimStringInterpolation extend
-VimFoldh syn region vimLetHereDoc	matchgroup=vimLetHereDocStart start='=<<\s*eval\%(\s\+\)\@>\z(\L\S*\)'			matchgroup=vimLetHereDocStop end='^\z1$' contains=@vimStringInterpolation extend
+VimFoldh syn region vimLetHeredoc	matchgroup=vimLetHeredocStart start='\%(^\z(\s*\)\S.*\)\@<==<<\s*trim\%(\s\+\)\@>\z(\L\S*\)'	matchgroup=vimLetHeredocStop end='^\z1\=\z2$' extend
+VimFoldh syn region vimLetHeredoc	matchgroup=vimLetHeredocStart start='=<<\%(\s*\)\@>\z(\L\S*\)'			matchgroup=vimLetHeredocStop end='^\z1$' extend
+VimFoldh syn region vimLetHeredoc	matchgroup=vimLetHeredocStart start='\%(^\z(\s*\)\S.*\)\@<==<<\s*\%(trim\s\+eval\|eval\s\+trim\)\%(\s\+\)\@>\z(\L\S*\)'	matchgroup=vimLetHeredocStop end='^\z1\=\z2$' contains=@vimStringInterpolation extend
+VimFoldh syn region vimLetHeredoc	matchgroup=vimLetHeredocStart start='=<<\s*eval\%(\s\+\)\@>\z(\L\S*\)'			matchgroup=vimLetHeredocStop end='^\z1$' contains=@vimStringInterpolation extend
 
 Vim9 syn keyword	vim9Const	const	skipwhite nextgroup=vim9Variable,vim9VariableList
 Vim9 syn keyword	vim9Final	final	skipwhite nextgroup=vim9Variable,vim9VariableList
 Vim9 syn keyword	vim9Var	var	skipwhite nextgroup=vim9Variable,vim9VariableList
 
-syn match	vim9Variable	contained	"\<\h\w*\>"	skipwhite nextgroup=vimTypeSep,vimLetHereDoc,vimOper
+syn match	vim9Variable	contained	"\<\h\w*\>"	skipwhite nextgroup=vimTypeSep,vimLetHeredoc,vimOper
 syn region	vim9VariableList	contained	start="\[" end="]" contains=@vimContinue,@vimSpecialVar,vim9Variable
 
 " Lockvar and Unlockvar: {{{2
@@ -1483,6 +1483,347 @@ syn region	vimHiLink	contained matchgroup=Type start="\%(\<hi\%[ghlight]!\=\s\+\
 " ==================
 syn match	vimCtrlChar	"[--]"
 
+" Embedded Scripts:  {{{2
+" ================
+"   perl,ruby	: Benoit Cerrina
+"   python,tcl	: Johannes Zellner
+"   mzscheme, lua : Charles Campbell
+
+" Allows users to specify the type of embedded script highlighting
+" they want:  (lua/mzscheme/perl/python/ruby/tcl support)
+"   g:vimsyn_embed == 0   : don't embed any scripts
+"   g:vimsyn_embed =~# 'l' : embed Lua
+"   g:vimsyn_embed =~# 'm' : embed MzScheme
+"   g:vimsyn_embed =~# 'p' : embed Perl
+"   g:vimsyn_embed =~# 'P' : embed Python
+"   g:vimsyn_embed =~# 'r' : embed Ruby
+"   g:vimsyn_embed =~# 't' : embed Tcl
+
+let s:interfaces = get(g:, "vimsyn_embed", "l")
+
+" [-- lua --] {{{3
+if s:interfaces =~# 'l'
+  syn include @vimLuaScript syntax/lua.vim
+  unlet b:current_syntax
+  syn clear luaParenError " See issue #11277
+endif
+
+syn keyword	vimLua	lua	skipwhite nextgroup=vimLuaHeredoc,vimLuaStatement
+syn keyword	vimLua	luado	skipwhite nextgroup=vimLuaStatement
+syn keyword	vimLua	luafile
+
+syn region	vimLuaStatement	contained
+      \ start="\S"
+      \ skip=+\n\s*\%(\\\|["#]\\ \)+
+      \ end="$"
+      \ contains=@vimLuaScript,@vimContinue
+VimFoldl syn region vimLuaHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+<<\s*\z(\S\+\)\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1$+
+      \ contains=@vimLuaScript
+VimFoldl syn region vimLuaHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+<<\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\.$+
+      \ contains=@vimLuaScript
+VimFoldl syn region vimLuaHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+\%(^\z(\s*\)\S.*\)\@<=<<\s*trim\s\+\z(\S\+\)\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1\=\z2$+
+      \ contains=@vimLuaScript
+VimFoldl syn region vimLuaHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+\%(^\z(\s*\)\S.*\)\@<=<<\s*trim\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1\=\.$+
+      \ contains=@vimLuaScript
+
+" [-- mzscheme --] {{{3
+if s:interfaces =~# 'm'
+  let s:iskKeep = &isk
+  syn include @vimMzSchemeScript syntax/scheme.vim
+  unlet b:current_syntax
+  let &isk = s:iskKeep
+endif
+
+syn keyword	vimMzScheme	mz[scheme]	skipwhite nextgroup=vimMzSchemeHeredoc,vimMzSchemeStatement
+syn keyword	vimMzScheme	mzf[ile]
+
+syn region	vimMzSchemeStatement	contained
+      \ start="\S"
+      \ skip=+\n\s*\%(\\\|["#]\\ \)+
+      \ end="$"
+      \ contains=@vimMzSchemeScript,@vimContinue
+VimFoldm syn region vimMzSchemeHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+<<\s*\z(\S\+\)\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1$+
+      \ contains=@vimMzSchemeScript
+VimFoldm syn region vimMzSchemeHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+<<\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\.$+
+      \ contains=@vimMzSchemeScript
+VimFoldm syn region vimMzSchemeHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+\%(^\z(\s*\)\S.*\)\@<=<<\s*trim\s\+\z(\S\+\)\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1\=\z2$+
+      \ contains=@vimMzSchemeScript
+VimFoldm syn region vimMzSchemeHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+\%(^\z(\s*\)\S.*\)\@<=<<\s*trim\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1\=\.$+
+      \ contains=@vimMzSchemeScript
+
+" [-- perl --] {{{3
+if s:interfaces =~# 'p'
+  syn include @vimPerlScript syntax/perl.vim
+  unlet b:current_syntax
+endif
+
+syn keyword	vimPerl	pe[rl]	skipwhite nextgroup=vimPerlHeredoc,vimPerlStatement
+syn keyword	vimPerl	perld[o]	skipwhite nextgroup=vimPerlStatement
+
+syn region	vimPerlStatement	contained
+       \ start="\S"
+       \ skip=+\n\s*\%(\\\|["#]\\ \)+
+       \ end="$"
+       \ contains=@vimPerlScript,@vimContinue
+VimFoldp syn region vimPerlHeredoc	contained
+       \ matchgroup=vimScriptHeredocStart
+       \ start=+<<\s*\z(\S\+\)\ze\s*$+
+       \ matchgroup=vimScriptHeredocStop
+       \ end=+^\z1$+ contains=@vimPerlScript
+VimFoldp syn region vimPerlHeredoc	contained
+       \ matchgroup=vimScriptHeredocStart
+       \ start=+<<\ze\s*$+	matchgroup=vimScriptHeredocStop
+       \ end=+^\.$+
+       \ contains=@vimPerlScript
+VimFoldp syn region vimPerlHeredoc	contained
+       \ matchgroup=vimScriptHeredocStart
+       \ start=+\%(^\z(\s*\)\S.*\)\@<=<<\s*trim\s\+\z(\S\+\)\ze\s*$+
+       \ matchgroup=vimScriptHeredocStop
+       \ end=+^\z1\=\z2$+
+       \ contains=@vimPerlScript
+VimFoldp syn region vimPerlHeredoc	contained
+       \ matchgroup=vimScriptHeredocStart
+       \ start=+\%(^\z(\s*\)\S.*\)\@<=<<\s*trim\ze\s*$+
+       \ matchgroup=vimScriptHeredocStop
+       \ end=+^\z1\=\.$+
+       \ contains=@vimPerlScript
+
+" [-- python --] {{{3
+if s:interfaces =~# 'P'
+  syn include @vimPythonScript syntax/python2.vim
+  unlet b:current_syntax
+endif
+
+syn keyword	vimPython	py[thon]	skipwhite nextgroup=vimPythonHeredoc,vimPythonStatement
+syn keyword	vimPython	pydo	skipwhite nextgroup=vimPythonStatement
+syn keyword	vimPython	pyfile
+
+syn region	vimPythonStatement	contained
+      \ start="\S"
+      \ skip=+\n\s*\%(\\\|["#]\\ \)+
+      \ end="$"
+      \ contains=@vimPythonScript,@vimContinue
+VimFoldP syn region vimPythonHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+<<\s*\z(\S\+\)\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1$+
+      \ contains=@vimPythonScript
+VimFoldP syn region vimPythonHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+<<\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\.$+
+      \ contains=@vimPythonScript
+VimFoldP syn region vimPythonHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+\%(^\z(\s*\)\S.*\)\@<=<<\s*trim\s\+\z(\S\+\)\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1\=\z2$+
+      \ contains=@vimPythonScript
+VimFoldP syn region vimPythonHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+\%(^\z(\s*\)\S.*\)\@<=<<\s*trim\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1\=\.$+
+      \ contains=@vimPythonScript
+
+" [-- python3 --] {{{3
+if s:interfaces =~# 'P'
+  syn include @vimPython3Script syntax/python.vim
+  unlet b:current_syntax
+endif
+
+syn keyword	vimPython3	python3 py3	skipwhite nextgroup=vimPython3Heredoc,vimPython3Statement
+syn keyword	vimPython3	py3do	skipwhite nextgroup=vimPython3Statement
+syn keyword	vimPython3	py3file
+
+syn region	vimPython3Statement	contained
+      \ start="\S"
+      \ skip=+\n\s*\%(\\\|["#]\\ \)+
+      \ end="$"
+      \ contains=@vimPython3Script,@vimContinue
+VimFoldP syn region vimPython3Heredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+<<\s*\z(\S\+\)\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1$+
+      \ contains=@vimPython3Script
+VimFoldP syn region vimPython3Heredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+<<\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\.$+
+      \ contains=@vimPython3Script
+VimFoldP syn region vimPython3Heredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+\%(^\z(\s*\)\S.*\)\@<=<<\s*trim\s\+\z(\S\+\)\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1\=\z2$+
+      \ contains=@vimPython3Script
+VimFoldP syn region vimPython3Heredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+\%(^\z(\s*\)\S.*\)\@<=<<\s*trim\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1\=\.$+
+      \ contains=@vimPython3Script
+
+" [-- pythonx --] {{{3
+if s:interfaces =~# 'P'
+  if &pyxversion == 2
+    syn cluster vimPythonXScript contains=@vimPythonScript
+  else
+    syn cluster vimPythonXScript contains=@vimPython3Script
+  endif
+endif
+
+syn keyword	vimPythonX	pythonx pyx	skipwhite nextgroup=vimPythonXHeredoc,vimPythonXStatement
+syn keyword	vimPythonX	pyxdo	skipwhite nextgroup=vimPythonXStatement
+syn keyword	vimPythonX	pyxfile
+
+syn region	vimPythonXStatement	contained
+      \ start="\S"
+      \ skip=+\n\s*\%(\\\|["#]\\ \)+
+      \ end="$"
+      \ contains=@vimPythonXScript,@vimContinue
+VimFoldP syn region vimPythonXHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+<<\s*\z(\S\+\)\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1$+
+      \ contains=@vimPythonXScript
+VimFoldP syn region vimPythonXHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+<<\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\.$+
+      \ contains=@vimPythonXScript
+VimFoldP syn region vimPythonXHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+\%(^\z(\s*\)\S.*\)\@<=<<\s*trim\s\+\z(\S\+\)\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1\=\z2$+
+      \ contains=@vimPythonXScript
+VimFoldP syn region vimPythonXHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+\%(^\z(\s*\)\S.*\)\@<=<<\s*trim\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1\=\.$+
+      \ contains=@vimPythonXScript
+
+" [-- ruby --] {{{3
+if s:interfaces =~# 'r'
+  let s:foldmethod = &l:foldmethod
+  syn include @vimRubyScript syntax/ruby.vim
+  let &l:foldmethod = s:foldmethod
+  unlet b:current_syntax
+endif
+
+syn keyword	vimRuby	rub[y]	skipwhite nextgroup=vimRubyHeredoc,vimRubyStatement
+syn keyword	vimRuby	rubyd[o]	skipwhite nextgroup=vimRubyStatement
+syn keyword	vimRuby	rubyf[ile]
+
+syn region	vimRubyStatement	contained
+      \ start="\S"
+      \ skip=+\n\s*\%(\\\|["#]\\ \)+
+      \ end="$"
+      \ contains=@vimRubyScript,@vimContinue
+VimFoldr syn region vimRubyHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+<<\s*\z(\S\+\)\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1$+
+      \ contains=@vimRubyScript
+VimFoldr syn region vimRubyHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+<<\ze\s*$+	matchgroup=vimScriptHeredocStop
+      \ end=+^\.$+
+      \ contains=@vimRubyScript
+VimFoldr syn region vimRubyHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+\%(^\z(\s*\)\S.*\)\@<=<<\s*trim\s\+\z(\S\+\)\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1\=\z2$+
+      \ contains=@vimRubyScript
+VimFoldr syn region vimRubyHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+\%(^\z(\s*\)\S.*\)\@<=<<\s*trim\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1\.$+
+      \ contains=@vimRubyScript
+
+" [-- tcl --] {{{3
+if s:interfaces =~# 't'
+  syn include @vimTclScript syntax/tcl.vim
+  unlet b:current_syntax
+endif
+
+syn keyword	vimTcl	tcl	skipwhite nextgroup=vimTclHeredoc,vimTclStatement
+syn keyword	vimTcl	tcld[o]	skipwhite nextgroup=vimTclStatement
+syn keyword	vimTcl	tclf[ile]
+syn region	vimTclStatement	contained
+      \ start="\S"
+      \ skip=+\n\s*\%(\\\|["#]\\ \)+
+      \ end="$"
+      \ contains=@vimTclScript,@vimContinue
+VimFoldt syn region vimTclHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+<<\s*\z(\S\+\)\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1$+
+      \ contains=@vimTclScript
+VimFoldt syn region vimTclHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+<<\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\.$+
+      \ contains=@vimTclScript
+VimFoldt syn region vimTclHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+\%(^\z(\s*\)\S.*\)\@<=<<\s*trim\s\+\z(\S\+\)\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1\=\z2$+
+      \ contains=@vimTclScript
+VimFoldt syn region vimTclHeredoc	contained
+      \ matchgroup=vimScriptHeredocStart
+      \ start=+\%(^\z(\s*\)\S.*\)\@<=<<\s*trim\ze\s*$+
+      \ matchgroup=vimScriptHeredocStop
+      \ end=+^\z1\=\.$+
+      \ contains=@vimTclScript
+
+unlet s:interfaces
 " Beginners - Patterns that involve ^ {{{2
 " =========
 Vim9 syn region	vim9LineComment	start=+^[ \t:]*\zs#.*$+ skip=+\n\s*\\\|\n\s*#\\ + end="$" contains=@vimCommentGroup,vimCommentString,vim9CommentTitle extend
@@ -1529,210 +1870,6 @@ if s:vim9script
   syn keyword vim9Vim9Script	vim9s[cript] nextgroup=vim9Vim9ScriptArg skipwhite
 endif
 
-" Embedded Scripts:  {{{2
-" ================
-"   perl,ruby     : Benoit Cerrina
-"   python,tcl    : Johannes Zellner
-"   mzscheme, lua : Charles Campbell
-
-" Allows users to specify the type of embedded script highlighting
-" they want:  (perl/python/ruby/tcl support)
-"   g:vimsyn_embed == 0   : don't embed any scripts
-"   g:vimsyn_embed =~# 'l' : embed Lua
-"   g:vimsyn_embed =~# 'm' : embed MzScheme
-"   g:vimsyn_embed =~# 'p' : embed Perl
-"   g:vimsyn_embed =~# 'P' : embed Python
-"   g:vimsyn_embed =~# 'r' : embed Ruby
-"   g:vimsyn_embed =~# 't' : embed Tcl
-if !exists("g:vimsyn_embed")
- let g:vimsyn_embed = 'l'
-endif
-
-" [-- lua --] {{{3
-let s:luapath= fnameescape(expand("<sfile>:p:h")."/lua.vim")
-if !filereadable(s:luapath)
- for s:luapath in split(globpath(&rtp,"syntax/lua.vim"),"\n")
-  if filereadable(fnameescape(s:luapath))
-   let s:luapath= fnameescape(s:luapath)
-   break
-  endif
- endfor
-endif
-if g:vimsyn_embed =~# 'l' && filereadable(s:luapath)
- unlet! b:current_syntax
- syn cluster vimFuncBodyList	add=vimLuaRegion
- exe "syn include @vimLuaScript ".s:luapath
- VimFoldl syn region vimLuaRegion matchgroup=vimScriptDelim start=+^\z(\s*\)lua\s*<<\s*trim\s\+\z(\S\+\)+ end=+^\z1\z2$+	contains=@vimLuaScript
- VimFoldl syn region vimLuaRegion matchgroup=vimScriptDelim start=+lua\s*<<\s*\z(\S*\)+ end=+^\z1$+		contains=@vimLuaScript
- VimFoldl syn region vimLuaRegion matchgroup=vimScriptDelim start=+^\z(\s*\)lua\s*<<\s*trim\s*$+ end=+^\z1\.$+	contains=@vimLuaScript
- VimFoldl syn region vimLuaRegion matchgroup=vimScriptDelim start=+lua\s*<<\s*$+ end=+^\.$+		contains=@vimLuaScript
- syn cluster vimFuncBodyList	add=vimLuaRegion
-else
- syn region vimEmbedError start=+^\z(\s*\)lua\s*<<\s*trim\s\+\z(\S\+\)+ end=+^\z1\z2$+
- syn region vimEmbedError start=+lua\s*<<\s*\z(\S*\)+ end=+^\z1$+
- syn region vimEmbedError start=+^\z(\s*\)lua\s*<<\s*trim\s\*$+ end=+^\z1\.$+
- syn region vimEmbedError start=+lua\s*<<\s*$+ end=+^\.$+
-endif
-unlet s:luapath
-
-" [-- perl --] {{{3
-let s:perlpath= fnameescape(expand("<sfile>:p:h")."/perl.vim")
-if !filereadable(s:perlpath)
- for s:perlpath in split(globpath(&rtp,"syntax/perl.vim"),"\n")
-  if filereadable(fnameescape(s:perlpath))
-   let s:perlpath= fnameescape(s:perlpath)
-   break
-  endif
- endfor
-endif
-if g:vimsyn_embed =~# 'p' && filereadable(s:perlpath)
- unlet! b:current_syntax
- syn cluster vimFuncBodyList	add=vimPerlRegion
- let s:foldmethod = &l:foldmethod
- exe "syn include @vimPerlScript ".s:perlpath
- let &l:foldmethod = s:foldmethod
- VimFoldp syn region vimPerlRegion	matchgroup=vimScriptDelim start=+^\z(\s*\)pe\%[rl]\s*<<\s*trim\s\+\z(\S\+\)+ end=+^\z1\z2$+	contains=@vimPerlScript
- VimFoldp syn region vimPerlRegion	matchgroup=vimScriptDelim start=+pe\%[rl]\s*<<\s*\z(\S*\)+ end=+^\z1$+		contains=@vimPerlScript
- VimFoldp syn region vimPerlRegion	matchgroup=vimScriptDelim start=+^\z(\s*\)pe\%[rl]\s*<<\s*trim\s*$+ end=+^\z1\.$+	contains=@vimPerlScript
- VimFoldp syn region vimPerlRegion	matchgroup=vimScriptDelim start=+pe\%[rl]\s*<<\s*$+ end=+\.$+		contains=@vimPerlScript
- syn cluster vimFuncBodyList	add=vimPerlRegion
-else
- syn region vimEmbedError start=+^\z(\s*\)pe\%[rl]\s*<<\s*trim\s\+\z(\S\+\)+ end=+^\z1\z2$+
- syn region vimEmbedError start=+pe\%[rl]\s*<<\s*\z(\S*\)+ end=+^\z1$+
- syn region vimEmbedError start=+^\z(\s*\)pe\%[rl]\s*<<\s*trim\s\*$+ end=+^\z1\.$+
- syn region vimEmbedError start=+pe\%[rl]\s*<<\s*$+ end=+^\.$+
-endif
-unlet s:perlpath
-
-" [-- ruby --] {{{3
-let s:rubypath= fnameescape(expand("<sfile>:p:h")."/ruby.vim")
-if !filereadable(s:rubypath)
- for s:rubypath in split(globpath(&rtp,"syntax/ruby.vim"),"\n")
-  if filereadable(fnameescape(s:rubypath))
-   let s:rubypath= fnameescape(s:rubypath)
-   break
-  endif
- endfor
-endif
-if g:vimsyn_embed =~# 'r' && filereadable(s:rubypath)
- syn cluster vimFuncBodyList	add=vimRubyRegion
- unlet! b:current_syntax
- let s:foldmethod = &l:foldmethod
- exe "syn include @vimRubyScript ".s:rubypath
- let &l:foldmethod = s:foldmethod
- VimFoldr syn region vimRubyRegion	matchgroup=vimScriptDelim start=+^\z(\s*\)rub\%[y]\s*<<\s*trim\s\+\z(\S\+\)+ end=+^\z1\z2$+	contains=@vimRubyScript
- VimFoldr syn region vimRubyRegion	matchgroup=vimScriptDelim start=+rub\%[y]\s*<<\s*\z(\S*\)+ end=+^\z1$+		contains=@vimRubyScript
- VimFoldr syn region vimRubyRegion	matchgroup=vimScriptDelim start=+^\z(\s*\)rub\%[y]\s*<<\s*trim\s*$+ end=+^\z1\.$+	contains=@vimRubyScript
- VimFoldr syn region vimRubyRegion	matchgroup=vimScriptDelim start=+rub\%[y]\s*<<\s*$+ end=+\.$+		contains=@vimRubyScript
- syn cluster vimFuncBodyList	add=vimRubyRegion
-else
- syn region vimEmbedError start=+^\z(\s*\)rub\%[y]\s*<<\s*trim\s\+\z(\S\+\)+ end=+^\z1\z2$+
- syn region vimEmbedError start=+rub\%[y]\s*<<\s*\z(\S.*\)+ end=+^\z1$+
- syn region vimEmbedError start=+^\z(\s*\)rub\%[y]\s*<<\s*trim\s\*$+ end=+^\z1\.$+
- syn region vimEmbedError start=+rub\%[y]\s*<<\s*$+ end=+^\.$+
-endif
-unlet s:rubypath
-
-" [-- python --] {{{3
-let s:pythonpath= fnameescape(expand("<sfile>:p:h")."/python.vim")
-if !filereadable(s:pythonpath)
- for s:pythonpath in split(globpath(&rtp,"syntax/python.vim"),"\n")
-  if filereadable(fnameescape(s:pythonpath))
-   let s:pythonpath= fnameescape(s:pythonpath)
-   break
-  endif
- endfor
-endif
-if g:vimsyn_embed =~# 'P' && filereadable(s:pythonpath)
- unlet! b:current_syntax
- syn cluster vimFuncBodyList	add=vimPythonRegion
- exe "syn include @vimPythonScript ".s:pythonpath
- VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+^\z(\s*\)py\%[thon][3x]\=\s*<<\s*trim\s\+\z(\S\+\)+ end=+^\z1\z2$+	contains=@vimPythonScript
- VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+py\%[thon][3x]\=\s*<<\s*\z(\S\+\)+ end=+^\z1$+		contains=@vimPythonScript
- VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+^\z(\s*\)py\%[thon][3x]\=\s*<<\s*trim\s*$+ end=+^\z1\.$+	contains=@vimPythonScript
- VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+py\%[thon][3x]\=\s*<<\s*$+ end=+^\.$+			contains=@vimPythonScript
- VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+Py\%[thon]2or3\s*<<\s*\%(trim\s*\)\=\z(\S\+\)+ end=+^\z1$+	contains=@vimPythonScript
- VimFoldP syn region vimPythonRegion matchgroup=vimScriptDelim start=+Py\%[thon]2or3\s*<<\s*\%(trim\s*\)\=$+ end=+^\.$+		contains=@vimPythonScript
- syn cluster vimFuncBodyList	add=vimPythonRegion
-else
- syn region vimEmbedError start=+^\z(\s*\)py\%[thon][3x]\=\s*<<\s*trim\s\+\z(\S\+\)+ end=+^\z1\z2$+
- syn region vimEmbedError start=+py\%[thon][3x]\=\s*<<\s*\z(\S\+\)+ end=+^\z1$+
- syn region vimEmbedError start=+^\z(\s*\)py\%[thon][3x]\=\s*<<\s*trim\s*$+ end=+^\z1\.$+
- syn region vimEmbedError start=+py\%[thon][3x]\=\s*<<\s*$+ end=+^\.$+
-endif
-unlet s:pythonpath
-
-" [-- tcl --] {{{3
-if has("win32") || has("win95") || has("win64") || has("win16")
- " apparently has("tcl") has been hanging vim on some windows systems with cygwin
- let s:trytcl= (&shell !~ '\<\%(bash\>\|4[nN][tT]\|\<zsh\)\>\%(\.exe\)\=$')
-else
- let s:trytcl= 1
-endif
-if s:trytcl
- let s:tclpath= fnameescape(expand("<sfile>:p:h")."/tcl.vim")
- if !filereadable(s:tclpath)
-  for s:tclpath in split(globpath(&rtp,"syntax/tcl.vim"),"\n")
-   if filereadable(fnameescape(s:tclpath))
-    let s:tclpath= fnameescape(s:tclpath)
-    break
-   endif
-  endfor
- endif
- if g:vimsyn_embed =~# 't' && filereadable(s:tclpath)
-  unlet! b:current_syntax
-  syn cluster vimFuncBodyList	add=vimTclRegion
-  exe "syn include @vimTclScript ".s:tclpath
-  VimFoldt syn region vimTclRegion matchgroup=vimScriptDelim start=+^\z(\s*\)tc\%[l]\s*<<\s*trim\s\+\z(\S\+\)+ end=+^\z1\z2$+	contains=@vimTclScript
-  VimFoldt syn region vimTclRegion matchgroup=vimScriptDelim start=+tc\%[l]\=\s*<<\s*\z(\S*\)+ end=+^\z1$+		contains=@vimTclScript
-  VimFoldt syn region vimTclRegion matchgroup=vimScriptDelim start=+^\z(\s*\)tc\%[l]\s*<<\s*trim\s*$+ end=+^\z1\.$+	contains=@vimTclScript
-  VimFoldt syn region vimTclRegion matchgroup=vimScriptDelim start=+tc\%[l]\=\s*<<\s*$+ end=+^\.$+		contains=@vimTclScript
-  syn cluster vimFuncBodyList	add=vimTclScript
- else
-  syn region vimEmbedError start=+^\z(\s*\)tc\%[l]\s*<<\s*trim\s\+\z(\S\+\)+ end=+^\z1\z2$+
-  syn region vimEmbedError start=+tc\%[l]\=\s*<<\s*\z(\S*\)+ end=+^\z1$+
-  syn region vimEmbedError start=+^\z(\s*\)tc\%[l]\s*<<\s*trim\s\*$+ end=+^\z1\.$+
-  syn region vimEmbedError start=+tc\%[l]\=\s*<<\s*$+ end=+^\.$+
- endif
- unlet s:tclpath
-else
- syn region vimEmbedError start=+^\z(\s*\)tc\%[l]\s*<<\s*trim\s\+\z(\S\+\)+ end=+^\z1\z2$+
- syn region vimEmbedError start=+tc\%[l]\=\s*<<\s*\z(\S*\)+ end=+^\z1$+
- syn region vimEmbedError start=+^\z(\s*\)tc\%[l]\s*<<\s*trim\s\*$+ end=+^\z1\.$+
- syn region vimEmbedError start=+tc\%[l]\=\s*<<\s*$+ end=+^\.$+
-endif
-unlet s:trytcl
-
-" [-- mzscheme --] {{{3
-let s:mzschemepath= fnameescape(expand("<sfile>:p:h")."/scheme.vim")
-if !filereadable(s:mzschemepath)
- for s:mzschemepath in split(globpath(&rtp,"syntax/mzscheme.vim"),"\n")
-  if filereadable(fnameescape(s:mzschemepath))
-   let s:mzschemepath= fnameescape(s:mzschemepath)
-   break
-  endif
- endfor
-endif
-if g:vimsyn_embed =~# 'm' && filereadable(s:mzschemepath)
- unlet! b:current_syntax
- let s:iskKeep= &isk
- syn cluster vimFuncBodyList	add=vimMzSchemeRegion
- exe "syn include @vimMzSchemeScript ".s:mzschemepath
- let &isk= s:iskKeep
- unlet s:iskKeep
- VimFoldm syn region vimMzSchemeRegion matchgroup=vimScriptDelim start=+^\z(\s*\)mz\%[scheme]\s*<<\s*trim\s\+\z(\S\+\)+ end=+^\z1\z2$+	contains=@vimMzSchemeScript
- VimFoldm syn region vimMzSchemeRegion matchgroup=vimScriptDelim start=+mz\%[scheme]\s*<<\s*\z(\S*\)+ end=+^\z1$+	contains=@vimMzSchemeScript
- VimFoldm syn region vimMzSchemeRegion matchgroup=vimScriptDelim start=+^\z(\s*\)mz\%[scheme]\s*<<\s*trim\s*$+ end=+^\z1\.$+	contains=@vimMzSchemeScript
- VimFoldm syn region vimMzSchemeRegion matchgroup=vimScriptDelim start=+mz\%[scheme]\s*<<\s*$+ end=+^\.$+		contains=@vimMzSchemeScript
- syn cluster vimFuncBodyList	add=vimMzSchemeRegion
-else
- syn region vimEmbedError start=+^\z(\s*\)mz\%[scheme]\s*<<\s*trim\s\+\z(\S\+\)+ end=+^\z1\z2$+
- syn region vimEmbedError start=+mz\%[scheme]\s*<<\s*\z(\S*\)+ end=+^\z1$+
- syn region vimEmbedError start=+^\z(\s*\)mz\%[scheme]\s*<<\s*trim\s\*$+ end=+^\z1\.$+
- syn region vimEmbedError start=+mz\%[scheme]\s*<<\s*$+ end=+^\.$+
-endif
-unlet s:mzschemepath
-
 " Synchronize (speed) {{{2
 "============
 if exists("g:vimsyn_minlines")
@@ -1752,7 +1889,6 @@ if !exists("skip_vim_syntax_inits")
   hi def link vimBehaveError	vimError
   hi def link vimCollClassErr	vimError
   hi def link vimErrSetting	vimError
-  hi def link vimEmbedError	Normal
   hi def link vimFTError	vimError
   hi def link vimFunctionError	vimError
   hi def link vimFunc         	vimError
@@ -1882,11 +2018,12 @@ if !exists("skip_vim_syntax_inits")
  hi def link vimLambdaBrace	Delimiter
  hi def link vimLambdaOperator	vimOper
  hi def link vimLet	vimCommand
- hi def link vimLetHereDoc	vimString
- hi def link vimLetHereDocStart	Special
- hi def link vimLetHereDocStop	Special
+ hi def link vimLetHeredoc	vimString
+ hi def link vimLetHeredocStart	Special
+ hi def link vimLetHeredocStop	Special
  hi def link vimLetRegister	vimRegister
  hi def link vimLineComment	vimComment
+ hi def link vimLua	vimCommand
  hi def link vimMake	vimCommand
  hi def link vimMakeadd	vimCommand
  hi def link vimMakeBang	vimBang
@@ -1912,6 +2049,8 @@ if !exists("skip_vim_syntax_inits")
  hi def link vimMenutranslateComment	vimComment
  hi def link vim9MethodName	vimFuncName
  hi def link vimMtchComment	vimComment
+ hi def link vimMzScheme	vimCommand
+ hi def link vimNonText	NonText
  hi def link vimNormal	vimCommand
  hi def link vimNotation	Special
  hi def link vimNotFunc	vimCommand
@@ -1931,8 +2070,12 @@ if !exists("skip_vim_syntax_inits")
  hi def link vimPatSepZone	vimString
  hi def link vimPatSepZ	vimPatSep
  hi def link vimPattern	Type
+ hi def link vimPerl	vimCommand
  hi def link vimPlainMark	vimMark
  hi def link vimPlainRegister	vimRegister
+ hi def link vimPython	vimCommand
+ hi def link vimPython3	vimCommand
+ hi def link vimPythonX	vimCommand
  hi def link vimQuoteEscape	vimEscape
  hi def link vimRedir	vimCommand
  hi def link vimRedirBang	vimBang
@@ -1942,7 +2085,10 @@ if !exists("skip_vim_syntax_inits")
  hi def link vimRedirEnd	Special
  hi def link vimRedirRegister	vimRegister
  hi def link vimRegister	SpecialChar
+ hi def link vimRuby	vimCommand
  hi def link vimScriptDelim	Comment
+ hi def link vimScriptHeredocStart	vimLetHeredocStart
+ hi def link vimScriptHeredocStop	vimLetHeredocStop
  hi def link vimSearch	vimString
  hi def link vimSearchDelim	Delimiter
  hi def link vimSep	Delimiter
@@ -2007,6 +2153,7 @@ if !exists("skip_vim_syntax_inits")
  hi def link vimSynSpell	Type
  hi def link vimSyntax	vimCommand
  hi def link vimSynType	vimSpecial
+ hi def link vimTcl	vimCommand
  hi def link vimThrow	vimCommand
  hi def link vimTodo	Todo
  hi def link vimType	Type


### PR DESCRIPTION
#### vim-patch:e957cba: runtime(vim): Update base-syntax, match quote separated numbers

closes: vim/vim#17250

https://github.com/vim/vim/commit/e957cba081d75bc9054230a26ebeeb0f43d901bd

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:a577e42: runtime(vim): Update base-syntax, improve script-interface command highlighting

- Normalise interface heredoc highlighting with that used for
  :let-heredocs.
- Remove interface feature testing.  The Lua and Python interface
  command scripts are now highlighted by default.  Loading all syntax
  files incurs an undesirable load-time burden so highlighting of the
  less popular MzScheme, Perl, Ruby and Tcl interfaces is disabled by
  default.  g:vimsyn_embed can still be used to customise the supported
  interfaces.
- Always highlight interface ex-commands as valid commands, even when
  the corresponding command-script highlighting is disabled.
- Highlight simple command-script statements as well as heredocs.
- Remove error highlighting of heredoc and statement command-script
  regions when an interface is disabled.  These are now highlighted as
  plain text.
- Allow indented heredoc end tokens when "trim" is specified.
- Match interface heredocs in :def functions.
- Fix runaway vimEmbedError regions.  These regions have been removed.
- Use python2 syntax for :python, and :pythonx when 'pyxversion' is
  appropriately set.

closes: vim/vim#15522

https://github.com/vim/vim/commit/a577e4289c3177309880592b85f225e487552f17

Co-authored-by: Doug Kearns <dougkearns@gmail.com>