### PR TITLE
feat(lsp): improve signature help display

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -404,15 +404,19 @@ function M.signature_help(config)
         return
       end
 
-      local sfx = total > 1
-          and string.format(' (%d/%d)%s', idx, total, can_cycle and ' (<C-s> to cycle)' or '')
-        or ''
-      config.title = config.title or string.format('Signature Help: %s%s', client.name, sfx)
-      if not config.border then
-        table.insert(lines, 1, '# ' .. config.title)
-        if hl then
-          hl[1] = hl[1] + 1
-          hl[3] = hl[3] + 1
+      -- Show title only if there are multiple clients or multiple signatures.
+      if total > 1 then
+        local sfx = total > 1
+            and string.format(' (%d/%d)%s', idx, total, can_cycle and ' (<C-s> to cycle)' or '')
+          or ''
+        config.title = config.title or string.format('Signature Help: %s%s', client.name, sfx)
+        -- If no border is set, render title inside the window.
+        if not (config.border or vim.o.winborder ~= '') then
+          table.insert(lines, 1, '# ' .. config.title)
+          if hl then
+            hl[1] = hl[1] + 1
+            hl[3] = hl[3] + 1
+          end
         end
       end
 

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -822,6 +822,10 @@ function M.convert_signature_help_to_markdown_lines(signature_help, ft, triggers
     if type(doc) == 'string' then
       signature.documentation = { kind = 'plaintext', value = doc }
     end
+    -- Add delimiter if there is documentation to display
+    if signature.documentation.value ~= '' then
+      contents[#contents + 1] = '---'
+    end
     M.convert_input_to_markdown_lines(signature.documentation, contents)
   end
   if signature.parameters and #signature.parameters > 0 then

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -3774,7 +3774,7 @@ describe('LSP', function()
         }
         return vim.lsp.util.convert_signature_help_to_markdown_lines(signature_help, 'cs', { ',' })
       end)
-      local expected = { '```cs', 'TestEntity.TestEntity()', '```', 'some doc' }
+      local expected = { '```cs', 'TestEntity.TestEntity()', '```', '---', 'some doc' }
       eq(expected, result)
     end)
 


### PR DESCRIPTION
- Add delimiter between function signature and documentation, matching hover formatting

- Show title only if there are multiple clients or multiple signatures

Before/After:
<img src="https://github.com/user-attachments/assets/c80d00df-a9aa-4d9b-b706-8999dd09e083"></img>
<img src="https://github.com/user-attachments/assets/2191c73c-eac8-46ab-ae47-bd1b82fc2bd4"></img>


- Avoid duplicating the title inside the window if it's already shown in the border

Before/After:
<img width="907" height="225" alt="1754488796_screenshot" src="https://github.com/user-attachments/assets/4d547dca-6863-483d-9114-bed7d8bd6cca" />
<img width="874" height="181" alt="1754488675_screenshot" src="https://github.com/user-attachments/assets/b05cce66-31dc-484d-b64b-ea5c1c927a7f" />