### PR TITLE
vim-patch: Python syntax updates

### DIFF
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -229,10 +229,10 @@ syn region  pythonFStringField
     \ start=/{/
     \ end=/\%(=\s*\)\=\%(!\a\s*\)\=\%(:\%({\_[^}]*}\|[^{}]*\)\+\)\=}/
     \ contained
-    \ contains=ALLBUT,pythonFStringField,pythonClass,pythonFunction,pythonDoctest,pythonDoctestValue,@Spell
+    \ contains=ALLBUT,pythonFStringField,pythonClass,pythonFunction,pythonType,pythonDoctest,pythonDoctestValue,@Spell
 syn match   pythonFStringFieldSkip  /(\_[^()]*)\|\[\_[^][]*]\|{\_[^{}]*}/
     \ contained
-    \ contains=ALLBUT,pythonFStringField,pythonClass,pythonFunction,pythonDoctest,pythonDoctestValue,@Spell
+    \ contains=ALLBUT,pythonFStringField,pythonClass,pythonFunction,pythonType,pythonDoctest,pythonDoctestValue,@Spell
 
 " Doubled braces are not replacement fields
 syn match   pythonFStringSkip	/{{/ transparent contained contains=NONE

--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Python
 " Maintainer:	Zvezdan Petkovic <zpetkovic@acm.org>
-" Last Change:	2025 Aug 23
+" Last Change:	2025 Sep 05
 " Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "		Rob B
@@ -218,21 +218,24 @@ syn region  pythonRawBytes
 
 " F-string replacement fields
 "
-" - Matched parentheses, brackets and braces are ignored
-" - A bare # is ignored to end of line
-" - A bare = (surrounded by optional whitespace) enables debugging
-" - A bare ! prefixes a conversion field
+" - Matched parentheses, brackets and braces are skipped
+" - A bare = (followed by optional whitespace) enables debugging
+" - A bare ! prefixes a conversion field (followed by optional whitespace)
 " - A bare : begins a format specification
-"     - Matched braces inside a format specification are ignored
+"     - Matched braces inside a format specification are skipped
 "
 syn region  pythonFStringField
     \ matchgroup=pythonFStringDelimiter
     \ start=/{/
-    \ skip=/([^)]*)\|\[[^]]*]\|{[^}]*}\|#.*$/
-    \ end=/\%(\s*=\s*\)\=\%(!\a\)\=\%(:\%({[^}]*}\|[^}]*\)\+\)\=}/
+    \ end=/\%(=\s*\)\=\%(!\a\s*\)\=\%(:\%({\_[^}]*}\|[^{}]*\)\+\)\=}/
     \ contained
-" Doubled braces and Unicode escapes are not replacement fields
-syn match   pythonFStringSkip	/{{\|\\N{/ transparent contained contains=NONE
+    \ contains=ALLBUT,pythonFStringField,pythonClass,pythonFunction,pythonDoctest,pythonDoctestValue,@Spell
+syn match   pythonFStringFieldSkip  /(\_[^()]*)\|\[\_[^][]*]\|{\_[^{}]*}/
+    \ contained
+    \ contains=ALLBUT,pythonFStringField,pythonClass,pythonFunction,pythonDoctest,pythonDoctestValue,@Spell
+
+" Doubled braces are not replacement fields
+syn match   pythonFStringSkip	/{{/ transparent contained contains=NONE
 
 syn match   pythonEscape	+\\[abfnrtv'"\\]+ contained
 syn match   pythonEscape	"\\\o\{1,3}" contained


### PR DESCRIPTION
#### vim-patch:d2b28dd: runtime(python): add syntax support inside f-strings

closes: vim/vim#17962

https://github.com/vim/vim/commit/d2b28ddfc2a7350c2f63b75d06cc53d17b3a66ff

Co-authored-by: Rob B <github@0x7e.net>


#### vim-patch:f1212a7: runtime(python): Do not match contained identifiers as pythonType

related: vim/vim#17962
closes: vim/vim#18206

https://github.com/vim/vim/commit/f1212a7b4554f2f544b581f7e819d6ef67c5e9ad

Co-authored-by: Rob B <github@0x7e.net>