### PR TITLE
fix(lua): vim.diff is nil in uv.new_work() thread

### DIFF
--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -1317,9 +1317,6 @@ require('vim._options')
 --- Remove at Nvim 1.0
 ---@deprecated
 vim.loop = vim.uv
---- Renamed to `vim.text.diff`, remove at Nvim 1.0
----@deprecated
-vim.diff = vim._diff ---@type fun(a: string, b: string, opts?: vim.text.diff.Opts): string|integer[][]?
 
 -- Deprecated. Remove at Nvim 2.0
 vim.highlight = vim._defer_deprecated_module('vim.highlight', 'vim.hl')

--- a/runtime/lua/vim/_meta/misc.lua
+++ b/runtime/lua/vim/_meta/misc.lua
@@ -14,3 +14,11 @@
 --- @param ... any
 --- @return any
 function vim.call(func, ...) end
+
+--- Renamed to `vim.text.diff`, remove at Nvim 1.0
+---@deprecated
+---@param a string First string to compare
+---@param b string Second string to compare
+---@param opts? vim.text.diff.Opts
+---@return string|integer[][]? # See {opts.result_type}. `nil` if {opts.on_hunk} is given.
+function vim.diff(a, b, opts) end

--- a/runtime/lua/vim/text.lua
+++ b/runtime/lua/vim/text.lua
@@ -73,7 +73,8 @@ local M = {}
 ---@param opts? vim.text.diff.Opts
 ---@return string|integer[][]? # See {opts.result_type}. `nil` if {opts.on_hunk} is given.
 function M.diff(...)
-  return vim._diff(...)
+  ---@diagnostic disable-next-line: deprecated
+  return vim.diff(...)
 end
 
 local alphabet = '0123456789ABCDEF'

--- a/src/nlua0.zig
+++ b/src/nlua0.zig
@@ -20,7 +20,6 @@ const Lua = ziglua.Lua;
 extern "c" fn luaopen_mpack(ptr: *anyopaque) c_int;
 extern "c" fn luaopen_lpeg(ptr: *anyopaque) c_int;
 extern "c" fn luaopen_bit(ptr: *anyopaque) c_int;
-extern "c" fn nlua_xdl_diff(ptr: ?*luajit_all.struct_lua_State) c_int;
 
 fn init() !*Lua {
     // Initialize the Lua vm
@@ -56,10 +55,6 @@ fn init() !*Lua {
     const retval2 = luaopen_lpeg(lua);
     if (retval2 != 1) return error.LoadError;
     lua.setField(-3, "lpeg");
-
-    // vim.text.diff
-    lua.pushFunction(nlua_xdl_diff);
-    lua.setField(-2, "_diff");
 
     lua.pop(2);
 

--- a/src/nlua0.zig
+++ b/src/nlua0.zig
@@ -20,6 +20,7 @@ const Lua = ziglua.Lua;
 extern "c" fn luaopen_mpack(ptr: *anyopaque) c_int;
 extern "c" fn luaopen_lpeg(ptr: *anyopaque) c_int;
 extern "c" fn luaopen_bit(ptr: *anyopaque) c_int;
+extern "c" fn nlua_xdl_diff(ptr: ?*luajit_all.struct_lua_State) c_int;
 
 fn init() !*Lua {
     // Initialize the Lua vm
@@ -55,6 +56,10 @@ fn init() !*Lua {
     const retval2 = luaopen_lpeg(lua);
     if (retval2 != 1) return error.LoadError;
     lua.setField(-3, "lpeg");
+
+    // vim.text.diff
+    lua.pushFunction(nlua_xdl_diff);
+    lua.setField(-2, "_diff");
 
     lua.pop(2);
 

--- a/src/nvim/lua/stdlib.c
+++ b/src/nvim/lua/stdlib.c
@@ -763,7 +763,8 @@ void nlua_state_add_stdlib(lua_State *const lstate, bool is_thread)
 
   // vim.text.diff
   lua_pushcfunction(lstate, &nlua_xdl_diff);
-  lua_setfield(lstate, -2, "_diff");
+  // TODO(justinmk): set vim.text.diff here, or rename this to "_diff". goddamnit.
+  lua_setfield(lstate, -2, "diff");
 
   // vim.json
   lua_cjson_new(lstate);

--- a/test/functional/lua/thread_spec.lua
+++ b/test/functional/lua/thread_spec.lua
@@ -217,7 +217,7 @@ describe('thread', function()
     it('diff', function()
       exec_lua [[
         local entry = function(async)
-          async:send(vim._diff('Hello\n', 'Helli\n'))
+          async:send(vim.diff('Hello\n', 'Helli\n'))
         end
         local on_async = function(ret)
           vim.rpcnotify(1, 'result', ret)
@@ -372,7 +372,7 @@ describe('threadpool', function()
     it('work', function()
       exec_lua [[
         local work_fn = function()
-          return vim._diff('Hello\n', 'Helli\n')
+          return vim.diff('Hello\n', 'Helli\n')
         end
         local after_work_fn = function(ret)
           vim.rpcnotify(1, 'result', ret)


### PR DESCRIPTION
## Problem
Since renaming `vim.diff` to `vim.text.diff` #34864, `thread_spec.lua` fails in the zig build. Is `vim.text.diff` not available in the thread context? Why does it only fail in the zig build?


    FAILED   ./test/functional/lua/thread_spec.lua @ 217: thread vim.* diff
    ./test/functional/lua/thread_spec.lua:229: Expected objects to be the same.
    Passed in:
    (nil)
    Expected:
    (table: 0x7f221d392218) {
      [1] = 'notification'
    E5113: Lua chunk:
      [2] = 'result'
      [3] = {
        [1] = '@@ -1 +1 @@
    -Hello
    +Helli
    ' } }

    stack traceback:
            ./test/functional/lua/thread_spec.lua:229: in function <./test/functional/lua/thread_spec.lua:217>

    FAILED   ./test/functional/lua/thread_spec.lua @ 372: threadpool vim.* work
    ./test/functional/lua/thread_spec.lua:384: Expected objects to be the same.
    Passed in:
    (table: 0x7f2225be2c30) {
      [1] = 'notification'
      [2] = 'result'
     *[3] = {
       *[1] = vim.NIL } }
    Expected:
    (table: 0x7f2225be25c0) {
      [1] = 'notification'
      [2] = 'result'
     *[3] = {
       *[1] = '@@ -1 +1 @@
    -Hello
    +Helli
    ' } }

    stack traceback:
            ./test/functional/lua/thread_spec.lua:384: in function <./test/functional/lua/thread_spec.lua:372>

## Solution

~~Use `vim._diff` in the test, until a root cause is found.~~
Revert the `vim._diff` change, keep `vim.diff` for now. https://github.com/neovim/neovim/pull/34909/commits/fbf156dd64a32af721cf4d511e5c71127873fe14
