### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/index.txt
+++ b/runtime/doc/index.txt
@@ -1017,7 +1017,7 @@ tag		command		action in Command-line editing mode	~
 |c_CTRL-D|	CTRL-D		list completions that match the pattern in
 				front of the cursor
 |c_CTRL-E|	CTRL-E		cursor to end of command-line
-'cedit'	CTRL-F		default value for 'cedit': opens the
+'cedit'		CTRL-F		default value for 'cedit': opens the
 				command-line window; otherwise not used
 |c_CTRL-G|	CTRL-G		next match when 'incsearch' is active
 |c_<BS>|	<BS>		delete the character in front of the cursor

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -11905,7 +11905,7 @@ wildtrigger()                                                    *wildtrigger()*
 						*cmdline-autocompletion*
 		Example: To make the completion menu pop up automatically as
 		you type on the command line, use: >vim
-			autocmd CmdlineChanged [:/?] call wildtrigger()
+			autocmd CmdlineChanged [:/\?] call wildtrigger()
 			set wildmode=noselect:lastused,full wildoptions=pum
 <
 		To retain normal history navigation (up/down keys): >vim

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -10837,7 +10837,7 @@ function vim.fn.wildmenumode() end
 ---         *cmdline-autocompletion*
 --- Example: To make the completion menu pop up automatically as
 --- you type on the command line, use: >vim
----   autocmd CmdlineChanged [:/?] call wildtrigger()
+---   autocmd CmdlineChanged [:/\?] call wildtrigger()
 ---   set wildmode=noselect:lastused,full wildoptions=pum
 --- <
 --- To retain normal history navigation (up/down keys): >vim

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -13095,7 +13095,7 @@ M.funcs = {
       				*cmdline-autocompletion*
       Example: To make the completion menu pop up automatically as
       you type on the command line, use: >vim
-      	autocmd CmdlineChanged [:/?] call wildtrigger()
+      	autocmd CmdlineChanged [:/\?] call wildtrigger()
       	set wildmode=noselect:lastused,full wildoptions=pum
       <
       To retain normal history navigation (up/down keys): >vim


### PR DESCRIPTION
#### vim-patch:bb0860a: runtime(doc): tweak option name notation further

related: vim/vim#17857
closes: vim/vim#17917

https://github.com/vim/vim/commit/bb0860abc9af6a6154e08fe0c29315b934e7ec42

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>


#### vim-patch:f7deb81: runtime(doc): fix typo at :h cmdline-autocompletion

The '?' needs to be escaped, because the autocommand is using
file-patterns (glob like) and not a regex). See :h file-pattern

closes: vim/vim#17890

https://github.com/vim/vim/commit/f7deb815b0b3f326a4b3b5b983da87e46df4f477

Co-authored-by: Girish Palya <girishji@gmail.com>