### PR TITLE
fix(float): ensure relative window grid is allocated

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -844,6 +844,7 @@ void ui_ext_win_position(win_T *wp, bool validate)
         }
         int row_off = 0;
         int col_off = 0;
+        win_grid_alloc(win);
         grid = grid_adjust(&win->w_grid, &row_off, &col_off);
         row += row_off;
         col += col_off;

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -909,6 +909,20 @@ describe('float window', function()
     eq({ 3, 3 }, { fn.winnr(), fn.win_id2win(win) })
   end)
 
+  it('no crash for unallocated relative window grid', function()
+    local win = api.nvim_open_win(0, false, { relative = 'editor', row = 0, col = 0, height = 1, width = 1 })
+    exec_lua(function()
+      vim.api.nvim_create_autocmd('CmdwinEnter', {
+        callback = function()
+          vim.api.nvim_win_set_config(win, { relative = 'win', win = 0, row = 0, col = 0 })
+          vim.api.nvim__redraw({ flush = true })
+        end,
+      })
+    end)
+    feed('q:')
+    assert_alive()
+  end)
+
   local function with_ext_multigrid(multigrid)
     local screen, attrs
     before_each(function()


### PR DESCRIPTION
Problem:  Uninitialized grid for a "win" relative float when redrawing
          just after it has been opened.
Solution: Ensure window grid is allocated or assigned the default grid.