### PR TITLE
vim-patch:9.1.1466: filetype: not all lex files are recognized

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -908,9 +908,13 @@ function M.ll(_, bufnr)
   local first_line = getline(bufnr, 1)
   if matchregex(first_line, [[;\|\<source_filename\>\|\<target\>]]) then
     return 'llvm'
-  else
-    return 'lifelines'
   end
+  for _, line in ipairs(getlines(bufnr, 1, 100)) do
+    if line:find('^%s*%%') then
+      return 'lex'
+    end
+  end
+  return 'lifelines'
 end
 
 --- @type vim.filetype.mapfn

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -2600,6 +2600,12 @@ func Test_ll_file()
   call assert_equal('llvm', &filetype)
   bwipe!
 
+  " lex (C++)
+  call writefile(['%{', '#include <iostream>', '%}'], 'Xfile.ll', 'D')
+  split Xfile.ll
+  call assert_equal('lex', &filetype)
+  bwipe!
+
   " lifelines
   call writefile(['proc main() {}'], 'Xfile.ll', 'D')
   split Xfile.ll


### PR DESCRIPTION
Problem:  filetype: not all lex files are recognized Solution: detect *.ll as lex, llvm or lifelines filetype, depending on
          the content (Eisuke Kawashima)

closes: vim/vim#17560

https://github.com/vim/vim/commit/48295111e578e2158c6234510f12081de4757c52

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
