### PR TITLE
ci: skip flaky cursor test on freebsd/cirrus

### DIFF
--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -781,6 +781,10 @@ describe('buffer cursor position is correct in terminal without number column', 
 end)
 
 describe('buffer cursor position is correct in terminal with number column', function()
+  if t.is_ci('cirrus') then
+    return
+  end
+
   local screen
 
   local function setup_ex_register(str)

--- a/test/functional/treesitter/fold_spec.lua
+++ b/test/functional/treesitter/fold_spec.lua
@@ -735,6 +735,9 @@ t2]])
     feed('dd')
     poke_eventloop()
 
+    if t.skip_fragile(pending, t.is_ci('cirrus')) then
+      return
+    end
     screen:expect {
       grid = [[
       {1:-}^t1                                     |


### PR DESCRIPTION
Problem:
Test often fails on cirrus CI (freebsd):

    buffer cursor position is correct in terminal with number column in a line with single-cell multibyte chars and no trailing spaces, before_each
    test/functional/terminal/cursor_spec.lua:805: Row 5 did not match.
    Expected:
      |{7:  1 }                                                                  |
      |{7:  2 }                                                                  |
      |{7:  3 }                                                                  |
      |{7:  4 }                                                                  |
      |*{7:  5 }Entering Ex mode.  Type "visual" to go to Normal mode.            |
      |{7:  6 }:^                                                                 |
      |{3:-- TERMINAL --}                                                        |
    Actual:
      |{7:  1 }                                                                  |
      |{7:  2 }                                                                  |
      |{7:  3 }                                                                  |
      |{7:  4 }                                                                  |
      |*{7:  5 }                                                                  |
      |{7:  6 }:^                                                                 |
      |{3:-- TERMINAL --}                                                        |

Solution:
Skip the whole describe() block. Ex mode isn't that important.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
