### PR TITLE
fix(terminal): don't disable scrolloff for non-terminal buffers

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -6321,7 +6321,8 @@ dict_T *get_winbuf_options(const int bufopt)
 int get_scrolloff_value(win_T *wp)
 {
   // Disallow scrolloff in terminal-mode. #11915
-  if (State & MODE_TERMINAL) {
+  // Still allow 'scrolloff' for non-terminal buffers. #34447
+  if ((State & MODE_TERMINAL) && wp->w_buffer->terminal) {
     return 0;
   }
   return (int)(wp->w_p_so < 0 ? p_so : wp->w_p_so);

--- a/test/functional/terminal/window_split_tab_spec.lua
+++ b/test/functional/terminal/window_split_tab_spec.lua
@@ -125,4 +125,32 @@ describe(':terminal', function()
     eq(2, eval('winnr()'))
     eq('t', eval('mode(1)'))
   end)
+
+  it("non-terminal opened in Terminal mode applies 'scrolloff' #34447", function()
+    api.nvim_set_option_value('scrolloff', 5, {})
+    api.nvim_set_option_value('showtabline', 0, {})
+    screen:try_resize(78, 10)
+    eq({ mode = 't', blocking = false }, api.nvim_get_mode())
+    n.exec_lua([[
+      vim.api.nvim_create_autocmd({ 'BufEnter' }, {
+        callback = function()
+          vim.schedule(function() vim.fn.line('w0') end)
+        end,
+      })
+    ]])
+    n.add_builddir_to_rtp()
+    n.exec('tab help api-types')
+    screen:expect([[
+                                                                                    |
+      ==============================================================================|
+      API Definitions                                         *api-definitions*     |
+                                                                                    |
+                                                              ^*api-types*           |
+      The Nvim C API defines custom types for all function parameters. Some are just|
+      typedefs around C99 standard types, others are Nvim-defined data structures.  |
+                                                                                    |
+      Basic types ~                                                                 |
+                                                                                    |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Fix #34447