### PR TITLE
fix(api): update topline when flushing with nvim__redraw()

### DIFF
--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -2376,6 +2376,8 @@ void nvim__redraw(Dict(redraw) *opts, Error *err)
   // Redraw pending screen updates when explicitly requested or when determined
   // that it is necessary to properly draw other requested components.
   if (opts->flush && !cmdpreview) {
+    validate_cursor(curwin);
+    update_topline(curwin);
     update_screen();
   }
 

--- a/test/functional/api/vim_spec.lua
+++ b/test/functional/api/vim_spec.lua
@@ -5674,4 +5674,32 @@ describe('API', function()
 
     n.assert_alive()
   end)
+
+  it('nvim__redraw updates topline', function()
+    local screen = Screen.new(40, 8)
+    fn.setline(1, fn.range(100))
+    feed(':call getchar()<CR>')
+    fn.cursor(50, 1)
+    screen:expect([[
+      0                                       |
+      1                                       |
+      2                                       |
+      3                                       |
+      4                                       |
+      5                                       |
+      6                                       |
+      ^:call getchar()                         |
+    ]])
+    api.nvim__redraw({ flush = true })
+    screen:expect([[
+      46                                      |
+      47                                      |
+      48                                      |
+      49                                      |
+      50                                      |
+      51                                      |
+      52                                      |
+      ^:call getchar()                         |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:  nvim__redraw may update the screen with an invalid topline.
Solution: Update the topline before calling `update_screen()` (as
          :redraw does).
