### PR TITLE
feat(defaults): default 'findfunc' to fd if available

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -131,6 +131,7 @@ DEFAULTS
   was implemented as an internal C routine).
 • Project-local configuration ('exrc') is also loaded from parent directories.
   Unset 'exrc' to stop further search.
+• 'findfunc' uses `fd` if available.
 
 DIAGNOSTICS
 
@@ -257,6 +258,7 @@ These existing features changed their behavior.
   the first writable directory in 'runtimepath'.
 • |vim.version.range()| doesn't exclude `to` if it is equal to `from`.
 • |searchcount()|'s maximal value is raised from 99 to 999.
+• |:find| uses `fd` if available by setting 'findfunc'.
 
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -53,6 +53,7 @@ Defaults                                            *defaults* *nvim-defaults*
 - 'display' defaults to "lastline"
 - 'encoding' is UTF-8 (cf. 'fileencoding' for file-content encoding)
 - 'fillchars' defaults (in effect) to "vert:│,fold:·,foldsep:│"
+- 'findfunc' uses `fd` if available
 - 'formatoptions' defaults to "tcqj"
 - 'grepprg' uses the -H and -I flags for regular grep,
   and defaults to using ripgrep if available

--- a/runtime/lua/vim/health/health.lua
+++ b/runtime/lua/vim/health/health.lua
@@ -406,6 +406,17 @@ local function check_external_tools()
   else
     health.warn('ripgrep not available')
   end
+
+  local fd_cmd = vim.fn.executable('fdfind') == 1 and 'fdfind'
+    or vim.fn.executable('fd') == 1 and 'fd'
+    or nil
+  if fd_cmd then
+    local fd = vim.fn.exepath(fd_cmd)
+    local result = vim.system({ fd_cmd, '-V' }, { text = true }):wait()
+    health.ok(('%s (%s)'):format(vim.trim(result.stdout), fd))
+  else
+    health.warn('fd not available')
+  end
 end
 
 function M.check()

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3171,7 +3171,8 @@ local options = {
       desc = [=[
         Function that is called to obtain the filename(s) for the |:find|
         command.  When this option is empty, the internal |file-searching|
-        mechanism is used.
+        mechanism is used. Defaults to `fd` if it is available (See "External
+        Tools" in |:checkhealth|).
 
         The value can be the name of a function, a |lambda| or a |Funcref|.
         See |option-value-function| for more information.


### PR DESCRIPTION
In similar vein as #28324, use [sharkdp/fd](https://github.com/sharkdp/fd) as default function for `:find` if available. As far as I'm aware, `fd` is as popular and robust as `rg`.
Problem:
Although `:find` had the same name as the CLI tool, it does not search recursively down for files. "Workarounds" include adding `**` to 'path' or the search string (e.g. `:find **/api.txt`. 

Solution:
If the user has `fd` (or `rg`, TBD), a modern `find` alternative installed, use that as 'findfunc'. Aligning the functionality with the
command line tool 'find'. 

---

N.B. Instead of the current approach with a global Lua function, where should I put the function? Could be in `runtime/lua/vim/_buf.lua`, as the other functions in that file are also temporary there until an option can take a lua function as value.
