### PR TITLE
feat(tui): support APC queries in TermResponse

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -4028,8 +4028,8 @@ nvim_ui_term_event({event}, {value})                    *nvim_ui_term_event()*
     Tells Nvim when a terminal event has occurred
 
     The following terminal events are supported:
-    • "termresponse": The terminal sent an OSC or DCS response sequence to
-      Nvim. The payload is the received response. Sets |v:termresponse| and
+    • "termresponse": The terminal sent an OSC, DCS, or APC response sequence
+      to Nvim. The payload is the received response. Sets |v:termresponse| and
       fires |TermResponse|.
 
     Attributes: ~

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1045,7 +1045,7 @@ TermRequest			When a |:terminal| child process emits an OSC,
 				autocommand defined without |autocmd-nested|.
 
 							*TermResponse*
-TermResponse			When Nvim receives an OSC or DCS response from
+TermResponse			When Nvim receives an OSC, DCS, or APC response from
 				the host terminal. Sets |v:termresponse|. The
 				|event-data| is a table with the following fields:
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -221,7 +221,7 @@ TREESITTER
 
 TUI
 
-• todo
+• |TermResponse| now supports APC query responses.
 
 UI
 

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -540,7 +540,7 @@ void nvim_ui_pum_set_bounds(uint64_t channel_id, Float width, Float height, Floa
 ///
 /// The following terminal events are supported:
 ///
-///   - "termresponse": The terminal sent an OSC or DCS response sequence to
+///   - "termresponse": The terminal sent an OSC, DCS, or APC response sequence to
 ///                     Nvim. The payload is the received response. Sets
 ///                     |v:termresponse| and fires |TermResponse|.
 ///

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -463,7 +463,8 @@ static void tk_getkeys(TermInput *input, bool force)
       handle_modereport(input, &key);
     } else if (key.type == TERMKEY_TYPE_UNKNOWN_CSI) {
       handle_unknown_csi(input, &key);
-    } else if (key.type == TERMKEY_TYPE_OSC || key.type == TERMKEY_TYPE_DCS) {
+    } else if (key.type == TERMKEY_TYPE_OSC || key.type == TERMKEY_TYPE_DCS
+               || key.type == TERMKEY_TYPE_APC) {
       handle_term_response(input, &key);
     }
   }
@@ -599,6 +600,9 @@ static void handle_term_response(TermInput *input, const TermKeyKey *key)
       break;
     case TERMKEY_TYPE_DCS:
       kv_printf(response, "\x1bP%s", str);
+      break;
+    case TERMKEY_TYPE_APC:
+      kv_printf(response, "\x1b_%s", str);
       break;
     default:
       // Key type already checked for OSC/DCS in termkey_interpret_string

--- a/src/nvim/tui/termkey/termkey.c
+++ b/src/nvim/tui/termkey/termkey.c
@@ -182,6 +182,9 @@ static void print_key(TermKey *tk, TermKeyKey *key)
   case TERMKEY_TYPE_OSC:
     fprintf(stderr, "Operating System Control");
     break;
+  case TERMKEY_TYPE_APC:
+    fprintf(stderr, "Application Program Command");
+    break;
   case TERMKEY_TYPE_UNKNOWN_CSI:
     fprintf(stderr, "unknown CSI\n");
     break;
@@ -231,7 +234,8 @@ TermKeyResult termkey_interpret_string(TermKey *tk, const TermKeyKey *key, const
   }
 
   if (key->type != TERMKEY_TYPE_DCS
-      && key->type != TERMKEY_TYPE_OSC) {
+      && key->type != TERMKEY_TYPE_OSC
+      && key->type != TERMKEY_TYPE_APC) {
     return TERMKEY_RES_NONE;
   }
 
@@ -1269,6 +1273,9 @@ size_t termkey_strfkey(TermKey *tk, char *buffer, size_t len, TermKeyKey *key, T
     break;
   case TERMKEY_TYPE_OSC:
     l = (size_t)snprintf(buffer + pos, len - pos, "OSC");
+    break;
+  case TERMKEY_TYPE_APC:
+    l = (size_t)snprintf(buffer + pos, len - pos, "APC");
     break;
   case TERMKEY_TYPE_UNKNOWN_CSI:
     l = (size_t)snprintf(buffer + pos, len - pos, "CSI %c", key->code.number & 0xff);

--- a/src/nvim/tui/termkey/termkey_defs.h
+++ b/src/nvim/tui/termkey/termkey_defs.h
@@ -111,6 +111,7 @@ typedef enum {
   TERMKEY_TYPE_MODEREPORT,
   TERMKEY_TYPE_DCS,
   TERMKEY_TYPE_OSC,
+  TERMKEY_TYPE_APC,
   // add other recognised types here
 
   TERMKEY_TYPE_UNKNOWN_CSI = -1,


### PR DESCRIPTION
Add support for APC sequences to libtermkey and the TermResponse autocommand event.

To test, create a file called `test.lua` with the contents:

```lua
vim.api.nvim_create_autocmd('TermResponse', {
  callback = function(ev)
    vim.print(ev.data)
  end,
})

io.stderr:write("\027_Gi=31,s=1,v=1,a=q,t=d,f=24;AAAA\027\\\027[c")
```

Then start `nvim --clean` and `:source test.lua`. If your terminal supports the kitty graphics protocol, you should see

```
{
  sequence = "\27_Gi=31;OK"
}
```