### PR TITLE
vim-patch:{8.1.0425,9.1.1601}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1729,9 +1729,6 @@ static void enter_buffer(buf_T *buf)
   // mark cursor position as being invalid
   curwin->w_valid = 0;
 
-  buflist_setfpos(curbuf, curwin, curbuf->b_last_cursor.mark.lnum,
-                  curbuf->b_last_cursor.mark.col, true);
-
   // Make sure the buffer is loaded.
   if (curbuf->b_ml.ml_mfp == NULL) {    // need to load the file
     // If there is no filetype, allow for detecting one.  Esp. useful for

--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -1729,6 +1729,9 @@ static void enter_buffer(buf_T *buf)
   // mark cursor position as being invalid
   curwin->w_valid = 0;
 
+  buflist_setfpos(curbuf, curwin, curbuf->b_last_cursor.mark.lnum,
+                  curbuf->b_last_cursor.mark.col, true);
+
   // Make sure the buffer is loaded.
   if (curbuf->b_ml.ml_mfp == NULL) {    // need to load the file
     // If there is no filetype, allow for detecting one.  Esp. useful for

--- a/test/old/testdir/test_buffer.vim
+++ b/test/old/testdir/test_buffer.vim
@@ -609,4 +609,31 @@ func Test_closed_buffer_still_in_window()
   %bw!
 endfunc
 
+" Cursor position should be restored when switching to a buffer previously
+" viewed in a window, regardless of whether it's visible in another one.
+func Test_switch_to_previously_viewed_buffer()
+  set nostartofline
+  new Xviewbuf
+  call setline(1, range(1, 200))
+  let oldwin = win_getid()
+  vsplit
+
+  call cursor(100, 3)
+  edit Xotherbuf
+  buffer Xviewbuf
+  call assert_equal([0, 100, 3, 0], getpos('.'))
+
+  exe win_id2win(oldwin) .. 'close'
+  setlocal bufhidden=hide
+
+  call cursor(200, 3)
+  edit Xotherbuf
+  buffer Xviewbuf
+  call assert_equal([0, 200, 3, 0], getpos('.'))
+
+  bwipe! Xotherbuf
+  bwipe! Xviewbuf
+  set startofline&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_bufline.vim
+++ b/test/old/testdir/test_bufline.vim
@@ -158,6 +158,33 @@ func Test_appendbufline()
   exe "bwipe! " . b
 endfunc
 
+func Test_appendbufline_no_E315()
+  let after = [
+    \ 'set stl=%f ls=2',
+    \ 'new',
+    \ 'let buf = bufnr("%")',
+    \ 'quit',
+    \ 'vsp',
+    \ 'exec "buffer" buf',
+    \ 'wincmd w',
+    \ 'call appendbufline(buf, 0, "abc")',
+    \ 'redraw',
+    \ 'while getbufline(buf, 1)[0] =~ "^\\s*$"',
+    \ '  sleep 10m',
+    \ 'endwhile',
+    \ 'au VimLeavePre * call writefile([v:errmsg], "Xerror")',
+    \ 'au VimLeavePre * call writefile(["done"], "Xdone")',
+    \ 'qall!',
+    \ ]
+  if !RunVim([], after, '--clean')
+    return
+  endif
+  call assert_notmatch("^E315:", readfile("Xerror")[0])
+  call assert_equal("done", readfile("Xdone")[0])
+  call delete("Xerror")
+  call delete("Xdone")
+endfunc
+
 func Test_deletebufline()
   new
   let b = bufnr('%')


### PR DESCRIPTION
#### vim-patch:8.1.0425: ml_get error and crash with appendbufline()

Problem:    ml_get error and crash with appendbufline(). (Masashi Iizuka)
Solution:   Set per-window buffer info. (Hirohito Higashi, closes vim/vim#3455)

https://github.com/vim/vim/commit/9cea87c5775948a35098f3602746c20ecf95dbcd

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.1.1601: Patch v8.1.0425 was wrong

Problem:  Patch v8.1.0425 was wrong
Solution: Revert that patch (Hirohito Higashi)

This is because the root cause was fixed in 8.1.0786 and a regression
occurred elsewhere.

related: vim/vim#3455
related: vim/vim#3830
closes: vim/vim#17899

https://github.com/vim/vim/commit/6abe5e490470d339f5e9a07a478f839cebf23812

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>
