### PR TITLE
feat(messages): add "prev_cmd" argument to msg_history_show

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -72,6 +72,7 @@ EVENTS
   emitted after the screen is cleared. These events arbitrarily assumed a
   message UI that mimicks the legacy message grid. Benefit: reduced UI event
   traffic and more flexibility for UIs.
+  The `msg_history_show` event has an additional "prev_cmd" argument.
 • A new `empty` message kind is emitted for an empty (e.g. `:echo ""`) message.
 
 HIGHLIGHTS

--- a/runtime/doc/ui.txt
+++ b/runtime/doc/ui.txt
@@ -893,8 +893,11 @@ must handle.
 	statusline. `content` has the same format as in "msg_show". This event is
 	sent with empty `content` to hide the last message.
 
-["msg_history_show", entries] ~
-	Sent when |:messages| command is invoked. History is sent as a list of
-	entries, where each entry is a `[kind, content, append]` tuple.
+["msg_history_show", entries, prev_cmd] ~
+	Sent when |:messages| or |g<| command is invoked. History is sent as a
+	list of entries, where each entry is a `[kind, content, append]` tuple.
+
+	prev_cmd
+	    True when sent with |g<| command, false with |:messages|.
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -172,7 +172,7 @@ void msg_showmode(Array content)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 void msg_ruler(Array content)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
-void msg_history_show(Array entries)
+void msg_history_show(Array entries, Boolean prev_cmd)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
 
 // This UI event is currently undocumented.

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -1212,7 +1212,7 @@ void ex_messages(exarg_T *eap)
     }
   }
   if (kv_size(entries) > 0) {
-    ui_call_msg_history_show(entries);
+    ui_call_msg_history_show(entries, eap->skip != 0);
     api_free_array(entries);
   }
 }

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -140,6 +140,7 @@ describe('vim.ui_attach', function()
           { 'lua_print', { { 0, 'message2', 0 } }, false },
           { 'echomsg', { { 0, 'message3', 0 } }, false },
         },
+        false,
       },
     }, actual, vim.inspect(actual))
   end)

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -705,12 +705,7 @@ describe('ui/ext_messages', function()
       {1:~                        }|*4
     ]],
       cmdline = { { abort = false } },
-      msg_history = {
-        {
-          content = { { 'bork\nfail', 9, 6 } },
-          kind = 'echoerr',
-        },
-      },
+      msg_history = { { content = { { 'bork\nfail', 9, 6 } }, kind = 'echoerr' } },
     }
   end)
 
@@ -861,10 +856,7 @@ describe('ui/ext_messages', function()
       {1:~                        }|*2
     ]],
       cmdline = { { abort = false } },
-      msg_history = { {
-        content = { { 'stuff' } },
-        kind = 'echomsg',
-      } },
+      msg_history = { { content = { { 'stuff' } }, kind = 'echomsg' } },
     }
   end)
 
@@ -1571,6 +1563,7 @@ stack traceback:
         {1:~                        }|*4
       ]],
       msg_history = {
+        prev_cmd = true,
         { content = { { 'foo' } }, kind = 'echo' },
         { content = { { 'bar' } }, kind = 'echo' },
         { content = { { 'baz' } }, kind = 'echo', append = true },
@@ -1597,10 +1590,8 @@ stack traceback:
         {1:~                        }|*4
       ]],
       msg_history = {
-        {
-          content = { { "E354: Invalid register name: '^@'", 9, 6 } },
-          kind = 'emsg',
-        },
+        prev_cmd = true,
+        { content = { { "E354: Invalid register name: '^@'", 9, 6 } }, kind = 'emsg' },
       },
     })
   end)

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -1409,8 +1409,8 @@ function Screen:_handle_msg_ruler(msg)
   self.ruler = msg
 end
 
-function Screen:_handle_msg_history_show(entries)
-  self.msg_history = entries
+function Screen:_handle_msg_history_show(entries, prev_cmd)
+  self.msg_history = { entries, prev_cmd }
 end
 
 function Screen:_clear_block(grid, top, bot, left, right)
@@ -1510,8 +1510,8 @@ function Screen:_extstate_repr(attr_state)
     }
   end
 
-  local msg_history = {}
-  for i, entry in ipairs(self.msg_history) do
+  local msg_history = { prev_cmd = self.msg_history[2] or nil }
+  for i, entry in ipairs(self.msg_history[1] or {}) do
     msg_history[i] = {
       kind = entry[1],
       content = self:_chunks_repr(entry[2], attr_state),


### PR DESCRIPTION
Problem:  Unable to tell whether msg_history_show event is emitted for a
          :messages or g< command.
Solution: Add "prev_cmd" argument that is set to true for g<.