### PR TITLE
fix(startup): keep empty file arg w/ stdin

### DIFF
--- a/test/functional/core/startup_spec.lua
+++ b/test/functional/core/startup_spec.lua
@@ -534,6 +534,26 @@ describe('startup', function()
     )
   end)
 
+  it('if stdin is empty and - is last: selects buffer 1, deletes buffer 3 #35269', function()
+    eq(
+      '\r\n  1 %a   "file1"                        line 0\r\n  2 #h   "file2"                        line 1',
+      fn.system({
+        nvim_prog,
+        '-n',
+        '-u',
+        'NONE',
+        '-i',
+        'NONE',
+        '--headless',
+        '+ls!',
+        '+qall!',
+        'file1',
+        'file2',
+        '-',
+      }, { '' })
+    )
+  end)
+
   it('stdin with -es/-Es #7679', function()
     local input = { 'append', 'line1', 'line2', '.', '%print', '' }
     local inputstr = table.concat(input, '\n')


### PR DESCRIPTION
Problem:

Running `echo dummy | nvim file1 file2` closes the buffer for file1 if file1 doesn't exist.

Solution:

It looks the timing or order of when the buffer for stdin was created changed in 43e8ec9 such that the stdin buffer may now be created after the file arguments. This change handles that case.

Fixes: #35269

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
