### PR TITLE
feat(undotree): set filetype to nvim-undotree

### DIFF
--- a/runtime/pack/dist/opt/nvim.undotree/lua/undotree.lua
+++ b/runtime/pack/dist/opt/nvim.undotree/lua/undotree.lua
@@ -361,7 +361,6 @@ function M.open(opts)
   vim.bo[b].buflisted = false
   vim.bo[b].buftype = 'nofile'
   vim.bo[b].bufhidden = 'wipe'
-  vim.bo[b].filetype = 'nvim-undotree'
   vim.bo[b].swapfile = false
 
   local meta = draw(buf, b)
@@ -402,6 +401,8 @@ function M.open(opts)
       end
     end,
   })
+
+  vim.bo[b].filetype = 'nvim-undotree'
 end
 
 return M

--- a/runtime/pack/dist/opt/nvim.undotree/lua/undotree.lua
+++ b/runtime/pack/dist/opt/nvim.undotree/lua/undotree.lua
@@ -361,6 +361,7 @@ function M.open(opts)
   vim.bo[b].buflisted = false
   vim.bo[b].buftype = 'nofile'
   vim.bo[b].bufhidden = 'wipe'
+  vim.bo[b].filetype = 'nvim-undotree'
   vim.bo[b].swapfile = false
 
   local meta = draw(buf, b)


### PR DESCRIPTION
Set the filetype of undotree buffers to "nvim-undotree", in line with nvim-pack buffers. Allows for using an ftplugin file to set local mappings/options.