### PR TITLE
feat: ":restart" can run arbitrary commands

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -70,7 +70,7 @@ Stop or detach the current UI
 Restart Nvim
 
                                                 *:restart*
-:restart [+cmd]
+:restart [+cmd] {command}
                 Restarts the Nvim server with the same startup arguments
                 |v:argv| and reattaches the current UI to the new server.
                 All other UIs will detach.
@@ -78,8 +78,12 @@ Restart Nvim
                 Use with `:confirm` to prompt if changes have been made.
 
                 Example: `:restart +qall!` stops the server using `:qall!`.
+                Example: `:restart +qall! lua vim.pack.update()` stops the
+                server using `:qall!` and starts the new server with the
+                argument `-c lua vim.pack.update()`. See also `-c`.
 
                 Note: |+cmd| defaults to `qall!` if not specified.
+                Note: {command} is omitted if not specified.
                 Note: If the current UI hasn't implemented the "restart" UI
                 event, this command is equivalent to `:qall`.
                 Note: Only works if the UI and server are on the same system.

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -70,7 +70,7 @@ Stop or detach the current UI
 Restart Nvim
 
                                                 *:restart*
-:restart [+cmd] {command}
+:restart [+cmd] [command]
                 Restarts the Nvim server with the same startup arguments
                 |v:argv| and reattaches the current UI to the new server.
                 All other UIs will detach.
@@ -80,10 +80,9 @@ Restart Nvim
                 Example: `:restart +qall!` stops the server using `:qall!`.
                 Example: `:restart +qall! lua vim.pack.update()` stops the
                 server using `:qall!` and starts the new server with the
-                argument `-c lua vim.pack.update()`. See also `-c`.
+                argument `-c lua vim.pack.update()`. See also |-c|.
 
                 Note: |+cmd| defaults to `qall!` if not specified.
-                Note: {command} is omitted if not specified.
                 Note: If the current UI hasn't implemented the "restart" UI
                 event, this command is equivalent to `:qall`.
                 Note: Only works if the UI and server are on the same system.

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -295,7 +295,7 @@ bool remote_ui_restart(uint64_t channel_id, Error *err)
       skipping_minc = false;
     }
     bool startswith_min = strlen(arg) > 0 && arg[0] == '-';
-    bool startswith_minmin = strlen(arg) > 1 && strequal("--", string_slice(arg, 0, 1, false));
+    bool startswith_minmin = strlen(arg) > 1 && arg[0] == '-' && arg[1] == '-';
     if (skipping_minc && (startswith_min || startswith_minmin)) {
       skipping_minc = false;
     }

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -308,6 +308,7 @@ bool remote_ui_restart(uint64_t channel_id, Error *err)
     }
     // Exclude --embed/--headless/-c <cmd> from `argv`, as the client may start the server in a
     // different way than how the server was originally started.
+    // Eg: 'nvim -c foo -c bar --embed --headless -- example.txt' would be parsed as { 'nvim', '-c', 'foo', '--', 'example.txt' }.
     if (argv.size == 0 || had_minmin
         || (!strequal(arg, "--embed") && !strequal(arg, "--headless") && !skipping_minc)) {
       ADD_C(argv, CSTR_AS_OBJ(arg));

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -2248,7 +2248,7 @@ M.cmds = {
   },
   {
     command = 'restart',
-    flags = bit.bor(CMDARG, TRLBAR),
+    flags = bit.bor(CMDARG, TRLBAR, EXTRA, NOTRLCOM),
     addr_type = 'ADDR_NONE',
     func = 'ex_restart',
   },

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -2248,7 +2248,7 @@ M.cmds = {
   },
   {
     command = 'restart',
-    flags = bit.bor(CMDARG, TRLBAR, EXTRA, NOTRLCOM),
+    flags = bit.bor(CMDARG, EXTRA, NOTRLCOM),
     addr_type = 'ADDR_NONE',
     func = 'ex_restart',
   },

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4869,22 +4869,8 @@ static void ex_restart(exarg_T *eap)
       if (!added_startup_arg) {
         tv_list_append_string(argv_cpy, "-c", 2);
         size_t cmd_size = strlen(eap->arg);
-        // Handle command after TRLBAR ("|").
-        if (eap->nextcmd != NULL) {
-          size_t next_cmd_size = strlen(eap->nextcmd);
-          assert(cmd_size + next_cmd_size + 3 <= SIZE_MAX);  // Include size of " | " as well.
-          cmd_size += next_cmd_size + 3;
-        }
         assert(cmd_size <= (size_t)SSIZE_MAX);
-        char *cmd;
-        if (eap->nextcmd != NULL) {
-          cmd = xmalloc(sizeof(char) * (cmd_size + 1));
-          snprintf(cmd, cmd_size + 1, "%s | %s", eap->arg, eap->nextcmd);
-        } else {
-          cmd = xstrdup(eap->arg);
-        }
-        tv_list_append_string(argv_cpy, cmd, (ssize_t)cmd_size);
-        xfree(cmd);
+        tv_list_append_string(argv_cpy, eap->arg, (ssize_t)cmd_size);
         added_startup_arg = true;
       }
     });

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4852,8 +4852,29 @@ static void ex_quitall(exarg_T *eap)
 
 /// ":restart": restart the Nvim server (using ":qall!").
 /// ":restart +cmd": restart the Nvim server using ":cmd".
+/// ":restart +cmd <command>": restart the Nvim server using ":cmd" and add -c <command> to the new server.
 static void ex_restart(exarg_T *eap)
 {
+  if (eap->arg != NULL) {
+    const list_T *l = get_vim_var_list(VV_ARGV);
+    int argc = tv_list_len(l);
+    list_T *argv_cpy = tv_list_alloc(argc + 2);
+    bool added_startup_arg = false;
+    TV_LIST_ITER_CONST(l, li, {
+      const char *arg = tv_get_string(TV_LIST_ITEM_TV(li));
+      size_t arg_size = strlen(arg);
+      assert(arg_size <= (size_t)SSIZE_MAX);
+      tv_list_append_string(argv_cpy, arg, (ssize_t)arg_size);
+      if (!added_startup_arg) {
+        tv_list_append_string(argv_cpy, "-c", 2);
+        size_t cmd_size = strlen(eap->arg);
+        assert(cmd_size <= (size_t)SSIZE_MAX);
+        tv_list_append_string(argv_cpy, eap->arg, (ssize_t)cmd_size);
+        added_startup_arg = true;
+      }
+    });
+    set_vim_var_list(VV_ARGV, argv_cpy);
+  }
   char *quit_cmd = (eap->do_ecmd_cmd) ? eap->do_ecmd_cmd : "qall!";
   Error err = ERROR_INIT;
   if ((cmdmod.cmod_flags & CMOD_CONFIRM) && check_changed_any(false, false)) {

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -313,7 +313,7 @@ describe('TUI :restart', function()
 
     -- Check ":confirm restart <cmd>" on a modified buffer.
     tt.feed_data(':confirm restart echo "Hello"\013')
-    screen:expect({ any = vim.pesc('Save changes to "Untitled"?'), unchanged = true })
+    screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
     tt.feed_data('N\013')
 
     -- Check if the -c <cmd> runs after restart.

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -255,8 +255,29 @@ describe('TUI :restart', function()
     tt.feed_data(':1restart\013')
     screen:expect({ any = vim.pesc('{101:E481: No range allowed}') })
 
-    tt.feed_data(':restart foo\013')
-    screen:expect({ any = vim.pesc('{101:E488: Trailing characters: foo}') })
+    local s1 = [[
+                                                        |
+                                                        |
+      {2:                                                  }|
+      {MATCH:%d+ +}|
+      Hello                                             |
+      {102:Press ENTER or type command to continue}^           |
+      {5:-- TERMINAL --}                                    |
+    ]]
+
+    -- Check trailing characters are considered in -c
+    tt.feed_data(':restart echo "Hello"\013')
+    screen_expect(s1)
+    tt.feed_data('\013')
+    restart_pid_check()
+    gui_running_check()
+
+    -- Check trailing characters after +cmd are considered in -c
+    tt.feed_data(':restart +qall echo "Hello"\013')
+    screen_expect(s1)
+    tt.feed_data('\013')
+    restart_pid_check()
+    gui_running_check()
 
     -- Check ":restart" on an unmodified buffer.
     tt.feed_data(':restart\013')

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -273,8 +273,16 @@ describe('TUI :restart', function()
     gui_running_check()
 
     -- Check trailing characters after +cmd are considered in -c
-    tt.feed_data(':restart +qall echo "Hello"\013')
-    screen_expect(s1)
+    tt.feed_data(':restart +qall echo "Hello" | echo "World"\013')
+    screen_expect([[
+                                                        |
+      {2:                                                  }|
+      {MATCH:%d+ +}|
+      Hello                                             |
+      World                                             |
+      {102:Press ENTER or type command to continue}^           |
+      {5:-- TERMINAL --}                                    |
+    ]])
     tt.feed_data('\013')
     restart_pid_check()
     gui_running_check()

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -311,6 +311,17 @@ describe('TUI :restart', function()
     -- Cancel the operation (abandons restart).
     tt.feed_data('C\013')
 
+    -- Check ":confirm restart <cmd>" on a modified buffer.
+    tt.feed_data(':confirm restart echo "Hello"\013')
+    screen:expect({ any = vim.pesc('Save changes to "Untitled"?'), unchanged = true })
+    tt.feed_data('N\013')
+
+    -- Check if the -c <cmd> runs after restart.
+    screen_expect(s1)
+    tt.feed_data('\013')
+    restart_pid_check()
+    gui_running_check()
+
     -- Check ":restart" on the modified buffer.
     tt.feed_data(':restart\013')
     screen_expect(s0)


### PR DESCRIPTION
### Problem:
There is no way for a user to tell ":restart" to "run this command(s) after restarting".

### Solution:
All ":restart" args following the optional +cmd arg #34788 are treated as a big cmdline that is passed as a "-c" CLI arg when restarting nvim.

Closes: #34822