### PR TITLE
vim-patch:57300a2: runtime(doc): fix claim that 'CTRL-W CTRL-C' and 'CTRL-W c' are the same

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -516,7 +516,7 @@ tag		command		   action in op-pending and Visual mode	~
 tag		command		   action in Normal mode	~
 ------------------------------------------------------------------------------ ~
 |CTRL-W_CTRL-B|	CTRL-W CTRL-B	   same as "CTRL-W b"
-|CTRL-W_CTRL-C|	CTRL-W CTRL-C	   same as "CTRL-W c"
+|CTRL-W_CTRL-C|	CTRL-W CTRL-C	   no-op |CTRL-W_CTRL-C|
 |CTRL-W_CTRL-D|	CTRL-W CTRL-D	   same as "CTRL-W d"
 |CTRL-W_CTRL-F|	CTRL-W CTRL-F	   same as "CTRL-W f"
 		CTRL-W CTRL-G	   same as "CTRL-W g .."


### PR DESCRIPTION
#### vim-patch:57300a2: runtime(doc): fix claim that 'CTRL-W CTRL-C' and 'CTRL-W c' are the same

closes: vim/vim#17776

https://github.com/vim/vim/commit/57300a22dc8efeba79ce22aa9ab7dd5369ba9613

Co-authored-by: Emilien Breton <bricktech2000@gmail.com>