### PR TITLE
vim-patch:f4b2fce: runtime(vim): Update base-syntax, fix missing luaParenError error

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -1505,7 +1505,6 @@ let s:interfaces = get(g:, "vimsyn_embed", "l")
 if s:interfaces =~# 'l'
   syn include @vimLuaScript syntax/lua.vim
   unlet b:current_syntax
-  syn clear luaParenError " See issue #11277
 endif
 
 syn keyword	vimLua	lua	skipwhite nextgroup=vimLuaHeredoc,vimLuaStatement


### PR DESCRIPTION
#### vim-patch:f4b2fce: runtime(vim): Update base-syntax, fix missing luaParenError error

We shouldn't assume that the luaParenError syntax group is present in
the, possibly custom, included file or that it hasn't already been
removed.  However, issue vim/vim#11277 has been fixed so it no longer needs to
be cleared.

Fixes comment https://github.com/vim/vim/pull/15375#issuecomment-2899791944

related: vim/vim#15375
closes: vim/vim#17357

https://github.com/vim/vim/commit/f4b2fce71c3b5a4f1cada0e852393efbd493e331

Co-authored-by: Doug Kearns <dougkearns@gmail.com>