### PR TITLE
refactor(qf): move syntax code for qf-toc to qf.lua

### DIFF
--- a/runtime/syntax/qf.lua
+++ b/runtime/syntax/qf.lua
@@ -1,0 +1,8 @@
+--- Hide file name and line number for filetype outline (TOC)
+local w = vim.w
+local qf_toc_title_regex = vim.regex [[\<TOC$\|\<Table of contents\>]]
+if w.qf_toc or (w.quickfix_title and qf_toc_title_regex:match_str(w.quickfix_title)) then
+  vim.wo.conceallevel = 3
+  vim.wo.concealcursor = 'nc'
+  vim.cmd [[syn match Ignore "^[^|]*|[^|]*| " conceal]]
+end

--- a/runtime/syntax/qf.vim
+++ b/runtime/syntax/qf.vim
@@ -18,12 +18,6 @@ syn match	qfText		".*"	 contained
 syn match	qfError		"error"	 contained
 syn cluster	qfType	contains=qfError
 
-" Hide file name and line number for help outline (TOC).
-if has_key(w:, 'qf_toc') || get(w:, 'quickfix_title') =~# '\<TOC$\|\<Table of contents\>'
-  setlocal conceallevel=3 concealcursor=nc
-  syn match	Ignore		"^[^|]*|[^|]*| " conceal
-endif
-
 " The default highlighting.
 hi def link qfFileName		Directory
 hi def link qfLineNr		LineNr


### PR DESCRIPTION
Problem:
From https://github.com/neovim/neovim/pull/27547#issuecomment-1954064201: "I would still like to have seen these modifications clearly documented to prevent confusion in the future. This is adding needless friction to people (me) porting runtime file updates."

Solution:
Move those "modifications" to qf.lua

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
