### PR TITLE
feat: add support for project-root in buffer level

### DIFF
--- a/runtime/ftplugin/c.vim
+++ b/runtime/ftplugin/c.vim
@@ -70,5 +70,8 @@ endif
 
 let b:man_default_sects = '3,2'
 
+" Set the root patterns for project root detection
+setlocal rootpattern+=.clangd,.clang-tidy,.clang-format,compile_commands.json,compile_flags.txt,configure.ac
+
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/ftplugin/c.vim
+++ b/runtime/ftplugin/c.vim
@@ -71,7 +71,7 @@ endif
 let b:man_default_sects = '3,2'
 
 " Set the root patterns for project root detection
-setlocal rootpattern+=.clangd,.clang-tidy,.clang-format,compile_commands.json,compile_flags.txt,configure.ac
+setlocal rootmarker+=.clangd,.clang-tidy,.clang-format,compile_commands.json,compile_flags.txt,configure.ac
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -83,6 +83,9 @@ function s:LuaInclude(fname) abort
   return fname
 endfunction
 
+" Set the root patterns for project root detection
+setlocal rootpattern+=.luarc.json,.luarc.jsonc,.luacheckrc,.stylua.toml,stylua.toml,selene.toml,selene.yml
+
 let &cpo = s:cpo_save
 unlet s:cpo_save
 

--- a/runtime/ftplugin/lua.vim
+++ b/runtime/ftplugin/lua.vim
@@ -84,7 +84,7 @@ function s:LuaInclude(fname) abort
 endfunction
 
 " Set the root patterns for project root detection
-setlocal rootpattern+=.luarc.json,.luarc.jsonc,.luacheckrc,.stylua.toml,stylua.toml,selene.toml,selene.yml
+setlocal rootmarker+=.luarc.json,.luarc.jsonc,.luacheckrc,.stylua.toml,stylua.toml,selene.toml,selene.yml
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -977,11 +977,12 @@ do
 
   local nvim_set_root = vim.api.nvim_create_augroup('nvim.setroot', {clear = true})
   local function set_buffer_root(buf)
-    local root_patterns = vim.api.nvim_get_option_value('rootpattern', { buf = buf })
-    root_patterns = vim.split(root_patterns, ',', { trimempty = true })
-    local root = vim.fs.root(buf, root_patterns)
+    local root_markers = vim.api.nvim_get_option_value('rootmarker', { buf = buf })
+    root_markers = vim.split(root_markers, ',', { trimempty = true })
+    local root = vim.fs.root(buf, root_markers)
     vim.api.nvim_set_option_value('root', root, { buf = buf })
   end
+
   vim.api.nvim_create_autocmd({'VimEnter', 'BufNew'}, {
     group = nvim_set_root,
     desc = 'set buffer root when buffer is being created',
@@ -992,10 +993,11 @@ do
   vim.api.nvim_create_autocmd('OptionSet', {
     nested = true,
     group = nvim_set_root,
-    pattern = 'rootpattern',
+    pattern = 'rootmarker',
     desc = 'set buffer root when root pattern is changed',
-    callback = function(event)
-      set_buffer_root(event.buf)
+    callback = function()
+      local buf = vim.api.nvim_get_current_buf()
+      set_buffer_root(buf)
     end,
   })
 end

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -975,7 +975,7 @@ do
     end,
   })
 
-  local nvim_set_root = vim.api.nvim_create_augroup('nvim.setroot', {clear = true})
+  local nvim_set_root = vim.api.nvim_create_augroup('nvim.setroot', { clear = true })
   local function set_buffer_root(buf)
     local root_markers = vim.api.nvim_get_option_value('rootmarker', { buf = buf })
     root_markers = vim.split(root_markers, ',', { trimempty = true })
@@ -983,7 +983,7 @@ do
     vim.api.nvim_set_option_value('root', root, { buf = buf })
   end
 
-  vim.api.nvim_create_autocmd({'VimEnter', 'BufNew'}, {
+  vim.api.nvim_create_autocmd({ 'VimEnter', 'BufNew' }, {
     group = nvim_set_root,
     desc = 'set buffer root when buffer is being created',
     callback = function(event)

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -984,6 +984,7 @@ do
   end
 
   vim.api.nvim_create_autocmd({ 'VimEnter', 'BufNew' }, {
+    nested = true,
     group = nvim_set_root,
     desc = 'set buffer root when buffer is being created',
     callback = function(event)

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -974,6 +974,30 @@ do
       end
     end,
   })
+
+  local nvim_set_root = vim.api.nvim_create_augroup('nvim.setroot', {clear = true})
+  local function set_buffer_root(buf)
+    local root_patterns = vim.api.nvim_get_option_value('rootpattern', { buf = buf })
+    root_patterns = vim.split(root_patterns, ',', { trimempty = true })
+    local root = vim.fs.root(buf, root_patterns)
+    vim.api.nvim_set_option_value('root', root, { buf = buf })
+  end
+  vim.api.nvim_create_autocmd({'VimEnter', 'BufNew'}, {
+    group = nvim_set_root,
+    desc = 'set buffer root when buffer is being created',
+    callback = function(event)
+      set_buffer_root(event.buf)
+    end,
+  })
+  vim.api.nvim_create_autocmd('OptionSet', {
+    nested = true,
+    group = nvim_set_root,
+    pattern = 'rootpattern',
+    desc = 'set buffer root when root pattern is changed',
+    callback = function(event)
+      set_buffer_root(event.buf)
+    end,
+  })
 end
 
 --- Default options

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2122,7 +2122,7 @@ void free_buf_options(buf_T *buf, bool free_p_ff)
   clear_string_option(&buf->b_p_bkc);
   clear_string_option(&buf->b_p_menc);
   clear_string_option(&buf->b_p_root);
-  clear_string_option(&buf->b_p_root_pat);
+  clear_string_option(&buf->b_p_root_marker);
 }
 
 /// Get alternate file "n".

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -2121,6 +2121,8 @@ void free_buf_options(buf_T *buf, bool free_p_ff)
   clear_string_option(&buf->b_p_lw);
   clear_string_option(&buf->b_p_bkc);
   clear_string_option(&buf->b_p_menc);
+  clear_string_option(&buf->b_p_root);
+  clear_string_option(&buf->b_p_root_pat);
 }
 
 /// Get alternate file "n".

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -373,7 +373,7 @@ struct file_buffer {
   int b_ro_locked;              // Non-zero when the buffer can't be changed.
                                 // Used for FileChangedRO
   char *b_p_root;               // Project root of the buffer.
-  char *b_p_root_pat;           // glob root patterns for detecting root of the buffer.
+  char *b_p_root_marker;           // glob root patterns for detecting root of the buffer.
 
   // b_ffname   has the full path of the file (NULL for no name).
   // b_sfname   is the name as the user typed it (or NULL).

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -372,8 +372,8 @@ struct file_buffer {
                                 // it in more windows.
   int b_ro_locked;              // Non-zero when the buffer can't be changed.
                                 // Used for FileChangedRO
-  char *b_root;                 // Project root of the buffer.
-  char *b_root_pat;             // glob root patterns for detecting root of the buffer.
+  char *b_p_root;               // Project root of the buffer.
+  char *b_p_root_pat;           // glob root patterns for detecting root of the buffer.
 
   // b_ffname   has the full path of the file (NULL for no name).
   // b_sfname   is the name as the user typed it (or NULL).

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -372,6 +372,8 @@ struct file_buffer {
                                 // it in more windows.
   int b_ro_locked;              // Non-zero when the buffer can't be changed.
                                 // Used for FileChangedRO
+  char *b_root;                 // Project root of the buffer.
+  char *b_root_pat;             // glob root patterns for detecting root of the buffer.
 
   // b_ffname   has the full path of the file (NULL for no name).
   // b_sfname   is the name as the user typed it (or NULL).

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4612,6 +4612,10 @@ void *get_varp_from(vimoption_T *p, buf_T *buf, win_T *win)
     return &(win->w_p_nu);
   case kOptRelativenumber:
     return &(win->w_p_rnu);
+  case kOptRoot:
+    return &(buf->b_root);
+  case kOptRootpattern:
+    return &(buf->b_root_pat);
   case kOptNumberwidth:
     return &(win->w_p_nuw);
   case kOptWinfixbuf:

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4614,8 +4614,8 @@ void *get_varp_from(vimoption_T *p, buf_T *buf, win_T *win)
     return &(win->w_p_rnu);
   case kOptRoot:
     return &(buf->b_p_root);
-  case kOptRootpattern:
-    return &(buf->b_p_root_pat);
+  case kOptRootmarker:
+    return &(buf->b_p_root_marker);
   case kOptNumberwidth:
     return &(win->w_p_nuw);
   case kOptWinfixbuf:
@@ -5072,7 +5072,7 @@ void buf_copy_options(buf_T *buf, int flags)
         buf->b_p_bh = empty_string_option;
         buf->b_p_bt = empty_string_option;
         buf->b_p_root = xstrdup(p_root);
-        buf->b_p_root_pat = xstrdup(p_root_pat);
+        buf->b_p_root_marker = xstrdup(p_root_marker);
       } else {
         free_buf_options(buf, false);
       }

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -4613,9 +4613,9 @@ void *get_varp_from(vimoption_T *p, buf_T *buf, win_T *win)
   case kOptRelativenumber:
     return &(win->w_p_rnu);
   case kOptRoot:
-    return &(buf->b_root);
+    return &(buf->b_p_root);
   case kOptRootpattern:
-    return &(buf->b_root_pat);
+    return &(buf->b_p_root_pat);
   case kOptNumberwidth:
     return &(win->w_p_nuw);
   case kOptWinfixbuf:
@@ -5071,6 +5071,8 @@ void buf_copy_options(buf_T *buf, int flags)
         }
         buf->b_p_bh = empty_string_option;
         buf->b_p_bt = empty_string_option;
+        buf->b_p_root = xstrdup(p_root);
+        buf->b_p_root_pat = xstrdup(p_root_pat);
       } else {
         free_buf_options(buf, false);
       }

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -444,6 +444,8 @@ EXTERN int p_pi;                ///< 'preserveindent'
 EXTERN OptInt p_pyx;            ///< 'pyxversion'
 EXTERN char *p_qe;              ///< 'quoteescape'
 EXTERN int p_ro;                ///< 'readonly'
+EXTERN char *p_root;            ///< 'root'
+EXTERN char *p_root_pat;        ///< 'rootpattern'
 EXTERN char *p_rdb;             ///< 'redrawdebug'
 EXTERN unsigned rdb_flags;
 EXTERN OptInt p_rdt;            ///< 'redrawtime'

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -445,7 +445,7 @@ EXTERN OptInt p_pyx;            ///< 'pyxversion'
 EXTERN char *p_qe;              ///< 'quoteescape'
 EXTERN int p_ro;                ///< 'readonly'
 EXTERN char *p_root;            ///< 'root'
-EXTERN char *p_root_pat;        ///< 'rootpattern'
+EXTERN char *p_root_marker;     ///< 'rootmarker'
 EXTERN char *p_rdb;             ///< 'redrawdebug'
 EXTERN unsigned rdb_flags;
 EXTERN OptInt p_rdt;            ///< 'redrawtime'

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7035,15 +7035,20 @@ local options = {
     {
       defaults = '.git,.hg,.svn',
       desc = [=[
-        The path to project-root of the current buffer.
+        Makers for dectecting project-root of the current buffer.
+        This is used to set 'root' option. First directory that matches one of
+        marker that is determined as 'root'. For example, if some parent folder
+        of current file has following structure $dir/$marker[0] then $dir is
+        considered as project root. If none of the rootmarkers match root is
+        set to empty string.
       ]=],
-      full_name = 'rootpattern',
+      full_name = 'rootmarker',
       noglob = true,
       scope = { 'buf' },
-      short_desc = N_('Glob patterns for detecting project root'),
+      short_desc = N_('Markers for detecting project root'),
       list = 'onecomma',
       type = 'string',
-      varname = 'p_root_pat',
+      varname = 'p_root_marker',
     },
     {
       abbreviation = 'rtp',

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -7021,6 +7021,31 @@ local options = {
       varname = 'p_ruf',
     },
     {
+      defaults = '',
+      desc = [=[
+        The path to project-root of the current buffer.
+      ]=],
+      full_name = 'root',
+      noglob = true,
+      scope = { 'buf' },
+      short_desc = N_('Project root of buffer'),
+      type = 'string',
+      varname = 'p_root',
+    },
+    {
+      defaults = '.git,.hg,.svn',
+      desc = [=[
+        The path to project-root of the current buffer.
+      ]=],
+      full_name = 'rootpattern',
+      noglob = true,
+      scope = { 'buf' },
+      short_desc = N_('Glob patterns for detecting project root'),
+      list = 'onecomma',
+      type = 'string',
+      varname = 'p_root_pat',
+    },
+    {
       abbreviation = 'rtp',
       cb = 'did_set_runtimepackpath',
       defaults = {

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -6963,6 +6963,36 @@ local options = {
       type = 'string',
     },
     {
+      defaults = '',
+      desc = [=[
+        The path to project-root of the current buffer.
+      ]=],
+      full_name = 'root',
+      noglob = true,
+      scope = { 'buf' },
+      short_desc = N_('Project root of buffer'),
+      type = 'string',
+      varname = 'p_root',
+    },
+    {
+      defaults = '.git,.hg,.svn',
+      desc = [=[
+        Makers for dectecting project-root of the current buffer.
+        This is used to set 'root' option. First directory that matches one of
+        marker that is determined as 'root'. For example, if some parent folder
+        of current file has following structure $dir/$marker[0] then $dir is
+        considered as project root. If none of the rootmarkers match root is
+        set to empty string.
+      ]=],
+      full_name = 'rootmarker',
+      noglob = true,
+      scope = { 'buf' },
+      short_desc = N_('Markers for detecting project root'),
+      list = 'onecomma',
+      type = 'string',
+      varname = 'p_root_marker',
+    },
+    {
       abbreviation = 'ru',
       defaults = true,
       desc = [=[
@@ -7019,36 +7049,6 @@ local options = {
       short_desc = N_('custom format for the ruler'),
       type = 'string',
       varname = 'p_ruf',
-    },
-    {
-      defaults = '',
-      desc = [=[
-        The path to project-root of the current buffer.
-      ]=],
-      full_name = 'root',
-      noglob = true,
-      scope = { 'buf' },
-      short_desc = N_('Project root of buffer'),
-      type = 'string',
-      varname = 'p_root',
-    },
-    {
-      defaults = '.git,.hg,.svn',
-      desc = [=[
-        Makers for dectecting project-root of the current buffer.
-        This is used to set 'root' option. First directory that matches one of
-        marker that is determined as 'root'. For example, if some parent folder
-        of current file has following structure $dir/$marker[0] then $dir is
-        considered as project root. If none of the rootmarkers match root is
-        set to empty string.
-      ]=],
-      full_name = 'rootmarker',
-      noglob = true,
-      scope = { 'buf' },
-      short_desc = N_('Markers for detecting project root'),
-      list = 'onecomma',
-      type = 'string',
-      varname = 'p_root_marker',
     },
     {
       abbreviation = 'rtp',

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -180,7 +180,7 @@ void check_buf_options(buf_T *buf)
   check_string_option(&buf->b_p_vsts);
   check_string_option(&buf->b_p_vts);
   check_string_option(&buf->b_p_root);
-  check_string_option(&buf->b_p_root_pat);
+  check_string_option(&buf->b_p_root_marker);
 }
 
 /// Free the string allocated for an option.

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -179,6 +179,8 @@ void check_buf_options(buf_T *buf)
   check_string_option(&buf->b_p_menc);
   check_string_option(&buf->b_p_vsts);
   check_string_option(&buf->b_p_vts);
+  check_string_option(&buf->b_p_root);
+  check_string_option(&buf->b_p_root_pat);
 }
 
 /// Free the string allocated for an option.


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Working toward https://github.com/neovim/neovim/issues/34622

Adds the following options:
- 'root' option as project root. That gets auto-set on buffer creation based on 'rootmarker'. lsp and other plugins can utilize it to find the project root.
- 'rootmarker' list of markers to determine the root for the buffer. Should get set by ftplugins.