### PR TITLE
fix(paste): don't use :echo immediately before :redraw

### DIFF
--- a/runtime/lua/vim/_editor.lua
+++ b/runtime/lua/vim/_editor.lua
@@ -250,7 +250,7 @@ do
       return false
     end
     undo_started = true
-    if phase ~= -1 and (now - tdots >= 100) then
+    if not is_last_chunk and (now - tdots >= 100) then
       local dots = ('.'):rep(tick % 4)
       tdots = now
       tick = tick + 1


### PR DESCRIPTION
- If tick == 0 at the last chunk, the first :echo will print an empty
  string, which isn't really helpful, and may cause :redraw to move
  cursor to the message area for 'showmode'.
- If tick > 0 at the last chunk, there'll be another :echo that prints
  an empty string immediately after the :redraw.

Fix #34925
