### PR TITLE
vim-patch:1fa3f0c: runtime(doc): fix :vmap example to avoid unwanted spaces with JJ

### DIFF
--- a/runtime/doc/visual.txt
+++ b/runtime/doc/visual.txt
@@ -391,7 +391,7 @@ want only part of the line to be replaced you will have to make a mapping for
 it.  In a future release ":" may work on partial lines.
 
 Here is an example, to replace the selected text with the output of "date": >
-	:vmap _a <Esc>`>a<CR><Esc>`<i<CR><Esc>!!date<CR>kJJ
+	:vmap _a <Esc>`>a<CR><Esc>`<i<CR><Esc>!!date<CR>kgJgJ
 
 (In the <> notation |<>|, when typing it you should type it literally; you
 need to remove the 'B' flag from 'cpoptions')


### PR DESCRIPTION
#### vim-patch:1fa3f0c: runtime(doc): fix :vmap example to avoid unwanted spaces with JJ

closes: vim/vim#17623

https://github.com/vim/vim/commit/1fa3f0c215d37b3cb36f69841d5ab29ca8e0faa5

Co-authored-by: Damien Lejay <damien@lejay.be>