### PR TITLE
vim-patch: runtime updates

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1742,6 +1742,15 @@ Certain modifiers are incompatible with each other, e.g. `abstract` and
 and can be differently highlighted as a group than other modifiers with >
 	:hi link javaConceptKind NonText
 
+All instances of variable-width lookbehind assertions (|/\@<!| and |/\@<=|),
+resorted to in syntax item definitions, are confined to arbitrary byte counts.
+Another arbitrary value can be selected for a related group of definitions.
+For example: >
+	:let g:java_lookbehind_byte_counts = {'javaMarkdownCommentTitle': 240}
+Where each key name of this dictionary is the name of a syntax item.  The use
+of these assertions in syntax items may vary among revisions, so no definitive
+set of supported key names is committed to.
+
 If you notice highlighting errors while scrolling backwards, which are fixed
 when redrawing with CTRL-L, try setting the "g:java_minlines" variable to
 a larger number: >

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1,11 +1,11 @@
 " These commands create the option window.
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2025 Jul 25
+" Last Change:	2025 Aug 07
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " If there already is an option window, jump to that one.
-let buf = bufnr('option-window')
+let buf = bufexists('option-window') ? bufnr('option-window') : -1
 if buf >= 0
   let winids = win_findbuf(buf)
   if len(winids) > 0


### PR DESCRIPTION
#### vim-patch:7132935: runtime(java): Manage byte limits for variable-width lookbehind assertions

Raise the byte limits from 80 to 120 for "javaFuncDef" and
"java*CommentTitle"; and support selecting other arbitrary
values with
------------------------------------------------------------
	let g:java_lookbehind_byte_counts = {
		\ 'javaMarkdownCommentTitle': 240,
	\ }
------------------------------------------------------------

for related groups of syntax definitions, referring to their
names with dictionary keys.

Over-80-Byte-Limit Lookbehind Examples:
https://raw.githubusercontent.com/openjdk/jdk/refs/tags/jdk-24%2B36/src/java.base/share/classes/sun/security/x509/NamedX509Key.java [Lines 43 & 44]
https://raw.githubusercontent.com/openjdk/jdk/refs/tags/jdk-24%2B36/src/jdk.compiler/share/classes/com/sun/tools/javac/util/GraphUtils.java [Line 154]

closes: vim/vim#17921

https://github.com/vim/vim/commit/7132935413dfda47e015015dbbc5b9eb097b90d6

Co-authored-by: Aliaksei Budavei <0x000c70@gmail.com>


#### vim-patch:3be4ad7: runtime(optwin): Fix E94 when searching for the option-window

Problem:  When the parameter debug=msg is set and the command :option is
          entered, error E94 will be displayed.
Solution: Add a check for the existence of the buffer before getting the
          buffer number “option-window”.

Reproduce:

vim --clean -c "set debug=msg" -c "option"

    Error detected while processing command line..script D:\Programs\Vim\vim91\optwin.vim:
    line 9: E94: No matching buffer for option-window

closes: vim/vim#17927

https://github.com/vim/vim/commit/3be4ad76df92086e29c3fcf5e6a25f285b6e188f

Co-authored-by: RestorerZ <restorer@mail2k.ru>