### PR TITLE
fix(lsp): show title when global winborder is set

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -942,7 +942,7 @@ function M.make_floating_popup_options(width, height, opts)
     col = 1
   end
 
-  local title = (opts.border and opts.title) and opts.title or nil
+  local title = ((opts.border or vim.o.winborder ~= '') and opts.title) and opts.title or nil
   local title_pos --- @type 'left'|'center'|'right'?
 
   if title then

--- a/test/functional/plugin/lsp/utils_spec.lua
+++ b/test/functional/plugin/lsp/utils_spec.lua
@@ -267,6 +267,14 @@ describe('vim.lsp.util', function()
 
         eq(56, opts.height)
       end)
+
+      it('title with winborder option #35179', function()
+        local opts = exec_lua(function()
+          vim.o.winborder = 'single'
+          return vim.lsp.util.make_floating_popup_options(100, 100, { title = 'Title' })
+        end)
+        eq('Title', opts.title)
+      end)
     end)
   end)
 


### PR DESCRIPTION
Problem: make_floating_popup_options only shows when opts.border is explicitly set, ignoring global winborder setting

Solution: check both opts.border and vim.o.winborder when determining whether to show title

Fix #35179

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
