### PR TITLE
fix(health): floating window closes when opening TOC (gO)

### DIFF
--- a/runtime/ftplugin/checkhealth.lua
+++ b/runtime/ftplugin/checkhealth.lua
@@ -1,5 +1,5 @@
 vim.keymap.set('n', 'gO', function()
-  require('vim.treesitter._headings').show_toc()
+  require('vim.treesitter._headings').show_toc(6)
 end, { buffer = 0, silent = true, desc = 'Show an Outline of the current buffer' })
 
 vim.keymap.set('n', ']]', function()

--- a/runtime/lua/vim/health.lua
+++ b/runtime/lua/vim/health.lua
@@ -389,15 +389,17 @@ function M._check(mods, plugin_names)
     and type(vim.g.health) == 'table'
     and vim.tbl_get(vim.g.health, 'style') == 'float'
   then
-    local max_height = math.floor(vim.o.lines * 0.8)
+    local available_lines = vim.o.lines - 12
+    local max_height = math.min(math.floor(vim.o.lines * 0.8), available_lines)
     local max_width = 80
     local float_winid
     bufnr, float_winid = vim.lsp.util.open_floating_preview({}, '', {
       height = max_height,
       width = max_width,
       offset_x = math.floor((vim.o.columns - max_width) / 2),
-      offset_y = math.floor((vim.o.lines - max_height) / 2) - 1,
+      offset_y = math.floor((available_lines - max_height) / 2),
       relative = 'editor',
+      close_events = {},
     })
     vim.api.nvim_set_current_win(float_winid)
     vim.bo[bufnr].modifiable = true

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1422,10 +1422,17 @@ local function close_preview_autocmd(events, winnr, bufnrs)
 
   -- close the preview window when entered a buffer that is not
   -- the floating window buffer or the buffer that spawned it
-  api.nvim_create_autocmd('BufEnter', {
+  api.nvim_create_autocmd('BufLeave', {
     group = augroup,
+    buffer = bufnrs[1],
     callback = function()
-      close_preview_window(winnr, bufnrs)
+      vim.schedule(function()
+        -- When jumping to the quickfix window from the preview window,
+        -- do not close the preview window.
+        if api.nvim_get_option_value('filetype', { buf = 0 }) ~= 'qf' then
+          close_preview_window(winnr, bufnrs)
+        end
+      end)
     end,
   })
 

--- a/runtime/lua/vim/treesitter/_headings.lua
+++ b/runtime/lua/vim/treesitter/_headings.lua
@@ -83,8 +83,9 @@ local get_headings = function(bufnr)
   return headings
 end
 
+--- @param qf_height? integer height of loclist window
 --- Shows an Outline (table of contents) of the current buffer, in the loclist.
-function M.show_toc()
+function M.show_toc(qf_height)
   local bufnr = api.nvim_get_current_buf()
   local bufname = api.nvim_buf_get_name(bufnr)
   local headings = get_headings(bufnr)
@@ -98,7 +99,7 @@ function M.show_toc()
   end
   vim.fn.setloclist(0, headings, ' ')
   vim.fn.setloclist(0, {}, 'a', { title = 'Table of contents' })
-  vim.cmd.lopen()
+  vim.cmd.lopen(qf_height)
   vim.w.qf_toc = bufname
   -- reload syntax file after setting qf_toc variable
   vim.bo.filetype = 'qf'

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -68,7 +68,10 @@ describe(':checkhealth', function()
   end)
 
   it('vim.g.health', function()
-    clear()
+    clear {
+      args_rm = { '-u' },
+      args = { '--clean', '+set runtimepath+=test/functional/fixtures' },
+    }
     command("let g:health = {'style':'float'}")
     command('checkhealth lsp')
     eq(
@@ -77,6 +80,14 @@ describe(':checkhealth', function()
       return vim.api.nvim_win_get_config(0).relative
     ]])
     )
+
+    -- gO should not close the :checkhealth floating window. #34784
+    command('checkhealth full_render')
+    local win = api.nvim_get_current_win()
+    api.nvim_win_set_cursor(win, { 5, 1 })
+    n.feed('gO')
+    eq(true, api.nvim_win_is_valid(win))
+    eq('qf', api.nvim_get_option_value('filetype', { buf = 0 }))
   end)
 
   it("vim.provider works with a misconfigured 'shell'", function()


### PR DESCRIPTION
Problem: Health check floating window gets closed when pressing 'gO' to show TOC because LSP floating preview system auto-closes on BufEnter events triggered by :lopen.

Solution: Temporarily disable BufEnter event for the current window during TOC operations and adjust window layout to prevent overlap.

Fix #34784

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
