### PR TITLE
vim-patch:9.1.1402: multi-byte mappings not properly stored in session file

### DIFF
--- a/src/nvim/keycodes.c
+++ b/src/nvim/keycodes.c
@@ -326,10 +326,11 @@ char *get_special_key_name(int c, int modifiers)
       string[idx++] = (char)(uint8_t)KEY2TERMCAP1(c);
     } else {
       // Not a special key, only modifiers, output directly.
-      if (utf_char2len(c) > 1) {
-        idx += utf_char2bytes(c, string + idx);
-      } else if (vim_isprintc(c)) {
+      int len = utf_char2len(c);
+      if (len == 1 && vim_isprintc(c)) {
         string[idx++] = (char)(uint8_t)c;
+      } else if (len > 1) {
+        idx += utf_char2bytes(c, string + idx);
       } else {
         char *s = transchar(c);
         while (*s) {

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -1926,7 +1926,17 @@ int put_escstr(FILE *fd, const char *strstart, int what)
       if (str[1] == KS_MODIFIER) {
         modifiers = str[2];
         str += 3;
-        c = *str;
+
+        // Modifiers can be applied too to multi-byte characters.
+        p = mb_unescape((const char **)&str);
+
+        if (p == NULL) {
+          c = *str;
+        } else {
+          // retrieve codepoint (character number) from unescaped string
+          c = utf_ptr2char(p);
+          str--;
+        }
       }
       if (c == K_SPECIAL) {
         c = TO_SPECIAL(str[1], str[2]);

--- a/test/old/testdir/test_mksession_utf8.vim
+++ b/test/old/testdir/test_mksession_utf8.vim
@@ -102,4 +102,35 @@ func Test_mksession_utf8()
   set sessionoptions& splitbelow& fileencoding&
 endfunc
 
+func Test_session_multibyte_mappings()
+
+  " some characters readily available on european keyboards
+  let entries = [
+        \ ['n', '<M-ç>', '<M-ç>'],
+        \ ['n', '<M-º>', '<M-º>'],
+        \ ['n', '<M-¡>', '<M-¡>'],
+        \ ]
+  for entry in entries
+    exe entry[0] .. 'map ' .. entry[1] .. ' ' .. entry[2]
+  endfor
+
+  mkvimrc Xtestvimrc
+
+  nmapclear
+
+  for entry in entries
+    call assert_equal('', maparg(entry[1], entry[0]))
+  endfor
+
+  source Xtestvimrc
+
+  for entry in entries
+    call assert_equal(entry[2], maparg(entry[1], entry[0]))
+  endfor
+
+  nmapclear
+
+  call delete('Xtestvimrc')
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1402: multi-byte mappings not properly stored in session file

Problem:  multi-byte mappings not properly stored in session file
Solution: unescape the mapping before writing out the mapping, prefer
          single-byte mapping name if possible (Miguel Barro)

closes: vim/vim#17355

https://github.com/vim/vim/commit/5b07aff2f665f290f2ec4a5e6bcf9873a178149a

Co-authored-by: GuyBrush <miguel.barro@live.com>