### PR TITLE
vim-patch:9.1.{0877,1519}

### DIFF
--- a/test/old/testdir/test_plugin_termdebug.vim
+++ b/test/old/testdir/test_plugin_termdebug.vim
@@ -177,6 +177,62 @@ func Test_termdebug_basic()
   %bw!
 endfunc
 
+func Test_termdebug_decimal_breakpoints()
+  let bin_name = 'XTD_decimal'
+  let src_name = bin_name .. '.c'
+  call s:generate_files(bin_name)
+
+  exe "edit " .. src_name
+
+  let g:termdebug_config = {}
+  let g:termdebug_config['sign_decimal'] = 1
+
+  exe "Termdebug " .. bin_name
+  call WaitForAssert({-> assert_true(get(g:, "termdebug_is_running", v:false))})
+  call WaitForAssert({-> assert_equal(3, winnr('$'))})
+  let gdb_buf = winbufnr(1)
+  wincmd b
+  Break 9
+  call Nterm_wait(gdb_buf)
+  redraw!
+
+  let i = 2
+  while i <= 258
+    Break
+    call Nterm_wait(gdb_buf)
+    if i == 2
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint2.0')[0].text, '02')})
+    endif
+    if i == 10
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint10.0')[0].text, '10')})
+    endif
+    if i == 168
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint168.0')[0].text, '9+')})
+    endif
+    if i == 255
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint255.0')[0].text, '9+')})
+    endif
+    if i == 256
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint256.0')[0].text, '9+')})
+    endif
+    if i == 258
+      call WaitForAssert({-> assert_equal(sign_getdefined('debugBreakpoint258.0')[0].text, '9+')})
+    endif
+    let i += 1
+  endwhile
+
+  wincmd t
+  quit!
+  redraw!
+  call WaitForAssert({-> assert_equal(1, winnr('$'))})
+  call assert_equal([], sign_getplaced('', #{group: 'TermDebug'})[0].signs)
+
+  call s:cleanup_files(bin_name)
+  %bw!
+
+  unlet g:termdebug_config
+endfunc
+
 func Test_termdebug_tbreak()
   let g:test_is_flaky = 1
   let bin_name = 'XTD_tbreak'

--- a/test/old/testdir/test_plugin_termdebug.vim
+++ b/test/old/testdir/test_plugin_termdebug.vim
@@ -188,13 +188,16 @@ func Test_termdebug_decimal_breakpoints()
   let g:termdebug_config['sign_decimal'] = 1
 
   exe "Termdebug " .. bin_name
-  call WaitForAssert({-> assert_true(get(g:, "termdebug_is_running", v:false))})
+  " Nvim: g:termdebug_is_running is not ported yet
+  " call WaitForAssert({-> assert_true(get(g:, "termdebug_is_running", v:false))})
   call WaitForAssert({-> assert_equal(3, winnr('$'))})
   let gdb_buf = winbufnr(1)
   wincmd b
   Break 9
   call Nterm_wait(gdb_buf)
   redraw!
+  Run
+  call Nterm_wait(gdb_buf, 400)
 
   let i = 2
   while i <= 258


### PR DESCRIPTION
#### vim-patch:9.1.0877: tests: missing test for termdebug + decimal signs

Problem:  tests: missing test for termdebug + decimal signs
Solution: Add a termdebug test (Ubaldo Tiberi)

closes: vim/vim#16081

https://github.com/vim/vim/commit/b5c1557323e4e3377c034f1a04fad9027a5bf59e

Co-authored-by: Ubaldo Tiberi <ubaldo.tiberi@volvo.com>


#### vim-patch:9.1.1519: tests: Test_termdebug_decimal_breakpoints() may fail

Problem:  Test_termdebug_decimal_breakpoints() fails with List index out
          of range, because when adding the second breakpoint, the
          cursor is still on the very first line (a header include line)
          and therefore gdb refuses to set the breakpoint with:
          `msg="No compiled code for line 1 in file XTD_decimal.c"`
Solution: Run the program, so that it will break at the very first
          defined breakpoint and then once we are in the program,
          set further breakpoints

closes: vim/vim#17689

https://github.com/vim/vim/commit/faed074ab7dee8d1c89978090a674008c50f65d8

Co-authored-by: Christian Brabandt <cb@256bit.org>