### PR TITLE
fix(conceal): assert tripped during startup

### DIFF
--- a/src/nvim/decoration.c
+++ b/src/nvim/decoration.c
@@ -865,8 +865,7 @@ static const uint32_t conceal_filter[kMTMetaCount] = {[kMTMetaConcealLines] = kM
 /// @return whether "row" is concealed
 bool decor_conceal_line(win_T *wp, int row, bool check_cursor)
 {
-  assert(row >= 0);
-  if (wp->w_p_cole < 2
+  if (row < 0 || wp->w_p_cole < 2
       || (!check_cursor && wp == curwin && row + 1 == wp->w_cursor.lnum
           && !conceal_cursor_line(wp))) {
     return false;


### PR DESCRIPTION
Problem:  Row assertion for concealed lines trips during startup.
Solution: Remove the assertion and return early instead.

Fix #36120