### PR TITLE
vim-patch:8.1.2008,v8.2.{844,853,3348,3795,4379}

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -157,12 +157,12 @@ static int read_buffer(bool read_stdin, exarg_T *eap, int flags)
   if (retval == OK) {
     // Delete the binary lines.
     while (--line_count >= 0) {
-      ml_delete(1, false);
+      ml_delete(1);
     }
   } else {
     // Delete the converted lines.
     while (curbuf->b_ml.ml_line_count > line_count) {
-      ml_delete(line_count, false);
+      ml_delete(line_count);
     }
   }
   // Put the cursor on the first line.
@@ -758,7 +758,7 @@ void buf_clear(void)
   linenr_T line_count = curbuf->b_ml.ml_line_count;
   extmark_free_all(curbuf);   // delete any extmarks
   while (!(curbuf->b_ml.ml_flags & ML_EMPTY)) {
-    ml_delete(1, false);
+    ml_delete(1);
   }
   deleted_lines_mark(1, line_count);  // prepare for display
 }

--- a/src/nvim/change.c
+++ b/src/nvim/change.c
@@ -1890,7 +1890,7 @@ void del_lines(linenr_T nlines, bool undo)
       break;
     }
 
-    ml_delete(first, true);
+    ml_delete_flags(first, ML_DEL_MESSAGE);
     n++;
 
     // If we delete the last line in the file, stop

--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -3814,7 +3814,7 @@ static void diffgetput(const int addr_count, const int idx_cur, const int idx_fr
       for (int i = 0; i < count; i++) {
         // remember deleting the last line of the buffer
         buf_empty = curbuf->b_ml.ml_line_count == 1;
-        if (ml_delete(lnum, false) == OK) {
+        if (ml_delete(lnum) == OK) {
           added--;
         }
       }
@@ -3835,7 +3835,7 @@ static void diffgetput(const int addr_count, const int idx_cur, const int idx_fr
           // which results in inaccurate reporting of the byte count of
           // previous contents in buffer-update events.
           buf_empty = false;
-          ml_delete(2, false);
+          ml_delete(2);
         }
       }
       linenr_T new_count = dp->df_count[idx_to] + added;

--- a/src/nvim/eval/buffer.c
+++ b/src/nvim/eval/buffer.c
@@ -453,7 +453,7 @@ void f_deletebufline(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
   }
 
   for (linenr_T lnum = first; lnum <= last; lnum++) {
-    ml_delete(first, true);
+    ml_delete_flags(first, ML_DEL_MESSAGE);
   }
 
   FOR_ALL_TAB_WINDOWS(tp, wp) {

--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -656,7 +656,7 @@ void ex_sort(exarg_T *eap)
   // delete the original lines if appending worked
   if (i == count) {
     for (i = 0; i < count; i++) {
-      ml_delete(eap->line1, false);
+      ml_delete(eap->line1);
     }
   } else {
     count = 0;
@@ -855,7 +855,7 @@ void ex_uniq(exarg_T *eap)
     }
 
     if (delete_lnum > 0) {
-      ml_delete(delete_lnum, false);
+      ml_delete(delete_lnum);
       i -= get_lnum - delete_lnum + 1;
       count--;
       deleted++;
@@ -999,7 +999,7 @@ int do_move(linenr_T line1, linenr_T line2, linenr_T dest)
   }
 
   for (l = line1; l <= line2; l++) {
-    ml_delete(line1 + extra, true);
+    ml_delete_flags(line1 + extra, ML_DEL_MESSAGE);
   }
   if (!global_busy && num_lines > p_report) {
     smsg(0, NGETTEXT("%" PRId64 " line moved",
@@ -3075,7 +3075,7 @@ void ex_append(exarg_T *eap)
     lnum++;
 
     if (empty) {
-      ml_delete(2, false);
+      ml_delete(2);
       empty = false;
     }
   }
@@ -3126,7 +3126,7 @@ void ex_change(exarg_T *eap)
     if (curbuf->b_ml.ml_flags & ML_EMPTY) {         // nothing to delete
       break;
     }
-    ml_delete(eap->line1, false);
+    ml_delete(eap->line1);
   }
 
   // make sure the cursor is not beyond the end of the file now
@@ -4316,7 +4316,7 @@ skip:
                 break;
               }
               for (i = 0; i < nmatch_tl; i++) {
-                ml_delete(lnum, false);
+                ml_delete(lnum);
               }
               mark_adjust(lnum, lnum + nmatch_tl - 1, MAXLNUM, -nmatch_tl, kExtmarkNOOP);
               if (subflags.do_ask) {

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -6023,7 +6023,7 @@ static void ex_read(exarg_T *eap)
         lnum = 1;
       }
       if (*ml_get(lnum) == NUL && u_savedel(lnum, 1) == OK) {
-        ml_delete(lnum, false);
+        ml_delete(lnum);
         if (curwin->w_cursor.lnum > 1
             && curwin->w_cursor.lnum >= lnum) {
           curwin->w_cursor.lnum--;

--- a/src/nvim/fileio.c
+++ b/src/nvim/fileio.c
@@ -732,7 +732,7 @@ retry:
     }
     // Delete the previously read lines.
     while (lnum > from) {
-      ml_delete(lnum--, false);
+      ml_delete(lnum--);
     }
     file_rewind = false;
     if (set_options) {
@@ -1659,7 +1659,7 @@ failed:
   if (!recoverymode) {
     // need to delete the last line, which comes from the empty buffer
     if (newfile && wasempty && !(curbuf->b_ml.ml_flags & ML_EMPTY)) {
-      ml_delete(curbuf->b_ml.ml_line_count, false);
+      ml_delete(curbuf->b_ml.ml_line_count);
       linecnt--;
     }
     curbuf->deleted_bytes = 0;
@@ -2821,7 +2821,7 @@ static int move_lines(buf_T *frombuf, buf_T *tobuf)
   if (retval != FAIL) {
     curbuf = frombuf;
     for (linenr_T lnum = curbuf->b_ml.ml_line_count; lnum > 0; lnum--) {
-      if (ml_delete(lnum, false) == FAIL) {
+      if (ml_delete(lnum) == FAIL) {
         // Oops!  We could try putting back the saved lines, but that
         // might fail again...
         retval = FAIL;
@@ -3137,7 +3137,7 @@ void buf_reload(buf_T *buf, int orig_mode, bool reload_options)
         // Put the text back from the save buffer.  First
         // delete any lines that readfile() added.
         while (!buf_is_empty(curbuf)) {
-          if (ml_delete(buf->b_ml.ml_line_count, false) == FAIL) {
+          if (ml_delete(buf->b_ml.ml_line_count) == FAIL) {
             break;
           }
         }

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -4902,7 +4902,7 @@ void ins_compl_delete(bool new_leader)
     }
 
     while (curwin->w_cursor.lnum > compl_lnum) {
-      if (ml_delete(curwin->w_cursor.lnum, false) == FAIL) {
+      if (ml_delete(curwin->w_cursor.lnum) == FAIL) {
         if (remaining.data) {
           xfree(remaining.data);
         }

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -2870,7 +2870,9 @@ static void ml_flush_line(buf_T *buf, bool noalloc)
         memmove(old_line - extra, new_line, (size_t)new_len);
         buf->b_ml.ml_flags |= (ML_LOCKED_DIRTY | ML_LOCKED_POS);
         // The else case is already covered by the insert and delete
-        ml_updatechunk(buf, lnum, extra, ML_CHNK_UPDLINE);
+        if (extra != 0) {
+          ml_updatechunk(buf, lnum, extra, ML_CHNK_UPDLINE);
+        }
       } else {
         // Cannot do it in one data block: Delete and append.
         // Append first, because ml_delete_int() cannot delete the
@@ -4003,7 +4005,7 @@ int ml_find_line_or_offset(buf_T *buf, linenr_T lnum, int *offp, bool no_ff)
     return 1;       // Not a "find offset" and offset 0 _must_ be in line 1
   }
   // Find the last chunk before the one containing our line. Last chunk is
-  // special because it will never qualify
+  // special because it will never qualify.
   linenr_T curline = 1;
   int curix = 0;
   int size = 0;

--- a/src/nvim/memline.c
+++ b/src/nvim/memline.c
@@ -959,7 +959,7 @@ void ml_recover(bool checkext)
   // Now that we are sure that the file is going to be recovered, clear the
   // contents of the current buffer.
   while (!(curbuf->b_ml.ml_flags & ML_EMPTY)) {
-    ml_delete(1, false);
+    ml_delete(1);
   }
 
   // Try reading the original file to obtain the values of 'fileformat',
@@ -1183,7 +1183,7 @@ void ml_recover(bool checkext)
   // empty buffer.  These will now be after the last line in the buffer.
   while (curbuf->b_ml.ml_line_count > lnum
          && !(curbuf->b_ml.ml_flags & ML_EMPTY)) {
-    ml_delete(curbuf->b_ml.ml_line_count, false);
+    ml_delete(curbuf->b_ml.ml_line_count);
   }
   curbuf->b_flags |= BF_RECOVERED;
   check_cursor(curwin);
@@ -2689,12 +2689,10 @@ static int ml_delete_int(buf_T *buf, linenr_T lnum, int flags)
 /// @note The caller of this function should probably also call
 /// deleted_lines() after this.
 ///
-/// @param message  true may give a "No lines in buffer" message.
-///
 /// @return  FAIL for failure, OK otherwise
-int ml_delete(linenr_T lnum, bool message)
+int ml_delete(linenr_T lnum)
 {
-  return ml_delete_flags(lnum, message ? ML_DEL_MESSAGE : 0);
+  return ml_delete_flags(lnum, 0);
 }
 
 /// Like ml_delete() but using flags (see ml_delete_int()).

--- a/src/nvim/memline.h
+++ b/src/nvim/memline.h
@@ -10,3 +10,16 @@
 
 /// LINEEMPTY() - return true if the line is empty
 #define LINEEMPTY(p) (*ml_get(p) == NUL)
+
+// Values for the flags argument of ml_delete_flags().
+enum {
+  ML_DEL_MESSAGE = 1,  // may give a "No lines in buffer" message
+  // ML_DEL_UNDO = 2,  // called from undo
+};
+
+// Values for the flags argument of ml_append_int().
+enum {
+  ML_APPEND_NEW = 1,   // starting to edit a new file
+  ML_APPEND_MARK = 2,  // mark the new line
+  // ML_APPEND_UNDO = 4,  // called from undo
+};

--- a/src/nvim/normal.c
+++ b/src/nvim/normal.c
@@ -6589,7 +6589,7 @@ static void nv_put_opt(cmdarg_T *cap, bool fix_indent)
   // When all lines were selected and deleted do_put() leaves an empty
   // line that needs to be deleted now.
   if (empty && *ml_get(curbuf->b_ml.ml_line_count) == NUL) {
-    ml_delete(curbuf->b_ml.ml_line_count, true);
+    ml_delete_flags(curbuf->b_ml.ml_line_count, ML_DEL_MESSAGE);
     deleted_lines(curbuf->b_ml.ml_line_count + 1, 1);
 
     // If the cursor was in that line, move it to the end of the last

--- a/src/nvim/quickfix.c
+++ b/src/nvim/quickfix.c
@@ -4359,7 +4359,7 @@ static void qf_fill_buffer(qf_list_T *qfl, buf_T *buf, qfline_T *old_last, int q
     while ((curbuf->b_ml.ml_flags & ML_EMPTY) == 0) {
       // If deletion fails, this loop may run forever, so
       // signal error and return.
-      if (ml_delete(1, false) == FAIL) {
+      if (ml_delete(1) == FAIL) {
         internal_error("qf_fill_buffer()");
         return;
       }
@@ -4429,7 +4429,7 @@ static void qf_fill_buffer(qf_list_T *qfl, buf_T *buf, qfline_T *old_last, int q
     }
     if (old_last == NULL) {
       // Delete the empty line which is now at the end
-      ml_delete(lnum + 1, false);
+      ml_delete(lnum + 1);
     }
 
     qfga_clear();

--- a/src/nvim/spell.c
+++ b/src/nvim/spell.c
@@ -3232,7 +3232,7 @@ void ex_spelldump(exarg_T *eap)
 
   // Delete the empty line that we started with.
   if (curbuf->b_ml.ml_line_count > 1) {
-    ml_delete(curbuf->b_ml.ml_line_count, false);
+    ml_delete(curbuf->b_ml.ml_line_count);
   }
   redraw_later(curwin, UPD_NOT_VALID);
 }

--- a/src/nvim/terminal.c
+++ b/src/nvim/terminal.c
@@ -2133,7 +2133,7 @@ static void adjust_scrollback(Terminal *term, buf_T *buf)
   if (scbk < term->sb_current) {
     size_t diff = term->sb_current - scbk;
     for (size_t i = 0; i < diff; i++) {
-      ml_delete(1, false);
+      ml_delete(1);
       term->sb_current--;
       xfree(term->sb_buffer[term->sb_current]);
     }

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2378,12 +2378,14 @@ static void u_undoredo(bool undo, bool do_buf_event)
       }
     }
 
-    changed_lines(curbuf, top + 1, 0, bot, newsize - oldsize, do_buf_event);
-    // When text has been changed, possibly the start of the next line
-    // may have SpellCap that should be removed or it needs to be
-    // displayed.  Schedule the next line for redrawing just in case.
-    if (spell_check_window(curwin) && bot <= curbuf->b_ml.ml_line_count) {
-      redrawWinline(curwin, bot);
+    if (oldsize > 0 || newsize > 0) {
+      changed_lines(curbuf, top + 1, 0, bot, newsize - oldsize, do_buf_event);
+      // When text has been changed, possibly the start of the next line
+      // may have SpellCap that should be removed or it needs to be
+      // displayed.  Schedule the next line for redrawing just in case.
+      if (spell_check_window(curwin) && bot <= curbuf->b_ml.ml_line_count) {
+        redrawWinline(curwin, bot);
+      }
     }
 
     // Set the '[ mark.

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -2341,7 +2341,7 @@ static void u_undoredo(bool undo, bool do_buf_event)
         if (curbuf->b_ml.ml_line_count == 1) {
           empty_buffer = true;
         }
-        ml_delete(lnum, false);
+        ml_delete(lnum);  // ML_DEL_UNDO
       }
     } else {
       newarray = NULL;
@@ -2360,7 +2360,7 @@ static void u_undoredo(bool undo, bool do_buf_event)
         if (empty_buffer && lnum == 0) {
           ml_replace(1, uep->ue_array[i], true);
         } else {
-          ml_append(lnum, uep->ue_array[i], 0, false);
+          ml_append_flags(lnum, uep->ue_array[i], 0, 0);  // ML_APPEND_UNDO
         }
         xfree(uep->ue_array[i]);
       }

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -248,7 +248,7 @@ int u_save_cursor(void)
 }
 
 /// Save the lines between "top" and "bot" for both the "u" and "U" command.
-/// "top" may be 0 and bot may be curbuf->b_ml.ml_line_count + 1.
+/// "top" may be 0 and "bot" may be curbuf->b_ml.ml_line_count + 1.
 /// Careful: may trigger autocommands that reload the buffer.
 /// Returns FAIL when lines could not be saved, OK otherwise.
 int u_save(linenr_T top, linenr_T bot)

--- a/test/old/testdir/test_jumplist.vim
+++ b/test/old/testdir/test_jumplist.vim
@@ -2,10 +2,6 @@
 
 " Tests for the getjumplist() function
 func Test_getjumplist()
-  if !has("jumplist")
-    return
-  endif
-
   %bwipe
   clearjumps
   call assert_equal([[], 0], getjumplist())


### PR DESCRIPTION
Problem:    Error for invalid range when using listener and undo. (Paul Jolly)
Solution:   Do not change the cursor before the lines are restored.
            (closes vim/vim#4908)

https://github.com/vim/vim/commit/4544bd2f247425c9dd743c76618dd70f53c72538

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

v8.2.0845 could be later until I figure out why exactly tests are failing.