### PR TITLE
test: remove unnecessary screen:expect_unchanged()

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -1443,7 +1443,8 @@ describe('TUI', function()
     ]])
     feed_data('\027[201~') -- End paste.
     poke_both_eventloop()
-    screen:expect_unchanged()
+    -- Don't use screen:expect_unchanged() here, as redrawing may move cursor.
+    -- screen:expect_unchanged()
     feed_data('\027[27u') -- ESC: go to Normal mode.
     wait_for_mode('n')
     screen:expect([[


### PR DESCRIPTION
This was added in #30481 to prevent race between input and paste, but it
turns out to be insufficient, and after #30751 the race is prevented by
poke_both_eventloop() instead, so this is no longer necessary.

Fix #34925
