### PR TITLE
fix: remove reference to runtime/indent/Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,6 @@ ifneq ($(wildcard build),)
 	$(CMAKE) --build build --target clean
 endif
 	$(MAKE) -C test/old/testdir clean
-	$(MAKE) -C runtime/indent clean
 
 distclean:
 	$(call rmdir, $(DEPS_BUILD_DIR))


### PR DESCRIPTION
### Problem

`runtime/indent/Makefile` was removed in 2d8ed73, and now `make clean` and `make distclean` fail since those jobs call `make -C runtime/indent clean`

### Solution 

Remove call to `make -C runtime/indent clean`


Fixes #35933