### PR TITLE
feat(lsp): enable high-level features per-config

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1802,6 +1802,52 @@ Lua module: vim.lsp.client                                        *lsp-client*
                                (navigation, hover) may or may not work
                                depending on the language server, even if the
                                server doesn't require a workspace.
+      • {features}?            (`vim.lsp.ClientConfig.Features`) An optional
+                               table to enable certain features for the
+                               client, such as completion, inlay hints, etc.
+                               See |vim.lsp.Client.Features| for more
+                               information. See
+                               |vim.lsp.ClientConfig.Features|.
+
+*vim.lsp.ClientConfig.Features*
+    A table representing which features to enable for a client. A `true` value
+    will enable the feature with the default configuration. A configuration
+    table can be passed to enable the feature with customizations. A `false`
+    value means the feature will be disabled.
+
+    Example: >lua
+        vim.lsp.config('lua_ls', {
+          features = {
+            semantic_tokens = false,
+            completion = true,
+          }
+        })
+<
+
+    Fields: ~
+      • {completion}?       (`boolean|vim.lsp.completion.BufferOpts`) Whether
+                            to enable |lsp-autocompletion|. Disabled by
+                            default. Opts are passed to
+                            |vim.lsp.completion.enable()|.
+      • {semantic_tokens}?  (`boolean|vim.lsp.semantic_tokens.start.Opts`)
+                            Whether to enable |lsp-semantic_tokens|. Enabled
+                            by default. Opts are passed to
+                            |vim.lsp.semantic_tokens.start()|.
+      • {inlay_hints}?      (`boolean`) Whether to enable |lsp-inlay_hint|.
+                            Disabled by default.
+      • {document_color}?   (`boolean|vim.lsp.document_color.enable.Opts`)
+                            Whether to enable |lsp-document_color|. Enabled by
+                            default. Opts are passed to
+                            |vim.lsp.document_color.enable()|.
+      • {diagnostics}?      (`boolean`) Whether to enable |lsp-diagnostic|.
+                            Enabled by default.
+      • {folding}?          (`boolean`) Whether to enable LSP folding ranges.
+                            Enabled by default.
+
+                            NOTE: This does NOT set the |'foldexpr'| to
+                            |vim.lsp.foldexpr()|.
+      • {linked_editing}?   (`boolean`) Whether to enable
+                            |lsp-linked_editing_range|. Disabled by default.
 
 
 Client:cancel_request({id})                          *Client:cancel_request()*

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -252,6 +252,8 @@ LSP
   See |lsp-inline_completion| for quickstart instructions.
 • Support for `textDocument/onTypeFormatting`: |lsp-on_type_formatting|
   https://microsoft.github.io/language-server-protocol/specification/#textDocument_onTypeFormatting
+• High-level LSP features such as inlay hints, semantic tokens, etc. can now
+  be enabled/disabled from the client setup. See |vim.lsp.Client.Features|.
 
 LUA
 

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -533,6 +533,7 @@ end
 --- clients as needed)
 function lsp.enable(name, enable)
   validate('name', name, { 'string', 'table' })
+  validate('enable', enable, 'boolean', true)
 
   local names = vim._ensure_list(name) --[[@as string[] ]]
   for _, nm in ipairs(names) do
@@ -781,9 +782,6 @@ function lsp._set_defaults(client, bufnr)
       end, { buffer = bufnr, desc = 'vim.lsp.buf.hover()' })
     end
   end)
-  if client:supports_method(ms.textDocument_diagnostic) then
-    lsp.diagnostic._enable(bufnr)
-  end
 end
 
 --- @deprecated

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -586,6 +586,12 @@ function M._start(bufnr, client_id, debounce)
   highlighter:on_attach(client_id)
 end
 
+--- @inlinedoc
+--- @class vim.lsp.semantic_tokens.start.Opts
+--- (default: 200): Debounce token requests
+--- to the server by the given number in milliseconds
+--- @field debounce? integer
+
 --- Start the semantic token highlighting engine for the given buffer with the
 --- given client. The client must already be attached to the buffer.
 ---
@@ -602,9 +608,7 @@ end
 ---@deprecated
 ---@param bufnr (integer) Buffer number, or `0` for current buffer
 ---@param client_id (integer) The ID of the |vim.lsp.Client|
----@param opts? (table) Optional keyword arguments
----  - debounce (integer, default: 200): Debounce token requests
----        to the server by the given number in milliseconds
+---@param opts? (vim.lsp.semantic_tokens.start.Opts) Optional keyword arguments
 function M.start(bufnr, client_id, opts)
   vim.deprecate('vim.lsp.semantic_tokens.start', 'vim.lsp.semantic_tokens.enable(true)', '0.13.0')
   vim.validate('bufnr', bufnr, 'number')

--- a/test/functional/plugin/lsp/semantic_tokens_spec.lua
+++ b/test/functional/plugin/lsp/semantic_tokens_spec.lua
@@ -502,9 +502,9 @@ describe('semantic token highlighting', function()
             name = 'dummy',
             cmd = _G.server.cmd,
             --- @param client vim.lsp.Client
-            on_attach = vim.schedule_wrap(function(client, _bufnr)
+            on_attach = function(client, _bufnr)
               client.server_capabilities.semanticTokensProvider = nil
-            end),
+            end,
           })
         end)
         eq(true, exec_lua('return vim.lsp.buf_is_attached(0, ...)', client_id))


### PR DESCRIPTION
This commit adds a new member, `features`, to the `ClientConfig` object. Features can be enabled/disabled from this object, allowing a more data-oriented style of configuring servers (per-server or globally).

Example:

```lua
vim.lsp.config('lua_ls', {
  features = {
    semantic_tokens = false,
    completion = true,
  }
})
```

Closes #34659

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

