### PR TITLE
vim-patch:9.1.1435: completion: various flaws in fuzzy completion

### DIFF
--- a/src/nvim/memory.h
+++ b/src/nvim/memory.h
@@ -21,6 +21,10 @@ typedef void *(*MemCalloc)(size_t, size_t);
 /// `realloc()` function signature
 typedef void *(*MemRealloc)(void *, size_t);
 
+typedef void *(*MergeSortGetFunc)(void *);
+typedef void (*MergeSortSetFunc)(void *, void *);
+typedef int (*MergeSortCompareFunc)(const void *, const void *);
+
 #ifdef UNIT_TESTING
 /// When unit testing: pointer to the `malloc()` function, may be altered
 extern MemMalloc mem_malloc;

--- a/src/nvim/popupmenu.h
+++ b/src/nvim/popupmenu.h
@@ -14,8 +14,6 @@ typedef struct {
   char *pum_kind;       ///< extra kind text (may be truncated)
   char *pum_extra;      ///< extra menu text (may be truncated)
   char *pum_info;       ///< extra info
-  int pum_score;        ///< fuzzy match score
-  int pum_idx;          ///< index of item before sorting by score
   int pum_cpt_source_idx;    ///< index of completion source in 'cpt'
   int pum_user_abbr_hlattr;  ///< highlight attribute for abbr
   int pum_user_kind_hlattr;  ///< highlight attribute for kind


### PR DESCRIPTION
#### vim-patch:9.1.1435: completion: various flaws in fuzzy completion

Problem:  completion: various flaws in fuzzy completion
Solution: fix the issues (Girish Palya)

- Remove the brittle `qsort()` on `compl_match_array`.
- Add a stable, non-recursive `mergesort` for the internal doubly
  linked list of matches.
- The sort now happens directly on the internal representation (`compl_T`),
  preserving sync with external structures and making sorting stable.
- Update fuzzy match logic to enforce `max_matches` limits after
  sorting.
- Remove `trim_compl_match_array()`, which is no longer necessary.
- Fixe test failures by correctly setting `selected` index and
  maintaining match consistency.
- Introduce `mergesort_list()` in `misc2.c`, which operates generically
  over doubly linked lists.
- Remove `pum_score` and `pum_idx` variables

closes: vim/vim#17430

https://github.com/vim/vim/commit/8cd42a58b49c948ab59ced6ca5f5ccfae5d9ecea

Co-authored-by: Girish Palya <girishji@gmail.com>