### PR TITLE
refactor(build): remove INCLUDE_GENERATED_DECLARATIONS guards

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -304,7 +304,6 @@ pub fn build(b: *std.Build) !void {
 
     const flags = [_][]const u8{
         "-std=gnu99",
-        "-DINCLUDE_GENERATED_DECLARATIONS",
         "-DZIG_BUILD",
         "-D_GNU_SOURCE",
         if (support_unittests) "-DUNIT_TESTING" else "",

--- a/runtime/doc/dev_style.txt
+++ b/runtime/doc/dev_style.txt
@@ -255,8 +255,7 @@ functions. >c
 
 Integration with declarations generator ~
 
-Every C file must contain #include of the generated header file, guarded by
-#ifdef INCLUDE_GENERATED_DECLARATIONS.
+Every C file must contain #include of the generated header file.
 
 Include must go after other #includes and typedefs in .c files and after
 everything else in header files. It is allowed to omit #include in a .c file
@@ -272,9 +271,7 @@ contain only non-static function declarations. >c
 
     typedef int FooType;
 
-    #ifdef INCLUDE_GENERATED_DECLARATIONS
-    # include "foo.c.generated.h"
-    #endif
+    #include "foo.c.generated.h"
 
     …
 
@@ -284,9 +281,7 @@ contain only non-static function declarations. >c
 
     …
 
-    #ifdef INCLUDE_GENERATED_DECLARATIONS
-    # include "foo.h.generated.h"
-    #endif
+    #include "foo.h.generated.h"
 
 
 64-bit Portability ~

--- a/src/nvim/CMakeLists.txt
+++ b/src/nvim/CMakeLists.txt
@@ -180,8 +180,6 @@ if(HAS_DIAG_COLOR_FLAG)
   endif()
 endif()
 
-target_compile_definitions(main_lib INTERFACE INCLUDE_GENERATED_DECLARATIONS)
-
 # Remove --sort-common from linker flags, as this seems to cause bugs (see #2641, #3374).
 # TODO: Figure out the root cause.
 if(CMAKE_EXE_LINKER_FLAGS MATCHES "--sort-common" OR
@@ -911,8 +909,14 @@ add_glob_target(
   FLAGS -c ${UNCRUSTIFY_CONFIG} --replace --no-backup
   FILES ${NVIM_SOURCES} ${NVIM_HEADERS})
 
-add_dependencies(lintc-uncrustify uncrustify_update_config)
-add_dependencies(formatc uncrustify_update_config)
+# TODO(bfredl): there is a bug in "uncrustify --update-config-with-doc" which breaks
+# our config (backslash escape in strings). Once fixed these two lines should be deleted
+# and the following two commented lines be uncomennetd.
+add_dependencies(lintc-uncrustify uncrustify)
+add_dependencies(formatc uncrustify)
+#add_dependencies(lintc-uncrustify uncrustify_update_config)
+#add_dependencies(formatc uncrustify_update_config)
+
 add_dependencies(uncrustify_update_config uncrustify)
 
 add_custom_target(lintc)

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -27,9 +27,7 @@
 #include "nvim/types_defs.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/autocmd.c.generated.h"
-#endif
+#include "api/autocmd.c.generated.h"
 
 #define AUCMD_MAX_PATTERNS 256
 

--- a/src/nvim/api/autocmd.h
+++ b/src/nvim/api/autocmd.h
@@ -5,6 +5,4 @@
 #include "nvim/api/keysets_defs.h"  // IWYU pragma: keep
 #include "nvim/api/private/defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/autocmd.h.generated.h"
-#endif
+#include "api/autocmd.h.generated.h"

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -46,9 +46,7 @@
 #include "nvim/undo_defs.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/buffer.c.generated.h"
-#endif
+#include "api/buffer.c.generated.h"
 
 /// @brief <pre>help
 /// For more information on buffers, see |buffers|.

--- a/src/nvim/api/buffer.h
+++ b/src/nvim/api/buffer.h
@@ -8,6 +8,4 @@
 #include "nvim/pos_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/buffer.h.generated.h"
-#endif
+#include "api/buffer.h.generated.h"

--- a/src/nvim/api/command.c
+++ b/src/nvim/api/command.c
@@ -37,9 +37,7 @@
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/command.c.generated.h"
-#endif
+#include "api/command.c.generated.h"
 
 /// Parse arguments for :map/:abbrev commands, preserving whitespace in RHS.
 /// @param arg_str  The argument string to parse

--- a/src/nvim/api/command.h
+++ b/src/nvim/api/command.h
@@ -5,6 +5,4 @@
 #include "nvim/api/keysets_defs.h"  // IWYU pragma: keep
 #include "nvim/api/private/defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/command.h.generated.h"
-#endif
+#include "api/command.h.generated.h"

--- a/src/nvim/api/deprecated.c
+++ b/src/nvim/api/deprecated.c
@@ -31,9 +31,7 @@
 #include "nvim/strings.h"
 #include "nvim/types_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/deprecated.c.generated.h"
-#endif
+#include "api/deprecated.c.generated.h"
 
 /// @deprecated Use nvim_exec2() instead.
 /// @see nvim_exec2

--- a/src/nvim/api/deprecated.h
+++ b/src/nvim/api/deprecated.h
@@ -5,6 +5,4 @@
 #include "nvim/api/keysets_defs.h"  // IWYU pragma: keep
 #include "nvim/api/private/defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/deprecated.h.generated.h"
-#endif
+#include "api/deprecated.h.generated.h"

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -32,9 +32,7 @@
 #include "nvim/pos_defs.h"
 #include "nvim/sign.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/extmark.c.generated.h"
-#endif
+#include "api/extmark.c.generated.h"
 
 void api_extmark_free_all_mem(void)
 {

--- a/src/nvim/api/extmark.h
+++ b/src/nvim/api/extmark.h
@@ -28,6 +28,4 @@ static inline bool ns_in_win(uint32_t ns_id, win_T *wp)
   return set_has(uint32_t, &wp->w_ns_set, ns_id);
 }
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/extmark.h.generated.h"
-#endif
+#include "api/extmark.h.generated.h"

--- a/src/nvim/api/options.c
+++ b/src/nvim/api/options.c
@@ -19,9 +19,7 @@
 #include "nvim/types_defs.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/options.c.generated.h"
-#endif
+#include "api/options.c.generated.h"
 
 static int validate_option_value_args(Dict(option) *opts, char *name, OptIndex *opt_idxp,
                                       int *opt_flags, OptScope *scope, void **from, char **filetype,

--- a/src/nvim/api/options.h
+++ b/src/nvim/api/options.h
@@ -6,6 +6,4 @@
 #include "nvim/api/private/defs.h"  // IWYU pragma: keep
 #include "nvim/option_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/options.h.generated.h"
-#endif
+#include "api/options.h.generated.h"

--- a/src/nvim/api/private/converter.c
+++ b/src/nvim/api/private/converter.c
@@ -26,9 +26,7 @@ typedef struct {
   bool reuse_strdata;
 } EncodedData;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/private/converter.c.generated.h"
-#endif
+#include "api/private/converter.c.generated.h"
 
 #define TYPVAL_ENCODE_ALLOW_SPECIALS false
 #define TYPVAL_ENCODE_CHECK_BEFORE

--- a/src/nvim/api/private/converter.h
+++ b/src/nvim/api/private/converter.h
@@ -3,6 +3,4 @@
 #include "nvim/api/private/defs.h"  // IWYU pragma: keep
 #include "nvim/eval/typval_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/private/converter.h.generated.h"
-#endif
+#include "api/private/converter.h.generated.h"

--- a/src/nvim/api/private/defs.h
+++ b/src/nvim/api/private/defs.h
@@ -15,19 +15,17 @@
 
 #define ERROR_SET(e) ((e)->type != kErrorTypeNone)
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# define ArrayOf(...) Array
-# define DictOf(...) Dict
-# define DictAs(name) Dict
-# define Dict(name) KeyDict_##name
-# define Enum(...) String
-# define DictHash(name) KeyDict_##name##_get_field
-# define DictKey(name)
-# define LuaRefOf(...) LuaRef
-# define Union(...) Object
-# define Tuple(...) Array
-# include "api/private/defs.h.inline.generated.h"
-#endif
+#define ArrayOf(...) Array
+#define DictOf(...) Dict
+#define DictAs(name) Dict
+#define Dict(name) KeyDict_##name
+#define Enum(...) String
+#define DictHash(name) KeyDict_##name##_get_field
+#define DictKey(name)
+#define LuaRefOf(...) LuaRef
+#define Union(...) Object
+#define Tuple(...) Array
+#include "api/private/defs.h.inline.generated.h"
 
 // Basic types
 typedef enum {

--- a/src/nvim/api/private/dispatch.c
+++ b/src/nvim/api/private/dispatch.c
@@ -4,9 +4,7 @@
 #include "nvim/api/private/dispatch.h"
 #include "nvim/api/private/helpers.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/private/dispatch_wrappers.generated.h"
-#endif
+#include "api/private/dispatch_wrappers.generated.h"
 
 /// @param name API method name
 /// @param name_len name size (includes terminating NUL)

--- a/src/nvim/api/private/dispatch.h
+++ b/src/nvim/api/private/dispatch.h
@@ -24,8 +24,6 @@ struct MsgpackRpcRequestHandler {
 
 extern const MsgpackRpcRequestHandler method_handlers[];
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/private/dispatch.h.generated.h"
-# include "api/private/dispatch_wrappers.h.generated.h"
-# include "keysets_defs.generated.h"
-#endif
+#include "api/private/dispatch.h.generated.h"
+#include "api/private/dispatch_wrappers.h.generated.h"
+#include "keysets_defs.generated.h"

--- a/src/nvim/api/private/helpers.c
+++ b/src/nvim/api/private/helpers.c
@@ -33,10 +33,8 @@
 #include "nvim/runtime.h"
 #include "nvim/types_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/private/api_metadata.generated.h"
-# include "api/private/helpers.c.generated.h"  // IWYU pragma: keep
-#endif
+#include "api/private/api_metadata.generated.h"
+#include "api/private/helpers.c.generated.h"  // IWYU pragma: keep
 
 /// Start block that may cause Vimscript exceptions while evaluating another code
 ///

--- a/src/nvim/api/private/helpers.h
+++ b/src/nvim/api/private/helpers.h
@@ -180,9 +180,7 @@ typedef struct {
     code; \
   }
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/private/helpers.h.generated.h"
-#endif
+#include "api/private/helpers.h.generated.h"
 
 #define WITH_SCRIPT_CONTEXT(channel_id, code) \
   do { \

--- a/src/nvim/api/private/validate.h
+++ b/src/nvim/api/private/validate.h
@@ -91,6 +91,4 @@
 #define VALIDATE_R(cond, name, code) \
   VALIDATE(cond, "Required: '%s'", name, code);
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/private/validate.h.generated.h"
-#endif
+#include "api/private/validate.h.generated.h"

--- a/src/nvim/api/tabpage.c
+++ b/src/nvim/api/tabpage.c
@@ -11,9 +11,7 @@
 #include "nvim/types_defs.h"
 #include "nvim/window.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/tabpage.c.generated.h"  // IWYU pragma: keep
-#endif
+#include "api/tabpage.c.generated.h"  // IWYU pragma: keep
 
 /// Gets the windows in a tabpage
 ///

--- a/src/nvim/api/tabpage.h
+++ b/src/nvim/api/tabpage.h
@@ -2,6 +2,4 @@
 
 #include "nvim/api/private/defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/tabpage.h.generated.h"
-#endif
+#include "api/tabpage.h.generated.h"

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -42,10 +42,8 @@
 
 #define BUF_POS(ui) ((size_t)((ui)->packer.ptr - (ui)->packer.startptr))
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/ui.c.generated.h"
-# include "ui_events_remote.generated.h"  // IWYU pragma: export
-#endif
+#include "api/ui.c.generated.h"
+#include "ui_events_remote.generated.h"  // IWYU pragma: export
 
 // TODO(bfredl): just make UI:s owned by their channels instead
 static PMap(uint64_t) connected_uis = MAP_INIT;

--- a/src/nvim/api/ui.h
+++ b/src/nvim/api/ui.h
@@ -22,7 +22,5 @@ EXTERN const char *ui_ext_names[] INIT( = {
   "_debug_float",
 });
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/ui.h.generated.h"
-# include "ui_events_remote.h.generated.h"
-#endif
+#include "api/ui.h.generated.h"
+#include "ui_events_remote.h.generated.h"

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -1,9 +1,7 @@
 #pragma once
 
 // This file is not compiled, just parsed for definitions
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# error "don't include this file, include nvim/ui.h"
-#endif
+#error "don't include this file, include nvim/ui.h"
 
 #include "nvim/api/private/defs.h"
 #include "nvim/func_attr.h"

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -86,9 +86,7 @@
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/vim.c.generated.h"
-#endif
+#include "api/vim.c.generated.h"
 
 /// Gets a highlight group by name
 ///

--- a/src/nvim/api/vim.h
+++ b/src/nvim/api/vim.h
@@ -5,6 +5,4 @@
 #include "nvim/api/keysets_defs.h"  // IWYU pragma: keep
 #include "nvim/api/private/defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/vim.h.generated.h"
-#endif
+#include "api/vim.h.generated.h"

--- a/src/nvim/api/vimscript.c
+++ b/src/nvim/api/vimscript.c
@@ -29,9 +29,7 @@
 #include "nvim/viml/parser/parser.h"
 #include "nvim/viml/parser/parser_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/vimscript.c.generated.h"
-#endif
+#include "api/vimscript.c.generated.h"
 
 /// Executes Vimscript (multiline block of Ex commands), like anonymous
 /// |:source|.

--- a/src/nvim/api/vimscript.h
+++ b/src/nvim/api/vimscript.h
@@ -5,6 +5,4 @@
 #include "nvim/api/keysets_defs.h"  // IWYU pragma: keep
 #include "nvim/api/private/defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/vimscript.h.generated.h"
-#endif
+#include "api/vimscript.h.generated.h"

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -36,9 +36,7 @@
 #include "nvim/window.h"
 #include "nvim/winfloat.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/win_config.c.generated.h"
-#endif
+#include "api/win_config.c.generated.h"
 
 /// Opens a new split window, or a floating window if `relative` is specified,
 /// or an external window (managed by the UI) if `external` is specified.

--- a/src/nvim/api/win_config.h
+++ b/src/nvim/api/win_config.h
@@ -6,6 +6,4 @@
 #include "nvim/api/private/defs.h"  // IWYU pragma: keep
 #include "nvim/buffer_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/win_config.h.generated.h"
-#endif
+#include "api/win_config.h.generated.h"

--- a/src/nvim/api/window.c
+++ b/src/nvim/api/window.c
@@ -26,9 +26,7 @@
 #include "nvim/types_defs.h"
 #include "nvim/window.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/window.c.generated.h"  // IWYU pragma: keep
-#endif
+#include "api/window.c.generated.h"  // IWYU pragma: keep
 
 /// Gets the current buffer in a window
 ///

--- a/src/nvim/api/window.h
+++ b/src/nvim/api/window.h
@@ -3,6 +3,4 @@
 #include "nvim/api/keysets_defs.h"  // IWYU pragma: keep
 #include "nvim/api/private/defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "api/window.h.generated.h"
-#endif
+#include "api/window.h.generated.h"

--- a/src/nvim/arabic.c
+++ b/src/nvim/arabic.c
@@ -158,9 +158,7 @@ static struct achar {
 
 #define a_BYTE_ORDER_MARK               0xfeff
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "arabic.c.generated.h"
-#endif
+#include "arabic.c.generated.h"
 
 /// Find the struct achar pointer to the given Arabic char.
 /// Returns NULL if not found.

--- a/src/nvim/arabic.h
+++ b/src/nvim/arabic.h
@@ -4,6 +4,4 @@
 
 #define ARABIC_CHAR(ch)            (((ch) & 0xFF00) == 0x0600)
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "arabic.h.generated.h"
-#endif
+#include "arabic.h.generated.h"

--- a/src/nvim/arglist.c
+++ b/src/nvim/arglist.c
@@ -64,9 +64,7 @@ typedef struct {
   tabpage_T *new_curtab;
 } arg_all_state_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "arglist.c.generated.h"
-#endif
+#include "arglist.c.generated.h"
 
 static const char e_window_layout_changed_unexpectedly[]
   = N_("E249: Window layout changed unexpectedly");

--- a/src/nvim/arglist.h
+++ b/src/nvim/arglist.h
@@ -4,6 +4,4 @@
 #include "nvim/cmdexpand_defs.h"  // IWYU pragma: keep
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "arglist.h.generated.h"
-#endif
+#include "arglist.h.generated.h"

--- a/src/nvim/ascii_defs.h
+++ b/src/nvim/ascii_defs.h
@@ -4,9 +4,7 @@
 
 #include "nvim/os/os_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ascii_defs.h.inline.generated.h"
-#endif
+#include "ascii_defs.h.inline.generated.h"
 
 // Definitions of various common control characters.
 

--- a/src/nvim/autocmd.c
+++ b/src/nvim/autocmd.c
@@ -7,9 +7,6 @@
 #include <stdlib.h>
 #include <string.h>
 
-#include "klib/kvec.h"
-#include "nvim/api/private/helpers.h"
-#include "nvim/ascii_defs.h"
 #include "nvim/autocmd.h"
 #include "nvim/buffer.h"
 #include "nvim/charset.h"
@@ -63,10 +60,8 @@
 #include "nvim/window.h"
 #include "nvim/winfloat.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "auevents_name_map.generated.h"
-# include "autocmd.c.generated.h"
-#endif
+#include "auevents_name_map.generated.h"
+#include "autocmd.c.generated.h"
 
 static const char e_autocommand_nesting_too_deep[]
   = N_("E218: Autocommand nesting too deep");

--- a/src/nvim/autocmd.h
+++ b/src/nvim/autocmd.h
@@ -68,6 +68,4 @@ enum { BUFLOCAL_PAT_LEN = 25, };
 #define FOR_ALL_AUEVENTS(event) \
   for (event_T event = (event_T)0; (int)event < (int)NUM_EVENTS; event = (event_T)((int)event + 1))
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "autocmd.h.generated.h"
-#endif
+#include "autocmd.h.generated.h"

--- a/src/nvim/autocmd_defs.h
+++ b/src/nvim/autocmd_defs.h
@@ -7,9 +7,7 @@
 #include "nvim/buffer_defs.h"
 #include "nvim/ex_cmds_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "auevents_enum.generated.h"
-#endif
+#include "auevents_enum.generated.h"
 
 /// Struct to save values in before executing autocommands for a buffer that is
 /// not the current buffer.

--- a/src/nvim/base64.c
+++ b/src/nvim/base64.c
@@ -12,9 +12,7 @@
 # include ENDIAN_INCLUDE_FILE
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "base64.c.generated.h"
-#endif
+#include "base64.c.generated.h"
 
 static const char alphabet[] = "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/";
 

--- a/src/nvim/base64.h
+++ b/src/nvim/base64.h
@@ -2,6 +2,4 @@
 
 #include <stddef.h>  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "base64.h.generated.h"
-#endif
+#include "base64.h.generated.h"

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -115,9 +115,7 @@
 #include "nvim/window.h"
 #include "nvim/winfloat.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "buffer.c.generated.h"
-#endif
+#include "buffer.c.generated.h"
 
 static const char e_attempt_to_delete_buffer_that_is_in_use_str[]
   = N_("E937: Attempt to delete a buffer that is in use: %s");

--- a/src/nvim/buffer.h
+++ b/src/nvim/buffer.h
@@ -73,10 +73,8 @@ enum bfa_values {
 EXTERN char *msg_loclist INIT( = N_("[Location List]"));
 EXTERN char *msg_qflist INIT( = N_("[Quickfix List]"));
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "buffer.h.generated.h"
-# include "buffer.h.inline.generated.h"
-#endif
+#include "buffer.h.generated.h"
+#include "buffer.h.inline.generated.h"
 
 /// Get b:changedtick value
 ///

--- a/src/nvim/buffer_updates.c
+++ b/src/nvim/buffer_updates.c
@@ -21,9 +21,7 @@
 #include "nvim/pos_defs.h"
 #include "nvim/types_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "buffer_updates.c.generated.h"  // IWYU pragma: keep
-#endif
+#include "buffer_updates.c.generated.h"  // IWYU pragma: keep
 
 // Register a channel. Return True if the channel was added, or already added.
 // Return False if the channel couldn't be added because the buffer is

--- a/src/nvim/buffer_updates.h
+++ b/src/nvim/buffer_updates.h
@@ -6,6 +6,4 @@
 #include "nvim/extmark_defs.h"  // IWYU pragma: keep
 #include "nvim/pos_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "buffer_updates.h.generated.h"
-#endif
+#include "buffer_updates.h.generated.h"

--- a/src/nvim/bufwrite.c
+++ b/src/nvim/bufwrite.c
@@ -91,9 +91,7 @@ struct bw_info {
   iconv_t bw_iconv_fd;            // descriptor for iconv() or -1
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "bufwrite.c.generated.h"
-#endif
+#include "bufwrite.c.generated.h"
 
 /// Convert a Unicode character to bytes.
 ///

--- a/src/nvim/bufwrite.h
+++ b/src/nvim/bufwrite.h
@@ -4,6 +4,4 @@
 #include "nvim/pos_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "bufwrite.h.generated.h"
-#endif
+#include "bufwrite.h.generated.h"

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -56,9 +56,7 @@
 #include "nvim/undo.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "change.c.generated.h"
-#endif
+#include "change.c.generated.h"
 
 /// If the file is readonly, give a warning message with the first change.
 /// Don't do this for autocommands.

--- a/src/nvim/change.h
+++ b/src/nvim/change.h
@@ -16,6 +16,4 @@ enum {
   OPENLINE_FORCE_INDENT = 0x40,  ///< use second_line_indent without indent logic
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "change.h.generated.h"
-#endif
+#include "change.h.generated.h"

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -58,9 +58,7 @@ static bool did_stdio = false;
 /// 2 is reserved for stderr channel
 static uint64_t next_chan_id = CHAN_STDERR + 1;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "channel.c.generated.h"
-#endif
+#include "channel.c.generated.h"
 
 /// Teardown the module
 void channel_teardown(void)

--- a/src/nvim/channel.h
+++ b/src/nvim/channel.h
@@ -46,10 +46,8 @@ struct Channel {
   bool callback_scheduled;
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "channel.h.generated.h"
-# include "channel.h.inline.generated.h"
-#endif
+#include "channel.h.generated.h"
+#include "channel.h.inline.generated.h"
 
 static inline bool callback_reader_set(CallbackReader reader)
 {

--- a/src/nvim/charset.c
+++ b/src/nvim/charset.c
@@ -31,9 +31,7 @@
 #include "nvim/types_defs.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "charset.c.generated.h"
-#endif
+#include "charset.c.generated.h"
 
 static bool chartab_initialized = false;
 

--- a/src/nvim/charset.h
+++ b/src/nvim/charset.h
@@ -28,10 +28,8 @@ typedef enum {
   STR2NR_QUOTE = (1 << 4),  ///< Ignore embedded single quotes.
 } ChStr2NrFlags;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "charset.h.generated.h"
-# include "charset.h.inline.generated.h"
-#endif
+#include "charset.h.generated.h"
+#include "charset.h.inline.generated.h"
 
 /// Check if `c` is one of the characters in 'breakat'.
 /// Used very often if 'linebreak' is set

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -81,9 +81,7 @@
 /// Type used by call_user_expand_func
 typedef void *(*user_expand_func_T)(const char *, int, typval_T *);
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "cmdexpand.c.generated.h"
-#endif
+#include "cmdexpand.c.generated.h"
 
 static bool cmd_showtail;  ///< Only show path tail in lists ?
 static bool may_expand_pattern = false;

--- a/src/nvim/cmdexpand.h
+++ b/src/nvim/cmdexpand.h
@@ -45,6 +45,4 @@ enum {
   WILD_FUNC_TRIGGER         = 0x10000,  ///< called from wildtrigger()
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "cmdexpand.h.generated.h"
-#endif
+#include "cmdexpand.h.generated.h"

--- a/src/nvim/cmdhist.c
+++ b/src/nvim/cmdhist.c
@@ -30,9 +30,7 @@
 #include "nvim/types_defs.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "cmdhist.c.generated.h"
-#endif
+#include "cmdhist.c.generated.h"
 
 static histentry_T *(history[HIST_COUNT]) = { NULL, NULL, NULL, NULL, NULL };
 static int hisidx[HIST_COUNT] = { -1, -1, -1, -1, -1 };  ///< lastused entry

--- a/src/nvim/cmdhist.h
+++ b/src/nvim/cmdhist.h
@@ -30,6 +30,4 @@ typedef struct {
   AdditionalData *additional_data;  ///< Additional entries from ShaDa file.
 } histentry_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "cmdhist.h.generated.h"
-#endif
+#include "cmdhist.h.generated.h"

--- a/src/nvim/context.c
+++ b/src/nvim/context.c
@@ -25,9 +25,7 @@
 #include "nvim/option_defs.h"
 #include "nvim/shada.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "context.c.generated.h"
-#endif
+#include "context.c.generated.h"
 
 int kCtxAll = (kCtxRegs | kCtxJumps | kCtxBufs | kCtxGVars | kCtxSFuncs
                | kCtxFuncs);

--- a/src/nvim/context.h
+++ b/src/nvim/context.h
@@ -33,6 +33,4 @@ typedef enum {
 
 extern int kCtxAll;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "context.h.generated.h"
-#endif
+#include "context.h.generated.h"

--- a/src/nvim/cursor.c
+++ b/src/nvim/cursor.c
@@ -27,9 +27,7 @@
 #include "nvim/types_defs.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "cursor.c.generated.h"
-#endif
+#include "cursor.c.generated.h"
 
 /// @return  the screen position of the cursor.
 int getviscol(void)

--- a/src/nvim/cursor.h
+++ b/src/nvim/cursor.h
@@ -3,6 +3,4 @@
 #include "nvim/pos_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "cursor.h.generated.h"
-#endif
+#include "cursor.h.generated.h"

--- a/src/nvim/cursor_shape.c
+++ b/src/nvim/cursor_shape.c
@@ -18,9 +18,7 @@
 #include "nvim/strings.h"
 #include "nvim/ui.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "cursor_shape.c.generated.h"
-#endif
+#include "cursor_shape.c.generated.h"
 
 static const char e_digit_expected[] = N_("E548: Digit expected");
 

--- a/src/nvim/cursor_shape.h
+++ b/src/nvim/cursor_shape.h
@@ -55,6 +55,4 @@ typedef struct {
 
 extern cursorentry_T shape_table[SHAPE_IDX_COUNT];
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "cursor_shape.h.generated.h"
-#endif
+#include "cursor_shape.h.generated.h"

--- a/src/nvim/debugger.c
+++ b/src/nvim/debugger.c
@@ -61,9 +61,7 @@ struct debuggy {
   int dbg_level;                ///< stored nested level for expr
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "debugger.c.generated.h"
-#endif
+#include "debugger.c.generated.h"
 
 /// Debug mode. Repeatedly get Ex commands, until told to continue normal
 /// execution.

--- a/src/nvim/debugger.h
+++ b/src/nvim/debugger.h
@@ -2,6 +2,4 @@
 
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "debugger.h.generated.h"
-#endif
+#include "debugger.h.generated.h"

--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -28,9 +28,7 @@
 #include "nvim/pos_defs.h"
 #include "nvim/sign.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "decoration.c.generated.h"
-#endif
+#include "decoration.c.generated.h"
 
 uint32_t decor_freelist = UINT32_MAX;
 

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -104,10 +104,8 @@ EXTERN DecorState decor_state INIT( = { 0 });
 // associated with a buffer can be freed when the buffer is unloaded.
 EXTERN kvec_t(DecorSignHighlight) decor_items INIT( = KV_INITIAL_VALUE);
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "decoration.h.generated.h"
-# include "decoration.h.inline.generated.h"
-#endif
+#include "decoration.h.generated.h"
+#include "decoration.h.inline.generated.h"
 
 static inline int decor_redraw_col(win_T *wp, int col, int win_col, bool hidden, DecorState *state)
   FUNC_ATTR_ALWAYS_INLINE

--- a/src/nvim/decoration_provider.c
+++ b/src/nvim/decoration_provider.c
@@ -19,9 +19,7 @@
 #include "nvim/move.h"
 #include "nvim/pos_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "decoration_provider.c.generated.h"
-#endif
+#include "decoration_provider.c.generated.h"
 
 static kvec_t(DecorProvider) decor_providers = KV_INITIAL_VALUE;
 

--- a/src/nvim/decoration_provider.h
+++ b/src/nvim/decoration_provider.h
@@ -6,6 +6,4 @@
 #include "nvim/macros_defs.h"
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "decoration_provider.h.generated.h"
-#endif
+#include "decoration_provider.h.generated.h"

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -142,9 +142,7 @@ typedef enum {
   DIFF_NONE,
 } diffstyle_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "diff.c.generated.h"
-#endif
+#include "diff.c.generated.h"
 
 #define FOR_ALL_DIFFBLOCKS_IN_TAB(tp, dp) \
   for ((dp) = (tp)->tp_first_diff; (dp) != NULL; (dp) = (dp)->df_next)

--- a/src/nvim/diff.h
+++ b/src/nvim/diff.h
@@ -14,6 +14,4 @@ EXTERN bool diff_need_scrollbind INIT( = false);
 
 EXTERN bool need_diff_redraw INIT( = false);  ///< need to call diff_redraw()
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "diff.h.generated.h"
-#endif
+#include "diff.h.generated.h"

--- a/src/nvim/digraph.c
+++ b/src/nvim/digraph.c
@@ -53,9 +53,7 @@ static const char e_digraph_argument_must_be_one_character_str[]
 static const char e_digraph_setlist_argument_must_be_list_of_lists_with_two_items[]
   = N_("E1216: digraph_setlist() argument must be a list of lists with two items");
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "digraph.c.generated.h"
-#endif
+#include "digraph.c.generated.h"
 // digraphs added by the user
 static garray_T user_digraphs = { 0, 0, (int)sizeof(digr_T), 10, NULL };
 

--- a/src/nvim/digraph.h
+++ b/src/nvim/digraph.h
@@ -5,6 +5,4 @@
 #include "nvim/garray_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "digraph.h.generated.h"
-#endif
+#include "digraph.h.generated.h"

--- a/src/nvim/drawline.c
+++ b/src/nvim/drawline.c
@@ -130,9 +130,7 @@ typedef struct {
   int *color_cols;           ///< if not NULL, highlight colorcolumn using according columns array
 } winlinevars_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "drawline.c.generated.h"
-#endif
+#include "drawline.c.generated.h"
 
 static char *extra_buf = NULL;
 static size_t extra_buf_size = 0;

--- a/src/nvim/drawline.h
+++ b/src/nvim/drawline.h
@@ -30,6 +30,4 @@ typedef struct {
   linenr_T spv_capcol_lnum;   ///< line number for "cap_col"
 } spellvars_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "drawline.h.generated.h"
-#endif
+#include "drawline.h.generated.h"

--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -128,9 +128,7 @@ typedef enum {
   WC_BOTTOM_RIGHT,
 } WindowCorner;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "drawscreen.c.generated.h"
-#endif
+#include "drawscreen.c.generated.h"
 
 static bool redraw_popupmenu = false;
 static bool msg_grid_invalid = false;

--- a/src/nvim/drawscreen.h
+++ b/src/nvim/drawscreen.h
@@ -35,6 +35,4 @@ EXTERN linenr_T search_hl_has_cursor_lnum INIT( = 0);
 #define W_ENDCOL(wp)   ((wp)->w_wincol + (wp)->w_width)
 #define W_ENDROW(wp)   ((wp)->w_winrow + (wp)->w_height)
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "drawscreen.h.generated.h"
-#endif
+#include "drawscreen.h.generated.h"

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -102,9 +102,7 @@ typedef struct {
   bool nomove;
 } InsertState;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "edit.c.generated.h"
-#endif
+#include "edit.c.generated.h"
 enum {
   BACKSPACE_CHAR = 1,
   BACKSPACE_WORD = 2,

--- a/src/nvim/edit.h
+++ b/src/nvim/edit.h
@@ -34,6 +34,4 @@ enum {
   INSCHAR_COM_LIST = 16,  ///< format comments with list/2nd line indent
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "edit.h.generated.h"
-#endif
+#include "edit.h.generated.h"

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -315,9 +315,7 @@ typedef enum {
   FILTERMAP_FOREACH,
 } filtermap_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval.c.generated.h"
-#endif
+#include "eval.c.generated.h"
 
 static uint64_t last_timer_id = 1;
 static PMap(uint64_t) timers = MAP_INIT;

--- a/src/nvim/eval.h
+++ b/src/nvim/eval.h
@@ -253,6 +253,4 @@ enum {
 /// Passed to an eval() function to enable evaluation.
 EXTERN evalarg_T EVALARG_EVALUATE INIT( = { EVAL_EVALUATE, NULL, NULL, NULL });
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval.h.generated.h"
-#endif
+#include "eval.h.generated.h"

--- a/src/nvim/eval/buffer.c
+++ b/src/nvim/eval/buffer.c
@@ -36,9 +36,7 @@ typedef struct {
   int cob_save_VIsual_active;
 } cob_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/buffer.c.generated.h"
-#endif
+#include "eval/buffer.c.generated.h"
 
 /// Find a buffer by number or exact name.
 buf_T *find_buffer(typval_T *avar)

--- a/src/nvim/eval/buffer.h
+++ b/src/nvim/eval/buffer.h
@@ -4,6 +4,4 @@
 #include "nvim/eval/typval_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/buffer.h.generated.h"
-#endif
+#include "eval/buffer.h.generated.h"

--- a/src/nvim/eval/decode.c
+++ b/src/nvim/eval/decode.c
@@ -51,9 +51,7 @@ typedef kvec_t(ValuesStackItem) ValuesStack;
 /// Vector containing containers, each next container is located inside previous
 typedef kvec_t(ContainerStackItem) ContainerStack;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/decode.c.generated.h"
-#endif
+#include "eval/decode.c.generated.h"
 
 /// Create special dictionary
 ///

--- a/src/nvim/eval/decode.h
+++ b/src/nvim/eval/decode.h
@@ -6,6 +6,4 @@
 #include "nvim/eval/typval_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/decode.h.generated.h"
-#endif
+#include "eval/decode.h.generated.h"

--- a/src/nvim/eval/deprecated.c
+++ b/src/nvim/eval/deprecated.c
@@ -14,9 +14,7 @@
 #include "nvim/message.h"           // for semsg
 #include "nvim/types_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/deprecated.c.generated.h"  // IWYU pragma: keep
-#endif
+#include "eval/deprecated.c.generated.h"  // IWYU pragma: keep
 
 /// "rpcstart()" function (DEPRECATED)
 void f_rpcstart(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)

--- a/src/nvim/eval/deprecated.h
+++ b/src/nvim/eval/deprecated.h
@@ -3,6 +3,4 @@
 #include "nvim/eval/typval_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/deprecated.h.generated.h"
-#endif
+#include "eval/deprecated.h.generated.h"

--- a/src/nvim/eval/encode.c
+++ b/src/nvim/eval/encode.c
@@ -42,9 +42,7 @@ const char *const encode_special_var_names[] = {
   [kSpecialVarNull] = "v:null",
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/encode.c.generated.h"
-#endif
+#include "eval/encode.c.generated.h"
 
 /// Msgpack callback for writing to a Blob
 int encode_blob_write(void *const data, const char *const buf, const size_t len)

--- a/src/nvim/eval/encode.h
+++ b/src/nvim/eval/encode.h
@@ -51,6 +51,4 @@ extern const char *const encode_special_var_names[];
 /// First character that needs to be encoded as surrogate pair
 #define SURROGATE_FIRST_CHAR 0x10000
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/encode.h.generated.h"
-#endif
+#include "eval/encode.h.generated.h"

--- a/src/nvim/eval/executor.c
+++ b/src/nvim/eval/executor.c
@@ -13,9 +13,7 @@
 #include "nvim/types_defs.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/executor.c.generated.h"
-#endif
+#include "eval/executor.c.generated.h"
 
 char *e_list_index_out_of_range_nr
   = N_("E684: List index out of range: %" PRId64);

--- a/src/nvim/eval/executor.h
+++ b/src/nvim/eval/executor.h
@@ -4,6 +4,4 @@
 
 extern char *e_list_index_out_of_range_nr;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/executor.h.generated.h"
-#endif
+#include "eval/executor.h.generated.h"

--- a/src/nvim/eval/fs.c
+++ b/src/nvim/eval/fs.c
@@ -45,9 +45,7 @@
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/fs.c.generated.h"
-#endif
+#include "eval/fs.c.generated.h"
 
 static const char e_error_while_writing_str[] = N_("E80: Error while writing: %s");
 

--- a/src/nvim/eval/fs.h
+++ b/src/nvim/eval/fs.h
@@ -3,6 +3,4 @@
 #include "nvim/eval/typval_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/fs.h.generated.h"
-#endif
+#include "eval/fs.h.generated.h"

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -141,23 +141,21 @@ typedef enum {
   kSomeMatchStrPos,  ///< Data for matchstrpos().
 } SomeMatchType;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/funcs.c.generated.h"
+#include "eval/funcs.c.generated.h"
 
-# ifdef _MSC_VER
+#ifdef _MSC_VER
 // This prevents MSVC from replacing the functions with intrinsics,
 // and causing errors when trying to get their addresses in funcs.generated.h
-#  pragma function(ceil)
-#  pragma function(floor)
-# endif
+# pragma function(ceil)
+# pragma function(floor)
+#endif
 
 PRAGMA_DIAG_PUSH_IGNORE_MISSING_PROTOTYPES
 PRAGMA_DIAG_PUSH_IGNORE_IMPLICIT_FALLTHROUGH
-# include "funcs.generated.h"
+#include "funcs.generated.h"
 
 PRAGMA_DIAG_POP
 PRAGMA_DIAG_POP
-#endif
 
 static const char *e_listblobarg = N_("E899: Argument of %s must be a List or Blob");
 static const char *e_invalwindow = N_("E957: Invalid window number");

--- a/src/nvim/eval/funcs.h
+++ b/src/nvim/eval/funcs.h
@@ -28,6 +28,4 @@ typedef struct {
   EvalFuncData data;  ///< Userdata for function implementation.
 } EvalFuncDef;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/funcs.h.generated.h"
-#endif
+#include "eval/funcs.h.generated.h"

--- a/src/nvim/eval/gc.c
+++ b/src/nvim/eval/gc.c
@@ -2,9 +2,7 @@
 
 #include "nvim/eval/gc.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/gc.c.generated.h"  // IWYU pragma: export
-#endif
+#include "eval/gc.c.generated.h"  // IWYU pragma: export
 
 /// Head of list of all dictionaries
 dict_T *gc_first_dict = NULL;

--- a/src/nvim/eval/gc.h
+++ b/src/nvim/eval/gc.h
@@ -5,6 +5,4 @@
 extern dict_T *gc_first_dict;
 extern list_T *gc_first_list;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/gc.h.generated.h"
-#endif
+#include "eval/gc.h.generated.h"

--- a/src/nvim/eval/typval.c
+++ b/src/nvim/eval/typval.c
@@ -69,9 +69,7 @@ typedef enum {
   kDict2ListItems,   ///< List dictionary contents: [keys, values].
 } DictListType;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/typval.c.generated.h"
-#endif
+#include "eval/typval.c.generated.h"
 
 static const char e_variable_nested_too_deep_for_unlock[]
   = N_("E743: Variable nested too deep for (un)lock");

--- a/src/nvim/eval/typval.h
+++ b/src/nvim/eval/typval.h
@@ -15,9 +15,7 @@
 #include "nvim/message.h"
 #include "nvim/types_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/typval.h.inline.generated.h"
-#endif
+#include "eval/typval.h.inline.generated.h"
 
 // In a hashtab item "hi_key" points to "di_key" in a dictitem.
 // This avoids adding a pointer to the hashtab item.
@@ -448,6 +446,4 @@ EXTERN const size_t kTVCstring INIT( = TV_CSTRING);
 EXTERN const size_t kTVTranslate INIT( = TV_TRANSLATE);
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/typval.h.generated.h"
-#endif
+#include "eval/typval.h.generated.h"

--- a/src/nvim/eval/typval_encode.h
+++ b/src/nvim/eval/typval_encode.h
@@ -12,9 +12,7 @@
 #include "klib/kvec.h"
 #include "nvim/eval/typval_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/typval_encode.h.inline.generated.h"
-#endif
+#include "eval/typval_encode.h.inline.generated.h"
 
 /// Type of the stack entry
 typedef enum {

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -56,9 +56,7 @@
 #include "nvim/ui_defs.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/userfunc.c.generated.h"
-#endif
+#include "eval/userfunc.c.generated.h"
 
 /// structure used as item in "fc_defer"
 typedef struct {

--- a/src/nvim/eval/userfunc.h
+++ b/src/nvim/eval/userfunc.h
@@ -90,6 +90,4 @@ typedef struct {
 #define FUNCARG(fp, j)  ((char **)(fp->uf_args.ga_data))[j]
 #define FUNCLINE(fp, j) ((char **)(fp->uf_lines.ga_data))[j]
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/userfunc.h.generated.h"
-#endif
+#include "eval/userfunc.h.generated.h"

--- a/src/nvim/eval/vars.c
+++ b/src/nvim/eval/vars.c
@@ -48,9 +48,7 @@
 
 typedef int (*ex_unletlock_callback)(lval_T *, char *, exarg_T *, int);
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/vars.c.generated.h"
-#endif
+#include "eval/vars.c.generated.h"
 
 // TODO(ZyX-I): Remove DICT_MAXNEST, make users be non-recursive instead
 

--- a/src/nvim/eval/vars.h
+++ b/src/nvim/eval/vars.h
@@ -8,6 +8,4 @@
 #include "nvim/option_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/vars.h.generated.h"
-#endif
+#include "eval/vars.h.generated.h"

--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -32,9 +32,7 @@
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/window.c.generated.h"
-#endif
+#include "eval/window.c.generated.h"
 
 static const char *e_invalwindow = N_("E957: Invalid window number");
 static const char e_cannot_resize_window_in_another_tab_page[]

--- a/src/nvim/eval/window.h
+++ b/src/nvim/eval/window.h
@@ -26,6 +26,4 @@ typedef struct {
   switchwin_T switchwin;
 } win_execute_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "eval/window.h.generated.h"
-#endif
+#include "eval/window.h.generated.h"

--- a/src/nvim/event/libuv_proc.c
+++ b/src/nvim/event/libuv_proc.c
@@ -14,9 +14,7 @@
 #include "nvim/types_defs.h"
 #include "nvim/ui_client.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/libuv_proc.c.generated.h"
-#endif
+#include "event/libuv_proc.c.generated.h"
 
 /// @returns zero on success, or negative error code
 int libuv_proc_spawn(LibuvProc *uvproc)

--- a/src/nvim/event/libuv_proc.h
+++ b/src/nvim/event/libuv_proc.h
@@ -11,6 +11,4 @@ typedef struct {
   uv_stdio_container_t uvstdio[4];
 } LibuvProc;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/libuv_proc.h.generated.h"
-#endif
+#include "event/libuv_proc.h.generated.h"

--- a/src/nvim/event/loop.c
+++ b/src/nvim/event/loop.c
@@ -10,9 +10,7 @@
 #include "nvim/os/time.h"
 #include "nvim/types_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/loop.c.generated.h"
-#endif
+#include "event/loop.c.generated.h"
 
 void loop_init(Loop *loop, void *data)
 {

--- a/src/nvim/event/loop.h
+++ b/src/nvim/event/loop.h
@@ -37,6 +37,4 @@ struct loop {
   bool closing;  ///< Set to true if loop_close() has been called
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/loop.h.generated.h"
-#endif
+#include "event/loop.h.generated.h"

--- a/src/nvim/event/multiqueue.c
+++ b/src/nvim/event/multiqueue.c
@@ -78,9 +78,7 @@ typedef struct {
   int refcount;
 } MulticastEvent;  ///< Event present on multiple queues.
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/multiqueue.c.generated.h"
-#endif
+#include "event/multiqueue.c.generated.h"
 
 static Event NILEVENT = { .handler = NULL, .argv = { NULL } };
 

--- a/src/nvim/event/multiqueue.h
+++ b/src/nvim/event/multiqueue.h
@@ -5,9 +5,7 @@
 #include "nvim/event/defs.h"  // IWYU pragma: keep
 #include "nvim/os/time.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/multiqueue.h.generated.h"
-#endif
+#include "event/multiqueue.h.generated.h"
 
 #define multiqueue_put(q, h, ...) \
   do { \

--- a/src/nvim/event/proc.c
+++ b/src/nvim/event/proc.c
@@ -23,9 +23,7 @@
 #include "nvim/os/time.h"
 #include "nvim/ui_client.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/proc.c.generated.h"
-#endif
+#include "event/proc.c.generated.h"
 
 // Time for a process to exit cleanly before we send KILL.
 // For PTY processes SIGTERM is sent first (in case SIGHUP was not enough).

--- a/src/nvim/event/proc.h
+++ b/src/nvim/event/proc.h
@@ -45,6 +45,4 @@ static inline bool proc_is_stopped(Proc *proc)
   return exited || (proc->stopped_time != 0);
 }
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/proc.h.generated.h"
-#endif
+#include "event/proc.h.generated.h"

--- a/src/nvim/event/rstream.c
+++ b/src/nvim/event/rstream.c
@@ -13,9 +13,7 @@
 #include "nvim/os/os_defs.h"
 #include "nvim/types_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/rstream.c.generated.h"
-#endif
+#include "event/rstream.c.generated.h"
 
 void rstream_init_fd(Loop *loop, RStream *stream, int fd)
   FUNC_ATTR_NONNULL_ARG(1, 2)

--- a/src/nvim/event/rstream.h
+++ b/src/nvim/event/rstream.h
@@ -3,6 +3,4 @@
 #include "nvim/event/defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/rstream.h.generated.h"
-#endif
+#include "event/rstream.h.generated.h"

--- a/src/nvim/event/signal.c
+++ b/src/nvim/event/signal.c
@@ -7,9 +7,7 @@
 #include "nvim/event/signal.h"
 #include "nvim/types_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/signal.c.generated.h"
-#endif
+#include "event/signal.c.generated.h"
 
 void signal_watcher_init(Loop *loop, SignalWatcher *watcher, void *data)
   FUNC_ATTR_NONNULL_ARG(1) FUNC_ATTR_NONNULL_ARG(2)

--- a/src/nvim/event/signal.h
+++ b/src/nvim/event/signal.h
@@ -3,6 +3,4 @@
 #include "nvim/event/defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/signal.h.generated.h"
-#endif
+#include "event/signal.h.generated.h"

--- a/src/nvim/event/socket.c
+++ b/src/nvim/event/socket.c
@@ -21,9 +21,7 @@
 #include "nvim/path.h"
 #include "nvim/types_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/socket.c.generated.h"
-#endif
+#include "event/socket.c.generated.h"
 
 int socket_watcher_init(Loop *loop, SocketWatcher *watcher, const char *endpoint)
   FUNC_ATTR_NONNULL_ALL

--- a/src/nvim/event/socket.h
+++ b/src/nvim/event/socket.h
@@ -3,6 +3,4 @@
 #include "nvim/event/defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/socket.h.generated.h"
-#endif
+#include "event/socket.h.generated.h"

--- a/src/nvim/event/stream.c
+++ b/src/nvim/event/stream.c
@@ -14,9 +14,7 @@
 # include "nvim/os/os_win_console.h"
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/stream.c.generated.h"
-#endif
+#include "event/stream.c.generated.h"
 
 // For compatibility with libuv < 1.19.0 (tested on 1.18.0)
 #if UV_VERSION_MINOR < 19

--- a/src/nvim/event/stream.h
+++ b/src/nvim/event/stream.h
@@ -3,6 +3,4 @@
 #include "nvim/event/defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/stream.h.generated.h"
-#endif
+#include "event/stream.h.generated.h"

--- a/src/nvim/event/time.c
+++ b/src/nvim/event/time.c
@@ -8,9 +8,7 @@
 #include "nvim/event/time.h"
 #include "nvim/types_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/time.c.generated.h"
-#endif
+#include "event/time.c.generated.h"
 
 void time_watcher_init(Loop *loop, TimeWatcher *watcher, void *data)
   FUNC_ATTR_NONNULL_ARG(1) FUNC_ATTR_NONNULL_ARG(2)

--- a/src/nvim/event/time.h
+++ b/src/nvim/event/time.h
@@ -3,6 +3,4 @@
 #include "nvim/event/defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/time.h.generated.h"
-#endif
+#include "event/time.h.generated.h"

--- a/src/nvim/event/wstream.c
+++ b/src/nvim/event/wstream.c
@@ -18,9 +18,7 @@ typedef struct {
   uv_write_t uv_req;
 } WRequest;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/wstream.c.generated.h"
-#endif
+#include "event/wstream.c.generated.h"
 
 void wstream_init_fd(Loop *loop, Stream *stream, int fd, size_t maxmem)
   FUNC_ATTR_NONNULL_ARG(1) FUNC_ATTR_NONNULL_ARG(2)

--- a/src/nvim/event/wstream.h
+++ b/src/nvim/event/wstream.h
@@ -3,6 +3,4 @@
 #include "nvim/event/defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "event/wstream.h.generated.h"
-#endif
+#include "event/wstream.h.generated.h"

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -133,9 +133,7 @@ typedef struct {
   linenr_T lines_needed;  // lines needed in the preview window
 } PreviewLines;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ex_cmds.c.generated.h"
-#endif
+#include "ex_cmds.c.generated.h"
 
 static const char e_non_numeric_argument_to_z[]
   = N_("E144: Non-numeric argument to :z");

--- a/src/nvim/ex_cmds.h
+++ b/src/nvim/ex_cmds.h
@@ -20,6 +20,4 @@ enum {
   ECMD_ONE   = 1,   ///< use first line
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ex_cmds.h.generated.h"
-#endif
+#include "ex_cmds.h.generated.h"

--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -49,9 +49,7 @@
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ex_cmds2.c.generated.h"
-#endif
+#include "ex_cmds2.c.generated.h"
 
 static const char e_compiler_not_supported_str[]
   = N_("E666: Compiler not supported: %s");

--- a/src/nvim/ex_cmds2.h
+++ b/src/nvim/ex_cmds2.h
@@ -12,6 +12,4 @@ enum {
   CCGD_EXCMD   = 16,  ///< may suggest using !
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ex_cmds2.h.generated.h"
-#endif
+#include "ex_cmds2.h.generated.h"

--- a/src/nvim/ex_cmds_defs.h
+++ b/src/nvim/ex_cmds_defs.h
@@ -8,9 +8,7 @@
 #include "nvim/os/time_defs.h"
 #include "nvim/regexp_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ex_cmds_enum.generated.h"
-#endif
+#include "ex_cmds_enum.generated.h"
 
 // When adding an Ex command:
 // 1. Add an entry to the table in src/nvim/ex_cmds.lua.  Keep it sorted on the

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -168,14 +168,10 @@ struct dbg_stuff {
   except_T *current_exception;
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ex_docmd.c.generated.h"
-#endif
+#include "ex_docmd.c.generated.h"
 
 // Declare cmdnames[].
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ex_cmds_defs.generated.h"
-#endif
+#include "ex_cmds_defs.generated.h"
 
 static char dollar_command[2] = { '$', 0 };
 

--- a/src/nvim/ex_docmd.h
+++ b/src/nvim/ex_docmd.h
@@ -44,6 +44,4 @@ typedef struct {
   tasave_T tabuf;
 } save_state_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ex_docmd.h.generated.h"
-#endif
+#include "ex_docmd.h.generated.h"

--- a/src/nvim/ex_eval.c
+++ b/src/nvim/ex_eval.c
@@ -33,9 +33,7 @@
 #include "nvim/strings.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ex_eval.c.generated.h"
-#endif
+#include "ex_eval.c.generated.h"
 
 static const char e_multiple_else[] = N_("E583: Multiple :else");
 static const char e_multiple_finally[] = N_("E607: Multiple :finally");

--- a/src/nvim/ex_eval.h
+++ b/src/nvim/ex_eval.h
@@ -3,6 +3,4 @@
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: keep
 #include "nvim/ex_eval_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ex_eval.h.generated.h"
-#endif
+#include "ex_eval.h.generated.h"

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -217,9 +217,7 @@ static bool getln_interrupted_highlight = false;
 
 static int cedit_key = -1;  ///< key value of 'cedit' option
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ex_getln.c.generated.h"
-#endif
+#include "ex_getln.c.generated.h"
 
 static handle_T cmdpreview_bufnr = 0;
 static int cmdpreview_ns = 0;

--- a/src/nvim/ex_getln.h
+++ b/src/nvim/ex_getln.h
@@ -15,6 +15,4 @@ enum {
   VSE_BUFFER = 2,  ///< escape for a ":buffer" command
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ex_getln.h.generated.h"
-#endif
+#include "ex_getln.h.generated.h"

--- a/src/nvim/ex_session.c
+++ b/src/nvim/ex_session.c
@@ -49,9 +49,7 @@
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ex_session.c.generated.h"
-#endif
+#include "ex_session.c.generated.h"
 
 /// Whether ":lcd" or ":tcd" was produced for a session.
 static int did_lcd;

--- a/src/nvim/ex_session.h
+++ b/src/nvim/ex_session.h
@@ -4,6 +4,4 @@
 
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ex_session.h.generated.h"
-#endif
+#include "ex_session.h.generated.h"

--- a/src/nvim/extmark.c
+++ b/src/nvim/extmark.c
@@ -45,9 +45,7 @@
 #include "nvim/undo.h"
 #include "nvim/undo_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "extmark.c.generated.h"
-#endif
+#include "extmark.c.generated.h"
 
 /// Create or update an extmark
 ///

--- a/src/nvim/extmark.h
+++ b/src/nvim/extmark.h
@@ -77,6 +77,4 @@ struct undo_object {
   } data;
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "extmark.h.generated.h"
-#endif
+#include "extmark.h.generated.h"

--- a/src/nvim/file_search.c
+++ b/src/nvim/file_search.c
@@ -186,9 +186,7 @@ typedef struct {
 
 // locally needed functions
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "file_search.c.generated.h"
-#endif
+#include "file_search.c.generated.h"
 
 static const char e_path_too_long_for_completion[]
   = N_("E854: Path too long for completion");

--- a/src/nvim/file_search.h
+++ b/src/nvim/file_search.h
@@ -24,6 +24,4 @@ enum {
   FNAME_UNESC = 32,  ///< remove backslashes used for escaping
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "file_search.h.generated.h"
-#endif
+#include "file_search.h.generated.h"

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -92,9 +92,7 @@
 # define UV_FS_COPYFILE_FICLONE 0
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "fileio.c.generated.h"
-#endif
+#include "fileio.c.generated.h"
 
 static const char *e_auchangedbuf = N_("E812: Autocommands changed buffer or buffer name");
 

--- a/src/nvim/fileio.h
+++ b/src/nvim/fileio.h
@@ -53,6 +53,4 @@ enum {
   ICONV_MULT = 8,
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "fileio.h.generated.h"
-#endif
+#include "fileio.h.generated.h"

--- a/src/nvim/fold.c
+++ b/src/nvim/fold.c
@@ -106,9 +106,7 @@ typedef void (*LevelGetter)(fline_T *);
 
 // static functions {{{2
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "fold.c.generated.h"
-#endif
+#include "fold.c.generated.h"
 static const char *e_nofold = N_("E490: No fold found");
 
 // While updating the folds lines between invalid_top and invalid_bot have an

--- a/src/nvim/fold.h
+++ b/src/nvim/fold.h
@@ -12,6 +12,4 @@
 
 EXTERN int disable_fold_update INIT( = 0);
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "fold.h.generated.h"
-#endif
+#include "fold.h.generated.h"

--- a/src/nvim/fuzzy.c
+++ b/src/nvim/fuzzy.c
@@ -66,9 +66,7 @@ typedef struct {
 
 typedef struct match_struct match_struct;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "fuzzy.c.generated.h"
-#endif
+#include "fuzzy.c.generated.h"
 
 /// fuzzy_match()
 ///

--- a/src/nvim/fuzzy.h
+++ b/src/nvim/fuzzy.h
@@ -20,6 +20,4 @@ typedef struct {
   int score;
 } fuzmatch_str_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "fuzzy.h.generated.h"
-#endif
+#include "fuzzy.h.generated.h"

--- a/src/nvim/garray.c
+++ b/src/nvim/garray.c
@@ -12,9 +12,7 @@
 #include "nvim/path.h"
 #include "nvim/strings.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "garray.c.generated.h"  // IWYU pragma: keep
-#endif
+#include "garray.c.generated.h"  // IWYU pragma: keep
 
 /// Clear an allocated growing array.
 void ga_clear(garray_T *gap)

--- a/src/nvim/garray.h
+++ b/src/nvim/garray.h
@@ -18,9 +18,7 @@
 #define GA_APPEND_VIA_PTR(item_type, gap) \
   ga_append_via_ptr(gap, sizeof(item_type))
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "garray.h.generated.h"
-#endif
+#include "garray.h.generated.h"
 
 /// Deep free a garray of specific type using a custom free function.
 /// Items in the array as well as the array itself are freed.

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -160,9 +160,7 @@ enum {
   KEYLEN_PART_MAP = -2,  ///< keylen value for incomplete mapping
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "getchar.c.generated.h"
-#endif
+#include "getchar.c.generated.h"
 
 static const char e_recursive_mapping[] = N_("E223: Recursive mapping");
 static const char e_cmd_mapping_must_end_with_cr[]

--- a/src/nvim/getchar.h
+++ b/src/nvim/getchar.h
@@ -19,6 +19,4 @@ enum { NSCRIPT = 15, };  ///< Maximum number of streams to read script from
 
 EXTERN bool test_disable_char_avail INIT( = false);
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "getchar.h.generated.h"
-#endif
+#include "getchar.h.generated.h"

--- a/src/nvim/grid.c
+++ b/src/nvim/grid.c
@@ -36,9 +36,7 @@
 #include "nvim/ui.h"
 #include "nvim/ui_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "grid.c.generated.h"
-#endif
+#include "grid.c.generated.h"
 
 // temporary buffer for rendering a single screenline, so it can be
 // compared with previous contents to calculate smallest delta.

--- a/src/nvim/grid.h
+++ b/src/nvim/grid.h
@@ -45,6 +45,4 @@ enum {
 # define schar_from_ascii(x) ((schar_T)(x))
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "grid.h.generated.h"
-#endif
+#include "grid.h.generated.h"

--- a/src/nvim/hashtab.c
+++ b/src/nvim/hashtab.c
@@ -34,9 +34,7 @@
 // Magic value for algorithm that walks through the array.
 #define PERTURB_SHIFT 5
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "hashtab.c.generated.h"
-#endif
+#include "hashtab.c.generated.h"
 
 char hash_removed;
 

--- a/src/nvim/hashtab.h
+++ b/src/nvim/hashtab.h
@@ -33,6 +33,4 @@ extern char hash_removed;
     } \
   } while (0)
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "hashtab.h.generated.h"
-#endif
+#include "hashtab.h.generated.h"

--- a/src/nvim/help.c
+++ b/src/nvim/help.c
@@ -48,9 +48,7 @@
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "help.c.generated.h"
-#endif
+#include "help.c.generated.h"
 
 /// ":help": open a read-only window on a help file
 void ex_help(exarg_T *eap)

--- a/src/nvim/help.h
+++ b/src/nvim/help.h
@@ -2,6 +2,4 @@
 
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "help.h.generated.h"
-#endif
+#include "help.h.generated.h"

--- a/src/nvim/highlight.c
+++ b/src/nvim/highlight.c
@@ -32,9 +32,7 @@
 #include "nvim/ui.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "highlight.c.generated.h"
-#endif
+#include "highlight.c.generated.h"
 
 static bool hlstate_active = false;
 

--- a/src/nvim/highlight.h
+++ b/src/nvim/highlight.h
@@ -106,9 +106,7 @@ EXTERN int *hl_attr_active INIT( = highlight_attr);
 // Enums need a typecast to be used as array index.
 #define HL_ATTR(n)      hl_attr_active[(int)(n)]
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "highlight.h.generated.h"
-#endif
+#include "highlight.h.generated.h"
 
 static inline int win_hl_attr(win_T *wp, int hlf)
 {

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -123,9 +123,7 @@ enum {
   kColorIdxBg = -4,
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "highlight_group.c.generated.h"
-#endif
+#include "highlight_group.c.generated.h"
 
 static const char e_highlight_group_name_not_found_str[]
   = N_("E411: Highlight group not found: %s");

--- a/src/nvim/highlight_group.h
+++ b/src/nvim/highlight_group.h
@@ -14,6 +14,4 @@ typedef struct {
 } color_name_table_T;
 extern color_name_table_T color_name_table[708];
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "highlight_group.h.generated.h"
-#endif
+#include "highlight_group.h.generated.h"

--- a/src/nvim/indent.c
+++ b/src/nvim/indent.c
@@ -49,9 +49,7 @@
 #include "nvim/undo.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "indent.c.generated.h"
-#endif
+#include "indent.c.generated.h"
 
 /// Set the integer values corresponding to the string setting of 'vartabstop'.
 /// "array" will be set, caller must free it if needed.

--- a/src/nvim/indent.h
+++ b/src/nvim/indent.h
@@ -17,6 +17,4 @@ enum {
 
 typedef int (*Indenter)(void);
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "indent.h.generated.h"
-#endif
+#include "indent.h.generated.h"

--- a/src/nvim/indent_c.c
+++ b/src/nvim/indent_c.c
@@ -36,9 +36,7 @@ typedef struct {
   lpos_T lpos;
 } cpp_baseclass_cache_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "indent_c.c.generated.h"
-#endif
+#include "indent_c.c.generated.h"
 // Find the start of a comment, not knowing if we are in a comment right now.
 // Search starts at w_cursor.lnum and goes backwards.
 // Return NULL when not inside a comment.

--- a/src/nvim/indent_c.h
+++ b/src/nvim/indent_c.h
@@ -4,6 +4,4 @@
 #include "nvim/pos_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "indent_c.h.generated.h"
-#endif
+#include "indent_c.h.generated.h"

--- a/src/nvim/input.c
+++ b/src/nvim/input.c
@@ -23,9 +23,7 @@
 #include "nvim/ui.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "input.c.generated.h"  // IWYU pragma: export
-#endif
+#include "input.c.generated.h"  // IWYU pragma: export
 
 /// Ask for a reply from the user, a 'y' or a 'n', with prompt "str" (which
 /// should have been translated already).

--- a/src/nvim/input.h
+++ b/src/nvim/input.h
@@ -2,6 +2,4 @@
 
 #include "nvim/event/defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "input.h.generated.h"
-#endif
+#include "input.h.generated.h"

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -196,9 +196,7 @@ typedef struct {
   Callback *func_cb;      ///< callback of function in 'cpt' option
 } ins_compl_next_state_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "insexpand.c.generated.h"
-#endif
+#include "insexpand.c.generated.h"
 
 /// values for cp_flags
 typedef enum {

--- a/src/nvim/insexpand.h
+++ b/src/nvim/insexpand.h
@@ -5,9 +5,7 @@
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 #include "nvim/vim_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "insexpand.h.generated.h"
-#endif
+#include "insexpand.h.generated.h"
 
 /// Array indexes used for cp_text[].
 typedef enum {

--- a/src/nvim/keycodes.c
+++ b/src/nvim/keycodes.c
@@ -24,10 +24,8 @@
 #include "nvim/option_vars.h"
 #include "nvim/strings.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "keycode_names.generated.h"
-# include "keycodes.c.generated.h"
-#endif
+#include "keycode_names.generated.h"
+#include "keycodes.c.generated.h"
 
 // Some useful tables.
 

--- a/src/nvim/keycodes.h
+++ b/src/nvim/keycodes.h
@@ -501,6 +501,4 @@ enum {
   FSK_SIMPLIFY   = 0x08,  ///< simplify <C-H>, etc.
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "keycodes.h.generated.h"
-#endif
+#include "keycodes.h.generated.h"

--- a/src/nvim/lib/queue_defs.h
+++ b/src/nvim/lib/queue_defs.h
@@ -26,9 +26,7 @@ typedef struct queue {
   struct queue *prev;
 } QUEUE;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lib/queue_defs.h.inline.generated.h"
-#endif
+#include "lib/queue_defs.h.inline.generated.h"
 
 // Public macros.
 #define QUEUE_DATA(ptr, type, field) \

--- a/src/nvim/linematch.c
+++ b/src/nvim/linematch.c
@@ -24,9 +24,7 @@ struct diffcmppath_S {
   size_t df_optimal_choice;
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "linematch.c.generated.h"
-#endif
+#include "linematch.c.generated.h"
 
 static size_t line_len(const mmfile_t *m)
 {

--- a/src/nvim/linematch.h
+++ b/src/nvim/linematch.h
@@ -5,6 +5,4 @@
 #include "nvim/pos_defs.h"  // IWYU pragma: keep
 #include "xdiff/xdiff.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "linematch.h.generated.h"
-#endif
+#include "linematch.h.generated.h"

--- a/src/nvim/log.c
+++ b/src/nvim/log.c
@@ -37,9 +37,7 @@ static char log_file_path[MAXPATHL + 1] = { 0 };
 static bool did_log_init = false;
 static uv_mutex_t mutex;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "log.c.generated.h"
-#endif
+#include "log.c.generated.h"
 
 #ifdef HAVE_EXECINFO_BACKTRACE
 # include <execinfo.h>

--- a/src/nvim/log.h
+++ b/src/nvim/log.h
@@ -51,6 +51,4 @@
 # define LOG_CALLSTACK_TO_FILE(fp) log_callstack_to_file(fp, __func__, __LINE__)
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "log.h.generated.h"
-#endif
+#include "log.h.generated.h"

--- a/src/nvim/lua/api_wrappers.c
+++ b/src/nvim/lua/api_wrappers.c
@@ -14,6 +14,4 @@
 #include "nvim/lua/executor.h"  // IWYU pragma: keep
 #include "nvim/memory.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lua_api_c_bindings.generated.h"  // IWYU pragma: keep
-#endif
+#include "lua_api_c_bindings.generated.h"  // IWYU pragma: keep

--- a/src/nvim/lua/base64.c
+++ b/src/nvim/lua/base64.c
@@ -7,9 +7,7 @@
 #include "nvim/lua/base64.h"
 #include "nvim/memory.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lua/base64.c.generated.h"
-#endif
+#include "lua/base64.c.generated.h"
 
 static int nlua_base64_encode(lua_State *L)
 {

--- a/src/nvim/lua/base64.h
+++ b/src/nvim/lua/base64.h
@@ -2,6 +2,4 @@
 
 #include <lua.h>  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lua/base64.h.generated.h"
-#endif
+#include "lua/base64.h.generated.h"

--- a/src/nvim/lua/converter.c
+++ b/src/nvim/lua/converter.c
@@ -39,9 +39,7 @@ typedef struct {
   bool has_type_key;  ///< True if type key is present.
 } LuaTableProps;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lua/converter.c.generated.h"
-#endif
+#include "lua/converter.c.generated.h"
 
 #define TYPE_IDX_VALUE true
 #define VAL_IDX_VALUE false

--- a/src/nvim/lua/converter.h
+++ b/src/nvim/lua/converter.h
@@ -19,6 +19,4 @@ enum {
   kNluaPushFreeRefs = 0x02,  ///< Free luarefs to elide an api_luarefs_free_*() later
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lua/converter.h.generated.h"
-#endif
+#include "lua/converter.h.generated.h"

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -95,10 +95,8 @@ typedef struct {
   size_t size;
 } ModuleDef;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lua/executor.c.generated.h"
-# include "lua/vim_module.generated.h"
-#endif
+#include "lua/executor.c.generated.h"
+#include "lua/vim_module.generated.h"
 
 #define PUSH_ALL_TYPVALS(lstate, args, argcount, special) \
   for (int i = 0; i < argcount; i++) { \

--- a/src/nvim/lua/executor.h
+++ b/src/nvim/lua/executor.h
@@ -50,9 +50,7 @@ enum { CB_MAX_ERROR = 3, };
 /// To use with kRetNilBool for quick truthiness check
 #define LUARET_TRUTHY(res) ((res).type == kObjectTypeBoolean && (res).data.boolean == true)
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lua/executor.h.generated.h"
-#endif
+#include "lua/executor.h.generated.h"
 
 EXTERN nlua_ref_state_t *nlua_global_refs INIT( = NULL);
 EXTERN bool nlua_disable_preload INIT( = false);

--- a/src/nvim/lua/secure.c
+++ b/src/nvim/lua/secure.c
@@ -12,9 +12,7 @@
 #include "nvim/memory.h"
 #include "nvim/message.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lua/secure.c.generated.h"
-#endif
+#include "lua/secure.c.generated.h"
 
 char *nlua_read_secure(const char *path)
 {

--- a/src/nvim/lua/secure.h
+++ b/src/nvim/lua/secure.h
@@ -2,6 +2,4 @@
 
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lua/secure.h.generated.h"
-#endif
+#include "lua/secure.h.generated.h"

--- a/src/nvim/lua/spell.c
+++ b/src/nvim/lua/spell.c
@@ -15,9 +15,7 @@
 #include "nvim/message.h"
 #include "nvim/spell.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lua/spell.c.generated.h"  // IWYU pragma: keep
-#endif
+#include "lua/spell.c.generated.h"  // IWYU pragma: keep
 
 int nlua_spell_check(lua_State *lstate)
   FUNC_ATTR_NONNULL_ALL

--- a/src/nvim/lua/spell.h
+++ b/src/nvim/lua/spell.h
@@ -2,6 +2,4 @@
 
 #include <lua.h>  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lua/spell.h.generated.h"
-#endif
+#include "lua/spell.h.generated.h"

--- a/src/nvim/lua/stdlib.c
+++ b/src/nvim/lua/stdlib.c
@@ -47,9 +47,7 @@
 #include "nvim/types_defs.h"
 #include "nvim/window.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lua/stdlib.c.generated.h"
-#endif
+#include "lua/stdlib.c.generated.h"
 
 static int regex_match(lua_State *lstate, regprog_T **prog, char *str)
 {

--- a/src/nvim/lua/stdlib.h
+++ b/src/nvim/lua/stdlib.h
@@ -3,6 +3,4 @@
 #include <lua.h>  // IWYU pragma: keep
 #include <stdbool.h>
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lua/stdlib.h.generated.h"
-#endif
+#include "lua/stdlib.h.generated.h"

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -60,9 +60,7 @@ typedef struct {
   uint64_t timeout_threshold_ns;
 } TSLuaParserCallbackPayload;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lua/treesitter.c.generated.h"
-#endif
+#include "lua/treesitter.c.generated.h"
 
 static PMap(cstr_t) langs = MAP_INIT;
 

--- a/src/nvim/lua/treesitter.h
+++ b/src/nvim/lua/treesitter.h
@@ -5,8 +5,6 @@
 
 #include "nvim/macros_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lua/treesitter.h.generated.h"
-#endif
+#include "lua/treesitter.h.generated.h"
 
 EXTERN uint64_t tslua_query_parse_count INIT( = 0);

--- a/src/nvim/lua/xdiff.c
+++ b/src/nvim/lua/xdiff.c
@@ -37,9 +37,7 @@ typedef struct {
   bool iwhite;
 } hunkpriv_t;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lua/xdiff.c.generated.h"
-#endif
+#include "lua/xdiff.c.generated.h"
 
 static void lua_pushhunk(lua_State *lstate, long start_a, long count_a, long start_b, long count_b)
 {

--- a/src/nvim/lua/xdiff.h
+++ b/src/nvim/lua/xdiff.h
@@ -2,6 +2,4 @@
 
 #include <lua.h>  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "lua/xdiff.h.generated.h"
-#endif
+#include "lua/xdiff.h.generated.h"

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -135,9 +135,7 @@ enum {
   EDIT_QF = 4,     // start in quickfix mode
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "main.c.generated.h"
-#endif
+#include "main.c.generated.h"
 
 Loop main_loop;
 

--- a/src/nvim/main.h
+++ b/src/nvim/main.h
@@ -52,6 +52,4 @@ typedef struct {
 # define __ubsan_default_options vim__ubsan_default_options
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "main.h.generated.h"
-#endif
+#include "main.h.generated.h"

--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -117,9 +117,7 @@ typedef struct map_arguments MapArguments;
 #define MAP_ARGUMENTS_INIT { false, false, false, false, false, false, false, false, \
                              { 0 }, 0, { 0 }, 0, NULL, 0, LUA_NOREF, false, NULL, 0, NULL }
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "mapping.c.generated.h"
-#endif
+#include "mapping.c.generated.h"
 
 static const char e_global_abbreviation_already_exists_for_str[]
   = N_("E224: Global abbreviation already exists for %s");

--- a/src/nvim/mapping.h
+++ b/src/nvim/mapping.h
@@ -13,9 +13,7 @@
 #include "nvim/regexp_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "mapping.h.generated.h"
-#endif
+#include "mapping.h.generated.h"
 
 /// Used for the first argument of do_map()
 enum {

--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -55,9 +55,7 @@
 // There are marks 'A - 'Z (set by user) and '0 to '9 (set when writing
 // shada).
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "mark.c.generated.h"
-#endif
+#include "mark.c.generated.h"
 
 // Set named mark "c" at current cursor position.
 // Returns OK on success, FAIL if bad name given.

--- a/src/nvim/mark.h
+++ b/src/nvim/mark.h
@@ -9,10 +9,8 @@
 #include "nvim/mark_defs.h"  // IWYU pragma: keep
 #include "nvim/os/time.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "mark.h.generated.h"
-# include "mark.h.inline.generated.h"
-#endif
+#include "mark.h.generated.h"
+#include "mark.h.inline.generated.h"
 
 /// Convert mark name to the offset
 static inline int mark_global_index(const char name)

--- a/src/nvim/mark_defs.h
+++ b/src/nvim/mark_defs.h
@@ -7,9 +7,7 @@
 #include "nvim/pos_defs.h"
 #include "nvim/types_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "mark_defs.h.inline.generated.h"
-#endif
+#include "mark_defs.h.inline.generated.h"
 
 // marks: positions in a file
 // (a normal mark is a lnum/col pair, the same as a file position)

--- a/src/nvim/marktree.c
+++ b/src/nvim/marktree.c
@@ -118,9 +118,7 @@ typedef struct {
 } Damage;
 typedef kvec_withinit_t(Damage, 8) DamageList;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "marktree.c.generated.h"
-#endif
+#include "marktree.c.generated.h"
 
 #define mt_generic_cmp(a, b) (((b) < (a)) - ((a) < (b)))
 static int key_cmp(MTKey a, MTKey b)

--- a/src/nvim/marktree.h
+++ b/src/nvim/marktree.h
@@ -136,6 +136,4 @@ static inline DecorVirtText *mt_decor_virt(MTKey mark)
   return (mark.flags & MT_FLAG_DECOR_EXT) ? mark.decor_data.ext.vt : NULL;
 }
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "marktree.h.generated.h"
-#endif
+#include "marktree.h.generated.h"

--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -37,9 +37,7 @@
 #include "nvim/types_defs.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "match.c.generated.h"
-#endif
+#include "match.c.generated.h"
 
 static const char *e_invalwindow = N_("E957: Invalid window number");
 

--- a/src/nvim/match.h
+++ b/src/nvim/match.h
@@ -5,6 +5,4 @@
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "match.h.generated.h"
-#endif
+#include "match.h.generated.h"

--- a/src/nvim/math.c
+++ b/src/nvim/math.c
@@ -12,9 +12,7 @@
 #include "nvim/math.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "math.c.generated.h"
-#endif
+#include "math.c.generated.h"
 
 int xfpclassify(double d)
   FUNC_ATTR_CONST

--- a/src/nvim/math.h
+++ b/src/nvim/math.h
@@ -9,6 +9,4 @@ static inline bool is_power_of_two(uint64_t x)
   return x != 0 && ((x & (x - 1)) == 0);
 }
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "math.h.generated.h"
-#endif
+#include "math.h.generated.h"

--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -83,9 +83,7 @@ struct interval {
 };
 
 // uncrustify:off
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "mbyte.c.generated.h"
-#endif
+#include "mbyte.c.generated.h"
 // uncrustify:on
 
 static const char e_list_item_nr_is_not_list[]

--- a/src/nvim/mbyte.h
+++ b/src/nvim/mbyte.h
@@ -14,10 +14,8 @@
 
 #define GRAPHEME_STATE_INIT 0
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "mbyte.h.generated.h"
-# include "mbyte.h.inline.generated.h"
-#endif
+#include "mbyte.h.generated.h"
+#include "mbyte.h.inline.generated.h"
 
 enum {
   kInvalidByteCells = 4,

--- a/src/nvim/memfile.c
+++ b/src/nvim/memfile.c
@@ -67,9 +67,7 @@
 
 #define MEMFILE_PAGE_SIZE 4096       /// default page size
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "memfile.c.generated.h"
-#endif
+#include "memfile.c.generated.h"
 
 static const char e_block_was_not_locked[] = N_("E293: Block was not locked");
 

--- a/src/nvim/memfile.h
+++ b/src/nvim/memfile.h
@@ -20,6 +20,4 @@ enum {
   MAX_SWAP_PAGE_SIZE = 50000,
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "memfile.h.generated.h"
-#endif
+#include "memfile.h.generated.h"

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -255,9 +255,7 @@ typedef enum {
   SEA_CHOICE_ABORT = 6,
 } sea_choice_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "memline.c.generated.h"
-#endif
+#include "memline.c.generated.h"
 
 static const char e_ml_get_invalid_lnum_nr[]
   = N_("E315: ml_get: Invalid lnum: %" PRId64);

--- a/src/nvim/memline.h
+++ b/src/nvim/memline.h
@@ -6,9 +6,7 @@
 #include "nvim/pos_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "memline.h.generated.h"
-#endif
+#include "memline.h.generated.h"
 
 /// LINEEMPTY() - return true if the line is empty
 #define LINEEMPTY(p) (*ml_get(p) == NUL)

--- a/src/nvim/memory.c
+++ b/src/nvim/memory.c
@@ -54,9 +54,7 @@ MemCalloc mem_calloc = &calloc;
 MemRealloc mem_realloc = &realloc;
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "memory.c.generated.h"
-#endif
+#include "memory.c.generated.h"
 
 #ifdef EXITFREE
 bool entered_free_all_mem = false;

--- a/src/nvim/memory.h
+++ b/src/nvim/memory.h
@@ -50,9 +50,7 @@ EXTERN size_t arena_alloc_count INIT( = 0);
   ((v).capacity = (s), \
    (v).items = (void *)arena_alloc(a, sizeof((v).items[0]) * (v).capacity, true))
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "memory.h.generated.h"
-#endif
+#include "memory.h.generated.h"
 
 #define XFREE_CLEAR(ptr) \
   do { \

--- a/src/nvim/menu.c
+++ b/src/nvim/menu.c
@@ -46,9 +46,7 @@
 
 #define MENUDEPTH   10          // maximum depth of menus
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "menu.c.generated.h"
-#endif
+#include "menu.c.generated.h"
 
 /// The character for each menu mode
 static char *menu_mode_chars[] = { "n", "v", "s", "o", "i", "c", "tl", "t" };

--- a/src/nvim/menu.h
+++ b/src/nvim/menu.h
@@ -5,6 +5,4 @@
 #include "nvim/menu_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "menu.h.generated.h"
-#endif
+#include "menu.h.generated.h"

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -89,9 +89,7 @@ enum {
 };
 
 static int confirm_msg_used = false;            // displaying confirm_msg
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "message.c.generated.h"
-#endif
+#include "message.c.generated.h"
 static char *confirm_msg = NULL;            // ":confirm" message
 static char *confirm_buttons;               // ":confirm" buttons sent to cmdline as prompt
 

--- a/src/nvim/message.h
+++ b/src/nvim/message.h
@@ -58,9 +58,7 @@ EXTERN int msg_grid_scroll_discount INIT( = 0);
 
 EXTERN int msg_listdo_overwrite INIT( = 0);
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "message.h.generated.h"
-#endif
+#include "message.h.generated.h"
 
 // Prefer using semsg(), because perror() may send the output to the wrong
 // destination and mess up the screen.

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -50,9 +50,7 @@
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "mouse.c.generated.h"
-#endif
+#include "mouse.c.generated.h"
 
 static linenr_T orig_topline = 0;
 static int orig_topfill = 0;

--- a/src/nvim/mouse.h
+++ b/src/nvim/mouse.h
@@ -50,6 +50,4 @@ enum {
   MSCR_RIGHT = -2,
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "mouse.h.generated.h"
-#endif
+#include "mouse.h.generated.h"

--- a/src/nvim/move.c
+++ b/src/nvim/move.c
@@ -56,9 +56,7 @@ typedef struct {
   int height;                   // height of added line
 } lineoff_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "move.c.generated.h"
-#endif
+#include "move.c.generated.h"
 
 /// Get the number of screen lines skipped with "wp->w_skipcol".
 int adjust_plines_for_skipcol(win_T *wp)

--- a/src/nvim/move.h
+++ b/src/nvim/move.h
@@ -4,6 +4,4 @@
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 #include "nvim/vim_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "move.h.generated.h"
-#endif
+#include "move.h.generated.h"

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -33,9 +33,7 @@
 #include "nvim/ui.h"
 #include "nvim/ui_client.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "msgpack_rpc/channel.c.generated.h"
-#endif
+#include "msgpack_rpc/channel.c.generated.h"
 
 #ifdef NVIM_LOG_DEBUG
 # define REQ "[request]  "

--- a/src/nvim/msgpack_rpc/channel.h
+++ b/src/nvim/msgpack_rpc/channel.h
@@ -15,6 +15,4 @@
 ///       of input_get(), so they are processed "just-in-time".
 EXTERN MultiQueue *ch_before_blocking_events INIT( = NULL);
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "msgpack_rpc/channel.h.generated.h"
-#endif
+#include "msgpack_rpc/channel.h.generated.h"

--- a/src/nvim/msgpack_rpc/packer.c
+++ b/src/nvim/msgpack_rpc/packer.c
@@ -13,9 +13,7 @@
 #include "nvim/msgpack_rpc/packer.h"
 #include "nvim/types_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "msgpack_rpc/packer.c.generated.h"
-#endif
+#include "msgpack_rpc/packer.c.generated.h"
 
 void mpack_check_buffer(PackerBuffer *packer)
 {

--- a/src/nvim/msgpack_rpc/packer.h
+++ b/src/nvim/msgpack_rpc/packer.h
@@ -76,6 +76,4 @@ static inline size_t mpack_remaining(PackerBuffer *packer)
   return (size_t)(packer->endptr - packer->ptr);
 }
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "msgpack_rpc/packer.h.generated.h"
-#endif
+#include "msgpack_rpc/packer.h.generated.h"

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -26,9 +26,7 @@
 
 static garray_T watchers = GA_EMPTY_INIT_VALUE;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "msgpack_rpc/server.c.generated.h"
-#endif
+#include "msgpack_rpc/server.c.generated.h"
 
 /// Initializes resources, handles `--listen`, starts the primary server at v:servername.
 ///

--- a/src/nvim/msgpack_rpc/server.h
+++ b/src/nvim/msgpack_rpc/server.h
@@ -3,6 +3,4 @@
 #include <stdbool.h>
 #include <stddef.h>  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "msgpack_rpc/server.h.generated.h"
-#endif
+#include "msgpack_rpc/server.h.generated.h"

--- a/src/nvim/msgpack_rpc/unpacker.c
+++ b/src/nvim/msgpack_rpc/unpacker.c
@@ -15,9 +15,7 @@
 #include "nvim/strings.h"
 #include "nvim/ui_client.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "msgpack_rpc/unpacker.c.generated.h"
-#endif
+#include "msgpack_rpc/unpacker.c.generated.h"
 
 Object unpack(const char *data, size_t size, Arena *arena, Error *err)
 {

--- a/src/nvim/msgpack_rpc/unpacker.h
+++ b/src/nvim/msgpack_rpc/unpacker.h
@@ -48,6 +48,4 @@ typedef kvec_t(char) AdditionalDataBuilder;
 // unrecovareble error. unpack_error should be set!
 #define unpacker_closed(p) ((p)->state < 0)
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "msgpack_rpc/unpacker.h.generated.h"
-#endif
+#include "msgpack_rpc/unpacker.h.generated.h"

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -112,9 +112,7 @@ typedef struct {
 
 static int VIsual_mode_orig = NUL;              // saved Visual mode
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "normal.c.generated.h"
-#endif
+#include "normal.c.generated.h"
 
 static const char e_changelist_is_empty[] = N_("E664: Changelist is empty");
 static const char e_cmdline_window_already_open[]

--- a/src/nvim/normal.h
+++ b/src/nvim/normal.h
@@ -17,6 +17,4 @@ enum {
 /// 'showcmd' buffer shared between normal.c and statusline.c
 EXTERN char showcmd_buf[SHOWCMD_BUFLEN];
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "normal.h.generated.h"
-#endif
+#include "normal.h.generated.h"

--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -87,9 +87,7 @@ static bool clipboard_delay_update = false;  // delay clipboard update
 static bool clipboard_needs_update = false;  // clipboard was updated
 static bool clipboard_didwarn = false;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ops.c.generated.h"
-#endif
+#include "ops.c.generated.h"
 
 static const char e_search_pattern_and_expression_register_may_not_contain_two_or_more_lines[]
   = N_("E883: Search pattern and expression register may not contain two or more lines");

--- a/src/nvim/ops.h
+++ b/src/nvim/ops.h
@@ -118,10 +118,8 @@ typedef enum {
   YREG_PUT,
 } yreg_mode_t;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ops.h.generated.h"
-# include "ops.h.inline.generated.h"
-#endif
+#include "ops.h.generated.h"
+#include "ops.h.inline.generated.h"
 
 /// Convert register name into register index
 ///

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -157,18 +157,14 @@ typedef enum {
   PREFIX_INV,     ///< "inv" prefix
 } set_prefix_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "option.c.generated.h"
-#endif
+#include "option.c.generated.h"
 
 // options[] is initialized in options.generated.h.
 // The options with a NULL variable are 'hidden': a set command for them is
 // ignored and they are not printed.
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "options.generated.h"
-# include "options_map.generated.h"
-#endif
+#include "options.generated.h"
+#include "options_map.generated.h"
 
 static int p_bin_dep_opts[] = {
   kOptTextwidth, kOptWrapmargin, kOptModeline, kOptExpandtab, kOptInvalid

--- a/src/nvim/option.h
+++ b/src/nvim/option.h
@@ -60,6 +60,4 @@ static inline const char *optval_type_get_name(const OptValType type)
 #define STATIC_CSTR_AS_OPTVAL(s) STRING_OPTVAL(STATIC_CSTR_AS_STRING(s))
 #define STATIC_CSTR_TO_OPTVAL(s) STRING_OPTVAL(STATIC_CSTR_TO_STRING(s))
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "option.h.generated.h"
-#endif
+#include "option.h.generated.h"

--- a/src/nvim/option_defs.h
+++ b/src/nvim/option_defs.h
@@ -7,9 +7,7 @@
 #include "nvim/cmdexpand_defs.h"
 #include "nvim/regexp_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "options_enum.generated.h"
-#endif
+#include "options_enum.generated.h"
 
 /// Option flags.
 typedef enum {

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -6,9 +6,7 @@
 #include "nvim/statusline_defs.h"
 #include "nvim/types_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "option_vars.generated.h"  // NOLINT(build/include_defs)
-#endif
+#include "option_vars.generated.h"  // NOLINT(build/include_defs)
 
 // option_vars.h: definition of global variables for settable options
 

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -54,9 +54,7 @@
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "optionstr.c.generated.h"
-#endif
+#include "optionstr.c.generated.h"
 
 static const char e_illegal_character_after_chr[]
   = N_("E535: Illegal character after <%c>");

--- a/src/nvim/optionstr.h
+++ b/src/nvim/optionstr.h
@@ -11,6 +11,4 @@ typedef enum {
   kListchars,
 } CharsOption;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "optionstr.h.generated.h"
-#endif
+#include "optionstr.h.generated.h"

--- a/src/nvim/os/dl.h
+++ b/src/nvim/os/dl.h
@@ -2,6 +2,4 @@
 
 #include <stdbool.h>
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/dl.h.generated.h"
-#endif
+#include "os/dl.h.generated.h"

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -47,10 +47,9 @@
 # include <sys/utsname.h>
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "auto/pathdef.h"
-# include "os/env.c.generated.h"
-#endif
+#include "auto/pathdef.h"
+
+#include "os/env.c.generated.h"
 
 /// Like getenv(), but returns NULL if the variable is empty.
 /// Result must be freed by the caller.

--- a/src/nvim/os/fileio.c
+++ b/src/nvim/os/fileio.c
@@ -24,9 +24,7 @@
 # include <sys/uio.h>
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/fileio.c.generated.h"  // IWYU pragma: keep
-#endif
+#include "os/fileio.c.generated.h"  // IWYU pragma: keep
 
 /// Open file
 ///

--- a/src/nvim/os/fileio.h
+++ b/src/nvim/os/fileio.h
@@ -38,6 +38,4 @@ static inline size_t file_space(FileDescriptor *fp)
   return (size_t)((fp->buffer + ARENA_BLOCK_SIZE) - fp->write_pos);
 }
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/fileio.h.generated.h"
-#endif
+#include "os/fileio.h.generated.h"

--- a/src/nvim/os/fileio_defs.h
+++ b/src/nvim/os/fileio_defs.h
@@ -15,9 +15,7 @@ typedef struct {
   uint64_t bytes_read;  ///< total bytes read so far
 } FileDescriptor;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/fileio_defs.h.inline.generated.h"
-#endif
+#include "os/fileio_defs.h.inline.generated.h"
 
 /// Check whether end of file was encountered
 ///

--- a/src/nvim/os/fs.c
+++ b/src/nvim/os/fs.c
@@ -60,9 +60,7 @@
 # include "nvim/strings.h"
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/fs.c.generated.h"
-#endif
+#include "os/fs.c.generated.h"
 
 #ifdef HAVE_XATTR
 static const char e_xattr_erange[]

--- a/src/nvim/os/fs.h
+++ b/src/nvim/os/fs.h
@@ -8,6 +8,4 @@
 #include "nvim/os/fs_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/fs.h.generated.h"
-#endif
+#include "os/fs.h.generated.h"

--- a/src/nvim/os/input.c
+++ b/src/nvim/os/input.c
@@ -44,9 +44,7 @@ static bool blocking = false;
 static int cursorhold_time = 0;  ///< time waiting for CursorHold event
 static int cursorhold_tb_change_cnt = 0;  ///< tb_change_cnt when waiting started
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/input.c.generated.h"
-#endif
+#include "os/input.c.generated.h"
 
 void input_start(void)
 {

--- a/src/nvim/os/input.h
+++ b/src/nvim/os/input.h
@@ -9,6 +9,4 @@
 
 EXTERN bool used_stdin INIT( = false);
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/input.h.generated.h"
-#endif
+#include "os/input.h.generated.h"

--- a/src/nvim/os/lang.c
+++ b/src/nvim/os/lang.c
@@ -32,9 +32,7 @@
 #include "nvim/profile.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/lang.c.generated.h"
-#endif
+#include "os/lang.c.generated.h"
 
 static char *get_locale_val(int what)
 {

--- a/src/nvim/os/lang.h
+++ b/src/nvim/os/lang.h
@@ -4,6 +4,4 @@
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/lang.h.generated.h"
-#endif
+#include "os/lang.h.generated.h"

--- a/src/nvim/os/os.h
+++ b/src/nvim/os/os.h
@@ -14,14 +14,12 @@ extern char *default_vim_dir;
 extern char *default_vimruntime_dir;
 extern char *default_lib_dir;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
 // IWYU pragma: begin_exports
-# include "os/env.h.generated.h"
-# include "os/mem.h.generated.h"
-# include "os/stdpaths.h.generated.h"
-# include "os/users.h.generated.h"
+#include "os/env.h.generated.h"
+#include "os/mem.h.generated.h"
+#include "os/stdpaths.h.generated.h"
+#include "os/users.h.generated.h"
 // IWYU pragma: end_exports
-#endif
 
 #define ENV_LOGFILE "NVIM_LOG_FILE"
 #define ENV_NVIM "NVIM"

--- a/src/nvim/os/os_win_console.c
+++ b/src/nvim/os/os_win_console.c
@@ -7,9 +7,7 @@
 #include "nvim/os/os.h"
 #include "nvim/os/os_win_console.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/os_win_console.c.generated.h"
-#endif
 
 static char origTitle[256] = { 0 };
 static HWND hWnd = NULL;

--- a/src/nvim/os/os_win_console.h
+++ b/src/nvim/os/os_win_console.h
@@ -1,8 +1,6 @@
 #pragma once
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/os_win_console.h.generated.h"
-#endif
+#include "os/os_win_console.h.generated.h"
 
 #ifndef ENABLE_VIRTUAL_TERMINAL_INPUT
 # define ENABLE_VIRTUAL_TERMINAL_INPUT 0x0200

--- a/src/nvim/os/proc.c
+++ b/src/nvim/os/proc.c
@@ -43,9 +43,7 @@
 # include "nvim/api/private/helpers.h"
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/proc.c.generated.h"
-#endif
+#include "os/proc.c.generated.h"
 
 #ifdef MSWIN
 static bool os_proc_tree_kill_rec(void *proc, int sig)

--- a/src/nvim/os/proc.h
+++ b/src/nvim/os/proc.h
@@ -4,6 +4,4 @@
 
 #include "nvim/api/private/defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/proc.h.generated.h"
-#endif
+#include "os/proc.h.generated.h"

--- a/src/nvim/os/pty_conpty_win.h
+++ b/src/nvim/os/pty_conpty_win.h
@@ -17,6 +17,4 @@ typedef struct conpty {
   STARTUPINFOEXW si_ex;
 } conpty_t;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/pty_conpty_win.h.generated.h"
-#endif
+#include "os/pty_conpty_win.h.generated.h"

--- a/src/nvim/os/pty_proc_unix.c
+++ b/src/nvim/os/pty_proc_unix.c
@@ -45,9 +45,7 @@ int forkpty(int *, char *, const struct termios *, const struct winsize *);
 #include "nvim/os/pty_proc_unix.h"
 #include "nvim/types_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/pty_proc_unix.c.generated.h"
-#endif
+#include "os/pty_proc_unix.c.generated.h"
 
 #if defined(__sun) && !defined(HAVE_FORKPTY)
 

--- a/src/nvim/os/pty_proc_unix.h
+++ b/src/nvim/os/pty_proc_unix.h
@@ -13,6 +13,4 @@ typedef struct {
   int tty_fd;
 } PtyProc;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/pty_proc_unix.h.generated.h"
-#endif
+#include "os/pty_proc_unix.h.generated.h"

--- a/src/nvim/os/pty_proc_win.c
+++ b/src/nvim/os/pty_proc_win.c
@@ -12,9 +12,7 @@
 #include "nvim/os/pty_conpty_win.h"
 #include "nvim/os/pty_proc_win.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "os/pty_proc_win.c.generated.h"
-#endif
 
 static void CALLBACK pty_proc_terminate_cb(void *context, BOOLEAN unused)
   FUNC_ATTR_NONNULL_ALL

--- a/src/nvim/os/pty_proc_win.h
+++ b/src/nvim/os/pty_proc_win.h
@@ -22,6 +22,4 @@ typedef struct arg_node {
   QUEUE node;  // QUEUE structure.
 } ArgNode;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/pty_proc_win.h.generated.h"
-#endif
+#include "os/pty_proc_win.h.generated.h"

--- a/src/nvim/os/shell.c
+++ b/src/nvim/os/shell.c
@@ -52,9 +52,7 @@
 
 #define SHELL_SPECIAL "\t \"&'$;<>()\\|"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/shell.c.generated.h"
-#endif
+#include "os/shell.c.generated.h"
 
 static void save_patterns(int num_pat, char **pat, int *num_file, char ***file)
 {

--- a/src/nvim/os/shell.h
+++ b/src/nvim/os/shell.h
@@ -13,6 +13,4 @@ typedef enum {
   kShellOptHideMess = 64,  ///< previously a global variable from os_unix.c
 } ShellOpts;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/shell.h.generated.h"
-#endif
+#include "os/shell.h.generated.h"

--- a/src/nvim/os/signal.c
+++ b/src/nvim/os/signal.c
@@ -34,9 +34,7 @@ static SignalWatcher spwr;
 
 static bool rejecting_deadly;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/signal.c.generated.h"
-#endif
+#include "os/signal.c.generated.h"
 
 void signal_init(void)
 {

--- a/src/nvim/os/signal.h
+++ b/src/nvim/os/signal.h
@@ -1,5 +1,3 @@
 #pragma once
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/signal.h.generated.h"
-#endif
+#include "os/signal.h.generated.h"

--- a/src/nvim/os/stdpaths.c
+++ b/src/nvim/os/stdpaths.c
@@ -13,9 +13,7 @@
 #include "nvim/path.h"
 #include "nvim/strings.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/stdpaths.c.generated.h"
-#endif
+#include "os/stdpaths.c.generated.h"
 
 /// Names of the environment variables, mapped to XDGVarType values
 static const char *xdg_env_vars[] = {

--- a/src/nvim/os/time.c
+++ b/src/nvim/os/time.c
@@ -18,9 +18,7 @@
 #include "nvim/os/os.h"
 #include "nvim/os/time.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/time.c.generated.h"
-#endif
+#include "os/time.c.generated.h"
 
 /// Gets a high-resolution (nanosecond), monotonically-increasing time relative
 /// to an arbitrary time in the past.

--- a/src/nvim/os/time.h
+++ b/src/nvim/os/time.h
@@ -6,6 +6,4 @@
 
 #include "nvim/os/time_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/time.h.generated.h"
-#endif
+#include "os/time.h.generated.h"

--- a/src/nvim/os/users.c
+++ b/src/nvim/os/users.c
@@ -24,9 +24,7 @@
 # include "nvim/message.h"
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "os/users.c.generated.h"
-#endif
+#include "os/users.c.generated.h"
 
 // All user names (for ~user completion as done by shell).
 static garray_T ga_users = GA_EMPTY_INIT_VALUE;

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -42,9 +42,7 @@ enum {
 # undef gen_expand_wildcards
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "path.c.generated.h"
-#endif
+#include "path.c.generated.h"
 
 /// Compare two file names.
 ///

--- a/src/nvim/path.h
+++ b/src/nvim/path.h
@@ -40,6 +40,4 @@ typedef enum file_comparison {
   kEqualFileNames = 7,  ///< Both don't exist and file names are same.
 } FileComparison;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "path.h.generated.h"
-#endif
+#include "path.h.generated.h"

--- a/src/nvim/plines.c
+++ b/src/nvim/plines.c
@@ -31,9 +31,7 @@
 #include "nvim/state_defs.h"
 #include "nvim/types_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "plines.c.generated.h"
-#endif
+#include "plines.c.generated.h"
 
 /// Functions calculating horizontal size of text, when displayed in a window.
 

--- a/src/nvim/plines.h
+++ b/src/nvim/plines.h
@@ -36,10 +36,8 @@ typedef struct {
   int head;  ///< Size of 'breakindent' etc. before the character (included in width).
 } CharSize;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "plines.h.generated.h"
-# include "plines.h.inline.generated.h"
-#endif
+#include "plines.h.generated.h"
+#include "plines.h.inline.generated.h"
 
 /// Get the number of cells taken up on the screen by the given character at vcol.
 /// "csarg->cur_text_width_left" and "csarg->cur_text_width_right" are set

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -81,9 +81,7 @@ static bool pum_is_drawn = false;
 static bool pum_external = false;
 static bool pum_invalid = false;  // the screen was just cleared
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "popupmenu.c.generated.h"
-#endif
+#include "popupmenu.c.generated.h"
 #define PUM_DEF_HEIGHT 10
 
 static void pum_compute_size(void)

--- a/src/nvim/popupmenu.h
+++ b/src/nvim/popupmenu.h
@@ -29,6 +29,4 @@ EXTERN struct {
   bool finish;
 } pum_want;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "popupmenu.h.generated.h"
-#endif
+#include "popupmenu.h.generated.h"

--- a/src/nvim/profile.c
+++ b/src/nvim/profile.c
@@ -33,9 +33,7 @@
 #include "nvim/runtime.h"
 #include "nvim/types_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "profile.c.generated.h"
-#endif
+#include "profile.c.generated.h"
 
 /// Struct used in sn_prl_ga for every line of a script.
 typedef struct {

--- a/src/nvim/profile.h
+++ b/src/nvim/profile.h
@@ -11,6 +11,4 @@
   if (time_fd != NULL) time_msg(s, NULL); \
 } while (0)
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "profile.h.generated.h"
-#endif
+#include "profile.h.generated.h"

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -258,9 +258,7 @@ typedef struct {
   char *qf_title;      ///< quickfix list title
 } vgr_args_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "quickfix.c.generated.h"
-#endif
+#include "quickfix.c.generated.h"
 
 static const char *e_no_more_items = N_("E553: No more items");
 static const char *e_current_quickfix_list_was_changed =

--- a/src/nvim/quickfix.h
+++ b/src/nvim/quickfix.h
@@ -14,6 +14,4 @@ enum {
   VGR_FUZZY  = 4,
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "quickfix.h.generated.h"
-#endif
+#include "quickfix.h.generated.h"

--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -645,9 +645,7 @@ typedef struct {
 static regengine_T bt_regengine;
 static regengine_T nfa_regengine;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "regexp.c.generated.h"
-#endif
+#include "regexp.c.generated.h"
 
 // Return true if compiled regular expression "prog" can match a line break.
 int re_multiline(const regprog_T *prog)

--- a/src/nvim/regexp.h
+++ b/src/nvim/regexp.h
@@ -17,6 +17,4 @@
 #define REX_USE        2       ///< to allow \z\1 et al.
 #define REX_ALL       (REX_SET | REX_USE)
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "regexp.h.generated.h"
-#endif
+#include "regexp.h.generated.h"

--- a/src/nvim/runtime.c
+++ b/src/nvim/runtime.c
@@ -99,9 +99,7 @@ typedef struct {
 typedef kvec_t(SearchPathItem) RuntimeSearchPath;
 typedef kvec_t(char *) CharVec;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "runtime.c.generated.h"
-#endif
+#include "runtime.c.generated.h"
 
 garray_T exestack = { 0, 0, sizeof(estack_T), 50, NULL };
 garray_T script_items = { 0, 0, sizeof(scriptitem_T *), 20, NULL };

--- a/src/nvim/runtime.h
+++ b/src/nvim/runtime.h
@@ -44,6 +44,4 @@ enum {
   DIP_DIRFILE = 0x200,  ///< find both files and directories
 };
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "runtime.h.generated.h"
-#endif
+#include "runtime.h.generated.h"

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -63,9 +63,7 @@
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "search.c.generated.h"
-#endif
+#include "search.c.generated.h"
 
 static const char e_search_hit_top_without_match_for_str[]
   = N_("E384: Search hit TOP without match for: %s");

--- a/src/nvim/search.h
+++ b/src/nvim/search.h
@@ -107,6 +107,4 @@ typedef struct {
   int last_maxcount;  // the max count of the last search
 } searchstat_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "search.h.generated.h"
-#endif
+#include "search.h.generated.h"

--- a/src/nvim/sha256.c
+++ b/src/nvim/sha256.c
@@ -20,9 +20,7 @@
 #include "nvim/memory.h"
 #include "nvim/sha256.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "sha256.c.generated.h"
-#endif
+#include "sha256.c.generated.h"
 #define GET_UINT32(n, b, i) { \
   (n) = ((uint32_t)(b)[(i)] << 24) \
         | ((uint32_t)(b)[(i) + 1] << 16) \

--- a/src/nvim/sha256.h
+++ b/src/nvim/sha256.h
@@ -13,6 +13,4 @@ typedef struct {
   uint8_t buffer[SHA256_BUFFER_SIZE];
 } context_sha256_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "sha256.h.generated.h"
-#endif
+#include "sha256.h.generated.h"

--- a/src/nvim/shada.c
+++ b/src/nvim/shada.c
@@ -338,9 +338,7 @@ typedef struct {
   PMap(cstr_t) file_marks;  ///< All file marks.
 } WriteMergerState;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "shada.c.generated.h"
-#endif
+#include "shada.c.generated.h"
 
 #define DEF_SDE(name, attr, ...) \
   [kSDItem##name] = { \

--- a/src/nvim/shada.h
+++ b/src/nvim/shada.h
@@ -11,6 +11,4 @@ typedef enum {
   kShaDaMissingError = 16,  ///< Error out when os_open returns -ENOENT.
 } ShaDaReadFileFlags;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "shada.h.generated.h"
-#endif
+#include "shada.h.generated.h"

--- a/src/nvim/sign.c
+++ b/src/nvim/sign.c
@@ -49,9 +49,7 @@
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "sign.c.generated.h"
-#endif
+#include "sign.c.generated.h"
 
 static PMap(cstr_t) sign_map = MAP_INIT;
 static kvec_t(Integer) sign_ns = KV_INITIAL_VALUE;

--- a/src/nvim/sign.h
+++ b/src/nvim/sign.h
@@ -5,6 +5,4 @@
 #include "nvim/sign_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "sign.h.generated.h"
-#endif
+#include "sign.h.generated.h"

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -186,9 +186,7 @@ typedef struct {
 spelltab_T spelltab;
 bool did_set_spelltab;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "spell.c.generated.h"
-#endif
+#include "spell.c.generated.h"
 
 /// mode values for find_word
 enum {

--- a/src/nvim/spell.h
+++ b/src/nvim/spell.h
@@ -28,6 +28,4 @@ typedef enum {
   SMT_RARE,     ///< Move to "rare" words only
 } smt_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "spell.h.generated.h"
-#endif
+#include "spell.h.generated.h"

--- a/src/nvim/spellfile.c
+++ b/src/nvim/spellfile.c
@@ -529,9 +529,7 @@ typedef struct {
   int si_newcompID;             // current value for compound ID
 } spellinfo_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "spellfile.c.generated.h"
-#endif
+#include "spellfile.c.generated.h"
 
 /// Read n bytes from fd to buf, returning on errors
 ///

--- a/src/nvim/spellfile.h
+++ b/src/nvim/spellfile.h
@@ -3,6 +3,4 @@
 #include "nvim/ex_cmds_defs.h"  // IWYU pragma: keep
 #include "nvim/spell_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "spellfile.h.generated.h"
-#endif
+#include "spellfile.h.generated.h"

--- a/src/nvim/spellsuggest.c
+++ b/src/nvim/spellsuggest.c
@@ -240,9 +240,7 @@ enum {
 
 static int spell_suggest_timeout = 5000;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "spellsuggest.c.generated.h"
-#endif
+#include "spellsuggest.c.generated.h"
 
 /// Returns true when the sequence of flags in "compflags" plus "flag" can
 /// possibly form a valid compounded word.  This also checks the COMPOUNDRULE

--- a/src/nvim/spellsuggest.h
+++ b/src/nvim/spellsuggest.h
@@ -4,6 +4,4 @@
 
 #include "nvim/garray_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "spellsuggest.h.generated.h"
-#endif
+#include "spellsuggest.h.generated.h"

--- a/src/nvim/state.c
+++ b/src/nvim/state.c
@@ -29,9 +29,7 @@
 #include "nvim/types_defs.h"
 #include "nvim/ui.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "state.c.generated.h"
-#endif
+#include "state.c.generated.h"
 
 void state_enter(VimState *s)
   FUNC_ATTR_NONNULL_ALL

--- a/src/nvim/state.h
+++ b/src/nvim/state.h
@@ -3,6 +3,4 @@
 #include "nvim/state_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "state.h.generated.h"
-#endif
+#include "state.h.generated.h"

--- a/src/nvim/statusline.h
+++ b/src/nvim/statusline.h
@@ -12,6 +12,4 @@ EXTERN StlClickDefinition *tab_page_click_defs INIT( = NULL);
 /// Size of the tab_page_click_defs array
 EXTERN size_t tab_page_click_defs_size INIT( = 0);
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "statusline.h.generated.h"
-#endif
+#include "statusline.h.generated.h"

--- a/src/nvim/strings.c
+++ b/src/nvim/strings.c
@@ -35,9 +35,7 @@
 #include "nvim/types_defs.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "strings.c.generated.h"
-#endif
+#include "strings.c.generated.h"
 
 static const char e_cannot_mix_positional_and_non_positional_str[]
   = N_("E1500: Cannot mix positional and non-positional arguments: %s");

--- a/src/nvim/strings.h
+++ b/src/nvim/strings.h
@@ -21,10 +21,8 @@ typedef struct {
 
 #define KEYVALUE_ENTRY(k, v) { (k), (v), STRLEN_LITERAL(v) }
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "strings.h.generated.h"
-# include "strings.h.inline.generated.h"
-#endif
+#include "strings.h.generated.h"
+#include "strings.h.inline.generated.h"
 
 /// Append string to string and return pointer to the next byte
 ///

--- a/src/nvim/syntax.c
+++ b/src/nvim/syntax.c
@@ -157,9 +157,7 @@ typedef struct {
   char *pattern;
 } time_entry_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "syntax.c.generated.h"
-#endif
+#include "syntax.c.generated.h"
 
 static char *(spo_name_tab[SPO_COUNT]) =
 { "ms=", "me=", "hs=", "he=", "rs=", "re=", "lc=" };

--- a/src/nvim/syntax.h
+++ b/src/nvim/syntax.h
@@ -34,6 +34,4 @@ enum {
 /// Array of highlight definitions, used for unit testing
 extern const char *const highlight_init_cmdline[];
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "syntax.h.generated.h"
-#endif
+#include "syntax.h.generated.h"

--- a/src/nvim/tag.c
+++ b/src/nvim/tag.c
@@ -192,9 +192,7 @@ typedef struct {
   hashtab_T ht_match[MT_COUNT];  ///< stores matches by key
 } findtags_state_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "tag.c.generated.h"
-#endif
+#include "tag.c.generated.h"
 
 static const char e_tag_stack_empty[]
   = N_("E73: Tag stack empty");

--- a/src/nvim/tag.h
+++ b/src/nvim/tag.h
@@ -45,6 +45,4 @@ typedef struct {
   void *tn_search_ctx;
 } tagname_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "tag.h.generated.h"
-#endif
+#include "tag.h.generated.h"

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -113,9 +113,7 @@ typedef struct {
   bool cursor_visible;  ///< cursor's current visibility; ensures matched busy_start/stop UI events
 } TerminalState;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "terminal.c.generated.h"
-#endif
+#include "terminal.c.generated.h"
 
 // Delay for refreshing the terminal buffer after receiving updates from
 // libvterm. Improves performance when receiving large bursts of data.

--- a/src/nvim/terminal.h
+++ b/src/nvim/terminal.h
@@ -20,6 +20,4 @@ typedef struct {
   bool force_crlf;
 } TerminalOptions;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "terminal.h.generated.h"
-#endif
+#include "terminal.h.generated.h"

--- a/src/nvim/testing.c
+++ b/src/nvim/testing.c
@@ -41,9 +41,7 @@ typedef enum {
   ASSERT_OTHER,
 } assert_type_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "testing.c.generated.h"
-#endif
+#include "testing.c.generated.h"
 
 static const char e_assert_fails_second_arg[]
   = N_(

--- a/src/nvim/testing.h
+++ b/src/nvim/testing.h
@@ -3,6 +3,4 @@
 #include "nvim/eval/typval_defs.h"  // IWYU pragma: keep
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "testing.h.generated.h"
-#endif
+#include "testing.h.generated.h"

--- a/src/nvim/textformat.c
+++ b/src/nvim/textformat.c
@@ -41,9 +41,7 @@
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "textformat.c.generated.h"
-#endif
+#include "textformat.c.generated.h"
 
 static bool did_add_space = false;  ///< auto_format() added an extra space
                                     ///< under the cursor

--- a/src/nvim/textformat.h
+++ b/src/nvim/textformat.h
@@ -3,6 +3,4 @@
 #include "nvim/normal_defs.h"  // IWYU pragma: keep
 #include "nvim/pos_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "textformat.h.generated.h"
-#endif
+#include "textformat.h.generated.h"

--- a/src/nvim/textobject.c
+++ b/src/nvim/textobject.c
@@ -27,9 +27,7 @@
 #include "nvim/textobject.h"
 #include "nvim/vim_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "textobject.c.generated.h"
-#endif
+#include "textobject.c.generated.h"
 
 /// Find the start of the next sentence, searching in the direction specified
 /// by the "dir" argument.  The cursor is positioned on the start of the next

--- a/src/nvim/textobject.h
+++ b/src/nvim/textobject.h
@@ -4,6 +4,4 @@
 #include "nvim/pos_defs.h"  // IWYU pragma: keep
 #include "nvim/vim_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "textobject.h.generated.h"
-#endif
+#include "textobject.h.generated.h"

--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -121,9 +121,7 @@ static const struct kitty_key_map_entry {
 
 static PMap(int) kitty_key_map = MAP_INIT;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "tui/input.c.generated.h"
-#endif
+#include "tui/input.c.generated.h"
 
 void tinput_init(TermInput *input, Loop *loop)
 {

--- a/src/nvim/tui/input.h
+++ b/src/nvim/tui/input.h
@@ -44,6 +44,4 @@ typedef struct {
   size_t key_buffer_len;
 } TermInput;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "tui/input.h.generated.h"
-#endif
+#include "tui/input.h.generated.h"

--- a/src/nvim/tui/terminfo.c
+++ b/src/nvim/tui/terminfo.c
@@ -17,9 +17,7 @@
 # include "nvim/os/os.h"
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "tui/terminfo.c.generated.h"
-#endif
+#include "tui/terminfo.c.generated.h"
 
 bool terminfo_is_term_family(const char *term, const char *family)
 {

--- a/src/nvim/tui/terminfo.h
+++ b/src/nvim/tui/terminfo.h
@@ -4,6 +4,4 @@
 
 #include "nvim/api/private/defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "tui/terminfo.h.generated.h"
-#endif
+#include "tui/terminfo.h.generated.h"

--- a/src/nvim/tui/termkey/driver-csi.c
+++ b/src/nvim/tui/termkey/driver-csi.c
@@ -7,9 +7,7 @@
 #include "nvim/tui/termkey/termkey-internal.h"
 #include "nvim/tui/termkey/termkey_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "tui/termkey/driver-csi.c.generated.h"
-#endif
+#include "tui/termkey/driver-csi.c.generated.h"
 
 // There are 64 codes 0x40 - 0x7F
 static int keyinfo_initialised = 0;

--- a/src/nvim/tui/termkey/driver-csi.h
+++ b/src/nvim/tui/termkey/driver-csi.h
@@ -2,6 +2,4 @@
 
 #include "nvim/tui/termkey/termkey_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "tui/termkey/driver-csi.h.generated.h"
-#endif
+#include "tui/termkey/driver-csi.h.generated.h"

--- a/src/nvim/tui/termkey/driver-ti.c
+++ b/src/nvim/tui/termkey/driver-ti.c
@@ -18,9 +18,7 @@
 # include <io.h>
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "tui/termkey/driver-ti.c.generated.h"
-#endif
+#include "tui/termkey/driver-ti.c.generated.h"
 
 #define streq(a, b) (!strcmp(a, b))
 

--- a/src/nvim/tui/termkey/driver-ti.h
+++ b/src/nvim/tui/termkey/driver-ti.h
@@ -2,6 +2,4 @@
 
 #include "nvim/tui/termkey/termkey_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "tui/termkey/driver-ti.h.generated.h"
-#endif
+#include "tui/termkey/driver-ti.h.generated.h"

--- a/src/nvim/tui/termkey/termkey.c
+++ b/src/nvim/tui/termkey/termkey.c
@@ -21,9 +21,7 @@
 # include <io.h>
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "tui/termkey/termkey.c.generated.h"
-#endif
+#include "tui/termkey/termkey.c.generated.h"
 
 #ifdef _MSC_VER
 # define strcaseeq(a, b) (_stricmp(a, b) == 0)

--- a/src/nvim/tui/termkey/termkey.h
+++ b/src/nvim/tui/termkey/termkey.h
@@ -5,6 +5,4 @@
 
 #include "nvim/tui/termkey/termkey_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "tui/termkey/termkey.h.generated.h"
-#endif
+#include "tui/termkey/termkey.h.generated.h"

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -159,9 +159,7 @@ struct TUIData {
 
 static int got_winch = 0;
 static bool cursor_style_enabled = false;
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "tui/tui.c.generated.h"
-#endif
+#include "tui/tui.c.generated.h"
 
 static Set(cstr_t) urls = SET_INIT;
 

--- a/src/nvim/tui/tui.h
+++ b/src/nvim/tui/tui.h
@@ -4,6 +4,4 @@
 #include "nvim/tui/tui_defs.h"  // IWYU pragma: keep
 #include "nvim/ui_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "tui/tui.h.generated.h"
-#endif
+#include "tui/tui.h.generated.h"

--- a/src/nvim/ugrid.c
+++ b/src/nvim/ugrid.c
@@ -5,9 +5,7 @@
 #include "nvim/memory.h"
 #include "nvim/ugrid.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ugrid.c.generated.h"
-#endif
+#include "ugrid.c.generated.h"
 
 void ugrid_init(UGrid *grid)
 {

--- a/src/nvim/ugrid.h
+++ b/src/nvim/ugrid.h
@@ -23,6 +23,4 @@ typedef struct {
     } \
   } while (0)
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ugrid.h.generated.h"
-#endif
+#include "ugrid.h.generated.h"

--- a/src/nvim/ui.c
+++ b/src/nvim/ui.c
@@ -48,9 +48,7 @@ typedef struct {
   bool ext_widgets[kUIGlobalCount];
 } UIEventCallback;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ui.c.generated.h"
-#endif
+#include "ui.c.generated.h"
 
 #define MAX_UI_COUNT 16
 
@@ -118,9 +116,7 @@ static void ui_log(const char *funname)
     } \
   } while (0)
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ui_events_call.generated.h"
-#endif
+#include "ui_events_call.generated.h"
 
 void ui_init(void)
 {

--- a/src/nvim/ui.h
+++ b/src/nvim/ui.h
@@ -11,11 +11,9 @@
 #include "nvim/ui_defs.h"  // IWYU pragma: keep
 
 // uncrustify:off
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ui.h.generated.h"
-# include "ui_events_call.h.generated.h"
+#include "ui.h.generated.h"
+#include "ui_events_call.h.generated.h"
 EXTERN Array noargs INIT(= ARRAY_DICT_INIT);
-#endif
 // uncrustify:on
 
 // vim.ui_attach() namespace of currently executed callback.

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -41,10 +41,8 @@ static bool tui_rgb = false;
 static bool ui_client_is_remote = false;
 
 // uncrustify:off
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ui_client.c.generated.h"
-# include "ui_events_client.generated.h"
-#endif
+#include "ui_client.c.generated.h"
+#include "ui_events_client.generated.h"
 // uncrustify:on
 
 uint64_t ui_client_start_server(const char *exepath, size_t argc, char **argv)

--- a/src/nvim/ui_client.h
+++ b/src/nvim/ui_client.h
@@ -33,8 +33,6 @@ EXTERN bool ui_client_forward_stdin INIT( = false);
 
 #define UI_CLIENT_STDIN_FD 3
 // uncrustify:off
-#ifdef INCLUDE_GENERATED_DECLARATIONS
 # include "ui_client.h.generated.h"
 # include "ui_events_client.h.generated.h"
-#endif
 // uncrustify:on

--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -30,9 +30,7 @@
 #include "nvim/ui.h"
 #include "nvim/ui_compositor.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ui_compositor.c.generated.h"
-#endif
+#include "ui_compositor.c.generated.h"
 
 static int composed_uis = 0;
 kvec_t(ScreenGrid *) layers = KV_INITIAL_VALUE;

--- a/src/nvim/ui_compositor.h
+++ b/src/nvim/ui_compositor.h
@@ -5,6 +5,4 @@
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 #include "nvim/ui_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "ui_compositor.h.generated.h"
-#endif
+#include "ui_compositor.h.generated.h"

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -140,9 +140,7 @@ typedef struct {
   FILE *bi_fp;
 } bufinfo_T;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "undo.c.generated.h"
-#endif
+#include "undo.c.generated.h"
 
 static const char e_undo_list_corrupt[]
   = N_("E439: Undo list corrupt");

--- a/src/nvim/undo.h
+++ b/src/nvim/undo.h
@@ -6,6 +6,4 @@
 #include "nvim/types_defs.h"  // IWYU pragma: keep
 #include "nvim/undo_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "undo.h.generated.h"
-#endif
+#include "undo.h.generated.h"

--- a/src/nvim/usercmd.c
+++ b/src/nvim/usercmd.c
@@ -36,9 +36,7 @@
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "usercmd.c.generated.h"
-#endif
+#include "usercmd.c.generated.h"
 
 garray_T ucmds = { 0, 0, sizeof(ucmd_T), 4, NULL };
 

--- a/src/nvim/usercmd.h
+++ b/src/nvim/usercmd.h
@@ -31,6 +31,4 @@ extern garray_T ucmds;
 #define USER_CMD(i) (&((ucmd_T *)(ucmds.ga_data))[i])
 #define USER_CMD_GA(gap, i) (&((ucmd_T *)((gap)->ga_data))[i])
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "usercmd.h.generated.h"
-#endif
+#include "usercmd.h.generated.h"

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -53,9 +53,7 @@ char *version_buildtype = "Build type: " NVIM_VERSION_BUILD_TYPE;
 char *version_cflags = "Compilation: " NVIM_VERSION_CFLAGS;
 #endif
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "version.c.generated.h"
-#endif
+#include "version.c.generated.h"
 
 // clang-format off
 static const int included_patches[] = {

--- a/src/nvim/version.h
+++ b/src/nvim/version.h
@@ -27,6 +27,4 @@ extern char *version_cflags;
 // swap file compatibility (max. length is 6 chars)
 #define VIM_VERSION_SHORT VIM_VERSION_MAJOR_STR "." VIM_VERSION_MINOR_STR
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "version.h.generated.h"
-#endif
+#include "version.h.generated.h"

--- a/src/nvim/viml/parser/expressions.c
+++ b/src/nvim/viml/parser/expressions.c
@@ -128,9 +128,7 @@ typedef enum {
   kEOpAssRight = 'r',  ///< Right associativity.
 } ExprOpAssociativity;
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "viml/parser/expressions.c.generated.h"
-#endif
+#include "viml/parser/expressions.c.generated.h"
 
 /// Scale number by a given factor
 ///

--- a/src/nvim/viml/parser/expressions.h
+++ b/src/nvim/viml/parser/expressions.h
@@ -381,6 +381,4 @@ extern const char *const ccs_tab[];
 /// Array mapping ExprAssignmentType values to their stringified versions
 extern const char *const expr_asgn_type_tab[];
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "viml/parser/expressions.h.generated.h"
-#endif
+#include "viml/parser/expressions.h.generated.h"

--- a/src/nvim/viml/parser/parser.c
+++ b/src/nvim/viml/parser/parser.c
@@ -3,9 +3,7 @@
 #include "nvim/memory.h"
 #include "nvim/viml/parser/parser.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "viml/parser/parser.c.generated.h"  // IWYU pragma: export
-#endif
+#include "viml/parser/parser.c.generated.h"  // IWYU pragma: export
 
 void parser_simple_get_line(void *cookie, ParserLine *ret_pline)
   FUNC_ATTR_NONNULL_ALL

--- a/src/nvim/viml/parser/parser.h
+++ b/src/nvim/viml/parser/parser.h
@@ -8,10 +8,8 @@
 #include "nvim/mbyte_defs.h"
 #include "nvim/viml/parser/parser_defs.h"  // IWYU pragma: keep
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "viml/parser/parser.h.generated.h"
-# include "viml/parser/parser.h.inline.generated.h"
-#endif
+#include "viml/parser/parser.h.generated.h"
+#include "viml/parser/parser.h.inline.generated.h"
 
 /// Initialize a new parser state instance
 ///

--- a/src/nvim/vterm/encoding.c
+++ b/src/nvim/vterm/encoding.c
@@ -1,9 +1,7 @@
 #include "nvim/vterm/encoding.h"
 #include "nvim/vterm/vterm_internal_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "vterm/encoding.c.generated.h"
-#endif
+#include "vterm/encoding.c.generated.h"
 
 #define UNICODE_INVALID 0xFFFD
 

--- a/src/nvim/vterm/encoding.h
+++ b/src/nvim/vterm/encoding.h
@@ -5,6 +5,4 @@
 #include "nvim/vterm/vterm_defs.h"
 #include "nvim/vterm/vterm_internal_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "vterm/encoding.h.generated.h"
-#endif
+#include "vterm/encoding.h.generated.h"

--- a/src/nvim/vterm/keyboard.c
+++ b/src/nvim/vterm/keyboard.c
@@ -6,9 +6,7 @@
 #include "nvim/vterm/vterm.h"
 #include "nvim/vterm/vterm_internal_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "vterm/keyboard.c.generated.h"
-#endif
+#include "vterm/keyboard.c.generated.h"
 
 static VTermKeyEncodingFlags vterm_state_get_key_encoding_flags(const VTermState *state)
 {

--- a/src/nvim/vterm/keyboard.h
+++ b/src/nvim/vterm/keyboard.h
@@ -5,6 +5,4 @@
 #include "nvim/vterm/vterm_defs.h"
 #include "nvim/vterm/vterm_keycodes_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "vterm/keyboard.h.generated.h"
-#endif
+#include "vterm/keyboard.h.generated.h"

--- a/src/nvim/vterm/mouse.c
+++ b/src/nvim/vterm/mouse.c
@@ -4,9 +4,7 @@
 #include "nvim/vterm/vterm.h"
 #include "nvim/vterm/vterm_internal_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "vterm/mouse.c.generated.h"
-#endif
+#include "vterm/mouse.c.generated.h"
 
 static void output_mouse(VTermState *state, int code, int pressed, int modifiers, int col, int row)
 {

--- a/src/nvim/vterm/mouse.h
+++ b/src/nvim/vterm/mouse.h
@@ -5,6 +5,4 @@
 #include "nvim/vterm/vterm_defs.h"
 #include "nvim/vterm/vterm_keycodes_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "vterm/mouse.h.generated.h"
-#endif
+#include "vterm/mouse.h.generated.h"

--- a/src/nvim/vterm/parser.c
+++ b/src/nvim/vterm/parser.c
@@ -6,9 +6,7 @@
 #include "nvim/vterm/vterm.h"
 #include "nvim/vterm/vterm_internal_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "vterm/parser.c.generated.h"
-#endif
+#include "vterm/parser.c.generated.h"
 
 #undef DEBUG_PARSER
 

--- a/src/nvim/vterm/parser.h
+++ b/src/nvim/vterm/parser.h
@@ -4,6 +4,4 @@
 
 #include "nvim/vterm/vterm_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "vterm/parser.h.generated.h"
-#endif
+#include "vterm/parser.h.generated.h"

--- a/src/nvim/vterm/pen.c
+++ b/src/nvim/vterm/pen.c
@@ -4,9 +4,7 @@
 #include "nvim/vterm/vterm.h"
 #include "nvim/vterm/vterm_internal_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "vterm/pen.c.generated.h"
-#endif
+#include "vterm/pen.c.generated.h"
 
 // Structure used to store RGB triples without the additional metadata stored in VTermColor.
 typedef struct {

--- a/src/nvim/vterm/pen.h
+++ b/src/nvim/vterm/pen.h
@@ -4,6 +4,4 @@
 
 #include "nvim/vterm/vterm_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "vterm/pen.h.generated.h"
-#endif
+#include "vterm/pen.h.generated.h"

--- a/src/nvim/vterm/screen.c
+++ b/src/nvim/vterm/screen.c
@@ -11,9 +11,7 @@
 #include "nvim/vterm/vterm_defs.h"
 #include "nvim/vterm/vterm_internal_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "vterm/screen.c.generated.h"
-#endif
+#include "vterm/screen.c.generated.h"
 
 #define UNICODE_SPACE 0x20
 #define UNICODE_LINEFEED 0x0a

--- a/src/nvim/vterm/screen.h
+++ b/src/nvim/vterm/screen.h
@@ -4,6 +4,4 @@
 
 #include "nvim/vterm/vterm_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "vterm/screen.h.generated.h"
-#endif
+#include "vterm/screen.h.generated.h"

--- a/src/nvim/vterm/state.c
+++ b/src/nvim/vterm/state.c
@@ -11,9 +11,7 @@
 #include "nvim/vterm/vterm.h"
 #include "nvim/vterm/vterm_internal_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "vterm/state.c.generated.h"
-#endif
+#include "vterm/state.c.generated.h"
 
 #define strneq(a, b, n) (strncmp(a, b, n) == 0)
 

--- a/src/nvim/vterm/state.h
+++ b/src/nvim/vterm/state.h
@@ -2,6 +2,4 @@
 
 #include "nvim/vterm/vterm_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "vterm/state.h.generated.h"
-#endif
+#include "vterm/state.h.generated.h"

--- a/src/nvim/vterm/vterm.c
+++ b/src/nvim/vterm/vterm.c
@@ -10,9 +10,7 @@
 #include "nvim/vterm/vterm.h"
 #include "nvim/vterm/vterm_internal_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "vterm/vterm.c.generated.h"
-#endif
+#include "vterm/vterm.c.generated.h"
 
 // *****************
 // * API functions *

--- a/src/nvim/vterm/vterm.h
+++ b/src/nvim/vterm/vterm.h
@@ -10,9 +10,7 @@
 #include "nvim/vterm/vterm_defs.h"
 #include "nvim/vterm/vterm_keycodes_defs.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "vterm/vterm.h.generated.h"
-#endif
+#include "vterm/vterm.h.generated.h"
 
 #define VTERM_VERSION_MAJOR 0
 #define VTERM_VERSION_MINOR 3

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -82,9 +82,7 @@
 #include "nvim/window.h"
 #include "nvim/winfloat.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "window.c.generated.h"
-#endif
+#include "window.c.generated.h"
 
 #define NOWIN           ((win_T *)-1)   // non-existing window
 

--- a/src/nvim/window.h
+++ b/src/nvim/window.h
@@ -35,6 +35,4 @@ enum {
 
 EXTERN int tabpage_move_disallowed INIT( = 0);  ///< moving tabpages around disallowed
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "window.h.generated.h"
-#endif
+#include "window.h.generated.h"

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -33,9 +33,7 @@
 #include "nvim/window.h"
 #include "nvim/winfloat.h"
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "winfloat.c.generated.h"
-#endif
+#include "winfloat.c.generated.h"
 
 /// Create a new float.
 ///

--- a/src/nvim/winfloat.h
+++ b/src/nvim/winfloat.h
@@ -10,6 +10,4 @@
 /// SE -> kFloatAnchorSouth | kFloatAnchorEast
 EXTERN const char *const float_anchor_str[] INIT( = { "NW", "NE", "SW", "SE" });
 
-#ifdef INCLUDE_GENERATED_DECLARATIONS
-# include "winfloat.h.generated.h"
-#endif
+#include "winfloat.h.generated.h"

--- a/src/uncrustify.cfg
+++ b/src/uncrustify.cfg
@@ -3575,7 +3575,7 @@ pp_unbalanced_if_action         = 0        # unsigned number
 #
 
 # The regex for include category with priority 0.
-include_category_0              = ""         # string
+include_category_0              = "(?!.*generated.h\").*"             # string
 
 # The regex for include category with priority 1.
 include_category_1              = ""         # string
@@ -3768,5 +3768,5 @@ set CLASS_COLON                  REAL_FATTR_CONST
 set CLASS_COLON                  REAL_FATTR_NONNULL_ALL
 set CLASS_COLON                  REAL_FATTR_PURE
 set CLASS_COLON                  REAL_FATTR_WARN_UNUSED_RESULT
-# option(s) with 'not default' value: 136
+# option(s) with 'not default' value: 137
 #

--- a/test/unit/preprocess.lua
+++ b/test/unit/preprocess.lua
@@ -123,7 +123,6 @@ function Gcc:init_defines()
   self:define('EXTERN', nil, 'extern')
   self:define('INIT', { '...' }, '')
   self:define('_GNU_SOURCE')
-  self:define('INCLUDE_GENERATED_DECLARATIONS')
   self:define('UNIT_TESTING')
   self:define('UNIT_TESTING_LUA_PREPROCESSING')
   -- Needed for FreeBSD


### PR DESCRIPTION
These are not needed after #35129 but making uncrustify still play nice with them was a bit tricky.

Unfortunately `uncrustify --update-config-with-doc` breaks strings with backslashes. Something something don't trust a C/C++ formatter to format a YAML-like file.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
