### PR TITLE
fix(health): false positive causes entire python check to fail

### DIFF
--- a/runtime/lua/vim/provider/health.lua
+++ b/runtime/lua/vim/provider/health.lua
@@ -364,7 +364,7 @@ end
 
 -- Resolves Python executable path by invoking and checking `sys.executable`.
 local function python_exepath(invocation)
-  if invocation == "" or invocation == nil then
+  if invocation == '' or invocation == nil then
     return nil
   end
   local p = vim.system({ invocation, '-c', 'import sys; sys.stdout.write(sys.executable)' }):wait()


### PR DESCRIPTION
fix https://github.com/neovim/neovim/issues/23622

# Problem

Currently there is no distinction between executables in `$VIRTUAL_ENV` called `python.*` and Python interpreter excutables. For example in the following case (assuming `$VIRTUAL_ENV == '.venv'`)
```
.venv/python-argcomplete-check-easy-install-script
.venv/bin/python3.13
.venv/bin/python
```
the `.venv/python-argcomplete-check-easy-install-script` is evaluated as if it was another Python version,  triggering the error described in https://github.com/neovim/neovim/issues/23622.

# Solution

Strict check on the executable name format.