### PR TITLE
fix(snippet): sync tabstop text also if pmenu is visible

### DIFF
--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -375,7 +375,7 @@ local function setup_autocmds(bufnr)
     end,
   })
 
-  vim.api.nvim_create_autocmd({ 'TextChanged', 'TextChangedI' }, {
+  vim.api.nvim_create_autocmd({ 'TextChanged', 'TextChangedI', 'TextChangedP' }, {
     group = snippet_group,
     desc = 'Update active tabstops when buffer text changes',
     buffer = bufnr,


### PR DESCRIPTION
Using a snippet like:

    ${1:name} :: ${2}\n${1:name} ${3}= ${4:undefined}${0}

The text for `${1:name}` stopped syncing if the completion popup menu
showed up. E.g. typing `par` where the `a` triggered completion resulted
in:

    pat ::
    pa = undefined

Instead of:

    pat ::
    pat = undefined
