### PR TITLE
fix(build): workaround errors in zig build due to stale cache

### DIFF
--- a/runtime/gen_runtime.zig
+++ b/runtime/gen_runtime.zig
@@ -31,6 +31,7 @@ pub fn nvim_gen_runtime(
         const file = gen_step.addOutputFileArg("tags");
         _ = gen_runtime.addCopyFile(file, "doc/tags");
         gen_step.addDirectoryArg(b.path("runtime/doc"));
+        gen_step.has_side_effects = true; // workaround: missing detection of input changes
     }
 
     return gen_runtime;


### PR DESCRIPTION
addDirectoryArg with a source dir is not enough to depend on changes to invidiual files. as a workaround, mark this step as having side-effects (always being run) for now.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
