### PR TITLE
vim-patch:0bc8709: runtime(doc): Correct allowed flags after :substitute repeat

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -644,8 +644,9 @@ original user.
 			Repeat last :substitute with same search pattern and
 			substitute string, but without the same flags.  You
 			may add [flags], see |:s_flags|.
-			Note that after `:substitute` the '&' flag can't be
-			used, it's recognized as a pattern separator.
+			Note that after `:substitute` the '&' and '#' flags
+			can't be used, they're recognized as a pattern
+			separator.
 			The space between `:substitute` and the 'c', 'g',
 			'i', 'I' and 'r' flags isn't required, but in scripts
 			it's a good idea to keep it to avoid confusion.


### PR DESCRIPTION
#### vim-patch:0bc8709: runtime(doc): Correct allowed flags after :substitute repeat

closes: vim/vim#17391

https://github.com/vim/vim/commit/0bc8709a634ff2ae4024a59aa3b9873efa9c7453

Co-authored-by: Christian Brabandt <cb@256bit.org>