### PR TITLE
fix(lsp): deprecate `vim.lsp.set_log_level` and `vim.lsp.get_log_path`

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -37,6 +37,8 @@ LSP
 					and return `nil` to omit entries from the logfile.
 • *vim.lsp.semantic_tokens.start()*	Use `vim.lsp.semantic_tokens.enable(true)` instead
 • *vim.lsp.semantic_tokens.stop()*	Use `vim.lsp.semantic_tokens.enable(false)` instead
+• *vim.lsp.set_log_level()*		Use `vim.lsp.log.set_level()` instead
+• *vim.lsp.get_log_path()*		Use `vim.lsp.log.get_filename()` instead
 
 LUA
 

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1133,12 +1133,6 @@ get_clients({filter})                                  *vim.lsp.get_clients()*
     Return: ~
         (`vim.lsp.Client[]`) List of |vim.lsp.Client| objects
 
-get_log_path()                                        *vim.lsp.get_log_path()*
-    Gets the path of the logfile used by the LSP client.
-
-    Return: ~
-        (`string`) path to log file
-
 is_enabled({name})                                      *vim.lsp.is_enabled()*
     Checks if the given LSP config is enabled (globally, not per-buffer).
 
@@ -1167,21 +1161,6 @@ omnifunc({findstart}, {base})                             *vim.lsp.omnifunc()*
       • |complete-functions|
       • |complete-items|
       • |CompleteDone|
-
-set_log_level({level})                               *vim.lsp.set_log_level()*
-    Sets the global log level for LSP logging.
-
-    Levels by name: "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "OFF"
-
-    Level numbers begin with "TRACE" at 0
-
-    Use `lsp.log_levels` for reverse lookup.
-
-    Parameters: ~
-      • {level}  (`integer|string`) the case insensitive level name or number
-
-    See also: ~
-      • |vim.lsp.log_levels|
 
 start({config}, {opts})                                      *vim.lsp.start()*
     Create a new LSP client and start a language server or reuses an already
@@ -2279,12 +2258,12 @@ The `vim.lsp.log` module provides logging for the Nvim LSP client.
 
 When debugging language servers, it is helpful to enable extra-verbose logging
 of the LSP client RPC events. Example: >lua
-    vim.lsp.set_log_level 'trace'
+    vim.lsp.log.set_level 'trace'
     require('vim.lsp.log').set_format_func(vim.inspect)
 <
 
 Then try to run the language server, and open the log with: >vim
-    :lua vim.cmd('tabnew ' .. vim.lsp.get_log_path())
+    :lua vim.cmd('tabnew ' .. vim.lsp.log.get_filename())
 <
 
 (Or use `:LspLog` if you have nvim-lspconfig installed.)

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -1504,10 +1504,13 @@ lsp.log_levels = log.levels
 ---
 --- Use `lsp.log_levels` for reverse lookup.
 ---
+---@deprecated
 ---@see |vim.lsp.log_levels|
 ---
 ---@param level (integer|string) the case insensitive level name or number
 function lsp.set_log_level(level)
+  vim.deprecate('vim.lsp.set_log_level()', 'vim.lsp.log.set_level()', '0.13')
+
   if type(level) == 'string' or type(level) == 'number' then
     log.set_level(level)
   else
@@ -1516,8 +1519,12 @@ function lsp.set_log_level(level)
 end
 
 --- Gets the path of the logfile used by the LSP client.
+---
+---@deprecated
 ---@return string path to log file
 function lsp.get_log_path()
+  vim.deprecate('vim.lsp.get_log_path()', 'vim.lsp.log.get_filename()', '0.13')
+
   return log.get_filename()
 end
 

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -1272,7 +1272,7 @@ function Client:_on_exit(code, signal)
         self and self.name or 'unknown',
         code,
         signal,
-        lsp.get_log_path()
+        log.get_filename()
       )
       vim.notify(msg, vim.log.levels.WARN)
     end

--- a/runtime/lua/vim/lsp/health.lua
+++ b/runtime/lua/vim/lsp/health.lua
@@ -18,7 +18,7 @@ local function check_log()
     )
   end
 
-  local log_path = vim.lsp.get_log_path()
+  local log_path = log.get_filename()
   report_info(string.format('Log path: %s', log_path))
 
   local log_file = vim.uv.fs_stat(log_path)

--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -4,13 +4,13 @@
 --- When debugging language servers, it is helpful to enable extra-verbose logging of the LSP client
 --- RPC events. Example:
 --- ```lua
---- vim.lsp.set_log_level 'trace'
+--- vim.lsp.log.set_level 'trace'
 --- require('vim.lsp.log').set_format_func(vim.inspect)
 --- ```
 ---
 --- Then try to run the language server, and open the log with:
 --- ```vim
---- :lua vim.cmd('tabnew ' .. vim.lsp.get_log_path())
+--- :lua vim.cmd('tabnew ' .. vim.lsp.log.get_filename())
 --- ```
 ---
 --- (Or use `:LspLog` if you have nvim-lspconfig installed.)


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
These functions are silly wrappers around `vim.lsp.log.set_level` and `vim.lsp.log.get_filename`.