### PR TITLE
fix(treesitter): ensure window is valid in async parsing

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -482,7 +482,9 @@ function TSHighlighter._on_win(_, win, buf, topline, botline)
       == self.tree:parse({ topline, botline + 1 }, function(_, trees)
         if trees and self.parsing[win] then
           self.parsing[win] = false
-          api.nvim__redraw({ win = win, valid = false, flush = false })
+          if api.nvim_win_is_valid(win) then
+            api.nvim__redraw({ win = win, valid = false, flush = false })
+          end
         end
       end)
   if not self.parsing[win] then


### PR DESCRIPTION
Problem: Error occurs if window is invalid in the middle of parsing.
Solution: Check if window is valid in parsing.

- Erorr
```
vim.schedule callback: ...im/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:485: Invalid window id: 1037
stack traceback:
	[C]: in function 'nvim__redraw'
	...im/share/nvim/runtime/lua/vim/treesitter/highlighter.lua:485: in function 'cb'
	...m/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:494: in function '_run_async_callbacks'
	...m/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:550: in function <...m/share/nvim/runtime/lua/vim/treesitter/languagetree.lua:529>
```
- Reproduce script
```lua
local bufnr = vim.api.nvim_create_buf(false, true)
local many_lines = vim.fn["repeat"]({ "local test = 'a'" }, 100000)
vim.api.nvim_buf_set_lines(bufnr, 0, -1, false, many_lines)
local window = vim.api.nvim_open_win(bufnr, true, {
  relative = "editor",
  row = 0,
  col = 0,
  width = 10,
  height = 10,
})
vim.bo.filetype = "lua"
vim.schedule(function()
  vim.api.nvim_win_close(window, true)
end)
```

