### PR TITLE
vim-patch:9.1.1724: Compiler warning about ununitialized variable in ex_docmd.

### DIFF
--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -7360,7 +7360,7 @@ ssize_t find_cmdline_var(const char *src, size_t *usedlen)
 char *eval_vars(char *src, const char *srcstart, size_t *usedlen, linenr_T *lnump,
                 const char **errormsg, int *escaped, bool empty_is_error)
 {
-  char *result;
+  char *result = "";
   char *resultbuf = NULL;
   size_t resultlen;
   int valid = VALID_HEAD | VALID_PATH;  // Assume valid result.
@@ -7576,7 +7576,6 @@ char *eval_vars(char *src, const char *srcstart, size_t *usedlen, linenr_T *lnum
     default:
       // should not happen
       *errormsg = "";
-      result = "";    // avoid gcc warning
       break;
     }
 


### PR DESCRIPTION
#### vim-patch:9.1.1724: Compiler warning about ununitialized variable in ex_docmd.

Problem:  Compiler warning about ununitialized variable in ex_docmd.
Solution: Initialize result variable (mityu)

Silence uninitialized variable warning produced by clang 21.1.0

closes: vim/vim#18182

https://github.com/vim/vim/commit/5f5a1c58768ca67d98eaf1a4fc6a0744e2fb4656

Co-authored-by: mityu <mityu.mail@gmail.com>