### PR TITLE
docs(lua-plugin): note on :helptags

### DIFF
--- a/runtime/doc/lua-plugin.txt
+++ b/runtime/doc/lua-plugin.txt
@@ -299,7 +299,9 @@ VERSIONING TOOLS
 Documentation                                                 *lua-plugin-doc*
 
 Provide vimdoc (see |help-writing|), so that users can read your plugin's
-documentation in Nvim, by entering `:h {plugin}` in |command-mode|.
+documentation in Nvim, by entering `:h {plugin}` in |command-mode|. The
+help-tags (the right-aligned "search keywords" in the help documents) are
+regenerated using the |:helptags| command.
 
 DOCUMENTATION TOOLS
 


### PR DESCRIPTION
Problem:
It's not clear for new plugin developers that `:help` uses a help-tags
file for searching the docs, generated by `:helptags`.

Solution:
Hint to the |:helptags| docs for regenerating the tags file for their
freshly written documentation.


---

I can also move this part to |help-writing|, as the TAGS section there doesn't even mention it.