### PR TITLE
fix(extui): ensure temporary cmdline config is not restored

### DIFF
--- a/runtime/lua/vim/_extui/messages.lua
+++ b/runtime/lua/vim/_extui/messages.lua
@@ -467,7 +467,6 @@ function M.set_pos(type)
     local height = type and math.min(texth.all, math.ceil(o.lines * 0.5))
     local top = { vim.opt.fcs:get().horiz or o.ambw == 'single' and '─' or '-', 'MsgSeparator' }
     local border = win ~= ext.wins.msg and { '', top, '', '', '', '', '', '' } or nil
-    local save_config = type == 'cmd' and api.nvim_win_get_config(win) or {}
     local config = {
       hide = false,
       relative = 'laststatus',
@@ -491,11 +490,11 @@ function M.set_pos(type)
           return
         end
         vim.schedule(function()
-          if api.nvim_win_is_valid(win) then
-            api.nvim_win_set_config(win, save_config)
-          end
-          cmd_on_key = nil
           local entered = api.nvim_get_current_win() == win
+          cmd_on_key = nil
+          if api.nvim_win_is_valid(win) then
+            api.nvim_win_close(win, true)
+          end
           ext.check_targets()
           -- Show or clear the message depending on if the pager was opened.
           if entered or not api.nvim_win_get_config(ext.wins.pager).hide then

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -234,4 +234,23 @@ describe('messages2', function()
       foo [+1]                                             |
     ]])
   end)
+
+  it('not restoring already open hit-enter-prompt config #35298', function()
+    command('echo "foo\nbar"')
+    screen:expect([[
+      ^                                                     |
+      {1:~                                                    }|*10
+      {3:─────────────────────────────────────────────────────}|
+      foo                                                  |
+      bar                                                  |
+    ]])
+    command('echo "foo\nbar"')
+    screen:expect_unchanged()
+    feed(':')
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*12
+      {16::}^                                                    |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:  Temporary cmdline config is saved to be restored later.
Solution: Close the cmdline window so that it is recreated with the appropriate config.

Fix #35298