### PR TITLE
fix(lsp): include client ID when receiving unknown fold kind

### DIFF
--- a/runtime/lua/vim/lsp/_folding_range.lua
+++ b/runtime/lua/vim/lsp/_folding_range.lua
@@ -46,7 +46,7 @@ local function renew(bufnr)
   ---@type table<integer, string?>
   local row_text = {}
 
-  for _, ranges in pairs(bufstate.client_ranges) do
+  for client_id, ranges in pairs(bufstate.client_ranges) do
     for _, range in ipairs(ranges) do
       local start_row = range.startLine
       local end_row = range.endLine
@@ -62,7 +62,7 @@ local function renew(bufnr)
             kinds[kind] = true
             row_kinds[start_row] = kinds
           else
-            log.info(('Received unsupported fold kind: "%s"'):format(kind))
+            log.info(('Unknown fold kind "%s" from client %d'):format(kind, client_id))
           end
         end
 


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

This more closely aligns with [the message logged when receiving unknown diagnostic tags](https://github.com/neovim/neovim/blob/492ea28612b2e47e187d6a37f582267655ba79fe/runtime/lua/vim/lsp/diagnostic.lua#L78), and including the client ID is useful for debugging purposes.