### PR TITLE
build: unset $TMUX when running tests

### DIFF
--- a/cmake/RunTests.cmake
+++ b/cmake/RunTests.cmake
@@ -7,6 +7,7 @@ set(ENV{XDG_DATA_HOME} ${BUILD_DIR}/Xtest_xdg/share)
 set(ENV{XDG_STATE_HOME} ${BUILD_DIR}/Xtest_xdg/state)
 unset(ENV{XDG_DATA_DIRS})
 unset(ENV{NVIM})  # Clear $NVIM in case tests are running from Nvim. #11009
+unset(ENV{TMUX})  # Nvim TUI shouldn't think it's running in tmux. #34173
 
 # TODO(dundargoc): The CIRRUS_CI environment variable isn't passed to here from
 # the main CMakeLists.txt, so we have to manually pass it to this script and


### PR DESCRIPTION
Fix #34173

This prevents Nvim TUI running in tests from thinking it's inside tmux.

Another solution is make :terminal unset $TMUX instead, but I'm not sure
if that'll break some other use cases.
