### PR TITLE
test: normalize test filepath

### DIFF
--- a/test/busted/outputHandlers/nvim.lua
+++ b/test/busted/outputHandlers/nvim.lua
@@ -140,10 +140,8 @@ return function(options)
   local getFileLine = function(element)
     local fileline = ''
     if element.trace or element.trace.short_src then
-      fileline = colors.cyan(element.trace.short_src)
-        .. ' @ '
-        .. colors.cyan(element.trace.currentline)
-        .. ': '
+      local fname = vim.fs.normalize(element.trace.short_src)
+      fileline = colors.cyan(fname) .. ' @ ' .. colors.cyan(element.trace.currentline) .. ': '
     end
     return fileline
   end


### PR DESCRIPTION
Problem:
Inconsistet slashes in Windows CI:

    ERROR test/functional\ex_cmds\mksession_spec.lua @ 36: ...

Solution:
Normalize the slashes.

    ERROR test/functional/ex_cmds/mksession_spec.lua @ 36: ...
