### PR TITLE
refactor(api): redundant w_pos_changed assignment

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -633,7 +633,6 @@ restore_curwin:
     }
   } else {
     win_config_float(win, fconfig);
-    win->w_pos_changed = true;
   }
   if (HAS_KEY_X(config, style)) {
     if (fconfig.style == kWinStyleMinimal) {


### PR DESCRIPTION
Problem: w_pos_changed flag was being set redundantly after win_config_float call

Solution: remove duplicate assignment since win_config_float already sets this flag internally

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
