### PR TITLE
fix(message): no wait return for delayed exception error

### DIFF
--- a/src/nvim/ex_cmds2.c
+++ b/src/nvim/ex_cmds2.c
@@ -388,10 +388,12 @@ bool check_changed_any(bool hidden, bool unload)
       msg_col = 0;
       msg_didout = false;
     }
-    if ((buf->terminal && channel_job_running((uint64_t)buf->b_p_channel))
-        ? semsg(_("E947: Job still running in buffer \"%s\""), buf->b_fname)
-        : semsg(_("E162: No write since last change for buffer \"%s\""),
-                buf_spname(buf) != NULL ? buf_spname(buf) : buf->b_fname)) {
+    if (((buf->terminal && channel_job_running((uint64_t)buf->b_p_channel))
+         ? semsg(_("E947: Job still running in buffer \"%s\""), buf->b_fname)
+         : semsg(_("E162: No write since last change for buffer \"%s\""),
+                 buf_spname(buf) != NULL ? buf_spname(buf) : buf->b_fname))
+        // Only makes sense if error is shown, which cause_errthrow() may prevent.
+        && msg_didany) {
       int save = no_wait_return;
       no_wait_return = false;
       wait_return(false);

--- a/test/functional/ui/messages_spec.lua
+++ b/test/functional/ui/messages_spec.lua
@@ -2053,6 +2053,16 @@ vimComment     xxx match /\s"[^\-:.%#=*].*$/ms=s+1,lc=1  excludenl contains=@vim
     feed('<CR>')
     assert_alive()
   end)
+
+  it('no wait return before delayed exception error message', function()
+    feed('ia<esc>:lua vim.cmd.quit()<CR>')
+    screen:expect({
+      any = {
+        '{9:.*Vim:E37: No write since.*}',
+        '{6:Press ENTER or type command to continue}^',
+      },
+    })
+  end)
 end)
 
 it('calling screenstring() after redrawing between messages without UI #20999', function()


### PR DESCRIPTION
Problem:  Wait return for delayed exception error message.
Solution: Check that error was actually shown.

Fix #35876