### PR TITLE
vim-patch:9.1.{1571,1573}: CmdlineChanged triggered to often

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -134,6 +134,7 @@ typedef struct {
   int save_msg_scroll;
   int save_State;                       // remember State when called
   int prev_cmdpos;
+  char *prev_cmdbuff;
   char *save_p_icm;
   bool some_key_typed;                  // one of the keys was typed
   // mouse drag and release events are ignored, unless they are
@@ -1013,12 +1014,14 @@ theend:
     ccline.cmdbuff = NULL;
   }
 
+  xfree(s->prev_cmdbuff);
   return (uint8_t *)p;
 }
 
 static int command_line_check(VimState *state)
 {
   CommandLineState *s = (CommandLineState *)state;
+  s->prev_cmdpos = ccline.cmdpos;
 
   redir_off = true;        // Don't redirect the typed command.
   // Repeated, because a ":redir" inside
@@ -1028,6 +1031,10 @@ static int command_line_check(VimState *state)
   did_emsg = false;        // There can't really be a reason why an error
                            // that occurs while typing a command should
                            // cause the command not to be executed.
+
+  if (ccline.cmdbuff != NULL) {
+    s->prev_cmdbuff = xmemdupz(ccline.cmdbuff, (size_t)ccline.cmdpos);
+  }
 
   // Trigger SafeState if nothing is pending.
   may_trigger_safestate(s->xpc.xp_numfiles <= 0);
@@ -2288,7 +2295,6 @@ static void may_trigger_cursormovedc(CommandLineState *s)
 {
   if (ccline.cmdpos != s->prev_cmdpos) {
     trigger_cmd_autocmd(s->cmdline_type, EVENT_CURSORMOVEDC);
-    s->prev_cmdpos = ccline.cmdpos;
     ccline.redraw_state = MAX(ccline.redraw_state, kCmdRedrawPos);
   }
 }
@@ -2296,12 +2302,14 @@ static void may_trigger_cursormovedc(CommandLineState *s)
 static int command_line_not_changed(CommandLineState *s)
 {
   may_trigger_cursormovedc(s);
+  s->prev_cmdpos = ccline.cmdpos;
   // Incremental searches for "/" and "?":
   // Enter command_line_not_changed() when a character has been read but the
   // command line did not change. Then we only search and redraw if something
   // changed in the past.
   // Enter command_line_changed() when the command line did change.
   if (!s->is_state.incsearch_postponed) {
+    XFREE_CLEAR(s->prev_cmdbuff);
     return 1;
   }
   return command_line_changed(s);
@@ -2772,8 +2780,14 @@ static void do_autocmd_cmdlinechanged(int firstc)
 
 static int command_line_changed(CommandLineState *s)
 {
-  // Trigger CmdlineChanged autocommands.
-  do_autocmd_cmdlinechanged(s->firstc > 0 ? s->firstc : '-');
+  if (ccline.cmdpos != s->prev_cmdpos
+      || (s->prev_cmdbuff != NULL
+          && strncmp(s->prev_cmdbuff, ccline.cmdbuff, (size_t)s->prev_cmdpos) != 0)) {
+    // Trigger CmdlineChanged autocommands.
+    do_autocmd_cmdlinechanged(s->firstc > 0 ? s->firstc : '-');
+  }
+
+  XFREE_CLEAR(s->prev_cmdbuff);
 
   may_trigger_cursormovedc(s);
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1021,7 +1021,9 @@ theend:
 static int command_line_check(VimState *state)
 {
   CommandLineState *s = (CommandLineState *)state;
+
   s->prev_cmdpos = ccline.cmdpos;
+  XFREE_CLEAR(s->prev_cmdbuff);
 
   redir_off = true;        // Don't redirect the typed command.
   // Repeated, because a ":redir" inside
@@ -2309,7 +2311,6 @@ static int command_line_not_changed(CommandLineState *s)
   // changed in the past.
   // Enter command_line_changed() when the command line did change.
   if (!s->is_state.incsearch_postponed) {
-    XFREE_CLEAR(s->prev_cmdbuff);
     return 1;
   }
   return command_line_changed(s);
@@ -2786,8 +2787,6 @@ static int command_line_changed(CommandLineState *s)
     // Trigger CmdlineChanged autocommands.
     do_autocmd_cmdlinechanged(s->firstc > 0 ? s->firstc : '-');
   }
-
-  XFREE_CLEAR(s->prev_cmdbuff);
 
   may_trigger_cursormovedc(s);
 


### PR DESCRIPTION
#### vim-patch:9.1.1571: CmdlineChanged triggered to often

Problem:  The CmdlineChanged event was firing unnecessarily, even when
          the command line's content hadn't actually changed.

Solution: I've added a check to compare the command-line buffer's state
          before and after key processing. The `CmdlineChanged` event
          now only triggers if the buffer's contents are genuinely
          different (Girish Palya).

closes: vim/vim#17803

https://github.com/vim/vim/commit/239c4e4abe79c0f3611f0b4776ee34fbf0ac53cf

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1573: Memory leak when pressing Ctrl-D in cmdline mode

Problem:  Memory leak when pressing Ctrl-D in cmdline mode
          (after 9.1.1571).
Solution: Free prev_cmdbuff before assigning to it.
          (zeertzjq).

Existing tests already cover this. This change fixes the CI failure.

closes: vim/vim#17807

https://github.com/vim/vim/commit/c02bef26fdfbffd442cbc5acef375256fa7fd6ff