### PR TITLE
vim-patch:9.1.1665: Outdated comment in eval.c

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2650,8 +2650,6 @@ int eval0_simple_funccal(char *arg, typval_T *rettv, exarg_T *eap, evalarg_T *co
 /// "arg" must point to the first non-white of the expression.
 /// "arg" is advanced to the next non-white after the recognized expression.
 ///
-/// Note: "rettv.v_lock" is not set.
-///
 /// @return  OK or FAIL.
 int eval1(char **arg, typval_T *rettv, evalarg_T *const evalarg)
 {


### PR DESCRIPTION
#### vim-patch:9.1.1665: Outdated comment in eval.c

Problem:  Outdated comment in eval.c.
Solution: Remove the comment, which is no longer true after 8.2.1672.
          Also fix a typo in version9.txt (zeertzjq).

closes: vim/vim#18077

https://github.com/vim/vim/commit/5d3c39af2a54996dc365b5b38e3eaa6c971ae33a