### PR TITLE
vim-patch: various 'complete' features

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1178,6 +1178,9 @@ For example, the function can contain this: >
 	let matches = ... list of words ...
 	return {'words': matches, 'refresh': 'always'}
 <
+If looking for matches is time-consuming, |complete_check()| may be used to
+maintain responsiveness.
+
 						*complete-items*
 Each list item can either be a string or a Dictionary.  When it is a string it
 is used as the completion.  When it is a Dictionary it can contain these

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -178,6 +178,10 @@ OPTIONS
 • 'chistory' and 'lhistory' set size of the |quickfix-stack|.
 • 'completefuzzycollect' enables fuzzy collection of candidates for (some)
   |ins-completion| modes.
+• 'complete' new flags:
+  • "f{func}"   complete using given function
+  • "f"         complete using 'completefunc'
+  • "o"         complete using 'omnifunc'
 • 'completeopt' flag "nearset" sorts completion results by distance to cursor.
 • 'diffopt' `inline:` configures diff highlighting for changes within a line.
 • 'grepformat' is now a |global-local| option.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -182,6 +182,7 @@ OPTIONS
   • "f{func}"   complete using given function
   • "f"         complete using 'completefunc'
   • "o"         complete using 'omnifunc'
+• 'complete' allows limiting matches for sources using "{flag}^<limit>".
 • 'completeopt' flag "nearset" sorts completion results by distance to cursor.
 • 'diffopt' `inline:` configures diff highlighting for changes within a line.
 • 'grepformat' is now a |global-local| option.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -179,8 +179,8 @@ OPTIONS
 • 'completefuzzycollect' enables fuzzy collection of candidates for (some)
   |ins-completion| modes.
 • 'complete' new flags:
-  • "f{func}"   complete using given function
-  • "f"         complete using 'completefunc'
+  • "F{func}"   complete using given function
+  • "F"         complete using 'completefunc'
   • "o"         complete using 'omnifunc'
 • 'complete' allows limiting matches for sources using "{flag}^<limit>".
 • 'completeopt' flag "nearset" sorts completion results by distance to cursor.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1506,7 +1506,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	]	tag completion
 	t	same as "]"
 	f	scan the buffer names (as opposed to buffer contents)
-	f{func}	call the function {func}.  Multiple "f" flags may be specified.
+	F{func}	call the function {func}.  Multiple "F" flags may be specified.
 		Refer to |complete-functions| for details on how the function
 		is invoked and what it should return.  The value can be the
 		name of a function or a |Funcref|.  For |Funcref| values,
@@ -1524,9 +1524,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 		If generating matches is potentially slow, |complete_check()|
 		should be used to avoid blocking and preserve editor
 		responsiveness.
-	f	equivalent to using "f{func}", where the function is taken from
+	F	equivalent to using "F{func}", where the function is taken from
 		the 'completefunc' option.
-	o	equivalent to using "f{func}", where the function is taken from
+	o	equivalent to using "F{func}", where the function is taken from
 		the 'omnifunc' option.
 
 	Unloaded buffers are not loaded, thus their autocmds |:autocmd| are

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1506,7 +1506,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	]	tag completion
 	t	same as "]"
 	f	scan the buffer names (as opposed to buffer contents)
-	f{func}	call the function {func}. Multiple "f" flags may be specified.
+	f{func}	call the function {func}.  Multiple "f" flags may be specified.
 		Refer to |complete-functions| for details on how the function
 		is invoked and what it should return.  The value can be the
 		name of a function or a |Funcref|.  For |Funcref| values,
@@ -1541,9 +1541,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	An optional match limit can be specified for a completion source by
 	appending a caret ("^") followed by a {count} to the source flag.
 	For example: ".^9,w,u,t^5" limits matches from the current buffer
-	to 9 and from tags to 5. Other sources remain unlimited.
-	The match limit takes effect only during forward completion (CTRL-N)
-	and is ignored during backward completion (CTRL-P).
+	to 9 and from tags to 5.  Other sources remain unlimited.
+	Note: The match limit takes effect only during forward completion
+	(CTRL-N) and is ignored during backward completion (CTRL-P).
 
 						*'completefunc'* *'cfu'*
 'completefunc' 'cfu'	string	(default "")

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1538,6 +1538,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	based expansion (e.g., dictionary |i_CTRL-X_CTRL-K|, included patterns
 	|i_CTRL-X_CTRL-I|, tags |i_CTRL-X_CTRL-]| and normal expansions).
 
+	An optional match limit can be specified for a completion source by
+	appending a caret ("^") followed by a {count} to the source flag.
+	For example: ".^9,w,u,t^5" limits matches from the current buffer
+	to 9 and from tags to 5. Other sources remain unlimited.
+	The match limit takes effect only during forward completion (CTRL-N)
+	and is ignored during backward completion (CTRL-P).
+
 						*'completefunc'* *'cfu'*
 'completefunc' 'cfu'	string	(default "")
 			local to buffer

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1506,6 +1506,28 @@ A jump table for the options with a short description can be found at |Q_op|.
 	]	tag completion
 	t	same as "]"
 	f	scan the buffer names (as opposed to buffer contents)
+	f{func}	call the function {func}. Multiple "f" flags may be specified.
+		Refer to |complete-functions| for details on how the function
+		is invoked and what it should return.  The value can be the
+		name of a function or a |Funcref|.  For |Funcref| values,
+		spaces must be escaped with a backslash ('\'), and commas with
+		double backslashes ('\\') (see |option-backslash|).
+		If the Dict returned by the {func} includes {"refresh": "always"},
+		the function will be invoked again whenever the leading text
+		changes.
+		Completion matches are always inserted at the keyword
+		boundary, regardless of the column returned by {func} when
+		a:findstart is 1.  This ensures compatibility with other
+		completion sources.
+		To make further modifications to the inserted text, {func}
+		can make use of |CompleteDonePre|.
+		If generating matches is potentially slow, |complete_check()|
+		should be used to avoid blocking and preserve editor
+		responsiveness.
+	f	equivalent to using "f{func}", where the function is taken from
+		the 'completefunc' option.
+	o	equivalent to using "f{func}", where the function is taken from
+		the 'omnifunc' option.
 
 	Unloaded buffers are not loaded, thus their autocmds |:autocmd| are
 	not executed, this may lead to unexpected completions from some files

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1027,7 +1027,7 @@ vim.bo.cms = vim.bo.commentstring
 --- ]	tag completion
 --- t	same as "]"
 --- f	scan the buffer names (as opposed to buffer contents)
---- f{func}	call the function {func}. Multiple "f" flags may be specified.
+--- f{func}	call the function {func}.  Multiple "f" flags may be specified.
 --- 	Refer to `complete-functions` for details on how the function
 --- 	is invoked and what it should return.  The value can be the
 --- 	name of a function or a `Funcref`.  For `Funcref` values,
@@ -1062,9 +1062,9 @@ vim.bo.cms = vim.bo.commentstring
 --- An optional match limit can be specified for a completion source by
 --- appending a caret ("^") followed by a {count} to the source flag.
 --- For example: ".^9,w,u,t^5" limits matches from the current buffer
---- to 9 and from tags to 5. Other sources remain unlimited.
---- The match limit takes effect only during forward completion (CTRL-N)
---- and is ignored during backward completion (CTRL-P).
+--- to 9 and from tags to 5.  Other sources remain unlimited.
+--- Note: The match limit takes effect only during forward completion
+--- (CTRL-N) and is ignored during backward completion (CTRL-P).
 ---
 --- @type string
 vim.o.complete = ".,w,b,u,t"

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1027,6 +1027,28 @@ vim.bo.cms = vim.bo.commentstring
 --- ]	tag completion
 --- t	same as "]"
 --- f	scan the buffer names (as opposed to buffer contents)
+--- f{func}	call the function {func}. Multiple "f" flags may be specified.
+--- 	Refer to `complete-functions` for details on how the function
+--- 	is invoked and what it should return.  The value can be the
+--- 	name of a function or a `Funcref`.  For `Funcref` values,
+--- 	spaces must be escaped with a backslash ('\'), and commas with
+--- 	double backslashes ('\\') (see `option-backslash`).
+--- 	If the Dict returned by the {func} includes {"refresh": "always"},
+--- 	the function will be invoked again whenever the leading text
+--- 	changes.
+--- 	Completion matches are always inserted at the keyword
+--- 	boundary, regardless of the column returned by {func} when
+--- 	a:findstart is 1.  This ensures compatibility with other
+--- 	completion sources.
+--- 	To make further modifications to the inserted text, {func}
+--- 	can make use of `CompleteDonePre`.
+--- 	If generating matches is potentially slow, `complete_check()`
+--- 	should be used to avoid blocking and preserve editor
+--- 	responsiveness.
+--- f	equivalent to using "f{func}", where the function is taken from
+--- 	the 'completefunc' option.
+--- o	equivalent to using "f{func}", where the function is taken from
+--- 	the 'omnifunc' option.
 ---
 --- Unloaded buffers are not loaded, thus their autocmds `:autocmd` are
 --- not executed, this may lead to unexpected completions from some files

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1027,7 +1027,7 @@ vim.bo.cms = vim.bo.commentstring
 --- ]	tag completion
 --- t	same as "]"
 --- f	scan the buffer names (as opposed to buffer contents)
---- f{func}	call the function {func}.  Multiple "f" flags may be specified.
+--- F{func}	call the function {func}.  Multiple "F" flags may be specified.
 --- 	Refer to `complete-functions` for details on how the function
 --- 	is invoked and what it should return.  The value can be the
 --- 	name of a function or a `Funcref`.  For `Funcref` values,
@@ -1045,9 +1045,9 @@ vim.bo.cms = vim.bo.commentstring
 --- 	If generating matches is potentially slow, `complete_check()`
 --- 	should be used to avoid blocking and preserve editor
 --- 	responsiveness.
---- f	equivalent to using "f{func}", where the function is taken from
+--- F	equivalent to using "F{func}", where the function is taken from
 --- 	the 'completefunc' option.
---- o	equivalent to using "f{func}", where the function is taken from
+--- o	equivalent to using "F{func}", where the function is taken from
 --- 	the 'omnifunc' option.
 ---
 --- Unloaded buffers are not loaded, thus their autocmds `:autocmd` are

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1059,6 +1059,13 @@ vim.bo.cms = vim.bo.commentstring
 --- based expansion (e.g., dictionary `i_CTRL-X_CTRL-K`, included patterns
 --- `i_CTRL-X_CTRL-I`, tags `i_CTRL-X_CTRL-]` and normal expansions).
 ---
+--- An optional match limit can be specified for a completion source by
+--- appending a caret ("^") followed by a {count} to the source flag.
+--- For example: ".^9,w,u,t^5" limits matches from the current buffer
+--- to 9 and from tags to 5. Other sources remain unlimited.
+--- The match limit takes effect only during forward completion (CTRL-N)
+--- and is ignored during backward completion (CTRL-P).
+---
 --- @type string
 vim.o.complete = ".,w,b,u,t"
 vim.o.cpt = vim.o.complete

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -5809,7 +5809,7 @@ static void get_cpt_func_completion_matches(Callback *cb)
 /// 'refresh:always' flag is set.
 static void cpt_compl_refresh(void)
 {
-  Callback *cb;
+  Callback *cb = NULL;
 
   // Make the completion list linear (non-cyclic)
   ins_compl_make_linear();

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1394,7 +1394,7 @@ static int ins_compl_build_pum(void)
   bool fuzzy_sort = fuzzy_filter && !(cur_cot_flags & kOptCotFlagNosort);
 
   compl_T *match_head = NULL, *match_tail = NULL;
-  int match_count;
+  int match_count = 0;
   int cur_source = -1;
   bool max_matches_found = false;
   bool is_forward = compl_shows_dir_forward() && !fuzzy_filter;

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3548,7 +3548,7 @@ static int process_next_cpt_value(ins_compl_next_state_T *st, int *compl_type_ar
         st->dict = st->e_cpt;
         st->dict_f = DICT_FIRST;
       }
-    } else if (*st->e_cpt == 'f' || *st->e_cpt == 'o') {
+    } else if (*st->e_cpt == 'F' || *st->e_cpt == 'o') {
       compl_type = CTRL_X_FUNCTION;
       if (*st->e_cpt == 'o') {
         st->func_cb = &curbuf->b_ofu_cb;
@@ -3563,10 +3563,8 @@ static int process_next_cpt_value(ins_compl_next_state_T *st, int *compl_type_ar
       compl_type = CTRL_X_PATH_PATTERNS;
     } else if (*st->e_cpt == 'd') {
       compl_type = CTRL_X_PATH_DEFINES;
-#if 0
     } else if (*st->e_cpt == 'f') {
       compl_type = CTRL_X_BUFNAMES;
-#endif
     } else if (*st->e_cpt == ']' || *st->e_cpt == 't') {
       compl_type = CTRL_X_TAGS;
       if (!shortmess(SHM_COMPLETIONSCAN)) {
@@ -5934,7 +5932,7 @@ static void cpt_compl_refresh(void)
     if (cpt_sources_array[cpt_sources_index].refresh_always) {
       if (*p == 'o') {
         cb = &curbuf->b_ofu_cb;
-      } else if (*p == 'f') {
+      } else if (*p == 'F') {
         cb = (*(p + 1) != ',' && *(p + 1) != NUL)
              ? get_cpt_func_callback(p + 1) : &curbuf->b_cfu_cb;
       }

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1469,6 +1469,13 @@ local options = {
         As you can see, CTRL-N and CTRL-P can be used to do any 'iskeyword'-
         based expansion (e.g., dictionary |i_CTRL-X_CTRL-K|, included patterns
         |i_CTRL-X_CTRL-I|, tags |i_CTRL-X_CTRL-]| and normal expansions).
+
+        An optional match limit can be specified for a completion source by
+        appending a caret ("^") followed by a {count} to the source flag.
+        For example: ".^9,w,u,t^5" limits matches from the current buffer
+        to 9 and from tags to 5. Other sources remain unlimited.
+        The match limit takes effect only during forward completion (CTRL-N)
+        and is ignored during backward completion (CTRL-P).
       ]=],
       full_name = 'complete',
       list = 'onecomma',

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1412,7 +1412,7 @@ local options = {
       abbreviation = 'cpt',
       cb = 'did_set_complete',
       defaults = '.,w,b,u,t',
-      values = { '.', 'w', 'b', 'u', 'k', 'kspell', 's', 'i', 'd', ']', 't', 'U', 'f', 'o' },
+      values = { '.', 'w', 'b', 'u', 'k', 'kspell', 's', 'i', 'd', ']', 't', 'U', 'f', 'F', 'o' },
       deny_duplicates = true,
       desc = [=[
         This option specifies how keyword completion |ins-completion| works
@@ -1438,7 +1438,7 @@ local options = {
         ]	tag completion
         t	same as "]"
         f	scan the buffer names (as opposed to buffer contents)
-        f{func}	call the function {func}.  Multiple "f" flags may be specified.
+        F{func}	call the function {func}.  Multiple "F" flags may be specified.
         	Refer to |complete-functions| for details on how the function
         	is invoked and what it should return.  The value can be the
         	name of a function or a |Funcref|.  For |Funcref| values,
@@ -1456,9 +1456,9 @@ local options = {
         	If generating matches is potentially slow, |complete_check()|
         	should be used to avoid blocking and preserve editor
         	responsiveness.
-        f	equivalent to using "f{func}", where the function is taken from
+        F	equivalent to using "F{func}", where the function is taken from
         	the 'completefunc' option.
-        o	equivalent to using "f{func}", where the function is taken from
+        o	equivalent to using "F{func}", where the function is taken from
         	the 'omnifunc' option.
 
         Unloaded buffers are not loaded, thus their autocmds |:autocmd| are

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1412,7 +1412,7 @@ local options = {
       abbreviation = 'cpt',
       cb = 'did_set_complete',
       defaults = '.,w,b,u,t',
-      values = { '.', 'w', 'b', 'u', 'k', 'kspell', 's', 'i', 'd', ']', 't', 'U', 'f' },
+      values = { '.', 'w', 'b', 'u', 'k', 'kspell', 's', 'i', 'd', ']', 't', 'U', 'f', 'o' },
       deny_duplicates = true,
       desc = [=[
         This option specifies how keyword completion |ins-completion| works
@@ -1438,6 +1438,28 @@ local options = {
         ]	tag completion
         t	same as "]"
         f	scan the buffer names (as opposed to buffer contents)
+        f{func}	call the function {func}. Multiple "f" flags may be specified.
+        	Refer to |complete-functions| for details on how the function
+        	is invoked and what it should return.  The value can be the
+        	name of a function or a |Funcref|.  For |Funcref| values,
+        	spaces must be escaped with a backslash ('\'), and commas with
+        	double backslashes ('\\') (see |option-backslash|).
+        	If the Dict returned by the {func} includes {"refresh": "always"},
+        	the function will be invoked again whenever the leading text
+        	changes.
+        	Completion matches are always inserted at the keyword
+        	boundary, regardless of the column returned by {func} when
+        	a:findstart is 1.  This ensures compatibility with other
+        	completion sources.
+        	To make further modifications to the inserted text, {func}
+        	can make use of |CompleteDonePre|.
+        	If generating matches is potentially slow, |complete_check()|
+        	should be used to avoid blocking and preserve editor
+        	responsiveness.
+        f	equivalent to using "f{func}", where the function is taken from
+        	the 'completefunc' option.
+        o	equivalent to using "f{func}", where the function is taken from
+        	the 'omnifunc' option.
 
         Unloaded buffers are not loaded, thus their autocmds |:autocmd| are
         not executed, this may lead to unexpected completions from some files

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1438,7 +1438,7 @@ local options = {
         ]	tag completion
         t	same as "]"
         f	scan the buffer names (as opposed to buffer contents)
-        f{func}	call the function {func}. Multiple "f" flags may be specified.
+        f{func}	call the function {func}.  Multiple "f" flags may be specified.
         	Refer to |complete-functions| for details on how the function
         	is invoked and what it should return.  The value can be the
         	name of a function or a |Funcref|.  For |Funcref| values,
@@ -1473,9 +1473,9 @@ local options = {
         An optional match limit can be specified for a completion source by
         appending a caret ("^") followed by a {count} to the source flag.
         For example: ".^9,w,u,t^5" limits matches from the current buffer
-        to 9 and from tags to 5. Other sources remain unlimited.
-        The match limit takes effect only during forward completion (CTRL-N)
-        and is ignored during backward completion (CTRL-P).
+        to 9 and from tags to 5.  Other sources remain unlimited.
+        Note: The match limit takes effect only during forward completion
+        (CTRL-N) and is ignored during backward completion (CTRL-P).
       ]=],
       full_name = 'complete',
       list = 'onecomma',

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -45,6 +45,7 @@
 #include "nvim/spellfile.h"
 #include "nvim/spellsuggest.h"
 #include "nvim/strings.h"
+#include "nvim/tag.h"
 #include "nvim/terminal.h"
 #include "nvim/types_defs.h"
 #include "nvim/vim_defs.h"
@@ -54,10 +55,12 @@
 # include "optionstr.c.generated.h"
 #endif
 
-static const char e_unclosed_expression_sequence[]
-  = N_("E540: Unclosed expression sequence");
+static const char e_illegal_character_after_chr[]
+  = N_("E535: Illegal character after <%c>");
 static const char e_comma_required[]
   = N_("E536: Comma required");
+static const char e_unclosed_expression_sequence[]
+  = N_("E540: Unclosed expression sequence");
 static const char e_unbalanced_groups[]
   = N_("E542: Unbalanced groups");
 static const char e_backupext_and_patchmode_are_equal[]
@@ -836,40 +839,45 @@ const char *did_set_commentstring(optset_T *args)
   return NULL;
 }
 
-/// The 'complete' option is changed.
+/// Check if value for 'complete' is valid when 'complete' option is changed.
 const char *did_set_complete(optset_T *args)
 {
   char **varp = (char **)args->os_varp;
+  char buffer[LSIZE];
 
-  // check if it is a valid value for 'complete' -- Acevedo
-  for (char *s = *varp; *s;) {
-    while (*s == ',' || *s == ' ') {
-      s++;
-    }
-    if (!*s) {
-      break;
-    }
-    if (vim_strchr(".wbuksid]tUf", (uint8_t)(*s)) == NULL) {
-      return illegal_char(args->os_errbuf, args->os_errbuflen, (uint8_t)(*s));
-    }
-    if (*++s != NUL && *s != ',' && *s != ' ') {
-      if (s[-1] == 'k' || s[-1] == 's') {
-        // skip optional filename after 'k' and 's'
-        while (*s && *s != ',' && *s != ' ') {
-          if (*s == '\\' && s[1] != NUL) {
-            s++;
-          }
-          s++;
-        }
+  for (char *p = *varp; *p;) {
+    memset(buffer, 0, LSIZE);
+    char *buf_ptr = buffer;
+    int escape = 0;
+
+    // Extract substring while handling escaped commas
+    while (*p && (*p != ',' || escape) && buf_ptr < (buffer + LSIZE - 1)) {
+      if (*p == '\\' && *(p + 1) == ',') {
+        escape = 1;  // Mark escape mode
+        p++;         // Skip '\'
       } else {
-        if (args->os_errbuf != NULL) {
-          vim_snprintf(args->os_errbuf, args->os_errbuflen,
-                       _("E535: Illegal character after <%c>"),
-                       *--s);
-          return args->os_errbuf;
-        }
-        return "";
+        escape = 0;
+        *buf_ptr++ = *p;
       }
+      p++;
+    }
+    *buf_ptr = NUL;
+
+    if (vim_strchr(".wbuksid]tUfo", (uint8_t)(*buffer)) == NULL) {
+      return illegal_char(args->os_errbuf, args->os_errbuflen, (uint8_t)(*buffer));
+    }
+
+    if (!vim_strchr("ksf", (uint8_t)(*buffer)) && *(buffer + 1) != NUL) {
+      if (args->os_errbuf != NULL) {
+        vim_snprintf(args->os_errbuf, args->os_errbuflen,
+                     _(e_illegal_character_after_chr), (uint8_t)(*buffer));
+        return args->os_errbuf;
+      }
+    }
+
+    // Skip comma and spaces
+    while (*p == ',' || *p == ' ') {
+      p++;
     }
   }
   return NULL;

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -864,11 +864,11 @@ const char *did_set_complete(optset_T *args)
     }
     *buf_ptr = NUL;
 
-    if (vim_strchr(".wbuksid]tUfo", (uint8_t)(*buffer)) == NULL) {
+    if (vim_strchr(".wbuksid]tUfFo", (uint8_t)(*buffer)) == NULL) {
       return illegal_char(args->os_errbuf, args->os_errbuflen, (uint8_t)(*buffer));
     }
 
-    if (vim_strchr("ksf", (uint8_t)(*buffer)) == NULL && *(buffer + 1) != NUL
+    if (vim_strchr("ksF", (uint8_t)(*buffer)) == NULL && *(buffer + 1) != NUL
         && *(buffer + 1) != '^') {
       char_before = (uint8_t)(*buffer);
     } else {

--- a/src/nvim/popupmenu.h
+++ b/src/nvim/popupmenu.h
@@ -16,6 +16,7 @@ typedef struct {
   char *pum_info;       ///< extra info
   int pum_score;        ///< fuzzy match score
   int pum_idx;          ///< index of item before sorting by score
+  int pum_cpt_source_idx;    ///< index of completion source in 'cpt'
   int pum_user_abbr_hlattr;  ///< highlight attribute for abbr
   int pum_user_kind_hlattr;  ///< highlight attribute for kind
 } pumitem_T;

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -4319,7 +4319,33 @@ func Test_complete_match_count()
   call assert_equal('abac', getline(4))
   bw!
 
-  set completeopt& complete&
+  " Items with '\n' that cause menu to shift, with no leader (issue #17394)
+  func! ComplFunc(findstart, base)
+    if a:findstart == 1
+      return col('.')  - 1
+    endif
+    return ["one\ntwo\nthree", "four five six", "hello\nworld\nhere"]
+  endfunc
+  set completeopt=menuone,popup,noselect,fuzzy infercase
+  set complete=.^1,FComplFunc^5
+  new
+  call setline(1, ["foo", "bar", "baz"])
+  execute "normal Go\<c-n>\<c-n>\<c-n>"
+  call assert_equal(['one', 'two', 'three'], getline(4, 6))
+  %d
+  call setline(1, ["foo", "bar", "baz"])
+  execute "normal Go\<c-n>\<c-n>\<c-n>\<c-p>"
+  call assert_equal('foo', getline(4))
+  execute "normal S\<c-n>\<c-n>\<c-n>\<c-n>\<c-n>\<c-n>\<c-n>"
+  call assert_equal('foo', getline(4))
+  set complete=.^1,FComplFunc^2
+  execute "normal S\<c-n>\<c-n>\<c-n>\<c-n>\<c-n>\<c-n>"
+  call assert_equal('foo', getline(4))
+  execute "normal S\<c-n>\<c-p>\<c-p>\<c-p>\<c-n>\<c-n>"
+  call assert_equal('four five six', getline(4))
+  bw!
+
+  set completeopt& complete& infercase&
   delfunc PrintMenuWords
   delfunc ComplFunc
   delfunc CompleteItemsSelect

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -199,7 +199,7 @@ func Test_completefunc_args()
   call assert_equal(0, s:args[1][0])
   set omnifunc=
 
-  set complete=fCompleteFunc
+  set complete=FCompleteFunc
   call feedkeys("i\<C-N>\<Esc>", 'x')
   call assert_equal([1, 1], s:args[0])
   call assert_equal(0, s:args[1][0])
@@ -275,7 +275,7 @@ func Test_CompleteDoneNone()
   call assert_equal(oldline, newline)
   let s:called_completedone = 0
 
-  set complete=f<SID>CompleteDone_CompleteFuncNone
+  set complete=F<SID>CompleteDone_CompleteFuncNone
   execute "normal a\<C-N>\<C-Y>"
   set complete&
   let newline = join(map(range(&columns), 'nr2char(screenchar(&lines-1, v:val+1))'), '')
@@ -302,7 +302,7 @@ func Test_CompleteDone_vevent_keys()
   endfunc
   set omnifunc=CompleteFunc
   set completefunc=CompleteFunc
-  set complete=.,fCompleteFunc
+  set complete=.,FCompleteFunc
   set completeopt+=menuone
 
   new
@@ -394,7 +394,7 @@ func Test_CompleteDoneDict()
   au CompleteDonePre * :call <SID>CompleteDone_CheckCompletedItemDict(2)
   au CompleteDone * :call <SID>CompleteDone_CheckCompletedItemDict(0)
 
-  set complete=.,f<SID>CompleteDone_CompleteFuncDict
+  set complete=.,F<SID>CompleteDone_CompleteFuncDict
   execute "normal a\<C-N>\<C-Y>"
   set complete&
 
@@ -447,7 +447,7 @@ func Test_CompleteDoneDictNoUserData()
 
   let s:called_completedone = 0
 
-  set complete=.,f<SID>CompleteDone_CompleteFuncDictNoUserData
+  set complete=.,F<SID>CompleteDone_CompleteFuncDictNoUserData
   execute "normal a\<C-N>\<C-Y>"
   set complete&
 
@@ -489,7 +489,7 @@ func Test_CompleteDoneList()
 
   let s:called_completedone = 0
 
-  set complete=.,f<SID>CompleteDone_CompleteFuncList
+  set complete=.,F<SID>CompleteDone_CompleteFuncList
   execute "normal a\<C-N>\<C-Y>"
   set complete&
 
@@ -498,7 +498,7 @@ func Test_CompleteDoneList()
 
   let s:called_completedone = 0
 
-  set complete=.,f
+  set complete=.,F
   execute "normal a\<C-N>\<C-Y>"
   set complete&
 
@@ -549,11 +549,11 @@ func Test_completefunc_info()
   call feedkeys("i\<C-X>\<C-U>\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
   call assert_equal("matched{'pum_visible': 1, 'mode': 'function', 'selected': 0, 'items': [{'word': 'matched', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}]}", getline(1))
   %d
-  set complete=.,fCompleteTest
+  set complete=.,FCompleteTest
   call feedkeys("i\<C-N>\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
   call assert_equal("matched{'pum_visible': 1, 'mode': 'keyword', 'selected': 0, 'items': [{'word': 'matched', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}]}", getline(1))
   %d
-  set complete=.,f
+  set complete=.,F
   call feedkeys("i\<C-N>\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
   call assert_equal("matched{'pum_visible': 1, 'mode': 'keyword', 'selected': 0, 'items': [{'word': 'matched', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}]}", getline(1))
   set completeopt&
@@ -573,7 +573,7 @@ func Test_cpt_func_cursorcol()
     " return v:none
   endfunc
 
-  set complete=fCptColTest
+  set complete=FCptColTest
   new
   call feedkeys("ifoo bar\<C-N>", "tx")
   bwipe!
@@ -666,12 +666,12 @@ func CompleteInfoTestUserDefinedFn(mvmt, idx, noselect)
   let completed = a:idx != -1 ? ['foo', 'bar', 'baz', 'qux']->get(a:idx) : ''
   call assert_equal(completed. "{'pum_visible': 1, 'mode': 'function', 'selected': " . a:idx . ", 'items': " . items . "}", getline(1))
   %d
-  set complete=.,fCompleteInfoUserDefinedFn
+  set complete=.,FCompleteInfoUserDefinedFn
   call feedkeys("i\<C-N>" . a:mvmt . "\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
   let completed = a:idx != -1 ? ['foo', 'bar', 'baz', 'qux']->get(a:idx) : ''
   call assert_equal(completed. "{'pum_visible': 1, 'mode': 'keyword', 'selected': " . a:idx . ", 'items': " . items . "}", getline(1))
   %d
-  set complete=.,f
+  set complete=.,F
   call feedkeys("i\<C-N>" . a:mvmt . "\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
   let completed = a:idx != -1 ? ['foo', 'bar', 'baz', 'qux']->get(a:idx) : ''
   call assert_equal(completed. "{'pum_visible': 1, 'mode': 'keyword', 'selected': " . a:idx . ", 'items': " . items . "}", getline(1))
@@ -1044,9 +1044,9 @@ func Test_completefunc_error()
   set completefunc=CompleteFunc
   call setline(1, ['', 'abcd', ''])
   call assert_fails('exe "normal 2G$a\<C-X>\<C-U>"', 'E565:')
-  set complete=fCompleteFunc
+  set complete=FCompleteFunc
   call assert_fails('exe "normal 2G$a\<C-N>"', 'E565:')
-  set complete=f
+  set complete=F
   call assert_fails('exe "normal 2G$a\<C-N>"', 'E565:')
 
   " delete text when called for the second time
@@ -1060,9 +1060,9 @@ func Test_completefunc_error()
   set completefunc=CompleteFunc2
   call setline(1, ['', 'abcd', ''])
   call assert_fails('exe "normal 2G$a\<C-X>\<C-U>"', 'E565:')
-  set complete=fCompleteFunc2
+  set complete=FCompleteFunc2
   call assert_fails('exe "normal 2G$a\<C-N>"', 'E565:')
-  set complete=f
+  set complete=F
   call assert_fails('exe "normal 2G$a\<C-N>"', 'E565:')
 
   " Jump to a different window from the complete function
@@ -1077,10 +1077,10 @@ func Test_completefunc_error()
   new
   call assert_fails('exe "normal a\<C-X>\<C-U>"', 'E565:')
   %d
-  set complete=fCompleteFunc3
+  set complete=FCompleteFunc3
   call assert_fails('exe "normal a\<C-N>"', 'E565:')
   %d
-  set complete=f
+  set complete=F
   call assert_fails('exe "normal a\<C-N>"', 'E565:')
   close!
 
@@ -1104,11 +1104,11 @@ func Test_completefunc_invalid_data()
   exe "normal i\<C-X>\<C-U>"
   call assert_equal('moon', getline(1))
   %d
-  set complete=fCompleteFunc
+  set complete=FCompleteFunc
   exe "normal i\<C-N>"
   call assert_equal('moon', getline(1))
   %d
-  set complete=f
+  set complete=F
   exe "normal i\<C-N>"
   call assert_equal('moon', getline(1))
   set completefunc& complete&
@@ -1796,13 +1796,13 @@ func Test_complete_item_refresh_always()
   call assert_equal(6, g:CallCount)
   %d
   let g:CallCount = 0
-  set complete=fTcomplete
+  set complete=FTcomplete
   exe "normal! iup\<C-N>\<BS>\<BS>\<BS>\<BS>\<BS>"
   call assert_equal('up', getline(1))
   call assert_equal(6, g:CallCount)
   %d
   let g:CallCount = 0
-  set complete=f
+  set complete=F
   exe "normal! iup\<C-N>\<BS>\<BS>\<BS>\<BS>\<BS>"
   call assert_equal('up', getline(1))
   call assert_equal(6, g:CallCount)
@@ -1829,10 +1829,10 @@ func Test_cpt_func_refresh_always_fail()
     call assert_equal(-999, a:findstart) " Should not reach here
   endfunc
   new
-  set complete=ffunction('CompleteFail'\\,\ [-2])
+  set complete=Ffunction('CompleteFail'\\,\ [-2])
   exe "normal! ia\<C-N>"
   %d
-  set complete=ffunction('CompleteFail'\\,\ [-3])
+  set complete=Ffunction('CompleteFail'\\,\ [-3])
   exe "normal! ia\<C-N>"
   bw!
 
@@ -1850,7 +1850,7 @@ func Test_cpt_func_refresh_always_fail()
   endfunc
   new
   set completeopt=menuone,noselect
-  set complete=ffunction('CompleteFailIntermittent'\\,\ [-2])
+  set complete=Ffunction('CompleteFailIntermittent'\\,\ [-2])
   let g:CallCount = 0
   exe "normal! if\<C-N>\<c-r>=complete_info([\"items\"])\<cr>"
   call assert_match('''word'': ''foo''.*''word'': ''fbar''', getline(1))
@@ -1861,13 +1861,13 @@ func Test_cpt_func_refresh_always_fail()
   call assert_match('''selected'': -1.*''word'': ''foo1''.*''word'': ''foo2''', getline(1))
   call assert_equal(2, g:CallCount)
   %d
-  set complete=ffunction('CompleteFailIntermittent'\\,\ [-3])
+  set complete=Ffunction('CompleteFailIntermittent'\\,\ [-3])
   let g:CallCount = 0
   exe "normal! if\<C-N>o\<c-r>=complete_info([\"items\", \"selected\"])\<cr>"
   call assert_match('''selected'': -1.*''word'': ''foo1''.*''word'': ''foo2''', getline(1))
   call assert_equal(2, g:CallCount)
   %d
-  set complete=ffunction('CompleteFailIntermittent'\\,\ [-2])
+  set complete=Ffunction('CompleteFailIntermittent'\\,\ [-2])
   " completion mode is dismissed when there are no matches in list
   let g:CallCount = 0
   exe "normal! if\<C-N>oo\<c-r>=complete_info([\"items\"])\<cr>"
@@ -1880,7 +1880,7 @@ func Test_cpt_func_refresh_always_fail()
   call assert_equal(3, g:CallCount)
   %d
   " completion mode continues when matches from other sources present
-  set complete=.,ffunction('CompleteFailIntermittent'\\,\ [-2])
+  set complete=.,Ffunction('CompleteFailIntermittent'\\,\ [-2])
   call setline(1, 'fooo1')
   let g:CallCount = 0
   exe "normal! Gof\<C-N>oo\<c-r>=complete_info([\"items\", \"selected\"])\<cr>"
@@ -1896,7 +1896,7 @@ func Test_cpt_func_refresh_always_fail()
   call assert_equal(4, g:CallCount)
   %d
   " refresh will stop when -3 is returned
-  set complete=.,,\ ffunction('CompleteFailIntermittent'\\,\ [-3])
+  set complete=.,,\ Ffunction('CompleteFailIntermittent'\\,\ [-3])
   call setline(1, 'fooo1')
   let g:CallCount = 0
   exe "normal! Gof\<C-N>o\<bs>\<c-r>=complete_info([\"items\", \"selected\"])\<cr>"
@@ -1941,7 +1941,7 @@ func Test_cpt_select_item_refresh_always()
   endfunc
 
   new
-  set complete=.,ffunction('CompleteItemsSelect'\\,\ [[]])
+  set complete=.,Ffunction('CompleteItemsSelect'\\,\ [[]])
   call setline(1, "foobarbar")
   let g:CallCount = 0
   exe "normal! Gof\<c-n>\<c-n>\<c-r>=CompleteMenuWords()\<cr>"
@@ -1973,7 +1973,7 @@ func Test_cpt_select_item_refresh_always()
   call assert_equal(2, g:CallCount)
 
   %d
-  set complete=.,ffunction('CompleteItemsSelect'\\,\ [['foonext']])
+  set complete=.,Ffunction('CompleteItemsSelect'\\,\ [['foonext']])
   call setline(1, "foobarbar")
   let g:CallCount = 0
   exe "normal! Gof\<c-n>\<c-n>\<bs>\<c-r>=CompleteMenuWords()\<cr>"
@@ -2013,7 +2013,7 @@ func Test_cpt_select_item_refresh_always()
   call assert_equal(3, g:CallCount)
 
   %d
-  set complete=.,ffunction('CompleteItemsSelect'\\,\ [['fo'\\,\ 'foonext']])
+  set complete=.,Ffunction('CompleteItemsSelect'\\,\ [['fo'\\,\ 'foonext']])
   call setline(1, "foobarbar")
   let g:CallCount = 0
   exe "normal! Gof\<c-n>\<c-n>\<bs>\<c-r>=CompleteMenuWords()\<cr>"
@@ -2065,7 +2065,7 @@ func Test_cpt_multi_func_refresh_always()
   call assert_equal("f\x0e" . '{''matches'': [], ''selected'': -1}', getline(1))
 
   set completeopt=menuone,noselect
-  set complete=fCompleteItems1,fCompleteItems2
+  set complete=FCompleteItems1,FCompleteItems2
 
   new
   let g:CallCount1 = 0
@@ -2197,7 +2197,7 @@ func Test_cpt_func_callback()
 
   let lines =<< trim END
     #" Test for using a global function name
-    set complete=fg:CompleteFunc2
+    set complete=Fg:CompleteFunc2
     new
     call setline(1, 'global')
     LET g:CompleteFunc2Args = []
@@ -2207,7 +2207,7 @@ func Test_cpt_func_callback()
     bw!
 
     #" Test for using a function()
-    set complete=ffunction('g:CompleteFunc1'\\,\ [10])
+    set complete=Ffunction('g:CompleteFunc1'\\,\ [10])
     new
     call setline(1, 'one')
     LET g:CompleteFunc1Args = []
@@ -2217,7 +2217,7 @@ func Test_cpt_func_callback()
     bw!
 
     #" Using a funcref variable
-    set complete=ffuncref('g:CompleteFunc1'\\,\ [11])
+    set complete=Ffuncref('g:CompleteFunc1'\\,\ [11])
     new
     call setline(1, 'two')
     LET g:CompleteFunc1Args = []
@@ -2234,7 +2234,7 @@ func Test_cpt_func_callback()
     call add(g:CompleteFunc3Args, [a:findstart, a:base])
     return a:findstart ? 0 : []
   endfunc
-  set complete=fs:CompleteFunc3
+  set complete=Fs:CompleteFunc3
   new
   call setline(1, 'script1')
   let g:CompleteFunc3Args = []
@@ -2243,7 +2243,7 @@ func Test_cpt_func_callback()
   set complete&
   bw!
 
-  let &complete = 'fs:CompleteFunc3'
+  let &complete = 'Fs:CompleteFunc3'
   new
   call setline(1, 'script2')
   let g:CompleteFunc3Args = []
@@ -2261,7 +2261,7 @@ func Test_cpt_func_callback()
         add(CompleteFunc4Args, [findstart, base])
         return findstart ? 0 : []
       enddef
-      set complete=fCompleteFunc4
+      set complete=FCompleteFunc4
       new
       setline(1, 'script1')
       feedkeys("A\<C-N>\<Esc>", 'x')
@@ -2281,7 +2281,7 @@ func Test_cpt_func_callback()
     enddef
 
     # Test for using a def function with completefunc
-    set complete=ffunction('Vim9CompleteFunc'\\,\ [60])
+    set complete=Ffunction('Vim9CompleteFunc'\\,\ [60])
     new | only
     setline(1, 'one')
     g:Vim9completeFuncArgs = []
@@ -2290,7 +2290,7 @@ func Test_cpt_func_callback()
     bw!
 
     # Test for using a global function name
-    &complete = 'fg:CompleteFunc2'
+    &complete = 'Fg:CompleteFunc2'
     new | only
     setline(1, 'two')
     g:CompleteFunc2Args = []
@@ -2303,7 +2303,7 @@ func Test_cpt_func_callback()
       add(g:LocalCompleteFuncArgs, [findstart, base])
       return findstart ? 0 : []
     enddef
-    &complete = 'fLocalCompleteFunc'
+    &complete = 'FLocalCompleteFunc'
     new | only
     setline(1, 'three')
     g:LocalCompleteFuncArgs = []
@@ -3202,12 +3202,12 @@ func Test_complete_smartindent()
   let result = getline(1,'$')
   call assert_equal(['', '{','}',''], result)
   %d
-  setlocal complete=fFooBarComplete
+  setlocal complete=FFooBarComplete
   exe "norm! o{\<cr>\<c-n>\<c-p>}\<cr>\<esc>"
   let result = getline(1,'$')
   call assert_equal(['', '{','}',''], result)
   %d
-  setlocal complete=f
+  setlocal complete=F
   exe "norm! o{\<cr>\<c-n>\<c-p>}\<cr>\<esc>"
   let result = getline(1,'$')
   call assert_equal(['', '{','}',''], result)
@@ -4202,7 +4202,7 @@ func Test_complete_match_count()
 
   %d
   set completefunc=ComplFunc
-  set cpt=.^1,f^2
+  set cpt=.^1,F^2
   call setline(1, ["fo", "foo", "foobar", "fobarbaz"])
   exe "normal! Gof\<c-n>\<c-r>=PrintMenuWords()\<cr>"
   call assert_equal('fo{''matches'': [''fo'', ''foo1'', ''foo2''], ''selected'': 0}', getline(5))
@@ -4237,7 +4237,7 @@ func Test_complete_match_count()
 
   %d
   call setline(1, ["foo"])
-  set cpt=fComplFunc^2,.
+  set cpt=FComplFunc^2,.
   exe "normal! Gof\<c-n>\<c-r>=PrintMenuWords()\<cr>"
   call assert_equal('foo1{''matches'': [''foo1'', ''foo2'', ''foo''], ''selected'': 0}', getline(2))
   bw!
@@ -4254,7 +4254,7 @@ func Test_complete_match_count()
   endfunc
 
   new
-  set complete=.,ffunction('CompleteItemsSelect')^2
+  set complete=.,Ffunction('CompleteItemsSelect')^2
   call setline(1, "foobarbar")
   let g:CallCount = 0
   exe "normal! Gof\<c-n>\<c-n>\<c-r>=PrintMenuWords()\<cr>"

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -4159,7 +4159,7 @@ func Test_complete_multiline_marks()
 endfunc
 
 func Test_complete_match_count()
-  func PrintMenuWords()
+  func! PrintMenuWords()
     let info = complete_info(["selected", "matches"])
     call map(info.matches, {_, v -> v.word})
     return info
@@ -4279,8 +4279,50 @@ func Test_complete_match_count()
   call assert_equal(3, g:CallCount)
   bw!
 
+  " Test 'fuzzy' with max_items
+  " XXX: Cannot use complete_info() since it is broken for 'fuzzy'
+  new
+  set completeopt=menu,noselect,fuzzy
+  set complete=.
+  call setline(1, ["abcd", "abac", "abdc"])
+  execute "normal Goa\<c-n>c\<c-n>"
+  call assert_equal('abac', getline(4))
+  execute "normal Sa\<c-n>c\<c-n>\<c-n>\<c-n>\<c-n>\<c-n>"
+  call assert_equal('abac', getline(4))
+  set complete=.^1
+  execute "normal Sa\<c-n>c\<c-n>\<c-n>\<c-n>"
+  call assert_equal('abac', getline(4))
+  set complete=.^2
+  execute "normal Sa\<c-n>c\<c-n>\<c-n>\<c-n>\<c-n>"
+  call assert_equal('abac', getline(4))
+  set complete=.^3
+  execute "normal Sa\<c-n>c\<c-n>\<c-n>\<c-n>\<c-n>\<c-n>"
+  call assert_equal('abac', getline(4))
+  set complete=.^4
+  execute "normal Sa\<c-n>c\<c-n>\<c-n>\<c-n>\<c-n>\<c-n>"
+  call assert_equal('abac', getline(4))
+
+  func! ComplFunc(findstart, base)
+    if a:findstart
+      return col(".")
+    endif
+    return ["abcde", "abacr"]
+  endfunc
+
+  set complete=.,FComplFunc^1
+  execute "normal Sa\<c-n>c\<c-n>\<c-n>"
+  call assert_equal('abacr', getline(4))
+  execute "normal Sa\<c-n>c\<c-n>\<c-n>\<c-n>\<c-n>\<c-n>\<c-n>"
+  call assert_equal('abac', getline(4))
+  set complete=.^1,FComplFunc^1
+  execute "normal Sa\<c-n>c\<c-n>\<c-n>\<c-n>\<c-n>"
+  call assert_equal('abac', getline(4))
+  bw!
+
   set completeopt& complete&
   delfunc PrintMenuWords
+  delfunc ComplFunc
+  delfunc CompleteItemsSelect
 endfunc
 
 func Test_complete_append_selected_match_default()
@@ -4402,7 +4444,7 @@ endfunc
 " Test 'nearest' flag of 'completeopt'
 func Test_nearest_cpt_option()
 
-  func PrintMenuWords()
+  func! PrintMenuWords()
     let info = complete_info(["selected", "matches"])
     call map(info.matches, {_, v -> v.word})
     return info

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -134,10 +134,15 @@ func Test_omni_dash()
   new
   exe "normal Gofind -\<C-x>\<C-o>"
   call assert_equal("find -help", getline('$'))
+  %d
+  set complete=o
+  exe "normal Gofind -\<C-n>"
+  " 'complete' inserts at 'iskeyword' boundary (so you get --help)
+  call assert_equal("find --help", getline('$'))
 
   bwipe!
   delfunc Omni
-  set omnifunc=
+  set omnifunc= complete&
 endfunc
 
 func Test_omni_throw()
@@ -157,11 +162,21 @@ func Test_omni_throw()
     call assert_exception('he he he')
     call assert_equal(1, g:CallCount)
   endtry
+  %d
+  set complete=o
+  let g:CallCount = 0
+  try
+    exe "normal ifoo\<C-n>"
+    call assert_false(v:true, 'command should have failed')
+  catch
+    call assert_exception('he he he')
+    call assert_equal(1, g:CallCount)
+  endtry
 
   bwipe!
   delfunc Omni
   unlet g:CallCount
-  set omnifunc=
+  set omnifunc= complete&
 endfunc
 
 func Test_completefunc_args()
@@ -183,6 +198,16 @@ func Test_completefunc_args()
   call assert_equal([1, 1], s:args[0])
   call assert_equal(0, s:args[1][0])
   set omnifunc=
+
+  set complete=fCompleteFunc
+  call feedkeys("i\<C-N>\<Esc>", 'x')
+  call assert_equal([1, 1], s:args[0])
+  call assert_equal(0, s:args[1][0])
+  set complete=o
+  call feedkeys("i\<C-N>\<Esc>", 'x')
+  call assert_equal([1, 1], s:args[0])
+  call assert_equal(0, s:args[1][0])
+  set complete&
 
   bwipe!
   unlet s:args
@@ -230,7 +255,7 @@ func s:CompleteDone_CheckCompletedItemDict(pre)
   call assert_equal( ['one', 'two'],   v:completed_item[ 'user_data' ] )
 
   if a:pre
-    call assert_equal('function', complete_info().mode)
+    call assert_equal(a:pre == 1 ? 'function' : 'keyword', complete_info().mode)
   endif
 
   let s:called_completedone = 1
@@ -248,7 +273,15 @@ func Test_CompleteDoneNone()
 
   call assert_true(s:called_completedone)
   call assert_equal(oldline, newline)
+  let s:called_completedone = 0
 
+  set complete=f<SID>CompleteDone_CompleteFuncNone
+  execute "normal a\<C-N>\<C-Y>"
+  set complete&
+  let newline = join(map(range(&columns), 'nr2char(screenchar(&lines-1, v:val+1))'), '')
+
+  call assert_true(s:called_completedone)
+  call assert_equal(oldline, newline)
   let s:called_completedone = 0
   au! CompleteDone
 endfunc
@@ -269,6 +302,7 @@ func Test_CompleteDone_vevent_keys()
   endfunc
   set omnifunc=CompleteFunc
   set completefunc=CompleteFunc
+  set complete=.,fCompleteFunc
   set completeopt+=menuone
 
   new
@@ -292,7 +326,11 @@ func Test_CompleteDone_vevent_keys()
   call assert_equal('vim', g:complete_word)
   call assert_equal('keyword', g:complete_type)
 
-  call feedkeys("Shello vim visual v\<C-X>\<C-N>\<C-Y>", 'tx')
+  call feedkeys("Shello vim visual v\<C-N>\<ESC>", 'tx')
+  call assert_equal('', g:complete_word)
+  call assert_equal('keyword', g:complete_type)
+
+  call feedkeys("Shello vim visual v\<C-N>\<C-Y>", 'tx')
   call assert_equal('vim', g:complete_word)
   call assert_equal('keyword', g:complete_type)
 
@@ -350,6 +388,21 @@ func Test_CompleteDoneDict()
   call assert_true(s:called_completedone)
 
   let s:called_completedone = 0
+  au! CompleteDonePre
+  au! CompleteDone
+
+  au CompleteDonePre * :call <SID>CompleteDone_CheckCompletedItemDict(2)
+  au CompleteDone * :call <SID>CompleteDone_CheckCompletedItemDict(0)
+
+  set complete=.,f<SID>CompleteDone_CompleteFuncDict
+  execute "normal a\<C-N>\<C-Y>"
+  set complete&
+
+  call assert_equal(['one', 'two'], v:completed_item[ 'user_data' ])
+  call assert_true(s:called_completedone)
+
+  let s:called_completedone = 0
+  au! CompleteDonePre
   au! CompleteDone
 endfunc
 
@@ -393,6 +446,15 @@ func Test_CompleteDoneDictNoUserData()
   call assert_true(s:called_completedone)
 
   let s:called_completedone = 0
+
+  set complete=.,f<SID>CompleteDone_CompleteFuncDictNoUserData
+  execute "normal a\<C-N>\<C-Y>"
+  set complete&
+
+  call assert_equal('', v:completed_item[ 'user_data' ])
+  call assert_true(s:called_completedone)
+
+  let s:called_completedone = 0
   au! CompleteDone
 endfunc
 
@@ -421,6 +483,24 @@ func Test_CompleteDoneList()
   set completefunc=<SID>CompleteDone_CompleteFuncList
   execute "normal a\<C-X>\<C-U>\<C-Y>"
   set completefunc&
+
+  call assert_equal('', v:completed_item[ 'user_data' ])
+  call assert_true(s:called_completedone)
+
+  let s:called_completedone = 0
+
+  set complete=.,f<SID>CompleteDone_CompleteFuncList
+  execute "normal a\<C-N>\<C-Y>"
+  set complete&
+
+  call assert_equal('', v:completed_item[ 'user_data' ])
+  call assert_true(s:called_completedone)
+
+  let s:called_completedone = 0
+
+  set complete=.,f
+  execute "normal a\<C-N>\<C-Y>"
+  set complete&
 
   call assert_equal('', v:completed_item[ 'user_data' ])
   call assert_true(s:called_completedone)
@@ -468,9 +548,49 @@ func Test_completefunc_info()
   set completefunc=CompleteTest
   call feedkeys("i\<C-X>\<C-U>\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
   call assert_equal("matched{'pum_visible': 1, 'mode': 'function', 'selected': 0, 'items': [{'word': 'matched', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}]}", getline(1))
-  bwipe!
+  %d
+  set complete=.,fCompleteTest
+  call feedkeys("i\<C-N>\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
+  call assert_equal("matched{'pum_visible': 1, 'mode': 'keyword', 'selected': 0, 'items': [{'word': 'matched', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}]}", getline(1))
+  %d
+  set complete=.,f
+  call feedkeys("i\<C-N>\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
+  call assert_equal("matched{'pum_visible': 1, 'mode': 'keyword', 'selected': 0, 'items': [{'word': 'matched', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}]}", getline(1))
   set completeopt&
+  set complete&
   set completefunc&
+endfunc
+
+func Test_cpt_func_cursorcol()
+  func CptColTest(findstart, query)
+    if a:findstart
+      call assert_equal("foo bar", getline(1))
+      call assert_equal(8, col('.'))
+      return col('.')
+    endif
+    call assert_equal("foo bar", getline(1))
+    call assert_equal(8, col('.'))
+    " return v:none
+  endfunc
+
+  set complete=fCptColTest
+  new
+  call feedkeys("ifoo bar\<C-N>", "tx")
+  bwipe!
+  new
+  set completeopt=longest
+  call feedkeys("ifoo bar\<C-N>", "tx")
+  bwipe!
+  new
+  set completeopt=menuone
+  call feedkeys("ifoo bar\<C-N>", "tx")
+  bwipe!
+  new
+  set completeopt=menuone,preinsert
+  call feedkeys("ifoo bar\<C-N>", "tx")
+  bwipe!
+  set complete& completeopt&
+  delfunc CptColTest
 endfunc
 
 func ScrollInfoWindowUserDefinedFn(findstart, query)
@@ -529,24 +649,34 @@ func CompleteInfoUserDefinedFn(findstart, query)
 endfunc
 
 func CompleteInfoTestUserDefinedFn(mvmt, idx, noselect)
-  new
   if a:noselect
     set completeopt=menuone,popup,noinsert,noselect
   else
     set completeopt=menu,preview
   endif
-  set completefunc=CompleteInfoUserDefinedFn
-  call feedkeys("i\<C-X>\<C-U>" . a:mvmt . "\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
-  let completed = a:idx != -1 ? ['foo', 'bar', 'baz', 'qux']->get(a:idx) : ''
-  call assert_equal(completed. "{'pum_visible': 1, 'mode': 'function', 'selected': " . a:idx . ", 'items': [" .
+  let items = "[" .
         \ "{'word': 'foo', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}, " .
         \ "{'word': 'bar', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}, " .
         \ "{'word': 'baz', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}, " .
         \ "{'word': 'qux', 'menu': '', 'user_data': '', 'info': '', 'kind': '', 'abbr': ''}" .
-        \ "]}", getline(1))
+        \ "]"
+  new
+  set completefunc=CompleteInfoUserDefinedFn
+  call feedkeys("i\<C-X>\<C-U>" . a:mvmt . "\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
+  let completed = a:idx != -1 ? ['foo', 'bar', 'baz', 'qux']->get(a:idx) : ''
+  call assert_equal(completed. "{'pum_visible': 1, 'mode': 'function', 'selected': " . a:idx . ", 'items': " . items . "}", getline(1))
+  %d
+  set complete=.,fCompleteInfoUserDefinedFn
+  call feedkeys("i\<C-N>" . a:mvmt . "\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
+  let completed = a:idx != -1 ? ['foo', 'bar', 'baz', 'qux']->get(a:idx) : ''
+  call assert_equal(completed. "{'pum_visible': 1, 'mode': 'keyword', 'selected': " . a:idx . ", 'items': " . items . "}", getline(1))
+  %d
+  set complete=.,f
+  call feedkeys("i\<C-N>" . a:mvmt . "\<C-R>\<C-R>=string(complete_info())\<CR>\<ESC>", "tx")
+  let completed = a:idx != -1 ? ['foo', 'bar', 'baz', 'qux']->get(a:idx) : ''
+  call assert_equal(completed. "{'pum_visible': 1, 'mode': 'keyword', 'selected': " . a:idx . ", 'items': " . items . "}", getline(1))
   bwipe!
-  set completeopt&
-  set completefunc&
+  set completeopt& completefunc& complete&
 endfunc
 
 func Test_complete_info_user_defined_fn()
@@ -914,6 +1044,10 @@ func Test_completefunc_error()
   set completefunc=CompleteFunc
   call setline(1, ['', 'abcd', ''])
   call assert_fails('exe "normal 2G$a\<C-X>\<C-U>"', 'E565:')
+  set complete=fCompleteFunc
+  call assert_fails('exe "normal 2G$a\<C-N>"', 'E565:')
+  set complete=f
+  call assert_fails('exe "normal 2G$a\<C-N>"', 'E565:')
 
   " delete text when called for the second time
   func CompleteFunc2(findstart, base)
@@ -926,6 +1060,10 @@ func Test_completefunc_error()
   set completefunc=CompleteFunc2
   call setline(1, ['', 'abcd', ''])
   call assert_fails('exe "normal 2G$a\<C-X>\<C-U>"', 'E565:')
+  set complete=fCompleteFunc2
+  call assert_fails('exe "normal 2G$a\<C-N>"', 'E565:')
+  set complete=f
+  call assert_fails('exe "normal 2G$a\<C-N>"', 'E565:')
 
   " Jump to a different window from the complete function
   func CompleteFunc3(findstart, base)
@@ -938,9 +1076,15 @@ func Test_completefunc_error()
   set completefunc=CompleteFunc3
   new
   call assert_fails('exe "normal a\<C-X>\<C-U>"', 'E565:')
+  %d
+  set complete=fCompleteFunc3
+  call assert_fails('exe "normal a\<C-N>"', 'E565:')
+  %d
+  set complete=f
+  call assert_fails('exe "normal a\<C-N>"', 'E565:')
   close!
 
-  set completefunc&
+  set completefunc& complete&
   delfunc CompleteFunc
   delfunc CompleteFunc2
   delfunc CompleteFunc3
@@ -959,7 +1103,15 @@ func Test_completefunc_invalid_data()
   set completefunc=CompleteFunc
   exe "normal i\<C-X>\<C-U>"
   call assert_equal('moon', getline(1))
-  set completefunc&
+  %d
+  set complete=fCompleteFunc
+  exe "normal i\<C-N>"
+  call assert_equal('moon', getline(1))
+  %d
+  set complete=f
+  exe "normal i\<C-N>"
+  call assert_equal('moon', getline(1))
+  set completefunc& complete&
   close!
 endfunc
 
@@ -1636,16 +1788,361 @@ func Test_complete_item_refresh_always()
       return #{words: res, refresh: 'always'}
     endif
   endfunc
-  new
   set completeopt=menu,longest
   set completefunc=Tcomplete
+  new
   exe "normal! iup\<C-X>\<C-U>\<BS>\<BS>\<BS>\<BS>\<BS>"
   call assert_equal('up', getline(1))
   call assert_equal(6, g:CallCount)
-  set completeopt&
-  set completefunc&
+  %d
+  let g:CallCount = 0
+  set complete=fTcomplete
+  exe "normal! iup\<C-N>\<BS>\<BS>\<BS>\<BS>\<BS>"
+  call assert_equal('up', getline(1))
+  call assert_equal(6, g:CallCount)
+  %d
+  let g:CallCount = 0
+  set complete=f
+  exe "normal! iup\<C-N>\<BS>\<BS>\<BS>\<BS>\<BS>"
+  call assert_equal('up', getline(1))
+  call assert_equal(6, g:CallCount)
+  %d
+  let g:CallCount = 0
+  set omnifunc=Tcomplete
+  set complete=o
+  exe "normal! iup\<C-N>\<BS>\<BS>\<BS>\<BS>\<BS>"
+  call assert_equal('up', getline(1))
+  call assert_equal(6, g:CallCount)
   bw!
+  set completeopt&
+  set complete&
+  set completefunc&
   delfunc Tcomplete
+endfunc
+
+" Test for 'cpt' user func that fails (return -2/-3) when refresh:always
+func Test_cpt_func_refresh_always_fail()
+  func! CompleteFail(retval, findstart, base)
+    if a:findstart
+      return a:retval
+    endif
+    call assert_equal(-999, a:findstart) " Should not reach here
+  endfunc
+  new
+  set complete=ffunction('CompleteFail'\\,\ [-2])
+  exe "normal! ia\<C-N>"
+  %d
+  set complete=ffunction('CompleteFail'\\,\ [-3])
+  exe "normal! ia\<C-N>"
+  bw!
+
+  func! CompleteFailIntermittent(retval, findstart, base)
+    if a:findstart
+      if g:CallCount == 2
+        let g:CallCount += 1
+        return a:retval
+      endif
+      return col('.') - 1
+    endif
+    let g:CallCount += 1
+    let res = [[], ['foo', 'fbar'], ['foo1', 'foo2'], ['foofail'], ['fooo3']]
+    return #{words: res[g:CallCount], refresh: 'always'}
+  endfunc
+  new
+  set completeopt=menuone,noselect
+  set complete=ffunction('CompleteFailIntermittent'\\,\ [-2])
+  let g:CallCount = 0
+  exe "normal! if\<C-N>\<c-r>=complete_info([\"items\"])\<cr>"
+  call assert_match('''word'': ''foo''.*''word'': ''fbar''', getline(1))
+  call assert_equal(1, g:CallCount)
+  %d
+  let g:CallCount = 0
+  exe "normal! if\<C-N>o\<c-r>=complete_info([\"items\", \"selected\"])\<cr>"
+  call assert_match('''selected'': -1.*''word'': ''foo1''.*''word'': ''foo2''', getline(1))
+  call assert_equal(2, g:CallCount)
+  %d
+  set complete=ffunction('CompleteFailIntermittent'\\,\ [-3])
+  let g:CallCount = 0
+  exe "normal! if\<C-N>o\<c-r>=complete_info([\"items\", \"selected\"])\<cr>"
+  call assert_match('''selected'': -1.*''word'': ''foo1''.*''word'': ''foo2''', getline(1))
+  call assert_equal(2, g:CallCount)
+  %d
+  set complete=ffunction('CompleteFailIntermittent'\\,\ [-2])
+  " completion mode is dismissed when there are no matches in list
+  let g:CallCount = 0
+  exe "normal! if\<C-N>oo\<c-r>=complete_info([\"items\"])\<cr>"
+  call assert_equal('foo{''items'': []}', getline(1))
+  call assert_equal(3, g:CallCount)
+  %d
+  let g:CallCount = 0
+  exe "normal! if\<C-N>oo\<bs>\<c-r>=complete_info([\"items\"])\<cr>"
+  call assert_equal('fo{''items'': []}', getline(1))
+  call assert_equal(3, g:CallCount)
+  %d
+  " completion mode continues when matches from other sources present
+  set complete=.,ffunction('CompleteFailIntermittent'\\,\ [-2])
+  call setline(1, 'fooo1')
+  let g:CallCount = 0
+  exe "normal! Gof\<C-N>oo\<c-r>=complete_info([\"items\", \"selected\"])\<cr>"
+  call assert_equal('foo{''selected'': -1, ''items'': [{''word'': ''fooo1'', ''menu'': '''', '
+        \ . '''user_data'': '''', ''info'': '''', ''kind'': '''', ''abbr'': ''''}]}',
+        \ getline(2))
+  call assert_equal(3, g:CallCount)
+  %d
+  call setline(1, 'fooo1')
+  let g:CallCount = 0
+  exe "normal! Gof\<C-N>oo\<bs>\<c-r>=complete_info([\"items\"])\<cr>"
+  call assert_match('''word'': ''fooo1''.*''word'': ''fooo3''', getline(2))
+  call assert_equal(4, g:CallCount)
+  %d
+  " refresh will stop when -3 is returned
+  set complete=.,,\ ffunction('CompleteFailIntermittent'\\,\ [-3])
+  call setline(1, 'fooo1')
+  let g:CallCount = 0
+  exe "normal! Gof\<C-N>o\<bs>\<c-r>=complete_info([\"items\", \"selected\"])\<cr>"
+  call assert_equal('f{''selected'': -1, ''items'': [{''word'': ''fooo1'', ''menu'': '''', '
+        \ . '''user_data'': '''', ''info'': '''', ''kind'': '''', ''abbr'': ''''}]}',
+        \ getline(2))
+  call assert_equal(3, g:CallCount)
+  %d
+  call setline(1, 'fooo1')
+  let g:CallCount = 0
+  exe "normal! Gof\<C-N>oo\<bs>\<c-r>=complete_info([\"items\", \"selected\"])\<cr>"
+  call assert_equal('fo{''selected'': -1, ''items'': [{''word'': ''fooo1'', ''menu'': '''', '
+        \ . '''user_data'': '''', ''info'': '''', ''kind'': '''', ''abbr'': ''''}]}',
+        \ getline(2))
+  call assert_equal(3, g:CallCount)
+  bw!
+
+  set complete& completeopt&
+  delfunc CompleteFail
+  delfunc CompleteFailIntermittent
+endfunc
+
+" Select items before they are removed by refresh:always
+func Test_cpt_select_item_refresh_always()
+
+  func CompleteMenuWords()
+    let info = complete_info(["items", "selected"])
+    call map(info.items, {_, v -> v.word})
+    return info
+  endfunc
+
+  func! CompleteItemsSelect(compl, findstart, base)
+    if a:findstart
+      return col('.') - 1
+    endif
+    let g:CallCount += 1
+    if g:CallCount == 2
+        return #{words: a:compl, refresh: 'always'}
+    endif
+    let res = [[], ['fo', 'foobar'], [], ['foo1', 'foo2']]
+    return #{words: res[g:CallCount], refresh: 'always'}
+  endfunc
+
+  new
+  set complete=.,ffunction('CompleteItemsSelect'\\,\ [[]])
+  call setline(1, "foobarbar")
+  let g:CallCount = 0
+  exe "normal! Gof\<c-n>\<c-n>\<c-r>=CompleteMenuWords()\<cr>"
+  call assert_equal('fo{''selected'': 1, ''items'': [''foobarbar'', ''fo'', ''foobar'']}', getline(2))
+  call assert_equal(1, g:CallCount)
+  %d
+  call setline(1, "foobarbar")
+  let g:CallCount = 0
+  exe "normal! Gof\<c-p>\<c-p>\<c-p>\<c-r>=CompleteMenuWords()\<cr>"
+  call assert_equal('fo{''selected'': 0, ''items'': [''fo'', ''foobar'', ''foobarbar'']}', getline(2))
+  call assert_equal(1, g:CallCount)
+  %d
+  call setline(1, "foobarbar")
+  let g:CallCount = 0
+  exe "normal! Gof\<c-n>\<c-n>o\<c-r>=CompleteMenuWords()\<cr>"
+  call assert_equal('foo{''selected'': -1, ''items'': []}' , getline(2))
+  call assert_equal(1, g:CallCount)
+  %d
+  call setline(1, "foobarbar")
+  let g:CallCount = 0
+  exe "normal! Gof\<c-n>\<c-n>\<bs>\<c-r>=CompleteMenuWords()\<cr>"
+  call assert_equal('f{''selected'': -1, ''items'': [''foobarbar'']}', getline(2))
+  call assert_equal(2, g:CallCount)
+  %d
+  call setline(1, "foobarbar")
+  let g:CallCount = 0
+  exe "normal! Gof\<c-p>\<c-p>\<c-p>\<bs>\<c-r>=CompleteMenuWords()\<cr>"
+  call assert_equal('f{''selected'': -1, ''items'': [''foobarbar'']}', getline(2))
+  call assert_equal(2, g:CallCount)
+
+  %d
+  set complete=.,ffunction('CompleteItemsSelect'\\,\ [['foonext']])
+  call setline(1, "foobarbar")
+  let g:CallCount = 0
+  exe "normal! Gof\<c-n>\<c-n>\<bs>\<c-r>=CompleteMenuWords()\<cr>"
+  call assert_equal('f{''selected'': -1, ''items'': [''foobarbar'', ''foonext'']}', getline(2))
+  call assert_equal(2, g:CallCount)
+  %d
+  call setline(1, "foobarbar")
+  let g:CallCount = 0
+  exe "normal! Gof\<c-p>\<c-p>\<c-p>\<bs>\<c-r>=CompleteMenuWords()\<cr>"
+  call assert_equal('f{''selected'': -1, ''items'': [''foonext'', ''foobarbar'']}', getline(2))
+  call assert_equal(2, g:CallCount)
+
+  %d
+  call setline(1, "foob")
+  let g:CallCount = 0
+  exe "normal! Gof\<c-n>\<bs>\<c-r>=CompleteMenuWords()\<cr>"
+  call assert_equal('foo{''selected'': 0, ''items'': [''foob'', ''foonext'']}', getline(2))
+  call assert_equal(2, g:CallCount)
+  %d
+  call setline(1, "foob")
+  let g:CallCount = 0
+  exe "normal! Gof\<c-n>\<bs>\<bs>\<c-r>=CompleteMenuWords()\<cr>"
+  call assert_equal('fo{''selected'': 0, ''items'': [''foob'', ''foo1'', ''foo2'']}', getline(2))
+  call assert_equal(3, g:CallCount)
+
+  %d
+  call setline(1, "foob")
+  let g:CallCount = 0
+  exe "normal! Gof\<c-p>\<bs>\<c-r>=CompleteMenuWords()\<cr>"
+  call assert_equal('foo{''selected'': 1, ''items'': [''foonext'', ''foob'']}', getline(2))
+  call assert_equal(2, g:CallCount)
+  %d
+  call setline(1, "foob")
+  let g:CallCount = 0
+  exe "normal! Gof\<c-p>\<bs>\<bs>\<c-r>=CompleteMenuWords()\<cr>"
+  call assert_equal('fo{''selected'': 2, ''items'': [''foo1'', ''foo2'', ''foob'']}', getline(2))
+  call assert_equal(3, g:CallCount)
+
+  %d
+  set complete=.,ffunction('CompleteItemsSelect'\\,\ [['fo'\\,\ 'foonext']])
+  call setline(1, "foobarbar")
+  let g:CallCount = 0
+  exe "normal! Gof\<c-n>\<c-n>\<bs>\<c-r>=CompleteMenuWords()\<cr>"
+  call assert_equal('f{''selected'': -1, ''items'': [''foobarbar'', ''fo'', ''foonext'']}', getline(2))
+  call assert_equal(2, g:CallCount)
+  %d
+  call setline(1, "foobarbar")
+  let g:CallCount = 0
+  exe "normal! Gof\<c-p>\<c-p>\<c-p>\<bs>\<c-r>=CompleteMenuWords()\<cr>"
+  call assert_equal('f{''selected'': -1, ''items'': [''fo'', ''foonext'', ''foobarbar'']}', getline(2))
+  call assert_equal(2, g:CallCount)
+  bw!
+
+  set complete&
+  delfunc CompleteMenuWords
+  delfunc CompleteItemsSelect
+endfunc
+
+" Test two functions together, each returning refresh:always
+func Test_cpt_multi_func_refresh_always()
+
+  func CompleteMenuMatches()
+    let info = complete_info(["matches", "selected"])
+    call map(info.matches, {_, v -> v.word})
+    return info
+  endfunc
+
+  func! CompleteItems1(findstart, base)
+    if a:findstart
+      return col('.') - 1
+    endif
+    let g:CallCount1 += 1
+    let res = [[], [], ['foo1', 'foobar1'], [], ['foo11', 'foo12'], [], ['foo13', 'foo14']]
+    return #{words: res[g:CallCount1], refresh: 'always'}
+  endfunc
+
+  func! CompleteItems2(findstart, base)
+    if a:findstart
+      return col('.') - 1
+    endif
+    let g:CallCount2 += 1
+    let res = [[], [], [], ['foo2', 'foobar2'], ['foo21', 'foo22'], ['foo23'], []]
+    return #{words: res[g:CallCount2], refresh: 'always'}
+  endfunc
+
+  set complete=
+  exe "normal! if\<C-N>\<c-r>=CompleteMenuMatches()\<cr>"
+  " \x0e is <c-n>
+  call assert_equal("f\x0e" . '{''matches'': [], ''selected'': -1}', getline(1))
+
+  set completeopt=menuone,noselect
+  set complete=fCompleteItems1,fCompleteItems2
+
+  new
+  let g:CallCount1 = 0
+  let g:CallCount2 = 0
+  exe "normal! if\<c-n>o\<c-n>o\<c-r>=CompleteMenuMatches()\<cr>"
+  call assert_equal('foo{''matches'': [''foo2'', ''foobar2''], ''selected'': -1}', getline(1))
+  call assert_equal(3, g:CallCount1)
+  call assert_equal(3, g:CallCount2)
+  %d
+  let g:CallCount1 = 0
+  let g:CallCount2 = 0
+  exe "normal! if\<c-p>o\<c-p>o\<c-r>=CompleteMenuMatches()\<cr>"
+  call assert_equal('foo{''matches'': [''foo2'', ''foobar2''], ''selected'': -1}', getline(1))
+  call assert_equal(3, g:CallCount1)
+  call assert_equal(3, g:CallCount2)
+  %d
+  let g:CallCount1 = 0
+  let g:CallCount2 = 0
+  exe "normal! if\<c-p>\<c-r>=CompleteMenuMatches()\<cr>"
+  call assert_equal('f{''matches'': [], ''selected'': -1}', getline(1))
+  call assert_equal(1, g:CallCount1)
+  call assert_equal(1, g:CallCount2)
+  %d
+  let g:CallCount1 = 1
+  let g:CallCount2 = 1
+  exe "normal! if\<c-n>\<c-r>=CompleteMenuMatches()\<cr>"
+  call assert_equal('f{''matches'': [''foo1'', ''foobar1''], ''selected'': -1}', getline(1))
+  call assert_equal(2, g:CallCount2)
+  call assert_equal(2, g:CallCount2)
+  %d
+  let g:CallCount1 = 1
+  let g:CallCount2 = 1
+  exe "normal! if\<c-n>o\<c-r>=CompleteMenuMatches()\<cr>"
+  call assert_equal('fo{''matches'': [''foo2'', ''foobar2''], ''selected'': -1}', getline(1))
+  call assert_equal(3, g:CallCount2)
+  call assert_equal(3, g:CallCount2)
+  %d
+  let g:CallCount1 = 1
+  let g:CallCount2 = 1
+  exe "normal! if\<c-p>o\<c-r>=CompleteMenuMatches()\<cr>"
+  call assert_equal('fo{''matches'': [''foo2'', ''foobar2''], ''selected'': -1}', getline(1))
+  call assert_equal(3, g:CallCount2)
+  call assert_equal(3, g:CallCount2)
+  %d
+  let g:CallCount1 = 1
+  let g:CallCount2 = 1
+  exe "normal! if\<c-n>oo\<c-r>=CompleteMenuMatches()\<cr>"
+  call assert_equal('foo{''matches'': [''foo11'', ''foo12'', ''foo21'', ''foo22''], ''selected'': -1}', getline(1))
+  call assert_equal(4, g:CallCount2)
+  call assert_equal(4, g:CallCount2)
+  %d
+  let g:CallCount1 = 1
+  let g:CallCount2 = 1
+  exe "normal! if\<c-n>oo\<bs>\<c-r>=CompleteMenuMatches()\<cr>"
+  call assert_equal('fo{''matches'': [''foo23''], ''selected'': -1}', getline(1))
+  call assert_equal(5, g:CallCount2)
+  call assert_equal(5, g:CallCount2)
+  %d
+  let g:CallCount1 = 1
+  let g:CallCount2 = 1
+  exe "normal! if\<c-p>oo\<bs>\<c-r>=CompleteMenuMatches()\<cr>"
+  call assert_equal('fo{''matches'': [''foo23''], ''selected'': -1}', getline(1))
+  call assert_equal(5, g:CallCount2)
+  call assert_equal(5, g:CallCount2)
+  %d
+  let g:CallCount1 = 1
+  let g:CallCount2 = 1
+  exe "normal! if\<c-n>oo\<bs>o\<c-r>=CompleteMenuMatches()\<cr>"
+  call assert_equal('foo{''matches'': [''foo13'', ''foo14''], ''selected'': -1}', getline(1))
+  call assert_equal(6, g:CallCount2)
+  call assert_equal(6, g:CallCount2)
+  bw!
+
+  set complete& completeopt&
+  delfunc CompleteMenuMatches
+  delfunc CompleteItems1
+  delfunc CompleteItems2
 endfunc
 
 " Test for completing from a thesaurus file without read permission
@@ -1685,6 +2182,143 @@ func Test_no_mapping_for_ctrl_x_key()
   call assert_equal('example ', getline(1))
   call assert_false(exists('was_mapped'))
   bwipe!
+endfunc
+
+" Test for different ways of setting a function in 'complete' option
+func Test_cpt_func_callback()
+  func CompleteFunc1(callnr, findstart, base)
+    call add(g:CompleteFunc1Args, [a:callnr, a:findstart, a:base])
+    return a:findstart ? 0 : []
+  endfunc
+  func CompleteFunc2(findstart, base)
+    call add(g:CompleteFunc2Args, [a:findstart, a:base])
+    return a:findstart ? 0 : []
+  endfunc
+
+  let lines =<< trim END
+    #" Test for using a global function name
+    set complete=fg:CompleteFunc2
+    new
+    call setline(1, 'global')
+    LET g:CompleteFunc2Args = []
+    call feedkeys("A\<C-N>\<Esc>", 'x')
+    call assert_equal([[1, ''], [0, 'global']], g:CompleteFunc2Args)
+    set complete&
+    bw!
+
+    #" Test for using a function()
+    set complete=ffunction('g:CompleteFunc1'\\,\ [10])
+    new
+    call setline(1, 'one')
+    LET g:CompleteFunc1Args = []
+    call feedkeys("A\<C-N>\<Esc>", 'x')
+    call assert_equal([[10, 1, ''], [10, 0, 'one']], g:CompleteFunc1Args)
+    set complete&
+    bw!
+
+    #" Using a funcref variable
+    set complete=ffuncref('g:CompleteFunc1'\\,\ [11])
+    new
+    call setline(1, 'two')
+    LET g:CompleteFunc1Args = []
+    call feedkeys("A\<C-N>\<Esc>", 'x')
+    call assert_equal([[11, 1, ''], [11, 0, 'two']], g:CompleteFunc1Args)
+    set complete&
+    bw!
+
+  END
+  call CheckLegacyAndVim9Success(lines)
+
+  " Test for using a script-local function name
+  func s:CompleteFunc3(findstart, base)
+    call add(g:CompleteFunc3Args, [a:findstart, a:base])
+    return a:findstart ? 0 : []
+  endfunc
+  set complete=fs:CompleteFunc3
+  new
+  call setline(1, 'script1')
+  let g:CompleteFunc3Args = []
+  call feedkeys("A\<C-N>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'script1']], g:CompleteFunc3Args)
+  set complete&
+  bw!
+
+  let &complete = 'fs:CompleteFunc3'
+  new
+  call setline(1, 'script2')
+  let g:CompleteFunc3Args = []
+  call feedkeys("A\<C-N>\<Esc>", 'x')
+  call assert_equal([[1, ''], [0, 'script2']], g:CompleteFunc3Args)
+  bw!
+  delfunc s:CompleteFunc3
+  set complete&
+
+  " In Vim9 script s: can be omitted
+  let lines =<< trim END
+      vim9script
+      var CompleteFunc4Args = []
+      def CompleteFunc4(findstart: bool, base: string): any
+        add(CompleteFunc4Args, [findstart, base])
+        return findstart ? 0 : []
+      enddef
+      set complete=fCompleteFunc4
+      new
+      setline(1, 'script1')
+      feedkeys("A\<C-N>\<Esc>", 'x')
+      assert_equal([[1, ''], [0, 'script1']], CompleteFunc4Args)
+      set complete&
+      bw!
+  END
+  call CheckScriptSuccess(lines)
+
+  " Vim9 tests
+  let lines =<< trim END
+    vim9script
+
+    def Vim9CompleteFunc(callnr: number, findstart: number, base: string): any
+      add(g:Vim9completeFuncArgs, [callnr, findstart, base])
+      return findstart ? 0 : []
+    enddef
+
+    # Test for using a def function with completefunc
+    set complete=ffunction('Vim9CompleteFunc'\\,\ [60])
+    new | only
+    setline(1, 'one')
+    g:Vim9completeFuncArgs = []
+    feedkeys("A\<C-N>\<Esc>", 'x')
+    assert_equal([[60, 1, ''], [60, 0, 'one']], g:Vim9completeFuncArgs)
+    bw!
+
+    # Test for using a global function name
+    &complete = 'fg:CompleteFunc2'
+    new | only
+    setline(1, 'two')
+    g:CompleteFunc2Args = []
+    feedkeys("A\<C-N>\<Esc>", 'x')
+    assert_equal([[1, ''], [0, 'two']], g:CompleteFunc2Args)
+    bw!
+
+    # Test for using a script-local function name
+    def LocalCompleteFunc(findstart: number, base: string): any
+      add(g:LocalCompleteFuncArgs, [findstart, base])
+      return findstart ? 0 : []
+    enddef
+    &complete = 'fLocalCompleteFunc'
+    new | only
+    setline(1, 'three')
+    g:LocalCompleteFuncArgs = []
+    feedkeys("A\<C-N>\<Esc>", 'x')
+    assert_equal([[1, ''], [0, 'three']], g:LocalCompleteFuncArgs)
+    bw!
+  END
+  call CheckScriptSuccess(lines)
+
+  " cleanup
+  set completefunc& complete&
+  delfunc CompleteFunc1
+  delfunc CompleteFunc2
+  unlet g:CompleteFunc1Args g:CompleteFunc2Args
+  %bw!
 endfunc
 
 " Test for different ways of setting the 'completefunc' option
@@ -2564,8 +3198,17 @@ endfunc
 func Test_complete_smartindent()
   new
   setlocal smartindent completefunc=FooBarComplete
-
   exe "norm! o{\<cr>\<c-x>\<c-u>\<c-p>}\<cr>\<esc>"
+  let result = getline(1,'$')
+  call assert_equal(['', '{','}',''], result)
+  %d
+  setlocal complete=fFooBarComplete
+  exe "norm! o{\<cr>\<c-n>\<c-p>}\<cr>\<esc>"
+  let result = getline(1,'$')
+  call assert_equal(['', '{','}',''], result)
+  %d
+  setlocal complete=f
+  exe "norm! o{\<cr>\<c-n>\<c-p>}\<cr>\<esc>"
   let result = getline(1,'$')
   call assert_equal(['', '{','}',''], result)
   bw!

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -279,7 +279,7 @@ func Test_complete()
   call assert_fails('set complete=ix', 'E535:')
   call assert_fails('set complete=x', 'E539:')
   call assert_fails('set complete=..', 'E535:')
-  set complete=.,w,b,u,k,\ s,i,d,],t,U,f,o
+  set complete=.,w,b,u,k,\ s,i,d,],t,U,F,o
   call assert_fails('set complete=i^-10', 'E535:')
   call assert_fails('set complete=i^x', 'E535:')
   call assert_fails('set complete=k^2,t^-1,s^', 'E535:')
@@ -287,13 +287,13 @@ func Test_complete()
   call assert_fails('set complete=kfoo^foo2', 'E535:')
   call assert_fails('set complete=kfoo^', 'E535:')
   call assert_fails('set complete=.^', 'E535:')
-  set complete=.,w,b,u,k,s,i,d,],t,U,f,o
+  set complete=.,w,b,u,k,s,i,d,],t,U,F,o
   set complete=.
   set complete=.^10,t^0
-  set complete+=ffuncref('foo'\\,\ [10])
-  set complete=ffuncref('foo'\\,\ [10])^10
+  set complete+=Ffuncref('foo'\\,\ [10])
+  set complete=Ffuncref('foo'\\,\ [10])^10
   set complete&
-  set complete+=ffunction('g:foo'\\,\ [10\\,\ 20])
+  set complete+=Ffunction('g:foo'\\,\ [10\\,\ 20])
   set complete&
 endfun
 

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -280,11 +280,20 @@ func Test_complete()
   call assert_fails('set complete=x', 'E539:')
   call assert_fails('set complete=..', 'E535:')
   set complete=.,w,b,u,k,\ s,i,d,],t,U,f,o
+  call assert_fails('set complete=i^-10', 'E535:')
+  call assert_fails('set complete=i^x', 'E535:')
+  call assert_fails('set complete=k^2,t^-1,s^', 'E535:')
+  call assert_fails('set complete=t^-1', 'E535:')
+  call assert_fails('set complete=kfoo^foo2', 'E535:')
+  call assert_fails('set complete=kfoo^', 'E535:')
+  call assert_fails('set complete=.^', 'E535:')
+  set complete=.,w,b,u,k,s,i,d,],t,U,f,o
   set complete=.
+  set complete=.^10,t^0
   set complete+=ffuncref('foo'\\,\ [10])
-  set complete=ffuncref('foo'\\,\ [10])
+  set complete=ffuncref('foo'\\,\ [10])^10
   set complete&
-  set complete+=ffunction('foo'\\,\ [10\\,\ 20])
+  set complete+=ffunction('g:foo'\\,\ [10\\,\ 20])
   set complete&
 endfun
 

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -277,6 +277,14 @@ func Test_complete()
   call feedkeys("i\<C-N>\<Esc>", 'xt')
   bwipe!
   call assert_fails('set complete=ix', 'E535:')
+  call assert_fails('set complete=x', 'E539:')
+  call assert_fails('set complete=..', 'E535:')
+  set complete=.,w,b,u,k,\ s,i,d,],t,U,f,o
+  set complete=.
+  set complete+=ffuncref('foo'\\,\ [10])
+  set complete=ffuncref('foo'\\,\ [10])
+  set complete&
+  set complete+=ffunction('foo'\\,\ [10\\,\ 20])
   set complete&
 endfun
 


### PR DESCRIPTION
Close #16012

#### vim-patch:9.1.1147: preview-window does not scroll correctly

Problem:  preview-window does not scroll correctly
Solution: init firstline = 0 for a preview window
          (Girish Palya)

The 'info' window, which appears during insert-mode completion to display
additional information, was not scrolling properly when using commands like:
	win_execute(popup_findinfo(), "normal! \<PageDown>")
This issue made it impossible to navigate through info window contents using
keyboard-based scrolling.
The fix correctly updates the w_firstline value of the popup window, ensuring
proper scrolling behavior. Mouse scrolling was already working as expected and
remains unaffected.

closes: vim/vim#16703

https://github.com/vim/vim/commit/12b1eb58abca1eabc4833ad855c8a31d8b40981e

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1301: completion: cannot configure completion functions with 'complete'

Problem:  completion: cannot configure completion functions with
          'complete'
Solution: add support for setting completion functions using the f and o
          flag for 'complete' (Girish Palya)

This change adds two new values to the `'complete'` (`'cpt'`) option:
- `f` – invokes the function specified by the `'completefunc'` option
- `f{func}` – invokes a specific function `{func}` (can be a string or `Funcref`)

These new flags extend keyword completion behavior (e.g., via `<C-N>` /
`<C-P>`) by allowing function-based sources to participate in standard keyword
completion.

**Key behaviors:**

- Multiple `f{func}` values can be specified, and all will be called in order.
- Functions should follow the interface defined in `:help complete-functions`.
- When using `f{func}`, escaping is required for spaces (with `\`) and commas
  (with `\\`) in `Funcref` names.
- If a function sets `'refresh'` to `'always'`, it will be re-invoked on every
  change to the input text. Otherwise, Vim will attempt to reuse and filter
  existing matches as the input changes, which matches the default behavior of
  other completion sources.
- Matches are inserted at the keyword boundary for consistency with other completion methods.
- If finding matches is time-consuming, `complete_check()` can be used to
  maintain responsiveness.
- Completion matches are gathered in the sequence defined by the `'cpt'`
  option, preserving source priority.

This feature increases flexibility of standard completion mechanism and may
reduce the need for external completion plugins for many users.

**Examples:**

Complete matches from [LSP](https://github.com/yegappan/lsp) client. Notice the use of `refresh: always` and `function()`.

```vim
set cpt+=ffunction("g:LspCompletor"\\,\ [5]). # maxitems = 5

def! g:LspCompletor(maxitems: number, findstart: number, base: string): any
    if findstart == 1
        return g:LspOmniFunc(findstart, base)
    endif
    return {words: g:LspOmniFunc(findstart, base)->slice(0, maxitems), refresh: 'always'}
enddef
autocmd VimEnter * g:LspOptionsSet({ autoComplete: false, omniComplete: true })
```

Complete matches from `:iabbrev`.

```vim
set cpt+=fAbbrevCompletor

def! g:AbbrevCompletor(findstart: number, base: string): any
    if findstart > 0
        var prefix = getline('.')->strpart(0, col('.') - 1)->matchstr('\S\+$')
        if prefix->empty()
            return -2
        endif
        return col('.') - prefix->len() - 1
    endif
    var lines = execute('ia', 'silent!')
    if lines =~? gettext('No abbreviation found')
        return v:none  # Suppresses warning message
    endif
    var items = []
    for line in lines->split("\n")
        var m = line->matchlist('\v^i\s+\zs(\S+)\s+(.*)$')
        if m->len() > 2 && m[1]->stridx(base) == 0
            items->add({ word: m[1], info: m[2], dup: 1 })
        endif
    endfor
    return items->empty() ? v:none :
        items->sort((v1, v2) => v1.word < v2.word ? -1 : v1.word ==# v2.word ? 0 : 1)
enddef
```

**Auto-completion:**

Vim's standard completion frequently checks for user input while searching for
new matches. It is responsive irrespective of file size. This makes it
well-suited for smooth auto-completion. You can try with above examples:

```vim
set cot=menuone,popup,noselect inf

autocmd TextChangedI * InsComplete()

def InsComplete()
    if getcharstr(1) == '' && getline('.')->strpart(0, col('.') - 1) =~ '\k$'
        SkipTextChangedIEvent()
        feedkeys("\<c-n>", "n")
    endif
enddef

inoremap <silent> <c-e> <c-r>=<SID>SkipTextChangedIEvent()<cr><c-e>

def SkipTextChangedIEvent(): string
    # Suppress next event caused by <c-e> (or <c-n> when no matches found)
    set eventignore+=TextChangedI
    timer_start(1, (_) => {
        set eventignore-=TextChangedI
    })
    return ''
enddef
```

closes: vim/vim#17065

https://github.com/vim/vim/commit/cbe53191d01926c045a39198b3a9517e3c5077d2

Temporarily remove bufname completion with #if 0 to make merging easier.

Co-authored-by: Girish Palya <girishji@gmail.com>
Co-authored-by: Christian Brabandt <cb@256bit.org>
Co-authored-by: glepnir <glephunter@gmail.com>


#### vim-patch:9.1.1302: Coverity warns about using uninitialized value

Problem:  Coverity warns about using uninitialized value
          (Coverity, Tony Mechelynck, after v9.1.1301)
Solution: initialize callback pointer to NULL

https://github.com/vim/vim/commit/d2079cff48117b121cd4afcc91fc14a696bdb142

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.1311: completion: not possible to limit number of matches

Problem:  completion: not possible to limit number of matches
Solution: allow to limit the matches for 'complete' sources by using the
          "{flag}^{limit}" notation (Girish Palya)

This change extends the 'complete'  option to support limiting the
number of matches returned from individual completion sources.

**Rationale:** In large files, certain sources (such as the current
buffer) can generate an overwhelming number of matches, which may cause
more relevant results from other sources (e.g., LSP or tags) to be
pushed out of view. By specifying per-source match limits, the
completion menu remains balanced and diverse, improving visibility and
relevance of suggestions.

A caret (`^`) followed by a number can be appended to a source flag to
specify the maximum number of matches for that source. For example:
```
  :set complete=.^9,w,u,t^5
```
In this configuration:
- The current buffer (`.`) will return up to 9 matches.
- The tag completion (`t`) will return up to 5 matches.
- Other sources (`w`, `u`) are not limited.

This feature is fully backward-compatible and does not affect behavior
when the `^count` suffix is not used.

The caret (`^`) was chosen as the delimiter because it is least likely
to appear in file names.

closes: vim/vim#17087

https://github.com/vim/vim/commit/0ac1eb3555445f4c458c06cef7c411de1c8d1020

Cherry-pick test_options.vim change from patch 9.1.1325.

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1313: compile warning about uninitialized value

Problem:  compile warning about uninitialized value
          (Tony Mechelynck, after v9.1.1311)
Solution: initialize variable on declaration

https://github.com/vim/vim/commit/b53d4fb63e0d4d36033d47ec35f2f302931f77ae

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:fa8b7db: runtime(doc): tweak documentation style in options.txt

closes: vim/vim#17229

https://github.com/vim/vim/commit/fa8b7db99afad9074e4e1f89b49046836ac61d5b

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>


#### vim-patch:9.1.1409: using f-flag in 'complete' conflicts with Neovim

Problem:  using f-flag in 'complete' conflicts with Neovims filename
          completion (glepnir, after v9.1.1301).
Solution: use upper-case "F" flag for completion functions
          (Girish Palya).

closes: vim/vim#17378

https://github.com/vim/vim/commit/14f6da5ba8d602263fc7bf6cb899c8520f4c3060

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1410: out-of-bounds access with 'completefunc'

Problem:  out-of-bounds access with 'completefunc' (csetc)
Solution: check if it is safe to advance cpt_sources_index
          (Girish Palya)

closes: vim/vim#17374

https://github.com/vim/vim/commit/7c621052c3f180c1ef70fb7abfdad18245f47fcc

Co-authored-by: Girish Palya <girishji@gmail.com>
Co-authored-by: @csetc


#### vim-patch:9.1.1416: completion limits not respected for fuzzy completions

Problem:  completion limits not respected when using fuzzy completion
          (Maxim Kim)
Solution: trim completion array (Girish Palya)

closes: vim/vim#17386

https://github.com/vim/vim/commit/19ef6b0b4b11a9775f9c90edc68c896034fd2a9d

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1422: scheduling of complete function can be improved

Problem:  scheduling of complete function can be improved
Solution: call user completion functions earlier when just determining
          the insertion column (Girish Palya)

This change improves the scheduling behavior of async user-defined
completion functions (such as `F{func}`, `F`, or `'o'` values in the
`'complete'` option), particularly benefiting LSP clients.

Currently, these user functions are invoked twice:

1. First with `findstart = 1` to determine the completion start
   position.
2. Then with `findstart = 0` to retrieve the actual matches.

Previously, both calls were executed back-to-back. With this change, the
first call (`findstart = 1`) is performed earlier—before any matches are
gathered from other sources.

This adjustment gives event-driven completion sources (e.g., LSP
clients) more time to send their requests while Vim concurrently
collects matches from other sources like the current buffer.

Not sure about the real-world performance gains, but this approach
should, in theory, improve responsiveness and reduce latency for
asynchronous completions.

To test, try using yegappan LSP client:

```vim
set cpt+=o^10
autocmd VimEnter * g:LspOptionsSet({ autoComplete: false, omniComplete: true })
```

If you prefer to use 'native' auto-completion (without plugins), try the
following configuration:

```vim
set cot=menuone,popup,noselect,nearest
autocmd TextChangedI * InsComplete()
def InsComplete()
  if getcharstr(1) == '' && getline('.')->strpart(0, col('.') - 1) =~ '\k$'
    SkipTextChangedI()
    feedkeys("\<c-n>", "n")
  endif
enddef
inoremap <silent> <c-e> <c-r>=<SID>SkipTextChangedI()<cr><c-e>
inoremap <silent> <c-y> <c-r>=<SID>SkipTextChangedI()<cr><c-y>
def SkipTextChangedI(): string
  set eventignore+=TextChangedI
  timer_start(1, (_) => {
    set eventignore-=TextChangedI
  })
  return ''
enddef
inoremap <silent><expr> <tab> pumvisible() ? "\<c-n>" : "\<tab>"
inoremap <silent><expr> <s-tab> pumvisible() ? "\<c-p>" : "\<s-tab>"
```

closes: vim/vim#17396

https://github.com/vim/vim/commit/98c29dbfd1c0765cbe5a2fce71072a33ad629f34

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1424: PMenu selection broken with multi-line selection and limits

Problem:  PMenu selection broken with multi-line selection and limits
          (Maxim Kim)
Solution: update completion match index when limiting the completion
          sources (Girish Palya)

closes: vim/vim#17401

https://github.com/vim/vim/commit/6c40df09e07dced75010be2d7a8e4831f6b9f796

Co-authored-by: Girish Palya <girishji@gmail.com>
