### PR TITLE
vim-patch:bfcf638: runtime(java): Make changes for JDK 25

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1783,11 +1783,11 @@ cycles for such a feature to become either integrated into the platform or
 withdrawn from this effort.  To cater for early adopters, there is optional
 support in Vim for syntax related preview features that are implemented.  You
 can request it by specifying a list of preview feature numbers as follows: >
-	:let g:java_syntax_previews = [488]
+	:let g:java_syntax_previews = [507]
 
 The supported JEP numbers are to be drawn from this table:
 	`430`: String Templates [JDK 21]
-	`488`: Primitive types in Patterns, instanceof, and switch
+	`507`: Primitive types in Patterns, instanceof, and switch
 
 Note that as soon as the particular preview feature will have been integrated
 into the Java platform, its entry will be removed from the table and related


### PR DESCRIPTION
#### vim-patch:bfcf638: runtime(java): Make changes for JDK 25

- Add to the list of java.lang classes three new types: IO,
  ScopedValue, and ScopedValue.Carrier.
- Add to the list of java.lang interfaces a new type:
  ScopedValue.CallableOp.
- "Demote" RuntimePermission from the list of java.lang
  class types to javaLangDeprecated.
- Reintroduce supported syntax-preview-feature numbers 455
  and 488 as _a new number_ 507.

References:
https://bugs.openjdk.org/browse/JDK-8353641
https://openjdk.org/jeps/506 (Scoped Values)
https://openjdk.org/jeps/507 (Primitive Types in Patterns etc.)
https://openjdk.org/jeps/512 (Compact Source Files etc.)

closes: vim/vim#18479

https://github.com/vim/vim/commit/bfcf638c738af658c0d170ab8f4b0eb17163380e

Co-authored-by: Aliaksei Budavei <0x000c70@gmail.com>