### PR TITLE
feat: add busy status for buffers

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -208,6 +208,7 @@ OPTIONS
 • 'pummaxwidth' sets maximum width for the completion popup menu.
 • 'winborder' "bold" style.
 • |g:clipboard| accepts a string name to force any builtin clipboard tool.
+• 'busy' sets a buffer "busy" status. Indicated in the default statusline.
 
 PERFORMANCE
 
@@ -249,6 +250,7 @@ UI
 • Error messages are more concise:
   • "Error detected while processing:" changed to "Error in:".
   • "Error executing Lua:" changed to "Lua:".
+• 'busy' status is shown in default statusline with symbol ◐
 
 VIMSCRIPT
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1217,11 +1217,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 	without saving.  For writing there must be matching |BufWriteCmd|,
 	|FileWriteCmd| or |FileAppendCmd| autocommands.
 
-						*'busy'* *'nobusy'*
-'busy'			boolean	(default off)
+							*'busy'*
+'busy'			number	(default 0)
 			local to buffer
 	Sets a buffer "busy" status. Indicated in the default statusline.
-	The semantics of "busy" are arbitrary, typically decided by the plugin that owns the buffer
+	When busy status is larger then 0 busy flag is shown in statusline.
+	The semantics of "busy" are arbitrary, typically decided by the plugin that owns the buffer.
 
 						*'casemap'* *'cmp'*
 'casemap' 'cmp'		string	(default "internal,keepascii")
@@ -6182,7 +6183,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	an expensive expression can negatively affect render performance.
 
 					*'statusline'* *'stl'* *E540* *E542*
-'statusline' 'stl'	string	(default "%<%f %h%w%m%r %=%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &busy ? '◐ ' : '' %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}")
+'statusline' 'stl'	string	(default "%<%f %h%w%m%r %=%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &busy > 0 ? '◐ ' : '' %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}")
 			global or local to window |global-local|
 	Sets the |status-line|.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1220,8 +1220,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 						*'busy'* *'nobusy'*
 'busy'			boolean	(default off)
 			local to buffer
-	This value specifies status if buffer. When it's set to true it marks
-	the buffer as busy.
+	Sets a buffer "busy" status. Indicated in the default statusline.
+	The semantics of "busy" are arbitrary, typically decided by the plugin that owns the buffer
 
 						*'casemap'* *'cmp'*
 'casemap' 'cmp'		string	(default "internal,keepascii")
@@ -6182,7 +6182,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	an expensive expression can negatively affect render performance.
 
 					*'statusline'* *'stl'* *E540* *E542*
-'statusline' 'stl'	string	(default "%<%f %h%w%m%r %=%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &busy ? '<busy> ' : '' %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}")
+'statusline' 'stl'	string	(default "%<%f %h%w%m%r %=%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &busy ? '◐ ' : '' %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}")
 			global or local to window |global-local|
 	Sets the |status-line|.
 

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1217,6 +1217,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 	without saving.  For writing there must be matching |BufWriteCmd|,
 	|FileWriteCmd| or |FileAppendCmd| autocommands.
 
+						*'busy'* *'nobusy'*
+'busy'			boolean	(default off)
+			local to buffer
+	This value specifies status if buffer. When it's set to true it marks
+	the buffer as busy.
+
 						*'casemap'* *'cmp'*
 'casemap' 'cmp'		string	(default "internal,keepascii")
 			global
@@ -6176,7 +6182,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	an expensive expression can negatively affect render performance.
 
 					*'statusline'* *'stl'* *E540* *E542*
-'statusline' 'stl'	string	(default "%<%f %h%w%m%r %=%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}")
+'statusline' 'stl'	string	(default "%<%f %h%w%m%r %=%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &busy ? '<busy> ' : '' %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}")
 			global or local to window |global-local|
 	Sets the |status-line|.
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -402,6 +402,7 @@ Options:
 - 'ttimeout', 'ttimeoutlen' behavior was simplified
 - 'winblend'    pseudo-transparency in floating windows |api-floatwin|
 - 'winhighlight' window-local highlights
+- 'busy' busy status for buffers
 
 Performance:
 - Signs are implemented using Nvim's internal "marktree" (btree) structure.

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -665,10 +665,11 @@ vim.bo.buftype = vim.o.buftype
 vim.bo.bt = vim.bo.buftype
 
 --- Sets a buffer "busy" status. Indicated in the default statusline.
---- The semantics of "busy" are arbitrary, typically decided by the plugin that owns the buffer
+--- When busy status is larger then 0 busy flag is shown in statusline.
+--- The semantics of "busy" are arbitrary, typically decided by the plugin that owns the buffer.
 ---
---- @type boolean
-vim.o.busy = false
+--- @type integer
+vim.o.busy = 0
 vim.bo.busy = vim.o.busy
 
 --- Specifies details about changing the case of letters.  It may contain
@@ -6852,7 +6853,7 @@ vim.wo.stc = vim.wo.statuscolumn
 ---
 ---
 --- @type string
-vim.o.statusline = "%<%f %h%w%m%r %=%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &busy ? '◐ ' : '' %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}"
+vim.o.statusline = "%<%f %h%w%m%r %=%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &busy > 0 ? '◐ ' : '' %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}"
 vim.o.stl = vim.o.statusline
 vim.wo.statusline = vim.o.statusline
 vim.wo.stl = vim.wo.statusline

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -664,6 +664,13 @@ vim.o.bt = vim.o.buftype
 vim.bo.buftype = vim.o.buftype
 vim.bo.bt = vim.bo.buftype
 
+--- This value specifies status if buffer. When it's set to true it marks
+--- the buffer as busy.
+---
+--- @type boolean
+vim.o.busy = false
+vim.bo.busy = vim.o.busy
+
 --- Specifies details about changing the case of letters.  It may contain
 --- these words, separated by a comma:
 --- internal	Use internal case mapping functions, the current
@@ -6845,7 +6852,7 @@ vim.wo.stc = vim.wo.statuscolumn
 ---
 ---
 --- @type string
-vim.o.statusline = "%<%f %h%w%m%r %=%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}"
+vim.o.statusline = "%<%f %h%w%m%r %=%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &busy ? '<busy> ' : '' %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}"
 vim.o.stl = vim.o.statusline
 vim.wo.statusline = vim.o.statusline
 vim.wo.stl = vim.wo.statusline

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -664,8 +664,8 @@ vim.o.bt = vim.o.buftype
 vim.bo.buftype = vim.o.buftype
 vim.bo.bt = vim.bo.buftype
 
---- This value specifies status if buffer. When it's set to true it marks
---- the buffer as busy.
+--- Sets a buffer "busy" status. Indicated in the default statusline.
+--- The semantics of "busy" are arbitrary, typically decided by the plugin that owns the buffer
 ---
 --- @type boolean
 vim.o.busy = false
@@ -6852,7 +6852,7 @@ vim.wo.stc = vim.wo.statuscolumn
 ---
 ---
 --- @type string
-vim.o.statusline = "%<%f %h%w%m%r %=%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &busy ? '<busy> ' : '' %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}"
+vim.o.statusline = "%<%f %h%w%m%r %=%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &busy ? '◐ ' : '' %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}"
 vim.o.stl = vim.o.statusline
 vim.wo.statusline = vim.o.statusline
 vim.wo.stl = vim.wo.statusline

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -4,7 +4,6 @@
 #include <stdint.h>
 #include <stdio.h>
 
-#include "nvim/api/private/defs.h"
 #include "nvim/arglist_defs.h"
 #include "nvim/grid_defs.h"
 #include "nvim/mapping_defs.h"
@@ -13,6 +12,7 @@
 #include "nvim/option_defs.h"
 #include "nvim/os/fs_defs.h"
 #include "nvim/statusline_defs.h"
+#include "nvim/types_defs.h"
 #include "nvim/undo_defs.h"
 
 /// Reference to a buffer that stores the value of buf_free_count.
@@ -523,7 +523,7 @@ struct file_buffer {
   int b_p_bomb;                 ///< 'bomb'
   char *b_p_bh;                 ///< 'bufhidden'
   char *b_p_bt;                 ///< 'buftype'
-  int b_p_busy;                  ///< 'busy'
+  OptInt b_p_busy;                  ///< 'busy'
   int b_has_qf_entry;           ///< quickfix exists for buffer
   int b_p_bl;                   ///< 'buflisted'
   OptInt b_p_channel;           ///< 'channel'

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -523,7 +523,7 @@ struct file_buffer {
   int b_p_bomb;                 ///< 'bomb'
   char *b_p_bh;                 ///< 'bufhidden'
   char *b_p_bt;                 ///< 'buftype'
-  int b_p_busy;                  ///< 'bufbusy'
+  int b_p_busy;                  ///< 'busy'
   int b_has_qf_entry;           ///< quickfix exists for buffer
   int b_p_bl;                   ///< 'buflisted'
   OptInt b_p_channel;           ///< 'channel'

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -523,7 +523,7 @@ struct file_buffer {
   int b_p_bomb;                 ///< 'bomb'
   char *b_p_bh;                 ///< 'bufhidden'
   char *b_p_bt;                 ///< 'buftype'
-  OptInt b_p_busy;                  ///< 'busy'
+  OptInt b_p_busy;              ///< 'busy'
   int b_has_qf_entry;           ///< quickfix exists for buffer
   int b_p_bl;                   ///< 'buflisted'
   OptInt b_p_channel;           ///< 'channel'

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -4,6 +4,7 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include "nvim/api/private/defs.h"
 #include "nvim/arglist_defs.h"
 #include "nvim/grid_defs.h"
 #include "nvim/mapping_defs.h"
@@ -522,6 +523,7 @@ struct file_buffer {
   int b_p_bomb;                 ///< 'bomb'
   char *b_p_bh;                 ///< 'bufhidden'
   char *b_p_bt;                 ///< 'buftype'
+  int b_p_busy;                  ///< 'bufbusy'
   int b_has_qf_entry;           ///< quickfix exists for buffer
   int b_p_bl;                   ///< 'buflisted'
   OptInt b_p_channel;           ///< 'channel'

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4681,6 +4681,8 @@ void *get_varp_from(vimoption_T *p, buf_T *buf, win_T *win)
     return &(buf->b_p_bt);
   case kOptBuflisted:
     return &(buf->b_p_bl);
+  case kOptBusy:
+    return &(buf->b_p_busy);
   case kOptChannel:
     return &(buf->b_p_channel);
   case kOptCopyindent:

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -279,7 +279,7 @@ EXTERN char *p_bsk;             ///< 'backupskip'
 EXTERN char *p_breakat;         ///< 'breakat'
 EXTERN char *p_bh;              ///< 'bufhidden'
 EXTERN char *p_bt;              ///< 'buftype'
-EXTERN OptInt p_busy;               ///< 'busy'
+EXTERN OptInt p_busy;           ///< 'busy'
 EXTERN char *p_cmp;             ///< 'casemap'
 EXTERN unsigned cmp_flags;
 EXTERN char *p_enc;             ///< 'encoding'

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -279,7 +279,7 @@ EXTERN char *p_bsk;             ///< 'backupskip'
 EXTERN char *p_breakat;         ///< 'breakat'
 EXTERN char *p_bh;              ///< 'bufhidden'
 EXTERN char *p_bt;              ///< 'buftype'
-EXTERN int p_busy;               ///< 'busy'
+EXTERN OptInt p_busy;               ///< 'busy'
 EXTERN char *p_cmp;             ///< 'casemap'
 EXTERN unsigned cmp_flags;
 EXTERN char *p_enc;             ///< 'encoding'

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -279,6 +279,7 @@ EXTERN char *p_bsk;             ///< 'backupskip'
 EXTERN char *p_breakat;         ///< 'breakat'
 EXTERN char *p_bh;              ///< 'bufhidden'
 EXTERN char *p_bt;              ///< 'buftype'
+EXTERN int p_busy;               ///< 'busy'
 EXTERN char *p_cmp;             ///< 'casemap'
 EXTERN unsigned cmp_flags;
 EXTERN char *p_enc;             ///< 'encoding'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -951,17 +951,18 @@ local options = {
       varname = 'p_bt',
     },
     {
-      defaults = false,
+      defaults = 0,
       desc = [=[
         Sets a buffer "busy" status. Indicated in the default statusline.
-        The semantics of "busy" are arbitrary, typically decided by the plugin that owns the buffer
+        When busy status is larger then 0 busy flag is shown in statusline.
+        The semantics of "busy" are arbitrary, typically decided by the plugin that owns the buffer.
       ]=],
       full_name = 'busy',
       redraw = { 'statuslines' },
       noglob = true,
       scope = { 'buf' },
       short_desc = N_('buffer is busy'),
-      type = 'boolean',
+      type = 'number',
       varname = 'p_busy',
     },
     {
@@ -8648,7 +8649,7 @@ local options = {
         '%=',
         "%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}",
         "%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}",
-        "%{% &busy ? '◐ ' : '' %}",
+        "%{% &busy > 0 ? '◐ ' : '' %}",
         "%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}",
       }),
       desc = [=[

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -311,6 +311,20 @@ local options = {
       varname = 'p_awa',
     },
     {
+      defaults = false,
+      desc = [=[
+        This value specifies status if buffer. When it's set to true it marks
+        the buffer as busy.
+      ]=],
+      full_name = 'busy',
+      redraw = { 'statuslines' },
+      noglob = true,
+      scope = { 'buf' },
+      short_desc = N_('buffer is busy'),
+      type = 'boolean',
+      varname = 'p_busy',
+    },
+    {
       abbreviation = 'bg',
       cb = 'did_set_background',
       defaults = 'dark',
@@ -8634,6 +8648,7 @@ local options = {
         '%=',
         "%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}",
         "%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}",
+        "%{% &busy ? '<busy> ' : '' %}",
         "%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}",
       }),
       desc = [=[

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -311,20 +311,6 @@ local options = {
       varname = 'p_awa',
     },
     {
-      defaults = false,
-      desc = [=[
-        Sets a buffer "busy" status. Indicated in the default statusline.
-        The semantics of "busy" are arbitrary, typically decided by the plugin that owns the buffer
-      ]=],
-      full_name = 'busy',
-      redraw = { 'statuslines' },
-      noglob = true,
-      scope = { 'buf' },
-      short_desc = N_('buffer is busy'),
-      type = 'boolean',
-      varname = 'p_busy',
-    },
-    {
       abbreviation = 'bg',
       cb = 'did_set_background',
       defaults = 'dark',
@@ -963,6 +949,20 @@ local options = {
       short_desc = N_('special type of buffer'),
       type = 'string',
       varname = 'p_bt',
+    },
+    {
+      defaults = false,
+      desc = [=[
+        Sets a buffer "busy" status. Indicated in the default statusline.
+        The semantics of "busy" are arbitrary, typically decided by the plugin that owns the buffer
+      ]=],
+      full_name = 'busy',
+      redraw = { 'statuslines' },
+      noglob = true,
+      scope = { 'buf' },
+      short_desc = N_('buffer is busy'),
+      type = 'boolean',
+      varname = 'p_busy',
     },
     {
       abbreviation = 'cmp',

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -313,8 +313,8 @@ local options = {
     {
       defaults = false,
       desc = [=[
-        This value specifies status if buffer. When it's set to true it marks
-        the buffer as busy.
+        Sets a buffer "busy" status. Indicated in the default statusline.
+        The semantics of "busy" are arbitrary, typically decided by the plugin that owns the buffer
       ]=],
       full_name = 'busy',
       redraw = { 'statuslines' },
@@ -8648,7 +8648,7 @@ local options = {
         '%=',
         "%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}",
         "%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}",
-        "%{% &busy ? '<busy> ' : '' %}",
+        "%{% &busy ? '◐ ' : '' %}",
         "%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}",
       }),
       desc = [=[

--- a/test/functional/legacy/autocmd_option_spec.lua
+++ b/test/functional/legacy/autocmd_option_spec.lua
@@ -355,8 +355,7 @@ describe('au OptionSet', function()
 
     it('with string global-local (to window) option', function()
       local oldval = eval('&statusline')
-      local default_statusline =
-        "%<%f %h%w%m%r %=%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}"
+      local default_statusline = api.nvim_get_option_info2('statusline', {}).default
 
       command('set statusline=foo')
       expected_combination({

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -786,12 +786,38 @@ describe('default statusline', function()
     eq('asdf', eval('&statusline'))
 
     local default_statusline =
-      "%<%f %h%w%m%r %=%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}"
+      "%<%f %h%w%m%r %=%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &busy ? '<busy> ' : '' %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}"
 
     exec_lua("vim.o.statusline = ''")
 
     eq(default_statusline, eval('&statusline'))
 
+    screen:expect([[
+      ^                                                            |
+      {1:~                                                           }|*13
+      {3:[No Name]                                 0,0-1          All}|
+                                                                  |
+    ]])
+  end)
+
+  it('shows busy status when buffer is set to be busy', function()
+    exec_lua("vim.o.statusline = ''")
+
+    screen:expect([[
+      ^                                                            |
+      {1:~                                                           }|*13
+      {3:[No Name]                                 0,0-1          All}|
+                                                                  |
+    ]])
+    exec_lua('vim.o.busy = true')
+    screen:expect([[
+      ^                                                            |
+      {1:~                                                           }|*13
+      {3:[No Name]                          <busy> 0,0-1          All}|
+                                                                  |
+    ]])
+
+    exec_lua('vim.o.busy = false')
     screen:expect([[
       ^                                                            |
       {1:~                                                           }|*13

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -791,7 +791,7 @@ describe('default statusline', function()
       '%=',
       "%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}",
       "%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}",
-      "%{% &busy ? '◐ ' : '' %}",
+      "%{% &busy > 0 ? '◐ ' : '' %}",
       "%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}",
     })
 
@@ -816,7 +816,7 @@ describe('default statusline', function()
       {3:[No Name]                                 0,0-1          All}|
                                                                   |
     ]])
-    exec_lua('vim.o.busy = true')
+    exec_lua('vim.o.busy = 1')
     screen:expect([[
       ^                                                            |
       {1:~                                                           }|*13
@@ -824,7 +824,7 @@ describe('default statusline', function()
                                                                   |
     ]])
 
-    exec_lua('vim.o.busy = false')
+    exec_lua('vim.o.busy = 0')
     screen:expect([[
       ^                                                            |
       {1:~                                                           }|*13

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -785,8 +785,15 @@ describe('default statusline', function()
     exec_lua("vim.o.statusline = 'asdf'")
     eq('asdf', eval('&statusline'))
 
-    local default_statusline =
-      "%<%f %h%w%m%r %=%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &busy ? '<busy> ' : '' %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}"
+    local default_statusline = table.concat({
+      '%<',
+      '%f %h%w%m%r ',
+      '%=',
+      "%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}",
+      "%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}",
+      "%{% &busy ? '◐ ' : '' %}",
+      "%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}",
+    })
 
     exec_lua("vim.o.statusline = ''")
 
@@ -813,7 +820,7 @@ describe('default statusline', function()
     screen:expect([[
       ^                                                            |
       {1:~                                                           }|*13
-      {3:[No Name]                          <busy> 0,0-1          All}|
+      {3:[No Name]                               ◐ 0,0-1          All}|
                                                                   |
     ]])
 


### PR DESCRIPTION
### busy status indicator for  buffers in statusline

Adds new buffer specific boolean option 'busy'.
When busy is set it indicates the buffer is busy. For now this busy status is shown in the default statusline as `<busy>`

![image](https://github.com/user-attachments/assets/1eeb6a81-ef20-4c73-9f6c-e6dae694b2a2)

related  #32084