### PR TITLE
vim-patch:0b7d094: runtime(doc): Tweak doc style in syntax.txt

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -4340,7 +4340,8 @@ Only the immediate containing item (the one at the top of the syntax stack) is
 considered.  Vim does not search other ancestors.  If the immediate container
 neither contains this item via |:syn-contains| nor is named in this item's
 "containedin=", the match will not start even if some ancestor would allow it.
-Note that a |:syn-transparent| region still enforces its own |:syn-contains| list.
+Note that a |:syn-transparent| region still enforces its own |:syn-contains|
+list.
 
 The {group-name}... can be used just like for "contains", as explained above.
 


### PR DESCRIPTION
#### vim-patch:0b7d094: runtime(doc): Tweak doc style in syntax.txt

closes: vim/vim#18310

https://github.com/vim/vim/commit/0b7d094d70eaeb2dbb1288144c28ad2a6fd05902

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>