### PR TITLE
vim-patch:9.1.1731: Not using const qualifier for opchars

### DIFF
--- a/src/nvim/ops.c
+++ b/src/nvim/ops.c
@@ -99,7 +99,7 @@ static const char e_search_pattern_and_expression_register_may_not_contain_two_o
 /// The names of operators.
 /// IMPORTANT: Index must correspond with defines in ops.h!!!
 /// The third field indicates whether the operator always works on lines.
-static char opchars[][3] = {
+static const char opchars[][3] = {
   { NUL, NUL, 0 },                       // OP_NOP
   { 'd', NUL, OPF_CHANGE },              // OP_DELETE
   { 'y', NUL, 0 },                       // OP_YANK


### PR DESCRIPTION
#### vim-patch:9.1.1731: Not using const qualifier for opchars

Problem:  Not using const qualifier
Solution: Mark the opchars array const

closes: vim/vim#18196

https://github.com/vim/vim/commit/63a02ca39a73c81683ffe182c8cea9000d523299

Co-authored-by: Damien Lejay <damien@lejay.be>