### PR TITLE
vim-patch:adfea9b: runtime(help): Unset `'comments'` and `'cms'` options

### DIFF
--- a/runtime/ftplugin/help.vim
+++ b/runtime/ftplugin/help.vim
@@ -3,6 +3,7 @@
 " Previous Maintainer:  Nikolai Weibull <now@bitwi.se>
 " Last Change:          2025 Apr 08
 " 2025 Apr 08 by Vim project (set 'omnifunc' and 'iskeyword', #17073)
+" 2025 Aug 08 by Vim project (unset comment options, #17889)
 
 if exists("b:did_ftplugin")
   finish
@@ -12,7 +13,9 @@ let b:did_ftplugin = 1
 let s:cpo_save = &cpo
 set cpo&vim
 
-let b:undo_ftplugin = "setl isk< fo< tw< cole< cocu< keywordprg< omnifunc<"
+let b:undo_ftplugin = "setl isk< fo< tw< cole< cocu< keywordprg< omnifunc< comments< cms<"
+
+setl comments= cms=
 
 setlocal formatoptions+=tcroql textwidth=78 keywordprg=:help omnifunc=s:HelpComplete
 let &l:iskeyword='!-~,^*,^|,^",192-255'


### PR DESCRIPTION
Problem:  Vim's help file doesn't have any syntax for comments, but
          'comments' and 'commentstring' are still set in the help
          buffer.
Solution: Unset 'comments' and 'cms' in help buffer

closes: vim/vim#17889

https://github.com/vim/vim/commit/adfea9b4e68f39744fcb6ce7840e1c3c3b4637db

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
