### PR TITLE
vim-patch:9.1.1498: completion: 'complete' funcs behave different to 'omnifunc'

### DIFF
--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -568,8 +568,8 @@ func Test_cpt_func_cursorcol()
       call assert_equal(8, col('.'))
       return col('.')
     endif
-    call assert_equal("foo bar", getline(1))
-    call assert_equal(8, col('.'))
+    call assert_equal("foo ", getline(1))
+    call assert_equal(5, col('.'))
     " return v:none
   endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.1498: completion: 'complete' funcs behave different to 'omnifunc'

Problem:  completion: Functions specified in the 'complete' option did
          not have the leader string removed when called with findstart = 0,
          unlike 'omnifunc' behavior
Solution: update behaviour and make behaviour consistent (Girish Palya)

closes: vim/vim#17636

https://github.com/vim/vim/commit/fa16c7ab3f219f93b24cf31ac8aafbd6b522d1bf

Co-authored-by: Girish Palya <girishji@gmail.com>