### PR TITLE
fix(lsp): restore Client:stop() force-stopping behavior

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -867,12 +867,12 @@ end
 ---
 --- @param force? boolean
 function Client:stop(force)
-  if self:is_stopped() then
+  local rpc = self.rpc
+  if rpc.is_closing() then
     return
   end
 
   self._is_stopping = true
-  local rpc = self.rpc
 
   lsp._watchfiles.cancel(self.id)
 


### PR DESCRIPTION
This fixes a regression from #33796.

I tried for several hours and cannot write a working test for this, but
this does fix the following warning in tests run with ASAN or TSAN:

    -------- Running tests from test/functional/plugin/lsp_spec.lua
    RUN      T4667 LSP server_name specified start_client(), stop_client(): 114.00 ms OK
    RUN      T4668 LSP server_name specified stop_client() also works on client objects: 97.00 ms OK
    RUN      T4669 LSP server_name specified does not reuse an already-stopping client #33616: 31.00 ms OK
    nvim took 2022 milliseconds to exit after last test
    This indicates a likely problem with the test even if it passed!

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
