### PR TITLE
fix(lua): don't leak handle when vim._watch.watch() fails

### DIFF
--- a/runtime/lua/vim/_watch.lua
+++ b/runtime/lua/vim/_watch.lua
@@ -102,6 +102,7 @@ function M.watch(path, opts, callback)
       -- This is mostly a placeholder until we have `nvim_log` API.
       vim.notify_once(('watch.watch: %s'):format(start_err), vim.log.levels.INFO)
     end
+    handle:close()
     -- TODO(justinmk): log important errors once we have `nvim_log` API.
     return function() end
   end

--- a/src/nvim/os/pty_proc_unix.c
+++ b/src/nvim/os/pty_proc_unix.c
@@ -13,7 +13,7 @@
 // forkpty is not in POSIX, so headers are platform-specific
 #if defined(__FreeBSD__) || defined(__DragonFly__)
 # include <libutil.h>
-// TODO(bfredl): this is avaliable on darwin, but there is an issue with cross-compile headers
+// TODO(bfredl): this is available on darwin, but there is an issue with cross-compile headers
 #elif defined(__APPLE__) && !defined(HAVE_FORKPTY)
 int forkpty(int *, char *, const struct termios *, const struct winsize *);
 #elif defined(__OpenBSD__) || defined(__NetBSD__) || defined(__APPLE__)

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -3539,7 +3539,7 @@ describe('extmark decorations', function()
     ]])
   end)
 
-  it('redraws extmark that starts and ends outisde the screen', function()
+  it('redraws extmark that starts and ends outside the screen', function()
     local lines = vim.split(('1'):rep(20), '', { plain = true })
     api.nvim_buf_set_lines(0, 0, -1, true, lines)
     api.nvim_buf_set_extmark(0, ns, 0, 0, { hl_group = 'ErrorMsg', end_row = 19, end_col = 0 })


### PR DESCRIPTION
This fixes the following warning in tests with ASAN or TSAN:

    -------- Running tests from test/functional/lua/watch_spec.lua
    RUN      T4253 vim._watch watch() ignores nonexistent paths: 29.00 ms OK
    nvim took 2006 milliseconds to exit after last test
    This indicates a likely problem with the test even if it passed!

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
