### PR TITLE
vim-patch:9.1.1625: Autocompletion slow with include- and tag-completion

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7070,7 +7070,7 @@ static void ex_checkpath(exarg_T *eap)
 {
   find_pattern_in_path(NULL, 0, 0, false, false, CHECK_PATH, 1,
                        eap->forceit ? ACTION_SHOW_ALL : ACTION_SHOW,
-                       1, (linenr_T)MAXLNUM, eap->forceit);
+                       1, (linenr_T)MAXLNUM, eap->forceit, false);
 }
 
 /// ":psearch"
@@ -7128,8 +7128,8 @@ static void ex_findpat(exarg_T *eap)
   }
   if (!eap->skip) {
     find_pattern_in_path(eap->arg, 0, strlen(eap->arg), whole, !eap->forceit,
-                         *eap->cmd == 'd' ? FIND_DEFINE : FIND_ANY,
-                         n, action, eap->line1, eap->line2, eap->forceit);
+                         *eap->cmd == 'd' ? FIND_DEFINE : FIND_ANY, n, action,
+                         eap->line1, eap->line2, eap->forceit, false);
   }
 }
 

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -4237,7 +4237,7 @@ static void nv_brackets(cmdarg_T *cap)
                             ? curwin->w_cursor.lnum + 1
                             : 1),
                            MAXLNUM,
-                           false);
+                           false, false);
       xfree(ptr);
       curwin->w_set_curswant = true;
     }

--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3852,9 +3852,10 @@ static char *get_line_and_copy(linenr_T lnum, char *buf)
 /// @param start_lnum     first line to start searching
 /// @param end_lnum       last line for searching
 /// @param forceit        If true, always switch to the found path
+/// @param silent         Do not print messages when ACTION_EXPAND
 void find_pattern_in_path(char *ptr, Direction dir, size_t len, bool whole, bool skip_comments,
                           int type, int count, int action, linenr_T start_lnum, linenr_T end_lnum,
-                          int forceit)
+                          bool forceit, bool silent)
 {
   SearchedFile *files;                  // Stack of included files
   SearchedFile *bigger;                 // When we need more space
@@ -4082,7 +4083,7 @@ void find_pattern_in_path(char *ptr, Direction dir, size_t len, bool whole, bool
           files[depth].name = curr_fname = new_fname;
           files[depth].lnum = 0;
           files[depth].matched = false;
-          if (action == ACTION_EXPAND) {
+          if (action == ACTION_EXPAND && !shortmess(SHM_COMPLETIONSCAN) && !silent) {
             msg_hist_off = true;                // reset in msg_trunc()
             vim_snprintf(IObuff, IOSIZE,
                          _("Scanning included file: %s"),
@@ -4411,8 +4412,7 @@ exit_matched:
         msg(_("No included files"), 0);
       }
     }
-  } else if (!found
-             && action != ACTION_EXPAND) {
+  } else if (!found && action != ACTION_EXPAND && !silent) {
     if (got_int || ins_compl_interrupted()) {
       emsg(_(e_interr));
     } else if (type == FIND_DEFINE) {

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -640,8 +640,8 @@ wingotofile:
     // Make a copy, if the line was changed it will be freed.
     ptr = xmemdupz(ptr, len);
 
-    find_pattern_in_path(ptr, 0, len, true, Prenum == 0,
-                         type, Prenum1, ACTION_SPLIT, 1, MAXLNUM, false);
+    find_pattern_in_path(ptr, 0, len, true, Prenum == 0, type,
+                         Prenum1, ACTION_SPLIT, 1, MAXLNUM, false, false);
     xfree(ptr);
     curwin->w_set_curswant = true;
     break;


### PR DESCRIPTION
#### vim-patch:9.1.1625: Autocompletion slow with include- and tag-completion

Problem:  Autocompletion slow with include- and tag-completion
Solution: Refactor ins_compl_interrupted() to also check for timeout,
          further refactor code to skip outputting message when
          performing autocompletion (Girish Palya).

Running `vim *` in `vim/src` was slower than expected when
'autocomplete' was enabled. Include-file and tag-file completion
sources were not subject to the timeout check, causing unnecessary
delays.

So apply the timeout check to these sources as well, improving
autocompletion responsiveness, refactor find_pattern_in_path() to take
an additional "silent" argument, to suppress any messages.

closes: vim/vim#17966

https://github.com/vim/vim/commit/59e1d7f353993e93be97dbec30d3218742960f62

Co-authored-by: Girish Palya <girishji@gmail.com>