### PR TITLE
fix(lsp): codelens extmark line out of range

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -260,7 +260,9 @@ local function resolve_lenses(lenses, bufnr, client_id, callback)
     local function display_line_countdown()
       num_resolved_line_lenses = num_resolved_line_lenses + 1
       if num_resolved_line_lenses == #line_lenses then
-        display_line_lenses(bufnr, ns, line, line_lenses)
+        if line <= api.nvim_buf_line_count(bufnr) then
+          display_line_lenses(bufnr, ns, line, line_lenses)
+        end
         countdown(#line_lenses)
       end
     end


### PR DESCRIPTION
Problem:
When setting extmark for a codelens after it's asynchronously resolved, the line may have been removed, raising "invalid 'line': out of range" error. This is a regression from #34888.

Solution:
Re-introduce the line count check.
