### PR TITLE
feat(lsp): return code and error instead of using `vim.notify`

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -1313,13 +1313,6 @@ the current buffer.
       • {context}?  (`{ bufnr: integer, method: string }`) Subset of `ctx`
                     from |lsp-handler|.
 
-*vim.lsp.buf.hover.Opts*
-    Extends: |vim.lsp.util.open_floating_preview.Opts|
-
-
-    Fields: ~
-      • {silent}?  (`boolean`)
-
 *vim.lsp.buf.signature_help.Opts*
     Extends: |vim.lsp.util.open_floating_preview.Opts|
 
@@ -1462,7 +1455,14 @@ hover({config})                                          *vim.lsp.buf.hover()*
 <
 
     Parameters: ~
-      • {config}  (`vim.lsp.buf.hover.Opts?`) See |vim.lsp.buf.hover.Opts|.
+      • {config}  (`vim.lsp.util.open_floating_preview.Opts?`) See
+                  |vim.lsp.util.open_floating_preview.Opts|.
+
+    Return (multiple): ~
+        (`boolean`) `true` if hover was successfully show, `false` and an
+        error message otherwise.
+        (`string?`) `true` if hover was successfully show, `false` and an
+        error message otherwise.
 
 implementation({opts})                          *vim.lsp.buf.implementation()*
     Lists all the implementations for the symbol under the cursor in the

--- a/runtime/lua/vim/lsp/buf.lua
+++ b/runtime/lua/vim/lsp/buf.lua
@@ -25,9 +25,6 @@ end
 
 local hover_ns = api.nvim_create_namespace('nvim.lsp.hover_range')
 
---- @class vim.lsp.buf.hover.Opts : vim.lsp.util.open_floating_preview.Opts
---- @field silent? boolean
-
 --- Displays hover information about the symbol under the cursor in a floating
 --- window. The window will be dismissed on cursor move.
 --- Calling the function twice will jump into the floating window
@@ -45,7 +42,8 @@ local hover_ns = api.nvim_create_namespace('nvim.lsp.hover_range')
 ---   end,
 --- })
 --- ```
---- @param config? vim.lsp.buf.hover.Opts
+--- @param config? vim.lsp.util.open_floating_preview.Opts
+--- @return boolean, string|nil # `true` if hover was successfully show, `false` and an error message otherwise.
 function M.hover(config)
   validate('config', config, 'table', true)
 
@@ -98,14 +96,11 @@ function M.hover(config)
     end
 
     if vim.tbl_isempty(results1) then
-      if config.silent ~= true then
-        if empty_response then
-          vim.notify('Empty hover response', vim.log.levels.INFO)
-        else
-          vim.notify('No information available', vim.log.levels.INFO)
-        end
+      if empty_response then
+        return false, 'Empty hover response'
+      else
+        return false, 'No information available'
       end
-      return
     end
 
     local contents = {} --- @type string[]
@@ -169,6 +164,8 @@ function M.hover(config)
       end,
     })
   end)
+
+  return true
 end
 
 local function request_with_opts(name, params, opts)


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

## Problem

The methods in `vim.lsp.buf.*` surface errors in different scenarios. The goal of https://github.com/neovim/neovim/pull/34523 is to introduce a new `callback` argument that will receive the errors returned by the language servers when handling the LSP request. However there are cases where we (the editor) error before even entering the async LSP loop, and the goal of this PR is to address those scenarios.

https://github.com/neovim/neovim/pull/34523#discussion_r2312648694 mentions an example of this: We invoke `vim.notify()` [in methods like `vim.lsp.buf.definition()`](https://github.com/neovim/neovim/blob/1cb1cfead017df79aa590d1d297b116a85cb31c0/runtime/lua/vim/lsp/buf.lua#L195) when there are no clients to handle the request. The `callback` argument from https://github.com/neovim/neovim/pull/34523 isn't exactly applicable to this "error" since we haven't even made a request.

## Proposal

Let's modify these LSP functions to return a boolean indicating success/failure and an optional error message. This way we can remove the `silent` option (as users can decide what to do on failure).