### PR TITLE
vim-patch:9.1.{1612,1613}

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1543,6 +1543,17 @@ static int may_do_command_line_next_incsearch(int firstc, int count, incsearch_s
     pat = ccline.cmdbuff + skiplen;
   }
 
+  bool bslsh = false;
+  // do not search for the search end delimiter,
+  // unless it is part of the pattern
+  if (patlen > 2 && firstc == pat[patlen - 1]) {
+    patlen--;
+    if (pat[patlen - 1] == '\\') {
+      pat[patlen - 1] = (char)(uint8_t)firstc;
+      bslsh = true;
+    }
+  }
+
   if (next_match) {
     t = s->match_end;
     if (lt(s->match_start, s->match_end)) {
@@ -1566,6 +1577,9 @@ static int may_do_command_line_next_incsearch(int firstc, int count, incsearch_s
                        RE_SEARCH, NULL);
   emsg_off--;
   pat[patlen] = save;
+  if (bslsh) {
+    pat[patlen - 1] = '\\';
+  }
   ui_busy_stop();
   if (found) {
     s->search_start = s->match_start;

--- a/test/functional/legacy/search_spec.lua
+++ b/test/functional/legacy/search_spec.lua
@@ -731,6 +731,111 @@ describe('search cmdline', function()
     feed('<Esc>')
     screen:expect(s)
   end)
+
+  -- oldtest: Test_incsearch_delimiter_ctrlg()
+  it('incsearch does not include trailing delimiter', function()
+    screen:try_resize(20, 6)
+    exec([[
+      set incsearch hls
+      call setline(1, ["1 vim inc", "2 vim /", "3 vim /", "4 vim ?", "5 vim ?"])
+      normal gg
+      redraw
+    ]])
+
+    feed('/')
+    poke_eventloop()
+    feed('v')
+    poke_eventloop()
+    feed('i')
+    poke_eventloop()
+    feed('m')
+    poke_eventloop()
+    feed(' ')
+    poke_eventloop()
+    feed('/')
+    poke_eventloop()
+    feed('<C-G>')
+    screen:expect([[
+      1 {10:vim }inc           |
+      2 {2:vim }/             |
+      3 {10:vim }/             |
+      4 {10:vim }?             |
+      5 {10:vim }?             |
+      /vim /^              |
+    ]])
+    feed('<Esc>')
+
+    command('5')
+    feed('?')
+    poke_eventloop()
+    feed('v')
+    poke_eventloop()
+    feed('i')
+    poke_eventloop()
+    feed('m')
+    poke_eventloop()
+    feed(' ')
+    poke_eventloop()
+    feed('?')
+    poke_eventloop()
+    feed('<C-T>')
+    screen:expect([[
+      1 {10:vim }inc           |
+      2 {10:vim }/             |
+      3 {2:vim }/             |
+      4 {10:vim }?             |
+      5 {10:vim }?             |
+      ?vim ?^              |
+    ]])
+    feed('<Esc>')
+
+    feed('/')
+    poke_eventloop()
+    feed('v')
+    poke_eventloop()
+    feed('i')
+    poke_eventloop()
+    feed('m')
+    poke_eventloop()
+    feed(' ')
+    poke_eventloop()
+    feed('\\/')
+    poke_eventloop()
+    feed('<C-G>')
+    screen:expect([[
+      1 vim inc           |
+      2 {10:vim /}             |
+      3 {2:vim /}             |
+      4 vim ?             |
+      5 vim ?             |
+      /vim \/^             |
+    ]])
+    feed('<Esc>')
+
+    command('5')
+    feed('?')
+    poke_eventloop()
+    feed('v')
+    poke_eventloop()
+    feed('i')
+    poke_eventloop()
+    feed('m')
+    poke_eventloop()
+    feed(' ')
+    poke_eventloop()
+    feed('\\?')
+    poke_eventloop()
+    feed('<C-T>')
+    screen:expect([[
+      1 vim inc           |
+      2 vim /             |
+      3 vim /             |
+      4 {10:vim ?}             |
+      5 {2:vim ?}             |
+      ?vim \?^             |
+    ]])
+    feed('<Esc>')
+  end)
 end)
 
 describe('Search highlight', function()

--- a/test/old/testdir/test_search.vim
+++ b/test/old/testdir/test_search.vim
@@ -2159,5 +2159,86 @@ func Test_search_with_invalid_range()
   bwipe!
 endfunc
 
+func Test_incsearch_delimiter_ctrlg()
+  CheckOption incsearch
+  CheckScreendump
+  CheckRunVimInTerminal
+  call assert_equal(0, &scrolloff)
+  call writefile([
+	\ 'set incsearch hls',
+  \ 'call setline(1, ["1 vim inc", "2 vim /", "3 vim /", "4 vim ?", "5 vim ?"])',
+	\ 'normal gg',
+	\ 'redraw',
+	\ ], 'Xscript_incsearch_delim', 'D')
+  let buf = RunVimInTerminal('-S Xscript_incsearch_delim', {'rows': 6})
+
+  call term_sendkeys(buf, '/')
+  sleep 100m
+  call term_sendkeys(buf, 'v')
+  sleep 100m
+  call term_sendkeys(buf, 'i')
+  sleep 100m
+  call term_sendkeys(buf, 'm')
+  sleep 100m
+  call term_sendkeys(buf, ' ')
+  sleep 100m
+  call term_sendkeys(buf, '/')
+  sleep 100m
+  call term_sendkeys(buf, "\<C-G>")
+  call VerifyScreenDump(buf, 'Test_incsearch_delim_01', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  call term_sendkeys(buf, ":5\<cr>")
+  call term_sendkeys(buf, '?')
+  sleep 100m
+  call term_sendkeys(buf, 'v')
+  sleep 100m
+  call term_sendkeys(buf, 'i')
+  sleep 100m
+  call term_sendkeys(buf, 'm')
+  sleep 100m
+  call term_sendkeys(buf, ' ')
+  sleep 100m
+  call term_sendkeys(buf, '?')
+  sleep 100m
+  call term_sendkeys(buf, "\<C-T>")
+  call VerifyScreenDump(buf, 'Test_incsearch_delim_02', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  call term_sendkeys(buf, '/')
+  sleep 100m
+  call term_sendkeys(buf, 'v')
+  sleep 100m
+  call term_sendkeys(buf, 'i')
+  sleep 100m
+  call term_sendkeys(buf, 'm')
+  sleep 100m
+  call term_sendkeys(buf, ' ')
+  sleep 100m
+  call term_sendkeys(buf, '\/')
+  sleep 100m
+  call term_sendkeys(buf, "\<C-G>")
+  call VerifyScreenDump(buf, 'Test_incsearch_delim_03', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  call term_sendkeys(buf, ":5\<cr>")
+  call term_sendkeys(buf, '?')
+  sleep 100m
+  call term_sendkeys(buf, 'v')
+  sleep 100m
+  call term_sendkeys(buf, 'i')
+  sleep 100m
+  call term_sendkeys(buf, 'm')
+  sleep 100m
+  call term_sendkeys(buf, ' ')
+  sleep 100m
+  call term_sendkeys(buf, '\?')
+  sleep 100m
+  call term_sendkeys(buf, "\<C-T>")
+  call VerifyScreenDump(buf, 'Test_incsearch_delim_04', {})
+  call term_sendkeys(buf, "\<Esc>")
+
+  call StopVimInTerminal(buf)
+endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_search.vim
+++ b/test/old/testdir/test_search.vim
@@ -1565,7 +1565,7 @@ func Test_search_match_at_curpos()
   call search('.', 'c')
   call assert_equal([3, 5], [line('.'), col('.')])
 
-  close!
+  bw!
 endfunc
 
 " Test for error cases with the search() function
@@ -1741,7 +1741,7 @@ func Test_search_pat_not_found()
   call assert_fails('normal n', 'E385:')
   call assert_fails('normal N', 'E384:')
   set wrapscan&
-  close
+  bw
 endfunc
 
 " Test for v:searchforward variable
@@ -1757,7 +1757,7 @@ func Test_searchforward_var()
   let v:searchforward = 1
   normal N
   call assert_equal(1, line('.'))
-  close!
+  bw!
 endfunc
 
 " Test for invalid regular expressions
@@ -1818,7 +1818,7 @@ func Test_search_in_visual_area()
   call assert_equal([2, 5], [line('.'), col('.')])
   exe "normal 2GVj$?\\%Vbar\<CR>\<Esc>"
   call assert_equal([3, 5], [line('.'), col('.')])
-  close!
+  bw!
 endfunc
 
 " Test for searching with 'smartcase' and 'ignorecase'
@@ -1846,7 +1846,7 @@ func Test_search_smartcase()
   call assert_equal([2, 4], [line('.'), col('.')])
 
   set ignorecase& smartcase&
-  close!
+  bw!
 endfun
 
 " Test 'smartcase' with utf-8.
@@ -1944,7 +1944,7 @@ func Test_search_offset()
   exe "normal /four/e+1\<CR>"
   call assert_equal([2, 10], [line('.'), col('.')])
 
-  close!
+  bw!
 endfunc
 
 " Test for searching for matching parenthesis using %
@@ -1970,7 +1970,7 @@ func Test_search_match_paren()
   normal 20|%
   call assert_equal(4, col('.'))
   set virtualedit&
-  close!
+  bw!
 endfunc
 
 " Test for searching a pattern and stopping before a specified line
@@ -1983,7 +1983,7 @@ func Test_search_stopline()
   call cursor(4, 1)
   call assert_equal(0, search('vim', 'bn', 2))
   call assert_equal(1, search('vim', 'bn', 1))
-  close!
+  bw!
 endfunc
 
 func Test_incsearch_highlighting_newline()


### PR DESCRIPTION
#### vim-patch:9.1.1612: Ctrl-G/Ctrl-T do not ignore the end search delimiter

Problem:  Ctrl-G/Ctrl-T does not ignore the end search delimiter
          (irisjae)
Solution: Check if the pattern ends with a search delimiter and ignore
          it, unless it is part of the pattern.

closes: vim/vim#17933

https://github.com/vim/vim/commit/c03990d30f742154d93184383cae713b69f1147c

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.1613: tests: test_search leaves a few swapfiles behind

Problem:  tests: test_search leaves a few swapfiles behind
Solution: Use :bw! instead of :close to close the swapfile at the end of
          the test.

related: vim/vim#17933

https://github.com/vim/vim/commit/a2bb21a895ce518baf36416737cc77e9db3b85af

Co-authored-by: Christian Brabandt <cb@256bit.org>