### PR TITLE
vim-patch:dba9eb4: runtime(python): Also sync syntax at 'async def'

### DIFF
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Python
 " Maintainer:	Zvezdan Petkovic <zpetkovic@acm.org>
-" Last Change:	2025 Aug 10
+" Last Change:	2025 Aug 11
 " Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "		Rob B
@@ -367,8 +367,8 @@ if !exists("python_no_doctest_highlight")
   endif
 endif
 
-" Sync at the beginning of class, function, or method definition.
-syn sync match pythonSync grouphere NONE "^\%(def\|class\)\s\+\h\w*\s*[(:]"
+" Sync at the beginning of (async) function or class definitions.
+syn sync match pythonSync grouphere NONE "^\%(async\s\+def\|def\|class\)\s\+\h\w*\s*[(:]"
 
 " The default highlight links.  Can be overridden later.
 hi def link pythonStatement		Statement


### PR DESCRIPTION
#### vim-patch:dba9eb4: runtime(python): Also sync syntax at 'async def'

A file containing only async functions (`async def func()`) wouldn't
previously match the pythonSync pattern.

Also, this pattern only matches at the beginning of the line, so it
won't ever match method definitions (which are indented within class
scopes). Update the comment accordingly.

closes: vim/vim#17963

https://github.com/vim/vim/commit/dba9eb46e622efe39331b75d0c57c5d8b61b526f

Co-authored-by: Jon Parise <jon@indelible.org>