### PR TITLE
vim-patch:5a8f995: runtime(doc): remove outdated Contribution section…

### DIFF
--- a/runtime/doc/pi_tutor.txt
+++ b/runtime/doc/pi_tutor.txt
@@ -4,6 +4,8 @@
 vim-tutor-mode provides a system to follow and create interactive tutorials
 for vim and third party plugins. It replaces the venerable `vimtutor` system.
 
+Original Author: Felipe Morales <https://github.com/fmoralesc>
+
 ==============================================================================
 1. Usage                                                      *vim-tutor-usage*
 
@@ -39,12 +41,5 @@ to be detected by the :Tutor command.
 It is recommended to use a less formal style when writing tutorials than in
 regular documentation (unless the content requires it).
 
-============================================================================
-3. Contributing
-
-Development of the plugin is done over at github [1].  Feel free to report
-issues and make suggestions.
-
-[1]: https://github.com/fmoralesc/vim-tutor-mode
-
-" vim: set ft=help :
+=============================================================================
+  vim:tw=78:ts=8:noet:ft=help:norl:


### PR DESCRIPTION
… in pi_tutor

Problem:  The Github repo link in the Contribution section has been
          archived for 5 years. So people who want to contribute to the
          tutor plugin should just send PR to Vim repo, similar to most
          other Vim features, so there is no need for a Contribution
          section in the plugin doc.

Solution: Replace it with an Original Author note at the beginning of
          the help document.

closes: vim/vim#17341

https://github.com/vim/vim/commit/5a8f9958e23ef0636425c0845fb534cc5c5319f8

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
