### PR TITLE
feat(lsp): expose `vim.lsp.inline_completion.get.Opts.on_accept`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2229,6 +2229,16 @@ is_enabled({filter})                         *vim.lsp.inlay_hint.is_enabled()*
 ==============================================================================
 Lua module: vim.lsp.inline_completion                  *lsp-inline_completion*
 
+*vim.lsp.inline_completion.Item*
+
+    Fields: ~
+      • {client_id}    (`integer`) Client ID
+      • {insert_text}  (`string|lsp.StringValue`) The text to be inserted, can
+                       be a snippet.
+      • {range}?       (`vim.Range`) Which range it be applied.
+      • {command}?     (`lsp.Command`) Corresponding server command.
+
+
 enable({enable}, {filter})                *vim.lsp.inline_completion.enable()*
     Enables or disables inline completion for the {filter}ed scope, inline
     completion will automatically be refreshed when you are in insert mode.
@@ -2246,9 +2256,9 @@ enable({enable}, {filter})                *vim.lsp.inline_completion.enable()*
                     for all.
 
 get({opts})                                  *vim.lsp.inline_completion.get()*
-    Apply the currently displayed completion candidate to the buffer.
+    Accept the currently displayed completion candidate to the buffer.
 
-    It returns false when no candidate can be applied, so you can use the
+    It returns false when no candidate can be accepted, so you can use the
     return value to implement a fallback: >lua
          vim.keymap.set('i', '<Tab>', function()
           if not vim.lsp.inline_completion.get() then
@@ -2265,6 +2275,10 @@ get({opts})                                  *vim.lsp.inline_completion.get()*
       • {opts}  (`table?`) A table with the following fields:
                 • {bufnr}? (`integer`, default: 0) Buffer handle, or 0 for
                   current.
+                • {on_accept}? (`fun(item: vim.lsp.inline_completion.Item)`)
+                  Accept handler, called with the accepted item. If not
+                  provided, the default handler is used, which applies changes
+                  to the buffer based on the completion item.
 
     Return: ~
         (`boolean`) `true` if a completion was applied, else `false`.


### PR DESCRIPTION
Closes https://github.com/neovim/neovim/issues/35485.

Allow users to customize how inline completion items should be accepted.

I've done some renaming so that it should be more suitable for the exposed API.