### PR TITLE
fix(health): highlight group conflicts with help

### DIFF
--- a/runtime/syntax/checkhealth.vim
+++ b/runtime/syntax/checkhealth.vim
@@ -15,7 +15,7 @@ syn keyword DiagnosticWarn WARNING[:]
 syn keyword DiagnosticOk OK[:]
 " Note: hs=e starts higlighting on the title line (instead of the "===" line).
 syn match healthSectionDelim /^======*\n.*$/hs=e
-hi def healthSectionDelim gui=reverse cterm=reverse
+highlight default healthSectionDelim gui=reverse cterm=reverse
 syn match healthHeadingChar "=" conceal cchar= contained containedin=healthSectionDelim
 
 let b:current_syntax = "checkhealth"

--- a/runtime/syntax/checkhealth.vim
+++ b/runtime/syntax/checkhealth.vim
@@ -14,8 +14,8 @@ syn keyword DiagnosticError ERROR[:]
 syn keyword DiagnosticWarn WARNING[:]
 syn keyword DiagnosticOk OK[:]
 " Note: hs=e starts higlighting on the title line (instead of the "===" line).
-syn match helpSectionDelim /^======*\n.*$/hs=e
-highlight helpSectionDelim gui=reverse cterm=reverse
-syn match healthHeadingChar "=" conceal cchar= contained containedin=helpSectionDelim
+syn match healthSectionDelim /^======*\n.*$/hs=e
+hi def healthSectionDelim gui=reverse cterm=reverse
+syn match healthHeadingChar "=" conceal cchar= contained containedin=healthSectionDelim
 
 let b:current_syntax = "checkhealth"


### PR DESCRIPTION
This is just a small fix that does not affect the visual appearance of either help files or the checkhealth buffer, but changes the code present in `syntax/checkhealth.vim` to use its own syntax group instead of patching an existing one from `syntax/help.vim`, and to define the highlight group with `:hi def` (before it was done without the `default` option). This patching caused a bug in that if you run `:checkhealth` once, the delimiter lines in all subsequently opened help buffers get a way more standout-ish look than the default one.