### PR TITLE
vim-patch:f2290a6: runtime(compiler): Add PHPStan compiler

### DIFF
--- a/runtime/compiler/phpstan.vim
+++ b/runtime/compiler/phpstan.vim
@@ -1,0 +1,12 @@
+" Vim compiler file
+" Compiler:	PHPStan
+" Maintainer:	Dietrich Moerman <dietrich.moerman@gmail.com>
+" Last Change:	2025 Jul 17
+
+if exists("current_compiler")
+  finish
+endif
+let current_compiler = "phpstan"
+
+CompilerSet makeprg=composer\ exec\ --\ phpstan\ analyse\ -v\ --no-progress\ --error-format=raw
+CompilerSet errorformat=%f:%l:%m,%-G%.%#


### PR DESCRIPTION
#### vim-patch:f2290a6: runtime(compiler): Add PHPStan compiler

closes: vim/vim#17781

https://github.com/vim/vim/commit/f2290a682365c3a99e582bb74c99b0e5c4b98113

Co-authored-by: Dietrich Moerman <dietrich.moerman@gmail.com>