### PR TITLE
fix(tui): wait for embedded server's exit code

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -81,7 +81,6 @@ Restart Nvim
                 Note: If the current UI hasn't implemented the "restart" UI
                 event, this command is equivalent to `:qall`.
                 Note: Only works if the UI and server are on the same system.
-                Note: Not supported on Windows yet.
 
 :restart!
                 Force restarts the Nvim server, abandoning unsaved buffers.

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -177,5 +177,13 @@ void msg_history_show(Array entries)
 void msg_history_clear(void)
   FUNC_API_SINCE(10) FUNC_API_REMOTE_ONLY;
 
+// This UI event is currently undocumented.
+// - When the server needs to intentionally exit with an exit code, and there is no
+//   message in server stderr for the user, this event is sent with positive `status`
+//   argument, to indicate that the UI should exit normally with `status`.
+// - When the server has crashed or there is a message in server stderr for the user,
+//   this event is not sent, and the UI should make server stderr visible.
+// - When :detach is used on the server, this event is sent with a zero `status`
+//   argument, to indicate that the UI shouldn't wait for server exit.
 void error_exit(Integer status)
-  FUNC_API_SINCE(12);
+  FUNC_API_SINCE(12) FUNC_API_CLIENT_IMPL;

--- a/src/nvim/event/proc.c
+++ b/src/nvim/event/proc.c
@@ -5,6 +5,7 @@
 #include <uv.h>
 
 #include "klib/kvec.h"
+#include "nvim/channel.h"
 #include "nvim/event/libuv_proc.h"
 #include "nvim/event/loop.h"
 #include "nvim/event/multiqueue.h"
@@ -437,16 +438,25 @@ static void on_proc_exit(Proc *proc)
   Loop *loop = proc->loop;
   ILOG("child exited: pid=%d status=%d" PRIu64, proc->pid, proc->status);
 
-#ifdef MSWIN
-  // XXX: This assumes the TUI never spawns any other processes...?
-  // TODO(justinmk): figure out why rpc_close sometimes(??) isn't called, then remove this jank.
+  // TODO(justinmk): figure out why rpc_close sometimes(??) isn't called.
   // Theories:
   // - EOF not received in receive_msgpack, then doesn't call chan_close_on_err().
   // - proc_close_handles not tickled by ui_client.c's LOOP_PROCESS_EVENTS?
   if (ui_client_channel_id) {
-    exit_on_closed_chan(proc->status);
+    uint64_t server_chan_id = ui_client_channel_id;
+    Channel *server_chan = find_channel(server_chan_id);
+    if (server_chan != NULL && server_chan->streamtype == kChannelStreamProc
+        && proc == &server_chan->stream.proc) {
+      // Need to call ui_client_may_restart_server() here as well, as sometimes
+      // rpc_close_event() hasn't been called yet (also see comments above).
+      ui_client_may_restart_server();
+      if (ui_client_channel_id == server_chan_id) {
+        // If the current embedded server has exited and no new server is started,
+        // the client should exit with the same status.
+        exit_on_closed_chan(proc->status);
+      }
+    }
   }
-#endif
 
   // Process has terminated, but there could still be data to be read from the
   // OS. We are still in the libuv loop, so we cannot call code that polls for

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5560,8 +5560,8 @@ static void ex_detach(exarg_T *eap)
   if (eap && eap->forceit) {
     emsg("bang (!) not supported yet");
   } else {
-    // 1. (TODO) Send "detach" UI-event (notification only).
-    // 2. Perform server-side `nvim_ui_detach`.
+    // 1. Send "error_exit" UI-event (notification only).
+    // 2. Perform server-side UI detach.
     // 3. Close server-side channel without self-exit.
 
     if (!current_ui) {
@@ -5578,7 +5578,7 @@ static void ex_detach(exarg_T *eap)
 
     // Server-side UI detach. Doesn't close the channel.
     Error err2 = ERROR_INIT;
-    nvim_ui_detach(chan->id, &err2);
+    remote_ui_disconnect(chan->id, &err2, true);
     if (ERROR_SET(&err2)) {
       emsg(err2.msg);  // UI disappeared already?
       api_clear_error(&err2);

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -348,6 +348,16 @@ cleanup:
   restart_args = (Array)ARRAY_DICT_INIT;
 }
 
+void ui_client_event_error_exit(Array args)
+{
+  if (args.size < 1
+      || args.items[0].type != kObjectTypeInteger) {
+    ELOG("Error handling ui event 'error_exit'");
+    return;
+  }
+  ui_client_error_exit = (int)args.items[0].data.integer;
+}
+
 #ifdef EXITFREE
 void ui_client_free_all_mem(void)
 {

--- a/src/nvim/ui_client.h
+++ b/src/nvim/ui_client.h
@@ -17,7 +17,11 @@ EXTERN sattr_T *grid_line_buf_attr INIT( = NULL);
 // Client-side UI channel. Zero during early startup or if not a (--remote-ui) UI client.
 EXTERN uint64_t ui_client_channel_id INIT( = 0);
 
-// exit status from embedded nvim process
+/// `status` argument of the last "error_exit" UI event, or -1 if none has been seen.
+/// NOTE: This assumes "error_exit" never has a negative `status` argument.
+EXTERN int ui_client_error_exit INIT( = -1);
+
+/// Server exit code.
 EXTERN int ui_client_exit_status INIT( = 0);
 
 /// Whether ui client has sent nvim_ui_attach yet


### PR DESCRIPTION
Fix #21608
Fix #34365

Uses the undocumented "error_exit" UI event for a different purpose:
When :detach is used on the server, send an "error_exit" with 0 `status`
to indicate that the server shouldn't wait for client exit.
