### PR TITLE
fix(lsp): clear document_color autocmds

### DIFF
--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -182,11 +182,19 @@ end
 local function buf_disable(bufnr)
   buf_clear(bufnr)
   reset_bufstate(bufnr, false)
+  api.nvim_clear_autocmds({
+    buffer = bufnr,
+    group = document_color_augroup,
+  })
 end
 
 --- @param bufnr integer
 local function buf_enable(bufnr)
   reset_bufstate(bufnr, true)
+  api.nvim_clear_autocmds({
+    buffer = bufnr,
+    group = document_color_augroup,
+  })
 
   api.nvim_buf_attach(bufnr, false, {
     on_reload = function(_, buf)


### PR DESCRIPTION
**Problem:** When enabling document_color multiple times for the same buffer (or when toggling it on and off), duplicate autocmds are created since the previous ones are not cleared.

**Solution:** Clear the appropriate buffer-local autocmds when enabling/disabling document color functionality.

---

Note that this will *not* clear the `ColorScheme` autocmd since it is not buffer-local :)

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
