### PR TITLE
vim-patch:37aabac: runtime(doc): update credit section for Girish Palya

### DIFF
--- a/runtime/doc/credits.txt
+++ b/runtime/doc/credits.txt
@@ -93,8 +93,8 @@ Vim would never have become what it is now, without the help of these people!
         Doug Kearns             Runtime file maintainer
         Foxe Chen               Wayland support, new features
         glepnir                 completion feature
-        Girish Palya            insert & cmdline autocompletion,
-                                search/substitute completion, etc.
+        Girish Palya            autocompletion (ins/cmdline), omnifunc
+                                composing, search/subst completion, and more.
         Hirohito Higashi        lots of patches and fixes
         Yee Cheng Chin          MacVim maintainer and diff improvements
         zeertzjq                many fixes and improvements


### PR DESCRIPTION
#### vim-patch:37aabac: runtime(doc): update credit section for Girish Palya

closes: vim/vim#18544

https://github.com/vim/vim/commit/37aabaca64b091004224f8d6815e6ce2874ec826

Co-authored-by: Girish Palya <girishji@gmail.com>