### PR TITLE
test: make preload of functional/testnvim.lua explicit

### DIFF
--- a/test/benchmark/preload.lua
+++ b/test/benchmark/preload.lua
@@ -1,4 +1,4 @@
 -- Modules loaded here will not be cleared and reloaded by Busted.
 -- Busted started doing this to help provide more isolation.  See issue #62
 -- for more information about this.
-local n = require('test.functional.testnvim')
+require('test.functional.testnvim')()

--- a/test/functional/preload.lua
+++ b/test/functional/preload.lua
@@ -2,6 +2,7 @@
 -- Busted started doing this to help provide more isolation.  See issue #62
 -- for more information about this.
 local t = require('test.testutil')
+require('test.functional.testnvim')()
 require('test.functional.ui.screen')
 
 local has_ffi, ffi = pcall(require, 'ffi')

--- a/test/unit/preload.lua
+++ b/test/unit/preload.lua
@@ -1,6 +1,6 @@
 -- Modules loaded here will not be cleared and reloaded by Busted.
 -- Busted started doing this to help provide more isolation.  See issue #62
 -- for more information about this.
-local ffi = require('ffi')
-local t = require('test.unit.testutil')
-local preprocess = require('test.unit.preprocess')
+require('ffi')
+require('test.unit.testutil')
+require('test.unit.preprocess')


### PR DESCRIPTION
Before functional/testnvim.lua was moved from functional/testutil.lua in
052498ed42780a76daea589d063cd8947a894673, it was explicitly preloaded,
but now it is preloaded implicitly via functional/ui/screen.lua.

Also fix warnings about unused variables in other preload.lua files.
