### PR TITLE
vim-patch:b7fc24d: runtime(python): Highlight f-strings in Python

### DIFF
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Python
 " Maintainer:	Zvezdan Petkovic <zpetkovic@acm.org>
-" Last Change:	2025 Jul 14
+" Last Change:	2025 Jul 17
 " Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "		Rob B
@@ -154,6 +154,33 @@ syn region  pythonRawString matchgroup=pythonQuotes
       \ contains=@Spell
 syn region  pythonRawString matchgroup=pythonTripleQuotes
       \ start=+[rR]\z('''\|"""\)+ end="\z1" keepend
+      \ contains=pythonSpaceError,pythonDoctest,@Spell
+
+" Formatted string literals (f-strings)
+" https://docs.python.org/3/reference/lexical_analysis.html#f-strings
+syn region  pythonFString
+      \ matchgroup=pythonQuotes
+      \ start=+\cF\z(['"]\)+
+      \ end="\z1"
+      \ skip="\\\\\|\\\z1"
+      \ contains=pythonEscape,pythonUnicodeEscape,@Spell
+syn region  pythonFString
+      \ matchgroup=pythonTripleQuotes
+      \ start=+\cF\z('''\|"""\)+
+      \ end="\z1"
+      \ keepend
+      \ contains=pythonEscape,pythonUnicodeEscape,pythonSpaceError,pythonDoctest,@Spell
+syn region  pythonRawFString
+      \ matchgroup=pythonQuotes
+      \ start=+\c\%(FR\|RF\)\z(['"]\)+
+      \ end="\z1"
+      \ skip="\\\\\|\\\z1"
+      \ contains=@Spell
+syn region  pythonRawFString
+      \ matchgroup=pythonTripleQuotes
+      \ start=+\c\%(FR\|RF\)\z('''\|"""\)+
+      \ end="\z1"
+      \ keepend
       \ contains=pythonSpaceError,pythonDoctest,@Spell
 
 " Bytes
@@ -338,6 +365,8 @@ hi def link pythonComment		Comment
 hi def link pythonTodo			Todo
 hi def link pythonString		String
 hi def link pythonRawString		String
+hi def link pythonFString		String
+hi def link pythonRawFString		String
 hi def link pythonBytes 		String
 hi def link pythonRawBytes 		String
 hi def link pythonQuotes		String


### PR DESCRIPTION
fixes: vim/vim#10734
fixes: vim/vim#14033
closes: vim/vim#17767

https://github.com/vim/vim/commit/b7fc24d3a3d21ccf1461c703eb7ff07ef3994c54

Co-authored-by: Rob B <github@0x7e.net>
