### PR TITLE
fix(column): missing redraw with virt_lines_leftcol

### DIFF
--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -1716,6 +1716,7 @@ int win_line(win_T *wp, linenr_T lnum, int startrow, int endrow, int col_rows, b
             break;
           }
           wlv.filler_todo--;
+          virt_line_index = -1;
           if (wlv.filler_todo == 0 && (wp->w_botfill || !draw_text)) {
             break;
           }

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -6160,8 +6160,7 @@ if (h->n_buckets < new_n_buckets) { // expand
     insert(example_text2)
     feed 'gg'
     command 'set number signcolumn=yes'
-    screen:expect {
-      grid = [[
+    screen:expect([[
       {7:  }{8:  1 }^if (h->n_buckets < new_n_buckets) { // expan|
       {7:  }{8:    }d                                           |
       {7:  }{8:  2 }  khkey_t *new_keys = (khkey_t *)krealloc((v|
@@ -6174,8 +6173,7 @@ if (h->n_buckets < new_n_buckets) { // expand
       {7:  }{8:  6 }    h->vals_buf = new_vals;                 |
       {7:  }{8:  7 }  }                                         |
                                                         |
-    ]],
-    }
+    ]])
 
     local markid = api.nvim_buf_set_extmark(0, ns, 2, 0, {
       virt_lines = {
@@ -6184,8 +6182,7 @@ if (h->n_buckets < new_n_buckets) { // expand
       },
     })
 
-    screen:expect {
-      grid = [[
+    screen:expect([[
       {7:  }{8:  1 }^if (h->n_buckets < new_n_buckets) { // expan|
       {7:  }{8:    }d                                           |
       {7:  }{8:  2 }  khkey_t *new_keys = (khkey_t *)krealloc((v|
@@ -6198,8 +6195,7 @@ if (h->n_buckets < new_n_buckets) { // expand
       {7:  }{8:  5 }    char *new_vals = krealloc( h->vals_buf, |
       {7:  }{8:    }new_n_buckets * val_size);                  |
                                                         |
-    ]],
-    }
+    ]])
 
     api.nvim_buf_set_extmark(0, ns, 2, 0, {
       virt_lines = {
@@ -6209,8 +6205,7 @@ if (h->n_buckets < new_n_buckets) { // expand
       virt_lines_leftcol = true,
       id = markid,
     })
-    screen:expect {
-      grid = [[
+    screen:expect([[
       {7:  }{8:  1 }^if (h->n_buckets < new_n_buckets) { // expan|
       {7:  }{8:    }d                                           |
       {7:  }{8:  2 }  khkey_t *new_keys = (khkey_t *)krealloc((v|
@@ -6223,8 +6218,40 @@ if (h->n_buckets < new_n_buckets) { // expand
       {7:  }{8:  5 }    char *new_vals = krealloc( h->vals_buf, |
       {7:  }{8:    }new_n_buckets * val_size);                  |
                                                         |
-    ]],
-    }
+    ]])
+
+    command('set nonumber relativenumber')
+    screen:expect([[
+      {7:  }{8:  0 }^if (h->n_buckets < new_n_buckets) { // expan|
+      {7:  }{8:    }d                                           |
+      {7:  }{8:  1 }  khkey_t *new_keys = (khkey_t *)krealloc((v|
+      {7:  }{8:    }oid *)h->keys, new_n_buckets * sizeof(khkey_|
+      {7:  }{8:    }t));                                        |
+      {7:  }{8:  2 }  h->keys = new_keys;                       |
+      {16:Some special}                                      |
+      {18:remark about codes}                                |
+      {7:  }{8:  3 }  if (kh_is_map && val_size) {              |
+      {7:  }{8:  4 }    char *new_vals = krealloc( h->vals_buf, |
+      {7:  }{8:    }new_n_buckets * val_size);                  |
+                                                        |
+    ]])
+
+    -- 'relativenumber' is redrawn with virt_lines_leftcol #34649
+    feed('j')
+    screen:expect([[
+      {7:  }{8:  1 }if (h->n_buckets < new_n_buckets) { // expan|
+      {7:  }{8:    }d                                           |
+      {7:  }{8:  0 }^  khkey_t *new_keys = (khkey_t *)krealloc((v|
+      {7:  }{8:    }oid *)h->keys, new_n_buckets * sizeof(khkey_|
+      {7:  }{8:    }t));                                        |
+      {7:  }{8:  1 }  h->keys = new_keys;                       |
+      {16:Some special}                                      |
+      {18:remark about codes}                                |
+      {7:  }{8:  2 }  if (kh_is_map && val_size) {              |
+      {7:  }{8:  3 }    char *new_vals = krealloc( h->vals_buf, |
+      {7:  }{8:    }new_n_buckets * val_size);                  |
+                                                        |
+    ]])
   end)
 
   it('works with hard TABs', function()


### PR DESCRIPTION
Problem:  Missing number column redraw with virt_lines_leftcol.
Solution: Set virt_line_index to -1 when skipping a virtual line.

Fix #34649