### PR TITLE
fix(lsp): update completion items on `TextChangedP`

### DIFF
--- a/runtime/lua/vim/lsp/inline_completion.lua
+++ b/runtime/lua/vim/lsp/inline_completion.lua
@@ -373,7 +373,7 @@ function M.select(opts)
   end
 
   local count = opts.count or vim.v.count1
-  local wrap = opts.wrap or true
+  local wrap = opts.wrap ~= false
 
   local current = completor.current
   if not current then

--- a/runtime/lua/vim/lsp/inline_completion.lua
+++ b/runtime/lua/vim/lsp/inline_completion.lua
@@ -42,7 +42,7 @@ Capability.all[Completor.name] = Completor
 function Completor:new(bufnr)
   self = Capability.new(self, bufnr)
   self.client_state = {}
-  api.nvim_create_autocmd({ 'InsertEnter', 'CursorMovedI', 'CursorHoldI' }, {
+  api.nvim_create_autocmd({ 'InsertEnter', 'CursorMovedI' }, {
     group = self.augroup,
     callback = function()
       self:automatic_request()

--- a/runtime/lua/vim/lsp/inline_completion.lua
+++ b/runtime/lua/vim/lsp/inline_completion.lua
@@ -42,7 +42,7 @@ Capability.all[Completor.name] = Completor
 function Completor:new(bufnr)
   self = Capability.new(self, bufnr)
   self.client_state = {}
-  api.nvim_create_autocmd({ 'InsertEnter', 'CursorMovedI' }, {
+  api.nvim_create_autocmd({ 'InsertEnter', 'CursorMovedI', 'TextChangedP' }, {
     group = self.augroup,
     callback = function()
       self:automatic_request()


### PR DESCRIPTION
Fixes https://github.com/neovim/neovim/issues/35494 and discussed there.

~~Try listening to the buffer change directly, instead of relying on autocmds.~~

Edit: I found that when listening to buffer changes, the event will be triggered before the cursor moves, so `get_current_cursor` will get the position before it actually moves. I changed it add listening to `TextChangedP`