### PR TITLE
vim-patch:9.1.1442: tests: Test_diff_fold_redraw() is insufficient

### DIFF
--- a/test/old/testdir/test_diffmode.vim
+++ b/test/old/testdir/test_diffmode.vim
@@ -52,32 +52,26 @@ endfunc
 
 " Test for diff folding redraw after last diff is resolved
 func Test_diff_fold_redraw()
-  " Set up two files with the minimal case
+  " Set up two files with a minimal case.
   call writefile(['Paragraph 1', '', 'Paragraph 2', '', 'Paragraph 3'], 'Xfile1')
   call writefile(['Paragraph 1', '', 'Paragraph 3'], 'Xfile2')
 
-  " Open in diff mode
-  exe 'edit Xfile1'
-  exe 'vert diffsplit Xfile2'
+  " Open in diff mode.
+  edit Xfile1
+  vert diffsplit Xfile2
 
-  " Ensure both windows are in diff mode and folds are enabled
-  set foldmethod=diff
-  set foldenable
+  " Go to the diff and apply :diffput to copy Paragraph 2 to Xfile2.
+  wincmd l
+  3
+  diffput
 
-  " Go to the diff and apply dp to copy Paragraph 2 to Xfile2
-  normal! ]c
-  normal! dp
+  " Check that the folds in both windows are closed and extend from the first
+  " line of the buffer to the last line of the buffer.
+  call assert_equal(1, foldclosed(line("$")))
+  wincmd h
+  call assert_equal(1, foldclosed(line("$")))
 
-  " Redraw and check folds
-  redraw!
-  let win1_fold = foldclosed(1)
-  let win2_fold = foldclosed(1)
-
-  " Both windows should be fully folded (foldclosed returns 1 for top fold)
-  call assert_equal(1, win1_fold)
-  call assert_equal(1, win2_fold)
-
-  " Clean up
+  " Clean up.
   bwipe!
   bwipe!
   call delete('Xfile1')


### PR DESCRIPTION
#### vim-patch:9.1.1442: tests: Test_diff_fold_redraw() is insufficient

Problem:  tests: Test_diff_fold_redraw() is insufficient
          (after v9.1.1439, Christ van Willegen)
Solution: improve the test (Gary Johnson)

The original Test_diff_fold_redraw() function, added 2025-06-08 at patch
9.1.1439, had a bug and didn't do a very good job of testing the fold
behavior.  This new version is simpler and more thorough.

The bug was that it checked the fold state of one window twice instead
of checking both windows.

closes: vim/vim#17492

https://github.com/vim/vim/commit/69565e3618209001eeeb6a35f14a19d47aaaa8f8

Co-authored-by: Gary Johnson <garyjohn@spocom.com>