### PR TITLE
fix(messages): capture execute("messages") with ext_messages

### DIFF
--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1722,6 +1722,32 @@ stack traceback:
       },
     })
   end)
+
+  it('can capture execute("messages"))', function()
+    feed('Q')
+    screen:expect({
+      grid = [[
+        ^                         |
+        {1:~                        }|*4
+      ]],
+      messages = {
+        {
+          content = { { "E354: Invalid register name: '^@'", 9, 6 } },
+          history = true,
+          kind = 'emsg',
+        },
+      },
+    })
+    feed(':let msg = execute("messages")<CR>')
+    screen:expect({
+      grid = [[
+        ^                         |
+        {1:~                        }|*4
+      ]],
+      cmdline = { { abort = false } },
+    })
+    eq("E354: Invalid register name: '^@'", eval('msg'):gsub('\n', ''))
+  end)
 end)
 
 describe('ui/builtin messages', function()


### PR DESCRIPTION
Problem:  "msg_history_show" event is emitted when `msg_silent > 0`.
          E.g. when capturing its output with `execute()`, which also
          doesn't work with ext_messages.
Solution: Don't emit the "msg_history_show" event when `msg_silent > 0`.
          Call regular messaging functions when `redirecting()`, to
          execute `redir_write()` while ensuring the message itself
          is not emitted.

Fix #34341
