### PR TITLE
fix(folds): prevent errors when deleting lines at end of buffer

### DIFF
--- a/src/nvim/lua/stdlib.c
+++ b/src/nvim/lua/stdlib.c
@@ -563,7 +563,7 @@ static int nlua_foldupdate(lua_State *lstate)
   }
   // input is zero-based end-exclusive range
   linenr_T top = (linenr_T)luaL_checkinteger(lstate, 2) + 1;
-  if (top < 1 || top > win->w_buffer->b_ml.ml_line_count) {
+  if (top < 1) {
     return luaL_error(lstate, "invalid top");
   }
   linenr_T bot = (linenr_T)luaL_checkinteger(lstate, 3);

--- a/test/functional/treesitter/fold_spec.lua
+++ b/test/functional/treesitter/fold_spec.lua
@@ -832,4 +832,16 @@ t2]])
     command('set ft=c')
     eq(foldlevels, get_fold_levels())
   end)
+
+  it('no error when deleting lines at end of buffer with fml=0', function()
+    local screen = Screen.new(40, 2)
+    insert('hello')
+    parse('markdown')
+    command('set foldmethod=expr foldexpr=v:lua.vim.treesitter.foldexpr() foldminlines=0')
+    feed('o<Esc>dd')
+    screen:expect([[
+      ^hello                                   |
+                                              |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:
with `foldmethod=expr foldexpr=v:lua.vim.treesitter.foldexpr() foldminlines=0`, deleting lines at the end of the buffer always reports an invalid top error, because the top value (i.e. the start line number of the deletion) is always 1 greater than the total line number of the modified buffer.

Solution:
remove the `ml_line_count` validation

This condition was introduced in #28460. I went with what seemed like the *simplest* fix on the surface. I did some test myself and didn't see any regressions, but since I'm still fairly new to neovim, please feel free to let me know if there are any concerns. :)

Fix #33926
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
