### PR TITLE
vim-patch:{9.1.1511,7a734b7}

### DIFF
--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -164,7 +164,7 @@ endif
 
 
 " Prepare for calling test_garbagecollect_now().
-" Also avois some delays in Insert mode completion.
+" Also avoids some delays in Insert mode completion.
 let v:testing = 1
 
 let s:has_ffi = luaeval('pcall(require, "ffi")')

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -164,6 +164,7 @@ endif
 
 
 " Prepare for calling test_garbagecollect_now().
+" Also avois some delays in Insert mode completion.
 let v:testing = 1
 
 let s:has_ffi = luaeval('pcall(require, "ffi")')

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -716,12 +716,9 @@ func Test_edit_CTRL_K()
   %d
   call setline(1, 'A')
   call cursor(1, 1)
-  let v:testing = 1
   try
     call feedkeys("A\<c-x>\<c-k>\<esc>", 'tnix')
   catch
-    " error sleeps 2 seconds, when v:testing is not set
-    let v:testing = 0
   endtry
 
   call Ntest_override("char_avail", 1)
@@ -970,12 +967,9 @@ func Test_edit_CTRL_T()
   %d
   call setline(1, 'mad')
   call cursor(1, 1)
-  let v:testing = 1
   try
     call feedkeys("A\<c-x>\<c-t>\<esc>", 'tnix')
   catch
-    " error sleeps 2 seconds, when v:testing is not set
-    let v:testing = 0
   endtry
   call assert_equal(['mad'], getline(1, '$'))
   bw!


### PR DESCRIPTION
#### vim-patch:9.1.1511: tests: two edit tests change v:testing from 1 to 0

Problem:  tests: two edit tests change v:testing from 1 to 0.
Solution: Don't change v:testing in these two tests, since it's already
          set to 1 in runtest.vim (zeertzjq).

closes: vim/vim#17660

https://github.com/vim/vim/commit/96076bf41e0163cd61ca738b352896d450ee3636


#### vim-patch:7a734b7: tests: fix typo in comment (after v9.1.1511)

related: vim/vim#17660

https://github.com/vim/vim/commit/7a734b714895df25ba7ca9996fe0cd36460923a3