### PR TITLE
Fix netrw failing to copy directories

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -6647,7 +6647,7 @@ fun! s:NetrwMarkFileCopy(islocal,...)
     "   call Decho("tgt    <".tgt.">",'~'.expand("<slnum>"))
     if isdirectory(s:NetrwFile(args))
       "    call Decho("args<".args."> is a directory",'~'.expand("<slnum>"))
-      let copycmd= g:netrw_localcopydircmd
+      let copycmd= g:netrw_localcopydircmd . g:netrw_localcopydircmdopt
       "    call Decho("using copydircmd<".copycmd.">",'~'.expand("<slnum>"))
       if !g:netrw_cygwin && has("win32")
         " window's xcopy doesn't copy a directory to a target properly.  Instead, it copies a directory's


### PR DESCRIPTION
This was caused by `g:netrw_localcopydircmdopt` not being respected in netrw.vim. This was a random bug I ran into when I was trying to learn netrw.

Adding the approprite command options fixes this issue.

Might I suggest that we also set `g:netrw_keepdir = 0`? The copy also fails unless that is set. I don't fully understand the implications, but I don't think anyone is worrying about vim 6 backwards compatability. I could also add that in this MR to keep netRW crawling around until it gets replaced. 

Resolves https://github.com/neovim/neovim/issues/35347
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
