### PR TITLE
vim-patch:93f6454: runtime(openscad): add a filetype plugin

### DIFF
--- a/runtime/ftplugin/openscad.vim
+++ b/runtime/ftplugin/openscad.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin file
+" Language:    OpenSCAD (https://openscad.org)
+" Maintainer:  Zachary Scheiman <me@zacharyscheiman.com>
+" Last Change: 2025 Aug 3
+
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+" Comments in openscad follow C/C++ syntax
+setlocal commentstring=//\ %s
+
+let b:undo_ftplugin = 'setl commentstring<'


### PR DESCRIPTION
closes: vim/vim#17902

https://github.com/vim/vim/commit/93f6454724ba62035f7292e4ec62f1bc96a7dc46

Co-authored-by: Squibid <me@zacharyscheiman.com>
