### PR TITLE
vim-patch:9.1.1762,10d1ec6

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1368,8 +1368,8 @@ In the first state these keys have a special meaning:
 <BS> and CTRL-H   Delete one character, find the matches for the word before
 		  the cursor.  This reduces the list of matches, often to one
 		  entry, and switches to the second state.
-		  When 'autocomplete' is set, clears the selected item in the
-		  menu.
+		  When 'autocomplete' is active, clears the selected item in
+		  the menu.
 Any non-special character:
 		  Stop completion without changing the match and insert the
 		  typed character.
@@ -1377,8 +1377,8 @@ Any non-special character:
 In the second and third state these keys have a special meaning:
 <BS> and CTRL-H   Delete one character, find the matches for the shorter word
 		  before the cursor.  This may find more matches.
-		  When 'autocomplete' is set, clears the selected item in the
-		  menu.
+		  When 'autocomplete' is active, clears the selected item in
+		  the menu.
 CTRL-L		  Add one character from the current match, may reduce the
 		  number of matches.
 any printable, non-white character:

--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -1368,6 +1368,8 @@ In the first state these keys have a special meaning:
 <BS> and CTRL-H   Delete one character, find the matches for the word before
 		  the cursor.  This reduces the list of matches, often to one
 		  entry, and switches to the second state.
+		  When 'autocomplete' is set, clears the selected item in the
+		  menu.
 Any non-special character:
 		  Stop completion without changing the match and insert the
 		  typed character.
@@ -1375,6 +1377,8 @@ Any non-special character:
 In the second and third state these keys have a special meaning:
 <BS> and CTRL-H   Delete one character, find the matches for the shorter word
 		  before the cursor.  This may find more matches.
+		  When 'autocomplete' is set, clears the selected item in the
+		  menu.
 CTRL-L		  Add one character from the current match, may reduce the
 		  number of matches.
 any printable, non-white character:

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2197,6 +2197,11 @@ int ins_compl_bs(void)
   compl_leader = cbuf_to_string(line + compl_col,
                                 (size_t)(p_off - (ptrdiff_t)compl_col));
 
+  // Clear selection if a menu item is currently selected in autocompletion
+  if (compl_autocomplete && compl_first_match) {
+    compl_shown_match = compl_first_match;
+  }
+
   ins_compl_new_leader();
   if (compl_shown_match != NULL) {
     // Make sure current match is not a hidden item.

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -5359,6 +5359,21 @@ func Test_autocomplete_trigger()
   call feedkeys("Sazx\<Left>\<BS>\<F2>\<Esc>0", 'tx!')
   call assert_equal(['and', 'afoo'], b:matches->mapnew('v:val.word'))
 
+  " Test 6: <BS> should clear the selected item
+  %d
+  call setline(1, ["foobarfoo", "foobar", "foobarbaz"])
+  call feedkeys("Gofo\<C-N>\<C-N>\<F2>\<F3>\<Esc>0", 'tx!')
+  call assert_equal(['foobarbaz', 'foobar', 'foobarfoo'], b:matches->mapnew('v:val.word'))
+  call assert_equal(1, b:selected)
+  call feedkeys("Sfo\<C-N>\<C-N>\<BS>\<F2>\<F3>\<Esc>0", 'tx!')
+  call assert_equal(['foobarbaz', 'foobar', 'foobarfoo'], b:matches->mapnew('v:val.word'))
+  call assert_equal(-1, b:selected)
+  call assert_equal('fooba', getline(4))
+  call feedkeys("Sfo\<C-N>\<C-N>\<BS>\<C-N>\<F2>\<F3>\<Esc>0", 'tx!')
+  call assert_equal(['foobarbaz', 'foobar', 'foobarfoo'], b:matches->mapnew('v:val.word'))
+  call assert_equal(0, b:selected)
+  call assert_equal('foobarbaz', getline(4))
+
   bw!
   call Ntest_override("char_avail", 0)
   delfunc NonKeywordComplete


### PR DESCRIPTION
#### vim-patch:9.1.1762: completion: selected item not cleared on <BS> with 'ac'

Problem:  completion: selected item not cleared on backspace when
          'autocomplete' is set
Solution: Clear the selected item (Girish Palya)

closes: vim/vim#18260

https://github.com/vim/vim/commit/5c9b71d63c1b324c6f4c7b84faf3fafa40c3fcc5

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:10d1ec6: runtime(doc): fix doc style from commit 5c9b71d63c1

related: vim/vim#18265

https://github.com/vim/vim/commit/10d1ec658cc4f0d5fca5d8518edcadf6027450e8

Co-authored-by: Christian Brabandt <cb@256bit.org>