### PR TITLE
fix(lsp): don't go back to the first item after inline_completion.select()

### DIFF
--- a/runtime/lua/vim/lsp/inline_completion.lua
+++ b/runtime/lua/vim/lsp/inline_completion.lua
@@ -373,7 +373,7 @@ function M.select(opts)
   end
 
   local count = opts.count or vim.v.count1
-  local wrap = opts.wrap or true
+  local wrap = opts.wrap ~= nil
 
   local current = completor.current
   if not current then


### PR DESCRIPTION
Problem: after inline_completion.select(), the item may change back to
the first one

Solution: select current one if it exists

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
