### PR TITLE
vim-patch:9.1.1690: Missing recursion guard in dos/unix_expandpath()

### DIFF
--- a/src/nvim/path.c
+++ b/src/nvim/path.c
@@ -754,9 +754,13 @@ static size_t do_path_expand(garray_T *gap, const char *path, size_t wildoff, in
 
         vim_snprintf(buf + len, buflen - len, "%s", path_end);
         if (path_has_exp_wildcard(path_end)) {      // handle more wildcards
-          // need to expand another component of the path
-          // remove backslashes for the remaining components only
-          do_path_expand(gap, buf, len + 1, flags, false);
+          if (stardepth < 100) {
+            stardepth++;
+            // need to expand another component of the path
+            // remove backslashes for the remaining components only
+            do_path_expand(gap, buf, len + 1, flags, false);
+            stardepth--;
+          }
         } else {
           FileInfo file_info;
 


### PR DESCRIPTION
#### vim-patch:9.1.1690: Missing recursion guard in dos/unix_expandpath()

Problem:  Missing recursion guard in dos/unix_expandpath()
Solution: Add guard variables (ashamedbit)

closes: vim/vim#18106

https://github.com/vim/vim/commit/e8948a1f807cb595446e896e00bdf0e5339f0dd2

Co-authored-by: ashamedbit <muralianiruddhan@gmail.com>
Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>