### PR TITLE
vim-patch:9.1.1689: CmdlineChanged not triggered by <Del>

### DIFF
--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1033,7 +1033,7 @@ static int command_line_check(VimState *state)
                            // cause the command not to be executed.
 
   if (ccline.cmdbuff != NULL) {
-    s->prev_cmdbuff = xmemdupz(ccline.cmdbuff, (size_t)ccline.cmdpos);
+    s->prev_cmdbuff = xstrdup(ccline.cmdbuff);
   }
 
   // Trigger SafeState if nothing is pending.
@@ -2827,8 +2827,7 @@ static int command_line_changed(CommandLineState *s)
   }
 
   if (ccline.cmdpos != s->prev_cmdpos
-      || (s->prev_cmdbuff != NULL
-          && strncmp(s->prev_cmdbuff, ccline.cmdbuff, (size_t)s->prev_cmdpos) != 0)) {
+      || (s->prev_cmdbuff != NULL && strcmp(s->prev_cmdbuff, ccline.cmdbuff) != 0)) {
     // Trigger CmdlineChanged autocommands.
     do_autocmd_cmdlinechanged(s->firstc > 0 ? s->firstc : '-');
   }

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -2103,6 +2103,17 @@ func Test_Cmdline()
         \ '0abc1abc2abc3',
         \ ], g:log)
 
+  " <Del> should trigger CmdlineChanged
+  let g:log = []
+  call feedkeys(":foo\<Left>\<Left>\<Del>\<Del>\<Esc>", 'xt')
+  call assert_equal([
+        \ 'f',
+        \ 'fo',
+        \ 'foo',
+        \ 'fo',
+        \ 'f',
+        \ ], g:log)
+
   unlet g:log
   au! CmdlineChanged
 


### PR DESCRIPTION
#### vim-patch:9.1.1689: CmdlineChanged not triggered by \<Del>

Problem:  CmdlineChanged not triggered by \<Del>
Solution: Use STRCMP() instead of STRNCMP()
          (Shougo Matsushita)

closes: vim/vim#18101

https://github.com/vim/vim/commit/540480697dd8c9a5c97188e8d0bc8f2ac4d751d1

Co-authored-by: Shougo Matsushita <Shougo.Matsu@gmail.com>