### PR TITLE
vim-patch:bda55df: Revert "runtime(haskell): Add single quote to `iskeyword` in ftplugin (vim/vim#8191)"

### DIFF
--- a/runtime/ftplugin/haskell.vim
+++ b/runtime/ftplugin/haskell.vim
@@ -3,6 +3,7 @@
 " Maintainer:           Daniel Campoverde <alx@sillybytes.net>
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
 " Latest Revision:      2018-08-27
+" 2025 Jul 09 by Vim Project revert setting iskeyword #8191
 
 if exists("b:did_ftplugin")
   finish
@@ -17,7 +18,6 @@ let b:undo_ftplugin = "setl com< cms< fo<"
 setlocal comments=s1fl:{-,mb:-,ex:-},:-- commentstring=--\ %s
 setlocal formatoptions-=t formatoptions+=croql
 setlocal omnifunc=haskellcomplete#Complete
-setlocal iskeyword+='
 
 let &cpo = s:cpo_save
 unlet s:cpo_save


### PR DESCRIPTION
This reverts commit 5e6e4042b1c9685bce86493e3ee6fe916a7f221c.

related: vim/vim#8191

https://github.com/vim/vim/commit/bda55df3b8919c70c006f55b23d926555ad06088

Co-authored-by: Christian Brabandt <cb@256bit.org>

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
