### PR TITLE
feat(lsp): support signature help noActiveParameterSupport

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -87,6 +87,11 @@ LSP
 • `vim.lsp.semantic_tokens.start/stop` now renamed to
   `vim.lsp.semantic_tokens.enable`
 • Missing fields in LSP messages are now represented using |vim.NIL| instead of nil.
+• |vim.lsp.util.convert_signature_help_to_markdown_lines()| activeParameter
+  handling updated:
+    • Values < 0 are now treated as `nil` instead of 0.
+    • Values outside the range of `signatures[activeSignature].parameters`
+      are now treated as `nil` instead of `#signatures[activeSignature].parameters`
 
 LUA
 
@@ -222,6 +227,7 @@ LSP
   https://microsoft.github.io/language-server-protocol/specification/#textDocument_linkedEditingRange
 • Support for related documents in pull diagnostics:
   https://microsoft.github.io/language-server-protocol/specifications/specification-current/#relatedFullDocumentDiagnosticReport
+• |vim.lsp.buf.signature_help()| supports "noActiveParameterSupport".
 
 LUA
 

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -330,8 +330,8 @@ local function process_signature_help_results(results)
       )
       api.nvim_command('redraw')
     else
-      local result = r.result --- @type lsp.SignatureHelp
-      if result and result.signatures and result.signatures[1] then
+      local result = r.result
+      if result and result.signatures then
         for i, sig in ipairs(result.signatures) do
           sig.activeParameter = sig.activeParameter or result.activeParameter
           local idx = #signatures + 1

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -514,6 +514,7 @@ function protocol.make_client_capabilities()
         dynamicRegistration = false,
         signatureInformation = {
           activeParameterSupport = true,
+          noActiveParameterSupport = true,
           documentationFormat = { constants.MarkupKind.Markdown, constants.MarkupKind.PlainText },
           parameterInformation = {
             labelOffsetSupport = true,


### PR DESCRIPTION
Fix handling of `activeParameter`: no longer defaults to 0 if missing or out of bounds.  
Current behavior violates the LSP spec; some servers may intentionally omit this value.  
For example, in languages with named arguments, `nil` means no parameter match.