### PR TITLE
build: support static build

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -259,6 +259,29 @@ cmake --build build
     - Using `ninja` is strongly recommended.
 4. If treesitter parsers are not bundled, they need to be available in a `parser/` runtime directory (e.g. `/usr/share/nvim/runtime/parser/`).
 
+### How to build static binary (on Linux)
+
+1. Use a linux distribution which uses musl C. We will use Alpine Linux but any distro with musl should work. (glibc does not support dynamic linking)
+2. Run make passing the `STATIC_BUILD` variable: `make CMAKE_EXTRA_FLAGS="-DSTATIC_BUILD=1"`
+
+In case you are not using Alpine Linux you can use a container to do the build the binary:
+
+```bash
+podman run \
+  --rm \
+  -it \
+  -v "$PWD:/workdir" \
+  -w /workdir \
+  alpine:latest \
+  bash -c 'apk add build-base cmake coreutils curl gettext-tiny-dev && make CMAKE_EXTRA_FLAGS="-DSTATIC_BUILD=1"'
+```
+
+The resulting binary in `build/bin/nvim` will have all the dependencies statically linked:
+
+```
+build/bin/nvim: ELF 64-bit LSB executable, ARM aarch64, version 1 (SYSV), statically linked, BuildID[sha1]=b93fa8e678d508ac0a76a2e3da20b119105f1b2d, with debug_info, not stripped
+```
+
 #### Debian 10 (Buster) example:
 
 ```sh

--- a/BUILD.md
+++ b/BUILD.md
@@ -261,7 +261,7 @@ cmake --build build
 
 ### How to build static binary (on Linux)
 
-1. Use a linux distribution which uses musl C. We will use Alpine Linux but any distro with musl should work. (glibc does not support dynamic linking)
+1. Use a linux distribution which uses musl C. We will use Alpine Linux but any distro with musl should work. (glibc does not support static linking)
 2. Run make passing the `STATIC_BUILD` variable: `make CMAKE_EXTRA_FLAGS="-DSTATIC_BUILD=1"`
 
 In case you are not using Alpine Linux you can use a container to do the build the binary:

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -748,7 +748,11 @@ endif()
 
 target_sources(nlua0 PUBLIC ${NLUA0_SOURCES})
 
+if(STATIC_BUILD)
+  target_link_options(nvim_bin PRIVATE -static-libgcc -static-libstdc++ -static)
+endif()
 target_link_libraries(nvim_bin PRIVATE main_lib PUBLIC libuv)
+
 install_helper(TARGETS nvim_bin)
 if(MSVC)
   install(FILES $<TARGET_PDB_FILE:nvim_bin> DESTINATION ${CMAKE_INSTALL_BINDIR} OPTIONAL)


### PR DESCRIPTION
### Problem

Currently we cannot build portable nvim binaries so we need to build with under older OS to enable compatibility across linux distributions. 

fixes https://github.com/neovim/neovim/issues/6575

### Solution

I added a conditional flag to enable static builds and added instructions to build portable binaries under Alpine Linux (other distros which use musl C may also be used).

I had previously posted a quick hack to achieved this in the linked issue but now I took the time to add the flag to the instructions would be easier to follow.

Let me know if this is acceptable

---

I see this was attempted before: https://github.com/neovim/neovim/pull/7914/files
I believe the previous attempt tries to handle this on Windows

just to clarify this small patch will only work on Linux as I have no idea about Windows.
