### PR TITLE
feat(prompt): prompt_getinput() gets current input

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -151,6 +151,8 @@ EDITOR
 • |omnicompletion| in `help` buffer. |ft-help-omni|
 • Setting "'0" in 'shada' prevents storing the jumplist in the shada file.
 • 'shada' now correctly respects "/0" and "f0".
+• |prompt-buffer| supports multiline input/paste, undo/redo, and o/O normal
+  commands.
 
 EVENTS
 
@@ -253,6 +255,7 @@ UI
 VIMSCRIPT
 
 • |cmdcomplete_info()| gets current cmdline completion info.
+• |prompt_getinput()| gets current user-input in prompt-buffer.
 
 ==============================================================================
 CHANGED FEATURES                                                 *news-changed*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -333,6 +333,7 @@ Functions:
 - |tempname()| tries to recover if the Nvim |tempdir| disappears.
 - |writefile()| with "p" flag creates parent directories.
 - |searchcount()|'s maximal value is raised from 99 to 999.
+- |prompt_getinput()|
 
 Highlight groups:
 - |highlight-blend| controls blend level for a highlight group

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -7548,6 +7548,19 @@ printf({fmt}, {expr1} ...)                                            *printf()*
                 Return: ~
                   (`string`)
 
+prompt_getinput({buf})                                       *prompt_getinput()*
+		Gets the current user-input in |prompt-buffer| {buf} without invoking
+		prompt_callback. {buf} can be a buffer name or number.
+
+		If the buffer doesn't exist or isn't a prompt buffer, an empty
+		string is returned.
+
+                Parameters: ~
+                  • {buf} (`integer|string`)
+
+                Return: ~
+                  (`any`)
+
 prompt_getprompt({buf})                                     *prompt_getprompt()*
 		Returns the effective prompt text for buffer {buf}.  {buf} can
 		be a buffer name or number.  See |prompt-buffer|.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -6867,6 +6867,16 @@ function vim.fn.prevnonblank(lnum) end
 --- @return string
 function vim.fn.printf(fmt, expr1) end
 
+--- Gets the current user-input in |prompt-buffer| {buf} without invoking
+--- prompt_callback. {buf} can be a buffer name or number.
+---
+--- If the buffer doesn't exist or isn't a prompt buffer, an empty
+--- string is returned.
+---
+--- @param buf integer|string
+--- @return any
+function vim.fn.prompt_getinput(buf) end
+
 --- Returns the effective prompt text for buffer {buf}.  {buf} can
 --- be a buffer name or number.  See |prompt-buffer|.
 ---

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1078,7 +1078,7 @@ check_pum:
       return 0;
     }
     if ((mod_mask & MOD_MASK_SHIFT) == 0 && bt_prompt(curbuf)) {
-      invoke_prompt_callback();
+      prompt_invoke_callback();
       if (!bt_prompt(curbuf)) {
         // buffer changed to a non-prompt buffer, get out of
         // Insert mode

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -8332,6 +8332,21 @@ M.funcs = {
     signature = 'printf({fmt}, {expr1} ...)',
     returns = 'string',
   },
+  prompt_getinput = {
+    args = 1,
+    base = 1,
+    desc = [=[
+      Gets the current user-input in |prompt-buffer| {buf} without invoking
+      prompt_callback. {buf} can be a buffer name or number.
+
+      If the buffer doesn't exist or isn't a prompt buffer, an empty
+      string is returned.
+
+    ]=],
+    name = 'prompt_getinput',
+    params = { { 'buf', 'integer|string' } },
+    signature = 'prompt_getinput({buf})',
+  },
   prompt_getprompt = {
     args = 1,
     base = 1,

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -5364,6 +5364,26 @@ static void f_prompt_setprompt(typval_T *argvars, typval_T *rettv, EvalFuncData 
   buf->b_prompt_text = xstrdup(text);
 }
 
+/// "prompt_getinput({buffer})" function
+static void f_prompt_getinput(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
+  FUNC_ATTR_NONNULL_ALL
+{
+  // return an empty string by default, e.g. it's not a prompt buffer
+  rettv->v_type = VAR_STRING;
+  rettv->vval.v_string = NULL;
+
+  buf_T *const buf = tv_get_buf_from_arg(&argvars[0]);
+  if (buf == NULL) {
+    return;
+  }
+
+  if (!bt_prompt(buf)) {
+    return;
+  }
+
+  rettv->vval.v_string = prompt_get_input(buf);
+}
+
 /// "pum_getpos()" function
 static void f_pum_getpos(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -3853,7 +3853,7 @@ static void nv_down(cmdarg_T *cap)
     } else if (bt_prompt(curbuf) && cap->cmdchar == CAR
                && curwin->w_cursor.lnum == curbuf->b_ml.ml_line_count) {
       // In a prompt buffer a <CR> in the last line invokes the callback.
-      invoke_prompt_callback();
+      prompt_invoke_callback();
       if (restart_edit == 0) {
         restart_edit = 'a';
       }


### PR DESCRIPTION
**Problem**:
Currently, there is no easy way to get user-input in prompt-buffer before
the user submits the input. Under the current system user/plugin needs to read
the buffer contents, figure out where the prompt is then extract the test
if they want to. With the addition of multiline support, it becomes more
complicated.

**Solution**:
Add a new vim-function prompt_getinput({buf}) that gets the user-input
without invoking the prompt-callback

**Additional**:
- refactor: Extract prompt text extraction logic to a separate function

**Signature**:
```
prompt_getinput(bufnr) -> str
```

followup to #33371
ref #34561
