### PR TITLE
fix snippet tabstop expansion and revisting choice nodes

### DIFF
--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -257,10 +257,21 @@ local M = { session = nil }
 local function display_choices(tabstop)
   assert(tabstop.choices, 'Tabstop has no choices')
 
+  local text = tabstop:get_text()
+  local found_text = false
+
   local start_col = tabstop:get_range()[2] + 1
   local matches = {} --- @type table[]
   for _, choice in ipairs(tabstop.choices) do
-    matches[#matches + 1] = { word = choice }
+    if choice ~= text then
+      matches[#matches + 1] = { word = choice }
+    else
+      found_text = true
+    end
+  end
+
+  if found_text then
+      table.insert(matches, 1, text)
   end
 
   vim.defer_fn(function()
@@ -298,6 +309,7 @@ local function select_tabstop(tabstop)
       vim.cmd.startinsert({ bang = range[4] >= #vim.api.nvim_get_current_line() })
     end
     if tabstop.choices then
+      vim.fn.cursor(range[3] + 1, range[4] + 1)
       display_choices(tabstop)
     end
   else

--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -119,7 +119,7 @@ local Tabstop = {}
 function Tabstop.new(index, bufnr, range, choices)
   local extmark_id = vim.api.nvim_buf_set_extmark(bufnr, snippet_ns, range[1], range[2], {
     right_gravity = true,
-    end_right_gravity = true,
+    end_right_gravity = false,
     end_line = range[3],
     end_col = range[4],
     hl_group = hl_group,
@@ -170,7 +170,7 @@ function Tabstop:set_right_gravity(right_gravity)
   local range = self:get_range()
   self.extmark_id = vim.api.nvim_buf_set_extmark(self.bufnr, snippet_ns, range[1], range[2], {
     right_gravity = right_gravity,
-    end_right_gravity = true,
+    end_right_gravity = not right_gravity,
     end_line = range[3],
     end_col = range[4],
     hl_group = hl_group,


### PR DESCRIPTION
Fix two different issues regarding the `vim.snippet` implementation

Opened this as a draft according to the contribution guidelines and to get feedback. Have not checked linting or tests yet (would need some guidance how to write a test for neovim). Feel free to comment on anything (commit messages, variable names, etc.) as I'm not familiar with the project conventions

### Tabstop Gravity

The value for `end_right_gravity` is always set to true which causes issues with tabstops that are right next to each other

#### Reproduction

- execute `:lua vim.snippet.expand('${1:first}${2:second}')`
- change first stop to `FIRST`
- jump to second tabstop with `<tab>`
- change second stop to `SECOND`
- jump back to first tabstop with `<s-tab>`
- change stop to `first`

##### Expected

`firstSECOND`

##### Actual

`first`

![snippet_1_problem_high_res](https://github.com/user-attachments/assets/896df66a-746a-4a93-8372-62b271290f73)

#### Solution

Set the value for `end_right_gravity` to the opposite of `right_gravity`:

- deactivate tabstop expansion
    - `right_gravity = true` so writing before the tabstop will move it to the right
    - `end_right_gravity = false` so that writing on the end extmark will not expand it
- activate tabstop expansion
    - `right_gravity = false` so writing before the tabstop will be included
    - `end_right_gravity = true` so that writing on the end extmark will be included

![snippet_1_solution](https://github.com/user-attachments/assets/bcfcd552-4995-4f9a-bb07-e340b83323b2)

### Jumping back to a Tabstop with Choices

Jumping back to a tabstop with choices will retrigger the completion and by that insert the first choice from the tabstop "additionally" to what was already selected before. This can be repeated multiple times and will always extend the text in the tabstop

#### Reproduction

- execute `:lua vim.snippet.expand('${1|choice one,choice two,choice three|} ${2:second}')`
- chose `choice one`
- jump to the next tabstop with `<tab>`
- jump back to the first tabstop with `<s-tab>`

##### Expected

`choice one second`

##### Actual

`choice onechoice one second`

![snippet_2_problem_high_res](https://github.com/user-attachments/assets/aa4e9403-454f-45cf-9d67-700c8d2b770e)

#### Solution

Set the cursor to the end of the tabstop instead of always to the beginning (which only makes sense if nothing is selected yet). If the tabstop text is equal to one of the choices set it as the first completion item before triggering the insert mode completion, to avoid changing the already choosen text to the first element of the list

![snippet_2_solution](https://github.com/user-attachments/assets/819011c1-cf83-4644-9235-a7c6e258b3af)

