### PR TITLE
vim-patch:9.1.1698: Some error numbers are not documented

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -306,6 +306,7 @@ BufUnload			Before unloading a buffer, when the text in
 				going to exit.
 				NOTE: Current buffer "%" is not the target
 				buffer "<afile>", "<abuf>". |<buffer=abuf>|
+								*E1546*
 				Do not switch buffers or windows!
 				Not triggered when exiting and v:dying is 2 or
 				more.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1359,7 +1359,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	This option cannot be set from a |modeline| or in the |sandbox|, for
 	security reasons.
 
-						*'chistory'* *'chi'*
+					*'chistory'* *'chi'* *E1542* *E1543*
 'chistory' 'chi'	number	(default 10)
 			global
 	Number of quickfix lists that should be remembered for the quickfix

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1205,6 +1205,7 @@ local options = {
       full_name = 'chistory',
       scope = { 'global' },
       short_desc = N_('number of quickfix lists stored in history'),
+      tags = { 'E1542', 'E1543' },
       type = 'number',
       varname = 'p_chi',
     },


### PR DESCRIPTION
#### vim-patch:9.1.1698: Some error numbers are not documented

Problem:  Some error numbers are not documented
          (Restorer)
Solution: Document missing error numbers (Yegappan Lakshmanan).

closes: vim/vim#18135

https://github.com/vim/vim/commit/5e27058fc4a98dbea16f72bc54e76bbe1d455168

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>