### PR TITLE
fix(lsp): advertise supported fold kinds

### DIFF
--- a/runtime/lua/vim/lsp/_folding_range.lua
+++ b/runtime/lua/vim/lsp/_folding_range.lua
@@ -3,6 +3,13 @@ local log = require('vim.lsp.log')
 local ms = require('vim.lsp.protocol').Methods
 local api = vim.api
 
+---@type table<lsp.FoldingRangeKind, true>
+local supported_fold_kinds = {
+  ['comment'] = true,
+  ['imports'] = true,
+  ['region'] = true,
+}
+
 local M = {}
 
 ---@class (private) vim.lsp.folding_range.BufState
@@ -49,9 +56,14 @@ local function renew(bufnr)
 
         local kind = range.kind
         if kind then
-          local kinds = row_kinds[start_row] or {}
-          kinds[kind] = true
-          row_kinds[start_row] = kinds
+          -- Ignore unsupported fold kinds.
+          if supported_fold_kinds[kind] then
+            local kinds = row_kinds[start_row] or {}
+            kinds[kind] = true
+            row_kinds[start_row] = kinds
+          else
+            log.info(('Received unsupported fold kind: "%s"'):format(kind))
+          end
         end
 
         for row = start_row, end_row do

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -440,6 +440,9 @@ function protocol.make_client_capabilities()
       foldingRange = {
         dynamicRegistration = false,
         lineFoldingOnly = true,
+        foldingRangeKind = {
+          valueSet = { 'comment', 'imports', 'region' },
+        },
         foldingRange = {
           collapsedText = true,
         },


### PR DESCRIPTION
The spec says that clients specifying this capability also guarantee to gracefully handle fold kinds which are *not* in this set, which is the case for Neovim I believe. Looking through the code, seems like the only place that we "enforce" a kind to be in this set is through type annotations.