### PR TITLE
feat(extui): don't enter pager for routed message

### DIFF
--- a/runtime/lua/vim/_extui/cmdline.lua
+++ b/runtime/lua/vim/_extui/cmdline.lua
@@ -114,7 +114,7 @@ end
 ---@param level integer
 ---@param abort boolean
 function M.cmdline_hide(level, abort)
-  if M.row > 0 or level > 1 then
+  if M.row > 0 or level > (fn.getcmdwintype() == '' and 1 or 2) then
     return -- No need to hide when still in nested cmdline or cmdline_block.
   end
 

--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -54,4 +54,38 @@ describe('cmdline2', function()
       /foo^                                                 |
     ]])
   end)
+
+  it('block mode', function()
+    feed(':if 1<CR>')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*11
+      {16::}{15:if} {26:1}                                                |
+      {16::}  ^                                                  |
+    ]])
+    feed('echo "foo"<CR>')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*9
+      {16::}{15:if} {26:1}                                                |
+      {16::}  {15:echo} {26:"foo"}                                        |
+      {15:foo}                                                  |
+      {16::}  ^                                                  |
+    ]])
+    feed('endif')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*9
+      {16::}{15:if} {26:1}                                                |
+      {16::}  {15:echo} {26:"foo"}                                        |
+      {15:foo}                                                  |
+      {16::}  {15:endif}^                                             |
+    ]])
+    feed('<CR>')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+                                                           |
+    ]])
+  end)
 end)

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -48,29 +48,42 @@ describe('messages2', function()
     -- Multiple messages in same event loop iteration are appended.
     feed([[q:echo "foo\nbar" | echo "baz"<CR>]])
     screen:expect([[
-                                                           |
+      ^                                                     |
       {1:~                                                    }|*8
       ─────────────────────────────────────────────────────|
-      {4:^foo                                                  }|
+      {4:foo                                                  }|
       {4:bar                                                  }|
       {4:baz                                                  }|
-                                          1,1           All|
+                                          0,0-1         All|
+    ]])
+    -- Any key press closes the routed pager.
+    feed('j')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+                                          0,0-1         All|
     ]])
     -- No error for ruler virt_text msg_row exceeding buffer length.
     command([[map Q <cmd>echo "foo\nbar" <bar> ls<CR>]])
-    feed('qQ')
+    feed('Q')
     screen:expect([[
-                                                           |
+      ^                                                     |
       {1:~                                                    }|*7
       ─────────────────────────────────────────────────────|
-      {4:^foo                                                  }|
+      {4:foo                                                  }|
       {4:bar                                                  }|
       {4:                                                     }|
       {4:  1 %a   "[No Name]"                    line 1       }|
-                                          1,1           All|
+                                          0,0-1         All|
+    ]])
+    feed('<Esc>')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+                                          0,0-1         All|
     ]])
     -- edit_unputchar() does not clear already updated screen #34515.
-    feed('qix<Esc>dwi<C-r>')
+    feed('ix<Esc>dwi<C-r>')
     screen:expect([[
       {18:^"}                                                    |
       {1:~                                                    }|*12


### PR DESCRIPTION
Problem:  Messages routed to the pager to be shown in full, enter the
          pager automatically, yielding another "press-q-prompt".
Solution: Only enter the pager when requested explicitly. Otherwise,
          close the pager on the next typed mapping, unless that mapping
          entered the pager.