### PR TITLE
fix(lsp): use correct `workspace.diagnostics` capability key

### DIFF
--- a/runtime/lua/vim/lsp/protocol.lua
+++ b/runtime/lua/vim/lsp/protocol.lua
@@ -607,7 +607,7 @@ function protocol.make_client_capabilities()
       inlayHint = {
         refreshSupport = true,
       },
-      workspace = {
+      diagnostics = {
         refreshSupport = false,
       },
     },


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

Changing the capability path here from `workspace.workspace` to `workspace.diagnostics` (see https://microsoft.github.io/language-server-protocol/specifications/lsp/3.18/specification/#diagnostic_refresh)