### PR TITLE
fix(tui): do not emit resize screen sequence after host terminal is resized

### DIFF
--- a/src/nvim/tui/input.c
+++ b/src/nvim/tui/input.c
@@ -726,7 +726,6 @@ static void handle_unknown_csi(TermInput *input, const TermKeyKey *key)
         int height_chars = args[1];
         int width_chars = args[2];
         tui_set_size(input->tui_data, width_chars, height_chars);
-        ui_client_set_size(width_chars, height_chars);
       }
     }
     break;


### PR DESCRIPTION
Some terminals support the CSI 8 t sequence to resize their own window area. Neovim will emit this sequence when the TUI is resized programatically, but it should not be emitted when the TUI is resized because the host terminal was resized, as that results in an infinite resize loop.

Fixes: https://github.com/neovim/neovim/issues/35324