### PR TITLE
vim-patch:9.1.1437: MS-Windows: internal compile error in uc_list()

### DIFF
--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -491,17 +491,21 @@ static void uc_list(char *name, size_t name_len)
         msg_putchar('|');
         len--;
       }
-      while (len-- > 0) {
-        msg_putchar(' ');
+      if (len != 0) {
+        msg_puts(&"    "[4 - len]);
       }
 
       msg_outtrans(cmd->uc_name, HLF_D, false);
       len = strlen(cmd->uc_name) + 4;
 
-      do {
-        msg_putchar(' ');
-        len++;
-      } while (len < 22);
+      if (len < 21) {
+        // Field padding spaces   12345678901234567
+        static char spaces[18] = "                 ";
+        msg_puts(&spaces[len - 4]);
+        len = 21;
+      }
+      msg_putchar(' ');
+      len++;
 
       // "over" is how much longer the name is than the column width for
       // the name, we'll try to align what comes after.

--- a/test/old/testdir/test_usercommands.vim
+++ b/test/old/testdir/test_usercommands.vim
@@ -756,4 +756,24 @@ func Test_multibyte_in_usercmd()
   delcommand SubJapanesePeriodToDot
 endfunc
 
+" Test for listing user commands.
+func Test_command_list_0()
+  " Check space padding of attribute and name in command list
+  set vbs&
+  command! ShortCommand echo "ShortCommand"
+  command! VeryMuchLongerCommand echo "VeryMuchLongerCommand"
+
+  redi @"> | com | redi END
+  pu
+
+  let bl = matchbufline(bufnr('%'), "^    ShortCommand      0", 1, '$')
+  call assert_false(bl == [])
+  let bl = matchbufline(bufnr('%'), "^    VeryMuchLongerCommand 0", 1, '$')
+  call assert_false(bl == [])
+
+  bwipe!
+  delcommand ShortCommand
+  delcommand VeryMuchLongerCommand
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1437: MS-Windows: internal compile error in uc_list()

Problem:  MS-Windows: internal compile error in uc_list() with VS 17.14
          (ibear)
Solution: refactor code slightly (Mike Williams)

closes: vim/vim#17464

https://github.com/vim/vim/commit/0174d8f3863067269f00c1e1be83b699372ca21e

Co-authored-by: Mike Williams <mrmrdubya@gmail.com>