### PR TITLE
vim-patch:9.1.1568: need a few more default highlight groups

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -180,7 +180,7 @@ EVENTS
 HIGHLIGHTS
 
 • |hl-DiffTextAdd| highlights added text within a changed line.
-• |hl-StderrMsg| |hl-StdoutMsg|
+• |hl-StderrMsg| |hl-StdoutMsg|, "Bold", "Italic", "BoldItalic".
 
 LSP
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -234,6 +234,9 @@ SpecialComment	special things inside a comment
 Debug		debugging statements
 
 Underlined	text that stands out, HTML links
+Bold		bold text
+Italic		italic text
+BoldItalic	bold and italic text
 
 Ignore		left blank, hidden  |hl-Ignore|
 

--- a/runtime/syntax/help.vim
+++ b/runtime/syntax/help.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:		Vim help file
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
-" Last Change:		2025 Jul 12
+" Last Change:		2025 Jul 20
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
@@ -173,6 +173,9 @@ syn match helpDelimiter		"\t[* ]Delimiter\t\+[a-z].*"
 syn match helpSpecialComment	"\t[* ]SpecialComment\t\+[a-z].*"
 syn match helpDebug		"\t[* ]Debug\t\+[a-z].*"
 syn match helpUnderlined	"\t[* ]Underlined\t\+[a-z].*"
+syn match helpBold		"\t[* ]Bold\t\+[a-z].*"
+syn match helpItalic		"\t[* ]Italic\t\+[a-z].*"
+syn match helpBoldItalic	"\t[* ]BoldItalic\t\+[a-z].*"
 syn match helpError		"\t[* ]Error\t\+[a-z].*"
 syn match helpTodo		"\t[* ]Todo\t\+[a-z].*"
 
@@ -243,6 +246,9 @@ hi def link helpDelimiter	Delimiter
 hi def link helpSpecialComment	SpecialComment
 hi def link helpDebug		Debug
 hi def link helpUnderlined	Underlined
+hi def link helpBold		Bold
+hi def link helpItalic		Italic
+hi def link helpBoldItalic	BoldItalic
 hi def link helpError		Error
 hi def link helpTodo		Todo
 hi def link helpURL		String

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -144,16 +144,19 @@ static const char e_missing_argument_str[]
 // they still work when the runtime files can't be found.
 
 static const char *highlight_init_both[] = {
-  "Cursor            guifg=bg      guibg=fg",
-  "CursorLineNr      gui=bold      cterm=bold",
-  "PmenuMatch        gui=bold      cterm=bold",
-  "PmenuMatchSel     gui=bold      cterm=bold",
-  "PmenuSel          gui=reverse   cterm=reverse,underline blend=0",
-  "RedrawDebugNormal gui=reverse   cterm=reverse",
-  "TabLineSel        gui=bold      cterm=NONE",
-  "TermCursor        gui=reverse   cterm=reverse",
-  "Underlined        gui=underline cterm=underline",
-  "lCursor           guifg=bg      guibg=fg",
+  "Cursor            guifg=bg        guibg=fg",
+  "CursorLineNr      gui=bold        cterm=bold",
+  "PmenuMatch        gui=bold        cterm=bold",
+  "PmenuMatchSel     gui=bold        cterm=bold",
+  "PmenuSel          gui=reverse     cterm=reverse,underline blend=0",
+  "RedrawDebugNormal gui=reverse     cterm=reverse",
+  "TabLineSel        gui=bold        cterm=NONE",
+  "TermCursor        gui=reverse     cterm=reverse",
+  "Underlined        gui=underline   cterm=underline",
+  "Bold              gui=bold        cterm=bold",
+  "Italic            gui=italic      cterm=italic",
+  "BoldItalic        gui=bold,italic cterm=bold,italic",
+  "lCursor           guifg=bg        guibg=fg",
 
   // UI
   "default link CursorIM         Cursor",


### PR DESCRIPTION
#### vim-patch:9.1.1568: need a few more default highlight groups

Problem:  need a few more default highlight groups
Solution: Add Bold, Italic and BoldItalic default highlight groups
          (Maxim Kim).

related: https://github.com/vim/vim/pull/17598#issuecomment-3007320523
closes: vim/vim#17804

https://github.com/vim/vim/commit/16f7098e68951ce421512c34d03810bdd1efbaed

Co-authored-by: Maxim Kim <habamax@gmail.com>