### PR TITLE
feat(keymaps): add 'grt' mapping for lsp type definition

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -81,12 +81,13 @@ the options are empty or were set by the builtin runtime (ftplugin) files. The
 options are not restored when the LSP client is stopped or detached.
 
 GLOBAL DEFAULTS
-                                *grr* *gra* *grn* *gri* *i_CTRL-S* *an* *in*
+                                *grr* *gra* *grn* *gri* *grt* *i_CTRL-S* *an* *in*
 These GLOBAL keymaps are created unconditionally when Nvim starts:
 - "grn" is mapped in Normal mode to |vim.lsp.buf.rename()|
 - "gra" is mapped in Normal and Visual mode to |vim.lsp.buf.code_action()|
 - "grr" is mapped in Normal mode to |vim.lsp.buf.references()|
 - "gri" is mapped in Normal mode to |vim.lsp.buf.implementation()|
+- "grt" is mapped in Normal mode to |vim.lsp.buf.type_definition()|
 - "gO" is mapped in Normal mode to |vim.lsp.buf.document_symbol()|
 - CTRL-S is mapped in Insert mode to |vim.lsp.buf.signature_help()|
 - "an" and "in" are mapped in Visual mode to outer and inner incremental

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -136,6 +136,8 @@ DEFAULTS
   was implemented as an internal C routine).
 • Project-local configuration ('exrc') is also loaded from parent directories.
   Unset 'exrc' to stop further search.
+• Mappings:
+  • |grt| in Normal mode maps to |vim.lsp.buf.type_definition()|
 
 DIAGNOSTICS
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -154,6 +154,7 @@ you never want any default mappings, call |:mapclear| early in your config.
   - |grr|
   - |gra|
   - |gri|
+  - |grt|
   - |gO|
 - <C-S> |i_CTRL-S|
 - ]d |]d-default|

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -191,7 +191,7 @@ do
   --- client is attached. If no client is attached, or if a server does not support a capability, an
   --- error message is displayed rather than exhibiting different behavior.
   ---
-  --- See |grr|, |grn|, |gra|, |gri|, |gO|, |i_CTRL-S|.
+  --- See |grr|, |grn|, |gra|, |gri|, |grt| |gO|, |i_CTRL-S|.
   do
     vim.keymap.set('n', 'grn', function()
       vim.lsp.buf.rename()
@@ -208,6 +208,10 @@ do
     vim.keymap.set('n', 'gri', function()
       vim.lsp.buf.implementation()
     end, { desc = 'vim.lsp.buf.implementation()' })
+
+    vim.keymap.set('n', 'grt', function()
+      vim.lsp.buf.type_definition()
+    end, { desc = 'vim.lsp.buf.type_definition()' })
 
     vim.keymap.set('x', 'an', function()
       vim.lsp.buf.selection_range(vim.v.count1)


### PR DESCRIPTION
Hello!

Problem:

I keep trying to use 'grt' as an intuitive mapping for LSP type definitions, but I forget that it doesn't exist.

Solution:

Add a new keymap 'grt' in Normal mode that maps to |vim.lsp.buf.type_definition()|, making it easier to access type definitions without users having to create a custom mapping.

Thanks!