### PR TITLE
vim-patch:bfeefc4: runtime(doc): clarify the effect of exclusive single char selections

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5151,9 +5151,14 @@ A jump table for the options with a short description can be found at |Q_op|.
 	the end of line the line break still isn't included.
 	When "exclusive" is used, cursor position in visual mode will be
 	adjusted for inclusive motions |inclusive-motion-selection-exclusive|.
-	Note that when "exclusive" is used and selecting from the end
-	backwards, you cannot include the last character of a line, when
-	starting in Normal mode and 'virtualedit' empty.
+
+	Note:
+	- When "exclusive" is used and selecting from the end backwards, you
+	  cannot include the last character of a line, when starting in Normal
+	  mode and 'virtualedit' empty.
+	- when "exclusive" is used with a single character visual selection,
+	  Vim will behave as if the 'selection' is inclusive (in other words,
+	  you cannot visually select an empty region).
 
 						*'selectmode'* *'slm'*
 'selectmode' 'slm'	string	(default "")

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -4168,6 +4168,10 @@ getregion({pos1}, {pos2} [, {opts}])                               *getregion()*
 		- It is evaluated in current window context, which makes a
 		  difference if the buffer is displayed in a window with
 		  different 'virtualedit' or 'list' values.
+		- When specifying an exclusive selection and {pos1} and {pos2}
+		  are equal, the returned list contains a single character as
+		  if selection is inclusive, to match the behavior of an empty
+		  exclusive selection in Visual mode.
 
 		Examples: >vim
 			xnoremap <CR>

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5414,9 +5414,14 @@ vim.go.sect = vim.go.sections
 --- the end of line the line break still isn't included.
 --- When "exclusive" is used, cursor position in visual mode will be
 --- adjusted for inclusive motions `inclusive-motion-selection-exclusive`.
---- Note that when "exclusive" is used and selecting from the end
---- backwards, you cannot include the last character of a line, when
---- starting in Normal mode and 'virtualedit' empty.
+---
+--- Note:
+--- - When "exclusive" is used and selecting from the end backwards, you
+---   cannot include the last character of a line, when starting in Normal
+---   mode and 'virtualedit' empty.
+--- - when "exclusive" is used with a single character visual selection,
+---   Vim will behave as if the 'selection' is inclusive (in other words,
+---   you cannot visually select an empty region).
 ---
 --- @type 'inclusive'|'exclusive'|'old'
 vim.o.selection = "inclusive"

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3763,6 +3763,10 @@ function vim.fn.getreginfo(regname) end
 --- - It is evaluated in current window context, which makes a
 ---   difference if the buffer is displayed in a window with
 ---   different 'virtualedit' or 'list' values.
+--- - When specifying an exclusive selection and {pos1} and {pos2}
+---   are equal, the returned list contains a single character as
+---   if selection is inclusive, to match the behavior of an empty
+---   exclusive selection in Visual mode.
 ---
 --- Examples: >vim
 ---   xnoremap <CR>

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -4660,6 +4660,10 @@ M.funcs = {
       - It is evaluated in current window context, which makes a
         difference if the buffer is displayed in a window with
         different 'virtualedit' or 'list' values.
+      - When specifying an exclusive selection and {pos1} and {pos2}
+        are equal, the returned list contains a single character as
+        if selection is inclusive, to match the behavior of an empty
+        exclusive selection in Visual mode.
 
       Examples: >vim
       	xnoremap <CR>

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7214,9 +7214,14 @@ local options = {
         the end of line the line break still isn't included.
         When "exclusive" is used, cursor position in visual mode will be
         adjusted for inclusive motions |inclusive-motion-selection-exclusive|.
-        Note that when "exclusive" is used and selecting from the end
-        backwards, you cannot include the last character of a line, when
-        starting in Normal mode and 'virtualedit' empty.
+
+        Note:
+        - When "exclusive" is used and selecting from the end backwards, you
+          cannot include the last character of a line, when starting in Normal
+          mode and 'virtualedit' empty.
+        - when "exclusive" is used with a single character visual selection,
+          Vim will behave as if the 'selection' is inclusive (in other words,
+          you cannot visually select an empty region).
       ]=],
       full_name = 'selection',
       scope = { 'global' },


### PR DESCRIPTION
#### vim-patch:bfeefc4: runtime(doc): clarify the effect of exclusive single char selections

https://github.com/vim/vim/commit/bfeefc474a3ed25852491a93e1e5610774f4de8c

Co-authored-by: Christian Brabandt <cb@256bit.org>