### PR TITLE
feat(lsp): synchronously request code actions

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1681,6 +1681,8 @@ code_action({opts})                                *vim.lsp.buf.code_action()*
                   this defaults to the active selection. Table must contain
                   `start` and `end` keys with {row,col} tuples using mark-like
                   indexing. See |api-indexing|
+                • {timeout}? (`integer`) Time (in milliseconds) to wait for
+                  all providers to respond (default: `2000`).
 
     See also: ~
       • https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_codeAction


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

When multiple code actions providers are active, it can take up to several minutes for all servers to reply, creating an awkward experience where the list is displayed way after triggering `vim.lsp.buf_code_action`.

Because of the nature of this request, I think we should make it sync and introduce a timeout. I'm also open to keeping it async by default and using the sync implementation if the `timeout` option is set.