### PR TITLE
vim-patch:8.1.0688: text properties are not restored by undo

### DIFF
--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -488,7 +488,7 @@ struct file_buffer {
   int b_u_save_nr_cur;         // file write nr after which we are now
 
   // variables for "U" command in undo.c
-  char *b_u_line_ptr;           // saved line for "U" command
+  undoline_T b_u_line_ptr;      // saved line for "U" command
   linenr_T b_u_line_lnum;       // line number of line in u_line
   colnr_T b_u_line_colnr;       // optional column number
 

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -159,7 +159,7 @@ typedef struct {
   int save_b_u_seq_cur;
   time_t save_b_u_time_cur;
   int save_b_u_save_nr_cur;
-  char *save_b_u_line_ptr;
+  undoline_T save_b_u_line_ptr;
   linenr_T save_b_u_line_lnum;
   colnr_T save_b_u_line_colnr;
 } CpUndoInfo;

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -589,7 +589,7 @@ int u_savecommon(buf_T *buf, linenr_T top, linenr_T bot, linenr_T newbot, bool r
   }
 
   if (size > 0) {
-    uep->ue_array = xmalloc(sizeof(char *) * (size_t)size);
+    uep->ue_array = xmalloc(sizeof(undoline_T) * (size_t)size);
     linenr_T lnum;
     int i;
     for (i = 0, lnum = top + 1; i < size; i++) {
@@ -598,7 +598,7 @@ int u_savecommon(buf_T *buf, linenr_T top, linenr_T bot, linenr_T newbot, bool r
         u_freeentry(uep, i);
         return FAIL;
       }
-      uep->ue_array[i] = u_save_line_buf(buf, lnum++);
+      u_save_line_buf(buf, &uep->ue_array[i], lnum++);
     }
   } else {
     uep->ue_array = NULL;
@@ -802,9 +802,10 @@ static bool serialize_header(bufinfo_T *bi, uint8_t *hash)
 
   // Write buffer-specific data.
   undo_write_bytes(bi, (uintmax_t)buf->b_ml.ml_line_count, 4);
-  size_t len = buf->b_u_line_ptr ? strlen(buf->b_u_line_ptr) : 0;
+  size_t len = buf->b_u_line_ptr.ul_line == NULL
+               ? 0 : strlen(buf->b_u_line_ptr.ul_line);
   undo_write_bytes(bi, len, 4);
-  if (len > 0 && !undo_write(bi, (uint8_t *)buf->b_u_line_ptr, len)) {
+  if (len > 0 && !undo_write(bi, (uint8_t *)buf->b_u_line_ptr.ul_line, len)) {
     return false;
   }
   undo_write_bytes(bi, (uintmax_t)buf->b_u_line_lnum, 4);
@@ -1064,11 +1065,11 @@ static bool serialize_uep(bufinfo_T *bi, u_entry_T *uep)
   undo_write_bytes(bi, (uintmax_t)uep->ue_size, 4);
 
   for (size_t i = 0; i < (size_t)uep->ue_size; i++) {
-    size_t len = strlen(uep->ue_array[i]);
+    size_t len = strlen(uep->ue_array[i].ul_line);
     if (!undo_write_bytes(bi, len, 4)) {
       return false;
     }
-    if (len > 0 && !undo_write(bi, (uint8_t *)uep->ue_array[i], len)) {
+    if (len > 0 && !undo_write(bi, (uint8_t *)uep->ue_array[i].ul_line, len)) {
       return false;
     }
   }
@@ -1087,11 +1088,11 @@ static u_entry_T *unserialize_uep(bufinfo_T *bi, bool *error, const char *file_n
   uep->ue_lcount = undo_read_4c(bi);
   uep->ue_size = undo_read_4c(bi);
 
-  char **array = NULL;
+  undoline_T *array = NULL;
   if (uep->ue_size > 0) {
-    if ((size_t)uep->ue_size < SIZE_MAX / sizeof(char *)) {
-      array = xmalloc(sizeof(char *) * (size_t)uep->ue_size);
-      memset(array, 0, sizeof(char *) * (size_t)uep->ue_size);
+    if ((size_t)uep->ue_size < SIZE_MAX / sizeof(undoline_T)) {
+      array = xmalloc(sizeof(undoline_T) * (size_t)uep->ue_size);
+      memset(array, 0, sizeof(undoline_T) * (size_t)uep->ue_size);
     }
   }
   uep->ue_array = array;
@@ -1109,7 +1110,8 @@ static u_entry_T *unserialize_uep(bufinfo_T *bi, bool *error, const char *file_n
       *error = true;
       return uep;
     }
-    array[i] = line;
+    array[i].ul_line = line;
+    array[i].ul_len = (size_t)line_len + 1;
   }
   return uep;
 }
@@ -1240,7 +1242,7 @@ void u_write_undo(const char *const name, const bool forceit, buf_T *const buf, 
 
   // If there is no undo information at all, quit here after deleting any
   // existing undo file.
-  if (buf->b_u_numhead == 0 && buf->b_u_line_ptr == NULL) {
+  if (buf->b_u_numhead == 0 && buf->b_u_line_ptr.ul_line == NULL) {
     if (p_verbose > 0) {
       verb_msg(_("Skipping undo file write, nothing to undo"));
     }
@@ -1372,7 +1374,6 @@ void u_read_undo(char *name, const uint8_t *hash, const char *orig_name FUNC_ATT
   FUNC_ATTR_NONNULL_ARG(2)
 {
   u_header_T **uhp_table = NULL;
-  char *line_ptr = NULL;
 
   char *file_name;
   if (name == NULL) {
@@ -1421,6 +1422,7 @@ void u_read_undo(char *name, const uint8_t *hash, const char *orig_name FUNC_ATT
     .bi_buf = curbuf,
     .bi_fp = fp,
   };
+  undoline_T line_ptr = { 0 };
 
   // Read the undo file header.
   char magic_buf[UF_START_MAGIC_LEN];
@@ -1462,7 +1464,8 @@ void u_read_undo(char *name, const uint8_t *hash, const char *orig_name FUNC_ATT
   }
 
   if (str_len > 0) {
-    line_ptr = undo_read_string(&bi, (size_t)str_len);
+    line_ptr.ul_line = undo_read_string(&bi, (size_t)str_len);
+    line_ptr.ul_len = (size_t)str_len + 1;
   }
   linenr_T line_lnum = (linenr_T)undo_read_4c(&bi);
   colnr_T line_colnr = (colnr_T)undo_read_4c(&bi);
@@ -1648,7 +1651,7 @@ void u_read_undo(char *name, const uint8_t *hash, const char *orig_name FUNC_ATT
   goto theend;
 
 error:
-  xfree(line_ptr);
+  xfree(line_ptr.ul_line);
   if (uhp_table != NULL) {
     for (int i = 0; i < num_read_uhps; i++) {
       if (uhp_table[i] != NULL) {
@@ -2248,7 +2251,7 @@ target_zero:
 /// @param do_buf_event If `true`, send buffer updates.
 static void u_undoredo(bool undo, bool do_buf_event)
 {
-  char **newarray = NULL;
+  undoline_T *newarray = NULL;
   linenr_T newlnum = MAXLNUM;
   pos_T new_curpos = curwin->w_cursor;
   u_entry_T *nuep;
@@ -2311,7 +2314,10 @@ static void u_undoredo(bool undo, bool do_buf_event)
         // line.
         int i;
         for (i = 0; i < newsize && i < oldsize; i++) {
-          if (strcmp(uep->ue_array[i], ml_get(top + 1 + (linenr_T)i)) != 0) {
+          char *p = ml_get(top + 1 + i);
+
+          if (curbuf->b_ml.ml_line_len != (colnr_T)uep->ue_array[i].ul_len
+              || memcmp(uep->ue_array[i].ul_line, p, (size_t)curbuf->b_ml.ml_line_len) != 0) {
             break;
           }
         }
@@ -2329,13 +2335,13 @@ static void u_undoredo(bool undo, bool do_buf_event)
 
     // Delete the lines between top and bot and save them in newarray.
     if (oldsize > 0) {
-      newarray = xmalloc(sizeof(char *) * (size_t)oldsize);
+      newarray = xmalloc(sizeof(undoline_T) * (size_t)oldsize);
       // delete backwards, it goes faster in most cases
       int i;
       linenr_T lnum;
       for (lnum = bot - 1, i = oldsize; --i >= 0; lnum--) {
         // what can we do when we run out of memory?
-        newarray[i] = u_save_line(lnum);
+        u_save_line(&newarray[i], lnum);
         // remember we deleted the last line in the buffer, and a
         // dummy empty line will be inserted
         if (curbuf->b_ml.ml_line_count == 1) {
@@ -2358,11 +2364,11 @@ static void u_undoredo(bool undo, bool do_buf_event)
         // If the file is empty, there is an empty line 1 that we
         // should get rid of, by replacing it with the new line
         if (empty_buffer && lnum == 0) {
-          ml_replace(1, uep->ue_array[i], true);
+          ml_replace_len((linenr_T)1, uep->ue_array[i].ul_line, uep->ue_array[i].ul_len - 1,  true);
         } else {
-          ml_append_flags(lnum, uep->ue_array[i], 0, 0);  // ML_APPEND_UNDO
+          ml_append_flags(lnum, uep->ue_array[i].ul_line, (colnr_T)uep->ue_array[i].ul_len, 0);  // ML_APPEND_UNDO
         }
-        xfree(uep->ue_array[i]);
+        xfree(uep->ue_array[i].ul_line);
       }
       xfree(uep->ue_array);
     }
@@ -2779,7 +2785,10 @@ void u_find_first_changed(void)
   linenr_T lnum;
   for (lnum = 1; lnum < curbuf->b_ml.ml_line_count
        && lnum <= uep->ue_size; lnum++) {
-    if (strcmp(ml_get_buf(curbuf, lnum), uep->ue_array[lnum - 1]) != 0) {
+    char *p = ml_get_buf(curbuf, lnum);
+
+    if ((colnr_T)uep->ue_array[lnum - 1].ul_len != curbuf->b_ml.ml_line_len
+        || memcmp(p, uep->ue_array[lnum - 1].ul_line, uep->ue_array[lnum - 1].ul_len) != 0) {
       clearpos(&(uhp->uh_cursor));
       uhp->uh_cursor.lnum = lnum;
       return;
@@ -2959,7 +2968,7 @@ static void u_freeentries(buf_T *buf, u_header_T *uhp, u_header_T **uhpp)
 static void u_freeentry(u_entry_T *uep, int n)
 {
   while (n > 0) {
-    xfree(uep->ue_array[--n]);
+    xfree(uep->ue_array[--n].ul_line);
   }
   xfree(uep->ue_array);
 #ifdef U_DEBUG
@@ -2974,7 +2983,8 @@ void u_clearall(buf_T *buf)
   buf->b_u_newhead = buf->b_u_oldhead = buf->b_u_curhead = NULL;
   buf->b_u_synced = true;
   buf->b_u_numhead = 0;
-  buf->b_u_line_ptr = NULL;
+  buf->b_u_line_ptr.ul_line = NULL;
+  buf->b_u_line_ptr.ul_len = 0;
   buf->b_u_line_lnum = 0;
 }
 
@@ -2989,7 +2999,7 @@ void u_blockfree(buf_T *buf)
     u_freeheader(buf, buf->b_u_oldhead, NULL);
     assert(buf->b_u_oldhead != previous_oldhead);
   }
-  xfree(buf->b_u_line_ptr);
+  xfree(buf->b_u_line_ptr.ul_line);
 }
 
 /// Free all allocated memory blocks for the buffer 'buf'.
@@ -3016,18 +3026,19 @@ static void u_saveline(buf_T *buf, linenr_T lnum)
   } else {
     buf->b_u_line_colnr = 0;
   }
-  buf->b_u_line_ptr = u_save_line_buf(buf, lnum);
+  u_save_line_buf(buf, &buf->b_u_line_ptr, lnum);
 }
 
 /// clear the line saved for the "U" command
 /// (this is used externally for crossing a line while in insert mode)
 void u_clearline(buf_T *buf)
 {
-  if (buf->b_u_line_ptr == NULL) {
+  if (buf->b_u_line_ptr.ul_line == NULL) {
     return;
   }
 
-  XFREE_CLEAR(buf->b_u_line_ptr);
+  XFREE_CLEAR(buf->b_u_line_ptr.ul_line);
+  buf->b_u_line_ptr.ul_len = 0;
   buf->b_u_line_lnum = 0;
 }
 
@@ -3037,7 +3048,7 @@ void u_clearline(buf_T *buf)
 /// Careful: may trigger autocommands that reload the buffer.
 void u_undoline(void)
 {
-  if (curbuf->b_u_line_ptr == NULL
+  if (curbuf->b_u_line_ptr.ul_line == NULL
       || curbuf->b_u_line_lnum > curbuf->b_ml.ml_line_count) {
     beep_flush();
     return;
@@ -3049,12 +3060,14 @@ void u_undoline(void)
     return;
   }
 
-  char *oldp = u_save_line(curbuf->b_u_line_lnum);
-  ml_replace(curbuf->b_u_line_lnum, curbuf->b_u_line_ptr, true);
-  extmark_splice_cols(curbuf, (int)curbuf->b_u_line_lnum - 1, 0, (colnr_T)strlen(oldp),
-                      (colnr_T)strlen(curbuf->b_u_line_ptr), kExtmarkUndo);
+  undoline_T oldp;
+  u_save_line(&oldp, curbuf->b_u_line_lnum);
+  ml_replace_len(curbuf->b_u_line_lnum, curbuf->b_u_line_ptr.ul_line,
+                 curbuf->b_u_line_ptr.ul_len - 1,
+                 false);
+  extmark_splice_cols(curbuf, (int)curbuf->b_u_line_lnum - 1, 0, (colnr_T)oldp.ul_len,
+                      (colnr_T)curbuf->b_u_line_ptr.ul_len, kExtmarkUndo);
   changed_bytes(curbuf->b_u_line_lnum, 0);
-  xfree(curbuf->b_u_line_ptr);
   curbuf->b_u_line_ptr = oldp;
 
   colnr_T t = curbuf->b_u_line_colnr;
@@ -3069,18 +3082,28 @@ void u_undoline(void)
 /// Allocate memory and copy curbuf line into it.
 ///
 /// @param lnum the line to copy
-static char *u_save_line(linenr_T lnum)
+static void u_save_line(undoline_T *ul, linenr_T lnum)
+  FUNC_ATTR_NONNULL_ALL
 {
-  return u_save_line_buf(curbuf, lnum);
+  u_save_line_buf(curbuf, ul, lnum);
 }
 
 /// Allocate memory and copy line into it
 ///
 /// @param lnum line to copy
 /// @param buf buffer to copy from
-static char *u_save_line_buf(buf_T *buf, linenr_T lnum)
+static void u_save_line_buf(buf_T *buf, undoline_T *ul, linenr_T lnum)
+  FUNC_ATTR_NONNULL_ALL
 {
-  return xstrdup(ml_get_buf(buf, lnum));
+  char *line = ml_get_buf(buf, lnum);
+
+  if (buf->b_ml.ml_line_len == 0) {
+    ul->ul_len = 1;
+    ul->ul_line = xstrdup("");
+  } else {
+    ul->ul_len = (size_t)buf->b_ml.ml_line_len;
+    ul->ul_line = xmemdup(line, ul->ul_len);
+  }
 }
 
 /// Check if the 'modified' flag is set, or 'ff' has changed (only need to

--- a/src/nvim/undo.c
+++ b/src/nvim/undo.c
@@ -1651,7 +1651,9 @@ void u_read_undo(char *name, const uint8_t *hash, const char *orig_name FUNC_ATT
   goto theend;
 
 error:
-  xfree(line_ptr.ul_line);
+  if (line_ptr.ul_line != NULL) {
+    XFREE_CLEAR(line_ptr.ul_line);
+  }
   if (uhp_table != NULL) {
     for (int i = 0; i < num_read_uhps; i++) {
       if (uhp_table[i] != NULL) {
@@ -2368,7 +2370,9 @@ static void u_undoredo(bool undo, bool do_buf_event)
         } else {
           ml_append_flags(lnum, uep->ue_array[i].ul_line, (colnr_T)uep->ue_array[i].ul_len, 0);  // ML_APPEND_UNDO
         }
-        xfree(uep->ue_array[i].ul_line);
+        if (uep->ue_array[i].ul_line != NULL) {
+          xfree(uep->ue_array[i].ul_line);
+        }
       }
       xfree(uep->ue_array);
     }
@@ -2968,7 +2972,10 @@ static void u_freeentries(buf_T *buf, u_header_T *uhp, u_header_T **uhpp)
 static void u_freeentry(u_entry_T *uep, int n)
 {
   while (n > 0) {
-    xfree(uep->ue_array[--n].ul_line);
+    n--;
+    if (uep->ue_array[n].ul_line != NULL) {
+      xfree(uep->ue_array[n].ul_line);
+    }
   }
   xfree(uep->ue_array);
 #ifdef U_DEBUG
@@ -2999,7 +3006,9 @@ void u_blockfree(buf_T *buf)
     u_freeheader(buf, buf->b_u_oldhead, NULL);
     assert(buf->b_u_oldhead != previous_oldhead);
   }
-  xfree(buf->b_u_line_ptr.ul_line);
+  if (buf->b_u_line_ptr.ul_line != NULL) {
+    XFREE_CLEAR(buf->b_u_line_ptr.ul_line);
+  }
 }
 
 /// Free all allocated memory blocks for the buffer 'buf'.

--- a/src/nvim/undo_defs.h
+++ b/src/nvim/undo_defs.h
@@ -17,13 +17,19 @@ typedef struct {
   colnr_T vi_curswant;  ///< MAXCOL from w_curswant
 } visualinfo_T;
 
+// One line saved for undo.
+typedef struct {
+  char *ul_line;  // text of the line
+  size_t ul_len;  // length of the line including NUL
+} undoline_T;
+
 typedef struct u_entry u_entry_T;
 struct u_entry {
   u_entry_T *ue_next;  ///< pointer to next entry in list
   linenr_T ue_top;     ///< number of line above undo block
   linenr_T ue_bot;     ///< number of line below undo block
   linenr_T ue_lcount;  ///< linecount when u_save called
-  char **ue_array;     ///< array of lines in undo block
+  undoline_T *ue_array;  ///< array of lines in undo block
   linenr_T ue_size;    ///< number of lines in ue_array
 #ifdef U_DEBUG
   int ue_magic;        ///< magic number to check allocation


### PR DESCRIPTION
Problem:    Text properties are not restored by undo.
Solution:   Also save text properties for undo.

https://github.com/vim/vim/commit/ccae4672fd622f2feac8322be71b6e43e68dc4fc

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
