### PR TITLE
fix: remove quotes around `nil` deprecation alternatives

### DIFF
--- a/runtime/lua/vim/lsp/util.lua
+++ b/runtime/lua/vim/lsp/util.lua
@@ -128,7 +128,7 @@ end
 ---@param new_lines string[] list of strings to replace the original
 ---@return string[] The modified {lines} object
 function M.set_lines(lines, A, B, new_lines)
-  vim.deprecate('vim.lsp.util.set_lines()', 'nil', '0.12')
+  vim.deprecate('vim.lsp.util.set_lines()', nil, '0.12')
   -- 0-indexing to 1-indexing
   local i_0 = A[1] + 1
   -- If it extends past the end, truncate it to the end. This is because the
@@ -2007,7 +2007,7 @@ end
 ---@param lines string[] list of lines
 ---@return string filetype or "markdown" if it was unchanged.
 function M.try_trim_markdown_code_blocks(lines)
-  vim.deprecate('vim.lsp.util.try_trim_markdown_code_blocks()', 'nil', '0.12')
+  vim.deprecate('vim.lsp.util.try_trim_markdown_code_blocks()', nil, '0.12')
   local language_id = assert(lines[1]):match('^```(.*)')
   if language_id then
     local has_inner_code_fence = false


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
Removing the quotes here to indicate that there's no alternative, not that the alternative is `nil`.