### PR TITLE
vim-patch:9.1.1802: 'nowrap' in a modeline may hide malicious code

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -7639,6 +7639,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 <	See 'sidescroll', 'listchars' and |wrap-off|.
 	This option can't be set from a |modeline| when the 'diff' option is
 	on.
+	If 'nowrap' was set from a |modeline| or in the |sandbox|, '>' is used
+	as the |lcs-extends| character regardless of the value of the 'list'
+	and 'listchars' options.  This is to prevent malicious code outside
+	the viewport from going unnoticed.  Use `:setlocal nowrap` manually
+	afterwards to disable this behavior.
 
 						*'wrapmargin'* *'wm'*
 'wrapmargin' 'wm'	number	(default 0)

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -8408,6 +8408,11 @@ vim.go.wiw = vim.go.winwidth
 --- See 'sidescroll', 'listchars' and `wrap-off`.
 --- This option can't be set from a `modeline` when the 'diff' option is
 --- on.
+--- If 'nowrap' was set from a `modeline` or in the `sandbox`, '>' is used
+--- as the `lcs-extends` character regardless of the value of the 'list'
+--- and 'listchars' options.  This is to prevent malicious code outside
+--- the viewport from going unnoticed.  Use `:setlocal nowrap` manually
+--- afterwards to disable this behavior.
 ---
 --- @type boolean
 vim.o.wrap = true

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1303,6 +1303,7 @@ struct window_S {
 #define GLOBAL_WO(p)    ((char *)(p) + sizeof(winopt_T))
 
   // A few options have local flags for kOptFlagInsecure.
+  uint32_t w_p_wrap_flags;          // flags for 'wrap'
   uint32_t w_p_stl_flags;           // flags for 'statusline'
   uint32_t w_p_wbr_flags;           // flags for 'winbar'
   uint32_t w_p_fde_flags;           // flags for 'foldexpr'

--- a/src/nvim/option.c
+++ b/src/nvim/option.c
@@ -1644,6 +1644,8 @@ uint32_t *insecure_flag(win_T *const wp, OptIndex opt_idx, int opt_flags)
   if (opt_flags & OPT_LOCAL) {
     assert(wp != NULL);
     switch (opt_idx) {
+    case kOptWrap:
+      return &wp->w_p_wrap_flags;
     case kOptStatusline:
       return &wp->w_p_stl_flags;
     case kOptWinbar:

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -10811,6 +10811,11 @@ local options = {
         <	See 'sidescroll', 'listchars' and |wrap-off|.
         This option can't be set from a |modeline| when the 'diff' option is
         on.
+        If 'nowrap' was set from a |modeline| or in the |sandbox|, '>' is used
+        as the |lcs-extends| character regardless of the value of the 'list'
+        and 'listchars' options.  This is to prevent malicious code outside
+        the viewport from going unnoticed.  Use `:setlocal nowrap` manually
+        afterwards to disable this behavior.
       ]=],
       full_name = 'wrap',
       redraw = { 'current_window' },


### PR DESCRIPTION
#### vim-patch:9.1.1802: 'nowrap' in a modeline may hide malicious code

Problem:  'nowrap' in a modeline may hide malicious code.
Solution: Forcibly use '>' as 'listchars' "extends" if 'nowrap' was set
          from a modeline (zeertzjq).

Manual `:setlocal nowrap` disables this behavior.  There is a separate
problem with `:set nowrap` that also applies to some other options.

related: vim/vim#18214
related: vim/vim#18399
closes: vim/vim#18425

https://github.com/vim/vim/commit/9d5208a9313dd8b0d62c97af5485f1715af98a1c

Cherry-pick some test_modeline.vim changes from patches 9.0.{0363,0626}.