### PR TITLE
vim-patch:9.1.1780: mbyte contains overlapping list of utf_classes table

### DIFF
--- a/src/nvim/mbyte.c
+++ b/src/nvim/mbyte.c
@@ -1272,7 +1272,7 @@ int utf_class_tab(const int c, const uint64_t *const chartab)
     { 0x202f, 0x202f, 0 },
     { 0x2030, 0x205e, 1 },              // punctuation and symbols
     { 0x205f, 0x205f, 0 },
-    { 0x2060, 0x27ff, 1 },              // punctuation and symbols
+    { 0x2060, 0x206f, 1 },              // punctuation and symbols
     { 0x2070, 0x207f, 0x2070 },         // superscript
     { 0x2080, 0x2094, 0x2080 },         // subscript
     { 0x20a0, 0x27ff, 1 },              // all kinds of symbols


### PR DESCRIPTION
#### vim-patch:9.1.1780: mbyte contains overlapping list of utf_classes table

Problem:  mbyte contains overlapping list of utf_classes table
Solution: Update table to contain non-overlapping list (Yuta Yamamoto)

closes: vim/vim#18362

https://github.com/vim/vim/commit/9fa8a114b250cc0eeab2bc93eac66eaa08ae2187

Co-authored-by: Yuta Yamamoto <jichael.y.yuta1995@gmail.com>