### PR TITLE
feat(system): add `cmd` field in wait() result

### DIFF
--- a/runtime/lua/vim/_system.lua
+++ b/runtime/lua/vim/_system.lua
@@ -16,6 +16,7 @@ local uv = vim.uv
 --- @field signal integer
 --- @field stdout? string
 --- @field stderr? string
+--- @field cmd string[]
 
 --- @class vim.SystemState
 --- @field cmd string[]
@@ -305,6 +306,7 @@ local function _on_exit(state, code, signal, on_exit)
       signal = signal,
       stdout = stdout_data and table.concat(stdout_data) or nil,
       stderr = stderr_data and table.concat(stderr_data) or nil,
+      cmd = state.cmd,
     }
 
     if on_exit then

--- a/test/functional/lua/system_spec.lua
+++ b/test/functional/lua/system_spec.lua
@@ -73,6 +73,11 @@ describe('vim.system', function()
         eq('hellocat', system({ 'cat' }, { stdin = 'hellocat', text = true }).stdout)
       end)
 
+      it('exposes the original command via result.cmd', function()
+        local cmd = { 'echo', 'hello' }
+        eq(cmd, system(cmd, { text = true }).cmd)
+      end)
+
       it('can set environment', function()
         eq(
           'TESTVAL',
@@ -94,12 +99,14 @@ describe('vim.system', function()
       end)
 
       it('supports timeout', function()
+        local cmd = { 'sleep', '10' }
         eq({
           code = 124,
           signal = 15,
           stdout = '',
           stderr = '',
-        }, system({ 'sleep', '10' }, { timeout = 1000 }))
+          cmd = cmd,
+        }, system(cmd, { timeout = 1000 }))
       end)
     end)
   end

--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -165,6 +165,8 @@ describe('vim.ui', function()
           vim.ui.open('foo', { cmd = { 'non-existent-tool' } })
         end)
       )
+      local url = 'https://example.com'
+      local test_cmd = { n.testprg('printargs-test'), 'arg1', url }
 
       eq(
         {
@@ -172,12 +174,13 @@ describe('vim.ui', function()
           signal = 0,
           stderr = '',
           stdout = 'arg1=arg1;arg2=https://example.com;',
+          cmd = test_cmd,
         },
-        exec_lua(function(cmd_)
-          local cmd, err = vim.ui.open('https://example.com', { cmd = cmd_ })
-          assert(cmd and not err)
-          return cmd:wait()
-        end, { n.testprg('printargs-test'), 'arg1' })
+        exec_lua(function(base_cmd, u)
+          local job, err = vim.ui.open(u, { cmd = base_cmd })
+          assert(job and not err)
+          return job:wait()
+        end, { test_cmd[1], test_cmd[2] }, url)
       )
     end)
   end)


### PR DESCRIPTION
Problem:
The table returned by `vim.system():wait()` after completition did not include the original executed command.

Solution:
Populate `state.result.cmd` with `state.cmd` in `_on_exit()` so callers can read `job.cmd` field directly.

closes #34703 

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
