### PR TITLE
perf(test): pre-spawn neovim instances

### DIFF
--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -299,6 +299,7 @@ static bool v_do_log_to_file(FILE *log_file, int log_level, const char *context,
 {
   // Name of the Nvim instance that produced the log.
   static char name[32] = { 0 };
+  static char *serv_name = NULL;
 
   static const char *log_levels[] = {
     [LOGLVL_DBG] = "DBG",
@@ -326,11 +327,18 @@ static bool v_do_log_to_file(FILE *log_file, int log_level, const char *context,
 
   bool ui = !!ui_client_channel_id;  // Running as a UI client (--remote-ui).
 
+  char const *serv = path_tail(get_vim_var_str(VV_SEND_SERVER));
+
   // Regenerate the name when:
   // - UI client (to ensure "ui" is in the name)
   // - not set yet
   // - no v:servername yet
   bool regen = ui || name[0] == NUL || name[0] == '?';
+  if (!strequal(serv_name, serv)) {
+    xfree(serv_name);
+    serv_name = xstrdup(serv);
+    regen = true;
+  }
 
   // Get a name for this Nvim instance.
   // TODO(justinmk): expose this as v:name ?
@@ -338,7 +346,6 @@ static bool v_do_log_to_file(FILE *log_file, int log_level, const char *context,
     // Parent servername ($NVIM).
     const char *parent = path_tail(os_getenv_noalloc(ENV_NVIM));
     // Servername. Empty until starting=false.
-    const char *serv = path_tail(get_vim_var_str(VV_SEND_SERVER));
     if (parent[0] != NUL) {
       snprintf(name, sizeof(name), ui ? "ui/c/%s" : "c/%s", parent);  // "c/" = child of $NVIM.
     } else if (serv[0] != NUL) {

--- a/test/functional/core/log_spec.lua
+++ b/test/functional/core/log_spec.lua
@@ -3,7 +3,7 @@ local n = require('test.functional.testnvim')()
 local tt = require('test.functional.testterm')
 
 local assert_log = t.assert_log
-local clear = n.clear
+local clear = n.clear_without_pool
 local command = n.command
 local eq = t.eq
 local exec_lua = n.exec_lua

--- a/test/functional/legacy/messages_spec.lua
+++ b/test/functional/legacy/messages_spec.lua
@@ -701,10 +701,11 @@ describe('messages', function()
       hide buffer a.txt
 
       autocmd CursorHold * buf b.txt | w | echo "'b' written"
+
+      set updatetime=50
+      normal! 0$
     ]])
 
-    command('set updatetime=50')
-    feed('0$')
     screen:expect([[
       ^hi                                      |
       {1:~                                       }|*4

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -491,7 +491,34 @@ function M.clear(...)
   return M.get_session()
 end
 
---- Starts a new Nvim process with the given args and returns a msgpack-RPC session.
+--- @type test.Session[]
+local session_pool = {}
+
+--- @param ... string Nvim CLI args (or see overload)
+--- @return test.Session
+--- @overload fun(opts: test.session.Opts): test.Session
+local function create_session(...)
+  local argv, env, io_extra = M._new_argv(...)
+  local proc = ProcStream.spawn(argv, env, io_extra)
+  return Session.new(proc)
+end
+
+--- Starts a new, global Nvim session and clears the current one.
+--- Unlike `clear()`, doesn't use instances from the pool.
+---
+--- @see clear()
+---
+--- @param ... string Nvim CLI args
+--- @return test.Session
+--- @overload fun(opts: test.session.Opts): test.Session
+function M.clear_without_pool(...)
+  M.check_close()
+  M.set_session(create_session(...))
+  return M.get_session()
+end
+
+--- Picks a Nvim process from the pool or starts a new one with the given args
+--- and returns a msgpack-RPC session.
 ---
 --- Does not replace the current global session, unlike `clear()`.
 ---
@@ -504,10 +531,23 @@ function M.new_session(keep, ...)
     M.check_close()
   end
 
-  local argv, env, io_extra = M._new_argv(...)
+  local args = { ... }
+  if #args == 0 then
+    for _ = #session_pool + 1, 10 do
+      table.insert(session_pool, create_session({ skip_rpc_server = true }))
+    end
+    local new_session = table.remove(session_pool, 1)
 
-  local proc = ProcStream.spawn(argv, env, io_extra)
-  return Session.new(proc)
+    if _G._nvim_test_id then
+      -- Set the server name to the test-id for logging. #8519
+      local cmd = 'vim.fn.serverstop(vim.v.servername); vim.fn.serverstart(...)'
+      new_session:request('nvim_exec_lua', cmd, { _G._nvim_test_id })
+    end
+
+    return new_session
+  end
+
+  return create_session(...)
 end
 
 --- Starts a (non-RPC, `--headless --listen "Tx"`) Nvim process, waits for exit, and returns result.
@@ -539,6 +579,8 @@ end
 --- @field env? table<string,string>
 --- Used for stdin_fd, see `:help ui-option`
 --- @field io_extra? uv.uv_pipe_t
+--- Skip setting RPC server.
+--- @field skip_rpc_server? boolean
 
 --- @private
 ---
@@ -552,12 +594,12 @@ end
 function M._new_argv(...)
   --- @type test.session.Opts|string
   local opts = select(1, ...)
-  local merge = type(opts) ~= 'table' and true or opts.merge ~= false
+  local merge = type(opts) ~= 'table' or opts.merge ~= false
 
   local args = merge and { unpack(M.nvim_argv) } or { M.nvim_prog }
   if merge then
     table.insert(args, '--headless')
-    if _G._nvim_test_id then
+    if _G._nvim_test_id and (not opts or not opts.skip_rpc_server) then
       -- Set the server name to the test-id for logging. #8519
       table.insert(args, '--listen')
       table.insert(args, _G._nvim_test_id)

--- a/test/functional/ui/diff_spec.lua
+++ b/test/functional/ui/diff_spec.lua
@@ -3,7 +3,6 @@ local n = require('test.functional.testnvim')()
 local Screen = require('test.functional.ui.screen')
 
 local feed = n.feed
-local clear = n.clear
 local command = n.command
 local insert = n.insert
 local write_file = t.write_file
@@ -11,6 +10,9 @@ local dedent = t.dedent
 local exec = n.exec
 local eq = t.eq
 local api = n.api
+
+-- See: https://github.com/neovim/neovim/pull/32644
+local clear = t.is_os('win') and n.clear_without_pool or n.clear
 
 local function WriteDiffFiles(text1, text2)
   write_file('Xdifile1', text1)


### PR DESCRIPTION
See: https://github.com/neovim/neovim/pull/32644

Functional tests call `clear()` before each test, which spawns a new neovim instance, and start using it immediately after. This forces each test to wait until the newly spawned neovim is ready.

Added a queue of 10 neovim instances that are spawned before they are needed. When `clear()` is called, the oldest instance in the queue is used. This makes it more likely that the instance is ready by the time it is needed. Queue is refilled when instances are removed from it.

This reduces total time taken by functional tests.

### Additional info

RPC server name is set at runtime, so some entries in `.nvimlog` don't have the server name. However, since pid of the process is printed, it's easy to know which message belongs to which session.

Added `clear_without_pool()` function for the cases where all log entries need to have the same name, e.g. `log_spec.lua`. Also needed for `diff_spec.lua` on windows, see previous PR.

### Results

I updated the results. Does anyone know why the tests became so much slower since February 2025? It's almost 1.5x slower. I saw some PRs related to parallelizing. Is it planned?

| | current | new |
|-|-|-|
| ubuntu asan clang functionaltest | 19m 46s | 16m 36s |
| ubuntu tsan clang functionaltest | 19m 14s | 19m 6s |
| ubuntu release gcc functionaltest | 10m 23s | 9m 11s |
| macos intel clang functionaltest | 11m 15s | 10m 38s |
| macos arm clang functionaltest | 8m 9s | 7m 18s |
| ubuntu puc-lua gcc functionaltest | 9m 5s | 8m 56s |
| windows / windows (functional) | 15m 12s | 11m 4s |

<details>

current:
https://github.com/neovim/neovim/actions/runs/16103434692/job/45435514123

new:
https://github.com/vanaigr/neovim/actions/runs/16103544445/job/45435754589

</details>
