### PR TITLE
vim-patch:partial:8f7256a

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -6464,8 +6464,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 'tabstop' 'ts'		number	(default 8)
 			local to buffer
 	Defines the column multiple used to display the Horizontal Tab
-	character (ASCII 9); a Horizontal Tab always advances to the next
-	tab stop.
+	character (ASCII 9); a Horizontal Tab always advances to the next tab
+	stop.
 	The value must be at least 1 and at most 9999.
 	If |'vartabstop'| is set, this option is ignored.
 	Leave it at 8 unless you have a strong reason (see usr |30.5|).

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -1278,8 +1278,8 @@ complete_match([{lnum}, {col}])                               *complete_match()*
 		  or empty string if no match was found or when using the
 		  default 'iskeyword' pattern.
 
-		When 'isexpand' is empty, uses the 'iskeyword' pattern
-		"\k\+$" to find the start of the current keyword.
+		When 'isexpand' is empty, uses the 'iskeyword' pattern "\k\+$"
+		to find the start of the current keyword.
 
 		Examples: >vim
 		  set isexpand=.,->,/,/*,abc

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -6962,8 +6962,8 @@ vim.go.tabpagemax = vim.o.tabpagemax
 vim.go.tpm = vim.go.tabpagemax
 
 --- Defines the column multiple used to display the Horizontal Tab
---- character (ASCII 9); a Horizontal Tab always advances to the next
---- tab stop.
+--- character (ASCII 9); a Horizontal Tab always advances to the next tab
+--- stop.
 --- The value must be at least 1 and at most 9999.
 --- If `'vartabstop'` is set, this option is ignored.
 --- Leave it at 8 unless you have a strong reason (see usr `30.5`).

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -1123,8 +1123,8 @@ function vim.fn.complete_info(what) end
 ---   or empty string if no match was found or when using the
 ---   default 'iskeyword' pattern.
 ---
---- When 'isexpand' is empty, uses the 'iskeyword' pattern
---- "\k\+$" to find the start of the current keyword.
+--- When 'isexpand' is empty, uses the 'iskeyword' pattern "\k\+$"
+--- to find the start of the current keyword.
 ---
 --- Examples: >vim
 ---   set isexpand=.,->,/,/*,abc

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -1495,8 +1495,8 @@ M.funcs = {
         or empty string if no match was found or when using the
         default 'iskeyword' pattern.
 
-      When 'isexpand' is empty, uses the 'iskeyword' pattern
-      "\k\+$" to find the start of the current keyword.
+      When 'isexpand' is empty, uses the 'iskeyword' pattern "\k\+$"
+      to find the start of the current keyword.
 
       Examples: >vim
         set isexpand=.,->,/,/*,abc

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -9088,8 +9088,8 @@ local options = {
       defaults = 8,
       desc = [=[
         Defines the column multiple used to display the Horizontal Tab
-        character (ASCII 9); a Horizontal Tab always advances to the next
-        tab stop.
+        character (ASCII 9); a Horizontal Tab always advances to the next tab
+        stop.
         The value must be at least 1 and at most 9999.
         If |'vartabstop'| is set, this option is ignored.
         Leave it at 8 unless you have a strong reason (see usr |30.5|).


### PR DESCRIPTION
#### vim-patch:partial:8f7256a: runtime(doc): fix some style issues and remove obsolete docs

https://github.com/vim/vim/commit/8f7256a5ee5b827722de4e7524da1c2adb68bbae

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>