### PR TITLE
vim-patch:f79695c: runtime(doc): fix a few typos introduced in 0ae9e19540dda5d

### DIFF
--- a/runtime/doc/usr_27.txt
+++ b/runtime/doc/usr_27.txt
@@ -7,8 +7,8 @@
 
 In chapter 3 a few simple search patterns were mentioned |03.9|.  Vim can do
 much more complex searches.  This chapter explains the most often used ones.
-A detailed specification can be found here: |pattern|  Options affecting how
-search is done can be found here: |search-options|
+A detailed specification can be found here: |pattern|
+Options affecting how search is done can be found here: |search-options|
 
 |27.1|	Ignoring case
 |27.2|	Wrapping around the file end


### PR DESCRIPTION
#### vim-patch:f79695c: runtime(doc): fix a few typos introduced in 0ae9e19540dda5d

https://github.com/vim/vim/commit/f79695c2d826ddc485a456ef417ebc91d60e7c4a

Co-authored-by: Christian Brabandt <cb@256bit.org>