### PR TITLE
vim-patch: commentstrings

### DIFF
--- a/runtime/ftplugin/lprolog.vim
+++ b/runtime/ftplugin/lprolog.vim
@@ -2,7 +2,7 @@
 " Language:     LambdaProlog (Teyjus)
 " Maintainer:   Markus Mottl  <markus.mottl@gmail.com>
 " URL:          http://www.ocaml.info/vim/ftplugin/lprolog.vim
-" Last Change:  2025 Apr 16
+" Last Change:  2025 Jun 08 - set 'comments', 'commentstring'
 "               2025 Apr 16 - set 'cpoptions' for line continuation
 "               2023 Aug 28 - added undo_ftplugin (Vim Project)
 "               2006 Feb 05
@@ -26,7 +26,9 @@ setlocal efm=%+A./%f:%l.%c:\ %m
 " Formatting of comments
 setlocal formatprg=fmt\ -w75\ -p\\%
 
-let b:undo_ftplugin = "setlocal efm< fp<"
+setlocal comments=s1:/*,mb:*,ex:*/,:% commentstring=%\ %s
+
+let b:undo_ftplugin = "setlocal efm< fp< com< cms<"
 
 " Add mappings, unless the user didn't want this.
 if !exists("no_plugin_maps") && !exists("no_lprolog_maps")

--- a/runtime/ftplugin/occam.vim
+++ b/runtime/ftplugin/occam.vim
@@ -3,7 +3,8 @@
 " Copyright:	Christian Jacobsen <clj3@kent.ac.uk>, Mario Schweigler <ms44@kent.ac.uk>
 " Maintainer:	Mario Schweigler <ms44@kent.ac.uk>
 " Last Change:	23 April 2003
-"		2024 Jan 14 by Vim Project (browsefilter)
+" 2024 Jan 14 by Vim Project (browsefilter)
+" 2025 Jun 08 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -26,6 +27,7 @@ setlocal expandtab
 " Break comment lines and insert comment leader in this case
 setlocal formatoptions-=t formatoptions+=cql
 setlocal comments+=:--
+setlocal commentstring=--\ %s
 " Maximum length of comments is 78
 setlocal textwidth=78
 "}}}
@@ -46,7 +48,7 @@ endif
 
 "{{{  Undo settings
 let b:undo_ftplugin = "setlocal shiftwidth< softtabstop< expandtab<"
-	\ . " formatoptions< comments< textwidth<"
+	\ . " formatoptions< comments< commentstring< textwidth<"
 	\ . "| unlet! b:browsefilter"
 "}}}
 

--- a/runtime/ftplugin/postscr.vim
+++ b/runtime/ftplugin/postscr.vim
@@ -3,6 +3,7 @@
 " Maintainer:	Mike Williams <mrw@eandem.co.uk>
 " Last Change:	24th April 2012
 "		2024 Jan 14 by Vim Project (browsefilter)
+"		2025 Jun 08 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -17,6 +18,7 @@ set cpo&vim
 
 " PS comment formatting
 setlocal comments=b:%
+setlocal commentstring=%\ %s
 setlocal formatoptions-=t formatoptions+=rol
 
 " Define patterns for the matchit macro
@@ -36,7 +38,7 @@ if (has("gui_win32") || has("gui_gtk")) && !exists("b:browsefilter")
   endif
 endif
 
-let b:undo_ftplugin = "setlocal comments< formatoptions<"
+let b:undo_ftplugin = "setlocal comments< commentstring< formatoptions<"
     \ . "| unlet! b:browsefilter b:match_ignorecase b:match_words"
 
 let &cpo = s:cpo_save

--- a/runtime/ftplugin/rpl.vim
+++ b/runtime/ftplugin/rpl.vim
@@ -1,7 +1,7 @@
 " Vim filetype plugin file
 " Language:     RPL/2
 " Maintainer:   Joël BERTRAND <rpl2@free.fr>
-" Last Change:	2012 Mar 07
+" Last Change:	2025 Jun 08
 " Version: 		0.1
 
 " Only do this when not done yet for this buffer
@@ -18,5 +18,6 @@ setlocal fo-=t fo+=croql
 
 " Set 'comments' to format dashed lists in comments.
 setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
+setlocal commentstring=//\ %s
 
-let b:undo_ftplugin = "setlocal fo< comments<"
+let b:undo_ftplugin = "setlocal fo< comments< commentstring<"

--- a/runtime/ftplugin/vue.vim
+++ b/runtime/ftplugin/vue.vim
@@ -1,5 +1,7 @@
 " Vim filetype plugin file
 " Language:	vue
+" Last Change:
+" 2025 Jun 09 by Vim project set comment options #17479
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -9,6 +11,11 @@ let b:did_ftplugin = 1
 let s:save_cpo = &cpo
 set cpo-=C
 
+setlocal commentstring=<!--\ %s\ -->
+setlocal comments=s:<!--,m:\ \ \ \ ,e:-->
+
+let b:undo_ftplugin = "setlocal comments< commentstring<"
+
 " Copied from ftplugin/html.vim
 " Original thanks to Johannes Zellner and Benji Fisher.
 if exists("loaded_matchit")
@@ -17,6 +24,7 @@ if exists("loaded_matchit")
 	\ .. '<\@<=[ou]l\>[^>]*\%(>\|$\):<\@<=li\>:<\@<=/[ou]l>,'
 	\ .. '<\@<=dl\>[^>]*\%(>\|$\):<\@<=d[td]\>:<\@<=/dl>,'
 	\ .. '<\@<=\([^/][^ \t>]*\)[^>]*\%(>\|$\):<\@<=/\1>'
+	let b:undo_ftplugin .= ' | unlet! b:match_words b:match_ignorecase'
 endif
 
 " Restore the saved compatibility options.


### PR DESCRIPTION
- **vim-patch:aa9fc8e: runtime(vue): set 'com' and 'cms' options in ftplugin**
- **vim-patch:df63097: runtime(lprolog): set com, cms options for lambda prolog**
- **vim-patch:de535cf: runtime(occam): set commentstring option in ftplugin**
- **vim-patch:9e9fe66: runtime(postscr): set commentstring option in ftplugin**
- **vim-patch:446a98f: runtime(rpl): set commentstring option in ftplugin**
