### PR TITLE
fix(lsp): malformed edit if apply_text_edits() is called twice

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2899,7 +2899,8 @@ apply_text_document_edit({text_document_edit}, {index}, {position_encoding},
                                              *vim.lsp.util.apply_text_edits()*
 apply_text_edits({text_edits}, {bufnr}, {position_encoding},
                  {change_annotations})
-    Applies a list of text edits to a buffer.
+    Applies a list of text edits to a buffer. Note: this mutates `text_edits`
+    (sorts in-place and adds `_index` fields).
 
     Parameters: ~
       • {text_edits}          (`(lsp.TextEdit|lsp.AnnotatedTextEdit)[]`)

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -291,7 +291,9 @@ local function get_line_byte_from_position(bufnr, position, position_encoding)
   return col
 end
 
---- Applies a list of text edits to a buffer.
+--- Applies a list of text edits to a buffer. Note: this mutates `text_edits` (sorts in-place and
+--- adds `_index` fields).
+---
 ---@param text_edits (lsp.TextEdit|lsp.AnnotatedTextEdit)[]
 ---@param bufnr integer Buffer id
 ---@param position_encoding 'utf-8'|'utf-16'|'utf-32'
@@ -320,7 +322,10 @@ function M.apply_text_edits(text_edits, bufnr, position_encoding, change_annotat
     -- Fix reversed range and indexing each text_edits
     for index, text_edit in ipairs(text_edits) do
       --- @cast text_edit lsp.TextEdit|{_index: integer}
-      text_edit._index = index
+      -- XXX: Preserve existing _index to avoid surprises if the same edit is reapplied. #39344
+      if text_edit._index == nil then
+        text_edit._index = index
+      end
 
       if
         text_edit.range.start.line > text_edit.range['end'].line


### PR DESCRIPTION
fix #39344

Problem:  
the same dict `text_edit` passed into `vim.lsp.util.apply_text_edit` twice(two independant function calls, but with the same `text_edit`) will result in incorrect "applying" behavior. Because of adding index and sorting in-place.

I found that it breaks `lspsaga` codeaction (specific actions), because the function is called once for preview, and then again to apply the action (second call with the same `text_edit`, described below).

Of course, it can be fixed on the plugin side, but you might consider handling it in core as well.

Reason:

1. `text_edits` is modified in place by setting `_index = index` for each `text_edit` in table order

   https://github.com/neovim/neovim/blob/8bccd07972523936fe536fdade22d2f72eab3ef0/runtime/lua/vim/lsp/util.lua#L322-L324

2. `text_edits` is reversed in place

   https://github.com/neovim/neovim/blob/8bccd07972523936fe536fdade22d2f72eab3ef0/runtime/lua/vim/lsp/util.lua#L343-L351

- The next `vim.lsp.util.apply_text_edit` call with the same `text_edits` will re-apply step 1, which results in wrong indexes, because the order was already reversed (step 2).

Real world example:

case: update multiline import

```typescript
import {
    x,
    y
} from "cool-lib";
```

To update the import, there are two edits:  
First is to add a comma after `y`,  
Second is to add the actual import name.

initial `text_edits`:

```lua
{ {
    newText = ",",
    range = {
      ["end"] = {
        character = 20,
        line = 12
      },
      start = {
        character = 20,
        line = 12
      }
    }
  }, {
    newText = "\n  useState",
    range = {
      ["end"] = {
        character = 20,
        line = 12
      },
      start = {
        character = 20,
        line = 12
      }
    }
  } }
```

After first call:

```lua
{ {
    _index = 2,
    newText = "\n  useState",
    range = {
      ["end"] = {
        character = 20,
        line = 12
      },
      start = {
        character = 20,
        line = 12
      }
    }
  }, {
    _index = 1,
    newText = ",",
    range = {
      ["end"] = {
        character = 20,
        line = 12
      },
      start = {
        character = 20,
        line = 12
      }
    }
  } }
```

After second call with the same `text_edit`:

```lua
{ {
    _index = 2,
    newText = ",",
    range = {
      ["end"] = {
        character = 20,
        line = 12
      },
      start = {
        character = 20,
        line = 12
      }
    }
  }, {
    _index = 1,
    newText = "\n  useState",
    range = {
      ["end"] = {
        character = 20,
        line = 12
      },
      start = {
        character = 20,
        line = 12
      }
    }
  } }
```

As you can see, because of incorrect `_index`(against initial `text_edits`), the order is after second call is different from result of first call.

Solution:  
Keep `_index` if it already exists. I haven't considered other use cases, so maybe this isn't the correct fix.

Another possible solution is to deepcopy `text_edits` to prevent in-place sorting.

Feel free to close this, as it can be solved on the plugin side(at least by deepcopying).
