### PR TITLE
fix(api): nvim_buf_set_lines returns modified region

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2702,6 +2702,15 @@ nvim_buf_set_lines({buffer}, {start}, {end}, {strict_indexing}, {replacement})
                            error.
       • {replacement}      (`string[]`) Array of lines to use as replacement
 
+    Return: ~
+        (`table<string,any>`) Dictionary containing:
+        • region: Array with modified region information:
+          • start_line: First modified line (zero-indexed)
+          • end_line: Last modified line after modification
+          • end_col: Ending column (length of last modified line)
+          • lines_added: Number of lines added (negative if deleted)
+          • deleted_bytes: Number of bytes deleted
+
     See also: ~
       • |nvim_buf_set_text()|
 

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -719,6 +719,13 @@ function vim.api.nvim_buf_set_keymap(buffer, mode, lhs, rhs, opts) end
 --- @param end_ integer Last line index, exclusive
 --- @param strict_indexing boolean Whether out-of-bounds should be an error.
 --- @param replacement string[] Array of lines to use as replacement
+--- @return table<string,any> # Dictionary containing:
+--- - region: Array with modified region information:
+---     - start_line: First modified line (zero-indexed)
+---     - end_line: Last modified line after modification
+---     - end_col: Ending column (length of last modified line)
+---     - lines_added: Number of lines added (negative if deleted)
+---     - deleted_bytes: Number of bytes deleted
 function vim.api.nvim_buf_set_lines(buffer, start, end_, strict_indexing, replacement) end
 
 --- Sets a named mark in the given buffer, all marks are allowed

--- a/test/functional/lua/api_spec.lua
+++ b/test/functional/lua/api_spec.lua
@@ -25,7 +25,10 @@ describe('luaeval(vim.api.…)', function()
     describe('nvim_buf_set_lines', function()
       it('works', function()
         fn.setline(1, { 'abc', 'def', 'a\nb', 'ttt' })
-        eq(NIL, fn.luaeval('vim.api.nvim_buf_set_lines(1, 1, 2, false, {"b\\0a"})'))
+        eq(
+          { region = { 1, 2, 3, 0, 4 } },
+          fn.luaeval('vim.api.nvim_buf_set_lines(1, 1, 2, false, {"b\\0a"})')
+        )
         eq(
           { 'abc', 'b\000a', 'a\000b', 'ttt' },
           fn.luaeval('vim.api.nvim_buf_get_lines(1, 0, 4, false)')


### PR DESCRIPTION
Problem: nvim_buf_set_lines returns void, plugins cannot easily set '[ '] marks

Solution: return a dict with start_line, end_line, end_col, inserted_bytes

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
