### PR TITLE
refactor(lsp): introduce `vim.lsp.Capability`

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -195,6 +195,7 @@ LSP
 • The function form of `cmd` in a vim.lsp.Config or vim.lsp.ClientConfig
   receives the resolved config as the second arg: `cmd(dispatchers, config)`.
 • Support for annotated text edits.
+• `:checkhealth vim.lsp` is now available to check which buffers the active LSP features are attached to.
 
 LUA
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -2,6 +2,7 @@ local api = vim.api
 local validate = vim.validate
 
 local lsp = vim._defer_require('vim.lsp', {
+  _capability = ..., --- @module 'vim.lsp._capability'
   _changetracking = ..., --- @module 'vim.lsp._changetracking'
   _folding_range = ..., --- @module 'vim.lsp._folding_range'
   _snippet_grammar = ..., --- @module 'vim.lsp._snippet_grammar'

--- a/runtime/lua/vim/lsp/_capability.lua
+++ b/runtime/lua/vim/lsp/_capability.lua
@@ -1,0 +1,77 @@
+local api = vim.api
+
+--- `vim.lsp.Capability` is expected to be created one-to-one with a buffer
+--- when there is at least one supported client attached to that buffer,
+--- and will be destroyed when all supporting clients are detached.
+---@class vim.lsp.Capability
+---
+--- Static field for retrieving the instance associated with a specific `bufnr`.
+---
+--- Index inthe form of `bufnr` -> `capability`
+---@field active table<integer, vim.lsp.Capability?>
+---
+--- The LSP feature it supports.
+---@field name string
+---
+--- Buffer number it associated with.
+---@field bufnr integer
+---
+--- The augroup owned by this instance, which will be cleared upon destruction.
+---@field augroup integer
+---
+--- Per-client state data, scoped to the lifetime of the attached client.
+---@field client_state table<integer, table>
+local M = {}
+M.__index = M
+
+---@generic T : vim.lsp.Capability
+---@param self T
+---@param bufnr integer
+---@return T
+function M:new(bufnr)
+  -- `self` in the `new()` function refers to the concrete type (i.e., the metatable).
+  -- `Class` may be a subtype of `Capability`, as it supports inheritance.
+  ---@type vim.lsp.Capability
+  local Class = self
+  assert(Class.name and Class.active, 'Do not instantiate the abstract class')
+
+  ---@type vim.lsp.Capability
+  self = setmetatable({}, Class)
+  self.bufnr = bufnr
+  self.augroup = api.nvim_create_augroup(
+    string.format('nvim.lsp.%s:%s', self.name:gsub('%s+', '_'):lower(), bufnr),
+    { clear = true }
+  )
+  self.client_state = {}
+
+  api.nvim_create_autocmd('LspDetach', {
+    group = self.augroup,
+    buffer = bufnr,
+    callback = function(args)
+      self:on_detach(args.data.client_id)
+      if next(self.client_state) == nil then
+        self:destroy()
+      end
+    end,
+  })
+
+  Class.active[bufnr] = self
+  return self
+end
+
+function M:destroy()
+  -- In case the function is called before all the clients detached.
+  for client_id, _ in pairs(self.client_state) do
+    self:on_detach(client_id)
+  end
+
+  api.nvim_del_augroup_by_id(self.augroup)
+  self.active[self.bufnr] = nil
+end
+
+---@param client_id integer
+function M:on_detach(client_id)
+  self.client_state[client_id] = nil
+end
+
+return M

--- a/runtime/lua/vim/lsp/_folding_range.lua
+++ b/runtime/lua/vim/lsp/_folding_range.lua
@@ -364,4 +364,6 @@ function M.foldexpr(lnum)
   return level and (level[2] or '') .. (level[1] or '0') or '0'
 end
 
+M.__FoldEvaluator = State
+
 return M

--- a/runtime/lua/vim/lsp/_folding_range.lua
+++ b/runtime/lua/vim/lsp/_folding_range.lua
@@ -17,6 +17,8 @@ local M = {}
 ---@field active table<integer, vim.lsp.folding_range.State?>
 ---@field bufnr integer
 ---@field augroup integer
+---
+--- `TextDocument` version this `state` corresponds to.
 ---@field version? integer
 ---
 --- Never use this directly, `renew()` the cached foldinfo
@@ -83,6 +85,9 @@ end
 --- Force `foldexpr()` to be re-evaluated, without opening folds.
 ---@param bufnr integer
 local function foldupdate(bufnr)
+  if not api.nvim_buf_is_loaded(bufnr) then
+    return
+  end
   for _, winid in ipairs(vim.fn.win_findbuf(bufnr)) do
     local wininfo = vim.fn.getwininfo(winid)[1]
     if wininfo and wininfo.tabnr == vim.fn.tabpagenr() then
@@ -192,19 +197,6 @@ function State.new(bufnr)
   State.active[bufnr] = self
 
   api.nvim_buf_attach(bufnr, false, {
-    -- `on_detach` also runs on buffer reload (`:e`).
-    -- Ensure `state` and hooks are cleared to avoid duplication or leftover states.
-    on_detach = function()
-      util._cancel_requests({
-        bufnr = bufnr,
-        method = ms.textDocument_foldingRange,
-        type = 'pending',
-      })
-      local state = State.active[bufnr]
-      if state then
-        state:destroy()
-      end
-    end,
     -- Reset `bufstate` and request folding ranges.
     on_reload = function()
       local state = State.active[bufnr]
@@ -242,37 +234,9 @@ function State.new(bufnr)
     group = self.augroup,
     buffer = bufnr,
     callback = function(args)
-      if not api.nvim_buf_is_loaded(bufnr) then
-        return
-      end
-
-      ---@type integer
-      local client_id = args.data.client_id
-      self.client_ranges[client_id] = nil
-
-      ---@type vim.lsp.Client[]
-      local clients = vim
-        .iter(vim.lsp.get_clients({ bufnr = bufnr, method = ms.textDocument_foldingRange }))
-        ---@param client vim.lsp.Client
-        :filter(function(client)
-          return client.id ~= client_id
-        end)
-        :totable()
-      if #clients == 0 then
-        self:reset()
-      end
-
-      self:renew()
-      foldupdate(bufnr)
-    end,
-  })
-  api.nvim_create_autocmd('LspAttach', {
-    group = self.augroup,
-    buffer = bufnr,
-    callback = function(args)
-      local client = assert(vim.lsp.get_client_by_id(args.data.client_id))
-      if client:supports_method(vim.lsp.protocol.Methods.textDocument_foldingRange, bufnr) then
-        self:request(client)
+      self:on_detach(args.data.client_id)
+      if next(self.client_ranges) == nil then
+        self:destroy()
       end
     end,
   })
@@ -301,18 +265,22 @@ function State:destroy()
   State.active[self.bufnr] = nil
 end
 
-local function setup(bufnr)
-  if not api.nvim_buf_is_loaded(bufnr) then
-    return
-  end
+---@params client_id integer
+function State:on_detach(client_id)
+  self.client_ranges[client_id] = nil
+  self:renew()
+  foldupdate(self.bufnr)
+end
 
+---@param bufnr integer
+---@param client_id? integer
+function M._setup(bufnr, client_id)
   local state = State.active[bufnr]
   if not state then
     state = State.new(bufnr)
   end
 
-  state:request()
-  return state
+  state:request(client_id and vim.lsp.get_client_by_id(client_id))
 end
 
 ---@param kind lsp.FoldingRangeKind
@@ -344,11 +312,11 @@ function M.foldclose(kind, winid)
     return
   end
 
+  -- Schedule `foldclose()` if the buffer is not up-to-date.
   if state.version == util.buf_versions[bufnr] then
     state:foldclose(kind, winid)
     return
   end
-  -- Schedule `foldclose()` if the buffer is not up-to-date.
 
   if not next(vim.lsp.get_clients({ bufnr = bufnr, method = ms.textDocument_foldingRange })) then
     return
@@ -380,7 +348,7 @@ end
 ---@return string level
 function M.foldexpr(lnum)
   local bufnr = api.nvim_get_current_buf()
-  local state = State.active[bufnr] or setup(bufnr)
+  local state = State.active[bufnr]
   if not state then
     return '0'
   end

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -1082,6 +1082,9 @@ function Client:on_attach(bufnr)
     if vim.tbl_get(self.server_capabilities, 'semanticTokensProvider', 'full') then
       lsp.semantic_tokens.start(bufnr, self.id)
     end
+    if vim.tbl_get(self.server_capabilities, 'foldingRangeProvider') then
+      lsp._folding_range._setup(bufnr)
+    end
   end)
 
   self.attached_buffers[bufnr] = true

--- a/test/functional/plugin/lsp/folding_range_spec.lua
+++ b/test/functional/plugin/lsp/folding_range_spec.lua
@@ -4,7 +4,6 @@ local Screen = require('test.functional.ui.screen')
 local t_lsp = require('test.functional.plugin.lsp.testutil')
 
 local eq = t.eq
-local tempname = t.tmpname
 
 local clear_notrace = t_lsp.clear_notrace
 local create_server_definition = t_lsp.create_server_definition
@@ -119,52 +118,6 @@ static int foldLevel(linenr_T lnum)
   end)
   after_each(function()
     api.nvim_exec_autocmds('VimLeavePre', { modeline = false })
-  end)
-
-  describe('setup()', function()
-    ---@type integer
-    local bufnr_set_expr
-    ---@type integer
-    local bufnr_never_set_expr
-
-    local function buf_autocmd_num(bufnr_to_check)
-      return exec_lua(function()
-        return #vim.api.nvim_get_autocmds({ buffer = bufnr_to_check, event = 'LspNotify' })
-      end)
-    end
-
-    before_each(function()
-      command([[setlocal foldexpr=v:lua.vim.lsp.foldexpr()]])
-      exec_lua(function()
-        bufnr_set_expr = vim.api.nvim_create_buf(true, false)
-        vim.api.nvim_set_current_buf(bufnr_set_expr)
-      end)
-      insert(text)
-      command('write ' .. tempname(false))
-      command([[setlocal foldexpr=v:lua.vim.lsp.foldexpr()]])
-      exec_lua(function()
-        bufnr_never_set_expr = vim.api.nvim_create_buf(true, false)
-        vim.api.nvim_set_current_buf(bufnr_never_set_expr)
-      end)
-      insert(text)
-      api.nvim_win_set_buf(0, bufnr_set_expr)
-    end)
-
-    it('only create event hooks where foldexpr has been set', function()
-      eq(1, buf_autocmd_num(bufnr))
-      eq(1, buf_autocmd_num(bufnr_set_expr))
-      eq(0, buf_autocmd_num(bufnr_never_set_expr))
-    end)
-
-    it('does not create duplicate event hooks after reloaded', function()
-      command('edit')
-      eq(1, buf_autocmd_num(bufnr_set_expr))
-    end)
-
-    it('cleans up event hooks when buffer is unloaded', function()
-      command('bdelete')
-      eq(0, buf_autocmd_num(bufnr_set_expr))
-    end)
   end)
 
   describe('expr()', function()

--- a/test/functional/plugin/lsp/folding_range_spec.lua
+++ b/test/functional/plugin/lsp/folding_range_spec.lua
@@ -135,6 +135,29 @@ static int foldLevel(linenr_T lnum)
       command([[split]])
     end)
 
+    it('controls the value of `b:_lsp_folding_range_enabled`', function()
+      eq(
+        true,
+        exec_lua(function()
+          return vim.b._lsp_folding_range_enabled
+        end)
+      )
+      command [[setlocal foldexpr=]]
+      eq(
+        nil,
+        exec_lua(function()
+          return vim.b._lsp_folding_range_enabled
+        end)
+      )
+      command([[set foldexpr=v:lua.vim.lsp.foldexpr()]])
+      eq(
+        true,
+        exec_lua(function()
+          return vim.b._lsp_folding_range_enabled
+        end)
+      )
+    end)
+
     it('can compute fold levels', function()
       ---@type table<integer, string>
       local foldlevels = {}


### PR DESCRIPTION
## Problem
Closes #31453

## Solution
This PR introduces a new class called `vim.lsp.Capability`, which may serve as the base class for all LSP features that require caching data. it
- was created if there is at least one client that supports the specific method;
- was destroyed if all clients that support the method were detached.

I've applied the refactor for `folding_range.lua` and `semantic_tokens.lua`. Among the modules I'm familiar with, I think we can do this for `inlay_hint.lua` (with some modification), and it could be used for `codelens.lua` too, but I think it would be better if we re-implement it to align with our inlay hint support. I will be trying to work on #30841 if this PR gets merged, because it was originally blocked by #31453. The refactor could also be applied to #34388 since we've discussed some of the ideas there.

I've also added the corresponding health check to show the active data.

## Next

I found that these features that are expected to be refactored by `vim.lsp.Capability` have one characteristic in common: they all send LSP requests once the document is modified. The following code is different, but they are all for this purpose.

- semantic tokens:
https://github.com/neovim/neovim/blob/fb8dba413f2bcaa61c15d1854b28112e3e91a035/runtime/lua/vim/lsp/semantic_tokens.lua#L192-L198

- inlay hints, folding ranges, document color
https://github.com/neovim/neovim/blob/fb8dba413f2bcaa61c15d1854b28112e3e91a035/runtime/lua/vim/lsp/inlay_hint.lua#L250-L266

I think I can sum up this characteristic as the need to keep certain data synchronized with the latest version computed by the server. I believe we can handle this at the `vim.lsp.Capability` level, and I think it will be very useful.

Therefore, my next step is to implement LSP request sending and data synchronization on `vim.lsp.Capability`, rather than limiting it to the current create/destroy data approach.
