### PR TITLE
feat(progress): status api, 'statusline' integration

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -5011,12 +5011,10 @@ vim.ui.open({path}, {opt})                                     *vim.ui.open()*
 
 vim.ui.progress_status()                            *vim.ui.progress_status()*
     Gets the status of currently running progress messages, in a format
-    convenient for inclusion in 'statusline'. Also returns a list of current
-    progress messages as the second return value.
+    convenient for inclusion in 'statusline'.
 
-    Return (multiple): ~
+    Return: ~
         (`string`) formatted text of progress status for statusline
-        (`ProgressMessage[]`) list of currently active progress messages
 
 vim.ui.select({items}, {opts}, {on_choice})                  *vim.ui.select()*
     Prompts the user to pick from a list of items, allowing arbitrary

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -5009,6 +5009,17 @@ vim.ui.open({path}, {opt})                                     *vim.ui.open()*
     See also: ~
       • |vim.system()|
 
+vim.ui.progress_status({opts})                      *vim.ui.progress_status()*
+    Function to format the list of running progress messages for statusline
+
+    Parameters: ~
+      • {opts}  (`table?`) Options
+                • {fmt}? (`fun(running: ProgressMessage[]):string`) custom
+                  formater for progress messages
+
+    Return: ~
+        (`string`) Statusline component text
+
 vim.ui.select({items}, {opts}, {on_choice})                  *vim.ui.select()*
     Prompts the user to pick from a list of items, allowing arbitrary
     (potentially asynchronous) work until `on_choice`.

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -5009,13 +5009,14 @@ vim.ui.open({path}, {opt})                                     *vim.ui.open()*
     See also: ~
       • |vim.system()|
 
-vim.ui.progress_status({opts})                      *vim.ui.progress_status()*
-    Function to format the list of running progress messages for statusline
+vim.ui.progress_get_running()                  *vim.ui.progress_get_running()*
+    Returns raw list of currently active progress objects.
 
-    Parameters: ~
-      • {opts}  (`table?`) Options
-                • {fmt}? (`fun(running: ProgressMessage[]):string`) custom
-                  formater for progress messages
+    Return: ~
+        (`ProgressMessage[]`)
+
+vim.ui.progress_status()                            *vim.ui.progress_status()*
+    Function to format the list of running progress messages for statusline
 
     Return: ~
         (`string`) Statusline component text

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -5009,17 +5009,14 @@ vim.ui.open({path}, {opt})                                     *vim.ui.open()*
     See also: ~
       • |vim.system()|
 
-vim.ui.progress_get_running()                  *vim.ui.progress_get_running()*
-    Returns raw list of currently active progress objects.
-
-    Return: ~
-        (`ProgressMessage[]`)
-
 vim.ui.progress_status()                            *vim.ui.progress_status()*
-    Function to format the list of running progress messages for statusline
+    Gets the status of currently running progress messages, in a format
+    convenient for inclusion in 'statusline'. Also returns a list of current
+    progress messages as the second return value.
 
-    Return: ~
-        (`string`) Statusline component text
+    Return (multiple): ~
+        (`string`) formatted text of progress status for statusline
+        (`ProgressMessage[]`) list of currently active progress messages
 
 vim.ui.select({items}, {opts}, {on_choice})                  *vim.ui.select()*
     Prompts the user to pick from a list of items, allowing arbitrary

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -458,6 +458,8 @@ UI
 • Cursor shape indicates when it is behind an unfocused floating window.
 • Improved LSP signature help rendering.
 • Multigrid UIs can call nvim_input_mouse with grid 0 to let Nvim decide the grid.
+• |vim.ui.progress_status()| returns a formatted string of currently
+running |progress-message|.
 
 VIMSCRIPT
 

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -6982,7 +6982,7 @@ vim.wo.stc = vim.wo.statuscolumn
 ---
 ---
 --- @type string
-vim.o.statusline = "%<%f %h%w%m%r %{% v:lua.require('vim._core.util').term_exitcode() %}%=%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &busy > 0 ? '◐ ' : '' %}%{% luaeval('(package.loaded[''vim.diagnostic''] and next(vim.diagnostic.count()) and vim.diagnostic.status() .. '' '') or '''' ') %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}"
+vim.o.statusline = "%<%f %h%w%m%r %{% v:lua.require('vim._core.util').term_exitcode() %}%=%{% luaeval('(package.loaded[''vim.ui''] and vim.ui.progress_status()) or '''' ')%}%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}%{% &busy > 0 ? '◐ ' : '' %}%{% luaeval('(package.loaded[''vim.diagnostic''] and next(vim.diagnostic.count()) and vim.diagnostic.status() .. '' '') or '''' ') %}%{% &ruler ? ( &rulerformat == '' ? '%-14.(%l,%c%V%) %P' : &rulerformat ) : '' %}"
 vim.o.stl = vim.o.statusline
 vim.wo.statusline = vim.o.statusline
 vim.wo.stl = vim.wo.statusline

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -319,33 +319,38 @@ do
   local progress = {}
 
   -- store progress events
-  local progress_group = vim.api.nvim_create_augroup('nvim.ui.progress_status', { clear = true })
-  vim.api.nvim_create_autocmd('Progress', {
-    group = progress_group,
-    desc = 'Track progress messages for statusline',
-    ---@param ev {data: {id: integer, title: string, status: string, percent: integer}}
-    callback = function(ev)
-      if not ev.data or not ev.data.id then
-        return
-      end
-      progress[ev.data.id] = {
-        id = ev.data.id,
-        title = ev.data.title,
-        status = ev.data.status,
-        percent = ev.data.percent or 0,
-      }
+  local progress_group, progress_autocmd = nil, nil
 
-      -- Clear finished items
-      if
-        ev.data.status == 'success'
-        or ev.data.percent == 100
-        or ev.data.status == 'failed'
-        or ev.data.status == 'cancel'
-      then
-        progress[ev.data.id] = nil
-      end
-    end,
-  })
+  ---Initialize progress event listeners
+  local function progress_init()
+    progress_group = vim.api.nvim_create_augroup('nvim.ui.progress_status', { clear = true })
+    progress_autocmd = vim.api.nvim_create_autocmd('Progress', {
+      group = progress_group,
+      desc = 'Track progress messages for statusline',
+      ---@param ev {data: {id: integer, title: string, status: string, percent: integer}}
+      callback = function(ev)
+        if not ev.data or not ev.data.id then
+          return
+        end
+        progress[ev.data.id] = {
+          id = ev.data.id,
+          title = ev.data.title,
+          status = ev.data.status,
+          percent = ev.data.percent or 0,
+        }
+
+        -- Clear finished items
+        if
+          ev.data.status == 'success'
+          or ev.data.percent == 100
+          or ev.data.status == 'failed'
+          or ev.data.status == 'cancel'
+        then
+          progress[ev.data.id] = nil
+        end
+      end,
+    })
+  end
 
   ---Return statusline text summarizing progress messages.
   --- - If none: returns empty string
@@ -375,12 +380,15 @@ do
 
   --- Gets the status of currently running progress messages, in a format
   --- convenient for inclusion in 'statusline'.
-  --- Also returns a list of current progress messages as the second return value.
   ---@return string formatted text of progress status for statusline
-  ---@return ProgressMessage[] list of currently active progress messages
   function M.progress_status()
+    -- Create progress event listener on first call
+    if progress_autocmd == nil then
+      progress_init()
+    end
+
     local running = vim.tbl_values(progress)
-    return progress_status_fmt(running) or '', running
+    return progress_status_fmt(running) or ''
   end
 end
 

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -314,7 +314,8 @@ do
   ---@field percent? integer Percent complete (0–100)
   ---@private
 
-  ---Cache of active progress messages, keyed by msg_id
+  --- Cache of active progress messages, keyed by msg_id
+  --- TODO(justinmk): visibility of "stale" (never-finished) Progress. https://github.com/neovim/neovim/pull/35428#discussion_r2942696157
   ---@type table<integer, ProgressMessage>
   local progress = {}
 

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -308,6 +308,7 @@ end
 
 do
   ---@class ProgressMessage
+  ---@field id? number|string  ID of the progress message
   ---@field title? string   Title of the progress message
   ---@field status string  Status: "running" | "success" | "failed" | "cancel"
   ---@field percent? integer Percent complete (0–100)
@@ -318,7 +319,7 @@ do
   local progress = {}
 
   -- store progress events
-  local progress_group = vim.api.nvim_create_augroup('nvim.status.progress', { clear = true })
+  local progress_group = vim.api.nvim_create_augroup('nvim.ui.progress_status', { clear = true })
   vim.api.nvim_create_autocmd('Progress', {
     group = progress_group,
     desc = 'Track progress messages for statusline',
@@ -328,6 +329,7 @@ do
         return
       end
       progress[ev.data.id] = {
+        id = ev.data.id,
         title = ev.data.title,
         status = ev.data.status,
         percent = ev.data.percent or 0,
@@ -371,31 +373,17 @@ do
     end
   end
 
-  ---@class vim.ui.progress_status.Opts
-  ---@inlinedoc
-  ---
-  ---custom formater for progress messages
-  ---@field fmt? fun(running: ProgressMessage[]):string
-  --
-  --- Function to format the list of running progress messages for statusline
-  ---@param opts? vim.ui.progress_status.Opts Options
-  ---@return string Statusline component text
-  function M.progress_status(opts)
-    vim.validate('opts', opts, 'table', true)
-    if opts ~= nil then
-      vim.validate('fmt', opts.fmt, 'function', true)
-    end
-    if opts == nil or opts.fmt == nil then
-      opts = { fmt = progress_status_fmt }
-    end
+  ---Returns raw list of currently active progress objects.
+  ---@return ProgressMessage[]
+  function M.progress_get_running()
+    return vim.tbl_values(progress)
+  end
 
-    local running = {} ---@type ProgressMessage[]
-    for _, msg in pairs(progress) do
-      if msg.status == 'running' then
-        table.insert(running, msg)
-      end
-    end
-    return opts.fmt(running) or ''
+  --- Function to format the list of running progress messages for statusline
+  ---@return string Statusline component text
+  function M.progress_status()
+    local running = M.progress_get_running()
+    return progress_status_fmt(running) or ''
   end
 end
 

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -306,4 +306,97 @@ function M._get_urls()
   return urls
 end
 
+do
+  ---@class ProgressMessage
+  ---@field title? string   Title of the progress message
+  ---@field status string  Status: "running" | "success" | "failed" | "cancel"
+  ---@field percent? integer Percent complete (0–100)
+  ---@private
+
+  ---Cache of active progress messages, keyed by msg_id
+  ---@type table<integer, ProgressMessage>
+  local progress = {}
+
+  -- store progress events
+  local progress_group = vim.api.nvim_create_augroup('nvim.status.progress', { clear = true })
+  vim.api.nvim_create_autocmd('Progress', {
+    group = progress_group,
+    desc = 'Track progress messages for statusline',
+    ---@param ev {data: {id: integer, title: string, status: string, percent: integer}}
+    callback = function(ev)
+      if not ev.data or not ev.data.id then
+        return
+      end
+      progress[ev.data.id] = {
+        title = ev.data.title,
+        status = ev.data.status,
+        percent = ev.data.percent or 0,
+      }
+
+      -- Clear finished items
+      if
+        ev.data.status == 'success'
+        or ev.data.percent == 100
+        or ev.data.status == 'failed'
+        or ev.data.status == 'cancel'
+      then
+        progress[ev.data.id] = nil
+      end
+    end,
+  })
+
+  ---Return statusline text summarizing progress messages.
+  --- - If none: returns empty string
+  --- - If one running item: "title: 42%"
+  --- - If multiple running items: "Progress: N items AVG%"
+  ---@param running ProgressMessage[]
+  ---@return string
+  local function progress_status_fmt(running)
+    local count = #running
+    if count == 0 then
+      return '' -- nothing to show
+    elseif count == 1 then
+      local progress_item = running[1]
+      if progress_item.title == nil then
+        return string.format('%d%%%% ', progress_item.percent or 0)
+      end
+      return string.format('%s: %d%%%% ', progress_item.title, progress_item.percent or 0)
+    else
+      local sum = 0 ---@type integer
+      for _, progress_item in ipairs(running) do
+        sum = sum + (progress_item.percent or 0)
+      end
+      local avg = math.floor(sum / count)
+      return string.format('Progress: %d items %d%%%% ', count, avg)
+    end
+  end
+
+  ---@class vim.ui.progress_status.Opts
+  ---@inlinedoc
+  ---
+  ---custom formater for progress messages
+  ---@field fmt? fun(running: ProgressMessage[]):string
+  --
+  --- Function to format the list of running progress messages for statusline
+  ---@param opts? vim.ui.progress_status.Opts Options
+  ---@return string Statusline component text
+  function M.progress_status(opts)
+    vim.validate('opts', opts, 'table', true)
+    if opts ~= nil then
+      vim.validate('fmt', opts.fmt, 'function', true)
+    end
+    if opts == nil or opts.fmt == nil then
+      opts = { fmt = progress_status_fmt }
+    end
+
+    local running = {} ---@type ProgressMessage[]
+    for _, msg in pairs(progress) do
+      if msg.status == 'running' then
+        table.insert(running, msg)
+      end
+    end
+    return opts.fmt(running) or ''
+  end
+end
+
 return M

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -326,7 +326,7 @@ do
     progress_group = vim.api.nvim_create_augroup('nvim.ui.progress_status', { clear = true })
     progress_autocmd = vim.api.nvim_create_autocmd('Progress', {
       group = progress_group,
-      desc = 'Track progress messages for statusline',
+      desc = 'Tracks progress messages for vim.ui.progress_status()',
       ---@param ev {data: {id: integer, title: string, status: string, percent: integer}}
       callback = function(ev)
         if not ev.data or not ev.data.id then

--- a/runtime/lua/vim/ui.lua
+++ b/runtime/lua/vim/ui.lua
@@ -373,17 +373,14 @@ do
     end
   end
 
-  ---Returns raw list of currently active progress objects.
-  ---@return ProgressMessage[]
-  function M.progress_get_running()
-    return vim.tbl_values(progress)
-  end
-
-  --- Function to format the list of running progress messages for statusline
-  ---@return string Statusline component text
+  --- Gets the status of currently running progress messages, in a format
+  --- convenient for inclusion in 'statusline'.
+  --- Also returns a list of current progress messages as the second return value.
+  ---@return string formatted text of progress status for statusline
+  ---@return ProgressMessage[] list of currently active progress messages
   function M.progress_status()
-    local running = M.progress_get_running()
-    return progress_status_fmt(running) or ''
+    local running = vim.tbl_values(progress)
+    return progress_status_fmt(running) or '', running
   end
 end
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -8795,6 +8795,7 @@ local options = {
           '%f %h%w%m%r ',
           "%{% v:lua.require('vim._core.util').term_exitcode() %}",
           '%=',
+          "%{% luaeval('(package.loaded[''vim.ui''] and vim.ui.progress_status()) or '''' ')%}",
           "%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}",
           "%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}",
           "%{% &busy > 0 ? '◐ ' : '' %}",

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -1078,22 +1078,6 @@ describe('default statusline', function()
       title = 'terminal(ripgrep)',
     })
     eq('second-item: 20% ', get_progress())
-
-    -- works with custom formater
-    eq(
-      '20/100',
-      exec_lua(function()
-        return vim.ui.progress_status({
-          fmt = function(items)
-            local tot = 0
-            for _, item in ipairs(items) do
-              tot = tot + item.percent
-            end
-            return tostring(math.floor(tot / #items)) .. '/100'
-          end,
-        })
-      end)
-    )
   end)
 end)
 

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -964,6 +964,7 @@ describe('default statusline', function()
       '%f %h%w%m%r ',
       "%{% v:lua.require('vim._core.util').term_exitcode() %}",
       '%=',
+      "%{% luaeval('(package.loaded[''vim.ui''] and vim.ui.progress_status()) or '''' ')%}",
       "%{% &showcmdloc == 'statusline' ? '%-10.S ' : '' %}",
       "%{% exists('b:keymap_name') ? '<'..b:keymap_name..'> ' : '' %}",
       "%{% &busy > 0 ? '◐ ' : '' %}",
@@ -1039,6 +1040,60 @@ describe('default statusline', function()
     command('terminal 9')
     screen:expect({ any = '%[Exit: 9%]' })
     expect_exitcode(9)
+  end)
+
+  it('shows and updates progress status', function()
+    local function get_progress()
+      return exec_lua(function()
+        local stl_str = vim.ui.progress_status()
+        return vim.api.nvim_eval_statusline(stl_str, {}).str
+      end)
+    end
+
+    eq('', get_progress())
+    ---@type integer|string
+    local id1 = api.nvim_echo(
+      { { 'searching...' } },
+      true,
+      { kind = 'progress', title = 'test', status = 'running', percent = 10 }
+    )
+    eq('test: 10% ', get_progress())
+    api.nvim_echo(
+      { { 'searching' } },
+      true,
+      { id = id1, kind = 'progress', percent = 50, status = 'running', title = 'terminal(ripgrep)' }
+    )
+    eq('terminal(ripgrep): 50% ', get_progress())
+    api.nvim_echo(
+      { { 'searching...' } },
+      true,
+      { kind = 'progress', title = 'second-item', status = 'running', percent = 20 }
+    )
+    eq('Progress: 2 items 35% ', get_progress())
+    api.nvim_echo({ { 'searching' } }, true, {
+      id = id1,
+      kind = 'progress',
+      percent = 100,
+      status = 'success',
+      title = 'terminal(ripgrep)',
+    })
+    eq('second-item: 20% ', get_progress())
+
+    -- works with custom formater
+    eq(
+      '20/100',
+      exec_lua(function()
+        return vim.ui.progress_status({
+          fmt = function(items)
+            local tot = 0
+            for _, item in ipairs(items) do
+              tot = tot + item.percent
+            end
+            return tostring(math.floor(tot / #items)) .. '/100'
+          end,
+        })
+      end)
+    )
   end)
 end)
 

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -944,6 +944,7 @@ describe('default statusline', function()
     screen = Screen.new(60, 16)
     screen:add_extra_attr_ids {
       [100] = { foreground = Screen.colors.Magenta1, bold = true },
+      [131] = { foreground = Screen.colors.NvimDarkGreen },
     }
     command('set laststatus=2')
     command('set ruler')
@@ -1043,10 +1044,11 @@ describe('default statusline', function()
   end)
 
   it('shows and updates progress status', function()
+    exec_lua("vim.o.statusline = ''")
     local function get_progress()
       return exec_lua(function()
-        local stl_str = vim.ui.progress_status()
-        return vim.api.nvim_eval_statusline(stl_str, {}).str
+        local stl_str, msgs = vim.ui.progress_status()
+        return vim.api.nvim_eval_statusline(stl_str, {}).str, msgs
       end)
     end
 
@@ -1058,18 +1060,28 @@ describe('default statusline', function()
       { kind = 'progress', title = 'test', status = 'running', percent = 10 }
     )
     eq('test: 10% ', get_progress())
+
     api.nvim_echo(
       { { 'searching' } },
       true,
       { id = id1, kind = 'progress', percent = 50, status = 'running', title = 'terminal(ripgrep)' }
     )
-    eq('terminal(ripgrep): 50% ', get_progress())
+    local status_text, progress_msgs = get_progress()
+    eq('terminal(ripgrep): 50% ', status_text)
+    eq({ { id = 1, percent = 50, status = 'running', title = 'terminal(ripgrep)' } }, progress_msgs)
+
     api.nvim_echo(
       { { 'searching...' } },
       true,
       { kind = 'progress', title = 'second-item', status = 'running', percent = 20 }
     )
-    eq('Progress: 2 items 35% ', get_progress())
+    status_text, progress_msgs = get_progress()
+    eq('Progress: 2 items 35% ', status_text)
+    eq({
+      { id = 1, percent = 50, status = 'running', title = 'terminal(ripgrep)' },
+      { id = 2, percent = 20, status = 'running', title = 'second-item' },
+    }, progress_msgs)
+
     api.nvim_echo({ { 'searching' } }, true, {
       id = id1,
       kind = 'progress',
@@ -1077,7 +1089,17 @@ describe('default statusline', function()
       status = 'success',
       title = 'terminal(ripgrep)',
     })
-    eq('second-item: 20% ', get_progress())
+    status_text, progress_msgs = get_progress()
+    eq('second-item: 20% ', status_text)
+    eq({ { id = 2, percent = 20, status = 'running', title = 'second-item' } }, progress_msgs)
+
+    exec('redrawstatus')
+    screen:expect([[
+      ^                                                           |
+      {1:~                                                           }|*13
+      {3:[No Name]                second-item: 20% 0,0-1          All}|
+      {131:terminal(ripgrep)}: {19:100% }searching                           |
+    ]])
   end)
 end)
 

--- a/test/functional/ui/statusline_spec.lua
+++ b/test/functional/ui/statusline_spec.lua
@@ -1047,8 +1047,8 @@ describe('default statusline', function()
     exec_lua("vim.o.statusline = ''")
     local function get_progress()
       return exec_lua(function()
-        local stl_str, msgs = vim.ui.progress_status()
-        return vim.api.nvim_eval_statusline(stl_str, {}).str, msgs
+        local stl_str = vim.ui.progress_status()
+        return vim.api.nvim_eval_statusline(stl_str, {}).str
       end)
     end
 
@@ -1066,21 +1066,14 @@ describe('default statusline', function()
       true,
       { id = id1, kind = 'progress', percent = 50, status = 'running', title = 'terminal(ripgrep)' }
     )
-    local status_text, progress_msgs = get_progress()
-    eq('terminal(ripgrep): 50% ', status_text)
-    eq({ { id = 1, percent = 50, status = 'running', title = 'terminal(ripgrep)' } }, progress_msgs)
+    eq('terminal(ripgrep): 50% ', get_progress())
 
     api.nvim_echo(
       { { 'searching...' } },
       true,
       { kind = 'progress', title = 'second-item', status = 'running', percent = 20 }
     )
-    status_text, progress_msgs = get_progress()
-    eq('Progress: 2 items 35% ', status_text)
-    eq({
-      { id = 1, percent = 50, status = 'running', title = 'terminal(ripgrep)' },
-      { id = 2, percent = 20, status = 'running', title = 'second-item' },
-    }, progress_msgs)
+    eq('Progress: 2 items 35% ', get_progress())
 
     api.nvim_echo({ { 'searching' } }, true, {
       id = id1,
@@ -1089,13 +1082,11 @@ describe('default statusline', function()
       status = 'success',
       title = 'terminal(ripgrep)',
     })
-    status_text, progress_msgs = get_progress()
-    eq('second-item: 20% ', status_text)
-    eq({ { id = 2, percent = 20, status = 'running', title = 'second-item' } }, progress_msgs)
+    eq('second-item: 20% ', get_progress())
 
     exec('redrawstatus')
     screen:expect([[
-      ^                                                           |
+      ^                                                            |
       {1:~                                                           }|*13
       {3:[No Name]                second-item: 20% 0,0-1          All}|
       {131:terminal(ripgrep)}: {19:100% }searching                           |


### PR DESCRIPTION
Follow up to #34846

### Problem
Currently, statusline by default doesn't show progress status.

### Solution
Add progress-message support to the default statusline.

### How it works
Displays statusline text summarizing 'running' progress messages.
 - If none: returns empty string
 - If one running item: "title:  percent%"
 - If multiple running items: "Progress: N items avg-percent%"


### Examples
<img width="1920" height="27" alt="image" src="https://github.com/user-attachments/assets/799716cd-7d27-45ef-b642-a8b492d970a1" />
<img width="1920" height="27" alt="image" src="https://github.com/user-attachments/assets/88a86562-5cd9-40b3-82a5-fbccc4dfb618" />

