### PR TITLE
fix(float): prevent crash in WinLeave when closing last tab

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -2640,6 +2640,7 @@ static bool close_last_window_tabpage(win_T *win, bool free_buf, tabpage_T *prev
   if (old_curbuf != curbuf) {
     apply_autocmds(EVENT_BUFENTER, NULL, NULL, false, curbuf);
   }
+
   return true;
 }
 
@@ -2977,6 +2978,12 @@ void win_close_othertab(win_T *win, int free_buf, tabpage_T *tp)
   if (win_locked(win)
       || (win->w_buffer != NULL && win->w_buffer->b_locked > 0)) {
     return;  // window is already being closed
+  }
+
+  // Check if closing this window would leave only floating windows.
+  if (tp->tp_firstwin == win && win->w_next && win->w_next->w_floating) {
+    emsg(e_floatonly);
+    return;
   }
 
   // Fire WinClosed just before starting to free window-related resources.

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -2153,6 +2153,17 @@ describe('API/win', function()
         })
       )
     end)
+
+    it('no crash when creating float in WinLeave during tab close #31236', function()
+      exec([[
+        autocmd WinLeave * call nvim_open_win(0, v:false,{'win': 0, 'relative': 'win', 'row': 2, 'col': 2, 'width': 2, 'height': 2})
+      ]])
+      command('tab split')
+      matches(
+        'Cannot close window, only floating window would remain',
+        pcall_err(n.exec_capture, 'quit')
+      )
+    end)
   end)
 
   describe('set_config', function()


### PR DESCRIPTION
Problem: Closing the last non-floating window in a tabpage via
win_close_othertab (e.g., during tab closure with autocommands)
can leave only floating windows, causing crashes.

Solution: Check if closing the first window would leave only
floating windows and prevent the operation.

Fix #31236 

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
