### PR TITLE
feat(lsp): handle deprecated document symbols

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -144,6 +144,11 @@ local constants = {
     TypeParameter = 26,
   },
 
+  -- Extra annotations that tweak the rendering of a symbol.
+  SymbolTag = {
+    Deprecated = 1,
+  },
+
   -- Represents reasons why a text document is saved.
   TextDocumentSaveReason = {
     -- Manually triggered, e.g. by the user pressing save, by starting debugging,
@@ -525,6 +530,9 @@ function protocol.make_client_capabilities()
           valueSet = get_value_set(constants.SymbolKind),
         },
         hierarchicalDocumentSymbolSupport = true,
+        tagSupport = {
+          valueSet = get_value_set(constants.SymbolTag),
+        },
       },
       rename = {
         dynamicRegistration = true,

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1892,6 +1892,11 @@ function M.symbols_to_items(symbols, bufnr, position_encoding)
       local end_lnum = range['end'].line + 1
       local end_col = get_line_byte_from_position(bufnr, range['end'], position_encoding) + 1
 
+      local is_deprecated = symbol.deprecated
+        or (symbol.tags and vim.tbl_contains(symbol.tags, protocol.SymbolTag.Deprecated))
+      local text =
+        string.format('[%s] %s%s', kind, symbol.name, is_deprecated and ' (deprecated)' or '')
+
       items[#items + 1] = {
         filename = filename,
         lnum = lnum,
@@ -1899,7 +1904,7 @@ function M.symbols_to_items(symbols, bufnr, position_encoding)
         end_lnum = end_lnum,
         end_col = end_col,
         kind = kind,
-        text = '[' .. kind .. '] ' .. symbol.name,
+        text = text,
       }
     end
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3234,6 +3234,89 @@ describe('LSP', function()
           end)
         )
       end)
+
+      it('handles deprecated items', function()
+        local expected = {
+          {
+            col = 1,
+            end_col = 1,
+            end_lnum = 2,
+            filename = '',
+            kind = 'File',
+            lnum = 2,
+            text = '[File] TestA (deprecated)',
+          },
+          {
+            col = 1,
+            end_col = 1,
+            end_lnum = 6,
+            filename = '',
+            kind = 'Namespace',
+            lnum = 6,
+            text = '[Namespace] TestC (deprecated)',
+          },
+        }
+        eq(
+          expected,
+          exec_lua(function()
+            local doc_syms = {
+              {
+                deprecated = true,
+                detail = 'A',
+                kind = 1,
+                name = 'TestA',
+                range = {
+                  start = {
+                    character = 0,
+                    line = 1,
+                  },
+                  ['end'] = {
+                    character = 0,
+                    line = 2,
+                  },
+                },
+                selectionRange = {
+                  start = {
+                    character = 0,
+                    line = 1,
+                  },
+                  ['end'] = {
+                    character = 4,
+                    line = 1,
+                  },
+                },
+              },
+              {
+                detail = 'C',
+                kind = 3,
+                name = 'TestC',
+                range = {
+                  start = {
+                    character = 0,
+                    line = 5,
+                  },
+                  ['end'] = {
+                    character = 0,
+                    line = 6,
+                  },
+                },
+                selectionRange = {
+                  start = {
+                    character = 0,
+                    line = 5,
+                  },
+                  ['end'] = {
+                    character = 4,
+                    line = 5,
+                  },
+                },
+                tags = { 1 }, -- deprecated
+              },
+            }
+            return vim.lsp.util.symbols_to_items(doc_syms, nil, 'utf-16')
+          end)
+        )
+      end)
     end)
 
     it('convert SymbolInformation[] to items', function()


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

Adding a visual annotation for deprecated document symbols. These can be indicated either with `symbol.deprecated` (which is the deprecated way lol) or via [symbol tags](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#symbolTag).