### PR TITLE
fix(meta): fix types for `getcmd[win]type()`

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -3430,7 +3430,7 @@ getcmdtype()                                                      *getcmdtype()*
 		Also see |getcmdpos()|, |setcmdpos()| and |getcmdline()|.
 
                 Return: ~
-                  (`':'|'>'|'/'|'?'|'@'|'-'|'='`)
+                  (`':'|'>'|'/'|'?'|'@'|'-'|'='|''`)
 
 getcmdwintype()                                                *getcmdwintype()*
 		Return the current |command-line-window| type. Possible return
@@ -3438,7 +3438,7 @@ getcmdwintype()                                                *getcmdwintype()*
 		when not in the command-line window.
 
                 Return: ~
-                  (`':'|'>'|'/'|'?'|'@'|'-'|'='`)
+                  (`':'|'>'|'/'|'?'|'@'|'-'|'='|''`)
 
 getcompletion({pat}, {type} [, {filtered}])                    *getcompletion()*
 		Return a list of command-line completion matches. The String

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -3075,14 +3075,14 @@ function vim.fn.getcmdscreenpos() end
 --- Returns an empty string otherwise.
 --- Also see |getcmdpos()|, |setcmdpos()| and |getcmdline()|.
 ---
---- @return ':'|'>'|'/'|'?'|'@'|'-'|'='
+--- @return ':'|'>'|'/'|'?'|'@'|'-'|'='|''
 function vim.fn.getcmdtype() end
 
 --- Return the current |command-line-window| type. Possible return
 --- values are the same as |getcmdtype()|. Returns an empty string
 --- when not in the command-line window.
 ---
---- @return ':'|'>'|'/'|'?'|'@'|'-'|'='
+--- @return ':'|'>'|'/'|'?'|'@'|'-'|'='|''
 function vim.fn.getcmdwintype() end
 
 --- Return a list of command-line completion matches. The String

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -3854,7 +3854,7 @@ M.funcs = {
     ]=],
     name = 'getcmdtype',
     params = {},
-    returns = "':'|'>'|'/'|'?'|'@'|'-'|'='",
+    returns = "':'|'>'|'/'|'?'|'@'|'-'|'='|''",
     signature = 'getcmdtype()',
   },
   getcmdwintype = {
@@ -3865,7 +3865,7 @@ M.funcs = {
     ]=],
     name = 'getcmdwintype',
     params = {},
-    returns = "':'|'>'|'/'|'?'|'@'|'-'|'='",
+    returns = "':'|'>'|'/'|'?'|'@'|'-'|'='|''",
     signature = 'getcmdwintype()',
   },
   getcompletion = {


### PR DESCRIPTION
These functions can return empty strings as described in their docs.
