### PR TITLE
fix(coverity/532324): freeing skip_until memory to prevent resource leak

### DIFF
--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2577,6 +2577,9 @@ static int get_function_body(exarg_T *eap, garray_T *newlines, char *line_arg_in
               heredoc_trimmedlen = (size_t)(skipwhite(theline) - theline);
               heredoc_trimmed = xmemdupz(theline, heredoc_trimmedlen);
             }
+            if (skip_until != NULL) {
+              XFREE_CLEAR(skip_until);
+            }
             skip_until = xmemdupz(p, (size_t)(skiptowhite(p) - p));
             do_concat = false;
             is_heredoc = true;

--- a/src/nvim/eval/userfunc.c
+++ b/src/nvim/eval/userfunc.c
@@ -2577,9 +2577,7 @@ static int get_function_body(exarg_T *eap, garray_T *newlines, char *line_arg_in
               heredoc_trimmedlen = (size_t)(skipwhite(theline) - theline);
               heredoc_trimmed = xmemdupz(theline, heredoc_trimmedlen);
             }
-            if (skip_until != NULL) {
-              XFREE_CLEAR(skip_until);
-            }
+            XFREE_CLEAR(skip_until);
             skip_until = xmemdupz(p, (size_t)(skiptowhite(p) - p));
             do_concat = false;
             is_heredoc = true;


### PR DESCRIPTION
<!--
  Thank you for contributing to Neovim!
  If this is your first time, check out https://github.com/neovim/neovim/blob/master/CONTRIBUTING.md#pull-requests-prs
  for our PR guidelines.
-->
