### PR TITLE
fix(highlight): prevent Normal-linked groups from overriding CursorLine

### DIFF
--- a/test/functional/ui/highlight_spec.lua
+++ b/test/functional/ui/highlight_spec.lua
@@ -1378,6 +1378,23 @@ describe('CursorLine and CursorLineNr highlights', function()
                                                         |
     ]])
   end)
+
+  it('CursorLine overlays hl group linked to Normal', function()
+    local screen = Screen.new(50, 12)
+    screen:add_extra_attr_ids({
+      [101] = { background = Screen.colors.Grey90, foreground = Screen.colors.Gray100 },
+    })
+    command('hi Normal guibg=black guifg=white')
+    command('hi def link Test Normal')
+    feed('ifoo bar<ESC>')
+    feed(':call matchadd("Test", "bar")<cr>')
+    command('set cursorline')
+    screen:expect([[
+      {21:foo }{101:ba^r}{21:                                           }|
+      {1:~                                                 }|*10
+      :call matchadd("Test", "bar")                     |
+    ]])
+  end)
 end)
 
 describe('CursorColumn highlight', function()


### PR DESCRIPTION
fix(highlight): prevent Normal-linked groups from overriding CursorLine

Problem: CursorLine doesn't consistently highlight text using groups
linked to Normal (e.g., in quickfix, passwd files), while it works
for direct Normal usage.

Solution: Don't let normal background from linked groups override
explicit non-normal backgrounds during attribute combination.
Fix #35017
Fix #9019

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
