### PR TITLE
fix: allow list of strings for vim.diagnostic.Opts.border

### DIFF
--- a/runtime/doc/diagnostic.txt
+++ b/runtime/doc/diagnostic.txt
@@ -626,7 +626,7 @@ Lua module: vim.diagnostic                                    *diagnostic-api*
                           diagnostic instead of prepending it. Overrides the
                           setting from |vim.diagnostic.config()|.
       • {focus_id}?       (`string`)
-      • {border}?         (`string`) see |nvim_open_win()|.
+      • {border}?         (`string|string[]`) see |nvim_open_win()|.
 
 *vim.diagnostic.Opts.Jump*
 

--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -186,7 +186,7 @@ end
 ---
 --- @field focus_id? string
 ---
---- @field border? string see |nvim_open_win()|.
+--- @field border? string|string[] see |nvim_open_win()|.
 
 --- @class vim.diagnostic.Opts.Underline
 ---


### PR DESCRIPTION
Type checkers complain if we pass a list of strings, but this should be allowed.