### PR TITLE
docs(treesitter): fix broken link for language-injection section

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -551,7 +551,7 @@ TREESITTER LANGUAGE INJECTIONS                *treesitter-language-injections*
 <
 
 Note the following information is adapted from:
-  https://tree-sitter.github.io/tree-sitter/syntax-highlighting#language-injection
+  https://tree-sitter.github.io/tree-sitter/3-syntax-highlighting?#language-injection
 
 Some source files contain code written in multiple different languages.
 Examples include:


### PR DESCRIPTION
Problem: the current link to treesitter's site for language-injection section is broken and lead to not found site
Solution: update the link to the correct url