### PR TITLE
fix(runtime): add "Added", "Changed", "Removed" to "vim" colorscheme

### DIFF
--- a/runtime/colors/vim.lua
+++ b/runtime/colors/vim.lua
@@ -256,6 +256,9 @@ if vim.o.background == 'light' then
   hi('Type',             { fg = 'SeaGreen', bold = true,                ctermfg = 'DarkGreen' })
   hi('Underlined',       { fg = 'SlateBlue', underline = true,          ctermfg = 'DarkMagenta', cterm = { underline = true } })
   hi('Ignore',           {                                              ctermfg = 'White' })
+  hi('Added',            { fg = 'SeaGreen',                             ctermfg = 'DarkGreen' })
+  hi('Changed',          { fg = 'DodgerBlue',                           ctermfg = 'Blue' })
+  hi('Removed',          { fg = 'Red',                                  ctermfg = 'Red' })
 else
   -- Default colors only used with a dark background.
   hi('ColorColumn',      { bg = 'DarkRed',                               ctermbg = 'DarkRed' })
@@ -297,5 +300,8 @@ else
   hi('Type',             { fg = '#60ff60', bold = true,                  ctermfg = 'LightGreen' })
   hi('Underlined',       { fg = '#80a0ff', underline = true,             ctermfg = 'LightBlue', cterm = { underline = true } })
   hi('Ignore',           {                                               ctermfg = 'Black' })
+  hi('Added',            { fg = 'LimeGreen',                             ctermfg = 'Green' })
+  hi('Changed',          { fg = 'DodgerBlue',                            ctermfg = 'Blue' })
+  hi('Removed',          { fg = 'Red',                                   ctermfg = 'Red' })
 end
 --stylua: ignore end

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -860,13 +860,13 @@ describe('vim.pack', function()
           ),
           '                                                                                     |',
           'Pending updates:                                                                     |',
-          ('{104:< %s │ Commit from `main` to be removed}                                         |'):format(
+          ('{19:< %s │ Commit from `main` to be removed}                                         |'):format(
             hashes.fetch_head
           ),
-          ('{105:> %s │ Commit to be added 2}                                                     |'):format(
+          ('{104:> %s │ Commit to be added 2}                                                     |'):format(
             hashes.fetch_new
           ),
-          ('{105:> %s │ Commit to be added 1 (tag: dev-tag)}                                      |'):format(
+          ('{104:> %s │ Commit to be added 1 (tag: dev-tag)}                                      |'):format(
             hashes.fetch_new_prev
           ),
           '                                                                                     |',
@@ -891,8 +891,7 @@ describe('vim.pack', function()
           [101] = { foreground = Screen.colors.Orange },
           [102] = { foreground = Screen.colors.LightGray },
           [103] = { foreground = Screen.colors.LightBlue },
-          [104] = { foreground = Screen.colors.NvimDarkRed },
-          [105] = { foreground = Screen.colors.NvimDarkGreen },
+          [104] = { foreground = Screen.colors.SeaGreen },
         })
         -- NOTE: Non LuaJIT reports errors differently due to 'coxpcall'
         if is_jit() then


### PR DESCRIPTION
These were added to syncolor.vim in Vim patch 9.1.0016.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
