### PR TITLE
fix(msgpack): flush incomplete big UI event before packing RPC event

### DIFF
--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -608,6 +608,12 @@ void serialize_response(Channel *channel, MsgpackRpcRequestHandler handler, Mess
 
 static void packer_buffer_init_channels(Channel **chans, size_t nchans, PackerBuffer *packer)
 {
+  for (size_t i = 0; i < nchans; i++) {
+    Channel *chan = chans[i];
+    if (chan->rpc.ui && chan->rpc.ui->incomplete_event) {
+      remote_ui_flush_pending_data(chan->rpc.ui);
+    }
+  }
   packer->startptr = alloc_block();
   packer->ptr = packer->startptr;
   packer->endptr = packer->startptr + ARENA_BLOCK_SIZE;

--- a/src/nvim/msgpack_rpc/channel_defs.h
+++ b/src/nvim/msgpack_rpc/channel_defs.h
@@ -5,6 +5,7 @@
 
 #include "nvim/api/private/dispatch.h"
 #include "nvim/map_defs.h"
+#include "nvim/ui_defs.h"
 
 typedef struct Channel Channel;
 typedef struct Unpacker Unpacker;
@@ -38,6 +39,7 @@ typedef struct {
 typedef struct {
   bool closed;
   Unpacker *unpacker;
+  RemoteUI *ui;
   uint32_t next_request_id;
   kvec_t(ChannelCallFrame *) call_stack;
   Dict info;

--- a/src/nvim/ui_defs.h
+++ b/src/nvim/ui_defs.h
@@ -72,6 +72,7 @@ typedef struct {
   uint32_t nevents;  ///< number of distinct events (top-level args to "redraw"
   uint32_t ncalls;  ///< number of calls made to the current event (plus one for the name!)
   bool flushed_events;  ///< events where sent to client without "flush" event
+  bool incomplete_event;  ///< incomplete event might be pending
 
   size_t ncells_pending;  ///< total number of cells since last buffer flush
 


### PR DESCRIPTION
fixes #31316 
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
