### PR TITLE
vim-patch: Python syntax updates

### DIFF
--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -1,7 +1,7 @@
 " Vim syntax file
 " Language:	Python
 " Maintainer:	Zvezdan Petkovic <zpetkovic@acm.org>
-" Last Change:	2025 Sep 05
+" Last Change:	2025 Sep 08
 " Credits:	Neil Schemenauer <nas@python.ca>
 "		Dmitry Vasiliev
 "		Rob B
@@ -271,7 +271,7 @@ if !exists("python_no_number_highlight")
   syn match   pythonNumber
         \ "\<\d\%(_\=\d\)*\.\%([eE][+-]\=\d\%(_\=\d\)*\)\=[jJ]\=\%(\W\|$\)\@="
   syn match   pythonNumber
-        \ "\%(^\|\W\)\zs\%(\d\%(_\=\d\)*\)\=\.\d\%(_\=\d\)*\%([eE][+-]\=\d\%(_\=\d\)*\)\=[jJ]\=\>"
+        \ "\%(^\|\W\)\@1<=\%(\d\%(_\=\d\)*\)\=\.\d\%(_\=\d\)*\%([eE][+-]\=\d\%(_\=\d\)*\)\=[jJ]\=\>"
 endif
 
 " Group the built-ins in the order in the 'Python Library Reference' for

--- a/runtime/syntax/python.vim
+++ b/runtime/syntax/python.vim
@@ -313,6 +313,8 @@ if !exists("python_no_builtin_highlight")
   syn match   pythonAttribute	/\.\h\w*/hs=s+1
 	\ contains=ALLBUT,pythonBuiltin,pythonClass,pythonFunction,pythonType,pythonAsync
 	\ transparent
+  " the ellipsis literal `...` can be used in multiple syntactic contexts
+  syn match   pythonEllipsis	"\.\@1<!.\.\.\ze\.\@!" display
 endif
 
 " From the 'Python Library Reference' class hierarchy at the bottom.
@@ -368,10 +370,12 @@ if !exists("python_no_doctest_highlight")
   if !exists("python_no_doctest_code_highlight")
     syn region pythonDoctest
 	  \ start="^\s*>>>\s" end="^\s*$"
-	  \ contained contains=ALLBUT,pythonDoctest,pythonClass,pythonFunction,pythonType,@Spell
+	  \ contained contains=ALLBUT,pythonDoctest,pythonEllipsis,pythonClass,pythonFunction,pythonType,@Spell
     syn region pythonDoctestValue
 	  \ start=+^\s*\%(>>>\s\|\.\.\.\s\|"""\|'''\)\@!\S\++ end="$"
-	  \ contained
+	  \ contained contains=pythonEllipsis
+    syn match pythonEllipsis "\%(^\s*\)\@<!\.\@1<!\zs\.\.\.\ze\.\@!" display
+	  \ contained containedin=pythonDoctest
   else
     syn region pythonDoctest
 	  \ start="^\s*>>>" end="^\s*$"
@@ -414,6 +418,7 @@ if !exists("python_no_number_highlight")
 endif
 if !exists("python_no_builtin_highlight")
   hi def link pythonBuiltin		Function
+  hi def link pythonEllipsis		pythonBuiltin
 endif
 if !exists("python_no_exception_highlight")
   hi def link pythonExceptions		Structure


### PR DESCRIPTION
#### vim-patch:6bb16d2: runtime(python): Update syntax file, fix f-string float highlighting

Fix matching of floats at the beginning of an f-string replacement
field, immediately after the opening brace.

The existing pattern, using `\zs`, cannot consume the already matched
`{` so use a lookbehind instead.

See comment: https://github.com/vim/vim/pull/17962#issuecomment-3201550443

closes: vim/vim#18220

https://github.com/vim/vim/commit/6bb16d2cee87f834f003bf368ce70c5688242ac1

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:77cfc49: runtime(python): highlight ellipsis literals

The ellipsis literal (`...`) can be used in multiple contexts:

- Placeholders:     `class Foo: ...`
- Containers:       `Tuple[int, ...]`
- Assignments:      `x = ...`

This is a trickier pattern to match because we can't rely on keyword
boundaries, so we instead look for exactly three dots (`...`).

This does mean that we will match the `...` portion of `x...x`, which
isn't valid Python syntax, but I think that's an acceptable trade-off
that avoids making this pattern much more complex.

Reference:
- https://docs.python.org/3/library/constants.html#Ellipsis

closes: vim/vim#18107

https://github.com/vim/vim/commit/77cfc49060a50daefd1675b8a1dece0e6e943384

Co-authored-by: Jon Parise <jon@indelible.org>