### PR TITLE
vim-patch:3571388: runtime(lf): update syntax to support lf version r37

### DIFF
--- a/runtime/syntax/lf.vim
+++ b/runtime/syntax/lf.vim
@@ -3,10 +3,10 @@
 " Maintainer: Andis Sprinkis <andis@sprinkis.com>
 " Former Maintainer: Cameron Wright
 " URL: https://github.com/andis-sprinkis/lf-vim
-" Last Change: 16 July 2025
+" Last Change: 16 August 2025
 "
 " The shell syntax highlighting is configurable. See $VIMRUNTIME/doc/syntax.txt
-" lf version: 36
+" lf version: 37
 
 if exists("b:current_syntax") | finish | endif
 
@@ -94,6 +94,7 @@ syn keyword lfOptions
   \ errorfmt
   \ filesep
   \ filter
+  \ filtermethod
   \ find
   \ find-back
   \ find-next
@@ -101,8 +102,6 @@ syn keyword lfOptions
   \ findlen
   \ glob-select
   \ glob-unselect
-  \ globfilter
-  \ globsearch
   \ half-down
   \ half-up
   \ hidden
@@ -169,6 +168,7 @@ syn keyword lfOptions
   \ search-back
   \ search-next
   \ search-prev
+  \ searchmethod
   \ select
   \ selectfmt
   \ selmode


### PR DESCRIPTION
#### vim-patch:3571388: runtime(lf): update syntax to support lf version r37

Adds the lf release 37 specific syntax highlighting changes.

From the PR andis-sprinkis/lf-vim#23 by @CatsDeservePets

closes: vim/vim#18115

https://github.com/vim/vim/commit/3571388ded6fc4e849e7ded3a4e6594d7bb8efaf

Co-authored-by: Andis Spriņķis <andis@sprinkis.com>