### PR TITLE
feat(lsp): support `textDocument/colorPresentation`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2253,6 +2253,9 @@ stop({bufnr}, {client_id})                    *vim.lsp.semantic_tokens.stop()*
 ==============================================================================
 Lua module: vim.lsp.document_color                        *lsp-document_color*
 
+color_presentation()             *vim.lsp.document_color.color_presentation()*
+    Select from a list of presentations for the color under the cursor.
+
 enable({enable}, {bufnr}, {opts})            *vim.lsp.document_color.enable()*
     Enables document highlighting from the given language client in the given
     buffer.

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -180,6 +180,8 @@ LSP
 • You can control priority of |vim.lsp.Config| `root_markers`.
 • Support for `textDocument/documentColor`: |lsp-document_color|
   https://microsoft.github.io/language-server-protocol/specification/#textDocument_documentColor
+• Support for `textDocument/colorPresentation |lsp-document_color|
+  https://microsoft.github.io/language-server-protocol/specification/#textDocument_colorPresentation
 • The `textDocument/diagnostic` request now includes the previous id in its
   parameters.
 • |vim.lsp.enable()| start/stops clients as necessary. And detaches


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

This is a follow-up of https://github.com/neovim/neovim/pull/33440, as [the spec says that this is basically a resolve request for `textDocument/documentColor`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#textDocument_colorPresentation).

Preview of how this looks:

https://github.com/user-attachments/assets/80131692-f62f-4da3-beed-4352a96dc7d2

