### PR TITLE
fix(treesitter): run FileType autocmds in the context of `<abuf>`

### DIFF
--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -191,10 +191,13 @@ function TSHighlighter:destroy()
     vim.b[self.bufnr].ts_highlight = nil
     api.nvim_buf_clear_namespace(self.bufnr, ns, 0, -1)
     if vim.g.syntax_on == 1 then
-      api.nvim_exec_autocmds(
-        'FileType',
-        { group = 'syntaxset', buffer = self.bufnr, modeline = false }
-      )
+      -- FileType autocmds commonly assume curbuf is the target buffer, so nvim_buf_call.
+      api.nvim_buf_call(self.bufnr, function()
+        api.nvim_exec_autocmds(
+          'FileType',
+          { group = 'syntaxset', buffer = self.bufnr, modeline = false }
+        )
+      end)
     end
   end
 end

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -5,6 +5,7 @@ local Screen = require('test.functional.ui.screen')
 local clear = n.clear
 local insert = n.insert
 local exec_lua = n.exec_lua
+local eval = n.eval
 local feed = n.feed
 local command = n.command
 local api = n.api
@@ -197,6 +198,14 @@ describe('treesitter highlighting (C)', function()
     end)
     -- legacy syntax highlighting is used
     screen:expect(hl_grid_legacy_c)
+
+    exec_lua(function()
+      vim.cmd 'new | wincmd p'
+      vim.treesitter.start()
+      vim.cmd 'bdelete!'
+    end)
+    -- Does not change &syntax of the other, unrelated buffer.
+    eq('', eval('&syntax'))
   end)
 
   it('is updated with edits', function()


### PR DESCRIPTION
Problem: many FileType autocommands assume `curbuf == <abuf>`; this can cause `&syntax` to be restored for the wrong buffer in some cases when `TSHighlighter:destroy` is called.

Solution: run `nvim_exec_autocmds` in the context of the target buffer via `nvim_buf_call`.

Fixes #35390
