### PR TITLE
fix(highlight): preserve background transparency with winblend=100

### DIFF
--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -754,10 +754,16 @@ int hl_blend_attrs(int back_attr, int front_attr, bool *through)
   }
 
   // Check if we should preserve background transparency
-  // Use the raw attributes (before forcing colors) to check original transparency
-  cattrs.rgb_bg_color = (battrs_raw.rgb_bg_color == -1) && (fattrs_raw.rgb_bg_color == -1)
-                        ? -1
-                        : rgb_blend(ratio, battrs.rgb_bg_color, fattrs.rgb_bg_color);
+  // Special case for blend=100: preserve back layer background exactly (including bg=NONE)
+  if (ratio == 100 && battrs_raw.rgb_bg_color == -1) {
+    // For 100% blend with transparent background, preserve the transparency
+    cattrs.rgb_bg_color = -1;
+  } else {
+    // Use the raw attributes (before forcing colors) to check original transparency
+    cattrs.rgb_bg_color = (battrs_raw.rgb_bg_color == -1) && (fattrs_raw.rgb_bg_color == -1)
+                          ? -1
+                          : rgb_blend(ratio, battrs.rgb_bg_color, fattrs.rgb_bg_color);
+  }
   cattrs.hl_blend = -1;  // blend property was consumed
   HlKind kind = *through ? kHlBlendThrough : kHlBlend;
   id = get_attr_entry((HlEntry){ .attr = cattrs, .kind = kind,

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -959,6 +959,7 @@ describe('float window', function()
         [28] = { foreground = Screen.colors.DarkBlue, background = Screen.colors.LightGrey },
         [29] = { background = Screen.colors.Yellow1, foreground = Screen.colors.Blue4 },
         [30] = { background = Screen.colors.Grey, foreground = Screen.colors.Blue4, bold = true },
+        [31] = { foreground = Screen.colors.Grey0 },
       }
       screen:set_default_attr_ids(attrs)
     end)
@@ -1839,9 +1840,9 @@ describe('float window', function()
           grid = [[
           neeed some dummy                        |
           background text                         |
-          to sh{1: halloj! }{23:f}ect                      |
+          to sh{1: halloj! }{31:f}ect                      |
           of co{1: BORDAA  }{24:i}ng                       |
-          of bo{23:r}{24:der shado}w                        |
+          of bo{31:r}{24:der shado}w                        |
           ^                                        |
                                                   |
         ]],


### PR DESCRIPTION
Problem: When winblend=100 is set on floating windows with transparent background, the desktop background is not visible through the window.

Solution: Add special case to preserve transparency (-1) when blend ratio is 100% and background was originally transparent.

Fix #10685 

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
