### PR TITLE
fix(api): crash when moving curwin to other tabpage

### DIFF
--- a/src/nvim/buffer.c
+++ b/src/nvim/buffer.c
@@ -570,7 +570,7 @@ bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last, bool i
     }
     buf->b_locked--;
     buf->b_locked_split--;
-    if (abort_if_last && one_window(win)) {
+    if (abort_if_last && win != NULL && one_window(win, NULL)) {
       // Autocommands made this the only window.
       emsg(_(e_auabort));
       return false;
@@ -589,7 +589,7 @@ bool close_buffer(win_T *win, buf_T *buf, int action, bool abort_if_last, bool i
       }
       buf->b_locked--;
       buf->b_locked_split--;
-      if (abort_if_last && one_window(win)) {
+      if (abort_if_last && win != NULL && one_window(win, NULL)) {
         // Autocommands made this the only window.
         emsg(_(e_auabort));
         return false;

--- a/src/nvim/version.c
+++ b/src/nvim/version.c
@@ -2730,7 +2730,7 @@ bool may_show_intro(void)
           && (curbuf->b_fname == NULL)
           && (curbuf->handle == 1)
           && (curwin->handle == LOWEST_WIN_ID)
-          && one_window(curwin)
+          && one_window(curwin, NULL)
           && (vim_strchr(p_shm, SHM_INTRO) == NULL));
 }
 


### PR DESCRIPTION
Problem: `nvim_win_set_config` may crash when attempting to move `curwin` to a
different tabpage if there is no other non-float available to switch to.

Solution: fix the crash. Fix `ONE_WINDOW` checks in `winframe_find_altwin` and
`win_altframe` to consider floating windows by instead using `one_window`. Allow
`one_window` to consider non-current tabpages. We can use `one_window` in
`win_close_othertab` now to also better reflect its use in `win_close`.
