### PR TITLE
refactor(windows): remove redundant icon messages

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -814,7 +814,7 @@ void getout(int exitval)
 
 #ifdef MSWIN
   // Restore Windows console icon before exiting.
-  os_icon_set(NULL, NULL);
+  os_icon_reset();
   os_title_reset();
 #endif
 

--- a/src/nvim/os/os_win_console.c
+++ b/src/nvim/os/os_win_console.c
@@ -31,7 +31,7 @@ int os_open_conin_fd(void)
 
 void os_clear_hwnd(void) 
 {
-    hWnd = NULL;
+  hWnd = NULL;
 }
 
 void os_replace_stdin_to_conin(void)
@@ -58,20 +58,17 @@ void os_replace_stdout_and_stderr_to_conout(void)
   assert(conerr_fd == STDERR_FILENO);
 }
 
-/// Sets Windows console icon, or pass NULL to restore original icon.
-void os_icon_set(HICON hIconSmall, HICON hIcon)
-{
+/// Resets Windows console icon if we got an original one on startup.
+void os_icon_reset(void) {
   if (hWnd == NULL) {
     return;
   }
-  hIconSmall = hIconSmall ? hIconSmall : hOrigIconSmall;
-  hIcon = hIcon ? hIcon : hOrigIcon;
 
-  if (hIconSmall != NULL) {
-    SendMessage(hWnd, WM_SETICON, (WPARAM)ICON_SMALL, (LPARAM)hIconSmall);
+  if (hOrigIconSmall) {
+    SendMessage(hWnd, WM_SETICON, (WPARAM)ICON_SMALL, (LPARAM)hOrigIconSmall);
   }
-  if (hIcon != NULL) {
-    SendMessage(hWnd, WM_SETICON, (WPARAM)ICON_BIG, (LPARAM)hIcon);
+  if (hOrigIcon) {
+    SendMessage(hWnd, WM_SETICON, (WPARAM)ICON_BIG, (LPARAM)hOrigIcon);
   }
 }
 
@@ -83,9 +80,6 @@ void os_icon_init(void)
   if ((hWnd = GetConsoleWindow()) == NULL) {
     return;
   }
-  // Save Windows console icon to be restored later.
-  hOrigIconSmall = (HICON)SendMessage(hWnd, WM_GETICON, (WPARAM)ICON_SMALL, (LPARAM)0);
-  hOrigIcon = (HICON)SendMessage(hWnd, WM_GETICON, (WPARAM)ICON_BIG, (LPARAM)0);
 
   char *vimruntime = os_getenv("VIMRUNTIME");
   if (vimruntime != NULL) {
@@ -95,7 +89,8 @@ void os_icon_init(void)
     } else {
       HICON hVimIcon = LoadImage(NULL, NameBuff, IMAGE_ICON, 64, 64,
                                  LR_LOADFROMFILE | LR_LOADMAP3DCOLORS);
-      os_icon_set(hVimIcon, hVimIcon);
+      hOrigIconSmall = (HICON)SendMessage(hWnd, WM_SETICON, (WPARAM)ICON_SMALL, (LPARAM)hVimIcon);
+      hOrigIcon = (HICON)SendMessage(hWnd, WM_SETICON, (WPARAM)ICON_BIG, (LPARAM)hVimIcon);
     }
     xfree(vimruntime);
   }


### PR DESCRIPTION
These are the changes discussed in comments of #34260

Problem:  Two separate window messages are used to get
          the original console icon and set a new
          one on windows, although the `WM_SETICON`
          message returns the original icon itself.

Solution: Replace the two `WM_GETICON` messages with
          two `WM_SETICON` messages, save the return
          values and remove the call to `os_icon_set`.
          Also, replace `os_icon_set` with `os_icon_reset`
          as its only usage is now resetting the
          icon to the original one.

Also fixed an indent
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
