### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/keymap/arabic_buckwalter.vim
+++ b/runtime/keymap/arabic_buckwalter.vim
@@ -1,0 +1,75 @@
+" Vim Keymap file for Arabic using Buckwalter Transliteration
+" see
+" http://qamus.org/transliteration.htm
+" https://en.wikipedia.org/wiki/Buckwalter_transliteration
+"
+" Created By:  Rafael Ketsetsides <rketsetsides@gmail.com>
+" Last Update: 2025 Sep 02
+
+let b:keymap_name = "arabic_buckwalter"
+
+loadkeymap
+
+A	<char-0x0627>			" ALEF
+b	<char-0x0628>			" BEH
+p	<char-0x0629>			" TEH MARBUTA
+t	<char-0x062a>			" TEH
+v	<char-0x062b>			" THEH
+j	<char-0x062c>			" JEEM
+H	<char-0x062d>			" HAH
+x	<char-0x062e>			" KHAH
+d	<char-0x062f>			" DAL
+*	<char-0x0630>			" THAL
+r	<char-0x0631>			" REH
+z	<char-0x0632>			" ZAIN
+s	<char-0x0633>			" SEEN
+$	<char-0x0634>			" SHEEN
+S	<char-0x0635>			" SAD
+D	<char-0x0636>			" DAD
+T	<char-0x0637>			" TAH
+Z	<char-0x0638>			" ZAH
+E	<char-0x0639>			" AIN
+g	<char-0x063a>			" GHAIN
+_	<char-0x0640>			" TATWEEL
+f	<char-0x0641>			" FEH
+q	<char-0x0642>			" QAF
+k	<char-0x0643>			" KAF
+l	<char-0x0644>			" LAM
+m	<char-0x0645>			" MEEM
+n	<char-0x0646>			" NOON
+h	<char-0x0647>			" HEH
+w	<char-0x0648>			" WAW
+Y	<char-0x0649>			" ALEF MAKSURA
+y	<char-0x064a>			" YEH
+'	<char-0x0621>			" HAMZA
+|	<char-0x0622>			" ALEF WITH MADDA ABOVE
+>	<char-0x0623>			" ALEF WITH HAMZA ABOVE
+&	<char-0x0624>			" WAW WITH HAMZA ABOVE
+<	<char-0x0625>			" ALEF WITH HAMZA BELOW
+}	<char-0x0626>			" YEH WITH HAMZA ABOVE
+F	<char-0x064b>			" Tanween -- FATHATAN
+N	<char-0x064c>			" Tanween -- DAMMATAN
+K	<char-0x064d>			" Tanween -- KASRATAN
+a	<char-0x064e>			" Tanween -- FATHA
+u	<char-0x064f>			" Tanween -- DAMMA
+i	<char-0x0650>			" Tanween -- KASRA
+~	<char-0x0651>			" Tanween -- SHADDA
+o	<char-0x0652>			" Tanween -- SUKUN
+;	<char-0x061b>			" Arabic Semicolon
+,	<char-0x060c>			" Arabic Comma
+?	<char-0x061f>			" Arabic Question Mark
+{	<char-0x0671>			" ALEF WASLA
+P	<char-0x067E>			" PEH
+J	<char-0x0686>			" TCHEH
+V	<char-0x06A4>			" VEH
+G	<char-0x06AF>			" GAF
+0	<char-0x06F0>			" Arabic-Indic 0
+1	<char-0x06F1>			" Arabic-Indic 1
+2	<char-0x06F2>			" Arabic-Indic 2
+3	<char-0x06F3>			" Arabic-Indic 3
+4	<char-0x06F4>			" Arabic-Indic 4
+5	<char-0x06F5>			" Arabic-Indic 5
+6	<char-0x06F6>			" Arabic-Indic 6
+7	<char-0x06F7>			" Arabic-Indic 7
+8	<char-0x06F8>			" Arabic-Indic 8
+9	<char-0x06F9>			" Arabic-Indic 9

--- a/runtime/syntax/m4.vim
+++ b/runtime/syntax/m4.vim
@@ -1,9 +1,8 @@
 " Vim syntax file
-" Language:		M4
+" Language:	M4
 " Maintainer:	Claudio Fleiner (claudio@fleiner.com)
-" URL:			http://www.fleiner.com/vim/syntax/m4.vim
-" 				(outdated)
 " Last Change:	2022 Jun 12
+" 2025 Sep 2 by Vim project: fix a few syntax issues #18192
 
 " This file will highlight user function calls if they use only
 " capital letters and have at least one argument (i.e. the '('
@@ -18,6 +17,23 @@ if !exists("main_syntax")
   let main_syntax='m4'
 endif
 
+" Reference: The Open Group Base Specifications, M4
+" https://pubs.opengroup.org/onlinepubs/9799919799/
+
+" Quoting in M4:
+" – Quotes are nestable;
+" – The delimiters can be redefined with changequote(); here we only handle
+"   the default pair: ` ... ';
+" – Quoted text in M4 is rescanned, not treated as a literal string;
+"   Therefore the region is marked transparent so contained items retain
+"   their normal highlighting.
+syn region m4Quoted
+  \ matchgroup=m4QuoteDelim
+  \ start=+`+
+  \ end=+'+
+  \ contains=@m4Top
+  \ transparent
+
 " define the m4 syntax
 syn match  m4Variable contained "\$\d\+"
 syn match  m4Special  contained "$[@*#]"
@@ -30,28 +46,26 @@ syn region m4Paren    matchgroup=m4Delimiter start="(" end=")" contained contain
 syn region m4Command  matchgroup=m4Function  start="\<\(m4_\)\=\(define\|defn\|pushdef\)(" end=")" contains=@m4Top
 syn region m4Command  matchgroup=m4Preproc   start="\<\(m4_\)\=\(include\|sinclude\)("he=e-1 end=")" contains=@m4Top
 syn region m4Command  matchgroup=m4Statement start="\<\(m4_\)\=\(syscmd\|esyscmd\|ifdef\|ifelse\|indir\|builtin\|shift\|errprint\|m4exit\|changecom\|changequote\|changeword\|m4wrap\|debugfile\|divert\|undivert\)("he=e-1 end=")" contains=@m4Top
-syn region m4Command  matchgroup=m4builtin start="\<\(m4_\)\=\(len\|index\|regexp\|substr\|translit\|patsubst\|format\|incr\|decr\|eval\|maketemp\)("he=e-1 end=")" contains=@m4Top
+syn region m4Command  matchgroup=m4Builtin start="\<\(m4_\)\=\(len\|index\|regexp\|substr\|translit\|patsubst\|format\|incr\|decr\|eval\|maketemp\)("he=e-1 end=")" contains=@m4Top
 syn keyword m4Statement divert undivert
 syn region m4Command  matchgroup=m4Type      start="\<\(m4_\)\=\(undefine\|popdef\)("he=e-1 end=")" contains=@m4Top
 syn region m4Function matchgroup=m4Type      start="\<[_A-Z][_A-Z0-9]*("he=e-1 end=")" contains=@m4Top
-syn region m4String   start="`" end="'" contains=SpellErrors
-syn cluster m4Top     contains=m4Comment,m4Constants,m4Special,m4Variable,m4String,m4Paren,m4Command,m4Statement,m4Function
+syn cluster m4Top     contains=m4Comment,m4Constants,m4Special,m4Variable,m4Paren,m4Command,m4Statement,m4Function,m4Quoted
 
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet
-hi def link m4Delimiter Delimiter
-hi def link m4Comment   Comment
-hi def link m4Function  Function
-hi def link m4Keyword   Keyword
-hi def link m4Special   Special
-hi def link m4String    String
-hi def link m4Statement Statement
-hi def link m4Preproc   PreProc
-hi def link m4Type      Type
-hi def link m4Special   Special
-hi def link m4Variable  Special
-hi def link m4Constants Constant
-hi def link m4Builtin   Statement
+hi def link m4QuoteDelim  Delimiter
+hi def link m4Delimiter   Delimiter
+hi def link m4Comment     Comment
+hi def link m4Function    Function
+hi def link m4Keyword     Keyword
+hi def link m4Special     Special
+hi def link m4Statement   Statement
+hi def link m4Preproc     PreProc
+hi def link m4Type        Type
+hi def link m4Variable    Special
+hi def link m4Constants   Constant
+hi def link m4Builtin     Statement
 
 let b:current_syntax = "m4"
 


### PR DESCRIPTION
#### vim-patch:e0704a3: runtime(keymap): Add transliteration (buckwalter) arabic keymap

References:
- https://en.wikipedia.org/wiki/Buckwalter_transliteration
- http://qamus.org/transliteration.htm

closes: vim/vim#18186

https://github.com/vim/vim/commit/e0704a359382ed3483c17db74b76110de6ef3519

Co-authored-by: Rafael Ketsetsides <rketsetsides@gmail.com>


#### vim-patch:f165798: runtime(m4): update syntax script

This change does the following to the M4 syntax script:

- In M4 there are no "strings" in the usual sense. Instead, M4 has
  quotes, but the text inside a quoted region is rescanned just like
  outside, and quotes can be nested.
- The old m4String region was misleading and removed. A new m4Quoted
  region reflects proper quoting semantics.
- Removed a duplicate highlight rule.
- Fixed a typo in a highlight group name (m4builtin → m4Builtin).
- Added a reference link to the POSIX M4 specification.
- Removed outdated maintainer URL.

closes: vim/vim#18192

https://github.com/vim/vim/commit/f165798184dc03895709704df864bd1e43eaf09f

Co-authored-by: Damien Lejay <damien@lejay.be>