### PR TITLE
vim-patch:9.1.1405: tests: no test for mapping with special keys in session file

### DIFF
--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -1086,10 +1086,10 @@ endfunc
 func Test_mkvimrc()
   let entries = [
         \ ['', 'nothing', '<Nop>'],
-        \ ['n', 'normal', 'NORMAL'],
-        \ ['v', 'visual', 'VISUAL'],
-        \ ['s', 'select', 'SELECT'],
-        \ ['x', 'visualonly', 'VISUALONLY'],
+        \ ['n', 'normal', 'NORMAL<Up>'],
+        \ ['v', 'visual', 'VISUAL<S-Down>'],
+        \ ['s', 'select', 'SELECT<C-Left>'],
+        \ ['x', 'visualonly', 'VISUALONLY<M-Right>'],
         \ ['o', 'operator', 'OPERATOR'],
         \ ['i', 'insert', 'INSERT'],
         \ ['l', 'lang', 'LANG'],

--- a/test/old/testdir/test_mksession_utf8.vim
+++ b/test/old/testdir/test_mksession_utf8.vim
@@ -103,12 +103,19 @@ func Test_mksession_utf8()
 endfunc
 
 func Test_session_multibyte_mappings()
-
-  " some characters readily available on european keyboards
+  " some characters readily available on european keyboards,
+  " as well as characters containing 0x80 or 0x9b bytes
   let entries = [
+        \ ['n', 'ç', 'ç'],
+        \ ['n', 'º', 'º'],
+        \ ['n', '¡', '¡'],
         \ ['n', '<M-ç>', '<M-ç>'],
         \ ['n', '<M-º>', '<M-º>'],
         \ ['n', '<M-¡>', '<M-¡>'],
+        \ ['n', '…', 'ě'],
+        \ ['n', 'ě', '…'],
+        \ ['n', '<M-…>', '<M-ě>'],
+        \ ['n', '<M-ě>', '<M-…>'],
         \ ]
   for entry in entries
     exe entry[0] .. 'map ' .. entry[1] .. ' ' .. entry[2]


### PR DESCRIPTION
#### vim-patch:9.1.1405: tests: no test for mapping with special keys in session file

Problem:  tests: no test for mapping with special keys in session file.
Solution: Add a special keys to an existing test.  Also test with UTF-8
          characters containing 0x80 or 0x9b bytes (zeertzjq).

closes: vim/vim#17360

https://github.com/vim/vim/commit/9ff1e598e8ee373b5623219ed38ad49470ec7938