### PR TITLE
vim-patch:9.1.1824: tests: no test for displaying 'foldcolumn' with Unicode "foldinner"

### DIFF
--- a/test/old/testdir/test_display.vim
+++ b/test/old/testdir/test_display.vim
@@ -343,7 +343,6 @@ func Test_fold_fillchars()
         \ ]
   call assert_equal(expected, lines)
 
-  " check setting foldinner
   set fdc=1 foldmethod=indent foldlevel=10
   call setline(1, ['one', '	two', '	two', '		three', '		three', 'four'])
   let lines = ScreenLines([1, 6], 22)
@@ -357,6 +356,7 @@ func Test_fold_fillchars()
         \ ]
   call assert_equal(expected, lines)
 
+  " check setting foldinner
   set fillchars+=foldinner:\ 
   let lines = ScreenLines([1, 6], 22)
   let expected = [
@@ -366,6 +366,42 @@ func Test_fold_fillchars()
         \ '[                three',
         \ '                 three',
         \ ' four                 ',
+        \ ]
+  call assert_equal(expected, lines)
+
+  " check Unicode chars
+  set fillchars=foldopen:▼,foldclose:▶,fold:⋯,foldsep:‖,foldinner:⋮
+  let lines = ScreenLines([1, 6], 22)
+  let expected = [
+        \ ' one                  ',
+        \ '▼        two          ',
+        \ '‖        two          ',
+        \ '▼                three',
+        \ '⋮                three',
+        \ ' four                 ',
+        \ ]
+  call assert_equal(expected, lines)
+
+  set fillchars-=foldinner:⋮
+  let lines = ScreenLines([1, 6], 22)
+  let expected = [
+        \ ' one                  ',
+        \ '▼        two          ',
+        \ '‖        two          ',
+        \ '▼                three',
+        \ '2                three',
+        \ ' four                 ',
+        \ ]
+  call assert_equal(expected, lines)
+
+  normal! 5ggzc
+  let lines = ScreenLines([1, 5], 24)
+  let expected = [
+        \ ' one                    ',
+        \ '▼        two            ',
+        \ '‖        two            ',
+        \ '▶+---  2 lines: three⋯⋯⋯',
+        \ ' four                   ',
         \ ]
   call assert_equal(expected, lines)
 


### PR DESCRIPTION
#### vim-patch:9.1.1824: tests: no test for displaying 'foldcolumn' with Unicode "foldinner"

Problem:  tests: no test for displaying 'foldcolumn' with Unicode
          "foldinner" in 'fillchars'.
Solution: Add a few more test cases.  Also fix misplaced "foldinner"
          entry in version9.txt (zeertzjq).

closes: vim/vim#18483

https://github.com/vim/vim/commit/bcf44668f6c865c8e2fb6429183a14f806a4130c