### PR TITLE
vim-patch:adc729c: runtime(doc): fix typo in :h credits section

### DIFF
--- a/runtime/doc/credits.txt
+++ b/runtime/doc/credits.txt
@@ -20,7 +20,8 @@ patches, suggestions and giving feedback about what is good and bad in Vim.
 
 Vim would never have become what it is now, without the help of these people!
 
-        |Bram| Moolenaar        Creator and benevolent dictor for life
+        |Bram| Moolenaar	Creator and benevolent dictator until his
+                                passing (3 August 2023)
         Ron Aaron               Win32 GUI changes
         Mohsin Ahmed            encryption
         Zoltan Arpadffy         work on VMS port


### PR DESCRIPTION
#### vim-patch:adc729c: runtime(doc): fix typo in :h credits section

https://github.com/vim/vim/commit/adc729cd32671c6a3bc6cbb3f0a64a984d454f01

Co-authored-by: Christian Brabandt <cb@256bit.org>