### PR TITLE
fix(treesitter): show capture-level priorities in `:Inspect`

### DIFF
--- a/runtime/lua/vim/_inspector.lua
+++ b/runtime/lua/vim/_inspector.lua
@@ -200,7 +200,9 @@ function vim.show_pos(bufnr, row, col, filter)
         capture,
         string.format(
           'priority: %d   language: %s',
-          capture.metadata.priority or vim.hl.priorities.treesitter,
+          capture.metadata.priority
+            or (capture.metadata[capture.id] and capture.metadata[capture.id].priority)
+            or vim.hl.priorities.treesitter,
           capture.lang
         )
       )


### PR DESCRIPTION
Fixes #35430

(I spent an annoying amount of time trying to add a test for this PR, and failed)

Interestingly, in the highlighter, capture-level priorities have lower precedence than pattern-level ones. Maybe this should be revisited? At a later time...