### PR TITLE
vim-patch: cmdline completion fixes

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -1087,12 +1087,11 @@ static void showmatches_oneline(expand_T *xp, char **matches, int numMatches, in
 /// Show all matches for completion on the command line.
 /// Returns EXPAND_NOTHING when the character that triggered expansion should
 /// be inserted like a normal character.
-int showmatches(expand_T *xp, bool wildmenu)
+int showmatches(expand_T *xp, bool wildmenu, bool noselect)
 {
   CmdlineInfo *const ccline = get_cmdline_info();
   int numMatches;
   char **matches;
-  int j;
   int maxlen;
   int lines;
   int columns;
@@ -1109,12 +1108,12 @@ int showmatches(expand_T *xp, bool wildmenu)
     if (xp->xp_context == EXPAND_LUA) {
       nlua_expand_pat(xp);
     }
-    int i = expand_cmdline(xp, ccline->cmdbuff, ccline->cmdpos,
-                           &numMatches, &matches);
-    showtail = expand_showtail(xp);
-    if (i != EXPAND_OK) {
-      return i;
+    int retval = expand_cmdline(xp, ccline->cmdbuff, ccline->cmdpos,
+                                &numMatches, &matches);
+    if (retval != EXPAND_OK) {
+      return retval;
     }
+    showtail = expand_showtail(xp);
   } else {
     numMatches = xp->xp_numfiles;
     matches = xp->xp_files;
@@ -1145,15 +1144,16 @@ int showmatches(expand_T *xp, bool wildmenu)
     // find the length of the longest file name
     maxlen = 0;
     for (int i = 0; i < numMatches; i++) {
+      int len;
       if (!showtail && (xp->xp_context == EXPAND_FILES
                         || xp->xp_context == EXPAND_SHELLCMD
                         || xp->xp_context == EXPAND_BUFFERS)) {
         home_replace(NULL, matches[i], NameBuff, MAXPATHL, true);
-        j = vim_strsize(NameBuff);
+        len = vim_strsize(NameBuff);
       } else {
-        j = vim_strsize(SHOW_MATCH(i));
+        len = vim_strsize(SHOW_MATCH(i));
       }
-      maxlen = MAX(maxlen, j);
+      maxlen = MAX(maxlen, len);
     }
 
     if (xp->xp_context == EXPAND_TAGS_LISTFILES) {

--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -381,7 +381,7 @@ int nextwild(expand_T *xp, int type, int options, bool escape)
   return OK;
 }
 
-/// Create completion popup menu with items from 'matches'.
+/// Create completion popup menu with items from "matches".
 static int cmdline_pum_create(CmdlineInfo *ccline, expand_T *xp, char **matches, int numMatches,
                               bool showtail, bool noselect)
 {

--- a/src/nvim/cmdexpand.h
+++ b/src/nvim/cmdexpand.h
@@ -40,7 +40,7 @@ enum {
   WILD_NOERROR              = 0x800,  ///< sets EW_NOERROR
   WILD_BUFLASTUSED          = 0x1000,
   BUF_DIFF_FILTER           = 0x2000,
-  WILD_KEEP_SOLE_ITEM       = 0x4000,
+  WILD_NOSELECT             = 0x4000,
   WILD_MAY_EXPAND_PATTERN   = 0x8000,
   WILD_FUNC_TRIGGER         = 0x10000,  ///< called from wildtrigger()
 };

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1195,6 +1195,9 @@ static int command_line_wildchar_complete(CommandLineState *s)
               nextwild(&s->xpc, WILD_NEXT, options, escape);
             }
             showmatches(&s->xpc, p_wmnu, wim_list_next, wim_noselect_next);
+            if (wim_list_next) {
+              s->did_wild_list = true;
+            }
           }
         }
       } else {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1188,13 +1188,11 @@ static int command_line_wildchar_complete(CommandLineState *s)
           bool wim_full_next = (wim_flags[1] & kOptWimFlagFull);
           bool wim_noselect_next = (wim_flags[1] & kOptWimFlagNoselect);
           if (wim_list_next || (p_wmnu && (wim_full_next || wim_noselect_next))) {
-            if (wim_noselect_next) {
-              options |= WILD_NOSELECT;
-            }
-            if (wim_full_next || wim_noselect_next) {
+            if (wim_full_next && !wim_noselect_next) {
               nextwild(&s->xpc, WILD_NEXT, options, escape);
+            } else {
+              showmatches(&s->xpc, p_wmnu, wim_list_next, wim_noselect_next);
             }
-            showmatches(&s->xpc, p_wmnu, wim_list_next, wim_noselect_next);
             if (wim_list_next) {
               s->did_wild_list = true;
             }

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1179,16 +1179,25 @@ static int command_line_wildchar_complete(CommandLineState *s)
 
     // Display matches
     if (res == OK && s->xpc.xp_numfiles > (wim_noselect ? 0 : 1)) {
-      // If "longest" fails to identify the longest item, try other
-      // 'wim' values if available
-      if (wim_longest && ccline.cmdpos == cmdpos_before) {
-        if (wim_full) {
-          nextwild(&s->xpc, WILD_NEXT, options, escape);
-        }
+      if (wim_longest) {
+        bool found_longest_prefix = (ccline.cmdpos != cmdpos_before);
         if (wim_list || (p_wmnu && wim_full)) {
-          showmatches(&s->xpc, p_wmnu, wim_list, false);
+          showmatches(&s->xpc, p_wmnu, wim_list, true);
+        } else if (!found_longest_prefix) {
+          bool wim_list_next = (wim_flags[1] & kOptWimFlagList);
+          bool wim_full_next = (wim_flags[1] & kOptWimFlagFull);
+          bool wim_noselect_next = (wim_flags[1] & kOptWimFlagNoselect);
+          if (wim_list_next || (p_wmnu && (wim_full_next || wim_noselect_next))) {
+            if (wim_noselect_next) {
+              options |= WILD_NOSELECT;
+            }
+            if (wim_full_next || wim_noselect_next) {
+              nextwild(&s->xpc, WILD_NEXT, options, escape);
+            }
+            showmatches(&s->xpc, p_wmnu, wim_list_next, wim_noselect_next);
+          }
         }
-      } else if (!wim_longest) {
+      } else {
         if (wim_list || (p_wmnu && (wim_full || wim_noselect))) {
           showmatches(&s->xpc, p_wmnu, wim_list, wim_noselect);
         } else {

--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -530,6 +530,47 @@ describe('cmdline', function()
       /global^                                                          |
     ]])
   end)
+
+  -- oldtest: Test_long_line_noselect()
+  it("long line is shown properly with noselect in 'wildmode'", function()
+    local screen = Screen.new(60, 8)
+    exec([[
+      set wildmenu wildoptions=pum wildmode=noselect,full
+      command -nargs=1 -complete=custom,Entries DoubleEntry echo
+      func Entries(a, b, c)
+        return 'loooooooooooooooong quite loooooooooooong, really loooooooooooong, probably too looooooooooooooooooooooooooong entry'
+      endfunc
+    ]])
+
+    feed(':DoubleEntry <Tab>')
+    screen:expect([[
+                                                                  |
+      {1:~                                                           }|*5
+      {1:~           }{4: loooooooooooooooong quite loooooooooooong, real}|
+      :DoubleEntry ^                                               |
+    ]])
+
+    feed('<C-N>')
+    screen:expect([[
+                                                                  |
+      {1:~                                                           }|*3
+      {3:                                                            }|
+      :DoubleEntry loooooooooooooooong quite loooooooooooong, real|
+      ly loooooooo{12: loooooooooooooooong quite loooooooooooong, real}|
+      ong entry^                                                   |
+    ]])
+
+    feed('<C-N>')
+    screen:expect([[
+                                                                  |
+      {1:~                                                           }|*3
+      {3:            }{4: loooooooooooooooong quite loooooooooooong, real}|
+      :DoubleEntry ^                                               |
+                                                                  |*2
+    ]])
+
+    feed('<Esc>')
+  end)
 end)
 
 describe('cmdwin', function()

--- a/test/functional/ui/cmdline_spec.lua
+++ b/test/functional/ui/cmdline_spec.lua
@@ -535,12 +535,40 @@ local function test_cmdline(linegrid)
         {2:långfile1                }|
                                  |
       ]],
+      cmdline = { { content = { { 'b långfile1' } }, firstc = ':', pos = 12 } },
       popupmenu = {
         anchor = { -1, 0, 2 },
         items = { { 'långfile1', '', '', '' }, { 'långfile2', '', '', '' } },
         pos = 0,
       },
-      cmdline = { { content = { { 'b långfile1' } }, firstc = ':', pos = 12 } },
+    }
+
+    feed('<Esc>')
+    command('silent %bwipe')
+
+    command('set shellslash')
+    -- position is correct when expanding environment variable #20348
+    command('silent cd test/functional/fixtures')
+    n.fn.setenv('XNDIR', 'wildpum/Xnamedir')
+    feed(':e $XNDIR/<Tab>')
+    screen:expect {
+      grid = [[
+        ^                         |
+        {1:~                        }|*3
+                                 |
+      ]],
+      cmdline = {
+        {
+          content = { { 'e wildpum/Xnamedir/XdirA/' } },
+          firstc = ':',
+          pos = 25,
+        },
+      },
+      popupmenu = {
+        anchor = { -1, 0, 19 },
+        items = { { 'XdirA/', '', '', '' }, { 'XfileA', '', '', '' } },
+        pos = 0,
+      },
     }
   end)
 

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -4795,8 +4795,9 @@ describe('builtin popupmenu', function()
           :cn^                             |
         ]])
 
-        feed('<C-U><Esc>')
         command('set wildmode& wildoptions=pum')
+
+        feed('<C-U><Esc>')
 
         -- check positioning with multibyte char in pattern
         command('e långfile1')
@@ -4981,24 +4982,52 @@ describe('builtin popupmenu', function()
 
         -- pressing <Tab> should display the wildmenu
         feed('<Tab>')
-        screen:expect([[
+        local s1 = [[
                                         |
           {1:~                             }|*4
           {1:~    }{12: undefine       }{1:         }|
           {1:~    }{n: unplace        }{1:         }|
           :sign undefine^                |
-        ]])
+        ]]
+        screen:expect(s1)
         eq(1, fn.wildmenumode())
 
         -- pressing <Tab> second time should select the next entry in the menu
         feed('<Tab>')
-        screen:expect([[
+        local s2 = [[
                                         |
           {1:~                             }|*4
           {1:~    }{n: undefine       }{1:         }|
           {1:~    }{12: unplace        }{1:         }|
           :sign unplace^                 |
+        ]]
+        screen:expect(s2)
+        eq(1, fn.wildmenumode())
+
+        -- If "longest" finds no candidate in "longest,full", "full" is used
+        feed('<Esc>')
+        command('set wildmode=longest,full')
+        command('set wildoptions=pum')
+        feed(':sign un<Tab>')
+        screen:expect(s1)
+        feed('<Tab>')
+        screen:expect(s2)
+
+        -- Similarly for "longest,noselect:full"
+        feed('<Esc>')
+        command('set wildmode=longest,noselect:full')
+        feed(':sign un<Tab>')
+        screen:expect([[
+                                        |
+          {1:~                             }|*4
+          {1:~    }{n: undefine       }{1:         }|
+          {1:~    }{n: unplace        }{1:         }|
+          :sign un^                      |
         ]])
+        feed('<Tab>')
+        screen:expect(s1)
+        feed('<Tab>')
+        screen:expect(s2)
       end)
 
       it('wildoptions=pum with a wrapped line in buffer vim-patch:8.2.4655', function()

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -1060,6 +1060,7 @@ describe('builtin popupmenu', function()
         [110] = { background = Screen.colors.Grey, foreground = Screen.colors.DarkYellow },
         [111] = { background = Screen.colors.Plum1, foreground = Screen.colors.DarkBlue },
         [112] = { background = Screen.colors.Plum1, foreground = Screen.colors.DarkGreen },
+        [113] = { background = Screen.colors.Yellow, foreground = Screen.colors.Black },
         -- popup non-selected item
         n = { background = Screen.colors.Plum1 },
         -- popup scrollbar knob
@@ -4693,6 +4694,107 @@ describe('builtin popupmenu', function()
         ]])
 
         feed('<Esc>')
+
+        -- "longest:list" shows list whether it finds a candidate or not
+        command('set wildmode=longest:list,full wildoptions=')
+        feed(':cn<Tab>')
+        screen:expect([[
+                                          |
+          {1:~                               }|*3
+          {3:                                }|
+          :cn                             |
+          cnewer       cnoreabbrev        |
+          cnext        cnoremap           |
+          cnfile       cnoremenu          |
+          :cn^                             |
+        ]])
+        feed('<Tab>')
+        screen:expect([[
+                                          |
+          {1:~                               }|*2
+          {3:                                }|
+          :cn                             |
+          cnewer       cnoreabbrev        |
+          cnext        cnoremap           |
+          cnfile       cnoremenu          |
+          {113:cnewer}{3:  cnext  cnfile  >        }|
+          :cnewer^                         |
+        ]])
+        feed('<Esc>:sign u<Tab>')
+        screen:expect([[
+                                          |
+          {1:~                               }|*5
+          {3:                                }|
+          :sign un                        |
+          undefine  unplace               |
+          :sign un^                        |
+        ]])
+
+        -- "longest:full" shows wildmenu whether it finds a candidate or not;
+        -- item not selected
+        feed('<Esc>')
+        command('set wildmode=longest:full,full')
+        feed(':sign u<Tab>')
+        screen:expect([[
+                                          |
+          {1:~                               }|*7
+          {3:undefine  unplace               }|
+          :sign un^                        |
+        ]])
+        feed('<Tab>')
+        screen:expect([[
+                                          |
+          {1:~                               }|*7
+          {113:undefine}{3:  unplace               }|
+          :sign undefine^                  |
+        ]])
+
+        feed('<Esc>:cn<Tab>')
+        screen:expect([[
+                                          |
+          {1:~                               }|*7
+          {3:cnewer  cnext  cnfile  >        }|
+          :cn^                             |
+        ]])
+        feed('<Tab>')
+        screen:expect([[
+                                          |
+          {1:~                               }|*7
+          {113:cnewer}{3:  cnext  cnfile  >        }|
+          :cnewer^                         |
+        ]])
+
+        -- If "longest,full" finds a candidate, wildmenu is not shown
+        feed('<Esc>')
+        command('set wildmode=longest,full')
+        feed(':sign u<Tab>')
+        screen:expect([[
+                                          |
+          {1:~                               }|*8
+          :sign un^                        |
+        ]])
+        -- Subsequent wildchar shows wildmenu
+        feed('<Tab>')
+        screen:expect([[
+                                          |
+          {1:~                               }|*7
+          {113:undefine}{3:  unplace               }|
+          :sign undefine^                  |
+        ]])
+
+        -- 'longest' does not find candidate, and displays menu without selecting item
+        feed('<Esc>')
+        command('set wildmode=longest,noselect')
+        feed(':cn<Tab>')
+        screen:expect([[
+                                          |
+          {1:~                               }|*7
+          {3:cnewer  cnext  cnfile  >        }|
+          :cn^                             |
+        ]])
+
+        feed('<C-U><Esc>')
+        command('set wildmode& wildoptions=pum')
 
         -- check positioning with multibyte char in pattern
         command('e långfile1')

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -4853,7 +4853,7 @@ describe('builtin popupmenu', function()
         ]])
 
         feed('<esc>')
-        command('close')
+        command('%bwipe')
         command('set wildmode=full')
 
         -- special case: when patterns ends with "/", show menu items aligned
@@ -4865,6 +4865,18 @@ describe('builtin popupmenu', function()
           {1:~         }{12: file1          }{1:                        }|
           {1:~         }{n: file2          }{1:                        }|
           :e compdir/file1^                                  |
+        ]])
+
+        -- position is correct when expanding environment variable #20348
+        command('cd ..')
+        fn.setenv('XNDIR', 'wildpum/Xnamedir')
+        feed('<C-U>e $XNDIR/<Tab>')
+        screen:expect([[
+                                                            |
+          {1:~                                                 }|*11
+          {1:~                  }{12: XdirA/         }{1:               }|
+          {1:~                  }{n: XfileA         }{1:               }|
+          :e wildpum/Xnamedir/XdirA/^                        |
         ]])
       end)
     end

--- a/test/functional/ui/popupmenu_spec.lua
+++ b/test/functional/ui/popupmenu_spec.lua
@@ -4517,7 +4517,7 @@ describe('builtin popupmenu', function()
 
         feed('<esc>')
 
-        -- Check "list" still works
+        -- Check that when "longest" produces no result, "list" works
         command('set wildmode=longest,list')
         feed(':cn<Tab>')
         screen:expect([[
@@ -4530,6 +4530,8 @@ describe('builtin popupmenu', function()
           cnfile       cnoremenu          |
           :cn^                             |
         ]])
+        feed('<Tab>')
+        screen:expect_unchanged()
         feed('s')
         screen:expect([[
                                           |

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -2900,7 +2900,7 @@ func Test_wildmenu_pum()
   call term_sendkeys(buf, "\<C-U>set wildmode=longest,list\<CR>")
   call term_sendkeys(buf, ":cn\<Tab>")
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_30', {})
-  call term_sendkeys(buf, "\<Tab>")
+  call term_sendkeys(buf, "s")
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_31', {})
 
   " Tests a directory name contained full-width characters.
@@ -3002,28 +3002,45 @@ func Test_wildmenu_pum()
 
   call term_sendkeys(buf, "\<Esc>:set showtabline& laststatus& lazyredraw&\<CR>")
 
-  " Verify that if "longest" finds nothing, wildmenu is still shown
-  call term_sendkeys(buf, ":set wildmode=longest:full,full wildoptions&\<CR>")
-  call term_sendkeys(buf, ":cn\<Tab>")
-  call TermWait(buf, 50)
-  call VerifyScreenDump(buf, 'Test_wildmenu_pum_54', {})
-
-  " Verify that if "longest" finds nothing, "list" is still shown
-  call term_sendkeys(buf, "\<Esc>:set wildmode=longest:list,full\<CR>")
+  " "longest:list" shows list whether it finds a candidate or not
+  call term_sendkeys(buf, ":set wildmode=longest:list,full wildoptions&\<CR>")
   call term_sendkeys(buf, ":cn\<Tab>")
   call TermWait(buf, 50)
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_55', {})
   call term_sendkeys(buf, "\<Tab>")
   call TermWait(buf, 50)
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_56', {})
-
-  " Verify that if "longest" finds a candidate, wildmenu is not shown
-  call term_sendkeys(buf, "\<Esc>:set wildmode=longest:full,full wildoptions&\<CR>")
-  call term_sendkeys(buf, ":sign u\<Tab>")
+  call term_sendkeys(buf, "\<Esc>:sign u\<Tab>")
+  call TermWait(buf, 50)
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_57', {})
+
+  " "longest:full" shows wildmenu whether it finds a candidate or not; item not selected
+  call term_sendkeys(buf, "\<Esc>:set wildmode=longest:full,full\<CR>")
+  call term_sendkeys(buf, ":sign u\<Tab>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_58', {})
+  call term_sendkeys(buf, "\<Tab>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_59', {})
+  call term_sendkeys(buf, "\<Esc>:cn\<Tab>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_60', {})
+  call term_sendkeys(buf, "\<Tab>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_61', {})
+
+  " If "longest,full" finds a candidate, wildmenu is not shown
+  call term_sendkeys(buf, "\<Esc>:set wildmode=longest,full\<CR>")
+  call term_sendkeys(buf, ":sign u\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_62', {})
   " Subsequent wildchar shows wildmenu
   call term_sendkeys(buf, "\<Tab>")
-  call VerifyScreenDump(buf, 'Test_wildmenu_pum_58', {})
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_63', {})
+
+  " 'longest' does not find candidate, and displays menu without selecting item
+  call term_sendkeys(buf, "\<Esc>:set wildmode=longest,noselect\<CR>")
+  call term_sendkeys(buf, ":cn\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_64', {})
 
   call term_sendkeys(buf, "\<C-U>\<Esc>")
   call StopVimInTerminal(buf)

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -2900,6 +2900,8 @@ func Test_wildmenu_pum()
   call term_sendkeys(buf, "\<C-U>set wildmode=longest,list\<CR>")
   call term_sendkeys(buf, ":cn\<Tab>")
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_30', {})
+  call term_sendkeys(buf, "\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_30', {})
   call term_sendkeys(buf, "s")
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_31', {})
 

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -3044,6 +3044,23 @@ func Test_wildmenu_pum()
   call term_sendkeys(buf, ":cn\<Tab>")
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_64', {})
 
+  " If "longest" finds no candidate in "longest,full", "full" is used
+  call term_sendkeys(buf, "\<Esc>:set wildmode=longest,full\<CR>")
+  call term_sendkeys(buf, ":set wildoptions=pum\<CR>")
+  call term_sendkeys(buf, ":sign un\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_09', {})
+  call term_sendkeys(buf, "\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_10', {})
+
+  " Similarly for "longest,noselect:full"
+  call term_sendkeys(buf, "\<Esc>:set wildmode=longest,noselect:full\<CR>")
+  call term_sendkeys(buf, ":sign un\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_65', {})
+  call term_sendkeys(buf, "\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_09', {})
+  call term_sendkeys(buf, "\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_10', {})
+
   call term_sendkeys(buf, "\<C-U>\<Esc>")
   call StopVimInTerminal(buf)
 endfunc

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -2896,11 +2896,11 @@ func Test_wildmenu_pum()
   call term_sendkeys(buf, "sign xyz\<Esc>:sign \<Tab>\<C-E>\<Up>")
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_29', {})
 
-  " Check "list" still works
+  " Check that when "longest" produces no result, "list" works
   call term_sendkeys(buf, "\<C-U>set wildmode=longest,list\<CR>")
   call term_sendkeys(buf, ":cn\<Tab>")
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_30', {})
-  call term_sendkeys(buf, "s")
+  call term_sendkeys(buf, "\<Tab>")
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_31', {})
 
   " Tests a directory name contained full-width characters.
@@ -3000,7 +3000,32 @@ func Test_wildmenu_pum()
   call term_sendkeys(buf, "\<Esc>:set wildchazz\<Left>\<Left>\<Tab>\<C-Y>")
   call VerifyScreenDump(buf, 'Test_wildmenu_pum_53', {})
 
-  call term_sendkeys(buf, "\<C-U>\<CR>")
+  call term_sendkeys(buf, "\<Esc>:set showtabline& laststatus& lazyredraw&\<CR>")
+
+  " Verify that if "longest" finds nothing, wildmenu is still shown
+  call term_sendkeys(buf, ":set wildmode=longest:full,full wildoptions&\<CR>")
+  call term_sendkeys(buf, ":cn\<Tab>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_54', {})
+
+  " Verify that if "longest" finds nothing, "list" is still shown
+  call term_sendkeys(buf, "\<Esc>:set wildmode=longest:list,full\<CR>")
+  call term_sendkeys(buf, ":cn\<Tab>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_55', {})
+  call term_sendkeys(buf, "\<Tab>")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_56', {})
+
+  " Verify that if "longest" finds a candidate, wildmenu is not shown
+  call term_sendkeys(buf, "\<Esc>:set wildmode=longest:full,full wildoptions&\<CR>")
+  call term_sendkeys(buf, ":sign u\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_57', {})
+  " Subsequent wildchar shows wildmenu
+  call term_sendkeys(buf, "\<Tab>")
+  call VerifyScreenDump(buf, 'Test_wildmenu_pum_58', {})
+
+  call term_sendkeys(buf, "\<C-U>\<Esc>")
   call StopVimInTerminal(buf)
 endfunc
 

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -5620,7 +5620,7 @@ func Test_completetimeout_autocompletetimeout()
   set completetimeout=1
   call feedkeys("Gof\<C-N>\<F2>\<Esc>0", 'xt!')
   let match_count = len(b:matches->mapnew('v:val.word'))
-  call assert_true(match_count < 2000)
+  call assert_true(match_count < 4000)
 
   set completetimeout=1000
   call feedkeys("\<Esc>Sf\<C-N>\<F2>\<Esc>0", 'xt!')


### PR DESCRIPTION
Fix #20348

#### vim-patch:partial:9.1.1639: completion: popup may be misplaced

Problem:  During commandline completiom, popup window placement can be
          incorrect when 'noselect' is present in 'wildmode'
          (Shane-XB-Qian)
Solution: Disable "showtail" feature when 'noselect' is present.

closes: vim/vim#18001

https://github.com/vim/vim/commit/1e38198a413f7235c909ccd0d55b339a3e920615

Partial port excluding the showtail change and the test.

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1676: completion: long line shown twice

Problem:  completion: long line shown twice
          (Maxim Kim)
Solution: Fix the issue, disable an incorrect test.
          (Girish Palya)

closes: vim/vim#18088

https://github.com/vim/vim/commit/57379302aa2a82ee0c9aca49ddd681308cf1483c

Omit removal of blank line in Test_noselect_expand_env_var() as it's
added again in patch 9.1.1682.
Cherry-pick two blank lines in Test_long_line_noselect() from patch
9.1.1682.

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1714: completion: wildmode=longest:full selects wrong item

Problem:  completion: wildmode=longest:full selects wrong item
          (zeertzjq)
Solution: Fix issue, refactor ex_getln.c slightly
          (Girish Palya)

closes: vim/vim#18125

https://github.com/vim/vim/commit/2eccb4d0bec87854cfc214e1feb96b5a8f4a69df

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1737: Patch v9.1.1714 introduce a regression for wildmenu

Problem:  Patch v9.1.1714 introduce a regression for wildmenu (zeertzjq)
Solution: Restore behavior of "longest" in 'wildmode' (Girish Palya)

- Fixed a regression caused by PR vim/vim#18125 selecting wrong item
- Fixed another regression where the first pasted text did not appear on
  the command-line after starting Vim.

closes: vim/vim#18212

https://github.com/vim/vim/commit/8fec92d631cf9d852ad794863721c2710ee2ff9e

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1739: Matches may be listed twice with wildmode=longest,list

Problem:  Matches may be listed twice with wildmode=longest,list when
          "longest" doesn't change command line (after 9.1.1737).
Solution: Set did_wild_list when trying "list" after "longest"
          (zeertzjq).

closes: vim/vim#18227

https://github.com/vim/vim/commit/a28a2eb9d9362adb1c7f9ebde66cd1329dd463bb


#### vim-patch:9.1.1740: Memory leak with wildmode=longest,full and wildoptions=pum

Problem:  Memory leak with wildmode=longest,full and wildoptions=pum
          (after 9.1.1737).
Solution: Avoid using showmatches() and WILD_NEXT together.  Also fix
          wildmode=longest,noselect:full selecting wrong item
          (zeertzjq).

closes: vim/vim#18229

https://github.com/vim/vim/commit/c7f235bd432c0a7500ae39acdad7d63a614a1b33