### PR TITLE
fix(:restart): formalize restart event

### DIFF
--- a/runtime/doc/api-ui-events.txt
+++ b/runtime/doc/api-ui-events.txt
@@ -249,8 +249,8 @@ the editor.
 
 ["restart", listen_addr, command] ~
 	|:restart| command has been used and the Nvim server is about to exit.
-	The UI should wait for EOF on the server's channel, and then attach to
-	the new server's listening address at `listen_addr`, and finally execute
+	After the current server's channel is closed, the UI should attach to
+	the new server's listening address at `listen_addr`, and then execute
 	`command` on the new server.
 
 ["suspend"] ~

--- a/runtime/doc/api-ui-events.txt
+++ b/runtime/doc/api-ui-events.txt
@@ -247,13 +247,11 @@ the editor.
 	Indicates to the UI that it must stop rendering the cursor. This event
 	is misnamed and does not actually have anything to do with busyness.
 
-["restart", progpath, argv] ~
+["restart", listen_addr, command] ~
 	|:restart| command has been used and the Nvim server is about to exit.
-	The UI should wait for the server to exit, and then start a new server
-	using `progpath` as the full path to the Nvim executable |v:progpath| and
-	`argv` as its arguments |v:argv|, and reattach to the new server.
-	Note: |--embed| and |--headless| are excluded from `argv`, and the client
-	should decide itself whether to add either flag.
+	The UI should wait for EOF on the server's channel, and then attach to
+	the new server's listening address at `listen_addr`, and finally execute
+	`command` on the new server.
 
 ["suspend"] ~
 	|:suspend| command or |CTRL-Z| mapping is used. A terminal client (or

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1687,6 +1687,19 @@ nvim_strwidth({text})                                        *nvim_strwidth()*
     Return: ~
         (`integer`) Number of cells
 
+nvim__chan_set_detach({detach})                      *nvim__chan_set_detach()*
+    WARNING: This feature is experimental/unstable.
+
+    Sets the detach flag for the channel.
+
+    Detached channels do not trigger self-exit when they are closed.
+
+    Attributes: ~
+        |RPC| only
+
+    Parameters: ~
+      • {detach}  (`boolean`) New detach value for the channel.
+
 nvim__complete_set({index}, {opts})                     *nvim__complete_set()*
     WARNING: This feature is experimental/unstable.
 

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1696,6 +1696,7 @@ nvim__chan_set_detach({detach})                      *nvim__chan_set_detach()*
 
     Attributes: ~
         |RPC| only
+        Since: 0.12.0
 
     Parameters: ~
       • {detach}  (`boolean`) New detach value for the channel.

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -87,7 +87,7 @@ Restart Nvim
 <
                 Note: Only works if the UI and server are on the same system.
                 Note: If the UI hasn't implemented the "restart" UI event,
-                this command is equivalent to `:qall` (or |+cmd|, if given).
+                this command will lead to a dangling server process.
 
 ------------------------------------------------------------------------------
 Connect UI to a different server

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -74,9 +74,9 @@ Restart Nvim
                 1. Stops Nvim using `:qall` (or |+cmd|, if given).
                 2. Starts a new Nvim server using the same |v:argv| (except
                    `-- [file…]` files), appended with `-c [command]`.
-                3. Attaches the current UI to the new Nvim server. Other UIs
-                   (if any) will not reattach on restart (this may change in
-                   the future).
+                3. Attaches the current UI to the new Nvim server and runs
+                   `[command]` on it. Other UIs (if any) will not reattach
+                   on restart (this may change in the future).
 
                 Example: discard changes and stop with `:qall!`, then restart: >
                     :restart +qall!

--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -73,7 +73,7 @@ Restart Nvim
 
                 1. Stops Nvim using `:qall` (or |+cmd|, if given).
                 2. Starts a new Nvim server using the same |v:argv| (except
-                   `-- [file…]` files), appended with `-c [command]`.
+                   `-- [file…]` files).
                 3. Attaches the current UI to the new Nvim server and runs
                    `[command]` on it. Other UIs (if any) will not reattach
                    on restart (this may change in the future).

--- a/src/nvim/api/ui.c
+++ b/src/nvim/api/ui.c
@@ -282,6 +282,7 @@ bool remote_ui_restart(uint64_t channel_id, const char *listen_addr, String comm
   ADD_C(args, STRING_OBJ(command));
 
   push_call(ui, "restart", args);
+  ui_flush_buf(ui, false);
   return true;
 }
 

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -29,7 +29,7 @@ void flush(void)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_IMPL;
 void connect(Array args)
   FUNC_API_SINCE(14) FUNC_API_REMOTE_ONLY FUNC_API_REMOTE_IMPL FUNC_API_CLIENT_IMPL;
-void restart(String progpath, Array argv)
+void restart(String listen_addr, String command)
   FUNC_API_SINCE(14) FUNC_API_REMOTE_ONLY FUNC_API_REMOTE_IMPL FUNC_API_CLIENT_IMPL;
 void suspend(void)
   FUNC_API_SINCE(3);

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -1717,6 +1717,24 @@ void nvim_set_client_info(uint64_t channel_id, String name, Dict version, String
   rpc_set_client_info(channel_id, copy_dict(info, NULL));
 }
 
+/// Sets the detach flag for the channel.
+///
+/// Detached channels do not trigger self-exit when they are closed.
+///
+/// @param channel_id
+/// @param detach   New detach value for the channel.
+/// @param[out] err Error details, if any.
+void nvim__chan_set_detach(uint64_t channel_id, Boolean detach, Error *err)
+  FUNC_API_SINCE(14) FUNC_API_REMOTE_ONLY
+{
+  Channel *chan = find_channel(channel_id);
+  VALIDATE(chan != NULL, "%s", e_invchan, {
+    return;
+  });
+
+  chan->detach = (bool)detach;
+}
+
 /// Gets information about a channel.
 ///
 /// See |nvim_list_uis()| for an example of how to get channel info.

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -42,6 +42,7 @@
 #include "nvim/os/shell.h"
 #include "nvim/terminal.h"
 #include "nvim/types_defs.h"
+#include "nvim/ui_client.h"
 
 #ifdef MSWIN
 # include "nvim/os/fs.h"
@@ -779,6 +780,21 @@ static void channel_proc_exit_cb(Proc *proc, int status, void *data)
   Channel *chan = data;
   if (chan->term) {
     terminal_close(&chan->term, status);
+  }
+
+  // TODO(justinmk): figure out why rpc_close sometimes(??) isn't called.
+  // Theories:
+  // - EOF not received in receive_msgpack, then doesn't call chan_close_on_err().
+  // - proc_close_handles not tickled by ui_client.c's LOOP_PROCESS_EVENTS?
+  if (ui_client_channel_id == chan->id) {
+    // Need to call ui_client_attach_to_restarted_server() here as well, as sometimes
+    // rpc_close_event() hasn't been called yet (also see comments above).
+    ui_client_attach_to_restarted_server();
+    if (ui_client_channel_id == chan->id) {
+      // If the current embedded server has exited and no new server is started,
+      // the client should exit with the same status.
+      exit_on_closed_chan(status);
+    }
   }
 
   // If process did not exit, we only closed the handle of a detached process.

--- a/src/nvim/channel.c
+++ b/src/nvim/channel.c
@@ -786,7 +786,7 @@ static void channel_proc_exit_cb(Proc *proc, int status, void *data)
   // Theories:
   // - EOF not received in receive_msgpack, then doesn't call chan_close_on_err().
   // - proc_close_handles not tickled by ui_client.c's LOOP_PROCESS_EVENTS?
-  if (ui_client_channel_id == chan->id) {
+  if (!exiting && ui_client_channel_id == chan->id) {
     // Need to call ui_client_attach_to_restarted_server() here as well, as sometimes
     // rpc_close_event() hasn't been called yet (also see comments above).
     ui_client_attach_to_restarted_server();

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6409,7 +6409,7 @@ static void f_serverstop(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   rettv->v_type = VAR_NUMBER;
   rettv->vval.v_number = 0;
   if (argvars[0].vval.v_string) {
-    bool rv = server_stop(argvars[0].vval.v_string, false, false);
+    bool rv = server_stop(argvars[0].vval.v_string, false);
     rettv->vval.v_number = (rv ? 1 : 0);
   }
 }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6409,7 +6409,7 @@ static void f_serverstop(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   rettv->v_type = VAR_NUMBER;
   rettv->vval.v_number = 0;
   if (argvars[0].vval.v_string) {
-    bool rv = server_stop(argvars[0].vval.v_string);
+    bool rv = server_stop(argvars[0].vval.v_string, false);
     rettv->vval.v_number = (rv ? 1 : 0);
   }
 }

--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -6409,7 +6409,7 @@ static void f_serverstop(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   rettv->v_type = VAR_NUMBER;
   rettv->vval.v_number = 0;
   if (argvars[0].vval.v_string) {
-    bool rv = server_stop(argvars[0].vval.v_string, false);
+    bool rv = server_stop(argvars[0].vval.v_string, false, false);
     rettv->vval.v_number = (rv ? 1 : 0);
   }
 }

--- a/src/nvim/event/proc.c
+++ b/src/nvim/event/proc.c
@@ -478,7 +478,7 @@ static void on_proc_exit(Proc *proc)
         && proc == &server_chan->stream.proc) {
       // Need to call ui_client_may_restart_server() here as well, as sometimes
       // rpc_close_event() hasn't been called yet (also see comments above).
-      ui_client_may_restart_server();
+      ui_client_attach_to_restarted_server();
       if (ui_client_channel_id == server_chan_id) {
         // If the current embedded server has exited and no new server is started,
         // the client should exit with the same status.

--- a/src/nvim/event/proc.c
+++ b/src/nvim/event/proc.c
@@ -5,7 +5,6 @@
 #include <uv.h>
 
 #include "klib/kvec.h"
-#include "nvim/channel.h"
 #include "nvim/event/libuv_proc.h"
 #include "nvim/event/loop.h"
 #include "nvim/event/multiqueue.h"
@@ -466,26 +465,6 @@ static void on_proc_exit(Proc *proc)
 {
   Loop *loop = proc->loop;
   ILOG("child exited: pid=%d status=%d" PRIu64, proc->pid, proc->status);
-
-  // TODO(justinmk): figure out why rpc_close sometimes(??) isn't called.
-  // Theories:
-  // - EOF not received in receive_msgpack, then doesn't call chan_close_on_err().
-  // - proc_close_handles not tickled by ui_client.c's LOOP_PROCESS_EVENTS?
-  if (ui_client_channel_id) {
-    uint64_t server_chan_id = ui_client_channel_id;
-    Channel *server_chan = find_channel(server_chan_id);
-    if (server_chan != NULL && server_chan->streamtype == kChannelStreamProc
-        && proc == &server_chan->stream.proc) {
-      // Need to call ui_client_attach_to_restarted_server() here as well, as sometimes
-      // rpc_close_event() hasn't been called yet (also see comments above).
-      ui_client_attach_to_restarted_server();
-      if (ui_client_channel_id == server_chan_id) {
-        // If the current embedded server has exited and no new server is started,
-        // the client should exit with the same status.
-        exit_on_closed_chan(proc->status);
-      }
-    }
-  }
 
   // Process has terminated, but there could still be data to be read from the
   // OS. We are still in the libuv loop, so we cannot call code that polls for

--- a/src/nvim/event/proc.c
+++ b/src/nvim/event/proc.c
@@ -476,7 +476,7 @@ static void on_proc_exit(Proc *proc)
     Channel *server_chan = find_channel(server_chan_id);
     if (server_chan != NULL && server_chan->streamtype == kChannelStreamProc
         && proc == &server_chan->stream.proc) {
-      // Need to call ui_client_may_restart_server() here as well, as sometimes
+      // Need to call ui_client_attach_to_restarted_server() here as well, as sometimes
       // rpc_close_event() hasn't been called yet (also see comments above).
       ui_client_attach_to_restarted_server();
       if (ui_client_channel_id == server_chan_id) {

--- a/src/nvim/event/proc.c
+++ b/src/nvim/event/proc.c
@@ -462,6 +462,20 @@ void exit_on_closed_chan(int status)
   multiqueue_put(main_loop.fast_events, exit_event, (void *)(intptr_t)status);
 }
 
+static void child_server_exit_event(void **argv)
+{
+  int status = (int)(intptr_t)argv[0];
+  uint64_t server_chan_id = (uint64_t)(intptr_t)argv[1];
+  // Need to call ui_client_attach_to_restarted_server() here as well, as sometimes
+  // rpc_close_event() hasn't been called yet (also see comments in on_proc_exit()).
+  ui_client_attach_to_restarted_server();
+  if (ui_client_channel_id == server_chan_id) {
+    // If the current embedded server has exited and no new server is started,
+    // the client should exit with the same status.
+    exit_on_closed_chan(status);
+  }
+}
+
 static void on_proc_exit(Proc *proc)
 {
   Loop *loop = proc->loop;
@@ -476,14 +490,9 @@ static void on_proc_exit(Proc *proc)
     Channel *server_chan = find_channel(server_chan_id);
     if (server_chan != NULL && server_chan->streamtype == kChannelStreamProc
         && proc == &server_chan->stream.proc) {
-      // Need to call ui_client_attach_to_restarted_server() here as well, as sometimes
-      // rpc_close_event() hasn't been called yet (also see comments above).
-      ui_client_attach_to_restarted_server();
-      if (ui_client_channel_id == server_chan_id) {
-        // If the current embedded server has exited and no new server is started,
-        // the client should exit with the same status.
-        exit_on_closed_chan(proc->status);
-      }
+      // Schedule this as ui_client_attach_to_restarted_server() runs event loop.
+      multiqueue_put(main_loop.fast_events, child_server_exit_event,
+                     (void *)(intptr_t)proc->status, (void *)(intptr_t)server_chan_id);
     }
   }
 

--- a/src/nvim/event/proc.c
+++ b/src/nvim/event/proc.c
@@ -462,20 +462,6 @@ void exit_on_closed_chan(int status)
   multiqueue_put(main_loop.fast_events, exit_event, (void *)(intptr_t)status);
 }
 
-static void child_server_exit_event(void **argv)
-{
-  int status = (int)(intptr_t)argv[0];
-  uint64_t server_chan_id = (uint64_t)(intptr_t)argv[1];
-  // Need to call ui_client_attach_to_restarted_server() here as well, as sometimes
-  // rpc_close_event() hasn't been called yet (also see comments in on_proc_exit()).
-  ui_client_attach_to_restarted_server();
-  if (ui_client_channel_id == server_chan_id) {
-    // If the current embedded server has exited and no new server is started,
-    // the client should exit with the same status.
-    exit_on_closed_chan(status);
-  }
-}
-
 static void on_proc_exit(Proc *proc)
 {
   Loop *loop = proc->loop;
@@ -490,9 +476,14 @@ static void on_proc_exit(Proc *proc)
     Channel *server_chan = find_channel(server_chan_id);
     if (server_chan != NULL && server_chan->streamtype == kChannelStreamProc
         && proc == &server_chan->stream.proc) {
-      // Schedule this as ui_client_attach_to_restarted_server() runs event loop.
-      multiqueue_put(main_loop.fast_events, child_server_exit_event,
-                     (void *)(intptr_t)proc->status, (void *)(intptr_t)server_chan_id);
+      // Need to call ui_client_attach_to_restarted_server() here as well, as sometimes
+      // rpc_close_event() hasn't been called yet (also see comments above).
+      ui_client_attach_to_restarted_server();
+      if (ui_client_channel_id == server_chan_id) {
+        // If the current embedded server has exited and no new server is started,
+        // the client should exit with the same status.
+        exit_on_closed_chan(proc->status);
+      }
     }
   }
 

--- a/src/nvim/event/socket.c
+++ b/src/nvim/event/socket.c
@@ -14,6 +14,7 @@
 #include "nvim/event/stream.h"
 #include "nvim/gettext_defs.h"
 #include "nvim/log.h"
+#include "nvim/macros_defs.h"
 #include "nvim/main.h"
 #include "nvim/memory.h"
 #include "nvim/os/fs.h"

--- a/src/nvim/event/socket.c
+++ b/src/nvim/event/socket.c
@@ -14,7 +14,6 @@
 #include "nvim/event/stream.h"
 #include "nvim/gettext_defs.h"
 #include "nvim/log.h"
-#include "nvim/macros_defs.h"
 #include "nvim/main.h"
 #include "nvim/memory.h"
 #include "nvim/os/fs.h"

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5076,7 +5076,7 @@ static void ex_restart(exarg_T *eap)
 
   // Kill the new nvim server.
   const int pid = channel->stream.proc.pid;
-  if (!os_proc_tree_kill(pid, SIGKILL)) {
+  if (!os_proc_tree_kill(pid, SIGTERM)) {
     emsg("killing new nvim server failed");
   }
 }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5005,14 +5005,6 @@ static void ex_restart(exarg_T *eap)
 
   bool server_stopped = false;
   if (listen_arg != NULL) {
-    // Send restart event with --listen address to current UI.
-    if (!remote_ui_restart(current_ui, listen_arg, cstr_as_string(eap->arg), &err)) {
-      if (ERROR_SET(&err)) {
-        ELOG("%s", err.msg);  // UI disappeared already?
-        api_clear_error(&err);
-      }
-      return;
-    }
     // Stop listening on the --listen address so that the new server can listen.
     server_stopped = server_stop(listen_arg, true, true);
   }
@@ -5046,37 +5038,35 @@ static void ex_restart(exarg_T *eap)
   }
   arena_mem_free(result_mem);
 
-  if (listen_arg == NULL) {
-    // Get new server's listen address.
-    MAXSIZE_TEMP_ARRAY(servername_args, 1);
-    ADD_C(servername_args, CSTR_AS_OBJ("servername"));
-    result_mem = NULL;
-    Object result = rpc_send_call(channel->id, "nvim_get_vvar", servername_args, &result_mem, &err);
-    if (ERROR_SET(&err)) {
-      emsg(err.msg);
-      api_clear_error(&err);
-      arena_mem_free(result_mem);
-      return;
-    }
-    if (result.type != kObjectTypeString || result.data.string.size == 0) {
-      arena_mem_free(result_mem);
-      emsg("restart failed: could not get listen address from new server");
-      return;
-    }
-    char *listen_addr = xmemdupz(result.data.string.data, result.data.string.size);
+  // Get new server's listen address.
+  MAXSIZE_TEMP_ARRAY(servername_args, 1);
+  ADD_C(servername_args, CSTR_AS_OBJ("servername"));
+  result_mem = NULL;
+  Object result = rpc_send_call(channel->id, "nvim_get_vvar", servername_args, &result_mem, &err);
+  if (ERROR_SET(&err)) {
+    emsg(err.msg);
+    api_clear_error(&err);
     arena_mem_free(result_mem);
+    return;
+  }
+  if (result.type != kObjectTypeString || result.data.string.size == 0) {
+    arena_mem_free(result_mem);
+    emsg("restart failed: could not get listen address from new server");
+    return;
+  }
+  char *listen_addr = xmemdupz(result.data.string.data, result.data.string.size);
+  arena_mem_free(result_mem);
 
-    // Send restart event with new listen address to current UI.
-    if (!remote_ui_restart(current_ui, listen_addr, cstr_as_string(eap->arg), &err)) {
-      if (ERROR_SET(&err)) {
-        ELOG("%s", err.msg);  // UI disappeared already?
-        api_clear_error(&err);
-      }
-      xfree(listen_addr);
-      return;
+  // Send restart event with new listen address to current UI.
+  if (!remote_ui_restart(current_ui, listen_addr, cstr_as_string(eap->arg), &err)) {
+    if (ERROR_SET(&err)) {
+      ELOG("%s", err.msg);  // UI disappeared already?
+      api_clear_error(&err);
     }
     xfree(listen_addr);
+    return;
   }
+  xfree(listen_addr);
 
   char *quit_cmd = (eap->do_ecmd_cmd) ? eap->do_ecmd_cmd : "qall";
   char *quit_cmd_copy = NULL;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4969,7 +4969,7 @@ static void ex_restart(exarg_T *eap)
 
   char **argv = xcalloc((size_t)argc + 3, sizeof(char *));
   size_t i = 0;
-  const char *listen_arg = NULL;
+  const char *listen_addr_deferred = NULL;
   TV_LIST_ITER_CONST(l, li, {
     const char *arg = tv_get_string(TV_LIST_ITEM_TV(li));
     // Drop "-- [files…]". Usually isn't wanted. User can :mksession instead.
@@ -4986,8 +4986,11 @@ static void ex_restart(exarg_T *eap)
       listitem_T *next_li = TV_LIST_ITEM_NEXT(l, li);
       if (next_li != NULL) {
         const char *addr = tv_get_string(TV_LIST_ITEM_TV(next_li));
-        if (strstr(addr, ":") || strstr(addr, "/") || strstr(addr, "\\")) {
-          listen_arg = addr;
+        if (server_find(addr)) {
+          // Drop --listen and its argument. Restore then later.
+          listen_addr_deferred = addr;
+          li = next_li;
+          continue;
         }
       }
     }
@@ -5002,12 +5005,6 @@ static void ex_restart(exarg_T *eap)
       }
     }
   });
-
-  bool server_stopped = false;
-  if (listen_arg != NULL) {
-    // Stop listening on the --listen address so that the new server can listen.
-    server_stopped = server_stop(listen_arg, true, true);
-  }
 
   CallbackReader on_err = CALLBACK_READER_INIT;
   // This temporary bootstrap channel is closed intentionally once we obtain
@@ -5068,6 +5065,35 @@ static void ex_restart(exarg_T *eap)
   }
   xfree(listen_addr);
 
+  lua_State *lstate = get_global_lstate();
+  lua_getglobal(lstate, "vim");
+  lua_getfield(lstate, -1, "_listen_addr");
+  char *listen_addr_from_lua = NULL;
+  if (lua_isstring(lstate, -1)) {
+    size_t len;
+    const char *s = lua_tolstring(lstate, -1, &len);
+    listen_addr_from_lua = xmemdupz(s, len);
+    listen_addr_deferred = listen_addr_from_lua;
+  }
+  lua_pop(lstate, 2);
+
+  if (listen_addr_deferred != NULL) {
+    (void)server_stop(listen_addr_deferred, true, true);
+
+    MAXSIZE_TEMP_ARRAY(serverstart_args, 1);
+    ADD_C(serverstart_args, CSTR_AS_OBJ(listen_addr_deferred));
+    MAXSIZE_TEMP_ARRAY(lua_args, 2);
+    // Save the listen address as vim._listen_addr, for further restarts.
+    ADD_C(lua_args, STATIC_CSTR_AS_OBJ("vim._listen_addr = vim.fn.serverstart(...)"));
+    ADD_C(lua_args, ARRAY_OBJ(serverstart_args));
+    result_mem = NULL;
+    rpc_send_call(channel->id, "nvim_exec_lua", lua_args, &result_mem, &err);
+    if (ERROR_SET(&err)) {
+      api_clear_error(&err);
+    }
+    arena_mem_free(result_mem);
+  }
+
   char *quit_cmd = (eap->do_ecmd_cmd) ? eap->do_ecmd_cmd : "qall";
   char *quit_cmd_copy = NULL;
 
@@ -5092,11 +5118,10 @@ static void ex_restart(exarg_T *eap)
     emsg("killing new nvim server failed");
   }
 
-  // Restart listening on the --listen address.
-  if (server_stopped && server_start(listen_arg) != 0) {
-    semsg("couldn't resume listening on %s", listen_arg);
-    return;
+  if (listen_addr_deferred != NULL && server_start(listen_addr_deferred) != 0) {
+    semsg("couldn't resume listening on %s", listen_addr_deferred);
   }
+  xfree(listen_addr_from_lua);
 }
 
 /// ":close": close current window, unless it is the last one

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4967,7 +4967,6 @@ static void ex_restart(exarg_T *eap)
   const list_T *l = get_vim_var_list(VV_ARGV);
   int argc = tv_list_len(l);
 
-
   char **argv = xcalloc((size_t)argc + 3, sizeof(char *));
   size_t i = 0;
   TV_LIST_ITER_CONST(l, li, {
@@ -5085,7 +5084,7 @@ static void ex_restart(exarg_T *eap)
   }
 
   // Reconnect to v:servername
-  if (!server_start(servername)) {
+  if (server_start(servername)) {
     emsg("couldn't start listening on v:servername");
     return;
   }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5005,6 +5005,9 @@ static void ex_restart(exarg_T *eap)
     emsg("couldn't stop listening on v:servername");
     return;
   }
+  if (socket_address_tcp_host_end(servername) == NULL) {  // is a pipe
+    os_remove(servername);
+  }
 
   Channel *channel = channel_job_start(argv, exepath,
                                        CALLBACK_READER_INIT, on_err, CALLBACK_NONE,

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5079,9 +5079,6 @@ static void ex_restart(exarg_T *eap)
 
   if (listen_addr_deferred != NULL) {
     (void)server_stop(listen_addr_deferred, true, true);
-    if (strchr(listen_addr_deferred, '/') || strchr(listen_addr_deferred, '\\')) {
-      os_remove(listen_addr_deferred);
-    }
 
     MAXSIZE_TEMP_ARRAY(serverstart_args, 1);
     ADD_C(serverstart_args, CSTR_AS_OBJ(listen_addr_deferred));

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4969,6 +4969,7 @@ static void ex_restart(exarg_T *eap)
 
   char **argv = xcalloc((size_t)argc + 3, sizeof(char *));
   size_t i = 0;
+  const char *listen_arg = NULL;
   TV_LIST_ITER_CONST(l, li, {
     const char *arg = tv_get_string(TV_LIST_ITEM_TV(li));
     // Drop "-- [files…]". Usually isn't wanted. User can :mksession instead.
@@ -4979,6 +4980,16 @@ static void ex_restart(exarg_T *eap)
     if (strequal(arg, "-s")) {
       li = TV_LIST_ITEM_NEXT(l, li);
       continue;
+    }
+    // The address after --listen may be in use by the current server.
+    if (strequal(arg, "--listen")) {
+      listitem_T *next_li = TV_LIST_ITEM_NEXT(l, li);
+      if (next_li != NULL) {
+        const char *addr = tv_get_string(TV_LIST_ITEM_TV(next_li));
+        if (strstr(addr, ":") || strstr(addr, "/") || strstr(addr, "\\")) {
+          listen_arg = addr;
+        }
+      }
     }
     // Replace `--embed` OR `--headless` with `--embed --headless` once.
     // Drop stdin ("-") argument.
@@ -4992,19 +5003,26 @@ static void ex_restart(exarg_T *eap)
     }
   });
 
+  bool server_stopped = false;
+  if (listen_arg != NULL) {
+    // Send restart event with --listen address to current UI.
+    if (!remote_ui_restart(current_ui, listen_arg, cstr_as_string(eap->arg), &err)) {
+      if (ERROR_SET(&err)) {
+        ELOG("%s", err.msg);  // UI disappeared already?
+        api_clear_error(&err);
+      }
+      return;
+    }
+    // Stop listening on the --listen address so that the new server can listen.
+    server_stopped = server_stop(listen_arg, true);
+  }
+
   CallbackReader on_err = CALLBACK_READER_INIT;
   // This temporary bootstrap channel is closed intentionally once we obtain
   // the new server address. Don't forward child stderr to the current UI.
   on_err.fwd_err = false;
   bool detach = true;
   varnumber_T exit_status;
-
-  // Stop listening on v:servername
-  char *servername = get_vim_var_str(VV_SEND_SERVER);
-  if (*servername != NUL && !server_stop(servername, true)) {
-    emsg("couldn't stop listening on v:servername");
-    return;
-  }
 
   Channel *channel = channel_job_start(argv, exepath,
                                        CALLBACK_READER_INIT, on_err, CALLBACK_NONE,
@@ -5015,27 +5033,8 @@ static void ex_restart(exarg_T *eap)
     return;
   }
 
-  // Get new server's listen address.
-  MAXSIZE_TEMP_ARRAY(servername_args, 1);
-  ADD_C(servername_args, CSTR_AS_OBJ("servername"));
-  ArenaMem result_mem = NULL;
-  Object result = rpc_send_call(channel->id, "nvim_get_vvar", servername_args, &result_mem, &err);
-  if (ERROR_SET(&err)) {
-    emsg(err.msg);
-    api_clear_error(&err);
-    arena_mem_free(result_mem);
-    return;
-  }
-  if (result.type != kObjectTypeString || result.data.string.size == 0) {
-    arena_mem_free(result_mem);
-    emsg("restart failed: could not get listen address from new server");
-    return;
-  }
-  char *listen_addr = xmemdupz(result.data.string.data, result.data.string.size);
-  arena_mem_free(result_mem);
-
   // Prevent new server from self-exiting when the channel closes.
-  result_mem = NULL;
+  ArenaMem result_mem = NULL;
   MAXSIZE_TEMP_ARRAY(detach_args, 1);
   ADD_C(detach_args, BOOLEAN_OBJ(true));
   rpc_send_call(channel->id, "nvim__chan_set_detach", detach_args, &result_mem, &err);
@@ -5043,21 +5042,41 @@ static void ex_restart(exarg_T *eap)
     emsg(err.msg);
     api_clear_error(&err);
     arena_mem_free(result_mem);
-    xfree(listen_addr);
     return;
   }
   arena_mem_free(result_mem);
 
-  // Send restart event to current UI.
-  if (!remote_ui_restart(current_ui, listen_addr, cstr_as_string(eap->arg), &err)) {
+  if (listen_arg == NULL) {
+    // Get new server's listen address.
+    MAXSIZE_TEMP_ARRAY(servername_args, 1);
+    ADD_C(servername_args, CSTR_AS_OBJ("servername"));
+    result_mem = NULL;
+    Object result = rpc_send_call(channel->id, "nvim_get_vvar", servername_args, &result_mem, &err);
     if (ERROR_SET(&err)) {
-      ELOG("%s", err.msg);  // UI disappeared already?
+      emsg(err.msg);
       api_clear_error(&err);
+      arena_mem_free(result_mem);
+      return;
+    }
+    if (result.type != kObjectTypeString || result.data.string.size == 0) {
+      arena_mem_free(result_mem);
+      emsg("restart failed: could not get listen address from new server");
+      return;
+    }
+    char *listen_addr = xmemdupz(result.data.string.data, result.data.string.size);
+    arena_mem_free(result_mem);
+
+    // Send restart event with new listen address to current UI.
+    if (!remote_ui_restart(current_ui, listen_addr, cstr_as_string(eap->arg), &err)) {
+      if (ERROR_SET(&err)) {
+        ELOG("%s", err.msg);  // UI disappeared already?
+        api_clear_error(&err);
+      }
+      xfree(listen_addr);
+      return;
     }
     xfree(listen_addr);
-    return;
   }
-  xfree(listen_addr);
 
   char *quit_cmd = (eap->do_ecmd_cmd) ? eap->do_ecmd_cmd : "qall";
   char *quit_cmd_copy = NULL;
@@ -5083,9 +5102,9 @@ static void ex_restart(exarg_T *eap)
     emsg("killing new nvim server failed");
   }
 
-  // Reconnect to v:servername
-  if (*servername != NUL && server_start(servername)) {
-    emsg("couldn't start listening on v:servername");
+  // Restart listening on the --listen address.
+  if (server_stopped && server_start(listen_arg) != 0) {
+    semsg("couldn't resume listening on %s", listen_arg);
     return;
   }
 }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5001,7 +5001,7 @@ static void ex_restart(exarg_T *eap)
 
   // Stop listening on v:servername
   char *servername = get_vim_var_str(VV_SEND_SERVER);
-  if (!server_stop(servername)) {
+  if (*servername != NUL && !server_stop(servername, true)) {
     emsg("couldn't stop listening on v:servername");
     return;
   }
@@ -5084,9 +5084,7 @@ static void ex_restart(exarg_T *eap)
   }
 
   // Reconnect to v:servername
-  // Unset v:servername first to reset it to the old value.
-  set_vim_var_string(VV_SEND_SERVER, "", -1);
-  if (server_start(servername)) {
+  if (*servername != NUL && server_start(servername)) {
     emsg("couldn't start listening on v:servername");
     return;
   }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4969,7 +4969,7 @@ static void ex_restart(exarg_T *eap)
 
   char **argv = xcalloc((size_t)argc + 3, sizeof(char *));
   size_t i = 0;
-  const char *listen_addr_deferred = NULL;
+  const char *listen_arg = NULL;
   TV_LIST_ITER_CONST(l, li, {
     const char *arg = tv_get_string(TV_LIST_ITEM_TV(li));
     // Drop "-- [files…]". Usually isn't wanted. User can :mksession instead.
@@ -4986,11 +4986,8 @@ static void ex_restart(exarg_T *eap)
       listitem_T *next_li = TV_LIST_ITEM_NEXT(l, li);
       if (next_li != NULL) {
         const char *addr = tv_get_string(TV_LIST_ITEM_TV(next_li));
-        if (server_find(addr)) {
-          // Drop --listen and its argument. Restore then later.
-          listen_addr_deferred = addr;
-          li = next_li;
-          continue;
+        if (strstr(addr, ":") || strstr(addr, "/") || strstr(addr, "\\")) {
+          listen_arg = addr;
         }
       }
     }
@@ -5005,6 +5002,12 @@ static void ex_restart(exarg_T *eap)
       }
     }
   });
+
+  bool server_stopped = false;
+  if (listen_arg != NULL) {
+    // Stop listening on the --listen address so that the new server can listen.
+    server_stopped = server_stop(listen_arg, true, true);
+  }
 
   CallbackReader on_err = CALLBACK_READER_INIT;
   // This temporary bootstrap channel is closed intentionally once we obtain
@@ -5065,35 +5068,6 @@ static void ex_restart(exarg_T *eap)
   }
   xfree(listen_addr);
 
-  lua_State *lstate = get_global_lstate();
-  lua_getglobal(lstate, "vim");
-  lua_getfield(lstate, -1, "_listen_addr");
-  char *listen_addr_from_lua = NULL;
-  if (lua_isstring(lstate, -1)) {
-    size_t len;
-    const char *s = lua_tolstring(lstate, -1, &len);
-    listen_addr_from_lua = xmemdupz(s, len);
-    listen_addr_deferred = listen_addr_from_lua;
-  }
-  lua_pop(lstate, 2);
-
-  if (listen_addr_deferred != NULL) {
-    (void)server_stop(listen_addr_deferred, true, true);
-
-    MAXSIZE_TEMP_ARRAY(serverstart_args, 1);
-    ADD_C(serverstart_args, CSTR_AS_OBJ(listen_addr_deferred));
-    MAXSIZE_TEMP_ARRAY(lua_args, 2);
-    // Save the listen address as vim._listen_addr, for further restarts.
-    ADD_C(lua_args, STATIC_CSTR_AS_OBJ("vim._listen_addr = vim.fn.serverstart(...)"));
-    ADD_C(lua_args, ARRAY_OBJ(serverstart_args));
-    result_mem = NULL;
-    rpc_send_call(channel->id, "nvim_exec_lua", lua_args, &result_mem, &err);
-    if (ERROR_SET(&err)) {
-      api_clear_error(&err);
-    }
-    arena_mem_free(result_mem);
-  }
-
   char *quit_cmd = (eap->do_ecmd_cmd) ? eap->do_ecmd_cmd : "qall";
   char *quit_cmd_copy = NULL;
 
@@ -5118,10 +5092,11 @@ static void ex_restart(exarg_T *eap)
     emsg("killing new nvim server failed");
   }
 
-  if (listen_addr_deferred != NULL && server_start(listen_addr_deferred) != 0) {
-    semsg("couldn't resume listening on %s", listen_addr_deferred);
+  // Restart listening on the --listen address.
+  if (server_stopped && server_start(listen_arg) != 0) {
+    semsg("couldn't resume listening on %s", listen_arg);
+    return;
   }
-  xfree(listen_addr_from_lua);
 }
 
 /// ":close": close current window, unless it is the last one

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5084,6 +5084,8 @@ static void ex_restart(exarg_T *eap)
   }
 
   // Reconnect to v:servername
+  // Unset v:servername first to reset it to the old value.
+  set_vim_var_string(VV_SEND_SERVER, "", -1);
   if (server_start(servername)) {
     emsg("couldn't start listening on v:servername");
     return;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5005,9 +5005,6 @@ static void ex_restart(exarg_T *eap)
     emsg("couldn't stop listening on v:servername");
     return;
   }
-  if (socket_address_tcp_host_end(servername) == NULL) {  // is a pipe
-    os_remove(servername);
-  }
 
   Channel *channel = channel_job_start(argv, exepath,
                                        CALLBACK_READER_INIT, on_err, CALLBACK_NONE,

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5079,6 +5079,9 @@ static void ex_restart(exarg_T *eap)
 
   if (listen_addr_deferred != NULL) {
     (void)server_stop(listen_addr_deferred, true, true);
+    if (strchr(listen_addr_deferred, '/') || strchr(listen_addr_deferred, '\\')) {
+      os_remove(listen_addr_deferred);
+    }
 
     MAXSIZE_TEMP_ARRAY(serverstart_args, 1);
     ADD_C(serverstart_args, CSTR_AS_OBJ(listen_addr_deferred));

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4977,12 +4977,12 @@ static void ex_restart(exarg_T *eap)
       break;
     }
     // Drop "-s <scriptfile>": skip the scriptfile arg too.
-    if (strequal(arg, "-s")) {
+    if (i > 0 && strequal(arg, "-s")) {
       li = TV_LIST_ITEM_NEXT(l, li);
       continue;
     }
     // The address after --listen may be in use by the current server.
-    if (strequal(arg, "--listen")) {
+    if (i > 0 && strequal(arg, "--listen")) {
       listitem_T *next_li = TV_LIST_ITEM_NEXT(l, li);
       if (next_li != NULL) {
         const char *addr = tv_get_string(TV_LIST_ITEM_TV(next_li));

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5028,7 +5028,7 @@ static void ex_restart(exarg_T *eap)
                                        NULL, 0, 0, NULL, &exit_status);
   if (!channel) {
     emsg("cannot create a channel job");
-    return;
+    goto fail_1;
   }
 
   // Prevent new server from self-exiting when the channel closes.
@@ -5040,7 +5040,7 @@ static void ex_restart(exarg_T *eap)
     emsg(err.msg);
     api_clear_error(&err);
     arena_mem_free(result_mem);
-    return;
+    goto fail_2;
   }
   arena_mem_free(result_mem);
 
@@ -5053,12 +5053,12 @@ static void ex_restart(exarg_T *eap)
     emsg(err.msg);
     api_clear_error(&err);
     arena_mem_free(result_mem);
-    return;
+    goto fail_2;
   }
   if (result.type != kObjectTypeString || result.data.string.size == 0) {
     arena_mem_free(result_mem);
     emsg("restart failed: could not get listen address from new server");
-    return;
+    goto fail_2;
   }
   char *listen_addr = xmemdupz(result.data.string.data, result.data.string.size);
   arena_mem_free(result_mem);
@@ -5070,7 +5070,7 @@ static void ex_restart(exarg_T *eap)
       api_clear_error(&err);
     }
     xfree(listen_addr);
-    return;
+    goto fail_2;
   }
   xfree(listen_addr);
 
@@ -5092,16 +5092,17 @@ static void ex_restart(exarg_T *eap)
     emsg("restart failed: +cmd did not quit the server");
   }
 
+fail_2:
   // Kill the new nvim server.
   proc_stop(&channel->stream.proc);
   if (proc_wait(&channel->stream.proc, -1, NULL) < 0) {
     emsg("killing new nvim server failed");
   }
 
+fail_1:
   // Restart listening on the --listen address.
   if (server_stopped && server_start(listen_arg) != 0) {
     semsg("couldn't resume listening on %s", listen_arg);
-    return;
   }
 }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5001,7 +5001,7 @@ static void ex_restart(exarg_T *eap)
 
   // Stop listening on v:servername
   char *servername = get_vim_var_str(VV_SEND_SERVER);
-  if (*servername != NUL && !server_stop(servername, true, true)) {
+  if (*servername != NUL && !server_stop(servername, true)) {
     emsg("couldn't stop listening on v:servername");
     return;
   }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4970,6 +4970,11 @@ static void ex_restart(exarg_T *eap)
   char **argv = xcalloc((size_t)argc + 3, sizeof(char *));
   size_t i = 0;
   const char *listen_arg = NULL;
+#ifdef MSWIN
+# define HANDLE_LISTEN_ADDR li = next_li; continue
+#else
+# define HANDLE_LISTEN_ADDR listen_arg = addr
+#endif
   TV_LIST_ITER_CONST(l, li, {
     const char *arg = tv_get_string(TV_LIST_ITEM_TV(li));
     // Drop "-- [files…]". Usually isn't wanted. User can :mksession instead.
@@ -4987,7 +4992,7 @@ static void ex_restart(exarg_T *eap)
       if (next_li != NULL) {
         const char *addr = tv_get_string(TV_LIST_ITEM_TV(next_li));
         if (strstr(addr, ":") || strstr(addr, "/") || strstr(addr, "\\")) {
-          listen_arg = addr;
+          HANDLE_LISTEN_ADDR;
         }
       }
     }
@@ -5002,6 +5007,7 @@ static void ex_restart(exarg_T *eap)
       }
     }
   });
+#undef HANDLE_LISTEN_ADDR
 
   bool server_stopped = false;
   if (listen_arg != NULL) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5027,7 +5027,7 @@ static void ex_restart(exarg_T *eap)
                                        false, true, true, detach, kChannelStdinPipe,
                                        NULL, 0, 0, NULL, &exit_status);
   if (!channel) {
-    ELOG("cannot create a channel job");
+    emsg("cannot create a channel job");
     return;
   }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5014,7 +5014,7 @@ static void ex_restart(exarg_T *eap)
       return;
     }
     // Stop listening on the --listen address so that the new server can listen.
-    server_stopped = server_stop(listen_arg, true);
+    server_stopped = server_stop(listen_arg, true, true);
   }
 
   CallbackReader on_err = CALLBACK_READER_INIT;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4,6 +4,7 @@
 #include <ctype.h>
 #include <inttypes.h>
 #include <limits.h>
+#include <signal.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdio.h>
@@ -40,8 +41,10 @@
 #include "nvim/eval/typval_defs.h"
 #include "nvim/eval/userfunc.h"
 #include "nvim/eval/vars.h"
+#include "nvim/eval_defs.h"
 #include "nvim/event/loop.h"
 #include "nvim/event/multiqueue.h"
+#include "nvim/event/socket.h"
 #include "nvim/ex_cmds.h"
 #include "nvim/ex_cmds2.h"
 #include "nvim/ex_cmds_defs.h"
@@ -73,6 +76,8 @@
 #include "nvim/message.h"
 #include "nvim/mouse.h"
 #include "nvim/move.h"
+#include "nvim/msgpack_rpc/channel.h"
+#include "nvim/msgpack_rpc/server.h"
 #include "nvim/normal.h"
 #include "nvim/normal_defs.h"
 #include "nvim/option.h"
@@ -83,6 +88,7 @@
 #include "nvim/os/input.h"
 #include "nvim/os/os.h"
 #include "nvim/os/os_defs.h"
+#include "nvim/os/proc.h"
 #include "nvim/os/shell.h"
 #include "nvim/path.h"
 #include "nvim/plines.h"
@@ -4808,13 +4814,6 @@ void not_exiting(bool save_exiting)
   exiting = save_exiting;
 }
 
-/// Call this function if we thought we were going to restart, but we won't
-/// (because of an error).
-void not_restarting(void)
-{
-  restarting = false;
-}
-
 bool before_quit_autocmds(win_T *wp, bool quit_all, bool forceit)
 {
   apply_autocmds(EVENT_QUITPRE, NULL, NULL, false, wp->w_buffer);
@@ -4960,55 +4959,102 @@ static void ex_quitall(exarg_T *eap)
 
 /// ":restart": restart the Nvim server (using ":qall!").
 /// ":restart +cmd": restart the Nvim server using ":cmd".
-/// ":restart +cmd <command>": restart the Nvim server using ":cmd" and add -c <command> to the new server.
+/// ":restart +cmd <command>": restart the Nvim server using ":cmd" and runs <command> in the new server.
 static void ex_restart(exarg_T *eap)
 {
+  Error err = ERROR_INIT;
+  const char *exepath = get_vim_var_str(VV_PROGPATH);
   const list_T *l = get_vim_var_list(VV_ARGV);
   int argc = tv_list_len(l);
-  list_T *argv_cpy = tv_list_alloc(eap->arg ? argc + 2 : argc);
 
-  // Copy v:argv, skipping unwanted items.
-  for (listitem_T *li = l != NULL ? l->lv_first : NULL; li != NULL; li = li->li_next) {
+  char **argv = xcalloc((size_t)argc + 3, sizeof(char *));
+  size_t i = 0;
+  TV_LIST_ITER_CONST(l, li, {
     const char *arg = tv_get_string(TV_LIST_ITEM_TV(li));
-    size_t arg_size = strlen(arg);
-    assert(arg_size <= (size_t)SSIZE_MAX);
-
-    if (strequal(arg, "--embed") || strequal(arg, "--headless")) {
-      continue;  // Drop --embed/--headless: the client decides how to start+attach the server.
-    } else if (strequal(arg, "-")) {
-      continue;  // Drop stdin ("-") argument.
-    } else if (strequal(arg, "-s")) {
-      // Drop "-s <scriptfile>": skip the scriptfile arg too.
-      if (li->li_next != NULL) {
-        li = li->li_next;
-      }
-      continue;
-    } else if (strequal(arg, "+:::")) {
-      // The special placeholder "+:::" marks a previous :restart command.
-      // Drop the `"+:::", "-c", "…"` triplet, to avoid "stacking" commands from previous :restart(s).
-      listitem_T *next1 = li->li_next;
-      if (next1 != NULL && strequal(tv_get_string(TV_LIST_ITEM_TV(next1)), "-c")) {
-        listitem_T *next2 = next1->li_next;
-        if (next2 != NULL) {
-          li = next2;
-          continue;
-        }
-      }
-      continue;  // If the triplet is incomplete, just skip "+:::"
-    } else if (strequal(arg, "--")) {
-      break;  // Drop "-- [files…]". Usually isn't wanted. User can :mksession instead.
+    // Drop "-- [files…]". Usually isn't wanted. User can :mksession instead.
+    if (i > 0 && strequal(arg, "--")) {
+      break;
     }
+    // The new server will not be able to listen on the same address as the old server.
+    if (strequal(arg, "--listen")) {
+      li = TV_LIST_ITEM_NEXT(l, li);
+      continue;
+    }
+    // Drop "-s <scriptfile>": skip the scriptfile arg too.
+    if (strequal(arg, "-s")) {
+      li = TV_LIST_ITEM_NEXT(l, li);
+      continue;
+    }
+    // Replace `--embed` OR `--headless` with `--embed --headless` once.
+    // Drop stdin ("-") argument.
+    if (i == 0
+        || (!strequal(arg, "--embed") && !strequal(arg, "--headless") && !strequal(arg, "-"))) {
+      argv[i++] = xstrdup(arg);
+      if (i == 1) {
+        argv[i++] = xstrdup("--embed");
+        argv[i++] = xstrdup("--headless");
+      }
+    }
+  });
 
-    tv_list_append_string(argv_cpy, arg, (ssize_t)arg_size);
+  CallbackReader on_err = CALLBACK_READER_INIT;
+  // This temporary bootstrap channel is closed intentionally once we obtain
+  // the new server address. Don't forward child stderr to the current UI.
+  on_err.fwd_err = false;
+  bool detach = true;
+  varnumber_T exit_status;
+  Channel *channel = channel_job_start(argv, exepath,
+                                       CALLBACK_READER_INIT, on_err, CALLBACK_NONE,
+                                       false, true, true, detach, kChannelStdinPipe,
+                                       NULL, 0, 0, NULL, &exit_status);
+  if (!channel) {
+    ELOG("cannot create a channel job");
+    return;
   }
-  // Append `"+:::", "-c", "<command>"` to end of v:argv.
-  // The "+:::" item is a no-op placeholder to mark the :restart "<command>".
-  if (eap->arg && eap->arg[0] != '\0') {
-    tv_list_append_string(argv_cpy, S_LEN("+:::"));
-    tv_list_append_string(argv_cpy, S_LEN("-c"));
-    tv_list_append_string(argv_cpy, eap->arg, (ssize_t)strlen(eap->arg));
+
+  // Get new server's listen address.
+  MAXSIZE_TEMP_ARRAY(servername_args, 1);
+  ADD_C(servername_args, CSTR_AS_OBJ("servername"));
+  ArenaMem result_mem = NULL;
+  Object result = rpc_send_call(channel->id, "nvim_get_vvar", servername_args, &result_mem, &err);
+  if (ERROR_SET(&err)) {
+    emsg(err.msg);
+    api_clear_error(&err);
+    arena_mem_free(result_mem);
+    return;
   }
-  set_vim_var_list(VV_ARGV, argv_cpy);
+  if (result.type != kObjectTypeString || result.data.string.size == 0) {
+    arena_mem_free(result_mem);
+    emsg("restart failed: could not get listen address from new server");
+    return;
+  }
+  char *listen_addr = xmemdupz(result.data.string.data, result.data.string.size);
+  arena_mem_free(result_mem);
+
+  // Prevent new server from self-exiting when the channel closes.
+  result_mem = NULL;
+  MAXSIZE_TEMP_ARRAY(detach_args, 1);
+  ADD_C(detach_args, BOOLEAN_OBJ(true));
+  rpc_send_call(channel->id, "nvim__chan_set_detach", detach_args, &result_mem, &err);
+  if (ERROR_SET(&err)) {
+    emsg(err.msg);
+    api_clear_error(&err);
+    arena_mem_free(result_mem);
+    xfree(listen_addr);
+    return;
+  }
+  arena_mem_free(result_mem);
+
+  // Send restart event to current UI.
+  if (!remote_ui_restart(current_ui, listen_addr, cstr_as_string(eap->arg), &err)) {
+    if (ERROR_SET(&err)) {
+      ELOG("%s", err.msg);  // UI disappeared already?
+      api_clear_error(&err);
+    }
+    xfree(listen_addr);
+    return;
+  }
+  xfree(listen_addr);
 
   char *quit_cmd = (eap->do_ecmd_cmd) ? eap->do_ecmd_cmd : "qall";
   char *quit_cmd_copy = NULL;
@@ -5018,20 +5064,20 @@ static void ex_restart(exarg_T *eap)
     quit_cmd_copy = concat_str("confirm ", quit_cmd);
     quit_cmd = quit_cmd_copy;
   }
-
-  Error err = ERROR_INIT;
-  restarting = true;
   nvim_command(cstr_as_string(quit_cmd), &err);
   xfree(quit_cmd_copy);
+
   if (ERROR_SET(&err)) {
     emsg(err.msg);  // Could not exit
     api_clear_error(&err);
-    not_restarting();
-    return;
-  }
-  if (!exiting) {
+  } else if (!exiting) {
     emsg("restart failed: +cmd did not quit the server");
-    not_restarting();
+  }
+
+  // Kill the new nvim server.
+  const int pid = channel->stream.proc.pid;
+  if (!os_proc_tree_kill(pid, SIGKILL)) {
+    emsg("killing new nvim server failed");
   }
 }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4970,7 +4970,7 @@ static void ex_restart(exarg_T *eap)
   char **argv = xcalloc((size_t)argc + 3, sizeof(char *));
   size_t i = 0;
   const char *listen_arg = NULL;
-#ifdef MSWIN
+#ifdef MSWIN  // FIXME: --listen doesn't work on Windows and needs to be dropped
 # define HANDLE_LISTEN_ADDR li = next_li; continue
 #else
 # define HANDLE_LISTEN_ADDR listen_arg = addr

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -44,6 +44,7 @@
 #include "nvim/eval_defs.h"
 #include "nvim/event/loop.h"
 #include "nvim/event/multiqueue.h"
+#include "nvim/event/proc.h"
 #include "nvim/event/socket.h"
 #include "nvim/ex_cmds.h"
 #include "nvim/ex_cmds2.h"
@@ -88,7 +89,6 @@
 #include "nvim/os/input.h"
 #include "nvim/os/os.h"
 #include "nvim/os/os_defs.h"
-#include "nvim/os/proc.h"
 #include "nvim/os/shell.h"
 #include "nvim/path.h"
 #include "nvim/plines.h"
@@ -5078,8 +5078,8 @@ static void ex_restart(exarg_T *eap)
   }
 
   // Kill the new nvim server.
-  const int pid = channel->stream.proc.pid;
-  if (!os_proc_tree_kill(pid, SIGTERM)) {
+  proc_stop(&channel->stream.proc);
+  if (proc_wait(&channel->stream.proc, -1, NULL) < 0) {
     emsg("killing new nvim server failed");
   }
 

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5012,7 +5012,7 @@ static void ex_restart(exarg_T *eap)
   bool server_stopped = false;
   if (listen_arg != NULL) {
     // Stop listening on the --listen address so that the new server can listen.
-    server_stopped = server_stop(listen_arg, true, true);
+    server_stopped = server_stop(listen_arg, true);
   }
 
   CallbackReader on_err = CALLBACK_READER_INIT;

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5001,7 +5001,7 @@ static void ex_restart(exarg_T *eap)
 
   // Stop listening on v:servername
   char *servername = get_vim_var_str(VV_SEND_SERVER);
-  if (*servername != NUL && !server_stop(servername, true)) {
+  if (*servername != NUL && !server_stop(servername, true, true)) {
     emsg("couldn't stop listening on v:servername");
     return;
   }

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -4967,6 +4967,7 @@ static void ex_restart(exarg_T *eap)
   const list_T *l = get_vim_var_list(VV_ARGV);
   int argc = tv_list_len(l);
 
+
   char **argv = xcalloc((size_t)argc + 3, sizeof(char *));
   size_t i = 0;
   TV_LIST_ITER_CONST(l, li, {
@@ -4974,11 +4975,6 @@ static void ex_restart(exarg_T *eap)
     // Drop "-- [files…]". Usually isn't wanted. User can :mksession instead.
     if (i > 0 && strequal(arg, "--")) {
       break;
-    }
-    // The new server will not be able to listen on the same address as the old server.
-    if (strequal(arg, "--listen")) {
-      li = TV_LIST_ITEM_NEXT(l, li);
-      continue;
     }
     // Drop "-s <scriptfile>": skip the scriptfile arg too.
     if (strequal(arg, "-s")) {
@@ -5003,6 +4999,14 @@ static void ex_restart(exarg_T *eap)
   on_err.fwd_err = false;
   bool detach = true;
   varnumber_T exit_status;
+
+  // Stop listening on v:servername
+  char *servername = get_vim_var_str(VV_SEND_SERVER);
+  if (!server_stop(servername)) {
+    emsg("couldn't stop listening on v:servername");
+    return;
+  }
+
   Channel *channel = channel_job_start(argv, exepath,
                                        CALLBACK_READER_INIT, on_err, CALLBACK_NONE,
                                        false, true, true, detach, kChannelStdinPipe,
@@ -5078,6 +5082,12 @@ static void ex_restart(exarg_T *eap)
   const int pid = channel->stream.proc.pid;
   if (!os_proc_tree_kill(pid, SIGTERM)) {
     emsg("killing new nvim server failed");
+  }
+
+  // Reconnect to v:servername
+  if (!server_start(servername)) {
+    emsg("couldn't start listening on v:servername");
+    return;
   }
 }
 

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -419,8 +419,6 @@ EXTERN int sc_col;              // column for shown command
 EXTERN int starting INIT( = NO_SCREEN);
 // Planning to exit. Might keep running if there is a changed buffer.
 EXTERN bool exiting INIT( = false);
-// Planning to restart.
-EXTERN bool restarting INIT( = false);
 // Internal value of v:dying
 EXTERN int v_dying INIT( = 0);
 // Is stdin a terminal?

--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -861,17 +861,6 @@ void getout(int exitval)
     ui_call_set_title(cstr_as_string(p_titleold));
   }
 
-  if (restarting) {
-    Error err = ERROR_INIT;
-    if (!remote_ui_restart(current_ui, &err)) {
-      if (ERROR_SET(&err)) {
-        ELOG("%s", err.msg);  // UI disappeared already?
-        api_clear_error(&err);
-      }
-    }
-    restarting = false;
-  }
-
   if (garbage_collect_at_exit) {
     garbage_collect(false);
   }

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -500,7 +500,7 @@ static void rpc_close_event(void **argv)
       // Avoid hanging when there are no other UIs and a prompt is triggered on exit.
       remote_ui_disconnect(channel->id, NULL, false);
     } else {
-      ui_client_may_restart_server();
+      ui_client_attach_to_restarted_server();
       if (ui_client_channel_id != channel->id) {
         // A new server has been started. Don't exit.
         return;

--- a/src/nvim/msgpack_rpc/channel.c
+++ b/src/nvim/msgpack_rpc/channel.c
@@ -502,7 +502,7 @@ static void rpc_close_event(void **argv)
     } else {
       ui_client_attach_to_restarted_server();
       if (ui_client_channel_id != channel->id) {
-        // A new server has been started. Don't exit.
+        // Attached to new server. Don't exit.
         return;
       }
     }

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -8,7 +8,6 @@
 #include "nvim/channel.h"
 #include "nvim/eval/vars.h"
 #include "nvim/event/defs.h"
-#include "nvim/event/multiqueue.h"
 #include "nvim/event/socket.h"
 #include "nvim/garray.h"
 #include "nvim/garray_defs.h"
@@ -215,7 +214,7 @@ int server_start(const char *addr)
 /// Stops listening on the address specified by `endpoint`.
 ///
 /// @param endpoint Address of the server.
-bool server_stop(const char *endpoint, bool keep_vservername, bool wait)
+bool server_stop(const char *endpoint, bool keep_vservername)
 {
   SocketWatcher *watcher;
   bool watcher_found = false;
@@ -238,12 +237,7 @@ bool server_stop(const char *endpoint, bool keep_vservername, bool wait)
     return false;
   }
 
-  bool stopped = false;
-  watcher->data = wait ? &stopped : NULL;
   socket_watcher_close(watcher, free_server);
-  if (wait) {
-    LOOP_PROCESS_EVENTS_UNTIL(&main_loop, NULL, -1, stopped);
-  }
 
   // Remove this server from the list by swapping it with the last item.
   if (i != watchers.ga_len - 1) {
@@ -288,8 +282,5 @@ static void connection_cb(SocketWatcher *watcher, int result, void *data)
 
 static void free_server(SocketWatcher *watcher, void *data)
 {
-  if (data != NULL) {
-    *(bool *)data = true;
-  }
   xfree(watcher);
 }

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -212,6 +212,22 @@ int server_start(const char *addr)
   return 0;
 }
 
+bool server_find(const char *endpoint)
+{
+  char addr[ADDRESS_MAX_SIZE];
+
+  // Trim to `ADDRESS_MAX_SIZE`
+  xstrlcpy(addr, endpoint, sizeof(addr));
+
+  for (int i = 0; i < watchers.ga_len; i++) {
+    SocketWatcher *watcher = ((SocketWatcher **)watchers.ga_data)[i];
+    if (strcmp(addr, watcher->addr) == 0) {
+      return true;
+    }
+  }
+  return false;
+}
+
 /// Stops listening on the address specified by `endpoint`.
 ///
 /// @param endpoint Address of the server.

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -212,22 +212,6 @@ int server_start(const char *addr)
   return 0;
 }
 
-bool server_find(const char *endpoint)
-{
-  char addr[ADDRESS_MAX_SIZE];
-
-  // Trim to `ADDRESS_MAX_SIZE`
-  xstrlcpy(addr, endpoint, sizeof(addr));
-
-  for (int i = 0; i < watchers.ga_len; i++) {
-    SocketWatcher *watcher = ((SocketWatcher **)watchers.ga_data)[i];
-    if (strcmp(addr, watcher->addr) == 0) {
-      return true;
-    }
-  }
-  return false;
-}
-
 /// Stops listening on the address specified by `endpoint`.
 ///
 /// @param endpoint Address of the server.

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -214,7 +214,7 @@ int server_start(const char *addr)
 /// Stops listening on the address specified by `endpoint`.
 ///
 /// @param endpoint Address of the server.
-bool server_stop(char *endpoint)
+bool server_stop(const char *endpoint, bool keep_vservername)
 {
   SocketWatcher *watcher;
   bool watcher_found = false;
@@ -247,7 +247,7 @@ bool server_stop(char *endpoint)
   watchers.ga_len--;
 
   // Bump v:servername to the next available server, if any.
-  if (strequal(addr, get_vim_var_str(VV_SEND_SERVER))) {
+  if (!keep_vservername && strequal(addr, get_vim_var_str(VV_SEND_SERVER))) {
     set_vservername(&watchers);
   }
 

--- a/src/nvim/msgpack_rpc/server.c
+++ b/src/nvim/msgpack_rpc/server.c
@@ -8,6 +8,7 @@
 #include "nvim/channel.h"
 #include "nvim/eval/vars.h"
 #include "nvim/event/defs.h"
+#include "nvim/event/multiqueue.h"
 #include "nvim/event/socket.h"
 #include "nvim/garray.h"
 #include "nvim/garray_defs.h"
@@ -214,7 +215,7 @@ int server_start(const char *addr)
 /// Stops listening on the address specified by `endpoint`.
 ///
 /// @param endpoint Address of the server.
-bool server_stop(const char *endpoint, bool keep_vservername)
+bool server_stop(const char *endpoint, bool keep_vservername, bool wait)
 {
   SocketWatcher *watcher;
   bool watcher_found = false;
@@ -237,7 +238,12 @@ bool server_stop(const char *endpoint, bool keep_vservername)
     return false;
   }
 
+  bool stopped = false;
+  watcher->data = wait ? &stopped : NULL;
   socket_watcher_close(watcher, free_server);
+  if (wait) {
+    LOOP_PROCESS_EVENTS_UNTIL(&main_loop, NULL, -1, stopped);
+  }
 
   // Remove this server from the list by swapping it with the last item.
   if (i != watchers.ga_len - 1) {
@@ -282,5 +288,8 @@ static void connection_cb(SocketWatcher *watcher, int result, void *data)
 
 static void free_server(SocketWatcher *watcher, void *data)
 {
+  if (data != NULL) {
+    *(bool *)data = true;
+  }
   xfree(watcher);
 }

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -320,14 +320,14 @@ void ui_client_event_restart(Array args)
   // NB: don't send nvim_ui_detach to server, as it may have already exited.
   // ui_client_detach();
 
-  // Save the arguments for ui_client_may_restart_server() later.
+  // Save the arguments for ui_client_attach_to_restarted_server() later.
   api_free_array(restart_args);
   restart_args = copy_array(args, NULL);
   restart_pending = true;
 }
 
 /// Called when the current server has exited.
-void ui_client_may_restart_server(void)
+void ui_client_attach_to_restarted_server(void)
 {
   if (!restart_pending) {
     return;

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -343,7 +343,7 @@ void ui_client_attach_to_restarted_server(void)
   }
 
   char *listen_addr = restart_args.items[0].data.string.data;
-  bool is_tcp = socket_address_is_tcp(listen_addr);
+  bool is_tcp = socket_address_tcp_host_end(listen_addr) != NULL;
   const char *err = "";
   uint64_t chan_id = channel_connect(is_tcp, listen_addr, true, CALLBACK_READER_INIT, 50, &err);
 

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -360,7 +360,7 @@ void ui_client_attach_to_restarted_server(void)
   ui_client_attach(tui_width, tui_height, tui_term, tui_rgb);
 
   String command = restart_args.items[1].data.string;
-  if (command.data && strlen(command.data) > 0) {
+  if (command.size > 0) {
     MAXSIZE_TEMP_ARRAY(cmd_args, 1);
     ADD_C(cmd_args, STRING_OBJ(command));
     // TODO(justinmk): if reattaching multiple UIs, only 1 UI should do this command.

--- a/src/nvim/ui_client.c
+++ b/src/nvim/ui_client.c
@@ -169,7 +169,9 @@ void ui_client_run(bool remote_ui)
 
   // os_exit() will be invoked when the client channel detaches
   while (true) {
-    LOOP_PROCESS_EVENTS(&main_loop, resize_events, -1);
+    // Need to process main_loop.events,
+    // otherwise channels closed due to server restart are never freed.
+    LOOP_PROCESS_EVENTS(&main_loop, main_loop.events, -1);
   }
 }
 

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -1498,7 +1498,17 @@ describe('user config init', function()
 
       -- a total of 2 exrc files are executed
       feed(':echo g:exrc_count<CR>')
-      screen:expect({ any = '2' })
+      screen:expect([[
+        ^{MATCH: +}|
+        ~{MATCH: +}|*4
+        [No Name]{MATCH: +}0,0-1{MATCH: +}All|
+        2{MATCH: +}|
+        -- TERMINAL --{MATCH: +}|
+      ]])
+
+      -- The server is now detached and needs to be quit explicitly.
+      feed(':qall!<CR>')
+      screen:expect({ any = vim.pesc('[Process exited 0]') })
     end)
   end)
 

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -1492,7 +1492,7 @@ describe('user config init', function()
         ^{MATCH: +}|
         ~{MATCH: +}|*4
         [No Name]{MATCH: +}0,0-1{MATCH: +}All|
-        {MATCH:.*}|
+        {MATCH: +}|
         -- TERMINAL --{MATCH: +}|
       ]])
 

--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -1492,7 +1492,7 @@ describe('user config init', function()
         ^{MATCH: +}|
         ~{MATCH: +}|*4
         [No Name]{MATCH: +}0,0-1{MATCH: +}All|
-        {MATCH: +}|
+        {MATCH:.*}|
         -- TERMINAL --{MATCH: +}|
       ]])
 

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -325,7 +325,7 @@ describe('TUI :restart', function()
 
     -- Check ":restart +echo" cannot restart server.
     tt.feed_data(':restart +echo\013')
-    screen_expect({ any = vim.pesc('+cmd did not quit the server') })
+    screen:expect({ any = vim.pesc('+cmd did not quit the server') })
 
     tt.feed_data('ithis will be removed\027')
     screen_expect([[
@@ -338,37 +338,37 @@ describe('TUI :restart', function()
 
     -- Check ":confirm restart" on a modified buffer.
     tt.feed_data(':confirm restart\013')
-    screen_expect({ any = vim.pesc('Save changes to "Untitled"?') })
+    screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
 
     -- Cancel the operation (abandons restart).
     tt.feed_data('C\013')
-    screen_expect({ any = vim.pesc('[No Name]') })
+    screen:expect({ any = vim.pesc('[No Name]') })
 
     -- Check :restart respects 'confirm' option.
     tt.feed_data(':set confirm\013')
     tt.feed_data(':restart\013')
-    screen_expect({ any = vim.pesc('Save changes to "Untitled"?') })
+    screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
     tt.feed_data('C\013')
-    screen_expect({ any = vim.pesc('[No Name]') })
+    screen:expect({ any = vim.pesc('[No Name]') })
     tt.feed_data(':set noconfirm\013')
 
     -- Check ":confirm restart <cmd>" on a modified buffer.
     tt.feed_data(":confirm restart put ='Hello3'\013")
-    screen_expect({ any = vim.pesc('Save changes to "Untitled"?') })
+    screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
     tt.feed_data('N\013')
-    screen_expect({ any = '%^Hello3' })
+    screen:expect({ any = '%^Hello3' })
     -- assert_new_pid()
     assert_no_gui_running()
     -- eq("--cmd echo getpid() +::: -c put ='Hello3'", get_argv(4))
 
     -- Check ":confirm restart +echo" correctly ignores ":confirm"
     tt.feed_data(':confirm restart +echo\013')
-    screen_expect({ any = vim.pesc('+cmd did not quit the server') })
+    screen:expect({ any = vim.pesc('+cmd did not quit the server') })
 
     -- Check ":restart" on a modified buffer.
     tt.feed_data('ithis will be removed\027')
     tt.feed_data(':restart\013')
-    screen_expect({ any = vim.pesc('Vim(qall):E37: No write since last change') })
+    screen:expect({ any = vim.pesc('Vim(qall):E37: No write since last change') })
 
     -- Check ":restart +qall!" on a modified buffer.
     tt.feed_data('ithis will be removed\027')

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -221,8 +221,6 @@ describe('TUI :restart', function()
       n.check_close()
     end)
 
-    t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows')
-
     -- local server_pipe = new_pipename()
     local screen = tt.setup_child_nvim({
       '-u',
@@ -291,14 +289,14 @@ describe('TUI :restart', function()
     tt.feed_data(':set nomodified\013')
     -- Command is run on new server.
     tt.feed_data(":restart put ='Hello1'\013")
-    screen:expect(s1)
+    screen_expect(s1)
     -- assert_new_pid()
     assert_no_gui_running()
     -- eq("--cmd echo getpid() +::: -c put ='Hello1'", get_argv(4))
 
     -- Complex command following +cmd.
     tt.feed_data(":restart +qall! put ='Hello2' | put ='World2'\013")
-    screen:expect([[
+    screen_expect([[
                                                         |
       Hello2                                            |
       ^World2                                            |
@@ -314,23 +312,23 @@ describe('TUI :restart', function()
     -- Check ":restart" on an unmodified buffer.
     tt.feed_data(':set nomodified\013')
     tt.feed_data(':restart\013')
-    screen:expect(s0)
+    screen_expect(s0)
     -- assert_new_pid()
     assert_no_gui_running()
 
     -- Check ":restart +qall!" on an unmodified buffer.
     tt.feed_data(':restart +qall!\013')
-    screen:expect(s0)
+    screen_expect(s0)
     -- assert_new_pid()
     assert_no_gui_running()
     -- eq('--cmd echo getpid()', get_argv(1))
 
     -- Check ":restart +echo" cannot restart server.
     tt.feed_data(':restart +echo\013')
-    screen:expect({ any = vim.pesc('+cmd did not quit the server') })
+    screen_expect({ any = vim.pesc('+cmd did not quit the server') })
 
     tt.feed_data('ithis will be removed\027')
-    screen:expect([[
+    screen_expect([[
       this will be remove^d                              |
       {100:~                                                 }|*3
       {3:[No Name] [+]                                     }|
@@ -340,53 +338,53 @@ describe('TUI :restart', function()
 
     -- Check ":confirm restart" on a modified buffer.
     tt.feed_data(':confirm restart\013')
-    screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
+    screen_expect({ any = vim.pesc('Save changes to "Untitled"?') })
 
     -- Cancel the operation (abandons restart).
     tt.feed_data('C\013')
-    screen:expect({ any = vim.pesc('[No Name]') })
+    screen_expect({ any = vim.pesc('[No Name]') })
 
     -- Check :restart respects 'confirm' option.
     tt.feed_data(':set confirm\013')
     tt.feed_data(':restart\013')
-    screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
+    screen_expect({ any = vim.pesc('Save changes to "Untitled"?') })
     tt.feed_data('C\013')
-    screen:expect({ any = vim.pesc('[No Name]') })
+    screen_expect({ any = vim.pesc('[No Name]') })
     tt.feed_data(':set noconfirm\013')
 
     -- Check ":confirm restart <cmd>" on a modified buffer.
     tt.feed_data(":confirm restart put ='Hello3'\013")
-    screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
+    screen_expect({ any = vim.pesc('Save changes to "Untitled"?') })
     tt.feed_data('N\013')
-    screen:expect({ any = '%^Hello3' })
+    screen_expect({ any = '%^Hello3' })
     -- assert_new_pid()
     assert_no_gui_running()
     -- eq("--cmd echo getpid() +::: -c put ='Hello3'", get_argv(4))
 
     -- Check ":confirm restart +echo" correctly ignores ":confirm"
     tt.feed_data(':confirm restart +echo\013')
-    screen:expect({ any = vim.pesc('+cmd did not quit the server') })
+    screen_expect({ any = vim.pesc('+cmd did not quit the server') })
 
     -- Check ":restart" on a modified buffer.
     tt.feed_data('ithis will be removed\027')
     tt.feed_data(':restart\013')
-    screen:expect({ any = vim.pesc('Vim(qall):E37: No write since last change') })
+    screen_expect({ any = vim.pesc('Vim(qall):E37: No write since last change') })
 
     -- Check ":restart +qall!" on a modified buffer.
     tt.feed_data('ithis will be removed\027')
     tt.feed_data(':restart +qall!\013')
-    screen:expect(s0)
+    screen_expect(s0)
     -- assert_new_pid()
     assert_no_gui_running()
 
     -- No --listen conflict when server exit is delayed.
     feed_data(':lua vim.schedule(function() vim.wait(100) end); vim.cmd.restart()\n')
-    screen:expect(s0)
+    screen_expect(s0)
     -- assert_new_pid()
     assert_no_gui_running()
 
     screen:try_resize(60, 6)
-    screen:expect([[
+    screen_expect([[
       ^                                                            |
       {100:~                                                           }|*2
       {3:[No Name]                                                   }|
@@ -396,7 +394,7 @@ describe('TUI :restart', function()
 
     --- Check that ":restart" uses the updated size after terminal resize.
     tt.feed_data(':restart\013')
-    screen:expect([[
+    screen_expect([[
       ^                                                            |
       {100:~                                                           }|*2
       {3:[No Name]                                                   }|

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -262,10 +262,23 @@ describe('TUI :restart', function()
     local server_session = n.connect(server_pipe)
     local _, server_pid = server_session:request('nvim_call_function', 'getpid', {})
     local function assert_new_pid()
-      tt.feed_data(':echo serverstart("' .. server_pipe .. '")\n')
-      screen:expect({ any = server_pipe })
+      --- HACK: On Windows, make a dummy serverstart from test env to create the pipe
+      --- and then stop it after the child has connected to it.
+      --- This avoids permission denied when the child nvim
+      --- tries to open the pipe by itself.
+      if is_os('win') then
+        local pipename = eval("serverstart('" .. server_pipe .. "')")
+        eq(server_pipe, pipename)
+      end
+      tt.feed_data(':call serverstart("' .. server_pipe .. '")\n')
+      screen:expect({ any = ':call serverstart' })
+      -- The :call command may sometimes overflow leaving the "Press ENTER" prompt.
+      tt.feed_data('\n')
 
       server_session = n.connect(server_pipe)
+      if is_os('win') then
+        fn.serverstop(server_pipe)
+      end
       local _, new_pid = server_session:request('nvim_call_function', 'getpid', {})
       t.neq(server_pid, new_pid)
       server_pid = new_pid
@@ -377,7 +390,7 @@ describe('TUI :restart', function()
     -- No --listen conflict when server exit is delayed.
     feed_data(':lua vim.schedule(function() vim.wait(100) end); vim.cmd.restart()\n')
     screen_expect(s0)
-    -- assert_new_pid()
+    assert_new_pid()
     assert_no_gui_running()
 
     screen:try_resize(60, 6)
@@ -402,12 +415,11 @@ describe('TUI :restart', function()
     assert_no_gui_running()
 
     -- Cleanup the environment
-    tt.feed_data(':echo serverstop("' .. server_pipe .. '")\013')
+    tt.feed_data(':call serverstop("' .. server_pipe .. '")\013')
     if server_session then
       server_session:close()
     end
     os.remove(server_pipe)
-    n.check_close()
   end)
 
   it('drops "-" and "-- [files…]" from v:argv #34417', function()
@@ -416,7 +428,7 @@ describe('TUI :restart', function()
     local server_session
     local server_pipe = new_pipename()
     finally(function()
-      tt.feed_data(':echo serverstop("' .. server_pipe .. '")\013')
+      tt.feed_data(':call serverstop("' .. server_pipe .. '")\013')
       if server_session then
         server_session:close()
       end
@@ -462,10 +474,23 @@ describe('TUI :restart', function()
       {5:-- TERMINAL --}                                    |
     ]])
     -- Tell the new server to start listening on the pipe again.
-    tt.feed_data(':echo serverstart("' .. server_pipe .. '")\013')
-    screen:expect({ any = server_pipe })
+    --- HACK: On Windows, make a dummy serverstart from test env to create the pipe
+    --- and then stop it after the child has connected to it.
+    --- This avoids permission denied when the child nvim
+    --- tries to open the pipe by itself.
+    if is_os('win') then
+      local pipename = eval("serverstart('" .. server_pipe .. "')")
+      eq(server_pipe, pipename)
+    end
+    tt.feed_data(':call serverstart("' .. server_pipe .. '")\013')
+    screen:expect({ any = ':call serverstart' })
+    -- The :call command may sometimes overflow leaving a "Press ENTER" prompt.
+    tt.feed_data('\013')
 
     server_session = n.connect(server_pipe)
+    if is_os('win') then
+      fn.serverstop(server_pipe)
+    end
 
     eq({ true, false }, { server_session:request('nvim_eval', expr) })
     eq({ true, false }, { server_session:request('nvim_eval', has_s) })

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -262,9 +262,9 @@ describe('TUI :restart', function()
     local server_session = n.connect(server_pipe)
     local _, server_pid = server_session:request('nvim_call_function', 'getpid', {})
     local function assert_new_pid()
-      tt.feed_data(':call serverstart("' .. server_pipe .. '")\n')
-      -- The :call command may sometimes overflow leaving the "Press ENTER" prompt.
-      tt.feed_data('\n')
+      tt.feed_data(':lua vim.fn.serverstart([[' .. server_pipe .. ']])\n')
+      -- The :lua command may sometimes overflow leaving the "Press ENTER" prompt.
+      -- tt.feed_data('\n')
       screen:expect({ unchanged = true })
 
       server_session = n.connect(server_pipe)
@@ -272,7 +272,7 @@ describe('TUI :restart', function()
       local _, new_pid = server_session:request('nvim_call_function', 'getpid', {})
       t.neq(server_pid, new_pid)
 
-      tt.feed_data(':call serverstop("' .. server_pipe .. '")\n')
+      tt.feed_data(':lua vim.fn.serverstop([[' .. server_pipe .. ']])\n')
       server_pid = new_pid
     end
 
@@ -464,9 +464,9 @@ describe('TUI :restart', function()
       {5:-- TERMINAL --}                                    |
     ]])
     -- Tell the new server to start listening on the pipe again.
-    tt.feed_data(':call serverstart("' .. server_pipe .. '")\013')
-    -- The :call command may sometimes overflow leaving a "Press ENTER" prompt.
-    tt.feed_data('\013')
+    tt.feed_data(':lua vim.fn.serverstart([[' .. server_pipe .. ']])\013')
+    -- The :lua command may sometimes overflow leaving a "Press ENTER" prompt.
+    -- tt.feed_data('\013')
     screen:expect({ unchanged = true })
 
     server_session = n.connect(server_pipe)
@@ -474,7 +474,7 @@ describe('TUI :restart', function()
     eq({ true, false }, { server_session:request('nvim_eval', expr) })
     eq({ true, false }, { server_session:request('nvim_eval', has_s) })
 
-    tt.feed_data(':call serverstop("' .. server_pipe .. '")\013')
+    tt.feed_data(':lua vim.fn.serverstop([[' .. server_pipe .. ']])\013')
     -- local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
     -- eq(13, #argv)
     -- eq("-c put='foo'", table.concat(argv, ' ', #argv - 1, #argv))

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -262,25 +262,17 @@ describe('TUI :restart', function()
     local server_session = n.connect(server_pipe)
     local _, server_pid = server_session:request('nvim_call_function', 'getpid', {})
     local function assert_new_pid()
-      --- HACK: On Windows, make a dummy serverstart from test env to create the pipe
-      --- and then stop it after the child has connected to it.
-      --- This avoids permission denied when the child nvim
-      --- tries to open the pipe by itself.
-      if is_os('win') then
-        local pipename = eval("serverstart('" .. server_pipe .. "')")
-        eq(server_pipe, pipename)
-      end
       tt.feed_data(':call serverstart("' .. server_pipe .. '")\n')
-      screen:expect({ any = ':call serverstart' })
       -- The :call command may sometimes overflow leaving the "Press ENTER" prompt.
       tt.feed_data('\n')
+      screen:expect({ unchanged = true })
 
       server_session = n.connect(server_pipe)
-      if is_os('win') then
-        fn.serverstop(server_pipe)
-      end
+
       local _, new_pid = server_session:request('nvim_call_function', 'getpid', {})
       t.neq(server_pid, new_pid)
+
+      tt.feed_data(':call serverstop("' .. server_pipe .. '")\n')
       server_pid = new_pid
     end
 
@@ -415,7 +407,6 @@ describe('TUI :restart', function()
     assert_no_gui_running()
 
     -- Cleanup the environment
-    tt.feed_data(':call serverstop("' .. server_pipe .. '")\013')
     if server_session then
       server_session:close()
     end
@@ -428,7 +419,6 @@ describe('TUI :restart', function()
     local server_session
     local server_pipe = new_pipename()
     finally(function()
-      tt.feed_data(':call serverstop("' .. server_pipe .. '")\013')
       if server_session then
         server_session:close()
       end
@@ -474,27 +464,17 @@ describe('TUI :restart', function()
       {5:-- TERMINAL --}                                    |
     ]])
     -- Tell the new server to start listening on the pipe again.
-    --- HACK: On Windows, make a dummy serverstart from test env to create the pipe
-    --- and then stop it after the child has connected to it.
-    --- This avoids permission denied when the child nvim
-    --- tries to open the pipe by itself.
-    if is_os('win') then
-      local pipename = eval("serverstart('" .. server_pipe .. "')")
-      eq(server_pipe, pipename)
-    end
     tt.feed_data(':call serverstart("' .. server_pipe .. '")\013')
-    screen:expect({ any = ':call serverstart' })
     -- The :call command may sometimes overflow leaving a "Press ENTER" prompt.
     tt.feed_data('\013')
+    screen:expect({ unchanged = true })
 
     server_session = n.connect(server_pipe)
-    if is_os('win') then
-      fn.serverstop(server_pipe)
-    end
 
     eq({ true, false }, { server_session:request('nvim_eval', expr) })
     eq({ true, false }, { server_session:request('nvim_eval', has_s) })
 
+    tt.feed_data(':call serverstop("' .. server_pipe .. '")\013')
     -- local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
     -- eq(13, #argv)
     -- eq("-c put='foo'", table.concat(argv, ' ', #argv - 1, #argv))

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -221,14 +221,14 @@ describe('TUI :restart', function()
       n.check_close()
     end)
 
-    -- local server_pipe = new_pipename()
+    local server_pipe = new_pipename()
     local screen = tt.setup_child_nvim({
       '-u',
       'NONE',
       '-i',
       'NONE',
-      -- '--listen',
-      -- server_pipe,
+      '--listen',
+      server_pipe,
       '--cmd',
       'colorscheme vim',
       '--cmd',
@@ -259,16 +259,17 @@ describe('TUI :restart', function()
     screen:expect(s0)
     assert_no_gui_running()
 
-    -- XXX: Cannot use this for pid validation.
-    -- local server_session = n.connect(server_pipe)
-    -- local _, server_pid = server_session:request('nvim_call_function', 'getpid', {})
-    -- local function assert_new_pid()
-    --   server_session:close()
-    --   server_session = n.connect(server_pipe)
-    --   local _, new_pid = server_session:request('nvim_call_function', 'getpid', {})
-    --   t.neq(server_pid, new_pid)
-    --   server_pid = new_pid
-    -- end
+    local server_session = n.connect(server_pipe)
+    local _, server_pid = server_session:request('nvim_call_function', 'getpid', {})
+    local function assert_new_pid()
+      tt.feed_data(':echo serverstart("' .. server_pipe .. '")\n')
+      screen:expect({ any = server_pipe })
+
+      server_session = n.connect(server_pipe)
+      local _, new_pid = server_session:request('nvim_call_function', 'getpid', {})
+      t.neq(server_pid, new_pid)
+      server_pid = new_pid
+    end
 
     --- XXX: No longer using -c <command> during new server startup.
     --- Gets the last `argn` items in v:argv as a joined string.
@@ -290,9 +291,8 @@ describe('TUI :restart', function()
     -- Command is run on new server.
     tt.feed_data(":restart put ='Hello1'\013")
     screen_expect(s1)
-    -- assert_new_pid()
+    assert_new_pid()
     assert_no_gui_running()
-    -- eq("--cmd echo getpid() +::: -c put ='Hello1'", get_argv(4))
 
     -- Complex command following +cmd.
     tt.feed_data(":restart +qall! put ='Hello2' | put ='World2'\013")
@@ -305,23 +305,21 @@ describe('TUI :restart', function()
                                                         |
       {5:-- TERMINAL --}                                    |
     ]])
-    -- assert_new_pid()
+    assert_new_pid()
     assert_no_gui_running()
-    -- eq("--cmd echo getpid() +::: -c put ='Hello2' | put ='World2'", get_argv(4))
 
     -- Check ":restart" on an unmodified buffer.
     tt.feed_data(':set nomodified\013')
     tt.feed_data(':restart\013')
     screen_expect(s0)
-    -- assert_new_pid()
+    assert_new_pid()
     assert_no_gui_running()
 
     -- Check ":restart +qall!" on an unmodified buffer.
     tt.feed_data(':restart +qall!\013')
     screen_expect(s0)
-    -- assert_new_pid()
+    assert_new_pid()
     assert_no_gui_running()
-    -- eq('--cmd echo getpid()', get_argv(1))
 
     -- Check ":restart +echo" cannot restart server.
     tt.feed_data(':restart +echo\013')
@@ -357,9 +355,8 @@ describe('TUI :restart', function()
     screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
     tt.feed_data('N\013')
     screen:expect({ any = '%^Hello3' })
-    -- assert_new_pid()
+    assert_new_pid()
     assert_no_gui_running()
-    -- eq("--cmd echo getpid() +::: -c put ='Hello3'", get_argv(4))
 
     -- Check ":confirm restart +echo" correctly ignores ":confirm"
     tt.feed_data(':confirm restart +echo\013')
@@ -374,7 +371,7 @@ describe('TUI :restart', function()
     tt.feed_data('ithis will be removed\027')
     tt.feed_data(':restart +qall!\013')
     screen_expect(s0)
-    -- assert_new_pid()
+    assert_new_pid()
     assert_no_gui_running()
 
     -- No --listen conflict when server exit is delayed.
@@ -401,29 +398,38 @@ describe('TUI :restart', function()
                                                                   |
       {5:-- TERMINAL --}                                              |
     ]])
-    -- assert_new_pid()
+    assert_new_pid()
     assert_no_gui_running()
+
+    -- Cleanup the environment
+    tt.feed_data(':echo serverstop("' .. server_pipe .. '")\013')
+    if server_session then
+      server_session:close()
+    end
+    os.remove(server_pipe)
+    n.check_close()
   end)
 
   it('drops "-" and "-- [files…]" from v:argv #34417', function()
     t.skip(is_os('win'), 'stdin behavior differs on Windows')
     clear()
-    -- XXX: Cannot use this for pid validation.
-    -- local server_session
-    -- finally(function()
-    --   if server_session then
-    --     server_session:close()
-    --   end
-    --   n.check_close()
-    -- end)
-    -- local server_pipe = new_pipename()
+    local server_session
+    local server_pipe = new_pipename()
+    finally(function()
+      tt.feed_data(':echo serverstop("' .. server_pipe .. '")\013')
+      if server_session then
+        server_session:close()
+      end
+      os.remove(server_pipe)
+      n.check_close()
+    end)
     local screen = tt.setup_child_nvim({
       '-u',
       'NONE',
       '-i',
       'NONE',
-      -- '--listen',
-      -- server_pipe,
+      '--listen',
+      server_pipe,
       '--cmd',
       'set notermguicolors',
       '-s',
@@ -440,15 +446,11 @@ describe('TUI :restart', function()
                                                         |
       {5:-- TERMINAL --}                                    |
     ]])
-    -- server_session = n.connect(server_pipe)
+    server_session = n.connect(server_pipe)
     local expr = 'index(v:argv, "-") >= 0 || index(v:argv, "--") >= 0 ? v:true : v:false'
     local has_s = 'index(v:argv, "-s") >= 0 ? v:true : v:false'
-    -- eq({ true, true }, { server_session:request('nvim_eval', expr) })
-
-    tt.feed_data(':echo ' .. expr .. '\013')
-    screen:expect({ any = 'v:true' })
-    tt.feed_data(':echo ' .. has_s .. '\013')
-    screen:expect({ any = 'v:true', unchanged = true })
+    eq({ true, true }, { server_session:request('nvim_eval', expr) })
+    eq({ true, true }, { server_session:request('nvim_eval', has_s) })
 
     tt.feed_data(":restart put='foo'\013")
     screen:expect([[
@@ -459,15 +461,14 @@ describe('TUI :restart', function()
                                                         |
       {5:-- TERMINAL --}                                    |
     ]])
-    -- server_session:close()
-    -- server_session = n.connect(server_pipe)
-    --
-    -- eq({ true, false }, { server_session:request('nvim_eval', expr) })
+    -- Tell the new server to start listening on the pipe again.
+    tt.feed_data(':echo serverstart("' .. server_pipe .. '")\013')
+    screen:expect({ any = server_pipe })
 
-    tt.feed_data(':echo ' .. expr .. '\013')
-    screen:expect({ any = 'v:false' })
-    tt.feed_data(':echo ' .. has_s .. '\013')
-    screen:expect({ any = 'v:false', unchanged = true })
+    server_session = n.connect(server_pipe)
+
+    eq({ true, false }, { server_session:request('nvim_eval', expr) })
+    eq({ true, false }, { server_session:request('nvim_eval', has_s) })
 
     -- local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
     -- eq(13, #argv)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -262,11 +262,8 @@ describe('TUI :restart', function()
     local server_session = n.connect(server_pipe)
     local _, server_pid = server_session:request('nvim_call_function', 'getpid', {})
     local function assert_new_pid()
-      tt.feed_data(string.format(':lua vim.fn.serverstart(%q)\n', server_pipe))
-      screen:expect({ unchanged = true })
-
+      server_session:close()
       server_session = n.connect(server_pipe)
-
       local _, new_pid = server_session:request('nvim_call_function', 'getpid', {})
       t.neq(server_pid, new_pid)
       server_pid = new_pid
@@ -392,36 +389,22 @@ describe('TUI :restart', function()
 
     --- Check that ":restart" uses the updated size after terminal resize.
     tt.feed_data(':restart\013')
-    screen_expect([[
-      ^                                                            |
-      {100:~                                                           }|*2
-      {3:[No Name]                                                   }|
-                                                                  |
-      {5:-- TERMINAL --}                                              |
-    ]])
+    screen:expect({ unchanged = true })
     assert_new_pid()
     assert_no_gui_running()
-
-    -- Cleanup the environment
-    if server_session then
-      server_session:close()
-    end
-    tt.feed_data(string.format(':lua vim.fn.serverstop(%q)\n', server_pipe))
-    os.remove(server_pipe)
   end)
 
   it('drops "-" and "-- [files…]" from v:argv #34417', function()
     t.skip(is_os('win'), 'stdin behavior differs on Windows')
     clear()
     local server_session
-    local server_pipe = new_pipename()
     finally(function()
       if server_session then
         server_session:close()
       end
-      os.remove(server_pipe)
       n.check_close()
     end)
+    local server_pipe = new_pipename()
     local screen = tt.setup_child_nvim({
       '-u',
       'NONE',
@@ -460,16 +443,12 @@ describe('TUI :restart', function()
                                                         |
       {5:-- TERMINAL --}                                    |
     ]])
-    -- Tell the new server to start listening on the pipe again.
-    tt.feed_data(string.format(':lua vim.fn.serverstart(%q)\013', server_pipe))
-    screen:expect({ unchanged = true })
-
+    server_session:close()
     server_session = n.connect(server_pipe)
 
     eq({ true, false }, { server_session:request('nvim_eval', expr) })
     eq({ true, false }, { server_session:request('nvim_eval', has_s) })
 
-    tt.feed_data(string.format(':lua vim.fn.serverstop(%q)\013', server_pipe))
     -- local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
     -- eq(13, #argv)
     -- eq("-c put='foo'", table.concat(argv, ' ', #argv - 1, #argv))

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -221,9 +221,7 @@ describe('TUI :restart', function()
       n.check_close()
     end)
 
-    if t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows') then
-      return
-    end
+    t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows')
 
     -- local server_pipe = new_pipename()
     local screen = tt.setup_child_nvim({
@@ -4183,9 +4181,7 @@ describe('TUI client', function()
   end)
 
   it(':restart works when connecting to remote instance (with its own TUI)', function()
-    if t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows') then
-      return
-    end
+    t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows')
 
     local _, screen_server, screen_client = start_tui_and_remote_client()
 
@@ -4285,9 +4281,7 @@ describe('TUI client', function()
   end)
 
   it(':restart works when connecting to remote instance (--headless)', function()
-    if t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows') then
-      return
-    end
+    t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows')
 
     local _, server_pipe, screen_client = start_headless_server_and_client(false)
 

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -4179,8 +4179,6 @@ describe('TUI client', function()
   end)
 
   it(':restart works when connecting to remote instance (with its own TUI)', function()
-    t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows')
-
     local _, screen_server, screen_client = start_tui_and_remote_client()
 
     -- Run :restart on the remote client.
@@ -4279,8 +4277,6 @@ describe('TUI client', function()
   end)
 
   it(':restart works when connecting to remote instance (--headless)', function()
-    t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows')
-
     local _, server_pipe, screen_client = start_headless_server_and_client(false)
 
     -- Run :restart on the client.

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -401,6 +401,10 @@ describe('TUI :restart', function()
     ]])
     assert_new_pid()
     assert_no_gui_running()
+
+    -- The server is now detached and needs to be quit explicitly.
+    feed_data(':qall!\r')
+    screen:expect({ any = vim.pesc('[Process exited 0]') })
   end)
 
   it('drops "-" and "-- [files…]" from v:argv #34417', function()
@@ -461,6 +465,10 @@ describe('TUI :restart', function()
     -- local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
     -- eq(13, #argv)
     -- eq("-c put='foo'", table.concat(argv, ' ', #argv - 1, #argv))
+
+    -- The server is now detached and needs to be quit explicitly.
+    feed_data(':qall!\r')
+    screen:expect({ any = vim.pesc('[Process exited 0]') })
   end)
 end)
 

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -262,6 +262,9 @@ describe('TUI :restart', function()
     local server_session = n.connect(server_pipe)
     local _, server_pid = server_session:request('nvim_call_function', 'getpid', {})
     local function assert_new_pid()
+      if is_os('win') then
+        return -- FIXME
+      end
       server_session:close()
       server_session = n.connect(server_pipe)
       local _, new_pid = server_session:request('nvim_call_function', 'getpid', {})

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -269,8 +269,6 @@ describe('TUI :restart', function()
 
       local _, new_pid = server_session:request('nvim_call_function', 'getpid', {})
       t.neq(server_pid, new_pid)
-
-      tt.feed_data(string.format(':lua vim.fn.serverstop(%q)\n', server_pipe))
       server_pid = new_pid
     end
 
@@ -408,6 +406,7 @@ describe('TUI :restart', function()
     if server_session then
       server_session:close()
     end
+    tt.feed_data(string.format(':lua vim.fn.serverstop(%q)\n', server_pipe))
     os.remove(server_pipe)
   end)
 

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -448,7 +448,7 @@ describe('TUI :restart', function()
     tt.feed_data(':echo ' .. expr .. '\013')
     screen:expect({ any = 'v:true' })
     tt.feed_data(':echo ' .. has_s .. '\013')
-    screen:expect({ any = 'v:true' })
+    screen:expect({ any = 'v:true', unchanged = true })
 
     tt.feed_data(":restart put='foo'\013")
     screen:expect([[
@@ -467,7 +467,7 @@ describe('TUI :restart', function()
     tt.feed_data(':echo ' .. expr .. '\013')
     screen:expect({ any = 'v:false' })
     tt.feed_data(':echo ' .. has_s .. '\013')
-    screen:expect({ any = 'v:false' })
+    screen:expect({ any = 'v:false', unchanged = true })
 
     -- local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
     -- eq(13, #argv)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -388,8 +388,14 @@ describe('TUI :restart', function()
     ]])
 
     --- Check that ":restart" uses the updated size after terminal resize.
-    tt.feed_data(':restart\013')
-    screen:expect({ unchanged = true })
+    tt.feed_data(':restart echo "restarted"\013')
+    screen_expect([[
+      ^                                                            |
+      {100:~                                                           }|*2
+      {3:[No Name]                                                   }|
+      restarted                                                   |
+      {5:-- TERMINAL --}                                              |
+    ]])
     assert_new_pid()
     assert_no_gui_running()
   end)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -262,7 +262,7 @@ describe('TUI :restart', function()
     local server_session = n.connect(server_pipe)
     local _, server_pid = server_session:request('nvim_call_function', 'getpid', {})
     local function assert_new_pid()
-      tt.feed_data(':lua vim.fn.serverstart([[' .. server_pipe .. ']])\n')
+      tt.feed_data(string.format(':lua vim.fn.serverstart(%q)\n', server_pipe))
       -- The :lua command may sometimes overflow leaving the "Press ENTER" prompt.
       -- tt.feed_data('\n')
       screen:expect({ unchanged = true })
@@ -272,7 +272,7 @@ describe('TUI :restart', function()
       local _, new_pid = server_session:request('nvim_call_function', 'getpid', {})
       t.neq(server_pid, new_pid)
 
-      tt.feed_data(':lua vim.fn.serverstop([[' .. server_pipe .. ']])\n')
+      tt.feed_data(string.format(':lua vim.fn.serverstop(%q)\n', server_pipe))
       server_pid = new_pid
     end
 
@@ -464,7 +464,7 @@ describe('TUI :restart', function()
       {5:-- TERMINAL --}                                    |
     ]])
     -- Tell the new server to start listening on the pipe again.
-    tt.feed_data(':lua vim.fn.serverstart([[' .. server_pipe .. ']])\013')
+    tt.feed_data(string.format(':lua vim.fn.serverstart(%q)\013', server_pipe))
     -- The :lua command may sometimes overflow leaving a "Press ENTER" prompt.
     -- tt.feed_data('\013')
     screen:expect({ unchanged = true })
@@ -474,7 +474,7 @@ describe('TUI :restart', function()
     eq({ true, false }, { server_session:request('nvim_eval', expr) })
     eq({ true, false }, { server_session:request('nvim_eval', has_s) })
 
-    tt.feed_data(':lua vim.fn.serverstop([[' .. server_pipe .. ']])\013')
+    tt.feed_data(string.format(':lua vim.fn.serverstop(%q)\013', server_pipe))
     -- local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
     -- eq(13, #argv)
     -- eq("-c put='foo'", table.concat(argv, ' ', #argv - 1, #argv))

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -221,20 +221,26 @@ describe('TUI :restart', function()
       n.check_close()
     end)
 
-    local server_pipe = new_pipename()
+    if t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows') then
+      return
+    end
+
+    -- local server_pipe = new_pipename()
     local screen = tt.setup_child_nvim({
       '-u',
       'NONE',
       '-i',
       'NONE',
-      '--listen',
-      server_pipe,
+      -- '--listen',
+      -- server_pipe,
       '--cmd',
       'colorscheme vim',
       '--cmd',
       nvim_set .. ' notermguicolors laststatus=2 background=dark',
-      '--cmd',
-      'echo getpid()',
+      -- XXX: New server starts before the UI connects to it.
+      -- So checking screen state for this pid is not possible.
+      -- '--cmd',
+      -- 'echo getpid()',
     }, { env = env_notermguicolors })
 
     local function screen_expect(s)
@@ -251,82 +257,82 @@ describe('TUI :restart', function()
       ^                                                  |
       {100:~                                                 }|*3
       {3:[No Name]                                         }|
-      {MATCH:%d+ +}|
+                                                        |
       {5:-- TERMINAL --}                                    |
     ]]
-    screen_expect(s0)
+    screen:expect(s0)
     assert_no_gui_running()
 
-    local server_session = n.connect(server_pipe)
-    local _, server_pid = server_session:request('nvim_call_function', 'getpid', {})
+    -- XXX: Cannot use this for pid validation.
+    -- local server_session = n.connect(server_pipe)
+    -- local _, server_pid = server_session:request('nvim_call_function', 'getpid', {})
+    -- local function assert_new_pid()
+    --   server_session:close()
+    --   server_session = n.connect(server_pipe)
+    --   local _, new_pid = server_session:request('nvim_call_function', 'getpid', {})
+    --   t.neq(server_pid, new_pid)
+    --   server_pid = new_pid
+    -- end
 
-    local function assert_new_pid()
-      server_session:close()
-      server_session = n.connect(server_pipe)
-      local _, new_pid = server_session:request('nvim_call_function', 'getpid', {})
-      t.neq(server_pid, new_pid)
-      server_pid = new_pid
-    end
-
+    --- XXX: No longer using -c <command> during new server startup.
     --- Gets the last `argn` items in v:argv as a joined string.
-    local function get_argv(argn)
-      local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
-      return table.concat(argv, ' ', #argv - argn, #argv)
-    end
+    -- local function get_argv(argn)
+    --   local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
+    --   return table.concat(argv, ' ', #argv - argn, #argv)
+    -- end
 
     local s1 = [[
                                                         |
       ^Hello1                                            |
       {100:~                                                 }|*2
       {3:[No Name] [+]                                     }|
-      {MATCH:%d+ +}|
+                                                        |
       {5:-- TERMINAL --}                                    |
     ]]
 
     tt.feed_data(':set nomodified\013')
-    -- Command is added as "-c" arg.
+    -- Command is run on new server.
     tt.feed_data(":restart put ='Hello1'\013")
-    screen_expect(s1)
-    tt.feed_data('\013')
-    assert_new_pid()
+    screen:expect(s1)
+    -- assert_new_pid()
     assert_no_gui_running()
-    eq("--cmd echo getpid() +::: -c put ='Hello1'", get_argv(4))
+    -- eq("--cmd echo getpid() +::: -c put ='Hello1'", get_argv(4))
 
     -- Complex command following +cmd.
     tt.feed_data(":restart +qall! put ='Hello2' | put ='World2'\013")
-    screen_expect([[
+    screen:expect([[
                                                         |
       Hello2                                            |
       ^World2                                            |
       {100:~                                                 }|
       {3:[No Name] [+]                                     }|
-      {MATCH:%d+ +}|
+                                                        |
       {5:-- TERMINAL --}                                    |
     ]])
-    assert_new_pid()
+    -- assert_new_pid()
     assert_no_gui_running()
-    eq("--cmd echo getpid() +::: -c put ='Hello2' | put ='World2'", get_argv(4))
+    -- eq("--cmd echo getpid() +::: -c put ='Hello2' | put ='World2'", get_argv(4))
 
     -- Check ":restart" on an unmodified buffer.
     tt.feed_data(':set nomodified\013')
     tt.feed_data(':restart\013')
-    screen_expect(s0)
-    assert_new_pid()
+    screen:expect(s0)
+    -- assert_new_pid()
     assert_no_gui_running()
 
     -- Check ":restart +qall!" on an unmodified buffer.
     tt.feed_data(':restart +qall!\013')
-    screen_expect(s0)
-    assert_new_pid()
+    screen:expect(s0)
+    -- assert_new_pid()
     assert_no_gui_running()
-    eq('--cmd echo getpid()', get_argv(1))
+    -- eq('--cmd echo getpid()', get_argv(1))
 
     -- Check ":restart +echo" cannot restart server.
     tt.feed_data(':restart +echo\013')
     screen:expect({ any = vim.pesc('+cmd did not quit the server') })
 
     tt.feed_data('ithis will be removed\027')
-    screen_expect([[
+    screen:expect([[
       this will be remove^d                              |
       {100:~                                                 }|*3
       {3:[No Name] [+]                                     }|
@@ -355,9 +361,9 @@ describe('TUI :restart', function()
     screen:expect({ any = vim.pesc('Save changes to "Untitled"?') })
     tt.feed_data('N\013')
     screen:expect({ any = '%^Hello3' })
-    assert_new_pid()
+    -- assert_new_pid()
     assert_no_gui_running()
-    eq("--cmd echo getpid() +::: -c put ='Hello3'", get_argv(4))
+    -- eq("--cmd echo getpid() +::: -c put ='Hello3'", get_argv(4))
 
     -- Check ":confirm restart +echo" correctly ignores ":confirm"
     tt.feed_data(':confirm restart +echo\013')
@@ -371,18 +377,18 @@ describe('TUI :restart', function()
     -- Check ":restart +qall!" on a modified buffer.
     tt.feed_data('ithis will be removed\027')
     tt.feed_data(':restart +qall!\013')
-    screen_expect(s0)
-    assert_new_pid()
+    screen:expect(s0)
+    -- assert_new_pid()
     assert_no_gui_running()
 
     -- No --listen conflict when server exit is delayed.
     feed_data(':lua vim.schedule(function() vim.wait(100) end); vim.cmd.restart()\n')
-    screen_expect(s0)
-    assert_new_pid()
+    screen:expect(s0)
+    -- assert_new_pid()
     assert_no_gui_running()
 
     screen:try_resize(60, 6)
-    screen_expect([[
+    screen:expect([[
       ^                                                            |
       {100:~                                                           }|*2
       {3:[No Name]                                                   }|
@@ -392,35 +398,36 @@ describe('TUI :restart', function()
 
     --- Check that ":restart" uses the updated size after terminal resize.
     tt.feed_data(':restart\013')
-    screen_expect([[
+    screen:expect([[
       ^                                                            |
       {100:~                                                           }|*2
       {3:[No Name]                                                   }|
-      {MATCH:%d+ +}|
+                                                                  |
       {5:-- TERMINAL --}                                              |
     ]])
-    assert_new_pid()
+    -- assert_new_pid()
     assert_no_gui_running()
   end)
 
   it('drops "-" and "-- [files…]" from v:argv #34417', function()
     t.skip(is_os('win'), 'stdin behavior differs on Windows')
     clear()
-    local server_session
-    finally(function()
-      if server_session then
-        server_session:close()
-      end
-      n.check_close()
-    end)
-    local server_pipe = new_pipename()
+    -- XXX: Cannot use this for pid validation.
+    -- local server_session
+    -- finally(function()
+    --   if server_session then
+    --     server_session:close()
+    --   end
+    --   n.check_close()
+    -- end)
+    -- local server_pipe = new_pipename()
     local screen = tt.setup_child_nvim({
       '-u',
       'NONE',
       '-i',
       'NONE',
-      '--listen',
-      server_pipe,
+      -- '--listen',
+      -- server_pipe,
       '--cmd',
       'set notermguicolors',
       '-s',
@@ -437,11 +444,15 @@ describe('TUI :restart', function()
                                                         |
       {5:-- TERMINAL --}                                    |
     ]])
-    server_session = n.connect(server_pipe)
+    -- server_session = n.connect(server_pipe)
     local expr = 'index(v:argv, "-") >= 0 || index(v:argv, "--") >= 0 ? v:true : v:false'
     local has_s = 'index(v:argv, "-s") >= 0 ? v:true : v:false'
-    eq({ true, true }, { server_session:request('nvim_eval', expr) })
-    eq({ true, true }, { server_session:request('nvim_eval', has_s) })
+    -- eq({ true, true }, { server_session:request('nvim_eval', expr) })
+
+    tt.feed_data(':echo ' .. expr .. '\013')
+    screen:expect({ any = 'v:true' })
+    tt.feed_data(':echo ' .. has_s .. '\013')
+    screen:expect({ any = 'v:true' })
 
     tt.feed_data(":restart put='foo'\013")
     screen:expect([[
@@ -452,14 +463,19 @@ describe('TUI :restart', function()
                                                         |
       {5:-- TERMINAL --}                                    |
     ]])
-    server_session:close()
-    server_session = n.connect(server_pipe)
+    -- server_session:close()
+    -- server_session = n.connect(server_pipe)
+    --
+    -- eq({ true, false }, { server_session:request('nvim_eval', expr) })
 
-    eq({ true, false }, { server_session:request('nvim_eval', expr) })
-    eq({ true, false }, { server_session:request('nvim_eval', has_s) })
-    local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
-    eq(13, #argv)
-    eq("-c put='foo'", table.concat(argv, ' ', #argv - 1, #argv))
+    tt.feed_data(':echo ' .. expr .. '\013')
+    screen:expect({ any = 'v:false' })
+    tt.feed_data(':echo ' .. has_s .. '\013')
+    screen:expect({ any = 'v:false' })
+
+    -- local argv = ({ server_session:request('nvim_eval', 'v:argv') })[2] --[[@type table]]
+    -- eq(13, #argv)
+    -- eq("-c put='foo'", table.concat(argv, ' ', #argv - 1, #argv))
   end)
 end)
 
@@ -4167,6 +4183,10 @@ describe('TUI client', function()
   end)
 
   it(':restart works when connecting to remote instance (with its own TUI)', function()
+    if t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows') then
+      return
+    end
+
     local _, screen_server, screen_client = start_tui_and_remote_client()
 
     -- Run :restart on the remote client.
@@ -4265,6 +4285,10 @@ describe('TUI client', function()
   end)
 
   it(':restart works when connecting to remote instance (--headless)', function()
+    if t.skip(is_os('win'), 'relies on chan.detach which is currently broken on Windows') then
+      return
+    end
+
     local _, server_pipe, screen_client = start_headless_server_and_client(false)
 
     -- Run :restart on the client.

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -263,8 +263,6 @@ describe('TUI :restart', function()
     local _, server_pid = server_session:request('nvim_call_function', 'getpid', {})
     local function assert_new_pid()
       tt.feed_data(string.format(':lua vim.fn.serverstart(%q)\n', server_pipe))
-      -- The :lua command may sometimes overflow leaving the "Press ENTER" prompt.
-      -- tt.feed_data('\n')
       screen:expect({ unchanged = true })
 
       server_session = n.connect(server_pipe)
@@ -465,8 +463,6 @@ describe('TUI :restart', function()
     ]])
     -- Tell the new server to start listening on the pipe again.
     tt.feed_data(string.format(':lua vim.fn.serverstart(%q)\013', server_pipe))
-    -- The :lua command may sometimes overflow leaving a "Press ENTER" prompt.
-    -- tt.feed_data('\013')
     screen:expect({ unchanged = true })
 
     server_session = n.connect(server_pipe)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -4167,8 +4167,7 @@ describe('TUI client', function()
   it(':restart works when connecting to remote instance (with its own TUI)', function()
     local _, screen_server, screen_client = start_tui_and_remote_client()
 
-    -- Run :restart on the remote client.
-    -- The remote client should start a new server while the original one should exit.
+    -- The remote client should attach to the new server.
     feed_data(':restart +qall!\n')
     screen_client:expect([[
       ^                                                  |
@@ -4265,8 +4264,7 @@ describe('TUI client', function()
   it(':restart works when connecting to remote instance (--headless)', function()
     local _, server_pipe, screen_client = start_headless_server_and_client(false)
 
-    -- Run :restart on the client.
-    -- The client should start a new server while the original server should exit.
+    -- The client should attach to the new server and the original server should exit.
     feed_data(':restart +qall!\n')
     screen_client:expect([[
       ^                                                  |


### PR DESCRIPTION
## Problem
The current design of the "restart" event:
- requires every UI to implement a somewhat complex set of setups
- requires the UI to be on the same machine as the server
- has race/edge cases: If the user config has errors / waiting for input, are all UIs able to attach while Nvim is waiting for input?

## Solution

- Perform the restart on the server, not the client.
- Pass listen address (instead of CLI args) in the UI event.
- Simplifies UI client logic: they only need to reattach to the new address.
- Opens the door for more enhancements in the future, such as allowing all UIs to reattach instead of only the "current" UI. #34367

### Protocol

From https://github.com/neovim/neovim/pull/35045#issuecomment-3146985628 : 
1. server (nvim-1) starts new nvim instance (nvim-2)
2. server emits `restart[addr, ... cmd]` ui event which includes the new listen address.
3. ui handler:
    1. opens a channel to nvim-2
    2. waits for nvim-1 to die (close the channel)
4. if the nvim-1 fails to quit:
    - server terminates nvim-2.
    - ui `restart` handler cancels its wait routine when it sees that nvim-2 died.


close #35149