### PR TITLE
vim-patch:9.1.1443: potential buffer underflow in insertchar()

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -2133,7 +2133,8 @@ void insertchar(int c, int flags, int second_indent)
       i -= middle_len;
 
       // Check some expected things before we go on
-      if (i >= 0 && (uint8_t)lead_end[end_len - 1] == end_comment_pending) {
+      if (i >= 0 && end_len > 0
+          && (uint8_t)lead_end[end_len - 1] == end_comment_pending) {
         // Backspace over all the stuff we want to replace
         backspace_until_column(i);
 


### PR DESCRIPTION
#### vim-patch:9.1.1443: potential buffer underflow in insertchar()

Problem:  potential buffer underflow in insertchar()
Solution: verify that end_len is larger than zero
          (jinyaoguo)

When parsing the end-comment leader, end_len can be zero if
copy_option_part() writes no characters. The existing check
unconditionally accessed lead_end[end_len-1], causing potential
underflow when end_len == 0.

This change adds an end_len > 0 guard to ensure we only index lead_end
if there is at least one character.

closes: vim/vim#17476

https://github.com/vim/vim/commit/82a96e3dc0ee8f45bb0c1fe17a0cec1db7582e8f

Co-authored-by: jinyaoguo <guo846@purdue.edu>