### PR TITLE
vim-patch:9.1.{0748,1608}

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -2020,6 +2020,7 @@ static const char *set_context_by_cmdname(const char *cmd, cmdidx_T cmdidx, expa
   case CMD_tab:
   case CMD_tabdo:
   case CMD_topleft:
+  case CMD_unsilent:
   case CMD_verbose:
   case CMD_vertical:
   case CMD_windo:

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -3025,13 +3025,16 @@ static void append_command(const char *cmd)
 }
 
 /// Return true and set "*idx" if "p" points to a one letter command.
-/// - The 'k' command can directly be followed by any character.
+/// - The 'k' command can directly be followed by any character
+///          but :keepa[lt] is another command, as are :keepj[umps],
+///          :kee[pmarks] and :keepp[atterns].
 /// - The 's' command can be followed directly by 'c', 'g', 'i', 'I' or 'r'
 ///          but :sre[wind] is another command, as are :scr[iptnames],
 ///          :scs[cope], :sim[alt], :sig[ns] and :sil[ent].
 static int one_letter_cmd(const char *p, cmdidx_T *idx)
 {
-  if (*p == 'k') {
+  if (p[0] == 'k'
+      && (p[1] != 'e' || (p[1] == 'e' && p[2] != 'e'))) {
     *idx = CMD_k;
     return true;
   }
@@ -3064,6 +3067,9 @@ char *find_ex_command(exarg_T *eap, int *full)
   char *p = eap->cmd;
   if (one_letter_cmd(p, &eap->cmdidx)) {
     p++;
+    if (full != NULL) {
+      *full = true;
+    }
   } else {
     while (ASCII_ISALPHA(*p)) {
       p++;

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -1244,6 +1244,10 @@ func Test_cmdline_complete_various()
   call feedkeys(":ka\<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal("\"ka\<C-A>", @:)
 
+  " completion for :keepmarks command
+  call feedkeys(":kee edi\<C-A>\<C-B>\"\<CR>", 'xt')
+  call assert_equal("\"kee edit", @:)
+
   " completion for short version of the :s command
   call feedkeys(":sI \<C-A>\<C-B>\"\<CR>", 'xt')
   call assert_equal("\"sI \<C-A>", @:)
@@ -4348,6 +4352,28 @@ func Test_term_option()
   call feedkeys(":set t_\<C-A>\<C-B>\"\<CR>", 'tx')
   call assert_match(expected, @:)
   let &cpo = _cpo
+endfunc
+
+func Test_ex_command_completion()
+  " required for :*
+  " set cpo+=*
+  let list = filter(getcompletion('', 'command'), 'exists(":" . v:val) == 0')
+  " :++ and :-- are only valid in Vim9 script context, so they can be ignored
+  " call assert_equal(['++', '--'], sort(list))
+  call assert_equal([], sort(list))
+  call assert_equal(2, exists(':k'))
+  call assert_equal(0, exists(':ke'))
+  call assert_equal(1, exists(':kee'))
+  call assert_equal(1, exists(':keep'))
+  call assert_equal(1, exists(':keepm'))
+  call assert_equal(1, exists(':keepma'))
+  call assert_equal(1, exists(':keepmar'))
+  call assert_equal(1, exists(':keepmark'))
+  call assert_equal(2, exists(':keepmarks'))
+  call assert_equal(2, exists(':keepalt'))
+  call assert_equal(2, exists(':keepjumps'))
+  call assert_equal(2, exists(':keeppatterns'))
+  set cpo-=*
 endfunc
 
 func Test_cd_bslash_completion_windows()

--- a/test/old/testdir/test_cmdmods.vim
+++ b/test/old/testdir/test_cmdmods.vim
@@ -1,0 +1,38 @@
+" Test for all command modifiers in
+
+func Test_keep_cmdmods_names()
+  call assert_equal('k', fullcommand(':k'))
+  call assert_equal('k', fullcommand(':ke'))
+  call assert_equal('keepmarks', fullcommand(':kee'))
+  call assert_equal('keepmarks', fullcommand(':keep'))
+  call assert_equal('keepmarks', fullcommand(':keepm'))
+  call assert_equal('keepmarks', fullcommand(':keepma'))
+  call assert_equal('keepmarks', fullcommand(':keepmar'))
+  call assert_equal('keepmarks', fullcommand(':keepmark'))
+  call assert_equal('keepmarks', fullcommand(':keepmarks'))
+  call assert_equal('keepalt', fullcommand(':keepa'))
+  call assert_equal('keepalt', fullcommand(':keepal'))
+  call assert_equal('keepalt', fullcommand(':keepalt'))
+  call assert_equal('keepjumps', fullcommand(':keepj'))
+  call assert_equal('keepjumps', fullcommand(':keepju'))
+  call assert_equal('keepjumps', fullcommand(':keepjum'))
+  call assert_equal('keepjumps', fullcommand(':keepjump'))
+  call assert_equal('keepjumps', fullcommand(':keepjumps'))
+  call assert_equal('keeppatterns', fullcommand(':keepp'))
+  call assert_equal('keeppatterns', fullcommand(':keeppa'))
+  call assert_equal('keeppatterns', fullcommand(':keeppat'))
+  call assert_equal('keeppatterns', fullcommand(':keeppatt'))
+  call assert_equal('keeppatterns', fullcommand(':keeppatte'))
+  call assert_equal('keeppatterns', fullcommand(':keeppatter'))
+  call assert_equal('keeppatterns', fullcommand(':keeppattern'))
+  call assert_equal('keeppatterns', fullcommand(':keeppatterns'))
+endfunc
+
+func Test_cmdmod_completion()
+  call assert_equal('edit', getcompletion('keepalt ed',      'cmdline')[0])
+  call assert_equal('edit', getcompletion('keepjumps ed',    'cmdline')[0])
+  call assert_equal('edit', getcompletion('keepmarks ed',    'cmdline')[0])
+  call assert_equal('edit', getcompletion('keeppatterns ed', 'cmdline')[0])
+endfunc
+
+" vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_exists.vim
+++ b/test/old/testdir/test_exists.vim
@@ -105,6 +105,13 @@ func Test_exists()
   " Internal command with a count
   call assert_equal(0, exists(':3buffer'))
 
+  " Valid internal command (full match)
+  call assert_equal(2, exists(':k'))
+  " Non-existing internal command (':k' with arg 'e')
+  call assert_equal(0, exists(':ke'))
+  " Valid internal command (partial match)
+  call assert_equal(1, exists(':kee'))
+
   " User defined command (full match)
   command! MyCmd :echo 'My command'
   call assert_equal(2, exists(':MyCmd'))


### PR DESCRIPTION
#### vim-patch:9.1.0748: :keep* commmands are sometimes misidentified as :k

Problem:  The :keep{alt,jumps,marks,patterns} commmands are sometimes
          misidentified as :k.
Solution: Make sure one_letter_cmd() only returns true for :k and not
          other :keep* commands (Doug Kearns).

This currently manifests as missing completion for :keep* commands and
incorrect results from fullcommand().

E.g., fullcommand("keepmarks") returns "k" rather than "keepmarks".

The correct command, however, is executed as command modifiers are
handled specially in do_one_cmd() rather than using find_ex_command().

Fix exists(':k') so that it returns 2 for a full match.

closes: vim/vim#15742

https://github.com/vim/vim/commit/ea84202372061be9b5a9d16b360d5a17d93ccf7e

Cherry-pick Test_ex_command_completion() from patch 9.1.0624.

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:9.1.1608: No command-line completion for :unsilent {command}

Problem:  No command-line completion for :unsilent {command}.
Solution: Add missing command arg completion (Doug Kearns).
          (author)

Add completion tests for all command modifiers.

closes: vim/vim#17524

https://github.com/vim/vim/commit/126731c8fde545e8aedb83076badbc8a6ef1201d

Co-authored-by: Doug Kearns <dougkearns@gmail.com>