### PR TITLE
vim-patch:3cee950: runtime(diff): fix mixed translations in zh_CN

### DIFF
--- a/runtime/syntax/diff.vim
+++ b/runtime/syntax/diff.vim
@@ -2,7 +2,7 @@
 " Language:	Diff (context or unified)
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
 "		Translations by Jakson Alves de Aquino.
-" Last Change:	2025 Jun 26
+" Last Change:	2025 Aug 16
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " Quit when a (custom) syntax file was already loaded
@@ -312,9 +312,9 @@ syn match diffCommon	"^Thư mục con chung: .* và .*"
 
 " zh_CN
 syn match diffOnly	"^只在 .* 存在：.*"
-syn match diffIdentical	"^檔案 .* 和 .* 相同$"
+syn match diffIdentical	"^文件 .* 和 .* 相同$"
 syn match diffDiffer	"^文件 .* 和 .* 不同$"
-syn match diffBDiffer	"^文件 .* 和 .* 不同$"
+syn match diffBDiffer	"^二进制文件 .* 和 .* 不同$"
 syn match diffIsA	"^文件 .* 是.*而文件 .* 是.*"
 syn match diffNoEOL	"^\\ 文件尾没有 newline 字符"
 syn match diffCommon	"^.* 和 .* 有共同的子目录$"

--- a/runtime/syntax/shared/hgcommitDiff.vim
+++ b/runtime/syntax/shared/hgcommitDiff.vim
@@ -3,6 +3,7 @@
 " Maintainer:	Max Coplan <mchcopl@gmail.com>
 "               Translations by Jakson Alves de Aquino.
 " Last Change:	2022-12-08
+" 2025-08-16 by Vim project, update zh_CN translations, #18011
 " Copied from:	runtime/syntax/diff.vim
 
 " Quit when a (custom) syntax file was already loaded
@@ -312,9 +313,9 @@ syn match hgDiffCommon		"^\%(SL\|HG\): Thư mục con chung: .* và .*"
 
 " zh_CN
 syn match hgDiffOnly		"^\%(SL\|HG\): 只在 .* 存在：.*"
-syn match hgDiffIdentical	"^\%(SL\|HG\): 檔案 .* 和 .* 相同$"
+syn match hgDiffIdentical	"^\%(SL\|HG\): 文件 .* 和 .* 相同$"
 syn match hgDiffDiffer		"^\%(SL\|HG\): 文件 .* 和 .* 不同$"
-syn match hgDiffBDiffer		"^\%(SL\|HG\): 文件 .* 和 .* 不同$"
+syn match hgDiffBDiffer		"^\%(SL\|HG\): 二进制文件 .* 和 .* 不同$"
 syn match hgDiffIsA		"^\%(SL\|HG\): 文件 .* 是.*而文件 .* 是.*"
 syn match hgDiffNoEOL		"^\%(SL\|HG\): \\ 文件尾没有 newline 字符"
 syn match hgDiffCommon		"^\%(SL\|HG\): .* 和 .* 有共同的子目录$"

--- a/src/nvim/po/zh_CN.UTF-8.po
+++ b/src/nvim/po/zh_CN.UTF-8.po
@@ -7597,7 +7597,7 @@ msgstr "\" 在索引行上按 <回车> 来跳转到那里。"
 
 #: ../../../runtime/optwin.vim:159
 msgid "\" Hit <Space> on a \"set\" line to refresh it."
-msgstr "\" 在 \"set\" 行上按 <空格> 来刷新。 "
+msgstr "\" 在 \"set\" 行上按 <空格> 来刷新。"
 
 #: ../../../runtime/optwin.vim:228
 msgid "important"


### PR DESCRIPTION
#### vim-patch:3cee950: runtime(diff): fix mixed translations in zh_CN

some translations confused zh_CN and zh_TW

https://github.com/vim/vim/commit/3cee950fc9f8cdcfe3f168fe83072b2a9eb15d47

Co-authored-by: 毛逸宁 <mao.yining@outlook.com>