### PR TITLE
feat(float): supports mouse drag move and resize

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3977,6 +3977,18 @@ nvim_open_win({buf}, {enter}, {config})                      *nvim_open_win()*
                     • If false, mouse events pass through this window.
                     • If true, mouse events interact with this window
                       normally.
+                  • mousedrag: Table controlling mouse drag interactions with
+                    the window, with fields:
+                    • title: (boolean) When true, dragging the title or footer
+                      text moves the window. Default false.
+                    • content: (boolean) When true, dragging the content area
+                      moves the window. Default false.
+                    • border: (`"none"|"move"|"resize"`) Behavior when
+                      dragging the border or corners. "resize" resizes the
+                      window, "move" moves it, "none" (default) ignores border
+                      drags. Has no effect without a border. Dragging a
+                      non-editor-relative float converts it to
+                      editor-relative.
                   • noautocmd: Block all autocommands for the duration of the
                     call. Cannot be changed by |nvim_win_set_config()|.
                   • relative: Sets the window layout to "floating", placed at

--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3990,6 +3990,15 @@ nvim_open_win({buf}, {enter}, {config})                      *nvim_open_win()*
                   • mouse: (default: `focusable` value) If true, mouse events
                     interact with the window normally; if false, they pass
                     through to the window behind it.
+                  • mousedrag: (`table?`) What the mouse can drag the window
+                    by. Only the given fields are changed. A drag makes the
+                    window editor-relative and NW-anchored.
+                    • title: (default: false) Drag the title or footer text to
+                      move the window.
+                    • content: (default: false) Drag the text area to move the
+                      window. Dragging there no longer selects text.
+                    • border: (default: false) Drag the border or a corner to
+                      resize the window.
                   • noautocmd: Block all autocommands for the duration of the
                     call. Cannot be changed by |nvim_win_set_config()|.
                   • relative: Sets the window layout to "floating", placed at

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -159,6 +159,8 @@ API
 • |nvim_set_option_value()| accepts a new `operation` field to modify the
   existing option value.
 • |nvim_set_option_value()| returns the new option value.
+• |nvim_open_win()| added a "mousedrag" option for mouse-driven moving and
+  resizing of floating windows.
 
 BUILD
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -215,6 +215,8 @@ API
 • |nvim_set_option_value()| returns the new option value.
 • |nvim_create_autocmd()| is now |api-fast|, so it can be called from a fast
   event context (e.g. |vim.uv| callbacks).
+• |nvim_open_win()| added a "mousedrag" option for mouse-driven moving and
+  resizing of floating windows.
 
 BUILD
 

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -1826,6 +1826,16 @@ function vim.api.nvim_open_term(buf, opts) end
 ---     Defaults to `focusable` value.
 ---     - If false, mouse events pass through this window.
 ---     - If true, mouse events interact with this window normally.
+--- - mousedrag: Table controlling mouse drag interactions with the window,
+---     with fields:
+---     - title: (boolean) When true, dragging the title or footer text moves
+---       the window. Default false.
+---     - content: (boolean) When true, dragging the content area moves the
+---       window. Default false.
+---     - border: (`"none"`"move"`"resize"`) Behavior when dragging the border
+---       or corners. "resize" resizes the window, "move" moves it, "none"
+---       (default) ignores border drags. Has no effect without a border.
+---     Dragging a non-editor-relative float converts it to editor-relative.
 --- - noautocmd: Block all autocommands for the duration of the call. Cannot be changed by
 ---   `nvim_win_set_config()`.
 --- - relative: Sets the window layout to "floating", placed at (row,col)

--- a/runtime/lua/vim/_meta/api.gen.lua
+++ b/runtime/lua/vim/_meta/api.gen.lua
@@ -1818,6 +1818,12 @@ function vim.api.nvim_open_term(buf, opts) end
 --- - hide: Hides the floating window. `window-hidden`
 --- - mouse: (default: `focusable` value) If true, mouse events interact with the window
 ---   normally; if false, they pass through to the window behind it.
+--- - mousedrag: (`table?`) What the mouse can drag the window by. Only the given fields are
+---   changed. A drag makes the window editor-relative and NW-anchored.
+---   - title: (default: false) Drag the title or footer text to move the window.
+---   - content: (default: false) Drag the text area to move the window. Dragging there
+---     no longer selects text.
+---   - border: (default: false) Drag the border or a corner to resize the window.
 --- - noautocmd: Block all autocommands for the duration of the call. Cannot be changed by
 ---   `nvim_win_set_config()`.
 --- - relative: Sets the window layout to "floating", placed at (row,col) coordinates relative to:

--- a/runtime/lua/vim/_meta/api_keysets.gen.lua
+++ b/runtime/lua/vim/_meta/api_keysets.gen.lua
@@ -483,6 +483,7 @@ error('Cannot require a meta file')
 --- @field height? integer
 --- @field hide? boolean
 --- @field mouse? boolean
+--- @field mousedrag? vim.api.keyset.win_config_mousedrag
 --- @field noautocmd? boolean
 --- @field relative? "cursor"|"editor"|"laststatus"|"mouse"|"tabline"|"win"
 --- @field row? number
@@ -495,6 +496,11 @@ error('Cannot require a meta file')
 --- @field win? integer
 --- @field zindex? integer
 --- @field _cmdline_offset? integer
+
+--- @class vim.api.keyset.win_config_mousedrag
+--- @field border? "none"|"move"|"resize"
+--- @field content? boolean
+--- @field title? boolean
 
 --- @class vim.api.keyset.win_resize
 --- @field anchor? string

--- a/runtime/lua/vim/_meta/api_keysets.gen.lua
+++ b/runtime/lua/vim/_meta/api_keysets.gen.lua
@@ -486,6 +486,7 @@ error('Cannot require a meta file')
 --- @field height? integer
 --- @field hide? boolean
 --- @field mouse? boolean
+--- @field mousedrag? vim.api.keyset.win_config_mousedrag
 --- @field noautocmd? boolean
 --- @field relative? "cursor"|"editor"|"laststatus"|"mouse"|"tabline"|"win"
 --- @field row? number
@@ -498,6 +499,11 @@ error('Cannot require a meta file')
 --- @field win? integer
 --- @field zindex? integer
 --- @field _cmdline_offset? integer
+
+--- @class vim.api.keyset.win_config_mousedrag
+--- @field border? boolean
+--- @field content? boolean
+--- @field title? boolean
 
 --- @class vim.api.keyset.win_resize
 --- @field anchor? string

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -115,6 +115,13 @@ typedef struct {
 } Dict(user_command);
 
 typedef struct {
+  OptionalKeys is_set__win_config_mousedrag_;
+  Boolean title;
+  Enum("none", "move", "resize") border;
+  Boolean content;
+} Dict(win_config_mousedrag);
+
+typedef struct {
   OptionalKeys is_set__win_config_;
   Boolean external;
   Boolean fixed;
@@ -140,6 +147,7 @@ typedef struct {
   Object title;
   Enum("center", "left", "right") title_pos;
   Integer _cmdline_offset;
+  DictAs(win_config_mousedrag) mousedrag;
 } Dict(win_config);
 
 typedef struct {

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -120,6 +120,13 @@ typedef struct {
 } Dict(user_command);
 
 typedef struct {
+  OptionalKeys is_set__win_config_mousedrag_;
+  Boolean title;
+  Boolean border;
+  Boolean content;
+} Dict(win_config_mousedrag);
+
+typedef struct {
   OptionalKeys is_set__win_config_;
   Boolean external;
   Boolean fixed;
@@ -145,6 +152,7 @@ typedef struct {
   Object title;
   Enum("center", "left", "right") title_pos;
   Integer _cmdline_offset;
+  DictAs(win_config_mousedrag) mousedrag;
 } Dict(win_config);
 
 typedef struct {

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -151,6 +151,16 @@
 ///       Defaults to `focusable` value.
 ///       - If false, mouse events pass through this window.
 ///       - If true, mouse events interact with this window normally.
+///   - mousedrag: Table controlling mouse drag interactions with the window,
+///       with fields:
+///       - title: (boolean) When true, dragging the title or footer text moves
+///         the window. Default false.
+///       - content: (boolean) When true, dragging the content area moves the
+///         window. Default false.
+///       - border: (`"none"|"move"|"resize"`) Behavior when dragging the border
+///         or corners. "resize" resizes the window, "move" moves it, "none"
+///         (default) ignores border drags. Has no effect without a border.
+///       Dragging a non-editor-relative float converts it to editor-relative.
 ///   - noautocmd: Block all autocommands for the duration of the call. Cannot be changed by
 ///     |nvim_win_set_config()|.
 ///   - relative: Sets the window layout to "floating", placed at (row,col)
@@ -871,6 +881,17 @@ Dict(win_config) nvim_win_get_config(Window win, Arena *arena, Error *err)
   PUT_KEY_X(rv, mouse, config->mouse);
   PUT_KEY_X(rv, style, cstr_as_string(win_style_str[config->style]));
 
+  Dict mousedrag = arena_dict(arena, 3);
+  PUT_C(mousedrag, "title", BOOLEAN_OBJ(config->mousedrag_title));
+  PUT_C(mousedrag, "content", BOOLEAN_OBJ(config->mousedrag_content));
+  const char *border_str = config->mousedrag_border == kMouseDragBorderMove ? "move"
+                                                                            : config->
+                           mousedrag_border == kMouseDragBorderResize ? "resize"
+                                                                      :
+                           "none";
+  PUT_C(mousedrag, "border", CSTR_AS_OBJ(border_str));
+  PUT_KEY_X(rv, mousedrag, mousedrag);
+
   if (wp->w_floating) {
     PUT_KEY_X(rv, width, config->width);
     PUT_KEY_X(rv, height, config->height);
@@ -1502,6 +1523,28 @@ static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fco
     fconfig->_cmdline_offset = (int)config->_cmdline_offset;
   }
 
+  if (HAS_KEY_X(config, mousedrag)) {
+    Dict(win_config_mousedrag) md[1] = KEYDICT_INIT;
+    if (!api_dict_to_keydict(md, DictHash(win_config_mousedrag), config->mousedrag, err)) {
+      return false;
+    }
+    if (HAS_KEY(md, win_config_mousedrag, title)) {
+      fconfig->mousedrag_title = md->title;
+    }
+    if (HAS_KEY(md, win_config_mousedrag, border)) {
+      String s = md->border;
+      if (s.size == 0 || strequal(s.data, "none")) {
+        fconfig->mousedrag_border = kMouseDragBorderNone;
+      } else if (strequal(s.data, "move")) {
+        fconfig->mousedrag_border = kMouseDragBorderMove;
+      } else if (strequal(s.data, "resize")) {
+        fconfig->mousedrag_border = kMouseDragBorderResize;
+      }
+    }
+    if (HAS_KEY(md, win_config_mousedrag, content)) {
+      fconfig->mousedrag_content = md->content;
+    }
+  }
   return true;
 
 fail:

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -147,6 +147,12 @@
 ///   - hide: Hides the floating window. |window-hidden|
 ///   - mouse: (default: `focusable` value) If true, mouse events interact with the window
 ///     normally; if false, they pass through to the window behind it.
+///   - mousedrag: (`table?`) What the mouse can drag the window by. Only the given fields are
+///     changed. A drag makes the window editor-relative and NW-anchored.
+///     - title: (default: false) Drag the title or footer text to move the window.
+///     - content: (default: false) Drag the text area to move the window. Dragging there
+///       no longer selects text.
+///     - border: (default: false) Drag the border or a corner to resize the window.
 ///   - noautocmd: Block all autocommands for the duration of the call. Cannot be changed by
 ///     |nvim_win_set_config()|.
 ///   - relative: Sets the window layout to "floating", placed at (row,col) coordinates relative to:
@@ -866,6 +872,12 @@ Dict(win_config) nvim_win_get_config(Window win, Arena *arena, Error *err)
   PUT_KEY_X(rv, mouse, config->mouse);
   PUT_KEY_X(rv, style, cstr_as_string(win_style_str[config->style]));
 
+  Dict mousedrag = arena_dict(arena, 3);
+  PUT_C(mousedrag, "title", BOOLEAN_OBJ(config->mousedrag_title));
+  PUT_C(mousedrag, "content", BOOLEAN_OBJ(config->mousedrag_content));
+  PUT_C(mousedrag, "border", BOOLEAN_OBJ(config->mousedrag_border));
+  PUT_KEY_X(rv, mousedrag, mousedrag);
+
   if (wp->w_floating) {
     PUT_KEY_X(rv, width, config->width);
     PUT_KEY_X(rv, height, config->height);
@@ -1497,6 +1509,27 @@ static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fco
     fconfig->_cmdline_offset = (int)config->_cmdline_offset;
   }
 
+  if (HAS_KEY_X(config, mousedrag)) {
+    Dict(win_config_mousedrag) md[1] = KEYDICT_INIT;
+    if (!api_dict_to_keydict(md, DictHash(win_config_mousedrag), config->mousedrag, err)) {
+      goto fail;
+    }
+    if (HAS_KEY(md, win_config_mousedrag, title)) {
+      fconfig->mousedrag_title = md->title;
+    }
+    if (HAS_KEY(md, win_config_mousedrag, border)) {
+      fconfig->mousedrag_border = md->border;
+    }
+    if (HAS_KEY(md, win_config_mousedrag, content)) {
+      fconfig->mousedrag_content = md->content;
+    }
+
+    VALIDATE_CON(will_float || !(fconfig->mousedrag_title || fconfig->mousedrag_border
+                                 || fconfig->mousedrag_content),
+                 "mousedrag", "non-float window", {
+      goto fail;
+    });
+  }
   return true;
 
 fail:

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -995,6 +995,21 @@ typedef enum {
   kBorderTextFooter = 1,
 } BorderTextType;
 
+typedef enum {
+  kDragMove       = 0x01,
+  kDragTop        = 0x02,
+  kDragBot        = 0x04,
+  kDragLeft       = 0x08,
+  kDragRight      = 0x10,
+  kDragResizeMask = 0x1e,  // Top|Bot|Left|Right
+} WinDragFlags;
+
+typedef enum {
+  kMouseDragBorderNone,
+  kMouseDragBorderMove,
+  kMouseDragBorderResize,
+} MouseDragBorder;
+
 /// See ":help nvim_open_win()" for documentation.
 typedef struct {
   Window window;
@@ -1026,6 +1041,9 @@ typedef struct {
   bool fixed;
   bool hide;
   int _cmdline_offset;
+  bool mousedrag_title;
+  MouseDragBorder mousedrag_border;
+  bool mousedrag_content;
 } WinConfig;
 
 #define WIN_CONFIG_INIT ((WinConfig){ .height = 0, .width = 0, \

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1000,6 +1000,15 @@ typedef enum {
   kBorderTextFooter = 1,
 } BorderTextType;
 
+typedef enum {
+  kDragMove       = 0x01,
+  kDragTop        = 0x02,
+  kDragBot        = 0x04,
+  kDragLeft       = 0x08,
+  kDragRight      = 0x10,
+  kDragContent    = 0x20,
+} WinDragFlags;
+
 /// See ":help nvim_open_win()" for documentation.
 typedef struct {
   Window window;
@@ -1031,6 +1040,9 @@ typedef struct {
   bool fixed;
   bool hide;
   int _cmdline_offset;
+  bool mousedrag_title;
+  bool mousedrag_border;
+  bool mousedrag_content;
 } WinConfig;
 
 #define WIN_CONFIG_INIT ((WinConfig){ .height = 0, .width = 0, \

--- a/src/nvim/grid.c
+++ b/src/nvim/grid.c
@@ -1124,7 +1124,7 @@ static void grid_draw_bordertext(VirtText vt, int col, int winbl, const int *hl_
   }
 }
 
-static int get_bordertext_col(int total_col, int text_width, AlignTextPos align)
+int get_bordertext_col(int total_col, int text_width, AlignTextPos align)
 {
   switch (align) {
   case kAlignLeft:

--- a/src/nvim/grid.c
+++ b/src/nvim/grid.c
@@ -1128,7 +1128,7 @@ static void grid_draw_bordertext(VirtText vt, int col, int winbl, const int *hl_
   }
 }
 
-static int get_bordertext_col(int total_col, int text_width, AlignTextPos align)
+int get_bordertext_col(int total_col, int text_width, AlignTextPos align)
 {
   switch (align) {
   case kAlignLeft:

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -53,6 +53,7 @@
 #include "nvim/ui_compositor.h"
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
+#include "nvim/winfloat.h"
 
 #include "mouse.c.generated.h"
 
@@ -685,6 +686,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, int count, bool fixindent)
   bool in_status_line = (jump_flags & IN_STATUS_LINE);
   bool in_global_statusline = in_status_line && global_stl_height() > 0;
   bool in_sep_line = (jump_flags & IN_SEP_LINE);
+  bool in_floatwin_edge = (jump_flags & MOUSE_FLOATWIN);
 
   if ((in_winbar || in_status_line || in_statuscol) && is_click) {
     // Handle click event on window bar, status line or status column
@@ -903,7 +905,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, int count, bool fixindent)
     } else {  // MOUSE_RIGHT
       stuffcharReadbuff('#');
     }
-  } else if (in_status_line || in_sep_line) {
+  } else if (in_status_line || in_sep_line || in_floatwin_edge) {
     // Do nothing if on status line or vertical separator
     // Handle double clicks otherwise
   } else if ((mod_mask & MOD_MASK_MULTI_CLICK) && (State & (MODE_NORMAL | MODE_INSERT))
@@ -1273,6 +1275,9 @@ int jump_to_mouse(int flags, bool *inclusive, int which_button)
   static int prev_row = -1;
   static int prev_col = -1;
   static int did_drag = false;          // drag was noticed
+  static int float_edge_type = 0;
+  static int float_mouse_col_offset = 0;
+  static int float_mouse_row_offset = 0;
 
   int count;
   bool first;
@@ -1293,6 +1298,9 @@ int jump_to_mouse(int flags, bool *inclusive, int which_button)
     }
     dragwin = NULL;
     did_drag = false;
+    float_edge_type = 0;
+    float_mouse_row_offset = 0;
+    float_mouse_col_offset = 0;
   }
 
   if ((flags & MOUSE_DID_MOVE)
@@ -1389,6 +1397,20 @@ retnomove:
       status_line_offset = 0;
     }
 
+    if (float_edge_type == 0 && wp->w_floating
+        && (wp->w_config.mousedrag_title
+            || wp->w_config.mousedrag_border != kMouseDragBorderNone
+            || wp->w_config.mousedrag_content)) {
+      float_edge_type = win_float_drag_at(wp, mouse_row, mouse_col);
+      if (float_edge_type > 0) {
+        float_mouse_col_offset = mouse_col - wp->w_wincol;
+        float_mouse_row_offset = mouse_row - wp->w_winrow;
+        if (float_edge_type != kDragMove) {
+          dragwin = wp;
+        }
+      }
+    }
+
     if (grid == DEFAULT_GRID_HANDLE && col >= wp->w_width) {
       // In separator line
       sep_line_offset = col - wp->w_width + 1;
@@ -1445,6 +1467,10 @@ retnomove:
       return IN_SEP_LINE | CURSOR_MOVED;
     }
 
+    if (float_edge_type > 0 && float_edge_type != kDragMove) {
+      return MOUSE_FLOATWIN;
+    }
+
     curwin->w_cursor.lnum = curwin->w_topline;
   } else if (status_line_offset) {
     if (which_button == MOUSE_LEFT && dragwin != NULL) {
@@ -1472,6 +1498,16 @@ retnomove:
   } else if (on_statuscol && which_button == MOUSE_RIGHT) {
     // After a click on the status column don't start Visual mode.
     return IN_OTHER_WIN | MOUSE_STATUSCOL;
+  } else if (float_edge_type && which_button == MOUSE_LEFT) {
+    if (dragwin == NULL && curwin->w_floating) {
+      dragwin = curwin;
+    }
+    if (dragwin != NULL) {
+      win_float_drag(dragwin, float_edge_type, mouse_row, mouse_col,
+                     float_mouse_row_offset, float_mouse_col_offset);
+      did_drag = true;
+    }
+    return MOUSE_FLOATWIN;
   } else {
     // keep_window_focus must be true
     // before moving the cursor for a left click, stop Visual mode

--- a/src/nvim/mouse.c
+++ b/src/nvim/mouse.c
@@ -53,6 +53,7 @@
 #include "nvim/ui_compositor.h"
 #include "nvim/vim_defs.h"
 #include "nvim/window.h"
+#include "nvim/winfloat.h"
 
 #include "mouse.c.generated.h"
 
@@ -685,6 +686,7 @@ bool do_mouse(oparg_T *oap, int c, int dir, int count, bool fixindent)
   bool in_status_line = (jump_flags & IN_STATUS_LINE);
   bool in_global_statusline = in_status_line && global_stl_height() > 0;
   bool in_sep_line = (jump_flags & IN_SEP_LINE);
+  bool in_floatwin_edge = (jump_flags & MOUSE_FLOATWIN);
 
   if ((in_winbar || in_status_line || in_statuscol) && is_click) {
     // Handle click event on window bar, status line or status column
@@ -744,8 +746,8 @@ bool do_mouse(oparg_T *oap, int c, int dir, int count, bool fixindent)
       }
     }
     return false;
-  } else if (in_winbar || in_statuscol) {
-    // A drag or release event in the window bar and status column has no side effects.
+  } else if (in_winbar || in_statuscol || in_floatwin_edge) {
+    // A drag or release event in the window bar, status column, or float edge has no side effects.
     return false;
   }
 
@@ -1228,11 +1230,27 @@ static bool mouse_model_popup(void)
 }
 
 static win_T *dragwin = NULL;  ///< window being dragged
+static int float_drag_action = 0;   ///< WinDragFlags for the gesture in progress
 
 /// Reset the window being dragged.  To be called when switching tab page.
 void reset_dragwin(void)
 {
   dragwin = NULL;
+  float_drag_action = 0;
+}
+
+/// Mouse position in screen coordinates.  ext_multigrid reports it per grid.
+static void mouse_screen_pos(int *rowp, int *colp)
+{
+  *rowp = mouse_row;
+  *colp = mouse_col;
+  if (mouse_grid > 1) {
+    win_T *wp = get_win_by_grid_handle(mouse_grid);
+    if (wp != NULL) {
+      *rowp += wp->w_grid_alloc.comp_row;
+      *colp += wp->w_grid_alloc.comp_col;
+    }
+  }
 }
 
 /// Move the cursor to the specified row and column on the screen.
@@ -1266,6 +1284,8 @@ int jump_to_mouse(int flags, bool *inclusive, int which_button)
 {
   static int status_line_offset = 0;        // #lines offset from status line
   static int sep_line_offset = 0;           // #cols offset from sep line
+  static int float_drag_row_offset = 0;     // #lines offset from the float's top
+  static int float_drag_col_offset = 0;     // #cols offset from the float's left
   static bool on_status_line = false;
   static bool on_sep_line = false;
   static bool on_winbar = false;
@@ -1295,9 +1315,9 @@ int jump_to_mouse(int flags, bool *inclusive, int which_button)
     did_drag = false;
   }
 
-  if ((flags & MOUSE_DID_MOVE)
-      && prev_row == mouse_row
-      && prev_col == mouse_col) {
+  // A dragged float follows the mouse, so mouse_row doesn't change with it.
+  if ((flags & MOUSE_DID_MOVE) && !float_drag_action
+      && prev_row == mouse_row && prev_col == mouse_col) {
 retnomove:
     // before moving the cursor for a left click which is NOT in a status
     // line, stop Visual mode
@@ -1369,6 +1389,35 @@ retnomove:
   win_T *old_curwin = curwin;
   pos_T old_cursor = curwin->w_cursor;
   if (!keep_focus) {
+    // Must be before the returns below, a stale offset can reach a float.
+    dragwin = NULL;
+    status_line_offset = 0;
+    sep_line_offset = 0;
+    float_drag_action = 0;
+
+    if (which_button == MOUSE_LEFT && wp->w_floating
+        && (wp->w_config.mousedrag_title
+            || wp->w_config.mousedrag_border
+            || wp->w_config.mousedrag_content)) {
+      int srow, scol;
+      mouse_screen_pos(&srow, &scol);
+      float_drag_action = win_float_drag_action(wp, srow, scol);
+      // A winbar or 'statuscolumn' keeps its own clicks; the border wins.
+      if ((float_drag_action & kDragContent) && (on_winbar || on_statuscol)) {
+        float_drag_action = 0;
+      }
+      if (float_drag_action) {
+        float_drag_row_offset = srow - wp->w_winrow;
+        float_drag_col_offset = scol - wp->w_wincol;
+      }
+    }
+
+    // A handle, not a click: don't enter the window, don't move the cursor.
+    if (float_drag_action && !(float_drag_action & kDragContent)) {
+      dragwin = wp;
+      return MOUSE_FLOATWIN;
+    }
+
     if (on_winbar) {
       return IN_OTHER_WIN | MOUSE_WINBAR;
     }
@@ -1378,7 +1427,6 @@ retnomove:
     }
 
     fdc = win_fdccol_count(wp);
-    dragwin = NULL;
 
     // winpos and height may change in win_enter()!
     if (below_window) {
@@ -1426,6 +1474,9 @@ retnomove:
     if (dragwin == NULL || (flags & MOUSE_RELEASED)) {
       win_enter(wp, true);                      // can make wp invalid!
     }
+    if (float_drag_action && win_valid(wp)) {
+      dragwin = wp;
+    }
     // set topline, to be able to check for double click ourselves
     if (curwin != old_curwin) {
       set_mouse_topline(curwin);
@@ -1472,6 +1523,19 @@ retnomove:
   } else if (on_statuscol && which_button == MOUSE_RIGHT) {
     // After a click on the status column don't start Visual mode.
     return IN_OTHER_WIN | MOUSE_STATUSCOL;
+  } else if (float_drag_action && which_button == MOUSE_LEFT) {
+    int srow, scol;
+    mouse_screen_pos(&srow, &scol);
+    if (flags & MOUSE_RELEASED) {
+      if (!(flags & MOUSE_FOCUS) && win_float_drag_action(wp, srow, scol)) {
+        win_enter(wp, true);
+      }
+      float_drag_action = 0;
+    } else if (win_valid(dragwin)) {
+      did_drag |= win_float_drag(dragwin, float_drag_action, srow, scol,
+                                 float_drag_row_offset, float_drag_col_offset);
+    }
+    return MOUSE_FLOATWIN;
   } else {
     // keep_window_focus must be true
     // before moving the cursor for a left click, stop Visual mode

--- a/src/nvim/mouse.h
+++ b/src/nvim/mouse.h
@@ -18,6 +18,7 @@ enum {
   MOUSE_FOLD_OPEN  = 0x400,   ///< clicked on '+' in fold column
   MOUSE_WINBAR     = 0x800,   ///< in window toolbar
   MOUSE_STATUSCOL  = 0x1000,  ///< in 'statuscolumn'
+  MOUSE_FLOATWIN   = 0x2000,  ///< in float window
 };
 
 /// flags for jump_to_mouse()

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -459,3 +459,119 @@ win_T *win_float_create_preview(bool enter, bool new_buf)
   }
   return wp;
 }
+
+static bool in_bordertext(win_T *wp, int rel_col, int width, AlignTextPos pos)
+{
+  int w = MIN(width, wp->w_width);
+  int start = wp->w_wincol_off + get_bordertext_col(wp->w_width, w, pos) - 1;
+  return rel_col >= start && rel_col < start + w;
+}
+
+/// Hit-test a screen position against a floating window's move/resize regions.
+/// @return 0, kDragMove, or a bitmask of kFloatDrag{Top,Bot,Left,Right}.
+int win_float_drag_at(win_T *wp, int row, int col)
+{
+  int rel_row = row - wp->w_winrow;
+  int rel_col = col - wp->w_wincol;
+  int outer_h = wp->w_height_outer;
+  int outer_w = wp->w_width_outer;
+  bool on_top = wp->w_border_adj[0] && rel_row == 0;
+  bool on_bot = wp->w_border_adj[2] && rel_row == outer_h - 1;
+  bool on_left = wp->w_border_adj[3] && rel_col == 0;
+  bool on_right = wp->w_border_adj[1] && rel_col == outer_w - 1;
+  bool on_border = on_top || on_bot || on_left || on_right;
+
+  if (!on_border) {
+    return wp->w_config.mousedrag_content ? kDragMove : 0;
+  }
+
+  // Title/footer text is a move handle when "title" is set.
+  if (wp->w_config.mousedrag_title) {
+    if (on_top && wp->w_config.title
+        && in_bordertext(wp, rel_col, wp->w_config.title_width, wp->w_config.title_pos)) {
+      return kDragMove;
+    }
+    if (on_bot && wp->w_config.footer
+        && in_bordertext(wp, rel_col, wp->w_config.footer_width, wp->w_config.footer_pos)) {
+      return kDragMove;
+    }
+  }
+
+  // The border proper: move handle, resize handle, or inert.
+  if (wp->w_config.mousedrag_border == kMouseDragBorderMove) {
+    return kDragMove;
+  }
+  if (wp->w_config.mousedrag_border == kMouseDragBorderResize) {
+    int hit = 0;
+    if (on_top) {
+      hit |= kDragTop;
+    }
+    if (on_bot) {
+      hit |= kDragBot;
+    }
+    if (on_left) {
+      hit |= kDragLeft;
+    }
+    if (on_right) {
+      hit |= kDragRight;
+    }
+    return hit;
+  }
+
+  if (wp->w_config.mousedrag_content) {
+    return kDragMove;
+  }
+  return 0;
+}
+
+/// Move or resize a floating window so the dragged point follows (row, col).
+void win_float_drag(win_T *wp, int edge, int row, int col, int row_off, int col_off)
+{
+  WinConfig new_config = wp->w_config;
+  FloatAnchor anchor = new_config.anchor;
+
+  new_config.relative = kFloatRelativeEditor;
+  new_config.bufpos.lnum = -1;
+  new_config.bufpos.col = 0;
+  new_config.window = 0;
+
+  // Anchor-adjusted screen position of the window's anchor corner.
+  int base_row = wp->w_winrow + ((anchor & kFloatAnchorSouth) ? wp->w_height_outer : 0);
+  int base_col = wp->w_wincol + ((anchor & kFloatAnchorEast) ? wp->w_width_outer : 0);
+
+  if (edge == kDragMove) {
+    new_config.row = row - row_off + (base_row - wp->w_winrow);
+    new_config.col = col - col_off + (base_col - wp->w_wincol);
+  } else if (edge & kDragResizeMask) {
+    new_config.row = base_row;
+    new_config.col = base_col;
+    if (edge & kDragTop) {
+      if (!(anchor & kFloatAnchorSouth)) {
+        new_config.row = row;
+      }
+      new_config.height = wp->w_winrow + wp->w_height - row;
+    } else if (edge & kDragBot) {
+      if (anchor & kFloatAnchorSouth) {
+        new_config.row = row;
+      }
+      new_config.height = row - wp->w_winrow - 1;
+    }
+    if (edge & kDragLeft) {
+      if (!(anchor & kFloatAnchorEast)) {
+        new_config.col = col;
+      }
+      new_config.width = wp->w_wincol + wp->w_width - col;
+    } else if (edge & kDragRight) {
+      if (anchor & kFloatAnchorEast) {
+        new_config.col = col;
+      }
+      new_config.width = col - wp->w_wincol - 1;
+    }
+  }
+
+  new_config.width = MAX(1, MIN(Columns, new_config.width));
+  new_config.height = MAX(1, MIN(Rows - 1, new_config.height));
+  new_config.row = MAX(0, MIN(Rows - 1, new_config.row));
+  new_config.col = MAX(0, MIN(Columns - 1, new_config.col));
+  win_config_float(wp, new_config);
+}

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -615,3 +615,128 @@ bool win_previewpopup_config(WinConfig *config)
   }
   return true;
 }
+
+static bool in_bordertext(win_T *wp, int rel_col, int width, AlignTextPos pos)
+  FUNC_ATTR_NONNULL_ALL
+{
+  int w = MIN(width, wp->w_view_width);
+  int start = get_bordertext_col(wp->w_view_width, w, pos);
+  return rel_col >= start && rel_col < start + w;
+}
+
+/// What a mouse gesture at (row, col), a screen position, does to a float.
+///
+/// @return 0, kDragMove (plus kDragContent inside the text area), or a bitmask
+///         of kDrag{Top,Bot,Left,Right}.
+int win_float_drag_action(win_T *wp, int row, int col)
+  FUNC_ATTR_NONNULL_ALL
+{
+  if (wp->w_config.external) {
+    return 0;
+  }
+
+  int rel_row = row - wp->w_winrow;
+  int rel_col = col - wp->w_wincol;
+  bool on_top = wp->w_border_adj[0] && rel_row == 0;
+  bool on_bot = wp->w_border_adj[2] && rel_row == wp->w_height_outer - 1;
+  bool on_left = wp->w_border_adj[3] && rel_col == 0;
+  bool on_right = wp->w_border_adj[1] && rel_col == wp->w_width_outer - 1;
+
+  if (!(on_top || on_bot || on_left || on_right)) {
+    return wp->w_config.mousedrag_content ? (kDragMove | kDragContent) : 0;
+  }
+
+  if (wp->w_config.mousedrag_title) {
+    if (on_top && wp->w_config.title
+        && in_bordertext(wp, rel_col, wp->w_config.title_width, wp->w_config.title_pos)) {
+      return kDragMove;
+    }
+    if (on_bot && wp->w_config.footer
+        && in_bordertext(wp, rel_col, wp->w_config.footer_width, wp->w_config.footer_pos)) {
+      return kDragMove;
+    }
+  }
+
+  if (wp->w_config.mousedrag_border) {
+    int hit = 0;
+    if (on_top) {
+      hit |= kDragTop;
+    }
+    if (on_bot) {
+      hit |= kDragBot;
+    }
+    if (on_left) {
+      hit |= kDragLeft;
+    }
+    if (on_right) {
+      hit |= kDragRight;
+    }
+    return hit;
+  }
+
+  return 0;
+}
+
+/// Move or resize a float so the dragged point follows the mouse at (row, col).
+///
+/// @param action            WinDragFlags: kDragMove, or a mask of dragged edges.
+/// @param row_off, col_off  where in the float the drag started.
+///
+/// @return  true if the window actually moved or resized.
+bool win_float_drag(win_T *wp, int action, int row, int col, int row_off, int col_off)
+  FUNC_ATTR_NONNULL_ALL
+{
+  WinConfig cfg = wp->w_config;
+  int chrome_h = wp->w_height_outer - wp->w_height;  // border and statusline
+  int chrome_w = wp->w_width_outer - wp->w_width;
+  int top = wp->w_winrow;
+  int left = wp->w_wincol;
+  int bot = top + wp->w_height_outer - 1;
+  int right = left + wp->w_width_outer - 1;
+  int above_ch = cfg.zindex < kZIndexMessages ? (int)p_ch : 0;
+
+  // Everything below is in screen coordinates, so the anchor becomes NW.
+  cfg.anchor = 0;
+  cfg.relative = kFloatRelativeEditor;
+  cfg.bufpos.lnum = -1;
+  cfg.bufpos.col = 0;
+  cfg.window = 0;
+  cfg._cmdline_offset = 0;
+  // A drag uses what is drawn, so a size that did not fit is normalised too.
+  cfg.height = wp->w_height;
+  cfg.width = wp->w_width;
+
+  if (action & kDragMove) {
+    top = MAX(MIN(row - row_off, Rows - wp->w_height_outer - above_ch), 0);
+    left = col - col_off;
+    if (!cfg.fixed) {
+      left = MAX(MIN(left, Columns - wp->w_width_outer), 0);
+    }
+  } else {
+    if (action & kDragTop) {
+      top = MIN(MAX(row, 0), bot - chrome_h);
+    } else if (action & kDragBot) {
+      bot = MAX(MIN(row, Rows - 1 - above_ch), top + chrome_h);
+    }
+    if (action & kDragLeft) {
+      left = MIN(MAX(col, 0), right - chrome_w);
+    } else if (action & kDragRight) {
+      right = MAX(MIN(col, Columns - 1), left + chrome_w);
+    }
+    cfg.height = MAX(bot - top + 1 - chrome_h, 1);
+    cfg.width = MAX(right - left + 1 - chrome_w, 1);
+  }
+
+  cfg.row = top;
+  cfg.col = left;
+
+  const WinConfig *old = &wp->w_config;
+  if (cfg.relative == old->relative && cfg.anchor == old->anchor
+      && (int)cfg.row == (int)old->row && (int)cfg.col == (int)old->col
+      && cfg.width == old->width && cfg.height == old->height) {
+    return false;
+  }
+
+  win_config_float(wp, cfg);
+  return true;
+}

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -1655,6 +1655,11 @@ describe('float window', function()
         width = 20,
         zindex = 60,
         hide = false,
+        mousedrag = {
+          border = 'none',
+          content = false,
+          title = false,
+        },
       }
       eq(expected, api.nvim_win_get_config(win))
       eq(
@@ -1663,8 +1668,11 @@ describe('float window', function()
           [[
         local expected, win = ...
         local actual = vim.api.nvim_win_get_config(win)
-        for k,v in pairs(expected) do
-          if v ~= actual[k] then
+        for k, v in pairs(expected) do
+          local ok = type(v) == 'table'
+              and vim.deep_equal(v, actual[k])
+              or v == actual[k]
+          if not ok then
             error(k)
           end
         end
@@ -1684,6 +1692,11 @@ describe('float window', function()
         split = 'left',
         width = 40,
         height = 6,
+        mousedrag = {
+          border = 'none',
+          content = false,
+          title = false,
+        },
       }, api.nvim_win_get_config(0))
 
       if multigrid then
@@ -1698,6 +1711,11 @@ describe('float window', function()
           style = '',
           hide = false,
           border = 'none',
+          mousedrag = {
+            border = 'none',
+            content = false,
+            title = false,
+          },
         }, api.nvim_win_get_config(win))
       end
     end)
@@ -4753,6 +4771,11 @@ describe('float window', function()
         focusable = true,
         mouse = true,
         zindex = 50,
+        mousedrag = {
+          border = 'none',
+          content = false,
+          title = false,
+        },
       }, api.nvim_win_get_config(win))
 
       feed('<c-e>')

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -208,7 +208,7 @@ describe('float window', function()
     )
 
     -- Reconfiguring split
-    local not_allowed = { hide = true, zindex = 1, title = '', footer = '', border = 'single' }
+    local not_allowed = { hide = true, zindex = 1, title = '', footer = '', border = 'single', mousedrag = { title = true } }
     for k, v in pairs(not_allowed) do
       local err = ("Conflict: '%s' not allowed with non-float window"):format(k)
       eq(err, pcall_err(api.nvim_win_set_config, winid, { [k] = v }))
@@ -1672,6 +1672,11 @@ describe('float window', function()
         width = 20,
         zindex = 60,
         hide = false,
+        mousedrag = {
+          border = false,
+          content = false,
+          title = false,
+        },
       }
       eq(expected, api.nvim_win_get_config(win))
       eq(
@@ -1680,8 +1685,11 @@ describe('float window', function()
           [[
         local expected, win = ...
         local actual = vim.api.nvim_win_get_config(win)
-        for k,v in pairs(expected) do
-          if v ~= actual[k] then
+        for k, v in pairs(expected) do
+          local ok = type(v) == 'table'
+              and vim.deep_equal(v, actual[k])
+              or v == actual[k]
+          if not ok then
             error(k)
           end
         end
@@ -1701,6 +1709,11 @@ describe('float window', function()
         split = 'left',
         width = 40,
         height = 6,
+        mousedrag = {
+          title = false,
+          border = false,
+          content = false,
+        },
       }, api.nvim_win_get_config(0))
 
       if multigrid then
@@ -1715,6 +1728,11 @@ describe('float window', function()
           style = '',
           hide = false,
           border = 'none',
+          mousedrag = {
+            border = false,
+            content = false,
+            title = false,
+          },
         }, api.nvim_win_get_config(win))
       end
     end)
@@ -4770,6 +4788,11 @@ describe('float window', function()
         focusable = true,
         mouse = true,
         zindex = 50,
+        mousedrag = {
+          border = false,
+          content = false,
+          title = false,
+        },
       }, api.nvim_win_get_config(win))
 
       feed('<c-e>')

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -2346,6 +2346,303 @@ describe('ui/mouse/input', function()
       api.nvim_input_mouse('left', 'release', '', 0, 7, 0)
       eq(3, fn.line('.'))
     end)
+
+    it('drag on float window border', function()
+      local function drag_cases(win, cases)
+        for _, c in ipairs(cases) do
+          local gx, gy = c.grab[1], c.grab[2]
+          feed(string.format('<LeftMouse><%d,%d>', gx, gy))
+          poke_eventloop()
+          feed(string.format('<LeftDrag><%d,%d>', gx + c.by[1], gy + c.by[2]))
+          local conf = api.nvim_win_get_config(win)
+          for k, exp in pairs(c.after) do
+            eq(exp, conf[k])
+          end
+          if c.back_to then
+            feed(string.format('<LeftDrag><%d,%d>', gx, gy))
+            conf = api.nvim_win_get_config(win)
+            for k, exp in pairs(c.back_to) do
+              eq(exp, conf[k])
+            end
+          end
+          feed('<LeftRelease><0,0>')
+        end
+      end
+      screen:try_resize(25, 15)
+      command('%delete')
+      local fwin = api.nvim_open_win(0, false, {
+        relative = 'editor',
+        row = 2,
+        col = 2,
+        height = 4,
+        width = 4,
+        border = 'single',
+        mousedrag = { title = true, content = true, border = 'resize' },
+      })
+      poke_eventloop()
+
+      drag_cases(fwin, {
+        { grab = { 7, 3 }, by = { 3, 0 }, after = { width = 7 }, back_to = { width = 4 } }, -- right border, +3 cols
+        { grab = { 2, 3 }, by = { -1, 0 }, after = { width = 5 }, back_to = { width = 4 } }, -- left border, -1 col
+        { grab = { 4, 7 }, by = { 0, 3 }, after = { height = 7 }, back_to = { height = 4 } }, -- bottom border, +3 rows
+        { grab = { 4, 2 }, by = { 0, -2 }, after = { height = 6 }, back_to = { height = 4 } }, -- top border, -2 rows
+      })
+
+      api.nvim_win_set_config(fwin, { title = 'test' }) -- title=true from baseline; drag title moves
+      drag_cases(fwin, {
+        { grab = { 5, 2 }, by = { 5, 0 }, after = { col = 7 }, back_to = { col = 2 } }, -- title, +5 cols
+      })
+
+      -- resize updates row/col of anchor after drag.
+      -- anchor SE = right-bot corner
+      api.nvim_win_set_config(fwin, { title = '', anchor = 'SE' })
+      drag_cases(fwin, {
+        { grab = { 5, 2 }, by = { 5, 0 }, after = { col = 10 }, back_to = { col = 5 } }, -- right border, +5 cols
+        { grab = { 2, 5 }, by = { 0, 5 }, after = { row = 10 }, back_to = { row = 5 } }, -- bot border, +5 rows
+      })
+
+      -- anchor NE = right-top corner
+      api.nvim_win_set_config(fwin, { anchor = 'NE' })
+      drag_cases(fwin, {
+        { grab = { 5, 6 }, by = { 5, 0 }, after = { col = 10 }, back_to = { col = 5 } }, -- right border, +5 cols
+        { grab = { 2, 5 }, by = { 0, -3 }, after = { row = 2 }, back_to = { row = 5 } }, -- top border, -3 rows
+      })
+
+      -- anchor SW = left-bot corner
+      api.nvim_win_set_config(fwin, { anchor = 'SW' })
+      drag_cases(fwin, {
+        { grab = { 6, 2 }, by = { -4, 0 }, after = { col = 2 }, back_to = { col = 6 } }, -- left border, -4 cols
+        { grab = { 7, 5 }, by = { 0, 2 }, after = { row = 7 }, back_to = { row = 5 } }, -- bot border, +2 rows
+      })
+
+      -- corner resize (NW anchor)
+      api.nvim_win_set_config(fwin, { relative = 'editor', anchor = 'NW', row = 4, col = 4 })
+      drag_cases(fwin, {
+        {
+          grab = { 4, 4 },
+          by = { -1, -1 }, -- left-top corner, out then back
+          after = { width = 5, height = 5, row = 3, col = 3 },
+          back_to = { width = 4, height = 4, row = 4, col = 4 },
+        },
+        {
+          grab = { 4, 9 },
+          by = { -3, 1 }, -- left-bot corner
+          after = { width = 7, height = 5, row = 4, col = 1 },
+          back_to = { width = 4, height = 4, row = 4, col = 4 },
+        },
+        {
+          grab = { 9, 4 },
+          by = { 1, -1 }, -- right-top corner
+          after = { width = 5, height = 5, row = 3, col = 4 },
+          back_to = { width = 4, height = 4, row = 4, col = 4 },
+        },
+        {
+          grab = { 9, 9 },
+          by = { -1, -1 }, -- right-bot corner
+          after = { width = 3, height = 3, row = 4, col = 4 },
+          back_to = { width = 4, height = 4, row = 4, col = 4 },
+        },
+        {
+          grab = { 6, 6 },
+          by = { 3, 1 }, -- content area (move)
+          after = { width = 4, height = 4, row = 5, col = 7 },
+          back_to = { width = 4, height = 4, row = 4, col = 4 },
+        },
+      })
+
+      -- non-square: catches w_height/w_width mix-up at corners
+      api.nvim_win_set_config(fwin, { width = 8, height = 4 })
+      drag_cases(fwin, {
+        {
+          grab = { 13, 9 },
+          by = { -1, -1 }, -- right-bot corner
+          after = { width = 7, height = 3 },
+          back_to = { width = 8, height = 4 },
+        },
+      })
+
+      -- long title must not cover corners
+      api.nvim_win_set_config(fwin, {
+        width = 4,
+        height = 4,
+        title = string.rep('x', 20),
+        title_pos = 'center',
+      })
+      drag_cases(fwin, {
+        {
+          grab = { 4, 4 },
+          by = { -1, -1 }, -- top-left corner under title
+          after = { width = 5, height = 5, row = 3, col = 3 },
+          back_to = { width = 4, height = 4, row = 4, col = 4 },
+        },
+      })
+
+      -- borderless dragall: first content row must be grabbable
+      api.nvim_win_set_config(fwin, {
+        relative = 'editor',
+        row = 4,
+        col = 4,
+        width = 6,
+        height = 4,
+        border = 'none',
+        title = '',
+        mousedrag = { title = false, border = 'none' },
+      })
+      drag_cases(fwin, {
+        {
+          grab = { 5, 4 },
+          by = { 3, 3 },
+          after = { row = 7, col = 7 },
+          back_to = { row = 4, col = 4 },
+        },
+      })
+
+      -- drag alone (no border, no title) is a no-op
+      api.nvim_win_set_config(fwin, { mousedrag = { title = true, content = false } })
+      feed('<LeftMouse><5,4>')
+      poke_eventloop()
+      feed('<LeftDrag><10,8>')
+      feed('<LeftRelease><10,8>')
+      local conf = api.nvim_win_get_config(fwin)
+      eq(4, conf.row)
+      eq(4, conf.col)
+
+      -- drag footer title to move
+      api.nvim_win_set_config(fwin, {
+        relative = 'editor',
+        anchor = 'NW',
+        row = 4,
+        col = 4,
+        width = 4,
+        height = 4,
+        border = 'single',
+        title = '',
+        footer = 'foo',
+        footer_pos = 'left',
+        mousedrag = { title = true, border = 'resize', content = false },
+      })
+      drag_cases(fwin, {
+        { grab = { 5, 9 }, by = { 5, 0 }, after = { col = 9 }, back_to = { col = 4 } }, -- footer, +5 cols
+      })
+
+      -- drag=true, resize=false: borders move instead of resizing
+      api.nvim_win_set_config(fwin, {
+        relative = 'editor',
+        anchor = 'NW',
+        row = 4,
+        col = 4,
+        width = 4,
+        height = 4,
+        border = 'single',
+        title = '',
+        footer = '',
+        mousedrag = { border = 'move' },
+      })
+      drag_cases(fwin, {
+        {
+          grab = { 9, 6 },
+          by = { 3, 0 }, -- right border moves, doesn't resize
+          after = { col = 7, width = 4 },
+          back_to = { col = 4, width = 4 },
+        },
+        {
+          grab = { 6, 9 },
+          by = { 0, 3 }, -- bot border moves
+          after = { row = 7, height = 4 },
+          back_to = { row = 4, height = 4 },
+        },
+        {
+          grab = { 9, 9 },
+          by = { 2, 2 }, -- bot-right corner moves diagonally
+          after = { row = 6, col = 6, width = 4, height = 4 },
+          back_to = { row = 4, col = 4, width = 4, height = 4 },
+        },
+      })
+
+      -- border='none': dragging the border does nothing
+      api.nvim_win_set_config(fwin, {
+        relative = 'editor',
+        anchor = 'NW',
+        row = 4,
+        col = 4,
+        width = 4,
+        height = 4,
+        border = 'single',
+        title = '',
+        footer = '',
+        mousedrag = { title = false, content = false, border = 'none' },
+      })
+      drag_cases(fwin, {
+        {
+          grab = { 4, 6 },
+          by = { -3, 0 }, -- drag left border inward: no-op
+          after = { row = 4, col = 4, width = 4, height = 4 },
+        }, -- no back_to
+      })
+    end)
+
+    it('float drag clamps to screen size', function()
+      screen:try_resize(20, 10)
+      command('%delete')
+      local fwin = api.nvim_open_win(0, false, {
+        relative = 'editor',
+        row = 1,
+        col = 1,
+        width = 4,
+        height = 4,
+        border = 'single',
+        mousedrag = { border = 'resize' },
+      })
+      poke_eventloop()
+
+      -- drag bot-right corner past screen: width and height clamp
+      feed('<LeftMouse><6,6>')
+      poke_eventloop()
+      feed('<LeftDrag><200,200>')
+      feed('<LeftRelease><200,200>')
+      local conf = api.nvim_win_get_config(fwin)
+      eq(true, conf.width >= 10)
+      eq(true, conf.width <= 20)
+      eq(true, conf.height >= 5)
+      eq(true, conf.height <= 9)
+
+      api.nvim_win_set_config(fwin, {
+        relative = 'editor',
+        row = 5,
+        col = 5,
+        width = 4,
+        height = 4,
+        border = 'single',
+        mousedrag = { title = true, border = 'resize' },
+      })
+      feed('<LeftMouse><5,5>')
+      poke_eventloop()
+      feed('<LeftDrag><-100,-100>')
+      feed('<LeftRelease><-100,-100>')
+      conf = api.nvim_win_get_config(fwin)
+      eq(true, conf.row >= 0)
+      eq(true, conf.col >= 0)
+    end)
+
+    it('drag converts relative=cursor float to editor', function()
+      screen:try_resize(25, 15)
+      api.nvim_buf_set_lines(0, 0, -1, false, { 'line1', 'line2', 'line3', 'line4' })
+      api.nvim_win_set_cursor(0, { 2, 0 })
+      local fwin = api.nvim_open_win(api.nvim_create_buf(false, true), false, {
+        relative = 'cursor',
+        row = 1,
+        col = 1,
+        width = 4,
+        height = 3,
+        mousedrag = { content = true },
+      })
+      poke_eventloop()
+      feed('<LeftMouse><4,4>')
+      poke_eventloop()
+      feed('<LeftDrag><10,8>')
+      feed('<LeftRelease><10,8>')
+      eq('editor', api.nvim_win_get_config(fwin).relative)
+    end)
   end
 
   describe('with ext_multigrid', function()

--- a/test/functional/ui/mouse_spec.lua
+++ b/test/functional/ui/mouse_spec.lua
@@ -2425,6 +2425,349 @@ describe('ui/mouse/input', function()
       api.nvim_input_mouse('left', 'release', '', 0, 7, 0)
       eq(3, fn.line('.'))
     end)
+
+    it('drag on float window border', function()
+      local function drag_cases(win, cases)
+        for _, c in ipairs(cases) do
+          local gx, gy = c.grab[1], c.grab[2]
+          feed(string.format('<LeftMouse><%d,%d>', gx, gy))
+          poke_eventloop()
+          feed(string.format('<LeftDrag><%d,%d>', gx + c.by[1], gy + c.by[2]))
+          local conf = api.nvim_win_get_config(win)
+          for k, exp in pairs(c.after) do
+            eq(exp, conf[k])
+          end
+          if c.back_to then
+            feed(string.format('<LeftDrag><%d,%d>', gx, gy))
+            conf = api.nvim_win_get_config(win)
+            for k, exp in pairs(c.back_to) do
+              eq(exp, conf[k])
+            end
+          end
+          feed('<LeftRelease><0,0>')
+        end
+      end
+      screen:try_resize(25, 15)
+      command('%delete')
+      local fwin = api.nvim_open_win(0, false, {
+        relative = 'editor',
+        row = 2,
+        col = 2,
+        height = 4,
+        width = 4,
+        border = 'single',
+        mousedrag = { title = true, content = true, border = true },
+      })
+      poke_eventloop()
+
+      drag_cases(fwin, {
+        { grab = { 7, 3 }, by = { 3, 0 }, after = { width = 7 }, back_to = { width = 4 } }, -- right border, +3 cols
+        { grab = { 2, 3 }, by = { -1, 0 }, after = { width = 5 }, back_to = { width = 4 } }, -- left border, -1 col
+        { grab = { 4, 7 }, by = { 0, 3 }, after = { height = 7 }, back_to = { height = 4 } }, -- bottom border, +3 rows
+        { grab = { 4, 2 }, by = { 0, -2 }, after = { height = 6 }, back_to = { height = 4 } }, -- top border, -2 rows
+      })
+
+      api.nvim_win_set_config(fwin, { title = 'test' }) -- title=true from baseline; drag title moves
+      drag_cases(fwin, {
+        { grab = { 5, 2 }, by = { 5, 0 }, after = { col = 7 }, back_to = { col = 2 } }, -- title, +5 cols
+      })
+
+      -- a drag normalises the anchor to NW
+      api.nvim_win_set_config(fwin, {
+        relative = 'editor',
+        title = '',
+        anchor = 'SE',
+        row = 10,
+        col = 10,
+        width = 4,
+        height = 4,
+      })
+      eq({ 4, 4 }, api.nvim_win_get_position(fwin)) -- outer rows 4..9, cols 4..9
+      drag_cases(fwin, {
+        -- right border, +5 cols
+        { grab = { 9, 6 }, by = { 5, 0 }, after = { anchor = 'NW', col = 4, width = 9 } },
+      })
+
+      -- top and left borders of an SE anchor, where w_winrow differs from cfg.row
+      api.nvim_win_set_config(
+        fwin,
+        { relative = 'editor', anchor = 'SE', row = 10, col = 10, width = 4, height = 4 }
+      )
+      eq({ 4, 4 }, api.nvim_win_get_position(fwin))
+      drag_cases(fwin, {
+        -- top border, -2 rows
+        { grab = { 6, 4 }, by = { 0, -2 }, after = { anchor = 'NW', row = 2, height = 6 } },
+      })
+
+      api.nvim_win_set_config(
+        fwin,
+        { relative = 'editor', anchor = 'SE', row = 10, col = 10, width = 4, height = 4 }
+      )
+      drag_cases(fwin, {
+        -- left border, -2 cols
+        { grab = { 4, 6 }, by = { -2, 0 }, after = { anchor = 'NW', col = 2, width = 6 } },
+      })
+
+      -- corner resize (NW anchor)
+      api.nvim_win_set_config(
+        fwin,
+        { relative = 'editor', anchor = 'NW', row = 4, col = 4, width = 4, height = 4 }
+      )
+      drag_cases(fwin, {
+        {
+          grab = { 4, 4 },
+          by = { -1, -1 }, -- left-top corner, out then back
+          after = { width = 5, height = 5, row = 3, col = 3 },
+          back_to = { width = 4, height = 4, row = 4, col = 4 },
+        },
+        {
+          grab = { 4, 9 },
+          by = { -3, 1 }, -- left-bot corner
+          after = { width = 7, height = 5, row = 4, col = 1 },
+          back_to = { width = 4, height = 4, row = 4, col = 4 },
+        },
+        {
+          grab = { 9, 4 },
+          by = { 1, -1 }, -- right-top corner
+          after = { width = 5, height = 5, row = 3, col = 4 },
+          back_to = { width = 4, height = 4, row = 4, col = 4 },
+        },
+        {
+          grab = { 9, 9 },
+          by = { -1, -1 }, -- right-bot corner
+          after = { width = 3, height = 3, row = 4, col = 4 },
+          back_to = { width = 4, height = 4, row = 4, col = 4 },
+        },
+        {
+          grab = { 6, 6 },
+          by = { 3, 1 }, -- content area (move)
+          after = { width = 4, height = 4, row = 5, col = 7 },
+          back_to = { width = 4, height = 4, row = 4, col = 4 },
+        },
+      })
+
+      -- non-square: catches w_height/w_width mix-up at corners
+      api.nvim_win_set_config(fwin, { width = 8, height = 4 })
+      drag_cases(fwin, {
+        {
+          grab = { 13, 9 },
+          by = { -1, -1 }, -- right-bot corner
+          after = { width = 7, height = 3 },
+          back_to = { width = 8, height = 4 },
+        },
+      })
+
+      -- long title must not cover corners
+      api.nvim_win_set_config(fwin, {
+        width = 4,
+        height = 4,
+        title = string.rep('x', 20),
+        title_pos = 'center',
+      })
+      drag_cases(fwin, {
+        {
+          grab = { 4, 4 },
+          by = { -1, -1 }, -- top-left corner under title
+          after = { width = 5, height = 5, row = 3, col = 3 },
+          back_to = { width = 4, height = 4, row = 4, col = 4 },
+        },
+      })
+
+      -- borderless dragall: first content row must be grabbable
+      api.nvim_win_set_config(fwin, {
+        relative = 'editor',
+        row = 4,
+        col = 4,
+        width = 6,
+        height = 4,
+        border = 'none',
+        title = '',
+        mousedrag = { title = false, border = false },
+      })
+      drag_cases(fwin, {
+        {
+          grab = { 5, 4 },
+          by = { 3, 3 },
+          after = { row = 7, col = 7 },
+          back_to = { row = 4, col = 4 },
+        },
+      })
+
+      -- title=true but no title: border and content are off, so nothing to grab
+      api.nvim_win_set_config(fwin, { mousedrag = { title = true, content = false } })
+      feed('<LeftMouse><5,4>')
+      poke_eventloop()
+      feed('<LeftDrag><10,8>')
+      feed('<LeftRelease><10,8>')
+      local conf = api.nvim_win_get_config(fwin)
+      eq(4, conf.row)
+      eq(4, conf.col)
+
+      -- drag footer title to move
+      api.nvim_win_set_config(fwin, {
+        relative = 'editor',
+        anchor = 'NW',
+        row = 4,
+        col = 4,
+        width = 4,
+        height = 4,
+        border = 'single',
+        title = '',
+        footer = 'foo',
+        footer_pos = 'left',
+        mousedrag = { title = true, border = true, content = false },
+      })
+      drag_cases(fwin, {
+        { grab = { 5, 9 }, by = { 5, 0 }, after = { col = 9 }, back_to = { col = 4 } }, -- footer, +5 cols
+      })
+
+      -- border=false: dragging the border does nothing
+      api.nvim_win_set_config(fwin, {
+        relative = 'editor',
+        anchor = 'NW',
+        row = 4,
+        col = 4,
+        width = 4,
+        height = 4,
+        border = 'single',
+        title = '',
+        footer = '',
+        mousedrag = { title = false, content = false, border = false },
+      })
+      drag_cases(fwin, {
+        {
+          grab = { 4, 6 },
+          by = { -3, 0 }, -- drag left border inward: no-op
+          after = { row = 4, col = 4, width = 4, height = 4 },
+        }, -- no back_to
+      })
+    end)
+
+    it('float drag clamps to screen size', function()
+      screen:try_resize(20, 10)
+      command('%delete')
+      local fwin = api.nvim_open_win(0, false, {
+        relative = 'editor',
+        row = 1,
+        col = 1,
+        width = 4,
+        height = 4,
+        border = 'single',
+        mousedrag = { border = true },
+      })
+      poke_eventloop()
+
+      -- past the screen: the dragged edges stop, the opposite corner stays
+      feed('<LeftMouse><6,6>')
+      poke_eventloop()
+      feed('<LeftDrag><200,200>')
+      feed('<LeftRelease><200,200>')
+      local conf = api.nvim_win_get_config(fwin)
+      eq(17, conf.width)
+      eq(6, conf.height) -- stops above the cmdline
+      eq(1, conf.row)
+      eq(1, conf.col)
+
+      api.nvim_win_set_config(fwin, {
+        relative = 'editor',
+        row = 5,
+        col = 5,
+        width = 4,
+        height = 4,
+        border = 'single',
+        mousedrag = { title = true, border = true },
+      })
+      -- does not fit at row 5, so it is drawn at row 3 and a drag uses that
+      eq({ 3, 5 }, api.nvim_win_get_position(fwin))
+      feed('<LeftMouse><5,5>')
+      poke_eventloop()
+      feed('<LeftDrag><0,5>')
+      feed('<LeftRelease><0,5>')
+      conf = api.nvim_win_get_config(fwin)
+      eq(0, conf.col)
+      eq(9, conf.width)
+      eq(3, conf.row) -- where it was drawn, not where it was configured
+      eq(4, conf.height)
+    end)
+
+    it('float drag after a status line drag', function()
+      screen:try_resize(25, 15)
+      command('%delete')
+      command('split')
+      -- derive the status line row, it depends on 'laststatus'
+      local top = api.nvim_get_current_win()
+      local sl_row = api.nvim_win_get_position(top)[1] + api.nvim_win_get_height(top)
+
+      local fwin = api.nvim_open_win(0, false, {
+        relative = 'editor',
+        row = 2,
+        col = 12,
+        width = 6,
+        height = 4,
+        border = 'single',
+        mousedrag = { border = true },
+      })
+      poke_eventloop()
+
+      -- drag a status line first, col 2 is clear of the float
+      feed(string.format('<LeftMouse><2,%d>', sl_row))
+      poke_eventloop()
+      feed(string.format('<LeftDrag><2,%d>', sl_row + 1))
+      feed(string.format('<LeftRelease><2,%d>', sl_row + 1))
+
+      -- then the float's right border, outer cols 12..19
+      feed('<LeftMouse><19,4>')
+      poke_eventloop()
+      feed('<LeftDrag><22,4>')
+      feed('<LeftRelease><22,4>')
+      eq(9, api.nvim_win_get_config(fwin).width)
+    end)
+
+    it('drag of a clamped float', function()
+      screen:try_resize(20, 10)
+      command('%delete')
+      -- 6 rows do not fit at row 5, so it is drawn at row 3
+      local fwin = api.nvim_open_win(0, false, {
+        relative = 'editor',
+        row = 5,
+        col = 5,
+        width = 4,
+        height = 4,
+        border = 'single',
+        mousedrag = { border = true },
+      })
+      poke_eventloop()
+      eq({ 3, 5 }, api.nvim_win_get_position(fwin))
+
+      -- top border, -1 row
+      feed('<LeftMouse><7,3>')
+      poke_eventloop()
+      feed('<LeftDrag><7,2>')
+      feed('<LeftRelease><7,2>')
+      local conf = api.nvim_win_get_config(fwin)
+      eq(5, conf.height)
+      eq(2, conf.row)
+    end)
+
+    it('drag converts relative=cursor float to editor', function()
+      screen:try_resize(25, 15)
+      api.nvim_buf_set_lines(0, 0, -1, false, { 'line1', 'line2', 'line3', 'line4' })
+      api.nvim_win_set_cursor(0, { 2, 0 })
+      local fwin = api.nvim_open_win(api.nvim_create_buf(false, true), false, {
+        relative = 'cursor',
+        row = 1,
+        col = 1,
+        width = 4,
+        height = 3,
+        mousedrag = { content = true },
+      })
+      poke_eventloop()
+      feed('<LeftMouse><4,4>')
+      poke_eventloop()
+      feed('<LeftDrag><10,8>')
+      feed('<LeftRelease><10,8>')
+      eq('editor', api.nvim_win_get_config(fwin).relative)
+    end)
   end
 
   describe('with ext_multigrid', function()


### PR DESCRIPTION
Problem: Floating windows lack mouse drag support for resizing and moving.

Solution:
Add a `mousedrag` option to `nvim_open_win()`, with three booleans that
default to false:
- `title`: drag the title or footer text to move the window.
- `content`: drag the text area to move the window. Dragging there no
  longer selects text.
- `border`: drag a border or a corner to resize the window.
  
Fix #35669

![test4](https://github.com/user-attachments/assets/50547ffe-5d7c-43a4-8943-d71701552a90)
