### PR TITLE
vim-patch:9.1.1476: missing out-of-memory checks in cmdexpand.c

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -329,7 +329,6 @@ int nextwild(expand_T *xp, int type, int options, bool escape)
     ccline->cmdlen += difflen;
     ccline->cmdpos += difflen;
   }
-  xfree(p2);
 
   redrawcmd();
   cursorcmd();
@@ -347,6 +346,8 @@ int nextwild(expand_T *xp, int type, int options, bool escape)
     ExpandOne(xp, NULL, NULL, 0, WILD_FREE);
   }
 
+  xfree(p2);
+
   return OK;
 }
 
@@ -357,8 +358,8 @@ static int cmdline_pum_create(CmdlineInfo *ccline, expand_T *xp, char **matches,
 {
   assert(numMatches >= 0);
   // Add all the completion matches
+  compl_match_array = xmalloc(sizeof(pumitem_T) * (size_t)numMatches);
   compl_match_arraysize = numMatches;
-  compl_match_array = xmalloc(sizeof(pumitem_T) * (size_t)compl_match_arraysize);
   for (int i = 0; i < numMatches; i++) {
     compl_match_array[i] = (pumitem_T){
       .pum_text = SHOW_MATCH(i),

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -851,6 +851,7 @@ char *fm_getname(fmark_T *fmark, int lead_len)
 /// Return the line at mark "mp".  Truncate to fit in window.
 /// The returned string has been allocated.
 static char *mark_line(pos_T *mp, int lead_len)
+  FUNC_ATTR_NONNULL_RET
 {
   char *p;
 


### PR DESCRIPTION
#### vim-patch:9.1.1476: missing out-of-memory checks in cmdexpand.c

Problem:  missing out-of-memory checks in cmdexpand.c
Solution: add missing out-of-memory checks, re-order code
          (John Marriott)

This commit does the following:
- in cmdline_pum_create() add out-of-memory check call of ALLOC_MULT()
- in expand_cmdline() move check for out-of-memory to cover both
  assignments of file_str
- in nextwild() don't free `p2` until after it's last use.

closes: vim/vim#17592

https://github.com/vim/vim/commit/1be5b375c4446976eb5a0a90d2cfa1d2d289a6ed

N/A patch:
vim-patch:9.1.1474: missing out-of-memory check in mark.c

Co-authored-by: John Marriott <basilisk@internode.on.net>