### PR TITLE
vim-patch:9.1.1606: filetype: a few more files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -2048,6 +2048,7 @@ local patterns_text = {
   ['^From [a-zA-Z][a-zA-Z_0-9%.=%-]*(@[^ ]*)? .* 20%d%d$'] = 'mail',
   ['^From %- .* 19%d%d$'] = 'mail',
   ['^From %- .* 20%d%d$'] = 'mail',
+  ['^[Rr][Ee][Tt][Uu][Rr][Nn]%-[Pp][Aa][Tt][Hh]:%s<.*@.*>$'] = 'mail',
   -- Mason
   ['^<[%%&].*>'] = 'mason',
   -- Vim scripts (must have '" vim' as the first line to trigger this)
@@ -2164,6 +2165,10 @@ local patterns_text = {
   -- #ncomment is allowed but most likely a false positive so require a space before any trailing comment text
   ['^#n%s'] = 'sed',
   ['^#n$'] = 'sed',
+  ['^#%s+Reconstructed via infocmp from file:'] = 'terminfo',
+  ['^File: .*%.info,  Node: .*,  Next: .*,  Up: '] = 'info',
+  ['^File: .*%.info,  Node: .*,  Prev: .*,  Up: '] = 'info',
+  ['This is the top of the INFO tree.'] = 'info',
 }
 
 --- File does not start with "#!".

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -2990,6 +2990,39 @@ func Test_org_file()
   filetype off
 endfunc
 
+func Test_info_file()
+  filetype on
+
+  call writefile(['File: coreutils.info,  Node: Top,  Next: Introduction,  Up: (dir)', 'D'], 'Xfile', 'D')
+  split Xfile
+  call assert_equal('info', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
+func Test_mail_file()
+  filetype on
+
+  call writefile(['Return-path: <lgc@debian.home.arpa>', 'D'], 'Xfile', 'D')
+  split Xfile
+  call assert_equal('mail', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
+func Test_terminfo_file()
+  filetype on
+
+  call writefile(['#	Reconstructed via infocmp from file: /etc/terminfo/x/xterm', 'D'], 'Xfile', 'D')
+  split Xfile
+  call assert_equal('terminfo', &filetype)
+  bwipe!
+
+  filetype off
+endfunc
+
 " Filetypes detected from names of existing files
 func Test_pacmanlog()
   filetype on


### PR DESCRIPTION
#### vim-patch:9.1.1606: filetype: a few more files are not recognized

Problem:  filetype: a few more files are not recognized
Solution: guess Mail, Info and Terminfo files by its content
          (lacygoill)

closes: vim/vim#17880

https://github.com/vim/vim/commit/eb2aebeb7982168ece3888c9c0b08fc46f9d4d15

Co-authored-by: lacygoill <lacygoill@lacygoill.me>