### PR TITLE
fix(extui): disable cmdline highlighter when showing a message

### DIFF
--- a/runtime/lua/vim/_extui/messages.lua
+++ b/runtime/lua/vim/_extui/messages.lua
@@ -199,7 +199,11 @@ local function msg_to_full(src)
         hlopts.end_col, hlopts.hl_group = mark[4].end_col, mark[4].hl_group
         api.nvim_buf_set_extmark(ext.bufs[tar], ext.ns, srow + mark[2], mark[3], hlopts)
       end
-      api.nvim_command('norm! G')
+      if tar == 'cmd' and ext.cmd.highlighter then
+        ext.cmd.highlighter.active[ext.bufs.cmd] = nil
+      elseif tar == 'pager' then
+        api.nvim_command('norm! G')
+      end
       M.virt.msg[M.virt.idx.spill][1] = nil
     else
       for _, id in pairs(M.virt.ids) do

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -176,6 +176,16 @@ describe('messages2', function()
       {1:~                                                 }{4:foo}|
       {16::}^                                                    |
     ]])
+    -- Highlighter disabled when message is moved to cmdline #34884
+    feed('ls<CR>')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*8
+      {3:─────────────────────────────────────────────────────}|
+      foo                                                  |
+                                                           |
+        1 %a   "[No Name]"                    line 1       |
+    ]])
   end)
 
   it("deleting buffer restores 'buftype'", function()


### PR DESCRIPTION
Problem:  When message is moved from message window to cmdline,
          the cmdline highlighter is not disabled.
Solution: Disable the highlighter (and only scroll to bottom when
          message was moved to pager).

Fix #34884