### PR TITLE
test(old): emulate test_override('char_avail') using FFI

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -602,6 +602,16 @@ static int may_add_char_to_search(int firstc, int *c, incsearch_state_T *s)
         stuffcharReadbuff(*c);
         *c = '\\';
       }
+      // add any composing characters
+      if (utf_char2len(*c) != utfc_ptr2len(get_cursor_pos_ptr())) {
+        const int save_c = *c;
+        while (utf_char2len(*c) != utfc_ptr2len(get_cursor_pos_ptr())) {
+          curwin->w_cursor.col += utf_char2len(*c);
+          *c = gchar_cursor();
+          stuffcharReadbuff(*c);
+        }
+        *c = save_c;
+      }
       return FAIL;
     }
   }

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1866,6 +1866,9 @@ int vpeekc_any(void)
 /// @return  true if a character is available, false otherwise.
 bool char_avail(void)
 {
+  if (disable_char_avail_for_testing) {
+    return false;
+  }
   no_mapping++;
   int retval = vpeekc();
   no_mapping--;

--- a/src/nvim/getchar.h
+++ b/src/nvim/getchar.h
@@ -17,6 +17,8 @@ typedef enum {
 
 enum { NSCRIPT = 15, };  ///< Maximum number of streams to read script from
 
+EXTERN bool disable_char_avail_for_testing INIT( = false);
+
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "getchar.h.generated.h"
 #endif

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -166,6 +166,57 @@ endif
 " Prepare for calling test_garbagecollect_now().
 let v:testing = 1
 
+let s:has_ffi = luaeval('pcall(require, "ffi")')
+if s:has_ffi
+  lua << trim EOF
+    require('ffi').cdef([[
+      int starting;
+      bool disable_char_avail_for_testing;
+    ]])
+  EOF
+endif
+
+" This can emulate test_override('starting') and test_override('char_avail')
+" if LuaJIT FFI is enabled.
+" Other flags are not supported.
+func Ntest_override(name, val)
+  if a:name !=# 'starting' && a:name != 'char_avail' && a:name !=# 'ALL'
+    throw 'Unexpected use of Ntest_override()'
+  endif
+  if !s:has_ffi
+    throw 'Skipped: missing LuaJIT FFI'
+  endif
+
+  if a:name ==# 'starting' || a:name ==# 'ALL'
+    if a:val
+      if !exists('s:save_starting')
+        let s:save_starting = luaeval('require("ffi").C.starting')
+      endif
+      lua require("ffi").C.starting = 0
+    elseif exists('s:save_starting')
+      exe 'lua require("ffi").C.starting =' s:save_starting
+      unlet s:save_starting
+    endif
+  endif
+
+  if a:name ==# 'char_avail' || a:name ==# 'ALL'
+    exe 'lua require("ffi").C.disable_char_avail_for_testing =' a:val
+  endif
+endfunc
+
+" roughly equivalent to test_setmouse() in Vim
+func Ntest_setmouse(row, col)
+  call nvim_input_mouse('move', '', '', 0, a:row - 1, a:col - 1)
+  if state('m') == ''
+    call getchar(0)
+  endif
+endfunc
+
+" roughly equivalent to term_wait() in Vim
+func Nterm_wait(buf, time = 10)
+  execute $'sleep {a:time}m'
+endfunc
+
 " Support function: get the alloc ID by name.
 func GetAllocId(name)
   exe 'split ' . s:srcdir . '/alloc.h'
@@ -277,6 +328,10 @@ func RunTheTest(test)
       call add(s:skipped, 'SKIPPED ' . a:test . ': ' . g:skipped_reason)
       let skipped = v:true
     endif
+  elseif !s:has_ffi && execute('func ' .. a:test[:-3])->match("\n[ 0-9]*call Ntest_override(") >= 0
+    call add(s:messages, '    Skipped')
+    call add(s:skipped, 'SKIPPED ' . a:test . ': missing LuaJIT FFI' . )
+    let skipped = v:true
   else
     try
       exe 'call ' . a:test

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -72,44 +72,6 @@ autocmd! nvim.popupmenu
 " Undo the 'grepprg' and 'grepformat' setting in _defaults.lua.
 set grepprg& grepformat&
 
-let s:has_ffi = luaeval('pcall(require, "ffi")')
-if s:has_ffi
-  lua require("ffi").cdef("int starting;")
-endif
-
-" This can emulate test_override('starting', val) if LuaJIT FFI is enabled.
-" Other flags are not supported.
-func Ntest_override(name, val)
-  if a:name !=# 'starting'
-    throw "Do not use Ntest_override() for this"
-  endif
-  if !s:has_ffi
-    throw 'Skipped: missing LuaJIT FFI'
-  endif
-  if a:val
-    if !exists('s:save_starting')
-      let s:save_starting = luaeval('require("ffi").C.starting')
-    endif
-    lua require("ffi").C.starting = 0
-  else
-    exe 'lua require("ffi").C.starting =' s:save_starting
-    unlet s:save_starting
-  endif
-endfunc
-
-" roughly equivalent to test_setmouse() in Vim
-func Ntest_setmouse(row, col)
-  call nvim_input_mouse('move', '', '', 0, a:row - 1, a:col - 1)
-  if state('m') == ''
-    call getchar(0)
-  endif
-endfunc
-
-" roughly equivalent to term_wait() in Vim
-func Nterm_wait(buf, time = 10)
-  execute $'sleep {a:time}m'
-endfunc
-
 " Prevent Nvim log from writing to stderr.
 let $NVIM_LOG_FILE = exists($NVIM_LOG_FILE) ? $NVIM_LOG_FILE : 'Xnvim.log'
 

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -2659,10 +2659,9 @@ endfunc
 
 " Test TextChangedI and TextChangedP
 func Test_ChangedP()
-  throw 'Skipped: use test/functional/autocmd/textchanged_spec.lua'
   new
   call setline(1, ['foo', 'bar', 'foobar'])
-  call test_override("char_avail", 1)
+  call Ntest_override("char_avail", 1)
   set complete=. completeopt=menuone
 
   func! TextChangedAutocmd(char)
@@ -2703,7 +2702,7 @@ func Test_ChangedP()
   " TODO: how should it handle completeopt=noinsert,noselect?
 
   " CleanUp
-  call test_override("char_avail", 0)
+  call Ntest_override("char_avail", 0)
   au! TextChanged
   au! TextChangedI
   au! TextChangedP
@@ -2723,9 +2722,8 @@ func SetLineOne()
 endfunc
 
 func Test_TextChangedI_with_setline()
-  throw 'Skipped: use test/functional/autocmd/textchanged_spec.lua'
   new
-  call test_override('char_avail', 1)
+  call Ntest_override('char_avail', 1)
   autocmd TextChangedI <buffer> call SetLineOne()
   call feedkeys("i(\<CR>\<Esc>", 'tx')
   call assert_equal('(', getline(1))
@@ -2734,7 +2732,7 @@ func Test_TextChangedI_with_setline()
   call assert_equal('', getline(1))
   call assert_equal('', getline(2))
 
-  call test_override('char_avail', 0)
+  call Ntest_override('char_avail', 0)
   bwipe!
 endfunc
 

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -724,15 +724,14 @@ func Test_edit_CTRL_K()
     let v:testing = 0
   endtry
 
-  if exists('*test_override')
-    call test_override("char_avail", 1)
-    set showcmd
-    %d
-    call feedkeys("A\<c-k>a:\<esc>", 'tnix')
-    call assert_equal(['ä'], getline(1, '$'))
-    call test_override("char_avail", 0)
-    set noshowcmd
-  endif
+  call Ntest_override("char_avail", 1)
+  set showcmd
+  %d
+  call feedkeys("A\<c-k>a:\<esc>", 'tnix')
+  call assert_equal(['ä'], getline(1, '$'))
+  call Ntest_override("char_avail", 0)
+  set noshowcmd
+
   bw!
 endfunc
 
@@ -764,9 +763,9 @@ func Test_edit_CTRL_L()
   call assert_equal(['one', 'two', 'three', 'three', "\<c-l>\<c-p>\<c-n>", '', ''], getline(1, '$'))
   set complete&
   %d
-  if has("conceal") && has("syntax") && !has("nvim")
+  if has("conceal") && has("syntax")
     call setline(1, ['foo', 'bar', 'foobar'])
-    call test_override("char_avail", 1)
+    call Ntest_override("char_avail", 1)
     set conceallevel=2 concealcursor=n
     syn on
     syn match ErrorMsg "^bar"
@@ -782,7 +781,7 @@ func Test_edit_CTRL_L()
     call assert_equal(['foo', 'bar ', 'foobar'], getline(1, '$'))
     call assert_equal(1, g:change)
 
-    call test_override("char_avail", 0)
+    call Ntest_override("char_avail", 0)
     call clearmatches()
     syn off
     au! TextChangedI
@@ -1157,7 +1156,7 @@ func Test_edit_CTRL_V()
 
   " force some redraws
   set showmode showcmd
-  " call test_override('char_avail', 1)
+  call Ntest_override('char_avail', 1)
 
   call feedkeys("A\<c-v>\<c-n>\<c-v>\<c-l>\<c-v>\<c-b>\<esc>", 'tnix')
   call assert_equal(["abc\x0e\x0c\x02"], getline(1, '$'))
@@ -1172,7 +1171,7 @@ func Test_edit_CTRL_V()
   endif
 
   set noshowmode showcmd
-  " call test_override('char_avail', 0)
+  call Ntest_override('char_avail', 0)
 
   " No modifiers should be applied to the char typed using i_CTRL-V_digit.
   call feedkeys(":append\<CR>\<C-V>76c\<C-V>76\<C-F2>\<C-V>u3c0j\<C-V>u3c0\<M-F3>\<CR>.\<CR>", 'tnix')

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -1004,7 +1004,6 @@ func Test_popup_complete_backwards_ctrl_p()
 endfunc
 
 func Test_complete_o_tab()
-  CheckFunction test_override
   let s:o_char_pressed = 0
 
   fun! s:act_on_text_changed()
@@ -1022,12 +1021,12 @@ func Test_complete_o_tab()
   call setline(1,  ['hoard', 'hoax', 'hoarse', ''])
   let l:expected = ['hoard', 'hoax', 'hoarse', 'hoax', 'hoax']
   call cursor(4,1)
-  call test_override("char_avail", 1)
+  call Ntest_override("char_avail", 1)
   call feedkeys("Ahoa\<tab>\<tab>\<c-y>\<esc>", 'tx')
   call feedkeys("oho\<tab>\<tab>\<c-y>\<esc>", 'tx')
   call assert_equal(l:expected, getline(1,'$'))
 
-  call test_override("char_avail", 0)
+  call Ntest_override("char_avail", 0)
   bwipe!
   set completeopt&
   delfunc s:act_on_text_changed

--- a/test/old/testdir/test_quickfix.vim
+++ b/test/old/testdir/test_quickfix.vim
@@ -3096,16 +3096,15 @@ endfunc
 " Test for incsearch highlighting of the :vimgrep pattern
 " This test used to cause "E315: ml_get: invalid lnum" errors.
 func Test_vimgrep_incsearch()
-  CheckFunction test_override
   enew
   set incsearch
-  call test_override("char_avail", 1)
+  call Ntest_override("char_avail", 1)
 
   call feedkeys(":2vimgrep assert test_quickfix.vim test_cdo.vim\<CR>", "ntx")
   let l = getqflist()
   call assert_equal(2, len(l))
 
-  call test_override("ALL", 0)
+  call Ntest_override("ALL", 0)
   set noincsearch
 endfunc
 

--- a/test/old/testdir/test_search.vim
+++ b/test/old/testdir/test_search.vim
@@ -4,14 +4,12 @@ source shared.vim
 source screendump.vim
 source check.vim
 
-" See test/functional/legacy/search_spec.lua
 func Test_search_cmdline()
-  CheckFunction test_override
   CheckOption incsearch
 
   " need to disable char_avail,
   " so that expansion of commandline works
-  call test_override("char_avail", 1)
+  call Ntest_override("char_avail", 1)
   new
   call setline(1, ['  1', '  2 these', '  3 the', '  4 their', '  5 there', '  6 their', '  7 the', '  8 them', '  9 these', ' 10 foobar'])
   " Test 1
@@ -198,18 +196,16 @@ func Test_search_cmdline()
   call assert_equal('  3 the', getline('.'))
 
   " clean up
-  call test_override("char_avail", 0)
+  call Ntest_override("char_avail", 0)
   bw!
 endfunc
 
-" See test/functional/legacy/search_spec.lua
 func Test_search_cmdline2()
-  CheckFunction test_override
   CheckOption incsearch
 
   " need to disable char_avail,
   " so that expansion of commandline works
-  call test_override("char_avail", 1)
+  call Ntest_override("char_avail", 1)
   new
   call setline(1, ['  1', '  2 these', '  3 the theother'])
   " Test 1
@@ -275,7 +271,7 @@ func Test_search_cmdline2()
 
   " clean up
   set noincsearch
-  call test_override("char_avail", 0)
+  call Ntest_override("char_avail", 0)
   bw!
 endfunc
 
@@ -434,19 +430,17 @@ func Test_searchc()
 endfunc
 
 func Cmdline3_prep()
-  CheckFunction test_override
   " need to disable char_avail,
   " so that expansion of commandline works
-  call test_override("char_avail", 1)
+  call Ntest_override("char_avail", 1)
   new
   call setline(1, ['  1', '  2 the~e', '  3 the theother'])
   set incsearch
 endfunc
 
 func Incsearch_cleanup()
-  CheckFunction test_override
   set noincsearch
-  call test_override("char_avail", 0)
+  call Ntest_override("char_avail", 0)
   bw!
 endfunc
 
@@ -525,14 +519,12 @@ func Test_search_cmdline3v()
   call Incsearch_cleanup()
 endfunc
 
-" See test/functional/legacy/search_spec.lua
 func Test_search_cmdline4()
-  CheckFunction test_override
   CheckOption incsearch
 
   " need to disable char_avail,
   " so that expansion of commandline works
-  call test_override("char_avail", 1)
+  call Ntest_override("char_avail", 1)
   new
   call setline(1, ['  1 the first', '  2 the second', '  3 the third'])
   set incsearch
@@ -556,7 +548,7 @@ func Test_search_cmdline4()
   call assert_equal('  2 the second', getline('.'))
   " clean up
   set noincsearch
-  call test_override("char_avail", 0)
+  call Ntest_override("char_avail", 0)
   bw!
 endfunc
 
@@ -582,12 +574,11 @@ endfunc
 func Test_search_cmdline6()
   " Test that consecutive matches
   " are caught by <c-g>/<c-t>
-  CheckFunction test_override
   CheckOption incsearch
 
   " need to disable char_avail,
   " so that expansion of commandline works
-  call test_override("char_avail", 1)
+  call Ntest_override("char_avail", 1)
   new
   call setline(1, [' bbvimb', ''])
   set incsearch
@@ -615,12 +606,11 @@ func Test_search_cmdline6()
   " clean up
   set wrapscan&vim
   set noincsearch
-  call test_override("char_avail", 0)
+  call Ntest_override("char_avail", 0)
   bw!
 endfunc
 
 func Test_search_cmdline7()
-  CheckFunction test_override
   " Test that pressing <c-g> in an empty command line
   " does not move the cursor
   if !exists('+incsearch')
@@ -628,7 +618,7 @@ func Test_search_cmdline7()
   endif
   " need to disable char_avail,
   " so that expansion of commandline works
-  call test_override("char_avail", 1)
+  call Ntest_override("char_avail", 1)
   new
   let @/ = 'b'
   call setline(1, [' bbvimb', ''])
@@ -654,7 +644,7 @@ func Test_search_cmdline7()
   call assert_equal(4, col('.'))
 
   set noincsearch
-  call test_override("char_avail", 0)
+  call Ntest_override("char_avail", 0)
   bw!
 endfunc
 
@@ -765,13 +755,12 @@ func Test_search_regexp()
 endfunc
 
 func Test_search_cmdline_incsearch_highlight()
-  CheckFunction test_override
   CheckOption incsearch
 
   set incsearch hlsearch
   " need to disable char_avail,
   " so that expansion of commandline works
-  call test_override("char_avail", 1)
+  call Ntest_override("char_avail", 1)
   new
   call setline(1, ['aaa  1 the first', '  2 the second', '  3 the third'])
 
@@ -794,7 +783,7 @@ func Test_search_cmdline_incsearch_highlight()
 
   " clean up
   set noincsearch nohlsearch
-  call test_override("char_avail", 0)
+  call Ntest_override("char_avail", 0)
   bw!
 endfunc
 
@@ -884,10 +873,9 @@ func Test_search_cmdline_incsearch_highlight_attr()
 endfunc
 
 func Test_incsearch_cmdline_modifier()
-  CheckFunction test_override
   CheckOption incsearch
 
-  call test_override("char_avail", 1)
+  call Ntest_override("char_avail", 1)
   new
   call setline(1, ['foo'])
   set incsearch
@@ -1011,10 +999,9 @@ func Test_hlsearch_block_visual_match()
 endfunc
 
 func Test_incsearch_substitute()
-  CheckFunction test_override
   CheckOption incsearch
 
-  call test_override("char_avail", 1)
+  call Ntest_override("char_avail", 1)
   new
   set incsearch
   for n in range(1, 10)
@@ -1032,9 +1019,8 @@ func Test_incsearch_substitute()
 endfunc
 
 func Test_incsearch_substitute_long_line()
-  CheckFunction test_override
   new
-  call test_override("char_avail", 1)
+  call Ntest_override("char_avail", 1)
   set incsearch
 
   call repeat('x', 100000)->setline(1)
@@ -1313,13 +1299,12 @@ func Test_incsearch_vimgrep_dump()
 endfunc
 
 func Test_keep_last_search_pattern()
-  CheckFunction test_override
   CheckOption incsearch
 
   new
   call setline(1, ['foo', 'foo', 'foo'])
   set incsearch
-  call test_override("char_avail", 1)
+  call Ntest_override("char_avail", 1)
   let @/ = 'bar'
   call feedkeys(":/foo/s//\<Esc>", 'ntx')
   call assert_equal('bar', @/)
@@ -1329,18 +1314,17 @@ func Test_keep_last_search_pattern()
   call assert_equal('bar', @/)
 
   bwipe!
-  call test_override("ALL", 0)
+  call Ntest_override("ALL", 0)
   set noincsearch
 endfunc
 
 func Test_word_under_cursor_after_match()
-  CheckFunction test_override
   CheckOption incsearch
 
   new
   call setline(1, 'foo bar')
   set incsearch
-  call test_override("char_avail", 1)
+  call Ntest_override("char_avail", 1)
   try
     call feedkeys("/foo\<C-R>\<C-W>\<CR>", 'ntx')
   catch /E486:/
@@ -1348,24 +1332,23 @@ func Test_word_under_cursor_after_match()
   call assert_equal('foobar', @/)
 
   bwipe!
-  call test_override("ALL", 0)
+  call Ntest_override("ALL", 0)
   set noincsearch
 endfunc
 
 func Test_subst_word_under_cursor()
-  CheckFunction test_override
   CheckOption incsearch
 
   new
   call setline(1, ['int SomeLongName;', 'for (xxx = 1; xxx < len; ++xxx)'])
   set incsearch
-  call test_override("char_avail", 1)
+  call Ntest_override("char_avail", 1)
   call feedkeys("/LongName\<CR>", 'ntx')
   call feedkeys(":%s/xxx/\<C-R>\<C-W>/g\<CR>", 'ntx')
   call assert_equal('for (SomeLongName = 1; SomeLongName < len; ++SomeLongName)', getline(2))
 
   bwipe!
-  call test_override("ALL", 0)
+  call Ntest_override("ALL", 0)
   set noincsearch
 endfunc
 
@@ -1546,17 +1529,16 @@ func Test_one_error_msg()
 endfunc
 
 func Test_incsearch_add_char_under_cursor()
-  CheckFunction test_override
   CheckOption incsearch
 
   set incsearch
   new
   call setline(1, ['find match', 'anything'])
   1
-  call test_override('char_avail', 1)
+  call Ntest_override('char_avail', 1)
   call feedkeys("fc/m\<C-L>\<C-L>\<C-L>\<C-L>\<C-L>\<CR>", 'tx')
   call assert_equal('match', @/)
-  call test_override('char_avail', 0)
+  call Ntest_override('char_avail', 0)
 
   set incsearch&
   bwipe!


### PR DESCRIPTION
#### test(old): emulate test_override('char_avail') using FFI

Add a non-static variable for this, otherwise it'll be really hacky.
This avoids having to rewrite many incsearch tests in Lua.


#### fix(incsearch): include compsing characters with Ctrl-L 

Cherry-picked from Vim patch 8.1.0579.