### PR TITLE
vim-patch:175662f: runtime(vim): Update base syntax, fix incorrect function error

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -281,7 +281,7 @@ syn keyword vimBehaveModel	contained	mswin	xterm
 
 " Call {{{2
 " ====
-syn match vimCall	"\<call\=\>"	skipwhite nextgroup=@vimFunc
+syn match vimCall	"\<call\=\>"	skipwhite nextgroup=vimVar,@vimFunc
 
 " Debuggreedy {{{2
 " ===========
@@ -2066,6 +2066,7 @@ unlet s:interfaces
 " (following Gautam Iyer's suggestion)
 " ==========================
 syn match	vimFunc	contained	"\<\l\w*\ze\s*("				skipwhite nextgroup=vimOperParen contains=vimFuncName
+syn match	vimUserFunc	contained	"\.\@1<=\l\w*\ze\s*("			skipwhite nextgroup=vimOperParen contains=vimFuncName
 syn match	vimUserFunc	contained	"\<\%([[:upper:]_]\|\%(\h\w*\.\)\+\h\)\w*\ze\s*("		skipwhite nextgroup=vimOperParen contains=vim9MethodName,vim9Super,vim9This
 syn match	vimUserFunc	contained	"\<\%(g:\)\=\%(\h\w*#\)\+\h\w*\ze\s*("		skipwhite nextgroup=vimOperParen contains=vimVarScope
 syn match	vimUserFunc	contained	"\%(\<[sgbwtlav]:\|<[sS][iI][dD]>\)\%(\h\w*\.\)*\h\w*\ze\s*("	skipwhite nextgroup=vimOperParen contains=vimVarScope,vimNotation


### PR DESCRIPTION
#### vim-patch:175662f: runtime(vim): Update base syntax, fix incorrect function error

Don't match lower-case function names as errors when the qualifier
includes a dict/list accessor.

This is a less than perfect fix until qualified function call matching
is reworked.

closes: vim/vim#17780

https://github.com/vim/vim/commit/175662f4f2a046a5ca33338cd3c1ca017e135ee8

Co-authored-by: Doug Kearns <dougkearns@gmail.com>