### PR TITLE
refactor(getchar): rename test variable

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -872,9 +872,8 @@ Startup:
 Test functions:
 - test_alloc_fail()
 - test_autochdir()
-- test_disable_char_avail()
 - test_feedinput()
-- test_garbagecollect_soon
+- test_garbagecollect_soon()
 - test_getvalue()
 - test_ignore_error()
 - test_null_blob()
@@ -892,6 +891,8 @@ Test functions:
 - test_setmouse()
 - test_settime()
 - test_srand_seed()
+- test_unknown()
+- test_void()
 
 TUI:
                           *t_xx* *termcap-options* *t_AB* *t_Sb* *t_vb* *t_SI*

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -1866,7 +1866,7 @@ int vpeekc_any(void)
 /// @return  true if a character is available, false otherwise.
 bool char_avail(void)
 {
-  if (disable_char_avail_for_testing) {
+  if (test_disable_char_avail) {
     return false;
   }
   no_mapping++;

--- a/src/nvim/getchar.h
+++ b/src/nvim/getchar.h
@@ -17,7 +17,7 @@ typedef enum {
 
 enum { NSCRIPT = 15, };  ///< Maximum number of streams to read script from
 
-EXTERN bool disable_char_avail_for_testing INIT( = false);
+EXTERN bool test_disable_char_avail INIT( = false);
 
 #ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "getchar.h.generated.h"

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -171,7 +171,7 @@ if s:has_ffi
   lua << trim EOF
     require('ffi').cdef([[
       int starting;
-      bool disable_char_avail_for_testing;
+      bool test_disable_char_avail;
     ]])
   EOF
 endif
@@ -200,7 +200,7 @@ func Ntest_override(name, val)
   endif
 
   if a:name ==# 'char_avail' || a:name ==# 'ALL'
-    exe 'lua require("ffi").C.disable_char_avail_for_testing =' a:val
+    exe 'lua require("ffi").C.test_disable_char_avail =' a:val
   endif
 endfunc
 


### PR DESCRIPTION
Also, test_disable_char_avail() is superseded by test_override() in Vim,
so remove that from vim_diff.txt.

Follow-up to #34744