### PR TITLE
vim-patch:partial:9.1.1847: No cmdline completion for :echoconsole and :echowindow

### DIFF
--- a/test/old/testdir/test_cmdline.vim
+++ b/test/old/testdir/test_cmdline.vim
@@ -1174,11 +1174,13 @@ endfunc
 
 func Test_cmdline_complete_expression()
   let g:SomeVar = 'blah'
-  for cmd in ['exe', 'echo', 'echon', 'echomsg']
+  for cmd in ['exe', 'echo', 'echon', 'echomsg', 'echoerr',
+        "\ 'echoconsole', 'echowindow']
+        \ ]
     call feedkeys(":" .. cmd .. " SomeV\<Tab>\<C-B>\"\<CR>", 'tx')
-    call assert_match('"' .. cmd .. ' SomeVar', @:)
+    call assert_match('"' .. cmd .. ' SomeVar', @:, cmd)
     call feedkeys(":" .. cmd .. " foo SomeV\<Tab>\<C-B>\"\<CR>", 'tx')
-    call assert_match('"' .. cmd .. ' foo SomeVar', @:)
+    call assert_match('"' .. cmd .. ' foo SomeVar', @:, cmd)
   endfor
   unlet g:SomeVar
 endfunc


### PR DESCRIPTION
#### vim-patch:partial:9.1.1847: No cmdline completion for :echoconsole and :echowindow

Problem:  No cmdline completion for :echoconsole, :echowindow and second
          expression after :echoerr.
Solution: Set EXPAND_EXPRESSION for :echoconsole and :echowindow, and
          check for multiple expressions after :echoerr (zeertzjq).

closes: vim/vim#18552

https://github.com/vim/vim/commit/7aaca97fc5154bb2f2483237b49e25786a061379