### PR TITLE
vim-patch:014d50d: runtime(systemverilog): Add syntax highlighting for 1800-2023 block strings

### DIFF
--- a/runtime/syntax/systemverilog.vim
+++ b/runtime/syntax/systemverilog.vim
@@ -1,7 +1,8 @@
 " Vim syntax file
 " Language:    SystemVerilog
 " Maintainer:  kocha <kocha.lsifrontend@gmail.com>
-" Last Change: 12-Aug-2013. 
+" Last Change: 12-Aug-2013.
+" 2025 Aug 20 by Vim project: Add IEE1800-2023 block #18056
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -68,6 +69,9 @@ syn keyword systemverilogConditional unique0
 syn keyword systemverilogStatement   implements
 syn keyword systemverilogStatement   interconnect soft nettype
 
+" IEEE1800-2023 add
+syn region systemverilogBlockString start=+"""+ end=+"""+ contains=verilogEscape,@Spell
+
 " Define the default highlighting.
 
 " The default highlighting.
@@ -78,6 +82,7 @@ hi def link systemverilogRepeat          Repeat
 hi def link systemverilogLabel           Label
 hi def link systemverilogGlobal          Define
 hi def link systemverilogNumber          Number
+hi def link systemverilogBlockString     String
 
 
 let b:current_syntax = "systemverilog"


### PR DESCRIPTION
#### vim-patch:014d50d: runtime(systemverilog): Add syntax highlighting for 1800-2023 block strings

closes: vim/vim#18056

https://github.com/vim/vim/commit/014d50df80d71ab0adcf9b2e649469945dd3bbc2

Co-authored-by: Ayan Banerjee <ayanbanrj@gmail.com>