### PR TITLE
feat(lua): vim.notify accepts hl_group

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1586,7 +1586,9 @@ vim.notify({msg}, {level}, {opts})                              *vim.notify()*
     Parameters: ~
       • {msg}    (`string`) Content of the notification to show to the user.
       • {level}  (`integer?`) One of the values from |vim.log.levels|.
-      • {opts}   (`table?`) Optional parameters. Unused by default.
+      • {opts}   (`table?`) Optional parameter that can also be used by a
+                 custom provider.
+                 • {hl_group}? (`string|number`) Custom highlight group.
 
 vim.notify_once({msg}, {level}, {opts})                    *vim.notify_once()*
     Displays a notification only one time.
@@ -1597,7 +1599,9 @@ vim.notify_once({msg}, {level}, {opts})                    *vim.notify_once()*
     Parameters: ~
       • {msg}    (`string`) Content of the notification to show to the user.
       • {level}  (`integer?`) One of the values from |vim.log.levels|.
-      • {opts}   (`table?`) Optional parameters. Unused by default.
+      • {opts}   (`table?`) Optional parameter that can also be used by a
+                 custom provider.
+                 • {hl_group}? (`string|number`) Custom highlight group.
 
     Return: ~
         (`boolean`) true if message was displayed, else false

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -226,6 +226,7 @@ These existing features changed their behavior.
 • 'spellfile' location defaults to `stdpath("data").."/site/spell/"` instead of
   the first writable directory in 'runtimepath'.
 • |vim.version.range()| doesn't exclude `to` if it is equal to `from`.
+• |vim.notify()| can colorize a message.
 
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*

--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -621,6 +621,11 @@ function vim.defer_fn(fn, timeout)
   return timer
 end
 
+---@class vim.notify.Opts
+---@inlinedoc
+---
+---@field hl_group? string|number Custom highlight group.
+
 --- Displays a notification to the user.
 ---
 --- This function can be overridden by plugins to display notifications using
@@ -628,10 +633,13 @@ end
 --- writes to |:messages|.
 ---@param msg string Content of the notification to show to the user.
 ---@param level integer|nil One of the values from |vim.log.levels|.
----@param opts table|nil Optional parameters. Unused by default.
----@diagnostic disable-next-line: unused-local
-function vim.notify(msg, level, opts) -- luacheck: no unused args
-  local chunks = { { msg, level == vim.log.levels.WARN and 'WarningMsg' or nil } }
+---@param opts vim.notify.Opts? Optional parameter that can also be used by a custom provider.
+function vim.notify(msg, level, opts)
+  local hl_group = opts and opts.hl_group or nil ---@type string|number|nil
+  if level == vim.log.levels.WARN then
+    hl_group = 'WarningMsg'
+  end
+  local chunks = { { msg, hl_group } }
   vim.api.nvim_echo(chunks, true, { err = level == vim.log.levels.ERROR })
 end
 
@@ -645,7 +653,7 @@ do
   ---
   ---@param msg string Content of the notification to show to the user.
   ---@param level integer|nil One of the values from |vim.log.levels|.
-  ---@param opts table|nil Optional parameters. Unused by default.
+  ---@param opts vim.notify.Opts? Optional parameter that can also be used by a custom provider.
   ---@return boolean true if message was displayed, else false
   function vim.notify_once(msg, level, opts)
     if not notified[msg] then

--- a/test/functional/lua/vim_spec.lua
+++ b/test/functional/lua/vim_spec.lua
@@ -3846,6 +3846,14 @@ stack traceback:
     }
     exec_lua [[vim.notify_once("I'll only tell you this once...")]]
     screen:expect_unchanged()
+    exec_lua [[vim.notify_once("A beautiful message", vim.log.levels.INFO, { hl_group = 'WarningMsg' })]]
+    screen:expect {
+      grid = [[
+      ^                                                            |
+      {1:~                                                           }|*3
+      {19:A beautiful message}                                         |
+    ]],
+    }
   end)
 
   describe('vim.schedule_wrap', function()


### PR DESCRIPTION
# Problem

There are no way to colorize a message provided by `vim.notify()` unlike raw `vim.api.nvim_echo()`.

# Solution

So I added a procedure to pass `hl_group` to `nvim_echo()` inside `vim.notify()`.
