### PR TITLE
vim-patch:ec19075: runtime(doc): Normalise ellipsis dots in syntax.txt

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -3757,9 +3757,9 @@ Vim understands three types of syntax items:
 
 Several syntax ITEMs can be put into one syntax GROUP.	For a syntax group
 you can give highlighting attributes.  For example, you could have an item
-to define a `/* .. */` comment and another one that defines a "// .." comment,
-and put them both in the "Comment" group.  You can then specify that a
-"Comment" will be in bold font and have a blue color.  You are free to make
+to define a `/* ... */` comment and another one that defines a "// ..."
+comment, and put them both in the "Comment" group.  You can then specify that
+a "Comment" will be in bold font and have a blue color.  You are free to make
 one highlight group for one syntax item, or put all items into one group.
 This depends on how you want to specify your highlighting attributes.  Putting
 each item in its own group results in having to specify the highlighting
@@ -3957,9 +3957,9 @@ DEFINING REGIONS	*:syn-region* *:syn-start* *:syn-skip* *:syn-end*
 		[keepend]
 		[extend]
 		[excludenl]
-		start={start-pattern} ..
+		start={start-pattern} ...
 		[skip={skip-pattern}]
-		end={end-pattern} ..
+		end={end-pattern} ...
 		[{options}]
 
 	This defines one region.  It may span several lines.
@@ -4292,7 +4292,7 @@ from its syntax items.
 
 
 			*:syn-contains* *E405* *E406* *E407* *E408* *E409*
-contains={group-name},..
+contains={group-name},...
 
 The "contains" argument is followed by a list of syntax group names.  These
 groups will be allowed to begin inside the item (they may extend past the
@@ -4305,7 +4305,7 @@ contains=ALL
 		If the only item in the contains list is "ALL", then all
 		groups will be accepted inside the item.
 
-contains=ALLBUT,{group-name},..
+contains=ALLBUT,{group-name},...
 		If the first item in the contains list is "ALLBUT", then all
 		groups will be accepted inside the item, except the ones that
 		are listed.  Example: >
@@ -4315,14 +4315,14 @@ contains=TOP
 		If the first item in the contains list is "TOP", then all
 		groups will be accepted that don't have the "contained"
 		argument.
-contains=TOP,{group-name},..
+contains=TOP,{group-name},...
 		Like "TOP", but excluding the groups that are listed.
 
 contains=CONTAINED
 		If the first item in the contains list is "CONTAINED", then
 		all groups will be accepted that have the "contained"
 		argument.
-contains=CONTAINED,{group-name},..
+contains=CONTAINED,{group-name},...
 		Like "CONTAINED", but excluding the groups that are
 		listed.
 
@@ -4345,7 +4345,7 @@ region where contained items do match.	Note that this may also limit the
 area that is highlighted
 
 
-containedin={group-name}...				*:syn-containedin*
+containedin={group-name},...				*:syn-containedin*
 
 The "containedin" argument is followed by a list of syntax group names.  The
 item will be allowed to begin inside these groups.  This works as if the
@@ -4358,7 +4358,7 @@ neither contains this item via |:syn-contains| nor is named in this item's
 Note that a |:syn-transparent| region still enforces its own |:syn-contains|
 list.
 
-The {group-name}... can be used just like for "contains", as explained above.
+The {group-name},... can be used just like for "contains", as explained above.
 
 This is useful when adding a syntax item afterwards.  An item can be told to
 be included inside an already existing item, without changing the definition
@@ -4375,7 +4375,7 @@ work.
 See also: |:syn-contains|, |:syn-transparent|.
 
 
-nextgroup={group-name},..				*:syn-nextgroup*
+nextgroup={group-name},...				*:syn-nextgroup*
 
 The "nextgroup" argument is followed by a list of syntax group names,
 separated by commas (just like with "contains", so you can also use patterns).
@@ -4631,22 +4631,22 @@ cannot be referred to.
 ==============================================================================
 9. Syntax clusters					*:syn-cluster* *E400*
 
-:sy[ntax] cluster {cluster-name} [contains={group-name}..]
-				 [add={group-name}..]
-				 [remove={group-name}..]
+:sy[ntax] cluster {cluster-name} [contains={group-name},...]
+				 [add={group-name},...]
+				 [remove={group-name},...]
 
 This command allows you to cluster a list of syntax groups together under a
 single name.
 
-	contains={group-name}..
+	contains={group-name},...
 		The cluster is set to the specified list of groups.
-	add={group-name}..
+	add={group-name},...
 		The specified groups are added to the cluster.
-	remove={group-name}..
+	remove={group-name},...
 		The specified groups are removed from the cluster.
 
-A cluster so defined may be referred to in a contains=.., containedin=..,
-nextgroup=.., add=..  or remove=.. list with a "@" prefix.  You can also use
+A cluster so defined may be referred to in a contains=..., containedin=...,
+nextgroup=..., add=... or remove=... list with a "@" prefix.  You can also use
 this notation to implicitly declare a cluster before specifying its contents.
 
 Example: >
@@ -4861,7 +4861,7 @@ highlighting.  The reduced number of patterns means it will go (much)
 faster.]
 
 					    *syn-sync-grouphere* *E393* *E394*
-    :syntax sync match {sync-group-name} grouphere {group-name} "pattern" ..
+    :syntax sync match {sync-group-name} grouphere {group-name} "pattern" ...
 
 	Define a match that is used for syncing.  {group-name} is the
 	name of a syntax group that follows just after the match.  Parsing
@@ -4870,7 +4870,7 @@ faster.]
 	"NONE" can be used for when there is no syntax group after the match.
 
 						*syn-sync-groupthere*
-    :syntax sync match {sync-group-name} groupthere {group-name} "pattern" ..
+    :syntax sync match {sync-group-name} groupthere {group-name} "pattern" ...
 
 	Like "grouphere", but {group-name} is the name of a syntax group that
 	is to be used at the start of the line where searching for the sync
@@ -4883,8 +4883,8 @@ faster.]
 	it's a bit more complicated, because the "/*" and "*/" could appear
 	inside a string.  That's left as an exercise to the reader...).
 
-    :syntax sync match ..
-    :syntax sync region ..
+    :syntax sync match ...
+    :syntax sync region ...
 
 	Without a "groupthere" argument.  Define a region or match that is
 	skipped while searching for a sync point.
@@ -4905,7 +4905,7 @@ You can clear all sync settings with: >
    :syntax sync clear
 
 You can clear specific sync patterns with: >
-   :syntax sync clear {sync-group-name} ..
+   :syntax sync clear {sync-group-name} ...
 
 ==============================================================================
 12. Listing syntax items		*:syntax* *:sy* *:syn* *:syn-list*
@@ -4993,7 +4993,7 @@ colorscheme.
 			Disable the highlighting for one highlight group.  It
 			is _not_ set back to the default colors.
 
-:hi[ghlight] [default] {group-name} {key}={arg} ..
+:hi[ghlight] [default] {group-name} {key}={arg} ...
 			Add a highlight group, or change the highlighting for
 			an existing group.
 			See |highlight-args| for the {key}={arg} arguments.
@@ -5530,11 +5530,11 @@ The command also deletes the "b:current_syntax" variable, since no syntax is
 loaded after this command.
 
 To clean up specific syntax groups for the current buffer: >
-  :syntax clear {group-name} ..
+  :syntax clear {group-name} ...
 This removes all patterns and keywords for {group-name}.
 
 To clean up specific syntax group lists for the current buffer: >
-  :syntax clear @{grouplist-name} ..
+  :syntax clear @{grouplist-name} ...
 This sets {grouplist-name}'s contents to an empty list.
 
 						*:syntax-off* *:syn-off*


### PR DESCRIPTION
#### vim-patch:ec19075: runtime(doc): Normalise ellipsis dots in syntax.txt

Use three dots rather than two.

closes: vim/vim#18521

https://github.com/vim/vim/commit/ec19075f6171cb7c9e1d9b483850595b9b12c256

Co-authored-by: Doug Kearns <dougkearns@gmail.com>