### PR TITLE
vim-patch:0977c8b: runtime(vim): Update base syntax, contain user command replacement text

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -851,6 +851,7 @@ syn region	vimUserCmdReplacement contained
       \ skip=+\n\s*\%(\\\|["#]\\ \)+
       \ end="$"
       \ contains=@vimContinue,@vimUserCmdList,vimComFilter
+      \ keepend
 syn region	vimUserCmdBlock	    contained
       \ matchgroup=vimSep
       \ start="{"


### PR DESCRIPTION
#### vim-patch:0977c8b: runtime(vim): Update base syntax, contain user command replacement text

Ensure that :command replacement text terminates at the end of the
logical line.

Add :command to the generator exclusion list.

closes: vim/vim#18415

https://github.com/vim/vim/commit/0977c8b03e7eca56bb640acd2fd1c6f5fc825899

Co-authored-by: Doug Kearns <dougkearns@gmail.com>