### PR TITLE
vim-patch:9.1.{1738,1744},d7d6a6f

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -384,6 +384,9 @@ word before the cursor.  This is available for:
 The number of help item matches is limited (currently to 300) to avoid a long
 delay when there are very many matches.
 
+For automatic completion as you type (without pressing a key like <Tab>),
+see |cmdline-autocompletion|.
+
 These are the commands that can be used:
 
 							*c_CTRL-D*
@@ -455,8 +458,6 @@ accepted when matching file names.
 When repeating 'wildchar' or CTRL-N you cycle through the matches, eventually
 ending up back to what was typed.  If the first match is not what you wanted,
 you can use <S-Tab> or CTRL-P to go straight back to what you typed.
-
-See also |wildtrigger()|.
 
 The 'wildmenu' option can be set to show the matches just above the command
 line.
@@ -1258,5 +1259,84 @@ The character used for the pattern indicates the type of command-line:
 	=	expression for "= |expr-register|
 	@	string for |input()|
 	`-`	text for |:insert| or |:append|
+
+==============================================================================
+8. Command-line autocompletion			 *cmdline-autocompletion*
+
+Autocompletion makes the command-line more efficient and easier to navigate by
+automatically showing a popup menu of suggestions as you type, whether
+searching (/ or ?) or entering commands (:).
+
+A basic setup is: >
+	autocmd CmdlineChanged [:/\?] call wildtrigger()
+	set wildmode=noselect:lastused,full
+	set wildoptions=pum
+
+With this configuration, suggestions appear immediately, and you can
+move through them with <Tab> or the arrow keys.
+
+To retain normal command-line history navigation with <Up>/<Down>: >
+	cnoremap <expr> <Up>   wildmenumode() ? "\<C-E>\<Up>"   : "\<Up>"
+	cnoremap <expr> <Down> wildmenumode() ? "\<C-E>\<Down>" : "\<Down>"
+
+Options can also be applied only for specific command-lines.  For
+example, to use a shorter popup menu height only during search: >
+	autocmd CmdlineEnter [/\?] set pumheight=8
+	autocmd CmdlineLeave [/\?] set pumheight&
+
+EXTRAS					*fuzzy-file-picker* *live-grep*
+
+Command-line autocompletion can also be extended for advanced uses.
+For example, you can turn the native |:find| command into a fuzzy, interactive
+file picker: >
+
+	set findfunc=Find
+	func Find(arg, _)
+	  if get(s:, 'filescache', []) == []
+	    let s:filescache = systemlist(
+		\ 'find . -path "*/.git" -prune -o -type f -print')
+	  endif
+	  return a:arg == '' ? s:filescache : matchfuzzy(s:filescache, a:arg)
+	endfunc
+	autocmd CmdlineEnter : let s:filescache = []
+
+The `:Grep` command searches for lines matching a pattern and updates the
+results dynamically as you type (triggered after two characters; note: needs
+the `CmdlineLeavePre` autocmd from the next section): >
+
+	command! -nargs=+ -complete=customlist,<SID>Grep
+		\ Grep call <SID>VisitFile()
+
+	func s:Grep(arglead, cmdline, cursorpos)
+	  let cmd = $'grep -REIHns "{a:arglead}" --exclude-dir=.git
+		\ --exclude=".*"'
+	  return len(a:arglead) > 1 ? systemlist(cmd) : []
+	endfunc
+
+	func s:VisitFile()
+	  let item = getqflist(#{lines: [s:selected]}).items[0]
+	  let pos  = '[0,\ item.lnum,\ item.col,\ 0]'
+	  exe $':b +call\ setpos(".",\ {pos}) {item.bufnr}'
+	  call setbufvar(item.bufnr, '&buflisted', 1)
+	endfunc
+
+Automatically select the first item in the completion list when leaving the
+command-line, and for `:Grep`, add the typed pattern to the command-line
+history: >
+
+	autocmd CmdlineLeavePre :
+	      \ if get(cmdcomplete_info(), 'matches', []) != [] |
+	      \   let s:info = cmdcomplete_info() |
+	      \   if getcmdline() =~ '^\s*fin\%[d]\s' && s:info.selected == -1 |
+	      \     call setcmdline($'find {s:info.matches[0]}') |
+	      \   endif |
+	      \   if getcmdline() =~ '^\s*Grep\s' |
+	      \     let s:selected = s:info.selected != -1
+	      \         ? s:info.matches[s:info.selected] : s:info.matches[0] |
+	      \     call setcmdline(s:info.cmdline_orig) |
+	      \   endif |
+	      \ endif
+
+For autocompletion in insert mode, see |ins-autocompletion|.
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -11903,7 +11903,6 @@ wildmenumode()                                                  *wildmenumode()*
 wildtrigger()                                                    *wildtrigger()*
 		Start wildcard expansion in the command-line, using the
 		behavior defined by the 'wildmode' and 'wildoptions' settings.
-		See |cmdline-completion|.
 
 		This function also enables completion in search patterns such
 		as |/|, |?|, |:s|, |:g|, |:v| and |:vimgrep|.
@@ -11911,22 +11910,15 @@ wildtrigger()                                                    *wildtrigger()*
 		Unlike pressing 'wildchar' manually, this function does not
 		produce a beep when no matches are found and generally
 		operates more quietly.  This makes it suitable for triggering
-		completion automatically, such as from an |:autocmd|.
-						*cmdline-autocompletion*
-		Example: To make the completion menu pop up automatically as
-		you type on the command line, use: >vim
-			autocmd CmdlineChanged [:/\?] call wildtrigger()
-			set wildmode=noselect:lastused,full wildoptions=pum
-<
-		To retain normal history navigation (up/down keys): >vim
-			cnoremap <Up>   <C-U><Up>
-			cnoremap <Down> <C-U><Down>
-<
-		To set an option specifically when performing a search, e.g.
-		to set 'pumheight': >vim
-			autocmd CmdlineEnter [/\?] set pumheight=8
-			autocmd CmdlineLeave [/\?] set pumheight&
-<
+		completion automatically.
+
+		Note: After navigating command-line history, the first call to
+		wildtrigger() is a no-op; a second call is needed to start
+		expansion.  This is to support history navigation in
+		command-line autocompletion.
+
+		See |cmdline-autocompletion|.
+
 		Return value is always 0.
 
                 Return: ~

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -10835,7 +10835,6 @@ function vim.fn.wildmenumode() end
 
 --- Start wildcard expansion in the command-line, using the
 --- behavior defined by the 'wildmode' and 'wildoptions' settings.
---- See |cmdline-completion|.
 ---
 --- This function also enables completion in search patterns such
 --- as |/|, |?|, |:s|, |:g|, |:v| and |:vimgrep|.
@@ -10843,22 +10842,15 @@ function vim.fn.wildmenumode() end
 --- Unlike pressing 'wildchar' manually, this function does not
 --- produce a beep when no matches are found and generally
 --- operates more quietly.  This makes it suitable for triggering
---- completion automatically, such as from an |:autocmd|.
----         *cmdline-autocompletion*
---- Example: To make the completion menu pop up automatically as
---- you type on the command line, use: >vim
----   autocmd CmdlineChanged [:/\?] call wildtrigger()
----   set wildmode=noselect:lastused,full wildoptions=pum
---- <
---- To retain normal history navigation (up/down keys): >vim
----   cnoremap <Up>   <C-U><Up>
----   cnoremap <Down> <C-U><Down>
---- <
---- To set an option specifically when performing a search, e.g.
---- to set 'pumheight': >vim
----   autocmd CmdlineEnter [/\?] set pumheight=8
----   autocmd CmdlineLeave [/\?] set pumheight&
---- <
+--- completion automatically.
+---
+--- Note: After navigating command-line history, the first call to
+--- wildtrigger() is a no-op; a second call is needed to start
+--- expansion.  This is to support history navigation in
+--- command-line autocompletion.
+---
+--- See |cmdline-autocompletion|.
+---
 --- Return value is always 0.
 ---
 --- @return number

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -13092,7 +13092,6 @@ M.funcs = {
     desc = [==[
       Start wildcard expansion in the command-line, using the
       behavior defined by the 'wildmode' and 'wildoptions' settings.
-      See |cmdline-completion|.
 
       This function also enables completion in search patterns such
       as |/|, |?|, |:s|, |:g|, |:v| and |:vimgrep|.
@@ -13100,22 +13099,15 @@ M.funcs = {
       Unlike pressing 'wildchar' manually, this function does not
       produce a beep when no matches are found and generally
       operates more quietly.  This makes it suitable for triggering
-      completion automatically, such as from an |:autocmd|.
-      				*cmdline-autocompletion*
-      Example: To make the completion menu pop up automatically as
-      you type on the command line, use: >vim
-      	autocmd CmdlineChanged [:/\?] call wildtrigger()
-      	set wildmode=noselect:lastused,full wildoptions=pum
-      <
-      To retain normal history navigation (up/down keys): >vim
-      	cnoremap <Up>   <C-U><Up>
-      	cnoremap <Down> <C-U><Down>
-      <
-      To set an option specifically when performing a search, e.g.
-      to set 'pumheight': >vim
-      	autocmd CmdlineEnter [/\?] set pumheight=8
-      	autocmd CmdlineLeave [/\?] set pumheight&
-      <
+      completion automatically.
+
+      Note: After navigating command-line history, the first call to
+      wildtrigger() is a no-op; a second call is needed to start
+      expansion.  This is to support history navigation in
+      command-line autocompletion.
+
+      See |cmdline-autocompletion|.
+
       Return value is always 0.
     ]==],
     name = 'wildtrigger',

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -4989,25 +4989,30 @@ endfunc
 " Skip wildmenu during history navigation via Up/Down keys
 func Test_skip_wildtrigger_hist_navigation()
   call Ntest_override("char_avail", 1)
-  cnoremap <F8> <C-R>=wildtrigger()[-1]<CR>
-  set wildmenu
-
-  call feedkeys(":ech\<F8>\<F4>\<C-B>\"\<CR>", "tx")
-  call assert_match('echo*', g:Sline)
-  call assert_equal('"echo', @:)
+  set wildmenu wildmode=noselect,full
+  augroup TestSkipWildtrigger | autocmd!
+    autocmd CmdlineChanged : call wildtrigger()
+  augroup END
+  cnoremap <expr> <Up>   wildmenumode() ? "\<C-E>\<Up>"   : "\<Up>"
+  cnoremap <expr> <Down> wildmenumode() ? "\<C-E>\<Down>" : "\<Down>"
 
   call feedkeys(":echom \"foo\"", "tx")
   call feedkeys(":echom \"foobar\"", "tx")
-  call feedkeys(":ech\<F8>\<C-E>\<UP>\<C-B>\"\<CR>", "tx")
+
+  call feedkeys(":ech\<Up>\<C-B>\"\<CR>", "tx")
   call assert_equal('"echom "foobar"', @:)
-  call feedkeys(":ech\<F8>\<C-E>\<UP>\<UP>\<UP>\<C-B>\"\<CR>", "tx")
+  call feedkeys(":ech\<Up>\<Up>\<C-B>\"\<CR>", "tx")
   call assert_equal('"echom "foo"', @:)
-  call feedkeys(":ech\<F8>\<C-E>\<UP>\<UP>\<UP>\<Down>\<C-B>\"\<CR>", "tx")
+  call feedkeys(":ech\<Up>\<Up>\<Down>\<C-B>\"\<CR>", "tx")
   call assert_equal('"echom "foobar"', @:)
+  call feedkeys(":ech\<Up>\<Up>\<Down>\<Down>\<C-B>\"\<CR>", "tx")
+  call assert_equal('"ech', @:)
 
   call Ntest_override("char_avail", 0)
-  set wildmenu&
-  cunmap <F8>
+  set wildmenu& wildmode& wildoptions&
+  augroup TestSkipWildtrigger | autocmd! | augroup END
+  cunmap <Up>
+  cunmap <Down>
 endfunc
 
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -4986,4 +4986,28 @@ func Test_CmdlineLeave_vchar_keys()
   unlet g:leave_key
 endfunc
 
+" Skip wildmenu during history navigation via Up/Down keys
+func Test_skip_wildtrigger_hist_navigation()
+  call Ntest_override("char_avail", 1)
+  cnoremap <F8> <C-R>=wildtrigger()[-1]<CR>
+  set wildmenu
+
+  call feedkeys(":ech\<F8>\<F4>\<C-B>\"\<CR>", "tx")
+  call assert_match('echo*', g:Sline)
+  call assert_equal('"echo', @:)
+
+  call feedkeys(":echom \"foo\"", "tx")
+  call feedkeys(":echom \"foobar\"", "tx")
+  call feedkeys(":ech\<F8>\<C-E>\<UP>\<C-B>\"\<CR>", "tx")
+  call assert_equal('"echom "foobar"', @:)
+  call feedkeys(":ech\<F8>\<C-E>\<UP>\<UP>\<UP>\<C-B>\"\<CR>", "tx")
+  call assert_equal('"echom "foo"', @:)
+  call feedkeys(":ech\<F8>\<C-E>\<UP>\<UP>\<UP>\<Down>\<C-B>\"\<CR>", "tx")
+  call assert_equal('"echom "foobar"', @:)
+
+  call Ntest_override("char_avail", 0)
+  set wildmenu&
+  cunmap <F8>
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1738: cmdline-autocompletion breaks history navigation

Problem:  cmdline-autocompletion breaks history navigation (ddad431)
Solution: Support history navigation in cmdline autocompletion (Girish
          Palya)

Up/Down arrows support history navigation when using wildtrigger()

closes: vim/vim#18219

https://github.com/vim/vim/commit/708ab7f5fbef95c43a3eb6c0a2ad4e02ad4c2f98

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1744: tests: Test_skip_wildtrigger_hist_navigation() may fail

Problem:  tests: Test_skip_wildtrigger_hist_navigation() may fail
          (zeertzjq).
Solution: Correct test to validate intended behavior (Girish Palya).

See https://github.com/vim/vim/pull/18219#issuecomment-3265183318

closes: vim/vim#18243

https://github.com/vim/vim/commit/3980c865250c9653ce63355f860ea1ccd5c6d0ee

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:d7d6a6f: runtime(doc): Improve doc for cmdline-autocompletion

- Address https://github.com/vim/vim/pull/18219#issuecomment-3264634710
- Make the cmdline-autocompletion help more user friendly

closes: vim/vim#18245

https://github.com/vim/vim/commit/d7d6a6f05a536b443188ff95a45bbd46485f11fb

Co-authored-by: Girish Palya <girishji@gmail.com>