### PR TITLE
fix(float): fix ghost cmdline on down-scroll

### DIFF
--- a/src/nvim/ui_compositor.c
+++ b/src/nvim/ui_compositor.c
@@ -667,7 +667,7 @@ void ui_comp_grid_scroll(Integer grid, Integer top, Integer bot, Integer left, I
   bot += curgrid->comp_row;
   left += curgrid->comp_col;
   right += curgrid->comp_col;
-  bool covered = curgrid_covered_above((int)(bot - MAX(rows, 0)));
+  bool covered = curgrid_covered_above((int)bot - 1);
 
   if (covered || curgrid->blending) {
     // TODO(bfredl):

--- a/test/functional/ex_cmds/normal_spec.lua
+++ b/test/functional/ex_cmds/normal_spec.lua
@@ -1,5 +1,6 @@
 local t = require('test.testutil')
 local n = require('test.functional.testnvim')()
+local Screen = require('test.functional.ui.screen')
 
 local clear = n.clear
 local command = n.command
@@ -36,5 +37,14 @@ describe(':normal!', function()
     command('normal! \027')
     eq('n', fn.mode(1))
     eq(':', fn.getcmdwintype())
+  end)
+
+  it('no crash when performing two scrolls #11019', function()
+    clear { args = { '--clean', '-u', 'NORC' } }
+    Screen.new(20, 8)
+    command('set redrawdebug=invalid')
+    n.insert('\n\n\n\n\n\n\n\n\n\nhello')
+    command('normal Gzz=ko')
+    n.assert_alive()
   end)
 end)

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -11053,4 +11053,22 @@ describe('float window', function()
   describe('without ext_multigrid', function()
     with_ext_multigrid(false)
   end)
+
+  it('no ghost cmdline on down-scroll #34512', function()
+    local screen = Screen.new(20, 4)
+    command('set ruler')
+    api.nvim_open_win(0, true, { relative = 'editor', width = 20, height = 4, row = 0, col = 0 })
+    insert([[
+      hello
+      hello
+      hello
+      hello]])
+    feed('Gzz')
+    screen:expect([[
+  {4:hello               }|
+  {4:^hello               }|
+  {11:~                   }|
+            4,1   Bot |
+    ]])
+  end)
 end)


### PR DESCRIPTION
Problem:
a ghost cmdline appears when scrolling a full-height float window downward

Solution:
Change `bot - MAX(rows, 0)` to `bot - 1` to correctly check if the float grid is being covered by msg_grid

will fix #34512

Additional notes:
1. `bot - 1` could also correctly detect if `default_grid` is covered by `msg_grid` when `laststatus=0`, this avoids triggering a `recompose`:
      | v0.11.3 | this PR |
      |--------|--------|
      | <video src="https://github.com/user-attachments/assets/c93d30d6-2174-4fc0-9859-ac3fa4b210ea" /> | <video src="https://github.com/user-attachments/assets/d17c3eb7-b58a-43f9-bb38-1fbd8ff931d2" /> | 
2. `bot - MAX(rows, 0)` is introduced in PR [#11025](https://github.com/neovim/neovim/pull/11025), and I also add a test case for its related issue [#11019](https://github.com/neovim/neovim/issues/11019). 
3. BTW, a later PR [#11121](https://github.com/neovim/neovim/pull/11121) ensures that `attrbuf[i] > 0`, so I feel the condition code below might be outdated. If we want to remove the code later, the test case might be useful.
     https://github.com/neovim/neovim/blob/1cb1cfead017df79aa590d1d297b116a85cb31c0/src/nvim/ui_compositor.c#L679-L686

This is the 4th issue I dug into. I picked up a lot of low-level concepts while debugging last week, but there might still be gaps in my understanding. Please feel free to point out anything if I'm wrong.  :)

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
