### PR TITLE
vim-patch:9.1.1572: expanding $var does not escape whitespace for 'path'

### DIFF
--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1593,13 +1593,13 @@ static char *option_expand(OptIndex opt_idx, const char *val)
   }
 
   // Expanding this with NameBuff, expand_env() must not be passed IObuff.
-  // Escape spaces when expanding 'tags', they are used to separate file
-  // names.
+  // Escape spaces when expanding 'tags' or 'path', they are used to separate
+  // file names.
   // For 'spellsuggest' expand after "file:".
-  expand_env_esc(val, NameBuff, MAXPATHL,
-                 (char **)options[opt_idx].var == &p_tags, false,
-                 (char **)options[opt_idx].var == &p_sps ? "file:"
-                                                         : NULL);
+  char **var = (char **)options[opt_idx].var;
+  bool esc = var == &p_tags || var == &p_path;
+  expand_env_esc(val, NameBuff, MAXPATHL, esc, false,
+                 (char **)options[opt_idx].var == &p_sps ? "file:" : NULL);
   if (strcmp(NameBuff, val) == 0) {   // they are the same
     return NULL;
   }

--- a/test/old/testdir/test_findfile.vim
+++ b/test/old/testdir/test_findfile.vim
@@ -840,5 +840,36 @@ func Test_findfunc_callback()
   %bw!
 endfunc
 
+" Test using environment variables with spaces
+func Test_path_env_variable_with_whitespaces()
+    let save_path = &path
+    defer execute('let &path = save_path')
+
+    let $testdir = 'Xpath with some whites'
+    call mkdir($testdir, 'R')
+
+    " Check direct usage yields the same result that autocomplete
+    call feedkeys(':set path=$testdir' .. "\<C-A>\<CR>", 'xt')
+    let auto_testpath = &path
+    " include autocomplete suffix
+    exe "set path=$testdir" .. "/"
+    call assert_equal(auto_testpath, &path)
+
+    " Check a file can be found using environment variables
+    let expanded_test_path = expand('$testdir/test.txt')
+    call writefile(['testing...'], expanded_test_path)
+
+    " hinting an environment variable path
+    call assert_equal(expanded_test_path, findfile('test.txt', $test_dir))
+
+    " using 'path' option with an environment variable
+    set path=$testdir
+    call assert_equal(expanded_test_path, findfile('test.txt'))
+
+    " using :find instead of findfile()
+    find test.txt
+    call assert_equal(expanded_test_path, expand('%:.'))
+    enew
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1572: expanding $var does not escape whitespace for 'path'

Problem:  expanding $var does not escape whitespace for 'path'
Solution: Escape whitespace when expanding 'path' option.
          (Miguel Barro)

closes: vim/vim#17801

https://github.com/vim/vim/commit/8b004081c4cd3788c3685420cbbe3b45e609724f

Co-authored-by: Miguel Barro <miguel.barro@live.com>