### PR TITLE
vim-patch:8.2.1672: v_lock is used when it is not initialized

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2655,6 +2655,8 @@ int eval0_simple_funccal(char *arg, typval_T *rettv, exarg_T *eap, evalarg_T *co
 /// @return  OK or FAIL.
 int eval1(char **arg, typval_T *rettv, evalarg_T *const evalarg)
 {
+  CLEAR_POINTER(rettv);
+
   // Get the first variable.
   if (eval2(arg, rettv, evalarg) == FAIL) {
     return FAIL;


### PR DESCRIPTION
Fix #35415

#### vim-patch:8.2.1672: v_lock is used when it is not initialized

Problem:    v_lock is used when it is not initialized. (Yegappan Lakshmanan)
Solution:   Initialize the typval in eval1().

https://github.com/vim/vim/commit/4a091b9978122428e7d9154d034c640c9c8d8c13

Co-authored-by: Bram Moolenaar <Bram@vim.org>