### PR TITLE
vim-patch:9.1.1695: Need more Vim script specific tests

### DIFF
--- a/test/old/testdir/test_vimscript.vim
+++ b/test/old/testdir/test_vimscript.vim
@@ -7523,6 +7523,7 @@ func Test_deeply_nested_source()
   call system(cmd)
 endfunc
 
+" Test for impact of silent! on an exception  {{{1
 func Test_exception_silent()
   XpathINIT
   let lines =<< trim END
@@ -7546,6 +7547,70 @@ func Test_exception_silent()
   END
 
   call RunInNewVim(lines, verify)
+endfunc
+
+" Test for an error message starting with "Vim E123: " {{{1
+func Test_skip_prefix_in_exception()
+  let emsg = ''
+  try
+    echoerr "Vim E123:"
+  catch
+    let emsg = v:exception
+  endtry
+  call assert_equal('Vim(echoerr):Vim E123:', emsg)
+
+  let emsg = ''
+  try
+    echoerr "Vim E123: abc"
+  catch
+    let emsg = v:exception
+  endtry
+  call assert_equal('Vim(echoerr):E123: abc', emsg)
+endfunc
+
+" Test for try/except messages displayed with 'verbose' level set to 13 {{{1
+func Test_verbose_try_except_messages()
+  let msgs = ''
+  redir => msgs
+  set verbose=13
+  try
+    echoerr 'foo'
+  catch
+    echo v:exception
+  endtry
+  set verbose=0
+  redir END
+  let expected =<< trim END
+    Exception thrown: Vim(echoerr):foo
+
+    Exception caught: Vim(echoerr):foo
+
+    Vim(echoerr):foo
+    Exception finished: Vim(echoerr):foo
+  END
+  call assert_equal(expected, msgs->split("\n"))
+endfunc
+
+" Test for trailing characters after a catch pattern {{{1
+func Test_catch_pattern_trailing_chars()
+  let lines =<< trim END
+    try
+      echoerr 'foo'
+    catch /foo/xxx
+      echo 'caught foo'
+    endtry
+  END
+
+  new
+  call setline(1, lines)
+  let caught_exception = v:false
+  try
+    source
+  catch /E488: Trailing characters: \/xxx/
+    let caught_exception = v:true
+  endtry
+  call assert_true(caught_exception)
+  bw!
 endfunc
 
 "-------------------------------------------------------------------------------


### PR DESCRIPTION
#### vim-patch:9.1.1695: Need more Vim script specific tests

Problem:  Need more Vim script specific tests
Solution: Add more tests (Yegappan Lakshmanan).

closes: vim/vim#18118

https://github.com/vim/vim/commit/e810ba5a1f6f256d2631b880641c0d7ce4d04ca5

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>