### PR TITLE
Revert "fix(runtime): set 'foldmethod' for Lua ftplugin #34929"

### DIFF
--- a/runtime/ftplugin/lua.lua
+++ b/runtime/ftplugin/lua.lua
@@ -4,8 +4,7 @@ vim.treesitter.start()
 vim.bo.includeexpr = [[v:lua.require'vim._ftplugin.lua'.includeexpr(v:fname)]]
 vim.bo.omnifunc = 'v:lua.vim.lua_omnifunc'
 vim.wo[0][0].foldexpr = 'v:lua.vim.treesitter.foldexpr()'
-vim.wo[0][0].foldmethod = 'expr'
 
 vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '')
   .. '\n call v:lua.vim.treesitter.stop()'
-  .. '\n setl omnifunc< foldexpr< foldmethod< includeexpr<'
+  .. '\n setl omnifunc< foldexpr< includeexpr<'


### PR DESCRIPTION
This reverts commit 12276832ab67b16f795d78c72386ab28c6ee26c7, because it is not really good as default, it breaks nvim-treesitter test

I personally want to [add `g:lua_folding` option like in Vim](https://github.com/neovim/neovim/pull/34929#issuecomment-3068833329), but that [doesn't seem wanted](https://github.com/neovim/neovim/pull/34929#issuecomment-3069303149), so I'll just revert it

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
