### PR TITLE
fix(extui): use visible to determine active "more"

### DIFF
--- a/runtime/lua/vim/_extui.lua
+++ b/runtime/lua/vim/_extui.lua
@@ -49,7 +49,7 @@ local function ui_callback(event, ...)
   ext.tab_check_wins()
   handler(...)
   api.nvim__redraw({
-    flush = true,
+    flush = handler ~= ext.cmd.cmdline_hide or nil,
     cursor = handler == ext.cmd[event] and true or nil,
     win = handler == ext.cmd[event] and ext.wins.cmd or nil,
   })

--- a/runtime/lua/vim/_extui/cmdline.lua
+++ b/runtime/lua/vim/_extui/cmdline.lua
@@ -99,6 +99,7 @@ function M.cmdline_pos(pos)
     curpos[1], curpos[2] = M.row + 1, promptlen + pos
     -- Add matchparen highlighting to non-prompt part of cmdline.
     if pos > 0 and fn.exists('#matchparen') then
+      api.nvim_win_set_cursor(ext.wins.cmd, { curpos[1], curpos[2] - 1 })
       vim._with({ win = ext.wins.cmd, wo = { eventignorewin = '' } }, function()
         api.nvim_exec_autocmds('CursorMoved', {})
       end)


### PR DESCRIPTION
Problem:  Current window is checked to determine whether "more" window
          is open. Making it the current window is scheduled in case the
          cmdwin is open so this can be too late.
          "cmdline_hide" may be emitted when the topline is
          temporarily invalid (after incsearch->restore_viewstate()).
Solution: Use the window visibility to determine an active "more"
          window instead.
          Don't nvim__redraw->flush the "cmdline_hide" event (a normal
          will already happen).

Fix #34324
Fix #34340