### PR TITLE
fix: Fix spurious errors in :checkhealth when using pyenv-virtualenv.

### DIFF
--- a/runtime/lua/vim/provider/health.lua
+++ b/runtime/lua/vim/provider/health.lua
@@ -805,27 +805,32 @@ local function python()
       local nvim_py_bin = python_exepath(vim.fn.exepath(py_bin_basename))
       if nvim_py_bin then
         local subshell_py_bin = python_exepath(py_bin_basename)
-        if venv_bin ~= nvim_py_bin then
-          errors[#errors + 1] = '$PATH yields this '
-            .. py_bin_basename
-            .. ' executable: '
-            .. nvim_py_bin
-          local hint = '$PATH ambiguities arise if the virtualenv is not '
-            .. 'properly activated prior to launching Nvim. Close Nvim, activate the virtualenv, '
-            .. 'check that invoking Python from the command line launches the correct one, '
-            .. 'then relaunch Nvim.'
-          hints[hint] = true
-        end
-        if venv_bin ~= subshell_py_bin then
-          errors[#errors + 1] = '$PATH in subshells yields this '
-            .. py_bin_basename
-            .. ' executable: '
-            .. subshell_py_bin
-          local hint = '$PATH ambiguities in subshells typically are '
-            .. 'caused by your shell config overriding the $PATH previously set by the '
-            .. 'virtualenv. Either prevent them from doing so, or use this workaround: '
-            .. 'https://vi.stackexchange.com/a/34996'
-          hints[hint] = true
+        local bintable = {
+          ['nvim'] = {
+            ['path'] = nvim_py_bin,
+            ['hint'] = '$PATH ambiguities arise if the virtualenv is not '
+              .. 'properly activated prior to launching Nvim. Close Nvim, activate the virtualenv, '
+              .. 'check that invoking Python from the command line launches the correct one, '
+              .. 'then relaunch Nvim.',
+          },
+          ['subshell'] = {
+            ['path'] = subshell_py_bin,
+            ['hint'] = '$PATH ambiguities in subshells typically are '
+              .. 'caused by your shell config overriding the $PATH previously set by the '
+              .. 'virtualenv. Either prevent them from doing so, or use this workaround: '
+              .. 'https://vi.stackexchange.com/a/34996',
+          },
+        }
+        for bintype, bin in pairs(bintable) do
+          if vim.fn.resolve(venv_bin) ~= vim.fn.resolve(bin['path']) then
+            local type_of_path = bintype == 'subshell' and '$PATH' or '$PATH in subshell'
+            errors[#errors + 1] = type_of_path
+              .. ' yields this '
+              .. py_bin_basename
+              .. ' executable: '
+              .. bin['path']
+            hints[bin['hint']] = true
+          end
         end
       end
     end


### PR DESCRIPTION
**Problem:**

pyenv-virtualenv sets a different path for VIRTUAL_ENV than the path to the python binary it provides, but these paths both symlink to the same file, so there should be no disparity. The python function in :checkhealth reports an error in this case, since it only checks if these paths are equal to one another, not where they point.

**Solution:**

Resolve the python symlinks before checking if they are equal. While here, condense down some repeated code.

**Additional:**

I did some manual testing of this inside a podman container and it seems to work with both pyenv-virtualenv and traditional venvs.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
