### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1639,12 +1639,11 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    see 'completefuzzycollect'.
 
 	   longest
-		    When 'autocomplete' is not active, only the longest
-		    common prefix of the matches is inserted.  If the popup
-		    menu is displayed, you can use CTRL-L to add more
-		    characters.  Whether case is ignored depends on the type
-		    of completion.  For buffer text the 'ignorecase' option
-		    applies.
+		    When 'autocomplete' is not active, only the longest common
+		    prefix of the matches is inserted.  If the popup menu is
+		    displayed, you can use CTRL-L to add more characters.
+		    Whether case is ignored depends on the type of completion.
+		    For buffer text the 'ignorecase' option applies.
 
 		    When 'autocomplete' is active and no completion item is
 		    selected, the longest common prefix of the matches is
@@ -1686,8 +1685,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 		    with "menu" or "menuone".  Overrides "preview".
 
 	   preinsert
-		    Inserts the text of the first completion candidate
-		    beyond the current leader, highlighted with |hl-PreInsert|.
+		    Inserts the text of the first completion candidate beyond
+		    the current leader, highlighted with |hl-PreInsert|.
 		    The cursor does not move.
 		    Requires "fuzzy" to be unset, and either "menuone" in
 		    'completeopt' or 'autocomplete' enabled.  When

--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1674,7 +1674,9 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	   noselect Same as "noinsert", except that no menu item is
 		    pre-selected.  If both "noinsert" and "noselect" are
-		    present, "noselect" has precedence.
+		    present, "noselect" takes precedence.  This options is
+		    enabled automatically when 'autocomplete' is on, unless
+		    "preinsert" is also enabled.
 
 	   nosort   Disable sorting of completion candidates based on fuzzy
 		    scores when "fuzzy" is enabled.  Candidates will appear

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1219,7 +1219,9 @@ vim.go.cia = vim.go.completeitemalign
 ---
 ---    noselect Same as "noinsert", except that no menu item is
 --- 	    pre-selected.  If both "noinsert" and "noselect" are
---- 	    present, "noselect" has precedence.
+--- 	    present, "noselect" takes precedence.  This options is
+--- 	    enabled automatically when 'autocomplete' is on, unless
+--- 	    "preinsert" is also enabled.
 ---
 ---    nosort   Disable sorting of completion candidates based on fuzzy
 --- 	    scores when "fuzzy" is enabled.  Candidates will appear

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1184,12 +1184,11 @@ vim.go.cia = vim.go.completeitemalign
 --- 	    see 'completefuzzycollect'.
 ---
 ---    longest
---- 	    When 'autocomplete' is not active, only the longest
---- 	    common prefix of the matches is inserted.  If the popup
---- 	    menu is displayed, you can use CTRL-L to add more
---- 	    characters.  Whether case is ignored depends on the type
---- 	    of completion.  For buffer text the 'ignorecase' option
---- 	    applies.
+--- 	    When 'autocomplete' is not active, only the longest common
+--- 	    prefix of the matches is inserted.  If the popup menu is
+--- 	    displayed, you can use CTRL-L to add more characters.
+--- 	    Whether case is ignored depends on the type of completion.
+--- 	    For buffer text the 'ignorecase' option applies.
 ---
 --- 	    When 'autocomplete' is active and no completion item is
 --- 	    selected, the longest common prefix of the matches is
@@ -1231,8 +1230,8 @@ vim.go.cia = vim.go.completeitemalign
 --- 	    with "menu" or "menuone".  Overrides "preview".
 ---
 ---    preinsert
---- 	    Inserts the text of the first completion candidate
---- 	    beyond the current leader, highlighted with `hl-PreInsert`.
+--- 	    Inserts the text of the first completion candidate beyond
+--- 	    the current leader, highlighted with `hl-PreInsert`.
 --- 	    The cursor does not move.
 --- 	    Requires "fuzzy" to be unset, and either "menuone" in
 --- 	    'completeopt' or 'autocomplete' enabled.  When

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1699,7 +1699,9 @@ local options = {
 
            noselect Same as "noinsert", except that no menu item is
         	    pre-selected.  If both "noinsert" and "noselect" are
-        	    present, "noselect" has precedence.
+        	    present, "noselect" takes precedence.  This options is
+        	    enabled automatically when 'autocomplete' is on, unless
+        	    "preinsert" is also enabled.
 
            nosort   Disable sorting of completion candidates based on fuzzy
         	    scores when "fuzzy" is enabled.  Candidates will appear

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1664,12 +1664,11 @@ local options = {
         	    see 'completefuzzycollect'.
 
            longest
-        	    When 'autocomplete' is not active, only the longest
-        	    common prefix of the matches is inserted.  If the popup
-        	    menu is displayed, you can use CTRL-L to add more
-        	    characters.  Whether case is ignored depends on the type
-        	    of completion.  For buffer text the 'ignorecase' option
-        	    applies.
+        	    When 'autocomplete' is not active, only the longest common
+        	    prefix of the matches is inserted.  If the popup menu is
+        	    displayed, you can use CTRL-L to add more characters.
+        	    Whether case is ignored depends on the type of completion.
+        	    For buffer text the 'ignorecase' option applies.
 
         	    When 'autocomplete' is active and no completion item is
         	    selected, the longest common prefix of the matches is
@@ -1711,8 +1710,8 @@ local options = {
         	    with "menu" or "menuone".  Overrides "preview".
 
            preinsert
-        	    Inserts the text of the first completion candidate
-        	    beyond the current leader, highlighted with |hl-PreInsert|.
+        	    Inserts the text of the first completion candidate beyond
+        	    the current leader, highlighted with |hl-PreInsert|.
         	    The cursor does not move.
         	    Requires "fuzzy" to be unset, and either "menuone" in
         	    'completeopt' or 'autocomplete' enabled.  When


### PR DESCRIPTION
#### vim-patch:6e28211: runtime(doc): Tweak documentation style

closes: vim/vim#18462

https://github.com/vim/vim/commit/6e282117c7409af15f33120e67a00c47eefbbba5

Co-authored-by: Hirohito Higashi <h.east.727@gmail.com>


#### vim-patch:cfcf1a5: runtime(doc): Clarify use of "noselect" in 'completeopt'

closes: vim/vim#18452

https://github.com/vim/vim/commit/cfcf1a57cbef90831c26626aee6ba9491fb85cb3

Co-authored-by: Girish Palya <girishji@gmail.com>
Co-authored-by: Tomasz N <przepompownia@users.noreply.github.com>