### PR TITLE
vim-patch:8.2.{2905,2906,2927},9.0.{2023,2042},9.1.{63,1453}

### DIFF
--- a/test/old/testdir/test_startup.vim
+++ b/test/old/testdir/test_startup.vim
@@ -1324,5 +1324,27 @@ func Test_rename_buffer_on_startup()
   call delete('Xresult')
 endfunc
 
+" Test that -cq works as expected
+func Test_cq_zero_exmode()
+  CheckFeature channel
+
+  let logfile = 'Xcq_log.txt'
+  let out = system(GetVimCommand() .. ' --clean --log ' .. logfile .. ' -es -X -c "argdelete foobar" -c"7cq"')
+  call assert_equal(8, v:shell_error)
+  let log = filter(readfile(logfile), {idx, val -> val =~ "E480"})
+  call assert_match('E480: No match: foobar', log[0])
+  call delete(logfile)
+
+  " wrap-around on Unix
+  let out = system(GetVimCommand() .. ' --clean --log ' .. logfile .. ' -es -X -c "argdelete foobar" -c"255cq"')
+  if !has('win32')
+    call assert_equal(0, v:shell_error)
+  else
+    call assert_equal(256, v:shell_error)
+  endif
+  let log = filter(readfile(logfile), {idx, val -> val =~ "E480"})
+  call assert_match('E480: No match: foobar', log[0])
+  call delete('Xcq_log.txt')
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_startup.vim
+++ b/test/old/testdir/test_startup.vim
@@ -282,6 +282,23 @@ func Test_V_arg()
    " call assert_match("sourcing \"$VIMRUNTIME[\\/]defaults\.vim\"\r\nline 1: \" The default vimrc file\..*  verbose=15\n", out)
 endfunc
 
+" Test that an error is shown when the defaults.vim file could not be read
+func Test_defaults_error()
+  throw 'Skipped: Nvim does not support defaults.vim'
+  " Can't catch the output of gvim.
+  CheckNotGui
+  CheckNotMSWindows
+  " For unknown reasons freeing all memory does not work here, even though
+  " EXITFREE is defined.
+  CheckNotAsan
+
+  let out = system('VIMRUNTIME=/tmp ' .. GetVimCommand() .. ' --clean -cq')
+  call assert_match("E1187: Failed to source defaults.vim", out)
+
+  let out = system('VIMRUNTIME=/tmp ' .. GetVimCommand() .. ' -u DEFAULTS -cq')
+  call assert_match("E1187: Failed to source defaults.vim", out)
+endfunc
+
 " Test the '-q [errorfile]' argument.
 func Test_q_arg()
   CheckFeature quickfix

--- a/test/old/testdir/test_startup.vim
+++ b/test/old/testdir/test_startup.vim
@@ -540,8 +540,10 @@ func Test_geometry()
       " Depending on the GUI library and the windowing system the final size
       " might be a bit different, allow for some tolerance.  Tuned based on
       " actual failures.
-      call assert_inrange(31, 35, str2nr(lines[0]))
-      call assert_equal('13', lines[1])
+      call assert_inrange(30, 35, str2nr(lines[0]))
+      " for some reason, the window may contain fewer lines than requested
+      " for GTK, so allow some tolerance
+      call assert_inrange(8, 13,  str2nr(lines[1]))
       call assert_equal('41', lines[2])
       call assert_equal('150', lines[3])
       call assert_equal('[41, 150]', lines[4])


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

vim-patch:9.1.1453: tests: Test_geometry() may fail
    
    Problem:  tests: Test_geometry() may fail
              (Gary Johnson)
    Solution: allow a slightly smaller value when checking the number of
              lines.
    
    fixes: vim/vim#17491
    
    https://github.com/vim/vim/commit/e965b7ac5f3bad78c66fe83d4f536ef0237fbee6
    
vim-patch:9.1.0063: GTK code can be improved
    
    Problem:  GTK code can be improved
    Solution: Improve GTK code for initial Wayland support
              (lilydjwg)
    
    related: vim/vim#9639
    
    https://github.com/vim/vim/commit/94ff09a0935bc78fd81e9c79f099d42c94e3c218
    
vim-patch:9.0.2023: need more tests for :cq
    
    Problem:  need more tests for :cq
    Solution: Add more tests, including wraparound on linux
    
    https://github.com/vim/vim/commit/ba9aed44975cc82290208fd45f35dd72fc66d6c1
    
    vim-patch:9.0.2042: Test_cq_zero_exmode fails without channel feature
    
    Problem:  Test_cq_zero_exmode fails without channel feature
    Solution: Make the test check the channel feature
    
    closes: vim/vim#13365
    
    https://github.com/vim/vim/commit/c290009e99405024a0d91ec7fab21ac7111c421b
    
    Co-authored-by: Christian Brabandt <cb@256bit.org>

vim-patch:8.2.2905: no error when defaults.vim cannot be loaded
    
    Problem:    No error when defaults.vim cannot be loaded.
    Solution:   Add an error message. (Christian Brabandt, closes vim/vim#8248)
    
    https://github.com/vim/vim/commit/1d3a14ecf0cdde026984894c592dc140a2b46887
    
    Neovim doesn't support defaults.vim.
    N/A test but this should "help" reduce patch rejections.
    
    vim-patch:8.2.2906: ASAN reports errors for test_startup
    
    Problem:    ASAN reports errors for test_startup for unknown reasons.
    Solution:   Temporarily disable the new test.
    
    https://github.com/vim/vim/commit/a5787c3742b43a8e662045a4e38c7a6ba957acbf
    
    vim-patch:8.2.2927: test commented out because it fails with ASAN
    
    Problem:    Test commented out because it fails with ASAN.
    Solution:   Only skip the test when running with ASAN.
    
    https://github.com/vim/vim/commit/a83d06026d0e0dad873de296bff97707ad2faff3

-----

Moved NA patches to https://github.com/neovim/neovim/pull/35024#issuecomment-3105742969 