### PR TITLE
fix(windows): don't set window icon on SIGHUP

### DIFF
--- a/src/nvim/os/os_win_console.c
+++ b/src/nvim/os/os_win_console.c
@@ -29,6 +29,11 @@ int os_open_conin_fd(void)
   return conin_fd;
 }
 
+void os_clear_hwnd(void) 
+{
+    hWnd = NULL;
+}
+
 void os_replace_stdin_to_conin(void)
 {
   close(STDIN_FILENO);

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -23,6 +23,10 @@
 # include "nvim/memline.h"
 #endif
 
+#ifdef MSWIN
+# include "nvim/os/os_win_console.h"
+#endif
+
 static SignalWatcher spipe, shup, squit, sterm, susr1, swinch, ststp;
 #ifdef SIGPWR
 static SignalWatcher spwr;
@@ -219,11 +223,14 @@ static void on_signal(SignalWatcher *handle, int signum, void *data)
     }
     break;
 #endif
+  case SIGHUP:
+#ifdef MSWIN
+    os_clear_hwnd();
+#endif
   case SIGTERM:
 #ifdef SIGQUIT
   case SIGQUIT:
 #endif
-  case SIGHUP:
     if (!rejecting_deadly) {
       deadly_signal(signum);
     }


### PR DESCRIPTION
Problem:
When using conhost and pressing the 'x' button
to close it while nvim is open, nvim hangs up
while trying to reset the window icon, causing a big delay before the terminal actually closes.

Solution:
Set the window handle to NULL after receiving SIGHUP so that nvim will not try resetting the icon.

Fixes: #34171
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
