### PR TITLE
vim-patch:71149df: runtime(java): Dismiss "g:markdown_fenced_languages" for Java buffers

### DIFF
--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Aliaksei Budavei <0x000c70 AT gmail DOT com>
 " Former Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
-" Last Change:		2025 Aug 07
+" Last Change:		2025 Aug 30
 
 " Please check ":help java.vim" for comments on some of the options
 " available.
@@ -447,6 +447,11 @@ if !exists("g:java_ignore_javadoc") && (s:with_html || s:with_markdown) && g:mai
 	unlet g:html_syntax_folding
       endif
 
+      if !empty(get(g:, 'markdown_fenced_languages', []))
+	let s:markdown_fenced_languages_copy = g:markdown_fenced_languages
+	unlet g:markdown_fenced_languages
+      endif
+
       syntax include @javaMarkdown syntax/markdown.vim
 
       try
@@ -463,6 +468,11 @@ if !exists("g:java_ignore_javadoc") && (s:with_html || s:with_markdown) && g:mai
       let s:no_support = 1
     finally
       unlet! b:current_syntax
+
+      if exists("s:markdown_fenced_languages_copy")
+	let g:markdown_fenced_languages = s:markdown_fenced_languages_copy
+	unlet s:markdown_fenced_languages_copy
+      endif
 
       if exists("s:html_syntax_folding_copy")
 	let g:html_syntax_folding = s:html_syntax_folding_copy


### PR DESCRIPTION
#### vim-patch:71149df: runtime(java): Dismiss "g:markdown_fenced_languages" for Java buffers

No support is provided or planned for language recognition
in code snippets of documentation comments.  Requesting to
load arbitrary syntax plugins with the aid of the concerned
variable is therefore wasteful in general and erroneous when
paired languages ":syn-include" one another without taking
steps to manage circularity.

related: vim/vim#17308
related: vim/vim#17220
closes: vim/vim#18172

https://github.com/vim/vim/commit/71149dfec502d7489cd7e46c721f891b486bdbf6

Co-authored-by: Aliaksei Budavei <0x000c70@gmail.com>