### PR TITLE
fix(extui): clear cmdline buffer for first message

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -1076,8 +1076,10 @@ vim.ui_attach({ns}, {opts}, {callback})                      *vim.ui_attach()*
                       enable events for the respective UI element.
                     • {set_cmdheight}? (`boolean`) If false, avoid setting
                       'cmdheight' to 0 when `ext_messages` is enabled.
-      • {callback}  (`fun(event: string, ...)`) Function called for each UI
-                    event
+      • {callback}  (`fun(event: string, ...): any`) Function called for each
+                    UI event. A truthy return value signals to Nvim that the
+                    event is handled, in which case it is not propagated to
+                    remote UIs.
 
 vim.ui_detach({ns})                                          *vim.ui_detach()*
     Detach a callback previously attached with |vim.ui_attach()| for the given

--- a/runtime/lua/vim/_extui/cmdline.lua
+++ b/runtime/lua/vim/_extui/cmdline.lua
@@ -110,11 +110,11 @@ end
 
 --- Leaving the cmdline, restore 'cmdheight' and 'ruler'.
 ---
---@param level integer
+---@param level integer
 ---@param abort boolean
-function M.cmdline_hide(_, abort)
-  if M.row > 0 then
-    return -- No need to hide when still in cmdline_block.
+function M.cmdline_hide(level, abort)
+  if M.row > 0 or level > 1 then
+    return -- No need to hide when still in nested cmdline or cmdline_block.
   end
 
   fn.clearmatches(ext.wins.cmd) -- Clear matchparen highlights.
@@ -166,7 +166,7 @@ end
 --- Clear cmdline buffer and leave the cmdline.
 function M.cmdline_block_hide()
   M.row = 0
-  M.cmdline_hide(nil, true)
+  M.cmdline_hide(M.level, true)
 end
 
 return M

--- a/runtime/lua/vim/_meta/builtin.lua
+++ b/runtime/lua/vim/_meta/builtin.lua
@@ -266,7 +266,9 @@ function vim.wait(time, callback, interval, fast_only) end
 ---               enable events for the respective UI element.
 ---             - {set_cmdheight}? (`boolean`) If false, avoid setting
 ---               'cmdheight' to 0 when `ext_messages` is enabled.
---- @param callback fun(event: string, ...) Function called for each UI event
+--- @param callback fun(event: string, ...): any Function called for each UI event.
+---                 A truthy return value signals to Nvim that the event is handled,
+---                 in which case it is not propagated to remote UIs.
 function vim.ui_attach(ns, opts, callback) end
 
 --- Detach a callback previously attached with |vim.ui_attach()| for the

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -759,9 +759,6 @@ void ui_call_event(char *name, bool fast, Array args)
     uint32_t ns_id = ui_event_ns_id;
     Object res = nlua_call_ref_ctx(fast, event_cb->cb, name, args, kRetNilBool, NULL, &err);
     ui_event_ns_id = 0;
-    // TODO(bfredl/luukvbaal): should this be documented or reconsidered?
-    // Why does truthy return from Lua callback mean remote UI should not receive
-    // the event.
     if (LUARET_TRUTHY(res)) {
       handled = true;
     }

--- a/test/functional/messages2_spec.lua
+++ b/test/functional/messages2_spec.lua
@@ -1,0 +1,73 @@
+local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
+
+local clear, command, exec_lua, feed = n.clear, n.command, n.exec_lua, n.feed
+
+describe('messages2', function()
+  local screen
+  describe('target=msg', function()
+    before_each(function()
+      clear()
+      screen = Screen.new()
+      screen:add_extra_attr_ids({
+        [100] = { foreground = Screen.colors.Magenta1, bold = true },
+      })
+      exec_lua(function()
+        require('vim._extui').enable({})
+      end)
+    end)
+
+    it('multiline messages and pager', function()
+      command('echo "foo\nbar"')
+      screen:expect([[
+        ^                                                     |
+        {1:~                                                    }|*12
+        foo[+1]                                              |
+      ]])
+      command('set ruler')
+      feed('g<lt>')
+      screen:expect([[
+                                                             |
+        {1:~                                                    }|*9
+        ─{100:Pager}───────────────────────────────────────────────|
+        {4:fo^o                                                  }|
+        {4:bar                                                  }|
+        foo[+1]                             1,3           All|
+      ]])
+      -- New message clears spill indicator.
+      feed('Q')
+      screen:expect([[
+                                                             |
+        {1:~                                                    }|*9
+        ─{100:Pager}───────────────────────────────────────────────|
+        {4:fo^o                                                  }|
+        {4:bar                                                  }|
+        {9:E354: Invalid register name: '^@'}   1,3           All|
+      ]])
+      -- Multiple messages in same event loop iteration are appended.
+      feed([[q:echo "foo\nbar" | echo "baz"<CR>]])
+      screen:expect([[
+                                                             |
+        {1:~                                                    }|*8
+        ─{100:Pager}───────────────────────────────────────────────|
+        {4:^foo                                                  }|
+        {4:bar                                                  }|
+        {4:baz                                                  }|
+                                            1,1           All|
+      ]])
+      -- No error for ruler virt_text msg_row exceeding buffer length.
+      command([[map Q <cmd>echo "foo\nbar" <bar> ls<CR>]])
+      feed('qQ')
+      screen:expect([[
+                                                             |
+        {1:~                                                    }|*7
+        ─{100:Pager}───────────────────────────────────────────────|
+        {4:^foo                                                  }|
+        {4:bar                                                  }|
+        {4:                                                     }|
+        {4:  1 %a   "[No Name]"                    line 1       }|
+                                            1,1           All|
+      ]])
+    end)
+  end)
+end)


### PR DESCRIPTION
Problem:  Cmdline buffer is not cleared for a new message (since c973c7ae),
          resulting in an incorrect spill indicator. When the cmdline
          buffer is cleared, "msg_row" is not invalidated, resulting in
          an error. The extui module is untested.
          Return value of `vim.ui_attach()->callback` is undocumented.
Solution: Clear the cmdline buffer for the first message in an event
          loop iteration. Ensure msg_row passed as end_row does not
          exceed buffer length.
          Add `messages_spec2.lua` to test the extui module, keeping in
          mind that test coverage will greatly increase if this UI is made
          the default. As such, only tests for specific extui functionality
          unlikely to be covered by tests leveraging the current message grid.
          Document the return value of `vim.ui_attach()->callback`, it seems
          to make sense, and is also used to suppress remote UI events in
          `messages_spec2.lua`.

Fix #21150