### PR TITLE
feat(ui2): more predictable routing

### DIFF
--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -22,8 +22,10 @@ describe('messages2', function()
     command('echo "foo\nbar"')
     screen:expect([[
       ^                                                     |
-      {1:~                                                    }|*12
-      foo[+1]                                              |
+      {1:~                                                    }|*10
+      {3:─────────────────────────────────────────────────────}|
+      foo                                                  |
+      bar                                                  |
     ]])
     command('set ruler showcmd noshowmode')
     feed('g<lt>')
@@ -47,14 +49,14 @@ describe('messages2', function()
       bar                                                  |
       baz                                                  |
       bar                                                  |
-      baz[+23]                                             |
+      baz [+23]                                            |
     ]])
     -- Any key press resizes the cmdline and updates the spill indicator.
     feed('j')
     screen:expect([[
       ^                                                     |
       {1:~                                                    }|*12
-      foo[+29]                            0,0-1         All|
+      foo [+29]                           0,0-1         All|
     ]])
     command('echo "foo"')
     -- New message clears spill indicator.
@@ -177,14 +179,14 @@ describe('messages2', function()
       {16::}^                                                    |
     ]])
     -- Highlighter disabled when message is moved to cmdline #34884
-    feed('ls<CR>')
+    feed([[echo "bar\n"->repeat(&lines)<CR>]])
     screen:expect([[
       ^                                                     |
-      {1:~                                                    }|*8
+      {1:~                                                    }|*4
       {3:─────────────────────────────────────────────────────}|
       foo                                                  |
-                                                           |
-        1 %a   "[No Name]"                    line 1       |
+      bar                                                  |*5
+      bar [+8]                                             |
     ]])
   end)
 
@@ -198,5 +200,15 @@ describe('messages2', function()
     -- Would trigger changed dialog if 'buftype' was not restored.
     command('%bdelete')
     screen:expect_unchanged()
+  end)
+
+  it("'readonly' warning can be read", function()
+    command('set readonly')
+    feed('i')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      {19:W10: Warning: Changing a readonly file}               |
+    ]])
   end)
 end)


### PR DESCRIPTION
Problem:  Routing based on message kinds can be perceived as unpredictable.
Solution: Implement phase 1 of #34281, always showing the full message
          in a window dismissed on any user input when it does not fit
          in the 'cmdheight'.

Fix #33952
Fix #35013