### PR TITLE
vim-patch:54fb7ba: runtime(doc): remove mentioning of netrwSettings.vim

### DIFF
--- a/runtime/pack/dist/opt/netrw/doc/netrw.txt
+++ b/runtime/pack/dist/opt/netrw/doc/netrw.txt
@@ -6,8 +6,8 @@
 Original Author:  Charles E. Campbell
 Copyright: Copyright (C) 2017 Charles E Campbell    *netrw-copyright*
 	The VIM LICENSE applies to the files in this package, including
-        netrw.vim, netrw.txt, netrwSettings.vim, and
-	syntax/netrw.vim.  Like anything else that's free, netrw.vim and its
+	netrw.vim, netrw.txt, and syntax/netrw.vim.
+	Like anything else that's free, netrw.vim and its
 	associated files are provided *as is* and comes with no warranty of
 	any kind, either expressed or implied.  No guarantees of
 	merchantability.  No guarantees of suitability for any purpose.  By
@@ -97,7 +97,6 @@ Copyright: Copyright (C) 2017 Charles E Campbell    *netrw-copyright*
       Marked Files: Unmarking.............................|netrw-mu|
       Netrw Browser Variables.............................|netrw-browser-var|
       Netrw Browsing And Option Incompatibilities.........|netrw-incompatible|
-      Netrw Settings Window...............................|netrw-settings-window|
       Obtaining A File....................................|netrw-O|
       Preview Window......................................|netrw-p|
       Previous Window.....................................|netrw-P|
@@ -120,7 +119,7 @@ you'll need to have at least the following in your <.vimrc>:
 	set nocp                    " 'compatible' is not set
 	filetype plugin on          " plugins are enabled
 <
-(see |'cp'| and |:filetype-plugin-on|)
+(see 'cp' and |:filetype-plugin-on|)
 
 Netrw supports "transparent" editing of files on other machines using urls
 (see |netrw-transparent|). As an example of this, let's assume you have an
@@ -675,7 +674,7 @@ However, |netrw-ssh-hack| can help with this problem.
 5. Activation						*netrw-activate* {{{1
 
 Network-oriented file transfers are available by default whenever Vim's
-|'nocompatible'| mode is enabled.  Netrw's script files reside in your
+'nocompatible' mode is enabled.  Netrw's script files reside in your
 system's plugin, autoload, and syntax directories; just the
 plugin/netrwPlugin.vim script is sourced automatically whenever you bring up
 vim.  The main script in autoload/netrw.vim is only loaded when you actually
@@ -1179,7 +1178,7 @@ The :NetrwMB command is available outside of netrw buffers (once netrw has been
 invoked in the session).
 
 The file ".netrwbook" holds bookmarks when netrw (and vim) is not active.  By
-default, its stored on the first directory on the user's |'runtimepath'|.
+default, its stored on the first directory on the user's 'runtimepath'.
 
 Related Topics:
 	|netrw-gb| how to return (go) to a bookmark
@@ -1405,7 +1404,7 @@ used in that count.
 See |g:netrw_dirhistmax| for how to control the quantity of history stack
 slots.  The file ".netrwhist" holds history when netrw (and vim) is not
 active.  By default, its stored on the first directory on the user's
-|'runtimepath'|.
+'runtimepath'.
 
 Related Topics:
 	|netrw-U| changing to a successor directory
@@ -1538,7 +1537,7 @@ DIRECTORY EXPLORATION COMMANDS  {{{2
 						*netrw-:Explore*
 :Explore  will open the local-directory browser on the current file's
           directory (or on directory [dir] if specified).  The window will be
-	  split only if the file has been modified and |'hidden'| is not set,
+	  split only if the file has been modified and 'hidden' is not set,
 	  otherwise the browsing window will take over that window.  Normally
 	  the splitting is taken horizontally.
 	  Also see: |netrw-:Rexplore|
@@ -2423,11 +2422,11 @@ your browsing preferences.  (see also: |netrw-settings|)
 
   *g:netrw_alto*		change from above splitting to below splitting
 				by setting this variable (see |netrw-o|)
-				 default: =&sb           (see |'sb'|)
+				 default: =&sb           (see 'sb')
 
   *g:netrw_altv*		change from left splitting to right splitting
 				by setting this variable (see |netrw-v|)
-				 default: =&spr          (see |'spr'|)
+				 default: =&spr          (see 'spr')
 
   *g:netrw_banner*		enable/suppress the banner
 				=0: suppress the banner
@@ -2494,7 +2493,7 @@ your browsing preferences.  (see also: |netrw-settings|)
 
   *g:netrw_cursor*		= 2 (default)
 				This option controls the use of the
-				|'cursorline'| (cul) and |'cursorcolumn'|
+				'cursorline' (cul) and 'cursorcolumn'
 				(cuc) settings by netrw:
 
 				Value   Thin-Long-Tree      Wide
@@ -2509,15 +2508,15 @@ your browsing preferences.  (see also: |netrw-settings|)
 				 =8        cul U-cuc        cul   cuc
 
 				Where
-				  u-cul : user's |'cursorline'|   initial setting used
-				  u-cuc : user's |'cursorcolumn'| initial setting used
-				  U-cul : user's |'cursorline'|   current setting used
-				  U-cuc : user's |'cursorcolumn'| current setting used
-				  cul   : |'cursorline'|   will be locally set
-				  cuc   : |'cursorcolumn'| will be locally set
+				  u-cul : user's 'cursorline'   initial setting used
+				  u-cuc : user's 'cursorcolumn' initial setting used
+				  U-cul : user's 'cursorline'   current setting used
+				  U-cuc : user's 'cursorcolumn' current setting used
+				  cul   : 'cursorline'   will be locally set
+				  cuc   : 'cursorcolumn' will be locally set
 
 				  The "initial setting" means the values of
-				  the |'cuc'| and |'cul'| settings in effect when
+				  the 'cuc' and 'cul' settings in effect when
 				  netrw last saw |g:netrw_cursor| >= 5 or when
 				  netrw was initially run.
 
@@ -2594,7 +2593,7 @@ your browsing preferences.  (see also: |netrw-settings|)
   *g:netrw_ffkeep*		(default: doesn't exist)
 				If this variable exists and is zero, then
 				netrw will not do a save and restore for
-				|'fileformat'|.
+				'fileformat'.
 
   *g:netrw_fname_escape*	=' ?&;%'
 				Used on filenames before remote reading/writing
@@ -2846,7 +2845,7 @@ your browsing preferences.  (see also: |netrw-settings|)
 					netrwYacc    : *.y
 
 				In addition, those groups mentioned in
-				|'suffixes'| are also added to the special
+				'suffixes' are also added to the special
 				file highlighting group.
 				 These syntax highlighting groups are linked
 				to netrwGray or Folded by default
@@ -2932,7 +2931,7 @@ your browsing preferences.  (see also: |netrw-settings|)
 				used to specify the quantity of lines or
 				columns for the new window.
 				 If g:netrw_winsize is zero, then a normal
-				split will be made (ie. |'equalalways'| will
+				split will be made (ie. 'equalalways' will
 				take effect, for example).
 				 default: 50  (for 50%)
 
@@ -2951,7 +2950,7 @@ your browsing preferences.  (see also: |netrw-settings|)
 				    codepoint; a hard tab is one; wide and
 				    narrow CJK are one each; etc.)
 				=3: virtual length (counting tabs as anything
-				    between 1 and |'tabstop'|, wide CJK as 2
+				    between 1 and 'tabstop', wide CJK as 2
 				    rather than 1, Arabic alif as zero when
 				    immediately preceded by lam, one
 				    otherwise, etc)
@@ -3043,7 +3042,7 @@ These will:
 	Related: if you like this idea, you may also find :Lexplore
 	         (|netrw-:Lexplore|) or |g:netrw_chgwin| of interest
 
-Also see: |g:netrw_chgwin| |netrw-P| |'previewwindow'| |CTRL-W_z| |:pclose|
+Also see: |g:netrw_chgwin| |netrw-P| 'previewwindow' |CTRL-W_z| |:pclose|
 
 
 PREVIOUS WINDOW					*netrw-P* *netrw-prvwin* {{{2
@@ -3441,7 +3440,7 @@ Example: Clear netrw's marked file list via a mapping on gu >
 		not by netrw, and there appears to be no way to work around
 		it.  Coupled with the default cmdheight of 1, this message
 		causes the "Press ENTER..." prompt.  So:  read |hit-enter|;
-		I also suggest that you set your |'cmdheight'| to 2 (or more) in
+		I also suggest that you set your 'cmdheight' to 2 (or more) in
 		your <.vimrc> file.
 
 								*netrw-p10*
@@ -3560,7 +3559,7 @@ Example: Clear netrw's marked file list via a mapping on gu >
 		I expect both buffers to exist, but only the last one does.
 
 	   (Lance) Problem is caused by "set autochdir" in .vimrc.
-	   (drchip) I am able to duplicate this problem with |'acd'| set.
+	   (drchip) I am able to duplicate this problem with 'acd' set.
 	            It appears that the buffers are not exactly closed;
 		    a ":ls!" will show them (although ":ls" does not).
 


### PR DESCRIPTION
#### vim-patch:54fb7ba: runtime(doc): remove mentioning of netrwSettings.vim

closes: vim/vim#17925

https://github.com/vim/vim/commit/54fb7ba25665b4a9cc9dc8639f2292e62b43d677

Co-authored-by: Lane East <laneast@laneast.com>