### PR TITLE
vim-patch:3987eac: runtime(doc): clarify how ex ranges are adjusted when acting on folds

### DIFF
--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -632,13 +632,16 @@ what you type!
 When using an operator, a closed fold is included as a whole.  Thus "dl"
 deletes the whole closed fold under the cursor.
 
-For Ex commands that work on buffer lines the range is adjusted to always
+For Ex commands that operate on buffer lines, the range is adjusted to always
 start at the first line of a closed fold and end at the last line of a closed
-fold.  Thus this command: >
+fold.  Thus, this command: >
 	:s/foo/bar/g
 when used with the cursor on a closed fold, will replace "foo" with "bar" in
 all lines of the fold.
 This does not happen for |:folddoopen| and |:folddoclosed|.
+
+Note that for some Ex commands like |:source| the range is only adjusted when
+using a two-address [range].
 
 When editing a buffer that has been edited before, the last used folding
 settings are used again.  For manual folding the defined folds are restored.

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -207,6 +207,11 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			sourced more than once, then the functions in the
 			buffer are defined again.
 
+			Implementation detail: When sourcing a [range] of
+			lines that falls inside a folded region, the range
+			will be adjusted to the start and end of the fold,
+			but only if a two-address range was used.
+
 							*:source!*
 :so[urce]! {file}
 			Runs |Normal-mode| commands from {file}. When used


### PR DESCRIPTION
#### vim-patch:3987eac: runtime(doc): clarify how ex ranges are adjusted when acting on folds

https://github.com/vim/vim/commit/3987eac5725087177fdb7bcf91ef6c1040820295

Co-authored-by: Christian Brabandt <cb@256bit.org>