### PR TITLE
vim-patch: autopkgtest

### DIFF
--- a/runtime/ftplugin/autopkgtest.vim
+++ b/runtime/ftplugin/autopkgtest.vim
@@ -1,0 +1,17 @@
+" Vim filetype plugin file
+" Language:     Debian autopkgtest control files
+" Maintainer:   Debian Vim Maintainers
+" Last Change:  2025 Jul 05
+" URL:          https://salsa.debian.org/vim-team/vim-debian/blob/main/ftplugin/autopkgtest.vim
+
+" Do these settings once per buffer
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin=1
+
+setlocal comments=:#
+setlocal commentstring=#\ %s
+
+" Clean unloading
+let b:undo_ftplugin = 'setlocal comments< commentstring<'

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1969,6 +1969,7 @@ local detect_xkb = starsetf('xkb')
 local pattern = {
   -- BEGIN PATTERN
   ['/debian/'] = {
+    ['/debian/tests/control$'] = 'autopkgtest',
     ['/debian/changelog$'] = 'debchangelog',
     ['/debian/control$'] = 'debcontrol',
     ['/debian/copyright$'] = 'debcopyright',

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -264,6 +264,8 @@ function M.control(_, bufnr)
   local line1 = getline(bufnr, 1)
   if line1 and findany(line1, { '^Source:', '^Package:' }) then
     return 'debcontrol'
+  elseif line1 and findany(line1, { '^Tests:', '^Test%-Command:' }) then
+    return 'autopkgtest'
   end
 end
 

--- a/runtime/syntax/autopkgtest.vim
+++ b/runtime/syntax/autopkgtest.vim
@@ -1,0 +1,95 @@
+" Vim syntax file
+" Language:    Debian autopkgtest control files
+" Maintainer:  Debian Vim Maintainers
+" Last Change: 2025 Jul 05
+" URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/autopkgtest.vim
+"
+" Specification of the autopkgtest format is available at:
+"   https://www.debian.org/doc/debian-policy/autopkgtest.txt
+
+" Standard syntax initialization
+if exists('b:current_syntax')
+  finish
+endif
+
+let s:cpo_save = &cpo
+set cpo&vim
+
+" Must call this first, because it will clear other settings
+syn sync clear
+syn sync match autopkgtestSync grouphere NONE '^$'
+
+" Should match case except for the keys of each field
+syn case match
+
+syn iskeyword @,48-57,-
+
+" #-Comments
+syn match autopkgtestComment "#.*" contains=@Spell
+
+syn match autopkgtestTests contained "[a-z0-9][a-z0-9+.-]\+\%(,\=\s*[a-z0-9][a-z0-9+.-]\+\)*,\="
+syn match autopkgtestArbitrary contained "[^#]*"
+syn keyword autopkgtestRestrictions contained
+      \ allow-stderr
+      \ breaks-testbe
+      \ build-neede
+      \ flaky
+      \ hint-testsuite-trigger
+      \ isolation-container
+      \ isolation-machine
+      \ needs-internet
+      \ needs-reboot
+      \ needs-root
+      \ needs-sudo
+      \ rw-build-tree
+      \ skip-foreign-architecture
+      \ skip-not-installable
+      \ skippable
+      \ superficial
+syn keyword autopkgtestDeprecatedRestrictions contained needs-recommends
+syn match autopkgtestFeatures contained 'test-name=[^, ]*\%([, ]*[^, #]\)*,\='
+syn match autopkgtestDepends contained '\%(@builddeps@\|@recommends@\|@\)'
+
+runtime! syntax/shared/debarchitectures.vim
+
+syn keyword autopkgtestArchitecture contained any
+exe 'syn keyword autopkgtestArchitecture contained '. join(g:debArchitectureKernelAnyArch)
+exe 'syn keyword autopkgtestArchitecture contained '. join(g:debArchitectureAnyKernelArch)
+exe 'syn keyword autopkgtestArchitecture contained '. join(g:debArchitectureArchs)
+
+syn case ignore
+
+" Catch-all for the legal fields
+syn region autopkgtestMultiField matchgroup=autopkgtestKey start="^Tests: *" skip="^[ \t]" end="^$"me=s-1 end="^[^ \t#]"me=s-1 contains=autopkgtestTests,autopkgtestComment
+syn region autopkgtestMultiField matchgroup=autopkgtestKey start="^Restrictions: *" skip="^[ \t]" end="^$"me=s-1 end="^[^ \t#]"me=s-1 contains=autopkgtestRestrictions,autopkgtestDeprecatedRestrictions,autopkgtestComment
+syn region autopkgtestMultiField matchgroup=autopkgtestKey start="^Features: *" skip="^[ \t]" end="^$"me=s-1 end="^[^ \t#]"me=s-1 contains=autopkgtestFeatures,autopkgtestComment
+syn region autopkgtestMultiField matchgroup=autopkgtestKey start="^Depends: *" skip="^[ \t]" end="^$"me=s-1 end="^[^ \t#]"me=s-1 contains=autopkgtestDepends,autopkgtestComment
+syn region autopkgtestMultiField matchgroup=autopkgtestKey start="^Classes: *" skip="^[ \t]" end="^$"me=s-1 end="^[^ \t#]"me=s-1 contains=autopkgtestComment
+syn region autopkgtestMultiField matchgroup=autopkgtestKey start="^Architecture: *" skip="^[ \t]" end="^$"me=s-1 end="^[^ \t#]"me=s-1 contains=autopkgtestArchitecture,autopkgtestComment
+
+" Fields for which we do strict syntax checking
+syn region autopkgtestStrictField matchgroup=autopkgtestKey start="^Test-Command: *" end="$" end='#'me=s-1 contains=autopkgtestArbitrary,autopkgtestComment oneline
+syn region autopkgtestStrictField matchgroup=autopkgtestKey start="^Tests-Directory: *" end="$" end='#'me=s-1 contains=autopkgtestArbitrary,autopkgtestComment oneline
+
+syn match autopkgtestError '^\%(\%(Architecture\|Classes\|Depends\|Features\|Restrictions\|Test-Command\|Tests-Directory\|Tests\)\@![^ #]*:\)'
+
+" Associate our matches and regions with pretty colours
+hi def link autopkgtestKey           Keyword
+hi def link autopkgtestRestrictions  Identifier
+hi def link autopkgtestFeatures      Keyword
+hi def link autopkgtestDepends       Identifier
+hi def link autopkgtestArchitecture  Identifier
+hi def link autopkgtestStrictField   Error
+hi def link autopkgtestDeprecatedRestrictions Error
+hi def link autopkgtestMultiField    Normal
+hi def link autopkgtestArbitrary     Normal
+hi def link autopkgtestTests         Normal
+hi def link autopkgtestComment       Comment
+hi def link autopkgtestError         Error
+
+let b:current_syntax = 'autopkgtest'
+
+let &cpo = s:cpo_save
+unlet s:cpo_save
+
+" vim: ts=8 sw=2

--- a/runtime/syntax/debcontrol.vim
+++ b/runtime/syntax/debcontrol.vim
@@ -3,8 +3,7 @@
 " Maintainer:  Debian Vim Maintainers
 " Former Maintainers: Gerfried Fuchs <alfie@ist.org>
 "                     Wichert Akkerman <wakkerma@debian.org>
-" Last Change: 2024 Mar 26
-"              2025 Jun 13 by Vim Project (add hurd-amd64 arch #17525)
+" Last Change: 2025 Jul 05
 " URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/debcontrol.vim
 
 " Standard syntax initialization
@@ -27,26 +26,13 @@ syn match debcontrolElse "^.*$"
 syn match debControlComma ",[ \t]*"
 syn match debControlSpace "[ \t]"
 
-let s:kernels = ['linux', 'hurd', 'kfreebsd', 'knetbsd', 'kopensolaris', 'netbsd']
-let s:archs = [
-      \ 'alpha', 'amd64', 'armeb', 'armel', 'armhf', 'arm64', 'avr32', 'hppa'
-      \, 'i386', 'ia64', 'loong64', 'lpia', 'm32r', 'm68k', 'mipsel', 'mips64el', 'mips'
-      \, 'powerpcspe', 'powerpc', 'ppc64el', 'ppc64', 'riscv64', 's390x', 's390', 'sh3eb'
-      \, 'sh3', 'sh4eb', 'sh4', 'sh', 'sparc64', 'sparc', 'x32'
-      \ ]
-let s:pairs = [
-      \ 'hurd-i386', 'hurd-amd64', 'kfreebsd-i386', 'kfreebsd-amd64', 'knetbsd-i386'
-      \, 'kopensolaris-i386', 'netbsd-alpha', 'netbsd-i386'
-      \ ]
+runtime! syntax/shared/debarchitectures.vim
 
 " Define some common expressions we can use later on
 syn keyword debcontrolArchitecture contained all any
-exe 'syn keyword debcontrolArchitecture contained '. join(map(copy(s:kernels), {k,v -> v .'-any'}))
-exe 'syn keyword debcontrolArchitecture contained '. join(map(copy(s:archs), {k,v -> 'any-'.v}))
-exe 'syn keyword debcontrolArchitecture contained '. join(s:archs)
-exe 'syn keyword debcontrolArchitecture contained '. join(s:pairs)
-
-unlet s:kernels s:archs s:pairs
+exe 'syn keyword debcontrolArchitecture contained '. join(g:debArchitectureKernelAnyArch)
+exe 'syn keyword debcontrolArchitecture contained '. join(g:debArchitectureAnyKernelArch)
+exe 'syn keyword debcontrolArchitecture contained '. join(g:debArchitectureArchs)
 
 " Keep in sync with https://metadata.ftp-master.org/sections.822
 " curl -q https://metadata.ftp-master.debian.org/sections.822 2>/dev/null| grep-dctrl -n --not -FSection -sSection  / -

--- a/runtime/syntax/shared/debarchitectures.vim
+++ b/runtime/syntax/shared/debarchitectures.vim
@@ -1,0 +1,27 @@
+" Language:     Debian architecture information
+" Maintainer:   Debian Vim Maintainers
+" Last Change:  2025 Jul 05
+" URL: https://salsa.debian.org/vim-team/vim-debian/blob/main/syntax/shared/debarchitectures.vim
+
+let s:cpo = &cpo
+set cpo-=C
+
+let s:kernels = ['linux', 'hurd', 'kfreebsd', 'knetbsd', 'kopensolaris', 'netbsd']
+let s:archs = [
+      \ 'alpha', 'amd64', 'armeb', 'armel', 'armhf', 'arm64', 'avr32', 'hppa'
+      \, 'i386', 'ia64', 'loong64', 'lpia', 'm32r', 'm68k', 'mipsel', 'mips64el', 'mips'
+      \, 'powerpcspe', 'powerpc', 'ppc64el', 'ppc64', 'riscv64', 's390x', 's390', 'sh3eb'
+      \, 'sh3', 'sh4eb', 'sh4', 'sh', 'sparc64', 'sparc', 'x32'
+      \ ]
+let s:pairs = [
+      \ 'hurd-i386', 'hurd-amd64', 'kfreebsd-i386', 'kfreebsd-amd64', 'knetbsd-i386'
+      \, 'kopensolaris-i386', 'netbsd-alpha', 'netbsd-i386'
+      \ ]
+
+let g:debArchitectureKernelAnyArch = map(copy(s:kernels), {k,v -> v.'-any'})
+let g:debArchitectureAnyKernelArch = map(copy(s:archs), {k,v -> 'any-'.v})
+let g:debArchitectureArchs = s:archs + s:pairs
+
+unlet s:kernels s:archs s:pairs
+
+let &cpo=s:cpo

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -126,6 +126,7 @@ func s:GetFilenameChecks() abort
     \ 'autohotkey': ['file.ahk'],
     \ 'autoit': ['file.au3'],
     \ 'automake': ['GNUmakefile.am', 'makefile.am', 'Makefile.am'],
+    \ 'autopkgtest': ['/debian/tests/control', 'any/debian/tests/control'],
     \ 'ave': ['file.ave'],
     \ 'awk': ['file.awk', 'file.gawk'],
     \ 'b': ['file.mch', 'file.ref', 'file.imp'],


### PR DESCRIPTION
- **vim-patch:9.1.1517: filetype: autopkgtest files are not recognized**
- **vim-patch:48c823c: runtime(debcontrol): move kernel/architecture definitions to shared/debarchitectures.vim**
- **vim-patch:e9d331d: runtime(autopkgtest): add syntax file for autopkgtest**
- **vim-patch:244198f: runtime(autopkgtest): add ftplugin file for autopkgtest**
