### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1342,10 +1342,10 @@ file picker: >
 
 	set findfunc=Find
 	func Find(arg, _)
-          if empty(s:filescache)
-            let s:filescache = globpath('.', '**', 1, 1)
-            call filter(s:filescache, '!isdirectory(v:val)')
-            call map(s:filescache, "fnamemodify(v:val, ':.')")
+	  if empty(s:filescache)
+	    let s:filescache = globpath('.', '**', 1, 1)
+	    call filter(s:filescache, '!isdirectory(v:val)')
+	    call map(s:filescache, "fnamemodify(v:val, ':.')")
 	  endif
 	  return a:arg == '' ? s:filescache : matchfuzzy(s:filescache, a:arg)
 	endfunc

--- a/runtime/doc/cmdline.txt
+++ b/runtime/doc/cmdline.txt
@@ -1342,12 +1342,14 @@ file picker: >
 
 	set findfunc=Find
 	func Find(arg, _)
-	  if get(s:, 'filescache', []) == []
-	    let s:filescache = systemlist(
-		\ 'find . -path "*/.git" -prune -o -type f -print')
+          if empty(s:filescache)
+            let s:filescache = globpath('.', '**', 1, 1)
+            call filter(s:filescache, '!isdirectory(v:val)')
+            call map(s:filescache, "fnamemodify(v:val, ':.')")
 	  endif
 	  return a:arg == '' ? s:filescache : matchfuzzy(s:filescache, a:arg)
 	endfunc
+	let s:filescache = []
 	autocmd CmdlineEnter : let s:filescache = []
 
 The `:Grep` command searches for lines matching a pattern and updates the
@@ -1358,8 +1360,8 @@ the `CmdlineLeavePre` autocmd from the next section): >
 		\ Grep call <SID>VisitFile()
 
 	func s:Grep(arglead, cmdline, cursorpos)
-	  let cmd = $'grep -REIHns "{a:arglead}" --exclude-dir=.git
-		\ --exclude=".*"'
+	  if match(&grepprg, '\$\*') == -1 | let &grepprg .= ' $*' | endif
+	  let cmd = substitute(&grepprg, '\$\*', shellescape(escape(a:arglead, '\')), '')
 	  return len(a:arglead) > 1 ? systemlist(cmd) : []
 	endfunc
 

--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -8,7 +8,7 @@
 " 2025 Sep 05 by Vim Project ensure netrw#fs#Dirname() returns trailing slash #18199
 " 2025 Sep 11 by Vim Project only keep cursor position in tree mode #18275
 " 2025 Sep 17 by Vim Project tighten the regex to handle remote compressed archives #18318
-" 2025 Sep 18 by Vim Project equalalwayse not always respected #18358
+" 2025 Sep 18 by Vim Project 'equalalways' not always respected #18358
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright


### PR DESCRIPTION
#### vim-patch:34747a1: runtime(doc): update live-grep and fuzzy-file-picker examples

closes: vim/vim#18371

https://github.com/vim/vim/commit/34747a13e08770ca871e08581551f05153dce9e2

Co-authored-by: Konfekt <Konfekt@users.noreply.github.com>


#### vim-patch:1ae980a: runtime(doc): fix inconsistent indent in cmdline.txt

Also fix typo in autoload/netrw.vim.

related: vim/vim#18371
closes: vim/vim#18376

https://github.com/vim/vim/commit/1ae980a9cb8d8cb5e5897f3708ddeb7c8c0555bd