### PR TITLE
vim-patch:5a9ef93: runtime(doc): Update autocmd examples for command line autocompletion

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1268,7 +1268,7 @@ automatically showing a popup menu of suggestions as you type, whether
 searching (/ or ?) or entering commands (:).
 
 A basic setup is: >
-	autocmd CmdlineChanged [:/\?] call wildtrigger()
+	autocmd CmdlineChanged [:\/\?] call wildtrigger()
 	set wildmode=noselect:lastused,full
 	set wildoptions=pum
 
@@ -1281,8 +1281,8 @@ To retain normal command-line history navigation with <Up>/<Down>: >
 
 Options can also be applied only for specific command-lines.  For
 example, to use a shorter popup menu height only during search: >
-	autocmd CmdlineEnter [/\?] set pumheight=8
-	autocmd CmdlineLeave [/\?] set pumheight&
+	autocmd CmdlineEnter [\/\?] set pumheight=8
+	autocmd CmdlineLeave [\/\?] set pumheight&
 
 EXTRAS					*fuzzy-file-picker* *live-grep*
 


### PR DESCRIPTION
#### vim-patch:5a9ef93: runtime(doc): Update autocmd examples for command line autocompletion

In Windows [/] should be escaped [\/]:

	autocmd CmdlineChanged [:\/\?] call wildtrigger()

This updated example works both in Linux and Windows.

closes: vim/vim#18262

https://github.com/vim/vim/commit/5a9ef93b2caeb0a7eb8838efbd992f6a9a72166c

Co-authored-by: Maxim Kim <habamax@gmail.com>