### PR TITLE
vim-patch:476b65e: runtime(doc): mention using <script> instead of <sfile> in :autocmd

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -78,9 +78,10 @@ exception is that "<sfile>" is expanded when the autocmd is defined.  Example:
 	:au BufNewFile,BufRead *.html so <sfile>:h/html.vim
 
 Here Vim expands <sfile> to the name of the file containing this line.
-Use <script> instead to avoid that: >
-
-	:au BufNewFile,BufRead *.html so <script>:h/html.vim
+However, <sfile> works differently in a function, in which case it's better to
+use `:execute` with <script> to achieve the same purpose:
+>
+	:exe $'au BufNewFile,BufRead *.html so {expand("<script>:h")}/html.vim'
 
 `:autocmd` adds to the list of autocommands regardless of whether they are
 already present.  When your .vimrc file is sourced twice, the autocommands
@@ -90,7 +91,7 @@ that you can easily clear them: >
 	augroup vimrc
 	  " Remove all vimrc autocommands
 	  autocmd!
-	  au BufNewFile,BufRead *.html so <script>:h/html.vim
+	  au BufNewFile,BufRead *.html so <sfile>:h/html.vim
 	augroup END
 
 If you don't want to remove all autocommands, you can instead use a variable


### PR DESCRIPTION
#### vim-patch:476b65e: runtime(doc): mention using \<script> instead of \<sfile> in :autocmd

https://github.com/vim/vim/commit/476b65ebac22eb7f4923c11d75da366eda95492e