### PR TITLE
feat(events): add `Search` event

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -878,6 +878,9 @@ RemoteReply			When a reply from a Vim that functions as
 				Note that even if an autocommand is defined,
 				the reply should be read with remote_read()
 				to consume it.
+							*SearchPost*
+SearchPost			After making a search with |n|, |*|, |#|, or
+				|N|, or after the |:substitute| command.
 							*SearchWrapped*
 SearchWrapped			After making a search with |n| or |N| if the
 				search wraps around the document back to

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -176,6 +176,7 @@ EVENTS
 
 • |CmdlineLeavePre| triggered before preparing to leave the command line.
 • New `append` paremeter for |ui-messages| `msg_show` event.
+• Added |SearchPost| event.
 
 HIGHLIGHTS
 

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -321,6 +321,7 @@ Events (autocommands):
 - Fixed inconsistent behavior in execution of nested autocommands #23368
 - |RecordingEnter|
 - |RecordingLeave|
+- |SearchPost|
 - |SearchWrapped|
 - |Signal|
 - |TabNewEntered|

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -172,6 +172,7 @@ error('Cannot require a meta file')
 --- |'RecordingLeave'
 --- |'RemoteReply'
 --- |'SafeState'
+--- |'SearchPost'
 --- |'SearchWrapped'
 --- |'SessionLoadPost'
 --- |'SessionWritePost'

--- a/src/nvim/auevents.lua
+++ b/src/nvim/auevents.lua
@@ -93,6 +93,7 @@ return {
     RecordingLeave = true, -- just before a macro stops recording
     RemoteReply = false, -- upon string reception from a remote vim
     SafeState = false, -- going to wait for a character
+    SearchPost = true, -- after a search is performed
     SearchWrapped = true, -- after the search wrapped around
     SessionLoadPost = false, -- after loading a session file
     SessionWritePost = false, -- after writing a session file

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6152,6 +6152,8 @@ static int search_cmn(typval_T *argvars, pos_T *match_pos, int *flagsp)
 theend:
   p_ws = save_p_ws;
 
+  apply_autocmds(EVENT_SEARCHPOST, NULL, NULL, false, curbuf);
+
   return retval;
 }
 

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -4906,6 +4906,7 @@ static int show_sub(exarg_T *eap, pos_T old_cusr, PreviewLines *preview_lines, i
 void ex_substitute(exarg_T *eap)
 {
   do_sub(eap, profile_zero(), 0, 0);
+  apply_autocmds(EVENT_SEARCHPOST, NULL, NULL, false, curbuf);
 }
 
 /// :substitute command preview callback.

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -2481,6 +2481,8 @@ bool find_decl(char *ptr, size_t len, bool locally, bool thisblock, int flags_ar
   p_ws = save_p_ws;
   p_scs = save_p_scs;
 
+  apply_autocmds(EVENT_SEARCHPOST, NULL, NULL, false, curbuf);
+
   return retval;
 }
 

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1465,6 +1465,11 @@ end_do_search:
   xfree(strcopy);
   xfree(msgbuf);
 
+  // fire EVENT_SEARCHPOST when search is complete
+  if (!(options & SEARCH_PEEK)) {
+    apply_autocmds(EVENT_SEARCHPOST, NULL, NULL, false, curbuf);
+  }
+
   return retval;
 }
 

--- a/test/functional/autocmd/searchpost_spec.lua
+++ b/test/functional/autocmd/searchpost_spec.lua
@@ -1,0 +1,122 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local api = n.api
+local clear = n.clear
+local command = n.command
+local eq = t.eq
+local eval = n.eval
+local feed = n.feed
+
+describe('autocmd SearchPost', function()
+  -- set up tests
+  before_each(function()
+    clear()
+    command('set ignorecase')
+
+    -- if incsearch is on, some searching functions will be called on each keypress. These "peek"
+    -- searches should not trigger the SearchPost event
+    command('set incsearch')
+
+    -- keep track of SearchPost events
+    command('let g:test = 0')
+    command('autocmd! SearchPost * let g:test += 1')
+
+    -- put some initial content into the buffer
+    api.nvim_buf_set_lines(0, 0, 1, false, {
+      'All avian aligators amidst aerial astronauts are awesome',
+      'Bad bells bing-bong before Bill Benfry Benson becomes bald',
+    })
+  end)
+
+  local count = function()
+    return eval('g:test')
+  end
+
+  it('gets triggered when a search is performed', function()
+    feed('/al<Return>')
+    eq(1, count())
+    feed('?al<Return>')
+    eq(2, count())
+  end)
+
+  it('gets triggered on n/N/*/#/gd/gD/g*/g# in normal mode', function()
+    feed('/al<Return>')
+
+    -- check trigger keys
+    feed('n')
+    eq(2, count())
+    feed('N')
+    eq(3, count())
+    feed('*')
+    eq(4, count())
+    feed('#')
+    eq(5, count())
+    feed('gd')
+    eq(6, count())
+    feed('gD')
+    eq(7, count())
+    feed('g*')
+    eq(8, count())
+    feed('g#')
+    eq(9, count())
+  end)
+
+  it('gets triggered on n/N/*/#/gd/gD/g*/g# in visual mode', function()
+    feed('/al<Return>')
+
+    -- enter visual mode
+    feed('v')
+
+    -- check trigger keys
+    feed('n')
+    eq(2, count())
+    feed('N')
+    eq(3, count())
+    feed('*')
+    eq(4, count())
+    feed('#')
+    eq(5, count())
+    feed('gd')
+    eq(6, count())
+    feed('gD')
+    eq(7, count())
+    feed('g*')
+    eq(8, count())
+    feed('g#')
+    eq(9, count())
+  end)
+
+  it('gets triggered on the :substitute command and its variants', function()
+    feed(':%s/a/b<Return>')
+    eq(1, count())
+    feed(':%smagic/a/b<Return>')
+    eq(2, count())
+    feed(':%snomagic/a/b<Return>')
+    eq(3, count())
+  end)
+
+  it('gets triggered by & and g&', function()
+    -- perform an initial :substitute
+    feed(':%s/a/b<Return>')
+    eq(1, count())
+
+    -- check trigger keys
+    feed('&')
+    eq(2, count())
+    feed('g&')
+    eq(3, count())
+
+    -- enter visual mode
+    feed('v')
+
+    -- check trigger keys
+    feed('g&')
+    eq(4, count())
+  end)
+
+  it('gets triggered on the search() function', function()
+    feed(':echo search("a")<Return>')
+    eq(1, count())
+  end)
+end)


### PR DESCRIPTION
### Problem

Many plugins will want to take some action when the user performs a search. Currently there is no built-in hook for this.

### Solution

The SearchPost event will fire whenever a search is made.

### Context/Examples

- [nullromo/cash.nvim](https://github.com/nullromo/cash.nvim): this plugin would love this event because it would make setting up autocommands much easier.
- [tuurep/registereditor](https://github.com/tuurep/registereditor): this plugin displays what's in the "/ register in real time, so it would be nice to be able to hook into changes on that register.

### Current Workaround

Truly catching all search events requires mapping keys like `n` and `*` in normal and visual modes, as well as somehow detecting the `:substitute` command. This means multiple keymaps, and they could all potentially conflict with existing keymaps. The correct way to handle this is unclear.

## Checklist

#### Event triggers in the following situations

- [x] `n`/`N` from normal mode
- [x] `*`/`#` from normal mode
- [x] `n`/`N` from visual mode
- [x] `*`/`#` from visual mode
- [x] `gd`, `gD` from normal mode
- [x] `g*`, `g#` from normal mode
- [x] `gd`, `gD` from visual mode
- [x] `g*`, `g#` from visual mode
- [x] `:substitute`/`:smagic`/`:snomagic`
- [x] `search()`

#### Event does NOT trigger in the following situations
- [x] `:vimgrep`/`:vimgrepadd`/`:lvimgrep`/`:lvimgrepadd`

#### Event triggers in the following `incsearch` situations
- [ ] `:global`/`:vglobal`/`:substitute`/`:smagic`/`:snomagic`
- [ ] typing after `/` or `?`
- [ ] `c_CTRL-T`/`c_CTRL-G`

#### Other
- [ ] Data in `v:event` to determine source
- [ ] Data in `v:event` to determine peek