### PR TITLE
feat(diagnostic): jump to related info location from `open_float`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1903,7 +1903,8 @@ Lua module: vim.lsp.diagnostic                                *lsp-diagnostic*
 This module provides functionality for requesting LSP diagnostics for a
 document/workspace and populating them using |vim.Diagnostic|s.
 `DiagnosticRelatedInformation` is supported: it is included in the window
-shown by |vim.diagnostic.open_float()|.
+shown by |vim.diagnostic.open_float()|. When the cursor is on a line with
+related information, |gf| jumps to the problem location.
 
 
 from({diagnostics})                                *vim.lsp.diagnostic.from()*

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -199,6 +199,9 @@ LSP
 • LSP `DiagnosticRelatedInformation` is now shown in
   |vim.diagnostic.open_float()|. It is read from the LSP diagnostic object
   stored in the `user_data` field.
+• When inside the float created by |vim.diagnostic.open_float()| and the
+  cursor is on a line with `DiagnosticRelatedInformation`, |gf| can be used to
+  jump to the problematic location.
 
 LUA
 

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -1,6 +1,7 @@
 ---@brief This module provides functionality for requesting LSP diagnostics for a document/workspace
 ---and populating them using |vim.Diagnostic|s. `DiagnosticRelatedInformation` is supported: it is
----included in the window shown by |vim.diagnostic.open_float()|.
+---included in the window shown by |vim.diagnostic.open_float()|. When the cursor is on a line with
+---related information, |gf| jumps to the problem location.
 
 local lsp = vim.lsp
 local protocol = lsp.protocol


### PR DESCRIPTION
This commit allows users to jump to the location specified in a diagnostic's `relatedInformation`, using `gf` from within the `open_float` window. The cursor need only be on line that displays the related info.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
