### PR TITLE
vim-patch: Vim syntax updates

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -323,7 +323,7 @@ if s:vim9script
             \\|
           \\%(^\s*#.*\)\@<=$
             \\|
-          \\n\s*\\\|\n\s*#\\ 
+          \\n\s*\\\|\n\s*#\\
         \+
         \ matchgroup=vimCommand
         \ end="\s\+\zsas\ze\s\+\h"
@@ -370,7 +370,7 @@ syn match	vimAugroupBang	contained	"\a\@1<=!"	skipwhite nextgroup=vimAugroupName
 syn keyword	vimAugroupKey	contained	aug[roup] 	skipwhite nextgroup=vimAugroupBang,vimAugroupName,vimAugroupEnd
 
 " remove
-syn match	vimAugroup	"\<aug\%[roup]!"		skipwhite nextgroup=vimAugroupName contains=vimAugroupKey,vimAugroupBang 
+syn match	vimAugroup	"\<aug\%[roup]!"		skipwhite nextgroup=vimAugroupName contains=vimAugroupKey,vimAugroupBang
 
 " list
 VimL syn match	vimAugroup	"\<aug\%[roup]\>\ze\s*\%(["|]\|$\)"	skipwhite nextgroup=vimCmdSep,vimComment  contains=vimAugroupKey
@@ -1050,7 +1050,7 @@ syn match	vimWildcardBracketEquivalenceClass	contained	"\[=[^=]\+=]"	nextgroup=@
 syn match	vimWildcardBracketCollatingSymbol	contained	"\[\.[^.]\+\.]"	nextgroup=@vimWildcardBracketCharacter,vimWildcardBracketEnd
 
 syn match	vimWildcardBracketStart	contained	"\["	nextgroup=vimWildcardBracketCaret,vimWildcardBracketRightBracket,@vimWildcardBracketCharacter
-syn match	vimWildcardBracketCaret	contained	"\^"	nextgroup=@vimWildcardBracketCharacter,vimWildcardBracketRightBracket 
+syn match	vimWildcardBracketCaret	contained	"\^"	nextgroup=@vimWildcardBracketCharacter,vimWildcardBracketRightBracket
 syn match	vimWildcardBracketEnd	contained	"]"
 
 syn cluster	vimWildcardBracketCharacter	contains=vimWildcardBracketCharacter,vimWildcardBracketEscape,vimWildcardBracketCharacterClass,vimWildcardBracketEquivalenceClass,vimWildcardBracketCollatingSymbol
@@ -1127,7 +1127,7 @@ syn region	vimExecute	matchgroup=vimCommand start="\<exe\%[cute]\>" skip=+\\|\|\
 syn match	vimExFilter		"\<filt\%[er]\>"	skipwhite nextgroup=vimExFilterBang,vimExFilterPattern
 syn match	vimExFilterBang	 contained	"\a\@1<=!"	skipwhite nextgroup=vimExFilterPattern
 syn region	vimExFilterPattern contained
-      \ start="[[:ident:]]"	
+      \ start="[[:ident:]]"
       \ end="\ze[[:space:]\n]"
       \ skipwhite nextgroup=@vimCmdList
       \ contains=@vimSubstList
@@ -1184,7 +1184,7 @@ syn match	vimVimgrep		"\<l\=vim\%[grep]\>"	skipwhite nextgroup=vimVimgrepBang,vi
 syn match	vimVimgrepadd		"\<l\=vimgrepa\%[dd]\>"	skipwhite nextgroup=vimVimgrepBang,vimVimgrepPattern
 syn match	vimVimgrepBang	  contained	"\a\@1<=!"		skipwhite nextgroup=vimVimgrepPattern
 syn region	vimVimgrepPattern   contained
-      \ start="[[:ident:]]"			    
+      \ start="[[:ident:]]"
       \ end="\ze[[:space:]\n]"
       \ skipwhite nextgroup=vimVimgrepFile,vimCmdSep
       \ contains=@vimSubstList

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -660,7 +660,12 @@ endif
 
 " Blocks: {{{2
 " ======
-Vim9 syn region	vim9Block	matchgroup=vimSep start="{" end="^\s*\zs}" contains=@vimDefBodyList
+Vim9 syn region	vim9Block
+      \ matchgroup=vimSep
+      \ start="{\ze\s*\%($\|[#|]\)"
+      \ end="^\s*\zs}"
+      \ skipwhite nextgroup=vim9Comment,vimCmdSep
+      \ contains=@vimDefBodyList
 
 " Keymaps: {{{2
 " =======

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -1555,7 +1555,7 @@ syn match	vimHiGuiFontname	contained	"'[a-zA-Z\-* ]\+'"
 syn match	vimHiGuiRgb	contained	"#\x\{6}"
 
 " Highlighting: hi group key=arg ... {{{2
-syn cluster	vimHiCluster contains=vimGroup,vimHiBlend,vimHiGroup,vimHiNone,vimHiTerm,vimHiCTerm,vimHiStartStop,vimHiCtermFgBg,vimHiCtermul,vimHiCtermfont,vimHiGui,vimHiGuiFont,vimHiGuiFgBg,vimHiKeyError,vimNotation,vimComment,vim9comment
+syn cluster	vimHiCluster contains=vimGroup,vimHLGroup,vimHiBlend,vimHiGroup,vimHiNone,vimHiTerm,vimHiCTerm,vimHiStartStop,vimHiCtermFgBg,vimHiCtermul,vimHiCtermfont,vimHiGui,vimHiGuiFont,vimHiGuiFgBg,vimHiKeyError,vimNotation,vimComment,vim9comment
 syn region	vimHiKeyList	contained 	start="\i\+" skip=+\\\\\|\\|\|\n\s*\\\|\n\s*"\\ + matchgroup=vimCmdSep end="|" excludenl end="$" contains=@vimContinue,@vimHiCluster
 if !exists("g:vimsyn_noerror") && !exists("g:vimsyn_vimhikeyerror")
  syn match	vimHiKeyError	contained	"\i\+="he=e-1
@@ -1574,7 +1574,7 @@ syn match	vimHiBlend	contained	"\cblend="he=e-1		nextgroup=vimHiNmbr
 syn match	vimHiNmbr	contained	'\d\+'
 
 " Highlight: clear {{{2
-syn keyword	vimHiClear	contained	clear	skipwhite nextgroup=vimGroup,vimHiGroup
+syn keyword	vimHiClear	contained	clear	skipwhite nextgroup=vimGroup,vimHLGroup,vimHiGroup
 
 " Highlight: link {{{2
 " see tst24 (hi def vs hi) (Jul 06, 2018)


### PR DESCRIPTION
#### vim-patch:1cccdeb: runtime(vim): Update base-syntax, improve Vim9 block start pattern

The opening curly brace must be followed by whitespace, comment or
trailing bar.

closes: vim/vim#17454

https://github.com/vim/vim/commit/1cccdebc0f20281daabce3bef0a5cec3a04ffd25

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:6acca4b: runtime(vim): remove trailing whitespace in Vim syntax generator

related: vim/vim#17450

https://github.com/vim/vim/commit/6acca4bc59471c38edf9d5303bd20905a1d4e4f2

Co-authored-by: Eisuke Kawashima <e-kwsm@users.noreply.github.com>


#### vim-patch:834bb85: runtime(vim): vimHLGroup is not highlighted correctly

Problem: vimHLGroup is not highlighted in "hi def link"
          and "hi clear" commands
Solution: highlight vimHLGroup similarly to vimGroup
          (Eisuke Kawashima)

closes: vim/vim#17450

https://github.com/vim/vim/commit/834bb85172e2fe541dfd3064866a91840280562a

Co-authored-by: Eisuke Kawashima <e-kwsm@users.noreply.github.com>