### PR TITLE
fix: map wincmd instead of remap

### DIFF
--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -450,7 +450,7 @@ function M.inspect_tree(opts)
     end,
   })
 
-  api.nvim_buf_set_keymap(b, 'n', 'q', '<C-w>c', { desc = 'Close language tree window' })
+  api.nvim_buf_set_keymap(b, 'n', 'q', '<Cmd>wincmd c<CR>', { desc = 'Close language tree window' })
 
   local group = api.nvim_create_augroup('nvim.treesitter.dev', {})
 


### PR DESCRIPTION
Same issue: a59b052857ca43997b9e8be0a1d5c870ce172807.
