### PR TITLE
vim-patch:9.1.1518: getcompletiontype() may crash

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -3351,8 +3351,8 @@ getcmdcompltype()                                            *getcmdcompltype()*
 		|getcmdprompt()|, |getcmdcomplpat()| and |setcmdline()|.
 		Returns an empty string when completion is not defined.
 
-		To get the type of the command-line completion for the
-		specified string, use |getcompletiontype()|.
+		To get the type of the command-line completion for a specified
+		string, use |getcompletiontype()|.
 
                 Return: ~
                   (`string`)

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3002,8 +3002,8 @@ function vim.fn.getcmdcomplpat() end
 --- |getcmdprompt()|, |getcmdcomplpat()| and |setcmdline()|.
 --- Returns an empty string when completion is not defined.
 ---
---- To get the type of the command-line completion for the
---- specified string, use |getcompletiontype()|.
+--- To get the type of the command-line completion for a specified
+--- string, use |getcompletiontype()|.
 ---
 --- @return string
 function vim.fn.getcmdcompltype() end

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -3854,10 +3854,7 @@ void f_getcompletiontype(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 
   int cmdline_len = (int)strlen(pat);
   set_cmd_context(&xpc, (char *)pat, cmdline_len, cmdline_len, false);
-  xpc.xp_pattern_len = strlen(xpc.xp_pattern);
-  xpc.xp_col = cmdline_len;
-
-  rettv->vval.v_string = get_cmdline_completion(&xpc);
+  rettv->vval.v_string = cmdcomplete_type_to_str(xpc.xp_context, xpc.xp_arg);
 
   ExpandCleanup(&xpc);
 }

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -3760,8 +3760,8 @@ M.funcs = {
       |getcmdprompt()|, |getcmdcomplpat()| and |setcmdline()|.
       Returns an empty string when completion is not defined.
 
-      To get the type of the command-line completion for the
-      specified string, use |getcompletiontype()|.
+      To get the type of the command-line completion for a specified
+      string, use |getcompletiontype()|.
     ]=],
     name = 'getcmdcompltype',
     params = {},

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -403,7 +403,7 @@ char *get_user_cmd_nargs(expand_T *xp, int idx)
 
 static char *get_command_complete(int arg)
 {
-  if (arg >= (int)(ARRAY_SIZE(command_complete))) {
+  if (arg < 0 || arg >= (int)(ARRAY_SIZE(command_complete))) {
     return NULL;
   }
   return (char *)command_complete[arg];
@@ -420,6 +420,26 @@ char *get_user_cmd_complete(expand_T *xp, int idx)
     return "";
   }
   return cmd_compl;
+}
+
+/// Get the name of completion type "expand" as an allocated string.
+/// "compl_arg" is the function name for "custom" and "customlist" types.
+/// Returns NULL if no completion is available.
+char *cmdcomplete_type_to_str(int expand, const char *compl_arg)
+{
+  char *cmd_compl = get_command_complete(expand);
+  if (cmd_compl == NULL || expand == EXPAND_USER_LUA) {
+    return NULL;
+  }
+
+  if (expand == EXPAND_USER_LIST || expand == EXPAND_USER_DEFINED) {
+    size_t buflen = strlen(cmd_compl) + strlen(compl_arg) + 2;
+    char *buffer = xmalloc(buflen);
+    snprintf(buffer, buflen, "%s,%s", cmd_compl, compl_arg);
+    return buffer;
+  }
+
+  return xstrdup(cmd_compl);
 }
 
 int cmdcomplete_str_to_type(const char *complete_str)

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -740,12 +740,13 @@ endfunc
 func Test_getcompletiontype()
   call assert_fails('call getcompletiontype()', 'E119:')
   call assert_fails('call getcompletiontype({})', 'E1174:')
-  call assert_equal(getcompletiontype(''), 'command')
-  call assert_equal(getcompletiontype('dummy '), '')
-  call assert_equal(getcompletiontype('cd '), 'dir_in_path')
-  call assert_equal(getcompletiontype('let v:n'), 'var')
-  call assert_equal(getcompletiontype('call tag'), 'function')
-  call assert_equal(getcompletiontype('help '), 'help')
+  call assert_equal('command', getcompletiontype(''))
+  call assert_equal('', getcompletiontype('dummy '))
+  call assert_equal('', getcompletiontype('ls '))
+  call assert_equal('dir_in_path', getcompletiontype('cd '))
+  call assert_equal('var', getcompletiontype('let v:n'))
+  call assert_equal('function', getcompletiontype('call tag'))
+  call assert_equal('help', getcompletiontype('help '))
 endfunc
 
 func Test_multibyte_expression()
@@ -4251,6 +4252,8 @@ func Test_custom_completion()
 
   call feedkeys(":Test1 \<C-R>=Check_custom_completion()\<CR>\<Esc>", "xt")
   call feedkeys(":Test2 \<C-R>=Check_customlist_completion()\<CR>\<Esc>", "xt")
+  call assert_equal('custom,CustomComplete1', getcompletiontype('Test1 '))
+  call assert_equal('customlist,CustomComplete2', getcompletiontype('Test2 '))
 
   call assert_fails("call getcompletion('', 'custom')", 'E475:')
   call assert_fails("call getcompletion('', 'customlist')", 'E475:')


### PR DESCRIPTION
#### vim-patch:9.1.1518: getcompletiontype() may crash

Problem:  getcompletiontype() crashes when no completion is available
          (after v9.1.1509).
Solution: Don't call set_expand_context() (zeertzjq)

closes: vim/vim#17684

https://github.com/vim/vim/commit/e2c0f81dd014b03a40af6b2c42463b7a0d92f5d6