### PR TITLE
vim-patch:9.1.{1554,1559}

### DIFF
--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -1044,11 +1044,13 @@ static bool pum_set_selected(int n, int repeat)
     // 'completeopt' contains "preview".
     // Skip this when tried twice already.
     // Skip this also when there is not much room.
+    // Skip this for command-window when 'completeopt' contains "preview".
     // NOTE: Be very careful not to sync undo!
     if ((pum_array[pum_selected].pum_info != NULL)
         && (Rows > 10)
         && (repeat <= 1)
-        && (cur_cot_flags & (kOptCotFlagPreview | kOptCotFlagPopup))) {
+        && (cur_cot_flags & (kOptCotFlagPreview | kOptCotFlagPopup))
+        && !((cur_cot_flags & kOptCotFlagPreview) && cmdwin_type != 0)) {
       win_T *curwin_save = curwin;
       tabpage_T *curtab_save = curtab;
 

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -1,7 +1,10 @@
 if exists('s:did_load')
   " Align Nvim defaults to Vim.
   set commentstring=/*\ %s\ */
-  set complete=.,w,b,u,t,i
+  if g:testname !~ 'test_ins_complete_no_halt\.vim$'
+    set complete=.,w,b,u,t,i
+    set completeopt=menu,preview
+  endif
   set define=^\\s*#\\s*define
   set diffopt=internal,filler,closeoff,inline:simple
   set directory^=.
@@ -32,7 +35,7 @@ if exists('s:did_load')
   if has('win32')
     set isfname+=:
   endif
-  if g:testname !~ 'test_mapping.vim$'
+  if g:testname !~ 'test_mapping\.vim$'
     " Make "Q" switch to Ex mode.
     " This does not work for all tests as Nvim only supports Vim Ex mode.
     nnoremap Q gQ<Cmd>call<SID>ExStart()<CR>

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -216,6 +216,8 @@ func Test_popup_complete()
   call feedkeys("aM\<f5>\<enter>\<esc>", 'tx')
   call assert_equal(["March", "M", "March"], getline(1,4))
   %d
+
+  set completeopt&
 endfunc
 
 
@@ -1081,6 +1083,7 @@ func Test_popup_complete_info_01()
   setlocal thesaurus=Xdummy.txt
   setlocal omnifunc=syntaxcomplete#Complete
   setlocal completefunc=syntaxcomplete#Complete
+  setlocal completeopt+=noinsert
   setlocal spell
   for [keys, mode_name] in [
         \ ["", ''],

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -2285,5 +2285,18 @@ func Test_pum_position_when_wrap()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test that Vim does not crash when completion inside cmdwin opens a 'info'
+" preview window.
+func Test_popup_complete_cmdwin_preview()
+  func! CompleteWithPreview(findstart, base)
+    if a:findstart
+      return getline('.')->strpart(0, col('.') - 1)
+    endif
+    return [#{word: 'echo', info: 'bar'}, #{word: 'echomsg', info: 'baz'}]
+  endfunc
+  set omnifunc=CompleteWithPreview
+  call feedkeys("q:if\<C-X>\<C-O>\<C-N>\<ESC>\<CR>", 'tx!')
+  set omnifunc&
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1554: crash when omni-completion opens command-line window

Problem:  Vim crashes during omnifunc completion inside the command-line
          window ("q:") if the completion item attempts to open an "info"
          preview window. This leads to a failed assert during execution.
Solution: Avoid opening preview windows while inside the command-line
          window to prevent the crash (Girish Palya).

closes: vim/vim#17764

https://github.com/vim/vim/commit/e4fdb1e4e7583d824d4d86efa9b507c218d0af6a

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1559: tests: Test_popup_complete_info_01() fails when run alone

Problem:  tests: Test_popup_complete_info_01() fails when run alone.
Solution: Set buffer-local competeopt+=noinsert and add missing cleanup
          in Test_popup_complete() (zeertzjq).

closes: vim/vim#17773

https://github.com/vim/vim/commit/12d274af44bce9002ece1dc115559d27fcd77602
