### PR TITLE
vim-patch: update runtime files

### DIFF
--- a/runtime/ftplugin/fga.vim
+++ b/runtime/ftplugin/fga.vim
@@ -1,0 +1,13 @@
+" Vim filetype plugin
+" Language:	FGA
+" Maintainer:	Riley Bruins <ribru17@gmail.com>
+" Last Change:	2025 Jul 14
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setl comments=:# commentstring=#\ %s
+
+let b:undo_ftplugin = 'setl com< cms<'

--- a/runtime/ftplugin/pkl.vim
+++ b/runtime/ftplugin/pkl.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin
+" Language:	Pkl
+" Maintainer:	Riley Bruins <ribru17@gmail.com>
+" Last Change:	2025 Jul 14
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
+setlocal commentstring=//\ %s
+
+let b:undo_ftplugin = 'setl com< cms<'

--- a/runtime/ftplugin/swig.vim
+++ b/runtime/ftplugin/swig.vim
@@ -2,6 +2,7 @@
 " Language:	SWIG
 " Maintainer:	Julien Marrec <julien.marrec 'at' gmail com>
 " Last Change:	2023 November 23
+" 2025 July 14 by Vim project: set 'comment'/'commentstring' options
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -9,5 +10,7 @@ if exists("b:did_ftplugin")
 endif
 let b:did_ftplugin = 1
 
-let b:undo_ftplugin = "setlocal iskeyword<"
+let b:undo_ftplugin = "setlocal iskeyword< comments< commentstring<"
 setlocal iskeyword+=%
+setlocal comments=sO:*\ -,mO:*\ \ ,exO:*/,s1:/*,mb:*,ex:*/,://
+setlocal commentstring=//\ %s

--- a/runtime/ftplugin/twig.vim
+++ b/runtime/ftplugin/twig.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin
+" Language:	twig
+" Maintainer:	Riley Bruins <ribru17@gmail.com>
+" Last Change:	2025 Jul 14
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setlocal comments=s:{#,e:#}
+setlocal commentstring={#\ %s\ #}
+
+let b:undo_ftplugin = 'setl comments< commentstring<'

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -949,6 +949,7 @@ local extension = {
   pike = 'pike',
   pmod = 'pike',
   rcp = 'pilrc',
+  pkl = 'pkl',
   PL = detect.pl,
   pli = 'pli',
   pl1 = 'pli',

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -459,6 +459,7 @@ local extension = {
   fwt = 'fan',
   lib = 'faust',
   fnl = 'fennel',
+  fga = 'fga',
   m4gl = 'fgl',
   ['4gl'] = 'fgl',
   ['4gh'] = 'fgl',

--- a/runtime/syntax/python2.vim
+++ b/runtime/syntax/python2.vim
@@ -3,6 +3,7 @@
 " Maintainer:	Zvezdan Petkovic <zpetkovic@acm.org>
 " Last Change:	2016 Oct 29
 " 2025 Jul 14 by Vim project: highlight unicode strings
+" 2025 Jul 15 by Vim project: highlight b-strings
 " Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "		Rob B
@@ -143,16 +144,16 @@ syn keyword pythonTodo		FIXME NOTE NOTES TODO XXX contained
 
 " Triple-quoted strings can contain doctests.
 syn region  pythonString matchgroup=pythonQuotes
-      \ start=+\z(['"]\)+ end="\z1" skip="\\\\\|\\\z1"
+      \ start=+[bB]\=\z(['"]\)+ end="\z1" skip="\\\\\|\\\z1"
       \ contains=pythonEscape,@Spell
 syn region  pythonString matchgroup=pythonTripleQuotes
-      \ start=+\z('''\|"""\)+ end="\z1" keepend
+      \ start=+[bB]\=\z('''\|"""\)+ end="\z1" keepend
       \ contains=pythonEscape,pythonSpaceError,pythonDoctest,@Spell
 syn region  pythonRawString matchgroup=pythonQuotes
-      \ start=+[rR]\z(['"]\)+ end="\z1" skip="\\\\\|\\\z1"
+      \ start=+[bB]\=[rR]\z(['"]\)+ end="\z1" skip="\\\\\|\\\z1"
       \ contains=@Spell
 syn region  pythonRawString matchgroup=pythonTripleQuotes
-      \ start=+[rR]\z('''\|"""\)+ end="\z1" keepend
+      \ start=+[bB]\=[rR]\z('''\|"""\)+ end="\z1" keepend
       \ contains=pythonSpaceError,pythonDoctest,@Spell
 
 " Unicode strings

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -602,6 +602,7 @@ func s:GetFilenameChecks() abort
     \ 'pilrc': ['file.rcp'],
     \ 'pine': ['.pinerc', 'pinerc', '.pinercex', 'pinercex'],
     \ 'pinfo': ['/etc/pinforc', '/.pinforc', 'any/.pinforc', 'any/etc/pinforc'],
+    \ 'pkl': ['file.pkl'],
     \ 'pli': ['file.pli', 'file.pl1'],
     \ 'plm': ['file.plm', 'file.p36', 'file.pac'],
     \ 'plp': ['file.plp'],

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -285,6 +285,7 @@ func s:GetFilenameChecks() abort
     \ 'faust': ['file.dsp', 'file.lib'],
     \ 'fennel': ['file.fnl', '.fennelrc', 'fennelrc'],
     \ 'fetchmail': ['.fetchmailrc'],
+    \ 'fga': ['file.fga'],
     \ 'fgl': ['file.4gl', 'file.4gh', 'file.m4gl'],
     \ 'firrtl': ['file.fir'],
     \ 'fish': ['file.fish'],


### PR DESCRIPTION
- **vim-patch:edce689: runtime(python2): Highlight b-strings in Python 2.7**
- **vim-patch:30df425: runtime(twig): include twig filetype plugin**
- **vim-patch:9a667b4: runtime(swig): add 'comments', 'commentstring' in filetype plugin**
- **vim-patch:9.1.1548: filetype: OpenFGA files are not recognized**
- **vim-patch:9.1.1549: filetype: pkl files are not recognized**

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
