### PR TITLE
Fix type of vim.fn.extend[new]() in runtime/lua/vim/_meta/vimfn.lua

### DIFF
--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -2007,7 +2007,7 @@ function vim.fn.expandcmd(string, options) end
 ---
 --- @param expr1 table
 --- @param expr2 table
---- @param expr3? table
+--- @param expr3? integer|'keep'|'force'|'error'
 --- @return any
 function vim.fn.extend(expr1, expr2, expr3) end
 
@@ -2017,7 +2017,7 @@ function vim.fn.extend(expr1, expr2, expr3) end
 ---
 --- @param expr1 table
 --- @param expr2 table
---- @param expr3? table
+--- @param expr3? integer|'keep'|'force'|'error'
 --- @return any
 function vim.fn.extendnew(expr1, expr2, expr3) end
 


### PR DESCRIPTION
The types for argument 3 of `vim.fn.extend()` and `vim.fn.extendnew()` are corrected.