### PR TITLE
vim-patch: Autoconf M4 syntax updates

### DIFF
--- a/runtime/syntax/config.vim
+++ b/runtime/syntax/config.vim
@@ -1,10 +1,11 @@
 " Vim syntax file
-" Language:		configure.in script: M4 with sh
+" Language:		Autoconf M4
 " Former Maintainer:	Christian Hammesr <ch@lathspell.westend.com>
 " Last Change:	2018 Feb 03
 " 				(patch from Yngve Inntjore Levinsen to detect AC_MSG)
 " 				(patch from Khym Chanur to add @Spell)
 " 				(patch from James McCoy to fix paren matching)
+" 				(2025 Sep 14 patch from Damien Lejay to detect unportable +=)
 
 " Well, I actually even do not know much about m4. This explains why there
 " is probably very much missing here, yet !
@@ -34,6 +35,9 @@ syn region  configstring    start=+\z(["'`]\)+ skip=+\\\z1+ end=+\z1+ contains=@
 syn region  configmsg matchgroup=configfunction start="AC_MSG_[A-Z]*\ze(\[" matchgroup=configdelimiter end="\])" contains=configdelimiter,@Spell
 syn region  configmsg matchgroup=configfunction start="AC_MSG_[A-Z]*\ze([^[]" matchgroup=configdelimiter end=")" contains=configdelimiter,@Spell
 
+" Help write portable shell code
+syn match acPlusEq '\v\+\=' containedin=ALLBUT,configcomment
+
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet
 
@@ -47,6 +51,7 @@ hi def link configkeyword   Keyword
 hi def link configspecial   Special
 hi def link configstring    String
 hi def link configmsg       String
+hi def link acPlusEq        Error
 
 
 let b:current_syntax = "config"

--- a/runtime/syntax/config.vim
+++ b/runtime/syntax/config.vim
@@ -6,6 +6,7 @@
 " 				(patch from Khym Chanur to add @Spell)
 " 				(patch from James McCoy to fix paren matching)
 " 				(2025 Sep 14 patch from Damien Lejay to detect unportable +=)
+" 				(2025 Sep 18 by Vim Project: fix inconsistent group name)
 
 " Well, I actually even do not know much about m4. This explains why there
 " is probably very much missing here, yet !
@@ -36,7 +37,7 @@ syn region  configmsg matchgroup=configfunction start="AC_MSG_[A-Z]*\ze(\[" matc
 syn region  configmsg matchgroup=configfunction start="AC_MSG_[A-Z]*\ze([^[]" matchgroup=configdelimiter end=")" contains=configdelimiter,@Spell
 
 " Help write portable shell code
-syn match acPlusEq '\v\+\=' containedin=ALLBUT,configcomment
+syn match configPlusEq '\v\+\=' containedin=ALLBUT,configcomment
 
 " Define the default highlighting.
 " Only when an item doesn't have highlighting yet
@@ -51,7 +52,7 @@ hi def link configkeyword   Keyword
 hi def link configspecial   Special
 hi def link configstring    String
 hi def link configmsg       String
-hi def link acPlusEq        Error
+hi def link configPlusEq    Error
 
 
 let b:current_syntax = "config"


### PR DESCRIPTION
#### vim-patch:1e7a288: runtime(config): mark unportable += as an error

closes: vim/vim#18292

https://github.com/vim/vim/commit/1e7a288cd3e522d70ad857a0a4d0ea7797f73bae

Co-authored-by: Damien Lejay <damien@lejay.be>


#### vim-patch:e8b0e92: runtime(config): fix inconsistent group name

related: vim/vim#18292

https://github.com/vim/vim/commit/e8b0e926d02d148d0bc785db7a6184d3844ceaaf
