### PR TITLE
vim-patch:9.1.1790: completion: Enter does not insert match with "noinsert"

### DIFF
--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -5451,7 +5451,7 @@ static int ins_compl_next(bool allow_get_expansion, int count, bool insert_match
 
   // Enter will select a match when the match wasn't inserted and the popup
   // menu is visible.
-  if (compl_no_insert && !started && compl_selected_item != -1) {
+  if (compl_no_insert && !started && !match_at_original_text(compl_shown_match)) {
     compl_enter_selects = true;
   } else {
     compl_enter_selects = !insert_match && compl_match_array != NULL;


### PR DESCRIPTION
#### vim-patch:9.1.1790: completion: Enter does not insert match with "noinsert"

Problem:  completion: Enter does not insert match with "noinsert".
          (Sergey Vlasov)
Solution: Check for compl_shown_match instead of compl_selected_item
          (zeertzjq).

related: vim/vim#1653
closes: vim/vim#18395

https://github.com/vim/vim/commit/ef818ae4448726b91c31e24406a554686dea19f5