### PR TITLE
refactor(runtime): migrate vim.fn.system() calls to vim.system() (WIP)

### DIFF
--- a/runtime/lua/vim/health/health.lua
+++ b/runtime/lua/vim/health/health.lua
@@ -171,6 +171,7 @@ local function check_performance()
   local slow_cmd_time = 1.5
   local start_time = vim.fn.reltime()
   vim.fn.system('echo')
+  vim.system({'echo'}):wait()
   local elapsed_time = vim.fn.reltimefloat(vim.fn.reltime(start_time))
   if elapsed_time > slow_cmd_time then
     health.warn(


### PR DESCRIPTION
Problem:
Several runtime Lua files still rely on `vim.fn.system()` for system calls instead of `vim.system()`
Solution:
Replace exisiting occurrences with `vim.system():wait()` and update surrounding checks to use `job.code`, `job.stderr` and `job.stdout` where useful.

WIP until I finish this quick PR #34705 

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
