### PR TITLE
fix(lua): coverity "unreachable" warning

### DIFF
--- a/src/nvim/lua/executor.c
+++ b/src/nvim/lua/executor.c
@@ -543,8 +543,6 @@ static int nlua_wait(lua_State *lstate)
     lua_pushinteger(lstate, -1);
     return 2;
   }
-
-  abort();
 }
 
 static nlua_ref_state_t *nlua_new_ref_state(lua_State *lstate, bool is_thread)


### PR DESCRIPTION
Problem:

    CID 584865:         Control flow issues  (UNREACHABLE)
    /src/nvim/lua/executor.c: 550             in nlua_wait()
    >>>     CID 584865:         Control flow issues  (UNREACHABLE)
    >>>     This code cannot be reached: "abort();".
    550       abort();
    551     }

Solution:
The abort is intentional, to avoid accidentally fallthrough from the if-else chain. Tell coverity to ignore it.
