### PR TITLE
build: allow comments in deps.txt

### DIFF
--- a/cmake.deps/deps.txt
+++ b/cmake.deps/deps.txt
@@ -54,5 +54,6 @@ WASMTIME_SHA256 b94b6c6fd6aebaf05d4c69c1b12b5dc217b0d42c1a95f435b33af63dddfa5304
 
 UNCRUSTIFY_URL https://github.com/uncrustify/uncrustify/archive/uncrustify-0.81.0.tar.gz
 UNCRUSTIFY_SHA256 484623dc16b92206adc6ac0770077c6c67c6e441102148c2a121a19549330ff9
+# This is where we get busted, luassert, ...
 LUA_DEV_DEPS_URL https://github.com/neovim/deps/raw/06ef2b58b0876f8de1a3f5a710473dcd7afff251/opt/lua-dev-deps.tar.gz
 LUA_DEV_DEPS_SHA256 49f8399e453103064a23c65534f266f3067cda716b6502f016bfafeed5799354

--- a/cmake/Deps.cmake
+++ b/cmake/Deps.cmake
@@ -68,9 +68,13 @@ set_directory_properties(PROPERTIES
 
 file(READ ${depsfile} DEPENDENCIES)
 STRING(REGEX REPLACE "\n" ";" DEPENDENCIES "${DEPENDENCIES}")
+# Process deps.txt:
 foreach(dep ${DEPENDENCIES})
   STRING(REGEX REPLACE " " ";" dep "${dep}")
   list(GET dep 0 name)
+  if(${name} MATCHES "^#") # Skip comment lines.
+    continue()
+  endif()
   list(GET dep 1 value)
   if(NOT ${name})
     # _URL variables must NOT be set when USE_EXISTING_SRC_DIR is set,


### PR DESCRIPTION
## Problem

It was not obvious where our source for "busted" is.

## Solution

Add a comment to `deps.txt`.