### PR TITLE
vim-patch:014c731: runtime(doc): make :h virtcol() more accurate

### DIFF
--- a/runtime/doc/vimfn.txt
+++ b/runtime/doc/vimfn.txt
@@ -11767,9 +11767,9 @@ values({dict})                                                        *values()*
 
 virtcol({expr} [, {list} [, {winid}]])                               *virtcol()*
 		The result is a Number, which is the screen column of the file
-		position given with {expr}.  That is, the last screen position
-		occupied by the character at that position, when the screen
-		would be of unlimited width.  When there is a <Tab> at the
+		position given with {expr}.  That is, the total number of
+		screen cells occupied by the part of the line until the end of
+		the character at that position.  When there is a <Tab> at the
 		position, the returned Number will be the column at the end of
 		the <Tab>.  For example, for a <Tab> in column 1, with 'ts'
 		set to 8, it returns 8. |conceal| is ignored.

--- a/runtime/lua/vim/_meta/vimfn.lua
+++ b/runtime/lua/vim/_meta/vimfn.lua
@@ -10711,9 +10711,9 @@ function vim.fn.utf16idx(string, idx, countcc, charidx) end
 function vim.fn.values(dict) end
 
 --- The result is a Number, which is the screen column of the file
---- position given with {expr}.  That is, the last screen position
---- occupied by the character at that position, when the screen
---- would be of unlimited width.  When there is a <Tab> at the
+--- position given with {expr}.  That is, the total number of
+--- screen cells occupied by the part of the line until the end of
+--- the character at that position.  When there is a <Tab> at the
 --- position, the returned Number will be the column at the end of
 --- the <Tab>.  For example, for a <Tab> in column 1, with 'ts'
 --- set to 8, it returns 8. |conceal| is ignored.

--- a/src/nvim/eval.lua
+++ b/src/nvim/eval.lua
@@ -12970,9 +12970,9 @@ M.funcs = {
     base = 1,
     desc = [=[
       The result is a Number, which is the screen column of the file
-      position given with {expr}.  That is, the last screen position
-      occupied by the character at that position, when the screen
-      would be of unlimited width.  When there is a <Tab> at the
+      position given with {expr}.  That is, the total number of
+      screen cells occupied by the part of the line until the end of
+      the character at that position.  When there is a <Tab> at the
       position, the returned Number will be the column at the end of
       the <Tab>.  For example, for a <Tab> in column 1, with 'ts'
       set to 8, it returns 8. |conceal| is ignored.


### PR DESCRIPTION
#### vim-patch:014c731: runtime(doc): make :h virtcol() more accurate

The current description (especially the "unlimited width" part) is
inaccurate in several ways:
- The size of virtual text can depend on window width. In particular,
  the size of "above" virtual text can be equal to window width.
- A double-width character that doesn't fit adds 1 to the virtual column
  of the following characters.
- The size of 'showbreak' and 'breakindent' is counted.

related: vim/vim#5713
closes: vim/vim#18447

https://github.com/vim/vim/commit/014c731fa50c28c94d56545938b6a05a86234c30