### PR TITLE
fix(cmdline): validate 'incsearch' cursor for "cmdline_show" redraw

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -556,6 +556,7 @@ static void may_do_incsearch_highlighting(int firstc, int count, incsearch_state
     curwin->w_cursor = s->search_start;
   } else if (found != 0) {
     curwin->w_cursor = end_pos;
+    curwin->w_valid_cursor = end_pos;  // mark as valid for cmdline_show redraw
   }
 
   msg_starthere();

--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -43,4 +43,15 @@ describe('cmdline2', function()
     ]])
     n.assert_alive()
   end)
+
+  it("redraw does not clear 'incsearch' highlight with conceal", function()
+    exec('call setline(1, ["foo", "foobar"]) | set conceallevel=1 concealcursor=c')
+    feed('/foo')
+    screen:expect([[
+      {10:foo}                                                  |
+      {2:foo}bar                                               |
+      {1:~                                                    }|*11
+      /foo^                                                 |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:  "cmdline_show" event may be emitted with an invalid cursor
          position, causing a redraw that will clear the match highlight.
Solution: Mark the cursor position as valid so that a "cmdline_show"
          callback that updates the screen does not clear the match highlight.

Fix #34628