### PR TITLE
test(tui_spec): avoid dangling Nvim processes on test failure

### DIFF
--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -3820,6 +3820,10 @@ describe('TUI client', function()
   it('connects to remote instance (with its own TUI)', function()
     local server_super = n.new_session(false)
     local client_super = n.new_session(true)
+    finally(function()
+      server_super:close()
+      client_super:close()
+    end)
 
     set_session(server_super)
     local server_pipe = new_pipename()
@@ -3894,14 +3898,15 @@ describe('TUI client', function()
     screen_client:expect({ any = 'GUI Running: 0' })
 
     feed_data(':q!\n')
-
-    server_super:close()
-    client_super:close()
   end)
 
   it('connects to remote instance (--headless)', function()
     local server = n.new_session(false)
     local client_super = n.new_session(true, { env = { NVIM_LOG_FILE = testlog } })
+    finally(function()
+      client_super:close()
+      server:close()
+    end)
 
     set_session(server)
     local server_pipe = api.nvim_get_vvar('servername')
@@ -3971,8 +3976,6 @@ describe('TUI client', function()
     feed_data(':echo "GUI Running: " .. has("gui_running")\013')
     screen_client:expect({ any = 'GUI Running: 0' })
 
-    client_super:close()
-    server:close()
     if is_os('mac') then
       assert_log('uv_tty_set_mode failed: Unknown system error %-102', testlog)
     end


### PR DESCRIPTION
Also don't wait indefinitely for all Nvim processes to exit.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
