### PR TITLE
fix(tui): don't crash when nvim__screenshot() is called with bad path

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -1653,12 +1653,16 @@ void tui_set_icon(TUIData *tui, String icon)
 
 void tui_screenshot(TUIData *tui, String path)
 {
+  FILE *f = fopen(path.data, "w");
+  if (f == NULL) {
+    return;
+  }
+
   UGrid *grid = &tui->grid;
   flush_buf(tui);
   grid->row = 0;
   grid->col = 0;
 
-  FILE *f = fopen(path.data, "w");
   tui->screenshot = f;
   fprintf(f, "%d,%d\n", grid->height, grid->width);
   unibi_out(tui, unibi_clear_screen);


### PR DESCRIPTION
Problem: Currently vim.api.nvim__screenshot crashes when called with an invalid path. This is because we don't check if `fopen()` returns a null pointer.

Solution: If `fopen()` return a null pointer, print a message and return.

Fixes: https://github.com/neovim/neovim/issues/34593

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
