### PR TITLE
fix(treesitter): support multiple `@injection.content` captures

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -573,7 +573,10 @@ parent tree. The language injection query allows you to specify these
 “injections” using the following captures:
 
     • `@injection.content` - indicates that the captured node should have its
-      contents re-parsed using another language.
+      contents re-parsed using another language. If there are multiple
+      `@injection.content` captures in one pattern, all ranges will be
+      collected and parsed as one tree. This allows query authors to create
+      "scoped" injections with injection query quantifiers.
     • `@injection.language` - indicates that the captured node’s text may
       contain the name of a language that should be used to re-parse the
       `@injection.content`.

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -1013,7 +1013,9 @@ function LanguageTree:_get_injection(match, metadata)
         local ft = vim.filetype.match({ filename = text })
         lang = ft and resolve_lang(ft)
       elseif name == 'injection.content' then
-        ranges = get_node_ranges(node, self._source, metadata[id], include_children)
+        for _, range in ipairs(get_node_ranges(node, self._source, metadata[id], include_children)) do
+          ranges[#ranges + 1] = range
+        end
       end
     end
   end


### PR DESCRIPTION
Before, only the last capture's range would be counted for injection. Now all captured ranges will be counted in the ranges array. This is more intuitive, and also provides a nice solution/alternative to the "scoped injections" issue.

---

### Before

For e.g. rust docstring injections, we would have to do the following:

```scm
(line_comment
  (doc_comment) @injection.content
  (#set! injection.language "markdown")
  (#set! injection.combined))
```

which would infect our query file with some yucky combined injections, and blend together different docstring sections where it would be undesirable.

![image](https://github.com/user-attachments/assets/e9e52571-4efb-49fb-bc0c-62d828316e42)

(note the incorrect highlighting of the second `Hello` header)

### After

Using the following query:

```scm
((line_comment
  (doc_comment) @injection.content)+
  (#set! injection.language "markdown"))
```

we get this result:

![image](https://github.com/user-attachments/assets/435ac192-29b6-49b7-acfb-349abab21b0f)

which is more correct and avoids the use of combined injections