### PR TITLE
fix(treesitter): ensure TSNode's tree is immutable

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -979,8 +979,7 @@ function Query:iter_captures(node, source, start, stop, opts)
 
   start, stop = value_or_node_range(start, stop, node)
 
-  -- Copy the tree to ensure it is valid during the entire lifetime of the iterator
-  local tree = node:tree():copy()
+  local tree = node:tree()
   local cursor = vim._create_ts_querycursor(node, self.query, start, stop, opts)
 
   -- For faster checks that a match is not in the cache.
@@ -1079,8 +1078,7 @@ function Query:iter_matches(node, source, start, stop, opts)
 
   start, stop = value_or_node_range(start, stop, node)
 
-  -- Copy the tree to ensure it is valid during the entire lifetime of the iterator
-  local tree = node:tree():copy()
+  local tree = node:tree()
   local cursor = vim._create_ts_querycursor(node, self.query, start, stop, opts)
 
   local function iter()


### PR DESCRIPTION
Fix #25254 and Fix #31758.

I provide a step-by-step description of how mutating the tree may cause a use-after-free bug in this comment: https://github.com/neovim/neovim/issues/25254#issuecomment-2941884848.

My commit description outlines the proposed fix:

> Problem:
>
> TSNode contains a `const TSTree*` and a `const void *id`. The `id` points to Tree-sitter's internal type `Subtree`, which resides inside the `TSTree` but may be deallocated if the `TSTree` is mutated (which is likely why it is `const`).
>
> The Lua method `TSTree:edit()` mutates the tree, which can deallocate `id`.
>
> See https://github.com/neovim/neovim/issues/25254 and https://github.com/neovim/neovim/issues/31758.
>
> Solution:
>
> To avoid this, we now make a copy of the tree before pushing its root to the Lua stack. This also removes the fenv from TSLuaTree, as it was only used when pushing the tree root to the Lua stack.
>
> We also copy the tree in `node_tree`.
>
> `ts_tree_copy()` just increments a couple of reference counters, so it's relatively cheap to call.

I also found a similar issue in the function [`tslua_push_querycursor`](https://github.com/neovim/neovim/blob/b16dc698cf445635fe094fc3482d1647341ed952/src/nvim/lua/treesitter.c#L1342-L1386), where `TSQueryCursor` stores a `const TSQuery*`, but does not keep a reference to the `TSQuery` on the Lua side. As a result, `TSQuery` could be garbage-collected before `TSQueryCursor`, and accesses to `TSQueryCursor` may trigger a use-after-free. From what I’ve seen, this type is not exposed to user Lua code — it is only used in two places in [this file](https://github.com/neovim/neovim/blob/5e4700152b79e090d880d2734e0eaec726f4b8a7/runtime/lua/vim/treesitter/query.lua#L1084) — so I’m not sure if this bug is actually reachable.
