### PR TITLE
fix(cmd): make :update work on new unmodified buffers

### DIFF
--- a/src/nvim/ex_cmds.c
+++ b/src/nvim/ex_cmds.c
@@ -1772,7 +1772,7 @@ void ex_file(exarg_T *eap)
 /// ":update".
 void ex_update(exarg_T *eap)
 {
-  if (curbufIsChanged()) {
+  if (curbufIsChanged() || (curbuf->b_ffname != NULL && !os_path_exists(curbuf->b_ffname))) {
     do_write(eap);
   }
 }


### PR DESCRIPTION
Problem: update command does not write new buffers that have
filenames but no corresponding file on disk, even when using ++p flag.

Solution: allow update to write when buffer has filename but file
doesn't exist.

Fix #35145 

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
