### PR TITLE
fix(lsp/health): ensure valid table before concatenating

### DIFF
--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -198,7 +198,7 @@ local function check_enabled_configs()
         local v_str --- @type string?
         if k == 'name' then
           v_str = nil
-        elseif k == 'filetypes' or k == 'root_markers' then
+        elseif k == 'filetypes' or (k == 'root_markers' and type(v[1]) == 'string') then
           v_str = table.concat(v, ', ')
         elseif type(v) == 'function' then
           v_str = func_tostring(v)


### PR DESCRIPTION
The root_markers field can now contain a table of tables (as of https://github.com/neovim/neovim/pull/33485) and :checkhealth will show an error in that case since Lua cannot concatenate a table of tables.

Ensure that tables contain strings before concatenating and if not, fall back to using vim.inspect().
