### PR TITLE
test(lua/secure_spec): clean up properly

### DIFF
--- a/test/functional/lua/secure_spec.lua
+++ b/test/functional/lua/secure_spec.lua
@@ -276,14 +276,10 @@ describe('vim.secure', function()
 
     setup(function()
       clear { env = { XDG_STATE_HOME = xstate } }
-      n.mkdir_p(xstate .. pathsep .. (is_os('win') and 'nvim-data' or 'nvim'))
-    end)
-
-    teardown(function()
-      n.rmdir(xstate)
     end)
 
     before_each(function()
+      n.mkdir_p(xstate .. pathsep .. (is_os('win') and 'nvim-data' or 'nvim'))
       t.write_file('test_file', 'test')
       t.mkdir('test_dir')
     end)
@@ -291,6 +287,7 @@ describe('vim.secure', function()
     after_each(function()
       os.remove('test_file')
       n.rmdir('test_dir')
+      n.rmdir(xstate)
     end)
 
     it('returns error when passing both path and bufnr', function()
@@ -309,70 +306,70 @@ describe('vim.secure', function()
 
     it('trust then deny then remove a file using bufnr', function()
       local cwd = fn.getcwd()
-      local hash = fn.sha256(read_file('test_file'))
+      local hash = fn.sha256(assert(read_file('test_file')))
       local full_path = cwd .. pathsep .. 'test_file'
 
       command('edit test_file')
       eq({ true, full_path }, exec_lua([[return {vim.secure.trust({action='allow', bufnr=0})}]]))
-      local trust = read_file(stdpath('state') .. pathsep .. 'trust')
+      local trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
       eq(string.format('%s %s', hash, full_path), vim.trim(trust))
 
       eq({ true, full_path }, exec_lua([[return {vim.secure.trust({action='deny', bufnr=0})}]]))
-      trust = read_file(stdpath('state') .. pathsep .. 'trust')
+      trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
       eq(string.format('! %s', full_path), vim.trim(trust))
 
       eq({ true, full_path }, exec_lua([[return {vim.secure.trust({action='remove', bufnr=0})}]]))
-      trust = read_file(stdpath('state') .. pathsep .. 'trust')
+      trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
       eq('', vim.trim(trust))
     end)
 
     it('deny then trust then remove a file using bufnr', function()
       local cwd = fn.getcwd()
-      local hash = fn.sha256(read_file('test_file'))
+      local hash = fn.sha256(assert(read_file('test_file')))
       local full_path = cwd .. pathsep .. 'test_file'
 
       command('edit test_file')
       eq({ true, full_path }, exec_lua([[return {vim.secure.trust({action='deny', bufnr=0})}]]))
-      local trust = read_file(stdpath('state') .. pathsep .. 'trust')
+      local trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
       eq(string.format('! %s', full_path), vim.trim(trust))
 
       eq({ true, full_path }, exec_lua([[return {vim.secure.trust({action='allow', bufnr=0})}]]))
-      trust = read_file(stdpath('state') .. pathsep .. 'trust')
+      trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
       eq(string.format('%s %s', hash, full_path), vim.trim(trust))
 
       eq({ true, full_path }, exec_lua([[return {vim.secure.trust({action='remove', bufnr=0})}]]))
-      trust = read_file(stdpath('state') .. pathsep .. 'trust')
+      trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
       eq('', vim.trim(trust))
     end)
 
     it('trust using bufnr then deny then remove a file using path', function()
       local cwd = fn.getcwd()
-      local hash = fn.sha256(read_file('test_file'))
+      local hash = fn.sha256(assert(read_file('test_file')))
       local full_path = cwd .. pathsep .. 'test_file'
 
       command('edit test_file')
       eq({ true, full_path }, exec_lua([[return {vim.secure.trust({action='allow', bufnr=0})}]]))
-      local trust = read_file(stdpath('state') .. pathsep .. 'trust')
+      local trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
       eq(string.format('%s %s', hash, full_path), vim.trim(trust))
 
       eq(
         { true, full_path },
         exec_lua([[return {vim.secure.trust({action='deny', path='test_file'})}]])
       )
-      trust = read_file(stdpath('state') .. pathsep .. 'trust')
+      trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
       eq(string.format('! %s', full_path), vim.trim(trust))
 
       eq(
         { true, full_path },
         exec_lua([[return {vim.secure.trust({action='remove', path='test_file'})}]])
       )
-      trust = read_file(stdpath('state') .. pathsep .. 'trust')
+      trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
       eq('', vim.trim(trust))
     end)
 
     it('deny then trust then remove a file using bufnr', function()
       local cwd = fn.getcwd()
-      local hash = fn.sha256(read_file('test_file'))
+      local hash = fn.sha256(assert(read_file('test_file')))
       local full_path = cwd .. pathsep .. 'test_file'
 
       command('edit test_file')
@@ -380,18 +377,18 @@ describe('vim.secure', function()
         { true, full_path },
         exec_lua([[return {vim.secure.trust({action='deny', path='test_file'})}]])
       )
-      local trust = read_file(stdpath('state') .. pathsep .. 'trust')
+      local trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
       eq(string.format('! %s', full_path), vim.trim(trust))
 
       eq({ true, full_path }, exec_lua([[return {vim.secure.trust({action='allow', bufnr=0})}]]))
-      trust = read_file(stdpath('state') .. pathsep .. 'trust')
+      trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
       eq(string.format('%s %s', hash, full_path), vim.trim(trust))
 
       eq(
         { true, full_path },
         exec_lua([[return {vim.secure.trust({action='remove', path='test_file'})}]])
       )
-      trust = read_file(stdpath('state') .. pathsep .. 'trust')
+      trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
       eq('', vim.trim(trust))
     end)
 
@@ -403,14 +400,22 @@ describe('vim.secure', function()
       )
     end)
 
-    it('trust directory bufnr', function()
+    it('trust then deny then remove a directory using bufnr', function()
       local cwd = fn.getcwd()
       local full_path = cwd .. pathsep .. 'test_dir'
       command('edit test_dir')
 
       eq({ true, full_path }, exec_lua([[return {vim.secure.trust({action='allow', bufnr=0})}]]))
-      local trust = read_file(stdpath('state') .. pathsep .. 'trust')
+      local trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
       eq(string.format('directory %s', full_path), vim.trim(trust))
+
+      eq({ true, full_path }, exec_lua([[return {vim.secure.trust({action='deny', bufnr=0})}]]))
+      trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
+      eq(string.format('! %s', full_path), vim.trim(trust))
+
+      eq({ true, full_path }, exec_lua([[return {vim.secure.trust({action='remove', bufnr=0})}]]))
+      trust = assert(read_file(stdpath('state') .. pathsep .. 'trust'))
+      eq('', vim.trim(trust))
     end)
   end)
 end)


### PR DESCRIPTION
- Remove "state" directory after each test, so that a failure in one
  test won't interfere with later tests.
- Still make sure the trust file is empty at the end of each test.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
