### PR TITLE
Don't set manwidth wider than the window

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -823,8 +823,8 @@ Variables:
                           For example in C one usually wants section 3 or 2: >
                                :let b:man_default_sections = '3,2'
 *g:man_hardwrap*            Hard-wrap to $MANWIDTH or window width if $MANWIDTH is
-                          empty. Enabled by default. Set |FALSE| to enable soft
-                          wrapping.
+                          empty or larger than the window width. Enabled by
+                          default. Set |FALSE| to enable soft wrapping.
 
 To use Nvim as a manpager: >bash
     export MANPAGER='nvim +Man!'

--- a/runtime/lua/man.lua
+++ b/runtime/lua/man.lua
@@ -415,11 +415,12 @@ local function get_page(path, silent)
   -- Disable hard-wrap by using a big $MANWIDTH (max 1000 on some systems #9065).
   -- Soft-wrap: ftplugin/man.lua sets wrap/breakindent/….
   -- Hard-wrap: driven by `man`.
-  local manwidth --- @type integer|string
+  local manwidth --- @type integer
   if (vim.g.man_hardwrap or 1) ~= 1 then
     manwidth = 999
   elseif vim.env.MANWIDTH then
-    manwidth = vim.env.MANWIDTH --- @type string|integer
+    vim.env.MANWIDTH = tonumber(vim.env.MANWIDTH) or 0
+    manwidth = math.min(vim.env.MANWIDTH, api.nvim_win_get_width(0) - vim.o.wrapmargin)
   else
     manwidth = api.nvim_win_get_width(0) - vim.o.wrapmargin
   end


### PR DESCRIPTION
If we set the `MANWIDTH` variable to a value wider than the window, the contents wrap and formatting breaks. A more sensible way to handle this is to interpret `MANWIDTH` as a maximum width, but to set the width to the window size if smaller.

See also: #9023, #10748.
