### PR TITLE
fix(windows): Set UTF-8 encoding for shell commands

### DIFF
--- a/Xtest-startupspec-log
+++ b/Xtest-startupspec-log
@@ -1,0 +1,2 @@
+ERR 2025-08-05T15:54:49.124 ui/c/T1633.35245.0 tui_stop:625: TUI already stopped (race?)
+ERR 2025-08-05T15:54:49.272 ui/c/T1635.35257.0 tui_stop:625: TUI already stopped (race?)

--- a/Xtest-tui-log
+++ b/Xtest-tui-log
@@ -1,0 +1,1 @@
+ERR 2025-08-05T16:00:27.160 ui/c/T5674.42834.0 tui_stop:625: TUI already stopped (race?)

--- a/Xtest_logging
+++ b/Xtest_logging
@@ -1,0 +1,2 @@
+ERR 2025-08-05T15:54:45.620 ui.35093   tui_stop:625: TUI already stopped (race?)
+ERR 2025-08-05T15:54:45.765 ui/c/T1563.35095.0 tui_stop:625: TUI already stopped (race?)

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -879,7 +879,9 @@ int os_system(char **argv, const char *input, size_t len, char **output,
 {
 #ifdef MSWIN
   SetConsoleOutputCP(CP_UTF8); SetConsoleCP(CP_UTF8);
-  if (!os_getenv("PYTHONIOENCODING")) os_setenv("PYTHONIOENCODING", "utf-8", 0);
+  if (!os_getenv("PYTHONIOENCODING")) {
+    os_setenv("PYTHONIOENCODING", "utf-8", 0);
+  }
 #endif
   return do_os_system(argv, input, len, output, nread, true, false);
 }

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -865,8 +865,7 @@ int os_system(char **argv, const char *input, size_t len, char **output,
               size_t *nread) FUNC_ATTR_NONNULL_ARG(1)
 {
 #ifdef MSWIN
-  SetConsoleOutputCP(CP_UTF8);
-  SetConsoleCP(CP_UTF8);
+  setup_windows_utf8_env();
 #endif
   return do_os_system(argv, input, len, output, nread, true, false);
 }

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -97,25 +97,12 @@ static bool have_dollars(int num, char **file)
 }
 #ifdef MSWIN
 static void setup_windows_utf8_env(void) {
-  // Set console to UTF-8
   SetConsoleOutputCP(CP_UTF8);
   SetConsoleCP(CP_UTF8);
-  
-  // Set environment variables for child processes
-  if (!os_getenv("PYTHONIOENCODING")) {
-    os_setenv("PYTHONIOENCODING", "utf-8", 1);
-  }
-  if (!os_getenv("PYTHONLEGACYWINDOWSFSENCODING")) {
-    os_setenv("PYTHONLEGACYWINDOWSFSENCODING", "utf-8", 1);
-  }
-  if (!os_getenv("FORCE_COLOR")) {
-    os_setenv("FORCE_COLOR", "1", 1);
-  }
-  if (!os_getenv("COLORTERM")) {
-    os_setenv("COLORTERM", "truecolor", 1);
-  }
 }
 #endif
+
+
 /// Performs wildcard pattern matching using the shell.
 ///
 /// @param      num_pat  is the number of input patterns.
@@ -878,18 +865,11 @@ int os_system(char **argv, const char *input, size_t len, char **output,
               size_t *nread) FUNC_ATTR_NONNULL_ARG(1)
 {
 #ifdef MSWIN
-  SetConsoleOutputCP(CP_UTF8); SetConsoleCP(CP_UTF8);
-  if (!os_getenv("PYTHONIOENCODING")) {
-    os_setenv("PYTHONIOENCODING", "utf-8", 0);
-  }
-  SetConsoleOutputCP(CP_UTF8); 
+  SetConsoleOutputCP(CP_UTF8);
   SetConsoleCP(CP_UTF8);
-  if (!os_getenv("PYTHONIOENCODING")) os_setenv("PYTHONIOENCODING", "utf-8", 0);
-c8ab86b15b (fix(windows): separate SetConsole function calls to different lines)
 #endif
   return do_os_system(argv, input, len, output, nread, true, false);
 }
-
 
 
 static int do_os_system(char **argv, const char *input, size_t len, char **output, size_t *nread,

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -882,6 +882,10 @@ int os_system(char **argv, const char *input, size_t len, char **output,
   if (!os_getenv("PYTHONIOENCODING")) {
     os_setenv("PYTHONIOENCODING", "utf-8", 0);
   }
+  SetConsoleOutputCP(CP_UTF8); 
+  SetConsoleCP(CP_UTF8);
+  if (!os_getenv("PYTHONIOENCODING")) os_setenv("PYTHONIOENCODING", "utf-8", 0);
+c8ab86b15b (fix(windows): separate SetConsole function calls to different lines)
 #endif
   return do_os_system(argv, input, len, output, nread, true, false);
 }

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -47,6 +47,13 @@
 #include "nvim/ui.h"
 #include "nvim/vim_defs.h"
 
+#ifdef MSWIN
+#include <io.h>
+#include <fcntl.h>
+#include <windows.h>
+#endif
+
+
 #define NS_1_SECOND         1000000000U     // 1 second, in nanoseconds
 #define OUT_DATA_THRESHOLD  1024 * 10U      // 10KB, "a few screenfuls" of data.
 
@@ -88,7 +95,27 @@ static bool have_dollars(int num, char **file)
   }
   return false;
 }
-
+#ifdef MSWIN
+static void setup_windows_utf8_env(void) {
+  // Set console to UTF-8
+  SetConsoleOutputCP(CP_UTF8);
+  SetConsoleCP(CP_UTF8);
+  
+  // Set environment variables for child processes
+  if (!os_getenv("PYTHONIOENCODING")) {
+    os_setenv("PYTHONIOENCODING", "utf-8", 1);
+  }
+  if (!os_getenv("PYTHONLEGACYWINDOWSFSENCODING")) {
+    os_setenv("PYTHONLEGACYWINDOWSFSENCODING", "utf-8", 1);
+  }
+  if (!os_getenv("FORCE_COLOR")) {
+    os_setenv("FORCE_COLOR", "1", 1);
+  }
+  if (!os_getenv("COLORTERM")) {
+    os_setenv("COLORTERM", "truecolor", 1);
+  }
+}
+#endif
 /// Performs wildcard pattern matching using the shell.
 ///
 /// @param      num_pat  is the number of input patterns.
@@ -845,11 +872,19 @@ done:
 ///             returned buffer is not NULL)
 /// @return the return code of the process, -1 if the process couldn't be
 ///         started properly
+
+
 int os_system(char **argv, const char *input, size_t len, char **output,
               size_t *nread) FUNC_ATTR_NONNULL_ARG(1)
 {
+#ifdef MSWIN
+  SetConsoleOutputCP(CP_UTF8); SetConsoleCP(CP_UTF8);
+  if (!os_getenv("PYTHONIOENCODING")) os_setenv("PYTHONIOENCODING", "utf-8", 0);
+#endif
   return do_os_system(argv, input, len, output, nread, true, false);
 }
+
+
 
 static int do_os_system(char **argv, const char *input, size_t len, char **output, size_t *nread,
                         bool silent, bool forward_output)


### PR DESCRIPTION
## Problem

On Windows, Neovim shell commands (`:!command`) don't properly handle Unicode characters or inherit Windows Terminal's UTF-8 settings, causing:

- Unicode text displays as question marks (`тест` → `????`)
- Python scripts fail with `UnicodeEncodeError: 'charmap' codec can't encode characters`
- Inconsistent behavior between Neovim shell commands and native Windows Terminal

## Root Cause

When Neovim executes shell commands via `os_system()`, it doesn't set UTF-8 encoding for the child process console, defaulting to Windows' legacy ANSI encoding (CP1252).

## Solution

Set console code pages to UTF-8 (CP_UTF8) and configure Python UTF-8 encoding before executing shell commands in `os_system()`.

**Changes:**
- `SetConsoleOutputCP(CP_UTF8)` - UTF-8 output encoding
- `SetConsoleCP(CP_UTF8)` - UTF-8 input encoding  
- `PYTHONIOENCODING=utf-8` - Fix Python Unicode errors

## Testing

**Before fix:**
```
:!echo тест          → ????
:!py -c "print('тест')" → UnicodeEncodeError
```

**After fix:**
```
:!echo тест          → тест
:!py -c "print('тест')" → тест
```

Tested on Windows 11 with Windows Terminal and Command Prompt.

## Impact

Fixes shell command Unicode support for all Windows users, making Neovim behavior consistent with modern Windows Terminal expectations.

Closes #33480