### PR TITLE
fix(docs): include `?` in list items

### DIFF
--- a/src/gen/gen_help_html.lua
+++ b/src/gen/gen_help_html.lua
@@ -633,7 +633,7 @@ local function visit_node(root, level, lang_tree, headings, opt, stats)
     end
     return s
   elseif node_name == 'argument' then
-    return ('%s<code>{%s}</code>'):format(ws(), text)
+    return ('%s<code>%s</code>'):format(ws(), trim(node_text(root)))
   elseif node_name == 'codeblock' then
     return text
   elseif node_name == 'language' then


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
I noticed that fields that we mark as optional ([example](https://github.com/neovim/neovim/blob/fcf752476a33a26058b3342ac09108f76801bd4b/runtime/lua/vim/lsp/inline_completion.lua#L51-L52)) don't have the `?` in the website ([example](https://neovim.io/doc/user/lsp.html#vim.lsp.inline_completion.Item)).

With this PR the generated HTML looks as follows:
<img width="1147" height="284" alt="image" src="https://github.com/user-attachments/assets/3763fd59-192d-4766-b263-6fce5f9a5163" />
