### PR TITLE
fix(edit): clear showcmd after clearing last put char

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -3270,12 +3270,13 @@ static void ins_reg(void)
     ins_need_undo = true;
   }
   u_sync_once = 0;
-  clear_showcmd();
 
-  // If the inserted register is empty, we need to remove the '"'
+  // If the inserted register is empty, we need to remove the '"'. Do this before
+  // clearing showcmd, which emits an event that can also update the screen.
   if (need_redraw || stuff_empty()) {
     edit_unputchar();
   }
+  clear_showcmd();
 
   // Disallow starting Visual mode here, would get a weird mode.
   if (!vis_active && VIsual_active) {

--- a/test/functional/messages2_spec.lua
+++ b/test/functional/messages2_spec.lua
@@ -24,7 +24,7 @@ describe('messages2', function()
         {1:~                                                    }|*12
         foo[+1]                                              |
       ]])
-      command('set ruler')
+      command('set ruler showcmd noshowmode')
       feed('g<lt>')
       screen:expect([[
                                                              |
@@ -67,6 +67,19 @@ describe('messages2', function()
         {4:                                                     }|
         {4:  1 %a   "[No Name]"                    line 1       }|
                                             1,1           All|
+      ]])
+      -- edit_unputchar() does not clear already updated screen #34515.
+      feed('qix<Esc>dwi<C-r>')
+      screen:expect([[
+        {18:^"}                                                    |
+        {1:~                                                    }|*12
+                                 ^R         1,1           All|
+      ]])
+      feed('-')
+      screen:expect([[
+        x^                                                    |
+        {1:~                                                    }|*12
+                                            1,2           All|
       ]])
     end)
   end)


### PR DESCRIPTION
Problem:  Screen may be updated by a msg_showcmd event before '"' is
          cleared from the screen with register insertion.
Solution: Emit the msg_showcmd event after clearing the '"'.

Fix #34515
