### PR TITLE
vim-patch:9.1.{1621,1771}

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -422,16 +422,16 @@ bool cmdline_pum_active(void)
 }
 
 /// Remove the cmdline completion popup menu (if present), free the list of items.
-void cmdline_pum_remove(void)
+void cmdline_pum_remove(bool defer_redraw)
 {
-  pum_undisplay(true);
+  pum_undisplay(!defer_redraw);
   XFREE_CLEAR(compl_match_array);
   compl_match_arraysize = 0;
 }
 
 void cmdline_pum_cleanup(CmdlineInfo *cclp)
 {
-  cmdline_pum_remove();
+  cmdline_pum_remove(false);
   wildmenu_cleanup(cclp);
 }
 
@@ -936,7 +936,7 @@ char *ExpandOne(expand_T *xp, char *str, char *orig, int options, int mode)
 
     // The entries from xp_files may be used in the PUM, remove it.
     if (compl_match_array != NULL) {
-      cmdline_pum_remove();
+      cmdline_pum_remove(false);
     }
   }
   xp->xp_selected = (options & WILD_NOSELECT) ? -1 : 0;

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -1241,10 +1241,11 @@ static int command_line_wildchar_complete(CommandLineState *s)
   return (res == OK) ? CMDLINE_CHANGED : CMDLINE_NOT_CHANGED;
 }
 
-static void command_line_end_wildmenu(CommandLineState *s)
+static void command_line_end_wildmenu(CommandLineState *s, bool key_is_wc)
 {
   if (cmdline_pum_active()) {
-    s->skip_pum_redraw = (s->skip_pum_redraw
+    s->skip_pum_redraw = (s->skip_pum_redraw && !key_is_wc
+                          && !ascii_iswhite(s->c)
                           && (vim_isprintc(s->c)
                               || s->c == K_BS || s->c == Ctrl_H || s->c == K_DEL
                               || s->c == K_KDEL || s->c == Ctrl_W || s->c == Ctrl_U));
@@ -1301,7 +1302,7 @@ static int command_line_execute(VimState *state, int key)
         nextwild(&s->xpc, WILD_PUM_WANT, 0, s->firstc != '@');
         if (pum_want.finish) {
           nextwild(&s->xpc, WILD_APPLY, WILD_NO_BEEP, s->firstc != '@');
-          command_line_end_wildmenu(s);
+          command_line_end_wildmenu(s, false);
         }
       }
       pum_want.active = false;
@@ -1408,7 +1409,7 @@ static int command_line_execute(VimState *state, int key)
 
   // free expanded names when finished walking through matches
   if (end_wildmenu) {
-    command_line_end_wildmenu(s);
+    command_line_end_wildmenu(s, key_is_wc);
   }
 
   if (p_wmnu) {

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -5189,12 +5189,14 @@ static void ins_compl_show_filename(void)
       MB_PTR_ADV(s);
     }
   }
-  msg_hist_off = true;
-  vim_snprintf(IObuff, IOSIZE, "%s %s%s", lead,
-               s > compl_shown_match->cp_fname ? "<" : "", s);
-  msg(IObuff, 0);
-  msg_hist_off = false;
-  redraw_cmdline = false;  // don't overwrite!
+  if (!compl_autocomplete) {
+    msg_hist_off = true;
+    vim_snprintf(IObuff, IOSIZE, "%s %s%s", lead,
+                 s > compl_shown_match->cp_fname ? "<" : "", s);
+    msg(IObuff, 0);
+    msg_hist_off = false;
+    redraw_cmdline = false;  // don't overwrite!
+  }
 }
 
 /// Find the appropriate completion item when 'complete' ('cpt') includes

--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -627,6 +627,35 @@ describe('cmdline', function()
 
     feed('<Esc>')
   end)
+
+  -- oldtest: Test_update_screen_after_wildtrigger()
+  it('pum is dismissed after wildtrigger() and whitespace', function()
+    local screen = Screen.new(40, 10)
+    exec([[
+      set wildmode=noselect:lastused,full wildmenu wildoptions=pum
+      autocmd CmdlineChanged : if getcmdcompltype() != 'shellcmd' | call wildtrigger() | endif
+    ]])
+
+    feed(':term')
+    screen:expect([[
+                                              |
+      {1:~                                       }|*7
+      {4: terminal       }{1:                        }|
+      :term^                                   |
+    ]])
+    feed(' ')
+    screen:expect([[
+                                              |
+      {1:~                                       }|*8
+      :term ^                                  |
+    ]])
+    feed('foo')
+    screen:expect([[
+                                              |
+      {1:~                                       }|*8
+      :term foo^                               |
+    ]])
+  end)
 end)
 
 describe('cmdwin', function()

--- a/test/functional/legacy/cmdline_spec.lua
+++ b/test/functional/legacy/cmdline_spec.lua
@@ -531,6 +531,62 @@ describe('cmdline', function()
     ]])
   end)
 
+  -- oldtest: Test_wildtrigger_update_screen()
+  it('pum by wildtrigger() avoids flicker', function()
+    local screen = Screen.new(40, 10)
+    exec([[
+      command! -nargs=* -complete=customlist,TestFn TestCmd echo
+      func TestFn(cmdarg, b, c)
+        if a:cmdarg == 'ax'
+          return []
+        else
+          return map(range(1, 5), 'printf("abc%d", v:val)')
+        endif
+      endfunc
+      set wildmode=noselect,full
+      set wildoptions=pum
+      set wildmenu
+      cnoremap <F8> <C-R>=wildtrigger()[-1]<CR>
+    ]])
+
+    feed(':TestCmd a<F8>')
+    screen:expect([[
+                                              |
+      {1:~                                       }|*3
+      {1:~       }{4: abc1           }{1:                }|
+      {1:~       }{4: abc2           }{1:                }|
+      {1:~       }{4: abc3           }{1:                }|
+      {1:~       }{4: abc4           }{1:                }|
+      {1:~       }{4: abc5           }{1:                }|
+      :TestCmd a^                              |
+    ]])
+
+    -- Typing a character when pum is open does not close the pum window
+    -- This is needed to prevent pum window from flickering during
+    -- ':h cmdline-autocompletion'.
+    feed('x')
+    screen:expect([[
+                                              |
+      {1:~                                       }|*3
+      {1:~       }{4: abc1           }{1:                }|
+      {1:~       }{4: abc2           }{1:                }|
+      {1:~       }{4: abc3           }{1:                }|
+      {1:~       }{4: abc4           }{1:                }|
+      {1:~       }{4: abc5           }{1:                }|
+      :TestCmd ax^                             |
+    ]])
+
+    -- pum window is closed when no completion candidates are available
+    feed('<F8>')
+    screen:expect([[
+                                              |
+      {1:~                                       }|*8
+      :TestCmd ax^                             |
+    ]])
+
+    feed('<esc>')
+  end)
+
   -- oldtest: Test_long_line_noselect()
   it("long line is shown properly with noselect in 'wildmode'", function()
     local screen = Screen.new(60, 8)

--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -5053,4 +5053,23 @@ func Test_skip_wildtrigger_hist_navigation()
   cunmap <Down>
 endfunc
 
+" Issue 18298: wildmenu should be dismissed after wildtrigger and whitespace
+func Test_update_screen_after_wildtrigger()
+  CheckScreendump
+  let lines =<< trim [SCRIPT]
+    call test_override("char_avail", 1)
+    set wildmode=noselect:lastused,full wildmenu wildoptions=pum
+    autocmd CmdlineChanged : if getcmdcompltype() != 'shellcmd' | call wildtrigger() | endif
+  [SCRIPT]
+  call writefile(lines, 'XTest_wildtrigger', 'D')
+  let buf = RunVimInTerminal('-S XTest_wildtrigger', {'rows': 10})
+
+  call term_sendkeys(buf, ":term foo")
+  call TermWait(buf, 50)
+  call VerifyScreenDump(buf, 'Test_update_screen_wildtrigger_1', {})
+
+  call term_sendkeys(buf, "\<esc>")
+  call StopVimInTerminal(buf)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -5359,7 +5359,7 @@ func Test_autocomplete_trigger()
   call feedkeys("Sazx\<Left>\<BS>\<F2>\<Esc>0", 'tx!')
   call assert_equal(['and', 'afoo'], b:matches->mapnew('v:val.word'))
 
-  " Test 6: <BS> should clear the selected item
+  " Test 6: <BS> should clear the selected item (PR #18265)
   %d
   call setline(1, ["foobarfoo", "foobar", "foobarbaz"])
   call feedkeys("Gofo\<C-N>\<C-N>\<F2>\<F3>\<Esc>0", 'tx!')
@@ -5373,6 +5373,13 @@ func Test_autocomplete_trigger()
   call assert_equal(['foobarbaz', 'foobar', 'foobarfoo'], b:matches->mapnew('v:val.word'))
   call assert_equal(0, b:selected)
   call assert_equal('foobarbaz', getline(4))
+
+  " Test 7: Remove selection when menu contents change (PR #18265)
+  %d
+  call setline(1, ["foobar", "fodxyz", "fodabc"])
+  call feedkeys("Gofoo\<C-N>\<BS>\<BS>\<BS>\<BS>d\<F2>\<F3>\<Esc>0", 'tx!')
+  call assert_equal(['fodabc', 'fodxyz'], b:matches->mapnew('v:val.word'))
+  call assert_equal(-1, b:selected)
 
   bw!
   call Ntest_override("char_avail", 0)


### PR DESCRIPTION
#### vim-patch:9.1.1621: flicker in popup menu during cmdline autocompletion

Problem:  When the popup menu (PUM) occupies more than half the screen
          height, it flickers whenever a character is typed or erased.
          This happens because the PUM is cleared and the screen is
          redrawn before a new PUM is rendered. The extra redraw between
          menu updates causes visible flicker.
Solution: A complete, non-hacky fix would require removing the
          CmdlineChanged event from the loop and letting autocompletion
          manage the process end-to-end. This is because screen redraws
          after any cmdline change are necessary for other features to
          work.
          This change modifies wildtrigger() so that the next typed
          character defers the screen update instead of redrawing
          immediately. This removes the intermediate redraw, eliminating
          flicker and making cmdline autocompletion feel smooth
          (Girish Palya).

Trade-offs:
This behavior change in wildtrigger() is tailored specifically for
:h cmdline-autocompletion. wildtrigger() now has no general-purpose use
outside this scenario.

closes: vim/vim#17932

https://github.com/vim/vim/commit/da9c9668931e5c8ee4dc0e430898ad2d80f56862

Use pum_check_clear() instead of update_screen().
Cherry-pick Test_wildtrigger_update_screen() change from patch 9.1.1682.

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1771: complete: some redraw issues with 'autocomplete'

Problem:  complete: some redraw issues with 'autocomplete'
Solution: Fix the issues (Girish Palya)

This commit contains the following changes:
* Fix that wildtrigger() might leave opened popupmenu around vim/vim#18298
* Remove blinking message on the command line when a menu item from a loaded
  buffer is selected during 'autocomplete'
* Add a test for PR vim/vim#18265 to demonstrate why the PR is required for correct
  'autocomplete' behavior

closes: vim/vim#18328

https://github.com/vim/vim/commit/ee9a2f0512e8b732e3c6a000974aa7e3f6028989

Co-authored-by: Girish Palya <girishji@gmail.com>