### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/ftplugin/fstab.vim
+++ b/runtime/ftplugin/fstab.vim
@@ -2,10 +2,11 @@
 " Language: fstab file
 " Maintainer: Radu Dineiu <radu.dineiu@gmail.com>
 " URL: https://raw.github.com/rid9/vim-fstab/master/ftplugin/fstab.vim
-" Last Change: 2025 Mar 31
-" Version: 1.0.1
+" Last Change: 2025 Aug 21
+" Version: 1.1.0
 "
 " Changelog:
+" - 2025 Aug 21 added support for mtab
 " - 2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
 " - 2025 Mar 31 added setlocal formatoptions-=t
 "
@@ -20,6 +21,10 @@ let b:did_ftplugin = 1
 setlocal commentstring=#\ %s
 setlocal formatoptions-=t
 
-let b:undo_ftplugin = "setlocal commentstring< formatoptions<"
+if expand('%:t') == 'mtab'
+  let b:fstab_enable_mtab = 1
+endif
+
+let b:undo_ftplugin = "setlocal commentstring< | setlocal formatoptions<"
 
 " vim: ts=8 ft=vim

--- a/runtime/syntax/fstab.vim
+++ b/runtime/syntax/fstab.vim
@@ -2,8 +2,8 @@
 " Language: fstab file
 " Maintainer: Radu Dineiu <radu.dineiu@gmail.com>
 " URL: https://raw.github.com/rid9/vim-fstab/master/syntax/fstab.vim
-" Last Change: 2024 Jul 11
-" Version: 1.6.4
+" Last Change: 2025 Aug 21
+" Version: 1.7.0
 "
 " Credits:
 "   David Necas (Yeti) <yeti@physics.muni.cz>
@@ -18,6 +18,9 @@
 "
 "   let fstab_unknown_device_errors = 0
 "     do not highlight unknown devices as errors
+"
+" Changelog:
+" - 2025 Aug 21 added support for mtab
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -401,6 +404,28 @@ syn match fsFreqPass /\s\+.\{-}$/ contains=@fsFreqPassCluster,@fsGeneralCluster 
 
 " Whole line comments
 syn match fsCommentLine /^#.*$/ contains=@Spell
+
+if exists('b:fstab_enable_mtab') && b:fstab_enable_mtab == 1
+  " mtab
+  " ----
+  syn keyword fsDeviceKeyword contained binfmt_misc bpf cgroup2 configfs debugfs efivarfs fusectl hugetlbfs mqueue portal pstore securityfs udev ramfs
+  syn match fsDeviceKeyword contained /^systemd-1/
+  syn match fsDeviceKeyword contained /^\/dev\S\+/
+
+  " devpts
+  syn match fsOptionsKeywords contained /\<ptmxmode=/ nextgroup=fsOptionsNumber
+
+  " cgroup2
+  syn keyword fsTypeKeyword contained cgroup2
+  syn keyword fsOptionsKeywords contained nsdelegate memory_recursiveprot
+
+  " hugetlbfs
+  syn match fsOptionsKeywords contained /\<pagesize=/ nextgroup=fsOptionsString
+
+  " systemd
+  syn match fsOptionsKeywords contained /\<\%(pgrp\|timeout\|minproto\|maxproto\|pipe_ino\)=/ nextgroup=fsOptionsNumber
+  syn keyword fsOptionsKeywords contained direct
+endif
 
 hi def link fsOperator Operator
 hi def link fsComment Comment

--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -1,10 +1,11 @@
 " Vim syntax file
 " Language:	Python
 " Maintainer:	Zvezdan Petkovic <zpetkovic@acm.org>
-" Last Change:	2025 Aug 18
+" Last Change:	2025 Aug 23
 " Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "		Rob B
+"		Jon Parise
 "
 "		This version is a major rewrite by Zvezdan Petkovic.
 "
@@ -112,6 +113,7 @@ syn keyword pythonAsync		async await
 " for more on this.
 syn match   pythonConditional   "^\s*\zscase\%(\s\+.*:.*$\)\@="
 syn match   pythonConditional   "^\s*\zsmatch\%(\s\+.*:\s*\%(#.*\)\=$\)\@="
+syn match   pythonStatement     "\<type\ze\s\+\h\w*" nextgroup=pythonType skipwhite
 
 " These names are special by convention. While they aren't real keywords,
 " giving them distinct highlighting provides a nice visual cue.
@@ -128,22 +130,23 @@ syn match   pythonDecoratorName	"@\s*\h\%(\w\|\.\)*" display contains=pythonDeco
 " Single line multiplication.
 syn match   pythonMatrixMultiply
       \ "\%(\w\|[])]\)\s*@"
-      \ contains=ALLBUT,pythonDecoratorName,pythonDecorator,pythonClass,pythonFunction,pythonDoctestValue
+      \ contains=ALLBUT,pythonDecoratorName,pythonDecorator,pythonClass,pythonFunction,pythonType,pythonDoctestValue
       \ transparent
 " Multiplication continued on the next line after backslash.
 syn match   pythonMatrixMultiply
       \ "[^\\]\\\s*\n\%(\s*\.\.\.\s\)\=\s\+@"
-      \ contains=ALLBUT,pythonDecoratorName,pythonDecorator,pythonClass,pythonFunction,pythonDoctestValue
+      \ contains=ALLBUT,pythonDecoratorName,pythonDecorator,pythonClass,pythonFunction,pythonType,pythonDoctestValue
       \ transparent
 " Multiplication in a parenthesized expression over multiple lines with @ at
 " the start of each continued line; very similar to decorators and complex.
 syn match   pythonMatrixMultiply
       \ "^\s*\%(\%(>>>\|\.\.\.\)\s\+\)\=\zs\%(\h\|\%(\h\|[[(]\).\{-}\%(\w\|[])]\)\)\s*\n\%(\s*\.\.\.\s\)\=\s\+@\%(.\{-}\n\%(\s*\.\.\.\s\)\=\s\+@\)*"
-      \ contains=ALLBUT,pythonDecoratorName,pythonDecorator,pythonClass,pythonFunction,pythonDoctestValue
+      \ contains=ALLBUT,pythonDecoratorName,pythonDecorator,pythonClass,pythonFunction,pythonType,pythonDoctestValue
       \ transparent
 
 syn match   pythonClass		"\h\w*" display contained
 syn match   pythonFunction	"\h\w*" display contained
+syn match   pythonType		"\h\w*" display contained
 
 syn match   pythonComment	"#.*$" contains=pythonTodo,@Spell
 syn keyword pythonTodo		FIXME NOTE NOTES TODO XXX contained
@@ -300,10 +303,12 @@ if !exists("python_no_builtin_highlight")
   syn keyword pythonBuiltin	memoryview min next object oct open ord pow
   syn keyword pythonBuiltin	print property range repr reversed round set
   syn keyword pythonBuiltin	setattr slice sorted staticmethod str sum super
-  syn keyword pythonBuiltin	tuple type vars zip __import__
+  syn keyword pythonBuiltin	tuple vars zip __import__
+  " only match `type` as a builtin when it's not followed by an identifier
+  syn match   pythonBuiltin	"\<type\ze\(\s\+\h\w*\)\@!"
   " avoid highlighting attributes as builtins
   syn match   pythonAttribute	/\.\h\w*/hs=s+1
-	\ contains=ALLBUT,pythonBuiltin,pythonClass,pythonFunction,pythonAsync
+	\ contains=ALLBUT,pythonBuiltin,pythonClass,pythonFunction,pythonType,pythonAsync
 	\ transparent
 endif
 
@@ -360,7 +365,7 @@ if !exists("python_no_doctest_highlight")
   if !exists("python_no_doctest_code_highlight")
     syn region pythonDoctest
 	  \ start="^\s*>>>\s" end="^\s*$"
-	  \ contained contains=ALLBUT,pythonDoctest,pythonClass,pythonFunction,@Spell
+	  \ contained contains=ALLBUT,pythonDoctest,pythonClass,pythonFunction,pythonType,@Spell
     syn region pythonDoctestValue
 	  \ start=+^\s*\%(>>>\s\|\.\.\.\s\|"""\|'''\)\@!\S\++ end="$"
 	  \ contained
@@ -387,6 +392,7 @@ hi def link pythonDecorator		Define
 hi def link pythonDecoratorName		Function
 hi def link pythonClass			Structure
 hi def link pythonFunction		Function
+hi def link pythonType			Type
 hi def link pythonComment		Comment
 hi def link pythonTodo			Todo
 hi def link pythonString		String

--- a/runtime/syntax/sh.vim
+++ b/runtime/syntax/sh.vim
@@ -16,7 +16,8 @@
 "		2025 May 10 improve wildcard character class lists
 "		2025 May 21 improve supported KornShell features
 "		2025 Jun 16 change how sh_fold_enabled is reset (#17557)
-"		2025 Jul 18 properly delete :commands #17785
+"		2025 Jul 18 properly delete :commands (#17785)
+"		2025 Aug 23 bash: add support for ${ cmd;} and ${|cmd;} (#18084)
 " }}}
 " Version:		208
 " Former URL:		http://www.drchip.org/astronaut/vim/index.html#SYNTAX_SH
@@ -474,6 +475,9 @@ if exists("b:is_kornshell") || exists("b:is_bash") || exists("b:is_posix")
   if exists("b:is_mksh") || exists("b:generic_korn")
    syn region shValsub matchgroup=shCmdSubRegion start="\${|"  skip='\\\\\|\\.' end="}"  contains=@shCommandSubList
   endif
+ elseif exists("b:is_bash")
+  syn region shSubshare matchgroup=shCmdSubRegion start="\${\ze[ \t\n]"  skip='\\\\\|\\.' end="\zs[;\n][ \t\n]*}"  contains=@shCommandSubList
+  syn region shValsub matchgroup=shCmdSubRegion start="\${|"  skip='\\\\\|\\.' end="[;\n][ \t\n]*}"  contains=@shCommandSubList
  endif
  syn region shArithmetic matchgroup=shArithRegion  start="\$((" skip='\\\\\|\\.' end="))" contains=@shArithList
  syn region shArithmetic matchgroup=shArithRegion  start="\$\[" skip='\\\\\|\\.' end="\]" contains=@shArithList
@@ -677,6 +681,8 @@ if exists("b:is_kornshell") && !exists("b:is_ksh88")
  else
   syn region shDeref	matchgroup=PreProc start="\${\ze[^ \t\n<]" end="}"	contains=@shDerefList,shDerefVarArray nextgroup=shSpecialStart
  endif
+elseif exists("b:is_bash")
+ syn region shDeref	matchgroup=PreProc start="\${\ze[^ \t\n|]" end="}"	contains=@shDerefList,shDerefVarArray nextgroup=shSpecialStart
 else
  syn region shDeref	matchgroup=PreProc start="\${" end="}"			contains=@shDerefList,shDerefVarArray nextgroup=shSpecialStart
 endif


### PR DESCRIPTION
#### vim-patch:f66674c: runtime(fstab): Added mtab support to fstab syntax.

closes: vim/vim#18074

https://github.com/vim/vim/commit/f66674cf429aa1fac79e522b45372d7e3d37a902

Co-authored-by: Radu Dineiu <radu.dineiu@gmail.com>


#### vim-patch:e06d81f: runtime(sh): add syntax highlighting support for ${ cmd;} and ${|cmd;}

bash 5.3 (released July 2025) added support for ${ cmd;} and
${|cmd;} style command substitution, which is similar (but not
identical) to ksh/mksh.

closes: vim/vim#18084

https://github.com/vim/vim/commit/e06d81fe675794d6e849cfa78e31a78c8001bbe5

Co-authored-by: Kevin Pulo <kevin.pulo@mongodb.com>


#### vim-patch:99964e2: runtime(python): support 'type's soft keyword form

`type` became a soft keyword in Python 3.12. In that form, it is a
statement that declares a type alias:

    # type_stmt ::= 'type' identifier [type_params] "=" expression
    type Point = tuple[float, float]

To implement support for this, this change does three things:

1. adds a `pythonType` group (linked to `Type`)
2. matches `type` followed by an identifier as `pythonStatement`
3. continues to match `type` in other forms as `pythonBuiltin`

Ref:
- https://docs.python.org/3/reference/lexical_analysis.html#soft-keywords
- https://docs.python.org/3/reference/simple_stmts.html#the-type-statement

closes: vim/vim#18090

https://github.com/vim/vim/commit/99964e2ea704465f25207c519fefb2bb6d6931bb

Co-authored-by: Jon Parise <jon@indelible.org>