### PR TITLE
fix: `fn.exists()` typo

### DIFF
--- a/runtime/lua/vim/_extui/cmdline.lua
+++ b/runtime/lua/vim/_extui/cmdline.lua
@@ -98,7 +98,7 @@ function M.cmdline_pos(pos)
   if curpos[1] ~= M.row + 1 or curpos[2] ~= promptlen + pos then
     curpos[1], curpos[2] = M.row + 1, promptlen + pos
     -- Add matchparen highlighting to non-prompt part of cmdline.
-    if pos > 0 and fn.exists('#matchparen') then
+    if pos > 0 and fn.exists('#matchparen#CursorMoved') == 1 then
       api.nvim_win_set_cursor(ext.wins.cmd, { curpos[1], curpos[2] - 1 })
       vim._with({ win = ext.wins.cmd, wo = { eventignorewin = '' } }, function()
         api.nvim_exec_autocmds('CursorMoved', {})

--- a/test/functional/ui/cmdline_highlight_spec.lua
+++ b/test/functional/ui/cmdline_highlight_spec.lua
@@ -157,7 +157,7 @@ end)
 
 local function set_color_cb(funcname, callback_return, id)
   api.nvim_set_var('id', id or '')
-  if id and id ~= '' and fn.exists('*' .. funcname .. 'N') then
+  if id and id ~= '' and fn.exists('*' .. funcname .. 'N') == 1 then
     command(('let g:Nvim_color_input%s = {cmdline -> %sN(%s, cmdline)}'):format(id, funcname, id))
     if callback_return then
       api.nvim_set_var('callback_return' .. id, callback_return)


### PR DESCRIPTION
When `/` search with `vim._extui` enabled, float win created by `:Gitsigns blame_line` disappear immediately.

This PR can already fix the bug for me...

Two related plugin:
* `gitsigns.nvim`: use `CursorMoved` to close float win
  * https://github.com/lewis6991/gitsigns.nvim/blob/425cb3942716554035ee56b0e36528355c238e3d/lua/gitsigns/popup.lua#L213-L224
  * maybe `vim.bo.ft == "cmdline"` can be excluded...
* `vim-matchup` source `matchpare.vim` but delete autocmd... so I use `#matchpare#CursorMoved` here.
  * https://github.com/andymass/vim-matchup/blob/0caff20a3612b24e886692bc1efef57bfb1a3009/plugin/matchup.vim#L33-L41
