### PR TITLE
docs(build): correction in static build using container

### DIFF
--- a/BUILD.md
+++ b/BUILD.md
@@ -266,14 +266,14 @@ cmake --build build
 
 In case you are not using Alpine Linux you can use a container to do the build the binary:
 
-```bash
+```sh
 podman run \
   --rm \
   -it \
   -v "$PWD:/workdir" \
   -w /workdir \
   alpine:latest \
-  bash -c 'apk add build-base cmake coreutils curl gettext-tiny-dev && make CMAKE_EXTRA_FLAGS="-DSTATIC_BUILD=1"'
+  sh -c 'apk add build-base cmake coreutils curl gettext-tiny-dev && make CMAKE_EXTRA_FLAGS="-DSTATIC_BUILD=1"'
 ```
 
 The resulting binary in `build/bin/nvim` will have all the dependencies statically linked:


### PR DESCRIPTION
Documentation: Fix static build using container command

Problem:
When running the default provided command in static build instruction,
```
docker: Error response from daemon: failed to create task for container: failed to create shim task: OCI runtime create failed: runc create failed: unable to start container process: exec: "bash": executable file not found in $PATH: unknown.
```

Solution:
Replace bash with sh