### PR TITLE
fix(api): nvim_open_win respects requested split window size (#35601)

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -277,6 +277,13 @@ Window nvim_open_win(Buffer buffer, Boolean enter, Dict(win_config) *config, Err
     });
     if (wp) {
       wp->w_config = fconfig;
+      // Without room for the requested size, window sizes may have been equalized instead.
+      // If the size differs from what was requested, try to set it again now.
+      if ((flags & WSP_VERT) && wp->w_width != fconfig.width) {
+        win_setwidth_win(fconfig.width, wp);
+      } else if (!(flags & WSP_VERT) && wp->w_height != fconfig.height) {
+        win_setheight_win(fconfig.height, wp);
+      }
     }
   } else {
     wp = win_new_float(NULL, false, fconfig, err);

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -1904,6 +1904,21 @@ describe('API/win', function()
         })
       )
     end)
+
+    it('respects requested size for large splits', function()
+      command('vsplit')
+      local win = api.nvim_open_win(0, false, { win = -1, split = 'right', width = 38 })
+      eq(38, api.nvim_win_get_width(win))
+
+      -- No zero-sized windows (e.g: from skipping forced equalization in win_split_ins) if
+      -- requesting a chonky window; that could lead to crashes!
+      api.nvim_open_win(0, false, { win = -1, split = 'right', width = 9999 })
+      eq({ 1, 1, 1, 74 }, eval("range(1, winnr('$'))->map({_, nr -> winwidth(nr)})"))
+
+      command('split')
+      win = api.nvim_open_win(0, false, { win = 0, split = 'below', height = 10 })
+      eq(10, api.nvim_win_get_height(win))
+    end)
   end)
 
   describe('set_config', function()


### PR DESCRIPTION
Problem: requested window size passed to nvim_open_win for splits may be ignored by win_split_ins if it decides to forcefully equalize window sizes instead (e.g: in an attempt to make room for the new window).

Solution: try to set the size again if it differs from what was requested.

Backports #35601 
