### PR TITLE
vim-patch:5830407: runtime(netrw): 'equalalways' is not always respected

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -8,6 +8,7 @@
 " 2025 Sep 05 by Vim Project ensure netrw#fs#Dirname() returns trailing slash #18199
 " 2025 Sep 11 by Vim Project only keep cursor position in tree mode #18275
 " 2025 Sep 17 by Vim Project tighten the regex to handle remote compressed archives #18318
+" 2025 Sep 18 by Vim Project equalalwayse not always respected #18358
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -3838,6 +3839,8 @@ function s:NetrwBrowseChgDir(islocal, newdir, cursor, ...)
                     exe "keepalt ".(g:netrw_alto? "bel " : "abo ").winsz."wincmd s"
                     if !&ea
                         keepalt wincmd _
+                    else
+                        exe "keepalt wincmd ="
                     endif
                     call s:SetRexDir(a:islocal,curdir)
 
@@ -3847,6 +3850,8 @@ function s:NetrwBrowseChgDir(islocal, newdir, cursor, ...)
                     exe "keepalt ".(g:netrw_alto? "top " : "bot ")."vert ".winsz."wincmd s"
                     if !&ea
                         keepalt wincmd |
+                    else
+                        exe "keepalt wincmd ="
                     endif
                     call s:SetRexDir(a:islocal,curdir)
 
@@ -7020,6 +7025,9 @@ function s:NetrwSplit(mode)
         NetrwKeepj call s:RestoreWinVars()
         NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,s:NetrwGetWord(),1))
         unlet s:didsplit
+        if &ea
+            exe "keepalt wincmd ="
+        endif
 
     elseif a:mode == 4
         " local and t
@@ -7057,6 +7065,9 @@ function s:NetrwSplit(mode)
         NetrwKeepj call s:RestoreWinVars()
         NetrwKeepj call netrw#LocalBrowseCheck(s:NetrwBrowseChgDir(1,s:NetrwGetWord(),1))
         unlet s:didsplit
+        if &ea
+            exe "keepalt wincmd ="
+        endif
 
     else
         call netrw#msg#Notify('ERROR', '(NetrwSplit) unsupported mode='.a:mode)


### PR DESCRIPTION
#### vim-patch:5830407: runtime(netrw): 'equalalways' is not always respected

https://github.com/vim/vim/commit/58304078ad0a4954fe57699acc6e75d0b9da86c0

Co-authored-by: Christian Brabandt <cb@256bit.org>