### PR TITLE
docs: sync gui.txt popup menu with actual Lua implementation

### DIFF
--- a/runtime/doc/gui.txt
+++ b/runtime/doc/gui.txt
@@ -728,9 +728,12 @@ when the right mouse button is pressed, if 'mousemodel' is set to popup or
 popup_setpos.
 
 The default "PopUp" menu is: >vim
-    anoremenu PopUp.Go\ to\ definition      <Cmd>lua vim.lsp.buf.definition()<CR>
     amenu     PopUp.Open\ in\ web\ browser  gx
     anoremenu PopUp.Inspect                 <Cmd>Inspect<CR>
+    anoremenu PopUp.Go\ to\ definition      <Cmd>lua vim.lsp.buf.definition()<CR>
+    anoremenu PopUp.Show\ Diagnostics       <Cmd>lua vim.diagnostic.open_float()<CR>
+    anoremenu PopUp.Show\ All\ Diagnostics  <Cmd>lua vim.diagnostic.setqflist()<CR>
+    anoremenu PopUp.Configure\ Diagnostics  <Cmd>help vim.diagnostic.config()<CR>
     anoremenu PopUp.-1-                     <Nop>
     vnoremenu PopUp.Cut                     "+x
     vnoremenu PopUp.Copy                    "+y


### PR DESCRIPTION
This PR completes the documentation updates that were missed in #32122 by adding the diagnostic-related menu items to gui.txt.

This change brings gui.txt in line with the actual Lua implementation, including:
- Show Diagnostics
- Show All Diagnostics  
- Configure Diagnostics

The menu ordering now matches [runtime/lua/vim/gui.lua](https://github.com/neovim/neovim/blob/28ccebd138ac1bccb13f7515bb647ed550fa94c5/runtime/lua/vim/_defaults.lua#L459) exactly.