### PR TITLE
fix(cjson): fix `strbuf_set_length` incorrectness introduced by #32114

### DIFF
--- a/src/cjson/fpconv.c
+++ b/src/cjson/fpconv.c
@@ -130,7 +130,7 @@ double fpconv_strtod(const char *nptr, char **endptr)
     /* Duplicate number into buffer */
     if (buflen >= FPCONV_G_FMT_BUFSIZE) {
         /* Handle unusually large numbers */
-        buf = malloc(buflen + 1);
+        buf = (char *)malloc(buflen + 1);
         if (!buf) {
             fprintf(stderr, "Out of memory");
             abort();

--- a/src/cjson/strbuf.c
+++ b/src/cjson/strbuf.c
@@ -39,7 +39,7 @@ static void die(const char *fmt, ...)
     va_end(arg);
     fprintf(stderr, "\n");
 
-    exit(-1);
+    abort();
 }
 
 void strbuf_init(strbuf_t *s, size_t len)
@@ -51,7 +51,7 @@ void strbuf_init(strbuf_t *s, size_t len)
     else
         size = len + 1;         /* \0 terminator */
     if (size < len)
-        die("Overflow, len %zu", len);
+        die("Overflow, len: %zu", len);
     s->buf = NULL;
     s->size = size;
     s->length = 0;
@@ -132,7 +132,7 @@ static size_t calculate_new_size(strbuf_t *s, size_t len)
     /* Ensure there is room for optional NULL termination */
     reqsize = len + 1;
     if (reqsize < len)
-        die("Overflow, len %zu", len);
+        die("Overflow, len: %zu", len);
 
     /* If the user has requested to shrink the buffer, do it exactly */
     if (s->size > reqsize)
@@ -193,6 +193,7 @@ void strbuf_append_string(strbuf_t *s, const char *str)
         space--;
     }
 }
+
 
 /* vi:ai et sw=4 ts=4:
  */

--- a/src/cjson/strbuf.h
+++ b/src/cjson/strbuf.h
@@ -103,7 +103,7 @@ static inline char *strbuf_empty_ptr(strbuf_t *s)
 
 static inline void strbuf_set_length(strbuf_t *s, int len)
 {
-    s->length += len;
+    s->length = len;
 }
 
 static inline void strbuf_extend_length(strbuf_t *s, size_t len)


### PR DESCRIPTION
Regression from #32114

`strbuf_set_length` was incorrectly updating length with `+=` instead of assignment.

Also syncs minor updates with upstream.