### PR TITLE
build: slience new clang-tidy warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -18,6 +18,7 @@ Checks: >
   -bugprone-not-null-terminated-result,
   -bugprone-suspicious-memory-comparison,
   -bugprone-switch-missing-default-case,
+  -bugprone-tagged-union-member-count,
   -cert-env33-c,
   -cert-err33-c,
   -cert-err34-c,
@@ -63,6 +64,7 @@ Checks: >
 
   Aliases. These are just duplicates of other warnings and should always be ignored,
   -bugprone-narrowing-conversions,
+  -cert-arr39-c,
   -cert-dcl37-c,
   -cert-dcl51-cpp,
   -cert-exp42-c,


### PR DESCRIPTION
Problem: The new `cert-arr39-c` and `bugprone-tagged-union-member-count` checks introduced in clang-tidy 20 fail on Neovim's codebase, even though the code is correct.

`cert-arr39-c` is just an alias for the disabled check `bugprone-sizeof-expression`.

`bugprone-tagged-union-member-count` is used to verify whether the number of enum members serving as the tag in a tagged union is the same as the number of members in the union itself. 

In `struct Channel`： 

https://github.com/neovim/neovim/blob/cd06e0c9d6bea2d91b553c2552e4654d2040480b/src/nvim/channel.h#L17-L32

the union member `stream` has 7 members, but its tag, `streamtype`, only has 5 members:

https://github.com/neovim/neovim/blob/cd06e0c9d6bea2d91b553c2552e4654d2040480b/src/nvim/channel_defs.h#L11-L17

So it fails the `bugprone-tagged-union-member-count` check. However, this is not actually a bug because the remaining two members (`uv` and `pty`) can be distinguished by the `type` field of `stream.proc`:

https://github.com/neovim/neovim/blob/cd06e0c9d6bea2d91b553c2552e4654d2040480b/src/nvim/event/defs.h#L144-L156

Solution: Disable these two checks by modifying the `.clang-tidy` configuration file.

