### PR TITLE
vim-patch:143686b: runtime(java): Fold adjacent "import" declarations

### DIFF
--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1725,14 +1725,17 @@ Note that these three variables are maintained in the HTML syntax file.
 Numbers and strings can be recognized in non-Javadoc comments with >
 	:let g:java_comment_strings = 1
 
-When 'foldmethod' is set to "syntax", blocks of code and multi-line comments
-will be folded.  No text is usually written in the first line of a multi-line
-comment, making folded contents of Javadoc comments less informative with the
-default 'foldtext' value; you may opt for showing the contents of a second
-line for any comments written in this way, and showing the contents of a first
-line otherwise, with >
+When 'foldmethod' is set to "syntax", multi-line blocks of code ("b"), plain
+comments ("c"), Javadoc comments ("d"), and adjacent "import" declarations
+("i") will be folded by default.  Syntax items of any supported kind will
+remain NOT foldable when its abbreviated name is delisted with >
+	:let g:java_ignore_folding = "bcdi"
+No text is usually written in the first line of a multi-line comment, making
+folded contents of Javadoc comments less informative with the default
+'foldtext' value; you may opt for showing the contents of a second line for
+any comments written in this way, and showing the contents of a first line
+otherwise, with >
 	:let g:java_foldtext_show_first_or_second_line = 1
-
 HTML tags in Javadoc comments can additionally be folded by following the
 instructions listed under |html-folding| and giving explicit consent with >
 	:let g:java_consent_to_html_syntax_folding = 1


### PR DESCRIPTION
#### vim-patch:143686b: runtime(java): Fold adjacent "import" declarations

Also, distinguish (by abbreviating their names) and manage
foldable kinds of syntax items: blocks of code ("b"), plain
comments ("c"), Javadoc comments ("d"), adjacent "import"
declarations ("i").  Fold all qualifying items by default;
otherwise, do not fold items of explicitly delisted kinds.
For example,
------------------------------------------------------------
	let g:java_ignore_folding = "bcdi"
------------------------------------------------------------

closes: vim/vim#18492

https://github.com/vim/vim/commit/143686b3c453d732b849a1528ca1b54badef644b

Co-authored-by: Aliaksei Budavei <0x000c70@gmail.com>