### PR TITLE
vim-patch:9.1.{1550,1761}

### DIFF
--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -77,7 +77,6 @@ Defaults                                            *defaults* *nvim-defaults*
 - 'ruler' is enabled
 - 'sessionoptions' includes "unix,slash", excludes "options"
 - 'shortmess' includes "CF", excludes "S"
-- 'showcmd' is enabled
 - 'sidescroll' defaults to 1
 - 'smarttab' is enabled
 - 'spellfile' defaults to `stdpath("data").."/site/spell/"`

--- a/runtime/doc/vim_diff.txt
+++ b/runtime/doc/vim_diff.txt
@@ -74,7 +74,6 @@ Defaults                                            *defaults* *nvim-defaults*
 - 'mousemodel' defaults to "popup_setpos"
 - 'nrformats' defaults to "bin,hex"
 - 'path' defaults to ".,,". The C ftplugin adds "/usr/include" if it exists.
-- 'ruler' is enabled
 - 'sessionoptions' includes "unix,slash", excludes "options"
 - 'shortmess' includes "CF", excludes "S"
 - 'sidescroll' defaults to 1

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -19,7 +19,7 @@ if exists('s:did_load')
   set listchars=eol:$
   set maxsearchcount=99
   set mousemodel=extend
-  set nohidden nosmarttab noautoindent noautoread noruler
+  set nohidden nosmarttab noautoindent noautoread
   set nohlsearch noincsearch
   set nrformats=bin,octal,hex
   set sessionoptions+=options

--- a/test/old/testdir/setup.vim
+++ b/test/old/testdir/setup.vim
@@ -19,7 +19,7 @@ if exists('s:did_load')
   set listchars=eol:$
   set maxsearchcount=99
   set mousemodel=extend
-  set nohidden nosmarttab noautoindent noautoread noruler noshowcmd
+  set nohidden nosmarttab noautoindent noautoread noruler
   set nohlsearch noincsearch
   set nrformats=bin,octal,hex
   set sessionoptions+=options

--- a/test/old/testdir/test_autocmd.vim
+++ b/test/old/testdir/test_autocmd.vim
@@ -2386,7 +2386,10 @@ func Test_BufReadCmd()
 
   call writefile(['one', 'two', 'three'], 'Xcmd.test', 'D')
   edit Xcmd.test
+  set noruler
   call assert_match('Xcmd.test" line 1 of 3', execute('file'))
+  set ruler
+  call assert_match('Xcmd.test" 3 lines --33%--', execute('file'))
   normal! Gofour
   write
   call assert_equal(['one', 'two', 'three', 'four'], readfile('Xcmd.test'))

--- a/test/old/testdir/test_display.vim
+++ b/test/old/testdir/test_display.vim
@@ -187,12 +187,29 @@ func Test_edit_long_file_name()
 
   let longName = 'x'->repeat(min([&columns, 255]))
   call writefile([], longName, 'D')
-  let buf = RunVimInTerminal('-N -u NONE --cmd ":set noshowcmd" ' .. longName, #{rows: 8})
+  let buf = RunVimInTerminal('-N -u NONE --cmd ":set noshowcmd noruler" ' .. longName, #{rows: 8})
 
   call VerifyScreenDump(buf, 'Test_long_file_name_1', {})
 
   call term_sendkeys(buf, ":set showcmd\<cr>:e!\<cr>")
   call VerifyScreenDump(buf, 'Test_long_file_name_2', {})
+
+  " clean up
+  call StopVimInTerminal(buf)
+  set ruler&vim
+endfunc
+
+func Test_edit_long_file_name_with_ruler()
+  CheckScreendump
+
+  let longName = 'x'->repeat(min([&columns, 255]))
+  call writefile([], longName, 'D')
+  let buf = RunVimInTerminal('-N -u NONE --cmd ":set noshowcmd" ' .. longName, #{rows: 8})
+
+  call VerifyScreenDump(buf, 'Test_long_file_name_3', {})
+
+  call term_sendkeys(buf, ":set showcmd\<cr>:e!\<cr>")
+  call VerifyScreenDump(buf, 'Test_long_file_name_4', {})
 
   " clean up
   call StopVimInTerminal(buf)

--- a/test/old/testdir/test_display.vim
+++ b/test/old/testdir/test_display.vim
@@ -187,9 +187,12 @@ func Test_edit_long_file_name()
 
   let longName = 'x'->repeat(min([&columns, 255]))
   call writefile([], longName, 'D')
-  let buf = RunVimInTerminal('-N -u NONE ' .. longName, #{rows: 8})
+  let buf = RunVimInTerminal('-N -u NONE --cmd ":set noshowcmd" ' .. longName, #{rows: 8})
 
   call VerifyScreenDump(buf, 'Test_long_file_name_1', {})
+
+  call term_sendkeys(buf, ":set showcmd\<cr>:e!\<cr>")
+  call VerifyScreenDump(buf, 'Test_long_file_name_2', {})
 
   " clean up
   call StopVimInTerminal(buf)

--- a/test/old/testdir/test_options.vim
+++ b/test/old/testdir/test_options.vim
@@ -2903,4 +2903,16 @@ func Test_set_missing_options()
   set w9600=23
 endfunc
 
+func Test_showcmd()
+  throw 'Skipped: Nvim does not support support Vi-compatible mode'
+  " in no-cp mode, 'showcmd' is enabled
+  let _cp=&cp
+  call assert_equal(1, &showcmd)
+  set cp
+  call assert_equal(0, &showcmd)
+  set nocp
+  call assert_equal(1, &showcmd)
+  let &cp = _cp
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_registers.vim
+++ b/test/old/testdir/test_registers.vim
@@ -170,6 +170,7 @@ func Test_register_one()
 endfunc
 
 func Test_recording_status_in_ex_line()
+  set noruler
   norm qx
   redraw!
   call assert_equal('recording @x', Screenline(&lines))
@@ -180,6 +181,17 @@ func Test_recording_status_in_ex_line()
   norm q
   redraw!
   call assert_equal('', Screenline(&lines))
+  set ruler
+  norm qx
+  redraw!
+  call assert_match('recording @x\s*0,0-1\s*All', Screenline(&lines))
+  set shortmess=q
+  redraw!
+  call assert_match('\s*0,0-1\s*All', Screenline(&lines)) " Nvim: shm+=q fully hides
+  set shortmess&
+  norm q
+  redraw!
+  call assert_match('\s*0,0-1\s*All', Screenline(&lines))
 endfunc
 
 " Check that replaying a typed sequence does not use an Esc and following

--- a/test/old/testdir/test_scroll_opt.vim
+++ b/test/old/testdir/test_scroll_opt.vim
@@ -954,10 +954,11 @@ func Test_smoothscroll_multi_skipcol()
 endfunc
 
 " this was dividing by zero bug in scroll_cursor_bot
-func Test_smoothscroll_zero_width_scroll_cursor_bot()
+func Test_smoothscroll_zero_width_scroll_cursor_bot_noruler()
   CheckScreendump
 
   let lines =<< trim END
+      set noruler
       silent normal yy
       silent normal 19p
       set cpoptions+=n
@@ -975,12 +976,34 @@ func Test_smoothscroll_zero_width_scroll_cursor_bot()
   call StopVimInTerminal(buf)
 endfunc
 
-" scroll_cursor_top() should reset skipcol when it changes topline
-func Test_smoothscroll_cursor_top()
+func Test_smoothscroll_zero_width_scroll_cursor_bot_ruler()
   CheckScreendump
 
   let lines =<< trim END
-      set smoothscroll scrolloff=2
+      set ruler
+      silent normal yy
+      silent normal 19p
+      set cpoptions+=n
+      vsplit
+      vertical resize 0
+      set foldcolumn=1
+      set number
+      set smoothscroll
+      silent normal 20G
+  END
+  call writefile(lines, 'XSmoothScrollZeroBot', 'D')
+  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollZeroBot', #{rows: 19})
+  call VerifyScreenDump(buf, 'Test_smoothscroll_zero_bot_ruler', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
+" scroll_cursor_top() should reset skipcol when it changes topline
+func Test_smoothscroll_cursor_top_noruler()
+  CheckScreendump
+
+  let lines =<< trim END
+      set smoothscroll scrolloff=2 noruler
       new | 11resize | wincmd j
       call setline(1, ['line1', 'line2', 'line3'->repeat(20), 'line4'])
       exe "norm G3\<C-E>k"
@@ -988,6 +1011,22 @@ func Test_smoothscroll_cursor_top()
   call writefile(lines, 'XSmoothScrollCursorTop', 'D')
   let buf = RunVimInTerminal('-u NONE -S XSmoothScrollCursorTop', #{rows: 12, cols: 40})
   call VerifyScreenDump(buf, 'Test_smoothscroll_cursor_top', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
+func Test_smoothscroll_cursor_top_ruler()
+  CheckScreendump
+
+  let lines =<< trim END
+      set smoothscroll scrolloff=2 ruler
+      new | 11resize | wincmd j
+      call setline(1, ['line1', 'line2', 'line3'->repeat(20), 'line4'])
+      exe "norm G3\<C-E>k"
+  END
+  call writefile(lines, 'XSmoothScrollCursorTop', 'D')
+  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollCursorTop', #{rows: 12, cols: 40})
+  call VerifyScreenDump(buf, 'Test_smoothscroll_cursor_ru_top', {})
 
   call StopVimInTerminal(buf)
 endfunc
@@ -1011,12 +1050,12 @@ func Test_smoothscroll_crash()
   call StopVimInTerminal(buf)
 endfunc
 
-func Test_smoothscroll_insert_bottom()
+func Test_smoothscroll_insert_bottom_noruler()
   CheckScreendump
 
   let lines =<< trim END
     call setline(1, repeat([repeat('A very long line ...', 10)], 5))
-    set wrap smoothscroll scrolloff=0
+    set wrap smoothscroll scrolloff=0 noruler
   END
   call writefile(lines, 'XSmoothScrollInsertBottom', 'D')
   let buf = RunVimInTerminal('-u NONE -S XSmoothScrollInsertBottom', #{rows: 9, cols: 40})
@@ -1026,12 +1065,27 @@ func Test_smoothscroll_insert_bottom()
   call StopVimInTerminal(buf)
 endfunc
 
-func Test_smoothscroll_in_qf_window()
+func Test_smoothscroll_insert_bottom_ruler()
+  CheckScreendump
+
+  let lines =<< trim END
+    call setline(1, repeat([repeat('A very long line ...', 10)], 5))
+    set wrap smoothscroll scrolloff=0 ruler
+  END
+  call writefile(lines, 'XSmoothScrollInsertBottom', 'D')
+  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollInsertBottom', #{rows: 9, cols: 40})
+  call term_sendkeys(buf, "Go123456789\<CR>")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_insert_bottom_ruler', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
+func Test_smoothscroll_in_qf_window_noruler()
   CheckFeature quickfix
   CheckScreendump
 
   let lines =<< trim END
-    set nocompatible display=lastline
+    set nocompatible display=lastline noruler
     copen 5
     setlocal number smoothscroll
     let g:l = [{'text': 'foo'}] + repeat([{'text': join(range(30))}], 10)
@@ -1067,6 +1121,51 @@ func Test_smoothscroll_in_qf_window()
 
   call term_sendkeys(buf, ":call setqflist(g:l, 'r')\<CR>")
   call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_3', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
+func Test_smoothscroll_in_qf_window_ruler()
+  CheckFeature quickfix
+  CheckScreendump
+
+  let lines =<< trim END
+    set nocompatible display=lastline ruler
+    copen 5
+    setlocal number smoothscroll
+    let g:l = [{'text': 'foo'}] + repeat([{'text': join(range(30))}], 10)
+    call setqflist(g:l, 'r')
+    normal! G
+    wincmd t
+    let g:l1 = [{'text': join(range(1000))}]
+  END
+  call writefile(lines, 'XSmoothScrollInQfWindow', 'D')
+  let buf = RunVimInTerminal('-u NONE -S XSmoothScrollInQfWindow', #{rows: 20, cols: 60})
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_ru_1', {})
+
+  call term_sendkeys(buf, ":call setqflist([], 'r')\<CR>")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_ru_2', {})
+
+  call term_sendkeys(buf, ":call setqflist(g:l, 'r')\<CR>")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_ru_3', {})
+
+  call term_sendkeys(buf, ":call setqflist(g:l1, 'r')\<CR>")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_ru_4', {})
+
+  call term_sendkeys(buf, "\<C-W>b$\<C-W>t")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_ru_5', {})
+
+  call term_sendkeys(buf, ":call setqflist([], 'r')\<CR>")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_ru_2', {})
+
+  call term_sendkeys(buf, ":call setqflist(g:l1, 'r')\<CR>")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_ru_4', {})
+
+  call term_sendkeys(buf, "\<C-W>b$\<C-W>t")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_ru_5', {})
+
+  call term_sendkeys(buf, ":call setqflist(g:l, 'r')\<CR>")
+  call VerifyScreenDump(buf, 'Test_smoothscroll_in_qf_window_ru_3', {})
 
   call StopVimInTerminal(buf)
 endfunc
@@ -1218,11 +1317,12 @@ func Test_smoothscroll_long_line_zb()
   bwipe!
 endfunc
 
-func Test_smooth_long_scrolloff()
+func Test_smooth_long_scrolloff_noruler()
   CheckScreendump
 
   let lines =<< trim END
     set smoothscroll scrolloff=3
+    set noruler
     call setline(1, ['one', 'two long '->repeat(100), 'three', 'four', 'five', 'six'])
   END
   call writefile(lines, 'XSmoothLongScrolloff', 'D')
@@ -1247,6 +1347,39 @@ func Test_smooth_long_scrolloff()
 
   call term_sendkeys(buf, "gk")
   call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_7', {})
+
+  call StopVimInTerminal(buf)
+endfunc
+
+func Test_smooth_long_scrolloff_ruler()
+  CheckScreendump
+
+  let lines =<< trim END
+    set smoothscroll scrolloff=3 ruler
+    call setline(1, ['one', 'two long '->repeat(100), 'three', 'four', 'five', 'six'])
+  END
+  call writefile(lines, 'XSmoothLongScrolloff', 'D')
+  let buf = RunVimInTerminal('-u NONE -S XSmoothLongScrolloff', #{rows: 8, cols: 40})
+  call term_sendkeys(buf, ":norm j721|\<CR>")
+  call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_ru_1', {})
+
+  call term_sendkeys(buf, "gj")
+  call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_ru_2', {})
+
+  call term_sendkeys(buf, "gj")
+  call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_ru_3', {})
+
+  call term_sendkeys(buf, "gj")
+  call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_ru_4', {})
+
+  call term_sendkeys(buf, "gj")
+  call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_ru_5', {})
+
+  call term_sendkeys(buf, "gj")
+  call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_ru_6', {})
+
+  call term_sendkeys(buf, "gk")
+  call VerifyScreenDump(buf, 'Test_smooth_long_scrolloff_ru_7', {})
 
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.1550: defaults: 'showcmd' is not enabled in non-compatible mode on Unix

Problem:  defaults: 'showcmd' is not enabled in non-compatible mode on
          Unix
Solution: Always enable 'showcmd' in non-compatible mode, drop it from
          defaults.vim.

'showcmd' was already always enabled in Vim compatible mode except for
UNIX environments. So let's just enable it always, there is no good
reason why UNIX platforms should be handled differently than other
platforms, especially since `defaults.vim` did enable this option
anyhow.

closes: vim/vim#17739

https://github.com/vim/vim/commit/3f9d2378bd70748fc59e02a402422269bd096492

Co-authored-by: Christian Brabandt <cb@256bit.org>


#### vim-patch:9.1.1761: 'ruler' is set in defaults.vim

Problem:  'ruler' is set in defaults.vim, but not enabled by default in
          non-compatible mode.
Solution: set the ruler option in non-compatible mode, remove it from
          defaults.vim, update tests

closes: vim/vim#18260

https://github.com/vim/vim/commit/ba36510920654a52d8b5908f5a61c6969bb31942

Co-authored-by: Christian Brabandt <cb@256bit.org>