### PR TITLE
fix(undotree): clear autocmd correctly

### DIFF
--- a/runtime/pack/dist/opt/nvim.undotree/lua/undotree.lua
+++ b/runtime/pack/dist/opt/nvim.undotree/lua/undotree.lua
@@ -371,9 +371,7 @@ function M.open(opts)
 
   vim.api.nvim_win_set_cursor(w, { vim.api.nvim_buf_line_count(b), 0 })
 
-  local group = vim.api.nvim_create_augroup('nvim.undotree', { clear = false })
-  vim.api.nvim_clear_autocmds({ buffer = b })
-  vim.api.nvim_clear_autocmds({ buffer = buf })
+  local group = vim.api.nvim_create_augroup('nvim.undotree', {})
 
   vim.api.nvim_win_call(w, function()
     vim.cmd.syntax('region Comment start="(" end=")"')


### PR DESCRIPTION
Problem: nvim_clear_autocmds clear some other autocmd unexpectedly

Solution: clear it correctly
