### PR TITLE
feat(lsp): dynamic registration support for onTypeFormatting

### DIFF
--- a/runtime/lua/vim/lsp/_capability.lua
+++ b/runtime/lua/vim/lsp/_capability.lua
@@ -5,6 +5,7 @@ local api = vim.api
 ---| 'folding_range'
 ---| 'linked_editing_range'
 ---| 'inline_completion'
+---| 'on_type_formatting'
 
 --- Tracks all supported capabilities, all of which derive from `vim.lsp.Capability`.
 --- Returns capability *prototypes*, not their instances.

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -925,6 +925,11 @@ function Client:_register(registrations)
     local method = reg.method
     if method == ms.workspace_didChangeWatchedFiles then
       lsp._watchfiles.register(reg, self.id)
+    elseif method == ms.textDocument_onTypeFormatting then
+      -- if we enabled OTF for this client before the capability was registered, reattach...
+      -- if vim.lsp.on_type_formatting.is_enabled({client_id = self.id}) then
+      --   vim.lsp.on_type_formatting.enable(true, { client_id = self.id })
+      -- end
     elseif not self:_supports_registration(method) then
       unsupported[#unsupported + 1] = method
     end
@@ -959,6 +964,9 @@ function Client:_unregister(unregistrations)
   for _, unreg in ipairs(unregistrations) do
     if unreg.method == ms.workspace_didChangeWatchedFiles then
       lsp._watchfiles.unregister(unreg, self.id)
+    elseif unreg.method == ms.textDocument_onTypeFormatting then
+      -- Detach OTF listeners upon unregistration
+      vim.lsp.on_type_formatting.enable(false, { client_id = self.id })
     end
   end
 end

--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -573,7 +573,7 @@ function protocol.make_client_capabilities()
         dynamicRegistration = false,
       },
       onTypeFormatting = {
-        dynamicRegistration = false,
+        dynamicRegistration = true,
       },
     },
     workspace = {


### PR DESCRIPTION
Draft for now. I have some questions, e.g.: is there a preferred way to handle `enable_foo()` vs. `attach_foo()`? Should they be one and the same? I ask because (you can see the first commented-out code chunk) that it can be a bit confusing to call `if foo_is_enabled() then foo_enable() end`, but it's not that big of a deal. 