### PR TITLE
fix(lsp): check whether buffer is valid when scheduled in client:on_attach()

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -1099,6 +1099,9 @@ function Client:on_attach(bufnr)
   -- on_attach and LspAttach callbacks the ability to schedule wrap the
   -- opt-out (deleting the semanticTokensProvider from capabilities)
   vim.schedule(function()
+    if not vim.api.nvim_buf_is_valid(bufnr) then
+      return
+    end
     for _, Capability in pairs(lsp._capability.all) do
       if
         self:supports_method(Capability.method)


### PR DESCRIPTION


Problem:
lsp._capability.is_enabled() can raise error if buffer is invalid in client:on_attach().

- error
```
./build/bin/nvim --clean --headless +"source ./minimal.lua"
vim.schedule callback: ...omo/workspace/neovim/runtime/lua/vim/lsp/_capability.lua:209: scoped variable: Invalid buffer id: 2
stack traceback:
        [C]: in function '__index'
        ...omo/workspace/neovim/runtime/lua/vim/lsp/_capability.lua:209: in function 'is_enabled'
        ...e/notomo/workspace/neovim/runtime/lua/vim/lsp/client.lua:1108: in function <...e/notomo/workspace/neovim/runtime/lua/vim/lsp/client.lua:1101>
```
- reproduction minimal.lua
```lua
vim.opt.runtimepath:append("/path/to/nvim-lspconfig/")
vim.lsp.enable("lua_ls")

vim.cmd.tabedit("runtime/lua/vim/_defaults.lua")
vim.api.nvim_create_autocmd({ "LspAttach" }, {
  group = vim.api.nvim_create_augroup("test", {}),
  callback = function()
    vim.cmd.tabedit("runtime/lua/vim/_defaults.lua")
    local bufnr = vim.api.nvim_get_current_buf()
    vim.api.nvim_buf_delete(bufnr, { force = true })
  end,
})
```

Solution:
Check whether buffer is valid.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
