### PR TITLE
feat(lua): add snapshot module for buffer diffs and restore

### DIFF
--- a/runtime/lua/vim/snapshot.lua
+++ b/runtime/lua/vim/snapshot.lua
@@ -1,0 +1,322 @@
+local M = {}
+
+--- Captures buffer state at file open (snapshot: 'open', also used as initial 'save').
+---
+--- @param bufnr integer
+function M.capture_open_snapshot(bufnr)
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  vim.api.nvim_buf_set_var(bufnr, 'snapshots', {
+    open = { time = os.time(), lines = lines },
+    save = { time = os.time(), lines = lines },
+  })
+end
+
+--- Captures buffer state at save (snapshot: 'save').
+---
+--- @param bufnr integer
+function M.capture_save_snapshot(bufnr)
+  local lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  local ok, val = pcall(vim.api.nvim_buf_get_var, bufnr, 'snapshots')
+  local snapshots = ok and val or {}
+  snapshots.save = { time = os.time(), lines = lines }
+  vim.api.nvim_buf_set_var(bufnr, 'snapshots', snapshots)
+end
+
+--- Retrieves a named snapshot ('open' or 'save').
+---
+--- @param bufnr integer
+--- @param snapname string
+---
+--- @return string[]|nil
+function M.get_snapshot(bufnr, snapname)
+  local ok, val = pcall(vim.api.nvim_buf_get_var, bufnr, 'snapshots')
+  return ok and val[snapname] and val[snapname].lines or nil
+end
+
+--- Computes a unified diff between two line arrays.
+---
+--- @param a string[]
+--- @param b string[]
+---
+--- @return table[] Diff
+local function compute_diff(a, b)
+  local diff = vim.diff(table.concat(a, '\n'), table.concat(b, '\n'), { result_type = 'indices' })
+  local result = {}
+  local a_idx, b_idx = 1, 1
+
+  ---@type integer[][]
+  local hunks = {}
+  if type(diff) == 'table' then
+    hunks = diff
+  end
+  for _, hunk in ipairs(hunks) do
+    local start_a, count_a, start_b, count_b = unpack(hunk)
+
+    while a_idx < start_a and b_idx < start_b do
+      table.insert(result, { type = 'same', left = a[a_idx], right = b[b_idx] })
+      a_idx = a_idx + 1
+      b_idx = b_idx + 1
+    end
+
+    for _ = 1, count_a do
+      table.insert(result, { type = 'remove', left = a[a_idx], right = '' })
+      a_idx = a_idx + 1
+    end
+
+    for _ = 1, count_b do
+      table.insert(result, { type = 'add', left = '', right = b[b_idx] })
+      b_idx = b_idx + 1
+    end
+  end
+
+  while a_idx <= #a and b_idx <= #b do
+    table.insert(result, { type = 'same', left = a[a_idx], right = b[b_idx] })
+    a_idx = a_idx + 1
+    b_idx = b_idx + 1
+  end
+  return result
+end
+
+--- Compares buffer with a snapshot ('open' or 'save').
+---
+--- @param opts table
+---
+--- @return table|nil, string|nil
+function M.get_diff(opts)
+  local bufnr = opts.bufnr or 0
+  local source_lines --- @type string[]|nil
+
+  if opts.against == 'open' or opts.against == 'save' then
+    source_lines = M.get_snapshot(bufnr, opts.against)
+  else
+    local err_msg = string.format('Unsupported against source: %s', tostring(opts.against))
+    return nil, err_msg
+  end
+
+  if not source_lines then
+    local notfound_msg =
+      string.format('No snapshot found for %s in buffer %d', tostring(opts.against), bufnr)
+    error(notfound_msg)
+  end
+
+  local current_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+
+  return {
+    diff = compute_diff(source_lines, current_lines),
+    left = source_lines,
+    right = current_lines,
+    meta = {
+      --- @type string
+      against = opts.against,
+      ---@type integer|string|nil
+      seq = opts.seq,
+      timestamp = os.time(),
+    },
+  }
+end
+
+--- Restores snapshot of buffer ('open' or 'save'), skip if contents don't differ.
+---
+--- @param bufnr integer
+--- @param snapname string
+function M.restore_snapshot(bufnr, snapname)
+  local lines = M.get_snapshot(bufnr, snapname)
+  if not lines then
+    local notfound_msg = string.format('No snapshot found for %s in buffer %d', snapname, bufnr)
+    error(notfound_msg)
+  end
+
+  local current_lines = vim.api.nvim_buf_get_lines(bufnr, 0, -1, false)
+  local is_modf = vim.diff(
+    table.concat(lines, '\n'),
+    table.concat(current_lines, '\n'),
+    { result_type = 'indices' }
+  )
+
+  if #is_modf == 0 then
+    local not_modf =
+      string.format('Snapshot %s identical — restore skipped in buffer %d', snapname, bufnr)
+    vim.notify(not_modf, vim.log.levels.INFO)
+  else
+    vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, lines)
+  end
+end
+
+--- Renders a side-by-side diff view in a vertical scratch buffer.
+---
+--- @param result { diff: {type: string, left: string, right: string}[] }
+function M.render_diff_view(result)
+  --- @type table[]
+  local diff_lines = result.diff
+  vim.cmd('vnew')
+  local buf = vim.api.nvim_get_current_buf()
+
+  vim.bo[buf].buftype = 'nofile'
+  vim.bo[buf].bufhidden = 'wipe'
+  vim.bo[buf].swapfile = false
+  vim.bo[buf].modifiable = true
+
+  local markers = {
+    add = '+ ',
+    remove = '- ',
+    same = '  ',
+  }
+  local lines = {}
+
+  --- @type table[]
+  for _, entry in ipairs(diff_lines) do
+    local left = (entry.left or ''):gsub('\t', '    ')
+    local right = (entry.right or ''):gsub('\t', '    ')
+    local marker = markers[entry.type] or '? '
+    local formatted_line = string.format('%s %-40s │ %s', marker, left, right)
+    table.insert(lines, formatted_line)
+  end
+
+  vim.api.nvim_buf_set_lines(buf, 0, -1, false, lines)
+  vim.bo[buf].modifiable = false
+
+  local ns = vim.api.nvim_create_namespace('diff_highlight')
+
+  --- @type table[]
+  for i, entry in ipairs(diff_lines) do
+    local line = i - 1
+    --- @type string
+    local marker_group = ({
+      add = 'DiffMarkerAdd',
+      remove = 'DiffMarkerRemove',
+    })[entry.type]
+
+    if marker_group then
+      vim.highlight.range(buf, ns, marker_group, { line, 0 }, { line, 2 }, { inclusive = false })
+    end
+
+    --- @type string
+    local content_group = ({
+      add = 'DiffAdd',
+      remove = 'DiffRemove',
+    })[entry.type]
+
+    if content_group then
+      vim.highlight.range(buf, ns, marker_group, { line, 3 }, { line, -1 }, { inclusive = false })
+    end
+  end
+end
+
+--- Generates a header as a formatted string with name and capture date of a snapshot diff.
+---
+--- @param bufnr integer
+local function get_export_header(bufnr)
+  local filename = vim.api.nvim_buf_get_name(bufnr or 0):gsub(vim.loop.cwd() .. '/', '')
+  local now = os.date('%Y-%m-%d %H:%M:%S')
+  return string.format(
+    [[
+  === Snapshot Diff ===
+  Buffer: %s
+  Timestamp: %s
+  =====================
+  ]],
+    filename ~= '' and filename or '[No Name]',
+    now
+  )
+end
+
+--- Exports a snapshot diff as a formatted string and copies it to the unnamed register.
+---
+--- @param bufnr integer
+--- @param snapname string
+function M.export_diff(bufnr, snapname)
+  bufnr = bufnr or 0
+  local ok, result = pcall(M.get_diff, {
+    bufnr = bufnr,
+    against = snapname,
+  })
+
+  if not ok or not result then
+    local errmsg =
+      string.format('Buffer %d - Export failed for diff against %s snapshot.', bufnr, snapname)
+    vim.notify(errmsg, vim.log.levels.ERROR)
+    return
+  end
+
+  local lines = {}
+  table.insert(lines, get_export_header(bufnr))
+  local markers = {
+    add = '+ ',
+    remove = '- ',
+    same = '  ',
+  }
+
+  local diff_lines = {}
+  if type(result.diff) == 'table' then
+    ---@type {type: string, left: string, right: string}[]
+    diff_lines = result.diff
+  end
+  for _, entry in ipairs(diff_lines) do
+    local marker = markers[entry.type] or '? '
+    ---@type string
+    local content
+
+    if entry.type == 'remove' then
+      content = entry.left or ''
+    elseif entry.type == 'add' then
+      content = entry.right or ''
+    else
+      content = entry.right or entry.left or ''
+    end
+
+    table.insert(lines, marker .. content)
+  end
+
+  local output = table.concat(lines, '\n')
+  vim.fn.setreg('"', output)
+  vim.fn.setreg('+', output)
+  local exprt =
+    string.format('Diff against %s snapshot for buffer %d - exported to clipboard', snapname, bufnr)
+  vim.notify(exprt, vim.log.levels.INFO)
+
+  return output
+end
+
+--- LSP command handler to render a diff with the given snapshot ('open' or 'save').
+---
+--- @param snapname string
+function M.lsp_diff_with(snapname)
+  return function(ctx)
+    local bufnr = ctx.bufnr or 0
+    local ok, result = pcall(M.get_diff, {
+      bufnr = bufnr,
+      against = snapname,
+    })
+    if ok and result then
+      M.render_diff_view(result)
+    else
+      local errmsg = string.format('DiffWith %s failed: %s', snapname, result)
+      vim.notify(errmsg, vim.log.levels.ERROR)
+    end
+  end
+end
+
+--- LSP command handler to restore the given snapshot ('open' or 'save').
+---
+--- @param snapname string
+function M.lsp_restore_snapshot(snapname)
+  return function(ctx)
+    local bufnr = ctx.bufnr or 0
+    local ok, err = pcall(M.restore_snapshot, bufnr, snapname)
+    if not ok then
+      local errmsg = string.format('Restore snapshot %s failed: %s', snapname, err)
+      vim.notify(errmsg, vim.log.levels.ERROR)
+    end
+  end
+end
+
+--- Registers LSP commands for snapshot diff and restore actions.
+function M.register_lsp_commands()
+  vim.lsp.commands = vim.lsp.commands or {}
+  vim.lsp.commands['snapshot.DiffWithOpen'] = M.lsp_diff_with('open')
+  vim.lsp.commands['snapshot.DiffWithSave'] = M.lsp_diff_with('save')
+  vim.lsp.commands['snapshot.RestoreOpenSnap'] = M.lsp_restore_snapshot('open')
+  vim.lsp.commands['snapshot.RestoreSaveSnap'] = M.lsp_restore_snapshot('save')
+end
+
+return M

--- a/runtime/plugin/snapshot.lua
+++ b/runtime/plugin/snapshot.lua
@@ -1,0 +1,88 @@
+local snapshot = require('vim.snapshot')
+
+vim.cmd([[
+  highlight default DiffMarkerAdd    guifg=#00ff00 gui=bold
+  highlight default DiffMarkerRemove guifg=#ff4444 gui=bold
+]])
+
+vim.api.nvim_create_autocmd('BufReadPost', {
+  callback = function(args)
+    snapshot.capture_open_snapshot(args.buf)
+  end,
+})
+
+vim.api.nvim_create_autocmd('BufWritePost', {
+  callback = function(args)
+    snapshot.capture_save_snapshot(args.buf)
+  end,
+})
+
+vim.api.nvim_create_user_command('DiffWithOpen', function(opts)
+  local bufnr = tonumber(opts.args) or 0
+  local result = snapshot.get_diff {
+    bufnr = bufnr,
+    against = 'open',
+  }
+  if result then
+    snapshot.render_diff_view(result)
+  else
+    vim.notify('No diff available for buffer ' .. bufnr, vim.log.levels.ERROR)
+  end
+end, {
+  nargs = '?',
+  desc = 'Diff buffer against on open snapshot.',
+})
+
+vim.api.nvim_create_user_command('DiffWithSave', function(opts)
+  local bufnr = tonumber(opts.args) or 0
+  local result = snapshot.get_diff {
+    bufnr = bufnr,
+    against = 'save',
+  }
+  if result then
+    snapshot.render_diff_view(result)
+  else
+    vim.notify('No diff available for buffer ' .. bufnr, vim.log.levels.ERROR)
+  end
+end, {
+  nargs = '?',
+  desc = 'Diff buffer against most recent save.',
+})
+
+vim.api.nvim_create_user_command('RestoreOpenSnap', function(opts)
+  local bufnr = tonumber(opts.args) or 0
+  snapshot.restore_snapshot(bufnr, 'open')
+end, {
+  nargs = '?',
+  desc = 'Restore buffer from on open snapshot.',
+})
+
+vim.api.nvim_create_user_command('RestoreSaveSnap', function(opts)
+  local bufnr = tonumber(opts.args) or 0
+  snapshot.restore_snapshot(bufnr, 'save')
+end, {
+  nargs = '?',
+  desc = 'Restore buffer from most recent save.',
+})
+
+vim.api.nvim_create_user_command('ExportDiffWithOpen', function(opts)
+  local bufnr = tonumber(opts.args) or 0
+  snapshot.export_diff(bufnr, 'open')
+end, {
+  nargs = '?',
+  desc = 'Export diff against open snapshot to clipboard.',
+})
+
+vim.api.nvim_create_user_command('ExportDiffWithSave', function(opts)
+  local bufnr = tonumber(opts.args) or 0
+  snapshot.export_diff(bufnr, 'save')
+end, {
+  nargs = '?',
+  desc = 'Export diff against most recent save to clipboard.',
+})
+
+vim.api.nvim_create_autocmd('LspAttach', {
+  callback = function()
+    require('vim.snapshot').register_lsp_commands()
+  end,
+})

--- a/test/functional/plugin/snapshot_spec.lua
+++ b/test/functional/plugin/snapshot_spec.lua
@@ -1,0 +1,420 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+local eq = t.eq
+local clear = n.clear
+local exec_lua = n.exec_lua
+local command = n.command
+
+describe('snapshot.nvim', function()
+  before_each(function()
+    clear()
+    exec_lua('require("vim.snapshot")')
+  end)
+
+  it('captures open and save snapshots', function()
+    command('enew')
+    exec_lua([[
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'foo', 'bar'})
+      require('vim.snapshot').capture_open_snapshot(0)
+    ]])
+
+    local snap = exec_lua('return require("vim.snapshot").get_snapshot(0, "open")')
+    eq({ 'foo', 'bar' }, snap)
+
+    exec_lua([[
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'foo', 'baz'})
+      require('vim.snapshot').capture_save_snapshot(0)
+    ]])
+
+    local save_snap = exec_lua('return require("vim.snapshot").get_snapshot(0, "save")')
+    eq({ 'foo', 'baz' }, save_snap)
+  end)
+
+  it('computes diff against on open snapshot', function()
+    command('enew')
+    exec_lua([[
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'a', 'b', 'c'})
+      require('vim.snapshot').capture_open_snapshot(0)
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, {'B'})
+    ]])
+
+    local diff = exec_lua([[
+      local snap = require('vim.snapshot')
+      local result = snap.get_diff({ bufnr = 0, against = 'open' })
+      return result.diff
+    ]])
+    eq({
+      { type = 'same', left = 'a', right = 'a' },
+      { type = 'remove', left = 'b', right = '' },
+      { type = 'add', left = '', right = 'B' },
+      { type = 'same', left = 'c', right = 'c' },
+    }, diff)
+
+    exec_lua([[
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, {})
+      vim.api.nvim_buf_set_lines(0, 1, 1, false, {'b'})
+    ]])
+
+    local diff_notmod = exec_lua([[
+      local snap = require('vim.snapshot')
+      local result = snap.get_diff({ bufnr = 0, against = 'open' })
+      return result.diff
+    ]])
+    eq({
+      { type = 'same', left = 'a', right = 'a' },
+      { type = 'same', left = 'b', right = 'b' },
+      { type = 'same', left = 'c', right = 'c' },
+    }, diff_notmod)
+
+    exec_lua([[
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'a', 'b', 'c'})
+      require('vim.snapshot').capture_open_snapshot(0)
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, {'b    '})
+    ]])
+
+    local diff_restrd = exec_lua([[
+      local snap = require('vim.snapshot')
+      local result = snap.get_diff({ bufnr = 0, against = 'open' })
+      return result.diff
+    ]])
+    eq({
+      { type = 'same', left = 'a', right = 'a' },
+      { type = 'remove', left = 'b', right = '' },
+      { type = 'add', left = '', right = 'b    ' },
+      { type = 'same', left = 'c', right = 'c' },
+    }, diff_restrd)
+  end)
+
+  it('computes diff against save snapshot', function()
+    command('enew')
+    exec_lua([[
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'foo', 'bar'})
+      require('vim.snapshot').capture_open_snapshot(0)
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'foo', 'baz'})
+      require('vim.snapshot').capture_save_snapshot(0)
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'foo', 'qux'})
+    ]])
+
+    local diff = exec_lua([[
+      local snap = require('vim.snapshot')
+      local result = snap.get_diff({ bufnr = 0, against = 'save' })
+      return result.diff
+    ]])
+    eq({
+      { type = 'same', left = 'foo', right = 'foo' },
+      { type = 'remove', left = 'baz', right = '' },
+      { type = 'add', left = '', right = 'qux' },
+    }, diff)
+  end)
+
+  it('handles unicode and multibyte characters', function()
+    command('enew')
+    exec_lua([[
+        vim.api.nvim_buf_set_lines(0, 0, -1, false, {'α', 'β', 'γ'})
+        require('vim.snapshot').capture_open_snapshot(0)
+        vim.api.nvim_buf_set_lines(0, 1, 2, false, {'δ'})
+    ]])
+    local diff = exec_lua([[
+        local snap = require('vim.snapshot')
+        local result = snap.get_diff({ bufnr = 0, against = 'open' })
+        return result.diff
+    ]])
+    eq({
+      { type = 'same', left = 'α', right = 'α' },
+      { type = 'remove', left = 'β', right = '' },
+      { type = 'add', left = '', right = 'δ' },
+      { type = 'same', left = 'γ', right = 'γ' },
+    }, diff)
+  end)
+
+  it('restores snapshot correctly when content differs against on open snapshot', function()
+    command('enew')
+    exec_lua([[
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'one', 'two'})
+      require('vim.snapshot').capture_open_snapshot(0)
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'changed'})
+      require('vim.snapshot').restore_snapshot(0, 'open')
+    ]])
+
+    local lines = exec_lua('return vim.api.nvim_buf_get_lines(0, 0, -1, false)')
+    eq({ 'one', 'two' }, lines)
+  end)
+
+  it('restores snapshot correctly when content differs against save snapshot', function()
+    command('enew')
+    exec_lua([[
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'one', 'two'})
+      require('vim.snapshot').capture_save_snapshot(0)
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'changed'})
+      require('vim.snapshot').restore_snapshot(0, 'save')
+    ]])
+
+    local lines = exec_lua('return vim.api.nvim_buf_get_lines(0, 0, -1, false)')
+    eq({ 'one', 'two' }, lines)
+  end)
+
+  it(
+    'restores notifies correctly when buffer contents are identical against on open snapshot',
+    function()
+      command('enew')
+      exec_lua([[
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'identical', 'lines'})
+      require('vim.snapshot').capture_open_snapshot(0)
+    ]])
+
+      local notify_msg = exec_lua([[
+      local _errmsg
+      local _notify = vim.notify
+      vim.notify = function(m, ...)
+        _errmsg = m
+        return _notify(m, ...)
+      end
+      require('vim.snapshot').restore_snapshot(0, 'open')
+      vim.notify = _notify
+      return _errmsg
+    ]])
+      eq(
+        string.format('Snapshot %s identical — restore skipped in buffer %d', 'open', 0),
+        notify_msg
+      )
+    end
+  )
+
+  it(
+    'restores notifies correctly when buffer contents are identical against save snapshot',
+    function()
+      command('enew')
+      exec_lua([[
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'identical', 'lines'})
+      require('vim.snapshot').capture_save_snapshot(0)
+    ]])
+
+      local notify_msg = exec_lua([[
+      local _errmsg
+      local _notify = vim.notify
+      vim.notify = function(m, ...)
+        _errmsg = m
+        return _notify(m, ...)
+      end
+      require('vim.snapshot').restore_snapshot(0, 'save')
+      vim.notify = _notify
+      return _errmsg
+    ]])
+      eq(
+        string.format('Snapshot %s identical — restore skipped in buffer %d', 'save', 0),
+        notify_msg
+      )
+    end
+  )
+
+  it('overwrites snapshot when capturing again', function()
+    command('enew')
+    exec_lua([[
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'first', 'version'})
+      require('vim.snapshot').capture_open_snapshot(0)
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'second', 'version'})
+      require('vim.snapshot').capture_open_snapshot(0)
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'other', 'content'})
+      require('vim.snapshot').restore_snapshot(0, 'open')
+    ]])
+
+    local lines = exec_lua('return vim.api.nvim_buf_get_lines(0, 0, -1, false)')
+    eq({ 'second', 'version' }, lines)
+  end)
+
+  it('returns nil and presents error if no on open snapshot is found', function()
+    command('enew')
+    local result = exec_lua('return require("vim.snapshot").get_snapshot(0, "open")')
+    eq(vim.NIL, result)
+
+    local ok, err = pcall(function()
+      exec_lua([[
+        require('vim.snapshot').get_diff({ bufnr = 0, against = 'open' })
+      ]])
+    end)
+    assert(not ok)
+    assert(string.match(err, 'No snapshot found for open in buffer 0'))
+  end)
+
+  it('returns nil and presents error if no save snapshot is found', function()
+    command('enew')
+    local result = exec_lua('return require("vim.snapshot").get_snapshot(0, "save")')
+    eq(vim.NIL, result)
+
+    local ok, err = pcall(function()
+      exec_lua([[
+        require('vim.snapshot').restore_snapshot(0, 'save')
+      ]])
+    end)
+    assert(not ok)
+    assert(string.match(err, 'No snapshot found for save in buffer 0'))
+  end)
+
+  it('handles empty buffers', function()
+    command('enew')
+    exec_lua('require("vim.snapshot").capture_open_snapshot(0)')
+
+    local diff = exec_lua([[
+      local snap = require('vim.snapshot')
+      local result = snap.get_diff({ bufnr = 0, against = 'open' })
+      return result.diff
+    ]])
+    eq({
+      { type = 'same', left = '', right = '' },
+    }, diff)
+  end)
+
+  it('handles snapshots for non-current buffers', function()
+    command('enew')
+    local bufnr = exec_lua('return vim.api.nvim_create_buf(false, true)')
+    exec_lua(
+      [[
+      vim.api.nvim_buf_set_lines(..., 0, -1, false, {'x', 'y', 'z'})
+      require('vim.snapshot').capture_open_snapshot(...)
+    ]],
+      bufnr
+    )
+    exec_lua(
+      [[
+      vim.api.nvim_buf_set_lines(..., 1, 2, false, {'Y'})
+    ]],
+      bufnr
+    )
+
+    local diff = exec_lua(
+      [[
+      local snap = require('vim.snapshot')
+      local result = snap.get_diff({ bufnr = ..., against = 'open' })
+      return result.diff
+    ]],
+      bufnr
+    )
+    eq({
+      { type = 'same', left = 'x', right = 'x' },
+      { type = 'remove', left = 'y', right = '' },
+      { type = 'add', left = '', right = 'Y' },
+      { type = 'same', left = 'z', right = 'z' },
+    }, diff)
+
+    exec_lua(
+      [[
+      require('vim.snapshot').restore_snapshot(..., 'open')
+    ]],
+      bufnr
+    )
+    local lines = exec_lua('return vim.api.nvim_buf_get_lines(..., 0, -1, false)', bufnr)
+    eq({ 'x', 'y', 'z' }, lines)
+  end)
+
+  it('renders diff view in a scratch buffer', function()
+    command('enew')
+    local buf = exec_lua([[
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'one', 'two', 'three'})
+      require('vim.snapshot').capture_open_snapshot(0)
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, {'TWO'})
+      local result = require('vim.snapshot').get_diff({ bufnr = 0, against = 'open' })
+      require('vim.snapshot').render_diff_view(result)
+      return vim.api.nvim_get_current_buf()
+    ]])
+
+    local _render = exec_lua('return vim.api.nvim_buf_get_lines(..., 0, -1, false)', buf)
+    local expected = {
+      '   one                                      │ one',
+      '-  two                                      │ ',
+      '+                                           │ TWO',
+      '   three                                    │ three',
+    }
+    eq(expected, _render)
+
+    local opts = exec_lua(
+      [[
+      return {
+        buftype = vim.bo[...].buftype,
+        bufhidden = vim.bo[...].bufhidden,
+        swapfile = vim.bo[...].swapfile,
+      }
+    ]],
+      buf
+    )
+    eq({ buftype = 'nofile', bufhidden = 'wipe', swapfile = false }, opts)
+  end)
+
+  it('exports correctly formatted diff with header', function()
+    command('enew')
+    exec_lua([[
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+        'a',
+        'b',
+        'c'
+      })
+      require('vim.snapshot').capture_open_snapshot(0)
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {
+        'a',
+        'c',
+        'd'
+      })
+    ]])
+
+    local output = exec_lua([[
+      return require('vim.snapshot').export_diff(0, 'open')
+    ]])
+    assert(output:match('=== Snapshot Diff ==='))
+    assert(output:match('Timestamp:%s+%d%d%d%d%-%d%d%-%d%d'))
+    assert(output:match('Buffer:%s+'))
+    assert(output:match('a'))
+    assert(output:match('- b'))
+    assert(output:match('c'))
+    assert(output:match('+ d'))
+  end)
+
+  it('registers LSP commands', function()
+    exec_lua('require("vim.snapshot").register_lsp_commands()')
+
+    local commands = exec_lua('return vim.tbl_keys(vim.lsp.commands)')
+    table.sort(commands)
+    eq({
+      'snapshot.DiffWithOpen',
+      'snapshot.DiffWithSave',
+      'snapshot.RestoreOpenSnap',
+      'snapshot.RestoreSaveSnap',
+    }, commands)
+  end)
+
+  it('lsp_diff_with paths correctly to get_diff and render_diff_view', function()
+    command('enew')
+    exec_lua([[
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'lsp', 'test'})
+      require('vim.snapshot').capture_open_snapshot(0)
+      vim.api.nvim_buf_set_lines(0, 1, 2, false, {'changed'})
+    ]])
+
+    local ok = exec_lua([[
+      local called_render = false
+      local snap = require('vim.snapshot')
+      local _render = snap.render_diff_view
+      snap.render_diff_view = function(result)
+        called_render = true
+        return _render(result)
+      end
+      local _handler = snap.lsp_diff_with('open')
+      local success, err = pcall(_handler, { bufnr = 0 })
+      snap.render_diff_view = _render
+      return success and called_render
+    ]])
+    eq(true, ok)
+  end)
+
+  it('lsp_restore_snapshot paths correctly and restores content', function()
+    command('enew')
+    exec_lua([[
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'before'})
+      require('vim.snapshot').capture_save_snapshot(0)
+      vim.api.nvim_buf_set_lines(0, 0, -1, false, {'after'})
+      local _handler = require('vim.snapshot').lsp_restore_snapshot('save')
+      _handler({ bufnr = 0 })
+    ]])
+
+    local lines = exec_lua('return vim.api.nvim_buf_get_lines(0, 0, -1, false)')
+    eq({ 'before' }, lines)
+  end)
+end)


### PR DESCRIPTION
### Proposes adding a new optional Lua runtime module `vim.snapshot`.
- This is **fully opt-in**, no global state or behavior unless explicitly used.
- Module is intended to live under `runtime/lua/vim/` as a reusable utility for plugin authors.
- No native dependencies, full functionality tested in Lua.

### Provides:

- Side-by-side visual diff rendering in a scratch buffer using `vim.diff`
![image](https://github.com/user-attachments/assets/fdf91690-690f-4ffc-89e7-88a2ca04134f)

- Snapshot restore with change detection
- Clipboard export of formatted diffs
![image](https://github.com/user-attachments/assets/77167ad6-9d23-4623-ad96-819d63e34582)
- Optional LSP and user command integration

### Testing `test/functional/lua/snapshot_spec.lua`:

- Snapshot capture/overwrite
- Diff accuracy
- Restore behavior (changed/unchanged)
- Unicode and multibyte support
- UI visual rendering of diffs
- Export correctness

**Draft** to gather feedback and clarify the appropriate place for the module (runtime vs. plugin)