### PR TITLE
test: unreliable cursor_spec.lua

### DIFF
--- a/test/functional/terminal/cursor_spec.lua
+++ b/test/functional/terminal/cursor_spec.lua
@@ -122,7 +122,7 @@ describe(':terminal cursor', function()
       screen:expect_unchanged()
     end)
 
-    it('becomes visible when exiting Terminal mode', function()
+    local function test_becomes_visible_when_exiting_Terminal_mode()
       skip(is_os('win'), '#31587')
       hide_cursor()
       screen:expect([[
@@ -179,6 +179,16 @@ describe(':terminal cursor', function()
         {120:[Scratch] [-]                                     }|
         {5:-- TERMINAL --}                                    |
       ]])
+    end
+
+    it('becomes visible when exiting Terminal mode', function()
+      retry(2, nil, function(i)
+        if i > 1 then
+          clear()
+          screen = tt.setup_screen()
+        end
+        test_becomes_visible_when_exiting_Terminal_mode()
+      end)
     end)
 
     it('becomes visible on TermLeave if hidden immediately by events #32456', function()

--- a/test/testutil.lua
+++ b/test/testutil.lua
@@ -66,11 +66,11 @@ function M.argss_to_cmd(...)
   return cmd
 end
 
---- Calls fn() until it succeeds, up to `max` times or until `max_ms`
---- milliseconds have passed.
+--- Calls fn() until it succeeds, up to `max` times or until `max_ms` milliseconds have passed.
+---
 --- @param max integer?
 --- @param max_ms integer?
---- @param fn function
+--- @param fn fun(try: number)
 --- @return any
 function M.retry(max, max_ms, fn)
   luaassert(max == nil or max > 0)
@@ -80,7 +80,7 @@ function M.retry(max, max_ms, fn)
   local start_time = uv.now()
   while true do
     --- @type boolean, any
-    local status, result = pcall(fn)
+    local status, result = pcall(fn, tries)
     if status then
       return result
     end


### PR DESCRIPTION
## Problem:
Flaky test ([example](https://github.com/neovim/neovim/actions/runs/17703645303/job/50312369335?pr=35749)):

    FAILED   test/functional/terminal/cursor_spec.lua @ 125: :terminal cursor when invisible becomes visible when exiting Terminal mode
    test/functional/terminal/cursor_spec.lua:163: Row 6 did not match.
    Expected:
      |^                                                  |
      |{100:~                                                 }|
      |{3:floob                                             }|
      |                                                  |
      |                                                  |
      |*{119:[Scratch] [-]                                     }|
      |*                                                  |
    Actual:
      |^                                                  |
      |{100:~                                                 }|
      |{3:floob                                             }|
      |                                                  |
      |                                                  |
      |*{2:[Scratch]                                         }|
      |*{5:-- INSERT --}                                      |

## Solution:

Retry the test.