### PR TITLE
build(win): "incompatible pointer type"

### DIFF
--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -147,9 +147,6 @@ bool os_env_exists(const char *name, bool nonempty)
 /// Sets an environment variable.
 ///
 /// Windows (Vim-compat): Empty string (:let $FOO="") undefines the env var.
-///
-/// @warning Existing pointers to the result of os_getenv("foo") are
-///          INVALID after os_setenv("foo", …).
 int os_setenv(const char *name, const char *value, int overwrite)
   FUNC_ATTR_NONNULL_ALL
 {

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -384,12 +384,14 @@ static void terminfo_start(TUIData *tui)
   tui->out_isatty = os_isatty(tui->out_fd);
   tui->input.tui_data = tui;
 
-#ifdef MSWIN
-  const char* guessed_term = NULL;
-  os_tty_guess_term(&guessed_term, tui->out_fd);
-  os_setenv("TERM", guessed_term, 1);
-#endif
   char *term = os_getenv("TERM");
+#ifdef MSWIN
+  const char *guessed_term = NULL;
+  os_tty_guess_term(&guessed_term, tui->out_fd);
+  if (term == NULL) {
+    os_setenv("TERM", guessed_term, 1);
+  }
+#endif
 
   // Set up unibilium/terminfo.
   if (term) {

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -388,7 +388,8 @@ static void terminfo_start(TUIData *tui)
 #ifdef MSWIN
   const char *guessed_term = NULL;
   os_tty_guess_term(&guessed_term, tui->out_fd);
-  if (term == NULL) {
+  if (term == NULL && guessed_term != NULL) {
+    term = xstrdup(guessed_term);
     os_setenv("TERM", guessed_term, 1);
   }
 #endif

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -388,8 +388,6 @@ static void terminfo_start(TUIData *tui)
 #ifdef MSWIN
   os_tty_guess_term((const char **)&term, tui->out_fd);
   os_setenv("TERM", term, 1);
-  // Old os_getenv() pointer is invalid after os_setenv(), fetch it again.
-  term = os_getenv("TERM");
 #endif
 
   // Set up unibilium/terminfo.

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -386,7 +386,7 @@ static void terminfo_start(TUIData *tui)
 
   char *term = os_getenv("TERM");
 #ifdef MSWIN
-  os_tty_guess_term(&term, tui->out_fd);
+  os_tty_guess_term((const char **)&term, tui->out_fd);
   os_setenv("TERM", term, 1);
   // Old os_getenv() pointer is invalid after os_setenv(), fetch it again.
   term = os_getenv("TERM");

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -384,11 +384,12 @@ static void terminfo_start(TUIData *tui)
   tui->out_isatty = os_isatty(tui->out_fd);
   tui->input.tui_data = tui;
 
-  char *term = os_getenv("TERM");
 #ifdef MSWIN
-  os_tty_guess_term((const char **)&term, tui->out_fd);
-  os_setenv("TERM", term, 1);
+  const char* guessed_term = NULL;
+  os_tty_guess_term(&guessed_term, tui->out_fd);
+  os_setenv("TERM", guessed_term, 1);
 #endif
+  char *term = os_getenv("TERM");
 
   // Set up unibilium/terminfo.
   if (term) {


### PR DESCRIPTION
From commit;
**Problem:**
    Building with GCC fails with ninja: build stopped: subcommand failed.
    This is a cmake build. Slightly above in the log I can see the message
    neovim/src/nvim/tui/tui.c:391:21: error: passing argument 1 of 'os_tty_guess_term' \
      from incompatible pointer type [-Wincompatible-pointer-types]
    This is on GCC 15.1.0 and MSYS2.

**Solution:**
    The call to os_tty_guess_term seems to only be used behind define MSWIN,
    it accepts a const char **. making term into a const pointer lets the
    build succeed.

If there is a better fix for this failure such as build config, function declaration change, anything else please let me know and I will try it. I first noticed this issue about one or two months ago on master.