### PR TITLE
vim-patch:9.1.1602: filetype: requirements-*.txt files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -2343,6 +2343,7 @@ local pattern = {
   },
   ['require'] = {
     ['%-requirements%.txt$'] = 'requirements',
+    ['requirements%-.*%.txt$'] = 'requirements',
     ['^requirements/.*%.txt$'] = 'requirements',
     ['^requires/.*%.txt$'] = 'requirements',
   },

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -659,7 +659,7 @@ func s:GetFilenameChecks() abort
     \ 'readline': ['.inputrc', 'inputrc'],
     \ 'rego': ['file.rego'],
     \ 'remind': ['.reminders', 'file.remind', 'file.rem', '.reminders-file'],
-    \ 'requirements': ['file.pip', 'requirements.txt', 'dev-requirements.txt', 'constraints.txt', 'requirements.in', 'requirements/dev.txt', 'requires/dev.txt'],
+    \ 'requirements': ['file.pip', 'requirements.txt', 'dev-requirements.txt', 'requirements-dev.txt', 'constraints.txt', 'requirements.in', 'requirements/dev.txt', 'requires/dev.txt'],
     \ 'rescript': ['file.res', 'file.resi'],
     \ 'resolv': ['resolv.conf'],
     \ 'reva': ['file.frt'],


### PR DESCRIPTION
Problem:  filetype: requirements-*.txt files are not recognized
Solution: Detect requirements-*.txt files as requirements filetype
          (Xudong Zheng).

References:
- https://github.com/search?q=path%3Arequirements-*.txt&type=code
- https://github.com/zephyrproject-rtos/zephyr/tree/v4.2.0/scripts

closes: vim/vim#17894

https://github.com/vim/vim/commit/d305729bc570fab478c3718bd4d07bd9ddd088e0

Co-authored-by: Xudong Zheng <7pkvm5aw@slicealias.com>
