### PR TITLE
fix(compositor): don't blend unitialized background cells

### DIFF
--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -699,8 +699,9 @@ static HlAttrs get_colors_force(int attr)
 /// @return the resulting attributes.
 int hl_blend_attrs(int back_attr, int front_attr, bool *through)
 {
+  // Cannot blend uninitialized cells, use front_attr for uninitialized background cells.
   if (front_attr < 0 || back_attr < 0) {
-    return -1;
+    return front_attr;
   }
 
   HlAttrs fattrs = get_colors_force(front_attr);

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -2491,6 +2491,29 @@ describe('TUI', function()
     }
   end)
 
+  it("float is still highlighted with 'winblend' over uninitialized cells #34360", function()
+    write_file(
+      'Xblend.lua',
+      [[
+        local win = vim.api.nvim_open_win(0, false, { relative = 'editor', width = 3, height = 1, row = 1000, col = 0, zindex = 400 })
+        vim.api.nvim_set_option_value('winblend', 30, { win = win })
+        vim.fn.setline(1, "foo")
+        vim.api.nvim_buf_set_extmark(0, vim.api.nvim_create_namespace(''), 0, 0, { end_col = 3, hl_group = 'Title' })
+    ]]
+    )
+    finally(function()
+      os.remove('Xblend.lua')
+    end)
+    local screen = tt.setup_child_nvim({ '--clean', '-u', 'Xblend.lua' })
+    screen:expect([[
+      {3:^foo}                                               |
+      ~                                                 |*3
+      [No Name] [+]                   1,1            All|
+      {3:foo}                                               |
+      {3:-- TERMINAL --}                                    |
+    ]])
+  end)
+
   it('with non-tty (pipe) stdout/stderr', function()
     finally(function()
       os.remove('testF')


### PR DESCRIPTION
Problem:  A 'winblend' window floating over uninitialized cells loses
          its highlighting.
Solution: Return the front attribute for uninitialized background cells.

Fix #34360