### PR TITLE
docs: update deprecated API references

### DIFF
--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1377,14 +1377,14 @@ function vim.api.nvim_get_current_win() end
 function vim.api.nvim_get_hl(ns_id, opts) end
 
 --- @deprecated
---- @see vim.api.nvim_get_hl_by_name
+--- @see vim.api.nvim_get_hl
 --- @param hl_id integer
 --- @param rgb boolean
 --- @return table<string,any>
 function vim.api.nvim_get_hl_by_id(hl_id, rgb) end
 
 --- @deprecated
---- @see vim.api.nvim_get_hl_by_id
+--- @see vim.api.nvim_get_hl
 --- @param name string
 --- @param rgb boolean
 --- @return table<string,any>

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -270,7 +270,7 @@ Integer nvim_buf_set_virtual_text(Buffer buffer, Integer src_id, Integer line, A
 /// @param rgb Export RGB colors
 /// @param[out] err Error details, if any
 /// @return Highlight definition map
-/// @see nvim_get_hl_by_name
+/// @see nvim_get_hl
 Dict nvim_get_hl_by_id(Integer hl_id, Boolean rgb, Arena *arena, Error *err)
   FUNC_API_SINCE(3)
   FUNC_API_DEPRECATED_SINCE(9)
@@ -291,7 +291,7 @@ Dict nvim_get_hl_by_id(Integer hl_id, Boolean rgb, Arena *arena, Error *err)
 /// @param rgb Export RGB colors
 /// @param[out] err Error details, if any
 /// @return Highlight definition map
-/// @see nvim_get_hl_by_id
+/// @see nvim_get_hl
 Dict nvim_get_hl_by_name(String name, Boolean rgb, Arena *arena, Error *err)
   FUNC_API_SINCE(3)
   FUNC_API_DEPRECATED_SINCE(9)


### PR DESCRIPTION
The two deprecated functions `nvim_get_hl_by_id` and `nvim_get_hl_by_name` were referencing each other instead of the current `nvim_get_hl` function.

Thanks!