### PR TITLE
vim-patch:9.1.{1603,1609}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -68,6 +68,7 @@
 #include "nvim/help.h"
 #include "nvim/indent.h"
 #include "nvim/indent_c.h"
+#include "nvim/insexpand.h"
 #include "nvim/main.h"
 #include "nvim/map_defs.h"
 #include "nvim/mapping.h"
@@ -2104,6 +2105,8 @@ void free_buf_options(buf_T *buf, bool free_p_ff)
   callback_free(&buf->b_ofu_cb);
   clear_string_option(&buf->b_p_tsrfu);
   callback_free(&buf->b_tsrfu_cb);
+  clear_cpt_callbacks(&buf->b_p_cpt_cb, buf->b_p_cpt_count);
+  buf->b_p_cpt_count = 0;
   clear_string_option(&buf->b_p_gefm);
   clear_string_option(&buf->b_p_gp);
   clear_string_option(&buf->b_p_mp);

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -540,6 +540,8 @@ struct file_buffer {
 #ifdef BACKSLASH_IN_FILENAME
   char *b_p_csl;                ///< 'completeslash'
 #endif
+  Callback *b_p_cpt_cb;         ///< F{func} in 'complete' callback
+  int b_p_cpt_count;            ///< Count of values in 'complete'
   char *b_p_cfu;                ///< 'completefunc'
   Callback b_cfu_cb;            ///< 'completefunc' callback
   char *b_p_ofu;                ///< 'omnifunc'

--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -4795,6 +4795,9 @@ bool garbage_collect(bool testing)
     ABORTING(set_ref_in_callback)(&buf->b_tsrfu_cb, copyID, NULL, NULL);
     ABORTING(set_ref_in_callback)(&buf->b_tfu_cb, copyID, NULL, NULL);
     ABORTING(set_ref_in_callback)(&buf->b_ffu_cb, copyID, NULL, NULL);
+    if (!abort && buf->b_p_cpt_cb != NULL) {
+      ABORTING(set_ref_in_cpt_callbacks)(buf->b_p_cpt_cb, buf->b_p_cpt_count, copyID);
+    }
   }
 
   // 'completefunc', 'omnifunc' and 'thesaurusfunc' callbacks

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -333,7 +333,6 @@ typedef struct cpt_source_T {
   uint64_t compl_start_tv;  ///< Timestamp when match collection starts
 } cpt_source_T;
 
-#define STARTCOL_NONE   -9
 /// Pointer to the array of completion sources
 static cpt_source_T *cpt_sources_array;
 /// Total number of completion sources specified in the 'cpt' option
@@ -4620,10 +4619,12 @@ static void prepare_cpt_compl_funcs(void)
         } else {
           startcol = -2;
         }
+      } else if (startcol < 0 || startcol > curwin->w_cursor.col) {
+        startcol = curwin->w_cursor.col;
       }
       cpt_sources_array[idx].cs_startcol = startcol;
     } else {
-      cpt_sources_array[idx].cs_startcol = STARTCOL_NONE;
+      cpt_sources_array[idx].cs_startcol = -3;
     }
 
     (void)copy_option_part(&p, IObuff, IOSIZE, ",");  // Advance p
@@ -6379,14 +6380,14 @@ static void cpt_compl_refresh(void)
           } else {
             startcol = -2;
           }
+        } else if (startcol < 0 || startcol > curwin->w_cursor.col) {
+          startcol = curwin->w_cursor.col;
         }
         cpt_sources_array[cpt_sources_index].cs_startcol = startcol;
         if (ret == OK) {
           compl_source_start_timer(cpt_sources_index);
           get_cpt_func_completion_matches(cb);
         }
-      } else {
-        cpt_sources_array[cpt_sources_index].cs_startcol = STARTCOL_NONE;
       }
     }
 

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -5109,6 +5109,7 @@ void buf_copy_options(buf_T *buf, int flags)
       }
       buf->b_p_cpt = xstrdup(p_cpt);
       COPY_OPT_SCTX(buf, kBufOptComplete);
+      set_buflocal_cpt_callbacks(buf);
 #ifdef BACKSLASH_IN_FILENAME
       buf->b_p_csl = xstrdup(p_csl);
       COPY_OPT_SCTX(buf, kBufOptCompleteslash);

--- a/src/nvim/optionstr.c
+++ b/src/nvim/optionstr.c
@@ -118,6 +118,15 @@ char *illegal_char(char *errbuf, size_t errbuflen, int c)
   return errbuf;
 }
 
+static char *illegal_char_after_chr(char *errbuf, size_t errbuflen, int c)
+{
+  if (errbuf == NULL) {
+    return "";
+  }
+  vim_snprintf(errbuf, errbuflen, _(e_illegal_character_after_chr), c);
+  return errbuf;
+}
+
 /// Check string options in a buffer for NULL value.
 void check_buf_options(buf_T *buf)
 {
@@ -902,9 +911,8 @@ const char *did_set_complete(optset_T *args)
     }
     if (char_before != NUL) {
       if (args->os_errbuf != NULL) {
-        vim_snprintf(args->os_errbuf, args->os_errbuflen,
-                     _(e_illegal_character_after_chr), char_before);
-        return args->os_errbuf;
+        return illegal_char_after_chr(args->os_errbuf, args->os_errbuflen,
+                                      char_before);
       }
       return NULL;
     }
@@ -912,6 +920,10 @@ const char *did_set_complete(optset_T *args)
     while (*p == ',' || *p == ' ') {
       p++;
     }
+  }
+
+  if (set_cpt_callbacks(args) != OK) {
+    return illegal_char_after_chr(args->os_errbuf, args->os_errbuflen, 'F');
   }
   return NULL;
 }

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -5524,4 +5524,32 @@ func Test_scriplocal_autoload_func()
   let &rtp = save_rtp
 endfunc
 
+" Issue #17907
+func Test_omni_start_invalid_col()
+  func OmniFunc(startcol, findstart, base)
+    if a:findstart
+      return a:startcol
+    else
+      return ['foo', 'foobar']
+    endif
+  endfunc
+
+  new
+  redraw  " need this to prevent NULL dereference in Nvim
+  set complete=o
+  set omnifunc=funcref('OmniFunc',\ [-1])
+  call setline(1, ['baz '])
+  call feedkeys("A\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('baz foo', getline(1))
+
+  set omnifunc=funcref('OmniFunc',\ [1000])
+  call setline(1, ['bar '])
+  call feedkeys("A\<C-N>\<Esc>0", 'tx!')
+  call assert_equal('bar foo', getline(1))
+  bw!
+
+  delfunc OmniFunc
+  set omnifunc& complete&
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -290,11 +290,17 @@ func Test_complete()
   set complete=.,w,b,u,k,s,i,d,],t,U,F,o
   set complete=.
   set complete=.^10,t^0
-  set complete+=Ffuncref('foo'\\,\ [10])
-  set complete=Ffuncref('foo'\\,\ [10])^10
+
+  func Foo(a, b)
+    return ''
+  endfunc
+
+  set complete+=Ffuncref('Foo'\\,\ [10])
+  set complete=Ffuncref('Foo'\\,\ [10])^10
   set complete&
-  set complete+=Ffunction('g:foo'\\,\ [10\\,\ 20])
+  set complete+=Ffunction('g:Foo'\\,\ [10\\,\ 20])
   set complete&
+  delfunc Foo
 endfun
 
 func Test_set_completion()


### PR DESCRIPTION
#### vim-patch:9.1.1603: completion: cannot use autoloaded funcs in 'complete' F{func}

Problem:  completion: cannot use autoloaded funcs in 'complete' F{func}
          (Maxim Kim)
Solution: Make it work (Girish Palya)

closes: vim/vim#17885

https://github.com/vim/vim/commit/1bfe86a7d37ea849078255f16f99ed69fbf205dc

Cherry-pick Test_omni_autoload() from patch 8.2.3223.

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1609: complete: Heap-buffer overflow with complete function

Problem:  complete: Heap-buffer overflow with complete function
          (zeertzjq)
Solution: Do not let startcol become negative (Girish Palya).

closes: vim/vim#17934

https://github.com/vim/vim/commit/761ea77670c4fdb96d6c6fb7d4db6dc77eb8095f

Co-authored-by: Girish Palya <girishji@gmail.com>
Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>