### PR TITLE
fix(progress): incorrect id in extui and memoryleak with history set to false

### DIFF
--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -352,6 +352,7 @@ MsgID msg_multihl(MsgID id, HlMessage hl_msg, const char *kind, bool history, bo
   msg_start();
   msg_clr_eos();
   bool need_clear = false;
+  bool hl_msg_updated = false;
   msg_ext_history = history;
   if (kind != NULL) {
     msg_ext_set_kind(kind);
@@ -375,6 +376,7 @@ MsgID msg_multihl(MsgID id, HlMessage hl_msg, const char *kind, bool history, bo
     HlMessage formated_message = format_progress_message(hl_msg, msg_data);
     if (formated_message.items != hl_msg.items) {
       *needs_msg_clear = true;
+      hl_msg_updated = true;
       hl_msg = formated_message;
     }
   }
@@ -397,6 +399,10 @@ MsgID msg_multihl(MsgID id, HlMessage hl_msg, const char *kind, bool history, bo
   is_multihl = false;
   no_wait_return--;
   msg_end();
+
+  if (hl_msg_updated && !(history && kv_size(hl_msg))) {
+    hl_msg_free(hl_msg);
+  }
   return id;
 }
 

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -368,6 +368,7 @@ MsgID msg_multihl(MsgID id, HlMessage hl_msg, const char *kind, bool history, bo
       msg_id_next = id.data.integer + 1;
     }
   }
+  msg_ext_id = id;
 
   // progress message are special displayed as "title: percent% msg"
   if (strequal(kind, "progress") && msg_data) {
@@ -1161,7 +1162,6 @@ static void msg_hist_add_multihl(MsgID msg_id, HlMessage msg, bool temp, Message
   msg_hist_last = entry;
   msg_ext_history = true;
 
-  msg_ext_id = msg_id;
   msg_hist_clear(msg_hist_max);
 }
 

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -3640,4 +3640,41 @@ describe('progress-message', function()
       {6:TestSuit}: {19: 10% }test-message             |
     ]])
   end)
+
+  it('works with history off', function()
+    api.nvim_echo({ { 'test-message' } }, false, {
+      kind = 'progress',
+      title = 'TestSuit',
+      percent = 10,
+      status = 'running',
+    })
+
+    screen:expect({
+      grid = [[
+        ^                         |
+        {1:~                        }|*4
+      ]],
+      messages = {
+        {
+          content = {
+            { 'TestSuit', 6, 'MoreMsg' },
+            { ': ' },
+            { ' 10% ', 19, 'WarningMsg' },
+            { 'test-message' },
+          },
+          id = 1,
+          kind = 'progress',
+        },
+      },
+    })
+
+    assert_progress_autocmd({
+      text = { 'test-message' },
+      percent = 10,
+      status = 'running',
+      title = 'TestSuit',
+      id = 1,
+      data = {},
+    }, 'progress autocmd receives progress messages')
+  end)
 end)


### PR DESCRIPTION
### Problem:
When history is set to false, the correct message ID is always sent as 0 to extui. And the formatted message doesn't get cleared, leading to a memory leak.

### Solution:
Send the correct msg-id when the message with `history=false`. Clear formatted message when it doesn't get stored in hisotry.

cc @justinmk 