### PR TITLE
perf(highlight): allow decoration providers to skip ranges without data

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3362,6 +3362,12 @@ nvim_set_decoration_provider({ns_id}, {opts})
                    included. >
                     ["range", winid, bufnr, begin_row, begin_col, end_row, end_col]
 <
+                   In addition to returning a boolean, it is also allowed to
+                   return a `skip_row, skip_col` pair of integers. This
+                   implies that this function does not need to be called until
+                   a range which continues beyond the skipped position. A
+                   single integer return value `skip_row` is short for
+                   `skip_row, 0`
                  • on_end: called at the end of a redraw cycle >
                     ["end", tick]
 <

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -2175,6 +2175,13 @@ function vim.api.nvim_set_current_win(window) end
 ---   ```
 ---     ["range", winid, bufnr, begin_row, begin_col, end_row, end_col]
 ---   ```
+---
+---   In addition to returning a boolean, it is also allowed to
+---   return a `skip_row, skip_col` pair of integers. This implies
+---   that this function does not need to be called until a range
+---   which continues beyond the skipped position. A single integer
+---   return value `skip_row` is short for `skip_row, 0`
+---
 --- - on_end: called at the end of a redraw cycle
 ---   ```
 ---     ["end", tick]

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -423,6 +423,7 @@ error('Cannot require a meta file')
 --- @field undo_restore? boolean
 --- @field url? string
 --- @field scoped? boolean
+--- @field _subpriority? integer
 
 --- @class vim.api.keyset.user_command
 --- @field addr? any

--- a/runtime/lua/vim/treesitter/highlighter.lua
+++ b/runtime/lua/vim/treesitter/highlighter.lua
@@ -360,7 +360,10 @@ local function on_range_impl(
   local MAX_ROW = 2147483647 -- sentinel for skipping to the end of file
   local skip_until_row = MAX_ROW
   local skip_until_col = 0
+
+  local subtree_counter = 0
   self:for_each_highlight_state(win, function(state)
+    subtree_counter = subtree_counter + 1
     local root_node = state.tstree:root()
     ---@type { [1]: integer, [2]: integer, [3]: integer, [4]: integer }
     local root_range = { root_node:range() }
@@ -449,6 +452,7 @@ local function on_range_impl(
               conceal = conceal,
               spell = spell,
               url = url,
+              _subpriority = subtree_counter,
             })
           end
 

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -1051,6 +1051,13 @@ void nvim_buf_clear_namespace(Buffer buffer, Integer ns_id, Integer line_start, 
 ///               ```
 ///                 ["range", winid, bufnr, begin_row, begin_col, end_row, end_col]
 ///               ```
+///
+///               In addition to returning a boolean, it is also allowed to
+///               return a `skip_row, skip_col` pair of integers. This implies
+///               that this function does not need to be called until a range
+///               which continues beyond the skipped position. A single integer
+///               return value `skip_row` is short for `skip_row, 0`
+///
 ///             - on_end: called at the end of a redraw cycle
 ///               ```
 ///                 ["end", tick]

--- a/src/nvim/api/extmark.c
+++ b/src/nvim/api/extmark.c
@@ -836,6 +836,15 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
       col2 = c;
     }
 
+    DecorPriority subpriority = 0;
+    if (HAS_KEY(opts, set_extmark, _subpriority)) {
+      VALIDATE_RANGE((opts->_subpriority >= 0 && opts->_subpriority <= UINT16_MAX),
+                     "_subpriority", {
+        goto error;
+      });
+      subpriority = (DecorPriority)opts->_subpriority;
+    }
+
     if (kv_size(virt_text.data.virt_text)) {
       decor_range_add_virt(&decor_state, r, c, line2, col2, decor_put_vt(virt_text, NULL), true);
     }
@@ -845,7 +854,8 @@ Integer nvim_buf_set_extmark(Buffer buffer, Integer ns_id, Integer line, Integer
     if (has_hl) {
       DecorSignHighlight sh = decor_sh_from_inline(hl);
       sh.url = url;
-      decor_range_add_sh(&decor_state, r, c, line2, col2, &sh, true, (uint32_t)ns_id, id);
+      decor_range_add_sh(&decor_state, r, c, line2, col2, &sh, true, (uint32_t)ns_id, id,
+                         subpriority);
     }
   } else {
     if (opts->ephemeral) {

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -62,6 +62,8 @@ typedef struct {
   Boolean undo_restore;
   String url;
   Boolean scoped;
+
+  Integer _subpriority;
 } Dict(set_extmark);
 
 typedef struct {

--- a/src/nvim/decoration.h
+++ b/src/nvim/decoration.h
@@ -37,7 +37,7 @@ typedef struct {
   int end_row;
   int end_col;
   int ordering;  ///< range insertion order
-  DecorPriority priority;
+  DecorPriorityInternal priority_internal;
   bool owned;  ///< ephemeral decoration, free memory immediately
   DecorRangeKind kind;
   // next pointers MUST NOT be used, these are separate ranges

--- a/src/nvim/decoration_defs.h
+++ b/src/nvim/decoration_defs.h
@@ -36,6 +36,7 @@ enum {
 typedef kvec_t(struct virt_line { VirtText line; int flags; }) VirtLines;
 
 typedef uint16_t DecorPriority;
+typedef uint32_t DecorPriorityInternal;
 #define DECOR_PRIORITY_BASE 0x1000
 
 /// Keep in sync with hl_mode_str[] in decoration.h

--- a/src/nvim/decoration_defs.h
+++ b/src/nvim/decoration_defs.h
@@ -145,6 +145,9 @@ typedef struct {
     kDecorProviderDisabled = 4,
   } state;
 
+  int win_skip_row;
+  int win_skip_col;
+
   LuaRef redraw_start;
   LuaRef redraw_buf;
   LuaRef redraw_win;
@@ -159,3 +162,8 @@ typedef struct {
 
   uint8_t error_count;
 } DecorProvider;
+
+#define DECORATION_PROVIDER_INIT(ns_id) (DecorProvider) \
+  { ns_id, kDecorProviderDisabled, 0, 0, LUA_NOREF, LUA_NOREF, \
+    LUA_NOREF, LUA_NOREF, LUA_NOREF, LUA_NOREF, \
+    LUA_NOREF, LUA_NOREF, -1, false, false, 0 }

--- a/src/nvim/decoration_provider.c
+++ b/src/nvim/decoration_provider.c
@@ -23,11 +23,6 @@
 
 static kvec_t(DecorProvider) decor_providers = KV_INITIAL_VALUE;
 
-#define DECORATION_PROVIDER_INIT(ns_id) (DecorProvider) \
-  { ns_id, kDecorProviderDisabled, LUA_NOREF, LUA_NOREF, \
-    LUA_NOREF, LUA_NOREF, LUA_NOREF, LUA_NOREF, \
-    LUA_NOREF, LUA_NOREF, -1, false, false, 0 }
-
 static void decor_provider_error(DecorProvider *provider, const char *name, const char *msg)
 {
   const char *ns = describe_ns(provider->ns_id, "(UNKNOWN PLUGIN)");
@@ -38,21 +33,28 @@ static void decor_provider_error(DecorProvider *provider, const char *name, cons
 // Note we pass in a provider index as this function may cause decor_providers providers to be
 // reallocated so we need to be careful with DecorProvider pointers
 static bool decor_provider_invoke(int provider_idx, const char *name, LuaRef ref, Array args,
-                                  bool default_true)
+                                  bool default_true, Array *res)
 {
   Error err = ERROR_INIT;
 
   textlock++;
-  Object ret = nlua_call_ref(ref, name, args, kRetNilBool, NULL, &err);
+  Object ret = nlua_call_ref(ref, name, args, res ? kRetMulti : kRetNilBool, NULL, &err);
   textlock--;
 
   // We get the provider here via an index in case the above call to nlua_call_ref causes
   // decor_providers to be reallocated.
   DecorProvider *provider = &kv_A(decor_providers, provider_idx);
-  if (!ERROR_SET(&err)
-      && api_object_to_bool(ret, "provider %s retval", default_true, &err)) {
+  if (!ERROR_SET(&err)) {
     provider->error_count = 0;
-    return true;
+    if (res) {
+      assert(ret.type == kObjectTypeArray);
+      *res = ret.data.array;
+      return true;
+    } else {
+      if (api_object_to_bool(ret, "provider %s retval", default_true, &err)) {
+        return true;
+      }
+    }
   }
 
   if (ERROR_SET(&err) && provider->error_count < CB_MAX_ERROR) {
@@ -65,7 +67,7 @@ static bool decor_provider_invoke(int provider_idx, const char *name, LuaRef ref
   }
 
   api_clear_error(&err);
-  api_free_object(ret);
+  api_free_object(ret);  // TODO(bfredl): wants to be on an arena
   return false;
 }
 
@@ -81,7 +83,7 @@ void decor_providers_invoke_spell(win_T *wp, int start_row, int start_col, int e
       ADD_C(args, INTEGER_OBJ(start_col));
       ADD_C(args, INTEGER_OBJ(end_row));
       ADD_C(args, INTEGER_OBJ(end_col));
-      decor_provider_invoke((int)i, "spell", p->spell_nav, args, true);
+      decor_provider_invoke((int)i, "spell", p->spell_nav, args, true, NULL);
     }
   }
 }
@@ -97,7 +99,7 @@ bool decor_providers_invoke_conceal_line(win_T *wp, int row)
       ADD_C(args, INTEGER_OBJ(wp->handle));
       ADD_C(args, INTEGER_OBJ(wp->w_buffer->handle));
       ADD_C(args, INTEGER_OBJ(row));
-      decor_provider_invoke((int)i, "conceal_line", p->conceal_line, args, true);
+      decor_provider_invoke((int)i, "conceal_line", p->conceal_line, args, true, NULL);
     }
   }
   return wp->w_buffer->b_marktree->n_keys > keys;
@@ -114,7 +116,7 @@ void decor_providers_start(void)
     if (p->state != kDecorProviderDisabled && p->redraw_start != LUA_NOREF) {
       MAXSIZE_TEMP_ARRAY(args, 2);
       ADD_C(args, INTEGER_OBJ((int)display_tick));
-      bool active = decor_provider_invoke((int)i, "start", p->redraw_start, args, true);
+      bool active = decor_provider_invoke((int)i, "start", p->redraw_start, args, true, NULL);
       kv_A(decor_providers, i).state = active ? kDecorProviderActive : kDecorProviderRedrawDisabled;
     } else if (p->state != kDecorProviderDisabled) {
       kv_A(decor_providers, i).state = kDecorProviderActive;
@@ -147,6 +149,9 @@ void decor_providers_invoke_win(win_T *wp)
       p->state = kDecorProviderActive;
     }
 
+    p->win_skip_row = 0;
+    p->win_skip_col = 0;
+
     if (p->state == kDecorProviderActive && p->redraw_win != LUA_NOREF) {
       MAXSIZE_TEMP_ARRAY(args, 4);
       ADD_C(args, WINDOW_OBJ(wp->handle));
@@ -154,7 +159,8 @@ void decor_providers_invoke_win(win_T *wp)
       // TODO(bfredl): we are not using this, but should be first drawn line?
       ADD_C(args, INTEGER_OBJ(wp->w_topline - 1));
       ADD_C(args, INTEGER_OBJ(botline - 1));
-      if (!decor_provider_invoke((int)i, "win", p->redraw_win, args, true)) {
+      // TODO(bfredl): could skip a call if retval was interpreted like range?
+      if (!decor_provider_invoke((int)i, "win", p->redraw_win, args, true, NULL)) {
         kv_A(decor_providers, i).state = kDecorProviderWinDisabled;
       }
     }
@@ -178,7 +184,7 @@ void decor_providers_invoke_line(win_T *wp, int row)
       ADD_C(args, WINDOW_OBJ(wp->handle));
       ADD_C(args, BUFFER_OBJ(wp->w_buffer->handle));
       ADD_C(args, INTEGER_OBJ(row));
-      if (!decor_provider_invoke((int)i, "line", p->redraw_line, args, true)) {
+      if (!decor_provider_invoke((int)i, "line", p->redraw_line, args, true, NULL)) {
         // return 'false' or error: skip rest of this window
         kv_A(decor_providers, i).state = kDecorProviderWinDisabled;
       }
@@ -195,6 +201,10 @@ void decor_providers_invoke_range(win_T *wp, int start_row, int start_col, int e
   for (size_t i = 0; i < kv_size(decor_providers); i++) {
     DecorProvider *p = &kv_A(decor_providers, i);
     if (p->state == kDecorProviderActive && p->redraw_range != LUA_NOREF) {
+      if (p->win_skip_row > end_row || (p->win_skip_row == end_row && p->win_skip_col >= end_col)) {
+        continue;
+      }
+
       MAXSIZE_TEMP_ARRAY(args, 6);
       ADD_C(args, WINDOW_OBJ(wp->handle));
       ADD_C(args, BUFFER_OBJ(wp->w_buffer->handle));
@@ -202,10 +212,34 @@ void decor_providers_invoke_range(win_T *wp, int start_row, int start_col, int e
       ADD_C(args, INTEGER_OBJ(start_col));
       ADD_C(args, INTEGER_OBJ(end_row));
       ADD_C(args, INTEGER_OBJ(end_col));
-      if (!decor_provider_invoke((int)i, "range", p->redraw_range, args, true)) {
-        // return 'false' or error: skip rest of this window
-        kv_A(decor_providers, i).state = kDecorProviderWinDisabled;
+      Array res = ARRAY_DICT_INIT;
+      bool status = decor_provider_invoke((int)i, "range", p->redraw_range, args, true, &res);
+      p = &kv_A(decor_providers, i);  // lua call might have reallocated decor_providers
+
+      if (!status) {
+        // error: skip rest of this window
+        p->state = kDecorProviderWinDisabled;
+      } else if (res.size >= 1) {
+        Object first = res.items[0];
+        if (first.type == kObjectTypeBoolean) {
+          if (first.data.boolean == false) {
+            p->state = kDecorProviderWinDisabled;
+          }
+        } else if (first.type == kObjectTypeInteger) {
+          Integer row = first.data.integer;
+          Integer col = 0;
+          if (res.size >= 2) {
+            Object second = res.items[1];
+            if (second.type == kObjectTypeInteger) {
+              col = second.data.integer;
+            }
+          }
+          p->win_skip_row = (int)row;
+          p->win_skip_col = (int)col;
+        }
       }
+
+      api_free_array(res);
 
       hl_check_ns();
     }
@@ -226,7 +260,7 @@ void decor_providers_invoke_buf(buf_T *buf)
       MAXSIZE_TEMP_ARRAY(args, 2);
       ADD_C(args, BUFFER_OBJ(buf->handle));
       ADD_C(args, INTEGER_OBJ((int64_t)display_tick));
-      decor_provider_invoke((int)i, "buf", p->redraw_buf, args, true);
+      decor_provider_invoke((int)i, "buf", p->redraw_buf, args, true, NULL);
     }
   }
 }
@@ -243,7 +277,7 @@ void decor_providers_invoke_end(void)
     if (p->state != kDecorProviderDisabled && p->redraw_end != LUA_NOREF) {
       MAXSIZE_TEMP_ARRAY(args, 1);
       ADD_C(args, INTEGER_OBJ((int)display_tick));
-      decor_provider_invoke((int)i, "end", p->redraw_end, args, true);
+      decor_provider_invoke((int)i, "end", p->redraw_end, args, true, NULL);
     }
   }
   decor_check_to_be_deleted();

--- a/src/nvim/lua/executor.h
+++ b/src/nvim/lua/executor.h
@@ -38,10 +38,11 @@ typedef struct {
   } while (0)
 
 typedef enum {
-  kRetObject,  ///< any object, but doesn't preserve nested luarefs
+  kRetObject,   ///< any object, but doesn't preserve nested luarefs
   kRetNilBool,  ///< NIL preserved as such, other values return their booleanness
                 ///< Should also be used when return value is ignored, as it is allocation-free
-  kRetLuaref,  ///< return value becomes a single Luaref, regardless of type (except NIL)
+  kRetLuaref,   ///< return value becomes a single Luaref, regardless of type (except NIL)
+  kRetMulti,    ///< like kRetObject but return muliple return values as an Array
 } LuaRetMode;
 
 /// Maximum number of errors in vim.ui_attach() and decor provider callbacks.

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -548,7 +548,7 @@ describe('treesitter highlighting (C)', function()
           lua = [[
             ; query
             (string) @string
-            (comment) @comment
+            ((comment) @comment (#set! priority 90))
             (function_call (identifier) @function.call)
             [ "(" ")" ] @punctuation.bracket
           ]],

--- a/test/functional/treesitter/highlight_spec.lua
+++ b/test/functional/treesitter/highlight_spec.lua
@@ -548,7 +548,7 @@ describe('treesitter highlighting (C)', function()
           lua = [[
             ; query
             (string) @string
-            ((comment) @comment (#set! priority 90))
+            (comment) @comment
             (function_call (identifier) @function.call)
             [ "(" ")" ] @punctuation.bracket
           ]],


### PR DESCRIPTION
Continuing the work of #31400

That PR allowed the provider to be invoked multiple times per line. But we only want to do that when there actually is more data later on the line, otherwise it is just lua VM overhead for no good. Additionally, we want to skip over lines which contain no new highlight items. The TS query cursor already tells us what the next position with more data is, so there is no need to reinvoke the range callback before that.

NB: this removes the double buffering introduced in #32619 which is fundamentally incompatible with this (nvim core is supposed to keep track of long ranges by itself, without requiring a callback reinvoke blitz). Need to adjust the priorities some other way to fix the same issue.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
