### PR TITLE
feat(json): support pretty-formatting with `vim.json.encode()`

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -3372,6 +3372,9 @@ vim.json.encode({obj}, {opts})                             *vim.json.encode()*
       • {opts}  (`table<string,any>?`) Options table with keys:
                 • escape_slash: (boolean) (default false) Escape slash
                   characters "/" in string values.
+                • indent: (string) (default "") String used for indentation at
+                  each nesting level. If non-empty enables newlines and a
+                  space after colons.
 
     Return: ~
         (`string`)

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -262,6 +262,7 @@ LUA
 • |vim.list.unique()| to deduplicate lists.
 • |vim.list.bisect()| for binary search.
 • Experimental `vim.pos` and `vim.range` for Position/Range abstraction.
+• |vim.json.encode()| has an `indent` option for pretty-formatting.
 
 OPTIONS
 

--- a/runtime/lua/vim/_meta/json.lua
+++ b/runtime/lua/vim/_meta/json.lua
@@ -38,5 +38,7 @@ function vim.json.decode(str, opts) end
 ---@param opts? table<string,any> Options table with keys:
 ---                                 - escape_slash: (boolean) (default false) Escape slash
 ---                                   characters "/" in string values.
+---                                 - indent: (string) (default "") String used for indentation at each nesting level.
+---                                   If non-empty enables newlines and a space after colons.
 ---@return string
 function vim.json.encode(obj, opts) end

--- a/test/functional/lua/json_spec.lua
+++ b/test/functional/lua/json_spec.lua
@@ -192,6 +192,41 @@ describe('vim.json.encode()', function()
     )
   end)
 
+  it('indent', function()
+    eq('"Test"', exec_lua([[return vim.json.encode('Test', { indent = "  " })]]))
+    eq('[]', exec_lua([[return vim.json.encode({}, { indent = "  " })]]))
+    eq('{}', exec_lua([[return vim.json.encode(vim.empty_dict(), { indent = "  " })]]))
+    eq(
+      '[\n  {\n    "a": "a"\n  },\n  {\n    "b": "b"\n  }\n]',
+      exec_lua([[return vim.json.encode({ { a = "a" }, { b = "b" } }, { indent = "  " })]])
+    )
+    eq(
+      '{\n  "a": {\n    "b": 1\n  }\n}',
+      exec_lua([[return vim.json.encode({ a = { b = 1 } }, { indent = "  " })]])
+    )
+    eq(
+      '[{"a":"a"},{"b":"b"}]',
+      exec_lua([[return vim.json.encode({ { a = "a" }, { b = "b" } }, { indent = "" })]])
+    )
+    eq(
+      '[\n  [\n    1,\n    2\n  ],\n  [\n    3,\n    4\n  ]\n]',
+      exec_lua([[return vim.json.encode({ { 1, 2 }, { 3, 4 } }, { indent = "  " })]])
+    )
+    eq(
+      '{\nabc"a": {\nabcabc"b": 1\nabc}\n}',
+      exec_lua([[return vim.json.encode({ a = { b = 1 } }, { indent = "abc" })]])
+    )
+
+    -- Checks for for global side-effects
+    eq(
+      '[{"a":"a"},{"b":"b"}]',
+      exec_lua([[
+        vim.json.encode('', { indent = "  " })
+        return vim.json.encode({ { a = "a" }, { b = "b" } })
+      ]])
+    )
+  end)
+
   it('dumps strings', function()
     eq('"Test"', exec_lua([[return vim.json.encode('Test')]]))
     eq('""', exec_lua([[return vim.json.encode('')]]))


### PR DESCRIPTION
## Problem:
There is no straightforward way to pretty-print objects as JSON.
The existing `vim.inspect` outputs LON.

## Solution:
Introduce an `indent` option for `vim.json.encode()` which enables human-readable output with configurable indentation.

Adapts PR to upstream: https://github.com/openresty/lua-cjson/pull/114.

CC @echasnovski for the original proposal and draft implementation.
