### PR TITLE
fix: serverlist() also returns pipes from stdpath("run")

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -8736,12 +8736,22 @@ searchpos({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])
                 Return: ~
                   (`any`)
 
-serverlist()                                                      *serverlist()*
+serverlist([{opts}])                                              *serverlist()*
 		Returns a list of server addresses, or empty if all servers
 		were stopped. |serverstart()| |serverstop()|
+
+		The optional argument {opts} is a Dict and supports the following items:
+
+		  peer  : If |TRUE|, servers not started by |serverstart()|
+		          will also be returned. (default: |FALSE|)
+		          Not supported on Windows yet.
+
 		Example: >vim
 			echo serverlist()
 <
+
+                Parameters: ~
+                  • {opts} (`table?`)
 
                 Return: ~
                   (`string[]`)

--- a/runtime/lua/vim/_core/server.lua
+++ b/runtime/lua/vim/_core/server.lua
@@ -1,0 +1,33 @@
+local M = {}
+
+--- Called by builtin serverlist(). Returns all running servers.
+--- in stdpath("run"). Does not include named pipes or TCP servers.
+---
+--- @param listed string[] Already listed servers
+--- @return string[] A list of currently running servers in stdpath("run")
+function M.serverlist(listed)
+  -- TODO: also get named pipes on Windows
+  local socket_paths = vim.fs.find(function(name, _)
+    return name:match('nvim.*')
+  end, { path = vim.fn.stdpath('run'), type = 'socket', limit = math.huge })
+
+  local running_sockets = {}
+  for _, socket in ipairs(socket_paths) do
+    -- Don't list servers twice
+    if not vim.list_contains(listed, socket) then
+      local ok, chan = pcall(vim.fn.sockconnect, 'pipe', socket, { rpc = true })
+      if ok and chan then
+        -- Check that the server is responding
+        -- TODO: do we need a timeout or error handling here?
+        if vim.fn.rpcrequest(chan, 'nvim_get_chan_info', 0).id then
+          table.insert(running_sockets, socket)
+        end
+        vim.fn.chanclose(chan)
+      end
+    end
+  end
+
+  return running_sockets
+end
+
+return M

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -7964,12 +7964,20 @@ function vim.fn.searchpos(pattern, flags, stopline, timeout, skip) end
 
 --- Returns a list of server addresses, or empty if all servers
 --- were stopped. |serverstart()| |serverstop()|
+---
+--- The optional argument {opts} is a Dict and supports the following items:
+---
+---   peer  : If |TRUE|, servers not started by |serverstart()|
+---           will also be returned. (default: |FALSE|)
+---           Not supported on Windows yet.
+---
 --- Example: >vim
 ---   echo serverlist()
 --- <
 ---
+--- @param opts? table
 --- @return string[]
-function vim.fn.serverlist() end
+function vim.fn.serverlist(opts) end
 
 --- Opens a socket or named pipe at {address} and listens for
 --- |RPC| messages. Clients can send |API| commands to the

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -9655,17 +9655,25 @@ M.funcs = {
     signature = 'searchpos({pattern} [, {flags} [, {stopline} [, {timeout} [, {skip}]]]])',
   },
   serverlist = {
+    args = { 0, 1 },
     desc = [=[
       Returns a list of server addresses, or empty if all servers
       were stopped. |serverstart()| |serverstop()|
+
+      The optional argument {opts} is a Dict and supports the following items:
+
+        peer  : If |TRUE|, servers not started by |serverstart()| 
+                will also be returned. (default: |FALSE|)
+                Not supported on Windows yet.
+
       Example: >vim
       	echo serverlist()
       <
     ]=],
     name = 'serverlist',
-    params = {},
+    params = { { 'opts', 'table' } },
     returns = 'string[]',
-    signature = 'serverlist()',
+    signature = 'serverlist([{opts}])',
   },
   serverstart = {
     args = { 0, 1 },

--- a/test/functional/core/server_spec.lua
+++ b/test/functional/core/server_spec.lua
@@ -162,7 +162,7 @@ describe('server', function()
   end)
 
   it('serverlist() returns the list of servers', function()
-    clear()
+    local current_server = clear()
     -- There should already be at least one server.
     local _n = eval('len(serverlist())')
 
@@ -186,6 +186,24 @@ describe('server', function()
     end
     -- After serverstop() the servers should NOT be in the list.
     eq(_n, eval('len(serverlist())'))
+
+    -- serverlist({ peer = true }) returns servers from other Nvim sessions.
+    if t.is_os('win') then
+      return
+    end
+    local client_address = n.new_pipename()
+    local client = n.new_session(
+      true,
+      { args = { '-u', 'NONE', '--listen', client_address, '--embed' }, merge = false }
+    )
+    n.set_session(client)
+    eq(client_address, fn.serverlist()[1])
+
+    n.set_session(current_server)
+
+    new_servs = fn.serverlist({ peer = true })
+    eq(true, vim.list_contains(new_servs, client_address))
+    client:close()
   end)
 end)
 


### PR DESCRIPTION
Problem: `serverlist()` only lists servers that were started by `serverstart().`

Solution: Also list running neovim servers in `stdpath("run")`.

The lua `serverlist()` should not be in `vim.fs` and it should be private. I'm not sure where to put it so I put it in `vim.fs` to get it running and do the testing and I don't know how to make functions private.

This doesn't list TCP servers or named pipes. The only method I found to look through TCP servers on a system is `netstat` and I'm not sure if it's a good idea to rely on it. Named pipes could be started anywhere on the system and it would be impractical to look everywhere.

Reference issue: https://github.com/neovim/neovim/issues/21600