### PR TITLE
fix(gen): prevent "make doc" failure due to temporary files

### DIFF
--- a/src/gen/gen_eval_files.lua
+++ b/src/gen/gen_eval_files.lua
@@ -178,7 +178,7 @@ local function get_api_meta()
   --- @type table<string,nvim.cdoc.parser.fun>
   local functions = {}
   for path, ty in vim.fs.dir(f) do
-    if ty == 'file' then
+    if ty == 'file' and (vim.endswith(path, '.c') or vim.endswith(path, '.h')) then
       local filename = vim.fs.joinpath(f, path)
       local _, funs = cdoc_parser.parse(filename)
       for _, fn in ipairs(funs) do


### PR DESCRIPTION
Notably, the existence of a swap file like `.buffer.c.swp` might cause mayhem. As a reasonable filter, only process *.c and *.h files using the c grammar.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
