### PR TITLE
feat(vim.fs) vim.fs.root() can control priority

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3216,6 +3216,10 @@ vim.fs.root({source}, {marker})                                *vim.fs.root()*
         vim.fs.root(0, function(name, path)
           return name:match('%.csproj$') ~= nil
         end)
+
+        -- Find the first ancestor directory containing EITHER "stylua.toml" or ".luarc.json"; if
+        -- not found, find the first ancestor containing ".git":
+        vim.fs.root(0, { { 'stylua.toml', '.luarc.json' }, '.git' })
 <
 
     Attributes: ~
@@ -3225,10 +3229,22 @@ vim.fs.root({source}, {marker})                                *vim.fs.root()*
       • {source}  (`integer|string`) Buffer number (0 for current buffer) or
                   file path (absolute or relative to the |current-directory|)
                   to begin the search from.
-      • {marker}  (`string|string[]|fun(name: string, path: string): boolean`)
-                  A marker, or list of markers, to search for. If a function,
-                  the function is called for each evaluated item and should
-                  return true if {name} and {path} are a match.
+      • {marker}  (`(string|string[]|fun(name: string, path: string): boolean)[]|string|fun(name: string, path: string): boolean`)
+                  A marker or a list of markers. A marker has one of three
+                  types: string, a list of strings or a function. The
+                  parameter also accepts a list of markers, each of which is
+                  any of those three types. If a marker is a function, it is
+                  called for each evaluated item and should return true if
+                  {name} and {path} are a match. If a list of markers is
+                  passed, each marker in the list is evaluated in order and
+                  the first marker which is matched returns the parent
+                  directory that it found. This allows listing markers with
+                  priority. E.g. - in the following list, a parent directory
+                  containing either 'a' or 'b' is searched for. If neither is
+                  found, then 'c' is searched for. So, 'c' has lower priority
+                  than 'a' and 'b' which have equal priority. >lua
+                          marker = { { 'a', 'b' }, 'c' }
+<
 
     Return: ~
         (`string?`) Directory path containing one of the given markers, or nil

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -171,6 +171,7 @@ LUA
 • Lua type annotations for `vim.uv`.
 • |vim.hl.range()| now allows multiple timed highlights.
 • |vim.tbl_extend()| and |vim.tbl_deep_extend()| now accept a function behavior argument.
+• |vim.fs.root()| can define "equal priority" via nested lists.
 
 OPTIONS
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -726,13 +726,7 @@ function lsp.start(config, opts)
     validate('root_markers', opts._root_markers, 'table')
     config = vim.deepcopy(config)
 
-    for _, marker in ipairs(opts._root_markers) do
-      local root = vim.fs.root(bufnr, marker)
-      if root ~= nil then
-        config.root_dir = root
-        break
-      end
-    end
+    config.root_dir = vim.fs.root(bufnr, opts._root_markers)
   end
 
   if

--- a/test/functional/lua/fs_spec.lua
+++ b/test/functional/lua/fs_spec.lua
@@ -366,6 +366,36 @@ describe('vim.fs', function()
       )
     end)
 
+    it('nested markers have equal priority', function()
+      local bufnr = api.nvim_get_current_buf()
+      eq(
+        vim.fs.joinpath(test_source_path, 'test/functional'),
+        exec_lua(
+          [[return vim.fs.root(..., { 'example_spec.lua', {'CMakeLists.txt', 'CMakePresets.json'}, '.luarc.json'})]],
+          bufnr
+        )
+      )
+      eq(
+        vim.fs.joinpath(test_source_path, 'test/functional/fixtures'),
+        exec_lua(
+          [[return vim.fs.root(..., { {'CMakeLists.txt', 'CMakePresets.json'}, 'example_spec.lua', '.luarc.json'})]],
+          bufnr
+        )
+      )
+      eq(
+        vim.fs.joinpath(test_source_path, 'test/functional/fixtures'),
+        exec_lua(
+          [[return vim.fs.root(..., {
+            function(name, _)
+              return name:match('%.txt$')
+            end,
+            'example_spec.lua',
+            '.luarc.json' })]],
+          bufnr
+        )
+      )
+    end)
+
     it('works with a function', function()
       ---@type string
       local result = exec_lua(function()


### PR DESCRIPTION
Adds the capability of controlling the priority of searched markers in vim.fs.root() by nesting lists.

Fix: https://github.com/neovim/neovim/issues/34258

I'm not sure whether to add tests or not because the test added in https://github.com/neovim/neovim/pull/33485/ already covers the use case of this comprehensively. Perhaps copying that over to `fs_spec.lua` would be desirable. I'm not sure.