### PR TITLE
feat(lsp): pass resolved config to cmd()

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1359,16 +1359,17 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                • Note: To send an empty dictionary use
                                  |vim.empty_dict()|, else it will be encoded
                                  as an array.
-      • {cmd}                  (`string[]|fun(dispatchers: vim.lsp.rpc.Dispatchers): vim.lsp.rpc.PublicClient`)
+      • {cmd}                  (`string[]|fun(dispatchers: vim.lsp.rpc.Dispatchers, config: vim.lsp.ClientConfig): vim.lsp.rpc.PublicClient`)
                                Command `string[]` that launches the language
                                server (treated as in |jobstart()|, must be
                                absolute or on `$PATH`, shell constructs like
                                "~" are not expanded), or function that creates
                                an RPC client. Function receives a
-                               `dispatchers` table and returns a table with
-                               member functions `request`, `notify`,
-                               `is_closing` and `terminate`. See
-                               |vim.lsp.rpc.request()|,
+                               `dispatchers` table and the `config` table tha
+                               was passed to |vim.lsp.start()|. The function
+                               then needs to return a table with member
+                               functions `request`, `notify`, `is_closing` and
+                               `terminate`. See |vim.lsp.rpc.request()|,
                                |vim.lsp.rpc.notify()|. For TCP there is a
                                builtin RPC client factory:
                                |vim.lsp.rpc.connect()|

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1365,10 +1365,9 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                absolute or on `$PATH`, shell constructs like
                                "~" are not expanded), or function that creates
                                an RPC client. Function receives a
-                               `dispatchers` table and the `config` table tha
-                               was passed to |vim.lsp.start()|. The function
-                               then needs to return a table with member
-                               functions `request`, `notify`, `is_closing` and
+                               `dispatchers` table and the resolved `config`,
+                               and must return a table with member functions
+                               `request`, `notify`, `is_closing` and
                                `terminate`. See |vim.lsp.rpc.request()|,
                                |vim.lsp.rpc.notify()|. For TCP there is a
                                builtin RPC client factory:

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -180,6 +180,8 @@ LSP
   `an` selects outwards and `in` selects inwards.
 • Support for multiline semantic tokens.
 • Support for the `disabled` field on code actions.
+• The function form of `cmd` in a vim.lsp.Config or vim.lsp.ClientConfig
+  receives the resolved config as the second arg: `cmd(dispatchers, config)`.
 
 LUA
 

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -45,11 +45,12 @@ local validate = vim.validate
 ---
 --- Command `string[]` that launches the language server (treated as in |jobstart()|, must be
 --- absolute or on `$PATH`, shell constructs like "~" are not expanded), or function that creates an
---- RPC client. Function receives a `dispatchers` table and returns a table with member functions
+--- RPC client. Function receives a `dispatchers` table and the `config` table tha was passed
+--- to |vim.lsp.start()|. The function then needs to return a table with member functions
 --- `request`, `notify`, `is_closing` and `terminate`.
 --- See |vim.lsp.rpc.request()|, |vim.lsp.rpc.notify()|.
 --- For TCP there is a builtin RPC client factory: |vim.lsp.rpc.connect()|
---- @field cmd string[]|fun(dispatchers: vim.lsp.rpc.Dispatchers): vim.lsp.rpc.PublicClient
+--- @field cmd string[]|fun(dispatchers: vim.lsp.rpc.Dispatchers, config: vim.lsp.ClientConfig): vim.lsp.rpc.PublicClient
 ---
 --- Directory to launch the `cmd` process. Not related to `root_dir`.
 --- (default: cwd)
@@ -455,7 +456,7 @@ function Client.create(config)
   -- Start the RPC client.
   local config_cmd = config.cmd
   if type(config_cmd) == 'function' then
-    self.rpc = config_cmd(dispatchers)
+    self.rpc = config_cmd(dispatchers, config)
   else
     self.rpc = lsp.rpc.start(config_cmd, dispatchers, {
       cwd = config.cmd_cwd,

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -45,9 +45,8 @@ local validate = vim.validate
 ---
 --- Command `string[]` that launches the language server (treated as in |jobstart()|, must be
 --- absolute or on `$PATH`, shell constructs like "~" are not expanded), or function that creates an
---- RPC client. Function receives a `dispatchers` table and the resolved `config`,
---- and must return a table with member functions
---- `request`, `notify`, `is_closing` and `terminate`.
+--- RPC client. Function receives a `dispatchers` table and the resolved `config`, and must return
+--- a table with member functions `request`, `notify`, `is_closing` and `terminate`.
 --- See |vim.lsp.rpc.request()|, |vim.lsp.rpc.notify()|.
 --- For TCP there is a builtin RPC client factory: |vim.lsp.rpc.connect()|
 --- @field cmd string[]|fun(dispatchers: vim.lsp.rpc.Dispatchers, config: vim.lsp.ClientConfig): vim.lsp.rpc.PublicClient

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -45,8 +45,8 @@ local validate = vim.validate
 ---
 --- Command `string[]` that launches the language server (treated as in |jobstart()|, must be
 --- absolute or on `$PATH`, shell constructs like "~" are not expanded), or function that creates an
---- RPC client. Function receives a `dispatchers` table and the `config` table tha was passed
---- to |vim.lsp.start()|. The function then needs to return a table with member functions
+--- RPC client. Function receives a `dispatchers` table and the resolved `config`,
+--- and must return a table with member functions
 --- `request`, `notify`, `is_closing` and `terminate`.
 --- See |vim.lsp.rpc.request()|, |vim.lsp.rpc.notify()|.
 --- For TCP there is a builtin RPC client factory: |vim.lsp.rpc.connect()|

--- a/test/functional/plugin/lsp/testutil.lua
+++ b/test/functional/plugin/lsp/testutil.lua
@@ -54,7 +54,7 @@ M.create_server_definition = function()
     local server = {}
     server.messages = {}
 
-    function server.cmd(dispatchers)
+    function server.cmd(dispatchers, _config)
       local closing = false
       local handlers = opts.handlers or {}
       local srv = {}


### PR DESCRIPTION
Problem:
In LSP configs, the function form of `cmd()` cannot easily get the
resolved root dir (workspace). One of the main use-cases of a dynamic
`cmd()` is to be able to start a new server  whose binary may be located
*in the workspace* ([example](https://github.com/neovim/nvim-lspconfig/pull/3912)).

Compare `reuse_client()`, which also receives the resolved config.

Solution:
Pass the resolved config to `cmd()`.


fix #34547