### PR TITLE
vim-patch:df68419: runtime(doc): clarify the use of change marks when writing a buffer

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -344,7 +344,8 @@ BufWriteCmd			Before writing the whole buffer to a file.
 				The buffer contents should not be changed.
 				When the command resets 'modified' the undo
 				information is adjusted to mark older undo
-				states as 'modified', like |:write| does.
+				states as 'modified', like |:write| does.  Use
+				the |'[| and |']| marks for the range of lines.
 				|Cmd-event|
 							*BufWritePost*
 BufWritePost			After writing the whole buffer to a file
@@ -658,14 +659,14 @@ FileType			When the 'filetype' option has been set.  The
 FileWriteCmd			Before writing to a file, when not writing the
 				whole buffer.  Should do the writing to the
 				file.  Should not change the buffer.  Use the
-				'[ and '] marks for the range of lines.
+				|'[| and |']| marks for the range of lines.
 				|Cmd-event|
 							*FileWritePost*
 FileWritePost			After writing to a file, when not writing the
 				whole buffer.
 							*FileWritePre*
 FileWritePre			Before writing to a file, when not writing the
-				whole buffer.  Use the '[ and '] marks for the
+				whole buffer.  Use the |'[| and |']| marks for the
 				range of lines.
 							*FilterReadPost*
 FilterReadPost			After reading a file from a filter command.

--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -141,8 +141,8 @@ the 'joinspaces' option is on, these commands insert two spaces after a '.',
 The 'B' and 'M' flags in 'formatoptions' change the behavior for inserting
 spaces before and after a multibyte character |fo-table|.
 
-The '[ mark is set at the end of the first line that was joined, '] at the end
-of the resulting line.
+The |'[| mark is set at the end of the first line that was joined, |']| at the
+end of the resulting line.
 
 
 ==============================================================================
@@ -1144,8 +1144,8 @@ the ":put" command, Vim always inserts the text in the next line.  You can
 exchange two characters with the command sequence "xp".  You can exchange two
 lines with the command sequence "ddp".  You can exchange two words with the
 command sequence "deep" (start with the cursor in the blank space before the
-first word).  You can use the "']" or "`]" command after the put command to
-move the cursor to the end of the inserted text, or use "'[" or "`[" to move
+first word).  You can use the |']| or |`]| command after the put command to
+move the cursor to the end of the inserted text, or use |'[| or |`[| to move
 the cursor to the start.
 
 						*put-Visual-mode* *v_p* *v_P*

--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -960,8 +960,9 @@ Note: When the 'write' option is off, you are not able to write any file.
 			executed like with ":!{cmd}", any '!' is replaced with
 			the previous command |:!|.
 
-The default [range] for the ":w" command is the whole buffer (1,$).  If you
-write the whole buffer, it is no longer considered changed.  When you
+The default [range] for the ":w" command is the whole buffer (1,$).  The |'[|
+and |']| marks will be set to the [range] being used for the write command.
+If you write the whole buffer, it is no longer considered changed.  When you
 write it to a different file with ":w somefile" it depends on the "+" flag in
 'cpoptions'.  When included, the write command will reset the 'modified' flag,
 even though the buffer itself may still be different from its file.

--- a/runtime/doc/motion.txt
+++ b/runtime/doc/motion.txt
@@ -878,12 +878,12 @@ Numbered mark should be stored.  See |shada-file-marks|.
 
 
 							*'[* *`[*
-'[  `[			To the first character of the previously changed
-			or yanked text.
+'[  `[			To the first character of the previously changed,
+			or yanked text.  Also set when writing the buffer.
 
 							*']* *`]*
 ']  `]			To the last character of the previously changed or
-			yanked text.
+			yanked text.  Also set when writing the buffer.
 
 After executing an operator the Cursor is put at the beginning of the text
 that was operated upon.  After a put command ("p" or "P") the cursor is


### PR DESCRIPTION
… writing a buffer

related: vim/vim#17008

https://github.com/vim/vim/commit/df68419ba0c911ff3b49c7f4835d9f29f0dd8f77

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
