### PR TITLE
fix(lsp): scope inline_completion autocmds to buffer

### DIFF
--- a/runtime/lua/vim/lsp/inline_completion.lua
+++ b/runtime/lua/vim/lsp/inline_completion.lua
@@ -76,12 +76,14 @@ function Completor:new(bufnr)
   self.client_state = {}
   api.nvim_create_autocmd({ 'InsertEnter', 'CursorMovedI', 'TextChangedP' }, {
     group = self.augroup,
+    buffer = bufnr,
     callback = function()
       self:automatic_request()
     end,
   })
   api.nvim_create_autocmd({ 'InsertLeave' }, {
     group = self.augroup,
+    buffer = bufnr,
     callback = function()
       self:abort()
     end,


### PR DESCRIPTION
Problem:
Autocmds in inline_completion Completor are not scoped to specific buffers. When multiple buffers have inline completion enabled, events (InsertEnter, CursorMovedI, TextChangedP, InsertLeave) in any buffer trigger callbacks for all Completor instances, causing incorrect behavior across buffers.

Solution:
Add `buffer = bufnr` parameter to nvim_create_autocmd() calls to make them buffer-local. Each Completor instance now only responds to events in its own buffer.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
