### PR TITLE
vim-patch:9.1.1732: filetype: .inc file detection can be improved

### DIFF
--- a/runtime/lua/vim/filetype/detect.lua
+++ b/runtime/lua/vim/filetype/detect.lua
@@ -844,27 +844,29 @@ function M.inc(path, bufnr)
   if vim.g.filetype_inc then
     return vim.g.filetype_inc
   end
-  local lines = table.concat(getlines(bufnr, 1, 3))
-  if lines:lower():find('perlscript') then
-    return 'aspperl'
-  elseif lines:find('<%%') then
-    return 'aspvbs'
-  elseif lines:find('<%?') then
-    return 'php'
+  for _, line in ipairs(getlines(bufnr, 1, 20)) do
+    if line:lower():find('perlscript') then
+      return 'aspperl'
+    elseif line:find('<%%') then
+      return 'aspvbs'
+    elseif line:find('<%?') then
+      return 'php'
     -- Pascal supports // comments but they're vary rarely used for file
     -- headers so assume POV-Ray
-  elseif findany(lines, { '^%s{', '^%s%(%*' }) or matchregex(lines, pascal_keywords) then
-    return 'pascal'
-  elseif findany(lines, { '^%s*inherit ', '^%s*require ', '^%s*%u[%w_:${}]*%s+%??[?:+]?= ' }) then
-    return 'bitbake'
-  else
-    local syntax = M.asm_syntax(path, bufnr)
-    if not syntax or syntax == '' then
-      return 'pov'
+    elseif findany(line, { '^%s{', '^%s%(%*' }) or matchregex(line, pascal_keywords) then
+      return 'pascal'
+    elseif
+      findany(line, { '^%s*inherit ', '^%s*require ', '^%s*%u[%w_:${}/]*%s+%??[?:+.]?=.? ' })
+    then
+      return 'bitbake'
     end
-    return syntax, function(b)
-      vim.b[b].asmsyntax = syntax
-    end
+  end
+  local syntax = M.asm_syntax(path, bufnr)
+  if not syntax or syntax == '' then
+    return 'pov'
+  end
+  return syntax, function(b)
+    vim.b[b].asmsyntax = syntax
   end
 end
 

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -2660,6 +2660,21 @@ func Test_inc_file()
   call assert_equal('bitbake', &filetype)
   bwipe!
 
+  call writefile(['PREFERRED_PROVIDER_virtual/kernel = "linux-yocto"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
+  call writefile(['MACHINEOVERRIDES =. "qemuall:"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
+  call writefile(['BBPATH .= ":${LAYERDIR}"'], 'Xfile.inc')
+  split Xfile.inc
+  call assert_equal('bitbake', &filetype)
+  bwipe!
+
   " asm
   call writefile(['asmsyntax=foo'], 'Xfile.inc')
   split Xfile.inc


### PR DESCRIPTION
#### vim-patch:9.1.1732: filetype: .inc file detection can be improved

Problem:  filetype: .inc file detection can be improved
Solution: Update filetype detection for Pascal and BitBake code
          (Martin Schwan).

Fix the detection of .inc files containing Pascal and BitBake code:

- the concatenated string, merged from three lines, only contains one
  beginning and the pattern "^" would not match as expected. Use a range()
  loop to iterate each line string individually. This way, the pattern "^"
  works for beginning of lines.

- improve BitBake include file detection by also matching forward-slashes
  "/" in variable names and assignment operators with a dot ".=" and "=.".
  Valid examples, which should match, are:

    PREFERRED_PROVIDER_virtual/kernel = "linux-yocto"
    MACHINEOVERRIDES =. "qemuall:"
    BBPATH .= ":${LAYERDIR}"

- parse twenty instead of just three lines, to accommodate for potential
  comments at the beginning of files

closes: vim/vim#18202

https://github.com/vim/vim/commit/9fd1a657d2efae5cff278eb5acaa380623a50cf6

Co-authored-by: Martin Schwan <m.schwan@phytec.de>