### PR TITLE
fix(coverity): unreachable code after return

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1465,7 +1465,6 @@ static int command_line_execute(VimState *state, int key)
 
   // If already used to cancel/accept wildmenu, don't process the key further.
   if (wild_type == WILD_CANCEL || wild_type == WILD_APPLY) {
-    return command_line_not_changed(s);
     // Apply search highlighting
     if (wild_type == WILD_APPLY) {
       if (s->is_state.winid != curwin->handle) {
@@ -1475,6 +1474,7 @@ static int command_line_execute(VimState *state, int key)
         may_do_incsearch_highlighting(s->firstc, s->count, &s->is_state);
       }
     }
+    return command_line_not_changed(s);
   }
 
   return command_line_handle_key(s);


### PR DESCRIPTION
Problem:

*** CID 569478:         Control flow issues  (UNREACHABLE)
```
/src/nvim/ex_getln.c: 1470             in command_line_execute()
1464       s->do_abbr = true;             // default: check for abbreviation
1465
1466       // If already used to cancel/accept wildmenu, don't process the key further.
1467       if (wild_type == WILD_CANCEL || wild_type == WILD_APPLY) {
1468         return command_line_not_changed(s);
1469         // Apply search highlighting
>>>     CID 569478:         Control flow issues  (UNREACHABLE)
>>>     This code cannot be reached: "if (wild_type == WILD_APPLY...".
1470         if (wild_type == WILD_APPLY) {
1471           if (s->is_state.winid != curwin->handle) {
1472             init_incsearch_state(&s->is_state);
1473           }
1474           if (KeyTyped || vpeekc() == NUL) {
1475             may_do_incsearch_highlighting(s->firstc, s->count, &s->is_state);
```

Solution: Move the return statement after the `WILD_APPLY` block

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
