### PR TITLE
vim-patch:partial:9.0.0323,9.1.1754

### DIFF
--- a/src/nvim/help.c
+++ b/src/nvim/help.c
@@ -939,10 +939,15 @@ static void helptags_one(char *dir, const char *ext, const char *tagfname, bool 
         }
         p1 = p2;
       }
-      size_t len = strlen(IObuff);
-      if ((len == 2 && strcmp(&IObuff[len - 2], ">\n") == 0)
-          || (len >= 3 && strcmp(&IObuff[len - 3], " >\n") == 0)) {
-        in_example = true;
+      size_t off = strlen(IObuff);
+      if (off >= 2 && IObuff[off - 1] == '\n') {
+        off -= 2;
+        while (off > 0 && (ASCII_ISLOWER(IObuff[off]) || ascii_isdigit(IObuff[off]))) {
+          off--;
+        }
+        if (IObuff[off] == '>' && (off == 0 || IObuff[off - 1] == ' ')) {
+          in_example = true;
+        }
       }
       line_breakcheck();
     }

--- a/test/old/testdir/test_help.vim
+++ b/test/old/testdir/test_help.vim
@@ -157,11 +157,17 @@ func Test_helptag_cmd()
   call delete('Xtagdir/tags')
 
   " Test parsing tags
-  call writefile(['*tag1*', 'Example: >', '  *notag*', 'Example end: *tag2*'],
+  call writefile(['*tag1*', 'Example: >', '  *notag1*', 'Example end: *tag2*',
+                \ '>', '  *notag2*', '<',
+                \ '*tag3*', 'Code: >vim', '  *notag3*', 'Code end: *tag4*',
+                \ '>i3config', '  *notag4*', '<'],
     \ 'Xtagdir/a/doc/sample.txt')
   helptags Xtagdir
   call assert_equal(["tag1\ta/doc/sample.txt\t/*tag1*",
-                  \  "tag2\ta/doc/sample.txt\t/*tag2*"], readfile('Xtagdir/tags'))
+                   \ "tag2\ta/doc/sample.txt\t/*tag2*",
+                   \ "tag3\ta/doc/sample.txt\t/*tag3*",
+                   \ "tag4\ta/doc/sample.txt\t/*tag4*"],
+    \ readfile('Xtagdir/tags'))
 
   " Duplicate tags in the help file
   call writefile(['*tag1*', '*tag1*', '*tag2*'], 'Xtagdir/a/doc/sample.txt')

--- a/test/old/testdir/test_help.vim
+++ b/test/old/testdir/test_help.vim
@@ -144,30 +144,30 @@ endfunc
 " Test for the :helptags command
 " NOTE: if you run tests as root this will fail.  Don't run tests as root!
 func Test_helptag_cmd()
-  call mkdir('Xdir/a/doc', 'p')
+  call mkdir('Xtagdir/a/doc', 'p')
 
   " No help file to process in the directory
-  call assert_fails('helptags Xdir', 'E151:')
+  call assert_fails('helptags Xtagdir', 'E151:')
 
-  call writefile([], 'Xdir/a/doc/sample.txt')
+  call writefile([], 'Xtagdir/a/doc/sample.txt')
 
   " Test for ++t argument
-  helptags ++t Xdir
-  call assert_equal(["help-tags\ttags\t1"], readfile('Xdir/tags'))
-  call delete('Xdir/tags')
+  helptags ++t Xtagdir
+  call assert_equal(["help-tags\ttags\t1"], readfile('Xtagdir/tags'))
+  call delete('Xtagdir/tags')
 
   " Test parsing tags
   call writefile(['*tag1*', 'Example: >', '  *notag*', 'Example end: *tag2*'],
-    \ 'Xdir/a/doc/sample.txt')
-  helptags Xdir
+    \ 'Xtagdir/a/doc/sample.txt')
+  helptags Xtagdir
   call assert_equal(["tag1\ta/doc/sample.txt\t/*tag1*",
-                  \  "tag2\ta/doc/sample.txt\t/*tag2*"], readfile('Xdir/tags'))
+                  \  "tag2\ta/doc/sample.txt\t/*tag2*"], readfile('Xtagdir/tags'))
 
   " Duplicate tags in the help file
-  call writefile(['*tag1*', '*tag1*', '*tag2*'], 'Xdir/a/doc/sample.txt')
-  call assert_fails('helptags Xdir', 'E154:')
+  call writefile(['*tag1*', '*tag1*', '*tag2*'], 'Xtagdir/a/doc/sample.txt')
+  call assert_fails('helptags Xtagdir', 'E154:')
 
-  call delete('Xdir', 'rf')
+  call delete('Xtagdir', 'rf')
 endfunc
 
 func Test_helptag_cmd_readonly()
@@ -175,25 +175,25 @@ func Test_helptag_cmd_readonly()
   CheckNotRoot
 
   " Read-only tags file
-  call mkdir('Xdir/doc', 'p')
-  call writefile([''], 'Xdir/doc/tags')
-  call writefile([], 'Xdir/doc/sample.txt')
-  call setfperm('Xdir/doc/tags', 'r-xr--r--')
-  call assert_fails('helptags Xdir/doc', 'E152:', getfperm('Xdir/doc/tags'))
+  call mkdir('Xrodir/doc', 'p')
+  call writefile([''], 'Xrodir/doc/tags')
+  call writefile([], 'Xrodir/doc/sample.txt')
+  call setfperm('Xrodir/doc/tags', 'r-xr--r--')
+  call assert_fails('helptags Xrodir/doc', 'E152:', getfperm('Xrodir/doc/tags'))
 
   let rtp = &rtp
-  let &rtp = 'Xdir'
+  let &rtp = 'Xrodir'
   helptags ALL
   let &rtp = rtp
 
-  call delete('Xdir/doc/tags')
+  call delete('Xrodir/doc/tags')
 
   " No permission to read the help file
-  call mkdir('Xdir/b/doc', 'p')
-  call writefile([], 'Xdir/b/doc/sample.txt')
-  call setfperm('Xdir/b/doc/sample.txt', '-w-------')
-  call assert_fails('helptags Xdir', 'E153:', getfperm('Xdir/b/doc/sample.txt'))
-  call delete('Xdir', 'rf')
+  call mkdir('Xrodir/b/doc', 'p')
+  call writefile([], 'Xrodir/b/doc/sample.txt')
+  call setfperm('Xrodir/b/doc/sample.txt', '-w-------')
+  call assert_fails('helptags Xrodir', 'E153:', getfperm('Xrodir/b/doc/sample.txt'))
+  call delete('Xrodir', 'rf')
 endfunc
 
 " Test for setting the 'helpheight' option in the help window


### PR DESCRIPTION
#### vim-patch:partial:9.0.0323: using common name in tests leads to flaky tests

Problem:    Using common name in tests leads to flaky tests.
Solution:   Rename files and directories to be more specific.

https://github.com/vim/vim/commit/3b0d70f4ff436cb144683dafd956e8a3ee485a90

This includes only test_help.vim changes.

Co-authored-by: Bram Moolenaar <Bram@vim.org>


#### vim-patch:9.1.1754: :helptags doesn't skip examples with syntax

Problem:  :helptags doesn't skip examples with syntax
          (Evgeni Chasnovski)
Solution: Check for examples with syntax (zeertzjq).

closes: vim/vim#18277

https://github.com/vim/vim/commit/6f020cde569073622cc085251e47d82323d5c4bd