### PR TITLE
fix(extui): write each message chunk pattern separately

### DIFF
--- a/runtime/lua/vim/_extui/shared.lua
+++ b/runtime/lua/vim/_extui/shared.lua
@@ -41,6 +41,7 @@ function M.tab_check_wins()
   for _, type in ipairs({ 'box', 'cmd', 'more', 'prompt' }) do
     if not api.nvim_buf_is_valid(M.bufs[type]) then
       M.bufs[type] = api.nvim_create_buf(false, true)
+      api.nvim_buf_set_name(M.bufs[type], 'vim._extui.' .. type)
       if type == 'cmd' then
         -- Attach highlighter to the cmdline buffer.
         local parser = assert(vim.treesitter.get_parser(M.bufs.cmd, 'vim', {}))


### PR DESCRIPTION
Problem:  Bulking message lines to write in a single API call is
          complicated and still not correct w.r.t. overwriting
          highlights.
Solution: Write each chunk pattern separately with it's highlight
          such that it will be spliced correctly for message chunks
          that contain a carriage return. Go with correctness over
          performance until this proves to be too inefficient.
          Also add an identifying name to the various extui buffers.
