### PR TITLE
fix(api): win_set_config error message for splitting from a float

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -415,25 +415,6 @@ void nvim_win_set_config(Window window, Dict(win_config) *config, Error *err)
   if (!parse_win_config(win, config, &fconfig, !was_split || to_split, err)) {
     return;
   }
-  win_T *parent = config->win == 0 ? curwin : NULL;
-  tabpage_T *parent_tp = config->win == 0 ? curtab : NULL;
-
-  if (config->win > 0) {
-    parent = find_window_by_handle(fconfig.window, err);
-    if (!parent) {
-      return;
-    } else if (to_split && parent->w_floating) {
-      api_set_error(err, kErrorTypeException, "Cannot split a floating window");
-      return;
-    }
-    parent_tp = win_find_tabpage(parent);
-
-    // Prevent autocmd window from being moved into another tabpage
-    if (is_aucmd_win(win) && win_tp != parent_tp) {
-      api_set_error(err, kErrorTypeException, "Cannot move autocmd win to another tabpage");
-      return;
-    }
-  }
 
   if (was_split && !to_split) {
     if (!win_new_float(win, false, fconfig, err)) {
@@ -441,6 +422,34 @@ void nvim_win_set_config(Window window, Dict(win_config) *config, Error *err)
     }
     redraw_later(win, UPD_NOT_VALID);
   } else if (to_split) {
+    win_T *parent = NULL;
+    tabpage_T *parent_tp = NULL;
+    if (config->win == 0) {
+      parent = curwin;
+      parent_tp = curtab;
+    } else if (config->win > 0) {
+      parent = find_window_by_handle(fconfig.window, err);
+      if (!parent) {
+        return;
+      }
+      parent_tp = win_find_tabpage(parent);
+    }
+    if (parent) {
+      if (parent->w_floating) {
+        api_set_error(err, kErrorTypeException, "Cannot split a floating window");
+        return;
+      }
+      if (is_aucmd_win(win) && win_tp != parent_tp) {
+        api_set_error(err, kErrorTypeException, "Cannot move autocmd window to another tabpage");
+        return;
+      }
+      // Can't move the cmdwin or its old curwin to a different tabpage.
+      if ((win == cmdwin_win || win == cmdwin_old_curwin) && win_tp != parent_tp) {
+        api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
+        return;
+      }
+    }
+
     WinSplit old_split = win_split_dir(win);
     if (has_vertical && !has_split) {
       if (config->vertical) {
@@ -467,11 +476,6 @@ void nvim_win_set_config(Window window, Dict(win_config) *config, Error *err)
 
     if (!check_split_disallowed_err(win, err)) {
       return;  // error already set
-    }
-    // Can't move the cmdwin or its old curwin to a different tabpage.
-    if ((win == cmdwin_win || win == cmdwin_old_curwin) && parent && parent_tp != win_tp) {
-      api_set_error(err, kErrorTypeException, "%s", e_cmdwin);
-      return;
     }
 
     bool to_split_ok = false;


### PR DESCRIPTION
Problem: after #34287 nvim_win_set_config no longer errors when attempting to split from a floating window only if "win" is 0.

Solution: fix the regression, reduce the scope of "parent" and similar checks to only where it's currently used and add test coverage for the errors.

(Note: splitting from a float generally works, but the API preferred this as an error as they're without a frame to split relative to; that said, could be useful for `nvim_open_win` as a way of copying the options from a float if it were allowed, I guess)