### PR TITLE
fix: stale lines("w$") after nvim_win_set_height when splitkeep=screen

### DIFF
--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -6726,7 +6726,7 @@ void win_set_inner_size(win_T *wp, bool valid_cursor)
 
   if (height != prev_height) {
     if (height > 0 && valid_cursor) {
-      if (wp == curwin && *p_spk == 'c') {
+      if (wp == curwin && (*p_spk == 'c' || wp->w_floating)) {
         // w_wrow needs to be valid. When setting 'laststatus' this may
         // call win_new_height() recursively.
         validate_cursor(curwin);
@@ -6743,7 +6743,7 @@ void win_set_inner_size(win_T *wp, bool valid_cursor)
 
     // There is no point in adjusting the scroll position when exiting.  Some
     // values might be invalid.
-    if (valid_cursor && !exiting && *p_spk == 'c') {
+    if (valid_cursor && !exiting && (*p_spk == 'c' || wp->w_floating)) {
       wp->w_skipcol = 0;
       scroll_to_fraction(wp, prev_height);
     }
@@ -6756,7 +6756,7 @@ void win_set_inner_size(win_T *wp, bool valid_cursor)
     if (valid_cursor) {
       changed_line_abv_curs_win(wp);
       invalidate_botline(wp);
-      if (wp == curwin && *p_spk == 'c') {
+      if (wp == curwin && (*p_spk == 'c' || wp->w_floating)) {
         curs_columns(wp, true);  // validate w_wrow
       }
     }

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -433,6 +433,18 @@ describe('float window', function()
     eq(5, api.nvim_get_option_value('scroll', { win = float_win }))
   end)
 
+  it("lines('w$') after nvim_win_set_height with 'splitkeep=screen' #36056", function()
+    api.nvim_set_option_value('splitkeep', 'screen', {})
+    local buf = api.nvim_create_buf(false, true)
+    local win = api.nvim_open_win(buf, false, { width = 5, height = 1, col = 0, row = 0, relative = 'cursor' })
+    api.nvim_buf_set_lines(buf, 0, -1, true, { ('1'):rep(10), ('2'):rep(10) })
+    local line = exec_lua(function()
+      vim.api.nvim_win_set_height(win, vim.api.nvim_win_get_height(win) + 3)
+      return vim.fn.line('w$', win)
+    end)
+    eq(2, line)
+  end)
+
   it(':unhide works when there are floating windows', function()
     local float_opts = { relative = 'editor', row = 1, col = 1, width = 5, height = 5 }
     local w0 = curwin()


### PR DESCRIPTION
Problem: when splitkeep=screen, after enlarge float window with
nvim_win_set_height, lines("w$") return stale value

Solution: update in win_set_inner_size

`nvim --clean repro.lua`, `:so`
```lua
vim.o.splitkeep = 'screen'
local buf = vim.api.nvim_create_buf(false, true)
local win = vim.api.nvim_open_win(
  buf,
  false,
  { width = 5, height = 1, col = 0, row = 0, relative = 'cursor' }
)
vim.api.nvim_buf_set_lines(buf, 0, -1, true, {
  ('1'):rep(10),
  ('2'):rep(10),
})
vim.api.nvim_win_set_height(win, vim.api.nvim_win_get_height(win) + 3)
assert(vim.fn.line('w$', win) == 2)
```

Similar snippet in gitsigns.nvim:
https://github.com/lewis6991/gitsigns.nvim/blob/a434c8cc97d8b96cb272e7a44112891d5a05bb06/lua/gitsigns/popup.lua#L31-L50
