### PR TITLE
docs(treesitter): fix comment format and generated docs for `Query:iter_matches`

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1521,11 +1521,12 @@ Query:iter_matches({node}, {source}, {start}, {stop}, {opts})
                     start depth for each match. This is used to prevent
                     traversing too deep into a tree.
                   • match_limit (integer) Set the maximum number of
-                    in-progress matches (Default: 256). all (boolean) When
-                    `false` (default `true`), the returned table maps capture
-                    IDs to a single (last) node instead of the full list of
-                    matching nodes. This option is only for backward
-                    compatibility and will be removed in a future release.
+                    in-progress matches (Default: 256).
+                  • all (boolean) When `false` (default `true`), the returned
+                    table maps capture IDs to a single (last) node instead of
+                    the full list of matching nodes. This option is only for
+                    backward compatibility and will be removed in a future
+                    release.
 
     Return: ~
         (`fun(): integer, table<integer, TSNode[]>, vim.treesitter.query.TSMetadata, TSTree`)

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -1056,9 +1056,9 @@ end
 ---   - max_start_depth (integer) if non-zero, sets the maximum start depth
 ---     for each match. This is used to prevent traversing too deep into a tree.
 ---   - match_limit (integer) Set the maximum number of in-progress matches (Default: 256).
---- - all (boolean) When `false` (default `true`), the returned table maps capture IDs to a single
----   (last) node instead of the full list of matching nodes. This option is only for backward
----   compatibility and will be removed in a future release.
+---   - all (boolean) When `false` (default `true`), the returned table maps capture IDs to a single
+---     (last) node instead of the full list of matching nodes. This option is only for backward
+---     compatibility and will be removed in a future release.
 ---
 ---@return (fun(): integer, table<integer, TSNode[]>, vim.treesitter.query.TSMetadata, TSTree): pattern id, match, metadata, tree
 function Query:iter_matches(node, source, start, stop, opts)


### PR DESCRIPTION
# Problem

The vimdoc documentation for `:h Query:iter_matches()` was messed up because the formatting of the option `all` in the comments annotations for the function was incorrect.

# Solution

Correctly format the part of the comment that mentions the `all` option and regenerate the vimdoc documentation.