### PR TITLE
feat(lsp): enable document colors by default

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -119,6 +119,8 @@ To remove or override BUFFER-LOCAL defaults, define a |LspAttach| handler: >lua
         vim.bo[args.buf].omnifunc = nil
         -- Unmap K
         vim.keymap.del('n', 'K', { buffer = args.buf })
+        -- Disable document colors
+        vim.lsp.buf.document_color.enable(false, args.buf)
       end,
     })
 <
@@ -2241,6 +2243,10 @@ is_enabled({filter})                    *vim.lsp.semantic_tokens.is_enabled()*
 
 ==============================================================================
 Lua module: vim.lsp.document_color                        *lsp-document_color*
+
+This module provides LSP support for highlighting color references in a
+document. Highlighting is enabled by default.
+
 
 color_presentation()             *vim.lsp.document_color.color_presentation()*
     Select from a list of presentations for the color under the cursor.

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -779,6 +779,7 @@ function lsp._set_defaults(client, bufnr)
   if client:supports_method(ms.textDocument_diagnostic) then
     lsp.diagnostic._enable(bufnr)
   end
+  lsp.document_color.enable(true, bufnr)
 end
 
 --- @deprecated

--- a/runtime/lua/vim/lsp/document_color.lua
+++ b/runtime/lua/vim/lsp/document_color.lua
@@ -1,3 +1,6 @@
+--- @brief This module provides LSP support for highlighting color references in a document.
+--- Highlighting is enabled by default.
+
 local api = vim.api
 local lsp = vim.lsp
 local util = lsp.util


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

Quoting @justinmk: "Enable [document colors] by default seems like the right tradeoff. It's zero-cost if the LS doesn't implement it; it's one line to disable it globally; and it's not very discoverable if it's not enabled by default..."

~This PR also creates a default mapping for the corresponding resolve request (`color_presentation()`).~