### PR TITLE
fix(clipboard): handle register type in OSC 52

### DIFF
--- a/runtime/lua/vim/ui/clipboard/osc52.lua
+++ b/runtime/lua/vim/ui/clipboard/osc52.lua
@@ -9,17 +9,16 @@ local function osc52(clipboard, contents)
   return string.format('\027]52;%s;%s\027\\', clipboard, contents)
 end
 
----@class clipboard_cache
+---@class ClipboardCache
 ---
 ---@field hash string sha256 of the lines passed to the copy() function
 ---@field regtype string regtype argument passed to the copy() function
 ---
----@type table<string, clipboard_cache>
+---@type table<string, ClipboardCache>
 local cache = {}
 
 function M.copy(reg)
   local clipboard = reg == '+' and 'c' or 'p'
-  ---@param regtype string
   return function(lines, regtype)
     local s = table.concat(lines, '\n')
     cache[reg] = {

--- a/runtime/lua/vim/ui/clipboard/osc52.lua
+++ b/runtime/lua/vim/ui/clipboard/osc52.lua
@@ -11,7 +11,7 @@ end
 
 ---@class clipboard_cache
 ---
----@field lines_str string String representation of lines passed to the copy() funciton
+---@field lines_str string String representation of lines passed to the copy() function
 ---@field regtype string regtype argument passed to the copy() function
 ---
 ---@type table<string, clipboard_cache>

--- a/runtime/lua/vim/ui/clipboard/osc52.lua
+++ b/runtime/lua/vim/ui/clipboard/osc52.lua
@@ -11,6 +11,7 @@ end
 
 function M.copy(reg)
   local clipboard = reg == '+' and 'c' or 'p'
+  ---@param regtype string
   return function(lines, regtype)
     local s = table.concat(lines, '\n') .. '\n' .. regtype
     -- The data to be written here can be quite long.

--- a/runtime/lua/vim/ui/clipboard/osc52.lua
+++ b/runtime/lua/vim/ui/clipboard/osc52.lua
@@ -71,7 +71,7 @@ function M.paste(reg)
 
     -- If we get here, contents should be non-nil
     local contents_list = vim.split(assert(contents), '\n')
-    local lines = { table.unpack(contents_list, 1, #contents_list - 1) }
+    local lines = { unpack(contents_list, 1, #contents_list - 1) }
     local regtype = contents_list[#contents_list]
     return { lines, regtype }
   end

--- a/runtime/lua/vim/ui/clipboard/osc52.lua
+++ b/runtime/lua/vim/ui/clipboard/osc52.lua
@@ -25,7 +25,7 @@ local function get_regtype(reg, lines_str)
       return cb_cache.regtype
     end
   end
-  return ""
+  return ''
 end
 
 function M.copy(reg)

--- a/runtime/lua/vim/ui/clipboard/osc52.lua
+++ b/runtime/lua/vim/ui/clipboard/osc52.lua
@@ -11,8 +11,8 @@ end
 
 function M.copy(reg)
   local clipboard = reg == '+' and 'c' or 'p'
-  return function(lines)
-    local s = table.concat(lines, '\n')
+  return function(lines, regtype)
+    local s = table.concat(lines, '\n') .. '\n' .. regtype
     -- The data to be written here can be quite long.
     -- Use nvim_chan_send() as io.stdout:write() doesn't handle EAGAIN. #26688
     vim.api.nvim_chan_send(2, osc52(clipboard, vim.base64.encode(s)))
@@ -70,7 +70,10 @@ function M.paste(reg)
     end
 
     -- If we get here, contents should be non-nil
-    return vim.split(assert(contents), '\n')
+    local contents_list = vim.split(assert(contents), '\n')
+    local lines = { table.unpack(contents_list, 1, #contents_list - 1) }
+    local regtype = contents_list[#contents_list]
+    return { lines, regtype }
   end
 end
 


### PR DESCRIPTION

# ❓ Problem
When setting
```lua
vim.opt.clipboard = 'unnamedplus'
vim.g.clipboard = 'osc52'
```
copy/pasting `blockwise-visual` (with `CTRL+V`) ends up incorrectly being pasted as a `linewise` mode because `regtype` is ignored.

Here is how to reproduce this:
* press  `CTRL+V` and select some characters
* press `p` and observe that it is pasted in `linewise` mode

# Solution

* store `regtype` in a cache when copying
* pass `regtype` when pasting if OSC 52 data matches the cache (similar to what is done in [clipboard.vim](https://github.com/neovim/neovim/blob/master/runtime/autoload/provider/clipboard.vim#L281-L283))

Fix https://github.com/neovim/neovim/issues/27706

# 📊 test coverage
Command: `make test`

It failed on `node` tests which seem unrelated with my changes:
```
-------- Global test environment teardown.
======== 8005 tests from 442 test files ran. (432211.00 ms total)
PASSED   7952 tests.
SKIPPED  50 tests, listed below:
SKIPPED  test/functional/api/autocmd_spec.lua @ 239: autocmd api nvim_create_autocmd script and verbose settings
SKIPPED  test/functional/api/server_requests_spec.lua @ 149: server -> client requests and notifications interleaved will close connection if not properly synchronized
SKIPPED  test/functional/autocmd/termxx_spec.lua @ 37: autocmd TermClose TermClose deleting its own buffer, altbuf = buffer 1 #10386
SKIPPED  test/functional/core/channels_spec.lua @ 36: channels can connect to socket
SKIPPED  test/functional/core/job_spec.lua @ 1012: jobs exit event follows stdout, stderr
SKIPPED  test/functional/editor/langmap_spec.lua @ 242: 'langmap' Translates modified keys correctly
SKIPPED  test/functional/editor/langmap_spec.lua @ 248: 'langmap' handles multi-byte characters
SKIPPED  test/functional/editor/langmap_spec.lua @ 258: 'langmap' handles multibyte mappings
SKIPPED  test/functional/ex_cmds/make_spec.lua @ 19: :make with powershell not tested; powershell was not found
SKIPPED  test/functional/ex_cmds/source_spec.lua @ 50: :source changing 'shellslash' changes the result of expand()
test/functional/ex_cmds/source_spec.lua:52: 'shellslash' only works on Windows
SKIPPED  test/functional/ex_cmds/verbose_spec.lua @ 209: lua :verbose with -V1 "Last set" shows full location using :luafile for command defined by nvim_command
test/functional/ex_cmds/verbose_spec.lua:211: nvim_command does not set the script context
SKIPPED  test/functional/ex_cmds/verbose_spec.lua @ 209: lua :verbose without -V1 "Last set" suggests -V1 when using :luafile for command defined by nvim_command
test/functional/ex_cmds/verbose_spec.lua:211: nvim_command does not set the script context
SKIPPED  .../functional/legacy/036_regexp_character_classes_spec.lua @ 295: character classes in regexp "\%1l^#.*" does not match on a line starting with "#". (vim-patch:7.4.1305)
SKIPPED  test/functional/lua/uri_spec.lua @ 208: URI methods uri from bufnr Windows paths should not be treated as uris
test/testutil.lua:829: Not applicable on non-Windows
SKIPPED  test/functional/lua/vim_spec.lua @ 2269: lua stdlib vim.opt handles STUPID window things
SKIPPED  test/functional/lua/watch_spec.lua @ 61: vim._watch inotify() ignores nonexistent paths
test/testutil.lua:829: inotifywait not found
SKIPPED  test/functional/lua/watch_spec.lua @ 82: vim._watch inotify() detects file changes
test/testutil.lua:829: inotifywait not found
SKIPPED  test/functional/lua/with_spec.lua @ 306: vim._with `emsg_silent` context works
SKIPPED  test/functional/lua/with_spec.lua @ 512: vim._with `hide` context works
SKIPPED  test/functional/lua/with_spec.lua @ 565: vim._with `horizontal` context works
SKIPPED  test/functional/lua/with_spec.lua @ 576: vim._with `horizontal` context can be nested
SKIPPED  test/functional/lua/with_spec.lua @ 591: vim._with `keepalt` context works
SKIPPED  test/functional/lua/with_spec.lua @ 625: vim._with `keepjumps` context works
SKIPPED  test/functional/lua/with_spec.lua @ 654: vim._with `keepmarks` context works
SKIPPED  test/functional/lua/with_spec.lua @ 687: vim._with `keepatterns` context works
SKIPPED  test/functional/lua/with_spec.lua @ 771: vim._with `noautocmd` context can be nested
SKIPPED  test/functional/lua/with_spec.lua @ 1040: vim._with `silent` context can be nested
SKIPPED  test/functional/lua/with_spec.lua @ 1062: vim._with `unsilent` context can be nested
SKIPPED  test/functional/lua/with_spec.lua @ 1496: vim._with can forward command modifiers to user command
SKIPPED  test/functional/options/keymap_spec.lua @ 195: 'keymap' / :lmap mappings not applied to macro replay of :lnoremap
SKIPPED  test/functional/plugin/lsp_spec.lua @ 1779: LSP basic_init test should check the body and didChange incremental normal mode editing
SKIPPED  test/functional/plugin/lsp_spec.lua @ 5744: LSP vim.lsp._watchfiles sends notifications when files change (watchfunc=inotify)
test/testutil.lua:829: inotify-tools not installed and not on CI
SKIPPED  test/functional/provider/perl_spec.lua @ 19: Missing perl host, or perl version is too old ("Neovim::Ext" cpan module is not installed)
SKIPPED  test/functional/provider/python3_spec.lua @ 31: Python 3 (or the pynvim module) is broken/missing (Could not load Python :
/usr/bin/python3 does not have the "neovim" module.
/usr/bin/python3.13 does not have the "neovim" module.
python3.12 not found in search path or not executable.
python3.11 not found in search path or not executable.
python3.10 not found in search path or not executable.
python3.9 not found in search path or not executable.
/usr/bin/python does not have the "neovim" module.)
SKIPPED  test/functional/provider/ruby_spec.lua @ 29: Missing neovim RubyGem (missing ruby or ruby-host)
SKIPPED  test/functional/terminal/tui_spec.lua @ 3105: TUI 't_Co' (terminal colors) TERM=interix uses 8 colors
SKIPPED  test/functional/ui/bufhl_spec.lua @ 450: Buffer highlighting prioritizes latest added highlight
SKIPPED  test/functional/ui/decorations_spec.lua @ 7595: decorations: window scoped sign_text
SKIPPED  test/functional/ui/float_spec.lua @ 740: float window with only one tabpage, deleting the last non-floating window's buffer closes other windows with that buffer when there are other buffers if called from floating window with another buffer
SKIPPED  test/functional/ui/float_spec.lua @ 773: float window with only one tabpage, deleting the last non-floating window's buffer creates an empty buffer when there is only one listed buffer if called from floating window with an unlisted buffer
SKIPPED  test/functional/ui/float_spec.lua @ 942: float window with multiple tabpages and multiple listed buffers, deleting the last non-floating window's buffer closes the tabpage when all floating windows are closeable if called from floating window with another buffer
SKIPPED  test/functional/ui/float_spec.lua @ 971: float window :close on non-float with floating windows does not crash if BufUnload makes it the only non-float in tabpage
SKIPPED  test/functional/ui/float_spec.lua @ 4985: float window with ext_multigrid supports second UI without multigrid
SKIPPED  test/functional/ui/messages_spec.lua @ 2584: ui/msg_puts_printf output multibyte characters correctly
test/testutil.lua:829: Nvim not built with ENABLE_TRANSLATIONS
SKIPPED  test/functional/vimscript/eval_spec.lua @ 90: backtick expansion with shell=fish
test/functional/vimscript/eval_spec.lua:92: missing "fish" command
SKIPPED  test/functional/vimscript/eval_spec.lua @ 108: List support code does not actually allows interrupting with just got_int
SKIPPED  test/functional/vimscript/executable_spec.lua @ 111: executable() (Windows) N/A for non-windows
SKIPPED  test/functional/vimscript/system_spec.lua @ 191: system() executes shell function powershell w/ UTF-8 text #13713
test/functional/vimscript/system_spec.lua:193: powershell not found
SKIPPED  test/functional/vimscript/system_spec.lua @ 543: systemlist() powershell w/ UTF-8 text #13713
test/functional/vimscript/system_spec.lua:545: powershell not found
SKIPPED  test/functional/vimscript/system_spec.lua @ 597: shell :! :{range}! with powershell using "cmdlets" filter/redirect #16271 #19250
test/functional/vimscript/system_spec.lua:599: powershell not found
FAILED   3 tests, listed below:
FAILED   test/functional/plugin/lsp_spec.lua @ 6680: LSP vim.lsp.config() and vim.lsp.enable() correctly handles root_markers
test/functional/plugin/lsp_spec.lua:6739: retry() attempts: 49
test/functional/plugin/lsp_spec.lua:6740: Expected objects to be the same.
Passed in:
(string) '/home/antoine'
Expected:
(nil)

stack traceback:
	test/testutil.lua:89: in function 'retry'
	test/functional/plugin/lsp_spec.lua:6739: in function 'markers_resolve_to'
	test/functional/plugin/lsp_spec.lua:6754: in function <test/functional/plugin/lsp_spec.lua:6680>

FAILED   test/functional/provider/nodejs_spec.lua @ 33: nodejs host works
test/functional/provider/nodejs_spec.lua:44: retry() attempts: 146
test/functional/testnvim.lua:139: Vim:E121: Undefined variable: g:job_out

stack traceback:
	test/testutil.lua:89: in function 'retry'
	test/functional/provider/nodejs_spec.lua:44: in function <test/functional/provider/nodejs_spec.lua:33>

FAILED   test/functional/provider/nodejs_spec.lua @ 48: nodejs host plugin works
test/functional/provider/nodejs_spec.lua:67: retry() attempts: 146
test/functional/testnvim.lua:139: Vim:E121: Undefined variable: g:job_out

stack traceback:
	test/testutil.lua:89: in function 'retry'
	test/functional/provider/nodejs_spec.lua:67: in function <test/functional/provider/nodejs_spec.lua:48>


 50 SKIPPED TESTS
 3 FAILED TESTS
------------------------------------------------------------------------------
$NVIM_LOG_FILE: /home/antoine/src/neovim_antoine/build/.nvimlog
(last 10 lines)
DBG 2025-05-29T16:38:26.961 T7845.71450.0 inbuf_poll:516: blocking... events=true
DBG 2025-05-29T16:38:26.961 T7845.71450.0 receive_msgpack:210: ch 1: parsing 108 bytes from msgpack Stream: 0x55b383658810
DBG 2025-05-29T16:38:26.961 T7845.71450.0 RPC: <- 1: [request]   id=3: nvim_command
DBG 2025-05-29T16:38:26.961 T7845.71450.0 handle_request:347: RPC: scheduled nvim_command
DBG 2025-05-29T16:38:26.961 T7845.71450.0 state_enter:99: input: K_EVENT
DBG 2025-05-29T16:38:26.961 T7845.71450.0 handle_nvim_command:9659: RPC: ch 1: invoke nvim_command
DBG 2025-05-29T16:38:26.961 T7845.71450.0 RPC: -> 1: [error]     id=3
DBG 2025-05-29T16:38:26.961 T7845.71450.0 may_trigger_safestate:307: SafeState: Start triggering
DBG 2025-05-29T16:38:26.961 T7845.71450.0 inbuf_poll:516: blocking... events=false
DBG 2025-05-29T16:38:26.961 T7845.71450.0 inbuf_poll:516: blocking... events=true
------------------------------------------------------------------------------
```
