### PR TITLE
feat(treesitter): auto reload query files on save

### DIFF
--- a/runtime/doc/filetype.txt
+++ b/runtime/doc/filetype.txt
@@ -905,6 +905,15 @@ Linting of treesitter queries for installed parsers using
 To disable linting completely, set >lua
 
 	vim.g.query_lint_on = {}
+
+Automatic reload of treesitter queries for installed parsers is enabled by
+default on `BufWritePost`. To change the events that trigger autoreload, use >lua
+
+	vim.g.query_autoreload_on = { 'InsertLeave', 'TextChanged' }
+<
+To disable autoreload completely, set >lua
+
+	vim.g.query_autoreload_on = {}
 <
 
 QF QUICKFIX					    *qf.vim* *ft-qf-plugin*

--- a/runtime/ftplugin/query.lua
+++ b/runtime/ftplugin/query.lua
@@ -30,6 +30,19 @@ if not vim.b.disable_query_linter and #query_lint_on > 0 then
   })
 end
 
+local query_autoreload_on = vim.g.query_autoreload_on or { 'BufWritePost' }
+if not vim.b.disable_query_autoreload and #query_autoreload_on > 0 then
+  vim.api.nvim_create_autocmd(query_autoreload_on, {
+    group = vim.api.nvim_create_augroup('nvim.queryautoreload', { clear = false }),
+    buffer = buf,
+    callback = function()
+      local guess = vim.treesitter._query_linter.guess_query_lang(buf)
+      vim.treesitter.query.clear_cache(guess and guess.lang, guess and guess.query)
+    end,
+    desc = 'Query linter',
+  })
+end
+
 -- it's a lisp!
 vim.cmd([[runtime! ftplugin/lisp.vim]])
 

--- a/runtime/lua/vim/treesitter/query.lua
+++ b/runtime/lua/vim/treesitter/query.lua
@@ -332,12 +332,28 @@ M.get = memoize('concat-2', function(lang, query_name)
   return M.parse(lang, query_string)
 end, false)
 
+-- Clears the query information cache for a given tuple of [language, query], or all cached query
+-- info if either is not given.
+--
+---@param lang string? Language to use for the query
+---@param query_name string? Name of the query (e.g. "highlights")
+M.clear_cache = function(lang, query_name)
+  if lang and query_name then
+    -- LuaLS is confused.
+    ---@diagnostic disable-next-line: undefined-field
+    M.get:clear(lang, query_name)
+  else
+    -- LuaLS is confused.
+    ---@diagnostic disable-next-line: undefined-field
+    M.get:clear()
+  end
+end
+
 api.nvim_create_autocmd('OptionSet', {
   pattern = { 'runtimepath' },
   group = api.nvim_create_augroup('nvim.treesitter.query_cache_reset', { clear = true }),
   callback = function()
-    --- @diagnostic disable-next-line: undefined-field LuaLS bad at generics
-    M.get:clear()
+    M.clear_cache()
   end,
 })
 


### PR DESCRIPTION
I can't figure out how to write the test for this so I'm not going to
submit it.

Problem: needing to restart nvim to reload queries is no fun (and
probably kills language servers and other undesired effects).

Solution: automatically reload the query files when users write to them.

CC: https://github.com/nvim-treesitter/nvim-treesitter/issues/3304
Fixes: https://github.com/neovim/neovim/issues/35056

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
