### PR TITLE
fix(api): nvim_open_win default to half-size for splits

### DIFF
--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -260,9 +260,9 @@ Window nvim_open_win(Buffer buffer, Boolean enter, Dict(win_config) *config, Err
       }
     }
     int flags = win_split_flags(fconfig.split, parent == NULL) | WSP_NOENTER;
+    int size = (flags & WSP_VERT) ? fconfig.width : fconfig.height;
 
     TRY_WRAP(err, {
-      int size = (flags & WSP_VERT) ? fconfig.width : fconfig.height;
       if (parent == NULL || parent == curwin) {
         wp = win_split_ins(size, flags, NULL, 0, NULL);
       } else {
@@ -277,12 +277,14 @@ Window nvim_open_win(Buffer buffer, Boolean enter, Dict(win_config) *config, Err
     });
     if (wp) {
       wp->w_config = fconfig;
-      // Without room for the requested size, window sizes may have been equalized instead.
-      // If the size differs from what was requested, try to set it again now.
-      if ((flags & WSP_VERT) && wp->w_width != fconfig.width) {
-        win_setwidth_win(fconfig.width, wp);
-      } else if (!(flags & WSP_VERT) && wp->w_height != fconfig.height) {
-        win_setheight_win(fconfig.height, wp);
+      if (size > 0) {
+        // Without room for the requested size, window sizes may have been equalized instead.
+        // If the size differs from what was requested, try to set it again now.
+        if ((flags & WSP_VERT) && wp->w_width != size) {
+          win_setwidth_win(size, wp);
+        } else if (!(flags & WSP_VERT) && wp->w_height != size) {
+          win_setheight_win(size, wp);
+        }
       }
     }
   } else {

--- a/test/functional/api/window_spec.lua
+++ b/test/functional/api/window_spec.lua
@@ -2273,6 +2273,16 @@ describe('API/win', function()
       command('split')
       win = api.nvim_open_win(0, false, { win = 0, split = 'below', height = 10 })
       eq(10, api.nvim_win_get_height(win))
+
+      -- Still defaults to half-sized when no size was specified.
+      command('only')
+      eq(80, api.nvim_win_get_width(0))
+      api.nvim_open_win(0, true, { split = 'right' })
+      eq(40, api.nvim_win_get_width(0))
+
+      eq(22, api.nvim_win_get_height(0))
+      api.nvim_open_win(0, true, { split = 'below' })
+      eq(11, api.nvim_win_get_height(0))
     end)
   end)
 


### PR DESCRIPTION
Problem: after #35601, `nvim_open_win` incorrectly attempts to set the size of a split window to 0 if it wasn't specified.

Solution: only attempt to set the size again if it was actually specified. This has the effect of defaulting to half the size of the parent window (or it may be equalized with other windows to make room), like before.

Fix #36080