### PR TITLE
fix(extui): when `<C-w>` is mapped

### DIFF
--- a/runtime/lua/vim/_extui/shared.lua
+++ b/runtime/lua/vim/_extui/shared.lua
@@ -47,7 +47,7 @@ function M.tab_check_wins()
         M.cmd.highlighter = vim.treesitter.highlighter.new(parser)
       elseif type == 'more' then
         -- Close more window with `q`, same as `checkhealth`
-        api.nvim_buf_set_keymap(M.bufs.more, 'n', 'q', '<C-w>c', {})
+        api.nvim_buf_set_keymap(M.bufs.more, 'n', 'q', '<Cmd>wincmd c<CR>', {})
       end
     end
 


### PR DESCRIPTION
Problem:
"q" cannot close window when `<c-w>` is mapped.
```
nvim --clean --cmd "noremap <c-w> <c-^>" --cmd "lua require('vim._extui').enable({})"
```

It's changed from `vim.keymap.set` since https://github.com/neovim/neovim/commit/302e59f734ec4d2e032b32e0134f6925c73d1f10.

Solution:
Map q to `<cmd>wincmd c<cr>`.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
