### PR TITLE
docs: remove trailing whitespace in ptprevious description

### DIFF
--- a/runtime/lua/vim/_defaults.lua
+++ b/runtime/lua/vim/_defaults.lua
@@ -405,7 +405,7 @@ do
     vim.keymap.set('n', '[<C-T>', function()
       -- count doesn't work with :ptprevious, must use range. See #30641.
       cmd({ cmd = 'ptprevious', range = { vim.v.count1 } })
-    end, { desc = ' :ptprevious' })
+    end, { desc = ':ptprevious' })
 
     vim.keymap.set('n', ']<C-T>', function()
       -- count doesn't work with :ptnext, must use range. See #30641.


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
<img width="1382" height="460" alt="image" src="https://github.com/user-attachments/assets/f18345e6-5864-4729-85df-6d1d36704282" />
