### PR TITLE
build(msvc): suppress msvc build warning for different enum types

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -251,8 +251,15 @@ static size_t handle_termkey_modifiers(TermKeyKey *key, char *buf, size_t buflen
 enum {
   KEYMOD_SUPER      = 1 << 3,
   KEYMOD_META       = 1 << 5,
+#ifdef _MSC_VER
+# pragma warning(push)
+# pragma warning(disable : 5287)
+#endif
   KEYMOD_RECOGNIZED = (TERMKEY_KEYMOD_SHIFT | TERMKEY_KEYMOD_ALT | TERMKEY_KEYMOD_CTRL
                        | KEYMOD_SUPER | KEYMOD_META),
+#ifdef _MSC_VER
+# pragma warning(pop)
+#endif
 };
 
 /// Handle modifiers not handled by libtermkey.


### PR DESCRIPTION
Problem: Currently our CI is failing due to msvc warning 5287. This warning tells us that we are performing a binary expression with enums of two different types. In this case however, this is clearly intended and valid.

Solution: Suppress warning 5287 on the line this occurs.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
