### PR TITLE
fix(lsp/health): always use vim.inspect to show root_markers

### DIFF
--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -198,7 +198,7 @@ local function check_enabled_configs()
         local v_str --- @type string?
         if k == 'name' then
           v_str = nil
-        elseif k == 'filetypes' or (k == 'root_markers' and type(v[1]) == 'string') then
+        elseif k == 'filetypes' then
           v_str = table.concat(v, ', ')
         elseif type(v) == 'function' then
           v_str = func_tostring(v)


### PR DESCRIPTION
In https://github.com/neovim/neovim/pull/34092 we changed the healthcheck to display root markers as a concatenated list if the first item in root_markers is a string (not a table). However, this does not solve the general case, because root_markers can contain a string as the first element, but a table as the 2nd element (example: `{".clangd", {"compile_commands.json", "compile_flags.txt"}}`).

Because root_markers has a more complex structure we should always just display it using vim.inspect, rather than adding a special case for when all items are a string.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
