### PR TITLE
vim-patch:09b1ce0: runtime(doc): fix typo after commit cfcf1a57cbef

### DIFF
--- a/runtime/doc/options.txt
+++ b/runtime/doc/options.txt
@@ -1674,8 +1674,8 @@ A jump table for the options with a short description can be found at |Q_op|.
 
 	   noselect Same as "noinsert", except that no menu item is
 		    pre-selected.  If both "noinsert" and "noselect" are
-		    present, "noselect" takes precedence.  This options is
-		    enabled automatically when 'autocomplete' is on, unless
+		    present, "noselect" takes precedence.  This is enabled
+		    automatically when 'autocomplete' is on, unless
 		    "preinsert" is also enabled.
 
 	   nosort   Disable sorting of completion candidates based on fuzzy

--- a/runtime/lua/vim/_meta/options.lua
+++ b/runtime/lua/vim/_meta/options.lua
@@ -1219,8 +1219,8 @@ vim.go.cia = vim.go.completeitemalign
 ---
 ---    noselect Same as "noinsert", except that no menu item is
 --- 	    pre-selected.  If both "noinsert" and "noselect" are
---- 	    present, "noselect" takes precedence.  This options is
---- 	    enabled automatically when 'autocomplete' is on, unless
+--- 	    present, "noselect" takes precedence.  This is enabled
+--- 	    automatically when 'autocomplete' is on, unless
 --- 	    "preinsert" is also enabled.
 ---
 ---    nosort   Disable sorting of completion candidates based on fuzzy

--- a/src/nvim/options.lua
+++ b/src/nvim/options.lua
@@ -1699,8 +1699,8 @@ local options = {
 
            noselect Same as "noinsert", except that no menu item is
         	    pre-selected.  If both "noinsert" and "noselect" are
-        	    present, "noselect" takes precedence.  This options is
-        	    enabled automatically when 'autocomplete' is on, unless
+        	    present, "noselect" takes precedence.  This is enabled
+        	    automatically when 'autocomplete' is on, unless
         	    "preinsert" is also enabled.
 
            nosort   Disable sorting of completion candidates based on fuzzy


### PR DESCRIPTION
#### vim-patch:09b1ce0: runtime(doc): fix typo after commit cfcf1a57cbef

related: vim/vim#18452

https://github.com/vim/vim/commit/09b1ce08600bf2b423cb5b3a16952bf183bed1ff

Co-authored-by: Christian Brabandt <cb@256bit.org>