### PR TITLE
vim-patch:a5b744e: runtime(vim): Update base-syntax, improve :syn-sync line defaults

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -191,13 +191,6 @@ if exists("g:vimsyntax_noerror")
  let g:vimsyn_noerror= g:vimsyntax_noerror
 endif
 
-" Variable options {{{2
-if exists("g:vim_maxlines")
- let s:vimsyn_maxlines= g:vim_maxlines
-else
- let s:vimsyn_maxlines= 60
-endif
-
 " Nulls {{{2
 " =====
 Vim9 syn keyword  vim9Null	null null_blob null_channel null_class null_dict null_function null_job null_list null_object null_partial null_string
@@ -2088,10 +2081,10 @@ endif
 
 " Synchronize (speed) {{{2
 "============
-if exists("g:vimsyn_minlines")
- exe "syn sync minlines=".g:vimsyn_minlines
-endif
-exe "syn sync maxlines=".s:vimsyn_maxlines
+
+exe "syn sync minlines=" .. get(g:, "vimsyn_minlines", 100)
+exe "syn sync maxlines=" .. get(g:, "vimsyn_maxlines", 200)
+
 syn sync linecont	"^\s\+\\"
 syn sync linebreaks=2
 syn sync match vimAugroupSyncA	groupthere NONE	"\<aug\%[roup]\>\s\+[eE][nN][dD]"


### PR DESCRIPTION
#### vim-patch:a5b744e: runtime(vim): Update base-syntax, improve :syn-sync line defaults

Set minlines and maxlines to 100 and 200 respectively.  Set these after
the script interface syntax files have been loaded to ensure the values
set in those are overridden.

closes: vim/vim#17614

https://github.com/vim/vim/commit/a5b744ef9366a4b694ce7f31783f3be266f5e3cf

Co-authored-by: Doug Kearns <dougkearns@gmail.com>