### PR TITLE
fix(defaults)!: make initial values of path option use "/" on Windows

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -101,6 +101,8 @@ LUA
 OPTIONS
 
 • 'shelltemp' defaults to "false".
+• 'runtimepath', 'packpath', 'cdpath', and 'path' now have initial values
+  use "/" separator on Windows.
 
 PLUGINS
 

--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -984,4 +984,15 @@ do
     vim.o.grepprg = 'rg --vimgrep -uu '
     vim.o.grepformat = '%f:%l:%c:%m'
   end
+
+  --- Normalize options that contain paths
+  if vim.fn.has('win32') == 1 then
+    local function normalize_path_option(name)
+      vim.o[name] = vim.o[name]:gsub('\\([^,])', '/%1'):gsub('\\$', '/') --- @type string
+    end
+    normalize_path_option('runtimepath')
+    normalize_path_option('packpath')
+    normalize_path_option('cdpath')
+    normalize_path_option('path')
+  end
 end


### PR DESCRIPTION
Problem: Initial values of options with list of directory paths use a mix of "\" and "/" path separators on Windows.

Solution: Normalize during startup.

---

As suggested in [this comment](https://github.com/neovim/neovim/pull/35220#issuecomment-3180994163).

I do have a feeling that this will break not insignificant amount of plugins (especially old non-supported Vimscript ones).
