### PR TITLE
fix(lsp): only auto-detach lsp.config enabled clients

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -541,7 +541,9 @@ local function lsp_enable_callback(bufnr)
   -- Stop any clients that no longer apply to this buffer.
   local clients = lsp.get_clients({ bufnr = bufnr, _uninitialized = true })
   for _, client in ipairs(clients) do
-    if lsp.config[client.name] and not can_start(bufnr, client.name, lsp.config[client.name]) then
+    if
+      lsp.is_enabled(client.name) and not can_start(bufnr, client.name, lsp.config[client.name])
+    then
       lsp.buf_detach_client(bufnr, client.id)
     end
   end


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

Problem: A custom server (initialized through `vim.lsp.start`) gets unexpectedly detached.

Solution: Only auto-detach the clients enabled through `vim.lsp.enable` to prevent unexpected behavior.

Follow up to https://github.com/neovim/neovim/pull/33707 https://github.com/neovim/neovim/pull/33834