### PR TITLE
fix(doc): setting legacy syntax highlighting after starting treesitter

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1132,7 +1132,7 @@ start({bufnr}, {lang})                                *vim.treesitter.start()*
     Can be used in an ftplugin or FileType autocommand.
 
     Note: By default, disables regex syntax highlighting, which may be
-    required for some plugins. In this case, add `vim.bo.syntax = 'on'` after
+    required for some plugins. In this case, add `vim.bo.syntax = 'ON'` after
     the call to `start`.
 
     Note: By default, the highlighter parses code asynchronously, using a
@@ -1142,7 +1142,7 @@ start({bufnr}, {lang})                                *vim.treesitter.start()*
         vim.api.nvim_create_autocmd( 'FileType', { pattern = 'tex',
             callback = function(args)
                 vim.treesitter.start(args.buf, 'latex')
-                vim.bo[args.buf].syntax = 'on'  -- only if additional legacy syntax is needed
+                vim.bo[args.buf].syntax = 'ON'  -- only if additional legacy syntax is needed
             end
         })
 <

--- a/runtime/lua/vim/treesitter.lua
+++ b/runtime/lua/vim/treesitter.lua
@@ -402,7 +402,7 @@ end
 --- Can be used in an ftplugin or FileType autocommand.
 ---
 --- Note: By default, disables regex syntax highlighting, which may be required for some plugins.
---- In this case, add `vim.bo.syntax = 'on'` after the call to `start`.
+--- In this case, add `vim.bo.syntax = 'ON'` after the call to `start`.
 ---
 --- Note: By default, the highlighter parses code asynchronously, using a segment time of 3ms.
 ---
@@ -412,7 +412,7 @@ end
 --- vim.api.nvim_create_autocmd( 'FileType', { pattern = 'tex',
 ---     callback = function(args)
 ---         vim.treesitter.start(args.buf, 'latex')
----         vim.bo[args.buf].syntax = 'on'  -- only if additional legacy syntax is needed
+---         vim.bo[args.buf].syntax = 'ON'  -- only if additional legacy syntax is needed
 ---     end
 --- })
 --- ```


### PR DESCRIPTION
Problem:
Previous advice was to set `syntax` to `'on'`. This value gets used in `synload.vim` and compared using `if s == "ON"`.
In Vimscript the `==` operator uses the value for `ignorecase` to decide equality. This means `on` only works for users who have `ignorecase`.

Solution:
One option is to update `synload.vim` to use case agnostic comparison via `if s ==? "ON"`, but this would need to be updated in `vim`. 
Instead update the advice to use the exact case `'ON'`, so the advice works for all configurations.
