### PR TITLE
vim-patch: Vim syntax updates

### DIFF
--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -106,7 +106,7 @@ syn keyword vimGroup contained Added Bold BoldItalic Boolean Changed Character C
 syn keyword vimHLGroup contained ErrorMsg IncSearch ModeMsg NonText StatusLine StatusLineNC EndOfBuffer VertSplit DiffText DiffTextAdd PmenuSbar TabLineSel TabLineFill Cursor lCursor QuickFixLine CursorLineSign CursorLineFold CurSearch PmenuKind PmenuKindSel PmenuMatch PmenuMatchSel PmenuExtra PmenuExtraSel PreInsert Normal Directory LineNr CursorLineNr MoreMsg Question Search SpellBad SpellCap SpellRare SpellLocal PmenuThumb Pmenu PmenuSel SpecialKey Title WarningMsg WildMenu Folded FoldColumn SignColumn Visual DiffAdd DiffChange DiffDelete TabLine CursorColumn CursorLine ColorColumn MatchParen StatusLineTerm StatusLineTermNC
 syn keyword vimHLGroup contained CursorIM ComplMatchIns LineNrAbove LineNrBelow MsgArea User1 User2 User3 User4 User5 User6 User7 User8 User9
 syn match vimHLGroup contained "\<Conceal\>"
-syn keyword vimOnlyHLGroup contained	Menu PopupSelected MessageWindow PopupNotification Scrollbar Terminal ToolbarButton ToolbarLine Tooltip VisualNOS
+syn keyword vimOnlyHLGroup contained	Menu PopupSelected MessageWindow PopupNotification Scrollbar Terminal TitleBar TitleBarNC ToolbarButton ToolbarLine Tooltip VisualNOS
 syn keyword nvimHLGroup contained	FloatBorder FloatFooter FloatTitle MsgSeparator NormalFloat NormalNC Substitute TermCursor VisualNC Whitespace WinBar WinBarNC WinSeparator
 "}}}2
 syn case match
@@ -1300,7 +1300,7 @@ syn region	vimEval
       \ end="\ze|"
       \ excludenl end="$"
       \ nextgroup=vimCmdSep
-      \ contains=@vimContinue,@vimExprList,vimComment,vim9Comment
+      \ contains=@vimContinue,@vimExprList,vim9Comment
       \ transparent
 
 " Filter: {{{2

--- a/runtime/syntax/vim.vim
+++ b/runtime/syntax/vim.vim
@@ -1300,7 +1300,7 @@ syn region	vimEval
       \ end="\ze|"
       \ excludenl end="$"
       \ nextgroup=vimCmdSep
-      \ contains=@vimContinue,@vimExprList,vim9Comment
+      \ contains=@vimContinue,@vimExprList,vim9Comment,vimComment
       \ transparent
 
 " Filter: {{{2

--- a/src/nvim/option_vars.h
+++ b/src/nvim/option_vars.h
@@ -178,6 +178,7 @@ enum {
 #define GO_ASELML       'A'             // autoselect modeless selection
 #define GO_BOT          'b'             // use bottom scrollbar
 #define GO_CONDIALOG    'c'             // use console dialog
+#define GO_TITLEBAR     'C'             // use 'hl-TitleBar'
 #define GO_DARKTHEME    'd'             // use dark theme variant
 #define GO_TABLINE      'e'             // may show tabline
 #define GO_FORG         'f'             // start GUI in foreground
@@ -196,7 +197,7 @@ enum {
 #define GO_FOOTER       'F'             // add footer
 #define GO_VERTICAL     'v'             // arrange dialog buttons vertically
 #define GO_KEEPWINSIZE  'k'             // keep GUI window size
-#define GO_ALL "!aAbcdefFghilLmMpPrRtTvk"  // all possible flags for 'go'
+#define GO_ALL "!aAbcCdefFghilLmMpPrRtTvk"  // all possible flags for 'go'
 
 // flags for 'comments' option
 #define COM_NEST        'n'             // comments strings nest


### PR DESCRIPTION
#### vim-patch:9.1.1834: MS-Windows: not possible to highlight the title bar

Problem:  MS-Windows: not possible to highlight the title bar
Solution: Make the title/caption bar configurable by introducing the
          'go-C' option value which allows to highlight it using the
          TitleBar and TitleBarNC highlighting groups (Mao-Yining).

Introduce titlebar color customization for Windows 11 GUI through
highlight groups and new 'guioptions' flag:

- Add 'C' flag to enable titlebar color customization (opt-in)
- New highlight groups: TitleBar (active) and TitleBarNC (inactive)
- Uses DWMWA_CAPTION_COLOR and DWMWA_TEXT_COLOR DWM attributes
- Dynamically loads dwmapi.dll for Windows 11 compatibility
- Defaults to system colors when set to NONE or feature disabled

closes: vim/vim#18449

https://github.com/vim/vim/commit/2c093682738cb2e01864aa2934b7bafdb277c011

Co-authored-by: Mao-Yining <mao.yining@outlook.com>


#### vim-patch:ce5f9f4: runtime(vim): Update base syntax, allow legacy script comments after :eval

closes: vim/vim#18522

https://github.com/vim/vim/commit/ce5f9f45afebd9f3d06dc4bf240f8c538560709e

Co-authored-by: Doug Kearns <dougkearns@gmail.com>