### PR TITLE
docs(maintain): luv moved docs in docs folder

### DIFF
--- a/MAINTAIN.md
+++ b/MAINTAIN.md
@@ -128,8 +128,8 @@ Some can be auto-bumped by `scripts/bump_deps.lua`.
 * [Lua](https://www.lua.org/download.html)
 * [Luv](https://github.com/luvit/luv)
     * When bumping, also sync
-      - [our bundled meta file](https://github.com/neovim/neovim/blob/master/runtime/lua/uv/_meta.lua) with [the upstream meta file](https://github.com/luvit/luv/blob/master/meta.lua);
-      - [our bundled documentation](https://github.com/neovim/neovim/blob/master/runtime/doc/luvref.txt) with [the upstream documentation](https://github.com/luvit/luv/blob/master/docs.md).
+      - [our bundled meta file](https://github.com/neovim/neovim/blob/master/runtime/lua/uv/_meta.lua) with [the upstream meta file](https://github.com/luvit/luv/blob/master/docs/meta.lua);
+      - [our bundled documentation](https://github.com/neovim/neovim/blob/master/runtime/doc/luvref.txt) with [the upstream documentation](https://github.com/luvit/luv/blob/master/docs/docs.md).
 * [gettext](https://ftp.gnu.org/pub/gnu/gettext/)
 * [libiconv](https://ftp.gnu.org/pub/gnu/libiconv)
 * [libuv](https://github.com/libuv/libuv)


### PR DESCRIPTION
Luv docs were moved to a separate folder in https://github.com/luvit/luv/commit/64601e9818a13ee30ad941c674c1a1ef12a58506.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
