### PR TITLE
fix(lsp): lsp.WatchKind can be vim.NIL

### DIFF
--- a/runtime/lua/vim/lsp/_meta/protocol.lua
+++ b/runtime/lua/vim/lsp/_meta/protocol.lua
@@ -2696,7 +2696,7 @@ error('Cannot require a meta file')
 ---The kind of events of interest. If omitted it defaults
 ---to WatchKind.Create | WatchKind.Change | WatchKind.Delete
 ---which is 7.
----@field kind? lsp.WatchKind
+---@field kind? lsp.WatchKind|lsp.null
 
 ---Represents a diagnostic, such as a compiler error or warning. Diagnostic objects
 ---are only valid in the scope of a resource.

--- a/runtime/lua/vim/lsp/_watchfiles.lua
+++ b/runtime/lua/vim/lsp/_watchfiles.lua
@@ -58,7 +58,7 @@ function M.register(reg, client_id)
   ---@type table<string, {pattern: vim.lpeg.Pattern, kind: lsp.WatchKind}[]> by base_dir
   local watch_regs = vim.defaulttable()
   for _, w in ipairs(register_options.watchers) do
-    local kind = w.kind
+    local kind = (w.kind ~= vim.NIL and w.kind)
       or (protocol.WatchKind.Create + protocol.WatchKind.Change + protocol.WatchKind.Delete)
     local glob_pattern = w.globPattern
 

--- a/test/functional/plugin/lsp_spec.lua
+++ b/test/functional/plugin/lsp_spec.lua
@@ -6258,6 +6258,13 @@ describe('LSP', function()
             kind = i,
           })
         end
+        table.insert(watchers, {
+          globPattern = {
+            baseUri = vim.uri_from_fname('/dir'),
+            pattern = 'watch' .. tostring(max_kind),
+          },
+          kind = vim.NIL,
+        })
         vim.lsp.handlers['client/registerCapability'](nil, {
           registrations = {
             {


### PR DESCRIPTION
https://microsoft.github.io/language-server-protocol/specifications/lsp/3.17/specification/#fileSystemWatcher

E.g. leanls sends requests which look like:

```
{
  id = "lean_watcher",
  method = "workspace/didChangeWatchedFiles",
  registerOptions = {
    watchers = { {
        globPattern = "**/*.lean",
        kind = vim.NIL
      }, {
        globPattern = "**/*.ilean",
        kind = vim.NIL
      } }
  }
```

which in this code path end up triggering:

```
Lua callback:
...n/Development/neovim/runtime/lua/vim/lsp/_watchfiles.lua:99: bad argument #1 to 'band' (number expected, got userdata)
stack traceback:
	[C]: in function 'band'
	...n/Development/neovim/runtime/lua/vim/lsp/_watchfiles.lua:99: in function 'callback'
	/Users/julian/Development/neovim/runtime/lua/vim/_watch.lua:96: in function </Users/julian/Development/neovim/runtime/lua/vim/_watch.lua:72>
	[builtin#36]: at 0x010547728c
	...ent/lean.nvim/packpath/inanis.nvim/lua/inanis/busted.lua:270: in function 'run'
	[string ":lua"]:1: in main chunk
```

Refs: #34849

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
