### PR TITLE
docs: remove obsolete 'backspace' number values from |i_backspacing|

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -282,9 +282,6 @@ nostop	    like start, except CTRL-W and CTRL-U do not stop at the start of
 When 'backspace' is empty, Vi compatible backspacing is used.  You cannot
 backspace over autoindent, before column 1 or before where insert started.
 
-For backwards compatibility the values "0", "1", "2" and "3" are also allowed,
-see 'backspace'.
-
 If the 'backspace' option does contain "eol" and the cursor is in column 1
 when one of the three keys is used, the current line is joined with the
 previous line.  This effectively deletes the <EOL> in front of the cursor.


### PR DESCRIPTION
support for number values for the `'backspace'` option was dropped in [#24350](https://github.com/neovim/neovim/pull/24350)