### PR TITLE
vim-patch:9.1.{1781,1783}

### DIFF
--- a/src/nvim/eval.c
+++ b/src/nvim/eval.c
@@ -2632,7 +2632,7 @@ static int may_call_simple_func(const char *arg, typval_T *rettv)
 
 /// Handle zero level expression with optimization for a simple function call.
 /// Same arguments and return value as eval0().
-int eval0_simple_funccal(char *arg, typval_T *rettv, exarg_T *eap, evalarg_T *const evalarg)
+static int eval0_simple_funccal(char *arg, typval_T *rettv, exarg_T *eap, evalarg_T *const evalarg)
 {
   int r = may_call_simple_func(arg, rettv);
 

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1090,6 +1090,12 @@ static void ins_compl_insert_bytes(char *p, int len)
   compl_ins_end_col = curwin->w_cursor.col;
 }
 
+/// Get current completion leader length
+static size_t ins_compl_leader_len(void)
+{
+  return compl_leader.data != NULL ? compl_leader.size : compl_orig_text.size;
+}
+
 /// Checks if the column is within the currently inserted completion text
 /// column range. If it is, it returns a special highlight attribute.
 /// -1 means normal item.
@@ -1738,12 +1744,6 @@ bool compl_match_curr_select(int selected)
 char *ins_compl_leader(void)
 {
   return compl_leader.data != NULL ? compl_leader.data : compl_orig_text.data;
-}
-
-/// Get current completion leader length
-size_t ins_compl_leader_len(void)
-{
-  return compl_leader.data != NULL ? compl_leader.size : compl_orig_text.size;
 }
 
 /// Add any identifiers that match the given pattern "pat" in the list of

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -1090,6 +1090,12 @@ static void ins_compl_insert_bytes(char *p, int len)
   compl_ins_end_col = curwin->w_cursor.col;
 }
 
+/// Get current completion leader
+char *ins_compl_leader(void)
+{
+  return compl_leader.data != NULL ? compl_leader.data : compl_orig_text.data;
+}
+
 /// Get current completion leader length
 static size_t ins_compl_leader_len(void)
 {
@@ -1739,12 +1745,6 @@ bool compl_match_curr_select(int selected)
 
 #define DICT_FIRST      (1)     ///< use just first element in "dict"
 #define DICT_EXACT      (2)     ///< "dict" is the exact name of a file
-
-/// Get current completion leader
-char *ins_compl_leader(void)
-{
-  return compl_leader.data != NULL ? compl_leader.data : compl_orig_text.data;
-}
 
 /// Add any identifiers that match the given pattern "pat" in the list of
 /// dictionary files "dict_start" to the list of completions.


### PR DESCRIPTION
#### vim-patch:9.1.1781: some functions could be defined static

Problem:  some functions could be defined static
Solution: Change function definitions and make them static
          (Yegappan Lakshmanan)

closes: vim/vim#18354

https://github.com/vim/vim/commit/3a6cf6d53b0ecf84ae4a0f8073996b34117251db

Co-authored-by: Yegappan Lakshmanan <yegappan@yahoo.com>


#### vim-patch:9.1.1783: ins_compl_leader() too far away from ins_compl_leader_len()

Problem:  ins_compl_leader() defined too far away from
          ins_compl_leader_len() (after 9.1.1781).
Solution: Move ins_compl_leader() just before ins_compl_leader_len().
          Add missing "static" to eval0_simple_funccal() definition.
          (zeertzjq).

closes: vim/vim#18364

https://github.com/vim/vim/commit/94c128184f926e6330973e5979fde320f04102f5