### PR TITLE
fix(ui): prevent first line loss in nvim_echo with cmdheight=0

### DIFF
--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -1520,4 +1520,32 @@ describe('cmdheight=0', function()
       {3:[No Name]                }|
     ]])
   end)
+
+  it('nvim_echo does not lose first line with cmdheight=0 #22875', function()
+    clear()
+    screen = Screen.new(25, 5)
+    command('set cmdheight=0')
+    n.exec_lua([[
+      vim.defer_fn(function() vim.api.nvim_echo({ { "foo\nbar" } }, false, {}) end, 0)
+    ]])
+    screen:expect([[
+      {3:                         }|
+      foo                      |
+      bar                      |
+      {6:Press ENTER or type comma}|
+      {6:nd to continue}^           |
+    ]])
+
+    feed('<ESC>')
+    n.exec_lua([[
+      vim.defer_fn(function() vim.api.nvim_echo({ { "one\ntwo\nthree\nfour\nfive\nsix" } }, false, {}) end, 0)
+    ]])
+    screen:expect([[
+      four                     |
+      five                     |
+      six                      |
+      {6:Press ENTER or type comma}|
+      {6:nd to continue}^           |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem: When using nvim_echo() to display multi-line messages with cmdheight=0, the first line gets scrolled out of view due to double scrolling - once during msg_start() initialization and again when processing newlines in msg_puts_display().

Solution: Skip initial scroll in msg_start() for multi-line messages (is_multihl=true) and let the natural scrolling mechanism in msg_puts_display() handle all necessary scrolling based on actual content length.

Fix #22875 

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
