### PR TITLE
fix(messages): only msg_clear for UPD_CLEAR

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -264,9 +264,6 @@ void screenclear(void)
     msg_grid_invalid = false;
     clear_cmdline = true;
   }
-  if (ui_has(kUIMessages)) {
-    ui_call_msg_clear();
-  }
 }
 
 /// Unlike cmdline "one_key" prompts, the message part of the prompt is not stored
@@ -570,6 +567,9 @@ int update_screen(void)
     screenclear();  // will reset clear_cmdline
                     // and set UPD_NOT_VALID for each window
     cmdline_screen_cleared();   // clear external cmdline state
+    if (ui_has(kUIMessages)) {
+      ui_call_msg_clear();
+    }
     type = UPD_NOT_VALID;
     // must_redraw may be set indirectly, avoid another redraw later
     must_redraw = 0;

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -160,5 +160,14 @@ describe('messages2', function()
     ]])
     command('echo ""')
     screen:expect_unchanged()
+    -- Or a screen resize
+    screen:try_resize(screen._width, screen._height - 1)
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*9
+      {1:~                                               }┌───┐|
+      {1:~                                               }│{4:foo}│|
+      {1:~                                               }└───┘|
+    ]])
   end)
 end)


### PR DESCRIPTION
Problem:  "msg_clear" is emitted after resizing the screen and during startup.
Solution: Only emit "msg_clear" when `redraw_type == UPD_CLEAR`.

Fix #34685
