### PR TITLE
feat(lsp): handle disabled code actions

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -174,6 +174,7 @@ LSP
 • Incremental selection is now supported via `textDocument/selectionRange`.
   `an` selects outwards and `in` selects inwards.
 • Support for multiline semantic tokens.
+• Support for the `disabled` field on code actions.
 
 LUA
 

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -430,6 +430,7 @@ function protocol.make_client_capabilities()
         resolveSupport = {
           properties = { 'edit', 'command' },
         },
+        disabledSupport = true,
       },
       codeLens = {
         dynamicRegistration = false,


### PR DESCRIPTION
Spec description:

```js
	/**
	 * Marks that the code action cannot currently be applied.
	 *
	 * Clients should follow the following guidelines regarding disabled code
	 * actions:
	 *
	 * - Disabled code actions are not shown in automatic lightbulbs code
	 *   action menus.
	 *
	 * - Disabled actions are shown as faded out in the code action menu when
	 *   the user request a more specific type of code action, such as
	 *   refactorings.
	 *
	 * - If the user has a keybinding that auto applies a code action and only
	 *   a disabled code actions are returned, the client should show the user
	 *   an error message with `reason` in the editor.
	 *
	 * @since 3.16.0
	 */
	disabled?: {

		/**
		 * Human readable description of why the code action is currently
		 * disabled.
		 *
		 * This is displayed in the code actions UI.
		 */
		reason: string;
	};
```