### PR TITLE
docs: fix doc from `system.run` to correctly represent the expected type in the overload

### DIFF
--- a/runtime/lua/vim/_system.lua
+++ b/runtime/lua/vim/_system.lua
@@ -503,7 +503,7 @@ end
 ---   asynchronously. See return of SystemObj:wait().
 ---
 --- @return vim.SystemObj
---- @overload fun(cmd: string, on_exit: fun(out: vim.SystemCompleted)): vim.SystemObj
+--- @overload fun(cmd: string[], on_exit: fun(out: vim.SystemCompleted)): vim.SystemObj
 function vim.system(cmd, opts, on_exit)
   if type(opts) == 'function' then
     on_exit = opts


### PR DESCRIPTION
This is just a small fix in the docs of the `vim.system` lua function to correctly represent the expected type in the overload documentation. The `run` function validates explicitly for the `cmd` to be a table and the current docs states it can be a string.