### PR TITLE
vim-patch:a0f37db: runtime(doc): use a single pattern in :h 'incsearch' example

### DIFF
--- a/runtime/doc/autocmd.txt
+++ b/runtime/doc/autocmd.txt
@@ -1341,8 +1341,9 @@ The pattern is interpreted like mostly used in file names:
 	[^ch]   match any character but 'c' and 'h'
 
 Note that for all systems the '/' character is used for path separator (even
-Windows). This was done because the backslash is difficult to use in a pattern
-and to make the autocommands portable across different systems.
+for MS-Windows).  This was done because the backslash is difficult to use in a
+pattern and to make the autocommands portable across different systems.  To
+only match a '/' on all platforms (e.g. in a non-file pattern), use "\/".
 
 It is possible to use |pattern| items, but they may not work as expected,
 because of the translation done for the above.

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -3668,8 +3668,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 	autocmd.  Example: >vim
 		augroup vimrc-incsearch-highlight
 		  autocmd!
-		  autocmd CmdlineEnter /,\? :set hlsearch
-		  autocmd CmdlineLeave /,\? :set nohlsearch
+		  autocmd CmdlineEnter [\/\?] :set hlsearch
+		  autocmd CmdlineLeave [\/\?] :set nohlsearch
 		augroup END
 <
 	CTRL-L can be used to add one character from after the current match

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -3564,8 +3564,8 @@ vim.bo.inex = vim.bo.includeexpr
 --- ```vim
 --- 	augroup vimrc-incsearch-highlight
 --- 	  autocmd!
---- 	  autocmd CmdlineEnter /,\? :set hlsearch
---- 	  autocmd CmdlineLeave /,\? :set nohlsearch
+--- 	  autocmd CmdlineEnter [\/\?] :set hlsearch
+--- 	  autocmd CmdlineLeave [\/\?] :set nohlsearch
 --- 	augroup END
 --- ```
 ---

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -4700,8 +4700,8 @@ local options = {
         autocmd.  Example: >vim
         	augroup vimrc-incsearch-highlight
         	  autocmd!
-        	  autocmd CmdlineEnter /,\? :set hlsearch
-        	  autocmd CmdlineLeave /,\? :set nohlsearch
+        	  autocmd CmdlineEnter [\/\?] :set hlsearch
+        	  autocmd CmdlineLeave [\/\?] :set nohlsearch
         	augroup END
         <
         CTRL-L can be used to add one character from after the current match


### PR DESCRIPTION
#### vim-patch:a0f37db: runtime(doc): use a single pattern in :h 'incsearch' example

related: https://github.com/vim/vim/pull/18262#issuecomment-3277008408
closes: vim/vim#18270

https://github.com/vim/vim/commit/a0f37dbbf413537815656fb0752a8eb926acb05c
