### PR TITLE
help url extmarks improvements

### DIFF
--- a/test/functional/lua/ui_spec.lua
+++ b/test/functional/lua/ui_spec.lua
@@ -202,6 +202,15 @@ describe('vim.ui', function()
       local tagname =
         n.api.nvim_buf_get_text(0, tag[2], tag[3], tag[4].end_row, tag[4].end_col, {})[1]
       eq(vim.uri_encode(tagname), param)
+
+      -- non-nvim tags are ignored
+      local buf = n.api.nvim_create_buf(false, false)
+      n.api.nvim_buf_set_lines(buf, 0, 0, false, {
+        '|nonexisting|',
+      })
+      n.api.nvim_set_option_value('filetype', 'help', { buf = buf, scope = 'local' })
+      local tags = n.api.nvim_buf_get_extmarks(buf, link_ns, 0, -1, {})
+      eq(#tags, 0)
     end)
   end)
 end)


### PR DESCRIPTION
Closes #36083. Addresses these problems:

1. Currently extmarks are drawn for the full buffer which may slow down opening
   the helpfile. This PR only sets them for the current viewport using the
    `on_win` decoration provider.
2. The url is set for every tag/link without sanity check. This PR now checks
   if the tag is defined in a help file in $VIMRUNTIME.
3. TODO: url extmarks not cleared with `b:undo_ftplugin`. How to unset/remove/delete a decoration provider?
