### PR TITLE
refactor(treesitter): use scratch buffer for string parser

### DIFF
--- a/runtime/doc/treesitter.txt
+++ b/runtime/doc/treesitter.txt
@@ -1468,10 +1468,10 @@ LanguageTree:register_cbs({cbs}, {recursive})
                      callbacks.
 
 LanguageTree:source()                                  *LanguageTree:source()*
-    Returns the source content of the language tree (bufnr or string).
+    Returns the source bufnr of the language tree.
 
     Return: ~
-        (`integer|string`)
+        (`integer`)
 
                                                *LanguageTree:tree_for_range()*
 LanguageTree:tree_for_range({range}, {opts})

--- a/runtime/lua/vim/treesitter/_meta/misc.lua
+++ b/runtime/lua/vim/treesitter/_meta/misc.lua
@@ -5,7 +5,7 @@ error('Cannot require a meta file')
 ---@alias TSLoggerCallback fun(logtype: 'parse'|'lex', msg: string)
 
 ---@class TSParser: userdata
----@field parse fun(self: TSParser, tree: TSTree?, source: integer|string, include_bytes: boolean, timeout_ns: integer?): TSTree?, (Range4|Range6)[]
+---@field parse fun(self: TSParser, tree: TSTree?, source: integer, include_bytes: boolean, timeout_ns: integer?): TSTree?, (Range4|Range6)[]
 ---@field reset fun(self: TSParser)
 ---@field included_ranges fun(self: TSParser, include_bytes: boolean?): integer[]
 ---@field set_included_ranges fun(self: TSParser, ranges: (Range6|TSNode)[])

--- a/src/nvim/lua/treesitter.c
+++ b/src/nvim/lua/treesitter.c
@@ -513,50 +513,34 @@ static int parser_parse(lua_State *L)
     old_tree = ud ? ud->tree : NULL;
   }
 
-  TSTree *new_tree = NULL;
-  size_t len;
-  const char *str;
-  handle_T bufnr;
-  buf_T *buf;
-  TSInput input;
+  if (lua_type(L, 3) != LUA_TNUMBER) {
+    return luaL_argerror(L, 3, "expected buffer handle");
+  }
 
-  // This switch is necessary because of the behavior of lua_isstring, that
-  // consider numbers as strings...
-  switch (lua_type(L, 3)) {
-  case LUA_TSTRING:
-    str = lua_tolstring(L, 3, &len);
-    new_tree = ts_parser_parse_string(p, old_tree, str, (uint32_t)len);
-    break;
+  handle_T bufnr = (handle_T)lua_tointeger(L, 3);
+  buf_T *buf = handle_get_buffer(bufnr);
 
-  case LUA_TNUMBER:
-    bufnr = (handle_T)lua_tointeger(L, 3);
-    buf = handle_get_buffer(bufnr);
-
-    if (!buf) {
+  if (!buf) {
 #define BUFSIZE 256
-      char ebuf[BUFSIZE] = { 0 };
-      vim_snprintf(ebuf, BUFSIZE, "invalid buffer handle: %d", bufnr);
-      return luaL_argerror(L, 3, ebuf);
+    char ebuf[BUFSIZE] = { 0 };
+    vim_snprintf(ebuf, BUFSIZE, "invalid buffer handle: %d", bufnr);
+    return luaL_argerror(L, 3, ebuf);
 #undef BUFSIZE
-    }
+  }
 
-    input = (TSInput){ (void *)buf, input_cb, TSInputEncodingUTF8, NULL };
-    if (!lua_isnil(L, 5)) {
-      uint64_t timeout_ns = (uint64_t)lua_tointeger(L, 5);
-      TSLuaParserCallbackPayload payload =
-        (TSLuaParserCallbackPayload){ .parse_start_time = os_hrtime(),
-                                      .timeout_threshold_ns = timeout_ns };
-      TSParseOptions parse_options = { .payload = &payload,
-                                       .progress_callback = on_parser_progress };
-      new_tree = ts_parser_parse_with_options(p, old_tree, input, parse_options);
-    } else {
-      new_tree = ts_parser_parse(p, old_tree, input);
-    }
+  TSInput input = (TSInput){ (void *)buf, input_cb, TSInputEncodingUTF8, NULL };
+  TSTree *new_tree = NULL;
 
-    break;
-
-  default:
-    return luaL_argerror(L, 3, "expected either string or buffer handle");
+  if (!lua_isnil(L, 5)) {
+    uint64_t timeout_ns = (uint64_t)lua_tointeger(L, 5);
+    TSLuaParserCallbackPayload payload =
+      (TSLuaParserCallbackPayload){ .parse_start_time = os_hrtime(),
+                                    .timeout_threshold_ns = timeout_ns };
+    TSParseOptions parse_options = { .payload = &payload,
+                                     .progress_callback = on_parser_progress };
+    new_tree = ts_parser_parse_with_options(p, old_tree, input, parse_options);
+  } else {
+    new_tree = ts_parser_parse(p, old_tree, input);
   }
 
   bool include_bytes = (lua_gettop(L) >= 4) && lua_toboolean(L, 4);

--- a/test/functional/treesitter/parser_spec.lua
+++ b/test/functional/treesitter/parser_spec.lua
@@ -1264,6 +1264,12 @@ print()
       parser:for_each_tree(function(tstree, tree)
         ranges[tree:lang()] = { tstree:root():range(true) }
       end)
+
+      -- Scratch buffer should get cleaned up
+      assert(vim.api.nvim_buf_is_loaded(parser:source()))
+      parser:destroy()
+      assert(not vim.api.nvim_buf_is_loaded(parser:source()))
+
       return ranges
     end)
 


### PR DESCRIPTION
This commit changes `languagetree.lua` so that it creates a scratch buffer under the hood when dealing with string parsers. This will make it much easier to just use extmarks whenever we need to track injection trees in `languagetree.lua`. This also allows us to remove the `treesitter.c` code for parsing a string directly.

Note that the string parser's scratch buffer has `set noeol nofixeol` so that the parsed source exactly matches the passed-in string.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
