### PR TITLE
fix crashing on windows when loading large session files from :mksession

### DIFF
--- a/src/nvim/os/pty_conpty_win.c
+++ b/src/nvim/os/pty_conpty_win.c
@@ -165,6 +165,9 @@ bool os_conpty_spawn(conpty_t *conpty_object, HANDLE *proc_handle, wchar_t *name
 
 void os_conpty_set_size(conpty_t *conpty_object, uint16_t width, uint16_t height)
 {
+  if (!conpty_object) {
+    return;
+  }
   assert(width <= SHRT_MAX);
   assert(height <= SHRT_MAX);
   COORD size = { (int16_t)width, (int16_t)height };
@@ -176,14 +179,16 @@ void os_conpty_set_size(conpty_t *conpty_object, uint16_t width, uint16_t height
 
 void os_conpty_free(conpty_t *conpty_object)
 {
-  if (conpty_object != NULL) {
-    if (conpty_object->si_ex.lpAttributeList != NULL) {
-      DeleteProcThreadAttributeList(conpty_object->si_ex.lpAttributeList);
-      xfree(conpty_object->si_ex.lpAttributeList);
-    }
-    if (conpty_object->pty != NULL) {
-      pClosePseudoConsole(conpty_object->pty);
-    }
+  if (conpty_object == NULL) {
+    return;
   }
-  xfree(conpty_object);
+  if (conpty_object->si_ex.lpAttributeList != NULL) {
+    DeleteProcThreadAttributeList(conpty_object->si_ex.lpAttributeList);
+    XFREE_CLEAR(conpty_object->si_ex.lpAttributeList);
+  }
+  if (conpty_object->pty != NULL) {
+    pClosePseudoConsole(conpty_object->pty);
+    XFREE_CLEAR(conpty_object->pty);
+  }
+  XFREE_CLEAR(conpty_object);
 }

--- a/src/nvim/os/pty_conpty_win.c
+++ b/src/nvim/os/pty_conpty_win.c
@@ -12,6 +12,13 @@
 # define PROC_THREAD_ATTRIBUTE_PSEUDOCONSOLE 0x00020016
 #endif
 
+#ifndef VALIDPOINTERSIZE
+# define VALIDPOINTERSIZE 100
+#endif
+
+static HPCON validFilePointers[VALIDPOINTERSIZE];
+static int pointerCount = 0;
+
 HRESULT(WINAPI *pCreatePseudoConsole)(COORD, HANDLE, HANDLE, DWORD, HPCON *);
 HRESULT(WINAPI *pResizePseudoConsole)(HPCON, COORD);
 void(WINAPI *pClosePseudoConsole)(HPCON);
@@ -102,6 +109,10 @@ conpty_t *os_conpty_init(char **in_name, char **out_name, uint16_t width, uint16
     emsg = "create pseudo console failed";
     goto failed;
   }
+  if (pointerCount < VALIDPOINTERSIZE) {
+    validFilePointers[pointerCount] = conpty_object->pty;
+  }
+  pointerCount++;
 
   conpty_object->si_ex.StartupInfo.cb = sizeof(conpty_object->si_ex);
   size_t bytes_required;
@@ -168,6 +179,20 @@ void os_conpty_set_size(conpty_t *conpty_object, uint16_t width, uint16_t height
   assert(width <= SHRT_MAX);
   assert(height <= SHRT_MAX);
   COORD size = { (int16_t)width, (int16_t)height };
+  // is this pointer a valid pointer that was allocated from pCreatePseudoConsole
+  bool isValid = true;
+  if (pointerCount <= VALIDPOINTERSIZE) {
+    isValid = false;
+    for (int i = 0; i < pointerCount; i++) {
+      if (conpty_object->pty == validFilePointers[i]) {
+        isValid = true;
+        break;
+      }
+    }
+  }
+  if (isValid == false) {
+    return;
+  }
   if (pResizePseudoConsole(conpty_object->pty, size) != S_OK) {
     ELOG("ResizePseudoConsoel failed: error code: %d",
          os_translate_sys_error((int)GetLastError()));

--- a/src/nvim/os/pty_proc_win.c
+++ b/src/nvim/os/pty_proc_win.c
@@ -23,6 +23,7 @@ static void CALLBACK pty_proc_terminate_cb(void *context, BOOLEAN unused)
   Proc *proc = (Proc *)ptyproc;
 
   os_conpty_free(ptyproc->conpty);
+  ptyproc->conpty = NULL;
   // NB: pty_proc_terminate_cb() is called on a separate thread,
   // but finishing up the process needs to be done on the main thread.
   loop_schedule_fast(proc->loop, event_create(pty_proc_finish_when_eof, ptyproc));


### PR DESCRIPTION
I use neovim on both windows and linux. In my experience, this crash occurs only on windows.  I rely on session files with large amounts of buffers / windows / tabs created with :mksession to restore my workspace. I frequently would have crashing while loading  session file by starting neovim with nvim -S mysessionfile.vim. It's always been a sometimes, and sometimes more frequent than other times, particularly with larger session files. So I may start nvim with nvim -S mysessionfile.vim once, and it crashes, then I immediately run the same command and now it works. very annoying. So I ran in visual studio to see where it is crashing, and found that this address of conpty_object->pty is sometimes changing to some other random value, which is not NULL, and when this happens it crashes when trying to run pResizePseudoConsole with the invalid (changed) memory address. I've had this fix in my compiled version of neovim for about a year, and have not had the crash since putting in this fix. So I'm open to a better way to check for a valid pointer than what I have done here, but I'm confident this fixes the crash. one of the other things i initially tried is adding another address to the struct conpty
```
src/nvim/os/pty_conpty_win.h:
 typedef struct conpty {
   HPCON pty; 
   HPCON pty_oncreation;
   STARTUPINFOEXW si_ex;
 } conpty_t;
```

and then check if pty == pty_oncreation
but even the value of pty_oncreation was getting changed. So I think there is some out of bounds memory write happening somewhere.