### PR TITLE
feat(abbrev): add C function to register iabbrev definitions

### DIFF
--- a/src/nvim/mapping.c
+++ b/src/nvim/mapping.c
@@ -2903,3 +2903,30 @@ ArrayOf(Dict) keymap_array(String mode, buf_T *buf, Arena *arena)
 
   return arena_take_arraybuilder(arena, &mappings);
 }
+
+/// Add an insert-mode abbreviation.
+///
+/// @param lhs  Left-hand side of the abbreviation
+/// @param rhs  Right-hand side expansion text
+void add_iabbrev(const char *lhs, const char *rhs)
+  FUNC_ATTR_NONNULL_ALL
+{
+  MapArguments args = MAP_ARGUMENTS_INIT;
+  args.rhs = xstrdup(rhs);
+  args.orig_rhs = xstrdup(rhs);
+  args.rhs_lua = LUA_NOREF;
+
+  map_add(NULL,
+          NULL,
+          &first_abbr,
+          lhs,
+          &args,
+          false,
+          MODE_INSERT,
+          true,
+          0,
+          0,
+          false);
+
+  no_abbr = false;
+}


### PR DESCRIPTION
Problem: My [plugin](https://github.com/chris-ritsen/autocorrect.nvim) loads typo-correction pairs using :iabbrev but this is slow because of how many entries there are (about 52,000).

| System           | Method             | Time     |
|------------------|--------------------|----------|
| MacBook Pro M4   | `:iabbrev`     | 3951 ms  |
| Intel i9-7940X   | `:iabbrev`     | 15484 ms |

Solution: Introduce a helper function that constructs MapArguments and calls map_add directly, enabling much faster insertion of iabbrev entries programmatically. This gets called using FFI in my plugin.

| System           | Method             | Time     |
|------------------|--------------------|----------|
| MacBook Pro M4   | `add_iabbrev` (FFI) | **29 ms** |
| Intel i9-7940X   | `add_iabbrev` (FFI) | **90 ms** |
