### PR TITLE
fix(help): `:h` can focus unfocusable/hide window

### DIFF
--- a/src/nvim/help.c
+++ b/src/nvim/help.c
@@ -141,7 +141,7 @@ void ex_help(exarg_T *eap)
     } else {
       wp = NULL;
       FOR_ALL_WINDOWS_IN_TAB(wp2, curtab) {
-        if (bt_help(wp2->w_buffer)) {
+        if (bt_help(wp2->w_buffer) && !wp2->w_config.hide && wp2->w_config.focusable) {
           wp = wp2;
           break;
         }

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -2671,7 +2671,7 @@ static win_T *qf_find_help_win(void)
   FUNC_ATTR_PURE FUNC_ATTR_WARN_UNUSED_RESULT
 {
   FOR_ALL_WINDOWS_IN_TAB(wp, curtab) {
-    if (bt_help(wp->w_buffer)) {
+    if (bt_help(wp->w_buffer) && !wp->w_config.hide && wp->w_config.focusable) {
       return wp;
     }
   }

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -6225,6 +6225,19 @@ describe('float window', function()
         test_float_mouse_no_focus()
       end)
 
+      it(':help (focusable=false, hide=true)', function()
+        n.add_builddir_to_rtp()
+        command('help')
+        local unfocusable_win =
+          api.nvim_open_win(0, false, { focusable = false, relative = 'editor', width = 1, height = 1, row = 0, col = 0 })
+        local hide_win = api.nvim_open_win(0, false, { hide = true, relative = 'editor', width = 1, height = 1, row = 0, col = 0 })
+        command('helpclose')
+        command('help')
+        local cwin = curwin()
+        neq(unfocusable_win, cwin)
+        neq(hide_win, cwin)
+      end)
+
       it('j', function()
         feed('<c-w>ji') -- INSERT to trigger screen change
         if multigrid then

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -6227,15 +6227,23 @@ describe('float window', function()
 
       it(':help (focusable=false, hide=true)', function()
         n.add_builddir_to_rtp()
-        command('help')
-        local unfocusable_win =
-          api.nvim_open_win(0, false, { focusable = false, relative = 'editor', width = 1, height = 1, row = 0, col = 0 })
-        local hide_win = api.nvim_open_win(0, false, { hide = true, relative = 'editor', width = 1, height = 1, row = 0, col = 0 })
-        command('helpclose')
-        command('help')
-        local cwin = curwin()
-        neq(unfocusable_win, cwin)
-        neq(hide_win, cwin)
+        local w = curwin()
+        for _, helpcmd in ipairs({
+          'help',
+          'helpgrep api-types',
+          'lhelpgrep api-types',
+        }) do
+          command(helpcmd)
+          local badwins = {
+            api.nvim_open_win(0, false, { focusable = false, relative = 'editor', width = 1, height = 1, row = 0, col = 0 }),
+            api.nvim_open_win(0, false, { hide = true, relative = 'editor', width = 1, height = 1, row = 0, col = 0 }),
+          }
+          command('helpclose')
+          command(helpcmd)
+          eq(false, tbl_contains(badwins, curwin()))
+          command('helpclose')
+          eq(w, curwin())
+        end
       end)
 
       it('j', function()


### PR DESCRIPTION
Problem: `:help` can focus unfocusable/hide window

Solution: ignore unfocusable/hide window when reuse help buffer
