### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/usr_02.txt
+++ b/runtime/doc/usr_02.txt
@@ -590,7 +590,7 @@ Summary:					*help-summary*  >
 <    for how the '|' is handled in mappings.
 
 15) Command definitions are talked about :h command-topic, so use >
-	:help command-bar
+	:help command-bang
 <    to find out about the '!' argument for custom commands.
 
 16) Window management commands always start with CTRL-W, so you find the

--- a/runtime/doc/usr_23.txt
+++ b/runtime/doc/usr_23.txt
@@ -116,7 +116,7 @@ Someone sends you an e-mail message, which refers to a file by its URL.  For
 example:
 
 	You can find the information here: ~
-		ftp://ftp.vim.org/pub/vim/README ~
+		https://ftp.nluug.nl/pub/vim/README
 
 You could start a program to download the file, save it on your local disk and
 then start Vim to edit it.

--- a/runtime/doc/vimeval.txt
+++ b/runtime/doc/vimeval.txt
@@ -2099,7 +2099,7 @@ text...
 				CODE
 <
 								*E121*
-:let {var-name}	..	List the value of variable {var-name}.  Multiple
+:let {var-name}	...	List the value of variable {var-name}.  Multiple
 			variable names may be given.  Special names recognized
 			here:				*E738*
 			  g:	global variables

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -11890,7 +11890,7 @@ wildtrigger()                                                    *wildtrigger()*
 		produce a beep when no matches are found and generally
 		operates more quietly.  This makes it suitable for triggering
 		completion automatically, such as from an |:autocmd|.
-							*cmdline-autocompletion*
+						*cmdline-autocompletion*
 		Example: To make the completion menu pop up automatically as
 		you type on the command line, use: >vim
 			autocmd CmdlineChanged [:/?] call wildtrigger()

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -10824,7 +10824,7 @@ function vim.fn.wildmenumode() end
 --- produce a beep when no matches are found and generally
 --- operates more quietly.  This makes it suitable for triggering
 --- completion automatically, such as from an |:autocmd|.
----           *cmdline-autocompletion*
+---         *cmdline-autocompletion*
 --- Example: To make the completion menu pop up automatically as
 --- you type on the command line, use: >vim
 ---   autocmd CmdlineChanged [:/?] call wildtrigger()

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -13082,7 +13082,7 @@ M.funcs = {
       produce a beep when no matches are found and generally
       operates more quietly.  This makes it suitable for triggering
       completion automatically, such as from an |:autocmd|.
-      					*cmdline-autocompletion*
+      				*cmdline-autocompletion*
       Example: To make the completion menu pop up automatically as
       you type on the command line, use: >vim
       	autocmd CmdlineChanged [:/?] call wildtrigger()


### PR DESCRIPTION
#### vim-patch:61cec2e: runtime(doc): Fix typo in :help help-summary

closes: vim/vim#17823

https://github.com/vim/vim/commit/61cec2e761d630c8ee4be09c8e0096a98088a47a

Co-authored-by: Doug Kearns <dougkearns@gmail.com>
Co-authored-by: Alain Mosnier <alain@wanamoon.net>


#### vim-patch:5711d76: runtime(doc): Tweak documentation style

closes: https://github.com/vim/vim/pull/17824

https://github.com/vim/vim/commit/5711d768181c3b08869ac41ee947a56a26763450

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>


#### vim-patch:774fe9d: runtime(doc): remove mention of ftp.vim.org

https://github.com/vim/vim/commit/774fe9d8fcdc299f55502e79d6986eb866ec5b26

Co-authored-by: Christian Brabandt <cb@256bit.org>