### PR TITLE
vim-patch:152a450: runtime(sh): reset g:sh_fold_enabled after outputting its value in syntax script

### DIFF
--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -15,6 +15,7 @@
 "		2025 May 06 match KornShell compound arrays
 "		2025 May 10 improve wildcard character class lists
 "		2025 May 21 improve supported KornShell features
+"		2025 Jun 16 change how sh_fold_enabled is reset (#17557)
 " Version:		208
 " Former URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
 " For options and settings, please use:      :help ft-sh-syntax
@@ -147,8 +148,8 @@ endif
 if !exists("g:sh_fold_enabled")
  let g:sh_fold_enabled= 0
 elseif g:sh_fold_enabled != 0 && !has("folding")
- let g:sh_fold_enabled= 0
  echomsg "Ignoring g:sh_fold_enabled=".g:sh_fold_enabled."; need to re-compile vim for +fold support"
+ let g:sh_fold_enabled= 0
 endif
 let s:sh_fold_functions= and(g:sh_fold_enabled,1)
 let s:sh_fold_heredoc  = and(g:sh_fold_enabled,2)


### PR DESCRIPTION
fixes: vim/vim#10701
closes: vim/vim#17557

https://github.com/vim/vim/commit/152a450d88532ef9a352e0e9c9d8f4b7a491191b

Co-authored-by: hakkadaikon <hakkadaikon@yahoo.co.jp>

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
