### PR TITLE
fix(lsp): format_item should return string

### DIFF
--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -108,8 +108,10 @@ RSC[ms.window_showMessageRequest] = function(_, params, ctx)
       local opts = {
         kind = 'lsp_message',
         prompt = params.message .. ': ',
+        ---@param action lsp.MessageActionItem
+        ---@return string
         format_item = function(action)
-          return (action.title:gsub('\r\n', '\\r\\n')):gsub('\n', '\\n')
+          return (action.title:gsub('\r\n', '\\r\\n'):gsub('\n', '\\n'))
         end,
       }
       vim.ui.select(params.actions, opts, function(choice)


### PR DESCRIPTION
Problem: format_item return two value
Solution: `:h vim.ui.select()` say format_item should return string

I have a custom vim.ui.select snippet:
```lua
vim.iter(ui_items):map(ui_opts.format_item):totable()
```
Another factor here is `vim.iter():map()` will collect multiple return value into a new table entry.
