### PR TITLE
feat(progress): simplify progress ui-event and introduce default formating

### DIFF
--- a/runtime/doc/api-ui-events.txt
+++ b/runtime/doc/api-ui-events.txt
@@ -825,7 +825,7 @@ will be set to zero, but can be changed and used for the replacing cmdline or
 message window. Cmdline state is emitted as |ui-cmdline| events, which the UI
 must handle.
 
-["msg_show", kind, content, replace_last, history, append, msg_id, progress] ~
+["msg_show", kind, content, replace_last, history, append, msg_id] ~
 	Display a message to the user.
 
 	kind
@@ -885,18 +885,6 @@ must handle.
 	msg_id
 	    Unique identifier for the message. It can either be an integer or
 	    string. When message of same id appears it should replace the older message.
-
-	progress
-	    Progress-message properties:
-	       • title: Title string of the progress message.
-	       • status: Status of the progress message. Can contain one of
-	         the following values
-	            • success: The progress item completed successfully
-	            • running: The progress is ongoing
-	            • failed: The progress item failed
-	            • cancel: The progressing process should be canceled.
-	       • percent: How much progress is done on the progress
-                     message
 
 ["msg_clear"] ~
 	Clear all messages currently displayed by "msg_show", emitted after

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -39,6 +39,11 @@ TREESITTER
 
 • todo
 
+UI
+
+• `progress` attribute removed form |ui-messages| msg_show event
+
+
 ==============================================================================
 BREAKING CHANGES                                                *news-breaking*
 
@@ -190,7 +195,7 @@ EVENTS
 
 • |CmdlineLeavePre| triggered before preparing to leave the command line.
 • New `append` paremeter for |ui-messages| `msg_show` event.
-• New `msg_id` and `progress` paremeter for |ui-messages| `msg_show` event.
+• New `msg_id` paremeter for |ui-messages| `msg_show` event.
 • Creating or updating a progress message with |nvim_echo()| triggers a |Progress| event.
 
 HIGHLIGHTS

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -165,7 +165,7 @@ void wildmenu_hide(void)
   FUNC_API_SINCE(3) FUNC_API_REMOTE_ONLY;
 
 void msg_show(String kind, Array content, Boolean replace_last, Boolean history, Boolean append,
-              Object id, Dict progress)
+              Object id)
   FUNC_API_SINCE(6) FUNC_API_FAST FUNC_API_REMOTE_ONLY;
 void msg_clear(void)
   FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -152,7 +152,6 @@ bool keep_msg_more = false;    // keep_msg was set by msgmore()
 // Extended msg state, currently used for external UIs with ext_messages
 static const char *msg_ext_kind = NULL;
 static MsgID msg_ext_id = { .type = kObjectTypeInteger, .data.integer = 0 };
-static DictOf(Object) msg_ext_progress = ARRAY_DICT_INIT;
 static Array *msg_ext_chunks = NULL;
 static garray_T msg_ext_last_chunk = GA_INIT(sizeof(char), 40);
 static sattr_T msg_ext_last_attr = -1;
@@ -1106,18 +1105,6 @@ static void msg_hist_add_multihl(MsgID msg_id, HlMessage msg, bool temp, Message
   msg_ext_history = true;
 
   msg_ext_id = msg_id;
-  if (strequal(msg_ext_kind, "progress") && msg_data != NULL && ui_has(kUIMessages)) {
-    kv_resize(msg_ext_progress, 3);
-    if (msg_data->title.size != 0) {
-      PUT_C(msg_ext_progress, "title", STRING_OBJ(msg_data->title));
-    }
-    if (msg_data->status.size != 0) {
-      PUT_C(msg_ext_progress, "status", STRING_OBJ(msg_data->status));
-    }
-    if (msg_data->percent >= 0) {
-      PUT_C(msg_ext_progress, "percent", INTEGER_OBJ(msg_data->percent));
-    }
-  }
   msg_hist_clear(msg_hist_max);
 }
 
@@ -2210,8 +2197,7 @@ void msg_puts_len(const char *const str, const ptrdiff_t len, int hl_id, bool hi
   if (msg_silent != 0 || *str == NUL) {
     if (*str == NUL && ui_has(kUIMessages)) {
       ui_call_msg_show(cstr_as_string("empty"), (Array)ARRAY_DICT_INIT, false, false, false,
-                       INTEGER_OBJ(-1),
-                       (Dict)ARRAY_DICT_INIT);
+                       INTEGER_OBJ(-1));
     }
     return;
   }
@@ -3239,7 +3225,7 @@ void msg_ext_ui_flush(void)
     Array *tofree = msg_ext_init_chunks();
 
     ui_call_msg_show(cstr_as_string(msg_ext_kind), *tofree, msg_ext_overwrite, msg_ext_history,
-                     msg_ext_append, msg_ext_id, msg_ext_progress);
+                     msg_ext_append, msg_ext_id);
     // clear info after emiting message.
     if (msg_ext_history) {
       api_free_array(*tofree);
@@ -3260,7 +3246,6 @@ void msg_ext_ui_flush(void)
     msg_ext_append = false;
     msg_ext_kind = NULL;
     msg_ext_id = INTEGER_OBJ(0);
-    kv_destroy(msg_ext_progress);
   }
 }
 

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -3198,11 +3198,6 @@ describe('progress-message', function()
       messages = {
         {
           content = { { 'test-message' } },
-          progress = {
-            percent = 10,
-            status = 'running',
-            title = 'testsuit',
-          },
           history = true,
           id = 1,
           kind = 'progress',
@@ -3233,11 +3228,6 @@ describe('progress-message', function()
       messages = {
         {
           content = { { 'test-message-updated' } },
-          progress = {
-            percent = 50,
-            status = 'running',
-            title = 'TestSuit',
-          },
           history = true,
           id = 1,
           kind = 'progress',
@@ -3298,11 +3288,6 @@ describe('progress-message', function()
           history = true,
           id = 1,
           kind = 'progress',
-          progress = {
-            percent = 10,
-            status = 'running',
-            title = 'TestSuit',
-          },
         },
       },
     })
@@ -3495,11 +3480,6 @@ describe('progress-message', function()
           history = true,
           id = 'str-id',
           kind = 'progress',
-          progress = {
-            percent = 30,
-            status = 'running',
-            title = 'TestSuit',
-          },
         },
       },
     })

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -3197,7 +3197,7 @@ describe('progress-message', function()
       ]],
       messages = {
         {
-          content = { { 'test-message' } },
+          content = { { 'testsuit: test-message...10%' } },
           history = true,
           id = 1,
           kind = 'progress',
@@ -3227,7 +3227,7 @@ describe('progress-message', function()
       ]],
       messages = {
         {
-          content = { { 'test-message-updated' } },
+          content = { { 'TestSuit: test-message-updated...50%' } },
           history = true,
           id = 1,
           kind = 'progress',
@@ -3284,7 +3284,7 @@ describe('progress-message', function()
       ]],
       messages = {
         {
-          content = { { 'test-message' } },
+          content = { { 'TestSuit: test-message...10%' } },
           history = true,
           id = 1,
           kind = 'progress',
@@ -3476,7 +3476,7 @@ describe('progress-message', function()
       ]],
       messages = {
         {
-          content = { { 'supports str-id' } },
+          content = { { 'TestSuit: supports str-id...30%' } },
           history = true,
           id = 'str-id',
           kind = 'progress',
@@ -3498,5 +3498,20 @@ describe('progress-message', function()
       id = 'str-id',
       data = {},
     })
+  end)
+
+  it('tui displays progress message in proper format', function()
+    clear()
+    setup_screen(false)
+    api.nvim_echo(
+      { { 'test-message' } },
+      true,
+      { kind = 'progress', title = 'TestSuit', percent = 10, status = 'running' }
+    )
+    screen:expect([[
+      ^                                        |
+      {1:~                                       }|*3
+      TestSuit: test-message...10%            |
+    ]])
   end)
 end)


### PR DESCRIPTION
### Problem

Currently, progress-api takes in additional info from the user (title, status, percent) but doesn't display them anywhere in the.

### Solution

Format tui messages as `{title}: {msg}...{percent}%`. This also gets sent to UI. This was originally part of #34846 but was deferred to simplify the pr.

### Advantage
With specific formatting sent to UI we can remove the progress attribute from `msg_show` event. Since we are still not sure about it, it's best if we don't rush it in. Instead, it can be added if needed in the future. Also, with default formatting set UI by default has a better behavior (for adding support to `vim._extui` we just need to implement the replace msg on same id instruction). And TUI also represents progress-messages more progress like. And if any UI/plugin want's to do anything fancier Progress event provides all the tools they need.