### PR TITLE
fix(tests): fix unittests so they don't have hidden errors

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -408,6 +408,7 @@ pub fn test_config(b: *std.Build, gen_dir: LazyPath) ![]u8 {
         \\local M = {{}}
         \\
         \\M.include_paths = {{}}
+        \\M.apple_sysroot = ""
         \\M.translations_enabled = "$ENABLE_TRANSLATIONS" == "ON"
         \\M.is_asan = "$ENABLE_ASAN_UBSAN" == "ON"
         \\M.is_zig_build = true

--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -78,7 +78,6 @@ execute_process(
     ${TEST_PATH}
   TIMEOUT $ENV{TEST_TIMEOUT}
   WORKING_DIRECTORY ${WORKING_DIR}
-  ERROR_VARIABLE err
   RESULT_VARIABLE res
   ${EXTRA_ARGS})
 
@@ -87,11 +86,6 @@ file(REMOVE_RECURSE ${RM_FILES})
 
 if(res)
   message(STATUS "Tests exited non-zero: ${res}")
-  if("${err}" STREQUAL "")
-    message(STATUS "No output to stderr.")
-  else()
-    message(STATUS "Output to stderr:\n${err}")
-  endif()
 
   # Dump the logfile on CI (if not displayed and moved already).
   if(CI_BUILD)

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -481,11 +481,13 @@ foreach(target ${targets})
     message(STATUS "${target} props '${prop}'")
     foreach(gen_include ${prop})
       list(APPEND gen_cflags "-I${gen_include}")
+      list(APPEND TEST_INCLUDE_DIRS "${gen_include}")
     endforeach()
   endif()
 endforeach()
 
 list(REMOVE_DUPLICATES gen_cflags)
+list(REMOVE_DUPLICATES TEST_INCLUDE_DIRS)
 
 if(APPLE AND CMAKE_OSX_SYSROOT)
   list(APPEND gen_cflags "-isysroot" "${CMAKE_OSX_SYSROOT}")

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -1,6 +1,6 @@
 add_subdirectory(functional/fixtures)  # compile test programs
 
-get_target_property(TEST_INCLUDE_DIRS main_lib INTERFACE_INCLUDE_DIRECTORIES)
+get_directory_property(TEST_INCLUDE_DIRS DIRECTORY ${PROJECT_SOURCE_DIR}/src/nvim DEFINITION TEST_INCLUDE_DIRS)
 
 set(TEST_OPTIONS
       -D BUILD_DIR=${CMAKE_BINARY_DIR}

--- a/test/cmakeconfig/paths.lua.in
+++ b/test/cmakeconfig/paths.lua.in
@@ -4,6 +4,7 @@ M.include_paths = {}
 for p in ("${TEST_INCLUDE_DIRS}" .. ";"):gmatch("[^;]+") do
   table.insert(M.include_paths, p)
 end
+M.apple_sysroot = "${CMAKE_OSX_SYSROOT}"
 
 M.translations_enabled = "${ENABLE_TRANSLATIONS}" == "ON"
 M.is_asan = "${ENABLE_ASAN_UBSAN}" == "ON"

--- a/test/testutil.lua
+++ b/test/testutil.lua
@@ -5,17 +5,6 @@ local Paths = require('test.cmakeconfig.paths')
 
 luaassert:set_parameter('TableFormatLevel', 100)
 
-local quote_me = '[^.%w%+%-%@%_%/]' -- complement (needn't quote)
-
---- @param str string
---- @return string
-local function shell_quote(str)
-  if string.find(str, quote_me) or str == '' then
-    return '"' .. str:gsub('[$%%"\\]', '\\%0') .. '"'
-  end
-  return str
-end
-
 --- Functions executing in the context of the test runner (not the current nvim test session).
 --- @class test.testutil
 local M = {
@@ -66,19 +55,15 @@ function M.argss_to_cmd(...)
   for i = 1, select('#', ...) do
     local arg = select(i, ...)
     if type(arg) == 'string' then
-      cmd[#cmd + 1] = shell_quote(arg)
+      cmd[#cmd + 1] = arg
     else
       --- @cast arg string[]
       for _, subarg in ipairs(arg) do
-        cmd[#cmd + 1] = shell_quote(subarg)
+        cmd[#cmd + 1] = subarg
       end
     end
   end
-  return table.concat(cmd, ' ')
-end
-
-function M.popen_r(...)
-  return io.popen(M.argss_to_cmd(...), 'r')
+  return cmd
 end
 
 --- Calls fn() until it succeeds, up to `max` times or until `max_ms`
@@ -356,7 +341,7 @@ function M.check_logs()
           local status, f
           local out = io.stdout
           if os.getenv('SYMBOLIZER') then
-            status, f = pcall(M.popen_r, os.getenv('SYMBOLIZER'), '-l', file)
+            status, f = pcall(M.repeated_read_cmd, os.getenv('SYMBOLIZER'), '-l', file)
           end
           out:write(start_msg .. '\n')
           if status then
@@ -539,16 +524,37 @@ end
 
 --- @return string?
 function M.repeated_read_cmd(...)
-  for _ = 1, 10 do
-    local stream = M.popen_r(...)
-    local ret = stream:read('*a')
-    stream:close()
-    if ret then
-      return ret
+  local cmd = M.argss_to_cmd(...)
+  local data = {}
+  local got_code = nil
+  local stdout = assert(vim.uv.new_pipe(false))
+  local handle = assert(
+    vim.uv.spawn(
+      cmd[1],
+      { args = vim.list_slice(cmd, 2), stdio = { nil, stdout, 2 }, hide = true },
+      function(code, _signal)
+        got_code = code
+      end
+    )
+  )
+  stdout:read_start(function(err, chunk)
+    if err or chunk == nil then
+      stdout:read_stop()
+      stdout:close()
+    else
+      table.insert(data, chunk)
     end
+  end)
+
+  while not stdout:is_closing() or got_code == nil do
+    vim.uv.run('once')
   end
-  print('ERROR: Failed to execute ' .. M.argss_to_cmd(...) .. ': nil return after 10 attempts')
-  return nil
+
+  if got_code ~= 0 then
+    error('command ' .. vim.inspect(cmd) .. 'unexpectedly exited with status ' .. got_code)
+  end
+  handle:close()
+  return table.concat(data)
 end
 
 --- @generic T

--- a/test/unit/api/private_helpers_spec.lua
+++ b/test/unit/api/private_helpers_spec.lua
@@ -18,7 +18,7 @@ local type_key = api_t.type_key
 local obj2lua = api_t.obj2lua
 local func_type = api_t.func_type
 
-local api = cimport('./src/nvim/api/private/t.h', './src/nvim/api/private/converter.h')
+local api = cimport('./src/nvim/api/private/helpers.h', './src/nvim/api/private/converter.h')
 
 describe('vim_to_object', function()
   local vim_to_object = function(l)

--- a/test/unit/api/testutil.lua
+++ b/test/unit/api/testutil.lua
@@ -13,8 +13,11 @@ local int_type = t_eval.int_type
 local flt_type = t_eval.flt_type
 local type_key = t_eval.type_key
 
-local api =
-  cimport('./src/nvim/api/private/defs.h', './src/nvim/api/private/t.h', './src/nvim/memory.h')
+local api = cimport(
+  './src/nvim/api/private/defs.h',
+  './src/nvim/api/private/helpers.h',
+  './src/nvim/memory.h'
+)
 
 local obj2lua
 

--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -146,11 +146,18 @@ end
 
 --- @param ... string
 function Gcc:add_to_include_path(...)
+  local ef = self.preprocessor_extra_flags
   for i = 1, select('#', ...) do
     local path = select(i, ...)
-    local ef = self.preprocessor_extra_flags
     ef[#ef + 1] = '-I' .. path
   end
+end
+
+function Gcc:add_apple_sysroot(sysroot)
+  local ef = self.preprocessor_extra_flags
+
+  table.insert(ef, '-isysroot')
+  table.insert(ef, sysroot)
 end
 
 -- returns a list of the headers files upon which this file relies
@@ -276,6 +283,11 @@ end
 --- @param ... string
 function M.add_to_include_path(...)
   return cc:add_to_include_path(...)
+end
+
+--- @param ... string
+function M.add_apple_sysroot(...)
+  return cc:add_apple_sysroot(...)
 end
 
 return M

--- a/test/unit/testutil.lua
+++ b/test/unit/testutil.lua
@@ -19,6 +19,11 @@ for _, p in ipairs(paths.include_paths) do
   Preprocess.add_to_include_path(p)
 end
 
+-- add some nonstandard header locations
+if paths.apple_sysroot ~= '' then
+  Preprocess.add_apple_sysroot(paths.apple_sysroot)
+end
+
 local child_pid = nil --- @type integer?
 --- @generic F: function
 --- @param func F

--- a/test/unit/vterm_spec.lua
+++ b/test/unit/vterm_spec.lua
@@ -94,7 +94,7 @@ local vterm = t.cimport(
   './src/nvim/vterm/screen.h',
   './src/nvim/vterm/state.h',
   './src/nvim/vterm/vterm.h',
-  './src/nvim/vterm/vterm_internal.h',
+  './src/nvim/vterm/vterm_internal_defs.h',
   './test/unit/fixtures/vterm_test.h'
 )
 


### PR DESCRIPTION
before running unittests with build.zig #34054 , we need to make them work

The old implementation of repeated_read_cmd would attempt to run the
command multiple times to handle racyness of async output. Code
like this should not be written. Instead, use the libuv event
loop to read until the process has exited and the pipe has been closed.

This causes some previous discarded errors to be propagated. Fix these
as well.