### PR TITLE
fix(api): add missing nargs field to user command Lua callbacks

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -2206,6 +2206,26 @@ int nlua_do_ucmd(ucmd_T *cmd, exarg_T *eap, bool preview)
   }
   lua_setfield(lstate, -2, "count");
 
+  char nargs[2];
+  if (cmd->uc_argt & EX_EXTRA) {
+    if (cmd->uc_argt & EX_NOSPC) {
+      if (cmd->uc_argt & EX_NEEDARG) {
+        nargs[0] = '1';
+      } else {
+        nargs[0] = '?';
+      }
+    } else if (cmd->uc_argt & EX_NEEDARG) {
+      nargs[0] = '+';
+    } else {
+      nargs[0] = '*';
+    }
+  } else {
+    nargs[0] = '0';
+  }
+  nargs[1] = NUL;
+  lua_pushstring(lstate, nargs);
+  lua_setfield(lstate, -2, "nargs");
+
   // The size of this buffer is chosen empirically to be large enough to hold
   // every possible modifier (with room to spare). If the list of possible
   // modifiers grows this may need to be updated.

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -227,6 +227,7 @@ describe('nvim_create_user_command', function()
         line1 = 1,
         line2 = 1,
         mods = '',
+        nargs = '*',
         smods = {
           browse = false,
           confirm = false,
@@ -267,6 +268,7 @@ describe('nvim_create_user_command', function()
         line1 = 1,
         line2 = 1,
         mods = '',
+        nargs = '*',
         smods = {
           browse = false,
           confirm = false,
@@ -307,6 +309,7 @@ describe('nvim_create_user_command', function()
         line1 = 1,
         line2 = 1,
         mods = '',
+        nargs = '*',
         smods = {
           browse = false,
           confirm = false,
@@ -347,6 +350,7 @@ describe('nvim_create_user_command', function()
         line1 = 10,
         line2 = 10,
         mods = 'confirm unsilent botright horizontal',
+        nargs = '*',
         smods = {
           browse = false,
           confirm = true,
@@ -387,6 +391,7 @@ describe('nvim_create_user_command', function()
         line1 = 1,
         line2 = 42,
         mods = '',
+        nargs = '*',
         smods = {
           browse = false,
           confirm = false,
@@ -427,6 +432,7 @@ describe('nvim_create_user_command', function()
         line1 = 1,
         line2 = 1,
         mods = '',
+        nargs = '*',
         smods = {
           browse = false,
           confirm = false,
@@ -479,6 +485,7 @@ describe('nvim_create_user_command', function()
         line1 = 1,
         line2 = 1,
         mods = '',
+        nargs = '?',
         smods = {
           browse = false,
           confirm = false,
@@ -520,6 +527,7 @@ describe('nvim_create_user_command', function()
         line1 = 1,
         line2 = 1,
         mods = '',
+        nargs = '?',
         smods = {
           browse = false,
           confirm = false,
@@ -572,6 +580,7 @@ describe('nvim_create_user_command', function()
         line1 = 1,
         line2 = 1,
         mods = '',
+        nargs = '0',
         smods = {
           browse = false,
           confirm = false,
@@ -612,6 +621,7 @@ describe('nvim_create_user_command', function()
         line1 = 1,
         line2 = 1,
         mods = '',
+        nargs = '0',
         smods = {
           browse = false,
           confirm = false,


### PR DESCRIPTION
Problem: nvim_create_user_command() Lua callbacks were missing the documented nargs field in the options table passed to the callback function.

Solution: Add nargs field derivation from command argument type flags in nlua_do_ucmd(), using the same logic as nvim_parse_cmd().

Fix #34205 

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
