### PR TITLE
vim-patch:9.1.1758: Diff mode crashes when adding text property in autocommand

### DIFF
--- a/src/nvim/diff.c
+++ b/src/nvim/diff.c
@@ -874,7 +874,7 @@ static int diff_write(buf_T *buf, diffin_T *din, linenr_T start, linenr_T end)
   cmdmod.cmod_flags = save_cmod_flags;
   free_string_option(buf->b_p_ff);
   buf->b_p_ff = save_ff;
-  buf->b_ml.ml_flags = save_ml_flags;
+  buf->b_ml.ml_flags = (buf->b_ml.ml_flags & ~ML_EMPTY) | (save_ml_flags & ML_EMPTY);
   return r;
 }
 

--- a/test/old/testdir/test_diffmode.vim
+++ b/test/old/testdir/test_diffmode.vim
@@ -3286,4 +3286,29 @@ func Test_diffget_diffput_diffanchors()
   set diffanchors&
 endfunc
 
+func Test_diff_add_prop_in_autocmd()
+  CheckScreendump
+
+  let lines =<< trim END
+    func MyDiff() abort
+      let f1 = readfile(v:fname_in)
+      let f2 = readfile(v:fname_new)
+      let f0 = diff(f1, f2)
+      call writefile(split(f0, "\n"), v:fname_out)
+    endfunc
+
+    call prop_type_add('myprop', #{highlight: 'Search', override: 1})
+    autocmd OptionSet diff call prop_add(1, 1, #{type: 'myprop', length: 100})
+    set diffexpr=MyDiff()
+  END
+  call writefile(lines, 'Xtest_diff_add_prop_in_autocmd', 'D')
+  call writefile(['foo', 'bar', 'baz'], 'Xdiffsplit_file', 'D')
+
+  let buf = RunVimInTerminal('-S Xtest_diff_add_prop_in_autocmd', {})
+  call term_sendkeys(buf, ":diffsplit Xdiffsplit_file\<CR>")
+  call VerifyScreenDump(buf, 'Test_diff_add_prop_in_autocmd_01', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab


### PR DESCRIPTION
#### vim-patch:9.1.1758: Diff mode crashes when adding text property in autocommand

Problem:  Diff mode crashes when adding text property in autocommand
          (after 9.1.1557).
Solution: Only restore ML_EMPTY memline flag, ignore the others
          (zeertzjq).

closes: vim/vim#18291

https://github.com/vim/vim/commit/46e22fd2f73b03795a5922ba07621472713eddb3