### PR TITLE
fix(diagnostics): add type validation for opts.signs

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1527,6 +1527,7 @@ M.handlers.signs = {
     vim.validate('bufnr', bufnr, 'number')
     vim.validate('diagnostics', diagnostics, vim.islist, 'a list of diagnostics')
     vim.validate('opts', opts, 'table', true)
+    vim.validate('opts.signs', (opts and opts or {}).signs, 'table', true)
 
     bufnr = vim._resolve_bufnr(bufnr)
     opts = opts or {}


### PR DESCRIPTION
Based on the conclusion of #34482. Closes neovim/neovim#34482
