### PR TITLE
gx in help pages opens tag documentation in the browser

### DIFF
--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -194,6 +194,8 @@ EDITOR
    and |:vimgrep| commands.
 • For security, 'exrc' no longer shows an "(a)llow" choice. Instead you must
   "(v)iew" then run `:trust`.
+• |gx| in help buffers opens the online documentation for the tag under the
+  cursor.
 
 EVENTS
 


### PR DESCRIPTION
Problem:
`gx` did not work on tags in help buffers to open the documentation of that tag in the browser.

Solution:
Get the `optionlink`, `taglink` and `tag` TS nodes and create an extmark with url property for them. `gx` then works OOTB.

Closes: #35420
Closes: #35422