### PR TITLE
fix(undotree): highlight extmarks like normal text

### DIFF
--- a/runtime/pack/dist/opt/nvim.undotree/lua/undotree.lua
+++ b/runtime/pack/dist/opt/nvim.undotree/lua/undotree.lua
@@ -220,7 +220,7 @@ local function buf_apply_graph_lines(tree, graph_lines, buf, meta, find_seq)
         found_seq = #meta
       end
     elseif line then
-      table.insert(extmark_buffer, { { line, 'Comment' } })
+      table.insert(extmark_buffer, { { line, 'Normal' } })
     end
 
     if next(extmark_buffer) and (v.kind == 'node' or is_last) then


### PR DESCRIPTION
Problem:
Difference in highlight color between normal lines and extmark lines is
distracting and conveys little information. This is especially the case if a user has set something like `:hi Comment guifg=orange`.

Solution:
Set extmarks highlight to the Normal group.

Before:

<img width="369" height="428" alt="image" src="https://github.com/user-attachments/assets/ac44d204-63ca-4184-a7ee-16274642b6b9" />


After:

<img width="290" height="424" alt="image" src="https://github.com/user-attachments/assets/25b36aad-2056-454f-992f-aba3da8b5803" />
