### PR TITLE
Fix "Invalid 'end_col': out of range" error in Treesitter highlighter (issue #29550)

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -367,6 +367,20 @@ local function on_line_impl(self, win, buf, line, on_spell, on_conceal)
         local url = get_url(match, buf, capture, metadata)
 
         if hl and end_row >= line and not on_conceal and (not on_spell or spell ~= nil) then
+
+        -- Clamp end_row and end_col to valid values to prevent
+        -- "Invalid 'end_col': out of range" error reported in issue #29550
+        local total_lines = vim.api.nvim_buf_line_count(buf)
+        if end_row >= total_lines then
+          end_row = total_lines - 1
+        end
+
+        local line_text = vim.api.nvim_buf_get_lines(buf, end_row, end_row + 1, true)[1] or ""
+        local max_col = #line_text
+        if end_col > max_col then
+          end_col = max_col
+        end
+
           api.nvim_buf_set_extmark(buf, ns, start_row, start_col, {
             end_line = end_row,
             end_col = end_col,

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -367,19 +367,18 @@ local function on_line_impl(self, win, buf, line, on_spell, on_conceal)
         local url = get_url(match, buf, capture, metadata)
 
         if hl and end_row >= line and not on_conceal and (not on_spell or spell ~= nil) then
+          -- Clamp end_row and end_col to valid values to prevent
+          -- "Invalid 'end_col': out of range" error reported in issue #29550
+          local total_lines = vim.api.nvim_buf_line_count(buf)
+          if end_row >= total_lines then
+            end_row = total_lines - 1
+          end
 
-        -- Clamp end_row and end_col to valid values to prevent
-        -- "Invalid 'end_col': out of range" error reported in issue #29550
-        local total_lines = vim.api.nvim_buf_line_count(buf)
-        if end_row >= total_lines then
-          end_row = total_lines - 1
-        end
-
-        local line_text = vim.api.nvim_buf_get_lines(buf, end_row, end_row + 1, true)[1] or ""
-        local max_col = #line_text
-        if end_col > max_col then
-          end_col = max_col
-        end
+          local line_text = vim.api.nvim_buf_get_lines(buf, end_row, end_row + 1, true)[1] or ''
+          local max_col = #line_text
+          if end_col > max_col then
+            end_col = max_col
+          end
 
           api.nvim_buf_set_extmark(buf, ns, start_row, start_col, {
             end_line = end_row,


### PR DESCRIPTION
**Problem**

Deleting lines near the end of large files causes Neovim’s Treesitter highlighter to throw an error due to invalid `end_col` values passed to `nvim_buf_set_extmark()`.

**Fix**

Clamp `end_row` and `end_col` to valid ranges before the `nvim_buf_set_extmark()` call to prevent out-of-range errors:

```lua
local total_lines = vim.api.nvim_buf_line_count(buf)

if end_row >= total_lines then
  end_row = total_lines - 1
end

local line_text = vim.api.nvim_buf_get_lines(buf, end_row, end_row + 1, true)[1] or ''
local max_col = #line_text

if end_col > max_col then
  end_col = max_col
end
```

The snippet is inserted inside the block starting with:

```lua
if hl and end_row >= line and not on_conceal and (not on_spell or spell ~= nil) then
```

**Environment**

- Confirmed on Neovim v0.11.3 (official tar.gz release)
- OS: Arch Linux (kernel 6.15.8-arch1-2)

**Notes**

- This fix addresses the issue confirmed for Markdown files.
- Another user (@nwsteenberg) reported a similar issue in Lua files, but I have not personally tested that case.
- For detailed reproduction and testing setup, see my repository: https://github.com/liftctrl/nvim-highlight-error-repo

Thank you for your review!