### PR TITLE
feat(health): plugin hygiene

### DIFF
--- a/runtime/doc/lua-plugin.txt
+++ b/runtime/doc/lua-plugin.txt
@@ -121,6 +121,13 @@ In the user's config:
 ==============================================================================
 Initialization                                               *lua-plugin-init*
 
+Plugins (except colorschemes and ftplugins) should always create
+a `plugin/foo.lua` file, even if it is empty. This is how a plugin "declares"
+itself to Nvim. You can confirm this by checking if the plugin appears in
+|:scriptnames|. (Exception: If your "plugin" is actually just a Lua module,
+i.e. a "library" intended only for programmatic use, then a plugin/ file is
+not needed.)
+
 Strictly separated configuration and smart initialization allow your plugin to
 work out of the box. Common approaches are:
 

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -305,7 +305,7 @@ PLUGINS
 
 • Customize :checkhealth by handling a `FileType checkhealth` event.
   |health-usage|
-
+• `:checkhealth vim.health` checks plugin "hygiene".
 • Simplify Python provider setup to a single step: `uv tool install pynvim`
   Nvim will detect the plugin's location without user configuration, even if
   unrelated Python virtual environments are activated.


### PR DESCRIPTION
# Note: code is AI-generated, WIP

## Todo

- update docs for `lua-plugin`
- tests

## Problem:
Plugin hygiene is not checked by checkhealth.

## Solution:
Check these "hygiene" conditions:
- Plugins should always have a `plugin/<name>.{lua,vim}` file, even if it is empty, so that the plugin is found in `:scriptnames`.
  - This also declares the plugin's ["formal name"](https://github.com/neovim/neovim/issues/34704), which is important for us to be able to reason about plugins.
  - (Potential exception(?) to this rule is modules/libraries which are only intended for programmatic use via `require()`).
- The `<name>` used in these places must always be identical:
  - `plugin/<name>.{lua,vim}`
  - `lua/<name>.lua`
  - `lua/<name>/*.lua`

Example output:

```
Plugins ~
- ✅ OK Plugin vim-rhubarb is well-formed
- ✅ OK Plugin vim-rsi is well-formed
- ✅ OK Plugin vim-sneak is well-formed
- ✅ OK Plugin vim-surround is well-formed
- ✅ OK Plugin vim-unimpaired is well-formed
- ✅ OK Plugin zen-mode.nvim is well-formed
- ⚠️ WARNING Plugin firenvim has mismatched names:
  plugin/firenvim.vim
  lua/firenvim.lua
  lua/firenvim-utils.lua
  lua/firenvim-websocket.lua

```