### PR TITLE
feat(pack): `vim.pack.get()` gets VCS info

### DIFF
--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -272,8 +272,9 @@ Switch plugin's version:
 
 Freeze plugin from being updated:
 • Update 'init.lua' for plugin to have `version` set to current commit hash.
-  You can get it by running `vim.pack.update({ 'plugin-name' })` and yanking
-  the word describing current state (looks like `abc12345`).
+  You can get it by running
+  `:=vim.pack.get({ 'plugin-name' }, { details = true })` (located at
+  `details.state`; looks like `abc12345`).
 • |:restart|.
 
 Unfreeze plugin to start receiving updates:
@@ -355,8 +356,15 @@ del({names})                                                  *vim.pack.del()*
                  be managed by |vim.pack|, not necessarily already added to
                  current session.
 
-get()                                                         *vim.pack.get()*
-    Get data about all plugins managed by |vim.pack|
+get({names}, {opts})                                          *vim.pack.get()*
+    Get data about plugins managed by |vim.pack|
+
+    Parameters: ~
+      • {names}  (`string[]?`) List of plugin names. Default: all plugins
+                 managed by |vim.pack|.
+      • {opts}   (`table?`) A table with the following fields:
+                 • {details} (`boolean`) Whether to include plugin details.
+                   Default `false`.
 
     Return: ~
         (`table[]`) A list of objects with the following fields:
@@ -365,6 +373,10 @@ get()                                                         *vim.pack.get()*
         • {path} (`string`) Plugin's path on disk.
         • {active} (`boolean`) Whether plugin was added via |vim.pack.add()|
           to current session.
+        • {details}? (`{ branches: string[], state: string, tags: string[] }`)
+          • `branches` lists available Git branches (first is default).
+          • `state` is a current Git state.
+          • `tags` lists available Git tags.
 
 update({names}, {opts})                                    *vim.pack.update()*
     Update plugins

--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -271,10 +271,8 @@ Switch plugin's version:
   run |vim.pack.update()|.
 
 Freeze plugin from being updated:
-• Update 'init.lua' for plugin to have `version` set to current commit hash.
-  You can get it by running
-  `:=vim.pack.get({ 'plugin-name' }, { details = true })` (located at
-  `details.state`; looks like `abc12345`).
+• Update 'init.lua' for plugin to have `version` set to current revision. Get
+  it with `:=vim.pack.get({ 'plug-name' })[1].rev` (looks like `abc12345`).
 • |:restart|.
 
 Unfreeze plugin to start receiving updates:
@@ -357,26 +355,26 @@ del({names})                                                  *vim.pack.del()*
                  current session.
 
 get({names}, {opts})                                          *vim.pack.get()*
-    Get data about plugins managed by |vim.pack|
+    Gets |vim.pack| plugin info, optionally filtered by `names`.
 
     Parameters: ~
       • {names}  (`string[]?`) List of plugin names. Default: all plugins
                  managed by |vim.pack|.
       • {opts}   (`table?`) A table with the following fields:
-                 • {details} (`boolean`) Whether to include plugin details.
-                   Default `false`.
+                 • {info} (`boolean`) Whether to include extra plugin info.
+                   Default `true`.
 
     Return: ~
         (`table[]`) A list of objects with the following fields:
-        • {spec} (`vim.pack.SpecResolved`) A |vim.pack.Spec| with resolved
-          `name`.
-        • {path} (`string`) Plugin's path on disk.
         • {active} (`boolean`) Whether plugin was added via |vim.pack.add()|
           to current session.
-        • {details}? (`{ branches: string[], state: string, tags: string[] }`)
-          • `branches` lists available Git branches (first is default).
-          • `state` is a current Git state.
-          • `tags` lists available Git tags.
+        • {branches}? (`string[]`) Available Git branches (first is default).
+          Missing if `info=false`.
+        • {path} (`string`) Plugin's path on disk.
+        • {rev}? (`string`) Current Git revision. Missing if `info=false`.
+        • {spec} (`vim.pack.SpecResolved`) A |vim.pack.Spec| with resolved
+          `name`.
+        • {tags}? (`string[]`) Available Git tags. Missing if `info=false`.
 
 update({names}, {opts})                                    *vim.pack.update()*
     Update plugins

--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -360,8 +360,8 @@ get()                                                         *vim.pack.get()*
 
     Return: ~
         (`table[]`) A list of objects with the following fields:
-        • {spec} (`vim.pack.SpecResolved`) A |vim.pack.Spec| with defaults
-          made explicit.
+        • {spec} (`vim.pack.SpecResolved`) A |vim.pack.Spec| with resolved
+          `name`.
         • {path} (`string`) Plugin's path on disk.
         • {active} (`boolean`) Whether plugin was added via |vim.pack.add()|
           to current session.

--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -326,32 +326,20 @@ local function normalize_plugs(plugs)
   return res
 end
 
---- @param names string[]?
+--- @param names? string[]
 --- @return vim.pack.Plug[]
 local function plug_list_from_names(names)
-  local all_plugins = M.get()
+  local p_data_list = M.get(names)
   local plug_dir = get_plug_dir()
   local plugs = {} --- @type vim.pack.Plug[]
-  local used_names = {} --- @type table<string,boolean>
-  -- Preserve plugin order; might be important during checkout or event trigger
-  for _, p_data in ipairs(all_plugins) do
+  for _, p_data in ipairs(p_data_list) do
     -- NOTE: By default include only active plugins (and not all on disk). Using
     -- not active plugins might lead to a confusion as default `version` and
     -- user's desired one might mismatch.
-    -- TODO(echasnovski): Consider changing this if/when there is lockfile.
-    --- @cast names string[]
-    if (not names and p_data.active) or vim.tbl_contains(names or {}, p_data.spec.name) then
+    -- TODO(echasnovski): Change this when there is lockfile.
+    if names ~= nil or p_data.active then
       plugs[#plugs + 1] = new_plug(p_data.spec, plug_dir)
-      used_names[p_data.spec.name] = true
     end
-  end
-
-  if vim.islist(names) and #plugs ~= #names then
-    --- @param n string
-    local unused = vim.tbl_filter(function(n)
-      return not used_names[n]
-    end, names)
-    error('The following plugins are not installed: ' .. table.concat(unused, ', '))
   end
 
   return plugs

--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -328,7 +328,7 @@ end
 --- @param names? string[]
 --- @return vim.pack.Plug[]
 local function plug_list_from_names(names)
-  local p_data_list = M.get(names)
+  local p_data_list = M.get(names, { info = false })
   local plug_dir = get_plug_dir()
   local plugs = {} --- @type vim.pack.Plug[]
   for _, p_data in ipairs(p_data_list) do

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -597,7 +597,8 @@ describe('vim.pack', function()
         '`basic`:\n',
         -- Should report available branches and tags if revision is absent
         '`wrong%-version`',
-        'Available:\nTags: some%-tag\nBranches: feat%-branch, main',
+        -- Should list default branch first
+        'Available:\nTags: some%-tag\nBranches: main, feat%-branch',
         -- Should report available branches and versions if no constraint match
         '`semver`',
         'Available:\nVersions: v1%.0%.0, v0%.4, 0%.3%.1, v0%.3%.0.*\nBranches: main\n',

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -1153,7 +1153,7 @@ describe('vim.pack', function()
         vim.pack.add({ repos_src.basic })
       end)
 
-      validate('The following plugins are not installed: aaa, ccc', { 'aaa', 'basic', 'ccc' })
+      validate('Plugin `ccc` is not installed', { 'ccc', 'basic', 'aaa' })
 
       -- Empty list is allowed with warning
       n.exec('messages clear')
@@ -1276,16 +1276,16 @@ describe('vim.pack', function()
       eq(false, pack_exists('plugindirs'))
 
       eq(
-        "vim.pack: Removed plugin 'plugindirs'\nvim.pack: Removed plugin 'basic'",
+        "vim.pack: Removed plugin 'basic'\nvim.pack: Removed plugin 'plugindirs'",
         n.exec_capture('messages')
       )
 
       -- Should trigger relevant events in order as specified in `vim.pack.add()`
       local log = exec_lua('return _G.event_log')
-      eq(1, find_in_log(log, 'PackChangedPre', 'delete', 'plugindirs', nil))
-      eq(2, find_in_log(log, 'PackChanged', 'delete', 'plugindirs', nil))
-      eq(3, find_in_log(log, 'PackChangedPre', 'delete', 'basic', 'feat-branch'))
-      eq(4, find_in_log(log, 'PackChanged', 'delete', 'basic', 'feat-branch'))
+      eq(1, find_in_log(log, 'PackChangedPre', 'delete', 'basic', 'feat-branch'))
+      eq(2, find_in_log(log, 'PackChanged', 'delete', 'basic', 'feat-branch'))
+      eq(3, find_in_log(log, 'PackChangedPre', 'delete', 'plugindirs', nil))
+      eq(4, find_in_log(log, 'PackChanged', 'delete', 'plugindirs', nil))
       eq(4, #log)
     end)
 
@@ -1305,7 +1305,7 @@ describe('vim.pack', function()
         vim.pack.add({ repos_src.basic })
       end)
 
-      validate('The following plugins are not installed: aaa, ccc', { 'aaa', 'basic', 'ccc' })
+      validate('Plugin `ccc` is not installed', { 'ccc', 'basic', 'aaa' })
       eq(true, pack_exists('basic'))
 
       -- Empty list is allowed with warning


### PR DESCRIPTION
This PR addresses two issue.

---

`spec.version` on `master` is explicitly resolved (`nil` values are replaced with default branch) when triggering events and inside `get()`. This was done to allow users and wrapper plugins to know which actual branch is used. However, this comes at consistency (`PackChangedPre` for install can't have it inferred, for example) and performance cost. More importantly, it also hides the information about whether the user explicitly set `version` or not, which might matter in some use cases (like detecting if `version` has actually changed).

This PR stops doing that and tries to preserve `spec` in state as close to what user (eventually) set it to. I.e. it converts string `src` to table field and infers `name` (because it is required for further operations).

---

To allow users and wrapper plugins to compute information about installed plugins, this PR updates `get()` to allow to return data only for a handful of plugins and opt in for computing extra info about them. The API is `get(names, opts)` with `opts.info` being `true` by default.

Two examples of usages:

- Get current state: `get({ 'plug-name' })[1].rev`      
- Get default branch: `get({ 'plug-name' })[1].branches[1]`