### PR TITLE
fix(inccommand): prevent `input` from showing prompt during preview

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -4807,6 +4807,10 @@ void get_user_input(const typval_T *const argvars, typval_T *const rettv, const 
   rettv->v_type = VAR_STRING;
   rettv->vval.v_string = NULL;
 
+  if (cmdpreview) {
+    return;
+  }
+
   const char *prompt;
   const char *defstr = "";
   typval_T *cancelreturn = NULL;

--- a/test/functional/ui/inccommand_spec.lua
+++ b/test/functional/ui/inccommand_spec.lua
@@ -2937,3 +2937,15 @@ it("'inccommand' disables preview if preview buffer can't be created #27086", fu
   ]])
   eq('nosplit', api.nvim_get_option_value('inccommand', {}))
 end)
+
+it(':substitute with inccommand, does not show prompt during preview #11940', function()
+  clear()
+  local screen = Screen.new(30, 3)
+  common_setup(screen, 'split', 'foo')
+  feed([[:s/f/\=input("sub: ")]])
+  screen:expect([[
+    oo                            |
+    {1:~                             }|
+    :s/f/\=input("sub: ")^         |
+  ]])
+end)


### PR DESCRIPTION
Problem:
During preview, the `input` still prompts the user to enter something that won't be used later, which could be a bit confusing. e.g., `:s/a/\=input("")`. (#11940)

Solution:
make the `input` return early during preview.
BTW, I personally feel it's fine without a dummy string, because at this point the replacement hasn't been finalized.
Only hiding the matched characters here feels more consistent to me with other cases,
e.g., when I've only typed `:s/a/\="\<` (for `:s/a/\="\<Char-0x20ac>"/`). 😄

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
