### PR TITLE
fix(difftool): ensure split layout, use systemlist

### DIFF
--- a/runtime/doc/plugins.txt
+++ b/runtime/doc/plugins.txt
@@ -55,7 +55,7 @@ invoking `:DiffTool`.
 
 Example `git difftool -d` integration using `DiffTool` command: >ini
     [difftool "nvim_difftool"]
-      cmd = nvim -c "packadd nvim.difftool" -c "DiffTool $LOCAL $REMOTE"
+      cmd = nvim -c \"packadd nvim.difftool\" -c \"DiffTool $LOCAL $REMOTE\"
     [diff]
       tool = nvim_difftool
 <

--- a/runtime/pack/dist/opt/nvim.difftool/lua/difftool.lua
+++ b/runtime/pack/dist/opt/nvim.difftool/lua/difftool.lua
@@ -12,7 +12,7 @@
 ---
 --- ```ini
 --- [difftool "nvim_difftool"]
----   cmd = nvim -c "packadd nvim.difftool" -c "DiffTool $LOCAL $REMOTE"
+---   cmd = nvim -c \"packadd nvim.difftool\" -c \"DiffTool $LOCAL $REMOTE\"
 --- [diff]
 ---   tool = nvim_difftool
 --- ```
@@ -58,7 +58,7 @@ local function setup_layout(with_qf)
 
   vim.cmd.only()
   layout.left_win = vim.api.nvim_get_current_win()
-  vim.cmd.vsplit()
+  vim.cmd('rightbelow vsplit')
   layout.right_win = vim.api.nvim_get_current_win()
 
   if with_qf then
@@ -124,8 +124,7 @@ local function diff_dirs_diffr(left_dir, right_dir, opt)
   table.insert(args, left_dir)
   table.insert(args, right_dir)
 
-  local output = vim.fn.system(args)
-  local lines = vim.split(output, '\n')
+  local lines = vim.fn.systemlist(args)
   local qf_entries = {}
 
   for _, line in ipairs(lines) do

--- a/test/functional/plugin/difftool_spec.lua
+++ b/test/functional/plugin/difftool_spec.lua
@@ -49,6 +49,18 @@ describe('nvim.difftool', function()
     }, entries)
   end)
 
+  it('has consistent split layout', function()
+    command('set nosplitright')
+    command(('DiffTool %s %s'):format(testdir_left, testdir_right))
+    local wins = fn.getwininfo()
+    local left_win_col = wins[1].wincol
+    local right_win_col = wins[2].wincol
+    assert(
+      left_win_col < right_win_col,
+      'Left window should be to the left of right window even with nosplitright set'
+    )
+  end)
+
   it('has autocmds when diff window is opened', function()
     command(('DiffTool %s %s'):format(testdir_left, testdir_right))
     local autocmds = fn.nvim_get_autocmds({ group = 'nvim.difftool.events' })


### PR DESCRIPTION
- Always open the right window to the right, regardless of 'splitright' setting, ensuring the left window is always leftmost.
- Use `vim.fn.systemlist` for diffr output to avoid manual splitting.
- Add a test to verify window layout consistency with 'splitright' and 'nosplitright' options.
- Escape quotes in git difftool example properly.