### PR TITLE
fix(lsp): show notification with empty hover response

### DIFF
--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -7110,4 +7110,31 @@ describe('LSP', function()
       )
     end)
   end)
+
+  describe('vim.lsp.buf.hover()', function()
+    it('handles empty contents', function()
+      exec_lua(create_server_definition)
+      exec_lua(function()
+        local server = _G._create_server({
+          capabilities = {
+            hoverProvider = true,
+          },
+          handlers = {
+            ['textDocument/hover'] = function(_, _, callback)
+              local res = {
+                contents = {
+                  kind = 'markdown',
+                  value = '',
+                },
+              }
+              callback(nil, res)
+            end,
+          },
+        })
+        vim.lsp.start({ name = 'dummy', cmd = server.cmd })
+      end)
+
+      eq('Empty hover response', n.exec_capture('lua vim.lsp.buf.hover()'))
+    end)
+  end)
 end)


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

Includes the fix from https://github.com/neovim/neovim/pull/34928 with the suggestion from https://github.com/neovim/neovim/pull/34928#issuecomment-3079568894.