### PR TITLE
vim-patch:9.1.1681: tests: no test for actually moving cursor with 'acl'

### DIFF
--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1557,8 +1557,24 @@ describe('completion', function()
       {1:~                                                           }|*5
       {5:-- INSERT --}                                                |
     ]])
+    feed('<Up>')
+    screen:expect([[
+      foo                                                         |
+      foobar                                                      |
+      f^oobarbaz                                                   |
+      f                                                           |
+      {1:~                                                           }|*5
+      {5:-- INSERT --}                                                |
+    ]])
     feed('<Down>')
-    screen:expect_unchanged()
+    screen:expect([[
+      foo                                                         |
+      foobar                                                      |
+      foobarbaz                                                   |
+      f^                                                           |
+      {1:~                                                           }|*5
+      {5:-- INSERT --}                                                |
+    ]])
 
     feed('<esc>')
   end)

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -5608,7 +5608,6 @@ func Test_completetimeout_autocompletetimeout()
 
   " Clock does not have fine granularity, so checking 'elapsed time' is only
   " approximate. We can only test that some type of timeout is enforced.
-  call feedkeys("\<Esc>", 'xt!')
   call setline(1, map(range(60000), '"foo" . v:val'))
   set completetimeout=1
   call feedkeys("Gof\<C-N>\<F2>\<Esc>0", 'xt!')
@@ -5626,7 +5625,6 @@ func Test_completetimeout_autocompletetimeout()
   let match_count = len(b:matches->mapnew('v:val.word'))
   call assert_true(match_count < 50000)
 
-  call feedkeys("\<Esc>", 'xt!')
   set complete& omnifunc& autocomplete& autocompletetimeout& completetimeout&
   bwipe!
   %d
@@ -5676,8 +5674,10 @@ func Test_autocompletedelay()
 
   " When menu is not open Up/Down moves cursor to different line
   call term_sendkeys(buf, "\<Esc>Sf")
-  call term_sendkeys(buf, "\<Down>")
+  call term_sendkeys(buf, "\<Up>")
   call VerifyScreenDump(buf, 'Test_autocompletedelay_10', {})
+  call term_sendkeys(buf, "\<Down>")
+  call VerifyScreenDump(buf, 'Test_autocompletedelay_11', {})
 
   call term_sendkeys(buf, "\<esc>")
   call StopVimInTerminal(buf)


### PR DESCRIPTION
#### vim-patch:9.1.1681: tests: no test for actually moving cursor with 'acl'

Problem:  tests: no test for actually moving cursor when menu is not
          open with 'autocompletedelay'.
Solution: Use \<Up> first in the test. Also remove two unnecessary \<Esc>s
          in completion timeout test (zeertzjq).

closes: vim/vim#18097

https://github.com/vim/vim/commit/e8b99ff6d58b69639c29756edbfc655af38f9f03
