### PR TITLE
fix(messages): single event for multi-expr :echo

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -7846,6 +7846,7 @@ void ex_echo(exarg_T *eap)
     if (!eap->skip) {
       if (atstart) {
         atstart = false;
+        msg_ext_set_kind("echo");
         // Call msg_start() after eval1(), evaluating the expression
         // may cause a message to appear.
         if (eap->cmdidx == CMD_echo) {
@@ -7862,7 +7863,6 @@ void ex_echo(exarg_T *eap)
       }
       char *tofree = encode_tv2echo(&rettv, NULL);
       if (*tofree != NUL) {
-        msg_ext_set_kind("echo");
         msg_ext_append = eap->cmdidx == CMD_echon;
         msg_multiline(cstr_as_string(tofree), echo_hl_id, true, false, &need_clear);
       }

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1748,6 +1748,31 @@ stack traceback:
     })
     eq("E354: Invalid register name: '^@'", eval('msg'):gsub('\n', ''))
   end)
+
+  it('single event for multi-expr :echo', function()
+    command('echo 1 2 | echon 1 2')
+    screen:expect({
+      grid = [[
+        ^                         |
+        {1:~                        }|*4
+      ]],
+      messages = {
+        {
+          content = { { '1 2' } },
+          kind = 'echo',
+        },
+        {
+          append = true,
+          content = { { '12' } },
+          kind = 'echo',
+        },
+        {
+          content = { { 'Press ENTER or type command to continue', 6, 18 } },
+          kind = 'return_prompt',
+        },
+      },
+    })
+  end)
 end)
 
 describe('ui/builtin messages', function()


### PR DESCRIPTION
Problem:  Separate "msg_show" event for each expression in a multi-expr
          :echo(n) command.
Solution: Only set the kind when `atstart == true`.
