### PR TITLE
fix(excmd): :trust executed even when inside false condition

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -1714,8 +1714,8 @@ mark a file as trusted or untrusted using the |:trust| command or the
 			contents. The trust list is stored on disk, Nvim will
 			re-use it after restarting.
 
-			[++deny] marks [file] (or current buffer if no [file]) as
-			untrusted: it will never be executed, 'exrc' will
+			[++deny] marks [file] (or current buffer if no [file])
+			as untrusted: it will never be executed, 'exrc' will
 			ignore it.
 
 			[++remove] removes [file] (or current buffer if no

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -1951,7 +1951,6 @@ static bool skip_cmd(const exarg_T *eap)
     case CMD_throw:
     case CMD_tilde:
     case CMD_topleft:
-    case CMD_trust:
     case CMD_unlet:
     case CMD_unlockvar:
     case CMD_verbose:

--- a/test/functional/ex_cmds/trust_spec.lua
+++ b/test/functional/ex_cmds/trust_spec.lua
@@ -13,21 +13,21 @@ local fn = n.fn
 describe(':trust', function()
   local xstate = 'Xstate'
 
-  setup(function()
-    n.mkdir_p(xstate .. pathsep .. (is_os('win') and 'nvim-data' or 'nvim'))
-  end)
-
-  teardown(function()
-    n.rmdir(xstate)
-  end)
-
   before_each(function()
+    n.mkdir_p(xstate .. pathsep .. (is_os('win') and 'nvim-data' or 'nvim'))
     t.write_file('test_file', 'test')
     clear { env = { XDG_STATE_HOME = xstate } }
   end)
 
   after_each(function()
     os.remove('test_file')
+    n.rmdir(xstate)
+  end)
+
+  it('is not executed when inside false condition', function()
+    command('edit test_file')
+    eq('', exec_capture('if 0 | trust | endif'))
+    eq(nil, vim.uv.fs_stat(fn.stdpath('state') .. pathsep .. 'trust'))
   end)
 
   it('trust then deny then remove a file using current buffer', function()


### PR DESCRIPTION
Problem:  :trust is executed even when inside false condition.
Solution: Make skip_cmd() return true for CMD_trust, as ex_trust() does
          not handle eap->skip itself.

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
