### PR TITLE
workaround EACESS error on /windowsapps executables

### DIFF
--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -267,16 +267,16 @@ static bool is_executable(const char *name, char **abspath)
   FUNC_ATTR_NONNULL_ARG(1)
 {
   int32_t mode = os_getperm(name);
+#ifdef MSWIN
+  // Windows does not have exec bit; just check if the file exists and is not
+  // a directory.
+  const bool ok = mode < 0 ? mode == UV_EACCES : S_ISREG(mode);
+#else
 
   if (mode < 0) {
     return false;
   }
 
-#ifdef MSWIN
-  // Windows does not have exec bit; just check if the file exists and is not
-  // a directory.
-  const bool ok = S_ISREG(mode);
-#else
   int r = -1;
   if (S_ISREG(mode)) {
     RUN_UV_FS_FUNC(r, uv_fs_access, name, X_OK, NULL);


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
libuv give EACESS for executables under /WindowsApps making some installations of julia and python not `vim.fn.executable`.

```lua
local path_of_interest = vim.env['LOCALAPPDATA'] .. '/Microsoft/WindowsApps/python.exe' -- By default this just open the windows store, but it is an executable file
if vim.fn.executable(path_of_interest) ~= 1 then
  vim.notify('python not executable')
  vim.notify('searched: ' .. path_of_interest)
  assert(false)
end
```