### PR TITLE
docs(vim.system): use supported signal string in kill() example

### DIFF
--- a/runtime/doc/lua.txt
+++ b/runtime/doc/lua.txt
@@ -4509,11 +4509,12 @@ SystemObj:kill({signal})                                    *SystemObj:kill()*
 
     Example: >lua
         local obj = vim.system({'sleep', '10'})
-        obj:kill('TERM') -- sends SIGTERM to the process
+        obj:kill('sigterm') -- sends SIGTERM to the process
 <
 
     Parameters: ~
-      • {signal}  (`integer|string`) Signal to send to the process.
+      • {signal}  (`integer|string`) Signal to send to the process. See
+                  |luv-constants|.
 
 SystemObj:wait({timeout})                                   *SystemObj:wait()*
     Waits for the process to complete or until the specified timeout elapses.

--- a/runtime/lua/vim/_system.lua
+++ b/runtime/lua/vim/_system.lua
@@ -98,10 +98,10 @@ end
 --- Example:
 --- ```lua
 --- local obj = vim.system({'sleep', '10'})
---- obj:kill('TERM') -- sends SIGTERM to the process
+--- obj:kill('sigterm') -- sends SIGTERM to the process
 --- ```
 ---
---- @param signal integer|string Signal to send to the process.
+--- @param signal integer|string Signal to send to the process. See |luv-constants|.
 function SystemObj:kill(signal)
   self._state.handle:kill(signal)
 end


### PR DESCRIPTION
Problem: The example for SystemObj:kill() passes 'TERM' as the {signal} parameter which is not parsed as a valid signal by LUV, so it ends up doing nothing. LUV only understands lower cased strings which include a 'sig' prefix (e.g. 'sigkill')[1]. Additionally, there's no documentation of valid signal strings. This makes makes kill() hard to use correctly without reading its source code.

Solution: Replace 'TERM' with 'sigterm' in the documentation and link to the LUV constants documentation which has a list of valid signal strings.

[1]: https://github.com/luvit/luv/blob/8af11b714ffa37ca74e4b1bb54d29cc0e2200f10/src/constants.c#L500

<!--
  Thank you for contributing to Neovim!https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
