### PR TITLE
fix(events): crash on WinScrolled

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5773,13 +5773,17 @@ void may_trigger_win_scrolled_resized(void)
 
   // Save window info before autocmds since they can free windows
   char resize_winid[NUMBUFLEN];
+  bufref_T resize_bufref;
   if (trigger_resize) {
     vim_snprintf(resize_winid, sizeof(resize_winid), "%d", first_size_win->handle);
+    set_bufref(&resize_bufref, first_size_win->w_buffer);
   }
 
   char scroll_winid[NUMBUFLEN];
+  bufref_T scroll_bufref;
   if (trigger_scroll) {
     vim_snprintf(scroll_winid, sizeof(scroll_winid), "%d", first_scroll_win->handle);
+    set_bufref(&scroll_bufref, first_scroll_win->w_buffer);
   }
 
   // If both are to be triggered do WinResized first.
@@ -5789,7 +5793,8 @@ void may_trigger_win_scrolled_resized(void)
 
     if (tv_dict_add_list(v_event, S_LEN("windows"), windows_list) == OK) {
       tv_dict_set_keys_readonly(v_event);
-      apply_autocmds(EVENT_WINRESIZED, resize_winid, resize_winid, false, curbuf);
+      buf_T *buf = bufref_valid(&resize_bufref) ? resize_bufref.br_buf : curbuf;
+      apply_autocmds(EVENT_WINRESIZED, resize_winid, resize_winid, false, buf);
     }
     restore_v_event(v_event, &save_v_event);
   }
@@ -5803,7 +5808,8 @@ void may_trigger_win_scrolled_resized(void)
     tv_dict_set_keys_readonly(v_event);
     tv_dict_unref(scroll_dict);
 
-    apply_autocmds(EVENT_WINSCROLLED, scroll_winid, scroll_winid, false, curbuf);
+    buf_T *buf = bufref_valid(&scroll_bufref) ? scroll_bufref.br_buf : curbuf;
+    apply_autocmds(EVENT_WINSCROLLED, scroll_winid, scroll_winid, false, buf);
 
     restore_v_event(v_event, &save_v_event);
   }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5771,6 +5771,21 @@ void may_trigger_win_scrolled_resized(void)
 
   recursive = true;
 
+  // Save window info before autocmds since they can free windows
+  char resize_winid[NUMBUFLEN];
+  buf_T *resize_buf = NULL;
+  if (trigger_resize) {
+    vim_snprintf(resize_winid, sizeof(resize_winid), "%d", first_size_win->handle);
+    resize_buf = first_size_win->w_buffer;
+  }
+
+  char scroll_winid[NUMBUFLEN];
+  buf_T *scroll_buf = NULL;
+  if (trigger_scroll) {
+    vim_snprintf(scroll_winid, sizeof(scroll_winid), "%d", first_scroll_win->handle);
+    scroll_buf = first_scroll_win->w_buffer;
+  }
+
   // If both are to be triggered do WinResized first.
   if (trigger_resize) {
     save_v_event_T save_v_event;
@@ -5778,10 +5793,7 @@ void may_trigger_win_scrolled_resized(void)
 
     if (tv_dict_add_list(v_event, S_LEN("windows"), windows_list) == OK) {
       tv_dict_set_keys_readonly(v_event);
-
-      char winid[NUMBUFLEN];
-      vim_snprintf(winid, sizeof(winid), "%d", first_size_win->handle);
-      apply_autocmds(EVENT_WINRESIZED, winid, winid, false, first_size_win->w_buffer);
+      apply_autocmds(EVENT_WINRESIZED, resize_winid, resize_winid, false, resize_buf);
     }
     restore_v_event(v_event, &save_v_event);
   }
@@ -5795,9 +5807,7 @@ void may_trigger_win_scrolled_resized(void)
     tv_dict_set_keys_readonly(v_event);
     tv_dict_unref(scroll_dict);
 
-    char winid[NUMBUFLEN];
-    vim_snprintf(winid, sizeof(winid), "%d", first_scroll_win->handle);
-    apply_autocmds(EVENT_WINSCROLLED, winid, winid, false, first_scroll_win->w_buffer);
+    apply_autocmds(EVENT_WINSCROLLED, scroll_winid, scroll_winid, false, scroll_buf);
 
     restore_v_event(v_event, &save_v_event);
   }

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -5773,17 +5773,13 @@ void may_trigger_win_scrolled_resized(void)
 
   // Save window info before autocmds since they can free windows
   char resize_winid[NUMBUFLEN];
-  buf_T *resize_buf = NULL;
   if (trigger_resize) {
     vim_snprintf(resize_winid, sizeof(resize_winid), "%d", first_size_win->handle);
-    resize_buf = first_size_win->w_buffer;
   }
 
   char scroll_winid[NUMBUFLEN];
-  buf_T *scroll_buf = NULL;
   if (trigger_scroll) {
     vim_snprintf(scroll_winid, sizeof(scroll_winid), "%d", first_scroll_win->handle);
-    scroll_buf = first_scroll_win->w_buffer;
   }
 
   // If both are to be triggered do WinResized first.
@@ -5793,7 +5789,7 @@ void may_trigger_win_scrolled_resized(void)
 
     if (tv_dict_add_list(v_event, S_LEN("windows"), windows_list) == OK) {
       tv_dict_set_keys_readonly(v_event);
-      apply_autocmds(EVENT_WINRESIZED, resize_winid, resize_winid, false, resize_buf);
+      apply_autocmds(EVENT_WINRESIZED, resize_winid, resize_winid, false, curbuf);
     }
     restore_v_event(v_event, &save_v_event);
   }
@@ -5807,7 +5803,7 @@ void may_trigger_win_scrolled_resized(void)
     tv_dict_set_keys_readonly(v_event);
     tv_dict_unref(scroll_dict);
 
-    apply_autocmds(EVENT_WINSCROLLED, scroll_winid, scroll_winid, false, scroll_buf);
+    apply_autocmds(EVENT_WINSCROLLED, scroll_winid, scroll_winid, false, curbuf);
 
     restore_v_event(v_event, &save_v_event);
   }

--- a/test/functional/autocmd/win_scrolled_resized_spec.lua
+++ b/test/functional/autocmd/win_scrolled_resized_spec.lua
@@ -350,7 +350,6 @@ describe('WinScrolled', function()
     }, eval('g:v_event'))
   end)
 
-  -- Test for #35803
   it('does not crash when WinResized closes popup before WinScrolled #35803', function()
     exec([[
       set scrolloff=0


### PR DESCRIPTION
Save window info before running autocmds since they can free windows.

fixes: #35803

