### PR TITLE
fix(filetype): fix and improve BitBake .inc detection

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -858,7 +858,7 @@ function M.inc(path, bufnr)
       -- headers so assume POV-Ray
     elseif findany(line, { '^%s{', '^%s%(%*' }) or matchregex(line, pascal_keywords) then
       return 'pascal'
-    elseif findany(line, { '^%s*inherit ', '^%s*require ', '^%s*%u[%w_:${}]*%s+%??[?:+]?= ' }) then
+    elseif findany(line, { '^%s*inherit ', '^%s*require ', '^%s*%u[%w_:${}/]*%s*%??[?:+.]?=%.? ' }) then
       return 'bitbake'
     end
   end

--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -847,27 +847,28 @@ function M.inc(path, bufnr)
   if vim.g.filetype_inc then
     return vim.g.filetype_inc
   end
-  local lines = table.concat(getlines(bufnr, 1, 3))
-  if lines:lower():find('perlscript') then
-    return 'aspperl'
-  elseif lines:find('<%%') then
-    return 'aspvbs'
-  elseif lines:find('<%?') then
-    return 'php'
-    -- Pascal supports // comments but they're vary rarely used for file
-    -- headers so assume POV-Ray
-  elseif findany(lines, { '^%s{', '^%s%(%*' }) or matchregex(lines, pascal_keywords) then
-    return 'pascal'
-  elseif findany(lines, { '^%s*inherit ', '^%s*require ', '^%s*%u[%w_:${}]*%s+%??[?:+]?= ' }) then
-    return 'bitbake'
-  else
-    local syntax = M.asm_syntax(path, bufnr)
-    if not syntax or syntax == '' then
-      return 'pov'
+  for _, line in ipairs(getlines(bufnr, 1, 10)) do
+    if line:lower():find('perlscript') then
+      return 'aspperl'
+    elseif line:find('<%%') then
+      return 'aspvbs'
+    elseif line:find('<%?') then
+      return 'php'
+      -- Pascal supports // comments but they're vary rarely used for file
+      -- headers so assume POV-Ray
+    elseif findany(line, { '^%s{', '^%s%(%*' }) or matchregex(line, pascal_keywords) then
+      return 'pascal'
+    elseif findany(line, { '^%s*inherit ', '^%s*require ', '^%s*%u[%w_:${}]*%s+%??[?:+]?= ' }) then
+      return 'bitbake'
     end
-    return syntax, function(b)
-      vim.b[b].asmsyntax = syntax
-    end
+  end
+
+  local syntax = M.asm_syntax(path, bufnr)
+  if not syntax or syntax == '' then
+    return 'pov'
+  end
+  return syntax, function(b)
+    vim.b[b].asmsyntax = syntax
   end
 end
 

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -2591,6 +2591,21 @@ func Test_inc_file()
   call assert_equal('bitbake', &filetype)
   bwipe!
 
+  call writefile(['PREFERRED_PROVIDER_virtual/kernel = "somekernel"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
+  call writefile(['MACHINEOVERRIDES =. "qemuall:"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
+  call writefile(['BBPATH .= ":${LAYERDIR}"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
   " asm
   call writefile(['asmsyntax=foo'], 'Xfile.inc')
   split Xfile.inc


### PR DESCRIPTION
Fix the detection of .inc files containing Pascal and BitBake code. The concatenated string, merged from multiple lines, only contains one beginning and the pattern `^` would not match as expected. Use an `ipairs()` loop to iterate each string individually coming from `getlines()`. This way, the pattern `^` works for beginning of lines.

Additionally, parse ten instead of just three lines, to accommodate for potential comments at the beginning of files.

Improve BitBake include file detection by also matching forward-slashes `/` in variable names and assignment operators with a dot `.=` and `=.`. Valid examples, which should match, are:
```bitbake
PREFERRED_PROVIDER_virtual/kernel = "linux-yocto"
MACHINEOVERRIDES =. "qemuall:"
BBPATH .= ":${LAYERDIR}"
```

The same BitBake include files are correctly detected in regular Vim, but were not so far in NeoVim.