### PR TITLE
feat(api): mark nvim_create_autocmd as |api-fast|

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2008,6 +2008,7 @@ nvim_create_autocmd({event}, {opts})                   *nvim_create_autocmd()*
 <
 
     Attributes: ~
+        |api-fast|
         Since: 0.7.0
 
     Parameters: ~

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -135,6 +135,7 @@ API
 • Added |vim.lsp.is_enabled()| to check if a given LSP config has been enabled
   by |vim.lsp.enable()|.
 • |nvim_echo()| can set the |ui-messages| kind with which to emit the message.
+• |nvim_create_autocmd()| is now marked as |api-fast|.
 
 BUILD
 

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -393,6 +393,7 @@ cleanup:
 Integer nvim_create_autocmd(uint64_t channel_id, Object event, Dict(create_autocmd) *opts,
                             Arena *arena, Error *err)
   FUNC_API_SINCE(9)
+  FUNC_API_FAST
 {
   int64_t autocmd_id = -1;
   char *desc = NULL;


### PR DESCRIPTION
This allows the `vim.treesitter.query` module once again to be `require`d in fast API events.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

Fixes #35071 (I think, cc @misanthropicbit to confirm? and maybe help with a test case if possible) 