### PR TITLE
test(screen): still match by full row when {MATCH:} is present

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -113,11 +113,13 @@ describe('TUI :detach', function()
       nvim_set .. ' notermguicolors laststatus=2 background=dark',
     }, job_opts)
 
+    --- FIXME: On Windows spaces at the end of a screen line may have wrong attrs.
+    --- Remove the {MATCH:} when that's fixed.
     tt.feed_data('iHello, World')
     screen:expect([[
       Hello, World^                                      |
       {4:~                                                 }|*3
-      {MATCH:No Name}
+      {5:[No Name] [+]{MATCH: *}}{MATCH: *}|
       {3:-- INSERT --}                                      |
       {3:-- TERMINAL --}                                    |
     ]])

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -586,6 +586,7 @@ function Screen:expect(expected, attr_ids, ...)
             after = after:sub(e + 1)
           end
         end
+        pat = pat and '^' .. pat .. '$'
         if row ~= actual_rows[i] and (not pat or not actual_rows[i]:match(pat)) then
           msg_expected_rows[i] = '*' .. msg_expected_rows[i]
           if i <= #actual_rows then


### PR DESCRIPTION
Add '^' and '$' around the pattern. This makes it less likely to make
mistakes of when writing tests with {MATCH:}, as most such tests have
text before and after {MATCH:}.
