### PR TITLE
fix(lsp): handle array with empty string when checking empty hover

### DIFF
--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -70,8 +70,10 @@ function M.hover(config)
       elseif result and result.contents then
         -- Make sure the response is not empty
         if
-          (type(result.contents) == 'table' and #(vim.tbl_get(result.contents, 'value') or '') > 0)
-          or type(result.contents == 'string') and #result.contents > 0
+          (
+            type(result.contents) == 'table'
+            and #(vim.tbl_get(result.contents, 'value') or result.contents[1] or '') > 0
+          ) or (type(result.contents) == 'string' and #result.contents > 0)
         then
           results1[client_id] = result
         else


### PR DESCRIPTION
Follow-up to #35014

Hover contents may be of type [`markedString[]`](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#markedString), and `markedString` can be a single string, not an object. Therefore, we also have to treat the table as an array and check if its content (i.e., the first item) is empty.

This commit additionally fixes a typo when checking if contents is a string.