### PR TITLE
vim-patch:9.1.{1426,1428}: register completion improve

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -146,7 +146,7 @@ commands in CTRL-X submode				*i_CTRL-X_index*
 |i_CTRL-X_CTRL-N|	CTRL-X CTRL-N	next completion
 |i_CTRL-X_CTRL-O|	CTRL-X CTRL-O	omni completion
 |i_CTRL-X_CTRL-P|	CTRL-X CTRL-P	previous completion
-|i_CTRL-X_CTRL-R|	CTRL-X CTRL-R	complete words from registers
+|i_CTRL-X_CTRL-R|	CTRL-X CTRL-R	complete contents from registers
 |i_CTRL-X_CTRL-S|	CTRL-X CTRL-S	spelling suggestions
 |i_CTRL-X_CTRL-T|	CTRL-X CTRL-T	complete identifiers from thesaurus
 |i_CTRL-X_CTRL-Y|	CTRL-X CTRL-Y	scroll down

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -629,7 +629,7 @@ Completion can be done for:
 11. omni completion					|i_CTRL-X_CTRL-O|
 12. Spelling suggestions				|i_CTRL-X_s|
 13. keywords in 'complete'				|i_CTRL-N| |i_CTRL-P|
-14. words from registers				|i_CTRL-X_CTRL-R|
+14. contents from registers				|i_CTRL-X_CTRL-R|
 
 Additionally, |i_CTRL-X_CTRL-Z| stops completion without changing the text.
 
@@ -1000,7 +1000,7 @@ CTRL-X CTRL-V		Guess what kind of item is in front of the cursor and
 			completion, for example: >
 				:imap <Tab> <C-X><C-V>
 
-Completing words from registers				*compl-register-words*
+Completing contents from registers			*compl-register-words*
 							*i_CTRL-X_CTRL-R*
 CTRL-X CTRL-R		Guess what kind of item is in front of the cursor from
 			all registers and find the first match for it.
@@ -1013,6 +1013,11 @@ CTRL-X CTRL-R		Guess what kind of item is in front of the cursor from
 
 	CTRL-P		Search backwards for previous match.  This match
 			replaces the previous one.
+
+	CTRL-X CTRL-R	Further use of CTRL-X CTRL-R will copy the line
+			following the previous expansion in other contexts
+			unless a double CTRL-X is used (e.g. this switches
+			from completing register words to register contents).
 
 User defined completion					*compl-function*
 

--- a/runtime/doc/usr_24.txt
+++ b/runtime/doc/usr_24.txt
@@ -187,7 +187,7 @@ with a certain type of item:
 	CTRL-X CTRL-D		macro definitions (also in included files)
 	CTRL-X CTRL-I		current and included files
 	CTRL-X CTRL-K		words from a dictionary
-	CTRL-X CTRL-R		words from registers
+	CTRL-X CTRL-R		contents from registers
 	CTRL-X CTRL-T		words from a thesaurus
 	CTRL-X CTRL-]		tags
 	CTRL-X CTRL-V		Vim command line

--- a/runtime/doc/vi_diff.txt
+++ b/runtime/doc/vi_diff.txt
@@ -230,7 +230,7 @@ Insert-mode completion.					|ins-completion|
 	|i_CTRL-X_CTRL-D|	definitions or macros
 	|i_CTRL-X_CTRL-O|	Omni completion: clever completion
 				specifically for a file type
-	|i_CTRL-X_CTRL-R|	words from registers
+	|i_CTRL-X_CTRL-R|	contents from registers
 	etc.
 
 Long line support.					|'wrap'| |'linebreak'|

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -4751,7 +4751,7 @@ func Test_register_completion()
   call feedkeys("Sze\<C-X>\<C-R>\<C-R>=string(complete_info(['mode']))\<CR>\<ESC>", "tx")
   call assert_equal("zero{'mode': 'register'}", getline(1))
 
-  " Test consecutive CTRL-X CTRL-R (adding mode)Add commentMore actions
+  " Test consecutive CTRL-X CTRL-R (adding mode)
   " First CTRL-X CTRL-R should split into words, second should use full content
   let @f = "hello world test complete"
   call setline(1, "hel")

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -4751,6 +4751,27 @@ func Test_register_completion()
   call feedkeys("Sze\<C-X>\<C-R>\<C-R>=string(complete_info(['mode']))\<CR>\<ESC>", "tx")
   call assert_equal("zero{'mode': 'register'}", getline(1))
 
+  " Test consecutive CTRL-X CTRL-R (adding mode)Add commentMore actions
+  " First CTRL-X CTRL-R should split into words, second should use full content
+  let @f = "hello world test complete"
+  call setline(1, "hel")
+  call cursor(1, 3)
+  call feedkeys("a\<C-X>\<C-R>\<C-N>\<Esc>", 'tx')
+  call assert_equal("hello", getline(1))
+
+  " Second consecutive CTRL-X CTRL-R should complete with full content
+  call setline(1, "hello")
+  call cursor(1, 5)
+  call feedkeys("a\<C-X>\<C-R>\<C-X>\<C-R>\<Esc>", 'tx')
+  call assert_equal("hello world test complete", getline(1))
+
+  " Test consecutive completion with multi-line register
+  let @g = "first line content\nsecond line here\nthird line data"
+  call setline(1, "first")
+  call cursor(1, 5)
+  call feedkeys("a\<C-X>\<C-R>\<C-X>\<C-R>\<Esc>", 'tx')
+  call assert_equal("first line content", getline(1))
+
   " Clean up
   bwipe!
   delfunc GetItems


### PR DESCRIPTION
Problem:  CTRL-X CTRL-R only completes individual words from registers,
          making it difficult to insert complete register content.
Solution: Add consecutive CTRL-X CTRL-R support - first press completes
          words, second press completes full register lines, similar to
          CTRL-X CTRL-L and CTRL-X CTRL-P behavior (glepnir).

closes: vim/vim#17395

https://github.com/vim/vim/commit/d5fdfa5c9cf00790cf720e15c580a591a09fa906


vim-patch:9.1.1428: completion: register completion needs cleanup

Problem:  completion: register completion needs cleanup
Solution: slightly refactor get_register_completion()
              (glepnir)

closes: vim/vim#17432

https://github.com/vim/vim/commit/86d46a7018bb648fb27372329e6ddc274051067c

Co-authored-by: glepnir <glephunter@gmail.com>

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
