### PR TITLE
vim-patch:9.1.1475: completion: regression when "nearest" in 'completeopt'

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1330,7 +1330,7 @@ static int cp_compare_nearest(const void *a, const void *b)
 {
   int score_a = ((compl_T *)a)->cp_score;
   int score_b = ((compl_T *)b)->cp_score;
-  if (score_a < 0 || score_b < 0) {
+  if (score_a == 0 || score_b == 0) {
     return 0;
   }
   return (score_a > score_b) ? 1 : (score_a < score_b) ? -1 : 0;

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -4573,6 +4573,22 @@ func Test_nearest_cpt_option()
   exe "normal! of\<c-n>\<c-r>=PrintMenuWords()\<cr>"
   call assert_equal('f{''matches'': [''foo1'', ''foo3'', ''foo2''], ''selected'': -1}', getline(2))
 
+  " Multiple sources
+  func F1(findstart, base)
+    if a:findstart
+      return col('.') - 1
+    endif
+    return ['foo4', 'foo5']
+  endfunc
+  %d
+  set complete+=FF1
+  call setline(1, ["foo1", "foo2", "bar1", "foo3"])
+  exe "normal! 2jof\<c-n>\<c-r>=PrintMenuWords()\<cr>"
+  call assert_equal('f{''matches'': [''foo3'', ''foo2'', ''foo1'', ''foo4'', ''foo5''],
+        \ ''selected'': -1}', getline(4))
+  set complete-=FF1
+  delfunc F1
+
   set completeopt=menu,longest,nearest
   %d
   call setline(1, ["fo", "foo", "foobar", "foobarbaz"])


### PR DESCRIPTION
#### vim-patch:9.1.1475: completion: regression when "nearest" in 'completeopt'

Problem:  completion: regression when "nearest" in 'completeopt'
Solution: fix compare function (Girish Palya)

closes: vim/vim#17577

https://github.com/vim/vim/commit/cd68f21f6066778487a1cad30dd1e021debb7e78

Co-authored-by: Girish Palya <girishji@gmail.com>