### PR TITLE
test: increase timeout in 'autocompletedelay' test

### DIFF
--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1424,7 +1424,7 @@ describe('completion', function()
       {1:~                                                           }|*6
                                                                   |
     ]])
-    screen.timeout = 200
+    screen.timeout = 400
 
     feed('Gof')
     screen:expect([[


### PR DESCRIPTION
Change timeout from 200ms to 400ms, which is still 100ms lower than the
'autocompletedelay' value.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
