### PR TITLE
fix(quickfix): use correct lnume when appending

### DIFF
--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4190,20 +4190,20 @@ static void qf_update_buffer(qf_info_T *qi, qfline_T *old_last)
 
   linenr_T new_line_count = buf->b_ml.ml_line_count;
   colnr_T new_endcol = ml_get_buf_len(buf, new_line_count);
-  bcount_t new_byte_count;
-
+  bcount_t new_byte_count = 0;
   linenr_T delta = new_line_count - old_line_count;
+
   if (old_last == NULL) {
     new_byte_count = get_region_bytecount(buf, 1, new_line_count, 0, new_endcol);
     extmark_splice(buf, 0, 0, old_line_count - 1, 0, old_bytecount, new_line_count - 1, new_endcol,
                    new_byte_count, kExtmarkNoUndo);
     changed_lines(buf, 1, 0, old_line_count > 0 ? old_line_count + 1 : 1, delta, true);
-  } else {
+  } else if (delta > 0) {
     linenr_T start_lnum = old_line_count + 1;
     new_byte_count = get_region_bytecount(buf, start_lnum, new_line_count, 0, new_endcol);
     extmark_splice(buf, old_line_count - 1, old_endcol, 0, 0, 0, delta, new_endcol, new_byte_count,
                    kExtmarkNoUndo);
-    changed_lines(buf, start_lnum, 0, new_line_count + 1, delta + 1, true);
+    changed_lines(buf, start_lnum, 0, start_lnum, delta, true);
   }
   buf->b_changed = false;
 

--- a/test/functional/api/buffer_updates_spec.lua
+++ b/test/functional/api/buffer_updates_spec.lua
@@ -825,6 +825,20 @@ describe('API: buffer events:', function()
       },
     }, next_msg())
   end)
+
+  it('when updating quickfix list #34610', function()
+    command('copen')
+
+    local b = api.nvim_get_current_buf()
+    ok(api.nvim_buf_attach(b, true, {}))
+    expectn('nvim_buf_lines_event', { b, 2, 0, -1, { '' }, false })
+
+    command("cexpr ['Xa', 'Xb']")
+    expectn('nvim_buf_lines_event', { b, 3, 0, 1, { '|| Xa', '|| Xb' }, false })
+
+    command("caddexpr ['Xc']")
+    expectn('nvim_buf_lines_event', { b, 4, 2, 2, { '|| Xc' }, false })
+  end)
 end)
 
 describe('API: buffer events:', function()

--- a/test/functional/lua/buffer_updates_spec.lua
+++ b/test/functional/lua/buffer_updates_spec.lua
@@ -439,11 +439,11 @@ describe('lua buffer event callbacks: on_lines', function()
 
     command('caddexpr "bar"')
     eq({ 'bytes', 2, 3, 0, 6, 6, 0, 0, 0, 1, 6, 6 }, api.nvim_get_var('qf_on_bytes'))
-    eq({ 'lines', 2, 4, 1, 2, 4, 0 }, api.nvim_get_var('qf_on_lines'))
+    eq({ 'lines', 2, 4, 1, 1, 2, 0 }, api.nvim_get_var('qf_on_lines'))
 
     command('caddexpr ["line1", "line2", "line3"]')
     eq({ 'bytes', 2, 4, 1, 6, 13, 0, 0, 0, 3, 8, 26 }, api.nvim_get_var('qf_on_bytes'))
-    eq({ 'lines', 2, 5, 2, 5, 9, 0 }, api.nvim_get_var('qf_on_lines'))
+    eq({ 'lines', 2, 5, 2, 2, 5, 0 }, api.nvim_get_var('qf_on_lines'))
 
     command('cexpr "replace"')
     eq({ 'bytes', 2, 5, 0, 0, 0, 4, 0, 40, 0, 10, 10 }, api.nvim_get_var('qf_on_bytes'))


### PR DESCRIPTION
Problem: ml_get error when updating quickfix buffer with nvim_buf_attach
Solution: use correct lnume parameter in changed_lines for append mode

Fix #34610

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
