### PR TITLE
fix(treesitter): ensure TSLuaTree is always immutable

### DIFF
--- a/runtime/lua/vim/treesitter/_meta/tstree.lua
+++ b/runtime/lua/vim/treesitter/_meta/tstree.lua
@@ -26,6 +26,7 @@ function TSTree:root() end
 ---@param end_col_old integer
 ---@param end_row_new integer
 ---@param end_col_new integer
+---@return TSTree
 ---@nodoc
 function TSTree:edit(start_byte, end_byte_old, end_byte_new, start_row, start_col, end_row_old, end_col_old, end_row_new, end_col_new) end
 

--- a/runtime/lua/vim/treesitter/languagetree.lua
+++ b/runtime/lua/vim/treesitter/languagetree.lua
@@ -1107,8 +1107,8 @@ function LanguageTree:_edit(
   end_row_new,
   end_col_new
 )
-  for _, tree in pairs(self._trees) do
-    tree:edit(
+  for i, tree in pairs(self._trees) do
+    self._trees[i] = tree:edit(
       start_byte,
       end_byte_old,
       end_byte_new,

--- a/test/functional/treesitter/node_spec.lua
+++ b/test/functional/treesitter/node_spec.lua
@@ -228,4 +228,17 @@ describe('treesitter node API', function()
     end)
     eq({ 0, 0, 2, 3 }, lua_eval('range'))
   end)
+
+  it('tree:root() is idempotent', function()
+    insert([[
+      function x()
+        return true
+      end
+    ]])
+    exec_lua(function()
+      local tree = vim.treesitter.get_parser(0, 'lua'):parse()[1]
+      assert(tree:root() == tree:root())
+      assert(tree:root() == tree:root():tree():root())
+    end)
+  end)
 end)


### PR DESCRIPTION
Fix #34605, Fix #34631, and Fix https://github.com/ThePrimeagen/refactoring.nvim/issues/508.

This PR implements solution 3 that I described in this comment: https://github.com/neovim/neovim/issues/34631#issuecomment-3001965399. I was afraid that making `tree_edit` return a copy instead of mutating the tree in place would be too sensitive a change, but I saw that is already the case for `parser_parse`, so I don't think the change is that risky. However, I would still be more at ease if someone reviewed my changes.

## Problem

The previous fix in https://github.com/neovim/neovim/pull/34314 relies on copying the tree in `tree_root` to ensure the `TSNode`'s tree cannot be mutated. But that causes the problem where two calls to `tree_root` return nodes from different copies of a tree, which do not compare as equal. This has broken at least one plugin.

## Solution

Make all `TSTree`s on the Lua side always immutable, avoiding the need to copy the tree in `tree_root`, and make the only mutation point, `tree_edit`, copy the tree instead.

---

I tested that it fixed https://github.com/ThePrimeagen/refactoring.nvim/issues/508 with the reproduction below:

```sh
VIMRUNTIME="$PWD"/../runtime ../build/bin/nvim --clean -u minimal.lua foo.lua
```

- foo.lua
```lua
function hello()
  local foo = 23
  --     ^\  <leader>ai over foo
  return foo
end
```

- minimal.lua
```lua
vim.env.LAZY_STDPATH = ".repro"
load(vim.fn.system "curl -s https://raw.githubusercontent.com/folke/lazy.nvim/main/bootstrap.lua")()
vim.g.mapleader = ' '

require("lazy.minit").repro {
  spec = {
    {

      "theprimeagen/refactoring.nvim",
      config = function()
        vim.keymap.set({ "n", "x" }, "<leader>ai", function()
          return require('refactoring').refactor "Inline Variable"
        end, { desc = "Inline Variable", expr = true })
      end,
      dependencies = {
        'nvim-lua/plenary.nvim',
        'nvim-treesitter/nvim-treesitter',
      },
    },
  },
}
```