### PR TITLE
fix(messages): add append parameter to history entries

### DIFF
--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -892,7 +892,7 @@ must handle.
 
 ["msg_history_show", entries] ~
 	Sent when |:messages| command is invoked. History is sent as a list of
-	entries, where each entry is a `[kind, content]` tuple.
+	entries, where each entry is a `[kind, content, append]` tuple.
 
 ["msg_history_clear"] ~
 	Clear the |:messages| history.

--- a/runtime/lua/vim/_extui/messages.lua
+++ b/runtime/lua/vim/_extui/messages.lua
@@ -414,7 +414,7 @@ function M.msg_ruler(content)
   set_virttext('last')
 end
 
----@alias MsgHistory [string, MsgContent]
+---@alias MsgHistory [string, MsgContent, boolean]
 --- Open the message history in the pager.
 ---
 ---@param entries MsgHistory[]
@@ -425,7 +425,7 @@ function M.msg_history_show(entries)
 
   api.nvim_buf_set_lines(ext.bufs.pager, 0, -1, false, {})
   for i, entry in ipairs(entries) do
-    M.show_msg('pager', entry[2], i == 1, false)
+    M.show_msg('pager', entry[2], i == 1, entry[3])
   end
 
   M.set_pos('pager')

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1053,6 +1053,11 @@ static void msg_hist_add_multihl(HlMessage msg, bool temp)
   entry->kind = msg_ext_kind;
   entry->prev = msg_hist_last;
   entry->next = NULL;
+  // NOTE: this does not encode if the message was actually appended to the
+  // previous entry in the message history. However append is currently only
+  // true for :echon, which is stored in the history as a temporary entry for
+  // "g<" where it is guaranteed to be after the entry it was appended to.
+  entry->append = msg_ext_append;
 
   if (msg_hist_first == NULL) {
     msg_hist_first = entry;
@@ -1206,6 +1211,7 @@ void ex_messages(exarg_T *eap)
         ADD(content, ARRAY_OBJ(content_entry));
       }
       ADD(entry, ARRAY_OBJ(content));
+      ADD(entry, BOOLEAN_OBJ(p->append));
       ADD(entries, ARRAY_OBJ(entry));
     }
     if (redirecting() || !ui_has(kUIMessages)) {

--- a/src/nvim/message_defs.h
+++ b/src/nvim/message_defs.h
@@ -18,4 +18,6 @@ typedef struct msg_hist {
   HlMessage msg;          ///< Highlighted message.
   const char *kind;       ///< Message kind (for msg_ext)
   bool temp;              ///< Temporary message since last command ("g<")
+  bool append;            ///< Message should be appended to previous entry, as opposed
+                          ///< to on a new line (|ui-messages|->msg_show->append).
 } MessageHistoryEntry;

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -136,9 +136,9 @@ describe('vim.ui_attach', function()
       {
         'msg_history_show',
         {
-          { 'echomsg', { { 0, 'message1', 0 } } },
-          { 'lua_print', { { 0, 'message2', 0 } } },
-          { 'echomsg', { { 0, 'message3', 0 } } },
+          { 'echomsg', { { 0, 'message1', 0 } }, false },
+          { 'lua_print', { { 0, 'message2', 0 } }, false },
+          { 'echomsg', { { 0, 'message3', 0 } }, false },
         },
       },
     }, actual, vim.inspect(actual))

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -1604,14 +1604,21 @@ stack traceback:
   end)
 
   it('g< mapping shows recent messages', function()
-    command('echo "foo" | echo "bar"')
+    feed(':echo "foo" | echo "bar" | echon "baz"<CR>')
     screen:expect({
       grid = [[
         ^                         |
         {1:~                        }|*4
       ]],
+      cmdline = { { abort = false } },
       messages = {
+        { content = { { 'foo' } }, kind = 'echo' },
         { content = { { 'bar' } }, kind = 'echo' },
+        { content = { { 'baz' } }, kind = 'echo', append = true },
+        {
+          content = { { 'Press ENTER or type command to continue', 6, 18 } },
+          kind = 'return_prompt',
+        },
       },
     })
     feed('g<lt>')
@@ -1627,14 +1634,9 @@ stack traceback:
         },
       },
       msg_history = {
-        {
-          content = { { 'foo' } },
-          kind = 'echo',
-        },
-        {
-          content = { { 'bar' } },
-          kind = 'echo',
-        },
+        { content = { { 'foo' } }, kind = 'echo' },
+        { content = { { 'bar' } }, kind = 'echo' },
+        { content = { { 'baz' } }, kind = 'echo', append = true },
       },
     })
     feed('Q')

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1515,7 +1515,11 @@ function Screen:_extstate_repr(attr_state)
 
   local msg_history = {}
   for i, entry in ipairs(self.msg_history) do
-    msg_history[i] = { kind = entry[1], content = self:_chunks_repr(entry[2], attr_state) }
+    msg_history[i] = {
+      kind = entry[1],
+      content = self:_chunks_repr(entry[2], attr_state),
+      append = entry[3] or nil,
+    }
   end
 
   local win_viewport = (next(self.win_viewport) and self.win_viewport) or nil


### PR DESCRIPTION
Problem:  The "append" parameter added in abb40ece is missing from
          history entries, resulting in different message formatting
          for "g<".
Solution: Add "append" field to message history entries.

Co-authored-by: phanium <91544758+phanen@users.noreply.github.com>