### PR TITLE
feat(extui): show dismissed message in cmdline

### DIFF
--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -33,7 +33,7 @@ describe('messages2', function()
       ─────────────────────────────────────────────────────|
       {4:fo^o                                                  }|
       {4:bar                                                  }|
-      foo[+1]                             1,3           All|
+                                          1,3           All|
     ]])
     -- New message clears spill indicator.
     feed('Q')
@@ -45,38 +45,40 @@ describe('messages2', function()
       {4:bar                                                  }|
       {9:E354: Invalid register name: '^@'}   1,3           All|
     ]])
-    -- Multiple messages in same event loop iteration are appended.
-    feed([[q:echo "foo\nbar" | echo "baz"<CR>]])
+    -- Multiple messages in same event loop iteration are appended and shown in full.
+    feed([[q:echo "foo" | echo "bar\nbaz\n"->repeat(&lines)<CR>]])
     screen:expect([[
       ^                                                     |
-      {1:~                                                    }|*8
+      {1:~                                                    }|*5
       ─────────────────────────────────────────────────────|
-      {4:foo                                                  }|
-      {4:bar                                                  }|
-      {4:baz                                                  }|
-                                          0,0-1         All|
+      foo                                                  |
+      bar                                                  |
+      baz                                                  |
+      bar                                                  |
+      baz                                                  |
+      bar                                                  |
+      baz[+23]                                             |
     ]])
-    -- Any key press closes the routed pager.
+    -- Any key press resizes the cmdline and updates the spill indicator.
     feed('j')
     screen:expect([[
       ^                                                     |
       {1:~                                                    }|*12
-                                          0,0-1         All|
+      foo[+29]                            0,0-1         All|
     ]])
     -- No error for ruler virt_text msg_row exceeding buffer length.
     command([[map Q <cmd>echo "foo\nbar" <bar> ls<CR>]])
     feed('Q')
     screen:expect([[
       ^                                                     |
-      {1:~                                                    }|*7
+      {1:~                                                    }|*8
       ─────────────────────────────────────────────────────|
-      {4:foo                                                  }|
-      {4:bar                                                  }|
-      {4:                                                     }|
-      {4:  1 %a   "[No Name]"                    line 1       }|
-                                          0,0-1         All|
+      foo                                                  |
+      bar                                                  |
+                                                           |
+        1 %a   "[No Name]"                    line 1       |
     ]])
-    feed('<Esc>')
+    feed('<C-L>')
     screen:expect([[
       ^                                                     |
       {1:~                                                    }|*12


### PR DESCRIPTION
Problem:  An accidental key press can dismiss a routed message to be
          shown in full before the user was able to read it.
          'verbose' message routing based on an outdated condition results
          in "last_set" messages being separated from its message pair.
Solution: Show a message to be shown in full in the cmdline window instead
          of the pager. Keep it there and update the spill indicator when
          the message is dismissed.
          Remove the 'verbose' message routing.

Fix #34682
Fix #34760
