### PR TITLE
vim-patch:9.1.1463: Integer overflow in getmarklist() after linewise operation

### DIFF
--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -1799,7 +1799,7 @@ static int add_mark(list_T *l, const char *mname, const pos_T *pos, int bufnr, c
 
   tv_list_append_number(lpos, bufnr);
   tv_list_append_number(lpos, pos->lnum);
-  tv_list_append_number(lpos, pos->col + 1);
+  tv_list_append_number(lpos, pos->col < MAXCOL ? pos->col + 1 : MAXCOL);
   tv_list_append_number(lpos, pos->coladd);
 
   if (tv_dict_add_str(d, S_LEN("mark"), mname) == FAIL

--- a/test/old/testdir/test_marks.vim
+++ b/test/old/testdir/test_marks.vim
@@ -301,6 +301,11 @@ func Test_getmarklist()
   call assert_equal({'mark' : "'r", 'pos' : [bufnr(), 2, 2, 0]},
         \ bufnr()->getmarklist()[0])
   call assert_equal([], {}->getmarklist())
+  normal! yy
+  call assert_equal([
+        \ {'mark': "'[", 'pos': [bufnr(), 2, 1, 0]},
+        \ {'mark': "']", 'pos': [bufnr(), 2, v:maxcol, 0]},
+        \ ], getmarklist(bufnr())[-2:])
   close!
 endfunc
 


### PR DESCRIPTION
Fix #34524

#### vim-patch:9.1.1463: Integer overflow in getmarklist() after linewise operation

Problem:  Integer overflow in getmarklist() after linewise operation.
Solution: Don't add 1 to MAXCOL (zeertzjq)

closes: vim/vim#17552

https://github.com/vim/vim/commit/93318a9933893103442f552b26bd0a41b98cb68b