### PR TITLE
fix(api): reconfiguring float "relative" does not clear "win"

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -1206,6 +1206,8 @@ static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fco
                     "non-float with 'win' requires at least 'split' or 'vertical'");
       goto fail;
     }
+  } else {
+    fconfig->window = 0;
   }
 
   if (HAS_KEY_X(config, external)) {

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -369,6 +369,21 @@ describe('float window', function()
     )
   end)
 
+  it('no error message when reconfig relative field on closed win', function()
+    command('split')
+    local winid = api.nvim_open_win(0, false, {
+      relative = 'win',
+      width = 1,
+      height = 1,
+      col = 1,
+      row = 1,
+    })
+    eq(1001, api.nvim_win_get_config(winid).win)
+    command('close')
+    api.nvim_win_set_config(winid, { relative = 'editor', row = 1, col = 1 })
+    eq(nil, api.nvim_win_get_config(winid).win)
+  end)
+
   it('is not operated on by windo when non-focusable #15374', function()
     command([[
       let winids = []


### PR DESCRIPTION
Problem:  Unable to change the "relative" flag of a float after its
          target "win" no longer exists.
Solution: Unset target window if it is not present in config and
          reconfigured "relative" no longer expects a target window.