### PR TITLE
vim-patch:a7a2a2b: runtime(doc): Tweak documentation style

### DIFF
--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -625,6 +625,7 @@ Short explanation of each option:		*option-list*
 'arabic'	  'arab'    for Arabic as a default second language
 'arabicshape'	  'arshape' do shaping for Arabic characters
 'autochdir'	  'acd'     change directory to the file in the current window
+'autocomplete'	  'ac'      enable automatic completion in insert mode
 'autoindent'	  'ai'	    take indent for new line from previous line
 'autoread'	  'ar'	    autom. read file when changed outside of Vim
 'autowrite'	  'aw'	    automatically write file if changed


### PR DESCRIPTION
#### vim-patch:a7a2a2b: runtime(doc): Tweak documentation style

closes: vim/vim#17862

https://github.com/vim/vim/commit/a7a2a2b5ae45c02416d1489a023a840a7722d444

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>