### PR TITLE
fix(redraw): update curswant for Visual selection

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -595,6 +595,11 @@ int update_screen(void)
     curwin->w_redr_type = UPD_NOT_VALID;
   }
 
+  if (curwin->w_redr_type == UPD_INVERTED) {
+    // Update w_curswant so that the end of Visual selection is correct.
+    update_curswant();
+  }
+
   // Redraw the tab pages line if needed.
   if (redraw_tabline || type >= UPD_NOT_VALID) {
     update_window_hl(curwin, type >= UPD_NOT_VALID);

--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -423,6 +423,26 @@ describe('highlight', function()
     ]])
   end)
 
+  it('blockwise Visual highlight with virtualedit=block #34235', function()
+    local screen = Screen.new(45, 5)
+    command('set virtualedit=block')
+    insert('foobar\nfoo')
+    feed('0<C-V>k$')
+    screen:expect([[
+      {17:foobar}^                                       |
+      {17:foo    }                                      |
+      {1:~                                            }|*2
+      {5:-- VISUAL BLOCK --}                           |
+    ]])
+    feed('10l')
+    screen:expect([[
+      {17:foobar          }^                             |
+      {17:foo              }                            |
+      {1:~                                            }|*2
+      {5:-- VISUAL BLOCK --}                           |
+    ]])
+  end)
+
   it('cterm=standout gui=standout', function()
     local screen = Screen.new(20, 5)
     screen:add_extra_attr_ids {


### PR DESCRIPTION
Problem:  Blockwise Visual selection not redrawn correctly when moving
          cursor for more than 1 cells with 'virtualedit'.
Solution: Restore the curswant update removed in 6679687bb3909f853ae97dfa01ae08ea2baf7f97.

Fix #34235
