### PR TITLE
vim-patch:9.1.1747: completion: redo (.) broken with preinsert and autocompletion

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -240,9 +240,8 @@ static String compl_leader = STRING_INIT;
 
 static bool compl_get_longest = false;  ///< put longest common string in compl_leader
 
-/// This flag indicates that one of the items in the match list is currently
-/// selected.  False when no match is selected or the match was edited or using
-/// the longest common string.
+/// This flag is false when no match is selected (by ^N/^P) or the match was
+/// edited or using the longest common string.
 static bool compl_used_match;
 
 /// didn't finish finding completions.
@@ -5153,7 +5152,8 @@ int ins_compl_insert(bool move_cursor, bool preinsert_prefix)
       }
     }
   }
-  compl_used_match = !(match_at_original_text(compl_shown_match) || preinsert);
+  compl_used_match = !(match_at_original_text(compl_shown_match)
+                       || (preinsert && !compl_autocomplete));
 
   dict_T *dict = ins_compl_dict_alloc(compl_shown_match);
   set_vim_var_dict(VV_COMPLETED_ITEM, dict);

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -5747,6 +5747,13 @@ func Test_autocomplete_completeopt_preinsert()
   " Should not work with fuzzy
   set cot+=fuzzy
   call DoTest("f", 'f', 2)
+  set cot-=fuzzy
+
+  " Verify that redo (dot) works
+  call setline(1, ["foobar", "foozbar", "foobaz", "changed", "change"])
+  call feedkeys($"/foo\<CR>", 'tx')
+  call feedkeys($"cwch\<C-N>\<Esc>n.n.", 'tx')
+  call assert_equal(repeat(['changed'], 3), getline(1, 3))
 
   %delete _
   let &l:undolevels = &l:undolevels


### PR DESCRIPTION
#### vim-patch:9.1.1747: completion: redo (.) broken with preinsert and autocompletion

Problem:  completion: redo (.) broken with preinsert and autocompletion
Solution: Make redo (.) work with preinsert and autocompletion
          (Girish Palya)

closes: vim/vim#18253

https://github.com/vim/vim/commit/306a138172c83cebf573b2ef7f56bf94d84429cb

Co-authored-by: Girish Palya <girishji@gmail.com>