### PR TITLE
fix(api): populate `lhsrawalt` in `nvim_get_keymap` response

### DIFF
--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -2894,7 +2894,10 @@ ArrayOf(Dict) keymap_array(String mode, buf_T *buf, Arena *arena)
       }
       // Check for correct mode
       if (int_mode & current_maphash->m_mode) {
-        kvi_push(mappings, DICT_OBJ(mapblock_fill_dict(current_maphash, NULL, buffer_value,
+        kvi_push(mappings, DICT_OBJ(mapblock_fill_dict(current_maphash,
+                                                       current_maphash->m_alt
+                                                       ? current_maphash->m_alt->m_keys : NULL,
+                                                       buffer_value,
                                                        is_abbrev, false, arena)));
       }
     }

--- a/test/functional/api/keymap_spec.lua
+++ b/test/functional/api/keymap_spec.lua
@@ -316,7 +316,11 @@ describe('nvim_get_keymap', function()
     }
     local function cpomap(lhs, rhs, mode)
       local ret = shallowcopy(cpo_table)
+      local lhsraw = api.nvim_eval(('"%s"'):format(lhs:gsub('\\', '\\\\'):gsub('<', '\\<*')))
+      local lhsrawalt = api.nvim_eval(('"%s"'):format(lhs:gsub('\\', '\\\\'):gsub('<', '\\<')))
       ret.lhs = lhs
+      ret.lhsraw = lhsraw
+      ret.lhsrawalt = lhsrawalt ~= lhsraw and lhsrawalt or nil
       ret.rhs = rhs
       ret.mode = mode
       ret.mode_bits = mode_bits_map[mode]
@@ -339,16 +343,6 @@ describe('nvim_get_keymap', function()
     command('onoremap \\<C-a><C-a><LT>C-a>\\  \\<C-b><C-b><LT>C-b>\\')
     command('onoremap <special> \\<C-c><C-c><LT>C-c>\\  \\<C-d><C-d><LT>C-d>\\')
 
-    -- wrapper around get_keymap() that drops "lhsraw" and "lhsrawalt" which are hard to check
-    local function get_keymap_noraw(...)
-      local ret = api.nvim_get_keymap(...)
-      for _, item in ipairs(ret) do
-        item.lhsraw = nil
-        item.lhsrawalt = nil
-      end
-      return ret
-    end
-
     for _, cmd in ipairs({
       'set cpo-=B',
       'set cpo+=B',
@@ -357,19 +351,19 @@ describe('nvim_get_keymap', function()
       eq({
         cpomap('\\<C-C><C-C><lt>C-c>\\', '\\<C-D><C-D><lt>C-d>\\', 'n'),
         cpomap('\\<C-A><C-A><lt>C-a>\\', '\\<C-B><C-B><lt>C-b>\\', 'n'),
-      }, get_keymap_noraw('n'))
+      }, api.nvim_get_keymap('n'))
       eq({
         cpomap('\\<C-C><C-C><lt>C-c>\\', '\\<C-D><C-D><lt>C-d>\\', 'x'),
         cpomap('\\<C-A><C-A><lt>C-a>\\', '\\<C-B><C-B><lt>C-b>\\', 'x'),
-      }, get_keymap_noraw('x'))
+      }, api.nvim_get_keymap('x'))
       eq({
         cpomap('<lt>C-c><C-C><lt>C-c> ', '<lt>C-d><C-D><lt>C-d>', 's'),
         cpomap('<lt>C-a><C-A><lt>C-a> ', '<lt>C-b><C-B><lt>C-b>', 's'),
-      }, get_keymap_noraw('s'))
+      }, api.nvim_get_keymap('s'))
       eq({
         cpomap('<lt>C-c><C-C><lt>C-c> ', '<lt>C-d><C-D><lt>C-d>', 'o'),
         cpomap('<lt>C-a><C-A><lt>C-a> ', '<lt>C-b><C-B><lt>C-b>', 'o'),
-      }, get_keymap_noraw('o'))
+      }, api.nvim_get_keymap('o'))
     end
   end)
 


### PR DESCRIPTION
Problem:
The `nvim_get_keymap` function is missing the `lhsrawalt` field in its response for mappings with an alternate key representation. This makes its return value inconsistent with its documented `maparg()`-like structure and its formal type definition.

Solution:
Corrects the `keymap_array` function to pass the alternate mapping keys (`current_maphash->m_alt->m_keys`) to `mapblock_fill_dict`. The argument responsible for this was previously hardcoded to `NULL`.

For example, for a mapping of `<C-x>`, the API will now correctly return both `lhsraw` (`<80><fc>^DX`) and `lhsrawalt` (the alternate form, e.g., `^X`).

---

This is my first-ever contribution to an open-source project. I would be grateful for any feedback on my changes or the contribution process. Please let me know if any adjustments are needed!

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
