### PR TITLE
fix(extui): setup buffers after activating `eventignorewin`

### DIFF
--- a/runtime/lua/vim/_extui/shared.lua
+++ b/runtime/lua/vim/_extui/shared.lua
@@ -66,27 +66,20 @@ function M.check_targets()
 
     if setopt then
       local name = { cmd = 'Cmd', dialog = 'Dialog', msg = 'Msg', pager = 'Pager' }
-      api.nvim_buf_set_name(M.bufs[type], ('[%s]'):format(name[type]))
-      api.nvim_set_option_value('swapfile', false, { buf = M.bufs[type] })
-      api.nvim_set_option_value('modifiable', true, { buf = M.bufs[type] })
-      api.nvim_set_option_value('bufhidden', 'hide', { buf = M.bufs[type] })
-      api.nvim_set_option_value('buftype', 'nofile', { buf = M.bufs[type] })
-      if type == 'pager' then
-        -- Close pager with `q`, same as `checkhealth`
-        api.nvim_buf_set_keymap(M.bufs.pager, 'n', 'q', '<Cmd>wincmd c<CR>', {})
-      elseif type == M.cfg.msg.target then
-        M.msg.prev_msg = '' -- Will no longer be visible.
-      end
-
       -- Fire a FileType autocommand with window context to let the user reconfigure local options.
+      -- First set 'eventignorewin' to avoid firing OptionSet and BufFilePost.
       api.nvim_win_call(M.wins[type], function()
-        api.nvim_set_option_value('wrap', true, { scope = 'local' })
-        api.nvim_set_option_value('linebreak', false, { scope = 'local' })
-        api.nvim_set_option_value('smoothscroll', true, { scope = 'local' })
         local ft = name[type]:sub(1, 1):lower() .. name[type]:sub(2)
         api.nvim_set_option_value('filetype', ft, { scope = 'local' })
         local ignore = 'all' .. (type == 'pager' and ',-TextYankPost' or '')
         api.nvim_set_option_value('eventignorewin', ignore, { scope = 'local' })
+        api.nvim_set_option_value('wrap', true, { scope = 'local' })
+        api.nvim_set_option_value('linebreak', false, { scope = 'local' })
+        api.nvim_set_option_value('smoothscroll', true, { scope = 'local' })
+        api.nvim_set_option_value('swapfile', false, { scope = 'local' })
+        api.nvim_set_option_value('modifiable', true, { scope = 'local' })
+        api.nvim_set_option_value('bufhidden', 'hide', { scope = 'local' })
+        api.nvim_set_option_value('buftype', 'nofile', { scope = 'local' })
         if type ~= 'msg' then
           -- Use MsgArea and hide search highlighting in the cmdline window.
           local hl = 'Normal:MsgArea'
@@ -94,6 +87,14 @@ function M.check_targets()
           api.nvim_set_option_value('winhighlight', hl, { scope = 'local' })
         end
       end)
+      api.nvim_buf_set_name(M.bufs[type], ('[%s]'):format(name[type]))
+
+      if type == 'pager' then
+        -- Close pager with `q`, same as `checkhealth`
+        api.nvim_buf_set_keymap(M.bufs.pager, 'n', 'q', '<Cmd>wincmd c<CR>', {})
+      elseif type == M.cfg.msg.target then
+        M.msg.prev_msg = '' -- Will no longer be visible.
+      end
     end
   end
   tab = curtab


### PR DESCRIPTION
Problem: setting up extui buffers sends redundant events.

```lua
require('vim._extui').enable({enable = true, msg = {target = 'msg'}})
vim.api.nvim_create_autocmd('BufFilePost', {
  callback = function (ev) print(ev.match) end
})
```

For example, gitsigns attempts to attach these buffers.

Solution: set them up when `eventignorewin` is active.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
