### PR TITLE
feat(runtime): added commentstring for ColdFusion

### DIFF
--- a/runtime/ftplugin/cf.lua
+++ b/runtime/ftplugin/cf.lua
@@ -1,0 +1,12 @@
+local bufnr = vim.api.nvim_get_current_buf()
+local filename = vim.api.nvim_buf_get_name(bufnr)
+
+if vim.endswith(filename, '.cfc') then
+  -- .cfc files use // comments
+  vim.bo.commentstring = '// %s'
+else
+  -- .cfm and .cf files use <!--- ---> comments
+  vim.bo.commentstring = '<!--- %s --->'
+end
+
+vim.b.undo_ftplugin = (vim.b.undo_ftplugin or '') .. '\n setl commentstring<'


### PR DESCRIPTION
# Problem:
`commentstring` was undefined in cf files.

# Solution:
Added `runtime/ftplugin/cf.lua` to properly set commentstring based on file extension:

- For .cfc files (CfScript): Use '// %s' (double-slash comments)
- For .cfm/.cf files (CfTag): Use '<!--- %s --->' (XML-style comments)

This approach handles both ColdFusion syntax variations while maintaining the single 'cf' filetype used by Neovim for all ColdFusion files.