### PR TITLE
vim-patch:9.1.1512: completion: can only complete from keyword characters

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -628,7 +628,7 @@ Completion can be done for:
 10. User defined completion				|i_CTRL-X_CTRL-U|
 11. omni completion					|i_CTRL-X_CTRL-O|
 12. Spelling suggestions				|i_CTRL-X_s|
-13. keywords in 'complete'				|i_CTRL-N| |i_CTRL-P|
+13. completions from 'complete'				|i_CTRL-N| |i_CTRL-P|
 14. contents from registers				|i_CTRL-X_CTRL-R|
 
 Additionally, |i_CTRL-X_CTRL-Z| stops completion without changing the text.
@@ -1082,25 +1082,23 @@ CTRL-X s		Locate the word in front of the cursor and find the
 			previous one.
 
 
-Completing keywords from different sources		*compl-generic*
+Completing from different sources			*compl-generic*
 
 							*i_CTRL-N*
-CTRL-N			Find next match for words that start with the
-			keyword in front of the cursor, looking in places
-			specified with the 'complete' option.  The found
-			keyword is inserted in front of the cursor.
+CTRL-N			Find the next match for a word ending at the cursor,
+			using the sources specified in the 'complete' option.
+			All sources complete from keywords, except functions,
+			which may complete from non-keyword.  The matched
+			text is inserted before the cursor.
 
 							*i_CTRL-P*
-CTRL-P			Find previous match for words that start with the
-			keyword in front of the cursor, looking in places
-			specified with the 'complete' option.  The found
-			keyword is inserted in front of the cursor.
+CTRL-P			Same as CTRL-N, but find the previous match.
 
-	CTRL-N		Search forward for next matching keyword.  This
-			keyword replaces the previous matching keyword.
+	CTRL-N		Search forward through the matches and insert the
+			next one.
 
-	CTRL-P		Search backwards for next matching keyword.  This
-			keyword replaces the previous matching keyword.
+	CTRL-P		Search backward through the matches and insert the
+			previous one.
 
 	CTRL-X CTRL-N or
 	CTRL-X CTRL-P	Further use of CTRL-X CTRL-N or CTRL-X CTRL-P will

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1512,15 +1512,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 		name of a function or a |Funcref|.  For |Funcref| values,
 		spaces must be escaped with a backslash ('\'), and commas with
 		double backslashes ('\\') (see |option-backslash|).
+		Unlike other sources, functions can provide completions starting
+		from a non-keyword character before the cursor, and their
+		start position for replacing text may differ from other sources.
 		If the Dict returned by the {func} includes {"refresh": "always"},
 		the function will be invoked again whenever the leading text
 		changes.
-		Completion matches are always inserted at the keyword
-		boundary, regardless of the column returned by {func} when
-		a:findstart is 1.  This ensures compatibility with other
-		completion sources.
-		To make further modifications to the inserted text, {func}
-		can make use of |CompleteDonePre|.
 		If generating matches is potentially slow, |complete_check()|
 		should be used to avoid blocking and preserve editor
 		responsiveness.

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1033,15 +1033,12 @@ vim.bo.cms = vim.bo.commentstring
 --- 	name of a function or a `Funcref`.  For `Funcref` values,
 --- 	spaces must be escaped with a backslash ('\'), and commas with
 --- 	double backslashes ('\\') (see `option-backslash`).
+--- 	Unlike other sources, functions can provide completions starting
+--- 	from a non-keyword character before the cursor, and their
+--- 	start position for replacing text may differ from other sources.
 --- 	If the Dict returned by the {func} includes {"refresh": "always"},
 --- 	the function will be invoked again whenever the leading text
 --- 	changes.
---- 	Completion matches are always inserted at the keyword
---- 	boundary, regardless of the column returned by {func} when
---- 	a:findstart is 1.  This ensures compatibility with other
---- 	completion sources.
---- 	To make further modifications to the inserted text, {func}
---- 	can make use of `CompleteDonePre`.
 --- 	If generating matches is potentially slow, `complete_check()`
 --- 	should be used to avoid blocking and preserve editor
 --- 	responsiveness.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1444,15 +1444,12 @@ local options = {
         	name of a function or a |Funcref|.  For |Funcref| values,
         	spaces must be escaped with a backslash ('\'), and commas with
         	double backslashes ('\\') (see |option-backslash|).
+        	Unlike other sources, functions can provide completions starting
+        	from a non-keyword character before the cursor, and their
+        	start position for replacing text may differ from other sources.
         	If the Dict returned by the {func} includes {"refresh": "always"},
         	the function will be invoked again whenever the leading text
         	changes.
-        	Completion matches are always inserted at the keyword
-        	boundary, regardless of the column returned by {func} when
-        	a:findstart is 1.  This ensures compatibility with other
-        	completion sources.
-        	To make further modifications to the inserted text, {func}
-        	can make use of |CompleteDonePre|.
         	If generating matches is potentially slow, |complete_check()|
         	should be used to avoid blocking and preserve editor
         	responsiveness.


### PR DESCRIPTION
#### vim-patch:9.1.1512: completion: can only complete from keyword characters

Problem:  completion: can only complete from keyword characters
Solution: remove this restriction, allow completion functions when
          called from i_CTRL-N/i_CTRL-P to be triggered from non-keyword
          characters (Girish Palya)

Previously, functions specified in the `'complete'` option were
restricted to starting completion only from keyword characters (as
introduced in PR 17065). This change removes that restriction.

With this change, user-defined functions (e.g., `omnifunc`, `userfunc`)
used in `'complete'` can now initiate completion even when triggered
from non-keyword characters. This makes it easier to reuse existing
functions alongside other sources without having to consider whether the
cursor is on a keyword or non-keyword character, or worry about where
the replacement should begin (i.e., the `findstart=1` return value).

The logic for both the “collection” and “filtering” phases now fully
respects each source’s specified start column. This also extends to
fuzzy matching, making completions more predictable.

Internally, this builds on previously merged infrastructure that tracks
per-source metadata. This PR focuses on applying that metadata to
compute the leader string and insertion text appropriately for each
match.

Also, a memory corruption has been fixed in prepare_cpt_compl_funcs().

closes: vim/vim#17651

https://github.com/vim/vim/commit/ba11e78f1d5342786faed0ebd5b09ffee7f7ff86

Co-authored-by: Girish Palya <girishji@gmail.com>