### PR TITLE
vim-patch:9.1.1618: completion: incorrect selected index returned from complete_info()

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -3637,8 +3637,8 @@ static void get_complete_info(list_T *what_list, dict_T *retdict)
               && compl_curr_match->cp_number == match->cp_number) {
             selected_idx = list_idx;
           }
-          if (match->cp_in_match_array) {
-            list_idx += 1;
+          if (!has_matches || match->cp_in_match_array) {
+            list_idx++;
           }
         }
         match = match->cp_next;

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -3630,7 +3630,7 @@ func Test_complete_opt_fuzzy()
   set cot+=noinsert
   call feedkeys("i\<C-R>=CompAnother()\<CR>f", 'tx')
   call assert_equal("for", g:abbr)
-  call assert_equal(0, g:selected)
+  call assert_equal(2, g:selected)
 
   set cot=menu,menuone,noselect,fuzzy
   call feedkeys("i\<C-R>=CompAnother()\<CR>\<C-N>\<C-N>\<C-N>\<C-N>", 'tx')
@@ -4015,6 +4015,27 @@ func Test_complete_info_completed()
   set cot&
 endfunc
 
+func Test_complete_info_selected()
+  set completeopt=menuone,noselect
+  new
+  call setline(1, ["ward", "werd", "wurd", "wxrd"])
+
+  exe "normal! Gow\<c-n>u\<c-n>\<c-r>=complete_info().selected\<cr>"
+  call assert_equal('wurd2', getline(5))
+
+  exe "normal! Sw\<c-n>u\<c-n>\<c-r>=complete_info(['selected']).selected\<cr>"
+  call assert_equal('wurd2', getline(5))
+
+  exe "normal! Sw\<c-n>u\<c-n>\<c-r>=complete_info(['items', 'selected']).selected\<cr>"
+  call assert_equal('wurd2', getline(5))
+
+  exe "normal! Sw\<c-n>u\<c-n>\<c-r>=complete_info(['matches', 'selected']).selected\<cr>"
+  call assert_equal('wurd0', getline(5))
+
+  bw!
+  set cot&
+endfunc
+
 func Test_completeopt_preinsert()
   func Omni_test(findstart, base)
     if a:findstart
@@ -4035,7 +4056,7 @@ func Test_completeopt_preinsert()
   call assert_equal("fobar", g:line)
   call assert_equal(2, g:col)
 
-  call feedkeys("S\<C-X>\<C-O>foo\<F5><ESC>", 'tx')
+  call feedkeys("S\<C-X>\<C-O>foo\<F5>\<ESC>", 'tx')
   call assert_equal("foobar", g:line)
 
   call feedkeys("S\<C-X>\<C-O>foo\<BS>\<BS>\<BS>", 'tx')
@@ -5179,7 +5200,7 @@ func Test_autocomplete_trigger()
 
   new
   inoremap <buffer> <F2> <Cmd>let b:matches = complete_info(["matches"]).matches<CR>
-  inoremap <buffer> <F3> <Cmd>let b:selected = complete_info(["selected"]).selected<CR>
+  inoremap <buffer> <F3> <Cmd>let b:selected = complete_info(["matches", "selected"]).selected<CR>
 
   call setline(1, ['abc', 'abcd', 'fo', 'b', ''])
   set autocomplete


### PR DESCRIPTION
#### vim-patch:9.1.1618: completion: incorrect selected index returned from complete_info()

Problem:  completion: incorrect selected index returned from
          complete_info()
Solution: Return the index into "items" and restore the previous
          behaviour (Robert Muir).

complete_info() returned an incorrect selected index after
0ac1eb3555445f4c458c06cef7c411de1c8d1020 (Patch v9.1.1311). Effectively
it became an index into "matches" instead of "items". Return the index
into "items" by default to restore the previous behavior, unless
"matches" was requested.

closes: vim/vim#17952

https://github.com/vim/vim/commit/8e2a2291892935f28645cbe550ef2856bab1ee4e

Co-authored-by: Robert Muir <rmuir@apache.org>
Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>