### PR TITLE
test(ui/{cmdline,message}2_spec): reduce flakiness/runtime

### DIFF
--- a/runtime/lua/vim/_extui.lua
+++ b/runtime/lua/vim/_extui.lua
@@ -104,9 +104,11 @@ function M.enable(opts)
     ext.cmdheight = value
   end
 
-  vim.schedule(function()
-    check_cmdheight(vim.o.cmdheight)
-  end)
+  if vim.v.vim_did_enter == 0 then
+    vim.schedule(function()
+      check_cmdheight(vim.o.cmdheight)
+    end)
+  end
 
   api.nvim_create_autocmd('OptionSet', {
     group = ext.augroup,

--- a/runtime/lua/vim/_extui/messages.lua
+++ b/runtime/lua/vim/_extui/messages.lua
@@ -465,7 +465,7 @@ function M.set_pos(type)
   local function win_set_pos(win)
     local texth = type and api.nvim_win_text_height(win, {}) or {}
     local height = type and math.min(texth.all, math.ceil(o.lines * 0.5))
-    local top = { vim.opt.fcs:get().horiz or o.ambw == 'single' and '─' or '-', 'WinSeparator' }
+    local top = { vim.opt.fcs:get().horiz or o.ambw == 'single' and '─' or '-', 'MsgSeparator' }
     local border = win ~= ext.wins.msg and { '', top, '', '', '', '', '', '' } or nil
     local save_config = type == 'cmd' and api.nvim_win_get_config(win) or {}
     local config = {

--- a/runtime/lua/vim/_extui/shared.lua
+++ b/runtime/lua/vim/_extui/shared.lua
@@ -4,7 +4,7 @@ local M = {
   cmd = nil, ---@type vim._extui.cmdline
   ns = api.nvim_create_namespace('nvim._ext_ui'),
   augroup = api.nvim_create_augroup('nvim._ext_ui', {}),
-  cmdheight = 1, -- 'cmdheight' option value set by user.
+  cmdheight = vim.o.cmdheight, -- 'cmdheight' option value set by user.
   wins = { cmd = -1, dialog = -1, msg = -1, pager = -1 },
   bufs = { cmd = -1, dialog = -1, msg = -1, pager = -1 },
   cfg = {

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -30,27 +30,17 @@ describe('messages2', function()
     screen:expect([[
                                                            |
       {1:~                                                    }|*9
-      ─────────────────────────────────────────────────────|
+      {3:─────────────────────────────────────────────────────}|
       fo^o                                                  |
       bar                                                  |
                                           1,3           All|
-    ]])
-    -- New message clears spill indicator.
-    feed('Q')
-    screen:expect([[
-                                                           |
-      {1:~                                                    }|*9
-      ─────────────────────────────────────────────────────|
-      fo^o                                                  |
-      bar                                                  |
-      {9:E354: Invalid register name: '^@'}   1,3           All|
     ]])
     -- Multiple messages in same event loop iteration are appended and shown in full.
     feed([[q:echo "foo" | echo "bar\nbaz\n"->repeat(&lines)<CR>]])
     screen:expect([[
       ^                                                     |
       {1:~                                                    }|*5
-      ─────────────────────────────────────────────────────|
+      {3:─────────────────────────────────────────────────────}|
       foo                                                  |
       bar                                                  |
       baz                                                  |
@@ -66,13 +56,20 @@ describe('messages2', function()
       {1:~                                                    }|*12
       foo[+29]                            0,0-1         All|
     ]])
+    command('echo "foo"')
+    -- New message clears spill indicator.
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      foo                                 0,0-1         All|
+    ]])
     -- No error for ruler virt_text msg_row exceeding buffer length.
     command([[map Q <cmd>echo "foo\nbar" <bar> ls<CR>]])
     feed('Q')
     screen:expect([[
       ^                                                     |
       {1:~                                                    }|*8
-      ─────────────────────────────────────────────────────|
+      {3:─────────────────────────────────────────────────────}|
       foo                                                  |
       bar                                                  |
                                                            |
@@ -104,7 +101,7 @@ describe('messages2', function()
     screen:expect([[
                                                            |
       {1:~                                                    }|*10
-      ─────────────────────────────────────────────────────|
+      {3:─────────────────────────────────────────────────────}|
       fo^o                                                  |
       foo                                                  |
     ]])
@@ -182,7 +179,7 @@ describe('messages2', function()
   end)
 
   it("deleting buffer restores 'buftype'", function()
-    command('%bdelete')
+    feed(':%bdelete<CR>')
     screen:expect([[
       ^                                                     |
       {1:~                                                    }|*12


### PR DESCRIPTION
Problem:  Storing the configured 'cmdheight' value is scheduled and
          may happen after cmdline2_spec already entered block_mode.
          Excessive wait time for expected screen state due to delayed
          ruler after an error message.
Solution: Only schedule storing the user configured 'cmdheight' if
          v:vim_did_enter is unset. Use regular message instead of error.

Fix #34871
