### PR TITLE
fix(emmyrc.json): update .emmyrc.json to use StyLua as formatter

### DIFF
--- a/.emmyrc.json
+++ b/.emmyrc.json
@@ -1,6 +1,17 @@
 {
-  "diagnostics" : {
-    "disable" : [
+  "$schema": "https://raw.githubusercontent.com/EmmyLuaLs/emmylua-analyzer-rust/refs/heads/main/crates/emmylua_code_analysis/resources/schema.json",
+  "format": {
+    "externalTool": {
+      "program": "stylua",
+      "args": [
+        "-",
+        "--stdin-filepath",
+        "${file}"
+      ]
+    }
+  },
+  "diagnostics": {
+    "disable": [
       "unnecessary-if"
     ]
   },


### PR DESCRIPTION
Recently `emmylua_ls` [added support](https://github.com/EmmyLuaLs/emmylua-analyzer-rust/issues/689) for custom formatters, so it can now be configured to use StyLua.