### PR TITLE
fix(shada): check return value is 0

### DIFF
--- a/runtime/plugin/shada.lua
+++ b/runtime/plugin/shada.lua
@@ -52,8 +52,8 @@ end)
 
 def_autocmd('BufWriteCmd', {}, function(ev)
   local buflines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-  local err = vim.fn.writefile(shada_get_binstrings(buflines), ev.file, 'b')
-  if not err then
+  local ret = vim.fn.writefile(shada_get_binstrings(buflines), ev.file, 'b')
+  if ret == 0 then
     vim.bo[ev.buf].modified = false
   end
 end)


### PR DESCRIPTION
Just noticed a small error in just merged PR #34725:

Problem:
Vimscript functions return number to signal ok/error. Lua doesn't convert these to be falsey.

Solution:
Explicitly check if the return value is 0.