### PR TITLE
vim-patch:81ca991: runtime(html): guard against an existing b:undo_ftplugin var

### DIFF
--- a/runtime/ftplugin/html.vim
+++ b/runtime/ftplugin/html.vim
@@ -2,9 +2,7 @@
 " Language:		HTML
 " Maintainer:		Doug Kearns <dougkearns@gmail.com>
 " Previous Maintainer:	Dan Sharp
-" Last Change:		2024 Jan 14
-" 2024 May 24 update 'commentstring' option
-" 2025 May 10 add expression folding #17141
+" Last Change:		2025 Sep 12
 
 if exists("b:did_ftplugin")
   finish
@@ -18,7 +16,12 @@ setlocal matchpairs+=<:>
 setlocal commentstring=<!--\ %s\ -->
 setlocal comments=s:<!--,m:\ \ \ \ ,e:-->
 
-let b:undo_ftplugin = "setlocal comments< commentstring< matchpairs<"
+if exists('b:undo_ftplugin')
+  " no whitespace before |, handle possible :unmap at end of current value
+  let b:undo_ftplugin ..= "| setlocal comments< commentstring< matchpairs<"
+else
+  let b:undo_ftplugin = "setlocal comments< commentstring< matchpairs<"
+endif
 
 if get(g:, "ft_html_autocomment", 0)
   setlocal formatoptions-=t formatoptions+=croql


### PR DESCRIPTION
#### vim-patch:81ca991: runtime(html): guard against an existing b:undo_ftplugin var

Filetype plugins should not assume they are the only file to execute on
behalf of a buffer's filetype: other filetypes may use them, and
dotted filetypes may cause multiple to run. When this occurs, they
should _build_ on their respective b:undo_ftplugin settings, not
overwrite each other.

For example, when using a dotted filetype wiki.markdown, the wiki
filetype plugins go first. Then, during the markdown filetype plugins,
the HTML plugin's unconditional assignment to b:undo_ftplugin trashes
any data previously stored there by the wiki filetype.

Follow the pattern elsewhere of assigning or appending conditionally.

closes: vim/vim#18267

https://github.com/vim/vim/commit/81ca9916d2fb2675a1a6da22fd68d26fb0ee8b8e

Co-authored-by: D. Ben Knoble <ben.knoble+github@gmail.com>