### PR TITLE
test(unit): disable JIT when using mocks

### DIFF
--- a/test/unit/eval/typval_spec.lua
+++ b/test/unit/eval/typval_spec.lua
@@ -2318,7 +2318,7 @@ describe('typval.c', function()
           return lib.tv_dict_extend(d1, d2, action)
         end, emsg)
       end
-      pending('works (skip due to flakiness)', function()
+      itp('works', function()
         local d1 = dict()
         alloc_log:check({ a.dict(d1) })
         eq({}, dct2tbl(d1))
@@ -3206,7 +3206,7 @@ describe('typval.c', function()
         end)
       end)
       describe('lnum()', function()
-        pending('works (skip due to flakiness)', function()
+        itp('works', function()
           for _, v in ipairs({
             { lib.VAR_NUMBER, { v_number = 42 }, nil, 42 },
             { lib.VAR_STRING, { v_string = to_cstr('100500') }, nil, 100500 },
@@ -3335,7 +3335,7 @@ describe('typval.c', function()
         end
       end
       describe('string()', function()
-        pending('works (skip due to flakiness)', function()
+        itp('works', function()
           local buf = lib.tv_get_string(lua2typvalt(int(1)))
           local buf_chk = lib.tv_get_string_chk(lua2typvalt(int(1)))
           neq(buf, buf_chk)

--- a/test/unit/testutil.lua
+++ b/test/unit/testutil.lua
@@ -352,6 +352,9 @@ local function alloc_log_new()
         end
       end
     end
+    -- JIT-compiled FFI calls cannot call back into Lua, so disable JIT.
+    -- Ref: https://luajit.org/ext_ffi_semantics.html#callback
+    jit.off()
   end
 
   log.set_mocks = child_call(log.set_mocks)


### PR DESCRIPTION
Fix #24100

This fixes the flaky eval/typval_spec.lua tests.

100 runs without `jit.off()`: https://github.com/zeertzjq/neovim/actions/runs/18006172833
100 runs with `jit.off()` (macos intel job timed out at run 92): https://github.com/zeertzjq/neovim/actions/runs/18006084875