### PR TITLE
fix(lsp): check if buffer is valid when resolving code lenses

### DIFF
--- a/runtime/lua/vim/lsp/codelens.lua
+++ b/runtime/lua/vim/lsp/codelens.lua
@@ -260,7 +260,7 @@ local function resolve_lenses(lenses, bufnr, client_id, callback)
     local function display_line_countdown()
       num_resolved_line_lenses = num_resolved_line_lenses + 1
       if num_resolved_line_lenses == #line_lenses then
-        if line <= api.nvim_buf_line_count(bufnr) then
+        if api.nvim_buf_is_valid(bufnr) and line <= api.nvim_buf_line_count(bufnr) then
           display_line_lenses(bufnr, ns, line, line_lenses)
         end
         countdown(#line_lenses)


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

Fixes https://github.com/neovim/neovim/issues/35089