### PR TITLE
feat(snippet): highlight active tabstop

### DIFF
--- a/runtime/colors/vim.lua
+++ b/runtime/colors/vim.lua
@@ -134,6 +134,7 @@ hi('DiagnosticDeprecated',       { sp = 'Red', strikethrough = true,    cterm = 
 hi('DiagnosticUnnecessary', { link = 'Comment' })
 hi('LspInlayHint',          { link = 'NonText' })
 hi('SnippetTabstop',        { link = 'Visual' })
+hi('SnippetTabstopActive',  { link = 'SnippetTabstop' })
 
 -- Text
 hi('@markup.raw',       { link = 'Comment' })

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4354,7 +4354,8 @@ vim.snippet.expand({input})                             *vim.snippet.expand()*
     https://microsoft.github.io/language-server-protocol/specification/#snippet_syntax
     for the specification of valid input.
 
-    Tabstops are highlighted with |hl-SnippetTabstop|.
+    Tabstops are highlighted with |hl-SnippetTabstop| and
+    |hl-SnippetTabstopActive|.
 
     Parameters: ~
       • {input}  (`string`)

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -192,6 +192,7 @@ HIGHLIGHTS
 
 • |hl-DiffTextAdd| highlights added text within a changed line.
 • |hl-StderrMsg| |hl-StdoutMsg|
+• |hl-SnippetTabstopActive| highlights the currently active tabstop.
 
 LSP
 

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5343,6 +5343,9 @@ Search		Last search pattern highlighting (see 'hlsearch').
 		Also used for similar items that need to stand out.
 							*hl-SnippetTabstop*
 SnippetTabstop	Tabstops in snippets. |vim.snippet|
+							*hl-SnippetTabstopActive*
+SnippetTabstopActive
+		The currently active tabstop. |vim.snippet|
 							*hl-SpecialKey*
 SpecialKey	Unprintable characters: Text displayed differently from what
 		it really is. But not 'listchars' whitespace. |hl-Whitespace|

--- a/src/nvim/highlight_group.c
+++ b/src/nvim/highlight_group.c
@@ -221,6 +221,7 @@ static const char *highlight_init_both[] = {
   "default link LspReferenceTarget          LspReferenceText",
   "default link LspSignatureActiveParameter Visual",
   "default link SnippetTabstop              Visual",
+  "default link SnippetTabstopActive        SnippetTabstop",
 
   // Diagnostic
   "default link DiagnosticFloatingError    DiagnosticError",

--- a/test/functional/lua/snippet_spec.lua
+++ b/test/functional/lua/snippet_spec.lua
@@ -116,6 +116,20 @@ describe('vim.snippet', function()
     test_expand_success({ 'print($UNKNOWN)' }, { 'print(UNKNOWN)' })
   end)
 
+  it('highlights active tabstop with SnippetTabstopActive', function()
+    local function get_extmark_details(col, end_col)
+      return api.nvim_buf_get_extmarks(0, -1, { 0, col }, { 0, end_col }, { details = true })[1][4]
+    end
+
+    test_expand_success({ 'local ${1:name} = ${2:value}' }, { 'local name = value' })
+    eq('SnippetTabstopActive', get_extmark_details(6, 10).hl_group)
+    eq('SnippetTabstop', get_extmark_details(13, 18).hl_group)
+    feed('<Tab>')
+    poke_eventloop()
+    eq('SnippetTabstop', get_extmark_details(6, 10).hl_group)
+    eq('SnippetTabstopActive', get_extmark_details(13, 18).hl_group)
+  end)
+
   it('does not jump outside snippet range', function()
     test_expand_success({ 'function $1($2)', '  $0', 'end' }, { 'function ()', '  ', 'end' })
     eq(false, exec_lua('return vim.snippet.active({ direction = -1 })'))


### PR DESCRIPTION
Introduce a new highlight group `SnippetTabstopActive` for the currently active tabstop. This makes it easier to identify the current text that is changed, especially for directly adjacent tabstops or tabstops that appear multiple times in a snippet.

https://github.com/user-attachments/assets/54e3223e-8e59-4f89-8340-ff1874ce2cdd

By default the highlight is the same as `SnippetTabstop`, but this gives the user the option to adapt this behavior if wanted. The only annoyance is that extmarks can not overwrite the `Visual` highlight of visual mode, so for tabstops with placeholders the initial highlight after jumping towards them is not the configured `SnippetTabstopActive` highlight since the visual one takes priority. Only on typing the configured highlighting is seen. But this behavior is the same in the current state with `SnippetTabstop` (it is not seen by default since `SnippetTabstop` links to `Visual` there). My personal "hack" is:

```vim
hi link SnippetTabstopActive Visual
hi link SnippetTabstop <something else>
```

### Questions

- Is there a way for extmarks to overwrite the default highlighting in visual mode?
- Is there any other file that needs adoption due to adding a new highlight group that I missed?
