### PR TITLE
build(deps): bump luajit to f9140a622

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -1,8 +1,8 @@
 LIBUV_URL https://github.com/libuv/libuv/archive/v1.51.0.tar.gz
 LIBUV_SHA256 27e55cf7083913bfb6826ca78cde9de7647cded648d35f24163f2d31bb9f51cd
 
-LUAJIT_URL https://github.com/luajit/luajit/archive/51d4c26ec7805d77bfc3470fdf99b73c4ef2faec.tar.gz
-LUAJIT_SHA256 7fd632850d28430b7e999bec9255d23ba7c6ecb3ecf1cafb481b8b8ecdb60612
+LUAJIT_URL https://github.com/luajit/luajit/archive/871db2c84ecefd70a850e03a6c340214a81739f0.tar.gz
+LUAJIT_SHA256 ab3f16d82df6946543565cfb0d2810d387d79a3a43e0431695b03466188e2680
 
 LUA_URL https://www.lua.org/ftp/lua-5.1.5.tar.gz
 LUA_SHA256 2640fc56a795f29d28ef15e13c34a47e223960b0240e8cb0a82d9b0738695333

--- a/test/unit/marktree_spec.lua
+++ b/test/unit/marktree_spec.lua
@@ -590,7 +590,7 @@ describe('marktree', function()
     lib.marktree_check(tree)
     local iter = ffi.new('MarkTreeIter[1]')
     local filter = ffi.new('uint32_t[4]')
-    filter[0] = -1
+    filter[0] = -1ULL
     ok(lib.marktree_itr_get_filter(tree, 0, 0, 101, 0, filter, iter))
     local seen = {}
     repeat

--- a/test/unit/os/fs_spec.lua
+++ b/test/unit/os/fs_spec.lua
@@ -278,7 +278,7 @@ describe('fs.c', function()
       itp('does not change owner and group if respective IDs are equal to -1', function()
         local uid = uv.fs_stat(filename).uid
         local gid = uv.fs_stat(filename).gid
-        eq(0, os_fchown(filename, -1, -1))
+        eq(0, os_fchown(filename, -1ULL, -1ULL))
         eq(uid, uv.fs_stat(filename).uid)
         return eq(gid, uv.fs_stat(filename).gid)
       end)
@@ -304,7 +304,7 @@ describe('fs.c', function()
             -- User can be a member of only one group.
             -- In that case we can not perform this test.
             if new_gid then
-              eq(0, (os_fchown(filename, -1, new_gid)))
+              eq(0, (os_fchown(filename, -1ULL, new_gid)))
               eq(new_gid, uv.fs_stat(filename).gid)
             end
           end


### PR DESCRIPTION
* Prevent Clang UB 'optimization' which breaks integerness checks.
* Fix JIT slot overflow during up-recursion.
* Avoid out-of-range PC for stack overflow error from snapshot restore.
* FFI: Fix dangling CType references.
