### PR TITLE
vim-patch:3ab6941: runtime(doc): Tweak documentation

### DIFF
--- a/runtime/doc/change.txt
+++ b/runtime/doc/change.txt
@@ -965,7 +965,7 @@ This replaces each 'E' character with a euro sign.  Read more in |<Char->|.
 			not make any visible change.
 
 			When [-indentonly] is specified, only the leading
-			white-space will be targeted. Any other consecutive
+			white-space will be targeted.  Any other consecutive
 			white-space will not be changed.
 
 			Warning: This command modifies any <Tab> characters

--- a/runtime/doc/fold.txt
+++ b/runtime/doc/fold.txt
@@ -641,7 +641,7 @@ all lines of the fold.
 This does not happen for |:folddoopen| and |:folddoclosed|.
 
 Note that for some Ex commands like |:source| the range is only adjusted when
-using a two-address [range].
+using a two line specifiers [range].
 
 When editing a buffer that has been edited before, the last used folding
 settings are used again.  For manual folding the defined folds are restored.

--- a/runtime/doc/repeat.txt
+++ b/runtime/doc/repeat.txt
@@ -210,11 +210,10 @@ For writing a Vim script, see chapter 41 of the user manual |usr_41.txt|.
 			Implementation detail: When sourcing a [range] of
 			lines that falls inside a folded region, the range
 			will be adjusted to the start and end of the fold,
-			but only if a two-address range was used.
+			but only if a two line specifiers range was used.
 
 							*:source!*
-:so[urce]! {file}
-			Runs |Normal-mode| commands from {file}. When used
+:so[urce]! {file}	Runs |Normal-mode| commands from {file}. When used
 			after |:global|, |:argdo|, |:windo|, |:bufdo|, in
 			a loop or when another command follows the display
 			won't be updated while executing the commands.


### PR DESCRIPTION
#### vim-patch:3ab6941: runtime(doc): Tweak documentation

closes: vim/vim#17759

https://github.com/vim/vim/commit/3ab69417136ab0b1c9172188acbf1df6a3f2011d

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>