### PR TITLE
fix(undotree): mark title field annotation as optional

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -181,9 +181,9 @@ open({opts})                                                 *undotree.open()*
                 • {command} (`string?`) Vimscript command to create the
                   window. Default value is "30vnew". Only used when {winid} is
                   nil.
-                • {title} (`string|fun(bufnr:integer):string?`) Title of the
-                  window. If a function, it accepts the buffer number of the
-                  source buffer as its only argument and should return a
+                • {title} (`(string|fun(bufnr:integer):string?)?`) Title of
+                  the window. If a function, it accepts the buffer number of
+                  the source buffer as its only argument and should return a
                   string.
 
 

--- a/runtime/pack/dist/opt/nvim.undotree/lua/undotree.lua
+++ b/runtime/pack/dist/opt/nvim.undotree/lua/undotree.lua
@@ -287,7 +287,7 @@ end
 ---
 --- Title of the window. If a function, it accepts the buffer number of the
 --- source buffer as its only argument and should return a string.
---- @field title (string|fun(bufnr:integer):string|nil)
+--- @field title (string|fun(bufnr:integer):string|nil)?
 
 --- Open a window that displays a textual representation of the undotree.
 ---


### PR DESCRIPTION
Since the code handles a nil title, avoid unnecessary missing fields diagnostics.