### PR TITLE
vim-patch:9.1.1521: completion: pum does not reset scroll pos on reopen with 'noselect' (#34836)

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -378,6 +378,7 @@ static int cmdline_pum_create(CmdlineInfo *ccline, expand_T *xp, char **matches,
   // no default selection
   compl_selected = -1;
 
+  pum_clear();
   cmdline_pum_display(true);
 
   return EXPAND_OK;

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -5494,6 +5494,49 @@ describe('builtin popupmenu', function()
         ]])
       end)
 
+      -- oldtest: Test_pum_scroll_noselect()
+      it('cmdline pum does not retain scroll position with "noselect"', function()
+        screen:try_resize(32, 10)
+        exec([[
+          command! -nargs=* -complete=customlist,TestFn TestCmd echo
+          func TestFn(a, b, c)
+            return map(range(1, 50), 'printf("a%d", v:val)')
+          endfunc
+          set wildmode=noselect,full
+          set wildoptions=pum
+          set wildmenu
+          set noruler
+        ]])
+
+        feed(':TestCmd <tab>' .. ('<c-n>'):rep(20))
+        screen:expect([[
+                  {n: a15            }{s: }       |
+          {1:~       }{n: a16            }{s: }{1:       }|
+          {1:~       }{n: a17            }{s: }{1:       }|
+          {1:~       }{n: a18            }{c: }{1:       }|
+          {1:~       }{n: a19            }{s: }{1:       }|
+          {1:~       }{s: a20             }{1:       }|
+          {1:~       }{n: a21            }{s: }{1:       }|
+          {1:~       }{n: a22            }{s: }{1:       }|
+          {1:~       }{n: a23            }{s: }{1:       }|
+          :TestCmd a20^                    |
+        ]])
+
+        feed('<esc>:TestCmd <tab>')
+        screen:expect([[
+                  {n: a1             }{c: }       |
+          {1:~       }{n: a2             }{s: }{1:       }|
+          {1:~       }{n: a3             }{s: }{1:       }|
+          {1:~       }{n: a4             }{s: }{1:       }|
+          {1:~       }{n: a5             }{s: }{1:       }|
+          {1:~       }{n: a6             }{s: }{1:       }|
+          {1:~       }{n: a7             }{s: }{1:       }|
+          {1:~       }{n: a8             }{s: }{1:       }|
+          {1:~       }{n: a9             }{s: }{1:       }|
+          :TestCmd ^                       |
+        ]])
+      end)
+
       it(
         'cascading highlights for matched text (PmenuMatch, PmenuMatchSel) in cmdline pum',
         function()


### PR DESCRIPTION
Backport of #34836

Problem:  When 'wildmode' is set to include "noselect", the popup menu (pum)
          incorrectly retained its scroll position when reopened. This
          meant that after scrolling down through the menu with `<C-n>`,
          reopening the menu (e.g., by retyping the command and
          triggering completion again) would show the menu starting from
          the previously scrolled position, rather than from the top.
          This could confuse users, as the first visible item would not
          be the first actual match in the list.

Solution: Ensure that the popup menu resets its scroll position to the
          top when reopened (Girish Palya).

closes: vim/vim#17673

https://github.com/vim/vim/commit/0cd7f3536bde47cf9693090b839abf88c7f019c8

Co-authored-by: Girish Palya <girishji@gmail.com>
