### PR TITLE
fix(diagnostics): avoid jumping to diagnostics in deleted ranges

### DIFF
--- a/test/functional/lua/diagnostic_spec.lua
+++ b/test/functional/lua/diagnostic_spec.lua
@@ -1433,15 +1433,6 @@ describe('vim.diagnostic', function()
 
     describe('after inserting text before diagnostic position', function()
       before_each(function()
-        exec_lua(function()
-          vim.api.nvim_set_current_buf(_G.diagnostic_bufnr)
-
-          vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
-            _G.make_error('Diagnostic #1', 1, 4, 1, 7),
-            _G.make_error('Diagnostic #2', 3, 0, 3, 3),
-          })
-        end)
-
         api.nvim_buf_set_text(0, 3, 0, 3, 0, { 'new line', 'new ' })
       end)
 
@@ -1449,7 +1440,7 @@ describe('vim.diagnostic', function()
         eq(
           { 5, 4 },
           exec_lua(function()
-            vim.api.nvim_win_set_cursor(0, { 2, 4 })
+            vim.api.nvim_win_set_cursor(0, { 3, 1 })
             vim.diagnostic.jump({ count = 1 })
             return vim.api.nvim_win_get_cursor(0)
           end)
@@ -1471,8 +1462,6 @@ describe('vim.diagnostic', function()
     describe('if diagnostic is set after last character in line', function()
       before_each(function()
         exec_lua(function()
-          vim.api.nvim_set_current_buf(_G.diagnostic_bufnr)
-
           vim.diagnostic.set(_G.diagnostic_ns, _G.diagnostic_bufnr, {
             _G.make_error('Diagnostic #1', 2, 3, 3, 4),
           })
@@ -1495,6 +1484,34 @@ describe('vim.diagnostic', function()
           { 3, 2 },
           exec_lua(function()
             vim.api.nvim_win_set_cursor(0, { 4, 2 })
+            vim.diagnostic.jump({ count = -1 })
+            return vim.api.nvim_win_get_cursor(0)
+          end)
+        )
+      end)
+    end)
+
+    describe('after entire text range with a diagnostic was deleted', function()
+      before_each(function()
+        api.nvim_buf_set_text(0, 1, 1, 1, 4, {})
+      end)
+
+      it('does not find next diagnostic inside the deleted range', function()
+        eq(
+          { 3, 0 },
+          exec_lua(function()
+            vim.api.nvim_win_set_cursor(0, { 1, 0 })
+            vim.diagnostic.jump({ count = 1 })
+            return vim.api.nvim_win_get_cursor(0)
+          end)
+        )
+      end)
+
+      it('does not find previous diagnostic inside the deleted range', function()
+        eq(
+          { 1, 0 },
+          exec_lua(function()
+            vim.api.nvim_win_set_cursor(0, { 3, 0 })
             vim.diagnostic.jump({ count = -1 })
             return vim.api.nvim_win_get_cursor(0)
           end)


### PR DESCRIPTION
Problem:
diagnostic extmark used for positioning continues to exist after deleting a range containing it, so it's possible to jump to a next/previous diagnositc, which isn't visible in any way, including not being shown via `open_float`.

Solution:
enable `invalidate` flag when setting an extmark to be able to filter out diagnostics based on `invalid` flag when looking for next/previous diagnostic to jump to.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
