### PR TITLE
vim-patch:9.1.{1750,1752},b2c8848

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1134,7 +1134,7 @@ autocompletion.  To use |i_CTRL-N| or |i_CTRL-X_CTRL-N| specifically, press
 |CTRL-E| first to dismiss the popup menu (see |complete_CTRL-E|).
 
 						*ins-autocompletion-example*
-Example setup~
+Example setup ~
 A typical configuration for automatic completion with a popup menu: >
 	set autocomplete
 	set complete=.^5,w^5,b^5,u^5

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1675,12 +1675,12 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    with "menu" or "menuone".  Overrides "preview".
 
 	   preinsert
-		    When autocompletion is not enabled, inserts the part of the
+		    When 'autocomplete' is not active, inserts the part of the
 		    first candidate word beyond the current completion leader,
-		    highlighted with |hl-PreInsert|.  The cursor does not
-		    move.  Requires "fuzzy" unset and "menuone" in 'completeopt'.
+		    highlighted with |hl-PreInsert|.  The cursor doesn't move.
+		    Requires "fuzzy" unset and "menuone" in 'completeopt'.
 
-		    When 'autocomplete' is enabled, inserts the longest common
+		    When 'autocomplete' is active, inserts the longest common
 		    prefix of matches (from all shown items or from the
 		    current buffer items).  This occurs only when no menu item
 		    is selected.  Press CTRL-Y to accept.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1677,13 +1677,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 	   preinsert
 		    When autocompletion is not enabled, inserts the part of the
 		    first candidate word beyond the current completion leader,
-		    highlighted with |hl-ComplMatchIns|.  The cursor does not
+		    highlighted with |hl-PreInsert|.  The cursor does not
 		    move.  Requires "fuzzy" unset and "menuone" in 'completeopt'.
 
 		    When 'autocomplete' is enabled, inserts the longest common
-		    prefix of matches (from all shown items or buffer-specific
-		    matches), highlighted with |hl-PreInsert|.  This occurs only
-		    when no menu item is selected.  Press CTRL-Y to accept.
+		    prefix of matches (from all shown items or from the
+		    current buffer items).  This occurs only when no menu item
+		    is selected.  Press CTRL-Y to accept.
 
 	   preview  Show extra information about the currently selected
 		    completion in the preview window.  Only works in

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5354,7 +5354,7 @@ PmenuMatchSel	Popup menu: Matched text in selected item. Combined with
 							*hl-ComplMatchIns*
 ComplMatchIns	Matched text of the currently inserted completion.
 							*hl-PreInsert*
-PreInsert	Text inserted during autocompletion when "preinsert".
+PreInsert	Text inserted when "preinsert" is in 'completeopt'.
 							*hl-ComplHint*
 ComplHint	Virtual text of the currently selected completion.
 							*hl-ComplHintMore*

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1220,13 +1220,13 @@ vim.go.cia = vim.go.completeitemalign
 ---    preinsert
 --- 	    When autocompletion is not enabled, inserts the part of the
 --- 	    first candidate word beyond the current completion leader,
---- 	    highlighted with `hl-ComplMatchIns`.  The cursor does not
+--- 	    highlighted with `hl-PreInsert`.  The cursor does not
 --- 	    move.  Requires "fuzzy" unset and "menuone" in 'completeopt'.
 ---
 --- 	    When 'autocomplete' is enabled, inserts the longest common
---- 	    prefix of matches (from all shown items or buffer-specific
---- 	    matches), highlighted with `hl-PreInsert`.  This occurs only
---- 	    when no menu item is selected.  Press CTRL-Y to accept.
+--- 	    prefix of matches (from all shown items or from the
+--- 	    current buffer items).  This occurs only when no menu item
+--- 	    is selected.  Press CTRL-Y to accept.
 ---
 ---    preview  Show extra information about the currently selected
 --- 	    completion in the preview window.  Only works in

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1218,12 +1218,12 @@ vim.go.cia = vim.go.completeitemalign
 --- 	    with "menu" or "menuone".  Overrides "preview".
 ---
 ---    preinsert
---- 	    When autocompletion is not enabled, inserts the part of the
+--- 	    When 'autocomplete' is not active, inserts the part of the
 --- 	    first candidate word beyond the current completion leader,
---- 	    highlighted with `hl-PreInsert`.  The cursor does not
---- 	    move.  Requires "fuzzy" unset and "menuone" in 'completeopt'.
+--- 	    highlighted with `hl-PreInsert`.  The cursor doesn't move.
+--- 	    Requires "fuzzy" unset and "menuone" in 'completeopt'.
 ---
---- 	    When 'autocomplete' is enabled, inserts the longest common
+--- 	    When 'autocomplete' is active, inserts the longest common
 --- 	    prefix of matches (from all shown items or from the
 --- 	    current buffer items).  This occurs only when no menu item
 --- 	    is selected.  Press CTRL-Y to accept.

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1095,10 +1095,14 @@ static void ins_compl_insert_bytes(char *p, int len)
 /// -1 means normal item.
 int ins_compl_col_range_attr(linenr_T lnum, int col)
 {
+  const bool has_preinsert = ins_compl_has_preinsert();
+
   int attr;
   if ((get_cot_flags() & kOptCotFlagFuzzy)
-      || (!compl_autocomplete
+      || (!has_preinsert
           && (attr = syn_name2attr("ComplMatchIns")) == 0)
+      || (!compl_autocomplete && has_preinsert
+          && (attr = syn_name2attr("PreInsert")) == 0)
       || (compl_autocomplete
           && (!compl_autocomplete_preinsert
               || (attr = syn_name2attr("PreInsert")) == 0))) {
@@ -2283,9 +2287,7 @@ static void ins_compl_new_leader(void)
     compl_enter_selects = false;
   } else if (ins_compl_has_preinsert() && compl_leader.size > 0) {
     if (compl_started && compl_autocomplete && !ins_compl_preinsert_effect()) {
-      if (ins_compl_insert(true, true) != OK) {
-        (void)ins_compl_insert(false, false);
-      } else {
+      if (ins_compl_insert(true, true) == OK) {
         compl_autocomplete_preinsert = true;
       }
     } else {

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1,4 +1,4 @@
--- vim: tw=80
+-- vim: tw=78
 
 --- @class vim.option_meta
 --- @field full_name string
@@ -1700,12 +1700,12 @@ local options = {
         	    with "menu" or "menuone".  Overrides "preview".
 
            preinsert
-        	    When autocompletion is not enabled, inserts the part of the
+        	    When 'autocomplete' is not active, inserts the part of the
         	    first candidate word beyond the current completion leader,
-        	    highlighted with |hl-PreInsert|.  The cursor does not
-        	    move.  Requires "fuzzy" unset and "menuone" in 'completeopt'.
+        	    highlighted with |hl-PreInsert|.  The cursor doesn't move.
+        	    Requires "fuzzy" unset and "menuone" in 'completeopt'.
 
-        	    When 'autocomplete' is enabled, inserts the longest common
+        	    When 'autocomplete' is active, inserts the longest common
         	    prefix of matches (from all shown items or from the
         	    current buffer items).  This occurs only when no menu item
         	    is selected.  Press CTRL-Y to accept.

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1702,13 +1702,13 @@ local options = {
            preinsert
         	    When autocompletion is not enabled, inserts the part of the
         	    first candidate word beyond the current completion leader,
-        	    highlighted with |hl-ComplMatchIns|.  The cursor does not
+        	    highlighted with |hl-PreInsert|.  The cursor does not
         	    move.  Requires "fuzzy" unset and "menuone" in 'completeopt'.
 
         	    When 'autocomplete' is enabled, inserts the longest common
-        	    prefix of matches (from all shown items or buffer-specific
-        	    matches), highlighted with |hl-PreInsert|.  This occurs only
-        	    when no menu item is selected.  Press CTRL-Y to accept.
+        	    prefix of matches (from all shown items or from the
+        	    current buffer items).  This occurs only when no menu item
+        	    is selected.  Press CTRL-Y to accept.
 
            preview  Show extra information about the currently selected
         	    completion in the preview window.  Only works in

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -26,6 +26,7 @@ describe('completion', function()
     screen:add_extra_attr_ids {
       [100] = { foreground = Screen.colors.Gray0, background = Screen.colors.Yellow },
       [101] = { background = Screen.colors.Gray0 },
+      [102] = { foreground = Screen.colors.SeaGreen },
     }
   end)
 
@@ -1501,7 +1502,7 @@ describe('completion', function()
       foo                                                         |
       foobar                                                      |
       foobarbaz                                                   |
-      f^oo                                                         |
+      f{102:^oo}                                                         |
       {12:foo            }{1:                                             }|
       {4:foobar         }{1:                                             }|
       {4:foobarbaz      }{1:                                             }|

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -5755,6 +5755,12 @@ func Test_autocomplete_completeopt_preinsert()
   call feedkeys($"cwch\<C-N>\<Esc>n.n.", 'tx')
   call assert_equal(repeat(['changed'], 3), getline(1, 3))
 
+  " Select a match and delete up to text equal to another match
+  %delete
+  call setline(1, ["foobar", "foo"])
+  call feedkeys("Go\<ESC>", 'tx')
+  call DoTest("f\<C-N>\<C-N>\<BS>\<BS>\<BS>\<BS>", 'foo', 3)
+
   %delete _
   let &l:undolevels = &l:undolevels
   normal! ifoo


### PR DESCRIPTION
#### vim-patch:9.1.1750: completion: preinserted text highlighed using ComplMatchIns

Problem:  completion: preinserted text highlighed using ComplMatchIns
Solution: Use highlighting group PreInsert and update the documentation
          (Girish Palya).

When "preinsert" is included in 'completeopt', only the PreInsert
highlight group should be applied, whether autocompletion is active or not.
Previously, ComplMatchIns was used when autocompletion was not enabled.

Related to https://github.com/vim/vim/pull/18213.

closes: vim/vim#18254

https://github.com/vim/vim/commit/2525c56e423b3ddce8de925f582b9c4d00079675

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1752: tests: need another test for v9.1.1750 behaviour

Problem:  tests: No test when deleting text after autocompletion with preinsert
          did complete an entry
Solution: Verify, that after deletion autocompletion does not reinsert
          the deleted text. Note: the actual issue was fixed with v9.1.1750.
          (Girish Palya)

Pre v9.1.1750 behaviour:
When autocomplete is enabled with *preinsert*, deleting text after selecting a
longer match could cause unintended reinsertion, e.g.:

- Matches available: "foo" and "foobar".
- User selects "foobar" with Ctrl-N
- User deletes characters back to "foo".
- Autocomplete then incorrectly re-inserts "bar", preventing deletion past "foo".

v9.1.1750 removes the unwanted reinsertion so text can be deleted correctly.

closes: vim/vim#18259

https://github.com/vim/vim/commit/fe0061c6093aac817ed6061b75868a97a116d9c0

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:b2c8848: runtime(doc): improve docs related to 'autocomplete'

Manual completion can still be used when 'autocomplete' is set, so
saying "active" is better than "enabled".

closes: vim/vim#18261

https://github.com/vim/vim/commit/b2c88480553de7a7dc247fe8e361c8365eb4edec
