### PR TITLE
vim-patch:9.1.1649: attrs allocation and fuzzy growarray could leak

### DIFF
--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -460,6 +460,10 @@ static int *pum_compute_text_attrs(char *text, hlf_T hlf, int user_hlattr)
 
   if (in_fuzzy) {
     ga = fuzzy_match_str_with_pos(text, leader);
+    if (!ga) {
+      xfree(attrs);
+      return NULL;
+    }
   }
 
   const char *ptr = text;


### PR DESCRIPTION
#### vim-patch:9.1.1649: attrs allocation and fuzzy growarray could leak

Problem:  attrs allocation and fuzzy growarray could leak on early
          returns
Solution: Ensure proper cleanup of allocated memory on exit paths
          (glepnir)

closes: vim/vim#18038

https://github.com/vim/vim/commit/c7c10f8c116a87b49ef3ddb9a3b78f10375ca564

Co-authored-by: glepnir <glephunter@gmail.com>