### PR TITLE
vim-patch:9.1.1694: filetype: Buck eXtension Lang files are not recognized

### DIFF
--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -268,6 +268,7 @@ local extension = {
       or 'btm'
   end,
   bzl = 'bzl',
+  bxl = 'bzl',
   bazel = 'bzl',
   BUILD = 'bzl',
   mdh = 'c',

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -147,7 +147,7 @@ func s:GetFilenameChecks() abort
     \ 'brightscript': ['file.brs'],
     \ 'bsdl': ['file.bsd', 'file.bsdl'],
     \ 'bst': ['file.bst'],
-    \ 'bzl': ['file.bazel', 'file.bzl', 'WORKSPACE', 'WORKSPACE.bzlmod'],
+    \ 'bzl': ['file.bazel', 'file.bzl', 'file.bxl', 'WORKSPACE', 'WORKSPACE.bzlmod'],
     \ 'bzr': ['bzr_log.any', 'bzr_log.file'],
     \ 'c': ['enlightenment/file.cfg', 'file.qc', 'file.c', 'some-enlightenment/file.cfg', 'file.mdh', 'file.epro'],
     \ 'c3': ['file.c3', 'file.c3i', 'file.c3t'],


### PR DESCRIPTION
#### vim-patch:9.1.1694: filetype: Buck eXtension Lang files are not recognized

Problem:  filetype: Buck eXtension Lang files are not recognized
Solution: Detect *.bxl files as bzl filetype.
          (Jade Lovelace)

References:
- https://buck2.build/docs/bxl/

closes: vim/vim#18130

https://github.com/vim/vim/commit/3aea867b276360ab8eb675fc4a9af5be774323e4

Co-authored-by: Jade Lovelace <jadel@mercury.com>