### PR TITLE
feat(runtime): accept predicates in take and skip

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4545,17 +4545,24 @@ Iter:rskip({n})                                                 *Iter:rskip()*
         (`Iter`)
 
 Iter:skip({n})                                                   *Iter:skip()*
-    Skips `n` values of an iterator pipeline.
+    Skips `n` values of an iterator pipeline, or all values satisfying a
+    predicate of a |list-iterator|.
 
     Example: >lua
 
         local it = vim.iter({ 3, 6, 9, 12 }):skip(2)
         it:next()
         -- 9
+
+        local function pred(x) return x < 10 end
+        local it2 = vim.iter({ 3, 6, 9, 12 }):skip(pred)
+        it2:next()
+        -- 12
 <
 
     Parameters: ~
-      • {n}  (`number`) Number of values to skip.
+      • {n}  (`integer|fun(...):boolean`) Number of values to skip or a
+             predicate.
 
     Return: ~
         (`Iter`)
@@ -4573,7 +4580,8 @@ Iter:slice({first}, {last})                                     *Iter:slice()*
         (`Iter`)
 
 Iter:take({n})                                                   *Iter:take()*
-    Transforms an iterator to yield only the first n values.
+    Transforms an iterator to yield only the first n values, or all values
+    satisfying a predicate.
 
     Example: >lua
         local it = vim.iter({ 1, 2, 3, 4 }):take(2)
@@ -4583,10 +4591,18 @@ Iter:take({n})                                                   *Iter:take()*
         -- 2
         it:next()
         -- nil
+
+        local function pred(x) return x < 2 end
+        local it2 = vim.iter({ 1, 2, 3, 4 }):take(pred)
+        it2:next()
+        -- 1
+        it2:next()
+        -- nil
 <
 
     Parameters: ~
-      • {n}  (`integer`)
+      • {n}  (`integer|fun(...):boolean`) Number of values to take or a
+             predicate.
 
     Return: ~
         (`Iter`)

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -201,6 +201,7 @@ LUA
 • |vim.fs.root()| can define "equal priority" via nested lists.
 • |vim.version.range()| output can be converted to human-readable string with |tostring()|.
 • |vim.version.intersect()| computes intersection of two version ranges.
+• |Iter:take()| and |Iter:skip()| now optionally accept predicates.
 
 OPTIONS
 

--- a/test/functional/lua/iter_spec.lua
+++ b/test/functional/lua/iter_spec.lua
@@ -160,6 +160,30 @@ describe('vim.iter', function()
     end
 
     do
+      local function wrong()
+        return false
+      end
+
+      local function correct()
+        return true
+      end
+
+      local q = { 4, 3, 2, 1 }
+
+      eq({ 4, 3, 2, 1 }, vim.iter(q):skip(wrong):totable())
+      eq(
+        { 2, 1 },
+        vim
+          .iter(q)
+          :skip(function(x)
+            return x > 2
+          end)
+          :totable()
+      )
+      eq({}, vim.iter(q):skip(correct):totable())
+    end
+
+    do
       local function skip(n)
         return vim.iter(vim.gsplit('a|b|c|d', '|')):skip(n):totable()
       end
@@ -241,6 +265,14 @@ describe('vim.iter', function()
   end)
 
   it('take()', function()
+    local function correct()
+      return true
+    end
+
+    local function wrong()
+      return false
+    end
+
     do
       local q = { 4, 3, 2, 1 }
       eq({}, vim.iter(q):take(0):totable())
@@ -249,6 +281,22 @@ describe('vim.iter', function()
       eq({ 4, 3, 2 }, vim.iter(q):take(3):totable())
       eq({ 4, 3, 2, 1 }, vim.iter(q):take(4):totable())
       eq({ 4, 3, 2, 1 }, vim.iter(q):take(5):totable())
+    end
+
+    do
+      local q = { 4, 3, 2, 1 }
+
+      eq({}, vim.iter(q):take(wrong):totable())
+      eq(
+        { 4, 3 },
+        vim
+          .iter(q)
+          :take(function(x)
+            return x > 2
+          end)
+          :totable()
+      )
+      eq({ 4, 3, 2, 1 }, vim.iter(q):take(correct):totable())
     end
 
     do
@@ -270,6 +318,24 @@ describe('vim.iter', function()
       eq({ 'a', 'b' }, it:take(2):totable())
       -- non-array iterators are consumed by take()
       eq({}, it:take(2):totable())
+    end
+
+    do
+      eq({ 'a', 'b', 'c', 'd' }, vim.iter(vim.gsplit('a|b|c|d', '|')):take(correct):totable())
+      eq(
+        { 'a', 'b', 'c' },
+        vim
+          .iter(vim.gsplit('a|b|c|d', '|'))
+          :enumerate()
+          :take(function(i, x)
+            return i < 3 or x == 'c'
+          end)
+          :map(function(_, x)
+            return x
+          end)
+          :totable()
+      )
+      eq({}, vim.iter(vim.gsplit('a|b|c|d', '|')):take(wrong):totable())
     end
   end)
 


### PR DESCRIPTION
Make `vim.iter():take()` and `vim.iter():skip()`
optionally accept predicates to enable takewhile
and skipwhile patterns used in functional
programming. #33202

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
