### PR TITLE
fix(build): remove deprecated aliases in build.zig removed for zig 0.15

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -54,14 +54,14 @@ pub fn build(b: *std.Build) !void {
     const host_use_luajit = if (cross_compiling) false else use_luajit;
     const E = enum { luajit, lua51 };
 
-    const ziglua = b.dependency("lua_wrapper", .{
+    const ziglua = b.dependency("zlua", .{
         .target = target,
         .optimize = optimize_lua,
         .lang = if (use_luajit) E.luajit else E.lua51,
         .shared = false,
     });
 
-    const ziglua_host = if (cross_compiling) b.dependency("lua_wrapper", .{
+    const ziglua_host = if (cross_compiling) b.dependency("zlua", .{
         .target = target_host,
         .optimize = optimize_lua,
         .lang = if (host_use_luajit) E.luajit else E.lua51,
@@ -74,8 +74,8 @@ pub fn build(b: *std.Build) !void {
 
     // this is currently not necessary, as ziglua currently doesn't use lazy dependencies
     // to circumvent ziglua.artifact() failing in a bad way.
-    // const lua = lazyArtifact(ziglua, "lua") orelse return;
-    const lua = ziglua.artifact("lua");
+    const lua = lazyArtifact(ziglua, "lua") orelse return;
+    // const lua = ziglua.artifact("lua");
 
     const libuv_dep = b.dependency("libuv", .{ .target = target, .optimize = optimize });
     const libuv = libuv_dep.artifact("uv");
@@ -257,8 +257,10 @@ pub fn build(b: *std.Build) !void {
 
     const nvim_exe = b.addExecutable(.{
         .name = "nvim",
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     nvim_exe.rdynamic = true; // -E
 
@@ -371,8 +373,10 @@ pub fn test_fixture(
 ) *std.Build.Step {
     const fixture = b.addExecutable(.{
         .name = name,
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     const source = if (std.mem.eql(u8, name, "pwsh-test")) "shell-test" else name;
     fixture.addCSourceFile(.{ .file = b.path(b.fmt("./test/functional/fixtures/{s}.c", .{source})) });

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -5,9 +5,9 @@
     .minimum_zig_version = "0.14.0",
 
     .dependencies = .{
-        .lua_wrapper = .{
-            .url = "git+https://github.com/natecraddock/ziglua#7bfb3c2b87220cdc89ef01cc99a200dad7a28e50",
-            .hash = "lua_wrapper-0.1.0-OyMC27fOBAAU3E2ueB-EWGSgsuCFQZL83pT0nQJ1ufOI",
+        .zlua = .{
+            .url = "git+https://github.com/natecraddock/ziglua#6889b2d90ee6ae96810a9f04ec7c62d9aa91d088",
+            .hash = "zlua-0.1.0-hGRpCxctBQDEQgDArJ0Kc4RDIsD-Hw3pw9pPPw_kGmmY",
         },
         .lpeg = .{
             .url = "https://github.com/neovim/deps/raw/d495ee6f79e7962a53ad79670cb92488abe0b9b4/opt/lpeg-1.1.0.tar.gz",
@@ -22,8 +22,8 @@
             .hash = "N-V-__8AADi-AwDnVoXwDCQvv2wcYOmN0bJLqZ44J3lwoQY2",
         },
         .treesitter = .{
-            .url = "git+https://github.com/tree-sitter/tree-sitter?ref=v0.25.8#854f527f6ef9fdf563efb13d016e52df3ee6c45c",
-            .hash = "tree_sitter-0.26.0-Tw2sR8u8CwBPBvzDbE0Ggokap5sll_qol0WSVuwjdOfC",
+            .url = "git+https://github.com/tree-sitter/tree-sitter#d87921bb9c39b0b06c811f2082f9a9991cdca027",
+            .hash = "tree_sitter-0.26.0-Tw2sRxO7CwC0NyDrSygSi7UXRHMNUFEF8GRq6dK81lRF",
         },
         .libuv = .{ .path = "./deps/libuv" },
         .utf8proc = .{ .path = "./deps/utf8proc/" },

--- a/deps/iconv_apple/build.zig
+++ b/deps/iconv_apple/build.zig
@@ -5,10 +5,13 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
     const upstream = b.dependency("libiconv", .{});
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "iconv",
-        .target = target,
-        .optimize = optimize,
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     lib.addIncludePath(b.path("include/"));

--- a/deps/libuv/build.zig
+++ b/deps/libuv/build.zig
@@ -6,10 +6,13 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
     const upstream = b.dependency("libuv", .{});
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "uv",
-        .target = target,
-        .optimize = optimize,
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     lib.addIncludePath(upstream.path("include"));

--- a/deps/unibilium/build.zig
+++ b/deps/unibilium/build.zig
@@ -5,10 +5,13 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
     const upstream = b.dependency("unibilium", .{});
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "unibilium",
-        .target = target,
-        .optimize = optimize,
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     lib.addIncludePath(upstream.path(""));

--- a/deps/utf8proc/build.zig
+++ b/deps/utf8proc/build.zig
@@ -5,10 +5,13 @@ pub fn build(b: *std.Build) !void {
     const optimize = b.standardOptimizeOption(.{});
 
     const upstream = b.dependency("utf8proc", .{});
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "utf8proc",
-        .target = target,
-        .optimize = optimize,
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     lib.addIncludePath(upstream.path(""));

--- a/src/build_lua.zig
+++ b/src/build_lua.zig
@@ -14,16 +14,20 @@ pub fn build_nlua0(
 
     const nlua0_exe = b.addExecutable(.{
         .name = "nlua0",
-        .root_source_file = b.path("src/nlua0.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/nlua0.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
     const nlua0_mod = nlua0_exe.root_module;
 
     const exe_unit_tests = b.addTest(.{
-        .root_source_file = b.path("src/nlua0.zig"),
-        .target = target,
-        .optimize = optimize,
+        .root_module = b.createModule(.{
+            .root_source_file = b.path("src/nlua0.zig"),
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     const embedded_data = b.addModule("embedded_data", .{
@@ -31,7 +35,7 @@ pub fn build_nlua0(
     });
 
     for ([2]*std.Build.Module{ nlua0_mod, exe_unit_tests.root_module }) |mod| {
-        mod.addImport("ziglua", ziglua.module("lua_wrapper"));
+        mod.addImport("ziglua", ziglua.module("zlua"));
         mod.addImport("embedded_data", embedded_data);
         // addImport already links by itself. but we need headers as well..
         mod.linkLibrary(ziglua.artifact("lua"));
@@ -112,10 +116,13 @@ pub fn build_libluv(
 ) !*std.Build.Step.Compile {
     const upstream = b.dependency("luv", .{});
     const compat53 = b.dependency("lua_compat53", .{});
-    const lib = b.addStaticLibrary(.{
+    const lib = b.addLibrary(.{
         .name = "luv",
-        .target = target,
-        .optimize = optimize,
+        .linkage = .static,
+        .root_module = b.createModule(.{
+            .target = target,
+            .optimize = optimize,
+        }),
     });
 
     lib.linkLibrary(lua);


### PR DESCRIPTION
This makes the zig build compatible with the upcoming zig 0.15 release, while still supporting the current stable 0.14 release still used in CI.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
