### PR TITLE
vim-patch:4c39d0c: runtime(doc): quote partial urls with a backtick

### DIFF
--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -649,11 +649,11 @@ ask you where to write the file (there must be a writable directory in
 'runtimepath' for this).
 
 The plugin has a default place where to look for spell files, on the Vim ftp
-server.  The protocol used is SSL (https://) for security.  If you want to use
-another location or another protocol, set the g:spellfile_URL variable to the
-directory that holds the spell files.  You can use http:// or ftp://, but you
-are taking a security risk then.  The |netrw| plugin is used for getting the
-file, look there for the specific syntax of the URL.  Example: >
+server.  The protocol used is TLS (`https://`) for security.  If you want to
+use another location or another protocol, set the g:spellfile_URL variable to
+the directory that holds the spell files.  You can use `http://` or `ftp://`,
+but you are taking a security risk then.  The |netrw| plugin is used for
+getting the file, look there for the specific syntax of the URL.  Example: >
 	let g:spellfile_URL = 'https://ftp.nluug.nl/vim/runtime/spell'
 You may need to escape special characters.
 

--- a/runtime/doc/usr_23.txt
+++ b/runtime/doc/usr_23.txt
@@ -136,10 +136,10 @@ might want to try the manual way of downloading the file.
 Accessing files over the internet works with the netrw plugin.  Currently URLs
 with these formats are recognized:
 
-	ftp://		uses ftp
-	rcp://		uses rcp
-	scp://		uses scp
-	http://		uses wget (reading only)
+	`ftp://`	uses ftp
+	`rcp://`	uses rcp
+	`scp://`	uses scp
+	`http://`	uses wget (reading only)
 
 Vim doesn't do the communication itself, it relies on the mentioned programs
 to be available on your computer.  On most Unix systems "ftp" and "rcp" will
@@ -147,7 +147,7 @@ be present.  "scp" and "wget" might need to be installed.
 
 Vim detects these URLs for each command that starts editing a new file, also
 with ":edit" and ":split", for example.  Write commands also work, except for
-http://.
+`http://`.
 
 For more information, also about passwords, see |netrw|.
 


### PR DESCRIPTION
#### vim-patch:4c39d0c: runtime(doc): quote partial urls with a backtick

closes: vim/vim#18194

https://github.com/vim/vim/commit/4c39d0cc9b61dd512851c5145923cc52027f852d

Co-authored-by: Yochem van Rosmalen <git@yochem.nl>