### PR TITLE
Update INSTALL.md instructions for Linux pre-build archives

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -109,7 +109,7 @@ The [Releases](https://github.com/neovim/neovim/releases) page provides pre-buil
 
 ```sh
 curl -LO https://github.com/neovim/neovim/releases/latest/download/nvim-linux-x86_64.tar.gz
-sudo rm -rf /opt/nvim
+sudo rm -rf /opt/nvim-linux-x86_64
 sudo tar -C /opt -xzf nvim-linux-x86_64.tar.gz
 ```
 


### PR DESCRIPTION
Updates the installation instructions for Linux x86_64 build instructions. The `rm -rf /opt/nvim` line is incorrect, at least as of previous version `v0.10.4`. The `tar` extract will put nvim in `/opt/nvim-linux-x86_64` directory.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
