### PR TITLE
vim-patch:97e0f95: runtime(doc): tweak documentation style a bit more in options.txt

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -971,7 +971,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	  ensure file name uniqueness in the backup directory.
 	  On Win32, it is also possible to end with "\\".  However, When a
 	  separating comma is following, you must use "//", since "\\" will
-	  include the comma in the file name. Therefore it is recommended to
+	  include the comma in the file name.  Therefore it is recommended to
 	  use '//', instead of '\\'.
 	- Environment variables are expanded |:set_env|.
 	- Careful with '\' characters, type one before a space, type two to
@@ -4721,7 +4721,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	fit the highest line number in the buffer respectively the number of
 	rows in the window, depending on whether 'number' or 'relativenumber'
 	is set.  Thus with the Vim default of 4 there is room for a line
-	number up to 999. When the buffer has 1000 lines five columns will be
+	number up to 999.  When the buffer has 1000 lines five columns will be
 	used. The minimum value is 1, the maximum value is 20.
 
 						*'omnifunc'* *'ofu'*

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -381,7 +381,7 @@ vim.go.bkc = vim.go.backupcopy
 ---   ensure file name uniqueness in the backup directory.
 ---   On Win32, it is also possible to end with "\\".  However, When a
 ---   separating comma is following, you must use "//", since "\\" will
----   include the comma in the file name. Therefore it is recommended to
+---   include the comma in the file name.  Therefore it is recommended to
 ---   use '//', instead of '\\'.
 --- - Environment variables are expanded `:set_env`.
 --- - Careful with '\' characters, type one before a space, type two to
@@ -4866,7 +4866,7 @@ vim.wo.nu = vim.wo.number
 --- fit the highest line number in the buffer respectively the number of
 --- rows in the window, depending on whether 'number' or 'relativenumber'
 --- is set.  Thus with the Vim default of 4 there is room for a line
---- number up to 999. When the buffer has 1000 lines five columns will be
+--- number up to 999.  When the buffer has 1000 lines five columns will be
 --- used. The minimum value is 1, the maximum value is 20.
 ---
 --- @type integer

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -549,7 +549,7 @@ local options = {
           ensure file name uniqueness in the backup directory.
           On Win32, it is also possible to end with "\\".  However, When a
           separating comma is following, you must use "//", since "\\" will
-          include the comma in the file name. Therefore it is recommended to
+          include the comma in the file name.  Therefore it is recommended to
           use '//', instead of '\\'.
         - Environment variables are expanded |:set_env|.
         - Careful with '\' characters, type one before a space, type two to
@@ -6376,7 +6376,7 @@ local options = {
         fit the highest line number in the buffer respectively the number of
         rows in the window, depending on whether 'number' or 'relativenumber'
         is set.  Thus with the Vim default of 4 there is room for a line
-        number up to 999. When the buffer has 1000 lines five columns will be
+        number up to 999.  When the buffer has 1000 lines five columns will be
         used. The minimum value is 1, the maximum value is 20.
       ]=],
       full_name = 'numberwidth',


### PR DESCRIPTION
#### vim-patch:97e0f95: runtime(doc): tweak documentation style a bit more in options.txt

related: vim/vim#18284

https://github.com/vim/vim/commit/97e0f955dadc58e878d9933ca6a5d97374573199