### PR TITLE
refactor(ui): replace ui_has(kUIMultigrid) with multigrid specific events

### DIFF
--- a/src/gen/c_grammar.lua
+++ b/src/gen/c_grammar.lua
@@ -198,6 +198,7 @@ local fattr = (
   + attr('FUNC_API_TEXTLOCK', 'textlock')
   + attr('FUNC_API_REMOTE_IMPL', 'remote_impl')
   + attr('FUNC_API_COMPOSITOR_IMPL', 'compositor_impl')
+  + attr('FUNC_API_UI_MULTIGRID', 'ui_multigrid')
   + attr('FUNC_API_CLIENT_IMPL', 'client_impl')
   + attr('FUNC_API_CLIENT_IGNORE', 'client_ignore')
   + (P('FUNC_') * rep(alpha) * opt(fill * paren(rep(1 - P(')') * any))))

--- a/src/gen/gen_api_ui_events.lua
+++ b/src/gen/gen_api_ui_events.lua
@@ -145,6 +145,10 @@ for i = 1, #events do
       call_output:write('  UI_CALL')
       write_signature(call_output, ev, '!ui->composed, ' .. ev.name .. ', ui', true)
       call_output:write(';\n')
+    elseif ev.ui_multigrid then
+      call_output:write('  UI_CALL')
+      write_signature(call_output, ev, '!ui->composed, ' .. ev.name .. ', ui', true)
+      call_output:write(';\n')
     else
       call_output:write('  UI_CALL')
       write_signature(call_output, ev, 'true, ' .. ev.name .. ', ui', true)
@@ -163,14 +167,25 @@ for i = 1, #events do
     call_output:write('}\n\n')
   end
 
-  if (not ev.remote_only) and not ev.noexport and not ev.client_impl and not ev.client_ignore then
+  if
+    not ev.remote_only
+    and not ev.noexport
+    and not ev.client_impl
+    and not ev.client_ignore
+    and not ev.ui_multigrid
+  then
     call_ui_event_method(client_output, ev)
   end
 end
 
 local client_events = {}
 for _, ev in ipairs(events) do
-  if (not ev.noexport) and ((not ev.remote_only) or ev.client_impl) and not ev.client_ignore then
+  if
+    not ev.noexport
+    and ((not ev.remote_only) or ev.client_impl)
+    and not ev.client_ignore
+    and not ev.ui_multigrid
+  then
     client_events[ev.name] = ev
   end
 end

--- a/src/nvim/api/ui_events.in.h
+++ b/src/nvim/api/ui_events.in.h
@@ -93,7 +93,7 @@ void grid_scroll(Integer grid, Integer top, Integer bot, Integer left, Integer r
                  Integer cols)
   FUNC_API_SINCE(5) FUNC_API_REMOTE_IMPL FUNC_API_COMPOSITOR_IMPL;
 void grid_destroy(Integer grid)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_UI_MULTIGRID;
 
 // For performance and simplicity, we use the dense screen representation
 // in internal code, such as compositor and TUI. The remote_ui module will
@@ -104,17 +104,17 @@ void raw_line(Integer grid, Integer row, Integer startcol, Integer endcol, Integ
 
 void win_pos(Integer grid, Window win, Integer startrow, Integer startcol, Integer width,
              Integer height)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_UI_MULTIGRID;
 void win_float_pos(Integer grid, Window win, String anchor, Integer anchor_grid, Float anchor_row,
                    Float anchor_col, Boolean mouse_enabled, Integer zindex, Integer compindex,
                    Integer screen_row, Integer screen_col)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_UI_MULTIGRID;
 void win_external_pos(Integer grid, Window win)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_UI_MULTIGRID;
 void win_hide(Integer grid)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_UI_MULTIGRID;
 void win_close(Integer grid)
-  FUNC_API_SINCE(6) FUNC_API_REMOTE_ONLY;
+  FUNC_API_SINCE(6) FUNC_API_UI_MULTIGRID;
 
 void msg_set_pos(Integer grid, Integer row, Boolean scrolled, String sep_char, Integer zindex,
                  Integer compindex)
@@ -126,7 +126,7 @@ void win_viewport(Integer grid, Window win, Integer topline, Integer botline, In
 
 void win_viewport_margins(Integer grid, Window win, Integer top, Integer bottom, Integer left,
                           Integer right)
-  FUNC_API_SINCE(12) FUNC_API_CLIENT_IGNORE;
+  FUNC_API_SINCE(12) FUNC_API_UI_MULTIGRID;
 
 void win_extmark(Integer grid, Window win, Integer ns_id, Integer mark_id, Integer row, Integer col)
   FUNC_API_SINCE(10) FUNC_API_REMOTE_ONLY;

--- a/src/nvim/message.c
+++ b/src/nvim/message.c
@@ -2628,15 +2628,14 @@ void msg_reset_scroll(void)
 
 void msg_ui_refresh(void)
 {
-  if (ui_has(kUIMultigrid) && msg_grid.chars) {
+  if (msg_grid.chars) {
     ui_call_grid_resize(msg_grid.handle, msg_grid.cols, msg_grid.rows);
-    ui_ext_msg_set_pos(msg_grid_pos, msg_scrolled);
   }
 }
 
 void msg_ui_flush(void)
 {
-  if (ui_has(kUIMultigrid) && msg_grid.chars && msg_grid.pending_comp_index_update) {
+  if (msg_grid.chars && msg_grid.pending_comp_index_update) {
     ui_ext_msg_set_pos(msg_grid_pos, msg_scrolled);
   }
 }

--- a/src/nvim/popupmenu.c
+++ b/src/nvim/popupmenu.c
@@ -626,14 +626,12 @@ void pum_redraw(void)
   } else if (invalid_grid) {
     grid_invalidate(&pum_grid);
   }
-  if (ui_has(kUIMultigrid)) {
-    const char *anchor = pum_above ? "SW" : "NW";
-    int row_off = pum_above ? -pum_height : 0;
-    ui_call_win_float_pos(pum_grid.handle, -1, cstr_as_string(anchor), pum_anchor_grid,
-                          pum_row - row_off - pum_win_row_offset, pum_left_col - pum_win_col_offset,
-                          false, pum_grid.zindex, (int)pum_grid.comp_index, pum_grid.comp_row,
-                          pum_grid.comp_col);
-  }
+  const char *anchor = pum_above ? "SW" : "NW";
+  int row_off = pum_above ? -pum_height : 0;
+  ui_call_win_float_pos(pum_grid.handle, -1, cstr_as_string(anchor), pum_anchor_grid,
+                        pum_row - row_off - pum_win_row_offset, pum_left_col - pum_win_col_offset,
+                        false, pum_grid.zindex, (int)pum_grid.comp_index, pum_grid.comp_row,
+                        pum_grid.comp_col);
 
   int scroll_range = pum_size - pum_height;
   // Never display more than we have
@@ -1221,10 +1219,8 @@ void pum_check_clear(void)
       ui_call_popupmenu_hide();
     } else {
       ui_comp_remove_grid(&pum_grid);
-      if (ui_has(kUIMultigrid)) {
-        ui_call_win_close(pum_grid.handle);
-        ui_call_grid_destroy(pum_grid.handle);
-      }
+      ui_call_win_close(pum_grid.handle);
+      ui_call_grid_destroy(pum_grid.handle);
       // TODO(bfredl): consider keeping float grids allocated.
       grid_free(&pum_grid);
     }
@@ -1585,7 +1581,7 @@ void pum_make_popup(const char *path_name, int use_mouse_pos)
 
 void pum_ui_flush(void)
 {
-  if (ui_has(kUIMultigrid) && pum_is_drawn && !pum_external && pum_grid.handle != 0
+  if (pum_is_drawn && !pum_external && pum_grid.handle != 0
       && pum_grid.pending_comp_index_update) {
     const char *anchor = pum_above ? "SW" : "NW";
     int row_off = pum_above ? -pum_height : 0;

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -899,14 +899,12 @@ void ui_ext_win_position(win_T *wp, bool validate)
     if (!c.hide) {
       ui_comp_put_grid(&wp->w_grid_alloc, comp_row, comp_col,
                        wp->w_height_outer, wp->w_width_outer, valid, false);
-      if (ui_has(kUIMultigrid)) {
-        String anchor = cstr_as_string(float_anchor_str[c.anchor]);
-        ui_call_win_float_pos(wp->w_grid_alloc.handle, wp->handle, anchor,
-                              grid->handle, row, col, c.mouse,
-                              wp->w_grid_alloc.zindex, (int)wp->w_grid_alloc.comp_index,
-                              wp->w_winrow,
-                              wp->w_wincol);
-      }
+      String anchor = cstr_as_string(float_anchor_str[c.anchor]);
+      ui_call_win_float_pos(wp->w_grid_alloc.handle, wp->handle, anchor,
+                            grid->handle, row, col, c.mouse,
+                            wp->w_grid_alloc.zindex, (int)wp->w_grid_alloc.comp_index,
+                            wp->w_winrow,
+                            wp->w_wincol);
       ui_check_cursor_grid(wp->w_grid_alloc.handle);
       wp->w_grid_alloc.mouse_enabled = wp->w_config.mouse;
       if (!valid) {
@@ -914,9 +912,7 @@ void ui_ext_win_position(win_T *wp, bool validate)
         redraw_later(wp, UPD_NOT_VALID);
       }
     } else {
-      if (ui_has(kUIMultigrid)) {
-        ui_call_win_hide(wp->w_grid_alloc.handle);
-      }
+      ui_call_win_hide(wp->w_grid_alloc.handle);
       ui_comp_remove_grid(&wp->w_grid_alloc);
     }
   } else {
@@ -2836,9 +2832,7 @@ int win_close(win_T *win, bool free_buf, bool force)
   split_disallowed++;
 
   bool was_floating = win->w_floating;
-  if (ui_has(kUIMultigrid)) {
-    ui_call_win_close(win->w_grid_alloc.handle);
-  }
+  ui_call_win_close(win->w_grid_alloc.handle);
 
   if (win->w_floating) {
     ui_comp_remove_grid(&win->w_grid_alloc);
@@ -5364,7 +5358,7 @@ void win_free(win_T *wp, tabpage_T *tp)
 
 void win_free_grid(win_T *wp, bool reinit)
 {
-  if (wp->w_grid_alloc.handle != 0 && ui_has(kUIMultigrid)) {
+  if (wp->w_grid_alloc.handle != 0) {
     ui_call_grid_destroy(wp->w_grid_alloc.handle);
   }
   grid_free(&wp->w_grid_alloc);
@@ -6753,11 +6747,9 @@ void win_set_inner_size(win_T *wp, bool valid_cursor)
   wp->w_winrow_off = wp->w_border_adj[0] + wp->w_winbar_height;
   wp->w_wincol_off = wp->w_border_adj[3];
 
-  if (ui_has(kUIMultigrid)) {
-    ui_call_win_viewport_margins(wp->w_grid_alloc.handle, wp->handle,
-                                 wp->w_winrow_off, wp->w_border_adj[2],
-                                 wp->w_wincol_off, wp->w_border_adj[1]);
-  }
+  ui_call_win_viewport_margins(wp->w_grid_alloc.handle, wp->handle,
+                               wp->w_winrow_off, wp->w_border_adj[2],
+                               wp->w_wincol_off, wp->w_border_adj[1]);
 
   wp->w_redr_status = true;
 }


### PR DESCRIPTION
Problem:
The code has a lot of `ui_has(kUIMultigrid)` checks, which can cause different behaviour when a multigrid is connected to the same instance as a single grid UI, and therefore affect it as well.

And even when the behaviour is stays the same, the events will be wrongly sent to the single grid UI as well, even if it's not supposed to receive multigrid events.

Solution:
Tag the multigrid UI events to be sent to only multigrid UIs and remove checks around the codebase.

This is split from https://github.com/neovim/neovim/pull/32691

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
