### PR TITLE
fix(extui): reposition "more" window after entering cmdwin

### DIFF
--- a/runtime/lua/vim/_extui/messages.lua
+++ b/runtime/lua/vim/_extui/messages.lua
@@ -170,11 +170,10 @@ end
 
 --- Move message buffer to more window.
 local function msg_to_more(tar)
-  api.nvim_win_set_buf(ext.wins[ext.tab].more, ext.bufs[tar])
   api.nvim_buf_delete(ext.bufs.more, { force = true })
   api.nvim_buf_set_name(ext.bufs[tar], 'vim._extui.more')
   ext.bufs.more, ext.bufs[tar], M[tar].count = ext.bufs[tar], -1, 0
-  ext.tab_check_wins()
+  ext.tab_check_wins() -- Create and setup new/moved buffer.
   M.set_pos('more')
 end
 

--- a/runtime/lua/vim/_extui/shared.lua
+++ b/runtime/lua/vim/_extui/shared.lua
@@ -65,7 +65,7 @@ function M.tab_check_wins()
         anchor = type ~= 'cmd' and 'SE' or nil,
         hide = type ~= 'cmd' or M.cmdheight == 0 or nil,
         title = type == 'more' and 'Messages' or nil,
-        border = type == 'box' and not o.termguicolors and 'single' or border or 'none',
+        border = type == 'box' and 'single' or border or 'none',
         -- kZIndexMessages < zindex < kZIndexCmdlinePopupMenu (grid_defs.h), 'more' below others.
         zindex = 200 - (type == 'more' and 1 or 0),
         _cmdline_offset = type == 'cmd' and 0 or nil,
@@ -88,7 +88,7 @@ function M.tab_check_wins()
         api.nvim_set_option_value('smoothscroll', true, { scope = 'local' })
         local ft = type == 'cmd' and 'cmdline' or ('msg' .. type)
         api.nvim_set_option_value('filetype', ft, { scope = 'local' })
-        local ignore = 'all' .. (type == 'more' and ',-WinLeave,-TextYankPost' or '')
+        local ignore = 'all' .. (type == 'more' and ',-TextYankPost' or '')
         api.nvim_set_option_value('eventignorewin', ignore, { scope = 'local' })
       end)
     end

--- a/runtime/lua/vim/_extui/shared.lua
+++ b/runtime/lua/vim/_extui/shared.lua
@@ -39,20 +39,16 @@ function M.tab_check_wins()
   end
 
   for _, type in ipairs({ 'box', 'cmd', 'more', 'prompt' }) do
-    if not api.nvim_buf_is_valid(M.bufs[type]) then
+    local setopt = not api.nvim_buf_is_valid(M.bufs[type])
+    if setopt then
       M.bufs[type] = api.nvim_create_buf(false, true)
-      api.nvim_buf_set_name(M.bufs[type], 'vim._extui.' .. type)
       if type == 'cmd' then
         -- Attach highlighter to the cmdline buffer.
         local parser = assert(vim.treesitter.get_parser(M.bufs.cmd, 'vim', {}))
         M.cmd.highlighter = vim.treesitter.highlighter.new(parser)
-      elseif type == 'more' then
-        -- Close more window with `q`, same as `checkhealth`
-        api.nvim_buf_set_keymap(M.bufs.more, 'n', 'q', '<Cmd>wincmd c<CR>', {})
       end
     end
 
-    local setopt = false
     if
       not api.nvim_win_is_valid(M.wins[M.tab][type])
       or not api.nvim_win_get_config(M.wins[M.tab][type]).zindex -- no longer floating
@@ -81,6 +77,12 @@ function M.tab_check_wins()
     end
 
     if setopt then
+      api.nvim_buf_set_name(M.bufs[type], 'vim._extui.' .. type)
+      if type == 'more' then
+        -- Close more window with `q`, same as `checkhealth`
+        api.nvim_buf_set_keymap(M.bufs.more, 'n', 'q', '<Cmd>wincmd c<CR>', {})
+      end
+
       -- Fire a FileType autocommand with window context to let the user reconfigure local options.
       api.nvim_win_call(M.wins[M.tab][type], function()
         api.nvim_set_option_value('wrap', true, { scope = 'local' })


### PR DESCRIPTION
**fix(extui): reposition "more" window after entering cmdwin**

Problem:  Closing the "more" window for an entered cmdwin in ff95d7ff9
          still requires special casing to properly handle "more" visibility.
Solution: Reposition the "more" window instead; anchoring it to the
          cmdwin.

**fix(extui): properly setup "more" window for changed buffer**

Problem:  Buffer setup after moving the message buffer to the "more"
          window after ff95d7ff is incomplete.
Solution: Adjust and invoke tab_check_wins() to do the setup instead.

Fix #34275.
