### PR TITLE
feat: integrate ssh into :connect

### DIFF
--- a/src/nvim/event/stream.c
+++ b/src/nvim/event/stream.c
@@ -146,6 +146,7 @@ void stream_close_handle(Stream *stream, bool rstream)
 static void rstream_close_cb(uv_handle_t *handle)
 {
   RStream *stream = handle->data;
+  // check if stream exists first to avoid race condition in :connect
   if (stream && stream->buffer) {
     free_block(stream->buffer);
   }
@@ -155,9 +156,11 @@ static void rstream_close_cb(uv_handle_t *handle)
 static void close_cb(uv_handle_t *handle)
 {
   Stream *stream = handle->data;
+  // check if stream exists first to avoid race condition in :connect
   if (stream && stream->close_cb) {
     stream->close_cb(stream, stream->close_cb_data);
   }
+  // check if stream exists first to avoid race condition in :connect
   if (stream && stream->internal_close_cb) {
     stream->internal_close_cb(stream, stream->internal_data);
   }

--- a/src/nvim/ex_cmds.lua
+++ b/src/nvim/ex_cmds.lua
@@ -632,7 +632,7 @@ M.cmds = {
   },
   {
     command = 'connect',
-    flags = bit.bor(BANG, WORD1, NOTRLCOM, NEEDARG),
+    flags = bit.bor(BANG, WORD1, NOTRLCOM),
     addr_type = 'ADDR_NONE',
     func = 'ex_connect',
   },

--- a/test/functional/lua/ssh_spec.lua
+++ b/test/functional/lua/ssh_spec.lua
@@ -1,5 +1,5 @@
 local t = require('test.testutil')
-local parser = require('vim.net._ssh')
+local ssh = require('vim.net._ssh')
 local eq = t.eq
 
 describe('SSH parser', function()
@@ -45,7 +45,7 @@ describe('SSH parser', function()
       'test',
       'quoted string',
       'gh',
-    }, parser.parse_ssh_config(config))
+    }, ssh.parse_ssh_config(config))
   end)
 
   it('fails when a quote is not closed', function()
@@ -58,7 +58,7 @@ describe('SSH parser', function()
         ForwardAgent yes
     ]]
 
-    local ok, _ = pcall(parser.parse_ssh_config, config)
+    local ok, _ = pcall(ssh.parse_ssh_config, config)
     eq(false, ok)
   end)
 
@@ -72,7 +72,20 @@ describe('SSH parser', function()
         ForwardAgent yes
     ]]
 
-    local ok, _ = pcall(parser.parse_ssh_config, config)
+    local ok, _ = pcall(ssh.parse_ssh_config, config)
+    eq(false, ok)
+  end)
+end)
+
+describe('SSH connector', function()
+  it('validation', function()
+    local ok, _ = pcall(ssh.connect_to_address, '')
+    eq(false, ok)
+
+    ok, _ = pcall(ssh.connect_to_address, nil)
+    eq(false, ok)
+
+    ok, _ = pcall(ssh.connect_to_address, 'address cannot have spaces')
     eq(false, ok)
   end)
 end)

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -387,10 +387,14 @@ describe('TUI :connect', function()
     local screen1 = tt.setup_child_nvim({ '--listen', server1, '--clean' })
     screen1:expect({ any = vim.pesc('[No Name]') })
 
-    tt.feed_data(':connect\013')
-    screen1:expect({ any = 'E471: Argument required' })
-
     tt.feed_data('iThis is server 1.\027')
+    screen1:expect({ any = vim.pesc('This is server 1^.') })
+
+    -- If no argument is passed to connect, a list of options should be presented
+    tt.feed_data(':connect\013')
+    screen1:expect({ any = '(.*)Server(.*)' })
+    -- Input q to exit out of the selection
+    tt.feed_data('q\027')
     screen1:expect({ any = vim.pesc('This is server 1^.') })
 
     -- Prevent screen2 from receiving the old terminal state.


### PR DESCRIPTION
Running `:connect` without any address provided will provide the user with a list of options to connect to, including ssh hosts configured on the system.
Running `:connect ssh://host` will attempt to connect to host via connect and run Neovim remotely on the system.

I need some help writing the tests, not sure how to do that at all for this.

For the longest time I couldn't figure out how to avoid making the user input their password multiple time for password based authentication. Got the idea for caching prompts and responses from this plugin: https://github.com/amitds1997/remote-nvim.nvim/. Thanks a lot to https://github.com/amitds1997 for their amazing work.

Reference issue: https://github.com/neovim/neovim/issues/34257