### PR TITLE
docs(build): document Makefile limitation with spaces in directory paths

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -7,6 +7,7 @@
 2. `git clone https://github.com/neovim/neovim`
 3. `cd neovim`
     - If you want the **stable release**, also run `git checkout stable`.
+    - Spaces in path not allowed. See notes below.
 4. `make CMAKE_BUILD_TYPE=RelWithDebInfo`
     - If you want to install to a custom location, set `CMAKE_INSTALL_PREFIX`. See also [INSTALL.md](./INSTALL.md#install-from-source).
     - On BSD, use `gmake` instead of `make`.
@@ -21,6 +22,7 @@
 - After building, you can run the `nvim` executable without installing it by running `VIMRUNTIME=runtime ./build/bin/nvim`.
 - If you plan to develop Neovim, install [Ninja](https://ninja-build.org/) for faster builds. It will automatically be used.
 - Install [ccache](https://ccache.dev/) for faster rebuilds of Neovim. It's used by default. To disable it, use `CCACHE_DISABLE=true make`.
+- The neovim directory path cannot contain spaces due to limitations in the Makefile's path detection. If your path contains spaces, either move the project to a path without spaces or use the CMake commands directly.
 
 ## Running tests
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,7 @@ See [BUILD.md](./BUILD.md) and [supported platforms](https://neovim.io/doc/user/
 
 The build is CMake-based, but a Makefile is provided as a convenience.
 After installing the dependencies, run the following command.
+**Note:** The neovim directory path cannot contain spaces due to limitations in the Makefile's path detection. If your path contains spaces, either move the project to a path without spaces or use the CMake commands directly.
 
     make CMAKE_BUILD_TYPE=RelWithDebInfo
     sudo make install


### PR DESCRIPTION
In the `BUILD.md` as well as `README.md` it says to execute `make [...]`, but that doesn't work when the directory path contains spaces. Apparently, that's how it is with make, but I think it should be documented. It took me 10 min to figure this out, and other people may trip over this as well.

Problem:

```sh
➜  neovim git:(v0.11.3) pwd
/home/smail/Public Sources/neovim

➜  neovim git:(v0.11.3) make
mkdir -p ".deps"
/usr/bin/cmake -S /home/smail/ Sources/neovim//cmake.deps -B ".deps" -G "Ninja"   
CMake Error: The source directory "/home/smail" does not appear to contain CMakeLists.txt.
Specify --help for usage, or press the help button on the CMake GUI.
make: *** [Makefile:115: build/.ran-deps-cmake] Error 1
```

Solution: Document it.
