### PR TITLE
vim-patch:0ae9e19: runtime(doc): add a section for options influencing search

### DIFF
--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -170,6 +170,16 @@ found", for Vi compatibility.
 For the |:s| command the "e" flag can be used to avoid the error message
 |:s_flags|.
 
+					*search-options*
+The following options affect how a search is performed in Vim:
+    'hlsearch'		highlight matches
+    'ignorecase'	ignore case when searching
+    'imsearch'		use IME when entering the search pattern
+    'incsearch'		show matches incrementally as the pattern is typed
+    'shortmess'		suppress messages |shm-s|; show search count |shm-S|
+    'smartcase'		override 'ignorecase' if pattern contains uppercase
+    'wrapscan'		continue searching from the start of the file
+
 					*search-offset* *{offset}*
 These commands search for the specified pattern.  With "/" and "?" an
 additional offset may be given.  There are two types of offsets: line offsets

--- a/runtime/doc/usr_27.txt
+++ b/runtime/doc/usr_27.txt
@@ -7,7 +7,8 @@
 
 In chapter 3 a few simple search patterns were mentioned |03.9|.  Vim can do
 much more complex searches.  This chapter explains the most often used ones.
-A detailed specification can be found here: |pattern|
+A detailed specification can be found here: |pattern|  Options affecting how
+search is done can be found here: |search-options|
 
 |27.1|	Ignoring case
 |27.2|	Wrapping around the file end


### PR DESCRIPTION
#### vim-patch:0ae9e19: runtime(doc): add a section for options influencing search

https://github.com/vim/vim/commit/0ae9e19540dda5d18359013fadf20f7d6b04f1fb

Co-authored-by: Christian Brabandt <cb@256bit.org>