### PR TITLE
fix(extui): adjust "more" window routing

### DIFF
--- a/runtime/lua/vim/_extui.lua
+++ b/runtime/lua/vim/_extui.lua
@@ -110,10 +110,8 @@ function M.enable(opts)
     end
   end
 
-  if vim.v.vim_did_enter == 1 then
-    ext.tab_check_wins()
-    check_opt('cmdheight', vim.o.cmdheight)
-  end
+  ext.tab_check_wins()
+  check_opt('cmdheight', vim.o.cmdheight)
 
   api.nvim_create_autocmd('OptionSet', {
     group = ext.augroup,

--- a/runtime/lua/vim/_extui/shared.lua
+++ b/runtime/lua/vim/_extui/shared.lua
@@ -88,7 +88,8 @@ function M.tab_check_wins()
         api.nvim_set_option_value('smoothscroll', true, { scope = 'local' })
         local ft = type == 'cmd' and 'cmdline' or ('msg' .. type)
         api.nvim_set_option_value('filetype', ft, { scope = 'local' })
-        api.nvim_set_option_value('eventignorewin', 'all', { scope = 'local' })
+        local ignore = 'all' .. (type == 'more' and ',-WinLeave,-TextYankPost' or '')
+        api.nvim_set_option_value('eventignorewin', ignore, { scope = 'local' })
       end)
     end
   end


### PR DESCRIPTION
Problem:  Message lines from multiple message events that spill
          'cmdheight' end up spread out over the cmdline and "more"
          window.
          Messages emitted as feedback to a typed :command (rather than
          its sole purpose like :echo/:=) are routed to the more window.
          The more window isn't closed when entering the cmdwin, and
          doesn't allow `vim.hl.on_yank()`.
Solution: When first opening the "more" window for spilled messages,
          move the message buffer to the more window.
          Restrict routing of typed commands to echo kinds.
          Ignore all events but WinLeave and TextYankPost.

Fix #34213
Fix #34214
