### PR TITLE
add nbsp to trick html generator

### DIFF
--- a/runtime/doc/map.txt
+++ b/runtime/doc/map.txt
@@ -394,7 +394,7 @@ Overview of which map command works in which mode.  More details below.
 
 Same information in a table:
 							*map-table*
-         Mode  | Norm | Ins | Cmd | Vis | Sel | Opr | Term | Lang | ~
+         Mode  | Norm | Ins | Cmd | Vis | Sel | Opr | Term | Lang | ~
 Command        +------+-----+-----+-----+-----+-----+------+------+ ~
 [nore]map      | yes  |  -  |  -  | yes | yes | yes |  -   |  -   |
 n[nore]map     | yes  |  -  |  -  |  -  |  -  |  -  |  -   |  -   |


### PR DESCRIPTION
https://neovim.io/doc/user/map.html#map-table
This looks wrong because the initial whitespace is trimmed
apparently you can work around this by adding an nbsp

