### PR TITLE
vim-patch:8.1.1752: resizing hashtable is inefficient

### DIFF
--- a/src/nvim/hashtab.c
+++ b/src/nvim/hashtab.c
@@ -317,7 +317,7 @@ static void hash_may_resize(hashtab_T *ht, size_t minitems)
     // Use specified size.
     minitems = MAX(minitems, ht->ht_used);
     // array is up to 2/3 full
-    minsize = minitems * 3 / 2;
+    minsize = (minitems * 3 + 1) / 2;
   }
 
   size_t newsize = HT_INIT_SIZE;


### PR DESCRIPTION
Problem:    Resizing hashtable is inefficient.
Solution:   Avoid resizing when the final size is predictable.

https://github.com/vim/vim/commit/7b73d7ebf71c9148c90a500116f25ec2314c7273

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
