### PR TITLE
vim-patch:9.1.1467: too many strlen() calls

### DIFF
--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -1449,11 +1449,10 @@ char *find_file_in_path_option(char *ptr, size_t len, int options, int first, ch
     // copy file name into NameBuff, expanding environment variables
     char save_char = ptr[len];
     ptr[len] = NUL;
-    expand_env_esc(ptr, NameBuff, MAXPATHL, false, true, NULL);
+    file_to_findlen = expand_env_esc(ptr, NameBuff, MAXPATHL, false, true, NULL);
     ptr[len] = save_char;
 
     xfree(*file_to_find);
-    file_to_findlen = strlen(NameBuff);
     *file_to_find = xmemdupz(NameBuff, file_to_findlen);
     if (options & FNAME_UNESC) {
       // Change all "\ " to " ".

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -722,10 +722,8 @@ static void fname2fnum(xfmark_T *fm)
 #else
   if (fm->fname[0] == '~' && (fm->fname[1] == '/')) {
 #endif
-
-    expand_env("~/", NameBuff, MAXPATHL);
-    int len = (int)strlen(NameBuff);
-    xstrlcpy(NameBuff + len, fm->fname + 2, (size_t)(MAXPATHL - len));
+    size_t len = expand_env("~/", NameBuff, MAXPATHL);
+    xstrlcpy(NameBuff + len, fm->fname + 2, MAXPATHL - len);
   } else {
     xstrlcpy(NameBuff, fm->fname, MAXPATHL);
   }

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -1314,8 +1314,9 @@ static char *shada_filename(const char *file)
       //     because various expansions must have already be done by the shell.
       //     If shell is not performing them then they should be done in main.c
       //     where arguments are parsed, *not here*.
-      expand_env((char *)file, &(NameBuff[0]), MAXPATHL);
+      size_t len = expand_env((char *)file, &(NameBuff[0]), MAXPATHL);
       file = &(NameBuff[0]);
+      return xmemdupz(file, len);
     }
   }
   return xstrdup(file);


### PR DESCRIPTION
#### vim-patch:9.1.1467: too many strlen() calls

Problem:  too many strlen() calls
Solution: Change expand_env() to return string length
          (John Marriott)

This commit does the following changes:
- In expand_env_esc():
  - return the length of the returned dst string.
  - refactor to remove some calls to STRLEN() and STRCAT()
  - add check for out-of-memory condition.
- Change call sites in various source files to use the return value

closes: vim/vim#17561

https://github.com/vim/vim/commit/fff0132399082b7d012d0c1291cf0c6c99e200ff

Co-authored-by: John Marriott <basilisk@internode.on.net>