### PR TITLE
vim-patch:8.1.2371: FEAT_TEXT_PROP is a confusing name

### DIFF
--- a/src/nvim/eval/window.c
+++ b/src/nvim/eval/window.c
@@ -177,6 +177,7 @@ win_T *find_win_by_nr(typval_T *vp, tabpage_T *tp)
 
 /// Find a window: When using a Window ID in any tab page, when using a number
 /// in the current tab page.
+/// Returns NULL when not found.
 win_T *find_win_by_nr_or_id(typval_T *vp)
 {
   int nr = (int)tv_get_number_chk(vp, NULL);

--- a/src/nvim/getchar.c
+++ b/src/nvim/getchar.c
@@ -2675,7 +2675,7 @@ static int vgetorpeek(bool advance)
 
           if (result == map_result_get) {
             // get a character: 2. from the typeahead buffer
-            c = typebuf.tb_buf[typebuf.tb_off] & 255;
+            c = typebuf.tb_buf[typebuf.tb_off];
             if (advance) {  // remove chars from tb_buf
               cmd_silent = (typebuf.tb_silent > 0);
               if (typebuf.tb_maplen > 0) {

--- a/test/old/testdir/runtest.vim
+++ b/test/old/testdir/runtest.vim
@@ -375,6 +375,11 @@ func RunTheTest(test)
   au!
   au SwapExists * call HandleSwapExists()
 
+  " Close any stray popup windows
+  if has('popupwin')
+    call popup_clear()
+  endif
+
   " Close any extra tab pages and windows and make the current one not modified.
   while tabpagenr('$') > 1
     let winid = win_getid()

--- a/test/old/testdir/test_execute_func.vim
+++ b/test/old/testdir/test_execute_func.vim
@@ -99,7 +99,7 @@ func Test_win_execute()
   let line = win_execute(134343, 'echo getline(1)')
   call assert_equal('', line)
 
-  if has('textprop')
+  if has('popupwin')
     let popupwin = popup_create('the popup win', {'line': 2, 'col': 3})
     redraw
     let line = 'echo getline(1)'->win_execute(popupwin)


### PR DESCRIPTION
Problem:    FEAT_TEXT_PROP is a confusing name.
Solution:   Use FEAT_PROP_POPUP. (Naruhiko Nishino, closes vim/vim#5291)

https://github.com/vim/vim/commit/05ad5ff0ab34ed9a5296dedd420ca81698b8ce22

textprop,popuwin remain N/A features.
getchar.c has the relevant code changes.

Port runtest.vim changes from patch v8.1.1561.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
