### PR TITLE
vim-patch:9.1.1839: Window may have wrong height if resized from another tabpage

### DIFF
--- a/test/functional/legacy/window_cmd_spec.lua
+++ b/test/functional/legacy/window_cmd_spec.lua
@@ -407,3 +407,27 @@ it("'winfixwidth/height' does not leave stray vseps/statuslines", function()
   eq(2, fn.winheight(1))
   eq(4, fn.winheight(2))
 end)
+
+-- oldtest: Test_resize_from_another_tabpage()
+it('resizing window from another tabpage', function()
+  clear()
+  local screen = Screen.new(75, 8)
+  screen:add_extra_attr_ids({
+    [100] = { foreground = Screen.colors.Magenta1, bold = true },
+  })
+  exec([[
+    set laststatus=2
+    vnew
+    let w = win_getid()
+    tabnew
+    call win_execute(w, 'vertical resize 20')
+    tabprev
+  ]])
+  screen:expect([[
+    {5: }{100:2}{5: [No Name] }{24: [No Name] }{2:                                                  }{24:X}|
+    ^                    │                                                      |
+    {1:~                   }│{1:~                                                     }|*4
+    {3:[No Name]            }{2:[No Name]                                             }|
+                                                                               |
+  ]])
+end)

--- a/test/old/testdir/test_window_cmd.vim
+++ b/test/old/testdir/test_window_cmd.vim
@@ -2263,6 +2263,7 @@ endfunc
 
 func Test_winfixsize_vsep_statusline()
   CheckScreendump
+
   let lines =<< trim END
     set noequalalways splitbelow splitright
     vsplit
@@ -2303,6 +2304,24 @@ func Test_winfixsize_vsep_statusline()
   call term_sendkeys(buf, ":echo winheight(1) winheight(2)\n")
   " (Likewise, may be better if 'wfh' window remains at 3 rows)
   call WaitForAssert({-> assert_match('^2 4\>', term_getline(buf, 8))})
+
+  call StopVimInTerminal(buf)
+endfunc
+
+func Test_resize_from_another_tabpage()
+  CheckScreendump
+
+  let lines =<< trim END
+    set laststatus=2
+    vnew
+    let w = win_getid()
+    tabnew
+    call win_execute(w, 'vertical resize 20')
+    tabprev
+  END
+  call writefile(lines, 'XTestResizeFromAnotherTabpage', 'D')
+  let buf = RunVimInTerminal('-S XTestResizeFromAnotherTabpage', #{rows: 8})
+  call VerifyScreenDump(buf, 'Test_resize_from_another_tabpage_1', {})
 
   call StopVimInTerminal(buf)
 endfunc


### PR DESCRIPTION
#### vim-patch:9.1.1839: Window may have wrong height if resized from another tabpage

Problem:  Window may have wrong height if resized from another tabpage.
Solution: Improve check for whether a tabline has been added (zeertzjq).

closes: vim/vim#18519

https://github.com/vim/vim/commit/bd3b9580273e890951135686875de9bd49e798bc