### PR TITLE
vim-patch:9.1.1604: completion: incsearch highlight might be lost

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1489,13 +1489,11 @@ static int command_line_execute(VimState *state, int key)
   // If already used to cancel/accept wildmenu, don't process the key further.
   if (wild_type == WILD_CANCEL || wild_type == WILD_APPLY) {
     // Apply search highlighting
-    if (wild_type == WILD_APPLY) {
-      if (s->is_state.winid != curwin->handle) {
-        init_incsearch_state(&s->is_state);
-      }
-      if (KeyTyped || vpeekc() == NUL) {
-        may_do_incsearch_highlighting(s->firstc, s->count, &s->is_state);
-      }
+    if (s->is_state.winid != curwin->handle) {
+      init_incsearch_state(&s->is_state);
+    }
+    if (KeyTyped || vpeekc() == NUL) {
+      may_do_incsearch_highlighting(s->firstc, s->count, &s->is_state);
     }
     return command_line_not_changed(s);
   }

--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -484,6 +484,21 @@ describe('cmdline', function()
       /the^                                                        |
     ]])
 
+    -- 'incsearch' highlight is restored after dismissing popup (Ctrl_E)
+    feed('<esc>')
+    command('set wop=pum is nohls')
+    feed('gg/th<tab><c-e>')
+    screen:expect([[
+      the                                                         |
+      {2:th}ese                                                       |
+      the                                                         |
+      foobar                                                      |
+      thethe                                                      |
+      thethere                                                    |
+      {1:~                                                           }|*3
+      /th^                                                         |
+    ]])
+
     feed('<esc>')
   end)
 

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -4659,6 +4659,12 @@ func Test_search_wildmenu_screendump()
   call term_sendkeys(buf, "\<c-n>\<c-y>")
   call VerifyScreenDump(buf, 'Test_search_wildmenu_8', {})
 
+  " 'incsearch' highlight is restored after dismissing popup (Ctrl_E)
+  call term_sendkeys(buf, "\<esc>:set wop=pum is hls&\<cr>")
+  call term_sendkeys(buf, "gg/th\<tab>\<c-e>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_search_wildmenu_9', {})
+
   call term_sendkeys(buf, "\<esc>")
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.1604: completion: incsearch highlight might be lost

Problem:  completion: incsearch highlight might be lost after search
          completion (Hirohito Higashi)
Solution: Restore incsearch highlight after dismissing pum with Ctrl-E
          (Girish Palya)

related: vim/vim#17870
closes: vim/vim#17891

https://github.com/vim/vim/commit/04c9e78cd33216dfd2cc59b748d1e267d6920c9a

This change actually isn't needed as Nvim doesn't call update_screen()
to redraw pum, but it doesn't hurt either.

Co-authored-by: Girish Palya <girishji@gmail.com>