### PR TITLE
vim.pack: more control over "load" and "install" behavior

### DIFF
--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -336,7 +336,7 @@ add({specs}, {opts})                                          *vim.pack.add()*
       • {opts}   (`table?`) A table with the following fields:
                  • {load}? (`boolean`) Load `plugin/` files and `ftdetect/`
                    scripts. If `false`, works like `:packadd!`. Default
-                   `true`.
+                   `false` during startup and `true` afterwards.
 
 del({names})                                                  *vim.pack.del()*
     Remove plugins from disk

--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -341,6 +341,8 @@ add({specs}, {opts})                                          *vim.pack.add()*
                    works like `:packadd!`. If function, called with plugin
                    data and is fully responsible for loading plugin. Default
                    `false` during startup and `true` afterwards.
+                 • {confirm}? (`boolean`) Whether to ask user to confirm
+                   initial install. Default `true`.
 
 del({names})                                                  *vim.pack.del()*
     Remove plugins from disk

--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -315,11 +315,12 @@ add({specs}, {opts})                                          *vim.pack.add()*
     Add plugin to current session
     • For each specification check that plugin exists on disk in
       |vim.pack-directory|:
-      • If exists, do nothin in this step.
+      • If exists, do nothing in this step.
       • If doesn't exist, install it by downloading from `src` into `name`
         subdirectory (via `git clone`) and update state to match `version`
         (via `git checkout`).
-    • For each plugin execute |:packadd| making them reachable by Nvim.
+    • For each plugin execute |:packadd| (or customizable `load` function)
+      making it reachable by Nvim.
 
     Notes:
     • Installation is done in parallel, but waits for all to finish before
@@ -334,8 +335,11 @@ add({specs}, {opts})                                          *vim.pack.add()*
       • {specs}  (`(string|vim.pack.Spec)[]`) List of plugin specifications.
                  String item is treated as `src`.
       • {opts}   (`table?`) A table with the following fields:
-                 • {load}? (`boolean`) Load `plugin/` files and `ftdetect/`
-                   scripts. If `false`, works like `:packadd!`. Default
+                 • {load}?
+                   (`boolean|fun(plug_data: {spec: vim.pack.Spec, path: string})`)
+                   Load `plugin/` files and `ftdetect/` scripts. If `false`,
+                   works like `:packadd!`. If function, called with plugin
+                   data and is fully responsible for loading plugin. Default
                    `false` during startup and `true` afterwards.
 
 del({names})                                                  *vim.pack.del()*

--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -562,9 +562,9 @@ local function checkout(p, timestamp, skip_same_sha)
 end
 
 --- @param plug_list vim.pack.Plug[]
-local function install_list(plug_list)
+local function install_list(plug_list, confirm)
   -- Get user confirmation to install plugins
-  if not confirm_install(plug_list) then
+  if confirm and not confirm_install(plug_list) then
     for _, p in ipairs(plug_list) do
       p.info.err = 'Installation was not confirmed'
     end
@@ -681,6 +681,8 @@ end
 --- If function, called with plugin data and is fully responsible for loading plugin.
 --- Default `false` during startup and `true` afterwards.
 --- @field load? boolean|fun(plug_data: {spec: vim.pack.Spec, path: string})
+---
+--- @field confirm? boolean Whether to ask user to confirm initial install. Default `true`.
 
 --- Add plugin to current session
 ---
@@ -705,7 +707,7 @@ end
 --- @param opts? vim.pack.keyset.add
 function M.add(specs, opts)
   vim.validate('specs', specs, vim.islist, false, 'list')
-  opts = vim.tbl_extend('force', { load = vim.v.vim_did_enter == 1 }, opts or {})
+  opts = vim.tbl_extend('force', { load = vim.v.vim_did_enter == 1, confirm = true }, opts or {})
   vim.validate('opts', opts, 'table')
 
   --- @type vim.pack.Plug[]
@@ -720,7 +722,7 @@ function M.add(specs, opts)
 
   if #plugs_to_install > 0 then
     git_ensure_exec()
-    install_list(plugs_to_install)
+    install_list(plugs_to_install, opts.confirm)
   end
 
   -- Register and load those actually on disk while collecting errors

--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -669,7 +669,9 @@ end
 
 --- @class vim.pack.keyset.add
 --- @inlinedoc
---- @field load? boolean Load `plugin/` files and `ftdetect/` scripts. If `false`, works like `:packadd!`. Default `true`.
+--- Load `plugin/` files and `ftdetect/` scripts. If `false`, works like `:packadd!`.
+--- Default `false` during startup and `true` afterwards.
+--- @field load? boolean
 
 --- Add plugin to current session
 ---
@@ -693,7 +695,7 @@ end
 --- @param opts? vim.pack.keyset.add
 function M.add(specs, opts)
   vim.validate('specs', specs, vim.islist, false, 'list')
-  opts = vim.tbl_extend('force', { load = true }, opts or {})
+  opts = vim.tbl_extend('force', { load = vim.v.vim_did_enter == 1 }, opts or {})
   vim.validate('opts', opts, 'table')
 
   --- @type vim.pack.Plug[]

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -332,6 +332,22 @@ describe('vim.pack', function()
       eq({ confirm_msg, 'Proceed? &Yes\n&No', 1, 'Question' }, exec_lua('return _G.confirm_args'))
     end)
 
+    it('respects `opts.confirm`', function()
+      exec_lua(function()
+        _G.confirm_used = false
+        ---@diagnostic disable-next-line: duplicate-set-field
+        vim.fn.confirm = function()
+          _G.confirm_used = true
+          return 1
+        end
+
+        vim.pack.add({ repos_src.basic }, { confirm = false })
+      end)
+
+      eq(false, exec_lua('return _G.confirm_used'))
+      eq('basic main', exec_lua('return require("basic")'))
+    end)
+
     it('installs at proper version', function()
       local out = exec_lua(function()
         vim.pack.add({


### PR DESCRIPTION
close https://github.com/neovim/neovim/issues/35192
close https://github.com/neovim/neovim/issues/34770

This PR fixes #35192 and addresses most (if not all) ideas of #34770:
- Make default `opts.load` be `false` during startup to avoid sourcing 'plugin/' twice and make it work with `--noplugin`. After startup the default value is still `true` (to work with lazy loading).
- Allow `opts.load` to be a function to have full control over how plugin is loaded.
- Add `opts.confirm` to allow skipping install confirmation. Although requiring confirmation is good default design, it might be not necessary for most users. Since there should have been some action that lead to the plugin installation (usually adjusting `vim.pack.add()` in the 'init.lua').

---

My opinion is that the non-addressed ideas of #34770 might be a bit too much for `vim.pack.add` and hence this PR should also resolve it.

> Allow skipping automated installation of not presently installed plugins in favor of doing that manually later.

I like the current "block and install" because it allows the code after it to assume that plugin is installed and loaded.

> More straightforward plugin freeze/pin/lock.

The current suggestion of specifying commit hash or tag directly as `version` works as a freeze. Maybe the only downside would be that full changelog from target branch won't be shown in confirmation buffer after each update. To counter that, there are suggested newer version tags that can be used to track new releases. Plus #34919 might introduce an alternative to freezing via manual targeted "skip updating this plugin".

> Introduce something like `opts.convert_spec` ... a function that can be used to auto-transform plugin spec.

This can be achieved with a `vim.pack.add()` wrapper.

> Add `PackLoad[Pre]` events for easier config hooks

This can be achieved with function `opts.load`. Having a separate event would allow plugins to act on when other plugins are loaded, but I currently can not think of a use case where this would be the most appropriate solution.