### PR TITLE
vim-patch:f8b9251: runtime(doc): Fix typos in syntax.txt

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5619,8 +5619,8 @@ If your syntax causes redrawing to be slow, here are a few hints on making it
 faster.  To see slowness switch on some features that usually interfere, such
 as 'relativenumber' and |folding|.
 
-To find out what patterns are consuming most time, get an overview with this
-sequence: >
+To find out what patterns are consuming the most time, get an overview with
+this sequence: >
 	:syntime on
 	[ redraw the text at least once with CTRL-L ]
 	:syntime report


### PR DESCRIPTION
#### vim-patch:f8b9251: runtime(doc): Fix typos in syntax.txt

closes: vim/vim#18504

https://github.com/vim/vim/commit/f8b9251d8f3856b5a2fd19404ec28376c71e21de

Co-authored-by: Elijah Greenstein <197816462+elijahgreenstein@users.noreply.github.com>