### PR TITLE
vim-patch:9.1.1734: Memory leak when allocating match fails

### DIFF
--- a/src/nvim/match.c
+++ b/src/nvim/match.c
@@ -46,7 +46,7 @@ static const char *e_invalwindow = N_("E957: Invalid window number");
 /// Add match to the match list of window "wp".
 /// If "pat" is not NULL the pattern will be highlighted with the group "grp"
 /// with priority "prio".
-/// If "pos_list" is not NULL the list of posisions defines the highlights.
+/// If "pos_list" is not NULL the list of positions defines the highlights.
 /// Optionally, a desired ID "id" can be specified (greater than or equal to 1).
 /// If no particular ID is desired, -1 must be specified for "id".
 ///
@@ -214,6 +214,7 @@ static int match_add(win_T *wp, const char *const grp, const char *const pat, in
   return id;
 
 fail:
+  vim_regfree(regprog);
   xfree(m->mit_pattern);
   xfree(m->mit_pos_array);
   xfree(m);


### PR DESCRIPTION
#### vim-patch:9.1.1734: Memory leak when allocating match fails

Problem:  Memory leak when allocating match fails
Solution: Initialize m to NULL and centralize cleanup via goto fail to
          avoid leaks on early returns (Damien Lejay)

closes: vim/vim#18204

https://github.com/vim/vim/commit/37e77282949786bb178c8fb8d6717afcaa40688e

Co-authored-by: Damien Lejay <damien@lejay.be>