### PR TITLE
feat(vim.pack): more actions in confirm-update

### DIFF
--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -402,6 +402,9 @@ update({names}, {opts})                                    *vim.pack.update()*
         • 'textDocument/hover' (`K` via |lsp-defaults| or
           |vim.lsp.buf.hover()|) - show more information at cursor. Like
           details of particular pending change or newer tag.
+        • 'textDocument/codeAction' (`gra` via |lsp-defaults| or
+          |vim.lsp.buf.code_action()|) - show code actions available for
+          "plugin at cursor". Like "delete", "update", or "skip updating".
         Execute |:write| to confirm update, execute |:quit| to discard the
         update.
       • If `true`, make updates right away.

--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -393,9 +393,10 @@ update({names}, {opts})                                    *vim.pack.update()*
     • Depending on `force`:
       • If `false`, show confirmation buffer. It lists data about all set to
         update plugins. Pending changes starting with `>` will be applied
-        while the ones starting with `<` will be reverted. It has special
-        in-process LSP server attached to provide more interactive features.
-        Currently supported methods:
+        while the ones starting with `<` will be reverted. It has dedicated
+        buffer-local mappings:
+        • |]]| and |[[| to navigate through plugin sections.
+        Some features are provided via LSP:
         • 'textDocument/documentSymbol' (`gO` via |lsp-defaults| or
           |vim.lsp.buf.document_symbol()|) - show structure of the buffer.
         • 'textDocument/hover' (`K` via |lsp-defaults| or

--- a/runtime/ftplugin/nvim-pack.lua
+++ b/runtime/ftplugin/nvim-pack.lua
@@ -1,3 +1,4 @@
+-- Highlighting
 local ns = vim.api.nvim_create_namespace('nvim.pack.confirm')
 vim.api.nvim_buf_clear_namespace(0, ns, 0, -1)
 
@@ -49,3 +50,15 @@ for i, l in ipairs(lines) do
     hi_range(i, 4, l:len(), 'DiagnosticHint')
   end
 end
+
+-- Mappings
+local map_section_jump = function(lhs, search_flags, desc)
+  vim.keymap.set({ 'n', 'x' }, lhs, function()
+    for _ = 1, vim.v.count1 do
+      vim.fn.search('^## ', search_flags)
+    end
+  end, { buffer = 0, desc = desc })
+end
+
+map_section_jump('[[', 'bsW', 'Previous plugin')
+map_section_jump(']]', 'sW', 'Next plugin')

--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -957,8 +957,10 @@ end
 ---     - If `false`, show confirmation buffer. It lists data about all set to
 ---       update plugins. Pending changes starting with `>` will be applied while
 ---       the ones starting with `<` will be reverted.
----       It has special in-process LSP server attached to provide more interactive
----       features. Currently supported methods:
+---       It has dedicated buffer-local mappings:
+---       - |]]| and |[[| to navigate through plugin sections.
+---
+---       Some features are provided  via LSP:
 ---         - 'textDocument/documentSymbol' (`gO` via |lsp-defaults|
 ---           or |vim.lsp.buf.document_symbol()|) - show structure of the buffer.
 ---         - 'textDocument/hover' (`K` via |lsp-defaults| or |vim.lsp.buf.hover()|) -


### PR DESCRIPTION
This PR adds several interactive capabilities to a confirmation buffer.

### LSP code actions

Didn't intend to add them, but was curious to see how it fits in the overall "in-process LSP server" approach. This can also serve as a future reference of code actions for in-process LSP servers.

Currently implemented actions are (act on "plugin at cursor"):
  - "Update" and "Skip updating" (if has updates). The idea is the use case of looking at changelog and not wanting to update right away some plugins. So instead of "Yank hash(es), update `version` in 'init.lua', restart, `vim.pack.update()`, and possibly revert 'init.lua' updates" use code action.
  - "Delete". The idea is seeing a plugin that user forgot to delete. Instead of "yank plugin name and `:lua vim.pack.delete({ '<C-r>0' })<CR>` use code action.

After applying code action, plugin's section is removed from the update, so `:write` only acts on the left plugins.

### Jump to next/previous plugin section

Map locally to 'nvim-pack' buffer the `[[` and `]]` to jump to next/previous plugin section.

---

Here is a demo:

https://github.com/user-attachments/assets/ee426ea6-5687-46f6-8b27-f7527f135a6d

---

Resolve #34773