### PR TITLE
fix(build): `make clean` looks into `runtime/indent/Makefile`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -162,7 +162,6 @@ ifneq ($(wildcard build),)
 	$(CMAKE) --build build --target clean
 endif
 	$(MAKE) -C test/old/testdir clean
-	$(MAKE) -C runtime/indent clean
 
 distclean:
 	$(call rmdir, $(DEPS_BUILD_DIR))


### PR DESCRIPTION
Problem: `make clean` fails within `runtime/indent` (2d8ed73143d730b819beb40b71571b0785b72662)

Solution: remove that recipe (after #35911)

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
