### PR TITLE
feat(vim.treesitter): public API to clear query cache

### DIFF
--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -332,12 +332,28 @@ M.get = memoize('concat-2', function(lang, query_name)
   return M.parse(lang, query_string)
 end, false)
 
+-- Clears the query information cache for a given tuple of [language, query], or all cached query
+-- info if either is not given.
+--
+---@param lang string? Language to use for the query
+---@param query_name string? Name of the query (e.g. "highlights")
+M.clear_cache = function(lang, query_name)
+  if lang and query_name then
+    -- LuaLS is confused.
+    ---@diagnostic disable-next-line: undefined-field
+    M.get:clear(lang, query_name)
+  else
+    -- LuaLS is confused.
+    ---@diagnostic disable-next-line: undefined-field
+    M.get:clear()
+  end
+end
+
 api.nvim_create_autocmd('OptionSet', {
   pattern = { 'runtimepath' },
   group = api.nvim_create_augroup('nvim.treesitter.query_cache_reset', { clear = true }),
   callback = function()
-    --- @diagnostic disable-next-line: undefined-field LuaLS bad at generics
-    M.get:clear()
+    M.clear_cache()
   end,
 })
 


### PR DESCRIPTION
Problem: there's no public API to reload treesitter query metadata so
anyone trying to reload them needs to poke at private APIs that are
fragile.

Solution: make a trivial public API so that the internals are allowed to
change.

close https://github.com/neovim/neovim/issues/35056

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
