### PR TITLE
ci(test): re-enable ubuntu arm

### DIFF
--- a/.github/workflows/notes.md
+++ b/.github/workflows/notes.md
@@ -54,7 +54,7 @@ If your system does not have the required glibc version, try the (unsupported) [
 2. Extract: `tar xzvf nvim-linux-x86_64.tar.gz`
 3. Run `./nvim-linux-x86_64/bin/nvim`
 
-### Linux (arm64) - Untested
+### Linux (arm64)
 
 #### AppImage
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -28,7 +28,7 @@ env:
 
 jobs:
   lint:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     env:
       CC: clang
@@ -38,7 +38,7 @@ jobs:
 
       - name: Install stylua
         run: |
-          wget --directory-prefix="$BIN_DIR" https://github.com/JohnnyMorganz/StyLua/releases/latest/download/stylua-linux-x86_64.zip
+          wget --directory-prefix="$BIN_DIR" https://github.com/JohnnyMorganz/StyLua/releases/latest/download/stylua-linux-aarch64.zip
           (cd "$BIN_DIR"; unzip stylua*.zip)
 
       - name: Build third-party deps
@@ -82,7 +82,7 @@ jobs:
         run: cmake --build build --target lintc-uncrustify
 
   clang-analyzer:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 20
     env:
       CC: clang
@@ -111,7 +111,7 @@ jobs:
             { runner: ubuntu-24.04, os: ubuntu, flavor: asan, cc: clang, flags: -D ENABLE_ASAN_UBSAN=ON },
             { runner: ubuntu-24.04, os: ubuntu, flavor: tsan, cc: clang, flags: -D ENABLE_TSAN=ON },
             { runner: ubuntu-24.04, os: ubuntu, flavor: release, cc: gcc, flags: -D CMAKE_BUILD_TYPE=Release -D ENABLE_TRANSLATIONS=ON },
-            # { runner: ubuntu-24.04-arm, os: ubuntu, flavor: arm, cc: gcc, flags: -D CMAKE_BUILD_TYPE=RelWithDebInfo },
+            { runner: ubuntu-24.04-arm, os: ubuntu, flavor: arm, cc: clang, flags: -D CMAKE_BUILD_TYPE=RelWithDebInfo },
             { runner: macos-13, os: macos, flavor: intel, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
             { runner: macos-15, os: macos, flavor: arm, cc: clang, flags: -D CMAKE_FIND_FRAMEWORK=NEVER, deps_flags: -D CMAKE_FIND_FRAMEWORK=NEVER },
             { runner: ubuntu-24.04, os: ubuntu, flavor: puc-lua, cc: gcc, deps_flags: -D USE_BUNDLED_LUAJIT=OFF -D USE_BUNDLED_LUA=ON, flags: -D PREFER_LUA=ON },
@@ -124,6 +124,10 @@ jobs:
             build: { flavor: puc-lua }
           - test: oldtest
             build: { flavor: tsan }
+          - test: unittest
+            build: { runner: ubuntu-24.04-arm }
+          - test: oldtest
+            build: { runner: ubuntu-24.04-arm }
     runs-on: ${{ matrix.build.runner }}
     timeout-minutes: 45
     env:
@@ -220,7 +224,7 @@ jobs:
     uses: ./.github/workflows/test_windows.yml
 
   with-external-deps:
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-24.04-arm
     timeout-minutes: 10
     env:
       CC: gcc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -346,7 +346,7 @@ else()
   add_custom_target(lua_dev_deps)
 endif()
 
-if (CMAKE_SYSTEM_PROCESSOR MATCHES arm64)
+if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm|aarch")
   set(LUALS_ARCH arm64)
 else()
   set(LUALS_ARCH x64)

--- a/runtime/doc/support.txt
+++ b/runtime/doc/support.txt
@@ -13,11 +13,11 @@ Supported platforms					 *supported-platforms*
 
 `System`          `Tier`      `Versions`                  `Tested versions`
 Linux (x86_64)   1      >= 2.6.32, glibc >= 2.12     Ubuntu 24.04
+Linux (arm64)    1      >= 2.6.32, glibc >= 2.12     Ubuntu 24.04
 macOS (x86_64)   1      >= 11                        macOS 13
 macOS (arm64)    1      >= 11                        macOS 15
 Windows 64-bit   1      >= Windows 10 Version 1809   Windows Server 2022
 FreeBSD          1      >= 10                        FreeBSD 14
-Linux (arm64)    2      >= 2.6.32, glibc >= 2.12
 OpenBSD          2      >= 7
 MinGW            2      MinGW-w64
 Windows 64-bit   3      < Windows 10 Version 1809


### PR DESCRIPTION
https://github.com/actions/partner-runner-images/issues/47#issuecomment-2678170225 mentions that hardware was changed, so we can try re-enabling ARM linux CI.

reverts 8e4b77134a1cbc08b7372b6834eafc7cecdbc33e

ref https://github.com/neovim/neovim/issues/32339

Time comparisons (comparing the critical steps, since "setup" time varies):

- `lint` (step: `clang-tidy`)
    - master: 1m5s
    - this pr (linux ARM): 37s
- `clang-analyzer` (step: `cmake --build ...`)
    - master: 10m
    - this pr (linux ARM) 5m 55s
- `with-external-deps` (step: `Build`)
    - master: 26s
    - this pr (linux ARM): 21s
- `ubuntu puc-lua gcc functionaltest`
    - master: 10m 30s
    - this pr (linux ARM): 10m 6s
- `ubuntu asan clang functionaltest`
    - master: 20m
    - this pr (linux ARM): 18m 18s
- `ubuntu tsan clang functionaltest`
    - deps issue? `E970: Failed to initialize lua interpreter`
- `ubuntu arm gcc unittest`
    - need to update our unittests c parser?
      ```
      ERROR    test/unit/testutil.lua @ 802: Expressions parser works with &opt
      test/unit/testutil.lua:774: test/unit/testutil.lua:758: (string) '
      test/unit/testutil.lua:288: declaration specifier expected near '__SVFloat32_t''
      exit code: 256
      ```