### PR TITLE
fix(lsp): typos in methods

### DIFF
--- a/runtime/lua/vim/lsp/client.lua
+++ b/runtime/lua/vim/lsp/client.lua
@@ -615,7 +615,7 @@ local static_registration_capabilities = {
   ['textDocument/linkedEditingRange'] = 'linkedEditingRangeProvider',
   ['textDocument/moniker'] = 'monikerProvider',
   ['textDocument/selectionRange'] = 'selectionRangeProvider',
-  ['textDocument_semanticTokens/full'] = 'semanticTokensProvider',
+  ['textDocument/semanticTokens/full'] = 'semanticTokensProvider',
   ['textDocument/typeDefinition'] = 'typeDefinitionProvider',
   ['textDocument/prepareTypeHierarchy'] = 'typeHierarchyProvider',
 }

--- a/runtime/lua/vim/lsp/handlers.lua
+++ b/runtime/lua/vim/lsp/handlers.lua
@@ -650,12 +650,12 @@ RSC['window/showDocument'] = function(_, params, ctx)
 end
 
 ---@see https://microsoft.github.io/language-server-protocol/specification/#workspace_inlayHint_refresh
-RSC['workspace_inlayHint/refresh'] = function(err, result, ctx)
+RSC['workspace/inlayHint/refresh'] = function(err, result, ctx)
   return vim.lsp.inlay_hint.on_refresh(err, result, ctx)
 end
 
 ---@see https://microsoft.github.io/language-server-protocol/specifications/specification-current/#semanticTokens_refreshRequest
-RSC['workspace_semanticTokens/refresh'] = function(err, result, ctx)
+RSC['workspace/semanticTokens/refresh'] = function(err, result, ctx)
   return vim.lsp.semantic_tokens._refresh(err, result, ctx)
 end
 


### PR DESCRIPTION
Today, after updating, I noticed one of my LSP servers was crashing for no apparent reason. As it turns out, https://github.com/neovim/neovim/pull/35998 had some typos.

Edit: after going through every change on that PR, I found another typo, on another file