### PR TITLE
fix(lsp): _cancel_all_requests() tries to cancel completed requests

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1313,7 +1313,9 @@ function lsp.buf_request(bufnr, method, params, handler, on_unsupported)
   local function _cancel_all_requests()
     for client_id, request_id in pairs(client_request_ids) do
       local client = all_clients[client_id]
-      client:cancel_request(request_id)
+      if client.requests[request_id] then
+        client:cancel_request(request_id)
+      end
     end
   end
 


### PR DESCRIPTION
## Problem
The cancel function returned by `vim.lsp.buf_request` tries to cancel all the requests, including those that have already been completed, causing "Cannot find request with id ... whilst attempting to cancel" errors to be logged when it is called.

## Solution
Only cancel the requests that are present in `client.requests`.

Resolves #33074