### PR TITLE
vim-patch:9.1.{1701,1702}

### DIFF
--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -2048,10 +2048,9 @@ endfunc
 " window, the window contents should be scrolled one line up. If the top line
 " is part of a fold, then the entire fold should be scrolled up.
 func Test_edit_lastline_scroll()
-  if has('gui_running')
+  if has('linux')
     " TODO: For unknown reasons, this test fails on CI when run in Gui mode
-    "       with ASAN enabled, figure out why
-    CheckNotAsan
+    CheckNotGui
   endif
   new
   let h = winheight(0)

--- a/test/old/testdir/test_edit.vim
+++ b/test/old/testdir/test_edit.vim
@@ -1716,7 +1716,7 @@ func Test_edit_special_chars()
   exe "normal " . t
   call assert_equal("ABC !a\<C-O>g\<C-G>8", getline(2))
 
-  close!
+  bw!
 endfunc
 
 func Test_edit_startinsert()
@@ -1747,7 +1747,7 @@ func Test_edit_startreplace()
   call assert_equal("axyz\tb", getline(1))
   call feedkeys("0i\<C-R>=execute('startreplace')\<CR>12\e", 'xt')
   call assert_equal("12axyz\tb", getline(1))
-  close!
+  bw!
 endfunc
 
 func Test_edit_noesckeys()
@@ -1786,7 +1786,7 @@ func Test_edit_ctrl_o_invalid_cmd()
   call assert_equal('abc', getline(1))
   set showmode& showcmd&
   " call test_override('ui_delay', 0)
-  close!
+  bw!
 endfunc
 
 " Test for editing a file with a very long name
@@ -1990,7 +1990,7 @@ func Test_edit_hkmap()
   call assert_equal(expected, getline(1))
 
   set revins& hkmap& hkmapp&
-  close!
+  bw!
 endfunc
 
 " Test for 'allowrevins' and using CTRL-_ in insert mode
@@ -2001,7 +2001,7 @@ func Test_edit_allowrevins()
   call feedkeys("iABC\<C-_>DEF\<C-_>GHI", 'xt')
   call assert_equal('ABCFEDGHI', getline(1))
   set allowrevins&
-  close!
+  bw!
 endfunc
 
 " Test for inserting a register in insert mode using CTRL-R
@@ -2025,7 +2025,7 @@ func Test_edit_insert_reg()
   call feedkeys("a\<C-R>=[]\<CR>", "xt")
   call assert_equal(['r'], getbufline('', 1, '$'))
   call test_override('ALL', 0)
-  close!
+  bw!
 endfunc
 
 " Test for positioning cursor after CTRL-R expression failed
@@ -2048,6 +2048,11 @@ endfunc
 " window, the window contents should be scrolled one line up. If the top line
 " is part of a fold, then the entire fold should be scrolled up.
 func Test_edit_lastline_scroll()
+  if has('gui_running')
+    " TODO: For unknown reasons, this test fails on CI when run in Gui mode
+    "       with ASAN enabled, figure out why
+    CheckNotAsan
+  endif
   new
   let h = winheight(0)
   let lines = ['one', 'two', 'three']
@@ -2068,7 +2073,7 @@ func Test_edit_lastline_scroll()
   call assert_equal(h - 1, winline())
   call assert_equal(3, line('w0'))
 
-  close!
+  bw!
 endfunc
 
 func Test_edit_browse()


### PR DESCRIPTION
#### vim-patch:9.1.1701: tests: failure on CI with GUI and ASAN in test_edit.res

Problem:  tests: failure on CI with GUI and ASAN in test_edit.res
          (Hirohito Higashi)
Solution: Disable the test for that specific situation in CI, close
          swapfiles

https://github.com/vim/vim/commit/6c14c4625b99fab98ae3836d4f12e35c7aefa51a

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.1702: tests: test_edit still fails on CI

Problem:  tests: test_edit still fails on CI
          (after v9.1.1701)
Solution: Fix the skip condition

https://github.com/vim/vim/commit/42acf736a34904e4c030f9c164f41717bde96427

Co-authored-by: Christian Brabandt <cb@256bit.org>