### PR TITLE
vim-patch:e4c157b: runtime(nroff,groff): update commentstyle in filetype plugins

### DIFF
--- a/runtime/ftplugin/groff.vim
+++ b/runtime/ftplugin/groff.vim
@@ -2,6 +2,7 @@
 " Language:  groff(7)
 " Maintainer: Eisuke Kawashima ( e.kawaschima+vim AT gmail.com )
 " Last Change: 2025 Apr 24
+" 2025 Jun 18 by Vim Project: update commentstring option (#17516)
 
 if exists('b:did_ftplugin')
   finish
@@ -10,6 +11,9 @@ endif
 let b:nroff_is_groff = 1
 
 runtime! ftplugin/nroff.vim
+
+setlocal commentstring=\\#\ %s
+setlocal comments=:\\#,:.\\\",:\\\",:'\\\",:'''
 
 let b:undo_ftplugin .= '| unlet! b:nroff_is_groff'
 let b:did_ftplugin = 1

--- a/runtime/ftplugin/hgcommit.vim
+++ b/runtime/ftplugin/hgcommit.vim
@@ -1,10 +1,11 @@
 " Vim filetype plugin file
 " Language:	hg (Mercurial) commit file
 " Maintainer:	Ken Takata <kentkt at csc dot jp>
-" Last Change:	2016 Jan 6
+" Last Change:	2025 Jun 8
 " Filenames:	hg-editor-*.txt
 " License:	VIM License
 " URL:		https://github.com/k-takata/hg-vim
+" 2025 Jun 18 by Vim Project: update commentstring option (#17480)
 
 if exists("b:did_ftplugin")
   finish
@@ -13,4 +14,7 @@ let b:did_ftplugin = 1
 
 setlocal nomodeline
 
-let b:undo_ftplugin = 'setl modeline<'
+setlocal comments=:HG\:
+setlocal commentstring=HG:\ %s
+
+let b:undo_ftplugin = 'setl modeline< com< cms<'

--- a/runtime/ftplugin/ishd.vim
+++ b/runtime/ftplugin/ishd.vim
@@ -2,7 +2,8 @@
 " Language:		InstallShield (ft=ishd)
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Johannes Zellner <johannes@zellner.org>
-" Last Change:		2024 Jan 14
+" Last Change:		2025 Jun 18
+" 2025 Jun 18 by Vim Project: set comments and commentstring option (#17490)
 
 if exists("b:did_ftplugin") | finish | endif
 let b:did_ftplugin = 1
@@ -12,8 +13,10 @@ let s:cpo_save = &cpo
 set cpo-=C
 
 setlocal foldmethod=syntax
+setlocal commentstring=//\ %s
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
 
-let b:undo_ftplugin = "setl fdm<"
+let b:undo_ftplugin = "setl fdm< com< cms"
 
 " matchit support
 if exists("loaded_matchit")

--- a/runtime/ftplugin/nroff.vim
+++ b/runtime/ftplugin/nroff.vim
@@ -9,6 +9,7 @@
 "	2025 Feb 12 by Wu, Zhenyu <wuzhenyu@ustc.edu> (matchit configuration #16619)
 "	2025 Apr 16 by Eisuke Kawashima (cpoptions #17121)
 "	2025 Apr 24 by Eisuke Kawashima (move options from syntax to ftplugin #17174)
+"	2025 Jun 18 by Vim Project: update commentstring option (#17516)
 
 if exists("b:did_ftplugin")
   finish
@@ -19,7 +20,7 @@ let s:cpo_save = &cpo
 set cpo&vim
 
 setlocal commentstring=.\\\"\ %s
-setlocal comments=:.\\\"
+setlocal comments=:.\\\",:\\\",:'\\\",:'''
 setlocal sections+=Sh
 setlocal define=.\s*de
 


### PR DESCRIPTION
closes: vim/vim#17516

https://github.com/vim/vim/commit/e4c157b9c1225a733a5ff73a5325a35996c07559

Co-authored-by: jtmr05 <62111562+jtmr05@users.noreply.github.com>

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
