### PR TITLE
vim-patch:9.1.1507: symlinks are resolved on :cd commands

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1962,6 +1962,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 			character, the cursor won't move. When not included,
 			the cursor would skip over it and jump to the
 			following occurrence.
+								*cpo-~*
+		~	When included, don't resolve symbolic links when
+			changing directory with |:cd|, |:lcd|, or |:tcd|.
+			This preserves the symbolic link path in buffer names
+			and when displaying the current directory.  When
+			excluded (default), symbolic links are resolved to
+			their target paths.
 								*cpo-_*
 		_	When using |cw| on a word, do not include the
 			whitespace following the word in the motion.

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1515,6 +1515,13 @@ vim.bo.ci = vim.bo.copyindent
 --- 		character, the cursor won't move. When not included,
 --- 		the cursor would skip over it and jump to the
 --- 		following occurrence.
+--- 							*cpo-~*
+--- 	~	When included, don't resolve symbolic links when
+--- 		changing directory with `:cd`, `:lcd`, or `:tcd`.
+--- 		This preserves the symbolic link path in buffer names
+--- 		and when displaying the current directory.  When
+--- 		excluded (default), symbolic links are resolved to
+--- 		their target paths.
 --- 							*cpo-_*
 --- 	_	When using `cw` on a word, do not include the
 --- 		whitespace following the word in the motion.

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6016,7 +6016,7 @@ static void post_chdir(CdScope scope, bool trigger_dirchanged)
   }
 
   last_chdir_reason = NULL;
-  shorten_fnames(true);
+  shorten_fnames(vim_strchr(p_cpo, CPO_NOSYMLINKS) == NULL);
 
   if (trigger_dirchanged) {
     do_autocmd_dirchanged(cwd, scope, kCdCauseManual, false);

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -121,10 +121,11 @@
 #define CPO_REGAPPEND   '>'     // insert NL when appending to a register
 #define CPO_SCOLON      ';'     // using "," and ";" will skip over char if
                                 // cursor would not move
+#define CPO_NOSYMLINKS  '~'     // don't resolve symlinks when changing directory
 #define CPO_CHANGEW     '_'     // "cw" special-case
 // default values for Vim and Vi
 #define CPO_VIM         "aABceFs_"
-#define CPO_VI          "aAbBcCdDeEfFiIJKlLmMnoOpPqrRsStuvWxXyZ$!%+>;_"
+#define CPO_VI          "aAbBcCdDeEfFiIJKlLmMnoOpPqrRsStuvWxXyZ$!%+>;~_"
 
 // characters for p_ww option:
 #define WW_ALL          "bshl<>[]~"

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -2002,6 +2002,13 @@ local options = {
         		character, the cursor won't move. When not included,
         		the cursor would skip over it and jump to the
         		following occurrence.
+        							*cpo-~*
+        	~	When included, don't resolve symbolic links when
+        		changing directory with |:cd|, |:lcd|, or |:tcd|.
+        		This preserves the symbolic link path in buffer names
+        		and when displaying the current directory.  When
+        		excluded (default), symbolic links are resolved to
+        		their target paths.
         							*cpo-_*
         	_	When using |cw| on a word, do not include the
         		whitespace following the word in the motion.

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -2265,7 +2265,7 @@ func Test_VIM_POSIX()
     qall
   [CODE]
   if RunVim([], after, '')
-    call assert_equal(['aAbBcCdDeEfFgHiIjJkKlLmMnoOpPqrRsStuvwWxXyZ$!%*-+<>#{|&/\.;',
+    call assert_equal(['aAbBcCdDeEfFgHiIjJkKlLmMnoOpPqrRsStuvwWxXyZ$!%*-+<>#{|&/\.;~',
           \            'AS'], readfile('X_VIM_POSIX'))
   endif
 
@@ -2527,8 +2527,8 @@ func Test_string_option_revert_on_failure()
         \ ['completeopt', 'preview', 'a123'],
         "\ ['completepopup', 'width:20', 'border'],
         \ ['concealcursor', 'v', 'xyz'],
-        "\ ['cpoptions', 'HJ', '~'],
-        \ ['cpoptions', 'J', '~'],
+        "\ ['cpoptions', 'HJ', 'Q'],
+        \ ['cpoptions', 'J', 'Q'],
         "\ ['cryptmethod', 'zip', 'a123'],
         \ ['cursorlineopt', 'screenline', 'a123'],
         \ ['debug', 'throw', 'a123'],


### PR DESCRIPTION
Problem:  File paths change from symlink to target path after :cd command
          when editing files through symbolic links
Solution: Add "~" flag to 'cpoptions' to control symlink resolution.
          When not included (default), symlinks are resolved maintaining
          backward compatibility. When included, symlinks are preserved
          providing the improved behavior. (glepnir)

related: neovim/neovim#15695
closes: vim/vim#17628

https://github.com/vim/vim/commit/4ade668fb62ebf3f8be537fe451caed6bd1eba9

Fix https://github.com/neovim/neovim/issues/15695

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
