### PR TITLE
feat: ":restart +cmd"

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -75,8 +75,8 @@ Restart Nvim
                 |v:argv| and reattaches the current UI to the new server.
                 All other UIs will detach.
 
-                This fails when changes have been made and Vim refuses to
-                |abandon| the current buffer.
+                This fails when changes have been made.
+                Use `:confirm restart` to override.
 
                 Note: If the current UI hasn't implemented the "restart" UI
                 event, this command is equivalent to `:qall`.

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -75,12 +75,11 @@ Restart Nvim
                 |v:argv| and reattaches the current UI to the new server.
                 All other UIs will detach.
 
-                This fails when changes have been made.
-                Use `:confirm restart` to override.
+                Use with `:confirm` to prompt if changes have been made.
 
                 Example: `:restart +qall!` stops the server using `:qall!`.
 
-                Note: |+cmd| defaults to `qall` if not specified.
+                Note: |+cmd| defaults to `qall!` if not specified.
                 Note: If the current UI hasn't implemented the "restart" UI
                 event, this command is equivalent to `:qall`.
                 Note: Only works if the UI and server are on the same system.

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -82,9 +82,6 @@ Restart Nvim
                 event, this command is equivalent to `:qall`.
                 Note: Only works if the UI and server are on the same system.
 
-:restart!
-                Force restarts the Nvim server, abandoning unsaved buffers.
-
 ------------------------------------------------------------------------------
 GUI commands
 

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -70,7 +70,7 @@ Stop or detach the current UI
 Restart Nvim
 
                                                 *:restart*
-:restart
+:restart [+cmd]
                 Restarts the Nvim server with the same startup arguments
                 |v:argv| and reattaches the current UI to the new server.
                 All other UIs will detach.
@@ -78,6 +78,9 @@ Restart Nvim
                 This fails when changes have been made.
                 Use `:confirm restart` to override.
 
+                Example: `:restart +qall!` stops the server using `:qall!`.
+
+                Note: |+cmd| defaults to `qall` if not specified.
                 Note: If the current UI hasn't implemented the "restart" UI
                 event, this command is equivalent to `:qall`.
                 Note: Only works if the UI and server are on the same system.

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -2248,7 +2248,7 @@ M.cmds = {
   },
   {
     command = 'restart',
-    flags = bit.bor(BANG, CMDARG, TRLBAR),
+    flags = bit.bor(CMDARG, TRLBAR),
     addr_type = 'ADDR_NONE',
     func = 'ex_restart',
   },

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -2184,13 +2184,13 @@ M.cmds = {
     command = 'quitall',
     flags = bit.bor(BANG, TRLBAR),
     addr_type = 'ADDR_NONE',
-    func = 'ex_quitall_or_restart',
+    func = 'ex_quitall',
   },
   {
     command = 'qall',
     flags = bit.bor(BANG, TRLBAR, CMDWIN, LOCK_OK),
     addr_type = 'ADDR_NONE',
-    func = 'ex_quitall_or_restart',
+    func = 'ex_quitall',
   },
   {
     command = 'read',
@@ -2250,7 +2250,7 @@ M.cmds = {
     command = 'restart',
     flags = bit.bor(BANG, CMDARG, TRLBAR),
     addr_type = 'ADDR_NONE',
-    func = 'ex_quitall_or_restart',
+    func = 'ex_restart',
   },
   {
     command = 'retab',

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -2248,7 +2248,7 @@ M.cmds = {
   },
   {
     command = 'restart',
-    flags = bit.bor(BANG, TRLBAR),
+    flags = bit.bor(BANG, CMDARG, TRLBAR),
     addr_type = 'ADDR_NONE',
     func = 'ex_quitall_or_restart',
   },

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4850,14 +4850,13 @@ static void ex_quitall(exarg_T *eap)
   getout(0);
 }
 
-/// ":restart": restart the Nvim server (using ":qall").
+/// ":restart": restart the Nvim server (using ":qall!").
 /// ":restart +cmd": restart the Nvim server using ":cmd".
 static void ex_restart(exarg_T *eap)
 {
-  char *quit_cmd = (eap->do_ecmd_cmd) ? eap->do_ecmd_cmd : "qall";
+  char *quit_cmd = (eap->do_ecmd_cmd) ? eap->do_ecmd_cmd : "qall!";
   Error err = ERROR_INIT;
-  if (quit_cmd[strlen(quit_cmd) - 1] != '!' && check_changed_any(false,
-                                                                 false)) {
+  if ((cmdmod.cmod_flags & CMOD_CONFIRM) && check_changed_any(false, false)) {
     return;
   }
   restarting = true;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4841,7 +4841,7 @@ static void ex_quitall_or_restart(exarg_T *eap)
   if ((eap->forceit || !check_changed_any(false, false))
       && (eap->cmdidx != CMD_restart || remote_ui_restart(current_ui, &err))) {
     if (eap->cmdidx == CMD_restart) {
-      char *quit_cmd = (eap->do_ecmd_cmd) ? eap->do_ecmd_cmd : "qall";
+      char *quit_cmd = (eap->do_ecmd_cmd) ? eap->do_ecmd_cmd : (eap->forceit) ? "qall!" : "qall";
       nvim_command(cstr_as_string(quit_cmd), &err);
       if (ERROR_SET(&err)) {
         emsg(err.msg);  // Could not exit

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4836,7 +4836,7 @@ static void ex_quitall(exarg_T *eap)
     return;
   }
   exiting = true;
-  if (eap->forceit || !check_changed_any(false, false)) {
+  if (!eap->forceit && check_changed_any(false, false)) {
     not_exiting();
     return;
   }
@@ -4866,12 +4866,10 @@ static void ex_restart(exarg_T *eap)
     api_clear_error(&err);
     return;
   }
-  // XXX: Cannot do this as `exiting` isn't set to `true` early enough by commands that actually
-  // quit the server and it would still call `getout(0)`.
-  // if (!exiting) {
-  //   ELOG("':%s' did not quit the server, quitting manually", quit_cmd);
-  //   getout(0);
-  // }
+  if (!exiting) {
+    ELOG("':%s' did not quit the server, quitting manually", quit_cmd);
+    getout(0);
+  }
 }
 
 /// ":close": close current window, unless it is the last one

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4847,10 +4847,6 @@ static void ex_quitall(exarg_T *eap)
 /// ":restart +cmd": restart the Nvim server using ":cmd".
 static void ex_restart(exarg_T *eap)
 {
-  if (eap->forceit) {
-    emsg("bang (!) not supported");
-    return;
-  }
   Error err = ERROR_INIT;
   if (check_changed_any(false, false) || !remote_ui_restart(current_ui, &err)) {
     if (ERROR_SET(&err)) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4868,7 +4868,7 @@ static void ex_restart(exarg_T *eap)
     return;
   }
   if (!exiting) {
-    emsg("restart failed: +cmd did not quit the server, abandoning restart");
+    emsg("restart failed: +cmd did not quit the server");
     not_restarting();
   }
 }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4868,7 +4868,7 @@ static void ex_restart(exarg_T *eap)
     return;
   }
   if (!exiting) {
-    emsg("':cmd' did not quit the server, abandoning restart");
+    emsg("restart failed: +cmd did not quit the server, abandoning restart");
     not_restarting();
   }
 }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -179,8 +179,6 @@ struct dbg_stuff {
 
 static char dollar_command[2] = { '$', 0 };
 
-static char *quit_commands[6] = { "qall",  "qa", "q", "q!", "qa!", "qall!" };
-
 static void save_dbg_stuff(struct dbg_stuff *dsp)
 {
   dsp->trylevel = trylevel;
@@ -4703,6 +4701,13 @@ void not_exiting(void)
   exiting = false;
 }
 
+/// Call this function if we thought we were going to restart, but we won't
+/// (because of an error).
+void not_restarting(void)
+{
+  restarting = false;
+}
+
 bool before_quit_autocmds(win_T *wp, bool quit_all, bool forceit)
 {
   apply_autocmds(EVENT_QUITPRE, NULL, NULL, false, wp->w_buffer);
@@ -4845,44 +4850,27 @@ static void ex_quitall(exarg_T *eap)
   getout(0);
 }
 
-static bool cmd_will_quit_server(char *cmd)
-{
-  for (size_t i = 0; i < ARRAY_SIZE(quit_commands); i++) {
-    if (strequal(cmd, quit_commands[i])) {
-      return true;
-    }
-  }
-  return false;
-}
-
 /// ":restart": restart the Nvim server (using ":qall").
 /// ":restart +cmd": restart the Nvim server using ":cmd".
 static void ex_restart(exarg_T *eap)
 {
   char *quit_cmd = (eap->do_ecmd_cmd) ? eap->do_ecmd_cmd : "qall";
-  if (!cmd_will_quit_server(quit_cmd)) {
-    emsg("':cmd' does not quit the server, abandoning restart");
-    return;
-  }
   Error err = ERROR_INIT;
-  if ((quit_cmd[vim_strsize(quit_cmd) - 1] != '!' && check_changed_any(false,
-                                                                       false))
-      || !remote_ui_restart(current_ui, &err)) {
-    if (ERROR_SET(&err)) {
-      emsg(err.msg);  // UI disappeared already?
-      api_clear_error(&err);
-    }
+  if (quit_cmd[vim_strsize(quit_cmd) - 1] != '!' && check_changed_any(false,
+                                                                      false)) {
     return;
   }
+  restarting = true;
   nvim_command(cstr_as_string(quit_cmd), &err);
   if (ERROR_SET(&err)) {
     emsg(err.msg);  // Could not exit
     api_clear_error(&err);
+    not_restarting();
     return;
   }
   if (!exiting) {
-    ELOG("':%s' did not quit the server, quitting manually", quit_cmd);
-    getout(0);
+    emsg("':cmd' did not quit the server, abandoning restart");
+    not_restarting();
   }
 }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4856,8 +4856,8 @@ static void ex_restart(exarg_T *eap)
 {
   char *quit_cmd = (eap->do_ecmd_cmd) ? eap->do_ecmd_cmd : "qall";
   Error err = ERROR_INIT;
-  if (quit_cmd[vim_strsize(quit_cmd) - 1] != '!' && check_changed_any(false,
-                                                                      false)) {
+  if (quit_cmd[strlen(quit_cmd) - 1] != '!' && check_changed_any(false,
+                                                                 false)) {
     return;
   }
   restarting = true;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4847,7 +4847,7 @@ static void ex_quitall(exarg_T *eap)
 
 static bool cmd_will_quit_server(char *cmd)
 {
-  for (size_t i = 0; i < ARRAY_SIZE(quit_commands); ++i) {
+  for (size_t i = 0; i < ARRAY_SIZE(quit_commands); i++) {
     if (strequal(cmd, quit_commands[i])) {
       return true;
     }

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -423,6 +423,8 @@ EXTERN int sc_col;              // column for shown command
 EXTERN int starting INIT( = NO_SCREEN);
 // true when planning to exit. Might keep running if there is a changed buffer.
 EXTERN bool exiting INIT( = false);
+// true when planning to restart.
+EXTERN bool restarting INIT( = false);
 // internal value of v:dying
 EXTERN int v_dying INIT( = 0);
 // is stdin a terminal?

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -664,16 +664,6 @@ void os_exit(int r)
   FUNC_ATTR_NORETURN
 {
   exiting = true;
-  if (restarting) {
-    Error err = ERROR_INIT;
-    if (!remote_ui_restart(current_ui, &err)) {
-      if (ERROR_SET(&err)) {
-        ELOG("%s", err.msg);  // UI disappeared already?
-        api_clear_error(&err);
-      }
-    }
-    restarting = false;
-  }
 
   if (ui_client_channel_id) {
     ui_client_stop();
@@ -817,6 +807,17 @@ void getout(int exitval)
   // Apply 'titleold'.
   if (p_title && *p_titleold != NUL) {
     ui_call_set_title(cstr_as_string(p_titleold));
+  }
+
+  if (restarting) {
+    Error err = ERROR_INIT;
+    if (!remote_ui_restart(current_ui, &err)) {
+      if (ERROR_SET(&err)) {
+        ELOG("%s", err.msg);  // UI disappeared already?
+        api_clear_error(&err);
+      }
+    }
+    restarting = false;
   }
 
   if (garbage_collect_at_exit) {

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -664,6 +664,16 @@ void os_exit(int r)
   FUNC_ATTR_NORETURN
 {
   exiting = true;
+  if (restarting) {
+    Error err = ERROR_INIT;
+    if (!remote_ui_restart(current_ui, &err)) {
+      if (ERROR_SET(&err)) {
+        ELOG("%s", err.msg);  // UI disappeared already?
+        api_clear_error(&err);
+      }
+    }
+    restarting = false;
+  }
 
   if (ui_client_channel_id) {
     ui_client_stop();

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -285,7 +285,7 @@ describe('TUI :restart', function()
 
     -- Check ":confirm restart" on a modified buffer.
     tt.feed_data(':confirm restart\013')
-    screen:expect({ any = 'Save changes to "Untitled"?' })
+    screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
 
     -- Cancel the operation (abandons restart).
     tt.feed_data('C\013')

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -283,20 +283,15 @@ describe('TUI :restart', function()
       {5:-- TERMINAL --}                                    |
     ]])
 
-    -- Check ":restart" on a modified buffer.
-    tt.feed_data(':restart\013')
-    screen_expect([[
-      this will be removed                              |
-      {3:                                                  }|
-      {101:E37: No write since last change}                   |
-      {101:E162: No write since last change for buffer "[No N}|
-      {101:ame]"}                                             |
-      {102:Press ENTER or type command to continue}^           |
-      {5:-- TERMINAL --}                                    |
-    ]])
+    -- Check ":confirm restart" on a modified buffer.
+    tt.feed_data(':confirm restart\013')
+    screen:expect({ any = 'Save changes to "Untitled"?' })
 
-    -- Check ":restart +qall!".
-    tt.feed_data(':restart +qall!\013')
+    -- Cancel the operation (abandons restart).
+    tt.feed_data('C\013')
+
+    -- Check ":restart" on the modified buffer.
+    tt.feed_data(':restart\013')
     screen_expect(s0)
     restart_pid_check()
     gui_running_check()
@@ -3738,9 +3733,9 @@ describe('TUI client', function()
     screen_client:expect(s1)
     screen_server:expect(s1)
 
-    -- Run :restart +qall! on the remote client.
+    -- Run :restart on the remote client.
     -- The remote client should start a new server while the original one should exit.
-    feed_data(':restart +qall!\n')
+    feed_data(':restart\n')
     screen_client:expect([[
       ^                                                  |
       {100:~                                                 }|*3
@@ -3815,12 +3810,12 @@ describe('TUI client', function()
     feed_data(':echo "GUI Running: " .. has("gui_running")\013')
     screen_client:expect({ any = 'GUI Running: 1' })
 
-    -- Run :restart +qall! on the client.
+    -- Run :restart on the client.
     -- The client should start a new server while the original server should exit.
-    feed_data(':restart +qall!\n')
+    feed_data(':restart\n')
     screen_client:expect([[
       ^                                                  |
-      {4:~                                                 }|*4
+      {100:~                                                 }|*4
                                                         |
       {5:-- TERMINAL --}                                    |
     ]])

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -299,7 +299,7 @@ describe('TUI :restart', function()
 
     -- Check ":confirm restart".
     tt.feed_data(':confirm restart\013')
-    screen:expect({ any = vim.pesc('{10:Save changes to "Untitled"?}') })
+    screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
 
     tt.feed_data('N\013')
     screen_expect(s0)
@@ -3743,9 +3743,12 @@ describe('TUI client', function()
     screen_client:expect(s1)
     screen_server:expect(s1)
 
-    -- Run :restart! on the remote client.
+    -- Run :confirm restart on the remote client.
     -- The remote client should start a new server while the original one should exit.
-    feed_data(':restart!\n')
+    feed_data(':confirm restart\n')
+    screen_client:expect({ any = vim.pesc('Save changes to "Untitled"?') })
+
+    tt.feed_data('N\013')
     screen_client:expect([[
       ^                                                  |
       {100:~                                                 }|*3
@@ -3820,9 +3823,12 @@ describe('TUI client', function()
     feed_data(':echo "GUI Running: " .. has("gui_running")\013')
     screen_client:expect({ any = 'GUI Running: 1' })
 
-    -- Run :restart! on the client.
+    -- Run :confirm restart on the client.
     -- The client should start a new server while the original server should exit.
-    feed_data(':restart!\n')
+    feed_data(':confirm restart\n')
+    screen_client:expect({ any = vim.pesc('Save changes to "Untitled"?') })
+
+    tt.feed_data('N\013')
     screen_client:expect([[
       ^                                                  |
       {4:~                                                 }|*4

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -264,6 +264,18 @@ describe('TUI :restart', function()
     restart_pid_check()
     gui_running_check()
 
+    -- Check ":restart +qall" on an unmodified buffer.
+    tt.feed_data(':restart +qall\013')
+    screen_expect(s0)
+    restart_pid_check()
+    gui_running_check()
+
+    -- Check ":restart +echo" still restarts the server.
+    tt.feed_data(':restart +echo\013')
+    screen_expect(s0)
+    restart_pid_check()
+    gui_running_check()
+
     tt.feed_data('ithis will be removed\027')
     screen_expect([[
       this will be remove^d                              |
@@ -285,8 +297,11 @@ describe('TUI :restart', function()
       {5:-- TERMINAL --}                                    |
     ]])
 
-    -- Check ":restart!".
-    tt.feed_data(':restart!\013')
+    -- Check ":confirm restart".
+    tt.feed_data(':confirm restart\013')
+    screen:expect({ any = vim.pesc('{10:Save changes to "Untitled"?}') })
+
+    tt.feed_data('N\013')
     screen_expect(s0)
     restart_pid_check()
     gui_running_check()

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -272,7 +272,7 @@ describe('TUI :restart', function()
 
     -- Check ":restart +echo" cannot restart server.
     tt.feed_data(':restart +echo\013')
-    screen:expect({ any = '+cmd did not quit the server' })
+    screen:expect({ any = vim.pesc('+cmd did not quit the server') })
 
     tt.feed_data('ithis will be removed\027')
     screen_expect([[

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -272,7 +272,7 @@ describe('TUI :restart', function()
 
     -- Check ":restart +echo" cannot restart server.
     tt.feed_data(':restart +echo\013')
-    screen:expect({ any = "':cmd' does not quit the server" })
+    screen:expect({ any = "':cmd' did not quit the server" })
 
     tt.feed_data('ithis will be removed\027')
     screen_expect([[

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -272,7 +272,7 @@ describe('TUI :restart', function()
 
     -- Check ":restart +echo" cannot restart server.
     tt.feed_data(':restart +echo\013')
-    screen:expect({ any = "':cmd' did not quit the server" })
+    screen:expect({ any = '+cmd did not quit the server' })
 
     tt.feed_data('ithis will be removed\027')
     screen_expect([[

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -295,11 +295,8 @@ describe('TUI :restart', function()
       {5:-- TERMINAL --}                                    |
     ]])
 
-    -- Check ":confirm restart".
-    tt.feed_data(':confirm restart\013')
-    screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
-
-    tt.feed_data('N\013')
+    -- Check ":restart +qall!".
+    tt.feed_data(':restart +qall!\013')
     screen_expect(s0)
     restart_pid_check()
     gui_running_check()
@@ -3741,12 +3738,9 @@ describe('TUI client', function()
     screen_client:expect(s1)
     screen_server:expect(s1)
 
-    -- Run :confirm restart on the remote client.
+    -- Run :restart +qall! on the remote client.
     -- The remote client should start a new server while the original one should exit.
-    feed_data(':confirm restart\n')
-    screen_client:expect({ any = vim.pesc('Save changes to "Untitled"?') })
-
-    tt.feed_data('N\013')
+    feed_data(':restart +qall!\n')
     screen_client:expect([[
       ^                                                  |
       {100:~                                                 }|*3
@@ -3821,12 +3815,9 @@ describe('TUI client', function()
     feed_data(':echo "GUI Running: " .. has("gui_running")\013')
     screen_client:expect({ any = 'GUI Running: 1' })
 
-    -- Run :confirm restart on the client.
+    -- Run :restart +qall! on the client.
     -- The client should start a new server while the original server should exit.
-    feed_data(':confirm restart\n')
-    screen_client:expect({ any = vim.pesc('Save changes to "Untitled"?') })
-
-    tt.feed_data('N\013')
+    feed_data(':restart +qall!\n')
     screen_client:expect([[
       ^                                                  |
       {4:~                                                 }|*4

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -270,11 +270,9 @@ describe('TUI :restart', function()
     restart_pid_check()
     gui_running_check()
 
-    -- Check ":restart +echo" still restarts the server.
+    -- Check ":restart +echo" cannot restart server.
     tt.feed_data(':restart +echo\013')
-    screen_expect(s0)
-    restart_pid_check()
-    gui_running_check()
+    screen:expect({ any = "':cmd' does not quit the server" })
 
     tt.feed_data('ithis will be removed\027')
     screen_expect([[

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -3810,7 +3810,7 @@ describe('TUI client', function()
     feed_data(':restart!\n')
     screen_client:expect([[
       ^                                                  |
-      {100:~                                                 }|*4
+      {3:~}                                                 |*4
                                                         |
       {5:-- TERMINAL --}                                    |
     ]])

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -3810,7 +3810,7 @@ describe('TUI client', function()
     feed_data(':restart!\n')
     screen_client:expect([[
       ^                                                  |
-      {3:~}                                                 |*4
+      {4:~                                                 }|*4
                                                         |
       {5:-- TERMINAL --}                                    |
     ]])


### PR DESCRIPTION
### Problem:
":restart" always executes ":qall" on the server in order to exit it. 
https://github.com/neovim/neovim/pull/33953#discussion_r2119590367

### Solution:
Add an arg to ":restart" as ":restart +cmd" to control how the server exits.
