### PR TITLE
vim-patch:9.1.{1797,1800,1810}

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1638,11 +1638,22 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    to gather more alternatives for your candidate list,
 		    see 'completefuzzycollect'.
 
-	   longest  Only insert the longest common text of the matches.  If
-		    the menu is displayed you can use CTRL-L to add more
-		    characters.  Whether case is ignored depends on the kind
-		    of completion.  For buffer text the 'ignorecase' option is
-		    used.
+	   longest
+		    When 'autocomplete' is not active, only the longest
+		    common prefix of the matches is inserted.  If the popup
+		    menu is displayed, you can use CTRL-L to add more
+		    characters.  Whether case is ignored depends on the type
+		    of completion.  For buffer text the 'ignorecase' option
+		    applies.
+
+		    When 'autocomplete' is active and no completion item is
+		    selected, the longest common prefix of the matches is
+		    inserted after the cursor.  The prefix is taken either
+		    from all displayed items or only from items in the current
+		    buffer.  The inserted text is highlighted with
+		    |hl-PreInsert|, and the cursor position does not change
+		    (similar to `"preinsert"`).  Press CTRL-Y to accept.
+		    See also |preinserted()|.
 
 	   menu	    Use a popup menu to show the possible completions.  The
 		    menu is only shown when there is more than one match and
@@ -1675,22 +1686,21 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    with "menu" or "menuone".  Overrides "preview".
 
 	   preinsert
-		    When 'autocomplete' is not active, inserts the part of the
-		    first candidate word beyond the current completion leader,
-		    highlighted with |hl-PreInsert|.  The cursor doesn't move.
-		    Requires "fuzzy" unset and "menuone" in 'completeopt'.
-
-		    When 'autocomplete' is active, inserts the longest common
-		    prefix of matches (from all shown items or from the
-		    current buffer items).  This occurs only when no menu item
-		    is selected.  Press CTRL-Y to accept.
+		    Inserts the text of the first completion candidate
+		    beyond the current leader, highlighted with |hl-PreInsert|.
+		    The cursor does not move.
+		    Requires "fuzzy" to be unset, and either "menuone" in
+		    'completeopt' or 'autocomplete' enabled.  When
+		    'autocomplete' is enabled, this does not work if
+		    'ignorecase' is set without 'infercase'.
+		    See also |preinserted()|.
 
 	   preview  Show extra information about the currently selected
 		    completion in the preview window.  Only works in
 		    combination with "menu" or "menuone".
 
-	Only "fuzzy", "popup", "preinsert" and "preview" have an effect when
-	'autocomplete' is enabled.
+	Only "fuzzy", "longest", "popup", "preinsert" and "preview" have an
+	effect when 'autocomplete' is enabled.
 
 	This option does not apply to |cmdline-completion|.  See 'wildoptions'
 	for that.

--- a/runtime/doc/usr_41.txt
+++ b/runtime/doc/usr_41.txt
@@ -940,6 +940,7 @@ Insert mode completion:				*completion-functions*
 	complete_info()		get current completion information
 	complete_match()	get insert completion start match col and
 				trigger text
+	preinserted()		check if text is inserted after cursor
 	pumvisible()		check if the popup menu is displayed
 	pum_getpos()		position and size of popup menu if visible
 

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -7232,6 +7232,15 @@ pow({x}, {y})                                                            *pow()*
                 Return: ~
                   (`number`)
 
+preinserted()                                                    *preinserted()*
+		Returns non-zero if text has been inserted after the cursor
+		because "preinsert" is present in 'completeopt', or if
+		"longest" is present in 'completeopt' while 'autocomplete'
+		is enabled.  Otherwise returns zero.
+
+                Return: ~
+                  (`number`)
+
 prevnonblank({lnum})                                            *prevnonblank()*
 		Return the line number of the first line at or above {lnum}
 		that is not blank.  Example: >vim

--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -7234,9 +7234,9 @@ pow({x}, {y})                                                            *pow()*
 
 preinserted()                                                    *preinserted()*
 		Returns non-zero if text has been inserted after the cursor
-		because "preinsert" is present in 'completeopt', or if
+		because "preinsert" is present in 'completeopt', or because
 		"longest" is present in 'completeopt' while 'autocomplete'
-		is enabled.  Otherwise returns zero.
+		is active.  Otherwise returns zero.
 
                 Return: ~
                   (`number`)

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1183,11 +1183,22 @@ vim.go.cia = vim.go.completeitemalign
 --- 	    to gather more alternatives for your candidate list,
 --- 	    see 'completefuzzycollect'.
 ---
----    longest  Only insert the longest common text of the matches.  If
---- 	    the menu is displayed you can use CTRL-L to add more
---- 	    characters.  Whether case is ignored depends on the kind
---- 	    of completion.  For buffer text the 'ignorecase' option is
---- 	    used.
+---    longest
+--- 	    When 'autocomplete' is not active, only the longest
+--- 	    common prefix of the matches is inserted.  If the popup
+--- 	    menu is displayed, you can use CTRL-L to add more
+--- 	    characters.  Whether case is ignored depends on the type
+--- 	    of completion.  For buffer text the 'ignorecase' option
+--- 	    applies.
+---
+--- 	    When 'autocomplete' is active and no completion item is
+--- 	    selected, the longest common prefix of the matches is
+--- 	    inserted after the cursor.  The prefix is taken either
+--- 	    from all displayed items or only from items in the current
+--- 	    buffer.  The inserted text is highlighted with
+--- 	    `hl-PreInsert`, and the cursor position does not change
+--- 	    (similar to `"preinsert"`).  Press CTRL-Y to accept.
+--- 	    See also `preinserted()`.
 ---
 ---    menu	    Use a popup menu to show the possible completions.  The
 --- 	    menu is only shown when there is more than one match and
@@ -1220,22 +1231,21 @@ vim.go.cia = vim.go.completeitemalign
 --- 	    with "menu" or "menuone".  Overrides "preview".
 ---
 ---    preinsert
---- 	    When 'autocomplete' is not active, inserts the part of the
---- 	    first candidate word beyond the current completion leader,
---- 	    highlighted with `hl-PreInsert`.  The cursor doesn't move.
---- 	    Requires "fuzzy" unset and "menuone" in 'completeopt'.
----
---- 	    When 'autocomplete' is active, inserts the longest common
---- 	    prefix of matches (from all shown items or from the
---- 	    current buffer items).  This occurs only when no menu item
---- 	    is selected.  Press CTRL-Y to accept.
+--- 	    Inserts the text of the first completion candidate
+--- 	    beyond the current leader, highlighted with `hl-PreInsert`.
+--- 	    The cursor does not move.
+--- 	    Requires "fuzzy" to be unset, and either "menuone" in
+--- 	    'completeopt' or 'autocomplete' enabled.  When
+--- 	    'autocomplete' is enabled, this does not work if
+--- 	    'ignorecase' is set without 'infercase'.
+--- 	    See also `preinserted()`.
 ---
 ---    preview  Show extra information about the currently selected
 --- 	    completion in the preview window.  Only works in
 --- 	    combination with "menu" or "menuone".
 ---
---- Only "fuzzy", "popup", "preinsert" and "preview" have an effect when
---- 'autocomplete' is enabled.
+--- Only "fuzzy", "longest", "popup", "preinsert" and "preview" have an
+--- effect when 'autocomplete' is enabled.
 ---
 --- This option does not apply to `cmdline-completion`.  See 'wildoptions'
 --- for that.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -6554,6 +6554,14 @@ function vim.fn.perleval(expr) end
 --- @return number
 function vim.fn.pow(x, y) end
 
+--- Returns non-zero if text has been inserted after the cursor
+--- because "preinsert" is present in 'completeopt', or if
+--- "longest" is present in 'completeopt' while 'autocomplete'
+--- is enabled.  Otherwise returns zero.
+---
+--- @return number
+function vim.fn.preinserted() end
+
 --- Return the line number of the first line at or above {lnum}
 --- that is not blank.  Example: >vim
 ---   let ind = indent(prevnonblank(v:lnum - 1))

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -6555,9 +6555,9 @@ function vim.fn.perleval(expr) end
 function vim.fn.pow(x, y) end
 
 --- Returns non-zero if text has been inserted after the cursor
---- because "preinsert" is present in 'completeopt', or if
+--- because "preinsert" is present in 'completeopt', or because
 --- "longest" is present in 'completeopt' while 'autocomplete'
---- is enabled.  Otherwise returns zero.
+--- is active.  Otherwise returns zero.
 ---
 --- @return number
 function vim.fn.preinserted() end

--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -606,10 +606,10 @@ static int insert_execute(VimState *state, int key)
                && (s->c == CAR || s->c == K_KENTER || s->c == NL)))
           && stop_arrow() == OK) {
         ins_compl_delete(false);
-        if (ins_compl_has_preinsert() && ins_compl_autocomplete_enabled()) {
-          (void)ins_compl_insert(false, true);
-        } else {
-          (void)ins_compl_insert(false, false);
+        ins_compl_insert(false, !ins_compl_has_preinsert());
+        if (ins_compl_preinsert_longest()) {
+          ins_compl_init_get_longest();
+          return 1;
         }
       } else if (ascii_iswhite_nl_or_nul(s->c) && ins_compl_preinsert_effect()) {
         // Delete preinserted text when typing special chars

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -8024,6 +8024,18 @@ M.funcs = {
     returns = 'number',
     signature = 'pow({x}, {y})',
   },
+  preinserted = {
+    desc = [=[
+      Returns non-zero if text has been inserted after the cursor
+      because "preinsert" is present in 'completeopt', or if
+      "longest" is present in 'completeopt' while 'autocomplete'
+      is enabled.  Otherwise returns zero.
+    ]=],
+    name = 'preinserted',
+    params = {},
+    returns = 'number',
+    signature = 'preinserted()',
+  },
   prevnonblank = {
     args = 1,
     base = 1,

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -8027,9 +8027,9 @@ M.funcs = {
   preinserted = {
     desc = [=[
       Returns non-zero if text has been inserted after the cursor
-      because "preinsert" is present in 'completeopt', or if
+      because "preinsert" is present in 'completeopt', or because
       "longest" is present in 'completeopt' while 'autocomplete'
-      is enabled.  Otherwise returns zero.
+      is active.  Otherwise returns zero.
     ]=],
     name = 'preinserted',
     params = {},

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2266,7 +2266,11 @@ static void ins_compl_new_leader(void)
     // Matches were cleared, need to search for them now.
     // Set "compl_restarting" to avoid that the first match is inserted.
     compl_restarting = true;
-    compl_autocomplete = ins_compl_has_autocomplete();
+    if (ins_compl_has_autocomplete()) {
+      ins_compl_enable_autocomplete();
+    } else {
+      compl_autocomplete = false;
+    }
     if (ins_complete(Ctrl_N, true) == FAIL) {
       compl_cont_status = 0;
     }
@@ -2736,8 +2740,7 @@ bool ins_compl_prep(int c)
   // Set "compl_get_longest" when finding the first matches.
   if (ctrl_x_mode_not_defined_yet()
       || (ctrl_x_mode_normal() && !compl_started)) {
-    compl_get_longest = (get_cot_flags() & kOptCotFlagLongest) != 0
-                        && !ins_compl_has_autocomplete();
+    compl_get_longest = (get_cot_flags() & kOptCotFlagLongest) != 0;
     compl_used_match = true;
   }
 
@@ -6293,6 +6296,7 @@ int ins_complete(int c, bool enable_pum)
 void ins_compl_enable_autocomplete(void)
 {
   compl_autocomplete = true;
+  compl_get_longest = false;
 }
 
 /// Remove (if needed) and show the popup menu

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -2736,7 +2736,8 @@ bool ins_compl_prep(int c)
   // Set "compl_get_longest" when finding the first matches.
   if (ctrl_x_mode_not_defined_yet()
       || (ctrl_x_mode_normal() && !compl_started)) {
-    compl_get_longest = (get_cot_flags() & kOptCotFlagLongest) != 0;
+    compl_get_longest = (get_cot_flags() & kOptCotFlagLongest) != 0
+                        && !ins_compl_has_autocomplete();
     compl_used_match = true;
   }
 

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1663,11 +1663,22 @@ local options = {
         	    to gather more alternatives for your candidate list,
         	    see 'completefuzzycollect'.
 
-           longest  Only insert the longest common text of the matches.  If
-        	    the menu is displayed you can use CTRL-L to add more
-        	    characters.  Whether case is ignored depends on the kind
-        	    of completion.  For buffer text the 'ignorecase' option is
-        	    used.
+           longest
+        	    When 'autocomplete' is not active, only the longest
+        	    common prefix of the matches is inserted.  If the popup
+        	    menu is displayed, you can use CTRL-L to add more
+        	    characters.  Whether case is ignored depends on the type
+        	    of completion.  For buffer text the 'ignorecase' option
+        	    applies.
+
+        	    When 'autocomplete' is active and no completion item is
+        	    selected, the longest common prefix of the matches is
+        	    inserted after the cursor.  The prefix is taken either
+        	    from all displayed items or only from items in the current
+        	    buffer.  The inserted text is highlighted with
+        	    |hl-PreInsert|, and the cursor position does not change
+        	    (similar to `"preinsert"`).  Press CTRL-Y to accept.
+        	    See also |preinserted()|.
 
            menu	    Use a popup menu to show the possible completions.  The
         	    menu is only shown when there is more than one match and
@@ -1700,22 +1711,21 @@ local options = {
         	    with "menu" or "menuone".  Overrides "preview".
 
            preinsert
-        	    When 'autocomplete' is not active, inserts the part of the
-        	    first candidate word beyond the current completion leader,
-        	    highlighted with |hl-PreInsert|.  The cursor doesn't move.
-        	    Requires "fuzzy" unset and "menuone" in 'completeopt'.
-
-        	    When 'autocomplete' is active, inserts the longest common
-        	    prefix of matches (from all shown items or from the
-        	    current buffer items).  This occurs only when no menu item
-        	    is selected.  Press CTRL-Y to accept.
+        	    Inserts the text of the first completion candidate
+        	    beyond the current leader, highlighted with |hl-PreInsert|.
+        	    The cursor does not move.
+        	    Requires "fuzzy" to be unset, and either "menuone" in
+        	    'completeopt' or 'autocomplete' enabled.  When
+        	    'autocomplete' is enabled, this does not work if
+        	    'ignorecase' is set without 'infercase'.
+        	    See also |preinserted()|.
 
            preview  Show extra information about the currently selected
         	    completion in the preview window.  Only works in
         	    combination with "menu" or "menuone".
 
-        Only "fuzzy", "popup", "preinsert" and "preview" have an effect when
-        'autocomplete' is enabled.
+        Only "fuzzy", "longest", "popup", "preinsert" and "preview" have an
+        effect when 'autocomplete' is enabled.
 
         This option does not apply to |cmdline-completion|.  See 'wildoptions'
         for that.

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1496,18 +1496,18 @@ describe('completion', function()
 
     -- During delay wait, user can open menu using CTRL_N completion
     feed('<Esc>')
-    command('set completeopt=menuone,longest')
+    command('set completeopt=menuone')
     feed('Sf<C-N>')
     screen:expect([[
       foo                                                         |
       foobar                                                      |
       foobarbaz                                                   |
       foo^                                                         |
-      {4:foo            }{1:                                             }|
+      {12:foo            }{1:                                             }|
       {4:foobar         }{1:                                             }|
       {4:foobarbaz      }{1:                                             }|
       {1:~                                                           }|*2
-      {5:-- Keyword completion (^N^P) }{19:Back at original}               |
+      {5:-- Keyword completion (^N^P) }{6:match 1 of 3}                   |
     ]])
 
     -- After the menu is open, ^N/^P and Up/Down should not delay

--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1496,18 +1496,18 @@ describe('completion', function()
 
     -- During delay wait, user can open menu using CTRL_N completion
     feed('<Esc>')
-    command('set completeopt=menuone,preinsert')
+    command('set completeopt=menuone,longest')
     feed('Sf<C-N>')
     screen:expect([[
       foo                                                         |
       foobar                                                      |
       foobarbaz                                                   |
-      f{102:^oo}                                                         |
-      {12:foo            }{1:                                             }|
+      foo^                                                         |
+      {4:foo            }{1:                                             }|
       {4:foobar         }{1:                                             }|
       {4:foobarbaz      }{1:                                             }|
       {1:~                                                           }|*2
-      {5:-- Keyword completion (^N^P) }{6:match 1 of 3}                   |
+      {5:-- Keyword completion (^N^P) }{19:Back at original}               |
     ]])
 
     -- After the menu is open, ^N/^P and Up/Down should not delay

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -5834,7 +5834,7 @@ func Test_autocompletedelay()
   call VerifyScreenDump(buf, 'Test_autocompletedelay_6', {})
 
   " During delay wait, user can open menu using CTRL_N completion
-  call term_sendkeys(buf, "\<Esc>:set completeopt=menuone,longest\<CR>")
+  call term_sendkeys(buf, "\<Esc>:set completeopt=menuone\<CR>")
   call term_sendkeys(buf, "Sf\<C-N>")
   call VerifyScreenDump(buf, 'Test_autocompletedelay_7', {})
 
@@ -5984,6 +5984,16 @@ func Test_autocomplete_longest()
   call feedkeys("Go\<ESC>", 'tx')
   call DoTest("f\<C-N>\<C-N>\<BS>\<BS>\<BS>\<BS>", 'foo', 3)
 
+  " Issue #18410: When both 'preinsert' and 'longest' are set, 'preinsert'
+  " takes precedence
+  %delete
+  set autocomplete completeopt+=longest,preinsert
+  call setline(1, ['foobar', 'foofoo', 'foobaz', ''])
+  call feedkeys("G", 'tx')
+  call DoTest("f", 'foobar', 2)
+  call assert_equal(1, g:preinserted)
+
+  " Undo
   %delete _
   let &l:undolevels = &l:undolevels
   normal! ifoo

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -5984,7 +5984,7 @@ func Test_autocomplete_longest()
   call feedkeys("Go\<ESC>", 'tx')
   call DoTest("f\<C-N>\<C-N>\<BS>\<BS>\<BS>\<BS>", 'foo', 3)
 
-  " Issue #18410: When both 'preinsert' and 'longest' are set, 'preinsert'
+  " Issue #18410: When both "preinsert" and "longest" are set, "preinsert"
   " takes precedence
   %delete
   set autocomplete completeopt+=longest,preinsert
@@ -6034,6 +6034,21 @@ func Test_autocomplete_longest()
 
   %delete _
   delfunc CheckUndo
+
+  " Check that behavior of "longest" in manual completion is unchanged.
+  for ac in [v:false, v:true]
+    let &ac = ac
+    set completeopt=menuone,longest
+    call feedkeys("Ssign u\<C-X>\<C-V>", 'tx')
+    call assert_equal('sign un', getline('.'))
+    call feedkeys("Ssign u\<C-X>\<C-V>\<C-V>", 'tx')
+    call assert_equal('sign undefine', getline('.'))
+    call feedkeys("Ssign u\<C-X>\<C-V>\<C-V>\<C-V>", 'tx')
+    call assert_equal('sign unplace', getline('.'))
+    call feedkeys("Ssign u\<C-X>\<C-V>\<C-V>\<C-V>\<C-V>", 'tx')
+    call assert_equal('sign u', getline('.'))
+    %delete
+  endfor
 
   bw!
   set cot& autocomplete&


### PR DESCRIPTION
#### vim-patch:9.1.1797: completion: autocompletion can be improved

Problem:  completion: autocompletion can be improved
Solution: Add support for "longest" and "preinsert" in 'autocomplete';
          add preinserted() (Girish Palya)

* Add support for "longest" in 'completeopt' when 'autocomplete'
  is enabled. (Note: the cursor position does not change automatically
  when 'autocomplete' is enabled.)
* Add support for "preinsert" when 'autocomplete' is enabled. Ensure
  "preinsert" works the same with and without 'autocomplete'
* introduce the preinserted() Vim script function, useful for defining
  custom key mappings.

closes: vim/vim#18387

https://github.com/vim/vim/commit/c05335082adb21d99d96374779856444a3a0688f

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:4edaf89: runtime(doc): improve preinserted() doc

Change the second "if" to "because", otherwise it may be misinterpreted
that preinserted() can return non-zero just because these options are
set.

closes: vim/vim#18409

https://github.com/vim/vim/commit/4edaf8923335504c31810dc4c5213eaba84e7898


#### vim-patch:9.1.1800: completion: strange behaviour with 'ac' completeopt=longest,preinsert

Problem:  completion: strange behaviour with 'ac'
          completeopt=longest,preinsert (zeertzjq)
Solution: Let preinsert take precedence (Girish Palya)

closes: vim/vim#18428

https://github.com/vim/vim/commit/d35e5e4237ec578962d3d577bc5a4e4f6bf4abb2

Co-authored-by: Girish Palya <girishji@gmail.com>


#### vim-patch:9.1.1810: completion: "longest" doesn't work for manual completion with 'ac'

Problem:  completion: "longest" doesn't work for manual completion when
          'autocomplete' is on (after 9.1.1800).
Solution: Only reset compl_get_longest when enabling autocompletion
          (zeertzjq).

closes: vim/vim#18430

https://github.com/vim/vim/commit/b3966d6a8e96c9de45a344ec3d42fbb156863835