### PR TITLE
vim-patch:9.1.1751: potential buffer-overflow in find_pattern_in_path()

### DIFF
--- a/src/nvim/search.c
+++ b/src/nvim/search.c
@@ -3253,7 +3253,7 @@ search_line:
         }
         found = true;
         char *aux = p = startp;
-        if (compl_status_adding()) {
+        if (compl_status_adding() && (int)strlen(p) >= ins_compl_len()) {
           p += ins_compl_len();
           if (vim_iswordp(p)) {
             goto exit_matched;


### PR DESCRIPTION
#### vim-patch:9.1.1751: potential buffer-overflow in find_pattern_in_path()

Problem:  potential buffer-overflow in find_pattern_in_path()
Problem:  Verify ptr p has enough room before adding ins_compl_len()

closes: vim/vim#18249

https://github.com/vim/vim/commit/21ecb0d2e2888ded9da04c4f47758cec99063822

Co-authored-by: Christian Brabandt <cb@256bit.org>