### PR TITLE
build: remove redundant variable in cmake/Deps.cmake

### DIFF
--- a/cmake/Deps.cmake
+++ b/cmake/Deps.cmake
@@ -91,7 +91,7 @@ function(get_externalproject_options name DEPS_IGNORE_SHA)
 
   set(EXTERNALPROJECT_OPTIONS
     DOWNLOAD_NO_PROGRESS TRUE
-    EXTERNALPROJECT_OPTIONS URL ${${name_allcaps}_URL}
+    URL ${${name_allcaps}_URL}
     CMAKE_CACHE_ARGS ${DEPS_CMAKE_CACHE_ARGS})
 
   if(NOT ${DEPS_IGNORE_SHA})


### PR DESCRIPTION
build: remove redundant variable in cmake

Problem:
redundant variable `EXTERNALPROJECT_OPTIONS` in cmake/Deps.cmake

Solution:
remove it