### PR TITLE
vim-patch:6800da6: runtime(doc): Add missing optional tail command-name specs

### DIFF
--- a/runtime/doc/editing.txt
+++ b/runtime/doc/editing.txt
@@ -30,8 +30,8 @@ the |CTRL-^| command to toggle between the current and the alternate file.
 However, the alternate file name is not changed when |:keepalt| is used.
 An alternate file name is remembered for each window.
 
-							*:keepalt* *:keepa*
-:keepalt {cmd}		Execute {cmd} while keeping the current alternate file
+							*:keepa* *:keepalt*
+:keepa[lt] {cmd}	Execute {cmd} while keeping the current alternate file
 			name.  Note that commands invoked indirectly (e.g.,
 			with a function) may still set the alternate file
 			name.

--- a/runtime/doc/quickfix.txt
+++ b/runtime/doc/quickfix.txt
@@ -540,8 +540,8 @@ EXECUTE A COMMAND IN ALL THE BUFFERS IN QUICKFIX OR LOCATION LIST:
 			Also see |:bufdo|, |:tabdo|, |:argdo|, |:windo|,
 			|:ldo|, |:cfdo| and |:lfdo|.
 
-							*:cfdo*
-:cfdo[!] {cmd}		Execute {cmd} in each file in the quickfix list.
+							*:cfd* *:cfdo*
+:cfd[o][!] {cmd}	Execute {cmd} in each file in the quickfix list.
 			It works like doing this: >
 				:cfirst
 				:{cmd}
@@ -550,7 +550,7 @@ EXECUTE A COMMAND IN ALL THE BUFFERS IN QUICKFIX OR LOCATION LIST:
 				etc.
 <			Otherwise it works the same as `:cdo`.
 
-							*:ldo*
+							*:ld* *:ldo*
 :ld[o][!] {cmd}		Execute {cmd} in each valid entry in the location list
 			for the current window.
 			It works like doing this: >
@@ -562,8 +562,8 @@ EXECUTE A COMMAND IN ALL THE BUFFERS IN QUICKFIX OR LOCATION LIST:
 <			Only valid entries in the location list are used.
 			Otherwise it works the same as `:cdo`.
 
-							*:lfdo*
-:lfdo[!] {cmd}		Execute {cmd} in each file in the location list for
+							*:lfd* *:lfdo*
+:lfd[o][!] {cmd}	Execute {cmd} in each file in the location list for
 			the current window.
 			It works like doing this: >
 				:lfirst

--- a/runtime/doc/undo.txt
+++ b/runtime/doc/undo.txt
@@ -270,8 +270,8 @@ they are saved to the dedicated directory in the application data folder.
 
 You can also save and restore undo histories by using ":wundo" and ":rundo"
 respectively:
-							*:wundo* *:rundo*
-:wundo[!] {file}
+							*:wu* *:wundo*
+:wu[ndo][!] {file}
 		Write undo history to {file}.
 		When {file} exists and it does not look like an undo file
 		(the magic number at the start of the file is wrong), then
@@ -284,7 +284,8 @@ respectively:
 		name. So it is not possible to overwrite an existing undofile
 		in a write-protected directory.
 
-:rundo {file}	Read undo history from {file}.
+							*:rund* *:rundo*
+:rund[o] {file}	Read undo history from {file}.
 
 You can use these in autocommands to explicitly specify the name of the
 history file.  E.g.: >

--- a/runtime/doc/windows.txt
+++ b/runtime/doc/windows.txt
@@ -1182,21 +1182,23 @@ list of buffers. |unlisted-buffer|
 		from the buffer list |unlisted-buffer| and option values,
 		variables and mappings/abbreviations for the buffer are
 		cleared. Examples: >
-                    :.,$-bdelete   "delete buffers from the current one to
-                                   " last but one
-                    :%bdelete      " delete all buffers
+		    :.,$-bdelete    " delete buffers from the current one to
+				    " last but one
+		    :%bdelete	    " delete all buffers
 <
-:bdelete[!] {bufname}						*E93* *E94*
+
+:bd[elete][!] {bufname}						*E93* *E94*
 		Like ":bdelete[!] [N]", but buffer given by name, see
 		|{bufname}|.
 
-:bdelete[!] N1 N2 ...
+:bd[elete][!] N1 N2 ...
 		Do ":bdelete[!]" for buffer N1, N2, etc.  The arguments can be
 		buffer numbers or buffer names (but not buffer names that are
 		a number).  Insert a backslash before a space in a buffer
 		name.
 
-:N,Mbdelete[!]	Do ":bdelete[!]" for all buffers in the range N to M
+:N,Mbd[elete][!]
+		Do ":bdelete[!]" for all buffers in the range N to M
 		|inclusive|.
 
 :[N]bw[ipeout][!]			*:bw* *:bwipe* *:bwipeout* *E517*
@@ -1212,6 +1214,7 @@ list of buffers. |unlisted-buffer|
 				    " one
 		    :%bwipeout	    " wipe out all buffers
 <
+
 :[N]bun[load][!]				*:bun* *:bunload* *E515*
 :bun[load][!] [N]
 		Unload buffer [N] (default: current buffer).  The memory
@@ -1224,14 +1227,15 @@ list of buffers. |unlisted-buffer|
 		This is the most recent entry in the jump list that points
 		into a loaded buffer.
 
-:bunload[!] {bufname}
+:bun[load][!] {bufname}
 		Like ":bunload[!] [N]", but buffer given by name.
 		Also see |{bufname}|.
 
-:N,Mbunload[!]	Do ":bunload[!]" for all buffers in the range N to M
+:N,Mbun[load][!]
+		Do ":bunload[!]" for all buffers in the range N to M
 		|inclusive|.
 
-:bunload[!] N1 N2 ...
+:bun[load][!] N1 N2 ...
 		Do ":bunload[!]" for buffer N1, N2, etc.  The arguments can be
 		buffer numbers or buffer names (but not buffer names that are
 		a number).  Insert a backslash before a space in a buffer


### PR DESCRIPTION
#### vim-patch:6800da6: runtime(doc): Add missing optional tail command-name specs

- Use the optional tail command-name specs at help entries for :keepalt,
  :lcd, :cfdo, :lfdo, :wundo, :rundo, :bdelete and :bunload.
- Add missing shortname tags.

closes: vim/vim#18547

https://github.com/vim/vim/commit/6800da6ff115014aa71fdd396cd1496ea0da6509

Co-authored-by: Doug Kearns <dougkearns@gmail.com>