### PR TITLE
build: compile _core/*.lua into nvim binary

### DIFF
--- a/runtime/lua/vim/_core/example.lua
+++ b/runtime/lua/vim/_core/example.lua
@@ -1,0 +1,11 @@
+-- Example core module
+-- This file will be compiled into the nvim binary as vim._core.example
+
+local M = {}
+
+--- Example function
+function M.hello()
+  return "Hello from vim._core.example"
+end
+
+return M

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -346,6 +346,18 @@ set(LUA_OPTIONS_MODULE_SOURCE ${NVIM_RUNTIME_DIR}/lua/vim/_options.lua)
 set(LUA_SHARED_MODULE_SOURCE ${NVIM_RUNTIME_DIR}/lua/vim/shared.lua)
 set(LUA_TEXT_MODULE_SOURCE ${NVIM_RUNTIME_DIR}/lua/vim/text.lua)
 
+# Find all Lua files in vim/_core/ directory
+file(GLOB LUA_CORE_MODULE_SOURCES CONFIGURE_DEPENDS ${NVIM_RUNTIME_DIR}/lua/vim/_core/*.lua)
+
+# Generate module names and command arguments for _core files
+set(LUA_CORE_MODULE_ARGS "")
+set(LUA_CORE_MODULE_NAMES "")
+foreach(core_file ${LUA_CORE_MODULE_SOURCES})
+  get_filename_component(core_basename ${core_file} NAME_WE)
+  list(APPEND LUA_CORE_MODULE_ARGS ${core_file} "vim._core.${core_basename}")
+  list(APPEND LUA_CORE_MODULE_NAMES "vim._core.${core_basename}")
+endforeach()
+
 file(GLOB API_HEADERS CONFIGURE_DEPENDS api/*.h)
 list(REMOVE_ITEM API_HEADERS ${CMAKE_CURRENT_LIST_DIR}/api/ui_events.in.h)
 file(GLOB MSGPACK_RPC_HEADERS CONFIGURE_DEPENDS msgpack_rpc/*.h)
@@ -636,6 +648,8 @@ add_custom_command(
       ${LUA_OPTIONS_MODULE_SOURCE} "vim._options"
       ${LUA_SHARED_MODULE_SOURCE} "vim.shared"
       ${LUA_TEXT_MODULE_SOURCE} "vim.text"
+      # Add all _core module files
+      ${LUA_CORE_MODULE_ARGS}
   DEPENDS
     ${CHAR_BLOB_GENERATOR}
     ${LUA_INIT_PACKAGES_MODULE_SOURCE}
@@ -651,6 +665,8 @@ add_custom_command(
     ${LUA_OPTIONS_MODULE_SOURCE}
     ${LUA_SHARED_MODULE_SOURCE}
     ${LUA_TEXT_MODULE_SOURCE}
+    # Add _core module files as dependencies
+    ${LUA_CORE_MODULE_SOURCES}
   VERBATIM
 )
 


### PR DESCRIPTION
## continued at https://github.com/neovim/neovim/pull/36870

TODO:

- update [docs](https://github.com/neovim/neovim/blob/7ed8cbd095805b9e6079def91b13ec24ecec5348/runtime/lua/vim/_editor.lua#L3)
- move these core modules into `_core/*`:
  ``` 
  _editor.lua
  _system.lua
  _init_packages.lua
  _options.lua
  shared.lua
  ?? _defaults.lua ??
  ```

cc @bfredl 