### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1322,7 +1322,7 @@ may want to add >
 <
 as the final filter on Windows or >
 
-	All Files\t(*)\t*\n"
+	All Files\t(*)\t*\n
 <
 on other platforms, so that the user can still access any desired file.
 

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -510,7 +510,7 @@ paragraph, no matter where the cursor currently is.  Or you can use Visual
 mode: hit "v", move to the end of the block, and type "gq".  See also |gq|.
 
 ==============================================================================
-4. 'expandtab', 'smarttab' and 'softtabstop' options	*ins-expandtab*
+4. 'expandtab', 'softtabstop' and 'smarttab' options	*ins-expandtab*
 
 If the 'expandtab' option is on, spaces will be used to fill the amount of
 whitespace of the tab.  If you want to enter a real <Tab>, type CTRL-V first
@@ -520,13 +520,6 @@ character is replaced with several spaces.  The result of this is that the
 number of characters in the line increases.  Backspacing will delete one
 space at a time.  The original character will be put back for only one space
 that you backspace over (the last one).
-
-							*ins-smarttab*
-When the 'smarttab' option is on, a <Tab> inserts 'shiftwidth' positions at
-the beginning of a line and 'tabstop' positions in other places.  This means
-that often spaces instead of a <Tab> character are inserted.  When 'smarttab'
-is off, a <Tab> always inserts 'tabstop' positions, and 'shiftwidth' is only
-used for ">>" and the like.
 
 							*ins-softtabstop*
 When the 'softtabstop' option is non-zero, a <Tab> inserts 'softtabstop'
@@ -541,6 +534,13 @@ inserted character is a space, then it will only delete the character before
 the cursor.  Otherwise you cannot always delete a single character before the
 cursor.  You will have to delete 'softtabstop' characters first, and then type
 extra spaces to get where you want to be.
+
+							*ins-smarttab*
+When the 'smarttab' option is on, the <Tab> key indents by 'shiftwidth' if the
+cursor is in leading whitespace.  The <BS> key has the opposite effect. This
+behaves as if 'softtabstop' were set to the value of 'shiftwidth'. This option
+allows the user to set 'softtabstop' to a value other than 'shiftwidth' and
+still use the <Tab> key for indentation.
 
 ==============================================================================
 5. Replace mode				*Replace* *Replace-mode* *mode-replace*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5791,16 +5791,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 				*'smarttab'* *'sta'* *'nosmarttab'* *'nosta'*
 'smarttab' 'sta'	boolean	(default on)
 			global
-	When on, a <Tab> in front of a line inserts blanks according to
-	'shiftwidth'.  'tabstop' or 'softtabstop' is used in other places.  A
-	<BS> will delete a 'shiftwidth' worth of space at the start of the
-	line.
-	When off, a <Tab> always inserts blanks according to 'tabstop' or
-	'softtabstop'.  'shiftwidth' is only used for shifting text left or
-	right |shift-left-right|.
-	What gets inserted (a <Tab> or spaces) depends on the 'expandtab'
-	option.  Also see |ins-expandtab|.  When 'expandtab' is not set, the
-	number of spaces is minimized by using <Tab>s.
+	When enabled, the <Tab> key will indent by 'shiftwidth' if the cursor
+	is in leading whitespace.  The <BS> key has the opposite effect.
+	This behaves as if 'softtabstop' is set to the value of 'shiftwidth'.
+	Have a look at section |30.5| of the user guide for detailed
+	explanations on how Vim works with tabs and spaces.
 
 			*'smoothscroll'* *'sms'* *'nosmoothscroll'* *'nosms'*
 'smoothscroll' 'sms'	boolean	(default off)

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -869,7 +869,7 @@ Short explanation of each option:		*option-list*
 'signcolumn'	  'scl'	    when and how to display the sign column
 'smartcase'	  'scs'     no ignore case when pattern has uppercase
 'smartindent'	  'si'	    smart autoindenting for C programs
-'smarttab'	  'sta'     use 'shiftwidth' when inserting <Tab>
+'smarttab'	  'sta'     <Tab> in leading whitespace indents by 'shiftwidth'
 'smoothscroll'	  'sms'     scroll by screen lines when 'wrap' is set
 'softtabstop'	  'sts'     number of spaces that <Tab> uses while editing
 'spell'			    enable spell checking

--- a/runtime/doc/usr_22.txt
+++ b/runtime/doc/usr_22.txt
@@ -27,13 +27,15 @@ Vim has a plugin that makes it possible to edit a directory.  Try this: >
 	:edit .
 
 Through the magic of autocommands and Vim scripts, the window will be filled
-with the contents of the directory.  It looks like this: >
+with the contents of the directory.  It looks like this (slightly cleaned up
+so that it fits within 80 chars): >
 
   " ===========================================================================
-  " Netrw Directory Listing                                        (netrw v109)
+  " Netrw Directory Listing                                        (netrw v180)
+  "   /path/to/vim/runtime/doc
   "   Sorted by      name
-  "   Sort sequence: [\/]$,\.h$,\.c$,\.cpp$,*,\.info$,\.swp$,\.o$\.obj$,\.bak$
-  "   Quick Help: <F1>:help  -:go up dir  D:delete  R:rename  s:sort-by  x:exec
+  "   Sort sequence: [\/]$,*,\(\.bak\|\~\|\.o\|\.h\|\.info\|\.swp\)[*@]\=$
+  "   Quick Help: <F1>:help -:go up dir D:delete R:rename s:sort-by x:special
   " ===========================================================================
   ../
   ./

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -6168,16 +6168,11 @@ vim.o.si = vim.o.smartindent
 vim.bo.smartindent = vim.o.smartindent
 vim.bo.si = vim.bo.smartindent
 
---- When on, a <Tab> in front of a line inserts blanks according to
---- 'shiftwidth'.  'tabstop' or 'softtabstop' is used in other places.  A
---- <BS> will delete a 'shiftwidth' worth of space at the start of the
---- line.
---- When off, a <Tab> always inserts blanks according to 'tabstop' or
---- 'softtabstop'.  'shiftwidth' is only used for shifting text left or
---- right `shift-left-right`.
---- What gets inserted (a <Tab> or spaces) depends on the 'expandtab'
---- option.  Also see `ins-expandtab`.  When 'expandtab' is not set, the
---- number of spaces is minimized by using <Tab>s.
+--- When enabled, the <Tab> key will indent by 'shiftwidth' if the cursor
+--- is in leading whitespace.  The <BS> key has the opposite effect.
+--- This behaves as if 'softtabstop' is set to the value of 'shiftwidth'.
+--- Have a look at section `30.5` of the user guide for detailed
+--- explanations on how Vim works with tabs and spaces.
 ---
 --- @type boolean
 vim.o.smarttab = true

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -8182,16 +8182,11 @@ local options = {
       abbreviation = 'sta',
       defaults = true,
       desc = [=[
-        When on, a <Tab> in front of a line inserts blanks according to
-        'shiftwidth'.  'tabstop' or 'softtabstop' is used in other places.  A
-        <BS> will delete a 'shiftwidth' worth of space at the start of the
-        line.
-        When off, a <Tab> always inserts blanks according to 'tabstop' or
-        'softtabstop'.  'shiftwidth' is only used for shifting text left or
-        right |shift-left-right|.
-        What gets inserted (a <Tab> or spaces) depends on the 'expandtab'
-        option.  Also see |ins-expandtab|.  When 'expandtab' is not set, the
-        number of spaces is minimized by using <Tab>s.
+        When enabled, the <Tab> key will indent by 'shiftwidth' if the cursor
+        is in leading whitespace.  The <BS> key has the opposite effect.
+        This behaves as if 'softtabstop' is set to the value of 'shiftwidth'.
+        Have a look at section |30.5| of the user guide for detailed
+        explanations on how Vim works with tabs and spaces.
       ]=],
       full_name = 'smarttab',
       scope = { 'global' },


### PR DESCRIPTION
#### vim-patch:d6c9ac9: runtime(doc): clarify the effect of 'smarttab'

closes: vim/vim#17426

https://github.com/vim/vim/commit/d6c9ac97a009f7099b7d3636548aa3a4fabb5f1a

Co-authored-by: Damien Lejay <damien@lejay.be>


#### vim-patch:dfed077: runtime(doc): fix small errors from rev 2090405de5bb66facc29c74

- update the netrw window to current version (and trim it slightly to 80
  chars)
- remove a trailing double quote

https://github.com/vim/vim/commit/dfed077e06600df6ae71b06df273a4280dd76ff2

Co-authored-by: Christian Brabandt <cb@256bit.org>
Co-authored-by: Antonio Giovanni Colombo <azc100@gmail.com>