### PR TITLE
refactor: avoid mixed case use of cmake funcs

### DIFF
--- a/cmake.deps/cmake/BuildLuajit.cmake
+++ b/cmake.deps/cmake/BuildLuajit.cmake
@@ -42,7 +42,7 @@ if(APPLE)
 endif()
 
 if(UNIX)
-  BuildLuaJit(INSTALL_COMMAND ${BUILDCMD_UNIX}
+  BuildLuajit(INSTALL_COMMAND ${BUILDCMD_UNIX}
     CC=${DEPS_C_COMPILER} PREFIX=${DEPS_INSTALL_DIR}
     ${DEPLOYMENT_TARGET} install)
 
@@ -53,7 +53,7 @@ elseif(MINGW)
   else()
     set(LUAJIT_MAKE_PRG ${CMAKE_MAKE_PROGRAM})
   endif()
-  BuildLuaJit(BUILD_COMMAND ${LUAJIT_MAKE_PRG} CC=${DEPS_C_COMPILER}
+  BuildLuajit(BUILD_COMMAND ${LUAJIT_MAKE_PRG} CC=${DEPS_C_COMPILER}
                                 PREFIX=${DEPS_INSTALL_DIR}
                                 CFLAGS+=-DLUA_USE_APICHECK
                                 CFLAGS+=-funwind-tables
@@ -75,7 +75,7 @@ elseif(MINGW)
 	    )
 elseif(MSVC)
 
-  BuildLuaJit(
+  BuildLuajit(
     BUILD_COMMAND ${CMAKE_COMMAND} -E chdir ${DEPS_BUILD_DIR}/src/luajit/src ${DEPS_BUILD_DIR}/src/luajit/src/msvcbuild.bat
     INSTALL_COMMAND ${CMAKE_COMMAND} -E make_directory ${DEPS_BIN_DIR}
       COMMAND ${CMAKE_COMMAND} -E copy ${DEPS_BUILD_DIR}/src/luajit/src/luajit.exe ${DEPS_BIN_DIR}


### PR DESCRIPTION
CMake is functions/macros are case-insensitive (unlike variables), but names differing only by case (e.g. "BuildLuaJit" instead of "BuildLuajit") may look the same at a glance. This can be confusing if you do a case-sensitive search, such as by using the * key in neovim to search for other instances of the word under the cursor.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

I noticed this issue when I was reading through the sources and couldn't find the definition for `BuildLuaJit()`.
I wrote a small script that finds inconsistencies, but it seems `BuildLuajit()` was the only inconsistent function.

```sh
#!/bin/sh
# find inconsistent case usage of cmake macro/function

cmake_files="$(fd -i '\.cmake$|CMakeLists.txt')"
cmake_funcs="$(echo "${cmake_files}" \
  | xargs rg -ioIN '(function|macro)\([^ )]+' \
  | sed -E 's,(function|macro)\(,,' \
  | sort -u)"

for cmake_func in ${cmake_funcs} ; do
  echo "=== $cmake_func ==="
  func_calls="$(rg -iwoIN $cmake_func ${cmake_files} | sort -u)"
  func_call_count="$(echo "${func_calls}" | wc -l | xargs)"
  if [ ${func_call_count} -ne 1 ]; then
    echo "MISMATCH FOUND!!!"
    exit 42
  fi
done
```
