### PR TITLE
feat: set `'foldmethod'` for Lua ftplugin

### DIFF
--- a/runtime/ftplugin/lua.lua
+++ b/runtime/ftplugin/lua.lua
@@ -4,7 +4,8 @@ vim.treesitter.start()
 vim.bo.includeexpr = [[v:lua.require'vim._ftplugin.lua'.includeexpr(v:fname)]]
 vim.bo.omnifunc = 'v:lua.vim.lua_omnifunc'
 vim.wo[0][0].foldexpr = 'v:lua.vim.treesitter.foldexpr()'
+vim.wo[0][0].foldmethod = 'expr'
 
 vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '')
   .. '\n call v:lua.vim.treesitter.stop()'
-  .. '\n setl omnifunc< foldexpr< includeexpr<'
+  .. '\n setl omnifunc< foldexpr< foldmethod< includeexpr<'


### PR DESCRIPTION
Problem:
Neovim's Lua ftplugin doesn't set `'foldmethod'`, though Vim one set it https://github.com/vim/vim/blob/1341176e7b800238b30a137c1ea1a31ca2c3d488/runtime/ftplugin/lua.vim#L66-L68

Solution:
Set it

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
