### PR TITLE
vim-patch:fa0b069: runtime(doc): improve documentation style in editing.txt

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1316,15 +1316,15 @@ b:browsefilter variable.  You would most likely set b:browsefilter in a
 filetype plugin, so that the browse dialog would contain entries related to
 the type of file you are currently editing.  Disadvantage: This makes it
 difficult to start editing a file of a different type.  To overcome this, you
-may want to add >
+can add the following as the final filter on Windows: >
 
 	All Files\t(*.*)\t*\n
 <
-as the final filter on Windows or >
+Or the following on other platforms, so that the user can still access any
+desired file: >
 
 	All Files\t(*)\t*\n
 <
-on other platforms, so that the user can still access any desired file.
 
 To avoid setting browsefilter when Vim does not actually support it, you can
 use has("browsefilter"): >


### PR DESCRIPTION
#### vim-patch:fa0b069: runtime(doc): improve documentation style in editing.txt

Usually, Vim's document provides example code after explanations.
However some part of the editing.txt doesn't follow the style, therefore
this commit modifies it so that it follows the usual style.

closes: vim/vim#17607

https://github.com/vim/vim/commit/fa0b0697283487171981bea751f3c676399864d6

Co-authored-by: mityu <mityu.mail@gmail.com>
Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>