### PR TITLE
refactor: rename ga_concat_strings_sep() to ga_concat_strings()

### DIFF
--- a/src/nvim/eval/fs.c
+++ b/src/nvim/eval/fs.c
@@ -574,7 +574,7 @@ void f_globpath(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
     globpath((char *)tv_get_string(&argvars[0]), (char *)file, &ga, flags, false);
 
     if (rettv->v_type == VAR_STRING) {
-      rettv->vval.v_string = ga_concat_strings_sep(&ga, "\n");
+      rettv->vval.v_string = ga_concat_strings(&ga, "\n");
     } else {
       tv_list_alloc_ret(rettv, ga.ga_len);
       for (int i = 0; i < ga.ga_len; i++) {

--- a/src/nvim/garray.c
+++ b/src/nvim/garray.c
@@ -124,13 +124,13 @@ void ga_remove_duplicate_strings(garray_T *gap)
 }
 
 /// For a growing array that contains a list of strings: concatenate all the
-/// strings with sep as separator.
+/// strings with "sep" as separator.
 ///
 /// @param gap
 /// @param sep
 ///
 /// @returns the concatenated strings
-char *ga_concat_strings_sep(const garray_T *gap, const char *sep)
+char *ga_concat_strings(const garray_T *gap, const char *sep)
   FUNC_ATTR_NONNULL_RET
 {
   const size_t nelem = (size_t)gap->ga_len;
@@ -157,17 +157,6 @@ char *ga_concat_strings_sep(const garray_T *gap, const char *sep)
   strcpy(s, strings[nelem - 1]);  // NOLINT(runtime/printf)
 
   return ret;
-}
-
-/// For a growing array that contains a list of strings: concatenate all the
-/// strings with a separating comma.
-///
-/// @param gap
-///
-/// @returns the concatenated strings
-char *ga_concat_strings(const garray_T *gap) FUNC_ATTR_NONNULL_RET
-{
-  return ga_concat_strings_sep(gap, ",");
 }
 
 /// Concatenate a string to a growarray which contains characters.

--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -1472,7 +1472,7 @@ static void nlua_typval_exec(const char *lcmd, size_t lcmd_len, const char *name
 
 void nlua_exec_ga(garray_T *ga, char *name)
 {
-  char *code = ga_concat_strings_sep(ga, "\n");
+  char *code = ga_concat_strings(ga, "\n");
   size_t len = strlen(code);
   nlua_typval_exec(code, len, name, NULL, 0, false, NULL);
   xfree(code);

--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -1145,7 +1145,7 @@ static int expand_in_path(garray_T *const gap, char *const pattern, const int fl
     return 0;
   }
 
-  char *const paths = ga_concat_strings(&path_ga);
+  char *const paths = ga_concat_strings(&path_ga, ",");
   ga_clear_strings(&path_ga);
 
   int glob_flags = 0;

--- a/test/unit/garray_spec.lua
+++ b/test/unit/garray_spec.lua
@@ -93,12 +93,8 @@ local ga_append = function(garr, b)
   end
 end
 
-local ga_concat_strings = function(garr)
-  return internalize(garray.ga_concat_strings(garr))
-end
-
-local ga_concat_strings_sep = function(garr, sep)
-  return internalize(garray.ga_concat_strings_sep(garr, to_cstr(sep)))
+local ga_concat_strings = function(garr, sep)
+  return internalize(garray.ga_concat_strings(garr, to_cstr(sep)))
 end
 
 local ga_remove_duplicate_strings = function(garr)
@@ -320,19 +316,16 @@ describe('garray', function()
     end)
   end)
 
-  local function test_concat_fn(input, fn, sep)
+  local function test_concat_fn(input, sep)
     local garr = new_string_garray()
     ga_append_strings(garr, unpack(input))
-    if sep == nil then
-      eq(table.concat(input, ','), fn(garr))
-    else
-      eq(table.concat(input, sep), fn(garr, sep))
-    end
+    eq(table.concat(input, sep), ga_concat_strings(garr, sep))
   end
 
   describe('ga_concat_strings', function()
     itp('returns an empty string when concatenating an empty array', function()
-      test_concat_fn({}, ga_concat_strings)
+      test_concat_fn({}, ',')
+      test_concat_fn({}, '---')
     end)
 
     itp('can concatenate a non-empty array', function()
@@ -340,22 +333,12 @@ describe('garray', function()
         'oh',
         'my',
         'neovim',
-      }, ga_concat_strings)
-    end)
-  end)
-
-  describe('ga_concat_strings_sep', function()
-    itp('returns an empty string when concatenating an empty array', function()
-      test_concat_fn({}, ga_concat_strings_sep, '---')
-    end)
-
-    itp('can concatenate a non-empty array', function()
-      local sep = '-●●-'
+      }, ',')
       test_concat_fn({
         'oh',
         'my',
         'neovim',
-      }, ga_concat_strings_sep, sep)
+      }, '-●●-')
     end)
   end)
 


### PR DESCRIPTION
This adds a missing change from Vim patch 7.4.279.

N/A patch:
vim-patch:9.1.1691: over-allocation in ga_concat_strings()

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
