### PR TITLE
vim-patch:40dec46: runtime(doc): Replace rotted URL links

### DIFF
--- a/runtime/doc/spell.txt
+++ b/runtime/doc/spell.txt
@@ -494,7 +494,7 @@ You can create a Vim spell file from the .aff and .dic files that Myspell
 uses.  Myspell is used by OpenOffice.org and Mozilla. The OpenOffice .oxt
 files are zip files which contain the .aff and .dic files. You should be able
 to find them here:
-	https://extensions.services.openoffice.org/dictionary
+	https://extensions.openoffice.org/en/search@f[0]=field_project_application%253A1&f[1]=field_project_tags%253A94.html
 The older, OpenOffice 2 files may be used if this doesn't work:
 	http://wiki.services.openoffice.org/wiki/Dictionaries
 You can also use a plain word list.  The results are the same, the choice

--- a/runtime/doc/syntax.txt
+++ b/runtime/doc/syntax.txt
@@ -1491,7 +1491,7 @@ are read during initialization) >
 	:let html_my_rendering=1
 
 If you'd like to see an example download mysyntax.vim at
-https://www.fleiner.com/vim/download.html
+https://web.archive.org/web/20241129015117/https://www.fleiner.com/vim/download.html
 
 You can also disable this rendering by adding the following line to your
 vimrc file: >


### PR DESCRIPTION
#### vim-patch:40dec46: runtime(doc): Replace rotted URL links

Both links to libXpm and mysyntax.vim are up but the listed
libXpm version is not offered anymore and mysyntax.vim is no
longer served at all.  The link for searching dictionary
extensions of Apache OpenOffice is broken; an alternative
link can be discovered from the home page.  Finally, the
English dictionaries Apache OpenOffice extension is probably
gone for good (is it incompatible with more recent versions
of the suite?) as its page neither available directly nor
discoverable through search.

closes: 18549

https://github.com/vim/vim/commit/40dec4609d73c7ba2068aa3b4cea9d003bec5545

Co-authored-by: Aliaksei Budavei <0x000c70@gmail.com>