### PR TITLE
fix: serverlist({ peer = true }) only checks local stdpath('run')

### DIFF
--- a/runtime/lua/vim/_core/server.lua
+++ b/runtime/lua/vim/_core/server.lua
@@ -8,9 +8,10 @@ local M = {}
 --- @param listed string[] Already listed servers
 --- @return string[] # List of servers found on the current machine in stdpath("run").
 function M.serverlist(listed)
+  local root = vim.fs.normalize(vim.fn.stdpath('run') .. '/..')
   local socket_paths = vim.fs.find(function(name, _)
     return name:match('nvim.*')
-  end, { path = vim.fn.stdpath('run'), type = 'socket', limit = math.huge })
+  end, { path = root, type = 'socket', limit = math.huge })
 
   local found = {} ---@type string[]
   for _, socket in ipairs(socket_paths) do

--- a/test/functional/core/server_spec.lua
+++ b/test/functional/core/server_spec.lua
@@ -162,7 +162,9 @@ describe('server', function()
   end)
 
   it('serverlist() returns the list of servers', function()
-    local current_server = clear()
+    -- Set XDG_RUNTIME_DIR to a temp dir in this session to properly test serverlist({peer = true}). See #35492
+    local tmp_dir = assert(vim.uv.fs_mkdtemp(vim.fs.dirname(t.tmpname(false)) .. '/XXXXXX'))
+    local current_server = clear({ env = { XDG_RUNTIME_DIR = tmp_dir } })
     -- There should already be at least one server.
     local _n = eval('len(serverlist())')
 
@@ -191,16 +193,29 @@ describe('server', function()
     if t.is_os('win') then
       return
     end
-    local peer_addr = n.new_pipename()
-    local client =
-      n.new_session(true, { args = { '--clean', '--listen', peer_addr, '--embed' }, merge = false })
+
+    local old_servs_num = #fn.serverlist({ peer = true })
+    local peer_temp = n.new_pipename()
+    local peer_name = peer_temp:match('[^/]*$')
+
+    local tmp_dir2 = assert(vim.uv.fs_mkdtemp(vim.fs.dirname(t.tmpname(false)) .. '/XXXXXX'))
+    local peer_addr = ('%s/%s'):format(tmp_dir2, peer_name)
+    -- Set XDG_RUNTIME_DIR to a temp dir in this session to properly test serverlist({peer = true}). See #35492
+    local client = n.new_session(true, {
+      args = { '--clean', '--listen', peer_addr, '--embed' },
+      env = { XDG_RUNTIME_DIR = tmp_dir2 },
+      merge = false,
+    })
     n.set_session(client)
     eq(peer_addr, fn.serverlist()[1])
 
     n.set_session(current_server)
 
     new_servs = fn.serverlist({ peer = true })
+    local servers_without_peer = fn.serverlist()
     eq(true, vim.list_contains(new_servs, peer_addr))
+    eq(true, #servers_without_peer < #new_servs)
+    eq(true, old_servs_num < #new_servs)
     client:close()
   end)
 end)


### PR DESCRIPTION
Problem: The current implementation of `serverlist({ peer = true})` only checks the `stdpath('run')` of the calling neovim server. Since this is local to the server, `serverlist`, misses other servers.
Solution: Check one directory above the local `stdpath('run')` to find other servers that might have been missed.

Ref:
https://github.com/neovim/neovim/issues/35492
https://github.com/neovim/neovim/pull/34806#discussion_r2296987660