### PR TITLE
fix(snippet): early return for final tabstop

### DIFF
--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -585,6 +585,12 @@ function M.jump(direction)
   M._session.current_tabstop = dest
   select_tabstop(dest)
 
+  -- The cursor is not on a tabstop so exit the session.
+  if dest.index == 0 then
+    M.stop()
+    return
+  end
+
   -- Activate expansion of the destination tabstop.
   M._session:set_group_gravity(dest.index, false)
 

--- a/test/functional/lua/snippet_spec.lua
+++ b/test/functional/lua/snippet_spec.lua
@@ -214,6 +214,20 @@ describe('vim.snippet', function()
     eq(false, exec_lua('return vim.snippet.active()'))
   end)
 
+  it('stop session when jumping to $0', function()
+    test_expand_success({ 'local ${1:name} = ${2:value}$0' }, { 'local name = value' })
+    -- Jump to $2
+    feed('<Tab>')
+    poke_eventloop()
+    -- Jump to $0 (stop snippet)
+    feed('<Tab>')
+    poke_eventloop()
+    -- Insert literal \t
+    feed('<Tab>')
+    poke_eventloop()
+    eq({ 'local name = value\t' }, buf_lines(0))
+  end)
+
   it('inserts choice', function()
     test_expand_success({ 'console.${1|assert,log,error|}()' }, { 'console.()' })
     wait_for_pum()

--- a/test/functional/plugin/lsp/completion_spec.lua
+++ b/test/functional/plugin/lsp/completion_spec.lua
@@ -1309,7 +1309,7 @@ describe('vim.lsp.completion: integration', function()
     end)
     feed('<C-n><C-y>')
     eq(
-      { true, { 'if true then', '\t', 'end' } },
+      { false, { 'if true then', '\t', 'end' } },
       exec_lua(function()
         return {
           vim.snippet.active({ direction = 1 }),


### PR DESCRIPTION
The [cursor movement autocommand](https://github.com/TheBlob42/neovim/blob/e66e62e0a321e0b4b1ebe892e7534f8e451a5402/runtime/lua/vim/snippet.lua#L358-L370) can not detect when the final tabstop `$0` is directly adjacent to another tabstop, which prevents ending the snippet session. The fix is an early return when jumping.

### Example

- execute `:lua vim.snippet.expand('local ${1:local} = ${2:value}')`
> The example does not specify the `$0` tabstop explicitly but instead relies on the automatically inserted one at the end of the snippet text
- cursor is at the first tabstop
- press `<Tab>` to jump to the second tabstop
- press `<Tab>` to jump to the final tabstop `$0` (this should end the snippet)
- press `<Tab>` with the intention to insert a tab character, instead it cycles back to the first tabstop
- this cycle can not be broken 🌀 

https://github.com/user-attachments/assets/d2dbbefb-03f7-419d-8c3b-6078eef3d4d9

Note: We probably could also adjust the cursor movement autocommand in some way to achieve the same result, but I personally prefer the early return as it is very clear. However I am open for any feedback in case another approach is preferred.

