### PR TITLE
feat(api): rename buffer to buf

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2068,11 +2068,11 @@ nvim_clear_autocmds({opts})                            *nvim_clear_autocmds()*
                   • event: { "pat1" }
                   • event: { "pat1", "pat2", "pat3" }
                 • pattern: (`string|table?`) Filter by patterns (exact match).
-                  Not allowed with {buffer}.
+                  Not allowed with {buf}.
                   • Example: if you have `*.py` as that pattern for the
                     autocmd, you must pass `*.py` exactly to clear it.
                     `test.py` will not match the pattern.
-                • buffer: (`integer?`) Select |autocmd-buflocal| autocommands.
+                • buf: (`integer?`) Select |autocmd-buflocal| autocommands.
                   Not allowed with {pattern}.
                 • group: (`string|int?`) Group name or id.
                   • NOTE: If not given, matches autocmds not in any group.
@@ -2134,7 +2134,7 @@ nvim_create_autocmd({event}, {opts})                   *nvim_create_autocmd()*
       • {event}  (`vim.api.keyset.events|vim.api.keyset.events[]`) Event(s)
                  that will trigger the handler (`callback` or `command`).
       • {opts}   (`vim.api.keyset.create_autocmd`) Options dict:
-                 • buffer (`integer?`) Buffer id for buffer-local autocommands
+                 • buf (`integer?`) Buffer id for buffer-local autocommands
                    |autocmd-buflocal|. Not allowed with {pattern}.
                  • callback (`function|string?`) Lua function (or Vimscript
                    function name, if string) called when the event(s) is
@@ -2228,9 +2228,9 @@ nvim_exec_autocmds({event}, {opts})                     *nvim_exec_autocmds()*
                  • group (`string|integer?`) Group name or id to match
                    against. |autocmd-groups|.
                  • pattern (`string|array?`, default: current file name)
-                   |autocmd-pattern|. Not allowed with {buffer}.
-                 • buffer (`integer?`) Buffer id |autocmd-buflocal|. Not
-                   allowed with {pattern}.
+                   |autocmd-pattern|. Not allowed with {buf}.
+                 • buf (`integer?`) Buffer id |autocmd-buflocal|. Not allowed
+                   with {pattern}.
                  • modeline (`boolean?`, default: true) Process the modeline
                    after the autocommands <nomodeline>.
                  • data (`any`): Arbitrary data passed to the callback. See
@@ -2265,15 +2265,15 @@ nvim_get_autocmds({opts})                                *nvim_get_autocmds()*
     Parameters: ~
       • {opts}  (`vim.api.keyset.get_autocmds`) Dict with at least one of
                 these keys:
-                • buffer: (`integer[]|integer?`) Buffer id or list of buffer
-                  ids, for buffer-local autocommands |autocmd-buflocal|. Not
+                • buf: (`integer[]|integer?`) Buffer id or list of buffer ids,
+                  for buffer-local autocommands |autocmd-buflocal|. Not
                   allowed with {pattern}.
                 • event: (`vim.api.keyset.events|vim.api.keyset.events[]?`)
                   Event(s) to match |autocmd-events|.
                 • group: (`string|table?`) Group name or id to match.
                 • id: (`integer?`) Autocommand ID to match.
                 • pattern: (`string|table?`) Pattern(s) to match
-                  |autocmd-pattern|. Not allowed with {buffer}.
+                  |autocmd-pattern|. Not allowed with {buf}.
 
     Return: ~
         (`vim.api.keyset.get_autocmds.ret[]`) Array of matching autocommands,
@@ -2692,18 +2692,18 @@ nvim_buf_line_count({buffer})                          *nvim_buf_line_count()*
         (`integer`) Line count, or 0 for unloaded buffer. |api-buffer|
 
                                                        *nvim_buf_set_keymap()*
-nvim_buf_set_keymap({buffer}, {mode}, {lhs}, {rhs}, {opts})
+nvim_buf_set_keymap({buf}, {mode}, {lhs}, {rhs}, {opts})
     Sets a buffer-local |mapping| for the given mode.
 
     Attributes: ~
         Since: 0.4.0
 
     Parameters: ~
-      • {buffer}  (`integer`) Buffer id, or 0 for current buffer
-      • {mode}    (`string`)
-      • {lhs}     (`string`)
-      • {rhs}     (`string`)
-      • {opts}    (`vim.api.keyset.keymap`)
+      • {buf}   (`integer`) Buffer id, or 0 for current buffer
+      • {mode}  (`string`)
+      • {lhs}   (`string`)
+      • {rhs}   (`string`)
+      • {opts}  (`vim.api.keyset.keymap`)
 
     See also: ~
       • |nvim_set_keymap()|

--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -15,7 +15,10 @@ Deprecated features
 ------------------------------------------------------------------------------
 DEPRECATED IN 0.13					*deprecated-0.13*
 
-• todo
+API
+
+• "buffer" key in |nvim_create_autocmd()|, |nvim_get_autocmds()|,
+  |nvim_exec_autocmds()|, |nvim_clear_autocmds()|. Use "buf" instead.
 
 ------------------------------------------------------------------------------
 DEPRECATED IN 0.12					*deprecated-0.12*

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -147,6 +147,12 @@ CHANGED FEATURES                                                 *news-changed*
 These existing features changed their behavior.
 
 • |:Open| with no arguments uses the current file.
+• The "buffer" key was renamed to "buf" in these functions (but the old name
+  "buffer" is still accepted, for backwards compatibility):
+  • |nvim_clear_autocmds()|
+  • |nvim_create_autocmd()|
+  • |nvim_exec_autocmds()|
+  • |nvim_get_autocmds()|
 
 ==============================================================================
 REMOVED FEATURES                                                 *news-removed*

--- a/runtime/ftplugin/query.lua
+++ b/runtime/ftplugin/query.lua
@@ -22,7 +22,7 @@ local query_lint_on = vim.g.query_lint_on or {}
 if not vim.b.disable_query_linter and #query_lint_on > 0 then
   vim.api.nvim_create_autocmd(query_lint_on, {
     group = vim.api.nvim_create_augroup('nvim.querylint', { clear = false }),
-    buffer = buf,
+    buf = buf,
     callback = function()
       vim.treesitter.query.lint(buf)
     end,

--- a/runtime/lua/editorconfig.lua
+++ b/runtime/lua/editorconfig.lua
@@ -165,7 +165,7 @@ function properties.trim_trailing_whitespace(bufnr, val)
   if val == 'true' then
     vim.api.nvim_create_autocmd('BufWritePre', {
       group = 'nvim.editorconfig',
-      buffer = bufnr,
+      buf = bufnr,
       callback = function()
         local view = vim.fn.winsaveview()
         vim.api.nvim_command('silent! undojoin')
@@ -177,7 +177,7 @@ function properties.trim_trailing_whitespace(bufnr, val)
     vim.api.nvim_clear_autocmds({
       event = 'BufWritePre',
       group = 'nvim.editorconfig',
-      buffer = bufnr,
+      buf = bufnr,
     })
   end
 end
@@ -194,7 +194,7 @@ function properties.insert_final_newline(bufnr, val)
   if vim.bo[bufnr].endofline ~= endofline then
     vim.api.nvim_create_autocmd('BufWritePre', {
       group = 'nvim.editorconfig',
-      buffer = bufnr,
+      buf = bufnr,
       once = true,
       callback = function()
         vim.bo[bufnr].endofline = endofline

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -725,12 +725,12 @@ function vim.api.nvim_buf_set_extmark(buffer, ns_id, line, col, opts) end
 ---
 ---
 --- @see vim.api.nvim_set_keymap
---- @param buffer integer Buffer id, or 0 for current buffer
+--- @param buf integer Buffer id, or 0 for current buffer
 --- @param mode string
 --- @param lhs string
 --- @param rhs string
 --- @param opts vim.api.keyset.keymap
-function vim.api.nvim_buf_set_keymap(buffer, mode, lhs, rhs, opts) end
+function vim.api.nvim_buf_set_keymap(buf, mode, lhs, rhs, opts) end
 
 --- Sets (replaces) a line-range in the buffer.
 ---
@@ -867,10 +867,10 @@ function vim.api.nvim_chan_send(chan, data) end
 ---   - event: "pat1"
 ---   - event: { "pat1" }
 ---   - event: { "pat1", "pat2", "pat3" }
---- - pattern: (`string|table?`) Filter by patterns (exact match). Not allowed with {buffer}.
+--- - pattern: (`string|table?`) Filter by patterns (exact match). Not allowed with {buf}.
 ---   - Example: if you have `*.py` as that pattern for the autocmd, you must pass `*.py`
 ---     exactly to clear it. `test.py` will not match the pattern.
---- - buffer: (`integer?`) Select `autocmd-buflocal` autocommands. Not allowed with {pattern}.
+--- - buf: (`integer?`) Select `autocmd-buflocal` autocommands. Not allowed with {pattern}.
 --- - group: (`string|int?`) Group name or id.
 ---   - NOTE: If not given, matches autocmds *not* in any group.
 function vim.api.nvim_clear_autocmds(opts) end
@@ -973,7 +973,7 @@ function vim.api.nvim_create_augroup(name, opts) end
 --- @see vim.api.nvim_del_autocmd
 --- @param event vim.api.keyset.events|vim.api.keyset.events[] Event(s) that will trigger the handler (`callback` or `command`).
 --- @param opts vim.api.keyset.create_autocmd Options dict:
---- - buffer (`integer?`) Buffer id for buffer-local autocommands `autocmd-buflocal`.
+--- - buf (`integer?`) Buffer id for buffer-local autocommands `autocmd-buflocal`.
 ---   Not allowed with {pattern}.
 --- - callback (`function|string?`) Lua function (or Vimscript function name, if string)
 ---   called when the event(s) is triggered. Lua callback can return `lua-truthy` to delete
@@ -1224,8 +1224,8 @@ function vim.api.nvim_exec2(src, opts) end
 --- @param event vim.api.keyset.events|vim.api.keyset.events[] Event(s) to execute.
 --- @param opts vim.api.keyset.exec_autocmds Optional filters:
 --- - group (`string|integer?`) Group name or id to match against. `autocmd-groups`.
---- - pattern (`string|array?`, default: current file name) `autocmd-pattern`. Not allowed with {buffer}.
---- - buffer (`integer?`) Buffer id `autocmd-buflocal`. Not allowed with {pattern}.
+--- - pattern (`string|array?`, default: current file name) `autocmd-pattern`. Not allowed with {buf}.
+--- - buf (`integer?`) Buffer id `autocmd-buflocal`. Not allowed with {pattern}.
 --- - modeline (`boolean?`, default: true) Process the modeline after the autocommands
 ---   [<nomodeline>].
 --- - data (`any`): Arbitrary data passed to the callback. See `nvim_create_autocmd()`.
@@ -1288,12 +1288,12 @@ function vim.api.nvim_get_all_options_info() end
 --- ```
 ---
 --- @param opts vim.api.keyset.get_autocmds Dict with at least one of these keys:
---- - buffer: (`integer[]|integer?`) Buffer id or list of buffer ids, for buffer-local autocommands
+--- - buf: (`integer[]|integer?`) Buffer id or list of buffer ids, for buffer-local autocommands
 ---   `autocmd-buflocal`. Not allowed with {pattern}.
 --- - event: (`vim.api.keyset.events|vim.api.keyset.events[]?`) Event(s) to match `autocmd-events`.
 --- - group: (`string|table?`) Group name or id to match.
 --- - id: (`integer?`) Autocommand ID to match.
---- - pattern: (`string|table?`) Pattern(s) to match `autocmd-pattern`. Not allowed with {buffer}.
+--- - pattern: (`string|table?`) Pattern(s) to match `autocmd-pattern`. Not allowed with {buf}.
 --- @return vim.api.keyset.get_autocmds.ret[] # Array of matching autocommands, where each item has:
 --- - buffer (`integer?`): Buffer id (only for |autocmd-buffer-local|).
 --- - buflocal (`boolean?`): true if the autocommand is buffer-local |autocmd-buffer-local|.

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -18,6 +18,7 @@ error('Cannot require a meta file')
 
 --- @class vim.api.keyset.clear_autocmds
 --- @field buffer? integer
+--- @field buf? integer
 --- @field event? vim.api.keyset.events|vim.api.keyset.events[]
 --- @field group? integer|string
 --- @field pattern? string|string[]
@@ -226,6 +227,7 @@ error('Cannot require a meta file')
 
 --- @class vim.api.keyset.create_autocmd
 --- @field buffer? integer
+--- @field buf? integer
 --- @field callback? string|fun(args: vim.api.keyset.create_autocmd.callback_args): boolean?
 --- @field command? string
 --- @field desc? string
@@ -258,6 +260,7 @@ error('Cannot require a meta file')
 
 --- @class vim.api.keyset.exec_autocmds
 --- @field buffer? integer
+--- @field buf? integer
 --- @field group? integer|string
 --- @field modeline? boolean
 --- @field pattern? string|string[]
@@ -271,6 +274,7 @@ error('Cannot require a meta file')
 --- @field group? integer|string
 --- @field pattern? string|string[]
 --- @field buffer? integer|integer[]
+--- @field buf? integer|integer[]
 --- @field id? integer
 
 --- @class vim.api.keyset.get_commands

--- a/runtime/lua/vim/_meta/api_keysets_extra.lua
+++ b/runtime/lua/vim/_meta/api_keysets_extra.lua
@@ -65,7 +65,7 @@ error('Cannot require a meta file')
 --- @field once? boolean
 --- @field pattern? string
 --- @field buflocal? boolean
---- @field buffer? integer
+--- @field buf? integer
 
 --- @class vim.api.keyset.create_autocmd.callback_args
 --- @field id integer autocommand id
@@ -170,7 +170,7 @@ error('Cannot require a meta file')
 
 --- @class vim.api.keyset.get_keymap
 --- @field abbr? 0|1
---- @field buffer? 0|1
+--- @field buf? 0|1
 --- @field callback? function
 --- @field desc? string
 --- @field expr? 0|1

--- a/runtime/lua/vim/_meta/builtin_types.lua
+++ b/runtime/lua/vim/_meta/builtin_types.lua
@@ -197,7 +197,7 @@
 --- @field priority? integer
 
 --- @class vim.fn.sign_placelist.list.item
---- @field buffer integer|string
+--- @field buf integer|string
 --- @field group? string
 --- @field id? integer
 --- @field lnum? integer|string
@@ -205,11 +205,11 @@
 --- @field priority? integer
 
 --- @class vim.fn.sign_unplace.dict
---- @field buffer? integer|string
+--- @field buf? integer|string
 --- @field id? integer
 
 --- @class vim.fn.sign_unplacelist.list.item
---- @field buffer? integer|string
+--- @field buf? integer|string
 --- @field group? string
 --- @field id? integer
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -447,7 +447,7 @@ do
       assert(bufnr > 0, 'Invalid buffer number')
       api.nvim_create_autocmd('BufWipeout', {
         group = group,
-        buffer = bufnr,
+        buf = bufnr,
         callback = function()
           rawset(t, bufnr, nil)
         end,
@@ -867,7 +867,7 @@ local function schedule_display(namespace, bufnr, args)
     local group = api.nvim_create_augroup(key, { clear = true })
     api.nvim_create_autocmd(insert_leave_auto_cmds, {
       group = group,
-      buffer = bufnr,
+      buf = bufnr,
       callback = function()
         execute_scheduled_display(namespace, bufnr)
       end,
@@ -1352,8 +1352,8 @@ local function once_buf_loaded(bufnr, fn)
   if api.nvim_buf_is_loaded(bufnr) then
     fn()
   else
-    return api.nvim_create_autocmd('BufRead', {
-      buffer = bufnr,
+    api.nvim_create_autocmd('BufRead', {
+      buf = bufnr,
       once = true,
       callback = function()
         fn()
@@ -1455,7 +1455,7 @@ function M.set(namespace, bufnr, diagnostics, opts)
 
   api.nvim_exec_autocmds('DiagnosticChanged', {
     modeline = false,
-    buffer = bufnr,
+    buf = bufnr,
     -- TODO(lewis6991): should this be deepcopy()'d like they are in vim.diagnostic.get()
     data = { diagnostics = diagnostics },
   })
@@ -1944,14 +1944,13 @@ M.handlers.virtual_text = {
           { clear = true }
         )
       end
-
-      api.nvim_clear_autocmds({ group = ns.user_data.virt_text_augroup, buffer = bufnr })
+      api.nvim_clear_autocmds({ group = ns.user_data.virt_text_augroup, buf = bufnr })
 
       local line_diagnostics = diagnostic_lines(diagnostics, true)
 
       if opts.virtual_text.current_line ~= nil then
         api.nvim_create_autocmd('CursorMoved', {
-          buffer = bufnr,
+          buf = bufnr,
           group = ns.user_data.virt_text_augroup,
           callback = function()
             render_virtual_text(
@@ -1976,7 +1975,7 @@ M.handlers.virtual_text = {
       diagnostic_cache_extmarks[bufnr][ns.user_data.virt_text_ns] = {}
       if api.nvim_buf_is_valid(bufnr) then
         api.nvim_buf_clear_namespace(bufnr, ns.user_data.virt_text_ns, 0, -1)
-        api.nvim_clear_autocmds({ group = ns.user_data.virt_text_augroup, buffer = bufnr })
+        api.nvim_clear_autocmds({ group = ns.user_data.virt_text_augroup, buf = bufnr })
       end
     end
   end,
@@ -2197,7 +2196,7 @@ M.handlers.virtual_lines = {
         )
       end
 
-      api.nvim_clear_autocmds({ group = ns.user_data.virt_lines_augroup, buffer = bufnr })
+      api.nvim_clear_autocmds({ group = ns.user_data.virt_lines_augroup, buf = bufnr })
 
       diagnostics =
         reformat_diagnostics(opts.virtual_lines.format or format_virtual_lines, diagnostics)
@@ -2207,7 +2206,7 @@ M.handlers.virtual_lines = {
         -- diagnostics we need when the cursor line doesn't change.
         local line_diagnostics = diagnostic_lines(diagnostics, true)
         api.nvim_create_autocmd('CursorMoved', {
-          buffer = bufnr,
+          buf = bufnr,
           group = ns.user_data.virt_lines_augroup,
           callback = function()
             render_virtual_lines(
@@ -2237,7 +2236,7 @@ M.handlers.virtual_lines = {
       diagnostic_cache_extmarks[bufnr][ns.user_data.virt_lines_ns] = {}
       if api.nvim_buf_is_valid(bufnr) then
         api.nvim_buf_clear_namespace(bufnr, ns.user_data.virt_lines_ns, 0, -1)
-        api.nvim_clear_autocmds({ group = ns.user_data.virt_lines_augroup, buffer = bufnr })
+        api.nvim_clear_autocmds({ group = ns.user_data.virt_lines_augroup, buf = bufnr })
       end
     end
   end,
@@ -2713,7 +2712,7 @@ function M.reset(namespace, bufnr)
     if api.nvim_buf_is_valid(iter_bufnr) then
       api.nvim_exec_autocmds('DiagnosticChanged', {
         modeline = false,
-        buffer = iter_bufnr,
+        buf = iter_bufnr,
         data = { diagnostics = {} },
       })
     else

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -936,7 +936,7 @@ local function buf_attach(bufnr)
   local group = api.nvim_create_augroup(augroup, { clear = true })
   api.nvim_create_autocmd('BufWritePre', {
     group = group,
-    buffer = bufnr,
+    buf = bufnr,
     desc = 'vim.lsp: textDocument/willSave',
     callback = function(ctx)
       for _, client in ipairs(lsp.get_clients({ bufnr = ctx.buf })) do
@@ -963,7 +963,7 @@ local function buf_attach(bufnr)
   })
   api.nvim_create_autocmd('BufWritePost', {
     group = group,
-    buffer = bufnr,
+    buf = bufnr,
     desc = 'vim.lsp: textDocument/didSave handler',
     callback = function(ctx)
       text_document_did_save_handler(ctx.buf)

--- a/runtime/lua/vim/lsp/_folding_range.lua
+++ b/runtime/lua/vim/lsp/_folding_range.lua
@@ -113,7 +113,7 @@ local function schedule_foldupdate(bufnr)
   if not scheduled_foldupdate[bufnr] then
     scheduled_foldupdate[bufnr] = true
     api.nvim_create_autocmd('InsertLeave', {
-      buffer = bufnr,
+      buf = bufnr,
       once = true,
       callback = function()
         foldupdate(bufnr)
@@ -230,7 +230,7 @@ function State:new(bufnr)
   })
   api.nvim_create_autocmd('LspNotify', {
     group = self.augroup,
-    buffer = bufnr,
+    buf = bufnr,
     callback = function(ev)
       local client = assert(vim.lsp.get_client_by_id(ev.data.client_id))
       if

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -703,7 +703,7 @@ function Client:_process_request(id, req_type, bufnr, method)
   self.requests[id] = req_type ~= 'complete' and request or nil
 
   api.nvim_exec_autocmds('LspRequest', {
-    buffer = api.nvim_buf_is_valid(bufnr) and bufnr or nil,
+    buf = api.nvim_buf_is_valid(bufnr) and bufnr or nil,
     modeline = false,
     data = { client_id = self.id, request_id = id, request = request },
   })
@@ -1152,7 +1152,7 @@ function Client:on_attach(bufnr)
   lsp._set_defaults(self, bufnr)
 
   api.nvim_exec_autocmds('LspAttach', {
-    buffer = bufnr,
+    buf = bufnr,
     modeline = false,
     data = { client_id = self.id },
   })
@@ -1335,7 +1335,7 @@ end
 function Client:_on_detach(bufnr)
   if self.attached_buffers[bufnr] and api.nvim_buf_is_valid(bufnr) then
     api.nvim_exec_autocmds('LspDetach', {
-      buffer = bufnr,
+      buf = bufnr,
       modeline = false,
       data = { client_id = self.id },
     })

--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -774,7 +774,7 @@ end
 local function on_completechanged(group, bufnr)
   api.nvim_create_autocmd('CompleteChanged', {
     group = group,
-    buffer = bufnr,
+    buf = bufnr,
     callback = function(ev)
       local completed_item = vim.v.event.completed_item or {}
       local lsp_item = vim.tbl_get(completed_item, 'user_data', 'nvim', 'lsp', 'completion_item')
@@ -920,13 +920,13 @@ end
 ---@return integer
 local function register_completedone(bufnr)
   local group = api.nvim_create_augroup(get_augroup(bufnr), { clear = false })
-  if #api.nvim_get_autocmds({ buffer = bufnr, event = 'CompleteDone', group = group }) > 0 then
+  if #api.nvim_get_autocmds({ buf = bufnr, event = 'CompleteDone', group = group }) > 0 then
     return group
   end
 
   api.nvim_create_autocmd('CompleteDone', {
     group = group,
-    buffer = bufnr,
+    buf = bufnr,
     callback = function()
       local reason = api.nvim_get_vvar('event').reason ---@type string
       if reason == 'accept' then
@@ -1033,9 +1033,7 @@ local function trigger(bufnr, clients, ctx)
     Context.cursor = { cursor_row, start_col }
     if #matches > 0 and has_completeopt('popup') then
       local group = get_augroup(bufnr)
-      if
-        #api.nvim_get_autocmds({ buffer = bufnr, event = 'CompleteChanged', group = group }) == 0
-      then
+      if #api.nvim_get_autocmds({ buf = bufnr, event = 'CompleteChanged', group = group }) == 0 then
         on_completechanged(group, bufnr)
       end
     end
@@ -1148,7 +1146,7 @@ local function enable_completions(client_id, bufnr, opts)
     local group = register_completedone(bufnr)
     api.nvim_create_autocmd('LspDetach', {
       group = group,
-      buffer = bufnr,
+      buf = bufnr,
       desc = 'vim.lsp.completion: clean up client on detach',
       callback = function(ev)
         disable_completions(ev.data.client_id, ev.buf)
@@ -1158,14 +1156,14 @@ local function enable_completions(client_id, bufnr, opts)
     if opts.autotrigger then
       api.nvim_create_autocmd('InsertCharPre', {
         group = group,
-        buffer = bufnr,
+        buf = bufnr,
         callback = function()
           on_insert_char_pre(buf_handles[bufnr])
         end,
       })
       api.nvim_create_autocmd('InsertLeave', {
         group = group,
-        buffer = bufnr,
+        buf = bufnr,
         callback = on_insert_leave,
       })
     end

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -448,7 +448,7 @@ function M._enable(bufnr)
   end
 
   api.nvim_create_autocmd('LspNotify', {
-    buffer = bufnr,
+    buf = bufnr,
     callback = function(opts)
       if
         opts.data.method ~= 'textDocument/didChange'
@@ -476,7 +476,7 @@ function M._enable(bufnr)
   })
 
   api.nvim_create_autocmd('LspDetach', {
-    buffer = bufnr,
+    buf = bufnr,
     callback = function(ev)
       local clients = lsp.get_clients({ bufnr = bufnr, method = 'textDocument/diagnostic' })
 

--- a/runtime/lua/vim/lsp/linked_editing_range.lua
+++ b/runtime/lua/vim/lsp/linked_editing_range.lua
@@ -203,7 +203,7 @@ function LinkedEditor.new(bufnr)
   self.client_states = {}
 
   api.nvim_create_autocmd({ 'TextChanged', 'TextChangedI' }, {
-    buffer = bufnr,
+    buf = bufnr,
     group = augroup,
     callback = function()
       for _, client_state in pairs(self.client_states) do
@@ -214,14 +214,14 @@ function LinkedEditor.new(bufnr)
   })
   api.nvim_create_autocmd('CursorMoved', {
     group = augroup,
-    buffer = bufnr,
+    buf = bufnr,
     callback = function()
       self:refresh()
     end,
   })
   api.nvim_create_autocmd('LspDetach', {
     group = augroup,
-    buffer = bufnr,
+    buf = bufnr,
     callback = function(ev)
       self:detach(ev.data.client_id)
     end,

--- a/runtime/lua/vim/lsp/semantic_tokens.lua
+++ b/runtime/lua/vim/lsp/semantic_tokens.lua
@@ -258,7 +258,7 @@ function STHighlighter:on_attach(client_id)
   end
 
   api.nvim_create_autocmd({ 'BufWinEnter', 'InsertLeave' }, {
-    buffer = self.bufnr,
+    buf = self.bufnr,
     group = self.augroup,
     callback = function()
       self:send_request()
@@ -267,7 +267,7 @@ function STHighlighter:on_attach(client_id)
 
   if state.supports_range then
     api.nvim_create_autocmd('WinScrolled', {
-      buffer = self.bufnr,
+      buf = self.bufnr,
       group = self.augroup,
       callback = function()
         self:on_change()
@@ -721,7 +721,7 @@ function STHighlighter:on_win(topline, botline)
           token.marked = true
 
           api.nvim_exec_autocmds('LspTokenUpdate', {
-            buffer = self.bufnr,
+            buf = self.bufnr,
             modeline = false,
             data = {
               token = token,

--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -1478,7 +1478,7 @@ local function close_preview_autocmd(events, winnr, floating_bufnr, bufnr)
   -- the floating window buffer or the buffer that spawned it
   api.nvim_create_autocmd('BufLeave', {
     group = augroup,
-    buffer = bufnr,
+    buf = bufnr,
     callback = function()
       vim.schedule(function()
         -- When jumping to the quickfix window from the preview window,
@@ -1493,7 +1493,7 @@ local function close_preview_autocmd(events, winnr, floating_bufnr, bufnr)
   if #events > 0 then
     api.nvim_create_autocmd(events, {
       group = augroup,
-      buffer = bufnr,
+      buf = bufnr,
       callback = function()
         close_preview_window(winnr)
       end,

--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -1155,7 +1155,7 @@ local function show_confirm_buf(lines, on_finish)
     delete_buffer()
   end
   -- - Use `nested` to allow other events (useful for statuslines)
-  api.nvim_create_autocmd('BufWriteCmd', { buffer = bufnr, nested = true, callback = finish })
+  api.nvim_create_autocmd('BufWriteCmd', { buf = bufnr, nested = true, callback = finish })
 
   -- Define action to cancel confirm
   --- @type integer

--- a/runtime/lua/vim/snippet.lua
+++ b/runtime/lua/vim/snippet.lua
@@ -390,7 +390,7 @@ local function setup_autocmds(bufnr)
   vim.api.nvim_create_autocmd({ 'CursorMoved', 'CursorMovedI' }, {
     group = snippet_group,
     desc = 'Update snippet state when the cursor moves',
-    buffer = bufnr,
+    buf = bufnr,
     callback = function()
       -- Just update the tabstop in insert and select modes.
       if not vim.fn.mode():match('^[isS]') then
@@ -434,7 +434,7 @@ local function setup_autocmds(bufnr)
   vim.api.nvim_create_autocmd({ 'TextChanged', 'TextChangedI', 'TextChangedP' }, {
     group = snippet_group,
     desc = 'Update active tabstops when buffer text changes',
-    buffer = bufnr,
+    buf = bufnr,
     callback = function()
       -- Check that the snippet hasn't been deleted.
       local snippet_range = get_extmark_range(M._session.bufnr, M._session.extmark_id)
@@ -463,7 +463,7 @@ local function setup_autocmds(bufnr)
   vim.api.nvim_create_autocmd('BufLeave', {
     group = snippet_group,
     desc = 'Stop the snippet session when leaving the buffer',
-    buffer = bufnr,
+    buf = bufnr,
     callback = function()
       M.stop()
     end,
@@ -635,7 +635,7 @@ function M.jump(direction)
   end
 
   -- Clear the autocommands so that we can move the cursor freely while selecting the tabstop.
-  vim.api.nvim_clear_autocmds({ group = snippet_group, buffer = M._session.bufnr })
+  vim.api.nvim_clear_autocmds({ group = snippet_group, buf = M._session.bufnr })
 
   M._session.current_tabstop = dest
   M._session:set_gravity()
@@ -678,7 +678,7 @@ function M.stop()
     return
   end
 
-  vim.api.nvim_clear_autocmds({ group = snippet_group, buffer = M._session.bufnr })
+  vim.api.nvim_clear_autocmds({ group = snippet_group, buf = M._session.bufnr })
   vim.api.nvim_buf_clear_namespace(M._session.bufnr, snippet_ns, 0, -1)
 
   M._session = nil

--- a/runtime/lua/vim/treesitter/_fold.lua
+++ b/runtime/lua/vim/treesitter/_fold.lua
@@ -222,13 +222,13 @@ function FoldInfo:foldupdate(bufnr, srow, erow)
     -- foldUpdate() is guarded in insert mode. So update folds on InsertLeave
     if #(api.nvim_get_autocmds({
       group = group,
-      buffer = bufnr,
+      buf = bufnr,
     })) > 0 then
       return
     end
     api.nvim_create_autocmd('InsertLeave', {
       group = group,
-      buffer = bufnr,
+      buf = bufnr,
       once = true,
       callback = function()
         self:do_foldupdate(bufnr)
@@ -392,7 +392,7 @@ function M.foldexpr(lnum)
   if not foldinfos[bufnr] then
     foldinfos[bufnr] = FoldInfo.new(bufnr)
     api.nvim_create_autocmd({ 'BufUnload', 'VimEnter', 'FileType' }, {
-      buffer = bufnr,
+      buf = bufnr,
       once = true,
       callback = function()
         foldinfos[bufnr] = nil

--- a/runtime/lua/vim/treesitter/dev.lua
+++ b/runtime/lua/vim/treesitter/dev.lua
@@ -475,7 +475,7 @@ function M.inspect_tree(opts)
 
   api.nvim_create_autocmd('CursorMoved', {
     group = group,
-    buffer = b,
+    buf = b,
     callback = function()
       if not api.nvim_buf_is_loaded(buf) then
         return true
@@ -509,7 +509,7 @@ function M.inspect_tree(opts)
 
   api.nvim_create_autocmd('CursorMoved', {
     group = group,
-    buffer = buf,
+    buf = buf,
     callback = function()
       if not api.nvim_buf_is_loaded(b) then
         return true
@@ -521,7 +521,7 @@ function M.inspect_tree(opts)
 
   api.nvim_create_autocmd({ 'TextChanged', 'InsertLeave' }, {
     group = group,
-    buffer = buf,
+    buf = buf,
     callback = function()
       if not api.nvim_buf_is_loaded(b) then
         return true
@@ -536,7 +536,7 @@ function M.inspect_tree(opts)
 
   api.nvim_create_autocmd('BufLeave', {
     group = group,
-    buffer = b,
+    buf = b,
     callback = function()
       if not api.nvim_buf_is_loaded(buf) then
         return true
@@ -547,7 +547,7 @@ function M.inspect_tree(opts)
 
   api.nvim_create_autocmd('BufLeave', {
     group = group,
-    buffer = buf,
+    buf = buf,
     callback = function()
       if not api.nvim_buf_is_loaded(b) then
         return true
@@ -558,7 +558,7 @@ function M.inspect_tree(opts)
 
   api.nvim_create_autocmd({ 'BufHidden', 'BufUnload', 'QuitPre' }, {
     group = group,
-    buffer = buf,
+    buf = buf,
     callback = function()
       -- don't close inpector window if source buffer
       -- has more than one open window
@@ -677,7 +677,7 @@ function M.edit_query(lang)
   local group = api.nvim_create_augroup('nvim.treesitter.dev_edit', {})
   api.nvim_create_autocmd({ 'TextChanged', 'InsertLeave' }, {
     group = group,
-    buffer = query_buf,
+    buf = query_buf,
     desc = 'Update query editor diagnostics when the query changes',
     callback = function()
       vim.treesitter.query.lint(query_buf, { langs = lang, clear = false })
@@ -685,7 +685,7 @@ function M.edit_query(lang)
   })
   api.nvim_create_autocmd({ 'TextChanged', 'InsertLeave', 'CursorMoved', 'BufEnter' }, {
     group = group,
-    buffer = query_buf,
+    buf = query_buf,
     desc = 'Update query editor highlights when the cursor moves',
     callback = function()
       if api.nvim_win_is_valid(win) then
@@ -695,7 +695,7 @@ function M.edit_query(lang)
   })
   api.nvim_create_autocmd('BufLeave', {
     group = group,
-    buffer = query_buf,
+    buf = query_buf,
     desc = 'Clear highlights when leaving the query editor',
     callback = function()
       api.nvim_buf_clear_namespace(buf, edit_ns, 0, -1)
@@ -703,7 +703,7 @@ function M.edit_query(lang)
   })
   api.nvim_create_autocmd('BufLeave', {
     group = group,
-    buffer = buf,
+    buf = buf,
     desc = 'Clear the query editor highlights when leaving the source buffer',
     callback = function()
       if not api.nvim_buf_is_loaded(query_buf) then
@@ -715,7 +715,7 @@ function M.edit_query(lang)
   })
   api.nvim_create_autocmd({ 'BufHidden', 'BufUnload' }, {
     group = group,
-    buffer = buf,
+    buf = buf,
     desc = 'Close the editor window when the source buffer is hidden or unloaded',
     once = true,
     callback = function()

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -194,7 +194,7 @@ function TSHighlighter:destroy()
       api.nvim_buf_call(self.bufnr, function()
         api.nvim_exec_autocmds(
           'FileType',
-          { group = 'syntaxset', buffer = self.bufnr, modeline = false }
+          { group = 'syntaxset', buf = self.bufnr, modeline = false }
         )
       end)
     end

--- a/src/nvim/api/autocmd.c
+++ b/src/nvim/api/autocmd.c
@@ -66,12 +66,12 @@ static int64_t next_autocmd_id = 1;
 /// ```
 ///
 /// @param opts Dict with at least one of these keys:
-///        - buffer: (`integer[]|integer?`) Buffer id or list of buffer ids, for buffer-local autocommands
+///        - buf: (`integer[]|integer?`) Buffer id or list of buffer ids, for buffer-local autocommands
 ///          |autocmd-buflocal|. Not allowed with {pattern}.
 ///        - event: (`vim.api.keyset.events|vim.api.keyset.events[]?`) Event(s) to match |autocmd-events|.
 ///        - group: (`string|table?`) Group name or id to match.
 ///        - id: (`integer?`) Autocommand ID to match.
-///        - pattern: (`string|table?`) Pattern(s) to match |autocmd-pattern|. Not allowed with {buffer}.
+///        - pattern: (`string|table?`) Pattern(s) to match |autocmd-pattern|. Not allowed with {buf}.
 /// @return Array of matching autocommands, where each item has:
 ///         - buffer (`integer?`): Buffer id (only for |autocmd-buffer-local|).
 ///         - buflocal (`boolean?`): true if the autocommand is buffer-local |autocmd-buffer-local|.
@@ -146,8 +146,16 @@ ArrayOf(DictAs(get_autocmds__ret)) nvim_get_autocmds(Dict(get_autocmds) *opts, A
     }
   }
 
-  VALIDATE_CON((!HAS_KEY(opts, get_autocmds, pattern) || !HAS_KEY(opts, get_autocmds, buffer)),
-               "pattern", "buffer", {
+  bool has_buf = HAS_KEY(opts, get_autocmds, buf) || HAS_KEY(opts, get_autocmds, buffer);
+  Object buf = HAS_KEY(opts, get_autocmds, buf) ? opts->buf : opts->buffer;
+
+  VALIDATE_CON((!HAS_KEY(opts, get_autocmds, buf) || !HAS_KEY(opts, get_autocmds, buffer)),
+               "buf", "buffer", {
+    goto cleanup;
+  });
+
+  VALIDATE_CON((!HAS_KEY(opts, get_autocmds, pattern) || !has_buf),
+               "pattern", "buf", {
     goto cleanup;
   });
 
@@ -178,37 +186,37 @@ ArrayOf(DictAs(get_autocmds__ret)) nvim_get_autocmds(Dict(get_autocmds) *opts, A
     }
   }
 
-  if (opts->buffer.type == kObjectTypeInteger || opts->buffer.type == kObjectTypeBuffer) {
-    buf_T *buf = find_buffer_by_handle((Buffer)opts->buffer.data.integer, err);
+  if (buf.type == kObjectTypeInteger || buf.type == kObjectTypeBuffer) {
+    buf_T *b = find_buffer_by_handle((Buffer)buf.data.integer, err);
     if (ERROR_SET(err)) {
       goto cleanup;
     }
 
-    String pat = arena_printf(arena, "<buffer=%d>", (int)buf->handle);
+    String pat = arena_printf(arena, "<buffer=%d>", (int)b->handle);
     buffers = arena_array(arena, 1);
     ADD_C(buffers, STRING_OBJ(pat));
-  } else if (opts->buffer.type == kObjectTypeArray) {
-    VALIDATE((opts->buffer.data.array.size <= AUCMD_MAX_PATTERNS),
+  } else if (buf.type == kObjectTypeArray) {
+    VALIDATE((buf.data.array.size <= AUCMD_MAX_PATTERNS),
              "Too many buffers (maximum of %d)", AUCMD_MAX_PATTERNS, {
       goto cleanup;
     });
 
-    buffers = arena_array(arena, kv_size(opts->buffer.data.array));
-    FOREACH_ITEM(opts->buffer.data.array, bufnr, {
+    buffers = arena_array(arena, kv_size(buf.data.array));
+    FOREACH_ITEM(buf.data.array, bufnr, {
       VALIDATE_EXP((bufnr.type == kObjectTypeInteger || bufnr.type == kObjectTypeBuffer),
                    "buffer", "Integer", api_typename(bufnr.type), {
         goto cleanup;
       });
 
-      buf_T *buf = find_buffer_by_handle((Buffer)bufnr.data.integer, err);
+      buf_T *b = find_buffer_by_handle((Buffer)bufnr.data.integer, err);
       if (ERROR_SET(err)) {
         goto cleanup;
       }
 
-      ADD_C(buffers, STRING_OBJ(arena_printf(arena, "<buffer=%d>", (int)buf->handle)));
+      ADD_C(buffers, STRING_OBJ(arena_printf(arena, "<buffer=%d>", (int)b->handle)));
     });
-  } else if (HAS_KEY(opts, get_autocmds, buffer)) {
-    VALIDATE_EXP(false, "buffer", "Integer or Array", api_typename(opts->buffer.type), {
+  } else if (has_buf) {
+    VALIDATE_EXP(false, "buffer", "Integer or Array", api_typename(buf.type), {
       goto cleanup;
     });
   }
@@ -356,7 +364,7 @@ cleanup:
 ///
 /// @param event Event(s) that will trigger the handler (`callback` or `command`).
 /// @param opts Options dict:
-///        - buffer (`integer?`) Buffer id for buffer-local autocommands |autocmd-buflocal|.
+///        - buf (`integer?`) Buffer id for buffer-local autocommands |autocmd-buflocal|.
 ///          Not allowed with {pattern}.
 ///        - callback (`function|string?`) Lua function (or Vimscript function name, if string)
 ///          called when the event(s) is triggered. Lua callback can return |lua-truthy| to delete
@@ -438,13 +446,19 @@ Integer nvim_create_autocmd(uint64_t channel_id, Object event, Dict(create_autoc
     goto cleanup;
   }
 
-  bool has_buffer = HAS_KEY(opts, create_autocmd, buffer);
+  bool has_buf = HAS_KEY(opts, create_autocmd, buf) || HAS_KEY(opts, create_autocmd, buffer);
+  Buffer buf = HAS_KEY(opts, create_autocmd, buf) ? opts->buf : opts->buffer;
 
-  VALIDATE_CON((!HAS_KEY(opts, create_autocmd, pattern) || !has_buffer), "pattern", "buffer", {
+  VALIDATE_CON((!HAS_KEY(opts, create_autocmd, buf) || !HAS_KEY(opts, create_autocmd, buffer)),
+               "buf", "buffer", {
     goto cleanup;
   });
 
-  Array patterns = get_patterns_from_pattern_or_buf(opts->pattern, has_buffer, opts->buffer, "*",
+  VALIDATE_CON((!HAS_KEY(opts, create_autocmd, pattern) || !has_buf), "pattern", "buf", {
+    goto cleanup;
+  });
+
+  Array patterns = get_patterns_from_pattern_or_buf(opts->pattern, has_buf, buf, "*",
                                                     arena, err);
   if (ERROR_SET(err)) {
     goto cleanup;
@@ -520,10 +534,10 @@ void nvim_del_autocmd(Integer id, Error *err)
 ///          - event: "pat1"
 ///          - event: { "pat1" }
 ///          - event: { "pat1", "pat2", "pat3" }
-///        - pattern: (`string|table?`) Filter by patterns (exact match). Not allowed with {buffer}.
+///        - pattern: (`string|table?`) Filter by patterns (exact match). Not allowed with {buf}.
 ///          - Example: if you have `*.py` as that pattern for the autocmd, you must pass `*.py`
 ///            exactly to clear it. `test.py` will not match the pattern.
-///        - buffer: (`integer?`) Select |autocmd-buflocal| autocommands. Not allowed with {pattern}.
+///        - buf: (`integer?`) Select |autocmd-buflocal| autocommands. Not allowed with {pattern}.
 ///        - group: (`string|int?`) Group name or id.
 ///          - NOTE: If not given, matches autocmds *not* in any group.
 ///
@@ -541,9 +555,15 @@ void nvim_clear_autocmds(Dict(clear_autocmds) *opts, Arena *arena, Error *err)
     return;
   }
 
-  bool has_buffer = HAS_KEY(opts, clear_autocmds, buffer);
+  bool has_buf = HAS_KEY(opts, clear_autocmds, buf) || HAS_KEY(opts, clear_autocmds, buffer);
+  int buf = HAS_KEY(opts, clear_autocmds, buf) ? opts->buf : opts->buffer;
 
-  VALIDATE_CON((!HAS_KEY(opts, clear_autocmds, pattern) || !has_buffer), "pattern", "buffer", {
+  VALIDATE_CON((!HAS_KEY(opts, clear_autocmds, buf) || !HAS_KEY(opts, clear_autocmds, buffer)),
+               "buf", "buffer", {
+    return;
+  });
+
+  VALIDATE_CON((!HAS_KEY(opts, clear_autocmds, pattern) || !has_buf), "pattern", "buf", {
     return;
   });
 
@@ -554,7 +574,7 @@ void nvim_clear_autocmds(Dict(clear_autocmds) *opts, Arena *arena, Error *err)
 
   // When we create the autocmds, we want to say that they are all matched, so that's *
   // but when we clear them, we want to say that we didn't pass a pattern, so that's NUL
-  Array patterns = get_patterns_from_pattern_or_buf(opts->pattern, has_buffer, opts->buffer, "",
+  Array patterns = get_patterns_from_pattern_or_buf(opts->pattern, has_buf, buf, "",
                                                     arena, err);
   if (ERROR_SET(err)) {
     return;
@@ -660,8 +680,8 @@ void nvim_del_augroup_by_name(String name, Error *err)
 /// @param event Event(s) to execute.
 /// @param opts Optional filters:
 ///        - group (`string|integer?`) Group name or id to match against. |autocmd-groups|.
-///        - pattern (`string|array?`, default: current file name) |autocmd-pattern|. Not allowed with {buffer}.
-///        - buffer (`integer?`) Buffer id |autocmd-buflocal|. Not allowed with {pattern}.
+///        - pattern (`string|array?`, default: current file name) |autocmd-pattern|. Not allowed with {buf}.
+///        - buf (`integer?`) Buffer id |autocmd-buflocal|. Not allowed with {pattern}.
 ///        - modeline (`boolean?`, default: true) Process the modeline after the autocommands
 ///          [<nomodeline>].
 ///        - data (`any`): Arbitrary data passed to the callback. See |nvim_create_autocmd()|.
@@ -672,7 +692,7 @@ void nvim_exec_autocmds(Object event, Dict(exec_autocmds) *opts, Arena *arena, E
   int au_group = AUGROUP_ALL;
   bool modeline = true;
 
-  buf_T *buf = curbuf;
+  buf_T *b = curbuf;
 
   Object *data = NULL;
 
@@ -703,21 +723,26 @@ void nvim_exec_autocmds(Object event, Dict(exec_autocmds) *opts, Arena *arena, E
     });
   }
 
-  bool has_buffer = false;
-  if (HAS_KEY(opts, exec_autocmds, buffer)) {
-    VALIDATE_CON((!HAS_KEY(opts, exec_autocmds, pattern)), "pattern", "buffer", {
+  bool has_buf = HAS_KEY(opts, exec_autocmds, buf) || HAS_KEY(opts, exec_autocmds, buffer);
+  Buffer buf = HAS_KEY(opts, exec_autocmds, buf) ? opts->buf : opts->buffer;
+
+  VALIDATE_CON((!HAS_KEY(opts, exec_autocmds, buf) || !HAS_KEY(opts, exec_autocmds, buffer)),
+               "buf", "buffer", {
+    return;
+  });
+
+  if (has_buf) {
+    VALIDATE_CON((!HAS_KEY(opts, exec_autocmds, pattern)), "pattern", "buf", {
       return;
     });
 
-    has_buffer = true;
-    buf = find_buffer_by_handle(opts->buffer, err);
-
+    b = find_buffer_by_handle(buf, err);
     if (ERROR_SET(err)) {
       return;
     }
   }
 
-  Array patterns = get_patterns_from_pattern_or_buf(opts->pattern, has_buffer, opts->buffer, "",
+  Array patterns = get_patterns_from_pattern_or_buf(opts->pattern, has_buf, buf, "",
                                                     arena, err);
   if (ERROR_SET(err)) {
     return;
@@ -734,8 +759,8 @@ void nvim_exec_autocmds(Object event, Dict(exec_autocmds) *opts, Arena *arena, E
     GET_ONE_EVENT(event_nr, event_str, return )
 
     FOREACH_ITEM(patterns, pat, {
-      char *fname = !has_buffer ? pat.data.string.data : NULL;
-      did_aucmd |= apply_autocmds_group(event_nr, fname, NULL, true, au_group, buf, NULL, data);
+      char *fname = !has_buf ? pat.data.string.data : NULL;
+      did_aucmd |= apply_autocmds_group(event_nr, fname, NULL, true, au_group, b, NULL, data);
     })
   })
 

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -873,12 +873,12 @@ ArrayOf(DictAs(get_keymap)) nvim_buf_get_keymap(Buffer buffer, String mode, Aren
 ///
 /// @see |nvim_set_keymap()|
 ///
-/// @param  buffer  Buffer id, or 0 for current buffer
-void nvim_buf_set_keymap(uint64_t channel_id, Buffer buffer, String mode, String lhs, String rhs,
+/// @param  buf  Buffer id, or 0 for current buffer
+void nvim_buf_set_keymap(uint64_t channel_id, Buffer buf, String mode, String lhs, String rhs,
                          Dict(keymap) *opts, Error *err)
   FUNC_API_SINCE(6)
 {
-  modify_keymap(channel_id, buffer, false, mode, lhs, rhs, opts, err);
+  modify_keymap(channel_id, buf, false, mode, lhs, rhs, opts, err);
 }
 
 /// Unmaps a buffer-local |mapping| for the given mode.

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -253,7 +253,8 @@ typedef struct {
 
 typedef struct {
   OptionalKeys is_set__clear_autocmds_;
-  Buffer buffer;
+  Buffer buffer;  // deprecated - use buf
+  Buffer buf;
   Union(String, ArrayOf(String)) event;
   Union(Integer, String) group;
   Union(String, ArrayOf(String)) pattern;
@@ -261,7 +262,8 @@ typedef struct {
 
 typedef struct {
   OptionalKeys is_set__create_autocmd_;
-  Buffer buffer;
+  Buffer buffer;  // deprecated - use buf
+  Buffer buf;
   Union(String, LuaRefOf((DictAs(create_autocmd__callback_args) args), *Boolean)) callback;
   String command;
   String desc;
@@ -273,7 +275,8 @@ typedef struct {
 
 typedef struct {
   OptionalKeys is_set__exec_autocmds_;
-  Buffer buffer;
+  Buffer buffer;  // deprecated - use buf
+  Buffer buf;
   Union(Integer, String) group;
   Boolean modeline;
   Union(String, ArrayOf(String)) pattern;
@@ -285,7 +288,8 @@ typedef struct {
   Union(String, ArrayOf(String)) event;
   Union(Integer, String) group;
   Union(String, ArrayOf(String)) pattern;
-  Union(Integer, ArrayOf(Integer)) buffer;
+  Union(Integer, ArrayOf(Integer)) buffer;  // deprecated - use buf
+  Union(Integer, ArrayOf(Integer)) buf;
   Integer id;
 } Dict(get_autocmds);
 

--- a/test/functional/api/autocmd_spec.lua
+++ b/test/functional/api/autocmd_spec.lua
@@ -25,11 +25,29 @@ describe('autocmd api', function()
         })
       )
       eq(
-        "Conflict: 'pattern' not allowed with 'buffer'",
+        "Conflict: 'pattern' not allowed with 'buf'",
+        pcall_err(api.nvim_create_autocmd, 'FileType', {
+          command = 'let g:called = g:called + 1',
+          buf = 0,
+          pattern = '*.py',
+        })
+      )
+      -- Deprecated `buffer` key still triggers the same conflict.
+      eq(
+        "Conflict: 'pattern' not allowed with 'buf'",
         pcall_err(api.nvim_create_autocmd, 'FileType', {
           command = 'let g:called = g:called + 1',
           buffer = 0,
           pattern = '*.py',
+        })
+      )
+      -- Passing both `buf` and `buffer` is rejected.
+      eq(
+        "Conflict: 'buf' not allowed with 'buffer'",
+        pcall_err(api.nvim_create_autocmd, 'FileType', {
+          command = 'ls',
+          buf = 0,
+          buffer = 1,
         })
       )
       eq(
@@ -143,28 +161,33 @@ describe('autocmd api', function()
       )
     end)
 
-    it('allows passing buffer by key', function()
-      api.nvim_set_var('called', 0)
+    it('allows passing buf by key', function()
+      for _, buf_key in ipairs({
+        'buf',
+        'buffer', -- deprecated name
+      }) do
+        api.nvim_set_var('called', 0)
 
-      api.nvim_create_autocmd('FileType', {
-        command = 'let g:called = g:called + 1',
-        buffer = 0,
-      })
+        api.nvim_create_autocmd('FileType', {
+          command = 'let g:called = g:called + 1',
+          [buf_key] = 0,
+        })
 
-      command 'set filetype=txt'
-      eq(1, api.nvim_get_var('called'))
+        command 'set filetype=txt'
+        eq(1, api.nvim_get_var('called'))
 
-      -- switch to a new buffer
-      command 'new'
-      command 'set filetype=python'
+        -- switch to a new buffer
+        command 'new'
+        command 'set filetype=python'
 
-      eq(1, api.nvim_get_var('called'))
+        eq(1, api.nvim_get_var('called'))
+      end
     end)
 
     it('does not allow passing invalid buffers', function()
       local ok, msg = pcall(api.nvim_create_autocmd, 'FileType', {
         command = 'let g:called = g:called + 1',
-        buffer = -1,
+        buf = -1,
       })
 
       eq(false, ok)
@@ -484,7 +507,22 @@ describe('autocmd api', function()
       eq(
         "Invalid 'buffer': expected Integer or Array, got Boolean",
         pcall_err(api.nvim_get_autocmds, {
+          buf = true,
+        })
+      )
+      -- Deprecated `buffer` key still validated.
+      eq(
+        "Invalid 'buffer': expected Integer or Array, got Boolean",
+        pcall_err(api.nvim_get_autocmds, {
           buffer = true,
+        })
+      )
+      -- Passing both `buf` and `buffer` is rejected.
+      eq(
+        "Conflict: 'buf' not allowed with 'buffer'",
+        pcall_err(api.nvim_get_autocmds, {
+          buf = 0,
+          buffer = 1,
         })
       )
       eq(
@@ -585,7 +623,7 @@ describe('autocmd api', function()
         command [[au InsertEnter <buffer=1> :echo "1"]]
         command [[au InsertEnter <buffer=2> :echo "2"]]
 
-        local aus = api.nvim_get_autocmds { event = 'InsertEnter', buffer = 0 }
+        local aus = api.nvim_get_autocmds { event = 'InsertEnter', buf = 0 }
         eq({
           {
             buffer = 2,
@@ -597,7 +635,7 @@ describe('autocmd api', function()
           },
         }, aus)
 
-        aus = api.nvim_get_autocmds { event = 'InsertEnter', buffer = 1 }
+        aus = api.nvim_get_autocmds { event = 'InsertEnter', buf = 1 }
         eq({
           {
             buffer = 1,
@@ -609,7 +647,7 @@ describe('autocmd api', function()
           },
         }, aus)
 
-        aus = api.nvim_get_autocmds { event = 'InsertEnter', buffer = { 1, 2 } }
+        aus = api.nvim_get_autocmds { event = 'InsertEnter', buf = { 1, 2 } }
         eq({
           {
             buffer = 1,
@@ -628,18 +666,24 @@ describe('autocmd api', function()
             pattern = '<buffer=2>',
           },
         }, aus)
+
+        -- Deprecated `buffer` key still works.
+        eq(
+          api.nvim_get_autocmds { event = 'InsertEnter', buf = { 1, 2 } },
+          api.nvim_get_autocmds { event = 'InsertEnter', buffer = { 1, 2 } }
+        )
 
         eq(
           "Invalid 'buffer': expected Integer or Array, got String",
-          pcall_err(api.nvim_get_autocmds, { event = 'InsertEnter', buffer = 'foo' })
+          pcall_err(api.nvim_get_autocmds, { event = 'InsertEnter', buf = 'foo' })
         )
         eq(
           "Invalid 'buffer': expected Integer, got String",
-          pcall_err(api.nvim_get_autocmds, { event = 'InsertEnter', buffer = { 'foo', 42 } })
+          pcall_err(api.nvim_get_autocmds, { event = 'InsertEnter', buf = { 'foo', 42 } })
         )
         eq(
           'Invalid buffer id: 42',
-          pcall_err(api.nvim_get_autocmds, { event = 'InsertEnter', buffer = { 42 } })
+          pcall_err(api.nvim_get_autocmds, { event = 'InsertEnter', buf = { 42 } })
         )
 
         local bufs = {}
@@ -649,7 +693,7 @@ describe('autocmd api', function()
 
         eq(
           'Too many buffers (maximum of 256)',
-          pcall_err(api.nvim_get_autocmds, { event = 'InsertEnter', buffer = bufs })
+          pcall_err(api.nvim_get_autocmds, { event = 'InsertEnter', buf = bufs })
         )
       end)
 
@@ -1052,9 +1096,24 @@ describe('autocmd api', function()
         })
       )
       eq(
+        "Invalid 'buf': expected Buffer, got Array",
+        pcall_err(api.nvim_exec_autocmds, 'FileType', {
+          buf = {},
+        })
+      )
+      -- Deprecated `buffer` key still validated.
+      eq(
         "Invalid 'buffer': expected Buffer, got Array",
         pcall_err(api.nvim_exec_autocmds, 'FileType', {
           buffer = {},
+        })
+      )
+      -- Passing both `buf` and `buffer` is rejected.
+      eq(
+        "Conflict: 'buf' not allowed with 'buffer'",
+        pcall_err(api.nvim_exec_autocmds, 'FileType', {
+          buf = 0,
+          buffer = 1,
         })
       )
       eq(
@@ -1131,9 +1190,13 @@ describe('autocmd api', function()
       })
 
       -- Doesn't execute for other non-matching events
-      api.nvim_exec_autocmds('CursorHold', { buffer = 1 })
+      api.nvim_exec_autocmds('CursorHold', { buf = 1 })
       eq(-1, api.nvim_get_var('buffer_executed'))
 
+      -- Deprecated `buffer` key still works.
+      api.nvim_exec_autocmds('BufLeave', { buf = 1 })
+      eq(1, api.nvim_get_var('buffer_executed'))
+      api.nvim_set_var('buffer_executed', -1)
       api.nvim_exec_autocmds('BufLeave', { buffer = 1 })
       eq(1, api.nvim_get_var('buffer_executed'))
     end)
@@ -1148,7 +1211,7 @@ describe('autocmd api', function()
       })
 
       -- Doesn't execute for other non-matching events
-      api.nvim_exec_autocmds('CursorHold', { buffer = 1 })
+      api.nvim_exec_autocmds('CursorHold', { buf = 1 })
       eq('none', api.nvim_get_var('filename_executed'))
 
       command('edit __init__.py')
@@ -1157,6 +1220,14 @@ describe('autocmd api', function()
 
     it('cannot pass buf and fname', function()
       local ok = pcall(
+        api.nvim_exec_autocmds,
+        'BufReadPre',
+        { pattern = 'literally_cannot_error.rs', buf = 1 }
+      )
+      eq(false, ok)
+
+      -- Same conflict via deprecated `buffer` key.
+      ok = pcall(
         api.nvim_exec_autocmds,
         'BufReadPre',
         { pattern = 'literally_cannot_error.rs', buffer = 1 }
@@ -1178,10 +1249,10 @@ describe('autocmd api', function()
       })
 
       -- Doesn't execute for other non-matching events
-      api.nvim_exec_autocmds('CursorHoldI', { buffer = 1 })
+      api.nvim_exec_autocmds('CursorHoldI', { buf = 1 })
       eq('none', api.nvim_get_var('filename_executed'))
 
-      api.nvim_exec_autocmds('CursorHoldI', { buffer = api.nvim_get_current_buf() })
+      api.nvim_exec_autocmds('CursorHoldI', { buf = api.nvim_get_current_buf() })
       eq('__init__.py', api.nvim_get_var('filename_executed'))
 
       -- Reset filename
@@ -1600,10 +1671,26 @@ describe('autocmd api', function()
   describe('nvim_clear_autocmds', function()
     it('validation', function()
       eq(
-        "Conflict: 'pattern' not allowed with 'buffer'",
+        "Conflict: 'pattern' not allowed with 'buf'",
+        pcall_err(api.nvim_clear_autocmds, {
+          pattern = '*',
+          buf = 42,
+        })
+      )
+      -- Deprecated `buffer` key still triggers the same conflict.
+      eq(
+        "Conflict: 'pattern' not allowed with 'buf'",
         pcall_err(api.nvim_clear_autocmds, {
           pattern = '*',
           buffer = 42,
+        })
+      )
+      -- Passing both `buf` and `buffer` is rejected.
+      eq(
+        "Conflict: 'buf' not allowed with 'buffer'",
+        pcall_err(api.nvim_clear_autocmds, {
+          buf = 0,
+          buffer = 1,
         })
       )
       eq(
@@ -1691,22 +1778,27 @@ describe('autocmd api', function()
       eq(event_count, #api.nvim_get_autocmds {})
     end)
 
-    it('should allow clearing by buffer', function()
-      command('autocmd! InsertEnter')
-      command('autocmd InsertEnter <buffer> :echo "Enter Buffer"')
-      command('autocmd InsertEnter *.TestPat1 :echo "Enter Pattern"')
+    it('should allow clearing by buf', function()
+      for _, buf_key in ipairs({
+        'buf',
+        'buffer', -- deprecated name
+      }) do
+        command('autocmd! InsertEnter')
+        command('autocmd InsertEnter <buffer> :echo "Enter Buffer"')
+        command('autocmd InsertEnter *.TestPat1 :echo "Enter Pattern"')
 
-      local search = { event = 'InsertEnter' }
-      local before_delete = api.nvim_get_autocmds(search)
-      eq(2, #before_delete)
+        local search = { event = 'InsertEnter' }
+        local before_delete = api.nvim_get_autocmds(search)
+        eq(2, #before_delete)
 
-      api.nvim_clear_autocmds { buffer = 0 }
-      local after_delete = api.nvim_get_autocmds(search)
-      eq(1, #after_delete)
-      eq('*.TestPat1', after_delete[1].pattern)
+        api.nvim_clear_autocmds { [buf_key] = 0 }
+        local after_delete = api.nvim_get_autocmds(search)
+        eq(1, #after_delete)
+        eq('*.TestPat1', after_delete[1].pattern)
+      end
     end)
 
-    it('should allow clearing by buffer and group', function()
+    it('should allow clearing by buf and group', function()
       command('augroup TestNvimClearAutocmds')
       command('  au!')
       command('  autocmd InsertEnter <buffer> :echo "Enter Buffer"')
@@ -1718,12 +1810,12 @@ describe('autocmd api', function()
       eq(2, #before_delete)
 
       -- Doesn't clear without passing group.
-      api.nvim_clear_autocmds { buffer = 0 }
+      api.nvim_clear_autocmds { buf = 0 }
       local without_group = api.nvim_get_autocmds(search)
       eq(2, #without_group)
 
       -- Doesn't clear with passing group.
-      api.nvim_clear_autocmds { buffer = 0, group = search.group }
+      api.nvim_clear_autocmds { buf = 0, group = search.group }
       local with_group = api.nvim_get_autocmds(search)
       eq(1, #with_group)
     end)


### PR DESCRIPTION
Problem:

Described in https://github.com/neovim/neovim/issues/35316, there are some inconsistencies within the lua API.
`:h dev-name-common` states that "buf" should be used instead of "buffer"
but there are cases where buffer is mentioned in the lua API.

Solution:

This commit renames occurrences of "buffer" to "buf" for consistency
with the documentation.