### PR TITLE
fix(pack): handle lockfile in case of install errors

### DIFF
--- a/runtime/lua/vim/pack.lua
+++ b/runtime/lua/vim/pack.lua
@@ -789,6 +789,11 @@ function M.add(specs, opts)
   if #plugs_to_install > 0 then
     git_ensure_exec()
     install_list(plugs_to_install, opts.confirm)
+    for _, p in ipairs(plugs_to_install) do
+      if not p.info.installed then
+        plugin_lock.plugins[p.spec.name] = nil
+      end
+    end
   end
 
   if needs_lock_write then


### PR DESCRIPTION
Problem: If plugin was intended to install but there were errors (like
  if there is a typo in `src`), lockfile still includes its entry.
  This leads to all source of problems (like not correct `get()` output,
  not working `update()`, etc.).

Solution: Explicitly account for plugins that were not installed.
  Alternative solution might be to write a safe
  `lock_set(plug, field, value)` wrapper (which sets field for a correct
  `plugins` entry in the lockfile Lua table) and use it after install
  to detect the change in `version`. However, this always requires
  an extra pass through plugins on every startup, which is suboptimal.
  Optimizing for the "happy path" should be a priority in `add()`.

---

Fixes #36058
