### PR TITLE
fix(snippet): jumping backwards to choice node

### DIFF
--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -257,10 +257,21 @@ local M = { session = nil }
 local function display_choices(tabstop)
   assert(tabstop.choices, 'Tabstop has no choices')
 
+  local text = tabstop:get_text()
+  local found_text = false
+
   local start_col = tabstop:get_range()[2] + 1
   local matches = {} --- @type table[]
   for _, choice in ipairs(tabstop.choices) do
-    matches[#matches + 1] = { word = choice }
+    if choice ~= text then
+      matches[#matches + 1] = { word = choice }
+    else
+      found_text = true
+    end
+  end
+
+  if found_text then
+    table.insert(matches, 1, text)
   end
 
   vim.defer_fn(function()
@@ -298,6 +309,7 @@ local function select_tabstop(tabstop)
       vim.cmd.startinsert({ bang = range[4] >= #vim.api.nvim_get_current_line() })
     end
     if tabstop.choices then
+      vim.fn.cursor(range[3] + 1, range[4] + 1)
       display_choices(tabstop)
     end
   else

--- a/test/functional/lua/snippet_spec.lua
+++ b/test/functional/lua/snippet_spec.lua
@@ -240,6 +240,23 @@ describe('vim.snippet', function()
     eq({ 'public function foo() {', '\t', '}' }, buf_lines(0))
   end)
 
+  it('does not change the chosen text when jumping back to a choice tabstop', function()
+    test_expand_success(
+      { '${1|public,protected,private|} function ${2:name}() {', '\t$0', '}' },
+      { ' function name() {', '\t', '}' }
+    )
+    wait_for_pum()
+    feed('<C-n><C-y><Tab>')
+    poke_eventloop()
+    feed('<S-Tab>')
+    poke_eventloop()
+    wait_for_pum()
+    feed('<Tab>')
+    poke_eventloop()
+    feed('foo')
+    eq({ 'protected function foo() {', '\t', '}' }, buf_lines(0))
+  end)
+
   it('jumps through adjacent tabstops', function()
     test_expand_success(
       { 'for i=1,${1:to}${2:,step} do\n\t$3\nend' },


### PR DESCRIPTION

Jumping back to a tabstop with choices will retrigger the completion and by that insert the first choice from the tabstop "additionally" to what was already selected before. This can be repeated multiple times and will always extend the text in the tabstop

#### Reproduction

- execute `:lua vim.snippet.expand('${1|choice one,choice two,choice three|} ${2:second}')`
- chose `choice one`
- jump to the next tabstop with `<tab>`
- jump back to the first tabstop with `<s-tab>`

##### Expected

`choice one second`

##### Actual

`choice onechoice one second`

![snippet_2_problem_high_res](https://github.com/user-attachments/assets/aa4e9403-454f-45cf-9d67-700c8d2b770e)

#### Solution

Set the cursor to the end of the tabstop instead of always to the beginning (which only makes sense if nothing is selected yet). If the tabstop text is equal to one of the choices set it as the first completion item before triggering the insert mode completion, to avoid changing the already choosen text to the first element of the list

![snippet_2_solution](https://github.com/user-attachments/assets/819011c1-cf83-4644-9235-a7c6e258b3af)
