### PR TITLE
fix(prompt): "%" prefix is repeated on multiline input with formatoptions+=r

### DIFF
--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -696,8 +696,11 @@ const char *did_set_buftype(optset_T *args)
       || opt_strings_flags(buf->b_p_bt, opt_bt_values, NULL, false) != OK) {
     return e_invarg;
   }
-  // buftype=prompt: set the prompt start position to lastline.
+  // buftype=prompt:
   if (buf->b_p_bt[0] == 'p') {
+    // Set default value for 'comments'
+    set_option_direct(kOptComments, STATIC_CSTR_AS_OPTVAL(""), OPT_LOCAL, SID_NONE);
+    // set the prompt start position to lastline.
     pos_T next_prompt = { .lnum = buf->b_ml.ml_line_count, .col = 1, .coladd = 0 };
     RESET_FMARK(&buf->b_prompt_start, next_prompt, 0, ((fmarkv_T)INIT_FMARKV));
   }

--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -5,7 +5,6 @@
 #include <string.h>
 
 #include "nvim/ascii_defs.h"
-#include "nvim/buffer.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/change.h"
 #include "nvim/charset.h"

--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -5,6 +5,7 @@
 #include <string.h>
 
 #include "nvim/ascii_defs.h"
+#include "nvim/buffer.h"
 #include "nvim/buffer_defs.h"
 #include "nvim/change.h"
 #include "nvim/charset.h"

--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -536,4 +536,20 @@ describe('prompt buffer', function()
     source('set buftype=')
     eq("Invalid mark name: ':'", t.pcall_err(api.nvim_buf_get_mark, 0, ':'))
   end)
+
+  it('% prompt is not repeated with fomratoption+=r', function()
+    source([[
+      set formatoptions+=r
+      set buftype=prompt
+    ]])
+
+    feed('iline1<s-cr>line2')
+
+    screen:expect([[
+      % line1                  |
+      line2^                    |
+      {1:~                        }|*7
+      {5:-- INSERT --}             |
+    ]])
+  end)
 end)

--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -135,21 +135,6 @@ describe('prompt buffer', function()
       {1:~                        }|*8
                                |
     ]])
-
-    -- % prompt is not repeated with fomratoption+=r
-    source([[
-      bdelete
-      set formatoptions+=r
-      set buftype=prompt
-      call prompt_setprompt(bufnr(), "% ")
-    ]])
-    feed('iline1<s-cr>line2')
-    screen:expect([[
-      % line1                  |
-      line2^                    |
-      {1:~                        }|*7
-      {5:-- INSERT --}             |
-    ]])
   end)
 
   -- oldtest: Test_prompt_switch_windows()
@@ -286,6 +271,22 @@ describe('prompt buffer', function()
       {3:[Prompt]                 }|
       other buffer             |
       {1:~                        }|*3
+      {5:-- INSERT --}             |
+    ]])
+
+    -- % prompt is not repeated with formatoptions+=r
+    source([[
+      bdelete
+      set formatoptions+=r
+      set buftype=prompt
+      call prompt_setprompt(bufnr(), "% ")
+    ]])
+    feed('iline1<s-cr>line2')
+    screen:expect([[
+      other buffer             |
+      % line1                  |
+      line2^                    |
+      {1:~                        }|*6
       {5:-- INSERT --}             |
     ]])
   end)

--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -276,7 +276,7 @@ describe('prompt buffer', function()
 
     -- % prompt is not repeated with formatoptions+=r
     source([[
-      bdelete
+      bwipeout!
       set formatoptions+=r
       set buftype=prompt
       call prompt_setprompt(bufnr(), "% ")

--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -135,6 +135,21 @@ describe('prompt buffer', function()
       {1:~                        }|*8
                                |
     ]])
+
+    -- % prompt is not repeated with fomratoption+=r
+    source([[
+      bdelete
+      set formatoptions+=r
+      set buftype=prompt
+      call prompt_setprompt(bufnr(), "% ")
+    ]])
+    feed('iline1<s-cr>line2')
+    screen:expect([[
+      % line1                  |
+      line2^                    |
+      {1:~                        }|*7
+      {5:-- INSERT --}             |
+    ]])
   end)
 
   -- oldtest: Test_prompt_switch_windows()
@@ -535,21 +550,5 @@ describe('prompt buffer', function()
     -- ': mark is only available in prompt buffer.
     source('set buftype=')
     eq("Invalid mark name: ':'", t.pcall_err(api.nvim_buf_get_mark, 0, ':'))
-  end)
-
-  it('% prompt is not repeated with fomratoption+=r', function()
-    source([[
-      set formatoptions+=r
-      set buftype=prompt
-    ]])
-
-    feed('iline1<s-cr>line2')
-
-    screen:expect([[
-      % line1                  |
-      line2^                    |
-      {1:~                        }|*7
-      {5:-- INSERT --}             |
-    ]])
   end)
 end)


### PR DESCRIPTION
**Problem**:
Currently, default prompt % is treated as comment-start. As a
result it gets added to everyline when fomratoptions+=r is set.
% is treated as comment because of global default value of 'comments'
option contains '%'.

**Solution**:
Set default value of 'comments' option to '' in prompt buffer.

followup to #33371
working toward #34561