### PR TITLE
fix(float): crash from nasty :fclose autocmds (#36134)

### DIFF
--- a/src/nvim/winfloat.c
+++ b/src/nvim/winfloat.c
@@ -290,7 +290,8 @@ void win_float_remove(bool bang, int count)
     qsort(float_win_arr.items, float_win_arr.size, sizeof(win_T *), float_zindex_cmp);
   }
   for (size_t i = 0; i < float_win_arr.size; i++) {
-    if (win_close(float_win_arr.items[i], false, false) == FAIL) {
+    win_T *wp = float_win_arr.items[i];
+    if (win_valid(wp) && win_close(wp, false, false) == FAIL) {
       break;
     }
     if (!bang) {


### PR DESCRIPTION
Problem: :fclose may crash Nvim if autocommands close floats prematurely. Alternatively, :fclose may call win_close for windows not in curtab if autocommands change curtab or move windows between tab pages via nvim_win_set_config (may not crash, but is wrong).

Solution: check win_valid before calling win_close.

(cherry picked from commit 3ccba4cdffb82e8238475e52382b20e380322e8f)

Backports #36134.
