### PR TITLE
fix(window): don't store invalid height in window config

### DIFF
--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -724,8 +724,8 @@ void ui_grid_resize(handle_T grid_handle, int width, int height, Error *err)
 
   if (wp->w_floating) {
     if (width != wp->w_width || height != wp->w_height) {
-      wp->w_config.width = width;
-      wp->w_config.height = height;
+      wp->w_config.width = MAX(width, 1);
+      wp->w_config.height = MAX(height, 1);
       win_config_float(wp, wp->w_config);
     }
   } else {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5854,7 +5854,7 @@ void win_setheight_win(int height, win_T *win)
   height = MAX(height, (int)(win == curwin ? MAX(p_wmh, 1) : p_wmh) + win->w_winbar_height);
 
   if (win->w_floating) {
-    win->w_config.height = height;
+    win->w_config.height = MAX(height, 1);
     win_config_float(win, win->w_config);
     redraw_later(win, UPD_VALID);
   } else {

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -923,6 +923,13 @@ describe('float window', function()
     assert_alive()
   end)
 
+  it("no error for zero height with 'winminheight'", function()
+    local win = api.nvim_open_win(0, false, { relative = 'editor', row = 0, col = 0, height = 1, width = 1 })
+    api.nvim_set_option_value('winminheight', 0, {})
+    api.nvim_win_set_height(win, 0)
+    api.nvim_win_set_config(win, api.nvim_win_get_config(win))
+  end)
+
   local function with_ext_multigrid(multigrid)
     local screen, attrs
     before_each(function()


### PR DESCRIPTION
Problem:  When 'winminheight' is zero and the window height is set to
          zero, the actual height is clamped whereas the stored config
          value is not. Reciprocal window configuration through
          nvim_win_get_config() then results in an error.
Solution: Also clamp the stored dimensions in the window config.

Fix #34881
