### PR TITLE
fix(vim.hl.range): handle edge case when `start==finish && inclusive==false`

### DIFF
--- a/runtime/lua/vim/hl.lua
+++ b/runtime/lua/vim/hl.lua
@@ -91,6 +91,10 @@ function M.range(bufnr, ns, higroup, start, finish, opts)
     end
   end)
 
+  if not inclusive and pos1[2] == pos2[2] and pos1[3] == pos2[3] then
+    return
+  end
+
   local region = vim.fn.getregionpos(pos1, pos2, {
     type = regtype,
     exclusive = not inclusive,


### PR DESCRIPTION
Problem: `echo foo | nvim +"lua vim.hl.range(0,1,'DiffAdd',{0,1},{0,1},{inclusive=false})"` shouldn't add highlight.

Solution: early quit when `start==finish && inclusive==false`

Related: https://github.com/vim/vim/issues/17410

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
