### PR TITLE
Fix minor typos in documentation

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1012,7 +1012,8 @@ nvim_get_runtime_file({name}, {all})                 *nvim_get_runtime_file()*
     scheme files. Always use forward slashes (/) in the search pattern for
     subdirectories regardless of platform.
 
-    It is not an error to not find any files. An empty array is returned then.
+    If no files are found, an empty array is returned (this is not considered
+    an error).
 
     Attributes: ~
         |api-fast|
@@ -3098,7 +3099,7 @@ nvim_get_namespaces()                                  *nvim_get_namespaces()*
 
                                               *nvim_set_decoration_provider()*
 nvim_set_decoration_provider({ns_id}, {opts})
-    Set or change decoration provider for a |namespace|
+    Set or change decoration provider for a |namespace|.
 
     This is a very general purpose interface for having Lua callbacks being
     triggered during the redraw code.
@@ -4149,10 +4150,13 @@ nvim_ui_try_resize({width}, {height})                   *nvim_ui_try_resize()*
 
                                                    *nvim_ui_try_resize_grid()*
 nvim_ui_try_resize_grid({grid}, {width}, {height})
-    Tell Nvim to resize a grid. Triggers a grid_resize event with the
-    requested grid size or the maximum size if it exceeds size limits.
+ 
+    Instructs Nvim to resize a grid. This triggers a grid_resize event with
+    the requested grid size or the maximum allowable size if the request
+    exeeds the limits.
 
-    On invalid grid handle, fails with error.
+    If the grid handle is invalid, this function fails with an error.
+    
 
     Attributes: ~
         |RPC| only

--- a/runtime/doc/pi_msgpack.txt
+++ b/runtime/doc/pi_msgpack.txt
@@ -6,7 +6,7 @@ Copyright: (c) 2015 by Nikolay Pavlov
 The Apache license applies to the files in this package, including
 runtime/autoload/msgpack.vim, runtime/doc/pi_msgpack.txt and
 test/functional/plugin/msgpack_spec.lua.  Like anything else that's free,
-msgpack.vim and its associated files are provided as is and comes with no
+msgpack.vim and its associated files are provided as is and come with no
 warranty of any kind, either expressed or implied.  No guarantees of
 merchantability.  No guarantees of suitability for any purpose.  By using this
 plugin, you agree that in no event will the copyright holder be liable for any
@@ -43,7 +43,7 @@ This plugin contains utility functions to be used in conjunction with
 
 FUNCTION ARGUMENTS				*msgpack.vim-arguments*
 
-Disambiguation of arguments described below.  Note: if e.g. function is listed
+Disambiguation of arguments described below.  Note: if e.g. a function is listed
 as accepting |{msgpack-integer}| (or anything else) it means that function
 does not check whether argument matches its description.
 
@@ -70,7 +70,7 @@ msgpack#strftime({format}, {msgpack-integer})		*msgpack#strftime()*
 msgpack#strptime({format}, {time})			*msgpack#strptime()*
 	Reverse of |msgpack#strftime()|: for any time and format
 	|msgpack#equal|( |msgpack#strptime|(format, |msgpack#strftime|(format,
-	time)), time) be true.  Requires ||Python|, without it only supports
+	time)), time) will be true.  Requires ||Python|, without it only supports
 	non-|msgpack-special-dict| nonnegative times and format equal to
 	`%Y-%m-%dT%H:%M:%S`.
 
@@ -99,7 +99,7 @@ msgpack#deepcopy({msgpack-value})			*msgpack#deepcopy()*
 msgpack#string({msgpack-value})				*msgpack#string()*
 	Like |string()|, but saves information about msgpack types.  Values
 	dumped by msgpack#string may be read back by |msgpack#eval()|.
-	Returns is the following:
+	Returns the following:
 
 	- Dictionaries are dumped as "{key1: value1, key2: value2}". Note:
 	  msgpack allows any values in keys, so with some
@@ -111,7 +111,7 @@ msgpack#string({msgpack-value})				*msgpack#string()*
 	  2. `="abc"`: string.
 	  3. `+(10)"ext"`: extension strings (10 may be replaced with any
 	     8-bit signed integer).
-	  Inside strings the following escape sequences may be present: "\0"
+	  Inside strings, the following escape sequences may be present: "\0"
 	  (represents NUL byte), "\n" (represents line feed) and "\""
 	  (represents double quote).
 	- Floating-point and integer values are dumped using |string()| or

--- a/runtime/doc/pi_spec.txt
+++ b/runtime/doc/pi_spec.txt
@@ -7,9 +7,9 @@ This is a filetype plugin to work with rpm spec files.
 Currently, this Vim plugin allows you to easily update the %changelog
 section in RPM spec files.  It will even create a section for you if it
 doesn't exist yet.  If you've already inserted an entry today, it will
-give you the opportunity to just add a new item in today's entry.  If you
+give you the opportunity to just add a new item to today's entry.  If you
 don't provide a format string (|spec_chglog_format|), it'll ask you an
-email address and build a format string by itself.
+email address and build a format string for the edit session by itself.
 
 1. How to use it	|spec-how-to-use-it|
 2. Customizing		|spec-customizing|
@@ -26,8 +26,7 @@ your maplocalleader key (default is '\') plus 'c'.  If you do not have
 |spec_chglog_format| set, the plugin will ask you for an email address
 to use in this edit session.
 
-Every time you run the plugin, it will check to see if the last entry in the
-changelog has been written today and by you.  If the entry matches, it will
+Every time you run the plugin, it will check whether the last changelog entry was written today and by you. If the entry matches, it will
 just insert a new changelog item, otherwise it will create a new changelog
 entry.  If you are running with |spec_chglog_release_info| enabled, it will
 also check if the name, version and release matches.  The plugin is smart
@@ -75,8 +74,8 @@ function man page.
 ------------------------------------------------------------------------------
 Where to insert new items			*spec_chglog_prepend*
 
-The plugin will usually insert new %changelog entry items (note that it's
-not the entry itself) after the existing ones.  If you set the
+The plugin will usually insert new %changelog entry items (note: this affects
+only the items within the changelog entry, not the entry itself) after the existing ones.  If you set the
 spec_chglog_prepend variable >
 
 	let spec_chglog_prepend = 1


### PR DESCRIPTION
This PR fixes minor typos in several documentation files under runtime/doc.
