### PR TITLE
fix(diagnostics): diagnostic just after EOL is not drawn

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1581,11 +1581,14 @@ M.handlers.underline = {
         end
       end
 
+      local lines =
+        vim.api.nvim_buf_get_lines(diagnostic.bufnr, diagnostic.lnum, diagnostic.lnum + 1, true)
+
       vim.hl.range(
         bufnr,
         underline_ns,
         higroup,
-        { diagnostic.lnum, diagnostic.col },
+        { diagnostic.lnum, math.min(diagnostic.col, #lines[1] - 1) },
         { diagnostic.end_lnum, diagnostic.end_col },
         { priority = get_priority(diagnostic.severity) }
       )


### PR DESCRIPTION
Fixes #34013

Problem:
when diagnostic is set right after EOL, underline handler looks inconsistent compared to other handlers, visually underline is shown starting from the next line. On top of that it's also inconsistent with open_float and jump.

Solution:
clamp starting column position in underline handler to be right before EOL to make it visible and consistent with other handlers, open_float and jump.