### PR TITLE
fix(lsp): prevent empty content.value from causing invalid window height

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -66,8 +66,14 @@ function M.hover(config)
       local err, result = resp.err, resp.result
       if err then
         lsp.log.error(err.code, err.message)
-      elseif result then
-        results1[client_id] = result
+      elseif result and result.contents then
+        -- make sure MarkedString | MarkedString[] | MarkupContent has valid value
+        if
+          (type(result.contents) == 'table' and #(vim.tbl_get(result.contents, 'value') or '') > 0)
+          or type(result.contents == 'string') and #result.contents > 0
+        then
+          results1[client_id] = result
+        end
       end
     end
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -7110,4 +7110,34 @@ describe('LSP', function()
       )
     end)
   end)
+
+  describe('vim.lsp.buf.hover', function()
+    it('prevent empty content.value from causing invalid window height in hover preview', function()
+      exec_lua(create_server_definition)
+      exec_lua(function()
+        local server = _G._create_server({
+          capabilities = {
+            hoverProvider = true,
+          },
+          handlers = {
+            ['textDocument/hover'] = function(_, _, callback)
+              local res = {
+                contents = {
+                  kind = 'markdown',
+                  value = '',
+                },
+              }
+              callback(nil, res)
+            end,
+          },
+        })
+        vim.lsp.start({
+          name = 'dump',
+          cmd = server.cmd,
+        })
+      end)
+
+      eq('No information available', n.exec_capture('lua vim.lsp.buf.hover()'))
+    end)
+  end)
 end)


### PR DESCRIPTION
Problem: When LSP hover response has content.value as an empty string, it causes the floating preview height to be set to 0, triggering an error in nvim_open_win.

Solution: Add a check to avoid setting height to 0 when content.value is empty.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
