### PR TITLE
fix(lua): don't leak handle when vim._watch.watch() fails (#35768)

### DIFF
--- a/runtime/lua/vim/_watch.lua
+++ b/runtime/lua/vim/_watch.lua
@@ -102,6 +102,7 @@ function M.watch(path, opts, callback)
       -- This is mostly a placeholder until we have `nvim_log` API.
       vim.notify_once(('watch.watch: %s'):format(start_err), vim.log.levels.INFO)
     end
+    handle:close()
     -- TODO(justinmk): log important errors once we have `nvim_log` API.
     return function() end
   end

--- a/test/functional/ui/decorations_spec.lua
+++ b/test/functional/ui/decorations_spec.lua
@@ -3067,7 +3067,7 @@ describe('extmark decorations', function()
     ]])
   end)
 
-  it('redraws extmark that starts and ends outisde the screen', function()
+  it('redraws extmark that starts and ends outside the screen', function()
     local lines = vim.split(('1'):rep(20), '', { plain = true })
     api.nvim_buf_set_lines(0, 0, -1, true, lines)
     api.nvim_buf_set_extmark(0, ns, 0, 0, { hl_group = 'ErrorMsg', end_row = 19, end_col = 0 })


### PR DESCRIPTION
Backport of #35768

This fixes the following warning in tests with ASAN or TSAN:

    -------- Running tests from test/functional/lua/watch_spec.lua
    RUN      T4253 vim._watch watch() ignores nonexistent paths: 29.00 ms OK
    nvim took 2006 milliseconds to exit after last test
    This indicates a likely problem with the test even if it passed!
