### PR TITLE
vim-patch:partial:9.1.1708: tests: various tests can be improved

### DIFF
--- a/test/old/testdir/test_expr.vim
+++ b/test/old/testdir/test_expr.vim
@@ -22,7 +22,7 @@ func Test_equal()
   call assert_false(base.method == instance.other)
   call assert_false([base.method] == [instance.other])
 
-  call assert_fails('echo base.method > instance.method')
+  call assert_fails('echo base.method > instance.method', 'E694: Invalid operation for Funcrefs')
   " Nvim doesn't have null functions
   " call assert_equal(0, test_null_function() == function('min'))
   " call assert_equal(1, test_null_function() == test_null_function())

--- a/test/old/testdir/test_file_perm.vim
+++ b/test/old/testdir/test_file_perm.vim
@@ -1,30 +1,29 @@
 " Test getting and setting file permissions.
 
 func Test_file_perm()
-  call assert_equal('', getfperm('Xtest'))
-  call assert_equal(0, 'Xtest'->setfperm('r--------'))
+  call assert_equal('', getfperm('XtestPerm'))
+  call assert_equal(0, 'XtestPerm'->setfperm('r--------'))
 
-  call writefile(['one'], 'Xtest')
-  call assert_true(len('Xtest'->getfperm()) == 9)
+  call writefile(['one'], 'XtestPerm', 'D')
+  call assert_true(len('XtestPerm'->getfperm()) == 9)
 
-  call assert_equal(1, setfperm('Xtest', 'rwx------'))
+  call assert_equal(1, setfperm('XtestPerm', 'rwx------'))
   if has('win32')
-    call assert_equal('rw-rw-rw-', getfperm('Xtest'))
+    call assert_equal('rw-rw-rw-', getfperm('XtestPerm'))
   else
-    call assert_equal('rwx------', getfperm('Xtest'))
+    call assert_equal('rwx------', getfperm('XtestPerm'))
   endif
 
-  call assert_equal(1, setfperm('Xtest', 'r--r--r--'))
-  call assert_equal('r--r--r--', getfperm('Xtest'))
+  call assert_equal(1, setfperm('XtestPerm', 'r--r--r--'))
+  call assert_equal('r--r--r--', getfperm('XtestPerm'))
 
-  call assert_fails("setfperm('Xtest', '---')")
+  call assert_fails("call setfperm('XtestPerm', '---')", 'E475: Invalid argument: ---')
 
-  call assert_equal(1, setfperm('Xtest', 'rwx------'))
-  call delete('Xtest')
+  call assert_equal(1, setfperm('XtestPerm', 'rwx------'))
 
-  call assert_fails("call setfperm(['Xfile'], 'rw-rw-rw-')", 'E730:')
-  call assert_fails("call setfperm('Xfile', [])", 'E730:')
-  call assert_fails("call setfperm('Xfile', 'rwxrwxrwxrw')", 'E475:')
+  call assert_fails("call setfperm(['Xpermfile'], 'rw-rw-rw-')", 'E730:')
+  call assert_fails("call setfperm('Xpermfile', [])", 'E730:')
+  call assert_fails("call setfperm('Xpermfile', 'rwxrwxrwxrw')", 'E475:')
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_hide.vim
+++ b/test/old/testdir/test_hide.vim
@@ -21,7 +21,7 @@ function Test_hide()
 
   new Xf1
   set modified
-  call assert_fails('edit Xf2')
+  call assert_fails('edit Xf2', 'E37: No write since last change (add ! to override)')
   bwipeout! Xf1
 
   new Xf1

--- a/test/old/testdir/test_mksession.vim
+++ b/test/old/testdir/test_mksession.vim
@@ -1156,7 +1156,7 @@ func Test_mkvimrc()
   " set pastetoggle=<F5>
   set wildchar=<F6>
   set wildcharm=<F7>
-  call assert_fails('mkvimrc Xtestvimrc')
+  call assert_fails('mkvimrc Xtestvimrc', 'E189: "Xtestvimrc" exists')
   mkvimrc! Xtestvimrc
   " call assert_notequal(-1, index(readfile('Xtestvimrc'), 'set pastetoggle=<F5>'))
   call assert_notequal(-1, index(readfile('Xtestvimrc'), 'set wildchar=<F6>'))

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -176,7 +176,7 @@ func Test_signcolumn()
   call assert_equal("auto", &signcolumn)
   set signcolumn=yes
   set signcolumn=no
-  call assert_fails('set signcolumn=nope')
+  call assert_fails('set signcolumn=nope', 'E474: Invalid argument: signcolumn=nope')
 endfunc
 
 func Test_filetype_valid()

--- a/test/old/testdir/test_undo.vim
+++ b/test/old/testdir/test_undo.vim
@@ -220,7 +220,7 @@ func Test_undo_del_chars()
   call BackOne('3-456')
   call BackOne('23-456')
   call BackOne('123-456')
-  call assert_fails("BackOne('123-456')")
+  call assert_fails("BackOne('123-456')", "E492: Not an editor command: BackOne('123-456')")
 
   :" Delete three other characters and go back in time with g-
   call feedkeys('$x', 'xt')
@@ -236,7 +236,7 @@ func Test_undo_del_chars()
   call BackOne('3-456')
   call BackOne('23-456')
   call BackOne('123-456')
-  call assert_fails("BackOne('123-456')")
+  call assert_fails("BackOne('123-456')", "E492: Not an editor command: BackOne('123-456')")
   normal 10g+
   call assert_equal('123-', getline(1))
 

--- a/test/old/testdir/test_vartabs.vim
+++ b/test/old/testdir/test_vartabs.vim
@@ -387,14 +387,14 @@ func Test_vartabs_shiftwidth()
 endfunc
 
 func Test_vartabs_failures()
-  call assert_fails('set vts=8,')
-  call assert_fails('set vsts=8,')
-  call assert_fails('set vts=8,,8')
-  call assert_fails('set vsts=8,,8')
-  call assert_fails('set vts=8,,8,')
-  call assert_fails('set vsts=8,,8,')
-  call assert_fails('set vts=,8')
-  call assert_fails('set vsts=,8')
+  call assert_fails('set vts=8,', 'E475: Invalid argument: 8,')
+  call assert_fails('set vsts=8,', 'E475: Invalid argument: 8,')
+  call assert_fails('set vts=8,,8', 'E474: Invalid argument: vts=8,,8')
+  call assert_fails('set vsts=8,,8', 'E474: Invalid argument: vsts=8,,8')
+  call assert_fails('set vts=8,,8,', 'E474: Invalid argument: vts=8,,8,')
+  call assert_fails('set vsts=8,,8,', 'E474: Invalid argument: vsts=8,,8,')
+  call assert_fails('set vts=,8', 'E474: Invalid argument: vts=,8')
+  call assert_fails('set vsts=,8', 'E474: Invalid argument: vsts=,8')
 endfunc
 
 func Test_vartabs_reset()

--- a/test/old/testdir/test_winfixbuf.vim
+++ b/test/old/testdir/test_winfixbuf.vim
@@ -77,7 +77,7 @@ func s:make_buffer_trio()
   edit! third
   let l:third = bufnr()
 
-  execute ":buffer! " . l:second
+  exe $":buffer! {l:second}"
 
   return [l:first, l:second, l:third]
 endfunc
@@ -180,11 +180,11 @@ endfunc
 " Create a quickfix with at least 2 entries that are in the current 'winfixbuf' window.
 func s:make_quickfix_windows()
   let [l:current, _] = s:make_simple_quickfix()
-  execute "buffer! " . l:current
+  exe $"buffer! {l:current}"
 
   split
   let l:first_window = win_getid()
-  execute "normal \<C-w>j"
+  exe "normal \<C-w>j"
   let l:winfix_window = win_getid()
 
   " Open the quickfix in a separate split and go to it
@@ -210,7 +210,7 @@ func s:set_quickfix_by_buffer(buffer)
   let l:index = 1  " quickfix indices start at 1
   for l:entry in getqflist()
     if l:entry["bufnr"] == a:buffer
-      execute l:index . "cc"
+      exe $"{l:index} cc"
 
       return
     endif
@@ -218,7 +218,7 @@ func s:set_quickfix_by_buffer(buffer)
     let l:index += 1
   endfor
 
-  echoerr 'No quickfix entry matching "' . a:buffer . '" could be found.'
+  echoerr $'No quickfix entry matching {a:buffer} could be found.'
 endfunc
 
 " Fail to call :Next on a 'winfixbuf' window unless :Next! is used.
@@ -253,7 +253,7 @@ func Test_argdo_choose_available_window()
   split
   let l:nowinfixbuf_window = win_getid()
   " Move to the 'winfixbuf' window now
-  execute "normal \<C-w>j"
+  exe "normal \<C-w>j"
   let l:winfixbuf_window = win_getid()
   let l:expected_windows = s:get_windows_count()
 
@@ -274,7 +274,7 @@ func Test_argdo_make_new_window()
   argdo echo ''
   call assert_notequal(l:current, win_getid())
   call assert_equal(l:last, bufnr())
-  execute "normal \<C-w>j"
+  exe "normal \<C-w>j"
   call assert_equal(l:first, bufnr())
   call assert_equal(l:current_windows + 1, s:get_windows_count())
 endfunc
@@ -313,7 +313,7 @@ func Test_arglocal()
   let l:other = s:make_buffer_pairs()
   let l:current = bufnr()
   argglobal! other
-  execute "buffer! " . l:current
+  exe $"buffer! {l:current}"
 
   call assert_fails("arglocal other", "E1513:")
   call assert_equal(l:current, bufnr())
@@ -422,9 +422,9 @@ func Test_bmodified()
   let l:other = s:make_buffer_pairs()
   let l:current = bufnr()
 
-  execute "buffer! " . l:other
+  exe $"buffer! {l:other}"
   set modified
-  execute "buffer! " . l:current
+  exe $"buffer! {l:current}"
 
   call assert_fails("bmodified", "E1513:")
   call assert_equal(l:current, bufnr())
@@ -535,7 +535,7 @@ func Test_bufdo_choose_available_window()
   split
   let l:nowinfixbuf_window = win_getid()
   " Move to the 'winfixbuf' window now
-  execute "normal \<C-w>j"
+  exe "normal \<C-w>j"
   let l:winfixbuf_window = win_getid()
 
   let l:current = bufnr()
@@ -554,14 +554,14 @@ func Test_bufdo_make_new_window()
   call s:reset_all_buffers()
 
   let [l:first, l:last] = s:make_buffers_list()
-  execute "buffer! " . l:first
+  exe $"buffer! {l:first}"
   let l:current = win_getid()
   let l:current_windows = s:get_windows_count()
 
   bufdo echo ''
   call assert_notequal(l:current, win_getid())
   call assert_equal(l:last, bufnr())
-  execute "normal \<C-w>j"
+  exe "normal \<C-w>j"
   call assert_equal(l:first, bufnr())
   call assert_equal(l:current_windows + 1, s:get_windows_count())
 endfunc
@@ -573,10 +573,10 @@ func Test_buffer()
   let l:other = s:make_buffer_pairs()
   let l:current = bufnr()
 
-  call assert_fails("buffer " . l:other, "E1513:")
+  call assert_fails($"buffer {l:other}", "E1513:")
   call assert_equal(l:current, bufnr())
 
-  execute "buffer! " . l:other
+  exe $"buffer! {l:other}"
   call assert_equal(l:other, bufnr())
 endfunc
 
@@ -587,10 +587,10 @@ func Test_buffer_same_buffer()
   call s:make_buffer_pairs()
   let l:current = bufnr()
 
-  execute "buffer " . l:current
+  exe $"buffer {l:current}"
   call assert_equal(l:current, bufnr())
 
-  execute "buffer! " . l:current
+  exe $"buffer! {l:current}"
   call assert_equal(l:current, bufnr())
 endfunc
 
@@ -640,7 +640,7 @@ func Test_caddexpr()
 
   let l:file_path = tempname()
   call writefile(["Error - bad-thing-found"], l:file_path, 'D')
-  execute "edit " . l:file_path
+  exe $"edit {l:file_path}"
   let l:file_buffer = bufnr()
   let l:current = bufnr()
 
@@ -651,9 +651,9 @@ func Test_caddexpr()
 
   set winfixbuf
 
-  execute "buffer! " . l:file_buffer
+  exe $"buffer! {l:file_buffer}"
 
-  execute 'caddexpr expand("%") .. ":" .. line(".") .. ":" .. getline(".")'
+  exe 'caddexpr expand("%") .. ":" .. line(".") .. ":" .. getline(".")'
   call assert_equal(l:current, bufnr())
 endfunc
 
@@ -664,7 +664,7 @@ func Test_cbuffer()
 
   let l:file_path = tempname()
   call writefile(["first.unittest:1:Error - bad-thing-found"], l:file_path, 'D')
-  execute "edit " . l:file_path
+  exe $"edit {l:file_path}"
   let l:file_buffer = bufnr()
   let l:current = bufnr()
 
@@ -675,12 +675,12 @@ func Test_cbuffer()
 
   set winfixbuf
 
-  execute "buffer! " . l:file_buffer
+  exe $"buffer! {file_buffer}"
 
-  call assert_fails("cbuffer " . l:file_buffer)
-  call assert_equal(l:current, bufnr())
+  call assert_fails($"cbuffer {file_buffer}", "E1513: Cannot switch buffer. 'winfixbuf' is enabled")
+  call assert_equal(current, bufnr())
 
-  execute "cbuffer! " . l:file_buffer
+  exe $"cbuffer! {file_buffer}"
   call assert_equal("first.unittest", expand("%:t"))
 endfunc
 
@@ -715,7 +715,7 @@ func Test_cdo_choose_available_window()
   call s:reset_all_buffers()
 
   let [l:current, l:last] = s:make_simple_quickfix()
-  execute "buffer! " . l:current
+  exe $"buffer! {l:current}"
 
   " Make a split window that is 'nowinfixbuf' but make it the second-to-last
   " window so that :cdo will first try the 'winfixbuf' window, pass over it,
@@ -729,7 +729,7 @@ func Test_cdo_choose_available_window()
   split
   let l:nowinfixbuf_window = win_getid()
   " Move to the 'winfixbuf' window now
-  execute "normal \<C-w>j"
+  exe "normal \<C-w>j"
   let l:winfixbuf_window = win_getid()
   let l:expected_windows = s:get_windows_count()
 
@@ -737,7 +737,7 @@ func Test_cdo_choose_available_window()
 
   call assert_equal(l:nowinfixbuf_window, win_getid())
   call assert_equal(l:last, bufnr())
-  execute "normal \<C-w>j"
+  exe "normal \<C-w>j"
   call assert_equal(l:current, bufnr())
   call assert_equal(l:expected_windows, s:get_windows_count())
 endfunc
@@ -748,7 +748,7 @@ func Test_cdo_make_new_window()
   call s:reset_all_buffers()
 
   let [l:current_buffer, l:last] = s:make_simple_quickfix()
-  execute "buffer! " . l:current_buffer
+  exe $"buffer! {l:current_buffer}"
 
   let l:current_window = win_getid()
   let l:current_windows = s:get_windows_count()
@@ -756,7 +756,7 @@ func Test_cdo_make_new_window()
   cdo echo ''
   call assert_notequal(l:current_window, win_getid())
   call assert_equal(l:last, bufnr())
-  execute "normal \<C-w>j"
+  exe "normal \<C-w>j"
   call assert_equal(l:current_buffer, bufnr())
   call assert_equal(l:current_windows + 1, s:get_windows_count())
 endfunc
@@ -766,17 +766,17 @@ func Test_cexpr()
   CheckFeature quickfix
   call s:reset_all_buffers()
 
-  let l:file = tempname()
-  let l:entry = '["' . l:file . ':1:bar"]'
-  let l:current = bufnr()
+  let file = tempname()
+  let entry = $'["{file}:1:bar"]'
+  let current = bufnr()
 
   set winfixbuf
 
-  call assert_fails("cexpr " . l:entry)
-  call assert_equal(l:current, bufnr())
+  call assert_fails($"cexpr {entry}", "E1513: Cannot switch buffer. 'winfixbuf' is enabled")
+  call assert_equal(current, bufnr())
 
-  execute "cexpr! " . l:entry
-  call assert_equal(fnamemodify(l:file, ":t"), expand("%:t"))
+  exe $"cexpr! {entry}"
+  call assert_equal(fnamemodify(file, ":t"), expand("%:t"))
 endfunc
 
 " Call :cfdo and choose the next available 'nowinfixbuf' window.
@@ -785,7 +785,7 @@ func Test_cfdo_choose_available_window()
   call s:reset_all_buffers()
 
   let [l:current, l:last] = s:make_simple_quickfix()
-  execute "buffer! " . l:current
+  exe $"buffer! {l:current}"
 
   " Make a split window that is 'nowinfixbuf' but make it the second-to-last
   " window so that :cfdo will first try the 'winfixbuf' window, pass over it,
@@ -799,7 +799,7 @@ func Test_cfdo_choose_available_window()
   split
   let l:nowinfixbuf_window = win_getid()
   " Move to the 'winfixbuf' window now
-  execute "normal \<C-w>j"
+  exe "normal \<C-w>j"
   let l:winfixbuf_window = win_getid()
   let l:expected_windows = s:get_windows_count()
 
@@ -807,7 +807,7 @@ func Test_cfdo_choose_available_window()
 
   call assert_equal(l:nowinfixbuf_window, win_getid())
   call assert_equal(l:last, bufnr())
-  execute "normal \<C-w>j"
+  exe "normal \<C-w>j"
   call assert_equal(l:current, bufnr())
   call assert_equal(l:expected_windows, s:get_windows_count())
 endfunc
@@ -818,7 +818,7 @@ func Test_cfdo_make_new_window()
   call s:reset_all_buffers()
 
   let [l:current_buffer, l:last] = s:make_simple_quickfix()
-  execute "buffer! " . l:current_buffer
+  exe $"buffer! {l:current_buffer}"
 
   let l:current_window = win_getid()
   let l:current_windows = s:get_windows_count()
@@ -826,7 +826,7 @@ func Test_cfdo_make_new_window()
   cfdo echo ''
   call assert_notequal(l:current_window, win_getid())
   call assert_equal(l:last, bufnr())
-  execute "normal \<C-w>j"
+  exe "normal \<C-w>j"
   call assert_equal(l:current_buffer, bufnr())
   call assert_equal(l:current_windows + 1, s:get_windows_count())
 endfunc
@@ -839,26 +839,26 @@ func Test_cfile()
   edit first.unittest
   call append(0, ["some-search-term bad-thing-found"])
   write
-  let l:first = bufnr()
+  let first = bufnr()
 
   edit! second.unittest
   call append(0, ["some-search-term"])
   write
 
-  let l:file = tempname()
-  call writefile(["first.unittest:1:Error - bad-thing-found was detected"], l:file)
+  let file = tempname()
+  call writefile(["first.unittest:1:Error - bad-thing-found was detected"], file)
 
-  let l:current = bufnr()
+  let current = bufnr()
 
   set winfixbuf
 
-  call assert_fails(":cfile " . l:file)
-  call assert_equal(l:current, bufnr())
+  call assert_fails($":cfile {file}", "E1513: Cannot switch buffer. 'winfixbuf' is enabled")
+  call assert_equal(current, bufnr())
 
-  execute ":cfile! " . l:file
-  call assert_equal(l:first, bufnr())
+  exe $":cfile! {file}"
+  call assert_equal(first, bufnr())
 
-  call delete(l:file)
+  call delete(file)
   call delete("first.unittest")
   call delete("second.unittest")
 endfunc
@@ -932,7 +932,7 @@ func Test_cnext_no_previous_window()
   call s:reset_all_buffers()
 
   let [l:current, _] = s:make_simple_quickfix()
-  execute "buffer! " . l:current
+  exe $"buffer! {l:current}"
 
   let l:expected = s:get_windows_count()
 
@@ -1058,7 +1058,7 @@ func Test_ctrl_w_f()
 
   call setline(1, l:file_name)
   let l:current_windows = s:get_windows_count()
-  execute "normal \<C-w>f"
+  exe "normal \<C-w>f"
 
   call assert_equal(l:current_windows + 1, s:get_windows_count())
 
@@ -1069,9 +1069,9 @@ endfunc
 func Test_djump()
   call s:reset_all_buffers()
 
-  let l:include_file = tempname() . ".h"
+  let l:include_file = tempname() .. ".h"
   call writefile(["min(1, 12);",
-        \ '#include "' . l:include_file . '"'
+        \ $'#include "{l:include_file}"'
         \ ],
         \ "main.c")
   call writefile(["#define min(X, Y)  ((X) < (Y) ? (X) : (Y))"], l:include_file)
@@ -1135,23 +1135,23 @@ func Test_edit_different_buffer_on_disk_and_relative_path_to_disk()
   let l:file_on_disk = tempname()
   let l:directory_on_disk1 = fnamemodify(l:file_on_disk, ":p:h")
   let l:name = fnamemodify(l:file_on_disk, ":t")
-  execute "edit " . l:file_on_disk
+  exe $"edit {l:file_on_disk}"
   write!
 
-  let l:directory_on_disk2 = l:directory_on_disk1 . "_something_else"
+  let l:directory_on_disk2 = l:directory_on_disk1 .. "_something_else"
 
   if !isdirectory(l:directory_on_disk2)
     call mkdir(l:directory_on_disk2)
   endif
 
-  execute "cd " . l:directory_on_disk2
-  execute "edit " l:name
+  exe $"cd {l:directory_on_disk2}"
+  exe $"edit {l:name}"
 
   let l:current = bufnr()
 
   call assert_equal(l:current, bufnr())
   set winfixbuf
-  call assert_fails("edit " . l:file_on_disk, "E1513:")
+  call assert_fails($"edit {l:file_on_disk}", "E1513:")
   call assert_equal(l:current, bufnr())
 
   call delete(l:directory_on_disk1)
@@ -1174,26 +1174,26 @@ func Test_edit_different_buffer_on_disk_and_relative_path_to_memory()
   let l:file_on_disk = tempname()
   let l:directory_on_disk1 = fnamemodify(l:file_on_disk, ":p:h")
   let l:name = fnamemodify(l:file_on_disk, ":t")
-  execute "edit " . l:file_on_disk
+  exe $"edit {l:file_on_disk}"
   write!
 
-  let l:directory_on_disk2 = l:directory_on_disk1 . "_something_else"
+  let l:directory_on_disk2 = l:directory_on_disk1 .. "_something_else"
 
   if !isdirectory(l:directory_on_disk2)
     call mkdir(l:directory_on_disk2)
   endif
 
-  execute "cd " . l:directory_on_disk2
-  execute "edit " l:name
-  execute "cd " . l:directory_on_disk1
-  execute "edit " l:file_on_disk
-  execute "cd " . l:directory_on_disk2
+  exe $"cd {l:directory_on_disk2}"
+  exe $"edit {l:name}"
+  exe $"cd {l:directory_on_disk1}"
+  exe $"edit {l:file_on_disk}"
+  exe $"cd {l:directory_on_disk2}"
 
   let l:current = bufnr()
 
   call assert_equal(l:current, bufnr())
   set winfixbuf
-  call assert_fails("edit " . l:name, "E1513:")
+  call assert_fails($"edit {l:name}", "E1513:")
   call assert_equal(l:current, bufnr())
 
   call delete(l:directory_on_disk1)
@@ -1252,12 +1252,12 @@ func Test_edit_same_buffer_on_disk_absolute_path()
   call writefile([], file, 'D')
   let file = fnamemodify(file, ':p')
   let current = bufnr()
-  execute "edit " . file
+  exe $"edit {file}"
   write!
 
   call assert_equal(current, bufnr())
   set winfixbuf
-  execute "edit " file
+  exe $"edit {file}"
   call assert_equal(current, bufnr())
 
   set nowinfixbuf
@@ -1304,17 +1304,17 @@ func Test_find()
   let l:name = fnamemodify(l:file, ":p:t")
 
   let l:original_path = &path
-  execute "set path=" . l:directory
+  exe $"set path={l:directory}"
 
   set winfixbuf
 
-  call assert_fails("execute 'find " . l:name . "'", "E1513:")
+  call assert_fails($"exe 'find {l:name}'", "E1513:")
   call assert_equal(l:current, bufnr())
 
-  execute "find! " . l:name
+  exe $"find! {l:name}"
   call assert_equal(l:file, expand("%:p"))
 
-  execute "set path=" . l:original_path
+  exe $"set path={l:original_path}"
 endfunc
 
 " Fail :first but :first! is allowed
@@ -1357,7 +1357,7 @@ func Test_grep()
 
   call assert_fails("silent! grep some-search-term *.unittest", "E1513:")
   call assert_equal(l:current, bufnr())
-  execute "edit! " . l:first
+  exe $"edit! {l:first}"
 
   silent! grep! some-search-term *.unittest
   call assert_notequal(l:first, bufnr())
@@ -1371,9 +1371,9 @@ endfunc
 func Test_ijump()
   call s:reset_all_buffers()
 
-  let l:include_file = tempname() . ".h"
+  let l:include_file = tempname() .. ".h"
   call writefile([
-        \ '#include "' . l:include_file . '"'
+        \ $'#include "{l:include_file}"'
         \ ],
         \ "main.c", 'D')
   call writefile(["#define min(X, Y)  ((X) < (Y) ? (X) : (Y))"], l:include_file, 'D')
@@ -1463,7 +1463,7 @@ func Test_laddexpr()
 
   let l:file_path = tempname()
   call writefile(["Error - bad-thing-found"], l:file_path, 'D')
-  execute "edit " . l:file_path
+  exe $"edit {l:file_path}"
   let l:file_buffer = bufnr()
   let l:current = bufnr()
 
@@ -1474,9 +1474,9 @@ func Test_laddexpr()
 
   set winfixbuf
 
-  execute "buffer! " . l:file_buffer
+  exe $"buffer! {l:file_buffer}"
 
-  execute 'laddexpr expand("%") .. ":" .. line(".") .. ":" .. getline(".")'
+  exe 'laddexpr expand("%") .. ":" .. line(".") .. ":" .. getline(".")'
   call assert_equal(l:current, bufnr())
 endfunc
 
@@ -1501,7 +1501,7 @@ func Test_lbuffer()
 
   let l:file_path = tempname()
   call writefile(["first.unittest:1:Error - bad-thing-found"], l:file_path, 'D')
-  execute "edit " . l:file_path
+  exe $"edit {l:file_path}"
   let l:file_buffer = bufnr()
   let l:current = bufnr()
 
@@ -1512,12 +1512,12 @@ func Test_lbuffer()
 
   set winfixbuf
 
-  execute "buffer! " . l:file_buffer
+  exe $"buffer! {file_buffer}"
 
-  call assert_fails("lbuffer " . l:file_buffer)
-  call assert_equal(l:current, bufnr())
+  call assert_fails($"lbuffer {file_buffer}", "E1513: Cannot switch buffer. 'winfixbuf' is enabled")
+  call assert_equal(current, bufnr())
 
-  execute "lbuffer! " . l:file_buffer
+  exe $"lbuffer! {file_buffer}"
   call assert_equal("first.unittest", expand("%:t"))
 endfunc
 
@@ -1529,9 +1529,9 @@ func Test_ldo()
   let [l:first, l:middle, l:last] = s:make_simple_location_list()
   lnext!
 
-  call assert_fails('execute "ldo buffer ' . l:first . '"', "E1513:")
+  call assert_fails($'exe "ldo buffer {l:first}"', "E1513:")
   call assert_equal(l:middle, bufnr())
-  execute "ldo! buffer " . l:first
+  exe $"ldo! buffer {l:first}"
   call assert_notequal(l:last, bufnr())
 endfunc
 
@@ -1540,17 +1540,17 @@ func Test_lexpr()
   CheckFeature quickfix
   call s:reset_all_buffers()
 
-  let l:file = tempname()
-  let l:entry = '["' . l:file . ':1:bar"]'
-  let l:current = bufnr()
+  let file = tempname()
+  let entry = $'["{file}:1:bar"]'
+  let current = bufnr()
 
   set winfixbuf
 
-  call assert_fails("lexpr " . l:entry)
-  call assert_equal(l:current, bufnr())
+  call assert_fails($"lexpr {entry}", "E1513: Cannot switch buffer. 'winfixbuf' is enabled")
+  call assert_equal(current, bufnr())
 
-  execute "lexpr! " . l:entry
-  call assert_equal(fnamemodify(l:file, ":t"), expand("%:t"))
+  exe $"lexpr! {entry}"
+  call assert_equal(fnamemodify(file, ":t"), expand("%:t"))
 endfunc
 
 " Fail :lfdo but :lfdo! is allowed
@@ -1558,13 +1558,13 @@ func Test_lfdo()
   CheckFeature quickfix
   call s:reset_all_buffers()
 
-  let [l:first, l:middle, l:last] = s:make_simple_location_list()
+  let [first, middle, last] = s:make_simple_location_list()
   lnext!
 
-  call assert_fails('execute "lfdo buffer ' . l:first . '"', "E1513:")
-  call assert_equal(l:middle, bufnr())
-  execute "lfdo! buffer " . l:first
-  call assert_notequal(l:last, bufnr())
+  call assert_fails('exe "lfdo buffer ' .. first .. '"', "E1513:")
+  call assert_equal(middle, bufnr())
+  exe $"lfdo! buffer {first}"
+  call assert_notequal(last, bufnr())
 endfunc
 
 " Fail :lfile but :lfile! is allowed
@@ -1588,10 +1588,10 @@ func Test_lfile()
 
   set winfixbuf
 
-  call assert_fails(":lfile " . l:file)
+  call assert_fails($":lfile {l:file}", "E1513: Cannot switch buffer. 'winfixbuf' is enabled")
   call assert_equal(l:current, bufnr())
 
-  execute ":lfile! " . l:file
+  exe $":lfile! {l:file}"
   call assert_equal(l:first, bufnr())
 
   call delete("first.unittest")
@@ -1606,15 +1606,15 @@ func Test_ll()
   let [l:first, l:middle, l:last] = s:make_simple_location_list()
   lopen
   lfirst!
-  execute "normal \<C-w>j"
+  exe "normal \<C-w>j"
   normal j
 
   call assert_fails(".ll", "E1513:")
-  execute "normal \<C-w>k"
+  exe "normal \<C-w>k"
   call assert_equal(l:first, bufnr())
-  execute "normal \<C-w>j"
+  exe "normal \<C-w>j"
   .ll!
-  execute "normal \<C-w>k"
+  exe "normal \<C-w>k"
   call assert_equal(l:middle, bufnr())
 endfunc
 
@@ -1737,7 +1737,7 @@ func Test_ltag()
   call writefile(["one", "two", "three"], "Xfile", 'D')
   call writefile(["one"], "Xother", 'D')
   edit Xother
-  execute "normal \<C-]>"
+  exe "normal \<C-]>"
 
   set winfixbuf
 
@@ -1765,10 +1765,10 @@ func Test_lua_command()
 
   set winfixbuf
 
-  call assert_fails('lua vim.cmd("buffer " .. ' . l:previous . ')')
+  call assert_fails($'lua vim.cmd("buffer " .. {l:previous})')
   call assert_equal(l:current, bufnr())
 
-  execute 'lua vim.cmd("buffer! " .. ' . l:previous . ')'
+  exe $'lua vim.cmd("buffer! " .. {l:previous})'
   call assert_equal(l:previous, bufnr())
 endfunc
 
@@ -1829,7 +1829,7 @@ func Test_lvimgrepadd()
 
   buffer! winfix.unittest
 
-  call assert_fails("lvimgrepadd /some-search-term/ *.unittest")
+  call assert_fails("lvimgrepadd /some-search-term/ *.unittest", "E1513: Cannot switch buffer. 'winfixbuf' is enabled")
   call assert_equal(l:current, bufnr())
 
   lvimgrepadd! /some-search-term/ *.unittest
@@ -1846,9 +1846,9 @@ func Test_marks_mappings_fail()
 
   let l:other = s:make_buffer_pairs()
   let l:current = bufnr()
-  execute "buffer! " . l:other
+  exe $"buffer! {l:other}"
   normal mA
-  execute "buffer! " . l:current
+  exe $"buffer! {l:current}"
   normal mB
 
   call assert_fails("normal `A", "E1513:")
@@ -1982,7 +1982,7 @@ func Test_normal_g_rightmouse()
   call writefile(["one", "two", "three"], "Xfile", 'D')
   call writefile(["one"], "Xother", 'D')
   edit Xother
-  execute "normal \<C-]>"
+  exe "normal \<C-]>"
 
   set winfixbuf
 
@@ -2033,7 +2033,7 @@ func Test_normal_ctrl_rightmouse()
   call writefile(["one", "two", "three"], "Xfile", 'D')
   call writefile(["one"], "Xother", 'D')
   edit Xother
-  execute "normal \<C-]>"
+  exe "normal \<C-]>"
 
   set winfixbuf
 
@@ -2059,7 +2059,7 @@ func Test_normal_ctrl_t()
   call writefile(["one", "two", "three"], "Xfile", 'D')
   call writefile(["one"], "Xother", 'D')
   edit Xother
-  execute "normal \<C-]>"
+  exe "normal \<C-]>"
 
   set winfixbuf
 
@@ -2108,12 +2108,12 @@ func Test_normal_ctrl_i_pass()
   " Go up another line
   normal m`
   normal k
-  execute "normal \<C-o>"
+  exe "normal \<C-o>"
 
   set winfixbuf
 
   let l:line = getcurpos()[1]
-  execute "normal 1\<C-i>"
+  exe "normal 1\<C-i>"
   call assert_notequal(l:line, getcurpos()[1])
 endfunc
 
@@ -2157,7 +2157,7 @@ func Test_normal_ctrl_o_pass()
 
   set winfixbuf
 
-  execute "normal \<C-o>"
+  exe "normal \<C-o>"
   call assert_equal(l:current, bufnr())
 endfunc
 
@@ -2202,7 +2202,7 @@ func Test_normal_ctrl_w_ctrl_square_bracket_right()
   set winfixbuf
 
   let l:current_windows = s:get_windows_count()
-  execute "normal \<C-w>\<C-]>"
+  exe "normal \<C-w>\<C-]>"
   call assert_equal(l:current_windows + 1, s:get_windows_count())
 
   set tags&
@@ -2225,7 +2225,7 @@ func Test_normal_ctrl_w_g_ctrl_square_bracket_right()
   set winfixbuf
 
   let l:current_windows = s:get_windows_count()
-  execute "normal \<C-w>g\<C-]>"
+  exe "normal \<C-w>g\<C-]>"
   call assert_equal(l:current_windows + 1, s:get_windows_count())
 
   set tags&
@@ -2343,9 +2343,9 @@ endfunc
 func Test_normal_square_bracket_left_ctrl_d()
   call s:reset_all_buffers()
 
-  let l:include_file = tempname() . ".h"
+  let l:include_file = tempname() .. ".h"
   call writefile(["min(1, 12);",
-        \ '#include "' . l:include_file . '"'
+        \ $'#include "{l:include_file}"'
         \ ],
         \ "main.c", 'D')
   call writefile(["#define min(X, Y)  ((X) < (Y) ? (X) : (Y))"], l:include_file, 'D')
@@ -2361,7 +2361,7 @@ func Test_normal_square_bracket_left_ctrl_d()
 
   set nowinfixbuf
 
-  execute "normal [\<C-d>"
+  exe "normal [\<C-d>"
   call assert_notequal(l:current, bufnr())
 endfunc
 
@@ -2369,9 +2369,9 @@ endfunc
 func Test_normal_square_bracket_right_ctrl_d()
   call s:reset_all_buffers()
 
-  let l:include_file = tempname() . ".h"
+  let l:include_file = tempname() .. ".h"
   call writefile(["min(1, 12);",
-        \ '#include "' . l:include_file . '"'
+        \ $'#include "{l:include_file}"'
         \ ],
         \ "main.c", 'D')
   call writefile(["#define min(X, Y)  ((X) < (Y) ? (X) : (Y))"], l:include_file, 'D')
@@ -2386,7 +2386,7 @@ func Test_normal_square_bracket_right_ctrl_d()
 
   set nowinfixbuf
 
-  execute "normal ]\<C-d>"
+  exe "normal ]\<C-d>"
   call assert_notequal(l:current, bufnr())
 endfunc
 
@@ -2394,8 +2394,8 @@ endfunc
 func Test_normal_square_bracket_left_ctrl_i()
   call s:reset_all_buffers()
 
-  let l:include_file = tempname() . ".h"
-  call writefile(['#include "' . l:include_file . '"',
+  let l:include_file = tempname() .. ".h"
+  call writefile([$'#include "{l:include_file}"',
         \ "min(1, 12);",
         \ ],
         \ "main.c", 'D')
@@ -2416,7 +2416,7 @@ func Test_normal_square_bracket_left_ctrl_i()
 
   set nowinfixbuf
 
-  execute "normal [\<C-i>"
+  exe "normal [\<C-i>"
   call assert_notequal(l:current, bufnr())
 
   set define&
@@ -2428,9 +2428,9 @@ endfunc
 func Test_normal_square_bracket_right_ctrl_i()
   call s:reset_all_buffers()
 
-  let l:include_file = tempname() . ".h"
+  let l:include_file = tempname() .. ".h"
   call writefile(["min(1, 12);",
-        \ '#include "' . l:include_file . '"'
+        \ $'#include "{l:include_file}"'
         \ ],
         \ "main.c", 'D')
   call writefile(["#define min(X, Y)  ((X) < (Y) ? (X) : (Y))"], l:include_file, 'D')
@@ -2449,7 +2449,7 @@ func Test_normal_square_bracket_right_ctrl_i()
 
   set nowinfixbuf
 
-  execute "normal ]\<C-i>"
+  exe "normal ]\<C-i>"
   call assert_notequal(l:current, bufnr())
 
   set define&
@@ -2541,7 +2541,7 @@ func Test_pedit()
 
   pedit other
 
-  execute "normal \<C-w>w"
+  exe "normal \<C-w>w"
   call assert_equal(l:other, bufnr())
 endfunc
 
@@ -2551,9 +2551,9 @@ func Test_pbuffer()
 
   let l:other = s:make_buffer_pairs()
 
-  exe 'pbuffer ' . l:other
+  exe $'pbuffer {l:other}'
 
-  execute "normal \<C-w>w"
+  exe "normal \<C-w>w"
   call assert_equal(l:other, bufnr())
 endfunc
 
@@ -2738,7 +2738,7 @@ func Test_remap_key_pass()
   " Disallow <C-^> by default but allow it if the command does something else
   nnoremap <C-^> :echo "hello!"
 
-  execute "normal \<C-^>"
+  exe "normal \<C-^>"
   call assert_equal(l:current, bufnr())
 
   nunmap <C-^>
@@ -2817,7 +2817,7 @@ func Test_split_window()
   call s:reset_all_buffers()
 
   split
-  execute "normal \<C-w>j"
+  exe "normal \<C-w>j"
 
   set winfixbuf
 
@@ -2845,7 +2845,7 @@ func Test_tNext()
   edit Xother
 
   tag thesame
-  execute "normal \<C-^>"
+  exe "normal \<C-^>"
   tnext!
 
   set winfixbuf
@@ -2878,7 +2878,7 @@ func Test_tabdo_choose_available_window()
   split
   let l:nowinfixbuf_window = win_getid()
   " Move to the 'winfixbuf' window now
-  execute "normal \<C-w>j"
+  exe "normal \<C-w>j"
   let l:winfixbuf_window = win_getid()
 
   let l:expected_windows = s:get_windows_count()
@@ -2893,7 +2893,7 @@ func Test_tabdo_make_new_window()
   call s:reset_all_buffers()
 
   let [l:first, _] = s:make_buffers_list()
-  execute "buffer! " . l:first
+  exe $"buffer! {l:first}"
 
   let l:current = win_getid()
   let l:current_windows = s:get_windows_count()
@@ -2901,7 +2901,7 @@ func Test_tabdo_make_new_window()
   tabdo echo ''
   call assert_notequal(l:current, win_getid())
   call assert_equal(l:first, bufnr())
-  execute "normal \<C-w>j"
+  exe "normal \<C-w>j"
   call assert_equal(l:first, bufnr())
   call assert_equal(l:current_windows + 1, s:get_windows_count())
 endfunc
@@ -3033,7 +3033,7 @@ func Test_tnext()
   edit Xother
 
   tag thesame
-  execute "normal \<C-^>"
+  exe "normal \<C-^>"
 
   set winfixbuf
 
@@ -3064,7 +3064,7 @@ func Test_tprevious()
   edit Xother
 
   tag thesame
-  execute "normal \<C-^>"
+  exe "normal \<C-^>"
   tnext!
 
   set winfixbuf
@@ -3130,7 +3130,7 @@ func Test_vimgrep()
 
   buffer! winfix.unittest
 
-  call assert_fails("vimgrep /some-search-term/ *.unittest")
+  call assert_fails("vimgrep /some-search-term/ *.unittest", "E1513: Cannot switch buffer. 'winfixbuf' is enabled")
   call assert_equal(l:current, bufnr())
 
   " Don't error and also do swap to the first match because ! was included
@@ -3165,7 +3165,7 @@ func Test_vimgrepadd()
 
   buffer! winfix.unittest
 
-  call assert_fails("vimgrepadd /some-search-term/ *.unittest")
+  call assert_fails("vimgrepadd /some-search-term/ *.unittest", "E1513: Cannot switch buffer. 'winfixbuf' is enabled")
   call assert_equal(l:current, bufnr())
 
   vimgrepadd! /some-search-term/ *.unittest
@@ -3210,10 +3210,10 @@ func Test_windo()
   windo echo ''
   call assert_equal(l:current_window, win_getid())
 
-  call assert_fails('execute "windo buffer ' . l:current_buffer . '"', "E1513:")
+  call assert_fails($'exe "windo buffer {l:current_buffer}"', "E1513:")
   call assert_equal(l:current_window, win_getid())
 
-  execute "windo buffer! " . l:current_buffer
+  exe $"windo buffer! {l:current_buffer}"
   call assert_equal(l:current_window, win_getid())
 endfunc
 
@@ -3262,7 +3262,7 @@ func Test_quickfix_switchbuf_invalid_prevwin()
   set switchbuf=uselast
   split
   copen
-  execute winnr('#') 'quit'
+  exe winnr('#') 'quit'
   call assert_equal(2, winnr('$'))
 
   cnext  " Would've triggered a null pointer member access

--- a/test/old/testdir/test_writefile.vim
+++ b/test/old/testdir/test_writefile.vim
@@ -175,7 +175,7 @@ func Test_writefile_autowrite()
   next
   call assert_equal(['aaa'], readfile('Xa'))
   call setline(1, 'bbb')
-  call assert_fails('edit XX')
+  call assert_fails('edit XX', 'E37: No write since last change (add ! to override)')
   call assert_false(filereadable('Xb'))
 
   set autowriteall


### PR DESCRIPTION
#### vim-patch:partial:9.1.1708: tests: various tests can be improved

Problem:  tests: various tests can be improved
Solution: Use string interpolation to concatenate strings in
          test_winfixbuf, check for specific errors in assert_fails()
          (Yegappan Lakshmanan)

closes: vim/vim#18151

https://github.com/vim/vim/commit/97ea879b9bd80baf2a64378eedc06a9610105dad

Cherry-pick Test_file_perm.vim changes from patch 9.0.{0363,0611}.
Skip Test_colornames_assignment_and_unassignment().

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>