### PR TITLE
fix(lsp): announce `normalizesLineEndings` capability

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -551,6 +551,7 @@ function protocol.make_client_capabilities()
       applyEdit = true,
       workspaceEdit = {
         resourceOperations = { 'rename', 'create', 'delete' },
+        normalizesLineEndings = true,
       },
       semanticTokens = {
         refreshSupport = true,


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
We normalize line endings before applying text edits, so we should announce that in our capabilities. https://github.com/neovim/neovim/blob/8b9500c886bdb72620e331d430e166ad7d9c12f8/runtime/lua/vim/lsp/util.lua#L350-L351