### PR TITLE
vim-patch:9.1.1619: Incorrect E535 error message

### DIFF
--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -5487,7 +5487,7 @@ func s:TestCompleteScriptLocal(findstart, base)
 endfunc
 
 " Issue 17869
-func Test_scriplocal_autoload_func()
+func Test_scriptlocal_autoload_func()
   let save_rtp = &rtp
   set rtp=Xruntime/some
   let dir = 'Xruntime/some/autoload'

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -276,17 +276,17 @@ func Test_complete()
   new
   call feedkeys("i\<C-N>\<Esc>", 'xt')
   bwipe!
-  call assert_fails('set complete=ix', 'E535:')
-  call assert_fails('set complete=x', 'E539:')
-  call assert_fails('set complete=..', 'E535:')
+  call assert_fails('set complete=ix', 'E535: Illegal character after <i>')
+  call assert_fails('set complete=x', 'E539: Illegal character <x>')
+  call assert_fails('set complete=..', 'E535: Illegal character after <.>')
   set complete=.,w,b,u,k,\ s,i,d,],t,U,F,o
-  call assert_fails('set complete=i^-10', 'E535:')
-  call assert_fails('set complete=i^x', 'E535:')
-  call assert_fails('set complete=k^2,t^-1,s^', 'E535:')
-  call assert_fails('set complete=t^-1', 'E535:')
-  call assert_fails('set complete=kfoo^foo2', 'E535:')
-  call assert_fails('set complete=kfoo^', 'E535:')
-  call assert_fails('set complete=.^', 'E535:')
+  call assert_fails('set complete=i^-10', 'E535: Illegal character after <^>')
+  call assert_fails('set complete=i^x', 'E535: Illegal character after <^>')
+  call assert_fails('set complete=k^2,t^-1,s^', 'E535: Illegal character after <^>')
+  call assert_fails('set complete=t^-1', 'E535: Illegal character after <^>')
+  call assert_fails('set complete=kfoo^foo2', 'E535: Illegal character after <^>')
+  call assert_fails('set complete=kfoo^', 'E535: Illegal character after <^>')
+  call assert_fails('set complete=.^', 'E535: Illegal character after <^>')
   set complete=.,w,b,u,k,s,i,d,],t,U,F,o
   set complete=.
   set complete=.^10,t^0


### PR DESCRIPTION
#### vim-patch:9.1.1619: Incorrect E535 error message

Problem:  Incorrect E535 error message (after 9.1.1603).
Solution: Don't use transchar(), as the character is always printable
          (zeertzjq).

closes: vim/vim#17948

https://github.com/vim/vim/commit/b362995430ee809f866d74930897bc158a4eb4ca