### PR TITLE
fix(exrc): ensure consistent loading sequence for all startup scripts

### DIFF
--- a/runtime/lua/vim/_core/exrc.lua
+++ b/runtime/lua/vim/_core/exrc.lua
@@ -1,0 +1,19 @@
+local files = vim.fs.find({ '.nvim.lua', '.nvimrc', '.exrc' }, {
+  type = 'file',
+  upward = true,
+  limit = math.huge,
+})
+for _, file in ipairs(files) do
+  local trusted = vim.secure.read(file) --[[@as string|nil]]
+  if trusted then
+    if vim.endswith(file, '.lua') then
+      assert(loadstring(trusted, '@' .. file))()
+    else
+      vim.api.nvim_exec2(trusted, {})
+    end
+  end
+  -- If the user unset 'exrc' in the current exrc then stop searching
+  if not vim.o.exrc then
+    break
+  end
+end

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -952,37 +952,6 @@ do
     end
   end
 
-  vim.api.nvim_create_autocmd('VimEnter', {
-    group = vim.api.nvim_create_augroup('nvim.exrc', {}),
-    desc = 'Find exrc files in parent directories',
-    callback = function()
-      if not vim.o.exrc then
-        return
-      end
-      local files = vim.fs.find({ '.nvim.lua', '.nvimrc', '.exrc' }, {
-        type = 'file',
-        upward = true,
-        limit = math.huge,
-        -- exrc in cwd already handled from C, thus start in parent directory.
-        path = vim.fs.dirname((vim.uv.cwd())),
-      })
-      for _, file in ipairs(files) do
-        local trusted = vim.secure.read(file) --[[@as string|nil]]
-        if trusted then
-          if vim.endswith(file, '.lua') then
-            assert(loadstring(trusted, '@' .. file))()
-          else
-            vim.api.nvim_exec2(trusted, {})
-          end
-        end
-        -- If the user unset 'exrc' in the current exrc then stop searching
-        if not vim.o.exrc then
-          return
-        end
-      end
-    end,
-  })
-
   if tty then
     -- Show progress bars in supporting terminals
     vim.api.nvim_create_autocmd('Progress', {

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -2100,38 +2100,18 @@ static bool do_user_initialization(void)
 }
 
 // Read initialization commands from ".nvim.lua", ".nvimrc", or ".exrc" in
-// current directory.  This is only done if the 'exrc' option is set.
-// Only do this if VIMRC_FILE is not the same as vimrc file sourced in
-// do_user_initialization.
+// current directory and all parent directories.  This is only done if the 'exrc'
+// option is set. Only do this if VIMRC_FILE is not the same as vimrc file
+// sourced in do_user_initialization.
 static void do_exrc_initialization(void)
 {
-  char *str;
+  lua_State *const L = get_global_lstate();
+  assert(L);
 
-  if (os_path_exists(VIMRC_LUA_FILE)) {
-    str = nlua_read_secure(VIMRC_LUA_FILE);
-    if (str != NULL) {
-      Error err = ERROR_INIT;
-      nlua_exec(cstr_as_string(str), "@"VIMRC_LUA_FILE, (Array)ARRAY_DICT_INIT, kRetNilBool, NULL,
-                &err);
-      xfree(str);
-      if (ERROR_SET(&err)) {
-        semsg("Error in %s:", VIMRC_LUA_FILE);
-        semsg_multiline("emsg", err.msg);
-        api_clear_error(&err);
-      }
-    }
-  } else if (os_path_exists(VIMRC_FILE)) {
-    str = nlua_read_secure(VIMRC_FILE);
-    if (str != NULL) {
-      do_source_str(str, VIMRC_FILE);
-      xfree(str);
-    }
-  } else if (os_path_exists(EXRC_FILE)) {
-    str = nlua_read_secure(EXRC_FILE);
-    if (str != NULL) {
-      do_source_str(str, EXRC_FILE);
-      xfree(str);
-    }
+  lua_getglobal(L, "require");
+  lua_pushstring(L, "vim._core.exrc");
+  if (nlua_pcall(L, 1, 0)) {
+    fprintf(stderr, "%s\n", lua_tostring(L, -1));
   }
 }
 


### PR DESCRIPTION
Problem:
The execution of startup scripts in parent directories are too late compared to scripts in current direcctory.

Solution:
Execute all startup scripts with `lua/_core/exrc.lua`.

closes: #35147

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
