### PR TITLE
vim-patch:9.1.1590: cannot perform autocompletion

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1112,26 +1112,23 @@ Stop completion						*compl-stop*
 CTRL-X CTRL-Z		Stop completion without changing the text.
 
 
-AUTO-COMPLETION						*compl-autocomplete*
+AUTOCOMPLETION						*ins-autocompletion*
 
-To get LSP-driven auto-completion, see |lsp-completion|. To get basic
-auto-completion without installing plugins or LSP, try this: >lua
+Vim can display a completion menu as you type, similar to using |i_CTRL-N|,
+but triggered automatically.  See |'autocomplete'|. The menu items are
+collected from the sources listed in the |'complete'| option.
 
-  local triggers = {'.'}
-  vim.api.nvim_create_autocmd('InsertCharPre', {
-    buffer = vim.api.nvim_get_current_buf(),
-    callback = function()
-      if vim.fn.pumvisible() == 1 or vim.fn.state('m') == 'm' then
-        return
-      end
-      local char = vim.v.char
-      if vim.list_contains(triggers, char) then
-        local key = vim.keycode('<C-x><C-n>')
-        vim.api.nvim_feedkeys(key, 'm', false)
-      end
-    end
-  })
-<
+Unlike manual |i_CTRL-N| completion, this mode uses a decaying timeout to keep
+Vim responsive.  Sources earlier in the |'complete'| list are given more time
+(higher priority), but every source is guaranteed a time slice, however small.
+
+This mode is fully compatible with other completion modes.  You can invoke
+any of them at any time by typing |CTRL-X|, which temporarily suspends
+autocompletion.  To use |i_CTRL-N| specifically, press |CTRL-E| first to
+dismiss the popup menu (see |complete_CTRL-E|).
+
+To get LSP-driven auto-completion, see |lsp-completion|.
+
 
 FUNCTIONS FOR FINDING COMPLETIONS			*complete-functions*
 

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2059,8 +2059,7 @@ you want to trigger on EVERY keypress you can either:
   `LspAttach`, before you call
   `vim.lsp.completion.enable(… {autotrigger=true})`. See the |lsp-attach|
   example.
-• Call `vim.lsp.completion.get()` from the handler described at
-  |compl-autocomplete|.
+• Call `vim.lsp.completion.get()` from an |InsertCharPre| autocommand.
 
 
                                                  *vim.lsp.completion.enable()*

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -236,6 +236,7 @@ LUA
 
 OPTIONS
 
+• 'autocomplete' enables |ins-autocompletion|.
 • 'autowriteall' writes all buffers upon receiving `SIGHUP`, `SIGQUIT` or `SIGTSTP`.
 • 'chistory' and 'lhistory' set size of the |quickfix-stack|.
 • 'completefuzzycollect' enables fuzzy collection of candidates for (some)

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -741,6 +741,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 	the current directory won't change when navigating to it.
 	Note: When this option is on some plugins may not work.
 
+			*'autocomplete'* *'ac'* *'noautocomplete'* *'noac'*
+'autocomplete' 'ac'	boolean	(default off)
+			global
+	When on, Vim shows a completion menu as you type, similar to using
+	|i_CTRL-N|, but triggered automatically.  See |ins-autocompletion|.
+
 			*'autoindent'* *'ai'* *'noautoindent'* *'noai'*
 'autoindent' 'ai'	boolean	(default on)
 			local to buffer
@@ -1525,9 +1531,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 		If the Dict returned by the {func} includes {"refresh": "always"},
 		the function will be invoked again whenever the leading text
 		changes.
-		If generating matches is potentially slow, |complete_check()|
-		should be used to avoid blocking and preserve editor
-		responsiveness.
+		If generating matches is potentially slow, call
+		|complete_check()| periodically to keep Vim responsive. This
+		is especially important for |ins-autocompletion|.
 	F	equivalent to using "F{func}", where the function is taken from
 		the 'completefunc' option.
 	o	equivalent to using "F{func}", where the function is taken from
@@ -1654,6 +1660,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 	   preview  Show extra information about the currently selected
 		    completion in the preview window.  Only works in
 		    combination with "menu" or "menuone".
+
+	Only "fuzzy", "popup" and "preview" have an effect when 'autocomplete'
+	is enabled.
 
 	This option does not apply to |cmdline-completion|. See 'wildoptions'
 	for that.

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -111,6 +111,15 @@ vim.o.acd = vim.o.autochdir
 vim.go.autochdir = vim.o.autochdir
 vim.go.acd = vim.go.autochdir
 
+--- When on, Vim shows a completion menu as you type, similar to using
+--- `i_CTRL-N`, but triggered automatically.  See `ins-autocompletion`.
+---
+--- @type boolean
+vim.o.autocomplete = false
+vim.o.ac = vim.o.autocomplete
+vim.go.autocomplete = vim.o.autocomplete
+vim.go.ac = vim.go.autocomplete
+
 --- Copy indent from current line when starting a new line (typing <CR>
 --- in Insert mode or when using the "o" or "O" command).  If you do not
 --- type anything on the new line except <BS> or CTRL-D and then type
@@ -1047,9 +1056,9 @@ vim.bo.cms = vim.bo.commentstring
 --- 	If the Dict returned by the {func} includes {"refresh": "always"},
 --- 	the function will be invoked again whenever the leading text
 --- 	changes.
---- 	If generating matches is potentially slow, `complete_check()`
---- 	should be used to avoid blocking and preserve editor
---- 	responsiveness.
+--- 	If generating matches is potentially slow, call
+--- 	`complete_check()` periodically to keep Vim responsive. This
+--- 	is especially important for `ins-autocompletion`.
 --- F	equivalent to using "F{func}", where the function is taken from
 --- 	the 'completefunc' option.
 --- o	equivalent to using "F{func}", where the function is taken from
@@ -1188,6 +1197,9 @@ vim.go.cia = vim.go.completeitemalign
 ---    preview  Show extra information about the currently selected
 --- 	    completion in the preview window.  Only works in
 --- 	    combination with "menu" or "menuone".
+---
+--- Only "fuzzy", "popup" and "preview" have an effect when 'autocomplete'
+--- is enabled.
 ---
 --- This option does not apply to `cmdline-completion`. See 'wildoptions'
 --- for that.

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -29,7 +29,7 @@
 --- on EVERY keypress you can either:
 --- - Extend `client.server_capabilities.completionProvider.triggerCharacters` on `LspAttach`,
 ---   before you call `vim.lsp.completion.enable(… {autotrigger=true})`. See the |lsp-attach| example.
---- - Call `vim.lsp.completion.get()` from the handler described at |compl-autocomplete|.
+--- - Call `vim.lsp.completion.get()` from an |InsertCharPre| autocommand.
 
 local M = {}
 

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1,7 +1,7 @@
 " These commands create the option window.
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2025 Jul 16
+" Last Change:	2025 Jul 25
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " If there already is an option window, jump to that one.
@@ -734,13 +734,19 @@ endif
 if has("insert_expand")
   call <SID>AddOption("complete", gettext("specifies how Insert mode completion works for CTRL-N and CTRL-P"))
   call append("$", "\t" .. s:local_to_buffer)
-  call <SID>OptionL("cfc")
-  call <SID>AddOption("completefuzzycollect", gettext("use fuzzy collection for specific completion modes"))
   call <SID>OptionL("cpt")
+  call <SID>AddOption("autocomplete", gettext("automatic completion in insert mode"))
+  call <SID>BinOptionG("ac", &ac)
   call <SID>AddOption("completeopt", gettext("whether to use a popup menu for Insert mode completion"))
   call <SID>OptionL("cot")
   call <SID>AddOption("completeitemalign", gettext("popup menu item align order"))
   call <SID>OptionG("cia", &cia)
+  call <SID>AddOption("completefuzzycollect", gettext("use fuzzy collection for specific completion modes"))
+  call <SID>OptionL("cfc")
+  if exists("+completepopup")
+    call <SID>AddOption("completepopup", gettext("options for the Insert mode completion info popup"))
+    call <SID>OptionG("cpp", &cpp)
+  endif
   call <SID>AddOption("pumheight", gettext("maximum height of the popup menu"))
   call <SID>OptionG("ph", &ph)
   call <SID>AddOption("pumwidth", gettext("minimum width of the popup menu"))

--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -480,6 +480,19 @@ int gchar_cursor(void)
   return utf_ptr2char(get_cursor_pos_ptr());
 }
 
+/// Return the character immediately before the cursor.
+int char_before_cursor(void)
+{
+  if (curwin->w_cursor.col == 0) {
+    return -1;
+  }
+
+  char *line = get_cursor_line_ptr();
+  char *p = line + curwin->w_cursor.col;
+  int prev_len = utf_head_off(line, p - 1) + 1;
+  return utf_ptr2char(p - prev_len);
+}
+
 /// Write a character at the current cursor position.
 /// It is directly written into the block.
 void pchar_cursor(char c)

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -302,6 +302,7 @@ EXTERN char *p_cia;             ///< 'completeitemalign'
 EXTERN unsigned cia_flags;      ///< order flags of 'completeitemalign'
 EXTERN char *p_cot;             ///< 'completeopt'
 EXTERN unsigned cot_flags;      ///< flags from 'completeopt'
+EXTERN int p_ac;                ///< 'autocomplete'
 #ifdef BACKSLASH_IN_FILENAME
 EXTERN char *p_csl;             ///< 'completeslash'
 #endif

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -229,6 +229,19 @@ local options = {
       varname = 'p_acd',
     },
     {
+      abbreviation = 'ac',
+      defaults = false,
+      desc = [=[
+        When on, Vim shows a completion menu as you type, similar to using
+        |i_CTRL-N|, but triggered automatically.  See |ins-autocompletion|.
+      ]=],
+      full_name = 'autocomplete',
+      scope = { 'global' },
+      short_desc = N_('automatic completion in insert mode'),
+      type = 'boolean',
+      varname = 'p_ac',
+    },
+    {
       abbreviation = 'ai',
       defaults = true,
       desc = [=[
@@ -1465,9 +1478,9 @@ local options = {
         	If the Dict returned by the {func} includes {"refresh": "always"},
         	the function will be invoked again whenever the leading text
         	changes.
-        	If generating matches is potentially slow, |complete_check()|
-        	should be used to avoid blocking and preserve editor
-        	responsiveness.
+        	If generating matches is potentially slow, call
+        	|complete_check()| periodically to keep Vim responsive. This
+        	is especially important for |ins-autocompletion|.
         F	equivalent to using "F{func}", where the function is taken from
         	the 'completefunc' option.
         o	equivalent to using "F{func}", where the function is taken from
@@ -1652,6 +1665,9 @@ local options = {
            preview  Show extra information about the currently selected
         	    completion in the preview window.  Only works in
         	    combination with "menu" or "menuone".
+
+        Only "fuzzy", "popup" and "preview" have an effect when 'autocomplete'
+        is enabled.
 
         This option does not apply to |cmdline-completion|. See 'wildoptions'
         for that.


### PR DESCRIPTION
#### vim-patch:9.1.1590: cannot perform autocompletion

Problem:  cannot perform autocompletion
Solution: Add the 'autocomplete' option value
          (Girish Palya)

This change introduces the 'autocomplete' ('ac') boolean option to
enable automatic popup menu completion during insert mode. When enabled,
Vim shows a completion menu as you type, similar to pressing |i\_CTRL-N|
manually. The items are collected from sources defined in the
'complete' option.

To ensure responsiveness, this feature uses a time-sliced strategy:

- Sources earlier in the 'complete' list are given more time.
- If a source exceeds its allocated timeout, it is interrupted.
- The next source is then started with a reduced timeout (exponentially
  decayed).
- A small minimum ensures every source still gets a brief chance to
  contribute.

The feature is fully compatible with other |i_CTRL-X| completion modes,
which can temporarily suspend automatic completion when triggered.

See :help 'autocomplete' and :help ins-autocompletion for more details.

To try it out, use :set ac

You should see a popup menu appear automatically with suggestions. This
works seamlessly across:

- Large files (multi-gigabyte size)
- Massive codebases (:argadd thousands of .c or .h files)
- Large dictionaries via the `k` option
- Slow or blocking LSP servers or user-defined 'completefunc'

Despite potential slowness in sources, the menu remains fast,
responsive, and useful.

Compatibility: This mode is fully compatible with existing completion
methods. You can still invoke any CTRL-X based completion (e.g.,
CTRL-X CTRL-F for filenames) at any time (CTRL-X temporarily
suspends 'autocomplete'). To specifically use i_CTRL-N, dismiss the
current popup by pressing CTRL-E first.

---

How it works

To keep completion snappy under all conditions, autocompletion uses a
decaying time-sliced algorithm:

- Starts with an initial timeout (80ms).
- If a source does not complete within the timeout, it's interrupted and
  the timeout is halved for the next source.
- This continues recursively until a minimum timeout (5ms) is reached.
- All sources are given a chance, but slower ones are de-prioritized
  quickly.

Most of the time, matches are computed well within the initial window.

---

Implementation details

- Completion logic is mostly triggered in `edit.c` and handled in
  insexpand.c.

- Uses existing inc_compl_check_keys() mechanism, so no new polling
  hooks are needed.

- The completion system already checks for user input periodically; it
  now also checks for timer expiry.

---

Design notes

- The menu doesn't continuously update after it's shown to prevent
  visual distraction (due to resizing) and ensure the internal list
  stays synchronized with the displayed menu.

- The 'complete' option determines priority—sources listed earlier get
  more time.

- The exponential time-decay mechanism prevents indefinite collection,
  contributing to low CPU usage and a minimal memory footprint.

- Timeout values are intentionally not configurable—this system is
  optimized to "just work" out of the box. If autocompletion feels slow,
  it typically indicates a deeper performance bottleneck (e.g., a slow
  custom function not using `complete_check()`) rather than a
  configuration issue.

---

Performance

Based on testing, the total roundtrip time for completion is generally
under 200ms. For common usage, it often responds in under 50ms on an
average laptop, which falls within the "feels instantaneous" category
(sub-100ms) for perceived user experience.

| Upper Bound (ms) | Perceived UX
|----------------- |-------------
| <100 ms          | Excellent; instantaneous
| <200 ms          | Good; snappy
| >300 ms          | Noticeable lag
| >500 ms          | Sluggish/Broken

---

Why this belongs in core:

- Minimal and focused implementation, tightly integrated with existing
  Insert-mode completion logic.
- Zero reliance on autocommands and external scripting.
- Makes full use of Vim’s highly composable 'complete' infrastructure
  while avoiding the complexity of plugin-based solutions.
- Gives users C native autocompletion with excellent responsiveness and
  no configuration overhead.
- Adds a key UX functionality in a simple, performant, and Vim-like way.

closes: vim/vim#17812

https://github.com/vim/vim/commit/af9a7a04f18693eee4400dd134135527f4e8cd5f

Co-authored-by: Girish Palya <girishji@gmail.com>