### PR TITLE
docs: misc

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1266,6 +1266,7 @@ tag		command		action ~
 |:delcommand|	:delc[ommand]	delete user-defined command
 |:delfunction|	:delf[unction]	delete a user function
 |:delmarks|	:delm[arks]	delete marks
+|:detach|	:detach		detach the current UI
 |:diffupdate|	:dif[fupdate]	update 'diff' buffers
 |:diffget|	:diffg[et]	remove differences in current buffer
 |:diffoff|	:diffo[ff]	switch off diff mode
@@ -1525,6 +1526,7 @@ tag		command		action ~
 |:redrawtabline|  :redrawt[abline]  force a redraw of the tabline
 |:registers|	:reg[isters]	display the contents of registers
 |:resize|	:res[ize]	change current window height
+|:restart|	:restart	restart the Nvim server
 |:retab|	:ret[ab]	change tab size
 |:return|	:retu[rn]	return from a user function
 |:rewind|	:rew[ind]	go to the first file in the argument list

--- a/runtime/doc/intro.txt
+++ b/runtime/doc/intro.txt
@@ -89,7 +89,7 @@ To uninstall Nvim:
   - Scoop (Windows): `scoop uninstall neovim`
 
 ==============================================================================
-Sponsor Vim/Nvim development                            *sponsor* *register*
+Sponsor Vim/Nvim development                            *sponsor*
 
 Fixing bugs and adding new features takes a lot of time and effort.  To show
 your appreciation for the work and motivate developers to continue working on

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -225,6 +225,7 @@ MAJOR COMPONENTS
 - LSP framework                   |lsp|
 - Lua scripting                   |lua|
 - Parsing engine                  |treesitter|
+- Plugin manager                  |vim.pack|
 - Providers
   - Clipboard                     |provider-clipboard|
   - Node.js plugins               |provider-nodejs|
@@ -298,10 +299,15 @@ Command-line:
 
 Commands:
 - |:checkhealth|
+- |:detach|
 - |:drop| is always available
+- |:Inspect|
+- |:InspectTree|
 - |:Man| is available by default, with many improvements such as completion
 - |:match| can be invoked before highlight group is defined
+- |:restart|
 - |:source| works with Lua
+- |:trust|
 - User commands can support |:command-preview| to show results as you type
 - |:write| with "++p" flag creates parent directories.
 


### PR DESCRIPTION
Problems:
- Miss some entries in `vim_diff.txt` and `index.txt`.
- I want to learn about Vim register, but when I type `:h register`, it shows sponsor information instead. Note that unlike Nvim, Vim has a separate section for `*register*` https://github.com/vim/vim/blob/eb380b991c9d85f4622a27d1d35364615b7a71f4/runtime/doc/sponsor.txt#L25-L32

Solution:
- Add missing entries to `index.txt`, `vim_diff.txt`
- Remove tag `register` from `index.txt`

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
