### PR TITLE
vim-patch:d82c918: runtime(doc): Improve doc for cmdline-autocomplete

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -867,7 +867,7 @@ to insert special things while typing you can use the CTRL-R command.  For
 example, "%" stands for the current file name, while CTRL-R % inserts the
 current file name right away.  See |c_CTRL-R|.
 
-Note:  If you want to avoid the effects of special characters in a Vim script
+Note: If you want to avoid the effects of special characters in a Vim script
 you may want to use |fnameescape()|.  Also see |`=|.
 
 
@@ -1239,8 +1239,10 @@ Example: >
 	:au CmdwinLeave :  let &cpt = b:cpt_save
 This sets 'complete' to use completion in the current window for |i_CTRL-N|.
 Another example: >
-	:au CmdwinEnter [/?]  startinsert
+	:au CmdwinEnter [/\?]  startinsert
 This will make Vim start in Insert mode in the command-line window.
+Note: The "?" needs to be escaped, as this is a |file-pattern|.  See also
+|cmdline-autocompletion|.
 
 					*cmdline-char* *cmdwin-char*
 The character used for the pattern indicates the type of command-line:

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -11912,6 +11912,11 @@ wildtrigger()                                                    *wildtrigger()*
 			cnoremap <Up>   <C-U><Up>
 			cnoremap <Down> <C-U><Down>
 <
+		To set an option specifically when performing a search, e.g.
+		to set 'pumheight': >vim
+			autocmd CmdlineEnter [/\?] set pumheight=8
+			autocmd CmdlineLeave [/\?] set pumheight&
+<
 		Return value is always 0.
 
                 Return: ~

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -10844,6 +10844,11 @@ function vim.fn.wildmenumode() end
 ---   cnoremap <Up>   <C-U><Up>
 ---   cnoremap <Down> <C-U><Down>
 --- <
+--- To set an option specifically when performing a search, e.g.
+--- to set 'pumheight': >vim
+---   autocmd CmdlineEnter [/\?] set pumheight=8
+---   autocmd CmdlineLeave [/\?] set pumheight&
+--- <
 --- Return value is always 0.
 ---
 --- @return number

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -13102,6 +13102,11 @@ M.funcs = {
       	cnoremap <Up>   <C-U><Up>
       	cnoremap <Down> <C-U><Down>
       <
+      To set an option specifically when performing a search, e.g.
+      to set 'pumheight': >vim
+      	autocmd CmdlineEnter [/\?] set pumheight=8
+      	autocmd CmdlineLeave [/\?] set pumheight&
+      <
       Return value is always 0.
     ]==],
     name = 'wildtrigger',


### PR DESCRIPTION
#### vim-patch:d82c918: runtime(doc): Improve doc for cmdline-autocomplete

Maybe this was unnecessary, but saw this:
https://github.com/vim/vim/issues/17854

https://github.com/vim/vim/commit/d82c918e2f3e6af65c36fb14457968053dcc03a3

Co-authored-by: Girish Palya <girishji@gmail.com>