### PR TITLE
vim-patch:32d6bd6: runtime(doc): remove dead links

### DIFF
--- a/runtime/doc/ft_sql.txt
+++ b/runtime/doc/ft_sql.txt
@@ -412,7 +412,7 @@ Here are some examples of the entries which are pulled from the syntax files: >
 
 Dynamic mode populates the popups with data directly from a database.  In
 order for the dynamic feature to be enabled you must have the dbext.vim
-plugin installed, (https://vim.sourceforge.net/script.php?script_id=356).
+plugin installed, (https://www.vim.org/scripts/script.php?script_id=356).
 
 Dynamic mode is used by several features of the SQL completion plugin.
 After installing the dbext plugin see the dbext-tutorial for additional
@@ -496,7 +496,7 @@ depending on the syntax file you are using.  The SQL Anywhere syntax file
 Dynamic features ~
 
 To take advantage of the dynamic features you must first install the
-dbext.vim plugin (https://vim.sourceforge.net/script.php?script_id=356).  It
+dbext.vim plugin (https://www.vim.org/scripts/script.php?script_id=356).  It
 also comes with a tutorial.  From the SQL completion plugin's perspective,
 the main feature dbext provides is a connection to a database.  dbext
 connection profiles are the most efficient mechanism to define connection

--- a/runtime/doc/pi_tar.txt
+++ b/runtime/doc/pi_tar.txt
@@ -156,7 +156,7 @@ Copyright 2005-2017:					*tar-copyright*
 	v2			* converted to use Vim7's new autoload feature
 				  by Bram Moolenaar
 	v1	(original)	* Michael Toren
-				  (see http://michael.toren.net/code/
+				  (see michael.toren.net/code/
 				   link seems dead)
 
 ==============================================================================

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1152,7 +1152,7 @@ Elixir.
 FLEXWIKI				*flexwiki.vim* *ft-flexwiki-syntax*
 
 FlexWiki is an ASP.NET-based wiki package available at
-https://www.flexwiki.com
+www.flexwiki.com
 NOTE: This site currently doesn't work, on Wikipedia is mentioned that
 development stopped in 2009.
 

--- a/runtime/pack/dist/opt/netrw/doc/netrw.txt
+++ b/runtime/pack/dist/opt/netrw/doc/netrw.txt
@@ -1930,9 +1930,6 @@ passwords:
 	Thomer Gil has provided a hint on how to speed up netrw+ssh:
 	    http://thomer.com/howtos/netrw_ssh.html
 
-	Alex Young has several hints on speeding ssh up:
-	    http://usevim.com/2012/03/16/editing-remote-files/
-
 
 LISTING BOOKMARKS AND HISTORY		*netrw-qb* *netrw-listbookmark* {{{2
 

--- a/src/nvim/sha256.c
+++ b/src/nvim/sha256.c
@@ -3,7 +3,8 @@
 /// FIPS-180-2 compliant SHA-256 implementation
 /// GPL by Christophe Devine, applies to older version.
 /// Modified for md5deep, in public domain.
-/// Modified For Vim, Mohsin Ahmed, http://www.cs.albany.edu/~mosh
+/// Modified For Vim, Mohsin Ahmed,
+/// (original link www.cs.albany.edu/~mosh no longer available)
 /// Mohsin Ahmed states this work is distributed under the VIM License or GPL,
 /// at your choice.
 ///

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -35,8 +35,8 @@
 //
 // Thanks to Olaf Seibert for providing an example implementation of this tree
 // and the compression mechanism.
-// LZ trie ideas:
-//      http://www.irb.hr/hr/home/ristov/papers/RistovLZtrieRevision1.pdf
+// LZ trie ideas, original link (now dead)
+//      irb.hr/hr/home/ristov/papers/RistovLZtrieRevision1.pdf
 // More papers: http://www-igm.univ-mlv.fr/~laporte/publi_en.html
 //
 // Matching involves checking the caps type: Onecap ALLCAP KeepCap.


### PR DESCRIPTION
#### vim-patch:32d6bd6: runtime(doc): remove dead links

related: vim/vim#17879

https://github.com/vim/vim/commit/32d6bd6df2d0e13a8283ba80d506310ba5ba8b61

N/A patch:
vim-patch:8b18345: runtime(doc): Fix 2 minor issues after 32d6bd6df

Co-authored-by: Damien Lejay <damien@lejay.be>