### PR TITLE
vim-patch:8.1.{579,654,655},9.1.0546

### DIFF
--- a/test/functional/legacy/028_source_ctrl_v_spec.lua
+++ b/test/functional/legacy/028_source_ctrl_v_spec.lua
@@ -5,10 +5,10 @@ local n = require('test.functional.testnvim')()
 local clear, feed, insert = n.clear, n.feed, n.insert
 local feed_command, expect = n.feed_command, n.expect
 
-describe('CTRL-V at the end of the line', function()
-  setup(clear)
+describe('028', function()
+  before_each(clear)
 
-  it('is working', function()
+  it('CTRL-V at the end of the line is working', function()
     insert([[
       firstline
       map __1 afirst
@@ -33,6 +33,21 @@ describe('CTRL-V at the end of the line', function()
     expect([[
       sd
       map __2 asdsecondsdsd0map __5 asd0fifth]])
+  end)
+
+  it('CTRL-X/CTRL-A is working', function()
+    insert([[
+      12352
+
+      12354]])
+    feed_command('/12352')
+    feed('<C-A>')
+    feed_command('/12354')
+    feed('<C-X>')
+    expect([[
+      12353
+
+      12353]])
   end)
 
   teardown(function()


### PR DESCRIPTION
Problem:  vim-tiny fails on CTRL-X/CTRL-A
          (Rob Foehl, after 9.1.0172)
Solution: Move #ifdefs, so that after changing the line in del_bytes,
          the cached textlen value is invalidated

closes: vim/vim#15178

https://github.com/vim/vim/commit/03acd4761be1c2766d3ec17534ea63cdf8dd565d

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

----

Trying to track down problems with my port v8.2.0845 based on the N/A patches that affect memline.c

- 8.1.0581 is still N/A is because of 9.0.0013 (https://github.com/neovim/neovim/pull/12662)