### PR TITLE
fix(lsp): run `document_color.enable()` only if client supports it

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -784,7 +784,9 @@ function lsp._set_defaults(client, bufnr)
   if client:supports_method(ms.textDocument_diagnostic) then
     lsp.diagnostic._enable(bufnr)
   end
-  lsp.document_color.enable(true, bufnr)
+  if client:supports_method(ms.textDocument_documentColor) then
+    lsp.document_color.enable(true, bufnr)
+  end
 end
 
 --- @deprecated

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -149,15 +149,6 @@ RSC[ms.client_registerCapability] = function(_, params, ctx)
   for bufnr in pairs(client.attached_buffers) do
     vim.lsp._set_defaults(client, bufnr)
   end
-  for _, reg in ipairs(params.registrations) do
-    if reg.method == ms.textDocument_documentColor then
-      for bufnr in pairs(client.attached_buffers) do
-        if vim.lsp.document_color.is_enabled(bufnr) then
-          vim.lsp.document_color._buf_refresh(bufnr, client.id)
-        end
-      end
-    end
-  end
   return vim.NIL
 end
 


### PR DESCRIPTION
Fixes #35756

Also removes redundant `_buf_refresh()` calls, which are already invoked by `document_color.enable()`.