### PR TITLE
fix(lsp): decode 'null' in server responses as vim.NIL 

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -86,6 +86,7 @@ LSP
   arguments corresponding to a log entry instead of the individual arguments.
 • `vim.lsp.semantic_tokens.start/stop` now renamed to
   `vim.lsp.semantic_tokens.enable`
+• Missing fields in LSP messages are now represented using |vim.NIL| instead of nil.
 
 LUA
 

--- a/runtime/lua/vim/lsp/_meta/protocol.lua
+++ b/runtime/lua/vim/lsp/_meta/protocol.lua
@@ -11,7 +11,7 @@ nvim -l src/gen/gen_lsp.lua --version 3.18
 ---@meta
 error('Cannot require a meta file')
 
----@alias lsp.null nil
+---@alias lsp.null vim.NIL
 ---@alias uinteger integer
 ---@alias decimal number
 ---@alias lsp.DocumentUri string
@@ -3297,7 +3297,7 @@ error('Cannot require a meta file')
 ---@class lsp.FileOperationPattern
 ---
 ---The glob pattern to match. Glob patterns can have the following syntax:
----- `*` to match one or more characters in a path segment
+---- `*` to match zero or more characters in a path segment
 ---- `?` to match on one character in a path segment
 ---- `**` to match any number of path segments, including none
 ---- `{}` to group sub patterns into an OR expression. (e.g. `**/*.{ts,js}` matches all TypeScript and JavaScript files)
@@ -5699,7 +5699,7 @@ error('Cannot require a meta file')
 ---its resource, or a glob-pattern that is applied to the {@link TextDocument.fileName path}.
 ---
 ---Glob patterns can have the following syntax:
----- `*` to match one or more characters in a path segment
+---- `*` to match zero or more characters in a path segment
 ---- `?` to match on one character in a path segment
 ---- `**` to match any number of path segments, including none
 ---- `{}` to group sub patterns into an OR expression. (e.g. `**/*.{ts,js}` matches all TypeScript and JavaScript files)
@@ -5720,7 +5720,7 @@ error('Cannot require a meta file')
 ---@alias lsp.NotebookDocumentFilter lsp.NotebookDocumentFilterNotebookType|lsp.NotebookDocumentFilterScheme|lsp.NotebookDocumentFilterPattern
 
 ---The glob pattern to watch relative to the base path. Glob patterns can have the following syntax:
----- `*` to match one or more characters in a path segment
+---- `*` to match zero or more characters in a path segment
 ---- `?` to match on one character in a path segment
 ---- `**` to match any number of path segments, including none
 ---- `{}` to group conditions (e.g. `**/*.{ts,js}` matches all TypeScript and JavaScript files)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -520,7 +520,7 @@ function M.apply_text_document_edit(
     -- do not check the version after the first edit.
     not (index and index > 1)
     and (
-      text_document.version
+      text_document.version ~= vim.NIL
       and text_document.version > 0
       and M.buf_versions[bufnr] > text_document.version
     )
@@ -827,8 +827,12 @@ function M.convert_signature_help_to_markdown_lines(signature_help, ft, triggers
   if signature.parameters and #signature.parameters > 0 then
     -- First check if the signature has an activeParameter. If it doesn't check if the response
     -- had that property instead. Else just default to 0.
-    local active_parameter =
-      math.max(signature.activeParameter or signature_help.activeParameter or 0, 0)
+    --
+    -- NOTE: Using tonumber() as a temporary workaround to handle `vim.NIL` until #34838 is merged
+    local active_parameter = math.max(
+      tonumber(signature.activeParameter) or tonumber(signature_help.activeParameter) or 0,
+      0
+    )
 
     -- If the activeParameter is > #parameters, then set it to the last
     -- NOTE: this is not fully according to the spec, but a client-side interpretation

--- a/src/gen/gen_lsp.lua
+++ b/src/gen/gen_lsp.lua
@@ -370,7 +370,7 @@ local function write_to_meta_protocol(protocol, version, output_file)
     '---@meta',
     "error('Cannot require a meta file')",
     '',
-    '---@alias lsp.null nil',
+    '---@alias lsp.null vim.NIL',
     '---@alias uinteger integer',
     '---@alias decimal number',
     '---@alias lsp.DocumentUri string',

--- a/test/functional/fixtures/fake-lsp-server.lua
+++ b/test/functional/fixtures/fake-lsp-server.lua
@@ -172,7 +172,7 @@ function tests.prepare_rename_nil()
     body = function()
       notify('start')
       expect_request('textDocument/prepareRename', function()
-        return nil, nil
+        return {}, nil
       end)
       notify('shutdown')
     end,
@@ -197,7 +197,7 @@ function tests.prepare_rename_placeholder()
       end)
       expect_request('textDocument/rename', function(params)
         assert_eq(params.newName, 'renameto')
-        return nil, nil
+        return {}, nil
       end)
       notify('shutdown')
     end,
@@ -226,7 +226,7 @@ function tests.prepare_rename_range()
       end)
       expect_request('textDocument/rename', function(params)
         assert_eq(params.newName, 'renameto')
-        return nil, nil
+        return {}, nil
       end)
       notify('shutdown')
     end,

--- a/test/functional/plugin/lsp/document_color_spec.lua
+++ b/test/functional/plugin/lsp/document_color_spec.lua
@@ -129,7 +129,7 @@ body {
     exec_lua(function()
       _G.server2 = _G._create_server({
         colorProvider = {
-          documentSelector = nil,
+          documentSelector = vim.NIL,
         },
         handlers = {
           ['textDocument/documentColor'] = function(_, _, callback)

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -1976,7 +1976,7 @@ describe('LSP', function()
         {
           NIL,
           {
-            arguments = { 'EXTRACT_METHOD', { metadata = {} }, 3, 0, 6123, NIL },
+            arguments = { 'EXTRACT_METHOD', { metadata = { field = vim.NIL } }, 3, 0, 6123, NIL },
             command = 'refactor.perform',
             title = 'EXTRACT_METHOD',
           },
@@ -4498,7 +4498,7 @@ describe('LSP', function()
         name = 'prepare_rename_placeholder',
         expected_handlers = {
           { NIL, {}, { method = 'shutdown', client_id = 1 } },
-          { NIL, NIL, { method = 'textDocument/rename', client_id = 1, bufnr = 1 } },
+          { {}, NIL, { method = 'textDocument/rename', client_id = 1, bufnr = 1 } },
           { NIL, {}, { method = 'start', client_id = 1 } },
         },
         expected_text = 'placeholder', -- see fake lsp response
@@ -4508,7 +4508,7 @@ describe('LSP', function()
         name = 'prepare_rename_range',
         expected_handlers = {
           { NIL, {}, { method = 'shutdown', client_id = 1 } },
-          { NIL, NIL, { method = 'textDocument/rename', client_id = 1, bufnr = 1 } },
+          { {}, NIL, { method = 'textDocument/rename', client_id = 1, bufnr = 1 } },
           { NIL, {}, { method = 'start', client_id = 1 } },
         },
         expected_text = 'line', -- see test case and fake lsp response


### PR DESCRIPTION
The current LSP parser treats absent fields and explicitly `null` fields the same, collapsing both into nil.

One possible solution would be to remove the 'object' flag and do explicit presence checks in all LSP handlers. But this would introduce a lot of unnecessary boilerplate in places where it doesn't matter, since the distinction between `null` and missing only matters for a few specific LSP types.

The fix I currently have in a draft state is to track `?|null` paths in a static tree, which is (ideally) generated from the spec. This allows handling of certain key paths explicitly and emit `vim.NIL` for `null`, keeping nil reserved for missing fields. This approach works and fixes #31368 and unblocks #34838.

However, it comes with some drawbacks: the parser doesn't know the actual expected type when encountering a key path like "result.data"; this path could appear in multiple methods, not just CodeAction responses.


What would be ideal is to make the parser type-aware. That is:

- Parse the top-level response object.

- Use the "id" to find the method name that was originally sent.

- With that context, parse the "result" or "error" field according to the expected schema for that method.

This is how it typically works in statically typed languages: the response handler already knows the expected structure, since it needs to allocate a concrete struct. In Lua, we don’t have static typing, and as far as I know, there’s no native way to enforce such schemas during deserialization.

A type-aware parser would not only solve the `null` vs `undefined` distinction cleanly, but also allow validating responses and reporting errors early if the server breaks the spec contract. It would give us fully type-safe LSP handlers.

At this point, I’m not sure in which direction I should continue. Should I explore building a proper type-aware parser, or focus on improving the current approach by generating the path tree from the spec and documenting it better?

I feel like I might be missing something, so I'd really appreciate any feedback, guidance, or alternative ideas.