### PR TITLE
feat(vim.pack): lockfile support

### DIFF
--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -410,8 +410,7 @@ update({names}, {opts})                                    *vim.pack.update()*
     Parameters: ~
       • {names}  (`string[]?`) List of plugin names to update. Must be managed
                  by |vim.pack|, not necessarily already added to current
-                 session. Default: names of all plugins added to current
-                 session via |vim.pack.add()|.
+                 session. Default: names of all plugins managed by |vim.pack|.
       • {opts}   (`table?`) A table with the following fields:
                  • {force}? (`boolean`) Whether to skip confirmation and make
                    updates immediately. Default `false`.

--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -224,8 +224,9 @@ tags following semver convention `v<major>.<minor>.<patch>`.
 The latest state of all managed plugins is stored inside a *vim.pack-lockfile*
 located at `$XDG_CONFIG_HOME/nvim/nvim-pack-lock.json`. It is a JSON file that
 is used to persistently track data about plugins. For a more robust config
-treat lockfile like its part: put under version control, etc. Should not be
-edited by hand or deleted.
+treat lockfile like its part: put under version control, etc. In this case
+initial install prefers revision from the lockfile instead of inferring from
+`version`. Should not be edited by hand or deleted.
 
 Example workflows ~
 
@@ -260,7 +261,8 @@ Basic install and management:
     plugin1 = require('plugin1')
 <
 • Restart Nvim (for example, with |:restart|). Plugins that were not yet
-  installed will be available on disk in target state after `add()` call.
+  installed will be available on disk after `add()` call. Their revision is
+  taken from |vim.pack-lockfile| (if present) or inferred from the `version`.
 • To update all plugins with new changes:
   • Execute |vim.pack.update()|. This will download updates from source and
     show confirmation buffer in a separate tabpage.

--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -221,6 +221,12 @@ Uses Git to manage plugins and requires present `git` executable of at least
 version 2.36. Target plugins should be Git repositories with versions as named
 tags following semver convention `v<major>.<minor>.<patch>`.
 
+The latest state of all managed plugins is stored inside a *vim.pack-lockfile*
+located at `$XDG_CONFIG_HOME/nvim/nvim-pack-lock.json`. It is a JSON file that
+is used to persistently track data about plugins. For a more robust config
+treat lockfile like its part: put under version control, etc. Should not be
+edited by hand or deleted.
+
 Example workflows ~
 
 Basic install and management:
@@ -260,11 +266,13 @@ Basic install and management:
     show confirmation buffer in a separate tabpage.
   • Review changes. To confirm all updates execute |:write|. To discard
     updates execute |:quit|.
+  • (Optionally) |:restart| to start using code from updated plugins.
 
 Switch plugin's version:
 • Update 'init.lua' for plugin to have desired `version`. Let's say, plugin
   named 'plugin1' has changed to `vim.version.range('*')`.
-• |:restart|. The plugin's actual state on disk is not yet changed.
+• |:restart|. The plugin's actual state on disk is not yet changed. Only
+  plugin's `version` in |vim.pack-lockfile| is updated.
 • Execute `vim.pack.update({ 'plugin1' })`.
 • Review changes and either confirm or discard them. If discarded, revert any
   changes in 'init.lua' as well or you will be prompted again next time you
@@ -272,7 +280,7 @@ Switch plugin's version:
 
 Freeze plugin from being updated:
 • Update 'init.lua' for plugin to have `version` set to current revision. Get
-  it with `:=vim.pack.get({ 'plug-name' })[1].rev` (looks like `abc12345`).
+  it from |vim.pack-lockfile| (plugin's field `rev`; looks like `abc12345`).
 • |:restart|.
 
 Unfreeze plugin to start receiving updates:

--- a/runtime/doc/pack.txt
+++ b/runtime/doc/pack.txt
@@ -379,7 +379,7 @@ get({names}, {opts})                                          *vim.pack.get()*
         • {branches}? (`string[]`) Available Git branches (first is default).
           Missing if `info=false`.
         • {path} (`string`) Plugin's path on disk.
-        • {rev}? (`string`) Current Git revision. Missing if `info=false`.
+        • {rev} (`string`) Current Git revision.
         • {spec} (`vim.pack.SpecResolved`) A |vim.pack.Spec| with resolved
           `name`.
         • {tags}? (`string[]`) Available Git tags. Missing if `info=false`.

--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -401,15 +401,8 @@ local function plug_list_from_names(names)
   local plug_dir = get_plug_dir()
   local plugs = {} --- @type vim.pack.Plug[]
   for _, p_data in ipairs(p_data_list) do
-    -- NOTE: By default include only active plugins (and not all on disk). Using
-    -- not active plugins might lead to a confusion as default `version` and
-    -- user's desired one might mismatch.
-    -- TODO(echasnovski): Change this when there is lockfile.
-    if names ~= nil or p_data.active then
-      plugs[#plugs + 1] = new_plug(p_data.spec, plug_dir)
-    end
+    plugs[#plugs + 1] = new_plug(p_data.spec, plug_dir)
   end
-
   return plugs
 end
 
@@ -975,7 +968,7 @@ end
 ---
 --- @param names? string[] List of plugin names to update. Must be managed
 --- by |vim.pack|, not necessarily already added to current session.
---- Default: names of all plugins added to current session via |vim.pack.add()|.
+--- Default: names of all plugins managed by |vim.pack|.
 --- @param opts? vim.pack.keyset.update
 function M.update(names, opts)
   vim.validate('names', names, vim.islist, true, 'list')

--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -18,7 +18,8 @@
 ---located at `$XDG_CONFIG_HOME/nvim/nvim-pack-lock.json`. It is a JSON file that
 ---is used to persistently track data about plugins.
 ---For a more robust config treat lockfile like its part: put under version control, etc.
----Should not be edited by hand or deleted.
+---In this case initial install prefers revision from the lockfile instead of
+---inferring from `version`. Should not be edited by hand or deleted.
 ---
 ---Example workflows ~
 ---
@@ -56,7 +57,8 @@
 ---```
 ---
 ---- Restart Nvim (for example, with |:restart|). Plugins that were not yet
----installed will be available on disk in target state after `add()` call.
+---installed will be available on disk after `add()` call. Their revision is
+---taken from |vim.pack-lockfile| (if present) or inferred from the `version`.
 ---
 ---- To update all plugins with new changes:
 ---    - Execute |vim.pack.update()|. This will download updates from source and
@@ -624,6 +626,9 @@ local function install_list(plug_list, confirm)
     p.info.installed = true
 
     plugin_lock.plugins[p.spec.name].src = p.spec.src
+
+    -- Prefer revision from the lockfile instead of using `version`
+    p.info.sha_target = (plugin_lock.plugins[p.spec.name] or {}).rev
 
     -- Do not skip checkout even if HEAD and target have same commit hash to
     -- have new repo in expected detached HEAD state and generated help files.

--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -686,9 +686,8 @@ describe('vim.pack', function()
         eq({}, n.exec_lua('return { vim.g._plugin, vim.g._after_plugin }'))
 
         -- Plugins should still be marked as "active", since they were added
-        plugindirs_data.active = true
-        basic_data.active = true
-        eq({ plugindirs_data, basic_data }, exec_lua('return vim.pack.get(nil, { info = false })'))
+        eq(true, exec_lua('return vim.pack.get({ "plugindirs" })[1].active'))
+        eq(true, exec_lua('return vim.pack.get({ "basic" })[1].active'))
       end
 
       -- Works on initial install
@@ -1352,10 +1351,10 @@ describe('vim.pack', function()
     local make_basic_data = function(active, info)
       local spec = { name = 'basic', src = repos_src.basic, version = 'feat-branch' }
       local path = pack_get_plug_path('basic')
-      local res = { active = active, path = path, spec = spec }
+      local rev = git_get_hash('feat-branch', 'basic')
+      local res = { active = active, path = path, spec = spec, rev = rev }
       if info then
         res.branches = { 'main', 'feat-branch' }
-        res.rev = git_get_hash('feat-branch', 'basic')
         res.tags = { 'some-tag' }
       end
       return res
@@ -1364,10 +1363,10 @@ describe('vim.pack', function()
     local make_defbranch_data = function(active, info)
       local spec = { name = 'defbranch', src = repos_src.defbranch }
       local path = pack_get_plug_path('defbranch')
-      local res = { active = active, path = path, spec = spec }
+      local rev = git_get_hash('dev', 'defbranch')
+      local res = { active = active, path = path, spec = spec, rev = rev }
       if info then
         res.branches = { 'dev', 'main' }
-        res.rev = git_get_hash('dev', 'defbranch')
         res.tags = {}
       end
       return res


### PR DESCRIPTION
This PR adds initial lockfile support to `vim.pack`. Resolves #34776.

TL;DR (more details are in commit messages):

- Add tracking of relevant data via on disk file. It is located at '$XDG_CONFIG_HOME/nvim/nvim-pack.lock' and is recommended to be put under version control (as the rest of the config). **Edit**: it was decided to go with 'nvim-pack-lock.json' as a name.

    The file is read exactly once during an active session (for performance) and is updated (both in memory and on disk) only when needed.

- Update several functions to use lockfile internally:
    - `get()` takes `version` of non-active plugin from lockfile.
    - `get()` always returns plugin's `rev` regardless of `opts.info` (as it now doesn't need Git CLI call).
    - `update()` now updates all plugins by default, even non-active (because their `version` is now known).

- Prefer using revision from lockfile when installing a plugin, instead of pulling latest according to `version`. This seems to be the most expected side effect of present lockfile.

Notes:

- **Important**. The lockfile name is 'nvim-pack.lock', which doesn't make it immediately obvious that it is a JSON file. It will be detected like one within Neovim, but not outside. Since the file needs to contain 'nvim-pack' and 'lock' somewhere in its name, I decided to go with current name. The alternative is 'nvim-pack-lock.json', but it might be too verbose. If it is deemed not, I'd rather go with it. So this requires executive decision.

- The current implementation should work reliably when `vim.pack` is used as expected, but *might* be a bit brittle when it comes to unexpected situations. For example:

    - Lockfile is manually edited or deleted entirely. It is explicitly documented to not do that. To further mitigate that, I plan to add `:checkhealth` support for lockfile also (#34777) which will contain suggestions on how to fix situations.
    - There is an error in between state change and lockfile write. This doesn't seem likely based on the code, but not 100% sure.
    - There are several Neovim instances that try to write to the same lockfile. Not sure how to mitigate this without much complications. I guess just saying "please don't do that" should be enough.

- This PR does not contain all planned usages of lockfile data. I also plan to update `vim.pack.add()` to perform extra actions (#34771 and maybe ensuring installation of all plugins from lockfile), but those will probably require more discussions and this PR is already big enough.

**Edit**: Several hours after posting I realized that I made a demo and forgot to post here :facepalm: Here it is:

https://github.com/user-attachments/assets/58815610-16e4-4be0-a562-344953b61370