### PR TITLE
docs: enable syntax-highlight and fix syntax error in codeblock

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -47,7 +47,8 @@ opened by other processes connecting to TCP/IP sockets or named pipes listened
 to by Nvim.
 
 Nvim creates a default RPC socket at |startup|, given by |v:servername|. To
-start with a TCP/IP socket instead, use |--listen| with a TCP-style address: >
+start with a TCP/IP socket instead, use |--listen| with a TCP-style address:
+>sh
     nvim --listen 127.0.0.1:6666
 More endpoints can be started with |serverstart()|.
 
@@ -209,7 +210,7 @@ any of these approaches:
      can define functions at runtime.
 
   2. Start Nvim with |--api-info|. Useful for statically-compiled clients.
-     Example (requires Python "pyyaml" and "msgpack-python" modules): >
+     Example (requires Python "pyyaml" and "msgpack-python" modules): >sh
      nvim --api-info | python -c 'import msgpack, sys, yaml; yaml.dump(msgpack.unpackb(sys.stdin.buffer.read()), sys.stdout)'
 <
   3. Use the |api_info()| Vimscript function. >vim

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1223,7 +1223,7 @@ Thus you can resize the command-line window, but not others.
 The |getcmdwintype()| function returns the type of the command-line being
 edited as described in |cmdwin-char|.
 
-Nvim defines this default CmdwinEnter autocmd in the "nvim.cmdwin" group: >
+Nvim defines this default CmdwinEnter autocmd in the "nvim.cmdwin" group: >vim
     autocmd CmdwinEnter [:>] syntax sync minlines=1 maxlines=1
 <
 You can disable this in your config with "autocmd! nvim.cmdwin". |default-autocmds|

--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -139,7 +139,7 @@ LSP
 • *vim.lsp.util.extract_completion_items()*
 • *vim.lsp.util.parse_snippet()*
 • *vim.lsp.util.text_document_completion_list_to_complete_items()*
-• *vim.lsp.util.lookup_section()*		Use |vim.tbl_get()| instead: >
+• *vim.lsp.util.lookup_section()*		Use |vim.tbl_get()| instead: >lua
 						local keys = vim.split(section, '.', { plain = true })
 						local  vim.tbl_get(table, unpack(keys))
 

--- a/runtime/doc/dev_tools.txt
+++ b/runtime/doc/dev_tools.txt
@@ -102,7 +102,7 @@ Then, in another terminal:
 
 USING LLDB TO STEP THROUGH UNIT TESTS
 
->
+>sh
     lldb .deps/usr/bin/luajit -- .deps/usr/bin/busted --lpath="./build/?.lua" test/unit/
 <
 USING GDB

--- a/runtime/doc/develop.txt
+++ b/runtime/doc/develop.txt
@@ -143,7 +143,7 @@ DOCUMENTATION                                           *dev-doc*
     ❌ NO:
     /// Get a highlight definition.
 - Avoid starting docstrings with "The" or "A" unless needed to avoid
-  ambiguity. This is a visual aid and reduces noise. >
+  ambiguity. This is a visual aid and reduces noise. >c
     ✅ OK:
     /// @param dirname Path fragment before `pend`
     ❌ NO:
@@ -205,7 +205,7 @@ Docstring format:
   Code samples can be annotated as `vim` or `lua`
 
 Example: the help for |nvim_open_win()| is generated from a docstring defined
-in src/nvim/api/win_config.c like this: >
+in src/nvim/api/win_config.c like this: >c
 
     /// Opens a new window.
     /// ...
@@ -278,7 +278,7 @@ Docstring format:
 - Files declared as `@meta` are only used for typing and documentation (similar to "*.d.ts" typescript files).
 
 Example: the help for |vim.paste()| is generated from a docstring decorating
-vim.paste in runtime/lua/vim/_editor.lua like this: >
+vim.paste in runtime/lua/vim/_editor.lua like this: >lua
 
     --- Paste handler, invoked by |nvim_paste()| when a conforming UI
     --- (such as the |TUI|) pastes text into the editor.
@@ -502,7 +502,7 @@ Example: >
                                                         *continuation*
 A "continuation" is implemented as a callback function that returns the result
 of an async function and is called exactly once. Often accepts `err` as the
-first parameter, to avoid erroring on the main thread. Example: >
+first parameter, to avoid erroring on the main thread. Example: >lua
     foo(…, callback: fun(err, …))
 Use the name `callback` only for a continuation. All other callbacks and event
 handlers should be named with the |dev-name-events| "on_…" convention.
@@ -527,12 +527,12 @@ be a parameter (typically manifest as mutually-exclusive buf/win/… flags like
   and uses the "del" {verb}.
 
                                                         *dev-namespace-name*
-Use namespace names like `nvim.foo.bar`: >
+Use namespace names like `nvim.foo.bar`: >lua
     vim.api.nvim_create_namespace('nvim.lsp.codelens')
 <
 
                                                         *dev-augroup-name*
-Use autocommand group names like `nvim.foo.bar`: >
+Use autocommand group names like `nvim.foo.bar`: >lua
     vim.api.nvim_create_augroup('nvim.treesitter.dev')
 <
 

--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -85,13 +85,13 @@ HANDLERS                                                *diagnostic-handlers*
 Diagnostics are shown to the user with |vim.diagnostic.show()|. The display of
 diagnostics is managed through handlers. A handler is a table with a "show"
 and (optionally) a "hide" function. The "show" function has the signature
->
+>lua
     function(namespace, bufnr, diagnostics, opts)
 <
 and is responsible for displaying or otherwise handling the given
 diagnostics. The "hide" function takes care of "cleaning up" any actions taken
 by the "show" function and has the signature
->
+>lua
     function(namespace, bufnr)
 <
 Handlers can be configured with |vim.diagnostic.config()| and added by

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -142,16 +142,16 @@ EXAMPLE: DEFINE A CONFIG AS CODE ~
 
 EXAMPLE: DEFINE A CONFIG AS A FILE ~
 
-1. Create a file `lsp/foo.lua` somewhere on your 'runtimepath'. >
+1. Create a file `lsp/foo.lua` somewhere on your 'runtimepath'. >vim
    :exe 'edit' stdpath('config') .. '/lsp/foo.lua'
 2. Add this code to the file (or copy an example from
-   https://github.com/neovim/nvim-lspconfig): >
+   https://github.com/neovim/nvim-lspconfig): >lua
    return {
      cmd = { 'true' },
    }
-3. Save the file (with `++p` to ensure its parent directory is created). >
+3. Save the file (with `++p` to ensure its parent directory is created). >vim
    :write ++p
-4. Enable the config. >
+4. Enable the config. >vim
    :lua vim.lsp.enable('foo')
 5. Run `:checkhealth vim.lsp`, check "Enabled Configurations". 🌈
 
@@ -356,7 +356,7 @@ LSP handlers are functions that handle |lsp-response|s to requests made by Nvim
 to the server. (Notifications, as opposed to requests, are fire-and-forget:
 there is no response, so they can't be handled. |lsp-notification|)
 
-Each response handler has this signature: >
+Each response handler has this signature: >lua
 
     function(err, result, ctx)
 <

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -60,7 +60,8 @@ If Nvim is built with LuaJIT, Lua code can be profiled via >lua
     -- Stop the session. Profile is written to /tmp/profile.
     require('jit.p').stop()
 
-See https://luajit.org/ext_profiler.html or the `p.lua` source for details: >
+See https://luajit.org/ext_profiler.html or the `p.lua` source for details:
+>vim
     :lua vim.cmd.edit(package.searchpath('jit.p', package.path))
 
 ==============================================================================
@@ -91,7 +92,7 @@ which you can handle with |pcall()|.
 When failure is normal and expected, it's idiomatic to return `nil` which
 signals to the caller that failure is not "exceptional" and must be handled.
 This "result-or-message" pattern is expressed as the multi-value return type
-`any|nil,nil|string`, or in LuaLS notation: >
+`any|nil,nil|string`, or in LuaLS notation: >lua
 
     ---@return any|nil    # result on success, nil on failure.
     ---@return nil|string # nil on success, error message on failure.
@@ -231,7 +232,7 @@ Note:
   it is better to not have them in 'runtimepath' at all.
 
                                                          *lua-script-location*
-To get its own location, Lua scripts/modules can use |debug.getinfo()|: >
+To get its own location, Lua scripts/modules can use |debug.getinfo()|: >lua
     debug.getinfo(1, 'S').source:sub(2)
 <
 
@@ -439,7 +440,7 @@ You can peek at the module properties: >vim
 
     :lua vim.print(vim)
 
-Result is something like this: >
+Result is something like this: >lua
 
     {
       _os_proc_children = <function 1>,
@@ -4873,7 +4874,7 @@ vim.version.lt({v1}, {v2})                                  *vim.version.lt()*
 vim.version.parse({version}, {opts})                     *vim.version.parse()*
     Parses a semantic version string and returns a version object which can be
     used with other `vim.version` functions. For example "1.0.1-rc1+build.2"
-    returns: >
+    returns: >lua
         { major = 1, minor = 0, patch = 1, prerelease = "rc1", build = "build.2" }
 <
 

--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -1529,7 +1529,7 @@ handler (only from Lua, see |nvim_create_user_command()|).
 Before the preview callback is executed, Nvim will temporarily disable
 'cursorline' and 'cursorcolumn' to avoid highlighting issues.
 
-The preview callback must be a Lua function with this signature: >
+The preview callback must be a Lua function with this signature: >lua
 
     function cmdpreview(opts, ns, buf)
 <
@@ -1559,7 +1559,7 @@ preview and clears all highlights in the preview namespace.
 
 Here's an example of a command to trim trailing whitespace from lines that
 supports incremental command preview:
->
+>lua
 	-- If invoked as a preview callback, performs 'inccommand' preview by
 	-- highlighting trailing whitespace in the current buffer.
 	local function trim_space_preview(opts, preview_ns, preview_buf)
@@ -1580,8 +1580,7 @@ supports incremental command preview:
 	        preview_ns,
 	        'Substitute',
 	        {line1 + i - 2, start_idx - 1},
-	        {line1 + i - 2, end_idx},
-	      )
+	        {line1 + i - 2, end_idx})
 
 	      -- Add lines and set highlights in the preview buffer
 	      -- if inccommand=split
@@ -1593,15 +1592,15 @@ supports incremental command preview:
 	          preview_buf_line,
 	          preview_buf_line,
 	          false,
-	          { prefix .. line }
-	        )
+	          { prefix .. line })
+
 	        vim.hl.range(
 	          preview_buf,
 	          preview_ns,
 	          'Substitute',
 	          {preview_buf_line, #prefix + start_idx - 1},
-	          {preview_buf_line, #prefix + end_idx},
-	        )
+	          {preview_buf_line, #prefix + end_idx})
+
 	        preview_buf_line = preview_buf_line + 1
 	      end
 	    end

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -22,8 +22,8 @@ positions in files.  For example, |:vimgrep| finds pattern matches.  You can
 use the positions in a script with the |getqflist()| function.  Thus you can
 do a lot more than the edit/compile/fix cycle!
 
-If you have the error messages in a file you can start Vim with: >
-	vim -q filename
+If you have the error messages in a file you can start Nvim with: >
+	nvim -q filename
 
 From inside Vim an easy way to run a command and handle the output is with the
 |:make| command (see below).

--- a/runtime/lua/vim/version.lua
+++ b/runtime/lua/vim/version.lua
@@ -481,7 +481,7 @@ end
 --- Parses a semantic version string and returns a version object which can be used with other
 --- `vim.version` functions. For example "1.0.1-rc1+build.2" returns:
 ---
---- ```
+--- ```lua
 --- { major = 1, minor = 0, patch = 1, prerelease = "rc1", build = "build.2" }
 --- ```
 ---


### PR DESCRIPTION
Problem:
- Many codeblocks in Nvim-owned help don't have lang annotation
- There are many trailing comma in Lua codeblocks in `:h command-preview`, which causes syntax error.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
