### PR TITLE
fix(docs): ensure that numbered list items end with a new line

### DIFF
--- a/runtime/doc/lsp.txt
+++ b/runtime/doc/lsp.txt
@@ -2242,6 +2242,7 @@ To try it out, here is a quickstart example using Copilot:       *lsp-copilot*
 1. Install Copilot: >sh
     npm install --global @github/copilot-language-server
 <
+
 2. Define a config, (or copy `lsp/copilot.lua` from
    https://github.com/neovim/nvim-lspconfig): >lua
     vim.lsp.config('copilot', {
@@ -2249,14 +2250,18 @@ To try it out, here is a quickstart example using Copilot:       *lsp-copilot*
      root_markers = { '.git' },
    })
 <
+
 3. Activate the config: >lua
     vim.lsp.enable('copilot')
 <
+
 4. Sign in to Copilot, or use the `:LspCopilotSignIn` command from
    https://github.com/neovim/nvim-lspconfig
+
 5. Enable inline completion: >lua
     vim.lsp.inline_completion.enable()
 <
+
 6. Set a keymap for `vim.lsp.inline_completion.get()` and invoke the keymap.
 
 

--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -2162,6 +2162,7 @@ vim.validate({name}, {value}, {validator}, {optional}, {message})
           -- ...
         end
 <
+
     2. `vim.validate(spec)` (deprecated) where `spec` is of type
        `table<string,[value:any, validator: vim.validate.Validator, optional_or_msg? : boolean|string]>)`
        Validates a argument specification. Specs are evaluated in alphanumeric
@@ -2366,7 +2367,9 @@ vim.filetype.match({args})                              *vim.filetype.match()*
 
     The filetype can be detected using one of three methods:
     1. Using an existing buffer
+
     2. Using only a file name
+
     3. Using only file contents
 
     Of these, option 1 provides the most accurate result as it uses both the

--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1706,8 +1706,11 @@ Query:iter_captures({node}, {source}, {start_row}, {end_row}, {opts})
 
     The iterator returns four values:
     1. the numeric id identifying the capture
+
     2. the captured node
+
     3. metadata from any directives processing the match
+
     4. the match itself
 
     Example: how to get captures by name: >lua

--- a/src/gen/util.lua
+++ b/src/gen/util.lua
@@ -316,6 +316,10 @@ local function render_md(node, start_indent, indent, text_width, level, is_list)
   elseif contains(ntype, { 'list_marker_minus', 'list_marker_star' }) then
     parts[#parts + 1] = '• '
   elseif ntype == 'list_item' then
+    -- HACK(MariaSolOs): Revert this after the vimdoc parser supports numbered list-items (https://github.com/neovim/tree-sitter-vimdoc/issues/144)
+    if (node[1].text or ''):match('[2-9]%.') then
+      parts[#parts + 1] = '\n'
+    end
     parts[#parts + 1] = string.rep(' ', indent)
     local offset = node[1].type == 'list_marker_dot' and 3 or 2
     for i, child in ipairs(node) do


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
This way the generated HTML won't merge numbered lists into a single item (example in the brief [here](https://neovim.io/doc/user/lsp.html#_lua-module:-vim.lsp.inline_completion)).