### PR TITLE
vim-patch:80981e1: runtime(doc): mention 'findfunc' at :h :find

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -214,6 +214,7 @@ If you want to keep the changed buffer without saving it, switch on the
 							*:fin* *:find*
 :fin[d][!] [++opt] [+cmd] {file}
 			Find {file} in 'path' and then |:edit| it.
+			See also: 'findfunc'.
 
 :{count}fin[d][!] [++opt] [+cmd] {file}
 			Just like ":find", but use the {count} match in


### PR DESCRIPTION
#### vim-patch:80981e1: runtime(doc): mention 'findfunc' at :h :find

related: vim/vim#18253

https://github.com/vim/vim/commit/80981e1db93d2ebb4060fa1368fe76e336c1d65b

Co-authored-by: Girish Palya <girishji@gmail.com>