### PR TITLE
vim-patch:9.1.1596: tests: Test_search_wildmenu_iminsert() depends on help file

### DIFF
--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -489,21 +489,21 @@ describe('cmdline', function()
 
   -- oldtest: Test_search_wildmenu_iminsert()
   it('search wildmenu pum with iminsert=1', function()
-    local screen = Screen.new(65, 20)
+    local screen = Screen.new(65, 12)
     exec([[
       set wop=pum imi=1
       setlocal iskeyword=!-~,192-255
       call setline(1, [
-            \ " global toggle global-local global/local glyphs toggles English",
-            \ "accordingly. toggled accordingly single-byte glob() glob(pat,",
-            \ "English, 'gli' global-ime single-repeat 'toggle' 'toggle'.",
+            \ "global toggle global-local global/local glyphs toggles English",
+            \ "accordingly. toggled accordingly single-byte",
             \ ])
+      call cursor(2, 42)
     ]])
     feed('/gl<Tab>')
     screen:expect([[
-      {12: global         }lobal-local global/local glyphs toggles English  |
-      {4: gle            }gled accordingly single-byte glob() glob(pat,    |
-      {4: global-local   }lobal-ime single-repeat 'toggle' 'toggle'.       |
+      {12: global         }obal-local global/local glyphs toggles English   |
+      {4: gle            }gled accordingly single-byte                     |
+      {4: global-local   }{1:                                                 }|
       {4: global/local   }{1:                                                 }|
       {4: glyphs         }{1:                                                 }|
       {4: gles           }{1:                                                 }|
@@ -512,14 +512,6 @@ describe('cmdline', function()
       {4: gled           }{1:                                                 }|
       {4: gly            }{1:                                                 }|
       {4: gle-byte       }{1:                                                 }|
-      {4: glob()         }{1:                                                 }|
-      {4: glob(pat,      }{1:                                                 }|
-      {4: glish,         }{1:                                                 }|
-      {4: gli'           }{1:                                                 }|
-      {4: global-ime     }{1:                                                 }|
-      {4: gle-repeat     }{1:                                                 }|
-      {4: gle'           }{1:                                                 }|
-      {4: gle'.          }{1:                                                 }|
       /global^                                                          |
     ]])
   end)

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -3751,7 +3751,7 @@ describe('builtin popupmenu', function()
         ]])
       end
 
-      -- not rightleft on the cmdline
+      -- oldtest: Test_wildmenu_pum_rightleft()
       feed('<esc>:sign ')
       if multigrid then
         screen:expect([[
@@ -3771,9 +3771,8 @@ describe('builtin popupmenu', function()
           :sign ^                          |
         ]])
       end
-
-      -- oldtest: Test_wildmenu_pum_rightleft()
-      feed('<tab>')
+      -- Not rightleft on the cmdline.
+      feed('<Tab>')
       if multigrid then
         screen:expect({
           grid = [[
@@ -3808,6 +3807,15 @@ describe('builtin popupmenu', function()
           :sign define^                    |
         ]])
       end
+
+      -- Behavior is the same when using 'keymap'.
+      feed('<Esc>')
+      command('set keymap=dvorak')
+      -- ";gul" -> "sign" when using Dvorak keymap.
+      feed(':<C-^>;gul <Tab>')
+      screen:expect_unchanged(true)
+      feed('<Esc>')
+      command('set keymap&')
     end)
 
     it('with rightleft vsplits', function()

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -3095,6 +3095,14 @@ func Test_wildmenu_pum_rightleft()
   call term_sendkeys(buf, ":sign \<Tab>")
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_rl', {})
 
+  " Behavior is the same when using 'keymap'.
+  call term_sendkeys(buf, "\<Esc>:set keymap=dvorak\<CR>")
+  call TermWait(buf)
+  " ";gul" -> "sign" when using Dvorak keymap.
+  call term_sendkeys(buf, ":\<C-^>;gul \<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_rl', {})
+  call term_sendkeys(buf, "\<Esc>:set keymap&\<CR>")
+
   call StopVimInTerminal(buf)
 endfunc
 
@@ -4661,10 +4669,15 @@ func Test_search_wildmenu_iminsert()
 
   let lines =<< trim [SCRIPT]
     set wop=pum imi=1
-    h wildoptions
+    setlocal iskeyword=!-~,192-255
+    call setline(1, [
+          \ "global toggle global-local global/local glyphs toggles English",
+          \ "accordingly. toggled accordingly single-byte",
+          \ ])
+    call cursor(2, 42)
   [SCRIPT]
   call writefile(lines, 'XTest_search_wildmenu', 'D')
-  let buf = RunVimInTerminal('-S XTest_search_wildmenu', {'rows': 20})
+  let buf = RunVimInTerminal('-S XTest_search_wildmenu', {'rows': 12})
 
   call term_sendkeys(buf, "/gl\<Tab>")
   call TermWait(buf, 50)


### PR DESCRIPTION
#### vim-patch:9.1.1596: tests: Test_search_wildmenu_iminsert() depends on help file

Problem:  tests: Test_search_wildmenu_iminsert() depends on help file
          (after 9.1.1594).
Solution: Set buffer text using setline() instead of loading help file.
          Add a test for another bug fixed by 9.1.1594 (zeertzjq).

related: vim/vim#17870
closes: vim/vim#17922

https://github.com/vim/vim/commit/615ad4ced1825d2c6099b4bc36312c02b6c01c8a