### PR TITLE
fix(lsp): remove `vim.lsp.diagnostic.reset()`

### DIFF
--- a/runtime/doc/deprecated.txt
+++ b/runtime/doc/deprecated.txt
@@ -255,7 +255,6 @@ For each of the functions below, use the corresponding function in
 • *vim.lsp.diagnostic.goto_next()*
 • *vim.lsp.diagnostic.goto_prev()*
 • *vim.lsp.diagnostic.redraw()*		Use |vim.diagnostic.show()| instead.
-• *vim.lsp.diagnostic.reset()*
 • *vim.lsp.diagnostic.save()*		Use |vim.diagnostic.set()| instead.
 • *vim.lsp.diagnostic.set_loclist()*	Use |vim.diagnostic.setloclist()| instead.
 • *vim.lsp.diagnostic.set_qflist()*	Use |vim.diagnostic.setqflist()| instead.

--- a/runtime/lua/vim/lsp/diagnostic.lua
+++ b/runtime/lua/vim/lsp/diagnostic.lua
@@ -301,27 +301,6 @@ function M.on_diagnostic(error, result, ctx)
   end
 end
 
---- Clear push diagnostics and diagnostic cache.
----
---- Diagnostic producers should prefer |vim.diagnostic.reset()|. However,
---- this method signature is still used internally in some parts of the LSP
---- implementation so it's simply marked @private rather than @deprecated.
----
----@param client_id integer
----@param buffer_client_map table<integer, table<integer, table>> map of buffers to active clients
----@private
-function M.reset(client_id, buffer_client_map)
-  buffer_client_map = vim.deepcopy(buffer_client_map)
-  vim.schedule(function()
-    for bufnr, client_ids in pairs(buffer_client_map) do
-      if client_ids[client_id] then
-        local namespace = M.get_namespace(client_id, false)
-        vim.diagnostic.reset(namespace, bufnr)
-      end
-    end
-  end)
-end
-
 --- Get the diagnostics by line
 ---
 --- Marked private as this is used internally by the LSP subsystem, but


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->

This function was added in https://github.com/neovim/neovim/pull/15585 and has been deprecated since. I didn't find any usages of it in this repo and because it was private anyway I say we just kill it.