### PR TITLE
feat(api): add experimental nvim__exec_lua_fast function

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -1674,6 +1674,30 @@ nvim__complete_set({index}, {opts})                     *nvim__complete_set()*
         • winid: (number) floating window id
         • bufnr: (number) buffer id in floating window
 
+nvim__exec_lua_fast({code}, {args})                    *nvim__exec_lua_fast()*
+    WARNING: This feature is experimental/unstable.
+
+    EXPERIMENTAL: this API may change or be removed in the future.
+
+    Like |nvim_exec_lua()|, but can be called during |api-fast| contexts.
+
+    Execute Lua code. Parameters (if any) are available as `...` inside the
+    chunk. The chunk can return a value.
+
+    Only statements are executed. To evaluate an expression, prefix it with
+    `return`: return my_function(...)
+
+    Attributes: ~
+        |api-fast|
+        |RPC| only
+
+    Parameters: ~
+      • {code}  (`string`) Lua code to execute
+      • {args}  (`any[]`) Arguments to the code
+
+    Return: ~
+        (`any`) Return value of Lua code if present or NIL.
+
 nvim__get_runtime({pat}, {all}, {opts})                  *nvim__get_runtime()*
     Find files in runtime directories
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -156,6 +156,8 @@ API
 • |nvim_echo()| can create |Progress| messages
 • |nvim_open_win()| floating windows can show a 'statusline'. Plugins can use
   `style='minimal'` or `:setlocal statusline=` to hide the statusline.
+• Added experimental |nvim__exec_lua_fast()| to allow remote API clients to
+  execute code while nvim is blocking for input.
 
 BUILD
 

--- a/src/nvim/api/vim.c
+++ b/src/nvim/api/vim.c
@@ -517,6 +517,30 @@ Object nvim_exec_lua(String code, Array args, Arena *arena, Error *err)
   return nlua_exec(code, NULL, args, kRetObject, arena, err);
 }
 
+/// EXPERIMENTAL: this API may change or be removed in the future.
+///
+/// Like |nvim_exec_lua()|, but can be called during |api-fast| contexts.
+///
+/// Execute Lua code. Parameters (if any) are available as `...` inside the
+/// chunk. The chunk can return a value.
+///
+/// Only statements are executed. To evaluate an expression, prefix it
+/// with `return`: return my_function(...)
+///
+/// @param code       Lua code to execute
+/// @param args       Arguments to the code
+/// @param[out] err   Details of an error encountered while parsing
+///                   or executing the Lua code.
+///
+/// @return           Return value of Lua code if present or NIL.
+Object nvim__exec_lua_fast(String code, Array args, Arena *arena, Error *err)
+  FUNC_API_SINCE(14)
+  FUNC_API_REMOTE_ONLY
+  FUNC_API_FAST
+{
+  return nvim_exec_lua(code, args, arena, err);
+}
+
 /// Calculates the number of display cells occupied by `text`.
 /// Control characters including [<Tab>] count as one cell.
 ///


### PR DESCRIPTION
**Problem:**
Remote UIs can't execute lua code when a blocking prompt is waiting for input. This is needed when implementing IME pre-edit for example.

**Solution:**
Add an `nvim__exec_lua_fast` experimental API function, which is allowed to run instead of being queued until after the message has been shown.

I'm not sure how this properly can be tested through unit tests, but it has been tested through Neovide here https://github.com/neovide/neovide/pull/3221. 

Note that a new function was added, rather than modifying the existing `nvim__exec_lua` function, since that would be a breaking change. Some code might break if the function is suddenly allowed to run in a fast context, when it has been queued before.

Fixes https://github.com/neovim/neovim/issues/35739

The API is currently experimental as discussed here https://github.com/neovim/neovim/issues/35739#issuecomment-3316236363 and might be replaced by something better in the future.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
