### PR TITLE
fix(api): support comma-separated border in nvim_open_win

### DIFF
--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -1855,6 +1855,11 @@ describe('float window', function()
         ]],
         }
       end
+
+      api.nvim_win_set_config(win, { border = '+,-,+,|,+,-,+,|' })
+      eq({ '+', '-', '+', '|', '+', '-', '+', '|' }, api.nvim_win_get_config(win).border)
+      eq('invalid number of border chars', pcall_err(api.nvim_win_set_config, win, { border = '+,-,+,|,+,-,+,|,|' }))
+      eq('invalid border char', pcall_err(api.nvim_win_set_config, win, { border = '+,-,+,|,+,,+,|,' }))
     end)
 
     it('validates title title_pos', function()


### PR DESCRIPTION
Problem: nvim_open_win border parameter only accepts array or predefined styles, but winborder option supports comma-separated format like ┌,─,┐,│,┘,─,└,│

Solution: Extract comma parsing logic into parse_comma_separated_border() and reuse it in both parse_winborder() and parse_border_style()

Fix #35065 

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
