### PR TITLE
vim-patch:9.1.1820: completion: some issues with 'acl'

### DIFF
--- a/test/functional/editor/completion_spec.lua
+++ b/test/functional/editor/completion_spec.lua
@@ -1591,6 +1591,7 @@ describe('completion', function()
     feed('<esc>')
   end)
 
+  -- oldtest: Test_fuzzy_select_item_when_acl()
   it([[first item isn't selected with "fuzzy" and 'acl']], function()
     screen:try_resize(60, 10)
     source([[
@@ -1631,6 +1632,100 @@ describe('completion', function()
       {4:vi             }{1:                                             }|
       {4:vim            }{1:                                             }|
       {1:~                                                           }|*3
+      {5:-- INSERT --}                                                |
+    ]])
+  end)
+
+  -- oldtest: Test_autocompletedelay_longest_preinsert()
+  it("'autocompletedelay' with 'completeopt' longest/preinsert", function()
+    source([[
+      call setline(1, ['autocomplete', 'autocomxxx'])
+      set autocomplete completeopt+=longest autocompletedelay=500
+    ]])
+    screen:expect([[
+      ^autocomplete                                                |
+      autocomxxx                                                  |
+      {1:~                                                           }|*5
+                                                                  |
+    ]])
+    screen.timeout = 400
+
+    -- No spurious characters when autocompletedelay is in effect
+    feed('Goau')
+    screen:expect([[
+      autocomplete                                                |
+      autocomxxx                                                  |
+      au{102:^tocom}                                                     |
+      {1:~                                                           }|*4
+      {5:-- INSERT --}                                                |
+    ]])
+    feed('toc')
+    screen:expect([[
+      autocomplete                                                |
+      autocomxxx                                                  |
+      autoc{102:^om}                                                     |
+      {1:~                                                           }|*4
+      {5:-- INSERT --}                                                |
+    ]])
+    vim.uv.sleep(500)
+    screen:expect([[
+      autocomplete                                                |
+      autocomxxx                                                  |
+      autoc{102:^om}                                                     |
+      {4:autocomxxx     }{1:                                             }|
+      {4:autocomplete   }{1:                                             }|
+      {1:~                                                           }|*2
+      {5:-- INSERT --}                                                |
+    ]])
+
+    -- Deleting a char should still show longest text
+    feed('<Esc>Saut')
+    screen:expect([[
+      autocomplete                                                |
+      autocomxxx                                                  |
+      aut{102:^ocom}                                                     |
+      {1:~                                                           }|*4
+      {5:-- INSERT --}                                                |
+    ]])
+    feed('<BS>')
+    screen:expect([[
+      autocomplete                                                |
+      autocomxxx                                                  |
+      au{102:^tocom}                                                     |
+      {1:~                                                           }|*4
+      {5:-- INSERT --}                                                |
+    ]])
+    vim.uv.sleep(500)
+    screen:expect([[
+      autocomplete                                                |
+      autocomxxx                                                  |
+      au{102:^tocom}                                                     |
+      {4:autocomxxx     }{1:                                             }|
+      {4:autocomplete   }{1:                                             }|
+      {1:~                                                           }|*2
+      {5:-- INSERT --}                                                |
+    ]])
+
+    -- Preinsert
+    command('set completeopt& completeopt+=preinsert')
+
+    -- Show preinserted text right away but display popup later
+    feed('<Esc>Sau')
+    screen:expect([[
+      autocomplete                                                |
+      autocomxxx                                                  |
+      au{102:^tocomplete}                                                |
+      {1:~                                                           }|*4
+      {5:-- INSERT --}                                                |
+    ]])
+    vim.uv.sleep(500)
+    screen:expect([[
+      autocomplete                                                |
+      autocomxxx                                                  |
+      au{102:^tocomplete}                                                |
+      {12:autocomplete   }{1:                                             }|
+      {4:autocomxxx     }{1:                                             }|
+      {1:~                                                           }|*2
       {5:-- INSERT --}                                                |
     ]])
   end)


### PR DESCRIPTION
#### vim-patch:9.1.1820: completion: some issues with 'acl'

Problem:  completion: some issues with 'acl' when "preinsert" and
          "longest" is in 'completeopt' (musonius, after v9.1.1638)
Solution: Fix various issues (see details below) (Girish Palya)

This commit addresses multiple issues in the 'autocompletedelay' behavior with
"preinsert" and "longest":

- Prevents spurious characters from being inserted.
- Ensures the completion menu is not shown until `autocompletedelay` has
  expired.
- Shows the "preinsert" effect immediately.
- Keeps the "preinsert" effect visible even when a character is deleted.

closes: vim/vim#18460

https://github.com/vim/vim/commit/f77c187277c3fd2af7a48f8b15093a3e40ca95a0

Co-authored-by: Girish Palya <girishji@gmail.com>