### PR TITLE
docs: optionlinks don't need the bars

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -2227,7 +2227,7 @@ For more information on buffers, see |buffers|.
 Unloaded Buffers: ~
 
 Buffers may be unloaded by the |:bunload| command or the buffer's
-|'bufhidden'| option. When a buffer is unloaded its file contents are freed
+'bufhidden' option. When a buffer is unloaded its file contents are freed
 from memory and vim cannot operate on the buffer lines until it is reloaded
 (usually by opening the buffer again in a new window). API methods such as
 |nvim_buf_get_lines()| and |nvim_buf_line_count()| will be affected.
@@ -3738,7 +3738,7 @@ nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
     current window. If -1 is provided, a top-level split will be created.
     `vertical` and `split` are only valid for normal windows, and are used to
     control split direction. For `vertical`, the exact direction is determined
-    by |'splitright'| and |'splitbelow'|. Split windows cannot have
+    by 'splitright' and 'splitbelow'. Split windows cannot have
     `bufpos`/`row`/`col`/`border`/`title`/`footer` properties.
 
     With relative=editor (row=0,col=0) refers to the top-left corner of the

--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -95,7 +95,7 @@ BUFFER-LOCAL DEFAULTS
 - 'formatexpr' is set to |vim.lsp.formatexpr()|, so you can format lines via
   |gq| if the language server supports it.
   - To opt out of this use |gw| instead of gq, or clear 'formatexpr' on |LspAttach|.
-- |K| is mapped to |vim.lsp.buf.hover()| unless |'keywordprg'| is customized or
+- |K| is mapped to |vim.lsp.buf.hover()| unless 'keywordprg' is customized or
   a custom keymap for `K` exists.
 - Document colors are enabled for highlighting color references in a document.
   - To opt out call `vim.lsp.document_color.enable(false, args.buf)` on |LspAttach|.

--- a/runtime/doc/lua-guide.txt
+++ b/runtime/doc/lua-guide.txt
@@ -98,13 +98,13 @@ not both at the same time. This should be placed in your |config| directory
 Lua in `init.vim` and Vimscript in `init.lua`, which will be covered below.
 
 If you'd like to run any other Lua script on |startup| automatically, then you
-can simply put it in `plugin/` in your |'runtimepath'|.
+can simply put it in `plugin/` in your 'runtimepath'.
 
 ------------------------------------------------------------------------------
 Lua modules                                                  *lua-guide-modules*
 
 If you want to load Lua files on demand, you can place them in the `lua/`
-directory in your |'runtimepath'| and load them with `require`. (This is the
+directory in your 'runtimepath' and load them with `require`. (This is the
 Lua equivalent of Vimscript's |autoload| mechanism.)
 
 Let's assume you have the following directory structure:
@@ -154,7 +154,7 @@ its functions if this succeeds and prints an error message otherwise:
     end
 <
 In contrast to |:source|, |require()| not only searches through all `lua/` directories
-under |'runtimepath'|, it also caches the module on first use. Calling
+under 'runtimepath', it also caches the module on first use. Calling
 `require()` a second time will therefore _not_ execute the script again and
 instead return the cached file. To rerun the file, you need to remove it from
 the cache manually first:
@@ -234,7 +234,7 @@ e.g., |autoload| functions have to be called with this syntax:
 See also:
 • |vimscript-functions|: descriptions of all Vimscript functions
 • |function-list|: Vimscript functions grouped by topic
-• |:runtime|: run all Lua scripts matching a pattern in |'runtimepath'|
+• |:runtime|: run all Lua scripts matching a pattern in 'runtimepath'
 
 ==============================================================================
 Variables                                                  *lua-guide-variables*

--- a/runtime/doc/lua-plugin.txt
+++ b/runtime/doc/lua-plugin.txt
@@ -131,7 +131,7 @@ work out of the box. Common approaches are:
   See also |lua-vim-variables|.
 
 Typically, automatic initialization logic is done in a |plugin| or |ftplugin|
-script. See also |'runtimepath'|.
+script. See also 'runtimepath'.
 
 On the other hand, a single `setup(opts)` that combines configuration and
 initialization may be useful in specific cases:

--- a/runtime/doc/nvim.txt
+++ b/runtime/doc/nvim.txt
@@ -71,9 +71,9 @@ See |provider-python| and |provider-clipboard| for additional software you
 might need to use some features.
 
 Your Vim configuration might not be entirely Nvim-compatible (see
-|vim-differences|). For example the |'ttymouse'| option was removed from Nvim,
+|vim-differences|). For example the 'ttymouse' option was removed from Nvim,
 because mouse support is always enabled if possible. If you use the same
-|vimrc| for Vim and Nvim you could guard |'ttymouse'| in your configuration
+|vimrc| for Vim and Nvim you could guard 'ttymouse' in your configuration
 like so:
 >vim
     if !has('nvim')

--- a/runtime/doc/terminal.txt
+++ b/runtime/doc/terminal.txt
@@ -248,7 +248,7 @@ Example: >vim
 - *b:term_title*  Terminal title (user-writable), typically displayed in the
   window title or tab title of a graphical terminal emulator. Terminal
   programs can set this by emitting an escape sequence.
-- |'channel'|  Terminal PTY |job-id|.  Can be used with |chansend()| to send
+- 'channel'  Terminal PTY |job-id|.  Can be used with |chansend()| to send
   input to the terminal.
 - The |TermClose| event gives the terminal job exit code in the |v:event|
   "status" field. For example, this autocommand outputs the terminal's exit

--- a/runtime/doc/usr_26.txt
+++ b/runtime/doc/usr_26.txt
@@ -81,7 +81,7 @@ other numbers.
 
 The CTRL-X command does subtraction in a similar way.
 
-The behavior of CTRL-A and CTRL-X depends on the value of |'nrformats'|. For
+The behavior of CTRL-A and CTRL-X depends on the value of 'nrformats'. For
 example, if you use: >
 
         :set nrformats+=octal

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1726,7 +1726,7 @@ function vim.api.nvim_open_term(buffer, opts) end
 --- provided or `win == 0`, a window will be created adjacent to the current window.
 --- If -1 is provided, a top-level split will be created. `vertical` and `split` are
 --- only valid for normal windows, and are used to control split direction. For `vertical`,
---- the exact direction is determined by `'splitright'` and `'splitbelow'`.
+--- the exact direction is determined by 'splitright' and 'splitbelow'.
 --- Split windows cannot have `bufpos`/`row`/`col`/`border`/`title`/`footer`
 --- properties.
 ---

--- a/src/nvim/api/buffer.c
+++ b/src/nvim/api/buffer.c
@@ -54,7 +54,7 @@
 /// Unloaded Buffers: ~
 ///
 /// Buffers may be unloaded by the |:bunload| command or the buffer's
-/// |'bufhidden'| option. When a buffer is unloaded its file contents are freed
+/// 'bufhidden' option. When a buffer is unloaded its file contents are freed
 /// from memory and vim cannot operate on the buffer lines until it is reloaded
 /// (usually by opening the buffer again in a new window). API methods such as
 /// |nvim_buf_get_lines()| and |nvim_buf_line_count()| will be affected.

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -56,7 +56,7 @@
 /// provided or `win == 0`, a window will be created adjacent to the current window.
 /// If -1 is provided, a top-level split will be created. `vertical` and `split` are
 /// only valid for normal windows, and are used to control split direction. For `vertical`,
-/// the exact direction is determined by |'splitright'| and |'splitbelow'|.
+/// the exact direction is determined by 'splitright' and 'splitbelow'.
 /// Split windows cannot have `bufpos`/`row`/`col`/`border`/`title`/`footer`
 /// properties.
 ///


### PR DESCRIPTION
Problem:
Options links work even without vertical bars around them due to their
single quotes: the bars are unnecessary.

Solution:
Remove them.
