### PR TITLE
fix(lsp): treat nil inlay hint result as empty array

### DIFF
--- a/runtime/lua/vim/lsp/inlay_hint.lua
+++ b/runtime/lua/vim/lsp/inlay_hint.lua
@@ -44,9 +44,9 @@ function M.on_inlayhint(err, result, ctx)
     return
   end
   local bufnr = assert(ctx.bufnr)
+
   if
     util.buf_versions[bufnr] ~= ctx.version
-    or not result
     or not api.nvim_buf_is_loaded(bufnr)
     or not bufstates[bufnr].enabled
   then
@@ -60,6 +60,9 @@ function M.on_inlayhint(err, result, ctx)
   end
   local client_hints = bufstate.client_hints
   local client = assert(vim.lsp.get_client_by_id(client_id))
+
+  -- If there's no error but the result is nil, clear existing hints.
+  result = result or {}
 
   local new_lnum_hints = vim.defaulttable()
   local num_unprocessed = #result


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Fixes https://github.com/neovim/neovim/issues/35110

`gopls` seems to send a nil result when there are no inlay hints for the buffer. [The protocol](https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#textDocument_inlayHint) allows for the server to send an array or nil, and it isn't clear what nil should represent. I think it's reasonable to treat it as an empty array though.