### PR TITLE
feat(pack): warn if package unreachable

### DIFF
--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -133,6 +133,16 @@ end
 --- @param url string
 --- @param path string
 local function git_clone(url, path)
+  local can_ping = async.await(5,
+    vim.system,
+    { "git", 'ls-remote', url, 'HEAD' },
+    { env = { GIT_TERMINAL_PROMPT = "0", GIT_ASKPASS = "echo" } }
+  )
+  if can_ping.code ~= 0 then
+    error(string.format("Unable to reach repo '%s'", url))
+    return
+  end
+
   local cmd = { 'clone', '--quiet', '--origin', 'origin' }
 
   if vim.startswith(url, 'file://') then


### PR DESCRIPTION
Problem: Typo in url produces error message about missing credentials

Solution: Utilize `git-ls-remote` to ping the url before attempting to clone, which expects user credentials if the repo is not public. This works on URIs containing filepaths as well.