### PR TITLE
fix(snippet): setting end_right_gravity

### DIFF
--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -119,7 +119,7 @@ local Tabstop = {}
 function Tabstop.new(index, bufnr, range, choices)
   local extmark_id = vim.api.nvim_buf_set_extmark(bufnr, snippet_ns, range[1], range[2], {
     right_gravity = true,
-    end_right_gravity = true,
+    end_right_gravity = false,
     end_line = range[3],
     end_col = range[4],
     hl_group = hl_group,
@@ -170,7 +170,7 @@ function Tabstop:set_right_gravity(right_gravity)
   local range = self:get_range()
   self.extmark_id = vim.api.nvim_buf_set_extmark(self.bufnr, snippet_ns, range[1], range[2], {
     right_gravity = right_gravity,
-    end_right_gravity = true,
+    end_right_gravity = not right_gravity,
     end_line = range[3],
     end_col = range[4],
     hl_group = hl_group,

--- a/test/functional/lua/snippet_spec.lua
+++ b/test/functional/lua/snippet_spec.lua
@@ -249,7 +249,11 @@ describe('vim.snippet', function()
     feed('<Tab>')
     poke_eventloop()
     feed(',2')
-    eq({ 'for i=1,10,2 do', '\t', 'end' }, buf_lines(0))
+    -- Make sure changes on previous tabstops does not change following ones
+    feed('<S-Tab>')
+    poke_eventloop()
+    feed('20')
+    eq({ 'for i=1,20,2 do', '\t', 'end' }, buf_lines(0))
   end)
 
   it('updates snippet state when built-in completion menu is visible', function()


### PR DESCRIPTION
The value for `end_right_gravity` is always set to true which causes issues with tabstops that are right next to each other

#### Reproduction

- execute `:lua vim.snippet.expand('${1:first}${2:second}')`
- change first stop to `FIRST`
- jump to second tabstop with `<tab>`
- change second stop to `SECOND`
- jump back to first tabstop with `<s-tab>`
- change stop to `first`

##### Expected

`firstSECOND`

##### Actual

`first`

![snippet_1_problem_high_res](https://github.com/user-attachments/assets/896df66a-746a-4a93-8372-62b271290f73)

#### Solution

Set the value for `end_right_gravity` to the opposite of `right_gravity`:

- deactivate tabstop expansion
    - `right_gravity = true` so writing before the tabstop will move it to the right
    - `end_right_gravity = false` so that writing on the end extmark will not expand it
- activate tabstop expansion
    - `right_gravity = false` so writing before the tabstop will be included
    - `end_right_gravity = true` so that writing on the end extmark will be included

![snippet_1_solution](https://github.com/user-attachments/assets/bcfcd552-4995-4f9a-bb07-e340b83323b2)
