### PR TITLE
vim-patch: 'autocompletedelay'

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1117,8 +1117,8 @@ CTRL-X CTRL-Z		Stop completion without changing the text.
 AUTOCOMPLETION						*ins-autocompletion*
 
 Vim can display a completion menu as you type, similar to using |i_CTRL-N|,
-but triggered automatically.  See 'autocomplete'. The menu items are collected
-from the sources listed in the 'complete' option.
+but triggered automatically.  See 'autocomplete' and 'autocompletedelay'.
+The menu items are collected from the sources listed in the 'complete' option.
 
 Unlike manual |i_CTRL-N| completion, this mode uses a decaying timeout to keep
 Vim responsive.  Sources earlier in the 'complete' list are given more time

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -751,8 +751,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 'autocompletedelay' 'acl'	number	(default 0)
 			global
 	Delay in milliseconds before the autocomplete menu appears after
-	typing. If you prefer it not to open too quickly, set this value
-	slightly above your typing speed. See |ins-autocompletion|.
+	typing.  If you prefer it not to open too quickly, set this value
+	slightly above your typing speed.  See |ins-autocompletion|.
 
 			*'autoindent'* *'ai'* *'noautoindent'* *'noai'*
 'autoindent' 'ai'	boolean	(default on)

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -747,6 +747,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	When on, Vim shows a completion menu as you type, similar to using
 	|i_CTRL-N|, but triggered automatically.  See |ins-autocompletion|.
 
+					*'autocompletedelay'* *'acl'*
+'autocompletedelay' 'acl'	number	(default 0)
+			global
+	Delay in milliseconds before the autocomplete menu appears after
+	typing. If you prefer it not to open too quickly, set this value
+	slightly above your typing speed. See |ins-autocompletion|.
+
 			*'autoindent'* *'ai'* *'noautoindent'* *'noai'*
 'autoindent' 'ai'	boolean	(default on)
 			local to buffer

--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -1485,11 +1485,11 @@ Fuzzy matching scores how well a string matches a pattern when the pattern
 characters appear in order but not necessarily contiguously.
 
 Example: >
-    Pattern:    "vim"
-    Candidates: "vim"        -> perfect
-                "vimeo"      -> good (v i m)
-                "voice mail" -> weaker (v _ i _ _ _ m)
-                "vintage"    -> no match (no "m")
+    Pattern:	"vim"
+    Candidates:	"vim"	     -> perfect
+		"vimeo"	     -> good (v i m)
+		"voice mail" -> weaker (v _ i _ _ _ m)
+		"vintage"    -> no match (no "m")
 <
 If the search string has multiple words, each word is matched separately and
 may appear in any order in the candidate.  For example "get pat" matches

--- a/runtime/doc/quickref.txt
+++ b/runtime/doc/quickref.txt
@@ -626,6 +626,7 @@ Short explanation of each option:		*option-list*
 'arabicshape'	  'arshape' do shaping for Arabic characters
 'autochdir'	  'acd'     change directory to the file in the current window
 'autocomplete'	  'ac'      enable automatic completion in insert mode
+'autocompletedelay' 'acl'   delay in msec before menu appears after typing
 'autoindent'	  'ai'	    take indent for new line from previous line
 'autoread'	  'ar'	    autom. read file when changed outside of Vim
 'autowrite'	  'aw'	    automatically write file if changed

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -121,8 +121,8 @@ vim.go.autocomplete = vim.o.autocomplete
 vim.go.ac = vim.go.autocomplete
 
 --- Delay in milliseconds before the autocomplete menu appears after
---- typing. If you prefer it not to open too quickly, set this value
---- slightly above your typing speed. See `ins-autocompletion`.
+--- typing.  If you prefer it not to open too quickly, set this value
+--- slightly above your typing speed.  See `ins-autocompletion`.
 ---
 --- @type integer
 vim.o.autocompletedelay = 0

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -120,6 +120,16 @@ vim.o.ac = vim.o.autocomplete
 vim.go.autocomplete = vim.o.autocomplete
 vim.go.ac = vim.go.autocomplete
 
+--- Delay in milliseconds before the autocomplete menu appears after
+--- typing. If you prefer it not to open too quickly, set this value
+--- slightly above your typing speed. See `ins-autocompletion`.
+---
+--- @type integer
+vim.o.autocompletedelay = 0
+vim.o.acl = vim.o.autocompletedelay
+vim.go.autocompletedelay = vim.o.autocompletedelay
+vim.go.acl = vim.go.autocompletedelay
+
 --- Copy indent from current line when starting a new line (typing <CR>
 --- in Insert mode or when using the "o" or "O" command).  If you do not
 --- type anything on the new line except <BS> or CTRL-D and then type

--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1,7 +1,7 @@
 " These commands create the option window.
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2025 Aug 07
+" Last Change:	2025 Aug 16
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " If there already is an option window, jump to that one.
@@ -737,6 +737,8 @@ if has("insert_expand")
   call <SID>OptionL("cpt")
   call <SID>AddOption("autocomplete", gettext("automatic completion in insert mode"))
   call <SID>BinOptionG("ac", &ac)
+  call <SID>AddOption("autocompletedelay", gettext("delay in msec before menu appears after typing"))
+  call append("$", " \tset acl=" . &acl)
   call <SID>AddOption("completeopt", gettext("whether to use a popup menu for Insert mode completion"))
   call <SID>OptionL("cot")
   call <SID>AddOption("completeitemalign", gettext("popup menu item align order"))

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -581,6 +581,10 @@ static int insert_execute(VimState *state, int key)
         return 1;  // continue
       }
 
+      if (p_ac) {
+        ins_compl_set_autocomplete(true);
+      }
+
       // A non-white character that fits in with the current
       // completion: Add to "compl_leader".
       if (ins_compl_accept_char(s->c)) {
@@ -596,6 +600,10 @@ static int insert_execute(VimState *state, int key)
           ins_compl_addleader(s->c);
         }
         return 1;  // continue
+      }
+
+      if (p_ac) {
+        ins_compl_set_autocomplete(false);
       }
 
       // Pressing CTRL-Y selects the current match.  When
@@ -849,10 +857,11 @@ static int insert_handle_key(InsertState *s)
     auto_format(false, true);
     if (s->did_backspace && p_ac && !char_avail() && curwin->w_cursor.col > 0) {
       s->c = char_before_cursor();
-      if (ins_compl_setup_autocompl(s->c)) {
+      if (vim_isprintc(s->c)) {
         redraw_later(curwin, UPD_VALID);
         update_screen();  // Show char deletion immediately
         ui_flush();
+        ins_compl_set_autocomplete(true);
         insert_do_complete(s);  // Trigger autocompletion
         return 1;
       }
@@ -1233,10 +1242,11 @@ normalchar:
     // closed fold.
     foldOpenCursor();
     // Trigger autocompletion
-    if (p_ac && !char_avail() && ins_compl_setup_autocompl(s->c)) {
+    if (p_ac && !char_avail() && vim_isprintc(s->c)) {
       redraw_later(curwin, UPD_VALID);
       update_screen();  // Show character immediately
       ui_flush();
+      ins_compl_set_autocomplete(true);
       insert_do_complete(s);
     }
 

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -581,10 +581,6 @@ static int insert_execute(VimState *state, int key)
         return 1;  // continue
       }
 
-      if (p_ac) {
-        ins_compl_set_autocomplete(true);
-      }
-
       // A non-white character that fits in with the current
       // completion: Add to "compl_leader".
       if (ins_compl_accept_char(s->c)) {
@@ -600,10 +596,6 @@ static int insert_execute(VimState *state, int key)
           ins_compl_addleader(s->c);
         }
         return 1;  // continue
-      }
-
-      if (p_ac) {
-        ins_compl_set_autocomplete(false);
       }
 
       // Pressing CTRL-Y selects the current match.  When
@@ -861,7 +853,7 @@ static int insert_handle_key(InsertState *s)
         redraw_later(curwin, UPD_VALID);
         update_screen();  // Show char deletion immediately
         ui_flush();
-        ins_compl_set_autocomplete(true);
+        ins_compl_enable_autocomplete();
         insert_do_complete(s);  // Trigger autocompletion
         return 1;
       }
@@ -1246,7 +1238,7 @@ normalchar:
       redraw_later(curwin, UPD_VALID);
       update_screen();  // Show character immediately
       ui_flush();
-      ins_compl_set_autocomplete(true);
+      ins_compl_enable_autocomplete();
       insert_do_complete(s);
     }
 

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -6027,6 +6027,7 @@ int ins_complete(int c, bool enable_pum)
 
   if (!compl_started) {
     if (ins_compl_start() == FAIL) {
+      compl_autocomplete = false;
       return FAIL;
     }
   } else if (insert_match && stop_arrow() == FAIL) {
@@ -6109,19 +6110,15 @@ int ins_complete(int c, bool enable_pum)
   }
   compl_was_interrupted = compl_interrupted;
   compl_interrupted = false;
+  compl_autocomplete = false;
 
   return OK;
 }
 
-/// Returns true if the given character 'c' can be used to trigger
-/// autocompletion.
-bool ins_compl_setup_autocompl(int c)
+/// Enable/disable autocompletion
+void ins_compl_set_autocomplete(bool value)
 {
-  if (vim_isprintc(c)) {
-    compl_autocomplete = true;
-    return true;
-  }
-  return false;
+  compl_autocomplete = value;
 }
 
 /// Remove (if needed) and show the popup menu

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -301,6 +301,7 @@ EXTERN unsigned cia_flags;      ///< order flags of 'completeitemalign'
 EXTERN char *p_cot;             ///< 'completeopt'
 EXTERN unsigned cot_flags;      ///< flags from 'completeopt'
 EXTERN int p_ac;                ///< 'autocomplete'
+EXTERN OptInt p_acl;            ///< 'autocompletedelay'
 #ifdef BACKSLASH_IN_FILENAME
 EXTERN char *p_csl;             ///< 'completeslash'
 #endif

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -242,6 +242,20 @@ local options = {
       varname = 'p_ac',
     },
     {
+      abbreviation = 'acl',
+      defaults = 0,
+      desc = [=[
+        Delay in milliseconds before the autocomplete menu appears after
+        typing. If you prefer it not to open too quickly, set this value
+        slightly above your typing speed. See |ins-autocompletion|.
+      ]=],
+      full_name = 'autocompletedelay',
+      scope = { 'global' },
+      short_desc = N_('delay in msec before menu appears after typing'),
+      type = 'number',
+      varname = 'p_acl',
+    },
+    {
       abbreviation = 'ai',
       defaults = true,
       desc = [=[

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -246,8 +246,8 @@ local options = {
       defaults = 0,
       desc = [=[
         Delay in milliseconds before the autocomplete menu appears after
-        typing. If you prefer it not to open too quickly, set this value
-        slightly above your typing speed. See |ins-autocompletion|.
+        typing.  If you prefer it not to open too quickly, set this value
+        slightly above your typing speed.  See |ins-autocompletion|.
       ]=],
       full_name = 'autocompletedelay',
       scope = { 'global' },

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1409,4 +1409,98 @@ describe('completion', function()
       {5:-- INSERT --}                              4,6           All |
     ]])
   end)
+
+  -- oldtest: Test_autocompletedelay()
+  it("'autocompletedelay' option", function()
+    source([[
+      call setline(1, ['foo', 'foobar', 'foobarbaz'])
+      set autocomplete
+    ]])
+    screen:try_resize(60, 10)
+
+    feed('Gof')
+    screen:expect([[
+      foo                                                         |
+      foobar                                                      |
+      foobarbaz                                                   |
+      f^                                                           |
+      {4:foobarbaz      }{1:                                             }|
+      {4:foobar         }{1:                                             }|
+      {4:foo            }{1:                                             }|
+      {1:~                                                           }|*2
+      {5:-- INSERT --}                                                |
+    ]])
+
+    feed('<Esc>')
+    command('set autocompletedelay=500')
+    feed('Sf')
+    screen:expect([[
+      foo                                                         |
+      foobar                                                      |
+      foobarbaz                                                   |
+      f^                                                           |
+      {1:~                                                           }|*5
+      {5:-- INSERT --}                                                |
+    ]])
+    feed('o')
+    screen:expect([[
+      foo                                                         |
+      foobar                                                      |
+      foobarbaz                                                   |
+      fo^                                                          |
+      {1:~                                                           }|*5
+      {5:-- INSERT --}                                                |
+    ]])
+    vim.uv.sleep(500)
+    screen:expect([[
+      foo                                                         |
+      foobar                                                      |
+      foobarbaz                                                   |
+      fo^                                                          |
+      {4:foobarbaz      }{1:                                             }|
+      {4:foobar         }{1:                                             }|
+      {4:foo            }{1:                                             }|
+      {1:~                                                           }|*2
+      {5:-- INSERT --}                                                |
+    ]])
+    feed('<BS>')
+    screen:expect([[
+      foo                                                         |
+      foobar                                                      |
+      foobarbaz                                                   |
+      f^                                                           |
+      {1:~                                                           }|*5
+      {5:-- INSERT --}                                                |
+    ]])
+    vim.uv.sleep(500)
+    screen:expect([[
+      foo                                                         |
+      foobar                                                      |
+      foobarbaz                                                   |
+      f^                                                           |
+      {4:foobarbaz      }{1:                                             }|
+      {4:foobar         }{1:                                             }|
+      {4:foo            }{1:                                             }|
+      {1:~                                                           }|*2
+      {5:-- INSERT --}                                                |
+    ]])
+
+    -- During delay wait, user can open menu using CTRL_N completion
+    feed('<Esc>')
+    command('set completeopt=menuone,preinsert')
+    feed('Sf<C-N>')
+    screen:expect([[
+      foo                                                         |
+      foobar                                                      |
+      foobarbaz                                                   |
+      f^oo                                                         |
+      {12:foo            }{1:                                             }|
+      {4:foobar         }{1:                                             }|
+      {4:foobarbaz      }{1:                                             }|
+      {1:~                                                           }|*2
+      {5:-- Keyword completion (^N^P) }{6:match 1 of 3}                   |
+    ]])
+
+    feed('<esc>')
+  end)
 end)

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1417,6 +1417,14 @@ describe('completion', function()
       set autocomplete
     ]])
     screen:try_resize(60, 10)
+    screen:expect([[
+      ^foo                                                         |
+      foobar                                                      |
+      foobarbaz                                                   |
+      {1:~                                                           }|*6
+                                                                  |
+    ]])
+    screen.timeout = 200
 
     feed('Gof')
     screen:expect([[
@@ -1500,6 +1508,57 @@ describe('completion', function()
       {1:~                                                           }|*2
       {5:-- Keyword completion (^N^P) }{6:match 1 of 3}                   |
     ]])
+
+    -- After the menu is open, ^N/^P and Up/Down should not delay
+    feed('<Esc>')
+    command('set completeopt=menu')
+    feed('Sf')
+    screen:expect([[
+      foo                                                         |
+      foobar                                                      |
+      foobarbaz                                                   |
+      f^                                                           |
+      {1:~                                                           }|*5
+      {5:-- INSERT --}                                                |
+    ]])
+    vim.uv.sleep(500)
+    feed('<C-N>')
+    screen:expect([[
+      foo                                                         |
+      foobar                                                      |
+      foobarbaz                                                   |
+      foobarbaz^                                                   |
+      {12:foobarbaz      }{1:                                             }|
+      {4:foobar         }{1:                                             }|
+      {4:foo            }{1:                                             }|
+      {1:~                                                           }|*2
+      {5:-- INSERT --}                                                |
+    ]])
+    feed('<Down>')
+    screen:expect([[
+      foo                                                         |
+      foobar                                                      |
+      foobarbaz                                                   |
+      foobarbaz^                                                   |
+      {4:foobarbaz      }{1:                                             }|
+      {12:foobar         }{1:                                             }|
+      {4:foo            }{1:                                             }|
+      {1:~                                                           }|*2
+      {5:-- INSERT --}                                                |
+    ]])
+
+    -- When menu is not open Up/Down moves cursor to different line
+    feed('<Esc>Sf')
+    screen:expect([[
+      foo                                                         |
+      foobar                                                      |
+      foobarbaz                                                   |
+      f^                                                           |
+      {1:~                                                           }|*5
+      {5:-- INSERT --}                                                |
+    ]])
+    feed('<Down>')
+    screen:expect_unchanged()
 
     feed('<esc>')
   end)

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -5471,7 +5471,7 @@ func Test_autocomplete_timer()
   call assert_equal(['abc', 'ab'], b:matches->mapnew('v:val.word'))
   call assert_equal(0, b:selected)
   call assert_equal(1, g:CallCount)
-  call assert_equal('abc', getline(4))
+  call assert_equal('ab', getline(4))
   set completeopt&
 
   " Test 8: {func} completes after space, but not '.'
@@ -5602,6 +5602,20 @@ func Test_autocompletedelay()
   call term_sendkeys(buf, "\<Esc>:set completeopt=menuone,preinsert\<CR>")
   call term_sendkeys(buf, "Sf\<C-N>")
   call VerifyScreenDump(buf, 'Test_autocompletedelay_7', {})
+
+  " After the menu is open, ^N/^P and Up/Down should not delay
+  call term_sendkeys(buf, "\<Esc>:set completeopt=menu noruler\<CR>")
+  call term_sendkeys(buf, "\<Esc>Sf")
+  sleep 500ms
+  call term_sendkeys(buf, "\<C-N>")
+  call VerifyScreenDump(buf, 'Test_autocompletedelay_8', {})
+  call term_sendkeys(buf, "\<Down>")
+  call VerifyScreenDump(buf, 'Test_autocompletedelay_9', {})
+
+  " When menu is not open Up/Down moves cursor to different line
+  call term_sendkeys(buf, "\<Esc>Sf")
+  call term_sendkeys(buf, "\<Down>")
+  call VerifyScreenDump(buf, 'Test_autocompletedelay_10', {})
 
   call term_sendkeys(buf, "\<esc>")
   call StopVimInTerminal(buf)

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -5573,4 +5573,38 @@ func Test_omni_start_invalid_col()
   set omnifunc& complete&
 endfunc
 
+func Test_autocompletedelay()
+  CheckScreendump
+
+  let lines =<< trim [SCRIPT]
+    call setline(1, ['foo', 'foobar', 'foobarbaz'])
+    set autocomplete
+  [SCRIPT]
+  call writefile(lines, 'XTest_autocomplete_delay', 'D')
+  let buf = RunVimInTerminal('-S XTest_autocomplete_delay', {'rows': 10})
+
+  call term_sendkeys(buf, "Gof")
+  call VerifyScreenDump(buf, 'Test_autocompletedelay_1', {})
+
+  call term_sendkeys(buf, "\<Esc>:set autocompletedelay=500\<CR>")
+  call term_sendkeys(buf, "Sf")
+  call VerifyScreenDump(buf, 'Test_autocompletedelay_2', {})
+  call term_sendkeys(buf, "o")
+  call VerifyScreenDump(buf, 'Test_autocompletedelay_3', {})
+  sleep 500m
+  call VerifyScreenDump(buf, 'Test_autocompletedelay_4', {})
+  call term_sendkeys(buf, "\<BS>")
+  call VerifyScreenDump(buf, 'Test_autocompletedelay_5', {})
+  sleep 500m
+  call VerifyScreenDump(buf, 'Test_autocompletedelay_6', {})
+
+  " During delay wait, user can open menu using CTRL_N completion
+  call term_sendkeys(buf, "\<Esc>:set completeopt=menuone,preinsert\<CR>")
+  call term_sendkeys(buf, "Sf\<C-N>")
+  call VerifyScreenDump(buf, 'Test_autocompletedelay_7', {})
+
+  call term_sendkeys(buf, "\<esc>")
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -5471,7 +5471,7 @@ func Test_autocomplete_timer()
   call assert_equal(['abc', 'ab'], b:matches->mapnew('v:val.word'))
   call assert_equal(0, b:selected)
   call assert_equal(1, g:CallCount)
-  call assert_equal('ab', getline(4))
+  call assert_equal('abc', getline(4))
   set completeopt&
 
   " Test 8: {func} completes after space, but not '.'


### PR DESCRIPTION
#### vim-patch:9.1.1638: completion: not possible to delay the autcompletion

Problem:  completion: not possible to delay the autcompletion
Solution: add the 'autocompletedelay' option value (Girish Palya).

This patch introduces a new global option 'autocompletedelay'/'acl' that
specifies the delay, in milliseconds, before the autocomplete menu
appears after typing.

When set to a non-zero value, Vim waits for the specified time before
showing the completion popup, allowing users to reduce distraction from
rapid suggestion pop-ups or to fine-tune the responsiveness of
completion.

The default value is 0, which preserves the current immediate-popup
behavior.

closes: vim/vim#17960

https://github.com/vim/vim/commit/a09b1604d4fe7516d87fbcbf2ffd2dc484799b23

N/A patch: vim-patch:9.1.1641: a few compiler warnings are output

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1657: Autocompletion adds delay

Problem:  Autocompletion adds delay
          (gcanat, char101, after v9.1.1638)
Solution: Temporarily disable autocomplation (Girish Palya).

related: vim/vim#17960
closes: vim/vim#18048

https://github.com/vim/vim/commit/196c376682f9ebad0d13a8d5458accfb33372537

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:5ca1ea8: runtime(doc): Tweak documentation style

closes: vim/vim#18078

https://github.com/vim/vim/commit/5ca1ea83ad79c8d1ebd25e61c91f1199c9bc4f09

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>


#### vim-patch:9.1.1670: completion: autocomplete breaks second completion

Problem:  completion: autocomplete breaks second completion
          (gravndal)
Solution: Fix the autocomplete bug (Girish Palya)

closes: vim/vim#18068

https://github.com/vim/vim/commit/b4e0bd93a9c09377b684c5bdf12c5c2eeb46aada

Co-authored-by: Girish Palya <girishji@gmail.com>
