### PR TITLE
fix(client): don't try to restart non-embedded server

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -161,7 +161,7 @@ if t.skip(is_os('win')) then
 end
 
 describe('TUI :restart', function()
-  it('resets buffer to blank', function()
+  it('restarts server with the same arguments', function()
     clear()
     finally(function()
       n.check_close()


### PR DESCRIPTION
Only an embedded server can be restarted.

Also, it should be unnecessary to retrieve args from v:argv, as argc and
argv originally passed to ui_client_start_server() are still valid.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
