### PR TITLE
fix: memory leak from double buffer initialization in read_stdin

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -1627,7 +1627,7 @@ static void read_stdin(void)
 
   if (curbuf->b_ffname) {
     // curbuf is already opened for a file, create a new buffer for stdin. #35269
-    buf_T *newbuf = buflist_new(NULL, NULL, 0, 0);
+    buf_T *newbuf = buflist_new(NULL, NULL, 0, BLN_LISTED);
     if (newbuf == NULL) {
       semsg("Failed to create buffer for stdin");
       return;
@@ -1636,11 +1636,13 @@ static void read_stdin(void)
     // remember the current buffer so we can go back to it
     prev_buf = curbuf;
     set_curbuf(newbuf, 0, false);
+    readfile(NULL, NULL, 0, 0, (linenr_T)MAXLNUM, NULL, READ_NEW + READ_STDIN, true);
+  } else {
+    set_buflisted(true);
+    // Create memfile and read from stdin.
+    open_buffer(true, NULL, 0);
   }
 
-  set_buflisted(true);
-  // Create memfile and read from stdin.
-  open_buffer(true, NULL, 0);
   if (buf_is_empty(curbuf)) {
     // stdin was empty so we should wipe it (e.g. "echo file1 | xargs nvim"). #8561
     // stdin buffer may be first or last ("echo foo | nvim file1 -"). #35269


### PR DESCRIPTION
Problem: When stdin follows files, set_curbuf() initializes buffer via 
enter_buffer(), then open_buffer() initializes again, causing memory leaks.

Solution: Use readfile() directly for new buffers already initialized by 
enter_buffer(), only call open_buffer() for original buffer case.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
