### PR TITLE
vim-patch:9.1.1454: tests: no test for pum at line break position

### DIFF
--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -6202,6 +6202,131 @@ describe('builtin popupmenu', function()
       feed('<Esc>')
     end)
 
+    -- oldtest: Test_pum_position_when_wrap()
+    it('with cursor on a wrapped line', function()
+      exec([[
+        func Omni_test(findstart, base)
+          if a:findstart
+            return col(".")
+          endif
+          return ['foo', 'bar', 'foobar']
+        endfunc
+        set omnifunc=Omni_test
+        set wrap
+        set cot+=noinsert
+      ]])
+      screen:try_resize(25, 15)
+
+      insert(('abcde '):rep(20))
+
+      feed('5|')
+      feed('a<C-X><C-O>')
+      if multigrid then
+        screen:expect({
+          float_pos = { [4] = { -1, 'NW', 2, 3, 4, false, 100, 1, 3, 4 } },
+        })
+      else
+        screen:expect([[
+          abcde^ abcde abcde abcde a|
+          bcde abcde abcde abcde ab|
+          cde abcde abcde abcde abc|
+          de a{s: foo            } abcd|
+          e ab{n: bar            }     |
+          {1:~   }{n: foobar         }{1:     }|
+          {1:~                        }|*8
+          {2:-- }{5:match 1 of 3}          |
+        ]])
+      end
+      feed('<Esc>')
+
+      feed('30|')
+      feed('a<C-X><C-O>')
+      if multigrid then
+        screen:expect({
+          float_pos = { [4] = { -1, 'NW', 2, 4, 4, false, 100, 1, 4, 4 } },
+        })
+      else
+        screen:expect([[
+          abcde abcde abcde abcde a|
+          bcde ^abcde abcde abcde ab|
+          cde abcde abcde abcde abc|
+          de abcde abcde abcde abcd|
+          e ab{s: foo            }     |
+          {1:~   }{n: bar            }{1:     }|
+          {1:~   }{n: foobar         }{1:     }|
+          {1:~                        }|*7
+          {2:-- }{5:match 1 of 3}          |
+        ]])
+      end
+      feed('<Esc>')
+
+      feed('55|')
+      feed('a<C-X><C-O>')
+      if multigrid then
+        screen:expect({
+          float_pos = { [4] = { -1, 'NW', 2, 5, 4, false, 100, 1, 5, 4 } },
+        })
+      else
+        screen:expect([[
+          abcde abcde abcde abcde a|
+          bcde abcde abcde abcde ab|
+          cde a^bcde abcde abcde abc|
+          de abcde abcde abcde abcd|
+          e abcde abcde abcde      |
+          {1:~   }{s: foo            }{1:     }|
+          {1:~   }{n: bar            }{1:     }|
+          {1:~   }{n: foobar         }{1:     }|
+          {1:~                        }|*6
+          {2:-- }{5:match 1 of 3}          |
+        ]])
+      end
+      feed('<Esc>')
+
+      feed('85|')
+      feed('a<C-X><C-O>')
+      if multigrid then
+        screen:expect({
+          float_pos = { [4] = { -1, 'NW', 2, 5, 9, false, 100, 1, 5, 9 } },
+        })
+      else
+        screen:expect([[
+          abcde abcde abcde abcde a|
+          bcde abcde abcde abcde ab|
+          cde abcde abcde abcde abc|
+          de abcde a^bcde abcde abcd|
+          e abcde abcde abcde      |
+          {1:~        }{s: foo            }|
+          {1:~        }{n: bar            }|
+          {1:~        }{n: foobar         }|
+          {1:~                        }|*6
+          {2:-- }{5:match 1 of 3}          |
+        ]])
+      end
+      feed('<C-E><Esc>')
+
+      feed('108|')
+      feed('a<C-X><C-O>')
+      if multigrid then
+        screen:expect({
+          float_pos = { [4] = { -1, 'NW', 2, 5, 7, false, 100, 1, 5, 7 } },
+        })
+      else
+        screen:expect([[
+          abcde abcde abcde abcde a|
+          bcde abcde abcde abcde ab|
+          cde abcde abcde abcde abc|
+          de abcde abcde abcde abcd|
+          e abcde ^abcde abcde      |
+          {1:~      }{s: foo            }{1:  }|
+          {1:~      }{n: bar            }{1:  }|
+          {1:~      }{n: foobar         }{1:  }|
+          {1:~                        }|*6
+          {2:-- }{5:match 1 of 3}          |
+        ]])
+      end
+      feed('<C-E><Esc>')
+    end)
+
     it('does not crash when displayed in last column with rightleft #12032', function()
       local col = 30
       local items = { 'word', 'choice', 'text', 'thing' }

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -2221,5 +2221,70 @@ func Test_pum_clear_when_switch_tab_or_win()
   call StopVimInTerminal(buf)
 endfunc
 
+func Test_pum_position_when_wrap()
+  CheckScreendump
+  let lines =<< trim END
+    func Omni_test(findstart, base)
+      if a:findstart
+        return col(".")
+      endif
+      return ['foo', 'bar', 'foobar']
+    endfunc
+    set omnifunc=Omni_test
+    set wrap
+    set cot+=noinsert
+  END
+  call writefile(lines, 'Xtest', 'D')
+  let buf = RunVimInTerminal('-S Xtest', #{rows: 15, cols: 25})
+
+  let long_text = repeat('abcde ', 20)
+  call term_sendkeys(buf, "i" .. long_text)
+  call TermWait(buf, 50)
+  call term_sendkeys(buf, "\<ESC>")
+  call TermWait(buf, 50)
+
+  call term_sendkeys(buf, "5|")
+  call TermWait(buf, 50)
+  call term_sendkeys(buf, "a\<C-X>\<C-O>")
+  call TermWait(buf, 100)
+  call VerifyScreenDump(buf, 'Test_pum_wrap_line1', {})
+  call term_sendkeys(buf, "\<ESC>")
+  call TermWait(buf, 50)
+
+  call term_sendkeys(buf, "30|")
+  call TermWait(buf, 50)
+  call term_sendkeys(buf, "a\<C-X>\<C-O>")
+  call TermWait(buf, 100)
+  call VerifyScreenDump(buf, 'Test_pum_wrap_line2', {})
+  call term_sendkeys(buf, "\<ESC>")
+  call TermWait(buf, 50)
+
+  call term_sendkeys(buf, "55|")
+  call TermWait(buf, 50)
+  call term_sendkeys(buf, "a\<C-X>\<C-O>")
+  call TermWait(buf, 100)
+  call VerifyScreenDump(buf, 'Test_pum_wrap_line3', {})
+  call term_sendkeys(buf, "\<C-E>\<ESC>")
+  call TermWait(buf, 50)
+
+  call term_sendkeys(buf, "85|")
+  call TermWait(buf, 50)
+  call term_sendkeys(buf, "a\<C-X>\<C-O>")
+  call TermWait(buf, 100)
+  call VerifyScreenDump(buf, 'Test_pum_wrap_line4', {})
+  call term_sendkeys(buf, "\<C-E>\<ESC>")
+  call TermWait(buf, 100)
+
+  call term_sendkeys(buf, "108|")
+  call TermWait(buf, 50)
+  call term_sendkeys(buf, "a\<C-X>\<C-O>")
+  call TermWait(buf, 100)
+  call VerifyScreenDump(buf, 'Test_pum_wrap_line5', {})
+  call term_sendkeys(buf, "\<C-E>\<ESC>")
+  call TermWait(buf, 100)
+
+  call StopVimInTerminal(buf)
+endfunc
+
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1454: tests: no test for pum at line break position

Problem:  Missing test case for pum display on a wrapped line.
Solution: Add a test case to cover pum behavior at line break positions.
          (glepnir)

closes: vim/vim#17520

https://github.com/vim/vim/commit/6cc9bd400192470cd8521fdde6b3d8a0d2e43111

Co-authored-by: glepnir <glephunter@gmail.com>