### PR TITLE
fix(cmd): allow fclose to be used with trailing bar

### DIFF
--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -1052,7 +1052,7 @@ M.cmds = {
   },
   {
     command = 'fclose',
-    flags = bit.bor(BANG, RANGE),
+    flags = bit.bor(BANG, RANGE, TRLBAR),
     addr_type = 'ADDR_OTHER',
     func = 'ex_fclose',
   },

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -10654,6 +10654,8 @@ describe('float window', function()
                                                   |
         ]])
       end
+      -- allow use with trailing bar
+      eq('hello', n.exec_capture('fclose | echo "hello"'))
     end)
 
     it('correctly placed in or above message area', function()


### PR DESCRIPTION
Problem: fclose command failed when used with trailing `|` bar.
Solution: Add `TRLBAR` flag to fclose command to support trailing bar.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
