### PR TITLE
vim-patch:9.1.1516: tests: no test that 'incsearch' is updated after search completion

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1465,7 +1465,6 @@ static int command_line_execute(VimState *state, int key)
 
   // If already used to cancel/accept wildmenu, don't process the key further.
   if (wild_type == WILD_CANCEL || wild_type == WILD_APPLY) {
-    return command_line_not_changed(s);
     // Apply search highlighting
     if (wild_type == WILD_APPLY) {
       if (s->is_state.winid != curwin->handle) {
@@ -1475,6 +1474,7 @@ static int command_line_execute(VimState *state, int key)
         may_do_incsearch_highlighting(s->firstc, s->count, &s->is_state);
       }
     }
+    return command_line_not_changed(s);
   }
 
   return command_line_handle_key(s);

--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -445,6 +445,45 @@ describe('cmdline', function()
       /t.*\n.*\n.^                                                 |
     ]])
 
+    -- 'incsearch' is redrawn after accepting completion
+    feed('<esc>')
+    command('set wim=full')
+    command('set incsearch hlsearch')
+    feed('/th')
+    screen:expect([[
+      {10:th}e                                                         |
+      {2:th}ese                                                       |
+      {10:th}e                                                         |
+      foobar                                                      |
+      {10:th}e{10:th}e                                                      |
+      {10:th}e{10:th}ere                                                    |
+      {1:~                                                           }|*3
+      /th^                                                         |
+    ]])
+    feed('<f5>')
+    screen:expect([[
+      {10:th}e                                                         |
+      {2:th}ese                                                       |
+      {10:th}e                                                         |
+      foobar                                                      |
+      {10:th}e{10:th}e                                                      |
+      {10:th}e{10:th}ere                                                    |
+      {1:~                                                           }|*2
+      {100:these}{3:  the  thethe  thethere  there                         }|
+      /these^                                                      |
+    ]])
+    feed('<c-n><c-y>')
+    screen:expect([[
+      {10:the}                                                         |
+      {2:the}se                                                       |
+      {10:the}                                                         |
+      foobar                                                      |
+      {10:thethe}                                                      |
+      {10:thethe}re                                                    |
+      {1:~                                                           }|*3
+      /the^                                                        |
+    ]])
+
     feed('<esc>')
   end)
 end)

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -4558,6 +4558,16 @@ func Test_search_wildmenu_screendump()
   call term_sendkeys(buf, "\<esc>gg/t.*\\n.*\\n.\<tab>")
   call VerifyScreenDump(buf, 'Test_search_wildmenu_5', {})
 
+  " 'incsearch' is redrawn after accepting completion
+  call term_sendkeys(buf, "\<esc>:set wim=full\<cr>")
+  call term_sendkeys(buf, ":set incsearch hlsearch\<cr>")
+  call term_sendkeys(buf, "/th")
+  call VerifyScreenDump(buf, 'Test_search_wildmenu_6', {})
+  call term_sendkeys(buf, "\<f5>")
+  call VerifyScreenDump(buf, 'Test_search_wildmenu_7', {})
+  call term_sendkeys(buf, "\<c-n>\<c-y>")
+  call VerifyScreenDump(buf, 'Test_search_wildmenu_8', {})
+
   call term_sendkeys(buf, "\<esc>")
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.1516: tests: no test that 'incsearch' is updated after search completion

Problem:  tests: no test that 'incsearch' is updated after accepting
          search completion.
Solution: Add a test case (zeertzjq).

closes: vim/vim#17682

https://github.com/vim/vim/commit/08e5b128b8fa274bc66774a79363f199cb09ced4