### PR TITLE
vim-patch:9.1.1501: filetype: flix files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -464,6 +464,7 @@ local extension = {
   ['4gh'] = 'fgl',
   fir = 'firrtl',
   fish = 'fish',
+  flix = 'flix',
   focexec = 'focexec',
   fex = 'focexec',
   ft = 'forth',

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -557,6 +557,7 @@ local extension = {
   persistentmodels = 'haskellpersistent',
   ht = 'haste',
   htpp = 'hastepreproc',
+  hx = 'haxe',
   hcl = 'hcl',
   hb = 'hb',
   h = detect.header,

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -871,6 +871,7 @@ local extension = {
   nsh = 'nsis',
   nt = 'ntriples',
   nu = 'nu',
+  nbt = 'numbat',
   obj = 'obj',
   objdump = 'objdump',
   cppobjdump = 'objdump',

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1007,6 +1007,7 @@ local extension = {
   qml = 'qml',
   qbs = 'qml',
   qmd = 'quarto',
+  bms = 'quickbms',
   R = detect.r,
   rkt = 'racket',
   rktd = 'racket',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -287,6 +287,7 @@ func s:GetFilenameChecks() abort
     \ 'fgl': ['file.4gl', 'file.4gh', 'file.m4gl'],
     \ 'firrtl': ['file.fir'],
     \ 'fish': ['file.fish'],
+    \ 'flix': ['file.flix'],
     \ 'focexec': ['file.fex', 'file.focexec'],
     \ 'form': ['file.frm'],
     \ 'forth': ['file.ft', 'file.fth', 'file.4th'],

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -348,6 +348,7 @@ func s:GetFilenameChecks() abort
     \ 'haskellpersistent': ['file.persistentmodels'],
     \ 'haste': ['file.ht'],
     \ 'hastepreproc': ['file.htpp'],
+    \ 'haxe': ['file.hx'],
     \ 'hb': ['file.hb'],
     \ 'hcl': ['file.hcl'],
     \ 'heex': ['file.heex'],

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -639,6 +639,7 @@ func s:GetFilenameChecks() abort
     \ 'qmldir': ['qmldir'],
     \ 'quake': ['anybaseq2/file.cfg', 'anyid1/file.cfg', 'quake3/file.cfg', 'baseq2/file.cfg', 'id1/file.cfg', 'quake1/file.cfg', 'some-baseq2/file.cfg', 'some-id1/file.cfg', 'some-quake1/file.cfg'],
     \ 'quarto': ['file.qmd'],
+    \ 'quickbms': ['file.bms'],
     \ 'r': ['file.r', '.Rhistory', '.Rprofile', 'Rprofile', 'Rprofile.site'],
     \ 'racket': ['file.rkt', 'file.rktd', 'file.rktl'],
     \ 'radiance': ['file.rad', 'file.mat'],

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -564,6 +564,7 @@ func s:GetFilenameChecks() abort
     \ 'nsis': ['file.nsi', 'file.nsh'],
     \ 'ntriples': ['file.nt'],
     \ 'nu': ['file.nu'],
+    \ 'numbat': ['file.nbt'],
     \ 'obj': ['file.obj'],
     \ 'objdump': ['file.objdump', 'file.cppobjdump'],
     \ 'obse': ['file.obl', 'file.obse', 'file.oblivion', 'file.obscript'],


### PR DESCRIPTION
Problem:  filetype: flix files are not recognized
Solution: detect *.flix files as flix filetype
          (0xadk)

References:
- https://flix.dev/
- https://doc.flix.dev/introduction.html

closes: vim/vim#17646

https://github.com/vim/vim/commit/b211916e0ae818e0653ae23ae71565b24ccba307

Co-authored-by: 0xadk <0xadk@users.noreply.github.com>

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
