### PR TITLE
feat(lsp): hide multiple whitespace for diagnostics in virtual text

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -1696,9 +1696,10 @@ M.handlers.virtual_text = {
     end
 
     if opts.virtual_text then
-      if opts.virtual_text.format then
-        diagnostics = reformat_diagnostics(opts.virtual_text.format, diagnostics)
+      local default_format = function(diagnostic)
+        return diagnostic.message:gsub('%s+', ' ')
       end
+      diagnostics = reformat_diagnostics(opts.virtual_text.format or default_format, diagnostics)
       if
         opts.virtual_text.source
         and (opts.virtual_text.source ~= 'if_many' or count_sources(bufnr) > 1)


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Similiarly to #28807 lsp diagnostics are hard to read when containing multiple whitespace.
Very simple example in Haskell:
Before
![image](https://github.com/user-attachments/assets/b3a6a9fd-3b9d-41a0-a7e1-979a7a3a8db4)
After
![image](https://github.com/user-attachments/assets/790a3ce0-ca5a-454a-9110-b9262680ae6a)

This pull request fixes the issue by adding a default formatting function to replace multiple whitespace with a single space.
For users who added a custom format function nothing will change. Only the default is changed to be more sane.