### PR TITLE
fix(lsp): avoid automatic request after leaving insert mode

### DIFF
--- a/runtime/lua/vim/lsp/inline_completion.lua
+++ b/runtime/lua/vim/lsp/inline_completion.lua
@@ -309,6 +309,7 @@ function Completor:abort()
     method = ms.textDocument_inlineCompletion,
     type = 'pending',
   })
+  self:reset_timer()
   self:hide()
   self.current = nil
 end

--- a/test/functional/plugin/lsp/inline_completion_spec.lua
+++ b/test/functional/plugin/lsp/inline_completion_spec.lua
@@ -172,6 +172,18 @@ describe('vim.lsp.inline_completion', function()
       feed('<Esc>')
       screen:expect({ grid = grid_without_candidates })
     end)
+
+    it('no request when leaving insert mode immediately after typing', function()
+      screen:expect({ grid = grid_without_candidates })
+      feed('ifoobar<Esc>')
+      screen:expect([[
+        function fibonacci()                                 |
+        fooba^r                                               |
+        {1:~                                                    }|*11
+                                                             |
+      ]])
+      screen:expect_unchanged(false, 500)
+    end)
   end)
 
   describe('get()', function()


### PR DESCRIPTION
This also fixes the following warning in tests with ASAN or TSAN:

    -------- Running tests from test/functional/plugin/lsp/inline_completion_spec.lua
    RUN      T4604 vim.lsp.inline_completion enable() requests or abort when entered/left insert mode: 225.00 ms OK
    RUN      T4605 vim.lsp.inline_completion get() applies the current candidate: 212.00 ms OK
    nvim took 2013 milliseconds to exit after last test
    This indicates a likely problem with the test even if it passed!

    RUN      T4606 vim.lsp.inline_completion get() accepts on_accept callback: 212.00 ms OK
    RUN      T4607 vim.lsp.inline_completion select() selects the next candidate: 220.00 ms OK
    -------- 4 tests from test/functional/plugin/lsp/inline_completion_spec.lua (3437.00 ms total)

    -------- Running tests from test/functional/plugin/lsp/linked_editing_range_spec.lua
    nvim took 2011 milliseconds to exit after last test
    This indicates a likely problem with the test even if it passed!

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
