### PR TITLE
vim-patch:9.1.1594: completion: search completion throws errors

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -4044,8 +4044,18 @@ static int copy_substring_from_pos(pos_T *start, pos_T *end, char **match, pos_T
 /// case sensitivity.
 static bool is_regex_match(char *pat, char *str)
 {
+  if (strcmp(pat, str) == 0) {
+    return true;
+  }
+
   regmatch_T regmatch;
+
+  emsg_off++;
+  msg_silent++;
   regmatch.regprog = vim_regcomp(pat, RE_MAGIC + RE_STRING);
+  emsg_off--;
+  msg_silent--;
+
   if (regmatch.regprog == NULL) {
     return false;
   }
@@ -4054,7 +4064,11 @@ static bool is_regex_match(char *pat, char *str)
     regmatch.rm_ic = !pat_has_uppercase(pat);
   }
 
+  emsg_off++;
+  msg_silent++;
   bool result = vim_regexec_nl(&regmatch, str, (colnr_T)0);
+  emsg_off--;
+  msg_silent--;
 
   vim_regfree(regmatch.regprog);
   return result;

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -142,10 +142,10 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
     // To keep the code simple, we only allow changing the
     // draw mode when the popup menu is not being displayed
     pum_external = ui_has(kUIPopupmenu)
-                   || (State == MODE_CMDLINE && ui_has(kUIWildmenu));
+                   || ((State & MODE_CMDLINE) && ui_has(kUIWildmenu));
   }
 
-  pum_rl = State != MODE_CMDLINE && curwin->w_p_rl;
+  pum_rl = (State & MODE_CMDLINE) == 0 && curwin->w_p_rl;
 
   do {
     // Mark the pum as visible already here,
@@ -163,7 +163,7 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
     pum_win_col_offset = 0;
 
     // wildoptions=pum
-    if (State == MODE_CMDLINE) {
+    if (State & MODE_CMDLINE) {
       pum_win_row = cmdline_win ? cmdline_win->w_wrow : ui_has(kUICmdline) ? 0 : cmdline_row;
       cursor_col = (cmdline_win ? cmdline_win->w_config._cmdline_offset : 0) + cmd_startcol;
       cursor_col %= cmdline_win ? cmdline_win->w_view_width : Columns;
@@ -257,7 +257,7 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
       // pum above "pum_win_row"
       pum_above = true;
 
-      if (State == MODE_CMDLINE && target_win == NULL) {
+      if ((State & MODE_CMDLINE) && target_win == NULL) {
         // For cmdline pum, no need for context lines unless target_win is set
         context_lines = 0;
       } else {
@@ -281,7 +281,7 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
       // pum below "pum_win_row"
       pum_above = false;
 
-      if (State == MODE_CMDLINE && target_win == NULL) {
+      if ((State & MODE_CMDLINE) && target_win == NULL) {
         // for cmdline pum, no need for context lines unless target_win is set
         context_lines = 0;
       } else {
@@ -437,7 +437,7 @@ void pum_display(pumitem_T *array, int size, int selected, bool array_changed, i
     // room the window size will keep changing.
   } while (pum_set_selected(selected, redo_count) && ++redo_count <= 2);
 
-  pum_grid.zindex = (State == MODE_CMDLINE) ? kZIndexCmdlinePopupMenu : kZIndexPopupMenu;
+  pum_grid.zindex = (State & MODE_CMDLINE) ? kZIndexCmdlinePopupMenu : kZIndexPopupMenu;
   pum_redraw();
 }
 
@@ -451,15 +451,15 @@ static int *pum_compute_text_attrs(char *text, hlf_T hlf, int user_hlattr)
     return NULL;
   }
 
-  char *leader = State == MODE_CMDLINE ? cmdline_compl_pattern()
-                                       : ins_compl_leader();
+  char *leader = (State & MODE_CMDLINE) ? cmdline_compl_pattern()
+                                        : ins_compl_leader();
   if (leader == NULL || *leader == NUL) {
     return NULL;
   }
 
   int *attrs = xmalloc(sizeof(int) * (size_t)vim_strsize(text));
-  bool in_fuzzy = State == MODE_CMDLINE ? cmdline_compl_is_fuzzy()
-                                        : (get_cot_flags() & kOptCotFlagFuzzy) != 0;
+  bool in_fuzzy = (State & MODE_CMDLINE) ? cmdline_compl_is_fuzzy()
+                                         : (get_cot_flags() & kOptCotFlagFuzzy) != 0;
   size_t leader_len = strlen(leader);
 
   garray_T *ga = NULL;

--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -486,6 +486,43 @@ describe('cmdline', function()
 
     feed('<esc>')
   end)
+
+  -- oldtest: Test_search_wildmenu_iminsert()
+  it('search wildmenu pum with iminsert=1', function()
+    local screen = Screen.new(65, 20)
+    exec([[
+      set wop=pum imi=1
+      setlocal iskeyword=!-~,192-255
+      call setline(1, [
+            \ " global toggle global-local global/local glyphs toggles English",
+            \ "accordingly. toggled accordingly single-byte glob() glob(pat,",
+            \ "English, 'gli' global-ime single-repeat 'toggle' 'toggle'.",
+            \ ])
+    ]])
+    feed('/gl<Tab>')
+    screen:expect([[
+      {12: global         }lobal-local global/local glyphs toggles English  |
+      {4: gle            }gled accordingly single-byte glob() glob(pat,    |
+      {4: global-local   }lobal-ime single-repeat 'toggle' 'toggle'.       |
+      {4: global/local   }{1:                                                 }|
+      {4: glyphs         }{1:                                                 }|
+      {4: gles           }{1:                                                 }|
+      {4: glish          }{1:                                                 }|
+      {4: gly.           }{1:                                                 }|
+      {4: gled           }{1:                                                 }|
+      {4: gly            }{1:                                                 }|
+      {4: gle-byte       }{1:                                                 }|
+      {4: glob()         }{1:                                                 }|
+      {4: glob(pat,      }{1:                                                 }|
+      {4: glish,         }{1:                                                 }|
+      {4: gli'           }{1:                                                 }|
+      {4: global-ime     }{1:                                                 }|
+      {4: gle-repeat     }{1:                                                 }|
+      {4: gle'           }{1:                                                 }|
+      {4: gle'.          }{1:                                                 }|
+      /global^                                                          |
+    ]])
+  end)
 end)
 
 describe('cmdwin', function()


### PR DESCRIPTION
#### vim-patch:9.1.1594: completion: search completion throws errors

Problem:  completion: search completion throws errors, wrong placement
          of pum menu with 'imi'=1 (berggeist)
Solution: Fix those errors (Girish Palya)

closes: vim/vim#17870

https://github.com/vim/vim/commit/66467cf5d80a2dcc19cc8de3747b5ecddde71996

Co-authored-by: Girish Palya <girishji@gmail.com>