### PR TITLE
vim-patch:992e307: runtime(doc): update list of modifiers at :h expand()

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -2711,7 +2711,7 @@ A jump table for the options with a short description can be found at |Q_op|.
 	illegal byte sequence.
 	WRONG VALUES:			WHAT'S WRONG:
 		latin1,utf-8		"latin1" will always be used
-		utf-8,ucs-bom,latin1	BOM won't be recognized in an utf-8
+		utf-8,ucs-bom,latin1	BOM won't be recognized in a utf-8
 					file
 		cp1250,latin1		"cp1250" will always be used
 	If 'fileencodings' is empty, 'fileencoding' is not modified.

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -2136,6 +2136,9 @@ expand({string} [, {nosuf} [, {list}]])                               *expand()*
 			:r		Root (one extension removed)
 			:e		Extension only
 
+		More modifiers are supported, for the full list see
+		|filename-modifiers|.
+
 		Example: >vim
 			let &tags = expand("%:p:h") .. "/tags"
 <		Note that when expanding a string that starts with '%', '#' or

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -2413,7 +2413,7 @@ vim.bo.fenc = vim.bo.fileencoding
 --- illegal byte sequence.
 --- WRONG VALUES:			WHAT'S WRONG:
 --- 	latin1,utf-8		"latin1" will always be used
---- 	utf-8,ucs-bom,latin1	BOM won't be recognized in an utf-8
+--- 	utf-8,ucs-bom,latin1	BOM won't be recognized in a utf-8
 --- 				file
 --- 	cp1250,latin1		"cp1250" will always be used
 --- If 'fileencodings' is empty, 'fileencoding' is not modified.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -1893,6 +1893,9 @@ function vim.fn.exp(expr) end
 ---   :r    Root (one extension removed)
 ---   :e    Extension only
 ---
+--- More modifiers are supported, for the full list see
+--- |filename-modifiers|.
+---
 --- Example: >vim
 ---   let &tags = expand("%:p:h") .. "/tags"
 --- <Note that when expanding a string that starts with '%', '#' or

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -2442,6 +2442,9 @@ M.funcs = {
       	:r		Root (one extension removed)
       	:e		Extension only
 
+      More modifiers are supported, for the full list see
+      |filename-modifiers|.
+
       Example: >vim
       	let &tags = expand("%:p:h") .. "/tags"
       <Note that when expanding a string that starts with '%', '#' or

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -3047,7 +3047,7 @@ local options = {
         illegal byte sequence.
         WRONG VALUES:			WHAT'S WRONG:
         	latin1,utf-8		"latin1" will always be used
-        	utf-8,ucs-bom,latin1	BOM won't be recognized in an utf-8
+        	utf-8,ucs-bom,latin1	BOM won't be recognized in a utf-8
         				file
         	cp1250,latin1		"cp1250" will always be used
         If 'fileencodings' is empty, 'fileencoding' is not modified.


### PR DESCRIPTION
#### vim-patch:992e307: runtime(doc): update list of modifiers at :h expand()

https://github.com/vim/vim/commit/992e30774f5ec81f53d5554c42137d3c85999081

Co-authored-by: Christian Brabandt <cb@256bit.org>