### PR TITLE
vim-patch:9.1.1850: completion: not triggered after i_Ctrl-W/i_Ctrl-U

### DIFF
--- a/runtime/doc/insert.txt
+++ b/runtime/doc/insert.txt
@@ -69,10 +69,11 @@ CTRL-W		Delete the word before the cursor (see |i_backspacing| about
 		By default, sets a new undo point before deleting.
 		|default-mappings|
 						*i_CTRL-U*
-CTRL-U		Delete all entered characters before the cursor in the current
-		line.  If there are no newly entered characters and
-		'backspace' is not empty, delete all characters before the
-		cursor in the current line.
+CTRL-U		Delete all characters that were entered after starting Insert
+		mode and before the cursor in the current line.
+		If there are no newly entered characters and 'backspace' is
+		not empty, delete all characters before the cursor in the
+		current line.
 		If C-indenting is enabled the indent will be adjusted if the
 		line becomes blank.
 		See |i_backspacing| about joining lines.

--- a/test/old/testdir/test_ins_complete.vim
+++ b/test/old/testdir/test_ins_complete.vim
@@ -5528,10 +5528,33 @@ func Test_autocomplete_trigger()
   call assert_equal(['fodabc', 'fodxyz'], b:matches->mapnew('v:val.word'))
   call assert_equal(-1, b:selected)
 
+  " Test 8: Ctrl_W / Ctrl_U (delete word/line) should restart autocompletion
+  func! TestComplete(findstart, base)
+    if a:findstart
+      return col('.') - 1
+    endif
+    return ['fooze', 'faberge']
+  endfunc
+  set omnifunc=TestComplete
+  set complete+=o
+  call feedkeys("Sprefix->fo\<F2>\<Esc>0", 'tx!')
+  call assert_equal(['fodabc', 'fodxyz', 'foobar', 'fooze'], b:matches->mapnew('v:val.word'))
+  call feedkeys("Sprefix->fo\<C-W>\<F2>\<Esc>0", 'tx!')
+  call assert_equal(['fooze', 'faberge'], b:matches->mapnew('v:val.word'))
+  call feedkeys("Sprefix->\<Esc>afo\<C-U>\<F2>\<Esc>0", 'tx!')
+  call assert_equal(['fooze', 'faberge'], b:matches->mapnew('v:val.word'))
+
+  " Test 9: Trigger autocomplete immediately upon entering Insert mode
+  call feedkeys("Sprefix->foo\<Esc>a\<F2>\<Esc>0", 'tx!')
+  call assert_equal(['foobar', 'fooze', 'faberge'], b:matches->mapnew('v:val.word'))
+  call feedkeys("Sprefix->fooxx\<Esc>hcw\<F2>\<Esc>0", 'tx!')
+  call assert_equal(['foobar', 'fooze', 'faberge'], b:matches->mapnew('v:val.word'))
+
   bw!
   call Ntest_override("char_avail", 0)
   delfunc NonKeywordComplete
-  set autocomplete&
+  delfunc TestComplete
+  set autocomplete& omnifunc& complete&
   unlet g:CallCount
 endfunc
 


### PR DESCRIPTION
#### vim-patch:9.1.1850: completion: not triggered after i_Ctrl-W/i_Ctrl-U

Problem:  completion: not triggered after i_Ctrl-W/i_Ctrl-U
Solution: Trigger autocomplete when entering Insert mode
          (Girish Palya).

closes: vim/vim#18543

https://github.com/vim/vim/commit/da2dabc6f740b1ed3397797af8a8b0b2ec02bc31

Co-authored-by: Girish Palya <girishji@gmail.com>