### PR TITLE
feat(lua): ordereddict

### DIFF
--- a/runtime/lua/vim/_ordereddict.lua
+++ b/runtime/lua/vim/_ordereddict.lua
@@ -1,0 +1,71 @@
+-- other names: indexmap (rust), or just "dict" ...
+local M = {}
+M.__index = M
+
+-- Creates a new ordered dict.
+function M.new()
+  return setmetatable({
+    _keys = {}, -- Ordered keys.
+    _vals = {}, -- Unordered key-value pairs.
+  }, M)
+end
+
+function M:set(key, value)
+  if self._vals[key] == nil then
+    table.insert(self._keys, key)
+  end
+  self._vals[key] = value
+end
+
+function M:get(key)
+  return self._vals[key]
+end
+
+function M:remove(key)
+  if self._vals[key] == nil then
+    return false
+  end
+  -- Remove the value.
+  self._vals[key] = nil
+  -- Remove from _keys
+  for i, k in ipairs(self._keys) do
+    if k == key then
+      table.remove(self._keys, i)
+      return true
+    end
+  end
+  return false
+end
+
+function M:pop()
+  local key = self._keys[#self._keys]
+  if not key then
+    return nil
+  end
+  local val = self._vals[key]
+  self._vals[key] = nil
+  table.remove(self._keys)
+  return key, val
+end
+
+--- Gets the item count.
+function M:len()
+  return #self._keys
+end
+
+-- Iterates over key-value pairs in insertion order.
+function M:__call()
+  local i = 0
+  local keys = self._keys
+  local vals = self._vals
+  return function()
+    i = i + 1
+    local k = keys[i]
+    if k ~= nil then
+      return k, vals[k]
+    end
+    return nil
+  end
+end
+
+return M

--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -419,7 +419,7 @@ end
 
 --- @param config vim.lsp.Config
 local function validate_config(config)
-  validate('cmd', config.cmd, validate_cmd, 'expected function or table with executable command')
+  validate('cmd', config.cmd, validate_cmd, 'function or table with executable command')
   validate('reuse_client', config.reuse_client, 'function', true)
   validate('filetypes', config.filetypes, 'table', true)
 end

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -1273,7 +1273,7 @@ local function reset_defaults(bufnr)
 end
 
 --- @private
---- Invoked on client exit.
+--- Invoked on server exit.
 ---
 --- @param code integer) exit code of the process
 --- @param signal integer the signal used to terminate (if any)
@@ -1299,7 +1299,7 @@ function Client:_on_exit(code, signal)
     end
     if code ~= 0 or (signal ~= 0 and signal ~= 15) then
       local msg = string.format(
-        'Client %s quit with exit code %s and signal %s. Check log for errors: %s',
+        'LSP server "%s" exited (code: %s, signal: %s). Check log for errors: %s',
         self and self.name or 'unknown',
         code,
         signal,

--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -21,10 +21,9 @@
 --- - "ERROR" messages containing "stderr" only indicate that the log was sent to stderr. Many
 ---   servers send harmless messages via stderr.
 
-local log = {}
+local M = {}
 
 local log_levels = vim.log.levels
-
 local protocol = require('vim.lsp.protocol')
 
 --- Log level dictionary with reverse lookup as well.
@@ -34,7 +33,7 @@ local protocol = require('vim.lsp.protocol')
 --- Level numbers begin with "TRACE" at 0
 --- @type table<string,integer> | table<integer, string>
 --- @nodoc
-log.levels = vim.deepcopy(log_levels)
+M.levels = vim.deepcopy(log_levels)
 
 -- Default log level is warn.
 local current_log_level = log_levels.WARN
@@ -84,12 +83,12 @@ vim.fn.mkdir(vim.fn.stdpath('log') --[[@as string]], 'p')
 
 --- Returns the log filename.
 ---@return string log filename
-function log.get_filename()
+function M.get_filename()
   return logfilename
 end
 
 --- @param s string
-function log._set_filename(s)
+function M._set_filename(s)
   logfilename = s
 end
 
@@ -131,10 +130,10 @@ end
 for level, levelnr in pairs(log_levels) do
   -- Also export the log level on the root object.
   ---@diagnostic disable-next-line: no-unknown
-  log[level] = levelnr
+  M[level] = levelnr
 
   -- Add a reverse lookup.
-  log.levels[levelnr] = level
+  M.levels[levelnr] = level
 end
 
 --- @param level string
@@ -162,37 +161,37 @@ end
 -- log at that level (if applicable, it is checked either way).
 
 --- @nodoc
-log.debug = create_logger('DEBUG')
+M.debug = create_logger('DEBUG')
 
 --- @nodoc
-log.error = create_logger('ERROR')
+M.error = create_logger('ERROR')
 
 --- @nodoc
-log.info = create_logger('INFO')
+M.info = create_logger('INFO')
 
 --- @nodoc
-log.trace = create_logger('TRACE')
+M.trace = create_logger('TRACE')
 
 --- @nodoc
-log.warn = create_logger('WARN')
+M.warn = create_logger('WARN')
 
 --- Sets the current log level.
 ---@param level (string|integer) One of |vim.log.levels|
-function log.set_level(level)
+function M.set_level(level)
   vim.validate('level', level, { 'string', 'number' })
 
   if type(level) == 'string' then
     current_log_level =
-      assert(log.levels[level:upper()], string.format('Invalid log level: %q', level))
+      assert(M.levels[level:upper()], string.format('Invalid log level: %q', level))
   else
-    assert(log.levels[level], string.format('Invalid log level: %d', level))
+    assert(M.levels[level], string.format('Invalid log level: %d', level))
     current_log_level = level
   end
 end
 
 --- Gets the current log level.
 ---@return integer current log level
-function log.get_level()
+function M.get_level()
   return current_log_level
 end
 
@@ -200,7 +199,7 @@ end
 --- be written to the log file.
 ---@param handle fun(level:string, ...): string? Function to apply to log entries. The default will log the level,
 ---date, source and line number of the caller, followed by the arguments.
-function log.set_format_func(handle)
+function M.set_format_func(handle)
   vim.validate('handle', handle, function(h)
     return type(h) == 'function' or h == vim.inspect
   end, false, 'handle must be a function')
@@ -212,7 +211,7 @@ end
 ---@deprecated
 ---@param level integer log level
 ---@return boolean : true if would log, false if not
-function log.should_log(level)
+function M.should_log(level)
   vim.deprecate('vim.lsp.log.should_log', 'vim.lsp.log.set_format_func', '0.13')
 
   vim.validate('level', level, 'number')
@@ -223,7 +222,7 @@ end
 --- Convert LSP MessageType to vim.log.levels
 ---
 ---@param message_type lsp.MessageType
-function log._from_lsp_level(message_type)
+function M._from_lsp_level(message_type)
   if message_type == protocol.MessageType.Error then
     return vim.log.levels.ERROR
   elseif message_type == protocol.MessageType.Warning then
@@ -235,4 +234,4 @@ function log._from_lsp_level(message_type)
   end
 end
 
-return log
+return M

--- a/runtime/lua/vim/lsp/log.lua
+++ b/runtime/lua/vim/lsp/log.lua
@@ -25,6 +25,8 @@ local M = {}
 
 local log_levels = vim.log.levels
 local protocol = require('vim.lsp.protocol')
+-- Tracks messages that we don't want to redundantly log.
+local logged = {}
 
 --- Log level dictionary with reverse lookup as well.
 ---

--- a/test/functional/lua/dict_spec.lua
+++ b/test/functional/lua/dict_spec.lua
@@ -1,0 +1,89 @@
+local t = require('test.testutil')
+local n = require('test.functional.testnvim')()
+
+local eq = t.eq
+
+describe('vim._ordereddict', function()
+  before_each(n.clear)
+
+  local ordereddict = require('vim._ordereddict')
+
+  it('preserves insertion order and supports set/get/len', function()
+    local d = ordereddict.new()
+    d:set('a', 1)
+    d:set('b', 2)
+    d:set('c', 3)
+
+    eq(1, d:get('a'))
+    eq(2, d:get('b'))
+    eq(3, d:get('c'))
+    eq(3, d:len())
+    eq({'a', 'b', 'c'}, vim.iter(d()):enumerate():totable())
+    -- eq({1, 2, 3}, d:values())
+  end)
+
+  it('overwrites value without changing order', function()
+    local d = ordereddict.new()
+    d:set('x', 10)
+    d:set('y', 20)
+    d:set('x', 99)
+
+    eq(99, d:get('x'))
+    eq({'x', 'y'}, d:keys())
+    eq({99, 20}, d:values())
+  end)
+
+  it('removes existing keys', function()
+    local d = ordereddict.new()
+    d:set('a', 1)
+    d:set('b', 2)
+
+    local removed = d:remove('a')
+    eq(true, removed)
+    eq(nil, d:get('a'))
+    eq({'b'}, d:keys())
+    eq({2}, d:values())
+    eq(1, d:len())
+  end)
+
+  it('returns false when removing non-existent keys', function()
+    local d = ordereddict.new()
+    eq(false, d:remove('missing'))
+  end)
+
+  it('pop removes and returns the last item', function()
+    local d = ordereddict.new()
+    d:set('one', 1)
+    d:set('two', 2)
+
+    local k, v = d:pop()
+    eq('two', k)
+    eq(2, v)
+    eq({'one'}, d:keys())
+    eq({1}, d:values())
+    eq(1, d:len())
+  end)
+
+  it('pop returns nil when empty', function()
+    local d = ordereddict.new()
+    local k, v = d:pop()
+    eq(nil, k)
+    eq(nil, v)
+  end)
+
+  it('iterates in insertion order', function()
+    local d = ordereddict.new()
+    d:set('k1', 'v1')
+    d:set('k2', 'v2')
+    d:set('k3', 'v3')
+
+    local items = {}
+    for k, v in d:items() do
+      table.insert(items, {k, v})
+    end
+
+    eq({{'k1', 'v1'}, {'k2', 'v2'}, {'k3', 'v3'}}, items)
+  end)
+
+end)
+


### PR DESCRIPTION
WIP, posting here to get early feedback.

## Problem

- Need a more flexible "Log once" interface, which can optionally.
- `vim.ringbuf` does not have key-value access.
- `vim.ringbuf` does not notify a callback/hook when it reaches its max.
    - Needed for optional handling (such as logging) when max is reached, for some applications.

## Solution

- Introduce `ordereddict`.
    - Alternative: enhance `vim.ringbuf`. I maybe prefer this but it might get a bit muddled. WDYT @mfussenegger 