### PR TITLE
vim-patch:9.1.1667: Another outdated comment in eval.c

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2553,7 +2553,6 @@ void clear_evalarg(evalarg_T *evalarg, exarg_T *eap)
 /// Handle zero level expression.
 /// This calls eval1() and handles error message and nextcmd.
 /// Put the result in "rettv" when returning OK and "evaluate" is true.
-/// Note: "rettv.v_lock" is not set.
 ///
 /// @param evalarg  can be NULL, &EVALARG_EVALUATE or a pointer.
 ///

--- a/test/old/testdir/test_filter_map.vim
+++ b/test/old/testdir/test_filter_map.vim
@@ -222,6 +222,16 @@ func Test_mapnew_dict()
 
   const dconst = #{one: 1, two: 2, three: 3}
   call assert_equal(#{one: 2, two: 3, three: 4}, mapnew(dconst, {_, v -> v + 1}))
+
+  " return value of mapnew() can be modified
+  let dout = mapnew(dconst, {k, v -> $'{k}={v}'})
+  let dout.one ..= '!'
+  call assert_equal(#{one: 'one=1!', two: 'two=2', three: 'three=3'}, dout)
+  unlet dout.three
+  call assert_equal(#{one: 'one=1!', two: 'two=2'}, dout)
+  " original Dict is still locked
+  call assert_fails('unlet dconst.three', 'E741:')
+  call assert_fails('let dconst.one += 1', 'E741:')
 endfunc
 
 func Test_mapnew_list()
@@ -232,6 +242,16 @@ func Test_mapnew_list()
 
   const lconst = [1, 2, 3]
   call assert_equal([2, 3, 4], mapnew(lconst, {_, v -> v + 1}))
+
+  " return value of mapnew() can be modified
+  let lout = mapnew(lconst, {k, v -> $'{k}={v}'})
+  let lout[0] ..= '!'
+  call assert_equal(['0=1!', '1=2', '2=3'], lout)
+  unlet lout[2]
+  call assert_equal(['0=1!', '1=2'], lout)
+  " original List is still locked
+  call assert_fails('unlet lconst[2]', 'E741:')
+  call assert_fails('let lconst[0] += 1', 'E741:')
 endfunc
 
 func Test_mapnew_blob()


### PR DESCRIPTION
#### vim-patch:9.1.1667: Another outdated comment in eval.c

Problem:  Another outdated comment in eval.c (after 9.1.1665).
Solution: Remove that comment as well. Add a few more tests for mapnew()
          that fail without patch 8.2.1672 (zeertzjq).

closes: vim/vim#18089

https://github.com/vim/vim/commit/6b5671180440f07f9f6955f46bab380bdc23f950