### PR TITLE
fix(floatwin): handle viewport width properly at end of window

### DIFF
--- a/src/nvim/drawscreen.c
+++ b/src/nvim/drawscreen.c
@@ -2567,37 +2567,46 @@ void win_scroll_lines(win_T *wp, int row, int line_count)
 void win_draw_end(win_T *wp, schar_T c1, bool draw_margin, int startrow, int endrow, hlf_T hl)
 {
   assert(hl >= 0 && hl < HLF_COUNT);
+  const int view_width = wp->w_view_width;
+  const int fdc = compute_foldcolumn(wp, 0);
+  const int scwidth = wp->w_scwidth;
+
   for (int row = startrow; row < endrow; row++) {
     grid_line_start(&wp->w_grid, row);
 
     int n = 0;
     if (draw_margin) {
       // draw the fold column
-      int fdc = MAX(0, compute_foldcolumn(wp, 0));
-      n = grid_line_fill(n, n + fdc, schar_from_ascii(' '), win_hl_attr(wp, HLF_FC));
+      if (fdc > 0) {
+        n = grid_line_fill(n, MIN(view_width, n + fdc),
+                           schar_from_ascii(' '), win_hl_attr(wp, HLF_FC));
+      }
 
       // draw the sign column
-      n = grid_line_fill(n, n + wp->w_scwidth * SIGN_WIDTH, schar_from_ascii(' '),
-                         win_hl_attr(wp, HLF_SC));
+      if (scwidth > 0) {
+        n = grid_line_fill(n, MIN(view_width, n + scwidth * SIGN_WIDTH),
+                           schar_from_ascii(' '), win_hl_attr(wp, HLF_SC));
+      }
 
       // draw the number column
       if ((wp->w_p_nu || wp->w_p_rnu) && vim_strchr(p_cpo, CPO_NUMCOL) == NULL) {
         int width = number_width(wp) + 1;
-        n = grid_line_fill(n, n + width, schar_from_ascii(' '), win_hl_attr(wp, HLF_N));
+        n = grid_line_fill(n, MIN(view_width, n + width),
+                           schar_from_ascii(' '), win_hl_attr(wp, HLF_N));
       }
     }
 
     int attr = win_hl_attr(wp, (int)hl);
 
-    if (n < wp->w_view_width) {
+    if (n < view_width) {
       grid_line_put_schar(n, c1, attr);
       n++;
     }
 
-    grid_line_clear_end(n, wp->w_view_width, win_bg_attr(wp), attr);
+    grid_line_clear_end(n, view_width, win_bg_attr(wp), attr);
 
     if (wp->w_p_rl) {
-      grid_line_mirror(wp->w_view_width);
+      grid_line_mirror(view_width);
     }
     grid_line_flush();
   }

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -1008,6 +1008,7 @@ describe('float window', function()
         [29] = { background = Screen.colors.Yellow1, foreground = Screen.colors.Blue4 },
         [30] = { background = Screen.colors.Grey, foreground = Screen.colors.Blue4, bold = true },
         [31] = { foreground = Screen.colors.Grey0 },
+        [32] = { background = Screen.colors.LightMagenta, foreground = Screen.colors.Brown },
       }
       screen:set_default_attr_ids(attrs)
     end)
@@ -3110,6 +3111,42 @@ describe('float window', function()
           {0:~    }{1:line     }{0:                          }|
           {0:~    }{1:abb acc  }{0:                          }|
           {0:~                                       }|*6
+                                                  |
+        ]])
+      end
+    end)
+
+    it('border is drawn properly when number column is too wide #35431', function()
+      local buf = api.nvim_create_buf(false, false)
+      local opts = { relative = 'editor', row = 1, col = 1, width = 3, height = 3, border = 'rounded' }
+      local win = api.nvim_open_win(buf, false, opts)
+      api.nvim_set_option_value('number', true, { win = win })
+      if multigrid then
+        screen:expect({
+          grid = [[
+        ## grid 1
+          [2:----------------------------------------]|*6
+          [3:----------------------------------------]|
+        ## grid 2
+          ^                                        |
+          {0:~                                       }|*5
+        ## grid 3
+                                                  |
+        ## grid 4
+          {5:╭───╮}|
+          {5:│}{32:  1}{5:│}|
+          {5:│}{32:   }{5:│}|*2
+          {5:╰───╯}|
+        ]],
+          float_pos = { [4] = { 1001, 'NW', 1, 1, 1, true, 50, 1, 1, 1 } },
+        })
+      else
+        screen:expect([[
+          ^                                        |
+          {0:~}{5:╭───╮}{0:                                  }|
+          {0:~}{5:│}{32:  1}{5:│}{0:                                  }|
+          {0:~}{5:│}{32:   }{5:│}{0:                                  }|*2
+          {0:~}{5:╰───╯}{0:                                  }|
                                                   |
         ]])
       end


### PR DESCRIPTION
Fix #35431

Also avoid repeated calls of compute_foldcolumn().

