### PR TITLE
fix(popup): handle custom winborder in `make_floating_popup_options()`

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -39,6 +39,11 @@ local function get_border_size(opts)
     border = 'none'
   end
 
+  -- Convert winborder string option with custom characters into a table
+  if type(border) == 'string' and border:find(',') then
+    border = vim.split(border, ',')
+  end
+
   if type(border) == 'string' then
     if not border_size[border] then
       border_error(border)


### PR DESCRIPTION
Problem: winborder option with custom border characters is not working for a lot of popups related to lsp

Solution: Convert the custom string to a list
