### PR TITLE
fix(coverity/554963): preallocate msg.items to avoid FORWARD_NULL

### DIFF
--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -1403,6 +1403,7 @@ int recover_names(char *fname, bool do_list, list_T *ret_list, int nr, char **fn
           msg_puts(path_tail(files[i]));
           msg_putchar('\n');
           StringBuilder msg = KV_INITIAL_VALUE;
+          kv_resize(msg, IOSIZE);
           swapfile_info(files[i], &msg);
           msg_outtrans(msg.items, 0, false);
           kv_destroy(msg);
@@ -3464,6 +3465,7 @@ static char *findswapname(buf_T *buf, char **dirp, char *old_fname, bool *found_
             no_wait_return++;
             // Show info about the existing swapfile.
             StringBuilder msg = KV_INITIAL_VALUE;
+            kv_resize(msg, IOSIZE);
             char *fhname = home_replace_save(NULL, fname);
             attention_message(buf, fname, fhname, &msg);
 


### PR DESCRIPTION
    *** CID 554963:           (FORWARD_NULL)
    /src/nvim/memline.c: 3484             in findswapname()
    3478                 if (swap_exists_action != SEA_NONE) {
    3479                   kv_printf(msg, _("Swap file \""));
    3480                   kv_printf(msg, "%s", fhname);
    3481                   kv_printf(msg, _("\" already exists!"));
    3482                   char *run_but = _("&Open Read-Only\n&Edit anyway\n&Recover\n&Quit\n&Abort");
    3483                   char *but = _("&Open Read-Only\n&Edit anyway\n&Recover\n&Delete it\n&Quit\n&Abort");
    >>>     CID 554963:           (FORWARD_NULL)
    >>>     Passing null pointer "msg.items" to "do_dialog", which dereferences it.
    3484                   choice = (sea_choice_T)do_dialog(VIM_WARNING, _("VIM - ATTENTION"), msg.items,
    3485                                                    proc_running ? run_but : but, 1, NULL, false);
    3486
    3487                   // compensate for missing "Delete it" button
    3488                   choice += proc_running && choice >= 4;
    3489                   // pretend screen didn't scroll, need redraw anyway
    /src/nvim/memline.c: 3492             in findswapname()
    3486
    3487                   // compensate for missing "Delete it" button
    3488                   choice += proc_running && choice >= 4;
    3489                   // pretend screen didn't scroll, need redraw anyway
    3490                   msg_reset_scroll();
    3491                 } else {
    >>>     CID 554963:           (FORWARD_NULL)
    >>>     Passing null pointer "msg.items" to "msg_outtrans", which dereferences it.
    3492                   msg_outtrans(msg.items, 0, false);
    3493                 }
    3494                 no_wait_return--;
    3495                 kv_destroy(msg);
    3496                 xfree(fhname);
    3497               }