### PR TITLE
fix(diagnostic): added a flag for invalid qflist items into previous …

### DIFF
--- a/runtime/lua/vim/diagnostic.lua
+++ b/runtime/lua/vim/diagnostic.lua
@@ -2823,13 +2823,16 @@ end
 --- Convert a list of quickfix items to a list of diagnostics.
 ---
 ---@param list table[] List of quickfix items from |getqflist()| or |getloclist()|.
+---@param include_invalid boolean? Whether to include items with valid field set to 0.
 ---@return vim.Diagnostic[]
-function M.fromqflist(list)
+function M.fromqflist(list, include_invalid)
   vim.validate('list', list, 'table')
+  vim.validate('include_invalid', include_invalid, 'boolean', true)
 
+  include_invalid = include_invalid == nil and false or include_invalid
   local diagnostics = {} --- @type vim.Diagnostic[]
   for _, item in ipairs(list) do
-    if item.valid == 1 then
+    if item.valid == 1 or (include_invalid and item.valid == 0) then
       local lnum = math.max(0, item.lnum - 1)
       local col = math.max(0, item.col - 1)
       local end_lnum = item.end_lnum > 0 and (item.end_lnum - 1) or lnum


### PR DESCRIPTION
# fix for #35640 vim.diagnostic.fromqflist: add option to include invalid qflist items

## Problem
`vim.diagnostic.fromqflist` currently ignores items with `valid == 0` from quickfix lists. This is problematic for multi-line error messages (common in language servers and compilers), where only the first line is captured as a diagnostic, causing the loss of important error details.

## Solution
Added a new optional parameter `include_invalid` to `vim.diagnostic.fromqflist()` that allows users to include items with `valid == 0` in the resulting diagnostics. By default, this behavior is disabled (false) to maintain backward compatibility.

Examples:
```lua
-- Current behavior (unchanged)
vim.diagnostic.fromqflist(vim.fn.getqflist())

-- New behavior with the option enabled
vim.diagnostic.fromqflist(vim.fn.getqflist(), true)
```

apologies if the commit message doesn't follow guidelines 