### PR TITLE
vim-patch:e8bbdb9: runtime(doc): Add :defe[r] shortname spec and tag

### DIFF
--- a/runtime/doc/userfunc.txt
+++ b/runtime/doc/userfunc.txt
@@ -360,8 +360,8 @@ is used as a method: >
 ==============================================================================
 
 3. Cleaning up in a function ~
-							*:defer*
-:defer {func}({args})	Call {func} when the current function is done.
+							*:defe* *:defer*
+:defe[r] {func}({args})	Call {func} when the current function is done.
 			{args} are evaluated here.
 
 Quite often a command in a function has a global effect, which must be undone


### PR DESCRIPTION
#### vim-patch:e8bbdb9: runtime(doc): Add :defe[r] shortname spec and tag

closes: vim/vim#18281

https://github.com/vim/vim/commit/e8bbdb90e449959dba9f3b270a78321e2cf1fae8

Co-authored-by: Doug Kearns <dougkearns@gmail.com>