### PR TITLE
vim-patch:5bf41e7: runtime(netrw): update regex to handle remote archives

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -7,6 +7,7 @@
 " 2025 Aug 22 by Vim Project netrw#Explore handle terminal correctly #18069
 " 2025 Sep 05 by Vim Project ensure netrw#fs#Dirname() returns trailing slash #18199
 " 2025 Sep 11 by Vim Project only keep cursor position in tree mode #18275
+" 2025 Sep 17 by Vim Project tighten the regex to handle remote compressed archives #18318
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -3048,12 +3049,12 @@ function s:NetrwBrowse(islocal,dirname)
             exe "sil! NetrwKeepj keepalt doau BufReadPre ".fnameescape(s:fname)
             sil call netrw#NetRead(2,url)
             " netrw.vim and tar.vim have already handled decompression of the tarball; avoiding gzip.vim error
-            if s:path =~ '.bz2'
+            if s:path =~ '\.bz2$'
                 exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(substitute(s:fname,'\.bz2$','',''))
-            elseif s:path =~ '.gz'
+            elseif s:path =~ '\.gz$'
                 exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(substitute(s:fname,'\.gz$','',''))
-            elseif s:path =~ '.gz'
-                exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(substitute(s:fname,'\.txz$','',''))
+            elseif s:path =~ '\.xz$'
+                exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(substitute(s:fname,'\.xz$','',''))
             else
                 exe "sil NetrwKeepj keepalt doau BufReadPost ".fnameescape(s:fname)
             endif


### PR DESCRIPTION
#### vim-patch:5bf41e7: runtime(netrw): update regex to handle remote archives

closes: vim/vim#18318

https://github.com/vim/vim/commit/5bf41e74185b903836948ef501375792f70acb12

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>