### PR TITLE
test(plugin/pack_spec): handle pcall path truncation

### DIFF
--- a/test/functional/plugin/pack_spec.lua
+++ b/test/functional/plugin/pack_spec.lua
@@ -983,6 +983,7 @@ describe('vim.pack', function()
         local fetch_path = pack_get_plug_path('fetch')
         local semver_src = repos_src.semver
         local semver_path = pack_get_plug_path('semver')
+        local pack_runtime = '/lua/vim/pack.lua'
 
         exec_lua(function()
           -- Replace matches in line to preserve extmark highlighting
@@ -998,10 +999,11 @@ describe('vim.pack', function()
 
           vim.bo.modifiable = true
           local lines = vim.api.nvim_buf_get_lines(0, 0, -1, false)
-          local pack_runtime = vim.fs.joinpath(vim.env.VIMRUNTIME, 'lua', 'vim', 'pack.lua')
           -- NOTE: replace path to `vim.pack` in error traceback accounting for
-          -- possibly different slashes on Windows
-          local pack_runtime_pattern = vim.pesc(pack_runtime):gsub('/', '[\\/]') .. ':%d+'
+          -- pcall source truncation and possibly different slashes on Windows
+          local pack_runtime_pattern = ('%%S.+%s:%%d+'):format(
+            vim.pesc(pack_runtime):gsub('/', '[\\/]')
+          )
           for i = 1, #lines do
             replace_in_line(i, pack_runtime_pattern, 'VIM_PACK_RUNTIME')
             replace_in_line(i, vim.pesc(fetch_path), 'FETCH_PATH')


### PR DESCRIPTION
Problem

In `vim.pack` the source of any errors is included in the `update` buffer from lua's `pcall` method. Since the full path is known it is replaced in the unit test by the string `VIM_PACK_RUNTIME`. The issue is that `pcall` does not necessarily include the full path, it instead uses the `lua_Debug` `short_src` value which can be truncated. This means depending on where you've cloned the repo locally the test can fail.

Solution

Change the replacement pattern for the traceback to be more generic and handle any path prefix, not just the value of `vim.env.VIMRUNTIME`.
