### PR TITLE
feat(api): nvim_buf_find

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2407,6 +2407,10 @@ nvim_buf_detach({buffer})                                  *nvim_buf_detach()*
       • |nvim_buf_attach()|
       • |api-lua-detach| for detaching Lua callbacks
 
+nvim_buf_find({buffer}, {opts})                              *nvim_buf_find()*
+    WARNING: This feature is experimental/unstable.
+
+
 nvim_buf_get_changedtick({buffer})                *nvim_buf_get_changedtick()*
     Gets a changed tick of a buffer
 

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -338,6 +338,11 @@ function vim.api.nvim_buf_del_var(buffer, name) end
 --- - unload: Unloaded only (`:bunload`), do not delete.
 function vim.api.nvim_buf_delete(buffer, opts) end
 
+--- @param buffer integer
+--- @param opts vim.api.keyset.buf_find
+--- @return any
+function vim.api.nvim_buf_find(buffer, opts) end
+
 --- Gets a changed tick of a buffer
 ---
 --- @param buffer integer Buffer id, or 0 for current buffer

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -16,6 +16,13 @@ error('Cannot require a meta file')
 --- @field force? boolean
 --- @field unload? boolean
 
+--- @class vim.api.keyset.buf_find
+--- @field start_row? integer
+--- @field start_col? integer
+--- @field end_row? integer
+--- @field end_col? integer
+--- @field substr? string
+
 --- @class vim.api.keyset.clear_autocmds
 --- @field buffer? integer
 --- @field event? string|string[]

--- a/src/nvim/api/buffer.h
+++ b/src/nvim/api/buffer.h
@@ -8,6 +8,26 @@
 #include "nvim/pos_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
+// positions are 0-indexed
+typedef struct {
+  buf_T *buf;
+  lpos_T begin;
+  lpos_T end;
+  size_t len;
+  char const *str;
+} SearchParams;
+
+typedef struct {
+  bool found;
+  lpos_T begin;
+  lpos_T end;
+} SearchResult;
+
+typedef struct {
+  char const *data;
+  size_t length;
+} StringView;
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "api/buffer.h.generated.h"
 #endif

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -371,6 +371,16 @@ typedef struct {
 } Dict(buf_attach);
 
 typedef struct {
+  OptionalKeys is_set__buf_find_;
+
+  Integer start_row;
+  Integer start_col;
+  Integer end_row;
+  Integer end_col;
+  String substr;
+} Dict(buf_find);
+
+typedef struct {
   OptionalKeys is_set__buf_delete_;
   Boolean force;
   Boolean unload;

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -3412,7 +3412,7 @@ describe('extmark decorations', function()
         {4:^1}                                                 |
         {4:1}                                                 |*13
                                                           |
-      ]]
+      ]],
     })
     feed('<C-e>')
     -- Newly visible line should also have the highlight.
@@ -3421,7 +3421,7 @@ describe('extmark decorations', function()
         {4:^1}                                                 |
         {4:1}                                                 |*13
                                                           |
-      ]]
+      ]],
     })
   end)
 end)


### PR DESCRIPTION
### Problem

There is a functions to search for a regex inside the buffer: `vim.fn.search()`, but there is no straightforward way to search for a plain (potentially multiline) string inside the buffer.

### Solution

Introduce `nvim_buf_find(buf, { substr, start_row, ... })` function, which searches for a given substring within the buffer. It supports multiline strings, allows specifying a range to limit the search to a specific portion of the buffer. Currently, only forward search is implemented, but I plan to add backwards search as well.

If the substring is not found, the function returns `vim.NIL`. Would it be possible to return `nil` for lua instead?

I also want to add an option to provide a list of lines instead of a multiline `substr`, which is why I moved it into the `opts` dictionary.