### PR TITLE
fix: remove typo from buffer-local LSP docs

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -115,7 +115,7 @@ To remove or override BUFFER-LOCAL defaults, define a |LspAttach| handler: >lua
         -- Unmap K
         vim.keymap.del('n', 'K', { buffer = args.buf })
         -- Disable document colors
-        vim.lsp.buf.document_color.enable(false, args.buf)
+        vim.lsp.document_color.enable(false, args.buf)
       end,
     })
 <


### PR DESCRIPTION
Problem: example code refers to `vim.lsp.buf.document_color`, but there is no such thing.

Solution: replace `vim.lsp.buf.document_color` with `vim.lsp.document_color`.