### PR TITLE
vim-patch:9.1.1685: Missing changes from PR 18068

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1126,8 +1126,8 @@ time slice.
 
 This mode is fully compatible with other completion modes.  You can invoke
 any of them at any time by typing |CTRL-X|, which temporarily suspends
-autocompletion.  To use |i_CTRL-N| specifically, press |CTRL-E| first to
-dismiss the popup menu (see |complete_CTRL-E|).
+autocompletion.  To use |i_CTRL-N| or |i_CTRL-X_CTRL-N| specifically, press
+|CTRL-E| first to dismiss the popup menu (see |complete_CTRL-E|).
 
 See also 'autocomplete', 'autocompletetimeout' and 'autocompletedelay'.
 

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -356,7 +356,7 @@ void ins_ctrl_x(void)
 {
   if (!ctrl_x_mode_cmdline()) {
     // if the next ^X<> won't ADD nothing, then reset compl_cont_status
-    if ((compl_cont_status & CONT_N_ADDS) && !p_ac) {
+    if (compl_cont_status & CONT_N_ADDS) {
       compl_cont_status |= CONT_INTRPT;
     } else {
       compl_cont_status = 0;

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -5311,7 +5311,7 @@ func Test_autocomplete_trigger()
 
   " Test 4a: When autocomplete menu is active, ^X^N completes buffer keywords
   let g:CallCount = 0
-  call feedkeys("S#a\<C-X>\<C-N>\<F2>\<Esc>0", 'tx!')
+  call feedkeys("S#a\<C-E>\<C-X>\<C-N>\<F2>\<Esc>0", 'tx!')
   call assert_equal(['abc', 'abcd'], b:matches->mapnew('v:val.word'))
   call assert_equal(2, g:CallCount)
 
@@ -5337,6 +5337,14 @@ func Test_autocomplete_trigger()
   call feedkeys("Goa\<C-X>\<C-L>\<F2>\<Esc>0", 'tx!')
   call assert_equal(['afoo bar', 'and'], b:matches->mapnew('v:val.word'))
   call assert_equal(1, g:CallCount)
+
+  " Issue #18044
+  %d
+  call setline(1, ["first line", "second line"])
+  call feedkeys("Gof\<C-X>\<C-L>\<Esc>", 'tx!')
+  call assert_equal("first line", getline(3))
+  call feedkeys("Sf\<C-X>\<C-L>\<C-X>\<C-L>\<Esc>", 'tx!')
+  call assert_equal("second line", getline(4))
 
   " Test 5: When invalid prefix stops completion, backspace should restart it
   %d


### PR DESCRIPTION
#### vim-patch:9.1.1685: Missing changes from PR 18068

Problem:  Missing changes from PR 18068
Solution: Include the missing changes
          (Girish Palya)

https://github.com/vim/vim/commit/c6a0f42cdb8b0d9c5beda98176caad0cf48550c2

Co-authored-by: Girish Palya <girishji@gmail.com>