### PR TITLE
vim-patch:8824526: runtime(zip): add *.pkpass to list of zip extensions

### DIFF
--- a/runtime/doc/pi_zip.txt
+++ b/runtime/doc/pi_zip.txt
@@ -110,14 +110,14 @@ Copyright: Copyright (C) 2005-2015 Charles E Campbell	 *zip-copyright*
    should be treated as zip files.
 
    Alternatively, one may change *g:zipPlugin_ext* in one's .vimrc.
-   Currently (as of April 2025) it holds: >
+   Currently (as of October 2025) it holds: >
 
         let g:zipPlugin_ext='*.aar,*.apk,*.celzip,*.crtx,*.docm,*.docx,
        \ *.dotm,*.dotx,*.ear,*.epub,*.gcsx,*.glox,*.gqsx,*.ja,*.jar,*.kmz,
        \ *.odb,*.odc,*.odf,*.odg,*.odi,*.odm,*.odp,*.ods,*.odt,*.otc,*.otf,
-       \ *.otg,*.oth,*.oti,*.otp,*.ots,*.ott,*.oxt,*.potm,*.potx,*.ppam,
-       \ *.ppsm,*.ppsx,*.pptm,*.pptx,*.sldx,*.thmx,*.vdw,*.war,*.whl,*.wsz,
-       \ *.xap,*.xlam,*.xlsb,*.xlsm,*.xlsx,*.xltm,*.xltx,*.xpi,*.zip'
+       \ *.otg,*.oth,*.oti,*.otp,*.ots,*.ott,*.oxt,*.pkpass,*.potm,*.potx,
+       \ *.ppam,*.ppsm,*.ppsx,*.pptm,*.pptx,*.sldx,*.thmx,*.vdw,*.war,*.whl,
+       \ *.wsz, *.xap,*.xlam,*.xlsb,*.xlsm,*.xlsx,*.xltm,*.xltx,*.xpi,*.zip'
 
 ==============================================================================
 4. History							*zip-history* {{{1

--- a/runtime/plugin/zipPlugin.vim
+++ b/runtime/plugin/zipPlugin.vim
@@ -5,6 +5,7 @@
 " Former Maintainer:	Charles E Campbell
 " Last Change:
 " 2025 Apr 02 by Vim Project: add *.whl to list of zip extensions (#17038)
+" 2025 Oct 06 by MultisampledNight: add *.pkpass to list of zip extensions (#18501)
 " License:		Vim License  (see vim's :help license)
 " Copyright:    Copyright (C) 2005-2016 Charles E. Campbell {{{1
 "               Permission is hereby granted to use and distribute this code,
@@ -30,7 +31,7 @@ set cpo&vim
 " ---------------------------------------------------------------------
 " Options: {{{1
 if !exists("g:zipPlugin_ext")
- let g:zipPlugin_ext='*.aar,*.apk,*.celzip,*.crtx,*.docm,*.docx,*.dotm,*.dotx,*.ear,*.epub,*.gcsx,*.glox,*.gqsx,*.ja,*.jar,*.kmz,*.odb,*.odc,*.odf,*.odg,*.odi,*.odm,*.odp,*.ods,*.odt,*.otc,*.otf,*.otg,*.oth,*.oti,*.otp,*.ots,*.ott,*.oxt,*.potm,*.potx,*.ppam,*.ppsm,*.ppsx,*.pptm,*.pptx,*.sldx,*.thmx,*.vdw,*.war,*.whl,*.wsz,*.xap,*.xlam,*.xlsb,*.xlsm,*.xlsx,*.xltm,*.xltx,*.xpi,*.zip'
+ let g:zipPlugin_ext='*.aar,*.apk,*.celzip,*.crtx,*.docm,*.docx,*.dotm,*.dotx,*.ear,*.epub,*.gcsx,*.glox,*.gqsx,*.ja,*.jar,*.kmz,*.odb,*.odc,*.odf,*.odg,*.odi,*.odm,*.odp,*.ods,*.odt,*.otc,*.otf,*.otg,*.oth,*.oti,*.otp,*.ots,*.ott,*.oxt,*.pkpass,*.potm,*.potx,*.ppam,*.ppsm,*.ppsx,*.pptm,*.pptx,*.sldx,*.thmx,*.vdw,*.war,*.whl,*.wsz,*.xap,*.xlam,*.xlsb,*.xlsm,*.xlsx,*.xltm,*.xltx,*.xpi,*.zip'
 endif
 
 " ---------------------------------------------------------------------


### PR DESCRIPTION
#### vim-patch:8824526: runtime(zip): add *.pkpass to list of zip extensions

Similar to a359c9c25e5c3c1e543fc720223aa7256e6f72cf.
See https://developer.apple.com/documentation/walletpasses/building-a-pass#Sign-the-Pass-and-Create-the-Bundle,
which explicitly mentions that pkpasses are just renamed ZIPs.

closes: vim/vim#18501

https://github.com/vim/vim/commit/882452644cd3258c887a09de856e4c59eb284a92

Co-authored-by: MultisampledNight <contact@multisamplednight.com>