### PR TITLE
vim-patch:9.1.1769: completion: "preinsert" insert wrong word with 'smartcase' and 'autocomplete'

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -5069,10 +5069,11 @@ static char *find_common_prefix(size_t *prefix_len, bool curbuf_only)
 
       if (!match_limit_exceeded
           && (!curbuf_only || cpt_sources_array[cur_source].cs_flag == '.')) {
-        if (first == NULL) {
+        if (first == NULL && strncmp(ins_compl_leader(), compl->cp_str.data,
+                                     ins_compl_leader_len()) == 0) {
           first = compl->cp_str.data;
           len = (int)strlen(first);
-        } else {
+        } else if (first != NULL) {
           int j = 0;  // count in bytes
           char *s1 = first;
           char *s2 = compl->cp_str.data;
@@ -5100,7 +5101,7 @@ static char *find_common_prefix(size_t *prefix_len, bool curbuf_only)
 
   xfree(match_count);
 
-  if (len > get_compl_len()) {
+  if (len > (int)ins_compl_leader_len()) {
     *prefix_len = (size_t)len;
     return first;
   }

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -5764,7 +5764,18 @@ func Test_autocomplete_completeopt_preinsert()
   call DoTest("f", 'f', 2)
   set cot-=fuzzy
 
+  " leader should match prefix of inserted word
+  %delete
+  set smartcase ignorecase
+  call setline(1, ["FOO"])
+  call feedkeys($"Gof\<F5>\<Esc>", 'tx')
+  call assert_equal('f', g:line)
+  call feedkeys($"SF\<F5>\<Esc>", 'tx')
+  call assert_equal('FOO', g:line)
+  set smartcase& ignorecase&
+
   " Verify that redo (dot) works
+  %delete
   call setline(1, ["foobar", "foozbar", "foobaz", "changed", "change"])
   call feedkeys($"/foo\<CR>", 'tx')
   call feedkeys($"cwch\<C-N>\<Esc>n.n.", 'tx')


### PR DESCRIPTION
#### vim-patch:9.1.1769: completion: "preinsert" insert wrong word with 'smartcase' and 'autocomplete'

Problem:  completion: "preinsert" insert wrong word with 'smartcase' and
          'autocomplete'
Solution: Add compare completed item with the leader (Girish Palya)

closes: vim/vim#18313

https://github.com/vim/vim/commit/a8f7957d0b5740983f9e48f5695fbeef0b9c76d6

Co-authored-by: Girish Palya <girishji@gmail.com>