### PR TITLE
vim-patch:9.1.1471: completion: inconsistent ordering with CTRL-P

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -607,7 +607,7 @@ static int insert_execute(VimState *state, int key)
                && (s->c == CAR || s->c == K_KENTER || s->c == NL)))
           && stop_arrow() == OK) {
         ins_compl_delete(false);
-        ins_compl_insert(false, false);
+        ins_compl_insert(false);
       } else if (ascii_iswhite_nl_or_nul(s->c) && ins_compl_preinsert_effect()) {
         // Delete preinserted text when typing special chars
         ins_compl_delete(false);


### PR DESCRIPTION
#### vim-patch:9.1.1471: completion: inconsistent ordering with CTRL-P

Problem:  completion: inconsistent ordering with CTRL-P
          (zeertzjq)
Solution: reset compl_curr_match when using CTRL-P (Girish Palya)

closes: vim/vim#17434

https://github.com/vim/vim/commit/5fbe72edda708692dba4286860e727e2e0b778cc

Co-authored-by: Girish Palya <girishji@gmail.com>