### PR TITLE
test(prompt): add test for multiline paste with nvim_paste

### DIFF
--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -302,6 +302,21 @@ describe('prompt buffer', function()
     ]])
   end)
 
+  it('can put multiline text with nvim_paste', function()
+    source_script()
+    api.nvim_paste('line 1\nline 2\nline 3', false, -1)
+    screen:expect([[
+      cmd: line 1              |
+      line 2                   |
+      line 3^                   |
+      {1:~                        }|
+      {3:[Prompt] [+]             }|
+      other buffer             |
+      {1:~                        }|*3
+      {5:-- INSERT --}             |
+    ]])
+  end)
+
   it('can undo current prompt', function()
     source_script()
     -- text editiing alowed in current prompt


### PR DESCRIPTION
Problem:
Currently, multiline paste with nvim_paste on prompt_buffer is not tested

Solution:
Add test for multiline paste with nvim_paste


Followup to #33371
Working toward #34561
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
