### PR TITLE
fix(lsp): support `containerName` in symbol requests

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2681,7 +2681,7 @@ symbols_to_items({symbols}, {bufnr}, {position_encoding})
     Converts symbols to quickfix list items.
 
     Parameters: ~
-      • {symbols}            (`lsp.DocumentSymbol[]|lsp.SymbolInformation[]`)
+      • {symbols}            (`lsp.DocumentSymbol[]|lsp.SymbolInformation[]|lsp.WorkspaceSymbol[]`)
                              list of symbols
       • {bufnr}              (`integer?`) buffer handle or 0 for current,
                              defaults to current

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1867,7 +1867,7 @@ end
 
 --- Converts symbols to quickfix list items.
 ---
----@param symbols lsp.DocumentSymbol[]|lsp.SymbolInformation[] list of symbols
+---@param symbols lsp.DocumentSymbol[]|lsp.SymbolInformation[]|lsp.WorkspaceSymbol[] list of symbols
 ---@param bufnr? integer buffer handle or 0 for current, defaults to current
 ---@param position_encoding? 'utf-8'|'utf-16'|'utf-32'
 ---                         default to first client of buffer
@@ -1907,8 +1907,13 @@ function M.symbols_to_items(symbols, bufnr, position_encoding)
 
       local is_deprecated = symbol.deprecated
         or (symbol.tags and vim.tbl_contains(symbol.tags, protocol.SymbolTag.Deprecated))
-      local text =
-        string.format('[%s] %s%s', kind, symbol.name, is_deprecated and ' (deprecated)' or '')
+      local text = string.format(
+        '[%s] %s%s%s',
+        kind,
+        symbol.name,
+        symbol.containerName and ' in ' .. symbol.containerName or '',
+        is_deprecated and ' (deprecated)' or ''
+      )
 
       items[#items + 1] = {
         filename = filename,

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3328,7 +3328,7 @@ describe('LSP', function()
           filename = '/test_a',
           kind = 'File',
           lnum = 2,
-          text = '[File] TestA',
+          text = '[File] TestA in TestAContainer',
         },
         {
           col = 1,
@@ -3337,7 +3337,7 @@ describe('LSP', function()
           filename = '/test_b',
           kind = 'Module',
           lnum = 4,
-          text = '[Module] TestB',
+          text = '[Module] TestB in TestBContainer (deprecated)',
         },
       }
       eq(
@@ -3364,7 +3364,7 @@ describe('LSP', function()
               containerName = 'TestAContainer',
             },
             {
-              deprecated = false,
+              deprecated = true,
               kind = 2,
               name = 'TestB',
               location = {


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

The field is present for `SymbolInformation` and `WorkspaceSymbol`