### PR TITLE
refactor(lsp): use `vim.lsp.buf_request_all` internally

### DIFF
--- a/runtime/lua/vim/lsp/_tagfunc.lua
+++ b/runtime/lua/vim/lsp/_tagfunc.lua
@@ -23,10 +23,6 @@ end
 ---@return table[]
 local function query_definition(pattern)
   local bufnr = api.nvim_get_current_buf()
-  local clients = vim.lsp.get_clients({ bufnr = bufnr, method = ms.textDocument_definition })
-  if not next(clients) then
-    return {}
-  end
   local win = api.nvim_get_current_win()
   local results = {}
 
@@ -37,33 +33,35 @@ local function query_definition(pattern)
     table.insert(results, mk_tag_item(pattern, range, uri, position_encoding))
   end
 
-  local remaining = #clients
-  for _, client in ipairs(clients) do
-    ---@param result nil|lsp.Location|lsp.Location[]|lsp.LocationLink[]
-    local function on_response(_, result)
-      if result then
-        local encoding = client.offset_encoding
-        -- single Location
-        if result.range then
-          add(result.range, result.uri, encoding)
-        else
-          for _, location in ipairs(result) do
-            if location.range then -- Location
-              add(location.range, location.uri, encoding)
-            else -- LocationLink
-              add(location.targetSelectionRange, location.targetUri, encoding)
-            end
+  local request_results, _ = lsp.buf_request_sync(
+    bufnr,
+    ms.textDocument_definition,
+    function(client)
+      return util.make_position_params(win, client.offset_encoding)
+    end
+  )
+
+  for client_id, res in pairs(request_results or {}) do
+    local client = assert(lsp.get_client_by_id(client_id))
+    local result = res.result ---@type lsp.Location|lsp.Location[]|lsp.LocationLink[]|nil
+
+    if result then
+      local encoding = client.offset_encoding
+      -- single Location
+      if result.range then
+        add(result.range, result.uri, encoding)
+      else
+        for _, location in ipairs(result) do
+          if location.range then -- Location
+            add(location.range, location.uri, encoding)
+          else -- LocationLink
+            add(location.targetSelectionRange, location.targetUri, encoding)
           end
         end
       end
-      remaining = remaining - 1
     end
-    local params = util.make_position_params(win, client.offset_encoding)
-    client:request(ms.textDocument_definition, params, on_response, bufnr)
   end
-  vim.wait(1000, function()
-    return remaining == 0
-  end)
+
   return results
 end
 

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -430,6 +430,8 @@ function M._convert_results(
   return matches, server_start_boundary
 end
 
+-- NOTE: The reason we don't use `lsp.buf_request_all` here is because we want to filter the clients
+-- that received the request based on the trigger characters.
 --- @param clients table<integer, vim.lsp.Client> # keys != client_id
 --- @param bufnr integer
 --- @param win integer


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Small refactor for using `vim.lsp.buf_request_all` instead of duplicating all the logic of keeping track of the remaining clients.

Also makes https://github.com/neovim/neovim/pull/34523 a bit easier.