### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -634,6 +634,23 @@ in the "after" directory in 'runtimepath'.  For Unix this would be
     syn sync fromstart
     set foldmethod=syntax
 
+CANGJIE					*cangjie.vim* *ft-cangjie-syntax*
+
+This file provides syntax highlighting for the Cangjie programming language, a
+new-generation language oriented to full-scenario intelligence.
+
+All highlighting is enabled by default.  To disable highlighting for a
+specific group, set the corresponding variable to 0 in your |vimrc|.
+All options to disable highlighting are: >
+	:let g:cangjie_comment_color = 0
+	:let g:cangjie_identifier_color = 0
+	:let g:cangjie_keyword_color = 0
+	:let g:cangjie_macro_color = 0
+	:let g:cangjie_number_color = 0
+	:let g:cangjie_operator_color = 0
+	:let g:cangjie_string_color = 0
+	:let g:cangjie_type_color = 0
+
 CH						*ch.vim* *ft-ch-syntax*
 
 C/C++ interpreter.  Ch has similar syntax highlighting to C and builds upon

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -278,6 +278,7 @@ local extension = {
   c3t = 'c3',
   cabal = 'cabal',
   cairo = 'cairo',
+  cj = 'cangjie',
   capnp = 'capnp',
   cdc = 'cdc',
   cdl = 'cdl',

--- a/runtime/makemenu.vim
+++ b/runtime/makemenu.vim
@@ -122,6 +122,7 @@ SynMenu C.C++:cpp
 SynMenu C.C#:cs
 SynMenu C.Cabal\ Haskell\ build\ file:cabal
 SynMenu C.Calendar:calendar
+SynMenu C.Cangjie:cangjie
 SynMenu C.Cascading\ Style\ Sheets:css
 SynMenu C.CDL:cdl
 SynMenu C.Cdrdao\ TOC:cdrtoc

--- a/runtime/synmenu.vim
+++ b/runtime/synmenu.vim
@@ -114,6 +114,7 @@ an 50.20.110 &Syntax.C.C++ :cal SetSyn("cpp")<CR>
 an 50.20.120 &Syntax.C.C# :cal SetSyn("cs")<CR>
 an 50.20.130 &Syntax.C.Cabal\ Haskell\ build\ file :cal SetSyn("cabal")<CR>
 an 50.20.140 &Syntax.C.Calendar :cal SetSyn("calendar")<CR>
+an 50.20.140 &Syntax.C.Cangjie :cal SetSyn("cangjie")<CR>
 an 50.20.150 &Syntax.C.Cascading\ Style\ Sheets :cal SetSyn("css")<CR>
 an 50.20.160 &Syntax.C.CDL :cal SetSyn("cdl")<CR>
 an 50.20.170 &Syntax.C.Cdrdao\ TOC :cal SetSyn("cdrtoc")<CR>

--- a/runtime/syntax/cangjie.vim
+++ b/runtime/syntax/cangjie.vim
@@ -1,0 +1,153 @@
+" Vim syntax file
+" Language: Cangjie
+" Maintainer: Wu Junkai <wu.junkai@qq.com>
+" Last Change: 2025 Aug 17
+"
+" The Cangjie programming language is a new-generation programming
+" language oriented to full-scenario intelligence. It features
+" native intelligence, being naturally suitable for all scenarios,
+" high performance and strong security. It is mainly applied in
+" scenarios such as native applications and service applications
+" of HarmonyOS NEXT, providing developers with a good programming
+" experience.
+"
+" For more information, see:
+" - https://cangjie-lang.cn/
+" - https://gitcode.com/Cangjie
+
+" quit when a syntax file was already loaded
+if exists("b:current_syntax")
+	finish
+endif
+
+let s:save_cpo = &cpo
+set cpo&vim
+
+" 0. check the user's settings
+" use let g:cangjie_<item>_color to enable/disable syntax highlighting
+function! s:enabled(item) abort
+	return get(g:, 'cangjie_' . a:item . '_color', 1)
+endfunction
+
+syn case match
+
+" 1. comments
+syn keyword cangjieTodo	TODO FIXME XXX NOTE BUG contained
+syn match   cangjieComment /\v\/\/.*/				contains=cangjieTodo
+syn region  cangjieComment start=/\/\*/ end=/\*\//	contains=cangjieTodo,@Spell
+
+" 2. keywords
+syn keyword cangjieDeclaration	abstract extend macro foreign
+syn keyword cangjieDeclaration	interface open operator override private prop protected
+syn keyword cangjieDeclaration	public redef static type
+syn keyword cangjieStatement	as break case catch continue do else finally for in
+syn keyword cangjieStatement	if in is match quote return spawn super synchronized
+syn keyword cangjieStatement	throw try unsafe where while
+syn keyword cangjieIdentlike	false init main this true
+syn keyword cangjieVariable		const let var
+syn keyword cangjieOption		Option Some None
+syn keyword cangjieDeclaration	func struct class enum import package nextgroup=cangjieTypeName skipwhite
+syn cluster cangjieKeywordCluster	contains=cangjieDeclaration,cangjieStatement,cangjieIdentlike,cangjieVariable,cangjieOption
+
+" 3. macro (e.g., @override)
+syn match cangjieMacro /@\h\w*/
+
+" 4. Type and Function Names
+syn match cangjieTypeName /\h\w*/ contained
+
+" 5. specail identifiers
+syn region cangjieSpIdentifier start=/`/ end=/`/ oneline
+
+" 6. types
+syn keyword cangjieSpType		Any Nothing Range Unit Iterable
+syn keyword cangjieArrayType	Array ArrayList VArray
+syn keyword cangjieHashType		HashMap HashSet
+syn keyword cangjieCommonType	Bool Byte Rune String
+syn keyword cangjieFloatType	Float16 Float32 Float64
+syn keyword cangjieIntType		Int8 Int16 Int32 Int64 IntNative
+syn keyword cangjieUIntType		UInt8 UInt16 UInt32 UInt64 UIntNative
+syn cluster cangjieTypeCluster contains=cangjieSpType,cangjieArrayType,cangjieHashType,cangjieCommonType,cangjieFloatType,cangjieIntType,cangjieUIntType
+
+" 7. character and strings
+syn cluster cangjieInterpolatedPart contains=@cangjieKeywordCluster,cangjieSpIdentifier,@cangjieTypeCluster,@cangjieNumberCluster,cangjieOperator
+syn region  cangjieInterpolation contained keepend start=/\${/ end=/}/ contains=@cangjieInterpolatedPart matchgroup=cangjieInterpolationDelimiter
+syn region cangjieRune   start=/r'/ skip=/\\\\\|\\'/ end=/'/ oneline
+syn region cangjieRune   start=/b'/ skip=/\\\\\|\\'/ end=/'/ oneline
+syn region cangjieString start=/"/ skip=/\\\\\|\\"/ end=/"/ oneline contains=cangjieInterpolation
+syn region cangjieString start=/'/ skip=/\\\\\|\\'/ end=/'/ oneline contains=cangjieInterpolation
+syn region cangjieString start=/"""/ skip=/\\\\\|\\"/ end=/"""/ contains=cangjieInterpolation keepend
+syn region cangjieString start=/'''/ skip=/\\\\\|\\'/ end=/'''/ contains=cangjieInterpolation keepend
+syn region cangjieRawString start='\z(#*\)#"'  end='"#\z1'
+syn region cangjieRawString start='\z(#*\)#\'' end='\'#\z1'
+
+" 8. number
+syn match cangjieFloatNumber	/\v\c<\d[0-9_]*\.\d[0-9_]*([ep][-+]?\d[0-9_]*)?(f(16|32|64))?>/
+syn match cangjieFloatNumber	/\v\c<\d[0-9_]*\.([ep][-+]?\d[0-9_]*)?(f(16|32|64))?>/
+syn match cangjieFloatNumber	/\v\c\.\d[0-9_]*([ep][-+]?\d[0-9_]*)?(f(16|32|64))?>/
+syn match cangjieScienceNumber	/\v\c<\d[0-9_]*[e][-+]?\d[0-9_]*>/
+syn match cangjieHexNumber		/\v\c<0x[0-9a-f_]+([iu](8|16|32|64))?>/
+syn match cangjieOctalNumber	/\v\c<0o[0-7_]+([iu](8|16|32|64))?>/
+syn match cangjieBinaryNumber	/\v\c<0b[01_]+([iu](8|16|32|64))?>/
+syn match cangjieDecimalNumber	/\v\c<\d[0-9_]*([iu](8|16|32|64))?>/
+syn cluster cangjieNumberCluster contains=cangjieFloatNumber,cangjieScienceNumber,cangjieHexNumber,cangjieOctalNumber,cangjieBinaryNumber,cangjieDecimalNumber
+
+" 9. operators
+syn match cangjieOperator /[-+%<>!&|^*=]=\?/
+syn match cangjieOperator /\/\%(=\|\ze[^/*]\)/
+syn match cangjieOperator /\%(<<\|>>\|&^\)=\?/
+syn match cangjieOperator /:=\|||\|<-\|++\|--/
+syn match cangjieOperator /[~]/
+syn match cangjieOperator /[:]/
+syn match cangjieOperator /\.\./
+syn match cangjieVarArgs  /\.\.\./
+
+" finally, link the syntax groups to the highlight groups
+if s:enabled('comment')
+	hi def link cangjieTodo				Todo
+	hi def link cangjieComment			Comment
+endif
+if s:enabled('identifier')
+	hi def link cangjieSpIdentifier		Identifier
+endif
+if s:enabled('keyword')
+	hi def link cangjieDeclaration		Keyword
+	hi def link cangjieStatement		Statement
+	hi def link cangjieIdentlike		Keyword
+	hi def link cangjieVariable			Keyword
+	hi def link cangjieOption			Keyword
+endif
+if s:enabled('macro')
+	hi def link cangjieMacro			PreProc
+endif
+if s:enabled('number')
+	hi def link cangjieFloatNumber		Float
+	hi def link cangjieScienceNumber	Float
+	hi def link cangjieHexNumber		Number
+	hi def link cangjieOctalNumber		Number
+	hi def link cangjieBinaryNumber		Number
+	hi def link cangjieDecimalNumber	Number
+endif
+if s:enabled('operator')
+	hi def link cangjieOperator			Operator
+	hi def link cangjieVarArgs			Operator
+endif
+if s:enabled('string')
+	hi def link cangjieRune				Character
+	hi def link cangjieString			String
+	hi def link cangjieRawString		String
+endif
+if s:enabled('type')
+	hi def link cangjieTypeName			Type
+	hi def link cangjieSpType			Type
+	hi def link cangjieArrayType		Type
+	hi def link cangjieHashType			Type
+	hi def link cangjieCommonType		Type
+	hi def link cangjieFloatType		Type
+	hi def link cangjieIntType			Type
+	hi def link cangjieUIntType			Type
+endif
+
+let b:current_syntax = "cangjie"
+
+let &cpo = s:save_cpo
+unlet s:save_cpo

--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Python
 " Maintainer:	Zvezdan Petkovic <zpetkovic@acm.org>
-" Last Change:	2025 Aug 13
+" Last Change:	2025 Aug 18
 " Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "		Rob B
@@ -372,7 +372,7 @@ if !exists("python_no_doctest_highlight")
 endif
 
 " Sync at the beginning of (async) function or class definitions.
-syn sync match pythonSync grouphere NONE "^\%(async\s\+def\|def\|class\)\s\+\h\w*\s*[(:]"
+syn sync match pythonSync grouphere NONE "^\%(def\|class\|async\s\+def\)\s\+\h\w*\s*[(:]"
 
 " The default highlight links.  Can be overridden later.
 hi def link pythonStatement		Statement

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -156,6 +156,7 @@ func s:GetFilenameChecks() abort
     \ 'cabalproject': ['cabal.project', 'cabal.project.local'],
     \ 'cairo': ['file.cairo'],
     \ 'calendar': ['calendar', '/.calendar/file', '/share/calendar/any/calendar.file', '/share/calendar/calendar.file', 'any/share/calendar/any/calendar.file', 'any/share/calendar/calendar.file'],
+    \ 'cangjie': ['file.cj'],
     \ 'capnp': ['file.capnp'],
     \ 'catalog': ['catalog', 'sgml.catalogfile', 'sgml.catalog', 'sgml.catalog-file'],
     \ 'cdc': ['file.cdc'],


### PR DESCRIPTION
#### vim-patch:9.1.1647: filetype: Cangjie files are not recognized

Problem:  filetype: Cangjie files are not recognized
Solution: Detect *.cj files as cangjie filetype, include a syntax plugin
          (WuJunkai2004)

This commit introduces a new syntax highlighting file for the Cangjie
programming language, includes 4 parts as required:
- The main syntax file: runtime/syntax/cangjie.vim
- The filetype detection rule in: runtime/filetype.vim
- The documentation update in: runtime/doc/syntax.txt
- Some menus

References:
- https://gitcode.com/Cangjie
- https://cangjie-lang.cn/

fixes: 18014
closes: vim/vim#18027

https://github.com/vim/vim/commit/0c4405a6b2bc4d93c127e1b66da1b93dcfbbe3db

Co-authored-by: WuJunkai2004 <wujunkai20041123@outlook.com>


#### vim-patch:2f7e4eb: runtime(python): optimize pythonSync pattern

Order the keywords by expected frequency: "def" and "class" are assumed
to be more likely than "async def" in the majority of Python code.

closes: vim/vim#18032

https://github.com/vim/vim/commit/2f7e4eb335df389d73aaeb2ff6879b233c1a293f

Co-authored-by: Jon Parise <jon@indelible.org>