### PR TITLE
vim-patch:4b97fc9: runtime(javascript): Add "using" keyword to JavaScript syntax highlighting

### DIFF
--- a/runtime/syntax/javascript.vim
+++ b/runtime/syntax/javascript.vim
@@ -12,6 +12,7 @@
 " 		2018 Apr 14: adjusted javaScriptRegexpString (LongJohnCoder)
 " 		2024 Aug 14: fix a few stylistic issues (#15480)
 " 		2025 Aug 07: as is a reserved keyword (#17912)
+" 		2025 Sep 24: using is a reserved keyword (Devin Weaver)
 
 " tuning parameters:
 " unlet javaScript_fold
@@ -68,7 +69,7 @@ syn keyword javaScriptMessage		alert confirm prompt status
 syn keyword javaScriptGlobal		self window top parent
 syn keyword javaScriptMember		document event location
 syn keyword javaScriptDeprecated	escape unescape
-syn keyword javaScriptReserved		abstract as boolean byte char class const debugger double enum export extends final float from goto implements import int interface let long native package private protected public short super synchronized throws transient var volatile async
+syn keyword javaScriptReserved		abstract as boolean byte char class const debugger double enum export extends final float from goto implements import int interface let long native package private protected public short super synchronized throws transient var volatile async using
 syn keyword javaScriptModifier  static
 
 syn cluster  javaScriptEmbededExpr	contains=javaScriptBoolean,javaScriptNull,javaScriptIdentifier,javaScriptStringD,javaScriptStringS,javaScriptStringT


### PR DESCRIPTION
#### vim-patch:4b97fc9: runtime(javascript): Add "using" keyword to JavaScript syntax highlighting

Prior to this change, const and let were keywords for variable
declarations.

This change adds `using` as another keyword for variable declaration.

This JavaScript feature was recently introduced.

Docs:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/using

closes: vim/vim#18381

https://github.com/vim/vim/commit/4b97fc901fd5fc52c2e9ac77c3710976cec5ea9a

Co-authored-by: Devin Weaver <suki@tritarget.org>