### PR TITLE
vim-patch:9.1.1563: completion: ruler may disappear

### DIFF
--- a/src/nvim/statusline.c
+++ b/src/nvim/statusline.c
@@ -415,7 +415,7 @@ void redraw_ruler(void)
     return;
   }
 
-  // Check if cursor.lnum is valid, since win_redr_ruler() may be called
+  // Check if cursor.lnum is valid, since redraw_ruler() may be called
   // after deleting lines, before cursor.lnum is corrected.
   if (wp->w_cursor.lnum > wp->w_buffer->b_ml.ml_line_count) {
     return;

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1376,6 +1376,7 @@ describe('completion', function()
 
   -- oldtest: Test_shortmess()
   it('shortmess+=c turns off completion messages', function()
+    command('set ruler')
     command([[call setline(1, ['hello', 'hullo', 'heee'])]])
     feed('Goh<C-N>')
     screen:expect([[
@@ -1399,7 +1400,7 @@ describe('completion', function()
       {12:hello          }{1:                                             }|
       {4:hullo          }{1:                                             }|
       {4:heee           }{1:                                             }|
-      {5:-- INSERT --}                                                |
-   ]])
+      {5:-- INSERT --}                              4,6           All |
+    ]])
   end)
 end)

--- a/test/old/testdir/test_popup.vim
+++ b/test/old/testdir/test_popup.vim
@@ -220,7 +220,6 @@ func Test_popup_complete()
   set completeopt&
 endfunc
 
-
 func Test_popup_completion_insertmode()
   new
   inoremap <F5> <C-R>=ListMonths()<CR>


### PR DESCRIPTION
#### vim-patch:9.1.1563: completion: ruler may disappear

Problem:  The ruler disappears after typing the second character during
          insert mode completion, even when completion messages are
          suppressed ('shortmess' includes "c"). This makes the UI
          appear inconsistent.
Solution: Ensure the ruler is restored during screen redraw when popup
          completion is active (Girish Palya).

Notes:
No new tests were added, as existing screen dump tests were updated to
reflect the corrected behavior.

closes: vim/vim#17770

https://github.com/vim/vim/commit/824286c9a727811ed93e4e2f4f10944f735436e7

Nvim already behaves correctly as the popup menu is a separate grid in
the compositor.

Co-authored-by: Girish Palya <girishji@gmail.com>