### PR TITLE
fix(prompt): cursor on prompt line, disallow ":edit"

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -1532,7 +1532,10 @@ static void init_prompt(int cmdchar_todo)
 {
   char *prompt = prompt_text();
 
-  if (curwin->w_cursor.lnum < curbuf->b_prompt_start.mark.lnum) {
+  if (curwin->w_cursor.lnum < curbuf->b_prompt_start.mark.lnum
+      || (cmdchar_todo != 'O'
+          && curwin->w_cursor.lnum == curbuf->b_prompt_start.mark.lnum
+          && (curwin->w_cursor.col < (int)strlen(prompt_text())))) {
     curwin->w_cursor.lnum = curbuf->b_ml.ml_line_count;
     coladvance(curwin, MAXCOL);
   }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5693,6 +5693,12 @@ static void ex_edit(exarg_T *eap)
     return;
   }
 
+  // prevent use of :edit on prompt-buffers
+  if (bt_prompt(curbuf) && eap->cmdidx == CMD_edit && *eap->arg == NUL) {
+    emsg("cannot :edit a prompt buffer");
+    return;
+  }
+
   do_exedit(eap, NULL);
 }
 

--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -130,9 +130,9 @@ describe('prompt buffer', function()
       {1:~                        }|*3
       {5:-- INSERT --}             |
     ]])
+
     -- :edit doesn't apply on prompt buffer
-    local can_edit, _ = pcall(api.nvim_command, 'edit')
-    eq(can_edit, false, ':edit command in prompt buffer throws error')
+    eq('Vim(edit):cannot :edit a prompt buffer', t.pcall_err(api.nvim_command, 'edit'))
 
     feed('<C-U>exit\n')
     screen:expect([[

--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -130,6 +130,10 @@ describe('prompt buffer', function()
       {1:~                        }|*3
       {5:-- INSERT --}             |
     ]])
+    -- :edit doesn't apply on prompt buffer
+    local can_edit, _ = pcall(api.nvim_command, 'edit')
+    eq(can_edit, false, ':edit command in prompt buffer throws error')
+
     feed('<C-U>exit\n')
     screen:expect([[
       ^other buffer             |
@@ -296,6 +300,47 @@ describe('prompt buffer', function()
       line2^                    |
       {1:~                        }|*6
       {5:-- INSERT --}             |
+    ]])
+
+    -- ensure cursor gets adjusted to end of user-text to prompt when insert mode
+    -- is entered from readonly region of prompt buffer
+    local prompt_pos = api.nvim_buf_get_mark(0, ':')
+    feed('<esc>')
+    -- works before prompt
+    api.nvim_win_set_cursor(0, { prompt_pos[1] - 1, 0 })
+    screen:expect([[
+      ^other buffer             |
+      % line1                  |
+      line2                    |
+      {1:~                        }|*6
+                               |
+    ]])
+    feed('a')
+    feed('<esc>')
+    screen:expect([[
+      other buffer             |
+      % line1                  |
+      line^2                    |
+      {1:~                        }|*6
+                               |
+    ]])
+    -- works on prompt
+    api.nvim_win_set_cursor(0, { prompt_pos[1], 0 })
+    screen:expect([[
+      other buffer             |
+      ^% line1                  |
+      line2                    |
+      {1:~                        }|*6
+                               |
+    ]])
+    feed('a')
+    feed('<esc>')
+    screen:expect([[
+      other buffer             |
+      % line1                  |
+      line^2                    |
+      {1:~                        }|*6
+                               |
     ]])
   end)
 

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -859,7 +859,7 @@ func Test_BufReadCmdNofile()
             \ 'quickfix',
             \ 'help',
             "\ 'terminal',
-            \ 'prompt',
+            "\ 'prompt',
             "\ 'popup',
             \ ]
     new somefile
@@ -977,7 +977,7 @@ func Test_BufEnter()
             \ 'quickfix',
             \ 'help',
             "\ 'terminal',
-            \ 'prompt',
+            "\ 'prompt',
             "\ 'popup',
             \ ]
     new somefile


### PR DESCRIPTION
Working toward #34561

- [ ] ~~modified flag is not set upon editing prompt buffer~~
- [x] :edit is forbidden in prompt buffer
- [x] If the cursor is within the prompt text upon insert start jumps to end,