### PR TITLE
fix(extui): set 'modifiable', 'noswapfile' for buffers

### DIFF
--- a/runtime/lua/vim/_extui/shared.lua
+++ b/runtime/lua/vim/_extui/shared.lua
@@ -77,6 +77,8 @@ function M.tab_check_wins()
     if setopt then
       local name = { cmd = 'Cmd', dialog = 'Dialog', msg = 'Msg', pager = 'Pager' }
       api.nvim_buf_set_name(M.bufs[type], ('[%s]'):format(name[type]))
+      api.nvim_set_option_value('swapfile', false, { buf = M.bufs[type] })
+      api.nvim_set_option_value('modifiable', true, { buf = M.bufs[type] })
       if type == 'pager' then
         -- Close pager with `q`, same as `checkhealth`
         api.nvim_buf_set_keymap(M.bufs.pager, 'n', 'q', '<Cmd>wincmd c<CR>', {})

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -5,7 +5,7 @@ local clear, command, exec_lua, feed = n.clear, n.command, n.exec_lua, n.feed
 
 describe('messages2', function()
   local screen
-  describe('target=msg', function()
+  describe('target=cmd', function()
     before_each(function()
       clear()
       screen = Screen.new()
@@ -81,6 +81,19 @@ describe('messages2', function()
         {1:~                                                    }|*12
                                             1,2           All|
       ]])
+    end)
+
+    it('new buffer, window and options after closing a buffer', function()
+      command('set nomodifiable | echom "foo" | messages')
+      screen:expect([[
+                                                             |
+        {1:~                                                    }|*10
+        ─{100:Pager}───────────────────────────────────────────────|
+        {4:fo^o                                                  }|
+        foo                                                  |
+      ]])
+      command('bdelete | messages')
+      screen:expect_unchanged()
     end)
   end)
 end)


### PR DESCRIPTION
Problem:  UI buffers may be 'unmodifiable' and use a 'swapfile'.
Solution: Set the 'modifiable' and 'noswapfile' options.
