### PR TITLE
fix(lsp): update window title when cycling through signatures

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -370,6 +370,7 @@ function M.signature_help(config)
 
   config = config and vim.deepcopy(config) or {}
   config.focus_id = method
+  local user_title = config.title
 
   lsp.buf_request_all(0, method, client_positional_params(), function(results, ctx)
     if api.nvim_get_current_buf() ~= ctx.bufnr then
@@ -409,7 +410,7 @@ function M.signature_help(config)
         local sfx = total > 1
             and string.format(' (%d/%d)%s', idx, total, can_cycle and ' (<C-s> to cycle)' or '')
           or ''
-        config.title = config.title or string.format('Signature Help: %s%s', client.name, sfx)
+        config.title = user_title or string.format('Signature Help: %s%s', client.name, sfx)
         -- If no border is set, render title inside the window.
         if not (config.border or vim.o.winborder ~= '') then
           table.insert(lines, 1, '# ' .. config.title)


### PR DESCRIPTION
Hold a separate reference to the user defined title, so that `config.title` is correctly updated when it is not set.

@adamu found this bug.