### PR TITLE
fix(cmdline): don't treat c_CTRL-D as wildmenu

### DIFF
--- a/src/nvim/cmdexpand.c
+++ b/src/nvim/cmdexpand.c
@@ -637,7 +637,7 @@ static void redraw_wildmenu(expand_T *xp, int num_matches, char **matches, int m
 
   int row = cmdline_row - 1;
   if (row >= 0) {
-    if (wild_menu_showing == 0 || wild_menu_showing == WM_LIST) {
+    if (wild_menu_showing == 0) {
       if (msg_scrolled > 0) {
         // Put the wildmenu just above the command line.  If there is
         // no room, scroll the screen one line up.
@@ -3796,13 +3796,10 @@ void wildmenu_cleanup(CmdlineInfo *cclp)
     redrawcmd();
     save_p_ls = -1;
     wild_menu_showing = 0;
-    // don't redraw statusline if WM_LIST is showing
-  } else if (wild_menu_showing != WM_LIST) {
+  } else {
     win_redraw_last_status(topframe);
     wild_menu_showing = 0;  // must be before redraw_statuslines #8385
     redraw_statuslines();
-  } else {
-    wild_menu_showing = 0;
   }
   KeyTyped = skt;
   if (cclp->input_fn) {

--- a/src/nvim/ex_getln.c
+++ b/src/nvim/ex_getln.c
@@ -2076,7 +2076,6 @@ static int command_line_handle_key(CommandLineState *s)
       break;                  // Use ^D as normal char instead
     }
 
-    wild_menu_showing = WM_LIST;
     redrawcmd();
     return 1;                 // don't do incremental search now
 
@@ -4976,7 +4975,7 @@ void get_user_input(const typval_T *const argvars, typval_T *const rettv, const 
 void f_wildtrigger(typval_T *argvars, typval_T *rettv, EvalFuncData fptr)
 {
   if (!(State & MODE_CMDLINE) || char_avail()
-      || (wild_menu_showing != 0 && wild_menu_showing != WM_LIST)
+      || wild_menu_showing
       || cmdline_pum_active()) {
     return;
   }

--- a/src/nvim/globals.h
+++ b/src/nvim/globals.h
@@ -724,7 +724,6 @@ EXTERN int wild_menu_showing INIT( = 0);
 enum {
   WM_SHOWN = 1,     ///< wildmenu showing
   WM_SCROLLED = 2,  ///< wildmenu showing with scroll
-  WM_LIST = 3,      ///< cmdline CTRL-D
 };
 
 // When a window has a local directory, the absolute path of the global

--- a/test/functional/ui/wildmode_spec.lua
+++ b/test/functional/ui/wildmode_spec.lua
@@ -424,6 +424,36 @@ describe("'wildmenu'", function()
     ]])
   end)
 
+  it("<C-D> doesn't make statuslines disappear with 'nowildmenu' #36053", function()
+    screen:try_resize(60, 10)
+    command('set laststatus=2 nowildmenu')
+    feed(':sign <C-D>')
+    screen:expect([[
+                                                                  |
+      {1:~                                                           }|*5
+      {3:                                                            }|
+      :sign                                                       |
+      define    jump      list      place     undefine  unplace   |
+      :sign ^                                                      |
+    ]])
+    feed('<Esc>')
+    screen:expect([[
+      ^                                                            |
+      {1:~                                                           }|*7
+      {3:[No Name]                                                   }|
+                                                                  |
+    ]])
+    command('mode')
+    screen:expect_unchanged()
+    feed('ifoobar<Esc>')
+    screen:expect([[
+      fooba^r                                                      |
+      {1:~                                                           }|*7
+      {3:[No Name] [+]                                               }|
+                                                                  |
+    ]])
+  end)
+
   it('works with c_CTRL_Z standard mapping', function()
     screen:add_extra_attr_ids {
       [100] = { background = Screen.colors.Yellow1, foreground = Screen.colors.Black },


### PR DESCRIPTION
Remove WM_LIST, which was previously added in #7110, but now statusline
and messages no longer interfere with each other thanks to the message
grid, etc., and terminal refreshing no longer calls update_screen()
directly since #9883.

Tests from #7110 and #10107 still pass.

Fix #36053
