### PR TITLE
vim-patch:9.1.{1630,1632}

### DIFF
--- a/src/nvim/fuzzy.c
+++ b/src/nvim/fuzzy.c
@@ -690,7 +690,7 @@ void fuzzymatches_to_strmatches(fuzmatch_str_T *const fuzmatch, char ***const ma
   FUNC_ATTR_NONNULL_ARG(2)
 {
   if (count <= 0) {
-    return;
+    goto theend;
   }
 
   *matches = xmalloc((size_t)count * sizeof(char *));
@@ -705,6 +705,8 @@ void fuzzymatches_to_strmatches(fuzmatch_str_T *const fuzmatch, char ***const ma
   for (int i = 0; i < count; i++) {
     (*matches)[i] = fuzmatch[i].str;
   }
+
+theend:
   xfree(fuzmatch);
 }
 

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -3266,11 +3266,11 @@ func Test_fuzzy_completion_bufname_fullpath()
   edit Xcmd/Xstate/Xfile.js
   cd Xcmd/Xstate
   enew
-  call feedkeys(":b CmdStateFile\<Tab>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"b CmdStateFile', @:)
+  call feedkeys(":b cmdstatefile\<Tab>\<C-B>\"\<CR>", 'tx')
+  call assert_equal('"b cmdstatefile', @:)
   set wildoptions=fuzzy
-  call feedkeys(":b CmdStateFile\<Tab>\<C-B>\"\<CR>", 'tx')
-  call assert_equal('"b CmdStateFile', @:)
+  call feedkeys(":b cmdstatefile\<Tab>\<C-B>\"\<CR>", 'tx')
+  call assert_match('Xcmd/Xstate/Xfile.js$', @:)
   cd -
   set wildoptions&
 endfunc

--- a/test/old/testdir/test_search_stat.vim
+++ b/test/old/testdir/test_search_stat.vim
@@ -493,6 +493,9 @@ endfunc
 func Test_search_stat_option()
   " Asan causes wrong results, because the search times out
   CheckNotAsan
+  " Mark the test as flaky as the search may still occasionally time out
+  let g:test_is_flaky = 1
+
   enew
   set shortmess-=S
   set maxsearchcount=999


### PR DESCRIPTION
#### vim-patch:9.1.1630: tests: fuzzy bufname completion test doesn't match successfully

Problem:  tests: fuzzy buffer name completion test doesn't match
          successfully (after 9.1.1627).
Solution: Update pattern to account for the change in case sensitivity.
          Also mark Test_search_stat_option() as flaky as it can still
          sometimes fail (zeertzjq).

closes: vim/vim#17992

https://github.com/vim/vim/commit/891353671a3bccc21854c12178f8e6623792f115


#### vim-patch:9.1.1632: memory leak in fuzzy.c

Problem:  memory leak in fuzzy.c
Solution: Free fuzmatch, add a few minor refactors
          (glepnir)

fixes neovim CID 584055: fuzmatch leak when count becomes 0
Fix partial allocation failure cleanup in buffer expansion

closes: vim/vim#17996

https://github.com/vim/vim/commit/03d6e06edd0aaf2f591d74349cb25dbeca5895ef

Co-authored-by: glepnir <glephunter@gmail.com>