### PR TITLE
vim-patch:9.1.1408: not easily possible to complete from register content

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -146,6 +146,7 @@ commands in CTRL-X submode				*i_CTRL-X_index*
 |i_CTRL-X_CTRL-N|	CTRL-X CTRL-N	next completion
 |i_CTRL-X_CTRL-O|	CTRL-X CTRL-O	omni completion
 |i_CTRL-X_CTRL-P|	CTRL-X CTRL-P	previous completion
+|i_CTRL-X_CTRL-R|	CTRL-X CTRL-R	complete words from registers
 |i_CTRL-X_CTRL-S|	CTRL-X CTRL-S	spelling suggestions
 |i_CTRL-X_CTRL-T|	CTRL-X CTRL-T	complete identifiers from thesaurus
 |i_CTRL-X_CTRL-Y|	CTRL-X CTRL-Y	scroll down

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -629,6 +629,7 @@ Completion can be done for:
 11. omni completion					|i_CTRL-X_CTRL-O|
 12. Spelling suggestions				|i_CTRL-X_s|
 13. keywords in 'complete'				|i_CTRL-N| |i_CTRL-P|
+14. words from registers				|i_CTRL-X_CTRL-R|
 
 Additionally, |i_CTRL-X_CTRL-Z| stops completion without changing the text.
 
@@ -998,6 +999,20 @@ CTRL-X CTRL-V		Guess what kind of item is in front of the cursor and
 			CTRL-V.  This allows mapping a key to do Vim command
 			completion, for example: >
 				:imap <Tab> <C-X><C-V>
+
+Completing words from registers				*compl-register-words*
+							*i_CTRL-X_CTRL-R*
+CTRL-X CTRL-R		Guess what kind of item is in front of the cursor from
+			all registers and find the first match for it.
+			Further use of CTRL-R (without CTRL-X) will insert the
+			register content, see |i_CTRL-R|.
+			'ignorecase' applies to the matching.
+
+	CTRL-N		Search forwards for next match.  This match replaces
+			the previous one.
+
+	CTRL-P		Search backwards for previous match.  This match
+			replaces the previous one.
 
 User defined completion					*compl-function*
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3345,7 +3345,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 'ignorecase' 'ic'	boolean	(default off)
 			global
 	Ignore case in search patterns, |cmdline-completion|, when
-	searching in the tags file, and |expr-==|.
+	searching in the tags file, |expr-==| and for Insert-mode completion
+	|ins-completion|.
 	Also see 'smartcase' and 'tagcase'.
 	Can be overruled by using "\c" or "\C" in the pattern, see
 	|/ignorecase|.

--- a/runtime/doc/usr_24.txt
+++ b/runtime/doc/usr_24.txt
@@ -187,6 +187,7 @@ with a certain type of item:
 	CTRL-X CTRL-D		macro definitions (also in included files)
 	CTRL-X CTRL-I		current and included files
 	CTRL-X CTRL-K		words from a dictionary
+	CTRL-X CTRL-R		words from registers
 	CTRL-X CTRL-T		words from a thesaurus
 	CTRL-X CTRL-]		tags
 	CTRL-X CTRL-V		Vim command line

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -230,6 +230,7 @@ Insert-mode completion.					|ins-completion|
 	|i_CTRL-X_CTRL-D|	definitions or macros
 	|i_CTRL-X_CTRL-O|	Omni completion: clever completion
 				specifically for a file type
+	|i_CTRL-X_CTRL-R|	words from registers
 	etc.
 
 Long line support.					|'wrap'| |'linebreak'|

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -3186,7 +3186,8 @@ vim.o.iconstring = ""
 vim.go.iconstring = vim.o.iconstring
 
 --- Ignore case in search patterns, `cmdline-completion`, when
---- searching in the tags file, and `expr-==`.
+--- searching in the tags file, `expr-==` and for Insert-mode completion
+--- `ins-completion`.
 --- Also see 'smartcase' and 'tagcase'.
 --- Can be overruled by using "\c" or "\C" in the pattern, see
 --- `/ignorecase`.

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -796,6 +796,10 @@ static int insert_handle_key(InsertState *s)
     break;
 
   case Ctrl_R:        // insert the contents of a register
+    if (ctrl_x_mode_register() && !ins_compl_active()) {
+      insert_do_complete(s);
+      break;
+    }
     ins_reg();
     auto_format(false, true);
     s->inserted_space = false;

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -4315,7 +4315,8 @@ local options = {
       defaults = false,
       desc = [=[
         Ignore case in search patterns, |cmdline-completion|, when
-        searching in the tags file, and |expr-==|.
+        searching in the tags file, |expr-==| and for Insert-mode completion
+        |ins-completion|.
         Also see 'smartcase' and 'tagcase'.
         Can be overruled by using "\c" or "\C" in the pattern, see
         |/ignorecase|.

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -124,7 +124,7 @@ describe('completion', function()
         foo                                                         |
         ^                                                            |
         {1:~                                                           }|*5
-        {5:-- ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)}                    |
+        {5:-- ^X mode (^]^D^E^F^I^K^L^N^O^P^Rs^U^V^Y)}                  |
       ]])
       feed('<C-n>')
       screen:expect([[

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -3519,7 +3519,7 @@ describe('float window', function()
                                                             |
           {0:~                                                 }|*7
         ## grid 3
-          {3:-- ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)}          |
+          {3:-- ^X mode (^]^D^E^F^I^K^L^N^O^P^Rs^U^V^Y)}        |
         ## grid 4
           {1:   }|
           {2:~  }|*2
@@ -3543,7 +3543,7 @@ describe('float window', function()
           {1:   }  {1:^   }                                          |
           {2:~  }{0:  }{2:~  }{0:                                          }|*2
           {0:~                                                 }|*5
-          {3:-- ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)}          |
+          {3:-- ^X mode (^]^D^E^F^I^K^L^N^O^P^Rs^U^V^Y)}        |
         ]],
         }
       end

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -798,7 +798,7 @@ describe('ui/ext_messages', function()
       ^                         |
       {1:~                        }|*2
     ]],
-      showmode = { { '-- ^X mode (^]^D^E^F^I^K^L^N^O^Ps^U^V^Y)', 5, 11 } },
+      showmode = { { '-- ^X mode (^]^D^E^F^I^K^L^N^O^P^Rs^U^V^Y)', 5, 11 } },
     }
 
     feed('<c-p>')


### PR DESCRIPTION
Problem:  not easily possible to complete from register content
Solution: add register-completion submode using i_CTRL-X_CTRL-R
          (glepnir)

closes: vim/vim#17354

https://github.com/vim/vim/commit/0546068aaef2b1a40faa2945ef7eba249739f219

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
