### PR TITLE
fix(lsp): consistent use of `vim.notify` in `lsp/buf.lua`

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -872,7 +872,7 @@ local hierarchy_methods = {
 local function hierarchy(method)
   local kind = hierarchy_methods[method]
   if not kind then
-    error('unsupported method ' .. method)
+    vim.notify(lsp._unsupported_method(method), vim.log.levels.WARN)
   end
 
   local prepare_method = kind == 'type' and ms.textDocument_prepareTypeHierarchy
@@ -1275,9 +1275,7 @@ function M.code_action(opts)
   local win = api.nvim_get_current_win()
   local clients = lsp.get_clients({ bufnr = bufnr, method = ms.textDocument_codeAction })
   if not next(clients) then
-    if next(lsp.get_clients({ bufnr = bufnr })) then
-      vim.notify(lsp._unsupported_method(ms.textDocument_codeAction), vim.log.levels.WARN)
-    end
+    vim.notify(lsp._unsupported_method(ms.textDocument_codeAction), vim.log.levels.WARN)
     return
   end
 

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -128,13 +128,6 @@ function M.hover(config)
     -- Remove last linebreak ('---')
     contents[#contents] = nil
 
-    if vim.tbl_isempty(contents) then
-      if config.silent ~= true then
-        vim.notify('No information available')
-      end
-      return
-    end
-
     local _, winid = lsp.util.open_floating_preview(contents, format, config)
 
     api.nvim_create_autocmd('WinClosed', {


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

Minor fixes:
- Hover doesn't need to check if `contents` is empty since we check if the results are empty [here](https://github.com/neovim/neovim/blob/e34e2289c22834239e0522b7331f17fdfb3705e0/runtime/lua/vim/lsp/buf.lua#L74).
- Let's use `lsp.__unsupported_method` in `hierarchy` for consistency.
- Removing an extra (?) call to `get_clients` from the code actions handler.