### PR TITLE
vim-patch: doc updates

### DIFF
--- a/runtime/doc/pattern.txt
+++ b/runtime/doc/pattern.txt
@@ -1529,7 +1529,8 @@ a List of strings.  |matchfuzzy()| returns the matching strings, while
 
 The "f" flag of `:vimgrep` enables fuzzy matching.
 
-To enable fuzzy matching for |ins-completion|, add the "fuzzy" value to the
-'completeopt' option.
+To enable fuzzy matching for |ins-completion|, add "fuzzy" to the
+'completeopt' option.  For |cmdline-completion|, add "fuzzy" to the
+'wildoptions' option.
 
  vim:tw=78:ts=8:noet:ft=help:norl:

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -5614,7 +5614,7 @@ To use it, execute this command: >
 Nvim uses 256-color and |true-color| terminal capabilities wherever possible.
 
 ==============================================================================
-18. When syntax is slow						*:syntime*
+18. When syntax is slow					*:synti* *:syntime*
 
 This is aimed at authors of a syntax file.
 
@@ -5631,15 +5631,15 @@ this sequence: >
 This will display a list of syntax patterns that were used, sorted by the time
 it took to match them against the text.
 
-:syntime on		Start measuring syntax times.  This will add some
+:synti[me] on		Start measuring syntax times.  This will add some
 			overhead to compute the time spent on syntax pattern
 			matching.
 
-:syntime off		Stop measuring syntax times.
+:synti[me] off		Stop measuring syntax times.
 
-:syntime clear		Set all the counters to zero, restart measuring.
+:synti[me] clear	Set all the counters to zero, restart measuring.
 
-:syntime report		Show the syntax items used since ":syntime on" in the
+:synti[me] report	Show the syntax items used since ":syntime on" in the
 			current window.  Use a wider display to see more of
 			the output.
 


### PR DESCRIPTION
#### vim-patch:partial:7dba04f: runtime(doc,vim): Update base syntax, match full :syntime command

- Use the optional tail command-name spec at :help :syntime.
- Match full :syntime command and highlight args.

https://github.com/vim/vim/commit/7dba04f15cc43562c67c4cd0db82c2165c1cdb40

Documentation changes only.

Co-authored-by: Doug Kearns <dougkearns@gmail.com>


#### vim-patch:1388fa6: runtime(doc): Add reference to 'wildoptions' in fuzzy-matching docs

The docs for fuzzy matching seems to try to list every possible use
case, but misses this one. It's a good idea to be consistent.

closes: vim/vim#18525

https://github.com/vim/vim/commit/1388fa62d25181df85c4460d6ecdc6c417c016df

Co-authored-by: Yee Cheng Chin <ychin.git@gmail.com>