### PR TITLE
vim-patch:9.1.{1431,1433}

### DIFF
--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -638,17 +638,13 @@ static int makeopens(FILE *fd, char *dirnow)
     return FAIL;
   }
 
-  // save 'shortmess' if not storing options
+  // Save 'shortmess' if not storing options.
   if ((ssop_flags & kOptSsopFlagOptions) == 0) {
     PUTLINE_FAIL("let s:shortmess_save = &shortmess");
   }
 
-  // set 'shortmess' for the following.  Add the 'A' flag if it was there
-  PUTLINE_FAIL("if &shortmess =~ 'A'");
-  PUTLINE_FAIL("  set shortmess+=aoOA");
-  PUTLINE_FAIL("else");
-  PUTLINE_FAIL("  set shortmess+=aoO");
-  PUTLINE_FAIL("endif");
+  // Set 'shortmess' for the following.
+  PUTLINE_FAIL("set shortmess+=aoO");
 
   // Now save the current files, current buffer first.
   // Put all buffers into the buffer list.

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -645,9 +645,9 @@ static int makeopens(FILE *fd, char *dirnow)
 
   // set 'shortmess' for the following.  Add the 'A' flag if it was there
   PUTLINE_FAIL("if &shortmess =~ 'A'");
-  PUTLINE_FAIL("  set shortmess=aoOA");
+  PUTLINE_FAIL("  set shortmess+=aoOA");
   PUTLINE_FAIL("else");
-  PUTLINE_FAIL("  set shortmess=aoO");
+  PUTLINE_FAIL("  set shortmess+=aoO");
   PUTLINE_FAIL("endif");
 
   // Now save the current files, current buffer first.


### PR DESCRIPTION
#### vim-patch:9.1.1431: Hit-Enter Prompt when loading session files

Problem:  Hit-Enter Prompt when loading session files
Solution: use set+= for 'shortmess' to keep the existing flags
          (Miguel Barro)

closes: vim/vim#17445

https://github.com/vim/vim/commit/0ca59661966dc3e7e4ce5e266acbe1dc01dd8477

Co-authored-by: Miguel Barro <miguel.barro@live.com>


#### vim-patch:9.1.1433: Unnecessary :if when writing session

Problem:  Unnecessary :if in session where both branches have the same
          effect (after 9.1.1431).
Solution: Remove the superfluous :if (zeertzjq).

closes: vim/vim#17448

https://github.com/vim/vim/commit/8f751d56f40b8b45b6d37c73c2c1abdda18c2d4c