### PR TITLE
feat(treesitter): support language argument in `:EditQuery`

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1323,6 +1323,9 @@ edit({lang})                                     *vim.treesitter.query.edit()*
 
     Can also be shown with `:EditQuery`.                          *:EditQuery*
 
+    `:EditQuery <tab>` completes the treesitter parser names in the runtime
+    path.
+
     If you move the cursor to a capture name ("@foo"), text matching the
     capture is highlighted in the source buffer. The query editor is a scratch
     buffer, use `:write` to save it. You can find example queries at

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -23,7 +23,13 @@ do
 
   vim.api.nvim_create_user_command('EditQuery', function(cmd)
     vim.treesitter.query.edit(cmd.fargs[1])
-  end, { desc = 'Edit treesitter query', nargs = '?' })
+  end, {
+    desc = 'Edit treesitter query',
+    nargs = '?',
+    complete = function()
+      return vim.treesitter.language._complete()
+    end,
+  })
 
   vim.api.nvim_create_user_command('Open', function(cmd)
     vim.ui.open(assert(cmd.fargs[1]))

--- a/runtime/lua/vim/treesitter/language.lua
+++ b/runtime/lua/vim/treesitter/language.lua
@@ -186,4 +186,15 @@ function M.inspect(lang)
   return vim._ts_inspect_language(lang)
 end
 
+--- Returns available treesitter languages.
+function M._complete()
+  local parsers = vim.api.nvim_get_runtime_file('parser/*', true)
+  local parser_names_set = {} ---@type table<string, boolean>
+  for _, parser in ipairs(parsers) do
+    local parser_name = vim.fn.fnamemodify(parser, ':t:r')
+    parser_names_set[parser_name] = true
+  end
+  return vim.tbl_keys(parser_names_set)
+end
+
 return M

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -1165,6 +1165,8 @@ end
 ---
 --- Can also be shown with `:EditQuery`. [:EditQuery]()
 ---
+--- `:EditQuery <tab>` completes the treesitter parser names in the runtime path.
+---
 --- If you move the cursor to a capture name ("@foo"), text matching the capture is highlighted in
 --- the source buffer. The query editor is a scratch buffer, use `:write` to save it. You can find
 --- example queries at `$VIMRUNTIME/queries/`.


### PR DESCRIPTION
Problem: The `:EditQuery` command accepts a language argument, but it
doesn't highlight properly for injected languages.

Solution: Fully parse with the root language and then filter the query on the
child trees that are of the language requested.

Closes #29943