### PR TITLE
docs: tag of `:EditQuery`

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1321,7 +1321,7 @@ add_predicate({name}, {handler}, {opts})
 edit({lang})                                     *vim.treesitter.query.edit()*
     Opens a live editor to query the buffer you started from.
 
-    Can also be shown with *:EditQuery*.
+    Can also be shown with `:EditQuery`.                          *:EditQuery*
 
     If you move the cursor to a capture name ("@foo"), text matching the
     capture is highlighted in the source buffer. The query editor is a scratch

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -301,6 +301,7 @@ Commands:
 - |:checkhealth|
 - |:detach|
 - |:drop| is always available
+- |:EditQuery|
 - |:Inspect|
 - |:InspectTree|
 - |:Man| is available by default, with many improvements such as completion

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -1163,7 +1163,7 @@ end
 
 --- Opens a live editor to query the buffer you started from.
 ---
---- Can also be shown with [:EditQuery]().
+--- Can also be shown with `:EditQuery`. [:EditQuery]()
 ---
 --- If you move the cursor to a capture name ("@foo"), text matching the capture is highlighted in
 --- the source buffer. The query editor is a scratch buffer, use `:write` to save it. You can find


### PR DESCRIPTION
Problem:
- Running `:h :EditQuery` throws error `E149: Sorry, no help for :EditQuery`
- vim_diff.txt miss an entry for `:EditQuery`

Solution:
- Make tag `[:EditQuery]()` right-aligned, similar to command `:Open`
- Update vim_diff.txt

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
