### PR TITLE
fix(tests): enable TUI tests on windows.

### DIFF
--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -398,6 +398,7 @@ static void terminfo_start(TUIData *tui)
   tui->out_fd = STDOUT_FILENO;
   tui->out_isatty = os_isatty(tui->out_fd);
   tui->input.tui_data = tui;
+  ELOG("very tty: %d\n", tui->out_isatty);
 
   char *term = os_getenv("TERM");
 #ifdef MSWIN
@@ -407,6 +408,10 @@ static void terminfo_start(TUIData *tui)
     term = xstrdup(guessed_term);
     os_setenv("TERM", guessed_term, 1);
   }
+
+  uv_tty_vtermstate_t state = -1;
+  uv_tty_get_vterm_state(&state);
+  ELOG("uv otherwise thinks: %d\n", state);
 #endif
 
   // Set up unibilium/terminfo.

--- a/src/nvim/tui/tui.c
+++ b/src/nvim/tui/tui.c
@@ -412,6 +412,7 @@ static void terminfo_start(TUIData *tui)
   uv_tty_vtermstate_t state = -1;
   uv_tty_get_vterm_state(&state);
   ELOG("uv otherwise thinks: %d\n", state);
+  uv_tty_set_vterm_state(UV_TTY_SUPPORTED);  // LETS FUCKING GOOOOOOOO
 #endif
 
   // Set up unibilium/terminfo.

--- a/test/functional/autocmd/autocmd_oldtest_spec.lua
+++ b/test/functional/autocmd/autocmd_oldtest_spec.lua
@@ -87,6 +87,7 @@ describe('oldtests', function()
 
     fn.delete('Xout')
     fn.system(string.format('%s --clean -N -S %s', api.nvim_get_vvar('progpath'), fname))
+    print("\nTHONK:\n", io.open(testlog):read'*a', "\n[einda]\n")
     eq(1, fn.filereadable('Xout'))
 
     fn.delete('Xxx1')

--- a/test/functional/terminal/tui_spec.lua
+++ b/test/functional/terminal/tui_spec.lua
@@ -460,10 +460,6 @@ describe('TUI :connect', function()
   end)
 end)
 
-if t.skip(is_os('win')) then
-  return
-end
-
 describe('TUI', function()
   local screen --[[@type test.functional.ui.screen]]
   local child_session --[[@type test.Session]]


### PR DESCRIPTION
Unfortunately this is too much bullshit now, as some other tests rely on TUI sorta kinda working. Let's enable individual tests that work and mark those which still don't as `pending()`

<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
