### PR TITLE
vim-patch:224f8ca: runtime(doc): clarify 'fileignorecase' option setting

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2791,7 +2791,13 @@ A jump table for the options with a short description can be found at |Q_op|.
 'fileignorecase' 'fic'	boolean	(default on for systems where case in file
                                  names is normally ignored)
 			global
-	When set case is ignored when using file names and directories.
+	When set, case is ignored when using file and directory names.
+
+	This option is on by default on systems where the filesystem is
+	traditionally case-insensitive (for example MS-Windows and macOS).
+	However, Vim cannot determine at runtime whether a particular
+	filesystem is case-sensitive or case-insensitive.
+
 	See 'wildignorecase' for only ignoring case when doing completion.
 
 						*'filetype'* *'ft'*

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -2501,7 +2501,13 @@ vim.o.ffs = vim.o.fileformats
 vim.go.fileformats = vim.o.fileformats
 vim.go.ffs = vim.go.fileformats
 
---- When set case is ignored when using file names and directories.
+--- When set, case is ignored when using file and directory names.
+---
+--- This option is on by default on systems where the filesystem is
+--- traditionally case-insensitive (for example MS-Windows and macOS).
+--- However, Vim cannot determine at runtime whether a particular
+--- filesystem is case-sensitive or case-insensitive.
+---
 --- See 'wildignorecase' for only ignoring case when doing completion.
 ---
 --- @type boolean

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3173,7 +3173,13 @@ local options = {
    names is normally ignored]],
       },
       desc = [=[
-        When set case is ignored when using file names and directories.
+        When set, case is ignored when using file and directory names.
+
+        This option is on by default on systems where the filesystem is
+        traditionally case-insensitive (for example MS-Windows and macOS).
+        However, Vim cannot determine at runtime whether a particular
+        filesystem is case-sensitive or case-insensitive.
+
         See 'wildignorecase' for only ignoring case when doing completion.
       ]=],
       full_name = 'fileignorecase',


### PR DESCRIPTION
#### vim-patch:224f8ca: runtime(doc): clarify 'fileignorecase' option setting

https://github.com/vim/vim/commit/224f8ca769f2f5c8c4f3293e2adf7672418ba2fe

Co-authored-by: Christian Brabandt <cb@256bit.org>