### PR TITLE
feat(fs): fs.find catches link paths that point to real targets of opts.type

### DIFF
--- a/runtime/lua/vim/fs.lua
+++ b/runtime/lua/vim/fs.lua
@@ -303,8 +303,12 @@ function M.find(names, opts)
       test = function(p)
         local t = {}
         for name, type in M.dir(p) do
-          if (not opts.type or opts.type == type) and names(name, p) then
-            table.insert(t, M.joinpath(p, name))
+          local f = M.joinpath(p, name)
+          if
+            (not opts.type or opts.type == type or (type == 'link' and (vim.uv.fs_stat(f) or {}).type == opts.type))
+            and names(name, p)
+          then
+            table.insert(t, f)
           end
         end
         return t
@@ -352,14 +356,20 @@ function M.find(names, opts)
       for other, type_ in M.dir(dir) do
         local f = M.joinpath(dir, other)
         if type(names) == 'function' then
-          if (not opts.type or opts.type == type_) and names(other, dir) then
+          if
+            (not opts.type or opts.type == type_ or (type_ == 'link' and (vim.uv.fs_stat(f) or {}).type == opts.type))
+            and names(other, dir)
+          then
             if add(f) then
               return matches
             end
           end
         else
           for _, name in ipairs(names) do
-            if name == other and (not opts.type or opts.type == type_) then
+            if
+              name == other
+              and (not opts.type or opts.type == type_ or (type_ == 'link' and (vim.uv.fs_stat(f) or {}).type == opts.type))
+            then
               if add(f) then
                 return matches
               end


### PR DESCRIPTION
I add a feature to catche  link paths that point to real targets of giving type to `vim.fs.find`.
It may need a new opt like `check_link` for switching this feature, if it is not expected normally.
I have checked tests for this PR.