### PR TITLE
vim-patch: Correct allowed characters at :help 'filetype'

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2621,7 +2621,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	one dot may appear.
 	This option is not copied to another buffer, independent of the 's' or
 	'S' flag in 'cpoptions'.
-	Only alphanumeric characters, '-' and '_' can be used.
+	Only alphanumeric characters, '-' and '_' can be used (and a '.' is
+	allowed as delimiter when combining different filetypes).
 
 						*'fillchars'* *'fcs'*
 'fillchars' 'fcs'	string	(default "")

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -2313,7 +2313,8 @@ vim.go.fic = vim.go.fileignorecase
 --- one dot may appear.
 --- This option is not copied to another buffer, independent of the 's' or
 --- 'S' flag in 'cpoptions'.
---- Only alphanumeric characters, '-' and '_' can be used.
+--- Only alphanumeric characters, '-' and '_' can be used (and a '.' is
+--- allowed as delimiter when combining different filetypes).
 ---
 --- @type string
 vim.o.filetype = ""

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3030,7 +3030,8 @@ local options = {
         one dot may appear.
         This option is not copied to another buffer, independent of the 's' or
         'S' flag in 'cpoptions'.
-        Only alphanumeric characters, '-' and '_' can be used.
+        Only alphanumeric characters, '-' and '_' can be used (and a '.' is 
+        allowed as delimiter when combining different filetypes).
       ]=],
       full_name = 'filetype',
       noglob = true,

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3030,7 +3030,7 @@ local options = {
         one dot may appear.
         This option is not copied to another buffer, independent of the 's' or
         'S' flag in 'cpoptions'.
-        Only alphanumeric characters, '-' and '_' can be used (and a '.' is 
+        Only alphanumeric characters, '-' and '_' can be used (and a '.' is
         allowed as delimiter when combining different filetypes).
       ]=],
       full_name = 'filetype',


### PR DESCRIPTION
#### vim-patch:a6172f8: runtime(doc): Correct allowed characters at :help 'filetype'

closes: vim/vim#17366

https://github.com/vim/vim/commit/a6172f8c5ce136d877965bf49881fc6e71ea4edf

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:f0c7090: runtime(doc): trailing whitespace in options.txt, delete it.

https://github.com/vim/vim/commit/f0c7090a3833f1c85b242a858e7d95a34456674c

Co-authored-by: Christian Brabandt <cb@256bit.org>