### PR TITLE
fix(gen_help_html): correct ASCII art rendering in docs

### DIFF
--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -608,8 +608,8 @@ local function visit_node(root, level, lang_tree, headings, opt, stats)
     return string.format('<div class="help-li" style="%s">%s</div>', margin, text)
   elseif node_name == 'taglink' or node_name == 'optionlink' then
     local helppage, tagname, ignored = validate_link(root, opt.buf, opt.fname)
-    if ignored then
-      return text
+    if ignored or not helppage then
+      return html_esc(node_text(root))
     end
     local s = ('%s<a href="%s#%s">%s</a>'):format(
       ws(),


### PR DESCRIPTION
The script was misinterpreting parts of ASCII diagrams as help tags (e.g., `|_________|` in `usr_28.txt`). This incorrectly triggered special alignment-fixing logic that is meant for columnar text.

fixes #35172

Also a workaround, without changing the script, would be to alter `|_________|` to `| _________|` in the `usr_28.txt` file.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
