### PR TITLE
fix(extui): attempt to perform arithmetic on field 'last_emsg'

### DIFF
--- a/runtime/lua/vim/_extui/messages.lua
+++ b/runtime/lua/vim/_extui/messages.lua
@@ -388,7 +388,7 @@ function M.msg_show(kind, content, replace_last, _, append)
       end
       -- Store the time when an important message was emitted in order to not overwrite
       -- it with 'last' virt_text in the cmdline so that the user has a chance to read it.
-      M.cmd.last_emsg = kind == 'emsg' or kind == 'wmsg' and os.time() or M.cmd.last_emsg
+      M.cmd.last_emsg = (kind == 'emsg' or kind == 'wmsg') and os.time() or M.cmd.last_emsg
       -- Should clear the search count now, mark itself is cleared by invalidate.
       M.virt.last[M.virt.idx.search][1] = nil
     end

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -202,13 +202,19 @@ describe('messages2', function()
     screen:expect_unchanged()
   end)
 
-  it("'readonly' warning can be read", function()
+  it('showmode does not overwrite important messages', function()
     command('set readonly')
     feed('i')
     screen:expect([[
       ^                                                     |
       {1:~                                                    }|*12
       {19:W10: Warning: Changing a readonly file}               |
+    ]])
+    feed('<Esc>Qi')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*12
+      {9:E354: Invalid register name: '^@'}                    |
     ]])
   end)
 end)


### PR DESCRIPTION
This error occured to me many times after updated:
```
/usr/share/nvim/runtime/lua/vim/_extui/messages.lua:143: attempt to perform arithmetic on field 'last_emsg' (a boolean value)
```
