### PR TITLE
feat!(editor): insert-mode ctrl-r should work like paste

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3247,6 +3247,8 @@ static void ins_reg(void)
     vim_beep(kOptBoFlagRegister);
     need_redraw = true;  // remove the '"'
   } else {
+    yankreg_T *reg = get_yank_register(regname, YREG_PASTE);
+
     if (literally == Ctrl_O || literally == Ctrl_P) {
       // Append the command to the redo buffer.
       AppendCharToRedobuff(Ctrl_R);
@@ -3255,7 +3257,11 @@ static void ins_reg(void)
 
       do_put(regname, NULL, BACKWARD, 1,
              (literally == Ctrl_P ? PUT_FIXINDENT : 0) | PUT_CURSEND);
-    } else if (insert_reg(regname, NULL, literally) == FAIL) {
+    } else if (reg->y_size > 1 && is_literal_register(regname)) {
+      AppendCharToRedobuff(Ctrl_R);
+      AppendCharToRedobuff(regname);
+      do_put(regname, NULL, BACKWARD, 1, PUT_CURSEND);
+    } else if (insert_reg(regname, NULL, !!literally || is_literal_register(regname)) == FAIL) {
       vim_beep(kOptBoFlagRegister);
       need_redraw = true;  // remove the '"'
     } else if (stop_insert_mode) {

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1366,36 +1366,35 @@ int insert_reg(int regname, yankreg_T *reg, bool literally_arg)
     if (reg->y_array == NULL) {
       retval = FAIL;
     } else {
-      do_put(0, reg, BACKWARD, 1, PUT_CURSEND);
-      // for (size_t i = 0; i < reg->y_size; i++) {
-      //   if (regname == '-' && reg->y_type == kMTCharWise) {
-      //     Direction dir = BACKWARD;
-      //     if ((State & REPLACE_FLAG) != 0) {
-      //       pos_T curpos;
-      //       if (u_save_cursor() == FAIL) {
-      //         return FAIL;
-      //       }
-      //       del_chars(mb_charlen(reg->y_array[0].data), true);
-      //       curpos = curwin->w_cursor;
-      //       if (oneright() == FAIL) {
-      //         // hit end of line, need to put forward (after the current position)
-      //         dir = FORWARD;
-      //       }
-      //       curwin->w_cursor = curpos;
-      //     }
-      //
-      //     AppendCharToRedobuff(Ctrl_R);
-      //     AppendCharToRedobuff(regname);
-      //     do_put(regname, NULL, dir, 1, PUT_CURSEND);
-      //   } else {
-      //     stuffescaped(reg->y_array[i].data, literally);
-      //     // Insert a newline between lines and after last line if
-      //     // y_type is kMTLineWise.
-      //     if (reg->y_type == kMTLineWise || i < reg->y_size - 1) {
-      //       stuffcharReadbuff('\n');
-      //     }
-      //   }
-      // }
+      for (size_t i = 0; i < reg->y_size; i++) {
+        if (regname == '-' && reg->y_type == kMTCharWise) {
+          Direction dir = BACKWARD;
+          if ((State & REPLACE_FLAG) != 0) {
+            pos_T curpos;
+            if (u_save_cursor() == FAIL) {
+              return FAIL;
+            }
+            del_chars(mb_charlen(reg->y_array[0].data), true);
+            curpos = curwin->w_cursor;
+            if (oneright() == FAIL) {
+              // hit end of line, need to put forward (after the current position)
+              dir = FORWARD;
+            }
+            curwin->w_cursor = curpos;
+          }
+
+          AppendCharToRedobuff(Ctrl_R);
+          AppendCharToRedobuff(regname);
+          do_put(regname, NULL, dir, 1, PUT_CURSEND);
+        } else {
+          stuffescaped(reg->y_array[i].data, literally);
+          // Insert a newline between lines and after last line if
+          // y_type is kMTLineWise.
+          if (reg->y_type == kMTLineWise || i < reg->y_size - 1) {
+            stuffcharReadbuff('\n');
+          }
+        }
+      }
     }
   }
 

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -1366,35 +1366,36 @@ int insert_reg(int regname, yankreg_T *reg, bool literally_arg)
     if (reg->y_array == NULL) {
       retval = FAIL;
     } else {
-      for (size_t i = 0; i < reg->y_size; i++) {
-        if (regname == '-' && reg->y_type == kMTCharWise) {
-          Direction dir = BACKWARD;
-          if ((State & REPLACE_FLAG) != 0) {
-            pos_T curpos;
-            if (u_save_cursor() == FAIL) {
-              return FAIL;
-            }
-            del_chars(mb_charlen(reg->y_array[0].data), true);
-            curpos = curwin->w_cursor;
-            if (oneright() == FAIL) {
-              // hit end of line, need to put forward (after the current position)
-              dir = FORWARD;
-            }
-            curwin->w_cursor = curpos;
-          }
-
-          AppendCharToRedobuff(Ctrl_R);
-          AppendCharToRedobuff(regname);
-          do_put(regname, NULL, dir, 1, PUT_CURSEND);
-        } else {
-          stuffescaped(reg->y_array[i].data, literally);
-          // Insert a newline between lines and after last line if
-          // y_type is kMTLineWise.
-          if (reg->y_type == kMTLineWise || i < reg->y_size - 1) {
-            stuffcharReadbuff('\n');
-          }
-        }
-      }
+      do_put(0, reg, BACKWARD, 1, PUT_CURSEND);
+      // for (size_t i = 0; i < reg->y_size; i++) {
+      //   if (regname == '-' && reg->y_type == kMTCharWise) {
+      //     Direction dir = BACKWARD;
+      //     if ((State & REPLACE_FLAG) != 0) {
+      //       pos_T curpos;
+      //       if (u_save_cursor() == FAIL) {
+      //         return FAIL;
+      //       }
+      //       del_chars(mb_charlen(reg->y_array[0].data), true);
+      //       curpos = curwin->w_cursor;
+      //       if (oneright() == FAIL) {
+      //         // hit end of line, need to put forward (after the current position)
+      //         dir = FORWARD;
+      //       }
+      //       curwin->w_cursor = curpos;
+      //     }
+      //
+      //     AppendCharToRedobuff(Ctrl_R);
+      //     AppendCharToRedobuff(regname);
+      //     do_put(regname, NULL, dir, 1, PUT_CURSEND);
+      //   } else {
+      //     stuffescaped(reg->y_array[i].data, literally);
+      //     // Insert a newline between lines and after last line if
+      //     // y_type is kMTLineWise.
+      //     if (reg->y_type == kMTLineWise || i < reg->y_size - 1) {
+      //       stuffcharReadbuff('\n');
+      //     }
+      //   }
+      // }
     }
   }
 

--- a/src/nvim/ops.h
+++ b/src/nvim/ops.h
@@ -156,7 +156,7 @@ static inline int op_reg_index(const int regname)
 static inline bool is_literal_register(const int regname)
   FUNC_ATTR_CONST
 {
-  return regname == '*' || regname == '+';
+  return regname == '*' || regname == '+' || ASCII_ISALNUM(regname);
 }
 
 EXTERN LuaRef repeat_luaref INIT( = LUA_NOREF);  ///< LuaRef for "."


### PR DESCRIPTION
## Problem:
insert-mode ctrl-r input is treated like raw user input, which almost(?) never useful. This means any newlines in the input are affected by autoindent, etc. This is (1) slow and (2) usually breaks the formatting of the input.

## Solution:

- ctrl-r should be treated like a paste, not user-input.
- does not affect `<c-r>=`, so `<c-r>=@x` can still be used to get the old behavior.

## Tests

only three(!) failing tests...

```
From test_ins_complete.vim:
Found errors in Test_complete_reginsert():
command line..script /Users/runner/work/neovim/neovim/test/old/testdir/runtest.vim[593]..function RunTheTest[57]..Test_complete_reginsert line 11: Expected 'a12' but got 'a1234\x10\x10'

From test_mapping.vim:
Found errors in Test_map_cursor_ctrl_gU():
command line..script /Users/runner/work/neovim/neovim/test/old/testdir/runtest.vim[593]..function RunTheTest[57]..Test_map_cursor_ctrl_gU line 6: Expected ['PREFIXfoo', 'foobar', '', 'PREFIXfoo'] but got ['PREFIXfoo', 'foobar', 'PREFIX', '']
command line..script /Users/runner/work/neovim/neovim/test/old/testdir/runtest.vim[593]..function RunTheTest[57]..Test_map_cursor_ctrl_gU line 18: Expected ['PREFIXPREFIX', ' foo', 'foobar', '', 'foo'] but got ['PREFIXPREFIX', ' ', 'foobar', '', 'foo']


FAILED   test/functional/ui/output_spec.lua @ 63: shell command :! throttles shell-command output greater than ~10KB
test/functional/ui/output_spec.lua:74: Row 1 did not match.
Expected:
  |*29997: foo                                        |
  |*29998: foo                                        |
  |*29999: foo                                        |
  |30000: foo                                        |
  |                                                  |
  |{10:Press ENTER or type command to continue}^           |
  |{3:-- TERMINAL --}                                    |
Actual:
  |*1115: foo                                         |
  |*1116: foo                                         |
  |*...                                               |
  |30000: foo                                        |
  |                                                  |
  |{10:Press ENTER or type command to continue}^           |
  |{3:-- TERMINAL --}                                    |
```
