### PR TITLE
test(swapfile_preserve_recover_spec): fix flaky test

### DIFF
--- a/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
+++ b/test/functional/ex_cmds/swapfile_preserve_recover_spec.lua
@@ -192,7 +192,9 @@ pcall(vim.cmd.edit, 'Xtest_swapredraw.lua')
     exec(init)
     command('autocmd! nvim.swapfile') -- Delete the default handler (which skips the dialog).
     feed(':edit ' .. testfile .. '<CR>')
+    eq('r?', api.nvim_get_mode().mode)
     feed('E:source<CR>')
+    eq('r?', api.nvim_get_mode().mode)
     screen2:sleep(1000)
     feed('E')
     screen2:expect([[


### PR DESCRIPTION
Invoke nvim_get_mode() to ensure that pending input is processed.

Fix #34915
