### PR TITLE
fix(api): nvim_create_user_command addr option should allow ranges

### DIFF
--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -1170,6 +1170,7 @@ void create_user_command(uint64_t channel_id, String name, Union(String, LuaRef)
       goto err;
     });
 
+    argt |= EX_RANGE;
     if (addr_type_arg != ADDR_LINES) {
       argt |= EX_ZEROR;
     }

--- a/test/functional/api/command_spec.lua
+++ b/test/functional/api/command_spec.lua
@@ -782,6 +782,13 @@ describe('nvim_create_user_command', function()
     eq(5, #api.nvim_list_tabpages())
     eq(1, fn.tabpagenr())
   end)
+
+  it('"addr" flag allows ranges without explicit "range" flag', function()
+    exec_lua([[
+      vim.api.nvim_create_user_command('Test2', 'echo "hello <line1><line2>"', { addr = 'other' })
+    ]])
+    eq('hello 12', n.exec_capture('1,2Test2'))
+  end)
 end)
 
 describe('nvim_del_user_command', function()


### PR DESCRIPTION
Problem: Using `addr` without `range` in nvim_create_user_command gives "No range allowed" error, inconsistent with `:command -addr` behavior.

Solution: Set EX_RANGE flag when `addr` option is specified to match `:command` behavior.

Fix #25920 

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
