### PR TITLE
fix(lsp): include context for each client in multi-handler results

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1331,7 +1331,7 @@ end
 --- a `client_id:result` map.
 ---@return function cancel Function that cancels all requests.
 function lsp.buf_request_all(bufnr, method, params, handler)
-  local results = {} --- @type table<integer,{err: lsp.ResponseError?, result: any}>
+  local results = {} --- @type table<integer,{err: lsp.ResponseError?, result: any, context: lsp.HandlerContext}>
   local remaining --- @type integer?
 
   local _, cancel = lsp.buf_request(bufnr, method, params, function(err, result, ctx, config)
@@ -1341,7 +1341,7 @@ function lsp.buf_request_all(bufnr, method, params, handler)
     end
 
     -- The error key is deprecated and will be removed in 0.13
-    results[ctx.client_id] = { err = err, error = err, result = result }
+    results[ctx.client_id] = { err = err, error = err, result = result, context = ctx }
     remaining = remaining - 1
 
     if remaining == 0 then

--- a/runtime/lua/vim/lsp/_meta.lua
+++ b/runtime/lua/vim/lsp/_meta.lua
@@ -2,7 +2,7 @@
 error('Cannot require a meta file')
 
 ---@alias lsp.Handler fun(err: lsp.ResponseError?, result: any, context: lsp.HandlerContext, config?: table): ...any
----@alias lsp.MultiHandler fun(results: table<integer,{err: lsp.ResponseError?, result: any}>, context: lsp.HandlerContext, config?: table): ...any
+---@alias lsp.MultiHandler fun(results: table<integer,{err: lsp.ResponseError?, result: any, context: lsp.HandlerContext}>, context: lsp.HandlerContext, config?: table): ...any
 
 ---@class lsp.HandlerContext
 ---@field method string

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -1075,7 +1075,7 @@ end
 ---@class vim.lsp.CodeActionResultEntry
 ---@field err? lsp.ResponseError
 ---@field result? (lsp.Command|lsp.CodeAction)[]
----@field ctx lsp.HandlerContext
+---@field context lsp.HandlerContext
 
 --- @class vim.lsp.buf.code_action.Opts
 --- @inlinedoc
@@ -1152,7 +1152,7 @@ local function on_code_action_results(results, opts)
   for _, result in pairs(results) do
     for _, action in pairs(result.result or {}) do
       if action_filter(action) then
-        table.insert(actions, { action = action, ctx = result.ctx })
+        table.insert(actions, { action = action, ctx = result.context })
       end
     end
   end
@@ -1325,12 +1325,7 @@ function M.code_action(opts)
     end
 
     return params
-  end, function(results, ctx)
-    for _, result in pairs(results) do
-      ---@cast result vim.lsp.CodeActionResultEntry
-      result.ctx = ctx
-    end
-
+  end, function(results)
     on_code_action_results(results, opts)
   end)
 end


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Fixes https://github.com/neovim/neovim/issues/34654

Currently `lsp.buf_request_all` uses the context from the last client when returning the merged results. Instead let's include the context in the client's specific result table.

I'm still leaving the existing context argument as there's a lot of code that uses it to get the buffer number etc, and it's less disruptive to the function signature.