### PR TITLE
feat(lsp): Allow for silent `vim.lsp.buf.format()`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1444,6 +1444,9 @@ format({opts})                                          *vim.lsp.buf.format()*
                   using (1,0) indexing. Can also be a list of tables that
                   contain `start` and `end` keys as described above, in which
                   case `textDocument/rangesFormatting` support is required.
+                • {notify}? (`boolean`, default: true) Notify if there are
+                  no matching language servers.
+
 
 hover({config})                                          *vim.lsp.buf.hover()*
     Displays hover information about the symbol under the cursor in a floating

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -574,6 +574,11 @@ end
 --- (Default: current selection in visual mode, `nil` in other modes,
 --- formatting the full buffer)
 --- @field range? {start:[integer,integer],end:[integer, integer]}|{start:[integer,integer],end:[integer,integer]}[]
+---
+--- Notify if no languagage servers match.
+--- If no language servers match, print a warning using `vim.notify()`.
+--- (Default: true)
+--- @field notify? boolean
 
 --- Formats a buffer using the attached (and optionally filtered) language
 --- server clients.
@@ -611,7 +616,7 @@ function M.format(opts)
     clients = vim.tbl_filter(opts.filter, clients)
   end
 
-  if #clients == 0 then
+  if #clients == 0 and opts.notify ~= false then
     vim.notify('[LSP] Format request failed, no matching language servers.')
   end
 


### PR DESCRIPTION
Problem: `vim.lsp.buf.format()` emits a warning if no matching language server is attached to the buffer. This is annoying when frequently calling `vim.lsp.buf.format()`.

For example, format on save setups that look like this
```lua
vim.api.nvim_create_autocmd("BufWritePre", {
	callback = function(event)
		vim.lsp.buf.format({ bufnr = event.buf })
	end,
})
```
print the warning for every buffer where no language server is attached.

Solution: Add a new field to the `opts` parameter called `notify`. When `notify` is false, `vim.lsp.buf.format()` does not print the warning.