### PR TITLE
vim-patch:9.1.1700: Multiline ignorecase specific pattern does not match with 'ignorecase'

### DIFF
--- a/src/nvim/regexp.c
+++ b/src/nvim/regexp.c
@@ -1582,6 +1582,7 @@ static void reg_nextline(void)
 // Returns RA_FAIL, RA_NOMATCH or RA_MATCH.
 // If "bytelen" is not NULL, it is set to the byte length of the match in the
 // last line.
+// Optional: ignore case if rex.reg_ic is set.
 static int match_with_backref(linenr_T start_lnum, colnr_T start_col, linenr_T end_lnum,
                               colnr_T end_col, int *bytelen)
 {
@@ -1619,7 +1620,8 @@ static int match_with_backref(linenr_T start_lnum, colnr_T start_col, linenr_T e
       len = reg_getline_len(clnum) - ccol;
     }
 
-    if (cstrncmp(p + ccol, (char *)rex.input, &len) != 0) {
+    if ((!rex.reg_ic && cstrncmp(p + ccol, (char *)rex.input, &len) != 0)
+        || (rex.reg_ic && mb_strnicmp(p + ccol, (char *)rex.input, (size_t)len) != 0)) {
       return RA_NOMATCH;  // doesn't match
     }
     if (bytelen != NULL) {

--- a/test/old/testdir/test_regexp_utf8.vim
+++ b/test/old/testdir/test_regexp_utf8.vim
@@ -455,7 +455,7 @@ func Run_regexp_multibyte_magic()
   @w
   call assert_equal('k œ̄ṣ́m̥̄ᾱ̆́', getline(18))
 
-  close!
+  bw!
 endfunc
 
 func Test_regexp_multibyte_magic()
@@ -473,7 +473,7 @@ func Test_split_multibyte_to_bytes()
   call setline(1, 'l äö üᾱ̆́')
   s/ \?/ /g
   call assert_equal(' l ä ö ü ᾱ̆́', getline(1))
-  close!
+  bw!
 endfunc
 
 " Test for matchstr() with multibyte characters
@@ -483,7 +483,7 @@ func Test_matchstr_multibyte()
   call assert_equal('בג', matchstr("אבגד", "..", 0, 2))
   call assert_equal('א', matchstr("אבגד", ".", 0, 0))
   call assert_equal('ג', matchstr("אבגד", ".", 4, -1))
-  close!
+  bw!
 endfunc
 
 " Test for 7.4.636
@@ -494,7 +494,7 @@ func Test_search_with_end_offset()
   exe "normal /(/e+\<CR>"
   normal n"ayn
   call assert_equal("a\ncat(", @a)
-  close!
+  bw!
 endfunc
 
 " Check that "^" matches even when the line starts with a combining char
@@ -623,7 +623,23 @@ func Test_search_multibyte_match_ascii()
     call assert_equal(['s', 'ss', 'ſſ', 'ſ'], ic_match3, "Ignorecase Collection Regex-engine: " .. &re)
     call assert_equal(['ſſ','ſ'], noic_match3, "No-Ignorecase Collection Regex-engine: " .. &re)
   endfor
+  set re&vim
   bw!
 endfunc
+
+func Test_replace_multibyte_match_in_multi_lines()
+  new
+  let text = ['ab 1c', 'ab 1c', 'def', '是否 a', '是否 a', 'ghi', '是否a', '是否a', '是否 1', '是否 1']
+  let expected = ['', 'def', '', 'ghi', '', '']
+  for i in range(0, 2)
+    exe "set ignorecase re="..i
+    :%d _
+    call setline(1, text)
+    :%s/\(.\+\)\n\1//g
+    call assert_equal(expected, getline(1, '$'))
+  endfor
+  bw!
+  set ignorecase&vim re&vim
+endfun
 
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1700: Multiline ignorecase specific pattern does not match with 'ignorecase'

Problem:  a pattern that involves a backref on a different line does not
          match when 'ignorecase' is set (QiWei, after v9.1.0645)
Solution: Use MB_STRNICMP when ignorecase is set, fix tests to close
          swapfiles

related: vim/vim#14756
closes: vim/vim#18104

https://github.com/vim/vim/commit/bf82e58a702900c70638e8047039fdf5f12f749f

Co-authored-by: Christian Brabandt <cb@256bit.org>