### PR TITLE
fix(health): accept tmux-direct as a valid tmux $TERM

### DIFF
--- a/runtime/lua/vim/health/health.lua
+++ b/runtime/lua/vim/health/health.lua
@@ -323,9 +323,11 @@ local function check_tmux()
       '$TERM differs from the tmux `default-terminal` setting. Colors might look wrong.',
       { '$TERM may have been set by some rc (.bashrc, .zshrc, ...).' }
     )
-  elseif not vim.regex([[\v(tmux-256color|screen-256color)]]):match_str(vim.env.TERM) then
+  elseif
+    not vim.regex([[\v(tmux-256color|tmux-direct|screen-256color)]]):match_str(vim.env.TERM)
+  then
     health.error(
-      '$TERM should be "screen-256color" or "tmux-256color" in tmux. Colors might look wrong.',
+      '$TERM should be "screen-256color", "tmux-256color", or "tmux-direct" in tmux. Colors might look wrong.',
       {
         'Set default-terminal in ~/.tmux.conf:\nset-option -g default-terminal "screen-256color"',
         suggest_faq,


### PR DESCRIPTION
tmux-direct is functionally the same as tmux-256color, except it directly reports 24-bit color and how to set them (setaf/setab) via ncurses 6.x's extended terminfo format.

`infocmp` output for demonstration:

```
❯ infocmp -d tmux-256color tmux-direct
comparing tmux-256color to tmux-direct.
    comparing booleans.
    comparing numbers.
        colors: 256, 16777216.
    comparing strings.
        setab: '\E[%?%p1%{8}%<%t4%p1%d%e%p1%{16}%<%t10%p1%{8}%-%d%e48;5;%p1%d%;m', '\E[%?%p1%{8}%<%t4%p1%d%e48:2::%p1%{65536}%/%d:%p1%{256}%/%{255}%&%d:%p1%{255}%&%d%;m'.
        setaf: '\E[%?%p1%{8}%<%t3%p1%d%e%p1%{16}%<%t9%p1%{8}%-%d%e38;5;%p1%d%;m', '\E[%?%p1%{8}%<%t3%p1%d%e38:2::%p1%{65536}%/%d:%p1%{256}%/%{255}%&%d:%p1%{255}%&%d%;m'.
```

There isn't, to my knowledge, a `screen-direct` entry, so I've only added the tmux one.