### PR TITLE
feat(lsp): support diagnostic related information

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1900,6 +1900,12 @@ workspace_symbol({query}, {opts})             *vim.lsp.buf.workspace_symbol()*
 ==============================================================================
 Lua module: vim.lsp.diagnostic                                *lsp-diagnostic*
 
+This module provides functionality for requesting LSP diagnostics for a
+document/workspace and populating them using |vim.Diagnostic|s.
+`DiagnosticRelatedInformation` is supported: it is included in the window
+shown by |vim.diagnostic.open_float()|.
+
+
 from({diagnostics})                                *vim.lsp.diagnostic.from()*
     Converts the input `vim.Diagnostic`s to LSP diagnostics.
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -196,6 +196,9 @@ LSP
   receives the resolved config as the second arg: `cmd(dispatchers, config)`.
 • Support for annotated text edits.
 • `:checkhealth vim.lsp` is now available to check which buffers the active LSP features are attached to.
+• LSP `DiagnosticRelatedInformation` is now shown in
+  |vim.diagnostic.open_float()|. It is read from the LSP diagnostic object
+  stored in the `user_data` field.
 
 LUA
 

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -1,3 +1,7 @@
+---@brief This module provides functionality for requesting LSP diagnostics for a document/workspace
+---and populating them using |vim.Diagnostic|s. `DiagnosticRelatedInformation` is supported: it is
+---included in the window shown by |vim.diagnostic.open_float()|.
+
 local lsp = vim.lsp
 local protocol = lsp.protocol
 local ms = protocol.Methods

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -349,6 +349,7 @@ function protocol.make_client_capabilities()
           valueSet = get_value_set(constants.DiagnosticTag),
         },
         dataSupport = true,
+        relatedInformation = true,
       },
       inlayHint = {
         dynamicRegistration = true,
@@ -540,6 +541,7 @@ function protocol.make_client_capabilities()
         honorsChangeAnnotations = true,
       },
       publishDiagnostics = {
+        relatedInformation = true,
         tagSupport = {
           valueSet = get_value_set(constants.DiagnosticTag),
         },


### PR DESCRIPTION
After 3 related information objects, the rest get folded to prevent them from taking up too much space. Closes #19649

### Before

![image](https://github.com/user-attachments/assets/2fc915a7-33d0-4732-843c-6e6916d2c255)

### After

![image](https://github.com/user-attachments/assets/411ad106-6ce6-404f-9a84-eb4a09b252a7)

Note: Should the floating window height be adjusted to fit the screen height after the folds are closed?