### PR TITLE
vim-patch:9.1.1567: crash when using inline diff mode

### DIFF
--- a/test/functional/ui/diff_spec.lua
+++ b/test/functional/ui/diff_spec.lua
@@ -2801,6 +2801,32 @@ it('diff mode inline highlighting with 3 buffers', function()
   screen:expect(s6)
 end)
 
+-- oldtest: Test_diff_inline_multibuffer_empty_block()
+it('diff mode inline highlighting with multi-buffer and empty block', function()
+  write_file('Xdifile1', 'anchor1\n1234567890abcde\nanchor2')
+  write_file('Xdifile2', 'anchor1\n1234567--0abc-e\nanchor2')
+  write_file('Xdifile3', 'anchor1\nanchor2')
+  write_file('Xdifile4', 'anchor1\n1???????90abcd?\nanchor2')
+  finally(function()
+    os.remove('Xdifile1')
+    os.remove('Xdifile2')
+    os.remove('Xdifile3')
+    os.remove('Xdifile4')
+  end)
+  local screen = Screen.new(83, 20)
+  command('args Xdifile1 Xdifile2 Xdifile3 Xdifile4 | vert all | windo diffthis')
+  command('1wincmd w | set diffopt=filler,internal,inline:char')
+  screen:expect([[
+    {7:  }^anchor1           │{7:  }anchor1           │{7:  }anchor1           │{7:  }anchor1           |
+    {7:  }{4:1}{27:23456789}{4:0abc}{27:de}{4:   }│{7:  }{4:1}{27:234567--}{4:0abc}{27:-e}{4:   }│{7:  }{23:------------------}│{7:  }{4:1}{27:???????9}{4:0abc}{27:d?}{4:   }|
+    {7:  }anchor2           │{7:  }anchor2           │{7:  }anchor2           │{7:  }anchor2           |
+    {1:~                   }│{1:~                   }│{1:~                   }│{1:~                   }|*15
+    {3:Xdifile1             }{2:Xdifile2             Xdifile3             Xdifile4            }|
+                                                                                       |
+  ]])
+  n.assert_alive()
+end)
+
 it('diff mode algorithm:histogram and inline:char with long lines #34329', function()
   local screen = Screen.new(55, 20)
   exec([[

--- a/test/old/testdir/test_diffmode.vim
+++ b/test/old/testdir/test_diffmode.vim
@@ -2384,6 +2384,22 @@ func Test_diff_inline_multibuffer()
   call StopVimInTerminal(buf)
 endfunc
 
+" Test that when using multi-buffer diff, an empty block would be correctly
+" skipped in the result, without resulting in invalid states or crashes.
+func Test_diff_inline_multibuffer_empty_block()
+  CheckScreendump
+
+  call writefile(['anchor1', '1234567890abcde', 'anchor2'], 'Xdifile1')
+  call writefile(['anchor1', '1234567--0abc-e', 'anchor2'], 'Xdifile2')
+  call writefile(['anchor1', 'anchor2'], 'Xdifile3')
+  call writefile(['anchor1', '1???????90abcd?', 'anchor2'], 'Xdifile4')
+
+  let buf = RunVimInTerminal('-d Xdifile1 Xdifile2 Xdifile3 Xdifile4', {})
+  call VerifyInternal(buf, "Test_diff_inline_multibuffer_empty_block_01", " diffopt+=inline:char")
+
+  call StopVimInTerminal(buf)
+endfunc
+
 func Test_diffget_diffput_linematch()
   CheckScreendump
   call delete('.Xdifile1.swp')


### PR DESCRIPTION
#### vim-patch:9.1.1567: crash when using inline diff mode

Problem:  Crash when using inline diff mode
          (Ilya Grigoriev)
Solution: Set tp_diffbuf to NULL when skipping a diff block
          (Yee Cheng Chin).

Fix an array out of bounds crash when using diffopt+=inline:char when 4
or more buffers are being diff'ed. This happens when one of the blocks
is empty. The inline highlight logic skips using that buffer's block,
but when another buffer is used later and calls diff_read() to merge the
diff blocks together, it could erroneously consider the empty block's
diff info which has not been initialized, leaving to diff numbers that
are invalid. Later on the diff num is used without bounds checking which
leads to the crash.

Fix this by making sure to unset tp_diffbuf to NULL when we skip a
block, so diff_read() will not consider this buffer to be used within
inline diff. Also, add more bounds checking just to be safe.

closes: vim/vim#17805

https://github.com/vim/vim/commit/c8b99e2d139cf72c567892e44939f2719f703fa8

Co-authored-by: Yee Cheng Chin <ychin.git@gmail.com>