### PR TITLE
vim-patch:9.1.1827: completion: v9.1.1797 broke Ctrl-Y behaviour

### DIFF
--- a/src/nvim/edit.c
+++ b/src/nvim/edit.c
@@ -607,10 +607,12 @@ static int insert_execute(VimState *state, int key)
                && (s->c == CAR || s->c == K_KENTER || s->c == NL)))
           && stop_arrow() == OK) {
         ins_compl_delete(false);
-        ins_compl_insert(false, !ins_compl_has_preinsert());
-        if (ins_compl_preinsert_longest()) {
+        if (ins_compl_preinsert_longest() && !ins_compl_is_match_selected()) {
+          ins_compl_insert(false, true);
           ins_compl_init_get_longest();
           return 1;
+        } else {
+          ins_compl_insert(false, false);
         }
       } else if (ascii_iswhite_nl_or_nul(s->c) && ins_compl_preinsert_effect()) {
         // Delete preinserted text when typing special chars

--- a/src/nvim/insexpand.c
+++ b/src/nvim/insexpand.c
@@ -890,6 +890,12 @@ static bool is_nearest_active(void)
          && !(flags & kOptCotFlagFuzzy);
 }
 
+/// True if a match is selected (even if it is not inserted).
+bool ins_compl_is_match_selected(void)
+{
+  return compl_shown_match != NULL && !is_first_match(compl_shown_match);
+}
+
 /// Returns true if autocomplete is active and the pre-insert effect targets the
 /// longest prefix.
 bool ins_compl_preinsert_longest(void)

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -6149,4 +6149,25 @@ func Test_autocompletedelay_longest_preinsert()
   call StopVimInTerminal(buf)
 endfunc
 
+" Issue 18493
+func Test_longest_preinsert_accept()
+  call Ntest_override("char_avail", 1)
+  new
+  call setline(1, ['func1', 'xfunc', 'func2'])
+  set completeopt+=noselect
+
+  call feedkeys("Gof\<C-N>\<Down>\<C-Y>", 'tx')
+  call assert_equal('func1', getline('.'))
+
+  set completeopt+=longest autocomplete
+  call feedkeys("Sf\<Down>\<C-Y>", 'tx')
+  call assert_equal('func2', getline('.'))
+  call feedkeys("Sf\<C-Y>", 'tx')
+  call assert_equal('func', getline('.'))
+
+  set completeopt& autocomplete&
+  bw!
+  call Ntest_override("char_avail", 0)
+endfunc
+
 " vim: shiftwidth=2 sts=2 expandtab nofoldenable


### PR DESCRIPTION
#### vim-patch:9.1.1827: completion: v9.1.1797 broke Ctrl-Y behaviour

Problem:  completion: v9.1.1797 broke Ctrl-Y behaviour
          (ddad431, after v9.1.1797)
Solution: Restore correct behaviour (Girish Palya).

closes: vim/vim#18494

https://github.com/vim/vim/commit/f3d0d089074c4517b26ea3d2253eaae36c6212eb

Co-authored-by: Girish Palya <girishji@gmail.com>