### PR TITLE
vim-patch:8337d77: runtime(netrw): MS-Windows: fix netrw not being able to navigate to parent folder

### DIFF
--- a/runtime/pack/dist/opt/netrw/autoload/netrw.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw.vim
@@ -9,6 +9,7 @@
 " 2025 Sep 11 by Vim Project only keep cursor position in tree mode #18275
 " 2025 Sep 17 by Vim Project tighten the regex to handle remote compressed archives #18318
 " 2025 Sep 18 by Vim Project 'equalalways' not always respected #18358
+" 2025 Oct 01 by Vim Project fix navigate to parent folder #18464
 " Copyright:  Copyright (C) 2016 Charles E. Campbell {{{1
 "             Permission is hereby granted to use and distribute this code,
 "             with or without modifications, provided that this copyright
@@ -3950,7 +3951,8 @@ function s:NetrwBrowseChgDir(islocal, newdir, cursor, ...)
         " NetrwBrowseChgDir: go up one directory {{{3
         " --------------------------------------
 
-        let dirname = netrw#fs#Dirname(dirname)
+        " The following regexps expect '/' as path separator
+        let dirname = substitute(netrw#fs#AbsPath(dirname), '\\', '/', 'ge') . '/'
 
         if w:netrw_liststyle == s:TREELIST && exists("w:netrw_treedict")
             " force a refresh

--- a/runtime/pack/dist/opt/netrw/autoload/netrw/fs.vim
+++ b/runtime/pack/dist/opt/netrw/autoload/netrw/fs.vim
@@ -2,18 +2,18 @@
 " THESE FUNCTIONS DON'T COMMIT TO ANY BACKWARDS COMPATIBILITY. SO CHANGES AND
 " BREAKAGES IF USED OUTSIDE OF NETRW.VIM ARE EXPECTED.
 
-let s:slash = !exists('+shellslash') || &shellslash ? '/' : '\'
 
 " netrw#fs#PathJoin: Appends a new part to a path taking different systems into consideration {{{
 
 function! netrw#fs#PathJoin(...)
+    const slash = !exists('+shellslash') || &shellslash ? '/' : '\'
     let path = ""
 
     for arg in a:000
         if empty(path)
             let path = arg
         else
-            let path .= s:slash . arg
+            let path .= slash . arg
         endif
     endfor
 
@@ -73,22 +73,14 @@ endfunction
 " netrw#fs#AbsPath: returns the full path to a directory and/or file {{{
 
 function! netrw#fs#AbsPath(path)
-    let path = a:path->substitute(s:slash . '$', '', 'e')
+    let path = a:path->substitute('[\/]$', '', 'e')
 
     " Nothing to do
     if isabsolutepath(path)
         return path
     endif
 
-    return path->fnamemodify(':p')->substitute(s:slash . '$', '', 'e')
-endfunction
-
-" }}}
-" netrw#fs#Dirname: {{{
-
-function netrw#fs#Dirname(path)
-    " Keep a slash as directory recognition pattern
-    return netrw#fs#AbsPath(a:path) . s:slash
+    return path->fnamemodify(':p')->substitute('[\/]$', '', 'e')
 endfunction
 
 " }}}


### PR DESCRIPTION
#### vim-patch:8337d77: runtime(netrw): MS-Windows: fix netrw not being able to navigate to parent folder

closes: vim/vim#18464

https://github.com/vim/vim/commit/8337d77effac6b556a4db1f5dd9f722c48e38a59

Co-authored-by: Miguel Barro <miguel.barro@live.com>