### PR TITLE
vim-patch:9.1.1626: cindent: does not handle compound literals

### DIFF
--- a/scripts/vim-patch.sh
+++ b/scripts/vim-patch.sh
@@ -262,6 +262,10 @@ preprocess_patch() {
   LC_ALL=C sed -Ee 's/( [ab]\/src\/nvim)\/evalwindow\.c/\1\/eval\/window.c/g' \
     "$file" > "$file".tmp && mv "$file".tmp "$file"
 
+  # Rename cindent.c to indent_c.c
+  LC_ALL=C sed -Ee 's/( [ab]\/src\/nvim)\/cindent\.c/\1\/indent_c.c/g' \
+    "$file" > "$file".tmp && mv "$file".tmp "$file"
+
   # Rename map.c to mapping.c
   LC_ALL=C sed -Ee 's/( [ab]\/src\/nvim)\/map\.c/\1\/mapping.c/g' \
     "$file" > "$file".tmp && mv "$file".tmp "$file"

--- a/test/old/testdir/test_indent.vim
+++ b/test/old/testdir/test_indent.vim
@@ -122,6 +122,31 @@ func Test_userlabel_indent()
   close!
 endfunc
 
+" Test that struct members are aligned
+func Test_struct_indent()
+  new
+  call setline(1, ['struct a a = {', '1,', '1,'])
+  normal gg=G
+  call assert_equal(getline(2), getline(3))
+
+  call setline(1, 'a = (struct a) {')
+  normal gg=G
+  call assert_equal(getline(2), getline(3))
+
+  call setline(1, 'void *ptr = &(static struct a) {{')
+  normal gg=G
+  call assert_equal(getline(2), getline(3))
+
+  call setline(1, 'a = (macro(arg1, "str)))")) {')
+  normal gg=G
+  call assert_equal(getline(2), getline(3))
+
+  call setline(1, 'return (struct a) {')
+  normal gg=G
+  call assert_equal(getline(2), getline(3))
+  close!
+endfunc
+
 " Test for 'copyindent'
 func Test_copyindent()
   new


### PR DESCRIPTION
#### vim-patch:9.1.1626: cindent: does not handle compound literals

Problem:  C-indent does not handle compound literals
          (@44100hertz, @Jorenar)
Solution: Detect and handle compound literal and structure
          initialization (Anttoni Erkkilä)

match '=' or "return" optionally followed by &, (typecast), {
Fixes also initialization which begins with multiple opening braces.

closes: vim/vim#17865

https://github.com/vim/vim/commit/5ba6e41d37ec29fc8360a4f06d4e95c63eb013ab

Co-authored-by: Anttoni Erkkilä <anttoni.erkkila@protonmail.com>