### PR TITLE
docs(plugins): add missing plugins to |standard-plugin-list|

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -299,7 +299,7 @@ Note the use of ":noremap" instead of "map" to avoid a recursive mapping.
 Map the X1 and X2 buttons to go forwards and backwards in the jump list, see
 |CTRL-O| and |CTRL-I|.
 
-                                                *mouse-swap-buttons*
+                                       *mouse-swap-buttons* *pi_swapmouse*
 To swap the meaning of the left and right mouse buttons: >vim
         :noremap        <LeftMouse>     <RightMouse>
         :noremap        <LeftDrag>      <RightDrag>
@@ -315,6 +315,10 @@ To swap the meaning of the left and right mouse buttons: >vim
         :noremap!       <RightMouse>    <LeftMouse>
         :noremap!       <RightDrag>     <LeftDrag>
         :noremap!       <RightRelease>  <LeftRelease>
+<
+
+The `swapmouse` plugin does exactly this. Use |pack-add| to load it: >vim
+    :packadd! swapmouse
 <
 
 ==============================================================================

--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -18,23 +18,25 @@ loaded by default while others are not loaded until requested by |:packadd|.
 Standard plugins ~
 						*standard-plugin-list*
 Help-link		Loaded	Short description ~
+|editorconfig|		Yes	Detect and interpret editorconfig
+|ft-shada|		Yes	Allows editing binary |shada| files
+|man.lua|		Yes	View manpages in Nvim
+|matchit|		Yes	Extended |%| matching
+|matchparen|		Yes	Highlight matching pairs
+|netrw|			Yes	Reading and writing files over a network
 |package-cfilter|	No	Filtering quickfix/location list
 |package-justify|	No	Justify text
 |package-nohlsearch|	No	Automatically run :nohlsearch
 |package-termdebug|	No	Debug inside Nvim with gdb
-|matchit|		Yes	Extended |%| matching
-|editorconfig|		Yes	Detect and internet editorconfig
-|spellfile.vim|		Yes	Install spellfile if missing
-|pi_tutor.txt|		Yes	Interactive tutorial
 |pi_gzip.txt|		Yes	Reading and writing compressed files
 |pi_msgpack.txt|	No	msgpack utilities
 |pi_paren.txt|		Yes	Highlight matching parens
+|pi_spec.txt|		Yes	Filetype plugin to work with rpm spec files
+|pi_swapmouse|		No	Swap meaning of left and right mouse buttons
 |pi_tar.txt|		Yes	Tar file explorer
+|pi_tutor.txt|		Yes	Interactive tutorial
 |pi_zip.txt|		Yes	Zip archive explorer
-|netrw|			Yes	Reading and writing files over a network
-|ftplugin-docs|		*	Filetype specific plugins
-    |man.lua|		Yes	Opening and viewing manpages
-    |pi_spec.txt|	Yes	Filetype plugin to work with rpm spec files
+|spellfile.vim|		Yes	Install spellfile if missing
 |tohtml|		Yes	Convert buffer to html, syntax included
 
 ==============================================================================


### PR DESCRIPTION
Plugins that are not included yet:
- `osc52.lua`: does not fit this "plugin" description I guess?
- `rplugin.vim`: include this? `|remote-plugin|`
- `shada.lua`: include this? `|shada|`
- `shellmenu`: no docs available
- `swapmouse`: no docs available (or mention it at `|mouse-swap-buttons|`?)

N.B.: Before merging I'd like to update the commit to mention the plugins that are intentionally left out and the reason for it. Let me know which of the plugins above should also be included (and if their documentation should be moved to plugins.txt).

N.B.2: Shouldn't the list be sorted alphabetically?