### PR TITLE
feat(filetype): associate Sapling commits with Hg

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2476,6 +2476,7 @@ local pattern = {
       end
     end,
     ['^hg%-editor%-.*%.txt$'] = 'hgcommit',
+    ['^sl%-editor%-.*%.txt$'] = 'hgcommit',
     ['%.html%.m4$'] = 'htmlm4',
     ['^JAM.*%.'] = starsetf('jam'),
     ['^Prl.*%.'] = starsetf('jam'),


### PR DESCRIPTION

Summary: Vim has supported Sapling syntax highlighting since
https://github.com/vim/vim/commit/f1dcd14fc5d4370476cd82895a4479ca2d252e54
However, we didn't associate the Sapling commit editor with the Hg filetype.

This commit associates Sapling commits with the Hg filetype.
