### PR TITLE
vim-patch:2a33b49: runtime(make): syntax highlighting update for makeDefine

### DIFF
--- a/runtime/syntax/make.vim
+++ b/runtime/syntax/make.vim
@@ -5,6 +5,7 @@
 " URL:		https://github.com/vim/vim/blob/master/runtime/syntax/make.vim
 " Last Change:	2022 Nov 06
 " 2025 Apr 15 by Vim project: rework Make flavor detection (#17089)
+" 2025 Oct 12 by Vim project: update makeDefine highlighting (#18403)
 
 " quit when a syntax file was already loaded
 if exists("b:current_syntax")
@@ -23,7 +24,7 @@ syn match makeNextLine	"\\\n\s*"
 
 " catch unmatched define/endef keywords.  endef only matches it is by itself on a line, possibly followed by a commend
 syn region makeDefine start="^\s*define\s" end="^\s*endef\s*\(#.*\)\?$"
-	\ contains=makeStatement,makeIdent,makePreCondit,makeDefine
+	\ contains=makeStatement,makeIdent,makePreCondit,makeDefine,makeComment,makeTargetinDefine
 
 if get(b:, 'make_flavor', s:make_flavor) == 'microsoft'
   " Microsoft Makefile specials
@@ -33,20 +34,26 @@ if get(b:, 'make_flavor', s:make_flavor) == 'microsoft'
   syn case match
 endif
 
-" identifiers
-if get(b:, 'make_flavor', s:make_flavor) == 'microsoft'
-  syn region makeIdent	start="\$(" end=")" contains=makeStatement,makeIdent
-  syn region makeIdent	start="\${" end="}" contains=makeStatement,makeIdent
-else
-  syn region makeIdent	start="\$(" skip="\\)\|\\\\" end=")" contains=makeStatement,makeIdent
-  syn region makeIdent	start="\${" skip="\\}\|\\\\" end="}" contains=makeStatement,makeIdent
-endif
+" identifiers; treat $$X like $X inside makeDefine
 syn match makeIdent	"\$\$\w*"
+syn match makeIdent	"\$\$\$\$\w*" containedin=makeDefine
 syn match makeIdent	"\$[^({]"
+syn match makeIdent	"\$\$[^({]" containedin=makeDefine
 syn match makeIdent	"^ *[^:#= \t]*\s*[:+?!*]="me=e-2
 syn match makeIdent	"^ *[^:#= \t]*\s*::="me=e-3
 syn match makeIdent	"^ *[^:#= \t]*\s*="me=e-1
 syn match makeIdent	"%"
+if get(b:, 'make_flavor', s:make_flavor) == 'microsoft'
+  syn region makeIdent	start="\$(" end=")" contains=makeStatement,makeIdent
+  syn region makeIdent	start="\${" end="}" contains=makeStatement,makeIdent
+  syn region makeIdent	start="\$\$(" end=")" containedin=makeDefine contains=makeStatement,makeIdent
+  syn region makeIdent	start="\$\${" end="}" containedin=makeDefine contains=makeStatement,makeIdent
+else
+  syn region makeIdent	start="\$(" skip="\\)\|\\\\" end=")" contains=makeStatement,makeIdent
+  syn region makeIdent	start="\${" skip="\\}\|\\\\" end="}" contains=makeStatement,makeIdent
+  syn region makeIdent	start="\$\$(" skip="\\)\|\\\\" end=")" containedin=makeDefine contains=makeStatement,makeIdent
+  syn region makeIdent	start="\$\${" skip="\\}\|\\\\" end="}" containedin=makeDefine contains=makeStatement,makeIdent
+endif
 
 " Makefile.in variables
 syn match makeConfig "@[A-Za-z0-9_]\+@"
@@ -54,6 +61,12 @@ syn match makeConfig "@[A-Za-z0-9_]\+@"
 " make targets
 syn match makeImplicit		"^\.[A-Za-z0-9_./\t -]\+\s*:$"me=e-1
 syn match makeImplicit		"^\.[A-Za-z0-9_./\t -]\+\s*:[^=]"me=e-2
+
+syn region makeTargetinDefine transparent matchgroup=makeTargetinDefine
+	\ start="^[~A-Za-z0-9_./$(){}%-][A-Za-z0-9_./\t ${}()%-]*&\?:\?:\{1,2}[^:=]"rs=e-1
+	\ end="[^\\]$"
+syn match makeTargetinDefine           "^[~A-Za-z0-9_./$(){}%*@-][A-Za-z0-9_./\t $(){}%*@-]*&\?::\=\s*$"
+	\ contains=makeIdent,makeSpecTarget,makeComment
 
 syn region makeTarget transparent matchgroup=makeTarget
 	\ start="^[~A-Za-z0-9_./$(){}%-][A-Za-z0-9_./\t ${}()%-]*&\?:\?:\{1,2}[^:=]"rs=e-1
@@ -155,6 +168,7 @@ hi def link makeCommands	Number
 endif
 hi def link makeImplicit	Function
 hi def link makeTarget		Function
+hi def link makeTargetinDefine		Function
 hi def link makeInclude		Include
 hi def link makePreCondit	PreCondit
 hi def link makeStatement	Statement


### PR DESCRIPTION
#### vim-patch:2a33b49: runtime(make): syntax highlighting update for makeDefine

Previously contents in makeDefine are nearly highlighted as Define, so
comments and targets shares the same color as Define, making it hard to
distinguish if someone write large block of targets-recipes as defined
function.

Such scenario is common in building data analysis pipeline. Recipes are
reused and targets may have multiple variables, and a single % implicit
rule is not enough.

closes: vim/vim#18403

https://github.com/vim/vim/commit/2a33b499a3d7f46dc307234847a6562cef6cf1d8

Co-authored-by: Yiyang Wu <xgreenlandforwyy@gmail.com>