### PR TITLE
vim-patch: runtime file updates

### DIFF
--- a/runtime/ftplugin/ada.vim
+++ b/runtime/ftplugin/ada.vim
@@ -2,7 +2,8 @@
 "  Description: Perform Ada specific completion & tagging.
 "     Language: Ada (2005)
 "	   $Id: ada.vim 887 2008-07-08 14:29:01Z krischik $
-"   Maintainer: Martin Krischik <krischik@users.sourceforge.net>
+"   Maintainer: This runtime file is looking for a new maintainer.
+"   Previous Maintainer: Martin Krischik <krischik@users.sourceforge.net>
 "		Taylor Venable <taylor@metasyntax.net>
 "		Neil Bird <neil@fnxweb.com>
 "      $Author: krischik $
@@ -19,6 +20,10 @@
 "                             autoload
 "		05.11.2006 MK Bram suggested to save on spaces
 "		08.07.2007 TV fix default compiler problems.
+"		05.09.2025    do not globally set 'ignorecase'/'smartcase' option
+"			      set undo_ftplugin
+"			      mark as unmaintained
+"			      use buffer-local abbreviation
 "    Help Page: ft-ada-plugin
 "------------------------------------------------------------------------------
 " Provides mapping overrides for tag jumping that figure out the current
@@ -48,8 +53,8 @@ setlocal complete=.,w,b,u,t,i
 
 " Section: case	     {{{1
 "
-setlocal nosmartcase
-setlocal ignorecase
+" setlocal nosmartcase
+" setlocal ignorecase
 
 " Section: formatoptions {{{1
 "
@@ -115,7 +120,6 @@ if !exists ("b:match_words")  &&
       \ s:notend . '\<record\>:\<end\>\s\+\<record\>'
 endif
 
-
 " Section: Compiler {{{1
 "
 if ! exists("g:ada_default_compiler")
@@ -148,10 +152,10 @@ endif
 " Section: Abbrev {{{1
 "
 if exists("g:ada_abbrev")
-   iabbrev ret	return
-   iabbrev proc procedure
-   iabbrev pack package
-   iabbrev func function
+   iabbrev <buffer> ret	return
+   iabbrev <buffer> proc procedure
+   iabbrev <buffer> pack package
+   iabbrev <buffer> func function
 endif
 
 " Section: Commands, Mapping, Menus {{{1
@@ -190,6 +194,12 @@ if !exists(':AdaTagFile')
      \ ':AdaTypes',
      \'call ada#Switch_Syntax_Option (''standard_types'')')
 endif
+"
+" Section: b:undo_ftplugin {{{1
+let b:undo_ftplugin = "setl fo< comments< tw< commentstring< complete< "
+	\ . "| setl completefunc< omnifunc< ts< sts< sw< fdm< fde< fdi< "
+	\ . "| setl fdm< fde< fdi< fdn< "
+	\ . "| unlet! b:match_words "
 
 " 1}}}
 " Reset cpoptions

--- a/runtime/ftplugin/hamster.vim
+++ b/runtime/ftplugin/hamster.vim
@@ -4,6 +4,7 @@
 " Maintainer:  David Fishburn <dfishburn dot vim at gmail dot com>
 " Last Change: 2021 Jan 19
 "              2024 May 23 by Riley Bruins <ribru17@gmail.com> ('commentstring')
+"              2025 Sep 05 by Vim Project, disable setting global ignorecase
 
 " Only do this when not done yet for this buffer
 if exists("b:did_ftplugin")
@@ -57,7 +58,7 @@ if exists("loaded_matchit")
   "	\ synIDattr(synID(line("."),col("."),1),"name") =~? "comment\\|string"'
 endif
 
-setlocal ignorecase
+" setlocal ignorecase
 
 let &cpo = s:cpo_save
 unlet s:cpo_save

--- a/runtime/syntax/m4.vim
+++ b/runtime/syntax/m4.vim
@@ -3,6 +3,7 @@
 " Maintainer:	Claudio Fleiner (claudio@fleiner.com)
 " Last Change:	2022 Jun 12
 " 2025 Sep 2 by Vim project: fix a few syntax issues #18192
+" 2025 Sep 5 by Vim project: introduce m4Disabled region #18200
 
 " This file will highlight user function calls if they use only
 " capital letters and have at least one argument (i.e. the '('
@@ -24,7 +25,7 @@ endif
 " – Quotes are nestable;
 " – The delimiters can be redefined with changequote(); here we only handle
 "   the default pair: ` ... ';
-" – Quoted text in M4 is rescanned, not treated as a literal string;
+" – Quoted text in M4 is rescanned, not treated as a literal string.
 "   Therefore the region is marked transparent so contained items retain
 "   their normal highlighting.
 syn region m4Quoted
@@ -34,11 +35,20 @@ syn region m4Quoted
   \ contains=@m4Top
   \ transparent
 
+" Comments in M4:
+" – According to the Open Group Base Specification, comments start with
+"   a <number-sign> (#) and end at <newline>, unless redefined with changecom().
+"   We only handle the default here.
+" – Comments in M4 are not like in most languages: they do not remove the text,
+"   they simply prevent any macros from being expanded, while the text remains
+"   in the output. This region therefore disables any other matches.
+" – Comments themselves are disabled when quoted.
+syn region m4Disabled start=+#+ end=+$+ containedin=ALLBUT,m4Quoted
+
 " define the m4 syntax
 syn match  m4Variable contained "\$\d\+"
 syn match  m4Special  contained "$[@*#]"
 syn match  m4Comment  "\<\(m4_\)\=dnl\>.*" contains=SpellErrors
-syn match  m4Comment  "#.*" contains=SpellErrors
 syn match  m4Constants "\<\(m4_\)\=__file__"
 syn match  m4Constants "\<\(m4_\)\=__line__"
 syn keyword m4Constants divnum sysval m4_divnum m4_sysval


### PR DESCRIPTION
#### vim-patch:510ca80: runtime(m4): Improve comments, distinguish them from #-lines

closes: vim/vim#18200

https://github.com/vim/vim/commit/510ca80c58088276d8b1744a729f69d34c550566

Co-authored-by: Damien Lejay <damien@lejay.be>


#### vim-patch:f737ff8: runtime(hamster): do not globally set ignorecase

related: vim/vim#15772

https://github.com/vim/vim/commit/f737ff8c88b5fb77050ba44d986ee20d59ad37be

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:dfcd9ac: runtime(ada): mark as unmaintained, fix a few issues with the ftplugin

closes: vim/vim#18178

https://github.com/vim/vim/commit/dfcd9ac120fd40d7e869922cec0bb273e9bc154a

Co-authored-by: Christian Brabandt <cb@256bit.org>