### PR TITLE
fix(undotree): error on `undotree.open()` with title as string

### DIFF
--- a/runtime/pack/dist/opt/nvim.undotree/lua/undotree.lua
+++ b/runtime/pack/dist/opt/nvim.undotree/lua/undotree.lua
@@ -348,6 +348,8 @@ function M.open(opts)
     title = string.format('Undo tree for %s', vim.fn.fnamemodify(bufname, ':.'))
   elseif type(opts_title) == 'function' then
     title = opts_title(buf)
+  elseif type(opts_title) == 'string' then
+    title = opts_title
   end
 
   assert(type(title) == 'string', 'Window title must be a string')


### PR DESCRIPTION
Simple fix for title strings not being used:

`require('undotree').open({ title = "some string" })` fails the assertion.