### PR TITLE
vim-patch:1f6faff: runtime(doc): mention the "pipefail" shell option

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -5557,6 +5557,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	Don't forget to precede the space with a backslash: ":set sp=\ ".
 	In the future pipes may be used for filtering and this option will
 	become obsolete (at least for Unix).
+	Note: When using a pipe like "| tee", you'll lose the exit code of the
+	shell command.  This might be configurable by your shell, look for
+	the pipefail option (for bash and zsh, use ":set -o pipefail").
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -5859,6 +5859,9 @@ vim.go.shcf = vim.go.shellcmdflag
 --- Don't forget to precede the space with a backslash: ":set sp=\ ".
 --- In the future pipes may be used for filtering and this option will
 --- become obsolete (at least for Unix).
+--- Note: When using a pipe like "| tee", you'll lose the exit code of the
+--- shell command.  This might be configurable by your shell, look for
+--- the pipefail option (for bash and zsh, use ":set -o pipefail").
 --- This option cannot be set from a `modeline` or in the `sandbox`, for
 --- security reasons.
 ---

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7687,6 +7687,9 @@ local options = {
         Don't forget to precede the space with a backslash: ":set sp=\ ".
         In the future pipes may be used for filtering and this option will
         become obsolete (at least for Unix).
+        Note: When using a pipe like "| tee", you'll lose the exit code of the
+        shell command.  This might be configurable by your shell, look for
+        the pipefail option (for bash and zsh, use ":set -o pipefail").
         This option cannot be set from a |modeline| or in the |sandbox|, for
         security reasons.
       ]=],


### PR DESCRIPTION
#### vim-patch:1f6faff: runtime(doc): mention the "pipefail" shell option

related: vim/vim#17787

https://github.com/vim/vim/commit/1f6faff9126dde38029bd5a1eed279c294b72dca

Co-authored-by: Christian Brabandt <cb@256bit.org>