### PR TITLE
test: don't block to wait for previous session's exit

### DIFF
--- a/test/client/rpc_stream.lua
+++ b/test/client/rpc_stream.lua
@@ -105,8 +105,8 @@ function RpcStream:read_stop()
   self._stream:read_stop()
 end
 
-function RpcStream:close(signal)
-  self._stream:close(signal)
+function RpcStream:close(signal, noblock)
+  self._stream:close(signal, noblock)
 end
 
 return RpcStream

--- a/test/client/session.lua
+++ b/test/client/session.lua
@@ -13,7 +13,7 @@ local RpcStream = require('test.client.rpc_stream')
 --- @field private _prepare uv.uv_prepare_t
 --- @field private _timer uv.uv_timer_t
 --- @field private _is_running boolean true during `Session:run()` scope.
---- @field exec_lua_setup boolean
+--- @field data table Arbitrary user data.
 local Session = {}
 Session.__index = Session
 if package.loaded['jit'] then
@@ -172,14 +172,14 @@ function Session:stop()
   uv.stop()
 end
 
-function Session:close(signal)
+function Session:close(signal, noblock)
   if not self._timer:is_closing() then
     self._timer:close()
   end
   if not self._prepare:is_closing() then
     self._prepare:close()
   end
-  self._rpc_stream:close(signal)
+  self._rpc_stream:close(signal, noblock)
   self.closed = true
 end
 

--- a/test/functional/testnvim.lua
+++ b/test/functional/testnvim.lua
@@ -1,5 +1,6 @@
 local uv = vim.uv
 local t = require('test.testutil')
+local busted = require('busted')
 
 local Session = require('test.client.session')
 local uv_stream = require('test.client.uv_stream')
@@ -438,24 +439,12 @@ local function remove_args(args, args_rm)
   return new_args
 end
 
-function M.check_close()
+function M.check_close(noblock)
   if not session then
     return
   end
-  local start_time = uv.now()
-  session:close()
-  uv.update_time() -- Update cached value of luv.now() (libuv: uv_now()).
-  local end_time = uv.now()
-  local delta = end_time - start_time
-  if delta > 500 then
-    print(
-      'nvim took '
-        .. delta
-        .. ' milliseconds to exit after last test\n'
-        .. 'This indicates a likely problem with the test even if it passed!\n'
-    )
-    io.stdout:flush()
-  end
+
+  session:close(nil, noblock)
   session = nil
 end
 
@@ -492,6 +481,8 @@ function M.clear(...)
   return M.get_session()
 end
 
+local n_processes = 0
+
 --- Starts a new Nvim process with the given args and returns a msgpack-RPC session.
 ---
 --- Does not replace the current global session, unlike `clear()`.
@@ -501,15 +492,43 @@ end
 --- @return test.Session
 --- @overload fun(keep: boolean, opts: test.session.Opts): test.Session
 function M.new_session(keep, ...)
-  if not keep then
-    M.check_close()
+  local test_id = _G._nvim_test_id
+  if not keep and session ~= nil then
+    -- Don't block for the previous session's exit if it's from a different test.
+    session:close(nil, session.data and session.data.test_id ~= test_id)
+    session = nil
   end
 
   local argv, env, io_extra = M._new_argv(...)
 
-  local proc = ProcStream.spawn(argv, env, io_extra)
-  return Session.new(proc)
+  local proc = ProcStream.spawn(argv, env, io_extra, function(closed)
+    n_processes = n_processes - 1
+    local delta = 0
+    if closed then
+      uv.update_time() -- Update cached value of uv.now() (libuv: uv_now()).
+      delta = uv.now() - closed
+    end
+    if delta > 500 then
+      print(
+        ('Nvim session %s took %d milliseconds to exit\n'):format(test_id, delta)
+          .. 'This indicates a likely problem with the test even if it passed!\n'
+      )
+      io.stdout:flush()
+    end
+  end)
+  n_processes = n_processes + 1
+
+  local new_session = Session.new(proc)
+  new_session.data = { test_id = test_id }
+  return new_session
 end
+
+busted.subscribe({ 'suite', 'end' }, function()
+  M.check_close(true)
+  while n_processes > 0 do
+    uv.run('once')
+  end
+end)
 
 --- Starts a (non-RPC, `--headless --listen "Tx"`) Nvim process, waits for exit, and returns result.
 ---
@@ -1015,6 +1034,11 @@ return function()
 
   if after_each then
     after_each(function()
+      if not vim.endswith(_G._nvim_test_id, 'x') then
+        -- Use a different test ID for skipped tests as well as Nvim instances spawned
+        -- between this after_each() and the next before_each() (e.g. in setup()).
+        _G._nvim_test_id = _G._nvim_test_id .. 'x'
+      end
       check_logs()
       check_cores('build/bin/nvim')
       if session then
@@ -1027,5 +1051,6 @@ return function()
       end
     end)
   end
+
   return M
 end


### PR DESCRIPTION
This reduces the time taken by clear() by over 20% with ASAN.

Comparison of 3 runs from [`d92c098` (#35753)](https://github.com/neovim/neovim/commit/d92c098378a9febc6a8e3b0c739b5ac1ff0f8d97) and 3 runs from [`d12f2f6` (#35885)](https://github.com/neovim/neovim/commit/d12f2f6e557e910fb6b21d9651cbe460f1ebf6fc) (running time of functionaltest step only):

| **job** | **old (1)** | **old (2)** | **old (3)** | **new (1)** | **new (2)** | **new (3)** |
|---|---|---|---|---|---|---|
| **ubuntu asan clang functionaltest** | 18m 2s | 17m 19s | 17m 5s | 15m 26s | 15m 36s | 15m 21s |
| **ubuntu tsan clang functionaltest** | 17m 59s | 17m 48s | 18m 41s | 16m 24s | 18m 29s | 18m 52s |
| **ubuntu release gcc functionaltest** | 7m 22s | 7m 53s | 7m 44s | 7m 40s | 7m 28s | 7m 10s |
| **ubuntu arm clang functionaltest** | 8m 22s | 7m 42s | 7m 46s | 8m 4s | 8m 6s | 7m 51s |
| **macos intel clang functionaltest** | 13m 7s | 10m 44s | 12m 39s | 11m 38s | 13m 27s | 13m 12s |
| **macos arm clang functionaltest** | 7m 54s | 8m 4s | 7m 8s | 8m 0s | 7m 9s | 7m 42s |
| **ubuntu puc-lua gcc functionaltest** | 8m 29s | 8m 47s | 8m 37s | 8m 44s | 9m 9s | 8m 16s |
| **build using zig build (linux)** | 17m 15s | 17m 4s | 17m 12s | 16m 57s | 16m 48s | 16m 32s |
| **build using zig build (macos 15)** | 19m 6s | 17m 59s | 20m 17s | 20m 56s | 19m 7s | 18m 24s |
| **windows (functional)** | 13m 15s | 13m 34s | 13m 14s | 13m 13s | 12m 38s | 12m 49s |

There are a lot of fluctuations in runs of the the same commit, but at least the running time is consistently reduced in the **ubuntu asan clang functionaltest**, **build using zig build (linux)** and **windows (functional)** jobs.