### PR TITLE
vim-patch:9.1.1611: possible undefined behaviour in mb_decompose()

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1729,7 +1729,8 @@ static void mb_decompose(int c, int *c1, int *c2, int *c3)
     *c3 = d.c;
   } else {
     *c1 = c;
-    *c2 = *c3 = 0;
+    *c2 = 0;
+    *c3 = 0;
   }
 }
 


### PR DESCRIPTION
#### vim-patch:9.1.1611: possible undefined behaviour in mb_decompose()

Problem:  possible undefined behaviour in mb_decompose(), when using the
          same pointer as argument several times
Solution: use separate assignments to avoid reading and writing the same
          object at the same time (Áron Hárnási)

closes: vim/vim#17953

https://github.com/vim/vim/commit/c43a0614d40a3892a9cb2b9d75f61a19a3de0226

Co-authored-by: Áron Hárnási <aron.harnasi@gmail.com>