### PR TITLE
fix(iter): ArrayIter:last returns nil when filtered to empty

### DIFF
--- a/runtime/lua/vim/iter.lua
+++ b/runtime/lua/vim/iter.lua
@@ -957,6 +957,9 @@ end
 
 ---@private
 function ArrayIter:last()
+  if self._head >= self._tail then
+    return nil
+  end
   local inc = self._head < self._tail and 1 or -1
   local v = self._table[self._tail - inc]
   self._head = self._tail

--- a/test/functional/lua/iter_spec.lua
+++ b/test/functional/lua/iter_spec.lua
@@ -339,6 +339,15 @@ describe('vim.iter', function()
     local s = 'abcdefghijklmnopqrstuvwxyz'
     eq('z', vim.iter(vim.split(s, '')):last())
     eq('z', vim.iter(vim.gsplit(s, '')):last())
+    eq(
+      nil,
+      vim
+        .iter({ 1, 2, 3, 4, 5 })
+        :filter(function()
+          return false
+        end)
+        :last()
+    )
   end)
 
   it('enumerate()', function()


### PR DESCRIPTION
Problem: After filtering out all elements, ArrayIter:last still returns a stale element. Solution: Add check for self._head == self._tail and return nil early. 

Fix #34696

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
