### PR TITLE
vim-patch:714671d: runtime(misc): use :hor :term to ensure new term window is split horizontally

### DIFF
--- a/runtime/ftplugin/gpg.vim
+++ b/runtime/ftplugin/gpg.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
 " Language:             gpg(1) configuration file
+" Maintainer:           This runtime file is looking for a new maintainer.
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2024-09-19 (simplify keywordprg #15696)
+" Latest Revision:      2025-07-22 (use :hor term #17822)
 
 if exists("b:did_ftplugin")
   finish
@@ -17,7 +18,7 @@ setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
 if has('unix') && executable('less') && exists(':terminal') == 2
   command -buffer -nargs=1 GpgKeywordPrg
-        \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+--' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'gpg'
+        \ silent exe ':hor term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+--' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'gpg'
   setlocal iskeyword+=-
   setlocal keywordprg=:GpgKeywordPrg
   let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer GpgKeywordPrg'

--- a/runtime/ftplugin/modconf.vim
+++ b/runtime/ftplugin/modconf.vim
@@ -2,7 +2,7 @@
 " Language:             modules.conf(5) configuration file
 " Maintainer:           This runtime file is looking for a new maintainer.
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2024-09-20 (remove erroneous endif)
+" Latest Revision:      2025-07-22 (use :hor term #17822)
 
 if exists("b:did_ftplugin")
   finish
@@ -19,7 +19,7 @@ setlocal formatoptions-=t formatoptions+=croql
 
 if has('unix') && executable('less') && exists(':terminal') == 2
   command -buffer -nargs=1 ModconfKeywordPrg
-        \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'modprobe.d'
+        \ silent exe ':hor term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'modprobe.d'
   setlocal iskeyword+=-
   setlocal keywordprg=:ModconfKeywordPrg
   let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer ModconfKeywordPrg'

--- a/runtime/ftplugin/muttrc.vim
+++ b/runtime/ftplugin/muttrc.vim
@@ -1,7 +1,8 @@
 " Vim filetype plugin file
 " Language:             mutt RC File
+" Maintainer:           This runtime file is looking for a new maintainer.
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
-" Latest Revision:      2024-09-19 (simplify keywordprg #15696)
+" Latest Revision:      2025-07-22 (use :hor term #17822)
 
 if exists("b:did_ftplugin")
   finish
@@ -20,7 +21,7 @@ let &l:include = '^\s*source\>'
 
 if has('unix') && executable('less') && exists(':terminal') == 2
   command -buffer -nargs=1 MuttrcKeywordPrg
-        \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'muttrc'
+        \ silent exe 'hor term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'muttrc'
   setlocal iskeyword+=-
   setlocal keywordprg=:MuttrcKeywordPrg
   let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer MuttrcKeywordPrg'

--- a/runtime/ftplugin/ps1.vim
+++ b/runtime/ftplugin/ps1.vim
@@ -5,6 +5,7 @@
 "              2024 Jan 14 by Vim Project (browsefilter)
 "              2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 "              2024 Sep 19 by Konfekt (simplify keywordprg #15696)
+"              2025 Jul 22 by phanium (use :hor term #17822)
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin") | finish | endif
@@ -51,7 +52,7 @@ endif
 
 if exists('s:pwsh_cmd')
   if exists(':terminal') == 2
-    command! -buffer -nargs=1 GetHelp silent exe 'term ' . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full "<args>"' . (executable('less') ? ' | less' : '')
+    command! -buffer -nargs=1 GetHelp silent exe 'hor term ' . s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full "<args>"' . (executable('less') ? ' | less' : '')
   else
     command! -buffer -nargs=1 GetHelp echo system(s:pwsh_cmd . ' -NoLogo -NoProfile -NonInteractive -ExecutionPolicy RemoteSigned -Command Get-Help -Full <args>')
   endif

--- a/runtime/ftplugin/readline.vim
+++ b/runtime/ftplugin/readline.vim
@@ -3,6 +3,7 @@
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
 " Last Change:		2024 Sep 19 (simplify keywordprg #15696)
+" 2024 Jul 22 by Vim project (use :hor term #17822)
 
 if exists("b:did_ftplugin")
   finish
@@ -36,7 +37,7 @@ endif
 
 if has('unix') && executable('less') && exists(':terminal') == 2
   command -buffer -nargs=1 ReadlineKeywordPrg
-        \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . '3 readline'
+        \ silent exe 'hor term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . '3 readline'
   setlocal iskeyword+=-
   setlocal keywordprg=:ReadlineKeywordPrg
   let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer ReadlineKeywordPrg'

--- a/runtime/ftplugin/sh.vim
+++ b/runtime/ftplugin/sh.vim
@@ -7,6 +7,7 @@
 " Last Change:		2024 Sep 19 by Vim Project (compiler shellcheck)
 "			2024 Dec 29 by Vim Project (improve setting shellcheck compiler)
 "			2025 Mar 09 by Vim Project (set b:match_skip)
+"			2025 Jul 22 by phanium (use :hor term #17822)
 
 if exists("b:did_ftplugin")
   finish
@@ -53,7 +54,7 @@ let s:is_kornshell = get(b:, "is_kornshell", get(g:, "is_kornshell", 0))
 
 if s:is_bash
   if exists(':terminal') == 2
-    command! -buffer -nargs=1 ShKeywordPrg silent exe ':term bash -c "help "<args>" 2>/dev/null || man "<args>""'
+    command! -buffer -nargs=1 ShKeywordPrg silent exe ':hor term bash -c "help "<args>" 2>/dev/null || man "<args>""'
   else
     command! -buffer -nargs=1 ShKeywordPrg echo system('bash -c "help <args>" 2>/dev/null || MANPAGER= man "<args>"')
   endif

--- a/runtime/ftplugin/sshconfig.vim
+++ b/runtime/ftplugin/sshconfig.vim
@@ -2,7 +2,7 @@
 " Language:	OpenSSH client configuration file
 " Maintainer:	This runtime file is looking for a new maintainer.
 " Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
-" Latest Revision:	2024-09-19 (simplify keywordprg #15696)
+" Latest Revision:	2025-07-22 (use :hor term #17822)
 
 if exists("b:did_ftplugin")
   finish
@@ -17,7 +17,7 @@ let b:undo_ftplugin = 'setlocal com< cms< fo<'
 
 if has('unix') && executable('less') && exists(':terminal') == 2
   command -buffer -nargs=1 SshconfigKeywordPrg
-        \ silent exe 'term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '$', '\') . ''' --hilite-search" man ' . 'ssh_config'
+        \ silent exe 'hor term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s+' . <q-args> . '$', '\') . ''' --hilite-search" man ' . 'ssh_config'
   setlocal iskeyword+=-
   setlocal keywordprg=:SshconfigKeywordPrg
   let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer SshconfigKeywordPrg'

--- a/runtime/ftplugin/sudoers.vim
+++ b/runtime/ftplugin/sudoers.vim
@@ -2,7 +2,7 @@
 " Language:	sudoers(5) configuration files
 " Maintainer:	This runtime file is looking for a new maintainer.
 " Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
-" Latest Revision:	2024-09-19 (simplify keywordprg #15696)
+" Latest Revision:	2025-07-22 (use :hor term #17822)
 
 if exists("b:did_ftplugin")
   finish
@@ -18,7 +18,7 @@ setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
 if has('unix') && executable('less') && exists(':terminal') == 2
   command -buffer -nargs=1 SudoersKeywordPrg
-        \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('\b' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'sudoers'
+        \ silent exe ':hor term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('\b' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'sudoers'
   setlocal iskeyword+=-
   setlocal keywordprg=:SudoersKeywordPrg
   let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer SudoersKeywordPrg'

--- a/runtime/ftplugin/udevrules.vim
+++ b/runtime/ftplugin/udevrules.vim
@@ -2,7 +2,7 @@
 " Language:	udev(8) rules file
 " Maintainer:	This runtime file is looking for a new maintainer.
 " Previous Maintainer:	Nikolai Weibull <now@bitwi.se>
-" Latest Revision:	2024-09-19 (simplify keywordprg #15696)
+" Latest Revision:	2025-07-22 (use :hor term #17822)
 
 if exists("b:did_ftplugin")
   finish
@@ -18,7 +18,7 @@ setlocal comments=:# commentstring=#\ %s formatoptions-=t formatoptions+=croql
 
 if has('unix') && executable('less') && exists(':terminal') == 2
   command -buffer -nargs=1 UdevrulesKeywordPrg
-        \ silent exe ':term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'udev'
+        \ silent exe ':hor term ' . 'env LESS= MANPAGER="less --pattern=''' . escape('^\s{,8}' . <q-args> . '\b', '\') . ''' --hilite-search" man ' . 'udev'
   setlocal iskeyword+=-
   setlocal keywordprg=:UdevrulesKeywordPrg
   let b:undo_ftplugin .= '| setlocal keywordprg< iskeyword< | sil! delc -buffer UdevrulesKeywordPrg'

--- a/runtime/ftplugin/zsh.vim
+++ b/runtime/ftplugin/zsh.vim
@@ -5,6 +5,8 @@
 " Latest Revision:      2024 Sep 19
 " License:              Vim (see :h license)
 " Repository:           https://github.com/chrisbra/vim-zsh
+" Last Change:
+" 2025 Jul 23 by Vim Project (use :hor term #17822)
 
 if exists("b:did_ftplugin")
   finish
@@ -20,7 +22,7 @@ let b:undo_ftplugin = "setl com< cms< fo< "
 
 if executable('zsh') && &shell !~# '/\%(nologin\|false\)$'
   if exists(':terminal') == 2
-    command! -buffer -nargs=1 ZshKeywordPrg silent exe ':term zsh -c "autoload -Uz run-help; run-help <args>"'
+    command! -buffer -nargs=1 ZshKeywordPrg silent exe ':hor term zsh -c "autoload -Uz run-help; run-help <args>"'
   else
     command! -buffer -nargs=1 ZshKeywordPrg echo system('MANPAGER= zsh -c "autoload -Uz run-help; run-help <args> 2>/dev/null"')
   endif


### PR DESCRIPTION
#### vim-patch:714671d: runtime(misc): use :hor :term to ensure new term window is split horizontally

Problem:  :term splits new window above in vim, but in nvim it change
          the buffer for current window
Solution: :hor term to ensure consistent splitting for Vim and Neovim

closes: vim/vim#17822

https://github.com/vim/vim/commit/714671de3538266233d3411e0e375dba7d83005c

Co-authored-by: phanium <91544758+phanen@users.noreply.github.com>