### PR TITLE
ci(release): bump windows runner to windows-2022

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -132,7 +132,7 @@ jobs:
 
   windows:
     needs: setup
-    runs-on: windows-2019
+    runs-on: windows-2022
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Windows-20219 runner will be retired June 30, 2025 and receive several brownouts before then:
https://github.com/actions/runner-images/issues/12045

Safe for another three years 😌 