### PR TITLE
vim-patch:91ac18c: runtime(java): Recognise _module_ import declarations

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1783,12 +1783,11 @@ cycles for such a feature to become either integrated into the platform or
 withdrawn from this effort.  To cater for early adopters, there is optional
 support in Vim for syntax related preview features that are implemented.  You
 can request it by specifying a list of preview feature numbers as follows: >
-	:let g:java_syntax_previews = [488, 494]
+	:let g:java_syntax_previews = [488]
 
 The supported JEP numbers are to be drawn from this table:
 	`430`: String Templates [JDK 21]
 	`488`: Primitive types in Patterns, instanceof, and switch
-	`494`: Module Import Declarations
 
 Note that as soon as the particular preview feature will have been integrated
 into the Java platform, its entry will be removed from the table and related

--- a/runtime/syntax/java.vim
+++ b/runtime/syntax/java.vim
@@ -3,7 +3,7 @@
 " Maintainer:		Aliaksei Budavei <0x000c70 AT gmail DOT com>
 " Former Maintainer:	Claudio Fleiner <claudio@fleiner.com>
 " Repository:		https://github.com/zzzyxwvut/java-vim.git
-" Last Change:		2025 Aug 30
+" Last Change:		2025 Sep 28
 
 " Please check ":help java.vim" for comments on some of the options
 " available.
@@ -110,12 +110,9 @@ syn keyword javaTypedef		this super
 syn keyword javaOperator	new instanceof
 syn match   javaOperator	"\<var\>\%(\s*(\)\@!"
 
-if s:ff.IsAnyRequestedPreviewFeatureOf([476, 494])
-  " Module imports can be used in any source file.
-  syn match   javaExternal	"\<import\s\+module\>" contains=javaModuleImport
-  syn keyword javaModuleImport	contained module
-  hi def link javaModuleImport	Statement
-endif
+" Module imports can be used in any source file.
+syn match   javaExternal	"\<import\s\+module\>" contains=javaModuleImport
+syn keyword javaModuleImport	contained module
 
 " Since the yield statement, which could take a parenthesised operand,
 " and _qualified_ yield methods get along within the switch block
@@ -921,6 +918,7 @@ hi def link javaAnnotation		PreProc
 hi def link javaAnnotationStart		javaAnnotation
 hi def link javaType			Type
 hi def link javaExternal		Include
+hi def link javaModuleImport		Statement
 
 hi def link javaUserLabel		Label
 hi def link javaUserLabelRef		javaUserLabel


### PR DESCRIPTION
#### vim-patch:91ac18c: runtime(java): Recognise _module_ import declarations

After two preview proposals (JEPs 476 and 494), _module_
import declarations are now a part of the language (JDK 25).

Reference:
https://openjdk.org/jeps/511

closes: vim/vim#18424

https://github.com/vim/vim/commit/91ac18cb036f87ceff83bf8d05f7c03b50b94633

Co-authored-by: Aliaksei Budavei <0x000c70@gmail.com>