### PR TITLE
test(screen): remove screen:get_default_attr_ids()

### DIFF
--- a/test/functional/ui/fold_spec.lua
+++ b/test/functional/ui/fold_spec.lua
@@ -29,34 +29,21 @@ describe('folded lines', function()
     local screen
     before_each(function()
       screen = Screen.new(45, 8, { rgb = true, ext_multigrid = multigrid })
-      screen:set_default_attr_ids({
-        [1] = { bold = true, foreground = Screen.colors.Blue1 },
-        [2] = { reverse = true },
-        [3] = { bold = true, reverse = true },
-        [4] = { foreground = Screen.colors.White, background = Screen.colors.Red },
-        [5] = { foreground = Screen.colors.DarkBlue, background = Screen.colors.LightGrey },
-        [6] = { background = Screen.colors.Yellow },
-        [7] = { foreground = Screen.colors.DarkBlue, background = Screen.colors.WebGray },
-        [8] = { foreground = Screen.colors.Brown },
-        [9] = { bold = true, foreground = Screen.colors.Brown },
-        [10] = { background = Screen.colors.LightGrey, underline = true },
-        [11] = { bold = true },
-        [12] = { foreground = Screen.colors.Red },
-        [13] = { foreground = Screen.colors.Red, background = Screen.colors.LightGrey },
-        [14] = { background = Screen.colors.Red },
-        [15] = { foreground = Screen.colors.DarkBlue, background = Screen.colors.Red },
-        [16] = { foreground = Screen.colors.Black, background = Screen.colors.LightGrey },
-        [17] = { background = Screen.colors.Yellow, foreground = Screen.colors.Red },
-        [18] = {
-          background = Screen.colors.LightGrey,
+      screen:add_extra_attr_ids({
+        [100] = { foreground = Screen.colors.Red },
+        [101] = { foreground = Screen.colors.Red, background = Screen.colors.LightGrey },
+        [102] = { underline = true },
+        [103] = { foreground = Screen.colors.Blue4, background = Screen.colors.Red },
+        [104] = {
           bold = true,
-          foreground = Screen.colors.Blue,
+          background = Screen.colors.LightGray,
+          foreground = Screen.colors.Blue1,
         },
-        [19] = { background = Screen.colors.Yellow, foreground = Screen.colors.DarkBlue },
-        [20] = { background = Screen.colors.Red, bold = true, foreground = Screen.colors.Blue },
-        [21] = { background = Screen.colors.LightGrey, foreground = Screen.colors.Green },
-        [22] = { background = Screen.colors.Red, foreground = Screen.colors.Green },
-        [23] = { foreground = Screen.colors.Blue1, bold = true, background = Screen.colors.Yellow },
+        [105] = { background = Screen.colors.Yellow1, foreground = Screen.colors.Blue4 },
+        [106] = { bold = true, background = Screen.colors.Red, foreground = Screen.colors.Blue1 },
+        [107] = { background = Screen.colors.LightGrey, foreground = Screen.colors.WebGreen },
+        [108] = { foreground = Screen.colors.Green, background = Screen.colors.Red },
+        [109] = { foreground = Screen.colors.Blue, bold = true, background = Screen.colors.Yellow1 },
       })
     end)
 
@@ -70,14 +57,14 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {7:                  }{5:^+--  2 lines: ·············}|
+          {7:                  }{13:^+--  2 lines: ·············}|
           {1:~                                            }|*6
         ## grid 3
                                                        |
         ]])
       else
         screen:expect([[
-          {7:                  }{5:^+--  2 lines: ·············}|
+          {7:                  }{13:^+--  2 lines: ·············}|
           {1:~                                            }|*6
                                                        |
         ]])
@@ -100,8 +87,8 @@ describe('folded lines', function()
             [2:---------------------------------------------]|*7
             [3:---------------------------------------------]|
           ## grid 2
-            {7:+ }{8:  1 }{5:+--  4 lines: This is a················}|
-            {6:  }{9:  5 }{12:^in his cave.                           }|
+            {7:+ }{8:  1 }{13:+--  4 lines: This is a················}|
+            {10:  }{15:  5 }{100:^in his cave.                           }|
             {7:  }{8:  6 }                                       |
             {1:~                                            }|*4
           ## grid 3
@@ -113,8 +100,8 @@ describe('folded lines', function()
             [2:---------------------------------------------]|*7
             [3:---------------------------------------------]|
           ## grid 2
-            {7:+ }{8:  1 }{5:This is a······························}|
-            {6:  }{9:  5 }{12:^in his cave.                           }|
+            {7:+ }{8:  1 }{13:This is a······························}|
+            {10:  }{15:  5 }{100:^in his cave.                           }|
             {7:  }{8:  6 }                                       |
             {1:~                                            }|*4
           ## grid 3
@@ -124,16 +111,16 @@ describe('folded lines', function()
       else
         if foldtext then
           screen:expect([[
-            {7:+ }{8:  1 }{5:+--  4 lines: This is a················}|
-            {6:  }{9:  5 }{12:^in his cave.                           }|
+            {7:+ }{8:  1 }{13:+--  4 lines: This is a················}|
+            {10:  }{15:  5 }{100:^in his cave.                           }|
             {7:  }{8:  6 }                                       |
             {1:~                                            }|*4
                                                          |
           ]])
         else
           screen:expect([[
-            {7:+ }{8:  1 }{5:This is a······························}|
-            {6:  }{9:  5 }{12:^in his cave.                           }|
+            {7:+ }{8:  1 }{13:This is a······························}|
+            {10:  }{15:  5 }{100:^in his cave.                           }|
             {7:  }{8:  6 }                                       |
             {1:~                                            }|*4
                                                          |
@@ -150,7 +137,7 @@ describe('folded lines', function()
             [2:---------------------------------------------]|*7
             [3:---------------------------------------------]|
           ## grid 2
-            {6:+ }{9:  1 }{13:^+--  4 lines: This is a················}|
+            {10:+ }{15:  1 }{101:^+--  4 lines: This is a················}|
             {7:  }{8:  5 }in his cave.                           |
             {7:  }{8:  6 }                                       |
             {1:~                                            }|*4
@@ -163,7 +150,7 @@ describe('folded lines', function()
             [2:---------------------------------------------]|*7
             [3:---------------------------------------------]|
           ## grid 2
-            {6:+ }{9:  1 }{13:^This is a······························}|
+            {10:+ }{15:  1 }{101:^This is a······························}|
             {7:  }{8:  5 }in his cave.                           |
             {7:  }{8:  6 }                                       |
             {1:~                                            }|*4
@@ -174,7 +161,7 @@ describe('folded lines', function()
       else
         if foldtext then
           screen:expect([[
-            {6:+ }{9:  1 }{13:^+--  4 lines: This is a················}|
+            {10:+ }{15:  1 }{101:^+--  4 lines: This is a················}|
             {7:  }{8:  5 }in his cave.                           |
             {7:  }{8:  6 }                                       |
             {1:~                                            }|*4
@@ -182,7 +169,7 @@ describe('folded lines', function()
           ]])
         else
           screen:expect([[
-            {6:+ }{9:  1 }{13:^This is a······························}|
+            {10:+ }{15:  1 }{101:^This is a······························}|
             {7:  }{8:  5 }in his cave.                           |
             {7:  }{8:  6 }                                       |
             {1:~                                            }|*4
@@ -206,7 +193,7 @@ describe('folded lines', function()
             [2:---------------------------------------------]|*7
             [3:---------------------------------------------]|
           ## grid 2
-            {7:+ }{8:  1 }{13:^+--  4 lines: This is a················}|
+            {7:+ }{8:  1 }{101:^+--  4 lines: This is a················}|
             {7:  }{8:  5 }in his cave.                           |
             {7:  }{8:  6 }                                       |
             {1:~                                            }|*4
@@ -219,7 +206,7 @@ describe('folded lines', function()
             [2:---------------------------------------------]|*7
             [3:---------------------------------------------]|
           ## grid 2
-            {7:+ }{8:  1 }{13:^This is a······························}|
+            {7:+ }{8:  1 }{101:^This is a······························}|
             {7:  }{8:  5 }in his cave.                           |
             {7:  }{8:  6 }                                       |
             {1:~                                            }|*4
@@ -230,7 +217,7 @@ describe('folded lines', function()
       else
         if foldtext then
           screen:expect([[
-            {7:+ }{8:  1 }{13:^+--  4 lines: This is a················}|
+            {7:+ }{8:  1 }{101:^+--  4 lines: This is a················}|
             {7:  }{8:  5 }in his cave.                           |
             {7:  }{8:  6 }                                       |
             {1:~                                            }|*4
@@ -238,7 +225,7 @@ describe('folded lines', function()
           ]])
         else
           screen:expect([[
-            {7:+ }{8:  1 }{13:^This is a······························}|
+            {7:+ }{8:  1 }{101:^This is a······························}|
             {7:  }{8:  5 }in his cave.                           |
             {7:  }{8:  6 }                                       |
             {1:~                                            }|*4
@@ -256,7 +243,7 @@ describe('folded lines', function()
             [2:---------------------------------------------]|*7
             [3:---------------------------------------------]|
           ## grid 2
-            {6:+ }{9:1   }{5:^+--  4 lines: This is a················}|
+            {10:+ }{15:1   }{13:^+--  4 lines: This is a················}|
             {7:  }{8:  1 }in his cave.                           |
             {7:  }{8:  2 }                                       |
             {1:~                                            }|*4
@@ -269,7 +256,7 @@ describe('folded lines', function()
             [2:---------------------------------------------]|*7
             [3:---------------------------------------------]|
           ## grid 2
-            {6:+ }{9:1   }{5:^This is a······························}|
+            {10:+ }{15:1   }{13:^This is a······························}|
             {7:  }{8:  1 }in his cave.                           |
             {7:  }{8:  2 }                                       |
             {1:~                                            }|*4
@@ -280,7 +267,7 @@ describe('folded lines', function()
       else
         if foldtext then
           screen:expect([[
-            {6:+ }{9:1   }{5:^+--  4 lines: This is a················}|
+            {10:+ }{15:1   }{13:^+--  4 lines: This is a················}|
             {7:  }{8:  1 }in his cave.                           |
             {7:  }{8:  2 }                                       |
             {1:~                                            }|*4
@@ -288,7 +275,7 @@ describe('folded lines', function()
           ]])
         else
           screen:expect([[
-            {6:+ }{9:1   }{5:^This is a······························}|
+            {10:+ }{15:1   }{13:^This is a······························}|
             {7:  }{8:  1 }in his cave.                           |
             {7:  }{8:  2 }                                       |
             {1:~                                            }|*4
@@ -308,14 +295,14 @@ describe('folded lines', function()
 
         it('with low-priority CursorLine' .. sfx, function()
           command('hi! CursorLine guibg=NONE guifg=NONE gui=underline')
-          local attrs = screen:get_default_attr_ids()
-          attrs[12] = { underline = true }
-          attrs[13] = {
-            foreground = Screen.colors.DarkBlue,
-            background = Screen.colors.LightGrey,
-            underline = true,
-          }
-          screen:set_default_attr_ids(attrs)
+          screen:add_extra_attr_ids({
+            [100] = { underline = true },
+            [101] = {
+              background = Screen.colors.LightGray,
+              underline = true,
+              foreground = Screen.colors.Blue4,
+            },
+          })
           test_folded_cursorline(foldtext)
         end)
       end
@@ -331,15 +318,13 @@ describe('folded lines', function()
       feed('gg')
       feed('zf3j')
       if not multigrid then
-        screen:expect {
-          grid = [[
-          {5:^+--  4 lines: This is a······················}|
+        screen:expect([[
+          {13:^+--  4 lines: This is a······················}|
           in his cave.                                 |
                                                        |
           {1:~                                            }|*4
                                                        |
-        ]],
-        }
+        ]])
       end
     end)
 
@@ -350,15 +335,13 @@ describe('folded lines', function()
       feed('gg')
       feed('zf3j')
       if not multigrid then
-        screen:expect {
-          grid = [[
-          {5:^+--  4 lines: This is a······················}|
+        screen:expect([[
+          {13:^+--  4 lines: This is a······················}|
           in his cave.                                 |
                                                        |
           {1:~                                            }|*4
                                                        |
-        ]],
-        }
+        ]])
       end
     end)
 
@@ -443,7 +426,7 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {7:▾▸}{5:^+---  5 lines: aa··························}|
+          {7:▾▸}{13:^+---  5 lines: aa··························}|
           {7:│ }ff                                         |
           {1:~                                            }|*5
         ## grid 3
@@ -452,7 +435,7 @@ describe('folded lines', function()
       else
         api.nvim_input_mouse('left', 'press', '', 0, 0, 1)
         screen:expect([[
-          {7:▾▸}{5:^+---  5 lines: aa··························}|
+          {7:▾▸}{13:^+---  5 lines: aa··························}|
           {7:│ }ff                                         |
           {1:~                                            }|*5
           :set norightleft                             |
@@ -466,7 +449,7 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {7:▸ }{5:^+--  6 lines: aa···························}|
+          {7:▸ }{13:^+--  6 lines: aa···························}|
           {1:~                                            }|*6
         ## grid 3
           :set norightleft                             |
@@ -474,7 +457,7 @@ describe('folded lines', function()
       else
         api.nvim_input_mouse('left', 'press', '', 0, 0, 0)
         screen:expect([[
-          {7:▸ }{5:^+--  6 lines: aa···························}|
+          {7:▸ }{13:^+--  6 lines: aa···························}|
           {1:~                                            }|*6
           :set norightleft                             |
         ]])
@@ -489,8 +472,8 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {11:!!!!!!                                       }|
-          {7:▾▸}{5:^+---  5 lines: aa··························}|
+          {5:!!!!!!                                       }|
+          {7:▾▸}{13:^+---  5 lines: aa··························}|
           {7:│ }ff                                         |
           {1:~                                            }|*4
         ## grid 3
@@ -499,8 +482,8 @@ describe('folded lines', function()
       else
         api.nvim_input_mouse('left', 'press', '', 0, 1, 0)
         screen:expect([[
-          {11:!!!!!!                                       }|
-          {7:▾▸}{5:^+---  5 lines: aa··························}|
+          {5:!!!!!!                                       }|
+          {7:▾▸}{13:^+---  5 lines: aa··························}|
           {7:│ }ff                                         |
           {1:~                                            }|*4
           :set norightleft                             |
@@ -514,7 +497,7 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {11:!!!!!!                                       }|
+          {5:!!!!!!                                       }|
           {7:▾▾}^aa                                         |
           {7:││}bb                                         |
           {7:││}cc                                         |
@@ -527,7 +510,7 @@ describe('folded lines', function()
       else
         api.nvim_input_mouse('left', 'press', '', 0, 1, 1)
         screen:expect([[
-          {11:!!!!!!                                       }|
+          {5:!!!!!!                                       }|
           {7:▾▾}^aa                                         |
           {7:││}bb                                         |
           {7:││}cc                                         |
@@ -582,7 +565,7 @@ describe('folded lines', function()
           :1                                           |
         ## grid 4
           {7:-}^aa                                          |
-          {7:+}{5:+---  4 lines: bb···························}|
+          {7:+}{13:+---  4 lines: bb···························}|
           {7:│}ff                                          |
         ]])
       else
@@ -592,7 +575,7 @@ describe('folded lines', function()
           {7:-}bb                                          |
           {2:[No Name] [+]                                }|
           {7:-}^aa                                          |
-          {7:+}{5:+---  4 lines: bb···························}|
+          {7:+}{13:+---  4 lines: bb···························}|
           {7:│}ff                                          |
           {3:[No Name] [+]                                }|
           :1                                           |
@@ -643,7 +626,7 @@ describe('folded lines', function()
           [3:---------------------------------------------]|
         ## grid 2
           {7:-}aa                                          |
-          {7:+}{5:^+---  4 lines: bb···························}|
+          {7:+}{13:^+---  4 lines: bb···························}|
         ## grid 3
           :1                                           |
         ## grid 4
@@ -655,7 +638,7 @@ describe('folded lines', function()
         api.nvim_input_mouse('left', 'press', '', 0, 1, 0)
         screen:expect([[
           {7:-}aa                                          |
-          {7:+}{5:^+---  4 lines: bb···························}|
+          {7:+}{13:^+---  4 lines: bb···························}|
           {3:[No Name] [+]                                }|
           {7:-}aa                                          |
           {7:-}bb                                          |
@@ -675,7 +658,7 @@ describe('folded lines', function()
           {2:[No Name] [+]                                }|
           [3:---------------------------------------------]|
         ## grid 2
-          {7:+}{5:^+--  6 lines: aa····························}|
+          {7:+}{13:^+--  6 lines: aa····························}|
           {1:~                                            }|
         ## grid 3
           :1                                           |
@@ -687,7 +670,7 @@ describe('folded lines', function()
       else
         api.nvim_input_mouse('left', 'press', '', 0, 0, 0)
         screen:expect([[
-          {7:+}{5:^+--  6 lines: aa····························}|
+          {7:+}{13:^+--  6 lines: aa····························}|
           {1:~                                            }|
           {3:[No Name] [+]                                }|
           {7:-}aa                                          |
@@ -744,7 +727,7 @@ describe('folded lines', function()
           :1                                           |
         ## grid 4
           {7:-}^aa                   |
-          {7:+}{5:+---  4 lines: bb····}|
+          {7:+}{13:+---  4 lines: bb····}|
           {7:│}ff                   |
           {1:~                     }|*3
         ]])
@@ -752,7 +735,7 @@ describe('folded lines', function()
         api.nvim_input_mouse('left', 'press', '', 0, 0, 23)
         screen:expect([[
           {7:-}aa                   {2:│}{7:-}^aa                   |
-          {7:-}bb                   {2:│}{7:+}{5:+---  4 lines: bb····}|
+          {7:-}bb                   {2:│}{7:+}{13:+---  4 lines: bb····}|
           {7:2}cc                   {2:│}{7:│}ff                   |
           {7:2}dd                   {2:│}{1:~                     }|
           {7:2}ee                   {2:│}{1:~                     }|
@@ -809,7 +792,7 @@ describe('folded lines', function()
           [3:---------------------------------------------]|
         ## grid 2
           {7:-}aa                   |
-          {7:+}{5:^+---  4 lines: bb····}|
+          {7:+}{13:^+---  4 lines: bb····}|
           {7:│}ff                   |
           {1:~                     }|*3
         ## grid 3
@@ -826,7 +809,7 @@ describe('folded lines', function()
         api.nvim_input_mouse('left', 'press', '', 0, 1, 0)
         screen:expect([[
           {7:-}aa                   {2:│}{7:-}aa                   |
-          {7:+}{5:^+---  4 lines: bb····}{2:│}{7:-}bb                   |
+          {7:+}{13:^+---  4 lines: bb····}{2:│}{7:-}bb                   |
           {7:│}ff                   {2:│}{7:2}cc                   |
           {1:~                     }{2:│}{7:2}dd                   |
           {1:~                     }{2:│}{7:2}ee                   |
@@ -844,7 +827,7 @@ describe('folded lines', function()
           {3:[No Name] [+]          }{2:[No Name] [+]         }|
           [3:---------------------------------------------]|
         ## grid 2
-          {7:+}{5:^+--  6 lines: aa·····}|
+          {7:+}{13:^+--  6 lines: aa·····}|
           {1:~                     }|*5
         ## grid 3
           :1                                           |
@@ -859,7 +842,7 @@ describe('folded lines', function()
       else
         api.nvim_input_mouse('left', 'press', '', 0, 0, 0)
         screen:expect([[
-          {7:+}{5:^+--  6 lines: aa·····}{2:│}{7:-}aa                   |
+          {7:+}{13:^+--  6 lines: aa·····}{2:│}{7:-}aa                   |
           {1:~                     }{2:│}{7:-}bb                   |
           {1:~                     }{2:│}{7:2}cc                   |
           {1:~                     }{2:│}{7:2}dd                   |
@@ -890,7 +873,7 @@ describe('folded lines', function()
         api.nvim_input_mouse('left', 'press', '', 4, 1, 1)
         screen:expect([[
         ## grid 1
-          {10: + [No Name] }{11: + [No Name] }{2:                  }{10:X}|
+          {24: + [No Name] }{5: + [No Name] }{2:                  }{24:X}|
           [4:---------------------------------------------]|*6
           [3:---------------------------------------------]|
         ## grid 2 (hidden)
@@ -905,16 +888,16 @@ describe('folded lines', function()
           :tab split                                   |
         ## grid 4
           {7:- }^aa                                         |
-          {7:│+}{5:+---  4 lines: bb··························}|
+          {7:│+}{13:+---  4 lines: bb··························}|
           {7:│ }ff                                         |
           {1:~                                            }|*3
         ]])
       else
         api.nvim_input_mouse('left', 'press', '', 0, 2, 1)
         screen:expect([[
-          {10: + [No Name] }{11: + [No Name] }{2:                  }{10:X}|
+          {24: + [No Name] }{5: + [No Name] }{2:                  }{24:X}|
           {7:- }^aa                                         |
-          {7:│+}{5:+---  4 lines: bb··························}|
+          {7:│+}{13:+---  4 lines: bb··························}|
           {7:│ }ff                                         |
           {1:~                                            }|*3
           :tab split                                   |
@@ -925,7 +908,7 @@ describe('folded lines', function()
         api.nvim_input_mouse('left', 'press', '', 4, 0, 0)
         screen:expect([[
         ## grid 1
-          {10: + [No Name] }{11: + [No Name] }{2:                  }{10:X}|
+          {24: + [No Name] }{5: + [No Name] }{2:                  }{24:X}|
           [4:---------------------------------------------]|*6
           [3:---------------------------------------------]|
         ## grid 2 (hidden)
@@ -939,14 +922,14 @@ describe('folded lines', function()
         ## grid 3
           :tab split                                   |
         ## grid 4
-          {7:+ }{5:^+--  6 lines: aa···························}|
+          {7:+ }{13:^+--  6 lines: aa···························}|
           {1:~                                            }|*5
         ]])
       else
         api.nvim_input_mouse('left', 'press', '', 0, 1, 0)
         screen:expect([[
-          {10: + [No Name] }{11: + [No Name] }{2:                  }{10:X}|
-          {7:+ }{5:^+--  6 lines: aa···························}|
+          {24: + [No Name] }{5: + [No Name] }{2:                  }{24:X}|
+          {7:+ }{13:^+--  6 lines: aa···························}|
           {1:~                                            }|*5
           :tab split                                   |
         ]])
@@ -957,26 +940,26 @@ describe('folded lines', function()
         api.nvim_input_mouse('left', 'press', '', 2, 1, 1)
         screen:expect([[
         ## grid 1
-          {11: + [No Name] }{10: + [No Name] }{2:                  }{10:X}|
+          {5: + [No Name] }{24: + [No Name] }{2:                  }{24:X}|
           [2:---------------------------------------------]|*6
           [3:---------------------------------------------]|
         ## grid 2
           {7:- }^aa                                         |
-          {7:│+}{5:+---  4 lines: bb··························}|
+          {7:│+}{13:+---  4 lines: bb··························}|
           {7:│ }ff                                         |
           {1:~                                            }|*3
         ## grid 3
           :tabnext                                     |
         ## grid 4 (hidden)
-          {7:+ }{5:+--  6 lines: aa···························}|
+          {7:+ }{13:+--  6 lines: aa···························}|
           {1:~                                            }|*5
         ]])
       else
         api.nvim_input_mouse('left', 'press', '', 0, 2, 1)
         screen:expect([[
-          {11: + [No Name] }{10: + [No Name] }{2:                  }{10:X}|
+          {5: + [No Name] }{24: + [No Name] }{2:                  }{24:X}|
           {7:- }^aa                                         |
-          {7:│+}{5:+---  4 lines: bb··························}|
+          {7:│+}{13:+---  4 lines: bb··························}|
           {7:│ }ff                                         |
           {1:~                                            }|*3
           :tabnext                                     |
@@ -987,23 +970,23 @@ describe('folded lines', function()
         api.nvim_input_mouse('left', 'press', '', 2, 0, 0)
         screen:expect([[
         ## grid 1
-          {11: + [No Name] }{10: + [No Name] }{2:                  }{10:X}|
+          {5: + [No Name] }{24: + [No Name] }{2:                  }{24:X}|
           [2:---------------------------------------------]|*6
           [3:---------------------------------------------]|
         ## grid 2
-          {7:+ }{5:^+--  6 lines: aa···························}|
+          {7:+ }{13:^+--  6 lines: aa···························}|
           {1:~                                            }|*5
         ## grid 3
           :tabnext                                     |
         ## grid 4 (hidden)
-          {7:+ }{5:+--  6 lines: aa···························}|
+          {7:+ }{13:+--  6 lines: aa···························}|
           {1:~                                            }|*5
         ]])
       else
         api.nvim_input_mouse('left', 'press', '', 0, 1, 0)
         screen:expect([[
-          {11: + [No Name] }{10: + [No Name] }{2:                  }{10:X}|
-          {7:+ }{5:^+--  6 lines: aa···························}|
+          {5: + [No Name] }{24: + [No Name] }{2:                  }{24:X}|
+          {7:+ }{13:^+--  6 lines: aa···························}|
           {1:~                                            }|*5
           :tabnext                                     |
         ]])
@@ -1043,14 +1026,14 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {5:^+--  2 lines: å 语 x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ ﺎﻠﻋَﺮَﺒِﻳَّﺓ·················}|
+          {13:^+--  2 lines: å 语 x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ ﺎﻠﻋَﺮَﺒِﻳَّﺓ·················}|
           {1:~                                            }|*6
         ## grid 3
                                                        |
         ]])
       else
         screen:expect([[
-          {5:^+--  2 lines: å 语 x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ ﺎﻠﻋَﺮَﺒِﻳَّﺓ·················}|
+          {13:^+--  2 lines: å 语 x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ ﺎﻠﻋَﺮَﺒِﻳَّﺓ·················}|
           {1:~                                            }|*6
                                                        |
         ]])
@@ -1063,14 +1046,14 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {5:^+--  2 lines: å 语 x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ العَرَبِيَّة·················}|
+          {13:^+--  2 lines: å 语 x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ العَرَبِيَّة·················}|
           {1:~                                            }|*6
         ## grid 3
           :set noarabicshape                           |
         ]])
       else
         screen:expect([[
-          {5:^+--  2 lines: å 语 x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ العَرَبِيَّة·················}|
+          {13:^+--  2 lines: å 语 x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ العَرَبِيَّة·················}|
           {1:~                                            }|*6
           :set noarabicshape                           |
         ]])
@@ -1083,14 +1066,14 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {7:+ }{8:  1 }{5:^+--  2 lines: å 语 x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ العَرَبِيَّة···········}|
+          {7:+ }{8:  1 }{13:^+--  2 lines: å 语 x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ العَرَبِيَّة···········}|
           {1:~                                            }|*6
         ## grid 3
           :set number foldcolumn=2                     |
         ]])
       else
         screen:expect([[
-          {7:+ }{8:  1 }{5:^+--  2 lines: å 语 x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ العَرَبِيَّة···········}|
+          {7:+ }{8:  1 }{13:^+--  2 lines: å 语 x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ العَرَبِيَّة···········}|
           {1:~                                            }|*6
           :set number foldcolumn=2                     |
         ]])
@@ -1104,14 +1087,14 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {5:···········ةيَّبِرَعَلا x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ 语 å :senil 2  --^+}{8: 1  }{7: +}|
+          {13:···········ةيَّبِرَعَلا x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ 语 å :senil 2  --^+}{8: 1  }{7: +}|
           {1:                                            ~}|*6
         ## grid 3
           :set rightleft                               |
         ]])
       else
         screen:expect([[
-          {5:···········ةيَّبِرَعَلا x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ 语 å :senil 2  --^+}{8: 1  }{7: +}|
+          {13:···········ةيَّبِرَعَلا x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ 语 å :senil 2  --^+}{8: 1  }{7: +}|
           {1:                                            ~}|*6
           :set rightleft                               |
         ]])
@@ -1124,14 +1107,14 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {5:·················ةيَّبِرَعَلا x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ 语 å :senil 2  --^+}|
+          {13:·················ةيَّبِرَعَلا x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ 语 å :senil 2  --^+}|
           {1:                                            ~}|*6
         ## grid 3
           :set nonumber foldcolumn=0                   |
         ]])
       else
         screen:expect([[
-          {5:·················ةيَّبِرَعَلا x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ 语 å :senil 2  --^+}|
+          {13:·················ةيَّبِرَعَلا x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ 语 å :senil 2  --^+}|
           {1:                                            ~}|*6
           :set nonumber foldcolumn=0                   |
         ]])
@@ -1144,14 +1127,14 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {5:·················ﺔﻴَّﺑِﺮَﻌَﻟﺍ x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ 语 å :senil 2  --^+}|
+          {13:·················ﺔﻴَّﺑِﺮَﻌَﻟﺍ x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ 语 å :senil 2  --^+}|
           {1:                                            ~}|*6
         ## grid 3
           :set arabicshape                             |
         ]])
       else
         screen:expect([[
-          {5:·················ﺔﻴَّﺑِﺮَﻌَﻟﺍ x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ 语 å :senil 2  --^+}|
+          {13:·················ﺔﻴَّﺑِﺮَﻌَﻟﺍ x̨̣̘̫̲͚͎̎͂̀̂͛͛̾͢ 语 å :senil 2  --^+}|
           {1:                                            ~}|*6
           :set arabicshape                             |
         ]])
@@ -1254,7 +1237,7 @@ describe('folded lines', function()
         ## grid 3
           :                                            |
         ## grid 4
-          {1::}{7:+}{5:^+--  2 lines: set foldmethod=manual foldcol}|
+          {1::}{7:+}{13:^+--  2 lines: set foldmethod=manual foldcol}|
           {1::}{7: }                                           |
           {1:~                                            }|*2
         ]])
@@ -1262,7 +1245,7 @@ describe('folded lines', function()
         screen:expect([[
           {7: }                                            |
           {2:[No Name]                                    }|
-          {1::}{7:+}{5:^+--  2 lines: set foldmethod=manual foldcol}|
+          {1::}{7:+}{13:^+--  2 lines: set foldmethod=manual foldcol}|
           {1::}{7: }                                           |
           {1:~                                            }|*2
           {3:[Command Line]                               }|
@@ -1305,7 +1288,7 @@ describe('folded lines', function()
           /                                            |
         ## grid 5
           {1:/}{7: }alpha                                      |
-          {1:/}{7: }{6:omega}                                      |
+          {1:/}{7: }{10:omega}                                      |
           {1:/}{7: }^                                           |
           {1:~                                            }|
         ]])
@@ -1314,7 +1297,7 @@ describe('folded lines', function()
           {7: }                                            |
           {2:[No Name]                                    }|
           {1:/}{7: }alpha                                      |
-          {1:/}{7: }{6:omega}                                      |
+          {1:/}{7: }{10:omega}                                      |
           {1:/}{7: }^                                           |
           {1:~                                            }|
           {3:[Command Line]                               }|
@@ -1336,14 +1319,14 @@ describe('folded lines', function()
         ## grid 3
           /                                            |
         ## grid 5
-          {1:/}{7:+}{5:^+--  3 lines: alpha························}|
+          {1:/}{7:+}{13:^+--  3 lines: alpha························}|
           {1:~                                            }|*3
         ]])
       else
         screen:expect([[
           {7: }                                            |
           {2:[No Name]                                    }|
-          {1:/}{7:+}{5:^+--  3 lines: alpha························}|
+          {1:/}{7:+}{13:^+--  3 lines: alpha························}|
           {1:~                                            }|*3
           {3:[Command Line]                               }|
           /                                            |
@@ -1365,7 +1348,7 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {5:^+--  2 lines: line 1·························}|
+          {13:^+--  2 lines: line 1·························}|
           line 3                                       |
           line 4                                       |
           {1:~                                            }|*4
@@ -1374,7 +1357,7 @@ describe('folded lines', function()
         ]])
       else
         screen:expect([[
-          {5:^+--  2 lines: line 1·························}|
+          {13:^+--  2 lines: line 1·························}|
           line 3                                       |
           line 4                                       |
           {1:~                                            }|*4
@@ -1389,7 +1372,7 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {7:+}{5:^+--  2 lines: line 1························}|
+          {7:+}{13:^+--  2 lines: line 1························}|
           {7: }line 3                                      |
           {7: }line 4                                      |
           {1:~                                            }|*4
@@ -1398,7 +1381,7 @@ describe('folded lines', function()
         ]])
       else
         screen:expect([[
-          {7:+}{5:^+--  2 lines: line 1························}|
+          {7:+}{13:^+--  2 lines: line 1························}|
           {7: }line 3                                      |
           {7: }line 4                                      |
           {1:~                                            }|*4
@@ -1413,7 +1396,7 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {7:+}{5:^+--  2 lines: line 1························}|
+          {7:+}{13:^+--  2 lines: line 1························}|
           {7: }line 3                                      |
           {7: }line 4                                      |
           {1:~                                            }|*4
@@ -1425,7 +1408,7 @@ describe('folded lines', function()
       else
         screen:expect {
           grid = [[
-          {7:+}{5:^+--  2 lines: line 1························}|
+          {7:+}{13:^+--  2 lines: line 1························}|
           {7: }line 3                                      |
           {7: }line 4                                      |
           {1:~                                            }|*4
@@ -1443,14 +1426,14 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {7:+}{5:^+--  4 lines: line 1························}|
+          {7:+}{13:^+--  4 lines: line 1························}|
           {1:~                                            }|*6
         ## grid 3
                                                        |
         ]])
       else
         screen:expect([[
-          {7:+}{5:^+--  4 lines: line 1························}|
+          {7:+}{13:^+--  4 lines: line 1························}|
           {1:~                                            }|*6
                                                        |
         ]])
@@ -1458,28 +1441,7 @@ describe('folded lines', function()
 
       command('set foldcolumn=auto:1')
       if multigrid then
-        screen:expect {
-          grid = [[
-        ## grid 1
-          [2:---------------------------------------------]|*7
-          [3:---------------------------------------------]|
-        ## grid 2
-          {7:+}{5:^+--  4 lines: line 1························}|
-          {1:~                                            }|*6
-        ## grid 3
-                                                       |
-        ]],
-          unchanged = true,
-        }
-      else
-        screen:expect {
-          grid = [[
-          {7:+}{5:^+--  4 lines: line 1························}|
-          {1:~                                            }|*6
-                                                       |
-        ]],
-          unchanged = true,
-        }
+        screen:expect_unchanged()
       end
 
       -- relax the maximum fdc thus fdc should expand to
@@ -1491,14 +1453,14 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {7:+ }{5:^+--  4 lines: line 1·······················}|
+          {7:+ }{13:^+--  4 lines: line 1·······················}|
           {1:~                                            }|*6
         ## grid 3
                                                        |
         ]])
       else
         screen:expect([[
-          {7:+ }{5:^+--  4 lines: line 1·······················}|
+          {7:+ }{13:^+--  4 lines: line 1·······················}|
           {1:~                                            }|*6
                                                        |
         ]])
@@ -1520,14 +1482,14 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {5:^---------------------------------------------}|
+          {13:^---------------------------------------------}|
           {1:~                                            }|*6
         ## grid 3
                                                        |
         ]])
       else
         screen:expect([[
-          {5:^---------------------------------------------}|
+          {13:^---------------------------------------------}|
           {1:~                                            }|*6
                                                        |
         ]])
@@ -1548,7 +1510,7 @@ describe('folded lines', function()
         ## grid 2
           {8:  1 }^This is a                                |
           {8:  2 }valid English                            |
-          {8:  3 }{5:+--  2 lines: sentence composed by·······}|
+          {8:  3 }{13:+--  2 lines: sentence composed by·······}|
           {8:  5 }in his cave.                             |
           {8:  6 }                                         |
           {1:~                                            }|*2
@@ -1559,7 +1521,7 @@ describe('folded lines', function()
         screen:expect([[
           {8:  1 }^This is a                                |
           {8:  2 }valid English                            |
-          {8:  3 }{5:+--  2 lines: sentence composed by·······}|
+          {8:  3 }{13:+--  2 lines: sentence composed by·······}|
           {8:  5 }in his cave.                             |
           {8:  6 }                                         |
           {1:~                                            }|*2
@@ -1576,7 +1538,7 @@ describe('folded lines', function()
         ## grid 2
           {8:  1 }^his is a                                 |
           {8:  2 }alid English                             |
-          {8:  3 }{5:+--  2 lines: sentence composed by·······}|
+          {8:  3 }{13:+--  2 lines: sentence composed by·······}|
           {8:  5 }n his cave.                              |
           {8:  6 }                                         |
           {1:~                                            }|*2
@@ -1587,7 +1549,7 @@ describe('folded lines', function()
         screen:expect([[
           {8:  1 }^his is a                                 |
           {8:  2 }alid English                             |
-          {8:  3 }{5:+--  2 lines: sentence composed by·······}|
+          {8:  3 }{13:+--  2 lines: sentence composed by·······}|
           {8:  5 }n his cave.                              |
           {8:  6 }                                         |
           {1:~                                            }|*2
@@ -1613,7 +1575,7 @@ describe('folded lines', function()
         ## grid 2
           {8:  1 }                                         |
           {8:  2 }                                         |
-          {8:  3 }{5:αβγ······································}|
+          {8:  3 }{13:αβγ······································}|
           {8:  5 }                                         |
           {8:  6 }                                         |
           {8:  7 }!!!!!!!!!!!!!!!!!!!!^!                    |
@@ -1625,7 +1587,7 @@ describe('folded lines', function()
         screen:expect([[
           {8:  1 }                                         |
           {8:  2 }                                         |
-          {8:  3 }{5:αβγ······································}|
+          {8:  3 }{13:αβγ······································}|
           {8:  5 }                                         |
           {8:  6 }                                         |
           {8:  7 }!!!!!!!!!!!!!!!!!!!!^!                    |
@@ -1677,7 +1639,7 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {5:^+--  2 lines: line 1·························}|
+          {13:^+--  2 lines: line 1·························}|
           virt_line above line 3                       |
           line 3                                       |
           line 4                                       |
@@ -1700,7 +1662,7 @@ describe('folded lines', function()
         }
       else
         screen:expect([[
-          {5:^+--  2 lines: line 1·························}|
+          {13:^+--  2 lines: line 1·························}|
           virt_line above line 3                       |
           line 3                                       |
           line 4                                       |
@@ -1718,8 +1680,8 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {5:+--  2 lines: line 1·························}|
-          {5:^+--  2 lines: line 3·························}|
+          {13:+--  2 lines: line 1·························}|
+          {13:^+--  2 lines: line 3·························}|
           {1:~                                            }|*5
         ## grid 3
                                                        |
@@ -1738,8 +1700,8 @@ describe('folded lines', function()
         }
       else
         screen:expect([[
-          {5:+--  2 lines: line 1·························}|
-          {5:^+--  2 lines: line 3·························}|
+          {13:+--  2 lines: line 1·························}|
+          {13:^+--  2 lines: line 3·························}|
           {1:~                                            }|*5
                                                        |
         ]])
@@ -1758,7 +1720,7 @@ describe('folded lines', function()
           ^line 1                                       |
           line 2                                       |
           virt_line below line 2                       |
-          {5:+--  2 lines: line 3·························}|
+          {13:+--  2 lines: line 3·························}|
           line 5                                       |
           {1:~                                            }|
         ## grid 3
@@ -1782,7 +1744,7 @@ describe('folded lines', function()
           ^line 1                                       |
           line 2                                       |
           virt_line below line 2                       |
-          {5:+--  2 lines: line 3·························}|
+          {13:+--  2 lines: line 3·························}|
           line 5                                       |
           {1:~                                            }|
                                                        |
@@ -1820,7 +1782,7 @@ describe('folded lines', function()
           line 2                                       |
           virt_line below line 2                       |
           more virt_line below line 2                  |
-          {5:+--  2 lines: line 3·························}|
+          {13:+--  2 lines: line 3·························}|
           ^line 5                                       |
           {1:~                                            }|
         ## grid 3
@@ -1844,7 +1806,7 @@ describe('folded lines', function()
           line 2                                       |
           virt_line below line 2                       |
           more virt_line below line 2                  |
-          {5:+--  2 lines: line 3·························}|
+          {13:+--  2 lines: line 3·························}|
           ^line 5                                       |
           {1:~                                            }|
                                                        |
@@ -1862,7 +1824,7 @@ describe('folded lines', function()
           line 2                                       |
           virt_line below line 2                       |
           more virt_line below line 2                  |
-          {5:+--  2 lines: line 3·························}|
+          {13:+--  2 lines: line 3·························}|
           ^line 5                                       |
           {1:~                                            }|*2
         ## grid 3
@@ -1885,7 +1847,7 @@ describe('folded lines', function()
           line 2                                       |
           virt_line below line 2                       |
           more virt_line below line 2                  |
-          {5:+--  2 lines: line 3·························}|
+          {13:+--  2 lines: line 3·························}|
           ^line 5                                       |
           {1:~                                            }|*2
                                                        |
@@ -1902,7 +1864,7 @@ describe('folded lines', function()
         ## grid 2
           virt_line below line 2                       |
           more virt_line below line 2                  |
-          {5:+--  2 lines: line 3·························}|
+          {13:+--  2 lines: line 3·························}|
           ^line 5                                       |
           {1:~                                            }|*3
         ## grid 3
@@ -1924,7 +1886,7 @@ describe('folded lines', function()
         screen:expect([[
           virt_line below line 2                       |
           more virt_line below line 2                  |
-          {5:+--  2 lines: line 3·························}|
+          {13:+--  2 lines: line 3·························}|
           ^line 5                                       |
           {1:~                                            }|*3
                                                        |
@@ -1940,7 +1902,7 @@ describe('folded lines', function()
           [3:---------------------------------------------]|
         ## grid 2
           more virt_line below line 2                  |
-          {5:+--  2 lines: line 3·························}|
+          {13:+--  2 lines: line 3·························}|
           ^line 5                                       |
           {1:~                                            }|*4
         ## grid 3
@@ -1961,7 +1923,7 @@ describe('folded lines', function()
       else
         screen:expect([[
           more virt_line below line 2                  |
-          {5:+--  2 lines: line 3·························}|
+          {13:+--  2 lines: line 3·························}|
           ^line 5                                       |
           {1:~                                            }|*4
                                                        |
@@ -1976,7 +1938,7 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {5:+--  2 lines: line 3·························}|
+          {13:+--  2 lines: line 3·························}|
           ^line 5                                       |
           {1:~                                            }|*5
         ## grid 3
@@ -1996,7 +1958,7 @@ describe('folded lines', function()
         }
       else
         screen:expect([[
-          {5:+--  2 lines: line 3·························}|
+          {13:+--  2 lines: line 3·························}|
           ^line 5                                       |
           {1:~                                            }|*5
                                                        |
@@ -2046,7 +2008,7 @@ describe('folded lines', function()
         ## grid 2
           virt_line below line 2                       |
           more virt_line below line 2                  |
-          {5:+--  2 lines: line 3·························}|
+          {13:+--  2 lines: line 3·························}|
           ^line 5                                       |
           {1:~                                            }|*3
         ## grid 3
@@ -2068,7 +2030,7 @@ describe('folded lines', function()
         screen:expect([[
           virt_line below line 2                       |
           more virt_line below line 2                  |
-          {5:+--  2 lines: line 3·························}|
+          {13:+--  2 lines: line 3·························}|
           ^line 5                                       |
           {1:~                                            }|*3
                                                        |
@@ -2079,18 +2041,18 @@ describe('folded lines', function()
       if multigrid then
         screen:expect {
           grid = [[
-        ## grid 1
-          [2:---------------------------------------------]|*7
-          [3:---------------------------------------------]|
-        ## grid 2
-          virt_line below line 2                       |
-          more virt_line below line 2                  |
-          {5:+--  2 lines: line 3·························}|
-          ^l{16:ine 5}                                       |
-          {1:~                                            }|*3
-        ## grid 3
-          {11:-- VISUAL LINE --}                            |
-        ]],
+          ## grid 1
+            [2:---------------------------------------------]|*7
+            [3:---------------------------------------------]|
+          ## grid 2
+            virt_line below line 2                       |
+            more virt_line below line 2                  |
+            {13:+--  2 lines: line 3·························}|
+            ^l{17:ine 5}                                       |
+            {1:~                                            }|*3
+          ## grid 3
+            {5:-- VISUAL LINE --}                            |
+          ]],
           win_viewport = {
             [2] = {
               win = 1000,
@@ -2107,10 +2069,10 @@ describe('folded lines', function()
         screen:expect([[
           virt_line below line 2                       |
           more virt_line below line 2                  |
-          {5:+--  2 lines: line 3·························}|
-          ^l{16:ine 5}                                       |
+          {13:+--  2 lines: line 3·························}|
+          ^l{17:ine 5}                                       |
           {1:~                                            }|*3
-          {11:-- VISUAL LINE --}                            |
+          {5:-- VISUAL LINE --}                            |
         ]])
       end
 
@@ -2118,17 +2080,17 @@ describe('folded lines', function()
       if multigrid then
         screen:expect {
           grid = [[
-        ## grid 1
-          [2:---------------------------------------------]|*7
-          [3:---------------------------------------------]|
-        ## grid 2
-          more virt_line below line 2                  |
-          {5:+--  2 lines: line 3·························}|
-          ^l{16:ine 5}                                       |
-          {1:~                                            }|*4
-        ## grid 3
-          {11:-- VISUAL LINE --}                            |
-        ]],
+          ## grid 1
+            [2:---------------------------------------------]|*7
+            [3:---------------------------------------------]|
+          ## grid 2
+            more virt_line below line 2                  |
+            {13:+--  2 lines: line 3·························}|
+            ^l{17:ine 5}                                       |
+            {1:~                                            }|*4
+          ## grid 3
+            {5:-- VISUAL LINE --}                            |
+          ]],
           win_viewport = {
             [2] = {
               win = 1000,
@@ -2144,10 +2106,10 @@ describe('folded lines', function()
       else
         screen:expect([[
           more virt_line below line 2                  |
-          {5:+--  2 lines: line 3·························}|
-          ^l{16:ine 5}                                       |
+          {13:+--  2 lines: line 3·························}|
+          ^l{17:ine 5}                                       |
           {1:~                                            }|*4
-          {11:-- VISUAL LINE --}                            |
+          {5:-- VISUAL LINE --}                            |
         ]])
       end
 
@@ -2155,16 +2117,16 @@ describe('folded lines', function()
       if multigrid then
         screen:expect {
           grid = [[
-        ## grid 1
-          [2:---------------------------------------------]|*7
-          [3:---------------------------------------------]|
-        ## grid 2
-          {5:+--  2 lines: line 3·························}|
-          {16:line }^5                                       |
-          {1:~                                            }|*5
-        ## grid 3
-          {11:-- VISUAL LINE --}                            |
-        ]],
+          ## grid 1
+            [2:---------------------------------------------]|*7
+            [3:---------------------------------------------]|
+          ## grid 2
+            {13:+--  2 lines: line 3·························}|
+            {17:line }^5                                       |
+            {1:~                                            }|*5
+          ## grid 3
+            {5:-- VISUAL LINE --}                            |
+          ]],
           win_viewport = {
             [2] = {
               win = 1000,
@@ -2179,10 +2141,10 @@ describe('folded lines', function()
         }
       else
         screen:expect([[
-          {5:+--  2 lines: line 3·························}|
-          {16:line }^5                                       |
+          {13:+--  2 lines: line 3·························}|
+          {17:line }^5                                       |
           {1:~                                            }|*5
-          {11:-- VISUAL LINE --}                            |
+          {5:-- VISUAL LINE --}                            |
         ]])
       end
 
@@ -2191,22 +2153,22 @@ describe('folded lines', function()
       if multigrid then
         screen:expect {
           grid = [[
-        ## grid 1
-          [2:---------------------------------------------]|*4
-          {3:[No Name] [+]                                }|
-          [4:---------------------------------------------]|
-          {2:[No Name] [+]                                }|
-          [3:---------------------------------------------]|
-        ## grid 2
-          ^line 1                                       |
-          line 2                                       |
-          virt_line below line 2                       |
-          more virt_line below line 2                  |
-        ## grid 3
-                                                       |
-        ## grid 4
-          line 1                                       |
-        ]],
+          ## grid 1
+            [2:---------------------------------------------]|*4
+            {3:[No Name] [+]                                }|
+            [4:---------------------------------------------]|
+            {2:[No Name] [+]                                }|
+            [3:---------------------------------------------]|
+          ## grid 2
+            ^line 1                                       |
+            line 2                                       |
+            virt_line below line 2                       |
+            more virt_line below line 2                  |
+          ## grid 3
+                                                         |
+          ## grid 4
+            line 1                                       |
+          ]],
           win_viewport = {
             [2] = {
               win = 1000,
@@ -2317,24 +2279,24 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {14:" foofoofoofoofo}ofoo                         |
-          {15:+--  3 lines: " }{5:口···························}|
-          {14:" barbarbarbarba}rbar                         |
-          {15:+--  3 lines: " }{5:口···························}|
-          {14:" bazbazbazbazb}^azbaz                         |
+          {30:" foofoofoofoofo}ofoo                         |
+          {103:+--  3 lines: " }{13:口···························}|
+          {30:" barbarbarbarba}rbar                         |
+          {103:+--  3 lines: " }{13:口···························}|
+          {30:" bazbazbazbazb}^azbaz                         |
           {1:~                                            }|*2
         ## grid 3
-          {11:-- VISUAL BLOCK --}                           |
+          {5:-- VISUAL BLOCK --}                           |
         ]])
       else
         screen:expect([[
-          {14:" foofoofoofoofo}ofoo                         |
-          {15:+--  3 lines: " }{5:口···························}|
-          {14:" barbarbarbarba}rbar                         |
-          {15:+--  3 lines: " }{5:口···························}|
-          {14:" bazbazbazbazb}^azbaz                         |
+          {30:" foofoofoofoofo}ofoo                         |
+          {103:+--  3 lines: " }{13:口···························}|
+          {30:" barbarbarbarba}rbar                         |
+          {103:+--  3 lines: " }{13:口···························}|
+          {30:" bazbazbazbazb}^azbaz                         |
           {1:~                                            }|*2
-          {11:-- VISUAL BLOCK --}                           |
+          {5:-- VISUAL BLOCK --}                           |
         ]])
       end
 
@@ -2345,24 +2307,24 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {14:" foofoofoofoofoo}foo                         |
-          {15:+--  3 lines: " 口}{5:···························}|
-          {14:" barbarbarbarbar}bar                         |
-          {15:+--  3 lines: " 口}{5:···························}|
-          {14:" bazbazbazbazba}^zbaz                         |
+          {30:" foofoofoofoofoo}foo                         |
+          {103:+--  3 lines: " 口}{13:···························}|
+          {30:" barbarbarbarbar}bar                         |
+          {103:+--  3 lines: " 口}{13:···························}|
+          {30:" bazbazbazbazba}^zbaz                         |
           {1:~                                            }|*2
         ## grid 3
-          {11:-- VISUAL BLOCK --}                           |
+          {5:-- VISUAL BLOCK --}                           |
         ]])
       else
         screen:expect([[
-          {14:" foofoofoofoofoo}foo                         |
-          {15:+--  3 lines: " 口}{5:···························}|
-          {14:" barbarbarbarbar}bar                         |
-          {15:+--  3 lines: " 口}{5:···························}|
-          {14:" bazbazbazbazba}^zbaz                         |
+          {30:" foofoofoofoofoo}foo                         |
+          {103:+--  3 lines: " 口}{13:···························}|
+          {30:" barbarbarbarbar}bar                         |
+          {103:+--  3 lines: " 口}{13:···························}|
+          {30:" bazbazbazbazba}^zbaz                         |
           {1:~                                            }|*2
-          {11:-- VISUAL BLOCK --}                           |
+          {5:-- VISUAL BLOCK --}                           |
         ]])
       end
 
@@ -2373,24 +2335,24 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {14:" foofoofoofoofoof}oo                         |
-          {15:+--  3 lines: " 口}{5:···························}|
-          {14:" barbarbarbarbarb}ar                         |
-          {15:+--  3 lines: " 口}{5:···························}|
-          {14:" bazbazbazbazbaz}^baz                         |
+          {30:" foofoofoofoofoof}oo                         |
+          {103:+--  3 lines: " 口}{13:···························}|
+          {30:" barbarbarbarbarb}ar                         |
+          {103:+--  3 lines: " 口}{13:···························}|
+          {30:" bazbazbazbazbaz}^baz                         |
           {1:~                                            }|*2
         ## grid 3
-          {11:-- VISUAL BLOCK --}                           |
+          {5:-- VISUAL BLOCK --}                           |
         ]])
       else
         screen:expect([[
-          {14:" foofoofoofoofoof}oo                         |
-          {15:+--  3 lines: " 口}{5:···························}|
-          {14:" barbarbarbarbarb}ar                         |
-          {15:+--  3 lines: " 口}{5:···························}|
-          {14:" bazbazbazbazbaz}^baz                         |
+          {30:" foofoofoofoofoof}oo                         |
+          {103:+--  3 lines: " 口}{13:···························}|
+          {30:" barbarbarbarbarb}ar                         |
+          {103:+--  3 lines: " 口}{13:···························}|
+          {30:" bazbazbazbazbaz}^baz                         |
           {1:~                                            }|*2
-          {11:-- VISUAL BLOCK --}                           |
+          {5:-- VISUAL BLOCK --}                           |
         ]])
       end
 
@@ -2401,24 +2363,24 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {14:" foofoofoofoofoofoo}                         |
-          {15:+--  3 lines: " 口··}{5:·························}|
-          {14:" barbarbarbarbarbar}                         |
-          {15:+--  3 lines: " 口··}{5:·························}|
-          {14:" bazbazbazbazbazba}^z                         |
+          {30:" foofoofoofoofoofoo}                         |
+          {103:+--  3 lines: " 口··}{13:·························}|
+          {30:" barbarbarbarbarbar}                         |
+          {103:+--  3 lines: " 口··}{13:·························}|
+          {30:" bazbazbazbazbazba}^z                         |
           {1:~                                            }|*2
         ## grid 3
-          {11:-- VISUAL BLOCK --}                           |
+          {5:-- VISUAL BLOCK --}                           |
         ]])
       else
         screen:expect([[
-          {14:" foofoofoofoofoofoo}                         |
-          {15:+--  3 lines: " 口··}{5:·························}|
-          {14:" barbarbarbarbarbar}                         |
-          {15:+--  3 lines: " 口··}{5:·························}|
-          {14:" bazbazbazbazbazba}^z                         |
+          {30:" foofoofoofoofoofoo}                         |
+          {103:+--  3 lines: " 口··}{13:·························}|
+          {30:" barbarbarbarbarbar}                         |
+          {103:+--  3 lines: " 口··}{13:·························}|
+          {30:" bazbazbazbazbazba}^z                         |
           {1:~                                            }|*2
-          {11:-- VISUAL BLOCK --}                           |
+          {5:-- VISUAL BLOCK --}                           |
         ]])
       end
 
@@ -2429,24 +2391,24 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          " foofoofoofoofo{14:ofoo}                         |
-          {5:+--  3 lines: " }{15:口··}{5:·························}|
-          " barbarbarbarba{14:rbar}                         |
-          {5:+--  3 lines: " }{15:口··}{5:·························}|
-          " bazbazbazbazba^z{14:baz}                         |
+          " foofoofoofoofo{30:ofoo}                         |
+          {13:+--  3 lines: " }{103:口··}{13:·························}|
+          " barbarbarbarba{30:rbar}                         |
+          {13:+--  3 lines: " }{103:口··}{13:·························}|
+          " bazbazbazbazba^z{30:baz}                         |
           {1:~                                            }|*2
         ## grid 3
-          {11:-- VISUAL BLOCK --}                           |
+          {5:-- VISUAL BLOCK --}                           |
         ]])
       else
         screen:expect([[
-          " foofoofoofoofo{14:ofoo}                         |
-          {5:+--  3 lines: " }{15:口··}{5:·························}|
-          " barbarbarbarba{14:rbar}                         |
-          {5:+--  3 lines: " }{15:口··}{5:·························}|
-          " bazbazbazbazba^z{14:baz}                         |
+          " foofoofoofoofo{30:ofoo}                         |
+          {13:+--  3 lines: " }{103:口··}{13:·························}|
+          " barbarbarbarba{30:rbar}                         |
+          {13:+--  3 lines: " }{103:口··}{13:·························}|
+          " bazbazbazbazba^z{30:baz}                         |
           {1:~                                            }|*2
-          {11:-- VISUAL BLOCK --}                           |
+          {5:-- VISUAL BLOCK --}                           |
         ]])
       end
 
@@ -2457,24 +2419,24 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          " foofoofoofoofoo{14:foo}                         |
-          {5:+--  3 lines: " }{15:口··}{5:·························}|
-          " barbarbarbarbar{14:bar}                         |
-          {5:+--  3 lines: " }{15:口··}{5:·························}|
-          " bazbazbazbazbaz^b{14:az}                         |
+          " foofoofoofoofoo{30:foo}                         |
+          {13:+--  3 lines: " }{103:口··}{13:·························}|
+          " barbarbarbarbar{30:bar}                         |
+          {13:+--  3 lines: " }{103:口··}{13:·························}|
+          " bazbazbazbazbaz^b{30:az}                         |
           {1:~                                            }|*2
         ## grid 3
-          {11:-- VISUAL BLOCK --}                           |
+          {5:-- VISUAL BLOCK --}                           |
         ]])
       else
         screen:expect([[
-          " foofoofoofoofoo{14:foo}                         |
-          {5:+--  3 lines: " }{15:口··}{5:·························}|
-          " barbarbarbarbar{14:bar}                         |
-          {5:+--  3 lines: " }{15:口··}{5:·························}|
-          " bazbazbazbazbaz^b{14:az}                         |
+          " foofoofoofoofoo{30:foo}                         |
+          {13:+--  3 lines: " }{103:口··}{13:·························}|
+          " barbarbarbarbar{30:bar}                         |
+          {13:+--  3 lines: " }{103:口··}{13:·························}|
+          " bazbazbazbazbaz^b{30:az}                         |
           {1:~                                            }|*2
-          {11:-- VISUAL BLOCK --}                           |
+          {5:-- VISUAL BLOCK --}                           |
         ]])
       end
     end)
@@ -2494,8 +2456,8 @@ describe('folded lines', function()
           [3:---------------------------------------------]|
         ## grid 2
           {2:line} 1                                       |
-          {5:+--  2 lines: line 2·························}|
-          {6:line} 4                                       |
+          {13:+--  2 lines: line 2·························}|
+          {10:line} 4                                       |
           {1:~                                            }|*4
         ## grid 3
           /line^                                        |
@@ -2503,8 +2465,8 @@ describe('folded lines', function()
       else
         screen:expect([[
           {2:line} 1                                       |
-          {5:+--  2 lines: line 2·························}|
-          {6:line} 4                                       |
+          {13:+--  2 lines: line 2·························}|
+          {10:line} 4                                       |
           {1:~                                            }|*4
           /line^                                        |
         ]])
@@ -2517,18 +2479,18 @@ describe('folded lines', function()
           [2:---------------------------------------------]|*7
           [3:---------------------------------------------]|
         ## grid 2
-          {6:line} 1                                       |
-          {5:+--  2 lines: line 2·························}|
-          {6:line} ^4                                       |
+          {10:line} 1                                       |
+          {13:+--  2 lines: line 2·························}|
+          {10:line} ^4                                       |
           {1:~                                            }|*4
         ## grid 3
                                                        |
         ]])
       else
         screen:expect([[
-          {6:line} 1                                       |
-          {5:+--  2 lines: line 2·························}|
-          {6:line} ^4                                       |
+          {10:line} 1                                       |
+          {13:+--  2 lines: line 2·························}|
+          {10:line} ^4                                       |
           {1:~                                            }|*4
                                                        |
         ]])
@@ -2563,7 +2525,7 @@ describe('folded lines', function()
           [3:------------------------------]|
         ## grid 2
           {7:    }This is a                 |
-          {7:+   }{4:^▶}{13:-}{17:      }{18:valid English}{13:·····}|
+          {7:+   }{9:^▶}{101:-}{20:      }{104:valid English}{101:·····}|
           {1:~                             }|*4
         ## grid 3
                                         |
@@ -2571,7 +2533,7 @@ describe('folded lines', function()
       else
         screen:expect([[
           {7:    }This is a                 |
-          {7:+   }{4:^▶}{13:-}{17:      }{18:valid English}{13:·····}|
+          {7:+   }{9:^▶}{101:-}{20:      }{104:valid English}{101:·····}|
           {1:~                             }|*4
                                         |
         ]])
@@ -2587,8 +2549,8 @@ describe('folded lines', function()
         ## grid 2
           {7:    }This is a                 |
           {7:-   }valid English             |
-          {7:│+  }{4:▶}{5:--}{19:     }{18:sentence composed }|
-          {7:│+  }{4:^▶}{13:--}{17:     }{18:in his cave.}{13:······}|
+          {7:│+  }{9:▶}{13:--}{105:     }{104:sentence composed }|
+          {7:│+  }{9:^▶}{101:--}{20:     }{104:in his cave.}{101:······}|
           {1:~                             }|*2
         ## grid 3
                                         |
@@ -2597,8 +2559,8 @@ describe('folded lines', function()
         screen:expect([[
           {7:    }This is a                 |
           {7:-   }valid English             |
-          {7:│+  }{4:▶}{5:--}{19:     }{18:sentence composed }|
-          {7:│+  }{4:^▶}{13:--}{17:     }{18:in his cave.}{13:······}|
+          {7:│+  }{9:▶}{13:--}{105:     }{104:sentence composed }|
+          {7:│+  }{9:^▶}{101:--}{20:     }{104:in his cave.}{101:······}|
           {1:~                             }|*2
                                         |
         ]])
@@ -2615,21 +2577,21 @@ describe('folded lines', function()
           [3:------------------------------]|
         ## grid 2
           {7:    }This is a                 |
-          {7:-   }^v{14:alid English}             |
-          {7:│+  }{4:▶}{15:--}{19:     }{20:sentence composed }|
-          {7:│+  }{4:▶}{15:--}{19:     }{20:in his cave.}{15:······}|
+          {7:-   }^v{30:alid English}             |
+          {7:│+  }{9:▶}{103:--}{105:     }{106:sentence composed }|
+          {7:│+  }{9:▶}{103:--}{105:     }{106:in his cave.}{103:······}|
           {1:~                             }|*2
         ## grid 3
-          {11:-- VISUAL LINE --}             |
+          {5:-- VISUAL LINE --}             |
         ]])
       else
         screen:expect([[
           {7:    }This is a                 |
-          {7:-   }^v{14:alid English}             |
-          {7:│+  }{4:▶}{15:--}{19:     }{20:sentence composed }|
-          {7:│+  }{4:▶}{15:--}{19:     }{20:in his cave.}{15:······}|
+          {7:-   }^v{30:alid English}             |
+          {7:│+  }{9:▶}{103:--}{105:     }{106:sentence composed }|
+          {7:│+  }{9:▶}{103:--}{105:     }{106:in his cave.}{103:······}|
           {1:~                             }|*2
-          {11:-- VISUAL LINE --}             |
+          {5:-- VISUAL LINE --}             |
         ]])
       end
 
@@ -2641,21 +2603,21 @@ describe('folded lines', function()
           [3:------------------------------]|
         ## grid 2
                            a si sihT{7:    }|
-                       {14:hsilgnE dila}^v{7:   -}|
-          {20: desopmoc ecnetnes}{19:     }{15:--}{4:▶}{7:  +│}|
-          {15:······}{20:.evac sih ni}{19:     }{15:--}{4:▶}{7:  +│}|
+                       {30:hsilgnE dila}^v{7:   -}|
+          {106: desopmoc ecnetnes}{105:     }{103:--}{9:▶}{7:  +│}|
+          {103:······}{106:.evac sih ni}{105:     }{103:--}{9:▶}{7:  +│}|
           {1:                             ~}|*2
         ## grid 3
-          {11:-- VISUAL LINE --}             |
+          {5:-- VISUAL LINE --}             |
         ]])
       else
         screen:expect([[
                            a si sihT{7:    }|
-                       {14:hsilgnE dila}^v{7:   -}|
-          {20: desopmoc ecnetnes}{19:     }{15:--}{4:▶}{7:  +│}|
-          {15:······}{20:.evac sih ni}{19:     }{15:--}{4:▶}{7:  +│}|
+                       {30:hsilgnE dila}^v{7:   -}|
+          {106: desopmoc ecnetnes}{105:     }{103:--}{9:▶}{7:  +│}|
+          {103:······}{106:.evac sih ni}{105:     }{103:--}{9:▶}{7:  +│}|
           {1:                             ~}|*2
-          {11:-- VISUAL LINE --}             |
+          {5:-- VISUAL LINE --}             |
         ]])
       end
     end)
@@ -2680,7 +2642,7 @@ describe('folded lines', function()
           [3:------------------------------]|
         ## grid 2
           {7:    }This is a                 |
-          {7:+   }{13:^valid English·············}|
+          {7:+   }{101:^valid English·············}|
           {1:~                             }|*4
         ## grid 3
                                         |
@@ -2688,7 +2650,7 @@ describe('folded lines', function()
       else
         screen:expect([[
           {7:    }This is a                 |
-          {7:+   }{13:^valid English·············}|
+          {7:+   }{101:^valid English·············}|
           {1:~                             }|*4
                                         |
         ]])
@@ -2703,8 +2665,8 @@ describe('folded lines', function()
         ## grid 2
           {7:    }This is a                 |
           {7:-   }valid English             |
-          {7:│+  }{21:sentence}{5: composed by······}|
-          {7:│+  }{13:^in his cave.··············}|
+          {7:│+  }{107:sentence}{13: composed by······}|
+          {7:│+  }{101:^in his cave.··············}|
           {1:~                             }|*2
         ## grid 3
                                         |
@@ -2713,8 +2675,8 @@ describe('folded lines', function()
         screen:expect([[
           {7:    }This is a                 |
           {7:-   }valid English             |
-          {7:│+  }{21:sentence}{5: composed by······}|
-          {7:│+  }{13:^in his cave.··············}|
+          {7:│+  }{107:sentence}{13: composed by······}|
+          {7:│+  }{101:^in his cave.··············}|
           {1:~                             }|*2
                                         |
         ]])
@@ -2729,21 +2691,21 @@ describe('folded lines', function()
           [3:------------------------------]|
         ## grid 2
           {7:    }This is a                 |
-          {7:-   }^v{14:alid English}             |
-          {7:│+  }{22:sentence}{15: composed by······}|
-          {7:│+  }{15:in his cave.··············}|
+          {7:-   }^v{30:alid English}             |
+          {7:│+  }{108:sentence}{103: composed by······}|
+          {7:│+  }{103:in his cave.··············}|
           {1:~                             }|*2
         ## grid 3
-          {11:-- VISUAL LINE --}             |
+          {5:-- VISUAL LINE --}             |
         ]])
       else
         screen:expect([[
           {7:    }This is a                 |
-          {7:-   }^v{14:alid English}             |
-          {7:│+  }{22:sentence}{15: composed by······}|
-          {7:│+  }{15:in his cave.··············}|
+          {7:-   }^v{30:alid English}             |
+          {7:│+  }{108:sentence}{103: composed by······}|
+          {7:│+  }{103:in his cave.··············}|
           {1:~                             }|*2
-          {11:-- VISUAL LINE --}             |
+          {5:-- VISUAL LINE --}             |
         ]])
       end
 
@@ -2755,21 +2717,21 @@ describe('folded lines', function()
           [3:------------------------------]|
         ## grid 2
                            a si sihT{7:    }|
-                       {14:hsilgnE dila}^v{7:   -}|
-          {15:······yb desopmoc }{22:ecnetnes}{7:  +│}|
-          {15:··············.evac sih ni}{7:  +│}|
+                       {30:hsilgnE dila}^v{7:   -}|
+          {103:······yb desopmoc }{108:ecnetnes}{7:  +│}|
+          {103:··············.evac sih ni}{7:  +│}|
           {1:                             ~}|*2
         ## grid 3
-          {11:-- VISUAL LINE --}             |
+          {5:-- VISUAL LINE --}             |
         ]])
       else
         screen:expect([[
                            a si sihT{7:    }|
-                       {14:hsilgnE dila}^v{7:   -}|
-          {15:······yb desopmoc }{22:ecnetnes}{7:  +│}|
-          {15:··············.evac sih ni}{7:  +│}|
+                       {30:hsilgnE dila}^v{7:   -}|
+          {103:······yb desopmoc }{108:ecnetnes}{7:  +│}|
+          {103:··············.evac sih ni}{7:  +│}|
           {1:                             ~}|*2
-          {11:-- VISUAL LINE --}             |
+          {5:-- VISUAL LINE --}             |
         ]])
       end
 
@@ -2783,9 +2745,9 @@ describe('folded lines', function()
           [3:------------------------------]|
         ## grid 2
           {7:    }his is a                  |
-          {7:-   }{12:^alid English              }|
-          {7:│+  }{21:entence}{5: composed by·······}|
-          {7:│+  }{5:n his cave.···············}|
+          {7:-   }{100:^alid English              }|
+          {7:│+  }{107:entence}{13: composed by·······}|
+          {7:│+  }{13:n his cave.···············}|
           {1:~                             }|*2
         ## grid 3
                                         |
@@ -2793,9 +2755,9 @@ describe('folded lines', function()
       else
         screen:expect([[
           {7:    }his is a                  |
-          {7:-   }{12:^alid English              }|
-          {7:│+  }{21:entence}{5: composed by·······}|
-          {7:│+  }{5:n his cave.···············}|
+          {7:-   }{100:^alid English              }|
+          {7:│+  }{107:entence}{13: composed by·······}|
+          {7:│+  }{13:n his cave.···············}|
           {1:~                             }|*2
                                         |
         ]])
@@ -2809,22 +2771,22 @@ describe('folded lines', function()
           [2:------------------------------]|*6
           [3:------------------------------]|
         ## grid 2
-          {7:    }{12:^!                         }|
+          {7:    }{100:^!                         }|
           {7:    }                          |
           {7:-   }                          |
-          {7:│+  }{5:sed by····················}|
-          {7:│+  }{5:··························}|
+          {7:│+  }{13:sed by····················}|
+          {7:│+  }{13:··························}|
           {1:~                             }|
         ## grid 3
                                         |
         ]])
       else
         screen:expect([[
-          {7:    }{12:^!                         }|
+          {7:    }{100:^!                         }|
           {7:    }                          |
           {7:-   }                          |
-          {7:│+  }{5:sed by····················}|
-          {7:│+  }{5:··························}|
+          {7:│+  }{13:sed by····················}|
+          {7:│+  }{13:··························}|
           {1:~                             }|
                                         |
         ]])
@@ -2838,28 +2800,26 @@ describe('folded lines', function()
 
       command("3,4fold | let v:hlsearch = 1 | let @/ = '.'")
       if multigrid then
-        screen:expect({
-          grid = [[
-          ## grid 1
-            [2:------------------------------]|*6
-            [3:------------------------------]|
-          ## grid 2
-            {6:This is a}                     |
-            {6:valid English}                 |
-            {19:sentence composed by}{5:··········}|
-            {6:in his cave.}                  |
-            ^                              |
-            {1:~                             }|
-          ## grid 3
-                                          |
-          ]],
-        })
+        screen:expect([[
+        ## grid 1
+          [2:------------------------------]|*6
+          [3:------------------------------]|
+        ## grid 2
+          {10:This is a}                     |
+          {10:valid English}                 |
+          {105:sentence composed by}{13:··········}|
+          {10:in his cave.}                  |
+          ^                              |
+          {1:~                             }|
+        ## grid 3
+                                        |
+        ]])
       else
         screen:expect([[
-          {6:This is a}                     |
-          {6:valid English}                 |
-          {19:sentence composed by}{5:··········}|
-          {6:in his cave.}                  |
+          {10:This is a}                     |
+          {10:valid English}                 |
+          {105:sentence composed by}{13:··········}|
+          {10:in his cave.}                  |
           ^                              |
           {1:~                             }|
                                         |
@@ -2868,29 +2828,27 @@ describe('folded lines', function()
 
       command("let @/ = '$'")
       if multigrid then
-        screen:expect({
-          grid = [[
-          ## grid 1
-            [2:------------------------------]|*6
-            [3:------------------------------]|
-          ## grid 2
-            This is a{6: }                    |
-            valid English{6: }                |
-            {5:sentence composed by}{19:·}{5:·········}|
-            in his cave.{6: }                 |
-            {6:^ }                             |
-            {1:~                             }|
-          ## grid 3
-                                          |
-          ]],
-        })
+        screen:expect([[
+        ## grid 1
+          [2:------------------------------]|*6
+          [3:------------------------------]|
+        ## grid 2
+          This is a{10: }                    |
+          valid English{10: }                |
+          {13:sentence composed by}{105:·}{13:·········}|
+          in his cave.{10: }                 |
+          {10:^ }                             |
+          {1:~                             }|
+        ## grid 3
+                                        |
+        ]])
       else
         screen:expect([[
-          This is a{6: }                    |
-          valid English{6: }                |
-          {5:sentence composed by}{19:·}{5:·········}|
-          in his cave.{6: }                 |
-          {6:^ }                             |
+          This is a{10: }                    |
+          valid English{10: }                |
+          {13:sentence composed by}{105:·}{13:·········}|
+          in his cave.{10: }                 |
+          {10:^ }                             |
           {1:~                             }|
                                         |
         ]])
@@ -2898,29 +2856,27 @@ describe('folded lines', function()
 
       command("let @/ = '.\\?'")
       if multigrid then
-        screen:expect({
-          grid = [[
-          ## grid 1
-            [2:------------------------------]|*6
-            [3:------------------------------]|
-          ## grid 2
-            {6:This is a }                    |
-            {6:valid English }                |
-            {19:sentence composed by·}{5:·········}|
-            {6:in his cave. }                 |
-            {6:^ }                             |
-            {1:~                             }|
-          ## grid 3
-                                          |
-          ]],
-        })
+        screen:expect([[
+        ## grid 1
+          [2:------------------------------]|*6
+          [3:------------------------------]|
+        ## grid 2
+          {10:This is a }                    |
+          {10:valid English }                |
+          {105:sentence composed by·}{13:·········}|
+          {10:in his cave. }                 |
+          {10:^ }                             |
+          {1:~                             }|
+        ## grid 3
+                                        |
+        ]])
       else
         screen:expect([[
-          {6:This is a }                    |
-          {6:valid English }                |
-          {19:sentence composed by·}{5:·········}|
-          {6:in his cave. }                 |
-          {6:^ }                             |
+          {10:This is a }                    |
+          {10:valid English }                |
+          {105:sentence composed by·}{13:·········}|
+          {10:in his cave. }                 |
+          {10:^ }                             |
           {1:~                             }|
                                         |
         ]])
@@ -2931,28 +2887,26 @@ describe('folded lines', function()
 
       command("set listchars+=eol:& | let @/ = '.'")
       if multigrid then
-        screen:expect({
-          grid = [[
-          ## grid 1
-            [2:------------------------------]|*6
-            [3:------------------------------]|
-          ## grid 2
-            {6:This is a}{1:&}                    |
-            {6:valid English}{1:&}                |
-            {19:sentence composed by}{18:&}{5:·········}|
-            {6:in his cave.}{1:&}                 |
-            {1:^&}                             |
-            {1:~                             }|
-          ## grid 3
-                                          |
-          ]],
-        })
+        screen:expect([[
+        ## grid 1
+          [2:------------------------------]|*6
+          [3:------------------------------]|
+        ## grid 2
+          {10:This is a}{1:&}                    |
+          {10:valid English}{1:&}                |
+          {105:sentence composed by}{104:&}{13:·········}|
+          {10:in his cave.}{1:&}                 |
+          {1:^&}                             |
+          {1:~                             }|
+        ## grid 3
+                                        |
+        ]])
       else
         screen:expect([[
-          {6:This is a}{1:&}                    |
-          {6:valid English}{1:&}                |
-          {19:sentence composed by}{18:&}{5:·········}|
-          {6:in his cave.}{1:&}                 |
+          {10:This is a}{1:&}                    |
+          {10:valid English}{1:&}                |
+          {105:sentence composed by}{104:&}{13:·········}|
+          {10:in his cave.}{1:&}                 |
           {1:^&}                             |
           {1:~                             }|
                                         |
@@ -2961,29 +2915,27 @@ describe('folded lines', function()
 
       command("let @/ = '$'")
       if multigrid then
-        screen:expect({
-          grid = [[
-          ## grid 1
-            [2:------------------------------]|*6
-            [3:------------------------------]|
-          ## grid 2
-            This is a{23:&}                    |
-            valid English{23:&}                |
-            {5:sentence composed by}{23:&}{5:·········}|
-            in his cave.{23:&}                 |
-            {23:^&}                             |
-            {1:~                             }|
-          ## grid 3
-                                          |
-          ]],
-        })
+        screen:expect([[
+        ## grid 1
+          [2:------------------------------]|*6
+          [3:------------------------------]|
+        ## grid 2
+          This is a{109:&}                    |
+          valid English{109:&}                |
+          {13:sentence composed by}{109:&}{13:·········}|
+          in his cave.{109:&}                 |
+          {109:^&}                             |
+          {1:~                             }|
+        ## grid 3
+                                        |
+        ]])
       else
         screen:expect([[
-          This is a{23:&}                    |
-          valid English{23:&}                |
-          {5:sentence composed by}{23:&}{5:·········}|
-          in his cave.{23:&}                 |
-          {23:^&}                             |
+          This is a{109:&}                    |
+          valid English{109:&}                |
+          {13:sentence composed by}{109:&}{13:·········}|
+          in his cave.{109:&}                 |
+          {109:^&}                             |
           {1:~                             }|
                                         |
         ]])
@@ -2991,29 +2943,27 @@ describe('folded lines', function()
 
       command("let @/ = '.\\?'")
       if multigrid then
-        screen:expect({
-          grid = [[
-          ## grid 1
-            [2:------------------------------]|*6
-            [3:------------------------------]|
-          ## grid 2
-            {6:This is a}{23:&}                    |
-            {6:valid English}{23:&}                |
-            {19:sentence composed by}{23:&}{5:·········}|
-            {6:in his cave.}{23:&}                 |
-            {23:^&}                             |
-            {1:~                             }|
-          ## grid 3
-                                          |
-          ]],
-        })
+        screen:expect([[
+        ## grid 1
+          [2:------------------------------]|*6
+          [3:------------------------------]|
+        ## grid 2
+          {10:This is a}{109:&}                    |
+          {10:valid English}{109:&}                |
+          {105:sentence composed by}{109:&}{13:·········}|
+          {10:in his cave.}{109:&}                 |
+          {109:^&}                             |
+          {1:~                             }|
+        ## grid 3
+                                        |
+        ]])
       else
         screen:expect([[
-          {6:This is a}{23:&}                    |
-          {6:valid English}{23:&}                |
-          {19:sentence composed by}{23:&}{5:·········}|
-          {6:in his cave.}{23:&}                 |
-          {23:^&}                             |
+          {10:This is a}{109:&}                    |
+          {10:valid English}{109:&}                |
+          {105:sentence composed by}{109:&}{13:·········}|
+          {10:in his cave.}{109:&}                 |
+          {109:^&}                             |
           {1:~                             }|
                                         |
         ]])

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -42,54 +42,40 @@ describe('ui/ext_popupmenu', function()
       foo^                                                         |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-    ]],
-      popupmenu = {
-        items = expected,
-        pos = 0,
-        anchor = { 1, 1, 0 },
-      },
+      ]],
+      popupmenu = { items = expected, pos = 0, anchor = { 1, 1, 0 } },
     }
 
     feed('<c-p>')
     screen:expect {
       grid = [[
-                                                                  |
-      ^                                                            |
-      {1:~                                                           }|*5
-      {5:-- INSERT --}                                                |
-    ]],
-      popupmenu = {
-        items = expected,
-        pos = -1,
-        anchor = { 1, 1, 0 },
-      },
+                                                                    |
+        ^                                                            |
+        {1:~                                                           }|*5
+        {5:-- INSERT --}                                                |
+      ]],
+      popupmenu = { items = expected, pos = -1, anchor = { 1, 1, 0 } },
     }
 
     -- down moves the selection in the menu, but does not insert anything
     feed('<down><down>')
     screen:expect {
       grid = [[
-                                                                  |
-      ^                                                            |
-      {1:~                                                           }|*5
-      {5:-- INSERT --}                                                |
-    ]],
-      popupmenu = {
-        items = expected,
-        pos = 1,
-        anchor = { 1, 1, 0 },
-      },
+                                                                    |
+        ^                                                            |
+        {1:~                                                           }|*5
+        {5:-- INSERT --}                                                |
+      ]],
+      popupmenu = { items = expected, pos = 1, anchor = { 1, 1, 0 } },
     }
 
     feed('<cr>')
-    screen:expect {
-      grid = [[
+    screen:expect([[
                                                                   |
       bar^                                                         |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-    ]],
-    }
+    ]])
   end)
 
   it('can be controlled by API', function()
@@ -100,12 +86,8 @@ describe('ui/ext_popupmenu', function()
       foo^                                                         |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-    ]],
-      popupmenu = {
-        items = expected,
-        pos = 0,
-        anchor = { 1, 1, 0 },
-      },
+      ]],
+      popupmenu = { items = expected, pos = 0, anchor = { 1, 1, 0 } },
     }
 
     api.nvim_select_popupmenu_item(1, false, false, {})
@@ -115,12 +97,8 @@ describe('ui/ext_popupmenu', function()
       foo^                                                         |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-    ]],
-      popupmenu = {
-        items = expected,
-        pos = 1,
-        anchor = { 1, 1, 0 },
-      },
+      ]],
+      popupmenu = { items = expected, pos = 1, anchor = { 1, 1, 0 } },
     }
 
     api.nvim_select_popupmenu_item(2, true, false, {})
@@ -130,12 +108,8 @@ describe('ui/ext_popupmenu', function()
       spam^                                                        |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-    ]],
-      popupmenu = {
-        items = expected,
-        pos = 2,
-        anchor = { 1, 1, 0 },
-      },
+      ]],
+      popupmenu = { items = expected, pos = 2, anchor = { 1, 1, 0 } },
     }
 
     api.nvim_select_popupmenu_item(0, true, true, {})
@@ -153,12 +127,8 @@ describe('ui/ext_popupmenu', function()
       foo^                                                         |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-    ]],
-      popupmenu = {
-        items = expected,
-        pos = 0,
-        anchor = { 1, 1, 0 },
-      },
+      ]],
+      popupmenu = { items = expected, pos = 0, anchor = { 1, 1, 0 } },
     }
 
     api.nvim_select_popupmenu_item(-1, false, false, {})
@@ -168,12 +138,8 @@ describe('ui/ext_popupmenu', function()
       foo^                                                         |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-    ]],
-      popupmenu = {
-        items = expected,
-        pos = -1,
-        anchor = { 1, 1, 0 },
-      },
+      ]],
+      popupmenu = { items = expected, pos = -1, anchor = { 1, 1, 0 } },
     }
 
     api.nvim_select_popupmenu_item(1, true, false, {})
@@ -183,12 +149,8 @@ describe('ui/ext_popupmenu', function()
       bar^                                                         |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-    ]],
-      popupmenu = {
-        items = expected,
-        pos = 1,
-        anchor = { 1, 1, 0 },
-      },
+      ]],
+      popupmenu = { items = expected, pos = 1, anchor = { 1, 1, 0 } },
     }
 
     api.nvim_select_popupmenu_item(-1, true, false, {})
@@ -198,12 +160,8 @@ describe('ui/ext_popupmenu', function()
       ^                                                            |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-    ]],
-      popupmenu = {
-        items = expected,
-        pos = -1,
-        anchor = { 1, 1, 0 },
-      },
+      ]],
+      popupmenu = { items = expected, pos = -1, anchor = { 1, 1, 0 } },
     }
 
     api.nvim_select_popupmenu_item(0, true, false, {})
@@ -213,12 +171,8 @@ describe('ui/ext_popupmenu', function()
       foo^                                                         |
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
-    ]],
-      popupmenu = {
-        items = expected,
-        pos = 0,
-        anchor = { 1, 1, 0 },
-      },
+      ]],
+      popupmenu = { items = expected, pos = 0, anchor = { 1, 1, 0 } },
     }
 
     api.nvim_select_popupmenu_item(-1, true, true, {})
@@ -246,11 +200,7 @@ describe('ui/ext_popupmenu', function()
       {1:~                                                           }|*5
       :sign define^                                                |
     ]],
-      popupmenu = {
-        items = expected_wildpum,
-        pos = 0,
-        anchor = { 1, 7, 6 },
-      },
+      popupmenu = { items = expected_wildpum, pos = 0, anchor = { 1, 7, 6 } },
     })
 
     api.nvim_select_popupmenu_item(-1, true, false, {})
@@ -260,11 +210,7 @@ describe('ui/ext_popupmenu', function()
       {1:~                                                           }|*5
       :sign ^                                                      |
     ]],
-      popupmenu = {
-        items = expected_wildpum,
-        pos = -1,
-        anchor = { 1, 7, 6 },
-      },
+      popupmenu = { items = expected_wildpum, pos = -1, anchor = { 1, 7, 6 } },
     })
 
     api.nvim_select_popupmenu_item(5, true, false, {})
@@ -274,11 +220,7 @@ describe('ui/ext_popupmenu', function()
       {1:~                                                           }|*5
       :sign unplace^                                               |
     ]],
-      popupmenu = {
-        items = expected_wildpum,
-        pos = 5,
-        anchor = { 1, 7, 6 },
-      },
+      popupmenu = { items = expected_wildpum, pos = 5, anchor = { 1, 7, 6 } },
     })
 
     api.nvim_select_popupmenu_item(-1, true, true, {})
@@ -297,21 +239,15 @@ describe('ui/ext_popupmenu', function()
       {1:~                                                           }|*5
       :sign define^                                                |
     ]],
-      popupmenu = {
-        items = expected_wildpum,
-        pos = 0,
-        anchor = { 1, 7, 6 },
-      },
+      popupmenu = { items = expected_wildpum, pos = 0, anchor = { 1, 7, 6 } },
     })
 
     api.nvim_select_popupmenu_item(5, true, true, {})
-    screen:expect({
-      grid = [[
+    screen:expect([[
                                                                   |*2
       {1:~                                                           }|*5
       :sign unplace^                                               |
-    ]],
-    })
+    ]])
 
     local function test_pum_select_mappings()
       screen:set_option('ext_popupmenu', true)
@@ -323,11 +259,7 @@ describe('ui/ext_popupmenu', function()
         {1:~                                                           }|*5
         {5:-- INSERT --}                                                |
       ]],
-        popupmenu = {
-          items = expected,
-          pos = 0,
-          anchor = { 1, 1, 0 },
-        },
+        popupmenu = { items = expected, pos = 0, anchor = { 1, 1, 0 } },
       }
 
       feed('<f1>')
@@ -338,11 +270,7 @@ describe('ui/ext_popupmenu', function()
         {1:~                                                           }|*5
         {5:-- INSERT --}                                                |
       ]],
-        popupmenu = {
-          items = expected,
-          pos = 2,
-          anchor = { 1, 1, 0 },
-        },
+        popupmenu = { items = expected, pos = 2, anchor = { 1, 1, 0 } },
       }
 
       feed('<f2>')
@@ -353,11 +281,7 @@ describe('ui/ext_popupmenu', function()
         {1:~                                                           }|*5
         {5:-- INSERT --}                                                |
       ]],
-        popupmenu = {
-          items = expected,
-          pos = -1,
-          anchor = { 1, 1, 0 },
-        },
+        popupmenu = { items = expected, pos = -1, anchor = { 1, 1, 0 } },
       }
 
       feed('<f3>')
@@ -376,11 +300,7 @@ describe('ui/ext_popupmenu', function()
         {1:~                                                           }|*5
         :sign define^                                                |
       ]],
-        popupmenu = {
-          items = expected_wildpum,
-          pos = 0,
-          anchor = { 1, 7, 6 },
-        },
+        popupmenu = { items = expected_wildpum, pos = 0, anchor = { 1, 7, 6 } },
       })
 
       feed('<f1>')
@@ -391,11 +311,7 @@ describe('ui/ext_popupmenu', function()
         {1:~                                                           }|*5
         :sign list^                                                  |
       ]],
-        popupmenu = {
-          items = expected_wildpum,
-          pos = 2,
-          anchor = { 1, 7, 6 },
-        },
+        popupmenu = { items = expected_wildpum, pos = 2, anchor = { 1, 7, 6 } },
       })
 
       feed('<f2>')
@@ -406,11 +322,7 @@ describe('ui/ext_popupmenu', function()
         {1:~                                                           }|*5
         :sign ^                                                      |
       ]],
-        popupmenu = {
-          items = expected_wildpum,
-          pos = -1,
-          anchor = { 1, 7, 6 },
-        },
+        popupmenu = { items = expected_wildpum, pos = -1, anchor = { 1, 7, 6 } },
       })
 
       feed('<f3>')
@@ -610,11 +522,7 @@ describe('ui/ext_popupmenu', function()
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
       ]],
-        popupmenu = {
-          items = month_expected,
-          pos = pum_height - 2,
-          anchor = { 1, 1, 0 },
-        },
+        popupmenu = { items = month_expected, pos = pum_height - 2, anchor = { 1, 1, 0 } },
       }
     end)
 
@@ -662,11 +570,7 @@ describe('ui/ext_popupmenu', function()
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
       ]],
-        popupmenu = {
-          items = month_expected,
-          pos = pum_height - 2,
-          anchor = { 1, 1, 0 },
-        },
+        popupmenu = { items = month_expected, pos = pum_height - 2, anchor = { 1, 1, 0 } },
       }
     end)
 
@@ -717,11 +621,7 @@ describe('ui/ext_popupmenu', function()
     {1:~                                                           }|*5
     {5:-- INSERT --}                                                |
     ]],
-      popupmenu = {
-        items = month_expected,
-        pos = 3,
-        anchor = { 1, 1, 0 },
-      },
+      popupmenu = { items = month_expected, pos = 3, anchor = { 1, 1, 0 } },
     }
     feed('<PageUp>')
     screen:expect {
@@ -731,11 +631,7 @@ describe('ui/ext_popupmenu', function()
     {1:~                                                           }|*5
     {5:-- INSERT --}                                                |
     ]],
-      popupmenu = {
-        items = month_expected,
-        pos = 0,
-        anchor = { 1, 1, 0 },
-      },
+      popupmenu = { items = month_expected, pos = 0, anchor = { 1, 1, 0 } },
     }
   end)
 
@@ -854,11 +750,7 @@ describe('ui/ext_popupmenu', function()
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
     ]],
-      popupmenu = {
-        items = expected,
-        pos = 0,
-        anchor = { 1, 1, 0 },
-      },
+      popupmenu = { items = expected, pos = 0, anchor = { 1, 1, 0 } },
     }
 
     feed('<c-p>')
@@ -869,22 +761,16 @@ describe('ui/ext_popupmenu', function()
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
     ]],
-      popupmenu = {
-        items = expected,
-        pos = -1,
-        anchor = { 1, 1, 0 },
-      },
+      popupmenu = { items = expected, pos = -1, anchor = { 1, 1, 0 } },
     }
 
     feed('<esc>')
-    screen:expect {
-      grid = [[
+    screen:expect([[
                                                                   |
       ^                                                            |
       {1:~                                                           }|*5
                                                                   |
-    ]],
-    }
+    ]])
     feed('<RightMouse><0,0>')
     screen:expect([[
                                                                   |
@@ -905,57 +791,58 @@ describe('ui/ext_popupmenu', function()
 end)
 
 describe("builtin popupmenu 'pumblend'", function()
-  before_each(clear)
+  local screen
+  before_each(function()
+    clear()
+    screen = Screen.new(60, 14)
+    screen:add_extra_attr_ids({
+      [100] = { background = Screen.colors.Gray55, foreground = Screen.colors.Grey45 },
+      [101] = { background = Screen.colors.Gray55, foreground = Screen.colors.Grey0 },
+      [102] = { background = tonumber('0x191919'), foreground = Screen.colors.Grey0 },
+      [103] = { background = tonumber('0xffc1ff'), foreground = tonumber('0xe5a8e5') },
+      [104] = { background = tonumber('0xffc1ff'), foreground = Screen.colors.Grey0 },
+      [105] = { foreground = tonumber('0xffc1ff'), background = tonumber('0xe5a8e5'), bold = true },
+      [106] = { foreground = Screen.colors.Grey55, background = Screen.colors.Gray45, bold = true },
+      [107] = { background = tonumber('0xffc1e5'), foreground = Screen.colors.Grey0 },
+      [108] = { background = tonumber('0xffc1e5'), foreground = tonumber('0xe5a8e5') },
+      [109] = { background = tonumber('0xffc1ff'), foreground = tonumber('0x080202') },
+      [110] = { background = tonumber('0xffc1ff'), bold = true, foreground = tonumber('0xf6ace9') },
+      [111] = { background = tonumber('0xffc1ff'), foreground = tonumber('0xe5a8ff') },
+      [112] = { background = tonumber('0xe5a8e5'), foreground = tonumber('0xffc1ff') },
+      [113] = { background = Screen.colors.Gray45, foreground = Screen.colors.Grey55 },
+      [114] = { background = Screen.colors.WebGray },
+      [115] = { background = Screen.colors.Grey0 },
+      [116] = { background = Screen.colors.Gray75, foreground = Screen.colors.Grey25 },
+      [117] = { background = Screen.colors.Gray75, foreground = Screen.colors.Grey0 },
+      [118] = { background = Screen.colors.Gray50, foreground = Screen.colors.Grey0 },
+      [119] = { background = tonumber('0xffddff'), foreground = tonumber('0x7f5d7f') },
+      [120] = { background = tonumber('0xffddff'), foreground = Screen.colors.Grey0 },
+      [121] = { foreground = tonumber('0xffddff'), background = tonumber('0x7f5d7f'), bold = true },
+      [123] = { foreground = tonumber('0xffddff'), background = Screen.colors.Grey0, bold = true },
+      [124] = { foreground = Screen.colors.Gray75, background = Screen.colors.Grey25, bold = true },
+      [125] = { background = tonumber('0xffdd7f'), foreground = Screen.colors.Grey0 },
+      [126] = { background = tonumber('0xffdd7f'), foreground = tonumber('0x7f5d7f') },
+      [127] = { background = tonumber('0xffddff'), bold = true, foreground = tonumber('0x290a0a') },
+      [128] = { background = tonumber('0xffddff'), bold = true, foreground = tonumber('0xd27294') },
+      [129] = { background = tonumber('0xffddff'), foreground = tonumber('0x7f5dff') },
+      [130] = { background = tonumber('0x7f5d7f'), foreground = tonumber('0xffddff') },
+      [131] = { background = Screen.colors.Grey0, foreground = tonumber('0xffddff') },
+      [132] = { background = Screen.colors.Gray25, foreground = Screen.colors.Grey75 },
+      [134] = { background = tonumber('0xffddff'), foreground = tonumber('0x00003f') },
+      [135] = { foreground = tonumber('0x0c0c0c'), background = tonumber('0xe5a8e5') },
+      [136] = { background = tonumber('0x7f5d7f'), bold = true, foreground = tonumber('0x3f3f3f') },
+      [137] = { foreground = tonumber('0x3f3f3f'), background = tonumber('0x7f5d7f') },
+      [138] = { background = Screen.colors.WebGray, blend = 0 },
+      [139] = { background = 7, foreground = Screen.colors.Gray0 },
+      [140] = { background = 7, foreground = 85 },
+      [141] = { background = 225, foreground = Screen.colors.Gray0 },
+      [142] = { background = 225, foreground = 209 },
+      [143] = { foreground = 12 },
+      [144] = { foreground = 2 },
+    })
+  end)
 
   it('RGB-color', function()
-    local screen = Screen.new(60, 14)
-    screen:set_default_attr_ids({
-      [1] = { background = Screen.colors.Yellow },
-      [2] = { bold = true, reverse = true },
-      [3] = { bold = true, foreground = Screen.colors.Brown },
-      [4] = { foreground = Screen.colors.Blue1 },
-      [5] = { reverse = true },
-      [6] = { background = Screen.colors.Gray55, foreground = Screen.colors.Grey45 },
-      [7] = { background = Screen.colors.Gray55, foreground = Screen.colors.Grey0 },
-      [8] = { background = tonumber('0x191919'), foreground = Screen.colors.Grey0 },
-      [9] = { background = tonumber('0xffc1ff'), foreground = tonumber('0xe5a8e5') },
-      [10] = { background = tonumber('0xffc1ff'), foreground = Screen.colors.Grey0 },
-      [11] = { foreground = tonumber('0xffc1ff'), background = tonumber('0xe5a8e5'), bold = true },
-      [12] = { foreground = Screen.colors.Grey55, background = Screen.colors.Gray45, bold = true },
-      [13] = { background = tonumber('0xffc1e5'), foreground = Screen.colors.Grey0 },
-      [14] = { background = tonumber('0xffc1e5'), foreground = tonumber('0xe5a8e5') },
-      [15] = { background = tonumber('0xffc1ff'), foreground = tonumber('0x080202') },
-      [16] = { background = tonumber('0xffc1ff'), bold = true, foreground = tonumber('0xf6ace9') },
-      [17] = { background = tonumber('0xffc1ff'), foreground = tonumber('0xe5a8ff') },
-      [18] = { background = tonumber('0xe5a8e5'), foreground = tonumber('0xffc1ff') },
-      [19] = { background = Screen.colors.Gray45, foreground = Screen.colors.Grey55 },
-      [20] = { bold = true },
-      [21] = { bold = true, foreground = Screen.colors.SeaGreen4 },
-      [22] = { background = Screen.colors.WebGray },
-      [23] = { background = Screen.colors.Grey0 },
-      [24] = { background = Screen.colors.LightMagenta },
-      [25] = { background = Screen.colors.Gray75, foreground = Screen.colors.Grey25 },
-      [26] = { background = Screen.colors.Gray75, foreground = Screen.colors.Grey0 },
-      [27] = { background = Screen.colors.Gray50, foreground = Screen.colors.Grey0 },
-      [28] = { background = tonumber('0xffddff'), foreground = tonumber('0x7f5d7f') },
-      [29] = { background = tonumber('0xffddff'), foreground = Screen.colors.Grey0 },
-      [30] = { foreground = tonumber('0xffddff'), background = tonumber('0x7f5d7f'), bold = true },
-      [31] = { foreground = tonumber('0xffddff'), background = Screen.colors.Grey0, bold = true },
-      [32] = { foreground = Screen.colors.Gray75, background = Screen.colors.Grey25, bold = true },
-      [33] = { background = tonumber('0xffdd7f'), foreground = Screen.colors.Grey0 },
-      [34] = { background = tonumber('0xffdd7f'), foreground = tonumber('0x7f5d7f') },
-      [35] = { background = tonumber('0xffddff'), bold = true, foreground = tonumber('0x290a0a') },
-      [36] = { background = tonumber('0xffddff'), bold = true, foreground = tonumber('0xd27294') },
-      [37] = { background = tonumber('0xffddff'), foreground = tonumber('0x7f5dff') },
-      [38] = { background = tonumber('0x7f5d7f'), foreground = tonumber('0xffddff') },
-      [39] = { background = Screen.colors.Grey0, foreground = tonumber('0xffddff') },
-      [40] = { background = Screen.colors.Gray25, foreground = Screen.colors.Grey75 },
-      [41] = { background = tonumber('0xffddff'), foreground = tonumber('0x00003f') },
-      [42] = { foreground = tonumber('0x0c0c0c'), background = tonumber('0xe5a8e5') },
-      [43] = { background = tonumber('0x7f5d7f'), bold = true, foreground = tonumber('0x3f3f3f') },
-      [44] = { foreground = tonumber('0x3f3f3f'), background = tonumber('0x7f5d7f') },
-      [45] = { background = Screen.colors.WebGray, blend = 0 },
-    })
     command('syntax on')
     command('set mouse=a')
     command('set pumblend=10')
@@ -977,147 +864,135 @@ describe("builtin popupmenu 'pumblend'", function()
     command('split')
     command('/ol')
     screen:expect([[
-      Lorem ipsum d{1:ol}or sit amet, consectetur                     |
+      Lorem ipsum d{10:ol}or sit amet, consectetur                     |
       adipisicing elit, sed do eiusmod tempor                     |
-      ^incididunt ut labore et d{1:ol}ore magna aliqua.                |
+      ^incididunt ut labore et d{10:ol}ore magna aliqua.                |
       Ut enim ad minim veniam, quis nostrud                       |
       exercitation ullamco laboris nisi ut aliquip ex             |
-      ea commodo consequat. Duis aute irure d{1:ol}or in              |
-      {2:[No Name] [+]                                               }|
-      Lorem ipsum d{1:ol}or sit amet, consectetur                     |
-      adipisicing {3:el}it, sed do eiusmod tempor                     |
-      incididunt {4:ut} labore et d{1:ol}ore magna aliqua.                |
+      ea commodo consequat. Duis aute irure d{10:ol}or in              |
+      {3:[No Name] [+]                                               }|
+      Lorem ipsum d{10:ol}or sit amet, consectetur                     |
+      adipisicing {15:el}it, sed do eiusmod tempor                     |
+      incididunt {18:ut} labore et d{10:ol}ore magna aliqua.                |
       Ut enim ad minim veniam, quis nostrud                       |
-      exercitation ullamco laboris nisi {4:ut} aliquip ex             |
-      {5:[No Name] [+]                                               }|
+      exercitation ullamco laboris nisi {18:ut} aliquip ex             |
+      {2:[No Name] [+]                                               }|
                                                                   |
     ]])
 
     feed('Obla bla <c-x><c-n>')
     screen:expect([[
-      Lorem ipsum d{1:ol}or sit amet, consectetur                     |
+      Lorem ipsum d{10:ol}or sit amet, consectetur                     |
       adipisicing elit, sed do eiusmod tempor                     |
       bla bla incididunt^                                          |
-      incidid{6:u}{7:incididunt}{6:re et}{8: }d{1:ol}ore magna aliqua.                |
-      Ut enim{9: }{10:ut}{9: minim veniam}{6:,} quis nostrud                       |
-      exercit{9:a}{10:labore}{9:llamco la}{6:b}oris nisi ut aliquip ex             |
-      {2:[No Nam}{11:e}{42:et}{11:[+]          }{12: }{2:                                    }|
-      Lorem i{9:p}{10:dolor}{13:e}{14:l}{9:or sit a}{6:m}et, consectetur                     |
-      adipisi{9:c}{10:magn}{15:a}{16:l}{9:it, sed d}{6:o} eiusmod tempor                     |
-      bla bla{9: }{10:aliqua}{9:dunt     }{6: }                                    |
-      incidid{9:u}{10:Ut}{9: }{17:ut}{9: labore et}{6: }d{1:ol}ore magna aliqua.                |
-      Ut enim{9: }{10:enim}{9:inim veniam}{6:,} quis nostrud                       |
-      {5:[No Nam}{18:e}{42:ad}{18:[+]          }{19: }{5:                                    }|
-      {20:-- Keyword Local completion (^N^P) }{21:match 1 of 65}            |
+      incidid{100:u}{101:incididunt}{100:re et}{102: }d{10:ol}ore magna aliqua.                |
+      Ut enim{103: }{104:ut}{103: minim veniam}{100:,} quis nostrud                       |
+      exercit{103:a}{104:labore}{103:llamco la}{100:b}oris nisi ut aliquip ex             |
+      {3:[No Nam}{105:e}{135:et}{105:[+]          }{106: }{3:                                    }|
+      Lorem i{103:p}{104:dolor}{107:e}{108:l}{103:or sit a}{100:m}et, consectetur                     |
+      adipisi{103:c}{104:magn}{109:a}{110:l}{103:it, sed d}{100:o} eiusmod tempor                     |
+      bla bla{103: }{104:aliqua}{103:dunt     }{100: }                                    |
+      incidid{103:u}{104:Ut}{103: }{111:ut}{103: labore et}{100: }d{10:ol}ore magna aliqua.                |
+      Ut enim{103: }{104:enim}{103:inim veniam}{100:,} quis nostrud                       |
+      {2:[No Nam}{112:e}{135:ad}{112:[+]          }{113: }{2:                                    }|
+      {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
     ]])
 
     command('set pumblend=0')
     screen:expect([[
-      Lorem ipsum d{1:ol}or sit amet, consectetur                     |
+      Lorem ipsum d{10:ol}or sit amet, consectetur                     |
       adipisicing elit, sed do eiusmod tempor                     |
       bla bla incididunt^                                          |
-      incidid{22: incididunt     }{23: }d{1:ol}ore magna aliqua.                |
-      Ut enim{24: ut             }{22: } quis nostrud                       |
-      exercit{24: labore         }{22: }oris nisi ut aliquip ex             |
-      {2:[No Nam}{24: et             }{22: }{2:                                    }|
-      Lorem i{24: dolore         }{22: }et, consectetur                     |
-      adipisi{24: magna          }{22: } eiusmod tempor                     |
-      bla bla{24: aliqua         }{22: }                                    |
-      incidid{24: Ut             }{22: }d{1:ol}ore magna aliqua.                |
-      Ut enim{24: enim           }{22: } quis nostrud                       |
-      {5:[No Nam}{24: ad             }{22: }{5:                                    }|
-      {20:-- Keyword Local completion (^N^P) }{21:match 1 of 65}            |
+      incidid{114: incididunt     }{115: }d{10:ol}ore magna aliqua.                |
+      Ut enim{4: ut             }{114: } quis nostrud                       |
+      exercit{4: labore         }{114: }oris nisi ut aliquip ex             |
+      {3:[No Nam}{4: et             }{114: }{3:                                    }|
+      Lorem i{4: dolore         }{114: }et, consectetur                     |
+      adipisi{4: magna          }{114: } eiusmod tempor                     |
+      bla bla{4: aliqua         }{114: }                                    |
+      incidid{4: Ut             }{114: }d{10:ol}ore magna aliqua.                |
+      Ut enim{4: enim           }{114: } quis nostrud                       |
+      {2:[No Nam}{4: ad             }{114: }{2:                                    }|
+      {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
     ]])
 
     command('set pumblend=50')
     screen:expect([[
-      Lorem ipsum d{1:ol}or sit amet, consectetur                     |
+      Lorem ipsum d{10:ol}or sit amet, consectetur                     |
       adipisicing elit, sed do eiusmod tempor                     |
       bla bla incididunt^                                          |
-      incidid{25:u}{26:incididunt}{25:re et}{27: }d{1:ol}ore magna aliqua.                |
-      Ut enim{28: }{29:ut}{28: minim veniam}{25:,} quis nostrud                       |
-      exercit{28:a}{29:labore}{28:llamco la}{25:b}oris nisi ut aliquip ex             |
-      {2:[No Nam}{30:e}{43:et}{30:[+]          }{32: }{2:                                    }|
-      Lorem i{28:p}{29:dolor}{33:e}{34:l}{28:or sit a}{25:m}et, consectetur                     |
-      adipisi{28:c}{29:magn}{35:a}{36:l}{28:it, sed d}{25:o} eiusmod tempor                     |
-      bla bla{28: }{29:aliqua}{28:dunt     }{25: }                                    |
-      incidid{28:u}{29:Ut}{28: }{37:ut}{28: labore et}{25: }d{1:ol}ore magna aliqua.                |
-      Ut enim{28: }{29:enim}{28:inim veniam}{25:,} quis nostrud                       |
-      {5:[No Nam}{38:e}{44:ad}{38:[+]          }{40: }{5:                                    }|
-      {20:-- Keyword Local completion (^N^P) }{21:match 1 of 65}            |
+      incidid{116:u}{117:incididunt}{116:re et}{118: }d{10:ol}ore magna aliqua.                |
+      Ut enim{119: }{120:ut}{119: minim veniam}{116:,} quis nostrud                       |
+      exercit{119:a}{120:labore}{119:llamco la}{116:b}oris nisi ut aliquip ex             |
+      {3:[No Nam}{121:e}{136:et}{121:[+]          }{124: }{3:                                    }|
+      Lorem i{119:p}{120:dolor}{125:e}{126:l}{119:or sit a}{116:m}et, consectetur                     |
+      adipisi{119:c}{120:magn}{127:a}{128:l}{119:it, sed d}{116:o} eiusmod tempor                     |
+      bla bla{119: }{120:aliqua}{119:dunt     }{116: }                                    |
+      incidid{119:u}{120:Ut}{119: }{129:ut}{119: labore et}{116: }d{10:ol}ore magna aliqua.                |
+      Ut enim{119: }{120:enim}{119:inim veniam}{116:,} quis nostrud                       |
+      {2:[No Nam}{130:e}{137:ad}{130:[+]          }{132: }{2:                                    }|
+      {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
     ]])
 
     api.nvim_input_mouse('wheel', 'down', '', 0, 9, 40)
     screen:expect([[
-      Lorem ipsum d{1:ol}or sit amet, consectetur                     |
+      Lorem ipsum d{10:ol}or sit amet, consectetur                     |
       adipisicing elit, sed do eiusmod tempor                     |
       bla bla incididunt^                                          |
-      incidid{25:u}{26:incididunt}{25:re et}{27: }d{1:ol}ore magna aliqua.                |
-      Ut enim{28: }{29:ut}{28: minim veniam}{25:,} quis nostrud                       |
-      exercit{28:a}{29:labore}{28:llamco la}{25:b}oris nisi ut aliquip ex             |
-      {2:[No Nam}{30:e}{43:et}{30:[+]          }{32: }{2:                                    }|
-      incidid{28:u}{29:dol}{41:or}{29:e}{28:labore et}{25: }d{1:ol}ore magna aliqua.                |
-      Ut enim{28: }{29:magna}{28:nim veniam}{25:,} quis nostrud                       |
-      exercit{28:a}{29:aliqua}{28:llamco la}{25:b}oris nisi {4:ut} aliquip ex             |
-      ea comm{28:o}{29:Ut}{28: consequat. D}{25:u}is a{4:ut}e irure d{1:ol}or in              |
-      reprehe{28:n}{29:enim}{28:t in v}{34:ol}{28:upt}{25:a}te v{3:el}it esse cillum                |
-      {5:[No Nam}{38:e}{44:ad}{38:[+]          }{40: }{5:                                    }|
-      {20:-- Keyword Local completion (^N^P) }{21:match 1 of 65}            |
+      incidid{116:u}{117:incididunt}{116:re et}{118: }d{10:ol}ore magna aliqua.                |
+      Ut enim{119: }{120:ut}{119: minim veniam}{116:,} quis nostrud                       |
+      exercit{119:a}{120:labore}{119:llamco la}{116:b}oris nisi ut aliquip ex             |
+      {3:[No Nam}{121:e}{136:et}{121:[+]          }{124: }{3:                                    }|
+      incidid{119:u}{120:dol}{134:or}{120:e}{119:labore et}{116: }d{10:ol}ore magna aliqua.                |
+      Ut enim{119: }{120:magna}{119:nim veniam}{116:,} quis nostrud                       |
+      exercit{119:a}{120:aliqua}{119:llamco la}{116:b}oris nisi {18:ut} aliquip ex             |
+      ea comm{119:o}{120:Ut}{119: consequat. D}{116:u}is a{18:ut}e irure d{10:ol}or in              |
+      reprehe{119:n}{120:enim}{119:t in v}{126:ol}{119:upt}{116:a}te v{15:el}it esse cillum                |
+      {2:[No Nam}{130:e}{137:ad}{130:[+]          }{132: }{2:                                    }|
+      {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
     ]])
 
     -- can disable blending for individual attribute. For instance current
     -- selected item. (also tests that `hi Pmenu*` take immediate effect)
     command('hi PMenuSel blend=0')
     screen:expect([[
-      Lorem ipsum d{1:ol}or sit amet, consectetur                     |
+      Lorem ipsum d{10:ol}or sit amet, consectetur                     |
       adipisicing elit, sed do eiusmod tempor                     |
       bla bla incididunt^                                          |
-      incidid{45: incididunt     }{27: }d{1:ol}ore magna aliqua.                |
-      Ut enim{28: }{29:ut}{28: minim veniam}{25:,} quis nostrud                       |
-      exercit{28:a}{29:labore}{28:llamco la}{25:b}oris nisi ut aliquip ex             |
-      {2:[No Nam}{30:e}{43:et}{30:[+]          }{32: }{2:                                    }|
-      incidid{28:u}{29:dol}{41:or}{29:e}{28:labore et}{25: }d{1:ol}ore magna aliqua.                |
-      Ut enim{28: }{29:magna}{28:nim veniam}{25:,} quis nostrud                       |
-      exercit{28:a}{29:aliqua}{28:llamco la}{25:b}oris nisi {4:ut} aliquip ex             |
-      ea comm{28:o}{29:Ut}{28: consequat. D}{25:u}is a{4:ut}e irure d{1:ol}or in              |
-      reprehe{28:n}{29:enim}{28:t in v}{34:ol}{28:upt}{25:a}te v{3:el}it esse cillum                |
-      {5:[No Nam}{38:e}{44:ad}{38:[+]          }{40: }{5:                                    }|
-      {20:-- Keyword Local completion (^N^P) }{21:match 1 of 65}            |
+      incidid{138: incididunt     }{118: }d{10:ol}ore magna aliqua.                |
+      Ut enim{119: }{120:ut}{119: minim veniam}{116:,} quis nostrud                       |
+      exercit{119:a}{120:labore}{119:llamco la}{116:b}oris nisi ut aliquip ex             |
+      {3:[No Nam}{121:e}{136:et}{121:[+]          }{124: }{3:                                    }|
+      incidid{119:u}{120:dol}{134:or}{120:e}{119:labore et}{116: }d{10:ol}ore magna aliqua.                |
+      Ut enim{119: }{120:magna}{119:nim veniam}{116:,} quis nostrud                       |
+      exercit{119:a}{120:aliqua}{119:llamco la}{116:b}oris nisi {18:ut} aliquip ex             |
+      ea comm{119:o}{120:Ut}{119: consequat. D}{116:u}is a{18:ut}e irure d{10:ol}or in              |
+      reprehe{119:n}{120:enim}{119:t in v}{126:ol}{119:upt}{116:a}te v{15:el}it esse cillum                |
+      {2:[No Nam}{130:e}{137:ad}{130:[+]          }{132: }{2:                                    }|
+      {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
     ]])
 
     feed('<c-e>')
     screen:expect([[
-      Lorem ipsum d{1:ol}or sit amet, consectetur                     |
+      Lorem ipsum d{10:ol}or sit amet, consectetur                     |
       adipisicing elit, sed do eiusmod tempor                     |
       bla bla ^                                                    |
-      incididunt ut labore et d{1:ol}ore magna aliqua.                |
+      incididunt ut labore et d{10:ol}ore magna aliqua.                |
       Ut enim ad minim veniam, quis nostrud                       |
       exercitation ullamco laboris nisi ut aliquip ex             |
-      {2:[No Name] [+]                                               }|
-      incididunt {4:ut} labore et d{1:ol}ore magna aliqua.                |
+      {3:[No Name] [+]                                               }|
+      incididunt {18:ut} labore et d{10:ol}ore magna aliqua.                |
       Ut enim ad minim veniam, quis nostrud                       |
-      exercitation ullamco laboris nisi {4:ut} aliquip ex             |
-      ea commodo consequat. Duis a{4:ut}e irure d{1:ol}or in              |
-      reprehenderit in v{1:ol}uptate v{3:el}it esse cillum                |
-      {5:[No Name] [+]                                               }|
-      {20:-- INSERT --}                                                |
+      exercitation ullamco laboris nisi {18:ut} aliquip ex             |
+      ea commodo consequat. Duis a{18:ut}e irure d{10:ol}or in              |
+      reprehenderit in v{10:ol}uptate v{15:el}it esse cillum                |
+      {2:[No Name] [+]                                               }|
+      {5:-- INSERT --}                                                |
     ]])
   end)
 
   it('256-color (non-RGB)', function()
-    local screen = Screen.new(60, 8, { rgb = false })
-    screen:set_default_attr_ids({
-      [1] = { foreground = Screen.colors.Grey0, background = tonumber('0x000007') },
-      [2] = { foreground = tonumber('0x000055'), background = tonumber('0x000007') },
-      [3] = { foreground = tonumber('0x00008f'), background = Screen.colors.Grey0 },
-      [4] = { foreground = Screen.colors.Grey0, background = tonumber('0x0000e1') },
-      [5] = { foreground = tonumber('0x0000d1'), background = tonumber('0x0000e1') },
-      [6] = { foreground = Screen.colors.NavyBlue, background = tonumber('0x0000f8') },
-      [7] = { foreground = tonumber('0x0000a5'), background = tonumber('0x0000f8') },
-      [8] = { foreground = tonumber('0x00000c') },
-      [9] = { bold = true },
-      [10] = { foreground = tonumber('0x000002') },
-    })
+    screen._options.rgb = false
     command('set pumblend=10')
     insert([[
       Lorem ipsum dolor sit amet, consectetur
@@ -1129,13 +1004,13 @@ describe("builtin popupmenu 'pumblend'", function()
     feed('ggOdo<c-x><c-n>')
     screen:expect([[
       dolor^                                                       |
-      {1:dolor}{2: ipsum dol}or sit amet, consectetur                     |
-      {4:do}{5:ipisicing eli}t, sed do eiusmod tempor                     |
-      {4:dolore}{5:dunt ut l}abore et dolore magna aliqua.                |
+      {139:dolor}{140: ipsum dol}or sit amet, consectetur                     |
+      {141:do}{142:ipisicing eli}t, sed do eiusmod tempor                     |
+      {141:dolore}{142:dunt ut l}abore et dolore magna aliqua.                |
       Ut enim ad minim veniam, quis nostrud                       |
       laborum.                                                    |
-      {8:~                                                           }|
-      {9:-- Keyword Local completion (^N^P) }{10:match 1 of 3}             |
+      {143:~                                                           }|*7
+      {5:-- Keyword Local completion (^N^P) }{144:match 1 of 3}             |
     ]])
   end)
 end)
@@ -1147,24 +1022,48 @@ describe('builtin popupmenu', function()
     local screen
     before_each(function()
       screen = Screen.new(32, 20, { ext_multigrid = multigrid })
-      screen:set_default_attr_ids({
-        -- popup selected item / scrollbar track
-        s = { background = Screen.colors.Grey },
+      screen:add_extra_attr_ids({
+        [100] = { foreground = Screen.colors.Yellow, background = Screen.colors.Green },
+        [101] = { foreground = Screen.colors.White, background = Screen.colors.Green },
+        [102] = { foreground = Screen.colors.Brown, bold = true, background = Screen.colors.Plum1 },
+        [103] = { foreground = Screen.colors.DarkCyan, background = Screen.colors.Plum1 },
+        [104] = { foreground = Screen.colors.SlateBlue, background = Screen.colors.Plum1 },
+        [105] = { foreground = Screen.colors.Magenta1, background = Screen.colors.Plum1 },
+        [106] = {
+          foreground = Screen.colors.Red,
+          italic = true,
+          background = Screen.colors.Gray,
+          strikethrough = true,
+          underline = true,
+        },
+        [107] = {
+          background = Screen.colors.Grey100,
+          foreground = Screen.colors.Black,
+          italic = true,
+          bold = true,
+          underline = true,
+          strikethrough = true,
+        },
+        [108] = {
+          italic = true,
+          background = Screen.colors.Gray,
+          underline = true,
+          foreground = Screen.colors.Grey100,
+        },
+        [109] = {
+          foreground = Screen.colors.Yellow,
+          italic = true,
+          bold = true,
+          underline = true,
+          background = Screen.colors.Pink,
+        },
+        [110] = { background = Screen.colors.Grey, foreground = Screen.colors.DarkYellow },
+        [111] = { background = Screen.colors.Plum1, foreground = Screen.colors.DarkBlue },
+        [112] = { background = Screen.colors.Plum1, foreground = Screen.colors.DarkGreen },
         -- popup non-selected item
         n = { background = Screen.colors.Plum1 },
         -- popup scrollbar knob
         c = { background = Screen.colors.Black },
-        [1] = { bold = true, foreground = Screen.colors.Blue },
-        [2] = { bold = true },
-        [3] = { reverse = true },
-        [4] = { bold = true, reverse = true },
-        [5] = { bold = true, foreground = Screen.colors.SeaGreen },
-        [6] = { foreground = Screen.colors.White, background = Screen.colors.Red },
-        [7] = { background = Screen.colors.Yellow }, -- Search
-        [8] = { foreground = Screen.colors.Red },
-        [9] = { foreground = Screen.colors.Yellow, background = Screen.colors.Green },
-        [10] = { foreground = Screen.colors.White, background = Screen.colors.Green },
-        [11] = { background = Screen.colors.LightGrey, underline = true },
         ks = { foreground = Screen.colors.Red, background = Screen.colors.Grey },
         kn = { foreground = Screen.colors.Red, background = Screen.colors.Plum1 },
         xs = { foreground = Screen.colors.Black, background = Screen.colors.Grey },
@@ -1205,29 +1104,29 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [4:--------------------------------]|*8
-          {3:[No Name] [Preview][+]          }|
+          {2:[No Name] [Preview][+]          }|
           [2:--------------------------------]|*9
-          {4:[No Name] [+]                   }|
+          {3:[No Name] [+]                   }|
           [3:--------------------------------]|
         ## grid 2
           aa bb cc dd ee ff gg hh ii jj   |
           aa^                              |
           {1:~                               }|*7
         ## grid 3
-          {2:-- }{5:match 1 of 10}                |
+          {5:-- }{6:match 1 of 10}                |
         ## grid 4
           aa bb cc dd ee ff gg hh ii jj   |
           aa                              |
           {1:~                               }|*6
         ## grid 5
-          {s:aa             }{c: }|
+          {12:aa             }{c: }|
           {n:bb             }{c: }|
           {n:cc             }{c: }|
           {n:dd             }{c: }|
           {n:ee             }{c: }|
           {n:ff             }{c: }|
-          {n:gg             }{s: }|
-          {n:hh             }{s: }|
+          {n:gg             }{12: }|
+          {n:hh             }{12: }|
         ]],
           float_pos = { [5] = { -1, 'NW', 2, 2, 0, false, 100, 1, 11, 0 } },
         }
@@ -1236,18 +1135,18 @@ describe('builtin popupmenu', function()
           aa bb cc dd ee ff gg hh ii jj   |
           aa                              |
           {1:~                               }|*6
-          {3:[No Name] [Preview][+]          }|
+          {2:[No Name] [Preview][+]          }|
           aa bb cc dd ee ff gg hh ii jj   |
           aa^                              |
-          {s:aa             }{c: }{1:                }|
+          {12:aa             }{c: }{1:                }|
           {n:bb             }{c: }{1:                }|
           {n:cc             }{c: }{1:                }|
           {n:dd             }{c: }{1:                }|
           {n:ee             }{c: }{1:                }|
           {n:ff             }{c: }{1:                }|
-          {n:gg             }{s: }{1:                }|
-          {n:hh             }{s: }{4:                }|
-          {2:-- }{5:match 1 of 10}                |
+          {n:gg             }{12: }{1:                }|
+          {n:hh             }{12: }{3:                }|
+          {5:-- }{6:match 1 of 10}                |
         ]])
       end
     end)
@@ -1261,29 +1160,29 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [2:--------------------------------]|*9
-          {4:[No Name] [+]                   }|
+          {3:[No Name] [+]                   }|
           [4:--------------------------------]|*8
-          {3:[No Name] [Preview][+]          }|
+          {2:[No Name] [Preview][+]          }|
           [3:--------------------------------]|
         ## grid 2
           aa bb cc dd ee ff gg hh ii jj   |
           aa^                              |
           {1:~                               }|*7
         ## grid 3
-          {2:-- }{5:match 1 of 10}                |
+          {5:-- }{6:match 1 of 10}                |
         ## grid 4
           aa bb cc dd ee ff gg hh ii jj   |
           aa                              |
           {1:~                               }|*6
         ## grid 5
-          {s:aa             }{c: }|
+          {12:aa             }{c: }|
           {n:bb             }{c: }|
           {n:cc             }{c: }|
           {n:dd             }{c: }|
           {n:ee             }{c: }|
           {n:ff             }{c: }|
-          {n:gg             }{s: }|
-          {n:hh             }{s: }|
+          {n:gg             }{12: }|
+          {n:hh             }{12: }|
         ]],
           float_pos = { [5] = { -1, 'NW', 2, 2, 0, false, 100, 1, 2, 0 } },
         }
@@ -1291,19 +1190,19 @@ describe('builtin popupmenu', function()
         screen:expect([[
           aa bb cc dd ee ff gg hh ii jj   |
           aa^                              |
-          {s:aa             }{c: }{1:                }|
+          {12:aa             }{c: }{1:                }|
           {n:bb             }{c: }{1:                }|
           {n:cc             }{c: }{1:                }|
           {n:dd             }{c: }{1:                }|
           {n:ee             }{c: }{1:                }|
           {n:ff             }{c: }{1:                }|
-          {n:gg             }{s: }{1:                }|
-          {n:hh             }{s: }{4:                }|
+          {n:gg             }{12: }{1:                }|
+          {n:hh             }{12: }{3:                }|
           aa bb cc dd ee ff gg hh ii jj   |
           aa                              |
           {1:~                               }|*6
-          {3:[No Name] [Preview][+]          }|
-          {2:-- }{5:match 1 of 10}                |
+          {2:[No Name] [Preview][+]          }|
+          {5:-- }{6:match 1 of 10}                |
         ]])
       end
     end)
@@ -1319,9 +1218,9 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [4:--------------------------------]|*4
-          {3:[No Name] [Preview][+]          }|
+          {2:[No Name] [Preview][+]          }|
           [2:--------------------------------]|*13
-          {4:[No Name] [+]                   }|
+          {3:[No Name] [+]                   }|
           [3:--------------------------------]|
         ## grid 2
           dd                              |
@@ -1338,14 +1237,14 @@ describe('builtin popupmenu', function()
           oo                              |
           aa^                              |
         ## grid 3
-          {2:-- }{5:match 1 of 15}                |
+          {5:-- }{6:match 1 of 15}                |
         ## grid 4
           aa                              |
           bb                              |
           cc                              |
           dd                              |
         ## grid 5
-          {s:aa             }{c: }|
+          {12:aa             }{c: }|
           {n:bb             }{c: }|
           {n:cc             }{c: }|
           {n:dd             }{c: }|
@@ -1356,8 +1255,8 @@ describe('builtin popupmenu', function()
           {n:ii             }{c: }|
           {n:jj             }{c: }|
           {n:kk             }{c: }|
-          {n:ll             }{s: }|
-          {n:mm             }{s: }|
+          {n:ll             }{12: }|
+          {n:mm             }{12: }|
         ]],
           float_pos = { [5] = { -1, 'SW', 2, 12, 0, false, 100, 1, 4, 0 } },
         }
@@ -1367,7 +1266,7 @@ describe('builtin popupmenu', function()
           bb                              |
           cc                              |
           dd                              |
-          {s:aa             }{c: }{3:ew][+]          }|
+          {12:aa             }{c: }{2:ew][+]          }|
           {n:bb             }{c: }                |
           {n:cc             }{c: }                |
           {n:dd             }{c: }                |
@@ -1378,11 +1277,11 @@ describe('builtin popupmenu', function()
           {n:ii             }{c: }                |
           {n:jj             }{c: }                |
           {n:kk             }{c: }                |
-          {n:ll             }{s: }                |
-          {n:mm             }{s: }                |
+          {n:ll             }{12: }                |
+          {n:mm             }{12: }                |
           aa^                              |
-          {4:[No Name] [+]                   }|
-          {2:-- }{5:match 1 of 15}                |
+          {3:[No Name] [+]                   }|
+          {5:-- }{6:match 1 of 15}                |
         ]])
       end
     end)
@@ -1397,9 +1296,9 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [4:--------------------------------]|*8
-          {3:[No Name] [Preview][+]          }|
+          {2:[No Name] [Preview][+]          }|
           [2:--------------------------------]|*9
-          {4:[No Name] [+]                   }|
+          {3:[No Name] [+]                   }|
           [3:--------------------------------]|
         ## grid 2
           cc                              |
@@ -1412,7 +1311,7 @@ describe('builtin popupmenu', function()
           jj                              |
           aa^                              |
         ## grid 3
-          {2:-- }{5:match 1 of 10}                |
+          {5:-- }{6:match 1 of 10}                |
         ## grid 4
           aa                              |
           bb                              |
@@ -1423,7 +1322,7 @@ describe('builtin popupmenu', function()
           gg                              |
           hh                              |
         ## grid 5
-          {s:aa             }{c: }|
+          {12:aa             }{c: }|
           {n:bb             }{c: }|
           {n:cc             }{c: }|
           {n:dd             }{c: }|
@@ -1431,7 +1330,7 @@ describe('builtin popupmenu', function()
           {n:ff             }{c: }|
           {n:gg             }{c: }|
           {n:hh             }{c: }|
-          {n:ii             }{s: }|
+          {n:ii             }{12: }|
         ]],
           float_pos = { [5] = { -1, 'SW', 2, 8, 0, false, 100, 1, 8, 0 } },
         }
@@ -1445,7 +1344,7 @@ describe('builtin popupmenu', function()
           ff                              |
           gg                              |
           hh                              |
-          {s:aa             }{c: }{3:ew][+]          }|
+          {12:aa             }{c: }{2:ew][+]          }|
           {n:bb             }{c: }                |
           {n:cc             }{c: }                |
           {n:dd             }{c: }                |
@@ -1453,10 +1352,10 @@ describe('builtin popupmenu', function()
           {n:ff             }{c: }                |
           {n:gg             }{c: }                |
           {n:hh             }{c: }                |
-          {n:ii             }{s: }                |
+          {n:ii             }{12: }                |
           aa^                              |
-          {4:[No Name] [+]                   }|
-          {2:-- }{5:match 1 of 10}                |
+          {3:[No Name] [+]                   }|
+          {5:-- }{6:match 1 of 10}                |
         ]])
       end
     end)
@@ -1471,9 +1370,9 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [2:--------------------------------]|*9
-          {4:[No Name] [+]                   }|
+          {3:[No Name] [+]                   }|
           [4:--------------------------------]|*8
-          {3:[No Name] [Preview][+]          }|
+          {2:[No Name] [Preview][+]          }|
           [3:--------------------------------]|
         ## grid 2
           cc                              |
@@ -1486,7 +1385,7 @@ describe('builtin popupmenu', function()
           jj                              |
           aa^                              |
         ## grid 3
-          {2:-- }{5:match 1 of 10}                |
+          {5:-- }{6:match 1 of 10}                |
         ## grid 4
           aa                              |
           bb                              |
@@ -1497,29 +1396,29 @@ describe('builtin popupmenu', function()
           gg                              |
           hh                              |
         ## grid 5
-          {s:aa             }{c: }|
+          {12:aa             }{c: }|
           {n:bb             }{c: }|
           {n:cc             }{c: }|
           {n:dd             }{c: }|
           {n:ee             }{c: }|
           {n:ff             }{c: }|
-          {n:gg             }{s: }|
-          {n:hh             }{s: }|
+          {n:gg             }{12: }|
+          {n:hh             }{12: }|
         ]],
           float_pos = { [5] = { -1, 'SW', 2, 8, 0, false, 100, 1, 0, 0 } },
         }
       else
         screen:expect([[
-          {s:aa             }{c: }                |
+          {12:aa             }{c: }                |
           {n:bb             }{c: }                |
           {n:cc             }{c: }                |
           {n:dd             }{c: }                |
           {n:ee             }{c: }                |
           {n:ff             }{c: }                |
-          {n:gg             }{s: }                |
-          {n:hh             }{s: }                |
+          {n:gg             }{12: }                |
+          {n:hh             }{12: }                |
           aa^                              |
-          {4:[No Name] [+]                   }|
+          {3:[No Name] [+]                   }|
           aa                              |
           bb                              |
           cc                              |
@@ -1528,8 +1427,8 @@ describe('builtin popupmenu', function()
           ff                              |
           gg                              |
           hh                              |
-          {3:[No Name] [Preview][+]          }|
-          {2:-- }{5:match 1 of 10}                |
+          {2:[No Name] [Preview][+]          }|
+          {5:-- }{6:match 1 of 10}                |
         ]])
       end
     end)
@@ -1555,9 +1454,9 @@ describe('builtin popupmenu', function()
             grid = [[
             ## grid 1
               [4:-----------------------------------------------------]|*9
-              {3:[No Name] [Preview][+]                               }|
+              {2:[No Name] [Preview][+]                               }|
               [2:-----------------------------------------------------]|*8
-              {4:[No Name] [+]                                        }|
+              {3:[No Name] [+]                                        }|
               [3:-----------------------------------------------------]|
             ## grid 2
               ab4                                                  |
@@ -1569,7 +1468,7 @@ describe('builtin popupmenu', function()
               ab0^                                                  |
               {1:~                                                    }|
             ## grid 3
-              {2:-- Keyword Local completion (^N^P) }{5:match 1 of 10}     |
+              {5:-- Keyword Local completion (^N^P) }{6:match 1 of 10}     |
             ## grid 4
               ab0                                                  |
               ab1                                                  |
@@ -1581,13 +1480,13 @@ describe('builtin popupmenu', function()
               ab7                                                  |
               ab8                                                  |
             ## grid 5
-              {s:ab0            }{c: }|
+              {12:ab0            }{c: }|
               {n:ab1            }{c: }|
               {n:ab2            }{c: }|
               {n:ab3            }{c: }|
-              {n:ab4            }{s: }|
-              {n:ab5            }{s: }|
-              {n:ab6            }{s: }|
+              {n:ab4            }{12: }|
+              {n:ab5            }{12: }|
+              {n:ab6            }{12: }|
             ]],
             float_pos = { [5] = { -1, 'SW', 2, 6, 0, false, 100, 1, 9, 0 } },
           })
@@ -1602,17 +1501,17 @@ describe('builtin popupmenu', function()
             ab6                                                  |
             ab7                                                  |
             ab8                                                  |
-            {s:ab0            }{c: }{3:ew][+]                               }|
+            {12:ab0            }{c: }{2:ew][+]                               }|
             {n:ab1            }{c: }                                     |
             {n:ab2            }{c: }                                     |
             {n:ab3            }{c: }                                     |
-            {n:ab4            }{s: }                                     |
-            {n:ab5            }{s: }                                     |
-            {n:ab6            }{s: }                                     |
+            {n:ab4            }{12: }                                     |
+            {n:ab5            }{12: }                                     |
+            {n:ab6            }{12: }                                     |
             ab0^                                                  |
             {1:~                                                    }|
-            {4:[No Name] [+]                                        }|
-            {2:-- Keyword Local completion (^N^P) }{5:match 1 of 10}     |
+            {3:[No Name] [+]                                        }|
+            {5:-- Keyword Local completion (^N^P) }{6:match 1 of 10}     |
           ]])
         end
       end)
@@ -1633,9 +1532,9 @@ describe('builtin popupmenu', function()
             grid = [[
             ## grid 1
               [4:-----------------------------------------------------]|*9
-              {3:[No Name] [Preview][+]                               }|
+              {2:[No Name] [Preview][+]                               }|
               [2:-----------------------------------------------------]|*8
-              {4:[No Name] [+]                                        }|
+              {3:[No Name] [+]                                        }|
               [3:-----------------------------------------------------]|
             ## grid 2
               ab5                                                  |
@@ -1646,7 +1545,7 @@ describe('builtin popupmenu', function()
               ab0^                                                  |
               {1:~                                                    }|*2
             ## grid 3
-              {2:-- Keyword Local completion (^N^P) }{5:match 1 of 10}     |
+              {5:-- Keyword Local completion (^N^P) }{6:match 1 of 10}     |
             ## grid 4
               ab0                                                  |
               ab1                                                  |
@@ -1658,12 +1557,12 @@ describe('builtin popupmenu', function()
               ab7                                                  |
               ab8                                                  |
             ## grid 5
-              {s:ab0            }{c: }|
+              {12:ab0            }{c: }|
               {n:ab1            }{c: }|
               {n:ab2            }{c: }|
-              {n:ab3            }{s: }|
-              {n:ab4            }{s: }|
-              {n:ab5            }{s: }|
+              {n:ab3            }{12: }|
+              {n:ab4            }{12: }|
+              {n:ab5            }{12: }|
             ]],
             float_pos = { [5] = { -1, 'SW', 2, 5, 0, false, 100, 1, 9, 0 } },
           })
@@ -1678,16 +1577,16 @@ describe('builtin popupmenu', function()
             ab6                                                  |
             ab7                                                  |
             ab8                                                  |
-            {s:ab0            }{c: }{3:ew][+]                               }|
+            {12:ab0            }{c: }{2:ew][+]                               }|
             {n:ab1            }{c: }                                     |
             {n:ab2            }{c: }                                     |
-            {n:ab3            }{s: }                                     |
-            {n:ab4            }{s: }                                     |
-            {n:ab5            }{s: }                                     |
+            {n:ab3            }{12: }                                     |
+            {n:ab4            }{12: }                                     |
+            {n:ab5            }{12: }                                     |
             ab0^                                                  |
             {1:~                                                    }|*2
-            {4:[No Name] [+]                                        }|
-            {2:-- Keyword Local completion (^N^P) }{5:match 1 of 10}     |
+            {3:[No Name] [+]                                        }|
+            {5:-- Keyword Local completion (^N^P) }{6:match 1 of 10}     |
           ]])
         end
       end)
@@ -1716,7 +1615,7 @@ describe('builtin popupmenu', function()
             ^                                |
             {1:~                               }|*18
           ## grid 3
-            {2:-- }{8:Back at original}             |
+            {5:-- }{19:Back at original}             |
           ## grid 4
             {n:one            }|
             {n:two            }|
@@ -1731,7 +1630,7 @@ describe('builtin popupmenu', function()
           {n:two            }{1:                 }|
           {n:three          }{1:                 }|
           {1:~                               }|*15
-          {2:-- }{8:Back at original}             |
+          {5:-- }{19:Back at original}             |
         ]])
       end
       feed('<C-N>')
@@ -1740,17 +1639,17 @@ describe('builtin popupmenu', function()
           grid = [[
           ## grid 1
             [5:--------------------------------]|*3
-            {3:[Scratch] [Preview][-]          }|
+            {2:[Scratch] [Preview][-]          }|
             [2:--------------------------------]|*14
-            {4:[No Name] [+]                   }|
+            {3:[No Name] [+]                   }|
             [3:--------------------------------]|
           ## grid 2
             one^                             |
             {1:~                               }|*13
           ## grid 3
-            {2:-- }{5:match 1 of 3}                 |
+            {5:-- }{6:match 1 of 3}                 |
           ## grid 4
-            {s:one            }|
+            {12:one            }|
             {n:two            }|
             {n:three          }|
           ## grid 5
@@ -1763,14 +1662,14 @@ describe('builtin popupmenu', function()
         screen:expect([[
           1info                           |
           {1:~                               }|*2
-          {3:[Scratch] [Preview][-]          }|
+          {2:[Scratch] [Preview][-]          }|
           one^                             |
-          {s:one            }{1:                 }|
+          {12:one            }{1:                 }|
           {n:two            }{1:                 }|
           {n:three          }{1:                 }|
           {1:~                               }|*10
-          {4:[No Name] [+]                   }|
-          {2:-- }{5:match 1 of 3}                 |
+          {3:[No Name] [+]                   }|
+          {5:-- }{6:match 1 of 3}                 |
         ]])
       end
     end)
@@ -1802,31 +1701,31 @@ describe('builtin popupmenu', function()
             aa3bb                           |
             aa4bb                           |
           ## grid 3
-            {2:-- }{5:match 1 of 10}                |
+            {5:-- }{6:match 1 of 10}                |
           ## grid 4
-            {s:aa0bb          }{c: }|
+            {12:aa0bb          }{c: }|
             {n:aa1bb          }{c: }|
             {n:aa2bb          }{c: }|
             {n:aa3bb          }{c: }|
             {n:aa4bb          }{c: }|
             {n:aa5bb          }{c: }|
-            {n:aa6bb          }{s: }|
-            {n:aa7bb          }{s: }|
+            {n:aa6bb          }{12: }|
+            {n:aa7bb          }{12: }|
           ]],
           float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
         })
       else
         screen:expect([[
           aa0bb^                           |
-          {s:aa0bb          }{c: }啊              |
+          {12:aa0bb          }{c: }啊              |
           {n:aa1bb          }{c: } 哦             |
           {n:aa2bb          }{c: }呃呃            |
           {n:aa3bb          }{c: }                |
           {n:aa4bb          }{c: }                |
           {n:aa5bb          }{c: }                |
-          {n:aa6bb          }{s: }                |
-          {n:aa7bb          }{s: }                |
-          {2:-- }{5:match 1 of 10}                |
+          {n:aa6bb          }{12: }                |
+          {n:aa7bb          }{12: }                |
+          {5:-- }{6:match 1 of 10}                |
         ]])
       end
     end)
@@ -1835,52 +1734,6 @@ describe('builtin popupmenu', function()
       before_each(function()
         --row must > 10
         screen:try_resize(40, 11)
-        screen:add_extra_attr_ids({
-          [100] = { foreground = Screen.colors.Blue1, bold = true },
-          [101] = { foreground = Screen.colors.SeaGreen4, bold = true },
-          [102] = { background = Screen.colors.Red1, foreground = Screen.colors.Grey100 },
-          [103] = { foreground = Screen.colors.Red1 },
-          [104] = { background = Screen.colors.Green, foreground = Screen.colors.Grey100 },
-          [105] = {
-            background = Screen.colors.Plum1,
-            foreground = Screen.colors.Brown,
-            bold = true,
-          },
-          [106] = { background = Screen.colors.Plum1, foreground = Screen.colors.Cyan4 },
-          [107] = { background = Screen.colors.Plum1, foreground = Screen.colors.SlateBlue },
-          [108] = { background = Screen.colors.Plum1, foreground = Screen.colors.Fuchsia },
-          n = { background = Screen.colors.Plum1 },
-          c = { background = Screen.colors.Grey0 },
-          xs = { background = Screen.colors.Grey, foreground = Screen.colors.Grey0 },
-          ks = { background = Screen.colors.Grey, foreground = Screen.colors.Red1 },
-          kn = { background = Screen.colors.Plum1, foreground = Screen.colors.Red1 },
-          s = { background = Screen.colors.Grey },
-          xn = { background = Screen.colors.Plum1, foreground = Screen.colors.Grey100 },
-          mn = { background = Screen.colors.Plum1, foreground = Screen.colors.Blue1 },
-          ds = { background = Screen.colors.Grey, foreground = Screen.colors.Red4 },
-          ms = { background = Screen.colors.Grey, foreground = Screen.colors.Blue1 },
-          dn = { background = Screen.colors.Plum1, foreground = Screen.colors.Red4 },
-          ums = {
-            background = Screen.colors.Grey,
-            foreground = Screen.colors.Blue1,
-            underline = true,
-          },
-          umn = {
-            background = Screen.colors.Plum1,
-            foreground = Screen.colors.Blue1,
-            underline = true,
-          },
-          uds = {
-            background = Screen.colors.Grey,
-            foreground = Screen.colors.Red4,
-            underline = true,
-          },
-          udn = {
-            background = Screen.colors.Plum1,
-            foreground = Screen.colors.Red4,
-            underline = true,
-          },
-        })
         exec([[
           let g:list = [#{word: "one", info: "1info"}, #{word: "two", info: "2info"}, #{word: "looooooooooooooong"}]
           let g:bufnrs = []
@@ -1935,13 +1788,13 @@ describe('builtin popupmenu', function()
               [3:----------------------------------------]|
             ## grid 2
               one^                                     |
-              {100:~                                       }|*9
+              {1:~                                       }|*9
             ## grid 3
-              {5:-- }{101:match 1 of 3}                         |
+              {5:-- }{6:match 1 of 3}                         |
             ## grid 4
               {n:1info}|
             ## grid 5
-              {s:one                }|
+              {12:one                }|
               {n:two                }|
               {n:looooooooooooooong }|
             ]],
@@ -1978,11 +1831,11 @@ describe('builtin popupmenu', function()
         else
           screen:expect([[
             one^                                     |
-            {s:one                }{n:1info}{100:                }|
-            {n:two                }{100:                     }|
-            {n:looooooooooooooong }{100:                     }|
-            {100:~                                       }|*6
-            {5:-- }{101:match 1 of 3}                         |
+            {12:one                }{n:1info}{1:                }|
+            {n:two                }{1:                     }|
+            {n:looooooooooooooong }{1:                     }|
+            {1:~                                       }|*6
+            {5:-- }{6:match 1 of 3}                         |
           ]])
         end
 
@@ -1997,13 +1850,13 @@ describe('builtin popupmenu', function()
               [3:----------------------------------------]|
             ## grid 2
               on^                                      |
-              {100:~                                       }|*9
+              {1:~                                       }|*9
             ## grid 3
-              {5:-- }{101:match 1 of 3}                         |
+              {5:-- }{6:match 1 of 3}                         |
             ## grid 4
               {n:1info}|
             ## grid 5
-              {s:one            }|
+              {12:one            }|
             ]],
             win_pos = { [2] = { height = 10, startcol = 0, startrow = 0, width = 40, win = 1000 } },
             float_pos = {
@@ -2038,9 +1891,9 @@ describe('builtin popupmenu', function()
         else
           screen:expect([[
             on^                                      |
-            {s:one            }{n:1info}{100:                    }|
-            {100:~                                       }|*8
-            {5:-- }{101:match 1 of 3}                         |
+            {12:one            }{n:1info}{1:                    }|
+            {1:~                                       }|*8
+            {5:-- }{6:match 1 of 3}                         |
           ]])
         end
 
@@ -2054,9 +1907,9 @@ describe('builtin popupmenu', function()
               [3:----------------------------------------]|
             ## grid 2
               on^                                      |
-              {100:~                                       }|*9
+              {1:~                                       }|*9
             ## grid 3
-              {5:-- }{103:Back at original}                     |
+              {5:-- }{19:Back at original}                     |
             ## grid 4 (hidden)
               {n:1info}|
             ## grid 5
@@ -2092,9 +1945,9 @@ describe('builtin popupmenu', function()
         else
           screen:expect([[
             on^                                      |
-            {n:one            }{100:                         }|
-            {100:~                                       }|*8
-            {5:-- }{103:Back at original}                     |
+            {n:one            }{1:                         }|
+            {1:~                                       }|*8
+            {5:-- }{19:Back at original}                     |
           ]])
         end
         feed('<C-E><ESC>')
@@ -2110,15 +1963,15 @@ describe('builtin popupmenu', function()
               [3:----------------------------------------]|
             ## grid 2
               looooooooooooooong^                      |
-              {100:~                                       }|*9
+              {1:~                                       }|*9
             ## grid 3
-              {5:-- }{101:match 3 of 3}                         |
+              {5:-- }{6:match 3 of 3}                         |
             ## grid 4
               {n:3info}|
             ## grid 5
               {n:one                }|
               {n:two                }|
-              {s:looooooooooooooong }|
+              {12:looooooooooooooong }|
             ]],
             win_pos = { [2] = { height = 10, startcol = 0, startrow = 0, width = 40, win = 1000 } },
             float_pos = {
@@ -2153,11 +2006,11 @@ describe('builtin popupmenu', function()
         else
           screen:expect([[
             looooooooooooooong^                      |
-            {n:one                3info}{100:                }|
-            {n:two                }{100:                     }|
-            {s:looooooooooooooong }{100:                     }|
-            {100:~                                       }|*6
-            {5:-- }{101:match 3 of 3}                         |
+            {n:one                3info}{1:                }|
+            {n:two                }{1:                     }|
+            {12:looooooooooooooong }{1:                     }|
+            {1:~                                       }|*6
+            {5:-- }{6:match 3 of 3}                         |
           ]])
         end
         feed('<C-E><ESC>')
@@ -2174,13 +2027,13 @@ describe('builtin popupmenu', function()
               [3:----------------------------------------]|
             ## grid 2
               testtesttesttesttesone^t                 |
-              {100:~                                       }|*9
+              {1:~                                       }|*9
             ## grid 3
-              {5:-- }{101:match 1 of 3}                         |
+              {5:-- }{6:match 1 of 3}                         |
             ## grid 4
               {n:1info}|
             ## grid 5
-              {s: one                }|
+              {12: one                }|
               {n: two                }|
               {n: looooooooooooooong }|
             ]],
@@ -2217,11 +2070,11 @@ describe('builtin popupmenu', function()
         else
           screen:expect([[
             testtesttesttesttesone^t                 |
-            {100:~            }{n:1info}{s: one                }{100:  }|
-            {100:~                 }{n: two                }{100:  }|
-            {100:~                 }{n: looooooooooooooong }{100:  }|
-            {100:~                                       }|*6
-            {5:-- }{101:match 1 of 3}                         |
+            {1:~            }{n:1info}{12: one                }{1:  }|
+            {1:~                 }{n: two                }{1:  }|
+            {1:~                 }{n: looooooooooooooong }{1:  }|
+            {1:~                                       }|*6
+            {5:-- }{6:match 1 of 3}                         |
           ]])
         end
         feed('<C-E><Esc>')
@@ -2238,17 +2091,17 @@ describe('builtin popupmenu', function()
               [3:----------------------------------------]|
             ## grid 2
               one^                                     |
-              {100:~                                       }|*9
+              {1:~                                       }|*9
             ## grid 3
-              {5:-- }{101:match 1 of 3}                         |
+              {5:-- }{6:match 1 of 3}                         |
             ## grid 4
-              {mn:```}{105:lua}{n:         }|
-              {105:function}{mn: }{106:test}{107:()}|
-              {mn:  }{107:print(}{108:'foo'}{107:)}{n: }|
-              {105:end}{n:            }|
+              {mn:```}{102:lua}{n:         }|
+              {102:function}{mn: }{103:test}{104:()}|
+              {mn:  }{104:print(}{105:'foo'}{104:)}{n: }|
+              {102:end}{n:            }|
               {mn:```}{n:            }|
             ## grid 5
-              {s:one                }|
+              {12:one                }|
               {n:two                }|
               {n:looooooooooooooong }|
             ]],
@@ -2285,14 +2138,14 @@ describe('builtin popupmenu', function()
         else
           screen:expect([[
             one^                                     |
-            {s:one                }{mn:```}{105:lua}{n:         }{100:      }|
-            {n:two                }{105:function}{mn: }{106:test}{107:()}{100:      }|
-            {n:looooooooooooooong }{mn:  }{107:print(}{108:'foo'}{107:)}{n: }{100:      }|
-            {100:~                  }{105:end}{n:            }{100:      }|
-            {100:~                  }{mn:```}{n:            }{100:      }|
-            {100:~                                       }|*4
-            {5:-- }{101:match 1 of 3}                         |
-        ]])
+            {12:one                }{mn:```}{102:lua}{n:         }{1:      }|
+            {n:two                }{102:function}{mn: }{103:test}{104:()}{1:      }|
+            {n:looooooooooooooong }{mn:  }{104:print(}{105:'foo'}{104:)}{n: }{1:      }|
+            {1:~                  }{102:end}{n:            }{1:      }|
+            {1:~                  }{mn:```}{n:            }{1:      }|
+            {1:~                                       }|*4
+            {5:-- }{6:match 1 of 3}                         |
+          ]])
         end
         feed('<C-E><ESC>')
       end)
@@ -2308,14 +2161,14 @@ describe('builtin popupmenu', function()
               [3:----------------------------------------]|
             ## grid 2
               for .. ipairs^                           |
-              {100:~                                       }|*9
+              {1:~                                       }|*9
             ## grid 3
-              {5:-- }{101:match 1 of 4}                         |
+              {5:-- }{6:match 1 of 4}                         |
             ## grid 4
               {n:one                }|
               {n:two                }|
               {n:looooooooooooooong }|
-              {s:for .. ipairs      }|
+              {12:for .. ipairs      }|
             ## grid 5
               {n:```lua              }|
               {n:for index, value in }|
@@ -2357,14 +2210,14 @@ describe('builtin popupmenu', function()
         else
           screen:expect([[
             for .. ipairs^                           |
-            {n:one                ```lua              }{100: }|
-            {n:two                for index, value in }{100: }|
-            {n:looooooooooooooong ipairs(t) do        }{100: }|
-            {s:for .. ipairs      }{n:                    }{100: }|
-            {100:~                  }{n:end                 }{100: }|
-            {100:~                  }{n:```                 }{100: }|
-            {100:~                                       }|*3
-            {5:-- }{101:match 1 of 4}                         |
+            {n:one                ```lua              }{1: }|
+            {n:two                for index, value in }{1: }|
+            {n:looooooooooooooong ipairs(t) do        }{1: }|
+            {12:for .. ipairs      }{n:                    }{1: }|
+            {1:~                  }{n:end                 }{1: }|
+            {1:~                  }{n:```                 }{1: }|
+            {1:~                                       }|*3
+            {5:-- }{6:match 1 of 4}                         |
           ]])
         end
 
@@ -2386,11 +2239,10 @@ describe('builtin popupmenu', function()
       insert('aaa aab aac\n')
       feed(':vsplit<cr>')
       if multigrid then
-        screen:expect {
-          grid = [[
+        screen:expect([[
         ## grid 1
           [4:--------------------]│[2:-----------]|*6
-          {4:[No Name] [+]        }{3:<Name] [+] }|
+          {3:[No Name] [+]        }{2:<Name] [+] }|
           [3:--------------------------------]|
         ## grid 2
           aaa aab aac|
@@ -2402,14 +2254,13 @@ describe('builtin popupmenu', function()
           aaa aab aac         |
           ^                    |
           {1:~                   }|*4
-        ]],
-        }
+        ]])
       else
         screen:expect([[
           aaa aab aac         │aaa aab aac|
           ^                    │           |
           {1:~                   }│{1:~          }|*4
-          {4:[No Name] [+]        }{3:<Name] [+] }|
+          {3:[No Name] [+]        }{2:<Name] [+] }|
           :vsplit                         |
         ]])
       end
@@ -2420,20 +2271,20 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [4:--------------------]│[2:-----------]|*6
-          {4:[No Name] [+]        }{3:<Name] [+] }|
+          {3:[No Name] [+]        }{2:<Name] [+] }|
           [3:--------------------------------]|
         ## grid 2
           aaa aab aac|
           bbb aaa    |
           {1:~          }|*4
         ## grid 3
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ## grid 4
           aaa aab aac         |
           bbb aaa^             |
           {1:~                   }|*4
         ## grid 5
-          {s: aaa            }|
+          {12: aaa            }|
           {n: aab            }|
           {n: aac            }|
         ]],
@@ -2443,12 +2294,12 @@ describe('builtin popupmenu', function()
         screen:expect([[
           aaa aab aac         │aaa aab aac|
           bbb aaa^             │bbb aaa    |
-          {1:~  }{s: aaa            }{1: }│{1:~          }|
+          {1:~  }{12: aaa            }{1: }│{1:~          }|
           {1:~  }{n: aab            }{1: }│{1:~          }|
           {1:~  }{n: aac            }{1: }│{1:~          }|
           {1:~                   }│{1:~          }|
-          {4:[No Name] [+]        }{3:<Name] [+] }|
-          {2:-- }{5:match 1 of 3}                 |
+          {3:[No Name] [+]        }{2:<Name] [+] }|
+          {5:-- }{6:match 1 of 3}                 |
         ]])
       end
 
@@ -2458,7 +2309,7 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [4:-----------]│[2:--------------------]|*6
-          {3:<Name] [+]  }{4:[No Name] [+]       }|
+          {2:<Name] [+]  }{3:[No Name] [+]       }|
           [3:--------------------------------]|
         ## grid 2
           aaa aab aac         |
@@ -2466,14 +2317,14 @@ describe('builtin popupmenu', function()
           c aaa^               |
           {1:~                   }|*3
         ## grid 3
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ## grid 4
           aaa aab aac|
           bbb aaa    |
           c aaa      |
           {1:~          }|*3
         ## grid 5
-          {s: aaa            }|
+          {12: aaa            }|
           {n: aab            }|
           {n: aac            }|
         ]],
@@ -2484,11 +2335,11 @@ describe('builtin popupmenu', function()
           aaa aab aac│aaa aab aac         |
           bbb aaa    │bbb aaa             |
           c aaa      │c aaa^               |
-          {1:~          }│{1:~}{s: aaa            }{1:   }|
+          {1:~          }│{1:~}{12: aaa            }{1:   }|
           {1:~          }│{1:~}{n: aab            }{1:   }|
           {1:~          }│{1:~}{n: aac            }{1:   }|
-          {3:<Name] [+]  }{4:[No Name] [+]       }|
-          {2:-- }{5:match 1 of 3}                 |
+          {2:<Name] [+]  }{3:[No Name] [+]       }|
+          {5:-- }{6:match 1 of 3}                 |
         ]])
       end
 
@@ -2498,7 +2349,7 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [4:-----------]│[2:--------------------]|*6
-          {3:<Name] [+]  }{4:[No Name] [+]       }|
+          {2:<Name] [+]  }{3:[No Name] [+]       }|
           [3:--------------------------------]|
         ## grid 2
           aaa aab aac         |
@@ -2506,7 +2357,7 @@ describe('builtin popupmenu', function()
           c aaabcdef ccc aaa^  |
           {1:~                   }|*3
         ## grid 3
-          {2:-- }{5:match 1 of 4}                 |
+          {5:-- }{6:match 1 of 4}                 |
         ## grid 4
           aaa aab aac|
           bbb aaa    |
@@ -2514,7 +2365,7 @@ describe('builtin popupmenu', function()
           ccc aaa    |
           {1:~          }|*2
         ## grid 5
-          {s: aaa     }|
+          {12: aaa     }|
           {n: aab     }|
           {n: aac     }|
           {n: aaabcdef}|
@@ -2526,11 +2377,11 @@ describe('builtin popupmenu', function()
           aaa aab aac│aaa aab aac         |
           bbb aaa    │bbb aaa             |
           c aaabcdef │c aaabcdef ccc aaa^  |
-          ccc aaa    │{1:~          }{s: aaa     }|
+          ccc aaa    │{1:~          }{12: aaa     }|
           {1:~          }│{1:~          }{n: aab     }|
           {1:~          }│{1:~          }{n: aac     }|
-          {3:<Name] [+]  }{4:[No Name] [}{n: aaabcdef}|
-          {2:-- }{5:match 1 of 4}                 |
+          {2:<Name] [+]  }{3:[No Name] [}{n: aaabcdef}|
+          {5:-- }{6:match 1 of 4}                 |
         ]])
       end
 
@@ -2540,7 +2391,7 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [4:-----------]│[2:--------------------]|*6
-          {3:<Name] [+]  }{4:[No Name] [+]       }|
+          {2:<Name] [+]  }{3:[No Name] [+]       }|
           [3:--------------------------------]|
         ## grid 2
           aaa aab aac         |
@@ -2549,7 +2400,7 @@ describe('builtin popupmenu', function()
           aaa^                 |
           {1:~                   }|*2
         ## grid 3
-          {2:-- }{5:match 1 of 6}                 |
+          {5:-- }{6:match 1 of 6}                 |
         ## grid 4
           aaa aab aac|
           bbb aaa    |
@@ -2558,9 +2409,9 @@ describe('builtin popupmenu', function()
           aaa        |
           {1:~          }|
         ## grid 5
-          {s: aaa            }{c: }|
-          {n: aab            }{s: }|
-          {n: aac            }{s: }|
+          {12: aaa            }{c: }|
+          {n: aab            }{12: }|
+          {n: aac            }{12: }|
         ]],
           float_pos = { [5] = { -1, 'NW', 2, 4, -1, false, 100, 1, 4, 11 } },
         }
@@ -2570,10 +2421,10 @@ describe('builtin popupmenu', function()
           bbb aaa    │bbb aaa             |
           c aaabcdef │c aaabcdef ccc aaa  |
           ccc aaa    │aaa^                 |
-          aaa        {s: aaa            }{c: }{1:    }|
-          {1:~          }{n: aab            }{s: }{1:    }|
-          {3:<Name] [+] }{n: aac            }{s: }{4:    }|
-          {2:-- }{5:match 1 of 6}                 |
+          aaa        {12: aaa            }{c: }{1:    }|
+          {1:~          }{n: aab            }{12: }{1:    }|
+          {2:<Name] [+] }{n: aac            }{12: }{3:    }|
+          {5:-- }{6:match 1 of 6}                 |
         ]])
       end
     end)
@@ -2599,13 +2450,12 @@ describe('builtin popupmenu', function()
       ]])
 
       if multigrid then
-        screen:expect({
-          grid = [[
+        screen:expect([[
           ## grid 1
             [4:------------------------------------------------------------]|*6
-            {4:[No Name] [+]                                               }|
-            [2:------------------------------------------------------------]|*5
             {3:[No Name] [+]                                               }|
+            [2:------------------------------------------------------------]|*5
+            {2:[No Name] [+]                                               }|
             [3:------------------------------------------------------------]|
           ## grid 2
               Lorem ipsum dolor sit amet, consectetur                   |
@@ -2622,8 +2472,7 @@ describe('builtin popupmenu', function()
               laborum.                                                  |
             .                                                           |
             ^                                                            |
-          ]],
-        })
+        ]])
       else
         screen:expect([[
             dolore eu fugiat nulla pariatur. Excepteur sint           |
@@ -2632,13 +2481,13 @@ describe('builtin popupmenu', function()
             laborum.                                                  |
           .                                                           |
           ^                                                            |
-          {4:[No Name] [+]                                               }|
+          {3:[No Name] [+]                                               }|
             Lorem ipsum dolor sit amet, consectetur                   |
             adipisicing elit, sed do eiusmod tempor                   |
             incididunt ut labore et dolore magna aliqua.              |
             Ut enim ad minim veniam, quis nostrud                     |
             exercitation ullamco laboris nisi ut aliquip ex           |
-          {3:[No Name] [+]                                               }|
+          {2:[No Name] [+]                                               }|
                                                                       |
         ]])
       end
@@ -2649,9 +2498,9 @@ describe('builtin popupmenu', function()
           grid = [[
           ## grid 1
             [4:------------------------------------------------------------]|*6
-            {4:[No Name] [+]                                               }|
-            [2:------------------------------------------------------------]|*5
             {3:[No Name] [+]                                               }|
+            [2:------------------------------------------------------------]|*5
+            {2:[No Name] [+]                                               }|
             [3:------------------------------------------------------------]|
           ## grid 2
             Est                                                         |
@@ -2660,7 +2509,7 @@ describe('builtin popupmenu', function()
               incididunt ut labore et dolore magna aliqua.              |
               Ut enim ad minim veniam, quis nostrud                     |
           ## grid 3
-            {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
+            {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
           ## grid 4
             Est ^                                                        |
               Lorem ipsum dolor sit amet, consectetur                   |
@@ -2669,37 +2518,37 @@ describe('builtin popupmenu', function()
               Ut enim ad minim veniam, quis nostrud                     |
               exercitation ullamco laboris nisi ut aliquip ex           |
           ## grid 5
-            {n: sunt           }{s: }|
-            {n: in             }{s: }|
-            {n: culpa          }{s: }|
-            {n: qui            }{s: }|
-            {n: officia        }{s: }|
-            {n: deserunt       }{s: }|
-            {n: mollit         }{s: }|
-            {n: anim           }{s: }|
-            {n: id             }{s: }|
-            {n: est            }{s: }|
+            {n: sunt           }{12: }|
+            {n: in             }{12: }|
+            {n: culpa          }{12: }|
+            {n: qui            }{12: }|
+            {n: officia        }{12: }|
+            {n: deserunt       }{12: }|
+            {n: mollit         }{12: }|
+            {n: anim           }{12: }|
+            {n: id             }{12: }|
+            {n: est            }{12: }|
             {n: laborum        }{c: }|
-            {s: Est            }{c: }|
+            {12: Est            }{c: }|
           ]],
           float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
         })
       else
         screen:expect([[
           Est ^                                                        |
-            L{n: sunt           }{s: }sit amet, consectetur                   |
-            a{n: in             }{s: }sed do eiusmod tempor                   |
-            i{n: culpa          }{s: }re et dolore magna aliqua.              |
-            U{n: qui            }{s: }eniam, quis nostrud                     |
-            e{n: officia        }{s: }co laboris nisi ut aliquip ex           |
-          {4:[No}{n: deserunt       }{s: }{4:                                        }|
-          Est{n: mollit         }{s: }                                        |
-            L{n: anim           }{s: }sit amet, consectetur                   |
-            a{n: id             }{s: }sed do eiusmod tempor                   |
-            i{n: est            }{s: }re et dolore magna aliqua.              |
+            L{n: sunt           }{12: }sit amet, consectetur                   |
+            a{n: in             }{12: }sed do eiusmod tempor                   |
+            i{n: culpa          }{12: }re et dolore magna aliqua.              |
+            U{n: qui            }{12: }eniam, quis nostrud                     |
+            e{n: officia        }{12: }co laboris nisi ut aliquip ex           |
+          {3:[No}{n: deserunt       }{12: }{3:                                        }|
+          Est{n: mollit         }{12: }                                        |
+            L{n: anim           }{12: }sit amet, consectetur                   |
+            a{n: id             }{12: }sed do eiusmod tempor                   |
+            i{n: est            }{12: }re et dolore magna aliqua.              |
             U{n: laborum        }{c: }eniam, quis nostrud                     |
-          {3:[No}{s: Est            }{c: }{3:                                        }|
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
+          {2:[No}{12: Est            }{c: }{2:                                        }|
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
         ]])
       end
 
@@ -2709,9 +2558,9 @@ describe('builtin popupmenu', function()
           grid = [[
           ## grid 1
             [4:------------------------------------------------------------]|*6
-            {4:[No Name] [+]                                               }|
-            [2:------------------------------------------------------------]|*5
             {3:[No Name] [+]                                               }|
+            [2:------------------------------------------------------------]|*5
+            {2:[No Name] [+]                                               }|
             [3:------------------------------------------------------------]|
           ## grid 2
               incididunt ut labore et dolore magna aliqua.              |
@@ -2720,7 +2569,7 @@ describe('builtin popupmenu', function()
               ea commodo consequat. Duis aute irure dolor in            |
               reprehenderit in voluptate velit esse cillum              |
           ## grid 3
-            {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
+            {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
           ## grid 4
             Est ^                                                        |
               Lorem ipsum dolor sit amet, consectetur                   |
@@ -2729,18 +2578,18 @@ describe('builtin popupmenu', function()
               Ut enim ad minim veniam, quis nostrud                     |
               exercitation ullamco laboris nisi ut aliquip ex           |
           ## grid 5
-            {n: sunt           }{s: }|
-            {n: in             }{s: }|
-            {n: culpa          }{s: }|
-            {n: qui            }{s: }|
-            {n: officia        }{s: }|
-            {n: deserunt       }{s: }|
-            {n: mollit         }{s: }|
-            {n: anim           }{s: }|
-            {n: id             }{s: }|
-            {n: est            }{s: }|
+            {n: sunt           }{12: }|
+            {n: in             }{12: }|
+            {n: culpa          }{12: }|
+            {n: qui            }{12: }|
+            {n: officia        }{12: }|
+            {n: deserunt       }{12: }|
+            {n: mollit         }{12: }|
+            {n: anim           }{12: }|
+            {n: id             }{12: }|
+            {n: est            }{12: }|
             {n: laborum        }{c: }|
-            {s: Est            }{c: }|
+            {12: Est            }{c: }|
           ]],
           float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
         })
@@ -2748,19 +2597,19 @@ describe('builtin popupmenu', function()
         api.nvim_input_mouse('wheel', 'down', '', 0, 9, 40)
         screen:expect([[
           Est ^                                                        |
-            L{n: sunt           }{s: }sit amet, consectetur                   |
-            a{n: in             }{s: }sed do eiusmod tempor                   |
-            i{n: culpa          }{s: }re et dolore magna aliqua.              |
-            U{n: qui            }{s: }eniam, quis nostrud                     |
-            e{n: officia        }{s: }co laboris nisi ut aliquip ex           |
-          {4:[No}{n: deserunt       }{s: }{4:                                        }|
-            i{n: mollit         }{s: }re et dolore magna aliqua.              |
-            U{n: anim           }{s: }eniam, quis nostrud                     |
-            e{n: id             }{s: }co laboris nisi ut aliquip ex           |
-            e{n: est            }{s: }at. Duis aute irure dolor in            |
+            L{n: sunt           }{12: }sit amet, consectetur                   |
+            a{n: in             }{12: }sed do eiusmod tempor                   |
+            i{n: culpa          }{12: }re et dolore magna aliqua.              |
+            U{n: qui            }{12: }eniam, quis nostrud                     |
+            e{n: officia        }{12: }co laboris nisi ut aliquip ex           |
+          {3:[No}{n: deserunt       }{12: }{3:                                        }|
+            i{n: mollit         }{12: }re et dolore magna aliqua.              |
+            U{n: anim           }{12: }eniam, quis nostrud                     |
+            e{n: id             }{12: }co laboris nisi ut aliquip ex           |
+            e{n: est            }{12: }at. Duis aute irure dolor in            |
             r{n: laborum        }{c: }oluptate velit esse cillum              |
-          {3:[No}{s: Est            }{c: }{3:                                        }|
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
+          {2:[No}{12: Est            }{c: }{2:                                        }|
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
         ]])
       end
 
@@ -2770,9 +2619,9 @@ describe('builtin popupmenu', function()
           grid = [[
           ## grid 1
             [4:------------------------------------------------------------]|*6
-            {4:[No Name] [+]                                               }|
-            [2:------------------------------------------------------------]|*5
             {3:[No Name] [+]                                               }|
+            [2:------------------------------------------------------------]|*5
+            {2:[No Name] [+]                                               }|
             [3:------------------------------------------------------------]|
           ## grid 2
               incididunt ut labore et dolore magna aliqua.              |
@@ -2781,7 +2630,7 @@ describe('builtin popupmenu', function()
               ea commodo consequat. Duis aute irure dolor in            |
               reprehenderit in voluptate velit esse cillum              |
           ## grid 3
-            {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
+            {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
           ## grid 4
             Est e^                                                       |
               Lorem ipsum dolor sit amet, consectetur                   |
@@ -2799,7 +2648,7 @@ describe('builtin popupmenu', function()
             {n: ea             }|
             {n: esse           }|
             {n: eu             }|
-            {s: est            }|
+            {12: est            }|
           ]],
           float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
         })
@@ -2811,14 +2660,14 @@ describe('builtin popupmenu', function()
             i{n: et             }ore et dolore magna aliqua.              |
             U{n: enim           }veniam, quis nostrud                     |
             e{n: exercitation   }mco laboris nisi ut aliquip ex           |
-          {4:[No}{n: ex             }{4:                                         }|
+          {3:[No}{n: ex             }{3:                                         }|
             i{n: ea             }ore et dolore magna aliqua.              |
             U{n: esse           }veniam, quis nostrud                     |
             e{n: eu             }mco laboris nisi ut aliquip ex           |
-            e{s: est            }uat. Duis aute irure dolor in            |
+            e{12: est            }uat. Duis aute irure dolor in            |
             reprehenderit in voluptate velit esse cillum              |
-          {3:[No Name] [+]                                               }|
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
+          {2:[No Name] [+]                                               }|
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
         ]])
       end
 
@@ -2828,9 +2677,9 @@ describe('builtin popupmenu', function()
           grid = [[
           ## grid 1
             [4:------------------------------------------------------------]|*6
-            {4:[No Name] [+]                                               }|
-            [2:------------------------------------------------------------]|*5
             {3:[No Name] [+]                                               }|
+            [2:------------------------------------------------------------]|*5
+            {2:[No Name] [+]                                               }|
             [3:------------------------------------------------------------]|
           ## grid 2
             Est e                                                       |
@@ -2839,7 +2688,7 @@ describe('builtin popupmenu', function()
               incididunt ut labore et dolore magna aliqua.              |
               Ut enim ad minim veniam, quis nostrud                     |
           ## grid 3
-            {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
+            {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
           ## grid 4
             Est e^                                                       |
               Lorem ipsum dolor sit amet, consectetur                   |
@@ -2857,7 +2706,7 @@ describe('builtin popupmenu', function()
             {n: ea             }|
             {n: esse           }|
             {n: eu             }|
-            {s: est            }|
+            {12: est            }|
           ]],
           float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
         })
@@ -2870,14 +2719,14 @@ describe('builtin popupmenu', function()
             i{n: et             }ore et dolore magna aliqua.              |
             U{n: enim           }veniam, quis nostrud                     |
             e{n: exercitation   }mco laboris nisi ut aliquip ex           |
-          {4:[No}{n: ex             }{4:                                         }|
+          {3:[No}{n: ex             }{3:                                         }|
           Est{n: ea             }                                         |
             L{n: esse           } sit amet, consectetur                   |
             a{n: eu             } sed do eiusmod tempor                   |
-            i{s: est            }ore et dolore magna aliqua.              |
+            i{12: est            }ore et dolore magna aliqua.              |
             Ut enim ad minim veniam, quis nostrud                     |
-          {3:[No Name] [+]                                               }|
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
+          {2:[No Name] [+]                                               }|
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
         ]])
       end
 
@@ -2887,9 +2736,9 @@ describe('builtin popupmenu', function()
           grid = [[
           ## grid 1
             [4:------------------------------------------------------------]|*6
-            {4:[No Name] [+]                                               }|
-            [2:------------------------------------------------------------]|*5
             {3:[No Name] [+]                                               }|
+            [2:------------------------------------------------------------]|*5
+            {2:[No Name] [+]                                               }|
             [3:------------------------------------------------------------]|
           ## grid 2
             Est es                                                      |
@@ -2898,7 +2747,7 @@ describe('builtin popupmenu', function()
               incididunt ut labore et dolore magna aliqua.              |
               Ut enim ad minim veniam, quis nostrud                     |
           ## grid 3
-            {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
+            {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
           ## grid 4
             Est es^                                                      |
               Lorem ipsum dolor sit amet, consectetur                   |
@@ -2908,7 +2757,7 @@ describe('builtin popupmenu', function()
               exercitation ullamco laboris nisi ut aliquip ex           |
           ## grid 5
             {n: esse           }|
-            {s: est            }|
+            {12: est            }|
           ]],
           float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
         })
@@ -2916,18 +2765,18 @@ describe('builtin popupmenu', function()
         screen:expect([[
           Est es^                                                      |
             L{n: esse           } sit amet, consectetur                   |
-            a{s: est            } sed do eiusmod tempor                   |
+            a{12: est            } sed do eiusmod tempor                   |
             incididunt ut labore et dolore magna aliqua.              |
             Ut enim ad minim veniam, quis nostrud                     |
             exercitation ullamco laboris nisi ut aliquip ex           |
-          {4:[No Name] [+]                                               }|
+          {3:[No Name] [+]                                               }|
           Est es                                                      |
             Lorem ipsum dolor sit amet, consectetur                   |
             adipisicing elit, sed do eiusmod tempor                   |
             incididunt ut labore et dolore magna aliqua.              |
             Ut enim ad minim veniam, quis nostrud                     |
-          {3:[No Name] [+]                                               }|
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
+          {2:[No Name] [+]                                               }|
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
         ]])
       end
 
@@ -2937,9 +2786,9 @@ describe('builtin popupmenu', function()
           grid = [[
           ## grid 1
             [4:------------------------------------------------------------]|*6
-            {4:[No Name] [+]                                               }|
-            [2:------------------------------------------------------------]|*5
             {3:[No Name] [+]                                               }|
+            [2:------------------------------------------------------------]|*5
+            {2:[No Name] [+]                                               }|
             [3:------------------------------------------------------------]|
           ## grid 2
               incididunt ut labore et dolore magna aliqua.              |
@@ -2948,7 +2797,7 @@ describe('builtin popupmenu', function()
               ea commodo consequat. Duis aute irure dolor in            |
               reprehenderit in voluptate velit esse cillum              |
           ## grid 3
-            {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
+            {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
           ## grid 4
             Est es^                                                      |
               Lorem ipsum dolor sit amet, consectetur                   |
@@ -2958,7 +2807,7 @@ describe('builtin popupmenu', function()
               exercitation ullamco laboris nisi ut aliquip ex           |
           ## grid 5
             {n: esse           }|
-            {s: est            }|
+            {12: est            }|
           ]],
           float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
         })
@@ -2967,18 +2816,18 @@ describe('builtin popupmenu', function()
         screen:expect([[
           Est es^                                                      |
             L{n: esse           } sit amet, consectetur                   |
-            a{s: est            } sed do eiusmod tempor                   |
+            a{12: est            } sed do eiusmod tempor                   |
             incididunt ut labore et dolore magna aliqua.              |
             Ut enim ad minim veniam, quis nostrud                     |
             exercitation ullamco laboris nisi ut aliquip ex           |
-          {4:[No Name] [+]                                               }|
+          {3:[No Name] [+]                                               }|
             incididunt ut labore et dolore magna aliqua.              |
             Ut enim ad minim veniam, quis nostrud                     |
             exercitation ullamco laboris nisi ut aliquip ex           |
             ea commodo consequat. Duis aute irure dolor in            |
             reprehenderit in voluptate velit esse cillum              |
-          {3:[No Name] [+]                                               }|
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
+          {2:[No Name] [+]                                               }|
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
         ]])
       end
 
@@ -2988,9 +2837,9 @@ describe('builtin popupmenu', function()
           grid = [[
           ## grid 1
             [4:------------------------------------------------------------]|*6
-            {4:[No Name] [+]                                               }|
-            [2:------------------------------------------------------------]|*5
             {3:[No Name] [+]                                               }|
+            [2:------------------------------------------------------------]|*5
+            {2:[No Name] [+]                                               }|
             [3:------------------------------------------------------------]|
           ## grid 2
               incididunt ut labore et dolore magna aliqua.              |
@@ -2999,7 +2848,7 @@ describe('builtin popupmenu', function()
               ea commodo consequat. Duis aute irure dolor in            |
               reprehenderit in voluptate velit esse cillum              |
           ## grid 3
-            {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
+            {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
           ## grid 4
             Est e^                                                       |
               Lorem ipsum dolor sit amet, consectetur                   |
@@ -3017,7 +2866,7 @@ describe('builtin popupmenu', function()
             {n: ea             }|
             {n: esse           }|
             {n: eu             }|
-            {s: est            }|
+            {12: est            }|
           ]],
           float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
         })
@@ -3029,14 +2878,14 @@ describe('builtin popupmenu', function()
             i{n: et             }ore et dolore magna aliqua.              |
             U{n: enim           }veniam, quis nostrud                     |
             e{n: exercitation   }mco laboris nisi ut aliquip ex           |
-          {4:[No}{n: ex             }{4:                                         }|
+          {3:[No}{n: ex             }{3:                                         }|
             i{n: ea             }ore et dolore magna aliqua.              |
             U{n: esse           }veniam, quis nostrud                     |
             e{n: eu             }mco laboris nisi ut aliquip ex           |
-            e{s: est            }uat. Duis aute irure dolor in            |
+            e{12: est            }uat. Duis aute irure dolor in            |
             reprehenderit in voluptate velit esse cillum              |
-          {3:[No Name] [+]                                               }|
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 65}            |
+          {2:[No Name] [+]                                               }|
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 65}            |
         ]])
       end
 
@@ -3046,9 +2895,9 @@ describe('builtin popupmenu', function()
           grid = [[
           ## grid 1
             [4:------------------------------------------------------------]|*6
-            {4:[No Name] [+]                                               }|
-            [2:------------------------------------------------------------]|*5
             {3:[No Name] [+]                                               }|
+            [2:------------------------------------------------------------]|*5
+            {2:[No Name] [+]                                               }|
             [3:------------------------------------------------------------]|
           ## grid 2
               incididunt ut labore et dolore magna aliqua.              |
@@ -3057,7 +2906,7 @@ describe('builtin popupmenu', function()
               ea commodo consequat. Duis aute irure dolor in            |
               reprehenderit in voluptate velit esse cillum              |
           ## grid 3
-            {2:-- Keyword Local completion (^N^P) }{5:match 22 of 65}           |
+            {5:-- Keyword Local completion (^N^P) }{6:match 22 of 65}           |
           ## grid 4
             Est eu^                                                      |
               Lorem ipsum dolor sit amet, consectetur                   |
@@ -3074,7 +2923,7 @@ describe('builtin popupmenu', function()
             {n: ex             }|
             {n: ea             }|
             {n: esse           }|
-            {s: eu             }|
+            {12: eu             }|
             {n: est            }|
           ]],
           float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
@@ -3087,14 +2936,14 @@ describe('builtin popupmenu', function()
             i{n: et             }ore et dolore magna aliqua.              |
             U{n: enim           }veniam, quis nostrud                     |
             e{n: exercitation   }mco laboris nisi ut aliquip ex           |
-          {4:[No}{n: ex             }{4:                                         }|
+          {3:[No}{n: ex             }{3:                                         }|
             i{n: ea             }ore et dolore magna aliqua.              |
             U{n: esse           }veniam, quis nostrud                     |
-            e{s: eu             }mco laboris nisi ut aliquip ex           |
+            e{12: eu             }mco laboris nisi ut aliquip ex           |
             e{n: est            }uat. Duis aute irure dolor in            |
             reprehenderit in voluptate velit esse cillum              |
-          {3:[No Name] [+]                                               }|
-          {2:-- Keyword Local completion (^N^P) }{5:match 22 of 65}           |
+          {2:[No Name] [+]                                               }|
+          {5:-- Keyword Local completion (^N^P) }{6:match 22 of 65}           |
         ]])
       end
 
@@ -3104,9 +2953,9 @@ describe('builtin popupmenu', function()
           grid = [[
           ## grid 1
             [4:------------------------------------------------------------]|*6
-            {4:[No Name] [+]                                               }|
-            [2:------------------------------------------------------------]|*5
             {3:[No Name] [+]                                               }|
+            [2:------------------------------------------------------------]|*5
+            {2:[No Name] [+]                                               }|
             [3:------------------------------------------------------------]|
           ## grid 2
               ea commodo consequat. Duis aute irure dolor in            |
@@ -3115,7 +2964,7 @@ describe('builtin popupmenu', function()
               occaecat cupidatat non proident, sunt in culpa            |
               qui officia deserunt mollit anim id est                   |
           ## grid 3
-            {2:-- Keyword Local completion (^N^P) }{5:match 22 of 65}           |
+            {5:-- Keyword Local completion (^N^P) }{6:match 22 of 65}           |
           ## grid 4
             Est eu^                                                      |
               Lorem ipsum dolor sit amet, consectetur                   |
@@ -3132,7 +2981,7 @@ describe('builtin popupmenu', function()
             {n: ex             }|
             {n: ea             }|
             {n: esse           }|
-            {s: eu             }|
+            {12: eu             }|
             {n: est            }|
           ]],
           float_pos = { [5] = { -1, 'NW', 4, 1, 3, false, 100, 1, 1, 3 } },
@@ -3146,14 +2995,14 @@ describe('builtin popupmenu', function()
             i{n: et             }ore et dolore magna aliqua.              |
             U{n: enim           }veniam, quis nostrud                     |
             e{n: exercitation   }mco laboris nisi ut aliquip ex           |
-          {4:[No}{n: ex             }{4:                                         }|
+          {3:[No}{n: ex             }{3:                                         }|
             e{n: ea             }uat. Duis aute irure dolor in            |
             r{n: esse           }voluptate velit esse cillum              |
-            d{s: eu             }nulla pariatur. Excepteur sint           |
+            d{12: eu             }nulla pariatur. Excepteur sint           |
             o{n: est            }t non proident, sunt in culpa            |
             qui officia deserunt mollit anim id est                   |
-          {3:[No Name] [+]                                               }|
-          {2:-- Keyword Local completion (^N^P) }{5:match 22 of 65}           |
+          {2:[No Name] [+]                                               }|
+          {5:-- Keyword Local completion (^N^P) }{6:match 22 of 65}           |
         ]])
       end
 
@@ -3163,9 +3012,9 @@ describe('builtin popupmenu', function()
           grid = [[
           ## grid 1
             [4:------------------------------------------------------------]|*6
-            {4:[No Name] [+]                                               }|
-            [2:------------------------------------------------------------]|*5
             {3:[No Name] [+]                                               }|
+            [2:------------------------------------------------------------]|*5
+            {2:[No Name] [+]                                               }|
             [3:------------------------------------------------------------]|
           ## grid 2
               ea commodo consequat. Duis aute irure dolor in            |
@@ -3174,7 +3023,7 @@ describe('builtin popupmenu', function()
               occaecat cupidatat non proident, sunt in culpa            |
               qui officia deserunt mollit anim id est                   |
           ## grid 3
-            {2:-- Keyword Local completion (^N^P) }{5:match 1 of 9}             |
+            {5:-- Keyword Local completion (^N^P) }{6:match 1 of 9}             |
           ## grid 4
             Est eu^                                                      |
               Lorem ipsum dolor sit amet, consectetur                   |
@@ -3183,7 +3032,7 @@ describe('builtin popupmenu', function()
               Ut enim ad minim veniam, quis nostrud                     |
               exercitation ullamco laboris nisi ut aliquip ex           |
           ## grid 5
-            {s: ea                 }|
+            {12: ea                 }|
             {n: eeeeeeeeeeeeeeeeee }|
             {n: ei                 }|
             {n: eo                 }|
@@ -3198,19 +3047,19 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           Est eu^                                                      |
-            {s: ea                 }t amet, consectetur                   |
+            {12: ea                 }t amet, consectetur                   |
             {n: eeeeeeeeeeeeeeeeee }d do eiusmod tempor                   |
             {n: ei                 } et dolore magna aliqua.              |
             {n: eo                 }iam, quis nostrud                     |
             {n: eu                 } laboris nisi ut aliquip ex           |
-          {4:[N}{n: ey                 }{4:                                      }|
+          {3:[N}{n: ey                 }{3:                                      }|
             {n: eå                 }. Duis aute irure dolor in            |
             {n: eä                 }uptate velit esse cillum              |
             {n: eö                 }la pariatur. Excepteur sint           |
             occaecat cupidatat non proident, sunt in culpa            |
             qui officia deserunt mollit anim id est                   |
-          {3:[No Name] [+]                                               }|
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 9}             |
+          {2:[No Name] [+]                                               }|
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 9}             |
         ]])
       end
 
@@ -3220,9 +3069,9 @@ describe('builtin popupmenu', function()
           grid = [[
           ## grid 1
             [4:------------------------------------------------------------]|*6
-            {4:[No Name] [+]                                               }|
-            [2:------------------------------------------------------------]|*5
             {3:[No Name] [+]                                               }|
+            [2:------------------------------------------------------------]|*5
+            {2:[No Name] [+]                                               }|
             [3:------------------------------------------------------------]|
           ## grid 2
               ea commodo consequat. Duis aute irure dolor in            |
@@ -3231,7 +3080,7 @@ describe('builtin popupmenu', function()
               occaecat cupidatat non proident, sunt in culpa            |
               qui officia deserunt mollit anim id est                   |
           ## grid 3
-            {2:-- INSERT --}                                                |
+            {5:-- INSERT --}                                                |
           ## grid 4
             Est eu^                                                      |
               Lorem ipsum dolor sit amet, consectetur                   |
@@ -3240,7 +3089,7 @@ describe('builtin popupmenu', function()
               Ut enim ad minim veniam, quis nostrud                     |
               exercitation ullamco laboris nisi ut aliquip ex           |
           ## grid 5
-            {s: ea             }|
+            {12: ea             }|
             {n: eee            }|
             {n: ei             }|
             {n: eo             }|
@@ -3255,19 +3104,19 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           Est eu^                                                      |
-            {s: ea             }r sit amet, consectetur                   |
+            {12: ea             }r sit amet, consectetur                   |
             {n: eee            }, sed do eiusmod tempor                   |
             {n: ei             }bore et dolore magna aliqua.              |
             {n: eo             } veniam, quis nostrud                     |
             {n: eu             }amco laboris nisi ut aliquip ex           |
-          {4:[N}{n: ey             }{4:                                          }|
+          {3:[N}{n: ey             }{3:                                          }|
             {n: eå             }quat. Duis aute irure dolor in            |
             {n: eä             } voluptate velit esse cillum              |
             {n: eö             } nulla pariatur. Excepteur sint           |
             occaecat cupidatat non proident, sunt in culpa            |
             qui officia deserunt mollit anim id est                   |
-          {3:[No Name] [+]                                               }|
-          {2:-- INSERT --}                                                |
+          {2:[No Name] [+]                                               }|
+          {5:-- INSERT --}                                                |
         ]])
       end
 
@@ -3277,9 +3126,9 @@ describe('builtin popupmenu', function()
           grid = [[
           ## grid 1
             [4:------------------------------------------------------------]|*6
-            {4:[No Name] [+]                                               }|
-            [2:------------------------------------------------------------]|*5
             {3:[No Name] [+]                                               }|
+            [2:------------------------------------------------------------]|*5
+            {2:[No Name] [+]                                               }|
             [3:------------------------------------------------------------]|
           ## grid 2
               ea commodo consequat. Duis aute irure dolor in            |
@@ -3288,7 +3137,7 @@ describe('builtin popupmenu', function()
               occaecat cupidatat non proident, sunt in culpa            |
               qui officia deserunt mollit anim id est                   |
           ## grid 3
-            {2:-- INSERT --}                                                |
+            {5:-- INSERT --}                                                |
           ## grid 4
             Esteee^                                                      |
               Lorem ipsum dolor sit amet, consectetur                   |
@@ -3298,7 +3147,7 @@ describe('builtin popupmenu', function()
               exercitation ullamco laboris nisi ut aliquip ex           |
           ## grid 5
             {n: ea             }|
-            {s: eee            }|
+            {12: eee            }|
             {n: ei             }|
             {n: eo             }|
             {n: eu             }|
@@ -3313,18 +3162,18 @@ describe('builtin popupmenu', function()
         screen:expect([[
           Esteee^                                                      |
             {n: ea             }r sit amet, consectetur                   |
-            {s: eee            }, sed do eiusmod tempor                   |
+            {12: eee            }, sed do eiusmod tempor                   |
             {n: ei             }bore et dolore magna aliqua.              |
             {n: eo             } veniam, quis nostrud                     |
             {n: eu             }amco laboris nisi ut aliquip ex           |
-          {4:[N}{n: ey             }{4:                                          }|
+          {3:[N}{n: ey             }{3:                                          }|
             {n: eå             }quat. Duis aute irure dolor in            |
             {n: eä             } voluptate velit esse cillum              |
             {n: eö             } nulla pariatur. Excepteur sint           |
             occaecat cupidatat non proident, sunt in culpa            |
             qui officia deserunt mollit anim id est                   |
-          {3:[No Name] [+]                                               }|
-          {2:-- INSERT --}                                                |
+          {2:[No Name] [+]                                               }|
+          {5:-- INSERT --}                                                |
         ]])
       end
 
@@ -3334,9 +3183,9 @@ describe('builtin popupmenu', function()
           grid = [[
           ## grid 1
             [4:------------------------------------------------------------]|*6
-            {4:[No Name] [+]                                               }|
-            [2:------------------------------------------------------------]|*5
             {3:[No Name] [+]                                               }|
+            [2:------------------------------------------------------------]|*5
+            {2:[No Name] [+]                                               }|
             [3:------------------------------------------------------------]|
           ## grid 2
               ea commodo consequat. Duis aute irure dolor in            |
@@ -3345,7 +3194,7 @@ describe('builtin popupmenu', function()
               occaecat cupidatat non proident, sunt in culpa            |
               qui officia deserunt mollit anim id est                   |
           ## grid 3
-            {2:-- INSERT --}                                                |
+            {5:-- INSERT --}                                                |
           ## grid 4
             Esteee^                                                      |
               Lorem ipsum dolor sit amet, consectetur                   |
@@ -3354,7 +3203,7 @@ describe('builtin popupmenu', function()
               Ut enim ad minim veniam, quis nostrud                     |
               exercitation ullamco laboris nisi ut aliquip ex           |
           ## grid 5
-            {s: foo            }|
+            {12: foo            }|
             {n: bar            }|
           ]],
           float_pos = { [5] = { -1, 'NW', 4, 1, 4, false, 100, 1, 1, 4 } },
@@ -3362,31 +3211,30 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           Esteee^                                                      |
-            Lo{s: foo            }sit amet, consectetur                   |
+            Lo{12: foo            }sit amet, consectetur                   |
             ad{n: bar            }sed do eiusmod tempor                   |
             incididunt ut labore et dolore magna aliqua.              |
             Ut enim ad minim veniam, quis nostrud                     |
             exercitation ullamco laboris nisi ut aliquip ex           |
-          {4:[No Name] [+]                                               }|
+          {3:[No Name] [+]                                               }|
             ea commodo consequat. Duis aute irure dolor in            |
             reprehenderit in voluptate velit esse cillum              |
             dolore eu fugiat nulla pariatur. Excepteur sint           |
             occaecat cupidatat non proident, sunt in culpa            |
             qui officia deserunt mollit anim id est                   |
-          {3:[No Name] [+]                                               }|
-          {2:-- INSERT --}                                                |
+          {2:[No Name] [+]                                               }|
+          {5:-- INSERT --}                                                |
         ]])
       end
 
       feed('<c-y>')
       if multigrid then
-        screen:expect({
-          grid = [[
+        screen:expect([[
           ## grid 1
             [4:------------------------------------------------------------]|*6
-            {4:[No Name] [+]                                               }|
-            [2:------------------------------------------------------------]|*5
             {3:[No Name] [+]                                               }|
+            [2:------------------------------------------------------------]|*5
+            {2:[No Name] [+]                                               }|
             [3:------------------------------------------------------------]|
           ## grid 2
               ea commodo consequat. Duis aute irure dolor in            |
@@ -3395,7 +3243,7 @@ describe('builtin popupmenu', function()
               occaecat cupidatat non proident, sunt in culpa            |
               qui officia deserunt mollit anim id est                   |
           ## grid 3
-            {2:-- INSERT --}                                                |
+            {5:-- INSERT --}                                                |
           ## grid 4
             Esteefoo^                                                    |
               Lorem ipsum dolor sit amet, consectetur                   |
@@ -3403,8 +3251,7 @@ describe('builtin popupmenu', function()
               incididunt ut labore et dolore magna aliqua.              |
               Ut enim ad minim veniam, quis nostrud                     |
               exercitation ullamco laboris nisi ut aliquip ex           |
-          ]],
-        })
+          ]])
       else
         screen:expect([[
           Esteefoo^                                                    |
@@ -3413,14 +3260,14 @@ describe('builtin popupmenu', function()
             incididunt ut labore et dolore magna aliqua.              |
             Ut enim ad minim veniam, quis nostrud                     |
             exercitation ullamco laboris nisi ut aliquip ex           |
-          {4:[No Name] [+]                                               }|
+          {3:[No Name] [+]                                               }|
             ea commodo consequat. Duis aute irure dolor in            |
             reprehenderit in voluptate velit esse cillum              |
             dolore eu fugiat nulla pariatur. Excepteur sint           |
             occaecat cupidatat non proident, sunt in culpa            |
             qui officia deserunt mollit anim id est                   |
-          {3:[No Name] [+]                                               }|
-          {2:-- INSERT --}                                                |
+          {2:[No Name] [+]                                               }|
+          {5:-- INSERT --}                                                |
         ]])
       end
     end)
@@ -3440,7 +3287,7 @@ describe('builtin popupmenu', function()
             some long prefix before the ^    |
             {1:~                               }|*18
           ## grid 3
-            {2:-- INSERT --}                    |
+            {5:-- INSERT --}                    |
           ## grid 4
             {n: word  }|
             {n: choice}|
@@ -3457,7 +3304,7 @@ describe('builtin popupmenu', function()
           {1:~                        }{n: text  }|
           {1:~                        }{n: thing }|
           {1:~                               }|*14
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
 
@@ -3473,12 +3320,12 @@ describe('builtin popupmenu', function()
             thing^                           |
             {1:~                               }|*17
           ## grid 3
-            {2:-- INSERT --}                    |
+            {5:-- INSERT --}                    |
           ## grid 4
             {n:word           }|
             {n:choice         }|
             {n:text           }|
-            {s:thing          }|
+            {12:thing          }|
           ]],
           float_pos = { [4] = { -1, 'NW', 2, 2, 0, false, 100, 1, 2, 0 } },
         })
@@ -3489,9 +3336,9 @@ describe('builtin popupmenu', function()
           {n:word           }{1:                 }|
           {n:choice         }{1:                 }|
           {n:text           }{1:                 }|
-          {s:thing          }{1:                 }|
+          {12:thing          }{1:                 }|
           {1:~                               }|*13
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
 
@@ -3507,11 +3354,11 @@ describe('builtin popupmenu', function()
             {1:^~                               }|
             {1:~                               }|*17
           ## grid 3
-            {2:-- INSERT --}                    |
+            {5:-- INSERT --}                    |
           ## grid 4
             {n: word  }|
             {n: choice}|
-            {s: text  }|
+            {12: text  }|
             {n: thing }|
           ]],
           float_pos = { [4] = { -1, 'NW', 2, 1, 25, false, 100, 1, 1, 25 } },
@@ -3521,10 +3368,10 @@ describe('builtin popupmenu', function()
           some long prefix before the text|
           {1:^~                        }{n: word  }|
           {1:~                        }{n: choice}|
-          {1:~                        }{s: text  }|
+          {1:~                        }{12: text  }|
           {1:~                        }{n: thing }|
           {1:~                               }|*14
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
 
@@ -3540,11 +3387,11 @@ describe('builtin popupmenu', function()
             text^                          |
             {1:~                             }|*5
           ## grid 3
-            {2:-- INSERT --}                  |
+            {5:-- INSERT --}                  |
           ## grid 4
             {n:word           }|
             {n:choice         }|
-            {s:text           }|
+            {12:text           }|
             {n:thing          }|
           ]],
           float_pos = { [4] = { -1, 'NW', 2, 2, 0, false, 100, 1, 2, 0 } },
@@ -3555,10 +3402,10 @@ describe('builtin popupmenu', function()
           text^                          |
           {n:word           }{1:               }|
           {n:choice         }{1:               }|
-          {s:text           }{1:               }|
+          {12:text           }{1:               }|
           {n:thing          }{1:               }|
           {1:~                             }|
-          {2:-- INSERT --}                  |
+          {5:-- INSERT --}                  |
         ]])
       end
 
@@ -3573,11 +3420,11 @@ describe('builtin popupmenu', function()
             some long prefix before the text^                  |
             {1:~                                                 }|*6
           ## grid 3
-            {2:-- INSERT --}                                      |
+            {5:-- INSERT --}                                      |
           ## grid 4
             {n: word           }|
             {n: choice         }|
-            {s: text           }|
+            {12: text           }|
             {n: thing          }|
           ]],
           float_pos = { [4] = { -1, 'NW', 2, 1, 27, false, 100, 1, 1, 27 } },
@@ -3587,10 +3434,10 @@ describe('builtin popupmenu', function()
           some long prefix before the text^                  |
           {1:~                          }{n: word           }{1:       }|
           {1:~                          }{n: choice         }{1:       }|
-          {1:~                          }{s: text           }{1:       }|
+          {1:~                          }{12: text           }{1:       }|
           {1:~                          }{n: thing          }{1:       }|
           {1:~                                                 }|*2
-          {2:-- INSERT --}                                      |
+          {5:-- INSERT --}                                      |
         ]])
       end
 
@@ -3606,11 +3453,11 @@ describe('builtin popupmenu', function()
             the text^                 |
             {1:~                        }|*7
           ## grid 3
-            {2:-- INSERT --}             |
+            {5:-- INSERT --}             |
           ## grid 4
             {n: word           }|
             {n: choice         }|
-            {s: text           }|
+            {12: text           }|
             {n: thing          }|
           ]],
           float_pos = { [4] = { -1, 'NW', 2, 2, 3, false, 100, 1, 2, 3 } },
@@ -3621,10 +3468,10 @@ describe('builtin popupmenu', function()
           the text^                 |
           {1:~  }{n: word           }{1:      }|
           {1:~  }{n: choice         }{1:      }|
-          {1:~  }{s: text           }{1:      }|
+          {1:~  }{12: text           }{1:      }|
           {1:~  }{n: thing          }{1:      }|
           {1:~                        }|*3
-          {2:-- INSERT --}             |
+          {5:-- INSERT --}             |
         ]])
       end
 
@@ -3641,11 +3488,11 @@ describe('builtin popupmenu', function()
             before the  |
             text^        |
           ## grid 3
-            {2:-- INSERT --}|
+            {5:-- INSERT --}|
           ## grid 4
             {n: word           }|
             {n: choice         }|
-            {s: text           }|
+            {12: text           }|
             {n: thing          }|
           ]],
           float_pos = { [4] = { -1, 'NW', 2, 2, 3, false, 100, 1, 2, 3 } },
@@ -3656,7 +3503,7 @@ describe('builtin popupmenu', function()
           prefix      |
           bef{n: word  }  |
           tex{n: }^        |
-          {2:-- INSERT --}|
+          {5:-- INSERT --}|
         ]])
       end
 
@@ -3671,11 +3518,11 @@ describe('builtin popupmenu', function()
           ## grid 2
             {1:<<<}t^        |
           ## grid 3
-            {2:-- INSERT --}|
+            {5:-- INSERT --}|
           ## grid 4
             {n: word           }|
             {n: choice         }|
-            {s: text           }|
+            {12: text           }|
             {n: thing          }|
           ]],
           float_pos = { [4] = { -1, 'NW', 2, 2, 3, false, 100, 1, 2, 3 } },
@@ -3683,7 +3530,7 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           {1:<<<}t^        |
-          {2:-- INSERT --}|
+          {5:-- INSERT --}|
         ]])
       end
 
@@ -3700,11 +3547,11 @@ describe('builtin popupmenu', function()
             before the text^     |
             {1:~                   }|*5
           ## grid 3
-            {2:-- INSERT --}        |
+            {5:-- INSERT --}        |
           ## grid 4
             {n: word    }|
             {n: choice  }|
-            {s: text    }|
+            {12: text    }|
             {n: thing   }|
           ]],
           float_pos = { [4] = { -1, 'NW', 2, 2, 10, false, 100, 1, 2, 10 } },
@@ -3715,10 +3562,10 @@ describe('builtin popupmenu', function()
           before the text^     |
           {1:~         }{n: word    }{1: }|
           {1:~         }{n: choice  }{1: }|
-          {1:~         }{s: text    }{1: }|
+          {1:~         }{12: text    }{1: }|
           {1:~         }{n: thing   }{1: }|
           {1:~                   }|
-          {2:-- INSERT --}        |
+          {5:-- INSERT --}        |
         ]])
       end
     end)
@@ -3739,7 +3586,7 @@ describe('builtin popupmenu', function()
             some long prefix before the ^    |
             {1:~                               }|*18
           ## grid 3
-            {2:-- INSERT --}                    |
+            {5:-- INSERT --}                    |
           ## grid 4
             {n: word  }|
             {n: choice}|
@@ -3756,7 +3603,7 @@ describe('builtin popupmenu', function()
           {1:~                        }{n: text  }|
           {1:~                        }{n: thing }|
           {1:~                               }|*14
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
 
@@ -3773,7 +3620,7 @@ describe('builtin popupmenu', function()
             the ^            |
             {1:~               }|*6
           ## grid 3
-            {2:-- INSERT --}    |
+            {5:-- INSERT --}    |
           ## grid 4
             {n: word        }|
             {n: choice      }|
@@ -3792,7 +3639,7 @@ describe('builtin popupmenu', function()
           {1:~  }{n: text        }|
           {1:~  }{n: thing       }|
           {1:~               }|*2
-          {2:-- INSERT --}    |
+          {5:-- INSERT --}    |
         ]])
       end
     end)
@@ -3801,8 +3648,7 @@ describe('builtin popupmenu', function()
       command('set rl wildoptions+=pum')
       feed('isome rightleft ')
       if multigrid then
-        screen:expect({
-          grid = [[
+        screen:expect([[
           ## grid 1
             [2:--------------------------------]|*19
             [3:--------------------------------]|
@@ -3810,14 +3656,13 @@ describe('builtin popupmenu', function()
                             ^  tfelthgir emos|
             {1:                               ~}|*18
           ## grid 3
-            {2:-- INSERT --}                    |
-          ]],
-        })
+            {5:-- INSERT --}                    |
+        ]])
       else
         screen:expect([[
                           ^  tfelthgir emos|
           {1:                               ~}|*18
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
 
@@ -3833,7 +3678,7 @@ describe('builtin popupmenu', function()
                             ^  tfelthgir emos|
             {1:                               ~}|*18
           ## grid 3
-            {2:-- INSERT --}                    |
+            {5:-- INSERT --}                    |
           ## grid 4
             {n:           drow }|
             {n:         eciohc }|
@@ -3850,7 +3695,7 @@ describe('builtin popupmenu', function()
           {1:  }{n:           txet }{1:             ~}|
           {1:  }{n:          gniht }{1:             ~}|
           {1:                               ~}|*14
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
 
@@ -3865,9 +3710,9 @@ describe('builtin popupmenu', function()
                         ^ drow tfelthgir emos|
             {1:                               ~}|*18
           ## grid 3
-            {2:-- INSERT --}                    |
+            {5:-- INSERT --}                    |
           ## grid 4
-            {s:           drow }|
+            {12:           drow }|
             {n:         eciohc }|
             {n:           txet }|
             {n:          gniht }|
@@ -3877,19 +3722,18 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
                       ^ drow tfelthgir emos|
-          {1:  }{s:           drow }{1:             ~}|
+          {1:  }{12:           drow }{1:             ~}|
           {1:  }{n:         eciohc }{1:             ~}|
           {1:  }{n:           txet }{1:             ~}|
           {1:  }{n:          gniht }{1:             ~}|
           {1:                               ~}|*14
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
 
       feed('<c-y>')
       if multigrid then
-        screen:expect({
-          grid = [[
+        screen:expect([[
           ## grid 1
             [2:--------------------------------]|*19
             [3:--------------------------------]|
@@ -3897,22 +3741,20 @@ describe('builtin popupmenu', function()
                         ^ drow tfelthgir emos|
             {1:                               ~}|*18
           ## grid 3
-            {2:-- INSERT --}                    |
-          ]],
-        })
+            {5:-- INSERT --}                    |
+        ]])
       else
         screen:expect([[
                       ^ drow tfelthgir emos|
           {1:                               ~}|*18
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
 
       -- not rightleft on the cmdline
       feed('<esc>:sign ')
       if multigrid then
-        screen:expect({
-          grid = [[
+        screen:expect([[
           ## grid 1
             [2:--------------------------------]|*19
             [3:--------------------------------]|
@@ -3921,16 +3763,13 @@ describe('builtin popupmenu', function()
             {1:                               ~}|*18
           ## grid 3
             :sign ^                          |
-          ]],
-        })
+        ]])
       else
-        screen:expect {
-          grid = [[
+        screen:expect([[
                        drow tfelthgir emos|
           {1:                               ~}|*18
           :sign ^                          |
-        ]],
-        }
+        ]])
       end
 
       -- oldtest: Test_wildmenu_pum_rightleft()
@@ -3947,7 +3786,7 @@ describe('builtin popupmenu', function()
           ## grid 3
             :sign define^                    |
           ## grid 4
-            {s: define         }|
+            {12: define         }|
             {n: jump           }|
             {n: list           }|
             {n: place          }|
@@ -3957,19 +3796,17 @@ describe('builtin popupmenu', function()
           float_pos = { [4] = { -1, 'SW', 1, 19, 5, false, 250, 2, 13, 5 } },
         })
       else
-        screen:expect {
-          grid = [[
+        screen:expect([[
                        drow tfelthgir emos|
           {1:                               ~}|*12
-          {1:     }{s: define         }{1:          ~}|
+          {1:     }{12: define         }{1:          ~}|
           {1:     }{n: jump           }{1:          ~}|
           {1:     }{n: list           }{1:          ~}|
           {1:     }{n: place          }{1:          ~}|
           {1:     }{n: undefine       }{1:          ~}|
           {1:     }{n: unplace        }{1:          ~}|
           :sign define^                    |
-        ]],
-        }
+        ]])
       end
     end)
 
@@ -3986,19 +3823,19 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [2:-------------------]│[4:--------------------]|*4
-          {3:[No Name] [+]       }{4:[No Name] [+]       }|
+          {2:[No Name] [+]       }{3:[No Name] [+]       }|
           [3:----------------------------------------]|
         ## grid 2
                tfelthgir emos|
           {1:                  ~}|*3
         ## grid 3
-          {2:-- INSERT --}                            |
+          {5:-- INSERT --}                            |
         ## grid 4
               ^  tfelthgir emos|
           {1:                   ~}|*3
         ## grid 5
           {c: }{n:           drow }|
-          {s: }{n:         eciohc }|
+          {12: }{n:         eciohc }|
         ]],
           float_pos = { [5] = { -1, 'NW', 4, 1, -11, false, 100, 1, 1, 9 } },
         }
@@ -4006,10 +3843,10 @@ describe('builtin popupmenu', function()
         screen:expect([[
                tfelthgir emos│    ^  tfelthgir emos|
           {1:         }{c: }{n:           drow }{1:             ~}|
-          {1:         }{s: }{n:         eciohc }{1:             ~}|
+          {1:         }{12: }{n:         eciohc }{1:             ~}|
           {1:                  ~}│{1:                   ~}|
-          {3:[No Name] [+]       }{4:[No Name] [+]       }|
-          {2:-- INSERT --}                            |
+          {2:[No Name] [+]       }{3:[No Name] [+]       }|
+          {5:-- INSERT --}                            |
         ]])
       end
       feed('<C-E><CR>')
@@ -4019,21 +3856,21 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [2:-------------------]│[4:--------------------]|*4
-          {3:[No Name] [+]       }{4:[No Name] [+]       }|
+          {2:[No Name] [+]       }{3:[No Name] [+]       }|
           [3:----------------------------------------]|
         ## grid 2
                tfelthgir emos|
                              |
           {1:                  ~}|*2
         ## grid 3
-          {2:-- INSERT --}                            |
+          {5:-- INSERT --}                            |
         ## grid 4
                 tfelthgir emos|
                              ^ |
           {1:                   ~}|*2
         ## grid 5
           {c: }{n:           drow}|
-          {s: }{n:         eciohc}|
+          {12: }{n:         eciohc}|
         ]],
           float_pos = { [5] = { -1, 'NW', 4, 2, 4, false, 100, 1, 2, 24 } },
         }
@@ -4042,19 +3879,18 @@ describe('builtin popupmenu', function()
                tfelthgir emos│      tfelthgir emos|
                              │                   ^ |
           {1:                  ~}│{1:    }{c: }{n:           drow}|
-          {1:                  ~}│{1:    }{s: }{n:         eciohc}|
-          {3:[No Name] [+]       }{4:[No Name] [+]       }|
-          {2:-- INSERT --}                            |
+          {1:                  ~}│{1:    }{12: }{n:         eciohc}|
+          {2:[No Name] [+]       }{3:[No Name] [+]       }|
+          {5:-- INSERT --}                            |
         ]])
       end
       feed('<C-E>')
       async_meths.nvim_call_function('input', { '', '', 'sign' })
       if multigrid then
-        screen:expect {
-          grid = [[
+        screen:expect([[
         ## grid 1
           [2:-------------------]│[4:--------------------]|*4
-          {3:[No Name] [+]       }{4:[No Name] [+]       }|
+          {2:[No Name] [+]       }{3:[No Name] [+]       }|
           [3:----------------------------------------]|
         ## grid 2
                tfelthgir emos|
@@ -4066,14 +3902,13 @@ describe('builtin popupmenu', function()
                 tfelthgir emos|
                               |
           {1:                   ~}|*2
-        ]],
-        }
+        ]])
       else
         screen:expect([[
                tfelthgir emos│      tfelthgir emos|
                              │                    |
           {1:                  ~}│{1:                   ~}|*2
-          {3:[No Name] [+]       }{4:[No Name] [+]       }|
+          {2:[No Name] [+]       }{3:[No Name] [+]       }|
           ^                                        |
         ]])
       end
@@ -4084,7 +3919,7 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [2:-------------------]│[4:--------------------]|*4
-          {3:[No Name] [+]       }{4:[No Name] [+]       }|
+          {2:[No Name] [+]       }{3:[No Name] [+]       }|
           [3:----------------------------------------]|
         ## grid 2
                tfelthgir emos|
@@ -4097,8 +3932,8 @@ describe('builtin popupmenu', function()
                               |
           {1:                   ~}|*2
         ## grid 5
-          {s:define         }{c: }|
-          {n:jump           }{s: }|
+          {12:define         }{c: }|
+          {n:jump           }{12: }|
         ]],
           float_pos = { [5] = { -1, 'SW', 1, 5, 0, false, 250, 2, 3, 0 } },
         }
@@ -4107,8 +3942,8 @@ describe('builtin popupmenu', function()
                tfelthgir emos│      tfelthgir emos|
                              │                    |
           {1:                  ~}│{1:                   ~}|
-          {s:define         }{c: }{1:  ~}│{1:                   ~}|
-          {n:jump           }{s: }{3:    }{4:[No Name] [+]       }|
+          {12:define         }{c: }{1:  ~}│{1:                   ~}|
+          {n:jump           }{12: }{2:    }{3:[No Name] [+]       }|
           define^                                  |
         ]])
       end
@@ -4130,9 +3965,9 @@ describe('builtin popupmenu', function()
           word^                                    |
           {1:~                                       }|*5
         ## grid 3
-          {2:-- INSERT --}                            |
+          {5:-- INSERT --}                            |
         ## grid 4
-          {s:word           }|
+          {12:word           }|
           {n:choice         }|
           {n:text           }|
           {n:thing          }|
@@ -4143,12 +3978,12 @@ describe('builtin popupmenu', function()
         screen:expect([[
           xx                                      |
           word^                                    |
-          {s:word           }{1:                         }|
+          {12:word           }{1:                         }|
           {n:choice         }{1:                         }|
           {n:text           }{1:                         }|
           {n:thing          }{1:                         }|
           {1:~                                       }|
-          {2:-- INSERT --}                            |
+          {5:-- INSERT --}                            |
         ]])
       end
 
@@ -4164,12 +3999,12 @@ describe('builtin popupmenu', function()
           word                                    |
           {1:~                                       }|*5
         ## grid 3
-          {6:very}                                    |
-          {6:much}                                    |
-          {6:error}                                   |
-          {5:Press ENTER or type command to continue}^ |
+          {9:very}                                    |
+          {9:much}                                    |
+          {9:error}                                   |
+          {6:Press ENTER or type command to continue}^ |
         ## grid 4
-          {s:word           }|
+          {12:word           }|
           {n:choice         }|
           {n:text           }|
           {n:thing          }|
@@ -4180,12 +4015,12 @@ describe('builtin popupmenu', function()
         screen:expect([[
           xx                                      |
           word                                    |
-          {s:word           }{1:                         }|
-          {4:                                        }|
-          {6:very}                                    |
-          {6:much}                                    |
-          {6:error}                                   |
-          {5:Press ENTER or type command to continue}^ |
+          {12:word           }{1:                         }|
+          {3:                                        }|
+          {9:very}                                    |
+          {9:much}                                    |
+          {9:error}                                   |
+          {6:Press ENTER or type command to continue}^ |
         ]])
       end
 
@@ -4201,9 +4036,9 @@ describe('builtin popupmenu', function()
           word^                                    |
           {1:~                                       }|*5
         ## grid 3
-          {2:-- INSERT --}                            |
+          {5:-- INSERT --}                            |
         ## grid 4
-          {s:word           }|
+          {12:word           }|
           {n:choice         }|
           {n:text           }|
           {n:thing          }|
@@ -4214,12 +4049,12 @@ describe('builtin popupmenu', function()
         screen:expect([[
           xx                                      |
           word^                                    |
-          {s:word           }{1:                         }|
+          {12:word           }{1:                         }|
           {n:choice         }{1:                         }|
           {n:text           }{1:                         }|
           {n:thing          }{1:                         }|
           {1:~                                       }|
-          {2:-- INSERT --}                            |
+          {5:-- INSERT --}                            |
         ]])
       end
 
@@ -4235,10 +4070,10 @@ describe('builtin popupmenu', function()
           choice^                                  |
           {1:~                                       }|*5
         ## grid 3
-          {2:-- INSERT --}                            |
+          {5:-- INSERT --}                            |
         ## grid 4
           {n:word           }|
-          {s:choice         }|
+          {12:choice         }|
           {n:text           }|
           {n:thing          }|
         ]],
@@ -4249,11 +4084,11 @@ describe('builtin popupmenu', function()
           xx                                      |
           choice^                                  |
           {n:word           }{1:                         }|
-          {s:choice         }{1:                         }|
+          {12:choice         }{1:                         }|
           {n:text           }{1:                         }|
           {n:thing          }{1:                         }|
           {1:~                                       }|
-          {2:-- INSERT --}                            |
+          {5:-- INSERT --}                            |
         ]])
       end
 
@@ -4265,17 +4100,17 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [5:----------------------------------------]|*3
-          {4:[No Name] [+]                           }|
-          [2:----------------------------------------]|*2
           {3:[No Name] [+]                           }|
+          [2:----------------------------------------]|*2
+          {2:[No Name] [+]                           }|
           [3:----------------------------------------]|
         ## grid 2
           xx                                      |
           word                                    |
         ## grid 3
-          {2:-- INSERT --}                            |
+          {5:-- INSERT --}                            |
         ## grid 4
-          {s:word           }|
+          {12:word           }|
           {n:choice         }|
           {n:text           }|
           {n:thing          }|
@@ -4290,12 +4125,12 @@ describe('builtin popupmenu', function()
         screen:expect([[
           xx                                      |
           word^                                    |
-          {s:word           }{1:                         }|
-          {n:choice         }{4:                         }|
+          {12:word           }{1:                         }|
+          {n:choice         }{3:                         }|
           {n:text           }                         |
           {n:thing          }                         |
-          {3:[No Name] [+]                           }|
-          {2:-- INSERT --}                            |
+          {2:[No Name] [+]                           }|
+          {5:-- INSERT --}                            |
         ]])
       end
 
@@ -4305,17 +4140,17 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [5:----------------------------------------]|*3
-          {4:[No Name] [+]                           }|
-          [2:----------------------------------------]|*2
           {3:[No Name] [+]                           }|
+          [2:----------------------------------------]|*2
+          {2:[No Name] [+]                           }|
           [3:----------------------------------------]|
         ## grid 2
           word                                    |
           {1:~                                       }|
         ## grid 3
-          {2:-- INSERT --}                            |
+          {5:-- INSERT --}                            |
         ## grid 4
-          {s:word           }|
+          {12:word           }|
           {n:choice         }|
           {n:text           }|
           {n:thing          }|
@@ -4330,12 +4165,12 @@ describe('builtin popupmenu', function()
         screen:expect([[
           xx                                      |
           word^                                    |
-          {s:word           }{1:                         }|
-          {n:choice         }{4:                         }|
+          {12:word           }{1:                         }|
+          {n:choice         }{3:                         }|
           {n:text           }                         |
           {n:thing          }{1:                         }|
-          {3:[No Name] [+]                           }|
-          {2:-- INSERT --}                            |
+          {2:[No Name] [+]                           }|
+          {5:-- INSERT --}                            |
         ]])
       end
     end)
@@ -4351,11 +4186,11 @@ describe('builtin popupmenu', function()
         })
         screen:expect([[
           xx wordey^                               |
-          {1:~ }{s: wordey x extrainfo }{1:                  }|
+          {1:~ }{12: wordey x extrainfo }{1:                  }|
           {1:~ }{n: thing              }{1:                  }|
           {1:~ }{n: sneaky   bar       }{1:                  }|
           {1:~                                       }|*3
-          {2:-- INSERT --}                            |
+          {5:-- INSERT --}                            |
         ]])
 
         feed('<c-p>')
@@ -4365,7 +4200,7 @@ describe('builtin popupmenu', function()
           {1:~ }{n: thing              }{1:                  }|
           {1:~ }{n: sneaky   bar       }{1:                  }|
           {1:~                                       }|*3
-          {2:-- INSERT --}                            |
+          {5:-- INSERT --}                            |
         ]])
 
         feed('<c-p>')
@@ -4373,9 +4208,9 @@ describe('builtin popupmenu', function()
           xx secret^                               |
           {1:~ }{n: wordey x extrainfo }{1:                  }|
           {1:~ }{n: thing              }{1:                  }|
-          {1:~ }{s: sneaky   bar       }{1:                  }|
+          {1:~ }{12: sneaky   bar       }{1:                  }|
           {1:~                                       }|*3
-          {2:-- INSERT --}                            |
+          {5:-- INSERT --}                            |
         ]])
 
         feed('<esc>')
@@ -4404,7 +4239,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|*2
-          {1:~    }{s: define         }{1:           }|
+          {1:~    }{12: define         }{1:           }|
           {1:~    }{n: jump           }{1:           }|
           {1:~    }{n: list           }{1:           }|
           {1:~    }{n: place          }{1:           }|
@@ -4419,7 +4254,7 @@ describe('builtin popupmenu', function()
           {1:~                               }|*2
           {1:~    }{n: define         }{1:           }|
           {1:~    }{n: jump           }{1:           }|
-          {1:~    }{s: list           }{1:           }|
+          {1:~    }{12: list           }{1:           }|
           {1:~    }{n: place          }{1:           }|
           {1:~    }{n: undefine       }{1:           }|
           {1:~    }{n: unplace        }{1:           }|
@@ -4433,7 +4268,7 @@ describe('builtin popupmenu', function()
           {1:~    }{n: define         }{1:           }|
           {1:~    }{n: jump           }{1:           }|
           {1:~    }{n: list           }{1:           }|
-          {1:~    }{s: place          }{1:           }|
+          {1:~    }{12: place          }{1:           }|
           {1:~    }{n: undefine       }{1:           }|
           {1:~    }{n: unplace        }{1:           }|
           :sign place^                     |
@@ -4445,7 +4280,7 @@ describe('builtin popupmenu', function()
           {1:~                               }|*2
           {1:~    }{n: define         }{1:           }|
           {1:~    }{n: jump           }{1:           }|
-          {1:~    }{s: list           }{1:           }|
+          {1:~    }{12: list           }{1:           }|
           {1:~    }{n: place          }{1:           }|
           {1:~    }{n: undefine       }{1:           }|
           {1:~    }{n: unplace        }{1:           }|
@@ -4457,7 +4292,7 @@ describe('builtin popupmenu', function()
                                           |
           {1:~                               }|*2
           {1:~    }{n: define         }{1:           }|
-          {1:~    }{s: jump           }{1:           }|
+          {1:~    }{12: jump           }{1:           }|
           {1:~    }{n: list           }{1:           }|
           {1:~    }{n: place          }{1:           }|
           {1:~    }{n: undefine       }{1:           }|
@@ -4486,7 +4321,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|
-          {1:~           }{s: culhl=         }{1:    }|
+          {1:~           }{12: culhl=         }{1:    }|
           {1:~           }{n: icon=          }{1:    }|
           {1:~           }{n: linehl=        }{1:    }|
           {1:~           }{n: numhl=         }{1:    }|
@@ -4500,7 +4335,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|
-          {1:~                  }{s: culhl=     }{1: }|
+          {1:~                  }{12: culhl=     }{1: }|
           {1:~                  }{n: icon=      }{1: }|
           {1:~                  }{n: linehl=    }{1: }|
           {1:~                  }{n: numhl=     }{1: }|
@@ -4514,7 +4349,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|*6
-          {1:~          }{s: XdirA/         }{1:     }|
+          {1:~          }{12: XdirA/         }{1:     }|
           {1:~          }{n: XfileA         }{1:     }|
           :e Xnamedir/XdirA/^              |
         ]])
@@ -4524,7 +4359,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|*6
-          {1:~                }{s: XdirB/       }{1: }|
+          {1:~                }{12: XdirB/       }{1: }|
           {1:~                }{n: XfileB       }{1: }|
           :e Xnamedir/XdirA/XdirB/^        |
         ]])
@@ -4534,7 +4369,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|*6
-          {1:~          }{s: XdirA/         }{1:     }|
+          {1:~          }{12: XdirA/         }{1:     }|
           {1:~          }{n: XfileA         }{1:     }|
           :e Xnamedir/XdirA/^              |
         ]])
@@ -4545,7 +4380,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|*6
-          {4:                                }|
+          {3:                                }|
           :sign define jump list place und|
           efine unplace^                   |
         ]])
@@ -4555,7 +4390,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|*6
-          {4:                                }|
+          {3:                                }|
           :sign define jump list place und|
           efine unplac^e                   |
         ]])
@@ -4567,7 +4402,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|*5
-          {4:                                }|
+          {3:                                }|
           :sign define                    |
           define                          |
           :sign define^                    |
@@ -4582,7 +4417,7 @@ describe('builtin popupmenu', function()
           {1:~    }{n: jump           }{1:           }|
           {1:~    }{n: list           }{1:           }|
           {1:~    }{n: place          }{1:           }|
-          {1:~    }{s: undefine       }{1:           }|
+          {1:~    }{12: undefine       }{1:           }|
           {1:~    }{n: unplace        }{1:           }|
           :sign undefine^                  |
         ]])
@@ -4607,11 +4442,11 @@ describe('builtin popupmenu', function()
         feed('<C-U>sign <Tab><C-F>')
         screen:expect([[
                                           |
-          {3:[No Name]                       }|
+          {2:[No Name]                       }|
           {1::}sign define                    |
           {1::}sign define^                    |
           {1:~                               }|*4
-          {4:[Command Line]                  }|
+          {3:[Command Line]                  }|
           :sign define                    |
         ]])
         feed(':q<CR>')
@@ -4631,7 +4466,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|*4
-          {s: bufdo          }{1:                }|
+          {12: bufdo          }{1:                }|
           {n: buffer         }{1:                }|
           {n: buffers        }{1:                }|
           {n: bunload        }{1:                }|
@@ -4679,7 +4514,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|*3
-          {4:                                }|
+          {3:                                }|
           :cn                             |
           cnewer       cnoreabbrev        |
           cnext        cnoremap           |
@@ -4690,7 +4525,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|*3
-          {4:                                }|
+          {3:                                }|
           :cn                             |
           cnewer       cnoreabbrev        |
           cnext        cnoremap           |
@@ -4706,7 +4541,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|*5
-          {1:~        }{s: 123            }{1:       }|
+          {1:~        }{12: 123            }{1:       }|
           {1:~        }{n: abc            }{1:       }|
           {1:~        }{n: xyz            }{1:       }|
           :e あいう/123^                   |
@@ -4722,7 +4557,7 @@ describe('builtin popupmenu', function()
           {1:~    }{n: jump           }{1:           }|
           {1:~    }{n: list           }{1:           }|
           {1:~    }{n: place          }{1:           }|
-          {1:~    }{s: undefine       }{1:           }|
+          {1:~    }{12: undefine       }{1:           }|
           {1:~    }{n: unplace        }{1:           }|
           :sign undefine^                  |
         ]])
@@ -4735,7 +4570,7 @@ describe('builtin popupmenu', function()
           {1:~    }{n: list           }{1:           }|
           {1:~    }{n: place          }{1:           }|
           {1:~    }{n: undefine       }{1:           }|
-          {1:~    }{s: unplace        }{1:           }|
+          {1:~    }{12: unplace        }{1:           }|
           :sign unplace^                   |
         ]])
         feed('<PageDown>')
@@ -4754,7 +4589,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|*2
-          {1:~    }{s: define         }{1:           }|
+          {1:~    }{12: define         }{1:           }|
           {1:~    }{n: jump           }{1:           }|
           {1:~    }{n: list           }{1:           }|
           {1:~    }{n: place          }{1:           }|
@@ -4771,7 +4606,7 @@ describe('builtin popupmenu', function()
           {1:~    }{n: list           }{1:           }|
           {1:~    }{n: place          }{1:           }|
           {1:~    }{n: undefine       }{1:           }|
-          {1:~    }{s: unplace        }{1:           }|
+          {1:~    }{12: unplace        }{1:           }|
           :sign unplace^                   |
         ]])
 
@@ -4797,7 +4632,7 @@ describe('builtin popupmenu', function()
           {1:~    }{n: list           }{1:           }|
           {1:~    }{n: place          }{1:           }|
           {1:~    }{n: undefine       }{1:           }|
-          {1:~    }{s: unplace        }{1:           }|
+          {1:~    }{12: unplace        }{1:           }|
           :sign unplace^                   |
         ]])
         feed('<PageUp>')
@@ -4805,7 +4640,7 @@ describe('builtin popupmenu', function()
                                           |
           {1:~                               }|*2
           {1:~    }{n: define         }{1:           }|
-          {1:~    }{s: jump           }{1:           }|
+          {1:~    }{12: jump           }{1:           }|
           {1:~    }{n: list           }{1:           }|
           {1:~    }{n: place          }{1:           }|
           {1:~    }{n: undefine       }{1:           }|
@@ -4816,7 +4651,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|*2
-          {1:~    }{s: define         }{1:           }|
+          {1:~    }{12: define         }{1:           }|
           {1:~    }{n: jump           }{1:           }|
           {1:~    }{n: list           }{1:           }|
           {1:~    }{n: place          }{1:           }|
@@ -4830,7 +4665,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|*6
-          {1:~   }{s: wildchar       }{1:            }|
+          {1:~   }{12: wildchar       }{1:            }|
           {1:~   }{n: wildcharm      }{1:            }|
           :set wildchar^zz                 |
         ]])
@@ -4858,11 +4693,11 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|*3
-          {4:långfile2                       }|
+          {3:långfile2                       }|
                                           |
           {1:~                               }|
-          {1:~ }{s: långfile1      }{1:              }|
-          {3:lå}{n: långfile2      }{3:              }|
+          {1:~ }{12: långfile1      }{1:              }|
+          {2:lå}{n: långfile2      }{2:              }|
           :b långfile1^                    |
         ]])
 
@@ -4871,9 +4706,9 @@ describe('builtin popupmenu', function()
         screen:expect([[
                               |
           {1:~                   }|
-          {4:långfile2           }|
-            {s: långfile1      }  |
-          {3:lå}{n: långfile2      }{3:  }|
+          {3:långfile2           }|
+            {12: långfile1      }  |
+          {2:lå}{n: långfile2      }{2:  }|
           :b långfile1^        |
         ]])
 
@@ -4881,11 +4716,11 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                                             |
           {1:~                                                 }|
-          {4:långfile2                                         }|
+          {3:långfile2                                         }|
                                                             |
           {1:~                                                 }|*8
-          {1:~ }{s: långfile1      }{1:                                }|
-          {3:lå}{n: långfile2      }{3:                                }|
+          {1:~ }{12: långfile1      }{1:                                }|
+          {2:lå}{n: långfile2      }{2:                                }|
           :b långfile1^                                      |
         ]])
 
@@ -4896,11 +4731,11 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                                             |
           {1:~                                                 }|
-          {4:långfile2                                         }|
+          {3:långfile2                                         }|
                                                             |
           {1:~                                                 }|*8
           {1:~ }{n: långfile1      }{1:                                }|
-          {3:lå}{n: långfile2      }{3:                                }|
+          {2:lå}{n: långfile2      }{2:                                }|
           :b långfile^                                       |
         ]])
 
@@ -4914,7 +4749,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                                             |
           {1:~                                                 }|*11
-          {1:~         }{s: file1          }{1:                        }|
+          {1:~         }{12: file1          }{1:                        }|
           {1:~         }{n: file2          }{1:                        }|
           :e compdir/file1^                                  |
         ]])
@@ -4928,8 +4763,7 @@ describe('builtin popupmenu', function()
 
       feed(':echoerr "fail"|echoerr "error"<cr>')
       if multigrid then
-        screen:expect({
-          grid = [[
+        screen:expect([[
           ## grid 1
             [2:----------------------------------------]|*7
             [3:----------------------------------------]|*3
@@ -4937,22 +4771,19 @@ describe('builtin popupmenu', function()
                                                     |
             {1:~                                       }|*8
           ## grid 3
-            {6:fail}                                    |
-            {6:error}                                   |
-            {5:Press ENTER or type command to continue}^ |
-          ]],
-        })
+            {9:fail}                                    |
+            {9:error}                                   |
+            {6:Press ENTER or type command to continue}^ |
+        ]])
       else
-        screen:expect {
-          grid = [[
+        screen:expect([[
                                                   |
           {1:~                                       }|*5
-          {4:                                        }|
-          {6:fail}                                    |
-          {6:error}                                   |
-          {5:Press ENTER or type command to continue}^ |
-        ]],
-        }
+          {3:                                        }|
+          {9:fail}                                    |
+          {9:error}                                   |
+          {6:Press ENTER or type command to continue}^ |
+        ]])
       end
 
       feed(':sign <tab>')
@@ -4966,11 +4797,11 @@ describe('builtin popupmenu', function()
                                                     |
             {1:~                                       }|*8
           ## grid 3
-            {6:fail}                                    |
-            {6:error}                                   |
+            {9:fail}                                    |
+            {9:error}                                   |
             :sign define^                            |
           ## grid 4
-            {s: define         }|
+            {12: define         }|
             {n: jump           }|
             {n: list           }|
             {n: place          }|
@@ -4980,25 +4811,22 @@ describe('builtin popupmenu', function()
           float_pos = { [4] = { -1, 'SW', 1, 9, 5, false, 250, 2, 3, 5 } },
         })
       else
-        screen:expect {
-          grid = [[
+        screen:expect([[
                                                   |
           {1:~                                       }|*2
-          {1:~    }{s: define         }{1:                   }|
+          {1:~    }{12: define         }{1:                   }|
           {1:~    }{n: jump           }{1:                   }|
           {1:~    }{n: list           }{1:                   }|
-          {4:     }{n: place          }{4:                   }|
-          {6:fail} {n: undefine       }                   |
-          {6:error}{n: unplace        }                   |
+          {3:     }{n: place          }{3:                   }|
+          {9:fail} {n: undefine       }                   |
+          {9:error}{n: unplace        }                   |
           :sign define^                            |
-        ]],
-        }
+        ]])
       end
 
       feed('d')
       if multigrid then
-        screen:expect({
-          grid = [[
+        screen:expect([[
           ## grid 1
             [2:----------------------------------------]|*7
             [3:----------------------------------------]|*3
@@ -5006,22 +4834,19 @@ describe('builtin popupmenu', function()
                                                     |
             {1:~                                       }|*8
           ## grid 3
-            {6:fail}                                    |
-            {6:error}                                   |
+            {9:fail}                                    |
+            {9:error}                                   |
             :sign defined^                           |
-          ]],
-        })
+        ]])
       else
-        screen:expect {
-          grid = [[
+        screen:expect([[
                                                   |
           {1:~                                       }|*5
-          {4:                                        }|
-          {6:fail}                                    |
-          {6:error}                                   |
+          {3:                                        }|
+          {9:fail}                                    |
+          {9:error}                                   |
           :sign defined^                           |
-        ]],
-        }
+        ]])
       end
     end)
 
@@ -5035,39 +4860,33 @@ describe('builtin popupmenu', function()
         -- With 'wildmode' set to 'longest,full', completing a match should display
         -- the longest match, the wildmenu should not be displayed.
         feed(':sign u<Tab>')
-        screen:expect {
-          grid = [[
+        screen:expect([[
                                         |
           {1:~                             }|*6
           :sign un^                      |
-        ]],
-        }
+        ]])
         eq(0, fn.wildmenumode())
 
         -- pressing <Tab> should display the wildmenu
         feed('<Tab>')
-        screen:expect {
-          grid = [[
+        screen:expect([[
                                         |
           {1:~                             }|*4
-          {1:~    }{s: undefine       }{1:         }|
+          {1:~    }{12: undefine       }{1:         }|
           {1:~    }{n: unplace        }{1:         }|
           :sign undefine^                |
-        ]],
-        }
+        ]])
         eq(1, fn.wildmenumode())
 
         -- pressing <Tab> second time should select the next entry in the menu
         feed('<Tab>')
-        screen:expect {
-          grid = [[
+        screen:expect([[
                                         |
           {1:~                             }|*4
           {1:~    }{n: undefine       }{1:         }|
-          {1:~    }{s: unplace        }{1:         }|
+          {1:~    }{12: unplace        }{1:         }|
           :sign unplace^                 |
-        ]],
-        }
+        ]])
       end)
 
       it('wildoptions=pum with a wrapped line in buffer vim-patch:8.2.4655', function()
@@ -5078,7 +4897,7 @@ describe('builtin popupmenu', function()
         feed(':sign <Tab>')
         screen:expect([[
           aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa|*3
-          aaaa {s: define         }           |
+          aaaa {12: define         }           |
           {1:~    }{n: jump           }{1:           }|
           {1:~    }{n: list           }{1:           }|
           {1:~    }{n: place          }{1:           }|
@@ -5102,7 +4921,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                         |
           {1:~                             }|*2
-          {1:~    }{s: define         }{1:         }|
+          {1:~    }{12: define         }{1:         }|
           {1:~    }{n: jump           }{1:         }|
           {1:~    }{n: list           }{1:         }|
           {1:~    }{n: place          }{1:         }|
@@ -5117,7 +4936,7 @@ describe('builtin popupmenu', function()
                                         |
           {1:~                             }|*2
           {1:~    }{n: define         }{1:         }|
-          {1:~    }{s: jump           }{1:         }|
+          {1:~    }{12: jump           }{1:         }|
           {1:~    }{n: list           }{1:         }|
           {1:~    }{n: place          }{1:         }|
           {1:~    }{n: undefine       }{1:         }|
@@ -5139,7 +4958,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                         |
           {1:~                             }|*2
-          {1:~    }{s: define         }{1:         }|
+          {1:~    }{12: define         }{1:         }|
           {1:~    }{n: jump           }{1:         }|
           {1:~    }{n: list           }{1:         }|
           {1:~    }{n: place          }{1:         }|
@@ -5162,7 +4981,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                         |
           {1:~                             }|*2
-          {1:~    }{s: define         }{1:         }|
+          {1:~    }{12: define         }{1:         }|
           {1:~    }{n: jump           }{1:         }|
           {1:~    }{n: list           }{1:         }|
           {1:~    }{n: place          }{1:         }|
@@ -5191,7 +5010,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|*16
-          {1:~    }{s: }{ms:pl}{s:a}{ms:c}{s:e          }{1:           }|
+          {1:~    }{12: }{ms:pl}{12:a}{ms:c}{12:e          }{1:           }|
           {1:~    }{n: un}{mn:pl}{n:a}{mn:c}{n:e        }{1:           }|
           :sign place^                     |
         ]])
@@ -5200,7 +5019,7 @@ describe('builtin popupmenu', function()
                                           |
           {1:~                               }|*16
           {1:~    }{n: }{mn:pl}{n:a}{mn:c}{n:e          }{1:           }|
-          {1:~    }{s: un}{ms:pl}{s:a}{ms:c}{s:e        }{1:           }|
+          {1:~    }{12: un}{ms:pl}{12:a}{ms:c}{12:e        }{1:           }|
           :sign unplace^                   |
         ]])
         feed('<Tab>')
@@ -5217,7 +5036,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
                                           |
           {1:~                               }|*16
-          {1:~    }{s: }{ms:un}{s:define       }{1:           }|
+          {1:~    }{12: }{ms:un}{12:define       }{1:           }|
           {1:~    }{n: }{mn:un}{n:place        }{1:           }|
           :sign undefine^                  |
         ]])
@@ -5226,7 +5045,7 @@ describe('builtin popupmenu', function()
                                           |
           {1:~                               }|*16
           {1:~    }{n: }{mn:un}{n:define       }{1:           }|
-          {1:~    }{s: }{ms:un}{s:place        }{1:           }|
+          {1:~    }{12: }{ms:un}{12:place        }{1:           }|
           :sign unplace^                   |
         ]])
         feed('<Tab>')
@@ -5278,29 +5097,29 @@ describe('builtin popupmenu', function()
 
         feed(':TestCmd <tab>' .. ('<c-n>'):rep(20))
         screen:expect([[
-                  {n: a15            }{s: }       |
-          {1:~       }{n: a16            }{s: }{1:       }|
-          {1:~       }{n: a17            }{s: }{1:       }|
+                  {n: a15            }{12: }       |
+          {1:~       }{n: a16            }{12: }{1:       }|
+          {1:~       }{n: a17            }{12: }{1:       }|
           {1:~       }{n: a18            }{c: }{1:       }|
-          {1:~       }{n: a19            }{s: }{1:       }|
-          {1:~       }{s: a20             }{1:       }|
-          {1:~       }{n: a21            }{s: }{1:       }|
-          {1:~       }{n: a22            }{s: }{1:       }|
-          {1:~       }{n: a23            }{s: }{1:       }|
+          {1:~       }{n: a19            }{12: }{1:       }|
+          {1:~       }{12: a20             }{1:       }|
+          {1:~       }{n: a21            }{12: }{1:       }|
+          {1:~       }{n: a22            }{12: }{1:       }|
+          {1:~       }{n: a23            }{12: }{1:       }|
           :TestCmd a20^                    |
         ]])
 
         feed('<esc>:TestCmd <tab>')
         screen:expect([[
                   {n: a1             }{c: }       |
-          {1:~       }{n: a2             }{s: }{1:       }|
-          {1:~       }{n: a3             }{s: }{1:       }|
-          {1:~       }{n: a4             }{s: }{1:       }|
-          {1:~       }{n: a5             }{s: }{1:       }|
-          {1:~       }{n: a6             }{s: }{1:       }|
-          {1:~       }{n: a7             }{s: }{1:       }|
-          {1:~       }{n: a8             }{s: }{1:       }|
-          {1:~       }{n: a9             }{s: }{1:       }|
+          {1:~       }{n: a2             }{12: }{1:       }|
+          {1:~       }{n: a3             }{12: }{1:       }|
+          {1:~       }{n: a4             }{12: }{1:       }|
+          {1:~       }{n: a5             }{12: }{1:       }|
+          {1:~       }{n: a6             }{12: }{1:       }|
+          {1:~       }{n: a7             }{12: }{1:       }|
+          {1:~       }{n: a8             }{12: }{1:       }|
+          {1:~       }{n: a9             }{12: }{1:       }|
           :TestCmd ^                       |
         ]])
       end)
@@ -5308,36 +5127,6 @@ describe('builtin popupmenu', function()
       it(
         'cascading highlights for matched text (PmenuMatch, PmenuMatchSel) in cmdline pum',
         function()
-          screen:add_extra_attr_ids {
-            [100] = {
-              background = Screen.colors.Grey,
-              italic = true,
-              underline = true,
-              foreground = Screen.colors.White,
-            },
-            [101] = {
-              strikethrough = true,
-              foreground = Screen.colors.Grey0,
-              italic = true,
-              bold = true,
-              underline = true,
-              background = Screen.colors.White,
-            },
-            [102] = {
-              strikethrough = true,
-              foreground = Screen.colors.Red,
-              italic = true,
-              underline = true,
-              background = Screen.colors.Grey,
-            },
-            [103] = {
-              foreground = Screen.colors.Yellow,
-              italic = true,
-              bold = true,
-              underline = true,
-              background = Screen.colors.Pink,
-            },
-          }
           exec([[
             set wildoptions=pum,fuzzy
             hi Pmenu          guifg=White guibg=Grey gui=underline,italic
@@ -5350,8 +5139,8 @@ describe('builtin popupmenu', function()
           screen:expect([[
                                             |
             {1:~                               }|*16
-            {1:~    }{102: }{101:pl}{102:a}{101:c}{102:e          }{1:           }|
-            {1:~    }{100: un}{103:pl}{100:a}{103:c}{100:e        }{1:           }|
+            {1:~    }{106: }{107:pl}{106:a}{107:c}{106:e          }{1:           }|
+            {1:~    }{108: un}{109:pl}{108:a}{109:c}{108:e        }{1:           }|
             :sign place^                     |
           ]])
         end
@@ -5375,10 +5164,10 @@ describe('builtin popupmenu', function()
           some long prefix before the ^    |
           {1:~                               }|*6
         ## grid 3
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ## grid 4
           {n: word  }{c: }|
-          {n: choice}{s: }|
+          {n: choice}{12: }|
         ]],
           float_pos = { [4] = { -1, 'NW', 2, 1, 24, false, 100, 1, 1, 24 } },
         }
@@ -5386,9 +5175,9 @@ describe('builtin popupmenu', function()
         screen:expect([[
           some long prefix before the ^    |
           {1:~                       }{n: word  }{c: }|
-          {1:~                       }{n: choice}{s: }|
+          {1:~                       }{n: choice}{12: }|
           {1:~                               }|*4
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
     end)
@@ -5410,7 +5199,7 @@ describe('builtin popupmenu', function()
           some long prefix before the ^    |
           {1:~                               }|*6
         ## grid 3
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ## grid 4
           {n: word  }|
           {n: choice}|
@@ -5427,7 +5216,7 @@ describe('builtin popupmenu', function()
           {1:~                        }{n: text  }|
           {1:~                        }{n: thing }|
           {1:~                               }|*2
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
     end)
@@ -5454,9 +5243,9 @@ describe('builtin popupmenu', function()
                       123456789_123456789_123456789_a^                 |
           {1:~                                                           }|*4
         ## grid 3
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 2}             |
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 2}             |
         ## grid 4
-          {s: 123456789_123456789_123456789_a }|
+          {12: 123456789_123456789_123456789_a }|
           {n: 123456789_123456789_123456789_b }|
         ]],
           float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100, 1, 3, 11 } },
@@ -5466,10 +5255,10 @@ describe('builtin popupmenu', function()
           123456789_123456789_123456789_a                             |
           123456789_123456789_123456789_b                             |
                       123456789_123456789_123456789_a^                 |
-          {1:~          }{s: 123456789_123456789_123456789_a }{1:                }|
+          {1:~          }{12: 123456789_123456789_123456789_a }{1:                }|
           {1:~          }{n: 123456789_123456789_123456789_b }{1:                }|
           {1:~                                                           }|*2
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 2}             |
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 2}             |
         ]])
       end
       feed('<Esc>3Gdd"zp')
@@ -5488,9 +5277,9 @@ describe('builtin popupmenu', function()
                       123456789_123456789_123456789_a^                 |
           {1:~                                                           }|*4
         ## grid 3
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 2}             |
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 2}             |
         ## grid 4
-          {s: 123456789>}|
+          {12: 123456789>}|
           {n: 123456789>}|
         ]],
           float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100, 1, 3, 11 } },
@@ -5500,10 +5289,10 @@ describe('builtin popupmenu', function()
           123456789_123456789_123456789_a                             |
           123456789_123456789_123456789_b                             |
                       123456789_123456789_123456789_a^                 |
-          {1:~          }{s: 123456789>}{1:                                      }|
+          {1:~          }{12: 123456789>}{1:                                      }|
           {1:~          }{n: 123456789>}{1:                                      }|
           {1:~                                                           }|*2
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 2}             |
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 2}             |
         ]])
       end
       feed('<Esc>3Gdd"zp')
@@ -5522,9 +5311,9 @@ describe('builtin popupmenu', function()
                       123456789_123456789_123456789_a^                 |
           {1:~                                                           }|*4
         ## grid 3
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 2}             |
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 2}             |
         ## grid 4
-          {s: 123456789_123456789>}|
+          {12: 123456789_123456789>}|
           {n: 123456789_123456789>}|
         ]],
           float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100, 1, 3, 11 } },
@@ -5534,10 +5323,10 @@ describe('builtin popupmenu', function()
           123456789_123456789_123456789_a                             |
           123456789_123456789_123456789_b                             |
                       123456789_123456789_123456789_a^                 |
-          {1:~          }{s: 123456789_123456789>}{1:                            }|
+          {1:~          }{12: 123456789_123456789>}{1:                            }|
           {1:~          }{n: 123456789_123456789>}{1:                            }|
           {1:~                                                           }|*2
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 2}             |
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 2}             |
         ]])
       end
       feed('<Esc>3Gdd"zp')
@@ -5556,9 +5345,9 @@ describe('builtin popupmenu', function()
                       123456789_123456789_123456789_a^                 |
           {1:~                                                           }|*4
         ## grid 3
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 2}             |
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 2}             |
         ## grid 4
-          {s: 1234567>}|
+          {12: 1234567>}|
           {n: 1234567>}|
         ]],
           float_pos = { [4] = { -1, 'NW', 2, 3, 11, false, 100, 1, 3, 11 } },
@@ -5568,10 +5357,10 @@ describe('builtin popupmenu', function()
           123456789_123456789_123456789_a                             |
           123456789_123456789_123456789_b                             |
                       123456789_123456789_123456789_a^                 |
-          {1:~          }{s: 1234567>}{1:                                        }|
+          {1:~          }{12: 1234567>}{1:                                        }|
           {1:~          }{n: 1234567>}{1:                                        }|
           {1:~                                                           }|*2
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 2}             |
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 2}             |
         ]])
       end
       feed('<Esc>3Gdd"zp')
@@ -5591,9 +5380,9 @@ describe('builtin popupmenu', function()
           123456789_a^                     |
           {1:~                               }|*5
         ## grid 3
-          {2:-- }{5:match 1 of 2}                 |
+          {5:-- }{6:match 1 of 2}                 |
         ## grid 4
-          {s: 1234567>}|
+          {12: 1234567>}|
           {n: 1234567>}|
         ]],
           float_pos = { [4] = { -1, 'NW', 2, 4, 11, false, 100, 1, 4, 11 } },
@@ -5604,10 +5393,10 @@ describe('builtin popupmenu', function()
           123456789_123456789_123456789_b |
                       123456789_123456789_|
           123456789_a^                     |
-          {1:~          }{s: 1234567>}{1:            }|
+          {1:~          }{12: 1234567>}{1:            }|
           {1:~          }{n: 1234567>}{1:            }|
           {1:~                               }|*3
-          {2:-- }{5:match 1 of 2}                 |
+          {5:-- }{6:match 1 of 2}                 |
         ]])
       end
       feed('<Esc>3Gdd"zp')
@@ -5667,9 +5456,9 @@ describe('builtin popupmenu', function()
           123456789_123456789_123456789_^                              |
           {1:~                                                           }|*6
         ## grid 3
-          {2:-- Omni completion (^O^N^P) }{5:match 1 of 4}                    |
+          {5:-- Omni completion (^O^N^P) }{6:match 1 of 4}                    |
         ## grid 4
-          {s:123456789_123456789_123456789_ }|
+          {12:123456789_123456789_123456789_ }|
           {n:一二三四五六七八九十           }|
           {n:abcdefghij                     }|
           {n:上下左右                       }|
@@ -5679,12 +5468,12 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           123456789_123456789_123456789_^                              |
-          {s:123456789_123456789_123456789_ }{1:                             }|
+          {12:123456789_123456789_123456789_ }{1:                             }|
           {n:一二三四五六七八九十           }{1:                             }|
           {n:abcdefghij                     }{1:                             }|
           {n:上下左右                       }{1:                             }|
           {1:~                                                           }|*2
-          {2:-- Omni completion (^O^N^P) }{5:match 1 of 4}                    |
+          {5:-- Omni completion (^O^N^P) }{6:match 1 of 4}                    |
         ]])
       end
       feed('<Esc>')
@@ -5701,9 +5490,9 @@ describe('builtin popupmenu', function()
           123456789_123456789_123456789_^                              |
           {1:~                                                           }|*6
         ## grid 3
-          {2:-- Omni completion (^O^N^P) }{5:match 1 of 4}                    |
+          {5:-- Omni completion (^O^N^P) }{6:match 1 of 4}                    |
         ## grid 4
-          {s:123456789>}|
+          {12:123456789>}|
           {n:一二三四 >}|
           {n:abcdefghij}|
           {n:上下左右  }|
@@ -5713,12 +5502,12 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           123456789_123456789_123456789_^                              |
-          {s:123456789>}{1:                                                  }|
+          {12:123456789>}{1:                                                  }|
           {n:一二三四 >}{1:                                                  }|
           {n:abcdefghij}{1:                                                  }|
           {n:上下左右  }{1:                                                  }|
           {1:~                                                           }|*2
-          {2:-- Omni completion (^O^N^P) }{5:match 1 of 4}                    |
+          {5:-- Omni completion (^O^N^P) }{6:match 1 of 4}                    |
         ]])
       end
       feed('<Esc>')
@@ -5735,9 +5524,9 @@ describe('builtin popupmenu', function()
                                        ^ _987654321_987654321_987654321|
           {1:                                                           ~}|*6
         ## grid 3
-          {2:-- Omni completion (^O^N^P) }{5:match 1 of 4}                    |
+          {5:-- Omni completion (^O^N^P) }{6:match 1 of 4}                    |
         ## grid 4
-          {s:<987654321}|
+          {12:<987654321}|
           {n:< 四三二一}|
           {n:jihgfedcba}|
           {n:  右左下上}|
@@ -5747,12 +5536,12 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
                                        ^ _987654321_987654321_987654321|
-          {1:                                                  }{s:<987654321}|
+          {1:                                                  }{12:<987654321}|
           {1:                                                  }{n:< 四三二一}|
           {1:                                                  }{n:jihgfedcba}|
           {1:                                                  }{n:  右左下上}|
           {1:                                                           ~}|*2
-          {2:-- Omni completion (^O^N^P) }{5:match 1 of 4}                    |
+          {5:-- Omni completion (^O^N^P) }{6:match 1 of 4}                    |
         ]])
       end
       feed('<Esc>')
@@ -5770,9 +5559,9 @@ describe('builtin popupmenu', function()
           123456789_123456789_123456789_^                              |
           {1:~                                                           }|*6
         ## grid 3
-          {2:-- Omni completion (^O^N^P) }{5:match 1 of 4}                    |
+          {5:-- Omni completion (^O^N^P) }{6:match 1 of 4}                    |
         ## grid 4
-          {s:1>}|
+          {12:1>}|
           {n: >}|
           {n:a>}|
           {n: >}|
@@ -5782,12 +5571,12 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           123456789_123456789_123456789_^                              |
-          {s:1>}{1:                                                          }|
+          {12:1>}{1:                                                          }|
           {n: >}{1:                                                          }|
           {n:a>}{1:                                                          }|
           {n: >}{1:                                                          }|
           {1:~                                                           }|*2
-          {2:-- Omni completion (^O^N^P) }{5:match 1 of 4}                    |
+          {5:-- Omni completion (^O^N^P) }{6:match 1 of 4}                    |
         ]])
       end
       feed('<Esc>')
@@ -5806,9 +5595,9 @@ describe('builtin popupmenu', function()
           foo^                             |
           {1:~                               }|*18
         ## grid 3
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ## grid 4
-          {s:foo fooKind f>}|
+          {12:foo fooKind f>}|
           {n:bar barKind b>}|
           {n:baz bazKind b>}|
         ]],
@@ -5817,11 +5606,11 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           foo^                             |
-          {s:foo fooKind f>}{1:                  }|
+          {12:foo fooKind f>}{1:                  }|
           {n:bar barKind b>}{1:                  }|
           {n:baz bazKind b>}{1:                  }|
           {1:~                               }|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
       end
       feed('<Esc>')
@@ -5839,9 +5628,9 @@ describe('builtin popupmenu', function()
           foo^                             |
           {1:~                               }|*18
         ## grid 3
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ## grid 4
-          {s:foo fooKind f…}|
+          {12:foo fooKind f…}|
           {n:bar barKind b…}|
           {n:baz bazKind b…}|
         ]],
@@ -5850,11 +5639,11 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           foo^                             |
-          {s:foo fooKind f…}{1:                  }|
+          {12:foo fooKind f…}{1:                  }|
           {n:bar barKind b…}{1:                  }|
           {n:baz bazKind b…}{1:                  }|
           {1:~                               }|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
       end
       feed('<Esc>')
@@ -5871,9 +5660,9 @@ describe('builtin popupmenu', function()
           foo^                             |
           {1:~                               }|*18
         ## grid 3
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ## grid 4
-          {s:foo        fo…}|
+          {12:foo        fo…}|
           {n:bar        一…}|
           {n:一二三四五 mu…}|
         ]],
@@ -5882,11 +5671,11 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           foo^                             |
-          {s:foo        fo…}{1:                  }|
+          {12:foo        fo…}{1:                  }|
           {n:bar        一…}{1:                  }|
           {n:一二三四五 mu…}{1:                  }|
           {1:~                               }|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
       end
       feed('<Esc>')
@@ -5903,9 +5692,9 @@ describe('builtin popupmenu', function()
           foo^                             |
           {1:~                               }|*18
         ## grid 3
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ## grid 4
-          {s:foo        fo>}|
+          {12:foo        fo>}|
           {n:bar        一>}|
           {n:一二三四五 mu>}|
         ]],
@@ -5914,11 +5703,11 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           foo^                             |
-          {s:foo        fo>}{1:                  }|
+          {12:foo        fo>}{1:                  }|
           {n:bar        一>}{1:                  }|
           {n:一二三四五 mu>}{1:                  }|
           {1:~                               }|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
       end
       feed('<Esc>')
@@ -5936,9 +5725,9 @@ describe('builtin popupmenu', function()
           foo^                             |
           {1:~                               }|*18
         ## grid 3
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ## grid 4
-          {s:foo fooKind f_}|
+          {12:foo fooKind f_}|
           {n:bar barKind b_}|
           {n:baz bazKind b_}|
         ]],
@@ -5947,11 +5736,11 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           foo^                             |
-          {s:foo fooKind f_}{1:                  }|
+          {12:foo fooKind f_}{1:                  }|
           {n:bar barKind b_}{1:                  }|
           {n:baz bazKind b_}{1:                  }|
           {1:~                               }|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
       end
       feed('<Esc>')
@@ -5969,9 +5758,9 @@ describe('builtin popupmenu', function()
                                       ^ oof|
           {1:                               ~}|*18
         ## grid 3
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ## grid 4
-          {s:<f dniKoof oof}|
+          {12:<f dniKoof oof}|
           {n:<b dniKrab rab}|
           {n:<b dniKzab zab}|
         ]],
@@ -5980,11 +5769,11 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
                                       ^ oof|
-          {1:                  }{s:<f dniKoof oof}|
+          {1:                  }{12:<f dniKoof oof}|
           {1:                  }{n:<b dniKrab rab}|
           {1:                  }{n:<b dniKzab zab}|
           {1:                               ~}|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
       end
       feed('<Esc>')
@@ -6001,9 +5790,9 @@ describe('builtin popupmenu', function()
                                       ^ oof|
           {1:                               ~}|*18
         ## grid 3
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ## grid 4
-          {s:<of        oof}|
+          {12:<of        oof}|
           {n:<一        rab}|
           {n:<um 五四三二一}|
         ]],
@@ -6012,11 +5801,11 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
                                       ^ oof|
-          {1:                  }{s:<of        oof}|
+          {1:                  }{12:<of        oof}|
           {1:                  }{n:<一        rab}|
           {1:                  }{n:<um 五四三二一}|
           {1:                               ~}|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
       end
       feed('<Esc>')
@@ -6033,9 +5822,9 @@ describe('builtin popupmenu', function()
                                       ^ oof|
           {1:                               ~}|*18
         ## grid 3
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ## grid 4
-          {s:…of        oof}|
+          {12:…of        oof}|
           {n:…一        rab}|
           {n:…um 五四三二一}|
         ]],
@@ -6044,11 +5833,11 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
                                       ^ oof|
-          {1:                  }{s:…of        oof}|
+          {1:                  }{12:…of        oof}|
           {1:                  }{n:…一        rab}|
           {1:                  }{n:…um 五四三二一}|
           {1:                               ~}|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
       end
       feed('<Esc>')
@@ -6066,18 +5855,18 @@ describe('builtin popupmenu', function()
                                       ^ rab|
           {1:                               ~}|*18
         ## grid 3
-          {2:-- The only match}               |
+          {5:-- The only match}               |
         ## grid 4
-          {s:<of 三二一 rab}|
+          {12:<of 三二一 rab}|
         ]],
           float_pos = { [4] = { -1, 'NW', 2, 1, 18, false, 100, 1, 1, 18 } },
         })
       else
         screen:expect([[
                                       ^ rab|
-          {1:                  }{s:<of 三二一 rab}|
+          {1:                  }{12:<of 三二一 rab}|
           {1:                               ~}|*17
-          {2:-- The only match}               |
+          {5:-- The only match}               |
         ]])
       end
       feed('<Esc>')
@@ -6096,9 +5885,9 @@ describe('builtin popupmenu', function()
           foo^                             |
           {1:~                               }|*18
         ## grid 3
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ## grid 4
-          {s:foo>}|
+          {12:foo>}|
           {n:bar>}|
           {n:一 >}|
         ]],
@@ -6107,11 +5896,11 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           foo^                             |
-          {s:foo>}{1:                            }|
+          {12:foo>}{1:                            }|
           {n:bar>}{1:                            }|
           {n:一 >}{1:                            }|
           {1:~                               }|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
       end
       feed('<Esc>')
@@ -6128,9 +5917,9 @@ describe('builtin popupmenu', function()
                                       ^ oof|
           {1:                               ~}|*18
         ## grid 3
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ## grid 4
-          {s:<oof}|
+          {12:<oof}|
           {n:<rab}|
           {n:< 一}|
         ]],
@@ -6139,11 +5928,11 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
                                       ^ oof|
-          {1:                            }{s:<oof}|
+          {1:                            }{12:<oof}|
           {1:                            }{n:<rab}|
           {1:                            }{n:< 一}|
           {1:                               ~}|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
       end
       feed('<Esc>')
@@ -6161,9 +5950,9 @@ describe('builtin popupmenu', function()
           foo^                             |
           {1:~                               }|*18
         ## grid 3
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ## grid 4
-          {s:foo        fooK>}|
+          {12:foo        fooK>}|
           {n:bar        一二>}|
           {n:一二三四五 multi}|
         ]],
@@ -6172,11 +5961,11 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           foo^                             |
-          {s:foo        fooK>}{1:                }|
+          {12:foo        fooK>}{1:                }|
           {n:bar        一二>}{1:                }|
           {n:一二三四五 multi}{1:                }|
           {1:~                               }|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
       end
       feed('<Esc>')
@@ -6193,9 +5982,9 @@ describe('builtin popupmenu', function()
                                       ^ oof|
           {1:                               ~}|*18
         ## grid 3
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ## grid 4
-          {s:<Koof        oof}|
+          {12:<Koof        oof}|
           {n:<二一        rab}|
           {n:itlum 五四三二一}|
         ]],
@@ -6204,11 +5993,11 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
                                       ^ oof|
-          {1:                }{s:<Koof        oof}|
+          {1:                }{12:<Koof        oof}|
           {1:                }{n:<二一        rab}|
           {1:                }{n:itlum 五四三二一}|
           {1:                               ~}|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
       end
       feed('<Esc>')
@@ -6226,9 +6015,9 @@ describe('builtin popupmenu', function()
           一二三四五六七八九十^            |
           {1:~                               }|*18
         ## grid 3
-          {2:-- }{5:match 1 of 2}                 |
+          {5:-- }{6:match 1 of 2}                 |
         ## grid 4
-          {ds:一二三四五六七 }{s:>}|
+          {ds:一二三四五六七 }{12:>}|
           {dn:123456789_12345}{n:>}|
         ]],
           float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
@@ -6236,10 +6025,10 @@ describe('builtin popupmenu', function()
       else
         screen:expect([[
           一二三四五六七八九十^            |
-          {ds:一二三四五六七 }{s:>}{1:                }|
+          {ds:一二三四五六七 }{12:>}{1:                }|
           {dn:123456789_12345}{n:>}{1:                }|
           {1:~                               }|*16
-          {2:-- }{5:match 1 of 2}                 |
+          {5:-- }{6:match 1 of 2}                 |
         ]])
       end
       feed('<Esc>')
@@ -6273,11 +6062,11 @@ describe('builtin popupmenu', function()
           abcde^ abcde abcde abcde a|
           bcde abcde abcde abcde ab|
           cde abcde abcde abcde abc|
-          de a{s: foo            } abcd|
+          de a{12: foo            } abcd|
           e ab{n: bar            }     |
           {1:~   }{n: foobar         }{1:     }|
           {1:~                        }|*8
-          {2:-- }{5:match 1 of 3}          |
+          {5:-- }{6:match 1 of 3}          |
         ]])
       end
       feed('<Esc>')
@@ -6294,11 +6083,11 @@ describe('builtin popupmenu', function()
           bcde ^abcde abcde abcde ab|
           cde abcde abcde abcde abc|
           de abcde abcde abcde abcd|
-          e ab{s: foo            }     |
+          e ab{12: foo            }     |
           {1:~   }{n: bar            }{1:     }|
           {1:~   }{n: foobar         }{1:     }|
           {1:~                        }|*7
-          {2:-- }{5:match 1 of 3}          |
+          {5:-- }{6:match 1 of 3}          |
         ]])
       end
       feed('<Esc>')
@@ -6316,11 +6105,11 @@ describe('builtin popupmenu', function()
           cde a^bcde abcde abcde abc|
           de abcde abcde abcde abcd|
           e abcde abcde abcde      |
-          {1:~   }{s: foo            }{1:     }|
+          {1:~   }{12: foo            }{1:     }|
           {1:~   }{n: bar            }{1:     }|
           {1:~   }{n: foobar         }{1:     }|
           {1:~                        }|*6
-          {2:-- }{5:match 1 of 3}          |
+          {5:-- }{6:match 1 of 3}          |
         ]])
       end
       feed('<Esc>')
@@ -6338,11 +6127,11 @@ describe('builtin popupmenu', function()
           cde abcde abcde abcde abc|
           de abcde a^bcde abcde abcd|
           e abcde abcde abcde      |
-          {1:~        }{s: foo            }|
+          {1:~        }{12: foo            }|
           {1:~        }{n: bar            }|
           {1:~        }{n: foobar         }|
           {1:~                        }|*6
-          {2:-- }{5:match 1 of 3}          |
+          {5:-- }{6:match 1 of 3}          |
         ]])
       end
       feed('<C-E><Esc>')
@@ -6360,11 +6149,11 @@ describe('builtin popupmenu', function()
           cde abcde abcde abcde abc|
           de abcde abcde abcde abcd|
           e abcde ^abcde abcde      |
-          {1:~      }{s: foo            }{1:  }|
+          {1:~      }{12: foo            }{1:  }|
           {1:~      }{n: bar            }{1:  }|
           {1:~      }{n: foobar         }{1:  }|
           {1:~                        }|*6
-          {2:-- }{5:match 1 of 3}          |
+          {5:-- }{6:match 1 of 3}          |
         ]])
       end
       feed('<C-E><Esc>')
@@ -6402,7 +6191,7 @@ describe('builtin popupmenu', function()
                        ^                   |
           {1:~                               }|*6
         ## grid 3
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ## grid 4
           {n: 一二三四五六七八九>}|
         ]],
@@ -6413,7 +6202,7 @@ describe('builtin popupmenu', function()
                        ^                   |
           {1:~           }{n: 一二三四五六七八九>}|
           {1:~                               }|*5
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
       feed('<C-E>')
@@ -6429,7 +6218,7 @@ describe('builtin popupmenu', function()
                        ^                   |
           {1:~                               }|*6
         ## grid 3
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ## grid 4
           {n: 一二三 四五六 七八>}|
         ]],
@@ -6440,7 +6229,7 @@ describe('builtin popupmenu', function()
                        ^                   |
           {1:~           }{n: 一二三 四五六 七八>}|
           {1:~                               }|*5
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
       feed('<C-E>')
@@ -6457,7 +6246,7 @@ describe('builtin popupmenu', function()
                             ^              |
           {1:                               ~}|*6
         ## grid 3
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ## grid 4
           {n:<九八七六五四三二一 }|
         ]],
@@ -6468,7 +6257,7 @@ describe('builtin popupmenu', function()
                             ^              |
           {n:<九八七六五四三二一 }{1:           ~}|
           {1:                               ~}|*5
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
       feed('<C-E>')
@@ -6484,7 +6273,7 @@ describe('builtin popupmenu', function()
                             ^              |
           {1:                               ~}|*6
         ## grid 3
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ## grid 4
           {n:<八七 六五四 三二一 }|
         ]],
@@ -6495,7 +6284,7 @@ describe('builtin popupmenu', function()
                             ^              |
           {n:<八七 六五四 三二一 }{1:           ~}|
           {1:                               ~}|*5
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
       feed('<C-E>')
@@ -6535,10 +6324,10 @@ describe('builtin popupmenu', function()
                       ^                    |
           {1:~                               }|*6
         ## grid 3
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ## grid 4
           {n: 一二三四五六七八九>}{c: }|*2
-          {n: 一二三四五六七八九>}{s: }|*2
+          {n: 一二三四五六七八九>}{12: }|*2
         ]],
           float_pos = { [4] = { -1, 'NW', 2, 1, 11, false, 100, 1, 1, 11 } },
         })
@@ -6546,9 +6335,9 @@ describe('builtin popupmenu', function()
         screen:expect([[
                       ^                    |
           {1:~          }{n: 一二三四五六七八九>}{c: }|*2
-          {1:~          }{n: 一二三四五六七八九>}{s: }|*2
+          {1:~          }{n: 一二三四五六七八九>}{12: }|*2
           {1:~                               }|*2
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
       feed('<C-E>')
@@ -6564,10 +6353,10 @@ describe('builtin popupmenu', function()
                       ^                    |
           {1:~                               }|*6
         ## grid 3
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ## grid 4
           {n: abcdef ghijkl mnopq}{c: }|*2
-          {n: 一二三 四五六 七八>}{s: }|*2
+          {n: 一二三 四五六 七八>}{12: }|*2
         ]],
           float_pos = { [4] = { -1, 'NW', 2, 1, 11, false, 100, 1, 1, 11 } },
         })
@@ -6575,9 +6364,9 @@ describe('builtin popupmenu', function()
         screen:expect([[
                       ^                    |
           {1:~          }{n: abcdef ghijkl mnopq}{c: }|*2
-          {1:~          }{n: 一二三 四五六 七八>}{s: }|*2
+          {1:~          }{n: 一二三 四五六 七八>}{12: }|*2
           {1:~                               }|*2
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
       feed('<C-E>')
@@ -6594,10 +6383,10 @@ describe('builtin popupmenu', function()
                              ^             |
           {1:                               ~}|*6
         ## grid 3
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ## grid 4
           {c: }{n:<九八七六五四三二一 }|*2
-          {s: }{n:<九八七六五四三二一 }|*2
+          {12: }{n:<九八七六五四三二一 }|*2
         ]],
           float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
         })
@@ -6605,9 +6394,9 @@ describe('builtin popupmenu', function()
         screen:expect([[
                              ^             |
           {c: }{n:<九八七六五四三二一 }{1:          ~}|*2
-          {s: }{n:<九八七六五四三二一 }{1:          ~}|*2
+          {12: }{n:<九八七六五四三二一 }{1:          ~}|*2
           {1:                               ~}|*2
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
       feed('<C-E>')
@@ -6623,10 +6412,10 @@ describe('builtin popupmenu', function()
                              ^             |
           {1:                               ~}|*6
         ## grid 3
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ## grid 4
           {c: }{n:qponm lkjihg fedcba }|*2
-          {s: }{n:<八七 六五四 三二一 }|*2
+          {12: }{n:<八七 六五四 三二一 }|*2
         ]],
           float_pos = { [4] = { -1, 'NW', 2, 1, 0, false, 100, 1, 1, 0 } },
         })
@@ -6634,9 +6423,9 @@ describe('builtin popupmenu', function()
         screen:expect([[
                              ^             |
           {c: }{n:qponm lkjihg fedcba }{1:          ~}|*2
-          {s: }{n:<八七 六五四 三二一 }{1:          ~}|*2
+          {12: }{n:<八七 六五四 三二一 }{1:          ~}|*2
           {1:                               ~}|*2
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end
       feed('<C-E>')
@@ -6705,9 +6494,9 @@ describe('builtin popupmenu', function()
       end
       screen:expect(no_sel_screen)
       feed('<Down>')
-      screen:expect(screen_replace(no_sel_screen, '{n: foo }', '{s: foo }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: foo }', '{12: foo }'))
       feed('<Down>')
-      screen:expect(screen_replace(no_sel_screen, '{n: bar }', '{s: bar }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: bar }', '{12: bar }'))
       feed('<CR>')
       local no_menu_screen ---@type string
       if multigrid then
@@ -6864,7 +6653,7 @@ describe('builtin popupmenu', function()
       else
         feed('<RightDrag><6,3>')
       end
-      screen:expect(screen_replace(no_sel_screen, '{n: baz }', '{s: baz }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: baz }', '{12: baz }'))
       if multigrid then
         api.nvim_input_mouse('right', 'release', '', 2, 1, 6)
       else
@@ -6888,21 +6677,21 @@ describe('builtin popupmenu', function()
       else
         feed('<ScrollWheelUp><4,0>')
       end
-      screen:expect(screen_replace(no_sel_screen, '{n: foo }', '{s: foo }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: foo }', '{12: foo }'))
       eq(true, screen.options.mousemoveevent)
       if multigrid then
         api.nvim_input_mouse('move', '', '', 4, 2, 3)
       else
         feed('<MouseMove><6,3>')
       end
-      screen:expect(screen_replace(no_sel_screen, '{n: baz }', '{s: baz }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: baz }', '{12: baz }'))
       eq(true, screen.options.mousemoveevent)
       if multigrid then
         api.nvim_input_mouse('wheel', 'down', '', 4, 2, 3)
       else
         feed('<ScrollWheelDown><6,3>')
       end
-      screen:expect(screen_replace(no_sel_screen, '{n: bar }', '{s: bar }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: bar }', '{12: bar }'))
       eq(true, screen.options.mousemoveevent)
       if multigrid then
         api.nvim_input_mouse('left', 'press', '', 4, 1, 3)
@@ -6921,7 +6710,7 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [2:--------------------------------]|*2
-          {3:[No Name] [+]                   }|
+          {2:[No Name] [+]                   }|
           [5:--------------------------------]|*2
           [3:--------------------------------]|
         ## grid 2
@@ -6944,7 +6733,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
           popup menu test                 |
           {1:~                  }{n: foo }{1:        }|
-          {3:[No Name] [+]      }{n: bar }{3:        }|
+          {2:[No Name] [+]      }{n: bar }{2:        }|
           ^popup menu test    {n: baz }        |
           {1:~                               }|
           :let g:menustr = 'bar'          |
@@ -6952,11 +6741,10 @@ describe('builtin popupmenu', function()
       end
       if multigrid then
         api.nvim_input_mouse('left', 'press', '', 4, 2, 2)
-        screen:expect({
-          grid = [[
+        screen:expect([[
         ## grid 1
           [2:--------------------------------]|*2
-          {3:[No Name] [+]                   }|
+          {2:[No Name] [+]                   }|
           [5:--------------------------------]|*2
           [3:--------------------------------]|
         ## grid 2
@@ -6967,14 +6755,13 @@ describe('builtin popupmenu', function()
         ## grid 5
           ^popup menu test                 |
           {1:~                               }|
-        ]],
-        })
+        ]])
       else
         feed('<LeftMouse><21,3>')
         screen:expect([[
           popup menu test                 |
           {1:~                               }|
-          {3:[No Name] [+]                   }|
+          {2:[No Name] [+]                   }|
           ^popup menu test                 |
           {1:~                               }|
           :let g:menustr = 'baz'          |
@@ -6989,7 +6776,7 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [2:--------------------------------]|*2
-          {3:[No Name] [+]                   }|
+          {2:[No Name] [+]                   }|
           [5:---------------]│[6:----------------]|*2
           [3:--------------------------------]|
         ## grid 2
@@ -7015,7 +6802,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
           popup menu test                 |
           {1:~                           }{n: foo}|
-          {3:[No Name] [+]               }{n: bar}|
+          {2:[No Name] [+]               }{n: bar}|
           popup menu test│^popup menu t{n: baz}|
           {1:~              }│{1:~               }|
           :let g:menustr = 'baz'          |
@@ -7023,11 +6810,10 @@ describe('builtin popupmenu', function()
       end
       if multigrid then
         api.nvim_input_mouse('left', 'press', '', 4, 0, 2)
-        screen:expect({
-          grid = [[
+        screen:expect([[
         ## grid 1
           [2:--------------------------------]|*2
-          {3:[No Name] [+]                   }|
+          {2:[No Name] [+]                   }|
           [5:---------------]│[6:----------------]|*2
           [3:--------------------------------]|
         ## grid 2
@@ -7041,14 +6827,13 @@ describe('builtin popupmenu', function()
         ## grid 6
           ^popup menu test |
           {1:~               }|
-        ]],
-        })
+        ]])
       else
         feed('<LeftMouse><31,1>')
         screen:expect([[
           popup menu test                 |
           {1:~                               }|
-          {3:[No Name] [+]                   }|
+          {2:[No Name] [+]                   }|
           popup menu test│^popup menu test |
           {1:~              }│{1:~               }|
           :let g:menustr = 'foo'          |
@@ -7063,7 +6848,7 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [2:--------------------------------]|*2
-          {3:[No Name] [+]                   }|
+          {2:[No Name] [+]                   }|
           [5:---------------]│[6:----------------]|*2
           [3:--------------------------------]|
         ## grid 2
@@ -7079,7 +6864,7 @@ describe('builtin popupmenu', function()
           popup menu test|
           {1:~              }|
         ## grid 6
-          {2:WINBAR          }|
+          {5:WINBAR          }|
           ^popup menu test |
         ]],
           float_pos = { [4] = { -1, 'SW', 6, 1, 12, false, 250, 2, 1, 28 } },
@@ -7089,8 +6874,8 @@ describe('builtin popupmenu', function()
         no_sel_screen = [[
           popup menu test                 |
           {1:~                           }{n: foo}|
-          {3:[No Name] [+]               }{n: bar}|
-          popup menu test│{2:WINBAR      }{n: baz}|
+          {2:[No Name] [+]               }{n: bar}|
+          popup menu test│{5:WINBAR      }{n: baz}|
           {1:~              }│^popup menu test |
           :let g:menustr = 'foo'          |
         ]]
@@ -7101,7 +6886,7 @@ describe('builtin popupmenu', function()
       else
         feed('<RightDrag><31,3>')
       end
-      screen:expect(screen_replace(no_sel_screen, '{n: baz}', '{s: baz}'))
+      screen:expect(screen_replace(no_sel_screen, '{n: baz}', '{12: baz}'))
       if multigrid then
         api.nvim_input_mouse('right', 'release', '', 6, 1, 15)
       else
@@ -7113,7 +6898,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
         ## grid 1
           [2:--------------------------------]|*2
-          {3:[No Name] [+]                   }|
+          {2:[No Name] [+]                   }|
           [5:---------------]│[6:----------------]|*2
           [3:--------------------------------]|
         ## grid 2
@@ -7125,7 +6910,7 @@ describe('builtin popupmenu', function()
           popup menu test|
           {1:~              }|
         ## grid 6
-          {2:WINBAR          }|
+          {5:WINBAR          }|
           ^popup menu test |
         ]])
       else
@@ -7133,8 +6918,8 @@ describe('builtin popupmenu', function()
         screen:expect([[
           popup menu test                 |
           {1:~                               }|
-          {3:[No Name] [+]                   }|
-          popup menu test│{2:WINBAR          }|
+          {2:[No Name] [+]                   }|
+          popup menu test│{5:WINBAR          }|
           {1:~              }│^popup menu test |
           :let g:menustr = 'bar'          |
         ]])
@@ -7148,9 +6933,9 @@ describe('builtin popupmenu', function()
         no_menu_screen = [[
         ## grid 1
           [8:--------------------------------]|
-          {4:[No Name] [+]                   }|
+          {3:[No Name] [+]                   }|
           [7:----]│[2:---------------------------]|*2
-          {3:<+]  [No Name] [+]              }|
+          {2:<+]  [No Name] [+]              }|
           [5:---------------]│[6:----------------]|*3
           [3:--------------------------------]|
         ## grid 2
@@ -7162,7 +6947,7 @@ describe('builtin popupmenu', function()
           popup menu test|
           {1:~              }|*2
         ## grid 6
-          {2:WINBAR          }|
+          {5:WINBAR          }|
           popup menu test |
           {1:~               }|
         ## grid 7
@@ -7174,11 +6959,11 @@ describe('builtin popupmenu', function()
       else
         no_menu_screen = [[
           ^popup menu test                 |
-          {4:[No Name] [+]                   }|
+          {3:[No Name] [+]                   }|
           popu│popup menu test            |
           p me│{1:~                          }|
-          {3:<+]  [No Name] [+]              }|
-          popup menu test│{2:WINBAR          }|
+          {2:<+]  [No Name] [+]              }|
+          popup menu test│{5:WINBAR          }|
           {1:~              }│popup menu test |
           {1:~              }│{1:~               }|
                                           |
@@ -7191,9 +6976,9 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [8:--------------------------------]|
-          {4:[No Name] [+]                   }|
+          {3:[No Name] [+]                   }|
           [7:----]│[2:---------------------------]|*2
-          {3:<+]  [No Name] [+]              }|
+          {2:<+]  [No Name] [+]              }|
           [5:---------------]│[6:----------------]|*3
           [3:--------------------------------]|
         ## grid 2
@@ -7209,7 +6994,7 @@ describe('builtin popupmenu', function()
           popup menu test|
           {1:~              }|*2
         ## grid 6
-          {2:WINBAR          }|
+          {5:WINBAR          }|
           popup menu test |
           {1:~               }|
         ## grid 7
@@ -7221,19 +7006,17 @@ describe('builtin popupmenu', function()
           float_pos = { [4] = { -1, 'NW', 2, 1, 14, false, 250, 2, 3, 19 } },
         }
       else
-        no_sel_screen = {
-          grid = [[
+        no_sel_screen = [[
           ^popup menu test                 |
-          {4:[No Name] [+]                   }|
+          {3:[No Name] [+]                   }|
           popu│popup menu test            |
           p me│{1:~             }{n: foo }{1:        }|
-          {3:<+]  [No Name] [+] }{n: bar }{3:        }|
-          popup menu test│{2:WIN}{n: baz }{2:        }|
+          {2:<+]  [No Name] [+] }{n: bar }{2:        }|
+          popup menu test│{5:WIN}{n: baz }{5:        }|
           {1:~              }│popup menu test |
           {1:~              }│{1:~               }|
                                           |
-        ]],
-        }
+        ]]
       end
 
       local pos = {
@@ -7255,15 +7038,15 @@ describe('builtin popupmenu', function()
       api.nvim_input_mouse('right', 'press', '', unpack(pos[1]))
       screen:expect(no_sel_screen)
       api.nvim_input_mouse('right', 'drag', '', unpack(pos[2]))
-      screen:expect(screen_replace(no_sel_screen, '{n: foo }', '{s: foo }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: foo }', '{12: foo }'))
       api.nvim_input_mouse('right', 'drag', '', unpack(pos[3]))
       screen:expect(no_sel_screen)
       api.nvim_input_mouse('right', 'drag', '', unpack(pos[4]))
-      screen:expect(screen_replace(no_sel_screen, '{n: bar }', '{s: bar }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: bar }', '{12: bar }'))
       api.nvim_input_mouse('right', 'drag', '', unpack(pos[5]))
       screen:expect(no_sel_screen)
       api.nvim_input_mouse('right', 'drag', '', unpack(pos[6]))
-      screen:expect(screen_replace(no_sel_screen, '{n: baz }', '{s: baz }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: baz }', '{12: baz }'))
       api.nvim_input_mouse('right', 'release', '', unpack(pos[7]))
       screen:expect(no_sel_screen)
       api.nvim_input_mouse('left', 'press', '', unpack(pos[7]))
@@ -7280,15 +7063,15 @@ describe('builtin popupmenu', function()
       api.nvim_input_mouse('right', 'press', '', unpack(pos[1]))
       screen:expect(no_sel_screen)
       api.nvim_input_mouse('move', '', '', unpack(pos[2]))
-      screen:expect(screen_replace(no_sel_screen, '{n: foo }', '{s: foo }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: foo }', '{12: foo }'))
       api.nvim_input_mouse('move', '', '', unpack(pos[3]))
       screen:expect(no_sel_screen)
       api.nvim_input_mouse('move', '', '', unpack(pos[4]))
-      screen:expect(screen_replace(no_sel_screen, '{n: bar }', '{s: bar }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: bar }', '{12: bar }'))
       api.nvim_input_mouse('move', '', '', unpack(pos[5]))
       screen:expect(no_sel_screen)
       api.nvim_input_mouse('move', '', '', unpack(pos[6]))
-      screen:expect(screen_replace(no_sel_screen, '{n: baz }', '{s: baz }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: baz }', '{12: baz }'))
       api.nvim_input_mouse('left', 'press', '', unpack(pos[7]))
       screen:expect(no_menu_screen)
       eq('', api.nvim_get_var('menustr'))
@@ -7298,9 +7081,9 @@ describe('builtin popupmenu', function()
         no_menu_screen = [[
         ## grid 1
           [8:--------------------------------]|
-          {4:[No Name] [+]                   }|
+          {3:[No Name] [+]                   }|
           [7:----]│[2:---------------------------]|*2
-          {3:<+]  [No Name] [+]              }|
+          {2:<+]  [No Name] [+]              }|
           [5:---------------]│[6:----------------]|*3
           [3:--------------------------------]|
         ## grid 2
@@ -7312,7 +7095,7 @@ describe('builtin popupmenu', function()
           popup menu test|
           {1:~              }|*2
         ## grid 6
-          {2:WINBAR          }|
+          {5:WINBAR          }|
           popup menu test |
           {1:~               }|
         ## grid 7
@@ -7324,11 +7107,11 @@ describe('builtin popupmenu', function()
       else
         no_menu_screen = [[
                            tset unem pupo^p|
-          {4:[No Name] [+]                   }|
+          {3:[No Name] [+]                   }|
           popu│            tset unem pupop|
           p me│{1:                          ~}|
-          {3:<+]  [No Name] [+]              }|
-          popup menu test│{2:WINBAR          }|
+          {2:<+]  [No Name] [+]              }|
+          popup menu test│{5:WINBAR          }|
           {1:~              }│popup menu test |
           {1:~              }│{1:~               }|
                                           |
@@ -7341,9 +7124,9 @@ describe('builtin popupmenu', function()
           grid = [[
         ## grid 1
           [8:--------------------------------]|
-          {4:[No Name] [+]                   }|
+          {3:[No Name] [+]                   }|
           [7:----]│[2:---------------------------]|*2
-          {3:<+]  [No Name] [+]              }|
+          {2:<+]  [No Name] [+]              }|
           [5:---------------]│[6:----------------]|*3
           [3:--------------------------------]|
         ## grid 2
@@ -7359,7 +7142,7 @@ describe('builtin popupmenu', function()
           popup menu test|
           {1:~              }|*2
         ## grid 6
-          {2:WINBAR          }|
+          {5:WINBAR          }|
           popup menu test |
           {1:~               }|
         ## grid 7
@@ -7371,19 +7154,17 @@ describe('builtin popupmenu', function()
           float_pos = { [4] = { -1, 'NW', 2, 1, 12, false, 250, 2, 3, 17 } },
         }
       else
-        no_sel_screen = {
-          grid = [[
+        no_sel_screen = [[
                            tset unem pupo^p|
-          {4:[No Name] [+]                   }|
+          {3:[No Name] [+]                   }|
           popu│            tset unem pupop|
           p me│{1:            }{n: oof }{1:         ~}|
-          {3:<+]  [No Name] [+}{n: rab }{3:          }|
-          popup menu test│{2:W}{n: zab }{2:          }|
+          {2:<+]  [No Name] [+}{n: rab }{2:          }|
+          popup menu test│{5:W}{n: zab }{5:          }|
           {1:~              }│popup menu test |
           {1:~              }│{1:~               }|
                                           |
-        ]],
-        }
+        ]]
       end
 
       pos = {
@@ -7405,15 +7186,15 @@ describe('builtin popupmenu', function()
       api.nvim_input_mouse('right', 'press', '', unpack(pos[1]))
       screen:expect(no_sel_screen)
       api.nvim_input_mouse('move', '', '', unpack(pos[2]))
-      screen:expect(screen_replace(no_sel_screen, '{n: oof }', '{s: oof }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: oof }', '{12: oof }'))
       api.nvim_input_mouse('move', '', '', unpack(pos[3]))
       screen:expect(no_sel_screen)
       api.nvim_input_mouse('move', '', '', unpack(pos[4]))
-      screen:expect(screen_replace(no_sel_screen, '{n: rab }', '{s: rab }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: rab }', '{12: rab }'))
       api.nvim_input_mouse('move', '', '', unpack(pos[5]))
       screen:expect(no_sel_screen)
       api.nvim_input_mouse('move', '', '', unpack(pos[6]))
-      screen:expect(screen_replace(no_sel_screen, '{n: zab }', '{s: zab }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: zab }', '{12: zab }'))
       api.nvim_input_mouse('left', 'press', '', unpack(pos[7]))
       screen:expect(no_menu_screen)
       eq('', api.nvim_get_var('menustr'))
@@ -7428,15 +7209,15 @@ describe('builtin popupmenu', function()
       api.nvim_input_mouse('right', 'press', '', unpack(pos[1]))
       screen:expect(no_sel_screen)
       api.nvim_input_mouse('right', 'drag', '', unpack(pos[2]))
-      screen:expect(screen_replace(no_sel_screen, '{n: oof }', '{s: oof }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: oof }', '{12: oof }'))
       api.nvim_input_mouse('right', 'drag', '', unpack(pos[3]))
       screen:expect(no_sel_screen)
       api.nvim_input_mouse('right', 'drag', '', unpack(pos[4]))
-      screen:expect(screen_replace(no_sel_screen, '{n: rab }', '{s: rab }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: rab }', '{12: rab }'))
       api.nvim_input_mouse('right', 'drag', '', unpack(pos[5]))
       screen:expect(no_sel_screen)
       api.nvim_input_mouse('right', 'drag', '', unpack(pos[6]))
-      screen:expect(screen_replace(no_sel_screen, '{n: zab }', '{s: zab }'))
+      screen:expect(screen_replace(no_sel_screen, '{n: zab }', '{12: zab }'))
       api.nvim_input_mouse('right', 'release', '', unpack(pos[7]))
       screen:expect(no_sel_screen)
       api.nvim_input_mouse('left', 'press', '', unpack(pos[7]))
@@ -7472,7 +7253,7 @@ describe('builtin popupmenu', function()
         feed('/X<CR>:popup PopUp<CR>')
         screen:expect([[
           one two three four five         |
-          and one two {7:^X}three four five    |
+          and one two {10:^X}three four five    |
           one more tw{n: Undo             }   |
           {1:~          }{n:                  }{1:   }|
           {1:~          }{n: Paste            }{1:   }|
@@ -7491,10 +7272,10 @@ describe('builtin popupmenu', function()
         feed('jj')
         screen:expect([[
           one two three four five         |
-          and one two {7:^X}three four five    |
+          and one two {10:^X}three four five    |
           one more tw{n: Undo             }   |
           {1:~          }{n:                  }{1:   }|
-          {1:~          }{s: Paste            }{1:   }|
+          {1:~          }{12: Paste            }{1:   }|
           {1:~          }{n:                  }{1:   }|
           {1:~          }{n: Select Word      }{1:   }|
           {1:~          }{n: Select Sentence  }{1:   }|
@@ -7510,12 +7291,12 @@ describe('builtin popupmenu', function()
         feed('j')
         screen:expect([[
           one two three four five         |
-          and one two {7:^X}three four five    |
+          and one two {10:^X}three four five    |
           one more tw{n: Undo             }   |
           {1:~          }{n:                  }{1:   }|
           {1:~          }{n: Paste            }{1:   }|
           {1:~          }{n:                  }{1:   }|
-          {1:~          }{s: Select Word      }{1:   }|
+          {1:~          }{12: Select Word      }{1:   }|
           {1:~          }{n: Select Sentence  }{1:   }|
           {1:~          }{n: Select Paragraph }{1:   }|
           {1:~          }{n: Select Line      }{1:   }|
@@ -7531,7 +7312,7 @@ describe('builtin popupmenu', function()
         feed('/X<CR>:popup PopUp<CR>')
         screen:expect([[
                    evif ruof eerht owt eno|
-              evif ruof eerht{7:^X} owt eno dna|
+              evif ruof eerht{10:^X} owt eno dna|
              {n:             odnU }wt erom eno|
           {1:   }{n:                  }{1:          ~}|
           {1:   }{n:            etsaP }{1:          ~}|
@@ -7555,7 +7336,7 @@ describe('builtin popupmenu', function()
         feed('/X<CR>:popup PopUp<CR><F2>')
         screen:expect([[
           one two three four five         |
-          and one two {7:^X}three four five    |
+          and one two {10:^X}three four five    |
           one more tw{n: Undo             }   |
           {1:~          }{n:                  }{1:   }|
           {1:~          }{n: Paste            }{1:   }|
@@ -7574,7 +7355,7 @@ describe('builtin popupmenu', function()
         feed('jj<CR>')
         screen:expect([[
           one two three four five         |
-          and one two {7:^X}three four five    |
+          and one two {10:^X}three four five    |
           one more two three four five    |
           {1:~                               }|*16
           pasted                          |
@@ -7584,9 +7365,9 @@ describe('builtin popupmenu', function()
         command('setlocal winbar=TEST')
         feed('/X<CR>:popup PopUp<CR>')
         screen:expect([[
-          {2:TEST                            }|
+          {5:TEST                            }|
           one two three four five         |
-          and one two {7:^X}three four five    |
+          and one two {10:^X}three four five    |
           one more tw{n: Undo             }   |
           {1:~          }{n:                  }{1:   }|
           {1:~          }{n: Paste            }{1:   }|
@@ -7738,11 +7519,11 @@ describe('builtin popupmenu', function()
           feed('iaw<C-X><C-u>')
           screen:expect([[
             aword1^                        |
-            {s:aword1 W extra text 1 }{1:        }|
+            {12:aword1 W extra text 1 }{1:        }|
             {n:aword2 W extra text 2 }{1:        }|
             {n:aword3 W extra text 3 }{1:        }|
             {1:~                             }|*3
-            {2:-- }{5:match 1 of 3}               |
+            {5:-- }{6:match 1 of 3}               |
           ]])
         end)
 
@@ -7757,11 +7538,11 @@ describe('builtin popupmenu', function()
           feed('iaw<C-X><C-u>')
           screen:expect([[
             aword1^                        |
-            {s:aword1 }{ks:W }{xs:extra text 1 }{1:        }|
+            {12:aword1 }{ks:W }{xs:extra text 1 }{1:        }|
             {n:aword2 }{kn:W }{xn:extra text 2 }{1:        }|
             {n:aword3 }{kn:W }{xn:extra text 3 }{1:        }|
             {1:~                             }|*3
-            {2:-- }{5:match 1 of 3}               |
+            {5:-- }{6:match 1 of 3}               |
           ]])
         end)
       end)
@@ -7808,7 +7589,7 @@ describe('builtin popupmenu', function()
         feed('i<C-X><C-O>')
         local pum_start = [[
           ^                                |
-          {s:foo      fookind }{1:               }|
+          {12:foo      fookind }{1:               }|
           {n:foofoo   fookind }{1:               }|
           {n:foobar   fookind }{1:               }|
           {n:fooBaz   fookind }{1:               }|
@@ -7818,40 +7599,40 @@ describe('builtin popupmenu', function()
           {n:你不好吗         }{1:               }|
           {n:你可好吗         }{1:               }|
           {1:~                               }|*9
-          {2:-- }{5:match 1 of 9}                 |
+          {5:-- }{6:match 1 of 9}                 |
         ]]
         screen:expect(pum_start)
         feed('fo')
         screen:expect([[
           fo^                              |
-          {ms:fo}{s:o     fookind }{1:                }|
+          {ms:fo}{12:o     fookind }{1:                }|
           {mn:fo}{n:ofoo  fookind }{1:                }|
           {mn:fo}{n:obar  fookind }{1:                }|
           {mn:fo}{n:oBaz  fookind }{1:                }|
           {mn:fo}{n:obala fookind }{1:                }|
           {1:~                               }|*13
-          {2:-- }{5:match 1 of 9}                 |
+          {5:-- }{6:match 1 of 9}                 |
         ]])
         feed('<Esc>S<C-X><C-O>')
         screen:expect(pum_start)
         feed('你')
         screen:expect([[
           你^                              |
-          {ms:你}{s:好           }{1:                 }|
+          {ms:你}{12:好           }{1:                 }|
           {mn:你}{n:好吗         }{1:                 }|
           {mn:你}{n:不好吗       }{1:                 }|
           {mn:你}{n:可好吗       }{1:                 }|
           {1:~                               }|*14
-          {2:-- }{5:match 1 of 9}                 |
+          {5:-- }{6:match 1 of 9}                 |
         ]])
         feed('吗')
         screen:expect([[
           你吗^                            |
-          {ms:你}{s:好}{ms:吗}{s:         }{1:                 }|
+          {ms:你}{12:好}{ms:吗}{12:         }{1:                 }|
           {mn:你}{n:不好}{mn:吗}{n:       }{1:                 }|
           {mn:你}{n:可好}{mn:吗}{n:       }{1:                 }|
           {1:~                               }|*15
-          {2:-- }{5:match 1 of 9}                 |
+          {5:-- }{6:match 1 of 9}                 |
         ]])
         feed('<C-E><Esc>')
 
@@ -7859,7 +7640,7 @@ describe('builtin popupmenu', function()
         feed('S<C-X><C-O>')
         local pum_start_rl = [[
                                          ^ |
-          {1:               }{s: dnikoof      oof}|
+          {1:               }{12: dnikoof      oof}|
           {1:               }{n: dnikoof   oofoof}|
           {1:               }{n: dnikoof   raboof}|
           {1:               }{n: dnikoof   zaBoof}|
@@ -7869,40 +7650,40 @@ describe('builtin popupmenu', function()
           {1:               }{n:         吗好不你}|
           {1:               }{n:         吗好可你}|
           {1:                               ~}|*9
-          {2:-- }{5:match 1 of 9}                 |
+          {5:-- }{6:match 1 of 9}                 |
         ]]
         screen:expect(pum_start_rl)
         feed('fo')
         screen:expect([[
                                        ^ of|
-          {1:                }{s: dnikoof     o}{ms:of}|
+          {1:                }{12: dnikoof     o}{ms:of}|
           {1:                }{n: dnikoof  oofo}{mn:of}|
           {1:                }{n: dnikoof  rabo}{mn:of}|
           {1:                }{n: dnikoof  zaBo}{mn:of}|
           {1:                }{n: dnikoof alabo}{mn:of}|
           {1:                               ~}|*13
-          {2:-- }{5:match 1 of 9}                 |
+          {5:-- }{6:match 1 of 9}                 |
         ]])
         feed('<Esc>S<C-X><C-O>')
         screen:expect(pum_start_rl)
         feed('你')
         screen:expect([[
                                        ^ 你|
-          {1:                 }{s:           好}{ms:你}|
+          {1:                 }{12:           好}{ms:你}|
           {1:                 }{n:         吗好}{mn:你}|
           {1:                 }{n:       吗好不}{mn:你}|
           {1:                 }{n:       吗好可}{mn:你}|
           {1:                               ~}|*14
-          {2:-- }{5:match 1 of 9}                 |
+          {5:-- }{6:match 1 of 9}                 |
         ]])
         feed('吗')
         screen:expect([[
                                      ^ 吗你|
-          {1:                 }{s:         }{ms:吗}{s:好}{ms:你}|
+          {1:                 }{12:         }{ms:吗}{12:好}{ms:你}|
           {1:                 }{n:       }{mn:吗}{n:好不}{mn:你}|
           {1:                 }{n:       }{mn:吗}{n:好可}{mn:你}|
           {1:                               ~}|*15
-          {2:-- }{5:match 1 of 9}                 |
+          {5:-- }{6:match 1 of 9}                 |
         ]])
         feed('<C-E><Esc>')
         command('set norightleft')
@@ -7913,13 +7694,13 @@ describe('builtin popupmenu', function()
         feed('fo')
         screen:expect([[
           fo^                              |
-          {ms:fo}{s:o     fookind }{1:                }|
+          {ms:fo}{12:o     fookind }{1:                }|
           {mn:fo}{n:ofoo  fookind }{1:                }|
           {mn:fo}{n:obar  fookind }{1:                }|
           {mn:fo}{n:oBaz  fookind }{1:                }|
           {mn:fo}{n:obala fookind }{1:                }|
           {1:~                               }|*13
-          {2:-- }{5:match 1 of 9}                 |
+          {5:-- }{6:match 1 of 9}                 |
         ]])
         feed('<C-E><Esc>')
 
@@ -7929,13 +7710,13 @@ describe('builtin popupmenu', function()
         feed('fo')
         screen:expect([[
                                        ^ of|
-          {1:                }{s: dnikoof     o}{ms:of}|
+          {1:                }{12: dnikoof     o}{ms:of}|
           {1:                }{n: dnikoof  oofo}{mn:of}|
           {1:                }{n: dnikoof  rabo}{mn:of}|
           {1:                }{n: dnikoof  zaBo}{mn:of}|
           {1:                }{n: dnikoof alabo}{mn:of}|
           {1:                               ~}|*13
-          {2:-- }{5:match 1 of 9}                 |
+          {5:-- }{6:match 1 of 9}                 |
         ]])
         feed('<C-E><Esc>')
         command('set norightleft')
@@ -7943,11 +7724,11 @@ describe('builtin popupmenu', function()
         feed('S<C-R>=Comp()<CR>f')
         screen:expect([[
           f^                               |
-          {ms:f}{s:oo            }{1:                 }|
+          {ms:f}{12:oo            }{1:                 }|
           {mn:F}{n:oobar         }{1:                 }|
           {mn:f}{n:ooBaz         }{1:                 }|
           {1:~                               }|*15
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
         feed('o<BS><C-R>=Comp()<CR>')
         screen:expect_unchanged(true)
@@ -7961,11 +7742,11 @@ describe('builtin popupmenu', function()
         feed('fb')
         screen:expect([[
           fb^                              |
-          {ms:f}{s:oo}{ms:B}{s:az  fookind }{1:                }|
+          {ms:f}{12:oo}{ms:B}{12:az  fookind }{1:                }|
           {mn:f}{n:oo}{mn:b}{n:ar  fookind }{1:                }|
           {mn:f}{n:oo}{mn:b}{n:ala fookind }{1:                }|
           {1:~                               }|*15
-          {2:-- }{5:match 1 of 9}                 |
+          {5:-- }{6:match 1 of 9}                 |
         ]])
 
         feed('<C-E><Esc>')
@@ -7982,26 +7763,26 @@ describe('builtin popupmenu', function()
            hello helio hero hello^         |
           {1:~                }{n: hero         }{1: }|
           {1:~                }{n: helio        }{1: }|
-          {1:~                }{s: hello        }{1: }|
+          {1:~                }{12: hello        }{1: }|
           {1:~                               }|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
 
         feed('<Esc>S hello helio hero h<C-X><C-P><C-P>')
         screen:expect([[
            hello helio hero helio^         |
           {1:~                }{n: hero         }{1: }|
-          {1:~                }{s: helio        }{1: }|
+          {1:~                }{12: helio        }{1: }|
           {1:~                }{n: hello        }{1: }|
           {1:~                               }|*15
-          {2:-- }{5:match 2 of 3}                 |
+          {5:-- }{6:match 2 of 3}                 |
         ]])
 
         feed('<Esc>S/non_existing_folder<C-X><C-F>')
         screen:expect([[
           /non_existing_folder^            |
           {1:~                               }|*18
-          {2:-- }{6:Pattern not found}            |
+          {5:-- }{9:Pattern not found}            |
         ]])
         feed('<C-E><Esc>')
       end)
@@ -8028,18 +7809,18 @@ describe('builtin popupmenu', function()
         feed('i<C-X><C-O>')
         screen:expect([[
           ^                                |
-          {s:foobar    !    }{1:                 }|
+          {12:foobar    !    }{1:                 }|
           {n:foobaz    !    }{1:                 }|
           {1:~                               }|*16
-          {2:-- }{5:match 1 of 2}                 |
+          {5:-- }{6:match 1 of 2}                 |
         ]])
         feed('foo')
         screen:expect([[
           foo^                             |
-          {ms:foo}{s:bar    !    }{1:                 }|
+          {ms:foo}{12:bar    !    }{1:                 }|
           {mn:foo}{n:baz    !    }{1:                 }|
           {1:~                               }|*16
-          {2:-- }{5:match 1 of 2}                 |
+          {5:-- }{6:match 1 of 2}                 |
         ]])
 
         feed('<C-E><Esc>')
@@ -8083,11 +7864,11 @@ describe('builtin popupmenu', function()
         feed('Saw<C-X><C-U>')
         screen:expect([[
           aword1^                          |
-          {ds:aword1}{s: W extra text 1 }{1:          }|
+          {ds:aword1}{12: W extra text 1 }{1:          }|
           {n:aword2 W extra text 2 }{1:          }|
           {dn:你好}{n:   W extra text 3 }{1:          }|
           {1:~                               }|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
         feed('<C-E><Esc>')
 
@@ -8096,20 +7877,20 @@ describe('builtin popupmenu', function()
         feed('Saw<C-X><C-U>')
         screen:expect([[
           aword1^                          |
-          {uds:aw}{ds:ord1}{s: W extra text 1 }{1:          }|
+          {uds:aw}{ds:ord1}{12: W extra text 1 }{1:          }|
           {umn:aw}{n:ord2 W extra text 2 }{1:          }|
           {dn:你好}{n:   W extra text 3 }{1:          }|
           {1:~                               }|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
         feed('<C-N>')
         screen:expect([[
           aword2^                          |
           {udn:aw}{dn:ord1}{n: W extra text 1 }{1:          }|
-          {ums:aw}{s:ord2 W extra text 2 }{1:          }|
+          {ums:aw}{12:ord2 W extra text 2 }{1:          }|
           {dn:你好}{n:   W extra text 3 }{1:          }|
           {1:~                               }|*15
-          {2:-- }{5:match 2 of 3}                 |
+          {5:-- }{6:match 2 of 3}                 |
         ]])
         feed('<C-E><Esc>')
 
@@ -8117,10 +7898,10 @@ describe('builtin popupmenu', function()
         feed('S<C-X><C-U>')
         screen:expect([[
           aword1^                          |
-          {ds:aword1}{s:         }{1:                 }|
+          {ds:aword1}{12:         }{1:                 }|
           {dn:你好}{n:           }{1:                 }|
           {1:~                               }|*16
-          {2:-- }{5:match 1 of 2}                 |
+          {5:-- }{6:match 1 of 2}                 |
         ]])
         feed('<C-E><Esc>')
       end)
@@ -8148,20 +7929,14 @@ describe('builtin popupmenu', function()
           hi KindClass guifg=DarkGreen
         ]])
 
-        local attr_ids = screen:get_default_attr_ids()
-        attr_ids.kvs = { foreground = Screen.colors.DarkYellow, background = Screen.colors.Grey }
-        attr_ids.kfn = { foreground = Screen.colors.DarkBlue, background = Screen.colors.Plum1 }
-        attr_ids.kcn = { foreground = Screen.colors.DarkGreen, background = Screen.colors.Plum1 }
-        screen:set_default_attr_ids(attr_ids)
-
         feed('S<C-X><C-U>')
         screen:expect([[
           aword1^                          |
-          {ds:aword1}{s: }{kvs:variable}{s: extra text 1 }{1:   }|
-          {n:aword2 }{kfn:function}{n: extra text 2 }{1:   }|
-          {n:你好   }{kcn:class}{n:    extra text 3 }{1:   }|
+          {ds:aword1}{12: }{110:variable}{12: extra text 1 }{1:   }|
+          {n:aword2 }{111:function}{n: extra text 2 }{1:   }|
+          {n:你好   }{112:class}{n:    extra text 3 }{1:   }|
           {1:~                               }|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
         feed('<C-E><Esc>')
       end)
@@ -8199,11 +7974,11 @@ describe('builtin popupmenu', function()
         feed('S<C-X><C-O>')
         screen:expect([[
           foo^                           |
-          {s:foo  S menu    }{1:               }|
+          {12:foo  S menu    }{1:               }|
           {n:bar  T menu    }{1:               }|
           {n:你好 C 中文    }{1:               }|
           {1:~                             }|*10
-          {2:-- }{5:match 1 of 3}               |
+          {5:-- }{6:match 1 of 3}               |
         ]])
         feed('<C-E><ESC>')
         -- T2
@@ -8211,11 +7986,11 @@ describe('builtin popupmenu', function()
         feed('S<C-X><C-O>')
         screen:expect([[
           foo^                           |
-          {s:foo  menu S    }{1:               }|
+          {12:foo  menu S    }{1:               }|
           {n:bar  menu T    }{1:               }|
           {n:你好 中文 C    }{1:               }|
           {1:~                             }|*10
-          {2:-- }{5:match 1 of 3}               |
+          {5:-- }{6:match 1 of 3}               |
         ]])
         feed('<C-E><ESC>')
         -- T3
@@ -8223,11 +7998,11 @@ describe('builtin popupmenu', function()
         feed('S<C-X><C-O>')
         screen:expect([[
           foo^                           |
-          {s:S foo  menu    }{1:               }|
+          {12:S foo  menu    }{1:               }|
           {n:T bar  menu    }{1:               }|
           {n:C 你好 中文    }{1:               }|
           {1:~                             }|*10
-          {2:-- }{5:match 1 of 3}               |
+          {5:-- }{6:match 1 of 3}               |
         ]])
         feed('<C-E><ESC>')
         -- T4
@@ -8235,11 +8010,11 @@ describe('builtin popupmenu', function()
         feed('S<C-X><C-O>')
         screen:expect([[
           foo^                           |
-          {s:S menu foo     }{1:               }|
+          {12:S menu foo     }{1:               }|
           {n:T menu bar     }{1:               }|
           {n:C 中文 你好    }{1:               }|
           {1:~                             }|*10
-          {2:-- }{5:match 1 of 3}               |
+          {5:-- }{6:match 1 of 3}               |
         ]])
         feed('<C-E><ESC>')
         -- T5
@@ -8247,11 +8022,11 @@ describe('builtin popupmenu', function()
         feed('S<C-X><C-O>')
         screen:expect([[
           foo^                           |
-          {s:menu foo  S    }{1:               }|
+          {12:menu foo  S    }{1:               }|
           {n:menu bar  T    }{1:               }|
           {n:中文 你好 C    }{1:               }|
           {1:~                             }|*10
-          {2:-- }{5:match 1 of 3}               |
+          {5:-- }{6:match 1 of 3}               |
         ]])
         feed('<C-E><ESC>')
         -- T6
@@ -8259,11 +8034,11 @@ describe('builtin popupmenu', function()
         feed('S<C-X><C-O>')
         screen:expect([[
           foo^                           |
-          {s:menu S foo     }{1:               }|
+          {12:menu S foo     }{1:               }|
           {n:menu T bar     }{1:               }|
           {n:中文 C 你好    }{1:               }|
           {1:~                             }|*10
-          {2:-- }{5:match 1 of 3}               |
+          {5:-- }{6:match 1 of 3}               |
         ]])
         feed('<C-E><ESC>')
         -- T7
@@ -8271,11 +8046,11 @@ describe('builtin popupmenu', function()
         feed('S<C-X><C-O>')
         screen:expect([[
           foo^                           |
-          {s:foo  S menu    }{1:               }|
+          {12:foo  S menu    }{1:               }|
           {n:bar  T menu    }{1:               }|
           {n:你好 C 中文    }{1:               }|
           {1:~                             }|*10
-          {2:-- }{5:match 1 of 3}               |
+          {5:-- }{6:match 1 of 3}               |
         ]])
         feed('<C-E><ESC>')
 
@@ -8284,11 +8059,11 @@ describe('builtin popupmenu', function()
         feed('S<C-X><C-O>')
         screen:expect([[
           loooong_foo^ |
-          {s:menu S loooo}|
+          {12:menu S loooo}|
           {n:menu T loooo}|
           {1:~           }|*10
                       |
-          {2:--}          |
+          {5:--}          |
         ]])
         feed('<C-E><ESC>')
       end)
@@ -8313,34 +8088,34 @@ describe('builtin popupmenu', function()
 
         feed('Sαβγ <C-X><C-O>')
         screen:expect([[
-          αβγ {8:foo}^                         |
-          {1:~  }{s: foo            }{1:             }|
+          αβγ {19:foo}^                         |
+          {1:~  }{12: foo            }{1:             }|
           {1:~  }{n: bar            }{1:             }|
           {1:~  }{n: 你好           }{1:             }|
           {1:~                               }|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
         feed('<C-E><Esc>')
 
         feed('Sαβγ <C-X><C-O><C-N>')
         screen:expect([[
-          αβγ {8:bar}^                         |
+          αβγ {19:bar}^                         |
           {1:~  }{n: foo            }{1:             }|
-          {1:~  }{s: bar            }{1:             }|
+          {1:~  }{12: bar            }{1:             }|
           {1:~  }{n: 你好           }{1:             }|
           {1:~                               }|*15
-          {2:-- }{5:match 2 of 3}                 |
+          {5:-- }{6:match 2 of 3}                 |
         ]])
         feed('<C-E><Esc>')
 
         feed('Sαβγ <C-X><C-O><C-N><C-N>')
         screen:expect([[
-          αβγ {8:你好}^                        |
+          αβγ {19:你好}^                        |
           {1:~  }{n: foo            }{1:             }|
           {1:~  }{n: bar            }{1:             }|
-          {1:~  }{s: 你好           }{1:             }|
+          {1:~  }{12: 你好           }{1:             }|
           {1:~                               }|*15
-          {2:-- }{5:match 3 of 3}                 |
+          {5:-- }{6:match 3 of 3}                 |
         ]])
         feed('<C-E><Esc>')
 
@@ -8349,7 +8124,7 @@ describe('builtin popupmenu', function()
         screen:expect([[
           αβγ foo^                         |
           {1:~                               }|*18
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
         feed('<Esc>')
 
@@ -8358,19 +8133,19 @@ describe('builtin popupmenu', function()
         screen:expect([[
           αβγ foo ^                        |
           {1:~                               }|*18
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
         feed('<Esc>')
 
         -- text after the inserted text shouldn't be highlighted
         feed('0ea <C-X><C-O>')
         screen:expect([[
-          αβγ {8:foo}^ foo                     |
-          {1:~  }{s: foo            }{1:             }|
+          αβγ {19:foo}^ foo                     |
+          {1:~  }{12: foo            }{1:             }|
           {1:~  }{n: bar            }{1:             }|
           {1:~  }{n: 你好           }{1:             }|
           {1:~                               }|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
         feed('<C-P>')
         screen:expect([[
@@ -8379,22 +8154,22 @@ describe('builtin popupmenu', function()
           {1:~  }{n: bar            }{1:             }|
           {1:~  }{n: 你好           }{1:             }|
           {1:~                               }|*15
-          {2:-- }{8:Back at original}             |
+          {5:-- }{19:Back at original}             |
         ]])
         feed('<C-P>')
         screen:expect([[
-          αβγ {8:你好}^ foo                    |
+          αβγ {19:你好}^ foo                    |
           {1:~  }{n: foo            }{1:             }|
           {1:~  }{n: bar            }{1:             }|
-          {1:~  }{s: 你好           }{1:             }|
+          {1:~  }{12: 你好           }{1:             }|
           {1:~                               }|*15
-          {2:-- }{5:match 3 of 3}                 |
+          {5:-- }{6:match 3 of 3}                 |
         ]])
         feed('<C-Y>')
         screen:expect([[
           αβγ 你好^ foo                    |
           {1:~                               }|*18
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
         feed('<Esc>')
 
@@ -8402,14 +8177,14 @@ describe('builtin popupmenu', function()
         screen:expect([[
           info                            |
           {1:~                               }|*2
-          {3:[Scratch] [Preview][-]          }|
-          {8:foo}^                             |
-          {s:foo            }{1:                 }|
+          {2:[Scratch] [Preview][-]          }|
+          {19:foo}^                             |
+          {12:foo            }{1:                 }|
           {n:bar            }{1:                 }|
           {n:你好           }{1:                 }|
           {1:~                               }|*10
-          {4:[No Name] [+]                   }|
-          {2:-- }{5:match 1 of 3}                 |
+          {3:[No Name] [+]                   }|
+          {5:-- }{6:match 1 of 3}                 |
         ]])
         feed('<Esc>')
       end)
@@ -8436,18 +8211,18 @@ describe('builtin popupmenu', function()
         -- when ComplMatchIns is not set, CursorLine applies normally
         feed('0ea <C-X><C-O>')
         screen:expect([[
-          {10:aaa foo^ bbb                     }|
-          {1:~  }{s: foo            }{1:             }|
+          {101:aaa foo^ bbb                     }|
+          {1:~  }{12: foo            }{1:             }|
           {1:~  }{n: bar            }{1:             }|
           {1:~  }{n: 你好           }{1:             }|
           {1:~                               }|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
         feed('<C-E>')
         screen:expect([[
-          {10:aaa ^ bbb                        }|
+          {101:aaa ^ bbb                        }|
           {1:~                               }|*18
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
         feed('<BS><Esc>')
 
@@ -8455,36 +8230,36 @@ describe('builtin popupmenu', function()
         command('hi ComplMatchIns guifg=Yellow')
         feed('0ea <C-X><C-O>')
         screen:expect([[
-          {10:aaa }{9:foo}{10:^ bbb                     }|
-          {1:~  }{s: foo            }{1:             }|
+          {101:aaa }{100:foo}{101:^ bbb                     }|
+          {1:~  }{12: foo            }{1:             }|
           {1:~  }{n: bar            }{1:             }|
           {1:~  }{n: 你好           }{1:             }|
           {1:~                               }|*15
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
         feed('<C-P>')
         screen:expect([[
-          {10:aaa ^ bbb                        }|
+          {101:aaa ^ bbb                        }|
           {1:~  }{n: foo            }{1:             }|
           {1:~  }{n: bar            }{1:             }|
           {1:~  }{n: 你好           }{1:             }|
           {1:~                               }|*15
-          {2:-- }{8:Back at original}             |
+          {5:-- }{19:Back at original}             |
         ]])
         feed('<C-P>')
         screen:expect([[
-          {10:aaa }{9:你好}{10:^ bbb                    }|
+          {101:aaa }{100:你好}{101:^ bbb                    }|
           {1:~  }{n: foo            }{1:             }|
           {1:~  }{n: bar            }{1:             }|
-          {1:~  }{s: 你好           }{1:             }|
+          {1:~  }{12: 你好           }{1:             }|
           {1:~                               }|*15
-          {2:-- }{5:match 3 of 3}                 |
+          {5:-- }{6:match 3 of 3}                 |
         ]])
         feed('<C-E>')
         screen:expect([[
-          {10:aaa ^ bbb                        }|
+          {101:aaa ^ bbb                        }|
           {1:~                               }|*18
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
         feed('<Esc>')
 
@@ -8492,20 +8267,20 @@ describe('builtin popupmenu', function()
         command('set completeopt+=menuone,noselect')
         feed('S<C-X><C-O>')
         local pum_start = [[
-          {10:^                                }|
+          {101:^                                }|
           {n:foo            }{1:                 }|
           {n:bar            }{1:                 }|
           {n:你好           }{1:                 }|
           {1:~                               }|*15
-          {2:-- }{8:Back at original}             |
+          {5:-- }{19:Back at original}             |
         ]]
         screen:expect(pum_start)
         feed('f<C-N>')
         screen:expect([[
-          {10:f}{9:oo}{10:^                             }|
-          {s:foo            }{1:                 }|
+          {101:f}{100:oo}{101:^                             }|
+          {12:foo            }{1:                 }|
           {1:~                               }|*17
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
         feed('<C-E><ESC>')
 
@@ -8514,19 +8289,19 @@ describe('builtin popupmenu', function()
         screen:expect(pum_start)
         feed('f<C-N>')
         screen:expect([[
-          {10:foo^                             }|
-          {s:foo            }{1:                 }|
+          {101:foo^                             }|
+          {12:foo            }{1:                 }|
           {1:~                               }|*17
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
         feed('<C-E><Esc>')
 
         command('set completeopt-=fuzzy')
         feed('Sf<C-N>')
         screen:expect([[
-          {10:f^                               }|
+          {101:f^                               }|
           {1:~                               }|*18
-          {2:-- }{6:Pattern not found}            |
+          {5:-- }{9:Pattern not found}            |
         ]])
         feed('<C-E><Esc>')
       end)
@@ -8549,21 +8324,21 @@ describe('builtin popupmenu', function()
           func ()                         |
                                           |
           end^                             |
-          {s:function ()    }{1:                 }|
+          {12:function ()    }{1:                 }|
           {n:foobar         }{1:                 }|
           {n:你好^@  ^@我好 }{1:                 }|
           {1:~                               }|*13
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
 
         feed('<C-N>')
         screen:expect([[
           foobar^                          |
           {n:function ()    }{1:                 }|
-          {s:foobar         }{1:                 }|
+          {12:foobar         }{1:                 }|
           {n:你好^@  ^@我好 }{1:                 }|
           {1:~                               }|*15
-          {2:-- }{5:match 2 of 3}                 |
+          {5:-- }{6:match 2 of 3}                 |
         ]])
         feed('<C-E><ESC>')
 
@@ -8572,21 +8347,21 @@ describe('builtin popupmenu', function()
           hello func ()                   |
                                           |
           end^ hero                        |
-          {1:~    }{s: function ()    }{1:           }|
+          {1:~    }{12: function ()    }{1:           }|
           {1:~    }{n: foobar         }{1:           }|
           {1:~    }{n: 你好^@  ^@我好 }{1:           }|
           {1:~                               }|*13
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
 
         feed('<C-N>')
         screen:expect([[
           hello foobar^ hero               |
           {1:~    }{n: function ()    }{1:           }|
-          {1:~    }{s: foobar         }{1:           }|
+          {1:~    }{12: foobar         }{1:           }|
           {1:~    }{n: 你好^@  ^@我好 }{1:           }|
           {1:~                               }|*15
-          {2:-- }{5:match 2 of 3}                 |
+          {5:-- }{6:match 2 of 3}                 |
         ]])
 
         feed('<C-N>')
@@ -8596,9 +8371,9 @@ describe('builtin popupmenu', function()
           我好^ hero                       |
           {1:~  }{n: function ()    }{1:             }|
           {1:~  }{n: foobar         }{1:             }|
-          {1:~  }{s: 你好^@  ^@我好 }{1:             }|
+          {1:~  }{12: 你好^@  ^@我好 }{1:             }|
           {1:~                               }|*13
-          {2:-- }{5:match 3 of 3}                 |
+          {5:-- }{6:match 3 of 3}                 |
         ]])
 
         feed('<C-N>')
@@ -8608,81 +8383,81 @@ describe('builtin popupmenu', function()
           {1:~    }{n: foobar         }{1:           }|
           {1:~    }{n: 你好^@  ^@我好 }{1:           }|
           {1:~                               }|*15
-          {2:-- }{8:Back at original}             |
+          {5:-- }{19:Back at original}             |
         ]])
         feed('<C-E><ESC>')
 
         command(':hi ComplMatchIns guifg=red')
         feed('S<C-X><C-O>')
         screen:expect([[
-          {8:func ()}                         |
-          {8:        }                        |
-          {8:end}^                             |
-          {s:function ()    }{1:                 }|
+          {19:func ()}                         |
+          {19:        }                        |
+          {19:end}^                             |
+          {12:function ()    }{1:                 }|
           {n:foobar         }{1:                 }|
           {n:你好^@  ^@我好 }{1:                 }|
           {1:~                               }|*13
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
         feed('<C-E><ESC>')
 
         feed('Shello  hero<ESC>hhhhha<C-X><C-O>')
         screen:expect([[
-          hello {8:func ()}                   |
-          {8:        }                        |
-          {8:end^ }hero                        |
-          {1:~    }{s: function ()    }{1:           }|
+          hello {19:func ()}                   |
+          {19:        }                        |
+          {19:end^ }hero                        |
+          {1:~    }{12: function ()    }{1:           }|
           {1:~    }{n: foobar         }{1:           }|
           {1:~    }{n: 你好^@  ^@我好 }{1:           }|
           {1:~                               }|*13
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
         feed('<C-E><ESC>')
 
         command('setlocal autoindent shiftwidth=2 tabstop=2')
         feed('Slocal a = <C-X><C-O>')
         screen:expect([[
-          local a = {8:func ()}               |
-          {8:  }                              |
-          {8:end}^                             |
-          {1:~ }{s: function ()    }{1:              }|
+          local a = {19:func ()}               |
+          {19:  }                              |
+          {19:end}^                             |
+          {1:~ }{12: function ()    }{1:              }|
           {1:~ }{n: foobar         }{1:              }|
           {1:~ }{n: 你好^@  ^@我好 }{1:              }|
           {1:~                               }|*13
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
 
         feed('<C-Y>')
         screen:expect([[
-          local a = {8:func ()}               |
-          {8:  }                              |
+          local a = {19:func ()}               |
+          {19:  }                              |
           end^                             |
           {1:~                               }|*16
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
 
         feed('<ESC>kAlocal b = <C-X><C-O>')
         screen:expect([[
-          local a = {8:func ()}               |
-            local b = {8:func ()}             |
-          {8:    }                            |
-          {8:  end}^                           |
-          end {s: function ()    }            |
+          local a = {19:func ()}               |
+            local b = {19:func ()}             |
+          {19:    }                            |
+          {19:  end}^                           |
+          end {12: function ()    }            |
           {1:~   }{n: foobar         }{1:            }|
           {1:~   }{n: 你好^@  ^@我好 }{1:            }|
           {1:~                               }|*12
-          {2:-- }{5:match 1 of 3}                 |
+          {5:-- }{6:match 1 of 3}                 |
         ]])
 
         feed('<C-Y>')
         screen:expect([[
-          local a = {8:func ()}               |
-            local b = {8:func ()}             |
-          {8:    }                            |
+          local a = {19:func ()}               |
+            local b = {19:func ()}             |
+          {19:    }                            |
             end^                           |
           end                             |
           {1:~                               }|*14
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
 
         feed('<Esc>ggVGd')
@@ -8691,13 +8466,13 @@ describe('builtin popupmenu', function()
         command('setlocal ft=lua')
         feed('S<F5>')
         screen:expect([[
-          {8:my}                              |
-          {8:        multi}                   |
-          {8:line}^                            |
-          {s:my^@  multi^@line   }{1:            }|
+          {19:my}                              |
+          {19:        multi}                   |
+          {19:line}^                            |
+          {12:my^@  multi^@line   }{1:            }|
           {n:my^@    multi^@line }{1:            }|
           {1:~                               }|*14
-          {2:-- INSERT --}                    |
+          {5:-- INSERT --}                    |
         ]])
       end)
 
@@ -8712,19 +8487,19 @@ describe('builtin popupmenu', function()
         command('tabe')
         feed('Aaa aaa <C-X><C-N>')
         screen:expect([[
-          {11: [No Name] }{2: + [No Name] }{3:                              }{11:X}|
+          {24: [No Name] }{5: + [No Name] }{2:                              }{24:X}|
           aa aaa aa^                                              |
-          {1:~     }{s: aa             }{1:                                 }|
+          {1:~     }{12: aa             }{1:                                 }|
           {1:~     }{n: aaa            }{1:                                 }|
           {1:~                                                      }|*15
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 2}        |
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 2}        |
         ]])
         feed('<F5>')
         screen:expect([[
-          {2: [No Name] }{11: + [No Name] }{3:                              }{11:X}|
+          {5: [No Name] }{24: + [No Name] }{2:                              }{24:X}|
           ^                                                       |
           {1:~                                                      }|*17
-          {2:-- INSERT --}                                           |
+          {5:-- INSERT --}                                           |
         ]])
         feed('<Esc>')
         command('tabclose!')
@@ -8733,18 +8508,18 @@ describe('builtin popupmenu', function()
         feed('Abb bbb <C-X><C-N>')
         screen:expect([[
           bb bbb bb^                  │aa aaa aa                  |
-          {1:~     }{s: bb             }{1:     }│{1:~                          }|
+          {1:~     }{12: bb             }{1:     }│{1:~                          }|
           {1:~     }{n: bbb            }{1:     }│{1:~                          }|
           {1:~                          }│{1:~                          }|*15
-          {4:win_b [+]                   }{3:[No Name] [+]              }|
-          {2:-- Keyword Local completion (^N^P) }{5:match 1 of 2}        |
+          {3:win_b [+]                   }{2:[No Name] [+]              }|
+          {5:-- Keyword Local completion (^N^P) }{6:match 1 of 2}        |
         ]])
         feed('<F4>')
         screen:expect([[
           bb bbb bb                  │aa aaa a^a                  |
           {1:~                          }│{1:~                          }|*17
-          {3:win_b [+]                   }{4:[No Name] [+]              }|
-          {2:-- INSERT --}                                           |
+          {2:win_b [+]                   }{3:[No Name] [+]              }|
+          {5:-- INSERT --}                                           |
         ]])
       end)
     end

--- a/test/functional/ui/screen.lua
+++ b/test/functional/ui/screen.lua
@@ -274,10 +274,6 @@ function Screen:add_extra_attr_ids(extra_attr_ids)
   self._default_attr_ids = attr_ids
 end
 
-function Screen:get_default_attr_ids()
-  return deepcopy(self._default_attr_ids)
-end
-
 function Screen:set_rgb_cterm(val)
   self._rgb_cterm = val
 end


### PR DESCRIPTION
Problem:  get_default_attr_ids() is used to get and change a subset of
          the current highlight definitions in {fold,popupmenu}_spec.lua,
          for which we have add_extra_attr_ids().
Solution: Use global highlight definitions and use add_extra_attr_ids to
          replace.
