### PR TITLE
fix(cmdline): :checkhealth completion with multiple args

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -2295,7 +2295,6 @@ static const char *set_context_by_cmdname(const char *cmd, cmdidx_T cmdidx, expa
     break;
   case CMD_checkhealth:
     xp->xp_context = EXPAND_CHECKHEALTH;
-    xp->xp_pattern = (char *)arg;
     break;
 
   case CMD_retab:

--- a/test/functional/plugin/health_spec.lua
+++ b/test/functional/plugin/health_spec.lua
@@ -67,6 +67,14 @@ describe(':checkhealth', function()
     assert_alive()
   end)
 
+  it('cmdline completion works with multiple args #35054', function()
+    clear()
+    n.feed(':checkhealth vim.ls<Tab>')
+    eq('checkhealth vim.lsp', fn.getcmdline())
+    n.feed(' vim.prov<Tab>')
+    eq('checkhealth vim.lsp vim.provider', fn.getcmdline())
+  end)
+
   it('vim.g.health', function()
     clear {
       args_rm = { '-u' },


### PR DESCRIPTION
Fix #35054
