### PR TITLE
vim-patch:8.2.1983: ml_get error when using <Cmd> to open a terminal

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -104,6 +104,7 @@ typedef struct {
 typedef struct {
   pos_T search_start;   // where 'incsearch' starts searching
   pos_T save_cursor;
+  handle_T winid;       // window where this state is valid
   viewstate_T init_viewstate;
   viewstate_T old_viewstate;
   pos_T match_start;
@@ -257,6 +258,7 @@ static void restore_viewstate(win_T *wp, viewstate_T *vs)
 
 static void init_incsearch_state(incsearch_state_T *s)
 {
+  s->winid = curwin->handle;
   s->match_start = curwin->w_cursor;
   s->did_incsearch = false;
   s->incsearch_postponed = false;
@@ -1213,6 +1215,10 @@ static int command_line_execute(VimState *state, int key)
       do_cmdline(NULL, getcmdkeycmd, NULL, DOCMD_NOWAIT);
     } else {
       map_execute_lua(false);
+    }
+    // If the window changed incremental search state is not valid.
+    if (s->is_state.winid != curwin->handle) {
+      init_incsearch_state(&s->is_state);
     }
     // Re-apply 'incsearch' highlighting in case it was cleared.
     if (display_tick > display_tick_saved && s->is_state.did_incsearch) {

--- a/test/functional/ui/searchhl_spec.lua
+++ b/test/functional/ui/searchhl_spec.lua
@@ -682,6 +682,32 @@ describe('search highlighting', function()
     screen:expect_unchanged(true)
   end)
 
+  it('no ml_get error with incsearch and <Cmd> mapping that opens window', function()
+    command('cnoremap <F3> <Cmd>vnew<Bar>redraw!<CR>')
+    fn.setline(1, { 'foo', 'bar', 'baz' })
+    feed('G/z')
+    screen:expect([[
+      foo                                     |
+      bar                                     |
+      ba{2:z}                                     |
+      {1:~                                       }|*3
+      /z^                                      |
+    ]])
+    feed('<F3>')
+    screen:expect([[
+                          │foo                |
+      {1:~                   }│bar                |
+      {1:~                   }│baz                |
+      {1:~                   }│{1:~                  }|*2
+      {3:[No Name]            }{2:[No Name] [+]      }|
+      /z^                                      |
+    ]])
+    eq('', n.api.nvim_get_vvar('errmsg'))
+    feed('<C-G>')
+    screen:expect_unchanged(true)
+    eq('', n.api.nvim_get_vvar('errmsg'))
+  end)
+
   it('highlight is not after redraw during substitute confirm prompt', function()
     fn.setline(1, { 'foo', 'bar' })
     command('set nohlsearch')


### PR DESCRIPTION
#### vim-patch:8.2.1983: ml_get error when using \<Cmd> to open a terminal

Problem:    ml_get error when using \<Cmd> to open a terminal.
Solution:   If the window changed reset the incsearch state.

https://github.com/vim/vim/commit/f4d61bc559f8cb6adc4880183a4fd216865c0c30

Co-authored-by: Bram Moolenaar <Bram@vim.org>