### PR TITLE
docs(lsp): tweak `inline_completion.get` code snippet

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2295,11 +2295,7 @@ get({opts})                                  *vim.lsp.inline_completion.get()*
           if not vim.lsp.inline_completion.get() then
             return '<Tab>'
           end
-        end, {
-          expr = true,
-          replace_keycodes = true,
-          desc = 'Get the current inline completion',
-        })
+        end, { expr = true, desc = 'Accept the current inline completion' })
 <
 
     Parameters: ~

--- a/runtime/lua/vim/lsp/inline_completion.lua
+++ b/runtime/lua/vim/lsp/inline_completion.lua
@@ -439,11 +439,7 @@ end
 ---   if not vim.lsp.inline_completion.get() then
 ---     return '<Tab>'
 ---   end
---- end, {
----   expr = true,
----   replace_keycodes = true,
----   desc = 'Get the current inline completion',
---- })
+--- end, { expr = true, desc = 'Accept the current inline completion' })
 --- ````
 ---@param opts? vim.lsp.inline_completion.get.Opts
 ---@return boolean `true` if a completion was applied, else `false`.


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
`replace_keycodes` is true if `expr` is set, and "Accept" is a better term to describe the keymap.