### PR TITLE
fix: cursor shape don't resume after `:append`

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -2889,6 +2889,7 @@ void ex_append(exarg_T *eap)
     }
   }
   State = MODE_NORMAL;
+  ui_cursor_shape();
 
   if (eap->forceit) {
     curbuf->b_p_ai = !curbuf->b_p_ai;

--- a/test/functional/ui/mode_spec.lua
+++ b/test/functional/ui/mode_spec.lua
@@ -43,6 +43,11 @@ describe('ui mode_change event', function()
     ]],
       mode = 'normal',
     }
+
+    n.feed(':append<cr>')
+    screen:expect({ mode = 'cmdline_normal' })
+    n.feed('<esc>')
+    screen:expect({ mode = 'normal' })
   end)
 
   -- oldtest: Test_mouse_shape_after_failed_change()


### PR DESCRIPTION
Problem: cursor shape don't resume after `:append`.
e.g. `seq 1000 | nvim --clean +"se gcr+=c:ver25" -`

Solution: emit missing ui event.
