### PR TITLE
vim-patch:9.1.1764: filetype: CODEOWNERS file not recognized

### DIFF
--- a/runtime/ftplugin/codeowners.vim
+++ b/runtime/ftplugin/codeowners.vim
@@ -1,0 +1,14 @@
+" Vim filetype plugin
+" Language:	codeowners
+" Maintainer:	Jon Parise <jon@indelible.org>
+" Last Change:	2025 Sep 14
+"
+if exists('b:did_ftplugin')
+  finish
+endif
+let b:did_ftplugin = 1
+
+setl comments=:# commentstring=#\ %s
+setl formatoptions-=t formatoptions+=croql
+
+let b:undo_ftplugin = 'setl com< cms< fo<'

--- a/runtime/lua/vim/filetype.lua
+++ b/runtime/lua/vim/filetype.lua
@@ -1516,6 +1516,7 @@ local filename = {
   ['.trans'] = 'clojure',
   ['CMakeLists.txt'] = 'cmake',
   ['CMakeCache.txt'] = 'cmakecache',
+  ['CODEOWNERS'] = 'codeowners',
   ['.cling_history'] = 'cpp',
   ['.alias'] = detect.csh,
   ['.cshrc'] = detect.csh,

--- a/runtime/syntax/codeowners.vim
+++ b/runtime/syntax/codeowners.vim
@@ -1,0 +1,23 @@
+" Vim syntax file
+" Language:	codeowners
+" Maintainer:	Jon Parise <jon@indelible.org>
+" Last Change:	2025 Sep 14
+
+if exists('b:current_syntax')
+  finish
+endif
+
+" Comments
+syn match codeownersComment /#.*$/ contains=codeownersTodo,@Spell
+syn keyword codeownersTodo TODO FIXME XXX contained
+
+" Patterns
+syn match codeownersPattern /^#\@![^#]*/ contains=codeownersGlob
+syn match codeownersGlob /^\S\+/ contained nextgroup=codeownersOwner skipwhite
+syn match codeownersOwner /\S\+/ contained nextgroup=codeownersOwner skipwhite
+
+hi def link codeownersComment Comment
+hi def link codeownersOwner Identifier
+hi def link codeownersTodo Todo
+
+let b:current_syntax = 'codeowners'

--- a/test/old/testdir/test_filetype.vim
+++ b/test/old/testdir/test_filetype.vim
@@ -189,6 +189,7 @@ func s:GetFilenameChecks() abort
     \ 'cmusrc': ['any/.cmus/autosave', 'any/.cmus/rc', 'any/.cmus/command-history', 'any/.cmus/file.theme', 'any/cmus/rc', 'any/cmus/file.theme', '/.cmus/autosave', '/.cmus/command-history', '/.cmus/file.theme', '/.cmus/rc', '/cmus/file.theme', '/cmus/rc'],
     \ 'cobol': ['file.cbl', 'file.cob'],
     \ 'coco': ['file.atg'],
+    \ 'codeowners': ['CODEOWNERS'],
     \ 'conaryrecipe': ['file.recipe'],
     \ 'conf': ['auto.master', 'file.conf', 'texdoc.cnf', '.x11vncrc', '.chktexrc', '.ripgreprc', 'ripgreprc', 'file.ctags'],
     \ 'config': ['/etc/hostname.file', 'any/etc/hostname.file', 'configure.in', 'configure.ac', 'file.at', 'aclocal.m4'],


### PR DESCRIPTION
#### vim-patch:9.1.1764: filetype: CODEOWNERS file not recognized

Problem:  filetype: CODEOWNERS file not recognized
Solution: Detect CODEOWNERS file as codeowners filetype, include a
          syntax and filetype plugin (Jon Parise).

CODEOWNERS files define code ownership rules for GitHub-hosted (and
other) repositories. The syntax is similar to 'gitignore' files but
differs in enough ways to warrant its own filetype.

References:
- https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners

closes: vim/vim#18299

https://github.com/vim/vim/commit/817e4d3ee6b051477596ba1d86a2631d9fabc95b

Co-authored-by: Jon Parise <jon@indelible.org>