### PR TITLE
fix(excmd): don't allow range or args for :detach/:restart

### DIFF
--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -734,7 +734,7 @@ M.cmds = {
   },
   {
     command = 'detach',
-    flags = bit.bor(BANG, FILES, CMDARG, ARGOPT, TRLBAR, CMDWIN, LOCK_OK),
+    flags = TRLBAR,
     addr_type = 'ADDR_NONE',
     func = 'ex_detach',
   },
@@ -2247,6 +2247,12 @@ M.cmds = {
     func = 'ex_resize',
   },
   {
+    command = 'restart',
+    flags = bit.bor(BANG, TRLBAR),
+    addr_type = 'ADDR_NONE',
+    func = 'ex_restart',
+  },
+  {
     command = 'retab',
     flags = bit.bor(TRLBAR, RANGE, WHOLEFOLD, DFLALL, BANG, WORD1, CMDWIN, LOCK_OK, MODIFY),
     addr_type = 'ADDR_LINES',
@@ -3367,12 +3373,6 @@ M.cmds = {
     flags = bit.bor(RANGE, WHOLEFOLD, EXTRA, CMDWIN, LOCK_OK, MODIFY),
     addr_type = 'ADDR_LINES',
     func = 'ex_substitute',
-  },
-  {
-    command = 'restart',
-    flags = bit.bor(BANG, FILES, CMDARG, ARGOPT, TRLBAR, CMDWIN, LOCK_OK),
-    addr_type = 'ADDR_NONE',
-    func = 'ex_restart',
   },
   -- commands that start with an uppercase letter
   {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -69,8 +69,6 @@
 #include "nvim/message.h"
 #include "nvim/mouse.h"
 #include "nvim/move.h"
-#include "nvim/msgpack_rpc/channel.h"
-#include "nvim/msgpack_rpc/server.h"
 #include "nvim/normal.h"
 #include "nvim/normal_defs.h"
 #include "nvim/ops.h"
@@ -5599,17 +5597,6 @@ static void ex_detach(exarg_T *eap)
 static void ex_restart(exarg_T *eap)
 {
   bool forceit = eap && eap->forceit;
-
-  // Refuse to restart if text is locked (i.e in command line etc.)
-  if (text_locked()) {
-    text_locked_msg();
-    return;
-  }
-
-  // Refuse to restart if buffer is locked.
-  if (curbuf_locked()) {
-    return;
-  }
 
   win_T *wp = curwin;
 

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -108,6 +108,19 @@ describe('TUI :detach', function()
     assert(status)
     eq(1, #child_uis)
 
+    eq(
+      { false, { 0, 'Vim(detach):E477: No ! allowed: detach!' } },
+      { child_session:request('nvim_command', 'detach!') }
+    )
+    eq(
+      { false, { 0, 'Vim(detach):E481: No range allowed: 1detach' } },
+      { child_session:request('nvim_command', '1detach') }
+    )
+    eq(
+      { false, { 0, 'Vim(detach):E488: Trailing characters: foo: detach foo' } },
+      { child_session:request('nvim_command', 'detach foo') }
+    )
+
     tt.feed_data('\027\027:detach\013')
     -- Note: "Process exited" message is misleading; tt.setup_child_nvim() sees the foreground
     -- process (client) exited, and doesn't know the server is still running?
@@ -176,14 +189,11 @@ describe('TUI :restart', function()
     ]]
     screen:expect(s0)
 
-    tt.feed_data(':echo\013')
-    screen:expect([[
-      ^                                                  |
-      {4:~                                                 }|*3
-      {5:[No Name]                                         }|
-                                                        |
-      {3:-- TERMINAL --}                                    |
-    ]])
+    tt.feed_data(':1restart\013')
+    screen:expect({ any = vim.pesc('{8:E481: No range allowed}') })
+
+    tt.feed_data(':restart foo\013')
+    screen:expect({ any = vim.pesc('{8:E488: Trailing characters: foo}') })
 
     -- Check ":restart" on an unmodified buffer.
     tt.feed_data(':restart\013')


### PR DESCRIPTION
Also remove the CMDWIN and LOCK_OK flags, so that there is no need to
check for text_locked() and curbuf_locked().

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
