### PR TITLE
vim-patch:055cca8: runtime(java): Reference a modern syntax item generator for type names

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1582,13 +1582,8 @@ old way, put the following line into your Vim startup file: >
 All (exported) public types declared in `java.lang` are always automatically
 imported and available as simple names.  To highlight them, use: >
 	:let g:java_highlight_java_lang_ids = 1
-
-You can also highlight types of most standard Java packages if you download
-the javaid.vim script at https://www.fleiner.com/vim/download.html.  If you
-prefer to only highlight types of a certain package, say `java.io`, use the
-following: >
-	:let g:java_highlight_java_io = 1
-Check the javaid.vim file for a list of all the packages that are supported.
+You can also generate syntax items for other public and protected types and
+opt in to highlight some of their names see |java-package-info-url|.
 
 Headers of indented function declarations can be highlighted (along with parts
 of lambda expressions and method reference expressions), but it depends on how
@@ -1740,7 +1735,8 @@ The supported JEP numbers are to be drawn from this table:
 Note that as soon as the particular preview feature will have been integrated
 into the Java platform, its entry will be removed from the table and related
 optionality will be discontinued.
-
+						*java-package-info-url*
+https://github.com/zzzyxwvut/java-vim/blob/42cbd51/tools/javaid/src/javaid/package-info.java
 
 JSON			*json.vim* *ft-json-syntax* *g:vim_json_conceal*
 						*g:vim_json_warnings*

--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Aliaksei Budavei <0x000c70 AT gmail DOT com>
 " Former Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
-" Last Change:		2025 Apr 28
+" Last Change:		2025 May 30
 
 " Please check ":help java.vim" for comments on some of the options
 " available.
@@ -301,9 +301,7 @@ if exists("g:java_highlight_all") || exists("g:java_highlight_java") || exists("
   hi def link javaLangObject javaConstant
 endif
 
-if filereadable(expand("<sfile>:p:h") . "/javaid.vim")
-  source <sfile>:p:h/javaid.vim
-endif
+runtime syntax/javaid.vim
 
 if exists("g:java_space_errors")
   if !exists("g:java_no_trail_space_error")


### PR DESCRIPTION
#### vim-patch:055cca8: runtime(java): Reference a modern syntax item generator for type names

And generalise the sourcing of "javaid.vim" for Java
buffers.

closes: vim/vim#17411

https://github.com/vim/vim/commit/055cca88c45099073424b69074678bceadebbe09

Co-authored-by: Aliaksei Budavei <0x000c70@gmail.com>