### PR TITLE
feat(api): add "pinned" flag to nvim_open_win()

### DIFF
--- a/runtime/doc/api.txt
+++ b/runtime/doc/api.txt
@@ -3995,6 +3995,10 @@ nvim_open_win({buffer}, {enter}, {config})                   *nvim_open_win()*
                   • _cmdline_offset: (EXPERIMENTAL) When provided, anchor the
                     |cmdline-completion| popupmenu to this window, with an
                     offset in screen cell width.
+                  • pinned: Prevent the window from being closed by commands
+                    like |:fclose| or |:only|. The window can only be closed
+                    when explicitly targeted. Immutable after creation.
+                    Default: false.
 
     Return: ~
         (`integer`) |window-ID|, or 0 on error

--- a/runtime/doc/news.txt
+++ b/runtime/doc/news.txt
@@ -109,6 +109,8 @@ API
 • |vim.lsp.buf.declaration()|, |vim.lsp.buf.definition()|, |vim.lsp.buf.definition()|,
   and |vim.lsp.buf.implementation()| now follows 'switchbuf'.
 • |nvim_set_hl()| supports "font" key.
+• |nvim_open_win()| supports `pinned` flag to prevent closing by commands like
+  |:fclose| or |:only|.
 
 BUILD
 

--- a/runtime/lua/vim/_core/ui2.lua
+++ b/runtime/lua/vim/_core/ui2.lua
@@ -97,6 +97,7 @@ function M.check_targets()
       cfg.border = type ~= 'msg' and 'none' or nil
       cfg._cmdline_offset = type == 'cmd' and 0 or nil
       cfg.hide = type ~= 'cmd' or M.cmdheight == 0 or nil
+      cfg.pinned = type == 'cmd' or nil
       -- kZIndexMessages < cmd zindex < kZIndexCmdlinePopupMenu (grid_defs.h), pager below others.
       cfg.zindex = 201 - i
       M.wins[type] = api.nvim_open_win(M.bufs[type], false, cfg)

--- a/runtime/lua/vim/_meta/api.lua
+++ b/runtime/lua/vim/_meta/api.lua
@@ -1888,6 +1888,9 @@ function vim.api.nvim_open_term(buffer, opts) end
 ---   elements.
 --- - _cmdline_offset: (EXPERIMENTAL) When provided, anchor the `cmdline-completion`
 ---   popupmenu to this window, with an offset in screen cell width.
+--- - pinned: Prevent the window from being closed by commands like `:fclose` or
+---   `:only`. The window can only be closed when explicitly targeted. Immutable
+---   after creation. Default: false.
 --- @return integer # |window-ID|, or 0 on error
 function vim.api.nvim_open_win(buffer, enter, config) end
 

--- a/runtime/lua/vim/_meta/api_keysets.lua
+++ b/runtime/lua/vim/_meta/api_keysets.lua
@@ -487,6 +487,7 @@ error('Cannot require a meta file')
 --- @field title? any
 --- @field title_pos? "center"|"left"|"right"
 --- @field _cmdline_offset? integer
+--- @field pinned? boolean
 
 --- @class vim.api.keyset.win_text_height
 --- @field start_row? integer

--- a/src/nvim/api/keysets_defs.h
+++ b/src/nvim/api/keysets_defs.h
@@ -140,6 +140,7 @@ typedef struct {
   Object title;
   Enum("center", "left", "right") title_pos;
   Integer _cmdline_offset;
+  Boolean pinned;
 } Dict(win_config);
 
 typedef struct {

--- a/src/nvim/api/win_config.c
+++ b/src/nvim/api/win_config.c
@@ -197,6 +197,9 @@
 ///     elements.
 ///   - _cmdline_offset: (EXPERIMENTAL) When provided, anchor the |cmdline-completion|
 ///     popupmenu to this window, with an offset in screen cell width.
+///   - pinned: Prevent the window from being closed by commands like |:fclose| or
+///     |:only|. The window can only be closed when explicitly targeted. Immutable
+///     after creation. Default: false.
 ///
 /// @param[out] err Error details, if any
 ///
@@ -879,6 +882,7 @@ Dict(win_config) nvim_win_get_config(Window window, Arena *arena, Error *err)
   PUT_KEY_X(rv, hide, config->hide);
   PUT_KEY_X(rv, mouse, config->mouse);
   PUT_KEY_X(rv, style, cstr_as_string(win_style_str[config->style]));
+  PUT_KEY_X(rv, pinned, config->pinned);
 
   if (wp->w_floating) {
     PUT_KEY_X(rv, width, config->width);
@@ -1521,6 +1525,15 @@ static bool parse_win_config(win_T *wp, Dict(win_config) *config, WinConfig *fco
 
   if (HAS_KEY_X(config, _cmdline_offset)) {
     fconfig->_cmdline_offset = (int)config->_cmdline_offset;
+  }
+
+  if (HAS_KEY_X(config, pinned)) {
+    if (reconf && config->pinned != wp->w_config.pinned) {
+      api_set_error(err, kErrorTypeValidation, "'pinned' cannot be changed after window creation");
+      goto fail;
+    } else {
+      fconfig->pinned = config->pinned;
+    }
   }
 
   return true;

--- a/src/nvim/buffer_defs.h
+++ b/src/nvim/buffer_defs.h
@@ -1022,6 +1022,7 @@ typedef struct {
   bool fixed;
   bool hide;
   int _cmdline_offset;
+  bool pinned;
 } WinConfig;
 
 #define WIN_CONFIG_INIT ((WinConfig){ .height = 0, .width = 0, \

--- a/src/nvim/ex_docmd.c
+++ b/src/nvim/ex_docmd.c
@@ -5329,7 +5329,7 @@ void tabpage_close(int forceit)
     ex_win_close(forceit, curwin, NULL);
   }
   if (!ONE_WINDOW) {
-    close_others(true, forceit);
+    close_others(true, forceit, true);
   }
   if (ONE_WINDOW) {
     ex_win_close(forceit, curwin, NULL);
@@ -5402,7 +5402,7 @@ static void ex_only(exarg_T *eap)
       win_goto(wp);
     }
   }
-  close_others(true, eap->forceit);
+  close_others(true, eap->forceit, false);
 }
 
 static void ex_hide(exarg_T *eap)

--- a/src/nvim/window.c
+++ b/src/nvim/window.c
@@ -4248,10 +4248,12 @@ static int frame_minwidth(frame_T *topfrp, win_T *next_curwin)
 /// Buffers in the other windows become hidden if 'hidden' is set, or '!' is
 /// used and the buffer was modified.
 ///
-/// Used by ":bdel" and ":only".
+/// Used by ":tabclose" and ":only".
 ///
-/// @param forceit  always hide all other windows
-void close_others(int message, int forceit)
+/// @param message       if true, display error messages
+/// @param forceit       always hide all other windows
+/// @param ignore_pinned if true, also close pinned floating windows (for :tabclose)
+void close_others(int message, int forceit, bool ignore_pinned)
 {
   win_T *const old_curwin = curwin;
 
@@ -4280,7 +4282,8 @@ void close_others(int message, int forceit)
       curbuf = curwin->w_buffer;
     }
 
-    if (wp == curwin) {                 // don't close current window
+    // don't close current window or pinned floating windows
+    if (wp == curwin || (wp->w_floating && wp->w_config.pinned && !ignore_pinned)) {
       continue;
     }
 
@@ -4312,7 +4315,17 @@ void close_others(int message, int forceit)
   }
 
   if (message && !ONE_WINDOW) {
-    emsg(_("E445: Other window contains changes"));
+    // Check if remaining windows are non-pinned
+    bool has_non_pinned = false;
+    for (win_T *wp = firstwin; wp != NULL; wp = wp->w_next) {
+      if (wp != curwin && !(wp->w_floating && wp->w_config.pinned)) {
+        has_non_pinned = true;
+        break;
+      }
+    }
+    if (has_non_pinned) {
+      emsg(_("E445: Other window contains changes"));
+    }
   }
 }
 

--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -298,6 +298,9 @@ void win_float_remove(bool bang, int count)
 {
   kvec_t(win_T *) float_win_arr = KV_INITIAL_VALUE;
   for (win_T *wp = lastwin; wp && wp->w_floating; wp = wp->w_prev) {
+    if (wp->w_config.hide || wp->w_config.pinned) {
+      continue;
+    }
     kv_push(float_win_arr, wp);
   }
   if (float_win_arr.size > 0) {

--- a/test/functional/ui/float_spec.lua
+++ b/test/functional/ui/float_spec.lua
@@ -1619,6 +1619,7 @@ describe('float window', function()
         width = 20,
         zindex = 60,
         hide = false,
+        pinned = false,
       }
       eq(expected, api.nvim_win_get_config(win))
       eq(
@@ -1648,6 +1649,7 @@ describe('float window', function()
         split = 'left',
         width = 40,
         height = 6,
+        pinned = false,
       }, api.nvim_win_get_config(0))
 
       if multigrid then
@@ -1662,6 +1664,7 @@ describe('float window', function()
           style = '',
           hide = false,
           border = 'none',
+          pinned = false,
         }, api.nvim_win_get_config(win))
       end
     end)
@@ -4678,6 +4681,7 @@ describe('float window', function()
         focusable = true,
         mouse = true,
         zindex = 50,
+        pinned = false,
       }, api.nvim_win_get_config(win))
 
       feed('<c-e>')
@@ -11175,6 +11179,64 @@ describe('float window', function()
       end
       -- allow use with trailing bar
       eq('hello', n.exec_capture('fclose | echo "hello"'))
+    end)
+
+    it(':fclose and :only skip hidden and pinned floating windows #36123', function()
+      exec_lua(function()
+        require('vim._core.ui2').enable({ msg = { target = 'msg' } })
+      end)
+      local buf = api.nvim_create_buf(false, true)
+      local win = api.nvim_open_win(buf, false, {
+        relative = 'editor',
+        width = 20,
+        height = 2,
+        row = 0.9,
+        col = 0.9,
+        border = 'rounded',
+        style = 'minimal',
+      })
+      feed(':fclose<CR>')
+      eq(false, api.nvim_win_is_valid(win))
+      local config = {
+        relative = 'editor',
+        width = 10,
+        height = 3,
+        row = 1,
+        col = 1,
+        zindex = 200,
+        hide = true,
+      }
+      local win1 = api.nvim_open_win(api.nvim_create_buf(false, true), false, config)
+      local win2 = api.nvim_open_win(api.nvim_create_buf(false, true), false, {
+        relative = 'editor',
+        width = 20,
+        height = 2,
+        row = 5,
+        col = 5,
+        zindex = 50, -- Lower zindex than hidden window
+        focusable = false,
+      })
+      command('fclose')
+      eq(true, api.nvim_win_is_valid(win1))
+      eq(false, api.nvim_win_is_valid(win2))
+      api.nvim_win_close(win1, true)
+      local pinned_win = exec_lua(function()
+        for _, w in ipairs(vim.api.nvim_list_wins()) do
+          if vim.api.nvim_win_get_config(w).pinned then
+            return w
+          end
+        end
+      end)
+      command(':only')
+      eq(true, api.nvim_win_is_valid(pinned_win))
+      eq("'pinned' cannot be changed after window creation", pcall_err(api.nvim_win_set_config, pinned_win, { pinned = false }))
+      api.nvim_win_close(pinned_win, true)
+      local tab1 = api.nvim_get_current_tabpage()
+      command('tabnew')
+      config.pinned = true
+      api.nvim_open_win(api.nvim_create_buf(false, true), false, config)
+      command('tabclose')
+      eq(tab1, api.nvim_get_current_tabpage())
     end)
 
     it('correctly placed in or above message area', function()

--- a/test/functional/ui/messages2_spec.lua
+++ b/test/functional/ui/messages2_spec.lua
@@ -439,7 +439,7 @@ describe('messages2', function()
     screen:expect([[
       ^                                                     |
       {1:~                                                    }|*12
-                                                           |
+      foo [+1]                                             |
     ]])
   end)
 


### PR DESCRIPTION
Problem:
- :fclose closes hidden windows (even before visible windows).
- Unable to "pin" a window that is not closed by commands unless
  specifically targeted.

Solution:
- Skip over hidden (and pinned) windows with :fclose.
- Add immutable "pinned" flag to WinConfig. Windows with pinned=true are
  skipped by :fclose and :only. Pin the ui2 cmdline window (which should
  always be visible), so that it is not closed by :only/fclose.

Fix #36123