### PR TITLE
fix(difftool): fully resolve symlinks when comparing paths

### DIFF
--- a/runtime/lua/vim/_core/util.lua
+++ b/runtime/lua/vim/_core/util.lua
@@ -5,12 +5,20 @@ local M = {}
 --- @param file string
 --- @return number buffer number of the edited buffer
 M.edit_in = function(winnr, file)
+  local function resolved_path(path)
+    if not path or path == '' then
+      return ''
+    end
+    return vim.fn.resolve(vim.fs.abspath(path))
+  end
+
   return vim.api.nvim_win_call(winnr, function()
-    local current = vim.fs.abspath(vim.api.nvim_buf_get_name(vim.api.nvim_win_get_buf(winnr)))
+    local current_buf = vim.api.nvim_win_get_buf(winnr)
+    local current = resolved_path(vim.api.nvim_buf_get_name(current_buf))
 
     -- Check if the current buffer is already the target file
-    if current == (file and vim.fs.abspath(file) or '') then
-      return vim.api.nvim_get_current_buf()
+    if current == resolved_path(file) then
+      return current_buf
     end
 
     -- Read the file into the buffer

--- a/test/functional/plugin/difftool_spec.lua
+++ b/test/functional/plugin/difftool_spec.lua
@@ -61,6 +61,31 @@ describe('nvim.difftool', function()
     )
   end)
 
+  it('handles symlinks', function()
+    -- Create a symlink in right dir pointing to file2.txt in left dir
+    local symlink_path = vim.fs.joinpath(testdir_right, 'file2.txt')
+    local target_path = vim.fs.joinpath('..', testdir_left, 'file2.txt')
+    assert(vim.uv.fs_symlink(target_path, symlink_path) == true)
+    finally(function()
+      os.remove(symlink_path)
+    end)
+    assert(fn.getftype(symlink_path) == 'link')
+
+    -- Run difftool
+    command(('DiffTool %s %s'):format(testdir_left, testdir_right))
+    local qflist = fn.getqflist()
+    local entries = {}
+    for _, item in ipairs(qflist) do
+      table.insert(entries, { text = item.text, rel = item.user_data and item.user_data.rel })
+    end
+
+    -- file2.txt should not be reported as added or deleted anymore
+    eq({
+      { text = 'M', rel = 'file1.txt' },
+      { text = 'A', rel = 'file3.txt' },
+    }, entries)
+  end)
+
   it('has autocmds when diff window is opened', function()
     command(('DiffTool %s %s'):format(testdir_left, testdir_right))
     local autocmds = fn.nvim_get_autocmds({ group = 'nvim.difftool.events' })


### PR DESCRIPTION
Fixes issue on mac where it was constantly reloading buffers as paths
were not being normalized and resolved correctly (in relation to buffer
name).

Quickfix entry:
/var/folders/pt/2s7dzyw12v36tsslrghfgpkr0000gn/T/git-difftool.m95lj8/right/app.vue

Buffer name:
/private/var/folders/pt/2s7dzyw12v36tsslrghfgpkr0000gn/T/git-difftool.m95lj8/right/app.vue

/var was synlinked to /private/var and this was not being properly
handled.

Also added lazy redraw to avoid too many redraws when this happens in
future and added test for symlink handling.

See relevant reddit debugging "session": https://www.reddit.com/r/neovim/comments/1o4eo6s/new_difftool_command_added_to_neovim/nj270sw/