### PR TITLE
vim-patch:053aee0: runtime(doc): add more pointers to 'completeopt'

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -639,6 +639,9 @@ and one of the CTRL-X commands.  You exit CTRL-X mode by typing a key that is
 not a valid CTRL-X mode command.  Valid keys are the CTRL-X command itself,
 CTRL-N (next), and CTRL-P (previous).
 
+By default, the possible completions are showed in a menu and the first
+completion is inserted into the text. This can be adjusted with 'completeopt'.
+
 To get the current completion information, |complete_info()| can be used.
 Also see the 'infercase' option if you want to adjust the case of the match.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1651,6 +1651,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    completion in the preview window.  Only works in
 		    combination with "menu" or "menuone".
 
+	This option does not apply to |cmdline-completion|. See 'wildoptions'
+	for that.
+
 						*'completeslash'* *'csl'*
 'completeslash' 'csl'	string	(default "")
 			local to buffer
@@ -7231,6 +7234,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 			is displayed per line.  Often used tag kinds are:
 				d	#define
 				f	function
+
+	This option does not apply to |ins-completion|. See 'completeopt' for
+	that.
 
 						*'winaltkeys'* *'wak'*
 'winaltkeys' 'wak'	string	(default "menu")

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1184,6 +1184,9 @@ vim.go.cia = vim.go.completeitemalign
 --- 	    completion in the preview window.  Only works in
 --- 	    combination with "menu" or "menuone".
 ---
+--- This option does not apply to `cmdline-completion`. See 'wildoptions'
+--- for that.
+---
 --- @type string
 vim.o.completeopt = "menu,popup"
 vim.o.cot = vim.o.completeopt
@@ -7924,6 +7927,9 @@ vim.go.wim = vim.go.wildmode
 --- 		is displayed per line.  Often used tag kinds are:
 --- 			d	#define
 --- 			f	function
+---
+--- This option does not apply to `ins-completion`. See 'completeopt' for
+--- that.
 ---
 --- @type string
 vim.o.wildoptions = "pum,tagfile"

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1640,6 +1640,9 @@ local options = {
            preview  Show extra information about the currently selected
         	    completion in the preview window.  Only works in
         	    combination with "menu" or "menuone".
+
+        This option does not apply to |cmdline-completion|. See 'wildoptions'
+        for that.
       ]=],
       full_name = 'completeopt',
       list = 'onecomma',
@@ -10290,6 +10293,9 @@ local options = {
         		is displayed per line.  Often used tag kinds are:
         			d	#define
         			f	function
+
+        This option does not apply to |ins-completion|. See 'completeopt' for
+        that.
       ]=],
       full_name = 'wildoptions',
       list = 'onecomma',


### PR DESCRIPTION
#### vim-patch:053aee0: runtime(doc): add more pointers to 'completeopt'

Before this commit, I had trouble finding information about configuring
the insert mode completion. In particular, it was not clear that the
'wildopt' config that I already had in my vimrc does not apply here.

Also, `insert.txt` barely mentioned 'completeopt' except when
describing popups (I was more interested in bash-like behavior
where the unique prefix of all completions is completed first).

I'm hoping these edits will make the relevant docs easier to find.

closes: vim/vim#17515

https://github.com/vim/vim/commit/053aee01f7374fc8c985300399b1ad3b3626e40f

Co-authored-by: Ilya Grigoriev <ilyagr@users.noreply.github.com>