### PR TITLE
vim-patch:9.1.1506: tests: missing cleanup in Test_search_cmdline_incsearch_highlight()

### DIFF
--- a/test/old/testdir/test_search.vim
+++ b/test/old/testdir/test_search.vim
@@ -794,6 +794,7 @@ func Test_search_cmdline_incsearch_highlight()
 
   " clean up
   set noincsearch nohlsearch
+  call test_override("char_avail", 0)
   bw!
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.1506: tests: missing cleanup in Test_search_cmdline_incsearch_highlight()

Problem:  tests: missing cleanup test_override('char_avail', 0) in
          Test_search_cmdline_incsearch_highlight().
Solution: Add the missing cleanup (zeertzjq).

closes: vim/vim#17655

https://github.com/vim/vim/commit/29b29c6b303c891fa32ac14b0317fa4a342e0418