### PR TITLE
vim-patch:a644b79: runtime(optwin): Update formatting of option descriptions

### DIFF
--- a/runtime/optwin.vim
+++ b/runtime/optwin.vim
@@ -1,7 +1,7 @@
 " These commands create the option window.
 "
 " Maintainer:	The Vim Project <https://github.com/vim/vim>
-" Last Change:	2025 Sep 20
+" Last Change:	2025 Sep 30
 " Former Maintainer:	Bram Moolenaar <Bram@vim.org>
 
 " If there already is an option window, jump to that one.
@@ -335,7 +335,7 @@ call <SID>AddOption("sidescrolloff", gettext("minimal number of columns to keep 
 call append("$", " \tset siso=" . &siso)
 call <SID>AddOption("display", gettext("include \"lastline\" to show the last line even if it doesn't fit\ninclude \"uhex\" to show unprintable characters as a hex number"))
 call <SID>OptionG("dy", &dy)
-call <SID>AddOption("fillchars", gettext("characters to use for the status line, folds, diffs, buffer text, filler lines and truncation in the completion menu"))
+call <SID>AddOption("fillchars", gettext("characters to use for the status line, folds, diffs,\nbuffer text, filler lines and truncation in the completion menu"))
 call <SID>OptionG("fcs", &fcs)
 call <SID>AddOption("cmdheight", gettext("number of lines used for the command-line"))
 call append("$", " \tset ch=" . &ch)
@@ -597,7 +597,7 @@ if has("gui")
     endif
   endif
   if has("browse")
-    call <SID>AddOption("browsedir", gettext("\"last\", \"buffer\" or \"current\": which directory used for the file browser"))
+    call <SID>AddOption("browsedir", gettext("\"last\", \"buffer\" or \"current\": which directory used for\nthe file browser"))
     call <SID>OptionG("bsdir", &bsdir)
   endif
   if has("multi_lang")
@@ -620,7 +620,7 @@ if has("gui")
       call <SID>BinOptionG("beval", &beval)
     endif
     if has("balloon_eval_term")
-      call <SID>AddOption("balloonevalterm", gettext("use balloon evaluation in the terminal"))
+      call <SID>AddOption("balloonevalterm", gettext(" \nuse balloon evaluation in the terminal"))
       call <SID>BinOptionG("bevalterm", &beval)
     endif
     if has("eval")
@@ -738,17 +738,17 @@ if has("insert_expand")
   call <SID>AddOption("autocomplete", gettext("automatic completion in insert mode"))
   call append("$", "\t" .. s:global_or_local)
   call <SID>BinOptionG("ac", &ac)
-  call <SID>AddOption("autocompletetimeout", gettext("initial decay timeout for 'autocomplete' algorithm"))
+  call <SID>AddOption("autocompletetimeout", gettext(" \ninitial decay timeout for 'autocomplete' algorithm"))
   call append("$", " \tset act=" . &act)
-  call <SID>AddOption("completetimeout", gettext("initial decay timeout for CTRL-N and CTRL-P completion"))
+  call <SID>AddOption("completetimeout", gettext(" \ninitial decay timeout for CTRL-N and CTRL-P completion"))
   call append("$", " \tset cto=" . &cto)
-  call <SID>AddOption("autocompletedelay", gettext("delay in msec before menu appears after typing"))
+  call <SID>AddOption("autocompletedelay", gettext(" \ndelay in msec before menu appears after typing"))
   call append("$", " \tset acl=" . &acl)
   call <SID>AddOption("completeopt", gettext("whether to use a popup menu for Insert mode completion"))
   call <SID>OptionL("cot")
-  call <SID>AddOption("completeitemalign", gettext("popup menu item align order"))
+  call <SID>AddOption("completeitemalign", gettext(" \npopup menu item align order"))
   call <SID>OptionG("cia", &cia)
-  call <SID>AddOption("completefuzzycollect", gettext("use fuzzy collection for specific completion modes"))
+  call <SID>AddOption("completefuzzycollect", gettext(" \nuse fuzzy collection for specific completion modes"))
   call <SID>OptionL("cfc")
   if exists("+completepopup")
     call <SID>AddOption("completepopup", gettext("options for the Insert mode completion info popup"))
@@ -1103,6 +1103,8 @@ if has("quickfix")
   call <SID>AddOption("makeencoding", gettext("encoding of the \":make\" and \":grep\" output"))
   call append("$", "\t" .. s:global_or_local)
   call <SID>OptionG("menc", &menc)
+  call <SID>AddOption("quickfixtextfunc", gettext(" \nfunction to display text in the quickfix window"))
+  call <SID>OptionG("qftf", &qftf)
 endif
 
 
@@ -1261,9 +1263,11 @@ call append("$", "\t" .. s:local_to_buffer)
 call <SID>BinOptionL("bl")
 call <SID>AddOption("debug", gettext("set to \"msg\" to see all error messages"))
 call append("$", " \tset debug=" . &debug)
-call <SID>AddOption("signcolumn", gettext("whether to show the signcolumn"))
-call append("$", "\t" .. s:local_to_window)
-call <SID>OptionL("scl")
+if has("signs")
+  call <SID>AddOption("signcolumn", gettext("whether to show the signcolumn"))
+  call append("$", "\t" .. s:local_to_window)
+  call <SID>OptionL("scl")
+endif
 
 set cpo&vim
 


### PR DESCRIPTION
#### vim-patch:a644b79: runtime(optwin): Update formatting of option descriptions

closes: vim/vim#18446

https://github.com/vim/vim/commit/a644b7924dbfa42248d563f268b608003474e6eb

Co-authored-by: RestorerZ <restorer@mail2k.ru>