### PR TITLE
vim-patch:a9b95c3: runtime(doc): remove wrong documentation of the :digraph command

### DIFF
--- a/runtime/doc/usr_24.txt
+++ b/runtime/doc/usr_24.txt
@@ -568,14 +568,13 @@ that combination.  Thus CTRL-K dP also works.  Since there is no digraph for
 	using.  Always use ":digraphs" to find out which digraphs are currently
 	available.
 
-You can define your own digraphs.  Example: >
+You can define your own digraphs by specifying the target character with a
+decimal number.  Example: >
 
-	:digraph a" ä
+	:digraph a\" 228
 
-This defines that CTRL-K a" inserts an ä character.  You can also specify the
-character with a decimal number.  This defines the same digraph: >
-
-	:digraph a" 228
+This defines that CTRL-K a" inserts an ä character.  Note: we had to escape
+the " character since otherwise it would act as a comment character.
 
 More information about digraphs here: |digraphs|
    Another way to insert special characters is with a keymap.  More about that


### PR DESCRIPTION
#### vim-patch:a9b95c3: runtime(doc): remove wrong documentation of the :digraph command

https://github.com/vim/vim/commit/a9b95c3d337855b0f3cc26aad80f8d42dc566fa9

Co-authored-by: Christian Brabandt <cb@256bit.org>