### PR TITLE
fix(extui): error on :call input('')

### DIFF
--- a/runtime/lua/vim/_extui/cmdline.lua
+++ b/runtime/lua/vim/_extui/cmdline.lua
@@ -41,7 +41,7 @@ local promptlen = 0 -- Current length of the last line in the prompt.
 ---@param prompt string
 local function set_text(content, prompt)
   local lines = {} ---@type string[]
-  for line in prompt:gmatch('[^\n]+') do
+  for line in (prompt .. '\n'):gmatch('(.-)\n') do
     lines[#lines + 1] = fn.strtrans(line)
   end
   cmdbuff, promptlen, M.erow = '', #lines[#lines], M.srow + #lines - 1

--- a/test/functional/ui/cmdline2_spec.lua
+++ b/test/functional/ui/cmdline2_spec.lua
@@ -88,4 +88,13 @@ describe('cmdline2', function()
                                                            |
     ]])
   end)
+
+  it('handles empty prompt', function()
+    feed(":call input('')<CR>")
+    screen:expect([[
+                                                           |
+      {1:~                                                    }|*12
+      ^                                                     |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:  Error on empty string prompt.
Solution: (prompt .. '\n'):gmatch('(.-)\n').