### PR TITLE
vim-patch:9.1.1633: Search pattern shown incorrectly with negative offset

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -1209,13 +1209,10 @@ int do_search(oparg_T *oap, int dirc, int search_delim, char *pat, size_t patlen
         } else if (!spats[0].off.line) {
           off_buf[off_len++] = 's';
         }
-        if (spats[0].off.off > 0 || spats[0].off.line) {
-          off_buf[off_len++] = '+';
-        }
         off_buf[off_len] = NUL;
         if (spats[0].off.off != 0 || spats[0].off.line) {
           off_len += (size_t)snprintf(off_buf + off_len, sizeof(off_buf) - off_len,
-                                      "%" PRId64, spats[0].off.off);
+                                      "%+" PRId64, spats[0].off.off);
         }
       }
 

--- a/test/old/testdir/test_search.vim
+++ b/test/old/testdir/test_search.vim
@@ -1909,40 +1909,100 @@ func Test_search_offset()
   call assert_equal([1, 7], [line('.'), col('.')])
 
   " with cursor at the beginning of the file, use /s+1
-  call cursor(1, 1)
-  exe "normal /two/s+1\<CR>"
-  call assert_equal([1, 6], [line('.'), col('.')])
+  " '+' without a digit is the same as +1, and 'b' is an alias for 's'
+  for searchcmd in ['/two/s+1', '/two/s+', '/two/b+1', '/two/b+', '/']
+    call cursor(1, 1)
+    exe $"normal {searchcmd}\<CR>"
+    call assert_equal([1, 6], [line('.'), col('.')], searchcmd)
+    call assert_equal('/two/s+1', Screenline(&lines)->trim(), searchcmd)
+  endfor
+
+  " repeat the same search pattern with different offsets
+  for [offset, col] in [['s', 5], ['e-1', 6], ['s+2', 7], ['s-2', 3], ['', 5]]
+    let searchcmd = $'//{offset}'
+    call cursor(1, 1)
+    exe $"normal {searchcmd}\<CR>"
+    call assert_equal([1, col], [line('.'), col('.')], searchcmd)
+    call assert_equal(col == 5 ? '/two' : $'/two/{offset}',
+                      \ Screenline(&lines)->trim(), searchcmd)
+  endfor
 
   " with cursor at the end of the file, use /e-1
-  call cursor(2, 10)
-  exe "normal ?three?e-1\<CR>"
-  call assert_equal([2, 4], [line('.'), col('.')])
+  " '-' without a digit is the same as -1
+  for searchcmd in ['?three?e-1', '?three?e-', '?']
+    call cursor(2, 10)
+    exe $"normal {searchcmd}\<CR>"
+    call assert_equal([2, 4], [line('.'), col('.')], searchcmd)
+    call assert_equal('?three?e-1', Screenline(&lines)->trim(), searchcmd)
+  endfor
+
+  " repeat the same search pattern with different offsets
+  for [offset, col] in [['e', 5], ['s+1', 2], ['e-2', 3], ['e+2', 7], ['', 1]]
+    let searchcmd = $'??{offset}'
+    call cursor(2, 10)
+    exe $"normal {searchcmd}\<CR>"
+    call assert_equal([2, col], [line('.'), col('.')], searchcmd)
+    call assert_equal(col == 1 ? '?three' : $'?three?{offset}',
+                      \ Screenline(&lines)->trim(), searchcmd)
+  endfor
 
   " line offset - after the last line
-  call cursor(1, 1)
-  exe "normal /three/+1\<CR>"
-  call assert_equal([2, 1], [line('.'), col('.')])
+  " '+' without a digit and '1' without a sign are the same as +1
+  for searchcmd in ['/three/+1', '/three/+', '/three/1', '/']
+    call cursor(1, 1)
+    exe $"normal {searchcmd}\<CR>"
+    call assert_equal([2, 1], [line('.'), col('.')], searchcmd)
+    call assert_equal('/three/+1', Screenline(&lines)->trim(), searchcmd)
+  endfor
+
+  " repeat the same search pattern with different line offsets
+  for [offset, lnum] in [['+0', 2], ['-1', 1], ['+2', 2], ['-2', 1]]
+    let searchcmd = $'//{offset}'
+    call cursor(1, 1)
+    exe $"normal {searchcmd}\<CR>"
+    call assert_equal([lnum, 1], [line('.'), col('.')], searchcmd)
+    call assert_equal($'/three/{offset}',
+                      \ Screenline(&lines)->trim(), searchcmd)
+  endfor
 
   " line offset - before the first line
-  call cursor(2, 1)
-  exe "normal ?one?-1\<CR>"
-  call assert_equal([1, 1], [line('.'), col('.')])
+  " '-' without a digit is the same as -1
+  for searchcmd in ['?one?-1', '?one?-', '?']
+    call cursor(2, 1)
+    exe $"normal {searchcmd}\<CR>"
+    call assert_equal([1, 1], [line('.'), col('.')], searchcmd)
+    call assert_equal('?one?-1', Screenline(&lines)->trim(), searchcmd)
+  endfor
+
+  " repeat the same search pattern with different line offsets
+  for [offset, lnum] in [['+0', 1], ['+1', 2], ['-2', 1], ['+2', 2]]
+    let searchcmd = $'??{offset}'
+    call cursor(2, 1)
+    exe $"normal {searchcmd}\<CR>"
+    call assert_equal([lnum, 1], [line('.'), col('.')], searchcmd)
+    call assert_equal($'?one?{offset}',
+                      \ Screenline(&lines)->trim(), searchcmd)
+  endfor
 
   " character offset - before the first character in the file
   call cursor(2, 1)
   exe "normal ?one?s-1\<CR>"
   call assert_equal([1, 1], [line('.'), col('.')])
+  call assert_equal('?one?s-1', Screenline(&lines)->trim())
   call cursor(2, 1)
   exe "normal ?one?e-3\<CR>"
   call assert_equal([1, 1], [line('.'), col('.')])
+  call assert_equal('?one?e-3', Screenline(&lines)->trim())
 
   " character offset - after the last character in the file
   call cursor(1, 1)
   exe "normal /four/s+4\<CR>"
   call assert_equal([2, 10], [line('.'), col('.')])
+  call assert_equal('/four/s+4', Screenline(&lines)->trim())
   call cursor(1, 1)
   exe "normal /four/e+1\<CR>"
   call assert_equal([2, 10], [line('.'), col('.')])
+  call assert_equal('/four/e+1', Screenline(&lines)->trim())
 
   bw!
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.1633: Search pattern shown incorrectly with negative offset

Problem:  Search pattern shown incorrectly with negative offset.
          (lkintact)
Solution: Don't prepend a '+' sign to a negative offset (zeertzjq).

closes: vim/vim#17994

https://github.com/vim/vim/commit/ade0815856854f4b2e01345d9a9c6ade55b9b8de
