### PR TITLE
test(old): emulate test_override('starting') with FFI

### DIFF
--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -72,6 +72,31 @@ autocmd! nvim.popupmenu
 " Undo the 'grepprg' and 'grepformat' setting in _defaults.lua.
 set grepprg& grepformat&
 
+let s:has_ffi = luaeval('pcall(require, "ffi")')
+if s:has_ffi
+  lua require("ffi").cdef("int starting;")
+endif
+
+" This can emulate test_override('starting', val) if LuaJIT FFI is enabled.
+" Other flags are not supported.
+func Ntest_override(name, val)
+  if a:name !=# 'starting'
+    throw "Do not use Ntest_override() for this"
+  endif
+  if !s:has_ffi
+    throw 'Skipped: missing LuaJIT FFI'
+  endif
+  if a:val
+    if !exists('s:save_starting')
+      let s:save_starting = luaeval('require("ffi").C.starting')
+    endif
+    lua require("ffi").C.starting = 0
+  else
+    exe 'lua require("ffi").C.starting =' s:save_starting
+    unlet s:save_starting
+  endif
+endfunc
+
 " roughly equivalent to test_setmouse() in Vim
 func Ntest_setmouse(row, col)
   call nvim_input_mouse('move', '', '', 0, a:row - 1, a:col - 1)

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -128,8 +128,7 @@ if has('timers')
   endfunc
 
   func Test_OptionSet_modeline()
-    CheckFunction test_override
-    call test_override('starting', 1)
+    call Ntest_override('starting', 1)
     au! OptionSet
     augroup set_tabstop
       au OptionSet tabstop call timer_start(1, {-> execute("echo 'Handler called'", "")})
@@ -146,7 +145,7 @@ if has('timers')
     augroup END
     bwipe!
     set ts&
-    call test_override('starting', 0)
+    call Ntest_override('starting', 0)
   endfunc
 
 endif "has('timers')
@@ -1103,7 +1102,8 @@ func s:AutoCommandOptionSet(match)
 endfunc
 
 func Test_OptionSet()
-  CheckFunction test_override
+  " Use test/functional/legacy/autocmd_option_spec.lua
+  throw 'Skipped: Nvim changed types of OptionSet v: variables'
   CheckOption autochdir
 
   call test_override('starting', 1)
@@ -1705,8 +1705,7 @@ func Test_OptionSet()
 endfunc
 
 func Test_OptionSet_diffmode()
-  CheckFunction test_override
-  call test_override('starting', 1)
+  call Ntest_override('starting', 1)
   " 18: Changing an option when entering diff mode
   new
   au OptionSet diff :let &l:cul = v:option_new
@@ -1735,12 +1734,11 @@ func Test_OptionSet_diffmode()
 
   " Cleanup
   au! OptionSet
-  call test_override('starting', 0)
+  call Ntest_override('starting', 0)
 endfunc
 
 func Test_OptionSet_diffmode_close()
-  CheckFunction test_override
-  call test_override('starting', 1)
+  call Ntest_override('starting', 1)
   " 19: Try to close the current window when entering diff mode
   " should not segfault
   new
@@ -1760,7 +1758,7 @@ func Test_OptionSet_diffmode_close()
 
   " Cleanup
   au! OptionSet
-  call test_override('starting', 0)
+  call Ntest_override('starting', 0)
   "delfunc! AutoCommandOptionSet
 endfunc
 
@@ -3599,8 +3597,7 @@ func Test_Visual_doautoall_redraw()
 endfunc
 
 func Test_get_Visual_selection_in_curbuf_autocmd()
-  throw 'Skipped: use test/functional/legacy/autocmd_spec.lua'
-  call test_override('starting', 1)
+  call Ntest_override('starting', 1)
   new
   autocmd OptionSet list let b:text = getregion(getpos('.'), getpos('v'))
   call setline(1, 'foo bar baz')
@@ -3617,7 +3614,7 @@ func Test_get_Visual_selection_in_curbuf_autocmd()
 
   autocmd! OptionSet list
   bwipe!
-  call test_override('starting', 0)
+  call Ntest_override('starting', 0)
 endfunc
 
 " This was using freed memory.

--- a/test/old/testdir/test_gf.vim
+++ b/test/old/testdir/test_gf.vim
@@ -199,10 +199,9 @@ func Test_gf_error()
     au OptionSet diff norm! gf
   augroup END
   call setline(1, ['Xfile1', 'line2', 'line3', 'line4'])
-  " Nvim does not support test_override()
-  " call test_override('starting', 1)
-  " call assert_fails('diffthis', 'E788:')
-  " call test_override('starting', 0)
+  call Ntest_override('starting', 1)
+  call assert_fails('diffthis', 'E788:')
+  call Ntest_override('starting', 0)
   augroup Test_gf
     au!
   augroup END

--- a/test/old/testdir/test_quickfix.vim
+++ b/test/old/testdir/test_quickfix.vim
@@ -3284,7 +3284,7 @@ endfunc
 func Test_cclose_in_autocmd()
   " Problem is only triggered if "starting" is zero, so that the OptionSet
   " event will be triggered.
-  " call test_override('starting', 1)
+  call Ntest_override('starting', 1)
   augroup QF_Test
     au!
     au FileType qf :call assert_fails(':cclose', 'E788')
@@ -3294,7 +3294,7 @@ func Test_cclose_in_autocmd()
     au!
   augroup END
   augroup! QF_Test
-  " call test_override('starting', 0)
+  call Ntest_override('starting', 0)
 endfunc
 
 " Check that ":file" without an argument is possible even when "curbuf->b_ro_locked"


### PR DESCRIPTION
I was initially trying to port several cmdline tests from vim/vim#17570 involving test_override('char_avail') without having to rewrite entire tests in Lua, but haven't figured out a good way achieve that yet. Nevertheless emulating test_override('starting') is easier.