### PR TITLE
vim-patch:9.1.1765: f_isnan() and f_isinf() do not correctly initialize rettv type

### DIFF
--- a/src/nvim/eval/funcs.c
+++ b/src/nvim/eval/funcs.c
@@ -3667,6 +3667,9 @@ static void f_islocked(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 /// "isinf()" function
 static void f_isinf(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
+  rettv->v_type = VAR_NUMBER;
+  rettv->vval.v_number = 0;
+
   if (argvars[0].v_type == VAR_FLOAT
       && xisinf(argvars[0].vval.v_float)) {
     rettv->vval.v_number = argvars[0].vval.v_float > 0.0 ? 1 : -1;
@@ -3676,6 +3679,7 @@ static void f_isinf(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 /// "isnan()" function
 static void f_isnan(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
+  rettv->v_type = VAR_NUMBER;
   rettv->vval.v_number = argvars[0].v_type == VAR_FLOAT
                          && xisnan(argvars[0].vval.v_float);
 }


### PR DESCRIPTION
#### vim-patch:9.1.1765: f_isnan() and f_isinf() do not correctly initialize rettv type

Problem:  f_isnan() and f_isinf() do not correctly initialize rettv type
Solution: Initialize them with type: VAR_NUMBER and value 0 (Damien Lejay).

Both builtins wrote only rettv->vval.v_number and relied on call_func()
initialising rettv->v_type to VAR_NUMBER.  Explicitly set

    rettv->v_type = VAR_NUMBER;
    rettv->vval.v_number = 0;

at function entry to avoid undefined behaviour and make the return type
self-contained.

closes: vim/vim#18307

https://github.com/vim/vim/commit/19fa46a469743653a16a48c4222482d9f33e30a2

Co-authored-by: Damien Lejay <damien@lejay.be>