### PR TITLE
fix(prompt_buffer): plugins can't set `':` mark

### DIFF
--- a/src/nvim/mark.c
+++ b/src/nvim/mark.c
@@ -146,6 +146,11 @@ int setmark_pos(int c, pos_T *pos, int fnum, fmarkv_T *view_pt)
     return OK;
   }
 
+  if (c == ':' && bt_prompt(buf)) {
+    RESET_FMARK(&buf->b_prompt_start, *pos, buf->b_fnum, view);
+    return OK;
+  }
+
   if (ASCII_ISLOWER(c)) {
     i = c - 'a';
     RESET_FMARK(buf->b_namedm + i, *pos, fnum, view);
@@ -1720,8 +1725,7 @@ bool mark_set_local(const char name, buf_T *const buf, const fmark_T fm, const b
   } else if (name == '^') {
     fm_tgt = &(buf->b_last_insert);
   } else if (name == ':') {
-    // Readonly mark for prompt buffer. Can't be edited on user side.
-    return false;
+    fm_tgt = &(buf->b_prompt_start);
   } else if (name == '.') {
     fm_tgt = &(buf->b_last_change);
   } else {

--- a/test/functional/legacy/prompt_buffer_spec.lua
+++ b/test/functional/legacy/prompt_buffer_spec.lua
@@ -622,6 +622,12 @@ describe('prompt buffer', function()
     -- ': mark is only available in prompt buffer.
     source('set buftype=')
     eq("Invalid mark name: ':'", t.pcall_err(api.nvim_buf_get_mark, 0, ':'))
+
+    -- mark can be moved
+    source('set buftype=prompt')
+    eq({ 11, 1 }, api.nvim_buf_get_mark(0, ':'))
+    eq(true, api.nvim_buf_set_mark(0, ':', 1, 1, {}))
+    eq({ 1, 1 }, api.nvim_buf_get_mark(0, ':'))
   end)
 
   describe('prompt_getinput', function()


### PR DESCRIPTION
Problem:
Currently, prompt_buffer manages `':` mark by itself and exposes it read-only mark. However when it fails there can be no mitigation made by plugins. The `':` mark should act like a regular marks and be modifiable.

Solution:
Allow plugins to set `':` mark.

fixes: #35615

cc @justinmk 
