### PR TITLE
feat(term): increase max scrollback to 1000000

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -300,6 +300,7 @@ These existing features changed their behavior.
 • 'spellfile' location defaults to `stdpath("data").."/site/spell/"` instead of
   the first writable directory in 'runtimepath'.
 • |vim.version.range()| doesn't exclude `to` if it is equal to `from`.
+• 'scrollback' maximum value increased from 100000 to 1000000
 
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5151,7 +5151,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 			local to buffer
 	Maximum number of lines kept beyond the visible screen. Lines at the
 	top are deleted if new lines exceed this limit.
-	Minimum is 1, maximum is 100000.
+	Minimum is 1, maximum is 1000000.
 	Only in |terminal| buffers.
 
 	Note: Lines that are not visible and kept in scrollback are not

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5395,7 +5395,7 @@ vim.wo.scr = vim.wo.scroll
 
 --- Maximum number of lines kept beyond the visible screen. Lines at the
 --- top are deleted if new lines exceed this limit.
---- Minimum is 1, maximum is 100000.
+--- Minimum is 1, maximum is 1000000.
 --- Only in `terminal` buffers.
 ---
 --- Note: Lines that are not visible and kept in scrollback are not

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -592,7 +592,7 @@ EXTERN int p_cdh;               ///< 'cdhome'
 
 #define ERR_BUFLEN 80
 
-#define SB_MAX 100000  // Maximum 'scrollback' value.
+#define SB_MAX 1000000  // Maximum 'scrollback' value.
 
 #define MAX_NUMBERWIDTH 20      // used for 'numberwidth'
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7102,7 +7102,7 @@ local options = {
       desc = [=[
         Maximum number of lines kept beyond the visible screen. Lines at the
         top are deleted if new lines exceed this limit.
-        Minimum is 1, maximum is 100000.
+        Minimum is 1, maximum is 1000000.
         Only in |terminal| buffers.
 
         Note: Lines that are not visible and kept in scrollback are not

--- a/test/functional/terminal/scrollback_spec.lua
+++ b/test/functional/terminal/scrollback_spec.lua
@@ -517,8 +517,8 @@ describe("'scrollback' option", function()
   it('error if set to invalid value', function()
     eq('Vim(set):E474: Invalid argument: scrollback=-2', pcall_err(command, 'set scrollback=-2'))
     eq(
-      'Vim(set):E474: Invalid argument: scrollback=100001',
-      pcall_err(command, 'set scrollback=100001')
+      'Vim(set):E474: Invalid argument: scrollback=1000001',
+      pcall_err(command, 'set scrollback=1000001')
     )
   end)
 
@@ -538,14 +538,14 @@ describe("'scrollback' option", function()
     -- _Local_ scrollback=-1 in :terminal forces the _maximum_.
     command('setlocal scrollback=-1')
     retry(nil, nil, function() -- Fixup happens on refresh, not immediately.
-      eq(100000, api.nvim_get_option_value('scrollback', {}))
+      eq(1000000, api.nvim_get_option_value('scrollback', {}))
     end)
 
     -- _Local_ scrollback=-1 during TermOpen forces the maximum. #9605
     command('setglobal scrollback=-1')
     command('autocmd TermOpen * setlocal scrollback=-1')
     command('terminal')
-    eq(100000, api.nvim_get_option_value('scrollback', {}))
+    eq(1000000, api.nvim_get_option_value('scrollback', {}))
   end)
 
   it(':setlocal in a normal buffer', function()


### PR DESCRIPTION
Problem:
Cannot use `nvim_open_term()` to pipe terminal scrollback > 100000

Solution:
Increase scrollback limit to 1000000

If there's no technical consequences of doing this, can be set even
higher in the future.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
