### PR TITLE
feat(termdebug): allow custom signs

### DIFF
--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -657,6 +657,8 @@ than 99 will be displayed as "9+".
 
 If you want to customize the breakpoint signs to show `>>` in the signcolumn: >vim
 	let g:termdebug_config['sign'] = '>>'
+You can also specify individual signs for the first N breakpoints: >vim
+	let g:termdebug_config['signs'] = ['a', 'b', 'c', 'x', 'y', 'z']
 If you would like to use decimal (base 10) breakpoint signs: >vim
 	let g:termdebug_config['sign_decimal'] = 1
 If the variable g:termdebug_config does not yet exist, you can use: >vim

--- a/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
+++ b/runtime/pack/dist/opt/termdebug/plugin/termdebug.vim
@@ -1688,7 +1688,9 @@ func s:CreateBreakpoint(id, subid, enabled)
       let hiName = "debugBreakpoint"
     endif
     let label = ''
-    if exists('g:termdebug_config') && has_key(g:termdebug_config, 'sign')
+    if exists('g:termdebug_config') && has_key(g:termdebug_config, 'signs')
+      let label = get(g:termdebug_config.signs, a:id - 1, get(g:termdebug_config, 'sign', ''))
+    elseif exists('g:termdebug_config') && has_key(g:termdebug_config, 'sign')
       let label = g:termdebug_config['sign']
     elseif exists('g:termdebug_config') && has_key(g:termdebug_config, 'sign_decimal')
       let label = printf('%02d', a:id)


### PR DESCRIPTION
For example, one can do something like this:

```vim
let g:termdebug_config.signs = ["❶", "➋", "➌", "➍", "➎", "➏", "➐", "➑", "➒"]
let g:termdebug_config.sign = "⚫"
```

where the first 9 breakpoint signs will have numbers, and the rest will be just black circles. Or, one can define as many as 20 circled numbers provided by the Unicode.
