### PR TITLE
fix(runtime): no conceal in qf on `lopen`

### DIFF
--- a/runtime/syntax/qf.vim
+++ b/runtime/syntax/qf.vim
@@ -19,7 +19,7 @@ syn match	qfError		"error"	 contained
 syn cluster	qfType	contains=qfError
 
 " Hide file name and line number for help outline (TOC).
-if has_key(w:, 'qf_toc') || get(w:, 'quickfix_title') =~# '\<TOC$'
+if has_key(w:, 'qf_toc') || get(w:, 'quickfix_title') =~# '\<TOC$\|\<Table of contents\>'
   setlocal conceallevel=3 concealcursor=nc
   syn match	Ignore		"^[^|]*|[^|]*| " conceal
 endif


### PR DESCRIPTION
Problem: no conceal in qf on `lopen` since 74fcc945

Repro: `nvim --clean +'tab Man ls' +'norm gO' +lclose +lopen`

Solution: consider "Table of contents" title
