### PR TITLE
feat(tui): use DA1 response to determine OSC 52 support

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -4130,9 +4130,9 @@ nvim_ui_term_event({event}, {value})                    *nvim_ui_term_event()*
     Tells Nvim when a terminal event has occurred
 
     The following terminal events are supported:
-    • "termresponse": The terminal sent an OSC, DCS, or APC response sequence
-      to Nvim. The payload is the received response. Sets |v:termresponse| and
-      fires |TermResponse|.
+    • "termresponse": The terminal sent a DA1, OSC, DCS, or APC response
+      sequence to Nvim. The payload is the received response. Sets
+      |v:termresponse| and fires |TermResponse|.
 
     Attributes: ~
         |RPC| only

--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1049,7 +1049,7 @@ TermRequest			When a |:terminal| child process emits an OSC,
 				autocommand defined without |autocmd-nested|.
 
 							*TermResponse*
-TermResponse			When Nvim receives an OSC, DCS, or APC response from
+TermResponse			When Nvim receives a DA1, OSC, DCS, or APC response from
 				the host terminal. Sets |v:termresponse|. The
 				|event-data| is a table with the following fields:
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -261,7 +261,7 @@ TREESITTER
 
 TUI
 
-• |TermResponse| now supports APC query responses.
+• |TermResponse| now supports DA1 and APC query responses.
 
 UI
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -325,8 +325,8 @@ Events (autocommands):
 - |TabNewEntered|
 - |TermClose|
 - |TermOpen|
-- |TermResponse| is fired for any OSC sequence received from the terminal,
-  instead of the Primary Device Attributes response. |v:termresponse|
+- |TermResponse| is fired for DCS, OSC, and APC sequences received from the terminal,
+  in addition to the Primary Device Attributes response. |v:termresponse|
 - |UIEnter|
 - |UILeave|
 

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -543,7 +543,7 @@ void nvim_ui_pum_set_bounds(uint64_t channel_id, Float width, Float height, Floa
 ///
 /// The following terminal events are supported:
 ///
-///   - "termresponse": The terminal sent an OSC, DCS, or APC response sequence to
+///   - "termresponse": The terminal sent a DA1, OSC, DCS, or APC response sequence to
 ///                     Nvim. The payload is the received response. Sets
 ///                     |v:termresponse| and fires |TermResponse|.
 ///

--- a/src/nvim/vterm/state.c
+++ b/src/nvim/vterm/state.c
@@ -20,7 +20,7 @@
 // Primary Device Attributes (DA1) response.
 // We make this a global (extern) variable so that we can override it with FFI
 // in tests.
-char vterm_primary_device_attr[] = "1;2;52";
+char vterm_primary_device_attr[] = "61;22;52";
 
 // Some convenient wrappers to make callback functions easier
 

--- a/src/nvim/vterm/state.c
+++ b/src/nvim/vterm/state.c
@@ -17,6 +17,11 @@
 
 #define strneq(a, b, n) (strncmp(a, b, n) == 0)
 
+// Primary Device Attributes (DA1) response.
+// We make this a global (extern) variable so that we can override it with FFI
+// in tests.
+char vterm_primary_device_attr[] = "1;2;52";
+
 // Some convenient wrappers to make callback functions easier
 
 static void putglyph(VTermState *state, const schar_T schar, int width, VTermPos pos)
@@ -1385,7 +1390,7 @@ static int on_csi(const char *leader, const long args[], int argcount, const cha
     val = CSI_ARG_OR(args[0], 0);
     if (val == 0) {
       // DEC VT100 response
-      vterm_push_output_sprintf_ctrl(state->vt, C1_CSI, "?1;2c");
+      vterm_push_output_sprintf_ctrl(state->vt, C1_CSI, "?%sc", vterm_primary_device_attr);
     }
     break;
 

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -3539,7 +3539,7 @@ describe('TUI', function()
         extern char vterm_primary_device_attr[]
       ]]
 
-      ffi.copy(ffi.C.vterm_primary_device_attr, '1;2')
+      ffi.copy(ffi.C.vterm_primary_device_attr, '61;22')
     end)
 
     exec_lua([[

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -3526,9 +3526,24 @@ describe('TUI', function()
     end)
   end)
 
-  it('queries the terminal for OSC 52 support', function()
+  it('queries the terminal for OSC 52 support with XTGETTCAP', function()
     clear()
+    if not exec_lua('return pcall(require, "ffi")') then
+      pending('missing LuaJIT FFI')
+    end
+
+    -- Change vterm's DA1 response so that it doesn't include 52
+    exec_lua(function()
+      local ffi = require('ffi')
+      ffi.cdef [[
+        extern char vterm_primary_device_attr[]
+      ]]
+
+      ffi.copy(ffi.C.vterm_primary_device_attr, '1;2')
+    end)
+
     exec_lua([[
+      _G.query = false
       vim.api.nvim_create_autocmd('TermRequest', {
         callback = function(args)
           local req = args.data.sequence
@@ -3536,6 +3551,7 @@ describe('TUI', function()
           if sequence and vim.text.hexdecode(sequence) == 'Ms' then
             local resp = string.format('\027P1+r%s=%s\027\\', sequence, vim.text.hexencode('\027]52;;\027\\'))
             vim.api.nvim_chan_send(vim.bo[args.buf].channel, resp)
+            _G.query = true
             return true
           end
         end,
@@ -3546,7 +3562,6 @@ describe('TUI', function()
     screen = tt.setup_child_nvim({
       '--listen',
       child_server,
-      -- Use --clean instead of -u NONE to load the osc52 plugin
       '--clean',
     }, {
       env = {
@@ -3560,6 +3575,7 @@ describe('TUI', function()
     retry(nil, 1000, function()
       eq({ true, { osc52 = true } }, { child_session:request('nvim_eval', 'g:termfeatures') })
     end)
+    eq(true, exec_lua([[return _G.query]]))
 
     -- Attach another (non-TUI) UI to the child instance
     local alt = Screen.new(nil, nil, nil, child_session)
@@ -3578,6 +3594,43 @@ describe('TUI', function()
     eq({ true, {} }, { child_session:request('nvim_eval', 'g:termfeatures') })
   end)
 
+  it('determines OSC 52 support from DA1 response', function()
+    clear()
+    exec_lua([[
+      -- Check that we do not emit an XTGETTCAP request when DA1 indicates support
+      _G.query = false
+      vim.api.nvim_create_autocmd('TermRequest', {
+        callback = function(args)
+          local req = args.data.sequence
+          local sequence = req:match('^\027P%+q([%x;]+)$')
+          if sequence and vim.text.hexdecode(sequence) == 'Ms' then
+            _G.query = true
+            return true
+          end
+        end,
+      })
+    ]])
+
+    local child_server = new_pipename()
+    screen = tt.setup_child_nvim({
+      '--listen',
+      child_server,
+      '--clean',
+    }, {
+      env = {
+        VIMRUNTIME = os.getenv('VIMRUNTIME'),
+      },
+    })
+
+    screen:expect({ any = '%[No Name%]' })
+
+    local child_session = n.connect(child_server)
+    retry(nil, 1000, function()
+      eq({ true, { osc52 = true } }, { child_session:request('nvim_eval', 'g:termfeatures') })
+    end)
+    eq(false, exec_lua([[return _G.query]]))
+  end)
+
   it('does not query the terminal for OSC 52 support when disabled', function()
     clear()
     exec_lua([[
@@ -3588,6 +3641,7 @@ describe('TUI', function()
           local sequence = req:match('^\027P%+q([%x;]+)$')
           if sequence and vim.text.hexdecode(sequence) == 'Ms' then
             _G.query = true
+            return true
           end
         end,
       })
@@ -3597,7 +3651,6 @@ describe('TUI', function()
     screen = tt.setup_child_nvim({
       '--listen',
       child_server,
-      -- Use --clean instead of -u NONE to load the osc52 plugin
       '--clean',
       '--cmd',
       'let g:termfeatures = #{osc52: v:false}',

--- a/test/unit/vterm_spec.lua
+++ b/test/unit/vterm_spec.lua
@@ -2659,7 +2659,7 @@ putglyph 1f3f4,200d,2620,fe0f 2 0,4]])
     -- DA
     reset(state, nil)
     push('\x1b[c', vt)
-    expect_output('\x1b[?1;2;52c')
+    expect_output('\x1b[?61;22;52c')
 
     -- XTVERSION
     reset(state, nil)

--- a/test/unit/vterm_spec.lua
+++ b/test/unit/vterm_spec.lua
@@ -2659,7 +2659,7 @@ putglyph 1f3f4,200d,2620,fe0f 2 0,4]])
     -- DA
     reset(state, nil)
     push('\x1b[c', vt)
-    expect_output('\x1b[?1;2c')
+    expect_output('\x1b[?1;2;52c')
 
     -- XTVERSION
     reset(state, nil)


### PR DESCRIPTION
Many terminals now include support for OSC 52 in their Primary Device Attributes (DA1) response. This is preferable to using XTGETTCAP because DA1 is _much_ more broadly supported.

Closes: https://github.com/neovim/neovim/issues/34472