### PR TITLE
test(plugin/shada_spec): always use UTC formatted date

### DIFF
--- a/test/functional/plugin/shada_spec.lua
+++ b/test/functional/plugin/shada_spec.lua
@@ -3190,9 +3190,9 @@ describe('syntax/shada.vim', function()
       return { { 'ShaDaEntryHeader', 'ShaDaEntryTimestamp' }, s }
     end
     local synepoch = {
-      year = htsnum(os.date('%Y', 0)),
-      month = htsnum(os.date('%m', 0)),
-      day = htsnum(os.date('%d', 0)),
+      year = htsnum(os.date('!%Y', 0)),
+      month = htsnum(os.date('!%m', 0)),
+      day = htsnum(os.date('!%d', 0)),
       hour = htsnum(os.date('!%H', 0)),
       minute = htsnum(os.date('!%M', 0)),
       second = htsnum(os.date('!%S', 0)),


### PR DESCRIPTION
Problem

Similar to https://github.com/neovim/neovim/pull/33257, but for the date component. When timezone is behind UTC the epoch date of individual components mismatch causing the test to fail.

Solution

The `epoch` variable is created using `os.date` with a `!`, which means format the date in UTC instead of local timezone:
https://www.lua.org/manual/5.1/manual.html#pdf-os.date.

Since the individual components like year, month, and day are expected to match `epoch` they should all be created using a `!` as well.