### PR TITLE
fix(filetype): error when `vim.filetype.match{buf=fn.bufadd('a.sh')}`

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -1536,7 +1536,7 @@ local function sh(path, contents, name)
   end
 
   -- Get the name from the first line if not specified
-  name = name or contents[1]
+  name = name or contents[1] or ''
   if name:find('^csh$') or matchregex(name, [[^#!.\{-2,}\<csh\>]]) then
     -- Some .sh scripts contain #!/bin/csh.
     return M.shell(path, contents, 'csh')


### PR DESCRIPTION
Problem: Error when `vim.filetype.match` a buffer with suffix `sh`.

```sh
nvim --headless +"lua vim.filetype.match({buf=fn.bufadd('a.sh')})" +q
```
Bisect to 3aa833e0d90204102bb8a90a5d7dc1323b882bfd.

Solution: fallback to an empty string as buffer content.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
