### PR TITLE
vim-patch:570e71a: runtime(vim): Update base-syntax, improve :set highlighting

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -843,14 +843,14 @@ syn match	vimCmplxRepeat	'[^a-zA-Z_/\\()]q[0-9a-zA-Z"]\>'lc=1
 syn match	vimCmplxRepeat	'@[0-9a-z".=@:]\ze\($\|[^a-zA-Z]\>\)'
 
 " Set command and associated set-options (vimOptions) with comment {{{2
-syn match	vimSet		"\<\%(setl\%[ocal]\|setg\%[lobal]\|se\%[t]\)\>" skipwhite nextgroup=vimSetBang,vimSetArgs
+syn match	vimSet		"\<\%(setl\%[ocal]\|setg\%[lobal]\|se\%[t]\)\>" skipwhite nextgroup=vimSetBang,vimCmdSep,vimComment,vimSetArgs
 syn region	vimSetComment	contained	start=+"+ skip=+\n\s*\%(\\\||"\\ \)+ end="$" contains=@vimCommentGroup,vimCommentString extend
 syn match	vimSetCmdSep	contained	"|" skipwhite nextgroup=@vimCmdList,vimSubst1,vimFunc
 syn match	vimSetEscape	contained	"\\\%(\\[|"]\|.\)"
 syn match	vimSetBarEscape	contained	"\\|"
 syn match	vimSetQuoteEscape	contained	+\\"+
 syn region	vimSetArgs	contained
-      \ start="\S"
+      \ start="\l\|<"
       \ skip=+\n\s*\%(\\\|["#]\\ \)\|^\s*"\\ +
       \ end=+\ze\\\@1<![|"]+
       "\ assume this isn't an escaped char with backslash on the previous line
@@ -860,6 +860,8 @@ syn region	vimSetArgs	contained
       \ nextgroup=vimSetCmdSep,vimSetComment,vim9Comment
       \ contains=@vimContinue,vimErrSetting,vimOption,vimSetAll,vimSetTermcap
       \ keepend
+" TODO: restrict this to valid values?
+syn match	vimOption	contained	"<[^>]\+>"	contains=vimOption
 syn region	vimSetEqual	contained
       \ matchgroup=vimOper
       \ start="[=:]\|[-+^]="


### PR DESCRIPTION
#### vim-patch:570e71a: runtime(vim): Update base-syntax, improve :set highlighting

- Match comments and trailing bar after :set without args.
- Match the <...> form for key code options.
- Remove orphaned vim_ex_python[3x]* dump files (Aliaksei Budavei).

closes: vim/vim#17397

https://github.com/vim/vim/commit/570e71a2772d860af14a1b58e3fb1cdcbc7bf796

Co-authored-by: Doug Kearns <dougkearns@gmail.com>