### PR TITLE
fix(extui): incorrect cmdline cursor position

### DIFF
--- a/runtime/lua/vim/_extui/cmdline.lua
+++ b/runtime/lua/vim/_extui/cmdline.lua
@@ -39,12 +39,11 @@ local promptlen = 0 -- Current length of the prompt, stored for use in "cmdline_
 ---@param content CmdContent
 ---@param prompt string
 local function set_text(content, prompt)
-  promptlen = #prompt
+  promptlen, cmdbuff = #prompt, ''
   for _, chunk in ipairs(content) do
-    prompt = prompt .. chunk[2]
+    cmdbuff = cmdbuff .. chunk[2]
   end
-  cmdbuff = prompt
-  api.nvim_buf_set_lines(ext.bufs.cmd, M.row, -1, false, { fn.strtrans(cmdbuff) .. ' ' })
+  api.nvim_buf_set_lines(ext.bufs.cmd, M.row, -1, false, { prompt .. fn.strtrans(cmdbuff) .. ' ' })
 end
 
 --- Set the cmdline buffer text and cursor position.
@@ -95,7 +94,7 @@ local curpos = { 0, 0 } -- Last drawn cursor position.
 ---@param pos integer
 --@param level integer
 function M.cmdline_pos(pos)
-  pos = #fn.strtrans(cmdbuff:sub(1, pos + 1)) - 1
+  pos = #fn.strtrans(cmdbuff:sub(1, pos))
   if curpos[1] ~= M.row + 1 or curpos[2] ~= promptlen + pos then
     curpos[1], curpos[2] = M.row + 1, promptlen + pos
     -- Add matchparen highlighting to non-prompt part of cmdline.


### PR DESCRIPTION
Problem:  Calculated cmdline cursor position can be smaller than 0.
          Prompt part of the cmdline is translated, while it should
          support "\t" characters.
Solution: Remove prompt part from the stored "cmdbuff" and get rid of
          dubious +/-1 from cmdline cursor calculation.

Fix #34196