### PR TITLE
fix(window): avoid referencing cmdline_win after it is closed

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -3138,6 +3138,10 @@ static win_T *win_free_mem(win_T *win, int *dirp, tabpage_T *tp)
   if (win == win_tp->tp_curwin) {
     win_tp->tp_curwin = wp;
   }
+  // Avoid executing cmdline_win logic after it is closed.
+  if (win == cmdline_win) {
+    cmdline_win = NULL;
+  }
 
   return wp;
 }

--- a/test/functional/lua/ui_event_spec.lua
+++ b/test/functional/lua/ui_event_spec.lua
@@ -390,6 +390,13 @@ describe('vim.ui_attach', function()
       9              bufname(        {12: }        |
       Excommand:call bufadd^(                  |
     ]])
+    -- No crash after _cmdline_offset window is closed #35584.
+    exec_lua(function()
+      vim.ui_detach(_G.ns)
+      vim.api.nvim_win_close(_G.win, true)
+    end)
+    feed('<Esc>:<Tab>')
+    n.assert_alive()
   end)
 end)
 


### PR DESCRIPTION
Solution:  A window marked for ext_cmdline usage is still referenced
           after it is already closed and freed.
Solution:  Unset cmdline_win when the window is closed.

Fix #35584
