### PR TITLE
fix(highlight): link HLF_8 to something more prominent

### DIFF
--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -215,6 +215,8 @@ static const char *highlight_init_both[] = {
   "default link SpecialChar    Special",
   "default link SpecialComment Special",
   "default link Debug          Special",
+  // Used by HLF_8 (very common). None of the HLF_* things use the other Special* groups.
+  "default link SpecialKey     Special",
   "default link Ignore         Normal",
 
   // Built-in LSP
@@ -390,7 +392,6 @@ static const char *highlight_init_light[] = {
   "Removed              guifg=NvimDarkRed                                    ctermfg=1",
   "Search               guifg=NvimDarkGrey1  guibg=NvimLightYellow           ctermfg=15 ctermbg=3",
   "SignColumn           guifg=NvimLightGrey4",
-  "SpecialKey           guifg=NvimLightGrey4",
   "SpellBad             guisp=NvimDarkRed    gui=undercurl                   cterm=undercurl",
   "SpellCap             guisp=NvimDarkYellow gui=undercurl                   cterm=undercurl",
   "SpellLocal           guisp=NvimDarkGreen  gui=undercurl                   cterm=undercurl",
@@ -475,7 +476,6 @@ static const char *highlight_init_dark[] = {
   "Removed              guifg=NvimLightRed                                  ctermfg=9",
   "Search               guifg=NvimLightGrey1  guibg=NvimDarkYellow          ctermfg=0 ctermbg=11",
   "SignColumn           guifg=NvimDarkGrey4",
-  "SpecialKey           guifg=NvimDarkGrey4",
   "SpellBad             guisp=NvimLightRed    gui=undercurl                 cterm=undercurl",
   "SpellCap             guisp=NvimLightYellow gui=undercurl                 cterm=undercurl",
   "SpellLocal           guisp=NvimLightGreen  gui=undercurl                 cterm=undercurl",


### PR DESCRIPTION
(putting this out there to get feedback @echasnovski )

## Problem:
HLF_8 is used by :intro and :map. And none of the other HLF_x things use the other Special groups. So we have a darkgray highlight that's very common, and not easy to read.

Darkgray makes sense for "Conceal", "non-printing chars", etc. But not for keycodes or similar common elements.

## Solution:
Link SpecialKey to Special.

- before
    - <img width="584" height="590" alt="image" src="https://github.com/user-attachments/assets/ab6c1124-ae8f-4ad7-aea8-97389a29bafa" />
- after
    - <img width="625" height="572" alt="image" src="https://github.com/user-attachments/assets/92288bfc-becd-49da-afcb-c9831a0a7dae" />

