### PR TITLE
vim-patch:9.1.1398: completion: trunc does not follow Pmenu highlighting attributes

### DIFF
--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -651,7 +651,9 @@ void pum_redraw(void)
 
   for (int i = 0; i < pum_height; i++) {
     int idx = i + pum_first;
-    const hlf_T *const hlfs = (idx == pum_selected) ? hlfsSel : hlfsNorm;
+    const bool selected = idx == pum_selected;
+    const hlf_T *const hlfs = selected ? hlfsSel : hlfsNorm;
+    const int trunc_attr = win_hl_attr(curwin, selected ? HLF_PSI : HLF_PNI);
     hlf_T hlf = hlfs[0];  // start with "word" highlight
     int attr = win_hl_attr(curwin, (int)hlf);
     attr = hl_combine_attr(win_hl_attr(curwin, HLF_PNI), attr);
@@ -825,6 +827,7 @@ void pum_redraw(void)
       grid_line_fill(lcol, grid_col + 1, schar_from_ascii(' '), orig_attr);
       if (need_fcs_trunc) {
         linebuf_char[lcol] = fcs_trunc != NUL ? fcs_trunc : schar_from_ascii('<');
+        linebuf_attr[lcol] = trunc_attr;
         if (pum_width > 1 && linebuf_char[lcol + 1] == NUL) {
           linebuf_char[lcol + 1] = schar_from_ascii(' ');
         }
@@ -837,6 +840,7 @@ void pum_redraw(void)
           linebuf_char[rcol - 2] = schar_from_ascii(' ');
         }
         linebuf_char[rcol - 1] = fcs_trunc != NUL ? fcs_trunc : schar_from_ascii('>');
+        linebuf_attr[rcol - 1] = trunc_attr;
       }
     }
 

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -2036,6 +2036,7 @@ func Test_pum_maxwidth_multibyte()
   CheckScreendump
 
   let lines =<< trim END
+    hi StrikeFake ctermfg=9
     let g:change = 0
     func Omni_test(findstart, base)
       if a:findstart
@@ -2060,8 +2061,14 @@ func Test_pum_maxwidth_multibyte()
           \ #{word: "bar", menu: "fooMenu", kind: "一二三四"},
           \ #{word: "一二三四五", kind: "multi"},
           \ ]
-      else
         return [#{word: "bar", menu: "fooMenu", kind: "一二三"}]
+      elseif g:change == 3
+        return [#{word: "bar", menu: "fooMenu", kind: "一二三"}]
+      else
+        return [
+          \ #{word: "一二三四五六七八九十", abbr_hlgroup: "StrikeFake"},
+          \ #{word: "123456789_123456789_123456789_", abbr_hlgroup: "StrikeFake"},
+          \ ]
       endif
     endfunc
     set omnifunc=Omni_test
@@ -2173,6 +2180,12 @@ func Test_pum_maxwidth_multibyte()
     call VerifyScreenDump(buf, 'Test_pum_maxwidth_22', {'rows': 8})
     call term_sendkeys(buf, "\<Esc>:set norightleft\<CR>")
   endif
+
+  call term_sendkeys(buf, ":let g:change=4\<CR>")
+  call TermWait(buf, 50)
+  call term_sendkeys(buf, "S\<C-X>\<C-O>")
+  call VerifyScreenDump(buf, 'Test_pum_maxwidth_23', {'rows': 8})
+  call term_sendkeys(buf, "\<ESC>")
 
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.1398: completion: trunc does not follow Pmenu highlighting attributes

Problem:  When items are combined with user-defined highlight attributes
          (e.g., strikethrough), trunc inherits these attributes, making
          the text difficult to read.
Solution: trunc now uses the original Pmenu and PmenuSel highlight
          attributes (glepnir)

closes: vim/vim#17340

https://github.com/vim/vim/commit/0816f17e9a2ba2d1e132497b03905878c7340a78

Co-authored-by: glepnir <glephunter@gmail.com>