### PR TITLE
vim-patch:9.1.1417: missing info about register completion in complete_info()

### DIFF
--- a/runtime/doc/builtin.txt
+++ b/runtime/doc/builtin.txt
@@ -1236,6 +1236,7 @@ complete_info([{what}])                                        *complete_info()*
 		   "omni"	     Omni completion |i_CTRL-X_CTRL-O|
 		   "spell"	     Spelling suggestions |i_CTRL-X_s|
 		   "eval"	     |complete()| completion
+		   "register"	     Words from registers |i_CTRL-X_CTRL-R|
 		   "unknown"	     Other internal modes
 
 		If the optional {what} list argument is supplied, then only

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -1084,6 +1084,7 @@ function vim.fn.complete_check() end
 ---    "omni"       Omni completion |i_CTRL-X_CTRL-O|
 ---    "spell"       Spelling suggestions |i_CTRL-X_s|
 ---    "eval"       |complete()| completion
+---    "register"       Words from registers |i_CTRL-X_CTRL-R|
 ---    "unknown"       Other internal modes
 ---
 --- If the optional {what} list argument is supplied, then only

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -1450,6 +1450,7 @@ M.funcs = {
          "omni"	     Omni completion |i_CTRL-X_CTRL-O|
          "spell"	     Spelling suggestions |i_CTRL-X_s|
          "eval"	     |complete()| completion
+         "register"	     Words from registers |i_CTRL-X_CTRL-R|
          "unknown"	     Other internal modes
 
       If the optional {what} list argument is supplied, then only

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -3865,6 +3865,9 @@ func Test_register_completion()
   call feedkeys("a\<C-X>\<C-R>\<Esc>", 'tx')
   call assert_equal("zero", getline(1))
 
+  call feedkeys("Sze\<C-X>\<C-R>\<C-R>=string(complete_info(['mode']))\<CR>\<ESC>", "tx")
+  call assert_equal("zero{'mode': 'register'}", getline(1))
+
   " Clean up
   bwipe!
   delfunc GetItems


### PR DESCRIPTION
#### vim-patch:9.1.1417: missing info about register completion in complete_info()

Problem:  missing info about register completion in complete_info()
          (after v9.1.1408)
Solution: update documentation and mention that register is used as
          source, add a test (glepnir)

closes: vim/vim#17389

https://github.com/vim/vim/commit/49864aecd0d23676e202b30bc8705c78ae52d680

Co-authored-by: glepnir <glephunter@gmail.com>