### PR TITLE
update deps hash for zig 0.14.0

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -11,7 +11,7 @@
         },
         .lpeg = .{
             .url = "https://github.com/neovim/deps/raw/d495ee6f79e7962a53ad79670cb92488abe0b9b4/opt/lpeg-1.1.0.tar.gz",
-            .hash = "122084badadeb91106dd06b2055119a944c340563536caefd8e22d4064182f7cd6e6",
+            .hash = "N-V-__8AAMnaAwCEutreuREG3QayBVEZqUTDQFY1Nsrv2OIt",
         },
         .luv = .{
             .url = "git+https://github.com/luvit/luv?ref=1.51.0-1#4c9fbc6cf6f3338bb0e0426710cf885ee557b540",
@@ -19,7 +19,7 @@
         },
         .lua_compat53 = .{
             .url = "https://github.com/lunarmodules/lua-compat-5.3/archive/v0.13.tar.gz",
-            .hash = "1220e75685f00c242fbf6c1c60e98dd1b24ba99e38277970a10636e44ed08cf2af8a",
+            .hash = "N-V-__8AADi-AwDnVoXwDCQvv2wcYOmN0bJLqZ44J3lwoQY2",
         },
         .treesitter = .{
             .url = "git+https://github.com/tree-sitter/tree-sitter?ref=v0.25.6#50622f71f87fa97f1ec463f83447d524d5156286",

--- a/deps/iconv_apple/build.zig.zon
+++ b/deps/iconv_apple/build.zig.zon
@@ -6,7 +6,7 @@
     .dependencies = .{
         .libiconv = .{
             .url = "git+https://github.com/apple-oss-distributions/libiconv?ref=libiconv-107#a3f3b2c76dbf8ba11881debc6bcb4e309958d252",
-            .hash = "12202adcca76e9822f506b5acd2f0a3e285c152e2f48683341fd719d9f1df3a1296b",
+            .hash = "N-V-__8AAKce8wQq3Mp26YIvUGtazS8KPihcFS4vSGgzQf1x",
         },
     },
 }

--- a/deps/unibilium/build.zig.zon
+++ b/deps/unibilium/build.zig.zon
@@ -6,7 +6,7 @@
     .dependencies = .{
         .unibilium = .{
             .url = "git+https://github.com/neovim/unibilium?ref=v2.1.2#bfcb0350129dd76893bc90399cf37c45812268a2",
-            .hash = "1220a082fc7bdf2a6d9c19576c49bb4e33923ba54622a7340af611e9deb46f851f9a",
+            .hash = "N-V-__8AADO1CgCggvx73yptnBlXbEm7TjOSO6VGIqc0CvYR",
         },
     },
 }

--- a/deps/utf8proc/build.zig.zon
+++ b/deps/utf8proc/build.zig.zon
@@ -6,7 +6,7 @@
     .dependencies = .{
         .utf8proc = .{
             .url = "git+https://github.com/JuliaStrings/utf8proc?ref=v2.10.0#a1b99daa2a3393884220264c927a48ba1251a9c6",
-            .hash = "1220d80ce0bde71b8acae76b9686fa785aa0cdf165f0d6e93a853d57bfbed129a5e7",
+            .hash = "N-V-__8AAPJfKADYDOC95xuKyudrlob6eFqgzfFl8NbpOoU9",
         },
     },
 }


### PR DESCRIPTION
some deps: libiconv,unibilium,utf8proc,lpeg,lua_compat53 still use old hashes and cannot be compiled by zig 0.14.0, need to update the hash.
