### PR TITLE
feat(extui): use winborder for msg window

### DIFF
--- a/runtime/lua/vim/_extui.lua
+++ b/runtime/lua/vim/_extui.lua
@@ -87,14 +87,6 @@ function M.enable(opts)
     return true
   end)
 
-  -- Use MsgArea and hide search highlighting in the cmdline window.
-  -- TODO: Add new highlight group/namespaces for other windows? It is
-  -- not clear if MsgArea is wanted in the msg, pager and dialog windows.
-  api.nvim_set_hl(ext.ns, 'Normal', { link = 'MsgArea' })
-  api.nvim_set_hl(ext.ns, 'Search', { link = 'MsgArea' })
-  api.nvim_set_hl(ext.ns, 'CurSearch', { link = 'MsgArea' })
-  api.nvim_set_hl(ext.ns, 'IncSearch', { link = 'MsgArea' })
-
   -- The visibility and appearance of the cmdline and message window is
   -- dependent on some option values. Reconfigure windows when option value
   -- has changed and after VimEnter when the user configured value is known.

--- a/runtime/lua/vim/_extui/messages.lua
+++ b/runtime/lua/vim/_extui/messages.lua
@@ -104,7 +104,8 @@ local function set_virttext(type)
       -- of the last visible message line, overlapping the message text if necessary,
       -- but not overlapping the 'last' virt_text.
       local offset = tar ~= 'msg' and 0
-        or api.nvim_win_get_position(win)[2] + (api.nvim_win_get_config(win).border and 1 or 0)
+        or api.nvim_win_get_position(win)[2]
+          + (api.nvim_win_get_config(win).border ~= 'none' and 1 or 0)
 
       -- Check if adding the virt_text on this line will exceed the current window width.
       local maxwidth = math.max(M.msg.width, math.min(o.columns, scol - offset + width))
@@ -465,14 +466,14 @@ function M.set_pos(type)
     local texth = type and api.nvim_win_text_height(win, {}) or {}
     local height = type and math.min(texth.all, math.ceil(o.lines * 0.5))
     local top = { vim.opt.fcs:get().horiz or o.ambw == 'single' and '─' or '-', 'WinSeparator' }
-    local border = type ~= 'msg' and { '', top, '', '', '', '', '', '' } or nil
+    local border = win ~= ext.wins.msg and { '', top, '', '', '', '', '', '' } or nil
     local save_config = type == 'cmd' and api.nvim_win_get_config(win) or {}
     local config = {
       hide = false,
       relative = 'laststatus',
       border = border,
       height = height,
-      row = type == 'msg' and 0 or 1,
+      row = win == ext.wins.msg and 0 or 1,
       col = 10000,
       focusable = type == 'cmd' or nil, -- Allow entering the cmdline window.
     }

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -31,8 +31,8 @@ describe('messages2', function()
                                                            |
       {1:~                                                    }|*9
       ─────────────────────────────────────────────────────|
-      {4:fo^o                                                  }|
-      {4:bar                                                  }|
+      fo^o                                                  |
+      bar                                                  |
                                           1,3           All|
     ]])
     -- New message clears spill indicator.
@@ -41,8 +41,8 @@ describe('messages2', function()
                                                            |
       {1:~                                                    }|*9
       ─────────────────────────────────────────────────────|
-      {4:fo^o                                                  }|
-      {4:bar                                                  }|
+      fo^o                                                  |
+      bar                                                  |
       {9:E354: Invalid register name: '^@'}   1,3           All|
     ]])
     -- Multiple messages in same event loop iteration are appended and shown in full.
@@ -105,7 +105,7 @@ describe('messages2', function()
                                                            |
       {1:~                                                    }|*10
       ─────────────────────────────────────────────────────|
-      {4:fo^o                                                  }|
+      fo^o                                                  |
       foo                                                  |
     ]])
     command('bdelete | messages')
@@ -142,9 +142,9 @@ describe('messages2', function()
     screen:expect([[
       ^                                                     |
       {1:~                                                    }|*10
-      {1:~                                               }┌───┐|
-      {1:~                                               }│{4:foo}│|
-      {1:~                                               }└───┘|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                 }{4:foo}|
     ]])
     command('mode')
     screen:expect([[
@@ -156,9 +156,9 @@ describe('messages2', function()
     screen:expect([[
       ^                                                     |
       {1:~                                                    }|*10
-      {1:~                                               }┌───┐|
-      {1:~                                               }│{4:foo}│|
-      {1:~                                               }└───┘|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                 }{4:foo}|
     ]])
     command('echo ""')
     screen:expect_unchanged()
@@ -167,9 +167,29 @@ describe('messages2', function()
     screen:expect([[
       ^                                                     |
       {1:~                                                    }|*9
-      {1:~                                               }┌───┐|
-      {1:~                                               }│{4:foo}│|
-      {1:~                                               }└───┘|
+      {1:~                                                    }|
+      {1:~                                                    }|
+      {1:~                                                 }{4:foo}|
     ]])
+    -- Moved up when opening cmdline
+    feed(':')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*10
+      {1:~                                                 }{4:foo}|
+      {16::}^                                                    |
+    ]])
+  end)
+
+  it("deleting buffer restores 'buftype'", function()
+    command('%bdelete')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      5 buffers deleted                                    |
+    ]])
+    -- Would trigger changed dialog if 'buftype' was not restored.
+    command('%bdelete')
+    screen:expect_unchanged()
   end)
 end)


### PR DESCRIPTION
Problem:  The message window is essentially a regular floating window
          but does not use 'winborder'.
          Still some "scratch" buffer options unset after it was removed
          from its window.
Solution: Do not set the border when opening the window message.
          Forego passing `scratch = true` when opening a buffer,
          set the options manually when necessary.