### PR TITLE
fix(ui2): don't scroll beyond eob in dialog window

### DIFF
--- a/runtime/lua/vim/_extui/messages.lua
+++ b/runtime/lua/vim/_extui/messages.lua
@@ -544,11 +544,11 @@ function M.set_pos(type)
           f = [[\<C-F>]],
           b = [[\<C-B>]],
         }
-        if page_keys[key] then
-          local topline = fn.getwininfo(ext.wins.dialog)[1].topline
+        local info = page_keys[key] and fn.getwininfo(ext.wins.dialog)[1]
+        if info and (key ~= 'f' or info.botline < api.nvim_buf_line_count(ext.bufs.dialog)) then
           fn.win_execute(ext.wins.dialog, ('exe "norm! %s"'):format(page_keys[key]))
           set_top_bot_spill()
-          return fn.getwininfo(ext.wins.dialog)[1].topline ~= topline and '' or nil
+          return fn.getwininfo(ext.wins.dialog)[1].topline ~= info.topline and '' or nil
         end
       end)
     elseif type == 'msg' then

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -344,7 +344,23 @@ describe('messages2', function()
       99                                                                     |
       Type number and <Enter> or click with the mouse (q or empty cancels): ^ |
     ]])
-    feed('g')
+    -- No scrolling beyond end of buffer #36114
+    feed('f')
+    screen:expect([[
+                                                                             |
+      {1:~                                                                      }|*3
+      {3:───────────────────────────────────────────────────────────────────────}|
+      93 [+93]                                                               |
+      94                                                                     |
+      95                                                                     |
+      96                                                                     |
+      97                                                                     |
+      98                                                                     |
+      99                                                                     |
+      Type number and <Enter> or click with the mouse (q or empty cancels): f|
+      ^                                                                       |
+    ]])
+    feed('<Backspace>g')
     screen:expect(top)
   end)
 


### PR DESCRIPTION
Problem:  Forward page scrolling reveals eob lines in the dialog window.
Solution: Check if the end of the buffer is visible before scrolling down.

Fix #36114
