### PR TITLE
fix(lsp): show messages using vim.notify

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -588,12 +588,8 @@ NSC['window/showMessage'] = function(_, params, ctx)
   if not client then
     err_message('LSP[', client_name, '] client has shut down after sending ', message)
   end
-  if message_type == protocol.MessageType.Error then
-    err_message('LSP[', client_name, '] ', message)
-  else
-    message = ('LSP[%s][%s] %s\n'):format(client_name, protocol.MessageType[message_type], message)
-    api.nvim_echo({ { message } }, true, {})
-  end
+  message = ('LSP[%s] %s'):format(client_name, message)
+  vim.notify(message, log._from_lsp_level(message_type))
   return params
 end
 

--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -25,6 +25,8 @@ local log = {}
 
 local log_levels = vim.log.levels
 
+local protocol = require('vim.lsp.protocol')
+
 --- Log level dictionary with reverse lookup as well.
 ---
 --- Can be used to lookup the number from the name or the name from the number.
@@ -216,6 +218,21 @@ function log.should_log(level)
   vim.validate('level', level, 'number')
 
   return level >= current_log_level
+end
+
+--- Convert LSP MessageType to vim.log.levels
+---
+---@param message_type lsp.MessageType
+function log._from_lsp_level(message_type)
+  if message_type == protocol.MessageType.Error then
+    return vim.log.levels.ERROR
+  elseif message_type == protocol.MessageType.Warning then
+    return vim.log.levels.WARN
+  elseif message_type == protocol.MessageType.Info or message_type == protocol.MessageType.Log then
+    return vim.log.levels.INFO
+  else
+    return vim.log.levels.DEBUG
+  end
 end
 
 return log


### PR DESCRIPTION
Problem: Currently, `vim.notify` is only used to display messages when the message type is `Error`.
Solution: Use `vim.notify` to display messages for all message types.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
