### PR TITLE
perf: scheduler priority clamping on macOS

### DIFF
--- a/src/nvim/main.c
+++ b/src/nvim/main.c
@@ -188,6 +188,7 @@ static bool event_teardown(void)
 /// Needed for unit tests.
 void early_init(mparm_T *paramp)
 {
+  os_hint_priority();
   estack_init();
   cmdline_init();
   eval_init();          // init global variables

--- a/src/nvim/os/env.c
+++ b/src/nvim/os/env.c
@@ -39,6 +39,10 @@
 # include "nvim/fileio.h"
 #endif
 
+#ifdef __APPLE__
+# include <mach/task.h>
+#endif
+
 #ifdef HAVE__NSGETENVIRON
 # include <crt_externs.h>
 #endif
@@ -364,6 +368,18 @@ int64_t os_get_pid(void)
   return (int64_t)GetCurrentProcessId();
 #else
   return (int64_t)getpid();
+#endif
+}
+
+/// Signals to the OS that Nvim is an application for "interactive work"
+/// which should be prioritized similar to a GUI app.
+void os_hint_priority(void)
+{
+#ifdef __APPLE__
+  // By default, processes have the TASK_UNSPECIFIED "role", which means all of its threads are
+  // clamped to Default QoS. Setting the role to TASK_DEFAULT_APPLICATION removes this clamp.
+  integer_t policy = TASK_DEFAULT_APPLICATION;
+  task_policy_set(mach_task_self(), TASK_CATEGORY_POLICY, &policy, 1);
 #endif
 }
 


### PR DESCRIPTION
This PR allows Neovim to run at the same priority as GUI applications on macOS. This makes Neovim as responsive as other apps are when the system is under load. The video below is from vim/vim#18120 and as such displays Vim instead of Neovim, but the effect is the same.

https://github.com/user-attachments/assets/c3694125-81fd-43a8-882b-0f8b70357b18

The left terminal is before, and the right terminal is after. At first the system isn’t under load and both Vim instances scroll smoothly. Once I start a test program which pins all the cores of my machine, the left Vim instance’s responsiveness falls dramatically while the right one is barely affected.

Please let me know if I’ve put the code in the wrong spot, or if I should expand on how this change works. Thanks!