### PR TITLE
fix(lsp): avoid re-enabling `document_color` on `registerCapability`

### DIFF
--- a/runtime/lua/vim/lsp.lua
+++ b/runtime/lua/vim/lsp.lua
@@ -784,7 +784,6 @@ function lsp._set_defaults(client, bufnr)
   if client:supports_method(ms.textDocument_diagnostic) then
     lsp.diagnostic._enable(bufnr)
   end
-  lsp.document_color.enable(true, bufnr)
 end
 
 --- @deprecated

--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -1087,6 +1087,10 @@ function Client:on_attach(bufnr)
   self:_text_document_did_open_handler(bufnr)
 
   lsp._set_defaults(self, bufnr)
+  -- `enable(true)` cannot be called from `_set_defaults` for features with dynamic registration,
+  -- because it overrides the state every time `client/registerCapability` is received.
+  -- To allow disabling it once in `LspAttach`, we enable it once here instead.
+  lsp.document_color.enable(true, bufnr)
 
   api.nvim_exec_autocmds('LspAttach', {
     buffer = bufnr,


### PR DESCRIPTION
Problem: The registerCapability handler re-enables document_color, making it impossible to disable it in LspAttach.

Solution: Enable it once on initialization and avoid re-enabling on registerCapability.

fix #35756