### PR TITLE
fix: vim.lsp.omnifunc should not throw away other items

### DIFF
--- a/runtime/lua/vim/lsp/completion.lua
+++ b/runtime/lua/vim/lsp/completion.lua
@@ -503,7 +503,7 @@ local function trigger(bufnr, clients, ctx)
       return
     end
 
-    local matches = {}
+    local matches --[[@type table]] = vim.fn.complete_info({ 'items' })['items']
     local server_start_boundary --- @type integer?
     for client_id, response in pairs(responses) do
       local client = lsp.get_client_by_id(client_id)


### PR DESCRIPTION
This is a workaround to fix #35257 while https://github.com/vim/vim/pull/16662 is not resolved. It finally allows lsp completion to be combined with other sources.

Something like this can also be used to fix issue #32428, but that is somewhat more involved because we need to be smarter about tracking `isIncomplete` and filter/deduplicate items.