### PR TITLE
feat(pack): add arbitrary user-defined `data` field to plugin spec

### DIFF
--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -309,6 +309,7 @@ Each event populates the following |event-data| fields:
                     • String to use specific branch, tag, or commit hash.
                     • Output of |vim.version.range()| to install the
                       greatest/last semver tag inside the version constraint.
+      • {data}?     (`any`) Arbitrary data associated with a plugin.
 
 
 add({specs}, {opts})                                          *vim.pack.add()*

--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -234,8 +234,10 @@ end
 --- - Output of |vim.version.range()| to install the greatest/last semver tag
 ---   inside the version constraint.
 --- @field version? string|vim.VersionRange
+---
+--- @field data? any Arbitrary data associated with a plugin.
 
---- @alias vim.pack.SpecResolved { src: string, name: string, version: nil|string|vim.VersionRange }
+--- @alias vim.pack.SpecResolved { src: string, name: string, version: nil|string|vim.VersionRange, data: any|nil }
 
 --- @param spec string|vim.pack.Spec
 --- @return vim.pack.SpecResolved
@@ -247,7 +249,7 @@ local function normalize_spec(spec)
   name = (type(name) == 'string' and name or ''):match('[^/]+$') or ''
   vim.validate('spec.name', name, is_nonempty_string, true, 'non-empty string')
   vim.validate('spec.version', spec.version, is_version, true, 'string or vim.VersionRange')
-  return { src = spec.src, name = name, version = spec.version }
+  return { src = spec.src, name = name, version = spec.version, data = spec.data }
 end
 
 --- @class (private) vim.pack.PlugInfo

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -311,6 +311,34 @@ describe('vim.pack', function()
       eq(exec_lua('return #_G.event_log'), 0)
     end)
 
+    it('passes data field through to opts.load', function()
+      eq(
+        2,
+        exec_lua(function()
+          local successes = 0
+          vim.pack.add({
+            { name = 'tabletest', src = repos_src.basic, data = { test = 'value' } },
+            { name = 'stringtest', src = repos_src.basic, data = 'value' },
+          }, {
+            confirm = false,
+            load = function(p)
+              if p.spec.name == 'tabletest' then
+                if p.spec.data.test == 'value' then
+                  successes = successes + 1
+                end
+              end
+              if p.spec.name == 'stringtest' then
+                if p.spec.data == 'value' then
+                  successes = successes + 1
+                end
+              end
+            end,
+          })
+          return successes
+        end)
+      )
+    end)
+
     it('asks for installation confirmation', function()
       exec_lua(function()
         ---@diagnostic disable-next-line: duplicate-set-field
@@ -1177,6 +1205,23 @@ describe('vim.pack', function()
         { active = true, path = basic_path, spec = basic_spec },
         { active = false, path = defbranch_path, spec = defbranch_spec },
       }, exec_lua('return vim.pack.get()'))
+    end)
+
+    it('respects data field', function()
+      eq(
+        true,
+        exec_lua(function()
+          vim.pack.add {
+            { src = repos_src.basic, data = { test = 'value' } },
+          }
+          for _, p in ipairs(vim.pack.get()) do
+            if p.spec.name == 'basic' and p.spec.data.test == 'value' then
+              return true
+            end
+          end
+          return false
+        end)
+      )
     end)
 
     it('works with `del()`', function()


### PR DESCRIPTION
Hey! Question: can we make it so that the spec passed to the load function can have extra values placed into it?

If I put extra values in my spec, they are not being provided to the load function as it is currently and that in my opinion would further increase flexibility for very little cost?

This would solve most requests for more values in the spec beyond URL schema, build steps, or luarocks stuff (which is taken care of before the load function is called) but everything else people seem to be asking for is load related.

for example, it would be nice to be able to include our own little flag for our load function to identify what is loaded when. Simplest example would be something like this

```lua
  vim.pack.add({
      "https://github.com/BirdeeHub/lze",
      { src = "https://github.com/Wansmer/treesj", opt = true },
  }, {
    load = function(p)
      print(vim.inspect(p)) -- print for demonstration purposes to show what we are recieving, output shown below
      if not p.spec.opt then -- currently this opt flag would not be included in spec
        vim.cmd.packadd(p.spec.name)
      end
    end,
    confirm = true,
  })
```
  the above print will currently result in the following, with the opt not included (also I edited the path output and added a comment)
```lua
{
  path = "$XDG_DATA_HOME/nvim/site/pack/core/opt/lze",
  spec = {
    name = "lze",
    src = "https://github.com/BirdeeHub/lze"
  }
}
{
  path = "$XDG_DATA_HOME/nvim/site/pack/core/opt/treesj",
  spec = {
    name = "treesj",
    src = "https://github.com/Wansmer/treesj"
    -- opt = true -- isn't here?
  }
}
```
  
  But obviously you could do a lot more than just that. You could make it so that the load function provides the spec straight to the lze.load function for example and use the full spec in the same list you provide your download specs in, or any number of other things to that effect.
  
Currently I have been managing my lazy loading with lze, which you could use like this

```lua  
  vim.pack.add({
    "https://github.com/BirdeeHub/lze", -- https://github.com/nvim-neorocks/lz.n also works for this purpose
    "https://github.com/Wansmer/treesj",
    { src = "https://github.com/nvim-telescope/telescope.nvim" },
    { src = "https://github.com/NTBBloodBatch/sweetie.nvim", name = "sweetie" }
}, {
  -- prevent packadd! or packadd like this to allow on_require handler to load plugin spec (if you desire to use that handler, otherwise false is fine and you can remove the packadd for lze below)
  load = function() end,
  -- choose your preference for install confirmation
  confirm = true,
})
vim.cmd.packadd("lze")

require("lze").load {
    {
        "telescope.nvim",
        cmd = "Telescope",
        on_require = { "telescope" },
    },
    {
        "sweetie", -- note the name change above
        colorscheme = "sweetie",
    },
    {
        "treesj",
        cmd = { "TSJToggle" },
        keys = { { "<leader>Tt", ":TSJToggle<CR>", mode = { "n" }, desc = "treesj split/join" }, },
        after = function(spec)
            require("treesj").setup({})
        end,
    }
}
```

but with just that 1 change, you would be able to move all of the lze spec into the spec for the vim.pack.add specs. and just pass the specs straight to lze.load in the load function for vim.pack.add

```lua
vim.pack.add({ "https://github.com/BirdeeHub/lze" }, { confirm = false --[[or true idk]] })
vim.pack.add({
  {
    src = "https://github.com/nvim-telescope/telescope.nvim",
    cmd = "Telescope",
    on_require = { "telescope" },
  },
  {
    src = "https://github.com/Wansmer/treesj"
    cmd = { "TSJToggle" },
    keys = { { "<leader>Tt", ":TSJToggle<CR>", mode = { "n" }, desc = "treesj split/join" }, },
    after = function(spec)
      require('treesj').setup({})
    end,
  },
  {
    src = "https://github.com/NTBBloodBatch/sweetie.nvim",
    colorscheme = "sweetie",
  }
}, {
  load = function(p)
    require('lze').load(p.spec)
  end,
  -- choose your preference for install confirmation
  confirm = true,
})
```

TL;DR

If all values in the spec were passed on to the load function, it would solve people's issues with managing lazy loading while using vim.pack.add for very little maintenance effort.

It would not solve build steps, but I think that was to be handled via some sort of rockspec mechanism? But that would be a separate problem, not hindered by this change.

(this message is a repeat of [this comment](https://github.com/neovim/neovim/pull/35270#issuecomment-3193972166) on the last pr for vim.pack.add related to load functions)